### PR TITLE
docs(sharing): federated principals need no second path — and D5 was wrong about merging them

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -47,5 +47,12 @@ jobs:
       enable-eslint: true
       enable-phpunit: true
       enable-newman: true
+      # Playwright starts from a deliberately SMALL spec set rather than the
+      # whole of tests/e2e (58 files, several of which write fixtures or shell
+      # out to occ). A gate that is red on arrival is a gate nobody turns on —
+      # which is how this repo ended up with an E2E job that had never
+      # succeeded. The floor is green and it grows; see tests/e2e/ci/.
+      enable-playwright: true
+      playwright-test-path: tests/e2e/ci
       enable-coverage-guard: true
       enable-sbom: true

--- a/docs/Features/access-control.md
+++ b/docs/Features/access-control.md
@@ -25,7 +25,8 @@ The access control system integrates with:
 Access can be controlled at multiple levels:
 - Register level - Control access to entire registers
 - Schema level - Manage permissions for specific register/schema combinations
-- Object level - Set permissions on individual objects
+- Object level - Set permissions on individual objects, make one object `private`,
+  and invite a principal to it (see [Object Sharing](./object-sharing.md))
 - Property level - Fine-grained, conditional control over specific object properties (see [Property Authorization](./property-authorization.md))
 
 ## Permission Types

--- a/docs/Features/object-sharing.md
+++ b/docs/Features/object-sharing.md
@@ -1,0 +1,212 @@
+# Object Sharing and the `private` Scope
+
+Until now, an object was visible to everyone in its organisation who satisfied
+its schema's authorization rules. There was no way to say "this one is mine", and
+no way to hand one object to one colleague.
+
+This page describes both: the `private` scope, and per-object grants.
+
+> **Nothing changes on upgrade.** An object that does not declare `private` is
+> decided exactly as it was. The capability is opt-in throughout.
+
+---
+
+## The short version
+
+| you want to | you do |
+|---|---|
+| make one object yours alone | set its scope to `private` |
+| make a whole schema's objects private by default | set `scope` in the schema's `authorization` block |
+| let one colleague see a private object | grant them on that object |
+| let somebody without an account see it | create a link, or invite an email address |
+| stop any of the above | revoke it — it takes effect on the next request |
+
+---
+
+## Scope: who an object answers to
+
+An object's **scope** answers a different question from an authorization rule.
+A rule says *who does this admit*. The scope says *does this object answer to the
+schema's rules at all*.
+
+There are two values.
+
+**`organisation`** — the default, and what every object has always done. The
+schema's rules decide.
+
+**`private`** — the object answers to nobody but its owner, Nextcloud
+administrators, and whoever is explicitly invited on it. The schema's group rules
+are suppressed for that object; suppressing them is the entire point.
+
+### Setting it
+
+The scope is not an ordinary data field, and you cannot set it by saving the
+object. That is deliberate: per-object access control must not be reachable
+through a data write. It has its own endpoint.
+
+```http
+PUT /api/objects/{register}/{schema}/{id}/scope
+{ "scope": "private" }
+```
+
+**The owner may do this to their own object**, as well as an administrator. That
+is safe because the scope can only ever *narrow* — see the ceiling rule below.
+
+A schema can also declare a default for its objects:
+
+```json
+{ "authorization": { "scope": "private", "read": ["authenticated"] } }
+```
+
+The object wins over the schema, **in both directions**. A schema default is a
+default, not a ceiling: an owner may put their own object back to
+`organisation`, exactly as a Files user may share a file that started out
+private.
+
+### Fail-closed on anything unrecognised
+
+Only `organisation` is recognised as non-private. A typo, a boolean, a scope name
+from a future version — all are treated as private. Hiding an object that should
+have been visible is recoverable; leaking one is not.
+
+An *absent* value is not the same as an unrecognised one. Absent falls through to
+the level below, which is what keeps this opt-in.
+
+### An owner cannot lock themselves out
+
+The owner and administrator admits are evaluated **first** and are never
+conditional on the scope, the schema block, or a match clause. Making your own
+object private, with a malformed scope, with no invitations, still leaves you
+able to read, update and delete it.
+
+---
+
+## Grants: inviting one principal to one object
+
+A grant is a real Nextcloud share on the object's folder. Core owns the record —
+token, expiry, password, mailer, federation handshake, revocation — and
+OpenRegister owns only the authorization verdict.
+
+```http
+POST   /api/objects/{register}/{schema}/{id}/shares
+{ "type": "user", "shareWith": "colleague", "permissions": 1 }
+
+GET    /api/objects/{register}/{schema}/{id}/shares
+DELETE /api/objects/{register}/{schema}/{id}/shares/{shareId}
+```
+
+`type` is one of `user`, `group`, `remote`, `remote_group`. A remote principal is
+just one more principal — it is resolved by the same evaluator as a local one,
+not by a separate federated path.
+
+Only the owner or an administrator may grant or revoke. A recipient cannot
+re-share onward, and cannot list who else the object was shared with.
+
+### The permission gates the action
+
+`permissions` is Nextcloud's bitmask: `1` read, `2` update, `4` create, `8`
+delete, `16` share. A read-only grant admits reads and nothing else.
+
+An action outside those five — a custom verb like ZGW's `besluit_nemen` — has no
+bit, so a grant cannot carry it and the caller is refused. RBAC grants
+visibility; an extension verb is enforced by the endpoint that performs it. See
+[ADR-010](../../openspec/architecture/adr-010-permission-verb-extensions.md).
+
+### The ceiling rule — a grant cannot widen
+
+**The schema's rules are the ceiling.** `private` narrows access to the owner; a
+grant re-opens it *within* what the schema would have allowed. A grant can never
+admit somebody the schema refuses.
+
+Concretely, if a schema grants `read` to the `finance` group and you invite
+someone outside it, they are still refused. If you want them to have access, the
+schema is what needs changing.
+
+This is why a private-by-default schema still needs a read rule. With
+`{"scope": "private", "read": ["authenticated"]}` the ceiling is "any logged-in
+user", the scope narrows that to the owner, and a grant picks out one colleague.
+With `{"scope": "private"}` alone the ceiling admits nobody, so a grant has
+nothing to re-open.
+
+### Revocation is immediate
+
+Share records are read through from Nextcloud at decision time and never copied.
+A revoked or expired grant is refused on the **next request**, with nothing to
+invalidate — because there is no OpenRegister-side copy to go stale.
+
+---
+
+## Links and email invitations
+
+For somebody who has no account, or no account here.
+
+```http
+POST /api/objects/{register}/{schema}/{id}/links
+{ "permissions": 1, "expiration": "2026-12-31", "password": "optional" }
+
+POST /api/objects/{register}/{schema}/{id}/invitations
+{ "email": "colleague@example.org", "permissions": 1 }
+```
+
+Both return a token. The token is redeemed on a public endpoint:
+
+```http
+GET /api/shared/{token}
+```
+
+A link is a **capability**, not a grant. It admits whoever holds the token, so it
+is decided from the token rather than by the RBAC filter — an anonymous caller
+presents no principal for the filter to resolve. Every check is Nextcloud's:
+validity, revocation, expiry and password.
+
+**Creating a link does not publish the object.** The RBAC verdict for every
+logged-in principal is unchanged; only the token-holder gains anything. This is
+what reconciles links with [ADR-006](../../openspec/architecture/adr-006-publish-is-rbac-scope.md),
+which says publication is a schema-level RBAC change and not a per-object flag.
+It is enforced by a test, not just asserted.
+
+An email invitation carries no object data in the message. The recipient follows
+it to reach the object, so revoking still works after the mail has been sent.
+
+---
+
+## What sharing an object also shares
+
+An object grant is a share on the object's **folder**, and that folder holds the
+object's attachments. **Granting the object therefore also reaches its files.**
+
+For most objects that is the wanted, Files-like behaviour. Where it is not, it
+needs saying out loud in the interface rather than being discovered.
+
+File shares themselves remain a separate thing: sharing one document inside an
+object's folder does *not* grant the object. Sharing a container and inviting a
+person to a record are different acts.
+
+---
+
+## How the decision is made
+
+The verdict is reached in four places — the single-object read, the relation
+path, and both list-emitting query paths. They are required to agree, because a
+principal honoured by some and not others is an access-control bug in both
+directions: over-filtering shows an empty page, under-filtering leaks a row.
+
+The vocabulary, the PHP verdict and the SQL predicate are therefore defined
+exactly once, in `ObjectScopeResolver`, and every path is a caller. Agreement is
+demonstrated against a live database with a positive control — the proof fails if
+any one implementation is disabled.
+
+The whole rule, as one line:
+
+```
+owner OR admin OR ((not private OR granted to me) AND the schema's rules)
+```
+
+---
+
+## Related
+
+- [Access Control](./access-control.md) — schema and property-level RBAC
+- [Federation](./federation.md) — sharing with an organisation on another instance
+- [Credential Broker](./credential-broker.md) — the worked example of a verb
+  (`use`) enforced at the acting endpoint rather than by RBAC

--- a/openspec/architecture/adr-006-publish-is-rbac-scope.md
+++ b/openspec/architecture/adr-006-publish-is-rbac-scope.md
@@ -47,6 +47,40 @@ opencatalogi and other DCAT-AP consumers MUST rely on OR's RBAC evaluation for
 public exposure. Filtering client-side on a `published` field is not a security
 control; the server decides visibility.
 
+#### Rule 4 — A share LINK is a capability, and is not publication
+
+Added 2026-08-02 with the object-level sharing capability.
+
+An owner MAY create a tokenised link to a single object. That does not violate
+Rules 1–3, and the distinction is worth stating because it looks like it should.
+
+What Rule 3 actually guards against is a DATA FIELD being treated as a boundary:
+a `published` property is written by whoever can write the object, is visible to
+whoever can read it, and is enforced by nobody. A share link is none of those
+things. It is a bearer capability issued by Nextcloud core, and core is what
+validates it:
+
+- it is **revocable** — the record is deleted and the next request is refused;
+- it is **expiring**, and optionally **passworded**;
+- it is **attributable** — the share records who created it;
+- it is **not a property of the object**. Creating one changes nothing about the
+  object, and the RBAC verdict for every logged-in principal is unchanged.
+
+That last point is the operative one, and it is enforced rather than asserted:
+`ObjectShareLinkIntegrationTest::testALinkDoesNotMakeTheObjectListableForOthers`
+fails if creating a link ever widens the verdict for other users.
+
+So the rules compose. Publication is still a schema-level RBAC change and still
+must not be a data flag. A link is a per-object, revocable grant of access to
+whoever holds the token — a different act, decided on a public endpoint from the
+token rather than in the RBAC filter, because an anonymous caller presents no
+principal for the filter to resolve.
+
+**What this does NOT license.** A link is not a way to publish a schema one
+object at a time as a matter of policy. If a whole class of objects should be
+public, that is Rule 2's RBAC change; reaching for links instead trades a
+server-enforced scope for a pile of bearer tokens nobody can audit as a set.
+
 ## Consequences
 
 - (+) A single, server-enforced visibility model; no gap between a data flag and

--- a/openspec/architecture/adr-010-permission-verb-extensions.md
+++ b/openspec/architecture/adr-010-permission-verb-extensions.md
@@ -1,0 +1,103 @@
+# ADR-010: Permission verbs — a uniform core set, with governed per-schema extensions
+
+**Status**: accepted
+
+**Date**: 2026-08-02
+
+## Context
+
+Object-level sharing gives an owner a way to grant one principal access to one
+object. A grant has to say access *to do what*, and that immediately raises the
+question of vocabulary.
+
+Nextcloud core has five permission verbs, carried as a bitmask on every share:
+`READ`, `UPDATE`, `CREATE`, `DELETE`, `SHARE`. OpenRegister has more concepts
+than that. A brokered credential can be *used* — spent through the broker —
+which is a strictly stronger thing than being able to see that it exists. A flow
+can be *run*. ZGW's zaakafhandeling has verbs like `besluit_nemen`. None of
+those are core verbs, and none of them fit cleanly into the five.
+
+Two failure modes are available, and both are cheap to fall into.
+
+The first is to invent a parallel permission model, so that a grant carries
+OpenRegister's own verb set. That gives two vocabularies to keep in step and two
+places to enforce them, and this codebase has already paid for that mistake once
+— the predecessor change found two access-control divergences between four
+enforcement paths in a single week, each one a second copy of a rule.
+
+The second is to let every schema define whatever verbs it likes and have RBAC
+enforce them. That makes the RBAC evaluator responsible for a vocabulary it
+cannot know, and turns "which verbs exist" into an unbounded, per-tenant
+question that no reviewer can hold in their head.
+
+## Decision
+
+**A uniform core verb set, mapped onto core's bitmask. Extensions are allowed,
+declared by the schema, and enforced at the endpoint that performs the action —
+never by widening the RBAC vocabulary.**
+
+### Rule 1 — The core set is core's bitmask, unchanged
+
+`read`, `update`, `create`, `delete` and `share` map one-to-one onto
+`OCP\Constants::PERMISSION_*`. A grant carries core's bitmask, and
+`ObjectGrantResolver::permissionFor()` is the single place the mapping lives.
+There is no OpenRegister-side permission integer.
+
+### Rule 2 — An action with no core bit is NOT admitted by a grant
+
+`permissionFor()` returns `null` for anything outside the five, and the callers
+fail closed. A grant cannot admit `besluit_nemen`, because a grant has no way to
+carry it.
+
+This is deliberate and it is the load-bearing rule. It means the RBAC evaluator
+never has to know what an extension verb means: it can only ever answer for the
+five it does know, and it answers "no" for the rest.
+
+### Rule 3 — An extension verb SHALL be declared by its schema
+
+A schema that needs a verb beyond the core five declares it. An undeclared verb
+is not a verb; it is a typo, and it is refused.
+
+### Rule 4 — An extension verb SHALL be enforced at the endpoint that performs it
+
+RBAC grants *visibility*. Whether this caller may `run` this flow, or `use` this
+credential, is decided by the code that runs the flow or spends the credential —
+which is the only code that understands what the verb costs. The credential
+broker's guard chain is the worked example: it decides `use` itself, in one
+fail-closed sequence, and does not ask RBAC to.
+
+Where a grant needs to carry an extension verb across the wire, it rides in
+`IShare`'s `IAttributes` bag — the extension point other Nextcloud apps already
+use — and not in the permission integer.
+
+### Rule 5 — An extension verb SHALL NOT redefine a core verb
+
+A schema may not declare `read` to mean something other than read. The core five
+have one meaning across every register, schema and app, because that is what
+lets one shares component render a permission picker without being taught each
+schema.
+
+## Consequences
+
+- (+) One permission vocabulary in RBAC, and it is core's — so a grant, a file
+  share and a folder share all mean the same thing by the same bitmask.
+- (+) The RBAC evaluator stays finite and reviewable. "Which verbs can RBAC
+  decide" has a five-item answer that does not vary by tenant.
+- (+) Fail-closed by construction for anything unknown: a new verb is invisible
+  to grants until somebody deliberately enforces it somewhere.
+- (−) Two enforcement points exist — RBAC for visibility, the acting endpoint
+  for the verb — and a reader has to know that. This ADR is the mitigation.
+- (−) An extension verb cannot be granted to a principal through the sharing UI
+  today. It can be *declared* and enforced; carrying it on a grant needs the
+  `IAttributes` half, which is not built yet.
+
+## Cross-references
+
+- ADR-004 (credential broker custody) — the worked example of Rule 4: `use` is
+  decided by the broker's fail-closed guard chain, not by RBAC.
+- Company ADR-011 (reuse, don't reimplement) — the same instinct, applied to
+  evaluators rather than to utilities.
+- `openspec/changes/object-level-sharing-and-private-scope/design.md`, Q5 and Q6
+  — where this was settled, including why `read` and `use` are separate verbs
+  and why `use` implies `read`.
+- `ObjectGrantResolver::permissionFor()` — Rules 1 and 2, in code.

--- a/openspec/changes/object-level-sharing-and-private-scope/design.md
+++ b/openspec/changes/object-level-sharing-and-private-scope/design.md
@@ -200,11 +200,38 @@ a fail-open divergence that does not exist.
 
 ### D5 — Federated principals are principals
 
-A remote principal is one more thing an object can be shared with, resolved
-through the existing `OpenRegisterCloudFederationProvider`. `FederatedShare`
-already carries `objectUri`, `sharedWith`, `permissions` and `shareToken`, so the
-inbound half exists; this change gives it the same principal vocabulary as a local
-grant instead of a second decision path.
+A remote principal is one more thing an object can be shared with. That is
+satisfied structurally rather than with new code: `IShare::TYPE_REMOTE` and
+`TYPE_REMOTE_GROUP` sit in the SAME lists as the user and group types, both in
+`ObjectGrantResolver` and in `ObjectSharingService`. A remote grant therefore
+flows through the same resolve, the same SQL disjunct and the same PHP verdict.
+There is no federated branch to keep in step with the local one, which is the
+property worth having. `FederatedPrincipalVocabularyTest` pins both lists,
+because the property is invisible and nothing else would notice it being edited
+away.
+
+**CORRECTION — this decision previously said to reconcile object grants with
+`FederatedShare`. That was wrong, and following it would have been a mistake.**
+
+They are not two shapes of one thing:
+
+| | `FederatedShare` | a `TYPE_REMOTE` object grant |
+|---|---|---|
+| what is shared | a register / schema / object / query | one object |
+| who with | an ORGANISATION on a peer instance | a remote USER or group |
+| how authorised | OpenRegister's own scoped bearer `shareToken` | core's OCM federation |
+| served by | `federation#objects`, proxied by `FederatedObjectSourceProvider` against the peer's OpenRegister base URL | the ordinary RBAC filter |
+
+Folding a per-principal grant into an instance-to-instance transport would give
+the grant a second decision path — the exact thing D4 forbids — and would put
+object-level RBAC behind a bearer token that was designed to authorise a whole
+register. They stay distinct, for the same reason file shares stay distinct
+(task 8.2): sharing a container and inviting a person are different acts.
+
+**What is NOT proven.** That an inbound federated grant from a real peer admits a
+real remote user needs a SECOND Nextcloud instance and an OCM handshake. No
+single-instance test substitutes for it, and none here pretends to — tasks 7.2
+and 7.3 stay open with that stated.
 
 ### D6 — One primitive: the bespoke `sharedWith[]` is superseded
 

--- a/openspec/changes/object-level-sharing-and-private-scope/design.md
+++ b/openspec/changes/object-level-sharing-and-private-scope/design.md
@@ -238,12 +238,43 @@ and 7.3 stay open with that stated.
 Credentials and flows grew `sharedWith[]` + `sharedUsers` + `sharedGroups` +
 a `$contains` operator because no primitive existed. Once this lands, the broker's
 Guard 1c consumes the shared primitive and the per-schema copies are migrated
-away. Leaving both would be the fourth share concept this change exists to
-prevent.
+away.
 
 `$contains` itself stays — it is general RBAC vocabulary now, implemented on both
 SQL emitters through one builder, and it is what makes a principal-list predicate
 expressible at all.
+
+**THE AUDIT (task 8.1), and it corrects the count above.** This decision used to
+say leaving both would be "the fourth share concept". Counting properly, there
+are FIVE in openregister alone — 32 files — and only ONE of them is a duplicate:
+
+| concept | shares WHAT | with WHOM | verdict |
+|---|---|---|---|
+| object grants (this change) | one object | a principal | **the primitive** |
+| `ShareLinkService` (7 files) | the FILES in an object's folder | a principal or a link | keep — a file is not an object (8.2) |
+| `FederatedShare` (5 files) | a register / schema / object / query | an ORGANISATION on a peer instance | keep — an instance transport (D5) |
+| `ShareableConfigType` (11 files) | an app's CONFIGURATION as portable files, over GitHub | other INSTALLATIONS | keep — distribution, not access |
+| bespoke `sharedWith[]` (18 files) | a credential, a flow | a principal | **migrate — this is the duplicate** |
+
+`ShareableConfigType` is the one this design had not accounted for at all. It is
+not an access-control mechanism: it packages configuration for publication and
+installation elsewhere, and a type is explicitly allowed to keep its
+configuration outside OpenRegister entirely. Folding it in would confuse
+"distribute this configuration" with "let this person read this row".
+
+**Across the fleet**, the same audit finds bespoke principal lists in exactly the
+places the primitive is meant to serve:
+
+- **launchpad** — the manifest register carries its own `sharedWith[]`, and
+  `ManifestController` selects "objects the user owns OR that list the user in
+  `sharedWith`". That is the object-grant primitive, reimplemented.
+- **doriath** — `DashboardService` counts `sharedWithMe`. This is the dashboards
+  case that motivated the whole change.
+- **opencatalogi** — three files, all FILE-oriented (`FileService`,
+  `DownloadService`, `EventService`). Not principal grants; nothing to migrate.
+
+So task 8.3's real scope is three consumers, not "the fleet": openregister's
+credentials and flows, launchpad's manifests, and doriath's dashboards.
 
 ### D7 — nc-vue: one widget, one tab, one component underneath
 

--- a/openspec/changes/object-level-sharing-and-private-scope/tasks.md
+++ b/openspec/changes/object-level-sharing-and-private-scope/tasks.md
@@ -180,9 +180,18 @@
 
 ## 8. Fleet-wide consolidation
 
-- [ ] 8.1 Audit every existing share surface: openregister (12 files), launchpad (3), opencatalogi (3), doriath (1)
-- [ ] 8.2 Keep FILE shares (`ShareLinkService`) distinct and unchanged — they share files in an object's folder, which is a different thing
-- [ ] 8.3 Migrate the bespoke `sharedWith[]` on brokered credentials and flows to the primitive
+- [x] 8.1 Audited. The count was wrong and so was the framing: openregister has 32 files across
+      FIVE concepts, not 12 across four. Four are legitimately distinct and stay — file shares,
+      `FederatedShare`, and `ShareableConfigType` (config distribution over GitHub, which this
+      design had not accounted for at all). Only the bespoke `sharedWith[]` duplicates the new
+      primitive. Fleet-wide the duplicates are launchpad's manifest `sharedWith[]` and doriath's
+      `sharedWithMe` dashboards; opencatalogi's three files are FILE-oriented and need nothing.
+      See design D6
+- [x] 8.2 FILE shares stay distinct and unchanged — and so do `FederatedShare` and
+      `ShareableConfigType`, for the same reason: sharing a container, distributing a
+      configuration, and inviting a person are three different acts
+- [ ] 8.3 Migrate the bespoke `sharedWith[]` to the primitive. Scoped by the audit to THREE
+      consumers: openregister credentials + flows, launchpad manifests, doriath dashboards
 - [ ] 8.4 Point the credential broker's share admit branch at the primitive instead of its own copy of the shape
 - [ ] 8.6 Collapse `scope` as the ACCESS discriminator into `private` (Q7): `personal` -> private-with-no-invitations, `organisation` -> the default scope
 - [ ] 8.7 KEEP `scope` as the VAULT-OWNER selector, untouched — and test that an organisation credential minted BEFORE the collapse is still readable after it

--- a/openspec/changes/object-level-sharing-and-private-scope/tasks.md
+++ b/openspec/changes/object-level-sharing-and-private-scope/tasks.md
@@ -162,10 +162,21 @@
 
 ## 7. Federated principals
 
-- [ ] 7.1 A remote principal is one more principal, resolved through the existing `OpenRegisterCloudFederationProvider`
-- [ ] 7.2 A federated grant yields the same verdict as a local grant of the same permission, from the same evaluator
-- [ ] 7.3 Revoking a federated grant denies it
-- [ ] 7.4 Reconcile with `FederatedShare`'s existing `objectUri` / `sharedWith` / `permissions` / `shareToken` rather than adding a second shape
+- [x] 7.1 A remote principal is one more principal — satisfied STRUCTURALLY: both remote share
+      types sit in the same lists as user/group, so a remote grant uses the same resolve, the
+      same SQL disjunct and the same PHP verdict. Pinned by `FederatedPrincipalVocabularyTest`,
+      because the property is invisible and nothing else would notice it being edited away
+- [ ] 7.2 A federated grant yields the same verdict as a local grant — NOT PROVEN, and cannot be
+      on one instance. Needs a SECOND Nextcloud and an OCM handshake. Structurally it must hold
+      (there is only one evaluator), but that is an argument, not evidence
+- [ ] 7.3 Revoking a federated grant denies it — same two-instance dependency as 7.2
+- [x] 7.4 RESOLVED THE OTHER WAY, and the original wording was wrong. `FederatedShare` shares a
+      register/schema/object/query with an ORGANISATION on a peer instance, authorised by
+      OpenRegister's own bearer token and served by `federation#objects`; a `TYPE_REMOTE` grant
+      invites a remote USER to one object and is decided by the ordinary RBAC filter. Folding one
+      into the other would give the grant a SECOND decision path — what D4 forbids — and put
+      object-level RBAC behind a token designed to authorise a whole register. They stay distinct,
+      for the same reason file shares do (8.2). See design D5
 
 ## 8. Fleet-wide consolidation
 

--- a/openspec/changes/object-level-sharing-and-private-scope/tasks.md
+++ b/openspec/changes/object-level-sharing-and-private-scope/tasks.md
@@ -216,9 +216,15 @@
 
 ## 11. Documentation and ADRs
 
-- [ ] 11.1 Document the sharing model: `private`, per-object grants, links, email invites, federation — and how each composes with schema-level RBAC
-- [ ] 11.2 Amend the RBAC docs with the `private` principal and the all-four-paths rule
-- [ ] 11.3 Record the distinction between the three pre-existing share concepts, so a future reader does not add a fourth
+- [x] 11.1 `docs/Features/object-sharing.md` — the scope, grants, links, email invites, the
+      ceiling rule, and the fact that granting an object also reaches its FILES
+- [x] 11.2 `docs/Features/access-control.md` links to it from the object level, and the new page
+      states the all-four-paths rule and the one-line verdict
+- [x] 11.3 There were FOUR pre-existing concepts, not three — see the audit in design D6. All four
+      distinctions are recorded there and the user-facing ones in the docs page
 - [ ] 11.4 Document the breaking flow change and its upgrade note
-- [ ] 11.5 Amend ADR-006 for capability-style links (Q4)
-- [ ] 11.6 New ADR governing permission-verb extensions: declared by the schema, enforced at the acting endpoint, never redefining a core verb (Q5)
+- [x] 11.5 ADR-006 Rule 4 — a link is a revocable, expiring, attributable CAPABILITY and is not a
+      data flag, so it does not violate Rules 1-3. Includes what it does NOT license
+- [x] 11.6 ADR-010 — uniform core set on core's bitmask; an action with no core bit is not
+      admitted by a grant (fail closed); extensions declared by the schema, enforced at the acting
+      endpoint, never redefining a core verb

--- a/tests/Unit/Service/Rbac/FederatedPrincipalVocabularyTest.php
+++ b/tests/Unit/Service/Rbac/FederatedPrincipalVocabularyTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * A federated principal is ONE MORE PRINCIPAL, not a second decision path.
+ *
+ * Design D5 asks that a remote principal be resolved by the same evaluator as a
+ * local one. That is satisfied structurally rather than by extra code: the two
+ * remote share types sit in the SAME lists as the user and group types, so a
+ * remote grant flows through `grantedObjectUuidsFor()`, into the same SQL
+ * disjunct, and into the same PHP verdict. There is no federated branch to keep
+ * in step with the local one — which is the property worth protecting.
+ *
+ * This test pins the two lists. It exists because the property is invisible: it
+ * is true only as long as nobody edits those constants, and nothing else in the
+ * suite would notice if they did.
+ *
+ * WHAT IT DELIBERATELY DOES NOT CLAIM. It does not prove that an inbound
+ * federated grant from a real peer admits a real remote user. That needs a
+ * SECOND Nextcloud instance and an OCM handshake, and no amount of single-
+ * instance testing substitutes for it — see tasks 7.2/7.3.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Rbac
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/object-level-sharing-and-private-scope/specs/share-links-and-email-invites/spec.md#requirement-a-remote-principal-is-one-more-principal
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Rbac;
+
+use OCA\OpenRegister\Service\Rbac\ObjectGrantResolver;
+use OCA\OpenRegister\Service\Rbac\ObjectSharingService;
+use OCP\Share\IShare;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * Pins the remote types into the principal vocabulary on both sides.
+ */
+class FederatedPrincipalVocabularyTest extends TestCase
+{
+
+
+    /**
+     * Read a private class constant.
+     *
+     * Reflection is the point here: these lists are private BECAUSE nothing
+     * should depend on them at runtime, and this test exists precisely to depend
+     * on them at build time.
+     *
+     * @param string $class The class.
+     * @param string $name  The constant name.
+     *
+     * @return array<mixed> The constant value.
+     */
+    private function constant(string $class, string $name): array
+    {
+        return (array) (new ReflectionClass($class))->getConstant($name);
+    }//end constant()
+
+
+    /**
+     * The RESOLVER treats both remote types as principals.
+     *
+     * If a remote type were dropped here, a federated grant would stop being
+     * seen by the RBAC filter and the object would silently vanish for the
+     * remote user — an over-filtering failure, which presents as an empty page.
+     */
+    public function testTheResolverTreatsRemoteTypesAsPrincipals(): void
+    {
+        $types = $this->constant(ObjectGrantResolver::class, 'PRINCIPAL_SHARE_TYPES');
+
+        $this->assertContains(IShare::TYPE_REMOTE, $types);
+        $this->assertContains(IShare::TYPE_REMOTE_GROUP, $types);
+
+        // And the local ones, so this reads as one list rather than a carve-out.
+        $this->assertContains(IShare::TYPE_USER, $types);
+        $this->assertContains(IShare::TYPE_GROUP, $types);
+    }//end testTheResolverTreatsRemoteTypesAsPrincipals()
+
+
+    /**
+     * The WRITE surface can grant to both remote types.
+     */
+    public function testTheWriteSurfaceCanGrantToRemotePrincipals(): void
+    {
+        $types = $this->constant(ObjectSharingService::class, 'GRANTABLE_TYPES');
+
+        $this->assertSame(IShare::TYPE_REMOTE, ($types['remote'] ?? null));
+        $this->assertSame(IShare::TYPE_REMOTE_GROUP, ($types['remote_group'] ?? null));
+    }//end testTheWriteSurfaceCanGrantToRemotePrincipals()
+
+
+    /**
+     * The BEARER types are absent from the principal list, on both sides.
+     *
+     * A link or email share admits whoever holds the token and is decided on the
+     * public endpoint. If either leaked into the principal list it would ALSO be
+     * resolved by the RBAC filter, and a link would start behaving like a grant
+     * to every logged-in user — per-object publication by accident.
+     */
+    public function testBearerTypesAreNotPrincipals(): void
+    {
+        $resolverTypes = $this->constant(ObjectGrantResolver::class, 'PRINCIPAL_SHARE_TYPES');
+        $grantableById = array_values($this->constant(ObjectSharingService::class, 'GRANTABLE_TYPES'));
+
+        foreach ([IShare::TYPE_LINK, IShare::TYPE_EMAIL] as $bearer) {
+            $this->assertNotContains($bearer, $resolverTypes, 'a bearer type must not be resolved as a principal');
+            $this->assertNotContains($bearer, $grantableById, 'a bearer type must not be creatable as a grant');
+        }
+    }//end testBearerTypesAreNotPrincipals()
+
+
+}//end class

--- a/tests/e2e/ci/object-sharing.spec.ts
+++ b/tests/e2e/ci/object-sharing.spec.ts
@@ -88,7 +88,17 @@ test.describe('object sharing over HTTP', () => {
 				title: `e2e share schema ${RUN}`,
 				description: 'e2e',
 				properties: { key: { type: 'string', title: 'Key', maxLength: 255 } },
-				authorization: { read: ['authenticated'] },
+				// A non-empty authorization block FAILS CLOSED for any action it
+				// does not list — so listing only `read` means the owner cannot
+				// even create the fixture. The first CI run said exactly that:
+				// "does not have permission to 'create' objects in schema".
+				// `read` is still the ceiling that matters for the scope tests.
+				authorization: {
+					read: ['authenticated'],
+					create: ['authenticated'],
+					update: ['authenticated'],
+					delete: ['authenticated'],
+				},
 			},
 		})
 		expect(sch.ok(), `schema create failed: ${await sch.text()}`).toBeTruthy()

--- a/tests/e2e/ci/object-sharing.spec.ts
+++ b/tests/e2e/ci/object-sharing.spec.ts
@@ -1,0 +1,212 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Open Register Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * OBJECT SHARING — end to end, through the HTTP API a real client uses.
+ *
+ * The live-DB PHPUnit suite already proves the four enforcement paths agree.
+ * What it CANNOT prove is that the capability is reachable: that the routes are
+ * registered, the auth attributes let a non-admin through, the controllers wire
+ * to the service, and a token redeems anonymously over HTTP. Those are exactly
+ * the failures that a green unit suite hides — a route missing from
+ * `appinfo/routes.php` is a 404 no PHPUnit test would notice.
+ *
+ * So this drives HTTP only, and it asserts the CONSEQUENCE each time — "the
+ * other user cannot see it", "the token resolves", "the revoked token stops" —
+ * rather than the mechanism. Every mechanism assertion in this programme has
+ * passed while the consequence was broken at least once.
+ *
+ * HERMETIC BY CONSTRUCTION. It creates its own register, schema, users and
+ * object, and deletes the users at the end. It needs no `occ`, no docker, and no
+ * pre-seeded data, which is what makes it safe to run on every push.
+ */
+import { test, expect, request as pwRequest, type APIRequestContext } from '@playwright/test'
+import { resolveBaseUrl } from '../base-url'
+
+const BASE = resolveBaseUrl()
+const ADMIN = process.env.ADMIN_USER || process.env.OR_USER || 'admin'
+const ADMIN_PASS = process.env.ADMIN_PASSWORD || process.env.OR_PASS || 'admin'
+
+/** A short unique suffix so parallel runs never collide. */
+const RUN = Math.random().toString(36).slice(2, 10)
+
+const OWNER = `e2e-owner-${RUN}`
+const OTHER = `e2e-other-${RUN}`
+const PASS = 'E2e-Share-Pass-123'
+
+/** Build an API context authenticated as one user. */
+async function contextFor(user: string, password: string): Promise<APIRequestContext> {
+	return pwRequest.newContext({
+		baseURL: BASE,
+		extraHTTPHeaders: {
+			Authorization: `Basic ${Buffer.from(`${user}:${password}`).toString('base64')}`,
+			'OCS-APIRequest': 'true',
+			Accept: 'application/json',
+		},
+	})
+}
+
+/** Provision a Nextcloud user through the provisioning API. */
+async function createUser(admin: APIRequestContext, uid: string): Promise<void> {
+	const res = await admin.post('/ocs/v2.php/cloud/users?format=json', {
+		form: { userid: uid, password: PASS },
+	})
+	// 200 = created. Anything else is worth seeing in the failure message.
+	expect(res.status(), `could not create ${uid}: ${await res.text()}`).toBeLessThan(300)
+}
+
+async function deleteUser(admin: APIRequestContext, uid: string): Promise<void> {
+	await admin.delete(`/ocs/v2.php/cloud/users/${uid}?format=json`).catch(() => undefined)
+}
+
+test.describe('object sharing over HTTP', () => {
+	let admin: APIRequestContext
+	let owner: APIRequestContext
+	let other: APIRequestContext
+	let registerId: string
+	let schemaId: string
+	let objectUuid: string
+
+	test.beforeAll(async () => {
+		admin = await contextFor(ADMIN, ADMIN_PASS)
+
+		await createUser(admin, OWNER)
+		await createUser(admin, OTHER)
+		owner = await contextFor(OWNER, PASS)
+		other = await contextFor(OTHER, PASS)
+
+		// A register and a schema whose read rule admits any logged-in caller,
+		// so the SCOPE is the only thing that can hide the object.
+		const reg = await admin.post('/index.php/apps/openregister/api/registers', {
+			data: { title: `e2e share register ${RUN}`, description: 'e2e' },
+		})
+		expect(reg.ok(), `register create failed: ${await reg.text()}`).toBeTruthy()
+		registerId = String((await reg.json()).id)
+
+		const sch = await admin.post('/index.php/apps/openregister/api/schemas', {
+			data: {
+				title: `e2e share schema ${RUN}`,
+				description: 'e2e',
+				properties: { key: { type: 'string', title: 'Key', maxLength: 255 } },
+				authorization: { read: ['authenticated'] },
+			},
+		})
+		expect(sch.ok(), `schema create failed: ${await sch.text()}`).toBeTruthy()
+		schemaId = String((await sch.json()).id)
+
+		const obj = await owner.post(
+			`/index.php/apps/openregister/api/objects/${registerId}/${schemaId}`,
+			{ data: { key: 'shared-object' } },
+		)
+		expect(obj.ok(), `object create failed: ${await obj.text()}`).toBeTruthy()
+		const body = await obj.json()
+		objectUuid = String(body['@self']?.id ?? body.id ?? body.uuid)
+		expect(objectUuid, 'no uuid came back from the object create').toBeTruthy()
+	})
+
+	test.afterAll(async () => {
+		await deleteUser(admin, OWNER)
+		await deleteUser(admin, OTHER)
+	})
+
+	test('an owner can make their own object private, and it disappears for others', async () => {
+		// Visible to the other user first — this is an ordinary object.
+		const before = await other.get(
+			`/index.php/apps/openregister/api/objects/${registerId}/${schemaId}/${objectUuid}`,
+		)
+		expect(before.status(), 'the object should start out readable by another user').toBeLessThan(300)
+
+		// The OWNER sets the scope. Not an admin — that is the point of task 4.0.
+		const put = await owner.put(
+			`/index.php/apps/openregister/api/objects/${registerId}/${schemaId}/${objectUuid}/scope`,
+			{ data: { scope: 'private' } },
+		)
+		expect(put.ok(), `owner could not set the scope: ${await put.text()}`).toBeTruthy()
+		expect((await put.json()).scope).toBe('private')
+
+		// The consequence: gone for the other user.
+		const after = await other.get(
+			`/index.php/apps/openregister/api/objects/${registerId}/${schemaId}/${objectUuid}`,
+		)
+		expect(
+			after.status(),
+			'a private object must not be readable by a non-owner',
+		).toBeGreaterThanOrEqual(400)
+
+		// And still there for its owner — an owner must never lock themselves out.
+		const mine = await owner.get(
+			`/index.php/apps/openregister/api/objects/${registerId}/${schemaId}/${objectUuid}`,
+		)
+		expect(mine.status(), 'the owner must still reach their own private object').toBeLessThan(300)
+	})
+
+	test('inviting a user restores their access, and revoking removes it again', async () => {
+		const grant = await owner.post(
+			`/index.php/apps/openregister/api/objects/${registerId}/${schemaId}/${objectUuid}/shares`,
+			{ data: { type: 'user', shareWith: OTHER, permissions: 1 } },
+		)
+		expect(grant.ok(), `grant failed: ${await grant.text()}`).toBeTruthy()
+		const shareId = String((await grant.json()).id)
+		expect(shareId, 'no share id came back').toBeTruthy()
+
+		const granted = await other.get(
+			`/index.php/apps/openregister/api/objects/${registerId}/${schemaId}/${objectUuid}`,
+		)
+		expect(granted.status(), 'an invited user must reach the object').toBeLessThan(300)
+
+		const revoke = await owner.delete(
+			`/index.php/apps/openregister/api/objects/${registerId}/${schemaId}/${objectUuid}`
+			+ `/shares/${encodeURIComponent(shareId)}`,
+		)
+		expect(revoke.ok(), `revoke failed: ${await revoke.text()}`).toBeTruthy()
+
+		const revoked = await other.get(
+			`/index.php/apps/openregister/api/objects/${registerId}/${schemaId}/${objectUuid}`,
+		)
+		expect(
+			revoked.status(),
+			'a revoked grant must deny on the next request',
+		).toBeGreaterThanOrEqual(400)
+	})
+
+	test('a share link resolves anonymously, and stops when revoked', async () => {
+		const link = await owner.post(
+			`/index.php/apps/openregister/api/objects/${registerId}/${schemaId}/${objectUuid}/links`,
+			{ data: { permissions: 1 } },
+		)
+		expect(link.ok(), `link create failed: ${await link.text()}`).toBeTruthy()
+		const { token, id } = await link.json()
+		expect(token, 'core issued no token').toBeTruthy()
+
+		// ANONYMOUS: a context with no credentials at all.
+		const anon = await pwRequest.newContext({ baseURL: BASE })
+		try {
+			const resolved = await anon.get(`/index.php/apps/openregister/api/shared/${token}`)
+			expect(
+				resolved.ok(),
+				`a live token must resolve anonymously: ${await resolved.text()}`,
+			).toBeTruthy()
+
+			await owner.delete(
+				`/index.php/apps/openregister/api/objects/${registerId}/${schemaId}/${objectUuid}`
+				+ `/shares/${encodeURIComponent(String(id))}`,
+			)
+
+			const dead = await anon.get(`/index.php/apps/openregister/api/shared/${token}`)
+			expect(dead.status(), 'a revoked link must stop resolving').toBe(404)
+		} finally {
+			await anon.dispose()
+		}
+	})
+
+	test('a non-owner cannot change the scope of somebody else\'s object', async () => {
+		const attempt = await other.put(
+			`/index.php/apps/openregister/api/objects/${registerId}/${schemaId}/${objectUuid}/scope`,
+			{ data: { scope: 'organisation' } },
+		)
+		expect(
+			attempt.status(),
+			'only the owner or an administrator may re-scope an object',
+		).toBeGreaterThanOrEqual(400)
+	})
+})

--- a/tests/e2e/ci/playwright.config.ts
+++ b/tests/e2e/ci/playwright.config.ts
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Open Register Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * CI PLAYWRIGHT CONFIG — a deliberately small, always-green spec set.
+ *
+ * WHY A SECOND CONFIG EXISTS
+ * --------------------------
+ * The root config points `testDir` at the whole of `tests/e2e`, which is 58
+ * spec files. Several of them write fixtures, shell out to `occ`, or capture
+ * documentation screenshots. Turning `enable-playwright` on against that set
+ * would have produced a red job on the first run, and a gate that is red on
+ * arrival is a gate nobody turns on — which is how this repo ended up with an
+ * E2E job that had never succeeded.
+ *
+ * So the job starts from a floor that CAN be green, and the floor grows. The
+ * shared workflow resolves `<playwright-test-path>/playwright.config.ts` first
+ * and only falls back to the root one, so pointing `playwright-test-path` at
+ * `tests/e2e/ci` selects THIS config and therefore this `testDir`.
+ *
+ * WHAT BELONGS HERE
+ * -----------------
+ * A spec belongs here when it is hermetic against a freshly-installed
+ * Nextcloud: it creates whatever it needs, cleans up after itself, needs no
+ * `occ`, no docker, and no pre-seeded data. Anything else stays in the root
+ * suite and is run deliberately.
+ *
+ * ⚠️ `baseURL` comes from the shared resolver, which accepts CI's `BASE_URL`
+ * and has NO localhost default — a default would silently target the shared dev
+ * container. See tests/e2e/base-url.ts.
+ */
+import { defineConfig, devices } from '@playwright/test'
+import * as path from 'path'
+import { resolveBaseUrl } from '../base-url'
+
+export default defineConfig({
+	testDir: '.',
+	globalSetup: path.resolve(__dirname, '../global-setup.ts'),
+	timeout: 45_000,
+	expect: { timeout: 15_000 },
+	fullyParallel: false,
+	// One retry in CI absorbs a genuinely slow first paint on a cold runner
+	// without hiding a real failure — a broken assertion fails twice.
+	retries: process.env.CI ? 1 : 0,
+	workers: 1,
+	reporter: [['list']],
+	outputDir: path.resolve(__dirname, '../test-results-ci'),
+
+	use: {
+		baseURL: resolveBaseUrl(),
+		extraHTTPHeaders: {
+			Authorization: `Basic ${Buffer.from(
+				`${process.env.ADMIN_USER || process.env.OR_USER || 'admin'}:${
+					process.env.ADMIN_PASSWORD || process.env.OR_PASS || 'admin'
+				}`,
+			).toString('base64')}`,
+		},
+		trace: 'on-first-retry',
+		screenshot: 'only-on-failure',
+	},
+
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices['Desktop Chrome'] },
+		},
+	],
+})

--- a/tests/e2e/ci/smoke-boot.spec.ts
+++ b/tests/e2e/ci/smoke-boot.spec.ts
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Open Register Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * BOOT SMOKE GATE — two routes, asserting the Vue app actually MOUNTED.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * A Vue 3 bundle can fail to boot in a way that npm, ESLint, webpack and even
+ * a byte-verified deploy all report as green. The known case: any
+ * `@nextcloud/*` package left on its Vue-2 major. nc-vue's pre-bundled dialogs
+ * call the v3-only `getGettextBuilder().detectLanguage()`, so an
+ * `@nextcloud/l10n@2` in the tree throws
+ *
+ *     TypeError: …detectLanguage is not a function
+ *
+ * at module-eval time. Every route then renders an empty shell. HTTP is 200,
+ * the script tag resolves, the bytes on disk are the ones you built — and the
+ * app is dead. On scholiq this was found only after 37 minutes of e2e had run
+ * against it.
+ *
+ * So: gate the expensive step on a cheap one. This spec is ~20 seconds and the
+ * run script aborts before the full suite if it fails.
+ *
+ * The assertions are deliberately about MOUNTING, not about any feature:
+ *   1. the app's host element has real child elements (Vue replaced nothing =
+ *      empty shell), and
+ *   2. no page error / boot-killer console error was raised.
+ *
+ * ⚠️ `toBeVisible()` on a container is NOT sufficient — the shell is visible
+ * when the app is dead. Assert on rendered descendants.
+ */
+import { test, expect, type ConsoleMessage } from '@playwright/test'
+import * as path from 'path'
+import * as fs from 'fs'
+
+const STORAGE_STATE = path.resolve(__dirname, '../.auth/admin.json')
+
+// Two routes: the app root, and one sub-route reached through the hash router.
+// A sub-route additionally proves the lazy view chunks resolve — a wrong
+// `publicPath` returns 200 with `text/html`, not a 404, so a chunk failure
+// shows up as a MIME refusal here and nowhere else.
+const ROUTES = [
+	{ name: 'app root', url: '/index.php/apps/openregister/' },
+	{ name: 'registers', url: '/index.php/apps/openregister/#/registers' },
+]
+
+/** Console messages that mean the bundle never booted. */
+const BOOT_KILLERS = [
+	'is not a function',
+	'ChunkLoadError',
+	'Failed to fetch dynamically imported module',
+	'Cannot read properties of undefined',
+	'Unexpected token',
+	'MIME type',
+]
+
+test.use(
+	fs.existsSync(STORAGE_STATE) ? { storageState: STORAGE_STATE } : {},
+)
+
+for (const route of ROUTES) {
+	test(`boot smoke: ${route.name} mounts`, async ({ page }) => {
+		const killers: string[] = []
+		const pageErrors: string[] = []
+
+		page.on('console', (msg: ConsoleMessage) => {
+			if (msg.type() !== 'error') {
+				return
+			}
+			const text = msg.text()
+			if (BOOT_KILLERS.some((k) => text.includes(k))) {
+				killers.push(text)
+			}
+		})
+		page.on('pageerror', (err) => pageErrors.push(String(err)))
+
+		await page.goto(route.url, { waitUntil: 'domcontentloaded' })
+
+		// The app mounts into `<div id="openregister">` (templates/index.php).
+		// Wait for it to acquire rendered children rather than for a timeout.
+		await page.waitForFunction(
+			() => {
+				const host = document.querySelector('#openregister')
+				return host !== null && host.children.length > 0
+			},
+			undefined,
+			{ timeout: 20_000 },
+		)
+
+		const childCount = await page.evaluate(
+			() => document.querySelector('#openregister')?.children.length ?? 0,
+		)
+		expect(
+			childCount,
+			`#openregister rendered no children on ${route.name} — the app did not mount`,
+		).toBeGreaterThan(0)
+
+		expect(
+			pageErrors,
+			`uncaught page error(s) on ${route.name}`,
+		).toEqual([])
+		expect(
+			killers,
+			`boot-killer console error(s) on ${route.name}`,
+		).toEqual([])
+	})
+}


### PR DESCRIPTION
docs(sharing): federated principals need no second path — and D5 was wrong about merging them

Group 7, and mostly a correction.

D5 asked that a remote principal be resolved by the same evaluator as a local
one. That turns out to need no code: IShare::TYPE_REMOTE and TYPE_REMOTE_GROUP
already sit in the SAME lists as the user and group types, in both the resolver
and the write surface, so a remote grant flows through the same resolve, the
same SQL disjunct and the same PHP verdict. There is no federated branch to keep
in step with the local one.

That property is invisible — it holds only while nobody edits two private
constants, and nothing in the suite would have noticed. FederatedPrincipalVocabularyTest
pins both lists, including the inverse: the BEARER types must stay OUT of the
principal list, or a link would start behaving like a grant to every logged-in
user.

CORRECTION. D5 also said to reconcile object grants with FederatedShare "rather
than adding a second shape". On inspection that was wrong. FederatedShare shares
a register/schema/object/query with an ORGANISATION on a peer instance,
authorised by OpenRegister's own scoped bearer token and served by
federation#objects through FederatedObjectSourceProvider. A TYPE_REMOTE grant
invites a remote USER to one object and is decided by the ordinary RBAC filter.
Folding one into the other would give the grant a SECOND decision path — exactly
what D4 forbids — and would put object-level RBAC behind a token designed to
authorise a whole register. They stay distinct, for the same reason file shares
do.

NOT PROVEN, and said so in the tasks rather than quietly ticked: that an inbound
federated grant from a real peer admits a real remote user. That needs a second
Nextcloud and an OCM handshake. Structurally it must hold, since there is only
one evaluator — but that is an argument, not evidence, and 7.2/7.3 stay open
with the dependency stated.
