### PR TITLE
feat(broker): Guard 1d — the credential broker consumes the object-grant primitive

### DIFF
--- a/lib/Service/Credential/CredentialBrokerService.php
+++ b/lib/Service/Credential/CredentialBrokerService.php
@@ -69,6 +69,7 @@ namespace OCA\OpenRegister\Service\Credential;
 
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\Rbac\ObjectGrantResolver;
 use OCA\OpenRegister\Service\OrganisationService;
 use OCA\OpenRegister\Service\Sharing\SharePrincipalDeriver;
 use OCP\Http\Client\IClientService;
@@ -83,6 +84,9 @@ use Throwable;
 /**
  * Constrained, host-locked, secret-injecting outbound broker.
  *
+ * @SuppressWarnings(PHPMD.ExcessiveParameterList)   One over, from Guard 1d's grant
+ * resolver. Every parameter is a collaborator the guard chain needs, and the chain
+ * IS the class; a parameter object would only rename the coupling.
  * @SuppressWarnings(PHPMD.ExcessiveClassLength)     44 lines over, from Guard 1c. The guard
  * chain is one security policy read top to bottom; moving a guard elsewhere is how a
  * caller ends up skipping it.
@@ -127,15 +131,20 @@ class CredentialBrokerService
     /**
      * Constructor.
      *
-     * @param ObjectService       $objectService       OR object CRUD (loads credential metadata).
-     * @param CredentialStore     $credentialStore     Secret store leaf (reads the injected secret).
-     * @param ProviderCatalogue   $catalogue           Read-only provider catalogue (host-lock + rules).
-     * @param IUserSession        $userSession         Current session (owner guard identity).
-     * @param IClientService      $clientService       NC HTTP client factory (the outbound call).
-     * @param LoggerInterface     $logger              Logger for secret-free server-side diagnostics.
-     * @param OrganisationService $organisationService Resolves organisation membership (organisation guard branch).
-     * @param IGroupManager|null  $groupManager        Resolves group principals for the share guard; null ⇒ group shares admit nobody.
-     * @param IUserManager|null   $userManager         Resolves the asserted uid's groups on the sessionless path; null ⇒ no groups.
+     * @param ObjectService            $objectService       OR object CRUD (loads credential metadata).
+     * @param CredentialStore          $credentialStore     Secret store leaf (reads the injected secret).
+     * @param ProviderCatalogue        $catalogue           Read-only provider catalogue (host-lock + rules).
+     * @param IUserSession             $userSession         Current session (owner guard identity).
+     * @param IClientService           $clientService       NC HTTP client factory (the outbound call).
+     * @param LoggerInterface          $logger              Logger for secret-free server-side diagnostics.
+     * @param OrganisationService      $organisationService Resolves organisation membership (organisation guard branch).
+     * @param IGroupManager|null       $groupManager        Resolves group principals for the share guard; null ⇒ group shares admit
+     *                                                      nobody.
+     * @param IUserManager|null        $userManager         Resolves the asserted uid's groups on the sessionless path; null ⇒ no
+     *                                                      groups.
+     * @param ObjectGrantResolver|null $objectGrants        Per-object grant resolver for Guard 1d; nullable so
+     *                                                      adding it is not a fatal at existing construction
+     *                                                      sites.
      *
      * @return void
      */
@@ -156,6 +165,7 @@ class CredentialBrokerService
         // GROUP share resolves no groups and therefore admits nobody.
         private readonly ?IGroupManager $groupManager=null,
         private readonly ?IUserManager $userManager=null,
+        private readonly ?ObjectGrantResolver $objectGrants=null,
     ) {
     }//end __construct()
 
@@ -592,6 +602,57 @@ class CredentialBrokerService
             return $credential;
         }
 
+        // Guard 1d — an OBJECT GRANT on this credential admits (task 8.4).
+        //
+        // A brokered credential IS an OpenRegister object, so the per-object
+        // grant primitive applies to it directly. This is the bridge that lets
+        // the bespoke `sharedWith[]` be retired: both are read here, so a
+        // credential shared either way is admitted, and nothing has to be
+        // migrated before the new path works.
+        //
+        // The verb is `use`, NOT `read`. Seeing that a credential exists is
+        // strictly weaker than spending it (design Q6), and core's bitmask has
+        // no `use` — so it rides in the share's attribute bag and is asked for
+        // here, at the endpoint that performs the action, exactly as ADR-010
+        // Rule 4 requires. A plain read grant does not admit a broker call.
+        //
+        // ADMIT-ONLY, like 1c: a credential with no grant cannot admit here, so
+        // every pre-existing verdict is unchanged.
+        if ($this->objectGrantAdmits(data: $data, actingOrganisationId: $actingOrganisationId) === true) {
+            return $credential;
+        }
+
+        return $this->admitByScope(
+            credential: $credential,
+            data: $data,
+            credentialId: $credentialId,
+            actingUserId: $actingUserId,
+            actingOrganisationId: $actingOrganisationId
+        );
+    }//end loadAdmittedCredential()
+
+    /**
+     * The scope half of Guard 1 — organisation membership, or personal ownership.
+     *
+     * Extracted from {@see loadAdmittedCredential()} so that chain stays under the
+     * length budget as guards are added. The order and the verdicts are unchanged:
+     * the same code, in the same sequence, one call further down.
+     *
+     * @param object               $credential           The credential entity.
+     * @param array<string, mixed> $data                 Its serialised data.
+     * @param string               $credentialId         For the denial message.
+     * @param string|null          $actingUserId         The acting user.
+     * @param string|null          $actingOrganisationId Asserted organisation for in-process callers.
+     *
+     * @return object The admitted credential.
+     */
+    private function admitByScope(
+        object $credential,
+        array $data,
+        string $credentialId,
+        ?string $actingUserId,
+        ?string $actingOrganisationId
+    ): object {
         if ($this->scopeOf(data: $data) === self::SCOPE_ORGANISATION) {
             $this->assertOrganisationMember(
                 data: $data,
@@ -604,7 +665,7 @@ class CredentialBrokerService
         $this->assertPersonalOwner(credential: $credential, credentialId: $credentialId, actingUserId: $actingUserId);
 
         return $credential;
-    }//end loadAdmittedCredential()
+    }//end admitByScope()
 
     /**
      * Whether an explicit share admits the acting identity (Guard 1c).
@@ -669,6 +730,54 @@ class CredentialBrokerService
             permissions: ['use', null]
         );
     }//end sharedPrincipalAdmits()
+
+    /**
+     * Whether a per-object GRANT admits the acting identity (Guard 1d).
+     *
+     * A brokered credential is an OpenRegister object, so the object-grant
+     * primitive addresses it directly by UUID — no second share shape is needed
+     * here, which is the whole point of task 8.4.
+     *
+     * THE VERB IS `use`, NOT `read`. Being able to see that a credential exists
+     * is strictly weaker than being able to spend it (design Q6), and core's
+     * permission bitmask has no `use` to carry. So the verb rides in the share's
+     * attribute bag and is asked for HERE — at the endpoint that performs the
+     * action — which is what ADR-010 Rule 4 requires and what keeps the RBAC
+     * evaluator answering only for verbs it defines. A plain read grant on a
+     * credential does not admit a broker call.
+     *
+     * TENANT EDGE: identical to Guard 1c's. When the credential declares an
+     * organisation, a grant admits only inside it. The same helper decides both,
+     * so the two guards cannot drift on the edge that matters most.
+     *
+     * @param array<string, mixed> $data                 The credential's serialised data.
+     * @param string|null          $actingOrganisationId Asserted organisation for sessionless in-process callers.
+     *
+     * @return bool True when a grant carrying `use` admits the acting identity.
+     */
+    private function objectGrantAdmits(array $data, ?string $actingOrganisationId=null): bool
+    {
+        if ($this->objectGrants === null) {
+            // Fail CLOSED. No resolver means no grant, which denies rather than
+            // admits — and 1c plus the scope guards still run.
+            return false;
+        }
+
+        $uuid = (string) ($data['id'] ?? $data['uuid'] ?? '');
+        if ($uuid === '') {
+            return false;
+        }
+
+        if ($this->shareWithinTenant(data: $data, actingOrganisationId: $actingOrganisationId) === false) {
+            return false;
+        }
+
+        return $this->objectGrants->grantCarriesVerb(
+            userId: $this->userSession->getUser()?->getUID(),
+            objectUuid: $uuid,
+            verb: 'use'
+        );
+    }//end objectGrantAdmits()
 
     /**
      * Whether the acting identity is inside the credential's organisation, when it declares one.

--- a/lib/Service/Rbac/ObjectGrantResolver.php
+++ b/lib/Service/Rbac/ObjectGrantResolver.php
@@ -108,6 +108,17 @@ class ObjectGrantResolver
     private array $memoised = [];
 
     /**
+     * Extension verbs carried by the caller's grants, keyed by object UUID.
+     *
+     * Populated during the same resolve as the bitmask and cleared by the same
+     * `forget()`, so the two can never disagree about which request they belong
+     * to.
+     *
+     * @var array<string, string[]>
+     */
+    private array $verbs = [];
+
+    /**
      * Constructor.
      *
      * @param LoggerInterface         $logger    Logger.
@@ -276,10 +287,16 @@ class ObjectGrantResolver
     {
         if ($userId === null) {
             $this->memoised = [];
+            $this->verbs    = [];
             return;
         }
 
         unset($this->memoised[$userId]);
+
+        // The verb map is keyed by OBJECT, not by user, so a per-user forget
+        // cannot prune it precisely. Clearing it wholly is the safe direction:
+        // it is rebuilt on the next resolve, and a stale verb would admit.
+        $this->verbs = [];
     }//end forget()
 
     /**
@@ -332,7 +349,18 @@ class ObjectGrantResolver
                 // composes overlapping shares.
                 $existing       = ($granted[$uuid] ?? 0);
                 $granted[$uuid] = ($existing | $share->getPermissions());
-            }
+
+                // Extension verbs ride in IShare's attribute bag (ADR-010), not
+                // in the permission integer, because core's bitmask has no room
+                // for a verb it does not define. Unioned across overlapping
+                // grants for the same reason the bitmask is.
+                $verbs = $this->verbsOf(share: $share);
+                if (empty($verbs) === false) {
+                    $this->verbs[$uuid] = array_values(
+                        array_unique(array_merge(($this->verbs[$uuid] ?? []), $verbs))
+                    );
+                }
+            }//end foreach
 
             if (count($shares) < self::PAGE_SIZE) {
                 return;
@@ -351,6 +379,87 @@ class ObjectGrantResolver
             ]
         );
     }//end collectForType()
+
+    /**
+     * The attribute scope OpenRegister's extension verbs live under.
+     *
+     * @var string
+     */
+    public const VERB_ATTRIBUTE_SCOPE = 'openregister';
+
+    /**
+     * The attribute key holding the verb list.
+     *
+     * @var string
+     */
+    public const VERB_ATTRIBUTE_KEY = 'verbs';
+
+    /**
+     * Whether a grant carries one EXTENSION verb for this caller.
+     *
+     * Core's bitmask has five verbs and OpenRegister has more concepts than
+     * that — `use` a credential, `run` a flow. ADR-010 puts those in the share's
+     * attribute bag rather than widening the RBAC vocabulary, and this is the
+     * read side of it.
+     *
+     * Deliberately SEPARATE from {@see isGranted()}. That method answers for the
+     * five core verbs and refuses everything else, which is what keeps the RBAC
+     * evaluator finite and reviewable. An extension verb is asked for by the
+     * endpoint that performs the action, and only there.
+     *
+     * @param string|null $userId     The caller.
+     * @param string|null $objectUuid The object.
+     * @param string      $verb       The extension verb, e.g. `use`.
+     *
+     * @return bool True when a grant to this caller carries that verb.
+     */
+    public function grantCarriesVerb(?string $userId, ?string $objectUuid, string $verb): bool
+    {
+        if ($objectUuid === null || $objectUuid === '') {
+            return false;
+        }
+
+        // Force the resolve — that is what populates the verb map.
+        $granted = $this->grantedObjectUuids(userId: $userId);
+        if (array_key_exists($objectUuid, $granted) === false) {
+            return false;
+        }
+
+        return in_array($verb, ($this->verbs[$objectUuid] ?? []), true);
+    }//end grantCarriesVerb()
+
+    /**
+     * The extension verbs one share carries.
+     *
+     * @param IShare $share The share.
+     *
+     * @return string[] The verbs, empty when it carries none.
+     */
+    private function verbsOf(IShare $share): array
+    {
+        try {
+            $attributes = $share->getAttributes();
+            if ($attributes === null) {
+                return [];
+            }
+
+            $raw = $attributes->getAttribute(self::VERB_ATTRIBUTE_SCOPE, self::VERB_ATTRIBUTE_KEY);
+        } catch (Throwable $e) {
+            return [];
+        }
+
+        if (is_string($raw) === true) {
+            $raw = json_decode($raw, true);
+        }
+
+        if (is_array($raw) === false) {
+            return [];
+        }
+
+        return array_values(
+            array_filter($raw, static fn($verb) => is_string($verb) === true && $verb !== '')
+        );
+    }//end verbsOf()
 
     /**
      * The object UUID a share grants, or null when it grants no object.

--- a/lib/Service/Rbac/ObjectSharingService.php
+++ b/lib/Service/Rbac/ObjectSharingService.php
@@ -236,14 +236,23 @@ class ObjectSharingService
      * @param string       $type        One of the GRANTABLE_TYPES keys.
      * @param string       $shareWith   The principal to grant.
      * @param integer      $permissions Core permission bitmask.
+     * @param string[]     $verbs       Extension verbs (e.g. `use`, `run`) carried in the share's
+     *                                  attribute bag. Core's bitmask has no room for a verb it does
+     *                                  not define, so ADR-010 puts them here rather than widening
+     *                                  the RBAC vocabulary.
      *
      * @throws NotAuthorizedException When the caller is neither owner nor admin.
      * @throws InvalidArgumentException On an unsupported type or unresolvable folder.
      *
      * @return array<string, mixed> The created grant.
      */
-    public function grant(ObjectEntity $object, string $type, string $shareWith, int $permissions=1): array
-    {
+    public function grant(
+        ObjectEntity $object,
+        string $type,
+        string $shareWith,
+        int $permissions=1,
+        array $verbs=[]
+    ): array {
         $this->requireOwnerOrAdmin(object: $object);
 
         if (isset(self::GRANTABLE_TYPES[$type]) === false) {
@@ -273,6 +282,8 @@ class ObjectSharingService
         $share->setSharedBy($uid);
         $share->setPermissions($permissions);
 
+        $this->applyVerbs(share: $share, verbs: $verbs);
+
         $created = $this->shareManager->createShare($share);
 
         // The caller may re-decide access within this same request.
@@ -283,8 +294,43 @@ class ObjectSharingService
             'type'        => $type,
             'sharedWith'  => $created->getSharedWith(),
             'permissions' => $created->getPermissions(),
+            'verbs'       => array_values($verbs),
         ];
     }//end grant()
+
+    /**
+     * Attach extension verbs to a share.
+     *
+     * Stored as JSON in `IShare`'s attribute bag under OpenRegister's own scope,
+     * which is the extension point other Nextcloud apps use for exactly this.
+     * Values are filtered to non-empty strings so a malformed request cannot put
+     * an object or a null into the bag and have the read side trip over it.
+     *
+     * @param IShare   $share The share being built.
+     * @param string[] $verbs The verbs to carry.
+     *
+     * @return void
+     */
+    private function applyVerbs(IShare $share, array $verbs): void
+    {
+        $clean = array_values(
+            array_unique(
+                array_filter($verbs, static fn($verb) => is_string($verb) === true && trim($verb) !== '')
+            )
+        );
+
+        if (empty($clean) === true) {
+            return;
+        }
+
+        $attributes = ($share->getAttributes() ?? $share->newAttributes());
+        $attributes->setAttribute(
+            ObjectGrantResolver::VERB_ATTRIBUTE_SCOPE,
+            ObjectGrantResolver::VERB_ATTRIBUTE_KEY,
+            json_encode($clean)
+        );
+        $share->setAttributes($attributes);
+    }//end applyVerbs()
 
     /**
      * Create a tokenised LINK to an object, optionally expiring and passworded.

--- a/openspec/changes/object-level-sharing-and-private-scope/tasks.md
+++ b/openspec/changes/object-level-sharing-and-private-scope/tasks.md
@@ -192,7 +192,11 @@
       configuration, and inviting a person are three different acts
 - [ ] 8.3 Migrate the bespoke `sharedWith[]` to the primitive. Scoped by the audit to THREE
       consumers: openregister credentials + flows, launchpad manifests, doriath dashboards
-- [ ] 8.4 Point the credential broker's share admit branch at the primitive instead of its own copy of the shape
+- [x] 8.4 The broker reads the primitive as Guard 1d, ALONGSIDE its own 1c rather than instead of
+      it — so a credential shared either way is admitted and retiring the bespoke list becomes a
+      data migration, not a flag day. The verb is `use`, not `read` (Q6), which required building
+      ADR-010's IAttributes half: grants can now carry extension verbs, and `grantCarriesVerb()`
+      is separate from `isGranted()` so RBAC keeps answering only for the five core verbs
 - [ ] 8.6 Collapse `scope` as the ACCESS discriminator into `private` (Q7): `personal` -> private-with-no-invitations, `organisation` -> the default scope
 - [ ] 8.7 KEEP `scope` as the VAULT-OWNER selector, untouched — and test that an organisation credential minted BEFORE the collapse is still readable after it
 - [ ] 8.5 Remove the per-schema derived lists once nothing reads them, with a data migration — not before

--- a/tests/Db/ObjectShareLinkIntegrationTest.php
+++ b/tests/Db/ObjectShareLinkIntegrationTest.php
@@ -332,6 +332,71 @@ class ObjectShareLinkIntegrationTest extends TestCase
 
 
     /**
+     * An extension verb rides on the grant, and a plain read grant does not carry it.
+     *
+     * ADR-010: core's bitmask has five verbs and OpenRegister has more concepts
+     * than that. `use` a credential and `run` a flow live in the share's
+     * attribute bag instead of widening the RBAC vocabulary — and the point of
+     * keeping them separate is that a read grant must NOT imply them.
+     *
+     * This is the half the ADR listed as unbuilt when it was written. It is what
+     * lets the credential broker's Guard 1d admit on the shared primitive.
+     */
+    public function testAGrantCarriesExtensionVerbsAndReadAloneDoesNot(): void
+    {
+        [$register, $schema, $object] = $this->privateObject('verbgrant');
+
+        $recipientUid = 'verb-recipient-'.substr((string) Uuid::v4(), 0, 8);
+        $recipient    = $this->userManager->createUser($recipientUid, 'Link-Test-Pass-123');
+
+        try {
+            $resolver = \OC::$server->get(\OCA\OpenRegister\Service\Rbac\ObjectGrantResolver::class);
+
+            // A plain READ grant first — the control. Without it, a passing
+            // assertion below would not distinguish "the verb was carried" from
+            // "every grant reports every verb".
+            $this->sharing()->grant(
+                object: $object,
+                type: 'user',
+                shareWith: $recipientUid,
+                permissions: 1
+            );
+            $resolver->forget();
+
+            $this->assertFalse(
+                $resolver->grantCarriesVerb($recipientUid, $object->getUuid(), 'use'),
+                'a plain read grant must NOT carry `use` — seeing a credential is weaker than spending it'
+            );
+
+            // Now one that does carry it.
+            [, , $withVerb] = $this->privateObject('verbgrant2');
+            $this->sharing()->grant(
+                object: $withVerb,
+                type: 'user',
+                shareWith: $recipientUid,
+                permissions: 1,
+                verbs: ['use']
+            );
+            $resolver->forget();
+
+            $this->assertTrue(
+                $resolver->grantCarriesVerb($recipientUid, $withVerb->getUuid(), 'use'),
+                'a grant created with the `use` verb must carry it'
+            );
+            $this->assertFalse(
+                $resolver->grantCarriesVerb($recipientUid, $withVerb->getUuid(), 'run'),
+                'it must carry only the verbs it was given'
+            );
+        } finally {
+            $this->userSession->setUser($this->ownerUser);
+            if ($recipient !== false && $recipient !== null) {
+                $recipient->delete();
+            }
+        }
+    }//end testAGrantCarriesExtensionVerbsAndReadAloneDoesNot()
+
+
+    /**
      * Resolve a token the way the public endpoint does.
      *
      * Deliberately mirrors `ObjectShareLinkController` rather than calling it:


### PR DESCRIPTION
feat(broker): Guard 1d — the credential broker consumes the object-grant primitive

Task 8.4, and the bridge task 8.3 needs. A brokered credential IS an OpenRegister
object, so the per-object grant primitive addresses it directly by UUID. The
broker now reads BOTH the bespoke sharedWith[] (Guard 1c) and an object grant
(Guard 1d), which means a credential shared either way is admitted and nothing
has to be migrated before the new path works. Retiring the bespoke list becomes a
data migration rather than a flag day.

THE VERB IS `use`, NOT `read`, and that distinction needed building.

Seeing that a credential exists is strictly weaker than spending it (design Q6),
and core's permission bitmask has no `use` to carry. ADR-010 says an extension
verb rides in IShare's attribute bag and is enforced at the endpoint that
performs the action — and that ADR listed the attribute half as unbuilt when it
was written. This builds it: grants can now carry verbs
(ObjectSharingService::grant(verbs: ['use'])), the resolver collects them during
the same resolve as the bitmask, and grantCarriesVerb() is deliberately SEPARATE
from isGranted() so the RBAC evaluator keeps answering only for the five verbs it
defines and refusing the rest.

A plain read grant on a credential therefore does NOT admit a broker call. That
is asserted with its control: the test creates a read-only grant first and
requires `use` to be absent, so a passing assertion cannot mean "every grant
reports every verb".

Guard 1d is ADMIT-ONLY, like 1c, so no pre-existing verdict changes: a credential
with no grant cannot admit there, and the allowedApps, provider allow-rule and
host-lock guards all still run on every admitted call. The tenant edge uses the
SAME shareWithinTenant() helper as 1c, so the two guards cannot drift on the
check that matters most.

loadAdmittedCredential()'s scope half moves into admitByScope() — same code, same
order, one call further down — so the chain stays under the length budget as
guards accumulate rather than growing a block each time.

7 live-DB tests green; full unit suite identical to baseline by failing-test NAME,
not just count.
