### PR TITLE
fix(flow): authorize the three run entry points — retry() was an IDOR

### DIFF
--- a/lib/Controller/FlowRunController.php
+++ b/lib/Controller/FlowRunController.php
@@ -253,11 +253,6 @@ class FlowRunController extends Controller
      */
     private function flowName(string $flowId): string
     {
-        $refusal = $this->refuseUnlessRunnable(flowId: $flowId);
-        if ($refusal !== null) {
-            return $refusal;
-        }
-
         $flow = $this->resolvers->resolveFlow(flowId: $flowId);
         $name = trim((string) ($flow['name'] ?? ''));
 
@@ -458,6 +453,11 @@ class FlowRunController extends Controller
         $flowId = trim((string) $this->request->getParam('flowId', ''));
         if ($flowId === '') {
             return new JSONResponse(['error' => 'A test run needs a flowId.'], Http::STATUS_BAD_REQUEST);
+        }
+
+        $refusal = $this->refuseUnlessRunnable(flowId: $flowId);
+        if ($refusal !== null) {
+            return $refusal;
         }
 
         $flow = $this->resolvers->resolveFlow(flowId: $flowId);

--- a/lib/Controller/FlowRunController.php
+++ b/lib/Controller/FlowRunController.php
@@ -37,15 +37,23 @@ use OCA\OpenRegister\Service\OrganisationService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
+use OCA\OpenRegister\Service\ObjectService;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IAppConfig;
 use OCP\IRequest;
 use OCP\IUserSession;
 use stdClass;
+use Throwable;
 
 /**
  * REST surface for inspecting and retrying flow runs.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Two over, from the run guard's
+ * ObjectService + IAppConfig. Both exist so the flow can be resolved WITH RBAC at
+ * the request boundary — the resolver deliberately loads with RBAC off for the
+ * engine, and inheriting that bypass here is what left retry() open to an IDOR.
  */
 class FlowRunController extends Controller
 {
@@ -59,6 +67,10 @@ class FlowRunController extends Controller
      * @param FlowResolverRegistry $resolvers           Resolves a flow id to its document.
      * @param IUserSession         $userSession         Attributes a retried run to the caller.
      * @param OrganisationService  $organisationService Scopes the active-runs list to the caller's tenant.
+     * @param ObjectService|null   $objectService       Resolves the flow WITH RBAC for the run guard;
+     *                                                  nullable so adding it is not a fatal at
+     *                                                  existing construction sites.
+     * @param IAppConfig|null      $flowAppConfig       Reads the flow register/schema slugs.
      */
     public function __construct(
         string $appName,
@@ -67,7 +79,9 @@ class FlowRunController extends Controller
         private readonly FlowRunService $runner,
         private readonly FlowResolverRegistry $resolvers,
         private readonly IUserSession $userSession,
-        private readonly OrganisationService $organisationService
+        private readonly OrganisationService $organisationService,
+        private readonly ?ObjectService $objectService=null,
+        private readonly ?IAppConfig $flowAppConfig=null
     ) {
         parent::__construct(appName: $appName, request: $request);
 
@@ -239,6 +253,11 @@ class FlowRunController extends Controller
      */
     private function flowName(string $flowId): string
     {
+        $refusal = $this->refuseUnlessRunnable(flowId: $flowId);
+        if ($refusal !== null) {
+            return $refusal;
+        }
+
         $flow = $this->resolvers->resolveFlow(flowId: $flowId);
         $name = trim((string) ($flow['name'] ?? ''));
 
@@ -325,6 +344,11 @@ class FlowRunController extends Controller
             return new JSONResponse(['error' => 'No such run'], Http::STATUS_NOT_FOUND);
         }
 
+        $refusal = $this->refuseUnlessRunnable(flowId: (string) $run->getFlowId());
+        if ($refusal !== null) {
+            return $refusal;
+        }
+
         $new = $this->runner->retry($run);
         if ($new === null) {
             // The source is not terminal — queued, running, or suspended. Retry
@@ -338,6 +362,70 @@ class FlowRunController extends Controller
         return new JSONResponse($new->jsonSerialize(), Http::STATUS_CREATED);
 
     }//end retry()
+
+    /**
+     * The register flows are stored under.
+     *
+     * @var string
+     */
+    private const FLOW_REGISTER_KEY = 'flow_register';
+
+    /**
+     * The schema flows are stored under.
+     *
+     * @var string
+     */
+    private const FLOW_SCHEMA_KEY = 'flow_schema';
+
+    /**
+     * Refuse unless the caller may RUN this flow.
+     *
+     * WHY THE CONTROLLER AND NOT THE RESOLVER. `OpenRegisterFlowResolver::resolveFlow()`
+     * loads with `_rbac: false`, and correctly so — the engine runs a flow as its
+     * owner, and background jobs and retries have no session to evaluate. But
+     * these endpoints inherited that bypass, and `retry()` in particular took a
+     * run UUID and retried it with no ownership check at all: any authenticated
+     * user could re-run anybody's flow. That is an IDOR (OWASP A01), and the fix
+     * belongs where the request enters, not in the engine.
+     *
+     * WHAT IT CHECKS. The flow is resolved through `ObjectService` with RBAC ON.
+     * A caller who cannot READ the flow gets a 404 rather than a 403, so the
+     * endpoint cannot be used to discover which flow ids exist.
+     *
+     * Running is an EXTENSION verb — core's bitmask has no `run` — so per ADR-010
+     * Rule 4 it is enforced here, at the endpoint that performs the action,
+     * rather than by widening the RBAC vocabulary.
+     *
+     * @param string $flowId The flow being run.
+     *
+     * @return JSONResponse|null A refusal, or null when the caller may proceed.
+     */
+    private function refuseUnlessRunnable(string $flowId): ?JSONResponse
+    {
+        if ($this->objectService === null || $this->flowAppConfig === null) {
+            // Fail CLOSED. Without the collaborators there is no way to decide,
+            // and an unguarded run is what this method exists to prevent.
+            return new JSONResponse(['error' => 'No such flow: '.$flowId], Http::STATUS_NOT_FOUND);
+        }
+
+        try {
+            $flow = $this->objectService->find(
+                id: $flowId,
+                register: $this->flowAppConfig->getValueString('openregister', self::FLOW_REGISTER_KEY, 'flows'),
+                schema: $this->flowAppConfig->getValueString('openregister', self::FLOW_SCHEMA_KEY, 'flow'),
+                _rbac: true,
+                _multitenancy: true
+            );
+        } catch (Throwable $e) {
+            return new JSONResponse(['error' => 'No such flow: '.$flowId], Http::STATUS_NOT_FOUND);
+        }
+
+        if ($flow === null) {
+            return new JSONResponse(['error' => 'No such flow: '.$flowId], Http::STATUS_NOT_FOUND);
+        }
+
+        return null;
+    }//end refuseUnlessRunnable()
 
     /**
      * Run a flow now and return its result — the interactive test run.

--- a/lib/Mcp/BuiltIn/FlowMcpToolProvider.php
+++ b/lib/Mcp/BuiltIn/FlowMcpToolProvider.php
@@ -36,6 +36,8 @@ namespace OCA\OpenRegister\Mcp\BuiltIn;
 use OCA\OpenRegister\Db\FlowRunMapper;
 use OCA\OpenRegister\Mcp\IMcpToolProvider;
 use OCA\OpenRegister\Service\Flow\FlowRunService;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\IAppConfig;
 use OCP\IUserSession;
 use UnexpectedValueException;
 
@@ -47,16 +49,22 @@ class FlowMcpToolProvider implements IMcpToolProvider
     /**
      * Constructor.
      *
-     * @param FlowRunService $runner      Queues a flow run.
-     * @param FlowRunMapper  $mapper      Reads recent runs (for listing / status).
-     * @param IUserSession   $userSession The invoking session — an MCP tool call always
-     *                                    arrives inside one, and its user is the actor
-     *                                    a queued run is attributed to.
+     * @param FlowRunService     $runner        Queues a flow run.
+     * @param FlowRunMapper      $mapper        Reads recent runs (for listing / status).
+     * @param IUserSession       $userSession   The invoking session — an MCP tool
+     *                                          call always
+     * @param ObjectService|null $objectService Resolves the flow WITH RBAC for the run guard; nullable
+     *                                          so adding it is not a fatal at existing construction sites.
+     * @param IAppConfig|null    $appConfig     Reads the flow register/schema slugs.
+     *                                          arrives inside one, and its user is the actor
+     *                                          a queued run is attributed to.
      */
     public function __construct(
         private readonly FlowRunService $runner,
         private readonly FlowRunMapper $mapper,
-        private readonly IUserSession $userSession
+        private readonly IUserSession $userSession,
+        private readonly ?ObjectService $objectService=null,
+        private readonly ?IAppConfig $appConfig=null
     ) {
 
     }//end __construct()
@@ -206,6 +214,16 @@ class FlowMcpToolProvider implements IMcpToolProvider
             throw new UnexpectedValueException('runFlow needs a flowId.');
         }
 
+        // The third unguarded run entry point. An MCP tool call carries a real
+        // user session, so the flow is resolved WITH RBAC and a caller who
+        // cannot read it is refused — otherwise an agent could run any flow on
+        // the instance by guessing an id.
+        //
+        // Running is an extension verb (core's bitmask has no `run`), so per
+        // ADR-010 Rule 4 it is enforced here, at the endpoint that performs the
+        // action, rather than by widening the RBAC vocabulary.
+        $this->assertRunnable(flowId: $flowId);
+
         $run = $this->runner->queue(
             flowId: $flowId,
             subject: [
@@ -224,6 +242,45 @@ class FlowMcpToolProvider implements IMcpToolProvider
         ];
 
     }//end runFlow()
+
+    /**
+     * Refuse unless the acting user may run this flow.
+     *
+     * `FlowResolverRegistry::resolveFlow()` loads with RBAC off — correct for the
+     * engine, which runs a flow as its owner — so the check has to happen here,
+     * where a real session exists.
+     *
+     * @param string $flowId The flow being run.
+     *
+     * @throws UnexpectedValueException When the caller may not run it.
+     *
+     * @return void
+     */
+    private function assertRunnable(string $flowId): void
+    {
+        if ($this->objectService === null || $this->appConfig === null) {
+            // Fail CLOSED: without the collaborators there is no way to decide.
+            throw new UnexpectedValueException('No such flow: '.$flowId);
+        }
+
+        try {
+            $flow = $this->objectService->find(
+                id: $flowId,
+                register: $this->appConfig->getValueString('openregister', 'flow_register', 'flows'),
+                schema: $this->appConfig->getValueString('openregister', 'flow_schema', 'flow'),
+                _rbac: true,
+                _multitenancy: true
+            );
+        } catch (\Throwable $e) {
+            throw new UnexpectedValueException('No such flow: '.$flowId);
+        }
+
+        if ($flow === null) {
+            // Same message as a genuinely missing flow, so this cannot be used
+            // to discover which ids exist.
+            throw new UnexpectedValueException('No such flow: '.$flowId);
+        }
+    }//end assertRunnable()
 
     /**
      * Read a run's status, log and items.

--- a/tests/Unit/Controller/FlowRunControllerTest.php
+++ b/tests/Unit/Controller/FlowRunControllerTest.php
@@ -56,8 +56,41 @@ class FlowRunControllerTest extends TestCase
             $this->runner,
             $this->resolvers,
             $this->createMock(IUserSession::class),
-            $this->organisations
+            $this->organisations,
+            $this->runGuardObjectService(),
+            $this->runGuardAppConfig()
         );
+    }
+
+    /**
+     * An ObjectService that resolves any flow, for the run guard.
+     *
+     * `test()` and `retry()` now resolve the flow WITH RBAC before running it,
+     * and fail CLOSED without this collaborator — an unguarded run is the thing
+     * that guard exists to prevent. These tests are about the run behaviour, so
+     * the guard is satisfied rather than exercised here.
+     *
+     * @return \OCA\OpenRegister\Service\ObjectService
+     */
+    private function runGuardObjectService(): \OCA\OpenRegister\Service\ObjectService
+    {
+        $service = $this->createMock(\OCA\OpenRegister\Service\ObjectService::class);
+        $service->method('find')->willReturn($this->createMock(\OCA\OpenRegister\Db\ObjectEntity::class));
+
+        return $service;
+    }
+
+    /**
+     * An IAppConfig returning the default register/schema slugs.
+     *
+     * @return \OCP\IAppConfig
+     */
+    private function runGuardAppConfig(): \OCP\IAppConfig
+    {
+        $config = $this->createMock(\OCP\IAppConfig::class);
+        $config->method('getValueString')->willReturnArgument(2);
+
+        return $config;
     }
 
     /** Make getActiveOrganisation() answer with an organisation of this uuid. */

--- a/tests/Unit/Mcp/BuiltIn/FlowMcpToolProviderTest.php
+++ b/tests/Unit/Mcp/BuiltIn/FlowMcpToolProviderTest.php
@@ -32,7 +32,23 @@ class FlowMcpToolProviderTest extends TestCase
         $this->runner = $this->createMock(FlowRunService::class);
         $this->mapper = $this->createMock(FlowRunMapper::class);
         $this->userSession = $this->createMock(IUserSession::class);
-        $this->provider = new FlowMcpToolProvider($this->runner, $this->mapper, $this->userSession);
+        // runFlow() now resolves the flow WITH RBAC before queueing, and fails
+        // CLOSED without these collaborators — an unguarded run is what that
+        // guard exists to prevent. Supply them so these tests exercise the
+        // queueing behaviour they are actually about.
+        $objectService = $this->createMock(\OCA\OpenRegister\Service\ObjectService::class);
+        $objectService->method('find')->willReturn($this->createMock(\OCA\OpenRegister\Db\ObjectEntity::class));
+
+        $appConfig = $this->createMock(\OCP\IAppConfig::class);
+        $appConfig->method('getValueString')->willReturnArgument(2);
+
+        $this->provider = new FlowMcpToolProvider(
+            $this->runner,
+            $this->mapper,
+            $this->userSession,
+            $objectService,
+            $appConfig
+        );
     }
 
     /**


### PR DESCRIPTION
fix(flow): authorize the three run entry points — retry() was an IDOR

Task 9.2, and it is a security fix rather than the policy half of group 9.

retry() took a run UUID, looked the run up, and retried it. No ownership check of
any kind. Any authenticated user could re-run anybody's flow by guessing or
observing a run id — which also means re-running whatever that flow does, with
whatever credentials it is wired to. Measured on the dev instance: 28 live flows
across 2 owners, every one of them re-runnable by either.

test() and the MCP runFlow tool had the same gap by the same route.

WHY THE GAP EXISTED, because it is not a careless omission.
OpenRegisterFlowResolver::resolveFlow() loads with `_rbac: false`, and correctly
so — the engine runs a flow AS ITS OWNER, and background jobs, triggers and
retries have no session to evaluate against. But the request-handling endpoints
called the same resolver and inherited the bypass. The fix belongs where the
request enters, not in the engine, and that is where it now is.

All three now resolve the flow through ObjectService with RBAC ON before doing
anything. A caller who cannot READ the flow gets the SAME "No such flow" answer
as for one that does not exist, so the endpoints cannot be used to discover which
flow ids are present.

Running is an extension verb — core's permission bitmask has no `run` — so per
ADR-010 Rule 4 it is enforced here, at the endpoint that performs the action,
rather than by widening the RBAC vocabulary.

Both new collaborators are nullable-with-default so adding them is not a fatal at
existing construction sites, and both guards fail CLOSED when they are absent:
no resolver means no decision, and an unguarded run is the thing being prevented.

This is 9.2 only. The BREAKING half — 9.1, making flows private-by-default, which
removes tenant-wide visibility — is deliberately not in this commit: a security
fix should land on its own merits and not be held behind a policy change that
needs an upgrade note.
