### PR TITLE
fix(reporting): ReportRenderJob rendered zero dashboards on every run — the RBAC opt-out it needed already existed

### DIFF
--- a/lib/BackgroundJob/ReportRenderJob.php
+++ b/lib/BackgroundJob/ReportRenderJob.php
@@ -37,6 +37,7 @@ use OCA\OpenRegister\Db\MagicMapper;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\Register;
 use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Service\Reporting\ReportRenderService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
@@ -47,6 +48,42 @@ use Psr\Log\LoggerInterface;
 
 /**
  * Daily scheduled-report renderer.
+ *
+ * RBAC / multi-tenancy posture — written down deliberately, not implied
+ * (openregister#2282):
+ *
+ * This is a system job. It runs from cron with NO user session, so there is no
+ * principal for RBAC to evaluate and no organisation for multi-tenancy to scope
+ * to. An RBAC-applying read from here does not "fail safe" — it returns nothing,
+ * which is exactly the silent-zero this job shipped with. The job therefore reads
+ * with `_rbac`/`_multitenancy` explicitly DISABLED on every hop:
+ *
+ *   - `loadReportsRegister()` — `RegisterMapper::find(..., _rbac: false, _multitenancy: false)`
+ *   - `loadDashboards()`      — `SchemaMapper::findMultiple(..., _rbac: false, _multitenancy: false)`
+ *                               and the reserved `_rbac`/`_multitenancy` query
+ *                               filters on the object read.
+ *
+ * Access control is NOT abandoned, it is enforced at DELIVERY instead of at read.
+ * `writeToFiles()` resolves the target home from `$dashboard->getOwner()` — the
+ * dashboard object's own owner — refuses to deliver at all when that owner is
+ * null (rather than falling back to `admin`), and confines the path to a
+ * traversal-checked relative folder under that owner's home. A rendered report
+ * can therefore only ever land in the Files tree of the user the dashboard
+ * already belongs to. Widening the READ does not widen who receives the OUTPUT.
+ *
+ * This deliberately does NOT add `_rbac`/`_multitenancy` parameters to
+ * `MagicMapper::findAll()`. The central mapper already exposes the opt-out as
+ * first-class reserved query params (`MagicSearchHandler::getReservedParams()`,
+ * consumed at `buildFilteredQuery()`), and `SchemaDeletionService` already reads
+ * this way for the same system-level reason. Using the existing idiom leaves the
+ * mapper's RBAC contract untouched.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Injecting SchemaMapper to
+ * resolve the reports register's schemas takes this class from 12 to 13 coupled
+ * types, one over the threshold. Measured, not assumed: phpmd exits 0 on the
+ * pre-fix file and 2 on this one, with CouplingBetweenObjects as the only
+ * finding. The dependency is required — without it the job cannot name a schema,
+ * and `MagicMapper::findAll()` returns [] without one, which is openregister#2282.
  */
 class ReportRenderJob extends TimedJob
 {
@@ -80,12 +117,20 @@ class ReportRenderJob extends TimedJob
     private const REPORTS_REGISTER_SLUG = 'reports';
 
     /**
+     * Maximum dashboards read per schema in one pass.
+     *
+     * @var int
+     */
+    private const DASHBOARD_SCAN_LIMIT = 200;
+
+    /**
      * Constructor.
      *
      * @param ITimeFactory        $time           Time factory.
      * @param IAppConfig          $appConfig      App-config reader.
      * @param ReportRenderService $renderService  Render composer.
      * @param RegisterMapper      $registerMapper Register lookup.
+     * @param SchemaMapper        $schemaMapper   Schema lookup for the register's schemas.
      * @param MagicMapper         $objectMapper   Object loader.
      * @param IRootFolder         $rootFolder     Files root.
      * @param LoggerInterface     $logger         Logger.
@@ -95,6 +140,7 @@ class ReportRenderJob extends TimedJob
         private readonly IAppConfig $appConfig,
         private readonly ReportRenderService $renderService,
         private readonly RegisterMapper $registerMapper,
+        private readonly SchemaMapper $schemaMapper,
         private readonly MagicMapper $objectMapper,
         private readonly IRootFolder $rootFolder,
         private readonly LoggerInterface $logger
@@ -359,30 +405,91 @@ class ReportRenderJob extends TimedJob
     /**
      * Load every dashboard object in the reports register.
      *
+     * The dashboard schema is the only one in the reports register; we walk
+     * by-register so a future "report" schema (Phase 3 template variants) is
+     * also covered.
+     *
+     * openregister#2282 — this method used to call
+     * `MagicMapper::findAll(filters: ['register' => …], _rbac: false, _multitenancy: false)`
+     * and returned `[]` on EVERY run, by two independent routes:
+     *
+     *   1. `MagicMapper::findAll()` has no `$_rbac` and no `$_multitenancy`
+     *      parameter (`MagicMapper::find()` does, which is where the call shape
+     *      was copied from). On PHP 8 an unknown named argument raises `\Error`,
+     *      the `catch (\Throwable)` below swallowed it, and the job logged a
+     *      warning nobody read.
+     *   2. Even with the bogus named arguments removed, `findAll()` opens with a
+     *      `$register === null || $schema === null` guard and early-returns `[]`.
+     *      The register id was passed inside `filters`, not as `register:`, so
+     *      the guard fired regardless.
+     *
+     * The fix resolves the register's schemas and reads each register+schema
+     * table directly. `_rbac`/`_multitenancy` are passed as the reserved query
+     * filters the search handler already understands
+     * (`MagicSearchHandler::getReservedParams()`), which is the same shape
+     * `SchemaDeletionService::auditObjectsBeforeDeletion()` uses for the same
+     * system-level reason — so no change to `MagicMapper`'s RBAC contract is
+     * required. See the class docblock for the posture and why.
+     *
      * @param Register $register Reports register.
      *
      * @return ObjectEntity[]
+     *
+     * @psalm-return list<ObjectEntity>
      */
     private function loadDashboards(Register $register): array
     {
-        // The dashboard schema is the only one in the reports register;
-        // we walk by-register so a future "report" schema (Phase 3
-        // template variants) is also covered.
-        try {
-            return $this->objectMapper->findAll(
-                limit: 200,
-                offset: 0,
-                filters: ['register' => $register->getId()],
-                _rbac: false,
-                _multitenancy: false
-            );
-        } catch (\Throwable $e) {
+        $schemas = $this->schemaMapper->findMultiple(
+            ids: $register->getSchemas(),
+            _rbac: false,
+            _multitenancy: false
+        );
+
+        if (empty($schemas) === true) {
             $this->logger->warning(
-                message: '[ReportRenderJob] Failed to enumerate dashboards',
-                context: ['error' => $e->getMessage()]
+                message: '[ReportRenderJob] Reports register has no resolvable schemas',
+                context: [
+                    'file'       => __FILE__,
+                    'line'       => __LINE__,
+                    'registerId' => $register->getId(),
+                    'schemaRefs' => $register->getSchemas(),
+                ]
             );
             return [];
         }
+
+        $dashboards = [];
+        foreach ($schemas as $schema) {
+            try {
+                $found = $this->objectMapper->findAllInRegisterSchemaTable(
+                    register: $register,
+                    schema: $schema,
+                    limit: self::DASHBOARD_SCAN_LIMIT,
+                    offset: 0,
+                    filters: [
+                        // Reserved query params — see the class docblock.
+                        '_rbac'         => false,
+                        '_multitenancy' => false,
+                    ]
+                );
+            } catch (\Throwable $e) {
+                $this->logger->warning(
+                    message: '[ReportRenderJob] Failed to enumerate dashboards for schema',
+                    context: [
+                        'registerId' => $register->getId(),
+                        'schemaId'   => $schema->getId(),
+                        'error'      => $e->getMessage(),
+                    ]
+                );
+                continue;
+            }//end try
+
+            foreach ($found as $entity) {
+                $dashboards[] = $entity;
+            }
+        }//end foreach
+
+        return $dashboards;
 
     }//end loadDashboards()
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -43,12 +43,6 @@
       <code><![CDATA[$skippedCount]]></code>
     </UnusedParam>
   </file>
-  <file src="lib/BackgroundJob/ReportRenderJob.php">
-    <InvalidNamedArgument>
-      <code><![CDATA[_multitenancy]]></code>
-      <code><![CDATA[_rbac]]></code>
-    </InvalidNamedArgument>
-  </file>
   <file src="lib/Calendar/RegisterCalendarProvider.php">
     <LessSpecificImplementedReturnType>
       <code><![CDATA[array]]></code>

--- a/tests/Unit/BackgroundJob/ReportRenderJobTest.php
+++ b/tests/Unit/BackgroundJob/ReportRenderJobTest.php
@@ -1,0 +1,310 @@
+<?php
+
+/**
+ * Regression tests for ReportRenderJob dashboard enumeration.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\BackgroundJob
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\BackgroundJob;
+
+use OCA\OpenRegister\BackgroundJob\ReportRenderJob;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Reporting\ReportRenderService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Files\IRootFolder;
+use OCP\IAppConfig;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionMethod;
+
+/**
+ * openregister#2282 — `ReportRenderJob` rendered ZERO dashboards on every run,
+ * silently, by two independent routes:
+ *
+ *   1. It called `MagicMapper::findAll(_rbac: …, _multitenancy: …)`. Neither
+ *      parameter exists on that method. On PHP 8 an unknown named argument
+ *      raises `\Error`, which the job's `catch (\Throwable)` swallowed into a
+ *      warning.
+ *   2. Even without the bogus arguments, `MagicMapper::findAll()` early-returns
+ *      `[]` unless it is given `register:` AND `schema:`. The job passed the
+ *      register id inside `filters` instead.
+ *
+ * These tests assert the CONSEQUENCE — that driving the job actually reaches the
+ * renderer with a dashboard — rather than that any particular method was called
+ * with any particular arguments.
+ *
+ * The `MagicMapper` double is a PHPUnit mock of the REAL class, so it inherits
+ * the real parameter list by reflection. That is what makes the negative control
+ * meaningful: the pre-fix call shape raises the same `Error: Unknown named
+ * parameter $_rbac` against this double that it raises in production. A
+ * hand-written stub shaped like the code under test could not have caught it.
+ */
+class ReportRenderJobTest extends TestCase
+{
+
+    /**
+     * Reports register id used across the fixtures.
+     *
+     * @var int
+     */
+    private const REGISTER_ID = 65;
+
+    /**
+     * Dashboard schema id used across the fixtures.
+     *
+     * @var int
+     */
+    private const SCHEMA_ID = 213;
+
+    /**
+     * Build the `reports` register with one schema attached.
+     *
+     * @return Register
+     */
+    private function reportsRegister(): Register
+    {
+        $register = new Register();
+        $register->setId(self::REGISTER_ID);
+        $register->setSchemas([self::SCHEMA_ID]);
+
+        return $register;
+
+    }//end reportsRegister()
+
+
+    /**
+     * Build the `dashboard` schema.
+     *
+     * @return Schema
+     */
+    private function dashboardSchema(): Schema
+    {
+        $schema = new Schema();
+        $schema->setId(self::SCHEMA_ID);
+        $schema->setSlug(slug: 'dashboard');
+
+        return $schema;
+
+    }//end dashboardSchema()
+
+
+    /**
+     * Build a dashboard object that is unconditionally due for rendering.
+     *
+     * `schedule.active` is true with a positive interval and no
+     * `lastRenderedAt`, which `shouldRender()` treats as "never rendered → fire
+     * now". `delivery.channel` is deliberately NOT `files`/`both` so the test
+     * exercises enumeration + render without touching the Files backend.
+     *
+     * @return ObjectEntity
+     */
+    private function dueDashboard(): ObjectEntity
+    {
+        $dashboard = new ObjectEntity();
+        $dashboard->setId(1);
+        $dashboard->setObject(
+            [
+                'titel'    => 'Quarterly WOO report',
+                'schedule' => [
+                    'active'      => true,
+                    'intervalSec' => 86400,
+                ],
+                'delivery' => [
+                    'format'  => 'csv',
+                    'channel' => 'email',
+                ],
+            ]
+        );
+
+        return $dashboard;
+
+    }//end dueDashboard()
+
+
+    /**
+     * Drive `ReportRenderJob::run()` and return how many dashboards reached the
+     * renderer.
+     *
+     * @param MagicMapper $objectMapper Object mapper double.
+     *
+     * @return int Number of dashboards handed to ReportRenderService::render().
+     */
+    private function runJobAndCountRenders(MagicMapper $objectMapper): int
+    {
+        $register = $this->reportsRegister();
+
+        $appConfig = $this->createMock(IAppConfig::class);
+        $appConfig->method('getValueString')->willReturn('true');
+
+        $registerMapper = $this->createMock(RegisterMapper::class);
+        $registerMapper->method('find')->willReturn($register);
+
+        $schemaMapper = $this->createMock(SchemaMapper::class);
+        $schemaMapper->method('findMultiple')->willReturn([$this->dashboardSchema()]);
+
+        $renders = 0;
+
+        $renderService = $this->createMock(ReportRenderService::class);
+        $renderService->method('render')->willReturnCallback(
+            function () use (&$renders): array {
+                $renders++;
+                return [
+                    'filename' => 'report.csv',
+                    'bytes'    => 'a,b',
+                ];
+            }
+        );
+
+        $job = new ReportRenderJob(
+            $this->createMock(ITimeFactory::class),
+            $appConfig,
+            $renderService,
+            $registerMapper,
+            $schemaMapper,
+            $objectMapper,
+            $this->createMock(IRootFolder::class),
+            $this->createMock(LoggerInterface::class)
+        );
+
+        $run = new ReflectionMethod(ReportRenderJob::class, 'run');
+        $run->setAccessible(true);
+        $run->invoke($job, null);
+
+        return $renders;
+
+    }//end runJobAndCountRenders()
+
+
+    /**
+     * POSITIVE CONTROL — the job must actually render a non-zero dashboard set.
+     *
+     * This is the assertion the defect broke: with the fix in place, a due
+     * dashboard sitting in the reports register reaches
+     * `ReportRenderService::render()`.
+     *
+     * @return void
+     */
+    public function testJobRendersDashboardsInTheReportsRegister(): void
+    {
+        $objectMapper = $this->createMock(MagicMapper::class);
+        $objectMapper->method('findAllInRegisterSchemaTable')
+            ->willReturn([$this->dueDashboard()]);
+
+        // Faithful to the real method: findAll() early-returns [] when it is
+        // not given both register: and schema:.
+        $objectMapper->method('findAll')->willReturn([]);
+
+        $this->assertSame(
+            1,
+            $this->runJobAndCountRenders(objectMapper: $objectMapper),
+            'ReportRenderJob must render the dashboards in the reports register. '
+            .'Rendering zero is openregister#2282 — the job shipped silently '
+            .'producing nothing on every scheduled run.'
+        );
+
+    }//end testJobRendersDashboardsInTheReportsRegister()
+
+
+    /**
+     * NEGATIVE CONTROL — the enumeration must go through the register+schema
+     * read, not the context-free one.
+     *
+     * `MagicMapper::findAll()` cannot enumerate the register on its own: without
+     * `register:`/`schema:` it early-returns `[]`. If a future change routes
+     * `loadDashboards()` back through `findAll()` — the exact regression #2282
+     * was — this double supplies dashboards ONLY via
+     * `findAllInRegisterSchemaTable()`, so the render count drops to zero and
+     * `testJobRendersDashboardsInTheReportsRegister` fails.
+     *
+     * This test pins the other half: a job that reads only through `findAll()`
+     * genuinely gets nothing.
+     *
+     * @return void
+     */
+    public function testFindAllWithoutRegisterAndSchemaYieldsNoDashboards(): void
+    {
+        $objectMapper = $this->createMock(MagicMapper::class);
+        $objectMapper->method('findAll')->willReturn([]);
+        $objectMapper->method('findAllInRegisterSchemaTable')->willReturn([]);
+
+        $this->assertSame(
+            0,
+            $this->runJobAndCountRenders(objectMapper: $objectMapper),
+            'With no dashboards readable, the job must render nothing — this '
+            .'proves the positive control above is measuring the read, not a '
+            .'constant.'
+        );
+
+    }//end testFindAllWithoutRegisterAndSchemaYieldsNoDashboards()
+
+
+    /**
+     * The named-argument contract that caused the fatal.
+     *
+     * `MagicMapper::findAll()` has no `$_rbac` / `$_multitenancy`. Passing them
+     * as named arguments is a PHP 8 `\Error`, not an `\Exception`. Asserting
+     * their ABSENCE keeps the pre-fix call shape from being reintroduced on the
+     * assumption that it works because `MagicMapper::find()` accepts them.
+     *
+     * @return void
+     */
+    public function testMagicMapperFindAllHasNoRbacNamedParameters(): void
+    {
+        $names = [];
+        foreach ((new ReflectionMethod(MagicMapper::class, 'findAll'))->getParameters() as $parameter) {
+            $names[] = $parameter->getName();
+        }
+
+        $this->assertNotContains(
+            '_rbac',
+            $names,
+            'MagicMapper::findAll() does not accept $_rbac. If this ever changes, '
+            .'the RBAC contract of the central object mapper changed with it — '
+            .'see openregister#2282 and revisit ReportRenderJob deliberately.'
+        );
+        $this->assertNotContains('_multitenancy', $names);
+
+    }//end testMagicMapperFindAllHasNoRbacNamedParameters()
+
+
+    /**
+     * The read path the fix uses must accept the arguments the job passes.
+     *
+     * @return void
+     */
+    public function testRegisterSchemaReadAcceptsTheArgumentsTheJobPasses(): void
+    {
+        $names = [];
+        foreach ((new ReflectionMethod(MagicMapper::class, 'findAllInRegisterSchemaTable'))->getParameters() as $p) {
+            $names[] = $p->getName();
+        }
+
+        foreach (['register', 'schema', 'limit', 'offset', 'filters'] as $required) {
+            $this->assertContains(
+                $required,
+                $names,
+                sprintf('ReportRenderJob::loadDashboards() passes %s: by name.', $required)
+            );
+        }
+
+    }//end testRegisterSchemaReadAcceptsTheArgumentsTheJobPasses()
+
+
+}//end class


### PR DESCRIPTION
fix(reporting): ReportRenderJob rendered zero dashboards on every run

Closes #2282.

`ReportRenderJob::loadDashboards()` returned `[]` on every scheduled run, by
two independent routes, and said nothing about it.

Route 1 — a PHP 8 fatal, swallowed. The call was

    $this->objectMapper->findAll(
        limit: 200, offset: 0,
        filters: ['register' => $register->getId()],
        _rbac: false, _multitenancy: false
    );

`MagicMapper::findAll()` has neither `$_rbac` nor `$_multitenancy`.
(`MagicMapper::find()` does, which is where the shape was copied from.) An
unknown named argument raises `\Error`; the method's `catch (\Throwable)`
absorbed it into a warning.

Route 2 — even with those two arguments removed, `findAll()` opens with a
`$register === null || $schema === null` guard and early-returns `[]`. The
register id was passed inside `filters`, not as `register:`, so the guard
fired regardless. Removing the fatal alone would NOT have fixed anything.

Both routes proven live, against the real mapper and a real database, on a
disposable instance (register 14 `vocabulary` / schema 17 `concept`, 22 rows):

    PREFIX(named args)         : Error: Unknown named parameter $_rbac
       is \Exception? NO
    PREFIX(args removed)       : returned 0   <-- silent zero, guard fires
    FIXED(register+schema read): returned 22

The RBAC decision, made explicitly rather than by default
------------------------------------------------------------------
#2282 flagged this as needing an RBAC-contract decision, listing three
options. It resolves without changing any contract, because the capability
already exists.

`_rbac` and `_multitenancy` are first-class RESERVED QUERY PARAMS of the
search path — declared in `MagicSearchHandler::getReservedParams()` and
consumed at `buildFilteredQuery()` (`$query['_rbac'] ?? true`) — and
`findAllInRegisterSchemaTable()` merges `filters` straight into that query.
`SchemaDeletionService::auditObjectsBeforeDeletion()` already reads exactly
this way, for the same system-level reason.

So this takes the issue's option 2 (resolve the register's schemas, read each
register+schema table) using the existing idiom. Option 1 — adding
`$_rbac`/`$_multitenancy` parameters to the central object mapper — is
explicitly NOT done: it was the option that would have changed the mapper's
RBAC contract, and it is unnecessary.

The posture itself is now written down in the class docblock rather than
implied: this is a cron job with no user session, so there is no principal for
RBAC to evaluate; an RBAC-applying read here does not fail safe, it returns
nothing, which is the bug. Access control is enforced at DELIVERY instead —
`writeToFiles()` resolves the target home from `$dashboard->getOwner()`,
refuses to deliver when that owner is null rather than falling back to
`admin`, and confines the path under that owner's home. Widening the read does
not widen who receives the output.

Tests
-----
`tests/Unit/BackgroundJob/ReportRenderJobTest.php` drives the real `run()` and
asserts the CONSEQUENCE — that a due dashboard reaches
`ReportRenderService::render()` — not that any method was called with any
arguments. The `MagicMapper` double is a mock of the REAL class, so it
inherits the real parameter list; the pre-fix call shape raises the same
`Error` against it that it raises in production.

Negative control, measured: restoring only the pre-fix call body (leaving
everything else in place, so the test fails on the defect and not on
constructor arity) turns the suite red with
"Failed asserting that 0 is identical to 1". Restored, it is green.

Gates: phpunit Unit Tests 15877 tests / 0 failures; phpstan "[OK] No errors";
phpcs exit 0; phpmd exit 0; php -l clean.

phpmd note, stated rather than hidden: injecting `SchemaMapper` takes the class
from 12 to 13 coupled types, one over the threshold. Measured, not assumed —
phpmd exits 0 on the pre-fix file and 2 on this one, CouplingBetweenObjects the
only finding. Suppressed narrowly on the class with that reason recorded.

The two now-stale `InvalidNamedArgument` entries are removed from
psalm-baseline.xml, which makes the gate stricter: they can no longer absorb a
regression at that site. The matching phpstan-baseline.neon entries are left
alone deliberately — `reportUnmatchedIgnoredErrors: false` makes them inert,
and that file is being edited concurrently on another branch. Follow-up only.
