### PR TITLE
fix(mcp): IMcpToolProvider::getTools() declared a closed shape the providers never emitted (rebase of #2274)

### DIFF
--- a/lib/Mcp/IMcpToolProvider.php
+++ b/lib/Mcp/IMcpToolProvider.php
@@ -63,11 +63,34 @@ interface IMcpToolProvider
      * fail this check are silently dropped with a warning-level log entry and
      * MUST NOT be passed to the LLM.
      *
+     * `scope` and the three annotation hint keys are OPTIONAL and were missing
+     * from this contract, which described a closed four-key shape. Real
+     * providers have always emitted them — FlowMcpToolProvider sets `scope`,
+     * AttributeToolScanner copies it off the #[McpTool] attribute, and
+     * AttributeToolProvider copies every McpAnnotationValidator::HINT_KEYS
+     * entry — and consumers have always read them back
+     * (McpProviderBridge::getFunctions()). Because the declared shape omitted
+     * them, PHPStan resolved those reads against a shape that could not
+     * contain the key and reported the live `scope` forwarding as dead code
+     * ("array_key_exists() with 'scope' and array{...} will always evaluate to
+     * false"). The code was right and the contract was wrong.
+     *
+     * The hint keys below are exactly McpAnnotationValidator::HINT_KEYS, which
+     * has three entries — no more.
+     *
+     * These keys are ADVISORY metadata only. ObjectService RBAC remains the
+     * sole authoritative invoke-time gate (ADR-063), so `scope` never widens
+     * access on its own.
+     *
      * @return list<array{
      *   id: string,
      *   name: string,
      *   description: string,
-     *   inputSchema: array
+     *   inputSchema: array,
+     *   scope?: string,
+     *   readOnlyHint?: bool,
+     *   destructiveHint?: bool,
+     *   idempotentHint?: bool
      * }> Tool descriptors
      */
     public function getTools(): array;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,7 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Offset 'id' on array\\{id\\: string, name\\: string, description\\: string, inputSchema\\: array\\} in isset\\(\\) always exists and is not nullable\\.$#"
+			message: "#^Offset 'id' on array\\{id\\: string, name\\: string, description\\: string, inputSchema\\: array, scope\\?\\: string, readOnlyHint\\?\\: bool, destructiveHint\\?\\: bool, idempotentHint\\?\\: bool\\} in isset\\(\\) always exists and is not nullable\\.$#"
 			count: 1
 			path: lib/AppInfo/Application.php
 
@@ -4721,17 +4721,17 @@ parameters:
 			path: lib/Service/MappingService.php
 
 		-
-			message: "#^Offset 'id' on array\\{id\\: string, name\\: string, description\\: string, inputSchema\\: array\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			message: "#^Offset 'id' on array\\{id\\: string, name\\: string, description\\: string, inputSchema\\: array, scope\\?\\: string, readOnlyHint\\?\\: bool, destructiveHint\\?\\: bool, idempotentHint\\?\\: bool\\} on left side of \\?\\? always exists and is not nullable\\.$#"
 			count: 2
 			path: lib/Service/Mcp/McpToolsService.php
 
 		-
-			message: "#^Offset 'inputSchema' on array\\{id\\: string, name\\: string, description\\: string, inputSchema\\: array\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			message: "#^Offset 'inputSchema' on array\\{id\\: string, name\\: string, description\\: string, inputSchema\\: array, scope\\?\\: string, readOnlyHint\\?\\: bool, destructiveHint\\?\\: bool, idempotentHint\\?\\: bool\\} on left side of \\?\\? always exists and is not nullable\\.$#"
 			count: 1
 			path: lib/Service/Mcp/McpToolsService.php
 
 		-
-			message: "#^Offset 'name' on array\\{id\\: string, name\\: string, description\\: string, inputSchema\\: array\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			message: "#^Offset 'name' on array\\{id\\: string, name\\: string, description\\: string, inputSchema\\: array, scope\\?\\: string, readOnlyHint\\?\\: bool, destructiveHint\\?\\: bool, idempotentHint\\?\\: bool\\} on left side of \\?\\? always exists and is not nullable\\.$#"
 			count: 1
 			path: lib/Service/Mcp/McpToolsService.php
 
@@ -5886,22 +5886,17 @@ parameters:
 			path: lib/Settings/OpenRegisterAdmin.php
 
 		-
-			message: "#^Call to function array_key_exists\\(\\) with 'scope' and array\\{id\\: string, name\\: string, description\\: string, inputSchema\\: array\\} will always evaluate to false\\.$#"
+			message: "#^Offset 'description' on array\\{id\\: string, name\\: string, description\\: string, inputSchema\\: array, scope\\?\\: string, readOnlyHint\\?\\: bool, destructiveHint\\?\\: bool, idempotentHint\\?\\: bool\\} on left side of \\?\\? always exists and is not nullable\\.$#"
 			count: 1
 			path: lib/Tool/McpProviderBridge.php
 
 		-
-			message: "#^Offset 'description' on array\\{id\\: string, name\\: string, description\\: string, inputSchema\\: array\\} on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 1
-			path: lib/Tool/McpProviderBridge.php
-
-		-
-			message: "#^Offset 'id' on array\\{id\\: string, name\\: string, description\\: string, inputSchema\\: array\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			message: "#^Offset 'id' on array\\{id\\: string, name\\: string, description\\: string, inputSchema\\: array, scope\\?\\: string, readOnlyHint\\?\\: bool, destructiveHint\\?\\: bool, idempotentHint\\?\\: bool\\} on left side of \\?\\? always exists and is not nullable\\.$#"
 			count: 2
 			path: lib/Tool/McpProviderBridge.php
 
 		-
-			message: "#^Offset 'inputSchema' on array\\{id\\: string, name\\: string, description\\: string, inputSchema\\: array\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			message: "#^Offset 'inputSchema' on array\\{id\\: string, name\\: string, description\\: string, inputSchema\\: array, scope\\?\\: string, readOnlyHint\\?\\: bool, destructiveHint\\?\\: bool, idempotentHint\\?\\: bool\\} on left side of \\?\\? always exists and is not nullable\\.$#"
 			count: 1
 			path: lib/Tool/McpProviderBridge.php
 


### PR DESCRIPTION
fix(mcp): IMcpToolProvider::getTools() declared a closed shape the providers never emitted

Rebase of #2274 onto development, reduced to the one part of it that is
still unlanded.

WHAT IS LEFT OF #2274, AND WHY

Its defect 1 (DedupeConfigurationsCommand read $dupeRows without assigning
it) is ALREADY on development — `$dupeRows = count($deleteIds);` is live at
DedupeConfigurationsCommand.php:136. That hunk is dropped.

Its phpstan.neon / psalm.xml OCP-stub suppression clusters are ALSO already
on development (phpstan.neon carries 8 ContextChat patterns, psalm.xml 5).
Those hunks are dropped too.

What remains is the contract fix.

THE DEFECT

IMcpToolProvider::getTools() declared a CLOSED four-key descriptor shape:

    list<array{id: string, name: string, description: string, inputSchema: array}>

Real providers have always emitted more. FlowMcpToolProvider sets `scope`;
AttributeToolScanner copies `scope` off the #[McpTool] attribute;
AttributeToolProvider and SchemaDerivedToolProvider copy every
McpAnnotationValidator::HINT_KEYS entry. McpProviderBridge::getFunctions()
has always read them back.

Because the declared shape could not contain those keys, PHPStan resolved
the reads against it and called live code dead:

    Call to function array_key_exists() with 'scope' and
    array{id: string, name: string, description: string, inputSchema: array}
    will always evaluate to false

The code was right; the contract was wrong. Documenting the optional keys
is the fix.

HINT_KEYS HAS EXACTLY THREE ENTRIES

Verified against the constant rather than assumed
(lib/Service/Mcp/McpAnnotationValidator.php:67):

    public const HINT_KEYS = ['readOnlyHint', 'destructiveHint', 'idempotentHint'];

So the shape gains four optional keys total: `scope` plus those three. No
fourth hint key exists.

BASELINE RECONCILIATION — WHY 7 EDITS AND 1 DELETION

Widening the shape changes the shape STRING that PHPStan prints, and that
string is embedded verbatim in eight phpstan-baseline.neon entries. Landing
the docblock change alone turns phpstan RED with 9 errors — measured, not
predicted:

  lib/AppInfo/Application.php            1  ("Offset 'id' ... in isset()")
  lib/Service/Mcp/McpToolsService.php    4  (id x2, inputSchema, name)
  lib/Tool/McpProviderBridge.php         4  (id x2, inputSchema, description)

None of those nine is a new finding. They are the same pre-existing
"offset always exists" diagnostics, re-printed with the wider shape, so
their baseline patterns stopped matching. Their message text is updated in
place; every `count:` is unchanged, which is the check that nothing new
crept in.

The ninth baseline entry — the `array_key_exists('scope')` one at the old
line 5889 — is DELETED, because that diagnostic is precisely the false
dead-code claim this commit removes.

The baseline is NOT regenerated. openregister's baseline is known to carry
phantom entries; a blanket regeneration would silently rewrite unrelated
debt. Only the eight entries that this change provably touches are edited.

VERIFICATION (PHP 8.3.32 in nextcloud:32-apache, tools as locked)

  phpstan  before (unmodified development)  0 errors   <- control
  phpstan  docblock change alone            9 errors   <- the trap, reproduced
  phpstan  after baseline reconciliation    0 errors
  psalm                                     0 errors, exit 0
  phpcs    lib/Mcp/IMcpToolProvider.php     exit 0
  php -l   lib/Mcp/IMcpToolProvider.php     clean

The control matters: phpstan hard-errors ("Path /app/vendor/nextcloud/ocp
does not exist") when the scanDirectories path is missing, so the 0-error
control is a live measurement of a resolving analysis path, not a silent
skip.

Closes #2274
