### PR TITLE
fix(phpmd): repair DevelopmentCodeFragment — it never matched namespaced code (#2286)

### DIFF
--- a/phpmd.xml
+++ b/phpmd.xml
@@ -52,7 +52,30 @@
     <rule ref="rulesets/design.xml/NumberOfChildren"/>
     <rule ref="rulesets/design.xml/DepthOfInheritance"/>
     <rule ref="rulesets/design.xml/CouplingBetweenObjects"/>
-    <rule ref="rulesets/design.xml/DevelopmentCodeFragment"/>
+    <!-- DevelopmentCodeFragment MUST carry ignore-namespaces=true, or it is dead
+         code in this ruleset. See ConductionNL/openregister#2286.
+
+         PDepend resolves an unqualified call inside a namespaced file to the
+         CURRENT-NAMESPACE-qualified image, so `var_dump($x)` in
+         `namespace OCA\OpenRegister\Service;` reaches the rule as
+         `OCA\OpenRegister\Service\var_dump`, which never matches the
+         `unwanted-functions` list. All of our production PHP is namespaced, so
+         with the default (false) the rule catches nothing anywhere. Measured on
+         phpmd 2.15.0 / PHP 8.3.32: byte-identical probe class, namespaced ->
+         exit 0, non-namespaced -> exit 2. With ignore-namespaces=true the rule
+         strips the enclosing namespace before matching and the namespaced probe
+         is reported (exit 2), while a clean namespaced file stays exit 0.
+
+         Note: hydra gate 2 (forbidden-patterns) independently greps lib/ for
+         var_dump / die / error_log / print_r / dd / dump and is the broader
+         control — it also catches calls outside methods, which this rule (a
+         MethodAware/FunctionAware rule) cannot see. This rule is the
+         `composer check:strict` half of the same guard; keep both. -->
+    <rule ref="rulesets/design.xml/DevelopmentCodeFragment">
+        <properties>
+            <property name="ignore-namespaces" value="true"/>
+        </properties>
+    </rule>
     <rule ref="rulesets/design.xml/EmptyCatchBlock"/>
     <rule ref="rulesets/design.xml/CountInLoopExpression"/>
 


### PR DESCRIPTION
## What

`rulesets/design.xml/DevelopmentCodeFragment` was enabled in this ruleset but could never
fire: phpmd does not match `var_dump()` / `print_r()` / `var_export()` /
`debug_print_backtrace()` inside a **namespaced** file, and all of our production PHP is
namespaced. Fixes #2286.

This PR **makes the rule work** rather than deleting it — option 2 in the issue — by setting
the rule's `ignore-namespaces` property, and documents in the ruleset that hydra gate 2
(`forbidden-patterns`) is the broader control that owns this check.

## Root cause

`PHPMD\Rule\Design\DevelopmentCodeFragment::apply()`:

```php
$ignoreNS  = $this->getBooleanProperty('ignore-namespaces');
$namespace = $node->getNamespaceName();
foreach ($node->findChildrenOfType('FunctionPostfix') as $postfix) {
    $fragment = $postfix->getImage();
    if ($ignoreNS) {
        $fragment = str_replace("{$namespace}\\", "", $fragment);
    }
    ...
```

PDepend resolves an unqualified call inside a namespaced file to the
current-namespace-qualified image, so `var_dump($x)` in `namespace OCA\OpenRegister\Service;`
arrives as `OCA\OpenRegister\Service\var_dump` and never matches `unwanted-functions`.
`ignore-namespaces` (default `false`) is exactly the switch that strips the enclosing
namespace before matching.

## Reproduction — verbatim

Byte-identical probe class apart from the `namespace` line. phpmd 2.15.0, PHP 8.3.32,
`nextcloud:32-apache`, this repo's `vendor/bin/phpmd`.

```
=== NAMESPACED, upstream design ruleset ===
EXIT=0
=== GLOBAL, upstream design ruleset ===
/probe/global/ZzProbe.php:6  DevelopmentCodeFragment  The method ZzProbe::probe() calls the typical debug function var_dump() ...
EXIT=2
=== NAMESPACED, repo phpmd.xml ===
EXIT=0
=== GLOBAL, repo phpmd.xml ===
/probe/global/ZzProbe.php:6  DevelopmentCodeFragment  The method ZzProbe::probe() calls the typical debug function var_dump() ...
EXIT=2
```

Positive control that phpmd was live on the namespaced file the whole time — same file plus
an unused field / short var / unused locals / unused private method, repo ruleset:

```
/probe/nsctl/ZzProbe.php:5   UnusedPrivateField   ...
/probe/nsctl/ZzProbe.php:9   ShortVariable        ...
/probe/nsctl/ZzProbe.php:9   UnusedLocalVariable  ...
/probe/nsctl/ZzProbe.php:10  UnusedLocalVariable  ...
/probe/nsctl/ZzProbe.php:15  UnusedPrivateMethod  ...
EXIT=2
```

phpmd parses and fails on that file; `DevelopmentCodeFragment` specifically is what stayed
silent.

## Proof the fix fires — both directions

Rule in isolation with `ignore-namespaces=true`:

```
=== FIX CANDIDATE on NAMESPACED var_dump ===
/probe/ns/ZzProbe.php:7  DevelopmentCodeFragment  The method ZzProbe::probe() calls the typical debug function var_dump() ...
EXIT=2
=== FIX CANDIDATE on CLEAN namespaced file (no debug call) ===
EXIT=0
=== FIX CANDIDATE on GLOBAL var_dump (regression check) ===
/probe/global/ZzProbe.php:6  DevelopmentCodeFragment  ...
EXIT=2
```

End to end through the exact `composer phpmd` command (`vendor/bin/phpmd lib text phpmd.xml
--baseline-file phpmd.baseline.xml`), whole `lib/`, this branch:

```
=== E2E GREEN: composer phpmd entrypoint, clean lib/, FIXED ruleset ===
EXIT=0
=== E2E RED: same command, namespaced var_dump added at lib/ZzProbe.php ===
/app/lib/ZzProbe.php:7  DevelopmentCodeFragment  The method ZzProbe::probe() calls the typical debug function var_dump() which is mostly only used during development.
EXIT=2
```

Green without the probe, red with it, and the baseline file does not suppress it. The probe
file was deleted afterwards and is not part of this PR.

## Blast radius

Scanning the whole of `lib/` with the repaired rule returns **0 findings** — no existing
debug helper is shipped in namespaced code here, so this repairs the control without
introducing a backlog and nothing was added to `phpmd.baseline.xml`.

`composer phpmd` runs as its own matrix job in the shared `quality.yml` workflow
(`enable-phpmd` defaults to `true`), so the repaired rule has a live CI enforcement path.

## The other control

hydra gate 2 (`forbidden-patterns`) was verified independently, by executing
`scripts/run-hydra-gates.sh` against this repo:

```
# clean lib/
[gate-2] forbidden-patterns: PASS
[hydra-gates] 19 gate(s) failed        (runner exit 19)

# lib/ZzProbe.php containing a namespaced var_dump()
[gate-2] forbidden-patterns: FAIL — 1 forbidden calls
[hydra-gates] 20 gate(s) failed        (runner exit 20)
```

Both runs reached the summary line, so neither is an aborted run misread as green. Gate 2
is grep-based and therefore namespace-blind in the good sense; it was never affected. It
stays the primary control — this PR removes the false floor next to it.

## Fleet

All 25 repos with a `phpmd.xml` carry the same unconfigured rule, including
`nextcloud-app-template` (so every new scaffold inherits it). This PR fixes openregister as
the reference repo; the rollout is tracked in #2286.
