### PR TITLE
fix(quality): drop the file-presence guard masking a missing phpmd

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
 		"psalm:fix": "./vendor/bin/psalm --threads=1 --no-cache --alter || echo 'Psalm not installed, skipping...'",
 		"psalm:output": "./vendor/bin/psalm --threads=1 --no-cache --output-format=json 2>/dev/null | tail -1 > psalm-output.json || echo 'Psalm not installed, skipping...'",
 		"phpstan": "if [ -f vendor/bin/phpstan ]; then ./vendor/bin/phpstan analyse --memory-limit=1G; else echo 'PHPStan not installed, skipping...'; fi",
-		"phpmd": "if [ -f vendor/bin/phpmd ]; then ./vendor/bin/phpmd lib text phpmd.xml --baseline-file phpmd.baseline.xml; else echo 'PHPMD not installed, skipping...'; fi",
+		"phpmd": "./vendor/bin/phpmd lib text phpmd.xml --baseline-file phpmd.baseline.xml",
 		"phpmetrics": "./vendor/bin/phpmetrics --report-html=phpmetrics lib/",
 		"phpmetrics:json": "./vendor/bin/phpmetrics --report-json=phpmetrics/report.json lib/",
 		"phpmetrics:csv": "./vendor/bin/phpmetrics --report-csv=phpmetrics/report.csv lib/",


### PR DESCRIPTION
## What

Drops the `if [ -f vendor/bin/phpmd ]` wrapper from the `phpmd` composer script.

## Why

A file-presence guard that echoes and returns 0 is the same silent-pass defect
as the `|| echo '... skipping'` it replaced, just in a new costume: **a phpmd
that failed to install reads as a phpmd that found nothing.** The gate's
failure and the gate's absence stay indistinguishable.

`phpmd/phpmd` is a declared `require-dev`, and the shared quality workflow runs
`composer install` before the gate, so removing the guard is a **no-op whenever
the tool is present** and a loud failure when it is not — which is the point.

The shared workflow already states this rule explicitly for its own
`require_script` check (`ConductionNL/.github#121`):

> Deliberately NOT an `[ -f vendor/bin/<tool> ]` guard — a file-presence guard
> that skips is the same silent-pass defect in a new costume.

This repo's `phpmd.xml` already carries the `ignore-namespaces` fix
(openregister#2286); this PR is only the script half.

## Cost

Zero new findings. The command that runs is byte-for-byte the one that ran
before whenever `vendor/bin/phpmd` exists.

## Not done here

`psalm`, `phpstan` and the `test:*` scripts in this file still carry the same
guard. Left alone deliberately — their cost has not been measured in this pass,
and removing them is a separate, larger change.

## Also: the composer script guard

This PR also drops the `if [ -f vendor/bin/phpmd ]` wrapper from the `phpmd`
script. A file-presence guard that echoes and returns 0 is the same silent-pass
defect as the `|| echo '... skipping'` it replaced — a phpmd that failed to
install reads as a phpmd that found nothing.

`phpmd/phpmd` is a declared `require-dev` and the shared quality workflow runs
`composer install` before the gate, so this is a **no-op whenever the tool is
present** and a loud failure when it is not. The shared workflow already states
this rule for its own `require_script` check (`ConductionNL/.github#121`).

`psalm` / `phpstan` / `test:*` in the same file still carry the guard. Left
alone deliberately — not measured in this pass.
