### PR TITLE
fix(sharing): a grant must not delegate re-sharing (task 4.4)

### DIFF
--- a/lib/Controller/FlowRunController.php
+++ b/lib/Controller/FlowRunController.php
@@ -51,10 +51,21 @@ use Throwable;
 /**
  * REST surface for inspecting and retrying flow runs.
  *
- * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Two over, from the run guard's
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)   Two over, from the run guard's
  * ObjectService + IAppConfig. Both exist so the flow can be resolved WITH RBAC at
  * the request boundary — the resolver deliberately loads with RBAC off for the
  * engine, and inheriting that bypass here is what left retry() open to an IDOR.
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) Over budget for the same
+ * reason: the two authorization concerns this controller now carries — the run
+ * guard (retry/test may not run somebody else's flow) and history scoping (a run
+ * log is subject data, so it is visible per caller) — are both request-boundary
+ * checks. They belong at the boundary rather than in the engine, which is
+ * deliberately unauthenticated because it runs flows as their owner with no
+ * session. Moving them out would either re-open the bypass or add a second
+ * indirection over four small private helpers.
+ * @SuppressWarnings(PHPMD.ExcessiveParameterList)   Ten constructor parameters, the
+ * last three nullable-with-default precisely so adding them broke no existing
+ * construction site. They are collaborators of those same guards, not options.
  */
 class FlowRunController extends Controller
 {
@@ -530,31 +541,49 @@ class FlowRunController extends Controller
             return [];
         }
 
-        if (is_array($flows) === false) {
-            return [];
-        }
-
         $ids = [];
         foreach ($flows as $flow) {
-            $self = null;
-            if (is_array($flow) === true) {
-                $self = ($flow['@self'] ?? null);
-            }
-
-            $id = null;
-            if (is_array($self) === true) {
-                $id = ($self['id'] ?? null);
-            } else if (is_object($flow) === true && method_exists($flow, 'getUuid') === true) {
-                $id = $flow->getUuid();
-            }
-
-            if (is_string($id) === true && $id !== '') {
+            $id = $this->flowIdOf(flow: $flow);
+            if ($id !== null) {
                 $ids[] = $id;
             }
         }
 
         return array_values(array_unique($ids));
     }//end flowIdsOwnedByCaller()
+
+    /**
+     * The uuid of one flow, whichever shape `findAll()` returned it in.
+     *
+     * Rendered objects arrive as arrays with the uuid under `@self.id`; an
+     * unrendered entity exposes `getUuid()`. Extracted from
+     * `flowIdsOwnedByCaller()` so that method stays within the complexity budget
+     * as the shapes accumulate, and so the "which shape is this" question has one
+     * answer rather than one per call site.
+     *
+     * @param mixed $flow One element of the findAll() result.
+     *
+     * @return string|null The uuid, or null when it cannot be determined.
+     */
+    private function flowIdOf(mixed $flow): ?string
+    {
+        $id = null;
+
+        if (is_array($flow) === true) {
+            $self = ($flow['@self'] ?? null);
+            if (is_array($self) === true) {
+                $id = ($self['id'] ?? null);
+            }
+        } else if (is_object($flow) === true && method_exists($flow, 'getUuid') === true) {
+            $id = $flow->getUuid();
+        }
+
+        if (is_string($id) === true && $id !== '') {
+            return $id;
+        }
+
+        return null;
+    }//end flowIdOf()
 
     /**
      * Run a flow now and return its result — the interactive test run.

--- a/lib/Controller/FlowRunController.php
+++ b/lib/Controller/FlowRunController.php
@@ -42,6 +42,7 @@ use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
+use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IUserSession;
 use stdClass;
@@ -71,6 +72,11 @@ class FlowRunController extends Controller
      *                                                  nullable so adding it is not a fatal at
      *                                                  existing construction sites.
      * @param IAppConfig|null      $flowAppConfig       Reads the flow register/schema slugs.
+     * @param IGroupManager|null   $groupManager        Distinguishes an administrator, who gets
+     *                                                  the unscoped run history. Nullable so
+     *                                                  adding it is not a fatal at existing
+     *                                                  construction sites; absent means "not an
+     *                                                  admin", which SCOPES rather than widens.
      */
     public function __construct(
         string $appName,
@@ -81,7 +87,8 @@ class FlowRunController extends Controller
         private readonly IUserSession $userSession,
         private readonly OrganisationService $organisationService,
         private readonly ?ObjectService $objectService=null,
-        private readonly ?IAppConfig $flowAppConfig=null
+        private readonly ?IAppConfig $flowAppConfig=null,
+        private readonly ?IGroupManager $groupManager=null
     ) {
         parent::__construct(appName: $appName, request: $request);
 
@@ -116,11 +123,27 @@ class FlowRunController extends Controller
             $statusFilter = (string) $status;
         }
 
+        // Scope the history. Until this landed the endpoint returned EVERY run on
+        // the instance to any authenticated caller — including each run's log,
+        // which records the subject data the flow touched. Design D7 of
+        // `shared-credentials-and-flows`: a recipient sees their OWN runs; runs
+        // triggered by the owner or by other recipients stay invisible.
+        //
+        // A null uid means no scoping, which is correct only for an administrator.
+        $requesterUid = null;
+        $ownedFlowIds = [];
+        if ($this->isAdmin() === false) {
+            $requesterUid = $this->callerUid();
+            $ownedFlowIds = $this->flowIdsOwnedByCaller();
+        }
+
         $runs = $this->mapper->findAllRuns(
             flowId: $flowFilter,
             status: $statusFilter,
             limit: $limit,
-            offset: $offset
+            offset: $offset,
+            requesterUid: $requesterUid,
+            ownedFlowIds: $ownedFlowIds
         );
 
         return new JSONResponse(
@@ -144,9 +167,14 @@ class FlowRunController extends Controller
      *
      * Scoping is strict (see FlowRunMapper::findActive): a caller with no
      * resolvable organisation gets an empty list rather than everybody's runs.
-     * The full history surface (`index`) is unchanged and still unscoped —
-     * this endpoint exists precisely so that widening visibility of run
-     * activity to every user of every app does not widen it across tenants.
+     *
+     * The two surfaces scope DIFFERENTLY on purpose. This one is a tenant view of
+     * live activity — a dashboard widget, deliberately showing the organisation's
+     * runs. `index()` is the history surface, and history carries each run's LOG,
+     * which records the subject data the flow touched; it is therefore scoped per
+     * CALLER (runs you triggered, plus runs of flows you own) per design D7 of
+     * `shared-credentials-and-flows`. Until that landed `index()` was unscoped and
+     * returned every run on the instance to any authenticated user.
      *
      * @return JSONResponse `{results, total, limit}` — the live runs.
      *
@@ -421,6 +449,112 @@ class FlowRunController extends Controller
 
         return null;
     }//end refuseUnlessRunnable()
+
+    /**
+     * The current caller's uid, or null when anonymous.
+     *
+     * @return string|null
+     */
+    private function callerUid(): ?string
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return null;
+        }
+
+        return $user->getUID();
+    }//end callerUid()
+
+    /**
+     * Whether the caller is a Nextcloud administrator.
+     *
+     * Fails CLOSED — no group manager, or no session, means "not an admin", so
+     * the caller gets the scoped view rather than the unscoped one. The scoping
+     * switch in `index()` treats a null uid as "no scoping", which is only ever
+     * correct for an administrator; combined with this method returning false for
+     * an anonymous caller, `index()` must and does resolve a real uid before it
+     * can skip scoping.
+     *
+     * @return boolean
+     */
+    private function isAdmin(): bool
+    {
+        if ($this->groupManager === null) {
+            return false;
+        }
+
+        $uid = $this->callerUid();
+        if ($uid === null) {
+            return false;
+        }
+
+        return $this->groupManager->isAdmin($uid);
+    }//end isAdmin()
+
+    /**
+     * Flow ids the caller owns.
+     *
+     * Resolved in ONE query rather than per run: the owner filter is a metadata
+     * filter, and OpenRegister only recognises those NESTED under `@self` — a bare
+     * `owner` key is read as a filter on a schema PROPERTY called `owner`, which
+     * the flow schema does not have, so it silently matches nothing and this would
+     * return an empty list for everybody. `_rbac: false` is deliberate and safe:
+     * the query is already constrained to objects owned by this exact uid, so RBAC
+     * could only narrow a set the caller is by definition entitled to.
+     *
+     * Degrades to an empty list, which NARROWS the run history rather than
+     * widening it — the safe direction for a failure in a visibility filter.
+     *
+     * @return array<int, string> The owned flow ids (uuids), possibly empty.
+     */
+    private function flowIdsOwnedByCaller(): array
+    {
+        $uid = $this->callerUid();
+        if ($uid === null || $this->objectService === null || $this->flowAppConfig === null) {
+            return [];
+        }
+
+        try {
+            $flows = $this->objectService->findAll(
+                config: [
+                    'filters' => [
+                        'register' => $this->flowAppConfig->getValueString('openregister', self::FLOW_REGISTER_KEY, 'flows'),
+                        'schema'   => $this->flowAppConfig->getValueString('openregister', self::FLOW_SCHEMA_KEY, 'flow'),
+                        '@self'    => ['owner' => $uid],
+                    ],
+                    'limit'   => 1000,
+                ],
+                _rbac: false
+            );
+        } catch (Throwable $e) {
+            return [];
+        }
+
+        if (is_array($flows) === false) {
+            return [];
+        }
+
+        $ids = [];
+        foreach ($flows as $flow) {
+            $self = null;
+            if (is_array($flow) === true) {
+                $self = ($flow['@self'] ?? null);
+            }
+
+            $id = null;
+            if (is_array($self) === true) {
+                $id = ($self['id'] ?? null);
+            } else if (is_object($flow) === true && method_exists($flow, 'getUuid') === true) {
+                $id = $flow->getUuid();
+            }
+
+            if (is_string($id) === true && $id !== '') {
+                $ids[] = $id;
+            }
+        }
+
+        return array_values(array_unique($ids));
+    }//end flowIdsOwnedByCaller()
 
     /**
      * Run a flow now and return its result — the interactive test run.

--- a/lib/Db/FlowRunMapper.php
+++ b/lib/Db/FlowRunMapper.php
@@ -73,17 +73,47 @@ class FlowRunMapper extends QBMapper
     /**
      * List runs, newest first.
      *
-     * @param string|null $flowId Restrict to one flow.
-     * @param string|null $status Restrict to one status.
-     * @param integer     $limit  Page size.
-     * @param integer     $offset Page offset.
+     * VISIBILITY. `$requesterUid` is the scoping switch, and it is deliberately
+     * required-by-convention rather than optional-by-default: passing null means
+     * "no scoping", which is correct only for an administrator or a system read.
+     * Until this parameter existed the method had no scoping at ALL, so
+     * `GET /api/flow-runs` returned every run on the instance to any
+     * authenticated caller — including each run's log, which records the subject
+     * data the flow touched. That is precisely what design D7 of
+     * `shared-credentials-and-flows` exists to prevent.
+     *
+     * When scoping IS applied, a run is visible if the caller triggered it OR it
+     * belongs to a flow the caller owns. The second disjunct matters because
+     * `triggered_by` is NULL for cron- and trigger-fired runs, so a
+     * "only runs you triggered" rule would hide every automated run from the
+     * flow's own owner.
+     *
+     * An empty `$ownedFlowIds` is NOT the same as null: it means "the caller owns
+     * no flows", and the predicate must then reduce to `triggered_by = uid`
+     * rather than silently dropping the whole disjunction and matching nothing —
+     * or, worse, matching everything.
+     *
+     * @param string|null        $flowId       Restrict to one flow.
+     * @param string|null        $status       Restrict to one status.
+     * @param integer            $limit        Page size.
+     * @param integer            $offset       Page offset.
+     * @param string|null        $requesterUid The caller, or null to apply NO scoping
+     *                                         (administrators and system reads only).
+     * @param array<int, string> $ownedFlowIds Flow ids the caller owns; runs of these
+     *                                         are visible regardless of who triggered them.
      *
      * @return array<int, FlowRun> The runs.
      *
      * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
      */
-    public function findAllRuns(?string $flowId=null, ?string $status=null, int $limit=50, int $offset=0): array
-    {
+    public function findAllRuns(
+        ?string $flowId=null,
+        ?string $status=null,
+        int $limit=50,
+        int $offset=0,
+        ?string $requesterUid=null,
+        array $ownedFlowIds=[]
+    ): array {
         $qb = $this->db->getQueryBuilder();
         $qb->select('*')
             ->from($this->getTableName())
@@ -97,6 +127,23 @@ class FlowRunMapper extends QBMapper
 
         if ($status !== null && $status !== '') {
             $qb->andWhere($qb->expr()->eq('status', $qb->createNamedParameter($status)));
+        }
+
+        if ($requesterUid !== null) {
+            $visible = $qb->expr()->orX(
+                $qb->expr()->eq('triggered_by', $qb->createNamedParameter($requesterUid))
+            );
+
+            if (empty($ownedFlowIds) === false) {
+                $visible->add(
+                    $qb->expr()->in(
+                        'flow_id',
+                        $qb->createNamedParameter($ownedFlowIds, IQueryBuilder::PARAM_STR_ARRAY)
+                    )
+                );
+            }
+
+            $qb->andWhere($visible);
         }
 
         return $this->findEntities(query: $qb);

--- a/lib/Service/Rbac/ObjectSharingService.php
+++ b/lib/Service/Rbac/ObjectSharingService.php
@@ -280,7 +280,7 @@ class ObjectSharingService
         $share->setShareType(self::GRANTABLE_TYPES[$type]);
         $share->setSharedWith(trim($shareWith));
         $share->setSharedBy($uid);
-        $share->setPermissions($permissions);
+        $share->setPermissions($this->withoutReshare(permissions: $permissions));
 
         $this->applyVerbs(share: $share, verbs: $verbs);
 
@@ -481,7 +481,7 @@ class ObjectSharingService
         // check above establishes the sharer can reach the object at all; core
         // additionally clamps against the node's own permissions when the share
         // is created, so a wider request cannot become a wider share.
-        $share->setPermissions($permissions);
+        $share->setPermissions($this->withoutReshare(permissions: $permissions));
 
         if ($shareWith !== null) {
             $share->setSharedWith($shareWith);
@@ -652,6 +652,43 @@ class ObjectSharingService
             );
         }
     }//end requireOwnerOrAdmin()
+
+    /**
+     * Strip core's re-share bit from a requested permission mask.
+     *
+     * Task 4.4, and the half of it that `requireOwnerOrAdmin()` does NOT cover.
+     * That guard stops a recipient calling OUR endpoints — every write method here
+     * goes through it, so a recipient cannot add a principal or widen a grant
+     * through the sharing API.
+     *
+     * But an object grant is a share on the object's FOLDER, and core's Files
+     * sharing UI acts on that folder directly. With `PERMISSION_SHARE` (16) set,
+     * the recipient could re-share the folder to anyone through core, handing the
+     * object's data onward without ever touching an OpenRegister endpoint — and
+     * the resulting share would be a perfectly valid object grant, since the
+     * resolver reads grants from exactly those folder shares. The spec's "SHALL
+     * NOT be able to widen a grant, add a principal, or re-share onward" would be
+     * satisfied on paper and false in practice.
+     *
+     * So the bit is stripped rather than rejected. Rejecting would break callers
+     * that pass a convenience mask like 31 ("everything") without meaning to
+     * delegate re-sharing, and the safe reading of an ambiguous request is the
+     * narrower one — a grant narrows within what the schema permits and never
+     * widens the principal set. Re-sharing stays the owner's prerogative,
+     * exercised through `grant()`, where the owner check applies.
+     *
+     * Applied in ONE place used by both share-construction paths (`grant()` and
+     * `newFolderShare()`, which backs links and email invitations) so the two
+     * cannot drift on the bit that matters most.
+     *
+     * @param integer $permissions The requested core permission bitmask.
+     *
+     * @return integer The mask with the re-share bit cleared.
+     */
+    private function withoutReshare(int $permissions): int
+    {
+        return ($permissions & ~\OCP\Constants::PERMISSION_SHARE);
+    }//end withoutReshare()
 
     /**
      * The current caller's uid.

--- a/openspec/changes/object-level-sharing-and-private-scope/tasks.md
+++ b/openspec/changes/object-level-sharing-and-private-scope/tasks.md
@@ -110,7 +110,23 @@
       (`_multitenancy_explicit` turns the filter on by itself; and a schema whose rules do
       not bypass multitenancy gets the filter anyway). Only a schema whose read rule names a
       REAL group the caller is in reaches the branch where the forcing is load-bearing
-- [ ] 4.4 Reject a recipient's attempt to widen or re-share onward
+- [x] 4.4 Reject a recipient's attempt to widen or re-share onward. TWO halves, and only the
+      first was already covered. `requireOwnerOrAdmin()` guards all five write methods on
+      `ObjectSharingService`, so a recipient cannot add a principal or widen through OUR
+      endpoints — now asserted, with the control that matters: the caller is GRANTED read and
+      confirmed to see the object first, because a stranger would also be refused and that
+      would prove nothing about recipients. The second half was a real gap: a grant IS a share
+      on the object's FOLDER and core's Files UI acts on that folder directly, so a mask
+      carrying `PERMISSION_SHARE` let the recipient re-share the folder through core — and
+      since the resolver reads grants from exactly those folder shares, the result was a valid
+      object grant created by someone never allowed to create one. The API guard would be
+      intact and the property still false. Core's re-share bit is now cleared in ONE place used
+      by both share-construction paths (`grant()` and `newFolderShare()`, which backs links and
+      email invitations) so the two cannot drift. Stripped rather than rejected: a caller
+      passing a convenience mask like 31 does not mean to delegate re-sharing, and the safe
+      reading of an ambiguous request is the narrower one. Verified by removing the clamp and
+      watching the test fail on the persisted share (`16 is not identical to 0`); the test also
+      asserts read and update SURVIVE, so a blanket zero could not pass instead.
 - [x] 4.5 Carry a permission on the grant and gate the ACTION on it. Threaded through all
       three decision points; a read-only grant no longer admits update or delete. An action
       outside core's five verbs maps to no bit, so a grant cannot carry it and the caller

--- a/openspec/changes/object-level-sharing-and-private-scope/tasks.md
+++ b/openspec/changes/object-level-sharing-and-private-scope/tasks.md
@@ -240,7 +240,23 @@
       "the row is visible" cannot pass for a row that was never private.
 - [ ] 9.2 Give flows run authorization: `flowRun#test`, `flowRun#retry` and `FlowMcpToolProvider::runFlow()` all run a flow with zero ownership checks today
 - [ ] 9.3 Only then enable `credentialIdentity: owner` from `shared-credentials-and-flows` — until run authorization exists, any authenticated user could run someone else's flow and cause calls signed with that owner's secret
-- [ ] 9.4 Scope run history to the requester for a share recipient (that change's design D7)
+- [x] 9.4 Scope run history to the requester for a share recipient (that change's design D7).
+      The task understated it: `FlowRunController::index()` had NO scoping at all —
+      `findAllRuns()` filtered only by flowId and status — so any authenticated user could list
+      EVERY run on the instance, including each run's log, which records the subject data the
+      flow touched. That is the exposure D7 exists to prevent, and it was live for everyone, not
+      only for share recipients. Now scoped per caller: runs you TRIGGERED, plus runs of flows
+      you OWN. The second disjunct is load-bearing because `triggered_by` is NULL for cron- and
+      trigger-fired runs, so "only runs you triggered" would have blinded a flow's own owner to
+      every automated run of it. Owned flow ids resolve in ONE query, not per run, and the owner
+      filter is NESTED under `@self` — a bare `owner` key is read as a filter on a schema
+      PROPERTY, which the flow schema does not have, so it silently matches nothing. An
+      administrator still gets the unscoped view; `isAdmin()` fails CLOSED, so a missing group
+      manager or session scopes rather than widens, and an empty owned-list narrows to "runs I
+      triggered" rather than collapsing to nothing or to everything. Four live-DB tests, and the
+      control is the discriminating half: with the predicate disabled 3 of the 4 fail (another
+      user's run visible, an unowned cron run visible, everybody's runs visible on an empty
+      owned-list) while the null-requester admin test correctly still passes.
 
 ## 10. e2e (Playwright) and verification
 

--- a/tests/Db/FlowRunVisibilityIntegrationTest.php
+++ b/tests/Db/FlowRunVisibilityIntegrationTest.php
@@ -1,0 +1,235 @@
+<?php
+
+/**
+ * FlowRunVisibilityIntegrationTest
+ *
+ * Task 9.4 / design D7 of `shared-credentials-and-flows`: run HISTORY is not
+ * carried by a share. A recipient sees their own runs; runs triggered by the
+ * owner or by other recipients stay invisible.
+ *
+ * This is a live-database test because the scoping is a SQL predicate, and the
+ * defect it closes was a missing predicate: `findAllRuns()` filtered only by
+ * flowId and status, so `GET /api/flow-runs` returned every run on the instance
+ * to any authenticated caller — including each run's log, which records the
+ * subject data the flow touched. A run log is exactly the data D7 exists to keep
+ * out of a share.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Db
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @spec openspec/changes/object-level-sharing-and-private-scope/tasks.md#task-9-4
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Db;
+
+use OCA\OpenRegister\Db\FlowRun;
+use OCA\OpenRegister\Db\FlowRunMapper;
+use OCP\IDBConnection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Live-DB coverage for per-caller run-history scoping.
+ */
+class FlowRunVisibilityIntegrationTest extends TestCase
+{
+    private FlowRunMapper $mapper;
+
+    private IDBConnection $db;
+
+    /**
+     * Unique suffix so parallel runs and leftovers cannot collide.
+     *
+     * @var string
+     */
+    private string $tag;
+
+    /**
+     * Resolve the mapper from the real container.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mapper = \OC::$server->get(FlowRunMapper::class);
+        $this->db     = \OC::$server->get(IDBConnection::class);
+        $this->tag    = substr(bin2hex(random_bytes(6)), 0, 12);
+    }
+
+    /**
+     * Remove only the rows this test created.
+     *
+     * Deliberately keyed on the per-test tag rather than a range or a wildcard —
+     * a broad delete in a shared development database is how real fixtures get
+     * destroyed.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete('openregister_flow_runs')
+            ->where($qb->expr()->like('flow_id', $qb->createNamedParameter('%'.$this->tag)));
+        $qb->executeStatement();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Persist one run.
+     *
+     * @param string      $flowSuffix   Distinguishes the flow within this test.
+     * @param string|null $triggeredBy  The triggering uid, or null for a cron run.
+     *
+     * @return FlowRun
+     */
+    private function makeRun(string $flowSuffix, ?string $triggeredBy): FlowRun
+    {
+        $run = new FlowRun();
+        $run->setUuid('run-'.$flowSuffix.'-'.bin2hex(random_bytes(4)));
+        $run->setFlowId($flowSuffix.'-'.$this->tag);
+        $run->setStatus(FlowRun::STATUS_QUEUED);
+        $run->setTriggeredBy($triggeredBy);
+
+        return $this->mapper->insert($run);
+    }
+
+    /**
+     * Flow ids visible to a caller.
+     *
+     * @param string|null        $uid   The caller, or null for the unscoped read.
+     * @param array<int, string> $owned Flow ids the caller owns.
+     *
+     * @return array<int, string>
+     */
+    private function visibleFlowIds(?string $uid, array $owned=[]): array
+    {
+        $runs = $this->mapper->findAllRuns(
+            flowId: null,
+            status: null,
+            limit: 200,
+            offset: 0,
+            requesterUid: $uid,
+            ownedFlowIds: $owned
+        );
+
+        $ids = [];
+        foreach ($runs as $run) {
+            $flowId = $run->getFlowId();
+            if (is_string($flowId) === true && str_ends_with($flowId, $this->tag) === true) {
+                $ids[] = $flowId;
+            }
+        }
+
+        return $ids;
+    }
+
+    /**
+     * A caller sees their own runs and NOT another user's.
+     *
+     * The second assertion is the one that matters. "Alice sees her run" would
+     * pass just as well against the old unscoped query, which returned
+     * everything; only "Alice does NOT see Bob's" distinguishes a working filter
+     * from no filter at all.
+     *
+     * @return void
+     */
+    public function testACallerSeesTheirOwnRunsAndNotAnotherUsers(): void
+    {
+        $this->makeRun('mine', 'alice-'.$this->tag);
+        $this->makeRun('theirs', 'bob-'.$this->tag);
+
+        $visible = $this->visibleFlowIds('alice-'.$this->tag);
+
+        $this->assertContains('mine-'.$this->tag, $visible, 'a caller must see the runs they triggered');
+        $this->assertNotContains(
+            'theirs-'.$this->tag,
+            $visible,
+            "another user's run must be invisible — this is the assertion the missing predicate failed"
+        );
+    }
+
+    /**
+     * Runs of a flow the caller OWNS are visible whoever triggered them.
+     *
+     * `triggered_by` is NULL for cron- and trigger-fired runs, so without this
+     * disjunct a flow's own owner would be blind to every automated run of it.
+     *
+     * The control is the same fixture WITHOUT the ownership claim: it must be
+     * invisible then, or "owned runs are visible" would be indistinguishable from
+     * "everything is visible".
+     *
+     * @return void
+     */
+    public function testRunsOfAnOwnedFlowAreVisibleEvenWhenCronTriggered(): void
+    {
+        $this->makeRun('owned', null);
+
+        // CONTROL: not claimed as owned, and not triggered by this caller.
+        $withoutOwnership = $this->visibleFlowIds('carol-'.$this->tag);
+        $this->assertNotContains(
+            'owned-'.$this->tag,
+            $withoutOwnership,
+            'control: an unowned, cron-triggered run must NOT be visible'
+        );
+
+        // Same row, now claimed.
+        $withOwnership = $this->visibleFlowIds('carol-'.$this->tag, ['owned-'.$this->tag]);
+        $this->assertContains(
+            'owned-'.$this->tag,
+            $withOwnership,
+            "a flow's owner must see its automated runs"
+        );
+    }
+
+    /**
+     * Owning no flows narrows to "runs I triggered" — it does not widen.
+     *
+     * An empty owned-ids list must not collapse the predicate into nothing (which
+     * would hide the caller's own runs) or into everything (which would restore
+     * the leak). Both failure directions are asserted.
+     *
+     * @return void
+     */
+    public function testAnEmptyOwnedListNarrowsRatherThanWidens(): void
+    {
+        $this->makeRun('own', 'dave-'.$this->tag);
+        $this->makeRun('other', 'erin-'.$this->tag);
+
+        $visible = $this->visibleFlowIds('dave-'.$this->tag, []);
+
+        $this->assertContains('own-'.$this->tag, $visible, 'owning no flows must not hide my own runs');
+        $this->assertNotContains('other-'.$this->tag, $visible, 'owning no flows must not reveal everybody else');
+    }
+
+    /**
+     * A null uid means NO scoping — reserved for administrators.
+     *
+     * Pinned deliberately: it is the branch that reproduces the old leak, so it
+     * must be reached only on purpose. `index()` guards it behind an explicit
+     * `isAdmin()` that fails closed when the group manager or the session is
+     * absent.
+     *
+     * @return void
+     */
+    public function testANullRequesterAppliesNoScoping(): void
+    {
+        $this->makeRun('a', 'frank-'.$this->tag);
+        $this->makeRun('b', 'grace-'.$this->tag);
+
+        $visible = $this->visibleFlowIds(null);
+
+        $this->assertContains('a-'.$this->tag, $visible);
+        $this->assertContains('b-'.$this->tag, $visible, 'a null requester is the admin path and sees both');
+    }
+}//end class

--- a/tests/Db/PrivateScopeParityIntegrationTest.php
+++ b/tests/Db/PrivateScopeParityIntegrationTest.php
@@ -64,6 +64,7 @@ use OCA\OpenRegister\Service\Rbac\ObjectGrantResolver;
 use OCA\OpenRegister\Service\Rbac\ObjectSharingService;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Folder;
+use OCP\Constants;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
 use OCP\IDBConnection;
@@ -1060,6 +1061,127 @@ class PrivateScopeParityIntegrationTest extends TestCase
             'a revoked grant must deny on the next request'
         );
     }//end testGrantAndRevokeThroughTheService()
+
+
+    /**
+     * A RECIPIENT cannot add another principal to the object (task 4.4).
+     *
+     * The spec: "A recipient SHALL NOT be able to widen a grant, add a principal,
+     * or re-share onward."
+     *
+     * The control matters more than the refusal here. A stranger would also be
+     * refused, and that would prove nothing about recipients — so the caller is
+     * first GRANTED read and confirmed to actually see the object. Only then does
+     * the refusal mean "a legitimate recipient cannot re-share", rather than
+     * "someone who cannot reach the object at all cannot share it".
+     *
+     * @return void
+     *
+     * @spec openspec/changes/object-level-sharing-and-private-scope/specs/object-level-sharing/spec.md#scenario-a-recipient-cannot-re-share
+     */
+    public function testARecipientCannotAddAnotherPrincipal(): void
+    {
+        [$register, $schema] = $this->createFixtureTable();
+
+        $this->insertFixture($register, $schema, 'noreshare', ['scope' => 'private'], false, ownedByRealOwner: true);
+        $entity = $this->readBackByKey($register, $schema)['noreshare'];
+
+        // The owner invites this caller, so they are a genuine recipient.
+        $this->asOwner(
+            fn() => $this->sharingService()->grant(
+                object: $entity,
+                type: 'user',
+                shareWith: $this->testUid,
+                permissions: 1
+            )
+        );
+        $this->grantResolver()->forget();
+
+        // CONTROL: they really are a recipient — they can see the object.
+        $this->assertContains(
+            'noreshare',
+            $this->visibleKeys($register, $schema),
+            'control: the caller must be an admitted recipient, or the refusal below proves nothing'
+        );
+
+        // And still cannot pass it on.
+        $this->expectException(NotAuthorizedException::class);
+        $this->sharingService()->grant(
+            object: $entity,
+            type: 'user',
+            shareWith: 'somebody-else',
+            permissions: 1
+        );
+    }//end testARecipientCannotAddAnotherPrincipal()
+
+
+    /**
+     * A grant never carries core's re-share bit (task 4.4, second half).
+     *
+     * `requireOwnerOrAdmin()` stops a recipient using OUR endpoints, but a grant
+     * IS a share on the object's folder, and core's Files UI acts on that folder
+     * directly. With `PERMISSION_SHARE` set, the recipient could re-share the
+     * folder through core — and because the resolver reads grants from exactly
+     * those folder shares, the result would be a valid object grant created by
+     * someone who was never allowed to create one. The API guard would be intact
+     * and the property still false.
+     *
+     * The control is asserting that the OTHER requested bits survive. Without it,
+     * a mask of 0 — or a clamp that zeroed everything — would pass just as well.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/object-level-sharing-and-private-scope/specs/object-level-sharing/spec.md#scenario-a-recipient-cannot-re-share
+     */
+    public function testAGrantNeverCarriesCoresReshareBit(): void
+    {
+        [$register, $schema] = $this->createFixtureTable();
+
+        $this->insertFixture($register, $schema, 'nobit', ['scope' => 'private'], false, ownedByRealOwner: true);
+        $entity = $this->readBackByKey($register, $schema)['nobit'];
+
+        // Ask for read + update + share. Only the share bit may be dropped.
+        $requested = (Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE | Constants::PERMISSION_SHARE);
+
+        $grant = $this->asOwner(
+            fn() => $this->sharingService()->grant(
+                object: $entity,
+                type: 'user',
+                shareWith: $this->testUid,
+                permissions: $requested
+            )
+        );
+
+        $granted = (int) $grant['permissions'];
+
+        $this->assertSame(
+            0,
+            ($granted & Constants::PERMISSION_SHARE),
+            'a grant must never delegate re-sharing — the recipient could otherwise pass the object on via core Files'
+        );
+
+        // CONTROLS: the clamp is surgical, not a blanket zero.
+        $this->assertSame(
+            Constants::PERMISSION_READ,
+            ($granted & Constants::PERMISSION_READ),
+            'control: read must survive the clamp'
+        );
+        $this->assertSame(
+            Constants::PERMISSION_UPDATE,
+            ($granted & Constants::PERMISSION_UPDATE),
+            'control: update must survive the clamp'
+        );
+
+        // And the share on disk carries the clamped mask, not the requested one —
+        // asserting only the returned array would miss a clamp applied after the
+        // share was already created.
+        $stored = $this->shareManager()->getShareById((string) $grant['id']);
+        $this->assertSame(
+            0,
+            ($stored->getPermissions() & Constants::PERMISSION_SHARE),
+            'the PERSISTED share must not carry the re-share bit either'
+        );
+    }//end testAGrantNeverCarriesCoresReshareBit()
 
 
     /**


### PR DESCRIPTION
## Task 4.4 — "a recipient cannot widen or re-share onward"

Half was already true. The half that was missing is the one that mattered.

### Already true
`requireOwnerOrAdmin()` guards all five write methods on `ObjectSharingService`, so a recipient cannot add a principal or widen a grant **through our endpoints**. Now asserted — and the control is the point: the caller is *granted read and confirmed to see the object* before the refusal is checked. A stranger would be refused too, and that would prove nothing about recipients.

### The real gap
A grant **is a core share on the object's folder**, and core's Files sharing UI acts on that folder directly. With `PERMISSION_SHARE` (16) in the mask, the recipient could re-share the folder to anyone through core, never touching an OpenRegister endpoint. And because `ObjectGrantResolver` reads grants from exactly those folder shares, the result would be a **fully valid object grant created by someone never allowed to create one**. Our API guard intact; the property false.

Core's re-share bit is now cleared in **one** place used by both share-construction paths — `grant()` and `newFolderShare()` (which backs links and email invitations) — so the two cannot drift on the bit that matters most.

### Stripped, not rejected
A caller passing a convenience mask like 31 doesn't thereby mean to delegate re-sharing, and the safe reading of an ambiguous request is the narrower one. Re-sharing stays the owner's prerogative via `grant()`, where the owner check applies.

### Verified by removing the fix
With the clamp taken out the new test fails on the **persisted** share — `Failed asserting that 16 is identical to 0` — so the exposure was real, not theoretical.

The test asserts the persisted share rather than only the returned array, because a clamp applied *after* creation would satisfy the return value while leaving the share wide. It also asserts read and update **survive**, so a blanket zero couldn't pass in its place.

### Verification
- 21/21 `PrivateScopeParityIntegrationTest` (19 before)
- 7/7 `ObjectShareLinkIntegrationTest` — the link/email path shares the clamped constructor, so re-run rather than assumed unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)