### PR TITLE
feat(mcp): forward the `reach` annotation across the provider bridge

### DIFF
--- a/lib/Mcp/BuiltIn/FlowMcpToolProvider.php
+++ b/lib/Mcp/BuiltIn/FlowMcpToolProvider.php
@@ -95,7 +95,8 @@ class FlowMcpToolProvider implements IMcpToolProvider
      * invoke-time gate.
      *
      * @return list<array{id: string, name: string, description: string, inputSchema: array,
-     *         readOnlyHint: bool, destructiveHint: bool, idempotentHint: bool, scope: string}> The tools.
+     *         readOnlyHint: bool, destructiveHint: bool, idempotentHint: bool, scope: string,
+     *         reach: string}> The tools.
      *
      * @spec openspec/changes/or-flow-mcp/specs/flow-mcp/spec.md
      */
@@ -120,6 +121,11 @@ class FlowMcpToolProvider implements IMcpToolProvider
                 'destructiveHint' => true,
                 'idempotentHint'  => false,
                 'scope'           => 'create',
+                // A flow can write objects other users read, and can drive an
+                // outbound integration. `instance` is the floor, not a ceiling:
+                // a consumer composing reach should take the MAX of this and
+                // whatever the flow's own steps reach.
+                'reach'           => 'instance',
             ],
             [
                 'id'              => 'openregister.flowRunStatus',
@@ -136,6 +142,12 @@ class FlowMcpToolProvider implements IMcpToolProvider
                 'destructiveHint' => false,
                 'idempotentHint'  => true,
                 'scope'           => 'read',
+                // Polling a run the caller already started, through the same
+                // RBAC as any other read. Nothing observes an effect, so `user`
+                // — and declaring it matters: a consumer that fails closed on an
+                // absent reach would otherwise gate the STATUS POLL of a flow it
+                // had just been granted permission to start.
+                'reach'           => 'user',
             ],
         ];
 

--- a/lib/Tool/McpProviderBridge.php
+++ b/lib/Tool/McpProviderBridge.php
@@ -46,6 +46,24 @@ class McpProviderBridge implements ToolInterface
 {
 
     /**
+     * Non-boolean provider-descriptor annotations copied verbatim onto the
+     * LLphant function descriptor when present, alongside the boolean
+     * `McpAnnotationValidator::HINT_KEYS`.
+     *
+     * `scope` is the ADR-063 CRUD verb. `reach` is the orthogonal blast-radius
+     * axis (`self` < `user` < `instance` < `external`) that consuming apps gate
+     * on: it answers "who can observe or be affected by this call", which
+     * `scope` does not — a `read` tool that fetches a model-chosen URL leaves
+     * the instance, and a `delete` confined to an agent's own memory does not.
+     *
+     * Neither value is interpreted here. The bridge's job is to lose nothing;
+     * classification belongs to the consumer.
+     *
+     * @var array<int, string>
+     */
+    private const PASSTHROUGH_KEYS = ['scope', 'reach'];
+
+    /**
      * Optional agent context attached by the registry.
      *
      * @var \OCA\OpenRegister\Db\Agent|null
@@ -124,15 +142,25 @@ class McpProviderBridge implements ToolInterface
      * Each MCP descriptor becomes one LLphant function definition.
      *
      * Additively forwards the ADR-063 annotation hints
-     * (`readOnlyHint` / `destructiveHint` / `idempotentHint`) and `scope`
-     * onto the LLphant descriptor when the provider set them, so chat-surface
-     * consumers reached through {@see \OCA\OpenRegister\Service\Mcp\ToolRegistryFacade::listTools()}
+     * (`readOnlyHint` / `destructiveHint` / `idempotentHint`) and the
+     * `PASSTHROUGH_KEYS` (`scope`, `reach`) onto the LLphant descriptor when the
+     * provider set them, so chat-surface consumers reached through
+     * {@see \OCA\OpenRegister\Service\Mcp\ToolRegistryFacade::listTools()}
      * see the same annotations the JSON-RPC `tools/list` surface already
      * carries (previously dropped here — OR#369). A key is omitted entirely
      * when the provider descriptor didn't set it; no defaults are invented.
      * These hints are ADVISORY UX metadata only — OpenRegister's
      * `ObjectService` RBAC enforcement remains the sole authoritative
      * invoke-time gate, unaffected by this or any hint value (ADR-063).
+     *
+     * 🔴 A key this method does not copy is a key the consuming app cannot see,
+     * however carefully the provider declared it. That is not hypothetical:
+     * Hermiq annotated all fourteen of its native tools with a `reach` and its
+     * resolver fails closed on an absent one, so before `reach` was forwarded
+     * here every one of those tools would have arrived unannotated, resolved to
+     * `external`, and been stripped from every agent's catalogue — an app-wide
+     * outage produced entirely by a silent drop at this boundary. Anything added
+     * to a provider descriptor from now on belongs in `PASSTHROUGH_KEYS`.
      *
      * @return array<int,array<string,mixed>> LLphant-shaped function descriptors.
      *
@@ -169,8 +197,10 @@ class McpProviderBridge implements ToolInterface
                 }
             }
 
-            if (array_key_exists('scope', $descriptor) === true) {
-                $function['scope'] = $descriptor['scope'];
+            foreach (self::PASSTHROUGH_KEYS as $passthroughKey) {
+                if (array_key_exists($passthroughKey, $descriptor) === true) {
+                    $function[$passthroughKey] = $descriptor[$passthroughKey];
+                }
             }
 
             $functions[] = $function;

--- a/tests/Unit/Tool/McpProviderBridgeTest.php
+++ b/tests/Unit/Tool/McpProviderBridgeTest.php
@@ -63,6 +63,59 @@ class McpProviderBridgeTest extends TestCase
         $this->assertSame('delete', $function['scope']);
     }
 
+    /**
+     * 🔴 `reach` must survive the bridge.
+     *
+     * A consuming app that gates on reach and fails closed on its absence sees
+     * a dropped key as "external" — so losing it here does not degrade to the
+     * old behaviour, it strips the tool from every agent that had it. Hermiq
+     * annotates all fourteen of its native tools this way, so the blast radius
+     * of deleting the two lines this test guards is Hermiq's entire native
+     * catalogue, with no error anywhere to explain it.
+     */
+    public function testReachSurvivesTheBridge(): void
+    {
+        $bridge = $this->bridgeFor([
+            [
+                'id'           => 'hermiq.webFetch',
+                'name'         => 'web_fetch',
+                'description'  => 'Fetch a URL.',
+                'inputSchema'  => ['type' => 'object', 'properties' => []],
+                'readOnlyHint' => true,
+                'scope'        => 'read',
+                'reach'        => 'external',
+            ],
+        ]);
+
+        $function = $bridge->getFunctions()[0];
+
+        // The pair that makes the point: identical `scope`, and `reach` is the
+        // only thing telling the consumer this one leaves the building.
+        $this->assertSame('read', $function['scope']);
+        $this->assertSame('external', $function['reach']);
+    }
+
+    /**
+     * The bridge forwards `reach` verbatim and classifies nothing — an
+     * unrecognised value must arrive intact for the CONSUMER to reject, because
+     * a bridge that silently dropped a malformed reach would hand the consumer
+     * "absent" (fail-closed) when the truth is "wrong" (a bug to fix).
+     */
+    public function testAnUnrecognisedReachIsForwardedNotSanitised(): void
+    {
+        $bridge = $this->bridgeFor([
+            [
+                'id'          => 'pipelinq.lead.get',
+                'name'        => 'lead_get',
+                'description' => 'Get a lead.',
+                'inputSchema' => ['type' => 'object', 'properties' => []],
+                'reach'       => 'galaxy',
+            ],
+        ]);
+
+        $this->assertSame('galaxy', $bridge->getFunctions()[0]['reach']);
+    }
+
     public function testDescriptorWithoutHintsGainsNoPhantomKeys(): void
     {
         $bridge = $this->bridgeFor([
@@ -82,6 +135,7 @@ class McpProviderBridgeTest extends TestCase
         $this->assertArrayNotHasKey('destructiveHint', $function);
         $this->assertArrayNotHasKey('idempotentHint', $function);
         $this->assertArrayNotHasKey('scope', $function);
+        $this->assertArrayNotHasKey('reach', $function);
     }
 
     public function testExistingFourKeysAreUnchanged(): void
@@ -127,5 +181,6 @@ class McpProviderBridgeTest extends TestCase
         $this->assertArrayNotHasKey('destructiveHint', $function);
         $this->assertArrayNotHasKey('idempotentHint', $function);
         $this->assertArrayNotHasKey('scope', $function);
+        $this->assertArrayNotHasKey('reach', $function);
     }
 }


### PR DESCRIPTION
## What

`McpProviderBridge::getFunctions()` rebuilds each LLphant descriptor from a fixed key list. Anything a provider declares outside that list is dropped between the app that declared it and the app that consumes it. This adds `reach` to the forwarded set.

`reach` is the blast-radius axis — `self` < `user` < `instance` < `external` — introduced by Hermiq's `agent-capability-reach`. It answers *who can observe or be affected by this call*, which `scope` does not: a `read` tool that fetches a model-chosen URL leaves the instance, and a `delete` confined to an agent's own memory does not.

## Why this is not a cosmetic gap

A consumer gating on reach **fails closed** on an absent one. So an unforwarded `reach` does not degrade to the old behaviour — it reads as `external`, and the tool is stripped from the agent's catalogue.

Hermiq annotates all fourteen of its native tools. Without this change, every one of them would have disappeared from every agent, with no error anywhere to explain it. It was caught by a Hermiq unit fixture that mirrors this bridge key for key — the fixture was right and the code was wrong.

## Changes

- `PASSTHROUGH_KEYS = ['scope', 'reach']` replaces the single-key `scope` copy, so the next provider annotation has one obvious place to be registered.
- `FlowMcpToolProvider` declares its own reach: `runFlow` → `instance` (writes objects other users read; can drive an outbound integration), `flowRunStatus` → `user` (polling a run the caller started). Without the second, a consumer would gate the *status poll* of a flow it had just been granted permission to start.
- Tests pin both directions: `reach` survives; an unrecognised value arrives **intact** for the consumer to reject rather than being sanitised to "absent" (which would hand the consumer *fail-closed* when the truth is *a bug*); a descriptor declaring none still gains no phantom key.

## Verification

- `testReachSurvivesTheBridge` **fails** when `reach` is removed from `PASSTHROUGH_KEYS` — negative control run, confirmed.
- Full unit suite green: **15,884 tests, 35,627 assertions**.
- `phpcs` clean on both changed `lib/` files.

## Ordering

Hermiq's `agent-capability-reach` PR depends on this. Deploying Hermiq's union gating **before** this lands would strip its native tool catalogue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)