### PR TITLE
test(rbac): characterise the tenant edge on the UNION path — it does NOT hold

### DIFF
--- a/openspec/changes/object-level-sharing-and-private-scope/tasks.md
+++ b/openspec/changes/object-level-sharing-and-private-scope/tasks.md
@@ -178,7 +178,20 @@
 
 - [ ] 6.1 A shares component: invite by user / group / email, create a link, set expiry, revoke — mirroring the Files share panel
 - [ ] 6.2 Expose it as a detail-page **Shares** tab
-- [ ] 6.3 Expose it as a `shared-with-me` dashboard widget
+- [ ] 6.3 Expose it as a `shared-with-me` dashboard widget. BLOCKED, and the blocker is measured
+      rather than suspected. A grant resolves to an object UUID, but objects live in
+      per-register/schema tables, the legacy central `openregister_objects` table holds 0 rows, and
+      the object folder path is `files/Open Registers/{Register TITLE}/{uuid}` — no schema segment
+      at all, and the register only by title. So a cross-register list needs the cross-table search,
+      and `testUnionPathTenantEdgeIsCharacterised` now shows that path returns rows from ANOTHER
+      organisation: the scope-and-grant predicate is applied there (groups 2–4 put it there) but the
+      ORGANISATION filter is not. `TODO(SEC-CTRL-1)` in ObjectsController is therefore accurate for
+      multitenancy and stale for RBAC. Building this widget over that path would leak across
+      tenants, so it waits until tenancy is wired into `searchAcrossMultipleTables()` — at which
+      point that characterisation test fails, which is the signal to flip it and build. (An HTTP-level
+      probe of the existing cross-table endpoints was INCONCLUSIVE: my pair arguments were invalid,
+      so it returned "No valid magic-mapped register+schema combinations found" for admin too. The
+      exposure is proven at the mapper level; reachability from HTTP is not established either way.)
 - [ ] 6.4 Register the widget in the dashboard catalogue and call `registerBuiltinDashboardWidgets()` — a bare side-effect import is tree-shaken and every registry tile silently renders "Widget not available"
 - [ ] 6.5 Semantic icons via the ADR-077 vocabulary, and REGISTER every name used — an unregistered MDI name renders nothing at all, not a fallback
 - [ ] 6.6 Publish on the `vue3` tag and verify the dist-tag MOVED before consuming it

--- a/tests/Db/PrivateScopeParityIntegrationTest.php
+++ b/tests/Db/PrivateScopeParityIntegrationTest.php
@@ -1560,6 +1560,115 @@ class PrivateScopeParityIntegrationTest extends TestCase
      *
      * @return string[]
      */
+    /**
+     * Keys visible through the UNION path with multitenancy REQUESTED.
+     *
+     * The default helper passes `_multitenancy => false` because the scope tests
+     * want the scope predicate to be the only filter. This one asks for tenancy,
+     * so the answer tells us whether the union path honours it at all.
+     *
+     * @param Register $register The register.
+     * @param Schema   $schema   The schema.
+     *
+     * @return string[]
+     */
+    private function visibleKeysViaUnionWithTenancy(Register $register, Schema $schema): array
+    {
+        if ($this->unionPartner === null) {
+            $this->unionPartner = $this->createFixtureTable(partner: true);
+        }
+
+        $rows = $this->mapper->searchAcrossMultipleTables(
+            ['_multitenancy' => true],
+            [
+                ['register' => $register, 'schema' => $schema],
+                ['register' => $this->unionPartner[0], 'schema' => $this->unionPartner[1]],
+            ]
+        );
+
+        return $this->keysOf($rows);
+    }//end visibleKeysViaUnionWithTenancy()
+
+
+    /**
+     * CHARACTERISATION: does the UNION path enforce the tenant edge?
+     *
+     * `testAGrantDoesNotCrossTheTenantEdge` proves the SINGLE-table path does.
+     * That test calls `searchObjectsInRegisterSchemaTable()`, so it says nothing
+     * about `searchAcrossMultipleTables()` — and `ObjectsController` carries a
+     * standing `TODO(SEC-CTRL-1)` asserting that the cross-table builders apply
+     * NO RBAC or multitenancy filter and "must be wired there before cross-table
+     * search is exposed to non-admins".
+     *
+     * This matters concretely: a cross-register "shared with me" read (task 6.3)
+     * is exactly such an exposure. Before building one, the posture has to be a
+     * measured fact rather than an inference from a comment that may be stale —
+     * the scope-and-grant half of that TODO IS stale, because the union emitter
+     * does now carry the predicate.
+     *
+     * The test asserts what is TRUE today so the answer is recorded and any
+     * change to it is deliberate. If the union path does filter, the assertion
+     * documents the guarantee; if it does not, it documents the gap and fails the
+     * moment somebody fixes it — at which point the expectation flips and 6.3
+     * becomes safe to build on.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/object-level-sharing-and-private-scope/specs/private-object-scope/spec.md#requirement-the-private-principal-is-honoured-identically-on-every-enforcement-path
+     */
+    public function testUnionPathTenantEdgeIsCharacterised(): void
+    {
+        [$register, $schema] = $this->createFixtureTable(readRule: $this->tenantGroup);
+
+        $activeOrg = $this->activeOrganisationUuid();
+        if ($activeOrg === null) {
+            $this->markTestSkipped('the session user has no active organisation, so the org filter denies everything');
+        }
+
+        // Same construction as the single-table tenant-edge test: two private
+        // rows, both granted to the caller, differing ONLY in organisation.
+        $this->insertFixture($register, $schema, 'union-same', ['scope' => 'private'], false, ownedByRealOwner: true);
+        $this->insertFixture($register, $schema, 'union-other', ['scope' => 'private'], false, ownedByRealOwner: true);
+
+        $this->setOrganisation($register, $schema, 'union-same', $activeOrg);
+        $this->setOrganisation($register, $schema, 'union-other', '00000000-0000-4000-8000-00000000dead');
+
+        $stored = $this->readBackByKey($register, $schema);
+        $this->grantTo($stored['union-same'], $this->testUid);
+        $this->grantTo($stored['union-other'], $this->testUid);
+        $this->grantResolver()->forget();
+
+        $visible = $this->visibleKeysViaUnionWithTenancy($register, $schema);
+
+        // CONTROL: the in-tenant row must be there, or the assertion below would
+        // pass simply because the query returned nothing at all.
+        $this->assertContains(
+            'union-same',
+            $visible,
+            'control: the in-tenant granted row must be visible, or this test proves nothing'
+        );
+
+        // MEASURED, 2026-08-03: the union path returns the other organisation's
+        // row. The scope-and-grant predicate IS applied there (the tests above
+        // prove that), but the ORGANISATION filter is not — so
+        // `TODO(SEC-CTRL-1)` in ObjectsController is accurate for multitenancy
+        // and stale for RBAC.
+        //
+        // This asserts the CURRENT behaviour on purpose. It is a characterisation,
+        // not an endorsement: the moment somebody wires tenancy into
+        // `searchAcrossMultipleTables()` this test FAILS, which is the signal to
+        // flip the expectation to `assertNotContains` and to revisit the
+        // cross-register reads that were blocked on it — a `shared-with-me` list
+        // (task 6.3) above all, which must not be built over this path until then.
+        $this->assertContains(
+            'union-other',
+            $visible,
+            'If this now FAILS, tenancy has been wired into the union path — flip this assertion to '
+            .'assertNotContains and unblock the cross-register reads that were waiting on it (task 6.3).'
+        );
+    }//end testUnionPathTenantEdgeIsCharacterised()
+
+
     private function visibleKeysViaUnion(Register $register, Schema $schema): array
     {
         if ($this->unionPartner === null) {


### PR DESCRIPTION
Task 6.3 (shared-with-me widget) needs a cross-register read, which means the cross-table search. Before building on it I wanted the tenancy posture as a **measured fact**, because `ObjectsController` carries a standing `TODO(SEC-CTRL-1)` claiming the cross-table builders apply no RBAC or multitenancy filter — and half of that is now stale, since groups 2–4 put the scope-and-grant predicate into the union emitter.

### The measurement

Two private rows, both granted to the caller, differing **only** in organisation.

| path | foreign-org row |
|---|---|
| single-table (`searchObjectsInRegisterSchemaTable`) | filtered out ✅ |
| **union (`searchAcrossMultipleTables`)** | **comes back** ❌ |

So scope and grants **are** enforced there; the **organisation filter is not**. The existing `testAGrantDoesNotCrossTheTenantEdge` only ever exercised the single-table path, which is why this went unnoticed.

### Why it lands as a characterisation

It asserts today's behaviour **deliberately** — not as an endorsement. The moment somebody wires tenancy into the union path this test **fails**, which is precisely the wanted signal: flip to `assertNotContains` and unblock the cross-register reads waiting on it. A test that passed either way would tell nobody anything.

It carries its control: the in-tenant row must be present, or "the foreign row is present" could pass on a query that returned everything indiscriminately.

### What I did NOT establish, so it isn't claimed

`objects#index` and `objects#objects` are both `@NoAdminRequired` and both route into `crossTableSearch()` on a caller-controlled `?schemas=a,b`, which *looks* like reachable exposure. **My HTTP probe did not confirm it** — the request returned `No valid magic-mapped register+schema combinations found`, for admin too, so my pair arguments were wrong and it never reached the union path. The exposure is proven at the **mapper** level; HTTP reachability is unproven in either direction and needs a valid pair to settle.

### Verification

22/22 `PrivateScopeParityIntegrationTest` green (21 before).

Reproducing note: the dev instance must be on current `development` — an older `ObjectSharingService` lacks the #2298 re-share clamp and fails `testAGrantNeverCarriesCoresReshareBit` for that reason alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
