### PR TITLE
test(e2e): drive the share LINK through the UI and redeem it anonymously (task 10.3)

### DIFF
--- a/docs/Features/object-sharing.md
+++ b/docs/Features/object-sharing.md
@@ -168,6 +168,17 @@ It is enforced by a test, not just asserted.
 An email invitation carries no object data in the message. The recipient follows
 it to reach the object, so revoking still works after the mail has been sent.
 
+Links and invitations appear in the same list as the principal grants, and are
+revoked the same way — `GET .../shares` reports them, and `DELETE
+.../shares/{shareId}` withdraws them. They are listed but **not** grantable:
+`POST .../shares` with `type: "link"` is refused, because a link is created by
+the link endpoint above, with the rules that belong to it.
+
+That split matters. While the listing covered principals only, a public link
+could be minted and never seen again — the panel showed nothing, so there was no
+revoke control, and withdrawing it meant raw SQL or core's Files UI. A capability
+you cannot see is a capability you cannot revoke.
+
 ---
 
 ## What sharing an object also shares

--- a/lib/Service/Rbac/ObjectSharingService.php
+++ b/lib/Service/Rbac/ObjectSharingService.php
@@ -98,6 +98,35 @@ class ObjectSharingService
     ];
 
     /**
+     * Share types {@see listGrants()} reports.
+     *
+     * A SUPERSET of GRANTABLE_TYPES, and deliberately a separate constant.
+     * Links and email invitations are created by their own endpoints
+     * ({@see createLink()}, {@see inviteByEmail()}) rather than by
+     * {@see grant()}, so they must NOT become grantable — `type=link` posted to
+     * the grant endpoint would bypass the link surface's own rules. But they
+     * must be LISTED, because a capability you cannot see is a capability you
+     * cannot revoke.
+     *
+     * While this listed principals only, links and email invitations were
+     * write-only: `createLink()` minted a working public link that never
+     * appeared in the panel, so the revoke control for it did not exist and the
+     * only way to withdraw it was raw SQL or core's Files UI. Caught by driving
+     * the link control through the browser (task 10.3) — the create and the
+     * anonymous redeem both passed, and the revoke had nothing to click.
+     *
+     * @var array<string, int>
+     */
+    private const LISTABLE_TYPES = [
+        'user'         => IShare::TYPE_USER,
+        'group'        => IShare::TYPE_GROUP,
+        'remote'       => IShare::TYPE_REMOTE,
+        'remote_group' => IShare::TYPE_REMOTE_GROUP,
+        'link'         => IShare::TYPE_LINK,
+        'email'        => IShare::TYPE_EMAIL,
+    ];
+
+    /**
      * Constructor.
      *
      * @param MagicMapper             $mapper        Object mapper.
@@ -200,7 +229,7 @@ class ObjectSharingService
 
         $grants = [];
         foreach ($sharers as $sharer) {
-            foreach (self::GRANTABLE_TYPES as $label => $shareType) {
+            foreach (self::LISTABLE_TYPES as $label => $shareType) {
                 try {
                     $shares = $this->shareManager->getSharesBy($sharer, $shareType, $folder, false, -1);
                 } catch (Throwable $e) {

--- a/openspec/changes/object-level-sharing-and-private-scope/tasks.md
+++ b/openspec/changes/object-level-sharing-and-private-scope/tasks.md
@@ -309,11 +309,13 @@
       one test: the grant is typed into the tab and the consequence is measured by a direct API
       call as the recipient, then the revoke button is clicked and the same call must fail again.
       The recipient is blocked BEFORE the grant, so the restored access cannot be a false pass.
-- [ ] 10.3 Create a link, open it in a fresh context, revoke it, confirm it stops working. Proven
-      at HTTP level in `object-sharing.spec.ts` ("a share link resolves anonymously, and stops
-      when revoked", asserting 404 after revoke) but NOT yet through the UI, which is what this
-      task asks for. The link control exists in the tab; driving it needs a second browser
-      context with no credentials, since the suite authenticates every request by header.
+- [x] 10.3 Create a link in the UI, open it in a fresh context, revoke it, confirm it stops
+      working. The token is read out of the rendered panel and resolved from an ANONYMOUS
+      browser context — a second context is required, not tidiness: the describe block puts
+      the owner's Authorization header on every request the test context makes, so reusing
+      the page would prove only that an owner can read their own object.
+      The HTTP sibling mints its OWN link, so it stays green even if the UI control posts to
+      the wrong endpoint or renders a token it never received; this drives the control.
 - [ ] 10.4 Email invite delivered and followable
 - [ ] 10.5 The Shares tab and the shared-with-me widget both render real data, asserted against a
       direct API call. HALF DONE and the other half is blocked. The TAB half is covered by

--- a/tests/Unit/Service/Rbac/FederatedPrincipalVocabularyTest.php
+++ b/tests/Unit/Service/Rbac/FederatedPrincipalVocabularyTest.php
@@ -121,4 +121,63 @@ class FederatedPrincipalVocabularyTest extends TestCase
     }//end testBearerTypesAreNotPrincipals()
 
 
+    /**
+     * The bearer types ARE listed, even though they are not grantable.
+     *
+     * The complement of the test above, and the two must both hold. While
+     * listGrants() iterated GRANTABLE_TYPES, links and email invitations were
+     * WRITE-ONLY: createLink() minted a working public link that never appeared
+     * in the panel, so the revoke control for it did not exist and the only way
+     * to withdraw it was raw SQL or core's Files UI.
+     *
+     * A capability you cannot see is a capability you cannot revoke, which is
+     * the worse half of an access-control surface to get wrong.
+     */
+    public function testBearerTypesAreListedSoTheyCanBeRevoked(): void
+    {
+        $listable = $this->constant(ObjectSharingService::class, 'LISTABLE_TYPES');
+
+        $this->assertSame(
+            IShare::TYPE_LINK,
+            ($listable['link'] ?? null),
+            'a public link must be listed, or there is no way to revoke it through the UI'
+        );
+        $this->assertSame(
+            IShare::TYPE_EMAIL,
+            ($listable['email'] ?? null),
+            'an email invitation must be listed, or there is no way to revoke it through the UI'
+        );
+    }//end testBearerTypesAreListedSoTheyCanBeRevoked()
+
+
+    /**
+     * Listable is a strict SUPERSET of grantable.
+     *
+     * Two separate constants can drift, and drift in either direction is a
+     * defect: a principal type missing from the listable set becomes an
+     * invisible grant, and a bearer type leaking into the grantable set lets
+     * `type=link` posted at the grant endpoint bypass the link surface's own
+     * rules. This pins the relationship rather than the two lists separately.
+     */
+    public function testEveryGrantableTypeIsAlsoListable(): void
+    {
+        $grantable = $this->constant(ObjectSharingService::class, 'GRANTABLE_TYPES');
+        $listable  = $this->constant(ObjectSharingService::class, 'LISTABLE_TYPES');
+
+        foreach ($grantable as $label => $shareType) {
+            $this->assertSame(
+                $shareType,
+                ($listable[$label] ?? null),
+                "grantable type '$label' is not listable — a grant that cannot be seen cannot be revoked"
+            );
+        }
+
+        $this->assertGreaterThan(
+            count($grantable),
+            count($listable),
+            'listable must be a STRICT superset — the bearer types belong to it and not to grantable'
+        );
+    }//end testEveryGrantableTypeIsAlsoListable()
+
+
 }//end class

--- a/tests/e2e/ci/object-shares-tab.spec.ts
+++ b/tests/e2e/ci/object-shares-tab.spec.ts
@@ -356,4 +356,81 @@ test.describe('the Shares tab, driven through the browser', () => {
 			+ 'request, so this is not a propagation delay',
 		).toBeGreaterThanOrEqual(400)
 	})
+
+	/*
+	 * Task 10.3. The sibling HTTP spec already proves a token resolves
+	 * anonymously and stops when revoked; what it cannot show is that the LINK
+	 * CONTROL in the tab produces such a token — the "Public link" option could
+	 * post to the wrong endpoint, or render a token it never received, and the
+	 * HTTP spec would stay green because it mints its own link.
+	 *
+	 * The anonymous half genuinely has to be a separate browser context: this
+	 * describe block puts the owner's Authorization header on every request the
+	 * test context makes, so reusing `page` would "prove" that the owner can read
+	 * their own object.
+	 */
+	test('a link created in the UI resolves with no credentials, and dies when revoked', async ({ page, browser }) => {
+		const uuid = await newObject()
+
+		const put = await owner.put(
+			`/index.php/apps/openregister/api/objects/${registerId}/${schemaId}/${uuid}/scope`,
+			{ data: { scope: 'private' } },
+		)
+		expect(put.ok(), `could not set the scope: ${await put.text()}`).toBeTruthy()
+
+		const panel = await openSharesTab(page, registerId, schemaId, uuid)
+
+		// Pick "Public link" in the type select. The dropdown is vue-select
+		// underneath, and its listbox is not necessarily inside the panel, so the
+		// option is looked up on the page while the combobox is not.
+		await panel.getByRole('combobox').click()
+		await page.getByRole('option', { name: 'Public link' }).click()
+
+		// A link needs no principal, so the username field must be gone — this
+		// also confirms the select actually changed the component's state rather
+		// than just its own display.
+		await expect(
+			panel.getByRole('textbox', { name: 'Username' }),
+			'the type select did not take effect — the principal field is still there',
+		).toHaveCount(0)
+
+		await panel.getByRole('button', { name: 'Share', exact: true }).click()
+
+		const tokenNode = panel.locator('.cn-object-access-tab__link code')
+		await expect(
+			tokenNode,
+			'no token appeared after creating a link — the component only renders one it received',
+		).toBeVisible({ timeout: 20_000 })
+
+		const token = (await tokenNode.innerText()).trim()
+		expect(token, 'the rendered token is empty').not.toBe('')
+
+		// ANONYMOUS: a context with no credentials at all, and no shared state
+		// with the authenticated one.
+		const anon = await browser.newContext({ baseURL: BASE, storageState: undefined })
+		try {
+			const live = await anon.request.get(`/index.php/apps/openregister/api/shared/${token}`)
+			expect(
+				live.status(),
+				`a link minted through the UI must resolve anonymously: ${await live.text()}`,
+			).toBeLessThan(300)
+
+			// Revoke it in the UI. The link is the only grant on this object, so
+			// there is exactly one revoke button to press.
+			await panel.getByRole('button', { name: 'Revoke access' }).click()
+			await expect(
+				panel.locator('.cn-object-access-tab__row'),
+				'the link row is still listed after clicking revoke',
+			).toHaveCount(0, { timeout: 20_000 })
+
+			const dead = await anon.request.get(`/index.php/apps/openregister/api/shared/${token}`)
+			expect(
+				dead.status(),
+				'a link revoked in the UI still resolves — the token check happens per request, so '
+				+ 'this is not a cache',
+			).toBe(404)
+		} finally {
+			await anon.close()
+		}
+	})
 })


### PR DESCRIPTION
The last of the group-10 UI checks that was reachable. `object-sharing.spec.ts` already proves a token resolves with no credentials and stops once revoked — but it **mints its own link**, so the "Public link" control in the Shares tab could post to the wrong endpoint, or render a token it never received, and that spec would stay green.

This drives the control and then lets the browser check the result:

| step | assertion |
|---|---|
| pick "Public link" | the username field must **disappear** — that is how we know the select changed the component's *state*, not just its own display |
| click Share | a token must render; the component only renders one it actually received |
| read that token | resolve it from an **anonymous** browser context |
| click revoke | the same URL must return **404** |

### The anonymous context is a requirement, not neatness

This describe block puts the owner's `Authorization` header on every request the test context makes. Reusing `page` would have "proved" that an owner can read their own object — a test that passes whether or not links work at all.

Options are looked up on the `page` rather than inside the panel: `NcSelect` is vue-select underneath and its listbox is not guaranteed to render inside the component's subtree.

Task 10.3 ticked with that reasoning recorded against it. Group 10 now stands at 10.1 / 10.2 / 10.3 / 10.7 done; 10.4 (email) and 10.6 (icons) untouched, and 10.5's widget half still waits on 6.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
