### PR TITLE
chore(deps): nc-vue 3.0.0-vue3.3, and prove the GROUP grant it fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
-        "@conduction/nextcloud-vue": "3.0.0-vue3.2",
+        "@conduction/nextcloud-vue": "3.0.0-vue3.3",
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@nextcloud/auth": "^2.6.0",
@@ -2148,9 +2148,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "3.0.0-vue3.2",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-3.0.0-vue3.2.tgz",
-      "integrity": "sha512-Ge6uW0lJHAdZ/mlWgrfGTrSIeh2waSCOS4n8m2SSCDv9rpw1lHw8hPK5VdvYym+5+sj8OUU+xP9f5bSmclF7Yg==",
+      "version": "3.0.0-vue3.3",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-3.0.0-vue3.3.tgz",
+      "integrity": "sha512-cV1myCIfk4afV2aK+I9+Rg7SfvXgQ8xNdcSJc02Dgebr8UcPwNRvCyrmrvGwF3EvwjVSv+NXTlyCtX5VDAS7Vg==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
-    "@conduction/nextcloud-vue": "3.0.0-vue3.2",
+    "@conduction/nextcloud-vue": "3.0.0-vue3.3",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@nextcloud/auth": "^2.6.0",

--- a/tests/e2e/ci/object-shares-tab.spec.ts
+++ b/tests/e2e/ci/object-shares-tab.spec.ts
@@ -42,6 +42,9 @@ const OWNER = 'e2e-owner'
 const OTHER = 'e2e-other'
 const PASS = 'E2e-Share-Pass-123'
 
+/** Seeded group whose only member is OTHER — see tests/e2e/ci/seed.sh. */
+const GROUP = 'e2e-grantees'
+
 /** Build an API context authenticated as one user. */
 async function contextFor(user: string, password: string): Promise<APIRequestContext> {
 	return pwRequest.newContext({
@@ -354,6 +357,72 @@ test.describe('the Shares tab, driven through the browser', () => {
 			await statusFor(other, registerId, schemaId, uuid),
 			'a revoked user can still reach the object — revocation takes effect on the NEXT '
 			+ 'request, so this is not a propagation delay',
+		).toBeGreaterThanOrEqual(400)
+	})
+
+	/*
+	 * THE GROUP PATH, which is the one that was silently broken.
+	 *
+	 * The tab posted `shareType: 0 | 1` — a key
+	 * ObjectSharingController::createShare() does not read — so it fell through to
+	 * the controller's 'user' default and picking "Group" created a USER grant to
+	 * a uid spelled like the group name. A user grant worked by coincidence, so
+	 * every UI test that used one stayed green (nextcloud-vue#591).
+	 *
+	 * Access is checked as OTHER, who is in the group and is named nowhere in the
+	 * grant. That is the whole discriminator: under the old behaviour the share
+	 * went to a nonexistent user called "e2e-grantees" and OTHER got nothing.
+	 */
+	test('granting to a GROUP in the UI reaches a member of that group', async ({ page }) => {
+		const uuid = await newObject()
+
+		const put = await owner.put(
+			`/index.php/apps/openregister/api/objects/${registerId}/${schemaId}/${uuid}/scope`,
+			{ data: { scope: 'private' } },
+		)
+		expect(put.ok(), `could not set the scope: ${await put.text()}`).toBeTruthy()
+
+		expect(
+			await statusFor(other, registerId, schemaId, uuid),
+			'the group member must be locked out before the grant, or the grant proves nothing',
+		).toBeGreaterThanOrEqual(400)
+
+		const panel = await openSharesTab(page, registerId, schemaId, uuid)
+
+		await panel.getByRole('combobox').click()
+		await page.getByRole('option', { name: 'Group' }).click()
+
+		// The label changing to "Group name" is how we know the select changed the
+		// component's state and not merely its own display.
+		await panel.getByRole('textbox', { name: 'Group name' }).fill(GROUP)
+		await panel.getByRole('button', { name: 'Share', exact: true }).click()
+
+		await expect(
+			panel.locator('.cn-object-access-tab__row'),
+			'no grant row appeared after granting to a group',
+		).toHaveCount(1, { timeout: 20_000 })
+
+		// A sanity check only, NOT the discriminator: the row renders
+		// `sharedWith`, which was the group's name under the broken behaviour
+		// too — the share went to a nonexistent USER called "e2e-grantees" and
+		// still displayed "e2e-grantees". This line would have passed either way.
+		await expect(panel.locator('.cn-object-access-tab__row')).toContainText(GROUP)
+
+		// THIS is the discriminator. OTHER is named nowhere in the grant and can
+		// only have gained access through group membership, so a user share
+		// spelled like the group leaves them locked out.
+		expect(
+			await statusFor(other, registerId, schemaId, uuid),
+			'a member of the granted group cannot reach the object — the grant was probably '
+			+ 'created as a USER share named after the group',
+		).toBeLessThan(300)
+
+		await panel.getByRole('button', { name: 'Revoke access' }).click()
+		await expect(panel.locator('.cn-object-access-tab__row')).toHaveCount(0, { timeout: 20_000 })
+
+		expect(
+			await statusFor(other, registerId, schemaId, uuid),
+			'the group member still has access after the group grant was revoked',
 		).toBeGreaterThanOrEqual(400)
 	})
 

--- a/tests/e2e/ci/seed.sh
+++ b/tests/e2e/ci/seed.sh
@@ -41,4 +41,28 @@ for uid in e2e-owner e2e-other; do
 	fi
 done
 
+# A group with a member, for the GROUP grant path.
+#
+# Not decoration: a group grant is the case that was silently broken. The tab
+# posted `shareType: 0|1`, a key ObjectSharingController::createShare() does not
+# read, so it fell through to the 'user' default and picking "Group" created a
+# USER grant to a uid spelled like the group. A user grant worked by coincidence,
+# which is why nothing caught it (nextcloud-vue#591).
+#
+# The membership is what makes the assertion meaningful: access is checked as
+# e2e-other, who gains it only through the group.
+GROUP='e2e-grantees'
+
+if php occ group:add "$GROUP"; then
+	echo "seeded group $GROUP"
+else
+	echo "group $GROUP already present (or could not be created) — the specs will verify"
+fi
+
+if php occ group:adduser "$GROUP" e2e-other; then
+	echo "added e2e-other to $GROUP"
+else
+	echo "e2e-other already in $GROUP (or could not be added) — the specs will verify"
+fi
+
 echo 'e2e seed complete'


### PR DESCRIPTION
`3.0.0-vue3.2` → `3.0.0-vue3.3`, which carries ConductionNL/nextcloud-vue#591:

- the grant type is sent as **`type`** (the string the server validates) rather than `shareType: 0|1`, a key `ObjectSharingController::createShare()` does not read. Until now the tab's **Group** option fell through to the controller's `'user'` default and created a *user* grant to a uid spelled like the group.
- the file coupling is stated in the panel (task 5.9): *"Everyone listed here can also open the files attached to this item."*

### Verified from the published tarball, not from a green release run

```console
$ npm pack @conduction/nextcloud-vue@3.0.0-vue3.3
$ grep -A4 'base}/shares`, {' package/dist/esm/.../CnObjectAccessTab.vue2.js
  res = await this.post(`${this.base}/shares`, {
    type,
    shareWith: this.newPrincipal.trim(),
    permissions,
  });
```

The only remaining occurrence of `shareType` in the published dist is inside the explanatory comment.

### A fifth e2e, because the point of this bump is a behaviour change

A bump whose whole purpose is fixing behaviour should not be taken on trust. The new test grants to a group **in the UI**, then checks access as `e2e-other`, who is *in* the group and named nowhere in the grant. Under the old behaviour the share went to a nonexistent user called `e2e-grantees` and the member stayed locked out.

The row-text assertion is explicitly labelled a **sanity check and not the discriminator** — the row renders `sharedWith`, which was the group's name under the broken behaviour too, so it would have passed either way. The access check as the member is the assertion that can actually fail.

`seed.sh` gains the group and the membership.

### Housekeeping

`npm install` again rewrote the unrelated `vue` range from `^3.5.18` to `^3.5.0`; reverted, so the dependency diff is one line. `docs/features.json` is deliberately absent — `npm run build` rewrites it from 200 lines to 31, which is a build artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
