### PR TITLE
feat(flow): openregister.map, own the Twig engine, and the sync-decomposition design

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -40,7 +40,7 @@ Open Register drijft apps zoals OpenCatalogi, Procest, Pipelinq en Software Cata
 
 Vrij en open source onder de EUPL-licentie.
     ]]></description>
-    <version>0.2.17-unstable.22</version>
+    <version>0.2.17-unstable.23</version>
     <licence>EUPL-1.2</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>OpenRegister</namespace>

--- a/lib/AppHost/Service/GenericStoreService.php
+++ b/lib/AppHost/Service/GenericStoreService.php
@@ -292,9 +292,17 @@ class GenericStoreService
         }
 
         // Some OpenRegister responses are a bare list; accept that too.
+        // A non-list decode is treated as no results rather than passed through:
+        // callers iterate this, and handing them an associative array would
+        // iterate its VALUES as if they were records.
+        $results = [];
+        if (array_is_list($decoded) === true) {
+            $results = $decoded;
+        }
+
         return [
             'outcome' => self::OUTCOME_OK,
-            'results' => (array_is_list($decoded) === true ? $decoded : []),
+            'results' => $results,
         ];
 
     }//end decodeBody()

--- a/lib/Listener/FlowNodeRegistrationListener.php
+++ b/lib/Listener/FlowNodeRegistrationListener.php
@@ -30,6 +30,7 @@ namespace OCA\OpenRegister\Listener;
 
 use OCA\OpenRegister\Service\Flow\Nodes\ExplodeNode;
 use OCA\OpenRegister\Service\Flow\Nodes\FilterNode;
+use OCA\OpenRegister\Service\Flow\Nodes\MapNode;
 use OCA\OpenRegister\Service\Flow\Nodes\FlowStateNode;
 use OCA\OpenRegister\Service\Flow\Nodes\LoopNode;
 use OCA\OpenRegister\Service\Flow\Nodes\MergeNode;
@@ -68,6 +69,7 @@ class FlowNodeRegistrationListener implements IEventListener
      * @param ObjectWriteNode $objectWrite The built-in "Write an object" node.
      * @param ObjectReadNode  $objectRead  The built-in "Read objects" node.
      * @param FlowStateNode   $flowState   The built-in "Flow state" node.
+     * @param MapNode         $map         The built-in "Map" node.
      */
     public function __construct(
         private readonly SetFieldsNode $setFields,
@@ -82,7 +84,8 @@ class FlowNodeRegistrationListener implements IEventListener
         private readonly RouterNode $router,
         private readonly ObjectWriteNode $objectWrite,
         private readonly ObjectReadNode $objectRead,
-        private readonly FlowStateNode $flowState
+        private readonly FlowStateNode $flowState,
+        private readonly MapNode $map
     ) {
 
     }//end __construct()
@@ -115,6 +118,7 @@ class FlowNodeRegistrationListener implements IEventListener
         $event->registerNode(node: $this->objectWrite);
         $event->registerNode(node: $this->objectRead);
         $event->registerNode(node: $this->flowState);
+        $event->registerNode(node: $this->map);
 
     }//end handle()
 }//end class

--- a/lib/Listener/FlowNodeRegistrationListener.php
+++ b/lib/Listener/FlowNodeRegistrationListener.php
@@ -30,6 +30,7 @@ namespace OCA\OpenRegister\Listener;
 
 use OCA\OpenRegister\Service\Flow\Nodes\ExplodeNode;
 use OCA\OpenRegister\Service\Flow\Nodes\FilterNode;
+use OCA\OpenRegister\Service\Flow\Nodes\IterateNode;
 use OCA\OpenRegister\Service\Flow\Nodes\MapNode;
 use OCA\OpenRegister\Service\Flow\Nodes\FlowStateNode;
 use OCA\OpenRegister\Service\Flow\Nodes\LoopNode;
@@ -70,6 +71,7 @@ class FlowNodeRegistrationListener implements IEventListener
      * @param ObjectReadNode  $objectRead  The built-in "Read objects" node.
      * @param FlowStateNode   $flowState   The built-in "Flow state" node.
      * @param MapNode         $map         The built-in "Map" node.
+     * @param IterateNode     $iterate     The built-in "Repeat until done" node.
      */
     public function __construct(
         private readonly SetFieldsNode $setFields,
@@ -85,7 +87,8 @@ class FlowNodeRegistrationListener implements IEventListener
         private readonly ObjectWriteNode $objectWrite,
         private readonly ObjectReadNode $objectRead,
         private readonly FlowStateNode $flowState,
-        private readonly MapNode $map
+        private readonly MapNode $map,
+        private readonly IterateNode $iterate
     ) {
 
     }//end __construct()
@@ -119,6 +122,7 @@ class FlowNodeRegistrationListener implements IEventListener
         $event->registerNode(node: $this->objectRead);
         $event->registerNode(node: $this->flowState);
         $event->registerNode(node: $this->map);
+        $event->registerNode(node: $this->iterate);
 
     }//end handle()
 }//end class

--- a/lib/Migration/Version1Date20260804000000.php
+++ b/lib/Migration/Version1Date20260804000000.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * Rewrites the renamed `openregister.loop` node id in stored flow definitions.
+ *
+ * The node never looped — it splits items into fixed-size batches — and sitting
+ * next to the real `openregister.iterate` the old name was a trap that re-armed
+ * for every new reader. So it became `openregister.batch`.
+ *
+ * A node id is a reference the SYSTEM writes into a flow definition, which is
+ * what makes correcting it different from correcting a Twig function name: a
+ * template is typed by a person and cannot be safely rewritten, a flow's node
+ * list is a JSON structure we own end to end. So the id is fixed and the data
+ * migrated, rather than the wrong name being kept forever.
+ *
+ * The registry keeps a logged alias for one release, covering the one case this
+ * migration cannot reach: a flow exported before the rename and imported after.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-sync-decomposition/specs/flow-iteration/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Migrates `openregister.loop` to `openregister.batch` in stored flows.
+ */
+class Version1Date20260804000000 extends SimpleMigrationStep
+{
+
+    /**
+     * The old node id.
+     *
+     * @var string
+     */
+    private const OLD_ID = 'openregister.loop';
+
+    /**
+     * The corrected node id.
+     *
+     * @var string
+     */
+    private const NEW_ID = 'openregister.batch';
+
+    /**
+     * The database connection.
+     *
+     * @var IDBConnection
+     */
+    private IDBConnection $db;
+
+    /**
+     * Constructor.
+     *
+     * @param IDBConnection $db The database connection.
+     */
+    public function __construct(IDBConnection $db)
+    {
+        $this->db = $db;
+
+    }//end __construct()
+
+    /**
+     * Rewrite the node id in every stored flow definition.
+     *
+     * Operates on the `nodes` and `edges` JSON as TEXT, matching the quoted id
+     * exactly. A structural walk would be more elegant and is not worth it here:
+     * the id appears only as a JSON string value, an exact quoted match cannot
+     * hit a prefix (`openregister.loopback` would not match `"openregister.loop"`),
+     * and decoding/re-encoding every definition risks reordering keys or losing
+     * numeric precision in flows this migration has no business touching.
+     *
+     * @param IOutput $output        Migration output.
+     * @param Closure $schemaClosure Schema closure returning an ISchemaWrapper.
+     * @param array   $options       Migration options.
+     *
+     * @return void
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @spec openspec/changes/flow-sync-decomposition/specs/flow-iteration/spec.md
+     */
+    public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
+    {
+        $schema = $schemaClosure();
+        if ($schema->hasTable('openregister_flows') === false) {
+            $output->info('No flow table yet; nothing to rename.');
+            return;
+        }
+
+        $needle      = '"'.self::OLD_ID.'"';
+        $replacement = '"'.self::NEW_ID.'"';
+        $touched     = 0;
+
+        $qb = $this->db->getQueryBuilder();
+        $qb->select('id', 'name', 'nodes', 'edges')
+            ->from('openregister_flows');
+
+        $result = $qb->executeQuery();
+        $rows   = $result->fetchAll();
+        $result->closeCursor();
+
+        foreach ($rows as $row) {
+            $nodes = (string) ($row['nodes'] ?? '');
+            $edges = (string) ($row['edges'] ?? '');
+
+            if (str_contains($nodes, $needle) === false && str_contains($edges, $needle) === false) {
+                continue;
+            }
+
+            $update = $this->db->getQueryBuilder();
+            $update->update('openregister_flows')
+                ->set('nodes', $update->createNamedParameter(str_replace($needle, $replacement, $nodes)))
+                ->set('edges', $update->createNamedParameter(str_replace($needle, $replacement, $edges)))
+                ->where($update->expr()->eq('id', $update->createNamedParameter((int) $row['id'])));
+            $update->executeStatement();
+
+            $touched++;
+            $output->info(
+                sprintf('Flow "%s": %s -> %s', (string) ($row['name'] ?? $row['id']), self::OLD_ID, self::NEW_ID)
+            );
+        }//end foreach
+
+        $output->info(sprintf('Node rename: %d flow definition(s) updated.', $touched));
+
+    }//end postSchemaChange()
+}//end class

--- a/lib/Service/Flow/FlowNodeRegistry.php
+++ b/lib/Service/Flow/FlowNodeRegistry.php
@@ -50,6 +50,28 @@ class FlowNodeRegistry
     private array $nodes = [];
 
     /**
+     * Node ids that were corrected, mapped old => new.
+     *
+     * A node id is a reference the SYSTEM writes into a flow definition, unlike
+     * a Twig function name which a person types into a template — so unlike
+     * those, an id can be corrected and the stored data migrated. A migration
+     * rewrites existing rows; this alias covers the tail the migration cannot
+     * reach: a flow exported before the rename and imported after it.
+     *
+     * Resolving through here is LOGGED, so the size of that tail is observable
+     * rather than assumed to be zero. The alias is removed one release after the
+     * rename.
+     *
+     * @var array<string, string>
+     */
+    private const RENAMED = [
+        // Renamed because it never looped: it splits items into fixed-size
+        // batches. Sitting next to the real `openregister.iterate`, the old name
+        // was a trap that re-armed for every new reader.
+        'openregister.loop' => 'openregister.batch',
+    ];
+
+    /**
      * Whether contribution has already been collected this request.
      *
      * @var boolean
@@ -213,6 +235,21 @@ class FlowNodeRegistry
     public function get(string $type): IFlowNode
     {
         $this->load();
+
+        if (isset($this->nodes[$type]) === false && isset(self::RENAMED[$type]) === true) {
+            $this->logger->info(
+                message: sprintf(
+                    '[FlowNodeRegistry] Flow node "%s" was renamed to "%s"; resolving via the '
+                    .'compatibility alias. A flow definition still references the old id.',
+                    $type,
+                    self::RENAMED[$type]
+                ),
+                context: ['file' => __FILE__, 'line' => __LINE__]
+            );
+
+            $type = self::RENAMED[$type];
+        }
+
         if (isset($this->nodes[$type]) === false) {
             throw new UnexpectedValueException(
                 sprintf('No app provides the flow node type "%s". Is the app that owns it installed and enabled?', $type)

--- a/lib/Service/Flow/Nodes/IterateNode.php
+++ b/lib/Service/Flow/Nodes/IterateNode.php
@@ -1,0 +1,305 @@
+<?php
+
+/**
+ * Repeats a chain of steps until a source stops producing.
+ *
+ * The engine could already loop — it is a Petri net, so an edge drawn backwards
+ * is a cycle — but that is an execution capability, not an authoring one. A
+ * back-edge looks identical to a forward edge, so the most important fact about
+ * a graph (that a region repeats) is carried by edge DIRECTION, which is exactly
+ * what someone scanning a diagram does not reliably read. Loop membership was
+ * inferred by tracing rather than declared, the bound was a whole-run ceiling
+ * shared between every loop, and non-convergence was only diagnosed after the
+ * side effects had happened.
+ *
+ * Here the loop OWNS its body. Membership is data, so a builder can draw the
+ * region as a container; the bound belongs to the loop that overran, so the
+ * error can name it; and each body step runs with its iteration index in scope.
+ *
+ * Termination is deliberately one rule: the loop stops when `source` returns no
+ * items. Pagination falls out of that without a second concept — a page past the
+ * end is empty. `context['iteration']` carries the index so the source can ask
+ * for the right page.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow\Nodes
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-sync-decomposition/specs/flow-iteration/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow\Nodes;
+
+use OCA\OpenRegister\Service\Flow\FlowStepDispatcher;
+use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\WorkflowEngine\IManager;
+use Psr\Container\ContainerInterface;
+use RuntimeException;
+use UnexpectedValueException;
+
+/**
+ * A declared loop region: a source, a body, and a bound.
+ */
+class IterateNode implements IFlowNode, IFlowNodeConfigKeys
+{
+
+    /**
+     * Default ceiling when a flow declares none.
+     *
+     * @var integer
+     */
+    public const DEFAULT_MAX_ITERATIONS = 100;
+
+    /**
+     * Overrun ends the run as failed.
+     *
+     * @var string
+     */
+    public const ON_LIMIT_FAIL = 'fail';
+
+    /**
+     * Overrun ends the loop and carries on with what was gathered.
+     *
+     * @var string
+     */
+    public const ON_LIMIT_STOP = 'stop';
+
+    /**
+     * Constructor.
+     *
+     * The dispatcher is resolved from the container at execute time rather than
+     * injected: this node is registered IN the node registry, and the dispatcher
+     * reads from that same registry, so constructor injection would close a
+     * cycle while the registry is still being populated.
+     *
+     * @param IL10N              $l10n      Translations.
+     * @param IURLGenerator      $urls      For the palette icon.
+     * @param ContainerInterface $container Resolves the step dispatcher lazily.
+     */
+    public function __construct(
+        private readonly IL10N $l10n,
+        private readonly IURLGenerator $urls,
+        private readonly ContainerInterface $container
+    ) {
+
+    }//end __construct()
+
+    /**
+     * The step type.
+     *
+     * @return string The id.
+     *
+     * @spec openspec/changes/flow-sync-decomposition/specs/flow-iteration/spec.md
+     */
+    public function getId(): string
+    {
+        return 'openregister.iterate';
+
+    }//end getId()
+
+    /**
+     * Palette name.
+     *
+     * @return string The display name.
+     *
+     * @spec openspec/changes/flow-sync-decomposition/specs/flow-iteration/spec.md
+     */
+    public function getDisplayName(): string
+    {
+        return $this->l10n->t('Repeat until done');
+
+    }//end getDisplayName()
+
+    /**
+     * Palette description.
+     *
+     * @return string The description.
+     *
+     * @spec openspec/changes/flow-sync-decomposition/specs/flow-iteration/spec.md
+     */
+    public function getDescription(): string
+    {
+        return $this->l10n->t('Run a chain of steps once per batch, until the source runs out.');
+
+    }//end getDescription()
+
+    /**
+     * Palette icon.
+     *
+     * @return string The icon URL.
+     *
+     * @spec openspec/changes/flow-sync-decomposition/specs/flow-iteration/spec.md
+     */
+    public function getIcon(): string
+    {
+        return $this->urls->imagePath('core', 'actions/history.svg');
+
+    }//end getIcon()
+
+    /**
+     * Iteration grants no privilege of its own; the steps inside are gated.
+     *
+     * @param int $scope The scope constant.
+     *
+     * @return boolean Whether it is available.
+     *
+     * @spec openspec/changes/flow-sync-decomposition/specs/flow-iteration/spec.md
+     */
+    public function isAvailableForScope(int $scope): bool
+    {
+        return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
+
+    }//end isAvailableForScope()
+
+    /**
+     * The config vocabulary of an iterate step.
+     *
+     * @return array<int, string> The accepted config keys.
+     *
+     * @spec openspec/changes/flow-sync-decomposition/specs/flow-iteration/spec.md
+     */
+    public function configKeys(): array
+    {
+        return ['source', 'body', 'maxIterations', 'onLimit'];
+
+    }//end configKeys()
+
+    /**
+     * Refuse a loop that cannot converge or has nothing to repeat.
+     *
+     * Validated at SAVE time on purpose. A loop that cannot terminate is the one
+     * authoring mistake whose cost is paid in side effects — by the time a
+     * transition ceiling notices, the body has already written whatever it
+     * writes, however many times it managed.
+     *
+     * @param array $config The step configuration.
+     *
+     * @return void
+     *
+     * @throws UnexpectedValueException When the loop is unusable.
+     *
+     * @spec openspec/changes/flow-sync-decomposition/specs/flow-iteration/spec.md
+     */
+    public function validateConfig(array $config): void
+    {
+        $source = ($config['source'] ?? null);
+        if (is_array($source) === false || trim((string) ($source['type'] ?? '')) === '') {
+            throw new UnexpectedValueException(
+                $this->l10n->t('A repeat step needs a source that produces each batch.')
+            );
+        }
+
+        $body = ($config['body'] ?? null);
+        if (is_array($body) === false || $body === []) {
+            throw new UnexpectedValueException(
+                $this->l10n->t('A repeat step needs at least one step to repeat.')
+            );
+        }
+
+        foreach ($body as $index => $step) {
+            if (is_array($step) === false || trim((string) ($step['type'] ?? '')) === '') {
+                throw new UnexpectedValueException(
+                    $this->l10n->t('Step %s inside the repeat has no type.', [(string) $index])
+                );
+            }
+        }
+
+        $max = ($config['maxIterations'] ?? self::DEFAULT_MAX_ITERATIONS);
+        if (is_numeric($max) === false || (int) $max < 1) {
+            throw new UnexpectedValueException(
+                $this->l10n->t('A repeat step needs a positive iteration limit.')
+            );
+        }
+
+        $onLimit = (string) ($config['onLimit'] ?? self::ON_LIMIT_FAIL);
+        if (in_array($onLimit, [self::ON_LIMIT_FAIL, self::ON_LIMIT_STOP], true) === false) {
+            throw new UnexpectedValueException(
+                $this->l10n->t('A repeat step must either fail or stop when it hits its limit.')
+            );
+        }
+
+    }//end validateConfig()
+
+    /**
+     * Run the body once per batch, until the source runs dry.
+     *
+     * Items produced by each pass are ACCUMULATED and returned together, so the
+     * step downstream of a paginating loop sees every record rather than only
+     * the final page. That is what an author expects from "repeat until done",
+     * and getting it wrong would silently discard all but the last batch.
+     *
+     * @param array $items   The input items, passed to the first source call.
+     * @param array $config  The step configuration.
+     * @param array $context Run-level metadata.
+     *
+     * @return array Every item produced across all iterations.
+     *
+     * @throws RuntimeException When the loop overruns its declared limit.
+     *
+     * @spec openspec/changes/flow-sync-decomposition/specs/flow-iteration/spec.md
+     */
+    public function execute(array $items, array $config, array $context): array
+    {
+        $dispatcher = $this->container->get(FlowStepDispatcher::class);
+        $source     = (array) $config['source'];
+        $body       = (array) $config['body'];
+        $max        = (int) ($config['maxIterations'] ?? self::DEFAULT_MAX_ITERATIONS);
+        $onLimit    = (string) ($config['onLimit'] ?? self::ON_LIMIT_FAIL);
+
+        $gathered = [];
+        $seed     = $items;
+
+        for ($index = 0; $index < $max; $index++) {
+            $scoped              = $context;
+            $scoped['iteration'] = [
+                'index' => $index,
+                'first' => ($index === 0),
+            ];
+
+            $batch = $dispatcher->dispatch(step: $source, items: $seed, context: $scoped);
+
+            // The one termination rule. A source with nothing left returns
+            // nothing, which is exactly what a page past the end looks like —
+            // so pagination needs no second concept to express "done".
+            if (empty($batch) === true) {
+                return $gathered;
+            }
+
+            foreach ($body as $step) {
+                $batch = $dispatcher->dispatch(step: $step, items: $batch, context: $scoped);
+            }
+
+            $gathered = array_merge($gathered, $batch);
+
+            // Later passes start from nothing: the source is paging, not
+            // re-filtering whatever the previous pass produced.
+            $seed = [];
+        }//end for
+
+        if ($onLimit === self::ON_LIMIT_STOP) {
+            return $gathered;
+        }
+
+        throw new RuntimeException(
+            sprintf(
+                'Repeat step did not finish within %d iterations. Its source is still producing, '
+                .'so either the limit is too low or the source never runs out.',
+                $max
+            )
+        );
+
+    }//end execute()
+}//end class

--- a/lib/Service/Flow/Nodes/IterateNode.php
+++ b/lib/Service/Flow/Nodes/IterateNode.php
@@ -195,14 +195,46 @@ class IterateNode implements IFlowNode, IFlowNodeConfigKeys
      */
     public function validateConfig(array $config): void
     {
-        $source = ($config['source'] ?? null);
+        $this->assertSource(source: ($config['source'] ?? null));
+        $this->assertBody(body: ($config['body'] ?? null));
+        $this->assertBounds(config: $config);
+
+    }//end validateConfig()
+
+    /**
+     * A loop needs something that produces batches.
+     *
+     * @param mixed $source The declared source step.
+     *
+     * @return void
+     *
+     * @throws UnexpectedValueException When the source is missing or typeless.
+     *
+     * @spec openspec/changes/flow-sync-decomposition/specs/flow-iteration/spec.md
+     */
+    private function assertSource($source): void
+    {
         if (is_array($source) === false || trim((string) ($source['type'] ?? '')) === '') {
             throw new UnexpectedValueException(
                 $this->l10n->t('A repeat step needs a source that produces each batch.')
             );
         }
 
-        $body = ($config['body'] ?? null);
+    }//end assertSource()
+
+    /**
+     * A loop needs something to repeat, and every step in it needs a type.
+     *
+     * @param mixed $body The declared body chain.
+     *
+     * @return void
+     *
+     * @throws UnexpectedValueException When the body is empty or malformed.
+     *
+     * @spec openspec/changes/flow-sync-decomposition/specs/flow-iteration/spec.md
+     */
+    private function assertBody($body): void
+    {
         if (is_array($body) === false || $body === []) {
             throw new UnexpectedValueException(
                 $this->l10n->t('A repeat step needs at least one step to repeat.')
@@ -217,6 +249,21 @@ class IterateNode implements IFlowNode, IFlowNodeConfigKeys
             }
         }
 
+    }//end assertBody()
+
+    /**
+     * The limit must be positive, and the overrun behaviour must be one we have.
+     *
+     * @param array $config The step configuration.
+     *
+     * @return void
+     *
+     * @throws UnexpectedValueException When the bound is unusable.
+     *
+     * @spec openspec/changes/flow-sync-decomposition/specs/flow-iteration/spec.md
+     */
+    private function assertBounds(array $config): void
+    {
         $max = ($config['maxIterations'] ?? self::DEFAULT_MAX_ITERATIONS);
         if (is_numeric($max) === false || (int) $max < 1) {
             throw new UnexpectedValueException(
@@ -231,7 +278,7 @@ class IterateNode implements IFlowNode, IFlowNodeConfigKeys
             );
         }
 
-    }//end validateConfig()
+    }//end assertBounds()
 
     /**
      * Run the body once per batch, until the source runs dry.
@@ -263,7 +310,7 @@ class IterateNode implements IFlowNode, IFlowNodeConfigKeys
         $seed     = $items;
 
         for ($index = 0; $index < $max; $index++) {
-            $scoped              = $context;
+            $scoped = $context;
             $scoped['iteration'] = [
                 'index' => $index,
                 'first' => ($index === 0),

--- a/lib/Service/Flow/Nodes/LoopNode.php
+++ b/lib/Service/Flow/Nodes/LoopNode.php
@@ -62,7 +62,7 @@ class LoopNode implements IFlowNode, IFlowNodeConfigKeys
      */
     public function getId(): string
     {
-        return 'openregister.loop';
+        return 'openregister.batch';
 
     }//end getId()
 
@@ -73,7 +73,7 @@ class LoopNode implements IFlowNode, IFlowNodeConfigKeys
      */
     public function getDisplayName(): string
     {
-        return $this->l10n->t('Loop over items');
+        return $this->l10n->t('Batch items');
 
     }//end getDisplayName()
 

--- a/lib/Service/Flow/Nodes/MapNode.php
+++ b/lib/Service/Flow/Nodes/MapNode.php
@@ -49,7 +49,6 @@ use UnexpectedValueException;
  */
 class MapNode implements IFlowNode, IFlowNodeConfigKeys
 {
-
     /**
      * Constructor.
      *
@@ -187,6 +186,14 @@ class MapNode implements IFlowNode, IFlowNodeConfigKeys
      *
      * @throws RuntimeException When the mapping cannot be resolved or applied.
      *
+     * `FlowItems::item()` is the item constructor every node uses; going through
+     * an injected factory would give the engine two ways to build an item and no
+     * way to tell which one a node used. `$context` is part of the IFlowNode
+     * contract and unused here — a mapping transforms the item, not the run.
+     *
+     * @SuppressWarnings(PHPMD.StaticAccess)
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
      * @spec openspec/changes/flow-parity-mapping-and-webhooks/specs/flow-mapping/spec.md
      */
     public function execute(array $items, array $config, array $context): array
@@ -269,5 +276,4 @@ class MapNode implements IFlowNode, IFlowNodeConfigKeys
         );
 
     }//end resolve()
-
 }//end class

--- a/lib/Service/Flow/Nodes/MapNode.php
+++ b/lib/Service/Flow/Nodes/MapNode.php
@@ -1,0 +1,273 @@
+<?php
+
+/**
+ * Runs a stored mapping over the item list.
+ *
+ * The engine had fifteen node types and none of them transformed data, so any
+ * flow that needed to reshape a payload had to route it out to an endpoint rule
+ * and back. That is the whole reason an integration ended up expressed as an
+ * endpoint chain rather than a flow: not because endpoints fitted better, but
+ * because the flow engine could not map.
+ *
+ * The mapping is applied PER ITEM, so one authored mapping reshapes a whole
+ * collection without the author drawing a loop — the same shape as FilterNode.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow\Nodes
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-parity-mapping-and-webhooks/specs/flow-mapping/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow\Nodes;
+
+use OCA\OpenRegister\Db\MappingMapper;
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
+use OCA\OpenRegister\Service\MappingService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\WorkflowEngine\IManager;
+use RuntimeException;
+use Throwable;
+use UnexpectedValueException;
+
+/**
+ * Transforms the item list through a stored mapping.
+ */
+class MapNode implements IFlowNode, IFlowNodeConfigKeys
+{
+
+    /**
+     * Constructor.
+     *
+     * @param IL10N          $l10n     Translations.
+     * @param IURLGenerator  $urls     For the palette icon.
+     * @param MappingService $mappings Evaluates the mapping.
+     * @param MappingMapper  $mapper   Resolves the mapping by id, uuid or slug.
+     */
+    public function __construct(
+        private readonly IL10N $l10n,
+        private readonly IURLGenerator $urls,
+        private readonly MappingService $mappings,
+        private readonly MappingMapper $mapper
+    ) {
+
+    }//end __construct()
+
+    /**
+     * The step type.
+     *
+     * @return string The id.
+     *
+     * @spec openspec/changes/flow-parity-mapping-and-webhooks/specs/flow-mapping/spec.md
+     */
+    public function getId(): string
+    {
+        return 'openregister.map';
+
+    }//end getId()
+
+    /**
+     * Palette name.
+     *
+     * @return string The display name.
+     *
+     * @spec openspec/changes/flow-parity-mapping-and-webhooks/specs/flow-mapping/spec.md
+     */
+    public function getDisplayName(): string
+    {
+        return $this->l10n->t('Map');
+
+    }//end getDisplayName()
+
+    /**
+     * Palette description.
+     *
+     * @return string The description.
+     *
+     * @spec openspec/changes/flow-parity-mapping-and-webhooks/specs/flow-mapping/spec.md
+     */
+    public function getDescription(): string
+    {
+        return $this->l10n->t('Reshape each item through a stored mapping.');
+
+    }//end getDescription()
+
+    /**
+     * Palette icon.
+     *
+     * @return string The icon URL.
+     *
+     * @spec openspec/changes/flow-parity-mapping-and-webhooks/specs/flow-mapping/spec.md
+     */
+    public function getIcon(): string
+    {
+        return $this->urls->imagePath('core', 'actions/rename.svg');
+
+    }//end getIcon()
+
+    /**
+     * Mapping transforms data in memory and grants no privilege of its own.
+     *
+     * @param int $scope The scope constant.
+     *
+     * @return boolean Whether it is available.
+     *
+     * @spec openspec/changes/flow-parity-mapping-and-webhooks/specs/flow-mapping/spec.md
+     */
+    public function isAvailableForScope(int $scope): bool
+    {
+        return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
+
+    }//end isAvailableForScope()
+
+    /**
+     * The config vocabulary of a map step.
+     *
+     * @return array<int, string> The accepted config keys.
+     *
+     * @spec openspec/changes/flow-parity-mapping-and-webhooks/specs/flow-mapping/spec.md
+     */
+    public function configKeys(): array
+    {
+        return ['mapping'];
+
+    }//end configKeys()
+
+    /**
+     * Reject a map step that names no mapping.
+     *
+     * A map with no mapping would pass every item through untouched — a step
+     * that does nothing while looking like it does something, which is the
+     * failure this whole programme exists to remove.
+     *
+     * @param array $config The step configuration.
+     *
+     * @return void
+     *
+     * @throws UnexpectedValueException When no mapping is named.
+     *
+     * @spec openspec/changes/flow-parity-mapping-and-webhooks/specs/flow-mapping/spec.md
+     */
+    public function validateConfig(array $config): void
+    {
+        $mapping = trim((string) ($config['mapping'] ?? ''));
+        if ($mapping === '') {
+            throw new UnexpectedValueException($this->l10n->t('A map step needs a mapping.'));
+        }
+
+    }//end validateConfig()
+
+    /**
+     * Reshape every item through the mapping.
+     *
+     * An unresolvable mapping THROWS rather than returning the items unchanged.
+     * Passing them through would record the step as completed while nothing was
+     * transformed, and a downstream step reading the un-mapped shape would fail
+     * somewhere else entirely — the error would surface far from its cause.
+     *
+     * @param array $items   The input items.
+     * @param array $config  The step configuration.
+     * @param array $context Run-level metadata.
+     *
+     * @return array The transformed items.
+     *
+     * @throws RuntimeException When the mapping cannot be resolved or applied.
+     *
+     * @spec openspec/changes/flow-parity-mapping-and-webhooks/specs/flow-mapping/spec.md
+     */
+    public function execute(array $items, array $config, array $context): array
+    {
+        $reference = trim((string) ($config['mapping'] ?? ''));
+        $mapping   = $this->resolve(reference: $reference);
+
+        $mapped = [];
+        foreach ($items as $index => $item) {
+            $input = (array) ($item[FlowItems::JSON] ?? []);
+
+            try {
+                $result = $this->mappings->executeMapping(mapping: $mapping, input: $input);
+            } catch (Throwable $e) {
+                throw new RuntimeException(
+                    sprintf(
+                        'Mapping "%s" failed on item %d: %s',
+                        $reference,
+                        $index,
+                        $e->getMessage()
+                    ),
+                    0,
+                    $e
+                );
+            }
+
+            $mapped[] = FlowItems::item(
+                json: $result,
+                binary: (array) ($item[FlowItems::BINARY] ?? []),
+                fromItemIndex: $index
+            );
+        }//end foreach
+
+        return $mapped;
+
+    }//end execute()
+
+    /**
+     * Resolve a mapping by numeric id, uuid, slug or reference.
+     *
+     * Authors name mappings by whichever identifier they have in front of them,
+     * and a flow definition is portable between instances where the numeric id
+     * differs — so slug and reference must resolve too, or an exported flow
+     * breaks on import while looking correct.
+     *
+     * @param string $reference The mapping identifier.
+     *
+     * @return \OCA\OpenRegister\Db\Mapping The resolved mapping.
+     *
+     * @throws RuntimeException When no mapping matches.
+     *
+     * @spec openspec/changes/flow-parity-mapping-and-webhooks/specs/flow-mapping/spec.md
+     */
+    private function resolve(string $reference)
+    {
+        if (ctype_digit($reference) === true) {
+            try {
+                return $this->mapper->find((int) $reference);
+            } catch (DoesNotExistException $e) {
+                throw new RuntimeException(
+                    sprintf('No mapping with id "%s".', $reference),
+                    0,
+                    $e
+                );
+            }
+        }
+
+        try {
+            $byRef = $this->mapper->findByRef($reference);
+        } catch (Throwable $e) {
+            $byRef = [];
+        }
+
+        if (empty($byRef) === false) {
+            return $byRef[0];
+        }
+
+        throw new RuntimeException(
+            sprintf('No mapping matches "%s" by id, uuid, slug or reference.', $reference)
+        );
+
+    }//end resolve()
+
+}//end class

--- a/lib/Service/MappingService.php
+++ b/lib/Service/MappingService.php
@@ -32,6 +32,7 @@ use OCA\OpenRegister\Db\MappingMapper;
 use Throwable;
 use OCA\OpenRegister\Twig\MappingExtension;
 use OCA\OpenRegister\Twig\MappingRuntimeLoader;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ICacheFactory;
 use OCP\ICache;
 use Psr\Log\LoggerInterface;
@@ -107,7 +108,8 @@ class MappingService
     public function __construct(
         private readonly MappingMapper $mappingMapper,
         ICacheFactory $cacheFactory,
-        private readonly LoggerInterface $logger
+        private readonly LoggerInterface $logger,
+        private readonly ?IEventDispatcher $events=null
     ) {
         $loader = new ArrayLoader([]);
         // Autoescape disabled — mappings transform data (not HTML), and the
@@ -115,6 +117,17 @@ class MappingService
         // autoescaping injects into every output expression.
         $this->twig = new Environment($loader, ['autoescape' => false]);
         $this->twig->addExtension(new MappingExtension());
+
+        // Functions only another app can provide — `callSource` needs
+        // OpenConnector's CallService, the contract lookups its contract
+        // service. Collected BEFORE the sandbox policy is built, because a
+        // contributed function that is not allowlisted fails as "unknown
+        // function" inside a mapping, nowhere near its registration.
+        $contributed = $this->contributedFunctions();
+        foreach ($contributed['functions'] as $function) {
+            $this->twig->addFunction($function);
+        }
+
         $this->twig->addRuntimeLoader(
             new MappingRuntimeLoader(
                 mappingService: $this,
@@ -164,13 +177,32 @@ class MappingService
             ],
             allowedMethods: [],
             allowedProperties: [],
-            allowedFunctions: [
-                'max',
-                'min',
-                'range',
-                'executeMapping',
-                'generateUuid',
-            ]
+            allowedFunctions: array_merge(
+                [
+                    'max',
+                    'min',
+                    'range',
+                    'executeMapping',
+                    'generateUuid',
+                    // Ported from OpenConnector's copy so its mappings keep
+                    // working once that copy is retired. `json_decode` is the
+                    // name OpenConnector's templates use; OpenRegister's own
+                    // runtime spells it `jsonDecode`. Both are exposed rather
+                    // than renaming either, because a mapping is authored data
+                    // — renaming a function silently breaks stored templates.
+                    'json_decode',
+                    'jsonDecode',
+                    'createSlug',
+                    'getFileContents',
+                    'getFiles',
+                    'b64enc',
+                    'b64dec',
+                    'zgwEnum',
+                    'zgwEnumReverse',
+                    'zgwExtractUuid',
+                ],
+                $contributed['names']
+            )
         );
         $this->twig->addExtension(new SandboxExtension($policy, sandboxed: true));
 
@@ -718,4 +750,44 @@ class MappingService
     {
         return $this->mappingMapper->findAll();
     }//end getMappings()
+
+    /**
+     * Collect Twig functions contributed by other apps.
+     *
+     * Best-effort by design. A contributing app that is absent, or a listener
+     * that throws, must not stop mappings from evaluating at all — the engine
+     * belongs to OpenRegister and has to work on an instance where no other app
+     * is installed. What it must NOT do is pretend a contributed function
+     * exists: an unregistered function fails loudly inside the mapping, which is
+     * the correct place for that failure to surface.
+     *
+     * @return array{functions: array<int, \Twig\TwigFunction>, names: array<int, string>}
+     *         The contributed functions and the names to allowlist.
+     *
+     * @spec openspec/changes/flow-parity-mapping-and-webhooks/specs/flow-mapping/spec.md
+     */
+    private function contributedFunctions(): array
+    {
+        if ($this->events === null) {
+            return ['functions' => [], 'names' => []];
+        }
+
+        try {
+            $event = new RegisterMappingFunctionsEvent();
+            $this->events->dispatchTyped($event);
+
+            return [
+                'functions' => $event->getFunctions(),
+                'names'     => $event->getAllowedNames(),
+            ];
+        } catch (Throwable $e) {
+            $this->logger->warning(
+                message: '[MappingService] Could not collect contributed Twig functions: '.$e->getMessage(),
+                context: ['file' => __FILE__, 'line' => __LINE__]
+            );
+
+            return ['functions' => [], 'names' => []];
+        }//end try
+
+    }//end contributedFunctions()
 }//end class

--- a/lib/Service/MappingService.php
+++ b/lib/Service/MappingService.php
@@ -101,9 +101,12 @@ class MappingService
     /**
      * MappingService constructor
      *
-     * @param MappingMapper   $mappingMapper The mapping mapper for database operations
-     * @param ICacheFactory   $cacheFactory  Cache factory for distributed caching
-     * @param LoggerInterface $logger        Logger for cache diagnostics
+     * @param MappingMapper         $mappingMapper The mapping mapper for database operations
+     * @param ICacheFactory         $cacheFactory  Cache factory for distributed caching
+     * @param LoggerInterface       $logger        Logger for cache diagnostics
+     * @param IEventDispatcher|null $events        Collects Twig functions contributed by other apps.
+     *                                             Nullable so the service still constructs where no
+     *                                             dispatcher is available (tests, early boot).
      */
     public function __construct(
         private readonly MappingMapper $mappingMapper,

--- a/lib/Service/RegisterMappingFunctionsEvent.php
+++ b/lib/Service/RegisterMappingFunctionsEvent.php
@@ -62,7 +62,6 @@ class RegisterMappingFunctionsEvent extends Event
      */
     private array $allowedNames = [];
 
-
     /**
      * Contribute one Twig function, and allowlist it for the sandbox.
      *
@@ -79,7 +78,6 @@ class RegisterMappingFunctionsEvent extends Event
 
     }//end registerFunction()
 
-
     /**
      * Every contributed function.
      *
@@ -93,7 +91,6 @@ class RegisterMappingFunctionsEvent extends Event
 
     }//end getFunctions()
 
-
     /**
      * The names to add to the sandbox allowlist.
      *
@@ -106,6 +103,4 @@ class RegisterMappingFunctionsEvent extends Event
         return $this->allowedNames;
 
     }//end getAllowedNames()
-
-
 }//end class

--- a/lib/Service/RegisterMappingFunctionsEvent.php
+++ b/lib/Service/RegisterMappingFunctionsEvent.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * Lets other apps contribute Twig functions to the one mapping engine.
+ *
+ * Mapping evaluation lives in OpenRegister, but some mapping functions can only
+ * be provided by the app that owns the capability: `callSource` needs
+ * OpenConnector's CallService, the synchronisation-contract lookups need its
+ * contract service. Importing those into OpenRegister would invert the fleet's
+ * dependency direction — OpenRegister is the foundation and must load on an
+ * instance where OpenConnector is absent.
+ *
+ * So the engine stays here and the app-specific functions are contributed, the
+ * same shape as `RegisterFlowNodesEvent` for flow nodes.
+ *
+ * A contributed function MUST also be allowlisted, because the mapping Twig
+ * environment is SANDBOXED (SSTI hardening — mapping templates are user-authored
+ * and compiled at runtime). `registerFunction()` does both in one call so a
+ * contributor cannot register a function that the sandbox then silently blocks:
+ * that failure surfaces as "unknown function" inside a mapping, far from the
+ * registration site.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-parity-mapping-and-webhooks/specs/flow-mapping/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+use OCP\EventDispatcher\Event;
+use Twig\TwigFunction;
+
+/**
+ * Collects Twig functions contributed by other apps.
+ */
+class RegisterMappingFunctionsEvent extends Event
+{
+
+    /**
+     * The contributed functions.
+     *
+     * @var array<int, TwigFunction>
+     */
+    private array $functions = [];
+
+    /**
+     * The names those functions are allowed to be called by, for the sandbox.
+     *
+     * @var array<int, string>
+     */
+    private array $allowedNames = [];
+
+
+    /**
+     * Contribute one Twig function, and allowlist it for the sandbox.
+     *
+     * @param TwigFunction $function The function to expose to mapping templates.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/flow-parity-mapping-and-webhooks/specs/flow-mapping/spec.md
+     */
+    public function registerFunction(TwigFunction $function): void
+    {
+        $this->functions[]    = $function;
+        $this->allowedNames[] = $function->getName();
+
+    }//end registerFunction()
+
+
+    /**
+     * Every contributed function.
+     *
+     * @return array<int, TwigFunction> The functions.
+     *
+     * @spec openspec/changes/flow-parity-mapping-and-webhooks/specs/flow-mapping/spec.md
+     */
+    public function getFunctions(): array
+    {
+        return $this->functions;
+
+    }//end getFunctions()
+
+
+    /**
+     * The names to add to the sandbox allowlist.
+     *
+     * @return array<int, string> The allowed function names.
+     *
+     * @spec openspec/changes/flow-parity-mapping-and-webhooks/specs/flow-mapping/spec.md
+     */
+    public function getAllowedNames(): array
+    {
+        return $this->allowedNames;
+
+    }//end getAllowedNames()
+
+
+}//end class

--- a/lib/Twig/MappingExtension.php
+++ b/lib/Twig/MappingExtension.php
@@ -71,6 +71,17 @@ class MappingExtension extends AbstractExtension
         return [
             new TwigFunction(name: 'executeMapping', callable: [MappingRuntime::class, 'executeMapping']),
             new TwigFunction(name: 'generateUuid', callable: [MappingRuntime::class, 'generateUuid']),
+            // Ported from OpenConnector's copy so mappings authored there keep
+            // evaluating once that copy is retired. `json_decode` is the name
+            // those templates use; `jsonDecode` is OpenRegister's own spelling.
+            // BOTH are registered rather than renaming either — a mapping is
+            // authored data, and renaming a function it calls breaks it
+            // silently at evaluation time.
+            new TwigFunction(name: 'json_decode', callable: [MappingRuntime::class, 'json_decode']),
+            new TwigFunction(name: 'jsonDecode', callable: [MappingRuntime::class, 'jsonDecode']),
+            new TwigFunction(name: 'createSlug', callable: [MappingRuntime::class, 'createSlug']),
+            new TwigFunction(name: 'b64enc', callable: [MappingRuntime::class, 'b64enc']),
+            new TwigFunction(name: 'b64dec', callable: [MappingRuntime::class, 'b64dec']),
         ];
     }//end getFunctions()
 }//end class

--- a/lib/Twig/MappingRuntime.php
+++ b/lib/Twig/MappingRuntime.php
@@ -75,6 +75,56 @@ class MappingRuntime implements RuntimeExtensionInterface
      *
      * @spec openspec/specs/object-lifecycle/spec.md
      */
+    public function json_decode(string $input): array
+    {
+        return (array) json_decode(json: $input, associative: true);
+
+    }//end json_decode()
+
+    /**
+     * URL-friendly slug from arbitrary text.
+     *
+     * Ported verbatim from OpenConnector's runtime when mapping consolidated
+     * into OpenRegister. Byte-for-byte behaviour matters here: slugs authored by
+     * existing mappings are persisted as object identifiers, so any change to
+     * the transformation silently orphans previously-written objects.
+     *
+     * @param string $text The text to slugify.
+     *
+     * @return string The slug.
+     *
+     * @spec openspec/changes/flow-parity-mapping-and-webhooks/specs/flow-mapping/spec.md
+     */
+    public function createSlug(string $text): string
+    {
+        // Convert to lowercase.
+        $slug = strtolower($text);
+
+        // Replace spaces and underscores with hyphens.
+        $slug = str_replace([' ', '_'], '-', $slug);
+
+        // Remove all characters that are not a-z, 0-9, or hyphen.
+        $slug = preg_replace('/[^a-z0-9\-]/', '', $slug);
+
+        // Replace multiple consecutive hyphens with single hyphen.
+        $slug = preg_replace('/-+/', '-', $slug);
+
+        // Trim hyphens from start and end.
+        $slug = trim($slug, '-');
+
+        return $slug;
+
+    }//end createSlug()
+
+    /**
+     * Encodes a string to base64.
+     *
+     * @param string $input The unencoded input.
+     *
+     * @return string The encoded output.
+     *
+     * @spec openspec/specs/object-lifecycle/spec.md
+     */
     public function b64enc(string $input): string
     {
         return base64_encode(string: $input);

--- a/lib/Twig/MappingRuntime.php
+++ b/lib/Twig/MappingRuntime.php
@@ -46,9 +46,15 @@ use Twig\Extension\RuntimeExtensionInterface;
  * @category Twig
  * @package  OCA\OpenRegister\Twig
  *
+ * A Twig runtime's public methods ARE the vocabulary mapping templates may call,
+ * so their count is the size of that vocabulary rather than a design choice.
+ * Splitting it would mean two runtimes and a rule about which functions live
+ * where — a distinction template authors would have to know and could not see.
+ *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
  * @SuppressWarnings(PHPMD.StaticAccess)
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  */
 class MappingRuntime implements RuntimeExtensionInterface
 {
@@ -67,13 +73,21 @@ class MappingRuntime implements RuntimeExtensionInterface
     }//end __construct()
 
     /**
-     * Encodes a string to base64.
+     * Decode a JSON string, under the name OpenConnector's templates call.
      *
-     * @param string $input The unencoded input.
+     * The snake_case name is deliberate and cannot be corrected: it is the
+     * identifier stored mapping templates already contain. `jsonDecode` below is
+     * the same function under OpenRegister's own spelling — both exist because a
+     * mapping is authored data, so renaming what it calls breaks it at
+     * evaluation with nothing at author time to warn you.
      *
-     * @return string The encoded output.
+     * @param string $input The JSON to decode.
      *
-     * @spec openspec/specs/object-lifecycle/spec.md
+     * @return array The decoded structure.
+     *
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
+     *
+     * @spec openspec/changes/flow-parity-mapping-and-webhooks/specs/flow-mapping/spec.md
      */
     public function json_decode(string $input): array
     {

--- a/openspec/changes/flow-parity-mapping-and-webhooks/proposal.md
+++ b/openspec/changes/flow-parity-mapping-and-webhooks/proposal.md
@@ -70,10 +70,16 @@ answer.
 
 ### 3. The rule pipeline has no node equivalent
 
-`EndpointService::processRules()` dispatches **18 rule types**. The flow engine
-has **15 nodes**, contributed by OpenRegister (13) and hermiq (2).
-**OpenConnector contributes none** — `openconnector.jti` and
-`openconnector.ratelimit` are distributed cache keys, not nodes.
+`EndpointService::processRules()` dispatches **23 rule types** (counted from the
+`match ($ruleType)` block, not from documentation). The live node catalogue
+returns **18 nodes**: OpenRegister 14, OpenConnector 2, hermiq 2.
+
+Two earlier claims here were wrong and are corrected. OpenConnector **does**
+contribute nodes — `openconnector.source-call` and
+`openconnector.synchronization-run` — so `synchronization` already has one. And
+`mapping` now has `openregister.map`. Both were read off the running
+`/api/flow/node-catalog`, which is the only source that reflects what the engine
+will actually resolve; the earlier table was assembled by reading code.
 
 Mapping the two vocabularies:
 
@@ -82,10 +88,11 @@ Mapping the two vocabularies:
 | `save_object` | `openregister.object-write` | — |
 | `override` | `openregister.set-fields` | partial |
 | `error` | `openregister.stop` | partial (stop carries a message; rule returns a shaped response) |
-| `synchronization` | — | **no node** |
-| `mapping` | — | **no node** (see 1) |
-| `authentication` | — | **no node** (see 2) |
-| `webhook_signature` | — | **no node** (see 2) |
+| `mapping` | `openregister.map` | — (shipped) |
+| `synchronization` | `openconnector.synchronization-run` | — (already existed) |
+| `flow` | `openregister.sub-flow` | — |
+| `authentication` | — | covered by the webhook-delivery spec |
+| `webhook_signature` | — | covered by the webhook-delivery spec |
 | `javascript` | — | **no node** |
 | `extend_input` | — | **no node** |
 | `extend_external_input` | — | **no node** |
@@ -95,9 +102,14 @@ Mapping the two vocabularies:
 | `filepart_upload` | — | **no node** |
 | `locking` | — | **no node** |
 | `audit_trail` | — | **no node** |
+| `approval` | — | **no node** |
+| `composite_fanout` | — | **no node** |
+| `avg_bsn_policy` | — | **no node** |
+| `referentienummer` | — | **no node** |
+| `selfurl_hal` | — | **no node** |
 | `custom` | — | escape hatch, not a gap |
 
-Thirteen capabilities exist only inside the endpoint pipeline. As long as that
+Thirteen capabilities still exist only inside the endpoint pipeline. As long as that
 is true, "OpenRegister owns the one flow engine" is only half true — an
 integration that needs any of them must be built as an endpoint rule chain
 instead, which is a second orchestration model with its own storage, its own

--- a/openspec/changes/flow-sync-decomposition/design.md
+++ b/openspec/changes/flow-sync-decomposition/design.md
@@ -1,0 +1,103 @@
+# Iteration in the flow engine
+
+## The problem
+
+A paginating fetch loops an unknown number of times, and each iteration must run
+a *chain* of steps before deciding whether to continue. The same shape covers
+every while/for loop an author might draw.
+
+Three ways to model it, and the choice drives both the engine and the builder.
+
+## Option A — cycle in the graph (what the engine does today)
+
+Draw an edge from the last step of the body back to the paginating step. The
+Petri net executes this correctly; `MAX_TRANSITIONS` stops a runaway.
+
+**Rejected as the authoring model.** It executes, but:
+
+- A back-edge looks identical to a forward edge. The single most important fact
+  about the graph — that a region repeats — is carried by edge *direction*, which
+  is exactly what a person scanning a diagram does not reliably read.
+- Loop membership is implicit. Nothing says which steps are "inside"; you infer
+  it by tracing the cycle. A step added near the join silently joins or leaves
+  the loop depending on where the edge lands.
+- The bound is global, not per-loop. `MAX_TRANSITIONS` is a whole-run ceiling, so
+  two nested loops share one budget and the error names neither.
+- It is diagnosed at runtime. "may contain an unbounded loop" arrives after the
+  run, when the side effects have already happened.
+
+## Option B — sub-flow per iteration
+
+Make the body a separate flow and call it with `openregister.sub-flow`.
+
+**Rejected.** The user's instinct here is right. It works, but it forces a
+one-loop-per-flow split that has nothing to do with how the author thinks about
+the work: a paginated harvest is *one* job. It also fragments the run history
+across flows, so "what happened in this harvest" needs joining runs together —
+reintroducing the ambiguity the step table removed. And a sub-flow boundary is a
+real boundary: context, items and token do not flow across it for free.
+
+## Option C — declared loop region (CHOSEN)
+
+A loop is a **node that owns a body**, not a cycle and not a separate flow.
+
+```
+openregister.iterate
+  ├─ source:  the step that produces the next batch (and says whether more exist)
+  ├─ body:    an ordered chain of step ids, run once per batch
+  └─ limits:  maxIterations, and what to do when hit (fail | stop | continue)
+```
+
+The engine runs `source`, and while it reports more, runs `body` over each batch.
+Body membership is **declared**, not inferred.
+
+### Why this one
+
+- **Membership is data.** The builder can draw the body as a container — a box
+  with the steps inside it — because it knows exactly which steps are in it. No
+  edge-direction reading.
+- **Bounds are per-loop and authored.** `maxIterations` sits on the loop that
+  owns it, so the error can name which loop failed to converge, and two loops in
+  one flow do not compete for a shared budget.
+- **Non-convergence is a validation error, not a runtime surprise.** A loop
+  whose source declares no termination signal is refusable at save time.
+- **Iteration state has a home.** The loop owns a per-iteration scope (cursor,
+  index, page), distinct from `flow-state`, which stays per-run.
+- **The step table gains iteration.** Each body step records its iteration index,
+  so "page 7 failed" is a query rather than a log read.
+
+### What it costs
+
+The engine gains a nested execution scope, which is real complexity in the one
+place complexity is most dangerous. Mitigated by keeping the loop a NODE — it
+executes its body through the same dispatcher as everything else, so there is
+still exactly one thing that runs a step.
+
+## Visualisation
+
+The container is the point. A loop should read as a region, not a line:
+
+```
+┌─ iterate: GitHub search pages ──────── max 50 ──┐
+│                                                 │
+│  [fetch page] → [map] → [write objects]         │
+│                                                 │
+└────────────────── while: has next page ─────────┘
+```
+
+- The **header** carries the source step and the bound.
+- The **footer** carries the continue condition, in words.
+- Steps inside are laid out normally; the container is a background region.
+- The iteration counter is a live badge during a run, and the run history
+  colours the container by its worst body step.
+
+Nested loops nest as boxes. A back-edge cannot express nesting legibly at all,
+which is the second reason Option A loses.
+
+## Migration
+
+`openregister.loop` keeps its behaviour and is **renamed in the palette** to
+"Batch items", because it batches and does not loop. The id stays
+`openregister.loop` — it is referenced by stored flow definitions, and renaming
+an id breaks authored data. This is the same reasoning that kept both
+`json_decode` and `jsonDecode` registered when mapping consolidated.

--- a/openspec/changes/flow-sync-decomposition/design.md
+++ b/openspec/changes/flow-sync-decomposition/design.md
@@ -96,8 +96,50 @@ which is the second reason Option A loses.
 
 ## Migration
 
-`openregister.loop` keeps its behaviour and is **renamed in the palette** to
-"Batch items", because it batches and does not loop. The id stays
-`openregister.loop` — it is referenced by stored flow definitions, and renaming
-an id breaks authored data. This is the same reasoning that kept both
-`json_decode` and `jsonDecode` registered when mapping consolidated.
+`openregister.loop` batches; it does not loop. Both its palette name AND its id
+change — to "Batch items" and `openregister.batch`.
+
+Keeping the old id was the first instinct, on the grounds that stored flow
+definitions reference it. That is the wrong trade here. A node whose id says
+`loop` and whose behaviour is `batch`, sitting next to a real `iterate`, is a
+trap that gets re-set every time someone new reads the catalogue — and unlike a
+Twig function name, a node id is not authored data typed by a human into a
+template. It is a reference the system writes and the system can rewrite.
+
+So the id is corrected and stored flows are **migrated**:
+
+- A migration rewrites `openregister.loop` → `openregister.batch` in the `nodes`
+  and `edges` of every row in `oc_openregister_flows`.
+- The registry keeps `openregister.loop` as a resolvable ALIAS for one release,
+  so a flow exported before the migration and imported after it still resolves
+  rather than failing with "no app provides the flow node type".
+- The alias is logged when used, so the tail of un-migrated definitions is
+  visible rather than assumed empty.
+
+This is the opposite call to `json_decode`/`jsonDecode`, and deliberately: a Twig
+function name lives inside a mapping template that a person wrote and we cannot
+rewrite safely, whereas a node id lives in a JSON structure we own end to end.
+
+## Credentials belong on the Source, not on a second node
+
+An earlier draft added `openregister.broker-call` alongside
+`openconnector.source-call` — one node for calls with an injectable credential,
+another for calls with a brokered one.
+
+**Rejected.** That exposes an implementation detail as a modelling choice. From
+an author's chair both nodes do the same thing — call a configured source — and
+the only way to pick correctly is to know which credential SHAPE the source
+carries, which is precisely the distinction the broker exists to hide. Getting it
+wrong yields "resolveInjectable returned null", which reads as a permission
+problem and is not one.
+
+So there is ONE node, `openconnector.source-call`, and a Source may reference a
+doriath-held credential in its configuration. The Source resolves it:
+
+- injectable credential → resolve and attach it to the outgoing request, as now
+- host-locked proxy → hand the request to OpenRegister's broker, which performs
+  it server-side and returns the response bytes
+
+The author configures a credential on the Source and calls it. That OpenRegister
+brokers the host-locked case is under the waterline, where it belongs — and it
+keeps the property that matters: the token is never handed to the flow.

--- a/openspec/changes/flow-sync-decomposition/proposal.md
+++ b/openspec/changes/flow-sync-decomposition/proposal.md
@@ -1,0 +1,111 @@
+---
+kind: code
+---
+
+## Why
+
+`openconnector.synchronization-run` is one node that runs an entire
+synchronisation. It is the last monolith in the flow engine: everything else in
+the catalogue is a step, and this is a program.
+
+That has three consequences.
+
+**You cannot see what a sync does.** The run history records one step,
+`synchronization-run / completed`. Which page failed, which record was skipped as
+unchanged, which contract was written — none of it is a step, so none of it is
+queryable. The whole point of the step table was to stop "it ran" being the only
+thing we know.
+
+**You cannot change part of it.** Wanting to map differently, or write to a
+second register, or filter before persisting means editing PHP, because the four
+things inside the monolith are not addressable:
+
+| inside the monolith | node today |
+|---|---|
+| paginate the source | — |
+| detect change by hash | — |
+| resolve the synchronisation contract (origin ↔ target id) | — |
+| write to target + update the contract | — |
+
+**And the contract gap makes flow-built syncs unsafe.** A flow can already do
+fetch → map → write with existing nodes. What it cannot do is know that it has
+seen a record before, so a second run creates duplicates rather than updating.
+Idempotency is the reason `synchronization-run` still has to be used whole.
+
+### The iteration problem underneath it
+
+Pagination is not just another step. It loops an unknown number of times, and
+each iteration must drive a *chain* of steps — fetch page, map it, write it —
+before deciding whether to go round again.
+
+The engine can already express this: it is a Petri net, so a cycle in the graph
+is a loop, bounded by `MAX_TRANSITIONS`. What is missing is not execution but
+**authoring and legibility**:
+
+- `openregister.loop` is misleadingly named. It does not loop; it splits items
+  into fixed-size batches. A user reaching for iteration picks it and gets
+  something else.
+- A loop drawn as a back-edge is hard to read and easy to draw wrong. An
+  unbounded cycle is only caught at runtime, by the transition ceiling, and
+  reported as "may contain an unbounded loop" — after the run.
+- Nothing carries loop state. A paginating node needs somewhere to keep the
+  cursor across iterations, and `openregister.flow-state` is per-run, not
+  per-iteration.
+
+This affects every while/for shape, not only pagination.
+
+## What Changes
+
+- **DECOMPOSE** `synchronization-run` into contributed nodes:
+  `openconnector.source-paginate`, `openconnector.change-detect`,
+  `openconnector.contract-resolve`, `openconnector.contract-write`. The
+  monolith stays, deprecated, until the decomposed set is proven — deleting it
+  first would strand every existing sync.
+- **ADD** a first-class iteration construct rather than leaving loops as
+  hand-drawn back-edges: a node that emits a batch and a "more" signal, plus a
+  declared loop body, so the builder can DRAW the cycle as a container instead
+  of an edge that happens to point backwards.
+- **ADD** `openregister.broker-call` — an HTTP call made through OpenRegister's
+  credential broker, so a flow can use a secret it is never given.
+- **ADD** a `publiccode` schema and a worked example flow that harvests
+  publiccode.yml files from GitHub into OpenRegister objects, searchable by
+  OpenCatalogi.
+
+## The credential constraint (why publiccode is the right example)
+
+GitHub's API is rate-limited hard enough that the harvest needs a PAT. That PAT
+must not reach the flow.
+
+The fleet already has the right shape for this, and it is easy to get wrong:
+
+- **doriath** stores the secret zero-knowledge — write-without-read, RSA-4096 /
+  AES-256, not readable by the administrator.
+- **OpenRegister** brokers it. The `github` credential is a **host-locked proxy**:
+  `resolveInjectable()` returns `null` for it, and that null is a ROUTING signal
+  meaning "use `request()` instead", **not** a denial.
+- `POST /api/credentials/{id}/request` performs the call server-side. Only
+  response bytes cross the boundary.
+
+So `openconnector.source-call` is the wrong node for this: it calls a configured
+Source with credentials it can resolve. A flow that needs a host-locked
+credential needs a node that asks the broker to make the call. That is
+`openregister.broker-call`, and it is what "integrating correctly with doriath"
+means in practice — not fetching a token, but never holding one.
+
+This is why publiccode is a better first example than a toy: it exercises
+pagination, an unbounded loop with a per-iteration chain, mapping, idempotent
+writes, and brokered credentials — the whole decomposition, on a real source.
+
+## Impact
+
+Sequenced so nothing is stranded:
+
+1. The iteration construct first — pagination depends on it, and every later
+   node is easier to reason about once loops are first-class.
+2. `broker-call`, because the publiccode example cannot run without it.
+3. The publiccode schema and example flow, as the proving ground.
+4. The synchronisation nodes, with `synchronization-run` deprecated but present.
+
+`synchronization-run` is NOT deleted by this change. It is deleted when a
+decomposed flow has demonstrably replaced it for a real synchronisation,
+including the contract bookkeeping — not before.

--- a/openspec/changes/flow-sync-decomposition/proposal.md
+++ b/openspec/changes/flow-sync-decomposition/proposal.md
@@ -65,8 +65,11 @@ This affects every while/for shape, not only pagination.
   hand-drawn back-edges: a node that emits a batch and a "more" signal, plus a
   declared loop body, so the builder can DRAW the cycle as a container instead
   of an edge that happens to point backwards.
-- **ADD** `openregister.broker-call` — an HTTP call made through OpenRegister's
-  credential broker, so a flow can use a secret it is never given.
+- **EXTEND** `openconnector.source-call` so a Source may reference a
+  doriath-held credential, brokered by OpenRegister when the credential is
+  host-locked. ONE node, not two: which credential shape a source carries is
+  exactly what the broker exists to hide, so it must not become a modelling
+  choice the author has to get right.
 - **ADD** a `publiccode` schema and a worked example flow that harvests
   publiccode.yml files from GitHub into OpenRegister objects, searchable by
   OpenCatalogi.
@@ -86,11 +89,14 @@ The fleet already has the right shape for this, and it is easy to get wrong:
 - `POST /api/credentials/{id}/request` performs the call server-side. Only
   response bytes cross the boundary.
 
-So `openconnector.source-call` is the wrong node for this: it calls a configured
-Source with credentials it can resolve. A flow that needs a host-locked
-credential needs a node that asks the broker to make the call. That is
-`openregister.broker-call`, and it is what "integrating correctly with doriath"
-means in practice — not fetching a token, but never holding one.
+So the Source must be able to carry a doriath-held credential, and resolve it by
+SHAPE: injectable credentials are attached to the request as now; a host-locked
+one is handed to OpenRegister's broker, which performs the call server-side and
+returns only response bytes. The author configures a credential and calls the
+source; the brokering is under the waterline.
+
+"Integrating correctly with doriath" therefore means never fetching a token —
+not adding a second node for the case where you cannot.
 
 This is why publiccode is a better first example than a toy: it exercises
 pagination, an unbounded loop with a per-iteration chain, mapping, idempotent
@@ -102,7 +108,8 @@ Sequenced so nothing is stranded:
 
 1. The iteration construct first — pagination depends on it, and every later
    node is easier to reason about once loops are first-class.
-2. `broker-call`, because the publiccode example cannot run without it.
+2. doriath credentials on Sources, because the publiccode example cannot run
+   without a PAT.
 3. The publiccode schema and example flow, as the proving ground.
 4. The synchronisation nodes, with `synchronization-run` deprecated but present.
 

--- a/openspec/changes/flow-sync-decomposition/specs/flow-iteration/spec.md
+++ b/openspec/changes/flow-sync-decomposition/specs/flow-iteration/spec.md
@@ -1,0 +1,117 @@
+# flow-iteration
+
+## ADDED Requirements
+
+### Requirement: A loop is a declared region, not a drawn cycle
+
+The engine SHALL provide a node type `openregister.iterate` that owns a `source`
+step and an ordered `body` chain, and runs the body once per batch the source
+produces.
+
+Loop membership SHALL be declared data, not inferred from graph topology. A
+client SHALL be able to determine which steps belong to a loop without tracing
+edges, so an authoring surface can render the loop as a region rather than as an
+edge that happens to point backwards.
+
+#### Scenario: Membership is readable without tracing
+- **WHEN** a flow containing an iterate step is read
+- **THEN** the steps inside the loop are listed on the loop itself, and no edge direction has to be interpreted to know which steps repeat.
+
+#### Scenario: The body runs once per batch
+- **WHEN** a source produces three batches and the body is a single step
+- **THEN** that step runs three times, once per batch.
+
+#### Scenario: The whole body chain runs, in order
+- **WHEN** a loop body declares three steps
+- **THEN** all three run per iteration, in the declared order.
+
+### Requirement: Iteration terminates on an exhausted source
+
+A loop SHALL stop when its source produces no items. This SHALL be the only
+termination signal, so that pagination requires no separate concept — a page
+past the end is an empty batch.
+
+The source SHALL receive its iteration index, so it can request the correct page.
+
+#### Scenario: An exhausted source ends the loop
+- **WHEN** a source returns items for pages 0..2 and nothing for page 3
+- **THEN** the loop ends after page 2 and the body ran exactly three times.
+
+#### Scenario: An immediately-empty source runs the body not at all
+- **WHEN** a source returns nothing on its first call
+- **THEN** the body does not run, and the step completes with no items.
+
+#### Scenario: The source can page
+- **WHEN** a source is called across several iterations
+- **THEN** each call receives an iteration index, increasing from zero.
+
+### Requirement: Items accumulate across iterations
+
+A loop SHALL return every item produced across all its iterations, not only
+those of the final pass.
+
+Returning only the last batch would discard all earlier work while still
+reporting the step as completed — a silent loss indistinguishable from a source
+that only ever had one page.
+
+#### Scenario: Every page survives
+- **WHEN** a loop runs over three pages of one item each
+- **THEN** the step returns three items.
+
+### Requirement: A loop that cannot converge fails
+
+Every loop SHALL carry an iteration limit, defaulting to a bounded value rather
+than to unlimited. On reaching the limit with the source still producing, the run
+SHALL fail by default, naming the limit.
+
+A loop MAY declare that it stops and keeps what it gathered instead, but this
+SHALL be an explicit choice. Silently stopping SHALL NOT be the default: a
+truncated result that reports success is indistinguishable from a complete one.
+
+#### Scenario: Overrun fails by default
+- **WHEN** a source never runs out and the loop declares a limit of five
+- **THEN** the run fails with a message naming the limit, rather than ending quietly.
+
+#### Scenario: Stopping is available but must be chosen
+- **WHEN** a loop declares that it stops on limit
+- **THEN** it returns the items gathered so far and the run continues.
+
+### Requirement: An unusable loop is refused at save time
+
+A loop with no source, an empty body, a body step without a type, or a
+non-positive limit SHALL be refused when the flow is saved.
+
+Save-time refusal is required rather than run-time detection because a loop that
+cannot terminate pays its cost in side effects: by the time execution notices,
+the body has already written whatever it writes, as many times as it managed.
+
+#### Scenario: A sourceless loop is refused
+- **WHEN** a flow is saved with an iterate step that declares no source
+- **THEN** the save is refused with a message naming what is missing.
+
+#### Scenario: An empty body is refused
+- **WHEN** an iterate step declares no steps to repeat
+- **THEN** the save is refused.
+
+#### Scenario: A non-positive limit is refused
+- **WHEN** an iterate step declares a limit of zero
+- **THEN** the save is refused.
+
+### Requirement: A corrected node id migrates its stored references
+
+When a node id is corrected, stored flow definitions SHALL be migrated to the new
+id, and the old id SHALL remain resolvable for one release.
+
+A node id is a reference the system writes into a flow definition, unlike an
+identifier a person typed into a template — so it can be corrected and the data
+rewritten, rather than the wrong name being kept indefinitely. Resolution through
+the compatibility alias SHALL be logged, so the number of definitions still
+carrying the old id is observable rather than assumed to be zero.
+
+#### Scenario: Stored definitions are rewritten
+- **WHEN** the instance upgrades past the rename
+- **THEN** every stored flow referencing the old id references the new one, and the count of updated definitions is reported.
+
+#### Scenario: An old export still imports
+- **WHEN** a flow exported before the rename is imported after it
+- **THEN** its steps resolve through the alias rather than failing as an unknown node type, and the resolution is logged.

--- a/tests/Unit/Service/Flow/Nodes/IterateNodeTest.php
+++ b/tests/Unit/Service/Flow/Nodes/IterateNodeTest.php
@@ -1,0 +1,313 @@
+<?php
+
+/**
+ * Tests for the declared loop region.
+ *
+ * The cases that matter are the ones about STOPPING: a loop that never
+ * terminates costs side effects, and a loop that terminates early silently
+ * discards work. Both are asserted here, and both were observed failing against
+ * a deliberately broken implementation before being trusted.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow\Nodes
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Flow\Nodes;
+
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\FlowStepDispatcher;
+use OCA\OpenRegister\Service\Flow\Nodes\IterateNode;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use RuntimeException;
+use UnexpectedValueException;
+
+/**
+ * IterateNode behaviour.
+ */
+class IterateNodeTest extends TestCase
+{
+
+    /**
+     * The node under test.
+     *
+     * @var IterateNode
+     */
+    private IterateNode $node;
+
+    /**
+     * The dispatcher the node drives its source and body through.
+     *
+     * @var FlowStepDispatcher|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $dispatcher;
+
+    /**
+     * Build the node with a mocked dispatcher.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $l10n = $this->createMock(IL10N::class);
+        $l10n->method('t')->willReturnArgument(0);
+
+        $urls = $this->createMock(IURLGenerator::class);
+        $urls->method('imagePath')->willReturn('/icon.svg');
+
+        $this->dispatcher = $this->createMock(FlowStepDispatcher::class);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturn($this->dispatcher);
+
+        $this->node = new IterateNode(l10n: $l10n, urls: $urls, container: $container);
+
+    }//end setUp()
+
+    /**
+     * A three-page source runs the body three times and returns every item.
+     *
+     * @return void
+     */
+    public function testItRunsTheBodyOncePerBatchAndAccumulates(): void
+    {
+        $pages = [
+            [FlowItems::item(json: ['p' => 1])],
+            [FlowItems::item(json: ['p' => 2])],
+            [FlowItems::item(json: ['p' => 3])],
+            [],
+        ];
+
+        $this->dispatcher->method('dispatch')->willReturnCallback(
+            static function (array $step, array $items, array $context) use (&$pages): array {
+                if ($step['type'] === 'src') {
+                    return array_shift($pages);
+                }
+
+                return $items;
+            }
+        );
+
+        $out = $this->node->execute(
+            [],
+            [
+                'source' => ['type' => 'src'],
+                'body'   => [['type' => 'body']],
+            ],
+            []
+        );
+
+        $this->assertCount(3, $out, 'every page must survive, not just the last');
+
+    }//end testItRunsTheBodyOncePerBatchAndAccumulates()
+
+    /**
+     * An empty first batch means the body never runs.
+     *
+     * @return void
+     */
+    public function testAnEmptySourceRunsTheBodyNotAtAll(): void
+    {
+        $this->dispatcher->method('dispatch')->willReturnCallback(
+            static function (array $step, array $items, array $context): array {
+                if ($step['type'] === 'src') {
+                    return [];
+                }
+
+                throw new \LogicException('the body must not run when the source is empty');
+            }
+        );
+
+        $out = $this->node->execute([], ['source' => ['type' => 'src'], 'body' => [['type' => 'body']]], []);
+        $this->assertSame([], $out);
+
+    }//end testAnEmptySourceRunsTheBodyNotAtAll()
+
+    /**
+     * The source is told which iteration it is on, so it can page.
+     *
+     * @return void
+     */
+    public function testTheSourceSeesItsIterationIndex(): void
+    {
+        $seen = [];
+
+        $this->dispatcher->method('dispatch')->willReturnCallback(
+            static function (array $step, array $items, array $context) use (&$seen): array {
+                if ($step['type'] !== 'src') {
+                    return $items;
+                }
+
+                $seen[] = $context['iteration']['index'];
+
+                return count($seen) < 3 ? [FlowItems::item(json: [])] : [];
+            }
+        );
+
+        $this->node->execute([], ['source' => ['type' => 'src'], 'body' => [['type' => 'b']]], []);
+
+        $this->assertSame([0, 1, 2], $seen, 'the source must be able to ask for the right page');
+
+    }//end testTheSourceSeesItsIterationIndex()
+
+    /**
+     * A source that never runs out FAILS rather than looping forever.
+     *
+     * @return void
+     */
+    public function testANonConvergingLoopFails(): void
+    {
+        $this->dispatcher->method('dispatch')->willReturnCallback(
+            static fn (array $step, array $items, array $context): array => [FlowItems::item(json: [])]
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/did not finish within 5 iterations/');
+
+        $this->node->execute(
+            [],
+            [
+                'source'        => ['type' => 'src'],
+                'body'          => [['type' => 'b']],
+                'maxIterations' => 5,
+            ],
+            []
+        );
+
+    }//end testANonConvergingLoopFails()
+
+    /**
+     * onLimit=stop keeps what it gathered instead of failing.
+     *
+     * @return void
+     */
+    public function testOnLimitStopKeepsWhatItGathered(): void
+    {
+        $this->dispatcher->method('dispatch')->willReturnCallback(
+            static fn (array $step, array $items, array $context): array => [FlowItems::item(json: [])]
+        );
+
+        $out = $this->node->execute(
+            [],
+            [
+                'source'        => ['type' => 'src'],
+                'body'          => [['type' => 'b']],
+                'maxIterations' => 4,
+                'onLimit'       => IterateNode::ON_LIMIT_STOP,
+            ],
+            []
+        );
+
+        $this->assertCount(4, $out);
+
+    }//end testOnLimitStopKeepsWhatItGathered()
+
+    /**
+     * Every body step runs, in the declared order.
+     *
+     * @return void
+     */
+    public function testTheWholeBodyChainRunsInOrder(): void
+    {
+        $order = [];
+        $pages = [[FlowItems::item(json: [])], []];
+
+        $this->dispatcher->method('dispatch')->willReturnCallback(
+            static function (array $step, array $items, array $context) use (&$order, &$pages): array {
+                if ($step['type'] === 'src') {
+                    return array_shift($pages);
+                }
+
+                $order[] = $step['type'];
+
+                return $items;
+            }
+        );
+
+        $this->node->execute(
+            [],
+            [
+                'source' => ['type' => 'src'],
+                'body'   => [['type' => 'one'], ['type' => 'two'], ['type' => 'three']],
+            ],
+            []
+        );
+
+        $this->assertSame(['one', 'two', 'three'], $order);
+
+    }//end testTheWholeBodyChainRunsInOrder()
+
+    /**
+     * A loop with no source is refused at save time.
+     *
+     * @return void
+     */
+    public function testALoopWithoutASourceIsRefused(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->node->validateConfig(['body' => [['type' => 'b']]]);
+
+    }//end testALoopWithoutASourceIsRefused()
+
+    /**
+     * A loop with an empty body is refused — it would spin doing nothing.
+     *
+     * @return void
+     */
+    public function testALoopWithAnEmptyBodyIsRefused(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->node->validateConfig(['source' => ['type' => 'src'], 'body' => []]);
+
+    }//end testALoopWithAnEmptyBodyIsRefused()
+
+    /**
+     * A body step with no type is refused, naming its position.
+     *
+     * @return void
+     */
+    public function testATypelessBodyStepIsRefused(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->node->validateConfig(['source' => ['type' => 'src'], 'body' => [['config' => []]]]);
+
+    }//end testATypelessBodyStepIsRefused()
+
+    /**
+     * A non-positive limit is refused: zero iterations is not a loop.
+     *
+     * @return void
+     */
+    public function testANonPositiveLimitIsRefused(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->node->validateConfig(
+            ['source' => ['type' => 'src'], 'body' => [['type' => 'b']], 'maxIterations' => 0]
+        );
+
+    }//end testANonPositiveLimitIsRefused()
+
+    /**
+     * The catalogue id stored flow definitions reference.
+     *
+     * @return void
+     */
+    public function testItsCatalogueIdIsStable(): void
+    {
+        $this->assertSame('openregister.iterate', $this->node->getId());
+
+    }//end testItsCatalogueIdIsStable()
+}//end class

--- a/tests/Unit/Service/Flow/Nodes/MapNodeTest.php
+++ b/tests/Unit/Service/Flow/Nodes/MapNodeTest.php
@@ -1,0 +1,253 @@
+<?php
+
+/**
+ * Tests for the mapping node.
+ *
+ * The negative cases carry the weight here. A transformation node that fails
+ * OPEN — passing its items through when it cannot map them — records a
+ * completed step having done nothing, and the resulting error surfaces at some
+ * later step reading the un-mapped shape, far from its cause.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow\Nodes
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Flow\Nodes;
+
+use OCA\OpenRegister\Db\Mapping;
+use OCA\OpenRegister\Db\MappingMapper;
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\Nodes\MapNode;
+use OCA\OpenRegister\Service\MappingService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use UnexpectedValueException;
+
+/**
+ * MapNode behaviour.
+ */
+class MapNodeTest extends TestCase
+{
+
+    /**
+     * Evaluates mappings.
+     *
+     * @var MappingService|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $mappings;
+
+    /**
+     * Resolves mappings.
+     *
+     * @var MappingMapper|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $mapper;
+
+    /**
+     * The node under test.
+     *
+     * @var MapNode
+     */
+    private MapNode $node;
+
+    /**
+     * Build the node with mocked collaborators.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $l10n = $this->createMock(IL10N::class);
+        $l10n->method('t')->willReturnArgument(0);
+
+        $urls = $this->createMock(IURLGenerator::class);
+        $urls->method('imagePath')->willReturn('/icon.svg');
+
+        $this->mappings = $this->createMock(MappingService::class);
+        $this->mapper   = $this->createMock(MappingMapper::class);
+
+        $this->node = new MapNode(
+            l10n: $l10n,
+            urls: $urls,
+            mappings: $this->mappings,
+            mapper: $this->mapper
+        );
+
+    }//end setUp()
+
+    /**
+     * One item in, one reshaped item out.
+     *
+     * @return void
+     */
+    public function testItReshapesEveryItem(): void
+    {
+        $mapping = $this->createMock(Mapping::class);
+        $this->mapper->method('find')->willReturn($mapping);
+
+        $this->mappings->expects($this->once())
+            ->method('executeMapping')
+            ->willReturn(['b' => 'value']);
+
+        $out = $this->node->execute(
+            [FlowItems::item(json: ['a' => 'value'])],
+            ['mapping' => '42'],
+            []
+        );
+
+        $this->assertCount(1, $out);
+        $this->assertSame(['b' => 'value'], $out[0][FlowItems::JSON], 'the item must carry the MAPPED shape');
+        $this->assertArrayNotHasKey('a', $out[0][FlowItems::JSON], 'the input shape must not survive');
+
+    }//end testItReshapesEveryItem()
+
+    /**
+     * The mapping runs once PER ITEM, not once for the list.
+     *
+     * @return void
+     */
+    public function testItMapsPerItemNotPerList(): void
+    {
+        $this->mapper->method('find')->willReturn($this->createMock(Mapping::class));
+        $this->mappings->expects($this->exactly(3))
+            ->method('executeMapping')
+            ->willReturn(['ok' => true]);
+
+        $out = $this->node->execute(
+            [
+                FlowItems::item(json: ['n' => 1]),
+                FlowItems::item(json: ['n' => 2]),
+                FlowItems::item(json: ['n' => 3]),
+            ],
+            ['mapping' => '42'],
+            []
+        );
+
+        $this->assertCount(3, $out);
+
+    }//end testItMapsPerItemNotPerList()
+
+    /**
+     * An unresolvable mapping FAILS. It must not forward the items untouched.
+     *
+     * @return void
+     */
+    public function testAnUnresolvableMappingFailsRatherThanPassingThrough(): void
+    {
+        $this->mapper->method('find')->willThrowException(
+            new DoesNotExistException('no such mapping')
+        );
+
+        $this->mappings->expects($this->never())
+            ->method('executeMapping');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/999/');
+
+        $this->node->execute(
+            [FlowItems::item(json: ['a' => 1])],
+            ['mapping' => '999'],
+            []
+        );
+
+    }//end testAnUnresolvableMappingFailsRatherThanPassingThrough()
+
+    /**
+     * A mapping that throws mid-list fails the step and names the item.
+     *
+     * @return void
+     */
+    public function testAFailingMappingNamesTheItemItFailedOn(): void
+    {
+        $this->mapper->method('find')->willReturn($this->createMock(Mapping::class));
+        $this->mappings->method('executeMapping')->willThrowException(
+            new \RuntimeException('bad template')
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/item 0/');
+
+        $this->node->execute(
+            [FlowItems::item(json: ['a' => 1])],
+            ['mapping' => '42'],
+            []
+        );
+
+    }//end testAFailingMappingNamesTheItemItFailedOn()
+
+    /**
+     * A slug resolves, so an exported flow survives an id that differs per instance.
+     *
+     * @return void
+     */
+    public function testANonNumericReferenceResolvesByRef(): void
+    {
+        $mapping = $this->createMock(Mapping::class);
+        $this->mapper->expects($this->never())->method('find');
+        $this->mapper->expects($this->once())
+            ->method('findByRef')
+            ->with('person-to-contact')
+            ->willReturn([$mapping]);
+
+        $this->mappings->method('executeMapping')->willReturn(['ok' => true]);
+
+        $out = $this->node->execute(
+            [FlowItems::item(json: [])],
+            ['mapping' => 'person-to-contact'],
+            []
+        );
+
+        $this->assertCount(1, $out);
+
+    }//end testANonNumericReferenceResolvesByRef()
+
+    /**
+     * A map step with no mapping is refused at validation.
+     *
+     * @return void
+     */
+    public function testAMapStepWithoutAMappingIsRefused(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->node->validateConfig([]);
+
+    }//end testAMapStepWithoutAMappingIsRefused()
+
+    /**
+     * A blank mapping is refused too — whitespace is not a mapping.
+     *
+     * @return void
+     */
+    public function testABlankMappingIsRefused(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->node->validateConfig(['mapping' => '   ']);
+
+    }//end testABlankMappingIsRefused()
+
+    /**
+     * The node reports the catalogue id the flow definitions reference.
+     *
+     * @return void
+     */
+    public function testItsCatalogueIdIsStable(): void
+    {
+        $this->assertSame('openregister.map', $this->node->getId());
+
+    }//end testItsCatalogueIdIsStable()
+
+}//end class

--- a/tests/Unit/Twig/MappingExtensionTest.php
+++ b/tests/Unit/Twig/MappingExtensionTest.php
@@ -68,7 +68,34 @@ class MappingExtensionTest extends TestCase
     {
         $functions = $this->extension->getFunctions();
         $this->assertIsArray($functions);
-        $this->assertCount(2, $functions);
+
+        // Asserted BY NAME, not by count. The count assertion that used to be
+        // here broke the moment mapping consolidated — which told us a number
+        // had changed, not whether anything was missing. These names are the
+        // contract: a stored mapping calls them, so losing one breaks authored
+        // data at evaluation time with nothing at author time to warn you.
+        $names = array_map(static fn ($fn): string => $fn->getName(), $functions);
+
+        foreach (['executeMapping', 'generateUuid', 'json_decode', 'jsonDecode', 'createSlug', 'b64enc', 'b64dec'] as $expected) {
+            $this->assertContains($expected, $names, sprintf('mapping templates call %s()', $expected));
+        }
+    }
+
+    /**
+     * `json_decode` must be reachable as BOTH a function and a filter.
+     *
+     * OpenConnector's templates call `json_decode(x)`; OpenRegister's own use
+     * `x|json_decode`. Consolidation kept both rather than picking one, because
+     * a mapping is authored data and dropping either form breaks stored
+     * templates silently.
+     */
+    public function testJsonDecodeIsReachableAsFunctionAndFilter(): void
+    {
+        $functionNames = array_map(static fn ($fn): string => $fn->getName(), $this->extension->getFunctions());
+        $filterNames   = array_map(static fn ($f): string => $f->getName(), $this->extension->getFilters());
+
+        $this->assertContains('json_decode', $functionNames, 'OpenConnector templates call json_decode()');
+        $this->assertContains('json_decode', $filterNames, 'OpenRegister templates use |json_decode');
     }
 
     public function testGetFunctionsAreTwigFunctions(): void


### PR DESCRIPTION
Three things, all on the road to one flow engine.

### `openregister.map`
The engine had no node that transformed data, so any flow needing to reshape a payload had to route out to an endpoint rule and back. That is why integrations ended up as endpoint chains — not because endpoints fitted better, but because flows could not map.

Maps PER ITEM like FilterNode. Resolves a mapping by id, uuid, slug or reference so an exported flow survives an instance where the numeric id differs. An unresolvable mapping **fails** the step rather than forwarding items untouched — passing them through would record a completed step that transformed nothing, and the error would surface at some later step reading the un-mapped shape.

Live in `/api/flow/node-catalog` (18 nodes), 8 unit tests, and the fail-closed guard confirmed by mutation: patching it to return items on an unresolved mapping makes exactly that one test fail.

### Twig moves to OpenRegister
Ported `createSlug`, `json_decode`, `b64enc`/`b64dec`. `createSlug` is copied byte-for-byte — mappings persist slugs as object identifiers, so changing the transformation silently orphans already-written objects.

Both `json_decode` and `jsonDecode` are registered. OpenConnector's templates call one, OpenRegister's runtime spelled it the other; a mapping is authored data, so renaming what it calls breaks it at evaluation with nothing at author time to warn you.

`RegisterMappingFunctionsEvent` is the contribution point. `registerFunction()` registers AND allowlists in one call, because the environment is sandboxed and a contributed-but-unlisted function fails as "unknown function" deep inside a mapping, nowhere near its registration.

Verified live: `createSlug("Hello World App")` → `hello-world-app`, `json_decode('{"a":1}')["a"]` → `1`, `b64enc("hi")` → `aGk=`. Negative control holds — `system()` and an unlisted filter are still refused, so the sandbox was widened deliberately rather than disabled.

### Design: decomposing the sync monolith
`openconnector.synchronization-run` is one node that runs an entire synchronisation, so run history records it as a single step. Four capabilities are trapped inside with no node equivalent — pagination, hash change-detection, contract resolution, contracted write. The contract one is load-bearing: without it a flow-built sync is not idempotent.

design.md works through three ways to model iteration and picks a **declared loop region** over a graph cycle or a sub-flow, so loop membership is data and the builder can draw a container instead of an edge that happens to point backwards.