### PR TITLE
fix(security): guzzle 7.15.1 → 7.15.2 for CVE-2026-69246 / CVE-2026-69245

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -683,16 +683,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.15.1",
+            "version": "7.15.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/744101956d78b7c1384d0cbf379db13e859167bf",
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf",
                 "shasum": ""
             },
             "require": {
@@ -791,7 +791,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.2"
             },
             "funding": [
                 {
@@ -807,7 +807,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-18T11:23:11+00:00"
+            "time": "2026-07-26T23:23:20+00:00"
         },
         {
             "name": "guzzlehttp/promises",


### PR DESCRIPTION
`Security (composer)` went red on `development`, and it is **not** the merge that preceded it — both advisories were published *today*, minutes before that run.

| CVE | Severity | Title | Reported |
|---|---|---|---|
| CVE-2026-69246 | **high** | Guzzle: Noncanonical host can bypass host-based checks | 2026-08-03T21:07:26Z |
| CVE-2026-69245 | medium | Guzzle: Noncanonical cookie domain keeps subdomain scope | 2026-08-03T21:05:26Z |

Affected: `>=8.0.0,<8.0.1 | <7.15.2` — locked here at **7.15.1**.

The high one matters for this app specifically: OpenRegister makes outbound calls on user-supplied targets, and a host check that a noncanonical host can bypass is exactly the shape SSRF guards are built on.

### Minimal by construction

`composer.json` already allows `^7.0`, so this is lockfile-only and the `content-hash` is **unchanged**. Six lines, all guzzle:

```
-  "version": "7.15.1"
+  "version": "7.15.2"
```

`composer update guzzlehttp/guzzle --with-dependencies` moved nothing else, and composer's own audit now answers *"No security vulnerability advisories found."*

### Why this blocked more than itself

A red `Security (composer)` makes `E2E Tests (Playwright)` report **`skipped`, not `failure`**. So while this was red, the e2e gate produced **no verdict at all**, while the run merely looked like it had one red job — both of today's sharing e2e suites were silently not running on `development`.

Fleet-wide: any repo locking guzzle `<7.15.2` is red for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
