### PR TITLE
chore(deps): bump @conduction/nextcloud-vue to 3.0.0-vue3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
-        "@conduction/nextcloud-vue": "3.0.0-vue3.3",
+        "@conduction/nextcloud-vue": "3.0.0-vue3.4",
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@nextcloud/auth": "^2.6.0",
@@ -2148,9 +2148,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "3.0.0-vue3.3",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-3.0.0-vue3.3.tgz",
-      "integrity": "sha512-cV1myCIfk4afV2aK+I9+Rg7SfvXgQ8xNdcSJc02Dgebr8UcPwNRvCyrmrvGwF3EvwjVSv+NXTlyCtX5VDAS7Vg==",
+      "version": "3.0.0-vue3.4",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-3.0.0-vue3.4.tgz",
+      "integrity": "sha512-+x6lUVhpoZsozAW5S20C9Y3KHhLo5+0MIqKi00lJlK+yOHuJxBoZlra7ijaY0Wk0TOs6iBdhmbGNYptJa1Pkwg==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",
@@ -2487,6 +2487,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2503,6 +2504,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2519,6 +2521,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2535,6 +2538,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2551,6 +2555,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2567,6 +2572,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2583,6 +2589,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2599,6 +2606,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2615,6 +2623,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2631,6 +2640,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2647,6 +2657,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2663,6 +2674,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2679,6 +2691,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2695,6 +2708,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2711,6 +2725,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2727,6 +2742,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2743,6 +2759,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2759,6 +2776,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2775,6 +2793,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2791,6 +2810,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2807,6 +2827,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2823,6 +2844,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2839,6 +2861,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2855,6 +2878,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2871,6 +2895,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2887,6 +2912,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3819,15 +3845,15 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-core": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.64.0.tgz",
-      "integrity": "sha512-zs2TAq7Six5jgMuoMNjpspAvOP3mhtgq/k1UyQodEzCtQi/N83y2/y+zcvnZSGp/Rxq96DBN+bValOBQAyn/ew==",
+      "version": "4.66.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.66.1.tgz",
+      "integrity": "sha512-8nvZo0NSi4LArgvN0M+xJbIP+2p8Gl615y0tXYCsCCbYcRDKnAvxylc1zIEZoOs1oT/npotPVHIAKIx+savFlA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.64.0",
-        "@jsonjoy.com/fs-node-utils": "4.64.0",
+        "@jsonjoy.com/fs-node-builtins": "4.66.1",
+        "@jsonjoy.com/fs-node-utils": "4.66.1",
         "thingies": "^2.5.0"
       },
       "engines": {
@@ -3842,16 +3868,16 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-fsa": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.64.0.tgz",
-      "integrity": "sha512-nMWOVbkLFyEgmXZih3wyvxA9XpgyyqyfrINMHvEFqhi7uqfRl7c9ERJt6yX7vgMPrB9Uo+OJO+Spa0cFzPD01w==",
+      "version": "4.66.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.66.1.tgz",
+      "integrity": "sha512-7Ow+igS/bPSzlVWFiB/cjNzobhwBZn4pu7FHiy0/KSjUwJ//RaLG2UHHPnr+FmwdQykvVux9VQarZxozsSh1dA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.64.0",
-        "@jsonjoy.com/fs-node-builtins": "4.64.0",
-        "@jsonjoy.com/fs-node-utils": "4.64.0",
+        "@jsonjoy.com/fs-core": "4.66.1",
+        "@jsonjoy.com/fs-node-builtins": "4.66.1",
+        "@jsonjoy.com/fs-node-utils": "4.66.1",
         "thingies": "^2.5.0"
       },
       "engines": {
@@ -3866,18 +3892,18 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.64.0.tgz",
-      "integrity": "sha512-dO+NNkODbUli4uV42bcNrrLvq5rE7SNpdZ5TNd0dtbLsAaNK3MDiIC9lUi+brboGoIjW6vd2fB1qao60nrk5xA==",
+      "version": "4.66.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.66.1.tgz",
+      "integrity": "sha512-lFlBqITscYHoBq4xqZP090pXCeSYfv//yipuliA26D2l+50P/7L9IaQnSZE3QH6Ai1DLuZq72X0MeAj30QbzNw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.64.0",
-        "@jsonjoy.com/fs-node-builtins": "4.64.0",
-        "@jsonjoy.com/fs-node-utils": "4.64.0",
-        "@jsonjoy.com/fs-print": "4.64.0",
-        "@jsonjoy.com/fs-snapshot": "4.64.0",
+        "@jsonjoy.com/fs-core": "4.66.1",
+        "@jsonjoy.com/fs-node-builtins": "4.66.1",
+        "@jsonjoy.com/fs-node-utils": "4.66.1",
+        "@jsonjoy.com/fs-print": "4.66.1",
+        "@jsonjoy.com/fs-snapshot": "4.66.1",
         "glob-to-regex.js": "^1.0.0",
         "thingies": "^2.5.0"
       },
@@ -3893,9 +3919,9 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-builtins": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.64.0.tgz",
-      "integrity": "sha512-/o7WRFhUWaM/fOrslwLZGnzn4RmRILykn+lAL+mNObqqRNw+CQSiij6hpCeZ+C7buhdoVo7go/OYqzaSUfDYmA==",
+      "version": "4.66.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.66.1.tgz",
+      "integrity": "sha512-KWsERloam7LL2TMNnRQoosjTKmUchBUbkX3iSgEfxJh+CFQcjD1fUoDLrW4IkmdpDpCKvKtQtWU316ziCbadFA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -3911,16 +3937,16 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-to-fsa": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.64.0.tgz",
-      "integrity": "sha512-WDD9WVs0hb7UAEKTgZW2f66WDrbj7gIIWwpP3spbLyXa0rghtUaFTB8L4gdR3ZCWwiKIsj38/CNijpVmpnuPUw==",
+      "version": "4.66.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.66.1.tgz",
+      "integrity": "sha512-ZrLba5Li6EIBWIEf4d6Ynd0VvHZawmgMoU1KZb1+L0CGYrIME/sSlikqYXW6Rz8p9Qlh2lgLjTooDHUXEApHPA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@jsonjoy.com/fs-fsa": "4.64.0",
-        "@jsonjoy.com/fs-node-builtins": "4.64.0",
-        "@jsonjoy.com/fs-node-utils": "4.64.0"
+        "@jsonjoy.com/fs-fsa": "4.66.1",
+        "@jsonjoy.com/fs-node-builtins": "4.66.1",
+        "@jsonjoy.com/fs-node-utils": "4.66.1"
       },
       "engines": {
         "node": ">=10.0"
@@ -3934,14 +3960,14 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-utils": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.64.0.tgz",
-      "integrity": "sha512-k5Indsx9hWW9xSF7Y6oSKKwtCUNhzZxadub3owhIlitc+iMRVlPPdX2duTKQWBL3qNWpXya8jykgaaWpheeS4w==",
+      "version": "4.66.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.66.1.tgz",
+      "integrity": "sha512-uT47QQHagIwHXJLufJ0St5anvn5+XPft5coItIwXpu+BSIkchole1VcTWyrsrqNlkMkhoiPTCEsNROlDIc4u9A==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.64.0",
+        "@jsonjoy.com/fs-node-builtins": "4.66.1",
         "glob-to-regex.js": "^1.0.1"
       },
       "engines": {
@@ -3956,14 +3982,14 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-print": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.64.0.tgz",
-      "integrity": "sha512-PHZFccchvkhWrwPWHjmVAhbC3vSHCtyZvlZfJJ3ho2bnzl450hXri6/8e6pbkWdH+SkmLXNml0sV8e5HDAfxKw==",
+      "version": "4.66.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.66.1.tgz",
+      "integrity": "sha512-Hzor0pXAXkVIsmLvEcKTd8GG8I2DztOZEK1kxkf6eolZJfKQyKo2BLHVCwm99iiwfJZpfb7zbtGnENUGo+r8eg==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@jsonjoy.com/fs-node-utils": "4.64.0",
+        "@jsonjoy.com/fs-node-utils": "4.66.1",
         "tree-dump": "^1.1.0"
       },
       "engines": {
@@ -3978,15 +4004,15 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-snapshot": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.64.0.tgz",
-      "integrity": "sha512-oM7UDeL83q6NBzzsfKAsYKXKVXlykKFqqOLh4xZZKAzzROTlInkPbc6LTDGThEOnPiFiUzA7tYziHG9xavd76Q==",
+      "version": "4.66.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.66.1.tgz",
+      "integrity": "sha512-dDH60OcZ3Q9aOhg1CoKzoqGGsu6MPkepmRQqr1SGpYNrv3TgO7VuFAew7bmDbOpilBtq1MLr1ZzS5vmbz2XYgA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@jsonjoy.com/buffers": "^17.65.0",
-        "@jsonjoy.com/fs-node-utils": "4.64.0",
+        "@jsonjoy.com/fs-node-utils": "4.66.1",
         "@jsonjoy.com/json-pack": "^17.65.0",
         "@jsonjoy.com/util": "^17.65.0"
       },
@@ -4328,6 +4354,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5791,6 +5818,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5804,6 +5832,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5817,6 +5846,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5830,6 +5860,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5843,6 +5874,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5856,6 +5888,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5869,6 +5902,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5882,6 +5916,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5895,6 +5930,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5908,6 +5944,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5921,6 +5958,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5934,6 +5972,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5947,6 +5986,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5960,6 +6000,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5973,6 +6014,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5986,6 +6028,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5999,6 +6042,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6012,6 +6056,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6025,6 +6070,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6038,6 +6084,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6051,6 +6098,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6064,6 +6112,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6077,6 +6126,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6090,6 +6140,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6103,6 +6154,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6250,9 +6302,9 @@
       }
     },
     "node_modules/@stoplight/spectral-cli": {
-      "version": "6.16.2",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.16.2.tgz",
-      "integrity": "sha512-1BwNCglpvCA2J+MpdXSPH56h69rARthf0QG/t2eeFbuqg12rcQEbGfAXs70mCRUAewiCzf1QqzeHF1tnabfS3A==",
+      "version": "6.16.3",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.16.3.tgz",
+      "integrity": "sha512-corAOQ/WhGoPJOQ3Tcipyn64TgKYDkEhsDplS6vNSGys3kzi9+zzxiVOlbzk9mWuafovzoW+TpGCoNwIZvFf5w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6510,9 +6562,9 @@
       }
     },
     "node_modules/@stoplight/spectral-ruleset-migrator": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-ruleset-migrator/-/spectral-ruleset-migrator-1.12.1.tgz",
-      "integrity": "sha512-IUEbDmmTro0oF6VoAtrUySRV/b6bvYmV7wV6lB99f0Ym5lF9M2DXcgPLo7VMbKTPjCOQcaBzWRnIMXAyLjIRMA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-ruleset-migrator/-/spectral-ruleset-migrator-1.12.2.tgz",
+      "integrity": "sha512-9hTcyXnBGppM1kMA8vVvY6aWzF3vXbU7+mZvvd9wdPE8QdHj9NO//1s+A/TfiWOKdH9GOERC5NITCnVvbEYEWg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6559,13 +6611,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@stoplight/spectral-rulesets": {
-      "version": "1.22.6",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.22.6.tgz",
-      "integrity": "sha512-xBwrb2zjx+7AzGS3aX7aOtddChRRw8aoQMu8ZT5AmTfEr0VAj4ydGC6Pl7lIvAIomcO7hw+P4I2oylTOOCkUVw==",
+      "version": "1.22.7",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.22.7.tgz",
+      "integrity": "sha512-cT1B6Ly21923lvr235lu7iIgmcnoCTJaN3ANOyTqr4D5GA/4p2k0+yhjhdfj/1ks/Os3kUzSFnFkzpWH7WszFA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/specs": "^6.8.0",
+        "@asyncapi/specs": "6.11.1",
         "@scarf/scarf": "^1.4.0",
         "@stoplight/better-ajv-errors": "1.0.3",
         "@stoplight/json": "^3.17.0",
@@ -7174,9 +7226,9 @@
       "license": "MIT"
     },
     "node_modules/@types/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==",
       "license": "MIT"
     },
     "node_modules/@types/send": {
@@ -9400,9 +9452,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.10",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.10.tgz",
-      "integrity": "sha512-35JEvJ5/KKlbCHjMCsONI2w6HE88STjVdHk+C7d8LtcFxUjZR1KeLP9izofn2qs0KUxX5r4z73bwH/rd+JHacw==",
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+      "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -11602,9 +11654,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -18060,21 +18112,21 @@
       }
     },
     "node_modules/memfs": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.64.0.tgz",
-      "integrity": "sha512-Kw72fgY7Wn+sD8KmtNWSafl1dz0UvAsE/PHs3YVfLiaZuA3HxNm9sRLqAu0ATiBGJvME1PxZXbBZPv5GycDeAw==",
+      "version": "4.66.1",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.66.1.tgz",
+      "integrity": "sha512-kHQesIzNf/h57sTonjIFNF5oCTHkeDYV6QXtDdapn6TCKLJHCfKMM93Jq6BO0ubtzlgN+Yd53kKWl7TvU79X5Q==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.64.0",
-        "@jsonjoy.com/fs-fsa": "4.64.0",
-        "@jsonjoy.com/fs-node": "4.64.0",
-        "@jsonjoy.com/fs-node-builtins": "4.64.0",
-        "@jsonjoy.com/fs-node-to-fsa": "4.64.0",
-        "@jsonjoy.com/fs-node-utils": "4.64.0",
-        "@jsonjoy.com/fs-print": "4.64.0",
-        "@jsonjoy.com/fs-snapshot": "4.64.0",
+        "@jsonjoy.com/fs-core": "4.66.1",
+        "@jsonjoy.com/fs-fsa": "4.66.1",
+        "@jsonjoy.com/fs-node": "4.66.1",
+        "@jsonjoy.com/fs-node-builtins": "4.66.1",
+        "@jsonjoy.com/fs-node-to-fsa": "4.66.1",
+        "@jsonjoy.com/fs-node-utils": "4.66.1",
+        "@jsonjoy.com/fs-print": "4.66.1",
+        "@jsonjoy.com/fs-snapshot": "4.66.1",
         "@jsonjoy.com/json-pack": "^1.11.0",
         "@jsonjoy.com/util": "^1.9.0",
         "glob-to-regex.js": "^1.0.1",
@@ -18085,9 +18137,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
       }
     },
     "node_modules/meow": {
@@ -19175,9 +19224,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -32819,9 +32868,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
-    "@conduction/nextcloud-vue": "3.0.0-vue3.3",
+    "@conduction/nextcloud-vue": "3.0.0-vue3.4",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@nextcloud/auth": "^2.6.0",


### PR DESCRIPTION
## What

Bumps `@conduction/nextcloud-vue` from `3.0.0-vue3.3` to **`3.0.0-vue3.4`**, pinned exactly (no caret, no tilde).

Patch bump on the existing 3.x / Vue 3 line — this is not a major migration.

## Lockfile verification

Read out of `package-lock.json` itself (not `package.json`, not `npm ls`):

| package | resolved version | note |
|---|---|---|
| `@conduction/nextcloud-vue` | `3.0.0-vue3.4` | exact target |
| `vue3-apexcharts` | `1.8.0` | **below 1.9.0** — 1.9.0+ is proprietary and forbids sublicensing in our EUPL-1.2 apps. No override was added. |
| `apexcharts` (core) | `4.7.0` | still MIT |

- `lockfileVersion: 3`, 2338 package entries, 1.2 MB — sane, not a collapsed/empty resolve.
- `overrides` contains **no `//` key** (a `//` key makes npm resolve zero deps while reporting "up to date").

Install chain: `rm -rf package-lock.json node_modules` -> `npm install` (npm 11.13.0 / node 22.22.0) -> `npm install --package-lock-only` (npm 10.9.8 / node 20.20.2) -> `npm ci` (npm 10.9.8).

## Breaking surface — three removed components

`3.0.0` removes `CnFlowCanvas`, `CnEditFlowsModal` and `CnFlowCanvasModal`. OpenRegister owns the flow engine, so it is the app most likely to reference them.

Grep of the built output (`js/`, built with `USE_LOCAL_LIB=false`):

| symbol | occurrences in `js/` | expected |
|---|---|---|
| `CnFlowCanvas` | 0 | removed |
| `CnEditFlowsModal` | 0 | removed |
| `CnFlowCanvasModal` | 0 | removed |
| `CnFlowEditModal` | **4** (1 file) | **positive control — grep is working** |

The positive control is non-zero, so the three zeros are real absences rather than a broken query.

`src/` greps clean for all three removed names as well. The flow components OpenRegister actually imports are `CnFlowSidebar`, `CnFlowIndexPage`, `CnFlowDetail` — all still present in the library. No app code was deleted or rewritten.

## Local gates

| gate | result |
|---|---|
| `USE_LOCAL_LIB=false npm run build` | pass — webpack 5.109.2, 0 errors, 15 warnings (pre-existing asset-size warnings) |
| `npm run lint` | pass — exit 0, **0 errors**, 1051 pre-existing jsdoc warnings |
| `npm test` (jest) | pass — **35 suites, 298 tests, all green** |

`composer check:strict` was **not** run: this is a JS-only dependency pin and touches no PHP.

## Note on `docs/features.json`

Running the build executes the `prebuild` features-manifest generator, which rewrites `docs/features.json` into a different schema shape (`{schemaVersion, generatedAt, features[]}` with 5 entries) than the committed flat array (20 entries). **This drift is pre-existing and unrelated to this PR** — it was reproduced by running the generator on a pristine checkout of the base SHA `41f2963`, which produces the identical divergent output. The generated file is therefore deliberately **not** included in this commit.