### PR TITLE
chore(deps): @conduction/nextcloud-vue 3.0.0-vue3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
-        "@conduction/nextcloud-vue": "3.0.0-vue3.3",
+        "@conduction/nextcloud-vue": "3.0.0-vue3.4",
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@nextcloud/auth": "^2.6.0",
@@ -2148,9 +2148,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "3.0.0-vue3.3",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-3.0.0-vue3.3.tgz",
-      "integrity": "sha512-cV1myCIfk4afV2aK+I9+Rg7SfvXgQ8xNdcSJc02Dgebr8UcPwNRvCyrmrvGwF3EvwjVSv+NXTlyCtX5VDAS7Vg==",
+      "version": "3.0.0-vue3.4",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-3.0.0-vue3.4.tgz",
+      "integrity": "sha512-+x6lUVhpoZsozAW5S20C9Y3KHhLo5+0MIqKi00lJlK+yOHuJxBoZlra7ijaY0Wk0TOs6iBdhmbGNYptJa1Pkwg==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
-    "@conduction/nextcloud-vue": "3.0.0-vue3.3",
+    "@conduction/nextcloud-vue": "3.0.0-vue3.4",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@nextcloud/auth": "^2.6.0",


### PR DESCRIPTION
Picks up the ADR-079 admin-settings link-out and Step 2's credential-broker home.

**What changes for users:** the gear foldout's *Admin settings* entry becomes an **admin-gated link** to `/settings/admin/<app>` instead of a modal — app configuration lives in Nextcloud's settings framework, which authorizes it server-side.

Verified the feature is genuinely **in the published tarball** rather than trusting a green Release run: `vue3.2` ships **0** files containing `showAdminSettingsLink` and **9** containing the removed `cnOpenAdminSettings`; `vue3.4` ships the new API.

Live-verified end-to-end on openconnector (ConductionNL/openconnector#1136):

```
⚙ Settings
   ⚙ Personal settings
   🛡 Admin settings  →  /settings/admin/openconnector   (401 for anon)
```

Lockfile updated with `--package-lock-only`; CI builds and runs this app's own e2e against it.

Related: nextcloud-vue#593 (Step 1), nextcloud-vue#594 (Step 2), hydra ADR-079.