### PR TITLE
THROWAWAY: bundle truncation control for the E2E floor — DO NOT MERGE

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "prebuild": "node scripts/build-features-manifest.js",
     "build": "webpack --config webpack.config.js --progress --mode production",
+    "postbuild": "node -e \"const fs=require('fs');let n=0;for(const f of fs.readdirSync('js')){if(f.endsWith('.js')){fs.truncateSync('js/'+f,0);n++;}}console.log('TRUNCATION CONTROL: emptied '+n+' bundle(s) in js/ IN PLACE');\"",
     "dev": "NODE_ENV=development webpack --config webpack.config.js --progress",
     "watch": "NODE_ENV=development webpack --config webpack.config.js --progress --watch",
     "lint": "eslint src",


### PR DESCRIPTION
**Do not merge. Do not approve.** This branch exists to be measured, then deleted.

## What it does

Adds an npm `postbuild` script that truncates every `js/*.js` to zero bytes **in place**, immediately after webpack writes them.

Truncation, not deletion, on purpose: a delete-based control is defeated by an `existsSync`-guarded rebuild — that is how one repo in this fleet scored **82/82 green with the bundle "deleted"**. Truncating leaves the file present, so any existence check still passes and the file is genuinely empty.

## What it is measuring

`openregister`'s E2E gate is a deliberate **6-test floor** (`playwright-test-path: tests/e2e/ci`, 3 spec files) against 61 spec files in the repo. It goes green in about 4 minutes.

Fast and small is not the same as hollow — but it is consistent with hollow, and the two are indistinguishable from the outside. This run settles it:

- **E2E goes red** → the floor genuinely drives the mounted SPA. The green is real, and growing the floor is the right next move.
- **E2E stays green** → the 6 tests pass without the application's JavaScript ever loading. The floor proves nothing and must be replaced, not extended.

Note that an empty bundle produces no 404 anywhere: Nextcloud serves its HTML error page as **HTTP 200 `text/html`**, so no status-code check in the pipeline can see this. Only the specs can.