### PR TITLE
fix(perf): drop unconditional debug logs from the MagicMapper hot path

### DIFF
--- a/lib/Db/MagicMapper/MagicOrganizationHandler.php
+++ b/lib/Db/MagicMapper/MagicOrganizationHandler.php
@@ -125,10 +125,6 @@ class MagicOrganizationHandler
             }
 
             if ($saasMode !== true) {
-                $this->logger->debug(
-                    message: '[MagicOrganizationHandler] Admin bypass enabled, skipping org filter',
-                    context: ['file' => __FILE__, 'line' => __LINE__]
-                );
                 return;
             }
         }
@@ -137,11 +133,6 @@ class MagicOrganizationHandler
         $activeOrgUuids = $this->getActiveOrganizationUuids();
 
         if (empty($activeOrgUuids) === true) {
-            $this->logger->debug(
-                message: '[MagicOrganizationHandler] No active organization, applying public filter',
-                context: ['file' => __FILE__, 'line' => __LINE__]
-            );
-
             // No active organization - admins can see null-org objects, others get no results.
             if ($isAdmin !== true) {
                 $qb->andWhere('1 = 0');
@@ -176,16 +167,6 @@ class MagicOrganizationHandler
         // Apply OR of all conditions.
         $qb->andWhere($qb->expr()->orX(...$conditions));
 
-        $this->logger->debug(
-            message: '[MagicOrganizationHandler] Applied organization filter',
-            context: [
-                'file'            => __FILE__,
-                'line'            => __LINE__,
-                'activeOrgUuids'  => $activeOrgUuids,
-                'conditionsCount' => count($conditions),
-                'isAdmin'         => $isAdmin,
-            ]
-                );
     }//end applyOrganizationFilter()
 
     /**
@@ -208,11 +189,6 @@ class MagicOrganizationHandler
             return false;
         }
 
-        $this->logger->debug(
-            message: '[MagicOrganizationHandler] CLI/system context — skipping org filter',
-            context: ['file' => __FILE__, 'line' => __LINE__]
-        );
-
         return true;
     }//end isSystemContext()
 
@@ -233,16 +209,6 @@ class MagicOrganizationHandler
             // Get active organisations including parent chain.
             $orgUuids = $organisationService->getUserActiveOrganisations();
 
-            $this->logger->debug(
-                message: '[MagicOrganizationHandler] getUserActiveOrganisations returned',
-                context: [
-                    'file'     => __FILE__,
-                    'line'     => __LINE__,
-                    'orgUuids' => $orgUuids,
-                    'user'     => $this->userSession->getUser()?->getUID(),
-                ]
-                    );
-
             if (empty($orgUuids) === false) {
                 return $orgUuids;
             }
@@ -250,21 +216,9 @@ class MagicOrganizationHandler
             // Fallback: try to get just the active organisation.
             $activeOrg = $organisationService->getActiveOrganisation();
             if ($activeOrg !== null) {
-                $this->logger->debug(
-                    message: '[MagicOrganizationHandler] getActiveOrganisation returned',
-                    context: [
-                        'file' => __FILE__,
-                        'line' => __LINE__,
-                        'uuid' => $activeOrg->getUuid(),
-                    ]
-                        );
                 return [$activeOrg->getUuid()];
             }
 
-            $this->logger->debug(
-                message: '[MagicOrganizationHandler] No active organisation found',
-                context: ['file' => __FILE__, 'line' => __LINE__]
-            );
             return [];
         } catch (\Exception $e) {
             $this->logger->warning(

--- a/lib/Db/MagicMapper/MagicRbacHandler.php
+++ b/lib/Db/MagicMapper/MagicRbacHandler.php
@@ -333,10 +333,6 @@ class MagicRbacHandler
         // schema with explicit authorization rules would clamp every CLI query
         // to `1 = 0` and hide all rows from background calcs / list views.
         if ($user === null && PHP_SAPI === 'cli') {
-            $this->logger->debug(
-                message: '[MagicRbacHandler] CLI/system context — bypassing RBAC filter',
-                context: ['file' => __FILE__, 'line' => __LINE__]
-            );
             return;
         }
 

--- a/lib/Db/MagicMapper/MagicStatisticsHandler.php
+++ b/lib/Db/MagicMapper/MagicStatisticsHandler.php
@@ -718,25 +718,9 @@ class MagicStatisticsHandler
                 $objectEntity->$method($value);
                 // Debug critical fields.
                 if (in_array($field, ['id', 'uuid', 'owner'], true) === true) {
-                    $this->logger->debug(
-                        message: '[MagicStatisticsHandler] Set critical metadata field',
-                        context: ['file' => __FILE__, 'line' => __LINE__, 'field' => $field, 'value' => $value]
-                    );
                 }
             }//end foreach
 
-            // Verify entity state after setting metadata.
-            $this->logger->debug(
-                message: '[MagicStatisticsHandler] Entity state after metadata',
-                context: [
-                    'file'        => __FILE__,
-                    'line'        => __LINE__,
-                    'entityId'    => $objectEntity->getId(),
-                    'entityUuid'  => $objectEntity->getUuid(),
-                    'entityOwner' => $objectEntity->getOwner(),
-                ]
-            );
-            // End foreach.
             // Set object data.
             $objectEntity->setObject($objectData);
 
@@ -752,20 +736,6 @@ class MagicStatisticsHandler
             if (isset($metadata['uuid']) === true && $metadata['uuid'] !== null) {
                 $objectEntity->setUuid($metadata['uuid']);
             }
-
-            // Debug logging.
-            $this->logger->debug(
-                message: '[MagicStatisticsHandler] Successfully converted row to ObjectEntity',
-                context: [
-                    'file'           => __FILE__,
-                    'line'           => __LINE__,
-                    'uuid'           => $metadata['uuid'] ?? 'unknown',
-                    'register'       => $metadata['register'] ?? 'missing',
-                    'schema'         => $metadata['schema'] ?? 'missing',
-                    'objectDataKeys' => array_keys($objectData),
-                    'metadataCount'  => count($metadata),
-                ]
-            );
 
             return $objectEntity;
         } catch (Exception $e) {

--- a/lib/Db/MagicMapper/MagicTableHandler.php
+++ b/lib/Db/MagicMapper/MagicTableHandler.php
@@ -215,15 +215,6 @@ class MagicTableHandler
 
             if (empty($missingColumns) === true && empty($retypeColumns) === true) {
                 MagicMapper::setTableColumnsVerified(cacheKey: $cacheKey);
-                $this->logger->debug(
-                    message: '[MagicTableHandler] Table exists and schema unchanged, skipping',
-                    context: [
-                        'file'      => __FILE__,
-                        'line'      => __LINE__,
-                        'tableName' => $tableName,
-                        'cacheKey'  => $cacheKey,
-                    ]
-                );
                 return true;
             }
 
@@ -298,17 +289,6 @@ class MagicTableHandler
         $cachedTime = MagicMapper::getTableExistsCache(key: $cacheKey);
         if ($cachedTime !== null) {
             if ((time() - $cachedTime) < MagicMapper::TABLE_CACHE_TIMEOUT) {
-                $this->logger->debug(
-                    message: '[MagicTableHandler] Table existence check: cache hit',
-                    context: [
-                        'file'       => __FILE__,
-                        'line'       => __LINE__,
-                        'registerId' => $registerId,
-                        'schemaId'   => $schemaId,
-                        'cacheKey'   => $cacheKey,
-                        'exists'     => true,
-                    ]
-                );
                 return true;
             }
 
@@ -323,33 +303,7 @@ class MagicTableHandler
         if ($exists === true) {
             // Cache positive result.
             MagicMapper::setTableExistsCache(key: $cacheKey, value: time());
-
-            $this->logger->debug(
-                message: '[MagicTableHandler] Table existence check: database hit - exists',
-                context: [
-                    'file'       => __FILE__,
-                    'line'       => __LINE__,
-                    'registerId' => $registerId,
-                    'schemaId'   => $schemaId,
-                    'tableName'  => $tableName,
-                    'cacheKey'   => $cacheKey,
-                ]
-            );
         }
-
-        if ($exists === false) {
-            $this->logger->debug(
-                message: '[MagicTableHandler] Table existence check: database hit - not exists',
-                context: [
-                    'file'       => __FILE__,
-                    'line'       => __LINE__,
-                    'registerId' => $registerId,
-                    'schemaId'   => $schemaId,
-                    'tableName'  => $tableName,
-                    'cacheKey'   => $cacheKey,
-                ]
-            );
-        }//end if
 
         return $exists;
     }//end existsTableForRegisterSchema()


### PR DESCRIPTION
Second half of the runaway-log fix (#2320 was the first).

Removing the two calls from `isFileProperty()` cut the log rate from ~1 GB/min to ~0.7 GB/min — still enough to fill a disk mid-upgrade, because four more handlers log on **every query**.

Sampled from a live log, the top writers were:

| handler | line | frequency |
|---|---|---|
| MagicStatisticsHandler | "Set critical metadata field" | per field, per row |
| MagicTableHandler | "Table existence check: cache hit" | per query |
| MagicRbacHandler | "CLI/system context — bypassing RBAC filter" | per query, on every background job's path |
| MagicOrganizationHandler | "CLI/system context — skipping org filter" | per query |

**The rule applied:** a debug log that fires *unconditionally* on a hot path tells you nothing a single trace would not, while costing a line per call forever. A log that fires on an *unusual branch* is a real signal.

Removed: cache hit, cache miss, CLI-context bypass, admin bypass, filter applied, org lookups returned, row converted, metadata field set, entity state.

**Kept** — every one rare, every one about a decision that matters:
- `Authorization unresolvable; clamping query to deny-all (fail-closed)`
- `Action not configured on a non-empty authorization block — failing closed`
- `No access conditions met, denying all`
- `Array operand for a scalar comparison operator — emitting an impossible predicate`
- `Could not determine the database platform — defaulting to MariaDB syntax`

Nothing about RBAC or organisation **enforcement** changes; only whether the handler narrates itself on paths where the answer was never in doubt.

phpcs and phpmd clean on `lib/Db/MagicMapper`; 1358 Db tests, 4308 assertions.