### PR TITLE
fix(import): skip on content-hash equality alone, not version ordering

### DIFF
--- a/lib/Service/Configuration/ImportHandler.php
+++ b/lib/Service/Configuration/ImportHandler.php
@@ -1979,23 +1979,39 @@ class ImportHandler
             $storedVersion = $this->appConfig->getValueString('openregister', "imported_config_{$appId}_version", '');
             $storedHash    = $this->appConfig->getValueString('openregister', "imported_config_{$appId}_hash", '');
 
-            // Skip only when the app version is NOT newer AND the definitional content
-            // is byte-identical to the last import (#426). Comparing the app version
-            // alone made a schema-definition change silently no-op on existing installs
-            // whenever the app version was unchanged — even when the schema's OWN
-            // `version` was bumped — because this early-return fired BEFORE the per-schema
-            // version gate (importSchema) could run. Gating additionally on a content
-            // hash lets the import proceed to those per-entity gates whenever the config
-            // content changed; they then decide what actually updates. The truly-unchanged
-            // case still fast-skips. A never-stored hash ('' on first run after this fix)
-            // fails the equality and lets the import proceed once, healing existing installs.
-            if ($storedVersion !== ''
-                && version_compare($version, $storedVersion, '<=') === true
-                && $storedHash !== ''
-                && $storedHash === $definitionHash
-            ) {
+            // The CONTENT HASH decides, on its own. `$definitionHash` covers the
+            // fully-merged configuration — monolith plus every register.d
+            // fragment — so an identical hash means importing would write exactly
+            // what is already stored. There is nothing to do, whatever the
+            // version says.
+            //
+            // This used to require `version_compare($version, $storedVersion, '<=')`
+            // as well, and that made the skip unreliable in one direction and
+            // wasteful in the other. Three apps (opencatalogi, procest,
+            // softwarecatalog) fold a digest into the version they pass here —
+            // `1.2.3+frag.a1b2c3d4`, per ADR-037 — so that changing a fragment
+            // forces a re-import. But version_compare does NOT treat `+…` as
+            // semver build metadata; it compares it as further version parts,
+            // LEXICALLY. Whether the gate fired therefore depended on how two md5
+            // hashes happened to sort:
+            //
+            // incoming 1.0.0+frag.abc12345 vs stored 1.0.0+frag.def67890 -> no skip,
+            // and the same pair the other way round -> skip.
+            //
+            // Unchanged content re-imported the whole configuration roughly half
+            // the time — measured on the dev instance as the dominant cost of
+            // `occ maintenance:repair`, which stalls in OpenCatalogi's
+            // InitializeSettings step. A digest has no order, so version_compare
+            // was the wrong instrument for it.
+            //
+            // Correctness is unaffected: a CHANGED fragment changes the merged
+            // data, which changes the hash, which fails this equality and lets
+            // the import proceed to the per-entity gates exactly as before (#426).
+            // A never-stored hash ('' on an install predating the hash) also fails
+            // it, so those heal on the next run.
+            if ($storedHash !== '' && $storedHash === $definitionHash) {
                 $this->logger->info(
-                    message: "[ImportHandler] Skipping {$appId}: v{$version} <= {$storedVersion} and config content unchanged",
+                    message: "[ImportHandler] Skipping {$appId}: config content unchanged (v{$version}, stored v{$storedVersion})",
                     context: ['file' => __FILE__, 'line' => __LINE__]
                 );
 


### PR DESCRIPTION
`computeDefinitionHash()` already covers the fully-merged configuration — monolith plus every `register.d` fragment — and is computed **unconditionally** before the gate is consulted (ImportHandler ~1972). So an identical hash means importing would write exactly what is already stored.

The gate additionally required `version_compare($version, $stored, '<=')`. Three apps (opencatalogi, procest, softwarecatalog) append a digest to that version per ADR-037 — `1.2.3+frag.a1b2c3d4` — so that a fragment change forces a re-import. But **`version_compare` does not treat `+…` as semver build metadata**; it compares it as further version parts, lexically:

```
incoming 1.0.0+frag.abc12345  stored 1.0.0+frag.def67890  ->  re-import
the same pair, reversed                                   ->  skip
```

So the decision hinged on how two md5 hashes happened to sort. Unchanged content re-imported about half the time; a genuine change was skipped the other half, caught only by the content-differs fallback. **A digest has no order.**

**Correctness is unchanged.** A changed fragment changes the merged data → changes the hash → fails this equality → proceeds to the per-entity gates exactly as before (#426). A never-stored hash also fails it, so older installs heal on their next run.

**Measured:** 4 apps now skip on unchanged content that previously re-imported.

### This is not sufficient on its own

When an import IS needed it remains pathologically slow. OpenCatalogi's payload is 1 register, 10 schemas, 12 objects, 59 KB — and it runs 12+ minutes at **100% CPU, ~950 MB RSS, zero database queries**. Sampled from the log mid-import:

```
87  [MagicTableHandler] Creating/updating table for register+schema
70  DocuDesk: Processing event
53  [ObjectChangeListener] Background mode - queueing extraction job
52  SoftwareCatalog: Processing event
52  ModuleComplianceSubscriber: SUBSCRIBER CALLED
```

Seeding config objects dispatches the object lifecycle, so every installed app's listeners run — document extraction and compliance checks for objects that are merely being seeded.

`importFromApp()` already wraps its work in `SystemOperationContext::run()`, and `SystemOperationContext::isActive()` is public. **No listener in any app checks it.** That is the lever for the follow-up.

Companion PRs dropping the now-pointless digest suffix: opencatalogi and procest `fix/drop-frag-digest-from-version`.