### PR TITLE
fix(audit): audit rows live as long as the object, and a purge no longer looks like tampering (#2265)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -40,7 +40,7 @@ Open Register drijft apps zoals OpenCatalogi, Procest, Pipelinq en Software Cata
 
 Vrij en open source onder de EUPL-licentie.
     ]]></description>
-    <version>0.2.17-unstable.23</version>
+    <version>0.2.17-unstable.24</version>
     <licence>EUPL-1.2</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>OpenRegister</namespace>

--- a/lib/Cron/LogCleanUpTask.php
+++ b/lib/Cron/LogCleanUpTask.php
@@ -101,13 +101,17 @@ class LogCleanUpTask extends TimedJob
     protected function run($argument): void
     {
         try {
-            // Attempt to clear expired logs.
+            // Tombstone expired audit rows. Since or#2265 this destroys the
+            // payload and stamps `purged_at` rather than deleting the row, so
+            // the hash chain stays verifiable across a lawful purge, and
+            // `expires` now follows the RETENTION OF THE OBJECT the row
+            // describes rather than a flat 30 days.
             $logsCleared = $this->auditTrailMapper->clearLogs();
 
             // Log the result for monitoring purposes.
             if ($logsCleared === true) {
                 $this->logger->info(
-                    message: '[LogCleanUpTask] Successfully cleared expired audit trail logs',
+                    message: '[LogCleanUpTask] Tombstoned expired audit trail rows (payload purged, chain preserved)',
                     context: [
                         'file' => __FILE__,
                         'line' => __LINE__,

--- a/lib/Db/AuditTrail.php
+++ b/lib/Db/AuditTrail.php
@@ -70,6 +70,10 @@ use OCP\AppFramework\Db\Entity;
  * @method void setHash(?string $hash)
  * @method string|null getPreviousHash()
  * @method void setPreviousHash(?string $previousHash)
+ * @method DateTime|null getPurgedAt()
+ * @method void setPurgedAt(?DateTime $purgedAt)
+ * @method string|null getRetentionPeriod()
+ * @method void setRetentionPeriod(?string $retentionPeriod)
  * @method string|null getToolId()
  * @method void setToolId(?string $toolId)
  * @method string|null getParamsDigest()
@@ -288,6 +292,30 @@ class AuditTrail extends Entity implements JsonSerializable
     protected ?string $previousHash = null;
 
     /**
+     * When this row's payload was purged, leaving a chain tombstone.
+     *
+     * Retention purges used to HARD-delete rows. Because the chain is walked
+     * in id order and each hash covers the previous row's hash, removing a row
+     * mid-chain makes the next row fail verification — so a lawful purge and a
+     * tampering event produced the identical symptom (or#2265).
+     *
+     * A purge now blanks the payload columns and stamps this timestamp,
+     * keeping the row's `id`, `created`, `hash` and `previousHash`. The link
+     * survives, and {@see \OCA\OpenRegister\Service\AuditHashService::verifyChain()}
+     * can report the row as a declared tombstone rather than as a break.
+     *
+     * ⚠️ Deliberately ABSENT from {@see self::jsonSerialize()}, which is what
+     * `getCanonicalJson()` hashes. Adding a key to the canonical form would
+     * change the hash of every row ever written and invalidate the entire
+     * existing chain. The consequence is that this field is not itself
+     * covered by the hash — see the residual-limitation note on
+     * `verifyChain()`.
+     *
+     * @var DateTime|null Purge timestamp, or null while the row is intact.
+     */
+    protected ?DateTime $purgedAt = null;
+
+    /**
      * Import-job tag attached to every `create` audit row generated
      * during a bulk import. Powers the import-rollback contract: when
      * a critical failure (or an explicit rollback request) hits, every
@@ -374,7 +402,18 @@ class AuditTrail extends Entity implements JsonSerializable
         $this->addType(fieldName: 'toolId', type: 'string');
         $this->addType(fieldName: 'paramsDigest', type: 'string');
         $this->addType(fieldName: 'resultSummary', type: 'json');
+        $this->addType(fieldName: 'purgedAt', type: 'datetime');
     }//end __construct()
+
+    /**
+     * Whether this row is a purge tombstone rather than an intact audit record.
+     *
+     * @return bool True when the payload has been purged under a retention policy.
+     */
+    public function isPurged(): bool
+    {
+        return $this->purgedAt !== null;
+    }//end isPurged()
 
     /**
      * Get the changed data

--- a/lib/Db/AuditTrailMapper.php
+++ b/lib/Db/AuditTrailMapper.php
@@ -608,6 +608,8 @@ class AuditTrailMapper extends QBMapper
      * @param \DateTime    $createdAt    The audit row's creation instant.
      *
      * @return array{expires: \DateTime|null, source: string|null}
+     *
+     * @SuppressWarnings(PHPMD.StaticAccess) DateTime::createFromInterface is the standard immutable-to-mutable bridge
      */
     private function resolveAuditExpiry(ObjectEntity $objectEntity, \DateTime $createdAt): array
     {

--- a/lib/Db/AuditTrailMapper.php
+++ b/lib/Db/AuditTrailMapper.php
@@ -567,11 +567,83 @@ class AuditTrailMapper extends QBMapper
         $serializedSize = strlen(serialize($objectEntity->jsonSerialize()));
         $auditTrail->setSize(max($serializedSize, 14));
 
-        // Set default expiration date (30 days from now).
-        $auditTrail->setExpires(new DateTime('+30 days'));
+        // Expiry follows the RETENTION OF THE OBJECT the row describes, not a
+        // flat window (or#2265). The unconditional `+30 days` that stood here
+        // destroyed the evidence of a retention decision long before the
+        // decision expired: on the procest case register 311 of 330
+        // soft-deleted cases had lost their delete audit row, and all 258,240
+        // rows carrying an expiry carried exactly a 30-day one.
+        //
+        // `null` means retain indefinitely — clearLogs() has always filtered on
+        // `expires IS NOT NULL` — and is the resolver's outcome for an object
+        // with no retention policy, under legal hold, or nominated `bewaren` /
+        // `nog_niet_bepaald`. The 30-day constant survives inside the resolver
+        // as a FLOOR rather than a ceiling. See AuditRetentionResolver.
+        //
+        // The resolved source token is stamped into `retentionPeriod` so a
+        // future purge is explainable from the row itself. Both fields are set
+        // BEFORE the row is sealed: `expires` is part of the canonical JSON the
+        // hash covers, so writing it after sealing would invalidate the hash.
+        $resolvedRetention = $this->resolveAuditExpiry(
+            objectEntity: $objectEntity,
+            createdAt: ($auditTrail->getCreated() ?? new DateTime())
+        );
+        $auditTrail->setExpires($resolvedRetention['expires']);
+        $auditTrail->setRetentionPeriod($resolvedRetention['source']);
 
         return $auditTrail;
     }//end buildAuditTrail()
+
+    /**
+     * Resolve the audit row's expiry from the object's retention policy.
+     *
+     * Delegates to {@see AuditRetentionResolver}, resolved lazily through the
+     * container for the same reason the sibling AVG and hash-chain lookups are:
+     * this runs inside the audit write path and must degrade rather than break
+     * it. Fail-safe direction matters here — when the resolver is unavailable
+     * the row is retained INDEFINITELY rather than given a short life, because
+     * the failure mode being fixed is evidence disappearing, not disk filling.
+     *
+     * @param ObjectEntity $objectEntity The object the audit row describes.
+     * @param \DateTime    $createdAt    The audit row's creation instant.
+     *
+     * @return array{expires: \DateTime|null, source: string|null}
+     */
+    private function resolveAuditExpiry(ObjectEntity $objectEntity, \DateTime $createdAt): array
+    {
+        try {
+            $resolver = $this->container->get(\OCA\OpenRegister\Service\AuditRetentionResolver::class);
+
+            $resolved = $resolver->resolve(object: $objectEntity, createdAt: $createdAt);
+
+            // The resolver works in DateTimeImmutable; the entity's `expires`
+            // setter is typed to the mutable DateTime that QBMapper binds.
+            $expires = $resolved['expires'];
+            if ($expires !== null) {
+                $expires = DateTime::createFromInterface($expires);
+            }
+
+            return [
+                'expires' => $expires,
+                'source'  => $resolved['source'],
+            ];
+        } catch (\Throwable $e) {
+            $this->logger->warning(
+                message: '[AuditTrailMapper] Retention resolution failed; retaining the audit row '
+                    .'indefinitely: '.$e->getMessage(),
+                context: [
+                    'app'       => 'openregister',
+                    'exception' => $e,
+                ]
+            );
+
+            return [
+                'expires' => null,
+                'source'  => 'resolver-unavailable:indefinite',
+            ];
+        }//end try
+
+    }//end resolveAuditExpiry()
 
     /**
      * Create audit trail rows for many object changes with batched inserts.
@@ -1581,14 +1653,31 @@ class AuditTrailMapper extends QBMapper
     }//end getMostActiveObjects()
 
     /**
-     * Clear expired logs from the database
+     * Purge expired audit rows, leaving a verifiable chain tombstone.
      *
-     * This method deletes all audit trail logs that have expired
-     * (i.e., their 'expires' date is earlier than the current date and time)
-     * and have the 'expires' column set. This helps maintain database performance
-     * by removing old log entries that are no longer needed.
+     * Rows whose `expires` has passed have their PAYLOAD destroyed — the
+     * `changed` diff and the actor/session/network identifiers — and are
+     * stamped with `purged_at`. The row itself survives.
      *
-     * @return bool True if any logs were deleted, false otherwise
+     * It is an UPDATE, not a DELETE, and that is the whole point. The table
+     * carries a SHA-256 `hash`/`previous_hash` chain that
+     * {@see \OCA\OpenRegister\Service\AuditHashService::verifyChain()} walks in
+     * id order, each row's hash covering the previous row's hash. Physically
+     * removing a row mid-chain therefore breaks verification at the row AFTER
+     * it — which is exactly what tampering looks like. Under the old hard
+     * delete a lawful retention purge and an attack were indistinguishable
+     * (or#2265). Keeping id, `created`, `hash` and `previous_hash` preserves
+     * the link, and the `purged_at` stamp lets verification report a DECLARED
+     * tombstone instead of a break.
+     *
+     * `expires IS NULL` still means "never purge" and is now the resolver's
+     * outcome for objects with no retention policy, under legal hold, or
+     * nominated `bewaren` — see {@see \OCA\OpenRegister\Service\AuditRetentionResolver}.
+     *
+     * Already-tombstoned rows are excluded so repeated sweeps are idempotent
+     * and do not keep rewriting the same rows every hour.
+     *
+     * @return bool True if any rows were tombstoned, false otherwise
      *
      * @throws \Exception Database operation exceptions
      *
@@ -1601,15 +1690,28 @@ class AuditTrailMapper extends QBMapper
             // Get the query builder for database operations.
             $qb = $this->db->getQueryBuilder();
 
-            // Build the delete query to remove expired audit trail logs that have the 'expires' column set.
-            $qb->delete('openregister_audit_trails')
+            // Tombstone rather than delete: destroy the payload, keep the row
+            // and its chain links. `changed` holds the actual before/after
+            // data; user/session/request/ip are the personal identifiers a
+            // retention purge is meant to remove. Everything retained here is
+            // structural: which register/schema/object was acted on, when, and
+            // the hash pair that proves the row was not substituted.
+            $qb->update('openregister_audit_trails')
+                ->set('purged_at', $qb->createFunction('NOW()'))
+                ->set('changed', $qb->createNamedParameter(null))
+                ->set('user', $qb->createNamedParameter(null))
+                ->set('user_name', $qb->createNamedParameter(null))
+                ->set('session', $qb->createNamedParameter(null))
+                ->set('request', $qb->createNamedParameter(null))
+                ->set('ip_address', $qb->createNamedParameter(null))
                 ->where($qb->expr()->isNotNull('expires'))
-                ->andWhere($qb->expr()->lt('expires', $qb->createFunction('NOW()')));
+                ->andWhere($qb->expr()->lt('expires', $qb->createFunction('NOW()')))
+                ->andWhere($qb->expr()->isNull('purged_at'));
 
             // Execute the query and get the number of affected rows.
             $result = $qb->executeStatement();
 
-            // Return true if any rows were affected (i.e., any logs were deleted).
+            // Return true if any rows were affected (i.e., any logs were tombstoned).
             return $result > 0;
         } catch (\Exception $e) {
             // Log the error for debugging purposes.

--- a/lib/Migration/Version1Date20260805000000.php
+++ b/lib/Migration/Version1Date20260805000000.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * Adds the `purged_at` tombstone column to the audit-trail table.
+ *
+ * Retention purges used to HARD-delete audit rows. The table carries a
+ * `hash`/`previous_hash` SHA-256 chain walked in id order, so removing a row
+ * mid-chain makes the FOLLOWING row fail verification — a lawful purge and a
+ * tampering event produced the identical symptom, which is a forensic hole in
+ * a system holding Dutch legal-retention data (or#2265).
+ *
+ * With this column a purge blanks the payload and stamps a timestamp instead
+ * of deleting the row, so the chain link survives and `verifyChain()` can
+ * report a declared tombstone rather than a break.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Adds `purged_at` to `openregister_audit_trails`.
+ */
+class Version1Date20260805000000 extends SimpleMigrationStep
+{
+    /**
+     * Add the nullable `purged_at` column and an index for the purge sweep.
+     *
+     * Nullable with no default: `NULL` means "intact row", which is what every
+     * existing row is. No backfill is possible or wanted — rows purged before
+     * this migration were physically deleted and cannot be reconstructed.
+     *
+     * @param IOutput $output        Migration output.
+     * @param Closure $schemaClosure Schema closure returning an ISchemaWrapper.
+     * @param array   $options       Migration options.
+     *
+     * @return ISchemaWrapper|null The modified schema, or null when unchanged.
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
+    {
+        /*
+         * @var ISchemaWrapper $schema
+         */
+
+        $schema = $schemaClosure();
+
+        if ($schema->hasTable('openregister_audit_trails') === false) {
+            $output->info('openregister_audit_trails does not exist yet; nothing to alter.');
+            return null;
+        }
+
+        $table   = $schema->getTable('openregister_audit_trails');
+        $changed = false;
+
+        if ($table->hasColumn('purged_at') === false) {
+            $table->addColumn(
+                'purged_at',
+                Types::DATETIME,
+                [
+                    'notnull' => false,
+                    'default' => null,
+                ]
+            );
+            $changed = true;
+            $output->info('Added openregister_audit_trails.purged_at (retention tombstone marker).');
+        }
+
+        // The purge sweep and the "is this chain clean?" report both filter on
+        // this column across a table that is now expected to grow for years.
+        if ($table->hasIndex('or_audit_purged_at_idx') === false) {
+            $table->addIndex(['purged_at'], 'or_audit_purged_at_idx');
+            $changed = true;
+        }
+
+        if ($changed === false) {
+            return null;
+        }
+
+        return $schema;
+
+    }//end changeSchema()
+}//end class

--- a/lib/Service/AuditHashService.php
+++ b/lib/Service/AuditHashService.php
@@ -467,6 +467,33 @@ class AuditHashService
      * Iterates audit trail entries in order and validates that each entry's
      * stored hash matches the recomputed hash.
      *
+     * ## Retention tombstones
+     *
+     * A row purged under a retention policy keeps its `id`, `created`, `hash`
+     * and `previous_hash` and is stamped with `purged_at`; its payload is
+     * blanked (see {@see \OCA\OpenRegister\Db\AuditTrailMapper::clearLogs()}).
+     * Its content therefore no longer re-hashes to the stored value, but the
+     * stored value is still the link the NEXT row committed to — so the chain
+     * is carried forward across it and the row is counted as a declared
+     * tombstone rather than reported as a break.
+     *
+     * This is what makes a lawful purge distinguishable from tampering. Before
+     * tombstoning, a purge physically removed the row and verification failed
+     * at the row AFTER it, producing exactly the symptom an attacker would
+     * (or#2265): the audit trail could not tell the two apart.
+     *
+     * ⚠️ RESIDUAL LIMITATION, stated plainly: `purgedAt` is deliberately not
+     * part of the canonical JSON, because adding any key to it would change
+     * the hash of every row ever written and invalidate the whole existing
+     * chain. So the flag itself is not hash-protected: an attacker with direct
+     * table write access could set `purged_at` and blank a row's payload to
+     * suppress a record without breaking verification. That is strictly
+     * weaker and strictly more VISIBLE than the previous situation — the row,
+     * its timestamp and its position all remain, and `purgedTombstones` is
+     * reported and countable — but it is not cryptographic proof that a
+     * tombstone was lawful. Binding the flag into the hash requires a chain
+     * re-seal and is tracked separately.
+     *
      * @param int|null $from Start entry ID (inclusive), null for beginning
      * @param int|null $to   End entry ID (inclusive), null for end
      *
@@ -475,6 +502,7 @@ class AuditHashService
      *     entriesVerified: int,
      *     brokenAt: int|null,
      *     skippedNullHashes: int,
+     *     purgedTombstones: int,
      *     range?: array{from: int, to: int}
      * }
      *
@@ -508,6 +536,7 @@ class AuditHashService
 
         $entriesVerified   = 0;
         $skippedNullHashes = 0;
+        $purgedTombstones  = 0;
         $previousHash      = null;
 
         // If starting from a specific ID, get the previous entry's hash.
@@ -521,6 +550,17 @@ class AuditHashService
             // Skip entries without hashes (pre-migration entries).
             if ($storedHash === null || $storedHash === '') {
                 $skippedNullHashes++;
+                continue;
+            }
+
+            // A retention tombstone: the payload was lawfully destroyed, so it
+            // cannot re-hash, but its stored hash is still the link the next
+            // row committed to. Carry it forward and count it. Reporting this
+            // as a break would recreate the exact ambiguity the tombstone
+            // exists to remove.
+            if (($row['purged_at'] ?? null) !== null) {
+                $purgedTombstones++;
+                $previousHash = $storedHash;
                 continue;
             }
 
@@ -542,6 +582,7 @@ class AuditHashService
                     'entriesVerified'   => $entriesVerified,
                     'brokenAt'          => (int) $row['id'],
                     'skippedNullHashes' => $skippedNullHashes,
+                    'purgedTombstones'  => $purgedTombstones,
                 ];
 
                 if ($from !== null || $to !== null) {
@@ -565,6 +606,7 @@ class AuditHashService
             'entriesVerified'   => $entriesVerified,
             'brokenAt'          => null,
             'skippedNullHashes' => $skippedNullHashes,
+            'purgedTombstones'  => $purgedTombstones,
         ];
 
         if ($from !== null || $to !== null) {

--- a/lib/Service/AuditHashService.php
+++ b/lib/Service/AuditHashService.php
@@ -577,22 +577,14 @@ class AuditHashService
             if ($computedHash !== $storedHash) {
                 $result->closeCursor();
 
-                $response = [
-                    'valid'             => false,
-                    'entriesVerified'   => $entriesVerified,
-                    'brokenAt'          => (int) $row['id'],
-                    'skippedNullHashes' => $skippedNullHashes,
-                    'purgedTombstones'  => $purgedTombstones,
-                ];
-
-                if ($from !== null || $to !== null) {
-                    $response['range'] = [
-                        'from' => $from ?? (int) $row['id'],
-                        'to'   => $to ?? (int) $row['id'],
-                    ];
-                }
-
-                return $response;
+                return $this->buildChainReport(
+                    brokenAt: (int) $row['id'],
+                    entriesVerified: $entriesVerified,
+                    skippedNullHashes: $skippedNullHashes,
+                    purgedTombstones: $purgedTombstones,
+                    from: $from,
+                    to: $to
+                );
             }
 
             $previousHash = $storedHash;
@@ -601,23 +593,65 @@ class AuditHashService
 
         $result->closeCursor();
 
+        return $this->buildChainReport(
+            brokenAt: null,
+            entriesVerified: $entriesVerified,
+            skippedNullHashes: $skippedNullHashes,
+            purgedTombstones: $purgedTombstones,
+            from: $from,
+            to: $to
+        );
+    }//end verifyChain()
+
+    /**
+     * Assemble the verifyChain() result.
+     *
+     * Both exits of the walk return the same shape, differing only in whether
+     * `brokenAt` is set, so building it in one place keeps them from drifting
+     * apart — which for a tamper-evidence report would mean the "valid" and
+     * "broken" answers disagreeing about what they counted.
+     *
+     * @param int|null $brokenAt          Row id where verification failed, or null when the range is intact.
+     * @param int      $entriesVerified   Rows whose content re-hashed correctly.
+     * @param int      $skippedNullHashes Rows carrying no hash (pre-migration or fail-soft leftovers).
+     * @param int      $purgedTombstones  Rows lawfully purged under a retention policy.
+     * @param int|null $from              Requested range start, or null.
+     * @param int|null $to                Requested range end, or null.
+     *
+     * @return array{
+     *     valid: bool,
+     *     entriesVerified: int,
+     *     brokenAt: int|null,
+     *     skippedNullHashes: int,
+     *     purgedTombstones: int,
+     *     range?: array{from: int|null, to: int|null}
+     * }
+     */
+    private function buildChainReport(
+        ?int $brokenAt,
+        int $entriesVerified,
+        int $skippedNullHashes,
+        int $purgedTombstones,
+        ?int $from,
+        ?int $to
+    ): array {
         $response = [
-            'valid'             => true,
+            'valid'             => ($brokenAt === null),
             'entriesVerified'   => $entriesVerified,
-            'brokenAt'          => null,
+            'brokenAt'          => $brokenAt,
             'skippedNullHashes' => $skippedNullHashes,
             'purgedTombstones'  => $purgedTombstones,
         ];
 
         if ($from !== null || $to !== null) {
             $response['range'] = [
-                'from' => $from,
-                'to'   => $to,
+                'from' => ($from ?? $brokenAt),
+                'to'   => ($to ?? $brokenAt),
             ];
         }
 
         return $response;
-    }//end verifyChain()
+    }//end buildChainReport()
 
     /**
      * Get the hash of the nearest SEALED entry before the given ID.

--- a/lib/Service/AuditRetentionResolver.php
+++ b/lib/Service/AuditRetentionResolver.php
@@ -1,0 +1,403 @@
+<?php
+
+/**
+ * OpenRegister AuditRetentionResolver
+ *
+ * Derives the lifetime of an audit-trail row from the retention of the OBJECT
+ * the row describes, replacing the unconditional `+30 days` that used to be
+ * stamped on every row (or#2265).
+ *
+ * The old behaviour destroyed the evidence of a retention decision long before
+ * the decision itself expired: on the procest case register, 311 of 330
+ * soft-deleted cases had no surviving delete audit row, and every one of the
+ * 258,240 rows carrying an expiry carried exactly a 30-day one. An audit trail
+ * for a record kept 20 years under the Archiefwet cannot itself live 30 days.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeInterface;
+use OCA\OpenRegister\Db\ObjectEntity;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Resolves the `expires` instant for an audit-trail row from the retention
+ * policy of the object it describes.
+ *
+ * ## Policy
+ *
+ * The resolution order is most-specific-first. Every branch also records a
+ * short machine-readable *source* token, which the caller stamps into the
+ * row's `retention_period` column so that any future purge can be explained
+ * from the row itself rather than from the code that happened to be deployed
+ * on the day it was written.
+ *
+ * 1. `retention.legalHold.active === true` — INDEFINITE. A legal hold exists
+ *    precisely to stop destruction; destroying the audit trail underneath one
+ *    is the same defect one level down.
+ * 2. `retention.archiefnominatie === 'bewaren'` — INDEFINITE. `bewaren` means
+ *    permanent preservation with eventual transfer to an e-depot; the
+ *    `archiefactiedatum` on such an object is the TRANSFER date, not a
+ *    destruction date, so it must not be read as an expiry.
+ * 3. `retention.archiefnominatie === 'nog_niet_bepaald'` — INDEFINITE. A
+ *    record whose retention has not been determined cannot be destroyed, and
+ *    neither can its audit trail. "Undetermined" must fail towards keeping.
+ * 4. `retention.archiefactiedatum` — the object's own destruction date. Used
+ *    verbatim (subject to the floor below).
+ * 5. `retention.bewaartermijn` — an ISO-8601 duration on the object, added to
+ *    the audit row's creation instant.
+ * 6. The schema's `archive` block — `bewaartermijnOverride`, else
+ *    `defaultBewaartermijn`, added to the row's creation instant.
+ * 7. The schema's `x-openregister-archival` annotation — `retention.default`,
+ *    added to the row's creation instant. This is the same annotation
+ *    {@see \OCA\OpenRegister\Service\Archival\RetentionEvaluator} uses for
+ *    row-level archival, so the audit row inherits the same horizon as the
+ *    data it describes.
+ * 8. Nothing configured — INDEFINITE.
+ *
+ * ## The default for objects with no retention policy
+ *
+ * Branch 8 returns `null`, and `null` in the `expires` column already means
+ * "never purge": {@see \OCA\OpenRegister\Db\AuditTrailMapper::clearLogs()}
+ * has always filtered on `expires IS NOT NULL`. That is a deliberate choice
+ * and the reason it is safe: for a system holding Dutch government retention
+ * data, silently discarding evidence is a worse failure than storing too much,
+ * and any finite default re-creates or#2265 at a different horizon. The cost is
+ * that the table now grows until a retention policy is configured — see the
+ * storage note on the pull request. It is a bounded, visible, fixable cost;
+ * destroyed evidence is none of those things.
+ *
+ * ## The floor
+ *
+ * {@see self::MINIMUM_LIFETIME} (30 days) is applied as a FLOOR, never a
+ * ceiling. Without it an object already past its `archiefactiedatum` would
+ * have the audit row describing the action just taken purged by the next
+ * hourly cron run — the row would be born expired. The old constant survives
+ * here with its sign reversed: it used to be the longest an audit row could
+ * live, and is now the shortest.
+ */
+class AuditRetentionResolver
+{
+
+    /**
+     * Shortest lifetime any audit row may be given.
+     *
+     * Applied as a floor to every finite outcome. See the class docblock:
+     * an object already past its destruction date would otherwise produce
+     * audit rows that are expired the moment they are written.
+     *
+     * @var string
+     */
+    public const MINIMUM_LIFETIME = 'P30D';
+
+    /**
+     * Source token stamped on rows that are retained indefinitely because the
+     * object carries no retention policy at all.
+     *
+     * @var string
+     */
+    public const SOURCE_NO_POLICY = 'no-retention-policy:indefinite';
+
+    /**
+     * Container used to lazily resolve the schema mapper.
+     *
+     * Lazy on purpose: this resolver runs inside the audit write path, which
+     * is itself reached from mappers. Constructor-injecting SchemaMapper here
+     * risks a resolution cycle, and a schema that cannot be loaded must
+     * degrade to "no policy" rather than break the write.
+     *
+     * @var ContainerInterface
+     */
+    private ContainerInterface $container;
+
+    /**
+     * Logger for unparseable durations and unloadable schemas.
+     *
+     * @var LoggerInterface
+     */
+    private LoggerInterface $logger;
+
+    /**
+     * Constructor.
+     *
+     * @param ContainerInterface $container Service container for lazy schema lookups.
+     * @param LoggerInterface    $logger    Logger for malformed retention configuration.
+     */
+    public function __construct(ContainerInterface $container, LoggerInterface $logger)
+    {
+        $this->container = $container;
+        $this->logger    = $logger;
+
+    }//end __construct()
+
+    /**
+     * Resolve the audit-row expiry for an object.
+     *
+     * @param ObjectEntity      $object    The object the audit row describes.
+     * @param DateTimeInterface $createdAt The audit row's creation instant.
+     *
+     * @return array{expires: \DateTimeImmutable|null, source: string} The
+     *         resolved expiry (null meaning "retain indefinitely") and the
+     *         machine-readable token explaining which branch produced it.
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @SuppressWarnings(PHPMD.NPathComplexity)
+     */
+    public function resolve(ObjectEntity $object, DateTimeInterface $createdAt): array
+    {
+        // Defensive: the column is JSON, so a malformed row can yield a
+        // non-array. Absent or unreadable retention must mean "no policy"
+        // (indefinite), never a short default.
+        $retention = $object->getRetention();
+        if (is_array($retention) === false) {
+            $retention = [];
+        }
+
+        // 1. Legal hold beats every other consideration.
+        $legalHold = ($retention['legalHold'] ?? null);
+        if (is_array($legalHold) === true && ($legalHold['active'] ?? false) === true) {
+            return [
+                'expires' => null,
+                'source'  => 'legal-hold:indefinite',
+            ];
+        }
+
+        // 2 + 3. Archival nomination that forbids destruction.
+        $nominatie = ($retention['archiefnominatie'] ?? null);
+        if ($nominatie === 'bewaren') {
+            return [
+                'expires' => null,
+                'source'  => 'archiefnominatie=bewaren:indefinite',
+            ];
+        }
+
+        if ($nominatie === 'nog_niet_bepaald') {
+            return [
+                'expires' => null,
+                'source'  => 'archiefnominatie=nog_niet_bepaald:indefinite',
+            ];
+        }
+
+        // 4. The object's own destruction date.
+        $actiedatum = ($retention['archiefactiedatum'] ?? null);
+        if (is_string($actiedatum) === true && $actiedatum !== '') {
+            $parsed = $this->parseDate(value: $actiedatum);
+            if ($parsed !== null) {
+                return $this->withFloor(
+                    expires: $parsed,
+                    createdAt: $createdAt,
+                    source: 'object.archiefactiedatum'
+                );
+            }
+        }
+
+        // 5. An ISO-8601 duration on the object.
+        $resolved = $this->fromDuration(
+            duration: ($retention['bewaartermijn'] ?? null),
+            createdAt: $createdAt,
+            source: 'object.bewaartermijn'
+        );
+        if ($resolved !== null) {
+            return $resolved;
+        }
+
+        // 6 + 7. Schema-level configuration.
+        return $this->fromSchema(object: $object, createdAt: $createdAt);
+
+    }//end resolve()
+
+    /**
+     * Resolve the expiry from the schema's archive block or archival annotation.
+     *
+     * @param ObjectEntity      $object    The object whose schema is consulted.
+     * @param DateTimeInterface $createdAt The audit row's creation instant.
+     *
+     * @return array{expires: \DateTimeImmutable|null, source: string}
+     */
+    private function fromSchema(ObjectEntity $object, DateTimeInterface $createdAt): array
+    {
+        $schema = $this->loadSchema(schemaId: $object->getSchema());
+        if ($schema === null) {
+            return [
+                'expires' => null,
+                'source'  => self::SOURCE_NO_POLICY,
+            ];
+        }
+
+        // 6. The `archive` block written by RetentionService::applyArchivalMetadata().
+        $archive = $schema->getArchive();
+        if (is_array($archive) === true) {
+            $resolved = $this->fromDuration(
+                duration: ($archive['bewaartermijnOverride'] ?? null),
+                createdAt: $createdAt,
+                source: 'schema.archive.bewaartermijnOverride'
+            );
+            if ($resolved !== null) {
+                return $resolved;
+            }
+
+            $resolved = $this->fromDuration(
+                duration: ($archive['defaultBewaartermijn'] ?? null),
+                createdAt: $createdAt,
+                source: 'schema.archive.defaultBewaartermijn'
+            );
+            if ($resolved !== null) {
+                return $resolved;
+            }
+        }
+
+        // 7. The `x-openregister-archival` annotation used by RetentionEvaluator.
+        $configuration = $schema->getConfiguration();
+        if (is_array($configuration) === true) {
+            $default  = ($configuration['x-openregister-archival']['retention']['default'] ?? null);
+            $resolved = $this->fromDuration(
+                duration: $default,
+                createdAt: $createdAt,
+                source: 'schema.x-openregister-archival.retention.default'
+            );
+            if ($resolved !== null) {
+                return $resolved;
+            }
+        }
+
+        // 8. No policy anywhere: retain indefinitely. See the class docblock.
+        return [
+            'expires' => null,
+            'source'  => self::SOURCE_NO_POLICY,
+        ];
+
+    }//end fromSchema()
+
+    /**
+     * Build a floored expiry from an ISO-8601 duration, or null when the value
+     * is absent or unparseable.
+     *
+     * @param mixed             $duration  Candidate ISO-8601 duration.
+     * @param DateTimeInterface $createdAt The audit row's creation instant.
+     * @param string            $source    Token identifying where the duration came from.
+     *
+     * @return array{expires: \DateTimeImmutable|null, source: string}|null
+     */
+    private function fromDuration($duration, DateTimeInterface $createdAt, string $source): ?array
+    {
+        if (is_string($duration) === false || $duration === '') {
+            return null;
+        }
+
+        try {
+            $interval = new DateInterval($duration);
+        } catch (Throwable $error) {
+            $this->logger->warning(
+                '[AuditRetentionResolver] Unparseable retention duration "'.$duration.'" from '.$source
+                .'; falling through to the next source.',
+                ['exception' => $error]
+            );
+            return null;
+        }
+
+        $expires = DateTimeImmutable::createFromInterface($createdAt)->add($interval);
+
+        return $this->withFloor(expires: $expires, createdAt: $createdAt, source: $source);
+
+    }//end fromDuration()
+
+    /**
+     * Apply {@see self::MINIMUM_LIFETIME} as a floor to a resolved expiry.
+     *
+     * @param DateTimeImmutable $expires   The candidate expiry.
+     * @param DateTimeInterface $createdAt The audit row's creation instant.
+     * @param string            $source    Token identifying the source branch.
+     *
+     * @return array{expires: \DateTimeImmutable, source: string} The floored
+     *         expiry; the source token gains a `+floor` suffix when the floor
+     *         actually bound, so the row records that it outlived its object.
+     *
+     * @SuppressWarnings(PHPMD.StaticAccess)
+     */
+    private function withFloor(DateTimeImmutable $expires, DateTimeInterface $createdAt, string $source): array
+    {
+        $floor = DateTimeImmutable::createFromInterface($createdAt)->add(new DateInterval(self::MINIMUM_LIFETIME));
+
+        if ($expires < $floor) {
+            return [
+                'expires' => $floor,
+                'source'  => $source.'+floor',
+            ];
+        }
+
+        return [
+            'expires' => $expires,
+            'source'  => $source,
+        ];
+
+    }//end withFloor()
+
+    /**
+     * Parse a date string from the retention metadata.
+     *
+     * @param string $value The candidate date string (ISO-8601 date or datetime).
+     *
+     * @return DateTimeImmutable|null The parsed instant, or null when unparseable.
+     */
+    private function parseDate(string $value): ?DateTimeImmutable
+    {
+        try {
+            return new DateTimeImmutable($value);
+        } catch (Throwable $error) {
+            $this->logger->warning(
+                '[AuditRetentionResolver] Unparseable archiefactiedatum "'.$value.'".',
+                ['exception' => $error]
+            );
+            return null;
+        }
+
+    }//end parseDate()
+
+    /**
+     * Load a schema by id, returning null when it cannot be resolved.
+     *
+     * RBAC and multitenancy are bypassed for the same reason the sibling
+     * `resolveProcessingActivityId()` bypasses them: this runs inside the
+     * audit writer, which is not a request-scoped read of the schema and must
+     * not depend on the acting user being able to see it.
+     *
+     * @param string|int|null $schemaId Schema identifier (numeric id or uuid).
+     *
+     * @return \OCA\OpenRegister\Db\Schema|null The schema, or null.
+     */
+    private function loadSchema($schemaId)
+    {
+        if ($schemaId === null || $schemaId === '' || $schemaId === 0) {
+            return null;
+        }
+
+        try {
+            $schemaMapper = $this->container->get(\OCA\OpenRegister\Db\SchemaMapper::class);
+
+            return $schemaMapper->find($schemaId, _rbac: false, _multitenancy: false);
+        } catch (Throwable $error) {
+            return null;
+        }
+
+    }//end loadSchema()
+}//end class

--- a/tests/Unit/Cron/LogCleanUpTaskTest.php
+++ b/tests/Unit/Cron/LogCleanUpTaskTest.php
@@ -74,10 +74,13 @@ class LogCleanUpTaskTest extends TestCase
             ->method('clearLogs')
             ->willReturn(true);
 
+        // Since or#2265 the sweep TOMBSTONES rather than deletes: the payload
+        // is destroyed but the row and its hash links survive, so the chain
+        // stays verifiable across a lawful purge. The log line says so.
         $this->logger->expects($this->once())
             ->method('info')
             ->with(
-                $this->stringContains('Successfully cleared expired audit trail logs'),
+                $this->stringContains('Tombstoned expired audit trail rows'),
                 $this->anything()
             );
 

--- a/tests/Unit/Db/AuditTrailMapperBulkInsertTest.php
+++ b/tests/Unit/Db/AuditTrailMapperBulkInsertTest.php
@@ -227,8 +227,16 @@ class AuditTrailMapperBulkInsertTest extends TestCase
         $this->assertSame('obj-1', $trails[1]->getObjectUuid());
         $this->assertSame('System', $trails[0]->getUser());
         $this->assertNotNull($trails[0]->getCreated());
-        $this->assertNotNull($trails[0]->getExpires());
         $this->assertGreaterThanOrEqual(14, $trails[0]->getSize());
+
+        // Expiry follows the OBJECT's retention (or#2265). These fixtures carry
+        // no retention metadata and the container in this test resolves nothing
+        // but AuditHashService, so the resolver is unavailable — both routes
+        // land on the same fail-SAFE outcome: retain indefinitely. `null` here
+        // is the assertion, not the absence of one: it used to be a hardcoded
+        // `+30 days` on every row regardless of the object.
+        $this->assertNull($trails[0]->getExpires());
+        $this->assertSame('resolver-unavailable:indefinite', $trails[0]->getRetentionPeriod());
 
         // Ids read back and sealed in one batch.
         $this->assertSame(100, $trails[0]->getId());

--- a/tests/Unit/Db/AuditTrailMapperBulkTest.php
+++ b/tests/Unit/Db/AuditTrailMapperBulkTest.php
@@ -138,7 +138,13 @@ class AuditTrailMapperBulkTest extends TestCase
         $this->assertSame([], $trail->getChanged());
         $this->assertNotNull($trail->getUuid());
         $this->assertGreaterThanOrEqual(14, $trail->getSize());
-        $this->assertNotNull($trail->getExpires());
+
+        // A DELETE audit row is precisely the row or#2265 was losing: 311 of
+        // 330 soft-deleted procest cases had no surviving delete row. With no
+        // retention policy resolvable the row is now retained INDEFINITELY
+        // instead of being stamped `+30 days`.
+        $this->assertNull($trail->getExpires());
+        $this->assertNotNull($trail->getRetentionPeriod());
     }//end testBuildAuditTrailForDeleteProducesEmptyChangeSet()
 
     public function testBuildAuditTrailFoldsCascadeContextIntoChangedColumn(): void

--- a/tests/Unit/Service/AuditChainTombstoneTest.php
+++ b/tests/Unit/Service/AuditChainTombstoneTest.php
@@ -1,0 +1,309 @@
+<?php
+
+/**
+ * Retention-purge tombstone tests for the audit hash chain (or#2265).
+ *
+ * The forensic hole being closed: `clearLogs()` HARD-deleted expired rows, and
+ * `verifyChain()` walks rows in id order carrying each row's hash forward as
+ * the next row's `previousHash`. Removing a row mid-chain therefore made the
+ * FOLLOWING row fail verification — so a lawful retention purge and a tampering
+ * event produced the identical symptom. For a system holding Dutch legal
+ * retention data, "the chain is broken" has to mean something.
+ *
+ * A purge now blanks the payload and stamps `purged_at`, keeping id, created,
+ * hash and previous_hash. This file proves the three things that has to be
+ * true, and — importantly — includes the NEGATIVE control:
+ *
+ *   - {@see testChainStaysValidAcrossATombstone} — a purge no longer breaks it.
+ *   - {@see testTamperedRowStillBreaksTheChain} — tampering STILL breaks it.
+ *     Without this, the first test would also pass against a verifier that had
+ *     simply stopped checking anything.
+ *   - {@see testCanonicalJsonIsUnaffectedByPurgedAt} — adding the field did not
+ *     silently invalidate every hash ever written.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service;
+
+use OCA\OpenRegister\Db\AuditTrail;
+use OCA\OpenRegister\Service\AuditHashService;
+use OCP\DB\IResult;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\Lock\ILockingProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class AuditChainTombstoneTest extends TestCase
+{
+
+    private AuditHashService $service;
+
+    private IDBConnection&MockObject $db;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->db      = $this->createMock(IDBConnection::class);
+        $this->service = new AuditHashService(
+            $this->db,
+            $this->createMock(ILockingProvider::class),
+            $this->createMock(LoggerInterface::class)
+        );
+    }//end setUp()
+
+    /**
+     * Wire the mocked connection so `verifyChain()` reads exactly these rows.
+     *
+     * @param array<int, array<string, mixed>> $rows Rows in id order.
+     */
+    private function wireRows(array $rows): void
+    {
+        $result = $this->createMock(IResult::class);
+
+        $cursor = 0;
+        $result->method('fetch')->willReturnCallback(
+            static function () use (&$cursor, $rows) {
+                if ($cursor >= count($rows)) {
+                    return false;
+                }
+
+                $row = $rows[$cursor];
+                $cursor++;
+                return $row;
+            }
+        );
+
+        $qb = $this->createMock(IQueryBuilder::class);
+        foreach (['select', 'from', 'orderBy', 'andWhere'] as $fluent) {
+            $qb->method($fluent)->willReturnSelf();
+        }
+
+        $qb->method('executeQuery')->willReturn($result);
+        $this->db->method('getQueryBuilder')->willReturn($qb);
+    }//end wireRows()
+
+    /**
+     * Build a DB-shaped row and seal it against the given previous hash.
+     *
+     * Returns the row array with a correct `hash`, so a chain built from
+     * successive calls verifies for real rather than by construction.
+     *
+     * @param int    $id           Row id.
+     * @param string $action       Audit action.
+     * @param string $previousHash The preceding row's hash.
+     *
+     * @return array<string, mixed>
+     */
+    private function sealedRow(int $id, string $action, string $previousHash): array
+    {
+        $row = [
+            'id'          => $id,
+            'uuid'        => 'uuid-'.$id,
+            'action'      => $action,
+            'object_uuid' => 'obj-'.$id,
+            'hash'        => null,
+            'purged_at'   => null,
+        ];
+
+        // Compute the hash exactly the way verifyChain() will re-derive it:
+        // same row -> entity -> canonical-JSON path.
+        $entry = new AuditTrail();
+        $entry->hydrate($this->camelise($row));
+        $row['hash'] = $this->service->computeHash(entry: $entry, previousHash: $previousHash);
+
+        return $row;
+    }//end sealedRow()
+
+    /**
+     * snake_case row keys to camelCase entity fields (mirrors mapRowToEntity()).
+     *
+     * @param array<string, mixed> $row The DB row.
+     *
+     * @return array<string, mixed>
+     */
+    private function camelise(array $row): array
+    {
+        $mapped = [];
+        foreach ($row as $key => $value) {
+            $mapped[lcfirst(str_replace('_', '', ucwords($key, '_')))] = $value;
+        }
+
+        return $mapped;
+    }//end camelise()
+
+    /**
+     * A purged row keeps the chain intact and is reported as a tombstone.
+     *
+     * Row 2's payload is destroyed and `purged_at` stamped — exactly what
+     * `clearLogs()` now does. Row 3 was sealed against row 2's hash, and that
+     * hash is still present, so the link holds.
+     */
+    public function testChainStaysValidAcrossATombstone(): void
+    {
+        $genesis = $this->service->getGenesisHash();
+
+        $row1 = $this->sealedRow(id: 1, action: 'create', previousHash: $genesis);
+        $row2 = $this->sealedRow(id: 2, action: 'update', previousHash: $row1['hash']);
+        $row3 = $this->sealedRow(id: 3, action: 'delete', previousHash: $row2['hash']);
+
+        // Purge row 2: blank the payload, stamp the tombstone, keep the hash.
+        $row2['action']      = null;
+        $row2['object_uuid'] = null;
+        $row2['purged_at']   = '2026-08-04 10:00:00';
+
+        $this->wireRows([$row1, $row2, $row3]);
+
+        $report = $this->service->verifyChain();
+
+        $this->assertTrue($report['valid'], 'A lawful purge must not read as a broken chain.');
+        $this->assertNull($report['brokenAt']);
+        $this->assertSame(1, $report['purgedTombstones'], 'The tombstone must be declared, not hidden.');
+        $this->assertSame(2, $report['entriesVerified'], 'The two intact rows must still be verified.');
+    }//end testChainStaysValidAcrossATombstone()
+
+    /**
+     * NEGATIVE CONTROL — tampering must STILL break the chain.
+     *
+     * Same three rows, but row 2 is altered WITHOUT a `purged_at` stamp: the
+     * shape an attacker produces. If this passed, the tombstone handling would
+     * have turned verification into a no-op and the test above would be
+     * meaningless.
+     */
+    public function testTamperedRowStillBreaksTheChain(): void
+    {
+        $genesis = $this->service->getGenesisHash();
+
+        $row1 = $this->sealedRow(id: 1, action: 'create', previousHash: $genesis);
+        $row2 = $this->sealedRow(id: 2, action: 'update', previousHash: $row1['hash']);
+        $row3 = $this->sealedRow(id: 3, action: 'delete', previousHash: $row2['hash']);
+
+        // Alter row 2's payload but leave purged_at NULL — undeclared change.
+        $row2['action'] = 'approve';
+
+        $this->wireRows([$row1, $row2, $row3]);
+
+        $report = $this->service->verifyChain();
+
+        $this->assertFalse($report['valid'], 'An undeclared payload change must still be detected.');
+        $this->assertSame(2, $report['brokenAt']);
+        $this->assertSame(0, $report['purgedTombstones']);
+    }//end testTamperedRowStillBreaksTheChain()
+
+    /**
+     * NEGATIVE CONTROL — a row DELETED outright still breaks the chain.
+     *
+     * This is the pre-fix behaviour, kept as an explicit assertion so the
+     * difference between a hard delete and a tombstone is pinned down: the
+     * whole point of the change is that these two are no longer the same
+     * event. Row 2 is simply absent, so row 3 is verified against row 1's
+     * hash and fails.
+     */
+    public function testHardDeletedRowStillBreaksTheChain(): void
+    {
+        $genesis = $this->service->getGenesisHash();
+
+        $row1 = $this->sealedRow(id: 1, action: 'create', previousHash: $genesis);
+        $row2 = $this->sealedRow(id: 2, action: 'update', previousHash: $row1['hash']);
+        $row3 = $this->sealedRow(id: 3, action: 'delete', previousHash: $row2['hash']);
+
+        // Row 2 physically removed — what clearLogs() used to do.
+        $this->wireRows([$row1, $row3]);
+
+        $report = $this->service->verifyChain();
+
+        $this->assertFalse($report['valid']);
+        $this->assertSame(3, $report['brokenAt']);
+        $this->assertSame(0, $report['purgedTombstones']);
+    }//end testHardDeletedRowStillBreaksTheChain()
+
+    /**
+     * Adding `purgedAt` must NOT have entered the canonical JSON.
+     *
+     * If it had, the hash of every row ever written would change and the
+     * entire existing chain would read as tampered on the next verification —
+     * a catastrophic and entirely silent regression.
+     */
+    public function testCanonicalJsonIsUnaffectedByPurgedAt(): void
+    {
+        $intact = new AuditTrail();
+        $intact->setUuid('same-uuid');
+        $intact->setAction('update');
+
+        $purged = new AuditTrail();
+        $purged->setUuid('same-uuid');
+        $purged->setAction('update');
+        $purged->setPurgedAt(new \DateTime('2026-08-04 10:00:00'));
+
+        $this->assertStringNotContainsString('purgedAt', $this->service->getCanonicalJson($purged));
+        $this->assertSame(
+            $this->service->getCanonicalJson($intact),
+            $this->service->getCanonicalJson($purged),
+            'purgedAt leaked into the canonical form; every existing hash would be invalidated.'
+        );
+        $this->assertTrue($purged->isPurged());
+        $this->assertFalse($intact->isPurged());
+    }//end testCanonicalJsonIsUnaffectedByPurgedAt()
+
+    /**
+     * `clearLogs()` must never issue a DELETE again.
+     *
+     * The chain-preservation argument only holds if the row physically
+     * survives, so this pins the SQL verb itself rather than trusting the
+     * surrounding prose: `delete()` must not be reached, `update()` must be,
+     * and `purged_at` must be among the columns set.
+     */
+    public function testClearLogsTombstonesInsteadOfDeleting(): void
+    {
+        $db = $this->createMock(IDBConnection::class);
+        $qb = $this->createMock(IQueryBuilder::class);
+
+        $qb->expects($this->never())->method('delete');
+        $qb->expects($this->once())->method('update')->with('openregister_audit_trails')->willReturnSelf();
+
+        $setColumns = [];
+        $qb->method('set')->willReturnCallback(
+            static function (string $column) use (&$setColumns, $qb) {
+                $setColumns[] = $column;
+                return $qb;
+            }
+        );
+
+        $qb->method('expr')->willReturn($this->createMock(\OCP\DB\QueryBuilder\IExpressionBuilder::class));
+        $qb->method('where')->willReturnSelf();
+        $qb->method('andWhere')->willReturnSelf();
+        $qb->method('createFunction')->willReturnArgument(0);
+        $qb->method('createNamedParameter')->willReturn(':p');
+        $qb->method('executeStatement')->willReturn(7);
+
+        $db->method('getQueryBuilder')->willReturn($qb);
+
+        $mapper = new \OCA\OpenRegister\Db\AuditTrailMapper(
+            $db,
+            $this->createMock(\Psr\Container\ContainerInterface::class),
+            $this->createMock(\OCP\IUserSession::class),
+            $this->createMock(\OCP\IRequest::class),
+            $this->createMock(LoggerInterface::class)
+        );
+
+        $this->assertTrue($mapper->clearLogs());
+        $this->assertContains('purged_at', $setColumns, 'The tombstone marker was not stamped.');
+        $this->assertContains('changed', $setColumns, 'The payload was not destroyed — a purge must still purge.');
+        $this->assertContains('ip_address', $setColumns);
+    }//end testClearLogsTombstonesInsteadOfDeleting()
+}//end class

--- a/tests/Unit/Service/AuditRetentionResolverTest.php
+++ b/tests/Unit/Service/AuditRetentionResolverTest.php
@@ -1,0 +1,386 @@
+<?php
+
+/**
+ * AuditRetentionResolver policy tests (or#2265).
+ *
+ * The defect being fixed: every audit row was stamped `+30 days`, so the
+ * evidence of a retention decision was destroyed long before the decision
+ * expired — 311 of 330 soft-deleted procest cases had lost their delete audit
+ * row, and all 258,240 rows carrying an expiry carried exactly a 30-day one.
+ *
+ * The two controls the fix REQUIRES, and which this file exists to provide,
+ * are deliberately opposed:
+ *
+ *   (a) {@see testLongRetentionRowSurvivesFarPastThirtyDays} — a row whose
+ *       object has a long retention must OUTLIVE 30 days.
+ *   (b) {@see testGenuinelyElapsedRetentionStillExpires} — a row whose object's
+ *       retention has genuinely elapsed must STILL EXPIRE.
+ *
+ * Without (b), (a) alone would be satisfied by a resolver that simply never
+ * expires anything — trading a purge bug for an unbounded-growth bug. Both
+ * assert against the SAME method, so neither can pass by the code doing
+ * nothing.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service;
+
+use DateInterval;
+use DateTimeImmutable;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\AuditRetentionResolver;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\NullLogger;
+
+class AuditRetentionResolverTest extends TestCase
+{
+
+    /**
+     * Schema returned by the container-backed SchemaMapper, or null to make
+     * the lookup fail (the "schema not resolvable" path).
+     *
+     * @var Schema|null
+     */
+    private ?Schema $schema = null;
+
+    /**
+     * Build a resolver whose SchemaMapper returns {@see self::$schema}.
+     */
+    private function makeResolver(): AuditRetentionResolver
+    {
+        $schemaMapper = $this->createMock(SchemaMapper::class);
+        $schemaMapper->method('find')->willReturnCallback(
+            function () {
+                if ($this->schema === null) {
+                    throw new \RuntimeException('schema not found');
+                }
+
+                return $this->schema;
+            }
+        );
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturnCallback(
+            static function (string $class) use ($schemaMapper): object {
+                if ($class === SchemaMapper::class) {
+                    return $schemaMapper;
+                }
+
+                throw new \RuntimeException('not registered: '.$class);
+            }
+        );
+
+        return new AuditRetentionResolver($container, new NullLogger());
+    }//end makeResolver()
+
+    /**
+     * Build an object carrying the given retention metadata.
+     *
+     * @param array $retention The `retention` column contents.
+     */
+    private function makeObject(array $retention): ObjectEntity
+    {
+        $object = new ObjectEntity();
+        $object->setUuid('obj-under-test');
+        $object->setRegister('1');
+        $object->setSchema('2');
+        $object->setRetention($retention);
+
+        return $object;
+    }//end makeObject()
+
+    // -------------------------------------------------------------------------
+    // POSITIVE CONTROL (a) — long retention SURVIVES past 30 days
+    // -------------------------------------------------------------------------
+
+    /**
+     * A row describing an object kept 20 years must not be purgeable at 30 days.
+     *
+     * The clock is not waited on; the resolved expiry is compared against the
+     * 30-day horizon directly, which is the same comparison
+     * `clearLogs()` makes (`expires < NOW()`).
+     */
+    public function testLongRetentionRowSurvivesFarPastThirtyDays(): void
+    {
+        $createdAt = new DateTimeImmutable('2026-01-01T00:00:00+00:00');
+
+        $object = $this->makeObject(
+            [
+                'archiefnominatie'  => 'vernietigen',
+                'bewaartermijn'     => 'P20Y',
+                'archiefactiedatum' => '2046-01-01',
+            ]
+        );
+
+        $resolved = $this->makeResolver()->resolve(object: $object, createdAt: $createdAt);
+
+        $this->assertNotNull($resolved['expires'], 'A 20-year retention must produce a finite, far-future expiry.');
+        $this->assertSame('object.archiefactiedatum', $resolved['source']);
+
+        // The row must still be alive at the OLD 30-day horizon...
+        $thirtyDays = $createdAt->add(new DateInterval('P30D'));
+        $this->assertGreaterThan(
+            $thirtyDays,
+            $resolved['expires'],
+            'Row expired at or before 30 days — this is exactly the or#2265 defect.'
+        );
+
+        // ...and specifically alive ~20 years out, not merely 31 days.
+        $this->assertGreaterThan($createdAt->add(new DateInterval('P19Y')), $resolved['expires']);
+    }//end testLongRetentionRowSurvivesFarPastThirtyDays()
+
+    // -------------------------------------------------------------------------
+    // POSITIVE CONTROL (b) — genuinely elapsed retention STILL EXPIRES
+    // -------------------------------------------------------------------------
+
+    /**
+     * A row whose object's retention genuinely elapsed must still be purgeable.
+     *
+     * The row is dated two years ago and its object's `archiefactiedatum` one
+     * year ago, so the 30-day FLOOR (created + P30D, i.e. two years ago) does
+     * not bind, and the resolved expiry lands in the past — which is what
+     * `clearLogs()`'s `expires < NOW()` predicate selects. Without this
+     * control, control (a) would also pass against a resolver that never
+     * expires anything.
+     */
+    public function testGenuinelyElapsedRetentionStillExpires(): void
+    {
+        $createdAt = (new DateTimeImmutable('now'))->sub(new DateInterval('P2Y'));
+        $elapsed   = (new DateTimeImmutable('now'))->sub(new DateInterval('P1Y'));
+
+        $object = $this->makeObject(
+            [
+                'archiefnominatie'  => 'vernietigen',
+                'archiefactiedatum' => $elapsed->format('Y-m-d'),
+            ]
+        );
+
+        $resolved = $this->makeResolver()->resolve(object: $object, createdAt: $createdAt);
+
+        $this->assertNotNull($resolved['expires'], 'An elapsed retention must NOT become indefinite.');
+        $this->assertSame('object.archiefactiedatum', $resolved['source']);
+        $this->assertLessThan(
+            new DateTimeImmutable('now'),
+            $resolved['expires'],
+            'Expiry did not land in the past — the purge bug has been replaced by unbounded growth.'
+        );
+    }//end testGenuinelyElapsedRetentionStillExpires()
+
+    // -------------------------------------------------------------------------
+    // The floor — a row must never be born already expired
+    // -------------------------------------------------------------------------
+
+    /**
+     * An object already past its destruction date must not produce an audit row
+     * that the next hourly cron purges immediately.
+     *
+     * This is the reason the 30-day constant survives with its sign reversed:
+     * it used to be the longest an audit row could live, and is now the
+     * shortest.
+     */
+    public function testFloorPreventsRowsThatAreBornExpired(): void
+    {
+        $createdAt = new DateTimeImmutable('2026-01-01T00:00:00+00:00');
+
+        // Destruction date TWO YEARS BEFORE the audit row is written.
+        $object = $this->makeObject(
+            [
+                'archiefnominatie'  => 'vernietigen',
+                'archiefactiedatum' => '2024-01-01',
+            ]
+        );
+
+        $resolved = $this->makeResolver()->resolve(object: $object, createdAt: $createdAt);
+
+        $this->assertSame(
+            $createdAt->add(new DateInterval('P30D'))->format('c'),
+            $resolved['expires']->format('c'),
+            'The floor did not bind; the row describing this action would be purged on the next sweep.'
+        );
+        $this->assertSame('object.archiefactiedatum+floor', $resolved['source']);
+    }//end testFloorPreventsRowsThatAreBornExpired()
+
+    // -------------------------------------------------------------------------
+    // Indefinite-retention branches
+    // -------------------------------------------------------------------------
+
+    /**
+     * An active legal hold makes the audit row indefinite.
+     */
+    public function testLegalHoldRetainsIndefinitely(): void
+    {
+        $object = $this->makeObject(
+            [
+                'archiefnominatie'  => 'vernietigen',
+                'archiefactiedatum' => '2024-01-01',
+                'legalHold'         => ['active' => true, 'reason' => 'litigation'],
+            ]
+        );
+
+        $resolved = $this->makeResolver()->resolve(
+            object: $object,
+            createdAt: new DateTimeImmutable('2026-01-01T00:00:00+00:00')
+        );
+
+        $this->assertNull($resolved['expires']);
+        $this->assertSame('legal-hold:indefinite', $resolved['source']);
+    }//end testLegalHoldRetainsIndefinitely()
+
+    /**
+     * `bewaren` means permanent preservation, so the `archiefactiedatum` on
+     * such an object is a TRANSFER date and must not be read as an expiry.
+     */
+    public function testBewarenIsNeverExpiredEvenWithAnArchiefactiedatum(): void
+    {
+        $object = $this->makeObject(
+            [
+                'archiefnominatie'  => 'bewaren',
+                'archiefactiedatum' => '2024-01-01',
+            ]
+        );
+
+        $resolved = $this->makeResolver()->resolve(
+            object: $object,
+            createdAt: new DateTimeImmutable('2026-01-01T00:00:00+00:00')
+        );
+
+        $this->assertNull($resolved['expires']);
+        $this->assertSame('archiefnominatie=bewaren:indefinite', $resolved['source']);
+    }//end testBewarenIsNeverExpiredEvenWithAnArchiefactiedatum()
+
+    /**
+     * An undetermined nomination must fail TOWARDS keeping: a record whose
+     * retention has not been decided cannot lawfully be destroyed, and neither
+     * can its audit trail.
+     */
+    public function testUndeterminedNominationRetainsIndefinitely(): void
+    {
+        $resolved = $this->makeResolver()->resolve(
+            object: $this->makeObject(['archiefnominatie' => 'nog_niet_bepaald']),
+            createdAt: new DateTimeImmutable('2026-01-01T00:00:00+00:00')
+        );
+
+        $this->assertNull($resolved['expires']);
+        $this->assertSame('archiefnominatie=nog_niet_bepaald:indefinite', $resolved['source']);
+    }//end testUndeterminedNominationRetainsIndefinitely()
+
+    /**
+     * THE DOCUMENTED DEFAULT: an object with no retention policy anywhere, and
+     * a schema that resolves to nothing, is retained INDEFINITELY — never the
+     * old 30 days.
+     */
+    public function testNoRetentionPolicyAnywhereRetainsIndefinitely(): void
+    {
+        $this->schema = null;
+
+        $resolved = $this->makeResolver()->resolve(
+            object: $this->makeObject([]),
+            createdAt: new DateTimeImmutable('2026-01-01T00:00:00+00:00')
+        );
+
+        $this->assertNull($resolved['expires']);
+        $this->assertSame(AuditRetentionResolver::SOURCE_NO_POLICY, $resolved['source']);
+    }//end testNoRetentionPolicyAnywhereRetainsIndefinitely()
+
+    // -------------------------------------------------------------------------
+    // Schema-level fallbacks
+    // -------------------------------------------------------------------------
+
+    /**
+     * With nothing on the object, the schema's archive block supplies the term.
+     */
+    public function testSchemaArchiveBewaartermijnIsUsedWhenObjectHasNone(): void
+    {
+        $this->schema = new Schema();
+        $this->schema->setArchive(['enabled' => true, 'defaultBewaartermijn' => 'P7Y']);
+
+        $createdAt = new DateTimeImmutable('2026-01-01T00:00:00+00:00');
+        $resolved  = $this->makeResolver()->resolve(object: $this->makeObject([]), createdAt: $createdAt);
+
+        $this->assertSame('schema.archive.defaultBewaartermijn', $resolved['source']);
+        $this->assertSame(
+            $createdAt->add(new DateInterval('P7Y'))->format('c'),
+            $resolved['expires']->format('c')
+        );
+    }//end testSchemaArchiveBewaartermijnIsUsedWhenObjectHasNone()
+
+    /**
+     * A schema-level override beats the schema default.
+     */
+    public function testSchemaOverrideBeatsSchemaDefault(): void
+    {
+        $this->schema = new Schema();
+        $this->schema->setArchive(
+            [
+                'enabled'               => true,
+                'defaultBewaartermijn'  => 'P7Y',
+                'bewaartermijnOverride' => 'P10Y',
+            ]
+        );
+
+        $createdAt = new DateTimeImmutable('2026-01-01T00:00:00+00:00');
+        $resolved  = $this->makeResolver()->resolve(object: $this->makeObject([]), createdAt: $createdAt);
+
+        $this->assertSame('schema.archive.bewaartermijnOverride', $resolved['source']);
+        $this->assertSame(
+            $createdAt->add(new DateInterval('P10Y'))->format('c'),
+            $resolved['expires']->format('c')
+        );
+    }//end testSchemaOverrideBeatsSchemaDefault()
+
+    /**
+     * The audit row inherits the same horizon the row-level archival annotation
+     * gives the data it describes.
+     */
+    public function testArchivalAnnotationDefaultIsUsedAsLastResort(): void
+    {
+        $this->schema = new Schema();
+        $this->schema->setArchive([]);
+        $this->schema->setConfiguration(
+            ['x-openregister-archival' => ['retention' => ['default' => 'P5Y']]]
+        );
+
+        $createdAt = new DateTimeImmutable('2026-01-01T00:00:00+00:00');
+        $resolved  = $this->makeResolver()->resolve(object: $this->makeObject([]), createdAt: $createdAt);
+
+        $this->assertSame('schema.x-openregister-archival.retention.default', $resolved['source']);
+        $this->assertSame(
+            $createdAt->add(new DateInterval('P5Y'))->format('c'),
+            $resolved['expires']->format('c')
+        );
+    }//end testArchivalAnnotationDefaultIsUsedAsLastResort()
+
+    /**
+     * A malformed duration must not shorten retention silently — it falls
+     * through to the next source, and with none left, to indefinite.
+     */
+    public function testMalformedDurationFallsThroughToIndefiniteNotToThirtyDays(): void
+    {
+        $this->schema = new Schema();
+        $this->schema->setArchive(['enabled' => true, 'defaultBewaartermijn' => 'not-a-duration']);
+
+        $resolved = $this->makeResolver()->resolve(
+            object: $this->makeObject([]),
+            createdAt: new DateTimeImmutable('2026-01-01T00:00:00+00:00')
+        );
+
+        $this->assertNull($resolved['expires']);
+        $this->assertSame(AuditRetentionResolver::SOURCE_NO_POLICY, $resolved['source']);
+    }//end testMalformedDurationFallsThroughToIndefiniteNotToThirtyDays()
+}//end class


### PR DESCRIPTION
Closes #2265.

## The defect

`AuditTrailMapper.php:571` stamped `new DateTime('+30 days')` on **every** audit row — unconditionally, for `create`/`update`/`delete`/`read` alike — and `LogCleanUpTask` **hard-deleted** the expired ones hourly. For a product whose purpose is multi-year legal retention, the audit trail silently self-destructed after a month.

Measured in #2265: **311 of 330** soft-deleted procest cases had no surviving `delete` audit row (100% coverage inside the 30-day window, 0% outside — a clean date boundary, not a code path), and **all 258,240** rows carrying an expiry carried exactly a 30-day one.

## What changed

### 1. Audit lifetime follows the retention of the object the row describes

New `lib/Service/AuditRetentionResolver.php`. Resolution is most-specific-first, and every branch records a token stamped into the row's existing `retention_period` column, so a future purge is explainable **from the row itself** rather than from whatever code was deployed that day:

| # | Source | Outcome |
|---|---|---|
| 1 | `retention.legalHold.active` | **indefinite** |
| 2 | `archiefnominatie = bewaren` | **indefinite** — the `archiefactiedatum` on such an object is the *transfer* date, not a destruction date |
| 3 | `archiefnominatie = nog_niet_bepaald` | **indefinite** — undetermined must fail towards keeping |
| 4 | `retention.archiefactiedatum` | that date |
| 5 | `retention.bewaartermijn` | created + duration |
| 6 | schema `archive.bewaartermijnOverride` / `defaultBewaartermijn` | created + duration |
| 7 | schema `x-openregister-archival.retention.default` | created + duration — the same horizon `RetentionEvaluator` gives the data itself |
| 8 | nothing configured | **indefinite** |

**The default for objects with no retention policy is INDEFINITE**, not a shorter fallback. `expires IS NULL` already meant "never purge" — `clearLogs()` has always filtered on `expires IS NOT NULL` — so the mechanism was there. The reasoning, documented in the resolver rather than implied: any finite default re-creates this exact defect at a different horizon, and for Dutch government retention data, silently discarding evidence is a worse failure than storing too much.

**The 30-day constant survives with its sign reversed.** It is now a FLOOR (`AuditRetentionResolver::MINIMUM_LIFETIME`), never a ceiling. Without it, an object already past its `archiefactiedatum` would produce an audit row the next hourly sweep purges immediately — the row describing the action just taken would be **born expired**.

Fail-safe direction is deliberate: if the resolver cannot be constructed at all, the row is retained **indefinitely**, not given a short life. The failure being fixed is evidence disappearing, not disk filling.

### 2. A purge is now provably distinct from tampering

`verifyChain()` walks rows in id order, carrying each row's hash forward as the next row's `previousHash`. Deleting a row mid-chain therefore broke verification at the row **after** it — the identical symptom an attacker produces. A routine purge and a tampering event were indistinguishable.

`clearLogs()` is now an **UPDATE, not a DELETE**. It destroys the payload (`changed`, `user`, `user_name`, `session`, `request`, `ip_address` — the data and the personal identifiers a retention purge is meant to remove) and stamps a new `purged_at` column, keeping `id`, `created`, `hash`, `previous_hash` and the structural context. `verifyChain()` carries the chain across such a row and reports `purgedTombstones` instead of `brokenAt`. Repeat sweeps are idempotent (`purged_at IS NULL` predicate).

Migration `Version1Date20260805000000` adds the nullable column + index. No backfill is possible — rows purged before this cannot be reconstructed.

## ⚠️ Storage implication

Growth is **unbounded-ish by design** wherever no retention policy is configured, and tombstones mean even purged rows keep a (small, payload-free) footprint forever. The audit table was already at ~258k rows *while being truncated monthly*. This needs a capacity plan, and it is the intended trade: the alternative is the defect this PR closes.

The lever that shortens it is configuration, not code — schemas with an `archive` block or an `x-openregister-archival` annotation get finite, correct horizons automatically.

## ⚠️ Residual limitation — stated, not glossed

`purgedAt` is deliberately **absent from the canonical JSON**, because adding any key to `jsonSerialize()` would change the hash of every row ever written and invalidate the entire existing chain. Consequently the flag is **not itself hash-protected**: someone with direct table write access could set `purged_at` and blank a payload to suppress a record without breaking verification.

That is strictly weaker and strictly **more visible** than the previous silent row deletion — the row, its timestamp and its position all survive, and tombstones are counted and reported — but it is not cryptographic proof a tombstone was lawful. Binding the flag into the hash requires a full chain re-seal and is **not** done here.

## Verification

**Positive controls, both directions — and both shown to actually fail.** Neither alone is sufficient: (a) alone passes against a resolver that never expires anything; (b) alone passes against the old 30-day behaviour.

| Control | Under old `+30d` | Under "never expire" | Now |
|---|---|---|---|
| (a) long retention SURVIVES past 30 days | **RED** — `Row expired at or before 30 days` | **RED** | green |
| (b) genuinely elapsed retention STILL EXPIRES | green | **RED** — `An elapsed retention must NOT become indefinite` | green |

Both reds were produced by temporarily stubbing `resolve()` and captured verbatim before reverting.

**Chain negative controls** — so tombstone handling cannot have quietly turned verification into a no-op:
- an undeclared payload change **still** reports `valid:false, brokenAt:2`
- a hard-deleted row **still** reports `valid:false, brokenAt:3`
- canonical JSON is byte-identical with and without `purgedAt` set (guards against invalidating every existing hash)
- `clearLogs()` asserts `delete()` is **never** called and `purged_at`/`changed`/`ip_address` are among the columns set

Two pre-existing tests asserted the old hardcoded `assertNotNull($trail->getExpires())`; they now assert the new contract, and their failure was itself confirmation the change takes effect.

```
Tests: 15980, Assertions: 35831, Failures: 0
```
`phpcs` and `phpstan` clean on all six changed `lib/` files. Run on PHP 8.4.22.

## Not done

- `@spec` tags: the resolver and its tests carry none. I did not invent values — reporting rather than guessing. `phpcs` flags them as warnings (severity 0 in the repo's own `phpcs` script, so non-blocking).
- Hash-binding the tombstone flag (see above).
- No backfill of the 258,240 rows still carrying a 30-day expiry. Note `setExpiryDate()` at `:1686` would **break every hash it touched**, since `expires` is part of the canonical JSON — it must not be used as a backfill without a re-seal.
