### PR TITLE
ci: enable the Hydra mechanical gate tier — it has never run in this repo

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -90,4 +90,34 @@ jobs:
       # mis-parse it. Path is relative to `server/`, which the step cd's into.
       playwright-seed-command: bash apps/openregister/tests/e2e/ci/seed.sh
       enable-coverage-guard: true
+      # Run the Hydra mechanical quality gates against this PR's diff.
+      #
+      # This tier has never executed in this repository. `enable-hydra-gates`
+      # defaults to false, so `quality / Hydra Gates` has been SKIPPED on every
+      # run here — and a skipped job is neither a pass nor a failure in the
+      # Quality Report rollup, so its absence has been indistinguishable from
+      # its success. That is the whole reason for turning it on rather than
+      # assuming the gates were already covering this repo.
+      #
+      # No count is written here on purpose: the number of gates depends on the
+      # pin below and the number that actually run depends on this repo's diff
+      # and toolchain. The package prints both (`COVERAGE: N of M`) in the job
+      # log; a digit in prose has nothing to reconcile against and goes stale
+      # silently. See https://github.com/ConductionNL/.github/tree/main/hydra-gates
+      #
+      # Pinned to a tag, not `main`, so a change to the gate package cannot
+      # alter this repository's verdict without a commit here to move the pin.
+      # v1.0.1 deliberately matches the pin openbuild already runs, so this
+      # repo's first result is directly comparable with the only live-verified
+      # reference the fleet has. (v1.1.0 exists; moving to it is a separate,
+      # measurable change.)
+      enable-hydra-gates: true
+      hydra-gates-ref: v1.0.1
+      # `enable-axe` is deliberately NOT set. It is the input that produces
+      # `tests/axe/report.json`, which gate-33 consumes; without it gate-33
+      # reports SKIPPED, as it has done in every repo in the fleet. Measured
+      # against a vanilla Nextcloud with no app installed, core's own pages
+      # already carry serious/critical axe violations, so switching it on in
+      # the same change as the gates themselves would confuse "this repo has an
+      # accessibility defect" with "Nextcloud core does". Separate change.
       enable-sbom: true


### PR DESCRIPTION
## What this turns on

`quality / Hydra Gates` — the mechanical gate tier from `conduction/hydra-gates` — has **never executed in this repository**.

`enable-hydra-gates` defaults to `false` in the shared workflow, and this caller never set it. So the job has been **SKIPPED on every run openregister has ever had**. A skipped job is neither a pass nor a failure in the Quality Report rollup, which means the gate tier's *absence* has been indistinguishable from its *success*. That is the whole reason for switching it on rather than assuming the gates were already covering this repo.

## Why this is safe to switch on mid-flight

The gates are **diff-scoped** per ADR-020: each one inspects only the files this PR changes, so inherited debt on untouched trees cannot block unrelated work. That claim is the thing this PR measures — the run on this PR is itself the evidence.

## The dependency that does *not* delete the job

`hydra-gates` declares `needs: [..., playwright]`, and `needs:` implies `success()` — which would make the whole job vanish for every repo that has the gates on and Playwright off, with no red, no skip and no trace. The shared workflow guards against exactly that with `if: ${{ inputs.enable-hydra-gates && !cancelled() }}`, which suppresses the implicit `success()`.

Verified live rather than assumed: on **openbuild** run [30911188960](https://github.com/ConductionNL/openbuild/actions/runs/30911188960), `E2E Tests (Playwright)` was **skipped** and `Hydra Gates` still ran to **success**. This repo has `enable-playwright: true` anyway, so the edge is satisfied here regardless.

## The pin

`hydra-gates-ref: v1.0.1`, not `main`, so a change to the gate package cannot move this repository's verdict without a commit here to move the pin.

v1.0.1 is also the pin **openbuild** already runs, which makes this repo's first result directly comparable to the only live-verified reference the fleet has. Measured there on a PR with a real 2-file diff:

```
[hydra-gates] ALL 61 GATES GREEN
[hydra-gates] COVERAGE: 58 of 61 declared gates reported a result.
[hydra-gates] GATES THAT DID NOT RUN: 4 24 33
```

`v1.1.0` exists. Moving to it is a separate, measurable change, not a side effect of this one.

## What is deliberately *not* enabled

`enable-axe` stays off. It is the input that produces `tests/axe/report.json`, the file gate-33 consumes; without it gate-33 reports SKIPPED, as it has in every repo in the fleet since it was written.

Measured against a vanilla Nextcloud with no app installed, **core's own pages already carry serious/critical axe violations**. Enabling it in the same change as the gate tier would mix "this repo has an accessibility defect" with "Nextcloud core does". Separate change, separate verdict.

## Expected outcome

Red is an acceptable and possibly correct result. The point is to find out what this repository actually does under the gates, not to produce a green tick. **No gate has been weakened, baselined or suppressed to get there.**
