### PR TITLE
ci(quality): enable the Code Quality gates this repo was silently skipping

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -121,3 +121,20 @@ jobs:
       # the same change as the gates themselves would confuse "this repo has an
       # accessibility defect" with "Nextcloud core does". Separate change.
       enable-sbom: true
+
+      # ── Frontend Check legs ──────────────────────────────────────────────
+      # `frontend-checks` defaults to `[]`, and an empty list means the shared
+      # workflow emits NO "Frontend Check" job at all — which is why this repo's
+      # validator family had never run in CI even though everything else here is
+      # switched on. Both entries are self-contained `node` scripts, which is
+      # what a leg has to be (each leg is a fresh job with its own checkout +
+      # `npm ci`).
+      # `check:specs` is the aggregate (json-strict + manifest + register),
+      # listed as ONE leg rather than three.
+      # Measured on this tree before enabling: `check:specs` PASSES (with
+      # warnings), `test:l10n` FAILS on source strings missing from
+      # l10n/en.json, e.g. "Write an audit-trail entry for every step"
+      # (src/views/settings/sections/FlowConfiguration.vue:29). A real
+      # pre-existing defect; the gate is what makes it visible.
+      # `test` is NOT listed: "Frontend Tests (unit)" already runs it.
+      frontend-checks: '["check:specs", "test:l10n"]'


### PR DESCRIPTION
## What

Enables the Code Quality gates this repo was silently skipping.

| gate | was | now |
|---|---|---|
| Frontend Check | skipped (`frontend-checks: []` -> job not emitted) | `["check:specs", "test:l10n"]` |

## Why

A skipped job and a passing job are **indistinguishable in the Quality Report**.
Every gate listed above reported `skipped` in this repository's runs, which reads
as "fine". This turns them on.

Two prerequisites landed on `ConductionNL/.github@main` first and are what make
this viable:

- **#149** — hydra-gates gate-7 (`no-admin-idor`) now follows delegation, and
  gates 6/7 no longer pass on an empty scope. Before that, gate-7 flagged
  correctly-guarded methods whose guard is reached through a helper, which is
  why 19 of 20 repos kept the whole tier switched off.
- **#150** — an empty `frontend-checks` list *deleted* the Frontend Check job
  from the run rather than skipping it, because `inputs.frontend-checks != '[]'`
  was a literal string comparison.

## Not enabled, on purpose

- **Journeydoc Capture** — deliberately left off everywhere.
- **`enable-axe`** — it produces the report hydra-gates gate-33 consumes, but a
  vanilla Nextcloud 34 with no app installed already returns three
  serious/critical violations from core's own UI. Turning it on in the same
  change as the gates would confuse "this app has an accessibility defect" with
  "Nextcloud core does". Separate change.

## On red

Some legs below were measured failing *before* this PR was opened, and are
enabled anyway. The defects are pre-existing; the only thing that changed is
that CI can now see them. Per the brief, a gate is not switched back off because
it failed on arrival — the failure is the result.

## Measured before flipping, not after

Every leg below was run against this branch's tree *before* it was enabled:

- `check:specs` **PASSES** (with warnings from `validate-register` about `type` on two register fragments).
- `test:l10n` **FAILS** — source strings missing from `l10n/en.json`, e.g. *"Write an audit-trail entry for every step"* (`src/views/settings/sections/FlowConfiguration.vue:29`).

## Left off, with reasons

- Everything else — this repo already had Newman, Playwright, the coverage ratchet and Hydra Gates switched on. **Frontend Check was the only gate still dark here**, and it was dark for the subtlest reason: an empty `frontend-checks` list does not skip the job, it removes it from the run entirely.
- `test` — already run by the shared *Frontend Tests (unit)* job.

