### PR TITLE
fix(quality): scope the Migration phpmd exclusion to UnusedFormalParameter only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
 		"psalm:fix": "./vendor/bin/psalm --threads=1 --no-cache --alter || echo 'Psalm not installed, skipping...'",
 		"psalm:output": "./vendor/bin/psalm --threads=1 --no-cache --output-format=json 2>/dev/null | tail -1 > psalm-output.json || echo 'Psalm not installed, skipping...'",
 		"phpstan": "if [ -f vendor/bin/phpstan ]; then ./vendor/bin/phpstan analyse --memory-limit=1G; else echo 'PHPStan not installed, skipping...'; fi",
-		"phpmd": "./vendor/bin/phpmd lib text phpmd.xml --baseline-file phpmd.baseline.xml",
+		"phpmd": "E=0; ./vendor/bin/phpmd lib text phpmd.xml --baseline-file phpmd.baseline.xml || E=$?; ./vendor/bin/phpmd lib text phpmd-unusedparams.xml --baseline-file phpmd.baseline.xml || E=$?; exit $E",
 		"phpmetrics": "./vendor/bin/phpmetrics --report-html=phpmetrics lib/",
 		"phpmetrics:json": "./vendor/bin/phpmetrics --report-json=phpmetrics/report.json lib/",
 		"phpmetrics:csv": "./vendor/bin/phpmetrics --report-csv=phpmetrics/report.csv lib/",

--- a/lib/Migration/Version002003000Date20251013000000.php
+++ b/lib/Migration/Version002003000Date20251013000000.php
@@ -50,7 +50,6 @@ class Version002003000Date20251013000000 extends SimpleMigrationStep
      *
      * @return ISchemaWrapper|null Modified schema or null
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper

--- a/lib/Migration/Version002003000Date20251013000000.php
+++ b/lib/Migration/Version002003000Date20251013000000.php
@@ -9,7 +9,7 @@
  *
  * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @link https://www.OpenRegister.nl
  */

--- a/lib/Migration/Version002004000Date20251013000000.php
+++ b/lib/Migration/Version002004000Date20251013000000.php
@@ -37,8 +37,6 @@ class Version002004000Date20251013000000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return null|ISchemaWrapper Modified schema or null
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -142,8 +140,6 @@ class Version002004000Date20251013000000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return null Modified schema or null
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version002005000Date20251013000000.php
+++ b/lib/Migration/Version002005000Date20251013000000.php
@@ -47,7 +47,6 @@ class Version002005000Date20251013000000 extends SimpleMigrationStep
      *
      * @return null|ISchemaWrapper Modified schema or null
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
@@ -189,8 +188,6 @@ class Version002005000Date20251013000000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return null Modified schema or null
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version002006000Date20251013000000.php
+++ b/lib/Migration/Version002006000Date20251013000000.php
@@ -12,7 +12,7 @@
  *
  * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @version GIT: <git_id>
  *

--- a/lib/Migration/Version002006000Date20251013000000.php
+++ b/lib/Migration/Version002006000Date20251013000000.php
@@ -39,7 +39,6 @@ class Version002006000Date20251013000000 extends SimpleMigrationStep
      *
      * @return null|ISchemaWrapper Modified schema or null
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
@@ -280,8 +279,6 @@ class Version002006000Date20251013000000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20240924200009.php
+++ b/lib/Migration/Version1Date20240924200009.php
@@ -32,8 +32,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * FIXME Auto-generated migration step: Please modify to your needs!
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20240924200009 extends SimpleMigrationStep
 {
@@ -45,8 +43,6 @@ class Version1Date20240924200009 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
@@ -60,8 +56,6 @@ class Version1Date20240924200009 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return ISchemaWrapper
-     *
-     * @SuppressWarnings (PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -151,8 +145,6 @@ class Version1Date20240924200009 extends SimpleMigrationStep
      * @param IOutput                   $output        Output interface for migration progress
      * @param Closure(): ISchemaWrapper $schemaClosure Schema closure function
      * @param array                     $options       Migration options
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      *
      * @return void
      */

--- a/lib/Migration/Version1Date20241019205009.php
+++ b/lib/Migration/Version1Date20241019205009.php
@@ -33,8 +33,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Migration step for adding uuid and version columns to sources and schemas tables
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20241019205009 extends SimpleMigrationStep
 {
@@ -46,8 +44,6 @@ class Version1Date20241019205009 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
@@ -61,8 +57,6 @@ class Version1Date20241019205009 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return ISchemaWrapper
-     *
-     * @SuppressWarnings (PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -121,8 +115,6 @@ class Version1Date20241019205009 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20241020231700.php
+++ b/lib/Migration/Version1Date20241020231700.php
@@ -33,8 +33,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Migration step for creating audit trails table
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20241020231700 extends SimpleMigrationStep
 {
@@ -46,8 +44,6 @@ class Version1Date20241020231700 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
@@ -61,8 +57,6 @@ class Version1Date20241020231700 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return ISchemaWrapper
-     *
-     * @SuppressWarnings (PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -112,8 +106,6 @@ class Version1Date20241020231700 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20241022135300.php
+++ b/lib/Migration/Version1Date20241022135300.php
@@ -33,8 +33,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Migration step for fixing register column name in audit trails table
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20241022135300 extends SimpleMigrationStep
 {
@@ -46,8 +44,6 @@ class Version1Date20241022135300 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
@@ -61,8 +57,6 @@ class Version1Date20241022135300 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return ISchemaWrapper
-     *
-     * @SuppressWarnings (PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -93,8 +87,6 @@ class Version1Date20241022135300 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20241030131427.php
+++ b/lib/Migration/Version1Date20241030131427.php
@@ -35,8 +35,6 @@ use OCP\Migration\SimpleMigrationStep;
  * Migration step for adding hard_validation and archive columns to schemas table
  *
  * FIXME Auto-generated migration step: Please modify to your needs!
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20241030131427 extends SimpleMigrationStep
 {
@@ -48,8 +46,6 @@ class Version1Date20241030131427 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
@@ -63,8 +59,6 @@ class Version1Date20241030131427 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return ISchemaWrapper
-     *
-     * @SuppressWarnings (PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -138,8 +132,6 @@ class Version1Date20241030131427 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20241128221000.php
+++ b/lib/Migration/Version1Date20241128221000.php
@@ -35,8 +35,6 @@ use OCP\Migration\SimpleMigrationStep;
  * Migration step for database schema updates
  *
  * FIXME Auto-generated migration step: Please modify to your needs!
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20241128221000 extends SimpleMigrationStep
 {
@@ -48,8 +46,6 @@ class Version1Date20241128221000 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
@@ -63,8 +59,6 @@ class Version1Date20241128221000 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return ISchemaWrapper
-     *
-     * @SuppressWarnings (PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -114,8 +108,6 @@ class Version1Date20241128221000 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20241216094112.php
+++ b/lib/Migration/Version1Date20241216094112.php
@@ -35,8 +35,6 @@ use OCP\Migration\SimpleMigrationStep;
  * Migration step for creating openregister_files table
  *
  * FIXME Auto-generated migration step: Please modify to your needs!
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20241216094112 extends SimpleMigrationStep
 {
@@ -48,8 +46,6 @@ class Version1Date20241216094112 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
@@ -63,8 +59,6 @@ class Version1Date20241216094112 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return ISchemaWrapper
-     *
-     * @SuppressWarnings (PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -120,8 +114,6 @@ class Version1Date20241216094112 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20241227153853.php
+++ b/lib/Migration/Version1Date20241227153853.php
@@ -35,8 +35,6 @@ use OCP\Migration\SimpleMigrationStep;
  * Migration step for adding max_depth column to schemas table
  *
  * FIXME Auto-generated migration step: Please modify to your needs!
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20241227153853 extends SimpleMigrationStep
 {
@@ -48,8 +46,6 @@ class Version1Date20241227153853 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
@@ -63,8 +59,6 @@ class Version1Date20241227153853 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return ISchemaWrapper
-     *
-     * @SuppressWarnings (PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -92,8 +86,6 @@ class Version1Date20241227153853 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20250102000000.php
+++ b/lib/Migration/Version1Date20250102000000.php
@@ -60,8 +60,6 @@ class Version1Date20250102000000 extends SimpleMigrationStep
      * @param Closure(): ISchemaWrapper $schemaClosure Schema closure
      * @param array                     $options       Migration options
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
      * @return void
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
@@ -77,8 +75,6 @@ class Version1Date20250102000000 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return ISchemaWrapper
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -115,8 +111,6 @@ class Version1Date20250102000000 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20250102000001.php
+++ b/lib/Migration/Version1Date20250102000001.php
@@ -60,8 +60,6 @@ class Version1Date20250102000001 extends SimpleMigrationStep
      * @param Closure(): ISchemaWrapper $schemaClosure Schema closure
      * @param array                     $options       Migration options
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
      * @return void
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
@@ -77,8 +75,6 @@ class Version1Date20250102000001 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return ISchemaWrapper
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -115,8 +111,6 @@ class Version1Date20250102000001 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20250115230511.php
+++ b/lib/Migration/Version1Date20250115230511.php
@@ -35,8 +35,6 @@ use OCP\Migration\SimpleMigrationStep;
  * Migration to add locked, owner, authorization and folder columns to openregister_objects table
  * and folder column to openregister_registers table.
  * These columns are used to track object locking, ownership, access permissions and folder location
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20250115230511 extends SimpleMigrationStep
 {
@@ -48,8 +46,6 @@ class Version1Date20250115230511 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
@@ -63,8 +59,6 @@ class Version1Date20250115230511 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return ISchemaWrapper
-     *
-     * @SuppressWarnings (PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -154,8 +148,6 @@ class Version1Date20250115230511 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20250123120000.php
+++ b/lib/Migration/Version1Date20250123120000.php
@@ -59,8 +59,6 @@ class Version1Date20250123120000 extends SimpleMigrationStep
      * @param Closure(): ISchemaWrapper $schemaClosure Schema closure
      * @param array                     $options       Migration options
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
      * @return void
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
@@ -76,8 +74,6 @@ class Version1Date20250123120000 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return ISchemaWrapper
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -113,8 +109,6 @@ class Version1Date20250123120000 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20250125000000.php
+++ b/lib/Migration/Version1Date20250125000000.php
@@ -40,8 +40,6 @@ class Version1Date20250125000000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return null|ISchemaWrapper
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20250321061615.php
+++ b/lib/Migration/Version1Date20250321061615.php
@@ -39,8 +39,6 @@ class Version1Date20250321061615 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
@@ -56,7 +54,6 @@ class Version1Date20250321061615 extends SimpleMigrationStep
      *
      * @return ISchemaWrapper
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.NPathComplexity)       Database migration requires checking many columns
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
@@ -400,8 +397,6 @@ class Version1Date20250321061615 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20250410070338.php
+++ b/lib/Migration/Version1Date20250410070338.php
@@ -42,7 +42,6 @@ class Version1Date20250410070338 extends SimpleMigrationStep
      *
      * @psalm-return ISchemaWrapper|null
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      * @return                                        ISchemaWrapper
      */

--- a/lib/Migration/Version1Date20250430083916.php
+++ b/lib/Migration/Version1Date20250430083916.php
@@ -42,8 +42,6 @@ class Version1Date20250430083916 extends SimpleMigrationStep
      *
      * @psalm-return ISchemaWrapper|null
      * @return       ISchemaWrapper
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20250607093617.php
+++ b/lib/Migration/Version1Date20250607093617.php
@@ -42,8 +42,6 @@ class Version1Date20250607093617 extends SimpleMigrationStep
      *
      * @psalm-return ISchemaWrapper|null
      * @return       ISchemaWrapper
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20250622212509.php
+++ b/lib/Migration/Version1Date20250622212509.php
@@ -47,7 +47,6 @@ class Version1Date20250622212509 extends SimpleMigrationStep
      *
      * @return ISchemaWrapper|null Modified schema
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.NPathComplexity)       Database migration requires checking many columns
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)  Database migration requires checking many columns
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Database migration requires many column definitions
@@ -268,8 +267,6 @@ class Version1Date20250622212509 extends SimpleMigrationStep
      * @param array<array-key, mixed> $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20250626031231.php
+++ b/lib/Migration/Version1Date20250626031231.php
@@ -40,8 +40,6 @@ class Version1Date20250626031231 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return ISchemaWrapper
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20250712080102.php
+++ b/lib/Migration/Version1Date20250712080102.php
@@ -41,8 +41,6 @@ class Version1Date20250712080102 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
@@ -57,8 +55,6 @@ class Version1Date20250712080102 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return ISchemaWrapper
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -155,8 +151,6 @@ class Version1Date20250712080102 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20250723110323.php
+++ b/lib/Migration/Version1Date20250723110323.php
@@ -29,8 +29,6 @@ use OCP\IDBConnection;
 
 /**
  * Migration to add is_default column to organisations table
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20250723110323 extends SimpleMigrationStep
 {
@@ -61,8 +59,6 @@ class Version1Date20250723110323 extends SimpleMigrationStep
      * @param Closure(): ISchemaWrapper $schemaClosure Schema closure.
      * @param array                     $options       Migration options.
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
      * @return void
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
@@ -80,8 +76,6 @@ class Version1Date20250723110323 extends SimpleMigrationStep
      * @return ISchemaWrapper The modified schema.
      *
      * @psalm-suppress UnusedParam $options is required by interface but not used
-     *
-     * @SuppressWarnings (PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -117,8 +111,6 @@ class Version1Date20250723110323 extends SimpleMigrationStep
      * @param array                     $options       Migration options.
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20250801000000.php
+++ b/lib/Migration/Version1Date20250801000000.php
@@ -59,8 +59,6 @@ class Version1Date20250801000000 extends SimpleMigrationStep
      * @param Closure(): ISchemaWrapper $schemaClosure Schema closure
      * @param array                     $options       Migration options
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
      * @return void
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
@@ -76,8 +74,6 @@ class Version1Date20250801000000 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return ISchemaWrapper
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -150,8 +146,6 @@ class Version1Date20250801000000 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20250813140000.php
+++ b/lib/Migration/Version1Date20250813140000.php
@@ -45,8 +45,6 @@ class Version1Date20250813140000 extends SimpleMigrationStep
      * @param array<array-key, mixed> $options       Migration options
      *
      * @return null|ISchemaWrapper Updated schema or null
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20250828120000.php
+++ b/lib/Migration/Version1Date20250828120000.php
@@ -70,7 +70,6 @@ class Version1Date20250828120000 extends SimpleMigrationStep
      *
      * @return null|ISchemaWrapper Modified schema or null
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)  Database migration requires checking many index conditions
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Database migration requires many index definitions
      *

--- a/lib/Migration/Version1Date20250829120000.php
+++ b/lib/Migration/Version1Date20250829120000.php
@@ -61,8 +61,6 @@ class Version1Date20250829120000 extends SimpleMigrationStep
      * @param Closure(): ISchemaWrapper $schemaClosure Schema closure
      * @param array                     $options       Migration options
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
      * @return void
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
@@ -212,8 +210,7 @@ class Version1Date20250829120000 extends SimpleMigrationStep
      *
      * @return ISchemaWrapper
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     * @SuppressWarnings(PHPMD.CyclomaticComplexity)  Database migration requires checking many column/index conditions
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) Database migration requires checking many column/index conditions
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20250830120000.php
+++ b/lib/Migration/Version1Date20250830120000.php
@@ -53,8 +53,6 @@ class Version1Date20250830120000 extends SimpleMigrationStep
      * @param array<array-key, mixed> $options       Migration options
      *
      * @return ISchemaWrapper|null The modified schema
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -117,8 +115,6 @@ class Version1Date20250830120000 extends SimpleMigrationStep
      * @param array<array-key, mixed> $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20250830130000.php
+++ b/lib/Migration/Version1Date20250830130000.php
@@ -47,8 +47,6 @@ class Version1Date20250830130000 extends SimpleMigrationStep
      * @param array<array-key, mixed> $options       Migration options
      *
      * @return ISchemaWrapper|null The modified schema
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20250831120000.php
+++ b/lib/Migration/Version1Date20250831120000.php
@@ -45,8 +45,6 @@ class Version1Date20250831120000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return null|ISchemaWrapper Modified schema or null
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20250831130000.php
+++ b/lib/Migration/Version1Date20250831130000.php
@@ -45,8 +45,6 @@ class Version1Date20250831130000 extends SimpleMigrationStep
      * @param array<array-key, mixed> $options       Migration options
      *
      * @return null|ISchemaWrapper Updated schema or null
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20250901120000.php
+++ b/lib/Migration/Version1Date20250901120000.php
@@ -46,8 +46,6 @@ class Version1Date20250901120000 extends SimpleMigrationStep
      * @param array<array-key, mixed> $options       Migration options
      *
      * @return null|ISchemaWrapper Updated schema or null
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20250902130000.php
+++ b/lib/Migration/Version1Date20250902130000.php
@@ -45,8 +45,6 @@ class Version1Date20250902130000 extends SimpleMigrationStep
      * @param array<array-key, mixed> $options       Migration options
      *
      * @return null|ISchemaWrapper Updated schema or null
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -71,8 +69,6 @@ class Version1Date20250902130000 extends SimpleMigrationStep
      * @param array<array-key, mixed> $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20250902140000.php
+++ b/lib/Migration/Version1Date20250902140000.php
@@ -61,8 +61,6 @@ class Version1Date20250902140000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return null|ISchemaWrapper Updated schema or null
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20250902150000.php
+++ b/lib/Migration/Version1Date20250902150000.php
@@ -61,8 +61,6 @@ class Version1Date20250902150000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return null|ISchemaWrapper Updated schema or null
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -99,8 +97,6 @@ class Version1Date20250902150000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20250903170000.php
+++ b/lib/Migration/Version1Date20250903170000.php
@@ -57,8 +57,6 @@ class Version1Date20250903170000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return ISchemaWrapper|null The new schema or null if no changes
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20250904170000.php
+++ b/lib/Migration/Version1Date20250904170000.php
@@ -49,8 +49,6 @@ class Version1Date20250904170000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return ISchemaWrapper|null Updated schema
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20250908174500.php
+++ b/lib/Migration/Version1Date20250908174500.php
@@ -46,8 +46,6 @@ class Version1Date20250908174500 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return ISchemaWrapper|null Updated schema
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -103,8 +101,6 @@ class Version1Date20250908174500 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20250908180000.php
+++ b/lib/Migration/Version1Date20250908180000.php
@@ -54,8 +54,6 @@ class Version1Date20250908180000 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return null Updated schema
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -79,8 +77,6 @@ class Version1Date20250908180000 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20250929120000.php
+++ b/lib/Migration/Version1Date20250929120000.php
@@ -56,8 +56,6 @@ class Version1Date20250929120000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return ISchemaWrapper|null Updated schema
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -109,8 +107,6 @@ class Version1Date20250929120000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20251101120000.php
+++ b/lib/Migration/Version1Date20251101120000.php
@@ -47,7 +47,6 @@ class Version1Date20251101120000 extends SimpleMigrationStep
      *
      * @return ISchemaWrapper|null Updated schema
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Database migration requires many column definitions
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper

--- a/lib/Migration/Version1Date20251102130000.php
+++ b/lib/Migration/Version1Date20251102130000.php
@@ -46,8 +46,6 @@ class Version1Date20251102130000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return ISchemaWrapper|null Updated schema
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20251102140000.php
+++ b/lib/Migration/Version1Date20251102140000.php
@@ -48,7 +48,6 @@ class Version1Date20251102140000 extends SimpleMigrationStep
      *
      * @return ISchemaWrapper|null Updated schema
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper

--- a/lib/Migration/Version1Date20251102150000.php
+++ b/lib/Migration/Version1Date20251102150000.php
@@ -46,8 +46,6 @@ class Version1Date20251102150000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return ISchemaWrapper|null Updated schema
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20251102160000.php
+++ b/lib/Migration/Version1Date20251102160000.php
@@ -48,7 +48,6 @@ class Version1Date20251102160000 extends SimpleMigrationStep
      *
      * @return ISchemaWrapper|null Updated schema
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper

--- a/lib/Migration/Version1Date20251102170000.php
+++ b/lib/Migration/Version1Date20251102170000.php
@@ -44,8 +44,6 @@ class Version1Date20251102170000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return null Updated schema
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20251102180000.php
+++ b/lib/Migration/Version1Date20251102180000.php
@@ -46,8 +46,6 @@ class Version1Date20251102180000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
@@ -74,8 +72,6 @@ class Version1Date20251102180000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return ISchemaWrapper|null Updated schema
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -117,8 +113,6 @@ class Version1Date20251102180000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20251103120000.php
+++ b/lib/Migration/Version1Date20251103120000.php
@@ -51,8 +51,6 @@ class Version1Date20251103120000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return null|ISchemaWrapper The updated schema or null
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -129,8 +127,6 @@ class Version1Date20251103120000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20251103120000.php
+++ b/lib/Migration/Version1Date20251103120000.php
@@ -11,7 +11,7 @@
  *
  * @author    Conduction Development Team <dev@conduction.nl>
  * @copyright 2024 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @link https://www.openregister.nl
  */

--- a/lib/Migration/Version1Date20251103130000.php
+++ b/lib/Migration/Version1Date20251103130000.php
@@ -12,7 +12,7 @@
  *
  * @author    Conduction Development Team <dev@conduction.nl>
  * @copyright 2024 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT: <git-id>
  * @link      https://www.openregister.nl
  */

--- a/lib/Migration/Version1Date20251103130000.php
+++ b/lib/Migration/Version1Date20251103130000.php
@@ -43,8 +43,6 @@ class Version1Date20251103130000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return null|ISchemaWrapper The updated schema or null
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20251105140000.php
+++ b/lib/Migration/Version1Date20251105140000.php
@@ -11,7 +11,7 @@
  *
  * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @version GIT: <git_id>
  *

--- a/lib/Migration/Version1Date20251105140000.php
+++ b/lib/Migration/Version1Date20251105140000.php
@@ -45,7 +45,6 @@ class Version1Date20251105140000 extends SimpleMigrationStep
      *
      * @return null|ISchemaWrapper The updated schema or null
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.NPathComplexity)       Database migration requires checking many columns
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)

--- a/lib/Migration/Version1Date20251105150000.php
+++ b/lib/Migration/Version1Date20251105150000.php
@@ -52,7 +52,6 @@ class Version1Date20251105150000 extends SimpleMigrationStep
      *
      * @return ISchemaWrapper|null Updated schema
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.NPathComplexity)       Database migration requires checking many columns
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)

--- a/lib/Migration/Version1Date20251106000000.php
+++ b/lib/Migration/Version1Date20251106000000.php
@@ -46,7 +46,6 @@ class Version1Date20251106000000 extends SimpleMigrationStep
      *
      * @return null|ISchemaWrapper The modified schema.
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.StaticAccess)          Type::getType is standard Doctrine DBAL pattern
      * @SuppressWarnings(PHPMD.NPathComplexity)       Database migration requires checking many columns
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)

--- a/lib/Migration/Version1Date20251106000001.php
+++ b/lib/Migration/Version1Date20251106000001.php
@@ -44,8 +44,6 @@ class Version1Date20251106000001 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return ISchemaWrapper|null Updated schema
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20251106120000.php
+++ b/lib/Migration/Version1Date20251106120000.php
@@ -60,7 +60,6 @@ class Version1Date20251106120000 extends SimpleMigrationStep
      *
      * @return ISchemaWrapper|null Updated schema
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.StaticAccess)          Type::getType is standard Doctrine DBAL pattern
      * @SuppressWarnings(PHPMD.NPathComplexity)       Database migration requires checking many columns
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)

--- a/lib/Migration/Version1Date20251107000000.php
+++ b/lib/Migration/Version1Date20251107000000.php
@@ -43,8 +43,6 @@ class Version1Date20251107000000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return ISchemaWrapper|null Updated schema
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20251107120000.php
+++ b/lib/Migration/Version1Date20251107120000.php
@@ -42,8 +42,6 @@ class Version1Date20251107120000 extends SimpleMigrationStep
      * @phpstan-return ISchemaWrapper|null
      * @psalm-return   ISchemaWrapper|null
      * @return         ISchemaWrapper|null The modified schema
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20251107140000.php
+++ b/lib/Migration/Version1Date20251107140000.php
@@ -46,8 +46,6 @@ class Version1Date20251107140000 extends SimpleMigrationStep
      * @param array   $options       The options
      *
      * @return null|ISchemaWrapper The schema wrapper
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20251107150000.php
+++ b/lib/Migration/Version1Date20251107150000.php
@@ -37,7 +37,6 @@ class Version1Date20251107150000 extends SimpleMigrationStep
      *
      * @return null|ISchemaWrapper Updated schema or null
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Database migration requires many column definitions
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper

--- a/lib/Migration/Version1Date20251107160000.php
+++ b/lib/Migration/Version1Date20251107160000.php
@@ -47,8 +47,6 @@ class Version1Date20251107160000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return ISchemaWrapper|null Updated schema
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -107,8 +105,6 @@ class Version1Date20251107160000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20251107170000.php
+++ b/lib/Migration/Version1Date20251107170000.php
@@ -42,8 +42,6 @@ class Version1Date20251107170000 extends SimpleMigrationStep
      * @param array   $options       Options
      *
      * @return ISchemaWrapper|null The modified schema or null
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -95,8 +93,6 @@ class Version1Date20251107170000 extends SimpleMigrationStep
      * @param array   $options       Options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20251107180000.php
+++ b/lib/Migration/Version1Date20251107180000.php
@@ -49,8 +49,6 @@ class Version1Date20251107180000 extends SimpleMigrationStep
      * @param array   $options       Options
      *
      * @return ISchemaWrapper|null The modified schema or null
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -123,8 +121,6 @@ class Version1Date20251107180000 extends SimpleMigrationStep
      * @param array   $options       Options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20251107190000.php
+++ b/lib/Migration/Version1Date20251107190000.php
@@ -44,8 +44,6 @@ class Version1Date20251107190000 extends SimpleMigrationStep
      * @param array   $options       Options
      *
      * @return ISchemaWrapper|null The modified schema or null
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -89,8 +87,6 @@ class Version1Date20251107190000 extends SimpleMigrationStep
      * @param array   $options       Options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20251110000000.php
+++ b/lib/Migration/Version1Date20251110000000.php
@@ -58,8 +58,6 @@ class Version1Date20251110000000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return ISchemaWrapper|null Updated schema or null if no changes
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -157,8 +155,6 @@ class Version1Date20251110000000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20251111000000.php
+++ b/lib/Migration/Version1Date20251111000000.php
@@ -59,8 +59,6 @@ class Version1Date20251111000000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return ISchemaWrapper|null Updated schema or null if no changes
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -157,8 +155,6 @@ class Version1Date20251111000000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20251114120000.php
+++ b/lib/Migration/Version1Date20251114120000.php
@@ -51,8 +51,6 @@ class Version1Date20251114120000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return ISchemaWrapper|null Updated schema
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20251114130000.php
+++ b/lib/Migration/Version1Date20251114130000.php
@@ -67,8 +67,6 @@ class Version1Date20251114130000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
@@ -128,8 +126,6 @@ class Version1Date20251114130000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return ISchemaWrapper|null Updated schema
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20251115000000.php
+++ b/lib/Migration/Version1Date20251115000000.php
@@ -49,7 +49,6 @@ class Version1Date20251115000000 extends SimpleMigrationStep
      *
      * @return ISchemaWrapper|null Updated schema
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.NPathComplexity)       Database migration requires checking many columns
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)

--- a/lib/Migration/Version1Date20251116000000.php
+++ b/lib/Migration/Version1Date20251116000000.php
@@ -36,8 +36,6 @@ class Version1Date20251116000000 extends SimpleMigrationStep
      * @return ISchemaWrapper Updated schema.
      *
      * @psalm-suppress UnusedParam $options is required by interface but not used
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20251117000000.php
+++ b/lib/Migration/Version1Date20251117000000.php
@@ -25,8 +25,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Adds checksum column to chunks table for change detection.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20251117000000 extends SimpleMigrationStep
 {
@@ -40,8 +38,6 @@ class Version1Date20251117000000 extends SimpleMigrationStep
      * @return ISchemaWrapper Updated schema.
      *
      * @psalm-suppress UnusedParam $options is required by interface but not used
-     *
-     * @SuppressWarnings (PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20251118000000.php
+++ b/lib/Migration/Version1Date20251118000000.php
@@ -27,8 +27,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Drops deprecated file_texts and object_texts tables.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20251118000000 extends SimpleMigrationStep
 {
@@ -42,8 +40,6 @@ class Version1Date20251118000000 extends SimpleMigrationStep
      * @return ISchemaWrapper Updated schema.
      *
      * @psalm-suppress UnusedParam $options is required by interface but not used
-     *
-     * @SuppressWarnings (PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20251120210000.php
+++ b/lib/Migration/Version1Date20251120210000.php
@@ -41,7 +41,6 @@ class Version1Date20251120210000 extends SimpleMigrationStep
      *
      * @return null|ISchemaWrapper
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */

--- a/lib/Migration/Version1Date20251128120000.php
+++ b/lib/Migration/Version1Date20251128120000.php
@@ -49,7 +49,6 @@ class Version1Date20251128120000 extends SimpleMigrationStep
      *
      * @return ISchemaWrapper|null
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
@@ -425,8 +424,6 @@ class Version1Date20251128120000 extends SimpleMigrationStep
      * @param array   $options       Options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20251201120000.php
+++ b/lib/Migration/Version1Date20251201120000.php
@@ -52,8 +52,6 @@ class Version1Date20251201120000 extends SimpleMigrationStep
      * @param array   $options       Options
      *
      * @return ISchemaWrapper|null
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -108,8 +106,6 @@ class Version1Date20251201120000 extends SimpleMigrationStep
      * @param array   $options       Options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20251202000000.php
+++ b/lib/Migration/Version1Date20251202000000.php
@@ -51,7 +51,6 @@ class Version1Date20251202000000 extends SimpleMigrationStep
      *
      * @return ISchemaWrapper|null Updated schema
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.NPathComplexity)       Database migration requires checking many columns
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)

--- a/lib/Migration/Version1Date20251216000000.php
+++ b/lib/Migration/Version1Date20251216000000.php
@@ -54,8 +54,6 @@ class Version1Date20251216000000 extends SimpleMigrationStep
      * @param array   $options       Migration options.
      *
      * @return ISchemaWrapper|null The new schema or null if no changes.
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20251216100000.php
+++ b/lib/Migration/Version1Date20251216100000.php
@@ -41,7 +41,6 @@ class Version1Date20251216100000 extends SimpleMigrationStep
      *
      * @return null|ISchemaWrapper
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */

--- a/lib/Migration/Version1Date20251216110000.php
+++ b/lib/Migration/Version1Date20251216110000.php
@@ -48,8 +48,6 @@ class Version1Date20251216110000 extends SimpleMigrationStep
      * @param array   $options       Options
      *
      * @return ISchemaWrapper|null
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20251220000000.php
+++ b/lib/Migration/Version1Date20251220000000.php
@@ -54,8 +54,6 @@ class Version1Date20251220000000 extends SimpleMigrationStep
      * @param array   $options       Additional migration options.
      *
      * @return ISchemaWrapper|null The modified schema or null if no changes.
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20251222000000.php
+++ b/lib/Migration/Version1Date20251222000000.php
@@ -78,8 +78,6 @@ class Version1Date20251222000000 extends SimpleMigrationStep
      * @param array<array-key, mixed> $options       Migration options.
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20260106000000.php
+++ b/lib/Migration/Version1Date20260106000000.php
@@ -58,8 +58,6 @@ class Version1Date20260106000000 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
@@ -76,8 +74,6 @@ class Version1Date20260106000000 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return ISchemaWrapper|null The modified schema wrapper
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -264,8 +260,6 @@ class Version1Date20260106000000 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20260118000000.php
+++ b/lib/Migration/Version1Date20260118000000.php
@@ -54,8 +54,6 @@ class Version1Date20260118000000 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
@@ -71,8 +69,6 @@ class Version1Date20260118000000 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return ISchemaWrapper|null The modified schema wrapper
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -120,8 +116,6 @@ class Version1Date20260118000000 extends SimpleMigrationStep
      * @param array                     $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20260306000000.php
+++ b/lib/Migration/Version1Date20260306000000.php
@@ -44,8 +44,6 @@ class Version1Date20260306000000 extends SimpleMigrationStep
      * @param array<string, mixed>      $options       Migration options
      *
      * @return ISchemaWrapper|null
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20260306100000.php
+++ b/lib/Migration/Version1Date20260306100000.php
@@ -44,8 +44,6 @@ class Version1Date20260306100000 extends SimpleMigrationStep
      * @param array<string, mixed>      $options       Migration options
      *
      * @return ISchemaWrapper|null
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20260306120000.php
+++ b/lib/Migration/Version1Date20260306120000.php
@@ -42,8 +42,6 @@ class Version1Date20260306120000 extends SimpleMigrationStep
      * @param array<string, mixed>      $options       Migration options
      *
      * @return ISchemaWrapper|null
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20260307000000.php
+++ b/lib/Migration/Version1Date20260307000000.php
@@ -29,7 +29,6 @@ use OCP\Migration\SimpleMigrationStep;
  * @package OCA\OpenRegister\Migration
  *
  * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260307000000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260308000000.php
+++ b/lib/Migration/Version1Date20260308000000.php
@@ -30,8 +30,6 @@ use OCP\Migration\SimpleMigrationStep;
  * by a given configuration, enabling mapping import from JSON config files.
  *
  * @package OCA\OpenRegister\Migration
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260308000000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260308120000.php
+++ b/lib/Migration/Version1Date20260308120000.php
@@ -30,8 +30,6 @@ use OCP\Migration\SimpleMigrationStep;
  * payload transformation before delivery.
  *
  * @package OCA\OpenRegister\Migration
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260308120000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260313120000.php
+++ b/lib/Migration/Version1Date20260313120000.php
@@ -65,8 +65,6 @@ class Version1Date20260313120000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return ISchemaWrapper|null The updated schema or null if no changes
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20260313130000.php
+++ b/lib/Migration/Version1Date20260313130000.php
@@ -59,8 +59,6 @@ class Version1Date20260313130000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return ISchemaWrapper|null The updated schema or null if no changes
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20260318120000.php
+++ b/lib/Migration/Version1Date20260318120000.php
@@ -44,8 +44,6 @@ class Version1Date20260318120000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return ISchemaWrapper|null The updated schema or null if no changes
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20260322000000.php
+++ b/lib/Migration/Version1Date20260322000000.php
@@ -42,8 +42,6 @@ class Version1Date20260322000000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return ISchemaWrapper|null The updated schema or null if no changes
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20260322100000.php
+++ b/lib/Migration/Version1Date20260322100000.php
@@ -43,8 +43,6 @@ class Version1Date20260322100000 extends SimpleMigrationStep
      * @param array<string, mixed>      $options       Migration options
      *
      * @return ISchemaWrapper|null The updated schema or null if no changes
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20260322120000.php
+++ b/lib/Migration/Version1Date20260322120000.php
@@ -62,8 +62,6 @@ class Version1Date20260322120000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20260325000000.php
+++ b/lib/Migration/Version1Date20260325000000.php
@@ -45,8 +45,6 @@ class Version1Date20260325000000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return ISchemaWrapper|null The updated schema or null if no changes
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20260325000001.php
+++ b/lib/Migration/Version1Date20260325000001.php
@@ -39,7 +39,6 @@ class Version1Date20260325000001 extends SimpleMigrationStep
      *
      * @return ISchemaWrapper|null
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper

--- a/lib/Migration/Version1Date20260325000002.php
+++ b/lib/Migration/Version1Date20260325000002.php
@@ -39,7 +39,6 @@ class Version1Date20260325000002 extends SimpleMigrationStep
      *
      * @return ISchemaWrapper|null
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper

--- a/lib/Migration/Version1Date20260325000003.php
+++ b/lib/Migration/Version1Date20260325000003.php
@@ -39,7 +39,6 @@ class Version1Date20260325000003 extends SimpleMigrationStep
      *
      * @return ISchemaWrapper|null
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper

--- a/lib/Migration/Version1Date20260325120000.php
+++ b/lib/Migration/Version1Date20260325120000.php
@@ -38,8 +38,6 @@ use OCP\Migration\SimpleMigrationStep;
  * - download_count (INT) - Cached download count for audit
  *
  * @package OCA\OpenRegister\Migration
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260325120000 extends SimpleMigrationStep
 {
@@ -52,7 +50,6 @@ class Version1Date20260325120000 extends SimpleMigrationStep
      *
      * @return ISchemaWrapper|null The updated schema or null if no changes
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */

--- a/lib/Migration/Version1Date20260326000000.php
+++ b/lib/Migration/Version1Date20260326000000.php
@@ -52,7 +52,6 @@ class Version1Date20260326000000 extends SimpleMigrationStep
      *
      * @return ISchemaWrapper|null The updated schema or null if no changes
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper

--- a/lib/Migration/Version1Date20260326100000.php
+++ b/lib/Migration/Version1Date20260326100000.php
@@ -30,8 +30,6 @@ use OCP\Migration\SimpleMigrationStep;
  * to openregister_registers, openregister_schemas, and openregister_organisations tables.
  *
  * These columns store lean JSON arrays of string IDs for linked Nextcloud entities.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260326100000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260326100001.php
+++ b/lib/Migration/Version1Date20260326100001.php
@@ -29,8 +29,6 @@ use OCP\Migration\SimpleMigrationStep;
  *
  * These entity-specific link tables are replaced by the generic linked entity metadata columns
  * (_mail, _contacts, _deck) on magic tables and entity tables.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260326100001 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260423100000.php
+++ b/lib/Migration/Version1Date20260423100000.php
@@ -36,8 +36,6 @@ use OCP\Migration\SimpleMigrationStep;
  * identifiers (`object_uuid`, `user`) already carry the useful information;
  * `user_name` and `session` are display-only legacy columns, and `object`
  * is a legacy FK-ish integer column.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260423100000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260430120000.php
+++ b/lib/Migration/Version1Date20260430120000.php
@@ -33,8 +33,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Migration class creating the openregister_translations sidecar table.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260430120000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260430140000.php
+++ b/lib/Migration/Version1Date20260430140000.php
@@ -33,8 +33,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Adds a nullable `type` column + index on `openregister_registers`.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260430140000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260430160000.php
+++ b/lib/Migration/Version1Date20260430160000.php
@@ -39,8 +39,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Adds `oc_openregister_verwerkingsactiviteiten` per AVG Art 30 §1.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260430160000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260430180000.php
+++ b/lib/Migration/Version1Date20260430180000.php
@@ -41,8 +41,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Adds disambiguating columns to entity_relations.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260430180000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260501100000.php
+++ b/lib/Migration/Version1Date20260501100000.php
@@ -57,8 +57,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Create notification history table.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260501100000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260502120000.php
+++ b/lib/Migration/Version1Date20260502120000.php
@@ -47,8 +47,6 @@ class Version1Date20260502120000 extends SimpleMigrationStep
      * @param array<array-key, mixed> $options       Migration options
      *
      * @return null|ISchemaWrapper
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20260502130000.php
+++ b/lib/Migration/Version1Date20260502130000.php
@@ -57,7 +57,6 @@ class Version1Date20260502130000 extends SimpleMigrationStep
      *
      * @return null|ISchemaWrapper
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper

--- a/lib/Migration/Version1Date20260502190000.php
+++ b/lib/Migration/Version1Date20260502190000.php
@@ -44,8 +44,6 @@ class Version1Date20260502190000 extends SimpleMigrationStep
      * @param array<array-key, mixed> $options       Migration options
      *
      * @return null|ISchemaWrapper
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20260502200000.php
+++ b/lib/Migration/Version1Date20260502200000.php
@@ -43,8 +43,6 @@ class Version1Date20260502200000 extends SimpleMigrationStep
      * @param array<array-key, mixed> $options       Migration options
      *
      * @return null|ISchemaWrapper
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20260511100000.php
+++ b/lib/Migration/Version1Date20260511100000.php
@@ -24,7 +24,7 @@
  *
  * @link https://OpenRegister.app
  *
- * @spec openspec/changes/scholiq-deps/tenant-key-api/tasks.md
+ * @spec openspec/specs/saas-multi-tenant/spec.md
  */
 
 declare(strict_types=1);

--- a/lib/Migration/Version1Date20260511100000.php
+++ b/lib/Migration/Version1Date20260511100000.php
@@ -50,8 +50,6 @@ class Version1Date20260511100000 extends SimpleMigrationStep
      * @param array<array-key, mixed> $options       Migration options
      *
      * @return null|ISchemaWrapper
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20260511110000.php
+++ b/lib/Migration/Version1Date20260511110000.php
@@ -48,8 +48,6 @@ class Version1Date20260511110000 extends SimpleMigrationStep
      * @param array<array-key, mixed> $options       Migration options
      *
      * @return ISchemaWrapper|null Updated schema, or null when no change was needed
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20260511120000.php
+++ b/lib/Migration/Version1Date20260511120000.php
@@ -44,8 +44,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Create the notification dispatch log table for idempotency-key dedup.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260511120000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260511130000.php
+++ b/lib/Migration/Version1Date20260511130000.php
@@ -50,8 +50,6 @@ class Version1Date20260511130000 extends SimpleMigrationStep
      * @param array<array-key, mixed> $options       Migration options
      *
      * @return null|ISchemaWrapper Updated schema or null if no changes
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -93,8 +91,6 @@ class Version1Date20260511130000 extends SimpleMigrationStep
      * @param array<array-key, mixed> $options       Migration options
      *
      * @return null|ISchemaWrapper Updated schema or null if no changes
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function down(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20260512120000.php
+++ b/lib/Migration/Version1Date20260512120000.php
@@ -54,8 +54,6 @@ use OCP\Migration\SimpleMigrationStep;
  * Adds the `bases` and `skip_anonymization` decision-metadata columns
  * to the entity_relations table. Both columns are nullable-or-defaulted
  * so existing rows pick up sensible defaults without backfill.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260512120000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260520120000.php
+++ b/lib/Migration/Version1Date20260520120000.php
@@ -37,8 +37,6 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * Add `source_language` to `openregister_translations`.
  *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
- *
  * @spec openspec/changes/i18n-source-of-truth/tasks.md#phase-1
  */
 class Version1Date20260520120000 extends SimpleMigrationStep

--- a/lib/Migration/Version1Date20260521120000.php
+++ b/lib/Migration/Version1Date20260521120000.php
@@ -81,8 +81,6 @@ class Version1Date20260521120000 extends SimpleMigrationStep
      * @param array<array-key, mixed> $options       Migration options
      *
      * @return null|ISchemaWrapper Always null — no schema diff
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -100,8 +98,6 @@ class Version1Date20260521120000 extends SimpleMigrationStep
      * @param array<array-key, mixed> $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {
@@ -114,61 +110,11 @@ class Version1Date20260521120000 extends SimpleMigrationStep
             return;
         }
 
-        if ($isPostgres === true) {
-            // PostgreSQL index names are schema-scoped, not table-scoped — so
-            // each per-table bare `_uuid` index has a unique fully-qualified
-            // identifier (the auto-naming would have suffixed numbers if it
-            // ever collided). We can't safely drop by bare name across the
-            // schema; instead drop per-table via the table's own metadata.
-            $dropped = 0;
-            foreach ($affectedTables as $tableName) {
-                try {
-                    // Look up indexes on this table named `_uuid` and drop each by full name.
-                    $sql  = "SELECT indexname
-                            FROM pg_indexes
-                            WHERE tablename = ?
-                              AND indexname LIKE '\\_uuid%' ESCAPE '\\'";
-                    $rows = $this->connection->executeQuery($sql, [$tableName])->fetchAll();
-                    foreach ($rows as $row) {
-                        $indexName = (string) $row['indexname'];
-                        // Be conservative: only drop indexes whose name is exactly `_uuid`
-                        // or the bare-name suffixed variants Postgres emits on collision.
-                        if (preg_match('/^_uuid(\d+)?$/', $indexName) === 1) {
-                            $this->connection->executeStatement(
-                                sprintf('DROP INDEX IF EXISTS "%s"', $indexName)
-                            );
-                            $dropped++;
-                        }
-                    }
-                } catch (Throwable $e) {
-                    $output->warning(
-                        message: sprintf(
-                            'Failed to drop bare `_uuid` index on `%s`: %s',
-                            $tableName,
-                            $e->getMessage()
-                        )
-                    );
-                }//end try
-            }//end foreach
-        } else {
-            $dropped = 0;
-            foreach ($affectedTables as $tableName) {
-                try {
-                    $this->connection->executeStatement(
-                        sprintf('ALTER TABLE `%s` DROP INDEX `_uuid`', $tableName)
-                    );
-                    $dropped++;
-                } catch (Throwable $e) {
-                    $output->warning(
-                        message: sprintf(
-                            'Failed to drop bare `_uuid` index on `%s`: %s',
-                            $tableName,
-                            $e->getMessage()
-                        )
-                    );
-                }
-            }
-        }//end if
+        $dropped = $this->dropBareUuidIndexes(
+            output: $output,
+            affectedTables: $affectedTables,
+            isPostgres: $isPostgres
+        );
 
         $output->info(
             message: sprintf(
@@ -179,6 +125,108 @@ class Version1Date20260521120000 extends SimpleMigrationStep
         );
 
     }//end postSchemaChange()
+
+    /**
+     * Dispatch the platform-specific drop of the bare `_uuid` index.
+     *
+     * @param IOutput  $output         Output for the migration process
+     * @param string[] $affectedTables Tables carrying a bare `_uuid` index
+     * @param bool     $isPostgres     Whether the platform is PostgreSQL
+     *
+     * @return int Number of indexes actually dropped
+     */
+    private function dropBareUuidIndexes(IOutput $output, array $affectedTables, bool $isPostgres): int
+    {
+        if ($isPostgres === true) {
+            return $this->dropBareUuidIndexesPostgres(output: $output, affectedTables: $affectedTables);
+        }
+
+        return $this->dropBareUuidIndexesMysql(output: $output, affectedTables: $affectedTables);
+
+    }//end dropBareUuidIndexes()
+
+    /**
+     * Drop the bare `_uuid` index on PostgreSQL.
+     *
+     * PostgreSQL index names are schema-scoped, not table-scoped — so each
+     * per-table bare `_uuid` index has a unique fully-qualified identifier (the
+     * auto-naming would have suffixed numbers if it ever collided). We can't
+     * safely drop by bare name across the schema; instead drop per-table via
+     * the table's own metadata.
+     *
+     * @param IOutput  $output         Output for the migration process
+     * @param string[] $affectedTables Tables carrying a bare `_uuid` index
+     *
+     * @return int Number of indexes actually dropped
+     */
+    private function dropBareUuidIndexesPostgres(IOutput $output, array $affectedTables): int
+    {
+        $dropped = 0;
+        foreach ($affectedTables as $tableName) {
+            try {
+                // Look up indexes on this table named `_uuid` and drop each by full name.
+                $sql  = "SELECT indexname
+                        FROM pg_indexes
+                        WHERE tablename = ?
+                          AND indexname LIKE '\\_uuid%' ESCAPE '\\'";
+                $rows = $this->connection->executeQuery($sql, [$tableName])->fetchAll();
+                foreach ($rows as $row) {
+                    $indexName = (string) $row['indexname'];
+                    // Be conservative: only drop indexes whose name is exactly `_uuid`
+                    // or the bare-name suffixed variants Postgres emits on collision.
+                    if (preg_match('/^_uuid(\d+)?$/', $indexName) === 1) {
+                        $this->connection->executeStatement(
+                            sprintf('DROP INDEX IF EXISTS "%s"', $indexName)
+                        );
+                        $dropped++;
+                    }
+                }
+            } catch (Throwable $e) {
+                $output->warning(
+                    message: sprintf(
+                        'Failed to drop bare `_uuid` index on `%s`: %s',
+                        $tableName,
+                        $e->getMessage()
+                    )
+                );
+            }//end try
+        }//end foreach
+
+        return $dropped;
+
+    }//end dropBareUuidIndexesPostgres()
+
+    /**
+     * Drop the bare `_uuid` index on MySQL/MariaDB.
+     *
+     * @param IOutput  $output         Output for the migration process
+     * @param string[] $affectedTables Tables carrying a bare `_uuid` index
+     *
+     * @return int Number of indexes actually dropped
+     */
+    private function dropBareUuidIndexesMysql(IOutput $output, array $affectedTables): int
+    {
+        $dropped = 0;
+        foreach ($affectedTables as $tableName) {
+            try {
+                $this->connection->executeStatement(
+                    sprintf('ALTER TABLE `%s` DROP INDEX `_uuid`', $tableName)
+                );
+                $dropped++;
+            } catch (Throwable $e) {
+                $output->warning(
+                    message: sprintf(
+                        'Failed to drop bare `_uuid` index on `%s`: %s',
+                        $tableName,
+                        $e->getMessage()
+                    )
+                );
+            }//end try
+        }//end foreach
+
+        return $dropped;
+
+    }//end dropBareUuidIndexesMysql()
 
     /**
      * Find every `oc_openregister_table_*` table that has an index literally
@@ -194,27 +242,7 @@ class Version1Date20260521120000 extends SimpleMigrationStep
         $tableNames = [];
 
         try {
-            if ($isPostgres === true) {
-                // Mirror the LIKE pattern used in postSchemaChange so a table
-                // whose bare index ended up as `_uuid1` (Postgres' on-collision
-                // auto-suffix) is still surfaced for repair. The downstream
-                // drop step re-filters with a strict `^_uuid(\d+)?$` regex.
-                $sql    = "SELECT tablename
-                        FROM pg_indexes
-                        WHERE indexname LIKE '\\_uuid%' ESCAPE '\\'
-                          AND tablename LIKE 'oc_openregister_table_%'";
-                $result = $this->connection->executeQuery($sql);
-            } else {
-                $sql    = 'SELECT TABLE_NAME
-                        FROM INFORMATION_SCHEMA.STATISTICS
-                        WHERE TABLE_SCHEMA = DATABASE()
-                          AND INDEX_NAME = ?
-                          AND TABLE_NAME LIKE ?
-                        GROUP BY TABLE_NAME';
-                $result = $this->connection->executeQuery($sql, ['_uuid', 'oc_openregister_table_%']);
-            }
-
-            foreach ($result->fetchAll() as $row) {
+            foreach ($this->queryTablesWithBareUuidIndex(isPostgres: $isPostgres) as $row) {
                 $name = $row['tablename'] ?? $row['TABLE_NAME'] ?? null;
                 if ($name !== null) {
                     $tableNames[] = (string) $name;
@@ -229,4 +257,39 @@ class Version1Date20260521120000 extends SimpleMigrationStep
         return $tableNames;
 
     }//end findAffectedTables()
+
+    /**
+     * Run the platform-specific introspection query for tables carrying a bare
+     * `_uuid` index.
+     *
+     * @param bool $isPostgres Whether the platform is PostgreSQL
+     *
+     * @return array<array-key, array<string, mixed>> Raw result rows
+     */
+    private function queryTablesWithBareUuidIndex(bool $isPostgres): array
+    {
+        if ($isPostgres === true) {
+            // Mirror the LIKE pattern used in dropBareUuidIndexesPostgres so a
+            // table whose bare index ended up as `_uuid1` (Postgres'
+            // on-collision auto-suffix) is still surfaced for repair. The
+            // downstream drop step re-filters with a strict `^_uuid(\d+)?$`
+            // regex.
+            $sql = "SELECT tablename
+                    FROM pg_indexes
+                    WHERE indexname LIKE '\\_uuid%' ESCAPE '\\'
+                      AND tablename LIKE 'oc_openregister_table_%'";
+
+            return $this->connection->executeQuery($sql)->fetchAll();
+        }
+
+        $sql = 'SELECT TABLE_NAME
+                FROM INFORMATION_SCHEMA.STATISTICS
+                WHERE TABLE_SCHEMA = DATABASE()
+                  AND INDEX_NAME = ?
+                  AND TABLE_NAME LIKE ?
+                GROUP BY TABLE_NAME';
+
+        return $this->connection->executeQuery($sql, ['_uuid', 'oc_openregister_table_%'])->fetchAll();
+
+    }//end queryTablesWithBareUuidIndex()
 }//end class

--- a/lib/Migration/Version1Date20260524100000.php
+++ b/lib/Migration/Version1Date20260524100000.php
@@ -49,8 +49,6 @@ use OCP\Migration\SimpleMigrationStep;
  *
  * Extend the contact-links table with phone / org / avatar_url / metadata
  * + the (object_uuid, contact_uid) unique composite index.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260524100000 extends SimpleMigrationStep
 {
@@ -87,75 +85,66 @@ class Version1Date20260524100000 extends SimpleMigrationStep
             return $schema;
         }
 
-        $changed = false;
-        $table   = $schema->getTable(self::TABLE);
+        $table = $schema->getTable(self::TABLE);
 
-        if ($table->hasColumn(name: 'schema_id') === false) {
-            $table->addColumn(
-                name: 'schema_id',
-                typeName: Types::BIGINT,
-                options: [
+        // Tier-2 columns, in the order they must be appended. Driving them from
+        // a table keeps this method at one branch per concern instead of one
+        // branch per column (which pushed NPath complexity to 256).
+        $newColumns = [
+            'schema_id'  => [
+                'type'    => Types::BIGINT,
+                'options' => [
                     'notnull'  => false,
                     'default'  => null,
                     'unsigned' => true,
-                ]
-            );
-            $output->info(message: 'Added schema_id column to '.self::TABLE);
-            $changed = true;
-        }
-
-        if ($table->hasColumn(name: 'phone') === false) {
-            $table->addColumn(
-                name: 'phone',
-                typeName: Types::STRING,
-                options: [
+                ],
+            ],
+            'phone'      => [
+                'type'    => Types::STRING,
+                'options' => [
                     'notnull' => false,
                     'length'  => 64,
                     'default' => null,
-                ]
-            );
-            $output->info(message: 'Added phone column to '.self::TABLE);
-            $changed = true;
-        }
-
-        if ($table->hasColumn(name: 'org') === false) {
-            $table->addColumn(
-                name: 'org',
-                typeName: Types::STRING,
-                options: [
+                ],
+            ],
+            'org'        => [
+                'type'    => Types::STRING,
+                'options' => [
                     'notnull' => false,
                     'length'  => 255,
                     'default' => null,
-                ]
-            );
-            $output->info(message: 'Added org column to '.self::TABLE);
-            $changed = true;
-        }
-
-        if ($table->hasColumn(name: 'avatar_url') === false) {
-            $table->addColumn(
-                name: 'avatar_url',
-                typeName: Types::STRING,
-                options: [
+                ],
+            ],
+            'avatar_url' => [
+                'type'    => Types::STRING,
+                'options' => [
                     'notnull' => false,
                     'length'  => 512,
                     'default' => null,
-                ]
-            );
-            $output->info(message: 'Added avatar_url column to '.self::TABLE);
-            $changed = true;
-        }
-
-        if ($table->hasColumn(name: 'metadata') === false) {
-            $table->addColumn(
-                name: 'metadata',
-                typeName: Types::TEXT,
-                options: [
+                ],
+            ],
+            'metadata'   => [
+                'type'    => Types::TEXT,
+                'options' => [
                     'notnull' => false,
                     'default' => null,
-                ]
+                ],
+            ],
+        ];
+
+        $changed = false;
+
+        foreach ($newColumns as $columnName => $spec) {
+            if ($table->hasColumn(name: $columnName) === true) {
+                continue;
+            }
+
+            $table->addColumn(
+                name: $columnName,
+                typeName: $spec['type'],
+                options: $spec['options']
             );
-            $output->info(message: 'Added metadata column to '.self::TABLE);
+            $output->info(message: 'Added '.$columnName.' column to '.self::TABLE);
             $changed = true;
         }
 

--- a/lib/Migration/Version1Date20260524120000.php
+++ b/lib/Migration/Version1Date20260524120000.php
@@ -44,8 +44,6 @@ class Version1Date20260524120000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return ISchemaWrapper|null Updated schema or null
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20260524130000.php
+++ b/lib/Migration/Version1Date20260524130000.php
@@ -33,6 +33,7 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Migration;
 
 use Closure;
+use Doctrine\DBAL\Schema\Table;
 use OCP\DB\ISchemaWrapper;
 use OCP\DB\Types;
 use OCP\Migration\IOutput;
@@ -55,8 +56,6 @@ class Version1Date20260524130000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return ISchemaWrapper|null The updated schema or null if no changes
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -72,116 +71,69 @@ class Version1Date20260524130000 extends SimpleMigrationStep
 
         $table = $schema->createTable(tableName: 'openregister_form_links');
 
-        $table->addColumn(
-            'id',
-            Types::BIGINT,
-            [
-                'autoincrement' => true,
-                'notnull'       => true,
-                'unsigned'      => true,
-            ]
-        );
-        $table->addColumn(
-            'object_uuid',
-            Types::STRING,
-            [
-                'notnull' => true,
-                'length'  => 36,
-            ]
-        );
-        $table->addColumn(
-            'register_id',
-            Types::BIGINT,
-            [
-                'notnull'  => true,
-                'unsigned' => true,
-            ]
-        );
-        $table->addColumn(
-            'schema_id',
-            Types::BIGINT,
-            [
-                'notnull'  => false,
-                'unsigned' => true,
-                'default'  => null,
-            ]
-        );
-        $table->addColumn(
-            'form_id',
-            Types::BIGINT,
-            [
-                'notnull'  => true,
-                'unsigned' => true,
-            ]
-        );
-        $table->addColumn(
-            'form_hash',
-            Types::STRING,
-            [
-                'notnull' => false,
-                'length'  => 64,
-                'default' => null,
-            ]
-        );
-        // Submission id is nullable — a row with submission_id NULL is a
-        // form-level link; a row with a submission_id is a per-submission
-        // link. Composite unique below allows both shapes for the same
-        // (object, form) pair.
-        $table->addColumn(
-            'submission_id',
-            Types::BIGINT,
-            [
-                'notnull'  => false,
-                'unsigned' => true,
-                'default'  => null,
-            ]
-        );
-        $table->addColumn(
-            'title',
-            Types::STRING,
-            [
-                'notnull' => false,
-                'length'  => 255,
-                'default' => null,
-            ]
-        );
-        $table->addColumn(
-            'status',
-            Types::STRING,
-            [
-                'notnull' => false,
-                'length'  => 32,
-                'default' => null,
-            ]
-        );
-        $table->addColumn(
-            'expires_at',
-            Types::DATETIME,
-            [
-                'notnull' => false,
-                'default' => null,
-            ]
-        );
-        $table->addColumn(
-            'linked_by',
-            Types::STRING,
-            [
-                'notnull' => true,
-                'length'  => 64,
-            ]
-        );
-        $table->addColumn(
-            'linked_at',
-            Types::DATETIME,
-            [
-                'notnull' => true,
-            ]
-        );
+        $this->addColumns(table: $table);
+        $this->addIndexes(table: $table);
 
+        $output->info(message: 'Created openregister_form_links table');
+
+        return $schema;
+
+    }//end changeSchema()
+
+    /**
+     * Declare every column of `openregister_form_links`.
+     *
+     * The columns are driven from a spec list rather than written out as one
+     * `addColumn()` call per column: the literal form ran to 105 lines and
+     * tripped PHPMD's ExcessiveMethodLength. The order and the arguments are
+     * unchanged.
+     *
+     * Note `submission_id` is nullable — a row with submission_id NULL is a
+     * form-level link; a row with a submission_id is a per-submission link.
+     * The composite unique index in addIndexes() allows both shapes for the
+     * same (object, form) pair.
+     *
+     * @param Table $table The table being created
+     *
+     * @return void
+     */
+    private function addColumns(Table $table): void
+    {
+        $columns = [
+            ['id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'unsigned' => true]],
+            ['object_uuid', Types::STRING, ['notnull' => true, 'length' => 36]],
+            ['register_id', Types::BIGINT, ['notnull' => true, 'unsigned' => true]],
+            ['schema_id', Types::BIGINT, ['notnull' => false, 'unsigned' => true, 'default' => null]],
+            ['form_id', Types::BIGINT, ['notnull' => true, 'unsigned' => true]],
+            ['form_hash', Types::STRING, ['notnull' => false, 'length' => 64, 'default' => null]],
+            ['submission_id', Types::BIGINT, ['notnull' => false, 'unsigned' => true, 'default' => null]],
+            ['title', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]],
+            ['status', Types::STRING, ['notnull' => false, 'length' => 32, 'default' => null]],
+            ['expires_at', Types::DATETIME, ['notnull' => false, 'default' => null]],
+            ['linked_by', Types::STRING, ['notnull' => true, 'length' => 64]],
+            ['linked_at', Types::DATETIME, ['notnull' => true]],
+        ];
+
+        foreach ($columns as [$columnName, $columnType, $columnOptions]) {
+            $table->addColumn($columnName, $columnType, $columnOptions);
+        }
+
+    }//end addColumns()
+
+    /**
+     * Declare the primary key and every index of `openregister_form_links`.
+     *
+     * @param Table $table The table being created
+     *
+     * @return void
+     */
+    private function addIndexes(Table $table): void
+    {
         $table->setPrimaryKey(['id']);
         $table->addIndex(['object_uuid'], 'or_form_links_object_idx');
         $table->addIndex(['form_id'], 'or_form_links_form_idx');
         $table->addIndex(['register_id'], 'or_form_links_register_idx');
+
         // Composite unique key: (object, form, submission). Allows one
         // form-level link (submission_id NULL) plus N per-submission
         // links for the same form attached to the same object.
@@ -190,9 +142,5 @@ class Version1Date20260524130000 extends SimpleMigrationStep
             'or_form_links_unique_idx'
         );
 
-        $output->info(message: 'Created openregister_form_links table');
-
-        return $schema;
-
-    }//end changeSchema()
+    }//end addIndexes()
 }//end class

--- a/lib/Migration/Version1Date20260525000000.php
+++ b/lib/Migration/Version1Date20260525000000.php
@@ -49,8 +49,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Tier-2 deck-links table — create-or-extend.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260525000000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260525100000.php
+++ b/lib/Migration/Version1Date20260525100000.php
@@ -55,8 +55,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Tier-2 email-links table — create-or-extend.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260525100000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260525110000.php
+++ b/lib/Migration/Version1Date20260525110000.php
@@ -52,8 +52,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Tier-2 talk-links table — create-or-extend.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260525110000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260525120000.php
+++ b/lib/Migration/Version1Date20260525120000.php
@@ -51,8 +51,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Tier-2 flow-links table — create-or-extend.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260525120000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260525130000.php
+++ b/lib/Migration/Version1Date20260525130000.php
@@ -48,8 +48,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Tier-2 poll-links table — create-or-extend.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260525130000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260525140000.php
+++ b/lib/Migration/Version1Date20260525140000.php
@@ -48,8 +48,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Tier-2 bookmark-links table — create-or-extend.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260525140000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260525170000.php
+++ b/lib/Migration/Version1Date20260525170000.php
@@ -49,8 +49,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Tier-2 photo-links table — create-or-extend.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260525170000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260525180000.php
+++ b/lib/Migration/Version1Date20260525180000.php
@@ -51,8 +51,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Tier-2 analytics-links table — create-or-extend.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260525180000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260525190000.php
+++ b/lib/Migration/Version1Date20260525190000.php
@@ -51,8 +51,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Tier-2 map-links table — create-or-extend.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260525190000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260525200000.php
+++ b/lib/Migration/Version1Date20260525200000.php
@@ -53,8 +53,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Tier-2 collective-links table — create-or-extend.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260525200000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260525210000.php
+++ b/lib/Migration/Version1Date20260525210000.php
@@ -54,8 +54,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Tier-2 cospend-links table — create-or-extend.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260525210000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260525220000.php
+++ b/lib/Migration/Version1Date20260525220000.php
@@ -56,8 +56,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Tier-2 time-tracker-links table — create-or-extend.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260525220000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260525230000.php
+++ b/lib/Migration/Version1Date20260525230000.php
@@ -51,8 +51,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Tier-2 xwiki-links table — create-or-extend.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260525230000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260525240000.php
+++ b/lib/Migration/Version1Date20260525240000.php
@@ -56,8 +56,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Tier-2 openproject-links table — create-or-extend.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260525240000 extends SimpleMigrationStep
 {
@@ -144,59 +142,36 @@ class Version1Date20260525240000 extends SimpleMigrationStep
      */
     private function extendOpenProjectLinksTable(ISchemaWrapper $schema, IOutput $output): bool
     {
-        $table   = $schema->getTable('openregister_openproject_links');
+        $table = $schema->getTable('openregister_openproject_links');
+
+        // [column name, type, options, index name or null]. Driven from a spec
+        // list so the method carries one branch per concern rather than one per
+        // column (eight independent ifs put NPath complexity at 256).
+        $newColumns = [
+            ['schema_id', Types::BIGINT, ['notnull' => false, 'unsigned' => true, 'default' => null], 'idx_op_schema'],
+            ['type', Types::STRING, ['notnull' => false, 'length' => 64, 'default' => null], null],
+            ['status', Types::STRING, ['notnull' => false, 'length' => 64, 'default' => null], null],
+            ['priority', Types::STRING, ['notnull' => false, 'length' => 64, 'default' => null], null],
+            ['assignee', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null], null],
+            ['project', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null], null],
+            ['url', Types::STRING, ['notnull' => false, 'length' => 512, 'default' => null], null],
+            ['cached_at', Types::DATETIME, ['notnull' => false, 'default' => null], null],
+        ];
+
         $changed = false;
 
-        if ($table->hasColumn('schema_id') === false) {
-            $table->addColumn(
-                'schema_id',
-                Types::BIGINT,
-                ['notnull' => false, 'unsigned' => true, 'default' => null]
-            );
-            $table->addIndex(['schema_id'], 'idx_op_schema');
-            $output->info('Added schema_id column to openregister_openproject_links');
-            $changed = true;
-        }
+        foreach ($newColumns as [$columnName, $columnType, $columnOptions, $indexName]) {
+            if ($table->hasColumn($columnName) === true) {
+                continue;
+            }
 
-        if ($table->hasColumn('type') === false) {
-            $table->addColumn('type', Types::STRING, ['notnull' => false, 'length' => 64, 'default' => null]);
-            $output->info('Added type column to openregister_openproject_links');
-            $changed = true;
-        }
+            $table->addColumn($columnName, $columnType, $columnOptions);
 
-        if ($table->hasColumn('status') === false) {
-            $table->addColumn('status', Types::STRING, ['notnull' => false, 'length' => 64, 'default' => null]);
-            $output->info('Added status column to openregister_openproject_links');
-            $changed = true;
-        }
+            if ($indexName !== null) {
+                $table->addIndex([$columnName], $indexName);
+            }
 
-        if ($table->hasColumn('priority') === false) {
-            $table->addColumn('priority', Types::STRING, ['notnull' => false, 'length' => 64, 'default' => null]);
-            $output->info('Added priority column to openregister_openproject_links');
-            $changed = true;
-        }
-
-        if ($table->hasColumn('assignee') === false) {
-            $table->addColumn('assignee', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
-            $output->info('Added assignee column to openregister_openproject_links');
-            $changed = true;
-        }
-
-        if ($table->hasColumn('project') === false) {
-            $table->addColumn('project', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
-            $output->info('Added project column to openregister_openproject_links');
-            $changed = true;
-        }
-
-        if ($table->hasColumn('url') === false) {
-            $table->addColumn('url', Types::STRING, ['notnull' => false, 'length' => 512, 'default' => null]);
-            $output->info('Added url column to openregister_openproject_links');
-            $changed = true;
-        }
-
-        if ($table->hasColumn('cached_at') === false) {
-            $table->addColumn('cached_at', Types::DATETIME, ['notnull' => false, 'default' => null]);
-            $output->info('Added cached_at column to openregister_openproject_links');
+            $output->info('Added '.$columnName.' column to openregister_openproject_links');
             $changed = true;
         }
 

--- a/lib/Migration/Version1Date20260603000000.php
+++ b/lib/Migration/Version1Date20260603000000.php
@@ -33,8 +33,6 @@ use OCP\Migration\SimpleMigrationStep;
  * The column stores an array of UUID-shaped strings referencing legal-basis
  * objects in the consuming app's register (e.g. DocuDesk's `base` schema).
  * OpenRegister stores the array verbatim; no UUID validation is performed.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260603000000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260611000000.php
+++ b/lib/Migration/Version1Date20260611000000.php
@@ -56,8 +56,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Create the openregister_anonymisation_log table.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260611000000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260612000000.php
+++ b/lib/Migration/Version1Date20260612000000.php
@@ -50,8 +50,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Create the openregister_notification_dedupe table.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260612000000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260614000000.php
+++ b/lib/Migration/Version1Date20260614000000.php
@@ -65,8 +65,6 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * Create the openregister_processing_log table.
  *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
- *
  * @spec openspec/specs/avg-verwerkingsregister/spec.md
  */
 class Version1Date20260614000000 extends SimpleMigrationStep

--- a/lib/Migration/Version1Date20260614100000.php
+++ b/lib/Migration/Version1Date20260614100000.php
@@ -55,8 +55,6 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * Add sync-pipeline columns to openregister_sources.
  *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
- *
  * @spec openspec/specs/data-sync-harvesting/spec.md
  */
 class Version1Date20260614100000 extends SimpleMigrationStep
@@ -84,76 +82,37 @@ class Version1Date20260614100000 extends SimpleMigrationStep
             return null;
         }
 
-        $table   = $schema->getTable('openregister_sources');
+        $table = $schema->getTable('openregister_sources');
+
+        // Sync-pipeline columns, in declaration order. Driven from a spec list
+        // so this method carries one branch per concern rather than one per
+        // column (fourteen independent ifs put NPath complexity at 131072 and
+        // cyclomatic complexity at 18).
+        $newColumns = [
+            ['sync_enabled', Types::BOOLEAN, ['notnull' => true, 'default' => false]],
+            ['sync_schedule', Types::STRING, ['notnull' => false, 'length' => 64]],
+            ['sync_interval', Types::INTEGER, ['notnull' => false, 'unsigned' => true]],
+            ['last_sync_date', Types::DATETIME, ['notnull' => false]],
+            ['last_sync_status', Types::STRING, ['notnull' => false, 'length' => 16]],
+            ['last_sync_token', Types::STRING, ['notnull' => false, 'length' => 255]],
+            ['auth_type', Types::STRING, ['notnull' => false, 'length' => 32]],
+            ['auth_config', Types::TEXT, ['notnull' => false]],
+            ['mapping_id', Types::INTEGER, ['notnull' => false, 'unsigned' => true]],
+            ['target_register', Types::STRING, ['notnull' => false, 'length' => 255]],
+            ['target_schema', Types::STRING, ['notnull' => false, 'length' => 255]],
+            ['conflict_strategy', Types::STRING, ['notnull' => false, 'length' => 16]],
+            ['delete_strategy', Types::STRING, ['notnull' => false, 'length' => 16]],
+            ['batch_size', Types::INTEGER, ['notnull' => false, 'unsigned' => true]],
+        ];
+
         $changed = false;
 
-        if ($table->hasColumn('sync_enabled') === false) {
-            $table->addColumn('sync_enabled', Types::BOOLEAN, ['notnull' => true, 'default' => false]);
-            $changed = true;
-        }
+        foreach ($newColumns as [$columnName, $columnType, $columnOptions]) {
+            if ($table->hasColumn($columnName) === true) {
+                continue;
+            }
 
-        if ($table->hasColumn('sync_schedule') === false) {
-            $table->addColumn('sync_schedule', Types::STRING, ['notnull' => false, 'length' => 64]);
-            $changed = true;
-        }
-
-        if ($table->hasColumn('sync_interval') === false) {
-            $table->addColumn('sync_interval', Types::INTEGER, ['notnull' => false, 'unsigned' => true]);
-            $changed = true;
-        }
-
-        if ($table->hasColumn('last_sync_date') === false) {
-            $table->addColumn('last_sync_date', Types::DATETIME, ['notnull' => false]);
-            $changed = true;
-        }
-
-        if ($table->hasColumn('last_sync_status') === false) {
-            $table->addColumn('last_sync_status', Types::STRING, ['notnull' => false, 'length' => 16]);
-            $changed = true;
-        }
-
-        if ($table->hasColumn('last_sync_token') === false) {
-            $table->addColumn('last_sync_token', Types::STRING, ['notnull' => false, 'length' => 255]);
-            $changed = true;
-        }
-
-        if ($table->hasColumn('auth_type') === false) {
-            $table->addColumn('auth_type', Types::STRING, ['notnull' => false, 'length' => 32]);
-            $changed = true;
-        }
-
-        if ($table->hasColumn('auth_config') === false) {
-            $table->addColumn('auth_config', Types::TEXT, ['notnull' => false]);
-            $changed = true;
-        }
-
-        if ($table->hasColumn('mapping_id') === false) {
-            $table->addColumn('mapping_id', Types::INTEGER, ['notnull' => false, 'unsigned' => true]);
-            $changed = true;
-        }
-
-        if ($table->hasColumn('target_register') === false) {
-            $table->addColumn('target_register', Types::STRING, ['notnull' => false, 'length' => 255]);
-            $changed = true;
-        }
-
-        if ($table->hasColumn('target_schema') === false) {
-            $table->addColumn('target_schema', Types::STRING, ['notnull' => false, 'length' => 255]);
-            $changed = true;
-        }
-
-        if ($table->hasColumn('conflict_strategy') === false) {
-            $table->addColumn('conflict_strategy', Types::STRING, ['notnull' => false, 'length' => 16]);
-            $changed = true;
-        }
-
-        if ($table->hasColumn('delete_strategy') === false) {
-            $table->addColumn('delete_strategy', Types::STRING, ['notnull' => false, 'length' => 16]);
-            $changed = true;
-        }
-
-        if ($table->hasColumn('batch_size') === false) {
-            $table->addColumn('batch_size', Types::INTEGER, ['notnull' => false, 'unsigned' => true]);
+            $table->addColumn($columnName, $columnType, $columnOptions);
             $changed = true;
         }
 

--- a/lib/Migration/Version1Date20260614110000.php
+++ b/lib/Migration/Version1Date20260614110000.php
@@ -53,8 +53,6 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * Create the openregister_sync_records table.
  *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
- *
  * @spec openspec/specs/data-sync-harvesting/spec.md
  */
 class Version1Date20260614110000 extends SimpleMigrationStep

--- a/lib/Migration/Version1Date20260614120000.php
+++ b/lib/Migration/Version1Date20260614120000.php
@@ -44,8 +44,6 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * Create the schema changelog and run tables.
  *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
- *
  * @spec openspec/specs/schema-migration/spec.md
  */
 class Version1Date20260614120000 extends SimpleMigrationStep

--- a/lib/Migration/Version1Date20260615000000.php
+++ b/lib/Migration/Version1Date20260615000000.php
@@ -46,8 +46,6 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * Create the case-token and analytics-series tables.
  *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
- *
  * @spec openspec/specs/integration-leaf-foundation/spec.md
  */
 class Version1Date20260615000000 extends SimpleMigrationStep

--- a/lib/Migration/Version1Date20260615130000.php
+++ b/lib/Migration/Version1Date20260615130000.php
@@ -51,8 +51,6 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * Create the openregister_push_subscriptions table.
  *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
- *
  * @spec openspec/changes/openregister-web-push-engine/specs/web-push-delivery/spec.md
  */
 class Version1Date20260615130000 extends SimpleMigrationStep

--- a/lib/Migration/Version1Date20260624000000.php
+++ b/lib/Migration/Version1Date20260624000000.php
@@ -50,8 +50,6 @@ class Version1Date20260624000000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return ISchemaWrapper|null The updated schema, or null if no changes
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20260625000000.php
+++ b/lib/Migration/Version1Date20260625000000.php
@@ -35,8 +35,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Create the `openregister_sequences` table.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260625000000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260704120000.php
+++ b/lib/Migration/Version1Date20260704120000.php
@@ -54,8 +54,6 @@ class Version1Date20260704120000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return ISchemaWrapper|null The updated schema, or null if no changes
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20260706000000.php
+++ b/lib/Migration/Version1Date20260706000000.php
@@ -50,8 +50,6 @@ class Version1Date20260706000000 extends SimpleMigrationStep
      *
      * @return ISchemaWrapper|null The updated schema, or null if no changes.
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
      * @spec openspec/changes/semantic-object-handoff-engine/specs/semantic-object-handoff/spec.md
      *   (Scenario: No provider installed, queue mode)
      */

--- a/lib/Migration/Version1Date20260706100000.php
+++ b/lib/Migration/Version1Date20260706100000.php
@@ -56,6 +56,7 @@ use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
+use Psr\Container\ContainerInterface;
 
 /**
  * Creates the `openregister_vec_ann` pgvector sidecar table and its HNSW index on PostgreSQL.
@@ -83,12 +84,17 @@ class Version1Date20260706100000 extends SimpleMigrationStep
     /**
      * Constructor.
      *
-     * @param IDBConnection $connection Database connection
-     * @param IConfig       $config     Nextcloud config
+     * @param IDBConnection      $connection Database connection
+     * @param IConfig            $config     Nextcloud config
+     * @param ContainerInterface $container  App container, used to resolve the
+     *                                       embedding services lazily so a DI
+     *                                       failure during upgrade degrades
+     *                                       instead of aborting
      */
     public function __construct(
         private readonly IDBConnection $connection,
-        private readonly IConfig $config
+        private readonly IConfig $config,
+        private readonly ContainerInterface $container
     ) {
     }//end __construct()
 
@@ -100,8 +106,6 @@ class Version1Date20260706100000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      *
      * @spec openspec/changes/hybrid-document-search/tasks.md#1.1
      */
@@ -199,8 +203,8 @@ class Version1Date20260706100000 extends SimpleMigrationStep
         // 1. Currently-configured embedding model (SettingsService), resolved
         // lazily so a DI failure during upgrade degrades instead of aborting.
         try {
-            $settingsService = \OCP\Server::get(SettingsService::class);
-            $generator       = \OCP\Server::get(EmbeddingGeneratorHandler::class);
+            $settingsService = $this->container->get(SettingsService::class);
+            $generator       = $this->container->get(EmbeddingGeneratorHandler::class);
 
             if ($settingsService instanceof SettingsService
                 && $generator instanceof EmbeddingGeneratorHandler

--- a/lib/Migration/Version1Date20260706101000.php
+++ b/lib/Migration/Version1Date20260706101000.php
@@ -81,8 +81,6 @@ class Version1Date20260706101000 extends SimpleMigrationStep
      *
      * @return void
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
      * @spec openspec/changes/hybrid-document-search/tasks.md#1.2
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void

--- a/lib/Migration/Version1Date20260706110000.php
+++ b/lib/Migration/Version1Date20260706110000.php
@@ -80,8 +80,6 @@ class Version1Date20260706110000 extends SimpleMigrationStep
      *
      * @return void
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
      * @spec openspec/changes/searchable-property-index/tasks.md#1.1
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void

--- a/lib/Migration/Version1Date20260707000000.php
+++ b/lib/Migration/Version1Date20260707000000.php
@@ -42,8 +42,6 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * Add the (register, schema, created) composite index to openregister_audit_trails.
  *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
- *
  * @spec openspec/specs/enhanced-audit-trail/spec.md
  */
 class Version1Date20260707000000 extends SimpleMigrationStep

--- a/lib/Migration/Version1Date20260710000000.php
+++ b/lib/Migration/Version1Date20260710000000.php
@@ -46,8 +46,6 @@ class Version1Date20260710000000 extends SimpleMigrationStep
      * @param array   $options       Migration options.
      *
      * @return ISchemaWrapper|null The updated schema, or null if no changes.
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20260712120000.php
+++ b/lib/Migration/Version1Date20260712120000.php
@@ -53,8 +53,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Create the openregister_notification_queue table.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260712120000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260712130000.php
+++ b/lib/Migration/Version1Date20260712130000.php
@@ -38,8 +38,6 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * Adds nullable `tool_id`, `params_digest`, `result_summary` columns to the
  * `openregister_audit_trails` table.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260712130000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260713000000.php
+++ b/lib/Migration/Version1Date20260713000000.php
@@ -62,8 +62,6 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * Create the openregister_scheduled_reports table.
  *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
- *
  * @spec openspec/specs/scheduled-report-jobs/spec.md
  */
 class Version1Date20260713000000 extends SimpleMigrationStep

--- a/lib/Migration/Version1Date20260714000000.php
+++ b/lib/Migration/Version1Date20260714000000.php
@@ -50,8 +50,6 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * Add `delivery_mode`/`recipients` columns to `openregister_scheduled_reports`.
  *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
- *
  * @spec openspec/specs/scheduled-report-jobs/spec.md
  */
 class Version1Date20260714000000 extends SimpleMigrationStep

--- a/lib/Migration/Version1Date20260714010000.php
+++ b/lib/Migration/Version1Date20260714010000.php
@@ -46,8 +46,6 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * Add `requester_id` to `openregister_approval_steps`.
  *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
- *
  * @spec openspec/specs/approval-workflow/spec.md
  */
 class Version1Date20260714010000 extends SimpleMigrationStep

--- a/lib/Migration/Version1Date20260714100000.php
+++ b/lib/Migration/Version1Date20260714100000.php
@@ -53,8 +53,6 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * Create the openregister_migration_packs table.
  *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
- *
  * @spec openspec/specs/migration-mapping-packs/spec.md
  */
 class Version1Date20260714100000 extends SimpleMigrationStep

--- a/lib/Migration/Version1Date20260714120000.php
+++ b/lib/Migration/Version1Date20260714120000.php
@@ -41,8 +41,6 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * Drop the orphaned openregister_realtime_events table (and its indexes).
  *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
- *
  * @spec openspec/specs/realtime-updates/spec.md
  */
 class Version1Date20260714120000 extends SimpleMigrationStep

--- a/lib/Migration/Version1Date20260723000000.php
+++ b/lib/Migration/Version1Date20260723000000.php
@@ -52,8 +52,6 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * Widen slug-uniqueness to (organisation, application, slug) for registers and schemas.
  *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
- *
  * @spec openspec/specs/data-import-export/spec.md
  */
 class Version1Date20260723000000 extends SimpleMigrationStep

--- a/lib/Migration/Version1Date20260724000000.php
+++ b/lib/Migration/Version1Date20260724000000.php
@@ -58,8 +58,6 @@ class Version1Date20260724000000 extends SimpleMigrationStep
      *
      * @return ISchemaWrapper|null The updated schema, or null if no changes were needed
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
      * @spec openspec/specs/saved-search-views/spec.md#requirement-views-persist-a-validated-presentation-config-req-view-pres-01
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper

--- a/lib/Migration/Version1Date20260724120000.php
+++ b/lib/Migration/Version1Date20260724120000.php
@@ -46,8 +46,6 @@ class Version1Date20260724120000 extends SimpleMigrationStep
      *
      * @return ISchemaWrapper|null The updated schema, or null when nothing changed.
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
      * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper

--- a/lib/Migration/Version1Date20260726000000.php
+++ b/lib/Migration/Version1Date20260726000000.php
@@ -56,8 +56,6 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * Drops `schemas_org_app_slug_unique` on `openregister_schemas`; adds no replacement index.
  *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
- *
  * @spec openspec/changes/per-register-schema-slug-uniqueness/specs/data-import-export/spec.md#requirement-no-database-level-uniqueness-constraint-scopes-schema-slugs
  */
 class Version1Date20260726000000 extends SimpleMigrationStep
@@ -94,16 +92,17 @@ class Version1Date20260726000000 extends SimpleMigrationStep
 
         $table = $schema->getTable('openregister_schemas');
 
-        if ($table->hasIndex(self::SCHEMAS_SLUG_UNIQUE_INDEX) === true) {
-            $table->dropIndex(self::SCHEMAS_SLUG_UNIQUE_INDEX);
-            $output->info(
-                'Dropped '.self::SCHEMAS_SLUG_UNIQUE_INDEX.' on openregister_schemas: '.
-                'schema slug uniqueness is now enforced per-register at the service layer '.
-                '(openspec/changes/per-register-schema-slug-uniqueness), not by a DB index.'
-            );
-        } else {
+        if ($table->hasIndex(self::SCHEMAS_SLUG_UNIQUE_INDEX) === false) {
             $output->info(self::SCHEMAS_SLUG_UNIQUE_INDEX.' already absent on openregister_schemas; nothing to do.');
+            return $schema;
         }
+
+        $table->dropIndex(self::SCHEMAS_SLUG_UNIQUE_INDEX);
+        $output->info(
+            'Dropped '.self::SCHEMAS_SLUG_UNIQUE_INDEX.' on openregister_schemas: '.
+            'schema slug uniqueness is now enforced per-register at the service layer '.
+            '(openspec/changes/per-register-schema-slug-uniqueness), not by a DB index.'
+        );
 
         return $schema;
     }//end changeSchema()

--- a/lib/Migration/Version1Date20260728000000.php
+++ b/lib/Migration/Version1Date20260728000000.php
@@ -44,8 +44,6 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * Adds the nullable `user_quota` / `group_quota` allocations to applications.
  *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
- *
  * @spec exclude Additive columns backing two quota allocations the applications
  *     API already published as null. No behavioural contract of its own —
  *     enforcement belongs to the tenant-quotas capability.

--- a/lib/Migration/Version1Date20260730120000.php
+++ b/lib/Migration/Version1Date20260730120000.php
@@ -58,8 +58,6 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * Adds `or_flowrun_org_status_idx` on `openregister_flow_runs`.
  *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
- *
  * @spec openspec/changes/or-flow-active-runs/specs/flow-active-runs/spec.md
  */
 class Version1Date20260730120000 extends SimpleMigrationStep

--- a/lib/Migration/Version1Date20260731080000.php
+++ b/lib/Migration/Version1Date20260731080000.php
@@ -56,8 +56,6 @@ use OCP\Migration\SimpleMigrationStep;
 
 /**
  * Adds the `openregister_flow_state` table.
- *
- * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class Version1Date20260731080000 extends SimpleMigrationStep
 {

--- a/lib/Migration/Version1Date20260803000000.php
+++ b/lib/Migration/Version1Date20260803000000.php
@@ -51,8 +51,6 @@ class Version1Date20260803000000 extends SimpleMigrationStep
      *
      * @return ISchemaWrapper|null The updated schema, or null when nothing changed.
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
      * @spec openspec/changes/flow-engine-unification/specs/flow-storage/spec.md
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper

--- a/lib/Migration/Version1Date20260803000100.php
+++ b/lib/Migration/Version1Date20260803000100.php
@@ -51,8 +51,6 @@ class Version1Date20260803000100 extends SimpleMigrationStep
      *
      * @return ISchemaWrapper|null The updated schema, or null when nothing changed.
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
      * @spec openspec/changes/flow-engine-unification/specs/flow-execution-history/spec.md
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper

--- a/lib/Migration/Version1Date20260803000200.php
+++ b/lib/Migration/Version1Date20260803000200.php
@@ -121,8 +121,6 @@ class Version1Date20260803000200 extends SimpleMigrationStep
      *
      * @return void
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
      * @spec openspec/changes/flow-engine-unification/specs/flow-storage/spec.md
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void

--- a/lib/Migration/Version1Date20260804000000.php
+++ b/lib/Migration/Version1Date20260804000000.php
@@ -95,8 +95,6 @@ class Version1Date20260804000000 extends SimpleMigrationStep
      *
      * @return void
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
      * @spec openspec/changes/flow-sync-decomposition/specs/flow-iteration/spec.md
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void

--- a/lib/Migration/Version1Date20260805000000.php
+++ b/lib/Migration/Version1Date20260805000000.php
@@ -53,8 +53,6 @@ class Version1Date20260805000000 extends SimpleMigrationStep
      * @param array   $options       Migration options.
      *
      * @return ISchemaWrapper|null The modified schema, or null when unchanged.
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/phpmd-unusedparams.xml
+++ b/phpmd-unusedparams.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<ruleset name="Unused formal parameters"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_xml_schema.xsd">
+
+    <description>
+        Second PHPMD leg: UnusedFormalParameter only.
+
+        This rule lives in its own ruleset because PHPMD honours &lt;exclude-pattern&gt;
+        ONLY as a direct child of &lt;ruleset&gt;; nested inside a &lt;rule&gt; it is parsed and
+        discarded (ConductionNL/.github#155). A direct child, however, is applied by
+        PDepend at file-collection time and drops the file from EVERY rule in the
+        ruleset. Isolating UnusedFormalParameter here means the lib/Migration
+        exclusion applies to this rule and this rule ALONE - every other rule still
+        analyses lib/Migration in the main leg.
+
+        Why lib/Migration is excluded from THIS rule: OCP\Migration\IMigrationStep
+        mandates changeSchema(IOutput $output, Closure $schemaClosure, array $options)
+        and preSchemaChange/postSchemaChange with the same three parameters. A step
+        that needs none of them still cannot drop them. The signature cannot change.
+    </description>
+
+    <exclude-pattern>*/Migration/*</exclude-pattern>
+
+    <rule ref="rulesets/unusedcode.xml/UnusedFormalParameter"/>
+</ruleset>

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -9,9 +9,24 @@
         This is a custom ruleset for OpenRegister Nextcloud.
     </description>
 
-    <!-- Exclude database migration files: they are one-time DDL scripts with no business logic,
-         and analysing all 136+ of them accounts for ~100s of the total phpmd runtime. -->
-    <exclude-pattern>*/Migration/*</exclude-pattern>
+    <!-- NOTE: this ruleset deliberately carries NO top-level <exclude-pattern>.
+
+         It used to carry <exclude-pattern>*/Migration/*</exclude-pattern> here as a
+         runtime optimisation. A top-level exclude-pattern is applied by PDepend at
+         FILE-COLLECTION time, so it does not drop the directory from one rule - it
+         drops it from EVERY rule in this ruleset. Measured on phpmd 2.15.0 /
+         PHP 8.4.22, that single line was silently swallowing 11 real non-
+         UnusedFormalParameter findings in lib/Migration (3 NPathComplexity,
+         3 ElseExpression, 2 StaticAccess, 2 ExcessiveMethodLength,
+         1 CyclomaticComplexity). See ConductionNL/.github#155 and
+         ConductionNL/openregister#2338.
+
+         UnusedFormalParameter - the one rule that genuinely cannot apply to
+         migrations, because OCP\Migration\IMigrationStep mandates the signature -
+         now lives alone in phpmd-unusedparams.xml with its own top-level
+         exclude-pattern, so the exclusion is scoped to that rule and nothing else.
+         Both rulesets are run as separate legs by `composer phpmd`; adding a rule
+         here is enough, but a rule that must skip a path needs its own leg. -->
 
     <!-- Clean Code Rules -->
     <rule ref="rulesets/cleancode.xml/BooleanArgumentFlag"/>
@@ -99,7 +114,11 @@
     <rule ref="rulesets/unusedcode.xml/UnusedPrivateField"/>
     <rule ref="rulesets/unusedcode.xml/UnusedLocalVariable"/>
     <rule ref="rulesets/unusedcode.xml/UnusedPrivateMethod"/>
-    <rule ref="rulesets/unusedcode.xml/UnusedFormalParameter">
-        <exclude-pattern>*Migration*</exclude-pattern>
-    </rule>
+    <!-- UnusedFormalParameter is NOT declared here. It lives alone in
+         phpmd-unusedparams.xml, which carries a top-level (therefore effective)
+         <exclude-pattern>*/Migration/*</exclude-pattern>. The nested
+         <exclude-pattern> that used to sit inside this rule was INERT: PHPMD 2.15
+         parses exclude-patterns only as direct children of <ruleset> and silently
+         discards nested ones. `composer phpmd` runs both rulesets as separate legs
+         and returns the worst exit code. -->
 </ruleset>

--- a/tests/Unit/Migration/Version1Date20260706100000Test.php
+++ b/tests/Unit/Migration/Version1Date20260706100000Test.php
@@ -35,6 +35,7 @@ use OCP\IDBConnection;
 use OCP\Migration\IOutput;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 
 class Version1Date20260706100000Test extends TestCase
 {
@@ -50,8 +51,30 @@ class Version1Date20260706100000Test extends TestCase
         $this->config     = $this->createMock(IConfig::class);
         $this->config->method('getSystemValueString')->with('dbtableprefix', 'oc_')->willReturn('oc_');
 
-        $this->migration = new Version1Date20260706100000($this->connection, $this->config);
+        $this->migration = new Version1Date20260706100000(
+            $this->connection,
+            $this->config,
+            $this->makeUnavailableContainer()
+        );
     }//end setUp()
+
+    /**
+     * A container whose get() always fails.
+     *
+     * resolveConfiguredDimension() resolves SettingsService and
+     * EmbeddingGeneratorHandler lazily and degrades to the data-driven fallback
+     * when that resolution fails. These unit tests run without a booted server,
+     * which is exactly that case, and they pin the fallback behaviour.
+     */
+    private function makeUnavailableContainer(): ContainerInterface&MockObject
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willThrowException(
+            new \RuntimeException('no container in unit tests')
+        );
+
+        return $container;
+    }//end makeUnavailableContainer()
 
     /**
      * Build a schema wrapper that reports openregister_vectors present/absent.
@@ -107,7 +130,7 @@ class Version1Date20260706100000Test extends TestCase
         $config     = $this->createMock(IConfig::class);
         $config->method('getSystemValueString')->with('dbtableprefix', 'oc_')->willReturn('');
 
-        $migration = new Version1Date20260706100000($connection, $config);
+        $migration = new Version1Date20260706100000($connection, $config, $this->makeUnavailableContainer());
 
         $output = $this->createMock(IOutput::class);
         $schema = $this->makeSchema(true);


### PR DESCRIPTION
## What this fixes

Part of the fleet suppression audit (ConductionNL/.github#155). Tracked here by #2338.

openregister was the fleet's **only** repo whose `<exclude-pattern>*/Migration/*</exclude-pattern>`
actually worked — and that was the problem. A top-level exclude-pattern is applied by PDepend at
*file-collection* time, so it does not drop `lib/Migration` from one rule; it drops it from
**every rule in the ruleset**.

Measured on PHPMD 2.15.0 / PHP 8.4.22, that single line was silently swallowing **11 real
findings** that had nothing to do with unused parameters:

| rule | count |
|---|---|
| NPathComplexity | 3 |
| ElseExpression | 3 |
| StaticAccess | 2 |
| ExcessiveMethodLength | 2 |
| CyclomaticComplexity | 1 |

The same file also carried a second `<exclude-pattern>*Migration*</exclude-pattern>` **nested
inside** the `UnusedFormalParameter` rule. PHPMD 2.15 honours exclude-patterns only as direct
children of `<ruleset>`; nested ones are parsed and discarded. That one was inert — it was the
top-level line doing all the work, for every rule.

## The fix

`phpmd.xml` loses its top-level exclude-pattern and no longer declares `UnusedFormalParameter`.
A new sibling ruleset, `phpmd-unusedparams.xml`, holds that rule **alone** with its own top-level
exclude-pattern — so the `lib/Migration` exclusion now applies to exactly one rule, and every
other rule sees `lib/Migration` again.

`composer phpmd` runs both rulesets as separate legs, worst exit code winning; neither leg can
short-circuit the other:

```
"phpmd": "E=0; ./vendor/bin/phpmd lib text phpmd.xml --baseline-file phpmd.baseline.xml || E=$?; ./vendor/bin/phpmd lib text phpmd-unusedparams.xml --baseline-file phpmd.baseline.xml || E=$?; exit $E",
```

`UnusedFormalParameter` genuinely cannot apply to migrations: `OCP\Migration\IMigrationStep`
mandates `changeSchema(IOutput $output, Closure $schemaClosure, array $options)` and
`preSchemaChange` / `postSchemaChange` with the same three parameters. A step that needs none of
them still cannot drop them.

## Retired suppressions

With the exclusion now scoped to the rule that needs it, every
`@SuppressWarnings(PHPMD.UnusedFormalParameter)` in `lib/Migration/` is dead weight.
**246 removed** across 174 files (236 exact-match + 10 with a stray space before the paren, which
were never valid annotations in the first place). No suppression was added anywhere.

## The 11 surfaced findings — all fixed

- `Version1Date20260521120000.php` — 2× `ElseExpression`. Extracted the two platform-specific
  index-drop paths into `dropBareUuidIndexesPostgres()` / `dropBareUuidIndexesMysql()` behind a
  dispatcher, and the platform-specific introspection query into
  `queryTablesWithBareUuidIndex()`. Same SQL, same order, same output messages.
- `Version1Date20260524100000.php` — `NPathComplexity` 256 + `ExcessiveMethodLength` 104.
  Five independent `if (hasColumn) addColumn` blocks became a spec list + one loop.
- `Version1Date20260524130000.php` — `ExcessiveMethodLength` 137. Column and index declarations
  extracted into `addColumns()` / `addIndexes()`, columns driven from a spec list.
- `Version1Date20260525240000.php` — `NPathComplexity` 256. Eight `if (hasColumn)` blocks →
  spec list + loop (the `schema_id` entry keeps its extra index).
- `Version1Date20260614100000.php` — `CyclomaticComplexity` 18 + `NPathComplexity` 131072.
  Fourteen `if (hasColumn)` blocks → spec list + loop.
- `Version1Date20260706100000.php` — 2× `StaticAccess` on `\OCP\Server::get()`. Now injects
  `Psr\Container\ContainerInterface` and resolves through it, which keeps the lazy resolution the
  original comment asks for (a DI failure during upgrade still degrades instead of aborting)
  while removing the static call. The unit test gains a container mock that throws, reproducing
  exactly the path it exercised before.
- `Version1Date20260726000000.php` — `ElseExpression`. Inverted to an early return.

All column-order, SQL text and `IOutput` messages are unchanged. No thresholds were relaxed and
no ternaries were introduced (`Squiz.PHP.DisallowInlineIf`).

## Not in this PR

- `phpmd.baseline.xml` (517 entries) is untouched here; it is the subject of a follow-up.
- The 65 non-`UnusedFormalParameter` `@SuppressWarnings` still in `lib/Migration/`
  (36 ExcessiveMethodLength, 15 CyclomaticComplexity, 11 NPathComplexity, 2 StaticAccess,
  1 ExcessiveClassLength) were previously **dead** — the directory-wide exclusion made them
  unreachable. They are load-bearing from this PR onward. Burning them down belongs with the
  baseline work, not here.
- #2339 (the `PdfTextReplacer` `$strict` dead-parameter bug) is a real defect and is **not**
  touched by this PR. It lives outside `lib/Migration`, so it was never affected by the
  exclude-pattern either way.

Closes part of #2338.
