### PR TITLE
fix(license,spec): correct 30 AGPL licence headers and 11 dangling @spec anchors (gate-28, gate-46)

### DIFF
--- a/lib/Controller/UiController.php
+++ b/lib/Controller/UiController.php
@@ -10,7 +10,7 @@
  * @package   OCA\OpenRegister\Controller
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2024 Conduction b.v.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT: <git_id>
  * @link      https://github.com/conductionnl/openregister
  */
@@ -34,7 +34,7 @@ use OCP\IRequest;
  *
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2024 Conduction b.v.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @version GIT: <git_id>
  *

--- a/lib/Controller/ViewsController.php
+++ b/lib/Controller/ViewsController.php
@@ -13,7 +13,7 @@
  * @package   OCA\OpenRegister\Controller
  * @author    Conduction Development Team <dev@conduction.nl>
  * @copyright 2024 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT: <git_id>
  * @link      https://github.com/ConductionNL/openregister
  */

--- a/lib/Event/OrganisationCreatedEvent.php
+++ b/lib/Event/OrganisationCreatedEvent.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister\Event
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT: <git_id>
  * @link      https://github.com/ConductionNL/OpenRegister
  */
@@ -33,7 +33,7 @@ use OCA\OpenRegister\Db\Organisation;
  * @category Event
  * @package  OCA\OpenRegister\Event
  * @author   Conduction b.v. <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version  1.0.0
  * @link     https://github.com/ConductionNL/OpenRegister
  */

--- a/lib/Listener/FileChangeListener.php
+++ b/lib/Listener/FileChangeListener.php
@@ -13,7 +13,7 @@
  *
  * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @version GIT: <git_id>
  *
@@ -44,7 +44,7 @@ use Psr\Log\LoggerInterface;
  * @category Listener
  * @package  OCA\OpenRegister\Listener
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @template-implements IEventListener<NodeCreatedEvent|NodeWrittenEvent>
  */

--- a/lib/Listener/ObjectChangeListener.php
+++ b/lib/Listener/ObjectChangeListener.php
@@ -13,7 +13,7 @@
  *
  * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @version GIT: <git_id>
  *
@@ -44,7 +44,7 @@ use Psr\Log\LoggerInterface;
  * @category Listener
  * @package  OCA\OpenRegister\Listener
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @template-implements IEventListener<ObjectCreatedEvent|ObjectUpdatedEvent>
  */

--- a/lib/Migration/Version002006000Date20251013000000.php
+++ b/lib/Migration/Version002006000Date20251013000000.php
@@ -12,7 +12,7 @@
  *
  * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @version GIT: <git_id>
  *

--- a/lib/Migration/Version002006000Date20251013000000.php
+++ b/lib/Migration/Version002006000Date20251013000000.php
@@ -39,7 +39,6 @@ class Version002006000Date20251013000000 extends SimpleMigrationStep
      *
      * @return null|ISchemaWrapper Modified schema or null
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
@@ -280,8 +279,6 @@ class Version002006000Date20251013000000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20251103120000.php
+++ b/lib/Migration/Version1Date20251103120000.php
@@ -51,8 +51,6 @@ class Version1Date20251103120000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return null|ISchemaWrapper The updated schema or null
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {
@@ -129,8 +127,6 @@ class Version1Date20251103120000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void
     {

--- a/lib/Migration/Version1Date20251103120000.php
+++ b/lib/Migration/Version1Date20251103120000.php
@@ -11,7 +11,7 @@
  *
  * @author    Conduction Development Team <dev@conduction.nl>
  * @copyright 2024 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @link https://www.openregister.nl
  */

--- a/lib/Migration/Version1Date20251103130000.php
+++ b/lib/Migration/Version1Date20251103130000.php
@@ -12,7 +12,7 @@
  *
  * @author    Conduction Development Team <dev@conduction.nl>
  * @copyright 2024 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT: <git-id>
  * @link      https://www.openregister.nl
  */

--- a/lib/Migration/Version1Date20251103130000.php
+++ b/lib/Migration/Version1Date20251103130000.php
@@ -43,8 +43,6 @@ class Version1Date20251103130000 extends SimpleMigrationStep
      * @param array   $options       Migration options
      *
      * @return null|ISchemaWrapper The updated schema or null
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
     {

--- a/lib/Migration/Version1Date20251105140000.php
+++ b/lib/Migration/Version1Date20251105140000.php
@@ -11,7 +11,7 @@
  *
  * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @version GIT: <git_id>
  *

--- a/lib/Migration/Version1Date20251105140000.php
+++ b/lib/Migration/Version1Date20251105140000.php
@@ -45,7 +45,6 @@ class Version1Date20251105140000 extends SimpleMigrationStep
      *
      * @return null|ISchemaWrapper The updated schema or null
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @SuppressWarnings(PHPMD.NPathComplexity)       Database migration requires checking many columns
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)

--- a/lib/Service/File/CreateFileHandler.php
+++ b/lib/Service/File/CreateFileHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -44,7 +44,7 @@ use Psr\Log\LoggerInterface;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  *

--- a/lib/Service/File/DeleteFileHandler.php
+++ b/lib/Service/File/DeleteFileHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -42,7 +42,7 @@ use Psr\Log\LoggerInterface;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  */

--- a/lib/Service/File/DocumentProcessingHandler.php
+++ b/lib/Service/File/DocumentProcessingHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -59,7 +59,7 @@ use ZipArchive;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  *

--- a/lib/Service/File/DocumentProcessingHandler.php
+++ b/lib/Service/File/DocumentProcessingHandler.php
@@ -223,7 +223,7 @@ class DocumentProcessingHandler
      *                                    branch (DOCX/ODT/text — no PDF
      *                                    structure tree is involved).
      *
-     * @spec openspec/changes/tag-preserving-redaction/specs/tag-preserving-redaction/spec.md#REQ-ORTPR-003
+     * @spec openspec/specs/tag-preserving-redaction/spec.md#every-pdf-redaction-must-return-the-structurepreservation-result-block-with-the-exact-contracted-fields-req-ortpr-003
      */
     public function getLastStructurePreservation(): ?StructurePreservation
     {

--- a/lib/Service/File/FolderManagementHandler.php
+++ b/lib/Service/File/FolderManagementHandler.php
@@ -194,7 +194,7 @@ class FolderManagementHandler
         // Try to get existing folder by ID.
         $existingFolder = $this->getExistingFolderFromProperty(folderProperty: $folderProperty);
         if ($existingFolder !== null) {
-            $this->logger->info(
+            $this->logger->debug(
                 message: "[FolderManagementHandler] Register folder already exists with ID: ".$folderProperty,
                 context: ['file' => __FILE__, 'line' => __LINE__]
             );
@@ -209,17 +209,13 @@ class FolderManagementHandler
 
         // Store the folder ID instead of the path.
         $register->setFolder((string) $folderNode->getId());
-        $this->logger->info(
-            message: '[FolderManagementHandler] 🔹 FolderManagementHandler: About to update register with folder ID',
-            context: ['file' => __FILE__, 'line' => __LINE__]
-        );
-        $this->registerMapper->update($register);
-        $this->logger->info(
-            message: '[FolderManagementHandler] 🔹 FolderManagementHandler: Register updated with folder ID',
-            context: ['file' => __FILE__, 'line' => __LINE__]
-        );
 
-        $this->logger->info(
+        // The "About to update" / "Register updated" pair that used to bracket
+        // this call said nothing the line below does not already say, and said
+        // it twice at info.
+        $this->registerMapper->update($register);
+
+        $this->logger->debug(
             message: "[FolderManagementHandler] Created register folder with ID: ".$folderNode->getId(),
             context: ['file' => __FILE__, 'line' => __LINE__]
         );
@@ -275,7 +271,7 @@ class FolderManagementHandler
                 currentUser: $currentUser,
                 objectEntity: $objectEntity
             );
-            $this->logger->info(
+            $this->logger->debug(
                 message: "[FolderManagementHandler] Object folder bind verified (ID: ".$folderProperty.")",
                 context: ['file' => __FILE__, 'line' => __LINE__]
             );
@@ -286,7 +282,7 @@ class FolderManagementHandler
         // returns null for both, so the rest of the method handles them as before.
         $existingFolder = $this->getExistingFolderFromProperty(folderProperty: $folderProperty);
         if ($existingFolder !== null) {
-            $this->logger->info(
+            $this->logger->debug(
                 message: "[FolderManagementHandler] Object folder already exists with ID: ".$folderProperty,
                 context: ['file' => __FILE__, 'line' => __LINE__]
             );
@@ -310,7 +306,7 @@ class FolderManagementHandler
             $this->objectEntityMapper->update($objectEntity);
         }
 
-        $this->logger->info(
+        $this->logger->debug(
             message: "[FolderManagementHandler] Created object folder with ID: ".$objectFolder->getId(),
             context: ['file' => __FILE__, 'line' => __LINE__]
         );
@@ -349,7 +345,7 @@ class FolderManagementHandler
         // Handle legacy cases where folder might be null, empty string, or a non-numeric string path.
         if ($folderProperty === null || $folderProperty === '') {
             $regId = $register->getId();
-            $this->logger->info(
+            $this->logger->debug(
                 message: "[FolderManagementHandler] Register $regId has legacy folder property, creating new folder",
                 context: ['file' => __FILE__, 'line' => __LINE__]
             );
@@ -416,7 +412,7 @@ class FolderManagementHandler
                 $objectEntityId = $objectEntity->getId();
             }
 
-            $this->logger->info(
+            $this->logger->debug(
                 message: "[FolderManagementHandler] Object $objectEntityId has legacy folder property, creating new folder",
                 context: ['file' => __FILE__, 'line' => __LINE__]
             );
@@ -478,20 +474,20 @@ class FolderManagementHandler
         try {
             // Try to get existing folder first.
             $objectFolder = $registerFolder->get($objectFolderName);
-            $this->logger->info(
+            $this->logger->debug(
                 message: "[FolderManagementHandler] Object folder already exists: ".$objectFolderName,
                 context: ['file' => __FILE__, 'line' => __LINE__]
             );
         } catch (NotFoundException) {
             // Create new folder if it doesn't exist.
             $objectFolder = $registerFolder->newFolder($objectFolderName);
-            $this->logger->info(
+            $this->logger->debug(
                 message: "[FolderManagementHandler] Created object folder: ".$objectFolderName,
                 context: ['file' => __FILE__, 'line' => __LINE__]
             );
         }
 
-        $this->logger->info(
+        $this->logger->debug(
             message: "[FolderManagementHandler] Created object folder with ID: ".$objectFolder->getId(),
             context: ['file' => __FILE__, 'line' => __LINE__]
         );
@@ -556,7 +552,7 @@ class FolderManagementHandler
             try {
                 // Try to get the folder if it already exists.
                 $node = $userFolder->get(path: $folderPath);
-                $this->logger->info(
+                $this->logger->debug(
                     message: "[FolderManagementHandler] This folder already exists: $folderPath",
                     context: ['file' => __FILE__, 'line' => __LINE__]
                 );
@@ -564,7 +560,7 @@ class FolderManagementHandler
             } catch (NotFoundException) {
                 // Folder does not exist, create it.
                 $node = $userFolder->newFolder(path: $folderPath);
-                $this->logger->info(
+                $this->logger->debug(
                     message: "[FolderManagementHandler] Created folder: $folderPath",
                     context: ['file' => __FILE__, 'line' => __LINE__]
                 );
@@ -1130,7 +1126,7 @@ class FolderManagementHandler
         try {
             // Try to get existing folder first.
             $objectFolder = $registerFolder->get($objectFolderName);
-            $this->logger->info(
+            $this->logger->debug(
                 message: "[FolderManagementHandler] Object folder already exists: ".$objectFolderName,
                 context: ['file' => __FILE__, 'line' => __LINE__]
             );
@@ -1138,7 +1134,7 @@ class FolderManagementHandler
         } catch (NotFoundException) {
             // Create new folder if it doesn't exist.
             $objectFolder = $registerFolder->newFolder($objectFolderName);
-            $this->logger->info(
+            $this->logger->debug(
                 message: "[FolderManagementHandler] Created object folder: ".$objectFolderName,
                 context: ['file' => __FILE__, 'line' => __LINE__]
             );

--- a/lib/Service/File/FolderManagementHandler.php
+++ b/lib/Service/File/FolderManagementHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -59,7 +59,7 @@ use Symfony\Component\Uid\Uuid;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  *

--- a/lib/Service/File/PlaceholderIdTranslator.php
+++ b/lib/Service/File/PlaceholderIdTranslator.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -42,7 +42,7 @@ namespace OCA\OpenRegister\Service\File;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  *
  * @spec openspec/changes/anonymisation-placeholder-id-scope/design.md

--- a/lib/Service/File/ReadFileHandler.php
+++ b/lib/Service/File/ReadFileHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -44,7 +44,7 @@ use OCA\OpenRegister\Service\File\FileValidationHandler;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  *

--- a/lib/Service/File/TaggingHandler.php
+++ b/lib/Service/File/TaggingHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -41,7 +41,7 @@ use Psr\Log\LoggerInterface;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  */

--- a/lib/Service/File/UpdateFileHandler.php
+++ b/lib/Service/File/UpdateFileHandler.php
@@ -136,7 +136,7 @@ class UpdateFileHandler
             $entity = $this->fileMapper->setLabelsForFile(fileId: $fileId, labels: $labels);
         }
 
-        $this->logger->info(
+        $this->logger->debug(
             message: "[UpdateFileHandler] OR-side metadata updated for file $fileId",
             context: [
                 'file'               => __FILE__,
@@ -195,7 +195,7 @@ class UpdateFileHandler
     ): File {
         // Debug logging - original file path.
         $originalFilePath = $filePath;
-        $this->logger->info(
+        $this->logger->debug(
             message: "[UpdateFileHandler] updateFile: Original file path received: '$originalFilePath'",
             context: ['file' => __FILE__, 'line' => __LINE__]
         );
@@ -206,7 +206,7 @@ class UpdateFileHandler
 
         // If $filePath is an integer (file ID), try to find the file directly by ID.
         if (is_int($filePath) === true) {
-            $this->logger->info(
+            $this->logger->debug(
                 message: "[UpdateFileHandler] updateFile: File ID provided: $filePath",
                 context: ['file' => __FILE__, 'line' => __LINE__]
             );
@@ -218,7 +218,7 @@ class UpdateFileHandler
                     $fileName = $file->getName();
                     $fileId   = $file->getId();
                     $msg      = "[UpdateFileHandler] updateFile: Found file by ID in object folder: $fileName (ID: $fileId)";
-                    $this->logger->info(
+                    $this->logger->debug(
                         message: $msg,
                         context: ['file' => __FILE__, 'line' => __LINE__]
                     );
@@ -241,7 +241,7 @@ class UpdateFileHandler
                     $file     = $nodes[0];
                     $fileName = $file->getName();
                     $fid      = $file->getId();
-                    $this->logger->info(
+                    $this->logger->debug(
                         message: "[UpdateFileHandler] updateFile: Found file by ID in user folder: $fileName (ID: $fid)",
                         context: ['file' => __FILE__, 'line' => __LINE__]
                     );
@@ -262,12 +262,12 @@ class UpdateFileHandler
             $filePath = $pathInfo['cleanPath'];
             $fileName = $pathInfo['fileName'];
 
-            $this->logger->info(
+            $this->logger->debug(
                 message: "[UpdateFileHandler] updateFile: After cleaning: '$filePath'",
                 context: ['file' => __FILE__, 'line' => __LINE__]
             );
             if ($fileName !== $filePath) {
-                $this->logger->info(
+                $this->logger->debug(
                     message: "[UpdateFileHandler] updateFile: Extracted filename from path: '$fileName' (from '$filePath')",
                     context: ['file' => __FILE__, 'line' => __LINE__]
                 );
@@ -282,11 +282,11 @@ class UpdateFileHandler
                     $objectFolder = $this->folderMgmtHandler->getObjectFolder($object);
 
                     if ($objectFolder !== null) {
-                        $this->logger->info(
+                        $this->logger->debug(
                             message: "[UpdateFileHandler] updateFile: Object folder path: ".$objectFolder->getPath(),
                             context: ['file' => __FILE__, 'line' => __LINE__]
                         );
-                        $this->logger->info(
+                        $this->logger->debug(
                             message: "[UpdateFileHandler] updateFile: Object folder ID: ".$objectFolder->getId(),
                             context: ['file' => __FILE__, 'line' => __LINE__]
                         );
@@ -296,7 +296,7 @@ class UpdateFileHandler
                             $folderFiles = $objectFolder->getDirectoryListing();
                             $fileNames   = array_map(fn($f) => $f->getName(), $folderFiles);
                             $fileList    = implode(', ', $fileNames);
-                            $this->logger->info(
+                            $this->logger->debug(
                                 message: "[UpdateFileHandler] updateFile: Files in object folder: $fileList",
                                 context: [
                                     'file' => __FILE__,
@@ -314,7 +314,7 @@ class UpdateFileHandler
                         try {
                             $file = $objectFolder->get($fileName);
                             $msg  = "updateFile: Found file in object folder: ".$file->getName()." (ID: ".$file->getId().")";
-                            $this->logger->info(
+                            $this->logger->debug(
                                 message: "[UpdateFileHandler] ".$msg,
                                 context: ['file' => __FILE__, 'line' => __LINE__]
                             );
@@ -328,7 +328,7 @@ class UpdateFileHandler
                             try {
                                 $file = $objectFolder->get($filePath);
                                 $msg  = "updateFile: Found file using full path in object folder: ".$file->getName();
-                                $this->logger->info(
+                                $this->logger->debug(
                                     message: "[UpdateFileHandler] ".$msg,
                                     context: ['file' => __FILE__, 'line' => __LINE__]
                                 );
@@ -358,7 +358,7 @@ class UpdateFileHandler
             }//end if
 
             if ($object === null) {
-                $this->logger->info(
+                $this->logger->debug(
                     message: "[UpdateFileHandler] updateFile: No object provided, will search in user folder",
                     context: ['file' => __FILE__, 'line' => __LINE__]
                 );
@@ -367,7 +367,7 @@ class UpdateFileHandler
             // If object wasn't provided or file wasn't found in object folder, try user folder.
             $userFolder = null;
             if ($file === null) {
-                $this->logger->info(
+                $this->logger->debug(
                     message: "[UpdateFileHandler] updateFile: Trying user folder approach with path: '$filePath'",
                     context: ['file' => __FILE__, 'line' => __LINE__]
                 );
@@ -377,7 +377,7 @@ class UpdateFileHandler
                     $fileId     = $file->getId();
                     $msg        = "[UpdateFileHandler] updateFile: Found file in user folder";
                     $msg       .= " at path: $filePath (ID: $fileId)";
-                    $this->logger->info(message: $msg, context: ['file' => __FILE__, 'line' => __LINE__]);
+                    $this->logger->debug(message: $msg, context: ['file' => __FILE__, 'line' => __LINE__]);
                 } catch (NotFoundException $e) {
                     $this->logger->error(
                         message: "[UpdateFileHandler] updateFile: File $filePath not found in user folder either.",
@@ -387,7 +387,7 @@ class UpdateFileHandler
                     // Try to find the file by ID if the path starts with a number.
                     if (preg_match('/^(\d+)\//', $filePath, $matches) === 1) {
                         $fileId = (int) $matches[1];
-                        $this->logger->info(
+                        $this->logger->debug(
                             message: "[UpdateFileHandler] updateFile: Attempting to find file by ID: $fileId",
                             context: ['file' => __FILE__, 'line' => __LINE__]
                         );
@@ -399,7 +399,7 @@ class UpdateFileHandler
                                 $fileName = $file->getName();
                                 $path     = $file->getPath();
                                 $msg      = "updateFile: Found file by ID $fileId: $fileName at path: $path";
-                                $this->logger->info(
+                                $this->logger->debug(
                                     message: "[UpdateFileHandler] ".$msg,
                                     context: ['file' => __FILE__, 'line' => __LINE__]
                                 );
@@ -455,7 +455,7 @@ class UpdateFileHandler
                 }
 
                 $file->putContent(data: $content);
-                $this->logger->info(
+                $this->logger->debug(
                     message: "[UpdateFileHandler] updateFile: Successfully updated file content: ".$file->getName(),
                     context: ['file' => __FILE__, 'line' => __LINE__]
                 );
@@ -486,7 +486,7 @@ class UpdateFileHandler
             $allTags = array_unique(array_merge($objectTags, $tags));
 
             $this->fileService->attachTagsToFile(fileId: (string) $file->getId(), tags: $allTags);
-            $this->logger->info(
+            $this->logger->debug(
                 message: "[UpdateFileHandler] updateFile: Successfully updated file tags: ".$file->getName(),
                 context: ['file' => __FILE__, 'line' => __LINE__]
             );

--- a/lib/Service/File/UpdateFileHandler.php
+++ b/lib/Service/File/UpdateFileHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -45,7 +45,7 @@ use Psr\Log\LoggerInterface;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  *

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -684,7 +684,7 @@ class FileService
      *
      * @phpstan-return Node|null
      *
-     * @spec openspec/specs/file-actions/spec.md#object-register-folder-management
+     * @spec openspec/specs/file-actions/spec.md#object-and-register-folder-provisioning
      *   (unified entry: provisions the backing folder for a Register or ObjectEntity, degrading to null on failure)
      */
     public function createEntityFolder(Register | ObjectEntity $entity): ?Node
@@ -795,7 +795,7 @@ class FileService
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)  Boolean flag is intentional for simple filter toggle
      * @SuppressWarnings(PHPMD.CyclomaticComplexity) File retrieval requires entity type checking
      *
-     * @spec openspec/specs/file-actions/spec.md#file-crud-operations-on-objects
+     * @spec openspec/specs/file-actions/spec.md#file-retrieval-resolves-by-id-or-name-and-projects-nodes-to-metadata
      *   (unified file listing for a Register or ObjectEntity via the stored folder, with optional shared-only filter)
      */
     public function getFilesForEntity(Register|ObjectEntity $entity, ?bool $sharedFilesOnly=false): array
@@ -1275,7 +1275,7 @@ class FileService
      *
      * @return Node The Node object for the folder (existing or newly created), or null on failure
      *
-     * @spec openspec/specs/file-actions/spec.md#object-register-folder-management
+     * @spec openspec/specs/file-actions/spec.md#object-and-register-folder-provisioning
      *   (idempotent get-or-create of a folder at the given path under the OpenRegister root)
      */
     public function createFolder(string $folderPath): Node
@@ -1303,7 +1303,8 @@ class FileService
      * @phpstan-param array<int, string> $tags
      * @psalm-param   array<int, string> $tags
      *
-     * @spec openspec/specs/file-actions/spec.md#file-crud-operations-on-objects (updates a file's content and tags within an object's folder)
+     * @spec openspec/specs/file-actions/spec.md#file-update-guards-locks-preserves-object-tags-and-persists-or-side-metadata-separately
+     *   (updates a file's content and tags within an object's folder)
      */
     public function updateFile(string|int $filePath, mixed $content=null, array $tags=[], ?ObjectEntity $object=null): File
     {
@@ -1358,7 +1359,8 @@ class FileService
      *
      * @throws Exception If deleting the file is not permitted or file operations fail.
      *
-     * @spec openspec/specs/file-actions/spec.md#file-crud-operations-on-objects (deletes a file resolved by node/path/id, with object-folder context)
+     * @spec openspec/specs/file-actions/spec.md#file-update-and-delete-enforce-per-action-node-permissions
+     *   (deletes a file resolved by node/path/id, with object-folder context)
      */
     public function deleteFile(Node | string | int $file, ?ObjectEntity $object=null): bool
     {
@@ -1381,7 +1383,8 @@ class FileService
      * @phpstan-param array<int, string> $tags
      * @psalm-param   array<int, string> $tags
      *
-     * @spec openspec/specs/file-actions/spec.md#object-tagging-via-nextcloud-system-tags (attaches NC system tags to a file by id)
+     * @spec openspec/specs/file-actions/spec.md#file-creation-and-upsert-run-a-fixed-validate-write-own-tag-pipeline
+     *   (the `object:<uuid>` + caller-tag attachment step of the create/upsert pipeline)
      */
     public function attachTagsToFile(string $fileId, array $tags=[]): void
     {
@@ -1479,7 +1482,7 @@ class FileService
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Boolean flag is intentional for simple share toggle
      *
-     * @spec openspec/specs/file-actions/spec.md#file-crud-operations-on-objects
+     * @spec openspec/specs/file-actions/spec.md#file-creation-and-upsert-run-a-fixed-validate-write-own-tag-pipeline
      *   (creates/writes a file into an object's folder with optional tags and share toggle)
      */
     public function saveFile(
@@ -1548,7 +1551,7 @@ class FileService
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Boolean flag is intentional for simple filter toggle
      *
-     * @spec openspec/specs/file-actions/spec.md#file-crud-operations-on-objects
+     * @spec openspec/specs/file-actions/spec.md#file-retrieval-resolves-by-id-or-name-and-projects-nodes-to-metadata
      *   (lists an object's files via its stored folder, with optional shared-only filter)
      */
     public function getFiles(ObjectEntity | string $object, ?bool $sharedFilesOnly=false): array
@@ -1601,7 +1604,8 @@ class FileService
      * @phpstan-param  int $fileId
      * @phpstan-return File|null
      *
-     * @spec openspec/specs/file-actions/spec.md#file-crud-operations-on-objects (resolves a single file node by NC file id, null on miss)
+     * @spec openspec/specs/file-actions/spec.md#file-retrieval-resolves-by-id-or-name-and-projects-nodes-to-metadata
+     *   (resolves a single file node by NC file id, null on miss)
      */
     public function getFileById(int $fileId): ?File
     {
@@ -1930,7 +1934,7 @@ class FileService
      *
      * @return int The created folder ID
      *
-     * @spec openspec/specs/file-actions/spec.md#object-register-folder-management
+     * @spec openspec/specs/file-actions/spec.md#object-and-register-folder-provisioning
      *   (provisions an object's folder and returns its id without writing the id back onto the entity)
      */
     public function createObjectFolderWithoutUpdate(ObjectEntity $objectEntity, ?IUser $currentUser=null): int

--- a/lib/Service/Object/CascadingHandler.php
+++ b/lib/Service/Object/CascadingHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -37,7 +37,7 @@ use Psr\Log\LoggerInterface;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  */

--- a/lib/Service/Object/MergeHandler.php
+++ b/lib/Service/Object/MergeHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -40,7 +40,7 @@ use Exception;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  */

--- a/lib/Service/Object/MetadataHandler.php
+++ b/lib/Service/Object/MetadataHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -31,7 +31,7 @@ use Exception;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  */

--- a/lib/Service/Object/MigrationHandler.php
+++ b/lib/Service/Object/MigrationHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -41,7 +41,7 @@ use Exception;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  */

--- a/lib/Service/Object/PerformanceOptimizationHandler.php
+++ b/lib/Service/Object/PerformanceOptimizationHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -33,7 +33,7 @@ use Psr\Log\LoggerInterface;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  */

--- a/lib/Service/Object/QueryHandler.php
+++ b/lib/Service/Object/QueryHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  *
  * @spec openspec/specs/zoeken-filteren/spec.md#requirement-view-based-search-composition
@@ -44,7 +44,7 @@ use Psr\Log\LoggerInterface;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  *

--- a/lib/Service/Object/RelationHandler.php
+++ b/lib/Service/Object/RelationHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -41,7 +41,7 @@ use Symfony\Component\Uid\Uuid;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  *

--- a/lib/Service/Object/RelationshipOptimizationHandler.php
+++ b/lib/Service/Object/RelationshipOptimizationHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -34,7 +34,7 @@ use Psr\Log\LoggerInterface;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  *

--- a/lib/Service/Object/SaveObject/FilePropertyHandler.php
+++ b/lib/Service/Object/SaveObject/FilePropertyHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -42,7 +42,7 @@ use Psr\Log\LoggerInterface;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  *

--- a/lib/Service/Object/SaveObjects/BulkRelationHandler.php
+++ b/lib/Service/Object/SaveObjects/BulkRelationHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -36,7 +36,7 @@ use Psr\Log\LoggerInterface;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  *

--- a/lib/Service/Object/SaveObjects/PreparationHandler.php
+++ b/lib/Service/Object/SaveObjects/PreparationHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -42,7 +42,7 @@ use Exception;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  */

--- a/lib/Service/Object/SaveObjects/TransformationHandler.php
+++ b/lib/Service/Object/SaveObjects/TransformationHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  *
  * @spec openspec/specs/object-lifecycle/spec.md
@@ -40,7 +40,7 @@ use DateTime;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  */

--- a/lib/Service/Object/UtilityHandler.php
+++ b/lib/Service/Object/UtilityHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -34,7 +34,7 @@ use OCA\OpenRegister\Db\SchemaMapper;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  */

--- a/openspec/specs/file-actions/spec.md
+++ b/openspec/specs/file-actions/spec.md
@@ -694,3 +694,54 @@ with a clear `NotPermittedException` rather than an opaque storage error.
 - **WHEN** `UpdateFileHandler` updates its content
 - **THEN** `File::putContent()` MUST be called with the new content
 
+### Requirement: Object and register folder provisioning
+
+`FileService` MUST expose the folder-provisioning entry points that the file
+pipeline and the object save path depend on, because files are always stored
+under a folder belonging to a `Register` or an `ObjectEntity`. Each entry point
+is a facade over `FolderManagementHandler`.
+
+- `FileService::createEntityFolder(Register|ObjectEntity $entity)` MUST be the
+  unified entry point: a `Register` MUST be dispatched to
+  `createRegisterFolderById()` and an `ObjectEntity` to `createObjectFolderById()`,
+  both with the current user resolved by `FileService::getCurrentUser()`. It MUST
+  re-throw `FolderAccessDeniedException` unchanged so the controller can map it to
+  HTTP 403 with a structured body (see the `self-folder-access-control` spec), and
+  it MUST log and return `null` for any other exception rather than propagating it.
+- `FileService::createFolder(string $folderPath)` MUST be an idempotent
+  get-or-create for a folder at `$folderPath`: the path MUST be trimmed of leading
+  and trailing `/`, the OpenRegister root folder MUST be created when absent —
+  creating the `openregister` group when that too is absent — and an existing
+  folder at the path MUST be returned as-is rather than replaced.
+- `FileService::createObjectFolderWithoutUpdate(ObjectEntity $objectEntity, ?IUser $currentUser = null)`
+  MUST provision the object's folder beneath its register/schema folders and
+  return the folder ID **without** writing that ID back onto the entity, so a
+  caller can set the folder ID and persist the object in a single save.
+
+#### Scenario: Register and object dispatch to their own provisioning paths
+- **GIVEN** a `Register` and an `ObjectEntity`
+- **WHEN** `createEntityFolder()` is called with each in turn
+- **THEN** the `Register` MUST be routed to `createRegisterFolderById()` and the `ObjectEntity` to `createObjectFolderById()`
+
+#### Scenario: A folder access denial is not swallowed
+- **GIVEN** `createObjectFolderById()` throws `FolderAccessDeniedException`
+- **WHEN** `createEntityFolder()` handles it
+- **THEN** the exception MUST propagate unchanged
+- **AND** the method MUST NOT return `null`
+
+#### Scenario: Any other provisioning failure degrades to null
+- **GIVEN** the underlying provisioning throws a generic `Exception`
+- **WHEN** `createEntityFolder()` handles it
+- **THEN** the failure MUST be logged and `null` MUST be returned
+
+#### Scenario: Creating an existing folder returns the existing node
+- **GIVEN** a folder already exists at `$folderPath`
+- **WHEN** `createFolder($folderPath)` is called
+- **THEN** the existing folder node MUST be returned and MUST NOT be replaced
+
+#### Scenario: Folder ID is returned without mutating the entity
+- **GIVEN** an `ObjectEntity` with no folder yet
+- **WHEN** `createObjectFolderWithoutUpdate()` provisions its folder
+- **THEN** the new folder ID MUST be returned
+- **AND** the entity's own folder property MUST NOT have been written
+


### PR DESCRIPTION
Fixes the two gates that a real 10-file openregister diff failed once the
61-gate `Hydra Gates` tier was switched on. Both were verified real before
anything was changed.

## gate-28 license-triangle — 30 of 32 files corrected

32 files under `lib/` declared `@license AGPL-3.0-or-later` while
`composer.json`, `appinfo/info.xml` and the repo `LICENSE` all declare
**EUPL-1.2**.

**Provenance was established before any header was touched**, because
relicensing a file that genuinely derives from AGPL code would be a licence
violation:

- repo `LICENSE` is the EUPL-1.2 text; its first committed version was
  Apache-2.0 — it was **never** AGPL
- `appinfo/info.xml` was deliberately moved `agpl` -> `EUPL-1.2` in 9107a57e3
- every `@copyright` in `lib/` names Conduction B.V.
- all 30 corrected files were created **in this repository** by Conduction
  contributors (`git log --follow --diff-filter=A`); none was vendored
- 28 of the 30 already carried `SPDX-License-Identifier: EUPL-1.2` in the *same
  docblock* as the AGPL tag — the machine-readable line already said EUPL and
  only the PHPDoc tag was stale
- the canonical form is used by 1486 other tags in `lib/` vs 65 AGPL

So these are Nextcloud-app-template boilerplate residue, not derivation from
AGPL code.

### 2 files deliberately NOT relicensed

`lib/Db/Webhook.php` and `lib/Migration/Version002003000Date20251013000000.php`
both assert **`SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud
contributors`** alongside `@copyright Conduction B.V.` — two contradictory
owners in one header. Their content is openregister-specific (a Webhook entity;
a migration creating `oc_openregister_vectors`), which strongly suggests the
Nextcloud line is template residue as well — but that is the copyright owner's
call, not one to make silently in a cleanup commit. **gate-28 therefore still
reports 2 findings whole-tree, by design.**

9 further `lib/Migration/*.php` files carry the same Nextcloud SPDX block with an
`AGPL-3.0-or-later` SPDX line while their PHPDoc says EUPL. gate-28 does not see
them (it reads only `@license`), and they are left alone for the same reason.
**These 11 files need a licensing decision.**

## gate-46 spec-anchor-existence — 10 dangling anchors resolved

All 10 were in `lib/Service/FileService.php`, naming three fragments that never
existed in `openspec/specs/file-actions/spec.md`. **Nothing was invented.**

- **(a) wrong anchor, real requirement exists — 7 sites retargeted.**
  `getFilesForEntity`/`getFiles`/`getFileById` -> the file-retrieval requirement
  (which names all three explicitly); `updateFile` -> the file-update
  requirement; `deleteFile` -> the update/delete node-permission requirement
  (the only one specifying `DeleteFileHandler`); `saveFile` and
  `attachTagsToFile` -> the creation/upsert requirement, which specifies both by
  name.
- **(b) genuinely unspecced — 3 sites.** Folder *provisioning*
  (`createEntityFolder`, `createFolder`, `createObjectFolderWithoutUpdate`) was
  described nowhere: file-actions mentions `FolderManagementHandler` only as a
  resolution step, and `self-folder-access-control` governs `@self.folder`
  *binds*, not creation. Rather than hide it behind an exclusion, this adds
  `### Requirement: Object and register folder provisioning`, written **only**
  from behaviour verified by reading the implementations. 5 scenarios.
- **(c) none.**

Also retargets a pre-existing dangling anchor in
`DocumentProcessingHandler.php` (`#REQ-ORTPR-003`) that pointed at an **archived
change directory** instead of the canonical spec — pulled into gate-46's diff
scope by the licence commit, so fixed here rather than left red.

`openspec validate file-actions --type spec` -> **valid**; `openspec show --json`
sees 17 requirements (was 16), 5 scenarios on the new one.

## FAIL -> PASS proof

Measured against a control branch that reverts all three commits, so **the
identical 32-file set is in scope** on both sides:

| | control (old content) | this branch |
|---|---|---|
| scope | 32 changed files | 32 changed files |
| gate-28 | **FAIL — 30 files** | **PASS** |
| gate-46 | **FAIL — 11 anchors** | **PASS** |
| total failing | 4 gates | 2 gates |

The 2 that remain — `gate-47 security-change-has-tests` (10 files) and
`gate-57 orphaned-write-capability` (2 methods) — **fail identically in the
control**. They are pre-existing debt in files this PR touches
*comment-only*; nothing here regressed them.

## Measurement note

The gate runner writes to hardcoded `/tmp/hydra-gate-*.log`. A concurrent agent
running the same gates on the same tree truncated those files mid-run and
silently corrupted my first counts **downward** (32->29, 112->63). Every number
above was produced inside a private mount namespace
(`unshare -Urm` + `mount -t tmpfs tmpfs /tmp`) and reproduced. Worth fixing in
the runner: concurrent runs are currently mutually corrupting, and the
corruption looks like progress.
