### PR TITLE
chore(license): normalise licence declarations to EUPL-1.2

### DIFF
--- a/exapps/README.md
+++ b/exapps/README.md
@@ -238,4 +238,4 @@ curl http://localhost:9000/api/tags
 
 ## License
 
-AGPL-3.0 - See LICENSE file for details.
+EUPL-1.2 - See LICENSE file for details.

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -316,7 +316,7 @@ use OCA\OpenRegister\Service\TimeTrackerLinkService;
  * @package  OCA\OpenRegister\AppInfo
  *
  * @author  Nextcloud Dev Team
- * @license AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @link https://github.com/nextcloud/server/blob/master/apps-extra/openregister
  *

--- a/lib/Controller/FileSearchController.php
+++ b/lib/Controller/FileSearchController.php
@@ -38,7 +38,7 @@ use Psr\Log\LoggerInterface;
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @psalm-suppress UnusedClass
  */

--- a/lib/Controller/FileTextController.php
+++ b/lib/Controller/FileTextController.php
@@ -50,7 +50,7 @@ use Throwable;
  * @category Controller
  * @package  OCA\OpenRegister\Controller
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @psalm-suppress UnusedClass
  *

--- a/lib/Controller/NamesController.php
+++ b/lib/Controller/NamesController.php
@@ -49,7 +49,7 @@ use Psr\Log\LoggerInterface;
  * @category  Controller
  * @package   OCA\OpenRegister\Controller
  * @author    Conduction b.v. <info@conduction.nl>
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/OpenCatalogi/OpenRegister
  * @version   GIT: <git_id>
  * @copyright 2024 Conduction b.v.

--- a/lib/Controller/UiController.php
+++ b/lib/Controller/UiController.php
@@ -10,7 +10,7 @@
  * @package   OCA\OpenRegister\Controller
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2024 Conduction b.v.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT: <git_id>
  * @link      https://github.com/conductionnl/openregister
  */
@@ -34,7 +34,7 @@ use OCP\IRequest;
  *
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2024 Conduction b.v.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @version GIT: <git_id>
  *

--- a/lib/Controller/ViewsController.php
+++ b/lib/Controller/ViewsController.php
@@ -13,7 +13,7 @@
  * @package   OCA\OpenRegister\Controller
  * @author    Conduction Development Team <dev@conduction.nl>
  * @copyright 2024 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT: <git_id>
  * @link      https://github.com/ConductionNL/openregister
  */

--- a/lib/Controller/WebhooksController.php
+++ b/lib/Controller/WebhooksController.php
@@ -51,7 +51,7 @@ use Psr\Log\LoggerInterface;
  * @category Controller
  * @package  OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  *
  * @psalm-suppress UnusedClass

--- a/lib/Cron/WebhookRetryJob.php
+++ b/lib/Cron/WebhookRetryJob.php
@@ -44,7 +44,7 @@ use Psr\Log\LoggerInterface;
  * @category Cron
  * @package  OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  *
  * @psalm-suppress UnusedClass

--- a/lib/Db/Webhook.php
+++ b/lib/Db/Webhook.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * @author    Conduction Development Team <dev@conduction.nl>
  * @copyright 2026 Conduction B.V.

--- a/lib/Db/Webhook.php
+++ b/lib/Db/Webhook.php
@@ -6,7 +6,7 @@
  *
  * @author    Conduction Development Team <dev@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 
 namespace OCA\OpenRegister\Db;

--- a/lib/Event/OrganisationCreatedEvent.php
+++ b/lib/Event/OrganisationCreatedEvent.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister\Event
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version   GIT: <git_id>
  * @link      https://github.com/ConductionNL/OpenRegister
  */
@@ -33,7 +33,7 @@ use OCA\OpenRegister\Db\Organisation;
  * @category Event
  * @package  OCA\OpenRegister\Event
  * @author   Conduction b.v. <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version  1.0.0
  * @link     https://github.com/ConductionNL/OpenRegister
  */

--- a/lib/Listener/FileChangeListener.php
+++ b/lib/Listener/FileChangeListener.php
@@ -13,7 +13,7 @@
  *
  * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @version GIT: <git_id>
  *
@@ -44,7 +44,7 @@ use Psr\Log\LoggerInterface;
  * @category Listener
  * @package  OCA\OpenRegister\Listener
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @template-implements IEventListener<NodeCreatedEvent|NodeWrittenEvent>
  */

--- a/lib/Listener/ObjectChangeListener.php
+++ b/lib/Listener/ObjectChangeListener.php
@@ -13,7 +13,7 @@
  *
  * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @version GIT: <git_id>
  *
@@ -44,7 +44,7 @@ use Psr\Log\LoggerInterface;
  * @category Listener
  * @package  OCA\OpenRegister\Listener
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @template-implements IEventListener<ObjectCreatedEvent|ObjectUpdatedEvent>
  */

--- a/lib/Migration/Version002003000Date20251013000000.php
+++ b/lib/Migration/Version002003000Date20251013000000.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * @category Migration
  * @package  OCA\OpenRegister\Migration

--- a/lib/Migration/Version1Date20240924200009.php
+++ b/lib/Migration/Version1Date20240924200009.php
@@ -19,7 +19,7 @@ declare(strict_types=1);
 
 /*
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  */
 
 namespace OCA\OpenRegister\Migration;

--- a/lib/Migration/Version1Date20241019205009.php
+++ b/lib/Migration/Version1Date20241019205009.php
@@ -19,7 +19,7 @@ declare(strict_types=1);
 
 /*
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  */
 
 

--- a/lib/Migration/Version1Date20241020231700.php
+++ b/lib/Migration/Version1Date20241020231700.php
@@ -19,7 +19,7 @@ declare(strict_types=1);
 
 /*
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  */
 
 

--- a/lib/Migration/Version1Date20241022135300.php
+++ b/lib/Migration/Version1Date20241022135300.php
@@ -19,7 +19,7 @@ declare(strict_types=1);
 
 /*
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  */
 
 

--- a/lib/Migration/Version1Date20241030131427.php
+++ b/lib/Migration/Version1Date20241030131427.php
@@ -19,7 +19,7 @@ declare(strict_types=1);
 
 /*
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  */
 
 

--- a/lib/Migration/Version1Date20241128221000.php
+++ b/lib/Migration/Version1Date20241128221000.php
@@ -19,7 +19,7 @@ declare(strict_types=1);
 
 /*
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  */
 
 

--- a/lib/Migration/Version1Date20241216094112.php
+++ b/lib/Migration/Version1Date20241216094112.php
@@ -19,7 +19,7 @@ declare(strict_types=1);
 
 /*
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  */
 
 

--- a/lib/Migration/Version1Date20241227153853.php
+++ b/lib/Migration/Version1Date20241227153853.php
@@ -19,7 +19,7 @@ declare(strict_types=1);
 
 /*
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  */
 
 

--- a/lib/Migration/Version1Date20250115230511.php
+++ b/lib/Migration/Version1Date20250115230511.php
@@ -19,7 +19,7 @@ declare(strict_types=1);
 
 /*
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  */
 
 

--- a/lib/Service/File/CreateFileHandler.php
+++ b/lib/Service/File/CreateFileHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -44,7 +44,7 @@ use Psr\Log\LoggerInterface;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  *

--- a/lib/Service/File/DeleteFileHandler.php
+++ b/lib/Service/File/DeleteFileHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -42,7 +42,7 @@ use Psr\Log\LoggerInterface;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  */

--- a/lib/Service/File/DocumentProcessingHandler.php
+++ b/lib/Service/File/DocumentProcessingHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -59,7 +59,7 @@ use ZipArchive;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  *

--- a/lib/Service/File/FileCrudHandler.php
+++ b/lib/Service/File/FileCrudHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12 https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -46,7 +46,7 @@ use Psr\Log\LoggerInterface;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12 https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  * @todo     Extract full implementations from FileService in Phase 2

--- a/lib/Service/File/FileFormattingHandler.php
+++ b/lib/Service/File/FileFormattingHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12 https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -47,7 +47,7 @@ use Psr\Log\LoggerInterface;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12 https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  *

--- a/lib/Service/File/FileOwnershipHandler.php
+++ b/lib/Service/File/FileOwnershipHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12 https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -41,7 +41,7 @@ use Psr\Log\LoggerInterface;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12 https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  */

--- a/lib/Service/File/FilePublishingHandler.php
+++ b/lib/Service/File/FilePublishingHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12 https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -42,7 +42,7 @@ use ZipArchive;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12 https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  */

--- a/lib/Service/File/FileSharingHandler.php
+++ b/lib/Service/File/FileSharingHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12 https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -48,7 +48,7 @@ use Psr\Log\LoggerInterface;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12 https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  */

--- a/lib/Service/File/FileValidationHandler.php
+++ b/lib/Service/File/FileValidationHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12 https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -40,7 +40,7 @@ use Psr\Log\LoggerInterface;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12 https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  */

--- a/lib/Service/File/FolderManagementHandler.php
+++ b/lib/Service/File/FolderManagementHandler.php
@@ -59,7 +59,7 @@ use Symfony\Component\Uid\Uuid;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  *

--- a/lib/Service/File/PlaceholderIdTranslator.php
+++ b/lib/Service/File/PlaceholderIdTranslator.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -42,7 +42,7 @@ namespace OCA\OpenRegister\Service\File;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  *
  * @spec openspec/changes/anonymisation-placeholder-id-scope/design.md

--- a/lib/Service/File/ReadFileHandler.php
+++ b/lib/Service/File/ReadFileHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -44,7 +44,7 @@ use OCA\OpenRegister\Service\File\FileValidationHandler;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  *

--- a/lib/Service/File/TaggingHandler.php
+++ b/lib/Service/File/TaggingHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -41,7 +41,7 @@ use Psr\Log\LoggerInterface;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  */

--- a/lib/Service/File/UpdateFileHandler.php
+++ b/lib/Service/File/UpdateFileHandler.php
@@ -45,7 +45,7 @@ use Psr\Log\LoggerInterface;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  *

--- a/lib/Service/Object/CacheHandler.php
+++ b/lib/Service/Object/CacheHandler.php
@@ -50,7 +50,7 @@ use Psr\Log\LoggerInterface;
  * @category  Service
  * @package   OCA\OpenRegister\Service
  * @author    Conduction b.v. <info@conduction.nl>
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/OpenCatalogi/OpenRegister
  * @version   GIT: <git_id>
  * @copyright 2024 Conduction b.v.

--- a/lib/Service/Object/CascadingHandler.php
+++ b/lib/Service/Object/CascadingHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -37,7 +37,7 @@ use Psr\Log\LoggerInterface;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  */

--- a/lib/Service/Object/DeleteObject.php
+++ b/lib/Service/Object/DeleteObject.php
@@ -61,7 +61,7 @@ use Psr\Log\LoggerInterface;
  * @category  Service
  * @package   OCA\OpenRegister\Service\Objects
  * @author    Conduction b.v. <info@conduction.nl>
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/OpenCatalogi/OpenRegister
  * @version   GIT: <git_id>
  * @copyright 2024 Conduction b.v.

--- a/lib/Service/Object/GetObject.php
+++ b/lib/Service/Object/GetObject.php
@@ -49,7 +49,7 @@ use Psr\Log\LoggerInterface;
  * @category  Service
  * @package   OCA\OpenRegister\Service\Objects
  * @author    Conduction b.v. <info@conduction.nl>
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/OpenCatalogi/OpenRegister
  * @version   GIT: <git_id>
  * @copyright 2024 Conduction b.v.

--- a/lib/Service/Object/MergeHandler.php
+++ b/lib/Service/Object/MergeHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -40,7 +40,7 @@ use Exception;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  */

--- a/lib/Service/Object/MetadataHandler.php
+++ b/lib/Service/Object/MetadataHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -31,7 +31,7 @@ use Exception;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  */

--- a/lib/Service/Object/MigrationHandler.php
+++ b/lib/Service/Object/MigrationHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -41,7 +41,7 @@ use Exception;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  */

--- a/lib/Service/Object/PerformanceOptimizationHandler.php
+++ b/lib/Service/Object/PerformanceOptimizationHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -33,7 +33,7 @@ use Psr\Log\LoggerInterface;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  */

--- a/lib/Service/Object/QueryHandler.php
+++ b/lib/Service/Object/QueryHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  *
  * @spec openspec/specs/zoeken-filteren/spec.md#requirement-view-based-search-composition
@@ -44,7 +44,7 @@ use Psr\Log\LoggerInterface;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  *

--- a/lib/Service/Object/RelationHandler.php
+++ b/lib/Service/Object/RelationHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -41,7 +41,7 @@ use Symfony\Component\Uid\Uuid;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  *

--- a/lib/Service/Object/RelationshipOptimizationHandler.php
+++ b/lib/Service/Object/RelationshipOptimizationHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -34,7 +34,7 @@ use Psr\Log\LoggerInterface;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  *

--- a/lib/Service/Object/RenderObject.php
+++ b/lib/Service/Object/RenderObject.php
@@ -72,7 +72,7 @@ use Symfony\Component\Uid\Uuid;
  * @category  Service
  * @package   OCA\OpenRegister\Service\Objects
  * @author    Conduction b.v. <info@conduction.nl>
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/OpenCatalogi/OpenRegister
  * @version   GIT: <git_id>
  * @copyright 2024 Conduction b.v.

--- a/lib/Service/Object/SaveObject/FilePropertyHandler.php
+++ b/lib/Service/Object/SaveObject/FilePropertyHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -42,7 +42,7 @@ use Psr\Log\LoggerInterface;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  *

--- a/lib/Service/Object/SaveObjects/BulkRelationHandler.php
+++ b/lib/Service/Object/SaveObjects/BulkRelationHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -36,7 +36,7 @@ use Psr\Log\LoggerInterface;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  *

--- a/lib/Service/Object/SaveObjects/PreparationHandler.php
+++ b/lib/Service/Object/SaveObjects/PreparationHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -42,7 +42,7 @@ use Exception;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  */

--- a/lib/Service/Object/SaveObjects/TransformationHandler.php
+++ b/lib/Service/Object/SaveObjects/TransformationHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  *
  * @spec openspec/specs/object-lifecycle/spec.md
@@ -40,7 +40,7 @@ use DateTime;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  */

--- a/lib/Service/Object/UtilityHandler.php
+++ b/lib/Service/Object/UtilityHandler.php
@@ -12,7 +12,7 @@
  * @package   OCA\OpenRegister
  * @author    Conduction <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/ConductionNL/openregister
  */
 
@@ -34,7 +34,7 @@ use OCA\OpenRegister\Db\SchemaMapper;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
  */

--- a/lib/Service/Object/ValidateObject.php
+++ b/lib/Service/Object/ValidateObject.php
@@ -65,7 +65,7 @@ use Psr\Log\LoggerInterface;
  * @category  Service
  * @package   OCA\OpenRegister\Service\Objects
  * @author    Conduction b.v. <info@conduction.nl>
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://github.com/OpenCatalogi/OpenRegister
  * @version   GIT: <git_id>
  * @copyright 2024 Conduction b.v.

--- a/lib/Service/Settings/ConfigurationSettingsHandler.php
+++ b/lib/Service/Settings/ConfigurationSettingsHandler.php
@@ -1387,7 +1387,7 @@ class ConfigurationSettingsHandler
                 'name'        => ($appInfo['name'] ?? null) ?? 'OpenRegister',
                 'description' => ($appInfo['description'] ?? null) ?? '',
                 'author'      => ($appInfo['author'] ?? null) ?? 'Conduction',
-                'licence'     => ($appInfo['licence'] ?? null) ?? 'AGPL',
+                'licence'     => ($appInfo['licence'] ?? null) ?? 'EUPL-1.2',
                 'timestamp'   => time(),
                 'date'        => date('Y-m-d H:i:s'),
             ];

--- a/openapi.json
+++ b/openapi.json
@@ -5,7 +5,7 @@
         "version": "0.0.1",
         "description": "Open Register",
         "license": {
-            "name": "agpl"
+            "name": "EUPL-1.2"
         }
     },
     "components": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Playwright config for Open Register.
  *

--- a/scripts/generate-dependency-graph.php
+++ b/scripts/generate-dependency-graph.php
@@ -11,7 +11,7 @@
  * @category Script
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
- * @license  AGPL-3.0
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 
 // Configuration.

--- a/src/components/object-relations/ContactsTab.vue
+++ b/src/components/object-relations/ContactsTab.vue
@@ -1,6 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2026 Conduction <info@conduction.nl>
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: EUPL-1.2
 -->
 <template>
 	<div class="contacts-tab">

--- a/src/components/object-relations/DeckTab.vue
+++ b/src/components/object-relations/DeckTab.vue
@@ -1,6 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2026 Conduction <info@conduction.nl>
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: EUPL-1.2
 -->
 <template>
 	<div class="deck-tab">

--- a/src/components/object-relations/EmailsTab.vue
+++ b/src/components/object-relations/EmailsTab.vue
@@ -1,6 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2026 Conduction <info@conduction.nl>
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: EUPL-1.2
 -->
 <template>
 	<div class="emails-tab">

--- a/src/components/object-relations/EventsTab.vue
+++ b/src/components/object-relations/EventsTab.vue
@@ -1,6 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2026 Conduction <info@conduction.nl>
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: EUPL-1.2
 -->
 <template>
 	<div class="events-tab">

--- a/src/components/object-relations/RelationsTab.vue
+++ b/src/components/object-relations/RelationsTab.vue
@@ -1,6 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2026 Conduction <info@conduction.nl>
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: EUPL-1.2
 -->
 <template>
 	<div class="relations-tab">

--- a/src/modals/object/MassValidateObjects.vue
+++ b/src/modals/object/MassValidateObjects.vue
@@ -3,7 +3,7 @@
  * @module Modals/Object
  * @author Your Name
  * @copyright 2024 Your Organization
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version 1.0.0
  */
 

--- a/src/modals/webhook/ViewWebhookLog.vue
+++ b/src/modals/webhook/ViewWebhookLog.vue
@@ -144,7 +144,7 @@ import Refresh from 'vue-material-design-icons/Refresh.vue'
  * @module Modals/Webhook
  * @author Conduction
  * @copyright 2024 Conduction
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version 1.0.0
  */
 export default {

--- a/src/store/modules/object-relations/contacts.js
+++ b/src/store/modules/object-relations/contacts.js
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: 2026 Conduction <info@conduction.nl>
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  */
 
 import { defineStore } from 'pinia'

--- a/src/store/modules/object-relations/deck.js
+++ b/src/store/modules/object-relations/deck.js
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: 2026 Conduction <info@conduction.nl>
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  */
 
 import { defineStore } from 'pinia'

--- a/src/store/modules/object-relations/emails.js
+++ b/src/store/modules/object-relations/emails.js
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: 2026 Conduction <info@conduction.nl>
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  */
 
 import { defineStore } from 'pinia'

--- a/src/store/modules/object-relations/events.js
+++ b/src/store/modules/object-relations/events.js
@@ -1,6 +1,6 @@
 /**
  * SPDX-FileCopyrightText: 2026 Conduction <info@conduction.nl>
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  */
 
 import { defineStore } from 'pinia'

--- a/src/store/modules/views.js
+++ b/src/store/modules/views.js
@@ -11,7 +11,7 @@ import { defineStore } from 'pinia'
  * @package
  * @author Conduction Development Team
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version 1.0.0
  */
 export const useViewsStore = defineStore('views', {

--- a/tests/Unit/AppInfo/AttributeMcpDiscoveryTest.php
+++ b/tests/Unit/AppInfo/AttributeMcpDiscoveryTest.php
@@ -31,7 +31,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\AppInfo
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  *
  * @spec openspec/changes/or-mcp-tool-attribute/specs/ai-mcp/spec.md

--- a/tests/Unit/AppInfo/PerAppMcpProbeCacheTest.php
+++ b/tests/Unit/AppInfo/PerAppMcpProbeCacheTest.php
@@ -25,7 +25,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\AppInfo
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  *
  * @spec openspec/specs/chat-ai/spec.md#requirement-mcptoolsservice-provider-discovery-refactor

--- a/tests/Unit/BackgroundJob/FileTextExtractionJobTest.php
+++ b/tests/Unit/BackgroundJob/FileTextExtractionJobTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\BackgroundJob
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  */
 
 namespace OCA\OpenRegister\Tests\Unit\BackgroundJob;

--- a/tests/Unit/Controller/SettingsControllerTest.php
+++ b/tests/Unit/Controller/SettingsControllerTest.php
@@ -32,7 +32,7 @@ use Psr\Log\LoggerInterface;
  * @package OCA\OpenRegister\Tests\Unit\Controller
  * @category Testing
  * @author  OpenRegister Development Team
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version 1.0.0
  * @link    https://github.com/ConductionNL/openregister
  */

--- a/tests/Unit/Controller/SettingsControllerTest.php
+++ b/tests/Unit/Controller/SettingsControllerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  */
 
 namespace OCA\OpenRegister\Tests\Unit\Controller;

--- a/tests/Unit/Mcp/Attribute/McpToolTest.php
+++ b/tests/Unit/Mcp/Attribute/McpToolTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Mcp\Attribute
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  *
  * @spec openspec/specs/ai-mcp/spec.md

--- a/tests/Unit/Mcp/AttributeToolDualSurfaceTest.php
+++ b/tests/Unit/Mcp/AttributeToolDualSurfaceTest.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Mcp
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  *
  * @spec openspec/changes/or-mcp-tool-attribute/specs/ai-mcp/spec.md

--- a/tests/Unit/Mcp/AttributeToolScannerTest.php
+++ b/tests/Unit/Mcp/AttributeToolScannerTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Mcp
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  *
  * @spec openspec/specs/ai-mcp/spec.md

--- a/tests/Unit/Mcp/BuiltIn/AttributeToolProviderTest.php
+++ b/tests/Unit/Mcp/BuiltIn/AttributeToolProviderTest.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Mcp\BuiltIn
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  *
  * @spec openspec/specs/ai-mcp/spec.md

--- a/tests/Unit/Mcp/BuiltIn/ObjectsToolProviderTest.php
+++ b/tests/Unit/Mcp/BuiltIn/ObjectsToolProviderTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Mcp\BuiltIn
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Mcp/BuiltIn/RegistersToolProviderTest.php
+++ b/tests/Unit/Mcp/BuiltIn/RegistersToolProviderTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Mcp\BuiltIn
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Mcp/BuiltIn/SchemaDerivedToolProviderTest.php
+++ b/tests/Unit/Mcp/BuiltIn/SchemaDerivedToolProviderTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Mcp\BuiltIn
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  *
  * @spec openspec/changes/or-mcp-derived-tool-provider/specs/ai-mcp/spec.md

--- a/tests/Unit/Mcp/BuiltIn/SchemasToolProviderTest.php
+++ b/tests/Unit/Mcp/BuiltIn/SchemasToolProviderTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Mcp\BuiltIn
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Mcp/SchemaDerivedDualSurfaceTest.php
+++ b/tests/Unit/Mcp/SchemaDerivedDualSurfaceTest.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Mcp
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  *
  * @spec openspec/changes/or-mcp-derived-tool-provider/specs/ai-mcp/spec.md

--- a/tests/Unit/Service/Configuration/CacheHandlerTest.php
+++ b/tests/Unit/Service/Configuration/CacheHandlerTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Configuration
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/Configuration/ExportHandlerTest.php
+++ b/tests/Unit/Service/Configuration/ExportHandlerTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Configuration
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/Configuration/FetchHandlerTest.php
+++ b/tests/Unit/Service/Configuration/FetchHandlerTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Configuration
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/Configuration/GitHubHandlerTest.php
+++ b/tests/Unit/Service/Configuration/GitHubHandlerTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Configuration
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/Configuration/PreviewHandlerTest.php
+++ b/tests/Unit/Service/Configuration/PreviewHandlerTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Configuration
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/Configuration/UploadHandlerTest.php
+++ b/tests/Unit/Service/Configuration/UploadHandlerTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Configuration
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/File/DeleteFileHandlerTest.php
+++ b/tests/Unit/Service/File/DeleteFileHandlerTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\File
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/File/FileOwnershipHandlerTest.php
+++ b/tests/Unit/Service/File/FileOwnershipHandlerTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\File
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/File/FilePublishingHandlerTest.php
+++ b/tests/Unit/Service/File/FilePublishingHandlerTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\File
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/File/FileServiceGetFilesForEntityTest.php
+++ b/tests/Unit/Service/File/FileServiceGetFilesForEntityTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\File
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/File/FileValidationHandlerTest.php
+++ b/tests/Unit/Service/File/FileValidationHandlerTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\File
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/File/FolderManagementHandlerTest.php
+++ b/tests/Unit/Service/File/FolderManagementHandlerTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\File
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/File/UpdateFileHandlerTest.php
+++ b/tests/Unit/Service/File/UpdateFileHandlerTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\File
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/ImportServiceTest.php
+++ b/tests/Unit/Service/ImportServiceTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/Mcp/McpProtocolServiceTest.php
+++ b/tests/Unit/Service/Mcp/McpProtocolServiceTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Mcp
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/Mcp/McpResourcesServiceTest.php
+++ b/tests/Unit/Service/Mcp/McpResourcesServiceTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Mcp
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/Mcp/McpToolsServiceTest.php
+++ b/tests/Unit/Service/Mcp/McpToolsServiceTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Mcp
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/Object/CacheHandlerCoverageTest.php
+++ b/tests/Unit/Service/Object/CacheHandlerCoverageTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Object
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/Object/CacheHandlerTest.php
+++ b/tests/Unit/Service/Object/CacheHandlerTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Object
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  *
  * @SuppressWarnings(PHPMD.TooManyPublicMethods)     Comprehensive test coverage requires many test methods

--- a/tests/Unit/Service/Object/DeleteObjectTest.php
+++ b/tests/Unit/Service/Object/DeleteObjectTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Object
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)

--- a/tests/Unit/Service/Object/MetadataHandlerTest.php
+++ b/tests/Unit/Service/Object/MetadataHandlerTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Object
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/Object/ReferentialIntegrityServiceTest.php
+++ b/tests/Unit/Service/Object/ReferentialIntegrityServiceTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Object
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)

--- a/tests/Unit/Service/Object/RenderObjectCoverageTest.php
+++ b/tests/Unit/Service/Object/RenderObjectCoverageTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Object
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  *
  * @SuppressWarnings(PHPMD.TooManyPublicMethods)

--- a/tests/Unit/Service/Object/RenderObjectDeepTest.php
+++ b/tests/Unit/Service/Object/RenderObjectDeepTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Object
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  *
  * @SuppressWarnings(PHPMD.TooManyPublicMethods)

--- a/tests/Unit/Service/Object/RenderObjectTest.php
+++ b/tests/Unit/Service/Object/RenderObjectTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Object
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/Object/SaveObject/FilePropertyHandlerTest.php
+++ b/tests/Unit/Service/Object/SaveObject/FilePropertyHandlerTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Object\SaveObject
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  *
  * @SuppressWarnings(PHPMD.TooManyPublicMethods)

--- a/tests/Unit/Service/Object/SaveObjectCircularReferenceTest.php
+++ b/tests/Unit/Service/Object/SaveObjectCircularReferenceTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Object
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/Object/SaveObjectDeepTest.php
+++ b/tests/Unit/Service/Object/SaveObjectDeepTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Object
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  *
  * @SuppressWarnings(PHPMD.TooManyPublicMethods)

--- a/tests/Unit/Service/Object/SaveObjectReferenceValidationTest.php
+++ b/tests/Unit/Service/Object/SaveObjectReferenceValidationTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Object
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/Object/SaveObjectTest.php
+++ b/tests/Unit/Service/Object/SaveObjectTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Object
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/Object/SaveObjectWriteOnlyPreserveTest.php
+++ b/tests/Unit/Service/Object/SaveObjectWriteOnlyPreserveTest.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  *
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Object
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/Object/SaveObjectsTest.php
+++ b/tests/Unit/Service/Object/SaveObjectsTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Object
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/Object/ValidateObjectArrayRefTest.php
+++ b/tests/Unit/Service/Object/ValidateObjectArrayRefTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Object
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/Object/ValidateObjectCoverageTest.php
+++ b/tests/Unit/Service/Object/ValidateObjectCoverageTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Object
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/Object/ValidateObjectTest.php
+++ b/tests/Unit/Service/Object/ValidateObjectTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Object
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/PropertyRbacHandlerWriteOnlyPreserveTest.php
+++ b/tests/Unit/Service/PropertyRbacHandlerWriteOnlyPreserveTest.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  *
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/SchemaServiceCoverageTest.php
+++ b/tests/Unit/Service/SchemaServiceCoverageTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/Schemas/PropertyValidatorHandlerTest.php
+++ b/tests/Unit/Service/Schemas/PropertyValidatorHandlerTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Schemas
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/Settings/CacheSettingsHandlerTest.php
+++ b/tests/Unit/Service/Settings/CacheSettingsHandlerTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Settings
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  *
  * NOTE: getCachedObjectStats() uses `static` local variables with 30s TTL.

--- a/tests/Unit/Service/Settings/ConfigurationSettingsHandlerTest.php
+++ b/tests/Unit/Service/Settings/ConfigurationSettingsHandlerTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Settings
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/Settings/FileSettingsHandlerTest.php
+++ b/tests/Unit/Service/Settings/FileSettingsHandlerTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Settings
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/Settings/LlmSettingsHandlerTest.php
+++ b/tests/Unit/Service/Settings/LlmSettingsHandlerTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Settings
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/Settings/ObjectRetentionHandlerTest.php
+++ b/tests/Unit/Service/Settings/ObjectRetentionHandlerTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Settings
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/Settings/SearchBackendHandlerTest.php
+++ b/tests/Unit/Service/Settings/SearchBackendHandlerTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Settings
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/Settings/ValidationOperationsHandlerTest.php
+++ b/tests/Unit/Service/Settings/ValidationOperationsHandlerTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Settings
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/SettingsServiceTest.php
+++ b/tests/Unit/Service/SettingsServiceTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/TextExtraction/EntityRecognitionHandlerTest.php
+++ b/tests/Unit/Service/TextExtraction/EntityRecognitionHandlerTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\TextExtraction
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/Unit/Service/Webhook/CloudEventFormatterTest.php
+++ b/tests/Unit/Service/Webhook/CloudEventFormatterTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service\Webhook
  * @author   OpenRegister Team
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @link     https://github.com/OpenRegister/OpenRegister
  */
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,6 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2026 Open Register Contributors
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: EUPL-1.2
 -->
 
 # OpenRegister end-to-end (Playwright) specs

--- a/tests/e2e/_fixtures.ts
+++ b/tests/e2e/_fixtures.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Seeded-fixture helper for the deep, data-dependent e2e layer.
  *

--- a/tests/e2e/api-direct/README.md
+++ b/tests/e2e/api-direct/README.md
@@ -1,6 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2026 Open Register Contributors
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: EUPL-1.2
 -->
 
 # API-direct specs (excluded from the UI regression project)

--- a/tests/e2e/api-direct/advanced-features.spec.ts
+++ b/tests/e2e/api-direct/advanced-features.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Advanced features e2e tests — covers:
  *   - referential-integrity (related objects via object properties)

--- a/tests/e2e/api-direct/audit-content-versioning.spec.ts
+++ b/tests/e2e/api-direct/audit-content-versioning.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Audit trail and content versioning e2e tests — covers:
  *   - audit-trail-immutable (every mutation creates an audit entry)

--- a/tests/e2e/api-direct/chat-agents.spec.ts
+++ b/tests/e2e/api-direct/chat-agents.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Chat and Agents e2e tests — covers:
  *   - chat-ai (chat API surface: create conversation, send message)

--- a/tests/e2e/api-direct/configurations-endpoints.spec.ts
+++ b/tests/e2e/api-direct/configurations-endpoints.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Configurations and Endpoints e2e tests — covers:
  *   - (implicit: configurations) configuration sets CRUD

--- a/tests/e2e/api-direct/core-crud-lifecycle.spec.ts
+++ b/tests/e2e/api-direct/core-crud-lifecycle.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * object-lifecycle — REST CRUD pipeline (API-direct).
  *

--- a/tests/e2e/api-direct/entities-sources.spec.ts
+++ b/tests/e2e/api-direct/entities-sources.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Entities, Sources, and linked-entity types e2e tests — covers:
  *   - linked-entity-types (entities CRUD REST surface)

--- a/tests/e2e/api-direct/files-templates.spec.ts
+++ b/tests/e2e/api-direct/files-templates.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Files and Templates e2e tests — covers:
  *   - file-actions (file upload, download, list API surface)

--- a/tests/e2e/api-direct/graphql-mcp.spec.ts
+++ b/tests/e2e/api-direct/graphql-mcp.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * GraphQL API and MCP discovery e2e tests — covers:
  *   - graphql-api (auto-generated schema, introspection, basic query)

--- a/tests/e2e/api-direct/platform-admin.spec.ts
+++ b/tests/e2e/api-direct/platform-admin.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Platform administration e2e tests — covers:
  *   - platform-administration-modals (settings API surface)

--- a/tests/e2e/api-direct/registers-schemas.spec.ts
+++ b/tests/e2e/api-direct/registers-schemas.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Registers and Schemas e2e tests — covers:
  *   - (implicit spec: registers management REST surface)

--- a/tests/e2e/api-direct/reporting-avg.spec.ts
+++ b/tests/e2e/api-direct/reporting-avg.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Reporting, AVG, and specialized specs e2e tests — covers:
  *   - rapportage-bi-export (reports/BI export API surface)

--- a/tests/e2e/api-direct/search-views-presentation.spec.ts
+++ b/tests/e2e/api-direct/search-views-presentation.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Kanban + calendar view-presentation e2e tests — REST contract for the
  * "Tables that scale" feature (kanban/calendar object views shipped in

--- a/tests/e2e/api-direct/search-views.spec.ts
+++ b/tests/e2e/api-direct/search-views.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Search and Views e2e tests — covers:
  *   - zoeken-filteren (full-text search, faceted filtering, _search param)

--- a/tests/e2e/api-direct/security-rbac.spec.ts
+++ b/tests/e2e/api-direct/security-rbac.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Security and RBAC e2e tests — covers:
  *   - auth-system (Basic auth, session auth, unauthenticated rejection)

--- a/tests/e2e/base-url.ts
+++ b/tests/e2e/base-url.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Single source of truth for the Nextcloud base URL the e2e suite targets.
  *

--- a/tests/e2e/ci/object-shares-tab.spec.ts
+++ b/tests/e2e/ci/object-shares-tab.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * THE SHARES TAB — driven through the browser, group 10.1 / 10.2.
  *

--- a/tests/e2e/ci/object-sharing.spec.ts
+++ b/tests/e2e/ci/object-sharing.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * OBJECT SHARING — end to end, through the HTTP API a real client uses.
  *

--- a/tests/e2e/ci/playwright.config.ts
+++ b/tests/e2e/ci/playwright.config.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * CI PLAYWRIGHT CONFIG — a deliberately small, always-green spec set.
  *

--- a/tests/e2e/ci/smoke-boot.spec.ts
+++ b/tests/e2e/ci/smoke-boot.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * BOOT SMOKE GATE — two routes, asserting the Vue app actually MOUNTED.
  *

--- a/tests/e2e/core-crud.spec.ts
+++ b/tests/e2e/core-crud.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Core CRUD e2e tests — covers:
  *   - object-lifecycle (REQ-001..004)

--- a/tests/e2e/crud/object-crud.spec.ts
+++ b/tests/e2e/crud/object-crud.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Deep, data-dependent CRUD journey for OBJECTS — the highest-leverage case.
  *

--- a/tests/e2e/crud/register-crud.spec.ts
+++ b/tests/e2e/crud/register-crud.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Deep, data-dependent CRUD journey for REGISTERS — through the real UI.
  *

--- a/tests/e2e/crud/schema-crud.spec.ts
+++ b/tests/e2e/crud/schema-crud.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Deep, data-dependent CRUD journey for SCHEMAS.
  *

--- a/tests/e2e/docs-screenshots.spec.ts
+++ b/tests/e2e/docs-screenshots.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Documentation screenshot capture suite — openregister.
  *

--- a/tests/e2e/flow-engine.spec.ts
+++ b/tests/e2e/flow-engine.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Flow engine e2e — the one native flow store, end to end.
  *

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Playwright globalSetup — logs into Nextcloud once and persists the
  * resulting cookie jar / localStorage to `tests/e2e/.auth/admin.json`.

--- a/tests/e2e/integration-mount.spec.ts
+++ b/tests/e2e/integration-mount.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Integration mount-check fixture — Phase K / K3 regression guard for
  * the Phase-A "bespoke UI is dead code" wiring bug (ADR-019).

--- a/tests/e2e/manifest-shell.spec.ts
+++ b/tests/e2e/manifest-shell.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Manifest-driven shell e2e tests (browser-based).
  *

--- a/tests/e2e/mdm-seed.ts
+++ b/tests/e2e/mdm-seed.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Self-seeding MDM fixture for the deep, data-dependent e2e layer
  * (mdm-frontend / mdm-merge-ui / mdm-survivorship-override).

--- a/tests/e2e/smoke-boot.spec.ts
+++ b/tests/e2e/smoke-boot.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * BOOT SMOKE GATE — two routes, asserting the Vue app actually MOUNTED.
  *

--- a/tests/e2e/spec-coverage/admin-settings-pages.spec.ts
+++ b/tests/e2e/spec-coverage/admin-settings-pages.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * GENUINE behavioural UI e2e for OpenRegister's ADMIN / SETTINGS-section
  * pages (the lower nav group): Organisations, Configurations, Webhooks,

--- a/tests/e2e/spec-coverage/core-list-pages.spec.ts
+++ b/tests/e2e/spec-coverage/core-list-pages.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * GENUINE behavioural UI e2e for OpenRegister's CORE LIST pages — every
  * "Index" view reachable from the main nav. Goes deeper than shell-render:

--- a/tests/e2e/spec-coverage/data-import-export.spec.ts
+++ b/tests/e2e/spec-coverage/data-import-export.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Spec-coverage e2e tests for:  data-import-export
  *

--- a/tests/e2e/spec-coverage/entity-management-modals.spec.ts
+++ b/tests/e2e/spec-coverage/entity-management-modals.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * UI-only Playwright e2e tests for spec `entity-management-modals`.
  *

--- a/tests/e2e/spec-coverage/feature-pages.spec.ts
+++ b/tests/e2e/spec-coverage/feature-pages.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * GENUINE behavioural UI e2e for OpenRegister's FEATURE pages that aren't
  * plain entity lists: Files, AVG / Verwerkingsregister, Reports,

--- a/tests/e2e/spec-coverage/files-sidebar-tabs.spec.ts
+++ b/tests/e2e/spec-coverage/files-sidebar-tabs.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * UI-only Playwright e2e tests for spec `files-sidebar-tabs`.
  *

--- a/tests/e2e/spec-coverage/mdm-frontend.spec.ts
+++ b/tests/e2e/spec-coverage/mdm-frontend.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Spec-coverage e2e tests for: mdm-frontend (ADR-045 #3).
  *

--- a/tests/e2e/spec-coverage/mdm-merge-ui.spec.ts
+++ b/tests/e2e/spec-coverage/mdm-merge-ui.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Spec-coverage e2e tests for: mdm-merge-ui (ADR-045 follow-on #C).
  *

--- a/tests/e2e/spec-coverage/mdm-survivorship-override.spec.ts
+++ b/tests/e2e/spec-coverage/mdm-survivorship-override.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Spec-coverage e2e tests for: mdm-survivorship-override (ADR-045 follow-on #E).
  *

--- a/tests/e2e/spec-coverage/object-views-kanban-calendar.spec.ts
+++ b/tests/e2e/spec-coverage/object-views-kanban-calendar.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * GENUINE behavioural UI e2e for the kanban + calendar object-view
  * presentations ("Tables that scale", PRs #2063/#2098). Seeds a register + a

--- a/tests/e2e/spec-coverage/platform-administration-modals.spec.ts
+++ b/tests/e2e/spec-coverage/platform-administration-modals.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Spec-coverage e2e tests for:  platform-administration-modals
  *

--- a/tests/e2e/spec-coverage/register-i18n.spec.ts
+++ b/tests/e2e/spec-coverage/register-i18n.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Spec-coverage e2e tests for:  register-i18n
  *

--- a/tests/e2e/spec-coverage/saved-search-views.spec.ts
+++ b/tests/e2e/spec-coverage/saved-search-views.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * UI-only Playwright e2e tests for spec `saved-search-views`.
  *

--- a/tests/e2e/ui-navigation.spec.ts
+++ b/tests/e2e/ui-navigation.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * UI navigation and view e2e tests (browser-based) — covers:
  *   - frontend-app-bootstrap (full navigation, multiple routes)

--- a/tests/e2e/visual/_visual-helpers.ts
+++ b/tests/e2e/visual/_visual-helpers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Shared helpers for the visual-regression layer (GAP-5).
  *

--- a/tests/e2e/visual/dsar-cases.visual.spec.ts
+++ b/tests/e2e/visual/dsar-cases.visual.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Visual-regression baseline for the DSAR case-management surface
  * (dsar-case-ui) — the Cases tab + list added to the AVG view.

--- a/tests/e2e/visual/mdm-frontend.visual.spec.ts
+++ b/tests/e2e/visual/mdm-frontend.visual.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Visual-regression baselines for the mdm-frontend change (ADR-045 #3,
  * hydra gate-26). Each of the four new "Data quality" views —

--- a/tests/e2e/visual/mdm-merge-ui.visual.spec.ts
+++ b/tests/e2e/visual/mdm-merge-ui.visual.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Visual-regression baselines for the mdm-merge-ui change (ADR-045 follow-on
  * #C, hydra gate-26). Covers the two new surfaces:

--- a/tests/e2e/visual/mdm-survivorship-override.visual.spec.ts
+++ b/tests/e2e/visual/mdm-survivorship-override.visual.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Visual-regression baseline for the mdm-survivorship-override change
  * (ADR-045 follow-on #E, hydra gate-26). Covers the one new surface:

--- a/tests/e2e/visual/openregister.visual.spec.ts
+++ b/tests/e2e/visual/openregister.visual.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Visual-regression baselines for Open Register's key surfaces (GAP-5).
  *

--- a/tests/e2e/workflows/dsar-cases.spec.ts
+++ b/tests/e2e/workflows/dsar-cases.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * DSAR case-management surface (dsar-case-ui) — behavioural e2e for the
  * Cases tab added to the AVG view (src/views/avg/AvgIndex.vue): the case

--- a/tests/e2e/workflows/object-lifecycle-workflows.spec.ts
+++ b/tests/e2e/workflows/object-lifecycle-workflows.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Open Register Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Core object-lifecycle WORKFLOWS — deep, data-dependent:
  *


### PR DESCRIPTION
## What

OpenRegister declares **EUPL-1.2** in `composer.json`, `package.json`, `appinfo/info.xml` and `LICENSE` — but 175 files still carried AGPL-3.0 licence tags. This aligns every file-level licence declaration with the licence the project actually ships under.

This clears hydra **gate-28 (license-triangle)**, which failed with **25 files** under `lib/`.

## Changes — licence identifier only

| Category | Tags |
|---|---:|
| `@license AGPL-3.0-or-later <agpl-url>` → `EUPL-1.2 <eupl-url>` | 88 |
| `@license  AGPL-3.0-or-later` (no URL) → `EUPL-1.2` | 61 |
| `@license  AGPL-3.0` / URL-first shape → `EUPL-1.2 <eupl-url>` | 3 |
| `SPDX-License-Identifier: AGPL-3.0-or-later` → `EUPL-1.2` | 64 |
| stale AGPL URL appended after an already-correct `EUPL-1.2` id, removed | 12 |

**175 files changed, 204 insertions(+), 204 deletions(-).**

**No `@copyright`, `@author` or `SPDX-FileCopyrightText` line was touched.**

### One non-header change
`lib/Service/Settings/ConfigurationSettingsHandler.php` reported OpenRegister's *own* licence as `'AGPL'` when `info.xml` lacked one. Fallback is now `'EUPL-1.2'`. No test asserts this value.

### 29 files carried TWO `@license` tags
gate-28 only reads the **first** `@license` tag in a file, so a stale second tag can survive a green gate. Every occurrence was replaced, not just the blocking one.

## Deliberately NOT changed — needs an explicit decision

**12 files** whose `SPDX-License-Identifier: AGPL-3.0-or-later` is directly paired with `SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors`:

`lib/Db/Webhook.php`, `lib/Migration/Version002003000Date20251013000000.php`, `lib/Migration/Version1Date2024{0924200009,1019205009,1020231700,1022135300,1030131427,1128221000,1216094112,1227153853}.php`, `lib/Migration/Version1Date20250115230511.php`, `tests/Unit/Controller/SettingsControllerTest.php`

These are almost certainly `occ migration:generate` scaffolding residue — the content is 100% OpenRegister-specific (`oc_openregister_*` tables), one file still carries the generator's *"FIXME Auto-generated migration step"* comment, and in 10 of the 12 the block sits **below** a Conduction-authored `EUPL-1.2` file header. But an SPDX pair is a single legal statement about a **named third-party holder**, so relicensing it mechanically is not a call this PR should make. **None of them affect gate-28** (which reads `@license`, not SPDX). Their Conduction-attributed `@license` tags *were* normalised.

**Third-party, untouched:** `phpmetrics-deps/` (39 tracked files — includes a **GPLv3** asset, `clusterize.min.js`, sitting inside an EUPL-1.2 repo) and `composer-setup.php`. Neither carries an `@license` tag, so gate-28 is blind to them. Note `phpmetrics-deps/` is generated report output already listed in `.gitignore` line 30 — cleaning it up is a separate change.

## Verification

**gate-28:** `FAIL — 25 file(s)` → **`PASS`** (0 findings).
The gate was run against an **isolated** log path: hydra-gates hardcodes `/tmp/hydra-gate-license-triangle.log`, which is shared, and a concurrent run on another repo made it briefly report 39 files here. Same harness code, private log.

**PHP unit suite**, identically conditioned before and after (PHP 8.3.32, `nextcloud:32-apache`, `composer install` in this worktree):

```
BEFORE: Tests: 16030, Assertions: 35963  — 0 failures, 0 errors
AFTER:  Tests: 16030, Assertions: 35963  — 0 failures, 0 errors
```

Identical. (Exit 1 in both runs comes solely from the "No code coverage driver available" runner warning, present before and after.)

**Diff audit:** every changed line in the whole diff is an `@license` or `SPDX-License-Identifier` line, with the single documented exception of the fallback above.
