### PR TITLE
fix(flows): render the flow controls, which were declared but unreachable

### DIFF
--- a/src/sidebars/SideBars.vue
+++ b/src/sidebars/SideBars.vue
@@ -7,6 +7,20 @@
 	<EntitiesSideBar v-else-if="$route.path.startsWith('/entities')" />
 	<AuditTrailSideBar v-else-if="$route.path.startsWith('/audit-trails')" />
 	<SearchTrailSideBar v-else-if="$route.path.startsWith('/search-trails')" />
+	<!--
+		The flow canvas's controls — step palette, Save, Run, run history.
+
+		These are declared on the manifest page as `sidebarComponent:
+		FlowDetailSidebar`, and CnAppRoot does resolve that key. It could never
+		render here, though: CnAppRoot only falls back to it as the DEFAULT
+		content of its #sidebar slot, and this app fills that slot itself, so
+		consumer content wins by Vue's ordinary slot mechanic. The manifest key
+		was live config that rendered nothing.
+
+		The symptom was a flow page with no way to save, run, or add a step —
+		while its own empty state said "Add a step from the sidebar".
+	-->
+	<FlowDetailSidebar v-else-if="/^\/flows\/.+/.test($route.path)" />
 </template>
 
 <script>
@@ -18,6 +32,7 @@ import DeletedSideBar from './deleted/DeletedSideBar.vue'
 import EntitiesSideBar from './entities/EntitiesSideBar.vue'
 import AuditTrailSideBar from './logs/AuditTrailSideBar.vue'
 import SearchTrailSideBar from './logs/SearchTrailSideBar.vue'
+import FlowDetailSidebar from '../views/flows/FlowDetailSidebar.vue'
 
 export default {
 	name: 'SideBars',
@@ -30,6 +45,7 @@ export default {
 		EntitiesSideBar,
 		AuditTrailSideBar,
 		SearchTrailSideBar,
+		FlowDetailSidebar,
 	},
 }
 </script>


### PR DESCRIPTION
## The symptom

The flow page offered no way to **save, run, enable, add a step, or see run history** — while its own empty state read *"Add a step from the sidebar."*

## Why

Nothing was missing. It was all built and wired:

- `CnFlowSidebar` implements the panel — step palette, Name/Description/Trigger, Enabled, Save, Run now, Recent runs
- `FlowDetailSidebar` wires `save`/`run` to `useFlowStore`
- it is registered in `registry.js`
- the manifest declares `sidebarComponent: FlowDetailSidebar` on the `flowDetail` page, and `CnAppRoot` **does** resolve that key

It could still never render. `CnAppRoot` falls back to the manifest's `sidebarComponent` only as the **default content** of its `#sidebar` slot, and this app fills that slot itself with `SideBars` — so consumer content wins by Vue's ordinary slot mechanic. `CnAppRoot`'s own docblock says so, and records that `pages[].sidebarComponent` "was dead config for every app that tried it (#528)".

`SideBars` had no branch for `/flows`, so on a flow route it rendered nothing — and the manifest key was live config with no effect.

## The fix

One branch in `SideBars.vue`.

## Verified in the browser

Against a rebuilt bundle (in a clean session — the first attempt was reading a cached pre-build `main.js`):

- sidebar renders **Steps**, **Flow** (Name, Description, Trigger, restrict to register/schema, **Enabled**), **Recent runs**, **Save**, **Run now**
- built a flow from the palette and saved it — the route advanced `/flows/new` → returned uuid, so it persisted server-side
- **Run now** created a run; `FlowRunWorker` executed it and the history moved to `completed`, matching `oc_openregister_flow_runs`

The backend needed no change: `POST /api/flows/{id}/run`, the CRUD routes, `/api/flow/node-catalog` and `/api/flow-runs` were all already correct.

## Note for whoever builds next

`npm run build` **deletes** `js/openregister-flow-operator.js`, which is force-tracked past the `/js/` ignore rule. Restored here rather than committed.