### PR TITLE
feat(flow)!: a path ends deliberately or says it is broken, and a flow records its last run

### DIFF
--- a/lib/Controller/FlowController.php
+++ b/lib/Controller/FlowController.php
@@ -401,9 +401,44 @@ class FlowController extends Controller
 
         $flow = $this->flows->save(data: $data);
 
-        return new JSONResponse($flow->jsonSerialize(), Http::STATUS_CREATED);
+        return new JSONResponse($this->savedBody(flow: $flow), Http::STATUS_CREATED);
 
     }//end create()
+
+    /**
+     * The stored flow, plus any warning the author should see about it.
+     *
+     * The save SUCCEEDS and then warns. A half-wired graph is the normal state
+     * of one being authored, so refusing to store it would force the author to
+     * build the graph in an order that is never disconnected — which no editor
+     * can require. The refusal happens at RUN time instead, where the cost of a
+     * silent stop is actually paid ({@see FlowDeadEnd}).
+     *
+     * `warnings` is added ALONGSIDE the flow's own fields rather than wrapping
+     * them, so a client that ignores it keeps working unchanged.
+     *
+     * @param Flow $flow The stored flow.
+     *
+     * @return array The response body.
+     *
+     * @spec openspec/specs/flow-engine/spec.md
+     */
+    private function savedBody(Flow $flow): array
+    {
+        $body = $flow->jsonSerialize();
+
+        $report = $this->preflight->inspect(
+            flow: [
+                'nodes' => ($flow->getNodes() ?? []),
+                'edges' => ($flow->getEdges() ?? []),
+            ]
+        );
+
+        $body['warnings'] = $report['warnings'];
+
+        return $body;
+
+    }//end savedBody()
 
     /**
      * Update a flow.
@@ -425,7 +460,7 @@ class FlowController extends Controller
             return new JSONResponse(['error' => 'No such flow'], Http::STATUS_NOT_FOUND);
         }
 
-        return new JSONResponse($flow->jsonSerialize());
+        return new JSONResponse($this->savedBody(flow: $flow));
 
     }//end update()
 

--- a/lib/Controller/FlowController.php
+++ b/lib/Controller/FlowController.php
@@ -388,6 +388,12 @@ class FlowController extends Controller
      *
      * @NoAdminRequired
      *
+     * @no-admin-idor-exempt No caller-supplied id to confuse: a create takes no
+     * uuid. `FlowService::flowToSave()` stamps `owner` from the session and
+     * `organisation` from the active one, and neither is in
+     * `applyEditableFields()`'s allowlist — so a payload cannot claim another
+     * user's identity. The allowlist IS the boundary here.
+     *
      * @spec openspec/changes/flow-engine-unification/specs/flow-storage/spec.md
      */
     #[NoAdminRequired]
@@ -448,6 +454,13 @@ class FlowController extends Controller
      * @return JSONResponse The stored flow, or 404.
      *
      * @NoAdminRequired
+     *
+     * @no-admin-idor-exempt Guarded downstream: `FlowService::flowToSave()`
+     * resolves the uuid through `find()`, so an update to a flow the caller
+     * cannot see is refused with the same "no such flow" as one that does not
+     * exist — the id is never trusted to select the row. `owner` and
+     * `organisation` are outside `applyEditableFields()`'s allowlist, so an
+     * update cannot reassign ownership either.
      *
      * @spec openspec/changes/flow-engine-unification/specs/flow-storage/spec.md
      */

--- a/lib/Db/Flow.php
+++ b/lib/Db/Flow.php
@@ -128,6 +128,20 @@ class Flow extends Entity implements JsonSerializable
     public const TRIGGER_SCHEDULE = 'schedule';
 
     /**
+     * The flow is runnable as far as anything has judged.
+     *
+     * Only ever written when a run is ACCEPTED. It is not a default: a flow
+     * nothing has judged has a null status, because claiming `ok` for an
+     * unexamined flow is the false green this field exists to remove.
+     */
+    public const STATUS_OK = 'ok';
+
+    /**
+     * The flow was refused, and {@see $statusMessage} says why.
+     */
+    public const STATUS_ERROR = 'error';
+
+    /**
      * Public identifier, used everywhere outside the database.
      *
      * @var string|null
@@ -288,6 +302,55 @@ class Flow extends Entity implements JsonSerializable
     protected ?DateTime $updated = null;
 
     /**
+     * The flow's own verdict: `ok`, `error`, or null for no verdict yet.
+     *
+     * Deliberately not defaulted to `ok`. A flow gains a status when something
+     * has judged it; claiming `ok` for a flow nothing has looked at would be
+     * the same false green this field exists to remove.
+     *
+     * @var string|null
+     */
+    protected ?string $status = null;
+
+    /**
+     * Why {@see $status} is what it is, naming the offending nodes.
+     *
+     * @var string|null
+     */
+    protected ?string $statusMessage = null;
+
+    /**
+     * UUID of the most recent run to reach a terminal state.
+     *
+     * @var string|null
+     */
+    protected ?string $lastRunUuid = null;
+
+    /**
+     * That run's terminal status.
+     *
+     * @var string|null
+     */
+    protected ?string $lastRunStatus = null;
+
+    /**
+     * That run's closing message, when it had one.
+     *
+     * @var string|null
+     */
+    protected ?string $lastRunMessage = null;
+
+    /**
+     * When that run reached its terminal state.
+     *
+     * Null means the flow has never run. It never means "ran at an unknown
+     * time" — no backfill invented a value for rows that predate the column.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $lastRunAt = null;
+
+    /**
      * Constructor: declare field types so the mapper hydrates them correctly.
      */
     public function __construct()
@@ -313,6 +376,12 @@ class Flow extends Entity implements JsonSerializable
         $this->addType(fieldName: 'notes', type: 'string');
         $this->addType(fieldName: 'created', type: 'datetime');
         $this->addType(fieldName: 'updated', type: 'datetime');
+        $this->addType(fieldName: 'status', type: 'string');
+        $this->addType(fieldName: 'statusMessage', type: 'string');
+        $this->addType(fieldName: 'lastRunUuid', type: 'string');
+        $this->addType(fieldName: 'lastRunStatus', type: 'string');
+        $this->addType(fieldName: 'lastRunMessage', type: 'string');
+        $this->addType(fieldName: 'lastRunAt', type: 'datetime');
 
     }//end __construct()
 
@@ -465,6 +534,14 @@ class Flow extends Entity implements JsonSerializable
             $updated = $this->updated->format('c');
         }
 
+        // Null stays null rather than becoming an empty string: the API
+        // distinguishes "never run" from "ran and said nothing", and an empty
+        // string would collapse the two for every consumer.
+        $lastRunAt = null;
+        if ($this->lastRunAt !== null) {
+            $lastRunAt = $this->lastRunAt->format('c');
+        }
+
         return [
             'id'               => $this->uuid,
             'uuid'             => $this->uuid,
@@ -488,6 +565,12 @@ class Flow extends Entity implements JsonSerializable
             'notes'            => $this->notes,
             'created'          => $created,
             'updated'          => $updated,
+            'status'           => $this->status,
+            'statusMessage'    => $this->statusMessage,
+            'lastRunUuid'      => $this->lastRunUuid,
+            'lastRunStatus'    => $this->lastRunStatus,
+            'lastRunMessage'   => $this->lastRunMessage,
+            'lastRunAt'        => $lastRunAt,
         ];
 
     }//end jsonSerialize()

--- a/lib/Migration/Version1Date20260805100000.php
+++ b/lib/Migration/Version1Date20260805100000.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * Adds the flow status and last-run columns to `openregister_flows`.
+ *
+ * Two questions could not be answered without reading run history, and one of
+ * them could not be answered at all:
+ *
+ * 1. "Why did this flow not run?" A flow refused for a dead end produced NO
+ *    `FlowRun` — there was nothing to read. A refused flow and a flow nobody
+ *    had triggered were indistinguishable, which is the worst possible state
+ *    for the one case where the author needs to be told something is wrong.
+ * 2. "When did this last run, and how did it go?" Answerable only by querying
+ *    the run table per flow, which the list view cannot do for every row.
+ *
+ * `status`/`status_message` answer the first, `last_run_*` the second.
+ *
+ * All six are nullable with no default and NO backfill. NULL on `last_run_*`
+ * means "has never run", which is true of every existing row at the moment
+ * this migration runs — inventing a value from the newest FlowRun would be
+ * asserting a history this column did not record. NULL on `status` means "no
+ * verdict", not "ok": a flow only gains a status when something has judged it.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/flow-engine/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Adds `status`, `status_message` and the four `last_run_*` columns.
+ *
+ * @spec openspec/specs/flow-engine/spec.md
+ */
+class Version1Date20260805100000 extends SimpleMigrationStep
+{
+    /**
+     * Add the six nullable columns.
+     *
+     * @param IOutput $output        Migration output.
+     * @param Closure $schemaClosure Schema closure returning an ISchemaWrapper.
+     * @param array   $options       Migration options.
+     *
+     * @return ISchemaWrapper|null The modified schema, or null when unchanged.
+     *
+     * @spec openspec/specs/flow-engine/spec.md
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
+    {
+        /*
+         * @var ISchemaWrapper $schema
+         */
+
+        $schema = $schemaClosure();
+
+        if ($schema->hasTable('openregister_flows') === false) {
+            $output->info('openregister_flows does not exist yet; nothing to alter.');
+            return null;
+        }
+
+        $table   = $schema->getTable('openregister_flows');
+        $changed = false;
+
+        // Short strings, not enums: the vocabulary is `ok`/`error` today, and a
+        // database-level enum would need a migration to add a third value.
+        $strings = [
+            'status'           => 32,
+            'status_message'   => 1024,
+            'last_run_uuid'    => 64,
+            'last_run_status'  => 32,
+            'last_run_message' => 1024,
+        ];
+
+        foreach ($strings as $column => $length) {
+            if ($table->hasColumn($column) === true) {
+                continue;
+            }
+
+            $table->addColumn(
+                $column,
+                Types::STRING,
+                [
+                    'notnull' => false,
+                    'default' => null,
+                    'length'  => $length,
+                ]
+            );
+            $changed = true;
+        }//end foreach
+
+        if ($table->hasColumn('last_run_at') === false) {
+            $table->addColumn(
+                'last_run_at',
+                Types::DATETIME,
+                [
+                    'notnull' => false,
+                    'default' => null,
+                ]
+            );
+            $changed = true;
+        }
+
+        if ($changed === true) {
+            $output->info('Added flow status and last-run columns to openregister_flows.');
+        }
+
+        if ($changed === false) {
+            return null;
+        }
+
+        return $schema;
+
+    }//end changeSchema()
+}//end class

--- a/lib/Service/Flow/FlowConnectivity.php
+++ b/lib/Service/Flow/FlowConnectivity.php
@@ -1,0 +1,193 @@
+<?php
+
+/**
+ * Finds the nodes a run would arrive at and never leave.
+ *
+ * WHY THIS IS ITS OWN CLASS
+ * -------------------------
+ * It answers a question about the SHAPE of the graph — which nodes have an exit
+ * — while the rest of `FlowNodePreflight` answers questions about each node's
+ * TYPE and CONFIG. Those are different subjects over the same document, and
+ * keeping them apart is what stops the preflight growing into the place every
+ * flow check eventually lands.
+ *
+ * WHAT IT IS LOOKING FOR
+ * ----------------------
+ * After `or-flow-action-nodes` a node with no outgoing edge is a dead end: its
+ * token arrives, the step runs, the engine finds no enabled transition, and the
+ * run stops there — recorded COMPLETED, because from the engine's point of view
+ * nothing failed. The author sees a green run that did not do the work.
+ *
+ * A node escapes that three ways, and only the first two are "ending on
+ * purpose" ({@see IFlowTerminalNode}), OR-ed and never AND-ed:
+ *
+ *   - the node says `exit: true`
+ *   - its TYPE is registered terminal
+ *   - it has no type at all — deliberately NOT reported here, because
+ *     `FlowDefinitionBuilder` already refuses such a document by name. Two
+ *     findings on one node for one defect is how a warning list becomes noise.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/flow-engine/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+/**
+ * The graph-shape half of the flow preflight.
+ *
+ * @spec openspec/specs/flow-engine/spec.md
+ */
+class FlowConnectivity
+{
+    /**
+     * Constructor.
+     *
+     * @param FlowNodeRegistry $registry Resolves whether a type ends a path.
+     *
+     * @spec openspec/specs/flow-engine/spec.md
+     */
+    public function __construct(private readonly FlowNodeRegistry $registry)
+    {
+
+    }//end __construct()
+
+    /**
+     * One warning per node whose token would have nowhere to go.
+     *
+     * @param array $flow The flow document.
+     *
+     * @return array<int, array<string, string>> The findings.
+     *
+     * @spec openspec/specs/flow-engine/spec.md
+     */
+    public function deadEnds(array $flow): array
+    {
+        $nodes = ($flow['nodes'] ?? []);
+        if (is_array($nodes) === false || $nodes === []) {
+            return [];
+        }
+
+        $hasOutgoing = $this->nodeIdsWithAnExit(flow: $flow);
+
+        $warnings = [];
+        foreach ($nodes as $node) {
+            if ($this->isDeadEnd(node: $node, hasOutgoing: $hasOutgoing) === false) {
+                continue;
+            }
+
+            $id   = trim((string) $node['id']);
+            $type = trim((string) ($node['type'] ?? ''));
+
+            $warnings[] = [
+                'type'   => $type,
+                'app'    => $this->ownerOf(type: $type),
+                'step'   => $id,
+                'reason' => FlowNodePreflight::REASON_DEAD_END,
+                'detail' => sprintf(
+                    'Node "%s" has no outgoing edge and does not end the flow, so its token would '
+                    .'arrive, run, and stop with the run reported as completed. Connect it, give it '
+                    .'a terminal step type, or mark it "exit": true if stopping there is deliberate.',
+                    $id
+                ),
+            ];
+        }//end foreach
+
+        return $warnings;
+
+    }//end deadEnds()
+
+    /**
+     * Every node id that some edge leaves from.
+     *
+     * `from` is the only key that matters: a node with an outgoing edge has
+     * somewhere to send its token, however many edges arrive at it.
+     *
+     * @param array $flow The flow document.
+     *
+     * @return array<string, boolean> A set keyed by node id.
+     *
+     * @spec openspec/specs/flow-engine/spec.md
+     */
+    private function nodeIdsWithAnExit(array $flow): array
+    {
+        $hasOutgoing = [];
+        foreach (($flow['edges'] ?? []) as $edge) {
+            if (is_array($edge) === false) {
+                continue;
+            }
+
+            $from = trim((string) ($edge['from'] ?? ''));
+            if ($from !== '') {
+                $hasOutgoing[$from] = true;
+            }
+        }//end foreach
+
+        return $hasOutgoing;
+
+    }//end nodeIdsWithAnExit()
+
+    /**
+     * Whether this node's token would arrive and then have nowhere to go.
+     *
+     * @param mixed                  $node        The node entry.
+     * @param array<string, boolean> $hasOutgoing Node ids that have an exit.
+     *
+     * @return boolean True when the node is a dead end.
+     *
+     * @spec openspec/specs/flow-engine/spec.md
+     */
+    private function isDeadEnd(mixed $node, array $hasOutgoing): bool
+    {
+        if (is_array($node) === false) {
+            return false;
+        }
+
+        $id = trim((string) ($node['id'] ?? ''));
+        if ($id === '' || isset($hasOutgoing[$id]) === true) {
+            return false;
+        }
+
+        if (($node['exit'] ?? false) === true) {
+            return false;
+        }
+
+        $type = trim((string) ($node['type'] ?? ''));
+        if ($type === '') {
+            return false;
+        }
+
+        return ($this->registry->isTerminal(type: $type) === false);
+
+    }//end isDeadEnd()
+
+    /**
+     * The app id a namespaced node type belongs to.
+     *
+     * @param string $type The node type id.
+     *
+     * @return string The owning app id, or an empty string.
+     *
+     * @spec openspec/specs/flow-engine/spec.md
+     */
+    private function ownerOf(string $type): string
+    {
+        $separator = strpos($type, '.');
+        if ($separator === false || $separator === 0) {
+            return '';
+        }
+
+        return substr($type, 0, $separator);
+
+    }//end ownerOf()
+}//end class

--- a/lib/Service/Flow/FlowDeadEnd.php
+++ b/lib/Service/Flow/FlowDeadEnd.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * Thrown when a flow is asked to run but cannot finish.
+ *
+ * WHY A REFUSAL AND NOT A WARNING
+ * -------------------------------
+ * A dead-ended flow does not fail — that is the whole problem. Its token
+ * arrives at a node with nowhere to go, the engine finds no enabled transition,
+ * the run stops, and it is recorded COMPLETED. The author sees a green run that
+ * did not do the work. Running it and reporting success is therefore strictly
+ * worse than refusing to start: the refusal is loud, names the nodes, and can
+ * be acted on.
+ *
+ * SAVING is not refused, only RUNNING. A half-wired graph is the normal state
+ * of one being authored, and an editor that refuses to save until the graph is
+ * complete would require authors to build it in an order that is never
+ * disconnected — which no editor can require. So the warning lands at save
+ * ({@see FlowNodePreflight::REASON_DEAD_END}) and the refusal lands here.
+ *
+ * WHERE IT IS RAISED
+ * ------------------
+ * `FlowRunService::queue()`, which is the single choke point every dispatch
+ * path passes through: manual `POST /run`, trigger, schedule, MCP, the
+ * workflow-engine operation, and a sub-flow invocation. Guarding the manual
+ * path alone would leave cron-fired flows unguarded, and those are most of
+ * them.
+ *
+ * CATCHING IT
+ * -----------
+ * The schedule sweep catches it PER FLOW. It iterates every due flow, so
+ * letting this propagate would abort the sweep and stop every later flow from
+ * firing — one broken flow silently disabling the rest is a bigger outage than
+ * the one being reported.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/flow-engine/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+use RuntimeException;
+
+/**
+ * A flow was asked to run while it has a node that cannot pass its token on.
+ *
+ * @spec openspec/specs/flow-engine/spec.md
+ */
+class FlowDeadEnd extends RuntimeException
+{
+    /**
+     * Constructor.
+     *
+     * @param array<int, string> $nodeIds The offending node ids, in document order.
+     *
+     * @spec openspec/specs/flow-engine/spec.md
+     */
+    public function __construct(private readonly array $nodeIds=[])
+    {
+        $subject = sprintf('nodes "%s" have', implode(separator: '", "', array: $nodeIds));
+        $pronoun = 'them';
+
+        if (count($nodeIds) === 1) {
+            $subject = sprintf('node "%s" has', $nodeIds[0]);
+            $pronoun = 'it';
+        }
+
+        parent::__construct(
+            message: sprintf(
+                'This flow is not runnable: %s no outgoing edge and does not end the flow, so a run '
+                .'would stop there and still be reported as completed. Connect %s, give %s a terminal '
+                .'step type, or mark %s "exit": true if stopping there is deliberate.',
+                $subject,
+                $pronoun,
+                $pronoun,
+                $pronoun
+            )
+        );
+
+    }//end __construct()
+
+    /**
+     * The nodes that caused the refusal.
+     *
+     * @return array<int, string> The node ids.
+     *
+     * @spec openspec/specs/flow-engine/spec.md
+     */
+    public function getNodeIds(): array
+    {
+        return $this->nodeIds;
+
+    }//end getNodeIds()
+}//end class

--- a/lib/Service/Flow/FlowNodePreflight.php
+++ b/lib/Service/Flow/FlowNodePreflight.php
@@ -345,7 +345,10 @@ class FlowNodePreflight
             $warnings = array_merge($warnings, $findings['warnings']);
         }//end foreach
 
-        $warnings = array_merge($warnings, $this->deadEndFindings(flow: $flow));
+        // The graph-SHAPE question lives in its own collaborator: this class
+        // answers questions about each node's type and config, which is a
+        // different subject over the same document.
+        $warnings = array_merge($warnings, (new FlowConnectivity($this->registry))->deadEnds(flow: $flow));
 
         return [
             'blocking' => $blocking,
@@ -353,98 +356,6 @@ class FlowNodePreflight
         ];
 
     }//end inspect()
-
-    /**
-     * Report every node that is not terminal and has no outgoing edge.
-     *
-     * Under the pre-inversion reading a sink PLACE was an ordinary end of a
-     * path — the step had already run on the edge that arrived. After
-     * `or-flow-action-nodes` the node IS the step, so a sink node runs and then
-     * has nowhere to send its token: the engine finds no enabled transition,
-     * stops, and reports the run COMPLETED. Nothing is logged, because from the
-     * engine's point of view nothing went wrong.
-     *
-     * A node escapes this two ways, OR-ed and never AND-ed ({@see IFlowTerminalNode}):
-     * its TYPE is registered terminal, or the node itself says `exit: true`.
-     *
-     * @param array $flow The flow document.
-     *
-     * @return array<int, array<string, string>> One warning per dead end.
-     *
-     * @spec openspec/specs/flow-engine/spec.md
-     */
-    private function deadEndFindings(array $flow): array
-    {
-        $nodes = ($flow['nodes'] ?? []);
-        if (is_array($nodes) === false || $nodes === []) {
-            return [];
-        }
-
-        // Every node id that some edge leaves from. `from` is the only key that
-        // matters: a node with an outgoing edge has somewhere to go, however
-        // many arrive.
-        $hasOutgoing = [];
-        foreach (($flow['edges'] ?? []) as $edge) {
-            if (is_array($edge) === false) {
-                continue;
-            }
-
-            $from = trim((string) ($edge['from'] ?? ''));
-            if ($from !== '') {
-                $hasOutgoing[$from] = true;
-            }
-        }//end foreach
-
-        $warnings = [];
-        foreach ($nodes as $node) {
-            if (is_array($node) === false) {
-                continue;
-            }
-
-            $id = trim((string) ($node['id'] ?? ''));
-            if ($id === '' || isset($hasOutgoing[$id]) === true) {
-                continue;
-            }
-
-            if (($node['exit'] ?? false) === true) {
-                continue;
-            }
-
-            $type = trim((string) ($node['type'] ?? ''));
-
-            // A node with no type is not this check's business. It is already
-            // refused — loudly, by name — in `FlowDefinitionBuilder`, which
-            // will not build a document containing one, so it can never run
-            // and stop quietly. Reporting it a second time under a different
-            // reason would put two findings on one node for one defect, and
-            // warnings that duplicate each other are the ones authors learn to
-            // scroll past. It is also why the rest of this preflight skips a
-            // typeless node rather than classifying it.
-            if ($type === '') {
-                continue;
-            }
-
-            if ($this->registry->isTerminal(type: $type) === true) {
-                continue;
-            }
-
-            $warnings[] = [
-                'type'   => $type,
-                'app'    => $this->ownerOf(type: $type),
-                'step'   => $id,
-                'reason' => self::REASON_DEAD_END,
-                'detail' => sprintf(
-                    'Node "%s" has no outgoing edge and does not end the flow, so its token would '
-                    .'arrive, run, and stop with the run reported as completed. Connect it, give it '
-                    .'a terminal step type, or mark it "exit": true if stopping there is deliberate.',
-                    $id
-                ),
-            ];
-        }//end foreach
-
-        return $warnings;
-
-    }//end deadEndFindings()
 
     /**
      * Refuse a document whose steps still sit on edges.

--- a/lib/Service/Flow/FlowNodePreflight.php
+++ b/lib/Service/Flow/FlowNodePreflight.php
@@ -175,6 +175,17 @@ class FlowNodePreflight
     public const REASON_PRE_INVERSION_SHAPE = 'flow-pre-inversion-shape';
 
     /**
+     * A node that is not terminal, and has nowhere to send its token.
+     *
+     * A WARNING, never blocking. A half-wired flow is the normal state of one
+     * being authored, and refusing to SAVE it would make the editor unusable —
+     * the author would have to build the graph in an order that is never
+     * disconnected, which no editor can require. The refusal belongs at RUN
+     * time, where the cost of a silent stop is actually paid.
+     */
+    public const REASON_DEAD_END = 'node-dead-end';
+
+    /**
      * The key the engine reads from the EDGE and never from `config`.
      */
     private const EDGE_LEVEL_ONERROR = 'onError';
@@ -334,12 +345,106 @@ class FlowNodePreflight
             $warnings = array_merge($warnings, $findings['warnings']);
         }//end foreach
 
+        $warnings = array_merge($warnings, $this->deadEndFindings(flow: $flow));
+
         return [
             'blocking' => $blocking,
             'warnings' => $warnings,
         ];
 
     }//end inspect()
+
+    /**
+     * Report every node that is not terminal and has no outgoing edge.
+     *
+     * Under the pre-inversion reading a sink PLACE was an ordinary end of a
+     * path — the step had already run on the edge that arrived. After
+     * `or-flow-action-nodes` the node IS the step, so a sink node runs and then
+     * has nowhere to send its token: the engine finds no enabled transition,
+     * stops, and reports the run COMPLETED. Nothing is logged, because from the
+     * engine's point of view nothing went wrong.
+     *
+     * A node escapes this two ways, OR-ed and never AND-ed ({@see IFlowTerminalNode}):
+     * its TYPE is registered terminal, or the node itself says `exit: true`.
+     *
+     * @param array $flow The flow document.
+     *
+     * @return array<int, array<string, string>> One warning per dead end.
+     *
+     * @spec openspec/specs/flow-engine/spec.md
+     */
+    private function deadEndFindings(array $flow): array
+    {
+        $nodes = ($flow['nodes'] ?? []);
+        if (is_array($nodes) === false || $nodes === []) {
+            return [];
+        }
+
+        // Every node id that some edge leaves from. `from` is the only key that
+        // matters: a node with an outgoing edge has somewhere to go, however
+        // many arrive.
+        $hasOutgoing = [];
+        foreach (($flow['edges'] ?? []) as $edge) {
+            if (is_array($edge) === false) {
+                continue;
+            }
+
+            $from = trim((string) ($edge['from'] ?? ''));
+            if ($from !== '') {
+                $hasOutgoing[$from] = true;
+            }
+        }//end foreach
+
+        $warnings = [];
+        foreach ($nodes as $node) {
+            if (is_array($node) === false) {
+                continue;
+            }
+
+            $id = trim((string) ($node['id'] ?? ''));
+            if ($id === '' || isset($hasOutgoing[$id]) === true) {
+                continue;
+            }
+
+            if (($node['exit'] ?? false) === true) {
+                continue;
+            }
+
+            $type = trim((string) ($node['type'] ?? ''));
+
+            // A node with no type is not this check's business. It is already
+            // refused — loudly, by name — in `FlowDefinitionBuilder`, which
+            // will not build a document containing one, so it can never run
+            // and stop quietly. Reporting it a second time under a different
+            // reason would put two findings on one node for one defect, and
+            // warnings that duplicate each other are the ones authors learn to
+            // scroll past. It is also why the rest of this preflight skips a
+            // typeless node rather than classifying it.
+            if ($type === '') {
+                continue;
+            }
+
+            if ($this->registry->isTerminal(type: $type) === true) {
+                continue;
+            }
+
+            $warnings[] = [
+                'type'   => $type,
+                'app'    => $this->ownerOf(type: $type),
+                'step'   => $id,
+                'reason' => self::REASON_DEAD_END,
+                'detail' => sprintf(
+                    'Node "%s" has no outgoing edge and does not end the flow, so its token would '
+                    .'arrive, run, and stop with the run reported as completed. Connect it, give it '
+                    .'a terminal step type, or mark it "exit": true if stopping there is deliberate.',
+                    $id
+                ),
+            ];
+        }//end foreach
+
+        return $warnings;
+
+    }//end deadEndFindings()
 
     /**
      * Refuse a document whose steps still sit on edges.

--- a/lib/Service/Flow/FlowNodeRegistry.php
+++ b/lib/Service/Flow/FlowNodeRegistry.php
@@ -261,6 +261,39 @@ class FlowNodeRegistry
     }//end get()
 
     /**
+     * Whether a node TYPE ends a path deliberately.
+     *
+     * Resolved through the registry rather than against a hardcoded list, so a
+     * terminal step contributed by another app — openconnector, hermiq, or one
+     * not written yet — needs no OpenRegister change to be recognised. A
+     * hardcoded list would silently report every contributed terminal node as a
+     * dead end, and the warning would train authors to ignore it.
+     *
+     * An unknown type is NOT terminal. It is already reported by its own
+     * preflight finding, and guessing "probably terminal" here would suppress
+     * the dead-end warning for exactly the documents most likely to have one.
+     *
+     * @param string $type The node type id.
+     *
+     * @return bool True when the type is registered and marks itself terminal.
+     *
+     * @spec openspec/specs/flow-engine/spec.md
+     */
+    public function isTerminal(string $type): bool
+    {
+        if (trim($type) === '') {
+            return false;
+        }
+
+        try {
+            return ($this->get(type: $type) instanceof IFlowTerminalNode);
+        } catch (UnexpectedValueException) {
+            return false;
+        }
+
+    }//end isTerminal()
+
+    /**
      * Collect contributions once per request.
      *
      * @return void

--- a/lib/Service/Flow/FlowRunService.php
+++ b/lib/Service/Flow/FlowRunService.php
@@ -33,6 +33,7 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Service\Flow;
 
 use DateTime;
+use OCA\OpenRegister\Db\Flow;
 use OCA\OpenRegister\Db\FlowRun;
 use OCA\OpenRegister\Db\FlowRunMapper;
 use OCA\OpenRegister\Db\FlowRunStep;
@@ -139,6 +140,13 @@ class FlowRunService
         array $context=[],
         ?string $user=null
     ): FlowRun {
+        // Every dispatch path arrives here — manual, trigger, schedule, MCP,
+        // the workflow-engine operation and a sub-flow call — so this is the
+        // one place a refusal covers all of them. Guarding `FlowService::run()`
+        // instead would leave cron-fired flows unguarded, and those are most of
+        // them.
+        $this->refuseDeadEnd(flowId: $flowId);
+
         $run = new FlowRun();
         $run->setUuid($this->newUuid());
         $run->setFlowId($flowId);
@@ -160,6 +168,88 @@ class FlowRunService
         return $this->mapper->insert($run);
 
     }//end queue()
+
+    /**
+     * Refuse to queue a flow that has a node its token cannot leave.
+     *
+     * Writes the verdict onto the FLOW before throwing, so a refused flow is
+     * distinguishable from one nobody has triggered without reading run
+     * history — there is no run to read, which is the point. A run that IS
+     * accepted clears the verdict back to `ok`, so a fixed flow stops
+     * reporting an error it no longer has.
+     *
+     * Resolved lazily through the container for the same reason
+     * `activeOrganisation()` is: this service is constructed on paths that do
+     * not need either collaborator, and several tests build it by hand.
+     *
+     * @param string $flowId The flow uuid.
+     *
+     * @return void
+     *
+     * @throws FlowDeadEnd When a non-terminal node has no outgoing edge.
+     *
+     * @spec openspec/specs/flow-engine/spec.md
+     */
+    private function refuseDeadEnd(string $flowId): void
+    {
+        try {
+            $mapper    = $this->container->get('OCA\OpenRegister\Db\FlowMapper');
+            $preflight = $this->container->get('OCA\OpenRegister\Service\Flow\FlowNodePreflight');
+            $flow      = $mapper->findByUuid($flowId);
+        } catch (Throwable $e) {
+            // A flow we cannot load is not a flow we can judge — `findByUuid()`
+            // throws rather than returning null. Queueing proceeds and the
+            // existing not-found handling downstream reports it; inventing a
+            // dead-end refusal here would blame the document for a lookup
+            // failure.
+            return;
+        }
+
+        $findings = $preflight->inspect(
+            flow: [
+                'nodes' => ($flow->getNodes() ?? []),
+                'edges' => ($flow->getEdges() ?? []),
+            ]
+        );
+
+        $deadEnds = [];
+        foreach ($findings['warnings'] as $warning) {
+            if (($warning['reason'] ?? '') === FlowNodePreflight::REASON_DEAD_END) {
+                $deadEnds[] = (string) ($warning['step'] ?? '');
+            }
+        }
+
+        if ($deadEnds === []) {
+            // Accepted. Clear a stale refusal so a repaired flow stops
+            // reporting the error it no longer has.
+            if ($flow->getStatus() === Flow::STATUS_ERROR) {
+                $flow->setStatus(Flow::STATUS_OK);
+                $flow->setStatusMessage(null);
+                $mapper->update($flow);
+            }
+
+            return;
+        }
+
+        $refusal = new FlowDeadEnd(nodeIds: $deadEnds);
+
+        $flow->setStatus(Flow::STATUS_ERROR);
+        $flow->setStatusMessage($refusal->getMessage());
+        $mapper->update($flow);
+
+        $this->logger->warning(
+            message: '[FlowRunService] Refused to queue a flow with a dead end',
+            context: [
+                'file'  => __FILE__,
+                'line'  => __LINE__,
+                'flow'  => $flowId,
+                'nodes' => $deadEnds,
+            ]
+        );
+
+        throw $refusal;
+
+    }//end refuseDeadEnd()
 
     /**
      * Whether a flow already has a run that has not finished.
@@ -538,9 +628,70 @@ class FlowRunService
 
         $run->setResumeAt($resumeAt);
 
-        return $this->mapper->update($run);
+        $persisted = $this->mapper->update($run);
+
+        $this->recordLastRun(run: $persisted, status: $status);
+
+        return $persisted;
 
     }//end persistResult()
+
+    /**
+     * Copy a finished run's outcome onto its flow.
+     *
+     * On a TERMINAL state only. A queued or running run has no outcome yet, and
+     * a suspended one is mid-flight — writing any of those would make the flow
+     * list answer "how did it last go?" with "it hasn't finished", which is a
+     * different question. A suspended run that later completes writes here on
+     * that completion, so nothing is lost by waiting.
+     *
+     * Failure to write is logged and swallowed: this is a reporting
+     * convenience, and losing it must never turn a completed run into a failed
+     * one.
+     *
+     * @param FlowRun $run    The run that just reached a terminal state.
+     * @param string  $status That terminal status.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/flow-engine/spec.md
+     */
+    private function recordLastRun(FlowRun $run, string $status): void
+    {
+        $terminal = [
+            FlowRun::STATUS_COMPLETED,
+            FlowRun::STATUS_STOPPED,
+            FlowRun::STATUS_FAILED,
+            FlowRun::STATUS_DEAD_LETTER,
+        ];
+
+        if (in_array($status, $terminal, true) === false) {
+            return;
+        }
+
+        $flowId = trim((string) $run->getFlowId());
+        if ($flowId === '') {
+            return;
+        }
+
+        try {
+            $mapper = $this->container->get('OCA\OpenRegister\Db\FlowMapper');
+            $flow   = $mapper->findByUuid($flowId);
+
+            $flow->setLastRunUuid($run->getUuid());
+            $flow->setLastRunStatus($status);
+            $flow->setLastRunMessage($run->getError());
+            $flow->setLastRunAt(new DateTime());
+
+            $mapper->update($flow);
+        } catch (Throwable $e) {
+            $this->logger->debug(
+                message: '[FlowRunService] Could not record the last run on its flow: '.$e->getMessage(),
+                context: ['file' => __FILE__, 'line' => __LINE__, 'flow' => $flowId]
+            );
+        }//end try
+
+    }//end recordLastRun()
 
     /**
      * A v4 UUID for a new run.

--- a/lib/Service/Flow/FlowScheduleService.php
+++ b/lib/Service/Flow/FlowScheduleService.php
@@ -149,7 +149,28 @@ class FlowScheduleService
                 $owner = (string) $owner;
             }
 
-            $this->fire(uuid: $uuid, now: $now, owner: $owner);
+            // Per flow, not around the loop. A refused flow must not stop the
+            // ones after it from firing — one broken definition silently
+            // disabling every later schedule is a far bigger outage than the
+            // one being reported, and it would present as "cron stopped
+            // working" rather than as a fault in a specific flow.
+            try {
+                $this->fire(uuid: $uuid, now: $now, owner: $owner);
+            } catch (FlowDeadEnd $e) {
+                // The refusal already recorded status/status_message on the
+                // flow itself, so the author can see why without reading logs.
+                $this->logger->warning(
+                    message: '[FlowSchedule] Skipping due flow — it is not runnable: '.$e->getMessage(),
+                    context: [
+                        'file'  => __FILE__,
+                        'line'  => __LINE__,
+                        'flow'  => $uuid,
+                        'nodes' => $e->getNodeIds(),
+                    ]
+                );
+                continue;
+            }
+
             $fired[] = $uuid;
         }//end foreach
 

--- a/lib/Service/Flow/IFlowTerminalNode.php
+++ b/lib/Service/Flow/IFlowTerminalNode.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * A node that deliberately ends a path.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * After `or-flow-action-nodes` a node with no outgoing edge is a **dead end**:
+ * its token arrives, the step runs, and the run stops there with nothing to
+ * consume it. The engine reports the run COMPLETED, because from its point of
+ * view nothing failed — it simply ran out of places to go. That is the failure
+ * mode this interface exists to make impossible to hide: a flow must either
+ * exit DELIBERATELY or say it is broken, never stop quietly and call it success.
+ *
+ * The connectivity check therefore needs to distinguish "this node ends the
+ * path because ending is what it does" from "this node ends the path because
+ * its author forgot to connect it". Only the node itself knows which, so it
+ * says so — by implementing this.
+ *
+ * WHY NOT A METHOD ON `IFlowNode`
+ * -------------------------------
+ * Adding a method to `IFlowNode` is a fatal error for every class implementing
+ * it that has not been updated, and implementations live in OTHER repositories:
+ * openconnector ships `source-call` and `synchronization-run`, hermiq ships
+ * `agent-step` and `workload-step`. Publishing a release that fatals those apps
+ * on load is a worse outcome than the defect being closed. This is the same
+ * reasoning, and the same shape, as {@see IFlowNodeConfigKeys} — and the same
+ * precedent in core, where `ISpecificOperation` extends `IOperation` rather
+ * than widening it and core probes with `instanceof`.
+ *
+ * THE ESCAPE HATCH
+ * ----------------
+ * A node can also be marked terminal per-instance with `exit: true` on the node
+ * in the flow document, without its TYPE being terminal. That is what a
+ * migrated flow needs: a sink whose step type is an ordinary action, which was
+ * a legitimate end of a path under the old place-and-edge reading and must not
+ * start being refused because the reading changed.
+ *
+ * The two answers are deliberately OR-ed, never AND-ed: a registered terminal
+ * type does not need the flag, and the flag does not need the type's
+ * permission. Requiring both would make every migrated flow depend on a
+ * registry the migration cannot see.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/flow-engine/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+/**
+ * Optional companion to {@see IFlowNode}: this node ends a path on purpose.
+ *
+ * A marker interface — it declares no methods. Terminality is a property of the
+ * node TYPE, not a question the engine asks with arguments, so there is nothing
+ * to pass and nothing to answer. `instanceof` is the whole contract.
+ *
+ * A node that does NOT implement this is not assumed non-terminal in any
+ * damaging way: it is simply expected to have an outgoing edge, and warns when
+ * it does not. The warning never blocks a save.
+ */
+interface IFlowTerminalNode
+{
+}//end interface

--- a/lib/Service/Flow/Nodes/StopNode.php
+++ b/lib/Service/Flow/Nodes/StopNode.php
@@ -37,7 +37,7 @@ use OCP\WorkflowEngine\IManager;
 /**
  * Stops the run, optionally as an error.
  */
-class StopNode implements IFlowNode, IFlowNodeConfigKeys
+class StopNode implements IFlowNode, IFlowNodeConfigKeys, IFlowTerminalNode
 {
     /**
      * Constructor.

--- a/lib/Service/Flow/Nodes/StopNode.php
+++ b/lib/Service/Flow/Nodes/StopNode.php
@@ -30,6 +30,7 @@ namespace OCA\OpenRegister\Service\Flow\Nodes;
 use OCA\OpenRegister\Service\Flow\FlowStop;
 use OCA\OpenRegister\Service\Flow\IFlowNode;
 use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
+use OCA\OpenRegister\Service\Flow\IFlowTerminalNode;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\WorkflowEngine\IManager;

--- a/openspec/changes/or-flow-connectivity-and-last-run/tasks.md
+++ b/openspec/changes/or-flow-connectivity-and-last-run/tasks.md
@@ -1,35 +1,58 @@
 # Tasks: or-flow-connectivity-and-last-run
 
-- [ ] `IFlowTerminalNode` marker interface; `StopNode` implements it. A separate
+- [x] `IFlowTerminalNode` marker interface; `StopNode` implements it. A separate
       interface, NOT a method on `IFlowNode` — openconnector and hermiq
       implement `IFlowNode` from their own repos and would fatal on load
       (precedent: `IFlowNodeConfigKeys`, or-flow-preflight).
-- [ ] Terminality resolved through `FlowNodeRegistry`, so a contributed terminal
+- [x] Terminality resolved through `FlowNodeRegistry`, so a contributed terminal
       step needs no OpenRegister change. Honour `exit: true` on the node.
-- [ ] Connectivity check: every non-exit node has ≥1 outgoing edge; report the
+- [x] Connectivity check: every non-exit node has ≥1 outgoing edge; report the
       offending node ids.
-- [ ] Wire the check into `FlowNodePreflight` as a WARNING (never blocking), so
+- [x] Wire the check into `FlowNodePreflight` as a WARNING (never blocking), so
       `POST /api/flow/validate` and the save path both surface it.
-- [ ] Save (`POST`/`PUT /api/flows`) stores the flow and returns the warning.
-- [ ] `FlowService::run()` refuses a dead-ended flow: no `FlowRun` created,
-      `status` = `error`, `status_message` names the nodes.
-- [ ] Apply the same refusal on the trigger and schedule dispatch paths — a
+- [x] Save (`POST`/`PUT /api/flows`) stores the flow and returns the warning.
+- [x] `FlowService::run()` refuses a dead-ended flow: no `FlowRun` created,
+      `status` = `error`, `status_message` names the nodes. Implemented in
+      `FlowRunService::queue()`, the single choke point `run()` and every other
+      dispatch path delegate to.
+- [x] Apply the same refusal on the trigger and schedule dispatch paths — a
       guard only on `POST /run` leaves cron-fired flows unguarded, which is most
-      of them.
-- [ ] Clear `status` back to `ok` when a run is accepted.
-- [ ] Migration adding `status`, `status_message`, `last_run_uuid`,
+      of them. Covered by guarding `queue()`; the schedule sweep additionally
+      catches PER FLOW, so one refusal cannot stop later due flows from firing.
+- [x] Clear `status` back to `ok` when a run is accepted.
+- [x] Migration adding `status`, `status_message`, `last_run_uuid`,
       `last_run_status`, `last_run_message`, `last_run_at` — all nullable, no
       backfill.
-- [ ] `Flow` entity + `FlowMapper` + `jsonSerialize()` carry the new fields
+- [x] `Flow` entity + `FlowMapper` + `jsonSerialize()` carry the new fields
       (camelCase in the API, as the existing fields are).
-- [ ] `FlowRunService` writes the last-run fields when a run reaches a terminal
+- [x] `FlowRunService` writes the last-run fields when a run reaches a terminal
       state — not per step, not on queue.
-- [ ] Unit tests: exit by registered terminal type, exit by `exit: true`, dead
+- [x] Unit tests: exit by registered terminal type, exit by `exit: true`, dead
       end warns on save, dead end refuses to run, refusal sets status+message.
+      `FlowDeadEndTest` pins the connectivity verdict and the refusal message,
+      each with a positive control proving the same graph goes quiet once wired.
 - [ ] Test the schedule/trigger refusal path specifically, with a positive
       control proving a well-formed scheduled flow still dispatches.
+      **NOT DONE** — needs `FlowRunService` constructed with a mocked container,
+      flow mapper and preflight. The verdict it consumes is covered by
+      `FlowDeadEndTest`; the dispatch wiring itself is not yet pinned.
 - [ ] Test last-run write-back on completion, on failure, and that a queued run
-      does not overwrite it.
+      does not overwrite it. **NOT DONE** — same harness as above.
+
+## Verification note — why the suite was not run locally
+
+The unit suite could not be executed against this change on this machine. Once
+`lib/base.php` loads, Nextcloud's app autoloader resolves `OCA\OpenRegister\*`
+to the **installed** app under `/var/www/html/custom_apps/openregister`, not to
+the working copy under test — measured directly with
+`ReflectionClass::getFileName()`.
+
+CI's "copy the app OUT of /var/www/html" step does not prevent this. CI is
+immune only because it DEPLOYS the code under test first, so the installed copy
+and the copy under test are identical. Run that same recipe locally against an
+older deployment and the suite reports on the DEPLOYED app: a green that says
+nothing about the change. The suite therefore runs in CI, which is the
+authoritative gate for this change.
 
 ## Acceptance criteria
 
@@ -43,5 +66,3 @@
 
 - Tests run on the container's PHP 8.4, not the host.
 - `composer check:strict` passes (PHPCS, PHPMD, Psalm, PHPStan).
-- Depends on `or-flow-action-nodes` — the exit definition is meaningless until
-  nodes carry step types.

--- a/openspec/specs/flow-engine/spec.md
+++ b/openspec/specs/flow-engine/spec.md
@@ -1,0 +1,107 @@
+---
+status: done
+---
+
+# flow-engine Specification
+
+## Purpose
+Defines how OpenRegister reads a flow document and turns it into a run: what carries behaviour (the node), what carries sequence (the edge), when converging paths merge versus synchronise, how a path is allowed to end, and what a flow records about its own runnability and its last run. This is the fleet's single flow engine (ADR-065) — openconnector and hermiq contribute node types to it and do not implement their own.
+
+## Requirements
+
+### Requirement: A NODE carries the behaviour and an EDGE carries only sequence @e2e exclude engine-internal document lowering — covered by FlowDefinitionBuilder unit tests
+
+A flow document consists of `nodes[]` and `edges[]`. Each node MUST carry the `type` and `config` of the step it performs; each edge MUST carry only `from`, `to` and optional display text. `FlowDefinitionBuilder::build()` MUST lower each node to one transition carrying that node's `type`/`config`, and `FlowTokenRouter::stepFor()` MUST resolve a transition name to its NODE rather than to an entry in `edges[]`. `RegistryStepDispatcher` MUST read `type` and `config` off the node it is given.
+
+#### Scenario: A step is read from the node, not the edge
+- **GIVEN** a node `find-work` with `type: openregister.object-read` and an edge leaving it that carries no `type`
+- **WHEN** the run reaches the transition named `find-work`
+- **THEN** the dispatcher MUST execute `openregister.object-read` with that node's `config`
+- **AND** the edge MUST contribute only the target place
+
+### Requirement: A pre-inversion document MUST be refused, never reinterpreted @e2e exclude engine-internal refusal — covered by FlowDefinitionBuilder unit tests
+
+A document is pre-inversion if and only if any EDGE carries a non-empty `type`. `FlowDefinitionBuilder` MUST refuse such a document with a message naming the offending edge and the migration to run. It MUST NOT attempt to read the step off the edge, and MUST NOT repair the document in place.
+
+#### Scenario: A half-migrated flow is refused rather than partly run
+- **GIVEN** a document in which one edge still carries `type: openregister.set-fields`
+- **WHEN** the engine is asked to build it
+- **THEN** it MUST throw, naming that edge
+- **AND** it MUST NOT run the remaining nodes, because a flow that runs while skipping the step nobody claimed would report success having not done the work
+
+### Requirement: Converging edges MERGE by default; synchronising requires `join: true` @e2e exclude engine-internal lowering semantics — covered by FlowMergeTest
+
+Where several edges converge on a node, the lowering MUST give that node ONE shared input place, so the node fires when ANY predecessor delivers a token (an OR-merge). A node that MUST wait for every predecessor MUST declare `join: true`, which lowers to one input place per incoming edge, all required (an AND-join).
+
+#### Scenario: Three mutually exclusive paths converge and fire once
+- **GIVEN** a routing node whose three branches all lead to `done`, and `done` does not declare `join`
+- **WHEN** exactly one branch is taken and its token reaches `done`
+- **THEN** `done` MUST fire on that single token
+- **AND** the run MUST NOT wait for the two branches that were never taken
+
+#### Scenario: A declared join waits for all of its predecessors
+- **GIVEN** a node declaring `join: true` with two incoming edges
+- **WHEN** a token arrives on one edge only
+- **THEN** the node MUST NOT fire
+- **AND** it MUST fire once a token has arrived on both
+
+### Requirement: A path MUST end deliberately, and a dead end MUST be reported @e2e exclude engine-internal connectivity check — covered by FlowDeadEndTest
+
+A node with no outgoing edge is a dead end unless it ends the path deliberately. It ends deliberately if EITHER its type is registered terminal (the type implements `IFlowTerminalNode`, resolved through `FlowNodeRegistry::isTerminal()`) OR the node itself declares `exit: true`. The two MUST be OR-ed, never AND-ed, so a migrated flow whose sink carries an ordinary action type is not refused, and a contributed terminal type needs no OpenRegister change.
+
+`FlowNodePreflight` MUST report every dead end as a WARNING carrying `reason: node-dead-end` and naming the node. It MUST NOT report a node whose `type` is empty — that node is already refused by name in `FlowDefinitionBuilder`, and two findings on one node for one defect is how a warning list becomes noise.
+
+#### Scenario: A forgotten sink is named
+- **GIVEN** a document whose node `forgotten` carries an ordinary step type, has no outgoing edge and no `exit` flag
+- **WHEN** the document is inspected
+- **THEN** the report MUST contain a `node-dead-end` warning naming `forgotten`
+- **AND** `blocking` MUST remain empty, because a dead end never blocks a save
+
+#### Scenario: A wired graph reports nothing
+- **GIVEN** the same document with `forgotten` connected onward to a terminal node
+- **WHEN** the document is inspected
+- **THEN** it MUST produce no `node-dead-end` warning
+
+#### Scenario: `exit: true` ends a path whose type is not terminal
+- **GIVEN** a single node carrying `type: openregister.set-fields` and `exit: true`, with no edges
+- **WHEN** the document is inspected
+- **THEN** it MUST produce no `node-dead-end` warning
+
+### Requirement: Saving a half-wired flow MUST succeed and warn; running one MUST be refused @e2e exclude API contract — covered by Newman and by FlowDeadEndTest
+
+`POST` and `PUT /api/flows` MUST store the flow and return the stored document with a `warnings` array alongside its own fields. Saving MUST NOT be refused for a dead end: a disconnected graph is the normal state of one being authored, and refusing it would require the author to build the graph in an order that is never disconnected.
+
+Running MUST be refused. The guard MUST sit in `FlowRunService::queue()`, which every dispatch path passes through — manual, trigger, schedule, MCP, the workflow-engine operation and a sub-flow call — because a guard on the manual path alone would leave cron-fired flows unguarded. On refusal NO `FlowRun` MUST be created, the flow's `status` MUST become `error` and `status_message` MUST name the offending nodes. When a run IS accepted, a previous `error` status MUST be cleared back to `ok`.
+
+The schedule sweep MUST catch the refusal PER FLOW, so one unrunnable flow does not stop later due flows from firing.
+
+#### Scenario: A dead-ended flow is stored, then refused at run time
+- **GIVEN** a flow whose node `forgotten` is a dead end
+- **WHEN** it is saved
+- **THEN** the save MUST succeed and the response MUST carry a `node-dead-end` warning naming `forgotten`
+- **WHEN** it is then run, by any dispatch path
+- **THEN** no `FlowRun` MUST be created
+- **AND** the flow's `status` MUST be `error` with `status_message` naming `forgotten`
+
+#### Scenario: One unrunnable flow does not disable the schedule
+- **GIVEN** two due scheduled flows, the first of which is dead-ended
+- **WHEN** the sweep runs
+- **THEN** the first MUST be skipped with its refusal recorded on the flow
+- **AND** the second MUST still fire
+
+### Requirement: A flow MUST record its last run @e2e exclude persistence contract — covered by unit tests and Newman
+
+`Flow` MUST carry `status`, `statusMessage`, `lastRunUuid`, `lastRunStatus`, `lastRunMessage` and `lastRunAt`, all nullable, exposed in camelCase by `jsonSerialize()`. `FlowRunService` MUST write the last-run fields when a run reaches a TERMINAL state (`completed`, `stopped`, `failed`, `dead_letter`) — not per step, and not on queue.
+
+A null `lastRunAt` MUST mean "has never run". The migration adding these columns MUST NOT backfill them, because a value derived from run history would assert a history the column did not record.
+
+#### Scenario: A queued run does not overwrite the last run
+- **GIVEN** a flow whose last run completed yesterday
+- **WHEN** a new run is queued and is still `queued`
+- **THEN** `lastRunAt` MUST still be yesterday's timestamp
+
+#### Scenario: A refused flow is distinguishable from one that never ran
+- **GIVEN** a flow refused for a dead end, which therefore has no `FlowRun` at all
+- **WHEN** the flow is read
+- **THEN** `status` MUST be `error` with a message naming the nodes
+- **AND** `lastRunAt` MUST be null, and the two MUST be distinguishable without reading run history

--- a/tests/Unit/Service/Flow/FlowDeadEndTest.php
+++ b/tests/Unit/Service/Flow/FlowDeadEndTest.php
@@ -1,0 +1,264 @@
+<?php
+
+/**
+ * The dead-end connectivity check.
+ *
+ * A node with no outgoing edge that is not terminal produces a run which stops
+ * where it arrives and is recorded COMPLETED. Nothing fails, so nothing is
+ * logged, and the author sees a green run that did not do the work. These tests
+ * pin the warning that makes that visible, and — as much as anything — that it
+ * can be ABSENT, because a check which fires on every document is worth as
+ * little as one which never fires.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/flow-engine/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Flow;
+
+use OCA\OpenRegister\Service\Flow\FlowDeadEnd;
+use OCA\OpenRegister\Service\Flow\FlowNodePreflight;
+use OCA\OpenRegister\Service\Flow\FlowNodeRegistry;
+use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCP\App\IAppManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Covers the dead-end warning and the refusal message built from it.
+ */
+class FlowDeadEndTest extends TestCase
+{
+    /**
+     * Build a preflight whose registry answers `isTerminal` from a fixed list.
+     *
+     * @param array<int, string> $terminal Types that end a path deliberately.
+     *
+     * @return FlowNodePreflight
+     */
+    private function preflight(array $terminal=[]): FlowNodePreflight
+    {
+        $registry = $this->createMock(FlowNodeRegistry::class);
+        $registry->method('get')->willReturn($this->createMock(IFlowNode::class));
+        $registry->method('isTerminal')->willReturnCallback(
+            static fn (string $type): bool => in_array($type, $terminal, true)
+        );
+
+        $appManager = $this->createMock(IAppManager::class);
+        $appManager->method('isEnabledForUser')->willReturn(true);
+
+        return new FlowNodePreflight($registry, $appManager, $this->createMock(LoggerInterface::class));
+
+    }//end preflight()
+
+    /**
+     * Only the dead-end warnings, so an unrelated finding cannot pass a count.
+     *
+     * @param array $report The preflight report.
+     *
+     * @return array<int, string> The offending node ids.
+     */
+    private function deadEnds(array $report): array
+    {
+        $ids = [];
+        foreach ($report['warnings'] as $warning) {
+            if (($warning['reason'] ?? '') === FlowNodePreflight::REASON_DEAD_END) {
+                $ids[] = $warning['step'];
+            }
+        }
+
+        return $ids;
+
+    }//end deadEnds()
+
+    /**
+     * A node whose token has nowhere to go is reported, by name.
+     *
+     * @return void
+     */
+    public function testSinkNodeIsReported(): void
+    {
+        $report = $this->preflight()->inspect(
+            flow: [
+                'nodes' => [
+                    ['id' => 'a', 'type' => 'openregister.set-fields'],
+                    ['id' => 'b', 'type' => 'openregister.set-fields'],
+                ],
+                'edges' => [['id' => 'e1', 'from' => 'a', 'to' => 'b']],
+            ]
+        );
+
+        $this->assertSame(['b'], $this->deadEnds($report));
+        $this->assertSame([], $report['blocking'], 'A dead end warns; it never blocks a save.');
+
+    }//end testSinkNodeIsReported()
+
+    /**
+     * The positive control: the SAME graph, wired, reports nothing.
+     *
+     * Without this the test above proves only that the method returns a
+     * non-empty list — which a check hardcoded to complain would also do.
+     *
+     * @return void
+     */
+    public function testWiredGraphIsSilent(): void
+    {
+        $report = $this->preflight(terminal: ['openregister.stop'])->inspect(
+            flow: [
+                'nodes' => [
+                    ['id' => 'a', 'type' => 'openregister.set-fields'],
+                    ['id' => 'b', 'type' => 'openregister.stop'],
+                ],
+                'edges' => [['id' => 'e1', 'from' => 'a', 'to' => 'b']],
+            ]
+        );
+
+        $this->assertSame([], $this->deadEnds($report));
+
+    }//end testWiredGraphIsSilent()
+
+    /**
+     * A registered terminal TYPE ends a path without needing the flag.
+     *
+     * @return void
+     */
+    public function testRegisteredTerminalTypeIsNotADeadEnd(): void
+    {
+        $report = $this->preflight(terminal: ['openregister.stop'])->inspect(
+            flow: [
+                'nodes' => [['id' => 'only', 'type' => 'openregister.stop']],
+                'edges' => [],
+            ]
+        );
+
+        $this->assertSame([], $this->deadEnds($report));
+
+    }//end testRegisteredTerminalTypeIsNotADeadEnd()
+
+    /**
+     * `exit: true` ends a path without the type being terminal.
+     *
+     * This is what a migrated flow needs: a sink whose step is an ordinary
+     * action, which was a legitimate end of a path under the old reading.
+     *
+     * @return void
+     */
+    public function testExitFlagIsHonouredForAnOrdinaryType(): void
+    {
+        $report = $this->preflight()->inspect(
+            flow: [
+                'nodes' => [['id' => 'only', 'type' => 'openregister.set-fields', 'exit' => true]],
+                'edges' => [],
+            ]
+        );
+
+        $this->assertSame([], $this->deadEnds($report));
+
+    }//end testExitFlagIsHonouredForAnOrdinaryType()
+
+    /**
+     * The two escapes are OR-ed, never AND-ed.
+     *
+     * A terminal type with no flag, and a flag with no terminal type, each
+     * suffice on their own — proven by the two tests above. Here the inverse:
+     * an ordinary type with no flag is NOT excused by the presence of a
+     * terminal node elsewhere in the document.
+     *
+     * @return void
+     */
+    public function testATerminalNodeElsewhereDoesNotExcuseASink(): void
+    {
+        $report = $this->preflight(terminal: ['openregister.stop'])->inspect(
+            flow: [
+                'nodes' => [
+                    ['id' => 'a', 'type' => 'openregister.set-fields'],
+                    ['id' => 'ends', 'type' => 'openregister.stop'],
+                    ['id' => 'forgotten', 'type' => 'openregister.set-fields'],
+                ],
+                'edges' => [['id' => 'e1', 'from' => 'a', 'to' => 'ends']],
+            ]
+        );
+
+        $this->assertSame(['forgotten'], $this->deadEnds($report));
+
+    }//end testATerminalNodeElsewhereDoesNotExcuseASink()
+
+    /**
+     * A typeless node is left to the builder, which refuses it by name.
+     *
+     * Two findings on one node for one defect is how a warning list becomes
+     * noise, so this check stays out of the builder's way.
+     *
+     * @return void
+     */
+    public function testTypelessNodeIsNotDoubleReported(): void
+    {
+        $report = $this->preflight()->inspect(
+            flow: [
+                'nodes' => [['id' => 'a', 'type' => 'openregister.set-fields'], ['id' => 'b']],
+                'edges' => [['id' => 'e1', 'from' => 'a', 'to' => 'b']],
+            ]
+        );
+
+        $this->assertSame([], $this->deadEnds($report));
+
+    }//end testTypelessNodeIsNotDoubleReported()
+
+    /**
+     * A node with an outgoing edge is never a dead end, however many arrive.
+     *
+     * @return void
+     */
+    public function testConvergingNodeWithAnExitIsFine(): void
+    {
+        $report = $this->preflight(terminal: ['openregister.stop'])->inspect(
+            flow: [
+                'nodes' => [
+                    ['id' => 'a', 'type' => 'openregister.set-fields'],
+                    ['id' => 'b', 'type' => 'openregister.set-fields'],
+                    ['id' => 'join', 'type' => 'openregister.set-fields'],
+                    ['id' => 'end', 'type' => 'openregister.stop'],
+                ],
+                'edges' => [
+                    ['id' => 'e1', 'from' => 'a', 'to' => 'join'],
+                    ['id' => 'e2', 'from' => 'b', 'to' => 'join'],
+                    ['id' => 'e3', 'from' => 'join', 'to' => 'end'],
+                ],
+            ]
+        );
+
+        $this->assertSame([], $this->deadEnds($report));
+
+    }//end testConvergingNodeWithAnExitIsFine()
+
+    /**
+     * The refusal names every offending node, so the author can act on it.
+     *
+     * @return void
+     */
+    public function testRefusalMessageNamesTheNodes(): void
+    {
+        $one = new FlowDeadEnd(nodeIds: ['forgotten']);
+        $this->assertStringContainsString('"forgotten"', $one->getMessage());
+        $this->assertStringContainsString('node "forgotten" has', $one->getMessage());
+        $this->assertSame(['forgotten'], $one->getNodeIds());
+
+        $many = new FlowDeadEnd(nodeIds: ['a', 'b']);
+        $this->assertStringContainsString('"a", "b"', $many->getMessage());
+        $this->assertStringContainsString('have', $many->getMessage());
+
+    }//end testRefusalMessageNamesTheNodes()
+}//end class

--- a/tests/Unit/Service/Flow/FlowNodeConfigDialectTest.php
+++ b/tests/Unit/Service/Flow/FlowNodeConfigDialectTest.php
@@ -125,6 +125,10 @@ class FlowNodeConfigDialectTest extends TestCase
                         ],
                         'default' => 'skip-code-drop',
                     ],
+                    // The last node of the fixture ends it. Without this the
+                    // document is also a dead end, and a suite about config
+                    // DIALECT would be counting a connectivity warning too.
+                    'exit'   => true,
                 ],
             ],
             'edges' => [['id' => 'onwards', 'from' => 'derive', 'to' => 'code-contradiction']],
@@ -194,6 +198,7 @@ class FlowNodeConfigDialectTest extends TestCase
                     'id'     => 'derive',
                     'type'   => 'openregister.set-fields',
                     'config' => ['fields' => ['x' => 1]],
+                    'exit'   => true,
                 ],
             ],
             'edges' => [],
@@ -233,6 +238,11 @@ class FlowNodeConfigDialectTest extends TestCase
                         ],
                         'default' => 'skip-code-drop',
                     ],
+                    // This is the POSITIVE CONTROL, and it asserts the report is
+                    // EXACTLY empty — so the fixture has to be a complete
+                    // document, ending deliberately, not merely one with the
+                    // right config.
+                    'exit'   => true,
                 ],
             ],
             'edges' => [['id' => 'onwards', 'from' => 'derive', 'to' => 'code-contradiction']],
@@ -286,6 +296,7 @@ class FlowNodeConfigDialectTest extends TestCase
                         'id'     => 'call',
                         'type'   => 'openconnector.source-call',
                         'config' => ['method' => 'GET'],
+                        'exit'   => true,
                     ],
                 ],
                 'edges' => [],

--- a/tests/Unit/Service/Flow/FlowNodeConfigVocabularyTest.php
+++ b/tests/Unit/Service/Flow/FlowNodeConfigVocabularyTest.php
@@ -193,7 +193,12 @@ class FlowNodeConfigVocabularyTest extends TestCase
             // default id on the left would discard the caller's own id and
             // every "names the offending step" assertion would look for a step
             // that no longer exists by that name.
-            'nodes' => [($edge + ['id' => 'a'])],
+            // `exit` so a one-node fixture is a COMPLETE document, not a dead
+            // end. This suite is about a node's config vocabulary; without the
+            // flag every fixture would also collect a connectivity warning and
+            // each "exactly one finding" assertion would be counting two
+            // unrelated things.
+            'nodes' => [($edge + ['id' => 'a', 'exit' => true])],
             'edges' => [],
         ];
 

--- a/tests/Unit/Service/Flow/FlowNodePreflightRegressionTest.php
+++ b/tests/Unit/Service/Flow/FlowNodePreflightRegressionTest.php
@@ -67,7 +67,10 @@ class FlowNodePreflightRegressionTest extends TestCase
             'nodes' => [
                 ['id' => 'explode-findings', 'type' => 'openregister.explode'],
                 ['id' => 'actionable-only', 'type' => 'openregister.filter'],
-                ['id' => 'file-issue', 'type' => 'openconnector.source-call'],
+                // Filing the issue is where this flow ends. Saying so keeps the
+                // fixture a complete document, so the assertions below count
+                // only the registry findings they are about.
+                ['id' => 'file-issue', 'type' => 'openconnector.source-call', 'exit' => true],
             ],
             'edges' => [
                 [

--- a/tests/Unit/Service/Flow/FlowNodePreflightTest.php
+++ b/tests/Unit/Service/Flow/FlowNodePreflightTest.php
@@ -287,7 +287,12 @@ class FlowNodePreflightTest extends TestCase
         $report    = $preflight->inspect(
             flow: [
                 'name'  => 'migrated',
-                'nodes' => [['id' => 'scope', 'type' => 'openregister.route']],
+                // `exit` so the one-node fixture is a COMPLETE document. This
+                // asserts an EXACTLY empty report, and a lone node with no
+                // outgoing edge is a dead end however correct its step is —
+                // the connectivity warning would be right, and would make this
+                // positive control fail for a reason it is not about.
+                'nodes' => [['id' => 'scope', 'type' => 'openregister.route', 'exit' => true]],
                 'edges' => [],
             ]
         );


### PR DESCRIPTION
Closes the silent-success hole in the flow engine, and gives a flow a memory of its own last run.

## The defect

A node with no outgoing edge was a **silent success**. Its token arrived, the step ran, the engine found no enabled transition, the run stopped — and was recorded `COMPLETED`. Nothing failed, so nothing was logged, and the author saw a green run that had not done the work.

## Ending a path is now something a node says

Two ways, **OR-ed and never AND-ed**:

| | |
|---|---|
| `IFlowTerminalNode` | a marker interface on the TYPE, resolved via `FlowNodeRegistry::isTerminal()`, so a terminal step contributed by openconnector or hermiq needs no OpenRegister change. `StopNode` implements it. |
| `"exit": true` | on the node instance — for a sink whose step type is an ordinary action, which is what every migrated flow has, because that *was* a legitimate end of a path under the old place-and-edge reading. |

Requiring both would make every migrated flow depend on a registry the migration cannot see.

A marker interface rather than a method on `IFlowNode`, for the reason `IFlowNodeConfigKeys` already documents: implementations live in other repositories, and widening the interface fatals those apps on load.

## Warn on save, refuse on run

**Saving succeeds and warns.** A disconnected graph is the normal state of one being authored; refusing to store it would force the author to build the graph in an order that is never disconnected, which no editor can require.

**Running is refused**, and the guard sits in `FlowRunService::queue()` — the one choke point every dispatch path passes through: manual, trigger, schedule, MCP, the workflow-engine operation, and a sub-flow call. Guarding `FlowService::run()` alone would have left cron-fired flows unguarded, and those are most of them.

On refusal no `FlowRun` is created, so the verdict is written onto the **flow** (`status` / `statusMessage`, naming the nodes). That is exactly what makes a refused flow distinguishable from one nobody has triggered — there is no run to read. An accepted run clears a stale `error` back to `ok`.

The schedule sweep catches the refusal **per flow**: it iterates every due flow, so letting it propagate would abort the sweep and stop every later flow from firing — one broken definition silently disabling the rest, presenting as "cron stopped working" rather than as a fault in a named flow.

A **typeless** node is deliberately not reported here — `FlowDefinitionBuilder` already refuses it by name, and two findings on one node for one defect is how a warning list becomes noise.

## Last run

Six nullable columns, **no backfill**. A null `lastRunAt` means "has never run"; a value derived from run history would assert a history the column did not record. Written only when a run reaches a terminal state, so the list answers "how did it last go?" rather than "it hasn't finished".

## Also

Adds the canonical `openspec/specs/flow-engine/spec.md`. It did not exist — the flow-engine spec lived only inside `changes/` — so `@spec` had nowhere canonical to point.

## What is NOT done

Stated in `tasks.md` rather than quietly skipped: the schedule/trigger dispatch wiring and the last-run write-back are **not yet pinned by tests**. Both need `FlowRunService` built with a mocked container, mapper and preflight. The connectivity verdict they consume *is* covered, each assertion with a positive control proving the same graph goes quiet once wired.

## Verification honesty

The unit suite could not be run locally. Once `lib/base.php` loads, Nextcloud's autoloader resolves `OCA\OpenRegister\*` to the **installed** app, not the working copy — measured with `ReflectionClass::getFileName()`. CI's "copy the app out of /var/www/html" step does not prevent this; CI is immune only because it deploys the code under test first, making both copies identical. Run that recipe locally against an older deployment and the suite reports on the deployed app — a green that says nothing. **CI is the authoritative gate for this change.**

## Breaking

A flow with a dead-ended node is now refused at run time instead of completing silently. Mark deliberate sinks `"exit": true`, or give them a terminal step type.