### PR TITLE
fix(license): delete the Nextcloud GmbH SPDX residue instead of relabelling it

### DIFF
--- a/lib/Db/Webhook.php
+++ b/lib/Db/Webhook.php
@@ -1,9 +1,6 @@
 <?php
 
 /**
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: EUPL-1.2
- *
  * @author    Conduction Development Team <dev@conduction.nl>
  * @copyright 2026 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12

--- a/lib/Migration/Version002003000Date20251013000000.php
+++ b/lib/Migration/Version002003000Date20251013000000.php
@@ -1,9 +1,6 @@
 <?php
 
 /**
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: EUPL-1.2
- *
  * @category Migration
  * @package  OCA\OpenRegister\Migration
  *

--- a/lib/Migration/Version1Date20240924200009.php
+++ b/lib/Migration/Version1Date20240924200009.php
@@ -17,11 +17,6 @@
 
 declare(strict_types=1);
 
-/*
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: EUPL-1.2
- */
-
 namespace OCA\OpenRegister\Migration;
 
 use Closure;

--- a/lib/Migration/Version1Date20241019205009.php
+++ b/lib/Migration/Version1Date20241019205009.php
@@ -17,12 +17,6 @@
 
 declare(strict_types=1);
 
-/*
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: EUPL-1.2
- */
-
-
 namespace OCA\OpenRegister\Migration;
 
 use Closure;

--- a/lib/Migration/Version1Date20241020231700.php
+++ b/lib/Migration/Version1Date20241020231700.php
@@ -17,12 +17,6 @@
 
 declare(strict_types=1);
 
-/*
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: EUPL-1.2
- */
-
-
 namespace OCA\OpenRegister\Migration;
 
 use Closure;

--- a/lib/Migration/Version1Date20241022135300.php
+++ b/lib/Migration/Version1Date20241022135300.php
@@ -17,12 +17,6 @@
 
 declare(strict_types=1);
 
-/*
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: EUPL-1.2
- */
-
-
 namespace OCA\OpenRegister\Migration;
 
 use Closure;

--- a/lib/Migration/Version1Date20241030131427.php
+++ b/lib/Migration/Version1Date20241030131427.php
@@ -17,12 +17,6 @@
 
 declare(strict_types=1);
 
-/*
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: EUPL-1.2
- */
-
-
 namespace OCA\OpenRegister\Migration;
 
 use Closure;

--- a/lib/Migration/Version1Date20241128221000.php
+++ b/lib/Migration/Version1Date20241128221000.php
@@ -17,12 +17,6 @@
 
 declare(strict_types=1);
 
-/*
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: EUPL-1.2
- */
-
-
 namespace OCA\OpenRegister\Migration;
 
 use Closure;

--- a/lib/Migration/Version1Date20241216094112.php
+++ b/lib/Migration/Version1Date20241216094112.php
@@ -17,12 +17,6 @@
 
 declare(strict_types=1);
 
-/*
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: EUPL-1.2
- */
-
-
 namespace OCA\OpenRegister\Migration;
 
 use Closure;

--- a/lib/Migration/Version1Date20241227153853.php
+++ b/lib/Migration/Version1Date20241227153853.php
@@ -17,12 +17,6 @@
 
 declare(strict_types=1);
 
-/*
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: EUPL-1.2
- */
-
-
 namespace OCA\OpenRegister\Migration;
 
 use Closure;

--- a/lib/Migration/Version1Date20250115230511.php
+++ b/lib/Migration/Version1Date20250115230511.php
@@ -17,12 +17,6 @@
 
 declare(strict_types=1);
 
-/*
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: EUPL-1.2
- */
-
-
 namespace OCA\OpenRegister\Migration;
 
 use Closure;

--- a/tests/Unit/Controller/SettingsControllerTest.php
+++ b/tests/Unit/Controller/SettingsControllerTest.php
@@ -3,8 +3,16 @@
 declare(strict_types=1);
 
 /**
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: EUPL-1.2
+ * SettingsController Unit Test
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
  */
 
 namespace OCA\OpenRegister\Tests\Unit\Controller;


### PR DESCRIPTION
## What this fixes

PR #2350 (mine) flipped `SPDX-License-Identifier: AGPL-3.0-or-later` → `EUPL-1.2` in 12 files whose **adjacent line** reads:

```
 * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
 * SPDX-License-Identifier: EUPL-1.2      <- what #2350 made it say
```

That made `development` assert **EUPL-1.2 over Nextcloud GmbH's copyright** — a false licence claim over a third party's work, and strictly worse than the AGPL contradiction it replaced. I should have treated the copyright line as a stop sign instead of editing past it.

This PR **deletes the residue block** rather than relabelling it. No licence value is changed here; the false claim is removed.

## Evidence that the block is app-template residue, not a real Nextcloud GmbH copyright

1. **It occurs in exactly 12 source files.** The only other `Nextcloud GmbH` strings in the repo are dependency `author` fields inside `bom-npm-test.cdx.json` — an SBOM of genuine Nextcloud npm packages, correctly left untouched.
2. **11 of the 12 already carry their own Conduction copyright** in the same file (`@copyright 2024 Conduction B.V.`, `@copyright 2026 Conduction B.V.`), directly contradicting the SPDX line.
3. **No Nextcloud GmbH author appears anywhere in the 12 files' history.** `git log --follow` across all of them yields only Conduction people — Barry Brands, Conduction Development Team, Remko, Robert Zondervan, Ruben van der Linde, Thijn — plus the CI bot.
4. **The repo's other ~270 PHP files carry Conduction copyright only, with no SPDX pair at all** — this block is exactly the `nextcloud/app-template` scaffold that the rest of the codebase already shed.

## What changed per file

- 9 × `lib/Migration/Version1Date*.php` — a standalone `/* SPDX… */` comment sitting below an existing full Conduction PHPDoc header; the stray comment is deleted.
- `lib/Db/Webhook.php`, `lib/Migration/Version002003000Date20251013000000.php` — the SPDX pair were the first two lines *inside* the main PHPDoc, which already carries `@author` / `@copyright` / `@license`; those two lines are removed and the rest of the docblock is untouched.
- `tests/Unit/Controller/SettingsControllerTest.php` — this one had **no other licence header**, so deleting outright would have left it unlicensed. It gains the repo's standard test-file PHPDoc (matching `tests/Unit/Activity/FilterTest.php`) instead.

## Verification

- `Nextcloud GmbH` occurrences remaining under `lib/ src/ tests/ appinfo/`: **0**
- All 12 files still carry `@license EUPL-1.2` **and** `@copyright`: confirmed file by file
- `php -l` clean on all 12
- 12 files changed, deletions only apart from the one test-file header

A fleet sweep of the other 15 apps found no remaining `Nextcloud GmbH` copyright line in any app's source, so openregister was the only repo affected.
