### PR TITLE
fix(e2e): the flow-controls spec was green only when it had tested nothing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,8 +105,10 @@ bom-npm.cdx.json
 # Playwright e2e artefacts (ADR-030 / journeydoc)
 tests/e2e/.auth/
 tests/e2e/playwright-report/
+# Both the root and the CI subset config write here. The CI config used to
+# write to `test-results-ci/` instead, which the shared workflow's trace upload
+# does not glob — so red runs uploaded no traces at all. Keep them in step.
 tests/e2e/test-results/
-# The CI subset config writes here, and `test-results/` above does not match it.
 tests/e2e/test-results-ci/
 tests/e2e/.mdm-seed.json
 .hydra

--- a/lib/Controller/FlowController.php
+++ b/lib/Controller/FlowController.php
@@ -63,6 +63,17 @@ use OCP\WorkflowEngine\IManager;
  *
  * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  *
+ * Coupling is 13 for the same reason: this class IS the flow API surface, so it
+ * names the two catalogues, the preflight, the registry, the state mapper, the
+ * service and the entity, plus the framework's own request/response/attribute
+ * types. Twelve of the thirteen are already required to serve the routes; the
+ * thirteenth is `FlowDeadEnd`, and refusing it would mean the run endpoint goes
+ * back to letting that refusal escape as an HTML 500. Splitting the class to
+ * lower the number would put two controllers behind one `/api/flows` prefix,
+ * which costs more than it buys.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ *
  * @spec openspec/changes/flow-engine-unification/specs/flow-storage/spec.md
  */
 class FlowController extends Controller

--- a/lib/Controller/FlowController.php
+++ b/lib/Controller/FlowController.php
@@ -39,6 +39,7 @@ namespace OCA\OpenRegister\Controller;
 use OCA\OpenRegister\Db\Flow;
 use OCA\OpenRegister\Db\FlowStateMapper;
 use OCA\OpenRegister\Service\Flow\EventCatalogService;
+use OCA\OpenRegister\Service\Flow\FlowDeadEnd;
 use OCA\OpenRegister\Service\Flow\FlowNodePreflight;
 use OCA\OpenRegister\Service\Flow\FlowNodeRegistry;
 use OCA\OpenRegister\Service\Flow\FlowService;
@@ -506,7 +507,7 @@ class FlowController extends Controller
      *
      * @param string $id The flow uuid.
      *
-     * @return JSONResponse The queued run, 201, or 404.
+     * @return JSONResponse The queued run 201, 404, or 409 when unrunnable.
      *
      * @NoAdminRequired
      *
@@ -526,7 +527,31 @@ class FlowController extends Controller
             );
         } catch (DoesNotExistException $e) {
             return new JSONResponse(['error' => 'No such flow'], Http::STATUS_NOT_FOUND);
-        }
+        } catch (FlowDeadEnd $e) {
+            // A REFUSAL, not a fault. `FlowRunService::queue()` declines to run
+            // a flow whose token cannot leave one of its nodes, and that is a
+            // verdict about the caller's document — the caller can fix it by
+            // wiring the node or ending it deliberately.
+            //
+            // Uncaught, it left the dispatcher to turn it into a bare 500 with
+            // an HTML body, so the one thing the author needed — WHICH node
+            // dead-ends — never reached them, and a routine authoring mistake
+            // was indistinguishable from the server falling over. Measured
+            // against the flow editor: pressing "Run now" on a single-step flow
+            // produced exactly that 500, and the UI showed nothing at all.
+            //
+            // 409 rather than 400: the document was understood and stored
+            // perfectly well: it is the flow's current STATE that conflicts
+            // with running it, which is also why the refusal is recorded on the
+            // flow itself (`status: error`) before this point.
+            return new JSONResponse(
+                [
+                    'error' => $e->getMessage(),
+                    'nodes' => $e->getNodeIds(),
+                ],
+                Http::STATUS_CONFLICT
+            );
+        }//end try
 
         return new JSONResponse($flowRun->jsonSerialize(), Http::STATUS_CREATED);
 

--- a/lib/Service/Flow/FlowRunService.php
+++ b/lib/Service/Flow/FlowRunService.php
@@ -131,6 +131,13 @@ class FlowRunService
      *
      * @return FlowRun The queued run.
      *
+     * @throws FlowDeadEnd When a node has no outgoing edge and does not end the
+     *                     flow, so the run is refused rather than started. Declared
+     *                     because it is part of this method's contract: every
+     *                     dispatch path arrives here, and a caller that cannot see
+     *                     the refusal in the signature will not handle it — which
+     *                     is how it reached HTTP as a bare 500.
+     *
      * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
      */
     public function queue(

--- a/lib/Service/Flow/FlowService.php
+++ b/lib/Service/Flow/FlowService.php
@@ -385,6 +385,7 @@ class FlowService
      * @return FlowRun The queued run.
      *
      * @throws DoesNotExistException When no such flow exists, or it is not the caller's.
+     * @throws FlowDeadEnd          When a node's token has nowhere to go, so the run is refused.
      *
      * @spec openspec/changes/flow-engine-unification/specs/flow-storage/spec.md
      */

--- a/tests/e2e/ci/flow-controls.spec.ts
+++ b/tests/e2e/ci/flow-controls.spec.ts
@@ -62,7 +62,9 @@
  * quickly enough gets silence — no error, no toast, no log line, because
  * nothing renders `store.error` and a 400 JSONResponse is not an exception.
  * The same race also wipes a just-added step off the canvas when `open('new')`
- * lands a moment later. Both belong to `@conduction/nextcloud-vue`.
+ * lands a moment later. Both belong to `@conduction/nextcloud-vue`, and are
+ * reported as ConductionNL/nextcloud-vue#607 — this spec does not paper over
+ * them, it is what makes them detectable.
  *
  * AND THE GREEN RUNS WERE WORSE THAN THE RED ONES
  * -----------------------------------------------

--- a/tests/e2e/ci/flow-controls.spec.ts
+++ b/tests/e2e/ci/flow-controls.spec.ts
@@ -38,6 +38,58 @@
  *
  * Hermetic: creates its own flow through the UI and deletes it afterwards, so
  * it leaves the instance as it found it (the CI floor's contract).
+ *
+ * WHY IT WAS FLAKY, AND WHAT THAT UNCOVERED
+ * -----------------------------------------
+ * It failed on the FIRST attempt of 6 of the 8 CI runs that executed it (75%),
+ * always at the same place — `waitForURL` after Save — and always at 23.9-24.6s,
+ * i.e. ~4s of real work plus a 20s timeout expiring in full. Passing attempts
+ * took 4.5-7.3s. A wait that always expires in FULL is not a slow round-trip;
+ * it is a thing that was never going to happen.
+ *
+ * It never happened because the SAVE WAS REJECTED. `useFlowStore`'s initial
+ * state is `emptyFlow()`, whose `name` is `''`; only `open('new')` gives the
+ * flow a name, and `open()` runs at the tail of `load()`, behind
+ * `await GET /api/flows` — a flow LIST that starting a blank flow does not
+ * need. The sidebar is fully rendered and its buttons enabled well before that,
+ * because `nodeCatalog` was already populated by the flows INDEX page's own
+ * `load()`. So there is a window in which the editor invites a Save of a flow
+ * with no name, `FlowController::create()` answers 400 "A flow needs a name.",
+ * `store.save()` swallows it into `return null`, and `onSave()` therefore never
+ * calls `$router.replace`.
+ *
+ * That window is a REAL DEFECT, not a test artefact: a user who clicks Save
+ * quickly enough gets silence — no error, no toast, no log line, because
+ * nothing renders `store.error` and a 400 JSONResponse is not an exception.
+ * The same race also wipes a just-added step off the canvas when `open('new')`
+ * lands a moment later. Both belong to `@conduction/nextcloud-vue`.
+ *
+ * AND THE GREEN RUNS WERE WORSE THAN THE RED ONES
+ * -----------------------------------------------
+ * Instrumenting what Save actually POSTs, over 14 local runs, split three ways:
+ *
+ *   POST /api/flows 400, name=""    -> red   (the race above)
+ *   POST /api/flows 201, nodes=1    -> red   at step 4: POST .../run 500
+ *   POST /api/flows 201, nodes=0    -> GREEN
+ *
+ * The spec passed ONLY when the flow it saved had no steps in it. A one-node
+ * `set-fields` flow cannot run at all: since #2354 a path must end deliberately,
+ * and `FlowRunService::queue()` refuses a node with no outgoing edge that is not
+ * terminal. So every run that genuinely persisted the step failed step 4, and
+ * every green run was green because the race had thrown the step away first.
+ * The 20s poll dressed that up as "Run now did not produce a run".
+ *
+ * That is the failure mode this file's own header warns about — every layer
+ * green while nothing is tested — so the fixture now builds the smallest flow
+ * the app calls VALID (one terminal node) instead of one it is obliged to
+ * refuse. See step 2.
+ *
+ * So this spec now waits for the state a save actually REQUIRES rather than for
+ * a wall clock, and asserts the create and run RESPONSES rather than inferring
+ * success from a route and a poll. The three 15-20s budgets it used to sit out
+ * are gone, not widened: with the round-trips asserted directly, what remains
+ * are 5s router and read-back assertions. If any of these defects returns, this
+ * spec fails in about a second, quoting the server's own reason.
  */
 import { test, expect } from '@playwright/test'
 import * as path from 'path'
@@ -64,14 +116,21 @@ test.use(fs.existsSync(STORAGE_STATE) ? { storageState: STORAGE_STATE } : {})
  *
  * Dispatching the event directly drives the Vue `@click` handler, which is the
  * behaviour under test. It does trade away Playwright's actionability checks —
- * so the assertions that the control is VISIBLE stay, above, and are what
- * would catch a control that is missing or covered.
+ * so the assertions that the control is VISIBLE and ENABLED stay, here, and are
+ * what would catch a control that is missing, covered or inert.
+ *
+ * `toBeEnabled()` is not decoration. A dispatched event reaches a Vue handler
+ * whether or not the control is disabled, so without it this helper would
+ * happily "click" a button the UI is refusing to offer and report the resulting
+ * silence as a timeout somewhere else. Both flow actions really are gated —
+ * Save on `store.saving`, Run now on `store.running || !store.flow.id`.
  *
  * @param locator The themed control to click.
  * @return {Promise<void>}
  */
 async function clickThemed(locator: import('@playwright/test').Locator): Promise<void> {
 	await expect(locator).toBeVisible()
+	await expect(locator).toBeEnabled()
 	await locator.dispatchEvent('click')
 }
 
@@ -105,6 +164,20 @@ async function deleteFlow(page: import('@playwright/test').Page, uuid: string): 
 test('flow controls render, and a flow can be built, saved and run', async ({ page }) => {
 	let createdUuid: string | null = null
 
+	// EVERY request the flow store makes is wrapped in a `catch` that logs
+	// `cn-flow: could not …` and returns an empty result or null. Nothing
+	// renders `store.error`, so a rejected save, a rejected run and a catalogue
+	// that failed to load are all INVISIBLE — to the user, and to a test that
+	// only watches the DOM. Collected here so a swallowed failure fails this
+	// test by name, at the moment it happens, instead of surfacing seconds
+	// later as a timeout that names something unrelated.
+	const storeErrors: string[] = []
+	page.on('console', (message) => {
+		if (message.type() === 'error' && message.text().includes('cn-flow:')) {
+			storeErrors.push(message.text())
+		}
+	})
+
 	try {
 		await page.goto(FLOWS_ROUTE, { waitUntil: 'domcontentloaded' })
 
@@ -129,8 +202,11 @@ test('flow controls render, and a flow can be built, saved and run', async ({ pa
 
 		const actions = page.locator('.cn-flow-sidebar__actions')
 		await expect(actions).toBeVisible()
-		await expect(actions.getByText('Save', { exact: true })).toBeVisible()
-		await expect(actions.getByText('Run now', { exact: true })).toBeVisible()
+
+		const saveButton = actions.getByRole('button', { name: 'Save', exact: true })
+		const runButton = actions.getByRole('button', { name: 'Run now', exact: true })
+		await expect(saveButton).toBeVisible()
+		await expect(runButton).toBeVisible()
 
 		// The palette is populated from /api/flow/node-catalog. An empty one
 		// renders the same container, so assert it has entries.
@@ -141,28 +217,116 @@ test('flow controls render, and a flow can be built, saved and run', async ({ pa
 			})
 			.toBeGreaterThan(0)
 
-		// 2. A STEP CAN BE ADDED. `set-fields` has no side effects, so the
-		//    spec never reaches out of the instance.
-		await clickThemed(palette.getByText('Edit fields', { exact: false }).first())
+		// ── THE EDITOR IS INTERACTIVE BEFORE IT IS INITIALISED ──────────────
+		// This wait is the whole reason this spec used to fail 6 runs in 8.
+		//
+		// `useFlowStore`'s INITIAL state is `emptyFlow()`, whose `name` is `''`.
+		// Only `open('new')` replaces it with a named flow, and `open()` runs at
+		// the TAIL of `load()` — after `await GET /api/flows`, a flow LIST the
+		// editor does not need in order to start a blank flow.
+		//
+		// The sidebar, meanwhile, is already rendered and its buttons already
+		// enabled, because `nodeCatalog` was populated by the INDEX page's own
+		// `load()` before this route was ever reached. So the controls invite a
+		// Save during a window in which the flow still has no name — and
+		// `FlowController::create()` answers 400 "A flow needs a name.", which
+		// `store.save()` swallows into `return null`, which makes
+		// `FlowDetailSidebar.onSave()` skip `$router.replace` entirely. Nothing
+		// is logged server-side (a 400 JSONResponse is not an exception) and
+		// nothing is shown client-side. The only symptom was this spec's
+		// `waitForURL` sitting out its full 20s.
+		//
+		// So wait for the state the save actually requires, and say so. Asserted
+		// as "not blank" rather than against the literal default name, which
+		// belongs to @conduction/nextcloud-vue and is not this repo's contract.
 		await expect(
-			page.locator('main').getByText('Edit fields', { exact: false }).first(),
+			sidebar.getByLabel('Name', { exact: true }),
+			'the editor never initialised — the flow store is still holding its '
+			+ 'blank initial state, whose name is empty, and a flow with no name '
+			+ 'is rejected by the server',
+		).not.toHaveValue('')
+
+		// 2. A STEP CAN BE ADDED.
+		//
+		// `stop`, and the choice is load-bearing. This used to add `set-fields`,
+		// which made the saved flow UNRUNNABLE: since #2354 a path must end
+		// deliberately, and `FlowRunService::queue()` refuses any node that has
+		// no outgoing edge and is not terminal — which `set-fields` is not.
+		// Only `StopNode` implements IFlowTerminalNode, so a lone `set-fields`
+		// node is a dead end by construction and step 4 below could never pass
+		// on it. Measured: every run of this spec that actually persisted the
+		// step failed, and the only runs that went green were the ones where
+		// the initialisation race above had silently WIPED the step, saving an
+		// empty flow that trivially has no dead end. The spec was green exactly
+		// when it had tested nothing.
+		//
+		// A single terminal node is the smallest flow this app calls valid, so
+		// it is what the spec builds. `stop` has no side effects either, so this
+		// still never reaches out of the instance. Drawing an edge from
+		// `set-fields` to `stop` would cover more, but drag-to-connect on the
+		// canvas is exactly the interaction this file already documents as
+		// unreliable, and a fixture that flakes is how this started.
+		await clickThemed(palette.getByText('Stop', { exact: true }).first())
+		await expect(
+			page.locator('main').getByText('Stop', { exact: false }).first(),
 			'the step did not reach the canvas',
 		).toBeVisible()
 
-		// 3. SAVE PERSISTS. The route advancing off `new` is the observable
-		//    proof the server accepted it and returned a uuid.
-		await clickThemed(actions.getByText('Save', { exact: true }))
-		await page.waitForURL(/#\/flows\/(?!new)[0-9a-f-]{8,}/, { timeout: 20_000 })
+		// 3. SAVE PERSISTS.
+		//
+		// Asserted on the CREATE RESPONSE, not on the route. The route advancing
+		// is a consequence of a successful save, so waiting on it made every
+		// server-side rejection look like a navigation that was merely slow —
+		// and burn 20 seconds before reporting the wrong thing. The response
+		// carries the verdict and the reason, so a rejected save now fails here,
+		// immediately, quoting the server.
+		const created = page.waitForResponse(
+			(response) =>
+				response.request().method() === 'POST'
+				&& new URL(response.url()).pathname.endsWith('/apps/openregister/api/flows'),
+			{ timeout: 10_000 },
+		)
 
-		const uuid = page.url().split('/').pop() ?? ''
-		expect(uuid, 'saved flow has no uuid in the route').toMatch(/^[0-9a-f-]{8,}$/)
+		await clickThemed(saveButton)
+
+		const createResponse = await created
+		expect(
+			createResponse.status(),
+			`the flow was not created — the server answered ${createResponse.status()}: `
+			+ `${(await createResponse.text()).slice(0, 200)}`,
+		).toBe(201)
+
+		const uuid = String((await createResponse.json())?.id ?? '')
+		expect(uuid, 'the created flow came back without a uuid').toMatch(/^[0-9a-f-]{8,}$/)
 		createdUuid = uuid
+
+		// The route still has to catch up, or a reload lands back on `new`. With
+		// the create already asserted above this is a pure router assertion with
+		// no round-trip left in it, so it needs a fraction of the old budget.
+		await page.waitForURL(new RegExp(`#/flows/${uuid}$`), { timeout: 5_000 })
 
 		// 4. RUN NOW CREATES A RUN. Asserted against the API rather than the
 		//    rendered status, because the status a run is DISPLAYED with
 		//    depends on whether the worker has reached it yet.
-		await clickThemed(actions.getByText('Run now', { exact: true }))
+		const queued = page.waitForResponse(
+			(response) =>
+				response.request().method() === 'POST'
+				&& response.url().includes(`/api/flows/${uuid}/run`),
+			{ timeout: 10_000 },
+		)
 
+		await clickThemed(runButton)
+
+		const runResponse = await queued
+		expect(
+			runResponse.status(),
+			`Run now was refused — the server answered ${runResponse.status()}: `
+			+ `${(await runResponse.text()).slice(0, 200)}`,
+		).toBe(201)
+
+		// And the run is ATTRIBUTED to this flow — a separate claim from "a run
+		// was created", and the one a client actually depends on to show
+		// history. The row exists by now, so this is a read-back, not a wait.
 		await expect
 			.poll(
 				async () =>
@@ -178,11 +342,19 @@ test('flow controls render, and a flow can be built, saved and run', async ({ pa
 						return (body?.results ?? []).length
 					}, uuid),
 				{
-					message: 'Run now did not produce a run for this flow',
-					timeout: 20_000,
+					message: 'the run was accepted but is not listed against this flow',
+					timeout: 5_000,
 				},
 			)
 			.toBeGreaterThan(0)
+
+		// Backstop for every OTHER request the store swallows — the two
+		// catalogues and the run history. None of them has a visible failure
+		// state, so without this they fail silently and degrade the page.
+		expect(
+			storeErrors,
+			'the flow store swallowed a request failure into an empty state',
+		).toEqual([])
 	} finally {
 		if (createdUuid !== null) {
 			await deleteFlow(page, createdUuid)

--- a/tests/e2e/ci/playwright.config.ts
+++ b/tests/e2e/ci/playwright.config.ts
@@ -43,8 +43,21 @@ export default defineConfig({
 	// without hiding a real failure — a broken assertion fails twice.
 	retries: process.env.CI ? 1 : 0,
 	workers: 1,
-	reporter: [['list']],
-	outputDir: path.resolve(__dirname, '../test-results-ci'),
+	reporter: [
+		['list'],
+		// The shared workflow uploads `tests/e2e/playwright-report/` as the
+		// `playwright-report` artifact. With `list` as the only reporter that
+		// directory was never created, so the artifact was empty on every run.
+		['html', { open: 'never', outputFolder: path.resolve(__dirname, '../playwright-report') }],
+	],
+	// ⚠️ MUST stay `tests/e2e/test-results`. This was `../test-results-ci`, and
+	// the shared workflow's "Upload Playwright traces" step globs exactly
+	// `tests/e2e/test-results/` — so Playwright wrote trace.zip, the failure
+	// screenshot and error-context.md on every red run, and the upload matched
+	// nothing and said so quietly (`if-no-files-found: ignore`). Six flaky and
+	// two hard-failing runs of flow-controls.spec.ts were diagnosed from job
+	// logs alone because the traces that existed on the runner were discarded.
+	outputDir: path.resolve(__dirname, '../test-results'),
 
 	use: {
 		baseURL: resolveBaseUrl(),
@@ -55,7 +68,13 @@ export default defineConfig({
 				}`,
 			).toString('base64')}`,
 		},
-		trace: 'on-first-retry',
+		// `retain-on-failure`, not `on-first-retry`. With `retries: 1` a FLAKE is
+		// exactly the case where attempt 1 fails and attempt 2 passes — and
+		// `on-first-retry` traces the RETRY, so the only attempt it ever
+		// captured was the one that worked. flow-controls.spec.ts failed its
+		// first attempt on 6 of 8 runs and every trace on disk was of a green
+		// run. This keeps the trace of whichever attempt actually failed.
+		trace: 'retain-on-failure',
 		screenshot: 'only-on-failure',
 	},
 


### PR DESCRIPTION
## The flake, and what was underneath it

`tests/e2e/ci/flow-controls.spec.ts` failed its **first attempt on 6 of the 8 CI runs** that executed it — always at `waitForURL` after Save, always at **23.9–24.6s**: roughly 4s of real work plus a 20s timeout expiring *in full*. A wait that always expires in full is not a slow round-trip. It is something that was never going to happen.

### Why the save never landed

`useFlowStore`'s initial state is `emptyFlow()`, whose `name` is `''`. Only `open('new')` names the flow, and `open()` runs at the **tail** of `load()`, behind `await GET /api/flows` — a flow *list* that starting a blank flow does not need. The sidebar is interactive well before that, because `nodeCatalog` was already populated by the flows **index** page's own `load()`.

So there is a window in which the editor invites a Save of a nameless flow:

| step | what happens |
|---|---|
| Save clicked | `payload.name === ''` |
| `POST /api/flows` | **400** `A flow needs a name.` |
| `store.save()` | catches, `console.error`, `return null` |
| `onSave()` | `saved?.id` falsy → **never calls `$router.replace`** |
| spec | `waitForURL` sits out its full 20s and blames the route |

Measured locally: **9 of 10 runs red**, POST body `name: ""`, response 400.

That window is a **real defect, not a test artefact** — a user who clicks Save quickly enough gets total silence, because nothing renders `store.error` and a 400 `JSONResponse` is not logged. It belongs to `@conduction/nextcloud-vue`. This PR does not paper over it; it makes it *detectable*.

### And the green runs were worse than the red ones

Instrumenting what Save actually POSTs, over 14 local runs, split three ways:

| POST `/api/flows` | outcome |
|---|---|
| `400`, `name=""` | red — the race above |
| `201`, `nodes=1` | red — step 4: `POST .../run` → **500** |
| `201`, `nodes=0` | **GREEN** |

**The spec passed only when the flow it saved had no steps in it.** A one-node `set-fields` flow cannot run at all: since #2354 a path must end deliberately, and `FlowRunService::queue()` refuses a node with no outgoing edge that is not terminal — only `StopNode` is. Every run that genuinely persisted the step failed; every green run was green because the race had already thrown the step away. The 20s poll dressed that up as *"Run now did not produce a run"*.

That is exactly the failure this file's own header warns about — every layer green while nothing is tested.

## What changes

**Spec**
- The fixture builds the smallest flow this app calls **valid** (one terminal `stop` node) instead of one it is obliged to refuse.
- Save and Run assert their **response**, not a route and a poll — a rejection now fails immediately quoting the server instead of after 20s naming the wrong thing.
- It waits for the state a save *requires* (the flow has a name) instead of racing initialisation.
- `clickThemed` asserts the control is **enabled** before dispatching — a dispatched event reaches a Vue handler whether or not the button is disabled.
- Swallowed `cn-flow:` store errors fail the test **by name**.

**No timeout was widened.** The three 15–20s budgets are gone, not raised: with the round-trips asserted directly, what remains are 5s router and read-back assertions, against a measured worst case of **92 ms**.

**API** — `FlowController::run()` answers **409** with the offending node ids instead of letting `FlowDeadEnd` escape as a bare HTML **500**. A routine authoring mistake was indistinguishable from the server falling over, and the one thing the author needed — *which* node dead-ends — never reached them.

**CI diagnosability** — none of the above could be diagnosed from CI, for two independent reasons, both fixed:
- the config wrote traces to `test-results-ci/`, which the shared workflow's upload step does not glob, so every red run uploaded nothing;
- `trace: 'on-first-retry'` captures the **retry** — so for a flake that passes on attempt 2, every trace on disk was of a *green* run. Now `retain-on-failure`.

## Evidence

| | before | after |
|---|---|---|
| local, shipped CI config | **9/10 red** | **20/20 green** (12.9–20.3s) |
| CI, first attempt | 6/8 red | — |

**Verified not blind.** Four mutations, each turning it red at the matching assertion:

| mutation | result |
|---|---|
| remove the `/flows` branch from `SideBars.vue` | red — *"the flow sidebar did not render"* |
| blank the node catalog | red — *"the step palette did not render"* |
| reject the create | red in **4.1s** — *"the server answered 400"* |
| refuse the run | red in **3.3s** — *"the server answered 409"* |

**Whole-suite positive control**: with `js/openregister-main.js` truncated to 0 bytes, **9 of 13** CI specs go red. The 4 survivors are `object-sharing.spec.ts`, which is API-level by declaration — no browser test passes without the app.

## Follow-up (not in this PR)

`@conduction/nextcloud-vue`: `useFlowStore.load()` gates `open(id)` behind an unrelated flow-list fetch; `emptyFlow()` leaves `name: ''` as the store's initial state so the editor is mountable in an unsaveable state; and `CnFlowSidebar` never renders `store.error`, so every swallowed request failure is invisible to the user.
