### PR TITLE
chore(deps): nextcloud-vue 2.2.0-vue3.6 — the flow editor stops losing saves

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
-        "@conduction/nextcloud-vue": "2.2.0-vue3.5",
+        "@conduction/nextcloud-vue": "2.2.0-vue3.6",
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@nextcloud/auth": "^2.6.0",
@@ -2148,9 +2148,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.2.0-vue3.5",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.5.tgz",
-      "integrity": "sha512-EDb/AzTxayOyrkPEaNgsRX4btF8nXeWu9HDzOUSMrxQWU9zqZDkCoLn58Ilut1mRdzUXkX7cas80xgRsAxK/DQ==",
+      "version": "2.2.0-vue3.6",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.6.tgz",
+      "integrity": "sha512-OutxBnIIxlgEkkGkxy/kUQcJ4EtxEX3lQ27N1aUGW5sEYmvi8JaboqVnKfWcmmaoyqsJzy1IS4Jo3sEYe07K4w==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
-    "@conduction/nextcloud-vue": "2.2.0-vue3.5",
+    "@conduction/nextcloud-vue": "2.2.0-vue3.6",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@nextcloud/auth": "^2.6.0",


### PR DESCRIPTION
Carries ConductionNL/nextcloud-vue#608, closing nextcloud-vue#607.

## What was wrong

Pressing **Save** in the flow editor could do nothing at all, with no way to tell:

- `emptyFlow()` has `name: ''`, and only `open('new')` supplies the default — but `open()` ran behind `await GET /api/flows`, a flow *list* a blank flow does not need. The sidebar was already rendered and Save already enabled, so a save in that window posted `name: ""` and got **400 "A flow needs a name."**
- `store.error` was set on every refusal and **rendered nowhere**, so it looked identical to success. No server log line either — a 400 `JSONResponse` is not an exception.
- The late `open('new')` also reset the flow, **wiping a step already placed on the canvas**.

## Verified in the window itself

Clicking Save **120ms** after opening a blank flow — where a 400 was previously reproducible 9 times in 10:

```
POST /api/flows -> 201   name: "New flow"
route           -> #/flows/4b4b0a25-…
```

## The recurring npm trap

`vue` is pinned back to `^3.5.18` **by hand**, again. `npm install` rewrites it to `^3.5.0` to match the new package's own range, which contradicts the `overrides` entry — and CI's npm 10.8.2 refuses that outright:

```
npm error EOVERRIDE
Override for vue@^3.5.0 conflicts with direct dependency
```

Local npm 11 accepts it silently. `npx npm@10.8.2 ci --dry-run` is clean with the range restored.

This has now bitten twice on consecutive bumps of this one package. Worth automating; for now it is a hand check every time.