### PR TITLE
fix(security): CVE-2026-67434 — php_codesniffer OS command injection

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12474,16 +12474,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -12549,7 +12549,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "symfony/config",
@@ -13251,9 +13251,9 @@
     "platform": {
         "php": "^8.3"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.3"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
The **Security (composer)** job started failing on every branch today:

```
Advisory ID: PKSA-rdkp-vv9z-mjkg
CVE: CVE-2026-67434
Title: OS Command injection
Affected versions: <3.13.6|>=4.0.0,<4.0.2
Reported at: 2026-08-05T23:53:11+00:00
```

The lock held **3.13.5**. Nothing in any branch caused this — the advisory was published last night — and it affects `development` as much as anything else, which is why it is its own PR rather than a rider on an unrelated dependency bump.

## Change

`composer.json` already allowed the fix (`^3.9`), so only the lock moves: **3.13.5 → 3.13.6**. No constraint change, no other package touched (7 lines).

## Verification

`composer audit --locked` — the set CI installs from — no longer reports the CVE.

A plain `composer audit` still does *here*, because this checkout's `vendor/` is container-owned and still holds 3.13.5; the lock was updated with `--no-install`. CI runs `composer install` from the lock first, so it gets 3.13.6.

## Out of scope, deliberately

The audit also reports dompdf, guzzle and phpspreadsheet advisories that CI does not fail on. They predate today and are a separate decision — this PR does not widen to them.