### PR TITLE
fix(deps): php_codesniffer 3.13.6 — CVE-2026-67434 — plus 2 pre-existing phpcs errors

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12474,16 +12474,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -12549,7 +12549,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "symfony/config",

--- a/lib/Db/Webhook.php
+++ b/lib/Db/Webhook.php
@@ -1,6 +1,11 @@
 <?php
 
 /**
+ * OpenRegister Webhook
+ *
+ * This file contains the entity class for webhook subscriptions
+ * in the OpenRegister application.
+ *
  * @author    Conduction Development Team <dev@conduction.nl>
  * @copyright 2026 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12

--- a/lib/Migration/Version002003000Date20251013000000.php
+++ b/lib/Migration/Version002003000Date20251013000000.php
@@ -1,6 +1,10 @@
 <?php
 
 /**
+ * OpenRegister Migration Version002003000Date20251013000000
+ *
+ * This file contains the migration step for the OpenRegister application.
+ *
  * @category Migration
  * @package  OCA\OpenRegister\Migration
  *


### PR DESCRIPTION
## New advisory, fleet-wide

**squizlabs/php_codesniffer — CVE-2026-67434 / GHSA-hmqg-cxww-wqhq — OS command injection.** Reported **2026-08-05**. Affected: `<3.13.6 | >=4.0.0,<4.0.2`. All 16 Conduction repos checked were on **3.13.5**, so this is currently failing `Security (composer)` fleet-wide.

The advisory landed mid-session: `composer audit --locked` returned **zero** advisories for this repo about an hour before it returned this one.

## Also: two pre-existing phpcs errors

`development` was **already red** on phpcs before this PR:

- `lib/Db/Webhook.php`
- `lib/Migration/Version002003000Date20251013000000.php`

Both had a file docblock with no short description. Fixed here per the always-fix-pre-existing rule.

**These are not caused by the bump.** I ran an explicit A/B on the same tree:

| arm | phpcs | result |
|---|---|---|
| A | 3.13.5 | rc=1, 4 ERROR lines |
| B | 3.13.6 | rc=1, 4 ERROR lines — **byte-identical** after stripping ANSI codes |

Each arm's `--version` was asserted before running, so the arms genuinely differed. (My first comparison matched *nothing* in either arm — a 0-vs-0 "identical" that proved nothing — and was discarded.)

## Verification

- `composer audit --locked` → **"No security vulnerability advisories found"** (was 1).
- `vendor/bin/phpcs --version` → **3.13.6**.
- `composer phpcs` → **rc=1 before → rc=0 after**.
- `php -l` clean on both edited files.
- **Positive control**: a deliberately non-conforming file under `lib/` made phpcs exit **2** with **13 findings**, then was deleted.
- `config.platform.php` is `8.3`; the run above was on a host PHP where the vendor tree parses, so the rc=0 is a real pass and not a parse-error 255.