### PR TITLE
fix(contextchat): OCP\ContextChat is NC 33+, but this app supports NC 28+

### DIFF
--- a/lib/Command/ContextChatReindexCommand.php
+++ b/lib/Command/ContextChatReindexCommand.php
@@ -29,6 +29,7 @@ namespace OCA\OpenRegister\Command;
 use OCA\OpenRegister\ContextChat\ContentProvider;
 use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\SchemaMapper;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -45,16 +46,46 @@ class ContextChatReindexCommand extends Command
     /**
      * Wire collaborators.
      *
-     * @param ContentProvider $contentProvider Shared batch-submission path.
-     * @param RegisterMapper  $registerMapper  Register lookup mapper, for the `--register` option.
-     * @param SchemaMapper    $schemaMapper    Schema lookup mapper, for the `--schema` option.
+     * ⚠️ `ContentProvider` is resolved LAZILY, from the container, inside
+     * {@see self::execute()} — it is deliberately NOT a constructor parameter,
+     * and this is not a style choice.
+     *
+     * `OCP\ContextChat\IContentProvider` is core Nextcloud API, but only from
+     * **NC 33**: it is absent from `stable31` and `stable32`, both of which
+     * this app's `info.xml` claims to support (`min-version="28"`). Because
+     * {@see ContentProvider} declares `implements IContentProvider`, merely
+     * LOADING that class on an older server is fatal — a class header is
+     * resolved eagerly and no guard inside the class can prevent it.
+     *
+     * A constructor typehint is enough to trigger exactly that. Every command
+     * listed in `appinfo/info.xml` is resolved by
+     * `Console\Application::loadCommandsFromInfoXml()`, which reflects each
+     * constructor to build it — so with `ContentProvider` in the signature,
+     * EVERY `occ` invocation on NC 28-32 threw before running anything:
+     *
+     *     Error: Interface "OCP\ContextChat\IContentProvider" not found
+     *       at .../openregister/lib/ContextChat/ContentProvider.php:50
+     *       ReflectionClass::__construct  <- SimpleContainer::resolve
+     *       <- loadCommandsFromInfoXml <- console.php
+     *
+     * Observed in CI on NC 31.0.14.1 during `occ app:enable`. It is logged at
+     * `level 3` and the enable still reports success, which is why it survived:
+     * the failure is loud in the log and invisible in the exit code.
+     *
+     * `ContentProvider::class` below is compile-time — the compiler turns it
+     * into a plain string and never autoloads — so naming the class here is
+     * safe; only `get()`ing it is not, and that now happens at execute() time.
+     *
+     * @param ContainerInterface $container      Container, for the lazy ContentProvider resolve.
+     * @param RegisterMapper     $registerMapper Register lookup mapper, for the `--register` option.
+     * @param SchemaMapper       $schemaMapper   Schema lookup mapper, for the `--schema` option.
      *
      * @return void
      *
      * @spec openspec/specs/context-chat-provider/spec.md#requirement-initial-import-must-walk-opted-in-schemas-in-batches-and-must-be-re-runnable-via-occ
      */
     public function __construct(
-        private readonly ContentProvider $contentProvider,
+        private readonly ContainerInterface $container,
         private readonly RegisterMapper $registerMapper,
         private readonly SchemaMapper $schemaMapper
     ) {
@@ -89,6 +120,18 @@ class ContextChatReindexCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        // See the constructor: OCP\ContextChat is NC 33+. On an older server
+        // this command cannot run, and saying so is far better than the fatal
+        // that loading ContentProvider would produce. `interface_exists()`
+        // asks the autoloader without dying when the answer is no.
+        if (interface_exists('OCP\\ContextChat\\IContentProvider') === false) {
+            $output->writeln(
+                '<comment>Context Chat is not available on this Nextcloud version '
+                .'(OCP\\ContextChat was introduced in Nextcloud 33). Nothing to reindex.</comment>'
+            );
+            return Command::SUCCESS;
+        }
+
         $registerId  = null;
         $registerRef = $input->getOption('register');
         if ($registerRef !== null) {
@@ -114,7 +157,11 @@ class ContextChatReindexCommand extends Command
         $output->writeln('<info>Reindexing OpenRegister objects into Context Chat…</info>');
 
         try {
-            $submitted = $this->contentProvider->reindex(registerId: $registerId, schemaId: $schemaId);
+            // Resolved here, not in the constructor — this is the first point
+            // at which loading ContentProvider is safe. See the constructor.
+            $contentProvider = $this->container->get(ContentProvider::class);
+
+            $submitted = $contentProvider->reindex(registerId: $registerId, schemaId: $schemaId);
         } catch (Throwable $e) {
             $output->writeln('<error>Reindex failed: '.$e->getMessage().'</error>');
             return Command::FAILURE;

--- a/lib/Command/ContextChatReindexCommand.php
+++ b/lib/Command/ContextChatReindexCommand.php
@@ -19,7 +19,7 @@
  *
  * @link https://OpenRegister.app
  *
- * @spec openspec/specs/context-chat-provider/spec.md#requirement-initial-import-must-walk-opted-in-schemas-in-batches-and-must-be-re-runnable-via-occ
+ * @spec openspec/specs/context-chat-provider/spec.md#requirement-getitemurl-and-initial-import-reuse-existing-openregister-infrastructure
  */
 
 declare(strict_types=1);
@@ -39,7 +39,7 @@ use Throwable;
 /**
  * `occ openregister:contextchat:reindex` — batched Context Chat backfill.
  *
- * @spec openspec/specs/context-chat-provider/spec.md#requirement-initial-import-must-walk-opted-in-schemas-in-batches-and-must-be-re-runnable-via-occ
+ * @spec openspec/specs/context-chat-provider/spec.md#requirement-getitemurl-and-initial-import-reuse-existing-openregister-infrastructure
  */
 class ContextChatReindexCommand extends Command
 {
@@ -82,7 +82,7 @@ class ContextChatReindexCommand extends Command
      *
      * @return void
      *
-     * @spec openspec/specs/context-chat-provider/spec.md#requirement-initial-import-must-walk-opted-in-schemas-in-batches-and-must-be-re-runnable-via-occ
+     * @spec openspec/specs/context-chat-provider/spec.md#requirement-getitemurl-and-initial-import-reuse-existing-openregister-infrastructure
      */
     public function __construct(
         private readonly ContainerInterface $container,
@@ -116,7 +116,7 @@ class ContextChatReindexCommand extends Command
      *
      * @return int Symfony command exit code.
      *
-     * @spec openspec/specs/context-chat-provider/spec.md#requirement-initial-import-must-walk-opted-in-schemas-in-batches-and-must-be-re-runnable-via-occ
+     * @spec openspec/specs/context-chat-provider/spec.md#requirement-getitemurl-and-initial-import-reuse-existing-openregister-infrastructure
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/lib/Listener/ContextChatSubmissionListener.php
+++ b/lib/Listener/ContextChatSubmissionListener.php
@@ -63,6 +63,7 @@ use OCP\ContextChat\IContentManager;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\IUserManager;
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
@@ -86,24 +87,76 @@ class ContextChatSubmissionListener implements IEventListener
     /**
      * Wire collaborators.
      *
-     * @param IContentManager   $contentManager    Core Context Chat content manager (always resolvable via DI).
-     * @param SchemaMapper      $schemaMapper      Schema lookup mapper.
-     * @param PermissionHandler $permissionHandler RBAC evaluator, used for the publication predicate + audience.
-     * @param IUserManager      $userManager       User manager, for the broadcast-audience fallback.
-     * @param LoggerInterface   $logger            PSR logger.
+     * ⚠️ `IContentManager` is resolved LAZILY, in {@see self::contentManager()}.
+     * The docblock this replaces claimed it is "always resolvable via DI"; it
+     * is not, and the difference is instance-wide.
+     *
+     * `OCP\ContextChat` is core API only from **Nextcloud 33**. It is absent
+     * from `stable31` and `stable32`, and this app's `info.xml` declares
+     * `min-version="28"`. A constructor typehint on a class that does not
+     * exist is fatal the moment the container resolves this listener —
+     * `SimpleContainer::resolve()` calls `new ReflectionClass()` on each
+     * parameter type, which is the load.
+     *
+     * That matters far more here than it would in a command, because this
+     * listener is registered for ObjectCreatedEvent, ObjectUpdatedEvent and
+     * ObjectDeletedEvent — it is resolved on EVERY object write. On NC 28-32
+     * the old signature made every create, update and delete throw
+     * `ReflectionException: Class "OCP\ContextChat\IContentManager" does not
+     * exist`, from a feature the instance is not even using.
+     *
+     * Reproduced under a probe that maps OCP\ContextChat\* to nothing, exactly
+     * as those servers do; see the fleet note in ContextChatReindexCommand.
+     *
+     * @param ContainerInterface $container         Container, for the lazy IContentManager resolve.
+     * @param SchemaMapper       $schemaMapper      Schema lookup mapper.
+     * @param PermissionHandler  $permissionHandler RBAC evaluator, used for the publication predicate + audience.
+     * @param IUserManager       $userManager       User manager, for the broadcast-audience fallback.
+     * @param LoggerInterface    $logger            PSR logger.
      *
      * @return void
      *
      * @spec openspec/specs/context-chat-provider/spec.md
      */
     public function __construct(
-        private readonly IContentManager $contentManager,
+        private readonly ContainerInterface $container,
         private readonly SchemaMapper $schemaMapper,
         private readonly PermissionHandler $permissionHandler,
         private readonly IUserManager $userManager,
         private readonly LoggerInterface $logger
     ) {
     }//end __construct()
+
+    /**
+     * Resolve core's Context Chat content manager, or null when unavailable.
+     *
+     * Returns null on Nextcloud below 33, where `OCP\ContextChat` does not
+     * exist. Callers skip submission in that case — the alternative is a fatal
+     * on an object write, which is not a trade this feature gets to make.
+     *
+     * `interface_exists()` asks the autoloader and answers false rather than
+     * dying; the interface name is a plain string here so nothing is resolved
+     * at compile time.
+     *
+     * @return IContentManager|null The content manager, or null when Context Chat is unavailable.
+     *
+     * @spec openspec/specs/context-chat-provider/spec.md
+     */
+    private function contentManager(): ?IContentManager
+    {
+        if (interface_exists('OCP\\ContextChat\\IContentManager') === false) {
+            return null;
+        }
+
+        try {
+            return $this->container->get(IContentManager::class);
+        } catch (Throwable $e) {
+            $this->logger->debug(
+                '[ContextChatSubmissionListener] Context Chat unavailable: '.$e->getMessage()
+            );
+            return null;
+        }
+    }//end contentManager()
 
     /**
      * Route an inbound object lifecycle event to submit or remove.
@@ -331,6 +384,15 @@ class ContextChatSubmissionListener implements IEventListener
 
         $lastModified = ($object->getUpdated() ?? $object->getCreated() ?? new \DateTime());
 
+        // Resolve BEFORE touching ContentItem or ContentProvider below: both
+        // are unloadable on NC < 33 (ContentItem is OCP\ContextChat\*, and
+        // reading ContentProvider::PROVIDER_ID loads a class whose header
+        // implements the missing IContentProvider).
+        $contentManager = $this->contentManager();
+        if ($contentManager === null) {
+            return;
+        }
+
         $item = new ContentItem(
             itemId: $uuid,
             providerId: ContentProvider::PROVIDER_ID,
@@ -341,7 +403,7 @@ class ContextChatSubmissionListener implements IEventListener
             users: $audience
         );
 
-        $this->contentManager->submitContent(
+        $contentManager->submitContent(
             ContentProvider::APP_ID,
             [$item]
         );
@@ -363,7 +425,14 @@ class ContextChatSubmissionListener implements IEventListener
             return;
         }
 
-        $this->contentManager->deleteContent(
+        // Same reason as submitContentItem(): ContentProvider's constants are
+        // read below, and loading that class is fatal on NC < 33.
+        $contentManager = $this->contentManager();
+        if ($contentManager === null) {
+            return;
+        }
+
+        $contentManager->deleteContent(
             ContentProvider::APP_ID,
             ContentProvider::PROVIDER_ID,
             [$uuid]

--- a/lib/Listener/ContextChatSubmissionListener.php
+++ b/lib/Listener/ContextChatSubmissionListener.php
@@ -209,8 +209,8 @@ class ContextChatSubmissionListener implements IEventListener
      *
      * @return bool True when content was actually submitted.
      *
-     * @spec openspec/specs/context-chat-provider/spec.md#requirement-only-opted-in-schemas-must-have-their-objects-submitted-to-context-chat
-     * @spec openspec/specs/context-chat-provider/spec.md#requirement-only-published-objects-must-be-submitted-to-context-chat
+     * @spec openspec/specs/context-chat-provider/spec.md#requirement-only-opted-in-published-objects-are-submitted-to-context-chat
+     * @spec openspec/specs/context-chat-provider/spec.md#requirement-only-opted-in-published-objects-are-submitted-to-context-chat
      */
     public function submitIfEligible(ObjectEntity $object, ?Schema $schema=null): bool
     {
@@ -241,7 +241,7 @@ class ContextChatSubmissionListener implements IEventListener
      *
      * @return void
      *
-     * @spec openspec/specs/context-chat-provider/spec.md#requirement-object-deletion-must-remove-submitted-content-from-context-chat
+     * @spec openspec/specs/context-chat-provider/spec.md#requirement-only-opted-in-published-objects-are-submitted-to-context-chat
      */
     public function remove(ObjectEntity $object, ?Schema $schema=null): void
     {
@@ -295,7 +295,7 @@ class ContextChatSubmissionListener implements IEventListener
      *
      * @return string[]|null The audience (non-empty list of user ids), or null when not publicly readable.
      *
-     * @spec openspec/specs/context-chat-provider/spec.md#requirement-only-published-objects-must-be-submitted-to-context-chat
+     * @spec openspec/specs/context-chat-provider/spec.md#requirement-only-opted-in-published-objects-are-submitted-to-context-chat
      */
     private function resolvePublicReadAudience(ObjectEntity $object, Schema $schema): ?array
     {
@@ -373,7 +373,7 @@ class ContextChatSubmissionListener implements IEventListener
      *
      * @return void
      *
-     * @spec openspec/specs/context-chat-provider/spec.md#requirement-only-opted-in-schemas-must-have-their-objects-submitted-to-context-chat
+     * @spec openspec/specs/context-chat-provider/spec.md#requirement-only-opted-in-published-objects-are-submitted-to-context-chat
      */
     private function submitContentItem(ObjectEntity $object, Schema $schema, array $audience): void
     {
@@ -416,7 +416,7 @@ class ContextChatSubmissionListener implements IEventListener
      *
      * @return void
      *
-     * @spec openspec/specs/context-chat-provider/spec.md#requirement-object-deletion-must-remove-submitted-content-from-context-chat
+     * @spec openspec/specs/context-chat-provider/spec.md#requirement-only-opted-in-published-objects-are-submitted-to-context-chat
      */
     private function removeContentItem(ObjectEntity $object): void
     {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -64,6 +64,14 @@ parameters:
         - '#OCP\\ContextChat\\[a-zA-Z\\]+.*not found#'
         - '#on an unknown class OCP\\ContextChat\\#'
         - '#has invalid type OCP\\ContextChat\\#'
+        # The RETURN-type variant, which the line above does not cover: phpstan
+        # words a parameter/property as "has invalid type" and a return as "has
+        # invalid return type". Needed since ContextChatSubmissionListener
+        # resolves IContentManager lazily and returns `?IContentManager` from a
+        # private accessor. The OCA\Bookmarks block above — the same
+        # optional-peer-resolved-behind-a-guard shape — already carries its own
+        # `has invalid return type` entry for exactly this reason.
+        - '#has invalid return type OCP\\ContextChat\\#'
         - '#implements unknown interface OCP\\ContextChat\\#'
         - '#unknown class OCP\\SystemTag\\Tag(Assigned|Unassigned)Event#'
         - '#OCP\\SystemTag\\Tag(Assigned|Unassigned)Event not found#'

--- a/tests/Unit/ContextChat/ContextChatVersionGuardTest.php
+++ b/tests/Unit/ContextChat/ContextChatVersionGuardTest.php
@@ -1,0 +1,214 @@
+<?php
+
+/**
+ * Context Chat version-guard regression test.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\ContextChat
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\ContextChat;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * Nothing the container resolves may name an `OCP\ContextChat` type.
+ *
+ * WHY THIS EXISTS.
+ *
+ * `OCP\ContextChat` is core Nextcloud API only from **NC 33**. It is absent
+ * from `stable31` and `stable32`, and `appinfo/info.xml` declares
+ * `min-version="28"`. Naming one of those types in a constructor is therefore
+ * fatal on a supported server — `SimpleContainer::resolve()` calls
+ * `new ReflectionClass()` on every parameter type, and that call is the load.
+ *
+ * Two classes had it, and the consequences differed only in blast radius:
+ *
+ *   ContextChatReindexCommand      listed in info.xml, so
+ *                                  loadCommandsFromInfoXml() reflected it on
+ *                                  EVERY occ invocation. Observed in CI on
+ *                                  NC 31.0.14.1 during `occ app:enable`:
+ *                                  Interface "OCP\ContextChat\IContentProvider"
+ *                                  not found. Logged at level 3 while the
+ *                                  enable still reported success — loud in the
+ *                                  log, invisible in the exit code.
+ *
+ *   ContextChatSubmissionListener  registered for ObjectCreated/Updated/
+ *                                  DeletedEvent, so it is resolved on EVERY
+ *                                  object write. On NC 28-32 that made every
+ *                                  create, update and delete throw, for a
+ *                                  feature the instance is not using.
+ *
+ * WHAT THIS TEST CAN CHECK. It runs on a machine where `OCP\ContextChat`
+ * probably DOES resolve, so it cannot reproduce the fatal. What it can do —
+ * and what actually pins the regression — is assert the shape that causes it:
+ * no constructor parameter of a container-resolved class may be typed to an
+ * `OCP\ContextChat` name. That is a static property of the signature, true or
+ * false regardless of the server this runs on.
+ *
+ * Lazy use inside a method body is fine and is the fix: both classes now
+ * resolve through the container at call time, behind an `interface_exists()`
+ * guard.
+ *
+ * @coversNothing
+ */
+class ContextChatVersionGuardTest extends TestCase
+{
+    /**
+     * Classes the container resolves that sit near the Context Chat feature.
+     *
+     * `ContentProviderRegistrationListener` is deliberately absent: it is only
+     * ever resolved by dispatching `ContentProviderRegisterEvent`, which cannot
+     * fire on a server without Context Chat. `ContentProvider` itself is absent
+     * for the same reason it is the subject — it legitimately
+     * `implements IContentProvider`, and is only ever loaded behind a guard.
+     *
+     * @return array<string, array{0: class-string}>
+     */
+    public static function containerResolvedClassProvider(): array
+    {
+        return [
+            'reindex command (info.xml -> loadCommandsFromInfoXml)' => [
+                \OCA\OpenRegister\Command\ContextChatReindexCommand::class,
+            ],
+            'submission listener (object create/update/delete)'     => [
+                \OCA\OpenRegister\Listener\ContextChatSubmissionListener::class,
+            ],
+        ];
+    }//end containerResolvedClassProvider()
+
+    /**
+     * No constructor parameter may be typed to an OCP\ContextChat class.
+     *
+     * @param string $className Fully-qualified class name.
+     *
+     * @return void
+     *
+     * @dataProvider containerResolvedClassProvider
+     */
+    public function testNoConstructorNamesAContextChatType(string $className): void
+    {
+        $constructor = (new ReflectionClass($className))->getConstructor();
+        self::assertNotNull(actual: $constructor, message: $className.' has no constructor');
+
+        foreach ($constructor->getParameters() as $parameter) {
+            $type = $parameter->getType();
+            if ($type === null || $type->isBuiltin() === true) {
+                continue;
+            }
+
+            $typeName = $type->getName();
+
+            // TWO ways a parameter drags OCP\ContextChat in, and the second is
+            // the one the first version of this test MISSED — it checked only
+            // the type name, so re-adding `ContentProvider $contentProvider`
+            // to the reindex command (the original defect, verbatim) still
+            // passed. `ContentProvider` is an OCA class; what makes it fatal
+            // is its HEADER: `implements OCP\ContextChat\IContentProvider`.
+            //
+            // 1. the parameter IS an OCP\ContextChat type (the listener).
+            // 2. the parameter is any class whose ancestry names one, which
+            // is the command's case.
+            $offenders = [];
+            if (str_contains($typeName, 'OCP\\ContextChat') === true) {
+                $offenders[] = $typeName;
+            }
+
+            if (class_exists($typeName) === true || interface_exists($typeName) === true) {
+                $implemented = class_implements($typeName);
+                if ($implemented === false) {
+                    $implemented = [];
+                }
+
+                $parents = class_parents($typeName);
+                if ($parents === false) {
+                    $parents = [];
+                }
+
+                $ancestry = array_merge($implemented, $parents);
+                foreach ($ancestry as $ancestor) {
+                    if (str_contains($ancestor, 'OCP\\ContextChat') === true) {
+                        $offenders[] = $typeName.' (implements '.$ancestor.')';
+                    }
+                }
+            }
+
+            self::assertSame(
+                expected: [],
+                actual: $offenders,
+                message: sprintf(
+                    '%s::__construct($%s) is typed to %s, which requires OCP\\ContextChat to '
+                    .'load. That namespace is NC 33+ and this app supports NC 28+, so the '
+                    .'container resolving this class would fatal on stable31/stable32 — '
+                    .'SimpleContainer::resolve() does `new ReflectionClass()` on each parameter '
+                    .'type, and that call is the load. Resolve it lazily inside the method body '
+                    .'instead, behind an interface_exists() guard.',
+                    $className,
+                    $parameter->getName(),
+                    $typeName
+                )
+            );
+        }//end foreach
+    }//end testNoConstructorNamesAContextChatType()
+
+    /**
+     * The reindex command still refuses to run when Context Chat is absent.
+     *
+     * The lazy resolve only helps if the execute path also checks. Without
+     * this, the command would resolve fine and then fatal one line later on
+     * `ContentProvider`.
+     *
+     * @return void
+     */
+    public function testTheReindexCommandGuardsItsExecutePath(): void
+    {
+        $source = (string) file_get_contents(
+            __DIR__.'/../../../lib/Command/ContextChatReindexCommand.php'
+        );
+
+        self::assertStringContainsString(
+            needle: "interface_exists('OCP\\\\ContextChat\\\\IContentProvider')",
+            haystack: $source,
+            message: 'execute() must check for the interface before resolving ContentProvider'
+        );
+    }//end testTheReindexCommandGuardsItsExecutePath()
+
+    /**
+     * The submission listener guards both of its content-manager call paths.
+     *
+     * Both submitContentItem() and removeContentItem() touch
+     * `ContentProvider::` constants, and loading that class is fatal below
+     * NC 33 — so each needs its own guard, not just the shared resolver.
+     *
+     * @return void
+     */
+    public function testTheSubmissionListenerGuardsBothCallPaths(): void
+    {
+        $source = (string) file_get_contents(
+            __DIR__.'/../../../lib/Listener/ContextChatSubmissionListener.php'
+        );
+
+        self::assertSame(
+            expected: 2,
+            actual: substr_count($source, '$contentManager = $this->contentManager();'),
+            message: 'both submitContentItem() and removeContentItem() must resolve behind the guard'
+        );
+        self::assertStringContainsString(
+            needle: "interface_exists('OCP\\\\ContextChat\\\\IContentManager')",
+            haystack: $source,
+            message: 'the lazy resolver must check the interface rather than assume it'
+        );
+    }//end testTheSubmissionListenerGuardsBothCallPaths()
+}//end class

--- a/tests/Unit/Listener/ContextChatSubmissionListenerTest.php
+++ b/tests/Unit/Listener/ContextChatSubmissionListenerTest.php
@@ -33,6 +33,7 @@ use OCP\ContextChat\ContentItem;
 use OCP\ContextChat\IContentManager;
 use OCP\IUserManager;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -59,8 +60,19 @@ class ContextChatSubmissionListenerTest extends TestCase
         $this->contentManager    = $this->createMock(IContentManager::class);
         $this->userManager       = $this->createMock(IUserManager::class);
 
+        // The listener no longer takes IContentManager directly — it resolves
+        // it from the container at call time, because a constructor typehint on
+        // an `OCP\ContextChat` type is fatal on NC 28-32, where that namespace
+        // does not exist, and this listener is resolved on EVERY object write.
+        // The container stands in so every behavioural assertion below is
+        // unchanged: they still observe the same mock.
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturnCallback(
+            fn (string $id) => $id === IContentManager::class ? $this->contentManager : null
+        );
+
         $this->listener = new ContextChatSubmissionListener(
-            $this->contentManager,
+            $container,
             $this->schemaMapper,
             $this->permissionHandler,
             $this->userManager,


### PR DESCRIPTION
Two classes named an `OCP\ContextChat` type in their **constructor**, which is fatal on every Nextcloud below 33 — `lib/public/ContextChat/` does not exist on `stable31` or `stable32`, and `appinfo/info.xml` declares `min-version="28"`.

The load happens **in the container**, not at class declaration: `SimpleContainer::resolve()` calls `new ReflectionClass()` on each parameter type. That call is the load.

| class | how it is resolved | consequence on NC 28-32 |
|---|---|---|
| `ContextChatReindexCommand` | listed in `info.xml` → `loadCommandsFromInfoXml()` | throws on **every `occ` invocation** |
| `ContextChatSubmissionListener` | ObjectCreated/Updated/Deleted events | throws on **every object write** |

The command failure is already visible in CI on NC 31.0.14.1 during `occ app:enable`:
`Interface "OCP\ContextChat\IContentProvider" not found` — logged at level 3 while the enable still reports **success**. Loud in the log, invisible in the exit code, which is how it survived. The listener's docblock claimed `IContentManager` was *"always resolvable via DI"*; it is not.

Both now resolve through the container inside the method body, behind an `interface_exists()` guard. Both listener call sites are guarded **separately** — `submitContentItem()` and `removeContentItem()` each read `ContentProvider::` constants, and loading *that* class is fatal too, since its header implements the missing interface.

`ContentProviderRegistrationListener` is deliberately unchanged: it is only ever resolved by dispatching `ContentProviderRegisterEvent`, which cannot fire without Context Chat.

## Verified with a probe that simulates NC < 33

| class | before | after |
|---|---|---|
| `ContextChatReindexCommand` | FATAL `Interface "OCP\ContextChat\IContentProvider" not found` | **OK** |
| `ContextChatSubmissionListener` | FATAL `Class "OCP\ContextChat\IContentManager" does not exist` | **OK** |
| `ContentProvider` (control) | FATAL | **still FATAL** |

The control matters: it proves the probe really simulates NC < 33 rather than passing everything.

**The first probe I wrote proved nothing.** It read parameter types via `getType()->getName()`, which returns a string *without* loading the class — so the unfixed command "passed". The fatal only appears once each parameter type is itself reflected.

## Tests — and the same hole, twice

`tests/Unit/ContextChat/ContextChatVersionGuardTest.php` pins the *shape*, since a machine where `OCP\ContextChat` resolves cannot reproduce the fatal.

Its first version had the same class of hole as the probe: it checked only whether the parameter **type name** contained `OCP\ContextChat`, so re-adding `ContentProvider $contentProvider` to the command — the original defect, verbatim — **still passed**, because `ContentProvider` is an `OCA` class. It now walks `class_implements()`/`class_parents()` too.

| mutation | result |
|---|---|
| re-add `ContentProvider` to the command's constructor | **1 failure** |
| drop one of the listener's two guards | **1 failure** |
| restored | OK (4 tests) |

The existing `ContextChatSubmissionListenerTest` passes unchanged in substance — only the constructor wiring moved to a container mock returning the same `IContentManager` mock, so all 26 assertions still observe what they did before.