### PR TITLE
fix: untrack the .hydra dev symlink, it breaks every release archive

### DIFF
--- a/.hydra
+++ b/.hydra
@@ -1,1 +1,0 @@
-/home/rubenlinde/nextcloud-docker-dev/workspace/server/apps-extra/hydra


### PR DESCRIPTION
`.hydra` is a symlink to an absolute path on one developer's machine:

```
openregister/.hydra -> /home/rubenlinde/nextcloud-docker-dev/workspace/server/apps-extra/hydra
```

It is tracked (mode 120000) and therefore packaged into every release. Any extractor that guards against path traversal refuses **the whole archive** as a result, so installing OpenRegister through the App Versions app fails with `Out-of-path file extraction` and nothing is installed. `tar tzf` and GNU tar are perfectly happy with it, which is why this only shows up at install time.

**It was never meant to be committed.** It arrived on 2026-07-05 in `4e01030f3`, a commit titled *"chore: preserve WIP before development sync"* — a bulk sweep of the working directory. It was later added to `.gitignore`, but `.gitignore` does not untrack an already-tracked file, so it stayed.

Untracking it here. Anyone who wants the symlink locally still gets it: it remains ignored, so it will not come back.

ConductionNL/.github#197 additionally excludes `.hydra` from all three release workflows, so no app can ship one by accident.

(Checked opencatalogi too — its `.hydra` is a submodule gitlink with no working-tree content, so its archives are clean.)