### PR TITLE
chore(deps): remove dead runtime deps — bare axios, @fortawesome, @vue/compat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,6 @@
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
         "@conduction/nextcloud-vue": "2.2.0-vue3.6",
-        "@fortawesome/fontawesome-svg-core": "^6.5.2",
-        "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "^2.6.0",
         "@nextcloud/capabilities": "^1.2.1",
@@ -23,7 +21,6 @@
         "@nextcloud/vue": "^9.9.0",
         "@vueuse/core": "^14.3.0",
         "apexcharts": "^4.7.0",
-        "axios": "^1.7.3",
         "css-loader": "^7.1.1",
         "dexie": "^4.0.8",
         "dompurify": "^3.4.12",
@@ -3082,39 +3079,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
       "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
       "license": "MIT"
-    },
-    "node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
-      "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
-      "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
-      "license": "MIT",
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.7.2"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
-      "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
-      "license": "(CC-BY-4.0 AND MIT)",
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.7.2"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,6 @@
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
     "@conduction/nextcloud-vue": "2.2.0-vue3.6",
-    "@fortawesome/fontawesome-svg-core": "^6.5.2",
-    "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "^2.6.0",
     "@nextcloud/capabilities": "^1.2.1",
@@ -55,7 +53,6 @@
     "@nextcloud/vue": "^9.9.0",
     "@vueuse/core": "^14.3.0",
     "apexcharts": "^4.7.0",
-    "axios": "^1.7.3",
     "css-loader": "^7.1.1",
     "dexie": "^4.0.8",
     "dompurify": "^3.4.12",


### PR DESCRIPTION
None of these are imported anywhere in `src/`.

## Evidence

Measured with a grep over the checked-out tree, **positive-controlled** so an empty result means a real absence rather than a broken search — the same grep finds **66** files importing `@nextcloud/axios` in openregister.

| package | imports in `src/` |
|---|---|
| bare `axios` | **0** — these apps use `@nextcloud/axios` |
| `@fortawesome/*` | **0** |
| `@vue/compat` | **0** |

## `@vue/compat` is worth a note

A naive grep **does** hit it in `webpack.config.js` — but only inside comments recording that it was *removed*:

> build runs on the REAL Vue 3 runtime — NOT `@vue/compat`
> PURE VUE 3 (ADR-066): the `@vue/compat` MODE-2 compiler shim is gone

A check that greps a bare string matches every comment *about* a thing as readily as a *use* of it — the same failure that produced false ADR-040 findings earlier in this programme. Confirmed dead by reading the hits, not counting them.

## Deliberately NOT applied to opencatalogi

opencatalogi genuinely uses both: **2 files** import bare `axios`, **3** import `@fortawesome`. Identical manifest lines, opposite verdict — decided per repo rather than swept.

Lockfile regenerated with `npx npm@10.8.2`, never `--legacy-peer-deps`.