### PR TITLE
chore: require Nextcloud 32, which is where the ContextChat interfaces exist

### DIFF
--- a/.github/docker-compose.ci.yml
+++ b/.github/docker-compose.ci.yml
@@ -24,8 +24,9 @@ services:
       retries: 12
 
   nextcloud:
-    # NC 32+ for OCP\DB\Types::DATETIME_IMMUTABLE; matches stable32 in code-quality.yml
-    # and openregister's info.xml min-version=28 max-version=34.
+    # NC 32+ for OCP\DB\Types::DATETIME_IMMUTABLE and OCP\ContextChat\*;
+    # matches stable32 in code-quality.yml and info.xml min-version=32
+    # max-version=34.
     image: nextcloud:32-apache
     container_name: nextcloud
     user: root

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -66,7 +66,16 @@ Vrij en open source onder de EUPL-licentie.
         <database min-version="10">pgsql</database>
         <database>sqlite</database>
         <database min-version="8.0">mysql</database>
-        <nextcloud min-version="28" max-version="34"/>
+        <!-- 32, not 28. lib/ContextChat/ContentProvider.php implements
+             OCP\ContextChat\IContentProvider, and that interface does not
+             exist in core before Nextcloud 32. On 31 and below, loading the
+             class logs "Interface OCP\ContextChat\IContentProvider not
+             found"; the registration listener cannot prevent it, because the
+             failure happens when PHP reads the class header, not when the
+             provider is registered. CI has run against nextcloud:32-apache
+             for a while and the dev stack is on 34, so nothing was testing
+             28-31 either. -->
+        <nextcloud min-version="32" max-version="34"/>
     </dependencies>
 
 	<repair-steps>


### PR DESCRIPTION
`lib/ContextChat/ContentProvider.php` implements `OCP\ContextChat\IContentProvider`, and that interface does not exist in core before **Nextcloud 32**. On 31 and below, loading the class logs:

```
Interface "OCP\ContextChat\IContentProvider" not found
```

The registration listener cannot prevent this. It correctly gates *registration* on the event firing and `isContextChatAvailable()`, but the failure happens when PHP reads the **class header**, long before any of that runs. No amount of lazy DI defers a missing interface on an `implements` clause.

Observed on a clean Nextcloud 31: OpenRegister still enables and `/apps/openregister/` returns 200, so today it degrades to a log warning. That is luck about what touches the class, not design — the same shape has previously turned into a 500 on every route once something reflected the class.

**The old floor was already fiction.** CI runs `nextcloud:32-apache`, the dev stack is on 34, and the CI compose comment itself said "NC 32+ for OCP\DB\Types::DATETIME_IMMUTABLE" while citing `min-version=28`. Nothing exercised 28–31.

Also corrects that stale comment.

### Knock-on worth knowing
Ten apps depend on OpenRegister and most still declare a lower floor: pipelinq, softwarecatalog, procest, decidesk, openbuild and larpingapp say 28; docudesk says 30; opencatalogi and doriath say 31. Their declared ranges are now unsatisfiable at the bottom, since the dependency needs 32. Left alone here deliberately — that is a separate decision per app.