### PR TITLE
fix: restore Nextcloud 28 support — the 32 floor breaks eight consumer repos

### DIFF
--- a/.github/docker-compose.ci.yml
+++ b/.github/docker-compose.ci.yml
@@ -24,9 +24,18 @@ services:
       retries: 12
 
   nextcloud:
-    # NC 32+ for OCP\DB\Types::DATETIME_IMMUTABLE and OCP\ContextChat\*;
-    # matches stable32 in code-quality.yml and info.xml min-version=32
-    # max-version=34.
+    # Pinned to 32 because that is what code-quality.yml's matrix exercises,
+    # NOT because the app requires it. info.xml declares min-version=28.
+    #
+    # Both reasons the previous comment gave for a 32 floor were checked and
+    # neither holds:
+    #   OCP\DB\Types::DATETIME_IMMUTABLE — present in stable31 as well as 32.
+    #   OCP\ContextChat\*               — genuinely 32+, but #2372 made every
+    #                                     reference lazy and guarded, so the
+    #                                     feature is inert below 32 rather than
+    #                                     fatal.
+    # Eight fleet repos install this app while testing stable31, and procest's
+    # e2e proved a stable31 install green after #2372.
     image: nextcloud:32-apache
     container_name: nextcloud
     user: root

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -66,16 +66,35 @@ Vrij en open source onder de EUPL-licentie.
         <database min-version="10">pgsql</database>
         <database>sqlite</database>
         <database min-version="8.0">mysql</database>
-        <!-- 32, not 28. lib/ContextChat/ContentProvider.php implements
-             OCP\ContextChat\IContentProvider, and that interface does not
-             exist in core before Nextcloud 32. On 31 and below, loading the
-             class logs "Interface OCP\ContextChat\IContentProvider not
-             found"; the registration listener cannot prevent it, because the
-             failure happens when PHP reads the class header, not when the
-             provider is registered. CI has run against nextcloud:32-apache
-             for a while and the dev stack is on 34, so nothing was testing
-             28-31 either. -->
-        <nextcloud min-version="32" max-version="34"/>
+        <!-- 28 again, reverting #2378's bump to 32.
+
+             #2378's premise was correct when it was written and is no longer:
+             "the registration listener cannot prevent it, because the failure
+             happens when PHP reads the class header". That WAS true, and #2372
+             is what changed it — it removed every EAGER reference to
+             ContentProvider, so the class is now only loaded from inside
+             `interface_exists('OCP\ContextChat\IContentManager')` guards. On a
+             server without OCP\ContextChat the class header is never read, the
+             feature is simply inert, and nothing logs.
+
+             Empirically: procest's e2e installs openregister at `development`
+             and runs stable31. Its run at 2026-08-06T14:04Z — six minutes AFTER
+             #2372 merged at 13:58Z — passed. openregister demonstrably boots,
+             enables and serves on Nextcloud 31 with that fix in place.
+
+             The bump is not free. `min-version` is enforced at INSTALL time, so
+             32 makes `occ app:enable openregister` refuse on 31, and eight fleet
+             repos install openregister as an additional-app while testing
+             stable31: procest, shillinq, portaliq, openbuild, decidesk, doriath,
+             hermiq and larpingapp. Each fails its seed with "OpenRegister is not
+             installed or enabled" and then a 404 from
+             /api/configurations/import — observed on procest#758.
+
+             28-31 remain untested by this repo's own CI, exactly as #2378
+             observed. That is a coverage gap, and it is a separate thing from
+             declaring the versions unsupported: the eight repos above ARE the
+             coverage, and they were green on 31 until the floor moved. -->
+        <nextcloud min-version="28" max-version="34"/>
     </dependencies>
 
 	<repair-steps>

--- a/lib/Command/ContextChatReindexCommand.php
+++ b/lib/Command/ContextChatReindexCommand.php
@@ -51,7 +51,7 @@ class ContextChatReindexCommand extends Command
      * and this is not a style choice.
      *
      * `OCP\ContextChat\IContentProvider` is core Nextcloud API, but only from
-     * **NC 33**: it is absent from `stable31` and `stable32`, both of which
+     * **NC 32**: it is absent from `stable31`, which
      * this app's `info.xml` claims to support (`min-version="28"`). Because
      * {@see ContentProvider} declares `implements IContentProvider`, merely
      * LOADING that class on an older server is fatal — a class header is
@@ -120,14 +120,14 @@ class ContextChatReindexCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        // See the constructor: OCP\ContextChat is NC 33+. On an older server
+        // See the constructor: OCP\ContextChat is NC 32+. On an older server
         // this command cannot run, and saying so is far better than the fatal
         // that loading ContentProvider would produce. `interface_exists()`
         // asks the autoloader without dying when the answer is no.
         if (interface_exists('OCP\\ContextChat\\IContentProvider') === false) {
             $output->writeln(
                 '<comment>Context Chat is not available on this Nextcloud version '
-                .'(OCP\\ContextChat was introduced in Nextcloud 33). Nothing to reindex.</comment>'
+                .'(OCP\\ContextChat was introduced in Nextcloud 32). Nothing to reindex.</comment>'
             );
             return Command::SUCCESS;
         }

--- a/lib/Listener/ContextChatSubmissionListener.php
+++ b/lib/Listener/ContextChatSubmissionListener.php
@@ -91,7 +91,7 @@ class ContextChatSubmissionListener implements IEventListener
      * The docblock this replaces claimed it is "always resolvable via DI"; it
      * is not, and the difference is instance-wide.
      *
-     * `OCP\ContextChat` is core API only from **Nextcloud 33**. It is absent
+     * `OCP\ContextChat` is core API only from **Nextcloud 32**. It is absent
      * from `stable31` and `stable32`, and this app's `info.xml` declares
      * `min-version="28"`. A constructor typehint on a class that does not
      * exist is fatal the moment the container resolves this listener —
@@ -130,7 +130,7 @@ class ContextChatSubmissionListener implements IEventListener
     /**
      * Resolve core's Context Chat content manager, or null when unavailable.
      *
-     * Returns null on Nextcloud below 33, where `OCP\ContextChat` does not
+     * Returns null on Nextcloud below 32, where `OCP\ContextChat` does not
      * exist. Callers skip submission in that case — the alternative is a fatal
      * on an object write, which is not a trade this feature gets to make.
      *
@@ -385,7 +385,7 @@ class ContextChatSubmissionListener implements IEventListener
         $lastModified = ($object->getUpdated() ?? $object->getCreated() ?? new \DateTime());
 
         // Resolve BEFORE touching ContentItem or ContentProvider below: both
-        // are unloadable on NC < 33 (ContentItem is OCP\ContextChat\*, and
+        // are unloadable on NC < 32 (ContentItem is OCP\ContextChat\*, and
         // reading ContentProvider::PROVIDER_ID loads a class whose header
         // implements the missing IContentProvider).
         $contentManager = $this->contentManager();
@@ -426,7 +426,7 @@ class ContextChatSubmissionListener implements IEventListener
         }
 
         // Same reason as submitContentItem(): ContentProvider's constants are
-        // read below, and loading that class is fatal on NC < 33.
+        // read below, and loading that class is fatal on NC < 32.
         $contentManager = $this->contentManager();
         if ($contentManager === null) {
             return;

--- a/tests/Unit/ContextChat/ContextChatVersionGuardTest.php
+++ b/tests/Unit/ContextChat/ContextChatVersionGuardTest.php
@@ -28,7 +28,7 @@ use ReflectionClass;
  *
  * WHY THIS EXISTS.
  *
- * `OCP\ContextChat` is core Nextcloud API only from **NC 33**. It is absent
+ * `OCP\ContextChat` is core Nextcloud API only from **NC 32**. It is absent
  * from `stable31` and `stable32`, and `appinfo/info.xml` declares
  * `min-version="28"`. Naming one of those types in a constructor is therefore
  * fatal on a supported server — `SimpleContainer::resolve()` calls
@@ -150,7 +150,7 @@ class ContextChatVersionGuardTest extends TestCase
                 actual: $offenders,
                 message: sprintf(
                     '%s::__construct($%s) is typed to %s, which requires OCP\\ContextChat to '
-                    .'load. That namespace is NC 33+ and this app supports NC 28+, so the '
+                    .'load. That namespace is NC 32+ and this app supports NC 28+, so the '
                     .'container resolving this class would fatal on stable31/stable32 — '
                     .'SimpleContainer::resolve() does `new ReflectionClass()` on each parameter '
                     .'type, and that call is the load. Resolve it lazily inside the method body '
@@ -190,7 +190,7 @@ class ContextChatVersionGuardTest extends TestCase
      *
      * Both submitContentItem() and removeContentItem() touch
      * `ContentProvider::` constants, and loading that class is fatal below
-     * NC 33 — so each needs its own guard, not just the shared resolver.
+     * NC 32 — so each needs its own guard, not just the shared resolver.
      *
      * @return void
      */


### PR DESCRIPTION
#2378 raised `min-version` 28 → 32. **Its premise was correct when written and is no longer:**

> "the registration listener cannot prevent it, because the failure happens when PHP reads the class header, not when the provider is registered"

That was true — and **#2372 is what changed it**. #2372 removed every *eager* reference to `ContentProvider` (the command's constructor typehint and the listener's), so the class is now only loaded from inside `interface_exists(...)` guards. On a server without `OCP\ContextChat` the class header is never read: the feature is inert, and nothing logs.

## What the floor actually costs

`min-version` is enforced at **install** time, so 32 makes `occ app:enable openregister` refuse on 31. **Eight fleet repos** install openregister as an additional-app while testing `stable31` — procest, shillinq, portaliq, openbuild, decidesk, doriath, hermiq, larpingapp. Each now fails its seed with:

```
{"success":false,"message":"OpenRegister is not installed or enabled"}
```

and then a 404 from `/api/configurations/import`, because the fallback importer belongs to the app that did not install. Observed on procest#758, where it looked for a while like a manifest bug in that PR.

## Evidence that 31 works

procest's e2e installs openregister at `development` and runs `stable31`. Its run at **2026-08-06T14:04Z — six minutes after #2372 merged at 13:58Z — passed.** The app demonstrably boots, enables and serves on NC 31 with that fix in place.

The CI compose's second reason for a 32 floor does not hold either: `OCP\DB\Types::DATETIME_IMMUTABLE` is present in **stable31** as well as 32. Checked directly against both branches.

## This also corrects my own error

#2372 and its test say **"NC 33"** throughout. That came from a local lookup against refs this checkout does not have — which answers ABSENT for everything. It is exactly the failure a positive control exists to catch, and I did not run one at the time. Verified properly, with `IUserManager.php` as the control:

| branch | `IContentProvider` | control |
|---|---|---|
| stable31 | **404** | 200 |
| stable32 | **200** | 200 |

So the interfaces arrive in **32**, not 33. Every "NC 33" claim in the listener, the command and the guard test is corrected.

## What stays true from #2378

28-31 remain untested by this repo's own CI. That is a real coverage gap and worth closing — but it is a different thing from declaring those versions unsupported. The eight repos above **are** the coverage, and they were green on 31 until the floor moved.

26 ContextChat tests pass; phpcs clean.
