### PR TITLE
chore(compat): raise the Nextcloud floor to 32

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -66,35 +66,56 @@ Vrij en open source onder de EUPL-licentie.
         <database min-version="10">pgsql</database>
         <database>sqlite</database>
         <database min-version="8.0">mysql</database>
-        <!-- 28 again, reverting #2378's bump to 32.
+        <!-- 32, as a deliberate product decision: the platform floor moves to
+             Nextcloud 32 fleet-wide.
 
-             #2378's premise was correct when it was written and is no longer:
-             "the registration listener cannot prevent it, because the failure
-             happens when PHP reads the class header". That WAS true, and #2372
-             is what changed it — it removed every EAGER reference to
-             ContentProvider, so the class is now only loaded from inside
-             `interface_exists('OCP\ContextChat\IContentManager')` guards. On a
-             server without OCP\ContextChat the class header is never read, the
-             feature is simply inert, and nothing logs.
+             This repository has been round the 28/32 loop once already —
+             #2378 raised it to 32, #2379 recorded the fallout, #2380 put it
+             back to 28 — so the reasoning is written out here rather than
+             left to the commit log.
 
-             Empirically: procest's e2e installs openregister at `development`
-             and runs stable31. Its run at 2026-08-06T14:04Z — six minutes AFTER
-             #2372 merged at 13:58Z — passed. openregister demonstrably boots,
-             enables and serves on Nextcloud 31 with that fix in place.
+             WHY 32 IS THE RIGHT DECLARATION
 
-             The bump is not free. `min-version` is enforced at INSTALL time, so
-             32 makes `occ app:enable openregister` refuse on 31, and eight fleet
-             repos install openregister as an additional-app while testing
-             stable31: procest, shillinq, portaliq, openbuild, decidesk, doriath,
-             hermiq and larpingapp. Each fails its seed with "OpenRegister is not
-             installed or enabled" and then a 404 from
-             /api/configurations/import — observed on procest#758.
+             openregister is the foundation app. openconnector, openbuild,
+             larpingapp and scholiq all name it as a hard `<app>` dependency,
+             and the rule established by openconnector#1172/#1173 is that an
+             app's min-version must be at least the maximum floor of every
+             `<app>` it depends on — otherwise the App Store advertises a
+             range the app cannot deliver: on a server below the dependency's
+             floor the dependency refuses to install and every entity in the
+             dependent app is unreachable. openconnector's own info.xml
+             already justifies its floor by asserting that openregister
+             declares 32. Until this change that assertion was false.
 
-             28-31 remain untested by this repo's own CI, exactly as #2378
-             observed. That is a coverage gap, and it is a separate thing from
-             declaring the versions unsupported: the eight repos above ARE the
-             coverage, and they were green on 31 until the floor moved. -->
-        <nextcloud min-version="28" max-version="34"/>
+             It also matches what is actually tested. This repo's CI matrix is
+             a single leg — PHP 8.3 / stable32 (.github/workflows/
+             code-quality.yml). There has never been a job below 32, so
+             declaring 28-31 supported claimed coverage that does not exist.
+
+             WHAT THIS COSTS, MEASURED — read before lowering it again
+
+             min-version is enforced at INSTALL time. Eight fleet repos install
+             openregister as an additional-app while their own e2e runs on
+             stable31: procest, shillinq, portaliq, openbuild, decidesk,
+             doriath, hermiq and larpingapp. When #2378 last moved this floor,
+             each failed its seed with "OpenRegister is not installed or
+             enabled" followed by a 404 from /api/configurations/import —
+             observed on procest#758 and tracked in #2379.
+
+             Those eight repos must move their own test matrices to stable32.
+             Until they do, they will fail exactly as they did before. That is
+             the accepted, known cost of the decision, not an unforeseen
+             regression — if these failures reappear, the fix is to move the
+             consumer matrices up, NOT to lower this floor again.
+
+             Note: `<php min-version="8.3">` above is enforced independently of
+             the Nextcloud version, so the PHP 8.3 requirement does not itself
+             depend on this floor.
+
+             max-version stays 34, which is the fleet-wide value everywhere
+             except openconnector, which declares 35. That split is known and
+             deliberately not resolved here. -->
+        <nextcloud min-version="32" max-version="34"/>
     </dependencies>
 
 	<repair-steps>

--- a/tests/Unit/ContextChat/ContextChatVersionGuardTest.php
+++ b/tests/Unit/ContextChat/ContextChatVersionGuardTest.php
@@ -28,11 +28,18 @@ use ReflectionClass;
  *
  * WHY THIS EXISTS.
  *
- * `OCP\ContextChat` is core Nextcloud API only from **NC 32**. It is absent
- * from `stable31` and `stable32`, and `appinfo/info.xml` declares
- * `min-version="28"`. Naming one of those types in a constructor is therefore
- * fatal on a supported server — `SimpleContainer::resolve()` calls
- * `new ReflectionClass()` on every parameter type, and that call is the load.
+ * `OCP\ContextChat` is core Nextcloud API only from **NC 32**, and even on a
+ * server at or above that floor it is absent whenever the ContextChat feature
+ * itself is not present — it is not guaranteed by the Nextcloud version alone.
+ * Naming one of those types in a constructor is therefore fatal on a supported
+ * server — `SimpleContainer::resolve()` calls `new ReflectionClass()` on every
+ * parameter type, and that call is the load.
+ *
+ * NOTE ON THE FLOOR. `appinfo/info.xml` declared `min-version="28"` when this
+ * test was written; it now declares **32**. That does NOT retire this guard.
+ * The guard is about the namespace being resolvable at all, which is a
+ * property of the installed feature rather than of the server version, so the
+ * eager-constructor shape stays fatal at any floor.
  *
  * Two classes had it, and the consequences differed only in blast radius:
  *
@@ -150,8 +157,9 @@ class ContextChatVersionGuardTest extends TestCase
                 actual: $offenders,
                 message: sprintf(
                     '%s::__construct($%s) is typed to %s, which requires OCP\\ContextChat to '
-                    .'load. That namespace is NC 32+ and this app supports NC 28+, so the '
-                    .'container resolving this class would fatal on stable31/stable32 — '
+                    .'load. That namespace is not guaranteed to be resolvable on a supported '
+                    .'server — it is absent unless the ContextChat feature is installed — so '
+                    .'the container resolving this class would fatal — '
                     .'SimpleContainer::resolve() does `new ReflectionClass()` on each parameter '
                     .'type, and that call is the load. Resolve it lazily inside the method body '
                     .'instead, behind an interface_exists() guard.',


### PR DESCRIPTION
## What

`appinfo/info.xml`: `<nextcloud min-version="28" …>` → **`32`**. `max-version` stays **34**.

Product decision, taken fleet-wide. This repo has been round the 28/32 loop once already (#2378 up → #2379 fallout → #2380 back down), so the reasoning and the cost are written into the file itself rather than left in the commit log.

## Why 32

**The dependency rule.** openregister is the foundation app. openconnector, openbuild, larpingapp and scholiq all name it as a hard `<app>` dependency. Per openconnector#1172/#1173, an app's `min-version` must be **≥ the maximum floor of every `<app>` it depends on** — otherwise the App Store advertises a range the app cannot deliver: below the dependency's floor the dependency refuses to install and every entity in the dependent app is unreachable.

openconnector's `info.xml` already justifies its own floor by asserting that *openregister declares min-version 32*. **That assertion was false** — openregister said 28. This change makes it true.

**It matches what is actually tested.** The CI matrix here is one leg:

```
.github/workflows/code-quality.yml:81   php-version: "8.3"
.github/workflows/code-quality.yml:83   nextcloud-test-refs: '["stable32"]'
```

There is no job below 32 and there never has been. Declaring 28–31 supported claimed coverage that does not exist.

**On the CI-matrix question:** no leg targets NC < 32, so nothing needs dropping. The matrix was already the stricter of the two statements; this change makes the declaration agree with it.

## What it costs — measured, and accepted

`min-version` is enforced at **install** time. Eight fleet repos install openregister as an additional-app while their own e2e runs on stable31: procest, shillinq, portaliq, openbuild, decidesk, doriath, hermiq, larpingapp. When #2378 last moved this floor, each failed its seed with `OpenRegister is not installed or enabled`, then a 404 from `/api/configurations/import` — observed on procest#758, tracked in #2379.

**Those eight must move their own matrices to stable32.** Until they do they will fail exactly as before. That is the accepted cost of the decision, not an unforeseen regression — recorded in the file so that if it reappears the response is to move the consumers up, **not** to lower this floor a second time.

Note `<php min-version="8.3">` is enforced independently of the Nextcloud version, so the PHP 8.3 requirement does not itself depend on this floor.

## Evidence — and its limits

This is a declaration change, so I want to be exact about what is and isn't proven.

I checked the invariant *"never declare support for a version CI does not test"*, and **showed it can fail**:

| tree | result |
|---|---|
| as committed (`min-version=32`) | `declared 32; CI legs ['32']; lowest tested 32` → **CONSISTENT**, exit 0 |
| mutated back to `min-version=28` | `declared 28; CI legs ['32']` → **INCONSISTENT: declares support for NC 28-31, which CI never tests**, exit 1 |

The checker carries its own positive control (`assert refs` — it aborts loudly if it parses zero CI refs, so "consistent" can never be manufactured by a failed parse). The mutation was made on a copy and reverted; `git diff` confirms the only changed version line is `28` → `32`.

**What is not proven:** there is no unit test that can non-vacuously fail on this line. The dependency rule binds openregister's *dependents*, and openregister itself declares no `<app>` dependencies — so a "floor ≥ max dependency floor" assertion added here would be a check that cannot fail, which is worse than no check. I did not add one. Verifying install-time refusal on a real NC 31 would need a live NC 31 instance, which I did not run.

## Also in this PR

`tests/Unit/ContextChat/ContextChatVersionGuardTest.php` stated `min-version="28"` and *"this app supports NC 28+"* in a docblock and in an assertion **message**. Both are now false, so both are corrected. **No assertion logic changed** — the test still asserts the same `$offenders === []`.

The guard is not retired by this bump: `OCP\ContextChat` is absent whenever the ContextChat feature is not installed, which is a property of the installed feature rather than of the server version, so the eager-constructor shape stays fatal at any floor.

## Related, deliberately not resolved here

`max-version` is **34 everywhere except openconnector, which declares 35**. Recorded so it is visible; not resolved in this PR.

⚠️ This interacts with **#2381**, which bumps this repo's `max-version` to 35 to unblock opencatalogi#821 on the NC 35 dev image. Merging both would put openregister at `32–35` while the rest of the fleet sits at 34. Flagged on that PR; it should not be merged until the 34/35 split is decided.

⚠️ `quality / PHPUnit (PHP 8.3, NC stable32)` is failing on `development` already. That is a **stable32** leg, so this change cannot fix it and any movement there is not attributable to this edit.
