### PR TITLE
fix(nav): the Flows menu entry rendered with no icon

### DIFF
--- a/src/icons.js
+++ b/src/icons.js
@@ -42,6 +42,7 @@ import OfficeBuildingOutline from 'vue-material-design-icons/OfficeBuildingOutli
 import RobotOutline from 'vue-material-design-icons/RobotOutline.vue'
 import ShieldAccountOutline from 'vue-material-design-icons/ShieldAccountOutline.vue'
 import ShieldLockOutline from 'vue-material-design-icons/ShieldLockOutline.vue'
+import SitemapOutline from 'vue-material-design-icons/SitemapOutline.vue'
 import TextBoxOutline from 'vue-material-design-icons/TextBoxOutline.vue'
 import TrayFull from 'vue-material-design-icons/TrayFull.vue'
 import ViewDashboardOutline from 'vue-material-design-icons/ViewDashboardOutline.vue'
@@ -78,6 +79,7 @@ export default {
 	RobotOutline,
 	ShieldAccountOutline,
 	ShieldLockOutline,
+	SitemapOutline,
 	TextBoxOutline,
 	TrayFull,
 	ViewDashboardOutline,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -522,7 +522,7 @@
     {
       "id": "Flows",
       "label": "Flows",
-      "icon": "Sitemap",
+      "icon": "SitemapOutline",
       "route": "flows",
       "section": "main",
       "order": 45


### PR DESCRIPTION
## The defect

The **Flows** entry in the app navigation renders with **no icon** — a blank where the glyph belongs.

`src/manifest.json:525` named it `"Sitemap"`. `src/icons.js` never registered that name, and the registry's own header states the consequence:

> A name that is not registered renders NO icon in the navigation — not a fallback glyph — so this file must cover every `icon` the manifests and register files name.

Surfaced by a full-tree Hydra gate run on `development`:

```
[gate-60] icon-vocabulary: FAIL — 1 icon(s) outside the canonical vocabulary (ADR-077)
FAIL  src/icons.js: 1 icon name(s) used by the manifests are NOT registered — they render
      with no icon at all, not a fallback: Sitemap (ADR-077 rule 3).
```

## Two things were wrong

Fixing either one alone leaves it broken:

1. **The name is outside the canonical vocabulary.** `hydra-gates/scripts/schemas/semantic-icons.json` carries **`SitemapOutline`**; `Sitemap` is not in it. `src/integrations/builtin/flow.js:23` already documents the intended name as `SitemapOutline`.
2. **Neither name was registered** in `src/icons.js`.

So the manifest moves to the canonical `SitemapOutline` *and* the registry gains it. `vue-material-design-icons` ships `SitemapOutline.vue`, so the import resolves.

## Can-fail proof

Run with the gate's own checker (`check_icon_vocabulary.py`), three trees:

| tree | result |
|---|---|
| **as committed** | `checked 16 manifest(s): 0 failure(s), 0 warning(s)` |
| manifest reverted to `"Sitemap"`, registration kept | `FAIL … NOT registered: Sitemap` — 1 failure |
| manifest kept at `SitemapOutline`, **registration removed** | `FAIL … NOT registered: SitemapOutline` — 1 failure |

The third row is the one that matters. It proves the `src/icons.js` half is **load-bearing** — the gate genuinely checks registration, so renaming the manifest alone would *not* have satisfied it. This is a fix, not a rename that quiets a substring match.

Both mutations were reverted and `git diff` confirms only the two intended hunks remain; `src/manifest.json` still parses.

## Scope

Two lines added to `src/icons.js`, one word changed in `src/manifest.json`. Takes gate-60 from FAIL to PASS, which is a real reduction in `development`'s failing-gate set (20 → 19 by name).
