### PR TITLE
fix(build): stop npm run build deleting the tracked flow-operator script

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -270,11 +270,35 @@ webpackConfig.plugins = [new VueLoaderPlugin(), ...otherPlugins]
 webpackConfig.resolve.alias['@nextcloud/dialogs$'] = path.resolve(__dirname, 'node_modules/@nextcloud/dialogs/dist/index.mjs')
 
 // The base config sets `output.clean: true`, which wipes js/ on every build.
-// The Web Push Service Worker + opt-in client (openregister-push-client.js /
-// openregister-push-sw.js) are hand-written static assets served as-is — NOT
-// webpack entries — so keep them through the clean, otherwise the build deletes
-// them and the toggle reports "browser does not support web push".
-webpackConfig.output.clean = { keep: (asset) => asset.includes('openregister-push-') }
+// Some assets under js/ are hand-written static files served as-is — NOT
+// webpack entries — so they must survive the clean, otherwise the build
+// deletes them and they come back as a spurious deletion in the next diff.
+//
+// Keep this list in sync with `git ls-files js/`. Anything TRACKED in js/ that
+// no entry in `webpackConfig.entry` emits belongs here. Today that is:
+//
+//   openregister-push-client.js  \  Web Push opt-in client + Service Worker.
+//   openregister-push-sw.js      /  Without these the toggle reports
+//                                   "browser does not support web push".
+//
+//   openregister-flow-operator.js   Registers the "Run an OpenRegister flow"
+//                                   operation with the workflowengine admin
+//                                   UI. Loaded by
+//                                   FlowEngineRegistrationListener.php:86 via
+//                                   \OCP\Util::addScript(). Losing it 404s
+//                                   that script and the operator silently
+//                                   stops appearing in Flow settings.
+//
+// This predicate previously matched only `openregister-push-`, so every build
+// deleted the flow-operator script. It was picked up as a deletion and shipped
+// in a PR at least once (#2381) before being caught.
+const KEPT_STATIC_ASSETS = [
+	'openregister-push-',
+	'openregister-flow-operator',
+]
+webpackConfig.output.clean = {
+	keep: (asset) => KEPT_STATIC_ASSETS.some((name) => asset.includes(name)),
+}
 
 // Code-splitting (frontend-code-splitting-and-fetch-efficiency): dynamically
 // imported view chunks are fetched at runtime relative to output.publicPath.


### PR DESCRIPTION
## The defect

**Every `npm run build` in this repo deletes a tracked, live source file.**

The base `@nextcloud/webpack-vue-config` sets `output.clean: true`, which wipes `js/` on each build. This app keeps hand-written static assets there, and the keep-predicate rescued only one prefix:

```js
webpackConfig.output.clean = { keep: (asset) => asset.includes('openregister-push-') }
```

So `js/openregister-flow-operator.js` was deleted on every build.

## Why that matters

That file is **not build output**:

- It is **tracked**, and `FlowEngineRegistrationListener.php:86` loads it at runtime — `\OCP\Util::addScript('openregister', 'openregister-flow-operator')`. Once deleted the script 404s and the **"Run an OpenRegister flow"** operation stops registering with the workflowengine admin UI.
- It is **not a webpack entry**. `webpackConfig.entry` declares seven — `main`, `integrationGlobal`, `adminSettings`, `personalSettings`, `filesSidebar`, `mailSidebar`, `userDashboard` — and none emits this filename.
- Its own header says so: *"Hand-written render-function component (no build step)."*

The failure mode is silent and recurring: run a build, and the deletion appears **staged** in your next diff. It reached a PR that way — #2381 carried it as a commit titled *"remove stale flow-operator bundle"* — and was only caught on review. Anyone who builds picks it up again.

## The fix

Replaces the single substring with a named list, documenting why each entry is on it and the rule for extending it: **anything tracked in `js/` that no `webpackConfig.entry` emits belongs here.** `git ls-files js/` returns exactly these three files today.

## Can-fail proof — the real build, both ways

Not a predicate unit test; the actual `npm run build`.

| | build | result |
|---|---|---|
| **before the fix** | `webpack 5.109.2 compiled … in 160825 ms`, exit 0 | `git status` → **` D js/openregister-flow-operator.js`**, gone from disk. Both `openregister-push-*` files survived — exactly matching the old predicate. |
| **after the fix** | `webpack 5.109.2 compiled … in 86398 ms`, exit 0 | `git status -- js/` **clean**; all three hand-written assets present at full size. |

**The control that makes the second row mean something:** the after-build re-emitted `openregister-main.js`, `openregister-settings.js` and `openregister-openregister-vendor.js`, which confirms `output.clean` genuinely ran. Without that check, "the file survived" would be equally consistent with the clean having been skipped — a pass that proves nothing.

One honest note on process: my first attempt at the after-build returned **exit 127, `webpack: not found`** (`node_modules` had been removed underneath me by unrelated disk pressure). `git status` was clean at that point too — a "clean" produced by the build never running, which is exactly the shape this PR is about. I reinstalled and re-ran rather than reading that as a pass.

## Scope

One file, `webpack.config.js`. No behavioural change to any bundle — the emitted entries are identical; only which pre-existing files survive the clean changes. The build side-effect on `docs/features.json` was reverted and is not in this commit.
