### PR TITLE
fix(e2e): retain-on-failure traces + a globalTimeout under the 45m CI cap

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,6 +37,17 @@ export default defineConfig({
 	fullyParallel: false,
 	retries: process.env.CI ? 1 : 0,
 	workers: 1,
+	// The shared quality.yml Playwright job is `timeout-minutes: 45`, and a job
+	// cancelled by that cap produces NO verdict: Playwright never prints its
+	// tally, the `if: failure()` trace upload never fires, and the
+	// `if: always()` report upload does not run on a cancelled job either — the
+	// run you most need to read is the one that leaves nothing behind, and it
+	// still renders as "fail" in `gh pr checks` while carrying no information.
+	// Runs cancelled at ~45m16s have been observed in this fleet. Measured
+	// overhead before `Run Playwright tests` starts is 2.0-2.4 min and the
+	// uploads after it take seconds, so 38m keeps ~7 min of margin while
+	// guaranteeing both a tally and the artifacts that explain it.
+	globalTimeout: 38 * 60_000,
 	reporter: [
 		['list'],
 		['html', { open: 'never', outputFolder: 'tests/e2e/playwright-report' }],
@@ -55,7 +66,15 @@ export default defineConfig({
 				`${process.env.OR_USER || 'admin'}:${process.env.OR_PASS || 'admin'}`,
 			).toString('base64')}`,
 		},
-		trace: 'on-first-retry',
+		// `on-first-retry` writes a trace only when a retry actually happens, so
+		// the trace artifact is a function of `retries`. Off CI `retries` is 0
+		// above, so a local failure has never produced a trace at all; on CI it
+		// traces the SECOND attempt only, which means the failure that does not
+		// reproduce — the one actually worth a trace — leaves no record of the
+		// attempt that failed. `retain-on-failure` traces every attempt and
+		// keeps the ones that failed: strictly more informative, and
+		// independent of the retry count.
+		trace: 'retain-on-failure',
 		screenshot: 'only-on-failure',
 	},
 

--- a/tests/e2e/ci/playwright.config.ts
+++ b/tests/e2e/ci/playwright.config.ts
@@ -43,6 +43,18 @@ export default defineConfig({
 	// without hiding a real failure — a broken assertion fails twice.
 	retries: process.env.CI ? 1 : 0,
 	workers: 1,
+	// This is the config the shared workflow actually loads (it resolves
+	// `${playwright-test-path}/playwright.config.ts` — here `tests/e2e/ci` —
+	// before falling back to the app-root one), so the timeout belongs here.
+	// The job is `timeout-minutes: 45`, and a job cancelled by that cap
+	// produces NO verdict: Playwright never prints its tally, the
+	// `if: failure()` trace upload never fires, and the `if: always()` report
+	// upload does not run on a cancelled job either — which would undo the
+	// reporter and outputDir fixes noted just below, since a cancelled job
+	// uploads nothing however correct the paths are. Measured overhead before
+	// `Run Playwright tests` starts is 2.0-2.4 min and the uploads after it
+	// take seconds, so 38m keeps ~7 min of margin.
+	globalTimeout: 38 * 60_000,
 	reporter: [
 		['list'],
 		// The shared workflow uploads `tests/e2e/playwright-report/` as the


### PR DESCRIPTION
Part of the fleet-wide Playwright instrument sweep for ConductionNL/.github#188. Neither change can alter a verdict — both change whether you can *see* why a verdict happened.

## trace

`trace: 'on-first-retry'` only writes a trace when a retry actually happens, which makes the trace artifact a function of `retries`. `retain-on-failure` captures every test, keeps only the failures, and does not depend on the retry count.

Reproduced with two minimal Playwright projects differing only in the `trace` value, same deliberately failing test, `retries: 0` in both:

| config | trace zips written |
|---|---|
| `retries: 0` + `on-first-retry` | **0** |
| `retries: 0` + `retain-on-failure` | **1** (7.4 KB) |

## globalTimeout: 38 * 60_000

The shared `quality.yml` Playwright job is `timeout-minutes: 45`. A job cancelled by that cap yields **no verdict and no artifacts** — the trace upload is `if: failure()`, the report upload is `if: always()`, and neither runs on a cancelled job, while `gh pr checks` still renders it as "fail". Runs cancelled at ~45m16s have been observed in this fleet.

Margin, measured rather than assumed: overhead before `Run Playwright tests` starts is 2.0-2.4 min (openconnector run 31257480415 = 2m20s; opencatalogi, doriath, openregister in the same band); uploads after it take seconds. 38m + ~2.5m setup + uploads sits ~7 min under the cap. Verified that a fired `globalTimeout` exits with a tally (`3 did not run / 1 passed`) plus an HTML report and a trace zip on disk — exactly what a cancelled job does not give you.

Matches the value already landed in nldesign.