### PR TITLE
chore: raise Nextcloud floor to 32 and PHP floor to 8.3 on main

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -66,11 +66,21 @@ Vrij en open source onder de EUPL-licentie.
     </documentation>
 
     <dependencies>
-        <php min-version="8.0" min-int-size="64"/>
+        <php min-version="8.3" min-int-size="64"/>
         <database min-version="10">pgsql</database>
         <database>sqlite</database>
         <database min-version="8.0">mysql</database>
-        <nextcloud min-version="28" max-version="34"/>
+        <!--
+            Nextcloud minimum is 32 so this app can require PHP 8.3, which is the
+            fleet-wide standard. OpenRegister is the foundation the other Conduction
+            apps build on, so its minimum sets the floor for all of them: an app may
+            not advertise a Nextcloud minimum lower than the minimum of any app it
+            depends on, or the App Store offers a version range in which the
+            dependency refuses to install. See openconnector issues 1172 and 1173.
+            The development branch of this app already declares a Nextcloud
+            minimum of 32.
+        -->
+        <nextcloud min-version="32" max-version="34"/>
     </dependencies>
 
 	<repair-steps>


### PR DESCRIPTION
Raises the Nextcloud floor on `main` from **28 to 32** and the PHP floor from **8.0 to 8.3**. `max-version` preserved unchanged at **34**. `min-int-size="64"` preserved on the php element.

## Why

Product directive from the PO (Ruben): the fleet standardises on Nextcloud 32 so it can require PHP 8.3 — *"we want php 8.3 so going for min version nc 32 fleet wide is a good thing."*

The governing rule (openconnector#1172 / #1173): an app's `min-version` must be **>= the max of every app dependency's floor**, or the App Store advertises a range the app cannot deliver — the dependency refuses to install and the app is non-functional there.

`openregister@development` declares a Nextcloud floor of **32** (re-measured live with an XML parser immediately before this PR was written; also php floor 8.3).

## Shape

**Floor-only PR, opened directly against `main`.** Reason: `main` trails `development` by 188–5206 commits across this fleet (openregister alone is 5206 ahead), so a `development → main` merge would be a full release, not a floor fix. This PR changes `appinfo/info.xml` only.

## Method note

All floors were measured by parsing `appinfo/info.xml` with `xml.etree.ElementTree`, **not** grep. These files contain literal nextcloud-element examples *inside XML comments*, and grepping them has already produced false floor readings. The added comment is deliberately written in **prose with no angle-bracket XML syntax**: floor guards in this fleet count raw regex matches of the nextcloud element across the whole file including comments, and a quoted example would read as a second, contradictory declaration. Validated before push: the file parses as XML, and `<nextcloud\b[^>]*>` matches **exactly once**.

## Measured before / after (`main`)

| | before | after |
|---|---|---|
| nextcloud min-version | 28 | **32** |
| nextcloud max-version | 34 | 34 (unchanged) |
| php min-version | 8.0 | **8.3** |

## CI

Verified, not assumed: `.github/workflows/code-quality.yml` on `main` already sets `nextcloud-test-refs: '["stable32"]'` and `php-test-versions: '["8.3","8.4"]'`. **No CI leg installs Nextcloud < 32 and none runs PHP < 8.3, so no CI change is needed and no leg was dropped.**