### PR TITLE
fix(spec): resolve all 49 gate-46 @spec anchor findings (21 targets)

### DIFF
--- a/lib/ContextChat/ContentProviderRegistrationListener.php
+++ b/lib/ContextChat/ContentProviderRegistrationListener.php
@@ -22,7 +22,7 @@
  *
  * @template-implements IEventListener<ContentProviderRegisterEvent>
  *
- * @spec openspec/specs/context-chat-provider/spec.md#requirement-openregister-must-register-a-context-chat-content-provider-only-when-the-platform-is-available
+ * @spec openspec/specs/context-chat-provider/spec.md#openregister-registers-a-context-chat-content-provider-only-when-the-platform-is-available
  */
 
 declare(strict_types=1);
@@ -39,7 +39,7 @@ use OCP\EventDispatcher\IEventListener;
  * `IContentManager::isContextChatAvailable()` so a standalone instance
  * without the `context_chat` app installed is entirely unaffected.
  *
- * @spec openspec/specs/context-chat-provider/spec.md#requirement-openregister-must-register-a-context-chat-content-provider-only-when-the-platform-is-available
+ * @spec openspec/specs/context-chat-provider/spec.md#openregister-registers-a-context-chat-content-provider-only-when-the-platform-is-available
  */
 class ContentProviderRegistrationListener implements IEventListener
 {
@@ -50,7 +50,7 @@ class ContentProviderRegistrationListener implements IEventListener
      *
      * @return void
      *
-     * @spec openspec/specs/context-chat-provider/spec.md#requirement-openregister-must-register-a-context-chat-content-provider-only-when-the-platform-is-available
+     * @spec openspec/specs/context-chat-provider/spec.md#openregister-registers-a-context-chat-content-provider-only-when-the-platform-is-available
      */
     public function __construct(
         private readonly IContentManager $contentManager
@@ -66,7 +66,7 @@ class ContentProviderRegistrationListener implements IEventListener
      *
      * @return void
      *
-     * @spec openspec/specs/context-chat-provider/spec.md#requirement-openregister-must-register-a-context-chat-content-provider-only-when-the-platform-is-available
+     * @spec openspec/specs/context-chat-provider/spec.md#openregister-registers-a-context-chat-content-provider-only-when-the-platform-is-available
      */
     public function handle(Event $event): void
     {

--- a/lib/Controller/ManifestController.php
+++ b/lib/Controller/ManifestController.php
@@ -21,7 +21,7 @@
  *
  * @link https://OpenRegister.app
  *
- * @spec openspec/changes/manifest-user-context/tasks.md
+ * @spec openspec/specs/openregister-app-manifest/spec.md#req-or-man-012
  *
  * @psalm-suppress UnusedClass
  */
@@ -49,7 +49,7 @@ use Throwable;
  * can still load a manifest and receive `runtime.user = null`; public pages
  * are filtered by nc-vue using that null signal.
  *
- * @spec openspec/changes/manifest-user-context/tasks.md
+ * @spec openspec/specs/openregister-app-manifest/spec.md#req-or-man-012
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
@@ -89,7 +89,7 @@ class ManifestController extends Controller
      * @NoCSRFRequired
      * @PublicPage
      *
-     * @spec openspec/changes/manifest-user-context/tasks.md
+     * @spec openspec/specs/openregister-app-manifest/spec.md#req-or-man-012
      */
     #[NoAdminRequired]
     #[NoCSRFRequired]
@@ -143,7 +143,7 @@ class ManifestController extends Controller
      * @SuppressWarnings(PHPMD.StaticAccess)
      *
      * @spec exclude Private helper: loads + JSON-decodes a host app's bundled manifest.json; the manifest endpoint
-     *              contract is owned by manifest-user-context/tasks.md.
+     *              contract is owned by openregister-app-manifest REQ-OR-MAN-012.
      */
     private function loadBundledManifest(string $appId): ?array
     {

--- a/lib/Db/WebhookMapper.php
+++ b/lib/Db/WebhookMapper.php
@@ -293,7 +293,7 @@ class WebhookMapper extends QBMapper
      *
      * @psalm-return list<\OCA\OpenRegister\Db\Webhook>
      *
-     * @spec openspec/specs/webhook-payload-mapping/spec.md#request-interception-pre-event-webhooks
+     * @spec openspec/specs/webhook-payload-mapping/spec.md#request-interception-must-support-pre-event-webhooks
      */
     public function findEnabledForInterceptionScan(): array
     {

--- a/lib/Middleware/Exception/ChatProxiedResponseException.php
+++ b/lib/Middleware/Exception/ChatProxiedResponseException.php
@@ -32,7 +32,7 @@
  *
  * @link https://OpenRegister.app
  *
- * @spec openspec/changes/or-chat-proxy-deprecation/design.md#the-proxy-short-circuit-is-an-exception-not-an-inline-return
+ * @spec openspec/changes/or-chat-proxy-deprecation/design.md#the-short-circuit-is-an-exception-not-an-inline-return
  */
 
 declare(strict_types=1);

--- a/lib/Service/Configuration/GitHubRequestValidator.php
+++ b/lib/Service/Configuration/GitHubRequestValidator.php
@@ -198,7 +198,7 @@ class GitHubRequestValidator
      *
      * @return JSONResponse|null Null on success/absence, 400 with structured error_code on failure.
      *
-     * @spec openspec/changes/add-features-roadmap-menu/tasks.md#task-20b
+     * @spec openspec/specs/github-issue-proxy/spec.md#issues-list-endpoint
      */
     public function validateLabels(?array $labels): ?JSONResponse
     {

--- a/lib/Service/ExportService.php
+++ b/lib/Service/ExportService.php
@@ -623,7 +623,7 @@ class ExportService
      *
      * @return Spreadsheet Spreadsheet with a single sheet containing only header cells
      *
-     * @spec openspec/specs/data-import-export/spec.md#import-templates-downloadable-per-schema (builds a header-only
+     * @spec openspec/specs/data-import-export/spec.md#import-templates-must-be-downloadable-per-schema (builds a header-only
      *       template spreadsheet from a schema's properties, with register-context per-language column expansion)
      */
     public function buildTemplateSpreadsheet(
@@ -661,7 +661,7 @@ class ExportService
      *
      * @return string CSV content with a UTF-8 BOM prefix and a single header row
      *
-     * @spec openspec/specs/data-import-export/spec.md#import-templates-downloadable-per-schema (renders the per-schema
+     * @spec openspec/specs/data-import-export/spec.md#import-templates-must-be-downloadable-per-schema (renders the per-schema
      *       import template as a UTF-8 BOM-prefixed CSV so Excel opens it correctly)
      */
     public function buildTemplateCsv(

--- a/lib/Service/ImportService.php
+++ b/lib/Service/ImportService.php
@@ -211,7 +211,7 @@ class ImportService
      *     errors: list<array{uuid: string, error: string}>
      * }
      *
-     * @spec openspec/specs/data-import-export/spec.md#import-rollback-on-critical-failure (rolls back an import
+     * @spec openspec/specs/data-import-export/spec.md#import-must-support-rollback-on-critical-failure (rolls back an import
      *       unit: finds every create-audited object for the import job UUID and soft-deletes them, reporting
      *       per-object outcomes)
      */
@@ -2356,7 +2356,7 @@ class ImportService
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      *
-     * @spec openspec/changes/data-import-export/tasks.md#task-error-csv
+     * @spec openspec/specs/data-import-export/spec.md#import-must-provide-detailed-error-reporting-with-downloadable-error-files
      */
     public function serializeErrorsToCsv(array $summary): string
     {

--- a/lib/Service/LanguageService.php
+++ b/lib/Service/LanguageService.php
@@ -303,7 +303,7 @@ class LanguageService
      *
      * @return string[] Ordered array of language codes (highest priority first)
      *
-     * @spec openspec/specs/register-i18n/spec.md#language-negotiation-accept-language (parses the Accept-Language
+     * @spec openspec/specs/register-i18n/spec.md#the-api-must-support-language-negotiation-via-accept-language-header (parses the Accept-Language
      *       header per RFC 9110, ordering language tags by descending q-value then appearance)
      */
     public static function parseAcceptLanguageHeader(string $headerValue): array

--- a/lib/Service/ManifestService.php
+++ b/lib/Service/ManifestService.php
@@ -28,7 +28,7 @@
  *
  * @link https://OpenRegister.app
  *
- * @spec openspec/changes/manifest-user-context/tasks.md
+ * @spec openspec/specs/openregister-app-manifest/spec.md#req-or-man-013
  */
 
 declare(strict_types=1);
@@ -124,7 +124,7 @@ class ManifestService
      *   returns requires several guard branches; removing any guard would introduce
      *   an injection or data-leak risk.
      *
-     * @spec openspec/changes/manifest-user-context/tasks.md#task-1
+     * @spec openspec/specs/openregister-app-manifest/spec.md#req-or-man-013
      */
     public function getEnrichedManifest(array $manifest): array
     {

--- a/lib/Service/MigrationPack/MappingEngine.php
+++ b/lib/Service/MigrationPack/MappingEngine.php
@@ -58,7 +58,7 @@ class MappingEngine
      *
      * @return array{data: array<string, mixed>, errors: list<array{row: int, source: string, target: ?string, transform: ?string, message: string}>}
      *
-     * @spec openspec/specs/migration-mapping-packs/spec.md#mapping-engine
+     * @spec openspec/specs/migration-mapping-packs/spec.md#the-mapping-engine-must-apply-pack-transforms-per-row-and-never-leak-unresolved-references
      */
     public function mapRow(array $pack, array $sourceRow, int $rowNumber): array
     {

--- a/lib/Service/MigrationPack/PackDefinitionValidator.php
+++ b/lib/Service/MigrationPack/PackDefinitionValidator.php
@@ -73,7 +73,7 @@ class PackDefinitionValidator
      *
      * @return string[] List of validation error messages. Empty when valid.
      *
-     * @spec openspec/specs/migration-mapping-packs/spec.md#validation
+     * @spec openspec/specs/migration-mapping-packs/spec.md#the-system-must-validate-migration-pack-definitions-structurally-before-storing-them
      */
     public function validate(array $definition): array
     {
@@ -100,7 +100,7 @@ class PackDefinitionValidator
      *
      * @throws InvalidArgumentException When the definition is invalid. The message joins every error found.
      *
-     * @spec openspec/specs/migration-mapping-packs/spec.md#validation
+     * @spec openspec/specs/migration-mapping-packs/spec.md#the-system-must-validate-migration-pack-definitions-structurally-before-storing-them
      */
     public function assertValid(array $definition): void
     {

--- a/lib/Service/OperatorEvaluator.php
+++ b/lib/Service/OperatorEvaluator.php
@@ -55,7 +55,8 @@ class OperatorEvaluator
      *
      * @return bool True if value matches all operators
      *
-     * @spec openspec/specs/row-field-level-security/spec.md#mongodb-style-operators (evaluates $eq/$ne/$in/$nin/$exists/$gt/$gte/$lt/$lte
+     * @spec openspec/specs/row-field-level-security/spec.md#the-condition-syntax-must-support-mongodb-style-operators-for-match-expressions
+     *       (evaluates $eq/$ne/$in/$nin/$exists/$gt/$gte/$lt/$lte
      *       for RLS/FLS match conditions, fail-closed on unknown operators with null-handling that mirrors SQL
      *       three-valued logic so list and find verdicts stay aligned)
      */

--- a/lib/Service/PropertyRbacHandler.php
+++ b/lib/Service/PropertyRbacHandler.php
@@ -135,7 +135,7 @@ class PropertyRbacHandler
      *
      * @return array Filtered object with only readable properties
      *
-     * @spec openspec/specs/row-field-level-security/spec.md#fls-strips-restricted-fields (strips unreadable
+     * @spec openspec/specs/row-field-level-security/spec.md#fls-must-strip-restricted-fields-from-api-responses-and-export-outputs (strips unreadable
      *       property-authorized fields from outgoing data; admin + no-property-auth short-circuit)
      * @spec openspec/specs/row-field-level-security/spec.md#requirement-writeonly-properties-must-never-be-returned-on-any-read
      *       (writeOnly stripping runs before the admin bypass — admin is NOT exempt from writeOnly)

--- a/lib/Service/RegisterService.php
+++ b/lib/Service/RegisterService.php
@@ -390,7 +390,7 @@ class RegisterService
      *
      * @throws Exception If register creation fails
      *
-     * @spec openspec/specs/file-actions/spec.md#object-register-folder-management
+     * @spec openspec/specs/file-actions/spec.md#object-and-register-folder-provisioning
      *   (after mapper create, assigns the active/default organisation for multi-tenancy
      *   and provisions the register's backing folder)
      */
@@ -438,7 +438,7 @@ class RegisterService
      *
      * @throws Exception If register update fails
      *
-     * @spec openspec/specs/file-actions/spec.md#object-register-folder-management
+     * @spec openspec/specs/file-actions/spec.md#object-and-register-folder-provisioning
      *   (after mapper update, ensures the register's backing folder exists,
      *   healing legacy null/string folder properties)
      */

--- a/lib/Service/TenantKeyService.php
+++ b/lib/Service/TenantKeyService.php
@@ -28,7 +28,7 @@
  *
  * @link https://OpenRegister.app
  *
- * @spec openspec/changes/scholiq-deps/tenant-key-api/tasks.md
+ * @spec openspec/specs/saas-multi-tenant/spec.md#tenantkeyservice-must-be-di-registered-as-a-server-side-internal-api
  */
 
 declare(strict_types=1);
@@ -101,7 +101,7 @@ class TenantKeyService
      *
      * @throws RuntimeException When key decryption fails
      *
-     * @spec openspec/changes/scholiq-deps/tenant-key-api/tasks.md
+     * @spec openspec/specs/saas-multi-tenant/spec.md#per-tenant-active-hmac-key-must-be-a-single-most-recent-row
      */
     public function getCurrentTenantKey(string $tenantId): string
     {
@@ -140,7 +140,7 @@ class TenantKeyService
      *
      * @throws RuntimeException When key encryption fails
      *
-     * @spec openspec/changes/scholiq-deps/tenant-key-api/tasks.md
+     * @spec openspec/specs/saas-multi-tenant/spec.md#new-active-keys-must-be-stored-encrypted-with-status-active
      */
     public function rotateTenantKey(string $tenantId): array
     {

--- a/lib/Service/Webhook/WebhookInterceptionCache.php
+++ b/lib/Service/Webhook/WebhookInterceptionCache.php
@@ -129,7 +129,7 @@ class WebhookInterceptionCache
      *
      * @return bool|null True/false when cached, null on cache miss.
      *
-     * @spec openspec/specs/webhook-payload-mapping/spec.md#request-interception-pre-event-webhooks
+     * @spec openspec/specs/webhook-payload-mapping/spec.md#request-interception-must-support-pre-event-webhooks
      */
     public function get(string $eventType): ?bool
     {
@@ -155,7 +155,7 @@ class WebhookInterceptionCache
      *
      * @return void
      *
-     * @spec openspec/specs/webhook-payload-mapping/spec.md#request-interception-pre-event-webhooks
+     * @spec openspec/specs/webhook-payload-mapping/spec.md#request-interception-must-support-pre-event-webhooks
      */
     public function set(string $eventType, bool $hasWebhooks): void
     {
@@ -172,7 +172,7 @@ class WebhookInterceptionCache
      *
      * @return void
      *
-     * @spec openspec/specs/webhook-payload-mapping/spec.md#request-interception-pre-event-webhooks
+     * @spec openspec/specs/webhook-payload-mapping/spec.md#request-interception-must-support-pre-event-webhooks
      */
     public function invalidate(): void
     {

--- a/lib/Service/WebhookService.php
+++ b/lib/Service/WebhookService.php
@@ -1396,7 +1396,7 @@ class WebhookService
      * @SuppressWarnings(PHPMD.NPathComplexity)      Multiple webhook processing paths
      * Fallback when formatter is unavailable
      *
-     * @spec openspec/specs/webhook-payload-mapping/spec.md#request-interception-pre-event-webhooks
+     * @spec openspec/specs/webhook-payload-mapping/spec.md#request-interception-must-support-pre-event-webhooks
      *   (finds before-event webhooks for the event type, formats the request as a CloudEvent, delivers to each,
      *   and continues past per-webhook failures, returning the request data)
      */
@@ -1538,7 +1538,7 @@ class WebhookService
      *
      * @return bool True when the webhook intercepts requests for the event type
      *
-     * @spec openspec/specs/webhook-payload-mapping/spec.md#request-interception-pre-event-webhooks
+     * @spec openspec/specs/webhook-payload-mapping/spec.md#request-interception-must-support-pre-event-webhooks
      */
     private function matchesInterception(Webhook $webhook, string $eventType): bool
     {
@@ -1577,7 +1577,7 @@ class WebhookService
      *
      * @return bool True when at least one enabled interception webhook exists for the event type
      *
-     * @spec openspec/specs/webhook-payload-mapping/spec.md#request-interception-pre-event-webhooks
+     * @spec openspec/specs/webhook-payload-mapping/spec.md#request-interception-must-support-pre-event-webhooks
      */
     private function hasInterceptionWebhooks(string $eventType): bool
     {

--- a/openspec/specs/apphost-store-plane/spec.md
+++ b/openspec/specs/apphost-store-plane/spec.md
@@ -1,0 +1,202 @@
+---
+status: done
+---
+
+# apphost-store-plane Specification
+
+## Purpose
+
+Gives any AppHost-hosted app a read-only client for a remote "store" — another
+OpenRegister instance that exposes installable items over its objects API — so
+openbuild's application-template store, openconnector's connector store and
+hermiq's agent-template store share one engine-owned implementation instead of
+three app-local copies. The plane covers DISCOVERY only (configure / search /
+resolve); INSTALL stays in each consuming app, because cloning an application
+template, enabling a connector adapter and instantiating an agent template are
+different operations with different authorization. Everything that differs
+between apps is carried in a `StoreDescriptor` value object; everything else —
+SSRF guarding, redirect refusal, Bearer-token handling, outcome mapping and card
+normalisation — lives once in `GenericStoreService`. Implements ADR-080.
+
+@e2e exclude Backend HTTP client with no OpenRegister UI surface of its own — the store page belongs to the consuming app, and every behaviour here (SSRF rejection, redirect refusal, Bearer-only token transport, outcome mapping, card normalisation, descriptor-driven URL, slug verification) is asserted in tests/Unit/AppHost/GenericStoreServiceTest.php. Covered by PHPUnit.
+
+## Requirements
+
+### Requirement: A store descriptor MUST carry every per-app parameter
+
+`StoreDescriptor` SHALL be an immutable value object holding the `appId` whose
+`IAppConfig` carries the registry connection (`registry_url`, `registry_token`,
+`registry_register`), the remote `schema` slug, the `defaultRegister` used when
+`registry_register` is unset or empty, and a `cardFields` map of card field name
+to remote object property. The default `cardFields` map SHALL be `slug`, `title`,
+`description`, `category`, `version`. No other per-app parameter may be read by
+the generic service.
+
+#### Scenario: Two apps reach two different remote schemas
+
+- **GIVEN** descriptors for `openbuild`/`application-template` and
+  `openconnector`/`catalog_item`
+- **WHEN** each is passed to `GenericStoreService::search()`
+- **THEN** the outbound URL MUST be
+  `<base>/index.php/apps/openregister/api/objects/<register>/<schema>` with the
+  register and schema of that descriptor
+- **AND** the register segment MUST come from the app's `registry_register`
+  config, falling back to the descriptor's `defaultRegister` when that value is
+  absent or empty
+- **AND** both segments MUST be `rawurlencode`d
+
+---
+
+### Requirement: An unconfigured store MUST make no network call
+
+`GenericStoreService::isConfigured()` SHALL report a store as configured only
+when the app's `registry_url` trims to a non-empty string. When it is not
+configured, `search()` MUST return outcome `not_configured` with an empty card
+list and `resolve()` MUST return `null`, and neither MUST issue an HTTP request.
+This is the fallback that lets a consuming app's store page render its built-in
+items instead of an error.
+
+#### Scenario: Empty registry URL short-circuits the search
+
+- **GIVEN** `registry_url` is the empty string for the descriptor's app
+- **WHEN** `search()` is called
+- **THEN** the outcome MUST be `not_configured` and the card list MUST be empty
+- **AND** no HTTP client MUST be constructed
+
+---
+
+### Requirement: Every outbound registry URL MUST be SSRF-guarded and MUST NOT follow redirects
+
+The service SHALL pass every built URL through
+`SecurityService::assertSafeFetchUrl()` before any request is issued, and SHALL
+fail closed: a private, reserved, loopback or unresolvable host, and any
+non-`http(s)` scheme, MUST yield outcome `store_unreachable` with no request
+made. The request options MUST set `allow_redirects` to `false`, because
+`assertSafeFetchUrl` validates the URL at one point in time and following a 3xx
+would let a public host redirect the registry Bearer token to a private,
+link-local or metadata address (or exploit DNS rebinding between validation and
+connect). Connect and request timeouts MUST both be 10 seconds.
+
+#### Scenario: Private-address registry is rejected before the request
+
+- **GIVEN** `registry_url` is `http://192.168.1.10/`
+- **WHEN** `search()` is called
+- **THEN** the outcome MUST be `store_unreachable`
+- **AND** no HTTP client MUST be constructed
+
+#### Scenario: Non-http scheme is rejected fail-closed
+
+- **GIVEN** `registry_url` is `file:///etc/passwd`
+- **WHEN** `search()` is called
+- **THEN** the outcome MUST be `store_unreachable` and no request MUST be issued
+
+#### Scenario: Unresolvable host is rejected fail-closed
+
+- **GIVEN** `registry_url` names a host that does not resolve
+- **WHEN** `search()` is called
+- **THEN** the outcome MUST be `store_unreachable` and no request MUST be issued
+
+#### Scenario: Redirects are refused
+
+- **GIVEN** a configured, publicly-addressable registry
+- **WHEN** the service fetches from it
+- **THEN** the request options MUST carry `allow_redirects => false`
+
+---
+
+### Requirement: The registry token MUST travel only as a Bearer header
+
+When `registry_token` trims to a non-empty string it MUST be sent as an
+`Authorization: Bearer <token>` request header and MUST NOT appear in the URL or
+in the query parameters. The token MUST NOT be returned to callers in any
+outcome, card or resolved payload.
+
+#### Scenario: Token is absent from URL and query
+
+- **GIVEN** a configured registry with `registry_token` set
+- **WHEN** the service fetches from it
+- **THEN** the `Authorization` header MUST be `Bearer <token>`
+- **AND** neither the request URL nor the encoded query MUST contain the token
+
+---
+
+### Requirement: Upstream failures MUST map to generic outcomes, distinguishing unreachable from invalid
+
+A transport exception, a non-2xx status and a refused/guarded URL MUST all yield
+`store_unreachable`; a body that is not decodable JSON, or decodes to a
+non-array, MUST yield `store_invalid_response`. The two MUST NOT be collapsed —
+a misconfigured store would otherwise look offline. Upstream error detail MUST
+be logged server-side and MUST NOT reach the caller. A successful body MUST be
+read from its `results` key when present, and a bare JSON list MUST also be
+accepted; any other successful decode MUST be treated as zero results rather
+than iterated, because a caller iterating an associative array would walk its
+values as if they were records.
+
+#### Scenario: Transport failure yields a generic outcome
+
+- **GIVEN** the HTTP client throws while fetching
+- **WHEN** `search()` handles it
+- **THEN** the outcome MUST be `store_unreachable` with an empty card list
+- **AND** the upstream message MUST NOT appear in the returned value
+
+#### Scenario: Non-2xx status is unreachable, not an empty success
+
+- **GIVEN** the registry answers HTTP 503
+- **WHEN** `search()` handles it
+- **THEN** the outcome MUST be `store_unreachable`
+
+#### Scenario: Unparseable body is distinguishable from an empty one
+
+- **GIVEN** the registry answers 200 with a non-JSON body
+- **WHEN** `search()` handles it
+- **THEN** the outcome MUST be `store_invalid_response`
+
+---
+
+### Requirement: Search MUST return normalised cards that never carry the install payload
+
+`search()` SHALL request at most 50 items, SHALL forward a trimmed non-empty
+`$query` as `_search` and a trimmed non-empty `$kind` as `kind`, and SHALL
+flatten each returned object to a card using ONLY the descriptor's `cardFields`
+map plus a `kind` field. A field whose remote property is missing MUST be
+rendered as the empty string rather than omitted, so the frontend never has to
+null-check a card. Any remote property outside the map — including a `manifest`
+or a credential-shaped field — MUST NOT appear on the card.
+
+#### Scenario: Cards carry the descriptor's fields plus kind
+
+- **GIVEN** a registry returning an object with `slug`, `title`, `description`,
+  `category`, `version` and `kind`
+- **WHEN** `search()` normalises it
+- **THEN** the card MUST carry each descriptor field and `kind`
+
+#### Scenario: Fields outside the descriptor are dropped
+
+- **GIVEN** a registry returning an object that also carries `manifest` and
+  `token`
+- **WHEN** `search()` normalises it
+- **THEN** the card MUST NOT contain `manifest` and MUST NOT contain `token`
+
+---
+
+### Requirement: Resolve MUST verify the returned slug and return the full payload
+
+`resolve()` SHALL request `slug=<slug>` with a limit of 1 and SHALL return an
+item only when the object the registry actually returned carries that exact
+`slug`; otherwise it MUST return `null`. A registry that ignores an unknown
+query parameter would otherwise hand back an arbitrary first row. On success the
+FULL remote object MUST be returned — unlike a search card — because the calling
+app's install action needs the payload.
+
+#### Scenario: A mismatched slug resolves to null
+
+- **GIVEN** the registry returns an object whose `slug` is not the requested one
+- **WHEN** `resolve()` inspects it
+- **THEN** the result MUST be `null`
+
+#### Scenario: A matching slug returns the untrimmed object
+
+- **GIVEN** the registry returns an object with the requested `slug` and a
+  `manifest` property
+- **WHEN** `resolve()` returns it
+- **THEN** the returned array MUST still contain `manifest`

--- a/openspec/specs/deprecate-published-metadata/spec.md
+++ b/openspec/specs/deprecate-published-metadata/spec.md
@@ -42,7 +42,7 @@ The magic tables (`oc_or_*`) MUST NOT contain `_published` or `_depublished` col
 - **THEN** only objects with `publicatieDatum` in the past MUST be returned
 
 ### Requirement: Backward Compatibility
-Schema configuration containing the deprecated keys (`objectPublishedField`, `objectDepublishedField`, `autoPublish`) MUST be ignored without raising an error, and a deprecation warning MUST be logged when these keys are encountered. The `published`/`depublished` fields on the Register and Schema entities are out of scope (used for multi-tenancy bypass), and Nextcloud file publish/depublish operations are out of scope (handled by Nextcloud share management).
+Schema configuration containing the deprecated keys (`objectPublishedField`, `objectDepublishedField`, `autoPublish`) MUST be ignored without raising an error, and a deprecation warning MUST be logged when these keys are encountered. Nextcloud file publish/depublish operations are out of scope (handled by Nextcloud share management). The `published`/`depublished` fields on the Register and Schema entities were previously out of scope because the multi-tenancy filter used them as an anonymous-access bypass; that bypass has since been removed — see REQ-5 below, which is now the normative statement for those fields.
 
 #### Scenario: Deprecated Config Keys Ignored
 - **GIVEN** a schema with `objectPublishedField` in its configuration
@@ -57,3 +57,25 @@ The deprecation MUST ship with documentation that explains how to migrate from `
 - **WHEN** an operator with a schema using `objectPublishedField` consults the migration documentation
 - **THEN** the documentation MUST provide a step-by-step replacement using a `$now`-based RBAC rule
 - **AND** the example MUST be runnable against the current OpenRegister codebase
+
+### Requirement: REQ-5: The multi-tenancy filter MUST NOT bypass on published state
+`MultiTenancyTrait::applyOrganisationFilter()` MUST decide visibility from the organisation column alone and MUST NOT read a `published` or `depublished` column on any entity, including `Register` and `Schema`. The former published/depublished bypass — which widened a query for anonymous callers whenever a Register or Schema was marked published — is removed; anonymous visibility is now governed exclusively by RBAC (`authorization.read` containing `public` on the register/schema entity).
+
+The filter's remaining behaviour MUST be: it is skipped entirely when the caller passes `multiTenancyEnabled = false` or when the `openregister`/`multitenancy` app config declares `enabled: false`; an active organisation MUST match the caller's active organisation together with its parent organisations; an admin MUST see all entities only when `adminOverride` is enabled, and never in SaaS mode; and a caller with no active organisation MUST see `NULL`-organisation rows only when the caller explicitly passes `allowNullOrg`, otherwise the query MUST match nothing.
+
+#### Scenario: No published column is consulted
+- **GIVEN** any register, schema or object query that applies the organisation filter
+- **WHEN** the resulting SQL is inspected
+- **THEN** it MUST NOT reference a `published` or `depublished` column
+- **AND** visibility MUST be decided by the organisation column and RBAC alone
+
+#### Scenario: A published register is not anonymously visible by that fact alone
+- **GIVEN** a register whose legacy `published` field is set but whose RBAC `authorization.read` does not contain `public`
+- **WHEN** an anonymous caller lists registers
+- **THEN** the register MUST NOT be returned
+
+#### Scenario: No active organisation blocks results unless null-org is permitted
+- **GIVEN** a caller with no active organisation
+- **WHEN** the filter is applied without `allowNullOrg`
+- **THEN** the query MUST match nothing
+- **AND** with `allowNullOrg` it MUST match only rows whose organisation is `NULL`

--- a/openspec/specs/openregister-app-manifest/spec.md
+++ b/openspec/specs/openregister-app-manifest/spec.md
@@ -245,18 +245,136 @@ proposal is superseded by the shell-swap shipping the full shell at once).
 
 ### Requirement: REQ-OR-MAN-009 Backend `/api/manifest` endpoint is deferred @e2e exclude API-contract assertion (endpoint returns 404, loader falls back to bundled manifest) — covered by Newman
 
-OpenRegister SHALL NOT implement `GET /index.php/apps/openregister/api/
-manifest`. `useAppManifest`'s silent fallback on 404 makes absence
-non-regressive; the manifest ships statically inside the bundle. A follow-up
-change driven by a real admin-customisation use case (App Builder reorders
-menu / hides pages / overrides locale per tenant) SHALL add the endpoint
-when needed.
+**SUPERSEDED by REQ-OR-MAN-012.** The original deferral below no longer
+describes the shipped code: the endpoint exists, is routed, and is exercised.
+This heading is retained so existing references resolve; the normative statement
+is REQ-OR-MAN-012.
 
-#### Scenario: Endpoint returns 404 today
+The deferral read: OpenRegister SHALL NOT implement `GET
+/index.php/apps/openregister/api/manifest`; `useAppManifest`'s silent fallback on
+404 makes absence non-regressive, and a follow-up change driven by a real
+admin-customisation use case SHALL add the endpoint when needed. That follow-up
+landed — the driving use case was per-user `runtime.user` context for host apps.
 
-- **WHEN** a request hits `/index.php/apps/openregister/api/manifest`
+#### Scenario: The bundled-manifest fallback still holds for unknown apps
+
+- **WHEN** a request hits `/index.php/apps/openregister/api/manifest/{appId}`
+  for an app that ships no bundled manifest
 - **THEN** the response is HTTP 404 and the loader silently keeps the
   bundled manifest
+
+---
+
+### Requirement: REQ-OR-MAN-012 Backend manifest endpoint serves a host app's bundled manifest @e2e exclude API-contract assertion (public endpoint, appId validation, 404/500 mapping, ETag/304) — covered by Newman
+
+OpenRegister SHALL route `GET /index.php/apps/openregister/api/manifest/{appId}`
+to `ManifestController::index()`. The endpoint SHALL be a public page with no
+CSRF requirement and no admin requirement, so an unauthenticated client can load
+a manifest and receive `runtime.user = null` — nc-vue filters public pages on
+that null signal. `appId` SHALL be validated against `^[a-z0-9_-]+$` (case
+insensitive) before any path resolution, and SHALL yield HTTP 400 otherwise. The
+controller SHALL load the named app's bundled `manifest.json` through the
+Nextcloud app manager, return HTTP 404 when it is absent or unreadable, and
+return HTTP 500 with a generic body — logging the detail server-side — when
+enrichment throws. On success it SHALL return the enriched manifest with an
+`ETag` over the final per-user payload and `Cache-Control: private, no-cache`, so
+a matching `If-None-Match` becomes a 304 while enrichment still runs on every
+request.
+
+#### Scenario: Malformed app id is rejected before path resolution
+
+- **WHEN** `GET /api/manifest/../../etc` is requested
+- **THEN** the response MUST be HTTP 400 with an `Invalid app ID.` body
+- **AND** no manifest path MUST be resolved
+
+#### Scenario: Unknown app yields 404
+
+- **WHEN** the named app ships no readable bundled manifest
+- **THEN** the response MUST be HTTP 404
+
+#### Scenario: Warm reload revalidates rather than re-transfers
+
+- **GIVEN** a previous response carried an `ETag`
+- **WHEN** the same user re-requests with a matching `If-None-Match`
+- **THEN** the response MUST be HTTP 304
+- **AND** the `Cache-Control` header MUST be `private, no-cache`
+
+#### Scenario: Enrichment failure does not leak internals
+
+- **GIVEN** enrichment throws
+- **WHEN** the controller handles it
+- **THEN** the response MUST be HTTP 500 with a generic `Internal server error.`
+  body and the detail MUST be logged server-side only
+
+---
+
+### Requirement: REQ-OR-MAN-013 Manifest enrichment injects an allowlisted `runtime.user` block @e2e exclude backend enrichment pipeline (schema-slug validation, anonymous/no-profile shapes, field allowlist, calculation overlay) — covered by PHPUnit
+
+`ManifestService::getEnrichedManifest()` SHALL return the manifest unchanged when
+it declares no `currentUserSchema`. When it does, the slug SHALL be validated as
+a string of at most 128 characters matching `^[A-Za-z0-9_\-]{1,128}$` BEFORE any
+lookup uses it, and a failing slug SHALL fail closed to `runtime.user = null`
+with a warning — a compromised manifest MUST NOT be able to steer profile or
+calculation lookup at an arbitrary schema. An anonymous request SHALL yield
+`runtime.user = null`. An authenticated user with no profile object for that
+schema SHALL yield `runtime.user = { id, roles: ["learner"] }`.
+
+Profile lookup SHALL run through `ObjectService::findAll()` with RBAC and
+multi-tenancy left ON, narrowed by `(schema, ncUserId)`; the narrowing filter is
+NOT a substitute for the tenant scope, because the same Nextcloud UID may exist
+in more than one tenant.
+
+When a profile is found, `runtime.user` SHALL be built from an ALLOWLIST rather
+than from the raw profile payload: the fields named by the schema's
+`x-openregister-manifest-user-fields` configuration plus the non-materialised
+fields named in the schema's `x-openregister-calculations` map, with `id` always
+set to the Nextcloud user ID. Fields outside that allowlist MUST NOT be
+surfaced. Non-materialised calculations SHALL be evaluated at read time against
+the profile data plus an injected `@self` block (`id`, `uuid`, `register`,
+`schema`, `owner`, `created`, `updated`) and overlaid onto the block;
+materialised calculations MUST NOT be re-evaluated, since their values are
+already stored. A calculation that raises an evaluation error SHALL be logged
+and skipped, and MUST NOT fail the request.
+
+#### Scenario: No currentUserSchema leaves the manifest untouched
+
+- **GIVEN** a manifest with no `currentUserSchema` key
+- **WHEN** it is enriched
+- **THEN** the returned manifest MUST be identical to the input
+
+#### Scenario: Invalid schema slug fails closed
+
+- **GIVEN** a manifest whose `currentUserSchema` is not a string, is longer than
+  128 characters, or contains characters outside `[A-Za-z0-9_-]`
+- **WHEN** it is enriched
+- **THEN** `runtime.user` MUST be `null` and a warning MUST be logged
+- **AND** no schema or profile lookup MUST be performed
+
+#### Scenario: Anonymous request yields a null user
+
+- **GIVEN** no user in the session
+- **WHEN** a manifest declaring `currentUserSchema` is enriched
+- **THEN** `runtime.user` MUST be `null`
+
+#### Scenario: Authenticated user without a profile gets the minimal fallback
+
+- **GIVEN** an authenticated user with no profile object for the declared schema
+- **WHEN** the manifest is enriched
+- **THEN** `runtime.user` MUST be `{ id: <uid>, roles: ["learner"] }`
+
+#### Scenario: Fields outside the allowlist are not surfaced
+
+- **GIVEN** a profile object carrying a field that is named neither by
+  `x-openregister-manifest-user-fields` nor by the calculation map
+- **WHEN** the manifest is enriched
+- **THEN** that field MUST NOT appear in `runtime.user`
+
+#### Scenario: A failing calculation is skipped, not fatal
+
+- **GIVEN** one non-materialised calculation whose expression raises
+- **WHEN** the manifest is enriched
+- **THEN** the failure MUST be logged and the remaining calculations MUST still
+  be applied
 
 ---
 

--- a/src/components/userSettings/BrowserNotificationsSection.vue
+++ b/src/components/userSettings/BrowserNotificationsSection.vue
@@ -19,7 +19,7 @@
  mount point exists the component is unmounted; it is fully functional and only
  needs the host shell. See openspec/changes/openregister-web-push-engine.
 
- @spec openspec/changes/openregister-web-push-engine/tasks.md#task-52
+ @spec openspec/changes/openregister-web-push-engine/tasks.md#task-5.2
 -->
 <template>
 	<NcSettingsSection :name="t('openregister', 'Browser notifications')"
@@ -79,7 +79,7 @@ export default {
 		 * Human-readable label for the current permission state.
 		 *
 		 * @return {string} The localised permission label.
-		 * @spec openspec/changes/openregister-web-push-engine/tasks.md#task-52
+		 * @spec openspec/changes/openregister-web-push-engine/tasks.md#task-5.2
 		 */
 		permissionLabel() {
 			switch (this.permission) {
@@ -100,7 +100,7 @@ export default {
 		 * Resolve the WebPush client exposed by the always-loaded script.
 		 *
 		 * @return {object|null} The WebPush client, or null when absent.
-		 * @spec openspec/changes/openregister-web-push-engine/tasks.md#task-52
+		 * @spec openspec/changes/openregister-web-push-engine/tasks.md#task-5.2
 		 */
 		client() {
 			return (window.OCA && window.OCA.OpenRegister && window.OCA.OpenRegister.WebPush) || null
@@ -108,7 +108,7 @@ export default {
 		/**
 		 * Read support + permission state from the WebPush client. Never prompts.
 		 *
-		 * @spec openspec/changes/openregister-web-push-engine/tasks.md#task-52
+		 * @spec openspec/changes/openregister-web-push-engine/tasks.md#task-5.2
 		 * @return {void}
 		 */
 		refreshState() {
@@ -134,7 +134,7 @@ export default {
 		 * The permission prompt only ever fires from this user gesture.
 		 *
 		 * @param {boolean} checked The requested toggle state.
-		 * @spec openspec/changes/openregister-web-push-engine/tasks.md#task-52
+		 * @spec openspec/changes/openregister-web-push-engine/tasks.md#task-5.2
 		 * @return {Promise<void>}
 		 */
 		async onToggle(checked) {

--- a/src/tests/openregister-push-sw.spec.js
+++ b/src/tests/openregister-push-sw.spec.js
@@ -6,7 +6,7 @@
  * registered event listeners, then drive the `push` and `notificationclick`
  * handlers directly.
  *
- * @spec openspec/changes/openregister-web-push-engine/tasks.md#task-62
+ * @spec openspec/changes/openregister-web-push-engine/tasks.md#task-6.2
  */
 const fs = require('fs')
 const path = require('path')

--- a/src/views/settings/sections/PushNotificationsConfiguration.vue
+++ b/src/views/settings/sections/PushNotificationsConfiguration.vue
@@ -121,7 +121,7 @@ import { generateUrl } from '@nextcloud/router'
  * @link https://www.openregister.nl
  *
  * @spec openspec/changes/add-live-updates/tasks.md#task-11
- * @spec openspec/changes/openregister-web-push-engine/tasks.md#task-51
+ * @spec openspec/changes/openregister-web-push-engine/tasks.md#task-5.1
  */
 export default {
 	name: 'PushNotificationsConfiguration',
@@ -168,7 +168,7 @@ export default {
 		/**
 		 * Load the VAPID public key + configured flag from the backend.
 		 *
-		 * @spec openspec/changes/openregister-web-push-engine/tasks.md#task-51
+		 * @spec openspec/changes/openregister-web-push-engine/tasks.md#task-5.1
 		 * @return {Promise<void>}
 		 */
 		async loadVapidStatus() {


### PR DESCRIPTION
## gate-46 spec-anchor-existence: FAIL (49) → PASS

Measured with the sanctioned runner on a worktree detached at `origin/development` (`28c5d19f2`):

```
[hydra-gates] gate package: 48c88ba1e0d049f8f38538c33e790d3e603c55d0 (git checkout at /home/rubenlinde/gate19-worktrees/or-green-2026-08-09/dotgithub/hydra-gates/scripts)
```

| | before | after |
|---|---|---|
| `[gate-46] spec-anchor-existence` | `FAIL — 49 unresolved @spec finding(s) from 21 distinct target(s)` | `PASS` |

**No other gate moved.** Diffing the two full `[gate-*]` summary blocks (with the random `/tmp/hydra-gates.XXXX/` suffixes normalised) yields exactly one substantive line — gate-46. gate-19 stayed at 794, gate-25 at 66, gate-26 at 46, and so on. The new spec file carries a whole-spec `@e2e exclude` with a reason, and the requirements added to existing specs sit under specs that are already whole-spec-excluded or carry a requirement-level exclude, which is why gate-19 is unchanged.

No waivers, no `@spec exclude` added to silence anything, no tag deleted, no stub spec, no threshold or gate-package change.

### Can-it-fail proof

With every fix applied the helper reported `findings=0 / distinct_targets=0`. I then reverted one representative anchor repoint (`RegisterService.php`) **and** renamed the new `apphost-store-plane/spec.md` out of the way, and re-measured:

```
files_in_scope=1758
findings=9
distinct_targets=2
lib/Service/RegisterService.php: @spec anchor not found in openspec/specs/file-actions/spec.md → #object-register-folder-management
lib/AppHost/Service/StoreDescriptor.php: @spec target file not found → openspec/specs/apphost-store-plane/spec.md
… (7 more)
```

Both were re-applied and the count returned to 0. The gate can still fail on exactly the defects this PR fixed.

### Per-target table

`n` = findings the target produced in the baseline log.

#### A. Anchor drift — the file exists, the heading text moved. Tag repointed at the heading that is actually there.

| n | target (before) | fix | evidence |
|---|---|---|---|
| 7 | `webhook-payload-mapping/spec.md#request-interception-pre-event-webhooks` | → `#request-interception-must-support-pre-event-webhooks` | heading is `### Requirement: Request interception MUST support pre-event webhooks` (spec.md:446) |
| 2 | `migration-mapping-packs/spec.md#validation` | → `#the-system-must-validate-migration-pack-definitions-structurally-before-storing-them` | heading at spec.md:6; `PackDefinitionValidator::validate/assertValid` are exactly that requirement |
| 1 | `migration-mapping-packs/spec.md#mapping-engine` | → `#the-mapping-engine-must-apply-pack-transforms-per-row-and-never-leak-unresolved-references` | heading at spec.md:31; `MappingEngine::mapRow` |
| 2 | `file-actions/spec.md#object-register-folder-management` | → `#object-and-register-folder-provisioning` | heading at spec.md:697, which documents the folder-provisioning entry points `RegisterService::createFromArray/updateFromArray` call |
| 1 | `register-i18n/spec.md#language-negotiation-accept-language` | → `#the-api-must-support-language-negotiation-via-accept-language-header` | heading at spec.md:92 |
| 2 | `data-import-export/spec.md#import-templates-downloadable-per-schema` | → `#import-templates-must-be-downloadable-per-schema` | heading at spec.md:367 |
| 1 | `data-import-export/spec.md#import-rollback-on-critical-failure` | → `#import-must-support-rollback-on-critical-failure` | heading at spec.md:342 |
| 1 | `row-field-level-security/spec.md#mongodb-style-operators` | → `#the-condition-syntax-must-support-mongodb-style-operators-for-match-expressions` | heading at spec.md:193 |
| 1 | `row-field-level-security/spec.md#fls-strips-restricted-fields` | → `#fls-must-strip-restricted-fields-from-api-responses-and-export-outputs` | heading at spec.md:311 |
| 4 | `context-chat-provider/spec.md#requirement-openregister-must-register-a-context-chat-content-provider-only-when-the-platform-is-available` | → `#openregister-registers-a-context-chat-content-provider-only-when-the-platform-is-available` | the heading reads "**registers**", not "must register" (spec.md:19). The shorter colon-tail form also brings four pre-existing >150-char lines back under the PHPCS limit. |
| 1 | `changes/or-chat-proxy-deprecation/design.md#the-proxy-short-circuit-is-an-exception-not-an-inline-return` | → `#the-short-circuit-is-an-exception-not-an-inline-return` | the heading has no "proxy" (design.md:53) |
| 2 | `changes/openregister-web-push-engine/tasks.md#task-51` | → `#task-5.1` | task 5.1 *is* "Extend `PushNotificationsConfiguration.vue` (admin)" — the same file the tag is in. `#task-51` was being read positionally as the 51st checkbox, and the file has 33. |
| 5 | `…#task-52` | → `#task-5.2` | task 5.2 = "per-user opt-in *Enable browser notifications* toggle section" = `BrowserNotificationsSection.vue` |
| 1 | `…#task-62` | → `#task-6.2` | task 6.2 = "Frontend tests (subscribe client opt-in gating, Service Worker push/notificationclick)" = `openregister-push-sw.spec.js` |

#### B. Stale change-dir target that has a canonical `openspec/specs/` home. Repointed there, per `SpecTagSniff`'s own guidance ("POINT AT THE CANONICAL SPEC, NOT AT A CHANGE DIRECTORY").

| n | target (before) | fix | evidence |
|---|---|---|---|
| 1 | `changes/data-import-export/tasks.md#task-error-csv` | → `specs/data-import-export/spec.md#import-must-provide-detailed-error-reporting-with-downloadable-error-files` | the archived change's own status note says the per-row error CSV ships in the import response envelope; the canonical requirement is spec.md:116 |
| 1 | `changes/add-features-roadmap-menu/tasks.md#task-20b` | → `specs/github-issue-proxy/spec.md#issues-list-endpoint` | `validateLabels()` implements the `labels_invalid_format` / `labels_too_many` scenarios, which live under that requirement (spec.md:58, :64). The archived tasks file has no 1.20b. |
| 3 | `changes/scholiq-deps/tenant-key-api/tasks.md` (never existed in this repo) | → `specs/saas-multi-tenant/spec.md`, three anchors | that spec already specifies `TenantKeyService` requirement-for-requirement: file-level → the DI/internal-API requirement, `getCurrentTenantKey()` → single-most-recent-active-row, `rotateTenantKey()` → encrypted-insert-with-status-active |

#### C. Genuinely undocumented — the requirement was written from the code and its tests, then the tag pointed at it.

| n | target (before) | fix |
|---|---|---|
| 7 | `specs/apphost-store-plane/spec.md` (did not exist) | **New spec.** The ADR-080 store plane (`StoreDescriptor` + `GenericStoreService`) shipped with no spec anywhere in the repo — not in `openspec/specs/`, not in `openspec/changes/`, not in `changes/archive/`. Seven requirements written from `lib/AppHost/Service/*` and the fourteen cases in `tests/Unit/AppHost/GenericStoreServiceTest.php`: descriptor parameters and descriptor-driven URL, the unconfigured-store short-circuit that makes no network call, the SSRF guard + redirect refusal + 10s timeouts, Bearer-only token transport, the `store_unreachable` vs `store_invalid_response` split, card normalisation that never carries the install payload, and the slug-verified `resolve()`. Every scenario corresponds to an existing assertion. |
| 5 | `changes/manifest-user-context/tasks.md` (+ `#task-1`) | **`openregister-app-manifest` REQ-OR-MAN-012 + REQ-OR-MAN-013.** REQ-OR-MAN-009 states OpenRegister "SHALL NOT implement" the backend manifest endpoint and that it returns 404. That is no longer true: `appinfo/routes.php:258` routes `GET /api/manifest/{appId}` to `ManifestController::index()`. REQ-OR-MAN-009's heading is kept (so any reference still resolves) and marked superseded; REQ-OR-MAN-012 documents the endpoint as built (public page, `^[a-z0-9_-]+$` appId validation, 404/500 mapping, ETag + `private, no-cache`) and REQ-OR-MAN-013 documents the `runtime.user` enrichment `ManifestService` actually implements — the fail-closed schema-slug validation, the anonymous/no-profile shapes, RBAC+multitenancy left on during profile lookup, the `x-openregister-manifest-user-fields` allowlist, and the non-materialised calculation overlay with skip-on-error. |
| 1 | `deprecate-published-metadata/spec.md#REQ-5` | **New `REQ-5` requirement in that spec.** The spec's "Backward Compatibility" requirement said the Register/Schema `published`/`depublished` fields were out of scope *"(used for multi-tenancy bypass)"* — but `MultiTenancyTrait` does not read them at all any more; the only mention is a comment recording the removal. Added `### Requirement: REQ-5: The multi-tenancy filter MUST NOT bypass on published state`, describing what `applyOrganisationFilter()` actually does (organisation column + RBAC only; skip conditions; parent-org hierarchy; admin override disabled in SaaS mode; no-active-org blocks unless `allowNullOrg`), and corrected the now-false sentence to point at it. |

### Left red

Nothing. gate-46 is `PASS` with 0 findings.

### Deliberately out of scope

- **`#task-3` / `#task-16` / `#task-20` in `GitHubRequestValidator`** still point at `changes/add-features-roadmap-menu/tasks.md` and still resolve — but only *positionally*, as "the Nth checkbox", which is not what their authors meant (the docblocks say "task 1.20", "task 1.20b"). They are green today, so touching them is not this PR's job; flagging them because a positional resolution is a weaker green than it looks.
- **Pre-existing >150-char lines.** 140 lines in `lib/` exceed the PHPCS limit at `development`. This PR introduces none, removes four (the ContextChat listener), and leaves the rest — `ImportService` 587-589/885-886 and `WebhookService` 20/1026/1099 are untouched by any hunk here.
