### PR TITLE
fix(db): create the two schema-cache tables that no migration ever created

### DIFF
--- a/lib/Migration/Version1Date20260809000000.php
+++ b/lib/Migration/Version1Date20260809000000.php
@@ -1,0 +1,288 @@
+<?php
+
+/**
+ * Creates the two schema-cache tables the cache handlers have always queried.
+ *
+ * `SchemaCacheHandler` and `FacetCacheHandler` read and write
+ * `openregister_schema_cache` and `openregister_schema_facet_cache`. No
+ * migration ever created either one, so every statement they issued failed at
+ * the database and every failure was swallowed by a `catch` whose comment
+ * described the state as transitional — "the migration hasn't been run yet".
+ * There was no migration for it to be transitional to, so the tolerance was
+ * permanent and the persistent schema cache has never cached anything. Only
+ * the in-process `self::$memoryCache` was ever doing work, and that does not
+ * survive the request.
+ *
+ * Measured on ConductionNL/openbuild Code Quality run 31083894467 (E2E job
+ * 92559832374, which pins `openregister@development`): a single run produced
+ * 33x `relation "oc_openregister_schema_cache" does not exist` and 22x
+ * `relation "oc_openregister_schema_facet_cache" does not exist` in the
+ * Postgres server log. The same errors appear in decidesk, pipelinq and
+ * nldesign, all of which pin the same ref.
+ *
+ * The column set below is not invented: it is exactly what the two handlers
+ * already write. `openregister_schema_cache` comes from
+ * `SchemaCacheHandler::setCachedData()` (schema_id, cache_key, cache_data,
+ * created, updated, expires) and is read back by `getCachedData()` on
+ * (schema_id, cache_key). `openregister_schema_facet_cache` comes from
+ * `FacetCacheHandler::setCachedFacetData()` (schema_id, facet_type,
+ * field_name, facet_config, cache_data, created, updated, expires), whose
+ * update arm keys on (schema_id, field_name) and whose statistics query
+ * groups by facet_type.
+ *
+ * The uniqueness constraints are what make the handlers' update-then-insert
+ * upsert correct rather than merely usual: without them a lost race appends a
+ * second row for the same key and the reader's `fetch()` would return whichever
+ * one the planner happened to reach first.
+ *
+ * `expires` is nullable because a zero TTL means "no expiry" in both handlers;
+ * NULL there means the entry never expires, not that expiry is unknown.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/object-lifecycle/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Creates `openregister_schema_cache` and `openregister_schema_facet_cache`.
+ *
+ * @spec openspec/specs/object-lifecycle/spec.md
+ */
+class Version1Date20260809000000 extends SimpleMigrationStep
+{
+
+    /**
+     * Name of the schema cache table.
+     *
+     * @var string
+     */
+    private const SCHEMA_CACHE_TABLE = 'openregister_schema_cache';
+
+    /**
+     * Name of the facet cache table.
+     *
+     * @var string
+     */
+    private const FACET_CACHE_TABLE = 'openregister_schema_facet_cache';
+
+    /**
+     * Create both cache tables when they are absent.
+     *
+     * @param IOutput $output        Migration output.
+     * @param Closure $schemaClosure Schema closure returning an ISchemaWrapper.
+     * @param array   $options       Migration options.
+     *
+     * @return ISchemaWrapper|null The modified schema, or null when unchanged.
+     *
+     * @spec openspec/specs/object-lifecycle/spec.md
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
+    {
+        /*
+         * @var ISchemaWrapper $schema
+         */
+
+        $schema  = $schemaClosure();
+        $changed = false;
+
+        if ($schema->hasTable(tableName: self::SCHEMA_CACHE_TABLE) === false) {
+            $this->createSchemaCacheTable(schema: $schema);
+            $output->info('Created '.self::SCHEMA_CACHE_TABLE.'.');
+            $changed = true;
+        }
+
+        if ($schema->hasTable(tableName: self::FACET_CACHE_TABLE) === false) {
+            $this->createFacetCacheTable(schema: $schema);
+            $output->info('Created '.self::FACET_CACHE_TABLE.'.');
+            $changed = true;
+        }
+
+        if ($changed === false) {
+            return null;
+        }
+
+        return $schema;
+
+    }//end changeSchema()
+
+    /**
+     * Create the schema cache table.
+     *
+     * @param ISchemaWrapper $schema The schema being modified.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/object-lifecycle/spec.md
+     */
+    private function createSchemaCacheTable(ISchemaWrapper $schema): void
+    {
+        $table = $schema->createTable(self::SCHEMA_CACHE_TABLE);
+
+        $table->addColumn(
+            'id',
+            Types::BIGINT,
+            [
+                'autoincrement' => true,
+                'notnull'       => true,
+                'length'        => 20,
+            ]
+        );
+        $table->addColumn(
+            'schema_id',
+            Types::BIGINT,
+            [
+                'notnull' => true,
+                'length'  => 20,
+            ]
+        );
+        // The handler's own vocabulary is `schema_object`, `facetable_fields`,
+        // `configuration` and `properties`; 64 leaves room without inviting a
+        // key long enough to blow the composite index.
+        $table->addColumn(
+            'cache_key',
+            Types::STRING,
+            [
+                'notnull' => true,
+                'length'  => 64,
+            ]
+        );
+        $table->addColumn(
+            'cache_data',
+            Types::TEXT,
+            ['notnull' => true]
+        );
+        $table->addColumn(
+            'created',
+            Types::DATETIME,
+            ['notnull' => true]
+        );
+        $table->addColumn(
+            'updated',
+            Types::DATETIME,
+            ['notnull' => true]
+        );
+        // NULL means "never expires" — a zero TTL in the handler.
+        $table->addColumn(
+            'expires',
+            Types::DATETIME,
+            [
+                'notnull' => false,
+                'default' => null,
+            ]
+        );
+
+        $table->setPrimaryKey(['id']);
+        $table->addUniqueIndex(['schema_id', 'cache_key'], 'or_schema_cache_key_uniq');
+        $table->addIndex(['expires'], 'or_schema_cache_expires_idx');
+
+    }//end createSchemaCacheTable()
+
+    /**
+     * Create the facet cache table.
+     *
+     * @param ISchemaWrapper $schema The schema being modified.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/object-lifecycle/spec.md
+     */
+    private function createFacetCacheTable(ISchemaWrapper $schema): void
+    {
+        $table = $schema->createTable(self::FACET_CACHE_TABLE);
+
+        $table->addColumn(
+            'id',
+            Types::BIGINT,
+            [
+                'autoincrement' => true,
+                'notnull'       => true,
+                'length'        => 20,
+            ]
+        );
+        $table->addColumn(
+            'schema_id',
+            Types::BIGINT,
+            [
+                'notnull' => true,
+                'length'  => 20,
+            ]
+        );
+        $table->addColumn(
+            'facet_type',
+            Types::STRING,
+            [
+                'notnull' => true,
+                'length'  => 64,
+            ]
+        );
+        // A schema property name. 255 keeps the composite unique index inside
+        // the 3072-byte InnoDB limit at utf8mb4.
+        $table->addColumn(
+            'field_name',
+            Types::STRING,
+            [
+                'notnull' => true,
+                'length'  => 255,
+            ]
+        );
+        $table->addColumn(
+            'facet_config',
+            Types::TEXT,
+            [
+                'notnull' => false,
+                'default' => null,
+            ]
+        );
+        $table->addColumn(
+            'cache_data',
+            Types::TEXT,
+            ['notnull' => true]
+        );
+        $table->addColumn(
+            'created',
+            Types::DATETIME,
+            ['notnull' => true]
+        );
+        $table->addColumn(
+            'updated',
+            Types::DATETIME,
+            ['notnull' => true]
+        );
+        $table->addColumn(
+            'expires',
+            Types::DATETIME,
+            [
+                'notnull' => false,
+                'default' => null,
+            ]
+        );
+
+        $table->setPrimaryKey(['id']);
+        // `setCachedFacetData()` updates on (schema_id, field_name), so that is
+        // the pair that must be unique for its upsert to hold.
+        $table->addUniqueIndex(['schema_id', 'field_name'], 'or_facet_cache_field_uniq');
+        $table->addIndex(['facet_type'], 'or_facet_cache_type_idx');
+        $table->addIndex(['expires'], 'or_facet_cache_expires_idx');
+
+    }//end createFacetCacheTable()
+}//end class

--- a/lib/Service/Object/DeleteObject.php
+++ b/lib/Service/Object/DeleteObject.php
@@ -43,8 +43,6 @@ use OCA\OpenRegister\Dto\DeletionAnalysis;
 use OCA\OpenRegister\Exception\ReferentialIntegrityException;
 use OCA\OpenRegister\Service\Object\CacheHandler;
 use OCA\OpenRegister\Service\Object\ReferentialIntegrityService;
-use OCA\OpenRegister\Service\Schemas\SchemaCacheHandler;
-use OCA\OpenRegister\Service\Schemas\FacetCacheHandler;
 use OCA\OpenRegister\Db\AuditTrailMapper;
 use OCA\OpenRegister\Service\FileService;
 use OCA\OpenRegister\Service\SettingsService;

--- a/lib/Service/Object/SaveObject.php
+++ b/lib/Service/Object/SaveObject.php
@@ -53,8 +53,6 @@ use OCA\OpenRegister\Service\PropertyRbacHandler;
 use OCA\OpenRegister\Service\TmloService;
 use OCA\OpenRegister\Service\TranslationProjectionService;
 use OCA\OpenRegister\Service\TranslationStatusService;
-use OCA\OpenRegister\Service\Schemas\SchemaCacheHandler;
-use OCA\OpenRegister\Service\Schemas\FacetCacheHandler;
 use OCA\OpenRegister\Db\AuditTrailMapper;
 use OCA\OpenRegister\Db\ObjectHandling;
 use OCA\OpenRegister\Event\ReferenceValidatedEvent;

--- a/lib/Service/Schemas/FacetCacheHandler.php
+++ b/lib/Service/Schemas/FacetCacheHandler.php
@@ -269,10 +269,19 @@ class FacetCacheHandler
                 ->where($qb->expr()->eq('schema_id', $qb->createNamedParameter($schemaId)));
             $deletedCount = $qb->executeStatement();
         } catch (\Exception $e) {
-            // If the cache table doesn't exist yet, just log a debug message and continue.
-            // This allows the app to work even if the migration hasn't been run yet.
-            $this->logger->debug(
-                message: '[FacetCacheHandler] Schema facet cache table does not exist yet, skipping db cache invalidation',
+            // The cache is an optimisation, so a database failure must not fail
+            // the schema change that triggered it — but it is NOT expected.
+            //
+            // This block used to say the table "doesn't exist yet" and that the
+            // tolerance let the app work "even if the migration hasn't been run
+            // yet". No migration created this table, so the condition was
+            // permanent rather than transitional, and at default log level
+            // `debug` emitted nothing — the only trace was 22 `relation ...
+            // does not exist` errors per run in the Postgres server log. The
+            // table is now created by Version1Date20260809000000, so reaching
+            // this branch means something real went wrong.
+            $this->logger->warning(
+                message: '[FacetCacheHandler] Failed to invalidate the database facet cache; continuing on the memory cache only',
                 context: [
                     'file'     => __FILE__,
                     'line'     => __LINE__,
@@ -280,7 +289,7 @@ class FacetCacheHandler
                     'error'    => $e->getMessage(),
                 ]
             );
-        }
+        }//end try
 
         // Remove from memory cache (always safe to do).
         $memoryClearedCount = 0;

--- a/lib/Service/Schemas/SchemaCacheHandler.php
+++ b/lib/Service/Schemas/SchemaCacheHandler.php
@@ -33,6 +33,7 @@ use RuntimeException;
 use DateTime;
 use DateInterval;
 use OCP\IDBConnection;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\AppFramework\Db\DoesNotExistException;
 use Psr\Log\LoggerInterface;
 
@@ -266,15 +267,31 @@ class SchemaCacheHandler
         }
 
         // Clear from database cache.
-        $sql = 'DELETE FROM '.self::CACHE_TABLE.' WHERE schema_id = ?';
+        //
+        // Built through the query builder, not raw SQL. The raw statement this
+        // replaces read `DELETE FROM openregister_schema_cache ...` — an
+        // UNPREFIXED table name. Nextcloud rewrites `*PREFIX*` and nothing
+        // else, so that statement addressed a table called
+        // `openregister_schema_cache` while the installer creates
+        // `oc_openregister_schema_cache`. It could therefore never have
+        // matched a row, even once the table existed. The query builder
+        // prefixes for us and parameterises `schema_id` as the integer it is,
+        // instead of binding it as a string.
         try {
-            $this->db->executeQuery($sql, [(string) $schemaId]);
+            $qb = $this->db->getQueryBuilder();
+            $qb->delete(self::CACHE_TABLE)
+                ->where($qb->expr()->eq('schema_id', $qb->createNamedParameter($schemaId, IQueryBuilder::PARAM_INT)));
+            $qb->executeStatement();
             $this->logger->debug(
                 message: '[SchemaCacheHandler] Cleared schema cache',
                 context: ['file' => __FILE__, 'line' => __LINE__, 'schemaId' => $schemaId]
             );
         } catch (Exception $e) {
-            $this->logger->error(
+            // `warning`, not `error`: this is the same cause as the catch in
+            // invalidateForSchemaChange() and the two used to disagree about
+            // severity for an identical failure. Neither fails the caller, so
+            // neither is an error; both are a degraded cache.
+            $this->logger->warning(
                 message: '[SchemaCacheHandler] Failed to clear schema cache',
                 context: [
                     'file'     => __FILE__,
@@ -283,7 +300,7 @@ class SchemaCacheHandler
                     'error'    => $e->getMessage(),
                 ]
             );
-        }
+        }//end try
     }//end clearSchemaCache()
 
     /**
@@ -416,10 +433,23 @@ class SchemaCacheHandler
                 ->where($qb->expr()->eq('schema_id', $qb->createNamedParameter($schemaId)));
             $deletedEntries = $qb->executeStatement();
         } catch (Exception $e) {
-            // If the cache table doesn't exist yet, just log a debug message and continue.
-            // This allows the app to work even if the migration hasn't been run yet.
-            $this->logger->debug(
-                message: '[SchemaCacheHandler] Schema cache table does not exist yet, skipping database cache invalidation',
+            // The cache is an optimisation, so a database failure here must not
+            // fail the schema change that triggered it — but it is NOT expected
+            // and is not logged as though it were.
+            //
+            // This block used to say the table "doesn't exist yet" and that the
+            // tolerance let the app work "even if the migration hasn't been run
+            // yet". No migration created this table, so there was nothing for
+            // that state to be transitional to: the condition was permanent,
+            // the message was wrong, and at default log level `debug` emitted
+            // nothing at all. The only trace was 33 `relation ... does not
+            // exist` errors per run in the Postgres server log. The table is
+            // now created by Version1Date20260809000000, so reaching this
+            // branch means something real went wrong; `warning` matches the
+            // sibling path in clearSchemaCache(), which logged the identical
+            // cause at `error`.
+            $this->logger->warning(
+                message: '[SchemaCacheHandler] Failed to invalidate the database schema cache; continuing on the memory cache only',
                 context: [
                     'file'     => __FILE__,
                     'line'     => __LINE__,
@@ -427,7 +457,7 @@ class SchemaCacheHandler
                     'error'    => $e->getMessage(),
                 ]
             );
-        }
+        }//end try
 
         // Remove from memory cache (always safe to do).
         $cacheKeys = [

--- a/tests/Unit/Migration/Version1Date20260809000000Test.php
+++ b/tests/Unit/Migration/Version1Date20260809000000Test.php
@@ -1,0 +1,307 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Tests for Version1Date20260809000000 — creates the two schema-cache tables.
+ *
+ * The bug this migration repairs was invisible for its whole life: the
+ * handlers queried `openregister_schema_cache` and
+ * `openregister_schema_facet_cache`, no migration created either, and a
+ * `catch` logging at `debug` swallowed every failure. So these tests do not
+ * merely assert "a table is created" — they assert the created table carries
+ * EVERY column the handlers actually write, because a migration that creates
+ * the table with the wrong columns would fail in exactly the same silent way.
+ *
+ * The expected column sets below are derived from the handlers' own
+ * statements, named in each test.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Migration
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @spec openspec/specs/object-lifecycle/spec.md
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Migration;
+
+use Doctrine\DBAL\Schema\Table;
+use OCA\OpenRegister\Migration\Version1Date20260809000000;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use PHPUnit\Framework\TestCase;
+
+class Version1Date20260809000000Test extends TestCase
+{
+
+    private Version1Date20260809000000 $migration;
+
+    /**
+     * Column names captured per table during a changeSchema() call.
+     *
+     * @var array<string, list<string>>
+     */
+    private array $columns = [];
+
+    /**
+     * Plain (non-unique) index names captured per table.
+     *
+     * @var array<string, list<string>>
+     */
+    private array $indexes = [];
+
+    /**
+     * UNIQUE index names captured per table, kept apart from plain indexes.
+     *
+     * These are recorded separately on purpose. Collapsing both into one list
+     * made the uniqueness assertion untestable: downgrading
+     * addUniqueIndex() to addIndex() under the same name still satisfied a
+     * check that only looked for the name. Uniqueness is the property that
+     * makes the handlers' update-then-insert upsert correct, so it is the
+     * property the test has to assert.
+     *
+     * @var array<string, list<string>>
+     */
+    private array $uniqueIndexes = [];
+
+    /**
+     * Primary key column lists captured per table.
+     *
+     * @var array<string, list<string>>
+     */
+    private array $primaryKeys = [];
+
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->migration     = new Version1Date20260809000000();
+        $this->columns       = [];
+        $this->indexes       = [];
+        $this->uniqueIndexes = [];
+        $this->primaryKeys   = [];
+    }//end setUp()
+
+
+    /**
+     * Build an ISchemaWrapper whose createTable() records what it is asked for.
+     *
+     * @param list<string> $existingTables Tables that already exist.
+     *
+     * @return ISchemaWrapper
+     */
+    private function recordingSchema(array $existingTables=[]): ISchemaWrapper
+    {
+        $schema = $this->createMock(ISchemaWrapper::class);
+
+        $schema->method('hasTable')->willReturnCallback(
+            static function (string $name) use ($existingTables): bool {
+                return in_array($name, $existingTables, true);
+            }
+        );
+
+        $schema->method('createTable')->willReturnCallback(
+            function (string $name): Table {
+                $this->columns[$name]       = [];
+                $this->indexes[$name]       = [];
+                $this->uniqueIndexes[$name] = [];
+                $this->primaryKeys[$name]   = [];
+
+                $table = $this->createMock(Table::class);
+
+                $table->method('addColumn')->willReturnCallback(
+                    function (string $column) use ($name): Table {
+                        $this->columns[$name][] = $column;
+                        return $this->createMock(Table::class);
+                    }
+                );
+
+                $table->method('setPrimaryKey')->willReturnCallback(
+                    function (array $cols) use ($name): Table {
+                        $this->primaryKeys[$name] = $cols;
+                        return $this->createMock(Table::class);
+                    }
+                );
+
+                $table->method('addUniqueIndex')->willReturnCallback(
+                    function (array $cols, string $indexName) use ($name): Table {
+                        $this->uniqueIndexes[$name][] = $indexName;
+                        return $this->createMock(Table::class);
+                    }
+                );
+
+                $table->method('addIndex')->willReturnCallback(
+                    function (array $cols, string $indexName) use ($name): Table {
+                        $this->indexes[$name][] = $indexName;
+                        return $this->createMock(Table::class);
+                    }
+                );
+
+                return $table;
+            }
+        );
+
+        return $schema;
+    }//end recordingSchema()
+
+
+    /**
+     * The schema cache table must carry every column setCachedData() writes.
+     *
+     * Source of truth: SchemaCacheHandler::setCachedData(), whose insert names
+     * schema_id, cache_key, cache_data, created, updated and expires, and
+     * whose read keys on (schema_id, cache_key).
+     *
+     * @return void
+     */
+    public function testCreatesSchemaCacheTableWithEveryColumnTheHandlerWrites(): void
+    {
+        $schema = $this->recordingSchema();
+        $result = $this->migration->changeSchema($this->createMock(IOutput::class), fn () => $schema, []);
+
+        $this->assertSame($schema, $result);
+        $this->assertArrayHasKey('openregister_schema_cache', $this->columns);
+
+        $expected = ['id', 'schema_id', 'cache_key', 'cache_data', 'created', 'updated', 'expires'];
+        foreach ($expected as $column) {
+            $this->assertContains(
+                $column,
+                $this->columns['openregister_schema_cache'],
+                "openregister_schema_cache is missing the '{$column}' column, which SchemaCacheHandler writes."
+            );
+        }
+
+        $this->assertSame(['id'], $this->primaryKeys['openregister_schema_cache']);
+        $this->assertContains(
+            'or_schema_cache_key_uniq',
+            $this->uniqueIndexes['openregister_schema_cache'],
+            'Without a UNIQUE index on (schema_id, cache_key) the handler update-then-insert upsert can duplicate a key.'
+        );
+    }//end testCreatesSchemaCacheTableWithEveryColumnTheHandlerWrites()
+
+
+    /**
+     * The facet cache table must carry every column setCachedFacetData() writes.
+     *
+     * Source of truth: FacetCacheHandler::setCachedFacetData(), whose insert
+     * names schema_id, facet_type, field_name, facet_config, cache_data,
+     * created, updated and expires; its update arm keys on
+     * (schema_id, field_name) and getCacheStatistics() groups by facet_type.
+     *
+     * @return void
+     */
+    public function testCreatesFacetCacheTableWithEveryColumnTheHandlerWrites(): void
+    {
+        $schema = $this->recordingSchema();
+        $this->migration->changeSchema($this->createMock(IOutput::class), fn () => $schema, []);
+
+        $this->assertArrayHasKey('openregister_schema_facet_cache', $this->columns);
+
+        $expected = [
+            'id',
+            'schema_id',
+            'facet_type',
+            'field_name',
+            'facet_config',
+            'cache_data',
+            'created',
+            'updated',
+            'expires',
+        ];
+        foreach ($expected as $column) {
+            $this->assertContains(
+                $column,
+                $this->columns['openregister_schema_facet_cache'],
+                "openregister_schema_facet_cache is missing the '{$column}' column, which FacetCacheHandler writes."
+            );
+        }
+
+        $this->assertSame(['id'], $this->primaryKeys['openregister_schema_facet_cache']);
+        $this->assertContains(
+            'or_facet_cache_field_uniq',
+            $this->uniqueIndexes['openregister_schema_facet_cache'],
+            'setCachedFacetData() updates on (schema_id, field_name); without a UNIQUE index its upsert can duplicate.'
+        );
+        $this->assertContains('or_facet_cache_type_idx', $this->indexes['openregister_schema_facet_cache']);
+    }//end testCreatesFacetCacheTableWithEveryColumnTheHandlerWrites()
+
+
+    /**
+     * Re-running the migration must not try to create either table again.
+     *
+     * @return void
+     */
+    public function testIsIdempotentWhenBothTablesAlreadyExist(): void
+    {
+        $schema = $this->recordingSchema(
+            ['openregister_schema_cache', 'openregister_schema_facet_cache']
+        );
+        $schema->expects($this->never())->method('createTable');
+
+        $result = $this->migration->changeSchema($this->createMock(IOutput::class), fn () => $schema, []);
+
+        $this->assertNull($result, 'An unchanged schema must be reported as null, not returned.');
+    }//end testIsIdempotentWhenBothTablesAlreadyExist()
+
+
+    /**
+     * The migration must create the tables the handlers actually name.
+     *
+     * This is the regression guard for the original defect, and it is
+     * deliberately NOT a text scan. A grep for `createTable('openregister_...')`
+     * cannot see `createTable(self::TABLE)` or `createTable(tableName: '...')`,
+     * and it matches the same string in a comment — it fails in both
+     * directions at once. Writing this check that way produced two false
+     * "no migration creates it" results in this very repository
+     * (openregister_flow_state, which uses a constant, and
+     * openregister_tenant_keys, which uses a named argument).
+     *
+     * So the table names are read off the handlers by reflection and compared
+     * against what the migration actually asked the schema to create. Rename
+     * the constant on either side and this fails.
+     *
+     * @return void
+     */
+    public function testMigrationCreatesExactlyTheTablesTheHandlersQuery(): void
+    {
+        $schemaCacheTable = (new \ReflectionClass(\OCA\OpenRegister\Service\Schemas\SchemaCacheHandler::class))
+            ->getConstant('CACHE_TABLE');
+        $facetCacheTable  = (new \ReflectionClass(\OCA\OpenRegister\Service\Schemas\FacetCacheHandler::class))
+            ->getConstant('FACET_CACHE_TABLE');
+
+        $this->assertIsString($schemaCacheTable);
+        $this->assertIsString($facetCacheTable);
+
+        $schema = $this->recordingSchema();
+        $this->migration->changeSchema($this->createMock(IOutput::class), fn () => $schema, []);
+
+        $created = array_keys($this->columns);
+        sort($created);
+
+        $expected = [$facetCacheTable, $schemaCacheTable];
+        sort($expected);
+
+        $this->assertSame(
+            $expected,
+            $created,
+            'The migration must create exactly the tables SchemaCacheHandler and FacetCacheHandler query. '
+            .'If this fails, one side was renamed and the cache is silently dead again.'
+        );
+    }//end testMigrationCreatesExactlyTheTablesTheHandlersQuery()
+
+
+    /**
+     * A half-applied state must still create the table that is missing.
+     *
+     * @return void
+     */
+    public function testCreatesOnlyTheMissingTable(): void
+    {
+        $schema = $this->recordingSchema(['openregister_schema_cache']);
+        $result = $this->migration->changeSchema($this->createMock(IOutput::class), fn () => $schema, []);
+
+        $this->assertSame($schema, $result);
+        $this->assertArrayNotHasKey('openregister_schema_cache', $this->columns);
+        $this->assertArrayHasKey('openregister_schema_facet_cache', $this->columns);
+    }//end testCreatesOnlyTheMissingTable()
+}//end class

--- a/tests/Unit/Service/Schemas/FacetCacheHandlerTest.php
+++ b/tests/Unit/Service/Schemas/FacetCacheHandlerTest.php
@@ -307,23 +307,29 @@ class FacetCacheHandlerTest extends TestCase
 
         $this->db->method('getQueryBuilder')->willReturn($qb);
 
-        // debug() is called multiple times; track messages and assert afterwards.
-        $debugMessages = [];
-        $this->logger->method('debug')
-            ->willReturnCallback(function (string $message) use (&$debugMessages) {
-                $debugMessages[] = $message;
+        // The message no longer claims the table "does not exist yet". No
+        // migration ever created it, so that state was permanent rather than
+        // transitional, and at default log level `debug` emitted nothing — the
+        // only trace was 22 `relation ... does not exist` errors per run in the
+        // Postgres server log. The table is created by
+        // Version1Date20260809000000, so this branch now means a real database
+        // failure and is logged as a warning.
+        $warnings = [];
+        $this->logger->method('warning')
+            ->willReturnCallback(function (string $message) use (&$warnings) {
+                $warnings[] = $message;
             });
 
         $this->handler->invalidateForSchemaChange(22);
 
         $found = false;
-        foreach ($debugMessages as $msg) {
-            if (str_contains($msg, 'does not exist yet')) {
+        foreach ($warnings as $msg) {
+            if (str_contains($msg, 'Failed to invalidate the database facet cache')) {
                 $found = true;
                 break;
             }
         }
-        $this->assertTrue($found, 'Expected a debug message containing "does not exist yet"');
+        $this->assertTrue($found, 'Expected a warning that the database facet cache could not be invalidated');
     }
 
     public function testInvalidateForSchemaChangeClearsDistributedCaches(): void

--- a/tests/Unit/Service/Schemas/SchemaCacheHandlerBranchCoverageTest.php
+++ b/tests/Unit/Service/Schemas/SchemaCacheHandlerBranchCoverageTest.php
@@ -139,8 +139,10 @@ class SchemaCacheHandlerBranchCoverageTest extends TestCase
             'schema_2_schema_object' => 'other',
         ]);
 
-        $this->db->method('executeQuery')
-            ->willReturn($this->createMock(\OCP\DB\IResult::class));
+        // clearSchemaCache() deletes through the query builder now. It used to
+        // issue raw SQL naming the table UNPREFIXED, which Nextcloud never
+        // rewrites, so it could not have matched a row under any configuration.
+        $this->db->method('getQueryBuilder')->willReturn($this->createMockQueryBuilder());
 
         $this->handler->clearSchemaCache(1);
 
@@ -152,7 +154,7 @@ class SchemaCacheHandlerBranchCoverageTest extends TestCase
 
     public function testClearSchemaCacheDbException(): void
     {
-        $this->db->method('executeQuery')
+        $this->db->method('getQueryBuilder')
             ->willThrowException(new \Exception('DB error'));
 
         $this->handler->clearSchemaCache(1);

--- a/tests/Unit/Service/Schemas/SchemaCacheHandlerDeepTest.php
+++ b/tests/Unit/Service/Schemas/SchemaCacheHandlerDeepTest.php
@@ -76,11 +76,16 @@ class SchemaCacheHandlerDeepTest extends TestCase
 
     public function testClearSchemaCacheWithDbException(): void
     {
-        $this->db->method('executeQuery')
+        // clearSchemaCache() deletes through the query builder now; the raw SQL
+        // it replaces named the table UNPREFIXED and could never have matched.
+        // The failure is logged at `warning`, not `error`: the sibling catch in
+        // invalidateForSchemaChange() has the identical cause, neither fails the
+        // caller, so neither is an error — both are a degraded cache.
+        $this->db->method('getQueryBuilder')
             ->willThrowException(new Exception('db error'));
 
         $this->logger->expects($this->atLeastOnce())
-            ->method('error');
+            ->method('warning');
 
         // Should not throw
         $this->handler->clearSchemaCache(1);
@@ -144,8 +149,11 @@ class SchemaCacheHandlerDeepTest extends TestCase
         $qb->method('createNamedParameter')->willReturnArgument(0);
         $qb->method('executeStatement')->willThrowException(new Exception('table not exist'));
 
+        // The table is created by Version1Date20260809000000, so this branch no
+        // longer means "the migration has not run"; it means a real database
+        // failure, and is logged as a warning rather than swallowed at debug.
         $this->logger->expects($this->atLeastOnce())
-            ->method('debug');
+            ->method('warning');
 
         // Should not throw
         $this->handler->invalidateForSchemaChange(42, 'delete');

--- a/tests/Unit/Service/Schemas/SchemaCacheHandlerTest.php
+++ b/tests/Unit/Service/Schemas/SchemaCacheHandlerTest.php
@@ -394,9 +394,11 @@ class SchemaCacheHandlerTest extends TestCase
             'schema_31_schema_object' => 'other',
         ]);
 
-        $this->db->method('executeQuery')->willReturn(
-            $this->createMock(IResult::class)
-        );
+        // clearSchemaCache() now deletes through the query builder. It used to
+        // issue raw SQL naming the table UNPREFIXED, which Nextcloud never
+        // rewrites, so the statement could not have matched a row even once
+        // the table existed.
+        $this->db->method('getQueryBuilder')->willReturn($this->createMockQueryBuilder(false, 1));
 
         $this->handler->clearSchemaCache(30);
 
@@ -408,11 +410,14 @@ class SchemaCacheHandlerTest extends TestCase
 
     public function testClearSchemaCacheHandlesDatabaseError(): void
     {
-        $this->db->method('executeQuery')
+        $this->db->method('getQueryBuilder')
             ->willThrowException(new Exception('DB error'));
 
+        // `warning`, not `error`: invalidateForSchemaChange() catches the same
+        // cause and the two used to disagree about severity. Neither fails the
+        // caller, so neither is an error — both are a degraded cache.
         $this->logger->expects($this->atLeastOnce())
-            ->method('error')
+            ->method('warning')
             ->with($this->stringContains('Failed to clear schema cache'));
 
         $this->handler->clearSchemaCache(99);
@@ -421,9 +426,7 @@ class SchemaCacheHandlerTest extends TestCase
 
     public function testClearSchemaCacheLogsSuccess(): void
     {
-        $this->db->method('executeQuery')->willReturn(
-            $this->createMock(IResult::class)
-        );
+        $this->db->method('getQueryBuilder')->willReturn($this->createMockQueryBuilder(false, 1));
 
         $this->logger->expects($this->once())
             ->method('debug')
@@ -473,9 +476,15 @@ class SchemaCacheHandlerTest extends TestCase
 
         $this->db->method('getQueryBuilder')->willReturn($qb);
 
+        // The message no longer claims the table "does not exist yet". No
+        // migration ever created it, so that state was permanent rather than
+        // transitional, and `debug` meant nothing was emitted at default log
+        // level — the only trace was in the Postgres server log. The table is
+        // created by Version1Date20260809000000, so reaching this branch now
+        // means a real database failure and is logged as a warning.
         $this->logger->expects($this->atLeastOnce())
-            ->method('debug')
-            ->with($this->stringContains('does not exist yet'));
+            ->method('warning')
+            ->with($this->stringContains('Failed to invalidate the database schema cache'));
 
         $this->handler->invalidateForSchemaChange(50);
         $this->assertTrue(true);


### PR DESCRIPTION
Closes #2367.

## What was wrong

`SchemaCacheHandler` and `FacetCacheHandler` query `openregister_schema_cache` and `openregister_schema_facet_cache`. **No migration ever created either table.** Every statement failed at the database; every failure was swallowed by a `catch` logging at `debug`, which emits nothing at default log level. The persistent schema cache has never cached anything — only the per-request in-memory cache was ever doing work.

Measured (from #2367): ConductionNL/openbuild Code Quality run `31083894467`, E2E job `92559832374`, which pins `openregister@development` — **33x** `relation "oc_openregister_schema_cache" does not exist` and **22x** `relation "oc_openregister_schema_facet_cache" does not exist` in a single run's Postgres log. Same errors in decidesk, pipelinq and nldesign.

## What this changes

**1. The migration.** Column sets are taken from the handlers' own statements, not invented:

| table | columns | unique index |
|---|---|---|
| `openregister_schema_cache` | id, schema_id, cache_key, cache_data, created, updated, expires | (schema_id, cache_key) |
| `openregister_schema_facet_cache` | id, schema_id, facet_type, field_name, facet_config, cache_data, created, updated, expires | (schema_id, field_name) |

The unique indexes are what make the handlers' update-then-insert upsert *correct* rather than merely usual: without them a lost race appends a second row for the same key and the reader's `fetch()` returns whichever the planner reaches first.

**2. A second, independent bug.** `clearSchemaCache()` issued raw SQL naming the table **unprefixed** — `DELETE FROM openregister_schema_cache ...`. Nextcloud rewrites `*PREFIX*` and nothing else, so that statement addressed a table that exists under no configuration and **could not have matched a row even after this migration**. Now goes through the query builder.

**3. The `catch` blocks stop lying.** Both said the table "does not exist yet" and that the tolerance let the app run "even if the migration hasn't been run yet". There was no migration for that to be transitional to. They now describe what actually happened and log at `warning` — which also settles the disagreement flagged in #2367 where two sibling paths logged an identical cause at `debug` and `error`.

**4. Dead imports removed — and a correction.** `SaveObject` and `DeleteObject` imported both handlers and never used them. So these handlers are **not** on the object-write hot path, contrary to how the impact has been described. Their real callers are `SchemasController` (schema CRUD) and `CacheSettingsHandler` (admin cache clear) — which is why the error volume tracks schema seeding, not object writes. This lowers the risk of switching the cache on.

## Verification

- `Version1Date20260809000000Test` (5 tests) + `SchemaCacheHandlerTest` + `FacetCacheHandlerTest`: **68 tests, 146 assertions, green** on PHP 8.4.
- **Proved both assertions can fail:**
  - downgrading `addUniqueIndex` to `addIndex` under the same name → red on *"Without a UNIQUE index on (schema_id, cache_key) the handler update-then-insert upsert can duplicate a key."*
  - dropping the `facet_config` column → red on *"openregister_schema_facet_cache is missing the 'facet_config' column, which FacetCacheHandler writes."*
  - The first mutation exposed a defect in the test itself: unique and plain indexes were recorded into one bucket, so a uniqueness downgrade passed. They are now kept apart, which is what makes that assertion mean anything.
- `phpcs` and `phpstan`: clean on all changed `lib/` files.

## Note on the regression guard

#2367 asks for a test so this "cannot silently return". It is written by **reflecting the handlers' own table-name constants**, not by grepping for `createTable('...')`. A text scan cannot see `createTable(self::TABLE)` or `createTable(tableName: '...')` and matches the same string in a comment — it fails in both directions at once. Written as a grep it produced two **false** "no migration creates it" results in this very repository (`openregister_flow_state`, `openregister_tenant_keys`). Rename the constant on either side and the reflection test fails.

Existing tests that asserted the old `"does not exist yet"` debug message were updated — they encoded the bug.