### PR TITLE
fix(auth): declare the admin-only posture on ten workflow endpoints (gate-5)

### DIFF
--- a/lib/Controller/ScheduledWorkflowController.php
+++ b/lib/Controller/ScheduledWorkflowController.php
@@ -95,6 +95,12 @@ class ScheduledWorkflowController extends Controller
     /**
      * Create a new scheduled workflow.
      *
+     * @auth admin-only A scheduled workflow is instance-wide: ScheduledWorkflow carries no owner
+     *       column, and the TimedJob that runs it runs for the whole instance, not for the caller.
+     *       There is therefore no per-object guard to write here — nothing scopes a row to a user —
+     *       so admin is the only posture that is not a privilege escalation. Adding
+     *       #[NoAdminRequired] would let any authenticated user schedule work on the instance.
+     *
      * @return JSONResponse
      *
      * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-17
@@ -127,6 +133,10 @@ class ScheduledWorkflowController extends Controller
      *
      * @param int $id Scheduled workflow ID
      *
+     * @auth admin-only ScheduledWorkflow has no owner column, so "the caller's own workflow" is not
+     *       a thing that can be expressed, let alone guarded. Rescheduling or re-pointing a job
+     *       changes instance-wide behaviour for every user, so admin is the correct posture.
+     *
      * @return JSONResponse
      *
      * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-17
@@ -158,6 +168,10 @@ class ScheduledWorkflowController extends Controller
      * Delete a scheduled workflow.
      *
      * @param int $id Scheduled workflow ID
+     *
+     * @auth admin-only Deletes an instance-wide scheduled job by id. ScheduledWorkflow has no owner
+     *       column, so a per-object guard has nothing to compare the caller against; under
+     *       #[NoAdminRequired] this would be a direct object reference any user could delete.
      *
      * @return JSONResponse
      *

--- a/lib/Controller/WorkflowEngineController.php
+++ b/lib/Controller/WorkflowEngineController.php
@@ -85,7 +85,11 @@ class WorkflowEngineController extends Controller
     /**
      * List all registered engines.
      *
-     * @NoAdminRequired
+     * @auth admin-only Engine metadata serialises baseUrl, authType and healthStatus of an
+     *       instance-wide integration. The body already rejected non-admins; @NoAdminRequired said
+     *       the opposite, so the declared posture contradicted the enforced one. Declaring it here
+     *       makes middleware reject the request before the controller runs, which is the same
+     *       outcome one layer earlier.
      *
      * @return JSONResponse
      *
@@ -112,7 +116,9 @@ class WorkflowEngineController extends Controller
      *
      * @param int $id Engine ID
      *
-     * @NoAdminRequired
+     * @auth admin-only Same as index(): engine metadata exposes baseUrl and healthStatus of an
+     *       instance-wide integration, and the body already rejected non-admins while the removed
+     *       attribute declared the opposite.
      *
      * @return JSONResponse
      *
@@ -145,6 +151,11 @@ class WorkflowEngineController extends Controller
      * @param array|null  $authConfig     Auth configuration
      * @param bool        $enabled        Whether enabled
      * @param int         $defaultTimeout Default timeout
+     *
+     * @auth admin-only Registers an outbound integration target: baseUrl plus authType/authConfig
+     *       credentials that every later workflow execution will use. WorkflowEngine has no owner
+     *       column, so there is no per-object guard to write; a non-admin creating one would be
+     *       choosing where this instance sends data.
      *
      * @return JSONResponse
      *
@@ -206,6 +217,10 @@ class WorkflowEngineController extends Controller
      *
      * @param int $id Engine ID
      *
+     * @auth admin-only Can re-point baseUrl and replace the stored credentials of an instance-wide
+     *       integration, which redirects every subsequent execution. WorkflowEngine has no owner
+     *       column, so no per-object guard is expressible. The body enforces this too.
+     *
      * @return JSONResponse
      *
      * @spec openspec/specs/workflow-engine-abstraction/spec.md
@@ -233,6 +248,10 @@ class WorkflowEngineController extends Controller
      *
      * @param int $id Engine ID
      *
+     * @auth admin-only Removes an instance-wide integration by id, breaking every workflow bound to
+     *       it. WorkflowEngine has no owner column, so a per-object guard has nothing to compare the
+     *       caller against. The body enforces this too.
+     *
      * @return JSONResponse
      *
      * @spec openspec/specs/workflow-engine-abstraction/spec.md
@@ -259,6 +278,10 @@ class WorkflowEngineController extends Controller
      *
      * @return JSONResponse
      *
+     * @auth admin-only Makes this instance issue an outbound request to a stored baseUrl on demand
+     *       and reports whether it answered. That is a probe primitive, so it stays with the
+     *       administrator who configured the target rather than any authenticated user.
+     *
      * @spec openspec/specs/workflow-engine-abstraction/spec.md#requirement-engine-health-monitoring
      * @spec openspec/specs/workflow-engine-abstraction/spec.md
      */
@@ -278,6 +301,10 @@ class WorkflowEngineController extends Controller
     /**
      * List auto-discovered engine types from installed ExApps.
      *
+     * @auth admin-only Enumerates which ExApps are installed on this instance. That inventory is
+     *       administrative information and is only consumed by the engine admin UI, so it is gated
+     *       with the rest of that surface rather than exposed to every authenticated user.
+     *
      * @return JSONResponse
      *
      * @spec openspec/specs/workflow-engine-abstraction/spec.md
@@ -295,6 +322,11 @@ class WorkflowEngineController extends Controller
      * No database writes occur. The response includes dryRun: true.
      *
      * @param int $id Engine ID
+     *
+     * @auth admin-only "Dry run" describes this app's database, not the far side: the request is
+     *       really executed against the configured engine with caller-supplied sampleData, a
+     *       caller-supplied workflowId and a caller-supplied timeout. Under #[NoAdminRequired] any
+     *       authenticated user could drive outbound requests through a stored, credentialed target.
      *
      * @return JSONResponse
      *

--- a/lib/Controller/WorkflowExecutionController.php
+++ b/lib/Controller/WorkflowExecutionController.php
@@ -143,6 +143,11 @@ class WorkflowExecutionController extends Controller
      *
      * @param int $id Execution ID
      *
+     * @auth admin-only Execution rows are the audit trail of what this instance sent to an external
+     *       engine and what came back. Deleting audit history is an administrative act, and the
+     *       prose above already said "admin only" without anything enforcing or declaring it —
+     *       WorkflowExecution has no owner column, so no per-object guard is expressible either.
+     *
      * @return JSONResponse
      *
      * @spec openspec/specs/workflow-engine-abstraction/spec.md#requirement-workflow-execution-api-sync-and-async

--- a/tests/Unit/Controller/WorkflowEndpointsAdminPostureTest.php
+++ b/tests/Unit/Controller/WorkflowEndpointsAdminPostureTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * The workflow endpoints must stay admin-only.
+ *
+ * ScheduledWorkflow, WorkflowEngine and WorkflowExecution have NO owner column,
+ * so "the caller's own workflow" is not a thing that can be expressed and there
+ * is no per-object guard available to write. Admin is therefore the only posture
+ * that is not a privilege escalation, and the way that posture is expressed in
+ * Nextcloud is by the ABSENCE of #[NoAdminRequired] — which means a single added
+ * attribute silently opens every one of these endpoints to any authenticated
+ * user, with no diff to any guard to give it away.
+ *
+ * That is what this test exists to catch. It asserts the absence, so adding the
+ * attribute back turns it red.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Controller
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @spec openspec/specs/workflow-engine-abstraction/spec.md
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Controller;
+
+use OCA\OpenRegister\Controller\ScheduledWorkflowController;
+use OCA\OpenRegister\Controller\WorkflowEngineController;
+use OCA\OpenRegister\Controller\WorkflowExecutionController;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\PublicPage;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+class WorkflowEndpointsAdminPostureTest extends TestCase
+{
+
+
+    /**
+     * Every endpoint that must remain reachable by administrators only.
+     *
+     * @return array<string, array{0: class-string, 1: string}>
+     */
+    public static function adminOnlyEndpoints(): array
+    {
+        return [
+            'ScheduledWorkflow::create'   => [ScheduledWorkflowController::class, 'create'],
+            'ScheduledWorkflow::update'   => [ScheduledWorkflowController::class, 'update'],
+            'ScheduledWorkflow::destroy'  => [ScheduledWorkflowController::class, 'destroy'],
+            'WorkflowEngine::index'       => [WorkflowEngineController::class, 'index'],
+            'WorkflowEngine::show'        => [WorkflowEngineController::class, 'show'],
+            'WorkflowEngine::create'      => [WorkflowEngineController::class, 'create'],
+            'WorkflowEngine::update'      => [WorkflowEngineController::class, 'update'],
+            'WorkflowEngine::destroy'     => [WorkflowEngineController::class, 'destroy'],
+            'WorkflowEngine::health'      => [WorkflowEngineController::class, 'health'],
+            'WorkflowEngine::available'   => [WorkflowEngineController::class, 'available'],
+            'WorkflowEngine::testHook'    => [WorkflowEngineController::class, 'testHook'],
+            'WorkflowExecution::destroy'  => [WorkflowExecutionController::class, 'destroy'],
+        ];
+    }//end adminOnlyEndpoints()
+
+
+    /**
+     * The endpoint must not carry #[NoAdminRequired].
+     *
+     * This is the load-bearing assertion: the attribute's absence IS the admin
+     * gate, so its presence would make the endpoint reachable by every logged-in
+     * user without any other line of the diff changing.
+     *
+     * @param class-string $controller The controller class.
+     * @param string       $method     The method name.
+     *
+     * @return void
+     *
+     * @dataProvider adminOnlyEndpoints
+     */
+    public function testEndpointDoesNotDeclareNoAdminRequired(string $controller, string $method): void
+    {
+        $attributes = (new ReflectionMethod($controller, $method))->getAttributes(NoAdminRequired::class);
+
+        $this->assertSame(
+            [],
+            $attributes,
+            $controller.'::'.$method.'() carries #[NoAdminRequired]. These endpoints operate on '
+            .'instance-wide records with no owner column, so there is no per-object guard that could '
+            .'make them safe for a non-admin. Remove the attribute, or add an owner column and a guard '
+            .'first.'
+        );
+    }//end testEndpointDoesNotDeclareNoAdminRequired()
+
+
+    /**
+     * The endpoint must not be a public page either.
+     *
+     * #[PublicPage] drops authentication altogether, so it would be a strictly
+     * worse version of the same mistake and the NoAdminRequired assertion above
+     * would not notice it.
+     *
+     * @param class-string $controller The controller class.
+     * @param string       $method     The method name.
+     *
+     * @return void
+     *
+     * @dataProvider adminOnlyEndpoints
+     */
+    public function testEndpointIsNotAPublicPage(string $controller, string $method): void
+    {
+        $attributes = (new ReflectionMethod($controller, $method))->getAttributes(PublicPage::class);
+
+        $this->assertSame(
+            [],
+            $attributes,
+            $controller.'::'.$method.'() carries #[PublicPage], which removes authentication entirely.'
+        );
+    }//end testEndpointIsNotAPublicPage()
+
+
+    /**
+     * The legacy docblock form must be absent too.
+     *
+     * Nextcloud still honours `@NoAdminRequired` at docblock-tag position, so an
+     * attribute-only check would pass over an endpoint opened the old way. The
+     * tag is only recognised at tag position — preceded on its line by nothing
+     * but whitespace and comment punctuation — which is what the pattern below
+     * matches, so prose mentioning the name in a sentence does not trip it.
+     *
+     * @param class-string $controller The controller class.
+     * @param string       $method     The method name.
+     *
+     * @return void
+     *
+     * @dataProvider adminOnlyEndpoints
+     */
+    public function testEndpointDoesNotCarryTheLegacyDocblockTag(string $controller, string $method): void
+    {
+        $doc = (new ReflectionMethod($controller, $method))->getDocComment();
+        if ($doc === false) {
+            $this->addToAssertionCount(1);
+            return;
+        }
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/^[[:space:]]*(\/?\*+[[:space:]]*)@NoAdminRequired\b/m',
+            $doc,
+            $controller.'::'.$method.'() declares @NoAdminRequired at docblock-tag position, which '
+            .'Nextcloud honours exactly like the attribute.'
+        );
+    }//end testEndpointDoesNotCarryTheLegacyDocblockTag()
+
+
+    /**
+     * The admin-only posture must be stated, not merely implied by an absence.
+     *
+     * An endpoint that is admin-only because nobody wrote an attribute reads
+     * identically to one where the attribute was forgotten. `@auth admin-only`
+     * is what separates the two, and it is the marker the mechanical gates read.
+     *
+     * @param class-string $controller The controller class.
+     * @param string       $method     The method name.
+     *
+     * @return void
+     *
+     * @dataProvider adminOnlyEndpoints
+     */
+    public function testEndpointDeclaresItsAdminOnlyPostureWithAReason(string $controller, string $method): void
+    {
+        $doc = (new ReflectionMethod($controller, $method))->getDocComment();
+
+        $this->assertIsString($doc, $controller.'::'.$method.'() has no docblock to declare a posture in.');
+        $this->assertMatchesRegularExpression(
+            '/^[[:space:]]*(\/?\*+[[:space:]]*)@auth[[:space:]]+admin-only[[:space:]]+.{20,}/m',
+            $doc,
+            $controller.'::'.$method.'() does not declare `@auth admin-only <reason>`. Being admin-only '
+            .'by Nextcloud default is indistinguishable from having forgotten an attribute; say which it is.'
+        );
+    }//end testEndpointDeclaresItsAdminOnlyPostureWithAReason()
+}//end class


### PR DESCRIPTION
Refs #2386. **gate-5 route-auth: 10 → 0 (PASS).** No behaviour change — every endpoint stays exactly as reachable as it is today.

Measured with hydra-gates `48c88ba1e0d049f8f38538c33e790d3e603c55d0`.

## The finding

Ten routed methods across the three workflow controllers declared **no auth posture at all**. They were admin-only only because that is Nextcloud's default when no attribute is present — accidental, undocumented, and indistinguishable from an oversight.

## Why not `#[NoAdminRequired]` + a per-object guard

That is the repair gate-5 findings usually want, and here it would **create** the vulnerability rather than close it. None of the three entities has an owner or user column:

| entity | columns |
|---|---|
| `ScheduledWorkflow` | uuid, name, engine, workflowId, registerId, schemaId, intervalSec, enabled, payload, lastRun, lastStatus, created, updated |
| `WorkflowEngine` | uuid, name, engineType, baseUrl, authType, authConfig, enabled, defaultTimeout, healthStatus, … |
| `WorkflowExecution` | uuid, hookId, eventType, objectUuid, schemaId, registerId, engine, workflowId, mode, status, … |

**With no owner column there is nothing for a per-object guard to compare the caller against.** `#[NoAdminRequired]` would simply hand every authenticated user the ability to schedule instance-wide jobs, re-point a credentialed integration target, or delete audit history by id. These are instance configuration, not user-owned resources.

Per the gate's own design there is no attribute meaning "admin only" — *the absence of `#[NoAdminRequired]` **is** the admin gate* — so the posture is declared with the marker the gate package provides for exactly this case, `@auth admin-only <reason>`, at docblock-tag position. Each reason states why that endpoint is instance-wide.

Worth reading: **`testHook()`**'s "dry run" refers to *this app's database*, not the far side. It really does drive an outbound request through a stored, credentialed target using caller-supplied `workflowId`, `sampleData` and `timeout`.

## Also fixed: two real mismatches gate-9 does not see

`WorkflowEngineController::index()` and `::show()` carried `@NoAdminRequired` **while their bodies rejected non-admins** via `isCurrentUserAdmin()`. The declared posture contradicted the enforced one.

**gate-9 (semantic-auth) reported neither**, because it does not recognise an admin check reached through a *private helper method* — it flagged three methods elsewhere that use a different idiom. Both now declare admin-only, so middleware rejects before the controller runs: same outcome, one layer earlier. I'll raise the gate-9 blind spot on ConductionNL/.github separately.

## Measurement

| gate | before | after |
|---|---|---|
| gate-5 route-auth | FAIL — 10 | **PASS** |
| gate-7 no-admin-idor | FAIL — 12 | FAIL — 12 (unchanged) |
| gate-9 semantic-auth | FAIL — 3 | FAIL — 3 (unchanged) |

**Proof the marker is what moves the gate:** an intermediate run after only the three `ScheduledWorkflowController` declarations measured **FAIL — 7**. Three declarations, count down by exactly three.

`phpcs` and `phpstan` clean on all three files; the 22 existing controller unit tests pass.

## One thing deliberately left alone

`ScheduledWorkflowController::index/show` and `WorkflowExecutionController::index/show` keep their existing `@NoAdminRequired`. Those are pre-existing read endpoints, `index()` calls `findAll()` with no scoping, and `payload`/`errors` may carry sensitive content — but changing read posture is a behaviour change that could break the admin UI, and it is outside this gate's finding. Flagging it here rather than folding it in silently.