### PR TITLE
fix(a11y): close gates 39/43/44/45 and 8 of 10 gate-32 findings

### DIFF
--- a/css/mail-sidebar.css
+++ b/css/mail-sidebar.css
@@ -193,8 +193,14 @@ aside.or-mail-sidebar.app-sidebar,
 	font-size: 13px;
 }
 
-.or-action-result:hover {
+.or-action-result:hover,
+.or-action-result:focus-visible {
 	background: var(--color-background-hover);
+}
+
+.or-action-result:focus-visible {
+	outline: 2px solid var(--color-primary-element);
+	outline-offset: -2px;
 }
 
 .or-action-result-name {

--- a/src/components/AgentSelector.vue
+++ b/src/components/AgentSelector.vue
@@ -596,4 +596,11 @@ export default {
 		}
 	}
 }
+
+@media (prefers-reduced-motion: reduce) {
+	.agent-selector .agent-grid .agent-card,
+	.agent-selector .agent-grid .agent-card .agent-capabilities .capability-section .capability-list .capability-more {
+		transition: none;
+	}
+}
 </style>

--- a/src/components/RbacTable.vue
+++ b/src/components/RbacTable.vue
@@ -3,11 +3,21 @@
 		<table class="rbac-table">
 			<thead>
 				<tr>
-					<th>Group</th>
-					<th>Create</th>
-					<th>Read</th>
-					<th>Update</th>
-					<th>Delete</th>
+					<th scope="col">
+						Group
+					</th>
+					<th scope="col">
+						Create
+					</th>
+					<th scope="col">
+						Read
+					</th>
+					<th scope="col">
+						Update
+					</th>
+					<th scope="col">
+						Delete
+					</th>
 				</tr>
 			</thead>
 			<tbody>

--- a/src/components/cards/ConfigurationCard.vue
+++ b/src/components/cards/ConfigurationCard.vue
@@ -966,4 +966,11 @@ export default {
 	background-color: var(--color-error);
 	color: white;
 }
+
+@media (prefers-reduced-motion: reduce) {
+	.configurationCard,
+	.metaLink {
+		transition: none;
+	}
+}
 </style>

--- a/src/components/cards/RegisterSchemaCard.vue
+++ b/src/components/cards/RegisterSchemaCard.vue
@@ -99,7 +99,15 @@ import { dashboardStore, registerStore, schemaStore, navigationStore, configurat
 		</div>
 
 		<!-- Description -->
-		<div class="registerDescription-container" @click="item.description ? descriptionExpanded = !descriptionExpanded : null">
+		<!-- Only a disclosure control when there is actually a description to expand;
+			with no description the click is a no-op, so it must not be a tab stop. -->
+		<div class="registerDescription-container"
+			:role="item.description ? 'button' : null"
+			:tabindex="item.description ? 0 : null"
+			:aria-expanded="item.description ? String(descriptionExpanded) : null"
+			@click="item.description ? descriptionExpanded = !descriptionExpanded : null"
+			@keydown.enter="item.description ? descriptionExpanded = !descriptionExpanded : null"
+			@keydown.space.prevent="item.description ? descriptionExpanded = !descriptionExpanded : null">
 			<div class="registerDescription"
 				:class="{ 'registerDescription--expanded': descriptionExpanded, 'registerDescription--empty': !item.description }">
 				{{ item.description || t('openregister', 'No description found') }}
@@ -112,9 +120,15 @@ import { dashboardStore, registerStore, schemaStore, navigationStore, configurat
 				<table class="statisticsTable registerSchemas">
 					<thead>
 						<tr>
-							<th>{{ t('openregister', 'Schema Name') }}</th>
-							<th>{{ t('openregister', 'Objects') }}</th>
-							<th>{{ t('openregister', 'Configuration') }}</th>
+							<th scope="col">
+								{{ t('openregister', 'Schema Name') }}
+							</th>
+							<th scope="col">
+								{{ t('openregister', 'Objects') }}
+							</th>
+							<th scope="col">
+								{{ t('openregister', 'Configuration') }}
+							</th>
 						</tr>
 					</thead>
 					<tbody>
@@ -240,8 +254,12 @@ import { dashboardStore, registerStore, schemaStore, navigationStore, configurat
 				<table class="statisticsTable registerSchemas">
 					<thead>
 						<tr>
-							<th>{{ t('openregister', 'Name') }}</th>
-							<th>{{ t('openregister', 'Type') }}</th>
+							<th scope="col">
+								{{ t('openregister', 'Name') }}
+							</th>
+							<th scope="col">
+								{{ t('openregister', 'Type') }}
+							</th>
 						</tr>
 					</thead>
 					<tbody>
@@ -1223,5 +1241,11 @@ export default {
 	color: var(--color-warning-dark);
 	font-size: 0.8em;
 	margin-left: 4px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.registerDescription-container {
+		transition: none;
+	}
 }
 </style>

--- a/src/components/files-sidebar/ExtractionTab.vue
+++ b/src/components/files-sidebar/ExtractionTab.vue
@@ -479,4 +479,10 @@ export default {
 	height: 64px;
 	fill: currentColor;
 }
+
+@media (prefers-reduced-motion: reduce) {
+	.extraction-tab__chevron {
+		transition: none;
+	}
+}
 </style>

--- a/src/components/files-sidebar/RegisterObjectsTab.vue
+++ b/src/components/files-sidebar/RegisterObjectsTab.vue
@@ -229,4 +229,10 @@ export default {
 	height: 64px;
 	fill: currentColor;
 }
+
+@media (prefers-reduced-motion: reduce) {
+	.register-objects-tab__link {
+		transition: none;
+	}
+}
 </style>

--- a/src/components/i18n/BulkTranslateDialog.vue
+++ b/src/components/i18n/BulkTranslateDialog.vue
@@ -1,6 +1,10 @@
 <template>
 	<div v-if="open" class="bulk-translate-dialog__backdrop" @click.self="$emit('close')">
-		<div class="bulk-translate-dialog" role="dialog" aria-labelledby="bulk-translate-dialog-title">
+		<div class="bulk-translate-dialog"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="bulk-translate-dialog-title"
+			@keydown.escape="$emit('close')">
 			<header class="bulk-translate-dialog__header">
 				<h3 id="bulk-translate-dialog-title">
 					Bulk translate

--- a/src/components/shared/SettingsCard.vue
+++ b/src/components/shared/SettingsCard.vue
@@ -156,4 +156,20 @@ export default {
 	transform: translateY(-5px);
 	opacity: 0;
 }
+
+@media (prefers-reduced-motion: reduce) {
+	.collapsible-section h4.collapsible-header,
+	.collapsible-section h4.collapsible-header .chevron-icon,
+	.slide-fade-enter-active,
+	.slide-fade-leave-active {
+		transition: none;
+	}
+
+	/* The slide-fade transform is the motion itself — with reduced motion the
+	   section must appear and disappear in place. */
+	.slide-fade-enter-from,
+	.slide-fade-leave-to {
+		transform: none;
+	}
+}
 </style>

--- a/src/components/workflow/HookList.vue
+++ b/src/components/workflow/HookList.vue
@@ -7,13 +7,27 @@
 		<table v-else class="hook-table">
 			<thead>
 				<tr>
-					<th>Event</th>
-					<th>Engine</th>
-					<th>Workflow</th>
-					<th>Mode</th>
-					<th>Order</th>
-					<th>Enabled</th>
-					<th>Actions</th>
+					<th scope="col">
+						Event
+					</th>
+					<th scope="col">
+						Engine
+					</th>
+					<th scope="col">
+						Workflow
+					</th>
+					<th scope="col">
+						Mode
+					</th>
+					<th scope="col">
+						Order
+					</th>
+					<th scope="col">
+						Enabled
+					</th>
+					<th scope="col">
+						Actions
+					</th>
 				</tr>
 			</thead>
 			<tbody>

--- a/src/components/workflow/ScheduledWorkflowPanel.vue
+++ b/src/components/workflow/ScheduledWorkflowPanel.vue
@@ -4,13 +4,27 @@
 		<table v-if="schedules.length" class="schedule-table">
 			<thead>
 				<tr>
-					<th>Name</th>
-					<th>Engine</th>
-					<th>Workflow</th>
-					<th>Interval</th>
-					<th>Enabled</th>
-					<th>Last Run</th>
-					<th>Last Status</th>
+					<th scope="col">
+						Name
+					</th>
+					<th scope="col">
+						Engine
+					</th>
+					<th scope="col">
+						Workflow
+					</th>
+					<th scope="col">
+						Interval
+					</th>
+					<th scope="col">
+						Enabled
+					</th>
+					<th scope="col">
+						Last Run
+					</th>
+					<th scope="col">
+						Last Status
+					</th>
 				</tr>
 			</thead>
 			<tbody>

--- a/src/components/workflow/WorkflowExecutionPanel.vue
+++ b/src/components/workflow/WorkflowExecutionPanel.vue
@@ -7,11 +7,21 @@
 		<table v-else-if="executions.length" class="execution-table">
 			<thead>
 				<tr>
-					<th>Timestamp</th>
-					<th>Hook</th>
-					<th>Object</th>
-					<th>Status</th>
-					<th>Duration</th>
+					<th scope="col">
+						Timestamp
+					</th>
+					<th scope="col">
+						Hook
+					</th>
+					<th scope="col">
+						Object
+					</th>
+					<th scope="col">
+						Status
+					</th>
+					<th scope="col">
+						Duration
+					</th>
 				</tr>
 			</thead>
 			<tbody>

--- a/src/mail-sidebar/components/ActionsTab.vue
+++ b/src/mail-sidebar/components/ActionsTab.vue
@@ -30,12 +30,20 @@
 							:placeholder="t('openregister', 'Search {name}...', { name: schema.title })"
 							@input="debounceSearch(schema)"
 							@focus="showResults(schema)">
-						<ul v-if="visibleResults[schema.id] && (searchResults[schema.id] || []).length > 0" class="or-action-results">
+						<ul v-if="visibleResults[schema.id] && (searchResults[schema.id] || []).length > 0"
+							class="or-action-results"
+							role="listbox"
+							:aria-label="t('openregister', 'Search results for {name}', { name: schema.title })">
 							<li
 								v-for="obj in searchResults[schema.id]"
 								:key="obj.id"
 								class="or-action-result"
-								@click="linkObject(schema, obj)">
+								role="option"
+								tabindex="0"
+								:aria-selected="false"
+								@click="linkObject(schema, obj)"
+								@keydown.enter="linkObject(schema, obj)"
+								@keydown.space.prevent="linkObject(schema, obj)">
 								<span class="or-action-result-name">{{ objectName(obj) }}</span>
 							</li>
 						</ul>
@@ -112,11 +120,13 @@ export default {
 		 * A schema block is busy while it is creating a new record or
 		 * connecting an existing one — used to swap the search UI for a
 		 * spinner so the user sees the work happening.
+		 * @param schema
 		 */
 		isBusy(schema) {
 			return !!this.creating[schema.id] || !!this.linking[schema.id]
 		},
 		/**
+		 * @param obj
 		 * @spec openspec/specs/mail-sidebar/spec.md
 		 */
 		objectName(obj) {
@@ -167,6 +177,7 @@ export default {
 			}
 		},
 		/**
+		 * @param schema
 		 * @spec openspec/specs/mail-sidebar/spec.md
 		 */
 		async loadInitialResults(schema) {
@@ -189,12 +200,14 @@ export default {
 			}
 		},
 		/**
+		 * @param schema
 		 * @spec openspec/specs/mail-sidebar/spec.md
 		 */
 		showResults(schema) {
 			this.visibleResults[schema.id] = true
 		},
 		/**
+		 * @param schema
 		 * @spec openspec/specs/mail-sidebar/spec.md
 		 */
 		debounceSearch(schema) {
@@ -206,6 +219,7 @@ export default {
 			}, 300)
 		},
 		/**
+		 * @param schema
 		 * @spec openspec/specs/mail-sidebar/spec.md
 		 */
 		async searchObjects(schema) {
@@ -261,6 +275,7 @@ export default {
 		 * Schemas opt into create-from-email by declaring a field template in
 		 * `configuration.mailObjectTemplate` (e.g. pipelinq lead, shillinq invoice).
 		 *
+		 * @param schema
 		 * @spec openspec/specs/integration-email/spec.md
 		 */
 		hasCreateTemplate(schema) {
@@ -283,6 +298,7 @@ export default {
 		/**
 		 * Build the placeholder map available to mailObjectTemplate values.
 		 *
+		 * @param envelope
 		 * @spec openspec/specs/integration-email/spec.md
 		 */
 		buildPlaceholders(envelope) {
@@ -311,6 +327,8 @@ export default {
 		 * Substitute {{placeholder}} tokens in string template values; pass
 		 * non-string values (numbers, booleans) through untouched.
 		 *
+		 * @param template
+		 * @param placeholders
 		 * @spec openspec/specs/integration-email/spec.md
 		 */
 		applyTemplate(template, placeholders) {
@@ -330,6 +348,7 @@ export default {
 		 * Open the create-object dialog, prefilled from the schema's
 		 * mailObjectTemplate applied to the current email.
 		 *
+		 * @param schema
 		 * @spec openspec/specs/integration-email/spec.md
 		 */
 		async openCreate(schema) {
@@ -364,6 +383,7 @@ export default {
 		 * Create the object from the (possibly edited) dialog data, then
 		 * connect the email to it.
 		 *
+		 * @param data
 		 * @spec openspec/specs/integration-email/spec.md
 		 */
 		async submitCreate(data) {
@@ -390,6 +410,8 @@ export default {
 			}
 		},
 		/**
+		 * @param schema
+		 * @param obj
 		 * @spec openspec/specs/mail-sidebar/spec.md#requirement-link-and-unlink-actions-from-the-sidebar
 		 */
 		async linkObject(schema, obj) {

--- a/src/mail-sidebar/components/ActionsTab.vue
+++ b/src/mail-sidebar/components/ActionsTab.vue
@@ -33,7 +33,7 @@
 						<ul v-if="visibleResults[schema.id] && (searchResults[schema.id] || []).length > 0"
 							class="or-action-results"
 							role="listbox"
-							:aria-label="t('openregister', 'Search results for {name}', { name: schema.title })">
+							:aria-label="t('openregister', 'Search Results')">
 							<li
 								v-for="obj in searchResults[schema.id]"
 								:key="obj.id"

--- a/src/mail-sidebar/components/LinkObjectDialog.vue
+++ b/src/mail-sidebar/components/LinkObjectDialog.vue
@@ -35,7 +35,7 @@
 				<ul v-else
 					class="or-mail-link-dialog__results"
 					role="listbox"
-					:aria-label="t('openregister', 'Search results')">
+					:aria-label="t('openregister', 'Search Results')">
 					<li
 						v-for="result in searchResults"
 						:key="result.id || result.uuid"

--- a/src/mail-sidebar/components/LinkObjectDialog.vue
+++ b/src/mail-sidebar/components/LinkObjectDialog.vue
@@ -32,16 +32,22 @@
 						{{ t('openregister', 'Try searching by UUID or with different keywords') }}
 					</p>
 				</div>
-				<ul v-else class="or-mail-link-dialog__results">
+				<ul v-else
+					class="or-mail-link-dialog__results"
+					role="listbox"
+					:aria-label="t('openregister', 'Search results')">
 					<li
 						v-for="result in searchResults"
 						:key="result.id || result.uuid"
 						class="or-mail-link-dialog__result"
 						:class="{ 'or-mail-link-dialog__result--linked': isAlreadyLinked(result) }"
+						role="option"
 						tabindex="0"
+						:aria-selected="selectedResult === result"
 						:aria-label="resultAriaLabel(result)"
 						@click="selectResult(result)"
-						@keydown.enter="selectResult(result)">
+						@keydown.enter="selectResult(result)"
+						@keydown.space.prevent="selectResult(result)">
 						<span class="or-mail-link-dialog__result-title">
 							{{ result.title || result.uuid }}
 						</span>

--- a/src/modals/configuration/ImportConfiguration.vue
+++ b/src/modals/configuration/ImportConfiguration.vue
@@ -168,7 +168,12 @@ import { configurationStore, navigationStore, registerStore, schemaStore } from 
 								:key="file.path"
 								class="fileCard"
 								:class="{ selected: selectedFile === file }"
-								@click="selectedFile = file">
+								role="button"
+								tabindex="0"
+								:aria-pressed="selectedFile === file"
+								@click="selectedFile = file"
+								@keydown.enter="selectedFile = file"
+								@keydown.space.prevent="selectedFile = file">
 								<h4>{{ file.config.title }}</h4>
 								<p class="fileDescription">
 									{{ file.config.description || 'No description' }}
@@ -216,7 +221,12 @@ import { configurationStore, navigationStore, registerStore, schemaStore } from 
 
 						<div class="fileUploadZone"
 							:class="{ 'dragover': isDragging }"
+							role="button"
+							tabindex="0"
+							:aria-label="t('openregister', 'Browse for a configuration file to upload')"
 							@click="!selectedUploadFile && $refs.fileInput.click()"
+							@keydown.enter="!selectedUploadFile && $refs.fileInput.click()"
+							@keydown.space.prevent="!selectedUploadFile && $refs.fileInput.click()"
 							@drop.prevent="handleFileDrop"
 							@dragover.prevent="isDragging = true"
 							@dragleave.prevent="isDragging = false">
@@ -1076,5 +1086,12 @@ export default {
 .fileSize {
 	color: var(--color-text-maxcontrast);
 	font-size: 0.9em;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.fileCard,
+	.fileUploadZone {
+		transition: none;
+	}
 }
 </style>

--- a/src/modals/configuration/ImportConfiguration.vue
+++ b/src/modals/configuration/ImportConfiguration.vue
@@ -219,11 +219,14 @@ import { configurationStore, navigationStore, registerStore, schemaStore } from 
 							Upload a configuration JSON file from your computer.
 						</p>
 
+						<!-- Only a button while the zone is empty: once a file is picked the
+							click handler is inert and the body contains a real "Clear" button,
+							which role="button" would hide (children-presentational). The zone is
+							then named by its visible text in both states, so no aria-label. -->
 						<div class="fileUploadZone"
 							:class="{ 'dragover': isDragging }"
-							role="button"
-							tabindex="0"
-							:aria-label="t('openregister', 'Browse for a configuration file to upload')"
+							:role="selectedUploadFile ? null : 'button'"
+							:tabindex="selectedUploadFile ? null : 0"
 							@click="!selectedUploadFile && $refs.fileInput.click()"
 							@keydown.enter="!selectedUploadFile && $refs.fileInput.click()"
 							@keydown.space.prevent="!selectedUploadFile && $refs.fileInput.click()"

--- a/src/modals/configuration/PreviewConfiguration.vue
+++ b/src/modals/configuration/PreviewConfiguration.vue
@@ -644,4 +644,10 @@ export default {
 	color: var(--color-text-lighter);
 	font-style: italic;
 }
+
+@media (prefers-reduced-motion: reduce) {
+	.changeItem {
+		transition: none;
+	}
+}
 </style>

--- a/src/modals/configuration/ViewConfiguration.vue
+++ b/src/modals/configuration/ViewConfiguration.vue
@@ -300,4 +300,10 @@ export default {
 	align-items: center;
 	min-height: 200px;
 }
+
+@media (prefers-reduced-motion: reduce) {
+	.tabHeader {
+		transition: none;
+	}
+}
 </style>

--- a/src/modals/file/UploadFiles.vue
+++ b/src/modals/file/UploadFiles.vue
@@ -22,10 +22,10 @@ import { navigationStore, objectStore } from '../../store/store.js'
 					:taggable="true"
 					:multiple="true"
 					:selectable="(option) => isSelectable(option)" />
-				<NcCheckboxRadioSwitch :disabled="loading"
+				<NcCheckboxRadioSwitch v-model="share"
+					:disabled="loading"
 					:label="t('openregister', 'Auto share')"
-					type="switch"
-					v-model="share">
+					type="switch">
 					{{ t('openregister', 'Auto share') }}
 				</NcCheckboxRadioSwitch>
 			</div>
@@ -153,13 +153,13 @@ import { navigationStore, objectStore } from '../../store/store.js'
 					<thead>
 						<tr class="files-table-tr">
 							<th class="files-table-td-status" />
-							<th>
+							<th scope="col">
 								{{ t('openregister', 'File name') }}
 							</th>
-							<th>
+							<th scope="col">
 								{{ t('openregister', 'Size') }}
 							</th>
-							<th>
+							<th scope="col">
 								{{ t('openregister', 'Labels') }}
 							</th>
 						</tr>

--- a/src/modals/logs/AuditTrailChanges.vue
+++ b/src/modals/logs/AuditTrailChanges.vue
@@ -36,10 +36,18 @@ import { auditTrailStore, navigationStore } from '../../store/store.js'
 					<table class="changes-table">
 						<thead>
 							<tr>
-								<th>{{ t('openregister', 'Field') }}</th>
-								<th>{{ t('openregister', 'Old Value') }}</th>
-								<th>{{ t('openregister', 'New Value') }}</th>
-								<th>{{ t('openregister', 'Change Type') }}</th>
+								<th scope="col">
+									{{ t('openregister', 'Field') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Old Value') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'New Value') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Change Type') }}
+								</th>
 							</tr>
 						</thead>
 						<tbody>

--- a/src/modals/mdm/MdmMergeWizardModal.vue
+++ b/src/modals/mdm/MdmMergeWizardModal.vue
@@ -28,9 +28,15 @@
 				<table class="mergeWizard__table">
 					<thead>
 						<tr>
-							<th>{{ t('openregister', 'Attribute') }}</th>
-							<th>{{ t('openregister', 'Winning value') }}</th>
-							<th>{{ t('openregister', 'Source') }}</th>
+							<th scope="col">
+								{{ t('openregister', 'Attribute') }}
+							</th>
+							<th scope="col">
+								{{ t('openregister', 'Winning value') }}
+							</th>
+							<th scope="col">
+								{{ t('openregister', 'Source') }}
+							</th>
 						</tr>
 					</thead>
 					<tbody>

--- a/src/modals/object/MergeObject.vue
+++ b/src/modals/object/MergeObject.vue
@@ -50,7 +50,12 @@ import { objectStore, navigationStore, registerStore, schemaStore } from '../../
 					:key="obj['@self'].id"
 					class="object-item table-row-selectable"
 					:class="{ 'table-row-selected': selectedTargetObject?.['@self']?.id === obj['@self'].id }"
-					@click="selectTargetObject(obj)">
+					role="button"
+					tabindex="0"
+					:aria-pressed="selectedTargetObject?.['@self']?.id === obj['@self'].id"
+					@click="selectTargetObject(obj)"
+					@keydown.enter="selectTargetObject(obj)"
+					@keydown.space.prevent="selectTargetObject(obj)">
 					<div class="object-info">
 						<strong>{{ obj['@self']?.name || obj.name || obj.title || obj['@self']?.title || obj['@self']?.id }}</strong>
 						<p class="object-id">
@@ -80,10 +85,18 @@ import { objectStore, navigationStore, registerStore, schemaStore } from '../../
 				<table class="merge-table">
 					<thead>
 						<tr>
-							<th>Property</th>
-							<th>Source</th>
-							<th>Target</th>
-							<th>Result Value</th>
+							<th scope="col">
+								Property
+							</th>
+							<th scope="col">
+								Source
+							</th>
+							<th scope="col">
+								Target
+							</th>
+							<th scope="col">
+								Result Value
+							</th>
 						</tr>
 					</thead>
 					<tbody>
@@ -157,9 +170,15 @@ import { objectStore, navigationStore, registerStore, schemaStore } from '../../
 					<table class="file-table">
 						<thead>
 							<tr>
-								<th>Filename</th>
-								<th>Size</th>
-								<th>Type</th>
+								<th scope="col">
+									Filename
+								</th>
+								<th scope="col">
+									Size
+								</th>
+								<th scope="col">
+									Type
+								</th>
 							</tr>
 						</thead>
 						<tbody>
@@ -214,8 +233,12 @@ import { objectStore, navigationStore, registerStore, schemaStore } from '../../
 					<table class="relation-table">
 						<thead>
 							<tr>
-								<th>Related Object</th>
-								<th>Relation Type</th>
+								<th scope="col">
+									Related Object
+								</th>
+								<th scope="col">
+									Relation Type
+								</th>
 							</tr>
 						</thead>
 						<tbody>
@@ -272,9 +295,15 @@ import { objectStore, navigationStore, registerStore, schemaStore } from '../../
 					<table class="relation-table">
 						<thead>
 							<tr>
-								<th>Referencing Object</th>
-								<th>Type</th>
-								<th>Register / Schema</th>
+								<th scope="col">
+									Referencing Object
+								</th>
+								<th scope="col">
+									Type
+								</th>
+								<th scope="col">
+									Register / Schema
+								</th>
 							</tr>
 						</thead>
 						<tbody>
@@ -351,9 +380,15 @@ import { objectStore, navigationStore, registerStore, schemaStore } from '../../
 					<table class="report-table">
 						<thead>
 							<tr>
-								<th>Property</th>
-								<th>Old Value</th>
-								<th>New Value</th>
+								<th scope="col">
+									Property
+								</th>
+								<th scope="col">
+									Old Value
+								</th>
+								<th scope="col">
+									New Value
+								</th>
 							</tr>
 						</thead>
 						<tbody>
@@ -1280,5 +1315,11 @@ export default {
 
 .codeMirrorContainer.dark :deep(.cm-line .ͼd)::selection {
 	color: #623907;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.object-item {
+		transition: none;
+	}
 }
 </style>

--- a/src/modals/object/ViewObject.vue
+++ b/src/modals/object/ViewObject.vue
@@ -489,7 +489,7 @@ import { objectStore, navigationStore, registerStore, schemaStore } from '../../
 																</template>
 															</NcButton>
 															<NcButton :disabled="labelsLoading"
-																:aria-label="t('openregister', 'Cancel editing labels')"
+																:aria-label="t('openregister', 'Cancel')"
 																@click="cancelFileLabels()">
 																<template #icon>
 																	<Cancel :size="20" />

--- a/src/modals/object/ViewObject.vue
+++ b/src/modals/object/ViewObject.vue
@@ -23,9 +23,9 @@ import { objectStore, navigationStore, registerStore, schemaStore } from '../../
 							<div v-if="availableRegisters.length > 1" class="field-group">
 								<label for="register-select">{{ t('openregister', 'Register') }}</label>
 								<NcSelect
-									input-label="Selected Register For New Object"
 									id="register-select"
 									v-model="selectedRegisterForNewObject"
+									input-label="Selected Register For New Object"
 									:options="availableRegisters"
 									label="title"
 									track-by="id"
@@ -36,9 +36,9 @@ import { objectStore, navigationStore, registerStore, schemaStore } from '../../
 							<div v-if="availableSchemas.length > 1" class="field-group">
 								<label for="schema-select">{{ t('openregister', 'Schema') }}</label>
 								<NcSelect
-									input-label="Selected Schema For New Object"
 									id="schema-select"
 									v-model="selectedSchemaForNewObject"
+									input-label="Selected Schema For New Object"
 									:options="availableSchemas"
 									label="title"
 									track-by="id"
@@ -68,10 +68,10 @@ import { objectStore, navigationStore, registerStore, schemaStore } from '../../
 									<table class="viewTable">
 										<thead>
 											<tr class="viewTableRow">
-												<th class="tableColumnConstrained">
+												<th scope="col" class="tableColumnConstrained">
 													Property
 												</th>
-												<th class="tableColumnExpanded">
+												<th scope="col" class="tableColumnExpanded">
 													Value
 												</th>
 											</tr>
@@ -182,13 +182,13 @@ import { objectStore, navigationStore, registerStore, schemaStore } from '../../
 									<table class="viewTable">
 										<thead>
 											<tr class="viewTableRow">
-												<th class="tableColumnConstrained">
+												<th scope="col" class="tableColumnConstrained">
 													{{ t('openregister', 'Metadata') }}
 												</th>
-												<th class="tableColumnExpanded">
+												<th scope="col" class="tableColumnExpanded">
 													Value
 												</th>
-												<th class="tableColumnActions">
+												<th scope="col" class="tableColumnActions">
 													Actions
 												</th>
 											</tr>
@@ -256,11 +256,21 @@ import { objectStore, navigationStore, registerStore, schemaStore } from '../../
 									<table class="table">
 										<thead>
 											<tr class="table-row">
-												<th>ID</th>
-												<th>URI</th>
-												<th>Schema</th>
-												<th>Register</th>
-												<th>Actions</th>
+												<th scope="col">
+													ID
+												</th>
+												<th scope="col">
+													URI
+												</th>
+												<th scope="col">
+													Schema
+												</th>
+												<th scope="col">
+													Register
+												</th>
+												<th scope="col">
+													Actions
+												</th>
 											</tr>
 										</thead>
 										<tbody>
@@ -292,11 +302,21 @@ import { objectStore, navigationStore, registerStore, schemaStore } from '../../
 									<table class="table">
 										<thead>
 											<tr class="table-row">
-												<th>ID</th>
-												<th>URI</th>
-												<th>Schema</th>
-												<th>Register</th>
-												<th>Actions</th>
+												<th scope="col">
+													ID
+												</th>
+												<th scope="col">
+													URI
+												</th>
+												<th scope="col">
+													Schema
+												</th>
+												<th scope="col">
+													Register
+												</th>
+												<th scope="col">
+													Actions
+												</th>
 											</tr>
 										</thead>
 										<tbody>
@@ -328,11 +348,21 @@ import { objectStore, navigationStore, registerStore, schemaStore } from '../../
 									<table class="table">
 										<thead>
 											<tr class="table-row">
-												<th>ID</th>
-												<th>URI</th>
-												<th>Schema</th>
-												<th>Register</th>
-												<th>Actions</th>
+												<th scope="col">
+													ID
+												</th>
+												<th scope="col">
+													URI
+												</th>
+												<th scope="col">
+													Schema
+												</th>
+												<th scope="col">
+													Register
+												</th>
+												<th scope="col">
+													Actions
+												</th>
 											</tr>
 										</thead>
 										<tbody>
@@ -370,19 +400,19 @@ import { objectStore, navigationStore, registerStore, schemaStore } from '../../
 														:indeterminate="someFilesSelected"
 														@update:modelValue="toggleSelectAllFiles" />
 												</th>
-												<th class="tableColumnExpanded">
+												<th scope="col" class="tableColumnExpanded">
 													Name
 												</th>
-												<th class="tableColumnConstrained">
+												<th scope="col" class="tableColumnConstrained">
 													Size
 												</th>
-												<th class="tableColumnConstrained">
+												<th scope="col" class="tableColumnConstrained">
 													Type
 												</th>
-												<th class="tableColumnConstrained">
+												<th scope="col" class="tableColumnConstrained">
 													Labels
 												</th>
-												<th class="tableColumnActions">
+												<th scope="col" class="tableColumnActions">
 													<NcActions
 														:force-name="true"
 														:disabled="selectedAttachments.length === 0"
@@ -449,13 +479,18 @@ import { objectStore, navigationStore, registerStore, schemaStore } from '../../
 															:disabled="labelsLoading"
 															:input-label="t('openregister', 'Labels')" />
 														<div class="fileLabelsEditActions">
-															<NcButton :disabled="labelsLoading" variant="primary" @click="saveFileLabels(attachment)">
+															<NcButton :disabled="labelsLoading"
+																variant="primary"
+																:aria-label="t('openregister', 'Save labels')"
+																@click="saveFileLabels(attachment)">
 																<template #icon>
 																	<NcLoadingIcon v-if="labelsLoading" :size="20" />
 																	<Check v-else :size="20" />
 																</template>
 															</NcButton>
-															<NcButton :disabled="labelsLoading" @click="cancelFileLabels()">
+															<NcButton :disabled="labelsLoading"
+																:aria-label="t('openregister', 'Cancel editing labels')"
+																@click="cancelFileLabels()">
 																<template #icon>
 																	<Cancel :size="20" />
 																</template>
@@ -1055,6 +1090,7 @@ export default {
 	watch: {
 		objectStore: {
 			/**
+			 * @param newValue
 			 * @spec exclude watcher re-initializing data on store change
 			 */
 			handler(newValue) {
@@ -1067,6 +1103,7 @@ export default {
 		// Watch for schema changes to re-initialize data
 		currentSchema: {
 			/**
+			 * @param newSchema
 			 * @spec exclude watcher re-resolving schema and re-initializing data
 			 */
 			async handler(newSchema) {
@@ -1105,6 +1142,7 @@ export default {
 		// Watch for register changes to re-initialize data
 		currentRegister: {
 			/**
+			 * @param newRegister
 			 * @spec exclude watcher re-initializing data on register change
 			 */
 			handler(newRegister) {
@@ -1117,6 +1155,7 @@ export default {
 		},
 		jsonData: {
 			/**
+			 * @param newValue
 			 * @spec exclude watcher syncing form from JSON editor
 			 */
 			handler(newValue) {
@@ -1127,6 +1166,7 @@ export default {
 		},
 		formData: {
 			/**
+			 * @param _newValue
 			 * @spec exclude watcher syncing JSON editor from form
 			 */
 			handler(_newValue) {
@@ -1279,6 +1319,7 @@ export default {
 			navigationStore.setDialog(null)
 		},
 		/**
+		 * @param isOpen
 		 * @spec exclude modal open/close UI handler
 		 */
 		handleDialogClose(isOpen) {
@@ -1323,6 +1364,7 @@ export default {
 			return fileName.substring(0, 22) + '...'
 		},
 		/**
+		 * @param value
 		 * @spec exclude client-side date validation helper
 		 */
 		isValidDate(value) {
@@ -1331,6 +1373,7 @@ export default {
 			return date instanceof Date && !isNaN(date)
 		},
 		/**
+		 * @param val
 		 * @spec exclude display helper formatting value as JSON
 		 */
 		formatValue(val) {
@@ -1339,6 +1382,7 @@ export default {
 
 		getTheme,
 		/**
+		 * @param text
 		 * @spec exclude clipboard UI helper
 		 */
 		async copyToClipboard(text) {
@@ -1506,6 +1550,7 @@ export default {
 		},
 
 		/**
+		 * @param str
 		 * @spec exclude client-side JSON validation helper
 		 */
 		isValidJson(str) {
@@ -1538,6 +1583,9 @@ export default {
 			this.formData[key] = value
 		},
 		/**
+		 * @param key
+		 * @param index
+		 * @param value
 		 * @spec exclude form-state helper updating an array item
 		 */
 		updateArrayItem(key, index, value) {
@@ -1547,15 +1595,18 @@ export default {
 			this.formData[key][index] = value
 		},
 		/**
+		 * @param v
 		 * @spec exclude display/payload coercion helper for null values
 		 */
 		toDisplay(v) { return v === null ? '' : v },
 		/**
+		 * @param v
 		 * @spec exclude display/payload coercion helper for empty values
 		 */
 		toPayload(v) { return v === '' ? null : v },
 
 		/**
+		 * @param key
 		 * @spec exclude form-state helper adding an array item
 		 */
 		addArrayItem(key) {
@@ -1565,6 +1616,8 @@ export default {
 			this.formData[key].push('')
 		},
 		/**
+		 * @param key
+		 * @param i
 		 * @spec exclude form-state helper removing an array item
 		 */
 		removeArrayItem(key, i) {
@@ -1573,6 +1626,8 @@ export default {
 			}
 		},
 		/**
+		 * @param key
+		 * @param val
 		 * @spec exclude form-state helper updating an object-typed field
 		 */
 		updateObjectField(key, val) {
@@ -1584,6 +1639,7 @@ export default {
 			}
 		},
 		/**
+		 * @param checked
 		 * @spec exclude file-selection UI toggle (select all)
 		 */
 		toggleSelectAllFiles(checked) {
@@ -1601,6 +1657,8 @@ export default {
 			}
 		},
 		/**
+		 * @param fileId
+		 * @param checked
 		 * @spec exclude file-selection UI toggle (single file)
 		 */
 		toggleFileSelection(fileId, checked) {
@@ -1613,12 +1671,14 @@ export default {
 			}
 		},
 		/**
+		 * @param page
 		 * @spec exclude files pagination UI handler
 		 */
 		onFilesPageChanged(page) {
 			this.filesCurrentPage = page
 		},
 		/**
+		 * @param pageSize
 		 * @spec exclude files page-size UI handler
 		 */
 		onFilesPageSizeChanged(pageSize) {
@@ -1638,6 +1698,8 @@ export default {
 		// back to N sequential single-file calls when the runtime store
 		// doesn't expose batchFiles yet (older @conduction/nextcloud-vue).
 		/**
+		 * @param action
+		 * @param perFileFallback
 		 * @spec exclude file batch-action dispatch helper delegating to objectStore.batchFiles
 		 */
 		async _runBatchAction(action, perFileFallback) {
@@ -1676,6 +1738,7 @@ export default {
 			}
 		},
 		/**
+		 * @param file
 		 * @spec exclude single file-delete handler delegating to objectStore.deleteFile
 		 */
 		async deleteFile(file) {
@@ -1691,6 +1754,7 @@ export default {
 			}
 		},
 		/**
+		 * @param file
 		 * @spec exclude form-state handler entering file-label edit mode
 		 */
 		async editFileLabels(file) {
@@ -1713,6 +1777,7 @@ export default {
 		// API call shape is implemented in services/fileMetadata.js so it
 		// can be unit-tested without mounting this modal.
 		/**
+		 * @param file
 		 * @spec exclude file-label save handler delegating to services/fileMetadata
 		 */
 		async saveFileLabels(file) {
@@ -1753,6 +1818,8 @@ export default {
 			}
 		},
 		/**
+		 * @param key
+		 * @param value
 		 * @spec exclude computed CSS-class helper for property validation state
 		 */
 		getPropertyValidationClass(key, value) {
@@ -1785,6 +1852,9 @@ export default {
 			}
 		},
 		/**
+		 * @param key
+		 * @param value
+		 * @param schemaProperty
 		 * @spec exclude client-side property-value validation helper
 		 */
 		isValidPropertyValue(key, value, schemaProperty) {
@@ -1826,6 +1896,8 @@ export default {
 			}
 		},
 		/**
+		 * @param key
+		 * @param value
 		 * @spec exclude display helper building property error message
 		 */
 		getPropertyErrorMessage(key, value) {
@@ -1894,6 +1966,8 @@ export default {
 			return String(value)
 		},
 		/**
+		 * @param key
+		 * @param event
 		 * @spec exclude table-row click UI handler for inline edit
 		 */
 		handleRowClick(key, event) {
@@ -1931,6 +2005,7 @@ export default {
 			}
 		},
 		/**
+		 * @param key
 		 * @spec exclude form-state handler selecting/focusing a property for edit
 		 */
 		selectProperty(key) {
@@ -1948,6 +2023,8 @@ export default {
 			})
 		},
 		/**
+		 * @param key
+		 * @param newValue
 		 * @spec exclude form-state handler updating a property value with type coercion
 		 */
 		updatePropertyValue(key, newValue) {
@@ -2024,6 +2101,9 @@ export default {
 			})
 		},
 		/**
+		 * @param key
+		 * @param oldValue
+		 * @param newValue
 		 * @spec exclude toast notification UI helper for property changes
 		 */
 		showPropertyChangeNotification(key, oldValue, newValue) {
@@ -2058,6 +2138,7 @@ export default {
 			}, 3000)
 		},
 		/**
+		 * @param key
 		 * @spec exclude display helper checking string-typed property
 		 */
 		isStringProperty(key) {
@@ -2065,6 +2146,8 @@ export default {
 			return schemaProperty?.type === 'string'
 		},
 		/**
+		 * @param key
+		 * @param value
 		 * @spec exclude display helper checking property editability (const/immutable)
 		 */
 		isPropertyEditable(key, value) {
@@ -2086,6 +2169,8 @@ export default {
 			return true
 		},
 		/**
+		 * @param key
+		 * @param value
 		 * @spec exclude display helper building editability warning text
 		 */
 		getEditabilityWarning(key, value) {
@@ -2102,12 +2187,15 @@ export default {
 			return null
 		},
 		/**
+		 * @param value
+		 * @param format
 		 * @spec exclude display helper delegating to dateUtils.stringToDate
 		 */
 		stringToDate(value, format) {
 			return stringToDate(value, format)
 		},
 		/**
+		 * @param key
 		 * @spec exclude display helper mapping schema type to input type
 		 */
 		getPropertyInputType(key) {
@@ -2137,6 +2225,7 @@ export default {
 			}
 		},
 		/**
+		 * @param key
 		 * @spec exclude display helper mapping schema type to input component
 		 */
 		getPropertyInputComponent(key) {
@@ -2230,6 +2319,8 @@ export default {
 			return undefined
 		},
 		/**
+		 * @param key
+		 * @param value
 		 * @spec exclude display helper resolving value to show for a property
 		 */
 		getDisplayValue(key, value) {
@@ -2386,6 +2477,12 @@ export default {
 
 .viewTableRow.non-editable-row:hover {
 	background-color: var(--color-background-dark);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.viewTableRow {
+		transition: none;
+	}
 }
 </style>
 
@@ -2629,5 +2726,11 @@ export default {
 
 .codeMirrorContainer.dark :deep(.cm-line .ͼd)::selection {
 	color: #623907;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.viewTableRow {
+		transition: none;
+	}
 }
 </style>

--- a/src/modals/objectAuditTrail/ViewObjectAuditTrail.vue
+++ b/src/modals/objectAuditTrail/ViewObjectAuditTrail.vue
@@ -24,9 +24,15 @@ import { objectStore, navigationStore, schemaStore, registerStore } from '../../
 						<table class="audit-trail-table">
 							<thead>
 								<tr>
-									<th>Field</th>
-									<th>Old Value</th>
-									<th>New Value</th>
+									<th scope="col">
+										Field
+									</th>
+									<th scope="col">
+										Old Value
+									</th>
+									<th scope="col">
+										New Value
+									</th>
 								</tr>
 							</thead>
 							<tbody>

--- a/src/modals/organisation/EditOrganisation.vue
+++ b/src/modals/organisation/EditOrganisation.vue
@@ -25,22 +25,22 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 						</template>
 						<div class="form-editor">
 							<NcTextField
+								v-model="organisationItem.name"
 								:disabled="loading"
 								:label="t('openregister', 'Name *')"
-								v-model="organisationItem.name"
 								:error="!organisationItem.name.trim()"
 								:placeholder="t('openregister', 'Enter organisation name')" />
 
 							<NcTextField
+								v-model="organisationItem.slug"
 								:disabled="loading"
 								:label="t('openregister', 'Slug')"
-								v-model="organisationItem.slug"
 								:placeholder="t('openregister', 'Optional URL-friendly identifier')" />
 
 							<NcTextArea
+								v-model="organisationItem.description"
 								:disabled="loading"
 								:label="t('openregister', 'Description')"
-								v-model="organisationItem.description"
 								:placeholder="t('openregister', 'Enter organisation description (optional)')"
 								:rows="4" />
 
@@ -75,8 +75,8 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 							</div>
 
 							<NcCheckboxRadioSwitch
-								:disabled="loading"
-								v-model="organisationItem.active">
+								v-model="organisationItem.active"
+								:disabled="loading">
 								{{ t('openregister', 'Active') }}
 							</NcCheckboxRadioSwitch>
 
@@ -285,9 +285,15 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 											<table class="rbac-table special-rights-table">
 												<thead>
 													<tr>
-														<th>{{ t('openregister', 'Right') }}</th>
-														<th>{{ t('openregister', 'Description') }}</th>
-														<th>{{ t('openregister', 'Groups') }}</th>
+														<th scope="col">
+															{{ t('openregister', 'Right') }}
+														</th>
+														<th scope="col">
+															{{ t('openregister', 'Description') }}
+														</th>
+														<th scope="col">
+															{{ t('openregister', 'Groups') }}
+														</th>
 													</tr>
 												</thead>
 												<tbody>
@@ -382,9 +388,9 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 		<template #actions>
 			<NcCheckboxRadioSwitch
 				v-if="!organisationStore.organisationItem?.uuid"
+				v-model="createAnother"
 				class="create-another-checkbox"
-				:disabled="loading"
-				v-model="createAnother">
+				:disabled="loading">
 				{{ t('openregister', 'Create another') }}
 			</NcCheckboxRadioSwitch>
 			<NcButton @click="closeModal">

--- a/src/modals/organisation/SwitchOrganisationModal.vue
+++ b/src/modals/organisation/SwitchOrganisationModal.vue
@@ -114,4 +114,10 @@ export default {
 	margin-top: 4px;
 	display: block;
 }
+
+@media (prefers-reduced-motion: reduce) {
+	.organisationOption {
+		transition: none;
+	}
+}
 </style>

--- a/src/modals/register/ImportRegister.vue
+++ b/src/modals/register/ImportRegister.vue
@@ -27,14 +27,30 @@ import { registerStore, schemaStore, navigationStore, objectStore, dashboardStor
 				<table class="sheetSummaryTable">
 					<thead>
 						<tr>
-							<th>Sheet</th>
-							<th>Found</th>
-							<th>Created</th>
-							<th>Updated</th>
-							<th>Unchanged</th>
-							<th>Invalid</th>
-							<th>Errors</th>
-							<th>Total</th>
+							<th scope="col">
+								Sheet
+							</th>
+							<th scope="col">
+								Found
+							</th>
+							<th scope="col">
+								Created
+							</th>
+							<th scope="col">
+								Updated
+							</th>
+							<th scope="col">
+								Unchanged
+							</th>
+							<th scope="col">
+								Invalid
+							</th>
+							<th scope="col">
+								Errors
+							</th>
+							<th scope="col">
+								Total
+							</th>
 						</tr>
 					</thead>
 					<tbody>
@@ -90,8 +106,11 @@ import { registerStore, schemaStore, navigationStore, objectStore, dashboardStor
 										<span>{{ (sheetSummary.errors && sheetSummary.errors.length) || 0 }}</span>
 										<button
 											v-if="sheetSummary.errors && sheetSummary.errors.length > 0"
+											type="button"
 											class="expandButton"
 											:class="{ expanded: expandedErrors[sheetKey] }"
+											:aria-expanded="!!expandedErrors[sheetKey]"
+											:aria-label="t('openregister', 'Show error details for {sheet}', { sheet: sheetKey })"
 											@click="toggleErrorDetails(sheetKey)">
 											<ChevronDown :size="16" />
 										</button>
@@ -114,10 +133,18 @@ import { registerStore, schemaStore, navigationStore, objectStore, dashboardStor
 										<table class="errorTable">
 											<thead>
 												<tr>
-													<th>Row</th>
-													<th>Error Type</th>
-													<th>Error Message</th>
-													<th>Data</th>
+													<th scope="col">
+														Row
+													</th>
+													<th scope="col">
+														Error Type
+													</th>
+													<th scope="col">
+														Error Message
+													</th>
+													<th scope="col">
+														Data
+													</th>
 												</tr>
 											</thead>
 											<tbody>
@@ -1333,6 +1360,12 @@ export default {
 		flex-direction: column;
 		gap: 0.5rem;
 		align-items: flex-start;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.expandButton {
+		transition: none;
 	}
 }
 </style>

--- a/src/modals/register/ImportRegister.vue
+++ b/src/modals/register/ImportRegister.vue
@@ -110,7 +110,7 @@ import { registerStore, schemaStore, navigationStore, objectStore, dashboardStor
 											class="expandButton"
 											:class="{ expanded: expandedErrors[sheetKey] }"
 											:aria-expanded="!!expandedErrors[sheetKey]"
-											:aria-label="t('openregister', 'Show error details for {sheet}', { sheet: sheetKey })"
+											:aria-label="t('openregister', 'Error Details')"
 											@click="toggleErrorDetails(sheetKey)">
 											<ChevronDown :size="16" />
 										</button>

--- a/src/modals/schema/EditSchemaProperty.vue
+++ b/src/modals/schema/EditSchemaProperty.vue
@@ -394,7 +394,7 @@ import { navigationStore, schemaStore, registerStore } from '../../store/store.j
 									:label="t('openregister', 'To (e.g. -1 year or 2025-12-31)')" />
 								<NcButton :disabled="loading"
 									variant="tertiary-no-background"
-									:aria-label="t('openregister', 'Remove this range')"
+									:aria-label="t('openregister', 'Remove')"
 									@click="removeCustomRange(index)">
 									<template #icon>
 										<Cancel :size="20" />

--- a/src/modals/schema/EditSchemaProperty.vue
+++ b/src/modals/schema/EditSchemaProperty.vue
@@ -21,19 +21,19 @@ import { navigationStore, schemaStore, registerStore } from '../../store/store.j
 		</div>
 
 		<div v-if="success === null" class="form-group">
-			<NcTextField :disabled="loading"
+			<NcTextField v-model="propertyTitle"
+				:disabled="loading"
 				:label="t('openregister', 'Title*')"
 				:error="keyExists()"
-				:helper-text="keyExists() ? t('openregister', 'This key already exists on this schema') : ''"
-				v-model="propertyTitle" />
+				:helper-text="keyExists() ? t('openregister', 'This key already exists on this schema') : ''" />
 
-			<NcTextField :disabled="loading"
-				:label="t('openregister', 'Description')"
-				v-model="properties.description" />
+			<NcTextField v-model="properties.description"
+				:disabled="loading"
+				:label="t('openregister', 'Description')" />
 
-			<NcTextField :disabled="loading"
-				:label="t('openregister', 'Title')"
-				v-model="properties.title" />
+			<NcTextField v-model="properties.title"
+				:disabled="loading"
+				:label="t('openregister', 'Title')" />
 
 			<div class="ASP-selectContainer">
 				<NcSelect
@@ -73,9 +73,9 @@ import { navigationStore, schemaStore, registerStore } from '../../store/store.j
 					:model-value="properties.$ref"
 					@update:modelValue="handleSchemaChange($event)" />
 				<NcTextField
+					v-model="properties.objectConfiguration.queryParams"
 					:disabled="loading || !properties.$ref"
 					:label="t('openregister', 'Extra Query Parameters')"
-					v-model="properties.objectConfiguration.queryParams"
 					placeholder="key1=value1&key2=value2"
 					:helper-text="t('openregister', 'Optional: Add query parameters to filter the referenced schema (e.g., status=active&type=public)')" />
 				<NcSelect
@@ -87,8 +87,8 @@ import { navigationStore, schemaStore, registerStore } from '../../store/store.j
 					@update:modelValue="handleInversedByChange" />
 				<NcCheckboxRadioSwitch
 					v-if="properties.inversedBy"
-					:disabled="loading"
-					v-model="properties.writeBack">
+					v-model="properties.writeBack"
+					:disabled="loading">
 					{{ t('openregister', 'Enable write-back to target objects') }}
 				</NcCheckboxRadioSwitch>
 				<div v-if="properties.inversedBy && !properties.writeBack" class="helper-text">
@@ -96,8 +96,8 @@ import { navigationStore, schemaStore, registerStore } from '../../store/store.j
 				</div>
 				<NcCheckboxRadioSwitch
 					v-if="properties.inversedBy && properties.writeBack"
-					:disabled="loading"
-					v-model="properties.removeAfterWriteBack">
+					v-model="properties.removeAfterWriteBack"
+					:disabled="loading">
 					{{ t('openregister', 'Remove property after write-back') }}
 				</NcCheckboxRadioSwitch>
 				<div v-if="properties.inversedBy && properties.writeBack && !properties.removeAfterWriteBack" class="helper-text">
@@ -118,33 +118,33 @@ import { navigationStore, schemaStore, registerStore } from '../../store/store.j
 					:input-label="t('openregister', 'Allowed MIME Types')"
 					:label="t('openregister', 'Allowed MIME Types')"
 					multiple />
-				<NcTextField :disabled="loading"
-					:label="t('openregister', 'File Location')"
-					v-model="properties.fileConfiguration.location" />
-				<NcInputField :disabled="loading"
+				<NcTextField v-model="properties.fileConfiguration.location"
+					:disabled="loading"
+					:label="t('openregister', 'File Location')" />
+				<NcInputField v-model="properties.fileConfiguration.maxSize"
+					:disabled="loading"
 					type="number"
-					:label="t('openregister', 'Maximum File Size (MB)')"
-					v-model="properties.fileConfiguration.maxSize" />
+					:label="t('openregister', 'Maximum File Size (MB)')" />
 			</div>
 
 			<template v-if="properties.type !== 'object' && properties.type !== 'file'">
-				<NcTextField :disabled="loading"
-					:label="t('openregister', 'Pattern (regex)')"
-					v-model="properties.pattern" />
+				<NcTextField v-model="properties.pattern"
+					:disabled="loading"
+					:label="t('openregister', 'Pattern (regex)')" />
 
-				<NcTextField :disabled="loading"
-					:label="t('openregister', 'Behavior')"
-					v-model="properties.behavior" />
+				<NcTextField v-model="properties.behavior"
+					:disabled="loading"
+					:label="t('openregister', 'Behavior')" />
 				<template v-if="properties.type !== 'array'">
-					<NcInputField :disabled="loading"
+					<NcInputField v-model="properties.minLength"
+						:disabled="loading"
 						type="number"
-						:label="t('openregister', 'Minimum length')"
-						v-model="properties.minLength" />
+						:label="t('openregister', 'Minimum length')" />
 
-					<NcInputField :disabled="loading"
+					<NcInputField v-model="properties.maxLength"
+						:disabled="loading"
 						type="number"
-						:label="t('openregister', 'Maximum length')"
-						v-model="properties.maxLength" />
+						:label="t('openregister', 'Maximum length')" />
 				</template>
 			</template>
 
@@ -215,94 +215,94 @@ import { navigationStore, schemaStore, registerStore } from '../../store/store.j
 
 			<!-- TYPE : NUMBER -->
 			<NcInputField v-else-if="properties.type === 'number'"
+				v-model="properties.default"
 				:disabled="loading"
 				type="number"
 				step="any"
 				:label="t('openregister', 'Default value')"
-				v-model="properties.default"
 				:loading="loading" />
 			<!-- TYPE : INTEGER -->
 			<NcInputField v-else-if="properties.type === 'integer'"
+				v-model="properties.default"
 				:disabled="loading"
 				type="number"
 				step="1"
 				:label="t('openregister', 'Default value')"
-				v-model="properties.default"
 				:loading="loading" />
 			<!-- TYPE : OBJECT -->
 			<div v-else-if="properties.type === 'object'">
 				<NcTextArea
+					v-model="properties.default"
 					:disabled="loading"
 					:label="t('openregister', 'Default value')"
-					v-model="properties.default"
 					:loading="loading"
 					:error="!verifyJsonValidity(properties.default)"
 					:helper-text="!verifyJsonValidity(properties.default) ? t('openregister', 'This is not valid JSON') : ''" />
 
 				<NcCheckboxRadioSwitch
-					:disabled="loading"
-					v-model="properties.cascadeDelete">
+					v-model="properties.cascadeDelete"
+					:disabled="loading">
 					{{ t('openregister', 'Cascade delete') }}
 				</NcCheckboxRadioSwitch>
 			</div>
 
 			<!-- TYPE : ARRAY -->
 			<NcTextArea v-else-if="properties.type === 'array'"
+				v-model="properties.default"
 				:disabled="loading"
 				:label="t('openregister', 'Value list (split on ,)')"
-				v-model="properties.default"
 				:loading="loading" />
 			<!-- TYPE : BOOLEAN -->
 			<NcCheckboxRadioSwitch v-else-if="properties.type === 'boolean'"
-				:disabled="loading"
 				v-model="properties.default"
+				:disabled="loading"
 				:loading="loading">
 				{{ t('openregister', 'Default value') }}
 			</NcCheckboxRadioSwitch>
 			<!-- TYPE : dictionary -->
 			<NcTextField v-else-if="properties.type === 'dictionary'"
+				v-model="properties.default"
 				:disabled="loading"
-				:label="t('openregister', 'Default value')"
-				v-model="properties.default" />
+				:label="t('openregister', 'Default value')" />
 
-			<NcInputField :disabled="loading"
+			<NcInputField v-model="properties.order"
+				:disabled="loading"
 				type="number"
-				:label="t('openregister', 'Order')"
-				v-model="properties.order" />
+				:label="t('openregister', 'Order')" />
 
 			<NcCheckboxRadioSwitch
-				:disabled="loading"
-				v-model="properties.required">
+				v-model="properties.required"
+				:disabled="loading">
 				{{ t('openregister', 'Required') }}
 			</NcCheckboxRadioSwitch>
 
 			<NcCheckboxRadioSwitch
-				:disabled="loading"
-				v-model="properties.immutable">
+				v-model="properties.immutable"
+				:disabled="loading">
 				{{ t('openregister', 'Immutable') }}
 			</NcCheckboxRadioSwitch>
 
 			<NcCheckboxRadioSwitch
-				:disabled="loading"
-				v-model="properties.deprecated">
+				v-model="properties.deprecated"
+				:disabled="loading">
 				{{ t('openregister', 'Deprecated') }}
 			</NcCheckboxRadioSwitch>
 
 			<NcCheckboxRadioSwitch
-				:disabled="loading"
-				v-model="properties.visible">
+				v-model="properties.visible"
+				:disabled="loading">
 				{{ t('openregister', 'Visible to end users') }}
 			</NcCheckboxRadioSwitch>
 
 			<NcCheckboxRadioSwitch
-				:disabled="loading"
-				v-model="properties.hideOnCollection">
+				v-model="properties.hideOnCollection"
+				:disabled="loading">
 				{{ t('openregister', 'Hide in collection view') }}
 			</NcCheckboxRadioSwitch>
 
 			<NcCheckboxRadioSwitch
-				:disabled="loading"
-				v-model="facetableEnabled">
+				v-model="facetableEnabled"
+				:disabled="loading">
 				{{ t('openregister', 'Facetable') }}
 			</NcCheckboxRadioSwitch>
 
@@ -312,25 +312,25 @@ import { navigationStore, schemaStore, registerStore } from '../../store/store.j
 					{{ t('openregister', 'Faceting Configuration:') }}
 				</div>
 				<NcCheckboxRadioSwitch
-					:disabled="loading"
-					v-model="facetConfig.aggregated">
+					v-model="facetConfig.aggregated"
+					:disabled="loading">
 					{{ t('openregister', 'Aggregated across schemas') }}
 				</NcCheckboxRadioSwitch>
 				<div v-if="!facetConfig.aggregated" class="helper-text">
 					{{ t('openregister', 'When disabled, this facet will only show values from this schema and will include a schema filter when selected.') }}
 				</div>
-				<NcTextField :disabled="loading"
+				<NcTextField v-model="facetConfig.title"
+					:disabled="loading"
 					:label="t('openregister', 'Facet Title')"
-					v-model="facetConfig.title"
 					:placeholder="t('openregister', 'Custom display title for this facet')" />
-				<NcTextField :disabled="loading"
+				<NcTextField v-model="facetConfig.description"
+					:disabled="loading"
 					:label="t('openregister', 'Facet Description')"
-					v-model="facetConfig.description"
 					:placeholder="t('openregister', 'Description shown as tooltip')" />
-				<NcInputField :disabled="loading"
+				<NcInputField v-model="facetConfig.order"
+					:disabled="loading"
 					type="number"
-					:label="t('openregister', 'Facet Order')"
-					v-model="facetConfig.order" />
+					:label="t('openregister', 'Facet Order')" />
 				<div class="helper-text">
 					{{ t('openregister', 'Lower numbers appear first in the filter sidebar. Leave empty for automatic ordering.') }}
 				</div>
@@ -361,17 +361,17 @@ import { navigationStore, schemaStore, registerStore } from '../../store/store.j
 							:input-label="t('openregister', 'Interval')"
 							:clearable="false"
 							@update:modelValue="(opt) => facetInterval = opt.value" />
-						<NcTextField :disabled="loading"
+						<NcTextField v-model="facetFormat"
+							:disabled="loading"
 							:label="t('openregister', 'Display Format')"
-							v-model="facetFormat"
 							:placeholder="t('openregister', 'Auto (e.g. Y for year, F Y for month)')" />
 					</div>
 
 					<!-- Date range options -->
 					<div v-if="facetType === 'date_range'" class="facetDateOptions">
 						<NcCheckboxRadioSwitch
-							:disabled="loading"
-							v-model="facetUseDefaultRanges">
+							v-model="facetUseDefaultRanges"
+							:disabled="loading">
 							{{ t('openregister', 'Use default ranges (Last 7/30/90 days, Last year, Older)') }}
 						</NcCheckboxRadioSwitch>
 
@@ -383,17 +383,18 @@ import { navigationStore, schemaStore, registerStore } from '../../store/store.j
 							<div v-for="(range, index) in facetCustomRanges"
 								:key="index"
 								class="customRangeRow">
-								<NcTextField :disabled="loading"
-									:label="t('openregister', 'Label')"
-									v-model="range.label" />
-								<NcTextField :disabled="loading"
-									:label="t('openregister', 'From (e.g. -7 days or 2025-01-01)')"
-									v-model="range.from" />
-								<NcTextField :disabled="loading"
-									:label="t('openregister', 'To (e.g. -1 year or 2025-12-31)')"
-									v-model="range.to" />
+								<NcTextField v-model="range.label"
+									:disabled="loading"
+									:label="t('openregister', 'Label')" />
+								<NcTextField v-model="range.from"
+									:disabled="loading"
+									:label="t('openregister', 'From (e.g. -7 days or 2025-01-01)')" />
+								<NcTextField v-model="range.to"
+									:disabled="loading"
+									:label="t('openregister', 'To (e.g. -1 year or 2025-12-31)')" />
 								<NcButton :disabled="loading"
 									variant="tertiary-no-background"
+									:aria-label="t('openregister', 'Remove this range')"
 									@click="removeCustomRange(index)">
 									<template #icon>
 										<Cancel :size="20" />
@@ -413,9 +414,9 @@ import { navigationStore, schemaStore, registerStore } from '../../store/store.j
 				</div>
 			</div>
 
-			<NcTextField :disabled="loading"
-				:label="t('openregister', 'Example')"
-				v-model="properties.example" />
+			<NcTextField v-model="properties.example"
+				:disabled="loading"
+				:label="t('openregister', 'Example')" />
 
 			<!-- type integer and number only -->
 			<div v-if="properties.type === 'integer' || properties.type === 'number'">
@@ -423,30 +424,30 @@ import { navigationStore, schemaStore, registerStore } from '../../store/store.j
 					type: number
 				</h5>
 
-				<NcInputField :disabled="loading"
+				<NcInputField v-model="properties.minimum"
+					:disabled="loading"
 					type="number"
-					:label="t('openregister', 'Minimum value')"
-					v-model="properties.minimum" />
+					:label="t('openregister', 'Minimum value')" />
 
-				<NcInputField :disabled="loading"
+				<NcInputField v-model="properties.maximum"
+					:disabled="loading"
 					type="number"
-					:label="t('openregister', 'Maximum value')"
-					v-model="properties.maximum" />
+					:label="t('openregister', 'Maximum value')" />
 
-				<NcInputField :disabled="loading"
+				<NcInputField v-model="properties.multipleOf"
+					:disabled="loading"
 					type="number"
-					:label="t('openregister', 'Multiple of')"
-					v-model="properties.multipleOf" />
+					:label="t('openregister', 'Multiple of')" />
 
 				<NcCheckboxRadioSwitch
-					:disabled="loading"
-					v-model="properties.exclusiveMin">
+					v-model="properties.exclusiveMin"
+					:disabled="loading">
 					{{ t('openregister', 'Exclusive minimum') }}
 				</NcCheckboxRadioSwitch>
 
 				<NcCheckboxRadioSwitch
-					:disabled="loading"
-					v-model="properties.exclusiveMax">
+					v-model="properties.exclusiveMax"
+					:disabled="loading">
 					{{ t('openregister', 'Exclusive maximum') }}
 				</NcCheckboxRadioSwitch>
 			</div>
@@ -490,9 +491,9 @@ import { navigationStore, schemaStore, registerStore } from '../../store/store.j
 						:model-value="properties.items.$ref"
 						@update:modelValue="handleSchemaChange($event)" />
 					<NcTextField
+						v-model="properties.items.objectConfiguration.queryParams"
 						:disabled="loading || !properties.items.$ref"
 						:label="t('openregister', 'Extra Query Parameters')"
-						v-model="properties.items.objectConfiguration.queryParams"
 						placeholder="key1=value1&key2=value2"
 						:helper-text="t('openregister', 'Optional: Add query parameters to filter the referenced schema (e.g., status=active&type=public)')" />
 					<NcSelect
@@ -504,8 +505,8 @@ import { navigationStore, schemaStore, registerStore } from '../../store/store.j
 						@update:modelValue="handleInversedByChange" />
 					<NcCheckboxRadioSwitch
 						v-if="properties.items.inversedBy"
-						:disabled="loading"
-						v-model="properties.items.writeBack">
+						v-model="properties.items.writeBack"
+						:disabled="loading">
 						{{ t('openregister', 'Enable write-back to target objects') }}
 					</NcCheckboxRadioSwitch>
 					<div v-if="properties.items.inversedBy && !properties.items.writeBack" class="helper-text">
@@ -513,29 +514,29 @@ import { navigationStore, schemaStore, registerStore } from '../../store/store.j
 					</div>
 					<NcCheckboxRadioSwitch
 						v-if="properties.items.inversedBy && properties.items.writeBack"
-						:disabled="loading"
-						v-model="properties.items.removeAfterWriteBack">
+						v-model="properties.items.removeAfterWriteBack"
+						:disabled="loading">
 						{{ t('openregister', 'Remove property after write-back') }}
 					</NcCheckboxRadioSwitch>
 					<div v-if="properties.items.inversedBy && properties.items.writeBack && !properties.items.removeAfterWriteBack" class="helper-text">
 						{{ t('openregister', 'When enabled, this property will be removed from the source object after updating the target objects.') }}
 					</div>
 					<NcCheckboxRadioSwitch
-						:disabled="loading"
-						v-model="properties.items.cascadeDelete">
+						v-model="properties.items.cascadeDelete"
+						:disabled="loading">
 						{{ t('openregister', 'Cascade delete') }}
 					</NcCheckboxRadioSwitch>
 				</div>
 
-				<NcInputField :disabled="loading"
+				<NcInputField v-model="properties.minItems"
+					:disabled="loading"
 					type="number"
-					:label="t('openregister', 'Minimum number of items')"
-					v-model="properties.minItems" />
+					:label="t('openregister', 'Minimum number of items')" />
 
-				<NcInputField :disabled="loading"
+				<NcInputField v-model="properties.maxItems"
+					:disabled="loading"
 					type="number"
-					:label="t('openregister', 'Maximum number of items')"
-					v-model="properties.maxItems" />
+					:label="t('openregister', 'Maximum number of items')" />
 			</div>
 
 			<!-- type oneOf only -->

--- a/src/modals/schema/ExploreSchema.vue
+++ b/src/modals/schema/ExploreSchema.vue
@@ -1779,4 +1779,11 @@ export default {
 	color: var(--color-text-lighter);
 	line-height: 1.3;
 }
+
+@media (prefers-reduced-motion: reduce) {
+	.analysis-status .analysis-summary .stat-box,
+	.property-card {
+		transition: none;
+	}
+}
 </style>

--- a/src/modals/schema/ValidateSchema.vue
+++ b/src/modals/schema/ValidateSchema.vue
@@ -79,12 +79,24 @@ import SchemaStatsBlock from '../../components/SchemaStatsBlock.vue'
 					<table class="validation-table">
 						<thead>
 							<tr>
-								<th>Status</th>
-								<th>ID</th>
-								<th>Name</th>
-								<th>UUID</th>
-								<th>Errors</th>
-								<th>Actions</th>
+								<th scope="col">
+									Status
+								</th>
+								<th scope="col">
+									ID
+								</th>
+								<th scope="col">
+									Name
+								</th>
+								<th scope="col">
+									UUID
+								</th>
+								<th scope="col">
+									Errors
+								</th>
+								<th scope="col">
+									Actions
+								</th>
 							</tr>
 						</thead>
 						<tbody>
@@ -322,6 +334,7 @@ export default {
 
 		/**
 		 * @param object
+		 * @param _object
 		 * @spec exclude UI navigation stub — placeholder for viewing an object's details.
 		 */
 		viewObjectDetails(_object) {

--- a/src/modals/settings/LLMConfigModal.vue
+++ b/src/modals/settings/LLMConfigModal.vue
@@ -99,6 +99,7 @@
 						id="openai-org"
 						v-model="openaiConfig.organizationId"
 						type="text"
+						autocomplete="off"
 						:placeholder="t('openregister', 'org-...')"
 						class="input-field">
 				</div>

--- a/src/modals/settings/MassValidateModal.vue
+++ b/src/modals/settings/MassValidateModal.vue
@@ -1170,4 +1170,10 @@ export default {
 	gap: 0.5rem;
 	justify-content: flex-end;
 }
+
+@media (prefers-reduced-motion: reduce) {
+	.success-rate-fill {
+		transition: none;
+	}
+}
 </style>

--- a/src/modals/source/ViewSource.vue
+++ b/src/modals/source/ViewSource.vue
@@ -472,4 +472,10 @@ export default {
 	align-items: center;
 	min-height: 200px;
 }
+
+@media (prefers-reduced-motion: reduce) {
+	.tabHeader {
+		transition: none;
+	}
+}
 </style>

--- a/src/modals/webhook/ViewWebhookLog.vue
+++ b/src/modals/webhook/ViewWebhookLog.vue
@@ -12,25 +12,25 @@
 				<h3>{{ t('openregister', 'Basic Information') }}</h3>
 				<table class="logDetailsTable">
 					<tr>
-						<td class="logLabel">
+						<th scope="row" class="logLabel">
 							{{ t('openregister', 'Webhook') }}
-						</td>
+						</th>
 						<td class="logValue">
 							{{ getWebhookName(logItem.webhookId) }}
 						</td>
 					</tr>
 					<tr>
-						<td class="logLabel">
+						<th scope="row" class="logLabel">
 							{{ t('openregister', 'Event') }}
-						</td>
+						</th>
 						<td class="logValue">
 							<code class="event-class">{{ logItem.eventClass }}</code>
 						</td>
 					</tr>
 					<tr>
-						<td class="logLabel">
+						<th scope="row" class="logLabel">
 							{{ t('openregister', 'Status') }}
-						</td>
+						</th>
 						<td class="logValue">
 							<span :class="logItem.success ? 'status-success' : 'status-failed'">
 								{{ logItem.success ? t('openregister', 'Success') : t('openregister', 'Failed') }}
@@ -38,26 +38,26 @@
 						</td>
 					</tr>
 					<tr>
-						<td class="logLabel">
+						<th scope="row" class="logLabel">
 							{{ t('openregister', 'Status Code') }}
-						</td>
+						</th>
 						<td class="logValue">
 							<span v-if="logItem.statusCode">{{ logItem.statusCode }}</span>
 							<span v-else class="text-muted">-</span>
 						</td>
 					</tr>
 					<tr>
-						<td class="logLabel">
+						<th scope="row" class="logLabel">
 							{{ t('openregister', 'Attempt') }}
-						</td>
+						</th>
 						<td class="logValue">
 							{{ logItem.attempt }}
 						</td>
 					</tr>
 					<tr>
-						<td class="logLabel">
+						<th scope="row" class="logLabel">
 							{{ t('openregister', 'Created') }}
-						</td>
+						</th>
 						<td class="logValue">
 							{{ formatDate(logItem.created) }}
 						</td>
@@ -358,9 +358,11 @@ export default {
 	border-bottom: 1px solid var(--color-border);
 }
 
-.logDetailsTable td {
+.logDetailsTable td,
+.logDetailsTable th {
 	padding: 12px 0;
 	vertical-align: top;
+	text-align: left;
 }
 
 .logLabel {

--- a/src/reference/ObjectReferenceWidget.vue
+++ b/src/reference/ObjectReferenceWidget.vue
@@ -241,4 +241,10 @@ export default {
 		justify-content: flex-start;
 	}
 }
+
+@media (prefers-reduced-motion: reduce) {
+	.openregister-reference-widget {
+		transition: none;
+	}
+}
 </style>

--- a/src/sidebars/dashboard/DashboardSideBar.vue
+++ b/src/sidebars/dashboard/DashboardSideBar.vue
@@ -58,7 +58,7 @@ import { objectStore, registerStore, schemaStore, dashboardStore } from '../../s
 						<thead>
 							<tr>
 								<th scope="col">
-									{{ t('openregister', 'Item') }}
+									{{ t('openregister', 'Name') }}
 								</th>
 								<th scope="col">
 									{{ t('openregister', 'Count') }}
@@ -144,7 +144,7 @@ import { objectStore, registerStore, schemaStore, dashboardStore } from '../../s
 						<thead>
 							<tr>
 								<th scope="col">
-									{{ t('openregister', 'Item') }}
+									{{ t('openregister', 'Name') }}
 								</th>
 								<th scope="col">
 									{{ t('openregister', 'Count') }}

--- a/src/sidebars/dashboard/DashboardSideBar.vue
+++ b/src/sidebars/dashboard/DashboardSideBar.vue
@@ -55,50 +55,73 @@ import { objectStore, registerStore, schemaStore, dashboardStore } from '../../s
 				</div>
 				<div v-else-if="systemTotals" class="statsContainer">
 					<table class="statisticsTable">
+						<thead>
+							<tr>
+								<th scope="col">
+									{{ t('openregister', 'Item') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Count') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Size') }}
+								</th>
+							</tr>
+						</thead>
 						<tbody>
 							<tr>
-								<td>{{ t('openregister', 'Registers') }}</td>
+								<th scope="row">
+									{{ t('openregister', 'Registers') }}
+								</th>
 								<td>{{ filteredRegisters.length }}</td>
 								<td>-</td>
 							</tr>
 							<tr>
-								<td>{{ t('openregister', 'Schemas') }}</td>
+								<th scope="row">
+									{{ t('openregister', 'Schemas') }}
+								</th>
 								<td>{{ totalSchemas }}</td>
 								<td>-</td>
 							</tr>
 							<tr>
-								<td>{{ t('openregister', 'Objects') }}</td>
+								<th scope="row">
+									{{ t('openregister', 'Objects') }}
+								</th>
 								<td>{{ systemTotals.stats?.objects?.total || 0 }}</td>
 								<td>{{ formatBytes(systemTotals.stats?.objects?.size || 0) }}</td>
 							</tr>
 							<tr class="subRow">
-								<td class="indented">
+								<th scope="row" class="indented">
 									{{ t('openregister', 'Invalid') }}
-								</td>
+								</th>
 								<td>{{ systemTotals.stats?.objects?.invalid || 0 }}</td>
 								<td>-</td>
 							</tr>
 							<tr class="subRow">
-								<td class="indented">
+								<th scope="row" class="indented">
 									{{ t('openregister', 'Deleted') }}
-								</td>
+								</th>
 								<td>{{ systemTotals.stats?.objects?.deleted || 0 }}</td>
 								<td>-</td>
 							</tr>
 							<tr class="subRow">
-								<td class="indented">
+								<th scope="row" class="indented">
 									{{ t('openregister', 'Locked') }}
-								</td>
+								</th>
 								<td>{{ systemTotals.stats?.objects?.locked || 0 }}</td>
 								<td>-</td>
 							</tr>
 							<tr>
-								<td>{{ t('openregister', 'Logs') }}</td>
+								<th scope="row">
+									{{ t('openregister', 'Logs') }}
+								</th>
 								<td>{{ systemTotals.stats?.logs?.total || 0 }}</td>
 								<td>{{ formatBytes(systemTotals.stats?.logs?.size || 0) }}</td>
 							</tr>
 							<tr>
-								<td>{{ t('openregister', 'Files') }}</td>
+								<th scope="row">
+									{{ t('openregister', 'Files') }}
+								</th>
 								<td>{{ systemTotals.stats?.files?.total || 0 }}</td>
 								<td>{{ formatBytes(systemTotals.stats?.files?.size || 0) }}</td>
 							</tr>
@@ -118,40 +141,59 @@ import { objectStore, registerStore, schemaStore, dashboardStore } from '../../s
 				</div>
 				<div v-else-if="orphanedItems" class="statsContainer">
 					<table class="statisticsTable">
+						<thead>
+							<tr>
+								<th scope="col">
+									{{ t('openregister', 'Item') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Count') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Size') }}
+								</th>
+							</tr>
+						</thead>
 						<tbody>
 							<tr>
-								<td>{{ t('openregister', 'Objects') }}</td>
+								<th scope="row">
+									{{ t('openregister', 'Objects') }}
+								</th>
 								<td>{{ orphanedItems.stats?.objects?.total || 0 }}</td>
 								<td>{{ formatBytes(orphanedItems.stats?.objects?.size || 0) }}</td>
 							</tr>
 							<tr class="subRow">
-								<td class="indented">
+								<th scope="row" class="indented">
 									{{ t('openregister', 'Invalid') }}
-								</td>
+								</th>
 								<td>{{ orphanedItems.stats?.objects?.invalid || 0 }}</td>
 								<td>-</td>
 							</tr>
 							<tr class="subRow">
-								<td class="indented">
+								<th scope="row" class="indented">
 									{{ t('openregister', 'Deleted') }}
-								</td>
+								</th>
 								<td>{{ orphanedItems.stats?.objects?.deleted || 0 }}</td>
 								<td>-</td>
 							</tr>
 							<tr class="subRow">
-								<td class="indented">
+								<th scope="row" class="indented">
 									{{ t('openregister', 'Locked') }}
-								</td>
+								</th>
 								<td>{{ orphanedItems.stats?.objects?.locked || 0 }}</td>
 								<td>-</td>
 							</tr>
 							<tr>
-								<td>{{ t('openregister', 'Logs') }}</td>
+								<th scope="row">
+									{{ t('openregister', 'Logs') }}
+								</th>
 								<td>{{ orphanedItems.stats?.logs?.total || 0 }}</td>
 								<td>{{ formatBytes(orphanedItems.stats?.logs?.size || 0) }}</td>
 							</tr>
 							<tr>
-								<td>{{ t('openregister', 'Files') }}</td>
+								<th scope="row">
+									{{ t('openregister', 'Files') }}
+								</th>
 								<td>{{ orphanedItems.stats?.files?.total || 0 }}</td>
 								<td>{{ formatBytes(orphanedItems.stats?.files?.size || 0) }}</td>
 							</tr>
@@ -470,9 +512,11 @@ export default {
 	border-collapse: collapse;
 	font-size: 0.9em;
 
-	td {
+	td,
+	th {
 		padding: 4px 8px;
 		border-bottom: 1px solid var(--color-border);
+		text-align: left;
 
 		&:nth-child(2),
 		&:nth-child(3) {
@@ -480,7 +524,13 @@ export default {
 		}
 	}
 
-	.subRow td {
+	/* Row headers are labels, not emphasis — keep the original visual weight. */
+	tbody th {
+		font-weight: normal;
+	}
+
+	.subRow td,
+	.subRow th {
 		color: var(--color-text-maxcontrast);
 	}
 
@@ -488,7 +538,8 @@ export default {
 		padding-left: 24px;
 	}
 
-	tr:last-child td {
+	tr:last-child td,
+	tr:last-child th {
 		border-bottom: none;
 	}
 }

--- a/src/sidebars/logs/AuditTrailSideBar.vue
+++ b/src/sidebars/logs/AuditTrailSideBar.vue
@@ -945,4 +945,10 @@ export default {
 :deep(.v-select) {
 	margin-bottom: 8px;
 }
+
+@media (prefers-reduced-motion: reduce) {
+	.actionProgressBar {
+		transition: none;
+	}
+}
 </style>

--- a/src/sidebars/logs/SearchTrailSideBar.vue
+++ b/src/sidebars/logs/SearchTrailSideBar.vue
@@ -1311,4 +1311,10 @@ export default {
 :deep(.v-select) {
 	margin-bottom: 8px;
 }
+
+@media (prefers-reduced-motion: reduce) {
+	.complexityProgressBar {
+		transition: none;
+	}
+}
 </style>

--- a/src/sidebars/search/SearchSideBar.vue
+++ b/src/sidebars/search/SearchSideBar.vue
@@ -2445,4 +2445,13 @@ export default {
 	flex-direction: column;
 	gap: 8px;
 }
+
+@media (prefers-reduced-motion: reduce) {
+	.viewRow,
+	.chip-remove,
+	.editViewTab,
+	.columnGroupHeader {
+		transition: none;
+	}
+}
 </style>

--- a/src/views/avg/AvgIndex.vue
+++ b/src/views/avg/AvgIndex.vue
@@ -65,12 +65,24 @@
 					<table v-else class="avgTable">
 						<thead>
 							<tr>
-								<th>{{ t('openregister', 'Naam') }}</th>
-								<th>{{ t('openregister', 'Code') }}</th>
-								<th>{{ t('openregister', 'Rechtsgrond') }}</th>
-								<th>{{ t('openregister', 'Bewaartermijn') }}</th>
-								<th>{{ t('openregister', 'Status') }}</th>
-								<th>{{ t('openregister', 'Actions') }}</th>
+								<th scope="col">
+									{{ t('openregister', 'Naam') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Code') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Rechtsgrond') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Bewaartermijn') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Status') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Actions') }}
+								</th>
 							</tr>
 						</thead>
 						<tbody>
@@ -138,14 +150,30 @@
 					<table v-else class="avgTable">
 						<thead>
 							<tr>
-								<th>{{ t('openregister', 'Activity') }}</th>
-								<th>{{ t('openregister', 'Rechtsgrond') }}</th>
-								<th>{{ t('openregister', 'Bewaartermijn') }}</th>
-								<th>{{ t('openregister', 'Total events') }}</th>
-								<th>{{ t('openregister', 'Create') }}</th>
-								<th>{{ t('openregister', 'Update') }}</th>
-								<th>{{ t('openregister', 'Delete') }}</th>
-								<th>{{ t('openregister', 'Read') }}</th>
+								<th scope="col">
+									{{ t('openregister', 'Activity') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Rechtsgrond') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Bewaartermijn') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Total events') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Create') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Update') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Delete') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Read') }}
+								</th>
 							</tr>
 						</thead>
 						<tbody>
@@ -293,11 +321,21 @@
 					<table v-else class="avgTable">
 						<thead>
 							<tr>
-								<th>{{ t('openregister', 'Schema') }}</th>
-								<th>{{ t('openregister', 'Register') }}</th>
-								<th>{{ t('openregister', 'PII rows') }}</th>
-								<th>{{ t('openregister', 'Schema annotation') }}</th>
-								<th>{{ t('openregister', 'Register annotation') }}</th>
+								<th scope="col">
+									{{ t('openregister', 'Schema') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Register') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'PII rows') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Schema annotation') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Register annotation') }}
+								</th>
 							</tr>
 						</thead>
 						<tbody>
@@ -381,13 +419,27 @@
 						<table v-else class="avgTable">
 							<thead>
 								<tr>
-									<th>{{ t('openregister', 'Subject') }}</th>
-									<th>{{ t('openregister', 'Type') }}</th>
-									<th>{{ t('openregister', 'Status') }}</th>
-									<th>{{ t('openregister', 'Handler') }}</th>
-									<th>{{ t('openregister', 'Deadline') }}</th>
-									<th>{{ t('openregister', 'Escalation') }}</th>
-									<th>{{ t('openregister', 'Actions') }}</th>
+									<th scope="col">
+										{{ t('openregister', 'Subject') }}
+									</th>
+									<th scope="col">
+										{{ t('openregister', 'Type') }}
+									</th>
+									<th scope="col">
+										{{ t('openregister', 'Status') }}
+									</th>
+									<th scope="col">
+										{{ t('openregister', 'Handler') }}
+									</th>
+									<th scope="col">
+										{{ t('openregister', 'Deadline') }}
+									</th>
+									<th scope="col">
+										{{ t('openregister', 'Escalation') }}
+									</th>
+									<th scope="col">
+										{{ t('openregister', 'Actions') }}
+									</th>
 								</tr>
 							</thead>
 							<tbody>
@@ -559,8 +611,12 @@
 							<table v-else class="avgTable">
 								<thead>
 									<tr>
-										<th>{{ t('openregister', 'Source') }}</th>
-										<th>{{ t('openregister', 'Status') }}</th>
+										<th scope="col">
+											{{ t('openregister', 'Source') }}
+										</th>
+										<th scope="col">
+											{{ t('openregister', 'Status') }}
+										</th>
 									</tr>
 								</thead>
 								<tbody>
@@ -589,8 +645,12 @@
 							<table v-else class="avgTable">
 								<thead>
 									<tr>
-										<th>{{ t('openregister', 'Field') }}</th>
-										<th>{{ t('openregister', 'Ground') }}</th>
+										<th scope="col">
+											{{ t('openregister', 'Field') }}
+										</th>
+										<th scope="col">
+											{{ t('openregister', 'Ground') }}
+										</th>
 									</tr>
 								</thead>
 								<tbody>

--- a/src/views/configuration/ConfigurationsIndex.vue
+++ b/src/views/configuration/ConfigurationsIndex.vue
@@ -118,13 +118,25 @@ import { configurationStore, navigationStore } from '../../store/store.js'
 											:indeterminate="someSelected"
 											@update:modelValue="toggleSelectAll" />
 									</th>
-									<th>{{ t('openregister', 'Title') }}</th>
-									<th>{{ t('openregister', 'Source') }}</th>
-									<th>{{ t('openregister', 'Local Version') }}</th>
-									<th>{{ t('openregister', 'Remote Version') }}</th>
-									<th>{{ t('openregister', 'Status') }}</th>
-									<th>{{ t('openregister', 'Updated') }}</th>
-									<th class="tableColumnActions">
+									<th scope="col">
+										{{ t('openregister', 'Title') }}
+									</th>
+									<th scope="col">
+										{{ t('openregister', 'Source') }}
+									</th>
+									<th scope="col">
+										{{ t('openregister', 'Local Version') }}
+									</th>
+									<th scope="col">
+										{{ t('openregister', 'Remote Version') }}
+									</th>
+									<th scope="col">
+										{{ t('openregister', 'Status') }}
+									</th>
+									<th scope="col">
+										{{ t('openregister', 'Updated') }}
+									</th>
+									<th scope="col" class="tableColumnActions">
 										{{ t('openregister', 'Actions') }}
 									</th>
 								</tr>

--- a/src/views/deleted/DeletedIndex.vue
+++ b/src/views/deleted/DeletedIndex.vue
@@ -92,17 +92,25 @@ import formatBytes from '../../services/formatBytes.js'
 									:indeterminate="someSelected"
 									@update:modelValue="toggleSelectAll" />
 							</th>
-							<th>{{ t('openregister', 'Title') }}</th>
-							<th class="tableColumnConstrained">
+							<th scope="col">
+								{{ t('openregister', 'Title') }}
+							</th>
+							<th scope="col" class="tableColumnConstrained">
 								{{ t('openregister', 'Register') }}
 							</th>
-							<th class="tableColumnConstrained">
+							<th scope="col" class="tableColumnConstrained">
 								{{ t('openregister', 'Schema') }}
 							</th>
-							<th>{{ t('openregister', 'Deleted Date') }}</th>
-							<th>{{ t('openregister', 'Deleted By') }}</th>
-							<th>{{ t('openregister', 'Purge Date') }}</th>
-							<th class="tableColumnActions">
+							<th scope="col">
+								{{ t('openregister', 'Deleted Date') }}
+							</th>
+							<th scope="col">
+								{{ t('openregister', 'Deleted By') }}
+							</th>
+							<th scope="col">
+								{{ t('openregister', 'Purge Date') }}
+							</th>
+							<th scope="col" class="tableColumnActions">
 								{{ t('openregister', 'Actions') }}
 							</th>
 						</tr>

--- a/src/views/entities/EntitiesIndex.vue
+++ b/src/views/entities/EntitiesIndex.vue
@@ -95,15 +95,20 @@
 					<div class="cardGrid">
 						<div v-for="entity in paginatedEntities"
 							:key="entity.id"
-							class="card"
-							@click="viewEntity(entity)">
+							class="card">
 							<div class="cardHeader">
 								<h2>
 									<AccountOutline :size="20" />
-									{{ entity.value }}
+									<!-- The activator is a real <button>; its ::after overlay makes the
+										whole card clickable with the mouse without turning the card into
+										a role="button" (which would hide the heading, the stats table and
+										the actions menu from assistive technology). -->
+									<button type="button" class="cardActivator" @click="viewEntity(entity)">
+										{{ entity.value }}
+									</button>
 									<span class="badge badge-type">{{ entity.type }}</span>
 								</h2>
-								<NcActions :primary="true" menu-name="Actions">
+								<NcActions class="cardActions" :primary="true" menu-name="Actions">
 									<template #icon>
 										<DotsHorizontal :size="20" />
 									</template>
@@ -122,15 +127,21 @@
 							<table class="statisticsTable entityStats">
 								<tbody>
 									<tr>
-										<td><strong>{{ t('openregister', 'Category') }}</strong></td>
+										<th scope="row">
+											<strong>{{ t('openregister', 'Category') }}</strong>
+										</th>
 										<td><span class="badge badge-category">{{ entity.category }}</span></td>
 									</tr>
 									<tr>
-										<td><strong>{{ t('openregister', 'Detected At') }}</strong></td>
+										<th scope="row">
+											<strong>{{ t('openregister', 'Detected At') }}</strong>
+										</th>
 										<td>{{ formatDate(entity.detectedAt) }}</td>
 									</tr>
 									<tr>
-										<td><strong>{{ t('openregister', 'Relations') }}</strong></td>
+										<th scope="row">
+											<strong>{{ t('openregister', 'Relations') }}</strong>
+										</th>
 										<td>{{ entity.relationCount || 0 }}</td>
 									</tr>
 								</tbody>
@@ -152,12 +163,22 @@
 											:aria-label="t('openregister', 'Select all entities')"
 											@update:modelValue="toggleSelectAll" />
 									</th>
-									<th>{{ t('openregister', 'Value') }}</th>
-									<th>{{ t('openregister', 'Type') }}</th>
-									<th>{{ t('openregister', 'Category') }}</th>
-									<th>{{ t('openregister', 'Detected At') }}</th>
-									<th>{{ t('openregister', 'Relations') }}</th>
-									<th class="tableColumnActions">
+									<th scope="col">
+										{{ t('openregister', 'Value') }}
+									</th>
+									<th scope="col">
+										{{ t('openregister', 'Type') }}
+									</th>
+									<th scope="col">
+										{{ t('openregister', 'Category') }}
+									</th>
+									<th scope="col">
+										{{ t('openregister', 'Detected At') }}
+									</th>
+									<th scope="col">
+										{{ t('openregister', 'Relations') }}
+									</th>
+									<th scope="col" class="tableColumnActions">
 										{{ t('openregister', 'Actions') }}
 									</th>
 								</tr>
@@ -614,6 +635,7 @@ export default {
 }
 
 .card {
+	position: relative;
 	background: var(--color-main-background);
 	border: 1px solid var(--color-border);
 	border-radius: var(--border-radius-large);
@@ -624,6 +646,38 @@ export default {
 
 .card:hover {
 	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+/* Real button that carries the card's action. The ::after overlay restores
+   whole-card mouse clickability while keyboard users get a genuine button. */
+.cardActivator {
+	appearance: none;
+	background: none;
+	border: none;
+	padding: 0;
+	margin: 0;
+	font: inherit;
+	color: inherit;
+	text-align: left;
+	cursor: pointer;
+}
+
+.cardActivator::after {
+	content: '';
+	position: absolute;
+	inset: 0;
+}
+
+.cardActivator:focus-visible::after {
+	outline: 2px solid var(--color-primary-element);
+	outline-offset: -2px;
+	border-radius: var(--border-radius-large);
+}
+
+/* Keep the actions menu above the activator overlay so it stays clickable. */
+.cardActions {
+	position: relative;
+	z-index: 1;
 }
 
 .cardHeader {
@@ -658,11 +712,15 @@ export default {
 	border-bottom: none;
 }
 
-.entityStats td {
+.entityStats td,
+.entityStats th {
 	padding: 12px 16px;
+	text-align: left;
+	font-weight: normal;
 }
 
-.entityStats td:first-child {
+.entityStats td:first-child,
+.entityStats th:first-child {
 	width: 40%;
 	color: var(--color-text-maxcontrast);
 }
@@ -717,5 +775,11 @@ export default {
 
 .tableColumnActions {
 	width: 50px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.card {
+		transition: none;
+	}
 }
 </style>

--- a/src/views/entities/EntityDetail.vue
+++ b/src/views/entities/EntityDetail.vue
@@ -76,27 +76,39 @@
 					<table class="statisticsTable entityInfoTable">
 						<tbody>
 							<tr>
-								<td><strong>{{ t('openregister', 'Value') }}</strong></td>
+								<th scope="row">
+									<strong>{{ t('openregister', 'Value') }}</strong>
+								</th>
 								<td>{{ entity.value }}</td>
 							</tr>
 							<tr>
-								<td><strong>{{ t('openregister', 'Type') }}</strong></td>
+								<th scope="row">
+									<strong>{{ t('openregister', 'Type') }}</strong>
+								</th>
 								<td><span class="badge badge-type">{{ entity.type }}</span></td>
 							</tr>
 							<tr>
-								<td><strong>{{ t('openregister', 'Category') }}</strong></td>
+								<th scope="row">
+									<strong>{{ t('openregister', 'Category') }}</strong>
+								</th>
 								<td><span class="badge badge-category">{{ entity.category }}</span></td>
 							</tr>
 							<tr>
-								<td><strong>{{ t('openregister', 'Detected At') }}</strong></td>
+								<th scope="row">
+									<strong>{{ t('openregister', 'Detected At') }}</strong>
+								</th>
 								<td>{{ formatDate(entity.detectedAt) }}</td>
 							</tr>
 							<tr>
-								<td><strong>{{ t('openregister', 'Confidence Score') }}</strong></td>
+								<th scope="row">
+									<strong>{{ t('openregister', 'Confidence Score') }}</strong>
+								</th>
 								<td>{{ entity.confidence ? (entity.confidence * 100).toFixed(2) + '%' : '-' }}</td>
 							</tr>
 							<tr v-if="entity.source">
-								<td><strong>{{ t('openregister', 'Source') }}</strong></td>
+								<th scope="row">
+									<strong>{{ t('openregister', 'Source') }}</strong>
+								</th>
 								<td>{{ entity.source }}</td>
 							</tr>
 						</tbody>
@@ -470,11 +482,15 @@ export default {
 	border-bottom: none;
 }
 
-.entityInfoTable td {
+.entityInfoTable td,
+.entityInfoTable th {
 	padding: 12px 16px;
+	text-align: left;
+	font-weight: normal;
 }
 
-.entityInfoTable td:first-child {
+.entityInfoTable td:first-child,
+.entityInfoTable th:first-child {
 	width: 30%;
 	color: var(--color-text-maxcontrast);
 }

--- a/src/views/files/FilesIndex.vue
+++ b/src/views/files/FilesIndex.vue
@@ -65,34 +65,34 @@
 				<table v-else class="filesTable">
 					<thead>
 						<tr>
-							<th class="column-filename sortable" @click="toggleSort('fileName')">
+							<th scope="col" class="column-filename sortable" @click="toggleSort('fileName')">
 								{{ t('openregister', 'File Name') }}
 								<span v-if="sortField === 'fileName'" class="sort-indicator">{{ sortOrder === 'ASC' ? '▲' : '▼' }}</span>
 							</th>
-							<th class="column-mimetype">
+							<th scope="col" class="column-mimetype">
 								{{ t('openregister', 'Type') }}
 							</th>
-							<th class="column-size sortable" @click="toggleSort('fileSize')">
+							<th scope="col" class="column-size sortable" @click="toggleSort('fileSize')">
 								{{ t('openregister', 'Size') }}
 								<span v-if="sortField === 'fileSize'" class="sort-indicator">{{ sortOrder === 'ASC' ? '▲' : '▼' }}</span>
 							</th>
-							<th class="column-chunks sortable" @click="toggleSort('chunkCount')">
+							<th scope="col" class="column-chunks sortable" @click="toggleSort('chunkCount')">
 								{{ t('openregister', 'Chunks') }}
 								<span v-if="sortField === 'chunkCount'" class="sort-indicator">{{ sortOrder === 'ASC' ? '▲' : '▼' }}</span>
 							</th>
-							<th class="column-entities sortable" @click="toggleSort('entityCount')">
+							<th scope="col" class="column-entities sortable" @click="toggleSort('entityCount')">
 								{{ t('openregister', 'Entities') }}
 								<span v-if="sortField === 'entityCount'" class="sort-indicator">{{ sortOrder === 'ASC' ? '▲' : '▼' }}</span>
 							</th>
-							<th class="column-risk sortable" @click="toggleSort('riskLevel')">
+							<th scope="col" class="column-risk sortable" @click="toggleSort('riskLevel')">
 								{{ t('openregister', 'Risk Level') }}
 								<span v-if="sortField === 'riskLevel'" class="sort-indicator">{{ sortOrder === 'ASC' ? '▲' : '▼' }}</span>
 							</th>
-							<th class="column-extracted sortable" @click="toggleSort('extractedAt')">
+							<th scope="col" class="column-extracted sortable" @click="toggleSort('extractedAt')">
 								{{ t('openregister', 'Extracted At') }}
 								<span v-if="sortField === 'extractedAt'" class="sort-indicator">{{ sortOrder === 'ASC' ? '▲' : '▼' }}</span>
 							</th>
-							<th class="column-actions">
+							<th scope="col" class="column-actions">
 								{{ t('openregister', 'Actions') }}
 							</th>
 						</tr>

--- a/src/views/logs/AuditTrailIndex.vue
+++ b/src/views/logs/AuditTrailIndex.vue
@@ -693,4 +693,10 @@ export default {
 	50% { transform: scale(1.2); }
 	100% { transform: scale(1); }
 }
+
+@media (prefers-reduced-motion: reduce) {
+	:deep(.copySuccessIcon) {
+		animation: none;
+	}
+}
 </style>

--- a/src/views/logs/SearchTrailIndex.vue
+++ b/src/views/logs/SearchTrailIndex.vue
@@ -87,28 +87,28 @@ import formatBytes from '../../services/formatBytes.js'
 									:indeterminate="someSelected"
 									@update:modelValue="toggleSelectAll" />
 							</th>
-							<th class="searchTermColumn">
+							<th scope="col" class="searchTermColumn">
 								{{ t('openregister', 'Search Term') }}
 							</th>
-							<th class="timestampColumn">
+							<th scope="col" class="timestampColumn">
 								{{ t('openregister', 'Timestamp') }}
 							</th>
-							<th class="tableColumnConstrained">
+							<th scope="col" class="tableColumnConstrained">
 								{{ t('openregister', 'Register') }}
 							</th>
-							<th class="tableColumnConstrained">
+							<th scope="col" class="tableColumnConstrained">
 								{{ t('openregister', 'Schema') }}
 							</th>
-							<th class="tableColumnConstrained">
+							<th scope="col" class="tableColumnConstrained">
 								{{ t('openregister', 'User') }}
 							</th>
-							<th class="tableColumnConstrained">
+							<th scope="col" class="tableColumnConstrained">
 								{{ t('openregister', 'Results') }}
 							</th>
-							<th class="tableColumnConstrained">
+							<th scope="col" class="tableColumnConstrained">
 								{{ t('openregister', 'Execution Time') }}
 							</th>
-							<th class="tableColumnActions">
+							<th scope="col" class="tableColumnActions">
 								{{ t('openregister', 'Actions') }}
 							</th>
 						</tr>
@@ -715,5 +715,11 @@ export default {
 	0% { transform: scale(1); }
 	50% { transform: scale(1.2); }
 	100% { transform: scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+	:deep(.copySuccessIcon) {
+		animation: none;
+	}
 }
 </style>

--- a/src/views/organisation/OrganisationDetails.vue
+++ b/src/views/organisation/OrganisationDetails.vue
@@ -94,7 +94,7 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 							<strong>{{ t('openregister', 'UUID:') }}</strong>
 							<span class="uuid">{{ organisationStore.organisationItem.uuid }}</span>
 							<NcButton class="copy-button"
-								:aria-label="t('openregister', 'Copy UUID to clipboard')"
+								:aria-label="t('openregister', 'Copy to clipboard')"
 								@click="copyToClipboard(organisationStore.organisationItem.uuid)">
 								<template #icon>
 									<ContentCopy :size="16" />

--- a/src/views/organisation/OrganisationDetails.vue
+++ b/src/views/organisation/OrganisationDetails.vue
@@ -93,7 +93,9 @@ import { organisationStore, navigationStore } from '../../store/store.js'
 						<div class="metaRow">
 							<strong>{{ t('openregister', 'UUID:') }}</strong>
 							<span class="uuid">{{ organisationStore.organisationItem.uuid }}</span>
-							<NcButton class="copy-button" @click="copyToClipboard(organisationStore.organisationItem.uuid)">
+							<NcButton class="copy-button"
+								:aria-label="t('openregister', 'Copy UUID to clipboard')"
+								@click="copyToClipboard(organisationStore.organisationItem.uuid)">
 								<template #icon>
 									<ContentCopy :size="16" />
 								</template>

--- a/src/views/quality/DuplicatesIndex.vue
+++ b/src/views/quality/DuplicatesIndex.vue
@@ -35,11 +35,21 @@
 				<table class="duplicatesTable">
 					<thead>
 						<tr>
-							<th>{{ t('openregister', 'Object A') }}</th>
-							<th>{{ t('openregister', 'Object B') }}</th>
-							<th>{{ t('openregister', 'Score') }}</th>
-							<th>{{ t('openregister', 'Matched on') }}</th>
-							<th>{{ t('openregister', 'Actions') }}</th>
+							<th scope="col">
+								{{ t('openregister', 'Object A') }}
+							</th>
+							<th scope="col">
+								{{ t('openregister', 'Object B') }}
+							</th>
+							<th scope="col">
+								{{ t('openregister', 'Score') }}
+							</th>
+							<th scope="col">
+								{{ t('openregister', 'Matched on') }}
+							</th>
+							<th scope="col">
+								{{ t('openregister', 'Actions') }}
+							</th>
 						</tr>
 					</thead>
 					<tbody>

--- a/src/views/quality/GoldenRecordDetail.vue
+++ b/src/views/quality/GoldenRecordDetail.vue
@@ -41,10 +41,18 @@
 			<table v-else class="provenanceTable" data-testid="provenance-table">
 				<thead>
 					<tr>
-						<th>{{ t('openregister', 'Attribute') }}</th>
-						<th>{{ t('openregister', 'Winning source') }}</th>
-						<th>{{ t('openregister', 'Confidence') }}</th>
-						<th>{{ t('openregister', 'Timestamp') }}</th>
+						<th scope="col">
+							{{ t('openregister', 'Attribute') }}
+						</th>
+						<th scope="col">
+							{{ t('openregister', 'Winning source') }}
+						</th>
+						<th scope="col">
+							{{ t('openregister', 'Confidence') }}
+						</th>
+						<th scope="col">
+							{{ t('openregister', 'Timestamp') }}
+						</th>
 					</tr>
 				</thead>
 				<tbody>

--- a/src/views/quality/MasterEntitiesIndex.vue
+++ b/src/views/quality/MasterEntitiesIndex.vue
@@ -46,10 +46,18 @@
 				<table v-else class="masterEntitiesTable">
 					<thead>
 						<tr>
-							<th>{{ t('openregister', 'Id') }}</th>
-							<th>{{ t('openregister', 'Quality score') }}</th>
-							<th>{{ t('openregister', 'Quality status') }}</th>
-							<th>{{ t('openregister', 'Actions') }}</th>
+							<th scope="col">
+								{{ t('openregister', 'Id') }}
+							</th>
+							<th scope="col">
+								{{ t('openregister', 'Quality score') }}
+							</th>
+							<th scope="col">
+								{{ t('openregister', 'Quality status') }}
+							</th>
+							<th scope="col">
+								{{ t('openregister', 'Actions') }}
+							</th>
 						</tr>
 					</thead>
 					<tbody>

--- a/src/views/quality/MergeOperationsIndex.vue
+++ b/src/views/quality/MergeOperationsIndex.vue
@@ -28,12 +28,24 @@
 				<table class="mergeOperationsTable">
 					<thead>
 						<tr>
-							<th>{{ t('openregister', 'Survivor') }}</th>
-							<th>{{ t('openregister', 'Merged from') }}</th>
-							<th>{{ t('openregister', 'Reason') }}</th>
-							<th>{{ t('openregister', 'Merged at') }}</th>
-							<th>{{ t('openregister', 'Status') }}</th>
-							<th>{{ t('openregister', 'Actions') }}</th>
+							<th scope="col">
+								{{ t('openregister', 'Survivor') }}
+							</th>
+							<th scope="col">
+								{{ t('openregister', 'Merged from') }}
+							</th>
+							<th scope="col">
+								{{ t('openregister', 'Reason') }}
+							</th>
+							<th scope="col">
+								{{ t('openregister', 'Merged at') }}
+							</th>
+							<th scope="col">
+								{{ t('openregister', 'Status') }}
+							</th>
+							<th scope="col">
+								{{ t('openregister', 'Actions') }}
+							</th>
 						</tr>
 					</thead>
 					<tbody>

--- a/src/views/quality/QualityIndex.vue
+++ b/src/views/quality/QualityIndex.vue
@@ -64,8 +64,12 @@
 					<table v-else class="histogramTable" data-testid="histogram-fallback-table">
 						<thead>
 							<tr>
-								<th>{{ t('openregister', 'Bucket') }}</th>
-								<th>{{ t('openregister', 'Count') }}</th>
+								<th scope="col">
+									{{ t('openregister', 'Bucket') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Count') }}
+								</th>
 							</tr>
 						</thead>
 						<tbody>
@@ -90,9 +94,15 @@
 					<table v-else class="lowestQualityTable">
 						<thead>
 							<tr>
-								<th>{{ t('openregister', 'Id') }}</th>
-								<th>{{ t('openregister', 'Quality score') }}</th>
-								<th>{{ t('openregister', 'Quality status') }}</th>
+								<th scope="col">
+									{{ t('openregister', 'Id') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Quality score') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Quality status') }}
+								</th>
 							</tr>
 						</thead>
 						<tbody>

--- a/src/views/quality/QueueHealthIndex.vue
+++ b/src/views/quality/QueueHealthIndex.vue
@@ -26,10 +26,18 @@
 					<table class="webhookHealthTable">
 						<thead>
 							<tr>
-								<th>{{ t('openregister', 'Webhook') }}</th>
-								<th>{{ t('openregister', 'Delivered') }}</th>
-								<th>{{ t('openregister', 'Failed') }}</th>
-								<th>{{ t('openregister', 'Pending retries') }}</th>
+								<th scope="col">
+									{{ t('openregister', 'Webhook') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Delivered') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Failed') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Pending retries') }}
+								</th>
 							</tr>
 						</thead>
 						<tbody>
@@ -55,11 +63,21 @@
 					<table v-else class="recentFailuresTable">
 						<thead>
 							<tr>
-								<th>{{ t('openregister', 'Webhook') }}</th>
-								<th>{{ t('openregister', 'Event') }}</th>
-								<th>{{ t('openregister', 'Status code') }}</th>
-								<th>{{ t('openregister', 'Error') }}</th>
-								<th>{{ t('openregister', 'Created') }}</th>
+								<th scope="col">
+									{{ t('openregister', 'Webhook') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Event') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Status code') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Error') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Created') }}
+								</th>
 							</tr>
 						</thead>
 						<tbody>

--- a/src/views/reports/ReportView.vue
+++ b/src/views/reports/ReportView.vue
@@ -12,7 +12,10 @@
 					<h1 class="viewHeaderTitleIndented">
 						{{ dashboard?.titel || t('openregister', 'Dashboard') }}
 					</h1>
-					<NcButton variant="tertiary" :disabled="loading" @click="refresh">
+					<NcButton variant="tertiary"
+						:disabled="loading"
+						:aria-label="t('openregister', 'Refresh dashboard')"
+						@click="refresh">
 						<template #icon>
 							<NcLoadingIcon v-if="loading" :size="20" />
 							<Refresh v-else :size="20" />

--- a/src/views/reports/ReportsIndex.vue
+++ b/src/views/reports/ReportsIndex.vue
@@ -42,12 +42,18 @@
 				<article
 					v-for="dashboard in dashboards"
 					:key="dashboard.id || dashboard.uuid"
-					class="reportCard"
-					@click="openDashboard(dashboard)">
+					class="reportCard">
 					<div class="reportCardHeader">
 						<ChartBoxOutline :size="32" class="reportCardIcon" />
 						<div>
-							<h3>{{ dashboard.titel || dashboard['@self']?.name || t('openregister', 'Untitled') }}</h3>
+							<!-- The activator is a real <button>; its ::after overlay keeps the whole
+								card mouse-clickable without turning the <article> into a role="button",
+								which would hide the heading and the widget-count footer from AT. -->
+							<h3>
+								<button type="button" class="reportCardActivator" @click="openDashboard(dashboard)">
+									{{ dashboard.titel || dashboard['@self']?.name || t('openregister', 'Untitled') }}
+								</button>
+							</h3>
 							<span class="badge">{{ dashboard.category || 'operational' }}</span>
 						</div>
 					</div>
@@ -181,12 +187,36 @@ export default {
 	gap: 16px;
 }
 .reportCard {
+	position: relative;
 	background: var(--color-main-background);
 	border: 1px solid var(--color-border);
 	border-radius: var(--border-radius-large);
 	padding: 16px;
 	cursor: pointer;
 	transition: box-shadow 0.15s ease, border-color 0.15s ease;
+}
+/* Real button carrying the card's action; the ::after overlay restores
+   whole-card mouse clickability while keyboard users get a genuine button. */
+.reportCardActivator {
+	appearance: none;
+	background: none;
+	border: none;
+	padding: 0;
+	margin: 0;
+	font: inherit;
+	color: inherit;
+	text-align: left;
+	cursor: pointer;
+}
+.reportCardActivator::after {
+	content: '';
+	position: absolute;
+	inset: 0;
+	border-radius: var(--border-radius-large);
+}
+.reportCardActivator:focus-visible::after {
+	outline: 2px solid var(--color-primary-element);
+	outline-offset: -2px;
 }
 .reportCard:hover {
 	border-color: var(--color-primary);
@@ -233,5 +263,11 @@ export default {
 .badge-status-published {
 	background: var(--color-success);
 	color: var(--color-primary-text);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.reportCard {
+		transition: none;
+	}
 }
 </style>

--- a/src/views/schema/SchemaDetails.vue
+++ b/src/views/schema/SchemaDetails.vue
@@ -107,9 +107,15 @@ import formatBytes from '../../services/formatBytes.js'
 					<table class="statisticsTable schemaStats">
 						<thead>
 							<tr>
-								<th>{{ t('openregister', 'Type') }}</th>
-								<th>{{ t('openregister', 'Total') }}</th>
-								<th>{{ t('openregister', 'Size') }}</th>
+								<th scope="col">
+									{{ t('openregister', 'Type') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Total') }}
+								</th>
+								<th scope="col">
+									{{ t('openregister', 'Size') }}
+								</th>
 							</tr>
 						</thead>
 						<tbody>
@@ -439,6 +445,12 @@ export default {
 			color: var(--color-primary);
 			border-bottom-color: var(--color-primary);
 		}
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.schemaTabNav .tabButton {
+		transition: none;
 	}
 }
 </style>

--- a/src/views/settings/sections/CacheManagement.vue
+++ b/src/views/settings/sections/CacheManagement.vue
@@ -176,16 +176,16 @@
 						<table class="performance-table">
 							<thead>
 								<tr>
-									<th class="performance-table-header">
+									<th scope="col" class="performance-table-header">
 										Metric
 									</th>
-									<th class="performance-table-header">
+									<th scope="col" class="performance-table-header">
 										Current
 									</th>
-									<th class="performance-table-header">
+									<th scope="col" class="performance-table-header">
 										Target
 									</th>
-									<th class="performance-table-header">
+									<th scope="col" class="performance-table-header">
 										Status
 									</th>
 								</tr>

--- a/src/views/settings/sections/FileConfiguration.vue
+++ b/src/views/settings/sections/FileConfiguration.vue
@@ -2021,4 +2021,10 @@ export default {
 	color: var(--color-primary-element);
 	text-decoration: underline;
 }
+
+@media (prefers-reduced-motion: reduce) {
+	.stat-card {
+		transition: none;
+	}
+}
 </style>

--- a/src/views/settings/sections/LlmConfiguration.vue
+++ b/src/views/settings/sections/LlmConfiguration.vue
@@ -1262,4 +1262,12 @@ export default {
 		grid-template-columns: repeat(2, 1fr);
 	}
 }
+
+@media (prefers-reduced-motion: reduce) {
+	.stat-card,
+	.collapsible-section summary,
+	.stat-tile {
+		transition: none;
+	}
+}
 </style>

--- a/src/views/settings/sections/LogIntegrity.vue
+++ b/src/views/settings/sections/LogIntegrity.vue
@@ -389,4 +389,10 @@ export default {
 	padding: 4px 8px;
 	word-break: break-all;
 }
+
+@media (prefers-reduced-motion: reduce) {
+	.integrity__bar-fill {
+		transition: none;
+	}
+}
 </style>

--- a/src/views/settings/sections/PermissionMatrix.vue
+++ b/src/views/settings/sections/PermissionMatrix.vue
@@ -34,13 +34,16 @@ import { translate as t } from '@nextcloud/l10n'
 				<table class="matrix-table">
 					<thead>
 						<tr>
-							<th class="name-column">
+							<th scope="col" class="name-column">
 								{{ t('openregister', 'Register / Schema') }}
 							</th>
-							<th v-for="action in actions" :key="action" class="action-column">
+							<th v-for="action in actions"
+								:key="action"
+								scope="col"
+								class="action-column">
 								{{ t('openregister', action) }}
 							</th>
-							<th class="action-column">
+							<th scope="col" class="action-column">
 								{{ t('openregister', 'Public') }}
 							</th>
 						</tr>

--- a/src/views/settings/sections/StatisticsOverview.vue
+++ b/src/views/settings/sections/StatisticsOverview.vue
@@ -27,13 +27,13 @@
 							<table class="stats-table">
 								<thead>
 									<tr>
-										<th class="stats-table-header">
+										<th scope="col" class="stats-table-header">
 											Issue
 										</th>
-										<th class="stats-table-header">
+										<th scope="col" class="stats-table-header">
 											Count
 										</th>
-										<th class="stats-table-header">
+										<th scope="col" class="stats-table-header">
 											Size
 										</th>
 									</tr>
@@ -128,13 +128,13 @@
 							<table class="stats-table">
 								<thead>
 									<tr>
-										<th class="stats-table-header">
+										<th scope="col" class="stats-table-header">
 											Resource
 										</th>
-										<th class="stats-table-header">
+										<th scope="col" class="stats-table-header">
 											Count
 										</th>
-										<th class="stats-table-header">
+										<th scope="col" class="stats-table-header">
 											Size
 										</th>
 									</tr>

--- a/src/views/templates/TemplatesIndex.vue
+++ b/src/views/templates/TemplatesIndex.vue
@@ -65,19 +65,19 @@
 				<table v-else class="templatesTable">
 					<thead>
 						<tr>
-							<th class="column-name">
+							<th scope="col" class="column-name">
 								{{ t('openregister', 'Name') }}
 							</th>
-							<th class="column-type">
+							<th scope="col" class="column-type">
 								{{ t('openregister', 'Type') }}
 							</th>
-							<th class="column-description">
+							<th scope="col" class="column-description">
 								{{ t('openregister', 'Description') }}
 							</th>
-							<th class="column-updated">
+							<th scope="col" class="column-updated">
 								{{ t('openregister', 'Updated At') }}
 							</th>
-							<th class="column-actions">
+							<th scope="col" class="column-actions">
 								{{ t('openregister', 'Actions') }}
 							</th>
 						</tr>

--- a/src/views/webhooks/WebhookLogsIndex.vue
+++ b/src/views/webhooks/WebhookLogsIndex.vue
@@ -73,14 +73,28 @@
 				<table v-else class="webhooksTable">
 					<thead>
 						<tr>
-							<th>{{ t('openregister', 'Webhook') }}</th>
-							<th>{{ t('openregister', 'Event') }}</th>
-							<th>{{ t('openregister', 'Status') }}</th>
-							<th>{{ t('openregister', 'Status Code') }}</th>
-							<th>{{ t('openregister', 'Attempt') }}</th>
-							<th>{{ t('openregister', 'Created') }}</th>
-							<th>{{ t('openregister', 'Error') }}</th>
-							<th class="column-actions">
+							<th scope="col">
+								{{ t('openregister', 'Webhook') }}
+							</th>
+							<th scope="col">
+								{{ t('openregister', 'Event') }}
+							</th>
+							<th scope="col">
+								{{ t('openregister', 'Status') }}
+							</th>
+							<th scope="col">
+								{{ t('openregister', 'Status Code') }}
+							</th>
+							<th scope="col">
+								{{ t('openregister', 'Attempt') }}
+							</th>
+							<th scope="col">
+								{{ t('openregister', 'Created') }}
+							</th>
+							<th scope="col">
+								{{ t('openregister', 'Error') }}
+							</th>
+							<th scope="col" class="column-actions">
 								{{ t('openregister', 'Actions') }}
 							</th>
 						</tr>

--- a/src/views/webhooks/WebhooksIndex.vue
+++ b/src/views/webhooks/WebhooksIndex.vue
@@ -75,25 +75,25 @@
 				<table v-else class="webhooksTable">
 					<thead>
 						<tr>
-							<th class="column-name">
+							<th scope="col" class="column-name">
 								{{ t('openregister', 'Name') }}
 							</th>
-							<th class="column-url">
+							<th scope="col" class="column-url">
 								{{ t('openregister', 'URL') }}
 							</th>
-							<th class="column-method">
+							<th scope="col" class="column-method">
 								{{ t('openregister', 'Method') }}
 							</th>
-							<th class="column-status">
+							<th scope="col" class="column-status">
 								{{ t('openregister', 'Status') }}
 							</th>
-							<th class="column-last-triggered">
+							<th scope="col" class="column-last-triggered">
 								{{ t('openregister', 'Last Triggered') }}
 							</th>
-							<th class="column-success-rate">
+							<th scope="col" class="column-success-rate">
 								{{ t('openregister', 'Success Rate') }}
 							</th>
-							<th class="column-actions">
+							<th scope="col" class="column-actions">
 								{{ t('openregister', 'Actions') }}
 							</th>
 						</tr>

--- a/templates/settings/integrations-admin.php
+++ b/templates/settings/integrations-admin.php
@@ -53,15 +53,15 @@ $authBadgeClass = static function (string $authStatus): string {
         <table class="grid">
             <thead>
                 <tr>
-                    <th><?php p($l->t('ID')); ?></th>
-                    <th><?php p($l->t('Label')); ?></th>
-                    <th><?php p($l->t('Group')); ?></th>
-                    <th><?php p($l->t('Storage')); ?></th>
-                    <th><?php p($l->t('Required app')); ?></th>
-                    <th><?php p($l->t('Status')); ?></th>
-                    <th><?php p($l->t('Auth')); ?></th>
-                    <th><?php p($l->t('OpenConnector source')); ?></th>
-                    <th><?php p($l->t('Actions')); ?></th>
+                    <th scope="col"><?php p($l->t('ID')); ?></th>
+                    <th scope="col"><?php p($l->t('Label')); ?></th>
+                    <th scope="col"><?php p($l->t('Group')); ?></th>
+                    <th scope="col"><?php p($l->t('Storage')); ?></th>
+                    <th scope="col"><?php p($l->t('Required app')); ?></th>
+                    <th scope="col"><?php p($l->t('Status')); ?></th>
+                    <th scope="col"><?php p($l->t('Auth')); ?></th>
+                    <th scope="col"><?php p($l->t('OpenConnector source')); ?></th>
+                    <th scope="col"><?php p($l->t('Actions')); ?></th>
                 </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
## Measurement

Gate package line, verbatim, from both runs:

```
[hydra-gates] gate package: 48c88ba1e0d049f8f38538c33e790d3e603c55d0 (git checkout at /home/rubenlinde/gate19-worktrees/or-green-2026-08-09/dotgithub/hydra-gates/scripts)
```

Full-repo scope, `[hydra-gates] Scope: full repo`. Counts read from the stdout
`[gate-N] <name>: PASS|FAIL — <count> finding(s)` lines, never from the exit byte.

| gate | name | before | after |
|---|---|---|---|
| 32 | semantic-controls | **10** | **2** (FAIL, deliberate — see below) |
| 39 | button-name | **6** | **0** (PASS) |
| 43 | table-headers | **57** | **0** (PASS) |
| 44 | autocomplete-attr | **1** | **0** (PASS) |
| 45 | prefers-reduced-motion | **29** | **0** (PASS) |

No other gate changed verdict or finding count between the two runs (diffed the
full `[gate-N]` line set and the full `FAIL — <count>` set).

## Can-it-fail proof

For each of the five gates one representative fix was reverted, the checker
re-run, and the finding confirmed to reappear naming the exact element — then
re-applied:

| gate | reverted | count went | finding that reappeared |
|---|---|---|---|
| 32 | `role`/`tabindex`/`@keydown` on `MergeObject` object-item | 2 → 3 | `MergeObject.vue:49 … rule=missing[role=,tabindex=,@keydown]` |
| 39 | `:aria-label` on `OrganisationDetails` copy button | 0 → 1 | `<NcButton class="copy-button" …> rule=icon-only-button-without-accessible-name` |
| 43 | one `scope="col"` in `RbacTable` | 0 → 1 | `RbacTable.vue: <table> unscoped=1/5 rule=th-without-scope` |
| 44 | `autocomplete="off"` in `LLMConfigModal` | 0 → 1 | `<input name/id="openaiConfig.organizationId" …>` |
| 45 | reduced-motion block in `LogIntegrity` | 0 → 1 | `LogIntegrity.vue: <style> rule=motion-without-reduced-motion-fallback` |

## What changed, and why this shape

### gate-32 semantic-controls (10 → 2)

**Cards with a heading — `EntitiesIndex`, `ReportsIndex`.** These did *not* get
`role="button"`. ARIA's `button` role is **children-presentational**, so putting
it on the card container would have removed the `<h2>`/`<h3>`, the stats table
and (on Entities) the `NcActions` menu from the accessibility tree — trading one
defect for a worse one. Instead each card's title is now a real `<button>` whose
`::after` overlay covers the card, so whole-card mouse clicking is preserved,
keyboard users get a genuine button, and the heading and actions menu keep their
semantics (`.cardActions` is lifted above the overlay with `z-index`).

**Plain selection rows — `MergeObject`, `ImportConfiguration` file card and
upload zone.** No headings, no interactive children, so the repo's existing
pattern (`SwitchOrganisationModal`) applies: `role="button" tabindex="0"` plus
`@keydown.enter` / `@keydown.space.prevent`, with `:aria-pressed` conveying the
selection state.

**Search-result lists — `ActionsTab`, `LinkObjectDialog`.** Promoted to
`role="listbox"` + `role="option"` with `:aria-selected`, which is the exact
semantics of these dropdowns and costs no visual change. `LinkObjectDialog`
already had `tabindex`/`aria-label`/`@keydown.enter`; only `role` was missing.

**`RegisterSchemaCard` description disclosure.** `:role`/`:tabindex`/
`:aria-expanded` are bound, so the element is only a button (and only a tab
stop) when there actually is a description to expand — with no description the
click handler is a no-op and it must not be focusable.

### Left RED, deliberately: 2 modal backdrops

```
src/components/i18n/BulkTranslateDialog.vue:2  <div class="bulk-translate-dialog__backdrop" @click.self="$emit('close')">
src/mail-sidebar/components/LinkObjectDialog.vue:2  <div class="or-mail-link-dialog-overlay" @click.self="close">
```

These are not legitimate findings and no waiver, exclude or suppression was
added for them. `@click.self` on a backdrop is a *mouse* dismissal affordance;
the keyboard equivalent is Escape on the dialog, which `LinkObjectDialog`
already had and which this PR adds to `BulkTranslateDialog` (together with
`aria-modal="true"`). Satisfying the gate here would mean giving the backdrop
`tabindex="0"` — inserting a focusable tab stop *in front of* the dialog, which
is itself an accessibility defect. The checker's own `@click.stop` exemption is
the same idea; it just does not cover `@click.self`. **Measured reason: the gate
has no `@click.self` exemption, and the only edit that would close it is a
regression.**

### gate-43 table-headers (57 → 0)

`scope` was chosen per table from the markup, not blanket-applied. For all 53
`th-without-scope` tables every `<th>` was measured to sit inside a `<thead>`
(verified by parsing each table and comparing `th_total` against
`th_in_thead`), so `scope="col"` is correct in every one.

The 4 `table-without-th` tables were handled individually:

* `EntitiesIndex` entity-stats, `EntityDetail` entity-info, `ViewWebhookLog`
  log-details — two-column key/value tables. The label cell became
  `<th scope="row">`; CSS extended so `th` keeps the exact `td` padding,
  alignment and weight (no visual change).
* `DashboardSideBar` × 2 — three-column stats tables (label / count / size) with
  **no header row at all**, so the two numeric columns were unlabelled: a screen
  reader read "Objects 12 3.4 MB" with nothing to say what the numbers were.
  These gained a real `<thead>` with `Item` / `Count` / `Size`, plus
  `<th scope="row">` on each label.

### gate-45 prefers-reduced-motion (29 → 0)

Each `@media (prefers-reduced-motion: reduce)` block names the **exact
selectors** that declare the `transition:`/`animation:` in that same `<style>`
block (extracted by walking the SCSS nesting), not a blanket `* { transition:
none }`. `SettingsCard` additionally neutralises the `slide-fade` transform, and
the two `copySuccess` keyframe animations get `animation: none`.

### gate-44 autocomplete-attr (1 → 0)

The one finding is `openaiConfig.organizationId` — an **OpenAI API organization
ID**, not a personal detail about the user, so WCAG 1.3.5 has no autofill
purpose to declare. `autocomplete="off"` is the honest declaration here and also
stops a password manager offering to fill the admin's own organisation name into
an API credential field.

## Build

* `npm run lint` — **0 errors** before and after. Warnings 1041 → 1055.
  Adding `scope="col"` to a previously attribute-less `<th>` activates
  `vue/singleline-html-element-content-newline` (the rule's default
  `ignoreWhenNoAttributes`), which produced ~404 new warnings; these were
  normalised with the project's own `npm run lint-fix` scoped to the touched
  `.vue` files. That autofix also inserted 71 missing JSDoc `@param` tags
  (`jsdoc/require-param` is auto-fixable) — that accounts for the residual +14
  and for part of the diff size.
* `npm run stylelint` — clean.

No waivers, `@spec exclude`, `@e2e exclude`, `.skip`, `continue-on-error`,
baseline entries or threshold changes were added, and the gate package was not
modified.
