### PR TITLE
fix(auth): three endpoints declared #[NoAdminRequired] while enforcing admin (gate-9)

### DIFF
--- a/lib/Controller/CredentialController.php
+++ b/lib/Controller/CredentialController.php
@@ -584,9 +584,13 @@ class CredentialController extends Controller
      *
      * @return JSONResponse `{appId, secret}` once, or a static error.
      *
+     * @auth admin-only Mints a signing secret a consuming app uses to authenticate every later
+     *       broker call, returned once and never retrievable again. The body already required
+     *       admin; the #[NoAdminRequired] that used to sit here declared the opposite, so the
+     *       posture on the method contradicted the posture in the docblock and in the code.
+     *
      * @spec openspec/specs/credential-broker/spec.md
      */
-    #[NoAdminRequired]
     public function registerApp(string $appId): JSONResponse
     {
         $uid = $this->currentUid();

--- a/lib/Controller/FederatedConfigController.php
+++ b/lib/Controller/FederatedConfigController.php
@@ -255,12 +255,15 @@ class FederatedConfigController extends Controller
      *
      * @return JSONResponse `{sourceAllowlist, trustedKeys, publishGroups, installGroups}` or 403.
      *
-     * @NoAdminRequired
+     * @auth admin-only Returns the instance's federation trust configuration — the source
+     *       allowlist and the trusted publisher keys. The body already rejected non-admins and the
+     *       summary above already said "admin only"; the #[NoAdminRequired] that used to sit here
+     *       declared the opposite of all three.
+     *
      * @NoCSRFRequired
      *
      * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
      */
-    #[NoAdminRequired]
     #[NoCSRFRequired]
     public function trust(): JSONResponse
     {
@@ -281,12 +284,15 @@ class FederatedConfigController extends Controller
      *
      * @return JSONResponse The updated trust configuration, or a 4xx.
      *
-     * @NoAdminRequired
+     * @auth admin-only Writes the federation trust configuration: it can append a public key to the
+     *       trusted-keys list, which decides whose published configuration this instance will
+     *       accept. The body already rejected non-admins and the summary above already said
+     *       "admin only"; the #[NoAdminRequired] that used to sit here declared the opposite.
+     *
      * @NoCSRFRequired
      *
      * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
      */
-    #[NoAdminRequired]
     #[NoCSRFRequired]
     public function setTrust(): JSONResponse
     {

--- a/tests/Unit/Controller/AdminOnlyPostureTest.php
+++ b/tests/Unit/Controller/AdminOnlyPostureTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Endpoints whose bodies enforce admin must not declare otherwise.
+ *
+ * CredentialController::registerApp, FederatedConfigController::trust and
+ * ::setTrust each carried #[NoAdminRequired] while rejecting non-admins in the
+ * body. Nothing broke, because the body caught what the attribute let through —
+ * which is exactly why it survived: the contradiction was invisible at runtime
+ * and only showed up as a mechanical finding.
+ *
+ * The danger in that shape is that the in-body check is now the ONLY thing
+ * standing between a non-admin and the endpoint. Delete or short-circuit it —
+ * during a refactor, or by an early return added above it — and the declared
+ * posture says the endpoint was always meant to be open, so nothing reads as a
+ * regression. Removing #[NoAdminRequired] puts the middleware back in front of
+ * it; this test keeps it that way.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Controller
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @spec openspec/specs/credential-broker/spec.md
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Controller;
+
+use OCA\OpenRegister\Controller\CredentialController;
+use OCA\OpenRegister\Controller\FederatedConfigController;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\PublicPage;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+class AdminOnlyPostureTest extends TestCase
+{
+
+
+    /**
+     * Endpoints that must be reachable by administrators only.
+     *
+     * @return array<string, array{0: class-string, 1: string}>
+     */
+    public static function adminOnlyEndpoints(): array
+    {
+        return [
+            'Credential::registerApp'      => [CredentialController::class, 'registerApp'],
+            'FederatedConfig::trust'       => [FederatedConfigController::class, 'trust'],
+            'FederatedConfig::setTrust'    => [FederatedConfigController::class, 'setTrust'],
+        ];
+    }//end adminOnlyEndpoints()
+
+
+    /**
+     * The endpoint must not carry #[NoAdminRequired].
+     *
+     * @param class-string $controller The controller class.
+     * @param string       $method     The method name.
+     *
+     * @return void
+     *
+     * @dataProvider adminOnlyEndpoints
+     */
+    public function testEndpointDoesNotDeclareNoAdminRequired(string $controller, string $method): void
+    {
+        $attributes = (new ReflectionMethod($controller, $method))->getAttributes(NoAdminRequired::class);
+
+        $this->assertSame(
+            [],
+            $attributes,
+            $controller.'::'.$method.'() carries #[NoAdminRequired] while its body requires an admin. '
+            .'That leaves the in-body check as the only barrier, so losing it in a refactor would not '
+            .'read as a regression. Let the middleware reject instead.'
+        );
+    }//end testEndpointDoesNotDeclareNoAdminRequired()
+
+
+    /**
+     * The endpoint must not drop authentication entirely.
+     *
+     * @param class-string $controller The controller class.
+     * @param string       $method     The method name.
+     *
+     * @return void
+     *
+     * @dataProvider adminOnlyEndpoints
+     */
+    public function testEndpointIsNotAPublicPage(string $controller, string $method): void
+    {
+        $attributes = (new ReflectionMethod($controller, $method))->getAttributes(PublicPage::class);
+
+        $this->assertSame(
+            [],
+            $attributes,
+            $controller.'::'.$method.'() carries #[PublicPage], which removes authentication entirely.'
+        );
+    }//end testEndpointIsNotAPublicPage()
+
+
+    /**
+     * The legacy docblock form must be absent too.
+     *
+     * Nextcloud honours `@NoAdminRequired` at docblock-tag position exactly like
+     * the attribute, so checking only attributes would pass over an endpoint
+     * reopened the old way. Tag position means preceded on its line by nothing
+     * but whitespace and comment punctuation, so prose naming the tag in a
+     * sentence does not match.
+     *
+     * @param class-string $controller The controller class.
+     * @param string       $method     The method name.
+     *
+     * @return void
+     *
+     * @dataProvider adminOnlyEndpoints
+     */
+    public function testEndpointDoesNotCarryTheLegacyDocblockTag(string $controller, string $method): void
+    {
+        $doc = (new ReflectionMethod($controller, $method))->getDocComment();
+        if ($doc === false) {
+            $this->addToAssertionCount(1);
+            return;
+        }
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/^[[:space:]]*(\/?\*+[[:space:]]*)@NoAdminRequired\b/m',
+            $doc,
+            $controller.'::'.$method.'() declares @NoAdminRequired at docblock-tag position, which '
+            .'Nextcloud honours exactly like the attribute.'
+        );
+    }//end testEndpointDoesNotCarryTheLegacyDocblockTag()
+
+
+    /**
+     * The admin-only posture must be stated with a reason.
+     *
+     * @param class-string $controller The controller class.
+     * @param string       $method     The method name.
+     *
+     * @return void
+     *
+     * @dataProvider adminOnlyEndpoints
+     */
+    public function testEndpointDeclaresItsAdminOnlyPostureWithAReason(string $controller, string $method): void
+    {
+        $doc = (new ReflectionMethod($controller, $method))->getDocComment();
+
+        $this->assertIsString($doc, $controller.'::'.$method.'() has no docblock to declare a posture in.');
+        $this->assertMatchesRegularExpression(
+            '/^[[:space:]]*(\/?\*+[[:space:]]*)@auth[[:space:]]+admin-only[[:space:]]+.{20,}/m',
+            $doc,
+            $controller.'::'.$method.'() does not declare `@auth admin-only <reason>`. Admin-only by '
+            .'Nextcloud default is indistinguishable from a forgotten attribute; say which it is.'
+        );
+    }//end testEndpointDeclaresItsAdminOnlyPostureWithAReason()
+}//end class


### PR DESCRIPTION
**gate-9 semantic-auth: 3 → 0 (PASS).** No change to who can reach these endpoints.

Measured with hydra-gates `48c88ba1e0d049f8f38538c33e790d3e603c55d0`.

## The finding

Three methods carried `#[NoAdminRequired]` and then rejected non-admins in the body. The declared posture was the opposite of the enforced one — and in all three the docblock summary *already said "admin only"*, so the attribute contradicted the prose, the code and the intent simultaneously.

| method | what it does |
|---|---|
| `CredentialController::registerApp` | Mints a signing secret a consuming app uses to authenticate every later broker call. Returned **once**, never retrievable again. |
| `FederatedConfigController::trust` | Reads the federation trust configuration — source allowlist and trusted publisher keys. |
| `FederatedConfigController::setTrust` | Writes it, including appending a public key to the trusted-keys list — which decides **whose published configuration this instance will accept**. |

Every one answered 403 to a non-admin before and answers 403 now. The rejection just moves from the controller body to the middleware, one layer earlier.

## Why these are not the usual gate-9 false positive

Most gate-9 findings across the fleet are **self-authenticating** endpoints — webhooks and public portals that verify a signature, token or shared secret *instead of* a session, where removing `#[NoAdminRequired]` would break the endpoint and following the gate's advice would introduce the vulnerability rather than close it.

None of these three is that shape. Each body calls a plain `groupManager->isAdmin()` / `isAdmin()` **on the logged-in session user** — precisely the check the middleware exists to perform. There is no alternative credential in play.

Posture is declared with `@auth admin-only <reason>`, the marker the gate package provides for the case where no attribute can express "admin only" (the *absence* of `#[NoAdminRequired]` **is** the admin gate).

## Deliberately NOT changed — flagging it instead

`trust()` and `setTrust()` keep `#[NoCSRFRequired]`. On `setTrust()` — a state-changing admin write that can append a trusted publisher key — that is worth a second look on its own merits: with CSRF disabled, an admin's browser visiting a hostile page could be made to issue it. I have **not** touched it because I could not establish in this window whether a non-browser federation client depends on it, and removing CSRF protection's exemption is a behaviour change that belongs with that evidence rather than folded into an auth-declaration fix. Raising it separately.

## Measurement

| gate | before | after |
|---|---|---|
| gate-9 semantic-auth | FAIL — 3 | **PASS** |
| gate-7 no-admin-idor | FAIL — 12 | FAIL — 12 (unchanged) |
| gate-5 route-auth | FAIL — 10 | FAIL — 10 (unchanged; fixed in #2396) |

`phpcs` and `phpstan` clean; 211 related unit tests pass.