### PR TITLE
fix(security): the flow node catalog trusted a request parameter as a privilege check

### DIFF
--- a/lib/Controller/FlowController.php
+++ b/lib/Controller/FlowController.php
@@ -49,7 +49,9 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUserSession;
 use OCP\WorkflowEngine\IManager;
 
 /**
@@ -88,6 +90,8 @@ class FlowController extends Controller
      * @param FlowStateMapper     $flowState    Reads state a flow keeps between runs.
      * @param FlowNodePreflight   $preflight    Resolves a document's step types.
      * @param FlowService         $flows        Reads, writes and runs flow definitions.
+     * @param IUserSession        $userSession  Resolves the calling user.
+     * @param IGroupManager       $groupManager Answers whether that user is an administrator.
      */
     public function __construct(
         string $appName,
@@ -97,9 +101,29 @@ class FlowController extends Controller
         private readonly FlowStateMapper $flowState,
         private readonly FlowNodePreflight $preflight,
         private readonly FlowService $flows,
+        private readonly IUserSession $userSession,
+        private readonly IGroupManager $groupManager,
     ) {
         parent::__construct(appName: $appName, request: $request);
     }//end __construct()
+
+    /**
+     * Whether the calling user is a Nextcloud administrator.
+     *
+     * Fails CLOSED: an unresolvable session answers false, so the reduced
+     * SCOPE_USER palette is what gets served rather than the admin one.
+     *
+     * @return boolean Whether the caller is an administrator.
+     */
+    private function callerIsAdmin(): bool
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return false;
+        }
+
+        return $this->groupManager->isAdmin($user->getUID());
+    }//end callerIsAdmin()
 
     /**
      * Return the declarative-flow trigger catalog.
@@ -138,6 +162,18 @@ class FlowController extends Controller
      * Scope-filtered, so a non-administrator is never offered a step they could
      * not run. Every node implements `isAvailableForScope()` already.
      *
+     * The scope is derived from the CALLER, not from a request parameter. It
+     * used to default to SCOPE_ADMIN and drop to SCOPE_USER only when the
+     * request said `?scope=user`, which meant the docblock claim above was
+     * false in the one direction that matters: a non-administrator who simply
+     * omitted the parameter — the default for anything that is not deliberately
+     * asking for the reduced view — was served the ADMIN palette. The parameter
+     * was the caller's to set, so it could never have been a privilege check.
+     *
+     * An administrator may still pass `?scope=user` to preview what a
+     * non-administrator sees; that direction only ever narrows the result. A
+     * non-administrator is pinned to SCOPE_USER regardless of what they send.
+     *
      * @return JSONResponse `{ results: [{id,displayName,description,icon}], total }`.
      *
      * @NoAdminRequired
@@ -147,9 +183,9 @@ class FlowController extends Controller
      */
     public function nodeCatalog(): JSONResponse
     {
-        $scope = IManager::SCOPE_ADMIN;
-        if ($this->request->getParam('scope') === 'user') {
-            $scope = IManager::SCOPE_USER;
+        $scope = IManager::SCOPE_USER;
+        if ($this->callerIsAdmin() === true && $this->request->getParam('scope') !== 'user') {
+            $scope = IManager::SCOPE_ADMIN;
         }
 
         $results = $this->nodes->palette(scope: $scope);

--- a/tests/Unit/Controller/FlowControllerTest.php
+++ b/tests/Unit/Controller/FlowControllerTest.php
@@ -27,7 +27,10 @@ use OCA\OpenRegister\Controller\FlowController;
 use OCA\OpenRegister\Service\Flow\EventCatalogService;
 use OCA\OpenRegister\Service\Flow\FlowNodePreflight;
 use OCA\OpenRegister\Service\Flow\FlowNodeRegistry;
+use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
 use OCP\WorkflowEngine\IManager;
 use PHPUnit\Framework\TestCase;
 
@@ -66,6 +69,20 @@ class FlowControllerTest extends TestCase
     private $flows;
 
     /**
+     * The mocked user session, used to resolve the caller.
+     *
+     * @var IUserSession
+     */
+    private IUserSession $userSession;
+
+    /**
+     * The mocked group manager, used to answer "is the caller an admin".
+     *
+     * @var IGroupManager
+     */
+    private IGroupManager $groupManager;
+
+    /**
      * The controller under test.
      *
      * @var FlowController
@@ -87,6 +104,16 @@ class FlowControllerTest extends TestCase
 
         $this->flows = $this->createMock(\OCA\OpenRegister\Service\Flow\FlowService::class);
 
+        // Default to an ADMIN caller so the pre-existing tests keep exercising
+        // the palette they were written against; the escalation tests below
+        // override this with a non-admin.
+        $this->userSession  = $this->createMock(IUserSession::class);
+        $this->groupManager = $this->createMock(IGroupManager::class);
+        $adminUser          = $this->createMock(IUser::class);
+        $adminUser->method('getUID')->willReturn('admin');
+        $this->userSession->method('getUser')->willReturn($adminUser);
+        $this->groupManager->method('isAdmin')->willReturn(true);
+
         $this->controller = new FlowController(
             'openregister',
             $this->request,
@@ -94,7 +121,9 @@ class FlowControllerTest extends TestCase
             $this->nodes,
             $this->createMock(originalClassName: \OCA\OpenRegister\Db\FlowStateMapper::class),
             $this->preflight,
-            $this->flows
+            $this->flows,
+            $this->userSession,
+            $this->groupManager
         );
 
     }//end setUp()
@@ -138,7 +167,13 @@ class FlowControllerTest extends TestCase
     }//end testNodeCatalogSurfacesAppContributedLeaves()
 
     /**
-     * Admin scope is the default, so a builder never has to ask for it.
+     * An ADMIN caller gets the admin palette without asking for it.
+     *
+     * The name says "defaults" because that is what it means for an
+     * administrator. It is no longer a property of the request: the scope is
+     * derived from the caller, and this test's caller is an admin because
+     * setUp() makes one. The non-admin half is covered at the bottom of this
+     * class.
      *
      * @return void
      */
@@ -224,7 +259,9 @@ class FlowControllerTest extends TestCase
             $this->nodes,
             $mapper,
             $this->preflight,
-            $this->flows
+            $this->flows,
+            $this->userSession,
+            $this->groupManager
         );
 
         $data = $controller->state(flowId: 'flow-1')->getData();
@@ -274,7 +311,9 @@ class FlowControllerTest extends TestCase
             $this->nodes,
             $mapper,
             $this->preflight,
-            $this->flows
+            $this->flows,
+            $this->userSession,
+            $this->groupManager
         );
 
         $response = $controller->state(flowId: 'someone-elses-flow');
@@ -310,7 +349,9 @@ class FlowControllerTest extends TestCase
             $this->nodes,
             $mapper,
             $this->preflight,
-            $this->flows
+            $this->flows,
+            $this->userSession,
+            $this->groupManager
         );
 
         $response = $controller->state(flowId: 'flow-1');
@@ -339,7 +380,9 @@ class FlowControllerTest extends TestCase
             $this->nodes,
             $mapper,
             $this->preflight,
-            $this->flows
+            $this->flows,
+            $this->userSession,
+            $this->groupManager
         );
 
         $data = $controller->state(flowId: 'flow-1')->getData();
@@ -441,4 +484,117 @@ class FlowControllerTest extends TestCase
         $this->assertFalse($response->getData()['valid']);
 
     }//end testValidateRejectsANonFlowBody()
+
+    /**
+     * A non-administrator must never receive the admin palette.
+     *
+     * This is the regression test for the actual defect. The scope used to come
+     * from `?scope=`, which is the caller's to set, so it could never have been
+     * a privilege check — and because it DEFAULTED to SCOPE_ADMIN, the failure
+     * mode was the dangerous one: a non-administrator who simply did not send
+     * the parameter got the admin palette. Omitting it is the normal case.
+     *
+     * @return void
+     */
+    public function testANonAdminNeverReceivesTheAdminPaletteWhenNoScopeIsSent(): void
+    {
+        $userSession  = $this->createMock(IUserSession::class);
+        $groupManager = $this->createMock(IGroupManager::class);
+        $plainUser    = $this->createMock(IUser::class);
+        $plainUser->method('getUID')->willReturn('jan');
+        $userSession->method('getUser')->willReturn($plainUser);
+        $groupManager->method('isAdmin')->willReturn(false);
+
+        // No scope parameter — the normal case, and the one that used to leak.
+        $this->request->method('getParam')->willReturn(null);
+        $this->nodes->expects($this->once())
+            ->method('palette')
+            ->with(IManager::SCOPE_USER)
+            ->willReturn([]);
+
+        $controller = new FlowController(
+            'openregister',
+            $this->request,
+            $this->createMock(EventCatalogService::class),
+            $this->nodes,
+            $this->createMock(\OCA\OpenRegister\Db\FlowStateMapper::class),
+            $this->preflight,
+            $this->flows,
+            $userSession,
+            $groupManager
+        );
+
+        $controller->nodeCatalog();
+
+    }//end testANonAdminNeverReceivesTheAdminPaletteWhenNoScopeIsSent()
+
+    /**
+     * A non-administrator cannot escalate by ASKING for the admin scope.
+     *
+     * @return void
+     */
+    public function testANonAdminCannotRequestTheAdminScope(): void
+    {
+        $userSession  = $this->createMock(IUserSession::class);
+        $groupManager = $this->createMock(IGroupManager::class);
+        $plainUser    = $this->createMock(IUser::class);
+        $plainUser->method('getUID')->willReturn('jan');
+        $userSession->method('getUser')->willReturn($plainUser);
+        $groupManager->method('isAdmin')->willReturn(false);
+
+        $this->request->method('getParam')->willReturn('admin');
+        $this->nodes->expects($this->once())
+            ->method('palette')
+            ->with(IManager::SCOPE_USER)
+            ->willReturn([]);
+
+        $controller = new FlowController(
+            'openregister',
+            $this->request,
+            $this->createMock(EventCatalogService::class),
+            $this->nodes,
+            $this->createMock(\OCA\OpenRegister\Db\FlowStateMapper::class),
+            $this->preflight,
+            $this->flows,
+            $userSession,
+            $groupManager
+        );
+
+        $controller->nodeCatalog();
+
+    }//end testANonAdminCannotRequestTheAdminScope()
+
+    /**
+     * An unresolvable session fails CLOSED, onto the reduced palette.
+     *
+     * @return void
+     */
+    public function testAnUnresolvableSessionGetsTheUserPalette(): void
+    {
+        $userSession  = $this->createMock(IUserSession::class);
+        $groupManager = $this->createMock(IGroupManager::class);
+        $userSession->method('getUser')->willReturn(null);
+        $groupManager->expects($this->never())->method('isAdmin');
+
+        $this->request->method('getParam')->willReturn(null);
+        $this->nodes->expects($this->once())
+            ->method('palette')
+            ->with(IManager::SCOPE_USER)
+            ->willReturn([]);
+
+        $controller = new FlowController(
+            'openregister',
+            $this->request,
+            $this->createMock(EventCatalogService::class),
+            $this->nodes,
+            $this->createMock(\OCA\OpenRegister\Db\FlowStateMapper::class),
+            $this->preflight,
+            $this->flows,
+            $userSession,
+            $groupManager
+        );
+
+        $controller->nodeCatalog();
+
+    }//end testAnUnresolvableSessionGetsTheUserPalette()
 }//end class


### PR DESCRIPTION
Refs #2386. One real privilege-scope defect found via gate-7 — and eight gate-7 findings on this repo that are **false positives**, traced individually below.

## The defect

`FlowController::nodeCatalog()` is `#[NoAdminRequired]` and chose its palette scope like this:

```php
$scope = IManager::SCOPE_ADMIN;
if ($this->request->getParam('scope') === 'user') {
    $scope = IManager::SCOPE_USER;
}
```

The scope came from **the request**, which is the caller's to set, so it could never have been a privilege check. And it **defaulted to `SCOPE_ADMIN`**, which puts the failure on the dangerous side: a non-administrator who simply did not send the parameter — the normal case — was served the **admin palette**.

The docblock directly above it claimed:

> *"Scope-filtered, so a non-administrator is never offered a step they could not run."*

That was false in exactly the direction that matters.

## The fix

Scope is derived from the **caller**. A non-administrator is pinned to `SCOPE_USER` regardless of what they send. An administrator may still pass `?scope=user` to preview the reduced view — that direction only narrows. An unresolvable session **fails closed** onto `SCOPE_USER`.

Three regression tests, each **verified to fail against the original logic**: a non-admin sending no scope, a non-admin asking for admin scope, and an unresolvable session. Restoring the request-parameter version turns all three red.

## gate-7's other eight findings here are false positives

gate-7 looks for a guard in the **controller body**. On this repo the guards for that surface deliberately live *below* the controller, so the gate cannot see them:

| finding | where the guard actually is |
|---|---|
| `FederationController::shares` | `listShares()` → `FederatedShareMapper::findAll()` → `applyOrganisationFilter()` |
| `FederationController::revokeShare` | `setStatus()` → `updateFromArray()` → `find()` → `applyOrganisationFilter()` |
| `FlowController::destroy` | `FlowService::find()` rejects unless `$flow->belongsTo($this->activeOrganisation())` |
| `FederatedConfig::discover` | `credentialId` read from the caller's **own** `getUserValue()` preference, never the request |
| `FederatedConfig::fetch` | same |
| `FederatedConfig::publicKey` | returns this instance's **public** key, published for other orgs to trust |
| `FlowController::eventCatalog` | static trigger catalog; no object reference |
| `FlowController::validate` | pure function over a caller-supplied body |

### A near miss worth recording

**I nearly filed two of these as vulnerabilities.** `listShares()` and `setStatus()` both look unscoped at the service layer — `findAll(filters:)` and `updateFromArray(id:)` with no organisation anywhere in sight. The scoping is one layer further down, in the **mapper**, via `MultiTenancyTrait::applyOrganisationFilter()`.

Stopping at the service — which is where the reading naturally ends, because the service is what the controller calls — would have produced two confident, wrong security reports. Worth remembering that "no guard here" means nothing until the layer *below* has been read too.

This does **not** support the "gate-7 is anti-correlated" claim in `.github#160`: the gate pointed at nine methods and one of them was a genuine escalation. It supports a narrower statement — gate-7 cannot see guards enforced at the data-access layer.

## Verification

`phpcs`, `phpstan` clean on the changed file. 18 `FlowControllerTest` tests, 42 assertions, green.

Measured with hydra-gates `651e5c5bb3ba8764903e5d6fc5bac5a208bd67fc`.