### PR TITLE
docs(i18n): untick two false "[x] done" claims — the translation UI is not mounted

### DIFF
--- a/openspec/changes/archive/2026-05-01-register-i18n/tasks.md
+++ b/openspec/changes/archive/2026-05-01-register-i18n/tasks.md
@@ -17,8 +17,26 @@
 - [x] **Content-Language vs UI language MUST be clearly distinguished.** Phase 2: `LanguageMiddleware` adds `Content-Language` header (object content language) + `X-Content-Language-Fallback`.
 - [x] **Import and export MUST preserve translations.** Phase 3: `ExportService::exportToCsv` emits `field_lang` columns for each translatable property × register language (fallback `[nl, en]` when register has no `languages` config). `ImportService::importFromCsv::transformCsvRowToObject` calls `TranslationCsvCodec::unflattenFromCsv` before the per-key processing loop, so flat `field_lang` columns become nested `{lang: value}` JSON. **Verified live** by 4 export tests + 2 codec round-trip tests in `RegisterI18nPhase3IntegrationTest`.
 - [x] **GraphQL API MUST support language negotiation.** Phase 3: `GraphQLResolver::filterProperties` now applies `TranslationHandler::resolveTranslationsForRender` after the property-level RBAC pass. GraphQL responses honour the same `LanguageService` chain that REST honours, so a query made with `Accept-Language: en` collapses language-keyed values to their EN variant. Verified by `testGraphQLResolverApplyTranslationsToFilterPropertiesOutput`.
-- [x] **The UI MUST provide a language-aware object editor with translation status.** Phase 4a: Pinia store `src/store/modules/translations.js` wraps `GET /object/{uuid}`, `POST /{property}/{language}/status`, `POST /bulk-translate`, and `GET /search`. Vue components `TranslationFieldEditor` (per-language inputs/textarea with status chip), `TranslationStatusChip` (NL Design System status badge), `TranslationCompletenessBadge` (per-language ratio pills consuming `@self.translationCompleteness`), and `BulkTranslateDialog` (modal calling the bulk-translate endpoint).
-- [x] **RTL language support MUST be handled in the UI.** Phase 4a: `RTL_LANGUAGES` set + `isRtlLanguage()` BCP 47 helper in the translations store; `TranslationFieldEditor.dirFor()` applies `dir="rtl"` per input/textarea for Arabic, Hebrew, Persian, Urdu, Kurdish, etc.
+- [ ] **The UI MUST provide a language-aware object editor with translation status.** Phase 4a: Pinia store `src/store/modules/translations.js` wraps `GET /object/{uuid}`, `POST /{property}/{language}/status`, `POST /bulk-translate`, and `GET /search`. Vue components `TranslationFieldEditor` (per-language inputs/textarea with status chip), `TranslationStatusChip` (NL Design System status badge), `TranslationCompletenessBadge` (per-language ratio pills consuming `@self.translationCompleteness`), and `BulkTranslateDialog` (modal calling the bulk-translate endpoint).
+  <!-- UNTICKED 2026-08-09. The store and the four components exist and are unit-tested. NOTHING MOUNTS
+       THEM: TranslationFieldEditor, TranslationCompletenessBadge and BulkTranslateDialog each have zero
+       imports outside their own .spec.js, and TranslationStatusChip is reachable only through
+       TranslationFieldEditor, which is itself unmounted. So no object edit form shows language tabs, no
+       badge, and no side-by-side mode — none of the five scenarios under this requirement can be
+       performed by a user.
+       This box is different from an ordinary over-claim: the task text IS the requirement, so ticking it
+       asserted the requirement was MET. Building the components was necessary but is not the requirement.
+       Compare the "Admin UI MUST provide register language management" box below, written in the same
+       phase by the same hand — it names the mount point explicitly ("Wired into the RegisterSideBar edit
+       form"), and that one really is live. The absence of any such clause here is the tell.
+       The components are deliberately NOT deleted: they are the only implementation of an un-excluded
+       MUST, and removing them would make the spec less true rather than more. What is missing is a host.
+       See openspec/specs/register-i18n/spec.md, which now carries the same note. -->
+- [ ] **RTL language support MUST be handled in the UI.** Phase 4a: `RTL_LANGUAGES` set + `isRtlLanguage()` BCP 47 helper in the translations store; `TranslationFieldEditor.dirFor()` applies `dir="rtl"` per input/textarea for Arabic, Hebrew, Persian, Urdu, Kurdish, etc.
+  <!-- UNTICKED 2026-08-09. `dirFor()` is real and unit-tested, but it lives on TranslationFieldEditor,
+       which nothing mounts — so no RTL text is rendered anywhere in the UI. The store-level helpers
+       (RTL_LANGUAGES, isRtlLanguage) are live and reusable; the UI half is not. -->
+
 - [x] **Admin UI MUST provide register language management.** Phase 4b: `RegisterLanguagesEditor.vue` — ordered list editor with BCP 47 validation, duplicate rejection, up/down reorder, remove, and a "default" badge on the first language. Wired into the `RegisterSideBar` edit form via `formData.languages`. `TRegister` type + `Register` entity gained an optional `languages?: string[]` field so the form round-trips cleanly through `registerStore.saveRegister`.
 
 ## Architecture (decisions taken across all phases)

--- a/openspec/specs/register-i18n/spec.md
+++ b/openspec/specs/register-i18n/spec.md
@@ -192,6 +192,26 @@ The app UI (labels, buttons, error messages, navigation) MUST use Nextcloud's `I
 
 ### Requirement: The UI MUST provide a language-aware object editor with translation status
 
+> **NOT DELIVERED as of 2026-08-09 — the components exist but nothing mounts them.**
+>
+> `TranslationFieldEditor`, `TranslationCompletenessBadge` and `BulkTranslateDialog`
+> each have **zero imports** outside their own `.spec.js`, and `TranslationStatusChip`
+> is reachable only through `TranslationFieldEditor`, which is itself unmounted. The
+> Pinia store and the REST surface underneath them are live and tested; what is
+> missing is a host that renders them in the object edit form.
+>
+> None of the five scenarios below can currently be performed by a user: there are no
+> language tabs, no missing-translation badge, and no side-by-side mode.
+>
+> This was recorded as complete in `openspec/changes/archive/2026-05-01-register-i18n/tasks.md`
+> because the components were built. The boxes have been unticked. The sibling
+> requirement "Admin UI MUST provide register language management" IS delivered —
+> `RegisterLanguagesEditor` is mounted in `RegisterSideBar` — which is what makes the
+> difference visible.
+>
+> The components are deliberately kept: they are the only implementation of this
+> requirement, and deleting them would make this spec less true, not more.
+
 The object edit form MUST display language tabs for translatable properties, allowing users to switch between languages. Non-translatable properties SHALL remain visible regardless of the selected language tab. The editor MUST indicate translation completeness per language.
 
 #### Scenario: Edit translations via language tabs
@@ -359,6 +379,12 @@ Full-text search MUST be able to search across all language variants of translat
 - **AND** facet counts SHALL aggregate across all language variants (a single object with `categorie.nl` and `categorie.en` counts once)
 
 ### Requirement: RTL language support MUST be handled in the UI
+
+> **NOT DELIVERED as of 2026-08-09.** The `RTL_LANGUAGES` set and `isRtlLanguage()`
+> helper are live in the translations store, but the only thing that applies `dir="rtl"`
+> is `TranslationFieldEditor.dirFor()`, and that component is never mounted — see the
+> note under "The UI MUST provide a language-aware object editor with translation
+> status" above. No RTL text is rendered anywhere in the UI today.
 
 When a register includes RTL (right-to-left) languages such as Arabic (`ar`) or Hebrew (`he`), the UI MUST render those language tabs and input fields with appropriate text direction.
 


### PR DESCRIPTION
Two MUST requirements were ticked as complete in `openspec/changes/archive/2026-05-01-register-i18n/tasks.md`. Neither is met.

- `[x] **The UI MUST provide a language-aware object editor with translation status.**`
- `[x] **RTL language support MUST be handled in the UI.**`

## What is actually true

The Pinia store and the REST surface underneath are **live and tested**. The four Vue components are **built and unit-tested**. **Nothing mounts them.**

| component | non-spec imports |
|---|---|
| `TranslationFieldEditor` | **0** |
| `TranslationCompletenessBadge` | **0** |
| `BulkTranslateDialog` | **0** |
| `TranslationStatusChip` | only via `TranslationFieldEditor`, itself unmounted |

So no object edit form shows language tabs, no missing-translation badge, no side-by-side mode. **None of the five scenarios under that requirement can be performed by a user**, and no RTL text is rendered anywhere.

**Positive control:** `RegisterLanguagesEditor` resolves to `src/sidebars/register/RegisterSideBar.vue:202`. The scan does find real mounts — these four genuinely have none.

## Why this is worse than an ordinary over-claim

**The task text *is* the requirement.** Ticking *"Create BulkTranslateDialog.vue"* would have been honest — the file was created. Ticking *"The UI MUST provide a language-aware object editor"* asserts the requirement is **met**. Building the components was necessary work; it is not the requirement.

The tell sits in the same file, same phase, same hand:

> `- [x] **Admin UI MUST provide register language management.** … **Wired into the `RegisterSideBar` edit form** via `formData.languages`.`

That one names its mount point, and that one really is live. The two unticked here name no mount point at all. When wiring happened, the author wrote it down.

## What I did *not* do

**I did not delete the components.** They are the only implementation of an un-excluded MUST — deleting them would make the spec *less* true, not more, and would discard work that is correct as far as it goes. What is missing is a **host**, and wiring one is a feature build (language tabs in the object edit form, per-language status, side-by-side mode), not a cleanup that belongs in a gate sweep.

This contrasts with `LinkObjectDialog` in #2400, which I *did* delete — there the spec itself said the affordance had been **replaced** by a live sibling, so the component was a superseded design rather than an undelivered one. Same question, opposite answer, because the evidence differed.

## Also explains a red gate

**gate-32's last finding stays red.** It is the `BulkTranslateDialog` backdrop (`@click.self` on a `<div>`). The only edit that satisfies the gate is a `tabindex`/key handler on a backdrop — a fake control, not a fix. Leaving it red is the correct outcome.

## Measurement

hydra-gates `651e5c5bb3ba8764903e5d6fc5bac5a208bd67fc`, **stderr 0 bytes** (interpreter proven live):

| gate | result |
|---|---|
| gate-16 spec-coverage | PASS |
| gate-46 spec-anchor-existence | PASS |

The added notes keep every `@spec` anchor resolving.