### PR TITLE
fix(a11y): guard the stylesheet's motion behind prefers-reduced-motion (gate-45 cannot see this)

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1297,3 +1297,37 @@
     max-height: 300px;
   }
 }
+
+/* Reduced motion (WCAG 2.2 SC 2.3.3 Animation from Interactions).
+ *
+ * Every transition this stylesheet declares is listed here explicitly rather
+ * than being swept up by a `*` rule. A universal selector in an app stylesheet
+ * reaches Nextcloud's own components on the same page, so it would silently
+ * change the behaviour of code this app does not own.
+ *
+ * Only MOTION is removed. The two `transform: translateY(100%)` rules on
+ * .format-json-button and .error-message are static positioning — they place an
+ * element, they do not animate it — so disabling them would move those elements
+ * to the wrong place for exactly the users who asked for less motion.
+ *
+ * The hover transforms on .card and .detail-item are neutralised too: with the
+ * transition gone they would otherwise snap, which is the jump this preference
+ * exists to avoid. Their non-motion affordances (box-shadow, border, colour)
+ * are deliberately left alone, so hover is still visibly hover.
+ */
+@media (prefers-reduced-motion: reduce) {
+  .card,
+  .nestedCardHeader,
+  .toggleButton,
+  .viewTableRow,
+  .viewTable td span,
+  .table-row-selectable,
+  .detail-item {
+    transition: none;
+  }
+
+  .card:hover,
+  .detail-item:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
**gate-45 reports PASS on this repo — before and after this commit. That is the point.**

This reproduces `.github#287` on openregister: the a11y gate family scans **markup only**, so a `<style>` block inside a `.vue` file is examined and a `.css` file never is.

## Measured

`css/main.css` declares **7 transitions** and had **zero** `prefers-reduced-motion` guards. The earlier gate-45 29 → 0 was real work on markup, but it said nothing about this file — and no gate reading can find it, because no gate opens it.

| selector | motion |
|---|---|
| `.card` | `transition: transform 0.2s ease-in-out` + `:hover` `scale(1.01)` |
| `.nestedCardHeader` | `transition: background-color 0.2s ease` |
| `.toggleButton` | `transition: all 0.2s ease` |
| `.viewTableRow` | `transition: background-color 0.2s ease` |
| `.viewTable td span` | `transition: background-color 0.2s ease` |
| `.table-row-selectable` | `transition: background-color 0.2s ease` |
| `.detail-item` | `transition: transform 0.1s, box-shadow 0.1s` + `:hover` `translateY(-1px)` |

WCAG 2.2 SC 2.3.3 (Animation from Interactions).

## Two deliberate choices

**No `*` rule.** Every selector is listed explicitly. A universal selector in an app stylesheet reaches Nextcloud's own components on the same page, so it would silently change the behaviour of code this app does not own.

**Only motion is removed.** `css/main.css` also has two `transform: translateY(100%)` rules — on `.format-json-button` and `.error-message`. Those are **static positioning, not animation**. A blanket `transform: none` would have moved both elements to the wrong place for precisely the users who asked for less motion. The transform reset is therefore scoped to the two `:hover` rules that actually animate.

The hover transforms are neutralised alongside their transitions, because with the transition gone they would *snap* — the jump this preference exists to avoid. Their non-motion affordances (box-shadow, border, colour) are left alone, so hover still reads as hover.

`css/mail-sidebar.css` declares no motion at all and needs nothing.

## Verification

`npm run stylelint` passes.

Raw `npx stylelint css/main.css` throws a `postcss-selector-parser` TypeError at line 816 — but that **reproduces identically on `development`'s unmodified copy** of the file, so it is pre-existing and not introduced here. (Positive control run before claiming it.)