### PR TITLE
test(e2e): run 40 tests in CI instead of 13 — admit 4 proven-hermetic UI specs

### DIFF
--- a/tests/e2e/ci/playwright.config.ts
+++ b/tests/e2e/ci/playwright.config.ts
@@ -25,6 +25,40 @@
  * `occ`, no docker, and no pre-seeded data. Anything else stays in the root
  * suite and is run deliberately.
  *
+ * HOW THE SET GROWS — `testDir: '..'` + AN EXPLICIT `testMatch` ALLOW-LIST
+ * -----------------------------------------------------------------------
+ * The floor used to be "whatever file sits in `tests/e2e/ci/`", which meant
+ * growing it required MOVING files and rewriting their relative imports. It is
+ * now an explicit allow-list rooted at `tests/e2e`, so a spec is admitted by
+ * naming it here — a one-line, reviewable diff that says exactly which file
+ * started running and can be reverted just as precisely.
+ *
+ * The shared workflow runs `npx playwright test --config="$CONFIG"` with NO
+ * positional path filter (quality.yml, "Run Playwright tests"), so this
+ * config's `testDir` + `testMatch` are the only things deciding what executes.
+ * `playwright-test-path` selects the config and asserts the directory is
+ * non-empty; it does not scope the run.
+ *
+ * ⚠️ ADMISSION CRITERIA — all four, checked per file, and the last two are the
+ * ones that matter most because a suite can be GREEN and still assert nothing:
+ *
+ *   1. Hermetic: no `occ`, no docker, no pre-seeded fixtures.
+ *   2. Non-mutating, or self-cleaning: no `.fill()`/save/delete path that
+ *      leaves rows behind. All four files admitted below only navigate, open a
+ *      modal, and read — they write nothing.
+ *   3. NO UNCONDITIONAL-PASS DEGRADATION. A spec that wraps its assertions in
+ *      `if (await x.isVisible().catch(() => false)) { … }` with no `else`
+ *      PASSES WITHOUT ASSERTING when the data is absent. That is worse than a
+ *      skip, because gate-19 counts its `@e2e` refs as live coverage and the
+ *      run list shows a ✓. `tests/e2e/workflows/dsar-cases.spec.ts` (21 refs)
+ *      is built that way and is deliberately NOT admitted.
+ *   4. NO SEED-DEPENDENT `test.skip()`. The `spec-coverage/mdm-*.spec.ts` files
+ *      state in their own headers that they "degrade to test.skip()" without a
+ *      seed, and CI's own log confirms it every run:
+ *        `pipelinq/masterEntity not found — MDM fixture skipped; MDM specs
+ *         will self-skip.`
+ *      Admitting them would raise the executed count while covering nothing.
+ *
  * ⚠️ `baseURL` comes from the shared resolver, which accepts CI's `BASE_URL`
  * and has NO localhost default — a default would silently target the shared dev
  * container. See tests/e2e/base-url.ts.
@@ -34,7 +68,27 @@ import * as path from 'path'
 import { resolveBaseUrl } from '../base-url'
 
 export default defineConfig({
-	testDir: '.',
+	// Rooted at `tests/e2e` so the allow-list below can admit a spec without
+	// moving it (and without rewriting its `../.auth` / `../base-url` imports).
+	testDir: '..',
+	// EXPLICIT ALLOW-LIST — nothing runs unless it is named here. This is what
+	// keeps `testDir: '..'` from silently pulling in the ~59 other spec files,
+	// including `api-direct/**` (Newman's job, not Playwright's), `visual/**`
+	// (opt-in project, host-font-specific baselines) and `docs-screenshots`
+	// (journeydoc capture).
+	testMatch: [
+		// The original floor.
+		'ci/*.spec.ts',
+		// Admitted 2026-08-10. Genuine behavioural UI specs that assert named
+		// items — a page heading by text, a primary action button by
+		// accessible name — not just "a container rendered". Each was checked
+		// against all four criteria above: zero `test.skip`, zero
+		// conditional-assert guards, and zero write paths.
+		'manifest-shell.spec.ts',
+		'spec-coverage/core-list-pages.spec.ts',
+		'spec-coverage/admin-settings-pages.spec.ts',
+		'spec-coverage/feature-pages.spec.ts',
+	],
 	globalSetup: path.resolve(__dirname, '../global-setup.ts'),
 	timeout: 45_000,
 	expect: { timeout: 15_000 },

--- a/tests/e2e/manifest-shell.spec.ts
+++ b/tests/e2e/manifest-shell.spec.ts
@@ -118,11 +118,25 @@ test.describe('openregister-app-manifest — registry dispatch', () => {
 		// than an exact count so adding a KPI card is not a false regression.
 		expect(await page.locator('.kpi-card').count()).toBeGreaterThanOrEqual(4)
 
-		// A list widget renders either its data table or its empty-state placeholder
-		// (the dashboard always paints the widget body for popular-terms /
-		// objects-by-register / objects-by-schema, regardless of data presence).
+		// A list widget renders either its data table or its empty-state
+		// placeholder — never an unpainted body.
+		//
+		// ⚠️ This asserted `.list-widget-content .stats-table, .list-widget-content
+		// .widget-empty`, and NEITHER half could ever match: `.list-widget-content`
+		// appears nowhere in src/, and `.stats-table` only in
+		// views/settings/sections/StatisticsOverview.vue, which is not the
+		// dashboard. A populated widget renders `CnDataTable`, an empty one
+		// `div.widget-empty` (DashboardIndex.vue, `#widget-objects-by-register`).
+		// The selector went unnoticed because CI never executed this file.
+		//
+		// Scoped to the "Objects by Register" widget by its own title so this
+		// asserts THAT widget's body, not "some table exists on the page".
+		const widget = page.locator('.dashboard-widget, .widget, section, article')
+			.filter({ hasText: /Objects by Register/i })
+			.last()
+		await expect(widget).toBeVisible({ timeout: 15_000 })
 		await expect(
-			page.locator('.list-widget-content .stats-table, .list-widget-content .widget-empty').first(),
+			widget.locator('table tbody tr, .widget-empty').first(),
 		).toBeVisible({ timeout: 15_000 })
 	})
 

--- a/tests/e2e/manifest-shell.spec.ts
+++ b/tests/e2e/manifest-shell.spec.ts
@@ -129,14 +129,19 @@ test.describe('openregister-app-manifest — registry dispatch', () => {
 		// `div.widget-empty` (DashboardIndex.vue, `#widget-objects-by-register`).
 		// The selector went unnoticed because CI never executed this file.
 		//
-		// Scoped to the "Objects by Register" widget by its own title so this
-		// asserts THAT widget's body, not "some table exists on the page".
-		const widget = page.locator('.dashboard-widget, .widget, section, article')
-			.filter({ hasText: /Objects by Register/i })
-			.last()
-		await expect(widget).toBeVisible({ timeout: 15_000 })
+		// Scoped to the dashboard by the stable testid CnDashboardPage renders
+		// on its root. Guessing the per-widget wrapper class was the previous
+		// mistake and it is not needed: assert the widget's own TITLE (an item,
+		// and one that only exists if the manifest's widget list reached the
+		// page), then that the dashboard body paints real rows or an explicit
+		// empty state rather than an unpainted panel.
+		const dash = page.locator('[data-testid="cn-dashboard-page"]').first()
+		await expect(dash).toBeVisible({ timeout: 15_000 })
 		await expect(
-			widget.locator('table tbody tr, .widget-empty').first(),
+			dash.getByText('Objects by Register', { exact: true }).first(),
+		).toBeVisible({ timeout: 15_000 })
+		await expect(
+			dash.locator('table tbody tr, .widget-empty').first(),
 		).toBeVisible({ timeout: 15_000 })
 	})
 

--- a/tests/e2e/spec-coverage/admin-settings-pages.spec.ts
+++ b/tests/e2e/spec-coverage/admin-settings-pages.spec.ts
@@ -118,7 +118,17 @@ test.describe('admin-settings-pages — real UI render + actions', () => {
 		const activeName = (await activeBanner.locator('xpath=..').innerText())
 			.replace(/.*Active Organisation:\s*/is, '').trim()
 		expect(activeName, 'active organisation banner names no organisation').not.toBe('')
-		await expectListSurface(page)
+
+		// NOT expectListSurface(): this page renders a CARD GRID
+		// (`div.card` / `.cardHeader`, OrganisationsIndex.vue), and the shared
+		// helper only knows about tables, lists and empty-content — so it found
+		// nothing here. Asserting the card that carries the ACTIVE
+		// organisation's name is both correct for this page and a stronger item
+		// assertion than "a surface rendered": it ties the list back to the
+		// banner, so a grid of empty cards fails.
+		await expect(
+			page.locator('.card').filter({ hasText: activeName }).first(),
+		).toBeVisible({ timeout: 15_000 })
 		expect(e.console, e.console.join(' | ')).toHaveLength(0)
 		expect(e.http, e.http.join(' | ')).toHaveLength(0)
 	})

--- a/tests/e2e/spec-coverage/admin-settings-pages.spec.ts
+++ b/tests/e2e/spec-coverage/admin-settings-pages.spec.ts
@@ -27,9 +27,14 @@ const NOISE = [
 	// Benign OR bootstrap network-abort race (page still renders fully).
 	'[AppInit]', 'Failed to fetch', 'Failed to load data',
 	// Anonymous browser mirror of a failed request (no URL → can't attribute).
-	// Genuine OR 5xx are still caught by URL in the response tracker below;
+	// Genuine OR 4xx/5xx are still caught BY URL in the response tracker below;
 	// named OR JS errors are NOT matched here and still fail.
 	'Failed to load resource: the server responded with a status of 5',
+	'Failed to load resource: the server responded with a status of 404',
+	// OR probes the OPTIONAL hermiq app's chat health on every page. hermiq is
+	// a separate ExApp and is absent on a stock CI instance, so this 404s on
+	// every route. Filtered BY URL, not by status: any other 404 still fails.
+	'/apps/hermiq/',
 ]
 function isNoise(t: string): boolean { return NOISE.some((n) => t.includes(n)) }
 
@@ -40,8 +45,13 @@ function trackErrors(page: Page): { console: string[]; http: string[] } {
 		const t = m.text()
 		if (!isNoise(t)) errors.console.push(t.slice(0, 160))
 	})
+	// >= 400, not >= 500. The console mirror of a failed request carries NO
+	// url, so suppressing the anonymous 404 line above would have blinded the
+	// test to real 404s. Tracking by URL here is strictly STRONGER than what
+	// this file did before: a genuine 404 now fails the test and NAMES the
+	// endpoint, instead of surfacing as an unattributable console string.
 	page.on('response', (r) => {
-		if (r.status() < 500) return
+		if (r.status() < 400) return
 		const u = r.url()
 		if (!isNoise(u)) errors.http.push(`${r.status()} ${u.replace(/^https?:\/\/[^/]+/, '')}`)
 	})
@@ -89,12 +99,25 @@ async function expectButton(page: Page, name: RegExp): Promise<void> {
 test.describe('admin-settings-pages — real UI render + actions', () => {
 	test.use({ storageState: STORAGE_STATE })
 
-	test('Organisations: heading + Create Organisation + switch + list', async ({ page }) => {
+	test('Organisations: heading + Create Organisation + active organisation + list', async ({ page }) => {
 		const e = trackErrors(page)
 		await gotoPage(page, '/organisation')
 		await expectHeading(page, /^Organisations$/)
 		await expectButton(page, /Create Organisation/i)
-		await expectButton(page, /Switch Organisation/i)
+		// NOT "Switch Organisation": that button is `v-if="userStats.total > 1"`
+		// (OrganisationsIndex.vue), so on a stock instance with exactly one
+		// organisation it correctly does not exist. Asserting it made this test
+		// pass only on a dev container that happened to have several.
+		//
+		// The active-organisation banner is the data-independent equivalent and
+		// is a stronger ITEM assertion: it names the organisation currently in
+		// effect, so it fails if the banner renders an empty or placeholder
+		// value — which an assertion on the banner element alone would not.
+		const activeBanner = page.locator('text=/Active Organisation:/i').first()
+		await expect(activeBanner).toBeVisible({ timeout: 12_000 })
+		const activeName = (await activeBanner.locator('xpath=..').innerText())
+			.replace(/.*Active Organisation:\s*/is, '').trim()
+		expect(activeName, 'active organisation banner names no organisation').not.toBe('')
 		await expectListSurface(page)
 		expect(e.console, e.console.join(' | ')).toHaveLength(0)
 		expect(e.http, e.http.join(' | ')).toHaveLength(0)

--- a/tests/e2e/spec-coverage/core-list-pages.spec.ts
+++ b/tests/e2e/spec-coverage/core-list-pages.spec.ts
@@ -49,6 +49,17 @@ const NOISE = [
 	// errors surface as named messages (e.g. "[reports.fetchDashboards]
 	// AxiosError"), which are NOT matched here and still fail the test.
 	'Failed to load resource: the server responded with a status of 5',
+	// Same argument, same shape, for 404: the mirrored line names no URL, so it
+	// cannot be attributed to OpenRegister. 404s are now tracked BY URL in the
+	// response collector below, where they CAN be named — see the note there.
+	'Failed to load resource: the server responded with a status of 404',
+	// OR probes the OPTIONAL hermiq app's chat health on every page (the OR
+	// chat surface was decommissioned to hermiq in ffafd1c14). hermiq is a
+	// separate ExApp and is absent on a stock CI instance, so this 404s on
+	// every route — it was the single cause of 14 of 16 failures on the first
+	// run of this suite in CI. Filtered BY URL, not by status: any OTHER 404
+	// still fails the test.
+	'/apps/hermiq/',
 ]
 
 function isNoise(text: string): boolean {
@@ -63,8 +74,13 @@ function trackErrors(page: Page): { console: string[]; http: string[] } {
 		const t = m.text()
 		if (!isNoise(t)) errors.console.push(t.slice(0, 160))
 	})
+	// >= 400, not >= 500. Suppressing the anonymous 404 console line without
+	// this would have made the suite BLIND to 404s — the exact trade the
+	// 5xx entry above already makes, and it only holds because the failure is
+	// still caught here, by URL. This is strictly stronger than before: a
+	// genuine 404 now fails the test and NAMES the endpoint.
 	page.on('response', (r) => {
-		if (r.status() < 500) return
+		if (r.status() < 400) return
 		const u = r.url()
 		if (!isNoise(u)) errors.http.push(`${r.status()} ${u.replace(/^https?:\/\/[^/]+/, '')}`)
 	})

--- a/tests/e2e/spec-coverage/feature-pages.spec.ts
+++ b/tests/e2e/spec-coverage/feature-pages.spec.ts
@@ -32,9 +32,14 @@ const NOISE = [
 	// Benign OR bootstrap network-abort race (page still renders fully).
 	'[AppInit]', 'Failed to fetch', 'Failed to load data',
 	// Anonymous browser mirror of a failed request (no URL → can't attribute).
-	// Genuine OR 5xx are still caught by URL in the response tracker; named OR
-	// JS errors are NOT matched here and still fail.
+	// Genuine OR 4xx/5xx are still caught BY URL in the response tracker; named
+	// OR JS errors are NOT matched here and still fail.
 	'Failed to load resource: the server responded with a status of 5',
+	'Failed to load resource: the server responded with a status of 404',
+	// OR probes the OPTIONAL hermiq app's chat health on every page. hermiq is
+	// a separate ExApp and is absent on a stock CI instance, so this 404s on
+	// every route. Filtered BY URL, not by status: any other 404 still fails.
+	'/apps/hermiq/',
 ]
 function isNoise(t: string): boolean { return NOISE.some((n) => t.includes(n)) }
 
@@ -47,8 +52,13 @@ function trackErrors(page: Page, extraNoise: string[] = []): { console: string[]
 		const t = m.text()
 		if (!noisy(t)) errors.console.push(t.slice(0, 160))
 	})
+	// >= 400, not >= 500. The console mirror of a failed request carries NO
+	// url, so suppressing the anonymous 404 line above would have blinded the
+	// test to real 404s. Tracking by URL here is strictly STRONGER than what
+	// this file did before: a genuine 404 now fails the test and NAMES the
+	// endpoint, instead of surfacing as an unattributable console string.
 	page.on('response', (r) => {
-		if (r.status() < 500) return
+		if (r.status() < 400) return
 		const u = r.url()
 		if (!noisy(u)) errors.http.push(`${r.status()} ${u.replace(/^https?:\/\/[^/]+/, '')}`)
 	})
@@ -156,5 +166,50 @@ test.describe('feature-pages — real UI render + actions', () => {
 		await expectButton(page, /Show roadmap/i)
 		expect(e.console, e.console.join(' | ')).toHaveLength(0)
 		expect(e.http, e.http.join(' | ')).toHaveLength(0)
+	})
+
+	/**
+	 * The nav entry is a real router destination, not a decorative row.
+	 *
+	 * Asserts the ITEM, not the container: the specific nav entry
+	 * `FeaturesRoadmapMenu` (the manifest id, rendered by CnAppNav as
+	 * `data-testid="cn-nav-entry-<id>"`), the resulting hash route, and the
+	 * `.cn-features-and-roadmap-view` root that CnFeaturesAndRoadmapView
+	 * itself renders. Then it resolves the view's ANCESTRY, which is the only
+	 * way to tell the spec's two outcomes apart — "renders in the main content
+	 * area" and "renders as an overlay" both look like a visible view.
+	 *
+	 * Starts from /registers so the click is a genuine route TRANSITION; a test
+	 * that begins on the target route would pass without navigating at all.
+	 *
+	 * @e2e openspec/specs/features-roadmap-menu/spec.md#clicking-the-nav-entry-navigates-to-the-route
+	 */
+	test('clicking the Features & Roadmap nav entry routes to it in the main content area', async ({ page }) => {
+		await gotoPage(page, '/registers')
+		await expect(page).toHaveURL(/#\/registers$/)
+
+		// The manifest declares this entry in the `footer` section; CnAppNav
+		// renders footer entries as NcAppNavigationItem router-links.
+		const navEntry = page.locator('[data-testid="cn-nav-entry-FeaturesRoadmapMenu"]')
+		await expect(navEntry).toHaveCount(1)
+		await navEntry.first().click()
+
+		await expect(page).toHaveURL(/#\/features-roadmap$/, { timeout: 15_000 })
+
+		const view = page.locator('.cn-features-and-roadmap-view')
+		await expect(view).toBeVisible({ timeout: 15_000 })
+
+		// "in the main content area, NOT as an overlay" — assert both halves.
+		// `closest()` walks real ancestors, so a view teleported into a dialog
+		// or a modal mask fails here even though it is perfectly visible.
+		const overlayAncestor = await view.first().evaluate(
+			(el) => !!el.closest('[role="dialog"], .modal-container, .modal-mask, .modal-wrapper'),
+		)
+		expect(overlayAncestor, 'view rendered inside an overlay').toBe(false)
+
+		const contentAncestor = await view.first().evaluate(
+			(el) => !!el.closest('#app-content-vue, .app-content'),
+		)
+		expect(contentAncestor, 'view not rendered inside the app content area').toBe(true)
 	})
 })


### PR DESCRIPTION
## What CI actually ran

`playwright-test-path: tests/e2e/ci` selects a config whose `testDir` was `.`. Measured from `development`'s own **push** run at `33860f78` (run [31388244178](https://github.com/ConductionNL/openregister/actions/runs/31388244178), 27 jobs, 24 success / 3 skipped, zero cancelled):

```
Running 13 tests using 1 worker
13 passed (1.8m)
```

**13 tests, 4 files — against 63 spec files in the repo.**

## Change

Root the CI config at `tests/e2e` and gate it with an explicit `testMatch` allow-list, so a spec is admitted by **naming it** rather than by being moved. Nothing runs unless listed, so `api-direct/**` (Newman's job), `visual/**` (opt-in, host-font-specific baselines) and `docs-screenshots` stay out.

Verified the mechanism: the shared workflow runs `npx playwright test --config="$CONFIG"` with **no positional path filter**, so this config alone decides what executes.

**13 → 41 executed tests, 4 → 8 files.** 27 of the 28 added tests already existed; 25 of them passed unchanged, and 2 needed a selector fix (see below) because nothing had ever run them. Only 1 test is newly written.

## Why these four files, and not the others

Admitted: `manifest-shell` (9), `spec-coverage/core-list-pages` (7), `spec-coverage/admin-settings-pages` (6), `spec-coverage/feature-pages` (5+1 new). All assert named **items** — a heading by text, a button by accessible name — and all write nothing.

Held back, because a green suite can still assert nothing:

- **`workflows/dsar-cases.spec.ts` (21 refs)** wraps assertions in `if (await x.isVisible().catch(() => false)) { … }` with **no `else`**. Unseeded, the body runs nothing and the test **passes** — worse than a skip, since gate-19 counts the refs and the run list shows a tick. Separately, all 21 refs point at `openspec/specs/dsar-case-list/` and `dsar-case-detail-actions/`, **neither of which exists** (never synced out of `openspec/changes/dsar-case-ui/`).
- **`spec-coverage/mdm-*.spec.ts`** say in their own headers that they "degrade to `test.skip()`" without a seed — and CI's log confirms it every run: `pipelinq/masterEntity not found — MDM fixture skipped; MDM specs will self-skip.`
- **`spec-coverage/saved-search-views.spec.ts`** carries 19 `test.skip(true, …)` escape hatches that fire exactly when the UI is broken.
- **Mutating specs** create fixtures and are held pending a cleanup story.

No `@e2e exclude` was added anywhere.

## What the first CI run found — three real faults, none in the pages under test

The first run was 40 tests / 16 failed. Every trace was inspected; across **all 32 of them the only 4xx/5xx anywhere** was:

```
404 /index.php/apps/hermiq/api/chat/health
```

1. **14 failures — one optional-app 404.** OR probes the optional hermiq ExApp on every page; hermiq is present on the dev container and absent in CI, which is exactly why local screening was green and CI was not. Filtered **by URL**, and because the browser mirrors a failed request as an anonymous console line with no URL, the response collector now tracks **>= 400 instead of >= 500** — so a genuine 404 fails the test and *names* the endpoint. Strictly stronger than before.

2. **`manifest-shell` dashboard widgets — a selector that could never match.** It asserted `.list-widget-content .stats-table`. `.list-widget-content` appears **nowhere** in `src/`, and `.stats-table` only in a settings section. The failure screenshot shows the dashboard rendering perfectly. Now scoped to `[data-testid="cn-dashboard-page"]`, asserting the widget's own title and that its body paints rows or an explicit `.widget-empty`.

3. **`admin-settings-pages` Organisations — two data-dependent assumptions.** It asserted a `Switch Organisation` button that is `v-if="userStats.total > 1"` (a stock instance has one org), then `expectListSurface()`, which knows tables/lists but not this page's **card grid**. Now asserts the active-organisation banner and the card carrying that organisation's name — data-independent, and stronger than "a surface rendered".

Both selector faults are rot that survived precisely because CI never executed these files.

## Coverage added

One new test, `clicking the Features & Roadmap nav entry routes to it in the main content area`, covering `features-roadmap-menu::clicking-the-nav-entry-navigates-to-the-route`. It clicks the real nav entry from a different route and then resolves the view's **ancestry**, which is the only way to separate the scenario's two outcomes — "renders in the main content area" and "renders as an overlay" both look like a visible view.

Proven able to fail: passes as written; inverting its two ancestry expectations fails **at that assertion** (`view rendered inside an overlay / Expected: true / Received: false` — a computed DOM value, not a constant); restored, it passes again.

**gate-19: 796 → 795 uncovered, 64 → 65 covered.** The delta is exactly the one scenario anchored, nothing more. Measured at repo root with the current helper (`.github` `6b5baac`), 0-byte stderr on both runs.

⚠️ Note the gate cannot see this: gate-19 reads only the **root** `playwright.config.ts`, while CI runs `tests/e2e/ci/`. Before this PR every one of the 64 "covered" refs lived in a file CI never executed. Filed as [.github#331](https://github.com/ConductionNL/.github/issues/331).

## Left red deliberately

`features-roadmap-menu`'s `alphabetical-ordering`, `feature-docsurl-link-safety` and `empty-features-manifest` are **not** anchored: `docs/features.json` is generated by `prebuild` but never reaches the UI (`loadState('openregister','features_roadmap_features', [])` has no provider anywhere in the repo), so the Features tab renders the empty state on every instance. Anchoring `empty-features-manifest` today would cement a bug as expected behaviour. Filed as #2412.
