### PR TITLE
fix(flow): all four red jobs on development are one rename that stopped halfway

### DIFF
--- a/lib/Listener/FlowNodeRegistrationListener.php
+++ b/lib/Listener/FlowNodeRegistrationListener.php
@@ -65,7 +65,7 @@ class FlowNodeRegistrationListener implements IEventListener
      * @param FilterNode          $filter          The built-in "Filter" node.
      * @param WaitNode            $wait            The built-in "Wait" node.
      * @param SwitchNode          $switch          The built-in "Switch" node.
-     * @param EndNode            $stop            The built-in "Stop" node.
+     * @param EndNode             $end             The built-in "End" node.
      * @param MergeNode           $merge           The built-in "Merge" node.
      * @param LoopNode            $loop            The built-in "Loop over items" node.
      * @param SubFlowNode         $subFlow         The built-in "Run a flow" node.
@@ -85,7 +85,7 @@ class FlowNodeRegistrationListener implements IEventListener
         private readonly FilterNode $filter,
         private readonly WaitNode $wait,
         private readonly SwitchNode $switch,
-        private readonly EndNode $stop,
+        private readonly EndNode $end,
         private readonly MergeNode $merge,
         private readonly LoopNode $loop,
         private readonly SubFlowNode $subFlow,
@@ -122,7 +122,7 @@ class FlowNodeRegistrationListener implements IEventListener
         $event->registerNode(node: $this->filter);
         $event->registerNode(node: $this->wait);
         $event->registerNode(node: $this->switch);
-        $event->registerNode(node: $this->stop);
+        $event->registerNode(node: $this->end);
         $event->registerNode(node: $this->merge);
         $event->registerNode(node: $this->loop);
         $event->registerNode(node: $this->subFlow);

--- a/lib/Service/Flow/FlowConcurrency.php
+++ b/lib/Service/Flow/FlowConcurrency.php
@@ -51,6 +51,7 @@ namespace OCA\OpenRegister\Service\Flow;
 use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Promise\EachPromise;
 use GuzzleHttp\Promise\PromiseInterface;
+use RuntimeException;
 use Throwable;
 
 /**
@@ -104,6 +105,14 @@ class FlowConcurrency
      *         result per input item, in INPUT order.
      *
      * @spec openspec/specs/flow-engine/spec.md#requirement-a-node-that-calls-out-per-item-must-be-able-to-do-so-concurrently
+     *
+     * @SuppressWarnings(PHPMD.StaticAccess) `GuzzleHttp\Promise\Create` is a
+     * third-party STATIC FACTORY with no instance API — `rejectionFor()` and
+     * `promiseFor()` are the library's only supported way to lift a value or a
+     * throwable into a promise. Satisfying the rule would mean injecting a
+     * wrapper whose entire body is the same two static calls, which moves the
+     * static access one file sideways and buys nothing. The two calls are
+     * two lines apart in one generator, both visible above.
      */
     public function map(array $items, callable $work, ?int $limit=null): array
     {
@@ -149,7 +158,7 @@ class FlowConcurrency
                 'rejected'    => static function ($reason, $index) use (&$results): void {
                     $error = $reason;
                     if (($reason instanceof Throwable) === false) {
-                        $error = new \RuntimeException((string) $reason);
+                        $error = new RuntimeException((string) $reason);
                     }
 
                     $results[$index] = ['ok' => false, 'value' => null, 'error' => $error];

--- a/lib/Service/Flow/FlowConnectivity.php
+++ b/lib/Service/Flow/FlowConnectivity.php
@@ -144,8 +144,58 @@ class FlowConnectivity
             return [];
         }
 
+        $rolesPresent = $this->rolesPresent(nodes: $nodes);
+        $findings     = [];
+
+        if ($rolesPresent['trigger'] === false) {
+            $findings[] = [
+                'type'   => '',
+                'app'    => '',
+                'step'   => '',
+                'reason' => FlowNodePreflight::REASON_NO_TRIGGER,
+                'detail' => 'This flow has no trigger node, so nothing can ever start it. '
+                    .'Add a trigger — an object change, a schedule, or someone running it by hand.',
+            ];
+        }
+
+        if ($rolesPresent['end'] === false) {
+            $findings[] = [
+                'type'   => '',
+                'app'    => '',
+                'step'   => '',
+                'reason' => FlowNodePreflight::REASON_NO_END,
+                'detail' => 'This flow has no end node, so no path finishes deliberately. '
+                    .'Add an End node — it may end in success or in error, but the flow must say where it stops.',
+            ];
+        }
+
+        return $findings;
+
+    }//end entryAndExit()
+
+    /**
+     * Which of the two ROLES the document actually contains.
+     *
+     * Extracted from `entryAndExit()`, which sat exactly on the configured
+     * thresholds (Cyclomatic 10 of 10, NPath 204 of 200). The split is along a
+     * real seam rather than an arbitrary one: this method answers "what is in
+     * the document", and its caller answers "what should the author be told".
+     *
+     * `exit: true` is deliberately NOT consulted. That flag marks a node as
+     * ending this PATH, which is what the dead-end check honours; it does not
+     * make the FLOW's exit deliberate. It is a per-instance escape for migrated
+     * documents, not a node that says "the flow finishes here", so a flow whose
+     * only exit is a flag still has no end node and is told so.
+     *
+     * @param array<int|string, mixed> $nodes The document's nodes.
+     *
+     * @return array{trigger: bool, end: bool} Which roles are present.
+     */
+    private function rolesPresent(array $nodes): array
+    {
         $hasTrigger = false;
         $hasEnd     = false;
+
         foreach ($nodes as $node) {
             if (is_array($node) === false) {
                 continue;
@@ -163,42 +213,14 @@ class FlowConnectivity
             if ($this->registry->isEnd(type: $type) === true) {
                 $hasEnd = true;
             }
-
-            // `exit: true` marks a node as ending this PATH, which is what the
-            // dead-end check honours. It does NOT make the flow's exit
-            // deliberate in the sense this check is about: the flag is a
-            // per-instance escape for migrated documents, not a node that says
-            // "the flow finishes here". A flow whose only exit is a flag still
-            // has no end node, and is told so.
         }//end foreach
 
-        $findings = [];
+        return [
+            'trigger' => $hasTrigger,
+            'end'     => $hasEnd,
+        ];
 
-        if ($hasTrigger === false) {
-            $findings[] = [
-                'type'   => '',
-                'app'    => '',
-                'step'   => '',
-                'reason' => FlowNodePreflight::REASON_NO_TRIGGER,
-                'detail' => 'This flow has no trigger node, so nothing can ever start it. '
-                    .'Add a trigger — an object change, a schedule, or someone running it by hand.',
-            ];
-        }
-
-        if ($hasEnd === false) {
-            $findings[] = [
-                'type'   => '',
-                'app'    => '',
-                'step'   => '',
-                'reason' => FlowNodePreflight::REASON_NO_END,
-                'detail' => 'This flow has no end node, so no path finishes deliberately. '
-                    .'Add an End node — it may end in success or in error, but the flow must say where it stops.',
-            ];
-        }
-
-        return $findings;
-
-    }//end entryAndExit()
+    }//end rolesPresent()
 
     /**
      * Every node id that some edge leaves from.

--- a/lib/Service/Flow/FlowLocator.php
+++ b/lib/Service/Flow/FlowLocator.php
@@ -262,7 +262,28 @@ class FlowLocator
             }
         }//end foreach
 
+        return $this->dispatchableUuids(matched: $matched, event: $event);
+
+    }//end flowsForTrigger()
+
+    /**
+     * The uuids of the matched flows that can actually be dispatched.
+     *
+     * Extracted from `flowsForTrigger()`, which sat exactly on the configured
+     * Cyclomatic Complexity threshold (10 of 10). Behaviour is unchanged: the
+     * ownerless flow is still skipped and still says out loud why, which is the
+     * point — a flow that matched and then vanished without a word is the
+     * silent-engine failure the cutover work exists to prevent.
+     *
+     * @param array<string, Flow> $matched The flows that matched, by uuid.
+     * @param string              $event   The trigger being resolved, for the log line.
+     *
+     * @return array<int, string> The dispatchable flow uuids.
+     */
+    private function dispatchableUuids(array $matched, string $event): array
+    {
         $ids = [];
+
         foreach ($matched as $uuid => $flow) {
             if ($flow->canDispatch() === false) {
                 $this->logger->warning(
@@ -278,7 +299,7 @@ class FlowLocator
 
         return $ids;
 
-    }//end flowsForTrigger()
+    }//end dispatchableUuids()
 
     /**
      * The flows that run on a cron schedule.

--- a/lib/Service/Flow/FlowNodeRegistry.php
+++ b/lib/Service/Flow/FlowNodeRegistry.php
@@ -354,7 +354,7 @@ class FlowNodeRegistry
      *
      * @return bool True when the type is registered and marks itself an end.
      *
-     * @spec openspec/specs/flow-engine/spec.md#requirement-a-node-declares-whether-it-starts-or-stops-a-path
+     * @spec openspec/specs/flow-engine/spec.md#requirement-a-node-declares-whether-it-triggers-or-ends-a-path
      */
     public function isEnd(string $type): bool
     {
@@ -381,7 +381,7 @@ class FlowNodeRegistry
      *
      * @return bool True when the type is registered and marks itself a trigger.
      *
-     * @spec openspec/specs/flow-engine/spec.md#requirement-a-node-declares-whether-it-starts-or-stops-a-path
+     * @spec openspec/specs/flow-engine/spec.md#requirement-a-node-declares-whether-it-triggers-or-ends-a-path
      */
     public function isTrigger(string $type): bool
     {
@@ -414,7 +414,7 @@ class FlowNodeRegistry
      *
      * @return string `'trigger'`, `'end'` or `'step'`.
      *
-     * @spec openspec/specs/flow-engine/spec.md#requirement-a-node-declares-whether-it-starts-or-stops-a-path
+     * @spec openspec/specs/flow-engine/spec.md#requirement-a-node-declares-whether-it-triggers-or-ends-a-path
      */
     public function roleOf(string $type): string
     {
@@ -432,18 +432,6 @@ class FlowNodeRegistry
 
     }//end roleOf()
 
-    /**
-     * The role of a node INSTANCE the caller already holds.
-     *
-     * The one place the two marker interfaces are read, so `roleOf()`,
-     * `palette()` and anything added later cannot answer differently.
-     *
-     * @param IFlowNode $node The node.
-     *
-     * @return string `'trigger'`, `'end'` or `'step'`.
-     *
-     * @spec openspec/specs/flow-engine/spec.md#requirement-a-node-declares-whether-it-starts-or-stops-a-path
-     */
     /**
      * The old ids that still resolve to a type.
      *
@@ -468,6 +456,18 @@ class FlowNodeRegistry
 
     }//end aliasesFor()
 
+    /**
+     * The role of a node INSTANCE the caller already holds.
+     *
+     * The one place the two marker interfaces are read, so `roleOf()`,
+     * `palette()` and anything added later cannot answer differently.
+     *
+     * @param IFlowNode $node The node.
+     *
+     * @return string `'trigger'`, `'end'` or `'step'`.
+     *
+     * @spec openspec/specs/flow-engine/spec.md#requirement-a-node-declares-whether-it-triggers-or-ends-a-path
+     */
     private function roleFor(IFlowNode $node): string
     {
         if (($node instanceof IFlowTriggerNode) === true) {

--- a/lib/Service/Flow/FlowService.php
+++ b/lib/Service/Flow/FlowService.php
@@ -207,17 +207,12 @@ class FlowService
      */
     public function save(array $data, ?string $uuid=null): Flow
     {
-        $isCreate = ($uuid === null || $uuid === '');
-        $flow     = $this->flowToSave(data: $data, uuid: $uuid);
+        $flow = $this->flowToSave(data: $data, uuid: $uuid);
 
         $this->applyEditableFields(flow: $flow, data: $data);
         $flow->setUpdated(new DateTime());
 
-        if ($isCreate === true) {
-            $stored = $this->mapper->insert($flow);
-        } else {
-            $stored = $this->mapper->update($flow);
-        }
+        $stored = $this->persistFlow(flow: $flow, uuid: $uuid);
 
         // Re-derive the trigger index from the nodes that were just saved.
         // AFTER the write, so the index can never name a subscription the
@@ -228,6 +223,32 @@ class FlowService
         return $stored;
 
     }//end save()
+
+    /**
+     * Insert a new flow, or update the existing one.
+     *
+     * Extracted from `save()` so the create/update branch is expressed as two
+     * returns rather than an if/else — the `ElseExpression` rule is on in
+     * phpmd.xml, and the alternatives were worse: assigning in both arms of an
+     * `if`/`if` leaves `$stored` possibly-undefined for Psalm and PHPStan, and a
+     * ternary trips the `Inline IF statements are not allowed` sniff in
+     * phpcs.xml. It takes the uuid rather than a boolean so it does not
+     * introduce a `BooleanArgumentFlag` finding in place of the one it removes.
+     *
+     * @param Flow        $flow The flow to write.
+     * @param string|null $uuid The flow being updated, or null/empty to create.
+     *
+     * @return Flow The stored flow, as the mapper returned it.
+     */
+    private function persistFlow(Flow $flow, ?string $uuid): Flow
+    {
+        if ($uuid === null || $uuid === '') {
+            return $this->mapper->insert($flow);
+        }
+
+        return $this->mapper->update($flow);
+
+    }//end persistFlow()
 
     /**
      * The flow a save() will write to: a fresh one, or the caller's existing one.

--- a/lib/Service/Flow/FlowTriggerDerivation.php
+++ b/lib/Service/Flow/FlowTriggerDerivation.php
@@ -221,6 +221,61 @@ class FlowTriggerDerivation
         $columns = $this->columnTriggerOf(flow: $flow);
         $nodes   = $this->objectTriggersOf(flow: $flow);
 
+        $decided = $this->verdictWithoutComparing(columns: $columns, nodes: $nodes);
+        if ($decided !== null) {
+            return $decided;
+        }
+
+        foreach ($nodes as $node) {
+            if ($node !== $columns) {
+                continue;
+            }
+
+            $reason = 'exact match';
+            if (count($nodes) > 1) {
+                $reason = 'the column trigger is among the node triggers; the extra node triggers are NEW';
+            }
+
+            return [
+                'equivalent' => true,
+                'reason'     => $reason,
+                'columns'    => $columns,
+                'nodes'      => $nodes,
+            ];
+        }
+
+        return [
+            'equivalent' => false,
+            'reason'     => 'no node trigger matches the column trigger',
+            'columns'    => $columns,
+            'nodes'      => $nodes,
+        ];
+
+    }//end compare()
+
+    /**
+     * The verdicts reachable without comparing one trigger to another.
+     *
+     * Extracted from `compare()`, which sat exactly on the configured
+     * Cyclomatic Complexity threshold (10 of 10). The seam is real rather than
+     * arbitrary: every branch here is decided by what EXISTS on each side, and
+     * the caller keeps the one question that needs the two sides held together
+     * — does any node trigger equal the column trigger.
+     *
+     * THE ORDER OF THESE FOUR CHECKS IS LOAD-BEARING and is unchanged. The
+     * unscoped-column case must be judged before any equality test, because a
+     * `*` register or schema is not a value a node can hold: comparing it would
+     * report "no node matches" and read as a re-authoring gap, when the truth is
+     * that the column trigger cannot be expressed as a node at all.
+     *
+     * @param array{event: string, register: string, schema: string}|null        $columns The column trigger.
+     * @param array<int, array{event: string, register: string, schema: string}> $nodes   The node triggers.
+     *
+     * @return array{equivalent: bool, reason: string, columns: array|null, nodes: array}|null The
+     *         verdict, or null when the two sides must actually be compared.
+     */
+    private function verdictWithoutComparing(?array $columns, array $nodes): ?array
+    {
         if ($columns === null && $nodes === []) {
             return [
                 'equivalent' => true,
@@ -257,30 +312,7 @@ class FlowTriggerDerivation
             ];
         }
 
-        foreach ($nodes as $node) {
-            if ($node !== $columns) {
-                continue;
-            }
+        return null;
 
-            $reason = 'exact match';
-            if (count($nodes) > 1) {
-                $reason = 'the column trigger is among the node triggers; the extra node triggers are NEW';
-            }
-
-            return [
-                'equivalent' => true,
-                'reason'     => $reason,
-                'columns'    => $columns,
-                'nodes'      => $nodes,
-            ];
-        }
-
-        return [
-            'equivalent' => false,
-            'reason'     => 'no node trigger matches the column trigger',
-            'columns'    => $columns,
-            'nodes'      => $nodes,
-        ];
-
-    }//end compare()
+    }//end verdictWithoutComparing()
 }//end class

--- a/lib/Service/Flow/IFlowTriggerNode.php
+++ b/lib/Service/Flow/IFlowTriggerNode.php
@@ -37,7 +37,7 @@
  *
  * @link https://OpenRegister.app
  *
- * @spec openspec/specs/flow-engine/spec.md#requirement-a-node-declares-whether-it-starts-or-stops-a-path
+ * @spec openspec/specs/flow-engine/spec.md#requirement-a-node-declares-whether-it-triggers-or-ends-a-path
  */
 
 declare(strict_types=1);

--- a/lib/Service/Flow/Nodes/TriggerObjectNode.php
+++ b/lib/Service/Flow/Nodes/TriggerObjectNode.php
@@ -134,7 +134,8 @@ class TriggerObjectNode implements IFlowNode, IFlowNodeConfigKeys, IFlowTriggerN
     public function getDescription(): string
     {
         return $this->l10n->t(
-            'Start the flow when one kind of object is created, updated or deleted. One event, one register, one schema — use a mapping node to normalise other shapes.'
+            'Start the flow when one kind of object is created, updated or deleted. '
+            .'One event, one register, one schema — use a mapping node to normalise other shapes.'
         );
 
     }//end getDescription()
@@ -219,7 +220,8 @@ class TriggerObjectNode implements IFlowNode, IFlowNodeConfigKeys, IFlowTriggerN
             if (trim((string) ($config[$key] ?? '')) === '') {
                 throw new InvalidArgumentException(
                     sprintf(
-                        'An object trigger must name one "%s". A trigger with no %s either matches nothing and never fires, or matches everything — and both are silent.',
+                        'An object trigger must name one "%s". A trigger with no %s either matches nothing '
+                        .'and never fires, or matches everything — and both are silent.',
                         $key,
                         $key
                     )

--- a/lib/Service/Flow/Nodes/TriggerScheduleNode.php
+++ b/lib/Service/Flow/Nodes/TriggerScheduleNode.php
@@ -162,17 +162,23 @@ class TriggerScheduleNode implements IFlowNode, IFlowNodeConfigKeys, IFlowTrigge
         $cron = trim((string) ($config['cron'] ?? ''));
         if ($cron === '') {
             throw new InvalidArgumentException(
-                'A schedule trigger must carry a "cron" expression — without one nothing ever starts it, which is indistinguishable from a flow with nothing to do.'
+                'A schedule trigger must carry a "cron" expression — without one nothing ever starts it, '
+                .'which is indistinguishable from a flow with nothing to do.'
             );
         }
 
         $fields = preg_split('/\s+/', $cron);
         if (is_array($fields) === false || count($fields) !== 5) {
+            $fieldCount = 0;
+            if (is_array($fields) === true) {
+                $fieldCount = count($fields);
+            }
+
             throw new InvalidArgumentException(
                 sprintf(
                     'A cron expression has five space-separated fields (minute hour day month weekday); "%s" has %d.',
                     $cron,
-                    (is_array($fields) === true) ? count($fields) : 0
+                    $fieldCount
                 )
             );
         }

--- a/tests/Unit/Service/Flow/EndNodeTest.php
+++ b/tests/Unit/Service/Flow/EndNodeTest.php
@@ -1,14 +1,21 @@
 <?php
 
 /**
- * A stop only stops the branch that was actually taken.
+ * An end node only ends the branch that was actually taken.
  *
  * These tests exist because the distinction is invisible in the graph. After a
  * route, `FlowEngine::advanceItems()` marks EVERY place on the transition's
  * `to` list and distributes items to them by output tag — so the branch the
  * router did not choose is marked and holds zero items, and its steps still
- * fire. Item-driven nodes shrug that off; a stop did not, and ended the run on
- * a guard that had not tripped.
+ * fire. Item-driven nodes shrug that off; the end node did not, and ended the
+ * run on a guard that had not tripped.
+ *
+ * NAMING. The node is `EndNode` and the role is `end`; `FlowStop` keeps its
+ * name because it is a different thing — the control-flow EXCEPTION the engine
+ * throws to stop a run, not a node role. The three-names-for-one-idea problem
+ * that 4eac3a3 and 7ba3c21 set out to fix was about the NODE (id `stop`, class
+ * `StopNode`, interface `terminal`), and renaming the exception with it would
+ * re-merge two ideas that are deliberately separate.
  *
  * @category Test
  * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
@@ -30,7 +37,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \OCA\OpenRegister\Service\Flow\Nodes\EndNode
  */
-final class StopNodeTest extends TestCase
+final class EndNodeTest extends TestCase
 {
 
     /**
@@ -57,25 +64,25 @@ final class StopNodeTest extends TestCase
 
 
     /**
-     * A stop that received items ends the run, as an error when configured so.
+     * An end node that received items ends the run, as an error when configured so.
      *
      * The guard test below is only meaningful next to this one: a node that
-     * stopped stopping would pass that test and be useless.
+     * stopped ending anything at all would pass that test and be useless.
      *
      * @return void
      */
-    public function testAStopWithItemsEndsTheRun(): void
+    public function testAnEndWithItemsEndsTheRun(): void
     {
         $this->expectException(FlowStop::class);
         $this->expectExceptionMessage('the tip moved');
 
         $this->node->execute([['json' => ['a' => 1]]], ['error' => true, 'message' => 'the tip moved'], []);
 
-    }//end testAStopWithItemsEndsTheRun()
+    }//end testAnEndWithItemsEndsTheRun()
 
 
     /**
-     * A stop on a branch the router did NOT choose passes through.
+     * An end node on a branch the router did NOT choose passes through.
      *
      * Measured on hydra's commit-by-API flow before this: every step through
      * `move-ref` completed and the branch ref genuinely moved on GitHub, while
@@ -86,28 +93,28 @@ final class StopNodeTest extends TestCase
      *
      * @return void
      */
-    public function testAStopOnAnUntakenBranchDoesNotEndTheRun(): void
+    public function testAnEndOnAnUntakenBranchDoesNotEndTheRun(): void
     {
         $out = $this->node->execute([], ['error' => true, 'message' => 'the tip moved'], []);
 
         $this->assertSame([], $out);
 
-    }//end testAStopOnAnUntakenBranchDoesNotEndTheRun()
+    }//end testAnEndOnAnUntakenBranchDoesNotEndTheRun()
 
 
     /**
-     * The same holds for a clean (non-error) stop.
+     * The same holds for a clean (non-error) end.
      *
-     * A clean stop on an untaken branch is quieter but no less wrong: it ends
+     * A clean end on an untaken branch is quieter but no less wrong: it ends
      * the run early, so every step after the router never runs.
      *
      * @return void
      */
-    public function testACleanStopOnAnUntakenBranchAlsoPassesThrough(): void
+    public function testACleanEndOnAnUntakenBranchAlsoPassesThrough(): void
     {
         $out = $this->node->execute([], ['error' => false, 'message' => 'nothing to do'], []);
 
         $this->assertSame([], $out);
 
-    }//end testACleanStopOnAnUntakenBranchAlsoPassesThrough()
+    }//end testACleanEndOnAnUntakenBranchAlsoPassesThrough()
 }//end class

--- a/tests/Unit/Service/Flow/FlowLogicTest.php
+++ b/tests/Unit/Service/Flow/FlowLogicTest.php
@@ -291,7 +291,7 @@ class FlowLogicTest extends TestCase
     }
 }
 
-class SwitchAndStopNodeTest extends TestCase
+class SwitchAndEndNodeTest extends TestCase
 {
     private function l10n(): IL10N
     {

--- a/tests/e2e/ci/flow-controls.spec.ts
+++ b/tests/e2e/ci/flow-controls.spec.ts
@@ -254,7 +254,7 @@ test('flow controls render, and a flow can be built, saved and run', async ({ pa
 		// which made the saved flow UNRUNNABLE: since #2354 a path must end
 		// deliberately, and `FlowRunService::queue()` refuses any node that has
 		// no outgoing edge and is not terminal — which `set-fields` is not.
-		// Only `StopNode` implements IFlowTerminalNode, so a lone `set-fields`
+		// Only `EndNode` implements `IFlowEndNode`, so a lone `set-fields`
 		// node is a dead end by construction and step 4 below could never pass
 		// on it. Measured: every run of this spec that actually persisted the
 		// step failed, and the only runs that went green were the ones where
@@ -268,9 +268,15 @@ test('flow controls render, and a flow can be built, saved and run', async ({ pa
 		// `set-fields` to `stop` would cover more, but drag-to-connect on the
 		// canvas is exactly the interaction this file already documents as
 		// unreliable, and a fixture that flakes is how this started.
-		await clickThemed(palette.getByText('Stop', { exact: true }).first())
+		//
+		// THE LABEL IS 'End', NOT 'Stop'. The vocabulary moved twice in quick
+		// succession — terminal -> stop (4eac3a3), then stop -> end (7ba3c21) —
+		// and this locator was left on the middle spelling. That is the whole
+		// reason the job went red: `EndNode::getLabel()` returns `t('End')`, and
+		// the palette has carried no entry called "Stop" since that commit.
+		await clickThemed(palette.getByText('End', { exact: true }).first())
 		await expect(
-			page.locator('main').getByText('Stop', { exact: false }).first(),
+			page.locator('main').getByText('End', { exact: false }).first(),
 			'the step did not reach the canvas',
 		).toBeVisible()
 


### PR DESCRIPTION

`development` has been failing PHP Quality (phpcs), PHP Quality (phpmd), E2E
Tests (Playwright) and Hydra Gates since 7ba3c21. They are not four problems.
They are one: the flow vocabulary moved twice in quick succession — terminal ->
stop (4eac3a3), then stop -> end (7ba3c21) — and four different kinds of
reference were left on a spelling that no longer exists.

HYDRA GATES (gate-46, 5 findings from 1 target). 7ba3c21 renamed the spec
heading to "A node declares whether it triggers or ends a path" and left five
@spec anchors pointing at #requirement-a-node-declares-whether-it-starts-or-
stops-a-path. Every target FILE resolved, which is why this reads as an anchor
problem rather than a missing document. Retargeted, in FlowNodeRegistry (4) and
IFlowTriggerNode (1).

E2E (1 spec, both attempts). tests/e2e/ci/flow-controls.spec.ts looked for a
palette entry labelled 'Stop'. `EndNode::getLabel()` has returned `t('End')`
since 7ba3c21, so the palette has carried no such entry and the locator could
never resolve — element(s) not found, twice, 15s each. The surrounding comment
was updated with it: it still described `StopNode` and `IFlowTerminalNode`, both
of which are gone.

PHPCS (7 errors, 4 files). Two long lines, one inline IF, one parameter-type
alignment — and one real defect behind the last two: `roleFor()`'s docblock had
been ORPHANED. A second docblock was inserted directly beneath it, so
`aliasesFor()` absorbed one and `roleFor()` ended up documented by nothing.
Moved it back onto its own method.

PHPMD (8 violations, 5 files). Three methods sat EXACTLY on their thresholds
(Cyclomatic 10 of 10 three times, NPath 204 of 200) — cleared by extraction
along real seams, never by raising a threshold and never by baselining:

  FlowConnectivity::entryAndExit -> rolesPresent()          what is in the
                                                            document, vs what
                                                            the author is told
  FlowLocator::flowsForTrigger  -> dispatchableUuids()
  FlowTriggerDerivation::compare -> verdictWithoutComparing()  the four verdicts
                                                            reachable without
                                                            comparing two sides

`FlowService::save()`'s ElseExpression became `persistFlow()` rather than an
if/if — that leaves `$stored` possibly-undefined for Psalm and PHPStan — and it
takes the uuid rather than a boolean so it does not introduce a
BooleanArgumentFlag finding in place of the one it removes.
`new \RuntimeException` became an import. The two `GuzzleHttp\Promise\Create`
static calls carry a documented @SuppressWarnings: that class is a third-party
static factory with no instance API, and wrapping it would move the static
access one file sideways and buy nothing. 158 suppressions of this rule already
exist in lib/.

BEHAVIOUR IS UNCHANGED, and that is measured rather than asserted:

  phpcs               exit 0   (was exit 2, 7 errors)
  phpmd main          exit 0   (was exit 2, 8 violations)
  phpmd unusedparams  exit 0
  Unit Tests          867 tests, 1967 assertions, 0 failures

POSITIVE CONTROLS, because a green that cannot go red is not a measurement:
planting a static call and an else in FlowConnectivity turned phpmd red (exit 2,
both findings named); making `rolesPresent()` always report a trigger turned the
suite red (3 failures, FlowEntryAndExitTest). Both reverted and re-verified.

The trigger-cutover semantics in FlowLocator and FlowTriggerDerivation are
untouched: both extractions preserve check ORDER, which is load-bearing there —
an unscoped `*` column must be judged before any equality test, or it reads as a
re-authoring gap instead of a trigger no node can express.

---

**Baseline this is measured against:** `development` push run [31410968971](https://github.com/ConductionNL/openregister/actions/runs/31410968971) — phpcs, phpmd, E2E and Hydra Gates all red, PHPUnit green on both matrix legs.

**How the local runs were done:** a clone of `development` with `vendor/` copied (not symlinked — composer derives `$baseDir` from where vendor sits, and a symlink silently tests the main checkout), executed in `php:8.3-cli` because this box runs 8.2. One harness caveat worth stating: the Flow suite needs `tests/Unit/Service/Flow/FiltersFlowLevelFindings.php` pre-required via `auto_prepend_file`, because that trait is namespaced `OCA\\OpenRegister\\Tests\\…` while composer's psr-4 maps only `OCA\\OpenRegister\\ -> lib/`. **This is not a defect** — CI runs the app inside a Nextcloud checkout whose autoloader resolves it, and PHPUnit passed there on this very commit. It is a gap in running the suite standalone, and it is why the fatal appears without that flag.