### PR TITLE
fix(mapping): correct a docblock naming a caller that never existed, and test the invalidation that is real

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -57,19 +57,13 @@ use OCA\OpenRegister\Service\MySQLJsonService;
 use OCA\OpenRegister\Service\ConfigurationService;
 use OCA\OpenRegister\Service\WorkflowEngineRegistry;
 use OCA\OpenRegister\Service\UserService;
-use OCA\OpenRegister\Service\Objects\DataManipulationHandler;
-use OCA\OpenRegister\Service\Objects\DeleteObject;
-use OCA\OpenRegister\Service\Objects\GetObject;
-use OCA\OpenRegister\Service\Objects\PerformanceHandler;
-use OCA\OpenRegister\Service\Objects\PermissionHandler;
-use OCA\OpenRegister\Service\Objects\RenderObject;
-use OCA\OpenRegister\Service\Objects\SaveObject;
-use OCA\OpenRegister\Service\Objects\SaveObject\FilePropertyHandler;
-use OCA\OpenRegister\Service\Objects\SaveObject\MetadataHydrationHandler;
-use OCA\OpenRegister\Service\Objects\SaveObjects;
-use OCA\OpenRegister\Service\Objects\SaveObjects\BulkRelationHandler;
-use OCA\OpenRegister\Service\Objects\SaveObjects\BulkValidationHandler;
-use OCA\OpenRegister\Service\Objects\SearchQueryHandler;
+// Thirteen imports from OCA\OpenRegister\Service\Objects\ stood here — a
+// namespace that DOES NOT EXIST. Those classes live under Service\Object\
+// (singular); the plural was left behind by the rename. Every one was unused, so
+// PHP never resolved them and they were inert — which is why nothing ever
+// failed. The first person to actually reference one would have got a fatal at
+// boot, in the app's own bootstrap, from a line that looks like every other
+// import in the file.
 use OCA\OpenRegister\Service\Object\ValidateObject;
 use OCA\OpenRegister\Service\ObjectService\ValidationHandler;
 use OCA\OpenRegister\Service\ObjectService\FacetHandler;

--- a/lib/Service/MappingService.php
+++ b/lib/Service/MappingService.php
@@ -649,16 +649,32 @@ class MappingService
     }//end getCachedTemplate()
 
     /**
-     * Invalidates the distributed cache entry for a mapping.
+     * Evicts ONE distributed-cache key for a mapping.
      *
-     * Called by MappingMapper on create, update, or delete to ensure stale data
-     * is not served from the cache.
+     * NOT the write-path invalidation, despite what this docblock used to claim.
+     * It said "Called by MappingMapper on create, update, or delete" and no such
+     * call exists or ever did — `MappingMapper` invalidates through its OWN
+     * private `invalidateCache()`, on all three write paths, against the same
+     * `openregister_mapping_` prefix. The design the sentence described is real;
+     * it just never ran through here.
      *
-     * @param int|string $id The mapping ID, UUID, or slug to invalidate
+     * Prefer the mapper's version, and understand the difference before reaching
+     * for this one: `getMapping()` caches under WHATEVER identifier the caller
+     * passed, and `MappingMapper::find()` accepts an id, a uuid OR a slug — so
+     * one mapping can sit in the cache under three keys. This method removes
+     * exactly the one it is given. Evicting by id therefore leaves the uuid- and
+     * slug-keyed copies live, which looks like a flush and is not one. The
+     * mapper's `invalidateCache()` removes all three, from the entity.
+     *
+     * Kept as the single-key primitive for a caller that genuinely holds one key
+     * and means one key.
+     *
+     * @param int|string $id The single cache key to remove (id, uuid or slug).
      *
      * @return void
      *
-     * @spec exclude One-line distributed-cache invalidation called by MappingMapper on write; cache plumbing.
+     * @spec exclude Single-key distributed-cache eviction primitive; the write-path invalidation is
+     *              MappingMapper::invalidateCache(), pinned by MappingMapperCacheInvalidationTest.
      */
     public function invalidateMappingCache(int|string $id): void
     {

--- a/tests/Unit/Db/MappingMapperCacheInvalidationTest.php
+++ b/tests/Unit/Db/MappingMapperCacheInvalidationTest.php
@@ -1,0 +1,307 @@
+<?php
+
+/**
+ * The mapping cache is busted on write — enforced here, and until now untested.
+ *
+ * `MappingService::getMapping()` is a read-through against a DISTRIBUTED cache,
+ * so a stale entry outlives the request that created it. Two properties keep it
+ * honest, and both were load-bearing comments rather than checks:
+ *
+ *  1. ALL THREE KEYS. `MappingMapper::find()` accepts an id, a uuid or a slug,
+ *     and `getMapping()` caches under whichever identifier the caller passed —
+ *     so one mapping can occupy three cache keys. An invalidation that removed
+ *     only the id would look like a flush and leave two live copies.
+ *
+ *  2. THE SAME PREFIX. The mapper builds its cache handle from its own
+ *     `CACHE_PREFIX` constant, annotated "Cache key prefix matching
+ *     MappingService". If the two ever drift, the mapper deletes keys in a
+ *     namespace nothing reads and the service keeps serving the stale entry —
+ *     with no error anywhere, in either class, at any point. A comment asserting
+ *     that two constants are equal is a claim, so this asserts it.
+ *
+ * Filed as #2417 on the theory that the invalidation was missing entirely. It is
+ * not: it is present, correct, more complete than the public
+ * `MappingService::invalidateMappingCache()`, and simply lives under a different
+ * name. What was actually missing is this file.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Db
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Db;
+
+use OCA\OpenRegister\Db\Mapping;
+use OCA\OpenRegister\Db\MappingMapper;
+use OCA\OpenRegister\Service\MappingService;
+use OCP\ICache;
+use OCP\ICacheFactory;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * Write-path cache invalidation for mappings.
+ *
+ * @covers \OCA\OpenRegister\Db\MappingMapper
+ */
+class MappingMapperCacheInvalidationTest extends TestCase
+{
+
+    /**
+     * The distributed cache, mocked.
+     *
+     * @var ICache&MockObject
+     */
+    private ICache&MockObject $cache;
+
+    /**
+     * The mapper under test.
+     *
+     * @var MappingMapper
+     */
+    private MappingMapper $mapper;
+
+    /**
+     * Build the mapper over a cache factory that yields the mock.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->cache = $this->createMock(ICache::class);
+
+        $factory = $this->createMock(ICacheFactory::class);
+        $factory->method('createDistributed')->willReturn($this->cache);
+
+        $this->mapper = new MappingMapper(
+            $this->createMock(IDBConnection::class),
+            $this->createMock(IUserSession::class),
+            $this->createMock(IGroupManager::class),
+            $factory,
+            new NullLogger()
+        );
+
+    }//end setUp()
+
+    /**
+     * Invoke the private write-path invalidation.
+     *
+     * @param Mapping $mapping The mapping being written.
+     *
+     * @return void
+     */
+    private function invalidate(Mapping $mapping): void
+    {
+        $method = new ReflectionMethod(MappingMapper::class, 'invalidateCache');
+        $method->setAccessible(true);
+        $method->invoke($this->mapper, $mapping);
+
+    }//end invalidate()
+
+    /**
+     * Read a class's private constant.
+     *
+     * @param string $class The class name.
+     * @param string $name  The constant name.
+     *
+     * @return mixed The value.
+     */
+    private function constant(string $class, string $name): mixed
+    {
+        return (new ReflectionClass($class))->getConstant($name);
+
+    }//end constant()
+
+    /**
+     * PROPERTY 1. Every identifier the mapping can be looked up by is evicted,
+     * not just the numeric id. Narrow this to one key and the cache keeps
+     * serving the pre-write mapping under the other two.
+     *
+     * @return void
+     */
+    public function testAllThreeLookupKeysAreEvicted(): void
+    {
+        $mapping = new Mapping();
+        $mapping->setId(42);
+        $mapping->setUuid('bd2a6f2e-0000-4000-8000-000000000001');
+        $mapping->setSlug('person-to-contact');
+
+        $removed = [];
+        $this->cache->method('remove')->willReturnCallback(
+            static function (string $key) use (&$removed): bool {
+                $removed[] = $key;
+
+                return true;
+            }
+        );
+
+        $this->invalidate(mapping: $mapping);
+
+        sort($removed);
+        $this->assertSame(
+            ['42', 'bd2a6f2e-0000-4000-8000-000000000001', 'person-to-contact'],
+            $removed,
+            'MappingService::getMapping() caches under whichever identifier the caller passed, '
+            .'so all three have to go.'
+        );
+
+    }//end testAllThreeLookupKeysAreEvicted()
+
+    /**
+     * The DERIVED slug is evicted too, and it has to be.
+     *
+     * `Mapping::getSlug()` never returns empty: with no stored slug it derives
+     * one from the name, falling back to `mapping-{id}`. That derived value is a
+     * real lookup key — `MappingMapper::find()` matches on the slug column and
+     * `getMapping()` caches under whatever string it was handed — so an
+     * invalidation that only used the STORED slug would skip it.
+     *
+     * Pinned because the obvious "tidy-up" here is to stop evicting a value that
+     * looks computed, and that would reintroduce the stale read.
+     *
+     * @return void
+     */
+    public function testTheDerivedSlugIsEvictedAsWellAsTheId(): void
+    {
+        $mapping = new Mapping();
+        $mapping->setId(7);
+
+        $removed = [];
+        $this->cache->method('remove')->willReturnCallback(
+            static function (string $key) use (&$removed): bool {
+                $removed[] = $key;
+
+                return true;
+            }
+        );
+
+        $this->invalidate(mapping: $mapping);
+
+        $this->assertContains('7', $removed);
+        $this->assertContains(
+            $mapping->getSlug(),
+            $removed,
+            'Mapping::getSlug() derives a value when none is stored, and that derived value is a '
+            .'key MappingService::getMapping() can have cached under.'
+        );
+
+    }//end testTheDerivedSlugIsEvictedAsWellAsTheId()
+
+    /**
+     * Invalidation runs AFTER the insert on the create path, and the ordering is
+     * load-bearing. `getSlug()`'s last-resort fallback is
+     * `mapping-{random hex}` — a DIFFERENT value on every call — so invalidating
+     * an entity that has no id yet would evict a key nothing ever wrote.
+     * Asserting the entity is identified by the time it is invalidated.
+     *
+     * @return void
+     */
+    public function testInvalidationHappensAfterThePersistThatGivesTheEntityItsId(): void
+    {
+        $source = file_get_contents((new ReflectionClass(MappingMapper::class))->getFileName());
+        $this->assertIsString($source);
+
+        $body      = $this->bodyOf(source: $source, method: 'createFromArray');
+        $insertPos = strpos($body, '$this->insert(');
+        $evictPos  = strpos($body, 'invalidateCache');
+
+        $this->assertNotFalse($insertPos, 'createFromArray() no longer persists through insert().');
+        $this->assertNotFalse($evictPos);
+        $this->assertLessThan(
+            $evictPos,
+            $insertPos,
+            'invalidateCache() must run after insert(), or the entity has no id and getSlug() '
+            .'falls back to a random key that was never cached.'
+        );
+
+    }//end testInvalidationHappensAfterThePersistThatGivesTheEntityItsId()
+
+    /**
+     * PROPERTY 2, and the one that fails silently in both directions. The mapper
+     * deletes keys in the namespace named by its own CACHE_PREFIX; the service
+     * writes them into the namespace named by ITS CACHE_PREFIX. The mapper's
+     * constant carries the comment "Cache key prefix matching MappingService",
+     * which is a claim about another file that nothing checked.
+     *
+     * Drift them and there is no error at either end: the mapper reports a
+     * successful invalidation, and the service goes on serving the stale mapping
+     * from a distributed cache, across requests, until the TTL expires.
+     *
+     * @return void
+     */
+    public function testTheMapperEvictsInTheSameNamespaceTheServiceWritesTo(): void
+    {
+        $mapperPrefix  = $this->constant(class: MappingMapper::class, name: 'CACHE_PREFIX');
+        $servicePrefix = $this->constant(class: MappingService::class, name: 'CACHE_PREFIX');
+
+        $this->assertNotFalse($mapperPrefix, 'MappingMapper::CACHE_PREFIX has been renamed or removed.');
+        $this->assertNotFalse($servicePrefix, 'MappingService::CACHE_PREFIX has been renamed or removed.');
+        $this->assertSame(
+            $servicePrefix,
+            $mapperPrefix,
+            'The mapper would be deleting cache keys the service never writes, and the service '
+            .'would keep serving stale mappings from a distributed cache with no error anywhere.'
+        );
+
+    }//end testTheMapperEvictsInTheSameNamespaceTheServiceWritesTo()
+
+    /**
+     * The write paths that must reach the invalidation. Asserted by NAME against
+     * the source rather than by executing them, because create/update/delete all
+     * require a live database — and the failure being guarded against is someone
+     * adding a fourth write path, or removing the call from an existing one.
+     *
+     * @return void
+     */
+    public function testEveryWritePathInvalidatesTheCache(): void
+    {
+        $source = file_get_contents((new ReflectionClass(MappingMapper::class))->getFileName());
+        $this->assertIsString($source);
+
+        foreach (['createFromArray', 'updateFromArray', 'delete'] as $method) {
+            $body = $this->bodyOf(source: $source, method: $method);
+            $this->assertStringContainsString(
+                'invalidateCache',
+                $body,
+                sprintf('MappingMapper::%s() writes a mapping without busting its cache entries.', $method)
+            );
+        }
+
+    }//end testEveryWritePathInvalidatesTheCache()
+
+    /**
+     * The source text of one method, from its signature to the closing marker.
+     *
+     * @param string $source The file source.
+     * @param string $method The method name.
+     *
+     * @return string The body text.
+     */
+    private function bodyOf(string $source, string $method): string
+    {
+        $start = strpos($source, 'function '.$method.'(');
+        $this->assertNotFalse($start, sprintf('MappingMapper::%s() no longer exists.', $method));
+
+        $end = strpos($source, '}//end '.$method.'()', $start);
+        $this->assertNotFalse($end, sprintf('MappingMapper::%s() has no end marker to bound it.', $method));
+
+        return substr($source, $start, ($end - $start));
+
+    }//end bodyOf()
+}//end class


### PR DESCRIPTION
Follow-up to #2416, and **a correction to a finding I filed during it**. Issue #2417 is closed as not-a-defect.

## I got #2417 wrong

I claimed `MappingService::invalidateMappingCache()` was an unenforced invariant on a distributed cache — stale mappings served across requests. **It is not.** `MappingMapper::invalidateCache()` already busts the cache on `createFromArray`, `updateFromArray` and `delete`, removing **id + uuid + slug** against the same `openregister_mapping_` prefix the service writes to.

I found the orphan by grepping for callers of the public method and never checked whether the mapper enforced it **under a different name** — the exact check gate-57's own documentation prescribes, which I quoted in the issue and then did not perform.

## What is actually true, and much smaller

`getMapping()` caches under whatever identifier the caller passed, and `MappingMapper::find()` accepts an **id, a uuid or a slug** — so one mapping can occupy three cache keys. The public method removes exactly the one it is handed. Calling it with an id leaves the uuid- and slug-keyed copies live: it *looks* like a flush and is not one.

A footgun, not a bug — latent until its first caller. The docblock, which claimed to be the write-path invalidation, now says what it is and points at the mapper.

## What was genuinely missing: the test

The live invalidation had **none**. Two properties held it up, both as comments:

1. **All three keys.** Narrow it to the id and two stale copies keep being served.
2. **The same prefix.** The mapper's constant is annotated *"Cache key prefix matching MappingService"* — a claim about another file that nothing checked. Drift them and there is **no error at either end**: the mapper reports a successful invalidation into a namespace nothing reads, and the service serves stale mappings from a *distributed* cache until TTL.

Also pinned: the write-path coverage, and the insert-then-invalidate ordering — `getSlug()` falls back to `mapping-{random hex}` when the entity has no id, so evicting before persist would remove a key nothing ever wrote.

**Proven in both directions.** Planted true positives:

| plant | result |
|---|---|
| invalidate id only | 2 tests red |
| drift `CACHE_PREFIX` | prefix test red |
| drop the call from `delete()` | write-path test red |

`MappingMapper` itself is **unchanged** — verified byte-identical to `development` after reverting every plant.

## Separately: an import block naming a namespace that does not exist

`Application.php` imported 13 classes from `OCA\OpenRegister\Service\Objects\`. There is no such namespace — they live under `Service\Object\` (singular); the plural survived a rename. All 13 were **unused**, so PHP never resolved them and nothing ever failed. The first person to reference one would have got a fatal at boot, in the app's own bootstrap, from a line that looks like every other import in the file. Removed.

The `@package OCA\OpenRegister\Service\Objects\*` docblock tags in 9 other files name the same phantom namespace. Cosmetic, no runtime effect, left alone.

## Measurement note worth keeping

Running `phpstan analyse <single file>` reported `MappingMapper::$userSession is never read, only written` — **a false positive from subsetting**. The property is read by `MultiTenancyTrait`, which wasn't in the file list. A per-file phpstan run is not the same check as the full run, and it manufactures exactly this shape on trait-provided reads.

## Verification

`phpcs` clean on all three changed files; 1504 unit tests green across `tests/Unit/Db` plus both MappingService suites; 5 new tests.
