### PR TITLE
feat(openregister): mark the five mock registers as wire-exempt vocabulary

### DIFF
--- a/lib/Settings/bag_register.json
+++ b/lib/Settings/bag_register.json
@@ -5,6 +5,11 @@
     "description": "Mock BAG (Basisregistratie Adressen en Gebouwen) register with realistic Dutch address and building data from PDOK",
     "version": "1.0.0"
   },
+  "x-wire-standard": {
+    "standard": "BAG — Basisregistratie Adressen en Gebouwen (PDOK)",
+    "vocabulary": "exempt-from-english-vocabulary",
+    "reason": "Every schema and property name here is BAG's own. nummeraanduiding, verblijfsobject and pand are the standard's object types. This register exists so a connector developed against it works against the real BAG, so internationalising these names destroys the only property that makes it useful. See hydra/openspec/changes/fleet-english-vocabulary."
+  },
   "x-openregister": {
     "type": "mock",
     "app": "openregister",

--- a/lib/Settings/brp_register.json
+++ b/lib/Settings/brp_register.json
@@ -5,6 +5,11 @@
     "description": "Mock BRP (Basisregistratie Personen) register with RVIG test data for development and testing. Contains fictional person records aligned to the Haal Centraal BRP Personen Bevragen API v2 data model.",
     "version": "1.0.0"
   },
+  "x-wire-standard": {
+    "standard": "Haal Centraal BRP Personen Bevragen API v2 (RVIG test data)",
+    "vocabulary": "exempt-from-english-vocabulary",
+    "reason": "ingeschreven-persoon and its fields are the Haal Centraal resource and field names. Renaming them makes a connector built against this mock fail against the real BRP. See hydra/openspec/changes/fleet-english-vocabulary."
+  },
   "x-openregister": {
     "type": "mock",
     "app": "openregister",

--- a/lib/Settings/dso_register.json
+++ b/lib/Settings/dso_register.json
@@ -5,6 +5,11 @@
     "description": "Mock DSO (Digitaal Stelsel Omgevingswet) register with environmental permit data aligned to the CIM-OW/IMOW data model. Contains activities, locations, environmental documents, and permit applications for development and testing.",
     "version": "1.0.0"
   },
+  "x-wire-standard": {
+    "standard": "DSO — CIM-OW / IMOW data model (Omgevingswet)",
+    "vocabulary": "exempt-from-english-vocabulary",
+    "reason": "activiteit, locatie, omgevingsdocument and vergunningaanvraag are IMOW's own object types, and besluitdatum / indieningsdatum / bevoegdGezag are its field names. This register mirrors the model so a connector can be built without hitting the real DSO. See hydra/openspec/changes/fleet-english-vocabulary."
+  },
   "x-openregister": {
     "type": "mock",
     "app": "openregister",

--- a/lib/Settings/kvk_register.json
+++ b/lib/Settings/kvk_register.json
@@ -5,6 +5,11 @@
     "description": "Mock KVK (Kamer van Koophandel) register with Disney-themed test data from the official KVK test environment, supplemented with realistic fictional Dutch businesses.",
     "version": "1.0.0"
   },
+  "x-wire-standard": {
+    "standard": "KVK — Kamer van Koophandel (official KVK test environment)",
+    "vocabulary": "exempt-from-english-vocabulary",
+    "reason": "maatschappelijke-activiteit and vestiging are the KVK API's own resource names, and the seed data comes from KVK's official test environment. Renaming them makes a connector built here fail against the real KVK. See hydra/openspec/changes/fleet-english-vocabulary."
+  },
   "x-openregister": {
     "type": "mock",
     "app": "openregister",

--- a/lib/Settings/ori_register.json
+++ b/lib/Settings/ori_register.json
@@ -5,6 +5,11 @@
     "description": "Mock ORI (Open Raadsinformatie) register with fictional council data for the municipality of Voorbeeldstad. Based on the VNG ODS-Open-Raadsinformatie specification and Open State Foundation data model.",
     "version": "1.0.0"
   },
+  "x-wire-standard": {
+    "standard": "ORI — VNG ODS-Open-Raadsinformatie specification (Open State Foundation data model)",
+    "vocabulary": "exempt-from-english-vocabulary",
+    "reason": "vergadering, agendapunt, raadsdocument, stemming, raadslid and fractie are the ODS specification's own object types. ⚠️ procest declares the same six slugs in its own operational ori_register.json, and $ref slug resolution is instance-global — the two must be resolved together at fleet level, not renamed on one side. See hydra/openspec/changes/fleet-english-vocabulary."
+  },
   "x-openregister": {
     "type": "mock",
     "app": "openregister",


### PR DESCRIPTION
Task 2 of `openspec/changes/english-vocabulary`, shippable on its own. **This renames nothing**, so nothing can break — it protects 79 Dutch property names across 15 schemas from a future vocabulary sweep.

## The scope correction this encodes

The fleet programme originally scoped openregister as *"2 Dutch schemas / 20 properties"* to rename. A token-aware rescan (nested properties walked, `custom_apps/` and `.bak` excluded) shows openregister's **own schemas are already clean at 0/0**. Every Dutch property lives in five files that describe themselves as mirrors of published standards:

| register | mirrors |
|---|---|
| `bag_` | PDOK BAG |
| `brp_` | Haal Centraal BRP Personen Bevragen API v2 |
| `dso_` | CIM-OW / IMOW |
| `kvk_` | the official KVK test environment |
| `ori_` | VNG ODS-Open-Raadsinformatie |

**A mock register *is* the wire.** Its entire value is that a connector developed against it works against the real registry — so internationalising `nummeraanduiding`, `verblijfsobject`, `pand` or `ingeschreven-persoon` destroys the only property that makes it useful. Each register now carries `x-wire-standard` naming the standard and the reason.

## Two things the markers record beyond the exemption

The **ORI** marker notes that procest declares the same six slugs (`vergadering`, `agendapunt`, `raadsdocument`, `stemming`, `raadslid`, `fractie`) in its own operational register, and that `$ref` resolution is instance-global — so those must be resolved at fleet level, never renamed on one side.

Marker safety is **evidenced, not assumed**: `bag_register.json` already carries `x-schema-org` on its schemas and imports fine, so OpenRegister tolerates an unknown `x-` key. That closes open question 1.1 in the spec.

## Deliberately not here
The code-layer rename — measured at **519 refs across 66 files**, and it reaches `lib/Migration/Version1Date*.php`, which are historical and must not be edited. That needs its own change with a consuming-app sweep, since a class that stops resolving 500s every route in a leaf app.

Diff is **5 files, 25 insertions, 0 deletions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)