### PR TITLE
fix(deps): bump phpcsstandards/phpcsutils to 1.2.3 (CVE-2026-65954, arbitrary code execution)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9091,16 +9091,16 @@
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55"
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f",
                 "shasum": ""
             },
             "require": {
@@ -9180,7 +9180,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-12-08T14:27:58+00:00"
+            "time": "2026-07-27T10:28:41+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",


### PR DESCRIPTION
## What

Lock-only bump of `phpcsstandards/phpcsutils` **1.2.2 → 1.2.3**.

```
Package: phpcsstandards/phpcsutils
CVE: CVE-2026-65954          Title: Arbitrary code execution
Affected versions: >=1.0.0-alpha1,<1.2.3
Advisory: https://github.com/PHPCSStandards/PHPCSUtils/security/advisories/GHSA-r6hr-vr92-vv28
```

## Why now, and why this is not caused by any commit

`quality / Security (composer)` **passed** on PR #2427 at 19:27 and **failed** on
`development` at 20:29, over a merge whose diff (`gh pr diff --name-only`) is five
`lib/` files and four `tests/` files — **no composer file at all**. The advisory
database moved, not the tree. It currently blocks `development`.

## Why this is a one-line change

`phpcsutils` is **transitive**, via `phpcsstandards/phpcsextra ^1.4` →
`phpcsextra 1.5.0` → `phpcsutils ^1.2.0`. **1.2.3 satisfies the existing
constraint, so `composer.json` is untouched** and the lock `content-hash` is
unchanged.

Composer's own summary:

```
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading phpcsstandards/phpcsutils (1.2.2 => 1.2.3)
```

Verified by diffing every `(section, name, version, dist.reference)` tuple in the
lock before and after — **exactly one line differs**.

## Positive control that the target version resolves

`scholiq` already locks **1.2.3** with **identical constraints** (`composer.json:
phpcsstandards/phpcsextra ^1.4` → `phpcsextra 1.5.0` → `phpcsutils ^1.2.0`). The
only difference between the two repos is when the lock was last regenerated, so
this is not a speculative bump — one fleet app is already running it in CI.

## Fleet impact

**16 of 17** apps checked out under `apps-extra/` currently lock the vulnerable
1.2.2 and will fail `Security (composer)` on their next run:

> decidesk, docudesk, doriath, hermiq, larpingapp, nextcloud-app-template,
> openbuild, opencatalogi, openconnector, openregister, petstore, pipelinq,
> portaliq, procest, shillinq, softwarecatalog

scholiq is the sole clean one. The same one-line bump applies to each.

## Verification

The bump is **exercised by CI** rather than merely declared: `quality / PHP
Quality (phpcs)` runs PHPCS (and therefore PHPCSUtils) on every run, so a
regression in the patch release would surface as a phpcs failure on this PR.

⚠️ `Hydra Gates` is expected to remain red here for an unrelated, upstream
reason — gate-24 cannot locate the canonical JS check because the published
`@conduction/nextcloud-vue` tarball ships no `scripts/` dir (openregister#2431,
fix open as nextcloud-vue#631). `PHP Quality (phpmd)` is likewise expected red
(openregister#2429, pre-existing on `development`).
