### PR TITLE
fix: probe the property, not the method, on four __call() accessor guards

### DIFF
--- a/lib/Controller/SearchController.php
+++ b/lib/Controller/SearchController.php
@@ -25,6 +25,7 @@
 namespace OCA\OpenRegister\Controller;
 
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\Entity;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCA\OpenRegister\Service\ObjectService;
@@ -136,13 +137,28 @@ class SearchController extends Controller
              */
 
             function ($object): array {
-                if (is_object($object) === true && method_exists($object, 'getUuid') === true) {
+                // Probe the PROPERTY, not the method. searchObjectsPaginated()
+                // returns ObjectEntity rows, and ObjectEntity declares getUuid() and
+                // getName() only as `@method` — Nextcloud's Entity serves them through
+                // __call(). method_exists() is FALSE for both, so every row fell past
+                // this branch, and the array branch below cannot read an object either:
+                // $objectArr stayed [] and EVERY search hit was returned as
+                // `id: null, name: 'Unknown'`.
+                //
+                // There is no fallback to recover it here: unlike the getUuid probes
+                // elsewhere in this app, nothing on this path routes through
+                // getObject(), which is the concrete method that injects the uuid
+                // under 'id'. property_exists() is the same test Entity::getter() runs
+                // before returning the value, so it cannot throw.
+                if ($object instanceof Entity && property_exists($object, 'uuid') === true) {
                     $name = null;
-                    if (method_exists($object, 'getName') === true) {
+                    if (property_exists($object, 'name') === true) {
+                        // @phpstan-ignore-next-line Entity::getName() is dispatched via __call.
                         $name = $object->getName();
                     }
 
                     return [
+                        // @phpstan-ignore-next-line Entity::getUuid() is dispatched via __call.
                         'id'     => $object->getUuid(),
                         'name'   => $name ?? 'Unknown',
                         'type'   => 'object',

--- a/lib/Db/MultiTenancyTrait.php
+++ b/lib/Db/MultiTenancyTrait.php
@@ -739,10 +739,29 @@ trait MultiTenancyTrait
     protected function verifyOrganisationAccess(Entity $entity): void
     {
         // Check if entity has organisation property.
-        if (method_exists($entity, 'getOrganisation') === false) {
+        //
+        // property_exists(), NOT method_exists() — the same reason spelled out in
+        // setOrganisationOnCreate() and setOwnerOnCreate() above. Nextcloud's Entity
+        // serves get*() through __call(), and Entity::getter() resolves the name with
+        // property_exists() exactly as this line does, so method_exists() is FALSE for
+        // every accessor declared only as `@method`.
+        //
+        // Eight of the twelve mappers using this trait hold entities in that shape —
+        // Schema, Register, Configuration, Action, Mapping, Webhook, Agent (all
+        // `@method`) and Endpoint (no declaration at all) — so this guard returned
+        // early and cross-tenant enforcement was silently OFF for them: no
+        // organisation comparison, no cross_tenant_access_denied audit line, no 403.
+        // It was live only for Source, View and Application, whose getOrganisation()
+        // is concrete. All twelve declare `protected $organisation`, which is what
+        // this probe reads, and what __call() would have read.
+        if (property_exists($entity, 'organisation') === false) {
             return;
         }
 
+        // The parameter is typed Entity, whose organisation accessor exists only as
+        // `@method` on the subclasses, so static analysis cannot see it. The
+        // property_exists() guard above is what makes this call safe at runtime.
+        // @phpstan-ignore-next-line Entity::getOrganisation() is dispatched via __call.
         $entityOrgUuid = $entity->getOrganisation();
         $activeOrgUuid = $this->getActiveOrganisationUuid();
 

--- a/lib/Repair/LogDanglingLinkedTypes.php
+++ b/lib/Repair/LogDanglingLinkedTypes.php
@@ -39,6 +39,7 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Repair;
 
 use OCA\OpenRegister\Service\Integration\IntegrationRegistry;
+use OCP\AppFramework\Db\Entity;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 use Psr\Container\ContainerInterface;
@@ -288,7 +289,7 @@ class LogDanglingLinkedTypes implements IRepairStep
     private function safeStringAccessor($schema, array $accessors): ?string
     {
         foreach ($accessors as $method) {
-            if (method_exists($schema, $method) === false) {
+            if ($this->accessorIsAvailable(schema: $schema, method: $method) === false) {
                 continue;
             }
 
@@ -309,4 +310,46 @@ class LogDanglingLinkedTypes implements IRepairStep
 
         return null;
     }//end safeStringAccessor()
+
+    /**
+     * Decide whether an accessor can actually be invoked on a schema entity.
+     *
+     * Probing with method_exists() alone is the wrong instrument here. Nextcloud's Entity
+     * serves get*() through __call(), declaring the accessors only as `@method`,
+     * so method_exists() is FALSE for every one of them. Db\Schema declares no
+     * concrete getSlug()/getUuid() and inherits getId() as a docblock from
+     * Entity, so the old probe rejected every candidate this class passes in and
+     * scan() logged `slug: 'unknown', id: ''` for 100% of the rows — defeating
+     * the entire purpose of the report.
+     *
+     * Entity::getter() resolves the name with property_exists() and throws
+     * BadFunctionCallException otherwise, so mirroring that derivation here is a
+     * genuine membership test rather than the always-true answer is_callable()
+     * would give on a __call class.
+     *
+     * @param mixed  $schema Schema entity.
+     * @param string $method Accessor name to probe.
+     *
+     * @return bool True when calling $method on $schema will resolve.
+     *
+     * @spec openspec/specs/linked-entity-types/spec.md
+     */
+    private function accessorIsAvailable($schema, string $method): bool
+    {
+        if (is_object($schema) === false) {
+            return false;
+        }
+
+        if (method_exists($schema, $method) === true) {
+            return true;
+        }
+
+        if (($schema instanceof Entity) === false || str_starts_with($method, 'get') === false) {
+            return false;
+        }
+
+        // The exact derivation Entity::__call() performs before handing the name
+        // to Entity::getter(): lcfirst(substr($methodName, 3)).
+        return property_exists($schema, lcfirst(substr($method, 3)));
+    }//end accessorIsAvailable()
 }//end class

--- a/lib/Service/ViewPresentationService.php
+++ b/lib/Service/ViewPresentationService.php
@@ -30,6 +30,7 @@ namespace OCA\OpenRegister\Service;
 use InvalidArgumentException;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Db\View;
+use OCP\AppFramework\Db\Entity;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -369,8 +370,29 @@ class ViewPresentationService
             return md5(serialize($object));
         }
 
-        if (is_object($object) === true && method_exists($object, 'getId') === true) {
-            return (string) $object->getId();
+        // Nextcloud entities serve get*() through Entity::__call() and declare the
+        // accessors only as `@method`, so method_exists($row, 'getId') is FALSE for
+        // every ObjectEntity searchObjectsPaginated() hands back. That sent both
+        // queries to spl_object_hash(), which is unique per PHP instance — so the
+        // same DB row, hydrated once by the "starting" query and once by the
+        // "spanning" query, produced TWO keys and rendered twice on the calendar.
+        //
+        // property_exists() is the membership test Entity::getter() itself uses.
+        // uuid is preferred over id so an entity row and an already-rendered array
+        // row of the SAME object collapse to one key: getObject()/jsonSerialize()
+        // publish the uuid under 'id', which is what the is_array() branch reads.
+        if ($object instanceof Entity) {
+            if (property_exists($object, 'uuid') === true) {
+                // @phpstan-ignore-next-line Entity::getUuid() is dispatched via __call.
+                $uuid = $object->getUuid();
+                if ($uuid !== null && $uuid !== '') {
+                    return (string) $uuid;
+                }
+            }
+
+            if (property_exists($object, 'id') === true && $object->getId() !== null) {
+                return (string) $object->getId();
+            }
         }
 
         return spl_object_hash((object) $object);

--- a/tests/Unit/Controller/SearchControllerTest.php
+++ b/tests/Unit/Controller/SearchControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Tests\Unit\Controller;
 
 use OCA\OpenRegister\Controller\SearchController;
+use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
@@ -108,5 +109,96 @@ class SearchControllerTest extends TestCase
         $this->assertEquals('Unknown', $item['name']);
         $this->assertEquals('object', $item['type']);
         $this->assertEquals('openregister', $item['source']);
+    }
+
+    // ── ObjectEntity rows ──
+    //
+    // Every test above hands the controller plain arrays. searchObjectsPaginated()
+    // also returns ObjectEntity instances — ObjectService::collectNamesForResults()
+    // branches on `instanceof ObjectEntity` before it branches on is_array() — and
+    // the formatter was broken for exactly that shape: ObjectEntity declares
+    // getUuid()/getName() only as `@method`, served through Entity::__call(), so
+    // method_exists() was FALSE, the entity branch was never taken, and the array
+    // branch could not read an object either. Every hit came back id: null,
+    // name: 'Unknown'. Nothing on this path routes through getObject(), so there
+    // was no fallback to recover the uuid.
+
+    public function testSearchFormatsObjectEntityRowsWithTheirRealUuidAndName(): void
+    {
+        $this->request->method('getParam')
+            ->willReturnMap([
+                ['query', '', 'test'],
+                ['offset', 0, 0],
+                ['limit', 25, 25],
+                ['_search', [], []],
+            ]);
+
+        $entity = new ObjectEntity();
+        $entity->setUuid('entity-uuid-1');
+        $entity->setName('Entity Display Name');
+
+        $this->objectService->method('searchObjectsPaginated')->willReturn([
+            'results' => [$entity],
+            'total'   => 1,
+        ]);
+
+        $data = $this->controller->search()->getData();
+        $item = $data['results'][0];
+
+        $this->assertSame('entity-uuid-1', $item['id']);
+        $this->assertSame('Entity Display Name', $item['name']);
+        $this->assertSame('object', $item['type']);
+        $this->assertSame('openregister', $item['source']);
+    }
+
+    public function testSearchFallsBackToUnknownForAnEntityWithoutAName(): void
+    {
+        $this->request->method('getParam')
+            ->willReturnMap([
+                ['query', '', 'test'],
+                ['offset', 0, 0],
+                ['limit', 25, 25],
+                ['_search', [], []],
+            ]);
+
+        $entity = new ObjectEntity();
+        $entity->setUuid('entity-uuid-2');
+
+        $this->objectService->method('searchObjectsPaginated')->willReturn([
+            'results' => [$entity],
+            'total'   => 1,
+        ]);
+
+        $item = $this->controller->search()->getData()['results'][0];
+
+        $this->assertSame('entity-uuid-2', $item['id']);
+        $this->assertSame('Unknown', $item['name']);
+    }
+
+    /**
+     * A receiver that is neither an Entity nor an array must not fatal. This pins
+     * the reason the guard is `instanceof Entity && property_exists()` rather than
+     * is_callable(), which is unconditionally TRUE on any __call class and would
+     * turn this row into a BadFunctionCallException.
+     */
+    public function testSearchDoesNotFatalOnANonEntityObjectRow(): void
+    {
+        $this->request->method('getParam')
+            ->willReturnMap([
+                ['query', '', 'test'],
+                ['offset', 0, 0],
+                ['limit', 25, 25],
+                ['_search', [], []],
+            ]);
+
+        $this->objectService->method('searchObjectsPaginated')->willReturn([
+            'results' => [new \stdClass()],
+            'total'   => 1,
+        ]);
+
+        $item = $this->controller->search()->getData()['results'][0];
+
+        $this->assertNull($item['id']);
+        $this->assertSame('Unknown', $item['name']);
     }
 }

--- a/tests/Unit/Db/MultiTenancyTraitOrganisationAccessTest.php
+++ b/tests/Unit/Db/MultiTenancyTraitOrganisationAccessTest.php
@@ -1,0 +1,370 @@
+<?php
+
+/**
+ * Cross-tenant write enforcement in MultiTenancyTrait::verifyOrganisationAccess().
+ *
+ * The guard at the top of that method decides whether enforcement runs at all.
+ * It probed method_exists($entity, 'getOrganisation'), and Nextcloud's Entity
+ * serves get*() through __call() while declaring the accessors only as
+ * `@method` — so the probe was FALSE for eight of the twelve mappers that use
+ * this trait (Schema, Register, Configuration, Action, Mapping, Webhook, Agent
+ * declare `@method string|null getOrganisation()`; Endpoint declares nothing at
+ * all) and the method returned before comparing anything. No organisation
+ * comparison, no `cross_tenant_access_denied` audit line, no 403 — across the
+ * 24 update()/delete() call sites in lib/Db.
+ *
+ * Only Source, View and Application define getOrganisation() concretely, which
+ * is why enforcement was live for those three and nothing looked broken.
+ *
+ * All twelve entities declare `protected $organisation`, so property_exists() —
+ * the test Entity::getter() itself performs — covers every one of them and does
+ * not depend on a getter being written by hand. The two sibling helpers in the
+ * same file, setOrganisationOnCreate() and setOwnerOnCreate(), already use it.
+ *
+ * Each test below names, in its own docblock, whether it survives a revert of
+ * that one-line change.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Db;
+
+use Exception;
+use OCA\OpenRegister\Db\Action;
+use OCA\OpenRegister\Db\Agent;
+use OCA\OpenRegister\Db\Application;
+use OCA\OpenRegister\Db\Configuration;
+use OCA\OpenRegister\Db\Endpoint;
+use OCA\OpenRegister\Db\Mapping;
+use OCA\OpenRegister\Db\MultiTenancyTrait;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\Source;
+use OCA\OpenRegister\Db\View;
+use OCA\OpenRegister\Db\Webhook;
+use OCP\AppFramework\Db\Entity;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * A minimal host for the trait, standing in for the twelve mappers that use it.
+ *
+ * Only the session lookup is overridden — verifyOrganisationAccess() itself is
+ * the real trait code.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Db
+ */
+final class TenancyGuardHost
+{
+    use MultiTenancyTrait;
+
+    /**
+     * Logger the trait audit branch writes to; the trait checks isset() first.
+     *
+     * @var LoggerInterface|null
+     */
+    public ?LoggerInterface $logger = null;
+
+    /**
+     * The organisation the "session" is currently acting in.
+     *
+     * @var string|null
+     */
+    private ?string $activeOrganisation;
+
+    /**
+     * @param string|null          $activeOrganisation Active organisation uuid, or null for none.
+     * @param LoggerInterface|null $logger             Optional logger.
+     */
+    public function __construct(?string $activeOrganisation, ?LoggerInterface $logger=null)
+    {
+        $this->activeOrganisation = $activeOrganisation;
+        $this->logger             = $logger;
+    }//end __construct()
+
+    /**
+     * Stand in for the session/OrganisationMapper lookup.
+     *
+     * @return string|null
+     */
+    protected function getActiveOrganisationUuid(): ?string
+    {
+        return $this->activeOrganisation;
+    }//end getActiveOrganisationUuid()
+
+    /**
+     * Expose the protected guard under test.
+     *
+     * @param Entity $entity The entity being written.
+     *
+     * @return void
+     */
+    public function verify(Entity $entity): void
+    {
+        $this->verifyOrganisationAccess(entity: $entity);
+    }//end verify()
+}//end class
+
+/**
+ * Enforcement coverage across all twelve trait-using entity types.
+ *
+ * @covers \OCA\OpenRegister\Db\MultiTenancyTrait
+ */
+class MultiTenancyTraitOrganisationAccessTest extends TestCase
+{
+
+    /**
+     * Every entity class whose mapper uses MultiTenancyTrait.
+     *
+     * @return array<string, array{0: class-string<Entity>}>
+     */
+    public static function tenantEntityProvider(): array
+    {
+        $entities = [];
+        foreach (self::accessorShapeProvider() as $label => $row) {
+            $entities[$label] = [$row[0]];
+        }
+
+        return $entities;
+    }//end tenantEntityProvider()
+
+    /**
+     * The same entity classes, paired with whether getOrganisation() is written
+     * out concretely.
+     *
+     * @return array<string, array{0: class-string<Entity>, 1: bool}>
+     */
+    public static function accessorShapeProvider(): array
+    {
+        return [
+            // Accessor served through Entity::__call() — enforcement was OFF.
+            'Schema (@method)'        => [Schema::class, false],
+            'Register (@method)'      => [Register::class, false],
+            'Configuration (@method)' => [Configuration::class, false],
+            'Action (@method)'        => [Action::class, false],
+            'Mapping (@method)'       => [Mapping::class, false],
+            'Webhook (@method)'       => [Webhook::class, false],
+            'Agent (@method)'         => [Agent::class, false],
+            'Endpoint (undeclared)'   => [Endpoint::class, false],
+            // Concrete getter — enforcement was already live for these three.
+            'Source (concrete)'       => [Source::class, true],
+            'View (concrete)'         => [View::class, true],
+            'Application (concrete)'  => [Application::class, true],
+        ];
+    }//end accessorShapeProvider()
+
+    /**
+     * The premise, stated as an assertion rather than assumed: for the eight
+     * entities above, method_exists() is FALSE while the backing property is
+     * present. If this ever stops holding, the tests below stop meaning what
+     * their names say.
+     *
+     * REVERT: stays GREEN. This asserts the framework's behaviour, not the fix.
+     *
+     * @param class-string<Entity> $entityClass   Entity under test.
+     * @param bool                 $hasConcreteGetter Whether the getter is written out.
+     *
+     * @dataProvider accessorShapeProvider
+     *
+     * @return void
+     */
+    public function testOrganisationAccessorShapeIsWhatTheGuardAssumes(
+        string $entityClass,
+        bool $hasConcreteGetter
+    ): void {
+        $entity = new $entityClass();
+
+        $this->assertTrue(
+            property_exists($entity, 'organisation'),
+            $entityClass.' must declare $organisation for the guard to read it'
+        );
+        $this->assertSame(
+            $hasConcreteGetter,
+            method_exists($entity, 'getOrganisation'),
+            $entityClass.': method_exists() disagrees with the recorded accessor shape'
+        );
+    }//end testOrganisationAccessorShapeIsWhatTheGuardAssumes()
+
+    /**
+     * A write from organisation B against an entity owned by organisation A is
+     * refused with 403, for every trait-using entity type.
+     *
+     * REVERT: goes RED for the eight `@method`/undeclared entities — the guard
+     * returns early and no exception is thrown. The three concrete ones stay
+     * GREEN, which is the control that the harness itself works.
+     *
+     * @param class-string<Entity> $entityClass Entity under test.
+     *
+     * @dataProvider tenantEntityProvider
+     *
+     * @return void
+     */
+    public function testCrossOrganisationWriteIsRefused(string $entityClass): void
+    {
+        $entity = new $entityClass();
+        $entity->setOrganisation('org-a');
+
+        $host = new TenancyGuardHost('org-b');
+
+        try {
+            $host->verify($entity);
+            $this->fail($entityClass.': cross-tenant write was allowed through');
+        } catch (Exception $e) {
+            $this->assertSame(Response::HTTP_FORBIDDEN, $e->getCode());
+            $this->assertStringContainsString('different organisation', $e->getMessage());
+        }
+    }//end testCrossOrganisationWriteIsRefused()
+
+    /**
+     * A write inside the entity's own organisation is allowed.
+     *
+     * REVERT: stays GREEN — the broken guard also allowed it, by returning
+     * early. This is here so the suite pins BOTH branches: without it, deleting
+     * the comparison entirely and always throwing would still pass the test
+     * above.
+     *
+     * @param class-string<Entity> $entityClass Entity under test.
+     *
+     * @dataProvider tenantEntityProvider
+     *
+     * @return void
+     */
+    public function testSameOrganisationWriteIsAllowed(string $entityClass): void
+    {
+        $entity = new $entityClass();
+        $entity->setOrganisation('org-a');
+
+        $host = new TenancyGuardHost('org-a');
+        $host->verify($entity);
+
+        $this->addToAssertionCount(1);
+    }//end testSameOrganisationWriteIsAllowed()
+
+    /**
+     * An entity carrying no organisation is untouched — pre-tenancy rows must
+     * keep working.
+     *
+     * REVERT: stays GREEN.
+     *
+     * @param class-string<Entity> $entityClass Entity under test.
+     *
+     * @dataProvider tenantEntityProvider
+     *
+     * @return void
+     */
+    public function testEntityWithoutAnOrganisationIsAllowed(string $entityClass): void
+    {
+        $host = new TenancyGuardHost('org-b');
+        $host->verify(new $entityClass());
+
+        $this->addToAssertionCount(1);
+    }//end testEntityWithoutAnOrganisationIsAllowed()
+
+    /**
+     * FAIL-CLOSED, and deliberately pinned because it is the blast radius of
+     * this fix: when there is no active organisation at all — no session, or an
+     * install with no default organisation configured — a write against an
+     * entity that HAS one is refused. Repair steps, imports and CLI paths that
+     * touch a Schema or Register belonging to an organisation now hit this.
+     *
+     * That behaviour is not new; it has been live for Source, View and
+     * Application all along. Turning the guard on extends it to the other eight.
+     * If this ever needs to become fail-open, it should be a deliberate change
+     * against this test, not a silent property of a broken probe.
+     *
+     * REVERT: goes RED for Schema (the guard returns early instead).
+     *
+     * @return void
+     */
+    public function testNoActiveOrganisationStillRefusesAnEntityThatHasOne(): void
+    {
+        $schema = new Schema();
+        $schema->setOrganisation('org-a');
+
+        $host = new TenancyGuardHost(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(Response::HTTP_FORBIDDEN);
+        $host->verify($schema);
+    }//end testNoActiveOrganisationStillRefusesAnEntityThatHasOne()
+
+    /**
+     * The refusal writes the `cross_tenant_access_denied` audit line. The 403
+     * and the audit trail are two separate obligations and the broken guard
+     * dropped both.
+     *
+     * REVERT: goes RED — the logger is never called.
+     *
+     * @return void
+     */
+    public function testCrossOrganisationRefusalIsAudited(): void
+    {
+        $schema = new Schema();
+        $schema->setId(5);
+        $schema->setOrganisation('org-a');
+
+        $captured = [];
+        $logger   = $this->createMock(LoggerInterface::class);
+        $logger->method('warning')->willReturnCallback(
+            function (string $message, array $context = []) use (&$captured): void {
+                $captured[] = $context;
+            }
+        );
+
+        $host = new TenancyGuardHost('org-b', $logger);
+
+        try {
+            $host->verify($schema);
+        } catch (Exception $e) {
+            unset($e);
+        }
+
+        $this->assertCount(1, $captured);
+        $this->assertSame('cross_tenant_access_denied', $captured[0]['type']);
+        $this->assertSame('org-b', $captured[0]['sourceOrganisation']);
+        $this->assertSame('org-a', $captured[0]['targetOrganisation']);
+        $this->assertSame(Schema::class, $captured[0]['entityType']);
+        $this->assertSame(5, $captured[0]['entityId']);
+    }//end testCrossOrganisationRefusalIsAudited()
+
+    /**
+     * An Entity subclass with no organisation property at all must be waved
+     * through rather than fatalling — the guard has to stay a real membership
+     * test. is_callable() would be unconditionally TRUE here and the following
+     * getOrganisation() call would raise BadFunctionCallException.
+     *
+     * REVERT: stays GREEN.
+     *
+     * @return void
+     */
+    public function testEntityWithoutAnOrganisationPropertyIsWavedThrough(): void
+    {
+        $entity = new class extends Entity {
+            /**
+             * A column that is deliberately not `organisation`.
+             *
+             * @var string|null
+             */
+            protected ?string $label = null;
+        };
+
+        $host = new TenancyGuardHost('org-b');
+        $host->verify($entity);
+
+        $this->addToAssertionCount(1);
+    }//end testEntityWithoutAnOrganisationPropertyIsWavedThrough()
+}//end class

--- a/tests/Unit/Repair/LogDanglingLinkedTypesTest.php
+++ b/tests/Unit/Repair/LogDanglingLinkedTypesTest.php
@@ -1,0 +1,239 @@
+<?php
+
+/**
+ * LogDanglingLinkedTypes repair-step unit test.
+ *
+ * The step's whole product is a log line naming WHICH schema declares an
+ * unregistered linkedType. That naming went through safeStringAccessor(), which
+ * probed each candidate accessor with method_exists() — and Db\Schema serves
+ * getSlug()/getUuid() through Entity::__call() as `@method` docblocks, while
+ * getId() is a `@method` on Entity itself. So every candidate was rejected,
+ * scan() logged `slug: 'unknown', id: ''` for 100% of rows, and the report could
+ * not be acted on. These tests assert the identity actually reaches the log.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Repair
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Repair;
+
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Repair\LogDanglingLinkedTypes;
+use OCA\OpenRegister\Service\Integration\IntegrationRegistry;
+use OCP\Migration\IOutput;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit tests for the dangling-linkedType repair step.
+ *
+ * @covers \OCA\OpenRegister\Repair\LogDanglingLinkedTypes
+ */
+class LogDanglingLinkedTypesTest extends TestCase
+{
+
+    /**
+     * Integration registry supplying the set of registered leaf ids.
+     *
+     * @var IntegrationRegistry&MockObject
+     */
+    private IntegrationRegistry&MockObject $registry;
+
+    /**
+     * Container the step lazily resolves SchemaMapper from.
+     *
+     * @var ContainerInterface&MockObject
+     */
+    private ContainerInterface&MockObject $container;
+
+    /**
+     * Logger the warnings land in.
+     *
+     * @var LoggerInterface&MockObject
+     */
+    private LoggerInterface&MockObject $logger;
+
+    /**
+     * Build the collaborators.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registry  = $this->createMock(IntegrationRegistry::class);
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->logger    = $this->createMock(LoggerInterface::class);
+    }//end setUp()
+
+    /**
+     * Build the step over a mapper returning the given schemas.
+     *
+     * @param array<int, mixed> $schemas Schema entities findAll() should return.
+     *
+     * @return LogDanglingLinkedTypes
+     */
+    private function stepReturning(array $schemas): LogDanglingLinkedTypes
+    {
+        $mapper = new class($schemas) {
+
+            /**
+             * @param array<int, mixed> $schemas Rows to hand back.
+             */
+            public function __construct(private array $schemas)
+            {
+            }
+
+            /**
+             * @return array<int, mixed>
+             */
+            public function findAll(): array
+            {
+                return $this->schemas;
+            }
+        };
+
+        $this->container->method('get')->willReturn($mapper);
+
+        return new LogDanglingLinkedTypes(
+            registry: $this->registry,
+            container: $this->container,
+            logger: $this->logger
+        );
+    }//end stepReturning()
+
+    /**
+     * A REAL Db\Schema — the collaborator's own shape, magic accessors and all.
+     *
+     * @param string             $slug        The schema slug.
+     * @param int                $id          The schema primary key.
+     * @param array<int, string> $linkedTypes Declared linked types.
+     *
+     * @return Schema
+     */
+    private function schema(string $slug, int $id, array $linkedTypes): Schema
+    {
+        // fromRow() is how SchemaMapper actually hydrates these rows, and it is
+        // the only faithful fixture here: Schema::setConfiguration() validates
+        // linkedTypes against the live IntegrationRegistry and DROPS the key when
+        // an id is unknown, so building the fixture through the API-save path
+        // would silently produce a schema with no dangling type at all — the
+        // scenario this repair step exists to report could not be represented.
+        return Schema::fromRow(
+            [
+                'id'            => $id,
+                'slug'          => $slug,
+                'configuration' => ['linkedTypes' => $linkedTypes],
+            ]
+        );
+    }//end schema()
+
+    /**
+     * Collect every warning the step emits on the output handle.
+     *
+     * @param LogDanglingLinkedTypes $step The step to run.
+     *
+     * @return array<int, string>
+     */
+    private function runCollectingWarnings(LogDanglingLinkedTypes $step): array
+    {
+        $warnings = [];
+
+        $output = $this->createMock(IOutput::class);
+        $output->method('warning')->willReturnCallback(
+            function (string $message) use (&$warnings): void {
+                $warnings[] = $message;
+            }
+        );
+
+        $step->run($output);
+
+        return $warnings;
+    }//end runCollectingWarnings()
+
+    /**
+     * The dangling type is reported against the schema that declares it, by slug
+     * and by id — not as `Schema "unknown" (id=)`.
+     *
+     * @return void
+     */
+    public function testDanglingTypeIsReportedWithTheSchemaSlugAndId(): void
+    {
+        $this->registry->method('listIds')->willReturn(['files']);
+
+        $step     = $this->stepReturning([$this->schema('contactmoment', 77, ['files', 'nowhere'])]);
+        $warnings = $this->runCollectingWarnings($step);
+
+        $this->assertCount(1, $warnings);
+        $this->assertStringContainsString('"contactmoment"', $warnings[0]);
+        $this->assertStringContainsString('id=77', $warnings[0]);
+        $this->assertStringContainsString('"nowhere"', $warnings[0]);
+        $this->assertStringNotContainsString('unknown', $warnings[0]);
+    }//end testDanglingTypeIsReportedWithTheSchemaSlugAndId()
+
+    /**
+     * Fail-closed control: a schema whose linkedTypes are all registered must
+     * produce no warning at all, so the test above cannot pass by the step
+     * simply warning about everything.
+     *
+     * @return void
+     */
+    public function testNoWarningWhenEveryLinkedTypeIsRegistered(): void
+    {
+        $this->registry->method('listIds')->willReturn(['files', 'nowhere']);
+
+        $step = $this->stepReturning([$this->schema('contactmoment', 77, ['files', 'nowhere'])]);
+
+        $this->assertSame([], $this->runCollectingWarnings($step));
+    }//end testNoWarningWhenEveryLinkedTypeIsRegistered()
+
+    /**
+     * A schema with no slug still reports its id, and only then falls back to
+     * 'unknown' for the name half. This pins that the two accessor lists are
+     * resolved independently rather than both collapsing together.
+     *
+     * @return void
+     */
+    public function testSchemaWithoutASlugStillReportsItsId(): void
+    {
+        $this->registry->method('listIds')->willReturn([]);
+
+        $schema = Schema::fromRow(['id' => 91, 'configuration' => ['linkedTypes' => ['nowhere']]]);
+
+        $warnings = $this->runCollectingWarnings($this->stepReturning([$schema]));
+
+        $this->assertCount(1, $warnings);
+        $this->assertStringContainsString('id=91', $warnings[0]);
+        $this->assertStringContainsString('"unknown"', $warnings[0]);
+    }//end testSchemaWithoutASlugStillReportsItsId()
+
+    /**
+     * A row that is not an Entity at all must not fatal — the accessor probe has
+     * to stay a membership test, not the unconditionally-true answer
+     * is_callable() gives on any __call class.
+     *
+     * @return void
+     */
+    public function testNonEntityRowsAreSkippedWithoutFatal(): void
+    {
+        $this->registry->method('listIds')->willReturn([]);
+
+        $warnings = $this->runCollectingWarnings($this->stepReturning([new \stdClass(), 'not-an-object']));
+
+        $this->assertSame([], $warnings);
+    }//end testNonEntityRowsAreSkippedWithoutFatal()
+}//end class

--- a/tests/Unit/Service/ViewPresentationServiceTest.php
+++ b/tests/Unit/Service/ViewPresentationServiceTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace Unit\Service;
 
 use InvalidArgumentException;
+use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Db\View;
@@ -310,4 +311,126 @@ class ViewPresentationServiceTest extends TestCase
         $this->assertSame(['obj-spans-in', 'obj-starts-in-range'], $ids);
         $this->assertSame('endDate', $result['endDateField']);
     }//end testGetCalendarObjectsMergesSpanningObjectsWithEndDateField()
+
+    // ── getCalendarObjects() — de-duplication across the two queries, ENTITY rows ──
+    //
+    // Everything above feeds the service plain arrays. searchObjectsPaginated()
+    // also returns ObjectEntity rows — ObjectService::collectNamesForResults()
+    // branches on `instanceof ObjectEntity` before it branches on is_array() —
+    // and that is the shape the identity key was broken for: ObjectEntity
+    // declares getUuid()/getId() only as `@method`, served through
+    // Entity::__call(), so method_exists() is FALSE and every row fell through
+    // to spl_object_hash(). The tests below use REAL entities for that reason.
+
+    /**
+     * One database row hydrated twice — once by the "starting" query, once by the
+     * "spanning" query — must collapse to a single calendar entry.
+     *
+     * @return void
+     */
+    public function testGetCalendarObjectsDeduplicatesTheSameEntityRowAcrossBothQueries(): void
+    {
+        $view = $this->createView(
+            ['viewType' => 'calendar', 'calendar' => ['dateField' => 'startDate', 'endDateField' => 'endDate']],
+            ['registers' => [1], 'schemas' => [2]]
+        );
+
+        // Two SEPARATE PHP instances carrying the SAME uuid: exactly what two
+        // queries hydrating one row produce. spl_object_hash() differs between
+        // them, so an identity that falls back to it renders the object twice.
+        $startingRow = new ObjectEntity();
+        $startingRow->setUuid('shared-row-uuid');
+        $spanningRow = new ObjectEntity();
+        $spanningRow->setUuid('shared-row-uuid');
+
+        $callCount = 0;
+        $this->objectService->method('searchObjectsPaginated')->willReturnCallback(
+            function (array $query) use (&$callCount, $startingRow, $spanningRow) {
+                $callCount++;
+                if ($callCount === 1) {
+                    return ['results' => [$startingRow], 'total' => 1];
+                }
+
+                return ['results' => [$spanningRow], 'total' => 1];
+            }
+        );
+
+        $result = $this->service->getCalendarObjects(view: $view, rangeStart: '2026-07-01', rangeEnd: '2026-07-31');
+
+        $this->assertCount(1, $result['objects'], 'The same row must not render twice on the calendar');
+        $this->assertSame(1, $result['total']);
+    }//end testGetCalendarObjectsDeduplicatesTheSameEntityRowAcrossBothQueries()
+
+    /**
+     * Two genuinely different entity rows must still both survive the merge —
+     * the fail-closed control for the test above, which a "collapse everything"
+     * identity would pass.
+     *
+     * @return void
+     */
+    public function testGetCalendarObjectsKeepsDistinctEntityRows(): void
+    {
+        $view = $this->createView(
+            ['viewType' => 'calendar', 'calendar' => ['dateField' => 'startDate', 'endDateField' => 'endDate']],
+            ['registers' => [1], 'schemas' => [2]]
+        );
+
+        $first = new ObjectEntity();
+        $first->setUuid('row-one');
+        $second = new ObjectEntity();
+        $second->setUuid('row-two');
+
+        $callCount = 0;
+        $this->objectService->method('searchObjectsPaginated')->willReturnCallback(
+            function (array $query) use (&$callCount, $first, $second) {
+                $callCount++;
+                if ($callCount === 1) {
+                    return ['results' => [$first], 'total' => 1];
+                }
+
+                return ['results' => [$second], 'total' => 1];
+            }
+        );
+
+        $result = $this->service->getCalendarObjects(view: $view, rangeStart: '2026-07-01', rangeEnd: '2026-07-31');
+
+        $this->assertCount(2, $result['objects']);
+        $this->assertSame(2, $result['total']);
+    }//end testGetCalendarObjectsKeepsDistinctEntityRows()
+
+    /**
+     * An entity row and an already-rendered array row for the SAME object must
+     * produce the same key. getObject()/jsonSerialize() publish the uuid under
+     * `id`, which is what the is_array() branch reads, so the object branch has
+     * to prefer uuid over the numeric primary key or the two shapes diverge.
+     *
+     * @return void
+     */
+    public function testGetCalendarObjectsCollapsesAnEntityAndItsRenderedArrayForm(): void
+    {
+        $view = $this->createView(
+            ['viewType' => 'calendar', 'calendar' => ['dateField' => 'startDate', 'endDateField' => 'endDate']],
+            ['registers' => [1], 'schemas' => [2]]
+        );
+
+        $entityRow = new ObjectEntity();
+        $entityRow->setId(42);
+        $entityRow->setUuid('mixed-shape-uuid');
+
+        $callCount = 0;
+        $this->objectService->method('searchObjectsPaginated')->willReturnCallback(
+            function (array $query) use (&$callCount, $entityRow) {
+                $callCount++;
+                if ($callCount === 1) {
+                    return ['results' => [$entityRow], 'total' => 1];
+                }
+
+                return ['results' => [['id' => 'mixed-shape-uuid']], 'total' => 1];
+            }
+        );
+
+        $result = $this->service->getCalendarObjects(view: $view, rangeStart: '2026-07-01', rangeEnd: '2026-07-31');
+
+        $this->assertCount(1, $result['objects']);
+    }//end testGetCalendarObjectsCollapsesAnEntityAndItsRenderedArrayForm()
 }//end class


### PR DESCRIPTION
## What this fixes

Nextcloud's `Entity` serves `get*()` through `__call()` and declares the accessors only as `@method`, so `method_exists()` is **false** for every one of them — including `getId()`, which `Entity` itself declares that way. Four guards in this app were built on that probe and were therefore permanently false. Fixed with `property_exists()`, which is the membership test `Entity::getter()` itself performs.

Not `is_callable()`: that is unconditionally true on a `__call` class, so swapping to it produces a guard that is always true and converts a silent skip into a `BadFunctionCallException` on any non-entity receiver.

### 1. `MultiTenancyTrait::verifyOrganisationAccess()` — enforcement

The guard returned early for `Schema`, `Register`, `Configuration`, `Action`, `Mapping`, `Webhook`, `Agent` and `Endpoint`, so cross-tenant write enforcement was silently off for eight of the twelve mappers using the trait, across twenty-four `update()`/`delete()` call sites. The false branch is a bare `return` — no organisation comparison, no `cross_tenant_access_denied` audit line, no 403. It was live only for `Source`, `View` and `Application`, whose `getOrganisation()` is written out concretely, which is why nothing looked broken.

The two sibling helpers in the same file already use `property_exists()` and carry a written post-mortem of this exact bug fifty lines above the defect.

### 2. `ViewPresentationService::objectIdentity()` — data correctness

The de-duplication key merging the calendar view's "starting" and "spanning" queries fell through to `spl_object_hash()`, which is unique per PHP instance. The same database row hydrated by both queries produced two keys, so any object that both starts in range and spans it rendered twice.

### 3. `LogDanglingLinkedTypes::safeStringAccessor()` — report correctness

Every candidate accessor was rejected, so all reported rows named an unknown schema with an empty id. Fixed at the shared private seam both call sites funnel into rather than at each reported line.

### 4. `SearchController::search()` — data correctness

`is_array()` is false for an `ObjectEntity` too, so every search hit was returned with a null id and a placeholder name. Unlike the other `getUuid` probes in this app, nothing on this path routes through `getObject()`, so there was no fallback.

## Evidence

Each fix ships with tests whose docblocks state, in advance, which of them turn red on a revert. Each revert was then applied at the exact defect site and observed: the failure sets matched the predictions exactly, in every case — ten for the tenancy guard (the eight magic-accessor entity types plus the audit and no-active-organisation tests, with the three concrete types staying green as the harness control), and two each for the other three.

The tenancy suite is table-driven over all eleven entity types and asserts the accessor shape itself, so if the framework's dispatch ever changes the tests stop meaning something different silently.

Notably, the pre-existing tests for both `SearchController` and the calendar merge fed those code paths **plain arrays**, which is the one shape that worked. `ObjectService` branches on `instanceof ObjectEntity` before it branches on `is_array()`, so the entity shape is real and was untested. The new tests use real entities.

## Behaviour change, deliberately called out

Fixing the tenancy guard turns enforcement **on** for eight entity types at once. It refuses a write when the entity carries an organisation that differs from the caller's active one — including when there is no active organisation at all, e.g. a CLI or repair path on an install whose default organisation differs from the entity's. `hasRbacPermission()` has explicit CLI and system-context escape hatches; `verifyOrganisationAccess()` has none, and did not before this change either. A test pins that fail-closed behaviour so any future decision to soften it is made against an assertion rather than inherited from a broken probe.

The same predicate has been running in production for `Source`, `View` and `Application` throughout. On a single-organisation install nothing changes: `setOrganisationOnCreate()` already stamps the active organisation, and an entity with no organisation is still waved through.

One asymmetry worth a reviewer's eye, pre-existing and now wider: reads are scoped to the organisation **hierarchy** (active plus parents) while this guard compares against the direct active organisation only. A user whose active organisation is a child, writing an entity owned by the parent, can read it and cannot write it. That is unchanged in mechanism and now applies to eight more types.

## Checks run locally

Syntax, PHPCS, PHPStan and PHPMD were run on the four changed `lib/` files, and Psalm across the whole project, all clean. The four affected test files pass together. Gates were left to CI, which sees a real diff scope.
