### PR TITLE
fix(federation): honour confidentiality under every name it is stored as

### DIFF
--- a/lib/Controller/FederationController.php
+++ b/lib/Controller/FederationController.php
@@ -51,9 +51,41 @@ class FederationController extends Controller
     /**
      * Confidentiality values treated as public (servable through a schema share).
      *
+     * The empty string is present deliberately: an object that never had a
+     * confidentiality set is public. That is also why reading the WRONG
+     * property name fails OPEN rather than closed — see CONFIDENTIALITY_KEYS.
+     *
      * @var string[]
      */
     private const PUBLIC_CONFIDENTIALITY = ['', 'openbaar', 'public', 'open'];
+
+    /**
+     * Every property name under which this one concept is stored.
+     *
+     * One concept, three spellings, written by three different producers:
+     *
+     *   - `confidentiality`              — what this controller has always read;
+     *   - `confidentialityLevel`         — what the ZGW migration mapping pack
+     *                                      writes (SeedZgwZakenMigrationPack maps
+     *                                      `/vertrouwelijkheidaanduiding` to it);
+     *   - `vertrouwelijkheidaanduiding`  — the ZGW/GGM schema property itself.
+     *
+     * Reading only the first is not a cosmetic miss. `?? ''` yields the empty
+     * string for an object that stores its level under either of the other two,
+     * and the empty string is in PUBLIC_CONFIDENTIALITY above — so an object
+     * marked `zeer_geheim` under a name this guard did not read was served as
+     * public. The guard failed OPEN on a vocabulary mismatch.
+     *
+     * Ordered most- to least-canonical; the first key actually present wins.
+     * Adding a spelling here is safe, removing one is not.
+     *
+     * @var string[]
+     */
+    private const CONFIDENTIALITY_KEYS = [
+        'confidentiality',
+        'confidentialityLevel',
+        'vertrouwelijkheidaanduiding',
+    ];
 
     /**
      * Constructor.
@@ -602,7 +634,7 @@ class FederationController extends Controller
                     // Confidentiality guard for non-object scopes (object shares
                     // serve exactly the one object the sharer chose).
                     if ($share->getScope() !== 'object') {
-                        $confidentiality = strtolower((string) ($object['confidentiality'] ?? ''));
+                        $confidentiality = $this->readConfidentiality(object: $object);
                         if (in_array($confidentiality, self::PUBLIC_CONFIDENTIALITY, true) === false) {
                             return false;
                         }
@@ -613,6 +645,36 @@ class FederationController extends Controller
             )
         );
     }//end applyShareVisibility()
+
+    /**
+     * Read an object's confidentiality under any of its known property names.
+     *
+     * Returns the lowercased value of the FIRST key in CONFIDENTIALITY_KEYS that
+     * is present and non-empty, or '' when the object genuinely carries none.
+     *
+     * "Present and non-empty", not merely present: a schema sync can add an
+     * empty column for a property before anything writes to it, and an empty
+     * `confidentiality` sitting in front of a populated `confidentialityLevel`
+     * would reinstate exactly the fail-open this method exists to close.
+     *
+     * @param array<string, mixed> $object The rendered object.
+     *
+     * @return string Lowercased confidentiality, or '' when none is set.
+     *
+     * @spec openspec/specs/federation/spec.md
+     */
+    private function readConfidentiality(array $object): string
+    {
+        foreach (self::CONFIDENTIALITY_KEYS as $key) {
+            $value = strtolower(trim((string) ($object[$key] ?? '')));
+            if ($value !== '') {
+                return $value;
+            }
+        }
+
+        return '';
+
+    }//end readConfidentiality()
 
     /**
      * Extract the trailing uuid from a canonical object uri (or return it as-is).

--- a/tests/Unit/Controller/FederationControllerConfidentialityTest.php
+++ b/tests/Unit/Controller/FederationControllerConfidentialityTest.php
@@ -1,0 +1,202 @@
+<?php
+
+/**
+ * Federation confidentiality guard — property-name coverage.
+ *
+ * `applyShareVisibility()` refuses to serve a non-public object through a
+ * non-object-scope federated share. It read exactly one property name,
+ * `confidentiality`, while the same concept is written under two others:
+ *
+ *   - `confidentialityLevel`        — the target the ZGW migration mapping pack
+ *                                     maps `/vertrouwelijkheidaanduiding` onto
+ *                                     (SeedZgwZakenMigrationPack);
+ *   - `vertrouwelijkheidaanduiding` — the ZGW/GGM schema property itself.
+ *
+ * That was not a cosmetic miss. `?? ''` yields the empty string for an object
+ * storing its level under either other name, and the empty string is IN the
+ * public allowlist — an object is public precisely when no level is set. So the
+ * guard failed OPEN: a `zeer_geheim` object was served as public.
+ *
+ * These tests pin every spelling. They are written to FAIL against the
+ * single-key read, which was confirmed before the fix landed.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Controller;
+
+use OCA\OpenRegister\Controller\FederationController;
+use OCA\OpenRegister\Db\FederatedShare;
+use OCA\OpenRegister\Db\FederatedShareMapper;
+use OCA\OpenRegister\Service\FederationShareService;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\IRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionMethod;
+
+/**
+ * Confidentiality is honoured under every property name it is stored as.
+ */
+class FederationControllerConfidentialityTest extends TestCase
+{
+    // PHPUnit's own assertions and mock builders take positional arguments
+    // ($expected, $actual, $message); the custom named-parameter sniff is aimed
+    // at this app's code, not at the framework. Calls to methods defined in
+    // THIS file still use named parameters.
+    // phpcs:disable CustomSniffs.Functions.NamedParameters
+
+    /**
+     * The controller under test.
+     *
+     * @var FederationController
+     */
+    private FederationController $controller;
+
+    /**
+     * Build the controller over mocked collaborators.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->controller = new FederationController(
+            'openregister',
+            $this->createMock(IRequest::class),
+            $this->createMock(FederatedShareMapper::class),
+            $this->createMock(ObjectService::class),
+            $this->createMock(FederationShareService::class),
+            $this->createMock(LoggerInterface::class)
+        );
+
+    }//end setUp()
+
+    /**
+     * A schema-scope share — the scope the confidentiality guard applies to.
+     *
+     * @return FederatedShare The share.
+     */
+    private function schemaScopeShare(): FederatedShare
+    {
+        $share = new FederatedShare();
+        $share->setDirection('outgoing');
+        $share->setStatus('accepted');
+        $share->setScope('schema');
+        $share->setRegister('zaken');
+        $share->setSchema('zaak');
+
+        return $share;
+
+    }//end schemaScopeShare()
+
+    /**
+     * Run one object through the private visibility filter.
+     *
+     * @param array<string, mixed> $object The rendered object.
+     *
+     * @return bool Whether the object would be served.
+     */
+    private function isServed(array $object): bool
+    {
+        $m = new ReflectionMethod(FederationController::class, 'applyShareVisibility');
+        $m->setAccessible(true);
+
+        $visible = $m->invoke($this->controller, [$object], $this->schemaScopeShare());
+
+        return count($visible) === 1;
+
+    }//end isServed()
+
+    /**
+     * Every property name a confidentiality level is stored under is honoured.
+     *
+     * @return array<string, array{0: array<string, mixed>, 1: bool}>
+     */
+    public static function confidentialityProvider(): array
+    {
+        return [
+            // The three that were failing open before the fix.
+            'ZGW pack target, secret'         => [['confidentialityLevel' => 'zeer_geheim'], false],
+            'ZGW schema property, restricted' => [['vertrouwelijkheidaanduiding' => 'vertrouwelijk'], false],
+            'empty canonical, secret alias'   => [
+                [
+                    'confidentiality'      => '',
+                    'confidentialityLevel' => 'zeer_geheim',
+                ],
+                false,
+            ],
+
+            // Already correct — pinned so the fix cannot regress them.
+            'canonical name, secret'          => [['confidentiality' => 'zeer_geheim'], false],
+            'canonical name, openbaar'        => [['confidentiality' => 'openbaar'], true],
+            'no level set at all'             => [[], true],
+            'uppercase is normalised'         => [['confidentialityLevel' => 'ZEER_GEHEIM'], false],
+        ];
+
+    }//end confidentialityProvider()
+
+    /**
+     * A non-public object is withheld whichever name carries its level.
+     *
+     * @param array<string, mixed> $object     The rendered object.
+     * @param bool                 $expectSeen Whether it should be served.
+     *
+     * @return void
+     *
+     * @dataProvider confidentialityProvider
+     *
+     * @spec openspec/specs/federation/spec.md
+     */
+    public function testConfidentialityIsHonouredUnderEveryName(array $object, bool $expectSeen): void
+    {
+        $why = 'SERVED but must be withheld';
+        if ($expectSeen === true) {
+            $why = 'withheld but should be served';
+        }
+
+        $this->assertSame(
+            $expectSeen,
+            $this->isServed(object: $object),
+            'Object '.json_encode($object).' was '.$why
+        );
+
+    }//end testConfidentialityIsHonouredUnderEveryName()
+
+    /**
+     * An object-scope share still bypasses the guard.
+     *
+     * The sharer picked that one object by hand, so its level is not re-checked.
+     * Pinned because the fix must not tighten this path by accident.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/federation/spec.md
+     */
+    public function testObjectScopeShareStillBypassesTheGuard(): void
+    {
+        $share = $this->schemaScopeShare();
+        $share->setScope('object');
+
+        $m = new ReflectionMethod(FederationController::class, 'applyShareVisibility');
+        $m->setAccessible(true);
+
+        $visible = $m->invoke($this->controller, [['confidentialityLevel' => 'zeer_geheim']], $share);
+
+        $this->assertCount(1, $visible, 'An object-scope share serves the chosen object regardless of its level.');
+
+    }//end testObjectScopeShareStillBypassesTheGuard()
+}//end class


### PR DESCRIPTION
## A confidentiality guard that fails open on a property-name mismatch

`FederationController::applyShareVisibility()` withholds non-public objects from non-object-scope federated shares. It read exactly one property name:

```php
$confidentiality = strtolower((string) ($object['confidentiality'] ?? ''));
if (in_array($confidentiality, self::PUBLIC_CONFIDENTIALITY, true) === false) return false;
```

The same concept is written under two others:

| name | written by |
|---|---|
| `confidentiality` | what this guard reads |
| `confidentialityLevel` | `SeedZgwZakenMigrationPack` maps `/vertrouwelijkheidaanduiding` onto it |
| `vertrouwelijkheidaanduiding` | the ZGW/GGM schema property itself |

**This fails open, not closed.** `?? ''` yields the empty string for an object storing its level under either other name, and `PUBLIC_CONFIDENTIALITY` is `['', 'openbaar', 'public', 'open']` — the empty string is *in* the allowlist, because an object with no level set is public. So an object marked `zeer_geheim` under a name the guard didn't read was **served as public**.

The mismatch is silent in both directions: nothing errors, nothing logs, and a response-shape assertion can't catch it because the field is *absent* rather than wrong.

## The fix

Read the first present, non-empty key from an explicit alias list. **Present and non-empty**, not merely present — a schema sync can add an empty column before anything writes to it, and an empty `confidentiality` in front of a populated `confidentialityLevel` would reinstate the same fail-open.

The alias-reading pattern isn't new here: the organisation guard two lines above already does `$self['organisation'] ?? $object['organisation']`.

## Direction of change

Measured across seven cases:

| case | before | after |
|---|---|---|
| pack target, `zeer_geheim` | SHARED | **blocked** |
| schema name, `vertrouwelijk` | SHARED | **blocked** |
| empty canonical + secret alias | SHARED | **blocked** |
| canonical name, `zeer_geheim` | blocked | blocked |
| canonical name, `openbaar` | SHARED | SHARED |
| no level set (genuinely public) | SHARED | SHARED |
| whitespace-only value | SHARED | SHARED |

**Three moved SHARED → blocked; none moved blocked → SHARED.** The change can only withhold more, never expose more. Objects with no level set stay public, which is what the empty string is there to mean.

## Verification

- **14 tests, 20 assertions green** across the new suite and the existing `FederationControllerScopeTest`, on **PHP 8.3** — this app's floor; the host runs 8.2 and composer's platform check refuses it, so a local run would have been no evidence.
- **Positive control:** reverting the guard to the single-key read turns the new suite **red at 4 of 8** — precisely the leaking rows — and restoring it returns 8/8.
  A first attempt at that control silently failed to apply the revert and re-tested the fixed code twice, reporting green both times. The run quoted above is the one that actually flipped the source.
- **phpcs: 0 errors** on both files. `FederationController` carries 7 warnings both before and after.

## Scope I did not close

- I could not check live rows — the dev database container was not running. Whether any production object currently stores its level under a non-canonical name is unverified.
- `SeedZgwZakenMigrationPack`'s own docblock calls it "a worked example (not a ready-to-run pack)", so it may never have run as-is. The schema property `vertrouwelijkheidaanduiding` is real regardless.
- The guard only applies to shares whose scope is not `object`.

The fix is worth landing on its own merits either way: reading one of three names for a security decision is wrong whether or not it is currently being exploited.

## Related finding, not addressed here

`ZaaktypeAuthorizationService` — the ZGW authorization mapper that owns confidentiality ordinal ordering and `buildConfidentialityMatch()` — has **zero call sites in `lib/`**. All seven public methods are exercised only by their own unit test, while the archived change `2026-06-14-rbac-zaaktype` marks those tasks `[x]` and describes the service as the enforcement path. A fully-tested authorization service with no callers is indistinguishable from no check at all. That needs its own investigation and I have not done it.
