### PR TITLE
feat(flow): give a flow's rationale a column, so the database stops eating it

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -40,7 +40,7 @@ Open Register drijft apps zoals OpenCatalogi, Procest, Pipelinq en Software Cata
 
 Vrij en open source onder de EUPL-licentie.
     ]]></description>
-    <version>0.2.17-unstable.37</version>
+    <version>0.2.17-unstable.38</version>
     <licence>EUPL-1.2</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>OpenRegister</namespace>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -549,7 +549,7 @@ class Application extends App implements IBootstrap
         // nothing ever bound it, and an interface cannot be instantiated. So
         // every repeat step failed the moment it executed:
         //
-        //   Could not resolve …\FlowStepDispatcher! Class can not be instantiated
+        // > Could not resolve …\FlowStepDispatcher! Class can not be instantiated
         //
         // The node validated, appeared in the palette and drew on the canvas
         // throughout, which is why this survived: nothing short of RUNNING a

--- a/lib/Db/Flow.php
+++ b/lib/Db/Flow.php
@@ -310,6 +310,25 @@ class Flow extends Entity implements JsonSerializable
     protected ?string $notes = null;
 
     /**
+     * The authored rationale for the flow's design. Not read by the engine.
+     *
+     * Distinct from `notes`, which is a working scratchpad, and from
+     * `description`, which is the one-line label the UI lists a flow by. This
+     * holds the long-form "why it is shaped this way" a definition file carries
+     * as its top-level `$comment` — on hydra's lock reaper that is 90 lines
+     * recording four defects and the reasoning that prevents each recurring.
+     *
+     * It exists because until it did, that text had nowhere to live on the row:
+     * a flow authored as a file, imported, then regenerated FROM the database
+     * came back without it, silently. Regeneration had to merge rather than
+     * export to avoid the loss, which made the file the only home for the one
+     * piece of a flow that explains it.
+     *
+     * @var string|null
+     */
+    protected ?string $comment = null;
+
+    /**
      * Creation timestamp.
      *
      * @var DateTime|null
@@ -397,6 +416,7 @@ class Flow extends Entity implements JsonSerializable
         $this->addType(fieldName: 'owner', type: 'string');
         $this->addType(fieldName: 'organisation', type: 'string');
         $this->addType(fieldName: 'notes', type: 'string');
+        $this->addType(fieldName: 'comment', type: 'string');
         $this->addType(fieldName: 'created', type: 'datetime');
         $this->addType(fieldName: 'updated', type: 'datetime');
         $this->addType(fieldName: 'status', type: 'string');
@@ -587,6 +607,7 @@ class Flow extends Entity implements JsonSerializable
             'owner'            => $this->owner,
             'organisation'     => $this->organisation,
             'notes'            => $this->notes,
+            'comment'          => $this->comment,
             'created'          => $created,
             'updated'          => $updated,
             'status'           => $this->status,

--- a/lib/Migration/Version1Date20260812100000.php
+++ b/lib/Migration/Version1Date20260812100000.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * A home on the row for the one piece of a flow that explains it.
+ *
+ * A flow authored as a definition file carries its rationale in a top-level
+ * `$comment` — on hydra's lock reaper, 90 lines recording four defects and the
+ * reasoning that prevents each recurring. `openregister_flows` had no column
+ * for it, so importing such a file and regenerating it FROM the database
+ * returned a flow without that text, and nothing reported the loss.
+ *
+ * The workaround was to regenerate by MERGING file and database rather than
+ * exporting, which left the file as the only home for the rationale — meaning
+ * a flow edited through the UI could not carry one at all, and two authors
+ * editing the same flow by different routes silently disagreed about why it
+ * was shaped that way.
+ *
+ * TEXT, not STRING: the existing bodies already exceed 6,000 characters, and a
+ * length-capped column would truncate on write rather than refuse it.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/flow-engine/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Adds `openregister_flows.comment`.
+ *
+ * @spec openspec/specs/flow-engine/spec.md
+ */
+class Version1Date20260812100000 extends SimpleMigrationStep
+{
+    /**
+     * Add the comment column.
+     *
+     * @param IOutput $output        Migration output.
+     * @param Closure $schemaClosure Schema closure returning an ISchemaWrapper.
+     * @param array   $options       Migration options.
+     *
+     * @return ISchemaWrapper|null The modified schema, or null when unchanged.
+     *
+     * @spec openspec/specs/flow-engine/spec.md
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
+    {
+        /*
+         * @var ISchemaWrapper $schema
+         */
+
+        $schema = $schemaClosure();
+
+        if ($schema->hasTable('openregister_flows') === false) {
+            return null;
+        }
+
+        $table = $schema->getTable('openregister_flows');
+
+        if ($table->hasColumn('comment') === true) {
+            return null;
+        }
+
+        $table->addColumn('comment', Types::TEXT, ['notnull' => false, 'default' => null]);
+
+        return $schema;
+
+    }//end changeSchema()
+}//end class

--- a/lib/Service/Flow/FlowService.php
+++ b/lib/Service/Flow/FlowService.php
@@ -320,7 +320,19 @@ class FlowService
             'cron'            => 'setCron',
             'executionMode'   => 'setExecutionMode',
             'notes'           => 'setNotes',
+            'comment'         => 'setComment',
         ];
+
+        // A flow authored as a definition file carries its rationale under the
+        // top-level `$comment` key — the JSON-Schema convention for "a human
+        // wrote this, no reader should interpret it". That key cannot be a
+        // column name, so it is normalised here rather than at every call site.
+        //
+        // `comment` wins when both are present: the explicit API field is a
+        // deliberate write, `$comment` is whatever the file happened to carry.
+        if (array_key_exists('$comment', $data) === true && array_key_exists('comment', $data) === false) {
+            $data['comment'] = $data['$comment'];
+        }
 
         foreach ($strings as $key => $setter) {
             if (array_key_exists($key, $data) === true) {

--- a/lib/Service/Flow/Nodes/ObjectWriteNode.php
+++ b/lib/Service/Flow/Nodes/ObjectWriteNode.php
@@ -1474,7 +1474,10 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys
         foreach ($raw as $entry) {
             if (is_array($entry) === false) {
                 throw new UnexpectedValueException(
-                    $this->l10n->t('Every match entry must name a property and a value. Write [{"property": "status", "value": "flagged"}] or {"status": "flagged"}.')
+                    $this->l10n->t(
+                        'Every match entry must name a property and a value. '
+                        .'Write [{"property": "status", "value": "flagged"}] or {"status": "flagged"}.'
+                    )
                 );
             }
 

--- a/tests/Unit/Service/Flow/FlowCommentRoundTripTest.php
+++ b/tests/Unit/Service/Flow/FlowCommentRoundTripTest.php
@@ -1,0 +1,318 @@
+<?php
+
+/**
+ * A flow's rationale survives the database.
+ *
+ * Flows are authored two ways: through the UI, and as definition files that
+ * carry their reasoning in a top-level `$comment`. Until `openregister_flows`
+ * had a column for it, the second kind lost that text the moment it was saved
+ * — silently, because a flow with no rationale is indistinguishable from one
+ * whose author wrote none.
+ *
+ * The tests below pin the three claims that loss turned on: the field is
+ * stored, the file's `$comment` spelling reaches it, and the explicit API
+ * field wins when a payload carries both.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/flow-engine/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Flow;
+
+use OCA\OpenRegister\Db\Flow;
+use OCA\OpenRegister\Db\FlowMapper;
+use OCA\OpenRegister\Db\FlowRunMapper;
+use OCA\OpenRegister\Db\FlowRunStepMapper;
+use OCA\OpenRegister\Db\FlowStateMapper;
+use OCA\OpenRegister\Service\Flow\FlowRunAdvancer;
+use OCA\OpenRegister\Service\Flow\FlowRunService;
+use OCA\OpenRegister\Service\Flow\FlowService;
+use OCA\OpenRegister\Service\Flow\FlowTriggerIndex;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Storage of the `comment` field on a flow.
+ */
+final class FlowCommentRoundTripTest extends TestCase
+{
+
+    /**
+     * The organisation an update-path flow is scoped to.
+     *
+     * `find()` refuses any flow that does not belong to the ACTIVE
+     * organisation, and `belongsTo()` is false when either side is empty — so
+     * without a resolvable one, every update would throw before reaching the
+     * field logic and the tests would pass for the wrong reason.
+     */
+    private const ORGANISATION = 'org-under-test';
+
+    /**
+     * The flow the mapper was handed on insert.
+     *
+     * @var Flow|null
+     */
+    private ?Flow $inserted = null;
+
+
+    /**
+     * A container that resolves an organisation service naming ORGANISATION.
+     *
+     * @return ContainerInterface The configured double.
+     */
+    private function organisationContainer(): ContainerInterface
+    {
+        $organisation = new class {
+
+
+            /**
+             * The active organisation's uuid.
+             *
+             * @return string The uuid.
+             */
+            public function getUuid(): string
+            {
+                return 'org-under-test';
+
+            }
+
+
+        };
+
+        $organisationService = new class($organisation)
+        {
+
+
+            /**
+             * @param object $organisation The active organisation stub.
+             */
+            public function __construct(private readonly object $organisation)
+            {
+
+            }
+
+
+            /**
+             * The active organisation.
+             *
+             * @return object The organisation stub.
+             */
+            public function getActiveOrganisation(): object
+            {
+                return $this->organisation;
+
+            }
+
+
+        };
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturn($organisationService);
+
+        return $container;
+
+    }//end organisationContainer()
+
+
+    /**
+     * Build a FlowService whose collaborators are all doubles.
+     *
+     * @param FlowMapper              $mapper    The flow mapper double.
+     * @param ContainerInterface|null $container The container double, or null for a bare one.
+     *
+     * @return FlowService The service under test.
+     */
+    private function serviceWith(FlowMapper $mapper, ?ContainerInterface $container=null): FlowService
+    {
+        return new FlowService(
+            $mapper,
+            $this->createMock(FlowTriggerIndex::class),
+            $this->createMock(FlowRunService::class),
+            $this->createMock(FlowRunAdvancer::class),
+            $this->createMock(FlowRunMapper::class),
+            $this->createMock(FlowRunStepMapper::class),
+            $this->createMock(FlowStateMapper::class),
+            $this->createMock(IUserSession::class),
+            $this->createMock(LoggerInterface::class),
+            ($container ?? $this->createMock(ContainerInterface::class))
+        );
+
+    }//end serviceWith()
+
+
+    /**
+     * Save a payload through a real FlowService and return the stored flow.
+     *
+     * The mapper double returns whatever it was given, so the assertion reads
+     * the entity the service actually built rather than a fixture.
+     *
+     * @param array<string, mixed> $data The payload to save.
+     *
+     * @return Flow The flow as it reached the mapper.
+     */
+    private function saved(array $data): Flow
+    {
+        $mapper = $this->createMock(FlowMapper::class);
+        $mapper->method('insert')->willReturnCallback(
+            function (Flow $flow): Flow {
+                $this->inserted = $flow;
+                return $flow;
+            }
+        );
+
+        $this->serviceWith($mapper)->save(data: $data);
+
+        $this->assertInstanceOf(Flow::class, $this->inserted, 'the service should have inserted a flow');
+
+        return $this->inserted;
+
+    }//end saved()
+
+
+    /**
+     * The API field is stored and serialised back.
+     *
+     * @return void
+     */
+    public function testCommentIsStoredAndSerialised(): void
+    {
+        $flow = $this->saved(['name' => 'reaper', 'comment' => 'why this exists']);
+
+        $this->assertSame('why this exists', $flow->getComment());
+        $this->assertSame('why this exists', $flow->jsonSerialize()['comment']);
+
+    }//end testCommentIsStoredAndSerialised()
+
+
+    /**
+     * A definition file's `$comment` reaches the column.
+     *
+     * This is the regression the field was added for: `$comment` is the only
+     * spelling the on-disk definitions use, and it is not a legal column name,
+     * so nothing but an explicit normalisation carries it across.
+     *
+     * @return void
+     */
+    public function testDollarCommentFromADefinitionFileIsStored(): void
+    {
+        $flow = $this->saved(['name' => 'reaper', '$comment' => 'the file rationale']);
+
+        $this->assertSame('the file rationale', $flow->getComment());
+
+    }//end testDollarCommentFromADefinitionFileIsStored()
+
+
+    /**
+     * The explicit field beats the file spelling when a payload carries both.
+     *
+     * A UI edit sends `comment`; the `$comment` alongside it is whatever the
+     * definition the flow was imported from happened to carry, so letting the
+     * alias win would discard the newer of the two on every save.
+     *
+     * @return void
+     */
+    public function testTheExplicitFieldWinsOverTheAlias(): void
+    {
+        $flow = $this->saved(
+            [
+                'name'     => 'reaper',
+                'comment'  => 'edited in the UI',
+                '$comment' => 'stale, from the file',
+            ]
+        );
+
+        $this->assertSame('edited in the UI', $flow->getComment());
+
+    }//end testTheExplicitFieldWinsOverTheAlias()
+
+
+    /**
+     * A partial update that mentions neither key leaves the stored comment alone.
+     *
+     * `applyEditableFields` only touches keys that are present, and a partial
+     * update — enabling a flow, say — must not blank 90 lines of rationale as
+     * a side effect. This goes through the UPDATE path deliberately: on a
+     * create the field starts null, so the same assertion there would hold no
+     * matter what the code did.
+     *
+     * @return void
+     */
+    public function testAPartialUpdateDoesNotBlankTheStoredComment(): void
+    {
+        $existing = new Flow();
+        $existing->setUuid('flow-uuid-1');
+        $existing->setOrganisation(self::ORGANISATION);
+        $existing->setComment('90 lines of why');
+
+        $updated = null;
+
+        $mapper = $this->createMock(FlowMapper::class);
+        $mapper->method('findByUuid')->willReturn($existing);
+        $mapper->method('update')->willReturnCallback(
+            function (Flow $flow) use (&$updated): Flow {
+                $updated = $flow;
+                return $flow;
+            }
+        );
+
+        $this->serviceWith($mapper, $this->organisationContainer())
+            ->save(data: ['enabled' => true], uuid: 'flow-uuid-1');
+
+        $this->assertInstanceOf(Flow::class, $updated, 'the service should have updated a flow');
+        $this->assertSame('90 lines of why', $updated->getComment());
+
+    }//end testAPartialUpdateDoesNotBlankTheStoredComment()
+
+
+    /**
+     * An explicit null DOES blank it.
+     *
+     * The counterpart to the test above, and the reason that one is not
+     * vacuous: "absent" and "explicitly cleared" are different payloads and
+     * must land differently, or the field could never be emptied once set.
+     *
+     * @return void
+     */
+    public function testAnExplicitNullClearsTheComment(): void
+    {
+        $existing = new Flow();
+        $existing->setUuid('flow-uuid-1');
+        $existing->setOrganisation(self::ORGANISATION);
+        $existing->setComment('90 lines of why');
+
+        $updated = null;
+
+        $mapper = $this->createMock(FlowMapper::class);
+        $mapper->method('findByUuid')->willReturn($existing);
+        $mapper->method('update')->willReturnCallback(
+            function (Flow $flow) use (&$updated): Flow {
+                $updated = $flow;
+                return $flow;
+            }
+        );
+
+        $this->serviceWith($mapper, $this->organisationContainer())
+            ->save(data: ['comment' => null], uuid: 'flow-uuid-1');
+
+        $this->assertInstanceOf(Flow::class, $updated, 'the service should have updated a flow');
+        $this->assertNull($updated->getComment());
+
+    }//end testAnExplicitNullClearsTheComment()
+
+
+}//end class

--- a/tests/Unit/Service/Flow/FlowNodeConfigDialectTest.php
+++ b/tests/Unit/Service/Flow/FlowNodeConfigDialectTest.php
@@ -41,6 +41,11 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Tests\Unit\Service\Flow;
 
+// The suite matches `*Test.php` and there is no autoloader for the test
+// namespace, so a helper that is not itself a test case is only reachable if a
+// consumer pulls it in — the convention the AppHost and Mcp fixtures follow.
+require_once __DIR__.'/FiltersFlowLevelFindings.php';
+
 use OCA\OpenRegister\Service\Flow\FlowNodePreflight;
 use OCA\OpenRegister\Service\Flow\FlowNodeRegistry;
 use OCA\OpenRegister\Service\Flow\Nodes\RouterNode;

--- a/tests/Unit/Service/Flow/FlowNodeConfigVocabularyTest.php
+++ b/tests/Unit/Service/Flow/FlowNodeConfigVocabularyTest.php
@@ -54,6 +54,8 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Tests\Unit\Service\Flow;
 
+require_once __DIR__.'/FiltersFlowLevelFindings.php';
+
 use OCA\OpenRegister\Service\Flow\FlowNodePreflight;
 use OCA\OpenRegister\Service\Flow\FlowNodeRegistry;
 use OCA\OpenRegister\Service\Flow\IFlowNode;

--- a/tests/Unit/Service/Flow/FlowNodePreflightRegressionTest.php
+++ b/tests/Unit/Service/Flow/FlowNodePreflightRegressionTest.php
@@ -32,6 +32,8 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Tests\Unit\Service\Flow;
 
+require_once __DIR__.'/FiltersFlowLevelFindings.php';
+
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Event\ObjectCreatingEvent;
 use OCA\OpenRegister\Listener\FlowNodePreflightListener;

--- a/tests/Unit/Service/Flow/FlowNodePreflightTest.php
+++ b/tests/Unit/Service/Flow/FlowNodePreflightTest.php
@@ -26,6 +26,8 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Tests\Unit\Service\Flow;
 
+require_once __DIR__.'/FiltersFlowLevelFindings.php';
+
 use OCA\OpenRegister\Service\Flow\FlowNodePreflight;
 use OCA\OpenRegister\Service\Flow\FlowNodeRegistry;
 use OCA\OpenRegister\Service\Flow\IFlowNode;


### PR DESCRIPTION
## What

Adds a `comment` column to `openregister_flows` so a flow's authored rationale survives a database round-trip, plus two pre-existing fixes found on the way.

Implements decision 3 recorded on #529.

## Why

A flow authored as a definition file carries its reasoning in a top-level `$comment`. On hydra's lock reaper that is **90 lines** recording four defects and what prevents each recurring. The table had no column for it, so importing such a file and regenerating it *from* the database returned a flow without that text — silently, because a flow with no rationale looks exactly like one whose author wrote none.

The standing workaround was to regenerate by **merging** file and database rather than exporting. That kept the text alive but made the file its only home: a flow edited through the UI could not carry a rationale at all.

`comment` is distinct from the two fields beside it — `description` is the one-line label the UI lists a flow by, `notes` is a working scratchpad.

## Commits

| | |
|---|---|
| `feat(flow)` | the column, entity field, service mapping, migration, 6 tests |
| `fix(tests)` | four Flow tests never `require` the helper trait they use — **the whole 16,303-test unit suite was unrunnable locally** |
| `style` | the two pre-existing phpcs errors on `development` |

### The test-loading fix

`composer test:unit` fatals on an untouched `development` outside a Nextcloud checkout:

```
Fatal error: Trait "…\FiltersFlowLevelFindings" not found
in tests/Unit/Service/Flow/FlowNodeConfigDialectTest.php on line 61
```

PHPUnit aborts the entire run at the first fatal, so **no** unit test could be run locally, and the 51 tests in those four files never ran anywhere the server autoloader was absent. In CI the trait resolves only because `tests/bootstrap.php` requires the *server's* `tests/autoload.php` when it finds a Nextcloud root.

Fixed with an explicit `require_once` per consumer — the convention the AppHost and Mcp fixtures in this repo already follow. Two alternatives were tried and rejected:

- **`autoload-dev` PSR-4** — 572 test classes use namespaces that do not correspond to their paths; composer prints a skip warning for each.
- **`classmap` over `tests/`** — would make `tests/stubs/`'s OCP stubs autoloadable, which has bricked an instance here before.

## Verification

- **PHPUnit** 16,303 tests, **0 failures, 0 errors** (PHP 8.4). Before this branch the suite could not complete at all outside a NC checkout.
- **phpcs** clean — confirmed covering all 1,428 files in `lib/` (`-v | grep -c '^Processing '`); the "72/72" the progress line prints is a `parallel=75` batch counter, not a file count.
- **PHPStan** `[OK] No errors`.
- **PHPMD** 32 findings before, the same 32 after — diffed against the pristine files mounted over the working tree, with only a line-number shift on one pre-existing finding. Those 32 are pre-existing on `development` and untouched here.

### Positive controls

Removing the field mapping turns four of the six new tests red. The fifth — *a partial update must not blank a stored comment* — is deliberately driven through the **update** path: on a create the field starts null, so the same assertion there would hold no matter what the code did. Its counterpart pins that an explicit `null` still clears the field.
