### PR TITLE
fix(api): an object that does not exist is a 404 on the integration leaves, not a 500

### DIFF
--- a/lib/Controller/ObjectIntegrationsController.php
+++ b/lib/Controller/ObjectIntegrationsController.php
@@ -128,6 +128,15 @@ class ObjectIntegrationsController extends Controller
      * resolves to null and the request is refused with 404 (existence is not
      * leaked).
      *
+     * `setObject()` IS INSIDE THE TRY, and that is the whole point of the
+     * shape. It is not a setter: it calls `objectMapper->find()`, which throws
+     * `DoesNotExistException` when nothing matches. Left outside, a request for
+     * an object that does not exist escaped as a 500 — "Object not found in
+     * magic table" — rather than the 404 this method's own docblock promises.
+     * The `getObject()` call it guarded can only be reached once `setObject()`
+     * has already succeeded, so the catch was placed one line past the throw it
+     * needed to cover.
+     *
      * @param string $register Register slug or numeric id.
      * @param string $schema   Schema slug or numeric id.
      * @param string $id       Object uuid.
@@ -136,11 +145,11 @@ class ObjectIntegrationsController extends Controller
      */
     private function guardObjectAccess(string $register, string $schema, string $id): ?JSONResponse
     {
-        $this->objectService->setRegister($register);
-        $this->objectService->setSchema($schema);
-        $this->objectService->setObject($id);
-
         try {
+            $this->objectService->setRegister($register);
+            $this->objectService->setSchema($schema);
+            $this->objectService->setObject($id);
+
             $object = $this->objectService->getObject();
         } catch (\Throwable $e) {
             return new JSONResponse(['message' => 'Object not found'], Http::STATUS_NOT_FOUND);

--- a/tests/Unit/Controller/ObjectIntegrationsControllerTest.php
+++ b/tests/Unit/Controller/ObjectIntegrationsControllerTest.php
@@ -170,6 +170,88 @@ class ObjectIntegrationsControllerTest extends TestCase
         return $objectService;
     }//end deniedObjectService()
 
+    /**
+     * An ObjectService whose setObject() THROWS, which is what the real one
+     * does for an id that matches nothing: it is not a setter, it calls
+     * `objectMapper->find()`.
+     *
+     * `deniedObjectService()` above cannot cover this. It stubs `getObject()`
+     * alone, so on a mock `setObject()` is a silent no-op and the throwing
+     * path is unreachable — which is exactly why a 500 lived here unnoticed
+     * behind a green test named "denies inaccessible object".
+     */
+    private function missingObjectService(): \OCA\OpenRegister\Service\ObjectService
+    {
+        $objectService = $this->createMock(\OCA\OpenRegister\Service\ObjectService::class);
+        $objectService->method('setObject')->willThrowException(
+            new \OCP\AppFramework\Db\DoesNotExistException('Object not found in magic table')
+        );
+
+        return $objectService;
+    }//end missingObjectService()
+
+    /**
+     * An object id that resolves to nothing is a 404, not a 500.
+     *
+     * Found via openconnector's `synced-from-leaf` e2e spec, which asks this
+     * endpoint about a deliberately absent uuid and expects an empty 200/404.
+     * It got a 500 with "Object not found in magic table" — and had never run,
+     * because it is skipped unless `openconnector.storage_migrated` is true,
+     * which no fresh install ever set (ocon#1180).
+     */
+    public function testIndexReturns404WhenTheObjectDoesNotExist(): void
+    {
+        $stub     = new _ControllerStubProvider('stub');
+        $registry = new IntegrationRegistry(new NullLogger());
+        $registry->addProvider($stub);
+
+        $controller = $this->buildController($registry, null, $this->missingObjectService());
+
+        $response = $controller->index('r', 's', '00000000-0000-0000-0000-000000000000', 'stub');
+
+        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+        $this->assertSame([], $stub->listCalled, 'the provider must not be reached');
+    }//end testIndexReturns404WhenTheObjectDoesNotExist()
+
+    /**
+     * The same holds for the other four verbs, which share the guard.
+     *
+     * @dataProvider guardedVerbProvider
+     */
+    public function testEveryGuardedVerbReturns404WhenTheObjectDoesNotExist(string $verb): void
+    {
+        $registry = new IntegrationRegistry(new NullLogger());
+        $registry->addProvider(new _ControllerStubProvider('stub'));
+
+        $controller = $this->buildController($registry, $this->buildRequest(), $this->missingObjectService());
+
+        $missing = '00000000-0000-0000-0000-000000000000';
+
+        $response = match ($verb) {
+            'show'    => $controller->show('r', 's', $missing, 'stub', 'e1'),
+            'create'  => $controller->create('r', 's', $missing, 'stub'),
+            'update'  => $controller->update('r', 's', $missing, 'stub', 'e1'),
+            'destroy' => $controller->destroy('r', 's', $missing, 'stub', 'e1'),
+        };
+
+        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus(), $verb.' must 404, not 500');
+    }//end testEveryGuardedVerbReturns404WhenTheObjectDoesNotExist()
+
+    /**
+     * The verbs that go through guardObjectAccess().
+     *
+     * @return array<string, array{0: string}>
+     */
+    public static function guardedVerbProvider(): array
+    {
+        return [
+            'show'    => ['show'],
+            'create'  => ['create'],
+            'update'  => ['update'],
+            'destroy' => ['destroy'],
+        ];
+    }//end guardedVerbProvider()
+
     public function testIndexDeniesInaccessibleObject(): void
     {
         // IDOR: the caller cannot read the target OR object → 404, and the


### PR DESCRIPTION
## The bug

```
GET /api/objects/{register}/{schema}/{id}/integrations/{integrationId}
```

with an id matching nothing answered **500** — `DoesNotExistException: Object not found in magic table` — instead of the 404 `guardObjectAccess()`'s own docblock promises.

`setObject()` is **not a setter**. It calls `objectMapper->find()`, which throws when nothing matches. It sat one line *above* the `try` whose catch already returns 404:

```php
$this->objectService->setObject($id);   // ← throws here

try {
    $object = $this->objectService->getObject();   // ← only reachable if the above succeeded
} catch (\Throwable $e) {
    return new JSONResponse(['message' => 'Object not found'], Http::STATUS_NOT_FOUND);
}
```

The guard was wrapped around the wrong call. Moving the three resolution calls inside the `try` fixes all five verbs, which share it.

## Why no test caught it

The existing test is called `testIndexDeniesInaccessibleObject` and it is green. It stubs `getObject()` alone — and on a mock, `setObject()` is a silent no-op, so the throwing path was **unreachable from the suite**. A green test with exactly the right name was standing over a 500.

The new `missingObjectService()` throws from `setObject()` the way the real service does, rather than stubbing the call that comes after it.

## How it was found

From the other end, and only by accident. openconnector's `synced-from-leaf` e2e spec asks this endpoint about a deliberately absent uuid and expects an empty result. That spec had **never run**: it skips unless `openconnector.storage_migrated` is true, and no fresh install ever set that flag ([ocon#1180](https://github.com/ConductionNL/openconnector/issues/1180)).

Fixing the flag ran the spec, and the spec found this. The disabled feature was load-bearing for the silence.

**Reproduced live** on the dev instance, which has the flag set:

```
$ curl -u admin:admin ".../api/objects/<register>/<schema>/00000000-0000-0000-0000-000000000000/integrations/sync-contract"
HTTP 500
→ "Exception":"OCP\\AppFramework\\Db\\DoesNotExistException","Message":"Object not found in magic table"
```

## Verification

- **6 tests** — the index verb plus a data provider over `show` / `create` / `update` / `destroy`, which share the guard.
- **Positive control**: reverting the guard to its previous shape turns all five new cases red (errors, not failures — the exception escapes).
- `tests/Unit/Controller` — 2,802 tests green.
- **phpcs** clean on the changed file.

> The **full** unit suite cannot run on this branch: `development` currently fatals at `tests/Unit/Service/Flow/FlowNodeConfigDialectTest.php` on a helper trait nothing requires. That is fixed separately in #2439; this branch inherits it and is unaffected by it.
