### PR TITLE
chore(flow): rewrite stored node types so the alias table can actually retire

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -123,6 +123,9 @@ Vrij en open source onder de EUPL-licentie.
 			<step>OCA\OpenRegister\Repair\ReconcileDeclaredBackgroundJobs</step>
 			<step>OCA\OpenRegister\Repair\RegisterRiskLevelMetadata</step>
 			<step>OCA\OpenRegister\Repair\LogDanglingLinkedTypes</step>
+			<!-- Rewrite before the index is derived: the index is built FROM node
+			     types, so the types should already be the current ones. -->
+			<step>OCA\OpenRegister\Repair\MigrateRenamedFlowNodeTypes</step>
 			<step>OCA\OpenRegister\Repair\BackfillFlowTriggerIndex</step>
 			<step>OCA\OpenRegister\Repair\InitializeFlowActions</step>
 			<step>OCA\OpenRegister\Repair\MigrateNotificationSubscriptionsToUserConfig</step>
@@ -141,6 +144,9 @@ Vrij en open source onder de EUPL-licentie.
 			<step>OCA\OpenRegister\Repair\ReconcileDeclaredBackgroundJobs</step>
 			<step>OCA\OpenRegister\Repair\RegisterRiskLevelMetadata</step>
 			<step>OCA\OpenRegister\Repair\LogDanglingLinkedTypes</step>
+			<!-- Rewrite before the index is derived: the index is built FROM node
+			     types, so the types should already be the current ones. -->
+			<step>OCA\OpenRegister\Repair\MigrateRenamedFlowNodeTypes</step>
 			<step>OCA\OpenRegister\Repair\BackfillFlowTriggerIndex</step>
 			<step>OCA\OpenRegister\Repair\InitializeFlowActions</step>
 			<step>OCA\OpenRegister\Repair\SeedDirectoryVirtualSchemas</step>

--- a/lib/Repair/MigrateRenamedFlowNodeTypes.php
+++ b/lib/Repair/MigrateRenamedFlowNodeTypes.php
@@ -1,0 +1,223 @@
+<?php
+
+/**
+ * MigrateRenamedFlowNodeTypes — rewrite stored node types to their current names.
+ *
+ * `FlowNodeRegistry` resolves two old node ids through an alias table:
+ * `openregister.loop` → `openregister.batch` and `openregister.stop` →
+ * `openregister.end`. Its docblock says the alias is removed one release after
+ * the rename — and nothing has ever rewritten the stored definitions, so the
+ * day it goes, every flow still carrying an old name stops resolving.
+ *
+ * Measured on the development instance before this step existed: 13 nodes
+ * across 19 flows still named `openregister.stop`. They work, silently, on the
+ * alias. That is the shape of a deadline nobody can see: the definitions look
+ * fine, the runs succeed, and the breakage arrives with a release that touches
+ * none of them.
+ *
+ * The map is READ FROM the registry rather than repeated here, so dropping a
+ * pair there stops this step rewriting it in the same commit — the retirement
+ * order is correct by construction rather than by memory.
+ *
+ * SAFE TO RUN REPEATEDLY. A flow with no old names is not written at all, so a
+ * second run touches nothing and no flow's `updated` timestamp moves for a
+ * no-op.
+ *
+ * NEVER THROWS. An upgrade that aborted over a node-type rewrite would be a
+ * far worse outcome than a flow staying on an alias that still resolves today.
+ *
+ * @category Repair
+ * @package  OCA\OpenRegister\Repair
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/flow-engine/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Repair;
+
+use OCA\OpenRegister\Db\FlowMapper;
+use OCA\OpenRegister\Service\Flow\FlowNodeRegistry;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Rewrites renamed flow node types in stored definitions.
+ *
+ * @spec openspec/specs/flow-engine/spec.md
+ */
+class MigrateRenamedFlowNodeTypes implements IRepairStep
+{
+
+    /**
+     * How many flows to read per page.
+     *
+     * @var integer
+     */
+    private const PAGE_SIZE = 100;
+
+    /**
+     * Constructor.
+     *
+     * Resolved lazily from the container for the same reason the other flow
+     * repair steps are: this runs during install and upgrade, when the flow
+     * table may not exist yet, and a constructor-injected mapper would make
+     * that a fatal rather than a skip.
+     *
+     * @param ContainerInterface $container The app container.
+     * @param LoggerInterface    $logger    Diagnostics.
+     */
+    public function __construct(
+        private readonly ContainerInterface $container,
+        private readonly LoggerInterface $logger
+    ) {
+
+    }//end __construct()
+
+    /**
+     * The step's name.
+     *
+     * @return string The name.
+     */
+    public function getName(): string
+    {
+        return 'Rewrite renamed flow node types in stored flow definitions';
+
+    }//end getName()
+
+    /**
+     * Rewrite every stored node type that the registry only resolves by alias.
+     *
+     * @param IOutput $output Migration output.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/flow-engine/spec.md
+     */
+    public function run(IOutput $output): void
+    {
+        $renamed = FlowNodeRegistry::renamedTypes();
+        if ($renamed === []) {
+            $output->info('OpenRegister: no flow node types are aliased — nothing to rewrite.');
+            return;
+        }
+
+        try {
+            $mapper = $this->container->get(FlowMapper::class);
+        } catch (Throwable $e) {
+            $this->logger->info(
+                '[MigrateRenamedFlowNodeTypes] flow storage unavailable, skipping: '.$e->getMessage()
+            );
+            return;
+        }
+
+        $flowsSeen      = 0;
+        $flowsWritten   = 0;
+        $nodesRewritten = 0;
+        $offset         = 0;
+
+        while (true) {
+            try {
+                $flows = $mapper->findAllFlows(limit: self::PAGE_SIZE, offset: $offset);
+            } catch (Throwable $e) {
+                $output->warning('OpenRegister: could not read flows to rewrite node types: '.$e->getMessage());
+                $this->logger->warning('[MigrateRenamedFlowNodeTypes] read failed: '.$e->getMessage());
+                return;
+            }
+
+            if ($flows === []) {
+                break;
+            }
+
+            foreach ($flows as $flow) {
+                $flowsSeen++;
+
+                $nodes   = ($flow->getNodes() ?? []);
+                $changed = 0;
+
+                foreach ($nodes as $index => $node) {
+                    if (is_array($node) === false) {
+                        continue;
+                    }
+
+                    $type = (string) ($node['type'] ?? '');
+                    if ($type === '' || isset($renamed[$type]) === false) {
+                        continue;
+                    }
+
+                    $nodes[$index]['type'] = $renamed[$type];
+                    $changed++;
+                }
+
+                // Only write a flow that actually carried an old name. A blanket
+                // save would move every flow's `updated` timestamp for a no-op,
+                // which is the kind of churn that makes a later "what changed
+                // and when" impossible to answer.
+                if ($changed === 0) {
+                    continue;
+                }
+
+                $flow->setNodes($nodes);
+
+                try {
+                    $mapper->update($flow);
+                } catch (Throwable $e) {
+                    $output->warning(
+                        sprintf(
+                            'OpenRegister: could not rewrite node types on flow "%s": %s',
+                            (string) $flow->getUuid(),
+                            $e->getMessage()
+                        )
+                    );
+                    continue;
+                }
+
+                $flowsWritten++;
+                $nodesRewritten += $changed;
+            }//end foreach
+
+            if (count($flows) < self::PAGE_SIZE) {
+                break;
+            }
+
+            $offset += self::PAGE_SIZE;
+        }//end while
+
+        if ($nodesRewritten === 0) {
+            $output->info(
+                sprintf('OpenRegister: %d flow(s) checked, no renamed node types stored.', $flowsSeen)
+            );
+            return;
+        }
+
+        $output->info(
+            sprintf(
+                'OpenRegister: rewrote %d node(s) across %d flow(s) of %d to their current type ids (%s).',
+                $nodesRewritten,
+                $flowsWritten,
+                $flowsSeen,
+                implode(
+                        ', ',
+                        array_map(
+                    static fn (string $old, string $new): string => $old.' → '.$new,
+                    array_keys($renamed),
+                    array_values($renamed)
+                )
+                        )
+            )
+        );
+
+    }//end run()
+}//end class

--- a/lib/Service/Flow/FlowNodeRegistry.php
+++ b/lib/Service/Flow/FlowNodeRegistry.php
@@ -77,6 +77,29 @@ class FlowNodeRegistry
     ];
 
     /**
+     * The rename map, for the one caller that has to REWRITE rather than resolve.
+     *
+     * Resolution is this class's job and stays here. `MigrateRenamedFlowNodeTypes`
+     * exists to make the alias table redundant — it rewrites stored definitions
+     * to the new names — and it must not carry a second copy of the pairs, or
+     * removing an alias here would leave the migration rewriting a name nothing
+     * answers to.
+     *
+     * Reading it from here also makes the retirement order right by
+     * construction: drop a pair from `RENAMED` and the migration stops
+     * rewriting it in the same commit.
+     *
+     * @return array<string, string> Old type id => new type id.
+     *
+     * @spec openspec/specs/flow-engine/spec.md
+     */
+    public static function renamedTypes(): array
+    {
+        return self::RENAMED;
+
+    }//end renamedTypes()
+
+    /**
      * Whether contribution has already been collected this request.
      *
      * @var boolean

--- a/tests/Unit/Repair/MigrateRenamedFlowNodeTypesTest.php
+++ b/tests/Unit/Repair/MigrateRenamedFlowNodeTypesTest.php
@@ -1,0 +1,239 @@
+<?php
+
+/**
+ * Stored flow definitions stop depending on the alias table.
+ *
+ * `FlowNodeRegistry` resolves `openregister.loop` and `openregister.stop`
+ * through an alias its own docblock says is removed one release after the
+ * rename. Nothing rewrote the stored definitions, so on the development
+ * instance 13 nodes across 19 flows were still named `openregister.stop` —
+ * working, silently, on a deadline nobody can see.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Repair
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/flow-engine/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Repair;
+
+use OCA\OpenRegister\Db\Flow;
+use OCA\OpenRegister\Db\FlowMapper;
+use OCA\OpenRegister\Repair\MigrateRenamedFlowNodeTypes;
+use OCA\OpenRegister\Service\Flow\FlowNodeRegistry;
+use OCP\Migration\IOutput;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Behaviour of the renamed-node-type rewrite.
+ */
+final class MigrateRenamedFlowNodeTypesTest extends TestCase
+{
+
+    /**
+     * Flows the mapper was asked to update.
+     *
+     * @var Flow[]
+     */
+    private array $updated = [];
+
+
+    /**
+     * Run the step over the given flows and return them as the mapper saw them.
+     *
+     * @param Flow[] $flows The stored flows.
+     *
+     * @return void
+     */
+    private function runOver(array $flows): void
+    {
+        $this->updated = [];
+
+        $mapper = $this->createMock(FlowMapper::class);
+        $mapper->method('findAllFlows')->willReturnCallback(
+            static function (?string $app=null, ?string $org=null, ?bool $enabled=null, int $limit=100, int $offset=0) use ($flows): array {
+                return array_slice($flows, $offset, $limit);
+            }
+        );
+        $mapper->method('update')->willReturnCallback(
+            function (Flow $flow): Flow {
+                $this->updated[] = $flow;
+                return $flow;
+            }
+        );
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturn($mapper);
+
+        (new MigrateRenamedFlowNodeTypes($container, new NullLogger()))
+            ->run($this->createMock(IOutput::class));
+
+    }//end runOver()
+
+
+    /**
+     * Build a flow with the given node types.
+     *
+     * @param string[] $types The node type ids.
+     * @param string   $uuid  The flow uuid.
+     *
+     * @return Flow The flow.
+     */
+    private function flowWith(array $types, string $uuid='flow-1'): Flow
+    {
+        $flow = new Flow();
+        $flow->setUuid($uuid);
+        $flow->setNodes(
+            array_map(
+                static fn (string $type, int $i): array => ['id' => 'n'.$i, 'type' => $type],
+                $types,
+                array_keys($types)
+            )
+        );
+
+        return $flow;
+
+    }//end flowWith()
+
+
+    /**
+     * An old node id is rewritten to its current one.
+     *
+     * @return void
+     */
+    public function testAnAliasedTypeIsRewritten(): void
+    {
+        $this->runOver([$this->flowWith(['openregister.stop'])]);
+
+        $this->assertCount(1, $this->updated);
+        $this->assertSame('openregister.end', $this->updated[0]->getNodes()[0]['type']);
+
+    }//end testAnAliasedTypeIsRewritten()
+
+
+    /**
+     * Both pairs in the map are handled, not just the one that prompted this.
+     *
+     * @return void
+     */
+    public function testEveryPairInTheMapIsRewritten(): void
+    {
+        $this->runOver([$this->flowWith(['openregister.loop', 'openregister.stop'])]);
+
+        $this->assertCount(1, $this->updated);
+        $types = array_column($this->updated[0]->getNodes(), 'type');
+        $this->assertSame(['openregister.batch', 'openregister.end'], $types);
+
+    }//end testEveryPairInTheMapIsRewritten()
+
+
+    /**
+     * A flow with nothing to rewrite is NOT written.
+     *
+     * A blanket save would move every flow's `updated` timestamp for a no-op,
+     * which is the kind of churn that makes "what changed and when"
+     * unanswerable — and it would make a second run indistinguishable from a
+     * first.
+     *
+     * @return void
+     */
+    public function testAFlowWithNoAliasedTypesIsNotWritten(): void
+    {
+        $this->runOver([$this->flowWith(['openregister.end', 'openregister.route'])]);
+
+        $this->assertSame([], $this->updated);
+
+    }//end testAFlowWithNoAliasedTypesIsNotWritten()
+
+
+    /**
+     * Only the aliased nodes change; their neighbours are untouched.
+     *
+     * @return void
+     */
+    public function testUnrelatedNodesAreLeftAlone(): void
+    {
+        $this->runOver([$this->flowWith(['openregister.route', 'openregister.stop', 'hermiq.agent-step'])]);
+
+        $types = array_column($this->updated[0]->getNodes(), 'type');
+        $this->assertSame(['openregister.route', 'openregister.end', 'hermiq.agent-step'], $types);
+
+    }//end testUnrelatedNodesAreLeftAlone()
+
+
+    /**
+     * Running twice rewrites nothing the second time.
+     *
+     * @return void
+     */
+    public function testASecondRunIsANoop(): void
+    {
+        $flow = $this->flowWith(['openregister.stop']);
+
+        $this->runOver([$flow]);
+        $this->assertCount(1, $this->updated);
+
+        // `$flow` now carries the rewritten types, exactly as the stored row
+        // would on the next upgrade.
+        $this->runOver([$flow]);
+        $this->assertSame([], $this->updated, 'a second run must not write anything');
+
+    }//end testASecondRunIsANoop()
+
+
+    /**
+     * A malformed node entry is skipped rather than fataling the upgrade.
+     *
+     * @return void
+     */
+    public function testAMalformedNodeDoesNotBreakTheRun(): void
+    {
+        $flow = new Flow();
+        $flow->setUuid('flow-odd');
+        $flow->setNodes(['not-an-array', ['id' => 'n1', 'type' => 'openregister.stop'], ['id' => 'n2']]);
+
+        $this->runOver([$flow]);
+
+        $this->assertCount(1, $this->updated);
+        $this->assertSame('openregister.end', $this->updated[0]->getNodes()[1]['type']);
+
+    }//end testAMalformedNodeDoesNotBreakTheRun()
+
+
+    /**
+     * The step reads the registry's map rather than carrying its own copy.
+     *
+     * This is what makes the retirement order correct by construction: drop a
+     * pair from `FlowNodeRegistry::RENAMED` and this step stops rewriting it in
+     * the same commit. A second copy would keep rewriting a name nothing
+     * answers to any more.
+     *
+     * @return void
+     */
+    public function testTheMapComesFromTheRegistry(): void
+    {
+        $renamed = FlowNodeRegistry::renamedTypes();
+
+        $this->assertNotSame([], $renamed, 'the registry should still declare aliases');
+
+        foreach ($renamed as $old => $new) {
+            $this->runOver([$this->flowWith([$old])]);
+            $this->assertCount(1, $this->updated, $old.' should have been rewritten');
+            $this->assertSame($new, $this->updated[0]->getNodes()[0]['type']);
+        }
+
+    }//end testTheMapComesFromTheRegistry()
+}//end class


### PR DESCRIPTION
## A deadline nobody can see

`FlowNodeRegistry` resolves two old node ids through an alias table:

```php
'openregister.loop' => 'openregister.batch',
'openregister.stop' => 'openregister.end',
```

Its own docblock says the alias is **removed one release after the rename**. Nothing has ever rewritten the stored definitions.

Measured on the development instance:

```sql
select n->>'type', count(*) from oc_openregister_flows f,
       jsonb_array_elements(f.nodes::jsonb) n
 where n->>'type' in ('openregister.stop','openregister.loop') group by 1;

 openregister.stop | 13
```

**13 nodes across 19 flows.** They work, silently, on the alias. The definitions look fine, the runs succeed, and the breakage arrives with a release that touches none of them.

## The map is read, not copied

`FlowNodeRegistry::renamedTypes()` is new; the repair step reads it rather than carrying its own pairs. That makes the retirement order correct **by construction** — drop a pair from `RENAMED` and this step stops rewriting it in the same commit. A second copy would keep rewriting a name nothing answers to any more.

One of the tests drives *every* pair the registry declares, so a future rename is covered without anyone remembering to edit the test.

## Behaviour

- **Writes only flows that actually carried an old name.** A blanket save would move every flow's `updated` timestamp for a no-op — the churn that makes "what changed and when" unanswerable, and it would make a second run indistinguishable from a first.
- **Registered ahead of `BackfillFlowTriggerIndex`** in both `<install>` and `<post-migration>`: the trigger index is derived *from* node types, so the types should already be current when it runs.
- **Never throws.** An upgrade that aborted over a node-type rewrite is a worse outcome than a flow staying on an alias that still resolves today. Unreadable flow storage is an info-level skip; a failed write on one flow warns and continues to the next.

## Verification

- **7 tests** — both pairs, a flow with nothing to rewrite, a malformed node entry, unrelated neighbours, idempotency, and the registry-is-the-source-of-truth check.
- **Positive control**: removing the rewrite line turns 6 of the 7 red.
- `tests/Unit/Repair` + `FlowNodeRegistryTest` — 41 green.
- **PHPStan** `[OK] No errors`. **phpcs** clean.
