### PR TITLE
fix(tests,spec): unstick the two red PHPUnit cells and gate-46

### DIFF
--- a/openspec/specs/federation/spec.md
+++ b/openspec/specs/federation/spec.md
@@ -1,0 +1,124 @@
+---
+status: done
+---
+
+# federation Specification
+
+## Purpose
+
+The canonical home for what OpenRegister's federated-share serving surface
+(`FederationController`, `/api/federation/{shareToken}/...`) is allowed to hand
+to a remote instance.
+
+Two guards sit on that surface and they are independent: a share's SCOPE decides
+which objects the token addresses at all, and CONFIDENTIALITY decides which of
+the objects inside that scope may leave the instance. This spec owns both,
+because both have already failed in the direction that serves too much, and both
+failed silently — nothing errored and nothing logged.
+
+Related change history: `openspec/changes/federation-scope-enforcement`
+(scope, REQ-FSE-001) and `openspec/changes/federated-config-sharing`
+(the configuration-sharing transport, a separate surface).
+
+## Requirements
+
+### Requirement: Confidentiality is honoured under every property name it is stored under
+
+One concept — how confidential an object is — is written by three different
+producers under three different property names:
+
+- `confidentiality` — OpenRegister's own name;
+- `confidentialityLevel` — what the ZGW migration mapping pack writes
+  (`SeedZgwZakenMigrationPack` maps `/vertrouwelijkheidaanduiding` onto it);
+- `vertrouwelijkheidaanduiding` — the ZGW/GGM schema property itself.
+
+The visibility filter SHALL read the FIRST of those names that is present AND
+non-empty, lowercased and trimmed, and SHALL treat the object as public only
+when that value is one of `''`, `openbaar`, `public`, `open`.
+
+"Present and non-empty", not merely present, is load-bearing: a schema sync can
+add an empty column for a property before anything writes to it, and an empty
+`confidentiality` sitting in front of a populated `confidentialityLevel` would
+reinstate the fail-open this requirement exists to close.
+
+This guard FAILS OPEN when it reads the wrong name, which is why the alias list
+is a requirement rather than a convenience. An absent key coalesces to the empty
+string, and the empty string is a PUBLIC value — deliberately, because an object
+that never had a level set is public. So an object marked `zeer_geheim` under a
+name the guard does not read is served as public rather than refused. The
+failure is invisible to a response-shape assertion, because the field is absent
+rather than wrong.
+
+Adding a spelling to the alias list SHALL be safe; removing one SHALL NOT be
+done without evidence that no producer writes it.
+
+@e2e exclude covered by tests/Unit/Controller/FederationControllerConfidentialityTest.php
+(7 data-provider cases through the private `applyShareVisibility()` filter); the
+filter is reachable only by a REMOTE instance presenting a share token, so there
+is no browser path in this repo's Playwright suite that can reach it.
+
+#### Scenario: A level stored under the ZGW pack's name is honoured
+
+- **GIVEN** an accepted outgoing share of scope `schema`
+- **AND** an object carrying `confidentialityLevel: zeer_geheim` and no `confidentiality`
+- **WHEN** the share's visibility filter runs over it
+- **THEN** the object MUST NOT be served
+
+#### Scenario: A level stored under the ZGW schema property is honoured
+
+- **GIVEN** the same share
+- **AND** an object carrying `vertrouwelijkheidaanduiding: vertrouwelijk`
+- **WHEN** the share's visibility filter runs over it
+- **THEN** the object MUST NOT be served
+
+#### Scenario: An empty canonical name does not shadow a populated alias
+
+- **GIVEN** the same share
+- **AND** an object carrying `confidentiality: ''` AND `confidentialityLevel: zeer_geheim`
+- **WHEN** the share's visibility filter runs over it
+- **THEN** the object MUST NOT be served
+
+#### Scenario: The value is compared case-insensitively
+
+- **GIVEN** the same share
+- **AND** an object carrying `confidentialityLevel: ZEER_GEHEIM`
+- **WHEN** the share's visibility filter runs over it
+- **THEN** the object MUST NOT be served
+
+#### Scenario: A public level is still served
+
+- **GIVEN** the same share
+- **AND** an object carrying `confidentiality: openbaar`
+- **WHEN** the share's visibility filter runs over it
+- **THEN** the object MUST be served
+
+#### Scenario: An object with no level set at all is public
+
+- **GIVEN** the same share
+- **AND** an object carrying none of the confidentiality property names
+- **WHEN** the share's visibility filter runs over it
+- **THEN** the object MUST be served
+
+---
+
+### Requirement: An object-scope share serves its one object regardless of level
+
+A share whose `scope` is `object` names exactly one object, chosen by the
+sharing party. The confidentiality filter SHALL NOT be applied to it: the sharer
+has already made the per-object decision that the filter exists to make on their
+behalf for the broader scopes.
+
+The filter therefore applies to `register`, `schema` and `query` scopes only,
+where breadth IS the grant and confidentiality is the only remaining guard.
+
+@e2e exclude covered by
+tests/Unit/Controller/FederationControllerConfidentialityTest.php::testObjectScopeShareStillBypassesTheGuard;
+same reason as above — the serving surface answers a remote instance holding a
+share token, not a browser session.
+
+#### Scenario: An object-scope share serves a non-public object
+
+- **GIVEN** an accepted outgoing share of scope `object` naming one object
+- **AND** that object carries a non-public confidentiality level
+- **WHEN** the share's visibility filter runs over it
+- **THEN** the object MUST be served

--- a/tests/Unit/Service/Flow/Nodes/MapNodeTest.php
+++ b/tests/Unit/Service/Flow/Nodes/MapNodeTest.php
@@ -190,14 +190,24 @@ class MapNodeTest extends TestCase
     }//end testAFailingMappingNamesTheItemItFailedOn()
 
     /**
-     * A slug resolves, so an exported flow survives an id that differs per instance.
+     * A reference-column name still resolves once find() has missed on it.
+     *
+     * `resolve()` asks find() first for any non-numeric string, because find()
+     * is the only lookup that matches the uuid and slug columns. A name that
+     * lives in the `reference` column alone therefore has to survive find()
+     * MISSING before findByRef() gets its turn, and it is that fall-through the
+     * exception below exercises — an exported flow that names its mapping by
+     * reference breaks the moment find()'s throw stops being caught.
      *
      * @return void
      */
     public function testANonNumericReferenceResolvesByRef(): void
     {
         $mapping = $this->createMock(Mapping::class);
-        $this->mapper->expects($this->never())->method('find');
+        $this->mapper->expects($this->once())
+            ->method('find')
+            ->with('person-to-contact')
+            ->willThrowException(new DoesNotExistException('no such mapping'));
         $this->mapper->expects($this->once())
             ->method('findByRef')
             ->with('person-to-contact')
@@ -214,6 +224,39 @@ class MapNodeTest extends TestCase
         $this->assertCount(1, $out);
 
     }//end testANonNumericReferenceResolvesByRef()
+
+    /**
+     * A uuid or a slug resolves through find(), and findByRef() is never reached.
+     *
+     * find() is the only lookup that consults the uuid and slug columns, so
+     * asking findByRef() first left a flow naming its mapping by uuid or slug
+     * dying on "No mapping matches ..." while the row sat there matching two of
+     * the four identifiers. The `never()` on findByRef() is what pins the ORDER:
+     * without it a resolve() that consulted the `reference` column first would
+     * satisfy this test just as well.
+     *
+     * @return void
+     */
+    public function testAUuidReferenceResolvesThroughFind(): void
+    {
+        $mapping = $this->createMock(Mapping::class);
+        $this->mapper->expects($this->once())
+            ->method('find')
+            ->with('018f2a1e-0c3d-7c2b-9f11-6f0c9a1b2c3d')
+            ->willReturn($mapping);
+        $this->mapper->expects($this->never())->method('findByRef');
+
+        $this->mappings->method('executeMapping')->willReturn(['ok' => true]);
+
+        $out = $this->node->execute(
+            [FlowItems::item(json: [])],
+            ['mapping' => '018f2a1e-0c3d-7c2b-9f11-6f0c9a1b2c3d'],
+            []
+        );
+
+        $this->assertCount(1, $out);
+
+    }//end testAUuidReferenceResolvesThroughFind()
 
     /**
      * A map step with no mapping is refused at validation.


### PR DESCRIPTION
## What this fixes

Two of the six non-green cells on `development` at run `31577691221`.

### PHPUnit (PHP 8.3 / 8.4, NC stable32) — one failing test out of 16306

`a5b8dc22b` deliberately made `MapNode::resolve()` ask `find()` first for a non-numeric reference (it is the only lookup that consults the `uuid` and `slug` columns). `MapNodeTest::testANonNumericReferenceResolvesByRef` still pinned the old order with `expects($this->never())->method('find')`, so the fix and its own suite disagreed.

The test keeps its intent — a name living in the `reference` column alone still resolves — but now reaches `findByRef()` the way production does: through `find()` missing. A second test pins the new order, which nothing pinned at all.

`lib/Service/Flow/Nodes/MapNode.php` is **not** touched.

### Hydra Gates — `[gate-46] spec-anchor-existence`

`#2438` tagged three methods `@spec openspec/specs/federation/spec.md`; that file did not exist. The canonical spec is written (content read off `CONFIDENTIALITY_KEYS` / `PUBLIC_CONFIDENTIALITY` / `applyShareVisibility()`, scenarios matching the existing `FederationControllerConfidentialityTest` cases), rather than the tags retargeted at a change directory.

Its two requirements carry a reason-bearing `@e2e exclude`. Without that this PR would trade gate-46 for gate-19: the 7 new scenarios fail gate-19 as `missing @e2e` and pass with the exclusions.

## Positive controls

| check | without the fix | with the fix |
|---|---|---|
| `MapNodeTest` | 8 tests, 1 failure (the exact CI message) | 9/9 green |
| revert `find()`-first in `MapNode::resolve()` | 1 failure + 1 error, exactly the two tests | — |
| `check_spec_anchors.py` (gate-46) | 3 findings, 1 target | 0 |
| `check_e2e_coverage.py` (gate-19) | FAIL — 7 scenarios | PASS |
| `check_spec_coverage.py` (gate-16) | 0 | 0 |

## Not fixed here

- **phpmd** — 6 findings, all in `lib/Service/Flow/` (`FlowRunAdvancer:83`, `FlowService:55/78/480`, `IterateNode:238`, `ObjectWriteNode:1445`), another session's live work under #2429.
- **phpcs** — already fixed by that session in `61c9f389c`/`9c05a3f44`; full-tree phpcs is 0 errors on 1428 files at that base.
- **Quality Report** — a pure aggregator ("One or more quality jobs failed"); it carries no finding of its own.
