### PR TITLE
test(newman): print the flow-engine COVERAGE line, and fail an unexplained skip

### DIFF
--- a/tests/newman/build-flow-engine-collection.mjs
+++ b/tests/newman/build-flow-engine-collection.mjs
@@ -344,6 +344,48 @@ const caseFolder = (c) => {
 
 // ------------------------------------------------------------- teardown ----
 
+/**
+ * The COVERAGE line: which cases actually ran.
+ *
+ * Every guarded case already set `<case>_skipped` when its prerequisite was
+ * absent — and nothing ever read it. The only trace of a skip was a
+ * `console.log`, so a run in which the AI case never executed reported exactly
+ * the same all-green summary as one in which it did. That is how
+ * `hermiq.agent-step` came to be described as "executed through the engine"
+ * while openregister's CI, which never installs hermiq, has skipped it every
+ * time: the fixture request POSTs to `/objects/hermiq/agent`, fails, leaves
+ * `agent` empty, and closes with `pm.expect(true).to.be.true`.
+ *
+ * This folder makes the count visible and, more importantly, makes an
+ * UNEXPECTED skip fail. A case may only be missing when it declared a
+ * prerequisite; anything else skipping is a hole, not a configuration.
+ */
+const coverage = {
+	name: '98 — coverage',
+	item: [
+		req('report which cases ran', 'GET', '/apps/openregister/api/flows?limit=1', undefined, [
+			`const cases = ${JSON.stringify(CASES.map((c) => ({ key: c.key, requires: (c.requires ?? null) })))}`,
+			"const skipped = cases.filter((c) => pm.collectionVariables.get('case_' + c.key.replace(/-/g, '_') + '_skipped') === '1')",
+			"const ran = cases.length - skipped.length",
+			"console.log('COVERAGE: ' + ran + ' of ' + cases.length + ' flow-engine cases ran'",
+			"    + (skipped.length ? ' — skipped: ' + skipped.map((c) => c.key + ' (needs ' + c.requires + ')').join(', ') : ''))",
+			"",
+			"// A case may only be absent when it DECLARED a prerequisite. One that",
+			"// skipped without declaring why is a hole in the suite, and the whole",
+			"// point of this folder is that such a hole cannot pass as green.",
+			"const unexplained = skipped.filter((c) => !c.requires)",
+			"pm.test('every skipped case declared a prerequisite', () => {",
+			"    pm.expect(unexplained.map((c) => c.key), 'a case skipped without declaring what it needs').to.eql([])",
+			'})',
+			"",
+			"// Named so the count is in the run summary rather than only in stdout.",
+			"pm.test('COVERAGE: ' + ran + ' of ' + cases.length + ' flow-engine cases executed', () => {",
+			"    pm.expect(ran, 'no flow-engine case ran at all').to.be.above(0)",
+			'})',
+		]),
+	],
+}
+
 const teardown = {
 	name: '99 — teardown',
 	item: [
@@ -451,7 +493,7 @@ const collection = {
 		{ key: 'objectQueue', value: '[]' },
 		{ key: 'objectHead', value: '' },
 	],
-	item: [setup, ...CASES.map(caseFolder), teardown],
+	item: [setup, ...CASES.map(caseFolder), coverage, teardown],
 }
 
 const out = join(here, 'openregister-flow-engine.postman_collection.json')

--- a/tests/newman/openregister-flow-engine.postman_collection.json
+++ b/tests/newman/openregister-flow-engine.postman_collection.json
@@ -3074,6 +3074,71 @@
       ]
     },
     {
+      "name": "98 — coverage",
+      "item": [
+        {
+          "name": "report which cases ran",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const cases = [{\"key\":\"api-sync\",\"requires\":null},{\"key\":\"notify-on-change\",\"requires\":null},{\"key\":\"mailbox-summary-ai\",\"requires\":\"agent\"},{\"key\":\"data-quality-sweep\",\"requires\":null},{\"key\":\"enrichment\",\"requires\":null},{\"key\":\"approval-routing\",\"requires\":null},{\"key\":\"retention-sweep\",\"requires\":null},{\"key\":\"paginated-sync\",\"requires\":null},{\"key\":\"route-and-merge\",\"requires\":null},{\"key\":\"sync-cursor\",\"requires\":null},{\"key\":\"batch-export\",\"requires\":null},{\"key\":\"map-transform\",\"requires\":null},{\"key\":\"trigger-object\",\"requires\":null},{\"key\":\"wait-suspends\",\"requires\":null}]",
+                  "const skipped = cases.filter((c) => pm.collectionVariables.get('case_' + c.key.replace(/-/g, '_') + '_skipped') === '1')",
+                  "const ran = cases.length - skipped.length",
+                  "console.log('COVERAGE: ' + ran + ' of ' + cases.length + ' flow-engine cases ran'",
+                  "    + (skipped.length ? ' — skipped: ' + skipped.map((c) => c.key + ' (needs ' + c.requires + ')').join(', ') : ''))",
+                  "",
+                  "// A case may only be absent when it DECLARED a prerequisite. One that",
+                  "// skipped without declaring why is a hole in the suite, and the whole",
+                  "// point of this folder is that such a hole cannot pass as green.",
+                  "const unexplained = skipped.filter((c) => !c.requires)",
+                  "pm.test('every skipped case declared a prerequisite', () => {",
+                  "    pm.expect(unexplained.map((c) => c.key), 'a case skipped without declaring what it needs').to.eql([])",
+                  "})",
+                  "",
+                  "// Named so the count is in the run summary rather than only in stdout.",
+                  "pm.test('COVERAGE: ' + ran + ' of ' + cases.length + ' flow-engine cases executed', () => {",
+                  "    pm.expect(ran, 'no flow-engine case ran at all').to.be.above(0)",
+                  "})"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "OCS-APIRequest",
+                "value": "true"
+              },
+              {
+                "key": "Authorization",
+                "value": "Basic {{authToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/apps/openregister/api/flows?limit=1",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "apps",
+                "openregister",
+                "api",
+                "flows?limit=1"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
       "name": "99 — teardown",
       "item": [
         {


### PR DESCRIPTION
## The suite reported green over a case that never ran

Every guarded case already set `<case>_skipped` when its prerequisite was absent. **Nothing ever read it.** The only trace of a skip was a `console.log`, so a run in which a case never executed produced exactly the same all-green summary as one in which it did.

That is how `hermiq.agent-step` came to be described as *"executed through the engine"* (ConductionNL/hermiq#185's coverage table). It is — on an instance with hermiq and Ollama. openregister's CI installs **neither**:

```js
req('create summariser agent', 'POST', '/apps/openregister/api/objects/hermiq/agent', …, [
  "pm.collectionVariables.set('agent', …)",
  "pm.test('agent fixture resolved (or hermiq absent)', () => pm.expect(true).to.be.true)",
])
```

The POST fails, `agent` stays empty, the case guard skips, and the fixture's own test asserts `true`. So the single case covering hermiq's contribution to the flow engine has been skipped in **every** CI run, invisibly.

## What `98 — coverage` adds

1. **The count in a test title**, so `COVERAGE: N of M flow-engine cases executed` lands in the run summary rather than only in stdout.
2. **A failure when a case skipped without declaring a prerequisite.**

The second is the part that matters. A case may only be absent when it said what it needs; anything else skipping is a hole, and a hole must not pass as green. Today the check is satisfied — the one skip declares `requires: 'agent'` — which is precisely the state it exists to keep honest.

This does **not** turn CI red: the AI case remains legitimately skipped and legitimately declared.

## Verification

- Collection rebuilt from the generator: `14 cases, 17 folders`, `98 — coverage` present and ordered before teardown.
- Generated test script extracted and `node --check`ed — syntax valid.
- The generator is the source of truth; the committed collection JSON is its output, regenerated rather than hand-edited.
