### PR TITLE
docs(rbac): confidentiality is supported but configured nowhere

### DIFF
--- a/docs/rbac-confidentiality.md
+++ b/docs/rbac-confidentiality.md
@@ -1,0 +1,98 @@
+# Enforcing confidentiality (vertrouwelijkheidaanduiding)
+
+OpenRegister can filter objects by ZGW confidentiality level on read. The
+machinery is complete and shipped — but it is **off until a schema is configured
+for it**, and as of 2026-08-12 no schema in this repository is.
+
+This document is the missing half: what exists, what does not, and how to turn
+it on.
+
+## What already works
+
+| piece | where | state |
+|---|---|---|
+| `$in` operator | `lib/Service/OperatorEvaluator.php` | implemented |
+| conditional `match` on authorization entries | `lib/Service/Object/PermissionHandler.php` | implemented |
+| clearance ordinal ordering | `ZaaktypeAuthorizationService::confidentialityOrdinal()` | implemented, unit-tested |
+| clause builder | `ZaaktypeAuthorizationService::buildConfidentialityMatch()` | implemented, unit-tested |
+| ZGW Autorisaties mapping | `ZaaktypeAuthorizationService::mapZgwAutorisatie()` | implemented, unit-tested |
+
+## What does not
+
+**Nothing calls any of it.** `ZaaktypeAuthorizationService` has zero references
+in `lib/` and is not registered in the DI container; it is exercised only by
+`tests/Unit/Service/ZaaktypeAuthorizationServiceTest.php`.
+
+**No schema is configured.** Measured across `lib/Settings/*.json`: zero files
+contain a `match` clause of any kind. So no read is currently filtered by
+clearance.
+
+This matters because the archived change `2026-06-14-rbac-zaaktype` marks the
+confidentiality requirement complete, which reads as an active control. The
+capability is real; the enforcement is not switched on.
+
+## Turning it on
+
+Confidentiality is enforced by attaching a conditional `match` to an
+`authorization` entry on the schema. The engine then filters at both the PHP and
+SQL layers with no further code.
+
+```json
+{
+  "authorization": {
+    "read": [
+      {
+        "groups": ["zaakbehandelaars"],
+        "match": {
+          "vertrouwelijkheidaanduiding": {
+            "$in": ["openbaar", "beperkt_openbaar", "intern"]
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+`buildConfidentialityMatch()` generates the `match` value, so the list stays in
+step with the ordinal ordering rather than being hand-maintained:
+
+```php
+$service->buildConfidentialityMatch(maxLevel: 'intern');
+// => ['vertrouwelijkheidaanduiding' => ['$in' => ['openbaar', 'beperkt_openbaar', 'intern']]]
+```
+
+Pass `property:` when the schema stores the level under a different name — see
+the naming caveat below.
+
+## The decision this needs
+
+Enabling it is a **policy** question, not a technical one: *which group may read
+up to which level, on which schemas*. That mapping cannot be derived from the
+code, which is why no default is shipped here.
+
+Two properties of the design worth knowing before choosing:
+
+- **It fails closed on an unknown level.** `isAccessibleAtClearance()` returns
+  false when either level is unrecognised, so a typo denies rather than grants.
+- **It filters, it does not error.** Objects above the clearance disappear from
+  results. A user cannot distinguish "no such object" from "not cleared", which
+  is usually what you want for confidential records.
+
+## Naming caveat
+
+The same concept appears under three property names in this codebase:
+
+- `vertrouwelijkheidaanduiding` — the ZGW/GGM schema property, and the builder's
+  default
+- `confidentialityLevel` — what `SeedZgwZakenMigrationPack` maps it onto
+- `confidentiality` — what `FederationController` reads
+
+Point `buildConfidentialityMatch(property: ...)` at whichever name the schema
+actually declares. Getting this wrong does not error: the `$in` clause simply
+matches nothing, or everything, depending on the engine's null handling.
+
+That mismatch already caused a live fail-open in the federation path — see
+openregister#2438, where the guard read `confidentiality` while the migration
+pack wrote `confidentialityLevel`, and the empty-string fallback sat inside the
+public allowlist.

--- a/openspec/changes/archive/2026-06-14-rbac-zaaktype/tasks.md
+++ b/openspec/changes/archive/2026-06-14-rbac-zaaktype/tasks.md
@@ -13,6 +13,23 @@
 - [x] Implement: Role-to-zaaktype mapping MUST support per-zaaktype role differentiation — already shipped via group naming + `expandRoles()` role hierarchy.
 - [x] Implement: The system MUST enforce a zaaktype x operation x role permission matrix — `ZaaktypeAuthorizationService::extractPermissionMatrix()` derives the canonical (action x principal) matrix from the enforced authorization block.
 - [x] Implement: The system MUST support vertrouwelijkheidaanduiding (confidentiality levels) per zaaktype — `ZaaktypeAuthorizationService` ordinal ordering + `buildConfidentialityMatch()` emits the existing `$in` clause the engine enforces (PHP + SQL).
+  > **STATUS CLARIFIED 2026-08-12 — SUPPORTED, BUT NOT CONFIGURED ANYWHERE.**
+  > This box is accurate as written: the capability exists end to end.
+  > `OperatorEvaluator` implements `$in`, `PermissionHandler` applies conditional
+  > `match` clauses, and `buildConfidentialityMatch()` emits exactly that shape.
+  >
+  > What the box does NOT say, and what a reader reasonably assumes from it, is
+  > that confidentiality is being ENFORCED. It is not. Measured on this branch:
+  > **zero register files contain any `match` clause at all** — confidentiality
+  > or otherwise — and `ZaaktypeAuthorizationService` has **zero callers** in
+  > `lib/`, exercised only by its own unit test.
+  >
+  > So no object is currently filtered by clearance on the normal read path. The
+  > gap is CONFIGURATION, not a missing control: enabling it means adding a
+  > clause to a schema's `authorization` block, which is a POLICY decision about
+  > which group may read up to which level. See docs/rbac-confidentiality.md.
+  >
+  > Recorded because the unqualified `[x]` reads as a shipped, active control.
 - [x] Implement: Cross-zaaktype access MUST be supported for coordinator and management roles — already shipped (a group listed across multiple schemas grants cross-zaaktype access); configuration concern, no new code.
 - [x] Implement: Permission checks MUST apply to all API endpoints consistently — already shipped (`checkPermission()` enforced in ObjectService for REST/GraphQL/MCP); user-overrides flow through the same chokepoint.
 - [~] Implement: The frontend MUST render permission-aware UI components — DEFERRED (no JS touched this PR). Backend already filters schemas/properties; existing UI consumes it. A dedicated matrix-editor view is a separate frontend change; `extractPermissionMatrix()` supplies its data contract.


### PR DESCRIPTION
Corrects a status claim and supplies the missing operator documentation.

## What I got wrong first

I reported that ZGW confidentiality was "stored but not enforced", on the strength of `ZaaktypeAuthorizationService` having zero callers while every confidentiality primitive lived inside it.

**That framing was wrong**, and the service's own docblock says so: the primitives *build* a clause that the "unchanged RBAC engine" enforces. Verified on this branch:

| claim | evidence |
|---|---|
| `OperatorEvaluator` implements `$in` | `case '$in':` |
| `PermissionHandler` applies conditional `match` | lines 482, 1312, 1333 |
| `buildConfidentialityMatch()` emits that shape | line 181 |

So the capability is complete end to end, and the archived `[x]` is accurate as written.

## What is actually missing is configuration

Measured: **zero** files under `lib/Settings/` contain a `match` clause of any kind, and the service has **zero** references in `lib/` outside itself.

Nothing is filtered by clearance on the normal read path — not because the control is broken, but because **no schema opts into it**.

That distinction matters for anyone reading the archived change: an unqualified `[x] MUST support vertrouwelijkheidaanduiding` reads as an *active* control. The task file now carries a status note saying supported-but-unconfigured, with the measurement behind it.

## What this adds

`docs/rbac-confidentiality.md` — what exists, what does not, the exact `authorization` block that switches it on, and the fact that choosing **which group reads up to which level** is a policy decision that cannot be derived from code. That is why no default is shipped.

It also records the naming caveat that already caused a live failure: `vertrouwelijkheidaanduiding` / `confidentialityLevel` / `confidentiality` are three names for one concept, and pointing the builder at the wrong one fails silently — exactly the fail-open #2438 fixed in the federation path.

## Verification

Every factual claim in the doc was checked against this branch before writing. Two of my initial greps returned 0 and were re-checked rather than trusted — the patterns were wrong, not the code.
