### PR TITLE
chore(deps): pin @conduction/nextcloud-vue to 2.2.0-vue3.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
-        "@conduction/nextcloud-vue": "2.2.0-vue3.9",
+        "@conduction/nextcloud-vue": "2.2.0-vue3.16",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "^2.6.0",
         "@nextcloud/capabilities": "^1.2.1",
@@ -2142,9 +2142,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.2.0-vue3.9",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.9.tgz",
-      "integrity": "sha512-9HC1dhYfCqw7JeZ3mn4Zr260iBCWlWa/1slrPTdmIbODvbWlf82guAZEnMq17XvWmDJRcAVNBzYtIT2kWwZutA==",
+      "version": "2.2.0-vue3.16",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.16.tgz",
+      "integrity": "sha512-eqKSYzS8hrvqzedbgwAch5M/rn2uPEBDBccZZPIRVZ/XrQMYd0yzseTCLyalsBDrWtdb9HoTOp5OBW+p2WFdwQ==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
-    "@conduction/nextcloud-vue": "2.2.0-vue3.9",
+    "@conduction/nextcloud-vue": "2.2.0-vue3.16",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "^2.6.0",
     "@nextcloud/capabilities": "^1.2.1",


### PR DESCRIPTION
Moves the `@conduction/nextcloud-vue` pin from `2.2.0-vue3.9` to `2.2.0-vue3.16`, the current `vue3` dist-tag. Exact pin kept (no caret — on a prerelease line a caret silently pulls in component changes).

Seven prereleases of component change, so this is a real dependency bump rather than a config edit.

## Lockfile

Regenerated with **npm 10.8.2**, matching `engines: { npm: "^10.0.0" }` and the npm version CI runs. `npm ci` was then verified from a clean `node_modules` — the exact operation CI performs — and succeeded.

## Effect on gate-24 (integration-parity)

The published tarball first ships its `scripts/` directory at `2.2.0-vue3.14` (measured: 0 script files in the `vue3.9` tarball, 14 from `vue3.14` on).

On `vue3.9`, this repo's `scripts/check-integration-parity.sh` could not resolve the canonical checker and exited 0 with a skip message — so gate-24 reported a pass having correlated nothing.

On `vue3.16` the checker resolves and actually runs:

```
✓ integration parity: every registered integration has both a tab and a widget
correlated 29 server-side leaf faces [29 IntegrationProvider class]
against 1 JS registration in src/** + 26 contributed by
@conduction/nextcloud-vue; 24 server ids matched a JS face.
```

It also emits 4 **advisory, WARN-only** findings for render-surface providers (`brp-haalcentraal`, `kvk`, `message-dispatch`, `opencorporates`) that have no JS registration. These do not fail the gate and are pre-existing — they were simply invisible before, because the gate was not running.

## Verification (all measured locally, vue3.9 baseline vs vue3.16)

| check | development (vue3.9) | this branch (vue3.16) |
|---|---|---|
| `npm ci` (npm 10.8.2, clean) | pass | pass |
| `npm run build` | pass, 15 webpack warnings | pass, 15 webpack warnings |
| `npm test` | 35 suites / 304 tests pass | 35 suites / 304 tests pass |
| `npm run lint` (eslint) | 0 errors, 1045 warnings | 0 errors, 1045 warnings |
| `npm run stylelint` | pass | pass |

No call sites needed migrating — no component API this app uses moved across the seven prereleases.

## Note on a pre-existing issue found while verifying (not touched here)

`npm run build` triggers `prebuild: node scripts/build-features-manifest.js`, which rewrites the committed `docs/features.json` from 200 lines down to 31. That generator reads only `openspec/specs/`, never `node_modules`, so this is unrelated to this bump and reproduces identically on `development`. The regenerated file was reverted so this PR stays scoped to the dependency. Worth a separate look — the committed manifest and its generator have drifted apart.
