### PR TITLE
fix(phpstan): carry this app's own excludePaths, the base no longer does

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -7048,16 +7048,16 @@
         },
         {
             "name": "conduction/hydra-gates",
-            "version": "v1.7.1",
+            "version": "v1.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ConductionNL/.github.git",
-                "reference": "487e8d235b650a211328d5dfd1dbf90531b26436"
+                "reference": "9b9896abf87167e97b821d8ee86c5422f0b32e80"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/487e8d235b650a211328d5dfd1dbf90531b26436",
-                "reference": "487e8d235b650a211328d5dfd1dbf90531b26436",
+                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/9b9896abf87167e97b821d8ee86c5422f0b32e80",
+                "reference": "9b9896abf87167e97b821d8ee86c5422f0b32e80",
                 "shasum": ""
             },
             "require": {
@@ -7096,9 +7096,9 @@
             "support": {
                 "docs": "https://github.com/ConductionNL/.github/blob/main/hydra-gates/README.md",
                 "issues": "https://github.com/ConductionNL/.github/issues",
-                "source": "https://github.com/ConductionNL/.github/tree/v1.7.1"
+                "source": "https://github.com/ConductionNL/.github/tree/v1.7.3"
             },
-            "time": "2026-08-12T12:57:31+00:00"
+            "time": "2026-08-12T22:32:31+00:00"
         },
         {
             "name": "consolidation/annotated-command",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -34,6 +34,16 @@ parameters:
         # hiding a finding.
         - lib/ContextChat/ContentProvider.php
 
+        # `vendor-bin` USED to be excluded by the shared base. It left the base in
+        # conduction/hydra-gates v1.7.3, because a conditional path has no spelling
+        # that is safe on both PHPStan majors: plain aborts 2.x (it validates the
+        # entry), the `(?)` marker makes NEON parse it as an entity and aborts 2.x
+        # differently, and quoting stops 1.x stripping the marker so the exclusion
+        # silently matches nothing. openregister is the ONLY fleet app that has this
+        # directory, so it carries the path itself — where it exists, needs no
+        # marker, and behaves identically on 1.x and 2.x.
+        - vendor-bin
+
     ignoreErrors:
         # ConductionNL/sapp fork uses lowercase pseudo-classes `obj` /
         # `value` / `pdfentry` / `buffer` / `bytes` etc. in `@return`


### PR DESCRIPTION
## What

Carries this app's own `excludePaths` entry, and bumps `conduction/hydra-gates` to
**v1.7.3** in the same commit so the base losing the path and this app gaining it happen
in one lock generation.

## Why the path moved

The shared `phpstan-base.neon` used to exclude `vendor-bin` and `lib/Resources/template`
for every app. **A conditional path has no spelling that is safe on both PHPStan majors**
— measured against the real apps, not fixtures:

| spelling | PHPStan 1.12.33 | PHPStan 2.2.8 |
| --- | --- | --- |
| plain `%cwd%/vendor-bin` | accepted silently | **ABORTS** — validates the entry; zaakafhandelapp analysed **0 files** |
| `%cwd%/vendor-bin (?)` | fine | **ABORTS** — NEON reads `… (?)` after a `%…%` expansion as an *entity*: `isAbsolutePath(): … Nette\DI\Definitions\Statement given` |
| `'%cwd%/vendor-bin (?)'` | **marker not stripped** → resolves the literal `"/app/vendor-bin (?)"`, matching nothing | fine |

The quoted form is the dangerous one: harmless where the directory is absent, and
**silently breaking where it is present**. So v1.7.3 removes both conditional paths from
the base, and only the apps that actually ship the directory carry it — where it exists,
needs no marker, and behaves identically on both majors.

Measured across the fleet: `vendor-bin` exists **only in openregister**;
`lib/Resources/template` in **portaliq, openbuild and hermiq**. Fifteen to seventeen apps
were carrying an exclusion for a directory they do not have.

## Blast radius

None expected: this app keeps exactly the exclusion it had. `excludePaths` **appends** to
the base unless an app writes `excludePaths!`, so nothing else is affected. The check to
watch is that `phpstan` reports the **same finding count** as on `development`.

Related: `ConductionNL/.github#410`, `conduction/hydra-gates` v1.7.3.
