### PR TITLE
fix(flow): let a delete free its identifier, so a claim can be taken twice

### DIFF
--- a/lib/Service/Flow/Nodes/ObjectWriteNode.php
+++ b/lib/Service/Flow/Nodes/ObjectWriteNode.php
@@ -35,14 +35,27 @@
  *     nothing. That is the most expensive failure mode available: the flow looks
  *     green and the data is not there.
  *
- * DELETION is offered, behind four independent guards, so that no single mistake
+ * DELETION is offered, behind five independent guards, so that no single mistake
  * reaches a removal: an explicit `match` is mandatory (there is no shape that
  * means "delete everything in scope"), the match must resolve to exactly one
- * object, `confirmDelete: true` must be present and boolean, and the removal goes
- * through the ordinary `deleteObject()` path so RBAC, the audit trail,
- * soft-delete, append-only and archival immutability all still apply. The first
- * and third are enforced when the flow is SAVED, because a flow that could delete
+ * object, `confirmDelete: true` must be present and boolean, `permanent` — if
+ * named at all — must be boolean and may only qualify a delete, and the removal
+ * goes through the ordinary `deleteObject()` path so RBAC, the audit trail,
+ * append-only and archival immutability all still apply. The first, third and
+ * fourth are enforced when the flow is SAVED, because a flow that could delete
  * unboundedly must not be persistable at all.
+ *
+ * The delete is SOFT unless `permanent: true` says otherwise, and that default
+ * does not move: a tombstone is what makes a mistaken flow recoverable. The
+ * opt-out exists for a row that is a CLAIM rather than a record — a lock, a slot,
+ * a lease — whose identifier is deliberately a pure function of the thing being
+ * claimed, because that is what makes two concurrent claimants collide on it.
+ * Such an identifier cannot be varied per attempt without giving up the mutual
+ * exclusion it exists for, and the `_uuid` unique index carries no
+ * `WHERE _deleted IS NULL` predicate, so a soft-deleted claim goes on holding its
+ * identifier forever: the claim can be taken exactly once, and every attempt
+ * after that is refused with `already exists` about an object every read reports
+ * as absent (openregister#2459).
  *
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  * SPDX-License-Identifier: EUPL-1.2
@@ -397,6 +410,7 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys {
 			'replace',
 			'output',
 			'confirmDelete',
+			'permanent',
 			'maxWrites',
 			'onConflict',
 			'onMissing',
@@ -775,13 +789,25 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys {
 
 		// Guard 4: the ordinary delete path, with the run owner as the explicit
 		// acting user and the register / schema scope confining the lookup to
-		// one magic table. No `_retentionSweep`, no hard delete — a soft delete
-		// is what makes a mistaken flow recoverable.
+		// one magic table. No `_retentionSweep`, and a SOFT delete unless the
+		// author asked for otherwise — a soft delete is what makes a mistaken
+		// flow recoverable, so it stays the default.
+		//
+		// `permanent: true` is for a row that is a CLAIM rather than a record —
+		// a lock, a slot, a lease. Such a row's identifier is deliberately a
+		// pure function of the thing being claimed, which is what makes two
+		// concurrent claimants collide on it; it therefore cannot be varied per
+		// attempt. A soft delete leaves the tombstone holding that identifier
+		// (the `_uuid` unique index has no `WHERE _deleted IS NULL` predicate),
+		// so a claim that cannot destroy its own row can be taken exactly once,
+		// ever — and the second attempt is refused with `already exists` about
+		// an object every read reports as absent. See openregister#2459.
 		$this->objects->deleteObject(
 			uuid: $uuid,
 			register: $register,
 			schema: $schema,
-			currentUser: $owner
+			currentUser: $owner,
+			permanent: (($config['permanent'] ?? false) === true)
 		);
 		$writes++;
 
@@ -1505,8 +1531,26 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys {
 				);
 			}
 
+			// Guard 5, and the only one that is about IRREVERSIBILITY rather
+			// than about aim. The four above stop a delete from touching the
+			// wrong rows; this one stops a delete from being unrecoverable
+			// without the author having said so in as many words. Same rule as
+			// `confirmDelete`: a boolean, because the string "false" is truthy
+			// and would turn a paste into a destruction.
+			if (array_key_exists('permanent', $config) === true && is_bool($config['permanent']) === false) {
+				throw new UnexpectedValueException(
+					$this->l10n->t('"permanent" must be true or false, as a boolean.')
+				);
+			}
+
 			return;
 		}//end if
+
+		if (array_key_exists('permanent', $config) === true) {
+			throw new UnexpectedValueException(
+				$this->l10n->t('"permanent" has no meaning for a "%s" step; it only qualifies a delete.', [$operation])
+			);
+		}
 
 		if ($operation === self::OP_CREATE && array_key_exists('replace', $config) === true) {
 			throw new UnexpectedValueException(

--- a/lib/Service/Object/DeleteObject.php
+++ b/lib/Service/Object/DeleteObject.php
@@ -507,6 +507,32 @@ class DeleteObject {
 	 *                                       entities so the handler skips its own per-object
 	 *                                       cross-table lookup. Ignored unless its uuid matches
 	 *                                       `$uuid` and both scope entities are concrete.
+	 * @param bool $permanent Destroy the row instead of tombstoning it. Default false, which is
+	 *                        the soft delete every existing caller already gets.
+	 *
+	 *                        This is NOT a convenience. A soft delete leaves the row in place with
+	 *                        `_deleted` set, and the magic table's `_uuid` unique index carries NO
+	 *                        `WHERE _deleted IS NULL` predicate — so the tombstone goes on holding
+	 *                        the identifier forever. The create path disagrees: it looks for a
+	 *                        conflict with `includeDeleted: false`, finds nothing, and proceeds,
+	 *                        only for the write underneath to be refused. The caller is then told
+	 *                        `An object with identifier "x" already exists` about an object every
+	 *                        read says does not exist (openregister#2459).
+	 *
+	 *                        That contradiction is survivable for records, which are archived and
+	 *                        never re-created under the same identifier. It is fatal for a CLAIM —
+	 *                        a lock, a slot, a lease — whose identifier is deliberately a pure
+	 *                        function of the thing being claimed, because that is what makes two
+	 *                        concurrent claimants collide. Such an identifier cannot be varied per
+	 *                        attempt without giving up the mutual exclusion it exists for, so a
+	 *                        claim that cannot destroy its own row is a claim that can be taken
+	 *                        exactly once, ever. Measured: hydra's sequencer locked
+	 *                        `zz-lock-openregister-1561`, released it, and was still refused a
+	 *                        fresh claim eight hours later by its own tombstone.
+	 *
+	 *                        Reserve it for rows whose identifier must become reusable. For
+	 *                        anything that is a record, the soft delete is what makes a mistake
+	 *                        recoverable, and that remains the default.
 	 *
 	 * @return bool Whether the deletion was successful.
 	 *
@@ -530,6 +556,7 @@ class DeleteObject {
 		bool $_multitenancy = true,
 		bool $scoped = false,
 		?ObjectEntity $preResolved = null,
+		bool $permanent = false,
 	): bool {
 		// Read-only projection guard: a schema served from an external source
 		// (x-openregister-object-source) is read-only — deletes are not allowed.
@@ -597,6 +624,7 @@ class DeleteObject {
 			// Pass the already-resolved scope so delete() skips its own re-find.
 			return $this->delete(
 				object: $object,
+				permanent: $permanent,
 				register: $this->contextRegisterEntity(context: $context),
 				schema: $this->contextSchemaEntity(context: $context)
 			);

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -616,13 +616,13 @@ class ObjectService
      * @param Schema|string|int|null   $schema        The schema object or its ID/UUID.
      * @param bool                     $_rbac         Whether to apply RBAC checks (default: true).
      * @param bool                     $_multitenancy Whether to apply multitenancy filtering (default: true).
-     * @param bool                     $_audit        Whether this read is worth an audit-trail row (default: true).
-     *                                                Pass false for machine-to-machine reads inside one
-     *                                                operation; the instance setting is all-or-nothing.
      * @param bool                     $_render       Whether to render the entity before returning (default: true).
      *                                                Pass false when the caller performs its own single render
      *                                                (e.g. ObjectsController::show()) so the object is not
      *                                                rendered twice; permission checks and read logging still run.
+     * @param bool                     $_audit        Whether this read is worth an audit-trail row (default: true).
+     *                                                Pass false for machine-to-machine reads inside one
+     *                                                operation; the instance setting is all-or-nothing.
      *
      * @return ObjectEntity|null The rendered object (or the raw entity when $_render is false) or null.
      *
@@ -1915,6 +1915,15 @@ class ObjectService
      *                                                  import pipeline) MUST pass one: anonymous is
      *                                                  default-deny, so without it the delete is
      *                                                  neither attributable nor permitted.
+     * @param bool                     $permanent       Destroy the row rather than tombstone it, so
+     *                                                  its identifier becomes reusable. Defaults to
+     *                                                  false — the soft delete every existing caller
+     *                                                  already gets, and the thing that makes a
+     *                                                  mistaken delete recoverable. Reserve it for
+     *                                                  rows that are a CLAIM rather than a record;
+     *                                                  see the parameter's full note on
+     *                                                  `DeleteObject::deleteObject()` and
+     *                                                  openregister#2459.
      *
      * @return bool Whether the deletion was successful
      *
@@ -1937,7 +1946,8 @@ class ObjectService
         bool $_rbac=true,
         bool $_multitenancy=true,
         bool $_retentionSweep=false,
-        ?IUser $currentUser=null
+        ?IUser $currentUser=null,
+        bool $permanent=false
     ): bool {
         // Explicit acting user for the permission check; null keeps today's
         // session-resolved behaviour for every existing caller.
@@ -2052,7 +2062,8 @@ class ObjectService
             originalObjectId: null,
             _rbac: $_rbac,
             _multitenancy: $_multitenancy,
-            scoped: $hasScope
+            scoped: $hasScope,
+            permanent: $permanent
         );
     }//end deleteObject()
 

--- a/tests/Unit/Service/Flow/ObjectWriteNodeTest.php
+++ b/tests/Unit/Service/Flow/ObjectWriteNodeTest.php
@@ -216,6 +216,10 @@ class ObjectWriteNodeTest extends TestCase {
 			'delete confirm false' => [['register' => 'r', 'schema' => 's', 'operation' => 'delete', 'match' => $match, 'confirmDelete' => false], 'false is not an acknowledgement'],
 			'delete confirm string' => [['register' => 'r', 'schema' => 's', 'operation' => 'delete', 'match' => $match, 'confirmDelete' => 'true'], 'the string "true" is not boolean true'],
 			'delete confirm one' => [['register' => 'r', 'schema' => 's', 'operation' => 'delete', 'match' => $match, 'confirmDelete' => 1], '1 is not boolean true'],
+			'permanent string' => [['register' => 'r', 'schema' => 's', 'operation' => 'delete', 'match' => $match, 'confirmDelete' => true, 'permanent' => 'true'], 'the string "true" is truthy, and destruction is not something to reach by paste'],
+			'permanent one' => [['register' => 'r', 'schema' => 's', 'operation' => 'delete', 'match' => $match, 'confirmDelete' => true, 'permanent' => 1], '1 is not boolean true'],
+			'permanent on create' => [['register' => 'r', 'schema' => 's', 'operation' => 'create', 'fields' => ['a' => 1], 'permanent' => true], 'permanent only qualifies a delete'],
+			'permanent on update' => [['register' => 'r', 'schema' => 's', 'operation' => 'update', 'match' => $match, 'fields' => ['a' => 1], 'permanent' => true], 'permanent only qualifies a delete'],
 			'maxWrites zero' => [['register' => 'r', 'schema' => 's', 'operation' => 'create', 'fields' => ['a' => 1], 'maxWrites' => 0], 'a cap of zero is not a cap'],
 			'maxWrites negative' => [['register' => 'r', 'schema' => 's', 'operation' => 'create', 'fields' => ['a' => 1], 'maxWrites' => -1], 'a negative cap is not a cap'],
 			'maxWrites string' => [['register' => 'r', 'schema' => 's', 'operation' => 'create', 'fields' => ['a' => 1], 'maxWrites' => '10'], 'a cap must be a whole number'],
@@ -287,7 +291,7 @@ class ObjectWriteNodeTest extends TestCase {
 	public function testEachItemProducesOneAttributedCreate(): void {
 		$seen = [];
 		$this->objects->method('saveObject')->willReturnCallback(
-			function (mixed $object, ?array $extend = [], mixed $register = null, mixed $schema = null, ?string $uuid = null, bool $_rbac = true, bool $_multitenancy = true, bool $silent = false, ?array $uploadedFiles = null, ?IUser $currentUser = null) use (&$seen): ObjectEntity {
+			function (mixed $object, ?array $extend = [], mixed $register = null, mixed $schema = null, ?string $uuid = null, bool $_rbac = true, bool $_multitenancy = true, bool $silent = false, bool $_validation = true, ?array $uploadedFiles = null, ?IUser $currentUser = null) use (&$seen): ObjectEntity {
 				$seen[] = [
 					'object' => $object,
 					'register' => $register,
@@ -336,7 +340,7 @@ class ObjectWriteNodeTest extends TestCase {
 	public function testBypassKeysInTheConfigurationAreNeverForwarded(): void {
 		$seen = null;
 		$this->objects->method('saveObject')->willReturnCallback(
-			function (mixed $object, ?array $extend = [], mixed $register = null, mixed $schema = null, ?string $uuid = null, bool $_rbac = true, bool $_multitenancy = true, bool $silent = false, ?array $uploadedFiles = null, ?IUser $currentUser = null) use (&$seen): ObjectEntity {
+			function (mixed $object, ?array $extend = [], mixed $register = null, mixed $schema = null, ?string $uuid = null, bool $_rbac = true, bool $_multitenancy = true, bool $silent = false, bool $_validation = true, ?array $uploadedFiles = null, ?IUser $currentUser = null) use (&$seen): ObjectEntity {
 				$seen = ['rbac' => $_rbac, 'multitenancy' => $_multitenancy, 'silent' => $silent];
 
 				return $this->entity('uuid-1', $object);
@@ -811,6 +815,91 @@ class ObjectWriteNodeTest extends TestCase {
 	}//end testASkippedDeleteIsDistinguishableFromAPerformedOne()
 
 	/**
+	 * Capture the `permanent` argument the node forwards to the object service.
+	 *
+	 * @param array<string, mixed> $config The delete configuration under test.
+	 *
+	 * @return bool|null The forwarded flag, or null when no delete was attempted.
+	 */
+	private function permanentForwardedBy(array $config): ?bool {
+		$this->tableOf([['uuid' => 'u-gone', 'data' => ['sourceId' => 'r1']]]);
+
+		$seen = null;
+		$this->objects->method('deleteObject')->willReturnCallback(
+			function (
+				string $uuid,
+				mixed $register = null,
+				mixed $schema = null,
+				bool $_rbac = true,
+				bool $_multitenancy = true,
+				bool $_retentionSweep = false,
+				?IUser $currentUser = null,
+				bool $permanent = false
+			) use (&$seen): bool {
+				$seen = $permanent;
+
+				return true;
+			}
+		);
+
+		$this->node->execute($this->items([['retiredId' => 'r1']]), $config, $this->registerContext);
+
+		return $seen;
+
+	}//end permanentForwardedBy()
+
+	/**
+	 * The tombstone is the default, and it stays the default.
+	 *
+	 * A soft delete is what makes a mistaken flow recoverable, so a delete that
+	 * says nothing about permanence must not get it. This is the arm that makes
+	 * the next test mean something: without it, "permanent: true was forwarded"
+	 * is satisfied by a node that hardcodes true.
+	 *
+	 * @return void
+	 */
+	public function testADeleteIsSoftUnlessTheAuthorSaysOtherwise(): void {
+		$this->assertFalse(
+			$this->permanentForwardedBy($this->deleteConfig()),
+			'a delete with no "permanent" key must tombstone, not destroy'
+		);
+
+	}//end testADeleteIsSoftUnlessTheAuthorSaysOtherwise()
+
+	/**
+	 * `permanent: true` reaches the service, so a CLAIM can free its identifier.
+	 *
+	 * The tombstone goes on holding the identifier — the magic table's `_uuid`
+	 * unique index carries no `WHERE _deleted IS NULL` predicate — while the
+	 * create path looks for its conflict with `includeDeleted: false` and finds
+	 * nothing. A row that is a lock, a slot or a lease therefore cannot be
+	 * claimed twice, and the second attempt is refused with `already exists`
+	 * about an object every read reports as absent (openregister#2459).
+	 *
+	 * @return void
+	 */
+	public function testAPermanentDeleteReachesTheServiceSoAClaimCanFreeItsIdentifier(): void {
+		$this->assertTrue(
+			$this->permanentForwardedBy($this->deleteConfig(['permanent' => true])),
+			'"permanent": true must reach deleteObject(), or the identifier stays claimed'
+		);
+
+	}//end testAPermanentDeleteReachesTheServiceSoAClaimCanFreeItsIdentifier()
+
+	/**
+	 * `permanent: false` is a statement, not a gap, and means the same as absent.
+	 *
+	 * @return void
+	 */
+	public function testAnExplicitPermanentFalseIsStillASoftDelete(): void {
+		$this->assertFalse(
+			$this->permanentForwardedBy($this->deleteConfig(['permanent' => false])),
+			'an explicit false must not be read as an opt-in'
+		);
+
+	}//end testAnExplicitPermanentFalseIsStillASoftDelete()
+
+	/**
 	 * `config.output` on a delete used to be read by nothing.
 	 *
 	 * `outputJson()` is what honours the key, and it was only ever called on the
@@ -1060,7 +1149,7 @@ class ObjectWriteNodeTest extends TestCase {
 	 */
 	public function testAnOutputKeyPreservesTheIncomingRecord(): void {
 		$this->objects->method('saveObject')->willReturnCallback(
-			function (mixed $object, ?array $extend = [], mixed $register = null, mixed $schema = null, ?string $uuid = null, bool $_rbac = true, bool $_multitenancy = true, bool $silent = false, ?array $uploadedFiles = null, ?IUser $currentUser = null): ObjectEntity {
+			function (mixed $object, ?array $extend = [], mixed $register = null, mixed $schema = null, ?string $uuid = null, bool $_rbac = true, bool $_multitenancy = true, bool $silent = false, bool $_validation = true, ?array $uploadedFiles = null, ?IUser $currentUser = null): ObjectEntity {
 				return $this->entity('uuid-1', $object);
 			}
 		);
@@ -1090,7 +1179,7 @@ class ObjectWriteNodeTest extends TestCase {
 	 */
 	public function testWithoutAnOutputKeyTheWrittenObjectStillReplacesTheRecord(): void {
 		$this->objects->method('saveObject')->willReturnCallback(
-			function (mixed $object, ?array $extend = [], mixed $register = null, mixed $schema = null, ?string $uuid = null, bool $_rbac = true, bool $_multitenancy = true, bool $silent = false, ?array $uploadedFiles = null, ?IUser $currentUser = null): ObjectEntity {
+			function (mixed $object, ?array $extend = [], mixed $register = null, mixed $schema = null, ?string $uuid = null, bool $_rbac = true, bool $_multitenancy = true, bool $silent = false, bool $_validation = true, ?array $uploadedFiles = null, ?IUser $currentUser = null): ObjectEntity {
 				return $this->entity('uuid-1', $object);
 			}
 		);

--- a/tests/Unit/Service/ObjectServicePatchObjectTest.php
+++ b/tests/Unit/Service/ObjectServicePatchObjectTest.php
@@ -374,16 +374,49 @@ class ObjectServicePatchObjectTest extends TestCase {
 	// ── deleteObject's explicit acting user (REQ-OWN-003, REQ-OWN-012) ──
 
 	public function testDeleteObjectAcceptsAnExplicitActingUserAndDefaultsToTheSession(): void {
-		$method = $this->reflection->getMethod('deleteObject');
-		$parameters = $method->getParameters();
-		$last = $parameters[(count($parameters) - 1)];
+		// BY NAME, not by position. This read `$parameters[count - 1]` and so
+		// asserted "currentUser is LAST", which is not what the test is about —
+		// appending any further optional parameter broke it while the property
+		// it means to protect was untouched.
+		$found = null;
+		foreach ($this->reflection->getMethod('deleteObject')->getParameters() as $parameter) {
+			if ($parameter->getName() === 'currentUser') {
+				$found = $parameter;
+				break;
+			}
+		}
 
-		$this->assertSame('currentUser', $last->getName());
-		$this->assertSame(IUser::class, (string)$last->getType()->getName());
-		$this->assertTrue($last->isDefaultValueAvailable());
-		$this->assertNull($last->getDefaultValue(), 'null keeps today\'s session-resolved behaviour for every existing caller');
+		$this->assertNotNull($found, 'deleteObject() must accept an explicit acting user');
+		$this->assertSame(IUser::class, (string)$found->getType()->getName());
+		$this->assertTrue($found->isDefaultValueAvailable());
+		$this->assertNull($found->getDefaultValue(), 'null keeps today\'s session-resolved behaviour for every existing caller');
 
 	}//end testDeleteObjectAcceptsAnExplicitActingUserAndDefaultsToTheSession()
+
+	/**
+	 * The permanence opt-out exists, is boolean, and defaults to the tombstone.
+	 *
+	 * The default is the whole point: a soft delete is what makes a mistaken
+	 * delete recoverable, so `permanent` must be something a caller reaches for
+	 * deliberately rather than something they inherit (openregister#2459).
+	 *
+	 * @return void
+	 */
+	public function testDeleteObjectOffersPermanenceAndDefaultsToASoftDelete(): void {
+		$found = null;
+		foreach ($this->reflection->getMethod('deleteObject')->getParameters() as $parameter) {
+			if ($parameter->getName() === 'permanent') {
+				$found = $parameter;
+				break;
+			}
+		}
+
+		$this->assertNotNull($found, 'deleteObject() must offer a permanence opt-out');
+		$this->assertSame('bool', (string)$found->getType()->getName());
+		$this->assertTrue($found->isDefaultValueAvailable());
+		$this->assertFalse($found->getDefaultValue(), 'the tombstone stays the default for every existing caller');
+
+	}//end testDeleteObjectOffersPermanenceAndDefaultsToASoftDelete()
 
 	public function testDeleteObjectForwardsTheActingUserIntoThePermissionCheck(): void {
 		$existing = new ObjectEntity();


### PR DESCRIPTION
Closes #2459.

## The contradiction

A soft delete leaves the row in place with `_deleted` set. The magic table's `_uuid` unique index carries **no** `WHERE _deleted IS NULL` predicate, so the tombstone goes on holding the identifier:

```
openregister_table_2428_5020_uuid_uq    UNIQUE (_uuid)                    ← no predicate
openregister_table_2428_5020_live_owner_idx  (_owner) WHERE (_deleted IS NULL)  ← sibling, has one
```

The create path disagrees with the index. `findAndValidateExistingObject()` looks for a conflict with `includeDeleted: false`, finds nothing, and proceeds — only for the write underneath to be refused. The caller is told `An object with identifier "x" already exists` about an object every read reports as absent.

## Why it matters for a claim and not for a record

Survivable for records: they are archived, never re-created under the same identifier.

Fatal for a **claim**. A lock, a slot or a lease has an identifier that is deliberately a pure function of the thing being claimed — that is exactly what makes two concurrent claimants collide on it. It cannot be varied per attempt without giving up the mutual exclusion it exists for. So a claim that cannot destroy its own row can be taken **once, ever**.

Measured, not inferred — hydra's sequencer:

```
22:54  locked   zz-lock-openregister-1561
22:54  released (soft delete; every list endpoint now returns total: 0)
07:10  lock-issue | failed | An object with identifier "zz-lock-openregister-1561" already exists.
```

## The change

`ObjectService::deleteObject()` and `DeleteObject::deleteObject()` gain a `permanent` flag, forwarded to the permanent path `DeleteObject::delete()` **already had**. `ObjectWriteNode` exposes it as a fifth delete guard:

- boolean-only — the string `"false"` is truthy, and destruction is not something to reach by paste
- refused outright on any operation that is not a delete

**The default does not move.** Every existing caller keeps the soft delete. A test asserts that a delete saying nothing about permanence still tombstones — without that arm, "permanent: true was forwarded" is satisfied by a node that hardcodes `true`.

## Also fixed — pre-existing, found by running the suite

- Four mock closures in `ObjectWriteNodeTest` still described `saveObject()`'s pre-`$_validation` signature, so argument #9 arrived as `true` where the closure declared `?array $uploadedFiles`. **Four tests errored on every run** on `development` today.
- `testDeleteObjectAcceptsAnExplicitActingUser…` asserted `currentUser` was the **last** parameter — not what the test is about. Appending any optional parameter broke it while the property it protects was untouched. It now finds the parameter by name.
- A docblock in `ObjectService::find()` listed `$_audit` before `$_render` while the signature has them the other way round (2 PHPCS errors).

## Verification, by layer

These are not the same claim, so they are not reported as one.

| layer | result |
|---|---|
| Unit suite | 16374 tests. Pristine `development`: **45 errors + 5 failures**. With this change: **41 + 5**. A name-by-name diff of the failing set shows exactly the four repaired and **nothing new**. |
| Positive control | The new tests run against *unmodified* production code fail **5 of 7**, on the assertions that matter. |
| PHPCS | 0 errors |
| Psalm | No errors |
| PHPStan | ⚠️ **COULD NOT RUN** — `phpstan.neon` resolves `quality-config/vendor/nextcloud/ocp`, which does not exist in an ordinary install. The **untouched** checkout fails identically, so this is not a regression from this PR — but it does mean PHPStan is not covering this change locally, and that is worth its own issue. |
| Live | ❌ **NOT verified live.** The dev instance bind-mounts openregister from the shared host checkout, so deploying to prove it would mutate other agents' working trees. |

## Follow-up

hydra#542's `unlock` node documents this as a known limit and will set `permanent: true` once this ships.
