### PR TITLE
fix(tests): seven tests pinned to signatures and lookups that moved under them

### DIFF
--- a/tests/Unit/Service/Configuration/ImportHandlerResilienceTest.php
+++ b/tests/Unit/Service/Configuration/ImportHandlerResilienceTest.php
@@ -273,8 +273,20 @@ class ImportHandlerResilienceTest extends TestCase {
 		$this->objectService->method('searchObjects')->willReturn([]);
 
 		// Assert the resolved admin is forwarded as the acting user. saveObject()'s
-		// 10th parameter is $currentUser; the production code passes it by name and
-		// PHP maps it onto that positional slot.
+		// $currentUser is the ELEVENTH parameter of saveObject(). The production
+		// code passes it by name and PHP maps it onto that positional slot, so
+		// this closure has to mirror the real signature exactly up to it —
+		// including parameters it does not care about.
+		//
+		// ⚠️ THE FAILURE MODE IS SILENT AND IT ALREADY HAPPENED HERE. This
+		// comment said "10th", written when it was, and then `$_validation` was
+		// inserted at position 9. Every later parameter shifted one right: the
+		// slot named `$uploadedFiles` began receiving `$_validation`, the slot
+		// named `$currentUser` began receiving `$uploadedFiles` — which is null —
+		// and the assertion failed with "null is identical to an object of class
+		// MockObject_IUser", naming the acting user and saying nothing about the
+		// signature. A positional closure against a signature that grows in the
+		// MIDDLE reads the wrong argument under the right name.
 		$capturedUser = null;
 		$this->objectService->method('saveObject')
 			->willReturnCallback(function (
@@ -286,6 +298,7 @@ class ImportHandlerResilienceTest extends TestCase {
 				$rbac = true,
 				$multitenancy = true,
 				$silent = false,
+				$validation = true,
 				$uploadedFiles = null,
 				$currentUser = null,
 			) use (&$capturedUser) {

--- a/tests/Unit/Service/Merge/MergeServiceTest.php
+++ b/tests/Unit/Service/Merge/MergeServiceTest.php
@@ -140,8 +140,8 @@ class MergeServiceTest extends TestCase {
 		$this->schemaMapper->method('find')->willReturn($this->schemaWithConfig());
 		$this->objectService->method('find')->willReturnMap(
 			[
-				['from-uuid', [], false, null, null, true, true, true, $from],
-				['into-uuid', [], false, null, null, true, true, true, $into],
+				['from-uuid', [], false, null, null, true, true, true, true, $from],
+				['into-uuid', [], false, null, null, true, true, true, true, $into],
 			]
 		);
 		$this->objectService->method('findAll')->willReturn([]);
@@ -166,8 +166,8 @@ class MergeServiceTest extends TestCase {
 		$this->schemaMapper->method('find')->willReturn($this->schemaWithConfig());
 		$this->objectService->method('find')->willReturnMap(
 			[
-				['from-uuid', [], false, null, null, true, true, true, $from],
-				['into-uuid', [], false, null, null, true, true, true, $into],
+				['from-uuid', [], false, null, null, true, true, true, true, $from],
+				['into-uuid', [], false, null, null, true, true, true, true, $into],
 			]
 		);
 		$this->objectService->method('findAll')->willReturn([]);
@@ -228,8 +228,8 @@ class MergeServiceTest extends TestCase {
 		$this->schemaMapper->method('find')->willReturn($this->schemaWithConfig());
 		$this->objectService->method('find')->willReturnMap(
 			[
-				['from-uuid', [], false, null, null, true, true, true, $from],
-				['into-uuid', [], false, null, null, true, true, true, $into],
+				['from-uuid', [], false, null, null, true, true, true, true, $from],
+				['into-uuid', [], false, null, null, true, true, true, true, $into],
 			]
 		);
 
@@ -247,8 +247,8 @@ class MergeServiceTest extends TestCase {
 		$this->schemaMapper->method('find')->willReturn($this->schemaWithConfig());
 		$this->objectService->method('find')->willReturnMap(
 			[
-				['from-uuid', [], false, null, null, true, true, true, $from],
-				['into-uuid', [], false, null, null, true, true, true, $into],
+				['from-uuid', [], false, null, null, true, true, true, true, $from],
+				['into-uuid', [], false, null, null, true, true, true, true, $into],
 			]
 		);
 
@@ -293,9 +293,9 @@ class MergeServiceTest extends TestCase {
 
 		$this->objectService->method('find')->willReturnMap(
 			[
-				['op-uuid', [], false, null, MergeService::MERGE_SCHEMA, true, true, true, $operationEntity],
-				['from-uuid', [], false, null, null, true, true, true, $fromEntity],
-				['into-uuid', [], false, null, null, true, true, true, $intoEntity],
+				['op-uuid', [], false, null, MergeService::MERGE_SCHEMA, true, true, true, true, $operationEntity],
+				['from-uuid', [], false, null, null, true, true, true, true, $fromEntity],
+				['into-uuid', [], false, null, null, true, true, true, true, $intoEntity],
 			]
 		);
 

--- a/tests/Unit/Service/Object/Wave12BulkSafeguardsTest.php
+++ b/tests/Unit/Service/Object/Wave12BulkSafeguardsTest.php
@@ -278,11 +278,30 @@ class Wave12BulkSafeguardsTest extends TestCase {
 		$this->permissionHandler->method('hasPermission')->willReturn(true);
 
 		// Existing object returned → triggers UPDATE classification.
+		//
+		// 🔑 THE LOOKUP IS THE BATCH PREFETCH, NOT `find()`. This mocked `find()`
+		// alone, which is the per-row fallback and is only reached when a group's
+		// probe FAILED. `prefetchExistingRows()` runs first and calls
+		// `findObjectsByUuidsInRegisterSchema()`; an unmocked mapper answers `[]`,
+		// which the classifier reads as a SUCCESSFUL probe that found nothing —
+		// "this group was probed and the uuid was not in it" — and returns
+		// `create` without ever consulting `find()`.
+		//
+		// ⚠️ The failure that produced was a row sailing through the appendOnly
+		// gate, which is exactly what a real immutability bypass would look like.
+		// It was not one: measured with a probe at the gate,
+		// `uuid='1111…' action='create' appendOnly=true`. The gate is intact and
+		// fires on `update`; the row simply never got classified as one. A test
+		// mocking a superseded lookup does not fail loudly — it silently exercises
+		// the other branch and reports the safeguard missing.
 		$existing = new \OCA\OpenRegister\Db\ObjectEntity();
 		$existing->setUuid('11111111-1111-1111-1111-111111111111');
 		$this->objectMapper
 			->method('find')
 			->willReturn($existing);
+		$this->objectMapper
+			->method('findObjectsByUuidsInRegisterSchema')
+			->willReturn(['11111111-1111-1111-1111-111111111111' => $existing]);
 
 		$result = $this->initResult(1);
 		$passed = $this->callApplyBulkSafeguards(


### PR DESCRIPTION
All seven tests failing on `development` were pinned to a **shape** of the code rather than to its behaviour. None was reporting a real defect — and one was reporting a security hole that does not exist.

## `MergeServiceTest` — 5

Six `willReturnMap` rows listed **eight** inputs for `ObjectService::find()`. The signature has **nine** (`$_audit` was appended), and `willReturnMap` matches the FULL argument list — so every row missed and `find()` answered null. The test then failed as `Object "from-uuid" was not found`, which reads as a broken merge and is a mock that did not match.

## `ImportHandlerResilienceTest` — 1

Its capturing closure mirrored `saveObject()` positionally, and its comment said `$currentUser` is the 10th parameter — true when written. `$_validation` was later inserted at position 9, so every later parameter shifted one right:

| slot named | now receives |
|---|---|
| `$uploadedFiles` | `$_validation` |
| `$currentUser` | `$uploadedFiles` (null) |

🔑 **A positional closure against a signature that grows IN THE MIDDLE reads the wrong argument under the right name**, and the assertion blamed the acting user.

## `Wave12BulkSafeguardsTest` — 1, and read this one before trusting the rest

`testBulkUpdateRowAgainstAppendOnlySchemaIsRejected` was failing with the update row sailing straight through the appendOnly gate. **That is exactly what a real immutability bypass looks like**, so I measured instead of assuming. A probe at the gate printed:

```
uuid='11111111-…' action='create' appendOnly=true
```

The gate is **intact** and fires on `update`; the row was never classified as one. The test mocks `find()`, which is now only the per-row *fallback*, reached when a group's probe fails. `prefetchExistingRows()` runs first and calls `findObjectsByUuidsInRegisterSchema()`; an unmocked mapper answers `[]`, which the classifier reads as a **successful probe that found nothing** — "this group was probed and the uuid was not in it" — and returns `create`.

So the test silently exercised the other branch and reported a safeguard missing.

## ⚠️ What the probe did NOT find, and is worth someone's attention

`resolveSafeguardActionForRow()` catches `\Throwable` and returns `'create'`. A swallowed lookup error therefore becomes "this object is new", which **skips the appendOnly gate for real**. That is not what happened here — the probe never fired — but it is a live path to the same outcome, and it is a catch that converts a failure into the permissive answer. Flagged rather than changed in a test-only PR.

## Measured, full Unit suite, locally

```
before  47 broken
after   40 broken
fixed    7, by name — exactly the seven CI reports
newly broken  0
```

**No production file is touched by this PR.**