### PR TITLE
fix(psalm): drop a baseline entry for an issue that no longer exists

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -336,9 +336,6 @@
       <code><![CDATA[self::$registerCache]]></code>
       <code><![CDATA[self::$schemaCache]]></code>
     </ImplicitToStringCast>
-    <UnusedParam>
-      <code><![CDATA[$rowSchema]]></code>
-    </UnusedParam>
   </file>
   <file src="lib/Service/Object/SchemaTypeConverter.php">
     <UnusedParam>


### PR DESCRIPTION
CI:

```
ERROR: UnusedBaselineEntry - lib/Service/Object/SaveObjects.php:0:0
       Baseline for issue "UnusedParam" has 1 extra entry.
```

The baseline suppressed `UnusedParam` for `$rowSchema`. That parameter is now read in **sixteen** places — the bulk safeguards use it for per-row schema resolution and the appendOnly gate — so the suppression covers nothing.

Removed rather than regenerated: regenerating the whole baseline would fold in every other drift since it was last written, inside a commit whose subject says it fixed one entry.

⚠️ **Only the entry CI named is touched, deliberately.** Running psalm locally reports a second stale entry (`UndefinedMethod` on GraphQLController) and an `InvalidTemplateParam` that CI does not report at all. Local and CI resolve a different set of classes — CI has the Nextcloud server, this checkout has stubs — so a local psalm finding is not evidence about CI. Acting on the local list would have removed a suppression CI still needs.