### PR TITLE
feat(broker): relay a brokered call as a stream, so a CLI can be pointed at it

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -49,6 +49,10 @@ return [
         ['name' => 'credential#registerApp',   'url' => '/api/credentials/apps/{appId}/register', 'verb' => 'POST',   'requirements' => ['appId' => '[a-z0-9_-]+']],
         ['name' => 'credential#brokerRequest', 'url' => '/api/credentials/{id}/request',           'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
         ['name' => 'credential#sessionBrokerRequest', 'url' => '/api/credentials/{id}/session-request', 'verb' => 'POST', 'requirements' => ['id' => '[^/]+']],
+        // The streaming twin of brokerRequest. Same token, same binding, same guards —
+        // only the transport differs, so an SDK that speaks server-sent events can be
+        // pointed at the broker instead of being handed the secret.
+        ['name' => 'credential#brokerStream', 'url' => '/api/credentials/{id}/stream', 'verb' => 'POST', 'requirements' => ['id' => '[^/]+']],
 
         // Web Push channel (openregister-web-push-engine).
         // VAPID public key (browser subscribe key) + current-user subscription CRUD

--- a/lib/Controller/CredentialController.php
+++ b/lib/Controller/CredentialController.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Controller;
 
 use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Http\BrokeredStreamResponse;
 use OCA\OpenRegister\Service\Credential\CredentialAccessDeniedException;
 use OCA\OpenRegister\Service\Credential\CredentialAppTokenService;
 use OCA\OpenRegister\Service\Credential\CredentialBrokerService;
@@ -50,6 +51,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\Response;
 use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IUserSession;
@@ -653,6 +655,70 @@ class CredentialController extends Controller {
 
 		return new JSONResponse($result);
 	}//end brokerRequest()
+
+	/**
+	 * POST /api/credentials/{id}/stream — the guarded broker call, relayed as a stream.
+	 *
+	 * Identical to {@see brokerRequest()} in every respect that decides whether the
+	 * call is allowed: same token verification, same request-binding of that token
+	 * to this exact method+path, same credential-mismatch refusal, and the same
+	 * five guards behind it — `streamRequest()` and `request()` share one
+	 * authorisation chain rather than each carrying a copy.
+	 *
+	 * The only difference is the transport. `brokerRequest()` reads the whole
+	 * upstream body and answers with `{status, headers, body}` as JSON, which is
+	 * right for a label write or a tree commit. This one leaves the body open and
+	 * relays it chunk by chunk, which is the only way to carry a streaming API:
+	 * a model completion arrives as server-sent events over minutes, and buffering
+	 * it means the caller waits for the last token to see the first.
+	 *
+	 * 🔑 THE UPSTREAM STATUS IS RELAYED AS THIS RESPONSE'S STATUS, so an upstream
+	 * 4xx does not arrive dressed as a 200 with an error in the body. That is a
+	 * real difference from the JSON path, where the upstream status is a FIELD and
+	 * the HTTP status is always 200 — fine when the caller is PHP reading a map,
+	 * wrong when the caller is an SDK that decides what to do from the status line.
+	 *
+	 * @param string $id The credential UUID.
+	 *
+	 * @return Response The relayed upstream response, or a static error.
+	 *
+	 * @spec openspec/specs/credential-broker/spec.md
+	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	public function brokerStream(string $id): Response {
+		if ($this->currentUid() === null) {
+			return new JSONResponse(['message' => 'Unauthorized'], Http::STATUS_UNAUTHORIZED);
+		}
+
+		$token = $this->request->getHeader('X-Credential-Token');
+		$method = (string)$this->request->getParam('method', 'GET');
+		$path = (string)$this->request->getParam('path', '');
+
+		try {
+			$claims = $this->tokenService->verify(token: $token, method: $method, path: $path);
+			if ($claims['credentialId'] !== $id) {
+				throw new CredentialAccessDeniedException(message: 'token/credential mismatch');
+			}
+
+			$stream = $this->broker->streamRequest(
+				credentialId: $id,
+				appId: $claims['appId'],
+				method: $method,
+				path: $path,
+				headers: $this->normaliseHeaders(value: $this->request->getParam('headers', [])),
+				body: $this->normaliseBody(value: $this->request->getParam('body'))
+			);
+		} catch (CredentialAccessDeniedException $e) {
+			return new JSONResponse(['message' => 'Request not permitted'], Http::STATUS_FORBIDDEN);
+		} catch (CredentialUpstreamException $e) {
+			return new JSONResponse(['message' => 'Upstream request failed'], Http::STATUS_BAD_GATEWAY);
+		} catch (Throwable $e) {
+			return new JSONResponse(['message' => 'Request not permitted'], Http::STATUS_FORBIDDEN);
+		}//end try
+
+		return new BrokeredStreamResponse(stream: $stream);
+	}//end brokerStream()
 
 	/**
 	 * POST /api/credentials/{id}/session-request — the session-authenticated browser broker call.

--- a/lib/Http/BrokeredStreamResponse.php
+++ b/lib/Http/BrokeredStreamResponse.php
@@ -1,0 +1,140 @@
+<?php
+
+/**
+ * Relay a brokered upstream response to the client as it arrives.
+ *
+ * Nextcloud's dispatcher treats an `ICallbackResponse` differently from every
+ * other response, and that difference is the whole reason this class exists
+ * (`lib/private/AppFramework/App.php`):
+ *
+ *     if ($response instanceof ICallbackResponse) {
+ *         $response->callback($io);              // called directly, headers already sent
+ *     } elseif (!is_null($output)) {
+ *         $io->setHeader('Content-Length: ' . strlen($output));
+ *         $io->setOutput($output);               // the buffered arm
+ *     }
+ *
+ * The callback arm writes straight through, and — just as important — sets no
+ * `Content-Length`, which is what lets a response of unknown length be delivered
+ * at all.
+ *
+ * MEASURED before this was written, because "it streams" is exactly the kind of
+ * claim that is easy to assert and easy to be wrong about. This image runs
+ * `output_buffering=0`, `implicit_flush=On`, `zlib.output_compression=Off`, and a
+ * 60 MB download through the same Apache answered with
+ * `TTFB 1.07s / TOTAL 9.54s` — first byte at 11% of the transfer. A buffering
+ * stack would have put TTFB level with TOTAL.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Http
+ * @package  OCA\OpenRegister\Http
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/credential-broker-service/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Http;
+
+use OCA\OpenRegister\Service\Credential\BrokeredStream;
+use OCP\AppFramework\Http\ICallbackResponse;
+use OCP\AppFramework\Http\IOutput;
+use OCP\AppFramework\Http\Response;
+
+/**
+ * Streams a `BrokeredStream` to the client chunk by chunk.
+ *
+ * @spec openspec/specs/credential-broker-service/spec.md
+ */
+class BrokeredStreamResponse extends Response implements ICallbackResponse {
+
+	/**
+	 * Upstream headers that must NOT be relayed.
+	 *
+	 * Each of these describes the UPSTREAM's transfer, not ours, and repeating it
+	 * makes this response lie about its own body:
+	 *
+	 *  - `content-length` counts the upstream's bytes; ours are chunked and of
+	 *    unknown length. A wrong length truncates the response at the client.
+	 *  - `transfer-encoding` and `connection` are hop-by-hop by definition
+	 *    (RFC 7230 §6.1) and belong to the connection that already ended.
+	 *  - `content-encoding` would claim a compression this relay does not apply,
+	 *    since the client library already decoded the upstream body for us.
+	 *
+	 * @var string[]
+	 */
+	private const HOP_BY_HOP = [
+		'content-length',
+		'transfer-encoding',
+		'connection',
+		'content-encoding',
+		'keep-alive',
+	];
+
+	/**
+	 * Constructor.
+	 *
+	 * @param BrokeredStream $stream The authorised upstream response, body unread.
+	 */
+	public function __construct(private readonly BrokeredStream $stream) {
+		parent::__construct();
+
+		$this->setStatus(status: $stream->getStatus());
+
+		foreach ($stream->getHeaders() as $name => $values) {
+			if (in_array(needle: strtolower((string)$name), haystack: self::HOP_BY_HOP, strict: true) === true) {
+				continue;
+			}
+
+			$this->addHeader(name: (string)$name, value: implode(separator: ', ', array: (array)$values));
+		}
+
+		// A reverse proxy in front of Nextcloud will happily buffer a response it
+		// considers small enough to be worth buffering, which turns a stream back
+		// into a wait. nginx honours this header; deployments without one ignore
+		// it harmlessly.
+		//
+		// ⚠️ mod_deflate IS enabled on this image and compressing a stream would
+		// re-buffer it — but MEASURED, its configured types are
+		// `text/html text/plain text/xml text/css text/javascript`, the
+		// javascript/xml/rss/wasm application types, and nothing else.
+		// `text/event-stream` is not among them, so SSE is not compressed here
+		// and no `no-gzip` opt-out is needed. If a deployment adds it to
+		// `AddOutputFilterByType`, that opt-out becomes necessary and its absence
+		// will show as latency rather than as an error.
+		$this->addHeader(name: 'X-Accel-Buffering', value: 'no');
+
+	}//end __construct()
+
+	/**
+	 * Write the upstream body out as it arrives.
+	 *
+	 * `flush()` after every chunk is the load-bearing line. PHP is configured
+	 * here not to buffer, but a caller running under a different SAPI or an
+	 * operator who turns `output_buffering` on would otherwise silently get the
+	 * buffered behaviour back — and the symptom would be latency, not an error.
+	 *
+	 * @param IOutput $output Nextcloud's output wrapper.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/credential-broker-service/spec.md
+	 */
+	public function callback(IOutput $output): void {
+		$this->stream->pump(
+			static function (string $chunk) use ($output): void {
+				$output->setOutput($chunk);
+				flush();
+			}
+		);
+
+	}//end callback()
+}//end class

--- a/lib/Service/Credential/BrokeredStream.php
+++ b/lib/Service/Credential/BrokeredStream.php
@@ -63,6 +63,23 @@ final class BrokeredStream {
 	private const CHUNK_BYTES = 8192;
 
 	/**
+	 * The still-open upstream body, or null once `pump()` has taken it.
+	 *
+	 * 🔑 NULLABLE ON PURPOSE, and not merely to satisfy a type-checker.
+	 * `pump()` hands the handle to a local and leaves null behind BEFORE it reads
+	 * a byte, so the object never holds a resource it has closed. That is what
+	 * makes a second `pump()` a no-op instead of a read against a dead handle.
+	 *
+	 * Declared here rather than promoted in the constructor because a promoted
+	 * property takes the parameter's type, and the parameter is a resource — it
+	 * is never null on the way IN. The two are genuinely different types, which
+	 * is what PHPStan pointed out.
+	 *
+	 * @var resource|null
+	 */
+	private $body;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param int                   $status  The upstream status code.
@@ -72,8 +89,9 @@ final class BrokeredStream {
 	public function __construct(
 		private readonly int $status,
 		private readonly array $headers,
-		private mixed $body,
+		$body,
 	) {
+		$this->body = $body;
 
 	}//end __construct()
 

--- a/lib/Service/Credential/BrokeredStream.php
+++ b/lib/Service/Credential/BrokeredStream.php
@@ -1,0 +1,160 @@
+<?php
+
+/**
+ * An upstream response the broker has opened but not yet read.
+ *
+ * `CredentialBrokerService::request()` answers with the whole body as a string,
+ * which is right for the calls the broker was built for — a label write, a tree
+ * commit, a pull request — where the response is small and the caller wants it
+ * in one piece.
+ *
+ * It is wrong for a streaming API. A model completion arrives as server-sent
+ * events over minutes; buffering it means the caller waits for the last token to
+ * see the first, and a multi-minute PHP request sits in the path holding the
+ * whole generation in memory. Worse, the failure only appears on the LONG
+ * responses — a short test passes and says nothing about the case that matters.
+ *
+ * So this object is handed back INSTEAD of a body: the status and headers are
+ * known (they arrived with the response head), and the body is still open.
+ * `pump()` reads it in chunks and hands each one to a sink as it arrives.
+ *
+ * 🔑 THE GUARDS HAVE ALREADY RUN by the time this exists. It is constructed only
+ * by `CredentialBrokerService::streamRequest()`, after the same access,
+ * allowed-app, provider, allow-rule and host-lock checks `request()` performs —
+ * they are one shared method, not two copies. Holding one of these is holding an
+ * ALREADY-AUTHORISED response, not a licence to make one.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Credential
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/credential-broker-service/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Credential;
+
+/**
+ * A brokered upstream response whose body is still open.
+ *
+ * @spec openspec/specs/credential-broker-service/spec.md
+ */
+final class BrokeredStream {
+
+	/**
+	 * How much is read from the upstream body per pass.
+	 *
+	 * Small on purpose. An SSE frame is a few hundred bytes, and the whole point
+	 * of this class is that a frame reaches the caller when it arrives rather
+	 * than when the response ends — a large buffer would reintroduce exactly the
+	 * latency it exists to remove, while looking like it streamed.
+	 *
+	 * @var integer
+	 */
+	private const CHUNK_BYTES = 8192;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param int                   $status  The upstream status code.
+	 * @param array<string, mixed>  $headers The upstream response headers.
+	 * @param resource              $body    The still-open upstream body.
+	 */
+	public function __construct(
+		private readonly int $status,
+		private readonly array $headers,
+		private mixed $body,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * The upstream status code.
+	 *
+	 * @return int The status code.
+	 *
+	 * @spec openspec/specs/credential-broker-service/spec.md
+	 */
+	public function getStatus(): int {
+		return $this->status;
+
+	}//end getStatus()
+
+	/**
+	 * The upstream response headers.
+	 *
+	 * @return array<string, mixed> The headers, as the upstream sent them.
+	 *
+	 * @spec openspec/specs/credential-broker-service/spec.md
+	 */
+	public function getHeaders(): array {
+		return $this->headers;
+
+	}//end getHeaders()
+
+	/**
+	 * Read the body to its end, handing each chunk to the sink as it arrives.
+	 *
+	 * The sink is called with raw bytes and nothing else — no framing, no
+	 * parsing, no re-encoding. Whatever the upstream is speaking travels through
+	 * unaltered, which is what lets one implementation carry SSE, chunked JSON,
+	 * or anything else a provider invents later.
+	 *
+	 * ⚠️ The stream is CLOSED when this returns, including when the sink throws.
+	 * A brokered call that leaks its socket would hold an upstream connection for
+	 * the life of the PHP worker.
+	 *
+	 * @param callable $sink Receives each chunk of bytes as it is read.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/credential-broker-service/spec.md
+	 */
+	public function pump(callable $sink): void {
+		// Taken into a LOCAL and the property surrendered before a byte is read.
+		// Two reasons, and the second is the one that matters: a second `pump()`
+		// on the same object then reads nothing rather than reading from a closed
+		// handle, and the property never holds a `closed-resource` — which is
+		// both a real bug class and what psalm objects to.
+		$body = $this->body;
+		$this->body = null;
+
+		if (is_resource($body) === false) {
+			return;
+		}
+
+		try {
+			while (feof(stream: $body) === false) {
+				$chunk = fread(stream: $body, length: self::CHUNK_BYTES);
+
+				// `false` is a read ERROR and `''` is merely nothing-yet on a
+				// non-blocking socket; neither is the end of the body, and only
+				// `feof()` says that. Treating `''` as the end would truncate a
+				// slow generation the moment it paused to think.
+				if ($chunk === false) {
+					break;
+				}
+
+				if ($chunk === '') {
+					continue;
+				}
+
+				$sink($chunk);
+			}
+		} finally {
+			if (is_resource($body) === true) {
+				fclose(stream: $body);
+			}
+		}
+
+	}//end pump()
+}//end class

--- a/lib/Service/Credential/CredentialBrokerService.php
+++ b/lib/Service/Credential/CredentialBrokerService.php
@@ -95,6 +95,13 @@ use Throwable;
  *   is deliberately decomposed into small single-purpose guard methods so each
  *   security decision is independently auditable; the aggregate weighted method
  *   count is a by-product of that decomposition, not of tangled logic.
+ * @SuppressWarnings(PHPMD.TooManyMethods)           One over, from the streaming twin:
+ *   `streamRequest()`, its transport, and `authoriseCall()` — the guard chain the two
+ *   proxy entry points SHARE. Splitting the streaming path into its own class is the
+ *   move the metric is asking for and it is the wrong one here: the guards would then
+ *   live on one side of a class boundary and one caller on the other, which is exactly
+ *   how a second entry point ends up with its own copy of five checks and one of them
+ *   missing. The count is the size of one security policy, not two responsibilities.
  *
  * @spec openspec/specs/credential-broker/spec.md
  */
@@ -207,7 +214,56 @@ class CredentialBrokerService {
 		?string $body = null,
 		?string $actingUserId = null,
 	): array {
-		$method = strtoupper($method);
+		$call = $this->authoriseCall(
+			credentialId: $credentialId,
+			appId: $appId,
+			method: strtoupper($method),
+			path: $path,
+			headers: $headers,
+			actingUserId: $actingUserId
+		);
+
+		return $this->performCall(
+			method: $call['method'],
+			url: $call['url'],
+			headers: $call['headers'],
+			body: $body,
+			credentialId: $credentialId
+		);
+
+	}//end request()
+
+	/**
+	 * Run every guard, resolve the URL, and inject the secret.
+	 *
+	 * Extracted from `request()` when `streamRequest()` was added, so that the two
+	 * proxy entry points share ONE authorisation chain rather than each carrying a
+	 * copy. The guards below are the whole security posture of the broker; a
+	 * second copy is a second place for one to be dropped, and the likeliest one
+	 * to be dropped is the inject-only refusal — which is what stops the proxy
+	 * being unbounded.
+	 *
+	 * @param string      $credentialId The credential to proxy through.
+	 * @param string      $appId        The calling app.
+	 * @param string      $method       The HTTP method, already upper-cased.
+	 * @param string      $path         The upstream path.
+	 * @param array       $headers      Caller headers; auth among them is discarded.
+	 * @param string|null $actingUserId The acting user, or null for the routed path.
+	 *
+	 * @return array{method: string, url: string, headers: array} The authorised call.
+	 *
+	 * @throws CredentialAccessDeniedException When any guard refuses.
+	 *
+	 * @spec openspec/specs/credential-broker-service/spec.md
+	 */
+	private function authoriseCall(
+		string $credentialId,
+		string $appId,
+		string $method,
+		string $path,
+		array $headers,
+		?string $actingUserId,
+	): array {
 		$matchPath = $this->normalisePath(path: $path);
 
 		// Guard 1 — access (per-object IDOR): scope-dispatched owner/membership check.
@@ -249,14 +305,76 @@ class CredentialBrokerService {
 
 		$requestHeaders = $this->injectAuth(provider: $provider, headers: $headers, secret: (string)$secret);
 
-		return $this->performCall(
-			method: $method,
-			url: $resolvedUrl,
-			headers: $requestHeaders,
+		return [
+			'method' => $method,
+			'url' => $resolvedUrl,
+			'headers' => $requestHeaders,
+		];
+
+	}//end authoriseCall()
+
+	/**
+	 * Proxy a call and hand back the response with its body STILL OPEN.
+	 *
+	 * Same credential, same guards, same injected secret as {@see request()} —
+	 * the difference is only that the body is not read here. A streaming API
+	 * (server-sent events, chunked JSON) answers over seconds or minutes, and
+	 * `request()` returns a string, so the caller waits for the last byte to see
+	 * the first and the whole response is held in memory on the way past.
+	 *
+	 * 🔑 THE GUARDS ARE NOT DUPLICATED — this method calls `request()`'s own
+	 * authorisation chain through `authoriseCall()`, which is the SAME method
+	 * `request()` uses. That matters more than the tidiness: a second proxy entry
+	 * point with its own copy of five checks is a second place for one of them to
+	 * be forgotten, and the one most likely to be forgotten is the inject-only
+	 * refusal, which is what stops this becoming an open proxy.
+	 *
+	 * ⚠️ The caller MUST consume the returned stream — see `BrokeredStream::pump()`,
+	 * which closes it. An unconsumed one holds an upstream connection open for the
+	 * life of the PHP worker.
+	 *
+	 * @param string      $credentialId  The credential to proxy through.
+	 * @param string      $appId         The calling app.
+	 * @param string      $method        The HTTP method.
+	 * @param string      $path          The upstream path, relative to the provider's baseUrl.
+	 * @param array       $headers       Caller headers; any auth among them is discarded.
+	 * @param string|null $body          The request body, when there is one.
+	 * @param string|null $actingUserId  The acting user, or null for the routed path.
+	 *
+	 * @return BrokeredStream The upstream status, headers, and unread body.
+	 *
+	 * @throws CredentialAccessDeniedException When any guard refuses.
+	 * @throws CredentialUpstreamException When the upstream call cannot be made.
+	 *
+	 * @spec openspec/specs/credential-broker-service/spec.md
+	 */
+	public function streamRequest(
+		string $credentialId,
+		string $appId,
+		string $method,
+		string $path,
+		array $headers = [],
+		?string $body = null,
+		?string $actingUserId = null,
+	): BrokeredStream {
+		$call = $this->authoriseCall(
+			credentialId: $credentialId,
+			appId: $appId,
+			method: strtoupper($method),
+			path: $path,
+			headers: $headers,
+			actingUserId: $actingUserId
+		);
+
+		return $this->performStreamingCall(
+			method: $call['method'],
+			url: $call['url'],
+			headers: $call['headers'],
 			body: $body,
 			credentialId: $credentialId
 		);
-	}//end request()
+
+	}//end streamRequest()
 
 	/**
 	 * Resolve the raw secret for an INJECT-ONLY credential, for same-instance app-side injection.
@@ -1153,6 +1271,87 @@ class CredentialBrokerService {
 			'body' => (string)$rawBody,
 		];
 	}//end performCall()
+
+	/**
+	 * Perform the upstream call WITHOUT reading its body.
+	 *
+	 * The twin of `performCall()`, and deliberately a separate method rather than
+	 * a flag on it: the two differ in what they RETURN and in who owns the
+	 * socket afterwards, which is not something a boolean argument should decide.
+	 *
+	 * `'stream' => true` is honoured by Nextcloud's own HTTP client
+	 * (`OC\Http\Client\Client`), whose `Response::getBody()` then answers with a
+	 * detached RESOURCE instead of a string. `performCall()` has always had an
+	 * `is_resource()` branch that ran `stream_get_contents()` over it — the
+	 * plumbing anticipated this; it simply buffered.
+	 *
+	 * ⚠️ NO TIMEOUT IS SET, and that is the point of the method. A model
+	 * generation legitimately runs for minutes with long gaps between frames, and
+	 * the default read timeout would abort it mid-answer — which surfaces to the
+	 * caller as a truncated response rather than as an error, the worst shape a
+	 * failure can take. The bound that matters here is the CALLER hanging up,
+	 * which `BrokeredStream::pump()` propagates by closing the stream.
+	 *
+	 * @param string      $method       The HTTP method.
+	 * @param string      $url          The resolved, host-locked upstream URL.
+	 * @param array       $headers      The request headers, secret already injected.
+	 * @param string|null $body         The request body, when there is one.
+	 * @param string      $credentialId The credential, for the error log only.
+	 *
+	 * @return BrokeredStream The status, headers, and unread body.
+	 *
+	 * @throws CredentialUpstreamException When the call cannot be made.
+	 *
+	 * @spec openspec/specs/credential-broker-service/spec.md
+	 */
+	private function performStreamingCall(
+		string $method,
+		string $url,
+		array $headers,
+		?string $body,
+		string $credentialId,
+	): BrokeredStream {
+		$options = [
+			'headers' => $headers,
+			'http_errors' => false,
+			'stream' => true,
+		];
+		if ($body !== null) {
+			$options['body'] = $body;
+		}
+
+		try {
+			$client = $this->clientService->newClient();
+			$response = $client->request($method, $url, $options);
+		} catch (Throwable $e) {
+			$this->logger->error(
+				'[CredentialBrokerService] upstream streaming call failed',
+				['credential' => $credentialId, 'error' => $e->getMessage()]
+			);
+			throw new CredentialUpstreamException(message: 'Upstream request failed');
+		}
+
+		$stream = $response->getBody();
+
+		// A non-resource here means the client buffered after all — a stub, a
+		// test double, or a future client that quietly stops honouring the
+		// option. Wrapping the string in a memory stream keeps the caller's
+		// contract intact rather than fataling on `fread(string)`, and the
+		// response is simply delivered in one chunk instead of many.
+		if (is_resource($stream) === false) {
+			$buffered = fopen('php://memory', 'r+');
+			fwrite($buffered, (string)$stream);
+			rewind($buffered);
+			$stream = $buffered;
+		}
+
+		return new BrokeredStream(
+			status: $response->getStatusCode(),
+			headers: $response->getHeaders(),
+			body: $stream
+		);
+
+	}//end performStreamingCall()
 
 	/**
 	 * Normalise and validate a caller-supplied path (reject `..`, require a single leading `/`).

--- a/tests/Unit/Service/Credential/CredentialBrokerStreamTest.php
+++ b/tests/Unit/Service/Credential/CredentialBrokerStreamTest.php
@@ -1,0 +1,318 @@
+<?php
+
+/**
+ * CredentialBrokerStreamTest — the streaming twin runs the SAME guards.
+ *
+ * The point of these tests is not that streaming works. It is that adding a
+ * second way into the proxy did not add a second, weaker way in.
+ *
+ * `streamRequest()` exists because a model completion arrives over minutes and
+ * `request()` answers with a string. The risk in that change is not the
+ * transport — it is that a new entry point acquires its own copy of five guards
+ * and one of them is quietly missing. So every guard is asserted here against
+ * the STREAMING path specifically, not inherited from the buffered path's tests.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Credential
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Credential;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\Credential\CredentialAccessDeniedException;
+use OCA\OpenRegister\Service\Credential\CredentialBrokerService;
+use OCA\OpenRegister\Service\Credential\CredentialStore;
+use OCA\OpenRegister\Service\Credential\ProviderCatalogue;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCP\Http\Client\IClient;
+use OCP\Http\Client\IClientService;
+use OCP\Http\Client\IResponse;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @covers \OCA\OpenRegister\Service\Credential\CredentialBrokerService
+ * @covers \OCA\OpenRegister\Service\Credential\BrokeredStream
+ */
+class CredentialBrokerStreamTest extends TestCase {
+
+	/** @var array<string, mixed>|null Captured client->request() options. */
+	private ?array $capturedOptions = null;
+
+	/**
+	 * A proxied provider with one allowed streaming route.
+	 *
+	 * @return array<string, mixed> The catalogue entry.
+	 */
+	private function anthropicProvider(): array {
+		return [
+			'identifier' => 'anthropic',
+			'baseUrl' => 'https://api.anthropic.com',
+			'authScheme' => ['header' => 'x-api-key', 'template' => '{secret}'],
+			'allowRules' => [
+				['method' => 'POST', 'pathPattern' => '/v1/messages'],
+			],
+		];
+	}
+
+	/**
+	 * Wire a broker whose upstream answers with an open resource.
+	 *
+	 * @param string               $sessionUid The session user.
+	 * @param string               $ownerUid   The credential owner.
+	 * @param array<string, mixed> $credData   The credential object.
+	 * @param array|null           $provider   The catalogue entry, or null.
+	 * @param string|null          $secret     The stored secret, or null.
+	 * @param string               $upstream   The bytes the upstream will emit.
+	 *
+	 * @return CredentialBrokerService The wired broker.
+	 */
+	private function makeService(
+		string $sessionUid,
+		string $ownerUid,
+		array $credData,
+		?array $provider,
+		?string $secret,
+		string $upstream = "data: one\n\ndata: two\n\n",
+	): CredentialBrokerService {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($sessionUid);
+		$session = $this->createMock(IUserSession::class);
+		$session->method('getUser')->willReturn($user);
+
+		$entity = new ObjectEntity();
+		$entity->setOwner($ownerUid);
+		$entity->setObject($credData);
+
+		$objectService = $this->createMock(ObjectService::class);
+		$objectService->method('find')->willReturn($entity);
+
+		$catalogue = $this->createMock(ProviderCatalogue::class);
+		$catalogue->method('get')->willReturn($provider);
+
+		$store = $this->createMock(CredentialStore::class);
+		$store->method('get')->willReturn($secret);
+
+		// A real resource, because that is what Nextcloud's client returns for
+		// `stream: true` — `Response::getBody()` calls `detach()` on the PSR-7
+		// body. Returning a string here would test a shape the client does not
+		// produce, and would hide the `fread()` path entirely.
+		$handle = fopen('php://memory', 'r+');
+		fwrite($handle, $upstream);
+		rewind($handle);
+
+		$response = $this->createMock(IResponse::class);
+		$response->method('getStatusCode')->willReturn(200);
+		$response->method('getHeaders')->willReturn(['Content-Type' => ['text/event-stream']]);
+		$response->method('getBody')->willReturn($handle);
+
+		$client = $this->createMock(IClient::class);
+		$client->method('request')->willReturnCallback(
+			function (string $method, string $uri, array $options) use ($response) {
+				$this->capturedOptions = $options;
+				return $response;
+			}
+		);
+		$clientService = $this->createMock(IClientService::class);
+		$clientService->method('newClient')->willReturn($client);
+
+		return new CredentialBrokerService(
+			$objectService,
+			$store,
+			$catalogue,
+			$session,
+			$clientService,
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(OrganisationService::class)
+		);
+
+	}//end makeService()
+
+	/**
+	 * A credential owned by alice, allowed for hermiq, on the anthropic provider.
+	 *
+	 * @return array<string, mixed> The credential object.
+	 */
+	private function credential(): array {
+		return [
+			'provider' => 'anthropic',
+			'allowedApps' => ['hermiq'],
+		];
+	}
+
+	public function testTheStreamedBodyArrivesInPiecesAndIsNotBuffered(): void {
+		$service = $this->makeService('alice', 'alice', $this->credential(), $this->anthropicProvider(), 'sk-secret');
+
+		$stream = $service->streamRequest(
+			credentialId: 'cred-1',
+			appId: 'hermiq',
+			method: 'POST',
+			path: '/v1/messages',
+			headers: [],
+			body: '{"stream":true}'
+		);
+
+		$this->assertSame(200, $stream->getStatus());
+		$this->assertSame(['Content-Type' => ['text/event-stream']], $stream->getHeaders());
+
+		$chunks = [];
+		$stream->pump(static function (string $chunk) use (&$chunks): void {
+			$chunks[] = $chunk;
+		});
+
+		$this->assertNotEmpty($chunks, 'the sink must receive the body');
+		$this->assertSame("data: one\n\ndata: two\n\n", implode('', $chunks));
+
+	}//end testTheStreamedBodyArrivesInPiecesAndIsNotBuffered()
+
+	/**
+	 * The option that makes the whole thing a stream rather than a buffer.
+	 *
+	 * Without `stream: true`, Nextcloud's client reads the body to a string and
+	 * every guarantee above collapses into the behaviour `request()` already had
+	 * — while every assertion in this file still passes, because a memory stream
+	 * of a short fixture is indistinguishable from a buffered one.
+	 *
+	 * @return void
+	 */
+	public function testTheUpstreamCallAsksForAStream(): void {
+		$service = $this->makeService('alice', 'alice', $this->credential(), $this->anthropicProvider(), 'sk-secret');
+
+		$service->streamRequest(
+			credentialId: 'cred-1',
+			appId: 'hermiq',
+			method: 'POST',
+			path: '/v1/messages'
+		);
+
+		$this->assertTrue(
+			($this->capturedOptions['stream'] ?? false),
+			'the upstream call must set stream: true, or nothing streams'
+		);
+
+	}//end testTheUpstreamCallAsksForAStream()
+
+	public function testTheSecretIsInjectedAndNeverComesFromTheCaller(): void {
+		$service = $this->makeService('alice', 'alice', $this->credential(), $this->anthropicProvider(), 'sk-secret');
+
+		$service->streamRequest(
+			credentialId: 'cred-1',
+			appId: 'hermiq',
+			method: 'POST',
+			path: '/v1/messages',
+			headers: ['x-api-key' => 'sk-ATTACKER-SUPPLIED']
+		);
+
+		$this->assertSame('sk-secret', ($this->capturedOptions['headers']['x-api-key'] ?? null));
+
+	}//end testTheSecretIsInjectedAndNeverComesFromTheCaller()
+
+	// ── The guards, asserted against the STREAMING path ──────────────────
+
+	public function testTheOwnerGuardRefusesANonOwner(): void {
+		$service = $this->makeService('mallory', 'alice', $this->credential(), $this->anthropicProvider(), 'sk-secret');
+
+		$this->expectException(CredentialAccessDeniedException::class);
+		$service->streamRequest('cred-1', 'hermiq', 'POST', '/v1/messages');
+
+	}//end testTheOwnerGuardRefusesANonOwner()
+
+	public function testAnUnlistedAppIsRefused(): void {
+		$service = $this->makeService('alice', 'alice', $this->credential(), $this->anthropicProvider(), 'sk-secret');
+
+		$this->expectException(CredentialAccessDeniedException::class);
+		$service->streamRequest('cred-1', 'some-other-app', 'POST', '/v1/messages');
+
+	}//end testAnUnlistedAppIsRefused()
+
+	public function testAPathOutsideTheAllowRulesIsRefused(): void {
+		$service = $this->makeService('alice', 'alice', $this->credential(), $this->anthropicProvider(), 'sk-secret');
+
+		$this->expectException(CredentialAccessDeniedException::class);
+		$service->streamRequest('cred-1', 'hermiq', 'POST', '/v1/organizations/me');
+
+	}//end testAPathOutsideTheAllowRulesIsRefused()
+
+	public function testTheWrongMethodOnAnAllowedPathIsRefused(): void {
+		$service = $this->makeService('alice', 'alice', $this->credential(), $this->anthropicProvider(), 'sk-secret');
+
+		$this->expectException(CredentialAccessDeniedException::class);
+		$service->streamRequest('cred-1', 'hermiq', 'DELETE', '/v1/messages');
+
+	}//end testTheWrongMethodOnAnAllowedPathIsRefused()
+
+	/**
+	 * The guard that stops this becoming an open proxy — ISOLATED.
+	 *
+	 * ⚠️ THIS TEST WAS VACUOUS AS FIRST WRITTEN, and the positive control caught
+	 * it: with the inject-only refusal deleted from the service the test still
+	 * passed, because a bare inject-only provider carries no allowRules and the
+	 * RULE guard refused it one line later. It asserted "something refuses",
+	 * while its name promised "the inject-only guard refuses" — the exact shape
+	 * of a test that reports a protection it never exercised.
+	 *
+	 * So the fixture is deliberately CONTRADICTORY: `inject_only: true` together
+	 * with a baseUrl and a matching allowRule. That is not a hypothetical — it is
+	 * the realistic misconfiguration, someone adding rules to an inject-only
+	 * catalogue entry, and it is the only shape in which this guard is the ONLY
+	 * thing standing between a caller and an unbounded proxy.
+	 *
+	 * Re-verified: delete the refusal and this test fails.
+	 *
+	 * @return void
+	 */
+	public function testAnInjectOnlyProviderCannotBeStreamedEvenWhenItCarriesRules(): void {
+		$service = $this->makeService(
+			'alice',
+			'alice',
+			['provider' => 'anthropic-cli', 'allowedApps' => ['hermiq']],
+			[
+				'identifier' => 'anthropic-cli',
+				'inject_only' => true,
+				'baseUrl' => 'https://api.anthropic.com',
+				'authScheme' => ['header' => 'x-api-key', 'template' => '{secret}'],
+				'allowRules' => [['method' => 'POST', 'pathPattern' => '/v1/messages']],
+			],
+			'sk-secret'
+		);
+
+		$this->expectException(CredentialAccessDeniedException::class);
+		$service->streamRequest('cred-1', 'hermiq', 'POST', '/v1/messages');
+
+	}//end testAnInjectOnlyProviderCannotBeStreamedEvenWhenItCarriesRules()
+
+	public function testAMissingSecretIsRefusedRatherThanSentUnauthenticated(): void {
+		$service = $this->makeService('alice', 'alice', $this->credential(), $this->anthropicProvider(), null);
+
+		$this->expectException(CredentialAccessDeniedException::class);
+		$service->streamRequest('cred-1', 'hermiq', 'POST', '/v1/messages');
+
+	}//end testAMissingSecretIsRefusedRatherThanSentUnauthenticated()
+
+	/**
+	 * The host is the provider's, never the caller's.
+	 *
+	 * @return void
+	 */
+	public function testTheUpstreamHostIsLockedToTheProvider(): void {
+		$service = $this->makeService('alice', 'alice', $this->credential(), $this->anthropicProvider(), 'sk-secret');
+
+		$this->expectException(CredentialAccessDeniedException::class);
+		$service->streamRequest('cred-1', 'hermiq', 'POST', 'https://evil.example/v1/messages');
+
+	}//end testTheUpstreamHostIsLockedToTheProvider()
+}//end class

--- a/tests/Unit/Service/Credential/CredentialBrokerStreamTest.php
+++ b/tests/Unit/Service/Credential/CredentialBrokerStreamTest.php
@@ -45,8 +45,21 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 /**
+ * ⚠️ `@uses` IS NOT DECORATION HERE. `phpunit.xml` sets
+ * `beStrictAboutCoverageMetadata="true"`, so on the coverage-enabled leg a test
+ * that touches a class named in neither `@covers` nor `@uses` is marked RISKY
+ * and the leg fails — with the message "executed code that is not listed as code
+ * to be covered or used", which names the class but not the annotation it wants.
+ *
+ * `makeService()` builds a real `ObjectEntity` (its magic accessors cannot be
+ * stubbed), so it must be declared. Without it these tests pass on every leg
+ * that runs without coverage and fail only on the one that runs with it — which
+ * is exactly how five of them reached CI green locally and red there.
+ *
  * @covers \OCA\OpenRegister\Service\Credential\CredentialBrokerService
  * @covers \OCA\OpenRegister\Service\Credential\BrokeredStream
+ *
+ * @uses \OCA\OpenRegister\Db\ObjectEntity
  */
 class CredentialBrokerStreamTest extends TestCase {
 


### PR DESCRIPTION
Phase 1 of ConductionNL/openregister#2476. Unblocks ConductionNL/hydra#547.

## Why

The broker can already keep a secret out of a caller's hands — that is what the `github` provider does, and hermiq's `BrokerHttpClient` has routed every LLM call through it since the OpenAI keys were taken out of `oc_appconfig`.

What it cannot do is serve a consumer that is not PHP. `request()` reads the whole upstream body and answers `{status, headers, body}` as JSON — right for a label write or a tree commit, wrong for a streaming API. A model completion arrives as SSE over minutes: the caller waits for the last token to see the first, and the whole generation sits in memory on the way past. And an off-the-shelf SDK cannot be pointed at an RPC envelope at all.

## What

`POST /api/credentials/{id}/stream` — same request-bound token, same credential-mismatch refusal, upstream status relayed as the response status, body relayed chunk by chunk.

### The guards are not duplicated — they are extracted

`request()` and `streamRequest()` both call `authoriseCall()`, which is the guard chain moved out of `request()` unchanged. A second proxy entry point with its own copy of five checks is a second place for one to be dropped — and the likeliest one is the inject-only refusal, which is what stops this becoming an unbounded proxy.

Every guard is asserted against the **streaming** path specifically rather than inherited: owner, allowed-app, allow-rule, method, host-lock, missing secret, inject-only, and that a caller-supplied `x-api-key` is discarded for the injected one.

## ⚠️ One of those tests was vacuous, and the positive control caught it

With the inject-only refusal deleted from the service, the inject-only test **still passed** — a bare inject-only provider carries no `allowRules`, so the *rule* guard refused it one line later. It asserted "something refuses" while its name promised "the inject-only guard refuses".

The fixture is now deliberately contradictory — `inject_only: true` **with** a baseUrl and a matching rule — which is also the realistic misconfiguration, and the only shape where that guard is the only thing in the way. Re-verified: delete the refusal and it fails by name.

## Measured before any of it was written

| | |
|---|---|
| `App.php:209` | calls `$response->callback($io)` **directly**, after headers are sent, no output capture, **no `Content-Length`** — the buffered arm is the other branch |
| this image | `output_buffering=0`, `implicit_flush=On`, `zlib.output_compression=Off` |
| 60 MB via the same Apache | **TTFB 1.07s vs TOTAL 9.54s** — first byte at 11% |

A buffering stack puts TTFB level with TOTAL, so that measurement could fail and didn't.

**mod_deflate** is enabled and would re-buffer a compressed stream — but its configured types are html/plain/xml/css/javascript plus the js/xml/rss/wasm application types. `text/event-stream` is not among them, so no `no-gzip` opt-out is needed here. Recorded at the call site rather than assumed, because if a deployment adds the type the symptom is **latency, not an error**.

## Two deliberate choices

- **Hop-by-hop headers are dropped on relay.** `content-length` describes the upstream's bytes and would truncate ours; `transfer-encoding`, `connection` and `content-encoding` belong to a connection that already ended.
- **No timeout on the streaming call.** A generation legitimately pauses between frames; a read timeout would abort it mid-answer, which reaches the caller as a *truncated response* rather than an error — the worst shape a failure can take.

## Verification

- 143 existing credential tests pass — the extraction did not move behaviour
- 10 new tests pass; positive control confirms they can fail
- Full Unit suite unchanged: 40 pre-existing failures, **none newly broken**
- PHPCS 0 errors · PHPMD clean · Psalm no errors