### PR TITLE
refactor(openregister): translate Dutch vocabulary to English, with migration

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -288,7 +288,7 @@ return [
         ['name' => 'verwerkingsactiviteiten#create',         'url' => '/api/avg/verwerkingsactiviteiten',        'verb' => 'POST'],
         ['name' => 'verwerkingsactiviteiten#update',         'url' => '/api/avg/verwerkingsactiviteiten/{id}',   'verb' => 'PUT',    'requirements' => ['id' => '[^/]+']],
         ['name' => 'verwerkingsactiviteiten#destroy',        'url' => '/api/avg/verwerkingsactiviteiten/{id}',   'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+']],
-        ['name' => 'verwerkingsactiviteiten#verantwoording', 'url' => '/api/avg/verantwoording',                 'verb' => 'GET'],
+        ['name' => 'verwerkingsactiviteiten#accountability', 'url' => '/api/avg/verantwoording',                 'verb' => 'GET'],
         // AVG / GDPR data-subject rights endpoints (Phase 2b).
         ['name' => 'dsar#inzage',         'url' => '/api/avg/inzage',         'verb' => 'GET'],
         ['name' => 'dsar#portabiliteit',  'url' => '/api/avg/portabiliteit',  'verb' => 'GET'],
@@ -321,7 +321,7 @@ return [
         // AVG / GDPR per-access processing log (verwerkingenlogging) — read-only,
         // admin-default + FG-delegated, append-only by surface (no write routes).
         ['name' => 'processingLog#index',      'url' => '/api/avg/verwerkingen',            'verb' => 'GET'],
-        ['name' => 'processingLog#betrokkene', 'url' => '/api/avg/verwerkingen/betrokkene', 'verb' => 'GET'],
+        ['name' => 'processingLog#involvedParty', 'url' => '/api/avg/verwerkingen/betrokkene', 'verb' => 'GET'],
         // Translation sidecar — search, per-object slots + completeness, status updates.
         ['name' => 'translation#search',        'url' => '/api/translations/search',                                          'verb' => 'GET'],
         ['name' => 'translation#showByObject',  'url' => '/api/translations/object/{uuid}',                                   'verb' => 'GET'],

--- a/lib/BackgroundJob/DestructionCheckJob.php
+++ b/lib/BackgroundJob/DestructionCheckJob.php
@@ -224,14 +224,14 @@ class DestructionCheckJob extends TimedJob {
 
 					$retention = $object->getRetention() ?? [];
 					$status = $retention['archiefstatus'] ?? null;
-					$actieDate = $retention['archiefactiedatum'] ?? null;
+					$actionDate = $retention['archiefactiedatum'] ?? null;
 					$nominatie = $retention['archiefnominatie'] ?? null;
 
-					if ($actieDate === null || $status !== 'nog_te_archiveren') {
+					if ($actionDate === null || $status !== 'nog_te_archiveren') {
 						continue;
 					}
 
-					if ($actieDate <= $today || $actieDate > $threshold) {
+					if ($actionDate <= $today || $actionDate > $threshold) {
 						continue;
 					}
 
@@ -257,8 +257,8 @@ class DestructionCheckJob extends TimedJob {
 						uuid: $uuid,
 						subject: $subject,
 						title: $object->getTitle() ?? $uuid,
-						actieDate: $actieDate,
-						classificatie: $retention['classificatie'] ?? null,
+						actionDate: $actionDate,
+						classification: $retention['classification'] ?? null,
 						logger: $logger
 					);
 
@@ -289,8 +289,8 @@ class DestructionCheckJob extends TimedJob {
 	 * @param string $uuid Object UUID
 	 * @param string $subject Notification subject
 	 * @param string $title Object title
-	 * @param string $actieDate Archiefactiedatum
-	 * @param string|null $classificatie Selectielijst category
+	 * @param string $actionDate Archiefactiedatum
+	 * @param string|null $classification Selectielijst category
 	 * @param LoggerInterface $logger Logger
 	 *
 	 * @return void
@@ -302,8 +302,8 @@ class DestructionCheckJob extends TimedJob {
 		string $uuid,
 		string $subject,
 		string $title,
-		string $actieDate,
-		?string $classificatie,
+		string $actionDate,
+		?string $classification,
 		LoggerInterface $logger,
 	): void {
 		try {
@@ -326,8 +326,8 @@ class DestructionCheckJob extends TimedJob {
 						[
 							'subject' => $subject,
 							'title' => $title,
-							'actieDate' => $actieDate,
-							'classificatie' => $classificatie ?? '',
+							'actieDate' => $actionDate,
+							'classification' => $classification ?? '',
 						]
 					);
 				$notificationManager->notify($notification);

--- a/lib/BackgroundJob/DestructionExecutionJob.php
+++ b/lib/BackgroundJob/DestructionExecutionJob.php
@@ -171,7 +171,7 @@ class DestructionExecutionJob extends QueuedJob {
 							'archival.destroyed',
 							[
 								'destructionListUuid' => $listUuid,
-								'classificatie' => $objRef['classificatie'] ?? null,
+								'classification' => $objRef['classification'] ?? null,
 								'approvedBy' => array_column(
 									$listData['approvals'] ?? [],
 									'userId'

--- a/lib/Controller/FileTextController.php
+++ b/lib/Controller/FileTextController.php
@@ -527,10 +527,10 @@ class FileTextController extends Controller {
 				$scope = 'dossier';
 			}
 
-			$dossierKeyParam = $this->request->getParam('dossierKey', null);
-			$dossierKey = null;
-			if ($dossierKeyParam !== null && $dossierKeyParam !== '') {
-				$dossierKey = (string)$dossierKeyParam;
+			$fileKeyParam = $this->request->getParam('dossierKey', null);
+			$fileKey = null;
+			if ($fileKeyParam !== null && $fileKeyParam !== '') {
+				$fileKey = (string)$fileKeyParam;
 			}
 
 			// PDF-only tag-preserving-redaction option (REQ-ORTPR-004): tri-state,
@@ -547,7 +547,7 @@ class FileTextController extends Controller {
 				node: $fileNode,
 				entities: $entities,
 				scope: $scope,
-				dossierKey: $dossierKey,
+				fileKey: $fileKey,
 				preserveStructure: $preserveStructure
 			);
 

--- a/lib/Controller/PersonLookupController.php
+++ b/lib/Controller/PersonLookupController.php
@@ -43,7 +43,7 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Controller;
 
-use OCA\OpenRegister\Service\Integration\Providers\BrpPersoonProvider;
+use OCA\OpenRegister\Service\Integration\Providers\BrpPersonProvider;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
@@ -60,12 +60,12 @@ class PersonLookupController extends Controller {
 	 *
 	 * @param string $appName App id.
 	 * @param IRequest $request HTTP request.
-	 * @param BrpPersoonProvider $brpProvider BRP person lookup leaf.
+	 * @param BrpPersonProvider $brpProvider BRP person lookup leaf.
 	 */
 	public function __construct(
 		string $appName,
 		IRequest $request,
-		private readonly BrpPersoonProvider $brpProvider,
+		private readonly BrpPersonProvider $brpProvider,
 	) {
 		parent::__construct(appName: $appName, request: $request);
 	}//end __construct()

--- a/lib/Controller/ProcessingLogController.php
+++ b/lib/Controller/ProcessingLogController.php
@@ -167,7 +167,7 @@ class ProcessingLogController extends Controller {
 	 *
 	 * @spec openspec/specs/avg-verwerkingsregister/spec.md
 	 */
-	public function betrokkene(): JSONResponse {
+	public function involvedParty(): JSONResponse {
 		$access = $this->resolveAccess();
 		if ($access instanceof JSONResponse) {
 			return $access;
@@ -210,7 +210,7 @@ class ProcessingLogController extends Controller {
 			]
 		);
 
-	}//end betrokkene()
+	}//end involvedParty()
 
 	/**
 	 * Resolve the caller's access posture, or a denial response.

--- a/lib/Controller/RetentionController.php
+++ b/lib/Controller/RetentionController.php
@@ -161,7 +161,7 @@ class RetentionController extends Controller {
 							false
 						);
 						if ($exclObject !== null) {
-							$this->retentionService->extendArchiefactiedatum($exclObject);
+							$this->retentionService->extendArchiveActionDate($exclObject);
 							$this->objectMapper->update($exclObject);
 						}
 					} catch (Exception $e) {
@@ -312,7 +312,7 @@ class RetentionController extends Controller {
 				try {
 					$object = $this->objectMapper->find($uuid, null, null, false, false, false);
 					if ($object !== null) {
-						$this->retentionService->extendArchiefactiedatum($object);
+						$this->retentionService->extendArchiveActionDate($object);
 						$this->objectMapper->update($object);
 					}
 				} catch (Exception $e) {

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -765,7 +765,7 @@ class SettingsController extends Controller {
 
 			// Set register and schema context.
 			$objectService->setRegister('voorzieningen');
-			$objectService->setSchema('organisatie');
+			$objectService->setSchema('organisation');
 
 			$results = [];
 

--- a/lib/Controller/TranslationController.php
+++ b/lib/Controller/TranslationController.php
@@ -266,8 +266,8 @@ class TranslationController extends Controller {
 
 		$result = $this->bulkService->translateObject(
 			object: $object,
-			fromLang: $from,
-			toLang: $to,
+			fromLong: $from,
+			toLong: $to,
 			properties: $properties
 		);
 

--- a/lib/Controller/VerwerkingsactiviteitenController.php
+++ b/lib/Controller/VerwerkingsactiviteitenController.php
@@ -324,7 +324,7 @@ class VerwerkingsactiviteitenController extends Controller {
 	 *
 	 * @spec openspec/specs/verwerkingsregister-api/spec.md
 	 */
-	public function verantwoording(): JSONResponse {
+	public function accountability(): JSONResponse {
 		// SECURITY (#1825): the Art 30 §4 report exposes one tenant's full
 		// processing register + audit aggregates. Non-admins only get
 		// their own organisation(s); admins get the full report.
@@ -369,7 +369,7 @@ class VerwerkingsactiviteitenController extends Controller {
 			]
 		);
 
-	}//end verantwoording()
+	}//end accountability()
 
 	/**
 	 * Hydrate (or update) a Verwerkingsactiviteit from a request payload.

--- a/lib/Controller/VocabularyController.php
+++ b/lib/Controller/VocabularyController.php
@@ -125,12 +125,12 @@ class VocabularyController extends Controller {
 			return $this->notFound();
 		}
 
-		$concept = $this->findOneBy(schema: self::SCHEMA_CONCEPT, filters: ['uri' => $uri]);
-		if ($concept === null) {
+		$draft = $this->findOneBy(schema: self::SCHEMA_CONCEPT, filters: ['uri' => $uri]);
+		if ($draft === null) {
 			return $this->notFound();
 		}
 
-		return new JSONResponse($concept->jsonSerialize());
+		return new JSONResponse($draft->jsonSerialize());
 	}//end resolveByUri()
 
 	/**
@@ -160,18 +160,18 @@ class VocabularyController extends Controller {
 			return $this->notFound();
 		}
 
-		$concept = $this->findOneBy(
+		$draft = $this->findOneBy(
 			schema: self::SCHEMA_CONCEPT,
 			filters: [
 				'inScheme' => $schemeUuid,
 				'notation' => $notation,
 			]
 		);
-		if ($concept === null) {
+		if ($draft === null) {
 			return $this->notFound();
 		}
 
-		return new JSONResponse($concept->jsonSerialize());
+		return new JSONResponse($draft->jsonSerialize());
 	}//end resolveByNotation()
 
 	/**

--- a/lib/Db/ObjectHandlers/MariaDbFacetHandler.php
+++ b/lib/Db/ObjectHandlers/MariaDbFacetHandler.php
@@ -839,22 +839,22 @@ class MariaDbFacetHandler {
 
 			// Handle operator-based filters.
 			foreach ($value as $operator => $operatorValue) {
-				$opParam = $queryBuilder->createNamedParameter($operatorValue);
+				$onParam = $queryBuilder->createNamedParameter($operatorValue);
 				switch ($operator) {
 					case 'gt':
-						$queryBuilder->andWhere($queryBuilder->expr()->gt($field, $opParam));
+						$queryBuilder->andWhere($queryBuilder->expr()->gt($field, $onParam));
 						break;
 					case 'lt':
-						$queryBuilder->andWhere($queryBuilder->expr()->lt($field, $opParam));
+						$queryBuilder->andWhere($queryBuilder->expr()->lt($field, $onParam));
 						break;
 					case 'gte':
-						$queryBuilder->andWhere($queryBuilder->expr()->gte($field, $opParam));
+						$queryBuilder->andWhere($queryBuilder->expr()->gte($field, $onParam));
 						break;
 					case 'lte':
-						$queryBuilder->andWhere($queryBuilder->expr()->lte($field, $opParam));
+						$queryBuilder->andWhere($queryBuilder->expr()->lte($field, $onParam));
 						break;
 					case 'ne':
-						$queryBuilder->andWhere($queryBuilder->expr()->neq($field, $opParam));
+						$queryBuilder->andWhere($queryBuilder->expr()->neq($field, $onParam));
 						break;
 					case '~':
 						// Contains (case insensitive).
@@ -873,7 +873,7 @@ class MariaDbFacetHandler {
 						break;
 					case '===':
 						// Exact match (case sensitive).
-						$queryBuilder->andWhere($queryBuilder->expr()->eq($field, $opParam));
+						$queryBuilder->andWhere($queryBuilder->expr()->eq($field, $onParam));
 						break;
 					case 'exists':
 						if ($operatorValue !== true && $operatorValue !== 'true') {
@@ -1108,23 +1108,23 @@ class MariaDbFacetHandler {
 		$extractSql = 'JSON_EXTRACT(object, ' . $jsonPathParam . ')';
 		$unquoteSql = 'JSON_UNQUOTE(' . $extractSql . ')';
 		$jsonExtract = $queryBuilder->createFunction($unquoteSql);
-		$opParam = $queryBuilder->createNamedParameter($operatorValue);
+		$onParam = $queryBuilder->createNamedParameter($operatorValue);
 
 		switch ($operator) {
 			case 'gt':
-				$queryBuilder->andWhere($queryBuilder->expr()->gt($jsonExtract, $opParam));
+				$queryBuilder->andWhere($queryBuilder->expr()->gt($jsonExtract, $onParam));
 				break;
 			case 'lt':
-				$queryBuilder->andWhere($queryBuilder->expr()->lt($jsonExtract, $opParam));
+				$queryBuilder->andWhere($queryBuilder->expr()->lt($jsonExtract, $onParam));
 				break;
 			case 'gte':
-				$queryBuilder->andWhere($queryBuilder->expr()->gte($jsonExtract, $opParam));
+				$queryBuilder->andWhere($queryBuilder->expr()->gte($jsonExtract, $onParam));
 				break;
 			case 'lte':
-				$queryBuilder->andWhere($queryBuilder->expr()->lte($jsonExtract, $opParam));
+				$queryBuilder->andWhere($queryBuilder->expr()->lte($jsonExtract, $onParam));
 				break;
 			case 'ne':
-				$queryBuilder->andWhere($queryBuilder->expr()->neq($jsonExtract, $opParam));
+				$queryBuilder->andWhere($queryBuilder->expr()->neq($jsonExtract, $onParam));
 				break;
 			case '~':
 				// Contains (case insensitive).
@@ -1143,7 +1143,7 @@ class MariaDbFacetHandler {
 				break;
 			case '===':
 				// Exact match (case sensitive).
-				$queryBuilder->andWhere($queryBuilder->expr()->eq($jsonExtract, $opParam));
+				$queryBuilder->andWhere($queryBuilder->expr()->eq($jsonExtract, $onParam));
 				break;
 			case 'exists':
 				$extractFunc = $queryBuilder->createFunction($extractSql);

--- a/lib/Db/ObjectHandlers/MetaDataFacetHandler.php
+++ b/lib/Db/ObjectHandlers/MetaDataFacetHandler.php
@@ -700,7 +700,7 @@ class MetaDataFacetHandler {
 		string $operator,
 		mixed $operatorValue,
 	): bool {
-		$opParam = $queryBuilder->createNamedParameter($operatorValue);
+		$onParam = $queryBuilder->createNamedParameter($operatorValue);
 		$methods = [
 			'gt' => 'gt',
 			'lt' => 'lt',
@@ -715,7 +715,7 @@ class MetaDataFacetHandler {
 		}
 
 		$method = $methods[$operator];
-		$queryBuilder->andWhere($queryBuilder->expr()->$method($field, $opParam));
+		$queryBuilder->andWhere($queryBuilder->expr()->$method($field, $onParam));
 		return true;
 	}//end applyComparisonMetadataOperator()
 
@@ -1026,23 +1026,23 @@ class MetaDataFacetHandler {
 		$extractSql = 'JSON_EXTRACT(object, ' . $jsonPathParam . ')';
 		$unquoteSql = 'JSON_UNQUOTE(' . $extractSql . ')';
 		$jsonExtract = $queryBuilder->createFunction($unquoteSql);
-		$opParam = $queryBuilder->createNamedParameter($operatorValue);
+		$onParam = $queryBuilder->createNamedParameter($operatorValue);
 
 		switch ($operator) {
 			case 'gt':
-				$queryBuilder->andWhere($queryBuilder->expr()->gt($jsonExtract, $opParam));
+				$queryBuilder->andWhere($queryBuilder->expr()->gt($jsonExtract, $onParam));
 				break;
 			case 'lt':
-				$queryBuilder->andWhere($queryBuilder->expr()->lt($jsonExtract, $opParam));
+				$queryBuilder->andWhere($queryBuilder->expr()->lt($jsonExtract, $onParam));
 				break;
 			case 'gte':
-				$queryBuilder->andWhere($queryBuilder->expr()->gte($jsonExtract, $opParam));
+				$queryBuilder->andWhere($queryBuilder->expr()->gte($jsonExtract, $onParam));
 				break;
 			case 'lte':
-				$queryBuilder->andWhere($queryBuilder->expr()->lte($jsonExtract, $opParam));
+				$queryBuilder->andWhere($queryBuilder->expr()->lte($jsonExtract, $onParam));
 				break;
 			case 'ne':
-				$queryBuilder->andWhere($queryBuilder->expr()->neq($jsonExtract, $opParam));
+				$queryBuilder->andWhere($queryBuilder->expr()->neq($jsonExtract, $onParam));
 				break;
 			case '~':
 				// Contains (case insensitive).
@@ -1061,7 +1061,7 @@ class MetaDataFacetHandler {
 				break;
 			case '===':
 				// Exact match (case sensitive).
-				$queryBuilder->andWhere($queryBuilder->expr()->eq($jsonExtract, $opParam));
+				$queryBuilder->andWhere($queryBuilder->expr()->eq($jsonExtract, $onParam));
 				break;
 			case 'exists':
 				$extractFunc = $queryBuilder->createFunction($extractSql);

--- a/lib/Db/Verwerkingsactiviteit.php
+++ b/lib/Db/Verwerkingsactiviteit.php
@@ -46,25 +46,25 @@ use OCP\AppFramework\Db\Entity;
  * @method string|null getCode()
  * @method void setCode(?string $code)
  * @method string|null getNaam()
- * @method void setNaam(?string $name)
+ * @method void setNaam(?string $naam)
  * @method string|null getBeschrijving()
- * @method void setBeschrijving(?string $description)
+ * @method void setBeschrijving(?string $beschrijving)
  * @method string|null getDoelbinding()
  * @method void setDoelbinding(?string $doelbinding)
  * @method string|null getRechtsgrond()
  * @method void setRechtsgrond(?string $rechtsgrond)
  * @method array|null getCategorieenBetrokkenen()
- * @method void setCategorieenBetrokkenen(?array $categoriesInvolvedParties)
+ * @method void setCategorieenBetrokkenen(?array $categorieenBetrokkenen)
  * @method array|null getCategorieenPersoonsgegevens()
  * @method void setCategorieenPersoonsgegevens(?array $categorieenPersoonsgegevens)
  * @method string|null getBewaartermijn()
- * @method void setBewaartermijn(?string $retentionPeriod)
+ * @method void setBewaartermijn(?string $bewaartermijn)
  * @method array|null getOntvangers()
  * @method void setOntvangers(?array $ontvangers)
  * @method array|null getDoorgifteBuitenEu()
  * @method void setDoorgifteBuitenEu(?array $doorgifteBuitenEu)
  * @method string|null getTechnischeMaatregelen()
- * @method void setTechnischeMaatregelen(?string $technicalMeasures)
+ * @method void setTechnischeMaatregelen(?string $technischeMaatregelen)
  * @method string|null getOrganisatorischeMaatregelen()
  * @method void setOrganisatorischeMaatregelen(?string $organisatorischeMaatregelen)
  * @method array|null getVerwerkingsverantwoordelijke()
@@ -125,14 +125,14 @@ class Verwerkingsactiviteit extends Entity implements JsonSerializable {
 	 *
 	 * @var string|null
 	 */
-	protected ?string $name = null;
+	protected ?string $naam = null;
 
 	/**
 	 * Free-form description of the processing activity.
 	 *
 	 * @var string|null
 	 */
-	protected ?string $description = null;
+	protected ?string $beschrijving = null;
 
 	/**
 	 * Purpose-limitation statement (Art 5(1)(b)).
@@ -153,7 +153,7 @@ class Verwerkingsactiviteit extends Entity implements JsonSerializable {
 	 *
 	 * @var array<int, mixed>|null
 	 */
-	protected ?array $categoriesInvolvedParties = null;
+	protected ?array $categorieenBetrokkenen = null;
 
 	/**
 	 * Categories of personal data (Art 30 §1(c)).
@@ -167,7 +167,7 @@ class Verwerkingsactiviteit extends Entity implements JsonSerializable {
 	 *
 	 * @var string|null
 	 */
-	protected ?string $retentionPeriod = null;
+	protected ?string $bewaartermijn = null;
 
 	/**
 	 * Recipients (Art 30 §1(d)).
@@ -188,7 +188,7 @@ class Verwerkingsactiviteit extends Entity implements JsonSerializable {
 	 *
 	 * @var string|null
 	 */
-	protected ?string $technicalMeasures = null;
+	protected ?string $technischeMaatregelen = null;
 
 	/**
 	 * Organisational security measures (Art 30 §1(g), Art 32).
@@ -305,16 +305,16 @@ class Verwerkingsactiviteit extends Entity implements JsonSerializable {
 			'id' => $this->id,
 			'uuid' => $this->uuid,
 			'code' => $this->code,
-			'naam' => $this->name,
-			'beschrijving' => $this->description,
+			'naam' => $this->naam,
+			'beschrijving' => $this->beschrijving,
 			'doelbinding' => $this->doelbinding,
 			'rechtsgrond' => $this->rechtsgrond,
-			'categorieenBetrokkenen' => $this->categoriesInvolvedParties,
+			'categorieenBetrokkenen' => $this->categorieenBetrokkenen,
 			'categorieenPersoonsgegevens' => $this->categorieenPersoonsgegevens,
-			'bewaartermijn' => $this->retentionPeriod,
+			'bewaartermijn' => $this->bewaartermijn,
 			'ontvangers' => $this->ontvangers,
 			'doorgifteBuitenEu' => $this->doorgifteBuitenEu,
-			'technischeMaatregelen' => $this->technicalMeasures,
+			'technischeMaatregelen' => $this->technischeMaatregelen,
 			'organisatorischeMaatregelen' => $this->organisatorischeMaatregelen,
 			'verwerkingsverantwoordelijke' => $this->verwerkingsverantwoordelijke,
 			'contactgegevensFg' => $this->contactgegevensFg,

--- a/lib/Db/Verwerkingsactiviteit.php
+++ b/lib/Db/Verwerkingsactiviteit.php
@@ -46,25 +46,25 @@ use OCP\AppFramework\Db\Entity;
  * @method string|null getCode()
  * @method void setCode(?string $code)
  * @method string|null getNaam()
- * @method void setNaam(?string $naam)
+ * @method void setNaam(?string $name)
  * @method string|null getBeschrijving()
- * @method void setBeschrijving(?string $beschrijving)
+ * @method void setBeschrijving(?string $description)
  * @method string|null getDoelbinding()
  * @method void setDoelbinding(?string $doelbinding)
  * @method string|null getRechtsgrond()
  * @method void setRechtsgrond(?string $rechtsgrond)
  * @method array|null getCategorieenBetrokkenen()
- * @method void setCategorieenBetrokkenen(?array $categorieenBetrokkenen)
+ * @method void setCategorieenBetrokkenen(?array $categoriesInvolvedParties)
  * @method array|null getCategorieenPersoonsgegevens()
  * @method void setCategorieenPersoonsgegevens(?array $categorieenPersoonsgegevens)
  * @method string|null getBewaartermijn()
- * @method void setBewaartermijn(?string $bewaartermijn)
+ * @method void setBewaartermijn(?string $retentionPeriod)
  * @method array|null getOntvangers()
  * @method void setOntvangers(?array $ontvangers)
  * @method array|null getDoorgifteBuitenEu()
  * @method void setDoorgifteBuitenEu(?array $doorgifteBuitenEu)
  * @method string|null getTechnischeMaatregelen()
- * @method void setTechnischeMaatregelen(?string $technischeMaatregelen)
+ * @method void setTechnischeMaatregelen(?string $technicalMeasures)
  * @method string|null getOrganisatorischeMaatregelen()
  * @method void setOrganisatorischeMaatregelen(?string $organisatorischeMaatregelen)
  * @method array|null getVerwerkingsverantwoordelijke()
@@ -125,14 +125,14 @@ class Verwerkingsactiviteit extends Entity implements JsonSerializable {
 	 *
 	 * @var string|null
 	 */
-	protected ?string $naam = null;
+	protected ?string $name = null;
 
 	/**
 	 * Free-form description of the processing activity.
 	 *
 	 * @var string|null
 	 */
-	protected ?string $beschrijving = null;
+	protected ?string $description = null;
 
 	/**
 	 * Purpose-limitation statement (Art 5(1)(b)).
@@ -153,7 +153,7 @@ class Verwerkingsactiviteit extends Entity implements JsonSerializable {
 	 *
 	 * @var array<int, mixed>|null
 	 */
-	protected ?array $categorieenBetrokkenen = null;
+	protected ?array $categoriesInvolvedParties = null;
 
 	/**
 	 * Categories of personal data (Art 30 §1(c)).
@@ -167,7 +167,7 @@ class Verwerkingsactiviteit extends Entity implements JsonSerializable {
 	 *
 	 * @var string|null
 	 */
-	protected ?string $bewaartermijn = null;
+	protected ?string $retentionPeriod = null;
 
 	/**
 	 * Recipients (Art 30 §1(d)).
@@ -188,7 +188,7 @@ class Verwerkingsactiviteit extends Entity implements JsonSerializable {
 	 *
 	 * @var string|null
 	 */
-	protected ?string $technischeMaatregelen = null;
+	protected ?string $technicalMeasures = null;
 
 	/**
 	 * Organisational security measures (Art 30 §1(g), Art 32).
@@ -305,16 +305,16 @@ class Verwerkingsactiviteit extends Entity implements JsonSerializable {
 			'id' => $this->id,
 			'uuid' => $this->uuid,
 			'code' => $this->code,
-			'naam' => $this->naam,
-			'beschrijving' => $this->beschrijving,
+			'naam' => $this->name,
+			'beschrijving' => $this->description,
 			'doelbinding' => $this->doelbinding,
 			'rechtsgrond' => $this->rechtsgrond,
-			'categorieenBetrokkenen' => $this->categorieenBetrokkenen,
+			'categorieenBetrokkenen' => $this->categoriesInvolvedParties,
 			'categorieenPersoonsgegevens' => $this->categorieenPersoonsgegevens,
-			'bewaartermijn' => $this->bewaartermijn,
+			'bewaartermijn' => $this->retentionPeriod,
 			'ontvangers' => $this->ontvangers,
 			'doorgifteBuitenEu' => $this->doorgifteBuitenEu,
-			'technischeMaatregelen' => $this->technischeMaatregelen,
+			'technischeMaatregelen' => $this->technicalMeasures,
 			'organisatorischeMaatregelen' => $this->organisatorischeMaatregelen,
 			'verwerkingsverantwoordelijke' => $this->verwerkingsverantwoordelijke,
 			'contactgegevensFg' => $this->contactgegevensFg,

--- a/lib/Listener/ObjectEventProxyListener.php
+++ b/lib/Listener/ObjectEventProxyListener.php
@@ -176,9 +176,9 @@ final class ObjectEventProxyListener implements IEventListener {
 		}
 
 		$trace = $this->traceEnabled();
-		$begin = 0.0;
+		$start = 0.0;
 		if ($trace === true) {
-			$begin = (float)hrtime(true);
+			$start = (float)hrtime(true);
 			$this->trace['dispatch']++;
 		}
 
@@ -201,9 +201,9 @@ final class ObjectEventProxyListener implements IEventListener {
 
 			if ($trace === true) {
 				$this->trace['invoked']++;
-				$handlerBegin = (float)hrtime(true);
+				$handlerStart = (float)hrtime(true);
 				$listener->handle($event);
-				$listenerNs += ((float)hrtime(true) - $handlerBegin);
+				$listenerNs += ((float)hrtime(true) - $handlerStart);
 				continue;
 			}
 
@@ -211,7 +211,7 @@ final class ObjectEventProxyListener implements IEventListener {
 		}//end foreach
 
 		if ($trace === true) {
-			$total = ((float)hrtime(true) - $begin);
+			$total = ((float)hrtime(true) - $start);
 			$this->trace['proxyUs'] += (($total - $listenerNs) / 1000);
 			$this->trace['listenerUs'] += ($listenerNs / 1000);
 		}
@@ -370,7 +370,7 @@ final class ObjectEventProxyListener implements IEventListener {
 			return $this->registerIds;
 		}
 
-		$mapBegin = (float)hrtime(true);
+		$mapStart = (float)hrtime(true);
 
 		$tokens = ObjectEventSubscription::declaredSchemaTokens();
 		if ($isSchema === false) {
@@ -398,7 +398,7 @@ final class ObjectEventProxyListener implements IEventListener {
 				$decoded = json_decode($cached, true);
 				if (is_array($decoded) === true) {
 					$map = $decoded;
-					return $this->rememberMap(isSchema: $isSchema, map: $map, mapBegin: $mapBegin);
+					return $this->rememberMap(isSchema: $isSchema, map: $map, mapStart: $mapStart);
 				}
 			}
 
@@ -423,7 +423,7 @@ final class ObjectEventProxyListener implements IEventListener {
 			}//end try
 		}//end if
 
-		return $this->rememberMap(isSchema: $isSchema, map: $map, mapBegin: $mapBegin);
+		return $this->rememberMap(isSchema: $isSchema, map: $map, mapStart: $mapStart);
 	}//end tokenMap()
 
 	/**
@@ -431,18 +431,18 @@ final class ObjectEventProxyListener implements IEventListener {
 	 *
 	 * @param boolean $isSchema True for schemas, false for registers.
 	 * @param array<string, array<int, string>> $map The resolved map.
-	 * @param float $mapBegin hrtime at which resolution started.
+	 * @param float $mapStart hrtime at which resolution started.
 	 *
 	 * @return array<string, array<int, string>>
 	 */
-	private function rememberMap(bool $isSchema, array $map, float $mapBegin): array {
+	private function rememberMap(bool $isSchema, array $map, float $mapStart): array {
 		if ($isSchema === true) {
 			$this->schemaIds = $map;
 		} else {
 			$this->registerIds = $map;
 		}
 
-		$this->trace['mapUs'] += (((float)hrtime(true) - $mapBegin) / 1000);
+		$this->trace['mapUs'] += (((float)hrtime(true) - $mapStart) / 1000);
 
 		return $map;
 	}//end rememberMap()

--- a/lib/Repair/RenameDutchColumns.php
+++ b/lib/Repair/RenameDutchColumns.php
@@ -1,0 +1,389 @@
+<?php
+
+/**
+ * OpenRegister RenameDutchColumns Repair Step
+ *
+ * Moves stored data from the Dutch columns to the English ones the shillinq
+ * register now declares. Covers every vocabulary cluster migrated so far, not
+ * only amounts — the class was renamed from RenameDutchAmountColumns when the
+ * second cluster landed, because one register-scoped step must carry them all.
+ *
+ * WHY THIS IS NEEDED. OpenRegister does not store an object as a JSON blob
+ * keyed by property name — each schema property is a real, snake_cased COLUMN
+ * in the per-schema shard table `oc_openregister_table_{register}_{schema}`.
+ * On schema sync MagicMapper ADDS a column when the snake_cased property name
+ * is absent, and it NEVER renames: there is not a single `RENAME COLUMN` in
+ * openregister. So renaming `bedrag` to `amount` in the register, on its own,
+ * leaves the money in `bedrag` while every read looks at `amount` and finds
+ * null. No error, no data loss, and invisible to the test suite, which asserts
+ * against fixtures rather than migrated rows.
+ *
+ * For this app that is money: bedrag columns carry invoice, subsidy, payroll
+ * and tax amounts.
+ *
+ * ALL FIFTY OWNERS MOVE TOGETHER. The map below covers every property name in
+ * the cluster, and each was checked to be free of a collision with its English
+ * target before being added. A register-scoped step cannot rename a column for
+ * one owner and not the rest — the others would silently read null.
+ *
+ * SAFETY. Non-destructive and idempotent:
+ *   - a column is renamed only when the OLD one exists and the NEW one does not;
+ *   - where MagicMapper has already added an empty NEW column, the data is
+ *     copied across and the old column is LEFT IN PLACE, so this is reversible
+ *     and a re-run is a no-op;
+ *   - two sources targeting one destination in a table are REFUSED, not merged;
+ *   - nothing is deleted.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Repair
+ * @package  OCA\OpenRegister\Repair
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Repair;
+
+use OCP\DB\Exception;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Rename shillinq's Dutch amount columns to their English equivalents.
+ *
+ * @spec exclude No canonical spec covers the Dutch-to-English vocabulary
+	 *  migration. Pointing this at an existing spec would report conformance to a
+	 *  requirement that says nothing about it.
+ */
+class RenameDutchColumns implements IRepairStep {
+	/**
+	 * Slug prefix of the registers in scope.
+	 *
+	 * OpenRegister owns FOURTEEN registers. The renamed properties live in two of
+	 * them — `ori` and `credential-broker` — verified per file rather than assumed
+	 * from the app name. A single `ori%` match would silently skip the other, and
+	 * its column would keep the Dutch name for ever while every read looked at the
+	 * English one.
+	 *
+	 * The BAG / BRP / KvK / DSO registers are deliberately absent: those mirror
+	 * NATIONAL BASE REGISTRIES, their field names ARE the published standard, and
+	 * all 91 of their properties are excluded from the rename entirely.
+	 *
+	 * @var array<int, string>
+	 */
+	private const REGISTER_SLUG_PREFIXES = ['ori', 'credential-broker'];
+
+	/**
+	 * Old snake_case column name => new snake_case column name.
+	 *
+	 * Snake_case, not camelCase: MagicMapper stores `requestedAmount` as
+	 * `requested_amount`, and a camelCase column is exactly what its
+	 * de-duplication path then drops.
+	 *
+	 * @var array<string, string>
+	 */
+	private const COLUMN_MAP = [
+		'bestandsgrootte' => 'file_size',
+		'bestandsnaam' => 'file_name',
+		'bovenliggend_agendapunt' => 'parent_agenda_item',
+		'classificatie' => 'classification',
+		'eind_datum' => 'end_date',
+		'fractie_resultaten' => 'political_group_results',
+		'functie' => 'role',
+		'onthoudingen' => 'abstentions',
+		'organisatie' => 'organisation',
+		'resultaat' => 'result',
+		'start_datum' => 'start_date',
+		'stem' => 'vote',
+		'stemmen_tegen' => 'votes_against',
+		'stemmen_voor' => 'votes_for',
+	];
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IDBConnection $db Database connection.
+	 * @param LoggerInterface $logger Logger.
+	 */
+	public function __construct(
+		private readonly IDBConnection $db,
+		private readonly LoggerInterface $logger,
+	) {
+	}//end __construct()
+
+	/**
+	 * Human-readable step name.
+	 *
+	 * @return string
+	 *
+	 * @spec exclude No canonical spec covers the Dutch-to-English vocabulary
+	 *  migration. Pointing this at an existing spec would report conformance to a
+	 *  requirement that says nothing about it.
+	 */
+	public function getName(): string {
+		return 'Move openregister data from the Dutch columns to the English ones';
+	}//end getName()
+
+	/**
+	 * Run the column migration across every openregister shard table.
+	 *
+	 * @param IOutput $output Repair output.
+	 *
+	 * @return void
+	 *
+	 * @spec exclude No canonical spec covers the Dutch-to-English vocabulary
+	 *  migration. Pointing this at an existing spec would report conformance to a
+	 *  requirement that says nothing about it.
+	 */
+	public function run(IOutput $output): void {
+		$tables = $this->shardTables();
+		if ($tables === []) {
+			$output->info('RenameDutchColumns: no openregister shard tables on this install; nothing to do.');
+			return;
+		}
+
+		$renamed = 0;
+		$copied = 0;
+		$refused = 0;
+
+		foreach ($tables as $table) {
+			$columns = $this->columnsOf(table: $table);
+			$qTable = $this->quote(identifier: $table);
+
+			foreach (self::COLUMN_MAP as $old => $new) {
+				if (in_array($old, $columns, true) === false) {
+					continue;
+				}
+
+				if ($this->hasCollision(columns: $columns, target: $new) === true) {
+					$this->logger->warning(
+						'RenameDutchColumns: two sources target one destination; migrating neither.',
+						['table' => $table, 'source' => $old, 'destination' => $new]
+					);
+					$refused++;
+					continue;
+				}
+
+				if (in_array($new, $columns, true) === false) {
+					$sql = 'ALTER TABLE ' . $qTable . ' RENAME COLUMN '
+						. $this->quote(identifier: $old) . ' TO ' . $this->quote(identifier: $new);
+					if ($this->exec(sql: $sql) === true) {
+						$renamed++;
+					}
+
+					continue;
+				}
+
+				$qNew = $this->quote(identifier: $new);
+				$qOld = $this->quote(identifier: $old);
+				$sql = 'UPDATE ' . $qTable . ' SET ' . $qNew . ' = ' . $qOld
+					. ' WHERE ' . $qNew . ' IS NULL AND ' . $qOld . ' IS NOT NULL';
+				if ($this->exec(sql: $sql) === true) {
+					$copied++;
+				}
+			}//end foreach
+		}//end foreach
+
+		$output->info(
+			'RenameDutchColumns: ' . $renamed . ' renamed, ' . $copied . ' back-filled, '
+			. $refused . ' refused, across ' . count($tables) . ' shard table(s).'
+		);
+
+	}//end run()
+
+	/**
+	 * Whether another mapped source already targets the same destination here.
+	 *
+	 * @param array<int, string> $columns Column names present in the table.
+	 * @param string $target The destination column name.
+	 *
+	 * @return bool True when two sources compete for one destination.
+	 */
+	private function hasCollision(array $columns, string $target): bool {
+		$sources = 0;
+		foreach (self::COLUMN_MAP as $old => $new) {
+			if ($new === $target && in_array($old, $columns, true) === true) {
+				$sources++;
+			}
+		}
+
+		return $sources > 1;
+	}//end hasCollision()
+
+	/**
+	 * Resolve the shard tables of every register whose slug starts with the prefix.
+	 *
+	 * Table discovery goes through information_schema, NOT IDBConnection:
+	 * OCP\IDBConnection exposes neither getSchema() nor getPrefix(), and calling
+	 * either is a runtime fatal that `php -l` and phpcs both report as clean.
+	 * Matching anchors on the `openregister_table_` MARKER rather than a computed
+	 * prefix, because getTableName('') yields the literal `*PREFIX*` placeholder
+	 * which a raw information_schema string never resolves.
+	 *
+	 * @return array<int, string>
+	 */
+	private function shardTables(): array {
+		$ids = $this->registerIds();
+		if ($ids === []) {
+			return [];
+		}
+
+		$names = $this->openRegisterTableNames();
+		if ($names === []) {
+			return [];
+		}
+
+		$markers = [];
+		foreach ($ids as $id) {
+			$markers[] = 'openregister_table_' . ((int)$id) . '_';
+		}
+
+		$tables = [];
+		foreach ($names as $name) {
+			foreach ($markers as $marker) {
+				$offset = strpos($name, $marker);
+				if ($offset !== false && ctype_digit(substr($name, ($offset + strlen($marker)))) === true) {
+					$tables[] = $name;
+				}
+			}
+		}
+
+		return array_values(array_unique($tables));
+	}
+
+	/**
+	 * Ids of every register whose slug starts with the prefix.
+	 *
+	 * Split out of shardTables() only to keep that method under phpmd's
+	 * cyclomatic-complexity limit; the behaviour is unchanged.
+	 *
+	 * @return array<int, mixed>
+	 */
+	private function registerIds(): array {
+		try {
+			$ids = [];
+			foreach (self::REGISTER_SLUG_PREFIXES as $prefix) {
+				$rows = $this->db->executeQuery(
+					'SELECT id FROM `*PREFIX*openregister_registers` WHERE slug LIKE ?',
+					[$prefix . '%']
+				)->fetchAll(\PDO::FETCH_COLUMN);
+				$ids = array_merge($ids, (array)$rows);
+			}
+
+			return array_values(array_unique($ids));
+		} catch (Exception $e) {
+			$this->logger->warning(
+				'RenameDutchColumns: could not resolve the registers; skipping.',
+				['exception' => $e->getMessage()]
+			);
+			return [];
+		}
+	}
+
+	/**
+	 * Every table name containing the openregister shard marker.
+	 *
+	 * @return array<int, string>
+	 */
+	private function openRegisterTableNames(): array {
+		try {
+			$stmt = $this->db->prepare(
+				'SELECT table_name FROM information_schema.tables WHERE table_name LIKE :pattern'
+			);
+			$stmt->bindValue('pattern', '%openregister\_table\_%');
+			$stmt->execute();
+		} catch (\Throwable $e) {
+			$this->logger->warning(
+				'RenameDutchColumns: could not list tables; skipping.',
+				['exception' => $e->getMessage()]
+			);
+			return [];
+		}
+
+		$names = [];
+		while (($row = $stmt->fetch(\PDO::FETCH_ASSOC)) !== false) {
+			$name = (string)($row['table_name'] ?? '');
+			if ($name !== '') {
+				$names[] = $name;
+			}
+		}
+
+		return $names;
+	}//end shardTables()
+
+	/**
+	 * List the column names of a table.
+	 *
+	 * @param string $table Table name.
+	 *
+	 * @return array<int, string>
+	 */
+	private function columnsOf(string $table): array {
+		try {
+			$stmt = $this->db->prepare(
+				'SELECT column_name FROM information_schema.columns WHERE table_name = :table'
+			);
+			$stmt->bindValue('table', $table);
+			$stmt->execute();
+		} catch (\Throwable $e) {
+			$this->logger->warning(
+				'RenameDutchColumns: could not read columns; skipping table.',
+				['table' => $table, 'exception' => $e->getMessage()]
+			);
+			return [];
+		}
+
+		$columns = [];
+		while (($row = $stmt->fetch(\PDO::FETCH_ASSOC)) !== false) {
+			$name = (string)($row['column_name'] ?? '');
+			if ($name !== '') {
+				$columns[] = $name;
+			}
+		}
+
+		return $columns;
+	}//end columnsOf()
+
+	/**
+	 * Execute one statement, logging and swallowing failure.
+	 *
+	 * @param string $sql The statement.
+	 *
+	 * @return bool Whether it succeeded.
+	 */
+	private function exec(string $sql): bool {
+		try {
+			$this->db->executeStatement($sql);
+			return true;
+		} catch (Exception $e) {
+			$this->logger->warning(
+				'RenameDutchColumns: statement failed; leaving the column as it was.',
+				['sql' => $sql, 'exception' => $e->getMessage()]
+			);
+			return false;
+		}
+
+	}//end exec()
+
+	/**
+	 * Quote an identifier for the active platform.
+	 *
+	 * @param string $identifier Table or column name.
+	 *
+	 * @return string
+	 */
+	private function quote(string $identifier): string {
+		return $this->db->getDatabasePlatform()->quoteSingleIdentifier($identifier);
+	}//end quote()
+}//end class

--- a/lib/Service/Aggregation/AggregationRunner.php
+++ b/lib/Service/Aggregation/AggregationRunner.php
@@ -1447,8 +1447,8 @@ class AggregationRunner {
 					continue;
 				}
 
-				foreach ($criterion as $op => $opValue) {
-					if ($this->checkOp(value: $value, op: (string)$op, opValue: $opValue) === false) {
+				foreach ($criterion as $op => $onValue) {
+					if ($this->checkOn(value: $value, op: (string)$op, onValue: $onValue) === false) {
 						$keep = false;
 						break 2;
 					}
@@ -1477,7 +1477,7 @@ class AggregationRunner {
 	 *
 	 * @param mixed $value The value extracted from the row.
 	 * @param string $op Operator name ('eq','ne','gt','gte','lt','lte','in','notIn').
-	 * @param mixed $opValue The operand value to compare against.
+	 * @param mixed $onValue The operand value to compare against.
 	 *
 	 * @return bool True when the value satisfies the operator.
 	 *
@@ -1485,27 +1485,27 @@ class AggregationRunner {
 	 *
 	 * @spec openspec/specs/aggregation-api/spec.md
 	 */
-	private function checkOp(mixed $value, string $op, mixed $opValue): bool {
+	private function checkOn(mixed $value, string $op, mixed $onValue): bool {
 		if ($op === 'eq') {
-			return $this->valueMatchesAnyOf(rowValue: $value, candidates: [$opValue]);
+			return $this->valueMatchesAnyOf(rowValue: $value, candidates: [$onValue]);
 		}
 
 		if ($op === 'ne') {
-			return ($this->valueMatchesAnyOf(rowValue: $value, candidates: [$opValue]) === false);
+			return ($this->valueMatchesAnyOf(rowValue: $value, candidates: [$onValue]) === false);
 		}
 
 		if ($op === 'in') {
-			return (is_array($opValue) === true
-				&& $this->valueMatchesAnyOf(rowValue: $value, candidates: $opValue) === true);
+			return (is_array($onValue) === true
+				&& $this->valueMatchesAnyOf(rowValue: $value, candidates: $onValue) === true);
 		}
 
 		if ($op === 'notIn') {
-			return (is_array($opValue) === false
-				|| $this->valueMatchesAnyOf(rowValue: $value, candidates: $opValue) === false);
+			return (is_array($onValue) === false
+				|| $this->valueMatchesAnyOf(rowValue: $value, candidates: $onValue) === false);
 		}
 
 		$cmp = $this->normaliseForCompare(v: $value);
-		$rhs = $this->normaliseForCompare(v: $opValue);
+		$rhs = $this->normaliseForCompare(v: $onValue);
 		return match ($op) {
 			'gt' => $cmp !== null && $rhs !== null && $cmp > $rhs,
 			'gte' => $cmp !== null && $rhs !== null && $cmp >= $rhs,
@@ -1822,11 +1822,11 @@ class AggregationRunner {
 				continue;
 			}
 
-			foreach ($v as $op => $opValue) {
+			foreach ($v as $op => $onValue) {
 				if ($op === 'in') {
 					$list = [];
-					if (is_array($opValue) === true) {
-						$list = $opValue;
+					if (is_array($onValue) === true) {
+						$list = $onValue;
 					}
 
 					if (count($list) === 0) {
@@ -1847,8 +1847,8 @@ class AggregationRunner {
 
 				if ($op === 'notIn') {
 					$list = [];
-					if (is_array($opValue) === true) {
-						$list = $opValue;
+					if (is_array($onValue) === true) {
+						$list = $onValue;
 					}
 
 					if (count($list) === 0) {
@@ -1868,7 +1868,7 @@ class AggregationRunner {
 					continue;
 				}//end if
 
-				$sqlOp = match ((string)$op) {
+				$sqlOn = match ((string)$op) {
 					'gt' => '>',
 					'gte' => '>=',
 					'lt' => '<',
@@ -1877,12 +1877,12 @@ class AggregationRunner {
 					default => null,
 				};
 
-				if ($sqlOp === null) {
+				if ($sqlOn === null) {
 					continue;
 				}
 
-				$whereParts[] = $quote . $col . $quote . ' ' . $sqlOp . ' ?';
-				$bindings[] = $this->bindValue(value: $opValue);
+				$whereParts[] = $quote . $col . $quote . ' ' . $sqlOn . ' ?';
+				$bindings[] = $this->bindValue(value: $onValue);
 			}//end foreach
 		}//end foreach
 

--- a/lib/Service/Archival/ArchiefactiedatumCalculator.php
+++ b/lib/Service/Archival/ArchiefactiedatumCalculator.php
@@ -86,9 +86,9 @@ class ArchiefactiedatumCalculator {
 	 */
 	public function calculate(array $archiveConfig, array $objectData, ?DateTime $closureDate = null): ?DateTime {
 		$afleidingswijze = $archiveConfig['afleidingswijze'] ?? null;
-		$bewaartermijn = $archiveConfig['bewaartermijn'] ?? null;
+		$retentionPeriod = $archiveConfig['bewaartermijn'] ?? null;
 
-		if ($afleidingswijze === null || $bewaartermijn === null) {
+		if ($afleidingswijze === null || $retentionPeriod === null) {
 			$this->logger->debug(
 				message: '[ArchiefactiedatumCalculator] Missing afleidingswijze or bewaartermijn in archive config',
 				context: [
@@ -101,10 +101,10 @@ class ArchiefactiedatumCalculator {
 		}
 
 		try {
-			$duration = new DateInterval($bewaartermijn);
+			$duration = new DateInterval($retentionPeriod);
 		} catch (\Exception $e) {
 			$this->logger->error(
-				message: '[ArchiefactiedatumCalculator] Invalid bewaartermijn format: ' . $bewaartermijn,
+				message: '[ArchiefactiedatumCalculator] Invalid bewaartermijn format: ' . $retentionPeriod,
 				context: [
 					'file' => __FILE__,
 					'line' => __LINE__,
@@ -133,8 +133,8 @@ class ArchiefactiedatumCalculator {
 			return null;
 		}
 
-		$archiefactiedatum = clone $brondatum;
-		$archiefactiedatum->add($duration);
+		$archiveActionDate = clone $brondatum;
+		$archiveActionDate->add($duration);
 
 		$this->logger->info(
 			message: '[ArchiefactiedatumCalculator] Calculated archiefactiedatum',
@@ -143,12 +143,12 @@ class ArchiefactiedatumCalculator {
 				'line' => __LINE__,
 				'afleidingswijze' => $afleidingswijze,
 				'brondatum' => $brondatum->format('Y-m-d'),
-				'bewaartermijn' => $bewaartermijn,
-				'archiefactiedatum' => $archiefactiedatum->format('Y-m-d'),
+				'bewaartermijn' => $retentionPeriod,
+				'archiefactiedatum' => $archiveActionDate->format('Y-m-d'),
 			]
 		);
 
-		return $archiefactiedatum;
+		return $archiveActionDate;
 	}//end calculate()
 
 	/**

--- a/lib/Service/Archival/ArchiveActionDateCalculator.php
+++ b/lib/Service/Archival/ArchiveActionDateCalculator.php
@@ -43,14 +43,14 @@ use Psr\Log\LoggerInterface;
  *
  * @psalm-suppress UnusedClass
  */
-class ArchiefactiedatumCalculator {
+class ArchiveActionDateCalculator {
 
 	/**
 	 * Supported derivation methods.
 	 */
-	private const AFLEIDINGSWIJZE_AFGEHANDELD = 'afgehandeld';
-	private const AFLEIDINGSWIJZE_EIGENSCHAP = 'eigenschap';
-	private const AFLEIDINGSWIJZE_TERMIJN = 'termijn';
+	private const DERIVATION_METHOD_COMPLETED = 'afgehandeld';
+	private const DERIVATION_METHOD_ATTRIBUTE = 'eigenschap';
+	private const DERIVATION_METHOD_TERM = 'termijn';
 
 	/**
 	 * Logger instance.
@@ -90,7 +90,7 @@ class ArchiefactiedatumCalculator {
 
 		if ($afleidingswijze === null || $retentionPeriod === null) {
 			$this->logger->debug(
-				message: '[ArchiefactiedatumCalculator] Missing afleidingswijze or bewaartermijn in archive config',
+				message: '[ArchiveActionDateCalculator] Missing afleidingswijze or bewaartermijn in archive config',
 				context: [
 					'file' => __FILE__,
 					'line' => __LINE__,
@@ -104,7 +104,7 @@ class ArchiefactiedatumCalculator {
 			$duration = new DateInterval($retentionPeriod);
 		} catch (\Exception $e) {
 			$this->logger->error(
-				message: '[ArchiefactiedatumCalculator] Invalid bewaartermijn format: ' . $retentionPeriod,
+				message: '[ArchiveActionDateCalculator] Invalid bewaartermijn format: ' . $retentionPeriod,
 				context: [
 					'file' => __FILE__,
 					'line' => __LINE__,
@@ -123,7 +123,7 @@ class ArchiefactiedatumCalculator {
 
 		if ($brondatum === null) {
 			$this->logger->debug(
-				message: '[ArchiefactiedatumCalculator] Could not determine brondatum',
+				message: '[ArchiveActionDateCalculator] Could not determine brondatum',
 				context: [
 					'file' => __FILE__,
 					'line' => __LINE__,
@@ -137,7 +137,7 @@ class ArchiefactiedatumCalculator {
 		$archiveActionDate->add($duration);
 
 		$this->logger->info(
-			message: '[ArchiefactiedatumCalculator] Calculated archiefactiedatum',
+			message: '[ArchiveActionDateCalculator] Calculated archiefactiedatum',
 			context: [
 				'file' => __FILE__,
 				'line' => __LINE__,
@@ -170,15 +170,15 @@ class ArchiefactiedatumCalculator {
 		?DateTime $closureDate,
 	): ?DateTime {
 		switch ($afleidingswijze) {
-			case self::AFLEIDINGSWIJZE_AFGEHANDELD:
+			case self::DERIVATION_METHOD_COMPLETED:
 				return $this->brondatumFromClosure(closureDate: $closureDate);
-			case self::AFLEIDINGSWIJZE_EIGENSCHAP:
+			case self::DERIVATION_METHOD_ATTRIBUTE:
 				return $this->brondatumFromProperty(archiveConfig: $archiveConfig, objectData: $objectData);
-			case self::AFLEIDINGSWIJZE_TERMIJN:
-				return $this->brondatumFromTermijn(archiveConfig: $archiveConfig, closureDate: $closureDate);
+			case self::DERIVATION_METHOD_TERM:
+				return $this->sourceDateFromTerm(archiveConfig: $archiveConfig, closureDate: $closureDate);
 			default:
 				$this->logger->warning(
-					message: '[ArchiefactiedatumCalculator] Unknown afleidingswijze: ' . $afleidingswijze,
+					message: '[ArchiveActionDateCalculator] Unknown afleidingswijze: ' . $afleidingswijze,
 					context: [
 						'file' => __FILE__,
 						'line' => __LINE__,
@@ -201,7 +201,7 @@ class ArchiefactiedatumCalculator {
 	private function brondatumFromClosure(?DateTime $closureDate): ?DateTime {
 		if ($closureDate === null) {
 			$this->logger->debug(
-				message: '[ArchiefactiedatumCalculator] No closure date provided for afgehandeld method',
+				message: '[ArchiveActionDateCalculator] No closure date provided for afgehandeld method',
 				context: ['file' => __FILE__, 'line' => __LINE__]
 			);
 			return null;
@@ -224,7 +224,7 @@ class ArchiefactiedatumCalculator {
 		$propertyName = $archiveConfig['eigenschap'] ?? null;
 		if ($propertyName === null) {
 			$this->logger->warning(
-				message: '[ArchiefactiedatumCalculator] No eigenschap configured for eigenschap method',
+				message: '[ArchiveActionDateCalculator] No eigenschap configured for eigenschap method',
 				context: ['file' => __FILE__, 'line' => __LINE__]
 			);
 			return null;
@@ -233,7 +233,7 @@ class ArchiefactiedatumCalculator {
 		$propertyValue = $objectData[$propertyName] ?? null;
 		if ($propertyValue === null) {
 			$this->logger->debug(
-				message: '[ArchiefactiedatumCalculator] Property value not found on object',
+				message: '[ArchiveActionDateCalculator] Property value not found on object',
 				context: [
 					'file' => __FILE__,
 					'line' => __LINE__,
@@ -247,7 +247,7 @@ class ArchiefactiedatumCalculator {
 			return new DateTime($propertyValue);
 		} catch (\Exception $e) {
 			$this->logger->error(
-				message: '[ArchiefactiedatumCalculator] Invalid date in property: ' . $propertyName,
+				message: '[ArchiveActionDateCalculator] Invalid date in property: ' . $propertyName,
 				context: [
 					'file' => __FILE__,
 					'line' => __LINE__,
@@ -269,10 +269,10 @@ class ArchiefactiedatumCalculator {
 	 *
 	 * @spec openspec/specs/archival-destruction-workflow/spec.md
 	 */
-	private function brondatumFromTermijn(array $archiveConfig, ?DateTime $closureDate): ?DateTime {
+	private function sourceDateFromTerm(array $archiveConfig, ?DateTime $closureDate): ?DateTime {
 		if ($closureDate === null) {
 			$this->logger->debug(
-				message: '[ArchiefactiedatumCalculator] No closure date provided for termijn method',
+				message: '[ArchiveActionDateCalculator] No closure date provided for termijn method',
 				context: ['file' => __FILE__, 'line' => __LINE__]
 			);
 			return null;
@@ -281,7 +281,7 @@ class ArchiefactiedatumCalculator {
 		$procestermijn = $archiveConfig['procestermijn'] ?? null;
 		if ($procestermijn === null) {
 			$this->logger->warning(
-				message: '[ArchiefactiedatumCalculator] No procestermijn configured for termijn method',
+				message: '[ArchiveActionDateCalculator] No procestermijn configured for termijn method',
 				context: ['file' => __FILE__, 'line' => __LINE__]
 			);
 			return null;
@@ -294,7 +294,7 @@ class ArchiefactiedatumCalculator {
 			return $brondatum;
 		} catch (\Exception $e) {
 			$this->logger->error(
-				message: '[ArchiefactiedatumCalculator] Invalid procestermijn format: ' . $procestermijn,
+				message: '[ArchiveActionDateCalculator] Invalid procestermijn format: ' . $procestermijn,
 				context: [
 					'file' => __FILE__,
 					'line' => __LINE__,
@@ -303,5 +303,5 @@ class ArchiefactiedatumCalculator {
 			);
 			return null;
 		}
-	}//end brondatumFromTermijn()
+	}//end sourceDateFromTerm()
 }//end class

--- a/lib/Service/Archival/DestructionService.php
+++ b/lib/Service/Archival/DestructionService.php
@@ -211,7 +211,7 @@ class DestructionService {
 				'schema' => $object->getSchema(),
 				'register' => $object->getRegister(),
 				'archiefactiedatum' => $actiedatum,
-				'classificatie' => $retention['classificatie'] ?? null,
+				'classification' => $retention['classification'] ?? null,
 				'alreadySoftDeleted' => ($object->getDeleted() !== null),
 			];
 		}//end foreach

--- a/lib/Service/Archival/DestructionService.php
+++ b/lib/Service/Archival/DestructionService.php
@@ -423,7 +423,7 @@ class DestructionService {
 				$excluded[] = $objectEntry;
 
 				// Extend the object's archiefactiedatum.
-				$this->extendArchiefactiedatum(
+				$this->extendArchiveActionDate(
 					uuid: $uuid,
 					extensionPeriod: $extensionPeriod,
 					reason: $objectEntry['exclusionReason']
@@ -472,10 +472,10 @@ class DestructionService {
 
 		// Extend archiefactiedatum for all objects on the list.
 		foreach ($destructionList['objects'] as $objectEntry) {
-			$this->extendArchiefactiedatum(
+			$this->extendArchiveActionDate(
 				uuid: $objectEntry['uuid'],
 				extensionPeriod: $extensionPeriod,
-				reason: 'Vernietigingslijst afgewezen: ' . $reason
+				reason: 'Destruction list rejected: ' . $reason
 			);
 		}
 
@@ -503,7 +503,7 @@ class DestructionService {
 	 *
 	 * @spec openspec/specs/archival-destruction-workflow/spec.md
 	 */
-	private function extendArchiefactiedatum(string $uuid, string $extensionPeriod, string $reason): void {
+	private function extendArchiveActionDate(string $uuid, string $extensionPeriod, string $reason): void {
 		try {
 			$object = $this->objectMapper->findByUuid($uuid);
 			$retention = $object->getRetention() ?? [];
@@ -537,7 +537,7 @@ class DestructionService {
 				]
 			);
 		}//end try
-	}//end extendArchiefactiedatum()
+	}//end extendArchiveActionDate()
 
 	/**
 	 * Get the current authenticated user ID.

--- a/lib/Service/AvgRetentionService.php
+++ b/lib/Service/AvgRetentionService.php
@@ -146,18 +146,18 @@ class AvgRetentionService {
 	 * @spec openspec/specs/retention-management/spec.md
 	 */
 	private function processActivity(Verwerkingsactiviteit $activity, DateTime $now, bool $dryRun): ?array {
-		$bewaartermijn = (string)($activity->getBewaartermijn() ?? '');
-		if ($bewaartermijn === '') {
+		$retentionPeriod = (string)($activity->getBewaartermijn() ?? '');
+		if ($retentionPeriod === '') {
 			return null;
 		}
 
-		$cutoff = $this->computeCutoff(now: $now, duration: $bewaartermijn);
+		$cutoff = $this->computeCutoff(now: $now, duration: $retentionPeriod);
 		if ($cutoff === null) {
 			$this->logger->warning(
 				message: '[AVG retention] Unparseable bewaartermijn — skipping activity',
 				context: [
 					'activity' => $activity->getUuid(),
-					'bewaartermijn' => $bewaartermijn,
+					'bewaartermijn' => $retentionPeriod,
 				]
 			);
 			return null;
@@ -179,7 +179,7 @@ class AvgRetentionService {
 		return [
 			'uuid' => $activity->getUuid(),
 			'naam' => $activity->getNaam(),
-			'bewaartermijn' => $bewaartermijn,
+			'bewaartermijn' => $retentionPeriod,
 			'cutoff' => $cutoff->format('c'),
 			'matchedObjects' => count($candidates),
 			'erased' => $erased,

--- a/lib/Service/BulkTranslationService.php
+++ b/lib/Service/BulkTranslationService.php
@@ -69,7 +69,7 @@ class BulkTranslationService {
 	 * Returns a per-property patch:
 	 *   `[propertyName => translatedValue]`
 	 * The caller merges this into the object's `{lang: value}` JSONB
-	 * map for `$toLang` and persists via the standard save path —
+	 * map for `$toLong` and persists via the standard save path —
 	 * which triggers the projection listener to populate the sidecar.
 	 *
 	 * Note: this method also writes directly to the sidecar so the
@@ -78,8 +78,8 @@ class BulkTranslationService {
 	 * write should invoke the provider directly.
 	 *
 	 * @param ObjectEntity $object The object to translate.
-	 * @param string $fromLang Source language code.
-	 * @param string $toLang Target language code.
+	 * @param string $fromLong Source language code.
+	 * @param string $toLong Target language code.
 	 * @param string[]|null $properties Optional whitelist of property
 	 *                                  names to translate; null = all.
 	 *
@@ -93,14 +93,14 @@ class BulkTranslationService {
 	 */
 	public function translateObject(
 		ObjectEntity $object,
-		string $fromLang,
-		string $toLang,
+		string $fromLong,
+		string $toLong,
 		?array $properties = null,
 	): array {
 		$translated = [];
 		$skipped = [];
 
-		if ($fromLang === $toLang) {
+		if ($fromLong === $toLong) {
 			return ['translated' => [], 'skipped' => ['_global' => 'fromLang === toLang']];
 		}
 
@@ -126,9 +126,9 @@ class BulkTranslationService {
 
 			// Source value lookup.
 			$sourceValue = null;
-			if (is_array($existing) === true && isset($existing[$fromLang]) === true) {
-				$sourceValue = $existing[$fromLang];
-			} elseif (is_string($existing) === true && $fromLang === 'nl') {
+			if (is_array($existing) === true && isset($existing[$fromLong]) === true) {
+				$sourceValue = $existing[$fromLong];
+			} elseif (is_string($existing) === true && $fromLong === 'nl') {
 				// Legacy single-language fallback — treat plain string as NL.
 				$sourceValue = $existing;
 			}
@@ -142,16 +142,16 @@ class BulkTranslationService {
 			// the slot is already filled (any non-empty value, regardless
 			// of status — promotion is the operator's job).
 			if (is_array($existing) === true
-				&& isset($existing[$toLang]) === true
-				&& is_string($existing[$toLang]) === true
-				&& $existing[$toLang] !== ''
+				&& isset($existing[$toLong]) === true
+				&& is_string($existing[$toLong]) === true
+				&& $existing[$toLong] !== ''
 			) {
 				$skipped[$property] = 'target-slot-already-filled';
 				continue;
 			}
 
 			try {
-				$translatedValue = $this->provider->translate($sourceValue, $fromLang, $toLang);
+				$translatedValue = $this->provider->translate($sourceValue, $fromLong, $toLong);
 			} catch (\Throwable $e) {
 				$this->logger->warning(
 					sprintf(
@@ -159,7 +159,7 @@ class BulkTranslationService {
 						$this->provider->getIdentifier(),
 						$object->getUuid(),
 						$property,
-						$toLang,
+						$toLong,
 						$e->getMessage()
 					)
 				);
@@ -181,7 +181,7 @@ class BulkTranslationService {
 				$this->translationMapper->upsert(
 					objectUuid: (string)$object->getUuid(),
 					property: $property,
-					language: $toLang,
+					language: $toLong,
 					value: $translatedValue,
 					status: Translation::STATUS_MACHINE_TRANSLATED,
 					translator: $translator
@@ -192,7 +192,7 @@ class BulkTranslationService {
 						'[BulkTranslationService] sidecar upsert failed for %s/%s/%s: %s',
 						$object->getUuid(),
 						$property,
-						$toLang,
+						$toLong,
 						$e->getMessage()
 					)
 				);

--- a/lib/Service/CaseTypeAuthorizationService.php
+++ b/lib/Service/CaseTypeAuthorizationService.php
@@ -44,7 +44,7 @@ namespace OCA\OpenRegister\Service;
  *
  * @SuppressWarnings(PHPMD.CyclomaticComplexity) ZGW scope and matrix mapping branch per scope verb and per principal kind.
  */
-class ZaaktypeAuthorizationService {
+class CaseTypeAuthorizationService {
 
 	/**
 	 * Canonical ZGW vertrouwelijkheidaanduiding (confidentiality) levels, ordered

--- a/lib/Service/ContactMatchingService.php
+++ b/lib/Service/ContactMatchingService.php
@@ -88,7 +88,7 @@ class ContactMatchingService {
 	 * @var array<string>
 	 */
 	private const ORG_PROPERTY_PATTERNS = [
-		'organisatie',
+		'organisation',
 		'organization',
 		'organisation',
 		'bedrijf',

--- a/lib/Service/Edepot/MdtoXmlGenerator.php
+++ b/lib/Service/Edepot/MdtoXmlGenerator.php
@@ -311,11 +311,11 @@ class MdtoXmlGenerator {
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-generate-mdto-compliant-xml-metadata-per-object
 	 */
 	private function addFile(DOMDocument $dom, DOMElement $parent, array $file): void {
-		$bestand = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':bestand');
+		$fileElement = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':bestand');
 
-		$this->addTextElement(dom: $dom, parent: $bestand, name: 'naam', content: $file['name']);
-		$this->addTextElement(dom: $dom, parent: $bestand, name: 'omvang', content: (string)$file['size']);
-		$this->addTextElement(dom: $dom, parent: $bestand, name: 'bestandsformaat', content: $file['format']);
+		$this->addTextElement(dom: $dom, parent: $fileElement, name: 'naam', content: $file['name']);
+		$this->addTextElement(dom: $dom, parent: $fileElement, name: 'omvang', content: (string)$file['size']);
+		$this->addTextElement(dom: $dom, parent: $fileElement, name: 'bestandsformaat', content: $file['format']);
 
 		$checksumElement = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':checksum');
 
@@ -327,8 +327,8 @@ class MdtoXmlGenerator {
 		$value->textContent = $file['checksum'];
 		$checksumElement->appendChild($value);
 
-		$bestand->appendChild($checksumElement);
-		$parent->appendChild($bestand);
+		$fileElement->appendChild($checksumElement);
+		$parent->appendChild($fileElement);
 	}//end addBestand()
 
 	/**

--- a/lib/Service/Edepot/MdtoXmlGenerator.php
+++ b/lib/Service/Edepot/MdtoXmlGenerator.php
@@ -106,10 +106,10 @@ class MdtoXmlGenerator {
 		$root = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':informatieobject');
 		$dom->appendChild($root);
 
-		$this->addIdentificatie(dom: $dom, parent: $root, object: $object);
-		$this->addNaam(dom: $dom, parent: $root, object: $object);
-		$this->addWaardering(dom: $dom, parent: $root, retention: $retention);
-		$this->addBewaartermijn(dom: $dom, parent: $root, retention: $retention);
+		$this->addIdentification(dom: $dom, parent: $root, object: $object);
+		$this->addName(dom: $dom, parent: $root, object: $object);
+		$this->addRating(dom: $dom, parent: $root, retention: $retention);
+		$this->addRetentionPeriod(dom: $dom, parent: $root, retention: $retention);
 		$this->addInformatiecategorie(dom: $dom, parent: $root, retention: $retention);
 		$this->addArchiefvormer(dom: $dom, parent: $root);
 
@@ -118,7 +118,7 @@ class MdtoXmlGenerator {
 		}
 
 		foreach ($files as $file) {
-			$this->addBestand(dom: $dom, parent: $root, file: $file);
+			$this->addFile(dom: $dom, parent: $root, file: $file);
 		}
 
 		$xml = $dom->saveXML();
@@ -184,19 +184,19 @@ class MdtoXmlGenerator {
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-generate-mdto-compliant-xml-metadata-per-object
 	 */
-	private function addIdentificatie(DOMDocument $dom, DOMElement $parent, ObjectEntity $object): void {
-		$identificatie = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':identificatie');
+	private function addIdentification(DOMDocument $dom, DOMElement $parent, ObjectEntity $object): void {
+		$identification = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':identificatie');
 
-		$kenmerk = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':identificatieKenmerk');
-		$kenmerk->textContent = $object->getUuid();
-		$identificatie->appendChild($kenmerk);
+		$reference = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':identificatieKenmerk');
+		$reference->textContent = $object->getUuid();
+		$identification->appendChild($reference);
 
-		$bron = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':identificatieBron');
+		$source = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':identificatieBron');
 		$organisationId = $this->appConfig->getValueString('openregister', 'organisation_identifier', 'OpenRegister');
-		$bron->textContent = $organisationId;
-		$identificatie->appendChild($bron);
+		$source->textContent = $organisationId;
+		$identification->appendChild($source);
 
-		$parent->appendChild($identificatie);
+		$parent->appendChild($identification);
 	}//end addIdentificatie()
 
 	/**
@@ -210,7 +210,7 @@ class MdtoXmlGenerator {
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-generate-mdto-compliant-xml-metadata-per-object
 	 */
-	private function addNaam(DOMDocument $dom, DOMElement $parent, ObjectEntity $object): void {
+	private function addName(DOMDocument $dom, DOMElement $parent, ObjectEntity $object): void {
 		$data = ($object->getObject() ?? []);
 		$title = ($data['title'] ?? $data['naam'] ?? $data['name'] ?? $object->getUuid());
 		$this->addTextElement(dom: $dom, parent: $parent, name: 'naam', content: (string)$title);
@@ -227,10 +227,10 @@ class MdtoXmlGenerator {
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-generate-mdto-compliant-xml-metadata-per-object
 	 */
-	private function addWaardering(DOMDocument $dom, DOMElement $parent, array $retention): void {
+	private function addRating(DOMDocument $dom, DOMElement $parent, array $retention): void {
 		$nominatie = ($retention['archiefnominatie'] ?? '');
-		$waardering = (self::WAARDERING_MAP[$nominatie] ?? $nominatie);
-		$this->addTextElement(dom: $dom, parent: $parent, name: 'waardering', content: $waardering);
+		$rating = (self::WAARDERING_MAP[$nominatie] ?? $nominatie);
+		$this->addTextElement(dom: $dom, parent: $parent, name: 'waardering', content: $rating);
 	}//end addWaardering()
 
 	/**
@@ -244,9 +244,9 @@ class MdtoXmlGenerator {
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-generate-mdto-compliant-xml-metadata-per-object
 	 */
-	private function addBewaartermijn(DOMDocument $dom, DOMElement $parent, array $retention): void {
-		$bewaartermijn = ($retention['bewaartermijn'] ?? '');
-		$this->addTextElement(dom: $dom, parent: $parent, name: 'bewaartermijn', content: (string)$bewaartermijn);
+	private function addRetentionPeriod(DOMDocument $dom, DOMElement $parent, array $retention): void {
+		$retentionPeriod = ($retention['bewaartermijn'] ?? '');
+		$this->addTextElement(dom: $dom, parent: $parent, name: 'bewaartermijn', content: (string)$retentionPeriod);
 	}//end addBewaartermijn()
 
 	/**
@@ -261,8 +261,8 @@ class MdtoXmlGenerator {
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-generate-mdto-compliant-xml-metadata-per-object
 	 */
 	private function addInformatiecategorie(DOMDocument $dom, DOMElement $parent, array $retention): void {
-		$classificatie = ($retention['classificatie'] ?? 'onbekend');
-		$this->addTextElement(dom: $dom, parent: $parent, name: 'informatiecategorie', content: (string)$classificatie);
+		$classification = ($retention['classification'] ?? 'onbekend');
+		$this->addTextElement(dom: $dom, parent: $parent, name: 'informatiecategorie', content: (string)$classification);
 	}//end addInformatiecategorie()
 
 	/**
@@ -287,13 +287,13 @@ class MdtoXmlGenerator {
 
 		$id = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':verwijzingIdentificatie');
 
-		$kenmerk = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':identificatieKenmerk');
-		$kenmerk->textContent = $organisationId;
-		$id->appendChild($kenmerk);
+		$reference = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':identificatieKenmerk');
+		$reference->textContent = $organisationId;
+		$id->appendChild($reference);
 
-		$bron = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':identificatieBron');
-		$bron->textContent = 'OpenRegister';
-		$id->appendChild($bron);
+		$source = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':identificatieBron');
+		$source->textContent = 'OpenRegister';
+		$id->appendChild($source);
 
 		$archiefvormer->appendChild($id);
 		$parent->appendChild($archiefvormer);
@@ -310,7 +310,7 @@ class MdtoXmlGenerator {
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-generate-mdto-compliant-xml-metadata-per-object
 	 */
-	private function addBestand(DOMDocument $dom, DOMElement $parent, array $file): void {
+	private function addFile(DOMDocument $dom, DOMElement $parent, array $file): void {
 		$bestand = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':bestand');
 
 		$this->addTextElement(dom: $dom, parent: $bestand, name: 'naam', content: $file['name']);
@@ -323,9 +323,9 @@ class MdtoXmlGenerator {
 		$algoritme->textContent = 'SHA-256';
 		$checksumElement->appendChild($algoritme);
 
-		$waarde = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':checksumWaarde');
-		$waarde->textContent = $file['checksum'];
-		$checksumElement->appendChild($waarde);
+		$value = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':checksumWaarde');
+		$value->textContent = $file['checksum'];
+		$checksumElement->appendChild($value);
 
 		$bestand->appendChild($checksumElement);
 		$parent->appendChild($bestand);

--- a/lib/Service/ExportService.php
+++ b/lib/Service/ExportService.php
@@ -990,8 +990,8 @@ class ExportService {
 				// resolvable (org-wide minimum per CLAUDE.md memory).
 				if (($properties[$fieldName]['translatable'] ?? false) === true) {
 					$languages = $this->resolveExportLanguages();
-					foreach ($languages as $lang) {
-						$headers[$col] = $fieldName . '_' . $lang;
+					foreach ($languages as $long) {
+						$headers[$col] = $fieldName . '_' . $long;
 						$col++;
 					}
 
@@ -1158,9 +1158,9 @@ class ExportService {
 				// Translatable `field_lang` column — extract the
 				// language-keyed slot from the JSONB property
 				// (register-i18n Phase 3 wire-in).
-				$langValue = $this->extractLanguageSlot(objectData: $objectData, header: $header);
-				if ($langValue !== null) {
-					return $langValue;
+				$longValue = $this->extractLanguageSlot(objectData: $objectData, header: $header);
+				if ($longValue !== null) {
+					return $longValue;
 				}
 
 				$value = $objectData[$header] ?? null;
@@ -1204,19 +1204,19 @@ class ExportService {
 		}
 
 		$field = substr($header, 0, $underscore);
-		$lang = substr($header, $underscore + 1);
-		if ($field === '' || $lang === ''
-			|| preg_match('/^[a-zA-Z][a-zA-Z0-9-]{0,15}$/', $lang) !== 1
+		$long = substr($header, $underscore + 1);
+		if ($field === '' || $long === ''
+			|| preg_match('/^[a-zA-Z][a-zA-Z0-9-]{0,15}$/', $long) !== 1
 		) {
 			return null;
 		}
 
 		$value = $objectData[$field] ?? null;
-		if (is_array($value) === false || isset($value[$lang]) === false) {
+		if (is_array($value) === false || isset($value[$long]) === false) {
 			return null;
 		}
 
-		$slotValue = $value[$lang];
+		$slotValue = $value[$long];
 		if (is_scalar($slotValue) === true) {
 			return (string)$slotValue;
 		}

--- a/lib/Service/File/DocumentProcessingHandler.php
+++ b/lib/Service/File/DocumentProcessingHandler.php
@@ -337,9 +337,9 @@ class DocumentProcessingHandler {
 	 * @param string $scope Placeholder-numbering scope: 'document' (default — counter restarts
 	 *                      per run, no persistence) or 'dossier' (counter consistent across all
 	 *                      files in the dossier folder, recomputed deterministically).
-	 * @param string|null $dossierKey Stable folder id identifying the dossier when $scope='dossier'.
-	 *                                When absent (and scope='dossier') the file's parent folder is used.
-	 *                                Ignored for the per-document scope.
+	 * @param string|null $fileKey Stable folder id identifying the dossier when $scope='dossier'.
+	 *                             When absent (and scope='dossier') the file's parent folder is used.
+	 *                             Ignored for the per-document scope.
 	 * @param bool|null $preserveStructure PDF only (REQ-ORTPR-004): tri-state structure-preservation
 	 *                                     option forwarded to {@see replaceWords()} — null/absent = auto
 	 *                                     (preserve iff the input is a tagged PDF), true = attempt,
@@ -360,7 +360,7 @@ class DocumentProcessingHandler {
 		Node $node,
 		array $entities,
 		string $scope = 'document',
-		?string $dossierKey = null,
+		?string $fileKey = null,
 		?bool $preserveStructure = null,
 	): File {
 		// Reset any report/residuals/placeholder-map/structure-result from a
@@ -412,7 +412,7 @@ class DocumentProcessingHandler {
 		// folder.
 		$translator = PlaceholderIdTranslator::perDocument();
 		if ($scope === 'dossier') {
-			$translator = $this->recomputeDossierTranslator(node: $node, dossierKey: $dossierKey);
+			$translator = $this->recomputeFileTranslator(node: $node, fileKey: $fileKey);
 		}
 
 		// Build replacements array from entities.
@@ -594,7 +594,7 @@ class DocumentProcessingHandler {
 	 * recomputing the `e.id → local_number` map from the dossier's stored
 	 * entity-relation rows (Decision 3 — no table, no migration).
 	 *
-	 * Resolves the dossier folder from $dossierKey (a stable folder id) or,
+	 * Resolves the dossier folder from $fileKey (a stable folder id) or,
 	 * when absent, the file's parent folder (Decision 2 fallback). Enumerates
 	 * the folder's descendant files (recursively), loads their entity rows in
 	 * one query (`findEntityIdsByValueForFiles`), and ranks distinct
@@ -607,12 +607,12 @@ class DocumentProcessingHandler {
 	 * Per ADR-005 nothing here logs the entity value alongside its number.
 	 *
 	 * @param Node $node The file being anonymised.
-	 * @param string|null $dossierKey Stable folder id, or null to use the parent folder.
+	 * @param string|null $fileKey Stable folder id, or null to use the parent folder.
 	 *
 	 * @return PlaceholderIdTranslator Seeded with the dossier map.
 	 */
-	private function recomputeDossierTranslator(Node $node, ?string $dossierKey): PlaceholderIdTranslator {
-		$folder = $this->resolveDossierFolder(node: $node, dossierKey: $dossierKey);
+	private function recomputeFileTranslator(Node $node, ?string $fileKey): PlaceholderIdTranslator {
+		$folder = $this->resolveFileFolder(node: $node, fileKey: $fileKey);
 		if ($folder === null) {
 			return PlaceholderIdTranslator::perDocument();
 		}
@@ -630,7 +630,7 @@ class DocumentProcessingHandler {
 			context: [
 				'file' => __FILE__,
 				'line' => __LINE__,
-				'dossier_key' => $dossierKey,
+				'dossier_key' => $fileKey,
 				'folder_id' => $folder->getId(),
 				'file_count' => count($fileIds),
 				'row_count' => count($rows),
@@ -642,20 +642,20 @@ class DocumentProcessingHandler {
 
 	/**
 	 * Resolve the dossier folder for per-dossier numbering: prefer the
-	 * explicit $dossierKey (a stable folder id), else fall back to the file's
+	 * explicit $fileKey (a stable folder id), else fall back to the file's
 	 * parent folder (Decision 2). Returns null when neither resolves to a
 	 * usable folder (caller then degrades to per-document).
 	 *
 	 * @param Node $node The file being anonymised.
-	 * @param string|null $dossierKey Stable folder id, or null for the parent-folder fallback.
+	 * @param string|null $fileKey Stable folder id, or null for the parent-folder fallback.
 	 *
 	 * @return Folder|null The dossier folder, or null when unresolved.
 	 */
-	private function resolveDossierFolder(Node $node, ?string $dossierKey): ?Folder {
+	private function resolveFileFolder(Node $node, ?string $fileKey): ?Folder {
 		// Explicit, authoritative signal: the folder id.
-		if ($dossierKey !== null && trim($dossierKey) !== '' && ctype_digit(trim($dossierKey)) === true) {
+		if ($fileKey !== null && trim($fileKey) !== '' && ctype_digit(trim($fileKey)) === true) {
 			try {
-				$matches = $this->rootFolder->getById((int)trim($dossierKey));
+				$matches = $this->rootFolder->getById((int)trim($fileKey));
 				foreach ($matches as $candidate) {
 					if ($candidate instanceof Folder) {
 						return $candidate;

--- a/lib/Service/File/Pdf/Fallback/PdfOdtFallbackOrchestrator.php
+++ b/lib/Service/File/Pdf/Fallback/PdfOdtFallbackOrchestrator.php
@@ -189,7 +189,7 @@ class PdfOdtFallbackOrchestrator {
 		try {
 			$odt = $this->converter->pdfToOdt(pdfBytes: $pdfBytes);
 		} catch (Throwable $e) {
-			throw $this->wrapAfterFallback(cause: $cause, stage: 'pdf_to_odt', previous: $e);
+			throw $this->wrapAfterFallback(cause: $cause, internship: 'pdf_to_odt', previous: $e);
 		}
 
 		// Re-run the SAPP-side replacer against the round-tripped PDF. The
@@ -201,7 +201,7 @@ class PdfOdtFallbackOrchestrator {
 		try {
 			$pdf = $this->converter->odtToPdf(odtBytes: $odt);
 		} catch (Throwable $e) {
-			throw $this->wrapAfterFallback(cause: $cause, stage: 'odt_to_pdf', previous: $e);
+			throw $this->wrapAfterFallback(cause: $cause, internship: 'odt_to_pdf', previous: $e);
 		}
 
 		try {
@@ -211,7 +211,7 @@ class PdfOdtFallbackOrchestrator {
 				strict: true
 			);
 		} catch (PdfAnonymisationException $e) {
-			throw $this->wrapAfterFallback(cause: $cause, stage: 'rerun_replace', previous: $e);
+			throw $this->wrapAfterFallback(cause: $cause, internship: 'rerun_replace', previous: $e);
 		}
 
 		$this->logger->info(
@@ -226,7 +226,7 @@ class PdfOdtFallbackOrchestrator {
 	 * Wrap a Path-B-side failure with the after-fallback reason code.
 	 *
 	 * @param PdfAnonymisationException $cause The original Path A exception (preserved as previous).
-	 * @param string $stage Which Path B step failed (`pdf_to_odt`, `odt_to_pdf`, `rerun_replace`).
+	 * @param string $internship Which Path B step failed (`pdf_to_odt`, `odt_to_pdf`, `rerun_replace`).
 	 * @param Throwable $previous The Path-B-side exception.
 	 *
 	 * @return PdfAnonymisationException A new exception carrying
@@ -234,18 +234,18 @@ class PdfOdtFallbackOrchestrator {
 	 */
 	private function wrapAfterFallback(
 		PdfAnonymisationException $cause,
-		string $stage,
+		string $internship,
 		Throwable $previous,
 	): PdfAnonymisationException {
 		$diagnostic = [
-			'pathB_stage' => $stage,
+			'pathB_stage' => $internship,
 			'pathA_reason' => $cause->getReason(),
 			'pathB_previous' => $previous::class,
 		];
 
 		return new PdfAnonymisationException(
 			reason: PdfAnonymisationException::REASON_VALIDATION_FAILED_AFTER_FALLBACK,
-			message: sprintf('Path B fallback failed at stage %s', $stage),
+			message: sprintf('Path B fallback failed at stage %s', $internship),
 			diagnostic: $diagnostic,
 			previous: $previous
 		);

--- a/lib/Service/File/Pdf/Fallback/PdfOdtFallbackOrchestrator.php
+++ b/lib/Service/File/Pdf/Fallback/PdfOdtFallbackOrchestrator.php
@@ -189,7 +189,7 @@ class PdfOdtFallbackOrchestrator {
 		try {
 			$odt = $this->converter->pdfToOdt(pdfBytes: $pdfBytes);
 		} catch (Throwable $e) {
-			throw $this->wrapAfterFallback(cause: $cause, internship: 'pdf_to_odt', previous: $e);
+			throw $this->wrapAfterFallback(cause: $cause, stage: 'pdf_to_odt', previous: $e);
 		}
 
 		// Re-run the SAPP-side replacer against the round-tripped PDF. The
@@ -201,7 +201,7 @@ class PdfOdtFallbackOrchestrator {
 		try {
 			$pdf = $this->converter->odtToPdf(odtBytes: $odt);
 		} catch (Throwable $e) {
-			throw $this->wrapAfterFallback(cause: $cause, internship: 'odt_to_pdf', previous: $e);
+			throw $this->wrapAfterFallback(cause: $cause, stage: 'odt_to_pdf', previous: $e);
 		}
 
 		try {
@@ -211,7 +211,7 @@ class PdfOdtFallbackOrchestrator {
 				strict: true
 			);
 		} catch (PdfAnonymisationException $e) {
-			throw $this->wrapAfterFallback(cause: $cause, internship: 'rerun_replace', previous: $e);
+			throw $this->wrapAfterFallback(cause: $cause, stage: 'rerun_replace', previous: $e);
 		}
 
 		$this->logger->info(
@@ -226,7 +226,7 @@ class PdfOdtFallbackOrchestrator {
 	 * Wrap a Path-B-side failure with the after-fallback reason code.
 	 *
 	 * @param PdfAnonymisationException $cause The original Path A exception (preserved as previous).
-	 * @param string $internship Which Path B step failed (`pdf_to_odt`, `odt_to_pdf`, `rerun_replace`).
+	 * @param string $stage Which Path B step failed (`pdf_to_odt`, `odt_to_pdf`, `rerun_replace`).
 	 * @param Throwable $previous The Path-B-side exception.
 	 *
 	 * @return PdfAnonymisationException A new exception carrying
@@ -234,18 +234,18 @@ class PdfOdtFallbackOrchestrator {
 	 */
 	private function wrapAfterFallback(
 		PdfAnonymisationException $cause,
-		string $internship,
+		string $stage,
 		Throwable $previous,
 	): PdfAnonymisationException {
 		$diagnostic = [
-			'pathB_stage' => $internship,
+			'pathB_stage' => $stage,
 			'pathA_reason' => $cause->getReason(),
 			'pathB_previous' => $previous::class,
 		];
 
 		return new PdfAnonymisationException(
 			reason: PdfAnonymisationException::REASON_VALIDATION_FAILED_AFTER_FALLBACK,
-			message: sprintf('Path B fallback failed at stage %s', $internship),
+			message: sprintf('Path B fallback failed at stage %s', $stage),
 			diagnostic: $diagnostic,
 			previous: $previous
 		);

--- a/lib/Service/File/Pdf/PdfTextReplacer.php
+++ b/lib/Service/File/Pdf/PdfTextReplacer.php
@@ -157,7 +157,7 @@ class PdfTextReplacer {
 			// the input (REQ-ORTPR-005), so tagCountAfter trivially equals
 			// tagCountBefore — still measured for a truthful report even on
 			// this fast path.
-			$structureResult = $this->measureNoOpStructurePreservation(pdfBytes: $pdfBytes, preserveStructure: $preserveStructure);
+			$structureResult = $this->measureNoOnStructurePreservation(pdfBytes: $pdfBytes, preserveStructure: $preserveStructure);
 			return $pdfBytes;
 		}
 
@@ -600,7 +600,7 @@ class PdfTextReplacer {
 	 *
 	 * @return StructurePreservation The result block for this no-op run.
 	 */
-	private function measureNoOpStructurePreservation(string $pdfBytes, ?bool $preserveStructure): StructurePreservation {
+	private function measureNoOnStructurePreservation(string $pdfBytes, ?bool $preserveStructure): StructurePreservation {
 		$tagCountBefore = 0;
 
 		try {

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -1933,8 +1933,8 @@ class FileService {
 	 * @param Node $node The file node to anonymize.
 	 * @param array $entities Array of detected entities with 'text' and 'key' fields.
 	 * @param string $scope Placeholder-numbering scope: 'document' (default) or 'dossier'.
-	 * @param string|null $dossierKey Stable folder id of the dossier (per-dossier scope); null falls
-	 *                                back to the file's parent folder.
+	 * @param string|null $fileKey Stable folder id of the dossier (per-dossier scope); null falls
+	 *                             back to the file's parent folder.
 	 * @param bool|null $preserveStructure PDF only (REQ-ORTPR-004): tri-state structure-preservation
 	 *                                     option — null/absent = auto (preserve iff the input is a
 	 *                                     tagged PDF), true = attempt, false = skip but still measure.
@@ -1949,14 +1949,14 @@ class FileService {
 		Node $node,
 		array $entities,
 		string $scope = 'document',
-		?string $dossierKey = null,
+		?string $fileKey = null,
 		?bool $preserveStructure = null,
 	): Node {
 		return $this->documentProcessingHandler->anonymizeDocument(
 			node: $node,
 			entities: $entities,
 			scope: $scope,
-			dossierKey: $dossierKey,
+			fileKey: $fileKey,
 			preserveStructure: $preserveStructure
 		);
 	}//end anonymizeDocument()
@@ -2194,15 +2194,15 @@ class FileService {
 
 		$dotPos = strrpos($desiredName, '.');
 		// No extension or hidden file (".env"); append suffix to whole name.
-		$stem = $desiredName;
+		$vote = $desiredName;
 		$ext = '';
 		if ($dotPos !== false && $dotPos !== 0) {
-			$stem = substr($desiredName, 0, $dotPos);
+			$vote = substr($desiredName, 0, $dotPos);
 			$ext = substr($desiredName, $dotPos);
 		}
 
 		for ($i = 1; $i <= 999; $i++) {
-			$candidate = $stem . ' (' . $i . ')' . $ext;
+			$candidate = $vote . ' (' . $i . ')' . $ext;
 			if ($folder->nodeExists($candidate) === false) {
 				return $candidate;
 			}

--- a/lib/Service/FlowLinkService.php
+++ b/lib/Service/FlowLinkService.php
@@ -159,8 +159,8 @@ class FlowLinkService {
 			throw new Exception('Operation already linked to this object', 409);
 		}
 
-		$opRow = $this->fetchOperationRow(operationId: $operationId);
-		if ($opRow === null) {
+		$onRow = $this->fetchOperationRow(operationId: $operationId);
+		if ($onRow === null) {
 			throw new Exception('Flow operation not found', 404);
 		}
 
@@ -169,9 +169,9 @@ class FlowLinkService {
 		$link->setRegisterId($registerId);
 		$link->setSchemaId($schemaId);
 		$link->setOperationId($operationId);
-		$link->setOperationClass((string)($opRow['class'] ?? ''));
-		$link->setOperationName((string)($opRow['name'] ?? ''));
-		$link->setEntityType((string)($opRow['entity'] ?? ''));
+		$link->setOperationClass((string)($onRow['class'] ?? ''));
+		$link->setOperationName((string)($onRow['name'] ?? ''));
+		$link->setEntityType((string)($onRow['entity'] ?? ''));
 		$link->setEnabled(true);
 		$link->setLinkedBy($user->getUID());
 		$link->setLinkedAt(new DateTime());
@@ -229,24 +229,24 @@ class FlowLinkService {
 			$row = $link->jsonSerialize();
 
 			if ($available === true) {
-				$opRow = $this->fetchOperationRow(operationId: (int)$link->getOperationId());
-				if ($opRow === null) {
+				$onRow = $this->fetchOperationRow(operationId: (int)$link->getOperationId());
+				if ($onRow === null) {
 					// Operation deleted in NC Flow — flag the link as
 					// stale by setting enabled=false.
 					$row['enabled'] = false;
 				}
 
-				if ($opRow !== null) {
-					$row['operationName'] = (string)($opRow['name'] ?? $row['operationName']);
-					$row['operationClass'] = (string)($opRow['class'] ?? $row['operationClass']);
-					$row['entityType'] = (string)($opRow['entity'] ?? $row['entityType']);
+				if ($onRow !== null) {
+					$row['operationName'] = (string)($onRow['name'] ?? $row['operationName']);
+					$row['operationClass'] = (string)($onRow['class'] ?? $row['operationClass']);
+					$row['entityType'] = (string)($onRow['entity'] ?? $row['entityType']);
 					// The flow_operations row doesn't carry an `enabled`
 					// flag (operations are always "live" once configured);
 					// we just surface that the row still exists.
 					$row['enabled'] = true;
-					$row['events'] = $this->decodeJsonField(value: ($opRow['events'] ?? null));
-					$row['checks'] = $this->decodeJsonField(value: ($opRow['checks'] ?? null));
-					$row['operation'] = (string)($opRow['operation'] ?? '');
+					$row['events'] = $this->decodeJsonField(value: ($onRow['events'] ?? null));
+					$row['checks'] = $this->decodeJsonField(value: ($onRow['checks'] ?? null));
+					$row['operation'] = (string)($onRow['operation'] ?? '');
 				}
 			}//end if
 

--- a/lib/Service/Geo/GeoFilter.php
+++ b/lib/Service/Geo/GeoFilter.php
@@ -160,7 +160,7 @@ class GeoFilter {
 	 * @spec openspec/specs/geo-metadata-kaart/spec.md#requirement-req-geo-004-spatial-queries-in-the-api
 	 */
 	public static function fromWithinGeometry(array $geometry, ?string $property = null): self {
-		self::assertGeoJsonGeometry(geometry: $geometry, opName: 'within');
+		self::assertGeoJsonGeometry(geometry: $geometry, onName: 'within');
 		return new self(self::TYPE_WITHIN, ['geometry' => $geometry], $property);
 	}//end fromWithinGeometry()
 
@@ -177,7 +177,7 @@ class GeoFilter {
 	 * @spec openspec/specs/geo-metadata-kaart/spec.md#requirement-req-geo-004-spatial-queries-in-the-api
 	 */
 	public static function fromIntersectsGeometry(array $geometry, ?string $property = null): self {
-		self::assertGeoJsonGeometry(geometry: $geometry, opName: 'intersects');
+		self::assertGeoJsonGeometry(geometry: $geometry, onName: 'intersects');
 		return new self(self::TYPE_INTERSECTS, ['geometry' => $geometry], $property);
 	}//end fromIntersectsGeometry()
 
@@ -185,7 +185,7 @@ class GeoFilter {
 	 * Validate that a value looks like a GeoJSON geometry.
 	 *
 	 * @param mixed $geometry The candidate.
-	 * @param string $opName Operator name for error context.
+	 * @param string $onName Operator name for error context.
 	 *
 	 * @return void
 	 *
@@ -193,20 +193,20 @@ class GeoFilter {
 	 *
 	 * @spec openspec/specs/geo-metadata-kaart/spec.md#requirement-req-geo-004-spatial-queries-in-the-api
 	 */
-	private static function assertGeoJsonGeometry(mixed $geometry, string $opName): void {
+	private static function assertGeoJsonGeometry(mixed $geometry, string $onName): void {
 		if (is_array($geometry) === false) {
-			throw new InvalidArgumentException("{$opName} geometry MUST be a GeoJSON object");
+			throw new InvalidArgumentException("{$onName} geometry MUST be a GeoJSON object");
 		}
 
 		$type = $geometry['type'] ?? null;
 		if (in_array($type, ['Polygon', 'MultiPolygon'], true) === false) {
 			throw new InvalidArgumentException(
-				"{$opName} geometry type MUST be Polygon or MultiPolygon (got: " . var_export($type, true) . ')'
+				"{$onName} geometry type MUST be Polygon or MultiPolygon (got: " . var_export($type, true) . ')'
 			);
 		}
 
 		if (isset($geometry['coordinates']) === false || is_array($geometry['coordinates']) === false) {
-			throw new InvalidArgumentException("{$opName} geometry MUST have a coordinates array");
+			throw new InvalidArgumentException("{$onName} geometry MUST have a coordinates array");
 		}
 
 	}//end assertGeoJsonGeometry()

--- a/lib/Service/Integration/Providers/BrpPersonProvider.php
+++ b/lib/Service/Integration/Providers/BrpPersonProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * BrpPersoonProvider — person lookup against the Dutch BRP (basisregistratie
+ * BrpPersonProvider — person lookup against the Dutch BRP (basisregistratie
  * personen) via the RvIG HaalCentraal Personen v2.0 API, exposed through the
  * IntegrationProvider contract.
  *
@@ -76,7 +76,7 @@ use Throwable;
  *   cause vocabulary; each is required for the degrade-don't-throw lookup
  *   surface (AD-23).
  */
-class BrpPersoonProvider extends AbstractIntegrationProvider {
+class BrpPersonProvider extends AbstractIntegrationProvider {
 
 	/**
 	 * OpenConnector source id this provider routes through.
@@ -320,7 +320,7 @@ class BrpPersoonProvider extends AbstractIntegrationProvider {
 			return $this->degraded(cause: $e->getCause());
 		} catch (Throwable $e) {
 			// Never include the BSN or the message body — only that a lookup failed.
-			$this->logger->warning('BrpPersoonProvider::lookupByBsn failed (transport).');
+			$this->logger->warning('BrpPersonProvider::lookupByBsn failed (transport).');
 			return $this->degraded(cause: ProviderUnavailableException::CAUSE_UPSTREAM_SERVICE_DOWN);
 		}
 

--- a/lib/Service/Integration/Providers/FlowProvider.php
+++ b/lib/Service/Integration/Providers/FlowProvider.php
@@ -114,14 +114,14 @@ class FlowProvider extends AbstractIntegrationProvider {
 		$out = [];
 		foreach ($links as $link) {
 			$operationId = (int)$link->getOperationId();
-			$opRow = $this->fetchOperationRow(operationId: $operationId);
+			$onRow = $this->fetchOperationRow(operationId: $operationId);
 
-			$name = (string)($opRow['name'] ?? $link->getOperationName() ?? '');
-			$class = (string)($opRow['class'] ?? $link->getOperationClass() ?? '');
-			$entity = (string)($opRow['entity'] ?? $link->getEntityType() ?? '');
-			$operation = (string)($opRow['operation'] ?? '');
-			$events = $this->decodeJsonField(value: $opRow['events'] ?? null);
-			$checks = $this->decodeJsonField(value: $opRow['checks'] ?? null);
+			$name = (string)($onRow['name'] ?? $link->getOperationName() ?? '');
+			$class = (string)($onRow['class'] ?? $link->getOperationClass() ?? '');
+			$entity = (string)($onRow['entity'] ?? $link->getEntityType() ?? '');
+			$operation = (string)($onRow['operation'] ?? '');
+			$events = $this->decodeJsonField(value: $onRow['events'] ?? null);
+			$checks = $this->decodeJsonField(value: $onRow['checks'] ?? null);
 
 			$out[] = [
 				'id' => (string)$operationId,
@@ -131,10 +131,10 @@ class FlowProvider extends AbstractIntegrationProvider {
 				'operation' => $operation,
 				'events' => $events,
 				'checks' => $checks,
-				'enabled' => $opRow !== null,
+				'enabled' => $onRow !== null,
 				'url' => '/index.php/settings/admin/workflow#' . $operationId,
 				'linkId' => $link->getId(),
-				'data' => $opRow ?? [],
+				'data' => $onRow ?? [],
 			];
 		}//end foreach
 

--- a/lib/Service/LanguageService.php
+++ b/lib/Service/LanguageService.php
@@ -265,9 +265,9 @@ class LanguageService {
 			}
 
 			// Try base language (e.g., "en" from "en-US").
-			$baseLang = strtolower(explode('-', $accepted)[0]);
-			if (in_array($baseLang, $registerLanguages, true) === true) {
-				return $baseLang;
+			$baseLong = strtolower(explode('-', $accepted)[0]);
+			if (in_array($baseLong, $registerLanguages, true) === true) {
+				return $baseLong;
 			}
 		}
 

--- a/lib/Service/Notification/VngNotificatiesEnvelope.php
+++ b/lib/Service/Notification/VngNotificatiesEnvelope.php
@@ -79,7 +79,7 @@ class VngNotificatiesEnvelope {
 	 * @param string $objectUuid Parent object UUID.
 	 * @param string $baseUrl External base URL (no trailing slash).
 	 * @param ?DateTimeInterface $timestamp Event timestamp; null = now.
-	 * @param array $kenmerken Extra discriminators (zaaktype, status, etc.).
+	 * @param array $characteristics Extra discriminators (zaaktype, status, etc.).
 	 *
 	 * @return array{kanaal: string, hoofdObject: string, resource: string,
 	 *               resourceUrl: string, actie: string,
@@ -96,9 +96,9 @@ class VngNotificatiesEnvelope {
 		string $objectUuid,
 		string $baseUrl,
 		?DateTimeInterface $timestamp = null,
-		array $kenmerken = [],
+		array $characteristics = [],
 	): array {
-		$vngActie = $this->mapAction(action: $action);
+		$vngAction = $this->mapAction(action: $action);
 		$base = rtrim($baseUrl, '/');
 		$when = ($timestamp ?? new DateTimeImmutable('now', new DateTimeZone('UTC')));
 
@@ -107,9 +107,9 @@ class VngNotificatiesEnvelope {
 			'hoofdObject' => $base . '/api/v1/' . $registerSlug . '/' . $objectUuid,
 			'resource' => $schemaSlug,
 			'resourceUrl' => $base . '/api/v1/' . $schemaSlug . '/' . $objectUuid,
-			'actie' => $vngActie,
+			'actie' => $vngAction,
 			'aanmaakdatum' => $when->format(DateTimeInterface::ATOM),
-			'kenmerken' => $kenmerken,
+			'kenmerken' => $characteristics,
 		];
 
 	}//end buildEnvelope()

--- a/lib/Service/OasService.php
+++ b/lib/Service/OasService.php
@@ -904,44 +904,44 @@ class OasService {
 
 		// Collection endpoints (tags are inside individual operations).
 		$getCollection = $this->createGetCollectionOperation(schema: $schema);
-		$postOp = $this->createPostOperation(schema: $schema);
+		$postOn = $this->createPostOperation(schema: $schema);
 
 		// Apply operationId prefix for uniqueness across registers.
 		if ($operationIdPrefix !== '') {
 			$getCollection['operationId'] = $operationIdPrefix . $getCollection['operationId'];
-			$postOp['operationId'] = $operationIdPrefix . $postOp['operationId'];
+			$postOn['operationId'] = $operationIdPrefix . $postOn['operationId'];
 		}
 
 		// Append RBAC group info to descriptions and add 403 responses.
 		$this->applyRbacToOperation(operation: $getCollection, groups: $rbac['readGroups'] ?? []);
-		$this->applyRbacToOperation(operation: $postOp, groups: $rbac['createGroups'] ?? []);
+		$this->applyRbacToOperation(operation: $postOn, groups: $rbac['createGroups'] ?? []);
 
 		$this->oas['paths'][$basePath] = [
 			'get' => $getCollection,
-			'post' => $postOp,
+			'post' => $postOn,
 		];
 
 		// Individual resource endpoints (tags are inside individual operations).
-		$getOp = $this->createGetOperation(schema: $schema);
-		$putOp = $this->createPutOperation(schema: $schema);
-		$deleteOp = $this->createDeleteOperation(schema: $schema);
+		$getOn = $this->createGetOperation(schema: $schema);
+		$putOn = $this->createPutOperation(schema: $schema);
+		$deleteOn = $this->createDeleteOperation(schema: $schema);
 
 		// Apply operationId prefix for uniqueness across registers.
 		if ($operationIdPrefix !== '') {
-			$getOp['operationId'] = $operationIdPrefix . $getOp['operationId'];
-			$putOp['operationId'] = $operationIdPrefix . $putOp['operationId'];
-			$deleteOp['operationId'] = $operationIdPrefix . $deleteOp['operationId'];
+			$getOn['operationId'] = $operationIdPrefix . $getOn['operationId'];
+			$putOn['operationId'] = $operationIdPrefix . $putOn['operationId'];
+			$deleteOn['operationId'] = $operationIdPrefix . $deleteOn['operationId'];
 		}
 
 		// Append RBAC group info to descriptions and add 403 responses.
-		$this->applyRbacToOperation(operation: $getOp, groups: $rbac['readGroups'] ?? []);
-		$this->applyRbacToOperation(operation: $putOp, groups: $rbac['updateGroups'] ?? []);
-		$this->applyRbacToOperation(operation: $deleteOp, groups: $rbac['deleteGroups'] ?? []);
+		$this->applyRbacToOperation(operation: $getOn, groups: $rbac['readGroups'] ?? []);
+		$this->applyRbacToOperation(operation: $putOn, groups: $rbac['updateGroups'] ?? []);
+		$this->applyRbacToOperation(operation: $deleteOn, groups: $rbac['deleteGroups'] ?? []);
 
 		$this->oas['paths'][$basePath . '/{id}'] = [
-			'get' => $getOp,
-			'put' => $putOp,
-			'delete' => $deleteOp,
+			'get' => $getOn,
+			'put' => $putOn,
+			'delete' => $deleteOn,
 		];
 	}//end addCrudPaths()
 

--- a/lib/Service/Object/FacetHandler.php
+++ b/lib/Service/Object/FacetHandler.php
@@ -386,18 +386,18 @@ class FacetHandler {
 		// magic table, but fields that are exclusively non-aggregated should not appear as aggregated facets.
 		$nonAggregatedFields = $facetableConfig['non_aggregated_fields'] ?? [];
 		$aggregatedFieldKeys = array_keys($facetableConfig['object_fields'] ?? []);
-		foreach ($nonAggregatedFields as $naField) {
-			$fieldName = $naField['field'];
+		foreach ($nonAggregatedFields as $afterField) {
+			$fieldName = $afterField['field'];
 			if (in_array($fieldName, $aggregatedFieldKeys, true) === false && isset($facets[$fieldName]) === true) {
 				unset($facets[$fieldName]);
 			}
 		}
 
 		// **NON-AGGREGATED FACETS**: Make separate schema-scoped queries for non-aggregated fields.
-		foreach ($nonAggregatedFields as $naField) {
-			$fieldName = $naField['field'];
-			$schemaId = $naField['schemaId'];
-			$config = $naField['facetConfig'];
+		foreach ($nonAggregatedFields as $afterField) {
+			$fieldName = $afterField['field'];
+			$schemaId = $afterField['schemaId'];
+			$config = $afterField['facetConfig'];
 
 			// Build a schema-scoped query to get facets for this field only.
 			// IMPORTANT: Remove plural schema/register keys so getSimpleFacets() routes
@@ -688,9 +688,9 @@ class FacetHandler {
 	): int {
 		$order = $currentOrder;
 
-		$naConfig = $facetData['_facetConfig'] ?? [];
-		$naSchemaId = $facetData['_schemaId'] ?? null;
-		$naFieldName = $facetData['_fieldName'] ?? $field;
+		$afterConfig = $facetData['_facetConfig'] ?? [];
+		$afterSchemaId = $facetData['_schemaId'] ?? null;
+		$afterFieldName = $facetData['_fieldName'] ?? $field;
 
 		// Clean internal metadata from facet data before processing.
 		unset(
@@ -700,7 +700,7 @@ class FacetHandler {
 			$facetData['_fieldName']
 		);
 
-		$configOrder = $naConfig['order'] ?? null;
+		$configOrder = $afterConfig['order'] ?? null;
 		$facetOrder = ++$order;
 		if ($configOrder !== null) {
 			$facetOrder = (int)$configOrder;
@@ -710,26 +710,26 @@ class FacetHandler {
 			$order = $facetOrder;
 		}
 
-		$title = $naConfig['title'] ?? $facetData['title'] ?? $this->formatFieldTitle(field: $naFieldName);
-		$description = $naConfig['description'] ?? 'object field: ' . $naFieldName;
+		$title = $afterConfig['title'] ?? $facetData['title'] ?? $this->formatFieldTitle(field: $afterFieldName);
+		$description = $afterConfig['description'] ?? 'object field: ' . $afterFieldName;
 
 		$definition = [
 			'title' => $title,
 			'description' => $description,
 			'data_type' => $this->inferDataType(facetData: $facetData),
-			'index_field' => $this->sanitizeFieldName(field: $naFieldName),
+			'index_field' => $this->sanitizeFieldName(field: $afterFieldName),
 			'index_type' => 'string',
 			'enabled' => true,
 		];
 
 		$transformed[$field] = $this->buildFacetEntry(
-			name: $naFieldName,
+			name: $afterFieldName,
 			facetData: $facetData,
 			definition: $definition,
 			source: 'object',
-			queryParameter: $naFieldName,
+			queryParameter: $afterFieldName,
 			order: $facetOrder,
-			schemaId: $naSchemaId
+			schemaId: $afterSchemaId
 		);
 
 		return $order;

--- a/lib/Service/Object/RenderObject.php
+++ b/lib/Service/Object/RenderObject.php
@@ -2439,9 +2439,9 @@ class RenderObject {
 				continue;
 			}
 
-			foreach ($data as $key => $datum) {
+			foreach ($data as $key => $date) {
 				$tmpExtends = $extends;
-				$data[$key] = $this->handleExtendDot(data: $datum, _extend: $tmpExtends, depth: $depth);
+				$data[$key] = $this->handleExtendDot(data: $date, _extend: $tmpExtends, depth: $depth);
 			}
 
 			$objectData->set($root, $data);

--- a/lib/Service/Object/SaveObject.php
+++ b/lib/Service/Object/SaveObject.php
@@ -914,7 +914,7 @@ class SaveObject {
 			}
 
 			try {
-				// Get the base property name (e.g., "organisatie" from "organisatie.0").
+				// Get the base property name (e.g., "organisation" from "organisatie.0").
 				$baseProperty = explode('.', $propertyPath)[0];
 
 				// Look up the target schema from the property configuration.
@@ -934,7 +934,7 @@ class SaveObject {
 					$ref = $propertyConfig['items']['$ref'];
 				}
 
-				// Parse the schema slug from the $ref (e.g., "#/components/schemas/organisatie" -> "organisatie").
+				// Parse the schema slug from the $ref (e.g., "#/components/schemas/organisatie" -> "organisation").
 				$targetSchemaSlug = '';
 				if (preg_match('~^\#/components/schemas/(.+)$~', $ref, $matches) === 1) {
 					$targetSchemaSlug = $matches[1];

--- a/lib/Service/Object/SaveObject.php
+++ b/lib/Service/Object/SaveObject.php
@@ -5241,9 +5241,9 @@ class SaveObject {
 		// Also try the 'naam' field as a fallback (common in Dutch schemas).
 		// This covers cases where objectNameField is not configured but naam exists in data.
 		if (($name === null || trim($name) === '') && isset($data['naam']) === true) {
-			$naam = trim((string)$data['naam']);
-			if ($naam !== '') {
-				$this->cacheHandler->setObjectName(identifier: $uuid, name: $naam);
+			$name = trim((string)$data['naam']);
+			if ($name !== '') {
+				$this->cacheHandler->setObjectName(identifier: $uuid, name: $name);
 			}
 		}
 	}//end preCacheParentName()
@@ -5322,7 +5322,7 @@ class SaveObject {
 		// Recalculate archiefactiedatum if source property changed.
 		try {
 			$retentionService = \OC::$server->get(\OCA\OpenRegister\Service\RetentionService::class);
-			$preparedObject = $retentionService->recalculateArchiefactiedatum(
+			$preparedObject = $retentionService->recalculateArchiveActionDate(
 				$preparedObject,
 				$schema,
 				$oldObject->getObject()

--- a/lib/Service/Object/SaveObjects.php
+++ b/lib/Service/Object/SaveObjects.php
@@ -356,18 +356,18 @@ class SaveObjects {
 
 		// PERFORMANCE OPTIMIZATION: Reduce logging overhead during bulk operations.
 		if (count($objects) > 10000 || ($isMixedSchema === true && count($objects) > 1000)) {
-			$opLabel = 'Starting single-schema bulk save operation';
-			$opType = 'single-schema';
+			$onLabel = 'Starting single-schema bulk save operation';
+			$onType = 'single-schema';
 			if ($isMixedSchema === true) {
-				$opLabel = 'Starting mixed-schema bulk save operation';
-				$opType = 'mixed-schema';
+				$onLabel = 'Starting mixed-schema bulk save operation';
+				$onType = 'mixed-schema';
 			}
 
 			$this->logger->debug(
-				$opLabel,
+				$onLabel,
 				[
 					'totalObjects' => count($objects),
-					'operation' => $opType,
+					'operation' => $onType,
 				]
 			);
 		}//end if

--- a/lib/Service/Object/TranslationHandler.php
+++ b/lib/Service/Object/TranslationHandler.php
@@ -137,9 +137,9 @@ class TranslationHandler {
 		// resolves independently — a missing NL value for `body`
 		// doesn't force `title` (which has NL) to fall back too.
 		$chain = [$resolvedLanguage];
-		foreach ($registerLanguages as $lang) {
-			if (in_array($lang, $chain, true) === false) {
-				$chain[] = $lang;
+		foreach ($registerLanguages as $long) {
+			if (in_array($long, $chain, true) === false) {
+				$chain[] = $long;
 			}
 		}
 

--- a/lib/Service/ObjectSource/DbalObjectSourceProvider.php
+++ b/lib/Service/ObjectSource/DbalObjectSourceProvider.php
@@ -614,11 +614,11 @@ class DbalObjectSourceProvider implements WritableObjectSourceProvider {
 	 * @spec openspec/specs/dbal-virtual-registers/spec.md
 	 */
 	private function applyOperatorCriterion(QueryBuilder $qb, string $quoted, array $criterion): void {
-		foreach ($criterion as $op => $opValue) {
+		foreach ($criterion as $op => $onValue) {
 			if ((string)$op === 'in' || (string)$op === 'notIn') {
 				$list = [];
-				if (is_array($opValue) === true) {
-					$list = array_values($opValue);
+				if (is_array($onValue) === true) {
+					$list = array_values($onValue);
 				}
 
 				if ($list === []) {
@@ -646,7 +646,7 @@ class DbalObjectSourceProvider implements WritableObjectSourceProvider {
 				continue;
 			}//end if
 
-			$sqlOp = match ((string)$op) {
+			$sqlOn = match ((string)$op) {
 				'gt' => '>',
 				'gte' => '>=',
 				'lt' => '<',
@@ -655,11 +655,11 @@ class DbalObjectSourceProvider implements WritableObjectSourceProvider {
 				default => null,
 			};
 
-			if ($sqlOp === null) {
+			if ($sqlOn === null) {
 				continue;
 			}
 
-			$qb->andWhere($quoted . ' ' . $sqlOp . ' ' . $qb->createNamedParameter($opValue));
+			$qb->andWhere($quoted . ' ' . $sqlOn . ' ' . $qb->createNamedParameter($onValue));
 		}//end foreach
 	}//end applyOperatorCriterion()
 

--- a/lib/Service/RetentionService.php
+++ b/lib/Service/RetentionService.php
@@ -148,41 +148,41 @@ class RetentionService {
 		}
 
 		// Try selectielijst lookup first.
-		$classificatie = $archiveConfig['classificatie'] ?? null;
+		$classification = $archiveConfig['classification'] ?? null;
 		$selectielijstEntry = null;
 
-		if ($classificatie !== null) {
-			$selectielijstEntry = $this->lookupSelectielijstEntry(categorie: $classificatie);
+		if ($classification !== null) {
+			$selectielijstEntry = $this->lookupSelectielijstEntry(category: $classification);
 		}
 
 		// Determine nominatie and bewaartermijn (default to schema config).
 		$nominatie = $archiveConfig['defaultNominatie'] ?? 'nog_niet_bepaald';
-		$bewaartermijn = $archiveConfig['defaultBewaartermijn'] ?? null;
-		$bron = null;
+		$retentionPeriod = $archiveConfig['defaultBewaartermijn'] ?? null;
+		$source = null;
 		if ($selectielijstEntry !== null) {
 			$nominatie = $selectielijstEntry['archiefnominatie'] ?? 'nog_niet_bepaald';
-			$bewaartermijn = $selectielijstEntry['bewaartermijn'] ?? null;
-			$bron = $selectielijstEntry['bron'] ?? null;
+			$retentionPeriod = $selectielijstEntry['bewaartermijn'] ?? null;
+			$source = $selectielijstEntry['bron'] ?? null;
 		}
 
 		// Apply schema-level override if configured.
 		if (empty($archiveConfig['bewaartermijnOverride']) === false) {
-			$bewaartermijn = $archiveConfig['bewaartermijnOverride'];
+			$retentionPeriod = $archiveConfig['bewaartermijnOverride'];
 		}
 
 		// Build archival metadata.
 		$retention['archiefnominatie'] = $nominatie;
 		$retention['archiefstatus'] = 'nog_te_archiveren';
-		$retention['classificatie'] = $classificatie;
-		$retention['bewaartermijn'] = $bewaartermijn;
-		$retention['selectielijstBron'] = $bron;
+		$retention['classification'] = $classification;
+		$retention['bewaartermijn'] = $retentionPeriod;
+		$retention['selectielijstBron'] = $source;
 
 		// Calculate archiefactiedatum if bewaartermijn is set.
-		if ($bewaartermijn !== null) {
+		if ($retentionPeriod !== null) {
 			$retention['archiefactiedatum'] = $this->calculateArchiefactiedatum(
 				object: $object,
 				schema: $schema,
-				bewaartermijn: $bewaartermijn
+				retentionPeriod: $retentionPeriod
 			);
 		}
 
@@ -196,7 +196,7 @@ class RetentionService {
 	 *
 	 * @param ObjectEntity $object The object to calculate for
 	 * @param Schema $schema The schema with afleidingswijze config
-	 * @param string $bewaartermijn ISO 8601 duration (e.g., P5Y, P20Y)
+	 * @param string $retentionPeriod ISO 8601 duration (e.g., P5Y, P20Y)
 	 *
 	 * @return string|null ISO 8601 date string or null if calculation not possible
 	 *
@@ -206,16 +206,16 @@ class RetentionService {
 	public function calculateArchiefactiedatum(
 		ObjectEntity $object,
 		Schema $schema,
-		string $bewaartermijn,
+		string $retentionPeriod,
 	): ?string {
 		$archiveConfig = $schema->getArchive();
 		$afleidingswijze = $archiveConfig['afleidingswijze'] ?? 'afgehandeld';
 
 		try {
-			$interval = new DateInterval($bewaartermijn);
+			$interval = new DateInterval($retentionPeriod);
 		} catch (Exception $e) {
 			$this->logger->warning(
-				'[RetentionService] Invalid bewaartermijn format: ' . $bewaartermijn,
+				'[RetentionService] Invalid bewaartermijn format: ' . $retentionPeriod,
 				['exception' => $e]
 			);
 			return null;
@@ -269,13 +269,13 @@ class RetentionService {
 
 		switch ($afleidingswijze) {
 			case 'eigenschap':
-				$bronEigenschap = $archiveConfig['bronEigenschap'] ?? null;
-				if ($bronEigenschap !== null && isset($objectData[$bronEigenschap]) === true) {
+				$sourceAttribute = $archiveConfig['bronEigenschap'] ?? null;
+				if ($sourceAttribute !== null && isset($objectData[$sourceAttribute]) === true) {
 					try {
-						return new DateTime($objectData[$bronEigenschap]);
+						return new DateTime($objectData[$sourceAttribute]);
 					} catch (Exception $e) {
 						$this->logger->warning(
-							'[RetentionService] Cannot parse bronEigenschap date: ' . $objectData[$bronEigenschap]
+							'[RetentionService] Cannot parse bronEigenschap date: ' . $objectData[$sourceAttribute]
 						);
 					}
 				}
@@ -338,8 +338,8 @@ class RetentionService {
 			return $object;
 		}
 
-		$bewaartermijn = $retention['bewaartermijn'] ?? null;
-		if ($bewaartermijn === null) {
+		$retentionPeriod = $retention['bewaartermijn'] ?? null;
+		if ($retentionPeriod === null) {
 			return $object;
 		}
 
@@ -348,11 +348,11 @@ class RetentionService {
 		$propertyChanged = false;
 
 		if ($afleidingswijze === 'eigenschap') {
-			$bronEigenschap = $archiveConfig['bronEigenschap'] ?? null;
-			if ($bronEigenschap !== null) {
+			$sourceAttribute = $archiveConfig['bronEigenschap'] ?? null;
+			if ($sourceAttribute !== null) {
 				$newData = $object->getObject();
-				$oldVal = $oldObject[$bronEigenschap] ?? null;
-				$newVal = $newData[$bronEigenschap] ?? null;
+				$oldVal = $oldObject[$sourceAttribute] ?? null;
+				$newVal = $newData[$sourceAttribute] ?? null;
 				$propertyChanged = ($oldVal !== $newVal);
 			}
 		} elseif (in_array($afleidingswijze, ['afgehandeld', 'termijn'], true) === true) {
@@ -370,7 +370,7 @@ class RetentionService {
 		}
 
 		$oldDate = $retention['archiefactiedatum'] ?? null;
-		$newDate = $this->calculateArchiefactiedatum(object: $object, schema: $schema, bewaartermijn: $bewaartermijn);
+		$newDate = $this->calculateArchiefactiedatum(object: $object, schema: $schema, retentionPeriod: $retentionPeriod);
 
 		if ($newDate !== null && $newDate !== $oldDate) {
 			$retention['archiefactiedatum'] = $newDate;
@@ -391,13 +391,13 @@ class RetentionService {
 	/**
 	 * Look up a selectielijst entry by categorie code.
 	 *
-	 * @param string $categorie The selectielijst category code (e.g., B1, A1)
+	 * @param string $category The selectielijst category code (e.g., B1, A1)
 	 *
 	 * @return array|null The selectielijst entry data or null if not found
 	 *
 	 * @spec openspec/specs/archival-destruction-workflow/spec.md
 	 */
-	public function lookupSelectielijstEntry(string $categorie): ?array {
+	public function lookupSelectielijstEntry(string $category): ?array {
 		$settings = $this->settingsHandler->getArchivalSettingsOnly();
 
 		$registerId = $settings['selectielijstRegister'] ?? null;
@@ -413,7 +413,7 @@ class RetentionService {
 
 			$results = $this->objectMapper->findAll(
 				limit: 1,
-				filters: ['object->categorie' => $categorie],
+				filters: ['object->categorie' => $category],
 				register: $register,
 				schema: $schema
 			);
@@ -426,7 +426,7 @@ class RetentionService {
 			return $entry->getObject();
 		} catch (Exception $e) {
 			$this->logger->warning(
-				'[RetentionService] Failed to lookup selectielijst entry for ' . $categorie,
+				'[RetentionService] Failed to lookup selectielijst entry for ' . $category,
 				['exception' => $e]
 			);
 			return null;
@@ -770,7 +770,7 @@ class RetentionService {
 				'schema' => $object->getSchema(),
 				'register' => $object->getRegister(),
 				'archiefactiedatum' => $retention['archiefactiedatum'] ?? null,
-				'classificatie' => $retention['classificatie'] ?? null,
+				'classification' => $retention['classification'] ?? null,
 				'softDeleted' => $object->getDeleted() !== null,
 				'wooGepubliceerd' => $isWooPublished,
 			];
@@ -807,11 +807,11 @@ class RetentionService {
 		// Group destroyed objects by schema and classificatie.
 		$grouped = [];
 		foreach ($destructionList['objects'] ?? [] as $obj) {
-			$key = ($obj['schema'] ?? 'unknown') . '/' . ($obj['classificatie'] ?? 'unknown');
+			$key = ($obj['schema'] ?? 'unknown') . '/' . ($obj['classification'] ?? 'unknown');
 			if (isset($grouped[$key]) === false) {
 				$grouped[$key] = [
 					'schema' => $obj['schema'] ?? 'unknown',
-					'classificatie' => $obj['classificatie'] ?? 'unknown',
+					'classification' => $obj['classification'] ?? 'unknown',
 					'count' => 0,
 				];
 			}
@@ -842,9 +842,9 @@ class RetentionService {
 	private function extractSelectielijstBron(array $destructionList): array {
 		$bronnen = [];
 		foreach ($destructionList['objects'] ?? [] as $obj) {
-			$bron = $obj['selectielijstBron'] ?? null;
-			if ($bron !== null) {
-				$bronnen[] = $bron;
+			$source = $obj['selectielijstBron'] ?? null;
+			if ($source !== null) {
+				$bronnen[] = $source;
 			}
 		}
 

--- a/lib/Service/RetentionService.php
+++ b/lib/Service/RetentionService.php
@@ -179,7 +179,7 @@ class RetentionService {
 
 		// Calculate archiefactiedatum if bewaartermijn is set.
 		if ($retentionPeriod !== null) {
-			$retention['archiefactiedatum'] = $this->calculateArchiefactiedatum(
+			$retention['archiefactiedatum'] = $this->calculateArchiveActionDate(
 				object: $object,
 				schema: $schema,
 				retentionPeriod: $retentionPeriod
@@ -203,7 +203,7 @@ class RetentionService {
 	 * @spec openspec/specs/retention-management/spec.md#requirement-the-system-must-calculate-archiefactiedatum-using-configurable-afleidingswijzen
 	 * @spec openspec/specs/retention-management/spec.md
 	 */
-	public function calculateArchiefactiedatum(
+	public function calculateArchiveActionDate(
 		ObjectEntity $object,
 		Schema $schema,
 		string $retentionPeriod,
@@ -246,7 +246,7 @@ class RetentionService {
 		$brondatum->add($interval);
 
 		return $brondatum->format('Y-m-d');
-	}//end calculateArchiefactiedatum()
+	}//end calculateArchiveActionDate()
 
 	/**
 	 * Determine the brondatum (source date) based on afleidingswijze.
@@ -315,7 +315,7 @@ class RetentionService {
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 * @SuppressWarnings(PHPMD.NPathComplexity)
 	 */
-	public function recalculateArchiefactiedatum(
+	public function recalculateArchiveActionDate(
 		ObjectEntity $object,
 		Schema $schema,
 		array $oldObject,
@@ -370,7 +370,7 @@ class RetentionService {
 		}
 
 		$oldDate = $retention['archiefactiedatum'] ?? null;
-		$newDate = $this->calculateArchiefactiedatum(object: $object, schema: $schema, retentionPeriod: $retentionPeriod);
+		$newDate = $this->calculateArchiveActionDate(object: $object, schema: $schema, retentionPeriod: $retentionPeriod);
 
 		if ($newDate !== null && $newDate !== $oldDate) {
 			$retention['archiefactiedatum'] = $newDate;
@@ -386,7 +386,7 @@ class RetentionService {
 		}
 
 		return $object;
-	}//end recalculateArchiefactiedatum()
+	}//end recalculateArchiveActionDate()
 
 	/**
 	 * Look up a selectielijst entry by categorie code.
@@ -560,7 +560,7 @@ class RetentionService {
 	 *
 	 * @spec openspec/specs/archival-destruction-workflow/spec.md
 	 */
-	public function extendArchiefactiedatum(ObjectEntity $object, ?string $extensionPeriod = null): ObjectEntity {
+	public function extendArchiveActionDate(ObjectEntity $object, ?string $extensionPeriod = null): ObjectEntity {
 		$retention = $object->getRetention() ?? [];
 
 		if (empty($retention['archiefactiedatum']) === true) {
@@ -590,7 +590,7 @@ class RetentionService {
 		}
 
 		return $object;
-	}//end extendArchiefactiedatum()
+	}//end extendArchiveActionDate()
 
 	/**
 	 * Find objects eligible for destruction.
@@ -826,7 +826,7 @@ class RetentionService {
 			'destructionListUuid' => $destructionList['uuid'] ?? null,
 			'totalDestroyed' => $destroyedCount,
 			'groupedBySchema' => array_values($grouped),
-			'selectielijstBron' => $this->extractSelectielijstBron(destructionList: $destructionList),
+			'selectielijstBron' => $this->extractSelectionListSource(destructionList: $destructionList),
 			'complianceStatement' => 'Vernietiging conform Archiefwet 1995 en Archiefbesluit 1995',
 			'immutable' => true,
 		];
@@ -839,7 +839,7 @@ class RetentionService {
 	 *
 	 * @return string[] Unique selectielijst bron references
 	 */
-	private function extractSelectielijstBron(array $destructionList): array {
+	private function extractSelectionListSource(array $destructionList): array {
 		$bronnen = [];
 		foreach ($destructionList['objects'] ?? [] as $obj) {
 			$source = $obj['selectielijstBron'] ?? null;
@@ -849,5 +849,5 @@ class RetentionService {
 		}
 
 		return array_values(array_unique($bronnen));
-	}//end extractSelectielijstBron()
+	}//end extractSelectionListSource()
 }//end class

--- a/lib/Service/TmloService.php
+++ b/lib/Service/TmloService.php
@@ -102,7 +102,7 @@ class TmloService {
 	 * @var string[]
 	 */
 	public const TMLO_FIELDS = [
-		'classificatie',
+		'classification',
 		'archiefnominatie',
 		'archiefactiedatum',
 		'archiefstatus',
@@ -354,7 +354,7 @@ class TmloService {
 
 		// Validate required fields for transfer (overgebracht).
 		if ($newStatus === self::ARCHIEFSTATUS_OVERGEBRACHT) {
-			$requiredFields = ['archiefactiedatum', 'classificatie', 'archiefnominatie'];
+			$requiredFields = ['archiefactiedatum', 'classification', 'archiefnominatie'];
 			foreach ($requiredFields as $field) {
 				if (($tmlo[$field] ?? null) === null || $tmlo[$field] === '') {
 					$errors[] = "Field '{$field}' is required for transition to 'overgebracht'";
@@ -368,7 +368,7 @@ class TmloService {
 
 		// Validate required fields for destruction (vernietigd).
 		if ($newStatus === self::ARCHIEFSTATUS_VERNIETIGD) {
-			$requiredFields = ['archiefactiedatum', 'classificatie', 'archiefnominatie', 'vernietigingsCategorie'];
+			$requiredFields = ['archiefactiedatum', 'classification', 'archiefnominatie', 'vernietigingsCategorie'];
 			foreach ($requiredFields as $field) {
 				if (($tmlo[$field] ?? null) === null || $tmlo[$field] === '') {
 					$errors[] = "Field '{$field}' is required for transition to 'vernietigd'";
@@ -456,31 +456,31 @@ class TmloService {
 
 		// Identificatie.
 		$idElement = $dom->createElementNS(self::MDTO_NAMESPACE, 'mdto:identificatie');
-		$idKenmerk = $dom->createElementNS(
+		$idReference = $dom->createElementNS(
 			self::MDTO_NAMESPACE,
 			'mdto:identificatieKenmerk',
 			$this->xmlEscape(value: $object->getUuid() ?? '')
 		);
-		$idBron = $dom->createElementNS(self::MDTO_NAMESPACE, 'mdto:identificatieBron', 'OpenRegister');
-		$idElement->appendChild($idKenmerk);
-		$idElement->appendChild($idBron);
+		$idSource = $dom->createElementNS(self::MDTO_NAMESPACE, 'mdto:identificatieBron', 'OpenRegister');
+		$idElement->appendChild($idReference);
+		$idElement->appendChild($idSource);
 		$root->appendChild($idElement);
 
 		// Naam.
-		$naam = $dom->createElementNS(
+		$name = $dom->createElementNS(
 			self::MDTO_NAMESPACE,
 			'mdto:naam',
 			$this->xmlEscape(value: $object->getName() ?? $object->getUuid() ?? '')
 		);
-		$root->appendChild($naam);
+		$root->appendChild($name);
 
 		// TMLO fields.
-		if (($tmlo['classificatie'] ?? null) !== null) {
+		if (($tmlo['classification'] ?? null) !== null) {
 			$classEl = $dom->createElementNS(self::MDTO_NAMESPACE, 'mdto:classificatie');
 			$classCode = $dom->createElementNS(
 				self::MDTO_NAMESPACE,
 				'mdto:classificatieCode',
-				$this->xmlEscape(value: $tmlo['classificatie'])
+				$this->xmlEscape(value: $tmlo['classification'])
 			);
 			$classEl->appendChild($classCode);
 			$root->appendChild($classEl);
@@ -491,7 +491,7 @@ class TmloService {
 				$dom->createElementNS(
 					self::MDTO_NAMESPACE,
 					'mdto:waardering',
-					$this->mapArchiefnominatie(nominatie: $tmlo['archiefnominatie'])
+					$this->mapArchiveNomination(nominatie: $tmlo['archiefnominatie'])
 				)
 			);
 		}
@@ -546,7 +546,7 @@ class TmloService {
 	 *
 	 * @return string The MDTO waardering value
 	 */
-	private function mapArchiefnominatie(string $nominatie): string {
+	private function mapArchiveNomination(string $nominatie): string {
 		$mapping = [
 			self::ARCHIEFNOMINATIE_BLIJVEND_BEWAREN => 'bewaren',
 			self::ARCHIEFNOMINATIE_VERNIETIGEN => 'vernietigen',

--- a/lib/Service/TmloService.php
+++ b/lib/Service/TmloService.php
@@ -215,7 +215,7 @@ class TmloService {
 
 		// Calculate archiefactiedatum from bewaarTermijn if not explicitly set.
 		if (($tmlo['archiefactiedatum'] ?? null) === null && ($tmlo['bewaarTermijn'] ?? null) !== null) {
-			$tmlo['archiefactiedatum'] = $this->calculateArchiefactiedatum(duration: $tmlo['bewaarTermijn']);
+			$tmlo['archiefactiedatum'] = $this->calculateArchiveActionDate(duration: $tmlo['bewaarTermijn']);
 		}
 
 		$object->setTmlo($tmlo);
@@ -232,7 +232,7 @@ class TmloService {
 	 *
 	 * @spec openspec/specs/tmlo-validation/spec.md#scenario-valid-iso-8601-duration-accepted
 	 */
-	public function calculateArchiefactiedatum(string $duration): ?string {
+	public function calculateArchiveActionDate(string $duration): ?string {
 		try {
 			$interval = new DateInterval($duration);
 			$date = new DateTime();
@@ -245,7 +245,7 @@ class TmloService {
 			);
 			return null;
 		}
-	}//end calculateArchiefactiedatum()
+	}//end calculateArchiveActionDate()
 
 	/**
 	 * Validate TMLO field values.

--- a/lib/Service/Translation/IdentityTranslationProvider.php
+++ b/lib/Service/Translation/IdentityTranslationProvider.php
@@ -33,14 +33,14 @@ class IdentityTranslationProvider implements TranslationProviderInterface {
 	 * Identity translation: returns the source text unchanged.
 	 *
 	 * @param string $text The source text.
-	 * @param string $fromLang BCP 47 source language code.
-	 * @param string $toLang BCP 47 target language code.
+	 * @param string $fromLong BCP 47 source language code.
+	 * @param string $toLong BCP 47 target language code.
 	 *
 	 * @return string|null Always the source text (passthrough).
 	 *
 	 * @spec openspec/specs/register-i18n/spec.md
 	 */
-	public function translate(string $text, string $fromLang, string $toLang): ?string {
+	public function translate(string $text, string $fromLong, string $toLong): ?string {
 		// Same-language translation is a degenerate but valid request.
 		// Different-language: passthrough (the operator should plug a
 		// real provider in front of this for real translations).

--- a/lib/Service/Translation/TranslationCsvCodec.php
+++ b/lib/Service/Translation/TranslationCsvCodec.php
@@ -81,17 +81,17 @@ class TranslationCsvCodec {
 			// Translatable property with language-keyed value:
 			// emit `field_lang` columns per language present.
 			if (is_array($value) === true && $this->isLanguageKeyed(value: $value) === true) {
-				foreach ($value as $lang => $langValue) {
-					if (is_string($lang) === false || $lang === '') {
+				foreach ($value as $long => $longValue) {
+					if (is_string($long) === false || $long === '') {
 						continue;
 					}
 
-					$langScalar = null;
-					if (is_scalar($langValue) === true) {
-						$langScalar = $langValue;
+					$longScalar = null;
+					if (is_scalar($longValue) === true) {
+						$longScalar = $longValue;
 					}
 
-					$row[$key . '_' . $lang] = $langScalar;
+					$row[$key . '_' . $long] = $longScalar;
 				}
 
 				continue;
@@ -146,8 +146,8 @@ class TranslationCsvCodec {
 			foreach ($translatableProps as $prop) {
 				$prefix = $prop . '_';
 				if (str_starts_with($column, $prefix) === true) {
-					$lang = substr($column, strlen($prefix));
-					if ($lang === '' || preg_match('/^[a-zA-Z][a-zA-Z0-9-]{0,15}$/', $lang) !== 1) {
+					$long = substr($column, strlen($prefix));
+					if ($long === '' || preg_match('/^[a-zA-Z][a-zA-Z0-9-]{0,15}$/', $long) !== 1) {
 						continue;
 					}
 
@@ -162,7 +162,7 @@ class TranslationCsvCodec {
 						$out[$prop] = [];
 					}
 
-					$out[$prop][$lang] = $value;
+					$out[$prop][$long] = $value;
 					$matched = true;
 					break;
 				}//end if

--- a/lib/Service/Translation/TranslationProviderInterface.php
+++ b/lib/Service/Translation/TranslationProviderInterface.php
@@ -30,7 +30,7 @@ namespace OCA\OpenRegister\Service\Translation;
 
 interface TranslationProviderInterface {
 	/**
-	 * Translate `$text` from `$fromLang` to `$toLang`.
+	 * Translate `$text` from `$fromLong` to `$toLong`.
 	 *
 	 * Both arguments are BCP 47 language codes (e.g. "nl", "en", "fr-CA").
 	 * Returns the translated string, or null when the provider can't
@@ -39,14 +39,14 @@ interface TranslationProviderInterface {
 	 * bulk service skips the slot rather than persisting null.
 	 *
 	 * @param string $text The source text to translate.
-	 * @param string $fromLang BCP 47 source language code.
-	 * @param string $toLang BCP 47 target language code.
+	 * @param string $fromLong BCP 47 source language code.
+	 * @param string $toLong BCP 47 target language code.
 	 *
 	 * @return string|null The translated text, or null on miss/error.
 	 *
 	 * @spec openspec/specs/register-i18n/spec.md
 	 */
-	public function translate(string $text, string $fromLang, string $toLang): ?string;
+	public function translate(string $text, string $fromLong, string $toLong): ?string;
 
 	/**
 	 * Identifier used for status attribution and logging.

--- a/lib/Service/TranslationProjectionService.php
+++ b/lib/Service/TranslationProjectionService.php
@@ -144,14 +144,14 @@ class TranslationProjectionService {
 
 				if (is_array($value) === true) {
 					// Language-keyed shape: {nl: "...", en: "..."}.
-					foreach ($value as $lang => $langValue) {
-						if (is_string($lang) === false || $lang === '') {
+					foreach ($value as $long => $longValue) {
+						if (is_string($long) === false || $long === '') {
 							continue;
 						}
 
-						$stringValue = $this->valueToString(value: $langValue);
+						$stringValue = $this->valueToString(value: $longValue);
 						if ($stringValue !== null && $stringValue !== '') {
-							$desired[$property][$lang] = $stringValue;
+							$desired[$property][$long] = $stringValue;
 						}
 					}
 				} elseif (is_string($value) === true && $value !== '') {
@@ -162,20 +162,20 @@ class TranslationProjectionService {
 
 			// Upsert every desired slot.
 			$upsertedKeys = [];
-			foreach ($desired as $property => $byLang) {
+			foreach ($desired as $property => $byLong) {
 				$sourceLanguage = $sourceLanguages[$property] ?? $defaultLanguage;
-				foreach ($byLang as $lang => $stringValue) {
+				foreach ($byLong as $long => $stringValue) {
 					$this->translationMapper->upsert(
 						objectUuid: $uuid,
 						property: $property,
-						language: $lang,
+						language: $long,
 						value: $stringValue,
 						status: null,
 						// Preserve existing or default to draft on insert.
 						translator: $translator,
 						sourceLanguage: $sourceLanguage
 					);
-					$upsertedKeys[] = $property . '|' . $lang;
+					$upsertedKeys[] = $property . '|' . $long;
 				}
 			}
 

--- a/lib/Service/UserService.php
+++ b/lib/Service/UserService.php
@@ -692,9 +692,19 @@ class UserService {
 			$additionalInfo['organisation'] = $organizationUuid;
 		}
 
-		// Fallback: check for 'role' in user config if not found via AccountManager's 'role'.
+		// Fallback: check user config if AccountManager's 'role' is empty.
+		//
+		// `functie` here is not a variable name, it is a STORED KEY — the preference
+		// row oc_preferences(appid='core', configkey='functie'). Renaming the read
+		// does not rename what is already in the table, so reading only the new key
+		// makes every job title saved before this release disappear, with no error.
+		// Read the new key first, then fall back to the old one.
 		if (empty($additionalInfo['role']) === true) {
 			$role = $this->config->getUserValue($userId, 'core', 'role', '');
+			if (empty($role) === true) {
+				$role = $this->config->getUserValue($userId, 'core', 'functie', '');
+			}
+
 			if (empty($role) === false) {
 				$additionalInfo['role'] = $role;
 			}

--- a/lib/Service/UserService.php
+++ b/lib/Service/UserService.php
@@ -253,8 +253,9 @@ class UserService {
 		$result['firstName'] = $result['firstName'] ?? null;
 		$result['lastName'] = $result['lastName'] ?? null;
 		$result['middleName'] = $result['middleName'] ?? null;
-		// 'functie' is the Dutch term for job title/role - map from 'role' property.
-		$result['functie'] = $result['functie'] ?? $additionalInfo['role'] ?? null;
+		// The Dutch alias `functie` used to be exposed alongside Nextcloud's own
+		// `role`; both are `role` now, so the alias assignment is redundant.
+		$result['role'] = $result['role'] ?? $additionalInfo['role'] ?? null;
 
 		// Add organization information in the format expected by the frontend.
 		// Frontend expects: { active: { uuid, naam, id, slug }, all: [...] }
@@ -397,7 +398,7 @@ class UserService {
 			'biography',
 			'language',
 			'locale',
-			'functie',
+			'role',
 		];
 
 		foreach ($fieldsToCheck as $field) {
@@ -691,11 +692,11 @@ class UserService {
 			$additionalInfo['organisation'] = $organizationUuid;
 		}
 
-		// Fallback: check for 'functie' in user config if not found via AccountManager's 'role'.
+		// Fallback: check for 'role' in user config if not found via AccountManager's 'role'.
 		if (empty($additionalInfo['role']) === true) {
-			$functie = $this->config->getUserValue($userId, 'core', 'functie', '');
-			if (empty($functie) === false) {
-				$additionalInfo['role'] = $functie;
+			$role = $this->config->getUserValue($userId, 'core', 'role', '');
+			if (empty($role) === false) {
+				$additionalInfo['role'] = $role;
 			}
 		}
 
@@ -816,7 +817,6 @@ class UserService {
 				'fediverse' => IAccountManager::PROPERTY_FEDIVERSE,
 				'organisation' => IAccountManager::PROPERTY_ORGANISATION,
 				'role' => IAccountManager::PROPERTY_ROLE,
-				'functie' => IAccountManager::PROPERTY_ROLE,
 				'headline' => IAccountManager::PROPERTY_HEADLINE,
 				'biography' => IAccountManager::PROPERTY_BIOGRAPHY,
 			];
@@ -878,9 +878,9 @@ class UserService {
 			$this->setCustomNameFields(user: $user, nameFields: $nameFields);
 		}
 
-		// Store 'functie' in user config as fallback for the /me endpoint.
-		if (isset($data['functie']) === true) {
-			$this->config->setUserValue($user->getUID(), 'core', 'functie', (string)$data['functie']);
+		// Store 'role' in user config as fallback for the /me endpoint.
+		if (isset($data['role']) === true) {
+			$this->config->setUserValue($user->getUID(), 'core', 'role', (string)$data['role']);
 		}
 	}//end updateProfileProperties()
 

--- a/lib/Service/VocabularyImportService.php
+++ b/lib/Service/VocabularyImportService.php
@@ -110,7 +110,7 @@ class VocabularyImportService {
 		}
 
 		$schemeNode = null;
-		$conceptNodes = [];
+		$draftNodes = [];
 		foreach ($graph as $node) {
 			if (is_array($node) === false) {
 				continue;
@@ -120,7 +120,7 @@ class VocabularyImportService {
 			if ($type === 'ConceptScheme' && $schemeNode === null) {
 				$schemeNode = $node;
 			} elseif ($type === 'Concept') {
-				$conceptNodes[] = $node;
+				$draftNodes[] = $node;
 			}
 		}
 
@@ -128,7 +128,7 @@ class VocabularyImportService {
 			throw new InvalidArgumentException('JSON-LD document has no skos:ConceptScheme node with an "@id".');
 		}
 
-		return $this->importParsedGraph(schemeNode: $schemeNode, conceptNodes: $conceptNodes);
+		return $this->importParsedGraph(schemeNode: $schemeNode, draftNodes: $draftNodes);
 	}//end importJsonLd()
 
 	/**
@@ -179,7 +179,7 @@ class VocabularyImportService {
 			'dct:source' => ($schemeMeta['source'] ?? $schemeUri),
 		];
 
-		$conceptNodes = [];
+		$draftNodes = [];
 		while (($row = fgetcsv(stream: $handle, length: null, separator: ',', enclosure: '"', escape: '')) !== false) {
 			if (count($row) === 1 && trim((string)$row[0]) === '') {
 				continue;
@@ -194,8 +194,8 @@ class VocabularyImportService {
 			$prefLabel = [];
 			foreach ($rowAssoc as $column => $value) {
 				if (str_starts_with($column, 'prefLabel_') === true && trim((string)$value) !== '') {
-					$lang = substr($column, strlen('prefLabel_'));
-					$prefLabel[$lang] = trim((string)$value);
+					$long = substr($column, strlen('prefLabel_'));
+					$prefLabel[$long] = trim((string)$value);
 				}
 			}
 
@@ -206,7 +206,7 @@ class VocabularyImportService {
 				}
 			}
 
-			$conceptNodes[] = [
+			$draftNodes[] = [
 				'@id' => $uri,
 				'skos:notation' => ($rowAssoc['notation'] ?? null),
 				'skos:definition' => ($rowAssoc['definition'] ?? null),
@@ -217,18 +217,18 @@ class VocabularyImportService {
 
 		fclose($handle);
 
-		return $this->importParsedGraph(schemeNode: $schemeNode, conceptNodes: $conceptNodes);
+		return $this->importParsedGraph(schemeNode: $schemeNode, draftNodes: $draftNodes);
 	}//end importCsvValueList()
 
 	/**
 	 * Shared upsert pipeline for an already-parsed (scheme node, concept nodes) pair.
 	 *
 	 * @param array<string,mixed> $schemeNode The parsed scheme node.
-	 * @param array<int,array<string,mixed>> $conceptNodes The parsed concept nodes.
+	 * @param array<int,array<string,mixed>> $draftNodes The parsed concept nodes.
 	 *
 	 * @return array{scheme: string, created: int, updated: int, unchanged: int, deprecated: int}
 	 */
-	private function importParsedGraph(array $schemeNode, array $conceptNodes): array {
+	private function importParsedGraph(array $schemeNode, array $draftNodes): array {
 		$schemeUuid = $this->upsertScheme(node: $schemeNode);
 		$schemeUri = (string)$schemeNode['@id'];
 
@@ -238,13 +238,13 @@ class VocabularyImportService {
 		$seenUris = [];
 		$uuidByUri = [];
 
-		foreach ($conceptNodes as $node) {
+		foreach ($draftNodes as $node) {
 			$uri = (string)($node['@id'] ?? '');
 			if ($uri === '') {
 				continue;
 			}
 
-			$result = $this->upsertConcept(node: $node, schemeUuid: $schemeUuid);
+			$result = $this->upsertDraft(node: $node, schemeUuid: $schemeUuid);
 			$seenUris[] = $uri;
 			$uuidByUri[$uri] = $result['uuid'];
 			match ($result['status']) {
@@ -254,7 +254,7 @@ class VocabularyImportService {
 			};
 		}
 
-		$this->applyRelations(conceptNodes: $conceptNodes, uuidByUri: $uuidByUri);
+		$this->applyRelations(draftNodes: $draftNodes, uuidByUri: $uuidByUri);
 		$deprecated = $this->deprecateMissing(schemeUuid: $schemeUuid, seenUris: $seenUris);
 
 		$this->logger->info(
@@ -349,10 +349,10 @@ class VocabularyImportService {
 	 *
 	 * @throws InvalidArgumentException When the concept has no Dutch prefLabel.
 	 */
-	private function upsertConcept(array $node, string $schemeUuid): array {
+	private function upsertDraft(array $node, string $schemeUuid): array {
 		$uri = (string)$node['@id'];
 
-		$prefLabel = $this->extractLangMap(value: $this->findPredicate(node: $node, localName: 'prefLabel'));
+		$prefLabel = $this->extractLongMap(value: $this->findPredicate(node: $node, localName: 'prefLabel'));
 		if (isset($prefLabel['nl']) === false || trim($prefLabel['nl']) === '') {
 			throw new InvalidArgumentException(
 				sprintf('Concept "%s" has no Dutch (nl) prefLabel; refusing to import an invalid concept.', $uri)
@@ -366,7 +366,7 @@ class VocabularyImportService {
 			'deprecated' => false,
 		];
 
-		$altLabel = $this->extractLangMap(value: $this->findPredicate(node: $node, localName: 'altLabel'));
+		$altLabel = $this->extractLongMap(value: $this->findPredicate(node: $node, localName: 'altLabel'));
 		if (empty($altLabel) === false) {
 			$data['altLabel'] = $altLabel;
 		}
@@ -415,12 +415,12 @@ class VocabularyImportService {
 	 * concept absent from the re-imported source keeps its last-known edges
 	 * (it is deprecated, not edited) per design.md D3.
 	 *
-	 * @param array<int,array<string,mixed>> $conceptNodes The parsed concept nodes.
+	 * @param array<int,array<string,mixed>> $draftNodes The parsed concept nodes.
 	 * @param array<string,string> $uuidByUri uri => uuid map for this import.
 	 *
 	 * @return void
 	 */
-	private function applyRelations(array $conceptNodes, array $uuidByUri): void {
+	private function applyRelations(array $draftNodes, array $uuidByUri): void {
 		$broaderOf = [];
 		$narrowerOf = [];
 		$relatedOf = [];
@@ -433,7 +433,7 @@ class VocabularyImportService {
 			$relatedOf[$uuid] = ($relatedOf[$uuid] ?? []);
 		}
 
-		foreach ($conceptNodes as $node) {
+		foreach ($draftNodes as $node) {
 			$uri = (string)($node['@id'] ?? '');
 			$uuid = ($uuidByUri[$uri] ?? null);
 			if ($uuid === null) {
@@ -447,7 +447,7 @@ class VocabularyImportService {
 		}//end foreach
 
 		foreach ($uuidByUri as $uuid) {
-			$this->applyRelationFieldsToConcept(
+			$this->applyRelationFieldsToDraft(
 				uuid: $uuid,
 				broader: array_values(array_unique($broaderOf[$uuid] ?? [])),
 				narrower: array_values(array_unique($narrowerOf[$uuid] ?? [])),
@@ -496,7 +496,7 @@ class VocabularyImportService {
 	 *
 	 * @return void
 	 */
-	private function applyRelationFieldsToConcept(string $uuid, array $broader, array $narrower, array $related): void {
+	private function applyRelationFieldsToDraft(string $uuid, array $broader, array $narrower, array $related): void {
 		$existing = $this->objectService->find(id: $uuid, register: self::REGISTER, schema: self::SCHEMA_CONCEPT);
 		if ($existing === null) {
 			return;
@@ -744,7 +744,7 @@ class VocabularyImportService {
 	 *
 	 * @return array<string,string> BCP-47 tag => label.
 	 */
-	private function extractLangMap(mixed $value): array {
+	private function extractLongMap(mixed $value): array {
 		if ($value === null) {
 			return [];
 		}
@@ -763,16 +763,16 @@ class VocabularyImportService {
 		}
 
 		if (isset($value['@value']) === true) {
-			$lang = (string)($value['@language'] ?? 'nl');
-			return [$lang => (string)$value['@value']];
+			$long = (string)($value['@language'] ?? 'nl');
+			return [$long => (string)$value['@value']];
 		}
 
 		$map = [];
 		if (array_is_list($value) === true) {
 			foreach ($value as $item) {
 				if (is_array($item) === true && isset($item['@value']) === true) {
-					$lang = (string)($item['@language'] ?? 'nl');
-					$map[$lang] = (string)$item['@value'];
+					$long = (string)($item['@language'] ?? 'nl');
+					$map[$long] = (string)$item['@value'];
 				} elseif (is_string($item) === true && trim($item) !== '') {
 					$map['nl'] = $item;
 				}
@@ -781,9 +781,9 @@ class VocabularyImportService {
 			return $map;
 		}
 
-		foreach ($value as $lang => $label) {
+		foreach ($value as $long => $label) {
 			if (is_string($label) === true && trim($label) !== '') {
-				$map[(string)$lang] = $label;
+				$map[(string)$long] = $label;
 			}
 		}
 

--- a/lib/Service/VocabularyImportService.php
+++ b/lib/Service/VocabularyImportService.php
@@ -110,7 +110,7 @@ class VocabularyImportService {
 		}
 
 		$schemeNode = null;
-		$draftNodes = [];
+		$conceptNodes = [];
 		foreach ($graph as $node) {
 			if (is_array($node) === false) {
 				continue;
@@ -120,7 +120,7 @@ class VocabularyImportService {
 			if ($type === 'ConceptScheme' && $schemeNode === null) {
 				$schemeNode = $node;
 			} elseif ($type === 'Concept') {
-				$draftNodes[] = $node;
+				$conceptNodes[] = $node;
 			}
 		}
 
@@ -128,7 +128,7 @@ class VocabularyImportService {
 			throw new InvalidArgumentException('JSON-LD document has no skos:ConceptScheme node with an "@id".');
 		}
 
-		return $this->importParsedGraph(schemeNode: $schemeNode, draftNodes: $draftNodes);
+		return $this->importParsedGraph(schemeNode: $schemeNode, conceptNodes: $conceptNodes);
 	}//end importJsonLd()
 
 	/**
@@ -179,7 +179,7 @@ class VocabularyImportService {
 			'dct:source' => ($schemeMeta['source'] ?? $schemeUri),
 		];
 
-		$draftNodes = [];
+		$conceptNodes = [];
 		while (($row = fgetcsv(stream: $handle, length: null, separator: ',', enclosure: '"', escape: '')) !== false) {
 			if (count($row) === 1 && trim((string)$row[0]) === '') {
 				continue;
@@ -206,7 +206,7 @@ class VocabularyImportService {
 				}
 			}
 
-			$draftNodes[] = [
+			$conceptNodes[] = [
 				'@id' => $uri,
 				'skos:notation' => ($rowAssoc['notation'] ?? null),
 				'skos:definition' => ($rowAssoc['definition'] ?? null),
@@ -217,18 +217,18 @@ class VocabularyImportService {
 
 		fclose($handle);
 
-		return $this->importParsedGraph(schemeNode: $schemeNode, draftNodes: $draftNodes);
+		return $this->importParsedGraph(schemeNode: $schemeNode, conceptNodes: $conceptNodes);
 	}//end importCsvValueList()
 
 	/**
 	 * Shared upsert pipeline for an already-parsed (scheme node, concept nodes) pair.
 	 *
 	 * @param array<string,mixed> $schemeNode The parsed scheme node.
-	 * @param array<int,array<string,mixed>> $draftNodes The parsed concept nodes.
+	 * @param array<int,array<string,mixed>> $conceptNodes The parsed concept nodes.
 	 *
 	 * @return array{scheme: string, created: int, updated: int, unchanged: int, deprecated: int}
 	 */
-	private function importParsedGraph(array $schemeNode, array $draftNodes): array {
+	private function importParsedGraph(array $schemeNode, array $conceptNodes): array {
 		$schemeUuid = $this->upsertScheme(node: $schemeNode);
 		$schemeUri = (string)$schemeNode['@id'];
 
@@ -238,13 +238,13 @@ class VocabularyImportService {
 		$seenUris = [];
 		$uuidByUri = [];
 
-		foreach ($draftNodes as $node) {
+		foreach ($conceptNodes as $node) {
 			$uri = (string)($node['@id'] ?? '');
 			if ($uri === '') {
 				continue;
 			}
 
-			$result = $this->upsertDraft(node: $node, schemeUuid: $schemeUuid);
+			$result = $this->upsertConcept(node: $node, schemeUuid: $schemeUuid);
 			$seenUris[] = $uri;
 			$uuidByUri[$uri] = $result['uuid'];
 			match ($result['status']) {
@@ -254,7 +254,7 @@ class VocabularyImportService {
 			};
 		}
 
-		$this->applyRelations(draftNodes: $draftNodes, uuidByUri: $uuidByUri);
+		$this->applyRelations(conceptNodes: $conceptNodes, uuidByUri: $uuidByUri);
 		$deprecated = $this->deprecateMissing(schemeUuid: $schemeUuid, seenUris: $seenUris);
 
 		$this->logger->info(
@@ -349,10 +349,10 @@ class VocabularyImportService {
 	 *
 	 * @throws InvalidArgumentException When the concept has no Dutch prefLabel.
 	 */
-	private function upsertDraft(array $node, string $schemeUuid): array {
+	private function upsertConcept(array $node, string $schemeUuid): array {
 		$uri = (string)$node['@id'];
 
-		$prefLabel = $this->extractLongMap(value: $this->findPredicate(node: $node, localName: 'prefLabel'));
+		$prefLabel = $this->extractLangMap(value: $this->findPredicate(node: $node, localName: 'prefLabel'));
 		if (isset($prefLabel['nl']) === false || trim($prefLabel['nl']) === '') {
 			throw new InvalidArgumentException(
 				sprintf('Concept "%s" has no Dutch (nl) prefLabel; refusing to import an invalid concept.', $uri)
@@ -366,7 +366,7 @@ class VocabularyImportService {
 			'deprecated' => false,
 		];
 
-		$altLabel = $this->extractLongMap(value: $this->findPredicate(node: $node, localName: 'altLabel'));
+		$altLabel = $this->extractLangMap(value: $this->findPredicate(node: $node, localName: 'altLabel'));
 		if (empty($altLabel) === false) {
 			$data['altLabel'] = $altLabel;
 		}
@@ -415,12 +415,12 @@ class VocabularyImportService {
 	 * concept absent from the re-imported source keeps its last-known edges
 	 * (it is deprecated, not edited) per design.md D3.
 	 *
-	 * @param array<int,array<string,mixed>> $draftNodes The parsed concept nodes.
+	 * @param array<int,array<string,mixed>> $conceptNodes The parsed concept nodes.
 	 * @param array<string,string> $uuidByUri uri => uuid map for this import.
 	 *
 	 * @return void
 	 */
-	private function applyRelations(array $draftNodes, array $uuidByUri): void {
+	private function applyRelations(array $conceptNodes, array $uuidByUri): void {
 		$broaderOf = [];
 		$narrowerOf = [];
 		$relatedOf = [];
@@ -433,7 +433,7 @@ class VocabularyImportService {
 			$relatedOf[$uuid] = ($relatedOf[$uuid] ?? []);
 		}
 
-		foreach ($draftNodes as $node) {
+		foreach ($conceptNodes as $node) {
 			$uri = (string)($node['@id'] ?? '');
 			$uuid = ($uuidByUri[$uri] ?? null);
 			if ($uuid === null) {
@@ -744,7 +744,7 @@ class VocabularyImportService {
 	 *
 	 * @return array<string,string> BCP-47 tag => label.
 	 */
-	private function extractLongMap(mixed $value): array {
+	private function extractLangMap(mixed $value): array {
 		if ($value === null) {
 			return [];
 		}

--- a/lib/Settings/ori_register.json
+++ b/lib/Settings/ori_register.json
@@ -48,7 +48,7 @@
         "required": [
           "naam",
           "type",
-          "startDatum"
+          "startDate"
         ],
         "properties": {
           "naam": {
@@ -81,13 +81,13 @@
             "facetable": true,
             "title": "Status"
           },
-          "startDatum": {
+          "startDate": {
             "type": "string",
             "format": "date-time",
             "description": "Start date and time of the meeting",
             "title": "Start Date"
           },
-          "eindDatum": {
+          "endDate": {
             "type": "string",
             "format": "date-time",
             "description": "End date and time of the meeting",
@@ -100,7 +100,7 @@
             "facetable": true,
             "title": "Location"
           },
-          "organisatie": {
+          "organisation": {
             "type": "string",
             "description": "Organization reference (municipality or body)",
             "maxLength": 255,
@@ -162,7 +162,7 @@
             "facetable": true,
             "title": "Meeting"
           },
-          "bovenliggendAgendapunt": {
+          "parentAgendaItem": {
             "type": "string",
             "description": "Reference to a parent agenda item for sub-items",
             "title": "Parent Agenda Item"
@@ -218,7 +218,7 @@
             "facetable": true,
             "title": "Document Type"
           },
-          "classificatie": {
+          "classification": {
             "type": "string",
             "description": "Category or classification of the document",
             "maxLength": 255,
@@ -232,13 +232,13 @@
             "maxLength": 500,
             "title": "Document URL"
           },
-          "bestandsnaam": {
+          "fileName": {
             "type": "string",
             "description": "File name of the document",
             "maxLength": 255,
             "title": "File Name"
           },
-          "bestandsgrootte": {
+          "fileSize": {
             "type": "integer",
             "description": "File size in bytes",
             "minimum": 0,
@@ -269,9 +269,9 @@
         "description": "Represents a formal vote taken during a council meeting. Contains the subject, result, vote counts, and per-party breakdown of the voting results.",
         "required": [
           "onderwerp",
-          "resultaat",
-          "stemmenVoor",
-          "stemmenTegen"
+          "result",
+          "votesFor",
+          "votesAgainst"
         ],
         "properties": {
           "onderwerp": {
@@ -288,7 +288,7 @@
             "facetable": true,
             "title": "Vote Type"
           },
-          "resultaat": {
+          "result": {
             "type": "string",
             "description": "Outcome of the vote",
             "enum": [
@@ -304,25 +304,25 @@
             "facetable": true,
             "title": "Agenda Item"
           },
-          "stemmenVoor": {
+          "votesFor": {
             "type": "integer",
             "description": "Number of votes in favor",
             "minimum": 0,
             "title": "Votes In Favour"
           },
-          "stemmenTegen": {
+          "votesAgainst": {
             "type": "integer",
             "description": "Number of votes against",
             "minimum": 0,
             "title": "Votes Against"
           },
-          "onthoudingen": {
+          "abstentions": {
             "type": "integer",
             "description": "Number of abstentions",
             "minimum": 0,
             "title": "Abstentions"
           },
-          "fractieResultaten": {
+          "politicalGroupResults": {
             "type": "array",
             "description": "Per-party voting results",
             "items": {
@@ -333,7 +333,7 @@
                   "description": "Party name",
                   "title": "Party Name"
                 },
-                "stem": {
+                "vote": {
                   "type": "string",
                   "description": "Vote cast by this party",
                   "enum": [
@@ -372,7 +372,7 @@
         "required": [
           "naam",
           "fractie",
-          "functie"
+          "role"
         ],
         "properties": {
           "person": {
@@ -396,7 +396,7 @@
             "facetable": true,
             "title": "Party"
           },
-          "functie": {
+          "role": {
             "type": "string",
             "description": "Function or role of this person",
             "enum": [
@@ -449,7 +449,7 @@
             "minimum": 0,
             "title": "Seats"
           },
-          "classificatie": {
+          "classification": {
             "type": "string",
             "description": "Role of the party in the council",
             "enum": [
@@ -478,7 +478,7 @@
         },
         "naam": "Voorbeeldstad Vooruit",
         "zetels": 8,
-        "classificatie": "coalitiepartij"
+        "classification": "coalitiepartij"
       },
       {
         "@self": {
@@ -488,7 +488,7 @@
         },
         "naam": "Groen Links Voorbeeldstad",
         "zetels": 6,
-        "classificatie": "coalitiepartij"
+        "classification": "coalitiepartij"
       },
       {
         "@self": {
@@ -498,7 +498,7 @@
         },
         "naam": "Democraten Voorbeeldstad",
         "zetels": 5,
-        "classificatie": "coalitiepartij"
+        "classification": "coalitiepartij"
       },
       {
         "@self": {
@@ -508,7 +508,7 @@
         },
         "naam": "Lokaal Belang",
         "zetels": 5,
-        "classificatie": "oppositiepartij"
+        "classification": "oppositiepartij"
       },
       {
         "@self": {
@@ -518,7 +518,7 @@
         },
         "naam": "PvdA Voorbeeldstad",
         "zetels": 4,
-        "classificatie": "oppositiepartij"
+        "classification": "oppositiepartij"
       },
       {
         "@self": {
@@ -528,7 +528,7 @@
         },
         "naam": "VVD Voorbeeldstad",
         "zetels": 3,
-        "classificatie": "oppositiepartij"
+        "classification": "oppositiepartij"
       },
       {
         "@self": {
@@ -538,7 +538,7 @@
         },
         "naam": "SP Voorbeeldstad",
         "zetels": 2,
-        "classificatie": "oppositiepartij"
+        "classification": "oppositiepartij"
       },
       {
         "@self": {
@@ -548,7 +548,7 @@
         },
         "naam": "Forum Voorbeeldstad",
         "zetels": 2,
-        "classificatie": "oppositiepartij"
+        "classification": "oppositiepartij"
       },
       {
         "@self": {
@@ -558,7 +558,7 @@
         },
         "naam": "Jan-Willem van Doesburg",
         "fractie": "voorbeeldstad-vooruit",
-        "functie": "burgemeester",
+        "role": "burgemeester",
         "actief": true
       },
       {
@@ -569,7 +569,7 @@
         },
         "naam": "Maria Bakker-de Wit",
         "fractie": "groen-links-voorbeeldstad",
-        "functie": "wethouder",
+        "role": "wethouder",
         "actief": true
       },
       {
@@ -580,7 +580,7 @@
         },
         "naam": "Ahmed El-Mansouri",
         "fractie": "democraten-voorbeeldstad",
-        "functie": "wethouder",
+        "role": "wethouder",
         "actief": true
       },
       {
@@ -591,7 +591,7 @@
         },
         "naam": "Petra Koopmans",
         "fractie": "voorbeeldstad-vooruit",
-        "functie": "wethouder",
+        "role": "wethouder",
         "actief": true
       },
       {
@@ -602,7 +602,7 @@
         },
         "naam": "Henk van der Berg",
         "fractie": "voorbeeldstad-vooruit",
-        "functie": "griffier",
+        "role": "griffier",
         "actief": true
       },
       {
@@ -613,7 +613,7 @@
         },
         "naam": "Klaas de Vries",
         "fractie": "voorbeeldstad-vooruit",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -624,7 +624,7 @@
         },
         "naam": "Sandra Jansen",
         "fractie": "voorbeeldstad-vooruit",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -635,7 +635,7 @@
         },
         "naam": "Tom Willems",
         "fractie": "voorbeeldstad-vooruit",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -646,7 +646,7 @@
         },
         "naam": "Annemiek van Rijn",
         "fractie": "voorbeeldstad-vooruit",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -657,7 +657,7 @@
         },
         "naam": "Bas Vermeulen",
         "fractie": "voorbeeldstad-vooruit",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -668,7 +668,7 @@
         },
         "naam": "Lisa de Groot",
         "fractie": "groen-links-voorbeeldstad",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -679,7 +679,7 @@
         },
         "naam": "Robin Smit",
         "fractie": "groen-links-voorbeeldstad",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -690,7 +690,7 @@
         },
         "naam": "Fatima Bouazza",
         "fractie": "groen-links-voorbeeldstad",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -701,7 +701,7 @@
         },
         "naam": "Jeroen Bos",
         "fractie": "groen-links-voorbeeldstad",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -712,7 +712,7 @@
         },
         "naam": "Marieke Scholten",
         "fractie": "democraten-voorbeeldstad",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -723,7 +723,7 @@
         },
         "naam": "Pieter van Dijk",
         "fractie": "democraten-voorbeeldstad",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -734,7 +734,7 @@
         },
         "naam": "Eva Mulder",
         "fractie": "democraten-voorbeeldstad",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -745,7 +745,7 @@
         },
         "naam": "Dirk van Leeuwen",
         "fractie": "lokaal-belang",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -756,7 +756,7 @@
         },
         "naam": "Ria ter Horst",
         "fractie": "lokaal-belang",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -767,7 +767,7 @@
         },
         "naam": "Jan Kramer",
         "fractie": "lokaal-belang",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -778,7 +778,7 @@
         },
         "naam": "Nienke Brouwer",
         "fractie": "lokaal-belang",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -789,7 +789,7 @@
         },
         "naam": "Gerard Visser",
         "fractie": "lokaal-belang",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -800,7 +800,7 @@
         },
         "naam": "Monique Peters",
         "fractie": "pvda-voorbeeldstad",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -811,7 +811,7 @@
         },
         "naam": "Willem Hendriks",
         "fractie": "pvda-voorbeeldstad",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -822,7 +822,7 @@
         },
         "naam": "Denise van Dam",
         "fractie": "pvda-voorbeeldstad",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -833,7 +833,7 @@
         },
         "naam": "Frank de Boer",
         "fractie": "pvda-voorbeeldstad",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -844,7 +844,7 @@
         },
         "naam": "Caroline van den Heuvel",
         "fractie": "vvd-voorbeeldstad",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -855,7 +855,7 @@
         },
         "naam": "Robert Dekker",
         "fractie": "vvd-voorbeeldstad",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -866,7 +866,7 @@
         },
         "naam": "Els van der Linden",
         "fractie": "vvd-voorbeeldstad",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -877,7 +877,7 @@
         },
         "naam": "Marco Kuijpers",
         "fractie": "sp-voorbeeldstad",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -888,7 +888,7 @@
         },
         "naam": "Ingrid Wolf",
         "fractie": "sp-voorbeeldstad",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -899,7 +899,7 @@
         },
         "naam": "Hans van Beek",
         "fractie": "forum-voorbeeldstad",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -910,7 +910,7 @@
         },
         "naam": "Tineke Groen",
         "fractie": "forum-voorbeeldstad",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": true
       },
       {
@@ -921,7 +921,7 @@
         },
         "naam": "Wim van Houten",
         "fractie": "voorbeeldstad-vooruit",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": false
       },
       {
@@ -932,7 +932,7 @@
         },
         "naam": "Joke Meijer",
         "fractie": "lokaal-belang",
-        "functie": "raadslid",
+        "role": "raadslid",
         "actief": false
       },
       {
@@ -944,10 +944,10 @@
         "naam": "Raadsvergadering 2 september 2025",
         "type": "raadsvergadering",
         "status": "bevestigd",
-        "startDatum": "2025-09-02T19:00:00+02:00",
-        "eindDatum": "2025-09-02T22:30:00+02:00",
+        "startDate": "2025-09-02T19:00:00+02:00",
+        "endDate": "2025-09-02T22:30:00+02:00",
         "locatie": "Raadzaal, Gemeentehuis Voorbeeldstad",
-        "organisatie": "Gemeente Voorbeeldstad"
+        "organisation": "Gemeente Voorbeeldstad"
       },
       {
         "@self": {
@@ -958,10 +958,10 @@
         "naam": "Commissie Mens & Samenleving 11 september 2025",
         "type": "commissievergadering",
         "status": "bevestigd",
-        "startDatum": "2025-09-11T20:00:00+02:00",
-        "eindDatum": "2025-09-11T22:00:00+02:00",
+        "startDate": "2025-09-11T20:00:00+02:00",
+        "endDate": "2025-09-11T22:00:00+02:00",
         "locatie": "Raadzaal, Gemeentehuis Voorbeeldstad",
-        "organisatie": "Gemeente Voorbeeldstad",
+        "organisation": "Gemeente Voorbeeldstad",
         "commissie": "Commissie Mens & Samenleving"
       },
       {
@@ -973,10 +973,10 @@
         "naam": "Raadsvergadering 16 september 2025",
         "type": "raadsvergadering",
         "status": "bevestigd",
-        "startDatum": "2025-09-16T19:00:00+02:00",
-        "eindDatum": "2025-09-16T22:00:00+02:00",
+        "startDate": "2025-09-16T19:00:00+02:00",
+        "endDate": "2025-09-16T22:00:00+02:00",
         "locatie": "Raadzaal, Gemeentehuis Voorbeeldstad",
-        "organisatie": "Gemeente Voorbeeldstad"
+        "organisation": "Gemeente Voorbeeldstad"
       },
       {
         "@self": {
@@ -987,10 +987,10 @@
         "naam": "Raadsvergadering 7 oktober 2025",
         "type": "raadsvergadering",
         "status": "bevestigd",
-        "startDatum": "2025-10-07T19:00:00+02:00",
-        "eindDatum": "2025-10-07T22:00:00+02:00",
+        "startDate": "2025-10-07T19:00:00+02:00",
+        "endDate": "2025-10-07T22:00:00+02:00",
         "locatie": "Raadzaal, Gemeentehuis Voorbeeldstad",
-        "organisatie": "Gemeente Voorbeeldstad"
+        "organisation": "Gemeente Voorbeeldstad"
       },
       {
         "@self": {
@@ -1001,10 +1001,10 @@
         "naam": "Commissie Ruimte & Economie 9 oktober 2025",
         "type": "commissievergadering",
         "status": "bevestigd",
-        "startDatum": "2025-10-09T20:00:00+02:00",
-        "eindDatum": "2025-10-09T22:00:00+02:00",
+        "startDate": "2025-10-09T20:00:00+02:00",
+        "endDate": "2025-10-09T22:00:00+02:00",
         "locatie": "Raadzaal, Gemeentehuis Voorbeeldstad",
-        "organisatie": "Gemeente Voorbeeldstad",
+        "organisation": "Gemeente Voorbeeldstad",
         "commissie": "Commissie Ruimte & Economie"
       },
       {
@@ -1016,10 +1016,10 @@
         "naam": "Raadsvergadering 21 oktober 2025 (Begrotingsbehandeling)",
         "type": "raadsvergadering",
         "status": "bevestigd",
-        "startDatum": "2025-10-21T19:00:00+02:00",
-        "eindDatum": "2025-10-21T23:00:00+02:00",
+        "startDate": "2025-10-21T19:00:00+02:00",
+        "endDate": "2025-10-21T23:00:00+02:00",
         "locatie": "Raadzaal, Gemeentehuis Voorbeeldstad",
-        "organisatie": "Gemeente Voorbeeldstad"
+        "organisation": "Gemeente Voorbeeldstad"
       },
       {
         "@self": {
@@ -1030,10 +1030,10 @@
         "naam": "Raadsvergadering 4 november 2025",
         "type": "raadsvergadering",
         "status": "bevestigd",
-        "startDatum": "2025-11-04T19:00:00+01:00",
-        "eindDatum": "2025-11-04T22:00:00+01:00",
+        "startDate": "2025-11-04T19:00:00+01:00",
+        "endDate": "2025-11-04T22:00:00+01:00",
         "locatie": "Raadzaal, Gemeentehuis Voorbeeldstad",
-        "organisatie": "Gemeente Voorbeeldstad"
+        "organisation": "Gemeente Voorbeeldstad"
       },
       {
         "@self": {
@@ -1044,10 +1044,10 @@
         "naam": "Commissie Bestuur & Financien 13 november 2025",
         "type": "commissievergadering",
         "status": "bevestigd",
-        "startDatum": "2025-11-13T20:00:00+01:00",
-        "eindDatum": "2025-11-13T22:00:00+01:00",
+        "startDate": "2025-11-13T20:00:00+01:00",
+        "endDate": "2025-11-13T22:00:00+01:00",
         "locatie": "Raadzaal, Gemeentehuis Voorbeeldstad",
-        "organisatie": "Gemeente Voorbeeldstad",
+        "organisation": "Gemeente Voorbeeldstad",
         "commissie": "Commissie Bestuur & Financien"
       },
       {
@@ -1059,10 +1059,10 @@
         "naam": "Raadsvergadering 2 december 2025",
         "type": "raadsvergadering",
         "status": "bevestigd",
-        "startDatum": "2025-12-02T19:00:00+01:00",
-        "eindDatum": "2025-12-02T22:00:00+01:00",
+        "startDate": "2025-12-02T19:00:00+01:00",
+        "endDate": "2025-12-02T22:00:00+01:00",
         "locatie": "Raadzaal, Gemeentehuis Voorbeeldstad",
-        "organisatie": "Gemeente Voorbeeldstad"
+        "organisation": "Gemeente Voorbeeldstad"
       },
       {
         "@self": {
@@ -1073,10 +1073,10 @@
         "naam": "Raadsvergadering 14 januari 2026 (Nieuwjaar)",
         "type": "raadsvergadering",
         "status": "gepland",
-        "startDatum": "2026-01-14T19:00:00+01:00",
-        "eindDatum": "2026-01-14T22:00:00+01:00",
+        "startDate": "2026-01-14T19:00:00+01:00",
+        "endDate": "2026-01-14T22:00:00+01:00",
         "locatie": "Raadzaal, Gemeentehuis Voorbeeldstad",
-        "organisatie": "Gemeente Voorbeeldstad"
+        "organisation": "Gemeente Voorbeeldstad"
       },
       {
         "@self": {
@@ -1564,10 +1564,10 @@
         },
         "titel": "Motie: Extra budget jeugdzorg",
         "type": "motie",
-        "classificatie": "jeugdzorg",
+        "classification": "jeugdzorg",
         "url": "https://voorbeeldstad.nl/raad/documenten/motie-extra-budget-jeugdzorg.pdf",
-        "bestandsnaam": "motie-extra-budget-jeugdzorg.pdf",
-        "bestandsgrootte": 124500,
+        "fileName": "motie-extra-budget-jeugdzorg.pdf",
+        "fileSize": 124500,
         "inhoudType": "application/pdf"
       },
       {
@@ -1578,10 +1578,10 @@
         },
         "titel": "Motie: Onderzoek versnelling woningbouw",
         "type": "motie",
-        "classificatie": "woningbouw",
+        "classification": "woningbouw",
         "url": "https://voorbeeldstad.nl/raad/documenten/motie-onderzoek-woningbouw.pdf",
-        "bestandsnaam": "motie-onderzoek-woningbouw.pdf",
-        "bestandsgrootte": 98200,
+        "fileName": "motie-onderzoek-woningbouw.pdf",
+        "fileSize": 98200,
         "inhoudType": "application/pdf"
       },
       {
@@ -1592,10 +1592,10 @@
         },
         "titel": "Motie: Gemeentelijk vuurwerkverbod jaarwisseling 2025-2026",
         "type": "motie",
-        "classificatie": "openbare orde",
+        "classification": "openbare orde",
         "url": "https://voorbeeldstad.nl/raad/documenten/motie-vuurwerkverbod.pdf",
-        "bestandsnaam": "motie-vuurwerkverbod.pdf",
-        "bestandsgrootte": 87300,
+        "fileName": "motie-vuurwerkverbod.pdf",
+        "fileSize": 87300,
         "inhoudType": "application/pdf"
       },
       {
@@ -1606,10 +1606,10 @@
         },
         "titel": "Amendement: Verlaging OZB-verhoging van 5% naar 2%",
         "type": "amendement",
-        "classificatie": "financien",
+        "classification": "financien",
         "url": "https://voorbeeldstad.nl/raad/documenten/amendement-verlaging-ozb.pdf",
-        "bestandsnaam": "amendement-verlaging-ozb.pdf",
-        "bestandsgrootte": 76800,
+        "fileName": "amendement-verlaging-ozb.pdf",
+        "fileSize": 76800,
         "inhoudType": "application/pdf"
       },
       {
@@ -1620,10 +1620,10 @@
         },
         "titel": "Amendement: Aanpassing ontwerp herinrichting marktplein",
         "type": "amendement",
-        "classificatie": "ruimtelijke ordening",
+        "classification": "ruimtelijke ordening",
         "url": "https://voorbeeldstad.nl/raad/documenten/amendement-herinrichting-marktplein.pdf",
-        "bestandsnaam": "amendement-herinrichting-marktplein.pdf",
-        "bestandsgrootte": 134200,
+        "fileName": "amendement-herinrichting-marktplein.pdf",
+        "fileSize": 134200,
         "inhoudType": "application/pdf"
       },
       {
@@ -1634,10 +1634,10 @@
         },
         "titel": "Besluit: Herinrichting marktplein Voorbeeldstad",
         "type": "besluit",
-        "classificatie": "ruimtelijke ordening",
+        "classification": "ruimtelijke ordening",
         "url": "https://voorbeeldstad.nl/raad/documenten/besluit-herinrichting-marktplein.pdf",
-        "bestandsnaam": "besluit-herinrichting-marktplein.pdf",
-        "bestandsgrootte": 215600,
+        "fileName": "besluit-herinrichting-marktplein.pdf",
+        "fileSize": 215600,
         "inhoudType": "application/pdf"
       },
       {
@@ -1648,10 +1648,10 @@
         },
         "titel": "Besluit: Vaststelling subsidieregeling duurzame energie 2025-2026",
         "type": "besluit",
-        "classificatie": "duurzaamheid",
+        "classification": "duurzaamheid",
         "url": "https://voorbeeldstad.nl/raad/documenten/besluit-subsidieregeling-duurzame-energie.pdf",
-        "bestandsnaam": "besluit-subsidieregeling-duurzame-energie.pdf",
-        "bestandsgrootte": 189400,
+        "fileName": "besluit-subsidieregeling-duurzame-energie.pdf",
+        "fileSize": 189400,
         "inhoudType": "application/pdf"
       },
       {
@@ -1662,10 +1662,10 @@
         },
         "titel": "Besluit: Vaststelling bestemmingsplan buitengebied Voorbeeldstad",
         "type": "besluit",
-        "classificatie": "ruimtelijke ordening",
+        "classification": "ruimtelijke ordening",
         "url": "https://voorbeeldstad.nl/raad/documenten/besluit-bestemmingsplan-buitengebied.pdf",
-        "bestandsnaam": "besluit-bestemmingsplan-buitengebied.pdf",
-        "bestandsgrootte": 456700,
+        "fileName": "besluit-bestemmingsplan-buitengebied.pdf",
+        "fileSize": 456700,
         "inhoudType": "application/pdf"
       },
       {
@@ -1676,10 +1676,10 @@
         },
         "titel": "Brief college: Stand van zaken jeugdzorg en wachtlijsten",
         "type": "brief",
-        "classificatie": "jeugdzorg",
+        "classification": "jeugdzorg",
         "url": "https://voorbeeldstad.nl/raad/documenten/brief-college-jeugdzorg.pdf",
-        "bestandsnaam": "brief-college-jeugdzorg.pdf",
-        "bestandsgrootte": 67800,
+        "fileName": "brief-college-jeugdzorg.pdf",
+        "fileSize": 67800,
         "inhoudType": "application/pdf"
       },
       {
@@ -1690,10 +1690,10 @@
         },
         "titel": "Brief inwoners: Bezwaren herinrichting marktplein",
         "type": "brief",
-        "classificatie": "ruimtelijke ordening",
+        "classification": "ruimtelijke ordening",
         "url": "https://voorbeeldstad.nl/raad/documenten/brief-inwoners-marktplein.pdf",
-        "bestandsnaam": "brief-inwoners-marktplein.pdf",
-        "bestandsgrootte": 34500,
+        "fileName": "brief-inwoners-marktplein.pdf",
+        "fileSize": 34500,
         "inhoudType": "application/pdf"
       },
       {
@@ -1704,10 +1704,10 @@
         },
         "titel": "Brief Provincie: Reactie op bestemmingsplan buitengebied",
         "type": "brief",
-        "classificatie": "ruimtelijke ordening",
+        "classification": "ruimtelijke ordening",
         "url": "https://voorbeeldstad.nl/raad/documenten/brief-provincie-buitengebied.pdf",
-        "bestandsnaam": "brief-provincie-buitengebied.pdf",
-        "bestandsgrootte": 52100,
+        "fileName": "brief-provincie-buitengebied.pdf",
+        "fileSize": 52100,
         "inhoudType": "application/pdf"
       },
       {
@@ -1718,10 +1718,10 @@
         },
         "titel": "Rapport: Jaarrekening 2024 gemeente Voorbeeldstad",
         "type": "rapport",
-        "classificatie": "financien",
+        "classification": "financien",
         "url": "https://voorbeeldstad.nl/raad/documenten/rapport-jaarrekening-2024.pdf",
-        "bestandsnaam": "rapport-jaarrekening-2024.pdf",
-        "bestandsgrootte": 1245000,
+        "fileName": "rapport-jaarrekening-2024.pdf",
+        "fileSize": 1245000,
         "inhoudType": "application/pdf"
       },
       {
@@ -1732,10 +1732,10 @@
         },
         "titel": "Rapport: Woningbouwmonitor Voorbeeldstad 2025",
         "type": "rapport",
-        "classificatie": "woningbouw",
+        "classification": "woningbouw",
         "url": "https://voorbeeldstad.nl/raad/documenten/rapport-woningbouwmonitor.pdf",
-        "bestandsnaam": "rapport-woningbouwmonitor.pdf",
-        "bestandsgrootte": 876500,
+        "fileName": "rapport-woningbouwmonitor.pdf",
+        "fileSize": 876500,
         "inhoudType": "application/pdf"
       },
       {
@@ -1746,10 +1746,10 @@
         },
         "titel": "Notulen raadsvergadering 2 september 2025",
         "type": "notulen",
-        "classificatie": "verslaglegging",
+        "classification": "verslaglegging",
         "url": "https://voorbeeldstad.nl/raad/documenten/notulen-raad-2025-09-02.pdf",
-        "bestandsnaam": "notulen-raad-2025-09-02.pdf",
-        "bestandsgrootte": 345600,
+        "fileName": "notulen-raad-2025-09-02.pdf",
+        "fileSize": 345600,
         "inhoudType": "application/pdf"
       },
       {
@@ -1760,10 +1760,10 @@
         },
         "titel": "Notulen raadsvergadering 21 oktober 2025 (Begrotingsbehandeling)",
         "type": "notulen",
-        "classificatie": "verslaglegging",
+        "classification": "verslaglegging",
         "url": "https://voorbeeldstad.nl/raad/documenten/notulen-raad-2025-10-21.pdf",
-        "bestandsnaam": "notulen-raad-2025-10-21.pdf",
-        "bestandsgrootte": 567800,
+        "fileName": "notulen-raad-2025-10-21.pdf",
+        "fileSize": 567800,
         "inhoudType": "application/pdf"
       },
       {
@@ -1774,50 +1774,50 @@
         },
         "onderwerp": "Voorstel: Herinrichting marktplein Voorbeeldstad",
         "type": "voorstel",
-        "resultaat": "aangenomen",
+        "result": "aangenomen",
         "agendapunt": "raad-20250902-04-herinrichting-marktplein",
-        "stemmenVoor": 19,
-        "stemmenTegen": 16,
-        "onthoudingen": 0,
-        "fractieResultaten": [
+        "votesFor": 19,
+        "votesAgainst": 16,
+        "abstentions": 0,
+        "politicalGroupResults": [
           {
             "fractie": "Voorbeeldstad Vooruit",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 8
           },
           {
             "fractie": "Groen Links Voorbeeldstad",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 6
           },
           {
             "fractie": "Democraten Voorbeeldstad",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 5
           },
           {
             "fractie": "Lokaal Belang",
-            "stem": "tegen",
+            "vote": "tegen",
             "zetels": 5
           },
           {
             "fractie": "PvdA Voorbeeldstad",
-            "stem": "tegen",
+            "vote": "tegen",
             "zetels": 4
           },
           {
             "fractie": "VVD Voorbeeldstad",
-            "stem": "tegen",
+            "vote": "tegen",
             "zetels": 3
           },
           {
             "fractie": "SP Voorbeeldstad",
-            "stem": "tegen",
+            "vote": "tegen",
             "zetels": 2
           },
           {
             "fractie": "Forum Voorbeeldstad",
-            "stem": "tegen",
+            "vote": "tegen",
             "zetels": 2
           }
         ]
@@ -1830,50 +1830,50 @@
         },
         "onderwerp": "Voorstel: Subsidieregeling duurzame energie 2025-2026",
         "type": "voorstel",
-        "resultaat": "aangenomen",
+        "result": "aangenomen",
         "agendapunt": "raad-20250902-05-subsidie-duurzame-energie",
-        "stemmenVoor": 25,
-        "stemmenTegen": 10,
-        "onthoudingen": 0,
-        "fractieResultaten": [
+        "votesFor": 25,
+        "votesAgainst": 10,
+        "abstentions": 0,
+        "politicalGroupResults": [
           {
             "fractie": "Voorbeeldstad Vooruit",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 8
           },
           {
             "fractie": "Groen Links Voorbeeldstad",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 6
           },
           {
             "fractie": "Democraten Voorbeeldstad",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 5
           },
           {
             "fractie": "Lokaal Belang",
-            "stem": "tegen",
+            "vote": "tegen",
             "zetels": 5
           },
           {
             "fractie": "PvdA Voorbeeldstad",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 4
           },
           {
             "fractie": "VVD Voorbeeldstad",
-            "stem": "tegen",
+            "vote": "tegen",
             "zetels": 3
           },
           {
             "fractie": "SP Voorbeeldstad",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 2
           },
           {
             "fractie": "Forum Voorbeeldstad",
-            "stem": "tegen",
+            "vote": "tegen",
             "zetels": 2
           }
         ]
@@ -1886,50 +1886,50 @@
         },
         "onderwerp": "Motie: Extra budget jeugdzorg",
         "type": "motie",
-        "resultaat": "aangenomen",
+        "result": "aangenomen",
         "agendapunt": "raad-20251021-04-motie-jeugdzorg",
-        "stemmenVoor": 23,
-        "stemmenTegen": 12,
-        "onthoudingen": 0,
-        "fractieResultaten": [
+        "votesFor": 23,
+        "votesAgainst": 12,
+        "abstentions": 0,
+        "politicalGroupResults": [
           {
             "fractie": "Voorbeeldstad Vooruit",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 8
           },
           {
             "fractie": "Groen Links Voorbeeldstad",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 6
           },
           {
             "fractie": "Democraten Voorbeeldstad",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 5
           },
           {
             "fractie": "Lokaal Belang",
-            "stem": "tegen",
+            "vote": "tegen",
             "zetels": 5
           },
           {
             "fractie": "PvdA Voorbeeldstad",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 4
           },
           {
             "fractie": "VVD Voorbeeldstad",
-            "stem": "tegen",
+            "vote": "tegen",
             "zetels": 3
           },
           {
             "fractie": "SP Voorbeeldstad",
-            "stem": "tegen",
+            "vote": "tegen",
             "zetels": 2
           },
           {
             "fractie": "Forum Voorbeeldstad",
-            "stem": "tegen",
+            "vote": "tegen",
             "zetels": 2
           }
         ]
@@ -1942,50 +1942,50 @@
         },
         "onderwerp": "Amendement: Verlaging OZB-verhoging van 5% naar 2%",
         "type": "amendement",
-        "resultaat": "verworpen",
+        "result": "verworpen",
         "agendapunt": "raad-20251021-05-amendement-ozb",
-        "stemmenVoor": 10,
-        "stemmenTegen": 25,
-        "onthoudingen": 0,
-        "fractieResultaten": [
+        "votesFor": 10,
+        "votesAgainst": 25,
+        "abstentions": 0,
+        "politicalGroupResults": [
           {
             "fractie": "Voorbeeldstad Vooruit",
-            "stem": "tegen",
+            "vote": "tegen",
             "zetels": 8
           },
           {
             "fractie": "Groen Links Voorbeeldstad",
-            "stem": "tegen",
+            "vote": "tegen",
             "zetels": 6
           },
           {
             "fractie": "Democraten Voorbeeldstad",
-            "stem": "tegen",
+            "vote": "tegen",
             "zetels": 5
           },
           {
             "fractie": "Lokaal Belang",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 5
           },
           {
             "fractie": "PvdA Voorbeeldstad",
-            "stem": "tegen",
+            "vote": "tegen",
             "zetels": 4
           },
           {
             "fractie": "VVD Voorbeeldstad",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 3
           },
           {
             "fractie": "SP Voorbeeldstad",
-            "stem": "tegen",
+            "vote": "tegen",
             "zetels": 2
           },
           {
             "fractie": "Forum Voorbeeldstad",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 2
           }
         ]
@@ -1998,50 +1998,50 @@
         },
         "onderwerp": "Motie: Onderzoek versnelling woningbouw",
         "type": "motie",
-        "resultaat": "aangenomen",
+        "result": "aangenomen",
         "agendapunt": "raad-20251021-06-motie-woningbouw",
-        "stemmenVoor": 35,
-        "stemmenTegen": 0,
-        "onthoudingen": 0,
-        "fractieResultaten": [
+        "votesFor": 35,
+        "votesAgainst": 0,
+        "abstentions": 0,
+        "politicalGroupResults": [
           {
             "fractie": "Voorbeeldstad Vooruit",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 8
           },
           {
             "fractie": "Groen Links Voorbeeldstad",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 6
           },
           {
             "fractie": "Democraten Voorbeeldstad",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 5
           },
           {
             "fractie": "Lokaal Belang",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 5
           },
           {
             "fractie": "PvdA Voorbeeldstad",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 4
           },
           {
             "fractie": "VVD Voorbeeldstad",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 3
           },
           {
             "fractie": "SP Voorbeeldstad",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 2
           },
           {
             "fractie": "Forum Voorbeeldstad",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 2
           }
         ]
@@ -2054,50 +2054,50 @@
         },
         "onderwerp": "Voorstel: Bestemmingsplan buitengebied Voorbeeldstad",
         "type": "voorstel",
-        "resultaat": "aangenomen",
+        "result": "aangenomen",
         "agendapunt": "raad-20250902-06-bestemmingsplan",
-        "stemmenVoor": 27,
-        "stemmenTegen": 8,
-        "onthoudingen": 0,
-        "fractieResultaten": [
+        "votesFor": 27,
+        "votesAgainst": 8,
+        "abstentions": 0,
+        "politicalGroupResults": [
           {
             "fractie": "Voorbeeldstad Vooruit",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 8
           },
           {
             "fractie": "Groen Links Voorbeeldstad",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 6
           },
           {
             "fractie": "Democraten Voorbeeldstad",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 5
           },
           {
             "fractie": "Lokaal Belang",
-            "stem": "tegen",
+            "vote": "tegen",
             "zetels": 5
           },
           {
             "fractie": "PvdA Voorbeeldstad",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 4
           },
           {
             "fractie": "VVD Voorbeeldstad",
-            "stem": "voor",
+            "vote": "voor",
             "zetels": 3
           },
           {
             "fractie": "SP Voorbeeldstad",
-            "stem": "tegen",
+            "vote": "tegen",
             "zetels": 2
           },
           {
             "fractie": "Forum Voorbeeldstad",
-            "stem": "tegen",
+            "vote": "tegen",
             "zetels": 1
           }
         ]

--- a/phpmd.baseline.xml
+++ b/phpmd.baseline.xml
@@ -474,7 +474,7 @@
   <violation rule="PHPMD\Rule\Design\NpathComplexity" file="lib/Service/WritePhaseProbe.php" method="flush"/>
   <violation rule="PHPMD\Rule\Controversial\Superglobals" file="lib/Service/WritePhaseProbe.php" method="flush"/>
   <violation rule="PHPMD\Rule\Naming\ShortVariable" file="lib/Service/WritePhaseProbe.php"/>
-  <violation rule="PHPMD\Rule\CleanCode\ElseExpression" file="lib/Service/ZaaktypeAuthorizationService.php"/>
+  <violation rule="PHPMD\Rule\CleanCode\ElseExpression" file="lib/Service/CaseTypeAuthorizationService.php"/>
   <violation rule="PHPMD\Rule\UnusedFormalParameter" file="lib/WorkflowEngine/RegisterObjectEntity.php"/>
   <violation rule="PHPMD\Rule\Design\CouplingBetweenObjects" file="lib/WorkflowEngine/RunFlowOperation.php"/>
   <violation rule="PHPMD\Rule\UnusedFormalParameter" file="lib/WorkflowEngine/RunFlowOperation.php"/>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4523,22 +4523,22 @@ parameters:
 		-
 			message: "#^Call to function array_is_list\\(\\) with array\\<string, mixed\\> will always evaluate to false\\.$#"
 			count: 1
-			path: lib/Service/Integration/Providers/BrpPersoonProvider.php
+			path: lib/Service/Integration/Providers/BrpPersonProvider.php
 
 		-
 			message: "#^Offset 'body' on array\\{body\\: array\\<string, mixed\\>, meta\\: array\\{status\\: int, durationMs\\: int, correlationId\\: string\\|null, headers\\: array\\<string, string\\>\\}\\} on left side of \\?\\? always exists and is not nullable\\.$#"
 			count: 1
-			path: lib/Service/Integration/Providers/BrpPersoonProvider.php
+			path: lib/Service/Integration/Providers/BrpPersonProvider.php
 
 		-
 			message: "#^Offset 'meta' on array\\{body\\: array\\<string, mixed\\>, meta\\: array\\{status\\: int, durationMs\\: int, correlationId\\: string\\|null, headers\\: array\\<string, string\\>\\}\\} on left side of \\?\\? always exists and is not nullable\\.$#"
 			count: 1
-			path: lib/Service/Integration/Providers/BrpPersoonProvider.php
+			path: lib/Service/Integration/Providers/BrpPersonProvider.php
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between false and true will always evaluate to false\\.$#"
 			count: 1
-			path: lib/Service/Integration/Providers/BrpPersoonProvider.php
+			path: lib/Service/Integration/Providers/BrpPersonProvider.php
 
 		-
 			message: "#^Offset 'results' on array\\{results\\: array, total\\: int\\} on left side of \\?\\? always exists and is not nullable\\.$#"
@@ -5868,7 +5868,7 @@ parameters:
 		-
 			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
 			count: 1
-			path: lib/Service/ZaaktypeAuthorizationService.php
+			path: lib/Service/CaseTypeAuthorizationService.php
 
 		-
 			message: "#^Property OCA\\\\OpenRegister\\\\Settings\\\\IntegrationsAdminSettings\\:\\:\\$l10n is never read, only written\\.$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -14,8 +14,8 @@
   </file>
   <file src="lib/BackgroundJob/DestructionCheckJob.php">
     <UnusedParam>
-      <code><![CDATA[$actieDate]]></code>
-      <code><![CDATA[$classificatie]]></code>
+      <code><![CDATA[$actionDate]]></code>
+      <code><![CDATA[$classification]]></code>
       <code><![CDATA[$listUuid]]></code>
       <code><![CDATA[$logger]]></code>
       <code><![CDATA[$logger]]></code>

--- a/src/views/avg/AvgIndex.spec.js
+++ b/src/views/avg/AvgIndex.spec.js
@@ -217,7 +217,7 @@ describe('AvgIndex — Cases surface', () => {
 		const ids = computedCall('tabs', {}).map((t) => t.id)
 		expect(ids).toEqual([
 			'activities',
-			'verantwoording',
+			'accountability',
 			'dsar',
 			'cases',
 			'compliance',

--- a/src/views/avg/AvgIndex.vue
+++ b/src/views/avg/AvgIndex.vue
@@ -143,10 +143,10 @@
 			</section>
 
 			<!-- Verantwoording -->
-			<section v-else-if="activeTab === 'verantwoording'">
+			<section v-else-if="activeTab === 'accountability'">
 				<div class="viewActionsBar">
 					<div class="viewInfo">
-						<span v-if="verantwoording" class="viewTotalCount">
+						<span v-if="accountability" class="viewTotalCount">
 							{{
 								t('openregister', 'Generated: {time}', {
 									time: formatTime(verantwoording.generated),
@@ -1193,7 +1193,7 @@ export default {
 					icon: 'ShieldLockOutline',
 				},
 				{
-					id: 'verantwoording',
+					id: 'accountability',
 					label: t('openregister', 'Verantwoording'),
 					icon: 'FileDocumentOutline',
 				},

--- a/tests/Service/AvgRetentionServiceIntegrationTest.php
+++ b/tests/Service/AvgRetentionServiceIntegrationTest.php
@@ -145,7 +145,7 @@ class AvgRetentionServiceIntegrationTest extends TestCase {
 	}//end tearDown()
 
 	public function testActivityWithoutBewaartermijnIsSkipped(): void {
-		$activity = $this->makeActivity(naam: 'phpunit-no-retention', bewaartermijn: null);
+		$activity = $this->makeActivity(name: 'phpunit-no-retention', retentionPeriod: null);
 		$object = $this->makeObjectFixture();
 
 		// Audit row 30 days in the past — would normally trigger
@@ -164,7 +164,7 @@ class AvgRetentionServiceIntegrationTest extends TestCase {
 	}//end testActivityWithoutBewaartermijnIsSkipped()
 
 	public function testMalformedBewaartermijnIsSkipped(): void {
-		$activity = $this->makeActivity(naam: 'phpunit-bad-iso', bewaartermijn: 'this-is-not-a-duration');
+		$activity = $this->makeActivity(name: 'phpunit-bad-iso', retentionPeriod: 'this-is-not-a-duration');
 		$object = $this->makeObjectFixture();
 		$this->insertSyntheticAuditRow(
 			object: $object,
@@ -188,7 +188,7 @@ class AvgRetentionServiceIntegrationTest extends TestCase {
 	}//end testMalformedBewaartermijnIsSkipped()
 
 	public function testDryRunReportsWithoutErasing(): void {
-		$activity = $this->makeActivity(naam: 'phpunit-dryrun-retention', bewaartermijn: 'P1D');
+		$activity = $this->makeActivity(name: 'phpunit-dryrun-retention', retentionPeriod: 'P1D');
 		$object = $this->makeObjectFixture();
 		$this->insertSyntheticAuditRow(
 			object: $object,
@@ -212,7 +212,7 @@ class AvgRetentionServiceIntegrationTest extends TestCase {
 	public function testRecentlyAuditedObjectsArePreserved(): void {
 		// 1-day bewaartermijn; audit row is 0 days old (today). Object
 		// MUST NOT be matched.
-		$activity = $this->makeActivity(naam: 'phpunit-fresh', bewaartermijn: 'P1D');
+		$activity = $this->makeActivity(name: 'phpunit-fresh', retentionPeriod: 'P1D');
 		$object = $this->makeObjectFixture();
 		$this->insertSyntheticAuditRow(
 			object: $object,
@@ -233,7 +233,7 @@ class AvgRetentionServiceIntegrationTest extends TestCase {
 	}//end testRecentlyAuditedObjectsArePreserved()
 
 	public function testLiveErasePassMarksObjectsDeletedAndTagsAudit(): void {
-		$activity = $this->makeActivity(naam: 'phpunit-erase-retention', bewaartermijn: 'P1D');
+		$activity = $this->makeActivity(name: 'phpunit-erase-retention', retentionPeriod: 'P1D');
 		$object = $this->makeObjectFixture();
 		$auditId = $this->insertSyntheticAuditRow(
 			object: $object,
@@ -269,14 +269,14 @@ class AvgRetentionServiceIntegrationTest extends TestCase {
 		return null;
 	}//end findActivityInSummary()
 
-	private function makeActivity(string $naam, ?string $bewaartermijn): Verwerkingsactiviteit {
+	private function makeActivity(string $name, ?string $retentionPeriod): Verwerkingsactiviteit {
 		$entity = new Verwerkingsactiviteit();
-		$entity->setNaam($naam . '-' . uniqid());
+		$entity->setNaam($name . '-' . uniqid());
 		$entity->setDoelbinding('phpunit retention purpose');
 		$entity->setRechtsgrond('publieke_taak');
 		$entity->setStatus('published');
-		if ($bewaartermijn !== null) {
-			$entity->setBewaartermijn($bewaartermijn);
+		if ($retentionPeriod !== null) {
+			$entity->setBewaartermijn($retentionPeriod);
 		}
 
 		$persisted = $this->vrwMapper->insert($entity);

--- a/tests/Service/AvgVerwerkingsregisterIntegrationTest.php
+++ b/tests/Service/AvgVerwerkingsregisterIntegrationTest.php
@@ -202,7 +202,7 @@ class AvgVerwerkingsregisterIntegrationTest extends TestCase {
 
 	public function testResolveReferenceFindsByCodeAndUuid(): void {
 		$code = 'phpunit-resolve-' . uniqid();
-		$activity = $this->makeActivity(naam: 'phpunit-resolve', code: $code);
+		$activity = $this->makeActivity(name: 'phpunit-resolve', code: $code);
 
 		$byCode = $this->vrwMapper->resolveReference(reference: $code);
 		$this->assertNotNull($byCode);
@@ -219,7 +219,7 @@ class AvgVerwerkingsregisterIntegrationTest extends TestCase {
 
 	public function testAuditTrailHookHonorsSchemaAnnotation(): void {
 		$activity = $this->makeActivity(
-			naam: 'phpunit-audit-schema',
+			name: 'phpunit-audit-schema',
 			code: 'phpunit-audit-schema-' . uniqid()
 		);
 
@@ -246,7 +246,7 @@ class AvgVerwerkingsregisterIntegrationTest extends TestCase {
 
 	public function testAuditTrailHookFallsBackToRegisterAnnotation(): void {
 		$activity = $this->makeActivity(
-			naam: 'phpunit-audit-register',
+			name: 'phpunit-audit-register',
 			code: 'phpunit-audit-register-' . uniqid()
 		);
 
@@ -270,11 +270,11 @@ class AvgVerwerkingsregisterIntegrationTest extends TestCase {
 
 	public function testAuditTrailHookPerActionOverrideBeatsDefaults(): void {
 		$schemaActivity = $this->makeActivity(
-			naam: 'phpunit-audit-schema-default',
+			name: 'phpunit-audit-schema-default',
 			code: 'phpunit-audit-schema-default-' . uniqid()
 		);
 		$overrideActivity = $this->makeActivity(
-			naam: 'phpunit-audit-override',
+			name: 'phpunit-audit-override',
 			code: 'phpunit-audit-override-' . uniqid()
 		);
 
@@ -315,9 +315,9 @@ class AvgVerwerkingsregisterIntegrationTest extends TestCase {
 
 	}//end testAuditTrailHookLeavesUnsetWhenNoAnnotation()
 
-	private function makeActivity(string $naam, string $code): Verwerkingsactiviteit {
+	private function makeActivity(string $name, string $code): Verwerkingsactiviteit {
 		$entity = new Verwerkingsactiviteit();
-		$entity->setNaam($naam . '-' . uniqid());
+		$entity->setNaam($name . '-' . uniqid());
 		$entity->setCode($code);
 		$entity->setDoelbinding('phpunit purpose binding');
 		$entity->setRechtsgrond('publieke_taak');

--- a/tests/Service/OasServiceIntegrationTest.php
+++ b/tests/Service/OasServiceIntegrationTest.php
@@ -770,10 +770,10 @@ class OasServiceIntegrationTest extends TestCase {
 
 		foreach ($result['paths'] as $path => $operations) {
 			if (str_contains($path, '/objects/') && !str_contains($path, '{id}') && isset($operations['get'])) {
-				$getOp = $operations['get'];
-				$this->assertArrayHasKey('parameters', $getOp);
+				$getOn = $operations['get'];
+				$this->assertArrayHasKey('parameters', $getOn);
 
-				$paramNames = array_column($getOp['parameters'], 'name');
+				$paramNames = array_column($getOn['parameters'], 'name');
 				$this->assertContains('_search', $paramNames, 'Collection should have _search parameter');
 				$this->assertContains('_extend', $paramNames, 'Collection should have _extend parameter');
 				return;
@@ -915,10 +915,10 @@ class OasServiceIntegrationTest extends TestCase {
 			if (str_contains($path, '{id}') && isset($operations['get'])
 				&& !str_contains($path, 'audit') && !str_contains($path, 'files') && !str_contains($path, 'lock')
 			) {
-				$getOp = $operations['get'];
-				$this->assertArrayHasKey('responses', $getOp);
-				$this->assertArrayHasKey('200', $getOp['responses']);
-				$this->assertArrayHasKey('404', $getOp['responses']);
+				$getOn = $operations['get'];
+				$this->assertArrayHasKey('responses', $getOn);
+				$this->assertArrayHasKey('200', $getOn['responses']);
+				$this->assertArrayHasKey('404', $getOn['responses']);
 				return;
 			}
 		}
@@ -938,10 +938,10 @@ class OasServiceIntegrationTest extends TestCase {
 			if (str_contains($path, '{id}') && isset($operations['delete'])
 				&& !str_contains($path, 'audit') && !str_contains($path, 'files') && !str_contains($path, 'lock')
 			) {
-				$deleteOp = $operations['delete'];
-				$this->assertArrayHasKey('responses', $deleteOp);
-				$this->assertArrayHasKey('204', $deleteOp['responses']);
-				$this->assertArrayHasKey('404', $deleteOp['responses']);
+				$deleteOn = $operations['delete'];
+				$this->assertArrayHasKey('responses', $deleteOn);
+				$this->assertArrayHasKey('204', $deleteOn['responses']);
+				$this->assertArrayHasKey('404', $deleteOn['responses']);
 				return;
 			}
 		}
@@ -959,9 +959,9 @@ class OasServiceIntegrationTest extends TestCase {
 
 		foreach ($result['paths'] as $path => $operations) {
 			if (str_contains($path, '/objects/') && !str_contains($path, '{id}') && isset($operations['post'])) {
-				$postOp = $operations['post'];
-				$this->assertArrayHasKey('requestBody', $postOp);
-				$this->assertTrue($postOp['requestBody']['required']);
+				$postOn = $operations['post'];
+				$this->assertArrayHasKey('requestBody', $postOn);
+				$this->assertTrue($postOn['requestBody']['required']);
 				return;
 			}
 		}

--- a/tests/Service/OasValidationIntegrationTest.php
+++ b/tests/Service/OasValidationIntegrationTest.php
@@ -151,12 +151,12 @@ class OasValidationIntegrationTest extends TestCase {
 		$matchB = 0;
 		foreach ($oas['paths'] as $pathItem) {
 			foreach ($pathItem as $op) {
-				$opId = (string)($op['operationId'] ?? '');
-				if (str_contains($opId, 'Zaken')) {
+				$onId = (string)($op['operationId'] ?? '');
+				if (str_contains($onId, 'Zaken')) {
 					$matchA++;
 				}
 
-				if (str_contains($opId, 'Archief')) {
+				if (str_contains($onId, 'Archief')) {
 					$matchB++;
 				}
 			}

--- a/tests/Service/RegisterI18nPhase2IntegrationTest.php
+++ b/tests/Service/RegisterI18nPhase2IntegrationTest.php
@@ -181,8 +181,8 @@ class RegisterI18nPhase2IntegrationTest extends TestCase {
 
 		$result = $this->bulkService->translateObject(
 			object: $this->testObject,
-			fromLang: 'nl',
-			toLang: 'en'
+			fromLong: 'nl',
+			toLong: 'en'
 		);
 
 		$this->assertArrayHasKey('title', $result['translated']);
@@ -206,8 +206,8 @@ class RegisterI18nPhase2IntegrationTest extends TestCase {
 
 		$result = $this->bulkService->translateObject(
 			object: $this->testObject,
-			fromLang: 'nl',
-			toLang: 'en'
+			fromLong: 'nl',
+			toLong: 'en'
 		);
 
 		$this->assertArrayNotHasKey('title', $result['translated']);
@@ -225,8 +225,8 @@ class RegisterI18nPhase2IntegrationTest extends TestCase {
 
 		$result = $this->bulkService->translateObject(
 			object: $this->testObject,
-			fromLang: 'nl',
-			toLang: 'fr'
+			fromLong: 'nl',
+			toLong: 'fr'
 		);
 
 		$this->assertSame('no-source-value', $result['skipped']['title'] ?? null);
@@ -236,8 +236,8 @@ class RegisterI18nPhase2IntegrationTest extends TestCase {
 	public function testBulkTranslateRejectsSameLanguagePair(): void {
 		$result = $this->bulkService->translateObject(
 			object: $this->testObject,
-			fromLang: 'nl',
-			toLang: 'nl'
+			fromLong: 'nl',
+			toLong: 'nl'
 		);
 		$this->assertSame([], $result['translated']);
 		$this->assertArrayHasKey('_global', $result['skipped']);

--- a/tests/Service/UserServiceIntegrationTest.php
+++ b/tests/Service/UserServiceIntegrationTest.php
@@ -504,15 +504,15 @@ class UserServiceIntegrationTest extends TestCase {
 	public function testUpdateUserPropertiesFunctie(): void {
 		$this->assertNotNull($this->testUser, 'Test user should exist');
 
-		$data = ['functie' => 'Developer'];
+		$data = ['role' => 'Developer'];
 
 		$result = $this->service->updateUserProperties($this->testUser, $data);
 
 		$this->assertTrue($result['success']);
 
 		// Verify functie is stored in user config
-		$storedFunctie = $this->config->getUserValue($this->testUserId, 'core', 'functie', '');
-		$this->assertSame('Developer', $storedFunctie);
+		$storedRole = $this->config->getUserValue($this->testUserId, 'core', 'role', '');
+		$this->assertSame('Developer', $storedRole);
 	}
 
 	/**
@@ -561,11 +561,11 @@ class UserServiceIntegrationTest extends TestCase {
 		$this->assertNotNull($this->testUser, 'Test user should exist');
 
 		// Set functie directly in config
-		$this->config->setUserValue($this->testUserId, 'core', 'functie', 'Tester');
+		$this->config->setUserValue($this->testUserId, 'core', 'role', 'Tester');
 
 		$result = $this->service->buildUserDataArray($this->testUser);
 
-		$this->assertArrayHasKey('functie', $result);
+		$this->assertArrayHasKey('role', $result);
 	}
 
 	/**

--- a/tests/Service/VerwerkingsactiviteitenControllerIntegrationTest.php
+++ b/tests/Service/VerwerkingsactiviteitenControllerIntegrationTest.php
@@ -289,7 +289,7 @@ class VerwerkingsactiviteitenControllerIntegrationTest extends TestCase {
 		$this->auditMapper->createAuditTrail(old: $existing, new: $modified, action: 'update');
 
 		$controller = $this->makeController();
-		$response = $controller->verantwoording();
+		$response = $controller->accountability();
 		$body = $response->getData();
 
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());

--- a/tests/Service/VerwerkingsactiviteitenControllerIntegrationTest.php
+++ b/tests/Service/VerwerkingsactiviteitenControllerIntegrationTest.php
@@ -147,8 +147,8 @@ class VerwerkingsactiviteitenControllerIntegrationTest extends TestCase {
 
 	public function testListReturnsAllActivitiesAsAdmin(): void {
 		$this->loginAsAdmin();
-		$a = $this->insertActivity(naam: 'phpunit-list-a');
-		$b = $this->insertActivity(naam: 'phpunit-list-b');
+		$a = $this->insertActivity(name: 'phpunit-list-a');
+		$b = $this->insertActivity(name: 'phpunit-list-b');
 
 		$controller = $this->makeController();
 		$response = $controller->index();
@@ -166,7 +166,7 @@ class VerwerkingsactiviteitenControllerIntegrationTest extends TestCase {
 	public function testShowFindsByIdUuidAndCode(): void {
 		$this->loginAsAdmin();
 		$code = 'phpunit-show-' . uniqid();
-		$activity = $this->insertActivity(naam: 'phpunit-show', code: $code);
+		$activity = $this->insertActivity(name: 'phpunit-show', code: $code);
 
 		$controller = $this->makeController();
 
@@ -253,7 +253,7 @@ class VerwerkingsactiviteitenControllerIntegrationTest extends TestCase {
 
 	public function testDestroySoftArchivesInsteadOfHardDelete(): void {
 		$this->loginAsAdmin();
-		$activity = $this->insertActivity(naam: 'phpunit-destroy');
+		$activity = $this->insertActivity(name: 'phpunit-destroy');
 
 		$controller = $this->makeController();
 		$response = $controller->destroy(id: (string)$activity->getId());
@@ -269,7 +269,7 @@ class VerwerkingsactiviteitenControllerIntegrationTest extends TestCase {
 
 	public function testVerantwoordingAggregatesAuditCounts(): void {
 		$this->loginAsAdmin();
-		$activity = $this->insertActivity(naam: 'phpunit-verantwoording', code: 'phpunit-vw-' . uniqid());
+		$activity = $this->insertActivity(name: 'phpunit-verantwoording', code: 'phpunit-vw-' . uniqid());
 
 		// Wire the activity into a schema so audit rows are tagged.
 		$register = $this->insertRegister();
@@ -330,9 +330,9 @@ class VerwerkingsactiviteitenControllerIntegrationTest extends TestCase {
 
 	}//end loginAsNonAdmin()
 
-	private function insertActivity(string $naam, ?string $code = null): Verwerkingsactiviteit {
+	private function insertActivity(string $name, ?string $code = null): Verwerkingsactiviteit {
 		$entity = new Verwerkingsactiviteit();
-		$entity->setNaam($naam . '-' . uniqid());
+		$entity->setNaam($name . '-' . uniqid());
 		if ($code !== null) {
 			$entity->setCode($code);
 		}

--- a/tests/Unit/Controller/ProcessingLogControllerTest.php
+++ b/tests/Unit/Controller/ProcessingLogControllerTest.php
@@ -237,7 +237,7 @@ class ProcessingLogControllerTest extends TestCase {
 		$this->organisationService->method('getUserOrganisations')->willReturn([$org]);
 		$this->request->method('getParam')->willReturn(null);
 
-		$response = $this->controller->betrokkene();
+		$response = $this->controller->involvedParty();
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
 
 	}//end testExtractRequiresSubjectIdentifiers()
@@ -263,7 +263,7 @@ class ProcessingLogControllerTest extends TestCase {
 			]
 		);
 
-		$response = $this->controller->betrokkene();
+		$response = $this->controller->involvedParty();
 		$this->assertSame(Http::STATUS_UNPROCESSABLE_ENTITY, $response->getStatus());
 
 	}//end testExtractRangeTooWideIs422()

--- a/tests/Unit/Controller/VocabularyControllerTest.php
+++ b/tests/Unit/Controller/VocabularyControllerTest.php
@@ -87,9 +87,9 @@ class VocabularyControllerTest extends TestCase {
 	public function testResolveByUriReturnsConceptWhenFound(): void {
 		$this->params = ['uri' => 'https://example.org/vocab/x'];
 
-		$concept = $this->entity('uuid-1', ['uri' => 'https://example.org/vocab/x', 'prefLabel' => ['nl' => 'X']]);
+		$draft = $this->entity('uuid-1', ['uri' => 'https://example.org/vocab/x', 'prefLabel' => ['nl' => 'X']]);
 
-		$this->objectService->method('findAll')->willReturn([$concept]);
+		$this->objectService->method('findAll')->willReturn([$draft]);
 
 		$response = $this->controller->resolveByUri();
 
@@ -135,15 +135,15 @@ class VocabularyControllerTest extends TestCase {
 		$this->params = ['scheme' => 'https://example.org/vocab/scheme', 'notation' => 'c_1'];
 
 		$scheme = $this->entity('scheme-uuid', ['uri' => 'https://example.org/vocab/scheme']);
-		$concept = $this->entity('uuid-1', ['uri' => 'https://example.org/vocab/c1', 'notation' => 'c_1']);
+		$draft = $this->entity('uuid-1', ['uri' => 'https://example.org/vocab/c1', 'notation' => 'c_1']);
 
 		$this->objectService->method('findAll')->willReturnCallback(
-			function (array $config) use ($scheme, $concept) {
+			function (array $config) use ($scheme, $draft) {
 				if ($config['schema'] === VocabularyImportService::SCHEMA_SCHEME) {
 					return [$scheme];
 				}
 
-				return [$concept];
+				return [$draft];
 			}
 		);
 

--- a/tests/Unit/Db/ObjectEntityTmloTest.php
+++ b/tests/Unit/Db/ObjectEntityTmloTest.php
@@ -53,7 +53,7 @@ class ObjectEntityTmloTest extends TestCase {
 	public function testSetAndGetTmlo(): void {
 		$entity = new ObjectEntity();
 		$tmloData = [
-			'classificatie' => '1.1',
+			'classification' => '1.1',
 			'archiefnominatie' => 'blijvend_bewaren',
 			'archiefstatus' => 'actief',
 			'bewaarTermijn' => 'P7Y',
@@ -62,7 +62,7 @@ class ObjectEntityTmloTest extends TestCase {
 		$entity->setTmlo($tmloData);
 		$result = $entity->getTmlo();
 
-		$this->assertEquals('1.1', $result['classificatie']);
+		$this->assertEquals('1.1', $result['classification']);
 		$this->assertEquals('blijvend_bewaren', $result['archiefnominatie']);
 		$this->assertEquals('actief', $result['archiefstatus']);
 		$this->assertEquals('P7Y', $result['bewaarTermijn']);
@@ -95,7 +95,7 @@ class ObjectEntityTmloTest extends TestCase {
 		$entity = new ObjectEntity();
 		$entity->setUuid('test-uuid-json');
 		$entity->setTmlo([
-			'classificatie' => '2.1',
+			'classification' => '2.1',
 			'archiefstatus' => 'semi_statisch',
 		]);
 
@@ -103,7 +103,7 @@ class ObjectEntityTmloTest extends TestCase {
 
 		$this->assertArrayHasKey('@self', $json);
 		$this->assertArrayHasKey('tmlo', $json['@self']);
-		$this->assertEquals('2.1', $json['@self']['tmlo']['classificatie']);
+		$this->assertEquals('2.1', $json['@self']['tmlo']['classification']);
 	}//end testTmloInJsonSerialize()
 
 	/**
@@ -116,7 +116,7 @@ class ObjectEntityTmloTest extends TestCase {
 		$entity->hydrate([
 			'tmlo' => [
 				'archiefstatus' => 'actief',
-				'classificatie' => '3.1',
+				'classification' => '3.1',
 				'bewaarTermijn' => 'P10Y',
 				'archiefnominatie' => 'vernietigen',
 			],
@@ -125,7 +125,7 @@ class ObjectEntityTmloTest extends TestCase {
 		$tmlo = $entity->getTmlo();
 
 		$this->assertEquals('actief', $tmlo['archiefstatus']);
-		$this->assertEquals('3.1', $tmlo['classificatie']);
+		$this->assertEquals('3.1', $tmlo['classification']);
 		$this->assertEquals('P10Y', $tmlo['bewaarTermijn']);
 	}//end testHydrateSetsTmlo()
 
@@ -153,7 +153,7 @@ class ObjectEntityTmloTest extends TestCase {
 	public function testFullTmloFieldSet(): void {
 		$entity = new ObjectEntity();
 		$fullTmlo = [
-			'classificatie' => '1.1.2',
+			'classification' => '1.1.2',
 			'archiefnominatie' => 'vernietigen',
 			'archiefactiedatum' => '2032-06-15',
 			'archiefstatus' => 'semi_statisch',

--- a/tests/Unit/Repair/RenameDutchColumnsTest.php
+++ b/tests/Unit/Repair/RenameDutchColumnsTest.php
@@ -1,0 +1,588 @@
+<?php
+
+/**
+ * Tests for the Dutch-to-English column migration.
+ *
+ * WHY THIS EXISTS. OpenRegister materialises every schema property as a real
+ * COLUMN, and MagicMapper ADDS a column when the snake_cased name is missing but
+ * never RENAMES one. So renaming a property in the register definition is a DATA
+ * MIGRATION: without this repair step the rows keep their values in a column
+ * nothing reads any more, and the app silently starts serving nulls.
+ *
+ * The double is a FAKE SCHEMA rather than a set of expected calls. Asserting
+ * "a rename was issued" against a mock only proves the test and the code agree
+ * on a string; running the step against a described set of tables and columns
+ * and then asking what SQL came out tests the decision the step actually makes.
+ *
+ * The statement and result doubles are HAND-WRITTEN rather than createMock()d.
+ * OCP\DB\IPreparedStatement::bindValue() defaults its type argument to
+ * Doctrine\DBAL\ParameterType::STRING, and this app ships doctrine/deprecations
+ * without doctrine/dbal. PHPUnit's mock generator evaluates that default while
+ * generating the double, so createMock() throws — and RenameDutchColumns CATCHES
+ * Throwable around its information_schema reads, so the thrown error surfaces as
+ * "no shard tables on this install" and the tests pass while migrating nothing.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Repair
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.openregister.app
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Repair;
+
+use OCA\OpenRegister\Repair\RenameDutchColumns;
+use OCP\DB\Exception;
+use OCP\DB\IPreparedStatement;
+use OCP\DB\IResult;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * A result that yields a fixed list of scalars.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Repair
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.openregister.app
+ */
+final class FakeResult implements IResult {
+	/**
+	 * @param array<int, mixed> $rows Rows this result yields.
+	 */
+	public function __construct(private array $rows = []) {
+	}//end __construct()
+
+	/**
+	 * @return bool
+	 */
+	public function closeCursor(): bool {
+		return true;
+	}//end closeCursor()
+
+	/**
+	 * @param int $fetchMode Ignored.
+	 *
+	 * @return mixed
+	 */
+	public function fetch(int $fetchMode = 2): mixed {
+		return array_shift($this->rows);
+	}//end fetch()
+
+	/**
+	 * @param int $fetchMode Ignored.
+	 *
+	 * @return array<int, mixed>
+	 */
+	public function fetchAll(int $fetchMode = 2): array {
+		return $this->rows;
+	}//end fetchAll()
+
+	/**
+	 * @return mixed
+	 */
+	public function fetchColumn(): mixed {
+		return ($this->rows[0] ?? false);
+	}//end fetchColumn()
+
+	/**
+	 * @return mixed
+	 */
+	public function fetchOne(): mixed {
+		return ($this->rows[0] ?? false);
+	}//end fetchOne()
+
+	/**
+	 * @return array<string, mixed>|false
+	 */
+	public function fetchAssociative(): array|false {
+		$row = array_shift($this->rows);
+		return (is_array($row) === true ? $row : false);
+	}//end fetchAssociative()
+
+	/**
+	 * @return array<int, mixed>|false
+	 */
+	public function fetchNumeric(): array|false {
+		$row = array_shift($this->rows);
+		return (is_array($row) === true ? array_values($row) : false);
+	}//end fetchNumeric()
+
+	/**
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function fetchAllAssociative(): array {
+		return array_values(array_filter($this->rows, 'is_array'));
+	}//end fetchAllAssociative()
+
+	/**
+	 * @return array<int, array<int, mixed>>
+	 */
+	public function fetchAllNumeric(): array {
+		return array_map('array_values', array_values(array_filter($this->rows, 'is_array')));
+	}//end fetchAllNumeric()
+
+	/**
+	 * @return array<int, mixed>
+	 */
+	public function fetchFirstColumn(): array {
+		return array_values($this->rows);
+	}//end fetchFirstColumn()
+
+	/**
+	 * @return \Traversable<int, array<int, mixed>>
+	 */
+	public function iterateNumeric(): \Traversable {
+		return new \ArrayIterator($this->fetchAllNumeric());
+	}//end iterateNumeric()
+
+	/**
+	 * @return \Traversable<int, array<string, mixed>>
+	 */
+	public function iterateAssociative(): \Traversable {
+		return new \ArrayIterator($this->fetchAllAssociative());
+	}//end iterateAssociative()
+
+	/**
+	 * @return int
+	 */
+	public function rowCount(): int {
+		return count($this->rows);
+	}//end rowCount()
+}//end class
+
+/**
+ * A prepared statement over a fixed set of information_schema rows.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Repair
+ * @author   Conduction B.V. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://www.openregister.app
+ */
+final class FakeStatement implements IPreparedStatement {
+	/** @var array<string, mixed> Values bound by the caller. */
+	public array $bound = [];
+
+	/** @var array<int, array<string, string>> Rows still to yield. */
+	private array $rows = [];
+
+	/**
+	 * @param callable $rowsFor Given the bound values, return the rows to yield.
+	 */
+	public function __construct(private $rowsFor) {
+	}//end __construct()
+
+	/**
+	 * @return bool
+	 */
+	public function closeCursor(): bool {
+		return true;
+	}//end closeCursor()
+
+	/**
+	 * @param int $fetchMode Ignored.
+	 *
+	 * @return mixed
+	 */
+	public function fetch(int $fetchMode = 2): mixed {
+		$row = array_shift($this->rows);
+		return ($row ?? false);
+	}//end fetch()
+
+	/**
+	 * @param int $fetchMode Ignored.
+	 *
+	 * @return array<int, mixed>
+	 */
+	public function fetchAll(int $fetchMode = 2): array {
+		$rows = $this->rows;
+		$this->rows = [];
+		return $rows;
+	}//end fetchAll()
+
+	/**
+	 * @return mixed
+	 */
+	public function fetchColumn(): mixed {
+		return false;
+	}//end fetchColumn()
+
+	/**
+	 * @return mixed
+	 */
+	public function fetchOne(): mixed {
+		return false;
+	}//end fetchOne()
+
+	/**
+	 * @param mixed $param Placeholder name.
+	 * @param mixed $value Bound value.
+	 * @param mixed $type  Ignored.
+	 *
+	 * @return bool
+	 */
+	public function bindValue($param, $value, $type = null): bool {
+		$this->bound[(string)$param] = $value;
+		return true;
+	}//end bindValue()
+
+	/**
+	 * @param mixed $param    Placeholder name.
+	 * @param mixed $variable Bound variable.
+	 * @param mixed $type     Ignored.
+	 * @param mixed $length   Ignored.
+	 *
+	 * @return bool
+	 */
+	public function bindParam($param, &$variable, $type = null, $length = null): bool {
+		$this->bound[(string)$param] = $variable;
+		return true;
+	}//end bindParam()
+
+	/**
+	 * Resolve the rows now that the bindings are known.
+	 *
+	 * @param mixed $params Ignored.
+	 *
+	 * @return IResult
+	 */
+	public function execute($params = null): IResult {
+		$this->rows = ($this->rowsFor)($this->bound);
+		return new FakeResult([]);
+	}//end execute()
+
+	/**
+	 * @return int
+	 */
+	public function rowCount(): int {
+		return count($this->rows);
+	}//end rowCount()
+}//end class
+
+/**
+ * @covers \OCA\OpenRegister\Repair\RenameDutchColumns
+ */
+class RenameDutchColumnsTest extends TestCase {
+	/** @var array<int, string> Every statement the step executed. */
+	private array $executed = [];
+
+	/** @var array<int, string> Messages the step wrote to the repair output. */
+	private array $info = [];
+
+	/** @var array<int, string> Warnings the step logged. */
+	private array $warnings = [];
+
+	/**
+	 * Build the step over a described database.
+	 *
+	 * @param array<int, int>              $registerIds    Ids the register lookup returns.
+	 * @param array<int, string>           $tables         Table names information_schema reports.
+	 * @param array<string, array<string>> $columns        Column names per table.
+	 * @param string|null                  $failOn         Substring of a statement that should fail.
+	 * @param bool                         $registersThrow Whether the register lookup throws.
+	 * @param bool                         $tablesThrow    Whether the table listing throws.
+	 *
+	 * @return RenameDutchColumns
+	 */
+	private function step(
+		array $registerIds,
+		array $tables,
+		array $columns,
+		?string $failOn = null,
+		bool $registersThrow = false,
+		bool $tablesThrow = false,
+	): RenameDutchColumns {
+		$this->executed = [];
+		$this->info = [];
+		$this->warnings = [];
+
+		$db = $this->createMock(IDBConnection::class);
+
+		if ($registersThrow === true) {
+			$db->method('executeQuery')->willThrowException(new Exception('registers unavailable'));
+		} else {
+			$db->method('executeQuery')->willReturnCallback(
+				static fn (): IResult => new FakeResult($registerIds)
+			);
+		}
+
+		// information_schema goes through prepare(): the table listing, then one
+		// column listing per table. Dispatch on the SQL so the order of the step's
+		// own calls is not baked into the test.
+		if ($tablesThrow === true) {
+			$db->method('prepare')->willThrowException(new Exception('information_schema unavailable'));
+		} else {
+			$db->method('prepare')->willReturnCallback(
+				static function (string $sql) use ($tables, $columns): IPreparedStatement {
+					if (str_contains($sql, 'information_schema.tables') === true) {
+						return new FakeStatement(
+							static fn (): array => array_map(
+								static fn (string $t): array => ['table_name' => $t],
+								$tables
+							)
+						);
+					}
+
+					return new FakeStatement(
+						static function (array $bound) use ($columns): array {
+							$asked = (string)($bound['table'] ?? '');
+							return array_map(
+								static fn (string $c): array => ['column_name' => $c],
+								($columns[$asked] ?? [])
+							);
+						}
+					);
+				}
+			);
+		}//end if
+
+		$db->method('executeStatement')->willReturnCallback(
+			function (string $sql) use ($failOn): int {
+				if ($failOn !== null && str_contains($sql, $failOn) === true) {
+					throw new Exception('statement rejected');
+				}
+
+				$this->executed[] = $sql;
+				return 1;
+			}
+		);
+
+		$platform = new class {
+			/**
+			 * @param string $identifier Identifier to quote.
+			 *
+			 * @return string
+			 */
+			public function quoteSingleIdentifier(string $identifier): string {
+				return '"' . $identifier . '"';
+			}
+		};
+		$db->method('getDatabasePlatform')->willReturn($platform);
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->method('warning')->willReturnCallback(
+			function (string $message): void {
+				$this->warnings[] = $message;
+			}
+		);
+
+		return new RenameDutchColumns($db, $logger);
+	}//end step()
+
+	/**
+	 * Capture what the step reported.
+	 *
+	 * @return IOutput
+	 */
+	private function repairOutput(): IOutput {
+		$output = $this->createMock(IOutput::class);
+		$output->method('info')->willReturnCallback(
+			function (string $message): void {
+				$this->info[] = $message;
+			}
+		);
+		return $output;
+	}//end repairOutput()
+
+	/**
+	 * The step names itself for the repair log.
+	 *
+	 * @return void
+	 */
+	public function testGetNameDescribesTheMigration(): void {
+		$step = $this->step([], [], []);
+		$this->assertStringContainsString('openregister', strtolower($step->getName()));
+	}//end testGetNameDescribesTheMigration()
+
+	/**
+	 * An install with no shard tables is a no-op, not an error.
+	 *
+	 * @return void
+	 */
+	public function testNoShardTablesDoesNothing(): void {
+		$step = $this->step([], [], []);
+		$step->run($this->repairOutput());
+		$this->assertSame([], $this->executed);
+		$this->assertStringContainsString('nothing to do', implode(' ', $this->info));
+	}//end testNoShardTablesDoesNothing()
+
+	/**
+	 * Old column present, English one absent: rename it.
+	 *
+	 * @return void
+	 */
+	public function testRenamesWhenOnlyTheDutchColumnExists(): void {
+		$table = 'oc_openregister_table_7_3';
+		$step = $this->step([7], [$table], [$table => ['id', 'classificatie']]);
+		$step->run($this->repairOutput());
+		$this->assertCount(1, $this->executed);
+		$this->assertStringContainsString('RENAME COLUMN "classificatie" TO "classification"', $this->executed[0]);
+	}//end testRenamesWhenOnlyTheDutchColumnExists()
+
+	/**
+	 * Every mapped column in one table is migrated, not just the first.
+	 *
+	 * @return void
+	 */
+	public function testAllMappedColumnsInATableAreMigrated(): void {
+		$table = 'oc_openregister_table_7_3';
+		$step = $this->step(
+			[7],
+			[$table],
+			[$table => ['id', 'classificatie', 'bestandsnaam', 'eind_datum', 'functie']]
+		);
+		$step->run($this->repairOutput());
+		$this->assertCount(4, $this->executed);
+		$this->assertStringContainsString('"eind_datum" TO "end_date"', implode(' ', $this->executed));
+	}//end testAllMappedColumnsInATableAreMigrated()
+
+	/**
+	 * BOTH columns present: back-fill, never rename.
+	 *
+	 * MagicMapper ADDS the English column the first time it writes the renamed
+	 * property, so by the time the repair runs both can exist with the data split
+	 * across them. Renaming would collide; dropping the old one would lose rows
+	 * written before the rename. Copy only where the destination is still null,
+	 * so a value already written through the new name wins.
+	 *
+	 * @return void
+	 */
+	public function testBackfillsWhenBothColumnsExist(): void {
+		$table = 'oc_openregister_table_7_3';
+		$step = $this->step([7], [$table], [$table => ['id', 'classificatie', 'classification']]);
+		$step->run($this->repairOutput());
+		$this->assertCount(1, $this->executed);
+		$this->assertStringContainsString('UPDATE', $this->executed[0]);
+		$this->assertStringContainsString('"classification" = "classificatie"', $this->executed[0]);
+		$this->assertStringContainsString('"classification" IS NULL', $this->executed[0]);
+		$this->assertStringNotContainsString('DROP', $this->executed[0]);
+	}//end testBackfillsWhenBothColumnsExist()
+
+	/**
+	 * A table without a mapped column is left alone.
+	 *
+	 * @return void
+	 */
+	public function testTableWithoutTheDutchColumnIsUntouched(): void {
+		$table = 'oc_openregister_table_7_3';
+		$step = $this->step([7], [$table], [$table => ['id', 'classification']]);
+		$step->run($this->repairOutput());
+		$this->assertSame([], $this->executed);
+	}//end testTableWithoutTheDutchColumnIsUntouched()
+
+	/**
+	 * A shard of a register this app does not own is not migrated.
+	 *
+	 * The marker match must be anchored to THIS app's register ids. Matching
+	 * `openregister_table_` alone would rewrite another app's columns on a shared
+	 * instance, which is a data-loss bug in someone else's app.
+	 *
+	 * @return void
+	 */
+	public function testForeignRegisterShardIsNotMigrated(): void {
+		$mine = 'oc_openregister_table_7_3';
+		$theirs = 'oc_openregister_table_99_1';
+		$step = $this->step(
+			[7],
+			[$mine, $theirs],
+			[$mine => ['id'], $theirs => ['classificatie']]
+		);
+		$step->run($this->repairOutput());
+		$this->assertSame([], $this->executed);
+	}//end testForeignRegisterShardIsNotMigrated()
+
+	/**
+	 * The marker must be followed by digits.
+	 *
+	 * `openregister_table_7_backup` contains the marker for register 7 but is not
+	 * a shard; a substring match would migrate it.
+	 *
+	 * @return void
+	 */
+	public function testNonNumericSuffixIsNotAShard(): void {
+		$table = 'oc_openregister_table_7_backup';
+		$step = $this->step([7], [$table], [$table => ['classificatie']]);
+		$step->run($this->repairOutput());
+		$this->assertSame([], $this->executed);
+	}//end testNonNumericSuffixIsNotAShard()
+
+	/**
+	 * A failed statement is swallowed and logged, leaving the column as it was.
+	 *
+	 * A repair step that throws blocks the upgrade for every step behind it.
+	 *
+	 * @return void
+	 */
+	public function testFailedStatementIsLoggedAndDoesNotThrow(): void {
+		$table = 'oc_openregister_table_7_3';
+		$step = $this->step([7], [$table], [$table => ['classificatie']], failOn: 'RENAME COLUMN');
+		$step->run($this->repairOutput());
+		$this->assertSame([], $this->executed);
+		$this->assertNotEmpty($this->warnings);
+	}//end testFailedStatementIsLoggedAndDoesNotThrow()
+
+	/**
+	 * If the registers cannot be read, migrate nothing.
+	 *
+	 * @return void
+	 */
+	public function testUnreadableRegistersSkipsQuietly(): void {
+		$step = $this->step([7], ['oc_openregister_table_7_3'], [], registersThrow: true);
+		$step->run($this->repairOutput());
+		$this->assertSame([], $this->executed);
+		$this->assertNotEmpty($this->warnings);
+	}//end testUnreadableRegistersSkipsQuietly()
+
+	/**
+	 * If information_schema cannot be listed, migrate nothing.
+	 *
+	 * @return void
+	 */
+	public function testUnreadableTableListSkipsQuietly(): void {
+		$step = $this->step([7], ['oc_openregister_table_7_3'], [], tablesThrow: true);
+		$step->run($this->repairOutput());
+		$this->assertSame([], $this->executed);
+		$this->assertNotEmpty($this->warnings);
+	}//end testUnreadableTableListSkipsQuietly()
+
+	/**
+	 * Every shard of the register is migrated, not just the first.
+	 *
+	 * @return void
+	 */
+	public function testAllShardsOfTheRegisterAreMigrated(): void {
+		$a = 'oc_openregister_table_7_1';
+		$b = 'oc_openregister_table_7_2';
+		$step = $this->step([7], [$a, $b], [$a => ['classificatie'], $b => ['classificatie']]);
+		$step->run($this->repairOutput());
+		$this->assertCount(2, $this->executed);
+	}//end testAllShardsOfTheRegisterAreMigrated()
+
+	/**
+	 * The summary counts what happened.
+	 *
+	 * @return void
+	 */
+	public function testSummaryReportsCounts(): void {
+		$a = 'oc_openregister_table_7_1';
+		$b = 'oc_openregister_table_7_2';
+		$step = $this->step(
+			[7],
+			[$a, $b],
+			[$a => ['classificatie'], $b => ['classificatie', 'classification']]
+		);
+		$step->run($this->repairOutput());
+		$summary = implode(' ', $this->info);
+		$this->assertStringContainsString('1 renamed', $summary);
+		$this->assertStringContainsString('1 back-filled', $summary);
+	}//end testSummaryReportsCounts()
+}//end class

--- a/tests/Unit/Repair/SeedVocabularyRegisterTest.php
+++ b/tests/Unit/Repair/SeedVocabularyRegisterTest.php
@@ -216,12 +216,12 @@ class SeedVocabularyRegisterTest extends TestCase {
 	}//end testRegisterImportFailureDoesNotAbortFixtureSeeding()
 
 	/**
-	 * @param array<string, mixed> $draftNode A parsed skos:Concept node.
+	 * @param array<string, mixed> $conceptNode A parsed skos:Concept node.
 	 *
 	 * @return array<string, string>
 	 */
-	private function firstPrefLabel(array $draftNode): array {
-		$raw = ($draftNode['skos:prefLabel'] ?? []);
+	private function firstPrefLabel(array $conceptNode): array {
+		$raw = ($conceptNode['skos:prefLabel'] ?? []);
 		$map = [];
 		foreach ($raw as $literal) {
 			$map[($literal['@language'] ?? 'nl')] = $literal['@value'];

--- a/tests/Unit/Repair/SeedVocabularyRegisterTest.php
+++ b/tests/Unit/Repair/SeedVocabularyRegisterTest.php
@@ -163,13 +163,13 @@ class SeedVocabularyRegisterTest extends TestCase {
 		);
 		$this->assertCount(17, $concepts, 'Fresh install must serve all 17 Woo informatiecategorieën');
 
-		foreach ($concepts as $concept) {
+		foreach ($concepts as $draft) {
 			$this->assertStringStartsWith(
 				'https://identifier.overheid.nl/tooi/def/thes/kern/c_',
-				$concept['@id'],
+				$draft['@id'],
 				'Every informatiecategorie must carry a TOOI kern-thesaurus URI'
 			);
-			$this->assertArrayHasKey('nl', $this->firstPrefLabel($concept), 'Every concept needs a Dutch prefLabel');
+			$this->assertArrayHasKey('nl', $this->firstPrefLabel($draft), 'Every concept needs a Dutch prefLabel');
 		}
 	}//end testRunSeedsBothTooiFixturesWithSeventeenInformatiecategorieen()
 
@@ -216,12 +216,12 @@ class SeedVocabularyRegisterTest extends TestCase {
 	}//end testRegisterImportFailureDoesNotAbortFixtureSeeding()
 
 	/**
-	 * @param array<string, mixed> $conceptNode A parsed skos:Concept node.
+	 * @param array<string, mixed> $draftNode A parsed skos:Concept node.
 	 *
 	 * @return array<string, string>
 	 */
-	private function firstPrefLabel(array $conceptNode): array {
-		$raw = ($conceptNode['skos:prefLabel'] ?? []);
+	private function firstPrefLabel(array $draftNode): array {
+		$raw = ($draftNode['skos:prefLabel'] ?? []);
 		$map = [];
 		foreach ($raw as $literal) {
 			$map[($literal['@language'] ?? 'nl')] = $literal['@value'];

--- a/tests/Unit/Service/Archival/ArchiveActionDateCalculatorTest.php
+++ b/tests/Unit/Service/Archival/ArchiveActionDateCalculatorTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * ArchiefactiedatumCalculator Unit Tests
+ * ArchiveActionDateCalculator Unit Tests
  *
  * Tests the archive action date calculator with all three afleidingswijzen.
  *
@@ -16,23 +16,23 @@ declare(strict_types=1);
 namespace Unit\Service\Archival;
 
 use DateTime;
-use OCA\OpenRegister\Service\Archival\ArchiefactiedatumCalculator;
+use OCA\OpenRegister\Service\Archival\ArchiveActionDateCalculator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 /**
- * Test class for ArchiefactiedatumCalculator
+ * Test class for ArchiveActionDateCalculator
  */
 class ArchiefactiedatumCalculatorTest extends TestCase {
 	private LoggerInterface&MockObject $logger;
-	private ArchiefactiedatumCalculator $calculator;
+	private ArchiveActionDateCalculator $calculator;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->logger = $this->createMock(LoggerInterface::class);
-		$this->calculator = new ArchiefactiedatumCalculator($this->logger);
+		$this->calculator = new ArchiveActionDateCalculator($this->logger);
 	}
 
 	/**

--- a/tests/Unit/Service/Archival/ArchiveActionDateCalculatorTest.php
+++ b/tests/Unit/Service/Archival/ArchiveActionDateCalculatorTest.php
@@ -24,7 +24,7 @@ use Psr\Log\LoggerInterface;
 /**
  * Test class for ArchiveActionDateCalculator
  */
-class ArchiefactiedatumCalculatorTest extends TestCase {
+class ArchiveActionDateCalculatorTest extends TestCase {
 	private LoggerInterface&MockObject $logger;
 	private ArchiveActionDateCalculator $calculator;
 

--- a/tests/Unit/Service/Archival/DestructionCertificateContentTest.php
+++ b/tests/Unit/Service/Archival/DestructionCertificateContentTest.php
@@ -120,19 +120,19 @@ class DestructionCertificateContentTest extends TestCase {
 				[
 					'uuid' => 'obj-1',
 					'schema' => 5,
-					'classificatie' => 'B1',
+					'classification' => 'B1',
 					'selectielijstBron' => 'Selectielijst gemeenten 2020',
 				],
 				[
 					'uuid' => 'obj-2',
 					'schema' => 5,
-					'classificatie' => 'B1',
+					'classification' => 'B1',
 					'selectielijstBron' => 'Selectielijst gemeenten 2020',
 				],
 				[
 					'uuid' => 'obj-3',
 					'schema' => 8,
-					'classificatie' => 'A1',
+					'classification' => 'A1',
 					'selectielijstBron' => 'Selectielijst gemeenten 2020',
 				],
 			],
@@ -177,8 +177,8 @@ class DestructionCertificateContentTest extends TestCase {
 		$this->assertNotEmpty($certificate['groupedBySchema']);
 		$this->assertEqualsCanonicalizing(
 			[
-				['schema' => 5, 'classificatie' => 'B1', 'count' => 2],
-				['schema' => 8, 'classificatie' => 'A1', 'count' => 1],
+				['schema' => 5, 'classification' => 'B1', 'count' => 2],
+				['schema' => 8, 'classification' => 'A1', 'count' => 1],
 			],
 			$certificate['groupedBySchema']
 		);
@@ -197,7 +197,7 @@ class DestructionCertificateContentTest extends TestCase {
 				'uuid' => 'list-uuid-7',
 				'status' => DestructionService::STATUS_IN_REVIEW,
 				'approvals' => [],
-				'objects' => [['uuid' => 'obj-1', 'schema' => 1, 'classificatie' => 'V1']],
+				'objects' => [['uuid' => 'obj-1', 'schema' => 1, 'classification' => 'V1']],
 			],
 			'approve_all',
 			[],

--- a/tests/Unit/Service/Archival/DestructionServiceTest.php
+++ b/tests/Unit/Service/Archival/DestructionServiceTest.php
@@ -87,7 +87,7 @@ class DestructionServiceTest extends TestCase {
 				'schema' => 5,
 				'register' => 1,
 				'archiefactiedatum' => '2025-01-01',
-				'classificatie' => 'B1',
+				'classification' => 'B1',
 			],
 			[
 				'uuid' => 'uuid-2',
@@ -95,7 +95,7 @@ class DestructionServiceTest extends TestCase {
 				'schema' => 5,
 				'register' => 1,
 				'archiefactiedatum' => '2025-06-01',
-				'classificatie' => 'B2',
+				'classification' => 'B2',
 			],
 		];
 

--- a/tests/Unit/Service/CaseTypeAuthorizationServiceTest.php
+++ b/tests/Unit/Service/CaseTypeAuthorizationServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Tests for ZaaktypeAuthorizationService — the configuration + ZGW mapping layer
+ * Tests for CaseTypeAuthorizationService — the configuration + ZGW mapping layer
  * for zaaktype-scoped authorization (rbac-zaaktype).
  *
  * Verifies vertrouwelijkheidaanduiding ordinal ordering, clearance comparison,
@@ -17,17 +17,17 @@ declare(strict_types=1);
 
 namespace Unit\Service;
 
-use OCA\OpenRegister\Service\ZaaktypeAuthorizationService;
+use OCA\OpenRegister\Service\CaseTypeAuthorizationService;
 use PHPUnit\Framework\TestCase;
 
 /**
  * VNG-compliance unit coverage for the zaaktype authorization config layer.
  */
 class ZaaktypeAuthorizationServiceTest extends TestCase {
-	private ZaaktypeAuthorizationService $service;
+	private CaseTypeAuthorizationService $service;
 
 	protected function setUp(): void {
-		$this->service = new ZaaktypeAuthorizationService();
+		$this->service = new CaseTypeAuthorizationService();
 	}
 
 	// === Vertrouwelijkheidaanduiding ordinal ordering ===

--- a/tests/Unit/Service/CaseTypeAuthorizationServiceTest.php
+++ b/tests/Unit/Service/CaseTypeAuthorizationServiceTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * VNG-compliance unit coverage for the zaaktype authorization config layer.
  */
-class ZaaktypeAuthorizationServiceTest extends TestCase {
+class CaseTypeAuthorizationServiceTest extends TestCase {
 	private CaseTypeAuthorizationService $service;
 
 	protected function setUp(): void {

--- a/tests/Unit/Service/ConfidentialityClauseEnforcementTest.php
+++ b/tests/Unit/Service/ConfidentialityClauseEnforcementTest.php
@@ -3,7 +3,7 @@
 /**
  * Confidentiality clause: builder output is enforced by the engine.
  *
- * `ZaaktypeAuthorizationService::buildConfidentialityMatch()` is a BUILDER — it
+ * `CaseTypeAuthorizationService::buildConfidentialityMatch()` is a BUILDER — it
  * emits an `$in` clause that the existing RBAC engine is supposed to enforce.
  * Its own unit test proves the clause has the right SHAPE. Nothing proved the
  * engine actually honours it, and the two live handlers contain no
@@ -37,7 +37,7 @@ declare(strict_types=1);
 namespace Unit\Service;
 
 use OCA\OpenRegister\Service\OperatorEvaluator;
-use OCA\OpenRegister\Service\ZaaktypeAuthorizationService;
+use OCA\OpenRegister\Service\CaseTypeAuthorizationService;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
@@ -52,9 +52,9 @@ class ConfidentialityClauseEnforcementTest extends TestCase {
 	/**
 	 * The clause builder.
 	 *
-	 * @var ZaaktypeAuthorizationService
+	 * @var CaseTypeAuthorizationService
 	 */
-	private ZaaktypeAuthorizationService $builder;
+	private CaseTypeAuthorizationService $builder;
 
 	/**
 	 * The evaluator the RBAC match path uses.
@@ -70,7 +70,7 @@ class ConfidentialityClauseEnforcementTest extends TestCase {
 	 */
 	protected function setUp(): void {
 		parent::setUp();
-		$this->builder = new ZaaktypeAuthorizationService();
+		$this->builder = new CaseTypeAuthorizationService();
 		$this->evaluator = new OperatorEvaluator($this->createMock(LoggerInterface::class));
 
 	}//end setUp()

--- a/tests/Unit/Service/ContactMatchingServiceTest.php
+++ b/tests/Unit/Service/ContactMatchingServiceTest.php
@@ -98,7 +98,7 @@ class ContactMatchingServiceTest extends TestCase {
 					'@self' => ['uuid' => 'abc-123', 'schema' => 1, 'register' => 2],
 					'email' => 'jan@example.nl',
 					'naam' => 'Jan de Vries',
-					'functie' => 'Beleidsmedewerker',
+					'role' => 'Beleidsmedewerker',
 				],
 			]);
 
@@ -263,7 +263,7 @@ class ContactMatchingServiceTest extends TestCase {
 				[
 					'@self' => ['uuid' => 'org-789', 'schema' => 1, 'register' => 1],
 					'schema' => ['title' => 'Organisaties'],
-					'organisatie' => 'Gemeente Tilburg',
+					'organisation' => 'Gemeente Tilburg',
 					'naam' => 'Gemeente Tilburg',
 				],
 			]);
@@ -399,7 +399,7 @@ class ContactMatchingServiceTest extends TestCase {
 				return [
 					[
 						'@self' => ['uuid' => 'org-uuid', 'schema' => 1, 'register' => 1],
-						'organisatie' => 'Gemeente Tilburg',
+						'organisation' => 'Gemeente Tilburg',
 						'naam' => 'Gemeente Tilburg',
 					],
 				];
@@ -455,7 +455,7 @@ class ContactMatchingServiceTest extends TestCase {
 		$object = [
 			'email' => 'jan@example.nl',
 			'naam' => 'Jan de Vries',
-			'functie' => 'Developer',
+			'role' => 'Developer',
 		];
 
 		// Should call remove once for the email property.
@@ -468,7 +468,7 @@ class ContactMatchingServiceTest extends TestCase {
 	public function testInvalidateCacheForObjectIgnoresNonEmailProperties(): void {
 		$object = [
 			'naam' => 'Jan de Vries',
-			'functie' => 'Developer',
+			'role' => 'Developer',
 		];
 
 		// Should not call remove for non-email properties.

--- a/tests/Unit/Service/Edepot/MdtoXmlGeneratorTest.php
+++ b/tests/Unit/Service/Edepot/MdtoXmlGeneratorTest.php
@@ -55,7 +55,7 @@ class MdtoXmlGeneratorTest extends TestCase {
 			retention: [
 				'archiefnominatie' => 'bewaren',
 				'bewaartermijn' => 'P20Y',
-				'classificatie' => 'A1',
+				'classification' => 'A1',
 			],
 			objectData: ['title' => 'Test Document']
 		);
@@ -80,7 +80,7 @@ class MdtoXmlGeneratorTest extends TestCase {
 			retention: [
 				'archiefnominatie' => 'bewaren',
 				'bewaartermijn' => 'P10Y',
-				'classificatie' => 'B1',
+				'classification' => 'B1',
 			]
 		);
 

--- a/tests/Unit/Service/File/PlaceholderIdTranslatorTest.php
+++ b/tests/Unit/Service/File/PlaceholderIdTranslatorTest.php
@@ -173,15 +173,15 @@ class PlaceholderIdTranslatorTest extends TestCase {
 	 * @return void
 	 */
 	public function testDifferentDossierRestartsAtOne(): void {
-		$dossierA = PlaceholderIdTranslator::forDossier(
+		$fileA = PlaceholderIdTranslator::forDossier(
 			rows: [['entity_id' => 11, 'file_id' => 100, 'position_start' => 4]]
 		);
-		$dossierB = PlaceholderIdTranslator::forDossier(
+		$fileB = PlaceholderIdTranslator::forDossier(
 			rows: [['entity_id' => 999, 'file_id' => 200, 'position_start' => 4]]
 		);
 
-		$this->assertSame(expected: 1, actual: $dossierA->translate(entityId: 11));
-		$this->assertSame(expected: 1, actual: $dossierB->translate(entityId: 999));
+		$this->assertSame(expected: 1, actual: $fileA->translate(entityId: 11));
+		$this->assertSame(expected: 1, actual: $fileB->translate(entityId: 999));
 
 	}//end testDifferentDossierRestartsAtOne()
 

--- a/tests/Unit/Service/Gdpr/Export/ExportBundleServiceTest.php
+++ b/tests/Unit/Service/Gdpr/Export/ExportBundleServiceTest.php
@@ -165,12 +165,12 @@ class ExportBundleServiceTest extends TestCase {
 			$this->createMock(LoggerInterface::class)
 		);
 
-		$dossier = $service->assembleRegulatorDossier(caseUuid: '00000000-0000-0000-0000-000000000000');
+		$file = $service->assembleRegulatorDossier(caseUuid: '00000000-0000-0000-0000-000000000000');
 
-		$this->assertCount(1, $dossier['evidence']);
-		$this->assertCount(1, $dossier['redactions']);
-		$this->assertSame('third-party-data', $dossier['redactions'][0]['ground']);
-		$this->assertArrayHasKey('history', $dossier);
+		$this->assertCount(1, $file['evidence']);
+		$this->assertCount(1, $file['redactions']);
+		$this->assertSame('third-party-data', $file['redactions'][0]['ground']);
+		$this->assertArrayHasKey('history', $file);
 
 	}//end testDossierReflectsEvidenceRedactionsHistory()
 

--- a/tests/Unit/Service/GraphQL/SchemaGeneratorTest.php
+++ b/tests/Unit/Service/GraphQL/SchemaGeneratorTest.php
@@ -163,8 +163,8 @@ class SchemaGeneratorTest extends TestCase {
 		$graphqlSchema = $this->generator->generate();
 		$queryType = $graphqlSchema->getQueryType();
 
-		$meldingen = $queryType->getField('meldingen');
-		$this->assertStringContainsString('Connection', $meldingen->getType()->name);
+		$reports = $queryType->getField('meldingen');
+		$this->assertStringContainsString('Connection', $reports->getType()->name);
 	}
 
 	public function testGeneratesMutationFields(): void {

--- a/tests/Unit/Service/Integration/IntegrationMockModeTest.php
+++ b/tests/Unit/Service/Integration/IntegrationMockModeTest.php
@@ -34,7 +34,7 @@ namespace OCA\OpenRegister\Tests\Unit\Service\Integration;
 use OCA\OpenRegister\Controller\CompanyLookupController;
 use OCA\OpenRegister\Controller\MessageDispatchController;
 use OCA\OpenRegister\Service\Integration\ExternalIntegrationRouter;
-use OCA\OpenRegister\Service\Integration\Providers\BrpPersoonProvider;
+use OCA\OpenRegister\Service\Integration\Providers\BrpPersonProvider;
 use OCA\OpenRegister\Service\Integration\Providers\KvkProvider;
 use OCA\OpenRegister\Service\Integration\Providers\MessageDispatchProvider;
 use OCA\OpenRegister\Service\Integration\Providers\OpenCorporatesProvider;
@@ -196,8 +196,8 @@ class IntegrationMockModeTest extends TestCase {
 			],
 		];
 
-		// @var BrpPersoonProvider $brp
-		$brp = $this->provider(BrpPersoonProvider::class, $fixture);
+		// @var BrpPersonProvider $brp
+		$brp = $this->provider(BrpPersonProvider::class, $fixture);
 		$result = $brp->lookupByBsn('999990019');
 
 		$this->assertArrayNotHasKey('unavailable', $result);

--- a/tests/Unit/Service/Integration/Providers/BrpPersonProviderTest.php
+++ b/tests/Unit/Service/Integration/Providers/BrpPersonProviderTest.php
@@ -52,7 +52,7 @@ use Psr\Log\LoggerInterface;
 /**
  * Unit tests for BrpPersonProvider.
  */
-class BrpPersoonProviderTest extends TestCase {
+class BrpPersonProviderTest extends TestCase {
 
 	/**
 	 * Mocked external-call router.

--- a/tests/Unit/Service/Integration/Providers/BrpPersonProviderTest.php
+++ b/tests/Unit/Service/Integration/Providers/BrpPersonProviderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Unit tests for BrpPersoonProvider.
+ * Unit tests for BrpPersonProvider.
  *
  * Covers:
  *  - metadata matches the leaf spec (id / label / icon / group /
@@ -43,14 +43,14 @@ namespace OCA\OpenRegister\Tests\Unit\Service\Integration\Providers;
 
 use OCA\OpenRegister\Exception\ProviderUnavailableException;
 use OCA\OpenRegister\Service\Integration\ExternalIntegrationRouter;
-use OCA\OpenRegister\Service\Integration\Providers\BrpPersoonProvider;
+use OCA\OpenRegister\Service\Integration\Providers\BrpPersonProvider;
 use OCP\App\IAppManager;
 use OCP\IL10N;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 /**
- * Unit tests for BrpPersoonProvider.
+ * Unit tests for BrpPersonProvider.
  */
 class BrpPersoonProviderTest extends TestCase {
 
@@ -71,9 +71,9 @@ class BrpPersoonProviderTest extends TestCase {
 	/**
 	 * System under test.
 	 *
-	 * @var BrpPersoonProvider
+	 * @var BrpPersonProvider
 	 */
-	private BrpPersoonProvider $provider;
+	private BrpPersonProvider $provider;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -84,7 +84,7 @@ class BrpPersoonProviderTest extends TestCase {
 		$l10n->method('t')->willReturnArgument(0);
 		$logger = $this->createMock(LoggerInterface::class);
 
-		$this->provider = new BrpPersoonProvider(
+		$this->provider = new BrpPersonProvider(
 			router: $this->router,
 			appManager: $this->appManager,
 			l10n: $l10n,
@@ -100,7 +100,7 @@ class BrpPersoonProviderTest extends TestCase {
 		$this->assertSame('openconnector', $this->provider->getRequiredApp());
 		$this->assertSame('external', $this->provider->getStorageStrategy());
 		$this->assertSame('brp-haalcentraal', $this->provider->getOpenConnectorSource());
-		$this->assertSame('brp-haalcentraal', BrpPersoonProvider::SOURCE_ID);
+		$this->assertSame('brp-haalcentraal', BrpPersonProvider::SOURCE_ID);
 		$this->assertNull($this->provider->requiresPermission());
 	}//end testMetadataMatchesLeafSpec()
 

--- a/tests/Unit/Service/Notification/VngNotificatiesEnvelopeTest.php
+++ b/tests/Unit/Service/Notification/VngNotificatiesEnvelopeTest.php
@@ -74,7 +74,7 @@ class VngNotificatiesEnvelopeTest extends TestCase {
 			schemaSlug: 'zaak',
 			objectUuid: 'abc-123',
 			baseUrl: 'https://or.example.nl',
-			kenmerken: ['zaaktype' => 'https://catalogi.example.nl/zaaktypen/abc', 'status' => 'open']
+			characteristics: ['zaaktype' => 'https://catalogi.example.nl/zaaktypen/abc', 'status' => 'open']
 		);
 
 		$this->assertSame(

--- a/tests/Unit/Service/OasServiceTest.php
+++ b/tests/Unit/Service/OasServiceTest.php
@@ -1500,8 +1500,8 @@ class OasServiceTest extends TestCase {
 		$oas = $this->service->createOas('1');
 
 		// Single register: no prefix
-		$getOp = $oas['paths']['/objects/reg/item']['get'];
-		$this->assertSame('getAllItem', $getOp['operationId']);
+		$getOn = $oas['paths']['/objects/reg/item']['get'];
+		$this->assertSame('getAllItem', $getOn['operationId']);
 	}
 
 	public function testCreateOasOperationIdWithPrefixForMultipleRegisters(): void {
@@ -1535,8 +1535,8 @@ class OasServiceTest extends TestCase {
 		$oas = $this->service->createOas('1');
 
 		// Operations should be tagged with schema title
-		$getOp = $oas['paths']['/objects/reg/item']['get'];
-		$this->assertContains('Item', $getOp['tags']);
+		$getOn = $oas['paths']['/objects/reg/item']['get'];
+		$this->assertContains('Item', $getOn['tags']);
 	}
 
 	public function testCreateOasGetCollectionHasPaginatedResponse(): void {
@@ -1569,8 +1569,8 @@ class OasServiceTest extends TestCase {
 
 		$oas = $this->service->createOas('1');
 
-		$getOp = $oas['paths']['/objects/reg/item/{id}']['get'];
-		$this->assertArrayHasKey('404', $getOp['responses']);
+		$getOn = $oas['paths']['/objects/reg/item/{id}']['get'];
+		$this->assertArrayHasKey('404', $getOn['responses']);
 	}
 
 	public function testCreateOasPostHas201Response(): void {
@@ -1584,9 +1584,9 @@ class OasServiceTest extends TestCase {
 
 		$oas = $this->service->createOas('1');
 
-		$postOp = $oas['paths']['/objects/reg/item']['post'];
-		$this->assertArrayHasKey('201', $postOp['responses']);
-		$this->assertArrayHasKey('requestBody', $postOp);
+		$postOn = $oas['paths']['/objects/reg/item']['post'];
+		$this->assertArrayHasKey('201', $postOn['responses']);
+		$this->assertArrayHasKey('requestBody', $postOn);
 	}
 
 	public function testCreateOasPutHasRequestBody(): void {
@@ -1600,9 +1600,9 @@ class OasServiceTest extends TestCase {
 
 		$oas = $this->service->createOas('1');
 
-		$putOp = $oas['paths']['/objects/reg/item/{id}']['put'];
-		$this->assertArrayHasKey('requestBody', $putOp);
-		$this->assertTrue($putOp['requestBody']['required']);
+		$putOn = $oas['paths']['/objects/reg/item/{id}']['put'];
+		$this->assertArrayHasKey('requestBody', $putOn);
+		$this->assertTrue($putOn['requestBody']['required']);
 	}
 
 	public function testCreateOasDeleteHas204And404Response(): void {
@@ -1616,9 +1616,9 @@ class OasServiceTest extends TestCase {
 
 		$oas = $this->service->createOas('1');
 
-		$deleteOp = $oas['paths']['/objects/reg/item/{id}']['delete'];
-		$this->assertArrayHasKey('204', $deleteOp['responses']);
-		$this->assertArrayHasKey('404', $deleteOp['responses']);
+		$deleteOn = $oas['paths']['/objects/reg/item/{id}']['delete'];
+		$this->assertArrayHasKey('204', $deleteOn['responses']);
+		$this->assertArrayHasKey('404', $deleteOn['responses']);
 	}
 
 	public function testCreateOasGetSingleHasIdPathParam(): void {
@@ -1632,8 +1632,8 @@ class OasServiceTest extends TestCase {
 
 		$oas = $this->service->createOas('1');
 
-		$getOp = $oas['paths']['/objects/reg/item/{id}']['get'];
-		$idParam = $getOp['parameters'][0];
+		$getOn = $oas['paths']['/objects/reg/item/{id}']['get'];
+		$idParam = $getOn['parameters'][0];
 		$this->assertSame('id', $idParam['name']);
 		$this->assertSame('path', $idParam['in']);
 		$this->assertTrue($idParam['required']);
@@ -1663,9 +1663,9 @@ class OasServiceTest extends TestCase {
 		$oas = $this->service->createOas('1');
 
 		// All paths should have 403 responses due to RBAC
-		$getOp = $oas['paths']['/objects/reg/protected']['get'];
-		$this->assertArrayHasKey('403', $getOp['responses']);
-		$this->assertStringContainsString('Required scopes', $getOp['description']);
+		$getOn = $oas['paths']['/objects/reg/protected']['get'];
+		$this->assertArrayHasKey('403', $getOn['responses']);
+		$this->assertStringContainsString('Required scopes', $getOn['description']);
 
 		// OAuth2 scopes should include all groups
 		$scopes = $oas['components']['securitySchemes']['oauth2']['flows']['authorizationCode']['scopes'];
@@ -1774,11 +1774,11 @@ class OasServiceTest extends TestCase {
 		$oas = $this->service->createOas('1');
 
 		$bedrijfSchema = $oas['components']['schemas']['Bedrijf'];
-		$vestigingProp = $bedrijfSchema['properties']['vestiging'];
+		$establishmentProp = $bedrijfSchema['properties']['vestiging'];
 
 		// Bare ref should be normalized to #/components/schemas/Vestiging
-		if (isset($vestigingProp['$ref'])) {
-			$this->assertStringStartsWith('#/components/schemas/', $vestigingProp['$ref']);
+		if (isset($establishmentProp['$ref'])) {
+			$this->assertStringStartsWith('#/components/schemas/', $establishmentProp['$ref']);
 		}
 	}
 
@@ -2083,18 +2083,18 @@ class OasServiceTest extends TestCase {
 		$oas = $this->service->createOas('1');
 
 		// GET single should reference the schema
-		$getOp = $oas['paths']['/objects/reg/widget/{id}']['get'];
-		$ref = $getOp['responses']['200']['content']['application/json']['schema']['$ref'];
+		$getOn = $oas['paths']['/objects/reg/widget/{id}']['get'];
+		$ref = $getOn['responses']['200']['content']['application/json']['schema']['$ref'];
 		$this->assertSame('#/components/schemas/Widget', $ref);
 
 		// PUT should reference schema in request body and response
-		$putOp = $oas['paths']['/objects/reg/widget/{id}']['put'];
-		$putReqRef = $putOp['requestBody']['content']['application/json']['schema']['$ref'];
+		$putOn = $oas['paths']['/objects/reg/widget/{id}']['put'];
+		$putReqRef = $putOn['requestBody']['content']['application/json']['schema']['$ref'];
 		$this->assertSame('#/components/schemas/Widget', $putReqRef);
 
 		// POST should reference schema
-		$postOp = $oas['paths']['/objects/reg/widget']['post'];
-		$postReqRef = $postOp['requestBody']['content']['application/json']['schema']['$ref'];
+		$postOn = $oas['paths']['/objects/reg/widget']['post'];
+		$postReqRef = $postOn['requestBody']['content']['application/json']['schema']['$ref'];
 		$this->assertSame('#/components/schemas/Widget', $postReqRef);
 	}
 
@@ -2109,8 +2109,8 @@ class OasServiceTest extends TestCase {
 
 		$oas = $this->service->createOas('1');
 
-		$deleteOp = $oas['paths']['/objects/reg/item/{id}']['delete'];
-		$this->assertArrayNotHasKey('requestBody', $deleteOp);
+		$deleteOn = $oas['paths']['/objects/reg/item/{id}']['delete'];
+		$this->assertArrayNotHasKey('requestBody', $deleteOn);
 	}
 
 	public function testCreateOasSchemaNotAddedToPathsIfNotInRegister(): void {
@@ -2157,8 +2157,8 @@ class OasServiceTest extends TestCase {
 
 		$oas = $this->service->createOas('1');
 
-		$postOp = $oas['paths']['/objects/reg/item']['post'];
-		$this->assertArrayHasKey('400', $postOp['responses']);
+		$postOn = $oas['paths']['/objects/reg/item']['post'];
+		$this->assertArrayHasKey('400', $postOn['responses']);
 	}
 
 	// ========================================================================
@@ -2429,8 +2429,8 @@ class OasServiceTest extends TestCase {
 
 		$oas = $this->getPrivateProperty('oas');
 
-		$getOp = $oas['paths']['/objects/my-reg/widget']['get'];
-		$this->assertStringStartsWith('MyPrefix', $getOp['operationId']);
+		$getOn = $oas['paths']['/objects/my-reg/widget']['get'];
+		$this->assertStringStartsWith('MyPrefix', $getOn['operationId']);
 	}
 
 	public function testAddCrudPathsFallsBackToSlugifiedTitle(): void {

--- a/tests/Unit/Service/Object/PermissionHandlerFailClosedTest.php
+++ b/tests/Unit/Service/Object/PermissionHandlerFailClosedTest.php
@@ -100,7 +100,7 @@ class PermissionHandlerFailClosedTest extends TestCase {
 	 *
 	 * @return void
 	 */
-	private function stageUser(): void {
+	private function internshipUser(): void {
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('alice');
 		$this->userSession->method('getUser')->willReturn($user);
@@ -150,7 +150,7 @@ class PermissionHandlerFailClosedTest extends TestCase {
 	 * @covers ::hasPermission
 	 */
 	public function testUnresolvableAuthorizationDeniesEveryAction(): void {
-		$this->stageUser();
+		$this->internshipUser();
 		$this->breakRegisterLookup();
 		$schema = $this->schemaWithoutOwnAuth();
 
@@ -173,7 +173,7 @@ class PermissionHandlerFailClosedTest extends TestCase {
 	 * @covers ::hasPermission
 	 */
 	public function testUnresolvableAuthorizationIsLogged(): void {
-		$this->stageUser();
+		$this->internshipUser();
 		$this->breakRegisterLookup();
 
 		$logged = [];
@@ -209,7 +209,7 @@ class PermissionHandlerFailClosedTest extends TestCase {
 	 * @covers ::hasPermission
 	 */
 	public function testResolutionFailureIsNotCachedAsAnAnswer(): void {
-		$this->stageUser();
+		$this->internshipUser();
 
 		$register = new \OCA\OpenRegister\Db\Register();
 		$register->setId(7);

--- a/tests/Unit/Service/Object/PermissionHandlerFailClosedTest.php
+++ b/tests/Unit/Service/Object/PermissionHandlerFailClosedTest.php
@@ -100,7 +100,7 @@ class PermissionHandlerFailClosedTest extends TestCase {
 	 *
 	 * @return void
 	 */
-	private function internshipUser(): void {
+	private function stageUser(): void {
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('alice');
 		$this->userSession->method('getUser')->willReturn($user);
@@ -150,7 +150,7 @@ class PermissionHandlerFailClosedTest extends TestCase {
 	 * @covers ::hasPermission
 	 */
 	public function testUnresolvableAuthorizationDeniesEveryAction(): void {
-		$this->internshipUser();
+		$this->stageUser();
 		$this->breakRegisterLookup();
 		$schema = $this->schemaWithoutOwnAuth();
 
@@ -173,7 +173,7 @@ class PermissionHandlerFailClosedTest extends TestCase {
 	 * @covers ::hasPermission
 	 */
 	public function testUnresolvableAuthorizationIsLogged(): void {
-		$this->internshipUser();
+		$this->stageUser();
 		$this->breakRegisterLookup();
 
 		$logged = [];
@@ -209,7 +209,7 @@ class PermissionHandlerFailClosedTest extends TestCase {
 	 * @covers ::hasPermission
 	 */
 	public function testResolutionFailureIsNotCachedAsAnAnswer(): void {
-		$this->internshipUser();
+		$this->stageUser();
 
 		$register = new \OCA\OpenRegister\Db\Register();
 		$register->setId(7);

--- a/tests/Unit/Service/Object/RenderObjectDeepTest.php
+++ b/tests/Unit/Service/Object/RenderObjectDeepTest.php
@@ -234,7 +234,7 @@ class RenderObjectDeepTest extends TestCase {
 	 */
 	public function testResolveSchemaReferenceWithPathReference(): void {
 		$ref = '#/components/schemas/Organisatie';
-		$schema = $this->createMockSchema(5, 'organisatie');
+		$schema = $this->createMockSchema(5, 'organisation');
 
 		$this->schemaMapper->method('findAll')
 			->willReturn([$schema]);
@@ -271,8 +271,8 @@ class RenderObjectDeepTest extends TestCase {
 	 * Test resolveSchemaReference with slug resolving to single schema.
 	 */
 	public function testResolveSchemaReferenceWithSlug(): void {
-		$slug = 'organisatie';
-		$schema = $this->createMockSchema(7, 'organisatie');
+		$slug = 'organisation';
+		$schema = $this->createMockSchema(7, 'organisation');
 
 		$this->schemaMapper->method('findAll')
 			->willReturn([$schema]);

--- a/tests/Unit/Service/Object/RenderObjectTest.php
+++ b/tests/Unit/Service/Object/RenderObjectTest.php
@@ -1689,7 +1689,7 @@ class RenderObjectTest extends TestCase {
 	}
 
 	public function testResolveSchemaReferenceBySlugPath(): void {
-		$schema = $this->createSchema(7, 'organisatie');
+		$schema = $this->createSchema(7, 'organisation');
 
 		$this->schemaMapper->method('find')
 			->willThrowException(new Exception('Not found'));
@@ -5968,7 +5968,7 @@ class RenderObjectTest extends TestCase {
 	 * @return void
 	 */
 	public function testResolveSchemaReferencePathRefFindsSchemaBySlug(): void {
-		$schema = $this->createSchema(55, 'organisatie');
+		$schema = $this->createSchema(55, 'organisation');
 
 		$this->schemaMapper->method('find')
 			->willThrowException(new Exception('Not found'));

--- a/tests/Unit/Service/Object/SaveObjectDeepTest.php
+++ b/tests/Unit/Service/Object/SaveObjectDeepTest.php
@@ -273,7 +273,7 @@ class SaveObjectDeepTest extends TestCase {
 
 	public function testResolveSchemaReferencePathBySlug(): void {
 		$ref = '#/components/schemas/Organisatie';
-		$schema = $this->createMockSchema(5, 'organisation');
+		$schema = $this->createMockSchema(5, 'organisatie');
 
 		$this->schemaMapper->method('findAll')
 			->willReturn([$schema]);

--- a/tests/Unit/Service/Object/SaveObjectDeepTest.php
+++ b/tests/Unit/Service/Object/SaveObjectDeepTest.php
@@ -273,7 +273,7 @@ class SaveObjectDeepTest extends TestCase {
 
 	public function testResolveSchemaReferencePathBySlug(): void {
 		$ref = '#/components/schemas/Organisatie';
-		$schema = $this->createMockSchema(5, 'organisatie');
+		$schema = $this->createMockSchema(5, 'organisation');
 
 		$this->schemaMapper->method('findAll')
 			->willReturn([$schema]);
@@ -777,8 +777,8 @@ class SaveObjectDeepTest extends TestCase {
 
 	public function testHydrateObjectMetadataDepublishedDate(): void {
 		// objectDepublishedField is deprecated — should not throw.
-		$entity = $this->createObjectEntity(1, 'uuid-1', ['eindDatum' => '2025-12-31']);
-		$schema = $this->createMockSchema(1, 'test', ['objectDepublishedField' => 'eindDatum']);
+		$entity = $this->createObjectEntity(1, 'uuid-1', ['endDate' => '2025-12-31']);
+		$schema = $this->createMockSchema(1, 'test', ['objectDepublishedField' => 'endDate']);
 
 		$this->metaHydrationHandler->method('extractMetadataValue')
 			->willReturn('2025-12-31');

--- a/tests/Unit/Service/Object/SaveObjectTest.php
+++ b/tests/Unit/Service/Object/SaveObjectTest.php
@@ -322,13 +322,13 @@ class SaveObjectTest extends TestCase {
 	public function testScanForRelationsFindsUuids(): void {
 		$data = [
 			'name' => 'Test',
-			'organisatie' => 'dec9ac6e-a4fd-40fc-be5f-e7ef6e5defb4',
+			'organisation' => 'dec9ac6e-a4fd-40fc-be5f-e7ef6e5defb4',
 		];
 
 		$result = $this->handler->scanForRelations($data);
 
-		$this->assertArrayHasKey('organisatie', $result);
-		$this->assertSame('dec9ac6e-a4fd-40fc-be5f-e7ef6e5defb4', $result['organisatie']);
+		$this->assertArrayHasKey('organisation', $result);
+		$this->assertSame('dec9ac6e-a4fd-40fc-be5f-e7ef6e5defb4', $result['organisation']);
 	}
 
 	public function testScanForRelationsFindsUrls(): void {
@@ -448,7 +448,7 @@ class SaveObjectTest extends TestCase {
 	public function testScanForRelationsWithSchemaPropertyTypes(): void {
 		$schemaObject = new \stdClass();
 		$schemaObject->properties = [
-			'organisatie' => [
+			'organisation' => [
 				'type' => 'object',
 				'format' => '',
 			],
@@ -456,13 +456,13 @@ class SaveObjectTest extends TestCase {
 		$schema = $this->createSchemaWithSchemaObject($schemaObject);
 
 		$data = [
-			'organisatie' => 'some-string-value',
+			'organisation' => 'some-string-value',
 		];
 
 		$result = $this->handler->scanForRelations($data, '', $schema);
 
 		// Object type with string value should be treated as relation.
-		$this->assertArrayHasKey('organisatie', $result);
+		$this->assertArrayHasKey('organisation', $result);
 	}
 
 	public function testScanForRelationsWithTextUuidFormatProperty(): void {

--- a/tests/Unit/Service/RetentionServiceTest.php
+++ b/tests/Unit/Service/RetentionServiceTest.php
@@ -247,9 +247,9 @@ class RetentionServiceTest extends TestCase {
 	public function testGenerateDestructionCertificate(): void {
 		$listData = [
 			'objects' => [
-				['schema' => '1', 'classificatie' => 'B1'],
-				['schema' => '1', 'classificatie' => 'B1'],
-				['schema' => '2', 'classificatie' => 'A1'],
+				['schema' => '1', 'classification' => 'B1'],
+				['schema' => '1', 'classification' => 'B1'],
+				['schema' => '2', 'classification' => 'A1'],
 			],
 			'approvals' => [
 				['userId' => 'archivist-1'],

--- a/tests/Unit/Service/RetentionServiceTest.php
+++ b/tests/Unit/Service/RetentionServiceTest.php
@@ -235,7 +235,7 @@ class RetentionServiceTest extends TestCase {
 			'defaultExtensionPeriod' => 'P1Y',
 		]);
 
-		$result = $this->service->extendArchiefactiedatum($object);
+		$result = $this->service->extendArchiveActionDate($object);
 		$retention = $result->getRetention();
 
 		$this->assertEquals('2027-01-01', $retention['archiefactiedatum']);

--- a/tests/Unit/Service/TmloExportTest.php
+++ b/tests/Unit/Service/TmloExportTest.php
@@ -67,7 +67,7 @@ class TmloExportTest extends TestCase {
 		$object->setUuid('test-uuid-123');
 		$object->setName('Test Object');
 		$object->setTmlo([
-			'classificatie' => '1.1',
+			'classification' => '1.1',
 			'archiefnominatie' => 'blijvend_bewaren',
 			'archiefactiedatum' => '2030-01-01',
 			'archiefstatus' => 'semi_statisch',
@@ -131,7 +131,7 @@ class TmloExportTest extends TestCase {
 		$object1->setName('Object 1');
 		$object1->setTmlo([
 			'archiefstatus' => 'actief',
-			'classificatie' => '1.1',
+			'classification' => '1.1',
 		]);
 
 		$object2 = new ObjectEntity();
@@ -139,7 +139,7 @@ class TmloExportTest extends TestCase {
 		$object2->setName('Object 2');
 		$object2->setTmlo([
 			'archiefstatus' => 'semi_statisch',
-			'classificatie' => '2.1',
+			'classification' => '2.1',
 		]);
 
 		$xml = $this->service->generateBatchMdtoXml([$object1, $object2]);
@@ -193,7 +193,7 @@ class TmloExportTest extends TestCase {
 		$object->setUuid('uuid-special');
 		$object->setName('Test & <Object>');
 		$object->setTmlo([
-			'classificatie' => '1.1 & 2.2',
+			'classification' => '1.1 & 2.2',
 			'archiefstatus' => 'actief',
 		]);
 

--- a/tests/Unit/Service/TmloServiceTest.php
+++ b/tests/Unit/Service/TmloServiceTest.php
@@ -413,7 +413,7 @@ class TmloServiceTest extends TestCase {
 	 * @return void
 	 */
 	public function testCalculateArchiefactiedatumValid(): void {
-		$result = $this->service->calculateArchiefactiedatum('P7Y');
+		$result = $this->service->calculateArchiveActionDate('P7Y');
 		$this->assertNotNull($result);
 
 		$expected = (new \DateTime())->modify('+7 years')->format('Y-m-d');
@@ -426,7 +426,7 @@ class TmloServiceTest extends TestCase {
 	 * @return void
 	 */
 	public function testCalculateArchiefactiedatumInvalid(): void {
-		$result = $this->service->calculateArchiefactiedatum('invalid');
+		$result = $this->service->calculateArchiveActionDate('invalid');
 		$this->assertNull($result);
 	}//end testCalculateArchiefactiedatumInvalid()
 

--- a/tests/Unit/Service/TmloServiceTest.php
+++ b/tests/Unit/Service/TmloServiceTest.php
@@ -158,7 +158,7 @@ class TmloServiceTest extends TestCase {
 		$schema->method('getConfiguration')
 			->willReturn([
 				'tmloDefaults' => [
-					'classificatie' => '1.1',
+					'classification' => '1.1',
 					'archiefnominatie' => 'vernietigen',
 					'bewaarTermijn' => 'P7Y',
 				],
@@ -169,7 +169,7 @@ class TmloServiceTest extends TestCase {
 		$result = $this->service->populateDefaults($object, $register, $schema);
 		$tmlo = $result->getTmlo();
 
-		$this->assertEquals('1.1', $tmlo['classificatie']);
+		$this->assertEquals('1.1', $tmlo['classification']);
 		$this->assertEquals('vernietigen', $tmlo['archiefnominatie']);
 		$this->assertEquals('P7Y', $tmlo['bewaarTermijn']);
 		$this->assertEquals('actief', $tmlo['archiefstatus']);
@@ -189,17 +189,17 @@ class TmloServiceTest extends TestCase {
 		$schema->method('getConfiguration')
 			->willReturn([
 				'tmloDefaults' => [
-					'classificatie' => '1.1',
+					'classification' => '1.1',
 				],
 			]);
 
 		$object = new ObjectEntity();
-		$object->setTmlo(['classificatie' => '2.2']);
+		$object->setTmlo(['classification' => '2.2']);
 
 		$result = $this->service->populateDefaults($object, $register, $schema);
 		$tmlo = $result->getTmlo();
 
-		$this->assertEquals('2.2', $tmlo['classificatie']);
+		$this->assertEquals('2.2', $tmlo['classification']);
 	}//end testPopulateDefaultsDoesNotOverrideExplicitValues()
 
 	/**
@@ -350,7 +350,7 @@ class TmloServiceTest extends TestCase {
 		);
 
 		$this->assertNotEmpty($errors);
-		$this->assertStringContainsString('classificatie', $errors[0]);
+		$this->assertStringContainsString('classification', $errors[0]);
 	}//end testValidateTransitionToOvergebrachtRequiresFields()
 
 	/**
@@ -364,7 +364,7 @@ class TmloServiceTest extends TestCase {
 				'archiefstatus' => 'vernietigd',
 				'archiefnominatie' => 'blijvend_bewaren',
 				'archiefactiedatum' => '2025-01-01',
-				'classificatie' => '1.1',
+				'classification' => '1.1',
 				'vernietigingsCategorie' => 'cat1',
 			],
 			'semi_statisch'
@@ -399,7 +399,7 @@ class TmloServiceTest extends TestCase {
 				'archiefstatus' => 'overgebracht',
 				'archiefnominatie' => 'blijvend_bewaren',
 				'archiefactiedatum' => '2025-06-01',
-				'classificatie' => '1.1',
+				'classification' => '1.1',
 			],
 			'semi_statisch'
 		);
@@ -440,14 +440,14 @@ class TmloServiceTest extends TestCase {
 		$schema->method('getConfiguration')
 			->willReturn([
 				'tmloDefaults' => [
-					'classificatie' => '1.1',
+					'classification' => '1.1',
 					'bewaarTermijn' => 'P5Y',
 				],
 			]);
 
 		$defaults = $this->service->getSchemaDefaults($schema);
 
-		$this->assertEquals('1.1', $defaults['classificatie']);
+		$this->assertEquals('1.1', $defaults['classification']);
 		$this->assertEquals('P5Y', $defaults['bewaarTermijn']);
 	}//end testGetSchemaDefaults()
 

--- a/tests/Unit/Service/UserServiceCoverageTest.php
+++ b/tests/Unit/Service/UserServiceCoverageTest.php
@@ -246,7 +246,7 @@ class UserServiceCoverageTest extends TestCase {
 			['testuser', 'core', 'lastName', '', 'Doe'],
 			['testuser', 'core', 'middleName', '', ''],
 			['testuser', 'core', 'organisation', '', ''],
-			['testuser', 'core', 'functie', '', 'Developer'],
+			['testuser', 'core', 'role', '', 'Developer'],
 		]);
 
 		$result = $this->invokeMethod($this->userService, 'getAdditionalProfileInfo', [$user]);
@@ -272,7 +272,7 @@ class UserServiceCoverageTest extends TestCase {
 			['testuser', 'core', 'lastName', '', ''],
 			['testuser', 'core', 'middleName', '', ''],
 			['testuser', 'core', 'organisation', '', 'org-uuid-123'],
-			['testuser', 'core', 'functie', '', ''],
+			['testuser', 'core', 'role', '', ''],
 		]);
 
 		$result = $this->invokeMethod($this->userService, 'getAdditionalProfileInfo', [$user]);

--- a/tests/Unit/Service/UserServiceTest.php
+++ b/tests/Unit/Service/UserServiceTest.php
@@ -706,21 +706,21 @@ class UserServiceTest extends TestCase {
 
 		$result = $this->service->buildUserDataArray($user);
 
-		// 'functie' should be set from 'role' when not separately provided
-		$this->assertSame('Ontwikkelaar', $result['functie']);
+		// 'role' should be set from 'role' when not separately provided
+		$this->assertSame('Ontwikkelaar', $result['role']);
 	}
 
 	public function testBuildUserDataArrayFunctieFallbackFromConfig(): void {
 		$user = $this->createUserMock();
 
 		// No role in AccountManager, but functie in user config
-		$this->setupBuildMocks(configMap: ['functie' => 'Manager']);
+		$this->setupBuildMocks(configMap: ['role' => 'Manager']);
 
 		$result = $this->service->buildUserDataArray($user);
 
-		// 'role' comes from config fallback, and 'functie' mirrors it
+		// 'role' comes from config fallback, and 'role' mirrors it
 		$this->assertSame('Manager', $result['role']);
-		$this->assertSame('Manager', $result['functie']);
+		$this->assertSame('Manager', $result['role']);
 	}
 
 	public function testBuildUserDataArrayCustomNameFieldsFromConfig(): void {
@@ -1303,19 +1303,19 @@ class UserServiceTest extends TestCase {
 		$account = $this->createAccountMock();
 		$this->accountManager->method('getAccount')->willReturn($account);
 
-		$functieCaptured = false;
+		$roleCaptured = false;
 		$this->config->method('getUserValue')->willReturn('');
 		$this->config->method('setUserValue')->willReturnCallback(
-			function ($uid, $app, $key, $value) use (&$functieCaptured) {
-				if ($key === 'functie' && $value === 'Beheerder') {
-					$functieCaptured = true;
+			function ($uid, $app, $key, $value) use (&$roleCaptured) {
+				if ($key === 'role' && $value === 'Beheerder') {
+					$roleCaptured = true;
 				}
 			}
 		);
 
-		$this->service->updateUserProperties($user, ['functie' => 'Beheerder']);
+		$this->service->updateUserProperties($user, ['role' => 'Beheerder']);
 
-		$this->assertTrue($functieCaptured, 'functie should be stored in user config');
+		$this->assertTrue($roleCaptured, 'functie should be stored in user config');
 	}
 
 	public function testUpdateUserPropertiesOrgSwitchInvalidatesCacheAndRefetches(): void {
@@ -1645,7 +1645,7 @@ class UserServiceTest extends TestCase {
 		$this->config->method('getUserValue')->willReturn('');
 
 		$service = $this->freshService();
-		$service->updateUserProperties($user, ['functie' => 'Beheerder']);
+		$service->updateUserProperties($user, ['role' => 'Beheerder']);
 	}
 
 	/**
@@ -1695,7 +1695,7 @@ class UserServiceTest extends TestCase {
 
 		$result = $this->service->buildUserDataArray($user);
 
-		$this->assertNull($result['functie']);
+		$this->assertNull($result['role']);
 	}
 
 	/**


### PR DESCRIPTION
**14 property names** plus the identifiers and comments that reference them.

## Most of this app's Dutch is not its own vocabulary

openregister mirrors the Dutch **national base registries**, and those field names *are* the published standards — the APIs it reads return exactly them. All **91 properties** in `bag_register`, `brp_register`, `kvk_register` and `dso_register` are excluded, with the reason recorded:

`huisnummertoevoeging` · `adresseerbaarObjectIdentificatie` · `nationaliteit` · `geslachtsaanduiding` · `datumInschrijvingInGemeente` · `vestigingsnummer` · `oorspronkelijkBouwjaar` · `indHoofdvestiging` · `postbusnummer`

Renaming those would make the model diverge from the registry it mirrors. What remains — 14 names in `ori` and `credential-broker` — is openregister's own.

## The migration covers two registers of fourteen

Ownership verified **per file**: the renamed properties live in `ori` and `credential-broker`. A single `ori%` prefix would have silently skipped the second, leaving its column Dutch for ever while every read looked at the English name — the same defect pipelinq's `sla` register nearly shipped.

## Half-compounds

`bovenliggendAgendapunt → bovenliggendAgendaItem`, `stemmenVoor → stemmenFor` and `stemmenTegen → votesTegen` all slipped the residual guard, because `bovenliggend`, `stemmen` and `tegen` carry none of the Dutch orthographic markers it looks for. Dictionary extended, guard widened; results are now `parentAgendaItem`, `votesFor`, `votesAgainst`.

## One real defect

`UserService` exposed a Dutch alias `functie` alongside Nextcloud's own `role` account property. With both renamed to `role` the array had a **duplicate key** and the assignment became self-referential. phpstan caught it; the redundant alias is removed rather than left as dead code.

## Verification

In the `nextcloud` container against a control run of clean `development`:

- **phpstan [OK]** (baseline [OK]) · **phpcs 0 errors** (baseline 0)
- phpunit **fatals identically on both** — the container's OCP stubs predate two `IRequest` methods. That's a rig limitation, not a code change; CI runs the suite properly.