### PR TITLE
file-actions: built by hydra for #1549

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -307,7 +307,17 @@ return [
 		['name' => 'files#delete', 'url' => '/api/objects/{register}/{schema}/{id}/files/{fileId}', 'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+', 'fileId' => '\d+']],
 		['name' => 'files#publish', 'url' => '/api/objects/{register}/{schema}/{id}/files/{fileId}/publish', 'verb' => 'POST', 'requirements' => ['id' => '[^/]+', 'fileId' => '\d+']],
 		['name' => 'files#depublish', 'url' => '/api/objects/{register}/{schema}/{id}/files/{fileId}/depublish', 'verb' => 'POST', 'requirements' => ['id' => '[^/]+', 'fileId' => '\d+']],
-        
+		['name' => 'files#rename', 'url' => '/api/objects/{register}/{schema}/{id}/files/{fileId}/rename', 'verb' => 'PUT', 'requirements' => ['id' => '[^/]+', 'fileId' => '\d+']],
+		['name' => 'files#copy', 'url' => '/api/objects/{register}/{schema}/{id}/files/{fileId}/copy', 'verb' => 'POST', 'requirements' => ['id' => '[^/]+', 'fileId' => '\d+']],
+		['name' => 'files#move', 'url' => '/api/objects/{register}/{schema}/{id}/files/{fileId}/move', 'verb' => 'POST', 'requirements' => ['id' => '[^/]+', 'fileId' => '\d+']],
+		['name' => 'files#listVersions', 'url' => '/api/objects/{register}/{schema}/{id}/files/{fileId}/versions', 'verb' => 'GET', 'requirements' => ['id' => '[^/]+', 'fileId' => '\d+']],
+		['name' => 'files#restoreVersion', 'url' => '/api/objects/{register}/{schema}/{id}/files/{fileId}/versions/{versionId}/restore', 'verb' => 'POST', 'requirements' => ['id' => '[^/]+', 'fileId' => '\d+']],
+		['name' => 'files#lock', 'url' => '/api/objects/{register}/{schema}/{id}/files/{fileId}/lock', 'verb' => 'POST', 'requirements' => ['id' => '[^/]+', 'fileId' => '\d+']],
+		['name' => 'files#unlock', 'url' => '/api/objects/{register}/{schema}/{id}/files/{fileId}/unlock', 'verb' => 'POST', 'requirements' => ['id' => '[^/]+', 'fileId' => '\d+']],
+		['name' => 'files#batch', 'url' => '/api/objects/{register}/{schema}/{id}/files/batch', 'verb' => 'POST', 'requirements' => ['id' => '[^/]+']],
+		['name' => 'files#preview', 'url' => '/api/objects/{register}/{schema}/{id}/files/{fileId}/preview', 'verb' => 'GET', 'requirements' => ['id' => '[^/]+', 'fileId' => '\d+']],
+		['name' => 'files#updateLabels', 'url' => '/api/objects/{register}/{schema}/{id}/files/{fileId}/labels', 'verb' => 'PUT', 'requirements' => ['id' => '[^/]+', 'fileId' => '\d+']],
+
         // Direct file access by ID (authenticated).
         ['name' => 'files#downloadById', 'url' => '/api/files/{fileId}/download', 'verb' => 'GET', 'requirements' => ['fileId' => '\d+']],
 

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -187,6 +187,8 @@ class FilesController extends Controller
      * @NoCSRFRequired
      *
      * @PublicPage
+     *
+     * @spec openspec/changes/file-actions/tasks.md#phase-9-download-audit-logging
      */
     public function show(
         string $register,
@@ -524,6 +526,8 @@ class FilesController extends Controller
      * @param string $id       Object ID
      *
      * @return ObjectEntity|null Object entity or null if not found
+     *
+     * @throws DoesNotExistException If the register, schema, or object cannot be found.
      */
     private function validateAndGetObject(string $register, string $schema, string $id): ?ObjectEntity
     {
@@ -784,6 +788,8 @@ class FilesController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/file-actions/tasks.md#phase-5-file-locking
      */
     public function update(
         string $register,
@@ -1347,6 +1353,8 @@ class FilesController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/file-actions/tasks.md#phase-4-file-versioning
      */
     public function restoreVersion(
         string $register,
@@ -1405,6 +1413,8 @@ class FilesController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/file-actions/tasks.md#phase-5-file-locking
      */
     public function lock(string $register, string $schema, string $id, int $fileId): JSONResponse
     {
@@ -1453,6 +1463,8 @@ class FilesController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     *
+     * @spec openspec/changes/file-actions/tasks.md#phase-5-file-locking
      */
     public function unlock(string $register, string $schema, string $id, int $fileId): JSONResponse
     {

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -219,6 +219,14 @@ class FilesController extends Controller
                 );
             }
 
+            $this->fileService->getAuditHandler()->logDownload(
+                object: $object,
+                fileId: $fileId,
+                fileName: $file->getName(),
+                fileSize: $file->getSize(),
+                mimeType: $file->getMimeType()
+            );
+
             // Stream the file inline so browsers display images/logos directly.
             $response = new StreamResponse($file->fopen('r'));
             $response->addHeader('Content-Type', $file->getMimeType());
@@ -809,7 +817,8 @@ class FilesController extends Controller
         } catch (DoesNotExistException $e) {
             return new JSONResponse(data: ['error' => 'Object not found'], statusCode: 404);
         } catch (Exception $e) {
-            return new JSONResponse(data: ['error' => $e->getMessage()], statusCode: 400);
+            $statusCode = str_contains($e->getMessage(), 'locked') === true ? 423 : 400;
+            return new JSONResponse(data: ['error' => $e->getMessage()], statusCode: $statusCode);
         }//end try
     }//end update()
 
@@ -855,9 +864,10 @@ class FilesController extends Controller
         } catch (DoesNotExistException $e) {
             return new JSONResponse(data: ['error' => 'Object not found'], statusCode: 404);
         } catch (Exception $e) {
+            $statusCode = str_contains($e->getMessage(), 'locked') === true ? 423 : 400;
             return new JSONResponse(
                 data: ['error' => $e->getMessage()],
-                statusCode: 400
+                statusCode: $statusCode
             );
         }
     }//end delete()
@@ -1362,6 +1372,12 @@ class FilesController extends Controller
 
             $this->fileService->getVersioningHandler()->restoreVersion($file, $versionId);
 
+            $this->fileService->getAuditHandler()->logFileAction(
+                object: $object,
+                action: "file.version_restored",
+                data: ["versionId" => $versionId, "fileId" => $fileId]
+            );
+
             $this->eventDispatcher->dispatchTyped(
                 new FileVersionRestoredEvent(
                     objectUuid: $object->getUuid(),
@@ -1403,6 +1419,12 @@ class FilesController extends Controller
             }
 
             $result = $this->fileService->getLockHandler()->lockFile($fileId);
+
+            $this->fileService->getAuditHandler()->logFileAction(
+                object: $object,
+                action: "file.locked",
+                data: array_merge(["fileId" => $fileId], $result)
+            );
 
             $this->eventDispatcher->dispatchTyped(
                 new FileLockedEvent(
@@ -1448,6 +1470,12 @@ class FilesController extends Controller
             $force = $this->parseBool(value: $data["force"] ?? false);
 
             $result = $this->fileService->getLockHandler()->unlockFile($fileId, $force);
+
+            $this->fileService->getAuditHandler()->logFileAction(
+                object: $object,
+                action: $force === true ? "file.force_unlocked" : "file.unlocked",
+                data: ["fileId" => $fileId, "force" => $force]
+            );
 
             $this->eventDispatcher->dispatchTyped(
                 new FileUnlockedEvent(

--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -2711,6 +2711,8 @@ class ObjectsController extends Controller
      *
      * @psalm-suppress NoValue
      *
+     * @throws DoesNotExistException If the register or schema cannot be found.
+     *
      * @spec openspec/changes/retrofit-annotate-openregister-2026-04-30/tasks.md#task-22
      */
     public function export(string $register, string $schema, ObjectService $objectService): DataDownloadResponse
@@ -2981,6 +2983,8 @@ class ObjectsController extends Controller
      *
      * @throws ContainerExceptionInterface If there's an issue with dependency injection.
      * @throws NotFoundExceptionInterface If the FileService dependency is not found.
+     *
+     * @spec openspec/changes/file-actions/tasks.md#phase-9-download-audit-logging
      *
      * @NoAdminRequired
      * @NoCSRFRequired

--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -3028,6 +3028,13 @@ class ObjectsController extends Controller
                 unlink($zipInfo['path']);
             }
 
+            $includedFiles = $zipInfo['files'] ?? [];
+            $fileService->getAuditHandler()->logBulkDownload(
+                object: $object,
+                fileIds: array_column($includedFiles, 'fileId'),
+                fileNames: array_column($includedFiles, 'fileName')
+            );
+
             // Return the ZIP file as a download response.
             return new DataDownloadResponse(
                 $zipContent,

--- a/lib/Service/File/FileAuditHandler.php
+++ b/lib/Service/File/FileAuditHandler.php
@@ -8,6 +8,7 @@
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
  * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  */
@@ -35,6 +36,7 @@ use Psr\Log\LoggerInterface;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
  * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
@@ -67,6 +69,8 @@ class FileAuditHandler
      * @param string       $mimeType The file MIME type.
      *
      * @return void
+     *
+     * @spec openspec/changes/file-actions/tasks.md#phase-9-download-audit-logging
      */
     public function logDownload(
         ObjectEntity $object,
@@ -108,6 +112,8 @@ class FileAuditHandler
      * @param array        $fileNames Array of file names included in the archive.
      *
      * @return void
+     *
+     * @spec openspec/changes/file-actions/tasks.md#phase-9-download-audit-logging
      */
     public function logBulkDownload(ObjectEntity $object, array $fileIds, array $fileNames): void
     {
@@ -126,6 +132,8 @@ class FileAuditHandler
      * @param array        $data   Additional context data for the entry.
      *
      * @return void
+     *
+     * @spec openspec/changes/file-actions/tasks.md
      */
     public function logFileAction(ObjectEntity $object, string $action, array $data=[]): void
     {

--- a/lib/Service/File/FileAuditHandler.php
+++ b/lib/Service/File/FileAuditHandler.php
@@ -20,15 +20,17 @@ use DateTime;
 use Exception;
 use OCA\OpenRegister\Db\AuditTrail;
 use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
 use OCP\IRequest;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 /**
- * Handles file download audit logging.
+ * Handles audit logging for file actions.
  *
- * Creates audit trail entries for all file downloads (authenticated and anonymous),
- * tracks download counts, and logs bulk downloads.
+ * Creates audit trail entries for file downloads (authenticated and anonymous),
+ * bulk downloads, and other file actions (rename, copy, move, lock, unlock,
+ * version restore) via the shared AuditTrailMapper.
  *
  * @category Service
  * @package  OCA\OpenRegister
@@ -58,20 +60,20 @@ class FileAuditHandler
     /**
      * Log a file download event.
      *
-     * @param int    $fileId     The file ID that was downloaded.
-     * @param string $fileName   The file name.
-     * @param int    $fileSize   The file size in bytes.
-     * @param string $mimeType   The file MIME type.
-     * @param string $objectUuid The UUID of the parent object.
+     * @param ObjectEntity $object   The parent object entity.
+     * @param int          $fileId   The file ID that was downloaded.
+     * @param string       $fileName The file name.
+     * @param int          $fileSize The file size in bytes.
+     * @param string       $mimeType The file MIME type.
      *
      * @return void
      */
     public function logDownload(
+        ObjectEntity $object,
         int $fileId,
         string $fileName,
         int $fileSize,
-        string $mimeType,
-        string $objectUuid
+        string $mimeType
     ): void {
         try {
             $userId = $this->getCurrentUserId();
@@ -88,10 +90,7 @@ class FileAuditHandler
                 $data['userAgent']     = $this->request->getHeader('User-Agent');
             }
 
-            $this->logger->info(
-                message: "[FileAuditHandler] Download logged for file {$fileId} by {$userId}",
-                context: ['file' => __FILE__, 'line' => __LINE__]
-            );
+            $this->persistEntry(object: $object, action: 'file.downloaded', data: $data);
         } catch (Exception $e) {
             // Audit logging should never break the download flow.
             $this->logger->warning(
@@ -104,28 +103,56 @@ class FileAuditHandler
     /**
      * Log a bulk download event (ZIP archive).
      *
-     * @param array  $fileIds    Array of file IDs included in the archive.
-     * @param array  $fileNames  Array of file names included in the archive.
-     * @param string $objectUuid The UUID of the parent object.
+     * @param ObjectEntity $object    The parent object entity.
+     * @param array        $fileIds   Array of file IDs included in the archive.
+     * @param array        $fileNames Array of file names included in the archive.
      *
      * @return void
      */
-    public function logBulkDownload(array $fileIds, array $fileNames, string $objectUuid): void
+    public function logBulkDownload(ObjectEntity $object, array $fileIds, array $fileNames): void
+    {
+        $this->persistEntry(
+            object: $object,
+            action: 'file.bulk_downloaded',
+            data: ['fileIds' => $fileIds, 'fileNames' => $fileNames]
+        );
+    }//end logBulkDownload()
+
+    /**
+     * Log a generic file action event (rename, copy, move, lock, unlock, version restore, ...).
+     *
+     * @param ObjectEntity $object The object the action relates to.
+     * @param string       $action The audit action identifier (e.g. "file.renamed").
+     * @param array        $data   Additional context data for the entry.
+     *
+     * @return void
+     */
+    public function logFileAction(ObjectEntity $object, string $action, array $data=[]): void
+    {
+        $this->persistEntry(object: $object, action: $action, data: $data);
+    }//end logFileAction()
+
+    /**
+     * Persist an audit trail entry, never letting audit failures break the calling flow.
+     *
+     * @param ObjectEntity $object The object the entry relates to.
+     * @param string       $action The audit action identifier.
+     * @param array        $data   Additional context data for the entry.
+     *
+     * @return void
+     */
+    private function persistEntry(ObjectEntity $object, string $action, array $data): void
     {
         try {
-            $userId = $this->getCurrentUserId();
-
-            $this->logger->info(
-                message: '[FileAuditHandler] Bulk download logged for '.count($fileIds)." files by {$userId}",
-                context: ['file' => __FILE__, 'line' => __LINE__]
-            );
+            $this->auditTrailMapper->createAuditTrailEntry(object: $object, action: $action, context: $data);
         } catch (Exception $e) {
+            // Audit logging should never break the calling file operation.
             $this->logger->warning(
-                message: '[FileAuditHandler] Failed to log bulk download: '.$e->getMessage(),
+                message: "[FileAuditHandler] Failed to log {$action}: ".$e->getMessage(),
                 context: ['file' => __FILE__, 'line' => __LINE__]
             );
-        }//end try
-    }//end logBulkDownload()
+        }
+    }//end persistEntry()
 
     /**
      * Get the current user ID.

--- a/lib/Service/File/FilePublishingHandler.php
+++ b/lib/Service/File/FilePublishingHandler.php
@@ -8,6 +8,7 @@
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
  * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12 https://www.gnu.org/licenses/agpl-3.0.html
  * @link     https://github.com/ConductionNL/openregister
  */
@@ -38,6 +39,7 @@ use ZipArchive;
  * @category Service
  * @package  OCA\OpenRegister
  * @author   Conduction <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
  * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12 https://www.gnu.org/licenses/agpl-3.0.html
  * @link     https://github.com/ConductionNL/openregister
  * @version  1.0.0
@@ -500,6 +502,8 @@ class FilePublishingHandler
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)  ZIP creation requires handling multiple file and error scenarios
      * @SuppressWarnings(PHPMD.NPathComplexity)       Multiple paths for file processing and error handling
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength) ZIP archive creation with file processing requires extensive code
+     *
+     * @spec openspec/changes/file-actions/tasks.md#phase-9-download-audit-logging
      */
     public function createObjectFilesZip(ObjectEntity | string $object, ?string $zipName=null): array
     {

--- a/lib/Service/File/FilePublishingHandler.php
+++ b/lib/Service/File/FilePublishingHandler.php
@@ -489,13 +489,13 @@ class FilePublishingHandler
      * @param ObjectEntity|string $object  The object entity or ID.
      * @param string|null         $zipName Optional custom name for the ZIP file.
      *
-     * @return (int|string)[]
+     * @return (int|string|array)[]
      *
      * @throws Exception If ZIP creation fails.
      *
-     * @phpstan-return array{path: string, filename: string, size: int, mimeType: string}
+     * @phpstan-return array{path: string, filename: string, size: int, mimeType: string, files: array<int, array{fileId: int, fileName: string}>}
      *
-     * @psalm-return array{path: string, filename: string, size: int, mimeType: 'application/zip'}
+     * @psalm-return array{path: string, filename: string, size: int, mimeType: 'application/zip', files: array<int, array{fileId: int, fileName: string}>}
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)  ZIP creation requires handling multiple file and error scenarios
      * @SuppressWarnings(PHPMD.NPathComplexity)       Multiple paths for file processing and error handling
@@ -555,6 +555,7 @@ class FilePublishingHandler
 
         $addedFiles   = 0;
         $skippedFiles = 0;
+        $includedFiles = [];
 
         // Add each file to the ZIP archive.
         foreach ($files as $file) {
@@ -588,6 +589,7 @@ class FilePublishingHandler
                 }
 
                 $addedFiles++;
+                $includedFiles[] = ['fileId' => $file->getId(), 'fileName' => $fileName];
                 $this->logger->debug(
                     message: "[FilePublishingHandler] Added file to ZIP: ".$fileName,
                     context: ['file' => __FILE__, 'line' => __LINE__]
@@ -629,6 +631,7 @@ class FilePublishingHandler
             'filename' => $zipName,
             'size'     => $fileSize,
             'mimeType' => 'application/zip',
+            'files'    => $includedFiles,
         ];
     }//end createObjectFilesZip()
 

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -1151,6 +1151,8 @@ class FileService
      *
      * @phpstan-param array<int, string> $tags
      * @psalm-param   array<int, string> $tags
+     *
+     * @spec openspec/changes/file-actions/tasks.md#phase-5-file-locking
      */
     public function updateFile(string|int $filePath, mixed $content=null, array $tags=[], ?ObjectEntity $object=null): File
     {
@@ -1201,6 +1203,8 @@ class FileService
      * @return bool True if successful, false if the file didn't exist.
      *
      * @throws Exception If deleting the file is not permitted or file operations fail.
+     *
+     * @spec openspec/changes/file-actions/tasks.md#phase-5-file-locking
      */
     public function deleteFile(Node | string | int $file, ?ObjectEntity $object=null): bool
     {
@@ -1826,6 +1830,8 @@ class FileService
      * @return File The renamed file.
      *
      * @throws Exception If the rename fails.
+     *
+     * @spec openspec/changes/file-actions/tasks.md#phase-2-file-rename
      */
     public function renameFile(ObjectEntity $object, int $fileId, string $newName): File
     {
@@ -1887,6 +1893,8 @@ class FileService
      * @return File The new file copy.
      *
      * @throws Exception If the copy fails.
+     *
+     * @spec openspec/changes/file-actions/tasks.md#phase-3-file-copy-and-move
      */
     public function copyFile(ObjectEntity $sourceObject, int $fileId, ObjectEntity $targetObject): File
     {
@@ -1954,6 +1962,8 @@ class FileService
      * @return File The moved file.
      *
      * @throws Exception If the move fails.
+     *
+     * @spec openspec/changes/file-actions/tasks.md#phase-3-file-copy-and-move
      */
     public function moveFile(ObjectEntity $sourceObject, int $fileId, ObjectEntity $targetObject): File
     {

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -1154,6 +1154,11 @@ class FileService
      */
     public function updateFile(string|int $filePath, mixed $content=null, array $tags=[], ?ObjectEntity $object=null): File
     {
+        // Check lock.
+        if (is_int($filePath) === true) {
+            $this->fileLockHandler->assertCanModify($filePath);
+        }
+
         return $this->updateFileHandler->updateFile(
             filePath: $filePath,
             content: $content,
@@ -1199,6 +1204,13 @@ class FileService
      */
     public function deleteFile(Node | string | int $file, ?ObjectEntity $object=null): bool
     {
+        // Check lock.
+        if (is_int($file) === true) {
+            $this->fileLockHandler->assertCanModify($file);
+        } else if ($file instanceof Node === true) {
+            $this->fileLockHandler->assertCanModify($file->getId());
+        }
+
         return $this->deleteFileHandler->deleteFile(
             file: $file,
             object: $object
@@ -1547,10 +1559,10 @@ class FileService
      * @throws NotFoundException If the object folder is not found
      * @throws NotPermittedException If file access is not permitted
      *
-     * @return (int|string)[]
+     * @return (int|string|array)[]
      *
-     * @psalm-return   array{path: string, filename: string, size: int, mimeType: 'application/zip'}
-     * @phpstan-return array{path: string, filename: string, size: int, mimeType: string}
+     * @psalm-return   array{path: string, filename: string, size: int, mimeType: 'application/zip', files: array<int, array{fileId: int, fileName: string}>}
+     * @phpstan-return array{path: string, filename: string, size: int, mimeType: string, files: array<int, array{fileId: int, fileName: string}>}
      */
     public function createObjectFilesZip(ObjectEntity | string $object, ?string $zipName=null): array
     {
@@ -1846,12 +1858,20 @@ class FileService
             // Name is available.
         }
 
+        $oldName = $file->getName();
+
         // Perform the rename via move in same folder.
         $file->move($parent->getPath()."/".$newName);
 
         $this->logger->info(
             message: "[FileService] Renamed file {$fileId} to {$newName}",
             context: ["file" => __FILE__, "line" => __LINE__]
+        );
+
+        $this->fileAuditHandler->logFileAction(
+            object: $object,
+            action: "file.renamed",
+            data: ["fileId" => $fileId, "oldName" => $oldName, "newName" => $newName]
         );
 
         return $file;
@@ -1869,6 +1889,37 @@ class FileService
      * @throws Exception If the copy fails.
      */
     public function copyFile(ObjectEntity $sourceObject, int $fileId, ObjectEntity $targetObject): File
+    {
+        $newFile = $this->copyFileContent(sourceObject: $sourceObject, fileId: $fileId, targetObject: $targetObject);
+
+        $this->fileAuditHandler->logFileAction(
+            object: $sourceObject,
+            action: "file.copied_from",
+            data: ["fileId" => $fileId, "fileName" => $newFile->getName(), "targetObjectUuid" => $targetObject->getUuid(), "targetFileId" => $newFile->getId()]
+        );
+        $this->fileAuditHandler->logFileAction(
+            object: $targetObject,
+            action: "file.copied_to",
+            data: ["fileId" => $newFile->getId(), "fileName" => $newFile->getName(), "sourceObjectUuid" => $sourceObject->getUuid(), "sourceFileId" => $fileId]
+        );
+
+        return $newFile;
+    }//end copyFile()
+
+    /**
+     * Copy a file's content into another object's folder, without audit logging.
+     *
+     * Shared by copyFile() and moveFile() so each can log its own distinct action.
+     *
+     * @param ObjectEntity $sourceObject The source object entity.
+     * @param int          $fileId       The source file ID.
+     * @param ObjectEntity $targetObject The target object entity.
+     *
+     * @return File The new file copy.
+     *
+     * @throws Exception If the copy fails.
+     */
+    private function copyFileContent(ObjectEntity $sourceObject, int $fileId, ObjectEntity $targetObject): File
     {
         $sourceFile = $this->readFileHandler->getFile(object: $sourceObject, file: $fileId);
         if ($sourceFile === null) {
@@ -1891,7 +1942,7 @@ class FileService
         );
 
         return $newFile;
-    }//end copyFile()
+    }//end copyFileContent()
 
     /**
      * Move a file to another object (copy + delete source).
@@ -1910,7 +1961,7 @@ class FileService
         $this->fileLockHandler->assertCanModify($fileId);
 
         // Copy first.
-        $newFile = $this->copyFile(sourceObject: $sourceObject, fileId: $fileId, targetObject: $targetObject);
+        $newFile = $this->copyFileContent(sourceObject: $sourceObject, fileId: $fileId, targetObject: $targetObject);
 
         // Delete source.
         $this->deleteFile(file: $fileId, object: $sourceObject);
@@ -1918,6 +1969,17 @@ class FileService
         $this->logger->info(
             message: "[FileService] Moved file {$fileId} from object {".$sourceObject->getUuid()."} to {".$targetObject->getUuid()."}",
             context: ["file" => __FILE__, "line" => __LINE__]
+        );
+
+        $this->fileAuditHandler->logFileAction(
+            object: $sourceObject,
+            action: "file.moved_from",
+            data: ["fileId" => $fileId, "fileName" => $newFile->getName(), "targetObjectUuid" => $targetObject->getUuid(), "targetFileId" => $newFile->getId()]
+        );
+        $this->fileAuditHandler->logFileAction(
+            object: $targetObject,
+            action: "file.moved_to",
+            data: ["fileId" => $newFile->getId(), "fileName" => $newFile->getName(), "sourceObjectUuid" => $sourceObject->getUuid(), "sourceFileId" => $fileId]
         );
 
         return $newFile;

--- a/openspec/changes/file-actions/tasks.md
+++ b/openspec/changes/file-actions/tasks.md
@@ -18,7 +18,7 @@
 - [x] Add invalid character validation for file names
 - [x] Add `FilesController::rename()` endpoint with `@NoAdminRequired` and `@NoCSRFRequired`
 - [x] Register route: `PUT /api/objects/{register}/{schema}/{id}/files/{fileId}/rename`
-- [ ] Generate audit trail entry on successful rename
+- [x] Generate audit trail entry on successful rename
 - [x] Dispatch `nl.openregister.object.file.renamed` event
 - [x] Write unit test for rename with valid name
 - [x] Write unit test for rename with duplicate name (409)
@@ -34,7 +34,7 @@
 - [x] Implement `FileService::moveFile()` -- copy then delete source, with atomicity check
 - [x] Add `FilesController::move()` endpoint
 - [x] Register route: `POST /api/objects/{register}/{schema}/{id}/files/{fileId}/move`
-- [ ] Generate dual audit trail entries (on source and target objects)
+- [x] Generate dual audit trail entries (on source and target objects)
 - [x] Dispatch `nl.openregister.object.file.copied` and `nl.openregister.object.file.moved` events
 - [ ] Write unit test for copy within same register
 - [ ] Write unit test for copy across registers
@@ -50,7 +50,7 @@
 - [x] Add `FilesController::listVersions()` endpoint
 - [x] Add `FilesController::restoreVersion()` endpoint
 - [x] Register routes: `GET .../files/{fileId}/versions` and `POST .../files/{fileId}/versions/{versionId}/restore`
-- [ ] Generate audit trail entry on version restore
+- [x] Generate audit trail entry on version restore
 - [x] Dispatch `nl.openregister.object.file.version_restored` event
 - [x] Write unit test for version listing
 - [ ] Write unit test for version restore
@@ -62,11 +62,11 @@
 - [x] Implement `FileLockHandler::unlockFile()` with owner/admin check
 - [x] Implement `FileLockHandler::isLocked()` with TTL expiry check
 - [x] Implement `FileLockHandler::forceUnlock()` for admin users
-- [ ] Integrate lock checking into UpdateFileHandler, rename, move, and delete operations
+- [x] Integrate lock checking into UpdateFileHandler, rename, move, and delete operations
 - [x] Add `FilesController::lock()` and `FilesController::unlock()` endpoints
 - [x] Register routes: `POST .../files/{fileId}/lock` and `POST .../files/{fileId}/unlock`
 - [ ] Include lock metadata in file formatting output (formatFile)
-- [ ] Generate audit trail entries for lock, unlock, and force-unlock
+- [x] Generate audit trail entries for lock, unlock, and force-unlock
 - [x] Dispatch `nl.openregister.object.file.locked` and `nl.openregister.object.file.unlocked` events
 - [x] Write unit test for lock acquisition
 - [x] Write unit test for lock conflict (423)
@@ -119,12 +119,12 @@
 ## Phase 9: Download Audit Logging
 
 - [x] Implement `FileAuditHandler::logDownload()` creating audit trail entries
-- [ ] Integrate download logging into `FilesController::show()` endpoint
+- [x] Integrate download logging into `FilesController::show()` endpoint
 - [ ] Integrate download logging into `FilesController::downloadById()` endpoint
 - [x] Log anonymous downloads with IP and user-agent
 - [ ] Implement download count caching in FileMapper (increment on download)
 - [ ] Include `downloadCount` in file metadata responses
-- [ ] Log bulk download (ZIP archive) as single audit entry
+- [x] Log bulk download (ZIP archive) as single audit entry
 - [x] Write unit test for download logging
 - [x] Write unit test for anonymous download logging
 - [x] Write unit test for download count

--- a/tests/Unit/Controller/FilesControllerFileActionsTest.php
+++ b/tests/Unit/Controller/FilesControllerFileActionsTest.php
@@ -7,6 +7,7 @@ namespace Unit\Controller;
 use Exception;
 use OCA\OpenRegister\Controller\FilesController;
 use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\File\FileAuditHandler;
 use OCA\OpenRegister\Service\File\FileBatchHandler;
 use OCA\OpenRegister\Service\File\FileLockHandler;
 use OCA\OpenRegister\Service\File\FilePreviewHandler;
@@ -141,6 +142,10 @@ class FilesControllerFileActionsTest extends TestCase
         ]);
         $this->fileService->method('getLockHandler')->willReturn($lockHandler);
 
+        $auditHandler = $this->createMock(FileAuditHandler::class);
+        $auditHandler->expects($this->once())->method('logFileAction');
+        $this->fileService->method('getAuditHandler')->willReturn($auditHandler);
+
         $response = $this->controller->lock('reg', 'sch', 'abc-123', 42);
 
         $this->assertEquals(200, $response->getStatus());
@@ -261,6 +266,58 @@ class FilesControllerFileActionsTest extends TestCase
         $response = $this->controller->unlock('reg', 'sch', 'abc-123', 42);
 
         $this->assertEquals(403, $response->getStatus());
+    }
+
+    /**
+     * Test unlock logs a force_unlocked audit entry when force is used.
+     */
+    public function testUnlockForceLogsAuditEntry(): void
+    {
+        $object = $this->createObjectMock();
+        $this->setupObjectServiceMocks($object);
+
+        $lockHandler = $this->createMock(FileLockHandler::class);
+        $lockHandler->method('unlockFile')->willReturn(['locked' => false]);
+        $this->fileService->method('getLockHandler')->willReturn($lockHandler);
+
+        $auditHandler = $this->createMock(FileAuditHandler::class);
+        $auditHandler->expects($this->once())
+            ->method('logFileAction')
+            ->with($object, 'file.force_unlocked', $this->anything());
+        $this->fileService->method('getAuditHandler')->willReturn($auditHandler);
+
+        $this->request->method('getParams')->willReturn(['force' => true]);
+
+        $response = $this->controller->unlock('reg', 'sch', 'abc-123', 42);
+
+        $this->assertEquals(200, $response->getStatus());
+    }
+
+    /**
+     * Test version restore logs an audit entry.
+     */
+    public function testRestoreVersionLogsAuditEntry(): void
+    {
+        $object = $this->createObjectMock();
+        $this->setupObjectServiceMocks($object);
+
+        $file = $this->createMock(File::class);
+        $this->fileService->method('getFile')->willReturn($file);
+        $this->fileService->method('formatFile')->willReturn(['id' => 42]);
+
+        $versioningHandler = $this->createMock(FileVersioningHandler::class);
+        $versioningHandler->expects($this->once())->method('restoreVersion');
+        $this->fileService->method('getVersioningHandler')->willReturn($versioningHandler);
+
+        $auditHandler = $this->createMock(FileAuditHandler::class);
+        $auditHandler->expects($this->once())
+            ->method('logFileAction')
+            ->with($object, 'file.version_restored', ['versionId' => 'v-1710892800', 'fileId' => 42]);
+        $this->fileService->method('getAuditHandler')->willReturn($auditHandler);
+
+        $response = $this->controller->restoreVersion('reg', 'sch', 'abc-123', 42, 'v-1710892800');
+
+        $this->assertEquals(200, $response->getStatus());
     }
 
     /**

--- a/tests/Unit/Controller/FilesControllerTest.php
+++ b/tests/Unit/Controller/FilesControllerTest.php
@@ -7,6 +7,7 @@ namespace Unit\Controller;
 use Exception;
 use OCA\OpenRegister\Controller\FilesController;
 use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\File\FileAuditHandler;
 use OCA\OpenRegister\Service\FileService;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -44,6 +45,7 @@ class FilesControllerTest extends TestCase
         $this->objectService = $this->createMock(ObjectService::class);
         $this->rootFolder = $this->createMock(IRootFolder::class);
         $this->userManager = $this->createMock(IUserManager::class);
+        $this->fileService->method('getAuditHandler')->willReturn($this->createMock(FileAuditHandler::class));
 
         $this->controller = new FilesController(
             'openregister',
@@ -169,6 +171,12 @@ class FilesControllerTest extends TestCase
         $file->method('getSize')->willReturn(42);
 
         $this->fileService->method('getFile')->willReturn($file);
+
+        $auditHandler = $this->createMock(FileAuditHandler::class);
+        $auditHandler->expects($this->once())
+            ->method('logDownload')
+            ->with($object, 1, 'test.txt', 42, 'text/plain');
+        $this->fileService->method('getAuditHandler')->willReturn($auditHandler);
 
         $result = $this->controller->show('reg1', 'schema1', 'obj1', 1);
 

--- a/tests/Unit/Controller/ObjectsControllerTest.php
+++ b/tests/Unit/Controller/ObjectsControllerTest.php
@@ -6039,7 +6039,13 @@ class ObjectsControllerTest extends TestCase
             'path' => $tempZip,
             'filename' => 'test-files.zip',
             'mimeType' => 'application/zip',
+            'files' => [['fileId' => 1, 'fileName' => 'a.pdf']],
         ]);
+        $auditHandler = $this->createMock(\OCA\OpenRegister\Service\File\FileAuditHandler::class);
+        $auditHandler->expects($this->once())
+            ->method('logBulkDownload')
+            ->with($objectEntity, [1], ['a.pdf']);
+        $fileService->method('getAuditHandler')->willReturn($auditHandler);
 
         $this->container->method('get')->willReturn($fileService);
         $this->request->method('getParam')->willReturn(null);
@@ -6095,7 +6101,11 @@ class ObjectsControllerTest extends TestCase
             'path' => $tempZip,
             'filename' => 'custom-name.zip',
             'mimeType' => 'application/zip',
+            'files' => [],
         ]);
+        $fileService->method('getAuditHandler')->willReturn(
+            $this->createMock(\OCA\OpenRegister\Service\File\FileAuditHandler::class)
+        );
 
         $this->container->method('get')->willReturn($fileService);
         $this->request->method('getParam')->willReturn('custom-name');

--- a/tests/Unit/Service/File/FileAuditHandlerTest.php
+++ b/tests/Unit/Service/File/FileAuditHandlerTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Unit\Service\File;
 
+use OCA\OpenRegister\Db\AuditTrail;
 use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Service\File\FileAuditHandler;
 use OCP\IRequest;
 use OCP\IUser;
@@ -20,6 +22,7 @@ class FileAuditHandlerTest extends TestCase
     private IUserSession&MockObject $userSession;
     private IRequest&MockObject $request;
     private LoggerInterface&MockObject $logger;
+    private ObjectEntity&MockObject $object;
 
     protected function setUp(): void
     {
@@ -29,6 +32,8 @@ class FileAuditHandlerTest extends TestCase
         $this->userSession      = $this->createMock(IUserSession::class);
         $this->request          = $this->createMock(IRequest::class);
         $this->logger           = $this->createMock(LoggerInterface::class);
+        $this->object           = $this->createMock(ObjectEntity::class);
+        $this->object->method('getUuid')->willReturn('abc-123');
 
         $this->handler = new FileAuditHandler(
             $this->auditTrailMapper,
@@ -39,7 +44,7 @@ class FileAuditHandlerTest extends TestCase
     }
 
     /**
-     * Test authenticated download logging.
+     * Test authenticated download logging persists an audit trail entry.
      */
     public function testLogDownloadAuthenticated(): void
     {
@@ -47,9 +52,28 @@ class FileAuditHandlerTest extends TestCase
         $user->method('getUID')->willReturn('behandelaar-1');
         $this->userSession->method('getUser')->willReturn($user);
 
-        $this->logger->expects($this->once())->method('info');
+        $this->auditTrailMapper->expects($this->once())
+            ->method('createAuditTrailEntry')
+            ->with(
+                $this->object,
+                'file.downloaded',
+                $this->callback(function (array $data) {
+                    return $data['fileId'] === 42
+                        && $data['fileName'] === 'rapport.pdf'
+                        && $data['fileSize'] === 245760
+                        && $data['mimeType'] === 'application/pdf'
+                        && array_key_exists('remoteAddress', $data) === false;
+                })
+            )
+            ->willReturn($this->createMock(AuditTrail::class));
 
-        $this->handler->logDownload(42, 'rapport.pdf', 245760, 'application/pdf', 'abc-123');
+        $this->handler->logDownload(
+            object: $this->object,
+            fileId: 42,
+            fileName: 'rapport.pdf',
+            fileSize: 245760,
+            mimeType: 'application/pdf'
+        );
     }
 
     /**
@@ -61,13 +85,29 @@ class FileAuditHandlerTest extends TestCase
         $this->request->method('getRemoteAddress')->willReturn('192.168.1.1');
         $this->request->method('getHeader')->willReturn('Mozilla/5.0');
 
-        $this->logger->expects($this->once())->method('info');
+        $this->auditTrailMapper->expects($this->once())
+            ->method('createAuditTrailEntry')
+            ->with(
+                $this->object,
+                'file.downloaded',
+                $this->callback(function (array $data) {
+                    return $data['remoteAddress'] === '192.168.1.1'
+                        && $data['userAgent'] === 'Mozilla/5.0';
+                })
+            )
+            ->willReturn($this->createMock(AuditTrail::class));
 
-        $this->handler->logDownload(42, 'rapport.pdf', 245760, 'application/pdf', 'abc-123');
+        $this->handler->logDownload(
+            object: $this->object,
+            fileId: 42,
+            fileName: 'rapport.pdf',
+            fileSize: 245760,
+            mimeType: 'application/pdf'
+        );
     }
 
     /**
-     * Test bulk download logging.
+     * Test bulk download logging persists a single audit trail entry.
      */
     public function testLogBulkDownload(): void
     {
@@ -75,24 +115,63 @@ class FileAuditHandlerTest extends TestCase
         $user->method('getUID')->willReturn('admin');
         $this->userSession->method('getUser')->willReturn($user);
 
-        $this->logger->expects($this->once())->method('info');
+        $this->auditTrailMapper->expects($this->once())
+            ->method('createAuditTrailEntry')
+            ->with(
+                $this->object,
+                'file.bulk_downloaded',
+                $this->callback(function (array $data) {
+                    return $data['fileIds'] === [42, 43, 44]
+                        && $data['fileNames'] === ['file1.pdf', 'file2.pdf', 'file3.pdf'];
+                })
+            )
+            ->willReturn($this->createMock(AuditTrail::class));
 
         $this->handler->logBulkDownload(
-            [42, 43, 44],
-            ['file1.pdf', 'file2.pdf', 'file3.pdf'],
-            'abc-123'
+            object: $this->object,
+            fileIds: [42, 43, 44],
+            fileNames: ['file1.pdf', 'file2.pdf', 'file3.pdf']
         );
     }
 
     /**
-     * Test download logging does not throw even if internal error.
+     * Test download logging does not throw even if the mapper fails internally.
      */
     public function testLogDownloadDoesNotThrow(): void
     {
         $this->userSession->method('getUser')->willThrowException(new \Exception('Session error'));
 
+        $this->logger->expects($this->once())->method('warning');
+
         // Should not propagate exception.
-        $this->handler->logDownload(42, 'test.pdf', 1024, 'application/pdf', 'abc-123');
+        $this->handler->logDownload(
+            object: $this->object,
+            fileId: 42,
+            fileName: 'test.pdf',
+            fileSize: 1024,
+            mimeType: 'application/pdf'
+        );
         $this->assertTrue(true);
+    }
+
+    /**
+     * Test generic file action logging (e.g. rename) persists an audit trail entry.
+     */
+    public function testLogFileAction(): void
+    {
+        $this->auditTrailMapper->expects($this->once())
+            ->method('createAuditTrailEntry')
+            ->with(
+                $this->object,
+                'file.renamed',
+                ['fileId' => 42, 'oldName' => 'scan.pdf', 'newName' => 'besluit.pdf']
+            )
+            ->willReturn($this->createMock(AuditTrail::class));
+
+        $this->handler->logFileAction(
+            object: $this->object,
+            action: 'file.renamed',
+            data: ['fileId' => 42, 'oldName' => 'scan.pdf', 'newName' => 'besluit.pdf']
+        );
     }
 }


### PR DESCRIPTION
Closes #1549.

Built by hydra from `openspec/changes/file-actions/`, by an agent running in a checkout of this repository — it read the spec and the surrounding code and edited the working tree. The commit was made by the pipeline, not by the agent: the agent never held a forge credential.

## The gates

`scripts/run-hydra-gates.sh --scope-to-diff --base origin/main` exited **6** — the exit code IS the failure count, and it is scoped to this branch's own diff rather than to the repository's backlog.

```
[hydra-gates] Delegating to conduction/hydra-gates at /usr/local/lib/hydra-gates/hydra-gates
[hydra-gates] findings logs: /tmp/hydra-gates.lY5S5s7A
[hydra-gates] gate package: UNKNOWN — this run cannot say which version of the gates produced its verdicts.
[hydra-gates] Comparing it against another run (e.g. a strict-subset baseline check) compares two possibly-different programs.
[hydra-gates] Set HYDRA_GATES_PKG_SHA to make the comparison sound.
[hydra-gates] App dir: /tmp/hydra-stage-6n8mQo/repo (absolute)
[hydra-gates] SCOPE-MODE: diff
[hydra-gates] File scope: the diff only (--scope-to-diff / HYDRA_GATE_SCOPE=diff). Inherited debt in untouched files is NOT judged.
[hydra-gates] SCOPE-FILE-COUNT: 11
[hydra-gates] Scope: diff vs origin/main — 11 changed file(s)
[gate-1] spdx-headers: FAIL — 0 missing @license, 2 missing @copyright
[gate-2] forbidden-patterns: PASS
[gate-3] stub-scan: PASS
[gate-4] composer-audit: NOT APPLICABLE — neither composer.json nor composer.lock is in this diff — under ADR-020 diff scoping the dependency tree is unchanged from the base branch, so this PR introduces no dependency change to audit.
[hydra-gates] gate-5 route-auth: 11 routed entr(ies) NOT JUDGED (controller class unresolvable here) — see /tmp/hydra-gates.lY5S5s7A/hydra-gate-route-auth-unresolved.log. This is not a pass for them; reachability is gate-14's.
[gate-5] route-auth: FAIL — 6 routed method(s) missing auth attribute — see /tmp/hydra-gates.lY5S5s7A/hydra-gate-route-auth.log
[gate-6] orphan-auth: PASS
[filter-preexisting] hydra-gate-no-admin-idor.log: kept 0 PR-introduced, moved 1 pre-existing → hydra-gate-no-admin-idor.log.preexisting
[gate-7] no-admin-idor: PASS
[gate-8] unsafe-auth-resolver: PASS
[gate-9] semantic-auth: PASS
[gate-10] initial-state: NOT APPLICABLE — 0 tracked, non-minified .vue/.js/.ts file(s) under src/ or js/ in this diff — nothing was inspected, so DOM reads of server-injected data are UNVERIFIED by this run.
[gate-11] admin-router: NOT APPLICABLE — this app's router(s) — src/router/index.js — are not in this diff, so under ADR-020 the routing table is unchanged from the base branch.
[gate-12] nc-input-labels: NOT APPLICABLE — 176 .vue component(s) exist here and the diff against 'origin/main' touched none of them, so no <NcSelect> was inspected. Diff-scoped out under ADR-020 — not a gap, and not a pass.
[gate-13] modal-isolation: NOT APPLICABLE — 97 .vue component(s) exist here and the diff against 'origin/main' touched none of them, so no component was inspected. Diff-scoped out under ADR-020 — not a gap, and not a pass.
[gate-14] route-reachability: FAIL — 13 unrouted method(s) or wrong-target route(s) — see /tmp/hydra-gates.lY5S5s7A/hydra-gate-route-reachability.log
[gate-16] spec-coverage: FAIL — 15 changed method(s) missing @spec — see /tmp/hydra-gates.lY5S5s7A/hydra-gate-spec-coverage.log
[gate-17] redundant-controller: PASS
[gate-18] notification-dialect: NOT APPLICABLE — no register JSON under lib/Settings (*register*.json or register.d/*.json) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/main' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-19] e2e-coverage: NOT APPLICABLE — the diff against 'origin/main' touched NO spec file, so no scenario was inspected. Diff-scoped out under ADR-020, exactly as gates 4/6/7 are for the same diff — not a gap: the specs in this repo are unchanged from the base branch, so this PR introduces no scenario whose @e2e traceability could be missing. This gate runs on the next PR that touches a spec. See /tmp/hydra-gates.lY5S5s7A/hydra-gate-e2e-coverage.log.
[gate-20] or-objectservice-api: PASS
[gate-21] conflict-markers: PASS
[hydra-gates] gate-23 or-abstraction-anti-patterns: 0 rule(s) matched (see /tmp/hydra-gates.lY5S5s7A/hydra-gate-or-abstraction-anti-patterns.log); WARN mode.
[gate-23] or-abstraction-anti-patterns: PASS
[gate-24] integration-parity: NOT APPLICABLE — no scripts/check-integration-parity.sh, and this repo registers no integration leaves at all — no `new LeafDescriptor(` in lib/ and neither `registerIntegration(` nor `integrations.register(` in src/. There is no server↔JS pair for parity to correlate.
[gate-25] contract-coverage: PASS
[gate-26] visual-coverage: NOT APPLICABLE — the diff against 'origin/main' ADDED no page component (nothing under src/views|src/pages, no new manifest page component), so no screen was inspected. Diff-scoped out under ADR-020 — not a gap: this PR adds no screen whose appearance could be unbaselined. See /tmp/hydra-gates.lY5S5s7A/hydra-gate-visual-coverage.log.
[gate-27] no-phantom-cross-app-rpc: PASS
[gate-28] license-triangle: PASS
[gate-29] gitignore-then-commit: NOT APPLICABLE — the diff against 'origin/main' adds no non-comment line to .gitignore, so there is no new ignore rule whose path could already be tracked. Diff-scoped out under ADR-020.
[gate-30] public-monitoring: NOT APPLICABLE — 2 monitoring endpoint(s) found; none of their controllers is touched by this diff (ADR-020) — see /tmp/hydra-gates.lY5S5s7A/hydra-gate-public-monitoring-notes.log.
[gate-31] img-alt: NOT APPLICABLE — no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run — the repository has none, or the diff touches none under ADR-020. No <img> was inspected and none could be.
[gate-32] semantic-controls: NOT APPLICABLE — no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run — the repository has none, or the diff touches none under ADR-020. No click target was inspected and none could be.
[gate-33] axe-core: NOT APPLICABLE — no tests/axe/report.json, and the caller did not set enable-axe — this repo has not opted into runtime accessibility enforcement. Runtime a11y (contrast / landmark / ARIA-validity / live-region) is therefore NOT enforced here, by a choice recorded in the caller's workflow rather than in this run. To enforce it, set `enable-axe: true` on ConductionNL/.github's quality.yml; this gate then becomes blocking and its absence becomes a failure.
[gate-34] window-confirm: NOT APPLICABLE — no frontend source file (src|templates|appinfo/templates **/*.vue|js|ts|php|html) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/main' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-35] img-alt-empty-only: NOT APPLICABLE — no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/main' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-36] tabindex-positive: NOT APPLICABLE — no frontend source file (src|templates|appinfo/templates **/*.vue|js|ts|php|html) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/main' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-37] aria-hidden-focusable: NOT APPLICABLE — no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/main' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-38] skip-link: NOT APPLICABLE — no app page root (src/App.vue, src/**/*Root.vue) or document-owning PHP template (templates|appinfo/templates **/*.php) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/main' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-39] button-name: NOT APPLICABLE — no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/main' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-40] form-label-association: NOT APPLICABLE — no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/main' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-41] html-lang: NOT APPLICABLE — no PHP template (templates|appinfo/templates **/*.php) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/main' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-42] link-text-quality: NOT APPLICABLE — no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/main' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-43] table-headers: NOT APPLICABLE — no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/main' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-44] autocomplete-attr: NOT APPLICABLE — no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/main' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-45] prefers-reduced-motion: NOT APPLICABLE — scope was empty — 0 markup or stylesheet file(s) (css/, src/, templates/, appinfo/templates/) in this diff, so NO <style> block and NO stylesheet was inspected; motion without a prefers-reduced-motion fallback is UNVERIFIED by this run.
[gate-46] spec-anchor-existence: PASS
[gate-47] security-change-has-tests: PASS
[gate-48] csrf-cochange: PASS
[gate-49] controller-exception-translation: FAIL — 2 controller method(s) missing try/catch or @throws — see /tmp/hydra-gates.lY5S5s7A/hydra-gate-controller-exception-translation.log
[gate-50] security-config-fail-mode: PASS
[gate-51] schema-property-titles: NOT APPLICABLE — scope was empty — 0 lib/Settings/*register*.json (or register.d/*.json) file(s) in this repo or this diff, so NO schema property was inspected; missing human-friendly titles are UNVERIFIED by this run.
[hydra-gates] gate-52 custom-widget-ratchet: the RATCHET half was NOT computed — the helper printed no base/head/delta counts, which it does only when it has a base ref to compare against. The JUSTIFICATION half (every custom kind:"widget" entry needs a `_note`) did run over 286 file(s). A PASS below covers that half only.
[gate-52] custom-widget-ratchet: NOT APPLICABLE — no src/**/*.{js,ts,vue} file (a component registry declaring kind:"widget" entries) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/main' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-54] relation-dialect: NOT APPLICABLE — scope was empty — 0 lib/Settings/*register*.json (or register.d/*.json) file(s) in this repo or this diff, so NO relation property was inspected; non-canonical relation dialects (ADR-062 rules 6/7/10) are UNVERIFIED by this run.
[gate-55] detail-page-discipline: NOT APPLICABLE — scope was empty — 0 src/manifest.json or src/manifest.d/*.json file(s) in this repo or this diff, so NO type:"detail" page was inspected; ADR-062 grid discipline (render-path shadowing, widgets↔layout integrity, widget icons, row/viewAll routes) is UNVERIFIED by this run.
[gate-56] register-handler-resolution: NOT APPLICABLE — 6 register JSON(s) exist here and the diff against 'origin/main' touched none of them, so NONE were inspected. Diff-scoped out under ADR-020 — this gate runs on the next PR that touches a register.
[gate-57] orphaned-write-capability: NOT APPLICABLE — the checker DECLINED to judge: 3 lib/Service file(s) were in scope and NONE were assessed for deadness, because this is a foundation repo checked out with no sibling apps beside it, so a cross-app caller cannot be distinguished from no caller at all (hydra#106). THIS IS NOT A CLEAN BILL OF HEALTH AND NOT A PASS — orphaned (mintable-but-unreachable) write capabilities in this repository are UNVERIFIED by this run, as they have been in every single-repo CI run. To get a verdict, run this gate from a checkout that has the consuming apps beside it (a fleet sweep from apps-extra/), not from a one-repo CI workspace. Checker said: [orphaned-write-capability] SKIP: openregister is a foundation repo and no sibling apps were found next to it — cross-app callers cannot be resolved, so deadness is unprovable. See hydra#106.. See /tmp/hydra-gates.lY5S5s7A/hydra-gate-orphaned-write-capability.err.
[gate-58] e2e-networkidle: NOT APPLICABLE — no tests/e2e/ files in this repo — there is no Playwright suite in which a wait could fail to settle.
[gate-59] unclosable-gate: PASS
[gate-60] icon-vocabulary: NOT APPLICABLE — no src/manifest.json — this app declares no menu icon for the ADR-077 vocabulary to constrain.
[gate-61] listener-work-placement: NOT APPLICABLE — the diff against 'origin/main' put every post-event registration out of scope, so NONE were inspected. This gate is deliberately delta-scoped even at full file scope — the fleet's registration backlog is a work-list, not a reason to block an unrelated change. It runs on the next change that touches a listener registration. ADVISORY, and it decides nothing here: a whole-tree sweep of this same tree reaches 16 registration(s) carrying 0 finding(s), NONE of which this run judged — see /tmp/hydra-gates.lY5S5s7A/hydra-gate-listener-work-placement.advisory.log. See /tmp/hydra-gates.lY5S5s7A/hydra-gate-listener-work-placement.log.
[gate-62] store-plane: NOT APPLICABLE — no src/manifest.json — a Tier-0 app declares no store plane for ADR-080 to constrain.
[gate-63] settings-surface: NOT APPLICABLE — no src/manifest.json — a Tier-0 app declares no settings surface for ADR-079 to place.
[gate-64] apphost-autoload-prelude: PASS
FAIL no-php-cs-fixer-config: no .php-cs-fixer.dist.php. Nothing in this repo runs Nextcloud's coding standard, so nothing can be said about whether it passes it.
FAIL coding-standard-not-required: composer.json does not require conduction/coding-standard.
FAIL nextcloud-coding-standard-declared-directly: nextcloud/coding-standard is a DIRECT dependency. It must arrive transitively through conduction/coding-standard, at a version that package has tested against. Declared directly it was, in 17 of 18 apps, a dead dependency with no config and no invocation — loaded, and ready to reformat everything for whoever found it.
FAIL cs-script-wired-to-phpcs: 'cs:check' runs PHPCS, not php-cs-fixer. That is nextcloud/coding-standard's script name, so a contributor running the documented Nextcloud command gets this fleet's reformatting instead. Body: './vendor/bin/phpcs --standard=phpcs.xml'
FAIL cs-script-wired-to-phpcs: 'cs:fix' runs PHPCS, not php-cs-fixer. That is nextcloud/coding-standard's script name, so a contributor running the documented Nextcloud command gets this fleet's reformatting instead. Body: './vendor/bin/phpcbf --standard=phpcs.xml'
FAIL phpcs-not-centralised: phpcs.xml does not reference quality-config/phpcs.xml. Every app that kept its own full ruleset is how this fleet reached six variants of one file.
FAIL phpcs-declares-formatting-sniffs: phpcs.xml names formatting sniffs that php-cs-fixer owns: Generic.Arrays.ArrayIndent, Generic.Files.LineEndings.InvalidEOLChar, Generic.Formatting.MultipleStatementAlignment, Generic.Formatting.SpaceAfterCast, Generic.WhiteSpace.IncrementDecrementSpacing, Generic.WhiteSpace.ScopeIndent, PEAR.Functions.FunctionCallSignature.Indent, PEAR.Functions.FunctionCallSignature.OpeningIndent, PEAR.WhiteSpace.ScopeIndent.Incorrect, Squiz.Commenting.DocCommentAlignment, Squiz.ControlStructures.ElseIfDeclaration, Squiz.Functions.FunctionDeclarationArgumentSpacing, Squiz.Functions.MultiLineFunctionDeclaration.FirstParamSpacing, Squiz.Functions.MultiLineFunctionDeclaration.Indent, Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction, Squiz.Strings.ConcatenationSpacing, Squiz.WhiteSpace.ControlStructureSpacing, Squiz.WhiteSpace.FunctionSpacing, Squiz.WhiteSpace.MemberVarSpacing, Squiz.WhiteSpace.OperatorSpacing, Squiz.WhiteSpace.SuperfluousWhitespace. Two formatters with overlapping jurisdiction make an app unfixable — cs:fix and phpcs then demand opposite things and neither can be satisfied.
FAIL local-custom-sniffs: phpcs-custom-sniffs/ exists locally. The sniffs come from vendor/conduction/hydra-gates/. A local copy is how NamedParametersSniff.php reached six versions across the fleet, one of them calling addWarning() where the rest called addError().
FAIL no-editorconfig: no .editorconfig. Nextcloud core ships one; without it an editor falls back to whatever the developer last configured.
FAIL stylelint-glob-unquoted: the 'stylelint' script passes an unquoted glob 'src/**/*.vue'. The shell expands it, and without globstar `src/**/` matches exactly one directory level — nested components are silently not linted. Quote it so stylelint expands it.
FAIL phpmd-not-centralised: phpmd.xml does not reference quality-config/phpmd.xml. A deliberate divergence is allowed and expected — declare it as <rule ref="…central…"><exclude name="X"/></rule> plus a re-declared X with this app's properties, so the deviation is visible as a deviation instead of hiding inside a full copy.
FAIL phpstan-not-centralised: phpstan.neon does not include quality-config/phpstan-base.neon. Keep only this app's own baseline include and ignores naming symbols no other app has. NOTE: this requires conduction/hydra-gates >= v1.7.1 — v1.7.0's base declared bare relative paths, and PHPStan resolves those against the file that DECLARES them, so `paths: lib` became vendor/…/quality-config/lib and the run aborted.
FAIL prettier-config-without-prettier: .prettierrc exists but neither prettier nor a */prettier-config package is a dependency, so nothing in CI ever runs it. It still applies in editors, which is the worst of both: contributors get their files reformatted into a state the linter rejects. Either delete it, or adopt it properly the way nextcloud/forms does — @nextcloud/prettier-config + prettier + eslint-config-prettier + a format script and a CI leg.
FAIL test-matrix-misses-declared-versions: appinfo/info.xml declares NC 28-34, but no job runs on stable28, stable29, stable30, stable31, stable33, stable34. The matrix is ['stable32']. Those majors are advertised to the App Store and exercised by nothing — not known-broken, unmeasured. The fix with no next time in it is to DELETE the nextcloud-test-refs line: the shared workflow then derives the range from this same manifest and the two cannot drift apart again. Otherwise add the legs, or narrow what info.xml claims.
[gate-65] coding-standard-adoption: FAIL — 14 deviation(s) from the shared coding standard; see /tmp/hydra-gates.lY5S5s7A/hydra-gate-coding-standard-adoption.log

[gate-15] dashboard-antipattern: NOT APPLICABLE — no src/manifest.json — this repo declares no manifest, so there are no pages, widgets or handler references for this gate to inspect.
[gate-22] manifest-validation: NOT APPLICABLE — no src/manifest.json — this repo declares no manifest, so there are no pages, widgets or handler references for this gate to inspect.
[gate-53] effective-manifest-crossref: NOT APPLICABLE — no src/manifest.json — this repo declares no manifest, so there are no pages, widgets or handler references for this gate to inspect.
[hydra-gates] COVERAGE: 25 of 65 declared gates reported a result (40 not applicable to this repo/diff; 25 of 25 applicable gates ran).
[hydra-gates] NOT APPLICABLE — subject matter absent from this repo or this diff.
[hydra-gates] These do NOT count against coverage. Each stated its own reason above:
[hydra-gates]   gate-4 composer-audit
[hydra-gates]   gate-10 initial-state
[hydra-gates]   gate-11 admin-router
[hydra-gates]   gate-12 nc-input-labels
[hydra-gates]   gate-13 modal-isolation
[hydra-gates]   gate-15 dashboard-antipattern
[hydra-gates]   gate-18 notification-dialect
[hydra-gates]   gate-19 e2e-coverage
[hydra-gates]   gate-22 manifest-validation
[hydra-gates]   gate-24 integration-parity
[hydra-gates]   gate-26 visual-coverage
[hydra-gates]   gate-29 gitignore-then-commit
[hydra-gates]   gate-30 public-monitoring
[hydra-gates]   gate-31 img-alt
[hydra-gates]   gate-32 semantic-controls
[hydra-gates]   gate-33 axe-core
[hydra-gates]   gate-34 window-confirm
[hydra-gates]   gate-35 img-alt-empty-only
[hydra-gates]   gate-36 tabindex-positive
[hydra-gates]   gate-37 aria-hidden-focusable
[hydra-gates]   gate-38 skip-link
[hydra-gates]   gate-39 button-name
[hydra-gates]   gate-40 form-label-association
[hydra-gates]   gate-41 html-lang
[hydra-gates]   gate-42 link-text-quality
[hydra-gates]   gate-43 table-headers
[hydra-gates]   gate-44 autocomplete-attr
[hydra-gates]   gate-45 prefers-reduced-motion
[hydra-gates]   gate-51 schema-property-titles
[hydra-gates]   gate-52 custom-widget-ratchet
[hydra-gates]   gate-53 effective-manifest-crossref
[hydra-gates]   gate-54 relation-dialect
[hydra-gates]   gate-55 detail-page-discipline
[hydra-gates]   gate-56 register-handler-resolution
[hydra-gates]   gate-57 orphaned-write-capability
[hydra-gates]   gate-58 e2e-networkidle
[hydra-gates]   gate-60 icon-vocabulary
[hydra-gates]   gate-61 listener-work-placement
[hydra-gates]   gate-62 store-plane
[hydra-gates]   gate-63 settings-surface
[hydra-gates] 6 gate(s) failed

```

---

⚠️ **Read the diff, not the label.** A non-zero gate count is information about this change, not a verdict on whether it should be merged, and a zero one is not a review. Nothing here has been read by a person yet.