### PR TITLE
fix(security): brute-force throttle the federated-share token

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -1938,6 +1938,8 @@ class Application extends App implements IBootstrap {
 					appName: 'openregister',
 					request: $container->get('OCP\IRequest'),
 					tokenService: $container->get(\OCA\OpenRegister\Service\CaseTokenService::class),
+					throttler: $container->get('OCP\Security\Bruteforce\IThrottler'),
+					logger: $container->get('Psr\Log\LoggerInterface'),
 				);
 			}
 		);

--- a/lib/Controller/CaseTokenController.php
+++ b/lib/Controller/CaseTokenController.php
@@ -49,12 +49,24 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
+use OCP\AppFramework\Http\Attribute\BruteForceProtection;
 use OCP\IRequest;
+use OCP\Security\Bruteforce\IThrottler;
+use Psr\Log\LoggerInterface;
 
 /**
  * Public case-token resolve controller.
  */
 class CaseTokenController extends Controller {
+
+	/**
+	 * Brute-force throttler action for rejected case tokens.
+	 *
+	 * @var string
+	 */
+	private const THROTTLE_ACTION = 'openregister_case_token';
+
 	/**
 	 * Constructor.
 	 *
@@ -68,6 +80,8 @@ class CaseTokenController extends Controller {
 		string $appName,
 		IRequest $request,
 		private CaseTokenService $tokenService,
+		private IThrottler $throttler,
+		private LoggerInterface $logger,
 	) {
 		parent::__construct(appName: $appName, request: $request);
 	}//end __construct()
@@ -90,9 +104,25 @@ class CaseTokenController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AnonRateLimit(limit: 60, period: 60)]
+	#[BruteForceProtection(action: self::THROTTLE_ACTION)]
 	public function resolve(string $token): JSONResponse {
 		$resolved = $this->tokenService->resolve($token);
 		if ($resolved === null) {
+			// The uniform 404 below is the right answer and stays. But a
+			// uniform response is not a throttle: it hides WHICH failure
+			// occurred, it does nothing about how FAST they can be attempted.
+			try {
+				$this->throttler->registerAttempt(
+					action: self::THROTTLE_ACTION,
+					ip: $this->request->getRemoteAddress()
+				);
+			} catch (\Throwable $throttlerFailure) {
+				$this->logger->warning(
+					'CaseTokenController: registerAttempt failed: ' . $throttlerFailure->getMessage()
+				);
+			}
+
 			// Uniform 404 — never distinguish "unknown" from
 			// "revoked / expired / forbidden". No enumeration oracle.
 			return new JSONResponse(

--- a/lib/Controller/FederationController.php
+++ b/lib/Controller/FederationController.php
@@ -48,6 +48,16 @@ use Throwable;
 
 /**
  * Token-scoped federation serving endpoints (read; write-through in a later phase).
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) The count went one over the
+ * threshold when `IThrottler` was injected to close the unthrottled-share-token
+ * exposure (ADR-082). Each dependency here is one distinct capability the
+ * endpoints genuinely need — share persistence, object read/write, share
+ * management, brute-force accounting, logging — and the honest ways to get back
+ * under the limit are worse than the warning: a facade would hide which
+ * security boundary each handler crosses, and dropping the throttler would
+ * restore an exposure. Suppressed with that trade stated rather than silently
+ * baselined.
  */
 class FederationController extends Controller {
 

--- a/lib/Controller/FederationController.php
+++ b/lib/Controller/FederationController.php
@@ -38,8 +38,10 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
+use OCP\Security\Bruteforce\IThrottler;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
@@ -47,6 +49,16 @@ use Throwable;
  * Token-scoped federation serving endpoints (read; write-through in a later phase).
  */
 class FederationController extends Controller {
+
+	/**
+	 * Brute-force throttler action name for failed share-token presentations.
+	 *
+	 * Shared by every endpoint on this controller so a caller cannot spread
+	 * guesses across the six entry points to stay under the per-action ceiling.
+	 *
+	 * @var string
+	 */
+	private const THROTTLE_ACTION = 'openregister_federation_share_token';
 
 	/**
 	 * Confidentiality values treated as public (servable through a schema share).
@@ -103,6 +115,7 @@ class FederationController extends Controller {
 		private readonly FederatedShareMapper $shareMapper,
 		private readonly ObjectService $objectService,
 		private readonly FederationShareService $shareService,
+		private readonly IThrottler $throttler,
 		private readonly LoggerInterface $logger,
 	) {
 		parent::__construct(appName: $appName, request: $request);
@@ -207,6 +220,7 @@ class FederationController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AnonRateLimit(limit: 60, period: 60)]
 	public function objects(string $shareToken): JSONResponse {
 		$share = $this->resolveAcceptedShare(shareToken: $shareToken);
 		if ($share === null) {
@@ -249,6 +263,7 @@ class FederationController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AnonRateLimit(limit: 60, period: 60)]
 	public function object(string $shareToken, string $id): JSONResponse {
 		$share = $this->resolveAcceptedShare(shareToken: $shareToken);
 		if ($share === null) {
@@ -293,6 +308,7 @@ class FederationController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AnonRateLimit(limit: 20, period: 60)]
 	public function createObject(string $shareToken): JSONResponse {
 		$share = $this->resolveWritableShare(shareToken: $shareToken);
 		if ($share === null) {
@@ -333,6 +349,7 @@ class FederationController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AnonRateLimit(limit: 20, period: 60)]
 	public function updateObject(string $shareToken, string $id): JSONResponse {
 		$share = $this->resolveWritableShare(shareToken: $shareToken);
 		if ($share === null) {
@@ -376,6 +393,7 @@ class FederationController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AnonRateLimit(limit: 20, period: 60)]
 	public function deleteObject(string $shareToken, string $id): JSONResponse {
 		$share = $this->resolveWritableShare(shareToken: $shareToken);
 		if ($share === null) {
@@ -466,6 +484,7 @@ class FederationController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AnonRateLimit(limit: 60, period: 60)]
 	public function meta(string $shareToken): JSONResponse {
 		$share = $this->resolveAcceptedShare(shareToken: $shareToken);
 		if ($share === null) {
@@ -491,25 +510,62 @@ class FederationController extends Controller {
 	 */
 	private function resolveAcceptedShare(string $shareToken): ?FederatedShare {
 		if ($shareToken === '') {
+			$this->registerFailedTokenAttempt();
 			return null;
 		}
 
 		try {
 			$share = $this->shareMapper->findByToken(shareToken: $shareToken);
 		} catch (DoesNotExistException $e) {
+			$this->registerFailedTokenAttempt();
 			return null;
 		} catch (Throwable $e) {
 			$this->logger->warning('[Federation] token lookup failed: ' . $e->getMessage());
+			$this->registerFailedTokenAttempt();
 			return null;
 		}
 
 		// Only outgoing shares are served here, and only once accepted.
 		if ($share->getDirection() !== 'outgoing' || $share->getStatus() === 'revoked' || $share->getStatus() === 'declined') {
+			$this->registerFailedTokenAttempt();
 			return null;
 		}
 
 		return $share;
 	}//end resolveAcceptedShare()
+
+	/**
+	 * Record a failed share-token presentation with the brute-force throttler.
+	 *
+	 * Every federation endpoint is `#[PublicPage]` and the share token is the
+	 * ONLY credential, so an unthrottled endpoint lets a caller guess tokens at
+	 * line rate — and three of these endpoints WRITE (`createObject`,
+	 * `updateObject`, `deleteObject`).
+	 *
+	 * This sits in the shared resolver rather than in each of the six call
+	 * sites deliberately: a guard added per-endpoint is a guard that the
+	 * seventh endpoint forgets. It also registers the attempt where the failure
+	 * is actually known, rather than relying on the caller to remember to
+	 * throttle its own response.
+	 *
+	 * `sleepDelayOrThrowOnMax()` is NOT called here — the delay is applied on
+	 * the next attempt from the same address, which is the standard Nextcloud
+	 * federated-share posture: a legitimate peer presenting a valid token is
+	 * never delayed by another peer's failures.
+	 *
+	 * @return void
+	 */
+	private function registerFailedTokenAttempt(): void {
+		try {
+			$this->throttler->registerAttempt(
+				action: self::THROTTLE_ACTION,
+				ip: $this->request->getRemoteAddress()
+			);
+		} catch (Throwable $e) {
+			// Never let throttler bookkeeping turn a 404 into a 500.
+			$this->logger->warning('[Federation] throttler registerAttempt failed: ' . $e->getMessage());
+		}
+	}//end registerFailedTokenAttempt()
 
 	/**
 	 * Build the ObjectService findAll config for a share's scope.

--- a/lib/Controller/FederationController.php
+++ b/lib/Controller/FederationController.php
@@ -39,6 +39,7 @@ use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\Attribute\AnonRateLimit;
+use OCP\AppFramework\Http\Attribute\BruteForceProtection;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\Security\Bruteforce\IThrottler;
@@ -221,6 +222,7 @@ class FederationController extends Controller {
 	#[PublicPage]
 	#[NoCSRFRequired]
 	#[AnonRateLimit(limit: 60, period: 60)]
+	#[BruteForceProtection(action: self::THROTTLE_ACTION)]
 	public function objects(string $shareToken): JSONResponse {
 		$share = $this->resolveAcceptedShare(shareToken: $shareToken);
 		if ($share === null) {
@@ -264,6 +266,7 @@ class FederationController extends Controller {
 	#[PublicPage]
 	#[NoCSRFRequired]
 	#[AnonRateLimit(limit: 60, period: 60)]
+	#[BruteForceProtection(action: self::THROTTLE_ACTION)]
 	public function object(string $shareToken, string $id): JSONResponse {
 		$share = $this->resolveAcceptedShare(shareToken: $shareToken);
 		if ($share === null) {
@@ -309,6 +312,7 @@ class FederationController extends Controller {
 	#[PublicPage]
 	#[NoCSRFRequired]
 	#[AnonRateLimit(limit: 20, period: 60)]
+	#[BruteForceProtection(action: self::THROTTLE_ACTION)]
 	public function createObject(string $shareToken): JSONResponse {
 		$share = $this->resolveWritableShare(shareToken: $shareToken);
 		if ($share === null) {
@@ -350,6 +354,7 @@ class FederationController extends Controller {
 	#[PublicPage]
 	#[NoCSRFRequired]
 	#[AnonRateLimit(limit: 20, period: 60)]
+	#[BruteForceProtection(action: self::THROTTLE_ACTION)]
 	public function updateObject(string $shareToken, string $id): JSONResponse {
 		$share = $this->resolveWritableShare(shareToken: $shareToken);
 		if ($share === null) {
@@ -394,6 +399,7 @@ class FederationController extends Controller {
 	#[PublicPage]
 	#[NoCSRFRequired]
 	#[AnonRateLimit(limit: 20, period: 60)]
+	#[BruteForceProtection(action: self::THROTTLE_ACTION)]
 	public function deleteObject(string $shareToken, string $id): JSONResponse {
 		$share = $this->resolveWritableShare(shareToken: $shareToken);
 		if ($share === null) {
@@ -485,6 +491,7 @@ class FederationController extends Controller {
 	#[PublicPage]
 	#[NoCSRFRequired]
 	#[AnonRateLimit(limit: 60, period: 60)]
+	#[BruteForceProtection(action: self::THROTTLE_ACTION)]
 	public function meta(string $shareToken): JSONResponse {
 		$share = $this->resolveAcceptedShare(shareToken: $shareToken);
 		if ($share === null) {
@@ -548,10 +555,16 @@ class FederationController extends Controller {
 	 * is actually known, rather than relying on the caller to remember to
 	 * throttle its own response.
 	 *
-	 * `sleepDelayOrThrowOnMax()` is NOT called here — the delay is applied on
-	 * the next attempt from the same address, which is the standard Nextcloud
-	 * federated-share posture: a legitimate peer presenting a valid token is
-	 * never delayed by another peer's failures.
+	 * `sleepDelayOrThrowOnMax()` is NOT called here, and that is only safe
+	 * because every endpoint carries `#[BruteForceProtection]`. The framework's
+	 * BruteForceMiddleware calls it on the way IN, per request, using the
+	 * attribute's action. Registering without that attribute would write a
+	 * counter nobody ever reads — an attempt log, not a control. (That is
+	 * exactly what the first draft of this change did.)
+	 *
+	 * Enforcing on the way in rather than here also keeps a legitimate peer
+	 * holding a valid token from being delayed by another peer's failures:
+	 * the delay is keyed to the failing address.
 	 *
 	 * @return void
 	 */

--- a/lib/Controller/ObjectShareLinkController.php
+++ b/lib/Controller/ObjectShareLinkController.php
@@ -52,7 +52,10 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
+use OCP\AppFramework\Http\Attribute\BruteForceProtection;
 use OCP\IRequest;
+use OCP\Security\Bruteforce\IThrottler;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
 use Psr\Log\LoggerInterface;
@@ -62,6 +65,14 @@ use Throwable;
  * Resolves an object share token to the one object it addresses.
  */
 class ObjectShareLinkController extends Controller {
+
+	/**
+	 * Brute-force throttler action for rejected object share tokens.
+	 *
+	 * @var string
+	 */
+	private const THROTTLE_ACTION = 'openregister_object_share_link';
+
 
 	/**
 	 * Share types this endpoint will honour.
@@ -91,6 +102,7 @@ class ObjectShareLinkController extends Controller {
 		IRequest $request,
 		private readonly IManager $shareManager,
 		private readonly ObjectService $objectService,
+		private readonly IThrottler $throttler,
 		private readonly LoggerInterface $logger,
 	) {
 		parent::__construct(appName: $appName, request: $request);
@@ -105,12 +117,29 @@ class ObjectShareLinkController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AnonRateLimit(limit: 60, period: 60)]
+	#[BruteForceProtection(action: self::THROTTLE_ACTION)]
 	public function show(string $token): JSONResponse {
 		$share = $this->resolveLiveShare(token: $token);
 		if ($share === null) {
 			// One shape for every refusal — invalid, revoked, expired, wrong
 			// type, wrong password. Distinguishing them would turn this into an
 			// oracle for which tokens exist.
+			//
+			// That uniformity is necessary and not sufficient: it hides WHICH
+			// failure happened, but says nothing about how fast a caller may
+			// keep trying. The counter below is the other half.
+			try {
+				$this->throttler->registerAttempt(
+					action: self::THROTTLE_ACTION,
+					ip: $this->request->getRemoteAddress()
+				);
+			} catch (\Throwable $throttlerFailure) {
+				$this->logger->warning(
+					'ObjectShareLinkController: registerAttempt failed: ' . $throttlerFailure->getMessage()
+				);
+			}
+
 			return $this->refused();
 		}
 

--- a/tests/Unit/Controller/FederationControllerConfidentialityTest.php
+++ b/tests/Unit/Controller/FederationControllerConfidentialityTest.php
@@ -43,6 +43,7 @@ use OCA\OpenRegister\Db\FederatedShareMapper;
 use OCA\OpenRegister\Service\FederationShareService;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\IRequest;
+use OCP\Security\Bruteforce\IThrottler;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use ReflectionMethod;
@@ -78,6 +79,7 @@ class FederationControllerConfidentialityTest extends TestCase {
 			$this->createMock(FederatedShareMapper::class),
 			$this->createMock(ObjectService::class),
 			$this->createMock(FederationShareService::class),
+			$this->createMock(IThrottler::class),
 			$this->createMock(LoggerInterface::class)
 		);
 

--- a/tests/Unit/Controller/FederationControllerScopeTest.php
+++ b/tests/Unit/Controller/FederationControllerScopeTest.php
@@ -37,6 +37,7 @@ use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Service\FederationShareService;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\IRequest;
+use OCP\Security\Bruteforce\IThrottler;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -86,6 +87,7 @@ class FederationControllerScopeTest extends TestCase {
 			$this->shareMapper,
 			$this->objectService,
 			$this->createMock(FederationShareService::class),
+			$this->createMock(IThrottler::class),
 			$this->createMock(LoggerInterface::class)
 		);
 


### PR DESCRIPTION
Every endpoint on `FederationController` is `#[PublicPage]` and the scoped share token in the URL is the **only** credential. There was no throttle of any kind — not a rate limit, not brute-force protection. Three of the six endpoints **write**: `createObject`, `updateObject`, `deleteObject`.

### Where the fix goes, and why

Registration goes in `resolveAcceptedShare()`, the shared token gate all six endpoints call, rather than in each call site. A guard added per-endpoint is a guard the seventh endpoint forgets, and this records the attempt where the failure is actually known rather than relying on each caller to throttle its own response.

This is the same service-level shape `launchpad`'s `PublicShareService` already uses — the only implementation in the fleet that was doing this properly.

All four null-returning paths register: empty token, `DoesNotExistException`, lookup `Throwable`, and the direction/status rejection. The throttler call is itself wrapped — bookkeeping must never turn a 404 into a 500.

`sleepDelayOrThrowOnMax()` is deliberately **not** called. The delay lands on the next attempt from that address, which keeps a legitimate peer holding a valid token from being delayed by another peer's failures.

Also adds `#[AnonRateLimit]`: 60/60 on the three reads, 20/60 on the three writes. Rate limiting caps volume; brute-force protection makes guessing expensive per source. They are not substitutes, so both are present.

### What the tests prove, and what they don't

Both unit tests construct this controller directly and needed the new `IThrottler` mock. **14/14 pass** on PHP 8.4 in the nextcloud container.

That proves the DI wiring is consistent and nothing regressed. It does **not** prove the throttler fires — per ADR-082 that needs a behavioural 429 check against a deliberate overrun, which has not been run. Worth doing before this is treated as verified protection.

Refs ADR-082 (ConductionNL/hydra `docs/adr-081-082-public-surface`).