### PR TITLE
file-actions: built by hydra for #1549

### DIFF
--- a/lib/Db/FileLock.php
+++ b/lib/Db/FileLock.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * OpenRegister FileLock Entity
+ *
+ * This file contains the class for the FileLock entity.
+ *
+ * @category Database
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+namespace OCA\OpenRegister\Db;
+
+use DateTime;
+use JsonSerializable;
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * FileLock entity class.
+ *
+ * Persists advisory file-level locks (see FileLockHandler) so that a lock
+ * survives beyond the PHP request/worker that created it. Nextcloud's
+ * `openregister_files` table was deprecated and dropped in
+ * Version1Date20250430083916, so lock state lives in its own small table
+ * rather than being tacked onto a table that no longer exists.
+ *
+ * @method int|null getFileId()
+ * @method void setFileId(int $fileId)
+ * @method string|null getLockedBy()
+ * @method void setLockedBy(string $lockedBy)
+ * @method DateTime|null getLockedAt()
+ * @method void setLockedAt(DateTime $lockedAt)
+ * @method DateTime|null getLockExpires()
+ * @method void setLockExpires(DateTime $lockExpires)
+ *
+ * @psalm-suppress PropertyNotSetInConstructor $id is set by Nextcloud's Entity base class
+ */
+class FileLock extends Entity implements JsonSerializable
+{
+
+    /**
+     * The Nextcloud filecache file ID this lock applies to.
+     *
+     * @var int|null
+     */
+    protected ?int $fileId = null;
+
+    /**
+     * The user ID that holds the lock.
+     *
+     * @var string|null
+     */
+    protected ?string $lockedBy = null;
+
+    /**
+     * When the lock was acquired.
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $lockedAt = null;
+
+    /**
+     * When the lock expires (TTL).
+     *
+     * @var DateTime|null
+     */
+    protected ?DateTime $lockExpires = null;
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->addType(fieldName: 'fileId', type: 'integer');
+        $this->addType(fieldName: 'lockedBy', type: 'string');
+        $this->addType(fieldName: 'lockedAt', type: 'datetime');
+        $this->addType(fieldName: 'lockExpires', type: 'datetime');
+    }//end __construct()
+
+    /**
+     * JSON serialization.
+     *
+     * @return (int|null|string)[]
+     *
+     * @psalm-return array{id: int, fileId: int|null, lockedBy: null|string,
+     *     lockedAt: null|string, lockExpires: null|string}
+     */
+    public function jsonSerialize(): array
+    {
+        $lockedAt = null;
+        if ($this->lockedAt !== null) {
+            $lockedAt = $this->lockedAt->format('c');
+        }
+
+        $lockExpires = null;
+        if ($this->lockExpires !== null) {
+            $lockExpires = $this->lockExpires->format('c');
+        }
+
+        return [
+            'id'          => $this->id,
+            'fileId'      => $this->fileId,
+            'lockedBy'    => $this->lockedBy,
+            'lockedAt'    => $lockedAt,
+            'lockExpires' => $lockExpires,
+        ];
+    }//end jsonSerialize()
+}//end class

--- a/lib/Db/FileLockMapper.php
+++ b/lib/Db/FileLockMapper.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * OpenRegister FileLock Mapper
+ *
+ * This file contains the class for the FileLock mapper.
+ *
+ * @category Database
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+namespace OCA\OpenRegister\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\Entity;
+use OCP\AppFramework\Db\MultipleObjectsReturnedException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * Class FileLockMapper
+ *
+ * Mapper for FileLock entities. Backs FileLockHandler's advisory file locks
+ * with real storage so a lock survives past the request that created it.
+ *
+ * @package OCA\OpenRegister\Db
+ *
+ * @method FileLock insert(Entity $entity)
+ * @method FileLock update(Entity $entity)
+ * @method FileLock insertOrUpdate(Entity $entity)
+ * @method FileLock delete(Entity $entity)
+ * @method FileLock find(int|string $id)
+ * @method FileLock findEntity(\OCP\DB\QueryBuilder\IQueryBuilder $query)
+ * @method FileLock[] findAll(int|null $limit=null, int|null $offset=null)
+ * @method list<FileLock> findEntities(\OCP\DB\QueryBuilder\IQueryBuilder $query)
+ *
+ * @template-extends QBMapper<FileLock>
+ */
+class FileLockMapper extends QBMapper
+{
+    /**
+     * Constructor
+     *
+     * @param IDBConnection $db Database connection
+     */
+    public function __construct(IDBConnection $db)
+    {
+        parent::__construct(db: $db, tableName: 'openregister_file_locks', entityClass: FileLock::class);
+    }//end __construct()
+
+    /**
+     * Find the lock row for a given file, if any.
+     *
+     * @param int $fileId The Nextcloud filecache file ID.
+     *
+     * @return FileLock|null The lock, or null if the file has no lock row.
+     *
+     * @throws MultipleObjectsReturnedException If more than one lock row exists for the file.
+     */
+    public function findByFileId(int $fileId): ?FileLock
+    {
+        $qb = $this->db->getQueryBuilder();
+
+        $qb->select('*')
+            ->from($this->getTableName())
+            ->where($qb->expr()->eq('file_id', $qb->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)));
+
+        try {
+            return $this->findEntity(query: $qb);
+        } catch (DoesNotExistException $e) {
+            return null;
+        }
+    }//end findByFileId()
+
+    /**
+     * Delete the lock row for a given file, if any.
+     *
+     * @param int $fileId The Nextcloud filecache file ID.
+     *
+     * @return void
+     */
+    public function deleteByFileId(int $fileId): void
+    {
+        $qb = $this->db->getQueryBuilder();
+
+        $qb->delete($this->getTableName())
+            ->where($qb->expr()->eq('file_id', $qb->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)));
+
+        $qb->executeStatement();
+    }//end deleteByFileId()
+}//end class

--- a/lib/Migration/Version1Date20260814120000.php
+++ b/lib/Migration/Version1Date20260814120000.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * Database migration that creates the openregister_file_locks table.
+ *
+ * Part of the file-actions change (openspec/changes/file-actions): file
+ * locking (FileLockHandler) needs to persist lock state so a lock survives
+ * past the PHP request/worker that created it. `openregister_files` -- the
+ * table the file-actions design doc originally proposed adding lock columns
+ * to -- was deprecated and dropped in Version1Date20250430083916 and is
+ * never recreated, so Version1Date20260325120000's `locked_by`/`locked_at`/
+ * `lock_expires` columns are added to a table that no longer exists and are
+ * never actually created. This migration gives file locks a real home in a
+ * small dedicated table instead.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Creates the `openregister_file_locks` table used by FileLockHandler.
+ *
+ * @package OCA\OpenRegister\Migration
+ *
+ * @spec openspec/changes/file-actions/specs/file-actions/spec.md#File-Locking
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ */
+class Version1Date20260814120000 extends SimpleMigrationStep
+{
+    /**
+     * Change the database schema.
+     *
+     * @param IOutput $output        Migration output
+     * @param Closure $schemaClosure Schema closure
+     * @param array   $options       Migration options
+     *
+     * @return ISchemaWrapper|null The updated schema or null if no changes
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper
+    {
+        $schema    = $schemaClosure();
+        $tableName = 'openregister_file_locks';
+
+        if ($schema->hasTable($tableName) === true) {
+            $output->info("Table {$tableName} already exists, skipping");
+            return null;
+        }
+
+        $table = $schema->createTable($tableName);
+        $table->addColumn(
+            'id',
+            Types::INTEGER,
+            [
+                'autoincrement' => true,
+                'notnull'       => true,
+            ]
+        );
+        $table->addColumn(
+            'file_id',
+            Types::INTEGER,
+            [
+                'notnull' => true,
+                'comment' => 'Nextcloud filecache fileid the lock applies to',
+            ]
+        );
+        $table->addColumn(
+            'locked_by',
+            Types::STRING,
+            [
+                'notnull' => true,
+                'length'  => 64,
+                'comment' => 'User ID who holds the lock',
+            ]
+        );
+        $table->addColumn(
+            'locked_at',
+            Types::DATETIME,
+            [
+                'notnull' => true,
+                'comment' => 'Timestamp when the lock was acquired',
+            ]
+        );
+        $table->addColumn(
+            'lock_expires',
+            Types::DATETIME,
+            [
+                'notnull' => true,
+                'comment' => 'Timestamp when the lock expires (TTL)',
+            ]
+        );
+
+        $table->setPrimaryKey(['id']);
+        $table->addUniqueIndex(['file_id'], 'or_file_locks_file_id_idx');
+
+        $output->info("Created {$tableName} table");
+
+        return $schema;
+    }//end changeSchema()
+}//end class

--- a/lib/Service/File/FileLockHandler.php
+++ b/lib/Service/File/FileLockHandler.php
@@ -5,11 +5,12 @@
  *
  * This file is part of the OpenRegister app for Nextcloud.
  *
- * @category Service
- * @package  OCA\OpenRegister
- * @author   Conduction <info@conduction.nl>
- * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
- * @link     https://github.com/ConductionNL/openregister
+ * @category  Service
+ * @package   OCA\OpenRegister
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link      https://github.com/ConductionNL/openregister
  */
 
 declare(strict_types=1);
@@ -106,6 +107,8 @@ class FileLockHandler
      * @return array{locked: false} Unlock confirmation.
      *
      * @throws Exception If the current user is not the lock owner and not admin.
+     *
+     * @spec openspec/changes/file-actions/specs/file-actions/spec.md#File-Locking
      */
     public function unlockFile(int $fileId, bool $force=false): array
     {
@@ -157,6 +160,8 @@ class FileLockHandler
      * @param int $fileId The file ID.
      *
      * @return array{lockedBy: string, lockedAt: DateTime, expiresAt: DateTime}|null Lock metadata or null.
+     *
+     * @spec openspec/changes/file-actions/specs/file-actions/spec.md#File-Locking
      */
     public function getLockInfo(int $fileId): ?array
     {

--- a/lib/Service/File/FileLockHandler.php
+++ b/lib/Service/File/FileLockHandler.php
@@ -18,6 +18,9 @@ namespace OCA\OpenRegister\Service\File;
 
 use DateTime;
 use Exception;
+use OCA\OpenRegister\Db\FileLock;
+use OCA\OpenRegister\Db\FileLockMapper;
+use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\IGroupManager;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
@@ -26,7 +29,9 @@ use Psr\Log\LoggerInterface;
  * Handles file locking operations.
  *
  * Provides advisory file-level locking with TTL expiry and admin force-unlock.
- * Lock metadata is stored as in-memory state (to be backed by DB columns in FileMapper).
+ * Lock metadata is persisted via FileLockMapper (table `openregister_file_locks`)
+ * so a lock survives past the PHP request/worker that created it, rather than
+ * living only in a per-request in-memory array.
  *
  * @category Service
  * @package  OCA\OpenRegister
@@ -46,23 +51,18 @@ class FileLockHandler
     private const DEFAULT_TTL_MINUTES = 30;
 
     /**
-     * In-memory lock storage keyed by file ID.
-     *
-     * @var array<int, array{lockedBy: string, lockedAt: DateTime, expiresAt: DateTime}>
-     */
-    private array $locks = [];
-
-    /**
      * Constructor for FileLockHandler.
      *
-     * @param IUserSession    $userSession  User session for current user context.
-     * @param IGroupManager   $groupManager Group manager for admin checks.
-     * @param LoggerInterface $logger       Logger for logging operations.
+     * @param IUserSession    $userSession    User session for current user context.
+     * @param IGroupManager   $groupManager   Group manager for admin checks.
+     * @param LoggerInterface $logger         Logger for logging operations.
+     * @param FileLockMapper  $fileLockMapper Mapper for persisting lock state.
      */
     public function __construct(
         private readonly IUserSession $userSession,
         private readonly IGroupManager $groupManager,
-        private readonly LoggerInterface $logger
+        private readonly LoggerInterface $logger,
+        private readonly FileLockMapper $fileLockMapper
     ) {
     }//end __construct()
 
@@ -125,7 +125,7 @@ class FileLockHandler
             throw new Exception('Only administrators can force-unlock files');
         }
 
-        unset($this->locks[$fileId]);
+        $this->fileLockMapper->deleteByFileId(fileId: $fileId);
 
         $this->logger->info(
             message: "[FileLockHandler] File {$fileId} unlocked by {$currentUserId}".($force === true ? ' (force)' : ''),
@@ -156,20 +156,30 @@ class FileLockHandler
      *
      * @param int $fileId The file ID.
      *
-     * @return array|null Lock metadata or null.
+     * @return array{lockedBy: string, lockedAt: DateTime, expiresAt: DateTime}|null Lock metadata or null.
      */
     public function getLockInfo(int $fileId): ?array
     {
-        if (isset($this->locks[$fileId]) === false) {
+        try {
+            $lock = $this->fileLockMapper->findByFileId(fileId: $fileId);
+        } catch (MultipleObjectsReturnedException $e) {
+            // Should not happen given the unique index on file_id, but do not
+            // let a data inconsistency hard-fail every lock check.
+            $this->logger->warning(
+                message: "[FileLockHandler] Multiple lock rows found for file {$fileId}",
+                context: ['file' => __FILE__, 'line' => __LINE__]
+            );
             return null;
         }
 
-        $lock = $this->locks[$fileId];
+        if ($lock === null) {
+            return null;
+        }
 
         // Check TTL expiry.
         $now = new DateTime();
-        if ($lock['expiresAt'] <= $now) {
-            unset($this->locks[$fileId]);
+        if ($lock->getLockExpires() <= $now) {
+            $this->fileLockMapper->deleteByFileId(fileId: $fileId);
             $this->logger->info(
                 message: "[FileLockHandler] Lock on file {$fileId} expired, auto-cleared",
                 context: ['file' => __FILE__, 'line' => __LINE__]
@@ -177,7 +187,11 @@ class FileLockHandler
             return null;
         }
 
-        return $lock;
+        return [
+            'lockedBy'  => $lock->getLockedBy(),
+            'lockedAt'  => $lock->getLockedAt(),
+            'expiresAt' => $lock->getLockExpires(),
+        ];
     }//end getLockInfo()
 
     /**
@@ -205,7 +219,7 @@ class FileLockHandler
     }//end assertCanModify()
 
     /**
-     * Set a lock on a file.
+     * Set a lock on a file, creating or refreshing its lock row.
      *
      * @param int    $fileId     The file ID.
      * @param string $userId     The user ID.
@@ -218,11 +232,21 @@ class FileLockHandler
         $now     = new DateTime();
         $expires = (clone $now)->modify("+{$ttlMinutes} minutes");
 
-        $this->locks[$fileId] = [
-            'lockedBy'  => $userId,
-            'lockedAt'  => $now,
-            'expiresAt' => $expires,
-        ];
+        $lock = $this->fileLockMapper->findByFileId(fileId: $fileId);
+        if ($lock === null) {
+            $lock = new FileLock();
+            $lock->setFileId($fileId);
+        }
+
+        $lock->setLockedBy($userId);
+        $lock->setLockedAt($now);
+        $lock->setLockExpires($expires);
+
+        if ($lock->getId() === null) {
+            $this->fileLockMapper->insert($lock);
+        } else {
+            $this->fileLockMapper->update($lock);
+        }
 
         $this->logger->info(
             message: "[FileLockHandler] File {$fileId} locked by {$userId} until {$expires->format('c')}",

--- a/tests/Unit/Service/File/FileLockHandlerTest.php
+++ b/tests/Unit/Service/File/FileLockHandlerTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Unit\Service\File;
 
+use DateTime;
+use OCA\OpenRegister\Db\FileLock;
+use OCA\OpenRegister\Db\FileLockMapper;
 use OCA\OpenRegister\Service\File\FileLockHandler;
 use OCP\IGroupManager;
 use OCP\IUser;
@@ -14,41 +17,124 @@ use Psr\Log\LoggerInterface;
 
 class FileLockHandlerTest extends TestCase
 {
-    private FileLockHandler $handler;
     private IUserSession&MockObject $userSession;
     private IGroupManager&MockObject $groupManager;
     private LoggerInterface&MockObject $logger;
+    private FileLockMapper&MockObject $fileLockMapper;
+
+    /**
+     * Simulated `openregister_file_locks` table, keyed by file ID. Shared by
+     * every FileLockHandler built via newHandler() in a test, the same way
+     * every PHP worker in production shares one database row per file: this
+     * is what lets us prove a lock survives a fresh handler instance instead
+     * of only existing in that one instance's memory.
+     *
+     * @var array<int, FileLock>
+     */
+    private array $lockStore = [];
+
+    private int $nextId = 1;
+
+    /**
+     * The user ID FileLockHandler sees as "currently logged in". Mutable so
+     * a single test can simulate two different requests by two different
+     * users acting on the same underlying lock store.
+     */
+    private ?string $currentUserId = null;
 
     protected function setUp(): void
     {
         parent::setUp();
 
+        $this->lockStore     = [];
+        $this->nextId        = 1;
+        $this->currentUserId = null;
+
         $this->userSession  = $this->createMock(IUserSession::class);
         $this->groupManager = $this->createMock(IGroupManager::class);
         $this->logger       = $this->createMock(LoggerInterface::class);
 
-        $this->handler = new FileLockHandler(
-            $this->userSession,
-            $this->groupManager,
-            $this->logger
+        $this->userSession->method('getUser')->willReturnCallback(function (): ?IUser {
+            if ($this->currentUserId === null) {
+                return null;
+            }
+
+            $user = $this->createMock(IUser::class);
+            $user->method('getUID')->willReturn($this->currentUserId);
+            return $user;
+        });
+
+        $this->fileLockMapper = $this->createMock(FileLockMapper::class);
+
+        $this->fileLockMapper->method('findByFileId')->willReturnCallback(
+            fn (int $fileId): ?FileLock => $this->lockStore[$fileId] ?? null
+        );
+
+        $this->fileLockMapper->method('deleteByFileId')->willReturnCallback(
+            function (int $fileId): void {
+                unset($this->lockStore[$fileId]);
+            }
+        );
+
+        $this->fileLockMapper->method('insert')->willReturnCallback(
+            function (FileLock $lock): FileLock {
+                $lock->setId($this->nextId++);
+                $this->lockStore[$lock->getFileId()] = $lock;
+                return $lock;
+            }
+        );
+
+        $this->fileLockMapper->method('update')->willReturnCallback(
+            function (FileLock $lock): FileLock {
+                $this->lockStore[$lock->getFileId()] = $lock;
+                return $lock;
+            }
         );
     }
 
-    private function mockUser(string $userId): void
+    /**
+     * Build a fresh FileLockHandler backed by the shared lock store.
+     *
+     * Each call simulates a new request/PHP worker picking up a handler
+     * from the DI container: nothing carries over except what is in
+     * $this->lockStore (the "database").
+     */
+    private function newHandler(): FileLockHandler
     {
-        $user = $this->createMock(IUser::class);
-        $user->method('getUID')->willReturn($userId);
-        $this->userSession->method('getUser')->willReturn($user);
+        return new FileLockHandler(
+            $this->userSession,
+            $this->groupManager,
+            $this->logger,
+            $this->fileLockMapper
+        );
+    }
+
+    private function loginAs(string $userId): void
+    {
+        $this->currentUserId = $userId;
     }
 
     /**
-     * Test locking a file successfully.
+     * Seed an already-expired lock row directly into the store, bypassing
+     * lockFile()/setLock() so the expiry test does not depend on how the
+     * TTL arithmetic parses negative durations.
      */
+    private function seedExpiredLock(int $fileId, string $lockedBy): void
+    {
+        $lock = new FileLock();
+        $lock->setId($this->nextId++);
+        $lock->setFileId($fileId);
+        $lock->setLockedBy($lockedBy);
+        $lock->setLockedAt((new DateTime())->modify('-31 minutes'));
+        $lock->setLockExpires((new DateTime())->modify('-1 minute'));
+        $this->lockStore[$fileId] = $lock;
+    }
+
     public function testLockFileSuccess(): void
     {
-        $this->mockUser('user-1');
+        $this->loginAs('user-1');
 
-        $result = $this->handler->lockFile(42);
+        $result = $this->newHandler()->lockFile(42);
 
         $this->assertTrue($result['locked']);
         $this->assertEquals('user-1', $result['lockedBy']);
@@ -57,93 +143,154 @@ class FileLockHandlerTest extends TestCase
     }
 
     /**
-     * Test locking an already-locked file by another user throws exception.
+     * The whole point of persisting locks via FileLockMapper: a lock set by
+     * one handler instance (one request) must be visible to a completely
+     * separate handler instance (a later request) as long as the backing
+     * store still has the row. The old in-memory implementation could not
+     * pass this test across two independently constructed handlers.
      */
+    public function testLockPersistsAcrossHandlerInstances(): void
+    {
+        $this->loginAs('user-1');
+        $this->newHandler()->lockFile(42);
+
+        $laterHandler = $this->newHandler();
+
+        $this->assertTrue($laterHandler->isLocked(42));
+        $info = $laterHandler->getLockInfo(42);
+        $this->assertSame('user-1', $info['lockedBy']);
+    }
+
     public function testLockFileConflict(): void
     {
-        // First user locks.
-        $user1 = $this->createMock(IUser::class);
-        $user1->method('getUID')->willReturn('user-1');
-        $this->userSession->method('getUser')->willReturn($user1);
+        $this->loginAs('user-1');
+        $this->newHandler()->lockFile(42);
 
-        $this->handler->lockFile(42);
+        $this->loginAs('user-2');
+        $handler2 = $this->newHandler();
 
-        // Change user to user-2.
-        $handler2 = new FileLockHandler($this->userSession, $this->groupManager, $this->logger);
-
-        // We need a new handler to simulate a different user;
-        // but same handler is fine as long as user context changes.
-        // Since mockUser uses willReturn (not willReturnOnConsecutiveCalls),
-        // we'll test the in-memory state.
-        $this->assertTrue($this->handler->isLocked(42));
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('File is locked by user-1');
+        $handler2->lockFile(42);
     }
 
-    /**
-     * Test unlocking by the lock owner succeeds.
-     */
     public function testUnlockByOwner(): void
     {
-        $this->mockUser('user-1');
+        $this->loginAs('user-1');
+        $handler = $this->newHandler();
 
-        $this->handler->lockFile(42);
-        $result = $this->handler->unlockFile(42);
+        $handler->lockFile(42);
+        $result = $handler->unlockFile(42);
 
         $this->assertFalse($result['locked']);
-        $this->assertFalse($this->handler->isLocked(42));
+        $this->assertFalse($handler->isLocked(42));
     }
 
-    /**
-     * Test unlocking an already-unlocked file returns locked=false.
-     */
     public function testUnlockAlreadyUnlocked(): void
     {
-        $this->mockUser('user-1');
+        $this->loginAs('user-1');
 
-        $result = $this->handler->unlockFile(42);
+        $result = $this->newHandler()->unlockFile(42);
         $this->assertFalse($result['locked']);
     }
 
-    /**
-     * Test that assertCanModify passes for unlocked files.
-     */
+    public function testUnlockByNonOwnerDenied(): void
+    {
+        $this->loginAs('user-1');
+        $this->newHandler()->lockFile(42);
+
+        $this->loginAs('user-2');
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Only the lock owner or an admin can unlock this file');
+        $this->newHandler()->unlockFile(42);
+    }
+
+    public function testAdminForceUnlock(): void
+    {
+        $this->loginAs('user-1');
+        $this->newHandler()->lockFile(42);
+
+        $this->loginAs('admin-1');
+        $this->groupManager->method('isAdmin')->with('admin-1')->willReturn(true);
+
+        $result = $this->newHandler()->unlockFile(42, true);
+
+        $this->assertFalse($result['locked']);
+        $this->assertFalse($this->newHandler()->isLocked(42));
+    }
+
+    public function testForceUnlockByNonAdminDenied(): void
+    {
+        $this->loginAs('user-1');
+        $this->newHandler()->lockFile(42);
+
+        $this->loginAs('user-2');
+        $this->groupManager->method('isAdmin')->with('user-2')->willReturn(false);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Only administrators can force-unlock files');
+        $this->newHandler()->unlockFile(42, true);
+    }
+
     public function testAssertCanModifyUnlockedFile(): void
     {
-        $this->mockUser('user-1');
+        $this->loginAs('user-1');
         // Should not throw for unlocked file.
-        $this->handler->assertCanModify(42);
+        $this->newHandler()->assertCanModify(42);
         $this->assertTrue(true); // If we got here, no exception was thrown.
     }
 
-    /**
-     * Test that assertCanModify passes for lock owner.
-     */
     public function testAssertCanModifyByLockOwner(): void
     {
-        $this->mockUser('user-1');
-        $this->handler->lockFile(42);
-        // Lock owner should be able to modify.
-        $this->handler->assertCanModify(42);
+        $this->loginAs('user-1');
+        $handler = $this->newHandler();
+        $handler->lockFile(42);
+        // Lock owner should be able to modify, even via a fresh handler instance.
+        $this->newHandler()->assertCanModify(42);
         $this->assertTrue(true);
     }
 
-    /**
-     * Test getLockInfo returns null for unlocked file.
-     */
+    public function testAssertCanModifyByNonOwnerThrows(): void
+    {
+        $this->loginAs('user-1');
+        $this->newHandler()->lockFile(42);
+
+        $this->loginAs('user-2');
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('File is locked by user-1');
+        $this->newHandler()->assertCanModify(42);
+    }
+
     public function testGetLockInfoUnlocked(): void
     {
-        $this->assertNull($this->handler->getLockInfo(42));
+        $this->assertNull($this->newHandler()->getLockInfo(42));
+    }
+
+    public function testGetLockInfoLocked(): void
+    {
+        $this->loginAs('user-1');
+        $handler = $this->newHandler();
+        $handler->lockFile(42);
+
+        $info = $handler->getLockInfo(42);
+        $this->assertNotNull($info);
+        $this->assertEquals('user-1', $info['lockedBy']);
+        $this->assertInstanceOf(DateTime::class, $info['lockedAt']);
+        $this->assertInstanceOf(DateTime::class, $info['expiresAt']);
     }
 
     /**
-     * Test getLockInfo returns data for locked file.
+     * An expired lock must be auto-cleared (both reported as unlocked and
+     * removed from storage) the next time it is looked at, per the "Lock
+     * expires automatically" spec scenario.
      */
-    public function testGetLockInfoLocked(): void
+    public function testLockExpiryAutoClears(): void
     {
-        $this->mockUser('user-1');
-        $this->handler->lockFile(42);
+        $this->seedExpiredLock(42, 'user-1');
 
-        $info = $this->handler->getLockInfo(42);
-        $this->assertNotNull($info);
-        $this->assertEquals('user-1', $info['lockedBy']);
+        $this->assertFalse($this->newHandler()->isLocked(42));
+        $this->assertArrayNotHasKey(42, $this->lockStore);
     }
 }


### PR DESCRIPTION
Closes #1549.

Built by hydra from `openspec/changes/file-actions/`, by an agent running in a checkout of this repository — it read the spec and the surrounding code and edited the working tree. The commit was made by the pipeline, not by the agent: the agent never held a forge credential.

## The gates

`scripts/run-hydra-gates.sh --scope-to-diff --base origin/main` exited **1** — the exit code IS the failure count, and it is scoped to this branch's own diff rather than to the repository's backlog.

```
[hydra-gates] Delegating to conduction/hydra-gates at /usr/local/lib/hydra-gates/hydra-gates
[hydra-gates] findings logs: /tmp/hydra-gates.qJS3R21O
[hydra-gates] gate package: UNKNOWN — this run cannot say which version of the gates produced its verdicts.
[hydra-gates] Comparing it against another run (e.g. a strict-subset baseline check) compares two possibly-different programs.
[hydra-gates] Set HYDRA_GATES_PKG_SHA to make the comparison sound.
[hydra-gates] App dir: /tmp/hydra-stage-ouzuJE/repo (absolute)
[hydra-gates] SCOPE-MODE: diff
[hydra-gates] File scope: the diff only (--scope-to-diff / HYDRA_GATE_SCOPE=diff). Inherited debt in untouched files is NOT judged.
[hydra-gates] SCOPE-FILE-COUNT: 5
[hydra-gates] Scope: diff vs origin/main — 5 changed file(s)
[gate-1] spdx-headers: PASS
[gate-2] forbidden-patterns: PASS
[gate-3] stub-scan: PASS
[gate-4] composer-audit: NOT APPLICABLE — neither composer.json nor composer.lock is in this diff — under ADR-020 diff scoping the dependency tree is unchanged from the base branch, so this PR introduces no dependency change to audit.
[gate-5] route-auth: NOT APPLICABLE — 0 routed method(s) were judged — appinfo/routes.php is not in this diff and no controller serving a route is either, so under ADR-020 no endpoint's auth posture changed in this PR. 0 entr(ies) were additionally unresolvable here.
[gate-6] orphan-auth: PASS
[gate-7] no-admin-idor: NOT APPLICABLE — scope was empty — 0 lib/Controller PHP file(s) in this diff, so NOTHING was inspected; unguarded #[NoAdminRequired] endpoints (IDOR, OWASP A01:2021) are UNVERIFIED by this run.
[gate-8] unsafe-auth-resolver: PASS
[gate-9] semantic-auth: NOT APPLICABLE — scope was empty — 0 lib/Controller PHP file(s) in this diff, so NOTHING was inspected; auth-attribute-vs-body semantic mismatches are UNVERIFIED by this run.
[gate-10] initial-state: NOT APPLICABLE — 0 tracked, non-minified .vue/.js/.ts file(s) under src/ or js/ in this diff — nothing was inspected, so DOM reads of server-injected data are UNVERIFIED by this run.
[gate-11] admin-router: NOT APPLICABLE — this app's router(s) — src/router/index.js — are not in this diff, so under ADR-020 the routing table is unchanged from the base branch.
[gate-12] nc-input-labels: NOT APPLICABLE — 176 .vue component(s) exist here and the diff against 'origin/main' touched none of them, so no <NcSelect> was inspected. Diff-scoped out under ADR-020 — not a gap, and not a pass.
[gate-13] modal-isolation: NOT APPLICABLE — 97 .vue component(s) exist here and the diff against 'origin/main' touched none of them, so no component was inspected. Diff-scoped out under ADR-020 — not a gap, and not a pass.
[gate-14] route-reachability: NOT APPLICABLE — no routed controller method (an entry in appinfo/routes.php whose target class is in scope) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/main' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-16] spec-coverage: PASS
[gate-17] redundant-controller: PASS
[gate-18] notification-dialect: NOT APPLICABLE — no register JSON under lib/Settings (*register*.json or register.d/*.json) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/main' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-19] e2e-coverage: NOT APPLICABLE — the diff against 'origin/main' touched NO spec file, so no scenario was inspected. Diff-scoped out under ADR-020, exactly as gates 4/6/7 are for the same diff — not a gap: the specs in this repo are unchanged from the base branch, so this PR introduces no scenario whose @e2e traceability could be missing. This gate runs on the next PR that touches a spec. See /tmp/hydra-gates.qJS3R21O/hydra-gate-e2e-coverage.log.
[gate-20] or-objectservice-api: PASS
[gate-21] conflict-markers: PASS
[hydra-gates] gate-23 or-abstraction-anti-patterns: 0 rule(s) matched (see /tmp/hydra-gates.qJS3R21O/hydra-gate-or-abstraction-anti-patterns.log); WARN mode.
[gate-23] or-abstraction-anti-patterns: PASS
[gate-24] integration-parity: NOT APPLICABLE — no scripts/check-integration-parity.sh, and this repo registers no integration leaves at all — no `new LeafDescriptor(` in lib/ and neither `registerIntegration(` nor `integrations.register(` in src/. There is no server↔JS pair for parity to correlate.
[gate-25] contract-coverage: NOT APPLICABLE — the diff against 'origin/main' touched NO lib/Controller file, so no endpoint was inspected. Diff-scoped out under ADR-020, exactly as gates 6/7 are for the same diff — not a gap: this PR exposes no new endpoint whose wire contract could be untested. This gate runs on the next PR that touches a controller. See /tmp/hydra-gates.qJS3R21O/hydra-gate-contract-coverage.log.
[gate-26] visual-coverage: NOT APPLICABLE — the diff against 'origin/main' ADDED no page component (nothing under src/views|src/pages, no new manifest page component), so no screen was inspected. Diff-scoped out under ADR-020 — not a gap: this PR adds no screen whose appearance could be unbaselined. See /tmp/hydra-gates.qJS3R21O/hydra-gate-visual-coverage.log.
[gate-27] no-phantom-cross-app-rpc: PASS
[gate-28] license-triangle: PASS
[gate-29] gitignore-then-commit: NOT APPLICABLE — the diff against 'origin/main' adds no non-comment line to .gitignore, so there is no new ignore rule whose path could already be tracked. Diff-scoped out under ADR-020.
[gate-30] public-monitoring: NOT APPLICABLE — 2 monitoring endpoint(s) found; none of their controllers is touched by this diff (ADR-020) — see /tmp/hydra-gates.qJS3R21O/hydra-gate-public-monitoring-notes.log.
[gate-31] img-alt: NOT APPLICABLE — no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run — the repository has none, or the diff touches none under ADR-020. No <img> was inspected and none could be.
[gate-32] semantic-controls: NOT APPLICABLE — no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run — the repository has none, or the diff touches none under ADR-020. No click target was inspected and none could be.
[gate-33] axe-core: NOT APPLICABLE — no tests/axe/report.json, and the caller did not set enable-axe — this repo has not opted into runtime accessibility enforcement. Runtime a11y (contrast / landmark / ARIA-validity / live-region) is therefore NOT enforced here, by a choice recorded in the caller's workflow rather than in this run. To enforce it, set `enable-axe: true` on ConductionNL/.github's quality.yml; this gate then becomes blocking and its absence becomes a failure.
[gate-34] window-confirm: NOT APPLICABLE — no frontend source file (src|templates|appinfo/templates **/*.vue|js|ts|php|html) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/main' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-35] img-alt-empty-only: NOT APPLICABLE — no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/main' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-36] tabindex-positive: NOT APPLICABLE — no frontend source file (src|templates|appinfo/templates **/*.vue|js|ts|php|html) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/main' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-37] aria-hidden-focusable: NOT APPLICABLE — no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/main' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-38] skip-link: NOT APPLICABLE — no app page root (src/App.vue, src/**/*Root.vue) or document-owning PHP template (templates|appinfo/templates **/*.php) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/main' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-39] button-name: NOT APPLICABLE — no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/main' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-40] form-label-association: NOT APPLICABLE — no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/main' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-41] html-lang: NOT APPLICABLE — no PHP template (templates|appinfo/templates **/*.php) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/main' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-42] link-text-quality: NOT APPLICABLE — no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/main' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-43] table-headers: NOT APPLICABLE — no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/main' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-44] autocomplete-attr: NOT APPLICABLE — no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/main' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-45] prefers-reduced-motion: NOT APPLICABLE — scope was empty — 0 markup or stylesheet file(s) (css/, src/, templates/, appinfo/templates/) in this diff, so NO <style> block and NO stylesheet was inspected; motion without a prefers-reduced-motion fallback is UNVERIFIED by this run.
[gate-46] spec-anchor-existence: PASS
[gate-47] security-change-has-tests: PASS
[gate-48] csrf-cochange: NOT APPLICABLE — the diff against 'origin/main' touches NO lib/Controller/*.php, so there was no controller for a #[NoCSRFRequired] to be dropped FROM — NOT ONE controller line was read by this run. A removal is a property of a change set, and this change set contains no candidate for one. This is NOT a clean bill of health for the app's CSRF posture; it runs on the next change that touches a controller.
[gate-49] controller-exception-translation: NOT APPLICABLE — scope was empty — 0 lib/Controller PHP file(s) in this repo or this diff, so NO controller method was inspected; untranslated service exceptions (HTTP 500 on a defended path) are UNVERIFIED by this run.
[gate-50] security-config-fail-mode: NOT APPLICABLE — scope was empty — 0 lib/**/*Controller.php or *Service.php file(s) in this repo or this diff, so NO config read was inspected; a security-relevant key silently defaulting to empty is UNVERIFIED by this run.
[gate-51] schema-property-titles: NOT APPLICABLE — scope was empty — 0 lib/Settings/*register*.json (or register.d/*.json) file(s) in this repo or this diff, so NO schema property was inspected; missing human-friendly titles are UNVERIFIED by this run.
[hydra-gates] gate-52 custom-widget-ratchet: the RATCHET half was NOT computed — the helper printed no base/head/delta counts, which it does only when it has a base ref to compare against. The JUSTIFICATION half (every custom kind:"widget" entry needs a `_note`) did run over 286 file(s). A PASS below covers that half only.
[gate-52] custom-widget-ratchet: NOT APPLICABLE — no src/**/*.{js,ts,vue} file (a component registry declaring kind:"widget" entries) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/main' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-54] relation-dialect: NOT APPLICABLE — scope was empty — 0 lib/Settings/*register*.json (or register.d/*.json) file(s) in this repo or this diff, so NO relation property was inspected; non-canonical relation dialects (ADR-062 rules 6/7/10) are UNVERIFIED by this run.
[gate-55] detail-page-discipline: NOT APPLICABLE — scope was empty — 0 src/manifest.json or src/manifest.d/*.json file(s) in this repo or this diff, so NO type:"detail" page was inspected; ADR-062 grid discipline (render-path shadowing, widgets↔layout integrity, widget icons, row/viewAll routes) is UNVERIFIED by this run.
[gate-56] register-handler-resolution: NOT APPLICABLE — 6 register JSON(s) exist here and the diff against 'origin/main' touched none of them, so NONE were inspected. Diff-scoped out under ADR-020 — this gate runs on the next PR that touches a register.
[gate-57] orphaned-write-capability: NOT APPLICABLE — the checker DECLINED to judge: 1 lib/Service file(s) were in scope and NONE were assessed for deadness, because this is a foundation repo checked out with no sibling apps beside it, so a cross-app caller cannot be distinguished from no caller at all (hydra#106). THIS IS NOT A CLEAN BILL OF HEALTH AND NOT A PASS — orphaned (mintable-but-unreachable) write capabilities in this repository are UNVERIFIED by this run, as they have been in every single-repo CI run. To get a verdict, run this gate from a checkout that has the consuming apps beside it (a fleet sweep from apps-extra/), not from a one-repo CI workspace. Checker said: [orphaned-write-capability] SKIP: openregister is a foundation repo and no sibling apps were found next to it — cross-app callers cannot be resolved, so deadness is unprovable. See hydra#106.. See /tmp/hydra-gates.qJS3R21O/hydra-gate-orphaned-write-capability.err.
[gate-58] e2e-networkidle: NOT APPLICABLE — no tests/e2e/ files in this repo — there is no Playwright suite in which a wait could fail to settle.
[gate-59] unclosable-gate: PASS
[gate-60] icon-vocabulary: NOT APPLICABLE — no src/manifest.json — this app declares no menu icon for the ADR-077 vocabulary to constrain.
[gate-61] listener-work-placement: NOT APPLICABLE — the diff against 'origin/main' put every post-event registration out of scope, so NONE were inspected. This gate is deliberately delta-scoped even at full file scope — the fleet's registration backlog is a work-list, not a reason to block an unrelated change. It runs on the next change that touches a listener registration. ADVISORY, and it decides nothing here: a whole-tree sweep of this same tree reaches 16 registration(s) carrying 0 finding(s), NONE of which this run judged — see /tmp/hydra-gates.qJS3R21O/hydra-gate-listener-work-placement.advisory.log. See /tmp/hydra-gates.qJS3R21O/hydra-gate-listener-work-placement.log.
[gate-62] store-plane: NOT APPLICABLE — no src/manifest.json — a Tier-0 app declares no store plane for ADR-080 to constrain.
[gate-63] settings-surface: NOT APPLICABLE — no src/manifest.json — a Tier-0 app declares no settings surface for ADR-079 to place.
[gate-64] apphost-autoload-prelude: PASS
FAIL no-php-cs-fixer-config: no .php-cs-fixer.dist.php. Nothing in this repo runs Nextcloud's coding standard, so nothing can be said about whether it passes it.
FAIL coding-standard-not-required: composer.json does not require conduction/coding-standard.
FAIL nextcloud-coding-standard-declared-directly: nextcloud/coding-standard is a DIRECT dependency. It must arrive transitively through conduction/coding-standard, at a version that package has tested against. Declared directly it was, in 17 of 18 apps, a dead dependency with no config and no invocation — loaded, and ready to reformat everything for whoever found it.
FAIL cs-script-wired-to-phpcs: 'cs:check' runs PHPCS, not php-cs-fixer. That is nextcloud/coding-standard's script name, so a contributor running the documented Nextcloud command gets this fleet's reformatting instead. Body: './vendor/bin/phpcs --standard=phpcs.xml'
FAIL cs-script-wired-to-phpcs: 'cs:fix' runs PHPCS, not php-cs-fixer. That is nextcloud/coding-standard's script name, so a contributor running the documented Nextcloud command gets this fleet's reformatting instead. Body: './vendor/bin/phpcbf --standard=phpcs.xml'
FAIL phpcs-not-centralised: phpcs.xml does not reference quality-config/phpcs.xml. Every app that kept its own full ruleset is how this fleet reached six variants of one file.
FAIL phpcs-declares-formatting-sniffs: phpcs.xml names formatting sniffs that php-cs-fixer owns: Generic.Arrays.ArrayIndent, Generic.Files.LineEndings.InvalidEOLChar, Generic.Formatting.MultipleStatementAlignment, Generic.Formatting.SpaceAfterCast, Generic.WhiteSpace.IncrementDecrementSpacing, Generic.WhiteSpace.ScopeIndent, PEAR.Functions.FunctionCallSignature.Indent, PEAR.Functions.FunctionCallSignature.OpeningIndent, PEAR.WhiteSpace.ScopeIndent.Incorrect, Squiz.Commenting.DocCommentAlignment, Squiz.ControlStructures.ElseIfDeclaration, Squiz.Functions.FunctionDeclarationArgumentSpacing, Squiz.Functions.MultiLineFunctionDeclaration.FirstParamSpacing, Squiz.Functions.MultiLineFunctionDeclaration.Indent, Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction, Squiz.Strings.ConcatenationSpacing, Squiz.WhiteSpace.ControlStructureSpacing, Squiz.WhiteSpace.FunctionSpacing, Squiz.WhiteSpace.MemberVarSpacing, Squiz.WhiteSpace.OperatorSpacing, Squiz.WhiteSpace.SuperfluousWhitespace. Two formatters with overlapping jurisdiction make an app unfixable — cs:fix and phpcs then demand opposite things and neither can be satisfied.
FAIL local-custom-sniffs: phpcs-custom-sniffs/ exists locally. The sniffs come from vendor/conduction/hydra-gates/. A local copy is how NamedParametersSniff.php reached six versions across the fleet, one of them calling addWarning() where the rest called addError().
FAIL no-editorconfig: no .editorconfig. Nextcloud core ships one; without it an editor falls back to whatever the developer last configured.
FAIL stylelint-glob-unquoted: the 'stylelint' script passes an unquoted glob 'src/**/*.vue'. The shell expands it, and without globstar `src/**/` matches exactly one directory level — nested components are silently not linted. Quote it so stylelint expands it.
FAIL phpmd-not-centralised: phpmd.xml does not reference quality-config/phpmd.xml. A deliberate divergence is allowed and expected — declare it as <rule ref="…central…"><exclude name="X"/></rule> plus a re-declared X with this app's properties, so the deviation is visible as a deviation instead of hiding inside a full copy.
FAIL phpstan-not-centralised: phpstan.neon does not include quality-config/phpstan-base.neon. Keep only this app's own baseline include and ignores naming symbols no other app has. NOTE: this requires conduction/hydra-gates >= v1.7.1 — v1.7.0's base declared bare relative paths, and PHPStan resolves those against the file that DECLARES them, so `paths: lib` became vendor/…/quality-config/lib and the run aborted.
FAIL prettier-config-without-prettier: .prettierrc exists but neither prettier nor a */prettier-config package is a dependency, so nothing in CI ever runs it. It still applies in editors, which is the worst of both: contributors get their files reformatted into a state the linter rejects. Either delete it, or adopt it properly the way nextcloud/forms does — @nextcloud/prettier-config + prettier + eslint-config-prettier + a format script and a CI leg.
FAIL test-matrix-misses-declared-versions: appinfo/info.xml declares NC 28-34, but no job runs on stable28, stable29, stable30, stable31, stable33, stable34. The matrix is ['stable32']. Those majors are advertised to the App Store and exercised by nothing — not known-broken, unmeasured. The fix with no next time in it is to DELETE the nextcloud-test-refs line: the shared workflow then derives the range from this same manifest and the two cannot drift apart again. Otherwise add the legs, or narrow what info.xml claims.
[gate-65] coding-standard-adoption: FAIL — 14 deviation(s) from the shared coding standard; see /tmp/hydra-gates.qJS3R21O/hydra-gate-coding-standard-adoption.log

[gate-15] dashboard-antipattern: NOT APPLICABLE — no src/manifest.json — this repo declares no manifest, so there are no pages, widgets or handler references for this gate to inspect.
[gate-22] manifest-validation: NOT APPLICABLE — no src/manifest.json — this repo declares no manifest, so there are no pages, widgets or handler references for this gate to inspect.
[gate-53] effective-manifest-crossref: NOT APPLICABLE — no src/manifest.json — this repo declares no manifest, so there are no pages, widgets or handler references for this gate to inspect.
[hydra-gates] COVERAGE: 17 of 65 declared gates reported a result (48 not applicable to this repo/diff; 17 of 17 applicable gates ran).
[hydra-gates] NOT APPLICABLE — subject matter absent from this repo or this diff.
[hydra-gates] These do NOT count against coverage. Each stated its own reason above:
[hydra-gates]   gate-4 composer-audit
[hydra-gates]   gate-5 route-auth
[hydra-gates]   gate-7 no-admin-idor
[hydra-gates]   gate-9 semantic-auth
[hydra-gates]   gate-10 initial-state
[hydra-gates]   gate-11 admin-router
[hydra-gates]   gate-12 nc-input-labels
[hydra-gates]   gate-13 modal-isolation
[hydra-gates]   gate-14 route-reachability
[hydra-gates]   gate-15 dashboard-antipattern
[hydra-gates]   gate-18 notification-dialect
[hydra-gates]   gate-19 e2e-coverage
[hydra-gates]   gate-22 manifest-validation
[hydra-gates]   gate-24 integration-parity
[hydra-gates]   gate-25 contract-coverage
[hydra-gates]   gate-26 visual-coverage
[hydra-gates]   gate-29 gitignore-then-commit
[hydra-gates]   gate-30 public-monitoring
[hydra-gates]   gate-31 img-alt
[hydra-gates]   gate-32 semantic-controls
[hydra-gates]   gate-33 axe-core
[hydra-gates]   gate-34 window-confirm
[hydra-gates]   gate-35 img-alt-empty-only
[hydra-gates]   gate-36 tabindex-positive
[hydra-gates]   gate-37 aria-hidden-focusable
[hydra-gates]   gate-38 skip-link
[hydra-gates]   gate-39 button-name
[hydra-gates]   gate-40 form-label-association
[hydra-gates]   gate-41 html-lang
[hydra-gates]   gate-42 link-text-quality
[hydra-gates]   gate-43 table-headers
[hydra-gates]   gate-44 autocomplete-attr
[hydra-gates]   gate-45 prefers-reduced-motion
[hydra-gates]   gate-48 csrf-cochange
[hydra-gates]   gate-49 controller-exception-translation
[hydra-gates]   gate-50 security-config-fail-mode
[hydra-gates]   gate-51 schema-property-titles
[hydra-gates]   gate-52 custom-widget-ratchet
[hydra-gates]   gate-53 effective-manifest-crossref
[hydra-gates]   gate-54 relation-dialect
[hydra-gates]   gate-55 detail-page-discipline
[hydra-gates]   gate-56 register-handler-resolution
[hydra-gates]   gate-57 orphaned-write-capability
[hydra-gates]   gate-58 e2e-networkidle
[hydra-gates]   gate-60 icon-vocabulary
[hydra-gates]   gate-61 listener-work-placement
[hydra-gates]   gate-62 store-plane
[hydra-gates]   gate-63 settings-surface
[hydra-gates] 1 gate(s) failed

```

---

⚠️ **Read the diff, not the label.** A non-zero gate count is information about this change, not a verdict on whether it should be merged, and a zero one is not a review. Nothing here has been read by a person yet.