### PR TITLE
feat(flow-state): give a claimed slot a lease, so a lost one comes back

### DIFF
--- a/lib/Service/Flow/Nodes/FlowStateNode.php
+++ b/lib/Service/Flow/Nodes/FlowStateNode.php
@@ -61,6 +61,17 @@ use OCP\WorkflowEngine\IManager;
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @link https://OpenRegister.app
+ *
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) Five over, and all five come
+ *   from `leaseExpired()`. Its branches are not logic — they are four separate
+ *   reasons to FAIL SAFE: no lease configured, a slot value that is not a record,
+ *   a `since` that is absent or not a string, and a timestamp that will not
+ *   parse. Each keeps the slot HELD, because displacing a live holder hands one
+ *   slot to two runs and destroys the mutual exclusion the pool exists for,
+ *   whereas keeping an expired one only delays a recovery. Collapsing them into
+ *   a single condition would satisfy the metric and remove the one property that
+ *   makes the lease safe to turn on — that every uncertain case resolves the same
+ *   way, and it is possible to see which.
  */
 class FlowStateNode implements IFlowNode, IFlowNodeConfigKeys {
 
@@ -197,6 +208,7 @@ class FlowStateNode implements IFlowNode, IFlowNodeConfigKeys {
 			'record',
 			'slots',
 			'capacity',
+			'leaseSeconds',
 			'holder',
 			'slot',
 		];
@@ -376,11 +388,39 @@ class FlowStateNode implements IFlowNode, IFlowNodeConfigKeys {
 
 		$slots = $this->slotTable(stored: (array)$state->get($slotsKey, []), capacity: $capacity);
 
-		// A slot is free when it holds nothing. Slots are numbered from 1 so
-		// the value reads naturally in a dashboard ("slot 3 of 10").
+		// A slot is free when it holds nothing, OR when whoever holds it has
+		// held it for longer than the configured lease.
+		//
+		// 🔑 WITHOUT A LEASE A SLOT IS LOST, NOT BORROWED. `claim` and `release`
+		// are separate steps, and everything that can happen between them
+		// happens: a node with `onError: stop`, a refusal, a crashed worker, a
+		// run that outlives its deadline. Any of those ends the run holding a
+		// slot that nothing will ever give back — and unlike the per-issue lock
+		// beside it, which `hydra-lock-reaper` ages out, nothing reaps a slot.
+		//
+		// ⚠️ THE SYMPTOM IS NOT AN ERROR, IT IS SILENCE. Once the pool is full
+		// of dead holders every claim routes to whatever the caller's "at
+		// capacity" branch is, which is a NORMAL outcome — the flow reports
+		// `completed`, the queue stops moving, and the pipeline looks busy.
+		// Measured on hydra's sequencer: one run stopped at `lock-issue` with
+		// `onError: stop` and its slot was still held hours later; three of
+		// those and that repository can never be built again.
+		//
+		// The lease is opt-in (`leaseSeconds`) and absent by default, because a
+		// caller that genuinely wants a slot held until it is released — a
+		// long-running import, a manual gate — must keep that behaviour. Where
+		// it is set, an expired holder is treated as gone rather than deleted:
+		// the claim below simply overwrites the entry, so a slot recovers on
+		// the next attempt to use it and no reaper has to run at all.
+		$leaseSeconds = (int)($config['leaseSeconds'] ?? 0);
+
+		// Slots are numbered from 1 so the value reads naturally in a dashboard
+		// ("slot 3 of 10").
 		for ($n = 1; $n <= $capacity; $n++) {
 			$slot = (string)$n;
-			if (($slots[$slot] ?? null) !== null) {
+			if (($slots[$slot] ?? null) !== null
+				&& $this->leaseExpired(entry: $slots[$slot], leaseSeconds: $leaseSeconds) === false
+			) {
 				continue;
 			}
 
@@ -483,6 +523,43 @@ class FlowStateNode implements IFlowNode, IFlowNodeConfigKeys {
 
 		return ['holder' => $holder, 'since' => null];
 	}//end slotRecord()
+
+	/**
+	/**
+	 * Whether a held slot's lease has run out.
+	 *
+	 * Answers FALSE whenever it cannot be sure, and that direction is chosen
+	 * deliberately: treating a live holder as expired would hand its slot to a
+	 * second run and destroy the mutual exclusion the pool exists for, whereas
+	 * treating an expired holder as live only delays a recovery. So a missing
+	 * lease, an absent `since`, or a timestamp that will not parse all keep the
+	 * slot held.
+	 *
+	 * @param mixed $entry        The stored slot value.
+	 * @param int   $leaseSeconds The lease, or 0 for none.
+	 *
+	 * @return bool True when the holder may be displaced.
+	 *
+	 * @spec openspec/specs/flow-state/spec.md
+	 */
+	private function leaseExpired(mixed $entry, int $leaseSeconds): bool {
+		if ($leaseSeconds <= 0 || is_array($entry) === false) {
+			return false;
+		}
+
+		$since = ($entry['since'] ?? null);
+		if (is_string($since) === false || $since === '') {
+			return false;
+		}
+
+		$taken = strtotime($since);
+		if ($taken === false) {
+			return false;
+		}
+
+		return ((time() - $taken) > $leaseSeconds);
+
+	}//end leaseExpired()
 
 	/**
 	 * Give a held slot back.

--- a/tests/Unit/Service/Flow/FlowStateNodeTest.php
+++ b/tests/Unit/Service/Flow/FlowStateNodeTest.php
@@ -363,4 +363,121 @@ final class FlowStateNodeTest extends TestCase {
 		$this->node->validateConfig(config: ['operation' => 'claim', 'slots' => 'slots']);
 
 	}//end testClaimWithoutCapacityIsRejected()
+	// ── The lease (openregister#2468) ────────────────────────────────────
+
+	/**
+	 * A holder whose lease has run out is displaced, so the pool recovers.
+	 *
+	 * `claim` and `release` are separate steps, and a run can end between them —
+	 * a node with `onError: stop`, a refusal, a crashed worker. Without a lease
+	 * that slot is lost rather than borrowed: nothing reaps it, and once the pool
+	 * is full of dead holders every claim reports "at capacity", which is a
+	 * NORMAL outcome. The flow keeps reporting `completed` while the queue stops
+	 * moving.
+	 *
+	 * @return void
+	 */
+	public function testAnExpiredHolderIsDisplacedSoThePoolRecovers(): void {
+		$stale = (new \DateTime('-2 hours'))->format(\DateTimeInterface::ATOM);
+		$state = new FlowStateHandle(values: ['slots' => ['1' => ['holder' => 'dead-run', 'since' => $stale]]]);
+
+		$out = $this->node->execute(
+			items: [['json' => ['holder' => 'live-run'], 'binary' => [], 'pairedItem' => null]],
+			config: [
+				'operation' => 'claim',
+				'slots' => 'slots',
+				'capacity' => 1,
+				'holder' => 'holder',
+				'leaseSeconds' => 60,
+			],
+			context: $this->ctx($state)
+		);
+
+		$this->assertTrue($out[0]['json']['claimed'], 'the only slot was held by a run that ended two hours ago');
+		$this->assertSame('live-run', $state->get(key: 'slots')['1']['holder']);
+
+	}//end testAnExpiredHolderIsDisplacedSoThePoolRecovers()
+
+	/**
+	 * A holder INSIDE its lease is never displaced.
+	 *
+	 * 🔑 This is the arm that makes the one above safe rather than merely
+	 * convenient. Displacing a live holder hands one slot to two runs and
+	 * destroys the mutual exclusion the pool exists for — a lease that expires
+	 * too eagerly is worse than no lease at all, because the failure is silent
+	 * concurrency rather than a stalled queue.
+	 *
+	 * @return void
+	 */
+	public function testALiveHolderIsNeverDisplaced(): void {
+		$fresh = (new \DateTime('-5 seconds'))->format(\DateTimeInterface::ATOM);
+		$state = new FlowStateHandle(values: ['slots' => ['1' => ['holder' => 'busy-run', 'since' => $fresh]]]);
+
+		$out = $this->node->execute(
+			items: [['json' => ['holder' => 'other-run'], 'binary' => [], 'pairedItem' => null]],
+			config: [
+				'operation' => 'claim',
+				'slots' => 'slots',
+				'capacity' => 1,
+				'holder' => 'holder',
+				'leaseSeconds' => 3600,
+			],
+			context: $this->ctx($state)
+		);
+
+		$this->assertFalse($out[0]['json']['claimed'], 'a run five seconds into an hour-long lease was displaced');
+		$this->assertSame('busy-run', $state->get(key: 'slots')['1']['holder']);
+
+	}//end testALiveHolderIsNeverDisplaced()
+
+	/**
+	 * With no lease configured, a holder is kept forever — today's behaviour.
+	 *
+	 * The lease is opt-in because a caller may genuinely want a slot held until
+	 * it is released. This arm is what proves the addition changes nothing for
+	 * every flow that does not ask for it.
+	 *
+	 * @return void
+	 */
+	public function testWithoutALeaseAHolderIsKeptHowLongAgoItWasTaken(): void {
+		$ancient = (new \DateTime('-30 days'))->format(\DateTimeInterface::ATOM);
+		$state = new FlowStateHandle(values: ['slots' => ['1' => ['holder' => 'dead-run', 'since' => $ancient]]]);
+
+		$out = $this->node->execute(
+			items: [['json' => ['holder' => 'live-run'], 'binary' => [], 'pairedItem' => null]],
+			config: ['operation' => 'claim', 'slots' => 'slots', 'capacity' => 1, 'holder' => 'holder'],
+			context: $this->ctx($state)
+		);
+
+		$this->assertFalse($out[0]['json']['claimed'], 'an unleased pool must behave exactly as it did before');
+
+	}//end testWithoutALeaseAHolderIsKeptHowLongAgoItWasTaken()
+
+	/**
+	 * An unparseable or absent `since` keeps the slot HELD.
+	 *
+	 * Fails in the safe direction: an expired holder read as live only delays a
+	 * recovery, while a live holder read as expired duplicates work.
+	 *
+	 * @return void
+	 */
+	public function testAnUnreadableTimestampKeepsTheSlotHeld(): void {
+		$state = new FlowStateHandle(values: ['slots' => ['1' => ['holder' => 'odd-run', 'since' => 'not-a-date']]]);
+
+		$out = $this->node->execute(
+			items: [['json' => ['holder' => 'live-run'], 'binary' => [], 'pairedItem' => null]],
+			config: [
+				'operation' => 'claim',
+				'slots' => 'slots',
+				'capacity' => 1,
+				'holder' => 'holder',
+				'leaseSeconds' => 1,
+			],
+			context: $this->ctx($state)
+		);
+
+		$this->assertFalse($out[0]['json']['claimed'], 'a timestamp that will not parse must not free the slot');
+
+	}//end testAnUnreadableTimestampKeepsTheSlotHeld()
+
 }//end class


### PR DESCRIPTION
Closes #2468.

`claim` and `release` are separate steps, and everything that can happen between them does: a node with `onError: stop`, a refusal, a crashed worker, a run that outlives its deadline. Any of those ends the run still holding a slot — and unlike the per-issue lock beside it, which `hydra-lock-reaper` ages out, **nothing reaps a slot.** It is lost rather than borrowed.

## ⚠️ The symptom is not an error, it is silence

Once the pool is full of dead holders, every claim routes to the caller's "at capacity" branch — which is a **normal** outcome. The flow reports `completed`, the queue stops moving, and the pipeline looks busy while doing nothing.

Measured today on hydra's sequencer: one run stopped at `lock-issue` with `onError: stop`, and its slot was still held **four hours later** with the other two free.

## The design

`leaseSeconds` is **opt-in and absent by default** — a caller may genuinely want a slot held until released. Where set, an expired holder is treated as *gone* rather than deleted: the claim overwrites the entry, so the pool recovers on the next attempt to use it and no reaper has to exist.

🔑 **`leaseExpired()` answers FALSE whenever it cannot be sure**, and that direction is the whole safety argument. Displacing a live holder hands one slot to two runs and destroys the mutual exclusion the pool exists for; keeping an expired one only delays a recovery. So a missing lease, a non-record slot value, an absent or non-string `since`, and an unparseable timestamp **all keep the slot held**.

## Four tests, three of which exist to stop the fourth being dangerous

```
expired holder + lease   → displaced, pool recovers
LIVE holder + lease      → NOT displaced        ← this is what makes the first safe
no lease at all          → held forever, exactly today's behaviour
unparseable       → held
```

**Control:** remove the lease check and exactly **one** test fails, by name — the displacement one — while both safety arms still pass.

Full Unit suite unchanged at 40 pre-existing failures, **none newly broken**. PHPCS 0 errors, Psalm no errors.

⚠️ The PHPMD suppression is five over and all five come from `leaseExpired()`. Its branches are not logic, they are four separate reasons to fail safe; collapsing them would satisfy the metric and remove the property that makes the lease safe to turn on.