### PR TITLE
fix(flow): a firing that produced nothing must not erase a shared place

### DIFF
--- a/lib/Service/Flow/FlowItemPlacement.php
+++ b/lib/Service/Flow/FlowItemPlacement.php
@@ -116,6 +116,11 @@ class FlowItemPlacement {
 	 * Clearing the consumed inputs matters for a loop that re-enters the
 	 * transition — it must read fresh items, not a stale copy left behind.
 	 *
+	 * A firing that produced NO items only clears its inputs. Writing empty
+	 * lists to its outputs would erase items another branch has already placed
+	 * on a place they share, which is openregister#2488 and is invisible in a
+	 * run log — see the comment in the body.
+	 *
 	 * @param object $transition The fired transition.
 	 * @param array<string, array> $placeItems The current per-place buffers.
 	 * @param array $items What the step produced.
@@ -126,6 +131,42 @@ class FlowItemPlacement {
 	 * @spec openspec/changes/or-flow-per-item-routing/specs/flow-per-item-routing/spec.md
 	 */
 	public function advanceItems(object $transition, array $placeItems, array $items, array $taken): array {
+		// A FIRING THAT PRODUCED NOTHING PLACES NOTHING AND DESTROYS NOTHING.
+		//
+		// Every node in a flow fires on every pass, and most of them fire with
+		// no items — the familiar `in 0 out 0` heartbeat in a run log. Without
+		// this guard each of those heartbeats still ran the loop below and
+		// ASSIGNED an empty list to every one of its output places. A node that
+		// shares an output place with a branch scheduled later in the same pass
+		// therefore had its items erased before the consumer ever ran.
+		//
+		// Measured in hydra's sequencer (openregister#2488), twice:
+		//
+		//     built-gate     in 1 out 1   item tagged output: "build-blocked"
+		//     verdict-gate   in 0 out 0   heartbeat, in ANOTHER branch
+		//     build-blocked  in 0 out 0   nothing arrived
+		//
+		// The routing was correct in both cases — the emitted item carried the
+		// right output tag, visible in the run log's own output envelope. The
+		// loss was entirely here. And nothing reported it: the run said
+		// `completed`, the routing node said `in 1 out 1`, and the starved
+		// consumer said `completed` too, because a node with no items still
+		// fires. The only trace anywhere was an `in 0` on a node nobody was
+		// watching.
+		//
+		// The comment below justifies the unconditional write as keeping stale
+		// items off a branch the token never reached. That reasoning is about
+		// PLACING items, and there are none to place here — so returning early
+		// cannot seed anything. The input places are still cleared, because
+		// consuming them is what the firing did do.
+		if ($items === []) {
+			foreach ($transition->getFroms() as $from) {
+				unset($placeItems[(string)$from]);
+			}
+
+			return $placeItems;
+		}
+
 		foreach ($transition->getTos() as $to) {
 			// Only the taken exit receives items. Seeding a branch the token
 			// never reaches would leave stale items for a later firing to pick

--- a/tests/Unit/Service/Flow/FlowItemPlacementTest.php
+++ b/tests/Unit/Service/Flow/FlowItemPlacementTest.php
@@ -1,0 +1,182 @@
+<?php
+
+/**
+ * A firing that produced nothing must not erase what another branch placed.
+ *
+ * Every node in a flow fires on every pass, and most fire with no items — the
+ * `in 0 out 0` heartbeat that fills a run log. `advanceItems()` used to run its
+ * output loop for those firings too, ASSIGNING an empty list to each of the
+ * node's output places. Where two branches of one pass shared an output place,
+ * whichever fired last won, and the consumer found nothing.
+ *
+ * It is worth being explicit about why this needed a test rather than a review.
+ * Nothing reports it. The run finishes `completed`, the routing node reports
+ * `in 1 out 1`, and the starved consumer reports `completed` as well, because a
+ * node with no items still fires. In hydra's sequencer it stranded a lock and a
+ * slot and left an issue queued forever, and the only trace anywhere was an
+ * `in 0` on a node nobody was looking at (openregister#2488).
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author  Conduction Development Team <dev@conduction.nl>
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Service\Flow\FlowItemPlacement;
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Workflow\Transition;
+
+/**
+ * @covers \OCA\OpenRegister\Service\Flow\FlowItemPlacement
+ */
+final class FlowItemPlacementTest extends TestCase {
+
+	/**
+	 * The collaborator under test.
+	 *
+	 * @var FlowItemPlacement
+	 */
+	private FlowItemPlacement $placement;
+
+	/**
+	 * Build the subject.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$this->placement = new FlowItemPlacement();
+
+	}//end setUp()
+
+	/**
+	 * The measured defect, as a test: a heartbeat in one branch used to wipe
+	 * the place another branch had just filled.
+	 *
+	 * This mirrors hydra's sequencer exactly. `built-gate` routes an item to
+	 * `build-blocked`; `verdict-gate` sits in another branch of the same pass,
+	 * fires with nothing, and also lists `build-blocked` among its outputs.
+	 * Before the guard the second firing replaced the first's item with an
+	 * empty list and the consumer starved.
+	 *
+	 * @return void
+	 */
+	public function testAnEmptyFiringDoesNotEraseAnotherBranchesItems(): void {
+		$item = FlowItems::item(json: ['issue' => 1549], output: 'build-blocked');
+
+		// The routing node fires with work and tags the item for one exit.
+		$placeItems = $this->placement->advanceItems(
+			transition: new Transition('built-gate', ['built-gate'], ['run-stage', 'nothing-built', 'build-blocked']),
+			placeItems: ['built-gate' => [$item]],
+			items: [$item],
+			taken: ['run-stage', 'nothing-built', 'build-blocked']
+		);
+
+		$this->assertCount(
+			expectedCount: 1,
+			haystack: $placeItems['build-blocked'],
+			message: 'the routed item should land on the place its output tag names'
+		);
+
+		// A DIFFERENT branch of the same pass now fires with nothing, and it
+		// happens to share that output place.
+		$placeItems = $this->placement->advanceItems(
+			transition: new Transition('verdict-gate', ['verdict-gate'], ['advance', 'run-fix', 'build-blocked']),
+			placeItems: $placeItems,
+			items: [],
+			taken: ['advance', 'run-fix', 'build-blocked']
+		);
+
+		$this->assertCount(
+			expectedCount: 1,
+			haystack: ($placeItems['build-blocked'] ?? []),
+			message: 'a firing that produced no items must not erase a shared output place'
+		);
+
+	}//end testAnEmptyFiringDoesNotEraseAnotherBranchesItems()
+
+	/**
+	 * The guard must not stop a firing from consuming what it read.
+	 *
+	 * Leaving items on an input place is how a loop re-reads a stale copy
+	 * instead of fresh work, so the early return still clears the froms.
+	 *
+	 * @return void
+	 */
+	public function testAnEmptyFiringStillClearsItsOwnInputPlaces(): void {
+		$stale = FlowItems::item(json: ['stale' => true]);
+
+		$placeItems = $this->placement->advanceItems(
+			transition: new Transition('gate', ['gate'], ['next']),
+			placeItems: ['gate' => [$stale]],
+			items: [],
+			taken: ['next']
+		);
+
+		$this->assertArrayNotHasKey(
+			key: 'gate',
+			array: $placeItems,
+			message: 'the input place a firing consumed must be cleared even when it produced nothing'
+		);
+
+	}//end testAnEmptyFiringStillClearsItsOwnInputPlaces()
+
+	/**
+	 * A firing that DID produce items still clears the branches it did not take.
+	 *
+	 * This is the behaviour the guard must not weaken: an exit the token never
+	 * reached must not keep items from an earlier pass, or a later firing picks
+	 * them up as if they were fresh.
+	 *
+	 * @return void
+	 */
+	public function testAProductiveFiringStillClearsTheBranchesItDidNotTake(): void {
+		$old = FlowItems::item(json: ['from' => 'an earlier pass']);
+		$item = FlowItems::item(json: ['issue' => 1549], output: 'taken');
+
+		$placeItems = $this->placement->advanceItems(
+			transition: new Transition('gate', ['gate'], ['taken', 'not-taken']),
+			placeItems: ['gate' => [$item], 'not-taken' => [$old]],
+			items: [$item],
+			taken: ['taken']
+		);
+
+		$this->assertArrayNotHasKey(
+			key: 'not-taken',
+			array: $placeItems,
+			message: 'an exit the token did not reach must not keep stale items'
+		);
+		$this->assertCount(expectedCount: 1, haystack: $placeItems['taken']);
+
+	}//end testAProductiveFiringStillClearsTheBranchesItDidNotTake()
+
+	/**
+	 * An untagged item is still broadcast to every taken output.
+	 *
+	 * The ordinary case, and what a parallel split relies on. Included so the
+	 * guard cannot be "fixed" later by returning early on anything other than
+	 * a genuinely empty produce.
+	 *
+	 * @return void
+	 */
+	public function testAnUntaggedItemStillReachesEveryTakenOutput(): void {
+		$item = FlowItems::item(json: ['issue' => 1549]);
+
+		$placeItems = $this->placement->advanceItems(
+			transition: new Transition('split', ['split'], ['left', 'right']),
+			placeItems: ['split' => [$item]],
+			items: [$item],
+			taken: ['left', 'right']
+		);
+
+		$this->assertCount(expectedCount: 1, haystack: $placeItems['left']);
+		$this->assertCount(expectedCount: 1, haystack: $placeItems['right']);
+
+	}//end testAnUntaggedItemStillReachesEveryTakenOutput()
+
+}//end class


### PR DESCRIPTION
Closes #2488.

## A firing that produced nothing was erasing another branch's items

`advanceItems()` wrote every output place of a firing transition unconditionally — an **assignment**, not an append — and it ran for firings that produced no items. Every node in a flow fires on every pass, and most fire with nothing: the `in 0 out 0` heartbeat that fills a run log. So a node sharing an output place with a branch scheduled later in the same pass had its items replaced with an empty list before the consumer ever ran.

Measured in hydra's sequencer, twice:

```
built-gate     in 1 out 1   item tagged output: "build-blocked"
verdict-gate   in 0 out 0   heartbeat, in ANOTHER branch
build-blocked  in 0 out 0   nothing arrived
```

The **routing was correct** both times — the emitted item carried the right `output` tag, confirmed from the run log's own output envelope. The loss was entirely in placement.

## Why it needed a test rather than a review

Nothing reports it:

- the run finishes `completed`
- the routing node reports `in 1 out 1`
- the starved consumer reports `completed` too, because a node with no items still fires

In hydra this stranded a lock and a slot and left an issue queued forever, re-selected by `find-work` every five minutes. The only trace anywhere was an `in 0` on a node nobody was watching.

## The change

An empty firing clears its inputs and returns. The existing comment justifies the unconditional write as keeping stale items off a branch the token never reached — that reasoning is about **placing** items, and there are none to place here, so the early return cannot seed anything. Inputs are still cleared, because consuming them is what the firing did do.

## Proven three ways

**1. The unit test fails without the guard.** Neutralised, exactly the target assertion breaks and the other three still pass:

```
1) FlowItemPlacementTest::testAnEmptyFiringDoesNotEraseAnotherBranchesItems
   a firing that produced no items must not erase a shared output place
   Failed asserting that actual size 0 matches expected size 1.
Tests: 4, Assertions: 7, Failures: 1
```

Restored: `Tests: 4, Assertions: 7` green.

**2. The other three tests pin the behaviour this must not weaken** — an empty firing still clears its own inputs (or a loop re-reads stale work), a productive firing still clears branches it did not take, and an untagged item still broadcasts to every taken output.

**3. Live, on the running instance.** The shared place was deliberately restored so both gates target one node — the exact shape that lost the item before:

```
built-gate     in 1 out 1
verdict-gate   in 0 out 0
build-blocked  in 1 out 1   → dequeue 1 → unlock 1 → release 1
```

→ issue relabelled, lock row deleted, all three slots free. Before this change, the identical configuration gave `build-blocked in 0 out 0`.

## Scope note

hydra worked around this by splitting every convergence into its own node (`build-blocked` + `verdict-blocked`, `flag-nospec` + `dequeue-nospec`). Three further convergences in that one flow were still exposed — `advance`, `advance-failed` and `open-pr`, which between them mean a *passing* build may never get its label or its pull request. Splitting those would have meant duplicating the pull-request node four times. This fixes the class instead.

Note that convergence itself was never the problem: `dequeue` takes four incoming edges and works, because the engine visits it directly after each predecessor. The rule was much narrower and not visible on a canvas — *no two branches of one pass may write the same place with the consumer scheduled between them* — which is the argument for fixing it here rather than asking flow authors to avoid it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
