### PR TITLE
fix(security): rate-limit the public reference-data endpoints

### DIFF
--- a/lib/Controller/ChatHealthController.php
+++ b/lib/Controller/ChatHealthController.php
@@ -31,6 +31,7 @@ namespace OCA\OpenRegister\Controller;
 
 use OCA\OpenRegister\Service\SettingsService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
@@ -106,6 +107,10 @@ class ChatHealthController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	// A health probe is polled by monitoring on a schedule, so the ceiling is
+	// generous — it exists to stop an unauthenticated caller turning a liveness
+	// endpoint into a load generator, not to police the monitor.
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function health(): JSONResponse {
 		try {
 			$llmConfig = $this->settingsService->getLLMSettingsOnly();

--- a/lib/Controller/IconController.php
+++ b/lib/Controller/IconController.php
@@ -28,6 +28,7 @@ namespace OCA\OpenRegister\Controller;
 use OCA\OpenRegister\Service\MdiIconRenderer;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\DataDisplayResponse;
@@ -65,6 +66,9 @@ class IconController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	// Icons are fetched many-per-page, so this ceiling is deliberately high —
+	// set it near the data endpoints and a single dense screen trips it.
+	#[AnonRateLimit(limit: 240, period: 60)]
 	public function mdi(string $name): DataDisplayResponse {
 		$svg = MdiIconRenderer::svg(icon: $name);
 		if ($svg === null) {

--- a/lib/Controller/ManifestController.php
+++ b/lib/Controller/ManifestController.php
@@ -35,6 +35,7 @@ use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
@@ -93,6 +94,7 @@ class ManifestController extends Controller {
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
 	#[PublicPage]
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function index(string $appId): JSONResponse {
 		// Sanitise: appId must be a valid NC app slug (alphanumeric + underscore/hyphen).
 		if (preg_match('/^[a-z0-9_-]+$/i', $appId) !== 1) {

--- a/lib/Controller/NamesController.php
+++ b/lib/Controller/NamesController.php
@@ -33,6 +33,7 @@ namespace OCA\OpenRegister\Controller;
 use OCA\OpenRegister\Service\Object\CacheHandler;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
@@ -374,6 +375,7 @@ class NamesController extends Controller {
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
 	#[PublicPage]
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function show(string $id): JSONResponse {
 		$startTime = microtime(true);
 
@@ -470,6 +472,7 @@ class NamesController extends Controller {
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
 	#[PublicPage]
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function stats(): JSONResponse {
 		try {
 			$stats = $this->objectCacheService->getStats();
@@ -517,6 +520,9 @@ class NamesController extends Controller {
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
 	#[PublicPage]
+	// Much tighter than its siblings: warmup REBUILDS the cache, so it is the
+	// one endpoint here where a caller can make the server do real work.
+	#[AnonRateLimit(limit: 5, period: 60)]
 	public function warmup(): JSONResponse {
 		$startTime = microtime(true);
 

--- a/lib/Controller/VocabularyController.php
+++ b/lib/Controller/VocabularyController.php
@@ -42,6 +42,7 @@ use OCA\OpenRegister\Service\VocabularyImportService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
@@ -119,6 +120,9 @@ class VocabularyController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	// Published vocabulary — resolution is the point of it, so these are
+	// runaway ceilings rather than gates.
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function resolveByUri(): JSONResponse {
 		$uri = trim((string)$this->request->getParam('uri', ''));
 		if ($uri === '') {
@@ -148,6 +152,7 @@ class VocabularyController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function resolveByNotation(): JSONResponse {
 		$scheme = trim((string)$this->request->getParam('scheme', ''));
 		$notation = trim((string)$this->request->getParam('notation', ''));
@@ -190,6 +195,7 @@ class VocabularyController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function listConcepts(): JSONResponse {
 		$scheme = trim((string)$this->request->getParam('scheme', ''));
 		if ($scheme === '') {

--- a/lib/Controller/WebPushController.php
+++ b/lib/Controller/WebPushController.php
@@ -42,6 +42,7 @@ use OCA\OpenRegister\Service\WebPush\WebPushService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\DataDisplayResponse;
@@ -177,6 +178,8 @@ class WebPushController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	// Notification icons — fetched per-notification by the browser.
+	#[AnonRateLimit(limit: 240, period: 60)]
 	public function hexIcon(string $app): DataDisplayResponse {
 		$icon = $this->hexIconService->getIcon($app);
 		$response = new DataDisplayResponse($icon['body'], Http::STATUS_OK, ['Content-Type' => $icon['mime']]);
@@ -195,6 +198,7 @@ class WebPushController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AnonRateLimit(limit: 240, period: 60)]
 	public function hexBadge(string $app): DataDisplayResponse {
 		$badge = $this->hexIconService->getBadge($app);
 		$response = new DataDisplayResponse($badge['body'], Http::STATUS_OK, ['Content-Type' => $badge['mime']]);


### PR DESCRIPTION
The eleven remaining `#[PublicPage]` endpoints with no ceiling: chat health, mdi icons, app manifest, names (show/stats/warmup), vocabulary (resolveByUri/resolveByNotation/listConcepts), web-push hex icon/badge.

### No brute-force counters here, deliberately

None of these takes a credential — the ids are published vocabulary URIs, app slugs and icon names, and resolving them is the *point* of the endpoints. A counter would throttle exactly the consumers they exist to serve. Volume ceilings are a different control for a different problem, and that's the one they need.

### Limits reflect actual use, not one number everywhere

| limit | endpoints | why |
|---|---|---|
| 240/60 | icons, push badges | fetched many-per-page; a ceiling set near the data endpoints trips on one dense screen |
| 120/60 | vocabulary, names, manifest, health | published reference data / monitoring poll |
| **5/60** | `names/warmup` | **rebuilds the cache** — the one endpoint here where a caller makes the server do real work, so two orders of magnitude tighter than its own siblings |

### Verification

Controller suite: **2802 tests, identical to baseline** — Warnings 5, Deprecations 5, Skipped 8 before and after.

Completes the ADR-081/082 sweep for openregister (ConductionNL/hydra#554).