### PR TITLE
docs(spec): stop FlowStateNode citing a spec that does not exist

### DIFF
--- a/lib/Service/Flow/Nodes/FlowStateNode.php
+++ b/lib/Service/Flow/Nodes/FlowStateNode.php
@@ -540,7 +540,13 @@ class FlowStateNode implements IFlowNode, IFlowNodeConfigKeys {
 	 *
 	 * @return bool True when the holder may be displaced.
 	 *
-	 * @spec openspec/specs/flow-state/spec.md
+	 * @spec exclude The slot/lease contract has no canonical spec.
+	 *  openspec/specs/flow-state/spec.md does not exist and never has; the tag
+	 *  pointed at a file rather than at a requirement. flow-engine's spec is
+	 *  the nearest home and it covers resume and suspend-on-signal, NOT slot
+	 *  leases, so citing it here would be a reference that reads as coverage
+	 *  and is not. Excluded with the gap named until the flow-state slot
+	 *  contract is written down.
 	 */
 	private function leaseExpired(mixed $entry, int $leaseSeconds): bool {
 		if ($leaseSeconds <= 0 || is_array($entry) === false) {


### PR DESCRIPTION
gate-46 (spec-anchor-existence) reported `openspec/specs/flow-state/spec.md` as missing from `leaseExpired()`. It's missing because **it has never existed** — the tag named a file, not a requirement.

### Why I didn't just repoint it

Pointing it at `openspec/specs/flow-engine/spec.md` would have made the gate green and the codebase worse. That spec covers resume (*"A node MUST be able to resume from where it stopped"*) and suspend-on-signal (*"A run suspended on an external signal MUST be reachable"*) — it says **nothing about slot leases**, which is what this method decides.

A citation that *resolves* but doesn't *cover* the behaviour is exactly the failure I removed from pipelinq's `BrpController` this week, where a docblock cited a requirement that argued against it.

So: `@spec exclude` with the gap named. The slot/lease contract is unspecified, and the comment says so rather than pointing somewhere plausible.

### Verification

**gate-46 on openregister: 0 findings** after this change — verified by running `check_spec_anchors.py` over `lib/`, not by assuming.

The second finding I set out to fix (`AwaitSignalNode` citing `openspec/changes/or-flow-resume-state/...`) is already gone from `development`; my earlier count came from a lagging checkout.
