### PR TITLE
fix(security): give every public endpoint a volume ceiling (ADR-082)

### DIFF
--- a/lib/AppHost/Controller/GenericHealthController.php
+++ b/lib/AppHost/Controller/GenericHealthController.php
@@ -32,6 +32,7 @@ namespace OCA\OpenRegister\AppHost\Controller;
 use OCA\OpenRegister\AppHost\Observability\HealthCheckExecutor;
 use OCA\OpenRegister\AppHost\Observability\ManifestLoader;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
@@ -75,6 +76,10 @@ class GenericHealthController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	// Generous: a health endpoint is polled by monitoring on a short interval,
+	// and a ceiling that trips on a normal probe cadence turns the check itself
+	// into the outage it was meant to detect.
+	#[AnonRateLimit(limit: 240, period: 60)]
 	public function index(): JSONResponse {
 		$appId = $this->appName;
 		$manifest = $this->manifestLoader->load(appId: $appId);

--- a/lib/Controller/ContextsController.php
+++ b/lib/Controller/ContextsController.php
@@ -33,6 +33,7 @@ use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Service\JsonLd\JsonLdContextService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
@@ -80,6 +81,7 @@ class ContextsController extends Controller {
 	 *
 	 * @spec openspec/specs/json-ld-output/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function register(string $register): DataResponse {
 		try {
 			$registerEntity = $this->registerMapper->find($register);
@@ -110,6 +112,7 @@ class ContextsController extends Controller {
 	 *
 	 * @spec openspec/specs/json-ld-output/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function schema(string $register, string $schema): DataResponse {
 		try {
 			$registerEntity = $this->registerMapper->find($register);

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -37,6 +37,7 @@ use OCA\OpenRegister\Service\FileService;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\StreamResponse;
 use OCP\AppFramework\Http\TemplateResponse;
@@ -300,6 +301,7 @@ class FilesController extends Controller {
 	 *
 	 * @spec openspec/specs/object-interactions/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function index(
 		string $register,
 		string $schema,
@@ -357,6 +359,7 @@ class FilesController extends Controller {
 	 *
 	 * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-12
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function show(
 		string $register,
 		string $schema,
@@ -529,6 +532,7 @@ class FilesController extends Controller {
 	 *
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 30, period: 60)]
 	public function create(
 		string $register,
 		string $schema,
@@ -618,6 +622,7 @@ class FilesController extends Controller {
 	 *
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 30, period: 60)]
 	public function save(
 		string $register,
 		string $schema,
@@ -723,6 +728,7 @@ class FilesController extends Controller {
 	 *
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 30, period: 60)]
 	public function createMultipart(
 		string $register,
 		string $schema,
@@ -1045,6 +1051,7 @@ class FilesController extends Controller {
 	 *
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 30, period: 60)]
 	public function update(
 		string $register,
 		string $schema,
@@ -1108,6 +1115,7 @@ class FilesController extends Controller {
 	 *
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 30, period: 60)]
 	public function delete(
 		string $register,
 		string $schema,
@@ -1169,6 +1177,7 @@ class FilesController extends Controller {
 	 *
 	 * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-12
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function downloadById(int $fileId): JSONResponse|\OCP\AppFramework\Http\StreamResponse {
 		// SECURITY (C1): gate anonymous callers on the file being published.
 		// Authenticated callers are allowed through (they have a valid NC session).
@@ -1379,6 +1388,7 @@ class FilesController extends Controller {
 	 *
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 30, period: 60)]
 	public function rename(string $register, string $schema, string $id, int $fileId): JSONResponse {
 		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
@@ -1448,6 +1458,7 @@ class FilesController extends Controller {
 	 *
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 30, period: 60)]
 	public function copy(string $register, string $schema, string $id, int $fileId): JSONResponse {
 		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
@@ -1549,6 +1560,7 @@ class FilesController extends Controller {
 	 *
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 30, period: 60)]
 	public function move(string $register, string $schema, string $id, int $fileId): JSONResponse {
 		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
@@ -1650,6 +1662,7 @@ class FilesController extends Controller {
 	 *
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function listVersions(string $register, string $schema, string $id, int $fileId): JSONResponse {
 		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
@@ -1697,6 +1710,7 @@ class FilesController extends Controller {
 	 *
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 30, period: 60)]
 	public function restoreVersion(
 		string $register,
 		string $schema,
@@ -1770,6 +1784,7 @@ class FilesController extends Controller {
 	 *
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 30, period: 60)]
 	public function lock(string $register, string $schema, string $id, int $fileId): JSONResponse {
 		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
@@ -1832,6 +1847,7 @@ class FilesController extends Controller {
 	 *
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 30, period: 60)]
 	public function unlock(string $register, string $schema, string $id, int $fileId): JSONResponse {
 		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
@@ -1902,6 +1918,7 @@ class FilesController extends Controller {
 	 *
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 30, period: 60)]
 	public function batch(string $register, string $schema, string $id): JSONResponse {
 		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
@@ -1958,6 +1975,7 @@ class FilesController extends Controller {
 	 *
 	 * @spec openspec/specs/file-actions/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function preview(string $register, string $schema, string $id, int $fileId): JSONResponse|StreamResponse {
 		try {
 			// SetSchema/setRegister throw DoesNotExistException for an unknown
@@ -2035,6 +2053,7 @@ class FilesController extends Controller {
 	 *
 	 * @PublicPage
 	 */
+	#[AnonRateLimit(limit: 30, period: 60)]
 	public function updateLabels(string $register, string $schema, string $id, int $fileId): JSONResponse {
 		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);

--- a/lib/Controller/GraphQLController.php
+++ b/lib/Controller/GraphQLController.php
@@ -33,6 +33,8 @@ use OC\Security\CSP\ContentSecurityPolicyNonceManager;
 use OC\Security\CSRF\CsrfTokenManager;
 use OCA\OpenRegister\Service\GraphQL\GraphQLService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
+use OCP\AppFramework\Http\Attribute\UserRateLimit;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
@@ -89,6 +91,8 @@ class GraphQLController extends Controller {
 	 *
 	 * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-graphql-rt-dash/tasks.md#task-1
 	 */
+	#[AnonRateLimit(limit: 30, period: 60)]
+	#[UserRateLimit(limit: 240, period: 60)]
 	public function execute(): JSONResponse {
 		$body = file_get_contents('php://input');
 		$data = json_decode($body, true);

--- a/lib/Controller/McpController.php
+++ b/lib/Controller/McpController.php
@@ -31,6 +31,7 @@ namespace OCA\OpenRegister\Controller;
 use Exception;
 use OCA\OpenRegister\Service\McpDiscoveryService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
@@ -86,6 +87,7 @@ class McpController extends Controller {
 	 * @spec openspec/specs/mcp-discovery/spec.md#requirement-tier-1-discovery-catalog
 	 * @spec openspec/specs/mcp-discovery/spec.md
 	 */
+	#[AnonRateLimit(limit: 60, period: 60)]
 	public function discover(): JSONResponse {
 		try {
 			$catalog = $this->mcpDiscoveryService->getCatalog();

--- a/lib/Controller/OasController.php
+++ b/lib/Controller/OasController.php
@@ -36,6 +36,7 @@ use OCA\OpenRegister\Exception\OasValidationException;
 use OCA\OpenRegister\Service\Oas\OasETagComputer;
 use OCA\OpenRegister\Service\OasService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
@@ -88,6 +89,7 @@ class OasController extends Controller {
 	 *
 	 * @spec openspec/specs/oas-generation/spec.md
 	 */
+	#[AnonRateLimit(limit: 30, period: 60)]
 	public function generateAll(): JSONResponse {
 		return $this->generateInternal(registerId: null);
 	}//end generateAll()
@@ -109,6 +111,7 @@ class OasController extends Controller {
 	 *
 	 * @spec openspec/specs/oas-generation/spec.md
 	 */
+	#[AnonRateLimit(limit: 30, period: 60)]
 	public function generate(string $id): JSONResponse {
 		return $this->generateInternal(registerId: $id);
 	}//end generate()

--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -1087,6 +1087,7 @@ class ObjectsController extends Controller {
 	 *
 	 * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function index(string $register, string $schema, ObjectService $objectService): JSONResponse {
 		// Read paths were unmeasured: WritePhaseProbe::flush() is only reached
 		// from the write path, so search and single-read reported no
@@ -1760,6 +1761,7 @@ class ObjectsController extends Controller {
 	 *
 	 * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md
 	 */
+	#[AnonRateLimit(limit: 60, period: 60)]
 	public function geoSearch(string $register, string $schema, ObjectService $objectService): JSONResponse {
 		if ($this->geoFilterParser === null || $this->geoFilterApplier === null) {
 			return new JSONResponse(
@@ -2142,6 +2144,7 @@ class ObjectsController extends Controller {
 	 *
 	 * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function objects(ObjectService $objectService): JSONResponse {
 		// Check for register/schema in query parameters for magic mapper routing.
 		$params = $this->request->getParams();
@@ -2361,6 +2364,7 @@ class ObjectsController extends Controller {
 	 *
 	 * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function show(
 		string $id,
 		string $register,
@@ -2767,6 +2771,7 @@ class ObjectsController extends Controller {
 	 *
 	 * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md
 	 */
+	#[AnonRateLimit(limit: 30, period: 60)]
 	public function update(
 		string $register,
 		string $schema,
@@ -2988,6 +2993,7 @@ class ObjectsController extends Controller {
 	 *
 	 * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md
 	 */
+	#[AnonRateLimit(limit: 30, period: 60)]
 	public function patch(
 		string $register,
 		string $schema,
@@ -3222,6 +3228,7 @@ class ObjectsController extends Controller {
 	 *
 	 * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md
 	 */
+	#[AnonRateLimit(limit: 30, period: 60)]
 	public function postPatch(
 		string $register,
 		string $schema,
@@ -3363,6 +3370,7 @@ class ObjectsController extends Controller {
 	 *
 	 * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md
 	 */
+	#[AnonRateLimit(limit: 30, period: 60)]
 	public function destroy(string $id, string $register, string $schema, ObjectService $objectService): JSONResponse {
 		\OCA\OpenRegister\Service\WritePhaseProbe::stamp('ctrl.destroy.in');
 

--- a/lib/Controller/RegistersController.php
+++ b/lib/Controller/RegistersController.php
@@ -48,6 +48,7 @@ use OCA\OpenRegister\Service\UploadService;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\DataDownloadResponse;
@@ -260,6 +261,7 @@ class RegistersController extends Controller {
 	 *
 	 * @spec openspec/changes/register-schema-read-accessibility/tasks.md#task-1
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function index(): JSONResponse {
 		// Get request parameters for filtering and searching.
 		$params = $this->request->getParams();
@@ -476,6 +478,7 @@ class RegistersController extends Controller {
 	 *
 	 * @spec openspec/changes/register-schema-read-accessibility/tasks.md#task-2
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function show($id): JSONResponse {
 		try {
 			$extend = $this->request->getParam(key: '_extend', default: []);

--- a/lib/Controller/SchemasController.php
+++ b/lib/Controller/SchemasController.php
@@ -49,6 +49,7 @@ use OCA\OpenRegister\Service\UploadService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\DB\Exception as DBException;
 use OCP\IAppConfig;
@@ -179,6 +180,7 @@ class SchemasController extends Controller {
 	 *
 	 * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function index(): JSONResponse {
 		// Get request parameters for filtering and searching.
 		$params = $this->request->getParams();
@@ -310,6 +312,7 @@ class SchemasController extends Controller {
 	 *
 	 * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function show($id): JSONResponse {
 		try {
 			$extend = $this->request->getParam(key: '_extend', default: []);
@@ -1580,6 +1583,7 @@ class SchemasController extends Controller {
 	 * @spec openspec/changes/cross-app-semantic-references/specs/semantic-schema-references/spec.md
 	 *   (Requirement: Resolution is null-safe across installed schemas)
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function resolveByImplements(): JSONResponse {
 		$uri = (string)($this->request->getParam('uri', ''));
 		if ($uri === '' || $this->semanticTypeResolver === null) {

--- a/lib/Controller/TagsController.php
+++ b/lib/Controller/TagsController.php
@@ -32,6 +32,7 @@ use OCA\OpenRegister\Service\FileService;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\IUserSession;
@@ -96,6 +97,7 @@ class TagsController extends Controller {
 	 *
 	 * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-4
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function getAllTags(): JSONResponse {
 		// @PublicPage opens this route past the group-locked app gate so a
 		// consuming app (e.g. OpenCatalogi) can populate its label picker even

--- a/lib/Controller/UserController.php
+++ b/lib/Controller/UserController.php
@@ -29,6 +29,7 @@ use Exception;
 use OCA\OpenRegister\Service\SecurityService;
 use OCA\OpenRegister\Service\UserService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\DataDownloadResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IL10N;
@@ -230,6 +231,12 @@ class UserController extends Controller {
 	 *
 	 * @spec openspec/specs/auth-system/spec.md
 	 */
+	// A framework ceiling ALONGSIDE the app-level limiter, not instead of it.
+	// SecurityService::checkLoginRateLimit() already keys on username + IP with a
+	// progressive delay, which is finer-grained than anything the framework can
+	// do from an attribute. This bounds the volume that reaches that logic at
+	// all; it is not a claim that the login was unprotected.
+	#[AnonRateLimit(limit: 20, period: 60)]
 	public function login(): JSONResponse {
 		try {
 			// Memory monitoring: Check initial memory usage to prevent OOM.
@@ -389,6 +396,7 @@ class UserController extends Controller {
 	 *
 	 * @spec openspec/specs/auth-system/spec.md
 	 */
+	#[AnonRateLimit(limit: 60, period: 60)]
 	public function logout(): JSONResponse {
 		$this->userSession->logout();
 


### PR DESCRIPTION
## What

Adds `#[AnonRateLimit]` to **41 publicly reachable methods** that had no volume ceiling (ADR-082).

## Why these were missed

**40 of the 41 declare themselves public with the legacy `@PublicPage` annotation**, not the `#[PublicPage]` attribute. The fleet sweep that reported this app fully throttled line-anchored the *attribute* form and excluded docblock matches — a correction made for a good reason (an earlier count had matched the attribute name inside docblock prose), but the annotation is not a mention of anything. It is a live declaration:

```
POST /apps/openregister/api/graphql   (no auth)  ->  200
{"data":{"__typename":"Query"}}
```

The 41st, `GenericHealthController::index`, is an attribute-form endpoint the sweep simply missed.

## Authorisation is not the gap

Worth stating precisely, because the alarming reading is available and wrong:

| probe | anonymous | admin |
|---|---|---|
| `GET /api/objects` | 0 results | many |
| GraphQL `totalCount` | `0`, `0`, `0`, `0` | `1`, `2`, `10`, `221` |
| `FilesController::delete` | `ensureObjectAccess()` (ADR-005 / gate-7) | — |

That distinction only exists because the anon-vs-admin control was run — `totalCount: 0` alone reads equally well as "empty register" and as "correctly filtered".

What *is* exposed: reachability without a ceiling, plus **GraphQL schema introspection** — an anonymous caller can enumerate 2,292 queryable connections and drive the query engine unmetered.

## Why `AnonRateLimit` and not `BruteForceProtection`

These endpoints check no credential, and `#[BruteForceProtection]` without a paired `registerAttempt()` is the **inert half** of a two-half mechanism — a mistake already made once in this programme. `AnonRateLimit` also leaves authenticated server-to-server traffic untouched, so **no integration can be throttled by this change**.

Limits follow values already in use in this app: reads 120/60, writes 30/60, GraphQL 30/60 anon + 240/60 user, health 240/60, login 20/60.

**`UserController::login` was already protected.** `SecurityService::checkLoginRateLimit()` keys on username + IP with a progressive delay — finer-grained than any attribute. The attribute bounds what reaches that logic; it is *not* a claim the login was unprotected. That's written at the call site, because getting it backwards is exactly the correction openconnector#1251 had to make.

## Verification

- `php -l` clean on all 11 files.
- Diff is **61 added lines, 0 removed** — purely additive.
- gate-82 (.github#460) goes **41 findings → 0** on this tree.
- PHPCS was **not** run locally: this box has PHP 8.2 and the vendor tree requires 8.3. CI judges it, and I'll compare its result against the base rather than read a green flag.

## Deliberately not changed

Whether anonymous GraphQL **introspection** should be available at all. Disabling it alters an API contract — a product decision, not a throttling fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
