### PR TITLE
fix(files): actually transfer folder ownership — the four TODOs are done

### DIFF
--- a/lib/Service/File/FolderManagementHandler.php
+++ b/lib/Service/File/FolderManagementHandler.php
@@ -218,8 +218,7 @@ class FolderManagementHandler {
 
 		// Transfer ownership to OpenRegister and share with current user if needed.
 		if ($this->fileService !== null) {
-			// TODO: Call $this->fileService->transferFolderOwnershipIfNeeded($folderNode)
-			// once FileOwnershipHandler is extracted.
+			$this->fileService->transferFolderOwnershipIfNeeded(folder: $folderNode);
 		}
 
 		// Share the folder with the currently active user if there is one.
@@ -309,8 +308,7 @@ class FolderManagementHandler {
 
 		// Transfer ownership to OpenRegister and share with current user if needed.
 		if ($this->fileService !== null) {
-			// TODO: Call $this->fileService->transferFolderOwnershipIfNeeded($objectFolder)
-			// once FileOwnershipHandler is extracted.
+			$this->fileService->transferFolderOwnershipIfNeeded(folder: $objectFolder);
 		}
 
 		// Share the folder with the currently active user if there is one.
@@ -487,8 +485,7 @@ class FolderManagementHandler {
 
 		// Transfer ownership to OpenRegister and share with current user if needed.
 		if ($this->fileService !== null) {
-			// TODO: Call $this->fileService->transferFolderOwnershipIfNeeded($objectFolder)
-			// once FileOwnershipHandler is extracted.
+			$this->fileService->transferFolderOwnershipIfNeeded(folder: $objectFolder);
 		}
 
 		// Share the folder with the currently active user if there is one.
@@ -559,8 +556,7 @@ class FolderManagementHandler {
 
 				// Transfer ownership to OpenRegister and share with current user if needed.
 				if ($this->fileService !== null) {
-					// TODO: Call $this->fileService->transferFolderOwnershipIfNeeded($node)
-					// once FileOwnershipHandler is extracted.
+					$this->fileService->transferFolderOwnershipIfNeeded(folder: $node);
 				}
 
 				return $node;

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -1006,6 +1006,45 @@ class FileService {
 	}//end checkOwnership()
 
 	/**
+	 * Transfer folder ownership to the OpenRegister user, sharing it back.
+	 *
+	 * The facade seam FolderManagementHandler needs. Four call sites there
+	 * carried `// TODO: Call $this->fileService->transferFolderOwnershipIfNeeded()
+	 * once FileOwnershipHandler is extracted.` — the extraction happened, but
+	 * this delegation never did, so the literal call in those TODOs would have
+	 * been a fatal: the facade exposed neither ownership-transfer variant.
+	 *
+	 * FILES were transferred and FOLDERS were not. CreateFileHandler and
+	 * UpdateFileHandler both call transferFileOwnershipIfNeeded() directly on
+	 * the handler, so a register's files ended up owned by the OpenRegister
+	 * user while the folder containing them stayed owned by whoever created
+	 * it — two halves of one register with different owners and, when that
+	 * user is deleted, different lifetimes.
+	 *
+	 * The sharing handler is passed explicitly because the ownership handler's
+	 * own docblock requires it: without it the transfer would move the folder
+	 * away from the current user WITHOUT sharing it back, which takes their
+	 * access away instead of preserving it.
+	 *
+	 * @param Node $folder The folder to potentially transfer ownership for.
+	 *
+	 * @return void
+	 *
+	 * @throws Exception If ownership transfer fails.
+	 *
+	 * @psalm-return   void
+	 * @phpstan-return void
+	 *
+	 * @spec exclude Ownership-transfer delegation; the behaviour is specified on FileOwnershipHandler, this adds no rule of its own.
+	 */
+	public function transferFolderOwnershipIfNeeded(Node $folder): void {
+		$this->fileOwnershipHandler->transferFolderOwnershipIfNeeded(
+			folder: $folder,
+			fileSharingHandler: $this->fileSharingHandler
+		);
+	}//end transferFolderOwnershipIfNeeded()
+
+	/**
 	 * Formats a single Node file into a metadata array (DELEGATED to FileFormattingHandler).
 	 *
 	 * @param Node $file The Node file to format.


### PR DESCRIPTION
## What

Does the four `TODO`s in `FolderManagementHandler` — folder ownership is now actually transferred to the OpenRegister user. Closes #2495.

## The defect

**Files transferred ownership; folders never did.**

| variant | call sites before this PR |
|---|---|
| `transferFileOwnershipIfNeeded` | **2 live** — `CreateFileHandler:216`, `UpdateFileHandler:500` |
| `transferFolderOwnershipIfNeeded` | **0** — 4 commented TODOs |

So a register's files ended up owned by the OpenRegister user while the folder containing them stayed owned by whoever happened to create it. Two halves of one register, different owners — and when that user is deleted, different lifetimes. The folder also counted against an individual's quota.

## The TODOs could not have been done as written

Each said:

```php
// TODO: Call $this->fileService->transferFolderOwnershipIfNeeded($folderNode)
// once FileOwnershipHandler is extracted.
```

The extraction happened long ago — but **the facade exposed neither ownership-transfer variant**, so that literal call would have been a fatal. This PR adds the missing delegation on `FileService`, then makes the four calls.

## The sharing handler is passed explicitly

`FileOwnershipHandler::transferFolderOwnershipIfNeeded()`'s own docblock requires it:

> NOTE: This method depends on `FileSharingHandler->shareFolderWithUser()`. During integration, either inject `FileSharingHandler` or call through the `FileService` facade.

Without it the transfer would move the folder away from the current user **without sharing it back** — taking their access away rather than preserving it. That is the difference between this change working and this change locking users out of their own registers.

## Why enabling it on every folder creation is safe

`transferFolderOwnershipIfNeeded()` catches `Exception`, logs, and deliberately does not rethrow:

```php
} catch (Exception $e) {
    $this->logger->error(...);
    // Don't throw the exception to avoid breaking folder operations.
```

A transfer failure degrades to a log entry; folder creation still succeeds. I checked this *before* wiring it into four hot paths, because a method that threw would have turned every folder create into a potential 500.

## Scope note

This changes ownership for folders created **from now on**. It does not backfill folders already created under the old behaviour — those still sit with their original owner. If a backfill is wanted, that is a migration and belongs in its own change.

## Verification

- `php -l` clean on both changed files.
- 4 TODOs → **0**; 4 live calls.
- `tests/Unit/Service/File` + `FileSidebarServiceTest`: **319 tests, 728 assertions, 0 failures**.
- **Full unit suite: 16,440 tests, 36,774 assertions, 0 failures** (PHP 8.4 in the container — this box runs 8.2 and the app requires ^8.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
