### PR TITLE
fix(flow): a wait must not suspend the run on an EMPTY firing

### DIFF
--- a/lib/Service/Flow/Nodes/WaitNode.php
+++ b/lib/Service/Flow/Nodes/WaitNode.php
@@ -146,9 +146,33 @@ class WaitNode implements IFlowNode, IFlowNodeConfigKeys {
 	 *
 	 * @return array The items, unchanged, once the wait is over.
 	 *
-	 * @throws FlowSuspension On the first pass, to pause the run.
+	 * @throws FlowSuspension On the first pass that carries items, to pause the
+	 *                        run. An EMPTY firing never suspends: there is
+	 *                        nothing to wait for, and pausing on it would pause
+	 *                        every other branch of the run with it.
 	 */
 	public function execute(array $items, array $config, array $context): array {
+		if ($items === []) {
+			// AN EMPTY FIRING IS NOT SOMETHING TO WAIT FOR.
+			//
+			// A transition can fire with no items — a gate sent every item down
+			// another branch, or the branch simply had no work this pass — and
+			// suspending on that pauses the WHOLE RUN, not just this branch.
+			// In a flow whose branches are priorities rather than alternatives,
+			// that is a live defect: hydra's sequencer routes an in-flight
+			// stage to a collect branch and leaves the dispatch branch empty,
+			// and the empty branch's wait suspended the run before the branch
+			// carrying the item could advance. On resume the marking had moved
+			// on and every remaining transition fired empty, so the item was
+			// gone and the log read as a clean pass — 40 transitions, all
+			// `completed`, `in=0 out=0`.
+			//
+			// Nothing is skipped by returning here: with no items there is no
+			// work to delay, and a later pass that DOES carry items reaches
+			// this node again and suspends then.
+			return $items;
+		}
+
 		if (($context['resuming'] ?? false) === true) {
 			// Woken by the worker: the wait is over by construction, because
 			// the run was only eligible once `resumeAt` had passed.

--- a/lib/Service/Flow/Nodes/WaitNode.php
+++ b/lib/Service/Flow/Nodes/WaitNode.php
@@ -146,6 +146,8 @@ class WaitNode implements IFlowNode, IFlowNodeConfigKeys {
 	 *
 	 * @return array The items, unchanged, once the wait is over.
 	 *
+	 * @spec openspec/specs/flow-engine/spec.md#requirement-suspending-is-a-run-level-act-so-an-empty-firing-must-not-suspend
+	 *
 	 * @throws FlowSuspension On the first pass that carries items, to pause the
 	 *                        run. An EMPTY firing never suspends: there is
 	 *                        nothing to wait for, and pausing on it would pause

--- a/openspec/specs/flow-engine/spec.md
+++ b/openspec/specs/flow-engine/spec.md
@@ -45,6 +45,30 @@ Where several edges converge on a node, the lowering MUST give that node ONE sha
 - **THEN** the node MUST NOT fire
 - **AND** it MUST fire once a token has arrived on both
 
+### Requirement: SUSPENDING is a run-level act, so an EMPTY firing MUST NOT suspend @e2e exclude engine-internal suspend rule — covered by WaitNodeTest
+
+`FlowSuspension` stops the WHOLE run and stores its marking; it is not scoped to the branch that threw it. A transition MAY fire with no items — a routing node sent every item down another branch, or that branch had no work this pass — and a node that waits MUST return those items unchanged rather than suspend.
+
+This matters wherever branches are PRIORITIES rather than alternatives. Such a flow evaluates a preferred branch first and falls through when it is empty, so an empty branch reaching a wait is the normal case, not an error. Suspending on it stops the branch that DID carry an item, and when the run resumes the marking has moved on: every remaining transition fires empty and the item is gone, while the log records only `completed` steps with zero items in and zero out.
+
+Nothing is deferred by returning early. With no items there is nothing to delay, and a later pass that DOES carry items reaches the node and suspends then.
+
+#### Scenario: An empty branch does not pause the run
+- **GIVEN** a flow whose routing node sends its only item to a collect branch, leaving a dispatch branch that also contains a wait
+- **WHEN** the wait on the empty dispatch branch fires with no items
+- **THEN** the run MUST NOT suspend
+- **AND** the collect branch MUST advance in the same pass
+
+#### Scenario: A wait carrying work still suspends
+- **GIVEN** the same wait node and configuration
+- **WHEN** it fires with one or more items on its first pass
+- **THEN** it MUST suspend the run with the resolved `resumeAt`
+
+#### Scenario: A resumed wait passes its items through
+- **GIVEN** a run woken by the worker because `resumeAt` has passed
+- **WHEN** the wait node runs a second time with `resuming` set
+- **THEN** it MUST return its items unchanged rather than suspend again
+
 ### Requirement: A path MUST end deliberately, and a dead end MUST be reported @e2e exclude engine-internal connectivity check — covered by FlowDeadEndTest
 
 A node with no outgoing edge is a dead end unless it ends the path deliberately. It ends deliberately if EITHER its type is registered as an end (the type implements `IFlowEndNode`, resolved through `FlowNodeRegistry::isEnd()`) OR the node itself declares `exit: true`. The two MUST be OR-ed, never AND-ed, so a migrated flow whose sink carries an ordinary action type is not refused, and a contributed end type needs no OpenRegister change.

--- a/tests/Unit/Service/Flow/WaitNodeTest.php
+++ b/tests/Unit/Service/Flow/WaitNodeTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * The wait node's suspend decision.
+ *
+ * Suspending is a RUN-level act, not a branch-level one: `FlowSuspension`
+ * stops the whole run and stores its marking. So the question this node has to
+ * get right is not only WHEN to wait, but whether there is anything to wait
+ * for at all.
+ *
+ * A transition can fire with no items — a gate sent every item down another
+ * branch, or that branch simply had no work this pass. Suspending on that
+ * pauses every other branch with it, and in a flow whose branches are
+ * PRIORITIES rather than alternatives it loses the work outright: hydra's
+ * sequencer routes an in-flight stage to a collect branch and leaves the
+ * dispatch branch empty, and the empty branch's wait suspended the run before
+ * the branch carrying the item could advance. On resume the marking had moved
+ * on, every remaining transition fired empty, and the log read as a clean pass
+ * — forty transitions, all `completed`, all `in=0 out=0`.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author  Conduction Development Team <dev@conduction.nl>
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Flow;
+
+use OCA\OpenRegister\Service\Flow\FlowSuspension;
+use OCA\OpenRegister\Service\Flow\Nodes\WaitNode;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \OCA\OpenRegister\Service\Flow\Nodes\WaitNode
+ */
+final class WaitNodeTest extends TestCase {
+
+	/**
+	 * The node under test.
+	 *
+	 * @var WaitNode
+	 */
+	private WaitNode $node;
+
+	/**
+	 * Build the node with stub collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$l10n = $this->createMock(originalClassName: IL10N::class);
+		$l10n->method('t')->willReturnArgument(0);
+
+		$this->node = new WaitNode($l10n, $this->createMock(originalClassName: IURLGenerator::class));
+
+	}//end setUp()
+
+	/**
+	 * THE POSITIVE CONTROL: a wait that carries work still suspends.
+	 *
+	 * Without this, the empty-firing test below would pass just as happily
+	 * against a node that had stopped suspending altogether — which would make
+	 * every wait in every flow a no-op and look, from the log, like success.
+	 *
+	 * @return void
+	 */
+	public function testAWaitCarryingItemsStillSuspends(): void {
+		$this->expectException(exception: FlowSuspension::class);
+
+		$this->node->execute([['json' => ['a' => 1]]], ['for' => '60 seconds'], []);
+
+	}//end testAWaitCarryingItemsStillSuspends()
+
+	/**
+	 * An EMPTY firing does not suspend, because there is nothing to wait for.
+	 *
+	 * Suspending stops the RUN, so an empty branch that suspends takes every
+	 * other branch down with it.
+	 *
+	 * @return void
+	 */
+	public function testAnEmptyFiringDoesNotSuspendTheRun(): void {
+		$this->assertSame(
+			expected: [],
+			actual: $this->node->execute([], ['for' => '60 seconds'], []),
+			message: 'a branch with no work must not pause every other branch of the run'
+		);
+
+	}//end testAnEmptyFiringDoesNotSuspendTheRun()
+
+	/**
+	 * Nothing is skipped: a later pass that DOES carry items suspends then.
+	 *
+	 * This is what makes the early return safe rather than a way of disabling
+	 * the wait — the same node, same config, suspends as soon as there is
+	 * something to delay.
+	 *
+	 * @return void
+	 */
+	public function testTheSameNodeStillSuspendsOnceItemsArrive(): void {
+		$this->assertSame(expected: [], actual: $this->node->execute([], ['for' => '60 seconds'], []));
+
+		$this->expectException(exception: FlowSuspension::class);
+		$this->node->execute([['json' => []]], ['for' => '60 seconds'], []);
+
+	}//end testTheSameNodeStillSuspendsOnceItemsArrive()
+
+	/**
+	 * On the way back in, items pass straight through.
+	 *
+	 * The marking is not advanced while suspended, so the node runs a SECOND
+	 * time on resume. `context.resuming` is what stops that becoming an
+	 * infinite wait — and, as a consequence, what makes this node useless as a
+	 * loop body.
+	 *
+	 * @return void
+	 */
+	public function testResumingPassesItemsThrough(): void {
+		$items = [['json' => ['a' => 1]]];
+
+		$this->assertSame(
+			expected: $items,
+			actual: $this->node->execute($items, ['for' => '60 seconds'], ['resuming' => true])
+		);
+
+	}//end testResumingPassesItemsThrough()
+}//end class


### PR DESCRIPTION
fix(flow): a wait must not suspend the run on an EMPTY firing

Suspending is a RUN-level act, not a branch-level one — `FlowSuspension`
stops the whole run and stores its marking — but `WaitNode` threw it
unconditionally on its first pass, including when it fired with no items at
all.

A transition fires empty routinely: a gate sent every item down another
branch, or that branch had no work this pass. In a flow whose branches are
ALTERNATIVES that is harmless. In one whose branches are PRIORITIES it loses
the work outright.

That is how it was found. Hydra's sequencer checks for an already-running
stage before it considers starting a new one, so a tick that finds one routes
its single item to the collect branch and leaves the dispatch branch empty.
The empty branch's wait suspended the run before the branch holding the item
could advance; on resume the marking had moved on, and every remaining
transition fired empty. The run log read as a clean pass: forty transitions,
all `completed`, all `in=0 out=0`, no error anywhere — while the item had
simply ceased to exist.

Nothing is skipped by returning early. With no items there is nothing to
delay, and a later pass that DOES carry items reaches the node and suspends
then. The test pins both directions, and the positive control is the point:
without an assertion that a wait carrying items STILL suspends, the same
suite would pass against a node that had stopped suspending entirely — which
would make every wait in every flow a silent no-op. Verified by mutation:
restoring the unconditional throw fails exactly the two empty-firing tests
and leaves the control green.

This is the same class of defect as the empty-firing item loss fixed in
#2489: an empty firing is not a normal firing with zero rows, and treating it
as one destroys state that no log line reports.
