### PR TITLE
fix(entity): a named argument to a magic setter sets nothing — object locking was a no-op

### DIFF
--- a/lib/Db/ObjectEntity.php
+++ b/lib/Db/ObjectEntity.php
@@ -836,7 +836,7 @@ class ObjectEntity extends Entity implements JsonSerializable {
 
 		// Hydrate the entity with the metadata fields.
 		$this->hydrate(object: $metaDataFields);
-		$this->setObject(object: $object);
+		$this->setObject($object);
 
 		// Return the hydrated entity.
 		return $this;
@@ -1063,7 +1063,7 @@ class ObjectEntity extends Entity implements JsonSerializable {
 			$newExpiration->add(new DateInterval('PT' . ($duration ?? 0) . 'S'));
 
 			$this->setLocked(
-				locked: [
+				[
 					'user' => $userId,
 					'process' => ($process ?? $lock['process']),
 					'created' => $lock['created'],
@@ -1079,7 +1079,7 @@ class ObjectEntity extends Entity implements JsonSerializable {
 		$expiration->add(new DateInterval('PT' . ($duration ?? 0) . 'S'));
 
 		$this->setLocked(
-			locked: [
+			[
 				'user' => $userId,
 				'process' => $process,
 				'created' => $now->format('c'),
@@ -1123,7 +1123,7 @@ class ObjectEntity extends Entity implements JsonSerializable {
 			throw new Exception('Object is locked by another user');
 		}
 
-		$this->setLocked(locked: null);
+		$this->setLocked(null);
 		return true;
 	}//end unlock()
 
@@ -1214,7 +1214,7 @@ class ObjectEntity extends Entity implements JsonSerializable {
 		$purgeDate->add(new DateInterval('P31D'));
 
 		$this->setDeleted(
-			deleted: [
+			[
 				'deleted' => $now->format('c'),
 				'deletedBy' => $userId,
 				'deletedReason' => $deletedReason,

--- a/tests/Unit/Db/ObjectEntityLockExtensionTest.php
+++ b/tests/Unit/Db/ObjectEntityLockExtensionTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * Re-locking an object that is already locked.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Db;
+
+use DateTime;
+use Exception;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `ObjectEntity::lock()` has three paths and only one of them was tested.
+ *
+ * Taking a lock on an UNLOCKED object was covered. What was not: what happens
+ * when the object is ALREADY locked — the branch that decides whether a second
+ * caller extends the existing lock or is refused. That is the half of a lock
+ * that actually protects anything, and it was reached by no test at all.
+ *
+ * Found by reading the uncovered lines out of the CI coverage artifact rather
+ * than by guessing: lines 1132-1144 of lib/Db/ObjectEntity.php were a
+ * contiguous block of twelve unexecuted statements.
+ */
+class ObjectEntityLockExtensionTest extends TestCase {
+
+	/**
+	 * Build a session that reports the given user id.
+	 *
+	 * @param string $uid The user id the session should return.
+	 *
+	 * @return IUserSession The session double.
+	 */
+	private function sessionFor(string $uid): IUserSession {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+
+		$session = $this->createMock(IUserSession::class);
+		$session->method('getUser')->willReturn($user);
+
+		return $session;
+	}//end sessionFor()
+
+	/**
+	 * A lock is created on an object that is not yet locked.
+	 *
+	 * @return void
+	 */
+	public function testLockingAnUnlockedObjectCreatesTheLock(): void {
+		$entity = new ObjectEntity();
+
+		$this->assertTrue($entity->lock($this->sessionFor('alice'), 'import', 600));
+		$this->assertTrue($entity->isLocked());
+
+		$lock = $entity->getLocked();
+		$this->assertSame('alice', $lock['user']);
+		$this->assertSame('import', $lock['process']);
+		$this->assertSame(600, $lock['duration']);
+	}//end testLockingAnUnlockedObjectCreatesTheLock()
+
+	/**
+	 * The SAME user re-locking extends their own lock rather than being refused.
+	 *
+	 * The extension keeps the original `created` stamp — the lock is the same
+	 * lock, held longer — while `expiration` and `duration` move. Asserting
+	 * `created` is what distinguishes an extension from a silently replaced
+	 * lock, which would look identical from the outside.
+	 *
+	 * @return void
+	 */
+	public function testTheSameUserExtendsTheirOwnLock(): void {
+		$entity = new ObjectEntity();
+		$entity->lock($this->sessionFor('alice'), 'import', 600);
+
+		$created = $entity->getLocked()['created'];
+		$firstExpiry = $entity->getLocked()['expiration'];
+
+		$this->assertTrue($entity->lock($this->sessionFor('alice'), null, 7200));
+
+		$lock = $entity->getLocked();
+		$this->assertSame('alice', $lock['user']);
+		$this->assertSame($created, $lock['created'], 'An extension keeps the original created stamp.');
+		$this->assertSame(7200, $lock['duration']);
+		$this->assertSame(
+			'import',
+			$lock['process'],
+			'A null process on re-lock inherits the existing one rather than clearing it.'
+		);
+		$this->assertGreaterThan(
+			new DateTime($firstExpiry),
+			new DateTime($lock['expiration']),
+			'Extending must push the expiry out, or the lock is not actually extended.'
+		);
+	}//end testTheSameUserExtendsTheirOwnLock()
+
+	/**
+	 * A DIFFERENT user is refused.
+	 *
+	 * This is the assertion the whole lock exists for, and nothing was making it.
+	 *
+	 * @return void
+	 */
+	public function testADifferentUserIsRefused(): void {
+		$entity = new ObjectEntity();
+		$entity->lock($this->sessionFor('alice'), 'import', 600);
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Object is locked by another user');
+
+		$entity->lock($this->sessionFor('bob'), 'export', 600);
+	}//end testADifferentUserIsRefused()
+
+	/**
+	 * Locking without a session user is refused.
+	 *
+	 * @return void
+	 */
+	public function testAnAnonymousCallerIsRefused(): void {
+		$session = $this->createMock(IUserSession::class);
+		$session->method('getUser')->willReturn(null);
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('No user logged in');
+
+		(new ObjectEntity())->lock($session);
+	}//end testAnAnonymousCallerIsRefused()
+}//end class


### PR DESCRIPTION
## `ObjectEntity::lock()` returns `true` and locks nothing

`setLocked()` is a **magic** method — an `@method` annotation over Nextcloud's
`Entity::__call`. Five call sites in this file invoke such setters with a **named
argument**:

```php
$this->setLocked(locked: [...]);
```

PHP passes named arguments to `__call` as an **associative** array, so `$args`
arrives as `['locked' => [...]]` and `Entity::setter()` reads `$args[0]`. Result:
`Undefined array key 0`, and the property is never touched.

Proven by probe — the same call, named vs positional:

```
setLocked(locked: [...])   ->  WARNING: Undefined array key 0
                               property = NULL,  isLocked() = false
setLocked([...])           ->  property = [...],  isLocked() = true
```

## This is live

```
ObjectService::lockObject()
  └─ LockHandler::lock()
      └─ MagicMapper::lockObjectEntity()
          └─ ObjectEntity::lock()      ← sets nothing
```

…and `lockObjectEntity()` then **persists the entity, logs `"Locked object in
register+schema table"`, and dispatches `ObjectLockedEvent`.**

So the audit trail records a lock that does not exist, and concurrent writers are
not excluded. Every later `isLocked()` returns `false`.

## The five sites

| method | effect |
|---|---|
| `lock()` ×2 | neither the create branch nor the same-user **extend** branch stored anything |
| `unlock()` | `setLocked(null)` — releasing did nothing either |
| `delete()` | soft-delete metadata (`deletedBy`, `purgeDate`, retention) never recorded |
| `hydrateObject()` | **drops the entire object payload** — probe shows `getObject()` returning only `['id' => …]` after hydrating a title and body. No caller in `lib/`, so latent rather than live. |

## Tests

Cover the branch nothing reached: `lock()` on an **already-locked** object — the
half that decides whether a second caller extends or is refused, which is the
half that actually protects something.

Found by reading uncovered lines out of the CI coverage artifact rather than by
guessing: lines 1132–1144 were a contiguous block of twelve unexecuted
statements.

Control pair:

```
against the UNFIXED file:  3 failures + a stream of "Undefined array key 0"
with the fix:              OK (4 tests, 15 assertions)   PHP 8.4
```

## Where it came from

Surfaced while publishing the `ObjectService` contract (ADR-084,
openregister#2498), and it is the same lesson in a different costume: **a magic
method has no signature, so nothing checks how it is called** — not PHP, not
PHPStan, not the tests.

~100 further named-argument setter calls exist under `lib/`. Each is only a bug
where the receiver's setter is magic (many receivers declare theirs), so that
needs per-receiver checking rather than a sweep — not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
