### PR TITLE
chore(deps): hydra-gates 1.8.0 — turns gate-67 from a skip into an enforcement

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -7048,16 +7048,16 @@
         },
         {
             "name": "conduction/hydra-gates",
-            "version": "v1.7.3",
+            "version": "v1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ConductionNL/.github.git",
-                "reference": "9b9896abf87167e97b821d8ee86c5422f0b32e80"
+                "reference": "9fc64ab93f7a20b69f6b5912745ef9fc456c1cee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/9b9896abf87167e97b821d8ee86c5422f0b32e80",
-                "reference": "9b9896abf87167e97b821d8ee86c5422f0b32e80",
+                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/9fc64ab93f7a20b69f6b5912745ef9fc456c1cee",
+                "reference": "9fc64ab93f7a20b69f6b5912745ef9fc456c1cee",
                 "shasum": ""
             },
             "require": {
@@ -7072,6 +7072,11 @@
                     "runner": "hydra-gates/scripts/run-hydra-gates.sh",
                     "helpers": "hydra-gates/scripts/lib",
                     "schemas": "hydra-gates/scripts/schemas"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "OCA\\OpenRegister\\Contract\\": "hydra-gates/contracts/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -7096,9 +7101,9 @@
             "support": {
                 "docs": "https://github.com/ConductionNL/.github/blob/main/hydra-gates/README.md",
                 "issues": "https://github.com/ConductionNL/.github/issues",
-                "source": "https://github.com/ConductionNL/.github/tree/v1.7.3"
+                "source": "https://github.com/ConductionNL/.github/tree/v1.8.0"
             },
-            "time": "2026-08-12T22:32:31+00:00"
+            "time": "2026-08-15T06:24:48+00:00"
         },
         {
             "name": "consolidation/annotated-command",


### PR DESCRIPTION
## Why

openregister#2498 added `lib/Contract/`, but the shipped copy it must stay in step
with only exists from `conduction/hydra-gates` **v1.8.0**. Until this lock moves,
gate-67 says:

```
[gate-67] openregister-contract-parity: NOT APPLICABLE — lib/Contract/ exists but
no shipped copy was found to compare it against. NOT a pass — nothing was verified.
```

Which is the correct thing for it to say, and no use to anyone. A gate that can
only skip is not protecting the invariant.

## Verified, not assumed

- the published v1.8.0 archive's `hydra-gates/contracts/*.php` are **byte-identical**
  to `lib/Contract/*.php` on `development` — checked with `cmp`
- gate-67 run against the real installed layout: `checked 2 file(s)`, exit **0**
- the same checker returns exit **1** on a one-byte drift

## Scope

Exactly one package moves: `conduction/hydra-gates` v1.7.3 → v1.8.0. Diffed the
whole lock to confirm nothing else shifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)