### PR TITLE
docs(spec): a forms register — form, journey and journeyRun

### DIFF
--- a/openspec/changes/or-form-and-journey-registry/.openspec.yaml
+++ b/openspec/changes/or-form-and-journey-registry/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: conduction
+created: 2026-08-15

--- a/openspec/changes/or-form-and-journey-registry/proposal.md
+++ b/openspec/changes/or-form-and-journey-registry/proposal.md
@@ -1,0 +1,73 @@
+---
+kind: mixed
+---
+
+# Proposal: or-form-and-journey-registry
+
+## Summary
+
+Add a `forms` register carrying `form`, `journey` and `journeyRun`, the API to
+drive a run (start / answer / resume / submit), the named formats that replace
+per-app validator forks, and the retention job that purges expired runs.
+
+Chain link 4 of `hydra/openspec/changes/portaliq-phase-two`. `kind: mixed`
+because it is schemas **plus** a run API and a background job — the schemas
+alone would be an inert data model.
+
+## Motivation
+
+`tilburg-woo-ui` implements citizen and supplier intake as ~13,640 lines of
+hand-written React across seven wizards, each re-implementing step state,
+per-step validation, progress display and submission. None is resumable.
+
+The declarative half already exists: manifest v2 has `config.steps[]`,
+`$defs.fieldValidation` and `$defs.visibleWhen`, and `CnFormPage` renders them.
+What is missing is the primitive that spans forms — multiple objects, branching
+between forms, lookup-and-prefill, a review step, and resumability — and a
+place to keep a half-finished submission. That is what a `journey` and a
+`journeyRun` are.
+
+The name matters: OpenRegister already owns `flow` for the automation engine
+(ADR-065, ~40 change specs, `FlowController`, flow runs, a visual canvas). A
+journey is a UI-facing sequence; it may trigger a flow, and it is not one.
+
+## Affected Projects
+
+- [ ] `openregister` — `forms` register (`form`, `journey`, `journeyRun`); a
+      journey-run controller and service; `EmailFormat`, `WebsiteFormat`,
+      `NlPhoneFormat` beside the existing `BsnFormat` / `Iso8601DateTimeFormat`
+      / `UserFormat`; a retention background job.
+
+## Design notes
+
+**A `form` body is a manifest-v2 form-page config**, validated by the same
+`validateManifestV2()` path an app manifest uses. Not a subset, not a copy — if
+the two can drift, they will.
+
+**A `journey` declares** ordered steps (`form` / `review` / `confirmation`),
+`next` rules using `$defs.visibleWhen` verbatim, `writes[]` per step, and
+`access` (`anonymous` | `authenticated` | `minTrust`).
+
+**A `journeyRun` stages everything.** Answers accumulate there; objects are
+written only at steps declaring `writes[]`. This preserves the property the
+React wizards have by accident — an abandoned registration leaves no
+half-built organisation — while adding the resumability they lack.
+
+**Retention ships with the schema, not after it.** A `journeyRun` holds names,
+addresses, e-mail, phone numbers and uploads before any of it is a record.
+
+## Risks
+
+- **`journeyRun` is a personal-data store outside the register's normal
+  lifecycle.** The purge is part of this change and its first run is verified by
+  row count. The precedent is the audit retention purge on this instance, which
+  had never run — 0 of 3,254,448 rows — while looking exactly like a purge with
+  nothing to do.
+- **A resume token is a bearer credential for someone's half-filled form.** It
+  must be unguessable, single-purpose, and must not act as an existence oracle.
+- **`writes[]` makes authoring a privileged action.** A journey author can cause
+  writes into any register the mapping names; mappings validate against the
+  target schema at author time.
+- **Anonymous submission is an unauthenticated write path.** It is explicit,
+  throttled (ADR-082), stamps no ownership, and fails closed when `access` is
+  absent.

--- a/openspec/changes/or-form-and-journey-registry/specs/form-and-journey-registry/spec.md
+++ b/openspec/changes/or-form-and-journey-registry/specs/form-and-journey-registry/spec.md
@@ -1,0 +1,182 @@
+# form-and-journey-registry Delta: or-form-and-journey-registry
+
+**Status**: in-progress
+**Scope**: openregister
+**OpenSpec changes**:
+
+- [or-form-and-journey-registry](../../)
+
+## Purpose
+
+Declares `form`, `journey` and `journeyRun` in a `forms` register, the API that
+drives a run, the named formats that replace app-local validator forks, and the
+retention job that purges expired runs. Implements the OpenRegister half of
+ADR-085 and of the cross-app delta
+`hydra/openspec/changes/portaliq-phase-two/specs/forms-and-journeys/spec.md`.
+Related: ADR-065 (the flow engine this does not extend), ADR-005 (fail-closed),
+ADR-082 (throttling).
+
+## ADDED Requirements
+
+### Requirement: A form body MUST validate through the canonical manifest validator
+
+A `form` object's `config` SHALL be validated on write by the same
+`validateManifestV2()` path an app manifest is validated by. A separate or
+subset schema for form bodies MUST NOT exist.
+
+#### Scenario: The validator rejects what it rejects in a manifest
+
+- **GIVEN** a form config whose field declares `validation: { minLength: 2 }`
+- **WHEN** the object is written
+- **THEN** the write is rejected with the same error the manifest validator
+  emits for that input
+
+#### Scenario: A valid manifest form page is a valid form body
+
+- **GIVEN** a `type: "form"` page config taken from a shipping app manifest
+- **WHEN** it is written as a form body
+- **THEN** the write succeeds
+
+### Requirement: A journey MUST declare steps, branching, writes and access
+
+A `journey` SHALL declare an ordered `steps[]` of `form` | `review` |
+`confirmation`; optional per-step `next` rules whose conditions `$ref` the
+canonical `$defs.visibleWhen`; optional per-step `writes[]` of
+`{ register, schema, mapping }`; and a required `access` of `anonymous` |
+`authenticated` | `minTrust`.
+
+#### Scenario: A branching rule using an unknown operator is rejected on write
+
+- **GIVEN** a `next` rule declaring `op: "contains"`
+- **WHEN** the journey is written
+- **THEN** the write is rejected naming the accepted operators
+
+#### Scenario: A write mapping is validated against the target schema
+
+- **GIVEN** a `writes[]` entry whose mapping names a property absent from the
+  target schema
+- **WHEN** the journey is written
+- **THEN** the write is rejected naming the property and the target schema
+
+#### Scenario: A journey with no declared access is rejected
+
+- **GIVEN** a journey object with no `access`
+- **WHEN** it is written
+- **THEN** the write is rejected — access is never inferred
+
+### Requirement: The run API MUST stage answers and commit only at declared steps
+
+The API SHALL expose start, answer, resume and submit operations over a
+`journeyRun`. Answers SHALL be persisted to the run. Objects SHALL be created
+or updated only at a step declaring `writes[]`, in declared order, with a later
+entry able to reference an earlier entry's id.
+
+#### Scenario: Advancing without a writes step creates nothing
+
+- **GIVEN** a run advanced past two steps, neither declaring `writes[]`
+- **WHEN** the target registers are queried
+- **THEN** no object has been created
+
+#### Scenario: A dependent write receives the preceding write's id
+
+- **GIVEN** a step declaring an organisation write followed by a contact write
+  whose mapping references the organisation's id
+- **WHEN** the step commits
+- **THEN** the contact carries the organisation's id
+
+#### Scenario: A partial failure is recorded and is not duplicated on retry
+
+- **GIVEN** a step whose second write fails validation after the first
+  succeeded
+- **WHEN** the step is re-submitted
+- **THEN** the failure is recorded on the run, and the first object is updated
+  rather than created a second time
+
+#### Scenario: An answer for a field the current step does not declare is refused
+
+- **GIVEN** a run at step one
+- **WHEN** an answer is submitted for a field belonging to step three
+- **THEN** it is refused — the client does not choose which fields are in scope
+
+### Requirement: A run MUST be resumable without becoming an oracle
+
+A run SHALL be resumable by account for an authenticated filer and by an
+unguessable single-purpose token for an anonymous one. A token presented
+against a run it does not belong to, and a token for a run that does not exist,
+SHALL produce indistinguishable responses.
+
+#### Scenario: An anonymous filer resumes on a new device
+
+- **GIVEN** an anonymous run two steps in, and its resume token
+- **WHEN** the token is presented from a session-less client
+- **THEN** the run resumes at the recorded step with the recorded answers
+
+#### Scenario: A mismatched token and an unknown run look identical
+
+- **GIVEN** a valid token for run A and an identifier for run B
+- **WHEN** they are presented together
+- **THEN** the response is identical to the response for a wholly unknown run
+
+### Requirement: Anonymous submission MUST be throttled and MUST stamp no ownership
+
+A journey declaring `access: anonymous` SHALL be startable and submittable with
+no session. Its writes SHALL NOT stamp subject or organisation ownership. Its
+endpoints SHALL be rate-limited.
+
+#### Scenario: An anonymous write carries no owner
+
+- **GIVEN** a completed anonymous journey
+- **WHEN** the written object is inspected
+- **THEN** it carries no subject or organisation ownership stamp
+
+#### Scenario: Excess anonymous submissions are refused
+
+- **GIVEN** an anonymous journey
+- **WHEN** submissions from one source exceed the configured rate
+- **THEN** further submissions are refused
+- **AND** the refusal is confirmed by two independent discriminators, because
+  an absent success is not by itself evidence that throttling fired
+
+### Requirement: Named formats MUST replace the app-local validator forks
+
+OpenRegister SHALL provide `email`, `website` and `nl-phone` named formats
+alongside the existing `bsn`, `iso8601-datetime` and `user` formats,
+referenceable by name from a form field. They SHALL enforce identically whether
+reached through the UI or directly through the API.
+
+#### Scenario: The API rejects what the UI rejects
+
+- **GIVEN** a value the client-side check rejects for `nl-phone`
+- **WHEN** the same value is submitted directly to the API
+- **THEN** it is rejected with the named-format error
+
+#### Scenario: A rejected value never reaches the target register
+
+- **GIVEN** a `writes[]` step whose input fails a named format
+- **WHEN** the step commits
+- **THEN** no object is written
+
+### Requirement: Expired runs MUST be purged, and the purge MUST report its work
+
+A `journeyRun` SHALL carry a retention period. A background job SHALL delete
+expired runs, including any staged uploads, and SHALL report the number
+deleted.
+
+#### Scenario: A purge run reports a count
+
+- **WHEN** the retention job executes
+- **THEN** it reports the number of runs deleted
+- **AND** a run that deletes nothing is distinguishable from a job that never
+  executed
+
+#### Scenario: A purge failure is not swallowed
+
+- **GIVEN** a deletion that fails
+- **WHEN** the job executes
+- **THEN** the failure is surfaced, not caught and discarded
+
+#### Scenario: Staged uploads do not outlive their run
+
+- **GIVEN** an expired run carrying an uploaded file
+- **WHEN** the job executes
+- **THEN** the file is deleted with the run

--- a/openspec/changes/or-form-and-journey-registry/tasks.md
+++ b/openspec/changes/or-form-and-journey-registry/tasks.md
@@ -1,0 +1,60 @@
+# Tasks: or-form-and-journey-registry
+
+> Schemas + run API + formats + retention job (ADR-032 `kind: mixed`).
+> Checkbox budget: 5 tasks × 2 = 10 unindented `- [ ]` lines (cap 20).
+
+## Implementation Tasks
+
+### Task 1: Declare the forms register
+- **spec_ref**: `openspec/changes/or-form-and-journey-registry/specs/form-and-journey-registry/spec.md#requirement-a-form-body-must-validate-through-the-canonical-manifest-validator`
+- **files**: `lib/Settings/forms_register.json`, `lib/Service/FormValidationService.php`, `tests/Unit/Service/FormValidationServiceTest.php`
+- **acceptance_criteria**:
+  - `form.config` is validated by the SAME `validateManifestV2()` entry point an app manifest uses — asserted by feeding one fixture through both paths and comparing the error objects, not by reading the code
+  - `journey` declares `steps[]` (`form`|`review`|`confirmation`), `next` rules `$ref`ing the canonical `$defs.visibleWhen`, per-step `writes[]`, and a REQUIRED `access`
+  - A `writes[]` mapping naming a property absent from the target schema is rejected at author time, naming the property and schema
+  - A journey with no `access` is rejected; access is never inferred
+- [ ] Implement
+- [ ] Test
+
+### Task 2: Journey run service — staged answers, committed writes
+- **spec_ref**: `openspec/changes/or-form-and-journey-registry/specs/form-and-journey-registry/spec.md#requirement-the-run-api-must-stage-answers-and-commit-only-at-declared-steps`
+- **files**: `lib/Service/JourneyRunService.php`, `tests/Unit/Service/JourneyRunServiceTest.php`
+- **acceptance_criteria**:
+  - Answers persist to the `journeyRun`; no target-register object exists until a step declaring `writes[]` commits — proven by querying the target register mid-run
+  - Writes execute in declared order; a later entry resolves a preceding entry's id
+  - A mid-`writes[]` failure records the failure AND the already-written id; re-submitting UPDATES that object rather than creating a second
+  - An answer for a field outside the current step is refused — the client does not select its own scope
+- [ ] Implement
+- [ ] Test
+
+### Task 3: Run controller — start, answer, resume, submit
+- **spec_ref**: `openspec/changes/or-form-and-journey-registry/specs/form-and-journey-registry/spec.md#requirement-a-run-must-be-resumable-without-becoming-an-oracle`
+- **files**: `lib/Controller/JourneyRunController.php`, `appinfo/routes.php`, `tests/Unit/Controller/JourneyRunControllerTest.php`
+- **acceptance_criteria**:
+  - Every route declares its auth posture explicitly (route-auth gate); the anonymous routes carry `#[PublicPage]` in the attribute form the throttling sweep actually counts
+  - Resume works by account (authenticated) and by unguessable single-purpose token (anonymous); a token/run mismatch and an unknown run return IDENTICAL responses — asserted by comparing the full response, not the status code alone
+  - Anonymous writes stamp NO subject or organisation ownership
+  - Anonymous endpoints are throttled, and the throttle is proven by two independent discriminators — an absent success is not evidence
+- [ ] Implement
+- [ ] Test
+
+### Task 4: Named formats replacing the app-local forks
+- **spec_ref**: `openspec/changes/or-form-and-journey-registry/specs/form-and-journey-registry/spec.md#requirement-named-formats-must-replace-the-app-local-validator-forks`
+- **files**: `lib/Formats/EmailFormat.php`, `lib/Formats/WebsiteFormat.php`, `lib/Formats/NlPhoneFormat.php`, `tests/Unit/Formats/*Test.php`
+- **acceptance_criteria**:
+  - Behaviour is pinned against the cases `tilburg-woo-ui/src/views/ac-forms/validation/form-validations.js` handles today, including its explicit rejections (`www.nl`, `http://.nl`, hyphen-only labels) and its `06`/`+31` phone handling
+  - The API rejects exactly what the UI rejects — asserted by submitting the same corpus through both paths
+  - A format-rejected value never reaches the target register
+- [ ] Implement
+- [ ] Test
+
+### Task 5: Retention job for journey runs
+- **spec_ref**: `openspec/changes/or-form-and-journey-registry/specs/form-and-journey-registry/spec.md#requirement-expired-runs-must-be-purged-and-the-purge-must-report-its-work`
+- **files**: `lib/BackgroundJob/JourneyRunRetentionJob.php`, `tests/Unit/BackgroundJob/JourneyRunRetentionJobTest.php`
+- **acceptance_criteria**:
+  - Deletes expired runs and their staged uploads; REPORTS the count deleted, so a zero-row run is distinguishable from a job that never executed
+  - A deletion failure is surfaced, NOT caught and discarded — the audit-purge failure mode was a `catch` that swallowed the throw while the job reported success
+  - First execution against seeded expired runs is verified by counting rows before and after, not by the job's own success return
+  - Registered as a background job, never on the install hook
+- [ ] Implement
+- [ ] Test


### PR DESCRIPTION
## What

Spec only. Adds a `forms` register with `form`, `journey` and `journeyRun`, the API that drives a run, named formats, and a retention job.

Programme context: [hydra#581](https://github.com/ConductionNL/hydra/pull/581) (ADR-085).

## Why

`tilburg-woo-ui` implements citizen and supplier intake as **~13,640 lines of hand-written React across seven wizards**, each re-implementing step state, per-index validation, progress display and submission. **None is resumable** — closing the tab loses everything.

The declarative half already exists, here and in nc-vue: manifest v2 carries `config.steps[]`, `visibleWhen` and a closed `fieldValidation`, and `CnFormPage` renders them. What is missing is the primitive that spans **more than one form**: multiple objects, branching between forms, lookup-and-prefill, a review step, and somewhere to keep a half-finished submission.

## Naming

**`journey`, not `flow`.** OpenRegister already owns `flow` for the automation engine — ADR-065, ~40 change specs, `FlowController`, flow runs, a visual canvas. A journey is a UI-facing sequence; it *may trigger* a flow, and it is not one.

## What the spec pins

- **A form's config is validated by the same `validateManifestV2()` path an app manifest is** — not a subset schema maintained alongside it. If the two can drift, they will. The test feeds one fixture through both paths and compares the error objects.
- **Branching reuses `$defs.visibleWhen` verbatim.** A second condition grammar is the single most likely way this design rots, so it is forbidden and gated.
- **Nothing is written until a step declares `writes[]`.** This preserves the property the React wizards have by accident — an abandoned registration leaves no half-built organisation — while adding the resumability they lack.
- **A resume token is a bearer credential for someone's half-filled form.** It must not act as an existence oracle: a token/run mismatch and an unknown run return identical responses.
- **Retention ships with the schema.** A `journeyRun` holds names, addresses, e-mail, phone numbers and uploads *before* any of it is a record. The purge **reports its row count**, because a job that deletes nothing must be distinguishable from one that never ran — this instance's audit retention purge had never executed while looking exactly like a purge with nothing to do.
- **Named formats** (`email`, `website`, `nl-phone`) replace the per-app validator forks, pinned against the cases tilburg's `form-validations.js` handles today *including its explicit rejections* (`www.nl`, `http://.nl`, hyphen-only labels, `06`/`+31` phone handling).

## Depends on / feeds

Rendered by `nextcloud-vue/journey-runtime` ([#665](https://github.com/ConductionNL/nextcloud-vue/pull/665)); authored by `openbuild/journey-designer` ([#207](https://github.com/ConductionNL/openbuild/pull/207)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
