### PR TITLE
fix(build): make local-lib opt-in and validate the sibling by semver

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -160,30 +160,45 @@ webpackConfig.resolve.extensions = [
 // present, so a local build can reproduce what CI and production build — they have
 // no sibling, so they always resolve the npm dist.
 const localLib = path.resolve(__dirname, '../nextcloud-vue/src')
+// ⚠️ USE_LOCAL_LIB is opt-IN (ADR-090). Building against a developer's working
+// checkout is the wrong default for a build that can ship.
 let useLocalLib =
 	fs.existsSync(localLib)
 	&& !process.env.OR_SKIP_LOCAL_NCVUE
-	&& process.env.USE_LOCAL_LIB !== 'false'
+	&& process.env.USE_LOCAL_LIB === 'true'
 
-// ⚠️ USE_LOCAL_LIB is opt-OUT, and the shared `apps-extra/nextcloud-vue`
-// checkout sits on the Vue 2 (`beta.*`) line. Silently compiling Vue 2 library
-// sources into this Vue 3 app produces a bundle that builds cleanly and renders
-// nothing, so refuse rather than trust the default: read the sibling checkout's
-// own package.json and abort when its major does not match ours.
+// The sibling checkout is validated against THIS app's own declared range.
+// The previous test was `/^2\./` on the comment's premise that "the Vue 3 line is
+// 2.x; the Vue 2 line is 1.0.0-beta.*". That premise expired: the Vue 2 line is
+// now 2.0.5 and the Vue 3 line is 2.2.0-vue3.16 — BOTH major 2 — so the test
+// matched the Vue 2 checkout and passed it straight through, which is precisely
+// what it existed to prevent. Compiling those sources into this Vue 3 app yields
+// a bundle that builds cleanly and renders nothing.
+//
+// Fail CLOSED: if the check cannot run, the sibling is refused. A guard that
+// degrades to "allow" is not a guard.
 if (useLocalLib) {
 	const siblingPkgPath = path.resolve(__dirname, '../nextcloud-vue/package.json')
-	let siblingVersion = null
+	let siblingVersion = 'unreadable'
+	let satisfied = false
 	try {
+		// eslint-disable-next-line n/no-extraneous-require
+		const semver = require('semver')
+		const required =
+			require('./package.json').dependencies['@conduction/nextcloud-vue']
 		siblingVersion = JSON.parse(fs.readFileSync(siblingPkgPath, 'utf8')).version
+		satisfied = semver.satisfies(siblingVersion, required, {
+			includePrerelease: true,
+		})
 	} catch (e) {
-		siblingVersion = null
+		satisfied = false
 	}
-	// The Vue 3 line is `2.x`; the Vue 2 line is `1.0.0-beta.*`.
-	if (siblingVersion === null || !/^2\./.test(siblingVersion)) {
+
+	if (!satisfied) {
 		// eslint-disable-next-line no-console
 		console.warn(
 			'[openregister/webpack] Ignoring the sibling @conduction/nextcloud-vue checkout: '
-				+ `version ${siblingVersion ?? 'unknown'} is not on the Vue 3 (2.x) line. `
+				+ `version ${siblingVersion} does not satisfy this app's declared range. `
 				+ 'Building against the installed npm package instead.',
 		)
 		useLocalLib = false

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -168,12 +168,17 @@ let useLocalLib =
 	&& process.env.USE_LOCAL_LIB === 'true'
 
 // The sibling checkout is validated against THIS app's own declared range.
-// The previous test was `/^2\./` on the comment's premise that "the Vue 3 line is
-// 2.x; the Vue 2 line is 1.0.0-beta.*". That premise expired: the Vue 2 line is
-// now 2.0.5 and the Vue 3 line is 2.2.0-vue3.16 — BOTH major 2 — so the test
-// matched the Vue 2 checkout and passed it straight through, which is precisely
-// what it existed to prevent. Compiling those sources into this Vue 3 app yields
-// a bundle that builds cleanly and renders nothing.
+// The previous test was `/^2\./`, on the comment's premise that a bad sibling
+// would be `1.0.0-beta.*`. The sibling today is 2.0.5 while this app declares
+// 2.2.0-vue3.16 — both match `/^2\./` — so the test waved through a version the
+// app never asked for.
+//
+// The failure that skew produces is not obvious from the version alone. Building
+// against the sibling also pulls packages out of the SIBLING's node_modules, and
+// a stale vue-demi shim there (its postinstall picks v2/v2.7/v3 and does not
+// re-run on `npm install`) yields errors of the form
+//   export 'default' (imported as 'Vue') was not found in 'vue'
+// — a Vue-2-shaped failure from a library that is itself Vue 3.
 //
 // Fail CLOSED: if the check cannot run, the sibling is refused. A guard that
 // degrades to "allow" is not a guard.


### PR DESCRIPTION
Two defects in the sibling-checkout guard, both silent.

## 1. Polarity

`USE_LOCAL_LIB` was **opt-OUT** (`!== 'false'`), so with the variable unset — its normal state — the build used `../nextcloud-vue` instead of the published package. Defaulting to a developer's working checkout is the wrong default for a build that can ship. Now opt-in. `OR_SKIP_LOCAL_NCVUE` is untouched.

Fleet context: this flag is opt-in in 3 apps and opt-out in 8 — the same name means opposite things depending on the repo.

## 2. The version test matched the thing it was written to exclude

The guard was `/^2\./`, on the premise stated in its own comment: *"The Vue 3 line is `2.x`; the Vue 2 line is `1.0.0-beta.*`"*. That premise expired.

| Line | Version today |
|---|---|
| Vue 2 | `2.0.5` |
| Vue 3 | `2.2.0-vue3.16` |

**Both are major 2**, so `/^2\./` matched the Vue 2 checkout and passed it straight through — precisely what it existed to prevent. The sibling is `2.0.5` right now, sitting on branch `fix/chat-tab-uses-a-chat-icon`.

Compiling those sources into this Vue 3 app yields a bundle that builds cleanly and renders nothing — the failure mode we spent a day chasing across eight apps.

## The fix

Validate the sibling against **this app's own declared range**, which needs no maintenance when the 3.x line ships. This is the pattern [openbuild already uses](https://github.com/ConductionNL/openbuild) and it is better than a hand-rolled version test.

Verified: sibling `2.0.5` vs declared `2.2.0-vue3.16` → **refused**.

**Fails closed.** An unrunnable check (semver unresolvable, package unreadable) refuses the sibling. openbuild's variant wraps this in a `try/catch` that "degrades gracefully", which silently leaves the sibling enabled — a guard that degrades to *allow* is not a guard.

Build with no environment set compiles clean (exit 0). See ADR-090 ([hydra#582](https://github.com/ConductionNL/hydra/pull/582)).
---

## Correction to this PR's original description

The earlier text said the sibling checkout is "the Vue 2 line" and that building against it "compiles Vue 2 library sources into a Vue 3 app". **That diagnosis was wrong**, and it is worth stating plainly because it was also written into the code comments.

Checked directly: `../nextcloud-vue@2.0.5` declares `peerDependencies.vue: ^3.5.0` and its source uses `defineComponent` / `createApp` / `<script setup>`. **It is a Vue 3 library.**

The real cause of the 13 build errors is a **stale `vue-demi` shim inside the sibling's own `node_modules`**. `vue-demi` selects `v2` / `v2.7` / `v3` in a postinstall hook that does not re-run on `npm install`; that checkout still has the **v2** shim in place (`vue-demi/lib/index.mjs` opens with `import Vue from 'vue'`, and Vue 3 has no default export). Building from the sibling's *source* also resolves packages out of the *sibling's* `node_modules`, so that shim comes along — producing a Vue-2-shaped error from a Vue 3 library.

**The fix in this PR is unaffected**, and that is the point of validating against the declared range rather than against a hand-rolled notion of which "line" the sibling is on: `2.0.5` does not satisfy `2.2.0-vue3.16`, so the sibling is refused regardless of *why* it would have broken. The code comments have been updated to describe the actual mechanism.