### PR TITLE
fix(entity): Conversation soft delete and restore were both no-ops

### DIFF
--- a/lib/Db/Conversation.php
+++ b/lib/Db/Conversation.php
@@ -168,7 +168,7 @@ class Conversation extends Entity implements JsonSerializable {
 	 * @return static Returns self for method chaining
 	 */
 	public function softDelete(): static {
-		$this->setDeletedAt(deletedAt: new DateTime());
+		$this->setDeletedAt(new DateTime());
 		return $this;
 	}//end softDelete()
 
@@ -178,7 +178,7 @@ class Conversation extends Entity implements JsonSerializable {
 	 * @return static Returns self for method chaining
 	 */
 	public function restore(): static {
-		$this->setDeletedAt(deletedAt: null);
+		$this->setDeletedAt(null);
 		return $this;
 	}//end restore()
 


### PR DESCRIPTION
Same bug as #2502, in the last two sites the audit could confirm.

`setDeletedAt` is `@method`-only, so both

```php
$this->setDeletedAt(deletedAt: new DateTime());   // softDelete()
$this->setDeletedAt(deletedAt: null);             // restore()
```

reach `Entity::__call` with an **associative** array, and `Entity::setter()`
reads `$args[0]`. Neither wrote anything.

`softDelete()` returned `$this` and left the conversation undeleted. `restore()`
was equally inert — so the two **agreed with each other**, and with any test
that checked only the return value.

## The audit, since you asked for per-receiver

Resolve each `->setX(x: ...)` call's receiver from its property or local
declaration, then ask whether that class **declares** `setX` or only `@method`s
it. A word-based sweep would have rewritten correct code: 151 classes in one leaf
app alone legitimately take the arguments involved.

| | |
|---|---|
| confirmed magic-setter no-ops after #2502 | **2** → now 0 |
| receivers the audit could not resolve statically | 106 |

The 106 are container `get()`s, factories and chained calls. They are listed for
a human pass rather than guessed at.

Two false positives worth naming, because both are the same mistake in different
clothes: `Uuid::v4()` and `Foo::class` both match a naive "named argument"
pattern (`\w+\s*:`), since `::` contains a colon. The audit needs `(?!:)`, and
without it reported 31 bugs where there were 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)