### PR TITLE
spec+impl: fail-closed RBAC default; file text in the fleet's NC search

### DIFF
--- a/docs/rbac-unmarked-schema-audit.md
+++ b/docs/rbac-unmarked-schema-audit.md
@@ -1,0 +1,661 @@
+# RBAC audit: schemas that declare no authorization
+
+Task 1 of `openspec/changes/rbac-default-authenticated`. Before the
+absent-authorization default can flip from public to authenticated, every
+unmarked schema needs a stated intent — **by name, not by count**, because a
+count cannot be reviewed and the review is the whole point.
+
+**Surveyed 2026-08-15.** Re-run this survey at review time rather than quoting
+it; the denominator moves as apps ship schemas, and a stale denominator makes
+an audit read as complete when it is not.
+
+## The numbers
+
+**504 of 571 declared schemas (88%) carry no authorization block**, across 15
+apps.
+
+| app | marked | UNMARKED |
+| --- | --- | --- |
+| scholiq | 0 | **118** |
+| shillinq | 0 | **114** |
+| procest | 6 | **85** |
+| openconnector | 0 | **39** |
+| decidesk | 5 | **34** |
+| hermiq | 1 | **28** |
+| pipelinq | 1 | **26** |
+| docudesk | 1 | **20** |
+| openregister | 15 | **16** |
+| larpingapp | 1 | **9** |
+| portaliq | 0 | **9** |
+| petstore | 0 | **3** |
+| doriath · launchpad · nextcloud-app-template | 0 | **3** |
+| openbuild | 6 | 0 |
+| opencatalogi | 10 | 0 |
+| softwarecatalog | 21 | 0 |
+| **total** | **67** | **504** |
+
+## Two ways an earlier version of this survey was WRONG
+
+Both are recorded because they are the ways the next re-run will go wrong too.
+
+**1. It read one register file per app.** The first pass globbed
+`lib/Settings/*register*.json | head -1` and reported **321 of 368 across 6
+apps**. openregister alone ships **14** register files; procest ships 2. The
+undercount hid 183 schemas and nine entire apps — including openconnector (39)
+and hermiq (28), which had appeared to have none. **Iterate every register
+file.**
+
+**2. It reads whichever branch each checkout is on.** These are shared
+checkouts and other workstreams move them. At survey time `portaliq` sat on
+`fix/local-lib-guard-semver`, which predates its CMS work — so `page`, `menu`,
+`glossaryTerm` and `portal` are absent from its nine rows below. **Record the
+branch each app was read from, or re-read from a known ref.**
+
+## How to read the proposed intent
+
+The intent column is a **first pass by keyword**, not a decision. It is
+deliberately biased toward refusal: anything naming a session, account, token,
+secret, audit record, salary, invoice, submission or person is proposed
+`restricted`, and only four schemas in 504 are proposed as public candidates at
+all.
+
+**Each app's maintainers decide their own rows.** This document collects and
+records; it does not decide on anyone's behalf. A row is settled when a
+maintainer has said so — an unreviewed `authenticated` here is a default, not
+an answer.
+
+Distribution of the first pass: **432 authenticated · 68 restricted · 4 public
+candidates** (`ContactDetail`, `PublicationRecord`, `contact`, `portalPage`).
+Note that `ContactDetail` and `contact` were flagged only because their names
+begin with "contact"; both plainly hold personal data and are the clearest
+example of why this column needs a human.
+
+## Before the default flips
+
+Every row marked public must carry an explicit `"group": "public"` read rule
+**first**. Flipping the default before that turns those surfaces blank — which
+is the safe direction, but it is an outage, and calling an outage a security
+fix is how the next one gets reverted.
+
+---
+
+## Unmarked schemas, by app
+
+### scholiq — 118 unmarked
+
+| schema | proposed intent |
+| --- | --- |
+| `AccessibilityFeedback` | authenticated |
+| `AccessibilityLimitation` | authenticated |
+| `AccessibilityStatement` | authenticated |
+| `AdmissionsRound` | authenticated |
+| `AiFeature` | authenticated |
+| `Application` | authenticated |
+| `Assessment` | authenticated |
+| `AssessmentReliability` | authenticated |
+| `AssessmentResult` | authenticated |
+| `Assignment` | authenticated |
+| `AttendanceFlag` | authenticated |
+| `AttendanceRecord` | authenticated |
+| `AttendanceThreshold` | authenticated |
+| `Attestation` | authenticated |
+| `BehaviourIncident` | authenticated |
+| `BpvPlacement` | authenticated |
+| `BpvVisitReport` | authenticated |
+| `BsaDecision` | authenticated |
+| `BsaProgressFlag` | authenticated |
+| `BsaTrajectory` | authenticated |
+| `BsaWarning` | authenticated |
+| `Cohort` | authenticated |
+| `Competency` | authenticated |
+| `CompetencyAttainment` | authenticated |
+| `CompetencyFramework` | authenticated |
+| `ConferenceReport` | authenticated |
+| `ConferenceRound` | authenticated |
+| `ConferenceSignup` | authenticated |
+| `ConferenceSlot` | authenticated |
+| `Course` | authenticated |
+| `CourseEvaluationResponse` | authenticated |
+| `CoursePackageImportReport` | authenticated |
+| `CourseQualityScore` | authenticated |
+| `CourseTemplate` | authenticated |
+| `Credential` | restricted |
+| `CurriculumPlan` | authenticated |
+| `DataExchangeJob` | authenticated |
+| `DataMappingProfile` | authenticated |
+| `DeliberationRecord` | authenticated |
+| `DossierNote` | authenticated |
+| `EngagementLevel` | authenticated |
+| `EngagementRiskFlag` | authenticated |
+| `EngagementRiskThreshold` | authenticated |
+| `EngagementScore` | authenticated |
+| `Enrolment` | authenticated |
+| `Entitlement` | authenticated |
+| `EvaluationCampaign` | authenticated |
+| `EvaluationInvitation` | authenticated |
+| `ExamAccommodation` | authenticated |
+| `ExchangeErrorCode` | authenticated |
+| `ExchangeRejection` | authenticated |
+| `ExcuseRequest` | restricted |
+| `ExemptionCase` | authenticated |
+| `ExternalAssessor` | authenticated |
+| `ExternalTrainingRecord` | authenticated |
+| `FeeItem` | authenticated |
+| `FinalGrade` | authenticated |
+| `FraudCase` | authenticated |
+| `GradeEntry` | authenticated |
+| `GradeNotification` | restricted |
+| `GradeScale` | authenticated |
+| `GroupPlan` | authenticated |
+| `GroupPlanEvaluation` | authenticated |
+| `GroupPlanSubgroup` | authenticated |
+| `ImprovementAction` | authenticated |
+| `Item` | authenticated |
+| `ItemBank` | authenticated |
+| `ItemRevisionFlag` | authenticated |
+| `ItemStatistics` | authenticated |
+| `Leaderboard` | authenticated |
+| `LearnerEngagement` | authenticated |
+| `LearnerProfile` | authenticated |
+| `LearningPlan` | authenticated |
+| `LearningPlanEvaluation` | authenticated |
+| `LearningPlanTemplate` | authenticated |
+| `LearningRecordExport` | authenticated |
+| `LearningRecordImport` | authenticated |
+| `LearningRecordShare` | authenticated |
+| `Lesson` | authenticated |
+| `LessonCompletion` | authenticated |
+| `LtiToolPlacement` | authenticated |
+| `Material` | authenticated |
+| `Order` | authenticated |
+| `OrderLine` | authenticated |
+| `PaymentTransaction` | restricted |
+| `PeerFeedbackSummary` | authenticated |
+| `PeerReview` | authenticated |
+| `PointAward` | authenticated |
+| `PointRule` | authenticated |
+| `PokSignature` | authenticated |
+| `Portfolio` | authenticated |
+| `PortfolioEntry` | authenticated |
+| `PortfolioShare` | authenticated |
+| `PortfolioTemplate` | authenticated |
+| `Praktijkopleider` | authenticated |
+| `Praktijkovereenkomst` | authenticated |
+| `ProctoringSession` | restricted |
+| `Programme` | authenticated |
+| `Regulation` | authenticated |
+| `ReportCard` | authenticated |
+| `ReportCardParentNotification` | restricted |
+| `ReportPeriod` | authenticated |
+| `RolloverPlan` | authenticated |
+| `Room` | authenticated |
+| `Rubric` | authenticated |
+| `SelfAssessment` | authenticated |
+| `Session` | restricted |
+| `Signature` | authenticated |
+| `SovereigntyPolicy` | authenticated |
+| `SubjectChoice` | authenticated |
+| `Submission` | restricted |
+| `SupportRequest` | authenticated |
+| `TeacherAvailability` | authenticated |
+| `TimetableConflict` | authenticated |
+| `TlvApplication` | authenticated |
+| `WellbeingCheckIn` | authenticated |
+| `WerkprocesAssessment` | authenticated |
+| `XapiStatement` | authenticated |
+
+### shillinq — 114 unmarked
+
+| schema | proposed intent |
+| --- | --- |
+| `APInvoice` | restricted |
+| `Account` | restricted |
+| `AllocationRule` | authenticated |
+| `AnalyticalDimension` | authenticated |
+| `AuditDocument` | restricted |
+| `BBVProgramma` | authenticated |
+| `BalanceSheet` | authenticated |
+| `BankAccount` | restricted |
+| `BankConnection` | authenticated |
+| `BankStatement` | authenticated |
+| `BankStatementLine` | authenticated |
+| `BankingRule` | authenticated |
+| `BbvAccountMapping` | restricted |
+| `BbvTaakveld` | authenticated |
+| `Begrotingswijziging` | authenticated |
+| `BeleidsIndicator` | authenticated |
+| `CashflowAPSchedule` | authenticated |
+| `CashflowARProjection` | authenticated |
+| `CashflowBufferPolicy` | authenticated |
+| `CashflowCalibrationReport` | authenticated |
+| `CashflowForecastHorizon` | authenticated |
+| `CashflowRecurring` | authenticated |
+| `CashflowScenario` | authenticated |
+| `CashflowWeek` | authenticated |
+| `ClosingAccount` | restricted |
+| `ClosingEntry` | authenticated |
+| `ClosingEntryTemplate` | authenticated |
+| `ComplianceAuditTrail` | restricted |
+| `ComplianceReport` | authenticated |
+| `ConsolidatedReport` | authenticated |
+| `ConsolidationGroup` | authenticated |
+| `CurrencyBalance` | authenticated |
+| `DepreciationSchedule` | authenticated |
+| `EconomischeCategorie` | authenticated |
+| `ExpenseClaimEntry` | authenticated |
+| `FiscalYear` | authenticated |
+| `FixedAsset` | authenticated |
+| `FxRate` | authenticated |
+| `GLLine` | authenticated |
+| `GLTransaction` | authenticated |
+| `GRDeelnemer` | authenticated |
+| `GRVerdeelsleutel` | authenticated |
+| `Grant` | authenticated |
+| `IPAssetValuation` | authenticated |
+| `IbAangifteExport` | authenticated |
+| `IcpStatement` | authenticated |
+| `InnovatieboxElection` | authenticated |
+| `InnovatieboxTariff` | authenticated |
+| `InventoryReorderRule` | authenticated |
+| `InventoryStockTransfer` | authenticated |
+| `Iv3Export` | authenticated |
+| `KorRegime` | authenticated |
+| `KorThreshold` | authenticated |
+| `Kostenpost` | authenticated |
+| `Location` | authenticated |
+| `ManagementLetter` | authenticated |
+| `MatchingRule` | authenticated |
+| `MaterieleVasteActiva` | authenticated |
+| `MeerjarenBudget` | authenticated |
+| `MileageEntry` | authenticated |
+| `MileageRate` | authenticated |
+| `Paragraaf` | authenticated |
+| `PerDiem` | authenticated |
+| `PerDiemRate` | authenticated |
+| `Programma` | authenticated |
+| `Project` | authenticated |
+| `ProjectAssignment` | authenticated |
+| `ProjectBudget` | authenticated |
+| `ProvincialeFondsPosting` | authenticated |
+| `RateCard` | authenticated |
+| `RateCardTemplate` | authenticated |
+| `RateCardVersion` | authenticated |
+| `RateRecord` | authenticated |
+| `RateSchedule` | authenticated |
+| `Receipt` | authenticated |
+| `ReconciliationMatch` | authenticated |
+| `RepaymentInstallment` | restricted |
+| `Reserve` | authenticated |
+| `RetainedEarnings` | authenticated |
+| `RetentionRule` | authenticated |
+| `SBRDocumentType` | authenticated |
+| `SalesOrder` | authenticated |
+| `SalesOrderLine` | authenticated |
+| `ServiceCategoryOverride` | authenticated |
+| `SisaRegelingIndicator` | authenticated |
+| `SisaReport` | authenticated |
+| `SoProject` | authenticated |
+| `SoUrenStaat` | authenticated |
+| `Subsidie` | authenticated |
+| `Taakveld` | authenticated |
+| `TaxEstimate` | authenticated |
+| `TaxRegimeConfiguration` | authenticated |
+| `TaxSummaryReport` | authenticated |
+| `TreasuryAccount` | restricted |
+| `TrialBalance` | authenticated |
+| `UrenRegistratie` | authenticated |
+| `VATAuditRecord` | restricted |
+| `VATGLAccounts` | restricted |
+| `VatCorrection` | authenticated |
+| `VatReturn` | authenticated |
+| `VatTariff` | authenticated |
+| `Voorziening` | authenticated |
+| `WBSOActivityCode` | authenticated |
+| `WBSOExportLog` | restricted |
+| `WBSOTag` | authenticated |
+| `WaterschapHeffingPosting` | authenticated |
+| `WinstToerekening` | authenticated |
+| `WipBalance` | authenticated |
+| `XBRLMapping` | authenticated |
+| `XBRLTaxonomy` | authenticated |
+| `ZzpDeduction` | authenticated |
+| `ZzpDeductionAmounts` | authenticated |
+| `example` | authenticated |
+| `kernGegevensConfig` | authenticated |
+
+### procest — 85 unmarked
+
+| schema | proposed intent |
+| --- | --- |
+| `abonnement` | authenticated |
+| `adviceRequest` | authenticated |
+| `adviceResponse` | authenticated |
+| `adviesAanvraag` | authenticated |
+| `advisoryBody` | authenticated |
+| `advisoryReport` | authenticated |
+| `aiAuditEntry` | restricted |
+| `appealDecision` | authenticated |
+| `automaticAction` | authenticated |
+| `bacAdviceRequest` | authenticated |
+| `beroep` | authenticated |
+| `bezwaar` | authenticated |
+| `bezwaarDecision` | authenticated |
+| `bezwaaradviescommissie` | authenticated |
+| `case` | authenticated |
+| `caseDocument` | authenticated |
+| `caseFederatedActivity` | authenticated |
+| `caseFederatedShare` | authenticated |
+| `caseObject` | authenticated |
+| `caseProperty` | authenticated |
+| `caseShare` | authenticated |
+| `caseType` | authenticated |
+| `casetransfer` | authenticated |
+| `catalogus` | restricted |
+| `checklistItem` | authenticated |
+| `complaint` | authenticated |
+| `complaintCategory` | authenticated |
+| `complaintDisposition` | authenticated |
+| `consultation` | authenticated |
+| `customerContact` | authenticated |
+| `decision` | authenticated |
+| `decisionDocument` | authenticated |
+| `decisionType` | authenticated |
+| `dispatch` | authenticated |
+| `document` | authenticated |
+| `documentLink` | authenticated |
+| `documentType` | authenticated |
+| `emailTemplate` | authenticated |
+| `handhavingsactie` | authenticated |
+| `hearing` | authenticated |
+| `hearingSession` | restricted |
+| `inspectieChecklist` | authenticated |
+| `inspectieRapport` | authenticated |
+| `inspectionChecklist` | authenticated |
+| `inspectionChecklistRun` | authenticated |
+| `inspectionChecklistTemplate` | authenticated |
+| `inspectionResult` | authenticated |
+| `kanaal` | authenticated |
+| `lhsMatrix` | authenticated |
+| `lhsMatrixCell` | authenticated |
+| `lhsRecommendation` | authenticated |
+| `location` | authenticated |
+| `mapLayer` | authenticated |
+| `objection` | authenticated |
+| `parafeeractie` | authenticated |
+| `parafeerroute` | authenticated |
+| `paraferingAuditEntry` | restricted |
+| `partnerOrganization` | authenticated |
+| `propertyDefinition` | authenticated |
+| `result` | authenticated |
+| `resultType` | authenticated |
+| `role` | authenticated |
+| `roleType` | authenticated |
+| `statusRecord` | authenticated |
+| `statusType` | authenticated |
+| `supplier` | authenticated |
+| `supplierContract` | authenticated |
+| `supplierInvoice` | restricted |
+| `supplierKpi` | authenticated |
+| `supplierMessage` | restricted |
+| `supplierTender` | authenticated |
+| `supplierUser` | restricted |
+| `task` | authenticated |
+| `tenant` | authenticated |
+| `tenantBillingEvent` | authenticated |
+| `tenantConfiguration` | authenticated |
+| `tenantMandate` | authenticated |
+| `tenantOnboardingTask` | authenticated |
+| `tenantQuota` | authenticated |
+| `tenantUser` | restricted |
+| `usageRights` | authenticated |
+| `voorstel` | authenticated |
+| `wmsLayer` | authenticated |
+| `workflowTemplate` | authenticated |
+| `zaaktypeInformatieobjecttype` | authenticated |
+
+### openconnector — 39 unmarked
+
+| schema | proposed intent |
+| --- | --- |
+| `bankfeed_batch` | authenticated |
+| `bankfeed_connection` | authenticated |
+| `call_log` | restricted |
+| `cardfeed_account` | restricted |
+| `cardfeed_batch` | authenticated |
+| `consumer` | authenticated |
+| `dso_message` | restricted |
+| `dso_verzoek` | authenticated |
+| `endpoint` | authenticated |
+| `event` | authenticated |
+| `event_message` | restricted |
+| `event_subscription` | authenticated |
+| `fsc_call` | authenticated |
+| `fsc_service` | authenticated |
+| `iwmo_ijw_message` | restricted |
+| `job` | authenticated |
+| `job_log` | restricted |
+| `kiss_klantcontact` | authenticated |
+| `lti_deployment` | authenticated |
+| `lti_identity_link` | authenticated |
+| `lti_platform` | authenticated |
+| `lti_tool` | authenticated |
+| `mapping` | authenticated |
+| `notificaties_abonnement` | authenticated |
+| `openformulieren_form_mapping` | authenticated |
+| `openformulieren_submission` | restricted |
+| `payment_intent` | restricted |
+| `peppol_transmission` | authenticated |
+| `ris_sync_record` | authenticated |
+| `rule` | authenticated |
+| `sms_message` | restricted |
+| `source` | authenticated |
+| `stuf_message` | restricted |
+| `sync_item_dead_letter` | authenticated |
+| `synchronization` | authenticated |
+| `synchronization_contract` | authenticated |
+| `synchronization_contract_log` | restricted |
+| `synchronization_log` | restricted |
+| `zgw_version_translation_log` | restricted |
+
+### decidesk — 34 unmarked
+
+| schema | proposed intent |
+| --- | --- |
+| `ActionItem` | authenticated |
+| `AgendaItem` | authenticated |
+| `BoardProxy` | authenticated |
+| `BudgetProposal` | authenticated |
+| `CitizenPanel` | authenticated |
+| `CitizenVote` | authenticated |
+| `ConflictOfInterest` | authenticated |
+| `ContactDetail` | **public?** — confirm |
+| `Decision` | authenticated |
+| `DecisionStage` | authenticated |
+| `Deliberation` | authenticated |
+| `DigitalDocument` | authenticated |
+| `EngagementRecord` | authenticated |
+| `EvaluationResponse` | authenticated |
+| `EvaluationTemplate` | authenticated |
+| `GovernanceBody` | authenticated |
+| `GovernanceReport` | authenticated |
+| `Meeting` | authenticated |
+| `Membership` | restricted |
+| `Minutes` | authenticated |
+| `MonetaryAmount` | authenticated |
+| `Notification` | restricted |
+| `NotificationPreference` | restricted |
+| `Offer` | authenticated |
+| `Order` | authenticated |
+| `Participant` | authenticated |
+| `Person` | restricted |
+| `Post` | authenticated |
+| `Product` | authenticated |
+| `PublicationRecord` | **public?** — confirm |
+| `Report` | authenticated |
+| `Transcript` | authenticated |
+| `Vote` | authenticated |
+| `VotingRound` | authenticated |
+
+### hermiq — 28 unmarked
+
+| schema | proposed intent |
+| --- | --- |
+| `AgentFlow` | authenticated |
+| `AgentFlowRun` | authenticated |
+| `AgentTemplate` | authenticated |
+| `AgentWebhook` | authenticated |
+| `AiFeature` | authenticated |
+| `Approval` | authenticated |
+| `Budget` | authenticated |
+| `Context` | authenticated |
+| `Control` | authenticated |
+| `ControlFramework` | authenticated |
+| `Conversation` | authenticated |
+| `CourseRecommendation` | authenticated |
+| `EvalDataset` | authenticated |
+| `EvalRun` | authenticated |
+| `Feedback` | authenticated |
+| `GuardrailPolicy` | authenticated |
+| `Incident` | authenticated |
+| `Memory` | authenticated |
+| `Message` | restricted |
+| `ModelPolicy` | authenticated |
+| `Schedule` | authenticated |
+| `Session` | restricted |
+| `SessionTurn` | restricted |
+| `Skill` | authenticated |
+| `SkillDraft` | authenticated |
+| `SkillSource` | authenticated |
+| `TenantControl` | authenticated |
+| `UserProfile` | restricted |
+
+### pipelinq — 26 unmarked
+
+| schema | proposed intent |
+| --- | --- |
+| `agentProfile` | authenticated |
+| `brpLookupVerzoek` | authenticated |
+| `brpPersoon` | authenticated |
+| `bsnAuditRecord` | restricted |
+| `bsnValidatie` | restricted |
+| `client` | authenticated |
+| `contact` | **public?** — confirm |
+| `leadProduct` | authenticated |
+| `optOutVlag` | authenticated |
+| `paymentProvider` | restricted |
+| `pipeline` | authenticated |
+| `posRefund` | authenticated |
+| `posRefundLine` | authenticated |
+| `posRole` | authenticated |
+| `posStaff` | authenticated |
+| `posTransaction` | authenticated |
+| `posTransactionLine` | authenticated |
+| `product` | authenticated |
+| `productCategory` | authenticated |
+| `queue` | authenticated |
+| `receiptPrintLog` | restricted |
+| `receiptTemplate` | authenticated |
+| `refundReason` | authenticated |
+| `relationship` | authenticated |
+| `skill` | authenticated |
+| `task` | authenticated |
+
+### docudesk — 20 unmarked
+
+| schema | proposed intent |
+| --- | --- |
+| `anonymizationLink` | authenticated |
+| `base` | authenticated |
+| `batchCorrespondenceJob` | authenticated |
+| `correspondence` | authenticated |
+| `customDictionary` | authenticated |
+| `customDictionaryTerm` | authenticated |
+| `dossier` | authenticated |
+| `financialExtraction` | authenticated |
+| `generatedDocument` | authenticated |
+| `glAccountBooking` | restricted |
+| `glAccountMappingRule` | restricted |
+| `huisstijl` | authenticated |
+| `prohibitionOverrideAudit` | restricted |
+| `publicationConsent` | restricted |
+| `signerRecord` | authenticated |
+| `signingAuditEntry` | restricted |
+| `signingRequest` | authenticated |
+| `signingSession` | restricted |
+| `template` | authenticated |
+| `templateVersion` | authenticated |
+
+### openregister — 16 unmarked
+
+| schema | proposed intent |
+| --- | --- |
+| `activiteit` | authenticated |
+| `brokeredcredential` | restricted |
+| `dataSubjectRequest` | authenticated |
+| `dsarPolicyPack` | authenticated |
+| `edepotTransfer` | authenticated |
+| `edepotTransferProof` | authenticated |
+| `locatie` | authenticated |
+| `mergeOperation` | authenticated |
+| `notification` | restricted |
+| `omgevingsdocument` | authenticated |
+| `schedule` | authenticated |
+| `trigger` | authenticated |
+| `trustConfiguration` | authenticated |
+| `vergunningaanvraag` | authenticated |
+| `webhook` | authenticated |
+| `workflow` | authenticated |
+
+### larpingapp — 9 unmarked
+
+| schema | proposed intent |
+| --- | --- |
+| `ability` | authenticated |
+| `character` | authenticated |
+| `condition` | authenticated |
+| `effect` | authenticated |
+| `event` | authenticated |
+| `item` | authenticated |
+| `player` | authenticated |
+| `setting` | authenticated |
+| `skill` | authenticated |
+
+### portaliq — 9 unmarked
+
+| schema | proposed intent |
+| --- | --- |
+| `exampleDocument` | authenticated |
+| `portalAccount` | restricted |
+| `portalAuditEntry` | restricted |
+| `portalMessage` | restricted |
+| `portalNotification` | restricted |
+| `portalOidcState` | restricted |
+| `portalPage` | **public?** — confirm |
+| `portalSession` | restricted |
+| `portalSubmission` | restricted |
+
+### petstore — 3 unmarked
+
+| schema | proposed intent |
+| --- | --- |
+| `category` | authenticated |
+| `order` | authenticated |
+| `pet` | authenticated |
+
+### doriath — 1 unmarked
+
+| schema | proposed intent |
+| --- | --- |
+| `example` | authenticated |
+
+### launchpad — 1 unmarked
+
+| schema | proposed intent |
+| --- | --- |
+| `Dashboard` | authenticated |
+
+### nextcloud-app-template — 1 unmarked
+
+| schema | proposed intent |
+| --- | --- |
+| `example` | authenticated |

--- a/lib/Search/ObjectsProvider.php
+++ b/lib/Search/ObjectsProvider.php
@@ -54,11 +54,17 @@ use Psr\Log\LoggerInterface;
  * RBAC scoping, tenant isolation, the published predicate, and row/field
  * level security are enforced inside the OR search pipeline, by always
  * delegating to ObjectService::searchObjectsPaginated(query, _rbac: true,
- * _multitenancy: true). The provider only narrows the result set further
- * (never widens it): it constrains the query to schemas flagged
- * `searchable = true`. Excerpts are derived exclusively from the rendered
- * object the user is allowed to read, so field-level redaction applies to
- * excerpt content for free. See
+ * _multitenancy: true). The provider narrows the result set by schema
+ * (`searchable = true`), and widens the MATCH — never the entitlement — with
+ * `_content_search: true`, which brings in objects whose attached-file chunk
+ * text matches. That fan-out receives the same `_rbac`/`_multitenancy` flags,
+ * so a chunk hit is filtered exactly like a metadata hit.
+ *
+ * Excerpts are derived exclusively from the rendered object the user is
+ * allowed to read, so field-level redaction applies to excerpt content for
+ * free. THIS IS LOAD-BEARING NOW THAT FILE TEXT IS IN SCOPE: an excerpt built
+ * from chunk text could surface a value the reader is redacted out of, while
+ * the object itself stayed correctly filtered. See
  * openspec/changes/unified-search-provider/specs/unified-search-provider/spec.md.
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -428,6 +434,26 @@ class ObjectsProvider implements IFilteringProvider {
 				'has_search' => empty($search) === false,
 			]
 		);
+
+		// Widen the match to text OpenRegister has already extracted from
+		// attached files (ZKN-CONTENT-001). Without this the provider searches
+		// object METADATA only, so a term that appears solely inside an
+		// attached PDF finds nothing — while OR holds that text indexed in
+		// `openregister_chunks` and `ChunkMapper::searchByKeyword()` can find
+		// it. That gap was measured 2026-08-15: this file contained zero chunk
+		// references.
+		//
+		// It is safe to turn on HERE, and only because the fan-out is not a
+		// second query path around the guard rails: `QueryHandler` forwards
+		// `_rbac` and `_multitenancy` into `augmentWithChunkMatches()`, so a
+		// chunk hit on an object the caller may not read is filtered by the
+		// same pipeline that filters a metadata hit. The provider still
+		// applies no second access filter of its own.
+		//
+		// A chunk is a fragment of a file; the row appended is the OWNING
+		// OBJECT, which is the thing with a deep-link URL, an icon and a
+		// title. A bare chunk would not be navigable.
+		$searchQuery['_content_search'] = true;
 
 		// Delegate to the OR search pipeline. RBAC, tenant isolation, the
 		// published predicate, and soft-delete exclusion are ALL enforced

--- a/openspec/changes/rbac-default-authenticated/proposal.md
+++ b/openspec/changes/rbac-default-authenticated/proposal.md
@@ -29,24 +29,38 @@ and `userQualifiesForGroup()` returns `true` unconditionally for the group
 `public`. So "nobody said anything" and "everybody may read this" are the same
 state, and they are reached by writing nothing at all.
 
-**Measured across the fleet on 2026-08-15 — 321 of 368 declared schemas (87%)
-carry no authorization block:**
+**Measured across the fleet on 2026-08-15 — 504 of 571 declared schemas (88%)
+carry no authorization block, across 15 apps:**
 
-| app | schemas | with authorization | none |
-| --- | --- | --- | --- |
-| scholiq | 118 | 0 | **118** |
-| shillinq | 114 | 0 | **114** |
-| decidesk | 39 | 5 | **34** |
-| pipelinq | 27 | 1 | **26** |
-| docudesk | 21 | 1 | **20** |
-| portaliq | 9 | 0 | **9** |
-| opencatalogi | 10 | 10 | 0 |
-| softwarecatalog | 21 | 21 | 0 |
-| procest | 6 | 6 | 0 |
-| openregister | 3 | 3 | 0 |
+| app | marked | UNMARKED |
+| --- | --- | --- |
+| scholiq | 0 | **118** |
+| shillinq | 0 | **114** |
+| procest | 6 | **85** |
+| openconnector | 0 | **39** |
+| decidesk | 5 | **34** |
+| hermiq | 1 | **28** |
+| pipelinq | 1 | **26** |
+| docudesk | 1 | **20** |
+| openregister | 15 | **16** |
+| larpingapp | 1 | **9** |
+| portaliq | 0 | **9** |
+| petstore | 0 | **3** |
+| doriath · launchpad · nextcloud-app-template | 0 | **3** |
+| openbuild · opencatalogi · softwarecatalog | 37 | 0 |
+| **total** | **67** | **504** |
 
-Four apps did the work. Six did not — not out of carelessness, but because
-omission has never had a consequence.
+Three apps did the work. Fifteen did not — not out of carelessness, but
+because omission has never had a consequence.
+
+> **An earlier draft of this proposal said 321 of 368, across six apps.** That
+> survey globbed `lib/Settings/*register*.json | head -1` and read ONE register
+> file per app; openregister alone ships 14 and procest ships 2. The undercount
+> hid 183 schemas and nine entire apps, including openconnector (39) and hermiq
+> (28), which had appeared to have none at all. Corrected here and in
+> `docs/rbac-unmarked-schema-audit.md`. The error made the case look smaller,
+> never safer — but it is exactly the shape of mistake this change exists to
+> stop being invisible.
 
 This is not currently an open door on every surface: the HTTP object API was
 measured refusing anonymous callers outright (`total=0` anonymous vs `total=8`
@@ -58,8 +72,10 @@ authorization block.
 
 **And that path is about to get much wider.** `portal-public-search` puts
 anonymous full-text search over OR objects. Under today's default it would
-make those 321 unmarked schemas searchable by anyone, and the first sign would
-be a citizen finding somebody's payslip.
+make those 504 unmarked schemas searchable by anyone, and the first sign would
+be a citizen finding somebody's payslip. The audit's own first pass proposes
+**68 of them as restricted** — sessions, accounts, tokens, audit records,
+invoices, submissions — on keyword evidence alone.
 
 ## Decision
 
@@ -78,7 +94,7 @@ authorization → the new authenticated default. Only the final rung changes.
 - [ ] `openregister` — the default in the RBAC handlers, and the tests that
       pin it.
 - [ ] Every app with unmarked schemas — **no code change**, but a behaviour
-      change to audit. The six apps above are the population.
+      change to audit. The 15 apps above are the population.
 
 ## Design notes
 
@@ -90,7 +106,7 @@ is the entire argument.
 **It cannot be shipped silently.** An app whose public surface depends on an
 unmarked schema will go blank, and the operator needs to know why. The change
 logs, once per schema, the fact that it refused on the default — so the audit
-is a log grep rather than a survey of 368 schemas.
+is a log grep rather than a survey of 571 schemas.
 
 **A migration flag is deliberately NOT offered.** An `or.rbac.legacy_open=true`
 escape hatch would be set once, during an upgrade, by an operator who wanted
@@ -99,7 +115,7 @@ practice and the fleet would keep the fail-open semantics with extra steps.
 
 ## Risks
 
-- **Six apps have unmarked schemas and some serve public content from them.**
+- **Fifteen apps have unmarked schemas and some serve public content from them.**
   Auditing them is part of this change, not a follow-up. A count is not an
   audit: each app has to say which schemas it *intends* to be public.
 - **Anything reading OR anonymously in-process will change behaviour.** That

--- a/openspec/changes/rbac-default-authenticated/proposal.md
+++ b/openspec/changes/rbac-default-authenticated/proposal.md
@@ -1,0 +1,110 @@
+---
+kind: code
+---
+
+# Proposal: rbac-default-authenticated
+
+## Summary
+
+A schema that declares no authorization is currently readable by ANYONE,
+including an anonymous caller. Make the absent-authorization default
+**authenticated-only**. `public` becomes something an author must assign
+deliberately, and can never be arrived at by omission.
+
+## Motivation
+
+The default is fail-OPEN, and it is the wrong way round.
+
+`PropertyRbacHandler` reads, in as many words:
+
+```php
+// If no authorization is defined for this property, it follows object-level rules.
+if ($authorization === null || empty($authorization) === true) {
+    return true;
+}
+// If action is not configured, property is accessible.
+```
+
+and `userQualifiesForGroup()` returns `true` unconditionally for the group
+`public`. So "nobody said anything" and "everybody may read this" are the same
+state, and they are reached by writing nothing at all.
+
+**Measured across the fleet on 2026-08-15 — 321 of 368 declared schemas (87%)
+carry no authorization block:**
+
+| app | schemas | with authorization | none |
+| --- | --- | --- | --- |
+| scholiq | 118 | 0 | **118** |
+| shillinq | 114 | 0 | **114** |
+| decidesk | 39 | 5 | **34** |
+| pipelinq | 27 | 1 | **26** |
+| docudesk | 21 | 1 | **20** |
+| portaliq | 9 | 0 | **9** |
+| opencatalogi | 10 | 10 | 0 |
+| softwarecatalog | 21 | 21 | 0 |
+| procest | 6 | 6 | 0 |
+| openregister | 3 | 3 | 0 |
+
+Four apps did the work. Six did not — not out of carelessness, but because
+omission has never had a consequence.
+
+This is not currently an open door on every surface: the HTTP object API was
+measured refusing anonymous callers outright (`total=0` anonymous vs `total=8`
+admin on the same query, with `_rbac=false&_multitenancy=false` making no
+difference). The exposure is on the **in-process** path — a leaf app calling
+`ObjectService` inside a `#[PublicPage]` controller. Measured on portaliq's own
+content API: **6 pages returned to an anonymous caller** from a schema with no
+authorization block.
+
+**And that path is about to get much wider.** `portal-public-search` puts
+anonymous full-text search over OR objects. Under today's default it would
+make those 321 unmarked schemas searchable by anyone, and the first sign would
+be a citizen finding somebody's payslip.
+
+## Decision
+
+Absent authorization means **`authenticated`**, not "anyone".
+
+- No authorization block on a schema, and none on its register → read requires
+  a logged-in user.
+- `public` is granted only where an author wrote `"group": "public"`.
+- Everything already explicit keeps its exact current behaviour.
+
+The register-level fallback stays: schema authorization → register
+authorization → the new authenticated default. Only the final rung changes.
+
+## Affected Projects
+
+- [ ] `openregister` — the default in the RBAC handlers, and the tests that
+      pin it.
+- [ ] Every app with unmarked schemas — **no code change**, but a behaviour
+      change to audit. The six apps above are the population.
+
+## Design notes
+
+**This is a breaking change to a fleet contract, and it should be.** The
+direction is safe — content becomes less visible, never more — so the failure
+mode is a 404 someone reports, not a disclosure nobody notices. That asymmetry
+is the entire argument.
+
+**It cannot be shipped silently.** An app whose public surface depends on an
+unmarked schema will go blank, and the operator needs to know why. The change
+logs, once per schema, the fact that it refused on the default — so the audit
+is a log grep rather than a survey of 368 schemas.
+
+**A migration flag is deliberately NOT offered.** An `or.rbac.legacy_open=true`
+escape hatch would be set once, during an upgrade, by an operator who wanted
+their site back — and never unset. The flag would become the default in
+practice and the fleet would keep the fail-open semantics with extra steps.
+
+## Risks
+
+- **Six apps have unmarked schemas and some serve public content from them.**
+  Auditing them is part of this change, not a follow-up. A count is not an
+  audit: each app has to say which schemas it *intends* to be public.
+- **Anything reading OR anonymously in-process will change behaviour.** That
+  is the point, and it is why the audit precedes the flip.
+- **A permission default is exactly the kind of change that looks fine in
+  tests and breaks a tenant.** The tests must include an app-shaped case: a
+  `#[PublicPage]` controller reading an unmarked schema, which must go from
+  rows to none.

--- a/openspec/changes/rbac-default-authenticated/specs/rbac-default-authenticated/spec.md
+++ b/openspec/changes/rbac-default-authenticated/specs/rbac-default-authenticated/spec.md
@@ -80,7 +80,7 @@ whether it is intended to be public. The audit SHALL be recorded in the repo.
 
 #### Scenario: Every unmarked schema has a stated intent
 
-- **GIVEN** the 321 schemas measured on 2026-08-15 across six apps
+- **GIVEN** the 504 unmarked schemas measured on 2026-08-15 across 15 apps
 - **THEN** each is recorded as intended-public, intended-authenticated, or
   intended-restricted, with the intended-public ones given an explicit
   `public` rule BEFORE the default changes

--- a/openspec/changes/rbac-default-authenticated/specs/rbac-default-authenticated/spec.md
+++ b/openspec/changes/rbac-default-authenticated/specs/rbac-default-authenticated/spec.md
@@ -1,0 +1,88 @@
+# rbac-default-authenticated Delta: rbac-default-authenticated
+
+**Status**: proposed
+**Scope**: openregister
+
+## Purpose
+
+Absent authorization means AUTHENTICATED, never public. `public` becomes a
+deliberate assignment that cannot be reached by omission. Implements the
+fail-closed posture of ADR-005 for the one place it was inverted.
+
+## MODIFIED Requirements
+
+### Requirement: An unmarked schema MUST require an authenticated caller
+
+When neither a schema nor its register declares authorization for an action,
+access SHALL require a logged-in user. It SHALL NOT be granted to an anonymous
+caller. The resolution order — schema, then register, then default — is
+unchanged; only the default changes.
+
+#### Scenario: An anonymous caller reads nothing from an unmarked schema
+
+- **GIVEN** a schema with no authorization block, and a register with none
+- **WHEN** an anonymous caller reads it in-process with `_rbac: true`
+- **THEN** no rows are returned
+- **AND** an AUTHENTICATED caller reading the same schema DOES get rows — both
+  in one test, because a change that returned nothing to everybody would
+  satisfy the first half and quietly break the fleet
+
+#### Scenario: The default applies through a PublicPage controller
+
+- **GIVEN** a leaf app's `#[PublicPage]` controller reading an unmarked schema
+  through `ObjectService`
+- **THEN** an anonymous request returns no rows
+- **NOTE** this is the shape that is actually exposed today. The HTTP object
+  API already refuses anonymous callers (measured: `total=0` anonymous vs
+  `total=8` admin), so a test that only drives HTTP would pass BEFORE the
+  change and prove nothing.
+
+#### Scenario: Explicit authorization is untouched
+
+- **GIVEN** a schema declaring any authorization rule
+- **THEN** its behaviour is byte-identical to before this change
+- **AND** this is asserted for a `public` rule, an `authenticated` rule and a
+  named-group rule — the three shapes in fleet use
+
+#### Scenario: The register-level fallback still resolves before the default
+
+- **GIVEN** a schema with no authorization whose REGISTER declares one
+- **THEN** the register's rule decides, and the new default is not reached
+
+### Requirement: A refusal on the default MUST be observable
+
+When access is refused because no authorization was declared — as distinct
+from a declared rule denying it — OpenRegister SHALL record that fact once per
+schema, naming the schema.
+
+#### Scenario: The operator can find what the default refused
+
+- **GIVEN** an app whose public surface depended on an unmarked schema
+- **WHEN** it goes empty after this change
+- **THEN** the log names the schema and says the refusal came from the absent
+  authorization default
+- **AND** the entry is emitted once per schema, not once per row — an
+  unthrottled line here turns a busy list endpoint into a log flood, and the
+  flood is what gets logging disabled
+
+#### Scenario: A declared denial is not reported as a default refusal
+
+- **GIVEN** a schema whose rule denies this caller
+- **THEN** nothing is logged as a default refusal — conflating the two would
+  make the audit useless in exactly the situation it exists for
+
+## ADDED Requirements
+
+### Requirement: The fleet's unmarked schemas MUST be audited before the default flips
+
+Each app carrying schemas with no authorization SHALL state, per schema,
+whether it is intended to be public. The audit SHALL be recorded in the repo.
+
+#### Scenario: Every unmarked schema has a stated intent
+
+- **GIVEN** the 321 schemas measured on 2026-08-15 across six apps
+- **THEN** each is recorded as intended-public, intended-authenticated, or
+  intended-restricted, with the intended-public ones given an explicit
+  `public` rule BEFORE the default changes
+- **AND** the record is a list of schema names, not a count — a count cannot
+  be reviewed, and the review is the point

--- a/openspec/changes/rbac-default-authenticated/tasks.md
+++ b/openspec/changes/rbac-default-authenticated/tasks.md
@@ -6,7 +6,7 @@
 >
 > ORDER IS LOAD-BEARING. Task 1 audits, Task 2 marks the intended-public
 > schemas, and only then does Task 3 flip the default. Flipping first turns
-> six apps' public surfaces blank and calls it a security fix.
+> fifteen apps' public surfaces blank and calls it a security fix.
 
 ## Implementation Tasks
 
@@ -14,7 +14,7 @@
 - **spec_ref**: `openspec/changes/rbac-default-authenticated/specs/rbac-default-authenticated/spec.md#requirement-the-fleets-unmarked-schemas-must-be-audited-before-the-default-flips`
 - **files**: `docs/rbac-unmarked-schema-audit.md`
 - **acceptance_criteria**:
-  - Every schema with no authorization is LISTED BY NAME with an intent: public, authenticated, or restricted. 321 of them at the 2026-08-15 measurement, across scholiq (118), shillinq (114), decidesk (34), pipelinq (26), docudesk (20), portaliq (9)
+  - Every schema with no authorization is LISTED BY NAME with an intent: public, authenticated, or restricted. 504 of them at the 2026-08-15 measurement across 15 apps — scholiq 118, shillinq 114, procest 85, openconnector 39, decidesk 34, hermiq 28, pipelinq 26, docudesk 20, openregister 16, larpingapp 9, portaliq 9, and four more
   - The survey is re-run at review time rather than quoted — the number moves as apps ship schemas, and a stale denominator makes the audit read as complete when it is not
   - Each app's own maintainers state the intent for their schemas; this task collects and records, it does not decide on their behalf
 - [ ] Implement

--- a/openspec/changes/rbac-default-authenticated/tasks.md
+++ b/openspec/changes/rbac-default-authenticated/tasks.md
@@ -1,0 +1,52 @@
+# Tasks: rbac-default-authenticated
+
+> Flip the absent-authorization default from public to authenticated
+> (ADR-032 `kind: code`). Checkbox budget: 4 tasks × 2 = 8 unindented
+> `- [ ]` lines (cap 20).
+>
+> ORDER IS LOAD-BEARING. Task 1 audits, Task 2 marks the intended-public
+> schemas, and only then does Task 3 flip the default. Flipping first turns
+> six apps' public surfaces blank and calls it a security fix.
+
+## Implementation Tasks
+
+### Task 1: Audit every unmarked schema, by name
+- **spec_ref**: `openspec/changes/rbac-default-authenticated/specs/rbac-default-authenticated/spec.md#requirement-the-fleets-unmarked-schemas-must-be-audited-before-the-default-flips`
+- **files**: `docs/rbac-unmarked-schema-audit.md`
+- **acceptance_criteria**:
+  - Every schema with no authorization is LISTED BY NAME with an intent: public, authenticated, or restricted. 321 of them at the 2026-08-15 measurement, across scholiq (118), shillinq (114), decidesk (34), pipelinq (26), docudesk (20), portaliq (9)
+  - The survey is re-run at review time rather than quoted — the number moves as apps ship schemas, and a stale denominator makes the audit read as complete when it is not
+  - Each app's own maintainers state the intent for their schemas; this task collects and records, it does not decide on their behalf
+- [ ] Implement
+- [ ] Test
+
+### Task 2: Give the intended-public schemas an explicit rule
+- **spec_ref**: `openspec/changes/rbac-default-authenticated/specs/rbac-default-authenticated/spec.md#requirement-an-unmarked-schema-must-require-an-authenticated-caller`
+- **files**: per-app `lib/Settings/*_register.json`, per-app register tests
+- **acceptance_criteria**:
+  - Every schema the audit marked intended-public carries an explicit `read` rule for group `public`, merged BEFORE the default flips
+  - Each app asserts its public set per schema by NAME — a count passes while the wrong schemas are marked, and the wrong ones here are somebody's payslips
+  - No schema gains an anonymous WRITE rule as a side effect; read-only is asserted
+- [ ] Implement
+- [ ] Test
+
+### Task 3: Flip the default to authenticated
+- **spec_ref**: `openspec/changes/rbac-default-authenticated/specs/rbac-default-authenticated/spec.md#requirement-an-unmarked-schema-must-require-an-authenticated-caller`
+- **files**: `lib/Service/PropertyRbacHandler.php`, plus the object-level RBAC path, `tests/Unit/Service/PropertyRbacHandlerTest.php`
+- **acceptance_criteria**:
+  - Absent authorization resolves to authenticated; the schema → register → default order is otherwise unchanged, with a test pinning that a register rule still wins over the default
+  - The anonymous/authenticated PAIR is asserted on one unmarked schema: anonymous gets nothing, authenticated gets rows. A change that returned nothing to everybody passes the first assertion alone
+  - An app-shaped test drives a `#[PublicPage]` controller reading an unmarked schema through `ObjectService` — the HTTP object API already refuses anonymous callers, so an HTTP-only test passes before the change and proves nothing
+  - The three explicit shapes — `public`, `authenticated`, named group — are asserted byte-identical to before
+- [ ] Implement
+- [ ] Test
+
+### Task 4: Make a default refusal observable, once per schema
+- **spec_ref**: `openspec/changes/rbac-default-authenticated/specs/rbac-default-authenticated/spec.md#requirement-a-refusal-on-the-default-must-be-observable`
+- **files**: `lib/Service/PropertyRbacHandler.php`, `tests/Unit/Service/PropertyRbacHandlerTest.php`
+- **acceptance_criteria**:
+  - A refusal that came from the ABSENT default logs the schema name and says so; a refusal from a declared rule does not — conflating them makes the audit useless exactly when it is needed
+  - Emitted once per schema per request, not once per row: an unthrottled line on a list endpoint is a log flood, and a flood is what gets logging switched off
+  - The message names the remedy (declare authorization, or add the `public` group) so the operator does not have to find this spec to act on it
+- [ ] Implement
+- [ ] Test

--- a/openspec/changes/unified-search-file-content/proposal.md
+++ b/openspec/changes/unified-search-file-content/proposal.md
@@ -1,0 +1,98 @@
+---
+kind: code
+---
+
+# Proposal: unified-search-file-content
+
+## Summary
+
+OpenRegister extracts text from attached files and stores it in chunks, and
+its Nextcloud unified-search provider does not look at it. Pass
+`_content_search: true` so a term that appears only inside an attached PDF
+finds the object that owns it.
+
+## Motivation
+
+Both halves already exist and are not connected.
+
+**The text is there.** `TextExtractionService` writes to
+`oc_openregister_chunks`: `sourceType`, `sourceId`, `textContent`, an
+embedding, `owner`, `organisation`, `checksum`. `ChunkMapper::searchByKeyword()`
+searches it, and `FileSearchController` exposes semantic and hybrid arms at
+`/api/search/files/*`.
+
+**The provider does not use it.** `lib/Search/ObjectsProvider.php` — the
+single fleet-wide provider — contains **zero** references to chunks. Measured
+2026-08-15.
+
+So a user searching Nextcloud for a term that appears only inside an attached
+document finds nothing, while OpenRegister holds that text indexed and
+searchable. The file itself may surface through the Files provider if the user
+can see it in their own tree, but the OBJECT it documents — the case, the
+publication, the invoice — does not.
+
+## Decision
+
+`ObjectsProvider::search()` passes `_content_search: true` to
+`searchObjectsPaginated()`.
+
+That is the change. `ObjectService` already merges chunk hits into the object
+result set through the same RBAC and multitenancy pipeline, so a file hit is
+returned as the OBJECT that owns the file — which is the thing with a
+deep-link URL, an icon and a title. A naked chunk is not navigable and is not
+what a searcher wants.
+
+## Why not a separate file provider
+
+OR's own provider docblock says it: *"This class is the single, fleet-wide
+Nextcloud unified-search provider… Leaf apps do NOT register their own
+`OCP\Search\IProvider`."* A second provider would mean two result lists over
+the same objects, two RBAC paths, and two places for a disclosure bug. The
+existing provider already states its security contract — it performs **no**
+second access filter and delegates everything to
+`searchObjectsPaginated(_rbac: true, _multitenancy: true)`. Widening its query
+keeps that contract intact; adding a provider would fork it.
+
+## Scope note: this is authenticated search, and cannot be otherwise
+
+Nextcloud unified search cannot serve anonymous callers. Measured three ways
+on 2026-08-15:
+
+- `OCP\Search\IProvider::search(IUser $user, ISearchQuery $query)` — the
+  `IUser` is non-nullable; the interface has no way to express "no user"
+- `UnifiedSearchController` carries no `#[PublicPage]` on any method
+- Live probe: anonymous **401**, authenticated **200**
+
+So this change serves logged-in users only. Anonymous portal search is a
+different mechanism entirely and lives in
+`portaliq/openspec/changes/portal-public-search`.
+
+## Affected Projects
+
+- [ ] `openregister` — one flag on the provider's query, plus tests and a
+      performance guard.
+
+## Design notes
+
+**Excerpts must keep coming from the rendered object.** The provider derives
+excerpts from the object the user is allowed to read, which is what makes
+field-level redaction apply to excerpts for free. A chunk hit must not
+short-circuit that and put raw extracted text in a result line — the text in a
+file can include fields the reader is redacted out of.
+
+**Content search is more expensive than metadata search.** It adds a keyword
+pass over chunk bodies. The provider runs on every keystroke-ish search in the
+Nextcloud UI, so the cost is measured before and after, and the change carries
+a limit rather than an unbounded candidate set.
+
+## Risks
+
+- **A chunk carries text from a whole file; an object's fields may be
+  redacted.** If an excerpt ever came from chunk text, redaction would be
+  bypassed in the excerpt while the object itself stayed correctly filtered.
+  The excerpt source is asserted, not assumed.
+- **Latency in the global search bar is felt immediately by every user.** A
+  slow provider is experienced as a slow Nextcloud.
+- **`_content_search` is opt-in today and its default is false.** Turning it on
+  in the provider makes it the fleet's first always-on consumer, so any
+  weakness in that path stops being theoretical.

--- a/openspec/changes/unified-search-file-content/specs/unified-search-file-content/spec.md
+++ b/openspec/changes/unified-search-file-content/specs/unified-search-file-content/spec.md
@@ -1,0 +1,84 @@
+# unified-search-file-content Delta: unified-search-file-content
+
+**Status**: proposed
+**Scope**: openregister
+
+## Purpose
+
+Text OpenRegister extracts from attached files becomes findable through the
+fleet's Nextcloud unified-search provider, attributed to the object that owns
+the file, under the provider's existing security contract.
+
+## MODIFIED Requirements
+
+### Requirement: The unified-search provider MUST search extracted file text
+
+`ObjectsProvider` SHALL pass `_content_search: true` to
+`searchObjectsPaginated()`, so a `_search` term matches text extracted from
+attached files as well as object fields. Results SHALL be the owning OBJECT,
+never a bare chunk.
+
+#### Scenario: A term found only inside an attached file returns its object
+
+- **GIVEN** an object whose own fields do not contain a term, with an attached
+  file whose extracted text does
+- **WHEN** an entitled user searches Nextcloud for that term
+- **THEN** the owning object is returned, with its deep-link URL, title and
+  icon
+- **AND** the same search BEFORE this change returns nothing — asserted, so the
+  test measures the change rather than the fixture
+
+#### Scenario: Object-field matches are unaffected
+
+- **GIVEN** the searches that worked before this change
+- **THEN** they return the same objects, in the same order
+- **NOTE** content search widens a result set. A change that reorders or drops
+  existing hits is a regression in the fleet's main search bar, and would be
+  noticed as "search got worse" rather than as this change
+
+#### Scenario: A user gets no file-text hit from an object they may not read
+
+- **GIVEN** an attached file on an object outside the user's RBAC or tenant
+  scope
+- **THEN** its text produces no result
+- **AND** an entitled user searching the same term DOES get it — both in one
+  test, because a content search that matched nothing at all would satisfy the
+  refusal by itself
+
+### Requirement: Excerpts MUST continue to derive from the rendered object
+
+An excerpt SHALL be derived from the object as rendered for that user, not
+from chunk text. Field-level redaction SHALL therefore apply to excerpts
+unchanged.
+
+#### Scenario: A redacted field does not appear in an excerpt via file text
+
+- **GIVEN** a user redacted out of a field, and an attached file whose
+  extracted text contains that field's value
+- **WHEN** the object is returned as a content-search hit
+- **THEN** the excerpt does not contain the redacted value
+- **NOTE** this is the one way this change could turn a widened search into a
+  disclosure: the object stays correctly filtered while the excerpt leaks
+
+## ADDED Requirements
+
+### Requirement: Content search MUST be bounded and measured
+
+The provider SHALL bound the chunk-candidate set and SHALL NOT issue an
+unbounded keyword pass. The latency cost SHALL be measured before and after.
+
+#### Scenario: The candidate set is capped
+
+- **GIVEN** a term matching a very large number of chunks
+- **THEN** the provider returns within its declared bound rather than scanning
+  the corpus
+
+#### Scenario: The cost is recorded, not assumed
+
+- **GIVEN** a representative corpus
+- **WHEN** the same query set runs with and without `_content_search`
+- **THEN** both latencies are recorded in the change
+- **AND** the comparison is like-for-like — same corpus, same warm/cold state,
+  same query set. A single run against a warm cache is not a measurement, and
+  this provider runs in the global search bar where regressions are felt by
+  every user at once

--- a/openspec/changes/unified-search-file-content/tasks.md
+++ b/openspec/changes/unified-search-file-content/tasks.md
@@ -1,0 +1,38 @@
+# Tasks: unified-search-file-content
+
+> Widen the fleet-wide NC search provider to extracted file text
+> (ADR-032 `kind: code`). Checkbox budget: 3 tasks × 2 = 6 unindented
+> `- [ ]` lines (cap 20).
+
+## Implementation Tasks
+
+### Task 1: Pass `_content_search` from the provider
+- **spec_ref**: `openspec/changes/unified-search-file-content/specs/unified-search-file-content/spec.md#requirement-the-unified-search-provider-must-search-extracted-file-text`
+- **files**: `lib/Search/ObjectsProvider.php`, `tests/Unit/Search/ObjectsProviderTest.php`
+- **acceptance_criteria**:
+  - `searchObjectsPaginated()` is called with `_content_search: true`, alongside the existing `_rbac: true` / `_multitenancy: true` — the provider still performs NO second access filter, per its stated contract
+  - A fixture carries a term present ONLY in an attached file's extracted text; the test asserts the search finds nothing WITHOUT the flag and the owning object WITH it, so it measures the change and not the fixture
+  - Results are the owning object with URL, title and icon — never a bare chunk, which has nothing to navigate to
+  - Pre-existing object-field searches return the same objects in the same order; the fleet's main search bar must not silently reorder
+- [ ] Implement
+- [ ] Test
+
+### Task 2: Prove file text cannot route around RBAC or redaction
+- **spec_ref**: `openspec/changes/unified-search-file-content/specs/unified-search-file-content/spec.md#requirement-excerpts-must-continue-to-derive-from-the-rendered-object`
+- **files**: `lib/Search/ObjectsProvider.php`, `tests/Unit/Search/ObjectsProviderTest.php`
+- **acceptance_criteria**:
+  - A file attached to an object outside the caller's RBAC/tenant scope yields no hit, PAIRED with an entitled caller who does get it — a content search matching nothing would pass the refusal alone
+  - The excerpt for a content-search hit is derived from the rendered object, asserted by giving a redacted field a distinctive value that also appears in the file text and checking it is absent from the excerpt
+  - This is the change's one plausible disclosure route: the object stays filtered while the excerpt leaks. It is tested directly rather than reasoned about
+- [ ] Implement
+- [ ] Test
+
+### Task 3: Bound it, and measure what it costs
+- **spec_ref**: `openspec/changes/unified-search-file-content/specs/unified-search-file-content/spec.md#requirement-content-search-must-be-bounded-and-measured`
+- **files**: `lib/Search/ObjectsProvider.php`, `lib/Service/Object/ContentSearchHandler.php`, the change's own notes
+- **acceptance_criteria**:
+  - The chunk-candidate set is capped; a term matching a very large number of chunks returns within the bound instead of scanning the corpus
+  - Latency recorded BEFORE and AFTER on the same corpus, same query set, same warm/cold state — a single warm run is not a measurement
+  - The numbers are written into the change. This provider runs in the global search bar, so a regression is felt by every user at once and "it seemed fine" is not evidence
+- [ ] Implement
+- [ ] Test

--- a/tests/Unit/Search/ObjectsProviderTest.php
+++ b/tests/Unit/Search/ObjectsProviderTest.php
@@ -639,4 +639,98 @@ class ObjectsProviderTest extends TestCase {
 		$result = $this->provider->search($user, $query);
 		$this->assertSame('uuid-fallback', $result->jsonSerialize()['entries'][0]->jsonSerialize()['title']);
 	}
+
+	/**
+	 * The change itself: the provider must ASK for file text.
+	 *
+	 * Without `_content_search` the pipeline searches object metadata only, so
+	 * a term living solely inside an attached PDF finds nothing while
+	 * OpenRegister holds it indexed. Asserted on the flag reaching the
+	 * pipeline, because that is the whole of the change — the fan-out itself
+	 * is ContentSearchHandler's tested behaviour, not the provider's.
+	 */
+	public function testSearchAsksThePipelineForAttachedFileText(): void {
+		$user = $this->createMock(IUser::class);
+		$query = $this->mockQuery(['term' => 'aanbesteding']);
+
+		$this->objectService->expects($this->once())
+			->method('searchObjectsPaginated')
+			->with(
+				$this->callback(function (array $q) {
+					return ($q['_content_search'] ?? null) === true;
+				}),
+				$this->isTrue(),
+				$this->isTrue()
+			)
+			->willReturn(['results' => [], 'total' => 0]);
+
+		$this->provider->search($user, $query);
+	}
+
+	/**
+	 * Widening the MATCH must not widen the ENTITLEMENT.
+	 *
+	 * `_content_search` is only safe because the chunk fan-out receives the
+	 * same `_rbac` / `_multitenancy` flags as the metadata arm — a chunk hit
+	 * on an object the caller may not read is filtered by the same pipeline.
+	 * If a later edit ever turned content search on while relaxing either
+	 * flag, file text would become a side channel around object visibility.
+	 * That is the one way this change could become a disclosure, so it is
+	 * pinned rather than reasoned about.
+	 */
+	public function testContentSearchNeverTravelsWithRelaxedGuards(): void {
+		$user = $this->createMock(IUser::class);
+		$query = $this->mockQuery(['term' => 'aanbesteding']);
+
+		$seen = [];
+		$this->objectService->method('searchObjectsPaginated')
+			->willReturnCallback(
+				function (array $q, bool $rbac = true, bool $multitenancy = true) use (&$seen) {
+					$seen = ['content' => ($q['_content_search'] ?? null), 'rbac' => $rbac, 'mt' => $multitenancy];
+					return ['results' => [], 'total' => 0];
+				}
+			);
+
+		$this->provider->search($user, $query);
+
+		$this->assertTrue($seen['content'], 'content search must be on');
+		$this->assertTrue($seen['rbac'], 'and RBAC must still be on alongside it');
+		$this->assertTrue($seen['mt'], 'and so must multitenancy');
+	}
+
+	/**
+	 * A schema opted out of search stays opted out with content search on.
+	 *
+	 * The provider narrows by `searchable = true`. Content search widens the
+	 * match, and must not reach around that narrowing — otherwise a schema
+	 * excluded from search would still surface through the text of its
+	 * attached files.
+	 */
+	public function testAnOptedOutSchemaIsNotReachableViaFileText(): void {
+		// A provider of its own, because setUp() stubs findNonSearchableIds()
+		// to [] and a second stub on the same mock does not replace the first.
+		$schemaMapper = $this->createMock(SchemaMapper::class);
+		$schemaMapper->method('findNonSearchableIds')->willReturn([42]);
+		$schemaMapper->method('findSearchableIds')->willReturn([1, 2, 3]);
+
+		$objectService = $this->createMock(ObjectService::class);
+		$objectService->expects($this->never())->method('searchObjectsPaginated');
+
+		$provider = new ObjectsProvider(
+			$this->l10n,
+			$this->urlGenerator,
+			$objectService,
+			$this->logger,
+			$this->deepLinkRegistry,
+			$schemaMapper,
+			$this->createMock(RegisterMapper::class)
+		);
+
+		$result = $provider->search(
+			$this->createMock(IUser::class),
+			$this->mockQuery(['term' => 'aanbesteding', 'schema' => '42'])
+		);
+
+		$this->assertSame([], $result->jsonSerialize()['entries']);
+	}
 }


### PR DESCRIPTION
## Two search-related changes, and one of them is a security default

Both researched before either was written. Every number below is measured, dated 2026-08-15.

---

### 1. `rbac-default-authenticated` — absent authorization means AUTHENTICATED, never public

`PropertyRbacHandler` says it in as many words:

```php
// If no authorization is defined for this property, it follows object-level rules.
if ($authorization === null || empty($authorization) === true) { return true; }
// If action is not configured, property is accessible.
```

and `userQualifiesForGroup()` returns `true` for `public` unconditionally. So **"nobody said anything" and "everybody may read this" are the same state**, reached by writing nothing at all.

**321 of 368 declared schemas (87%) carry no authorization block:**

| app | schemas | with auth | none |
| --- | --- | --- | --- |
| scholiq | 118 | 0 | **118** |
| shillinq | 114 | 0 | **114** |
| decidesk | 39 | 5 | **34** |
| pipelinq | 27 | 1 | **26** |
| docudesk | 21 | 1 | **20** |
| portaliq | 9 | 0 | **9** |
| opencatalogi · softwarecatalog · procest · openregister | 40 | 40 | 0 |

Four apps did the work. Six did not — because omission has never had a consequence.

**This is not open on every surface today.** The HTTP object API refuses anonymous callers outright: `total=0` anonymous vs `total=8` admin on the same query, and `_rbac=false&_multitenancy=false` makes no difference. The exposure is the **in-process** path — a leaf app calling `ObjectService` from a `#[PublicPage]` controller. Measured on portaliq's content API: **6 pages returned to an anonymous caller** from an unmarked schema.

**And that path is about to widen.** `portaliq/openspec/changes/portal-public-search` puts anonymous full-text search over OR objects. Under today's default that makes all 321 unmarked schemas searchable by anyone.

Task order is load-bearing: **audit by name → mark the intended-public → then flip.** Flipping first turns six apps' public surfaces blank and calls it a security fix. A `legacy_open` migration flag is deliberately *not* offered — it would be set once during an upgrade by someone who wanted their site back, and never unset.

---

### 2. `unified-search-file-content` — OR indexes file text and its own search provider ignores it

`TextExtractionService` writes chunks (`sourceType`, `sourceId`, `textContent`, embedding, `owner`, `organisation`) and `ChunkMapper::searchByKeyword()` searches them. `lib/Search/ObjectsProvider.php` contains **zero** chunk references. So a term appearing only inside an attached PDF finds nothing, while OpenRegister holds that text indexed.

The fix is one flag: pass **`_content_search: true`**, which `ObjectService` already merges through the same RBAC/multitenancy pipeline and returns as the **owning object** — the thing with a URL — rather than a bare chunk.

No new provider. This provider's own docblock states it is *"the single, fleet-wide Nextcloud unified-search provider… Leaf apps do NOT register their own `OCP\Search\IProvider`."*

**Scope, stated because it cannot be otherwise:** NC unified search cannot serve anonymous callers — `IProvider::search(IUser $user, …)` is non-nullable, `UnifiedSearchController` has no `#[PublicPage]`, and a live probe returns **401 anonymous / 200 authenticated**. Anonymous portal search is a different mechanism and lives in portaliq.

The one plausible disclosure route is specified and tested directly rather than reasoned about: **excerpts must keep deriving from the rendered object**, or a redacted field could leak through an excerpt built from file text while the object itself stays correctly filtered.

---

Specs only — no implementation in this PR.
