### PR TITLE
docs(flow-engine-unification): mark tasks 6.2 + 6.4 done, live-verified

### DIFF
--- a/openspec/changes/flow-engine-unification/tasks.md
+++ b/openspec/changes/flow-engine-unification/tasks.md
@@ -41,9 +41,9 @@
 
 ## Phase 6 — Consumers
 - [ ] 6.1 OpenRegister: `/flows` + `/flows/:id` pages, menu entry, no app filter.
-- [ ] 6.2 OpenConnector: `/flows` + `/flows/:id` pages, menu entry, `app=openconnector`.
+- [x] 6.2 OpenConnector: `/flows` + `/flows/:id` pages, menu entry, `app=openconnector`. Live-verified 2026-08-16: list + detail (shared CnFlowDetail canvas), real run against openwoo.zaaksysteme.net, hard-reload survives the router-history-mode conversion. Left the pre-existing openconnector-native `flow`/`steps[]` backend running unmigrated — see openconnector#1255.
 - [ ] 6.3 hermiq: `/graphs` → `/flows` on the shared components, `app=hermiq`, old route kept as alias.
-- [ ] 6.4 OpenBuild: "Edit flows…" opens `CnFlowEditModal`.
+- [x] 6.4 OpenBuild: "Edit flows…" opens `CnFlowEditModal`. Live-verified 2026-08-16: button gated on an app selection, modal opens the shared canvas scoped to the selected app.
 
 ## Phase 7 — Verification
 - [ ] 7.1 `composer check:strict` green in openregister and hermiq.


### PR DESCRIPTION
## Summary
- Marks flow-engine-unification tasks 6.2 (OpenConnector) and 6.4 (OpenBuild) as done — both shipped to their respective `development` branches and were live-verified tonight via real Playwright e2e runs plus manual browser checks (list, detail canvas, hard-reload survival, a real flow run against openwoo.zaaksysteme.net for 6.2; the modal opening scoped to a selected app for 6.4).
- Notes that openconnector's own pre-existing `flow`/`steps[]` backend was deliberately left running, unmigrated — tracked separately at ConductionNL/openconnector#1255, out of this task's original scope.

## Test plan
- Docs-only change, no code touched.