### PR TITLE
fix(security): /api/names/{id} was anonymous and bypassed RBAC + tenancy

### DIFF
--- a/lib/Controller/NamesController.php
+++ b/lib/Controller/NamesController.php
@@ -372,9 +372,23 @@ class NamesController extends Controller {
 	 *
 	 * @spec openspec/specs/schema-driven-read-coercion/spec.md
 	 */
+	// NOT #[PublicPage] — deliberately. This resolves an arbitrary caller-supplied
+	// identifier through CacheHandler::getSingleObjectName(), which queries with
+	// `_rbac: false, _multitenancy: false`. Anonymous, that returned ANY object's
+	// name from ANY register/schema, ACROSS tenants, to anyone holding a UUID —
+	// and names are person names, case titles, document titles.
+	//
+	// The sibling endpoints on this controller (index, create) were already
+	// session-only; `show` being the public one was the anomaly.
+	//
+	// Verified before removing: `GET /api/names/{id}` has NO caller anywhere —
+	// not in the 18 fleet apps, not in @conduction/nextcloud-vue. The only
+	// `api/names` reference in the fleet is a POST to `.../names/warmup`.
+	//
+	// #[AnonRateLimit] is kept: it costs nothing now that a session is required,
+	// and it stays correct if this ever becomes public again.
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
-	#[PublicPage]
 	#[AnonRateLimit(limit: 120, period: 60)]
 	public function show(string $id): JSONResponse {
 		$startTime = microtime(true);


### PR DESCRIPTION
`NamesController::show()` carried `#[PublicPage]` and resolves an arbitrary caller-supplied identifier through `CacheHandler::getSingleObjectName()`, which queries:

```php
findAcrossAllSources(identifier: $id, _rbac: false, _multitenancy: false)
```

**Both flags are explicitly OFF.** Anonymously, that returned **any object's name, from any register/schema, across tenants**, to anyone holding a UUID. Names are person names, case titles, document titles — and this is the foundation repo, so the exposure was fleet-wide.

## The tell

The anomaly was visible inside the controller: its siblings `index` and `create` are `#[NoAdminRequired]` **only**. An endpoint more public than its own neighbours is worth a second look.

## Verified before changing anything

I did not guess that removing `#[PublicPage]` was safe — I measured it:

| question | answer |
|---|---|
| callers of `GET /api/names/{id}` in the 18 fleet apps | **none** |
| callers in `@conduction/nextcloud-vue` | **none** |
| any `api/names` reference at all | one — a **POST** to `.../names/warmup` from `RegistersIndex.vue`, a different route |

The endpoint keeps `#[NoAdminRequired]`, so every authenticated caller still reaches it. `#[AnonRateLimit]` is kept: it costs nothing now and stays correct if this is ever made public again.

## Effect on gate-7

The method reclassifies from `publicpage-unscoped-object-lookup` to `no-auth-guard-in-body`. **The file's finding count is unchanged at 3** — but the severity class is not. Identical counts are not identical content.

## ⚠️ Residual, deliberately not fixed here

The `_rbac: false, _multitenancy: false` in `CacheHandler` means an **authenticated** user can still resolve any object's name cross-tenant. That flag is shared by the name cache which populates list views, so flipping it is a behaviour change that needs its own measurement — not a drive-by in a security patch.
