### PR TITLE
docs(rbac): the ADR this audit points at is 091, not 085

### DIFF
--- a/docs/rbac-unmarked-schema-audit.md
+++ b/docs/rbac-unmarked-schema-audit.md
@@ -155,9 +155,9 @@ identity* — and neither `public` nor `authenticated` describes it. Task 3
 cannot land safely until that kind has an answer, and deciding it per-app,
 twelve times, is how twelve different answers happen.
 
-### That answer now exists: ADR-085
+### That answer now exists: ADR-091
 
-**hydra ADR-085 — "Externally-Authenticated API Surface Belongs to
+**hydra ADR-091 — "Externally-Authenticated API Surface Belongs to
 OpenConnector"** (amends ADR-081 §2) resolves this, and it resolves it by
 removing the population rather than by giving it an RBAC value:
 
@@ -174,10 +174,10 @@ The deciding argument in that ADR is not code duplication — it is that ZGW,
 StUF, DSO, Notificaties, iWmo/iJw and Berichtenbox are **national** standards.
 A leaf app that implements one only works in one country.
 
-⚠️ **Sequencing, therefore:** Task 3 waits on ADR-085's population having a
-migration path, not merely on ADR-085 being accepted. The fleet-wide census
+⚠️ **Sequencing, therefore:** Task 3 waits on ADR-091's population having a
+migration path, not merely on ADR-091 being accepted. The fleet-wide census
 behind it — 44 controllers, 210 public methods across 10 apps — is in
-`hydra/scripts/adr-085-self-auth-endpoint-census.py`.
+`hydra/scripts/adr-091-self-auth-endpoint-census.py`.
 
 ## Before the default flips
 


### PR DESCRIPTION
Follow-up to hydra#589, which renumbers that ADR.

**085 was claimed by hydra#581**, open since 07:54 on 2026-08-15 — before the ADR was written. I picked a number by listing files on `development` and never looked at open PRs.

portaliq's **shipped code** settles which document moves:

```
PortalPageController.php:175   "The built-in SITE renderer shell (ADR-084)."
CmsReader.php / PortalResolver.php / Application.php    ADR-086 §§1–11
```

Those reference #581's numbering, so the ADR moved to **091** rather than the one the code points at.

Updates four references in `docs/rbac-unmarked-schema-audit.md` and the census script's name (`adr-091-self-auth-endpoint-census.py`). Docs only.