### PR TITLE
fix(import): an annotation-only schema change must not be skipped

### DIFF
--- a/lib/Db/Schema.php
+++ b/lib/Db/Schema.php
@@ -2290,9 +2290,16 @@ class Schema extends Entity implements JsonSerializable {
 	 * configuration column and having the corresponding listener
 	 * never fire.
 	 *
+	 * PUBLIC because the import path needs it too: ImportHandler compares an
+	 * incoming schema's annotations against the stored ones to decide whether
+	 * a version-skipped import is really a no-op, and it must compare ONLY the
+	 * keys that can actually persist. Comparing a key outside this vocabulary
+	 * would make the comparison differ forever — the key is dropped on every
+	 * save — and re-import the schema on every single settings load.
+	 *
 	 * @var array<int, string>
 	 */
-	private const ANNOTATION_VOCABULARY = [
+	public const ANNOTATION_VOCABULARY = [
 		'x-openregister-lifecycle',
 		'x-openregister-aggregations',
 		'x-openregister-calculations',

--- a/lib/Service/Configuration/ImportHandler.php
+++ b/lib/Service/Configuration/ImportHandler.php
@@ -1253,10 +1253,9 @@ class ImportHandler {
 	 * @return bool True when a declared annotation is missing or different.
 	 */
 	private function schemaAnnotationsDiffer(array $data, Schema $existing): bool {
+		// `getConfiguration(): ?array`, so the null-coalesce already yields an
+		// array — an is_array() guard here is dead code and PHPStan says so.
 		$stored = ($existing->getConfiguration() ?? []);
-		if (is_array($stored) === false) {
-			$stored = [];
-		}
 
 		$incomingConfig = ($data['configuration'] ?? []);
 		if (is_array($incomingConfig) === false) {

--- a/lib/Service/Configuration/ImportHandler.php
+++ b/lib/Service/Configuration/ImportHandler.php
@@ -1204,8 +1204,91 @@ class ImportHandler {
 			}
 		}
 
-		return false;
+		return $this->schemaAnnotationsDiffer(data: $data, existing: $existing);
 	}//end schemaContentDiffers()
+
+	/**
+	 * Whether the incoming schema declares an `x-openregister-*` annotation
+	 * that the stored schema does not carry with the same value.
+	 *
+	 * WHY THIS EXISTS
+	 * ---------------
+	 * `schemaContentDiffers()` compared `properties`, `required` and
+	 * `authorization` and nothing else, so a change that ONLY adds or edits an
+	 * annotation block was invisible to it. Combined with the version gate
+	 * above ("skip when incoming <= existing") that produced a silent,
+	 * permanent no-op: the annotation sits declared in the app's register JSON,
+	 * visible in the repo, and never reaches the running system.
+	 *
+	 * Measured on openbuild (2026-08-16): `exportJob` declares
+	 * `x-openregister-lifecycle` at version 0.1.0 while the instance carried
+	 * 1.0.0 (a schema edited once through the UI bumps to 1.0.0). The version
+	 * said skip, the content check could not see the missing lifecycle, so
+	 * `TransitionEngine::transition()` found no state machine and returned
+	 * without doing anything — every export sat at `status: queued` forever,
+	 * its background job consumed, with not one line in the log. The same trap
+	 * applies to every key in the vocabulary: `mcp`, `calculations`,
+	 * `notifications`, `widgets`, `relations`, `archival`.
+	 *
+	 * TWO DELIBERATE NARROWINGS, both to avoid re-importing on every load:
+	 *
+	 *  1. Only keys in `Schema::ANNOTATION_VOCABULARY` are compared. An
+	 *     unknown key (openbuild really does declare
+	 *     `x-openregister-lifecycle-exception`) is dropped on every save, so
+	 *     comparing it would differ forever.
+	 *  2. Only keys the INCOMING declares are compared. The stored
+	 *     configuration also holds keys OpenRegister maintains itself
+	 *     (`objectNameField`, `objectDescriptionField`, …) plus annotations an
+	 *     operator may have added through the UI; treating those as a
+	 *     difference would rewrite them away on the next import.
+	 *
+	 * Incoming annotations are read from BOTH the top level and
+	 * `configuration`, because `Schema::hydrate()` folds sibling-of-properties
+	 * `x-openregister-*` keys into `configuration` — app register JSON declares
+	 * them at the top level, the stored schema keeps them nested.
+	 *
+	 * @param array<string,mixed> $data     Incoming schema definition.
+	 * @param Schema              $existing The stored schema.
+	 *
+	 * @return bool True when a declared annotation is missing or different.
+	 */
+	private function schemaAnnotationsDiffer(array $data, Schema $existing): bool {
+		$stored = ($existing->getConfiguration() ?? []);
+		if (is_array($stored) === false) {
+			$stored = [];
+		}
+
+		$incomingConfig = ($data['configuration'] ?? []);
+		if (is_array($incomingConfig) === false) {
+			$incomingConfig = [];
+		}
+
+		// Top level first, then `configuration` — the nested form wins, which
+		// is the same precedence hydrate() applies when it folds.
+		$incoming = [];
+		foreach ([$data, $incomingConfig] as $source) {
+			foreach ($source as $key => $value) {
+				if (is_string($key) === false || str_starts_with($key, 'x-openregister-') === false) {
+					continue;
+				}
+
+				if (in_array($key, Schema::ANNOTATION_VOCABULARY, true) === false) {
+					continue;
+				}
+
+				$incoming[$key] = $value;
+			}
+		}
+
+		foreach ($incoming as $key => $value) {
+			$storedValue = ($stored[$key] ?? null);
+			if ($this->normaliseForCompare(value: $value) !== $this->normaliseForCompare(value: $storedValue)) {
+				return true;
+			}
+		}
+
+		return false;
+	}//end schemaAnnotationsDiffer()
 
 	/**
 	 * Normalise a JSON-ish value into an order-insensitive canonical string.

--- a/tests/Unit/Service/Configuration/ImportHandlerSchemaContentDiffTest.php
+++ b/tests/Unit/Service/Configuration/ImportHandlerSchemaContentDiffTest.php
@@ -183,4 +183,138 @@ class ImportHandlerSchemaContentDiffTest extends TestCase {
 
 	}//end testAbsentEqualsEmpty()
 
+	/**
+	 * The openbuild `exportJob` case, reduced.
+	 *
+	 * An incoming definition whose ONLY change is a top-level
+	 * `x-openregister-lifecycle` block must read as different. Before this was
+	 * detected, the version gate skipped the import (declared 0.1.0 against a
+	 * stored 1.0.0) and the content check compared only properties/required/
+	 * authorization, so the lifecycle never reached the running schema —
+	 * `TransitionEngine` found no state machine, every export stayed at
+	 * `status: queued` forever, and nothing logged it.
+	 *
+	 * @return void
+	 */
+	public function testDeclaredAnnotationMissingFromStoredDiffers(): void {
+		$existing = $this->makeSchema(properties: ['naam' => ['type' => 'string']]);
+		$existing->setConfiguration(['objectNameField' => 'naam']);
+
+		$data = [
+			'properties' => ['naam' => ['type' => 'string']],
+			'x-openregister-lifecycle' => [
+				'field' => 'status',
+				'initial' => 'queued',
+				'transitions' => ['start' => ['from' => ['queued'], 'to' => 'running']],
+			],
+		];
+
+		$this->assertTrue($this->differs(data: $data, existing: $existing));
+
+	}//end testDeclaredAnnotationMissingFromStoredDiffers()
+
+	/**
+	 * An annotation whose value changed is a difference too.
+	 *
+	 * @return void
+	 */
+	public function testChangedAnnotationValueDiffers(): void {
+		$existing = $this->makeSchema();
+		$existing->setConfiguration(
+			[
+				'x-openregister-lifecycle' => [
+					'field' => 'status',
+					'transitions' => ['start' => ['from' => ['queued'], 'to' => 'running']],
+				],
+			]
+		);
+
+		$data = [
+			'x-openregister-lifecycle' => [
+				'field' => 'status',
+				'transitions' => ['start' => ['from' => ['queued'], 'to' => 'building']],
+			],
+		];
+
+		$this->assertTrue($this->differs(data: $data, existing: $existing));
+
+	}//end testChangedAnnotationValueDiffers()
+
+	/**
+	 * An identical annotation is NOT a difference, whichever level it is
+	 * declared at.
+	 *
+	 * `Schema::hydrate()` folds sibling-of-properties `x-openregister-*` keys
+	 * into `configuration`, so the app declares them at the top level and the
+	 * stored schema keeps them nested. Both forms must compare equal or every
+	 * settings load would rewrite the schema.
+	 *
+	 * @return void
+	 */
+	public function testIdenticalAnnotationDoesNotDiffer(): void {
+		$lifecycle = [
+			'field' => 'status',
+			'initial' => 'queued',
+			'transitions' => ['start' => ['from' => ['queued'], 'to' => 'running']],
+		];
+
+		$existing = $this->makeSchema();
+		$existing->setConfiguration(
+			['objectNameField' => 'naam', 'x-openregister-lifecycle' => $lifecycle]
+		);
+
+		$this->assertFalse(
+			$this->differs(data: ['x-openregister-lifecycle' => $lifecycle], existing: $existing)
+		);
+		$this->assertFalse(
+			$this->differs(
+				data: ['configuration' => ['x-openregister-lifecycle' => $lifecycle]],
+				existing: $existing
+			)
+		);
+
+	}//end testIdenticalAnnotationDoesNotDiffer()
+
+	/**
+	 * A key OUTSIDE the declared vocabulary must NOT count as a difference.
+	 *
+	 * openbuild really declares `x-openregister-lifecycle-exception`, which is
+	 * dropped on every save because it is not in the vocabulary. Comparing it
+	 * would differ forever and re-import the schema on every settings load —
+	 * turning a stale-schema fix into permanent write churn.
+	 *
+	 * @return void
+	 */
+	public function testUnknownAnnotationKeyDoesNotDiffer(): void {
+		$existing = $this->makeSchema();
+		$existing->setConfiguration(['objectNameField' => 'naam']);
+
+		$data = ['x-openregister-lifecycle-exception' => ['whatever' => true]];
+
+		$this->assertFalse($this->differs(data: $data, existing: $existing));
+
+	}//end testUnknownAnnotationKeyDoesNotDiffer()
+
+	/**
+	 * A stored annotation the incoming no longer declares is NOT a difference.
+	 *
+	 * The stored configuration also carries keys OpenRegister maintains itself
+	 * and annotations an operator may have added through the UI; treating
+	 * their absence as a change would rewrite them away on the next import.
+	 *
+	 * @return void
+	 */
+	public function testStoredOnlyAnnotationDoesNotDiffer(): void {
+		$existing = $this->makeSchema();
+		$existing->setConfiguration(
+			[
+				'objectNameField' => 'naam',
+				'x-openregister-mcp' => ['enabled' => true],
+			]
+		);
+
+		$this->assertFalse($this->differs(data: ['properties' => []], existing: $existing));
+
+	}//end testStoredOnlyAnnotationDoesNotDiffer()
+
 }//end class


### PR DESCRIPTION
## The bug

`ImportHandler::schemaContentDiffers()` compared `properties`, `required` and `authorization` and nothing else. A change that **only** adds or edits an `x-openregister-*` annotation was invisible to it — and combined with the version gate above it (`skip when incoming <= existing`) that is a silent, permanent no-op. The annotation sits declared in the app's register JSON, visible in the repo, and never reaches the running system.

## How it was found

Chasing an openbuild export that sat at `status: queued` forever.

- `exportJob` declares `x-openregister-lifecycle` at version **0.1.0**; the instance carried **1.0.0** (editing a schema once through the UI bumps it to 1.0.0).
- Version said skip. The content check could not see that the stored schema had **no lifecycle at all**.
- So `TransitionEngine::transition()` found no state machine and returned without doing anything. `RunExportJob` ran, its `oc_jobs` row was consumed, the object never moved off `queued`, and **not one line was logged**.
- Adding the lifecycle to the stored schema by hand fixed it immediately: the object's `available-actions` went from empty to `start → running`, and firing it moved the object to `running`.

The control case is in the same app: `applicationVersion` declares 0.4.0, is deployed at 0.4.0, and carries its lifecycle correctly.

The same trap applies to every key in the vocabulary — `mcp`, `calculations`, `notifications`, `widgets`, `relations`, `archival`.

## The fix

`schemaContentDiffers()` now also compares the declared annotations, via a new `schemaAnnotationsDiffer()`.

Two deliberate narrowings, both to avoid re-importing on every settings load:

1. **Only keys in `Schema::ANNOTATION_VOCABULARY`.** An unknown key is dropped on every save, so comparing it would differ forever — openbuild really does declare `x-openregister-lifecycle-exception`.
2. **Only keys the incoming declares.** The stored configuration also holds keys OpenRegister maintains itself (`objectNameField`, …) and annotations an operator added through the UI; treating those as a difference would rewrite them away.

Incoming annotations are read from both the top level and `configuration`, because `Schema::hydrate()` folds the sibling-of-properties form into the nested one. `ANNOTATION_VOCABULARY` becomes `public` so the import path can share the one list.

## Tests

`ImportHandlerSchemaContentDiffTest` gains five cases. Two of them **fail on the old behaviour and pass on the new** — verified as a control pair (reverting the one-line call site reproduces exactly those two failures, 10 tests / 2 failures). The other three pin the anti-churn narrowings so a future widening cannot silently reintroduce per-load rewrites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)