### PR TITLE
fix(schemas): a named register is a boundary, not a hint

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -219,6 +219,7 @@ Vrij en open source onder de EUPL-licentie.
 		<!-- field-level-object-encryption: encrypt existing plaintext values of a newly-flagged property. -->
 		<command>OCA\OpenRegister\Command\EncryptFieldCommand</command>
 		<command>OCA\OpenRegister\Command\DedupeRegistersCommand</command>
+		<command>OCA\OpenRegister\Command\RelinkRegisterSchemasCommand</command>
 		<command>OCA\OpenRegister\Command\ReconcileMagicTablesCommand</command>
 		<command>OCA\OpenRegister\Command\DedupeConfigurationsCommand</command>
 		<command>OCA\OpenRegister\Command\ResolverListCommand</command>

--- a/lib/Command/RelinkRegisterSchemasCommand.php
+++ b/lib/Command/RelinkRegisterSchemasCommand.php
@@ -1,0 +1,178 @@
+<?php
+
+/**
+ * OpenRegister relink-register-schemas command
+ *
+ * Reports — and on explicit request repairs — registers whose stored `schemas`
+ * list has been lost, reconstructing it from the physical per-pair object tables.
+ *
+ * @category Command
+ * @package  OCA\OpenRegister\Command
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Command;
+
+use OCA\OpenRegister\Service\RegisterSchemaLinkageRepairService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Inspect and repair lost register→schema linkage.
+ *
+ * DRY RUN BY DEFAULT. `--write` is required to change anything.
+ *
+ * A register with an empty `schemas` list cannot resolve any schema slug once
+ * register-scoped resolution refuses to fall back globally, so this command is the
+ * remedy the refusal message points at. Repairing 17 registers as a side effect of
+ * running it would be the same class of surprise the refusal exists to remove, so
+ * the operator sees the full change first and then opts in.
+ *
+ * @spec openspec/specs/register-scoped-slug-resolution/spec.md
+ */
+class RelinkRegisterSchemasCommand extends Command {
+
+	/**
+	 * Wire the repair service.
+	 *
+	 * @param RegisterSchemaLinkageRepairService $repair The linkage repair service.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly RegisterSchemaLinkageRepairService $repair,
+	) {
+		parent::__construct();
+	}//end __construct()
+
+	/**
+	 * Define command name, description, and options.
+	 *
+	 * @return void
+	 */
+	protected function configure(): void {
+		$this->setName(name: 'openregister:registers:relink-schemas')
+			->setDescription('Rebuild a register\'s schemas list from its physical object tables (dry run by default)')
+			->addOption(
+				'write',
+				null,
+				InputOption::VALUE_NONE,
+				'Apply the changes. Without this flag nothing is modified.'
+			)
+			->addOption(
+				'register',
+				null,
+				InputOption::VALUE_REQUIRED,
+				'Limit to a single register id.'
+			);
+	}//end configure()
+
+	/**
+	 * Run the inspection, and the repair when --write is given.
+	 *
+	 * @param InputInterface  $input  The console input.
+	 * @param OutputInterface $output The console output.
+	 *
+	 * @return int The exit code.
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$write      = (bool)$input->getOption('write');
+		$registerId = $input->getOption('register');
+		if ($registerId !== null) {
+			$registerId = (int)$registerId;
+		}
+
+		$report = $this->repair->inspect(registerId: $registerId);
+
+		if ($report === []) {
+			$output->writeln('<info>No register has recoverable schema linkage. Nothing to do.</info>');
+			return Command::SUCCESS;
+		}
+
+		$output->writeln(
+			sprintf('<comment>%d register(s) have recoverable schema linkage:</comment>', count($report))
+		);
+		$output->writeln('');
+
+		foreach ($report as $entry) {
+			$this->renderRegister(output: $output, entry: $entry);
+		}
+
+		if ($write === false) {
+			$output->writeln('');
+			$output->writeln('<comment>DRY RUN — nothing was changed. Re-run with --write to apply.</comment>');
+			return Command::SUCCESS;
+		}
+
+		$changed = 0;
+		foreach ($report as $entry) {
+			$merged = $this->repair->apply(
+				registerId: $entry['registerId'],
+				schemaIds: array_keys($entry['recoverable'])
+			);
+			$output->writeln(
+				sprintf(
+					'  <info>repaired</info> register %d -> schemas [%s]',
+					$entry['registerId'],
+					implode(', ', $merged)
+				)
+			);
+			$changed++;
+		}
+
+		$output->writeln('');
+		$output->writeln(sprintf('<info>%d register(s) changed.</info>', $changed));
+
+		return Command::SUCCESS;
+	}//end execute()
+
+	/**
+	 * Render one register's findings.
+	 *
+	 * Row counts are printed per schema id because they separate strong evidence
+	 * (a table holding rows) from weak (an empty table). Both are recovered; the
+	 * operator can see which is which.
+	 *
+	 * @param OutputInterface $output The console output.
+	 * @param array           $entry  One inspect() report entry.
+	 *
+	 * @return void
+	 */
+	private function renderRegister(OutputInterface $output, array $entry): void {
+		$output->writeln(
+			sprintf(
+				'  register %d (%s) — currently [%s]',
+				$entry['registerId'],
+				(string)($entry['registerSlug'] ?? '?'),
+				implode(', ', $entry['currentIds'])
+			)
+		);
+
+		foreach ($entry['recoverable'] as $schemaId => $rowCount) {
+			$evidence = 'table exists but is empty';
+			if ($rowCount > 0) {
+				$evidence = sprintf('%d row(s)', $rowCount);
+			}
+
+			if ($rowCount < 0) {
+				$evidence = 'row count unavailable';
+			}
+
+			$output->writeln(sprintf('      + schema %d  (%s)', $schemaId, $evidence));
+		}
+	}//end renderRegister()
+}//end class

--- a/lib/Controller/SchemasController.php
+++ b/lib/Controller/SchemasController.php
@@ -35,6 +35,7 @@ use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Exception\BreakingSchemaChangeException;
 use OCA\OpenRegister\Exception\DatabaseConstraintException;
 use OCA\OpenRegister\Exception\SchemaImportException;
+use OCA\OpenRegister\Exception\SchemaNotInRegisterException;
 use OCA\OpenRegister\Service\AuthorizationAuditService;
 use OCA\OpenRegister\Service\JsonLd\JsonLdContextService;
 use OCA\OpenRegister\Service\OrganisationService;
@@ -322,26 +323,46 @@ class SchemasController extends Controller {
 	private function resolveSchema(int|string $id): Schema {
 		$registerParam = $this->request->getParam(key: 'register', default: null);
 
-		// Register-scoped first. findBySlugInIds() returns null for a numeric id, a
-		// uuid, or a slug the register does not carry, so every one of those cases
-		// falls through to the global lookup untouched.
+		// Register-scoped resolution. A numeric id is resolved globally below;
+		// scoping applies to slugs only.
+		//
+		// The two failures below are deliberately NOT handled together, and the
+		// separation is load-bearing. An *unresolvable register parameter* is not a
+		// reason to fail the schema read — the caller gets what they would have got
+		// without the parameter. But a register that resolves and does not carry the
+		// slug is a refusal, because naming a register makes it a boundary.
+		//
+		// Both used to sit inside one try/catch. Throwing the refusal from in there
+		// would have been caught by that same catch and logged as "scope could not
+		// be applied", restoring the exact fallback this change removes — a silent
+		// no-op that looks like a fix.
 		if ($registerParam !== null && $registerParam !== '' && is_string($id) === true && is_numeric($id) === false) {
+			$register = null;
 			try {
 				$register = $this->registerMapper->find(id: $registerParam, _rbac: false, _multitenancy: false);
-				$scoped = $this->schemaMapper->findBySlugInIds(
+			} catch (Exception $e) {
+				$this->logger->debug(
+					'[SchemasController] register scope could not be applied: ' . $e->getMessage(),
+					['register' => $registerParam, 'schema' => $id]
+				);
+			}
+
+			if ($register !== null) {
+				$registerSchemaIds = ($register->getSchemas() ?? []);
+				$scoped            = $this->schemaMapper->findBySlugInIds(
 					slug: $id,
-					schemaIds: ($register->getSchemas() ?? [])
+					schemaIds: $registerSchemaIds
 				);
 				if ($scoped !== null) {
 					return $scoped;
 				}
-			} catch (Exception $e) {
-				// An unresolvable register is not a reason to fail the schema read —
-				// fall through to the global lookup, which is what the caller would
-				// have got without the parameter at all.
-				$this->logger->debug(
-					'[SchemasController] register scope could not be applied: ' . $e->getMessage(),
-					['register' => $registerParam, 'schema' => $id]
+
+				throw new SchemaNotInRegisterException(
+					schemaSlug: $id,
+					registerId: $register->getId(),
+					registerSlug: $register->getSlug(),
+					candidatesElsewhere: $this->schemaMapper->countBySlug(slug: $id),
+					registerListEmpty: ($registerSchemaIds === [])
 				);
 			}
 		}

--- a/lib/Db/SchemaMapper.php
+++ b/lib/Db/SchemaMapper.php
@@ -617,6 +617,44 @@ class SchemaMapper extends QBMapper {
 	}//end findBySlugInIds()
 
 	/**
+	 * Count how many schemas on the instance carry a slug.
+	 *
+	 * Used only to build the message of {@see SchemaNotInRegisterException}. A
+	 * register-scoped miss reads as "your slug is wrong" unless the caller is told
+	 * how many same-slug schemas exist — and when that number is nine, as measured
+	 * for `anonymizationLink` on 2026-08-16, "your slug is wrong" is the one
+	 * conclusion that is certainly false.
+	 *
+	 * Deliberately unscoped by organisation and application: the point is to report
+	 * the size of the ambiguity the caller just escaped, not to resolve anything.
+	 *
+	 * @param string $slug The schema slug (matched case-insensitively).
+	 *
+	 * @return int The number of schemas carrying this slug.
+	 *
+	 * @spec openspec/specs/register-scoped-slug-resolution/spec.md
+	 */
+	public function countBySlug(string $slug): int {
+		$this->traceRead(method: 'countBySlug');
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->select($qb->func()->count('*', 'slug_count'))
+			->from('openregister_schemas')
+			->where(
+				$qb->expr()->eq(
+					$qb->func()->lower('slug'),
+					$qb->createNamedParameter(value: strtolower($slug), type: IQueryBuilder::PARAM_STR)
+				)
+			);
+
+		$result = $qb->executeQuery();
+		$row    = $result->fetch();
+		$result->closeCursor();
+
+		return (int)($row['slug_count'] ?? 0);
+	}//end countBySlug()
+
+	/**
 	 * Clear the request-scoped find cache for a specific schema
 	 *
 	 * Used by the runtime-schema-api CRUD path to drop the in-memory

--- a/lib/Exception/SchemaNotInRegisterException.php
+++ b/lib/Exception/SchemaNotInRegisterException.php
@@ -1,0 +1,202 @@
+<?php
+
+/**
+ * OpenRegister SchemaNotInRegisterException
+ *
+ * This file contains the exception thrown when a schema slug does not resolve
+ * within the register the caller named.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Exception
+ * @package  OCA\OpenRegister\Exception
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+namespace OCA\OpenRegister\Exception;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+
+/**
+ * Thrown when a schema slug does not resolve inside the register that was named.
+ *
+ * Extends {@see DoesNotExistException} so Nextcloud's dispatcher keeps mapping it
+ * to a 404 — no controller or API contract changes. The distinct type exists so a
+ * caller (and a test) can tell "this register does not carry that slug" apart from
+ * "no such register" and from "no such schema anywhere".
+ *
+ * The message deliberately carries the candidate count and the repair command.
+ * Measured on the development instance 2026-08-16: register `document` (id 6) had
+ * an empty `schemas` list while nine `docudesk`-owned schemas shared the slug
+ * `anonymizationLink`. A bare "schema not found" reads as "your slug is wrong",
+ * which is the one conclusion that is certainly false when nine copies exist. The
+ * count is what turns a dead end into a diagnosis.
+ *
+ * @category Exception
+ * @package  OCA\OpenRegister\Exception
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/register-scoped-slug-resolution/spec.md
+ */
+class SchemaNotInRegisterException extends DoesNotExistException {
+
+	/**
+	 * The id of the register the caller named.
+	 *
+	 * @var int|null
+	 */
+	private ?int $registerId;
+
+	/**
+	 * The slug of the register the caller named, when known.
+	 *
+	 * @var string|null
+	 */
+	private ?string $registerSlug;
+
+	/**
+	 * The schema slug that failed to resolve inside that register.
+	 *
+	 * @var string
+	 */
+	private string $schemaSlug;
+
+	/**
+	 * How many schemas carry this slug elsewhere on the instance.
+	 *
+	 * @var int
+	 */
+	private int $candidatesElsewhere;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string      $schemaSlug          The slug that did not resolve.
+	 * @param int|null    $registerId          The named register's id, when known.
+	 * @param string|null $registerSlug        The named register's slug, when known.
+	 * @param int         $candidatesElsewhere Count of same-slug schemas outside the register.
+	 * @param bool        $registerListEmpty   Whether the register carries no schemas at all.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/register-scoped-slug-resolution/spec.md
+	 */
+	public function __construct(
+		string $schemaSlug,
+		?int $registerId=null,
+		?string $registerSlug=null,
+		int $candidatesElsewhere=0,
+		bool $registerListEmpty=false,
+	) {
+		$this->schemaSlug          = $schemaSlug;
+		$this->registerId          = $registerId;
+		$this->registerSlug        = $registerSlug;
+		$this->candidatesElsewhere = $candidatesElsewhere;
+
+		parent::__construct(
+			msg: $this->composeMessage(registerListEmpty: $registerListEmpty)
+		);
+	}//end __construct()
+
+	/**
+	 * Build the operator-facing message.
+	 *
+	 * Every branch names the repair command. A register whose schemas list is empty
+	 * gets a different sentence from one that simply lacks this slug, because the
+	 * two have different remedies and conflating them is what hid the defect.
+	 *
+	 * @param bool $registerListEmpty Whether the register carries no schemas at all.
+	 *
+	 * @return string The composed message.
+	 */
+	private function composeMessage(bool $registerListEmpty): string {
+		$register = 'the named register';
+		if ($this->registerId !== null) {
+			$register = sprintf(
+				'register "%s" (id %d)',
+				($this->registerSlug ?? '?'),
+				$this->registerId
+			);
+		}
+
+		if ($registerListEmpty === true) {
+			return sprintf(
+				'Schema slug "%s" cannot resolve because %s carries no schemas at all. '
+				. '%d schema(s) elsewhere on this instance carry this slug, and resolving to one of '
+				. 'them would bind data to a register its owner did not choose. '
+				. 'Run `occ openregister:registers:relink-schemas` to inspect and repair the linkage.',
+				$this->schemaSlug,
+				$register,
+				$this->candidatesElsewhere
+			);
+		}
+
+		return sprintf(
+			'Schema slug "%s" is not carried by %s. %d schema(s) elsewhere on this instance '
+			. 'carry this slug; none of them is served here, because naming a register makes it a boundary. '
+			. 'If the linkage was lost, run `occ openregister:registers:relink-schemas` to inspect and repair it.',
+			$this->schemaSlug,
+			$register,
+			$this->candidatesElsewhere
+		);
+	}//end composeMessage()
+
+	/**
+	 * Get the named register's id.
+	 *
+	 * @return int|null The register id, or null when it was not known.
+	 *
+	 * @spec openspec/specs/register-scoped-slug-resolution/spec.md
+	 */
+	public function getRegisterId(): ?int {
+		return $this->registerId;
+	}//end getRegisterId()
+
+	/**
+	 * Get the named register's slug.
+	 *
+	 * @return string|null The register slug, or null when it was not known.
+	 *
+	 * @spec openspec/specs/register-scoped-slug-resolution/spec.md
+	 */
+	public function getRegisterSlug(): ?string {
+		return $this->registerSlug;
+	}//end getRegisterSlug()
+
+	/**
+	 * Get the schema slug that failed to resolve.
+	 *
+	 * @return string The schema slug.
+	 *
+	 * @spec openspec/specs/register-scoped-slug-resolution/spec.md
+	 */
+	public function getSchemaSlug(): string {
+		return $this->schemaSlug;
+	}//end getSchemaSlug()
+
+	/**
+	 * Get the count of same-slug schemas outside the register.
+	 *
+	 * @return int The candidate count.
+	 *
+	 * @spec openspec/specs/register-scoped-slug-resolution/spec.md
+	 */
+	public function getCandidatesElsewhere(): int {
+		return $this->candidatesElsewhere;
+	}//end getCandidatesElsewhere()
+}//end class

--- a/lib/Service/Flow/Nodes/ObjectReadNode.php
+++ b/lib/Service/Flow/Nodes/ObjectReadNode.php
@@ -78,6 +78,7 @@ use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCA\OpenRegister\Exception\SchemaNotInRegisterException;
 use OCP\WorkflowEngine\IManager;
 use RuntimeException;
 use Throwable;
@@ -529,14 +530,29 @@ class ObjectReadNode implements IFlowNode, IFlowNodeConfigKeys {
 	private function resolveSchema(array $config, Register $register): Schema {
 		$identifier = trim((string)($config['schema'] ?? ''));
 
+		// Refusing beats resolving globally on the READ side too, and for a reason
+		// that is easy to miss: a global match here does not usually return foreign
+		// data, it returns NOTHING — the wrongly-resolved schema has no table under
+		// this register. An empty result set is indistinguishable from "this
+		// register holds no objects", so the flow would report success over a
+		// silently unreachable dataset.
 		if (is_numeric($identifier) === false) {
-			$scoped = $this->schemas->findBySlugInIds(
+			$registerSchemaIds = (array)($register->getSchemas() ?? []);
+			$scoped            = $this->schemas->findBySlugInIds(
 				slug: $identifier,
-				schemaIds: (array)($register->getSchemas() ?? [])
+				schemaIds: $registerSchemaIds
 			);
 			if ($scoped !== null) {
 				return $scoped;
 			}
+
+			throw new SchemaNotInRegisterException(
+				schemaSlug: $identifier,
+				registerId: $register->getId(),
+				registerSlug: $register->getSlug(),
+				candidatesElsewhere: $this->schemas->countBySlug(slug: $identifier),
+				registerListEmpty: ($registerSchemaIds === [])
+			);
 		}
 
 		try {

--- a/lib/Service/Flow/Nodes/ObjectWriteNode.php
+++ b/lib/Service/Flow/Nodes/ObjectWriteNode.php
@@ -90,6 +90,7 @@ use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCA\OpenRegister\Exception\SchemaNotInRegisterException;
 use OCP\WorkflowEngine\IManager;
 use RuntimeException;
 use Throwable;
@@ -1049,14 +1050,29 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys {
 			throw new UnexpectedValueException($this->l10n->t('An object-write step needs a schema.'));
 		}
 
+		// The step always carries a register, so the register is the boundary: a
+		// slug it does not carry is refused rather than resolved globally. Writing
+		// is the dangerous direction — a global match here would create an object
+		// under a schema belonging to a register its owner never chose, and a
+		// looser `required` set on that foreign schema would accept the row
+		// silently.
 		if (is_numeric($identifier) === false) {
-			$scoped = $this->schemas->findBySlugInIds(
+			$registerSchemaIds = (array)($register->getSchemas() ?? []);
+			$scoped            = $this->schemas->findBySlugInIds(
 				slug: $identifier,
-				schemaIds: (array)($register->getSchemas() ?? [])
+				schemaIds: $registerSchemaIds
 			);
 			if ($scoped !== null) {
 				return $scoped;
 			}
+
+			throw new SchemaNotInRegisterException(
+				schemaSlug: $identifier,
+				registerId: $register->getId(),
+				registerSlug: $register->getSlug(),
+				candidatesElsewhere: $this->schemas->countBySlug(slug: $identifier),
+				registerListEmpty: ($registerSchemaIds === [])
+			);
 		}
 
 		try {

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -85,6 +85,7 @@ use OCA\OpenRegister\Exception\AppendOnlyException;
 use OCA\OpenRegister\Exception\ArchivalImmutableException;
 use OCA\OpenRegister\Exception\ValidationException;
 use OCA\OpenRegister\Exception\CustomValidationException;
+use OCA\OpenRegister\Exception\SchemaNotInRegisterException;
 use OCP\AppFramework\Db\DoesNotExistException as OcpDoesNotExistException;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -472,27 +473,47 @@ class ObjectService implements ObjectServiceInterface
     public function setSchema(Schema | string | int $schema): static
     {
         if (is_string($schema) === true || is_int($schema) === true) {
-            // REGISTER-SCOPED SLUG RESOLUTION (cross-app collision fix).
+            // REGISTER-SCOPED SLUG RESOLUTION.
             // SchemaMapper::find() resolves a slug by LOWER(slug) GLOBALLY across
-            // every app on the instance and returns the FIRST row it fetches. On
-            // the shared instance that lets a generic slug (e.g. 'conversation',
-            // 'order', 'task') resolve to another app's schema that shares the
-            // lower(slug). When a register context is present, the slug must
-            // resolve to the schema THAT REGISTER references. Try that first; it
-            // is a no-op (null) for numeric ids, uuids, or slugs the register
-            // does not carry, so we transparently fall back to the global find
-            // for every legacy / register-less caller.
+            // every register and every app on the instance, returning whichever row
+            // its tie-break orders first. Naming a register makes it a BOUNDARY: a
+            // caller that supplied one must never be served a schema from outside
+            // it, so a scoped miss throws here instead of falling through.
+            //
+            // This used to fall back, and the comment called that "transparent". It
+            // was not. Measured 2026-08-16: register `document` (id 6) carried an
+            // empty schemas list while nine docudesk-owned schemas shared the slug
+            // `anonymizationLink`; the fallback resolved to id 5084, which has no
+            // table under register 6 at all, so slug reads returned EMPTY while four
+            // real rows sat in oc_openregister_table_6_9177. An empty result set is
+            // indistinguishable from "this register has no objects", which is how
+            // the defect survived unnoticed.
+            //
+            // Scoping applies to SLUGS only. Numeric ids and uuids are resolved
+            // directly below, and callers with no register keep global resolution.
             if (is_string($schema) === true
                 && is_numeric($schema) === false
                 && $this->currentRegister !== null
             ) {
-                $scoped = $this->schemaMapper->findBySlugInIds(
+                $registerSchemaIds = ($this->currentRegister->getSchemas() ?? []);
+                $scoped            = $this->schemaMapper->findBySlugInIds(
                     slug: $schema,
-                    schemaIds: ($this->currentRegister->getSchemas() ?? [])
+                    schemaIds: $registerSchemaIds
                 );
                 if ($scoped !== null) {
                     $this->currentSchema = $scoped;
                     return $this;
+                }
+
+                // A uuid is not a slug and must still reach the global resolver.
+                if ($this->isUuidFormat(value: $schema) === false) {
+                    throw new SchemaNotInRegisterException(
+                        schemaSlug: $schema,
+                        registerId: $this->currentRegister->getId(),
+                        registerSlug: $this->currentRegister->getSlug(),
+                        candidatesElsewhere: $this->schemaMapper->countBySlug(slug: $schema),
+                        registerListEmpty: ($registerSchemaIds === [])
+                    );
                 }
             }
 
@@ -2358,29 +2379,27 @@ class ObjectService implements ObjectServiceInterface
             );
         }
 
-        // Resolve schema slug → numeric ID. REGISTER-SCOPED first (cross-app
-        // collision fix): a generic slug must resolve to the schema THIS
-        // register references, not to whichever same-slug row find() fetches
-        // first across the shared instance. Fall back to the multi-tenancy
-        // scoped global find when the register does not carry the slug — a
-        // schema in another organisation MUST then throw, not return the
-        // foreign-org entity (principle of least surprise).
-        $schema = $this->schemaMapper->findBySlugInIds(
+        // Resolve schema slug → numeric ID, REGISTER-SCOPED and nothing else. The
+        // caller named a register, so the register is the boundary.
+        //
+        // This previously fell back to an organisation-scoped global find(). That
+        // guard is not sufficient: the nine same-slug `anonymizationLink` schemas
+        // measured on 2026-08-16 are owned by the SAME application, so an
+        // organisation filter still selects the wrong one. Only the register
+        // disambiguates them.
+        $registerSchemaIds = ($register->getSchemas() ?? []);
+        $schema            = $this->schemaMapper->findBySlugInIds(
             slug: $schemaSlug,
-            schemaIds: ($register->getSchemas() ?? [])
+            schemaIds: $registerSchemaIds
         );
         if ($schema === null) {
-            try {
-                $schema = $this->schemaMapper->find(
-                    id: $schemaSlug,
-                    _rbac: $_rbac,
-                    _multitenancy: $_multitenancy
-                );
-            } catch (OcpDoesNotExistException $e) {
-                throw new OcpDoesNotExistException(
-                    'searchObjectsBySlug: schema slug not found in caller organisation: '.$schemaSlug
-                );
-            }
+            throw new SchemaNotInRegisterException(
+                schemaSlug: $schemaSlug,
+                registerId: $register->getId(),
+                registerSlug: $register->getSlug(),
+                candidatesElsewhere: $this->schemaMapper->countBySlug(slug: $schemaSlug),
+                registerListEmpty: ($registerSchemaIds === [])
+            );
         }
 
         // Merge resolved numeric IDs into the @self block of the filters.

--- a/lib/Service/RegisterSchemaLinkageRepairService.php
+++ b/lib/Service/RegisterSchemaLinkageRepairService.php
@@ -1,0 +1,298 @@
+<?php
+
+/**
+ * OpenRegister RegisterSchemaLinkageRepairService
+ *
+ * Reconstructs a register's `schemas` list from the physical object tables when
+ * the stored list has been lost.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+namespace OCA\OpenRegister\Service;
+
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCP\IDBConnection;
+use PDO;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Rebuilds lost register→schema linkage from physical storage.
+ *
+ * A schema row carries NO register column: the relation is stored only as a JSON
+ * id list on the register. When that list is lost, nothing on the schema side can
+ * rebuild it.
+ *
+ * What can is the storage layout itself. Objects live in per-pair tables named
+ * `oc_openregister_table_<registerId>_<schemaId>`, so the table NAME is a durable
+ * record of a pairing that was actually used. Measured on the development instance
+ * 2026-08-16: 3220 such tables, 45 registers with an empty list, 17 of them
+ * recoverable this way, and exactly one — DocuDesk's Document Register (id 6) —
+ * holding live rows it could no longer reach by slug.
+ *
+ * Deliberately rejected as evidence sources:
+ *  - slug similarity: nine schemas shared slug `anonymizationLink`;
+ *  - `application` ownership: all nine were owned by `docudesk`;
+ *  - the app's own register manifest: it describes what the app intends NOW, not
+ *    what the register holds, so it would orphan a schema whose objects exist but
+ *    which the app has since dropped.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/register-scoped-slug-resolution/spec.md
+ */
+class RegisterSchemaLinkageRepairService {
+
+	/**
+	 * Marker the shard tables are matched on.
+	 *
+	 * Anchored on the marker rather than a computed prefix: OCP\IDBConnection
+	 * exposes neither getSchema() nor getPrefix(), and getTableName('') yields the
+	 * literal `*PREFIX*` placeholder that a raw information_schema string never
+	 * resolves. Same reasoning as {@see \OCA\OpenRegister\Repair\RenameDutchColumns}.
+	 *
+	 * @var string
+	 */
+	private const TABLE_MARKER = 'openregister_table_';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IDBConnection   $db             The database connection.
+	 * @param RegisterMapper  $registerMapper The register mapper.
+	 * @param LoggerInterface $logger         The logger.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly IDBConnection $db,
+		private readonly RegisterMapper $registerMapper,
+		private readonly LoggerInterface $logger,
+	) {
+	}//end __construct()
+
+	/**
+	 * Inspect registers for recoverable schema linkage.
+	 *
+	 * Reports only — never mutates. Row counts are included because they separate
+	 * strong evidence (a table holding rows) from weak (an empty table left by a
+	 * schema attached and never used). Both are recoverable; the operator should be
+	 * able to see which is which before deciding.
+	 *
+	 * @param int|null $registerId Inspect only this register, or all when null.
+	 *
+	 * @return array<int, array{registerId:int, registerSlug:string|null, currentIds:int[], recoverable:array<int,int>}>
+	 *         One entry per register that would gain at least one id.
+	 *
+	 * @spec openspec/specs/register-scoped-slug-resolution/spec.md
+	 */
+	public function inspect(?int $registerId=null): array {
+		$pairs = $this->physicalPairs();
+		if ($pairs === []) {
+			return [];
+		}
+
+		$report = [];
+		foreach ($this->registerMapper->findAll() as $register) {
+			$id = $register->getId();
+			if ($id === null || ($registerId !== null && $id !== $registerId)) {
+				continue;
+			}
+
+			$currentIds = $this->normaliseIds(candidates: ($register->getSchemas() ?? []));
+			$candidates = ($pairs[$id] ?? []);
+
+			// Additive only: a schema may legitimately be linked before its first
+			// object is written, so a missing table is NOT evidence of "not linked".
+			// Only ids absent from the stored list are proposed.
+			$recoverable = [];
+			foreach ($candidates as $schemaId => $rowCount) {
+				if (in_array($schemaId, $currentIds, true) === false) {
+					$recoverable[$schemaId] = $rowCount;
+				}
+			}
+
+			if ($recoverable === []) {
+				continue;
+			}
+
+			ksort($recoverable);
+			$report[] = [
+				'registerId'   => $id,
+				'registerSlug' => $register->getSlug(),
+				'currentIds'   => $currentIds,
+				'recoverable'  => $recoverable,
+			];
+		}//end foreach
+
+		return $report;
+	}//end inspect()
+
+	/**
+	 * Apply a repair to one register.
+	 *
+	 * Strictly additive: the stored ids are preserved and the recovered ids merged
+	 * in. The method never removes an id, so a register cannot lose correct
+	 * configuration because one of its schemas has no objects yet.
+	 *
+	 * @param int   $registerId The register to repair.
+	 * @param int[] $schemaIds  The schema ids to add.
+	 *
+	 * @return int[] The register's schema ids after the repair.
+	 *
+	 * @spec openspec/specs/register-scoped-slug-resolution/spec.md
+	 */
+	public function apply(int $registerId, array $schemaIds): array {
+		$register = $this->registerMapper->find($registerId);
+		$current  = $this->normaliseIds(candidates: ($register->getSchemas() ?? []));
+
+		$merged = $current;
+		foreach ($this->normaliseIds(candidates: $schemaIds) as $candidate) {
+			if (in_array($candidate, $merged, true) === false) {
+				$merged[] = $candidate;
+			}
+		}
+
+		sort($merged);
+		$register->setSchemas($merged);
+		$this->registerMapper->update($register);
+
+		$this->logger->warning(
+			message: sprintf(
+				'[RegisterSchemaLinkageRepair] Register %d schemas list repaired: %s -> %s.',
+				$registerId,
+				json_encode($current),
+				json_encode($merged)
+			),
+			context: ['file' => __FILE__, 'line' => __LINE__, 'register' => $registerId]
+		);
+
+		return $merged;
+	}//end apply()
+
+	/**
+	 * Map every register id to the schema ids it has physical tables for.
+	 *
+	 * @return array<int, array<int, int>> registerId => [schemaId => live row count].
+	 */
+	private function physicalPairs(): array {
+		$pairs = [];
+		foreach ($this->shardTableNames() as $name) {
+			$offset = strpos($name, self::TABLE_MARKER);
+			if ($offset === false) {
+				continue;
+			}
+
+			$suffix = substr($name, ($offset + strlen(self::TABLE_MARKER)));
+			$parts  = explode('_', $suffix);
+			if (count($parts) !== 2 || ctype_digit($parts[0]) === false || ctype_digit($parts[1]) === false) {
+				continue;
+			}
+
+			$pairs[(int)$parts[0]][(int)$parts[1]] = $this->countRows(table: $name);
+		}
+
+		return $pairs;
+	}//end physicalPairs()
+
+	/**
+	 * List every shard table name.
+	 *
+	 * `information_schema.tables` is honoured by both PostgreSQL and MySQL, so no
+	 * per-platform branch is needed here.
+	 *
+	 * @return array<int, string> The table names.
+	 */
+	private function shardTableNames(): array {
+		try {
+			$stmt = $this->db->prepare(
+				'SELECT table_name FROM information_schema.tables WHERE table_name LIKE :pattern'
+			);
+			$stmt->bindValue('pattern', '%openregister\_table\_%');
+			$stmt->execute();
+		} catch (Throwable $e) {
+			$this->logger->warning(
+				message: '[RegisterSchemaLinkageRepair] Could not list tables: ' . $e->getMessage(),
+				context: ['file' => __FILE__, 'line' => __LINE__]
+			);
+			return [];
+		}
+
+		$names = [];
+		while (($row = $stmt->fetch(PDO::FETCH_ASSOC)) !== false) {
+			$name = (string)($row['table_name'] ?? ($row['TABLE_NAME'] ?? ''));
+			if ($name !== '') {
+				$names[] = $name;
+			}
+		}
+
+		return $names;
+	}//end shardTableNames()
+
+	/**
+	 * Count the live rows in a shard table.
+	 *
+	 * The name is re-validated against the strict shard pattern before it reaches
+	 * the statement. It arrives from `information_schema`, not from a caller, but
+	 * an identifier cannot be bound as a parameter, so the guard is what keeps this
+	 * from being an interpolation hazard if the source ever changes.
+	 *
+	 * @param string $table The shard table name.
+	 *
+	 * @return int The row count, or -1 when it could not be read.
+	 */
+	private function countRows(string $table): int {
+		if (preg_match('/^[A-Za-z0-9]+_openregister_table_[0-9]+_[0-9]+$/', $table) !== 1) {
+			return -1;
+		}
+
+		try {
+			$stmt   = $this->db->prepare('SELECT COUNT(*) AS c FROM ' . $table);
+			$stmt->execute();
+			$row = $stmt->fetch(PDO::FETCH_ASSOC);
+			return (int)($row['c'] ?? ($row['C'] ?? 0));
+		} catch (Throwable $e) {
+			return -1;
+		}
+	}//end countRows()
+
+	/**
+	 * Normalise a stored schemas value into a list of positive ints.
+	 *
+	 * @param mixed $candidates The stored value.
+	 *
+	 * @return int[] The normalised ids.
+	 */
+	private function normaliseIds(mixed $candidates): array {
+		$ids = [];
+		foreach ((array)$candidates as $candidate) {
+			if (is_numeric($candidate) === true && (int)$candidate > 0) {
+				$ids[] = (int)$candidate;
+			}
+		}
+
+		return array_values(array_unique($ids));
+	}//end normaliseIds()
+}//end class

--- a/openspec/changes/register-scoped-slug-resolution/.openspec.yaml
+++ b/openspec/changes/register-scoped-slug-resolution/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-16

--- a/openspec/changes/register-scoped-slug-resolution/design.md
+++ b/openspec/changes/register-scoped-slug-resolution/design.md
@@ -1,0 +1,155 @@
+## Context
+
+The scoped resolvers already exist. `SchemaMapper::findBySlugInIds()` and
+`findByApplicationAndSlug()` were added with the cross-app slug-collision work, and
+their docblocks describe the defect correctly. What did not land is the refusal:
+every caller treats a scoped miss as "try harder" rather than "stop".
+
+Two structural facts constrain any fix, and both were verified against the live
+schema rather than assumed:
+
+1. **`oc_openregister_schemas` has no register column.** The register→schema
+   relation is stored one-directionally, as a JSON id list on the register row. A
+   lost list therefore cannot be rebuilt from the schema side.
+2. **Objects are stored in per-pair tables**, `oc_openregister_table_<reg>_<schema>`.
+   3220 such tables exist. The table *name* is a durable record of a
+   register/schema pairing that was actually used.
+
+A third fact shapes the error semantics. The defect's observable symptom on the
+one affected register is not corrupted data — it is an **empty result set**.
+Schema `5084` (what global `find()` returns for `anonymizationLink`) has no table
+under register `6`, so a slug read returns nothing while four rows sit in
+`oc_openregister_table_6_9177`. An empty set is indistinguishable from "this
+register has no objects", which is why the defect survived unnoticed.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A named register is a boundary. Having named one, a caller cannot be served a
+  schema from outside it.
+- The failure is loud and actionable — it names the register, the slug, and the
+  repair command.
+- A register whose linkage was lost can be repaired from evidence, not guesswork.
+- Register-less callers are unaffected, keeping the blast radius minimal.
+
+**Non-Goals:**
+
+- Cleaning up duplicate schemas. Nine `anonymizationLink` rows exist and
+  `occ openregister:schemas:dedup` already owns that problem. Register scoping makes
+  the duplicates *harmless*, which is a better property than requiring them gone.
+- Changing `SchemaMapper::find()`'s global behaviour or its tie-break. Callers with
+  no register still need it, and its ordering was deliberately chosen.
+- Automatic repair. See the decision below.
+- Preventing an app from linking a schema to more than one register. That is legal
+  and used.
+
+## Decisions
+
+### D1 — Refuse at the call site, not inside `SchemaMapper`
+
+`SchemaMapper::find()` has no idea whether its caller holds a register. Pushing the
+refusal into the mapper would require threading register context through every
+overload and would change behaviour for callers that legitimately have none.
+
+The refusal therefore lives at the five sites that already *have* the register in
+hand and already call `findBySlugInIds()`. Each one currently follows the scoped
+call with a fallback; the change is to replace that fallback with a throw.
+
+This is why the spec enumerates the five call sites by name rather than stating the
+rule generally: a rule stated generally would be satisfied by four of five, and the
+fifth would silently keep the defect for whichever consumer uses it.
+
+### D2 — A new exception type, extending `DoesNotExistException`
+
+`SchemaNotInRegisterException extends DoesNotExistException`. Extending it preserves
+Nextcloud's existing dispatcher mapping to `404`, so no controller changes and no
+API contract change. Introducing a distinct type is what lets tests assert the
+*reason* rather than merely that something failed — and lets a caller distinguish
+"this register does not carry that slug" from "no such register".
+
+### D3 — Rebuild linkage from table names, and only from table names
+
+The repair enumerates `pg_stat_user_tables` (and the MySQL equivalent) for
+`oc_openregister_table_<register>_<schema>` and reports every schema id paired with
+the target register.
+
+Rejected alternatives:
+
+- *Match on slug similarity* — the reason we are here. Nine same-slug candidates.
+- *Match on `application` ownership* — all nine duplicates are owned by `docudesk`.
+  Ownership does not disambiguate.
+- *Re-import from the app's `{app}_register.json`* — plausible, but it describes
+  what the app *intends* now, not what the register actually holds. It would miss a
+  schema whose objects exist but which the app has since dropped from its manifest,
+  and that is precisely the data we must not orphan.
+
+Table names are the only source that records what was *actually used*.
+
+### D4 — Additive only, never subtractive
+
+The repair may add schema ids to a register's list; it may never remove one. A
+schema can legitimately be linked before its first object is written, so "no
+physical table" is not evidence of "not linked". Making the repair subtractive
+would let it delete correct configuration on the basis of an empty register.
+
+### D5 — Dry-run by default, `--write` to apply
+
+17 registers are eligible. Repairing them silently as a side effect of running a
+command is the same shape of surprise as resolving a slug into a foreign register.
+The operator sees the full list — register, ids to add, live row count per id — and
+then opts in.
+
+Row counts are printed because they distinguish strong evidence (a table with rows)
+from weak (an empty table left by a schema that was attached and never used). Both
+are recovered, but the operator can see which is which.
+
+### D6 — The error message carries the remedy
+
+The message names the register (id and slug), the requested slug, and how many
+same-slug schemas exist elsewhere, then names
+`occ openregister:registers:relink-schemas`.
+
+Without the count, a developer hitting this reads "schema not found" and concludes
+the slug is wrong — which is exactly the wrong conclusion when nine copies exist and
+the register's list is empty. The count converts a dead end into a diagnosis.
+
+## Declarative-vs-imperative decision (ADR-031)
+
+| Behaviour | Path | Rationale |
+|---|---|---|
+| Register-scoped slug resolution | **Imperative** | This is OpenRegister's own resolution core, below the layer `x-openregister-*` dialects operate on. A declarative dialect cannot express "how this platform resolves an identifier" without circularity. |
+| Linkage repair | **Imperative** | Operator-invoked maintenance reading the physical storage catalogue. Not a derived field, lifecycle, aggregation, notification, relation or widget. |
+
+Neither behaviour matches an ADR-031 declarative category, so no schema-register
+patch is appropriate and no `lib/Settings/*_register.json` is touched.
+
+## Seed Data (ADR-001)
+
+**None.** This change introduces and modifies no OpenRegister schemas, so there are
+no objects to seed and no `_registers.json` entries to generate. The fixtures it
+does need are test-only: a register with a populated `schemas` list, a register with
+an empty one, and a set of same-slug schemas — all constructed in PHPUnit, not
+seeded into an instance.
+
+## Risks / Trade-offs
+
+**A consumer relying on the fallback breaks.** Intended, and bounded to callers that
+supplied a register. The one known consumer is DocuDesk against register `6`, which
+the repair command fixes. Mitigation is ordering: repair first, then the refusal
+takes effect — and because the repair is a separate operator command, an
+administrator can run it before deploying.
+
+**The repair is Postgres-and-MySQL-specific.** It reads the table catalogue, so it
+needs a per-platform query. Contained to one service with a platform switch;
+verified on the Postgres instance available here, and the MySQL arm must be marked
+unverified rather than claimed if it is not exercised.
+
+**17 registers is a measurement of one instance, not a fleet fact.** Another
+deployment may have more or none. The command is written to report before acting
+precisely so this number never has to be trusted in advance.
+
+**An empty result set is a poor tripwire.** Nothing in the current test suite would
+have caught this, because "returns nothing" is a valid outcome. The new tests must
+assert the *identity* of the resolved schema, not merely that a call succeeded —
+asserting success would pass both before and after the fix.

--- a/openspec/changes/register-scoped-slug-resolution/proposal.md
+++ b/openspec/changes/register-scoped-slug-resolution/proposal.md
@@ -1,0 +1,104 @@
+---
+kind: code
+---
+
+## Why
+
+When an object operation carries a register context, a schema slug must resolve to
+the schema **that register references**. Today it does — but only when the lookup
+hits. Every one of the five scoped call sites falls back to the global
+`SchemaMapper::find()` on a miss, and `ObjectService::setSchema()` says so in its
+own comment: *"we transparently fall back to the global find for every legacy /
+register-less caller."*
+
+That fallback is not transparent. It resolves `LOWER(slug)` across every register
+and every application on the instance, and returns the first row its tie-break
+orders. Measured on the shared development instance (2026-08-16):
+
+| Fact | Measured value |
+|---|---|
+| Registers total | 406 |
+| Registers with an empty `schemas` list | 45 |
+| Physical `oc_openregister_table_<reg>_<schema>` pairs | 3220 |
+| Empty-list registers that nonetheless have physical tables | 17 |
+| Empty-list registers holding live rows | **1** |
+
+That one is DocuDesk's **Document Register (id 6)**. Its `schemas` list is `[]`,
+yet it owns three populated tables — schemas 9173 `customDictionary`,
+9174 `customDictionaryTerm`, 9177 `anonymizationLink`.
+
+Because the list is empty, `findBySlugInIds()` can never match, so every slug
+resolution against register 6 falls through. And the fallback does not merely pick
+a *foreign app's* schema — the instance carries **nine** `docudesk`-owned schemas
+with slug `anonymizationLink`. Replaying `find()`'s exact tie-break in SQL
+(app-owned first, then lowest id) returns schema **5084**:
+
+```
+SELECT id FROM oc_openregister_schemas WHERE lower(slug)='anonymizationlink'
+ORDER BY (CASE WHEN application IS NULL OR application='' THEN 1 ELSE 0 END), id LIMIT 1;
+-- 5084
+```
+
+Schema 5084 has **no table under register 6** at all (only under registers 7 and
+2483, both zero rows). The register's four real `anonymizationLink` objects live in
+`oc_openregister_table_6_9177`.
+
+So the present behaviour of a slug read against the Document Register is: **return
+empty**. Not an error, not foreign data — an empty result set that is
+indistinguishable from "this register has no objects". The four rows are simply
+unreachable by slug.
+
+The write direction is the dangerous half and is what surfaced this. DocuDesk's
+2026-08-15 audit write resolved `generatedDocument` globally onto a foreign
+schema and failed only because that schema's `required` fields were stricter. A
+schema with looser `required` would have accepted the row silently, into a
+register its owner never chose.
+
+## What Changes
+
+- **BREAKING (bounded):** when a register context is present, a schema-slug miss
+  inside that register's schema list MUST NOT fall back to global resolution. It
+  throws, naming the register and the slug. Register-less callers are untouched, so
+  the blast radius is exactly "callers that already supplied a register".
+- The five scoped call sites stop falling through:
+  `ObjectService::setSchema()`, `ObjectService::searchObjectsBySlug()`,
+  `Flow\Nodes\ObjectWriteNode`, `Flow\Nodes\ObjectReadNode`,
+  `Controller\SchemasController`.
+- A new `RegisterSchemaLinkageRepairService` reconstructs a register's `schemas`
+  list from the physical `oc_openregister_table_<register>_<schema>` tables — the
+  storage layout is itself an authoritative record of which pairs were ever used.
+  **A schema row carries no register column**, so this is the only recoverable
+  source; a schema-side back-fill is not possible.
+- A new `occ openregister:registers:relink-schemas` command exposes it, **dry-run
+  by default**, printing every register it would change and the ids it would add.
+- The exception message names the register, the slug, and the candidate schemas
+  that exist elsewhere — so the operator is told to run the repair rather than
+  left to guess.
+
+## Capabilities
+
+### New Capabilities
+- `register-scoped-slug-resolution`: how a schema slug resolves when a register
+  context is present, what happens when it misses, and how a register whose
+  `schemas` list was lost is repaired from physical storage.
+
+### Modified Capabilities
+- `objects-crud`: `searchObjectsBySlug` no longer resolves a schema slug outside
+  the named register.
+
+## Impact
+
+- **Code**: `lib/Service/ObjectService.php`, `lib/Service/Flow/Nodes/ObjectWriteNode.php`,
+  `lib/Service/Flow/Nodes/ObjectReadNode.php`, `lib/Controller/SchemasController.php`,
+  new `lib/Service/RegisterSchemaLinkageRepairService.php`, new
+  `lib/Command/RelinkRegisterSchemas.php`.
+- **Data**: no migration. The repair is an explicit operator command, never automatic
+  — a silent write to 17 registers is precisely the class of surprise this change exists
+  to remove.
+- **Consumers**: any app calling a register-scoped object API with a slug the register
+  does not carry now receives an exception instead of a foreign or empty result.
+  DocuDesk is the known affected consumer and is repaired by the command.
+- **Not addressed here**: the duplicate-schema population itself (nine
+  `anonymizationLink` rows). `occ openregister:schemas:dedup` already owns that
+  problem. Register-scoped resolution makes the duplicates harmless without
+  requiring them to be cleaned up first.

--- a/openspec/changes/register-scoped-slug-resolution/specs/objects-crud/spec.md
+++ b/openspec/changes/register-scoped-slug-resolution/specs/objects-crud/spec.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: `searchObjectsBySlug` MUST resolve the schema slug within the named register only
+
+`ObjectService::searchObjectsBySlug()` takes a register slug and a schema slug. It
+previously resolved the schema slug register-scoped first and fell back to a
+multi-tenancy-scoped global `SchemaMapper::find()` when the register did not carry
+the slug. That fallback MUST be removed.
+
+The organisation filter the fallback applied is not a sufficient guard: on the
+measured instance nine schemas with slug `anonymizationLink` are owned by the same
+application, so a same-organisation fallback still selects the wrong schema. The
+register is the only context that disambiguates them.
+
+When the named register carries no schema with the requested slug, the method MUST
+throw `SchemaNotInRegisterException` naming both slugs. The register-slug
+resolution itself is unchanged.
+
+#### Scenario: Searching a slug the register does not carry is refused
+
+- **GIVEN** register slug `document` resolves to register `6` carrying schemas `[9173, 9174, 9177]`
+- **AND** schema slug `generatedDocument` exists on the instance but not in register `6`
+- **WHEN** `searchObjectsBySlug('document', 'generatedDocument')` is called
+- **THEN** the method MUST throw `SchemaNotInRegisterException`
+- **AND** the message MUST name register `document` and schema `generatedDocument`
+- **AND** the method MUST NOT return results from a schema outside register `6`
+
+#### Scenario: Searching a slug the register carries returns that register's objects
+
+- **GIVEN** register `6` carries schema `9177` with slug `anonymizationLink`
+- **AND** `oc_openregister_table_6_9177` holds 4 rows
+- **WHEN** `searchObjectsBySlug('document', 'anonymizationLink')` is called
+- **THEN** the method MUST search schema `9177`
+- **AND** MUST return the 4 rows, rather than the empty set that schema `5084` would yield
+
+#### Scenario: An unknown register slug still throws its own error
+
+- **GIVEN** no register carries slug `nonexistent`
+- **WHEN** `searchObjectsBySlug('nonexistent', 'anything')` is called
+- **THEN** the method MUST throw the existing register-not-found `DoesNotExistException`
+- **AND** MUST NOT throw `SchemaNotInRegisterException`, because the failure is register resolution, not schema scoping

--- a/openspec/changes/register-scoped-slug-resolution/specs/register-scoped-slug-resolution/spec.md
+++ b/openspec/changes/register-scoped-slug-resolution/specs/register-scoped-slug-resolution/spec.md
@@ -1,0 +1,156 @@
+## ADDED Requirements
+
+### Requirement: A register-scoped schema-slug miss MUST NOT fall back to global resolution
+
+When a caller supplies a register context and identifies a schema by slug, the
+system MUST resolve that slug only among the schema ids the register carries. If
+no schema in that register carries the slug, the system MUST throw
+`SchemaNotInRegisterException` (extending `DoesNotExistException`, so existing
+`404` mapping is preserved) rather than calling `SchemaMapper::find()`.
+
+Global resolution remains the behaviour for callers that supply **no** register
+context. The change is scoped precisely to callers that already named a register:
+having named one, they MUST NOT be served a schema from outside it.
+
+The exception message MUST name the register (id and slug), the requested slug,
+and the count of same-slug schemas that exist elsewhere on the instance, and MUST
+direct the operator to `occ openregister:registers:relink-schemas`. A message that
+says only "schema not found" reproduces the defect's core harm — it is
+indistinguishable from the slug genuinely not existing.
+
+#### Scenario: A slug the register does not carry is refused, not resolved elsewhere
+
+- **GIVEN** register `document` (id 6) carries schemas `[9173, 9174, 9177]`
+- **AND** nine other schemas on the instance carry slug `anonymizationLink`, the lowest app-owned being id `5084`
+- **WHEN** a caller resolves slug `signingRequest` against register `document`
+- **THEN** the system MUST throw `SchemaNotInRegisterException`
+- **AND** the message MUST name register `document` (id 6) and slug `signingRequest`
+- **AND** `SchemaMapper::find()` MUST NOT be called
+
+#### Scenario: A slug the register does carry resolves to the register's own schema
+
+- **GIVEN** register `document` (id 6) carries schemas `[9173, 9174, 9177]`
+- **AND** schema `9177` carries slug `anonymizationLink`
+- **AND** schema `5084` also carries slug `anonymizationLink` and is the row global `find()` would return
+- **WHEN** a caller resolves slug `anonymizationLink` against register `document`
+- **THEN** the system MUST return schema `9177`, not `5084`
+
+#### Scenario: A register with an empty schemas list refuses every slug
+
+- **GIVEN** register `document` (id 6) has an empty `schemas` list
+- **WHEN** a caller resolves slug `anonymizationLink` against register `document`
+- **THEN** the system MUST throw `SchemaNotInRegisterException`
+- **AND** the message MUST state that the register carries no schemas and name the repair command
+- **AND** the system MUST NOT return schema `5084`
+
+#### Scenario: A register-less caller keeps global resolution
+
+- **GIVEN** a caller that supplies no register context
+- **WHEN** it resolves slug `anonymizationLink`
+- **THEN** the system MUST resolve through `SchemaMapper::find()` exactly as before
+- **AND** MUST NOT throw `SchemaNotInRegisterException`
+
+#### Scenario: A numeric id or uuid is unaffected by register scoping
+
+- **GIVEN** a caller supplies register `document` and schema identifier `5084` as a numeric id
+- **WHEN** the schema is resolved
+- **THEN** the system MUST resolve `5084` directly, because scoping applies to slug resolution only
+- **AND** MUST NOT throw merely because `5084` is absent from the register's list
+
+### Requirement: Every register-scoped call site MUST enforce the refusal
+
+The refusal MUST hold at every site that resolves a schema slug with a register in
+hand, so that no path retains the fallback:
+
+- `ObjectService::setSchema()`
+- `ObjectService::searchObjectsBySlug()`
+- `Service\Flow\Nodes\ObjectWriteNode`
+- `Service\Flow\Nodes\ObjectReadNode`
+- `Controller\SchemasController`
+
+A single retained fallback re-opens the defect for whichever consumer happens to
+use that path, so the requirement is enumerated by call site rather than stated
+generally.
+
+#### Scenario: The write path refuses rather than writing into a foreign schema
+
+- **GIVEN** register `document` carries no schema with slug `generatedDocument`
+- **AND** a schema `generatedDocument` owned by another application exists
+- **WHEN** an object write targets register `document` and schema slug `generatedDocument`
+- **THEN** the write MUST be refused with `SchemaNotInRegisterException`
+- **AND** no object row MUST be created in any table
+
+#### Scenario: The flow read node refuses rather than returning an empty set
+
+- **GIVEN** a flow `ObjectReadNode` targets register `document` with slug `anonymizationLink`
+- **AND** the register's `schemas` list is empty
+- **WHEN** the node runs
+- **THEN** the node MUST fail with `SchemaNotInRegisterException`
+- **AND** MUST NOT return an empty result set, which would be indistinguishable from "no objects exist"
+
+### Requirement: A lost register-schema linkage MUST be repairable from physical storage
+
+Because a schema row carries no register column, a register's `schemas` list cannot
+be reconstructed from the schema table. The system MUST reconstruct it instead from
+the physical object tables, whose names encode the pairing as
+`oc_openregister_table_<registerId>_<schemaId>`.
+
+The system MUST expose `RegisterSchemaLinkageRepairService` that, for a given
+register, returns every schema id having a physical table under that register, and
+MUST distinguish tables that hold rows from tables that are empty — an empty table
+is weaker evidence and the operator MUST be able to see the difference before
+acting.
+
+#### Scenario: Linkage is reconstructed for a register whose list was lost
+
+- **GIVEN** register `6` has an empty `schemas` list
+- **AND** tables `oc_openregister_table_6_9173`, `oc_openregister_table_6_9174` and `oc_openregister_table_6_9177` exist
+- **WHEN** the repair service inspects register `6`
+- **THEN** it MUST report schema ids `9173`, `9174` and `9177` as recoverable
+- **AND** MUST report the live row count for each
+
+#### Scenario: Repair reports nothing when there is no physical evidence
+
+- **GIVEN** a register with an empty `schemas` list and no `oc_openregister_table_<id>_*` tables
+- **WHEN** the repair service inspects it
+- **THEN** it MUST report zero recoverable schema ids
+- **AND** MUST NOT guess from slug similarity, application ownership, or any other heuristic
+
+#### Scenario: Repair never removes an existing linkage
+
+- **GIVEN** a register whose `schemas` list contains id `500`
+- **AND** no physical table `oc_openregister_table_<id>_500` exists
+- **WHEN** the repair runs
+- **THEN** id `500` MUST be retained in the list
+- **AND** the repair MUST only ever add ids, because a schema may be legitimately linked before its first object is written
+
+### Requirement: The repair command MUST be dry-run by default
+
+`occ openregister:registers:relink-schemas` MUST NOT write anything unless
+`--write` is passed explicitly. Without it, the command MUST print each affected
+register, the schema ids it would add, and each id's live row count, then exit
+without mutation.
+
+Writing to 17 registers as a side effect of a routine command is the same class of
+surprise this change removes; the operator MUST see the change before it happens.
+
+#### Scenario: Default invocation changes nothing
+
+- **GIVEN** 17 registers have recoverable linkage
+- **WHEN** `occ openregister:registers:relink-schemas` runs with no flags
+- **THEN** it MUST print all 17 registers with their recoverable ids and row counts
+- **AND** the `schemas` column of every register MUST be byte-identical afterwards
+
+#### Scenario: Explicit write applies exactly what the dry run printed
+
+- **GIVEN** a dry run reported register `6` gaining ids `9173`, `9174`, `9177`
+- **WHEN** the command runs again with `--write`
+- **THEN** register `6`'s `schemas` list MUST contain `9173`, `9174` and `9177`
+- **AND** the command MUST report the number of registers actually changed
+
+#### Scenario: A single register can be targeted
+
+- **GIVEN** the operator wants to repair only register `6`
+- **WHEN** `occ openregister:registers:relink-schemas --register=6 --write` runs
+- **THEN** only register `6` MUST be modified
+- **AND** the other 16 recoverable registers MUST be left unchanged

--- a/openspec/changes/register-scoped-slug-resolution/tasks.md
+++ b/openspec/changes/register-scoped-slug-resolution/tasks.md
@@ -1,0 +1,56 @@
+# Tasks
+
+## 1. Prove the defect before fixing it
+
+- [ ] Write a failing test asserting `searchObjectsBySlug('document','anonymizationLink')` resolves schema `9177`, not `5084` — and confirm it FAILS against unmodified code first
+- [ ] Write a failing test asserting a register-scoped miss throws instead of returning a foreign schema
+
+Acceptance criteria:
+- Both tests fail before any production code changes. A test that passes on unmodified code is measuring nothing.
+- The assertions check the resolved schema **id**, not merely that the call succeeded — success is the pre-fix behaviour too.
+
+## 2. The refusal
+
+- [ ] Add `SchemaNotInRegisterException extends DoesNotExistException`, carrying register id, register slug, requested slug and same-slug candidate count
+- [ ] Replace the global fallback with a throw in `ObjectService::setSchema()`
+- [ ] Replace the global fallback with a throw in `ObjectService::searchObjectsBySlug()`
+- [ ] Replace the global fallback with a throw in `Service\Flow\Nodes\ObjectWriteNode`
+- [ ] Replace the global fallback with a throw in `Service\Flow\Nodes\ObjectReadNode`
+- [ ] Replace the global fallback with a throw in `Controller\SchemasController`
+- [ ] Verify no register-scoped call site retains a fallback — grep every `findBySlugInIds` caller and confirm each one throws
+
+Acceptance criteria:
+- Register-less callers still reach `SchemaMapper::find()` unchanged.
+- Numeric ids and uuids bypass scoping entirely; only slug resolution is scoped.
+- The exception message names the register, the slug, the candidate count, and the repair command.
+
+## 3. Linkage repair
+
+- [ ] Add `RegisterSchemaLinkageRepairService` reconstructing a register's schema ids from `oc_openregister_table_<reg>_<schema>` names, reporting live row count per id
+- [ ] Add a platform switch so the catalogue query works on both Postgres and MySQL, and mark the MySQL arm unverified if it is not exercised
+- [ ] Add `occ openregister:registers:relink-schemas` — dry-run by default, `--write` to apply, `--register=<id>` to target one
+- [ ] Make the repair strictly additive — never remove an id already in a register's list
+
+Acceptance criteria:
+- Default invocation mutates nothing and prints register, ids-to-add and row counts.
+- `--write` applies exactly what the dry run printed.
+- A register with no physical tables yields zero recoverable ids and no guessing from slug or ownership.
+
+## 4. Tests
+
+- [ ] Unit tests for all five call sites: scoped hit resolves the register's schema, scoped miss throws, register-less caller unchanged, numeric id unaffected
+- [ ] Unit tests for the repair: reconstruction from table names, additive-only, empty-evidence case, dry-run mutates nothing
+- [ ] Playwright E2E proving the fix end to end against the real instance — read `anonymizationLink` from register `document` and get the 4 rows that are currently unreachable
+
+Acceptance criteria:
+- The E2E asserts the four rows are returned. Today it returns zero, so the test distinguishes fixed from broken.
+- `composer check:strict` passes; hydra gates measured against the base run, not against zero.
+
+## 5. Verify on real data
+
+- [ ] Run the dry run against the development instance and confirm it reports 17 registers, register `6` gaining `9173`/`9174`/`9177`
+- [ ] Apply `--write` to register `6` only, then confirm the slug read returns the 4 rows
+
+Acceptance criteria:
+- The measured numbers match the proposal's table, or the proposal is corrected to match reality.
+- Registers other than `6` are untouched by the targeted write.

--- a/openspec/specs/register-scoped-slug-resolution/spec.md
+++ b/openspec/specs/register-scoped-slug-resolution/spec.md
@@ -1,0 +1,76 @@
+---
+status: in-progress
+---
+
+# register-scoped-slug-resolution Specification
+
+**OpenSpec changes**
+- register-scoped-slug-resolution
+
+## Purpose
+
+Defines how a schema slug resolves when a caller supplies a register context, what
+happens when it does not resolve, and how a register whose `schemas` list has been
+lost is repaired from physical storage.
+
+Naming a register makes it a **boundary**. A caller that named one is never served a
+schema from outside it — not from another register, not from another application,
+and not from a same-slug duplicate within its own application. Global resolution
+remains available to callers that name no register.
+
+The behaviour matters because its failure is quiet. Measured on the development
+instance 2026-08-16: DocuDesk's Document Register (id 6) carried an empty `schemas`
+list while nine `docudesk`-owned schemas shared the slug `anonymizationLink`. Global
+resolution returned schema 5084, which has no table under register 6, so slug reads
+returned an **empty result set** while four rows sat unreachable in
+`oc_openregister_table_6_9177`. An empty result is indistinguishable from "this
+register holds no objects", which is why the defect went unnoticed.
+
+## Requirements
+
+### Requirement: A register-scoped schema-slug miss MUST NOT fall back to global resolution
+
+When a caller supplies a register context and identifies a schema by slug, the
+system MUST resolve that slug only among the schema ids the register carries, and
+MUST throw `SchemaNotInRegisterException` when none matches.
+
+The exception message MUST name the register, the requested slug, and the count of
+same-slug schemas elsewhere on the instance, and MUST name the repair command. A
+bare "schema not found" reads as "your slug is wrong", which is the one conclusion
+that is certainly false when duplicates demonstrably exist.
+
+#### Scenario: A slug the register does not carry is refused
+
+- **GIVEN** a register carrying schemas `[9173, 9174, 9177]`
+- **WHEN** a caller resolves a slug none of them carries
+- **THEN** the system MUST throw `SchemaNotInRegisterException`
+- **AND** MUST NOT call the global resolver
+
+#### Scenario: A register-less caller keeps global resolution
+
+- **GIVEN** a caller that supplies no register context
+- **WHEN** it resolves a schema slug
+- **THEN** the system MUST resolve globally exactly as before
+
+### Requirement: A lost register-schema linkage MUST be repairable from physical storage
+
+A schema row carries no register column, so a register's `schemas` list cannot be
+rebuilt from the schema table. The system MUST reconstruct it from the physical
+object tables, whose names encode the pairing as
+`oc_openregister_table_<registerId>_<schemaId>`.
+
+The repair MUST be additive only, MUST NOT infer linkage from slug similarity or
+application ownership, and MUST be exposed as an operator command that is dry-run by
+default.
+
+#### Scenario: Linkage is reconstructed from table names
+
+- **GIVEN** a register with an empty `schemas` list and physical tables for schemas `9173`, `9174`, `9177`
+- **WHEN** the repair inspects it
+- **THEN** it MUST report those three ids together with each one's live row count
+
+#### Scenario: The repair never removes an existing id
+
+- **GIVEN** a register carrying an id with no physical table
+- **WHEN** the repair runs
+- **THEN** that id MUST be retained, because a schema may be linked before its first object is written

--- a/tests/Unit/Service/ObjectServiceSearchBySlugTest.php
+++ b/tests/Unit/Service/ObjectServiceSearchBySlugTest.php
@@ -61,6 +61,7 @@ use OCA\OpenRegister\Service\ObjectSource\ObjectSourceRegistry;
 use OCA\OpenRegister\Service\OrganisationService;
 use OCA\OpenRegister\Service\SearchTrailService;
 use OCA\OpenRegister\Service\SettingsService;
+use OCA\OpenRegister\Exception\SchemaNotInRegisterException;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\IAppContainer;
 use OCP\IGroupManager;
@@ -153,6 +154,11 @@ class ObjectServiceSearchBySlugTest extends TestCase {
 		$register = new Register();
 		$register->setId(7);
 		$register->setSlug('openbuild');
+		// The register MUST carry the schema. This used to be left unset, and the
+		// test passed only because resolution fell through to the global
+		// SchemaMapper::find() — i.e. the assertion was green *because of* the
+		// defect. openspec/changes/register-scoped-slug-resolution.
+		$register->setSchemas([42]);
 
 		$schema = new Schema();
 		$schema->setId(42);
@@ -166,9 +172,12 @@ class ObjectServiceSearchBySlugTest extends TestCase {
 
 		$this->schemaMapper
 			->expects($this->once())
-			->method('find')
-			->with($this->equalTo('application'))
+			->method('findBySlugInIds')
+			->with($this->equalTo('application'), $this->equalTo([42]))
 			->willReturn($schema);
+
+		// The global resolver MUST NOT be reached: the caller named a register.
+		$this->schemaMapper->expects($this->never())->method('find');
 
 		$this->queryHandler
 			->expects($this->once())
@@ -224,15 +233,18 @@ class ObjectServiceSearchBySlugTest extends TestCase {
 	}//end testSearchObjectsBySlugThrowsWhenRegisterSlugUnknown()
 
 	/**
-	 * REQ: Unknown schema slug (with valid register) throws DoesNotExistException
-	 * identifying the schema slug — proves the exception chain rewraps the
-	 * underlying mapper exception so the caller can distinguish register-side
-	 * vs schema-side resolution failures.
+	 * REQ: A schema slug the named register does not carry is REFUSED — never
+	 * resolved globally.
+	 *
+	 * This test previously asserted the opposite: that resolution fell through to
+	 * `SchemaMapper::find()`, whose failure was rewrapped. That fallback is the
+	 * defect. openspec/changes/register-scoped-slug-resolution.
 	 */
-	public function testSearchObjectsBySlugThrowsWhenSchemaSlugUnknown(): void {
+	public function testSearchObjectsBySlugRefusesSchemaSlugOutsideTheRegister(): void {
 		$register = new Register();
 		$register->setId(7);
 		$register->setSlug('openbuild');
+		$register->setSchemas([42]);
 
 		$this->registerMapper
 			->expects($this->once())
@@ -241,15 +253,25 @@ class ObjectServiceSearchBySlugTest extends TestCase {
 
 		$this->schemaMapper
 			->expects($this->once())
-			->method('find')
-			->with($this->equalTo('ghost-schema'))
-			->willThrowException(new DoesNotExistException('not found'));
+			->method('findBySlugInIds')
+			->with($this->equalTo('ghost-schema'), $this->equalTo([42]))
+			->willReturn(null);
 
+		// Three same-slug schemas exist elsewhere. The count reaches the message so
+		// the operator is not told "your slug is wrong" when copies demonstrably exist.
+		$this->schemaMapper
+			->expects($this->once())
+			->method('countBySlug')
+			->with($this->equalTo('ghost-schema'))
+			->willReturn(3);
+
+		// The global resolver MUST NOT be consulted.
+		$this->schemaMapper->expects($this->never())->method('find');
 		$this->queryHandler->expects($this->never())->method('searchObjects');
 
-		$this->expectException(DoesNotExistException::class);
+		$this->expectException(SchemaNotInRegisterException::class);
 		$this->expectExceptionMessageMatches(
-			'/searchObjectsBySlug: schema slug not found.*ghost-schema/'
+			'/"ghost-schema" is not carried by register "openbuild" \(id 7\).*3 schema\(s\) elsewhere/s'
 		);
 
 		$this->service->searchObjectsBySlug(
@@ -258,6 +280,53 @@ class ObjectServiceSearchBySlugTest extends TestCase {
 			[]
 		);
 
-	}//end testSearchObjectsBySlugThrowsWhenSchemaSlugUnknown()
+	}//end testSearchObjectsBySlugRefusesSchemaSlugOutsideTheRegister()
+
+	/**
+	 * REQ: A register carrying NO schemas refuses every slug, with a message that
+	 * names the repair command.
+	 *
+	 * This is the shape that bit DocuDesk: register `document` (id 6) had an empty
+	 * schemas list while nine same-slug schemas existed, so the old fallback
+	 * resolved to a schema with no table under that register — returning an EMPTY
+	 * result set indistinguishable from "this register holds no objects".
+	 */
+	public function testSearchObjectsBySlugRefusesWhenRegisterCarriesNoSchemas(): void {
+		$register = new Register();
+		$register->setId(6);
+		$register->setSlug('document');
+		$register->setSchemas([]);
+
+		$this->registerMapper
+			->expects($this->once())
+			->method('find')
+			->willReturn($register);
+
+		$this->schemaMapper
+			->expects($this->once())
+			->method('findBySlugInIds')
+			->with($this->equalTo('anonymizationLink'), $this->equalTo([]))
+			->willReturn(null);
+
+		$this->schemaMapper
+			->expects($this->once())
+			->method('countBySlug')
+			->willReturn(9);
+
+		$this->schemaMapper->expects($this->never())->method('find');
+		$this->queryHandler->expects($this->never())->method('searchObjects');
+
+		$this->expectException(SchemaNotInRegisterException::class);
+		$this->expectExceptionMessageMatches(
+			'/carries no schemas at all.*9 schema\(s\) elsewhere.*relink-schemas/s'
+		);
+
+		$this->service->searchObjectsBySlug(
+			'document',
+			'anonymizationLink',
+			[]
+		);
+
+	}//end testSearchObjectsBySlugRefusesWhenRegisterCarriesNoSchemas()
 
 }//end class

--- a/tests/Unit/Service/RegisterSchemaLinkageRepairServiceTest.php
+++ b/tests/Unit/Service/RegisterSchemaLinkageRepairServiceTest.php
@@ -1,0 +1,289 @@
+<?php
+
+/**
+ * Unit tests for RegisterSchemaLinkageRepairService.
+ *
+ * openspec/changes/register-scoped-slug-resolution. Proves that a register whose
+ * `schemas` list was lost can be rebuilt from the physical per-pair object tables,
+ * and — just as important — that the rebuild never guesses and never subtracts.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service;
+
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Service\RegisterSchemaLinkageRepairService;
+use OCP\DB\IPreparedStatement;
+use OCP\IDBConnection;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests for the linkage repair service.
+ *
+ * Prepared statements are PHPUnit mocks rather than a hand-written fake: an
+ * `implements IPreparedStatement` double has to track that interface's exact
+ * signatures (`execute()` returns `IResult`, not `bool`), and a drifted double is
+ * a test failure that says nothing about the code under test.
+ */
+class RegisterSchemaLinkageRepairServiceTest extends TestCase {
+
+	/**
+	 * Build a prepared-statement mock yielding the given rows then false.
+	 *
+	 * @param array<int, array<string, mixed>> $rows The rows to yield.
+	 *
+	 * @return IPreparedStatement The mock.
+	 */
+	private function statement(array $rows): IPreparedStatement {
+		$stmt = $this->createMock(IPreparedStatement::class);
+
+		$queue = $rows;
+		$stmt->method('fetch')->willReturnCallback(
+			static function () use (&$queue): mixed {
+				$row = array_shift($queue);
+				return ($row ?? false);
+			}
+		);
+
+		return $stmt;
+	}//end statement()
+
+	/**
+	 * Build a service whose catalogue reports the given shard tables.
+	 *
+	 * @param array<int, string>        $tables    Shard table names.
+	 * @param array<string, int>        $rowCounts Table name => row count.
+	 * @param array<int, Register>      $registers Registers the mapper returns.
+	 * @param RegisterMapper|null       $mapperOut Receives the mapper, for assertions.
+	 *
+	 * @return RegisterSchemaLinkageRepairService The service.
+	 */
+	private function makeService(
+		array $tables,
+		array $rowCounts,
+		array $registers,
+		&$mapperOut=null,
+	): RegisterSchemaLinkageRepairService {
+		$db = $this->createMock(IDBConnection::class);
+		$db->method('prepare')->willReturnCallback(
+			function (string $sql) use ($tables, $rowCounts): IPreparedStatement {
+				if (str_contains($sql, 'information_schema.tables') === true) {
+					return $this->statement(
+						array_map(static fn (string $t): array => ['table_name' => $t], $tables)
+					);
+				}
+
+				foreach ($rowCounts as $table => $count) {
+					if (str_contains($sql, $table) === true) {
+						return $this->statement([['c' => $count]]);
+					}
+				}
+
+				return $this->statement([['c' => 0]]);
+			}
+		);
+
+		$mapper = $this->createMock(RegisterMapper::class);
+		$mapper->method('findAll')->willReturn($registers);
+		$mapperOut = $mapper;
+
+		return new RegisterSchemaLinkageRepairService(
+			db: $db,
+			registerMapper: $mapper,
+			logger: $this->createMock(LoggerInterface::class)
+		);
+	}//end makeService()
+
+	/**
+	 * Build a register.
+	 *
+	 * @param int        $id      The id.
+	 * @param string     $slug    The slug.
+	 * @param array|null $schemas The schemas list.
+	 *
+	 * @return Register The register.
+	 */
+	private function register(int $id, string $slug, ?array $schemas): Register {
+		$register = new Register();
+		$register->setId($id);
+		$register->setSlug($slug);
+		$register->setSchemas($schemas);
+		return $register;
+	}//end register()
+
+	/**
+	 * REQ: linkage is reconstructed for a register whose list was lost.
+	 *
+	 * The live shape from 2026-08-16: register 6 with an empty list and three
+	 * populated shard tables.
+	 *
+	 * @return void
+	 */
+	public function testReconstructsLostLinkageFromTableNames(): void {
+		$service = $this->makeService(
+			tables: [
+				'oc_openregister_table_6_9173',
+				'oc_openregister_table_6_9174',
+				'oc_openregister_table_6_9177',
+			],
+			rowCounts: [
+				'oc_openregister_table_6_9173' => 1,
+				'oc_openregister_table_6_9174' => 2,
+				'oc_openregister_table_6_9177' => 4,
+			],
+			registers: [$this->register(id: 6, slug: 'document', schemas: [])]
+		);
+
+		$report = $service->inspect();
+
+		$this->assertCount(1, $report);
+		$this->assertSame(6, $report[0]['registerId']);
+		$this->assertSame('document', $report[0]['registerSlug']);
+		$this->assertSame([9173, 9174, 9177], array_keys($report[0]['recoverable']));
+
+		// Row counts are reported so weak evidence (empty table) is visibly
+		// different from strong (a table holding rows).
+		$this->assertSame(4, $report[0]['recoverable'][9177]);
+	}//end testReconstructsLostLinkageFromTableNames()
+
+	/**
+	 * REQ: no physical evidence means no recovery, and NO guessing.
+	 *
+	 * The rejected heuristics are the point: slug similarity and application
+	 * ownership both failed on the live data (nine same-slug schemas, all owned by
+	 * `docudesk`), so absence of a table must yield nothing at all.
+	 *
+	 * @return void
+	 */
+	public function testReportsNothingWithoutPhysicalEvidence(): void {
+		$service = $this->makeService(
+			tables: ['oc_openregister_table_99_1'],
+			rowCounts: [],
+			registers: [$this->register(id: 6, slug: 'document', schemas: [])]
+		);
+
+		$this->assertSame([], $service->inspect());
+	}//end testReportsNothingWithoutPhysicalEvidence()
+
+	/**
+	 * REQ: a register already carrying the id is not reported again.
+	 *
+	 * @return void
+	 */
+	public function testAlreadyLinkedIdsAreNotProposed(): void {
+		$service = $this->makeService(
+			tables: ['oc_openregister_table_6_9177'],
+			rowCounts: ['oc_openregister_table_6_9177' => 4],
+			registers: [$this->register(id: 6, slug: 'document', schemas: [9177])]
+		);
+
+		$this->assertSame([], $service->inspect());
+	}//end testAlreadyLinkedIdsAreNotProposed()
+
+	/**
+	 * REQ: the repair is additive — an id with no physical table is retained.
+	 *
+	 * A schema may legitimately be linked before its first object is written, so a
+	 * missing table is not evidence of "not linked". A subtractive repair would
+	 * delete correct configuration from an unused register.
+	 *
+	 * @return void
+	 */
+	public function testRepairIsAdditiveAndNeverRemoves(): void {
+		$existing = $this->register(id: 6, slug: 'document', schemas: [500]);
+
+		$service = $this->makeService(
+			tables: ['oc_openregister_table_6_9177'],
+			rowCounts: ['oc_openregister_table_6_9177' => 4],
+			registers: [$existing],
+			mapperOut: $mapper
+		);
+
+		$mapper->method('find')->willReturn($existing);
+		$mapper->expects($this->once())->method('update')->with($existing);
+
+		$merged = $service->apply(registerId: 6, schemaIds: [9177]);
+
+		$this->assertSame([500, 9177], $merged, 'the pre-existing id 500 must survive the repair');
+		$this->assertSame([500, 9177], $existing->getSchemas());
+	}//end testRepairIsAdditiveAndNeverRemoves()
+
+	/**
+	 * REQ: applying the same repair twice does not duplicate ids.
+	 *
+	 * @return void
+	 */
+	public function testRepairIsIdempotent(): void {
+		$existing = $this->register(id: 6, slug: 'document', schemas: [9177]);
+
+		$service = $this->makeService(
+			tables: ['oc_openregister_table_6_9177'],
+			rowCounts: ['oc_openregister_table_6_9177' => 4],
+			registers: [$existing],
+			mapperOut: $mapper
+		);
+
+		$mapper->method('find')->willReturn($existing);
+
+		$this->assertSame([9177], $service->apply(registerId: 6, schemaIds: [9177]));
+	}//end testRepairIsIdempotent()
+
+	/**
+	 * REQ: a malformed shard-table name is ignored rather than mis-parsed.
+	 *
+	 * @return void
+	 */
+	public function testMalformedTableNamesAreIgnored(): void {
+		$service = $this->makeService(
+			tables: [
+				'oc_openregister_table_6_notanumber',
+				'oc_openregister_table_6',
+				'oc_openregister_table_6_9177_extra',
+				'oc_openregister_table_6_9177',
+			],
+			rowCounts: ['oc_openregister_table_6_9177' => 4],
+			registers: [$this->register(id: 6, slug: 'document', schemas: [])]
+		);
+
+		$report = $service->inspect();
+
+		$this->assertCount(1, $report);
+		$this->assertSame([9177], array_keys($report[0]['recoverable']));
+	}//end testMalformedTableNamesAreIgnored()
+
+	/**
+	 * REQ: a single register can be targeted, leaving the others alone.
+	 *
+	 * @return void
+	 */
+	public function testInspectCanTargetOneRegister(): void {
+		$service = $this->makeService(
+			tables: ['oc_openregister_table_6_9177', 'oc_openregister_table_7_5084'],
+			rowCounts: ['oc_openregister_table_6_9177' => 4, 'oc_openregister_table_7_5084' => 0],
+			registers: [
+				$this->register(id: 6, slug: 'document', schemas: []),
+				$this->register(id: 7, slug: 'openbuild', schemas: []),
+			]
+		);
+
+		$this->assertCount(2, $service->inspect());
+
+		$scoped = $service->inspect(registerId: 6);
+		$this->assertCount(1, $scoped);
+		$this->assertSame(6, $scoped[0]['registerId']);
+	}//end testInspectCanTargetOneRegister()
+}//end class


### PR DESCRIPTION
## The defect

When a caller supplies a register context, a schema slug resolved within that register on a hit — and fell back to the **global** `SchemaMapper::find()` on a miss. `ObjectService::setSchema()` called that fallback "transparent" in its own comment.

## Measured, not remembered

Development instance, 2026-08-16:

| Fact | Value |
|---|---|
| Registers | 406 |
| With an empty `schemas` list | 45 |
| Physical `oc_openregister_table_<reg>_<schema>` pairs | 3220 |
| Empty-list registers recoverable from those tables | 17 |
| Empty-list registers holding live rows | **1** |

That one is DocuDesk's **Document Register (id 6)** — empty list, three populated tables (schemas 9173, 9174, 9177).

**This was never a cross-app collision.** Nine `docudesk`-owned schemas share the slug `anonymizationLink`, so the organisation filter the old fallback applied could not disambiguate them.

Replaying `find()`'s tie-break in SQL returns schema **5084**, which has **no table under register 6 at all**:

```
oc_openregister_table_7_5084     0 rows
oc_openregister_table_2483_5084  0 rows
oc_openregister_table_6_9177     4 rows   <-- the register's real data
```

So a slug read against the Document Register returns an **empty result set** — indistinguishable from "this register holds no objects". That is why it went unnoticed. The write direction is the dangerous half: a foreign schema with looser `required` fields would have accepted the row silently.

## The fix

Having named a register, a caller is never served a schema from outside it. Register-less callers keep global resolution; numeric ids and uuids are unaffected, so the blast radius is exactly "callers that already named a register".

- `SchemaNotInRegisterException extends DoesNotExistException` — 404 mapping and API contract unchanged. The message carries the same-slug count and the repair command, because a bare "schema not found" reads as *"your slug is wrong"*, the one conclusion that is certainly false when nine copies exist.
- All five register-scoped call sites throw rather than fall through.
- `RegisterSchemaLinkageRepairService` rebuilds a lost list from **physical table names** — a schema row has no register column, so that is the only recoverable source. Slug similarity and application ownership were both rejected as evidence; all nine duplicates are owned by `docudesk`.
- `occ openregister:registers:relink-schemas` — dry-run by default, additive only, per-register targetable.

### One thing worth a reviewer's eye

In `SchemasController` the refusal had to move **outside** the existing `try/catch`. Thrown from inside, it would have been caught by that same handler and logged as "scope could not be applied" — silently restoring the exact fallback this PR removes. A no-op that looks like a fix.

## Verification

- **Two existing tests asserted the fallback** and now assert the boundary. They were green *because of* the defect: the fixture register had no schemas list. This is the positive control — the change is observable by the suite.
- Full unit suite re-run: **16461 tests, zero failures**.
- `phpcs`: 0 errors, 0 warnings on all new files.
- Inspection logic reproduced by an equivalent SQL query against live data (17 registers; register 6 → 9173/9174/9177).

## Explicitly not done

- **The duplicate-schema population.** `occ openregister:schemas:dedup` owns it. Register scoping makes the duplicates harmless without requiring them cleaned up first.
- **A live run of the `occ` command.** That needs a deployment; the shared checkout is on another workstream's branch. The inspection logic is verified by equivalent query, not by executing the command.

Spec: `openspec/changes/register-scoped-slug-resolution/`
