### PR TITLE
spec(rbac): consolidate permission handling into one evaluator

### DIFF
--- a/openspec/changes/consolidate-permission-handling/proposal.md
+++ b/openspec/changes/consolidate-permission-handling/proposal.md
@@ -1,0 +1,119 @@
+---
+kind: code
+---
+
+# Proposal: consolidate-permission-handling
+
+## Summary
+
+OpenRegister decides "may this caller do this" in **two independent places**
+that answer differently for the same request. Consolidate them behind one
+handler that honours the `public` and `authenticated` groups uniformly, so an
+anonymous call is permitted exactly when a schema or object says so — and
+refused everywhere else for the same reason.
+
+## Motivation
+
+The two planes are not a layering; they are a split that nobody chose.
+
+**Plane 1 — objects.** `Service/Object/PermissionHandler::hasPermission()` has
+a real anonymous branch. For a request with no user it evaluates the `public`
+group, and writes are separately fail-closed unless `public` explicitly grants
+the verb (#1955):
+
+```php
+// For unauthenticated requests, check if 'public' group has permission.
+return $this->hasGroupPermission(authorization: $authorization, groupId: 'public', …);
+```
+
+**Plane 2 — entities.** `Db/MultiTenancyTrait::hasRbacPermission()`, used by
+`RegisterMapper`, `SchemaMapper`, `AgentMapper`, `WebhookMapper`,
+`ApplicationMapper`, `SourceMapper`, `ViewMapper`, `ActionMapper`,
+`MappingMapper` and `EndpointMapper`, has no such branch:
+
+```php
+$userId = $this->getCurrentUserId();
+if ($userId === null) {
+    if (PHP_SAPI === 'cli') { return true; }
+    if (SystemOperationContext::isActive() === true) { return true; }
+    return false;                       // <- everything else, unconditionally
+}
+```
+
+An anonymous caller is denied **regardless of what any schema or object
+declares**. The `public` group cannot reach this plane at all, and the only
+escapes are full system trust.
+
+### Both confusing results this week came from that split
+
+* **opencatalogi serves anonymously and is correct to.** Measured live:
+  `publication/page` returns 7 rows and `publication/publication` 3 rows to a
+  caller with no session, because those schemas declare
+  `read: [{group: public, match: {status: published}}, "authenticated"]` and
+  plane 1 honours it. Nothing about that touches plane 2.
+
+* **portaliq's first file attach failed and looked like a missing machine
+  identity.** It was not. `FolderManagementHandler` lazily creates the
+  register's folder and persists the id with `registerMapper->update()`, which
+  enters plane 2 and is refused. Proven by measurement: the `portaliq` register
+  had `folder=''`; one admin-authenticated attach set `folder='179'`; the
+  anonymous path then worked and portaliq's e2e went to **57 passed / 1
+  skipped / 0 failed**. The symptom appeared on the FIRST write only, which is
+  why it read as a permission model problem rather than an initialisation one.
+
+Two planes meant the same question — "is this anonymous caller allowed?" — got
+answered by whichever code path the call happened to enter. That is not a
+policy; it is an accident of routing.
+
+## What this is NOT
+
+**Not a loosening.** `public` must stay something an author assigns
+deliberately. This change makes the `public` grant *reachable* on the entity
+plane; it does not grant anything by default, and absent authorization must
+keep meaning "no anonymous access" on both planes.
+
+**Not the `rbac-default-authenticated` flip.** That change decides what
+*absence* means. This one decides where *presence* is honoured. They touch the
+same code and must be sequenced, but they are separate decisions and should
+not be argued as one.
+
+## Proposal
+
+1. **One handler.** Entity-level checks call the same evaluator as object-level
+   checks. `MultiTenancyTrait::hasRbacPermission()` becomes a thin delegation
+   rather than a second implementation.
+
+2. **The anonymous branch is uniform.** A caller with no Nextcloud user is
+   evaluated against the `public` group on both planes. If a schema or object
+   grants `public` the verb, it is allowed; otherwise refused. Writes stay
+   fail-closed unless `public` explicitly names the write action.
+
+3. **Entity-level `public` is opt-in and rare.** Register/schema/agent entities
+   have no `authorization` block today, so under the consolidated handler they
+   are refused for anonymous callers exactly as they are now. Nothing changes
+   for them unless someone writes a rule — which is the point.
+
+4. **System trust stays narrow.** `PHP_SAPI === 'cli'` and
+   `SystemOperationContext::isActive()` remain the only blanket bypasses, and
+   this change must not add a third. In particular the portal file-attach path
+   should be fixed by initialising the register folder in a trusted context
+   (openregister#2515), NOT by widening trust on a public-facing write path.
+
+## Risks
+
+**The dangerous failure is silent and it is a LOOSENING.** A consolidation that
+accidentally lets the `public` group reach an entity verb it could not reach
+before turns an unauthenticated caller into an editor of registers or schemas.
+Every step needs the anonymous/authenticated PAIR measured, and the anonymous
+half asserted as a refusal with the rule absent.
+
+**The second failure is an outage that looks like a fix**: making both planes
+refuse where one used to allow would take opencatalogi's public surfaces off
+the air. `publication/page` returning 7 rows anonymously is the regression
+test, not a curiosity.
+
+## Sequencing
+
+Before `rbac-default-authenticated` Task 3. Flipping what absence means, while
+absence is still interpreted by two different code paths, doubles the surface
+on which that flip has to be reasoned about.

--- a/openspec/changes/consolidate-permission-handling/specs/consolidate-permission-handling/spec.md
+++ b/openspec/changes/consolidate-permission-handling/specs/consolidate-permission-handling/spec.md
@@ -1,0 +1,90 @@
+# Spec: consolidate-permission-handling
+
+## Requirement: one evaluator decides anonymous access on both planes
+
+OpenRegister MUST decide "may this caller perform this action" through a
+single evaluator, used by both the object-level path
+(`Service/Object/PermissionHandler`) and the entity-level path
+(`Db/MultiTenancyTrait`).
+
+Today they are independent. The object plane evaluates the `public` group for
+a caller with no Nextcloud user; the entity plane returns `false` for that
+caller unconditionally, with only `PHP_SAPI === 'cli'` and
+`SystemOperationContext::isActive()` as escapes. The same question therefore
+receives different answers depending on which code path a request happens to
+enter.
+
+### Scenario: an anonymous read of a schema granting `public`
+
+- **GIVEN** a schema whose authorization grants the `public` group `read`
+- **WHEN** a caller with no Nextcloud session reads its objects
+- **THEN** the rows are served
+
+### Scenario: an anonymous read of a schema NOT granting `public`
+
+- **GIVEN** a schema whose authorization does not grant `public` `read`
+- **WHEN** a caller with no Nextcloud session reads its objects
+- **THEN** no rows are served
+
+Both scenarios are required together. A change that served nothing to anybody
+would satisfy the second alone, and that failure is indistinguishable from a
+working access control until someone visits the site.
+
+### Scenario: an anonymous write is fail-closed unless explicitly granted
+
+- **GIVEN** a schema whose authorization grants `public` `read` but not
+  `create`, `update` or `delete`
+- **WHEN** a caller with no Nextcloud session attempts a write
+- **THEN** it is refused
+
+## Requirement: an entity may declare anonymous access, and it must be honoured
+
+The entity plane MUST evaluate the same groups as the object plane. An entity
+whose authorization grants `public` a verb permits an anonymous caller that
+verb; one that does not, refuses.
+
+This changes where a rule is HONOURED, not what a missing rule MEANS. Registers,
+schemas, agents, webhooks, applications, sources, views, actions, mappings and
+endpoints declare no authorization today, so every one of them MUST continue to
+refuse an anonymous caller after this change.
+
+### Scenario: an entity with no authorization block
+
+- **GIVEN** a register that declares no authorization
+- **WHEN** a caller with no Nextcloud session attempts to update it
+- **THEN** it is refused, exactly as before this change
+
+### Scenario: the blanket bypasses stay narrow
+
+- **GIVEN** the consolidated evaluator
+- **WHEN** its bypasses are enumerated
+- **THEN** they are exactly `PHP_SAPI === 'cli'` and
+  `SystemOperationContext::isActive()`
+
+A third blanket bypass MUST break a test. The failure this guards against is a
+public-facing write path being handed system trust to make a symptom go away —
+which replaces a refusal with a silent bypass and is worse than the bug.
+
+## Requirement: a refusal and a grant must both be observable
+
+A refusal MUST record which plane decided it and whether the cause was an
+absent rule or a rule that said no. Conflating those makes the audit useless
+exactly when it is needed — an operator debugging a 403 cannot tell
+"nobody configured this" from "this is configured to refuse you".
+
+### Scenario: distinguishing absence from refusal
+
+- **GIVEN** an anonymous caller refused at the entity plane
+- **WHEN** the refusal is recorded
+- **THEN** it names the entity type, the action, and whether any authorization
+  block existed at all
+
+### Scenario: the observability must not become a flood
+
+- **GIVEN** a list endpoint refusing many rows for one caller
+- **WHEN** the refusals are recorded
+- **THEN** they are emitted once per (entity type, action) per request, not
+  once per row
+
+An unthrottled line on a list endpoint is a log flood, and a flood is what gets
+logging switched off.

--- a/openspec/changes/consolidate-permission-handling/tasks.md
+++ b/openspec/changes/consolidate-permission-handling/tasks.md
@@ -1,0 +1,50 @@
+# Tasks: consolidate-permission-handling
+
+> One evaluator for "may this caller do this", honouring `public` and
+> `authenticated` uniformly on the object AND entity planes.
+>
+> ORDER IS LOAD-BEARING. Task 1 pins today's behaviour on both planes BEFORE
+> anything moves, because this change's dangerous failure is a silent
+> LOOSENING and there is currently no test that would notice one.
+
+## Implementation Tasks
+
+### Task 1: Pin the CURRENT behaviour of both planes, by measurement
+- **spec_ref**: `openspec/changes/consolidate-permission-handling/specs/consolidate-permission-handling/spec.md#requirement-one-evaluator-decides-anonymous-access-on-both-planes`
+- **files**: `tests/Unit/Service/Object/PermissionHandlerTest.php`, `tests/Unit/Db/MultiTenancyTraitTest.php`
+- **acceptance_criteria**:
+  - The object plane's anonymous branch is pinned as a PAIR per verb: a schema granting `public` `read` serves an anonymous caller rows; the same schema without that grant serves none. A test that asserts only the refusal passes just as well when everything is refused.
+  - The entity plane's anonymous refusal is pinned for each mapper that uses `verifyRbacPermission()` — register, schema, agent, webhook, application, source, view, action, mapping, endpoint — so a consolidation that quietly widens ONE of them fails.
+  - The two blanket bypasses (`PHP_SAPI === 'cli'`, `SystemOperationContext::isActive()`) are pinned as the ONLY ones. A third arriving later must break a test.
+- [ ] Implement
+- [ ] Test
+
+### Task 2: Extract the evaluator
+- **spec_ref**: `openspec/changes/consolidate-permission-handling/specs/consolidate-permission-handling/spec.md#requirement-one-evaluator-decides-anonymous-access-on-both-planes`
+- **files**: `lib/Service/Object/PermissionHandler.php`, new shared evaluator, `lib/Db/MultiTenancyTrait.php`
+- **acceptance_criteria**:
+  - One function answers "does this authorization block grant this group this verb", and both planes call it. `MultiTenancyTrait::hasRbacPermission()` becomes delegation, not a second implementation.
+  - Task 1's tests pass UNCHANGED. This step is a refactor: if a behaviour test needed editing here, the extraction changed behaviour and the diff is wrong.
+  - The anonymous fail-closed write rule (#1955) lives in the shared evaluator, so it cannot be honoured on one plane and forgotten on the other — which is the class of bug this whole change exists to remove.
+- [ ] Implement
+- [ ] Test
+
+### Task 3: Honour `public` on the entity plane
+- **spec_ref**: `openspec/changes/consolidate-permission-handling/specs/consolidate-permission-handling/spec.md#requirement-an-entity-may-declare-anonymous-access-and-it-must-be-honoured`
+- **files**: `lib/Db/MultiTenancyTrait.php`, entity mappers, tests
+- **acceptance_criteria**:
+  - An entity whose authorization grants `public` a verb permits an anonymous caller that verb; one that does not still refuses. Asserted as a pair, per verb.
+  - **No entity gains access by this change.** Register/schema/agent entities declare no authorization today, so every one of them must still refuse an anonymous caller afterwards — asserted by name, not by count. A count passes while the wrong entity opened.
+  - opencatalogi's public surfaces are unaffected: `publication/page` and `publication/publication` still serve an anonymous caller the same row counts as before (7 and 3 on the reference instance). This is the outage tripwire.
+- [ ] Implement
+- [ ] Test
+
+### Task 4: Prove it on a live instance, both directions
+- **spec_ref**: `openspec/changes/consolidate-permission-handling/specs/consolidate-permission-handling/spec.md#requirement-a-refusal-and-a-grant-must-both-be-observable`
+- **files**: e2e / integration coverage
+- **acceptance_criteria**:
+  - Measured on a running instance, not only in unit doubles: an anonymous read of a `public` schema returns rows, an anonymous write to it is refused, and an anonymous register update is refused. A guard nobody has watched refuse is a guard nobody has tested.
+  - The portal file-attach path works for a portal-JWT caller once the register folder is initialised, WITHOUT widening system trust — the fix belongs in folder initialisation (openregister#2515), and this task asserts the permission model did not paper over it.
+  - A refusal that came from the shared evaluator says which plane and which rule it came from, so an operator can tell "no rule" from "rule said no".
+- [ ] Implement
+- [ ] Test


### PR DESCRIPTION
OpenRegister decides *"may this caller do this"* in **two independent places that answer differently for the same request**.

| plane | anonymous behaviour |
|---|---|
| `Service/Object/PermissionHandler::hasPermission()` | evaluates the **`public` group**; writes separately fail-closed (#1955) |
| `Db/MultiTenancyTrait::hasRbacPermission()` (10 entity mappers) | refuses **unconditionally**; `public` cannot reach this plane at all |

## Both of this week’s confusing results came from that split

- **opencatalogi serves anonymously and is right to.** Measured live: `publication/page` → 7 rows, `publication/publication` → 3 rows for a caller with no session, because those schemas grant `public` `read` and plane 1 honours it. Plane 2 is never involved.
- **portaliq’s first file attach failed and read as a missing machine identity.** It was not. `FolderManagementHandler` lazily persists the register’s folder id via `registerMapper->update()`, which enters plane 2. Proven by measurement — the register had `folder=''`; one admin-authenticated attach set `folder='179'`; the anonymous path then worked and portaliq’s e2e went to **57 passed / 1 skipped / 0 failed**. First-write-only, which is exactly why it looked like a permission-model problem instead of an initialisation one.

The same question got whichever answer the routing produced. That is not a policy; it is an accident of routing.

## What this is NOT

- **Not a loosening.** It changes where a rule is *honoured*, not what a missing rule *means*. Entities declare no authorization today, so **every one must still refuse an anonymous caller afterwards** — asserted by name, not by count, because a count passes while the wrong entity opens.
- **Not the `rbac-default-authenticated` flip.** That decides what *absence* means. Same code, separate decision, and this one should land first — flipping absence while absence is interpreted by two code paths doubles the surface to reason about.

## Risk shape

The dangerous failure is a **silent loosening**, and nothing today would notice one — so Task 1 pins current behaviour on *both* planes before anything moves, including that `PHP_SAPI === 'cli'` and `SystemOperationContext::isActive()` are the **only** blanket bypasses (a third must break a test).

The opposite failure is an outage that looks like a fix: making both planes refuse where one used to allow takes opencatalogi’s public surfaces off the air. Its anonymous row counts are the tripwire.

Spec only — proposal, spec and tasks. No code.