### PR TITLE
fix(import): one rejected schema detached a whole register

### DIFF
--- a/lib/Service/Configuration/ImportHandler.php
+++ b/lib/Service/Configuration/ImportHandler.php
@@ -2000,7 +2000,9 @@ class ImportHandler {
 	 *     mappings: array<Mapping>,
 	 *     jobs: array,
 	 *     synchronizations: array,
-	 *     rules: array
+	 *     rules: array,
+	 *     skipped: array{registers: int, schemas: int, objects: int, mappings: int, seedObjects: int},
+	 *     failed: array{schemas: list<array{key: string, slug: string, error: string}>}
 	 * }
 	 *
 	 * @SuppressWarnings(PHPMD.BooleanArgumentFlag)   Force flag to override version checks
@@ -2093,6 +2095,10 @@ class ImportHandler {
 				);
 
 				// Return empty result to indicate no import was performed.
+				// The `skipped`/`failed` keys are present and zeroed on this path
+				// too: a caller that reads them must not have to know which return
+				// it got, and "nothing was imported" is not the same answer as
+				// "something was rejected".
 				return [
 					'registers' => [],
 					'schemas' => [],
@@ -2104,6 +2110,14 @@ class ImportHandler {
 					'synchronizations' => [],
 					'rules' => [],
 					'objects' => [],
+					'skipped' => [
+						'registers' => 0,
+						'schemas' => 0,
+						'objects' => 0,
+						'mappings' => 0,
+						'seedObjects' => 0,
+					],
+					'failed' => ['schemas' => []],
 				];
 			}//end if
 		}//end if
@@ -2133,9 +2147,19 @@ class ImportHandler {
 			// skipped (with a logged warning) instead of aborting the import.
 			'skipped' => [
 				'registers' => 0,
+				'schemas' => 0,
 				'objects' => 0,
 				'mappings' => 0,
 				'seedObjects' => 0,
+			],
+			// The entities this import REJECTED, named with the reason. A count
+			// alone tells an operator something went wrong but not what, and a
+			// rejected SCHEMA is the one failure that propagates: the registers
+			// that declare it are created without the link, so the damage
+			// surfaces layers away (empty `*_schema` config keys, a seed step
+			// that cannot resolve a schema) with nothing pointing back here.
+			'failed' => [
+				'schemas' => [],
 			],
 		];
 
@@ -2187,12 +2211,26 @@ class ImportHandler {
 					$schemaData['title'] = $key;
 				}
 
+				// Blanking `schemasMap` is a TEMPORARY mutation of shared state
+				// whose only purpose is to stop importSchema() resolving $refs in
+				// Pass 1. Its undo therefore belongs to leaving this region — on
+				// EVERY path — which is what `finally` is for.
+				//
+				// 🔴 It used to be undone on the success path only. One rejected
+				// schema then left the map empty for everything that followed, so
+				// each later schema re-saved an already-emptied map and the map
+				// ended Pass 1 holding ONLY the schemas declared after the LAST
+				// failure. The register pass resolves its slugs against that map,
+				// finds nothing, and creates the register WITHOUT those links.
+				// The fingerprint is arithmetic: in softwarecatalog 2 rejected
+				// schemas produced 18 missing register<->schema links out of 20.
+				// See ImportHandlerSchemaMapRestoreTest.
+				$savedSchemasMap = $this->schemasMap;
+				$this->schemasMap = [];
+				$schema = null;
+
 				try {
 					// Create schema without resolving cross-references.
-					// We'll temporarily skip schema lookups in importSchema by clearing the schemasMap.
-					$savedSchemasMap = $this->schemasMap;
-					$this->schemasMap = [];
-					// Temporarily empty to prevent $ref resolution.
 					$schemaSlugLower = strtolower((string)($schemaData['slug'] ?? $key));
 					$schema = $this->importSchema(
 						data: $schemaData,
@@ -2203,24 +2241,16 @@ class ImportHandler {
 						force: $force,
 						registerSchemaIds: $slugToSchemaIds[$schemaSlugLower] ?? null
 					);
-
-					// Restore schemasMap and add newly created schema.
-					$this->schemasMap = $savedSchemasMap;
-					$this->schemasMap[$schema->getSlug()] = $schema;
-					$result['schemas'][] = $schema;
-					$schemasToResolve[$key] = $schemaData;
-					// Save for Pass 2.
-					$this->logger->debug(
-						message: '[ImportHandler] Successfully created schema (Pass 1)',
-						context: [
-							'file' => __FILE__,
-							'line' => __LINE__,
-							'schemaKey' => $key,
-							'schemaSlug' => $schema->getSlug(),
-							'schemaId' => $schema->getId(),
-						]
-					);
 				} catch (Exception $e) {
+					// A rejected schema is CONTAINED (siblings still import) but it
+					// is never silent: it is counted and NAMED in the result, so the
+					// operator sees it here rather than three layers downstream.
+					$result['skipped']['schemas']++;
+					$result['failed']['schemas'][] = [
+						'key' => (string)$key,
+						'slug' => (string)($schemaData['slug'] ?? $key),
+						'error' => $e->getMessage(),
+					];
 					$this->logger->error(
 						message: '[ImportHandler] Failed to create schema (Pass 1)',
 						context: [
@@ -2232,8 +2262,55 @@ class ImportHandler {
 						]
 					);
 					// Continue with other schemas instead of failing the entire import.
+				} finally {
+					// Restore on every path — success, rejection, or an \Error
+					// escaping this loop entirely.
+					$this->schemasMap = $savedSchemasMap;
 				}//end try
+
+				if ($schema === null) {
+					continue;
+				}
+
+				$this->schemasMap[$schema->getSlug()] = $schema;
+				$result['schemas'][] = $schema;
+				$schemasToResolve[$key] = $schemaData;
+				// Save for Pass 2.
+				$this->logger->debug(
+					message: '[ImportHandler] Successfully created schema (Pass 1)',
+					context: [
+						'file' => __FILE__,
+						'line' => __LINE__,
+						'schemaKey' => $key,
+						'schemaSlug' => $schema->getSlug(),
+						'schemaId' => $schema->getId(),
+					]
+				);
 			}//end foreach
+
+			// One warning naming every rejected schema, at the end of the pass.
+			// The per-schema `error` lines above are one line each in a log that
+			// is otherwise almost all `debug`, so on a real import they are easy
+			// to miss; this is the line that says the import was PARTIAL.
+			if ($result['failed']['schemas'] !== []) {
+				$rejectedSlugs = array_column($result['failed']['schemas'], 'slug');
+				$this->logger->warning(
+					message: sprintf(
+						'[ImportHandler] PARTIAL IMPORT: %d of %d schema(s) were rejected and are NOT '
+						. 'linked to any register in this import: %s. Registers declaring them were '
+						. 'created without those schema references.',
+						count($rejectedSlugs),
+						count($data['components']['schemas']),
+						implode(', ', $rejectedSlugs)
+					),
+					context: [
+						'file' => __FILE__,
+						'line' => __LINE__,
+						'appId' => $appId,
+						'failedSchemas' => $result['failed']['schemas'],
+					]
+				);
+			}
 
 			$this->logger->debug(
 				message: '[ImportHandler] Pass 1 completed - all schemas created',
@@ -2359,11 +2436,27 @@ class ImportHandler {
 							continue;
 						}
 
-						// Schema not in map - this should not happen after TWO-PASS schema import.
-						// Log a warning but don't try to look it up in database as that may fail due to
-						// organisation/multi-tenancy filters during cross-instance imports.
+						// Schema not in map. Since the Pass-1 restore fix this has
+						// exactly ONE cause — the schema pass rejected it — so name
+						// that reason here instead of leaving the operator to
+						// correlate two log lines. Do not fall back to a database
+						// lookup: it may fail on organisation/multi-tenancy filters
+						// during cross-instance imports.
+						$rejection = null;
+						foreach ($result['failed']['schemas'] as $failedSchema) {
+							if ($failedSchema['slug'] === $schemaSlug || $failedSchema['key'] === $schemaSlug) {
+								$rejection = $failedSchema['error'];
+								break;
+							}
+						}
+
+						$reason = 'This schema should have been created in the TWO-PASS schema import phase. ';
+						if ($rejection !== null) {
+							$reason = 'It was REJECTED by the schema import phase (' . $rejection . '). ';
+						}
+
 						$msg = 'Schema with slug %s not found in schemasMap during register import. ';
-						$msg .= 'This schema should have been created in the TWO-PASS schema import phase. ';
+						$msg .= $reason;
 						$msg .= 'This register will be created without this schema reference.';
 						$this->logger->warning(
 							message: '[ImportHandler] ' . sprintf($msg, $schemaSlug),

--- a/tests/Unit/Service/Configuration/ImportHandlerSchemaMapRestoreTest.php
+++ b/tests/Unit/Service/Configuration/ImportHandlerSchemaMapRestoreTest.php
@@ -1,0 +1,440 @@
+<?php
+
+/**
+ * One rejected schema must not detach the register from every schema before it.
+ *
+ * Locks the defect found while diagnosing why softwarecatalog's E2E job ran ZERO
+ * tests for two days: `importFromJson()`'s Pass-1 loop blanks `$this->schemasMap`
+ * before every `importSchema()` call and restores it on the SUCCESS path only.
+ * When a schema is rejected the `catch` leaves the map empty, so every schema
+ * imported BEFORE the failure is evicted from it. The register pass then resolves
+ * its schema slugs against that map, finds nothing, and creates the register
+ * WITHOUT those links — a fully detached register from a single bad schema.
+ *
+ * The fingerprint is arithmetic, which is what makes it provable: in
+ * softwarecatalog 2 rejected schemas produced 18 missing register<->schema links,
+ * and the survivors were exactly the schemas declared AFTER the last failing one.
+ * These tests assert that arithmetic, with the boundary at the last failure.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Configuration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Configuration;
+
+use Exception;
+use GuzzleHttp\Client;
+use OCA\OpenRegister\Db\Configuration;
+use OCA\OpenRegister\Db\ConfigurationMapper;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\MappingMapper;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Configuration\ImportHandler;
+use OCA\OpenRegister\Service\Configuration\UploadHandler;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IAppConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Regression tests for the schemasMap save/restore around importSchema().
+ */
+class ImportHandlerSchemaMapRestoreTest extends TestCase {
+
+	/**
+	 * Total schemas the fixture configuration declares.
+	 *
+	 * @var integer
+	 */
+	private const TOTAL_SCHEMAS = 20;
+
+	/**
+	 * 1-based positions of the two schemas the mapper rejects.
+	 *
+	 * Mirrors softwarecatalog: two bad `objectDescriptionField` values, the
+	 * later of which sits near the end of the declaration order so that the
+	 * amplification is unmistakable.
+	 *
+	 * @var integer[]
+	 */
+	private const FAILING_POSITIONS = [7, 18];
+
+	private SchemaMapper&MockObject $schemaMapper;
+
+	private RegisterMapper&MockObject $registerMapper;
+
+	private MagicMapper&MockObject $objectEntityMapper;
+
+	private ConfigurationMapper&MockObject $configurationMapper;
+
+	private MappingMapper&MockObject $mappingMapper;
+
+	private Client&MockObject $client;
+
+	private IAppConfig&MockObject $appConfig;
+
+	private LoggerInterface&MockObject $logger;
+
+	private UploadHandler&MockObject $uploadHandler;
+
+	private ObjectService&MockObject $objectService;
+
+	private ImportHandler $handler;
+
+	/**
+	 * Schema slugs the register was actually linked to, captured from the
+	 * register the mapper was asked to persist.
+	 *
+	 * @var string[]
+	 */
+	private array $linkedSchemaIds = [];
+
+	/**
+	 * Next schema id to hand out, so every created schema has a distinct id.
+	 *
+	 * @var integer
+	 */
+	private int $nextSchemaId = 100;
+
+	/**
+	 * Schema id => slug, so a captured register id list can be read as slugs.
+	 *
+	 * @var array<int, string>
+	 */
+	private array $slugForSchemaId = [];
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->schemaMapper = $this->createMock(SchemaMapper::class);
+		$this->registerMapper = $this->createMock(RegisterMapper::class);
+		$this->objectEntityMapper = $this->createMock(MagicMapper::class);
+		$this->configurationMapper = $this->createMock(ConfigurationMapper::class);
+		$this->mappingMapper = $this->createMock(MappingMapper::class);
+		$this->client = $this->createMock(Client::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->uploadHandler = $this->createMock(UploadHandler::class);
+		$this->objectService = $this->createMock(ObjectService::class);
+
+		// No previously-imported version -> never skip on the version check.
+		$this->appConfig->method('getValueString')->willReturn('');
+		$this->schemaMapper->method('getSlugToIdMap')->willReturn([]);
+		$this->registerMapper->method('getSlugToIdMap')->willReturn([]);
+		$this->mappingMapper->method('getSlugToIdMap')->willReturn([]);
+
+		// Nothing exists yet: a fresh instance importing an app's configuration.
+		$this->registerMapper->method('find')
+			->willThrowException(new DoesNotExistException('not found'));
+		$this->schemaMapper->method('find')
+			->willThrowException(new DoesNotExistException('not found'));
+		$this->schemaMapper->method('findBySlugInIds')->willReturn(null);
+		$this->schemaMapper->method('findByApplicationAndSlug')->willReturn(null);
+
+		// The rejection mechanism is the REAL one: SchemaMapper::createFromArray()
+		// runs validateConfigurationFields(), which throws when
+		// `configuration.objectDescriptionField` names a property the schema does
+		// not declare. This callback mirrors that rule and its exact message.
+		$this->schemaMapper->method('createFromArray')
+			->willReturnCallback(function (array $data): Schema {
+				$this->assertConfigurationFields($data);
+				return $this->makeSchema($data['slug']);
+			});
+		$this->schemaMapper->method('updateFromArray')
+			->willReturnCallback(function (int $id, array $data): Schema {
+				$this->assertConfigurationFields($data);
+				return $this->makeSchema($data['slug'], $id);
+			});
+		$this->schemaMapper->method('update')->willReturnArgument(0);
+
+		// Capture the resolved schema id list the register is created with.
+		$this->registerMapper->method('createFromArray')
+			->willReturnCallback(function (array $data): Register {
+				$this->linkedSchemaIds = ($data['schemas'] ?? []);
+				$register = new Register();
+				$register->hydrate(['slug' => $data['slug'], 'version' => '1.0.0']);
+				$register->setId(1);
+				return $register;
+			});
+		$this->registerMapper->method('update')->willReturnArgument(0);
+
+		$this->handler = new ImportHandler(
+			schemaMapper:        $this->schemaMapper,
+			registerMapper:      $this->registerMapper,
+			objectEntityMapper:  $this->objectEntityMapper,
+			configurationMapper: $this->configurationMapper,
+			mappingMapper:       $this->mappingMapper,
+			client:              $this->client,
+			appConfig:           $this->appConfig,
+			logger:              $this->logger,
+			appDataPath:         '/tmp',
+			uploadHandler:       $this->uploadHandler,
+			objectService:       $this->objectService
+		);
+	}//end setUp()
+
+	/**
+	 * Transcription of SchemaMapper::validateConfigurationFields() for the
+	 * simple (non-template, non-pipe) case the fixture uses.
+	 *
+	 * @param array $data The schema payload handed to the mapper.
+	 *
+	 * @throws Exception When objectDescriptionField names an absent property.
+	 *
+	 * @return void
+	 */
+	private function assertConfigurationFields(array $data): void {
+		$field = ($data['configuration']['objectDescriptionField'] ?? '');
+		if ($field === '') {
+			return;
+		}
+
+		$propertyKeys = array_keys($data['properties'] ?? []);
+		if (in_array($field, $propertyKeys, true) === false) {
+			throw new Exception(
+				"The value for objectDescriptionField ('{$field}') does not exist as a property in the schema."
+			);
+		}
+	}//end assertConfigurationFields()
+
+	/**
+	 * Build a hydrated Schema entity, remembering its id -> slug mapping.
+	 *
+	 * @param string       $slug The schema slug.
+	 * @param integer|null $id   An explicit id, or null to allocate one.
+	 *
+	 * @return Schema
+	 */
+	private function makeSchema(string $slug, ?int $id = null): Schema {
+		if ($id === null) {
+			$id = $this->nextSchemaId;
+			$this->nextSchemaId++;
+		}
+
+		$schema = new Schema();
+		$schema->hydrate(['slug' => $slug, 'title' => $slug, 'version' => '1.0.0', 'properties' => []]);
+		$schema->setId($id);
+		$this->slugForSchemaId[$id] = $slug;
+		return $schema;
+	}//end makeSchema()
+
+	/**
+	 * The fixture: 20 schemas in declaration order, two of which carry an
+	 * `objectDescriptionField` naming a property they do not declare, plus one
+	 * register declaring all 20 slugs.
+	 *
+	 * @return array
+	 */
+	private function configuration(): array {
+		$schemas = [];
+		$slugs = [];
+		for ($position = 1; $position <= self::TOTAL_SCHEMAS; $position++) {
+			$slug = sprintf('schema%02d', $position);
+			$slugs[] = $slug;
+			$schemas[$slug] = [
+				'slug' => $slug,
+				'title' => 'Schema ' . $position,
+				'version' => '1.0.0',
+				'properties' => ['name' => ['type' => 'string']],
+			];
+
+			if (in_array($position, self::FAILING_POSITIONS, true) === true) {
+				// `summary` is not among this schema's properties — the exact
+				// shape that rejected softwarecatalog's `view` and `bioMeasure`.
+				$schemas[$slug]['configuration'] = ['objectDescriptionField' => 'summary'];
+			}
+		}
+
+		return [
+			'appId' => 'softwarecatalog',
+			'version' => '9.9.9',
+			'components' => [
+				'schemas' => $schemas,
+				'registers' => [
+					'catalog' => ['slug' => 'catalog', 'version' => '1.0.0', 'schemas' => $slugs],
+				],
+			],
+		];
+	}//end configuration()
+
+	/**
+	 * Slugs of the schemas the register ended up linked to.
+	 *
+	 * @return string[]
+	 */
+	private function linkedSlugs(): array {
+		$slugs = [];
+		foreach ($this->linkedSchemaIds as $id) {
+			$slugs[] = ($this->slugForSchemaId[(int)$id] ?? ('unknown-' . $id));
+		}
+
+		sort($slugs);
+		return $slugs;
+	}//end linkedSlugs()
+
+	/**
+	 * THE ARITHMETIC. 2 rejected schemas must cost exactly 2 register links —
+	 * not 18.
+	 *
+	 * Before the fix the register is linked to `schema19` + `schema20` alone:
+	 * the survivors are exactly the schemas declared after the LAST failure, and
+	 * the 16 perfectly-valid schemas declared before it are collateral.
+	 *
+	 * @return void
+	 */
+	public function testTwoRejectedSchemasDetachOnlyThemselvesFromTheRegister(): void {
+		$config = new Configuration();
+		$result = $this->handler->importFromJson(
+			data: $this->configuration(),
+			configuration: $config,
+			appId: 'softwarecatalog',
+			version: '9.9.9'
+		);
+
+		$rejectedCount = count(self::FAILING_POSITIONS);
+		$expectedLinks = (self::TOTAL_SCHEMAS - $rejectedCount);
+
+		$this->assertCount(
+			$expectedLinks,
+			$this->linkedSchemaIds,
+			sprintf(
+				'%d rejected schemas must cost %d register links, not %d — every schema declared '
+				. 'before the last failure was evicted from schemasMap by the unrestored catch.',
+				$rejectedCount,
+				$rejectedCount,
+				(self::TOTAL_SCHEMAS - count($this->linkedSchemaIds))
+			)
+		);
+
+		// And name them, so a right count for a wrong reason still fails.
+		$expectedSlugs = [];
+		for ($position = 1; $position <= self::TOTAL_SCHEMAS; $position++) {
+			if (in_array($position, self::FAILING_POSITIONS, true) === true) {
+				continue;
+			}
+
+			$expectedSlugs[] = sprintf('schema%02d', $position);
+		}
+
+		sort($expectedSlugs);
+		$this->assertSame($expectedSlugs, $this->linkedSlugs(), 'exactly the valid schemas must be linked');
+
+		// The schemas the import reports as created must match the same set.
+		$this->assertCount($expectedLinks, $result['schemas'], 'created-schema list must exclude only the rejected two');
+	}//end testTwoRejectedSchemasDetachOnlyThemselvesFromTheRegister()
+
+	/**
+	 * The boundary is the LAST failure, which is what identifies the mechanism
+	 * rather than merely detecting a wrong number. With a single rejection at
+	 * position 7, the buggy code links 13 schemas (positions 8..20); the correct
+	 * code links 19.
+	 *
+	 * @return void
+	 */
+	public function testASingleRejectionDoesNotEvictTheSchemasDeclaredBeforeIt(): void {
+		$data = $this->configuration();
+		// Drop the second failure, keeping only the one at position 7.
+		unset($data['components']['schemas']['schema18']['configuration']);
+
+		$config = new Configuration();
+		$this->handler->importFromJson(
+			data: $data,
+			configuration: $config,
+			appId: 'softwarecatalog',
+			version: '9.9.9'
+		);
+
+		$this->assertCount(
+			(self::TOTAL_SCHEMAS - 1),
+			$this->linkedSchemaIds,
+			'one rejected schema must cost exactly one register link'
+		);
+		$this->assertContains(
+			'schema01',
+			$this->linkedSlugs(),
+			'a schema imported BEFORE the failure must still be linked — this is the eviction'
+		);
+	}//end testASingleRejectionDoesNotEvictTheSchemasDeclaredBeforeIt()
+
+	/**
+	 * A rejected schema must be VISIBLE to the operator in the import result.
+	 *
+	 * The silent partial import is the actual defect: softwarecatalog's two bad
+	 * schemas were only discovered three layers downstream, in a seed step, via
+	 * empty `*_schema` app-config keys. `skipped.registers`, `skipped.objects`,
+	 * `skipped.mappings` and `skipped.seedObjects` all existed; `skipped.schemas`
+	 * did not, so the one failure that amplifies was the one nothing counted.
+	 *
+	 * @return void
+	 */
+	public function testRejectedSchemasAreReportedInTheImportResult(): void {
+		$config = new Configuration();
+		$result = $this->handler->importFromJson(
+			data: $this->configuration(),
+			configuration: $config,
+			appId: 'softwarecatalog',
+			version: '9.9.9'
+		);
+
+		$this->assertArrayHasKey('schemas', $result['skipped'], 'the result must count skipped schemas at all');
+		$this->assertSame(
+			count(self::FAILING_POSITIONS),
+			$result['skipped']['schemas'],
+			'both rejected schemas must be counted as skipped'
+		);
+
+		$this->assertArrayHasKey('failed', $result, 'the result must name what it could not import');
+		$this->assertArrayHasKey('schemas', $result['failed']);
+		$this->assertSame(
+			['schema07', 'schema18'],
+			array_column($result['failed']['schemas'], 'slug'),
+			'the failed list must name the rejected schemas in declaration order'
+		);
+		$this->assertStringContainsString(
+			"objectDescriptionField ('summary')",
+			(string)($result['failed']['schemas'][0]['error'] ?? ''),
+			'the operator must get the mapper\'s own reason, not just a count'
+		);
+	}//end testRejectedSchemasAreReportedInTheImportResult()
+
+	/**
+	 * Positive control: with no rejected schema, all 20 link and nothing is
+	 * reported as skipped or failed. Without this, a fix that linked everything
+	 * unconditionally would pass the tests above.
+	 *
+	 * @return void
+	 */
+	public function testACleanImportLinksEverySchemaAndReportsNoFailures(): void {
+		$data = $this->configuration();
+		foreach (self::FAILING_POSITIONS as $position) {
+			unset($data['components']['schemas'][sprintf('schema%02d', $position)]['configuration']);
+		}
+
+		$config = new Configuration();
+		$result = $this->handler->importFromJson(
+			data: $data,
+			configuration: $config,
+			appId: 'softwarecatalog',
+			version: '9.9.9'
+		);
+
+		$this->assertCount(self::TOTAL_SCHEMAS, $this->linkedSchemaIds, 'a clean import links every schema');
+		$this->assertSame(0, $result['skipped']['schemas']);
+		$this->assertSame([], $result['failed']['schemas']);
+	}//end testACleanImportLinksEverySchemaAndReportsNoFailures()
+}//end class


### PR DESCRIPTION
## The defect

`ImportHandler::importFromJson()` blanks `$this->schemasMap` before every Pass-1 `importSchema()` call — deliberately, to stop `$ref` resolution while the schemas are still being created — and restores it afterwards.

**The `catch` did not restore it.**

So one rejected schema left the map empty for everything that followed. Each later schema saved an already-emptied map and put it back, and the map ended Pass 1 holding **only the schemas declared after the LAST failure**. The register pass resolves its declared slugs against that map, finds nothing, and creates the register **without those links**.

This affects any app shipping a configuration JSON, which is most of the fleet.

## The arithmetic — reproduced before the fix

Found while diagnosing why softwarecatalog's E2E job had run **zero** tests for two days: 2 rejected schemas produced **18 missing register↔schema links**, every schema except the two declared after the last failure. Downstream the registers imported without their links, `configureVoorzieningen()` wrote every `*_schema` app-config key empty, and the seed step failed honestly — three layers from the cause.

`tests/Unit/Service/Configuration/ImportHandlerSchemaMapRestoreTest.php` reproduces it against the **real** rejection mechanism: `SchemaMapper::validateConfigurationFields()` throwing on an `objectDescriptionField` naming a property the schema does not declare — exactly how `view` and `bioMeasure` failed. The mock transcribes that rule and its error string.

**Before the fix (`vendor/bin/phpunit --filter ImportHandlerSchemaMapRestoreTest`, 4/4 FAIL):**

```
1) testTwoRejectedSchemasDetachOnlyThemselvesFromTheRegister
   2 rejected schemas must cost 2 register links, not 18
   Failed asserting that actual size 2 matches expected size 18.

2) testASingleRejectionDoesNotEvictTheSchemasDeclaredBeforeIt
   one rejected schema must cost exactly one register link
   Failed asserting that actual size 13 matches expected size 19.

3) testRejectedSchemasAreReportedInTheImportResult
   the result must count skipped schemas at all
   Failed asserting that an array has the key 'schemas'.

4) testACleanImportLinksEverySchemaAndReportsNoFailures
   Failed asserting that null is identical to 0.
```

| declared | rejected (positions) | linked, before | linked, after |
|---|---|---|---|
| 20 | 2 (at 7 and 18) | **2** — only `schema19`, `schema20` | **18** |
| 20 | 1 (at 7) | **13** — positions 8..20 | **19** |

The boundary sitting exactly at the last failure is what identifies the *mechanism*, rather than merely detecting a wrong number. Test 4 is the positive control: a clean import must link all 20 and report nothing skipped, so a fix that linked everything unconditionally would still fail.

**After the fix: `OK (4 tests, 14 assertions)`.**

## The fix

**1. The restore moves into `finally`.** Blanking the map is a temporary mutation of shared state whose undo belongs to *leaving the region* — on every path, including an `\Error` that escapes the loop entirely — not to the happy path. This is the same construct `ObjectService::find()` already uses for `currentRegister`/`currentSchema` (BUG-OBJ-13, #1520). The success-path work (adding the schema to the map, appending to `result['schemas']`) now happens after the `try`/`catch`/`finally`, guarded on `$schema !== null`, because `finally` runs *after* the try block and would otherwise discard it.

**2. A rejected schema is no longer silent.** A silent partial import that looks successful is the other half of the defect — the failure that propagates was the one nothing counted:

- `result.skipped.schemas` counts them, alongside the `registers`/`objects`/`mappings`/`seedObjects` counters that already existed.
- `result.failed.schemas` **names** them (`key`, `slug`, `error`) with the mapper's own reason.
- one `WARNING` at the end of the schema pass states the import was **PARTIAL** and lists the rejected slugs. The per-schema `error` lines sit in a log that is otherwise almost entirely `debug`.
- the register pass's *"not found in schemasMap"* warning now carries the rejection reason, so the two halves are not left for someone to correlate.
- the version-skip early return carries the same keys, zeroed, so a caller never has to know which `return` it got. (This is what phpstan flagged once the return shape was documented — a latent inconsistency that predates this change.)

**Import semantics are unchanged.** A rejected schema is still contained rather than aborting the import; no register, object or mapping behaviour moves.

## Other handlers with the same shape

Swept `lib/` (1,447 files) for "member field mutated before a call, restored only on the success path": 146 property-to-literal assignments, 52 capture sites, 38 methods assigning one property twice, 3 `++`/`--` guards.

Everything else that matches **already uses `finally`** — `CalculationEvaluator::evaluate()`, `ObjectService::find()`/`runAs()`, `RenderObject` page-render caches, `AuditHashService` seal lock, `MessageDispatchProvider::targetSource`, `ImportService` notify-push batch mode, `SaveObject`'s call-stack depth guard, and four session-impersonation jobs.

**One genuine exception, reported and deliberately not fixed here:** `ObjectService::handleCascadingWithContextPreservation()` (~1583–1607) captures `currentRegister`/`currentSchema`, calls `CascadingHandler::handlePreValidationCascading()`, and restores at the end with **no `try`/`finally` at all**. Its blast radius is `ObjectService`, its reachability is narrow (the callee catches `Exception`, so only `\Error`/`\TypeError` escape), and it has no amplification mechanism — a different defect of the same shape. It needs its own test and its own PR, not this one. See the board.

## Verification

| check | result |
|---|---|
| Unit suite | **16472 tests, 0 failures** (`Tests: 16472, Assertions: 36853, Skipped: 32`) |
| `phpcs` (repo standard, `lib`) | **0 errors** on the changed file |
| `phpmd` (both rulesets) | **rc=0** |
| `psalm` | **rc=0** |
| `phpstan` | **1 error, base and head** — pre-existing, see below |
| `composer lint` | no syntax errors |

**Hydra Gates, same instrument both sides**, fetched from `ConductionNL/.github@main` (`run-hydra-gates.sh` 10 678 lines, 154 `lib/` checkers) — **not** the vendored v1.8.0 copy, which differs from `main`. Run `--full` in an image with php 8.3.33 + python 3.11.2 + git 2.39.5 (`php:8.3-cli` has neither python3 nor git, and a helper it cannot execute reports as absence-of-findings):

```
base 4df002a  71 gates  5 FAIL   gate-7: 8   gate-25: 72   gate-26: 27   gate-22/53: ajv unresolvable
head e6a0839  71 gates  5 FAIL   gate-7: 8   gate-25: 72   gate-26: 27   gate-22/53: ajv unresolvable
```

**Zero gates introduced, zero counts moved.** gate-22 and gate-53 fail identically on both sides because `ajv` is not resolvable without `npm ci` — environmental, not code. On head the delta gates had a usable base (`4df002a`, 2 changed files) and reported **gate-16 spec-coverage PASS** and **gate-47 security-change-has-tests PASS**.

**File count measured: 2 changed files**, both named above; the state gates read the entire tracked tree on both runs.

## ⚠️ A pre-existing red this PR does not cause and does not fix

`phpstan` reports **1 error on `development` itself**:

```
lib/Service/RegisterSchemaLinkageRepairService.php:120
  Strict comparison using === between int and null will always evaluate to false.
```

Measured on the pristine base as well as on this branch — identical. That file is **new in #2526** (298 insertions, merged 14:21 today), so openregister's `PHP Quality (phpstan)` leg is red as of that merge and will read as an inherited failure on every openregister PR opened from now on. Not touched here: it is someone else's change in the foundation repo and the right fix is a judgement call for its author, not a drive-by.
