### PR TITLE
fix(quality): the one phpmd and the one phpstan finding (reapply of #2530)

### DIFF
--- a/lib/Exception/SchemaNotInRegisterException.php
+++ b/lib/Exception/SchemaNotInRegisterException.php
@@ -94,6 +94,14 @@ class SchemaNotInRegisterException extends DoesNotExistException {
 	 *
 	 * @return void
 	 *
+	 * @SuppressWarnings(PHPMD.BooleanArgumentFlag) $registerListEmpty selects
+	 * between two operator-facing sentences — "this register has no schemas at
+	 * all" versus "this register has schemas but not this slug" — and the
+	 * caller is the only place that can tell those apart. The alternatives are
+	 * worse: two named constructors for one exception, or composing the message
+	 * at every throw site, which is how the two sentences drift apart. The flag
+	 * reaches exactly one call, composeMessage(), and never changes state.
+	 *
 	 * @spec openspec/specs/register-scoped-slug-resolution/spec.md
 	 */
 	public function __construct(

--- a/lib/Service/RegisterSchemaLinkageRepairService.php
+++ b/lib/Service/RegisterSchemaLinkageRepairService.php
@@ -116,8 +116,12 @@ class RegisterSchemaLinkageRepairService {
 
 		$report = [];
 		foreach ($this->registerMapper->findAll() as $register) {
+			// No null check on the id: Entity declares `@method int getId()`, and
+			// findAll() only ever yields persisted rows, so phpstan is right that
+			// `$id === null` can never be true here. The scope filter is the part
+			// that does work.
 			$id = $register->getId();
-			if ($id === null || ($registerId !== null && $id !== $registerId)) {
+			if ($registerId !== null && $id !== $registerId) {
 				continue;
 			}
 


### PR DESCRIPTION
Reapplies what #2530 was supposed to contain, from a clean clone. #2530 was reverted in #2532 — it was built in a submodule worktree and staged 6,886 phantom deletions.

**phpstan** — `inspect()` guarded on `$id === null` after `getId()`; Entity declares `@method int getId()` and `findAll()` only yields persisted rows, so the branch is unreachable.

**phpmd** — reason-bearing `@SuppressWarnings` for the boolean flag that selects between two operator-facing sentences.

Two files, thirteen insertions, one deletion.