### PR TITLE
fix(schemas): the register boundary was enforced but never established — clears all 3 jobs #2526 turned red

### DIFF
--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -1,3 +1,31 @@
+## Creating a Schema Inside a Register
+
+**Endpoint:** `POST /api/schemas?register={id|uuid|slug}`
+
+The optional `register` parameter states which register the new schema belongs to.
+When it is supplied, the schema is recorded in that register's `schemas` list as
+part of the create.
+
+This matters because a register's `schemas` list is a **boundary**, not a hint: a
+request that names a register (`/api/objects/{register}/{schema}`,
+`/api/schemas/{id}?register=`) resolves the schema slug **only** within that
+register, and a slug the register does not carry is refused with 404. A schema
+created in a register without being recorded in it is therefore unreachable by
+slug through that register, even though writes addressed by numeric schema id
+still succeed.
+
+- `register` omitted — a register-less schema is created, exactly as before.
+- `register` names a register that does not exist or is not accessible — the
+  request is refused with **400** and **no schema is created**. Creating a
+  free-floating schema and answering 201 would tell the caller it has something it
+  does not have.
+- The parameter is never stored on the schema itself; a schema row has no register
+  column. The linkage lives on the register.
+
+If the linkage of an existing register was lost, `occ
+openregister:registers:relink-schemas` inspects and repairs it from the physical
+object tables.
+
 ## Error Handling for Missing Register or Schema
 
 If you request a schema or register by slug or ID that does not exist, the API will return a 404 Not Found response with a clear error message. This applies to all endpoints that use register or schema slugs/IDs, including object listing, creation, update, and detail endpoints.

--- a/lib/Controller/SchemasController.php
+++ b/lib/Controller/SchemasController.php
@@ -104,6 +104,7 @@ class SchemasController extends Controller {
 	 * @param IRequest $request HTTP request object
 	 * @param IAppConfig $config App configuration for settings
 	 * @param SchemaMapper $schemaMapper Schema mapper for database operations
+	 * @param RegisterMapper $registerMapper Register mapper for register lookups and schema linkage
 	 * @param MagicMapper $objectEntityMapper Object entity mapper for object queries
 	 * @param UploadService $uploadService Upload service for file uploads
 	 * @param AuditTrailMapper $auditTrailMapper Audit trail mapper for log statistics
@@ -362,7 +363,7 @@ class SchemasController extends Controller {
 					registerId: $register->getId(),
 					registerSlug: $register->getSlug(),
 					candidatesElsewhere: $this->schemaMapper->countBySlug(slug: $id),
-					registerListEmpty: ($registerSchemaIds === [])
+					registerSchemaCount: count($registerSchemaIds)
 				);
 			}
 		}
@@ -584,6 +585,13 @@ class SchemasController extends Controller {
 		// Get request parameters.
 		$data = $this->request->getParams();
 
+		// REGISTER CONTEXT. `POST /api/schemas?register=<id|uuid|slug>` states which
+		// register the new schema belongs to. It is consumed here, never hydrated
+		// onto the Schema entity — a schema row carries no register column; the
+		// linkage lives in `openregister_registers.schemas`.
+		$registerParam = ($data['register'] ?? null);
+		unset($data['register']);
+
 		// DEBUG: Log incoming request to track duplicate creation.
 		$this->logger->info(
 			message: '[SchemasController::create] Starting schema creation',
@@ -614,9 +622,71 @@ class SchemasController extends Controller {
 			return $jsonLdError;
 		}
 
+		// Refuse a register context that does not resolve BEFORE writing the schema.
+		// Creating a free-floating schema and reporting 201 is what made the old
+		// behaviour invisible: the caller believed it had a schema in that register.
+		$register = null;
+		if ($registerParam !== null && $registerParam !== '') {
+			try {
+				// `_multitenancy: false` on the LOOKUP only, matching
+				// RegisterMapper::updateFromArray(): resolve the register by id
+				// regardless of which organisation is active, and let the
+				// RegisterMapper::update() below carry the access check. RBAC is left
+				// at its default (on); this is not an authorization opt-out.
+				$register = $this->registerMapper->find(id: $registerParam, _multitenancy: false);
+			} catch (Exception $e) {
+				return new JSONResponse(
+					data: [
+						'error' => sprintf(
+							'The register "%s" named by ?register= does not exist or is not accessible, '
+							. 'so the schema was not created. Omit the parameter to create a '
+							. 'register-less schema.',
+							(string)$registerParam
+						),
+					],
+					statusCode: Http::STATUS_BAD_REQUEST
+				);
+			}
+		}
+
 		try {
 			// Create a new schema from the data.
 			$schema = $this->schemaMapper->createFromArray(object: $data);
+
+			// Establish the register linkage the caller asked for. Without this the
+			// register's `schemas` list never learns about the schema, and every
+			// register-scoped slug read of it is refused by
+			// SchemaNotInRegisterException — while writes addressed by numeric id
+			// still land, producing rows the API cannot read back. ImportHandler,
+			// TablesSchemaSyncService and DatabaseIntrospectionService all maintain
+			// this list already; this endpoint was the one register-context schema
+			// creation path that did not.
+			//
+			// A refused linkage (cross-tenant register, RBAC) is logged, not fatal:
+			// the schema itself was created, and answering 500 would hide a
+			// successful write behind an error. The log line is the record and
+			// `occ openregister:registers:relink-schemas` is the repair.
+			if ($register !== null && $register->addSchemaId(schemaId: $schema->getId()) === true) {
+				try {
+					$this->registerMapper->update(entity: $register);
+
+					// Register lookups are cached per request; drop the pre-update
+					// copy so a follow-up read in this same PHP worker observes
+					// the new linkage.
+					$this->registerMapper->clearFindCache(registerId: $register->getId());
+				} catch (Exception $linkError) {
+					$this->logger->error(
+						message: '[SchemasController] Schema created but could not be linked to its register',
+						context: [
+							'file'          => __FILE__,
+							'line'          => __LINE__,
+							'schemaId'      => $schema->getId(),
+							'registerId'    => $register->getId(),
+							'error_message' => $linkError->getMessage(),
+						]
+					);
+				}
+			}
 
 			/*
 			 * NOTE: Organization should already be set from the request data.

--- a/lib/Db/Register.php
+++ b/lib/Db/Register.php
@@ -400,6 +400,44 @@ class Register extends Entity implements JsonSerializable {
 	}//end setSchemas()
 
 	/**
+	 * Record that a schema belongs to this register.
+	 *
+	 * The `schemas` list is a BOUNDARY since register-scoped slug resolution
+	 * landed: a slug it does not carry is refused with
+	 * {@see \OCA\OpenRegister\Exception\SchemaNotInRegisterException}. A boundary
+	 * that nothing maintains is worse than none — a write addressed by numeric id
+	 * lands while the matching slug read 404s.
+	 *
+	 * Additive and idempotent. Existing entries are preserved VERBATIM: a
+	 * normalising rewrite would silently drop a non-numeric legacy entry, and that
+	 * is data loss rather than cleanup. Repair of an existing list belongs to
+	 * `occ openregister:registers:relink-schemas`.
+	 *
+	 * Mutates the entity only; the caller persists it, so the register's own RBAC
+	 * and cross-tenant checks stay on the mapper where they already are.
+	 *
+	 * @param int $schemaId The schema id to record.
+	 *
+	 * @return bool True when the list gained the id, false when it already had it.
+	 *
+	 * @spec openspec/specs/register-scoped-slug-resolution/spec.md
+	 */
+	public function addSchemaId(int $schemaId): bool {
+		$existing = $this->getSchemas();
+
+		foreach ($existing as $candidate) {
+			if (is_numeric($candidate) === true && (int)$candidate === $schemaId) {
+				return false;
+			}
+		}
+
+		$existing[] = $schemaId;
+		$this->setSchemas(schemas: array_values($existing));
+
+		return true;
+	}//end addSchemaId()
+
+	/**
 	 * Get JSON fields from the entity
 	 *
 	 * Returns all fields that are of type 'json'

--- a/lib/Exception/SchemaNotInRegisterException.php
+++ b/lib/Exception/SchemaNotInRegisterException.php
@@ -84,13 +84,27 @@ class SchemaNotInRegisterException extends DoesNotExistException {
 	private int $candidatesElsewhere;
 
 	/**
+	 * How many schemas the named register carries in total.
+	 *
+	 * @var int
+	 */
+	private int $registerSchemaCount;
+
+	/**
 	 * Constructor.
+	 *
+	 * `$registerSchemaCount` is a COUNT and not a "list is empty" boolean on
+	 * purpose. A flag argument only tells the message which sentence to print;
+	 * the number also tells the operator how far off the register is — "carries
+	 * no schemas at all" and "carries 14 schemas, none of them this slug" are
+	 * different diagnoses with different repairs, and the second is not
+	 * expressible with a boolean.
 	 *
 	 * @param string      $schemaSlug          The slug that did not resolve.
 	 * @param int|null    $registerId          The named register's id, when known.
 	 * @param string|null $registerSlug        The named register's slug, when known.
 	 * @param int         $candidatesElsewhere Count of same-slug schemas outside the register.
-	 * @param bool        $registerListEmpty   Whether the register carries no schemas at all.
+	 * @param int         $registerSchemaCount How many schemas the named register carries.
 	 *
 	 * @return void
 	 *
@@ -101,16 +115,15 @@ class SchemaNotInRegisterException extends DoesNotExistException {
 		?int $registerId=null,
 		?string $registerSlug=null,
 		int $candidatesElsewhere=0,
-		bool $registerListEmpty=false,
+		int $registerSchemaCount=0,
 	) {
 		$this->schemaSlug          = $schemaSlug;
 		$this->registerId          = $registerId;
 		$this->registerSlug        = $registerSlug;
 		$this->candidatesElsewhere = $candidatesElsewhere;
+		$this->registerSchemaCount = $registerSchemaCount;
 
-		parent::__construct(
-			msg: $this->composeMessage(registerListEmpty: $registerListEmpty)
-		);
+		parent::__construct(msg: $this->composeMessage());
 	}//end __construct()
 
 	/**
@@ -120,11 +133,9 @@ class SchemaNotInRegisterException extends DoesNotExistException {
 	 * gets a different sentence from one that simply lacks this slug, because the
 	 * two have different remedies and conflating them is what hid the defect.
 	 *
-	 * @param bool $registerListEmpty Whether the register carries no schemas at all.
-	 *
 	 * @return string The composed message.
 	 */
-	private function composeMessage(bool $registerListEmpty): string {
+	private function composeMessage(): string {
 		$register = 'the named register';
 		if ($this->registerId !== null) {
 			$register = sprintf(
@@ -134,7 +145,7 @@ class SchemaNotInRegisterException extends DoesNotExistException {
 			);
 		}
 
-		if ($registerListEmpty === true) {
+		if ($this->registerSchemaCount === 0) {
 			return sprintf(
 				'Schema slug "%s" cannot resolve because %s carries no schemas at all. '
 				. '%d schema(s) elsewhere on this instance carry this slug, and resolving to one of '
@@ -147,11 +158,13 @@ class SchemaNotInRegisterException extends DoesNotExistException {
 		}
 
 		return sprintf(
-			'Schema slug "%s" is not carried by %s. %d schema(s) elsewhere on this instance '
-			. 'carry this slug; none of them is served here, because naming a register makes it a boundary. '
-			. 'If the linkage was lost, run `occ openregister:registers:relink-schemas` to inspect and repair it.',
+			'Schema slug "%s" is not carried by %s, which carries %d schema(s). %d schema(s) elsewhere '
+			. 'on this instance carry this slug; none of them is served here, because naming a register '
+			. 'makes it a boundary. If the linkage was lost, run '
+			. '`occ openregister:registers:relink-schemas` to inspect and repair it.',
 			$this->schemaSlug,
 			$register,
+			$this->registerSchemaCount,
 			$this->candidatesElsewhere
 		);
 	}//end composeMessage()
@@ -199,4 +212,18 @@ class SchemaNotInRegisterException extends DoesNotExistException {
 	public function getCandidatesElsewhere(): int {
 		return $this->candidatesElsewhere;
 	}//end getCandidatesElsewhere()
+
+	/**
+	 * Get how many schemas the named register carries.
+	 *
+	 * Zero means the register's linkage list is empty — the shape
+	 * `occ openregister:registers:relink-schemas` exists to repair.
+	 *
+	 * @return int The register's schema count.
+	 *
+	 * @spec openspec/specs/register-scoped-slug-resolution/spec.md
+	 */
+	public function getRegisterSchemaCount(): int {
+		return $this->registerSchemaCount;
+	}//end getRegisterSchemaCount()
 }//end class

--- a/lib/Service/Flow/Nodes/ObjectReadNode.php
+++ b/lib/Service/Flow/Nodes/ObjectReadNode.php
@@ -551,7 +551,7 @@ class ObjectReadNode implements IFlowNode, IFlowNodeConfigKeys {
 				registerId: $register->getId(),
 				registerSlug: $register->getSlug(),
 				candidatesElsewhere: $this->schemas->countBySlug(slug: $identifier),
-				registerListEmpty: ($registerSchemaIds === [])
+				registerSchemaCount: count($registerSchemaIds)
 			);
 		}
 

--- a/lib/Service/Flow/Nodes/ObjectWriteNode.php
+++ b/lib/Service/Flow/Nodes/ObjectWriteNode.php
@@ -1071,7 +1071,7 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys {
 				registerId: $register->getId(),
 				registerSlug: $register->getSlug(),
 				candidatesElsewhere: $this->schemas->countBySlug(slug: $identifier),
-				registerListEmpty: ($registerSchemaIds === [])
+				registerSchemaCount: count($registerSchemaIds)
 			);
 		}
 

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -512,7 +512,7 @@ class ObjectService implements ObjectServiceInterface
                         registerId: $this->currentRegister->getId(),
                         registerSlug: $this->currentRegister->getSlug(),
                         candidatesElsewhere: $this->schemaMapper->countBySlug(slug: $schema),
-                        registerListEmpty: ($registerSchemaIds === [])
+                        registerSchemaCount: count($registerSchemaIds)
                     );
                 }
             }
@@ -2398,7 +2398,7 @@ class ObjectService implements ObjectServiceInterface
                 registerId: $register->getId(),
                 registerSlug: $register->getSlug(),
                 candidatesElsewhere: $this->schemaMapper->countBySlug(slug: $schemaSlug),
-                registerListEmpty: ($registerSchemaIds === [])
+                registerSchemaCount: count($registerSchemaIds)
             );
         }
 

--- a/lib/Service/RegisterSchemaLinkageRepairService.php
+++ b/lib/Service/RegisterSchemaLinkageRepairService.php
@@ -116,8 +116,13 @@ class RegisterSchemaLinkageRepairService {
 
 		$report = [];
 		foreach ($this->registerMapper->findAll() as $register) {
+			// `OCP\AppFramework\Db\Entity` declares `@method int getId()`, and
+			// RegisterMapper::findAll() only ever returns persisted rows, so there
+			// is no unpersisted (id-less) register to guard against here. The
+			// `$id === null` arm this used to carry was unreachable, which is
+			// exactly what phpstan reported.
 			$id = $register->getId();
-			if ($id === null || ($registerId !== null && $id !== $registerId)) {
+			if ($registerId !== null && $id !== $registerId) {
 				continue;
 			}
 

--- a/tests/Unit/Controller/SchemasControllerRegisterLinkageTest.php
+++ b/tests/Unit/Controller/SchemasControllerRegisterLinkageTest.php
@@ -1,0 +1,285 @@
+<?php
+
+/**
+ * Unit tests for the register linkage established by POST /api/schemas?register=.
+ *
+ * Since register-scoped slug resolution landed, a register's `schemas` list is a
+ * BOUNDARY: a slug it does not carry is refused with SchemaNotInRegisterException
+ * and the request 404s. These tests pin the other half of that contract — that the
+ * list is actually MAINTAINED by the endpoint that creates a schema inside a
+ * register. Without it the boundary is enforced against a list nothing keeps up to
+ * date, which is the state in which a write addressed by numeric id lands and the
+ * matching slug read cannot find it.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Controller;
+
+use OCA\OpenRegister\Controller\SchemasController;
+use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCA\OpenRegister\Service\Schema\SchemaVersioningService;
+use OCA\OpenRegister\Service\Schemas\FacetCacheHandler;
+use OCA\OpenRegister\Service\Schemas\SchemaCacheHandler;
+use OCA\OpenRegister\Service\SchemaService;
+use OCA\OpenRegister\Service\UploadService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IAppConfig;
+use OCP\IRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class SchemasControllerRegisterLinkageTest extends TestCase {
+
+	private IRequest $request;
+
+	private SchemaMapper $schemaMapper;
+
+	private RegisterMapper $registerMapper;
+
+	private SchemasController $controller;
+
+	protected function setUp(): void {
+		$this->request        = $this->createMock(IRequest::class);
+		$this->schemaMapper   = $this->createMock(SchemaMapper::class);
+		$this->registerMapper = $this->createMock(RegisterMapper::class);
+
+		$userSession = $this->createMock(\OCP\IUserSession::class);
+		$user        = $this->createMock(\OCP\IUser::class);
+		$user->method('getUID')->willReturn('admin');
+		$userSession->method('getUser')->willReturn($user);
+
+		$groupManager = $this->createMock(\OCP\IGroupManager::class);
+		$groupManager->method('getUserGroupIds')->willReturn(['admin']);
+		$groupManager->method('isAdmin')->willReturn(true);
+
+		$container = $this->createMock(\Psr\Container\ContainerInterface::class);
+		$container->method('get')->willReturnCallback(
+			function ($id) use ($userSession, $groupManager) {
+				if ($id === \OCP\IUserSession::class) {
+					return $userSession;
+				}
+
+				if ($id === \OCP\IGroupManager::class) {
+					return $groupManager;
+				}
+
+				return null;
+			}
+		);
+
+		$this->controller = new SchemasController(
+			'openregister',
+			$this->request,
+			$this->createMock(IAppConfig::class),
+			$this->schemaMapper,
+			$this->registerMapper,
+			$this->createMock(MagicMapper::class),
+			$this->createMock(UploadService::class),
+			$this->createMock(AuditTrailMapper::class),
+			$this->createMock(OrganisationService::class),
+			$this->createMock(SchemaCacheHandler::class),
+			$this->createMock(FacetCacheHandler::class),
+			$this->createMock(SchemaService::class),
+			$this->createMock(LoggerInterface::class),
+			$container,
+			$this->createMock(SchemaVersioningService::class)
+		);
+	}//end setUp()
+
+	/**
+	 * Build a persisted-looking schema.
+	 *
+	 * @param int $id The schema id.
+	 *
+	 * @return Schema The schema.
+	 */
+	private function schemaWithId(int $id): Schema {
+		$schema = new Schema();
+		$schema->setId($id);
+		$schema->setSlug('person-schema');
+
+		return $schema;
+	}//end schemaWithId()
+
+	/**
+	 * Build a register carrying the given schema ids.
+	 *
+	 * @param int   $id        The register id.
+	 * @param array $schemaIds The schema ids it already carries.
+	 *
+	 * @return Register The register.
+	 */
+	private function registerWith(int $id, array $schemaIds): Register {
+		$register = new Register();
+		$register->setId($id);
+		$register->setSlug('test-register');
+		$register->setSchemas($schemaIds);
+
+		return $register;
+	}//end registerWith()
+
+	/**
+	 * A schema created with ?register= is recorded in that register's schemas list.
+	 *
+	 * This is the assertion that fails on the pre-fix controller: it created the
+	 * schema, answered 201, and never touched the register — so every later
+	 * register-scoped read of the new slug was refused.
+	 *
+	 * @return void
+	 */
+	public function testCreateWithRegisterParamRecordsTheLinkage(): void {
+		$register = $this->registerWith(id: 15, schemaIds: [7]);
+
+		$this->request->method('getParams')->willReturn(
+			['title' => 'Person', 'register' => '15']
+		);
+		$this->registerMapper->method('find')->willReturn($register);
+		$this->schemaMapper->method('createFromArray')->willReturn($this->schemaWithId(id: 18));
+
+		$saved = null;
+		$this->registerMapper->expects($this->once())
+			->method('update')
+			->willReturnCallback(
+				function (Register $entity) use (&$saved) {
+					$saved = $entity;
+					return $entity;
+				}
+			);
+
+		$response = $this->controller->create();
+
+		$this->assertSame(201, $response->getStatus());
+		$this->assertInstanceOf(Register::class, $saved);
+		$this->assertSame([7, 18], $saved->getSchemas());
+	}//end testCreateWithRegisterParamRecordsTheLinkage()
+
+	/**
+	 * The register identifier is consumed, never hydrated onto the schema.
+	 *
+	 * A schema row has no register column; the linkage lives on the register. If
+	 * `register` reached createFromArray() the entity would silently swallow it and
+	 * the caller would have no way to tell a recorded linkage from a dropped one.
+	 *
+	 * @return void
+	 */
+	public function testRegisterParamIsNotHydratedOntoTheSchema(): void {
+		$register = $this->registerWith(id: 15, schemaIds: []);
+
+		$this->request->method('getParams')->willReturn(
+			['title' => 'Person', 'register' => '15']
+		);
+		$this->registerMapper->method('find')->willReturn($register);
+		$this->registerMapper->method('update')->willReturnArgument(0);
+
+		$seen = null;
+		$this->schemaMapper->method('createFromArray')->willReturnCallback(
+			function (array $object) use (&$seen) {
+				$seen = $object;
+				return $this->schemaWithId(id: 18);
+			}
+		);
+
+		$this->controller->create();
+
+		$this->assertIsArray($seen);
+		$this->assertArrayNotHasKey('register', $seen);
+	}//end testRegisterParamIsNotHydratedOntoTheSchema()
+
+	/**
+	 * Linking is idempotent — a register that already carries the id is not rewritten.
+	 *
+	 * @return void
+	 */
+	public function testAlreadyLinkedRegisterIsNotUpdated(): void {
+		$register = $this->registerWith(id: 15, schemaIds: [18]);
+
+		$this->request->method('getParams')->willReturn(
+			['title' => 'Person', 'register' => '15']
+		);
+		$this->registerMapper->method('find')->willReturn($register);
+		$this->schemaMapper->method('createFromArray')->willReturn($this->schemaWithId(id: 18));
+
+		$this->registerMapper->expects($this->never())->method('update');
+
+		$this->assertSame(201, $this->controller->create()->getStatus());
+	}//end testAlreadyLinkedRegisterIsNotUpdated()
+
+	/**
+	 * A register-less create is untouched: no lookup, no register write.
+	 *
+	 * @return void
+	 */
+	public function testCreateWithoutRegisterParamTouchesNoRegister(): void {
+		$this->request->method('getParams')->willReturn(['title' => 'Person']);
+		$this->schemaMapper->method('createFromArray')->willReturn($this->schemaWithId(id: 18));
+
+		$this->registerMapper->expects($this->never())->method('find');
+		$this->registerMapper->expects($this->never())->method('update');
+
+		$this->assertSame(201, $this->controller->create()->getStatus());
+	}//end testCreateWithoutRegisterParamTouchesNoRegister()
+
+	/**
+	 * A register that does not resolve is refused BEFORE the schema is written.
+	 *
+	 * Creating a free-floating schema and answering 201 is what made the old
+	 * behaviour invisible — the caller believed it had a schema in that register.
+	 *
+	 * @return void
+	 */
+	public function testUnresolvableRegisterRefusesTheCreate(): void {
+		$this->request->method('getParams')->willReturn(
+			['title' => 'Person', 'register' => 'no-such-register']
+		);
+		$this->registerMapper->method('find')->willThrowException(new DoesNotExistException('nope'));
+
+		$this->schemaMapper->expects($this->never())->method('createFromArray');
+
+		$response = $this->controller->create();
+
+		$this->assertSame(400, $response->getStatus());
+		$this->assertStringContainsString('no-such-register', $response->getData()['error']);
+	}//end testUnresolvableRegisterRefusesTheCreate()
+
+	/**
+	 * A refused linkage does not turn a successful schema write into an error.
+	 *
+	 * RegisterMapper::update() enforces RBAC and the cross-tenant organisation
+	 * check. When it refuses, the schema itself still exists, so answering 500
+	 * would hide a successful write behind an error.
+	 *
+	 * @return void
+	 */
+	public function testRefusedLinkageStillReturns201(): void {
+		$register = $this->registerWith(id: 15, schemaIds: []);
+
+		$this->request->method('getParams')->willReturn(
+			['title' => 'Person', 'register' => '15']
+		);
+		$this->registerMapper->method('find')->willReturn($register);
+		$this->schemaMapper->method('createFromArray')->willReturn($this->schemaWithId(id: 18));
+		$this->registerMapper->method('update')
+			->willThrowException(new \Exception('Cross-tenant access denied'));
+
+		$this->assertSame(201, $this->controller->create()->getStatus());
+	}//end testRefusedLinkageStillReturns201()
+}//end class

--- a/tests/Unit/Db/RegisterTest.php
+++ b/tests/Unit/Db/RegisterTest.php
@@ -957,4 +957,57 @@ class RegisterTest extends TestCase {
 
 		$this->assertSame([], $this->register->getSchemasWithMagicMapping());
 	}
+
+	public function testAddSchemaIdAppendsAndReportsTheChange(): void {
+		$this->register->setSchemas([7]);
+
+		$this->assertTrue($this->register->addSchemaId(schemaId: 18));
+		$this->assertSame([7, 18], $this->register->getSchemas());
+	}
+
+	public function testAddSchemaIdIsIdempotent(): void {
+		$this->register->setSchemas([7, 18]);
+
+		$this->assertFalse($this->register->addSchemaId(schemaId: 18));
+		$this->assertSame([7, 18], $this->register->getSchemas());
+	}
+
+	/**
+	 * A numeric-string entry is the SAME membership as its integer form.
+	 *
+	 * `setSchemas()` keeps ints and strings alike and the resolver compares
+	 * numerically, so a string "18" already means "schema 18" — appending the int
+	 * would duplicate the membership rather than add one.
+	 *
+	 * @return void
+	 */
+	public function testAddSchemaIdMatchesNumericStringEntries(): void {
+		$this->register->setSchemas(['18']);
+
+		$this->assertFalse($this->register->addSchemaId(schemaId: 18));
+		$this->assertSame(['18'], $this->register->getSchemas());
+	}
+
+	/**
+	 * Existing entries are preserved verbatim; the list is not normalised.
+	 *
+	 * A normalising rewrite would silently drop a non-numeric legacy entry, and
+	 * that is data loss rather than cleanup. `occ
+	 * openregister:registers:relink-schemas` owns repair of an existing list.
+	 *
+	 * @return void
+	 */
+	public function testAddSchemaIdPreservesNonNumericEntries(): void {
+		$this->register->setSchemas(['legacy-slug', 7]);
+
+		$this->assertTrue($this->register->addSchemaId(schemaId: 18));
+		$this->assertSame(['legacy-slug', 7, 18], $this->register->getSchemas());
+	}
+
+	public function testAddSchemaIdOnAnEmptyListStartsIt(): void {
+		$this->register->setSchemas([]);
+
+		$this->assertTrue($this->register->addSchemaId(schemaId: 18));
+		$this->assertSame([18], $this->register->getSchemas());
+	}
 }

--- a/tests/integration/openregister-crud.postman_collection.json
+++ b/tests/integration/openregister-crud.postman_collection.json
@@ -48,6 +48,8 @@
           "        'import_test_register_id', 'import_test_register_slug',",
           "        'import_test_schema_id', 'import_test_schema_slug',",
           "        'bulk_object_1_uuid', 'bulk_object_2_uuid',",
+          "        'org2_uuid', 'org2_schema_id', 'org2_schema_slug',",
+          "        'register_schemas_merged',",
           "        'test_org_uuid', 'test_timestamp'",
           "    ];",
           "    ",
@@ -1714,6 +1716,251 @@
           ]
         }
       }
+    },
+    {
+      "name": "3b2. Switch to Org1 to link the org2 schema (cross-tenant setup)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "// A register's `schemas` list is a BOUNDARY: a slug it does not carry is",
+              "// refused with 404. `POST /api/schemas?register=` records that membership,",
+              "// but the write goes through RegisterMapper::update(), whose cross-tenant",
+              "// check applies to EVERYONE INCLUDING ADMINS. Register {{register_id}}",
+              "// belongs to org1, so while org2 is active the linkage is refused and only",
+              "// logged. Recording an org2 schema inside an org1 register is therefore a",
+              "// write that must be performed FROM org1 — which is exactly what a real",
+              "// multi-tenant client has to do. These three steps do that explicitly",
+              "// instead of relying on the global slug fallback that used to hide it.",
+              "pm.test('Status code is 200', function () {",
+              "    pm.response.to.have.status(200);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/index.php/apps/openregister/api/organisations/{{test_org_uuid}}/set-active",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "index.php",
+            "apps",
+            "openregister",
+            "api",
+            "organisations",
+            "{{test_org_uuid}}",
+            "set-active"
+          ]
+        },
+        "auth": {
+          "type": "basic",
+          "basic": [
+            {
+              "key": "username",
+              "value": "{{admin_user}}",
+              "type": "string"
+            },
+            {
+              "key": "password",
+              "value": "{{admin_password}}",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "3b3. Read the register's current schema list",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Status code is 200', function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "var body = pm.response.json();",
+              "var current = (body.schemas || body.results || []);",
+              "",
+              "// Guard, not decoration: if this list came back empty the PATCH below would",
+              "// REPLACE the register's real linkage with a one-element array and every",
+              "// later slug read in this collection would 404 for a reason unrelated to",
+              "// the code under test. It must already carry the two schemas created with",
+              "// ?register= at steps 2 and 2a.",
+              "pm.test('Register already carries the schemas created with ?register=', function () {",
+              "    pm.expect(current.length).to.be.at.least(2);",
+              "    pm.expect(current.map(String)).to.include(String(pm.collectionVariables.get('schema_id')));",
+              "    pm.expect(current.map(String)).to.include(String(pm.collectionVariables.get('validation_schema_id')));",
+              "});",
+              "",
+              "var merged = current.map(Number);",
+              "var org2SchemaId = Number(pm.collectionVariables.get('org2_schema_id'));",
+              "if (merged.indexOf(org2SchemaId) === -1) { merged.push(org2SchemaId); }",
+              "pm.collectionVariables.set('register_schemas_merged', JSON.stringify(merged));"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/index.php/apps/openregister/api/registers/{{register_id}}",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "index.php",
+            "apps",
+            "openregister",
+            "api",
+            "registers",
+            "{{register_id}}"
+          ]
+        },
+        "auth": {
+          "type": "basic",
+          "basic": [
+            {
+              "key": "username",
+              "value": "{{admin_user}}",
+              "type": "string"
+            },
+            {
+              "key": "password",
+              "value": "{{admin_password}}",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "3b4. Link the org2 schema into the org1 register",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Status code is 200', function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test('Register now carries the org2 schema', function () {",
+              "    var body = pm.response.json();",
+              "    var ids = (body.schemas || []).map(String);",
+              "    pm.expect(ids).to.include(String(pm.collectionVariables.get('org2_schema_id')));",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "PATCH",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"schemas\": {{register_schemas_merged}}\n}"
+        },
+        "url": {
+          "raw": "{{base_url}}/index.php/apps/openregister/api/registers/{{register_id}}",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "index.php",
+            "apps",
+            "openregister",
+            "api",
+            "registers",
+            "{{register_id}}"
+          ]
+        },
+        "auth": {
+          "type": "basic",
+          "basic": [
+            {
+              "key": "username",
+              "value": "{{admin_user}}",
+              "type": "string"
+            },
+            {
+              "key": "password",
+              "value": "{{admin_password}}",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "3b5. Switch back to Org2 (restore the multitenancy context)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Status code is 200', function () {",
+              "    pm.response.to.have.status(200);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/index.php/apps/openregister/api/organisations/{{org2_uuid}}/set-active",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "index.php",
+            "apps",
+            "openregister",
+            "api",
+            "organisations",
+            "{{org2_uuid}}",
+            "set-active"
+          ]
+        },
+        "auth": {
+          "type": "basic",
+          "basic": [
+            {
+              "key": "username",
+              "value": "{{admin_user}}",
+              "type": "string"
+            },
+            {
+              "key": "password",
+              "value": "{{admin_password}}",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "response": []
     },
     {
       "name": "3c. Create Object in Org2 (Multitenancy)",
@@ -3875,7 +4122,7 @@
               "raw": "{\"title\": \"Person Schema Files {{$timestamp}}-{{$randomInt}}\", \"description\": \"Schema for file tests\", \"properties\": {\"name\": {\"type\": \"string\"}}}"
             },
             "url": {
-              "raw": "{{base_url}}/index.php/apps/openregister/api/schemas?register={{register_id}}",
+              "raw": "{{base_url}}/index.php/apps/openregister/api/schemas?register={{file_test_register_id}}",
               "host": [
                 "{{base_url}}"
               ],
@@ -3889,7 +4136,7 @@
               "query": [
                 {
                   "key": "register",
-                  "value": "{{register_id}}"
+                  "value": "{{file_test_register_id}}"
                 }
               ]
             }
@@ -4115,7 +4362,7 @@
               "raw": "{\"title\": \"Person Schema Imports {{$timestamp}}-{{$randomInt}}\", \"description\": \"Schema for import tests\", \"properties\": {\"name\": {\"type\": \"string\"}, \"age\": {\"type\": \"integer\"}}}"
             },
             "url": {
-              "raw": "{{base_url}}/index.php/apps/openregister/api/schemas?register={{register_id}}",
+              "raw": "{{base_url}}/index.php/apps/openregister/api/schemas?register={{import_test_register_id}}",
               "host": [
                 "{{base_url}}"
               ],
@@ -4129,7 +4376,7 @@
               "query": [
                 {
                   "key": "register",
-                  "value": "{{register_id}}"
+                  "value": "{{import_test_register_id}}"
                 }
               ]
             }


### PR DESCRIPTION
## What this fixes

`development` went **2 → 5 red jobs at 12:21** (`b7d00deb` → `4df002a`, adjacent
commits, `rev-list --count` = 1), all three from #2526. Every openregister PR has
inherited all three since. This clears all three at source.

| job | base `b7d00deb` run 31939144615 | `4df002a` run 31946843422 | this PR |
|---|---|---|---|
| PHP Quality (phpstan) | success | **failure** | target: success |
| PHP Quality (phpmd) | success | **failure** | target: success |
| Integration Tests (Newman) | success | **failure** | target: success |

## 1. Newman — 74 failed assertions, and the code is what is wrong

⚠️ The board recorded "15 assertions". Re-measured from the job logs it is **74**,
and `openregister-crud` also **aborted 33 assertions short** (194 executed on the
base, 161 after) — so the true blast radius is 107 assertions across three
collections.

| collection | base | after #2526 |
|---|---|---|
| `magic-mapper-import` | 17 exec / 0 fail | 17 / **3** |
| `openregister-crud` | 194 / 0 | **161** / **54** |
| `openregister-jsonld` | 29 / 0 | 29 / **17** |

**#2526's body says "the 404 mapping and the API contract are unchanged". True of
the mapping, false of which requests receive one.**

### Which contract is correct: the code's

Not a judgement call — the server contradicts itself inside a single Newman run:

```
magic-mapper-import 5.  POST /api/registers/14/import      -> 200 OK, "All 3 CSV rows were created, none errored"
magic-mapper-import 6.  GET  /api/objects/<reg>/<schema>   -> 404
openregister-jsonld 7.  GET  /api/contexts/<reg>/<schema>  -> 200 OK
openregister-jsonld 3.  POST /api/objects/<reg>/<schema>   -> 404
```

openregister **wrote three rows into a (register, schema) pair and then could not
read that pair back by slug**, and answers 200 on one register-scoped endpoint and
404 on another for the same pair. That is exactly the "rows written and
unreachable" state #2526 was written to eliminate, now produced by the fix itself.
It is a defect in the code, independent of any test collection — and editing the
collections would hide it.

### Root cause: the boundary is enforced but never established

#2526 made `openregister_registers.schemas` **authoritative**. Nothing was changed
to **maintain** it. `POST /api/schemas?register=<id>` has always accepted the
parameter and always ignored it — harmless only while the global fallback existed.

`ImportHandler`, `TablesSchemaSyncService` and `DatabaseIntrospectionService` all
call `setSchemas()` already. `SchemasController::create()` was **the one
register-context schema-creation path that did not**.

### The fix

- `Register::addSchemaId()` records the membership. Additive and idempotent.
  Existing entries are preserved **verbatim** — a normalising rewrite would
  silently drop a non-numeric legacy entry, which is data loss, not cleanup. A
  numeric-string entry counts as the same membership as its int form.
- `create()` consumes `?register=` and persists via `RegisterMapper::update()`, so
  **RBAC and the cross-tenant organisation check both apply**. The lookup passes
  `_multitenancy: false` exactly as `RegisterMapper::updateFromArray()` already
  does; RBAC is left at its default. This is not an authorization opt-out.
- An **unresolvable** register is refused with **400 before the schema is
  written**. Creating a free-floating schema and answering 201 is what made the
  old behaviour invisible.
- A **refused** linkage is logged, not fatal — the schema exists, and a 500 would
  hide a successful write behind an error.
- `register` is no longer passed to `createFromArray()`; a schema row has no
  register column.

**The 404 mapping and import semantics are untouched.** No assertion was relaxed
to accept a 404.

## 2. phpstan — `RegisterSchemaLinkageRepairService.php:120`

`if ($id === null || …)` is unreachable: OCP's `Entity` declares
`@method int getId()` and `RegisterMapper::findAll()` returns only persisted rows.
Guard removed. **No baseline entry, no `ignoreErrors`, no
`treatPhpDocTypesAsCertain: false`.**

## 3. phpmd — `SchemaNotInRegisterException.php:104` BooleanArgumentFlag

`bool $registerListEmpty` becomes `int $registerSchemaCount`. The count is
strictly better than the flag: *"carries no schemas at all"* and *"carries 14
schemas, none of them this slug"* are different diagnoses with different repairs,
and the second is not expressible with a boolean. The message now names the
number. All five call sites updated. **No suppression added.**

## Before / after — each tool's own command, `hermiq-llm-runner:gates`, repo's own `composer install`

| tool | command | files | before | after |
|---|---|---|---|---|
| phpstan | `./vendor/bin/phpstan analyse --memory-limit=1G` | **1446** | 1 error, rc 1 | **0 errors, rc 0** |
| phpmd | the `phpmd` composer script verbatim (both configs, both baselines) | `lib/` | 1 violation, rc 2 | **0, rc 0** |
| phpcs | `--standard=phpcs.xml --warning-severity=0` | **7 changed** | **14** errors | **0** |
| psalm | `--threads=1 --no-cache` | 4 changed lib files | — | **No errors found** |
| phpunit | `--testsuite="Unit Tests"` | 16472 → **16483** tests | — | new tests pass |

The 14 phpcs errors were **pre-existing** in `SchemasController` (the constructor
docblock never gained `$registerMapper` when #2526 injected it). Fixed per L10.

### Shown to fail first (L1)

The six new controller tests, run against the **pre-fix** `SchemasController`
(only that file reverted):

```
FF..F.   3 failed / 6
1) testCreateWithRegisterParamRecordsTheLinkage
   Failed asserting that null is an instance of class OCA\OpenRegister\Db\Register.
   (RegisterMapper::update() was never called)
2) testRegisterParamIsNotHydratedOntoTheSchema
   Failed asserting that an array does not have the key 'register'.
3) testUnresolvableRegisterRefusesTheCreate
   Failed asserting that 500 is identical to 400.
```

Restored: **6 passed**.

⚠️ The full Unit suite hits a `NextcloudInternalStubs` fatal at test 472 in a bare
container (no NC root). **Control run: pristine `development` fails at the
identical point** (472/16472 vs 472/16483) — an environment artefact, not this
change. CI runs the suite inside a Nextcloud checkout.

## Deliberately NOT done

- **No openspec Scenario added.** A new `#### Scenario:` obliges a Playwright spec
  under gate-19; writing one that does not really exercise the behaviour is the
  invisible pass this programme exists to prevent. The behaviour is documented in
  `docs/api/schemas.md` and in code comments instead, and the honest scenario+e2e
  is worth its own slot.
- **`GET /api/schemas?register=` still ignores the parameter** (`index()` filters
  only on `filters`, so `MigrationObject.vue` gets an unfiltered list). Separate
  defect, separate blast radius, not touched.
- **`RegisterMapper` is ~28 lines from PHPMD's `ExcessiveClassLength` (1000).** The
  linkage method's other natural home; putting it there tipped the rule at 1002
  lines. It went on the `Register` entity instead — where list semantics belong —
  rather than growing a foundation class 18 apps depend on, or suppressing the
  rule.

---

## Update after merging `origin/development` (`1395d54f`)

⚠️ **Duplicate work — #2533 fixed the same phpstan and phpmd findings while this
was in flight** (after #2530 was reverted in #2532 for staging 6 886 phantom
deletions). Merged in; both conflicts resolved:

| file | resolution |
|---|---|
| `RegisterSchemaLinkageRepairService.php` | **took `development` wholesale** (`git checkout --theirs`, then `diff`ed byte-identical against `origin/development`). Both sides deleted the identical unreachable `$id === null` arm; only the comment wording differed, and neither side carries behaviour. |
| `SchemaNotInRegisterException.php` | **kept this branch's fix and removed `development`'s `@SuppressWarnings(PHPMD.BooleanArgumentFlag)`.** Its reasoning weighs the flag against two named constructors and against composing the message at each throw site — but the caller already holds the **count**, and passing it satisfies the rule instead of silencing it while making the message strictly more useful. §2 L8: no suppressions. A note in the docblock records the reversal and why. |

Re-measured on the **merged** tree, same commands: **phpstan rc 0, `[OK] No
errors`** · **phpmd rc 0** · 196 tests in the touched suites pass.

### Baseline for parity (L6)

`development` **`1395d54f`**, run **31955355877**, `event=push`, completed,
**36 jobs, ZERO cancelled**, 47 check-runs.

| job | base `1395d54f` | this PR |
|---|---|---|
| PHP Quality (phpstan) | success (via #2533) | success |
| PHP Quality (phpmd) | success (via #2533's suppression) | success (**without** the suppression) |
| **Integration Tests (Newman)** | **failure** — 3 + 54 + 17 = **74** assertions, crud still 33 short | the target of this PR |
| Hydra Gates | failure | inherited |
| Quality Report | failure | derivative |

⚠️ **This PR got NO `Code Quality` run from its `pull_request` trigger** — 5
check-runs (CodeQL ×4 + Conflict markers), no PHPUnit, no gates, no PHP Quality,
no Newman. Same hole the board recorded on shillinq#591. Recovered with
`gh workflow run code-quality.yml --ref S34/openregister-2526-followups`.

## scholiq's E2E seed: this does NOT fix it, and the reason is precise

The board (S29) attributed scholiq's seed failure to #2526. Correct — but this
change does **not** repair it, and the seed log says exactly why.
scholiq run **31957570239**, job **95190681688** (16:09Z, i.e. after #2528):

```
[seed] register import: 118/118 scholiq schemas now present (114 created individually)
[seed]   ! create cohort failed (status 404): {"message":"Schema not found: 'cohort'"}
```

`tests/e2e/seed-example-data.mjs:153` POSTs each schema to
`/api/schemas` **with no `?register=`**, then creates objects at
`/api/objects/${REGISTER_SLUG}/${slug}`. 114 unlinked schemas, therefore 114
unreachable slugs. **This PR supplies the mechanism that fix needs
(`?register=` now records the linkage) but the caller must pass it** — a one-line
change in scholiq, in scholiq's repo, which only works once this lands.

### And the root cause is one level further up — a separate live openregister defect

`SchemaMapper::extractAllOfDelta()` (line 3644) passes each `allOf` entry
straight to `loadSchema(identifier: string|int)`. A JSON-Schema `allOf` entry is
an **object**, so any schema carrying inline conditional validation raises

```
SchemaMapper::loadSchema(): Argument #1 ($identifier) must be of type string|int, array given
```

This is what makes scholiq's **bulk** import (which *does* link schemas) return
`{"success":false}` and fall back to the unlinked per-schema path. It is
long-standing — scholiq's `ci-seed.sh` documents it against CI run 30796644591,
months before #2526 — and it is **still live on `development`**. **Not fixed
here**: it changes schema-composition semantics for 18 apps and needs its own
slot with its own tests.

---

## Measured result — CI run 31958507968 (`workflow_dispatch`, this branch)

**Newman: 74 failed assertions → 6, and `openregister-crud` 161 → 192 executed** —
31 of the 33 assertions that never ran are back.

| collection | base `1395d54f` | this branch |
|---|---|---|
| `magic-mapper-import` | 17 exec / **3** fail | 17 / **0** |
| `openregister-crud` | **161** / **54** | **192** / **6** |
| `openregister-jsonld` | 29 / **17** | 29 / **0** |

**PHP Quality (phpstan) `success` · PHP Quality (phpmd) `success`** — the phpmd
one **without** the `@SuppressWarnings` `development` uses.

### The last six were two different causes — a follow-up commit closes both

**Four: a copy-paste slip in the collection.** `Setup: Create Schema for File
Tests` creates its own register into `file_test_register_id`, then posts
`?register={{register_id}}` — the **main** register — while `File 1/2: Upload`
address the object under `{{file_test_register_slug}}`. It links the schema to a
register it did not mean; the global fallback used to paper over it.
`Setup: Create Schema for Import Tests` carries the identical slip against
`import_test_register_id` and does **not** fail today only because the import
steps address the register by numeric id — i.e. the exact "write lands, slug read
404s" state, sitting latent. Both now name their own register.

**Two: a genuine cross-tenant write.** `3b. Create Schema in Org2` names register
`{{register_id}}`, which belongs to **org1**. Recording that membership goes
through `RegisterMapper::update()`, whose cross-tenant check applies — in the
trait's own words — *"to everyone including admins"*. So while org2 is active the
linkage is refused (logged, not fatal) and 3c/3d 404.

**openregister is not wrong here.** A register's schema list is register state,
and writing another organisation's register from org2 is what multitenancy exists
to stop. `setOrganisationOnCreate()` is the other half: it **overwrites** the
body's `organisation` with the **active** org, which is why the schema is org2's
at all. The link therefore has to be made from org1 — as a real multi-tenant
client would have to — and the collection now does it explicitly:
`3b2` switch to org1 → `3b3` read the list → `3b4` PATCH it with the org2 schema
appended → `3b5` switch back. **3c and 3d are untouched and still assert 201 and
200.**

`3b3` carries a real guard, not a decoration: it asserts the register **already**
carries the two schemas created with `?register=` at steps 2 and 2a before
merging. Without it an empty read would make `3b4` **replace** the register's
linkage with a one-element array, and every later slug read would 404 for a
reason unrelated to the code under test.

**No assertion was relaxed and no expected status was changed to accept a 404.**

⚠️ **A `workflow_dispatch` run has 34 jobs, not 36** — it carries **no
`Hydra Gates` and no `Quality Report`**. Parity on those two is judged from the
`pull_request` run on the final head.

---

# ✅ FINAL — CI run **31958970412**, `pull_request`, head `d6d91175`, **36 jobs, ZERO cancelled**

## Newman is GREEN. 74 failed assertions → **0**.

| collection | base `1395d54f` (run 31955355877) | this PR |
|---|---|---|
| `magic-mapper-import` | 17 exec / **3** fail | 17 / **0** |
| `openregister-crud` | **161** exec / **54** fail | **200** / **0** |
| `openregister-jsonld` | 29 / **17** | 29 / **0** |
| every other collection | 0 | 0 |
| **total AssertionError/TypeError in the log** | **74** | **0** |

`openregister-crud` executes **200** assertions — more than the **194** it managed
before #2526, because the four new linkage steps assert too.

## Parity, job by job, `?per_page=100`, run `conclusion` read via `gh api`

| | base `1395d54f` run 31955355877 (`push`) | PR `d6d91175` run 31958970412 (`pull_request`) |
|---|---|---|
| jobs | 36 | **36** |
| cancelled | 0 | **0** |
| `PHP Quality (phpstan)` | success | **success** |
| `PHP Quality (phpmd)` | success (with a suppression) | **success (without one)** |
| **`Integration Tests (Newman)`** | **failure** | ✅ **success** |
| `PHPUnit` ×6 cells | success | **success ×6** |
| `E2E Tests (Playwright)` | success | **success** |
| `Hydra Gates` | failure | failure — **identical findings** |
| `Quality Report` | failure | failure — derivative of gates |

**Hydra Gates, both sides, same three gates, same counts:**

```
[gate-25] contract-coverage:  FAIL — 72     [gate-25] contract-coverage:  FAIL — 72
[gate-26] visual-coverage:    FAIL — 27     [gate-26] visual-coverage:    FAIL — 27
[gate-7]  no-admin-idor:      FAIL —  8     [gate-7]  no-admin-idor:      FAIL —  8
```

**Zero introduced, one job removed.**

## Across all workflows, not just `Code Quality`

Compared as `commits/<sha>/check-runs?per_page=100` on both heads:

| check | base | PR |
|---|---|---|
| `Newman API Test Suite` (`api-test-coverage`) | **failure** | ✅ **success** |
| `quality / Integration Tests (Newman)` | **failure** | ✅ **success** |
| `quality / Hydra Gates` | failure | failure (identical) |
| `quality / Quality Report` | failure | failure (derivative) |
| everything else | success | success |

**Two failing checks across two workflows cleared; none introduced.**

⚠️ The base head carries 47 check-runs and the PR head 44. The difference is
exactly four **push-only** checks — `beta`, `stable`, `sync / create-pr`,
`unstable / release` — none of which a `pull_request` head can produce. **No
measurement is missing from the PR side.**

⚠️ Also on the record: **the `pull_request` trigger produced NO `Code Quality`
run when this PR was opened** — 5 check-runs, no PHPUnit, no gates, no Newman.
Same hole the board recorded on shillinq#591. It fired normally on the next
`synchronize`. And a **`workflow_dispatch` run is not a substitute for parity
judgement**: it carries 34 jobs and its `Hydra Gates` / `Quality Report` were
cancelled by concurrency when the real run started.
