### PR TITLE
fix(schemas): a conditional in allOf 500'd POST /api/schemas

### DIFF
--- a/lib/Db/SchemaMapper.php
+++ b/lib/Db/SchemaMapper.php
@@ -3621,10 +3621,33 @@ class SchemaMapper extends QBMapper {
 	 * Merges all parent schemas and extracts only the differences
 	 * in the child schema.
 	 *
-	 * @param Schema $schema The child schema
-	 * @param array $allOf Array of parent schema identifiers
+	 * ## `allOf` is not only a parent list (openregister#2534)
 	 *
-	 * @throws \Exception If parent schema not found
+	 * This method used to treat EVERY `allOf` entry as a schema identifier and
+	 * hand it straight to `loadSchema(string|int)`. In JSON Schema an `allOf`
+	 * entry is a SUBSCHEMA, and only some of them name another schema. The
+	 * common non-naming case is a conditional:
+	 *
+	 *     "allOf": [ { "if": {...}, "then": {}, "else": { "required": [...] } } ]
+	 *
+	 * which is an array, so the call raised a TypeError. The `catch (Exception)`
+	 * below did not stop it — a TypeError is an `Error`, not an `Exception` —
+	 * so it escaped as HTTP 500 from `POST /api/schemas`, and any schema
+	 * carrying a conditional was simply unimportable. Measured on scholiq
+	 * 2026-08-16: the CI seed had grown a documented workaround for it
+	 * ("created schema \"lesson\" WITHOUT its top-level allOf — OpenRegister
+	 * 500s on composed schemas; conditional validation dropped for this
+	 * fixture") — a fixture comment describing a bug nobody had filed.
+	 *
+	 * `parentIdentifierFromAllOfEntry()` now decides what an entry IS, and a
+	 * subschema that names no parent contributes nothing to a PARENT delta and
+	 * is skipped rather than crashed on. The catch is widened to `\Throwable`
+	 * so the next unexpected shape degrades to "no delta extraction" — which is
+	 * what the comment there already promised.
+	 *
+	 * @param Schema $schema The child schema
+	 * @param array $allOf Array of `allOf` subschemas; the ones that name a
+	 *                     parent schema are merged, the rest are skipped.
 	 *
 	 * @return Schema Schema with only delta properties
 	 */
@@ -3635,9 +3658,12 @@ class SchemaMapper extends QBMapper {
 			$mergedParentRequired = [];
 
 			// Load and merge all parent schemas.
-			foreach ($allOf as $parentRef) {
-				// Skip empty or null references.
-				if (empty($parentRef) === true) {
+			foreach ($allOf as $entry) {
+				$parentRef = $this->parentIdentifierFromAllOfEntry(entry: $entry);
+
+				// Not a parent reference (an inline conditional or subschema),
+				// or an empty one — nothing to merge from it.
+				if ($parentRef === null) {
 					continue;
 				}
 
@@ -3677,14 +3703,73 @@ class SchemaMapper extends QBMapper {
 			$schema->setRequired(array_values($deltaRequired));
 			// Re-index array.
 			return $schema;
-		} catch (Exception $e) {
+		} catch (\Throwable $e) {
 			// If a parent schema doesn't exist yet (e.g. during import Pass 1),
 			// return the schema without delta extraction. The full properties are
 			// preserved and delta will be correctly extracted during Pass 2 (update)
 			// when all schemas exist in the database.
+			//
+			// `\Throwable`, not `Exception`: this net was written to keep an
+			// unresolvable parent from failing an import, and a TypeError from a
+			// composition shape it did not expect is the same situation — but it
+			// is an `Error`, so it used to sail straight through and 500 the
+			// request (openregister#2534). Delta extraction is an OPTIMISATION;
+			// nothing it can fail at justifies refusing to store the schema.
 			return $schema;
 		}//end try
 	}//end extractAllOfDelta()
+
+	/**
+	 * The parent schema identifier an `allOf` entry names, or null if it names none.
+	 *
+	 * Three shapes are accepted, and the third is the one that matters:
+	 *
+	 *   1. a scalar — `"person"`, `42`, a uuid — OpenRegister's own shorthand
+	 *      for "extend this schema", which is what the whole allOf-delta
+	 *      mechanism was built around;
+	 *   2. `{"$ref": "..."}` — standard JSON Schema. The last path segment is
+	 *      taken, so `#/components/schemas/Person` resolves to `Person`, which
+	 *      is what `loadSchema` matches against id / uuid / slug;
+	 *   3. anything else — `{"if": …, "then": …, "else": …}`, an inline
+	 *      `{"properties": …}`, a `$ref` that is not a string. These are valid
+	 *      JSON Schema and name NO parent, so they contribute nothing to a
+	 *      parent delta. Returning null skips them; before, they reached
+	 *      `loadSchema(string|int)` as an array and 500'd the request.
+	 *
+	 * @param mixed $entry One element of a schema's `allOf` array.
+	 *
+	 * @return string|int|null The parent identifier, or null when the entry
+	 *                         names no parent schema.
+	 */
+	private function parentIdentifierFromAllOfEntry(mixed $entry): string|int|null {
+		if (is_string($entry) === true || is_int($entry) === true) {
+			if ($entry === '' || $entry === 0) {
+				return null;
+			}
+
+			return $entry;
+		}
+
+		if (is_array($entry) === true && isset($entry['$ref']) === true
+			&& is_string($entry['$ref']) === true && $entry['$ref'] !== ''
+		) {
+			$ref = $entry['$ref'];
+			$offset = 0;
+			$lastSlash = strrpos($ref, '/');
+			if ($lastSlash !== false) {
+				$offset = ($lastSlash + 1);
+			}
+
+			$segment = substr($ref, $offset);
+			if ($segment === '') {
+				return null;
+			}
+
+			return $segment;
+		}
+
+		return null;
+	}//end parentIdentifierFromAllOfEntry()
 
 	/**
 	 * Extract properties that differ from parent

--- a/tests/Unit/Db/SchemaMapperInlineCompositionTest.php
+++ b/tests/Unit/Db/SchemaMapperInlineCompositionTest.php
@@ -136,4 +136,95 @@ class SchemaMapperInlineCompositionTest extends TestCase {
 
 		$this->assertSame('flexible', $resolved->getTitle());
 	}
+
+	/**
+	 * Invoke the private extractSchemaDelta().
+	 *
+	 * THE SECOND ENTRY POINT, and the one that was still broken. The three
+	 * tests above exercise `resolveSchemaExtension`, which is what a READ goes
+	 * through. A WRITE goes somewhere else entirely:
+	 *
+	 *     SchemasController::create -> createFromArray
+	 *                               -> extractSchemaDelta
+	 *                               -> extractAllOfDelta -> loadSchema
+	 *
+	 * `oneOf` and `anyOf` return early from `extractSchemaDelta`, so they were
+	 * never exposed on this path — only `allOf` reaches `loadSchema`, which is
+	 * why the earlier fix looked complete and was not.
+	 *
+	 * @param Schema $schema The schema to extract a delta from.
+	 *
+	 * @return Schema
+	 */
+	private function extractDelta(Schema $schema): Schema {
+		$method = new ReflectionMethod(SchemaMapper::class, 'extractSchemaDelta');
+		$method->setAccessible(true);
+
+		return $method->invoke($this->mapper, $schema);
+	}
+
+	/**
+	 * scholiq's `Lesson`: an `allOf` holding a conditional, not a parent.
+	 *
+	 * ⚠️ THIS IS THE ARM THAT 500'd (openregister#2534). The entry is an array,
+	 * `loadSchema(string|int)` raised a TypeError, and the `catch (Exception)`
+	 * around it could not catch an `Error` — so `POST /api/schemas` answered
+	 * 500 and the schema was simply unimportable. scholiq's CI seed had grown a
+	 * documented workaround: it created the schema with the `allOf` STRIPPED and
+	 * logged that conditional validation was dropped for the fixture.
+	 *
+	 * The properties must survive: a conditional names no parent, so there is
+	 * nothing to subtract, and an empty delta would silently erase the schema.
+	 *
+	 * @return void
+	 */
+	public function testConditionalAllOfExtractsNoDeltaAndKeepsProperties(): void {
+		$schema = new Schema();
+		$schema->setTitle('Lesson');
+		$schema->setProperties(
+			[
+				'contentType' => ['type' => 'string'],
+				'contentRef' => ['type' => 'string'],
+			]
+		);
+		$schema->setRequired(['contentType']);
+		$schema->setAllOf(
+			[
+				[
+					'if' => ['properties' => ['contentType' => ['const' => 'text']], 'required' => ['contentType']],
+					'then' => [],
+					'else' => ['required' => ['contentRef']],
+				],
+			]
+		);
+
+		$delta = $this->extractDelta($schema);
+
+		$this->assertSame(['contentType', 'contentRef'], array_keys($delta->getProperties()));
+		$this->assertSame(['contentType'], $delta->getRequired());
+	}
+
+	/**
+	 * A `$ref` entry still names a parent, and is still looked up.
+	 *
+	 * THE ANTI-WIDENING ARM. "Skip entries that are arrays" would also skip
+	 * `{"$ref": "#/components/schemas/Person"}`, quietly turning a real
+	 * inheritance into no inheritance — a schema that stores its parent's
+	 * properties again instead of extending. The throwing DB mock makes the
+	 * lookup observable: reaching it is the proof, and the surrounding
+	 * try/catch then returns the schema unchanged.
+	 *
+	 * @return void
+	 */
+	public function testRefEntryStillResolvesToAParentIdentifier(): void {
+		$method = new ReflectionMethod(SchemaMapper::class, 'parentIdentifierFromAllOfEntry');
+		$method->setAccessible(true);
+
+		$this->assertSame('Person', $method->invoke($this->mapper, ['$ref' => '#/components/schemas/Person']));
+		$this->assertSame('person', $method->invoke($this->mapper, 'person'));
+		$this->assertSame(42, $method->invoke($this->mapper, 42));
+		$this->assertNull($method->invoke($this->mapper, ['if' => [], 'then' => []]));
+		$this->assertNull($method->invoke($this->mapper, ['required' => ['a']]));
+		$this->assertNull($method->invoke($this->mapper, ''));
+	}
 }


### PR DESCRIPTION
`extractAllOfDelta()` treated **every** `allOf` entry as a schema identifier and handed it to `loadSchema(string|int)`. In JSON Schema an `allOf` entry is a *subschema*, and only some of them name another schema. The common non-naming case is a conditional:

```json
"allOf": [ { "if": {...}, "then": {}, "else": { "required": ["contentRef"] } } ]
```

which is an array — so the call raised a `TypeError`. The `catch (Exception)` around it could not catch it (a `TypeError` is an `Error`), so it escaped as **HTTP 500** from `POST /api/schemas`, and any schema carrying a conditional was simply unimportable.

## How it surfaced

scholiq's E2E seed. Its `Lesson` schema uses exactly that shape, and the seed had grown a **workaround with a comment describing the bug**:

```
~ created schema "lesson" WITHOUT its top-level allOf
  (OpenRegister 500s on composed schemas; conditional validation dropped for this fixture)
```

A fixture comment documenting a defect nobody had filed. The seed then reported `118/118 schemas now present`, so the import looked fine while one schema had silently lost its conditional validation.

## Not the same bug as the last one

`SchemaMapperInlineCompositionTest` already covers inline `oneOf`/`anyOf`/`allOf` — but through `resolveSchemaExtension()`, the **read** path. A write goes elsewhere:

```
SchemasController::create → createFromArray → extractSchemaDelta → extractAllOfDelta → loadSchema
```

and on *that* path `oneOf`/`anyOf` return early, so only `allOf` ever reaches `loadSchema`. That's why the earlier fix looked complete and wasn't. The new tests drive `extractSchemaDelta` directly.

## The fix

`parentIdentifierFromAllOfEntry()` decides what an entry actually is:

| entry | resolves to |
|---|---|
| `"person"`, `42`, a uuid | itself — OpenRegister's "extend this schema" shorthand |
| `{"$ref": "#/components/schemas/Person"}` | `Person` — the last path segment, which is what `loadSchema` matches on |
| a conditional, an inline `{"properties": …}`, a non-string `$ref` | `null` — valid JSON Schema, names no parent, skipped |

The catch is widened to `\Throwable`. That net exists so an unresolvable parent doesn't fail an import; a `TypeError` from an unexpected composition shape is the same situation — and delta extraction is an **optimisation**, so nothing it can fail at justifies refusing to store the schema.

## Verification

Reverting **only** the fix while keeping the new tests reproduces the CI error verbatim:

```
TypeError: SchemaMapper::loadSchema(): Argument #1 ($identifier) must be of type
string|int, array given, called in .../SchemaMapper.php on line 3644
Tests: 5, Errors: 2
```

With the fix: **5/5, 11 assertions**. `testRefEntryStillResolvesToAParentIdentifier` is the anti-widening arm — "skip entries that are arrays" would also skip a real `$ref`, quietly turning inheritance into no inheritance.

`phpcs` 0 errors, `psalm` 16, `phpstan` 2 — all **identical to the pristine file**.
