### PR TITLE
test(e2e): widen the CI E2E floor from 9 files to 12 — the write path was unmeasurable

### DIFF
--- a/tests/e2e/ci/playwright.config.ts
+++ b/tests/e2e/ci/playwright.config.ts
@@ -6,8 +6,11 @@
  *
  * WHY A SECOND CONFIG EXISTS
  * --------------------------
- * The root config points `testDir` at the whole of `tests/e2e`, which is 58
- * spec files. Several of them write fixtures, shell out to `occ`, or capture
+ * The root config points `testDir` at the whole of `tests/e2e`, which is 64
+ * spec files / 383 tests (measured 2026-08-16 with `playwright test --list`
+ * from `git archive HEAD`; the prose said 58 and had gone stale, which is why
+ * this line now names the command that produced it). Several of them write
+ * fixtures, shell out to `occ`, or capture
  * documentation screenshots. Turning `enable-playwright` on against that set
  * would have produced a red job on the first run, and a gate that is red on
  * arrival is a gate nobody turns on — which is how this repo ended up with an
@@ -59,6 +62,39 @@
  *         will self-skip.`
  *      Admitting them would raise the executed count while covering nothing.
  *
+ * ⚠️ CRITERION 2 HAS TWO BRANCHES AND ONLY ONE HAD EVER BEEN USED.
+ * ---------------------------------------------------------------
+ * "Non-mutating, OR self-cleaning" — every file admitted before 2026-08-16 took
+ * the first branch, and the sentence that followed it ("All four files admitted
+ * below only navigate, open a modal, and read — they write nothing") described
+ * that accident as though it were the rule. It is not the rule: a spec that
+ * seeds what it needs and removes it again satisfies criterion 2 by its second
+ * branch, and refusing those made the whole write path unmeasurable.
+ *
+ * That mattered, because it is not a small corner. Measured on `development`
+ * `cbb0c813` with `playwright test --list` run from `git archive HEAD` (which
+ * reproduces CI's `Running N tests` exactly): the repo holds **64 spec files /
+ * 383 tests**, and this allow-list ran **9 files / 44 tests — 14 % of the files
+ * and 11 % of the tests**. openregister is the foundation repo for 18 apps, and
+ * a green E2E column that speaks for an eighth of the suite is worth less than
+ * it looks. Every remaining create/update/delete assertion in the repo sat on
+ * the far side of a criterion that had been read one branch too narrowly.
+ *
+ * ⚠️ AND THE INSTANCE IS DISPOSABLE, WHICH IS THE OTHER HALF.
+ * The objection to admitting a fixture-writing spec is that it corrupts the
+ * instance for whatever runs next. That is true of the SHARED dev container on
+ * :8080 — which is why these specs cannot be rehearsed there — and it is not
+ * true here: `quality.yml`'s `playwright` job runs on its own `ubuntu-latest`
+ * runner with its own `postgres:16` service container and its own Nextcloud
+ * checkout, created and destroyed per run. Nothing outside the job can see what
+ * a spec writes. The constraint that kept these files out was a constraint on
+ * REHEARSING them locally, not on running them in CI, and the two were being
+ * treated as one.
+ *
+ * `tests/e2e/_fixtures.ts` already implements the discipline criterion 2's
+ * second branch asks for: every entity is namespaced `e2e-<Date.now()>` so two
+ * runs cannot collide, and `afterAll` deletes exactly what `beforeAll` seeded.
+ *
  * ⚠️ `baseURL` comes from the shared resolver, which accepts CI's `BASE_URL`
  * and has NO localhost default — a default would silently target the shared dev
  * container. See tests/e2e/base-url.ts.
@@ -72,10 +108,10 @@ export default defineConfig({
 	// moving it (and without rewriting its `../.auth` / `../base-url` imports).
 	testDir: '..',
 	// EXPLICIT ALLOW-LIST — nothing runs unless it is named here. This is what
-	// keeps `testDir: '..'` from silently pulling in the ~59 other spec files,
-	// including `api-direct/**` (Newman's job, not Playwright's), `visual/**`
-	// (opt-in project, host-font-specific baselines) and `docs-screenshots`
-	// (journeydoc capture).
+	// keeps `testDir: '..'` from silently pulling in the other 52 spec files,
+	// including `api-direct/**` (25 files / 199 tests — Newman's job, not
+	// Playwright's), `visual/**` (5 files, opt-in project, host-font-specific
+	// baselines) and `docs-screenshots` (journeydoc capture).
 	testMatch: [
 		// The original floor.
 		'ci/*.spec.ts',
@@ -95,6 +131,40 @@ export default defineConfig({
 		// a single test's `finally`. Its outbound GitHub call is stubbed with
 		// `page.route()`, so admitting it adds no external network dependency.
 		'spec-coverage/features-roadmap-surface.spec.ts',
+		// Admitted 2026-08-16. The first specs here to take criterion 2's SECOND
+		// branch — they write, and they clean up after themselves. Until now the
+		// CI floor could not fail on a create, an update or a delete at all: the
+		// nine files above navigate and read, so persistence was the one thing
+		// the E2E column never spoke about. These three assert it end to end
+		// (POST → fresh GET returns the submitted values → the row renders →
+		// DELETE → GET is >=400 and the row is gone), which is the guarantee the
+		// shell specs cannot reach.
+		//
+		// Checked per file against all four criteria:
+		//   1. Hermetic — each seeds its own register/schema/object through the
+		//      documented REST controllers. No `occ`, no docker, no pre-seeded
+		//      data. (`core-crud.spec.ts` is NOT admitted for exactly this
+		//      reason: it hard-codes "the larpingapp register (id=8, schema=18)".)
+		//   2. Self-cleaning — `_fixtures.ts` namespacing plus an `afterAll` that
+		//      re-resolves by slug when a mid-run failure lost the id, so an
+		//      aborted run still tears its fixtures down.
+		//   3. No conditional-assert guards — zero `isVisible().catch(() => false)`
+		//      in all three files.
+		//   4. Their `test.skip()`s are NOT seed-dependent. Each is
+		//      `test.skip(<id> === null)` inside a `mode: 'serial'` describe: a
+		//      cascade guard that can only fire when the CREATE step in the same
+		//      file already failed, which is a red run, not a quiet one. No skip
+		//      here is reachable on a healthy instance.
+		//
+		// 📌 `object-crud.spec.ts` carries one pre-existing `test.fixme` — the
+		// Add Object modal's CodeMirror form is not deterministically fillable
+		// headlessly. It is admitted WITH that fixme visible in the skip column
+		// rather than deleted: a declared gap that reports as a non-pass is the
+		// honest shape, and hiding the file to keep the skip count at zero would
+		// be the invisible pass this config exists to refuse.
+		'crud/register-crud.spec.ts',
+		'crud/schema-crud.spec.ts',
+		'crud/object-crud.spec.ts',
 	],
 	globalSetup: path.resolve(__dirname, '../global-setup.ts'),
 	timeout: 45_000,

--- a/tests/e2e/ci/playwright.config.ts
+++ b/tests/e2e/ci/playwright.config.ts
@@ -165,6 +165,35 @@ export default defineConfig({
 		'crud/register-crud.spec.ts',
 		'crud/schema-crud.spec.ts',
 		'crud/object-crud.spec.ts',
+		// Admitted 2026-08-16, in a SEPARATE commit so the three files above keep
+		// an isolated CI verdict.
+		//
+		// ⚠️ THIS FILE WAS FIRST REFUSED ON THE STRENGTH OF ITS OWN HEADER, AND
+		// THE HEADER IS STALE. The refusal read: "it carries `test.fixme` blocks
+		// for real defects — see its BUG LIST". The file contains **zero**
+		// `test.fixme` calls (`grep -cE '^\s*test\.fixme\(' -> 0`). Its BUG LIST
+		// describes three defects — soft-deleted objects never appearing in
+		// GET /api/deleted, restore returning 200 while restoring nothing, and
+		// `_includeDeleted=true` returning 500 — that are each annotated
+		// `// BUG-N (FIXED)` in the code beside the test, with the root cause
+		// (DeletedController.index() searching without a register/schema context,
+		// so it never reached the per-register/schema magic tables). The three
+		// tests are LIVE REGRESSION LOCKS on that fix, not disabled reports of it.
+		//
+		// Reading the prose instead of the code is the failure mode this repo has
+		// paid for repeatedly: an explanation of a pattern matches the pattern.
+		// The correction is recorded here rather than quietly applied.
+		//
+		// Against the four criteria: hermetic and self-seeding through
+		// `_fixtures.ts` (register + schema + object per describe block);
+		// self-cleaning, including a hard `DELETE /api/deleted/{uuid}` in
+		// `afterAll` so a soft-deleted fixture cannot survive the run; zero
+		// conditional-assert guards. Its single `test.skip` —
+		// `test.skip(trails.length === 0, 'no audit trail entries to render')` —
+		// sits downstream of two tests in the same file that assert the "create"
+		// and "update" audit entries EXIST unconditionally, so a broken audit
+		// trail fails loudly before this skip is ever reachable.
+		'workflows/object-lifecycle-workflows.spec.ts',
 	],
 	globalSetup: path.resolve(__dirname, '../global-setup.ts'),
 	timeout: 45_000,


### PR DESCRIPTION
## openregister's green E2E column is a verdict about NINE FILES

`development` `cbb0c813`, E2E job `95201521110`: **`Running 44 tests using 1 worker` → `44 passed`**, 0 failed, 0 skipped, not truncated, 5.1 min of a 45-min cap. Green, and it speaks for an eighth of the suite.

### The true numbers, measured — not read off the prose

Instrument: `npx playwright test --list`, run from **`git archive HEAD`** (not the working tree — a working-tree `--list` is inflated by the opt-in `visual` project). Calibration: its before-figure is **44**, byte-identical to CI's own `Running 44 tests`. So the instrument is the same one CI uses.

| | files | tests |
|---|---:|---:|
| in `tests/e2e` | **64** | **383** |
| run by the CI allow-list | **9** | **44** |
| **share** | **14.1 %** | **11.5 %** |

The header comment said "58 spec files". It was stale by six files; corrected here, and the line now names the command that produced the number so the next drift is checkable.

### The allow-list's own criteria, quoted

> ⚠️ ADMISSION CRITERIA — all four, checked per file, and the last two are the ones that matter most because a suite can be GREEN and still assert nothing:
>
> 1. Hermetic: no `occ`, no docker, no pre-seeded fixtures.
> 2. Non-mutating, or self-cleaning: no `.fill()`/save/delete path that leaves rows behind. All four files admitted below only navigate, open a modal, and read — they write nothing.
> 3. NO UNCONDITIONAL-PASS DEGRADATION. A spec that wraps its assertions in `if (await x.isVisible().catch(() => false)) { … }` with no `else` PASSES WITHOUT ASSERTING when the data is absent.
> 4. NO SEED-DEPENDENT `test.skip()`. […] Admitting them would raise the executed count while covering nothing.

Criteria 3 and 4 are correct and this PR keeps them. **Criterion 2 was being read one branch too narrowly**, and that is what this PR changes.

### Two things kept the write path unmeasurable, and neither was a criterion

**1. Criterion 2 says "non-mutating, OR self-cleaning" — only the first branch had ever been used.** The sentence following it ("All four files admitted below only navigate, open a modal, and read — they write nothing") described an accident of what happened to be admitted as though it were the rule. Consequence: the nine admitted files navigate and read, so **the E2E column has never been able to fail on a create, an update or a delete.** Persistence is the one thing it does not speak about, in the repo whose entire subject is persistence.

**2. "These specs write fixtures, so they cannot run" conflates rehearsal with execution.** Writing fixtures is genuinely unsafe against the **shared `:8080` dev container** — ten agents share it, and its openregister bind-mount is on another workstream's branch, so it is not even the right bytes. That is why these specs cannot be rehearsed locally. It is **not** true of CI: `quality.yml`'s `playwright` job runs on its own `ubuntu-latest` runner, with its own `postgres:16` service container and its own Nextcloud checkout, created and destroyed per run. Nothing outside the job can observe what a spec writes.

`tests/e2e/_fixtures.ts` already implements the discipline criterion 2's second branch asks for — every entity namespaced `e2e-<Date.now()>`, `afterAll` deleting exactly what `beforeAll` seeded, and a teardown that re-resolves by slug when a mid-run failure lost the id.

### Before / after

| | files | collected | executing | declared skip |
|---|---:|---:|---:|---:|
| before | 9 | **44** | 44 | 0 |
| after | 12 | **57** | 56 | 1 |

Both measured with the same command from `git archive HEAD`, `git status --porcelain` empty on both sides.

### Admitted, and why

| file | tests | what it can now fail on |
|---|---:|---|
| `crud/register-crud.spec.ts` | 4 | CREATE through the **real UI form** (`cn-cta-primary` → `cn-form-dialog` → fill → submit), then persistence, list re-render, DELETE gone from API *and* list |
| `crud/schema-crud.spec.ts` | 4 | a schema's property set round-tripping across an update, asserted on a **fresh GET** rather than the write's own echo |
| `crud/object-crud.spec.ts` | 5 | field-value persistence and a deep-link that renders the created object's own uuid |

All four criteria, checked per file:

1. **Hermetic** — each seeds its own register/schema/object through the documented REST controllers. No `occ`, no docker, no pre-seeded data.
2. **Self-cleaning** — `_fixtures.ts` namespacing plus an `afterAll` that re-resolves by slug, so an aborted run still tears its fixtures down.
3. **No conditional-assert guards** — zero `isVisible().catch(() => false)` in all three files.
4. **Their `test.skip()`s are not seed-dependent.** Every one is `test.skip(<id> === null)` inside a `mode: 'serial'` describe — a cascade guard reachable only when the CREATE step *in the same file* has already failed, which is a red run, not a quiet one.

📌 **`object-crud.spec.ts` carries one pre-existing `test.fixme`** — the Add Object modal's CodeMirror form is not deterministically fillable headlessly. It is admitted **with that fixme visible in the skip column**. Deleting it, or holding the file back to keep the skip count at zero, would be exactly the invisible pass this config exists to refuse. **The skip count therefore goes 0 → 1, and it is declared, reason-bearing and pre-existing.**

⚠️ **The failure count may go up.** A spec that has never executed is an unknown verdict, not a latent pass. If one of these thirteen fails, that is this PR working.

### Not admitted, per file — the other 52

Refused **by design, permanently** (32 files / 221 tests): `api-direct/**` (25 / 199 — Newman's job, and the root config excludes them too), `visual/**` (5 / 10 — opt-in project, host-font-specific PNG baselines), `docs-screenshots.spec.ts` (11) and `leaf-screenshots.spec.ts` (1) — journeydoc/ADR-030 capture harnesses that write PNGs into `docs/`.

Refused on a **measured** criterion (18 files / 93 tests):

| file | tests | criterion | evidence |
|---|---:|---|---|
| `core-crud.spec.ts` | 7 | 1 | its own header: *"Uses the larpingapp register (id=8, schema=18) which has a known test object"* — a hard-coded pre-seeded fixture |
| `spec-coverage/mdm-frontend` / `mdm-merge-ui` / `mdm-survivorship-override` | 12 | 4 | headers state they *"degrade to `test.skip()`"* without the MDM seed; CI's log confirms it every run |
| `workflows/dsar-cases.spec.ts` | 11 | 3 | named in the config already; 8 `isVisible` guards |
| `spec-coverage/saved-search-views.spec.ts` | 6 | 3 + 4 | 27 `isVisible` guards, 19 `test.skip` |
| `spec-coverage/platform-administration-modals.spec.ts` | 9 | 3 + 4 | 11 `isVisible`, 5 `test.skip`; SOLR/LLM-config dependent |
| `spec-coverage/files-sidebar-tabs.spec.ts` | 6 | 3 + 4 | 10 `isVisible`, 7 `test.skip` |
| `spec-coverage/register-i18n.spec.ts` | 7 | — | the spec itself records these surfaces as **NOT YET IMPLEMENTED** |
| `spec-coverage/entity-management-modals.spec.ts` | 3 | 3 | an `isVisible`-gated `test.skip` |
| `spec-coverage/data-import-export.spec.ts` | 2 | 3 | 5 `isVisible` guards |
| `spec-coverage/object-views-kanban-calendar.spec.ts` | 2 | 4 | `test.skip(!kanbanViewId, 'no kanban view seeded')` |
| `flow-engine.spec.ts` | 9 | 1 | needs a provisioned flow store |
| `integration-mount.spec.ts` | 1 | 1 | needs provider leaf apps installed |
| `workflows/dsar-escalation-and-dpia.spec.ts` | 3 | 1 | drives temporal sweep jobs via `occ` |
| `workflows/semantic-object-handoff.spec.ts` | 4 | 1 | needs a providing app deployed |
| `workflows/archival-transfer-hardening.spec.ts` | 3 | 4 | every test is gated on an `OR_EDEPOT_*_FIXTURE` env var (`'OR_EDEPOT_BAGIT_FIXTURE (a completed bagit transfer uuid) not seeded'`) — textbook seed-dependent skip |
| `workflows/object-lifecycle-workflows.spec.ts` | 8 | **none — I was wrong, see below** | — |

**Reconciliation** — 32 + 18 + 2 excluded files + 12 admitted = **64**; 221 + 93 + 12 excluded tests + 57 admitted = **383**. Every file is accounted for exactly once. ⚠️ Both bucket totals above are corrected: I first published "35 files" and "16 files / 90 tests", and the reconciliation is what caught them — I had dropped `workflows/archival-transfer-hardening.spec.ts` from the table entirely and mis-added the by-design files. A per-file table that does not sum to the census is not a table, it is a list.

> 🔴 **Second correction, and it is the same mistake in a new costume.** I first excluded
> `workflows/object-lifecycle-workflows.spec.ts` because *"it carries `test.fixme` blocks for real defects (see its
> BUG LIST)"*. **I was reading its header comment, not its code.** The file contains **zero `test.fixme` calls**
> (`grep -cE '^\s*test\.fixme\(' → 0`). Its header's BUG LIST — soft-deleted objects invisible in `/api/deleted`,
> restore a silent no-op, `_includeDeleted=true` returning 500 — is **stale prose**: all three are annotated
> `// BUG-N (FIXED)` in the code beside the tests, each with its root cause, and the three tests are now live
> regression locks on that fix. The file is self-seeding through `_fixtures.ts`, self-cleaning in `afterAll`
> (including a hard `DELETE /api/deleted/{uuid}`), and has **0** conditional-assert guards.
>
> This is the board's named pattern — *an explanation of a pattern matches the pattern* — with the sign flipped:
> prose describing fixmes that no longer exist read as evidence that they do. It is the exact class of error this
> slot exists to find, committed by me, in the artefact I wrote to report it. **The file is a candidate, and it is
> being admitted in a second, separately-measured commit** so the three CRUD files keep an isolated verdict.

Two findings that are not exclusion reasons:

🔴 **`smoke-boot.spec.ts` (root, 2 tests) is a duplicate.** It is byte-identical to the admitted `ci/smoke-boot.spec.ts` apart from one `../` in the storage-state path. Admitting it would add two tests and zero coverage. It is dead weight and should be deleted, in its own PR.

🔴 **`ui-navigation.spec.ts` (10 tests) passes all four criteria and is still refused** — but my first reason for refusing it was wrong, and the corrected one is narrower.

> ⚠️ **Correction, recorded rather than edited away.** I first wrote that its assertions — `#header` visible, and `main, .app-content` visible — are "Nextcloud chrome that renders whether or not the app mounts." **That is true of `#header` and false of `main`.** `#header` comes from core's `layout.user.php:65`. `main.app-content` does **not** exist in any PHP template: openregister's `templates/index.php` emits only `<div id="openregister"></div>`, and the `<main>` carrying `app-content-vue` is created by **nc-vue's `NcAppContent`** (`createElementBlock("main", …)` in its dist chunk). So it requires the Vue app to have mounted. I reasoned from a template I had not finished reading.

The accurate objection is **route-insensitivity**, not "it can never fail". All seven hash routes in its loop are served identical server HTML, and the assertion reads nothing that varies by route — so the seven tests named `#/registers renders`, `#/schemas renders`, `#/objects renders` … are **seven copies of one assertion: "the bundle mounted"**. The three tests below the loop are a fourth, fifth and sixth copy. And that assertion is already made, better, by the admitted `ci/smoke-boot.spec.ts`, which counts `#openregister`'s rendered children *and* tracks boot-killer console errors — its own header explains why the container form is insufficient: *"`toBeVisible()` on a container is NOT sufficient — the shell is visible when the app is dead."*

So admitting it would add **10 to the executed count and nothing to the measured surface**, while attaching six route names to a signal that does not depend on the route. **A fifth criterion is owed:** *a test named for a route must assert something that only that route produces.*

### ✅ MEASURED — commit 1 (three CRUD files), CI job `95208100238`

```
Running 57 tests using 1 worker
  1 skipped
  56 passed (6.3m)
```

**57 collected = 56 + 1 + 0. Not truncated.** Baseline for comparison, job `95201521110` on `development` `cbb0c813`: `Running 44 tests` → `44 passed`, 0 failed, 0 skipped, 5.1m.

| | collected | passed | failed | skipped |
|---|---:|---:|---:|---:|
| before | 44 | 44 | 0 | 0 |
| after | **57** | **56** | **0** | **1** |

The 1 skip is the declared `test.fixme` in `object-crud.spec.ts`, exactly as stated above. Proved rather than assumed that a `test.fixme` lands in the skipped bucket: a two-test throwaway spec run through this repo's own Playwright gives `1 skipped / 1 passed`.

⚠️ **Zero failures was the OPPOSITE of my prediction, so I treated it as suspect rather than as success.** The check is whether the thirteen actually executed. From the run's own list output — all twelve executing tests present by name, with durations proportional to real browser work, and the fixme as `-`:

```
✓ 19 crud/register-crud.spec.ts:63  › CREATE a register through the UI and assert it persisted (8.7s)
✓ 20 crud/register-crud.spec.ts:129 › READ — the new register renders as a real row … (5.7s)
✓ 21 crud/register-crud.spec.ts:145 › UPDATE — edit the title and assert persistence + re-render (5.8s)
✓ 22 crud/register-crud.spec.ts:179 › DELETE — remove the register and assert it is gone … (6.3s)
✓ 23-26 crud/schema-crud.spec.ts    › CREATE / READ / UPDATE / DELETE (0.5s, 5.7s, 6.5s, 6.4s)
✓ 14-17 crud/object-crud.spec.ts    › CREATE / READ / UPDATE / DELETE (0.95s, 6.6s, 7.4s, 0.93s)
-  18 crud/object-crud.spec.ts:208  › UI: create an object through the Add Object modal
```

The 8.7 s CREATE is the one that drove the real `CnFormDialog`. Job duration 6.3 m against a 45-min cap and a 38-min `globalTimeout` — **ample headroom for the floor to keep growing.**

📌 **Stated honestly: I did not run a mutation control against the application to prove these thirteen CAN fail.** What is established is that they collected, executed, took real time, and asserted against real persisted state — and that they had **never executed in CI before**, so their verdict was unknown rather than latent. "Unknown → green" is a smaller claim than "green", and it is the one I am making.

### ✅ MEASURED — commit 2 (`workflows/object-lifecycle-workflows.spec.ts`), CI job `95209483088`

```
Running 65 tests using 1 worker
  1 skipped
  64 passed (6.4m)
```

**65 collected = 64 + 1 + 0. Not truncated.** All eight executed by name — including the three `BUG-N` regression locks, which now hold the soft-delete/restore path:

```
✓ 61 › deleting an object makes its direct GET return 404 (soft-delete applied) (893ms)
✓ 62 › BUG-1: the soft-deleted object appears in GET /api/deleted (439ms)
✓ 63 › BUG-2: restoring brings the object back into its register/schema (870ms)
✓ 64 › BUG-3: objects list with _includeDeleted=true does not 500 (427ms)
```

📌 That file's own `test.skip(trails.length === 0, 'no audit trail entries to render')` **did not fire** — test 60 ran and passed in 5.8 s. **The whole 65-test run contains exactly one `-`, and it is the declared `object-crud` fixme.**

### Net result

| | files | collected | passed | failed | skipped |
|---|---:|---:|---:|---:|---:|
| `development` (job `95201521110`) | 9 | 44 | 44 | 0 | 0 |
| commit 1 (job `95208100238`) | 12 | 57 | 56 | 0 | 1 |
| **commit 2 (job `95209483088`)** | **13** | **65** | **64** | **0** | **1** |

**9 → 13 files, 44 → 65 tests. 14.1 % → 20.3 % of the suite's files, 11.5 % → 17.0 % of its tests.** More to the point than the percentages: openregister's E2E column can now fail on a create, an update, a delete, a soft-delete and a restore, and until today it could not fail on any of them.

⚠️ Commit 1's run reads `completed/cancelled` at RUN level — my own push superseded it. Its **job** is `completed/success`, attempt 1, and the tally above is read from the job endpoint. A run-level cancellation says nothing about jobs that already finished inside it.

### Parity vs `development` — TRULY NEW: none

Both sides read complete and unpaginated (`total_count == rows`), **both at `pending=0`**, all workflows compared:

```
PR   S43/e2e-widen-ci-allowlist  total=44 rows=44 pending=0   failing: {Hydra Gates, Quality Report}
BASE development                 total=47 rows=47 pending=0   failing: {Hydra Gates, Quality Report}
TRULY NEW: (none)      FIXED: (none)
```

The four checks on `development` with no PR counterpart are `beta`, `stable`, `sync / create-pr` and `unstable / release` — **push/branch-only workflows that can never appear on a PR**, so they are excluded rather than counted as fixed.

Gate-level, reconciled against the runner's own `RESULT` line on both sides (3 parsed = `RESULT: 3 GATE(S) FAILED`):

| gate | base | PR |
|---|---:|---:|
| gate-7 no-admin-idor | 8 | **8** |
| gate-25 contract-coverage | 72 | **72** |
| gate-26 visual-coverage | 27 | **27** |

**Byte-identical apart from the run's temp-directory name. INTRODUCED: none. FIXED: none.** 44 check-runs on the PR.

### Deliberately NOT done

- **No spec was rehearsed locally.** `:8080` is the wrong instrument twice over — it bind-mounts a checkout on another branch, and ten agents share its data. A private instance was rejected on machine load (385 MB free, 13.4 GB of 16 GB swap in use — the condition that took this box down earlier today). **CI is the instrument, and CI's verdict on this PR is the measurement.**
- **Nothing was skipped, quarantined, excluded, or given a longer timeout.** No `test.skip` was added or removed anywhere.
- **No import or composition semantics touched** — the diff is one config file's `testMatch` array and its header comments.
