### PR TITLE
fix(security): an anon-only rate limit throttles AUTHENTICATED callers — 8 endpoints

### DIFF
--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -1087,6 +1087,7 @@ class ObjectsController extends Controller {
 	 *
 	 * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md
 	 */
+	#[UserRateLimit(limit: 600, period: 60)]
 	#[AnonRateLimit(limit: 120, period: 60)]
 	public function index(string $register, string $schema, ObjectService $objectService): JSONResponse {
 		// Read paths were unmeasured: WritePhaseProbe::flush() is only reached
@@ -1761,6 +1762,7 @@ class ObjectsController extends Controller {
 	 *
 	 * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md
 	 */
+	#[UserRateLimit(limit: 300, period: 60)]
 	#[AnonRateLimit(limit: 60, period: 60)]
 	public function geoSearch(string $register, string $schema, ObjectService $objectService): JSONResponse {
 		if ($this->geoFilterParser === null || $this->geoFilterApplier === null) {
@@ -2144,6 +2146,7 @@ class ObjectsController extends Controller {
 	 *
 	 * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md
 	 */
+	#[UserRateLimit(limit: 600, period: 60)]
 	#[AnonRateLimit(limit: 120, period: 60)]
 	public function objects(ObjectService $objectService): JSONResponse {
 		// Check for register/schema in query parameters for magic mapper routing.
@@ -2364,6 +2367,7 @@ class ObjectsController extends Controller {
 	 *
 	 * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md
 	 */
+	#[UserRateLimit(limit: 600, period: 60)]
 	#[AnonRateLimit(limit: 120, period: 60)]
 	public function show(
 		string $id,
@@ -2771,6 +2775,7 @@ class ObjectsController extends Controller {
 	 *
 	 * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md
 	 */
+	#[UserRateLimit(limit: 300, period: 60)]
 	#[AnonRateLimit(limit: 30, period: 60)]
 	public function update(
 		string $register,
@@ -2993,6 +2998,7 @@ class ObjectsController extends Controller {
 	 *
 	 * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md
 	 */
+	#[UserRateLimit(limit: 300, period: 60)]
 	#[AnonRateLimit(limit: 30, period: 60)]
 	public function patch(
 		string $register,
@@ -3228,6 +3234,7 @@ class ObjectsController extends Controller {
 	 *
 	 * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md
 	 */
+	#[UserRateLimit(limit: 300, period: 60)]
 	#[AnonRateLimit(limit: 30, period: 60)]
 	public function postPatch(
 		string $register,
@@ -3370,6 +3377,7 @@ class ObjectsController extends Controller {
 	 *
 	 * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md
 	 */
+	#[UserRateLimit(limit: 300, period: 60)]
 	#[AnonRateLimit(limit: 30, period: 60)]
 	public function destroy(string $id, string $register, string $schema, ObjectService $objectService): JSONResponse {
 		\OCA\OpenRegister\Service\WritePhaseProbe::stamp('ctrl.destroy.in');


### PR DESCRIPTION
BUG-RATE-1 was diagnosed and fixed for `create()` alone. Seven sibling endpoints
on the same controller still carry `#[AnonRateLimit]` with no `#[UserRateLimit]`,
and the comment above `create()` already spells out why that is a defect —
including that it caps "this app's own CI test suite".

Nextcloud's `RateLimitingMiddleware::beforeController()`, verified in this
checkout rather than taken from the docblock:

    if ($this->userSession->isLoggedIn()) {
        $rateLimit = …readLimit…(UserRateLimit::class);
        if ($rateLimit !== null) { registerUserRequest(…); return; }
        // If not user specific rate limit is found the Anon rate limit applies!
    }
    $rateLimit = …readLimit…(AnonRateLimit::class);
    if ($rateLimit !== null) {
        registerAnonRequest(…, $this->request->getRemoteAddress());
    }

🔴 Note the last argument: the anon limiter keys on **IP ADDRESS**. So it is not
merely that logged-in users get the anonymous budget — every authenticated user
behind a shared egress IP shares ONE bucket. On `destroy` that is 30 deletes per
minute for an entire NAT'd office, or for a whole CI runner.

Before → after:

    index       anon 120  user (none) → 600
    geoSearch   anon  60  user (none) → 300
    objects     anon 120  user (none) → 600
    show        anon 120  user (none) → 600
    create      anon  30  user 300     (unchanged — the existing precedent)
    update      anon  30  user (none) → 300
    patch       anon  30  user (none) → 300
    postPatch   anon  30  user (none) → 300
    destroy     anon  30  user (none) → 300

Writes mirror `create()`'s existing 300/60 exactly. Reads get 600/60, keeping the
same 5× ratio over their own anon limit. **No anon limit is changed**, so the
anonymous abuse surface is untouched — this only stops an anonymous cap being
applied to identified callers.

#### How it surfaced, and the measurement
decidesk's `Integration Tests (Newman)` fails intermittently on `development`
with `Teardown: all seeded objects deleted (governance body 200/204)`, which
reads like a leaked object. It is not:

    expected 429 to be one of [ 200, 204 ]

Its teardown issues 46 DELETEs; against a 30/60 cap the window overflows in every
run measured. Whether it goes red is decided by RUNNER SPEED — a fast run
compresses the deletes into ~66s and 17 of them 429, a slow run spreads them over
~84s so the overflow is absorbed by an earlier collection whose deletes carry no
assertions. **A faster machine fails.** That is why it looks random, and why
"success on development right now" was not evidence of health: 4 of the last 10
`development` runs failed.

⚠️ Scope note: this repairs the CAUSE. decidesk's assertion is doing its job and
is deliberately not relaxed; its misleading NAME (it asserts one status code, not
the absence of leaks) is worth a separate decidesk change.

---

## Provenance

Found while clearing a blocker on **decidesk#511**. The coordinator asked me to fix a suspected object leak at its source; the leak does not exist — the assertion that looked like a leak check is a status-code check, and the status is **429**.

## Why the anon limit is worse than "logged-in users get the anon budget"

`registerAnonRequest()` is keyed on `$this->request->getRemoteAddress()`. So the bucket is **per-IP, not per-user**. Every authenticated user behind one egress IP — a NAT'd office, a CI runner, an integration host — shares a single 30/minute budget on `destroy`, `update`, `patch` and `postPatch`.

This is a production defect, not only CI hygiene: any authenticated bulk import or integration deleting/updating more than 30 objects a minute is getting 429s today.

## Verified, not inferred

I read the middleware in this checkout rather than trusting the docblock — `lib/private/AppFramework/Middleware/Security/RateLimitingMiddleware.php`, `beforeController()`. The comment `// If not user specific rate limit is found the Anon rate limit applies!` sits directly on the fall-through, and the `registerAnonRequest` call passes the remote address.

The precedent is in this same file: `create()` already carries `#[UserRateLimit(limit: 300, period: 60)]` with a docblock (BUG-RATE-1) that names *"bulk imports/integrations and this app's own CI test suite"*. **The fix was simply never propagated to the other eight.** After this change, every `#[AnonRateLimit]` on the controller has a `#[UserRateLimit]` sibling — verified programmatically, 0 gaps.

`php -l` clean. No anon limit is altered, so the anonymous abuse surface is unchanged.

## What I did NOT do

- **Did not relax decidesk's Newman assertion.** It is doing exactly what the fleet wants.
- **Did not fix the assertion's misleading name** (`decidesk.postman_collection.json:828` asserts one status code, not the absence of leaks) — that belongs in decidesk.
- **Did not sweep other controllers** for the same pattern. `ObjectsController` is where the evidence is; a fleet-wide `AnonRateLimit`-without-`UserRateLimit` sweep is worth its own slot.

⚠️ I could not run `phpcs` locally (vendor requires PHP ≥ 8.3, local is 8.2), so CI is the first real lint verdict on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)