### PR TITLE
fix(security): tenant-scope object-name resolution — closes gate-7 (SEC-CTRL-2 step 2)

### DIFF
--- a/CODE-REVIEW-IMPROVEMENT-PLAN.md
+++ b/CODE-REVIEW-IMPROVEMENT-PLAN.md
@@ -84,7 +84,15 @@ Performance work is dominated by N+1 query patterns in the render path and per-r
   (If non-admins are meant to read configs they own, use an owner check instead of leaving it open.)
 - **Verify:** As a non-admin, `curl '.../api/configurations/1/export?includeObjects=true'` → 403. Add an integration test.
 
-## SEC-CTRL-2 — Public `names` endpoint leaks object/organisation names _(high, partially verified)_
+## SEC-CTRL-2 — Public `names` endpoint leaks object/organisation names _(high — **CLOSED**)_
+- **Status:** step 1 landed in #2523 (`show`/`stats`/`warmup` removed, `@PublicPage` dropped from `index`/`create`). **Step 2 is done**: name resolution is tenant-scoped inside `CacheHandler`.
+  - `hasOrganisationAccess()` mirrors `Db\MultiTenancyTrait::applyOrganisationFilter()` — multitenancy-off or an admin under an enabled override is unrestricted; otherwise the active organisation plus its parents; no active organisation means no names. An entity whose owning organisation cannot be established is refused rather than guessed.
+  - The magic-table queries select `_organisation` alongside `_name`; that column is the tenancy oracle, because an `ObjectEntity` produced by `MagicMapper::rowToObjectEntity()` never carries an organisation at all (measured — a separate, still-open defect, deliberately not fixed here because populating it changes `PermissionHandler::filterUuidsForPermissions()` behaviour).
+  - The **cache key is unchanged**; the tenancy rides in the value (a parallel in-memory map, a `{n,o}` envelope in the distributed cache), so all existing invalidation sites keep matching and a moved object cannot orphan an entry under a stale prefix. A pre-upgrade bare-string entry reads as a MISS, not as an unscoped hit.
+- **Controls:** `tests/Unit/Service/Object/CacheHandlerTenantScopeTest.php` — nine tests, six of which were RED against the pre-fix implementation (object path, organisation path, warm-cache path, `getAllObjectNames()`, magic-table warmup, unknown tenancy) plus the partial-map contract the six internal callers consume.
+- **Still open (separate change):** RBAC (register/schema `authorization` blocks) is not evaluated by the name resolver — only the organisation dimension is. `getSingleObjectName()`'s database lookup is still `_rbac: false, _multitenancy: false`; it is the ANSWER that is now gated, not the query.
+
+### Original finding (kept for the record)
 - **File:** `lib/Controller/NamesController.php` — `index()` `:114-117` (`#[NoAdminRequired]`/`#[PublicPage]`, no auth check, calls `getAllObjectNames()` at `:173`). Backing: `lib/Service/Object/CacheHandler.php` `warmupNameCache()` — `findAllWithUserCount()` `:1460` (all orgs) + `getObjectMapper()->findAll()` `:1472` (no RBAC).
 - **Verification nuance:** `index()` + `warmupNameCache` confirmed unauthenticated and RBAC-blind. **But** `create()` requires an `ids[]` body (resolves via `getMultipleObjectNames`, not the full dump), and `MagicMapper::findAll()` returns `[]` when no register/schema is supplied (`MagicMapper.php:7032-7038`), so the *full* unbounded object-name dump may not materialise via that exact path — the **organisation** name leak and the per-`ids` resolution leak are the concrete risks.
 - **Fix:**

--- a/lib/Controller/NamesController.php
+++ b/lib/Controller/NamesController.php
@@ -119,11 +119,13 @@ class NamesController extends Controller {
 			return new JSONResponse(data: ['error' => 'Authentication required'], statusCode: 401);
 		}
 
-		// TODO(SEC-CTRL-2): make name resolution RBAC/tenant-aware. getMultipleObjectNames()
-		// and getAllObjectNames() in lib/Service/Object/CacheHandler.php
-		// (warmupNameCache / findAllWithUserCount / getObjectMapper()->findAll()) currently
-		// return names across ALL organisations with no RBAC filtering. Filter by the
-		// caller's read permissions + active organisation there before widening exposure.
+		// SEC-CTRL-2 step 2 (closed): name resolution is tenant-scoped in
+		// CacheHandler itself. getMultipleObjectNames() and getAllObjectNames()
+		// resolve the caller's active organisation (plus its parents, mirroring
+		// Db\MultiTenancyTrait) and refuse any name whose owning organisation is
+		// outside it — including names already sitting in the shared cache, whose
+		// tenancy is stored alongside the value. A name with no resolvable owning
+		// organisation is refused rather than guessed.
 		$startTime = microtime(true);
 
 		try {
@@ -268,8 +270,9 @@ class NamesController extends Controller {
 			return new JSONResponse(data: ['error' => 'Authentication required'], statusCode: 401);
 		}
 
-		// TODO(SEC-CTRL-2): getMultipleObjectNames() in CacheHandler resolves names with
-		// no RBAC/tenant filtering; restrict resolved ids to those the caller may read.
+		// SEC-CTRL-2 step 2 (closed): getMultipleObjectNames() only resolves ids
+		// whose owning organisation is inside the caller's active-organisation
+		// scope, so a caller-supplied UUID from another tenant resolves to nothing.
 		$startTime = microtime(true);
 
 		try {

--- a/lib/Service/Object/CacheHandler.php
+++ b/lib/Service/Object/CacheHandler.php
@@ -109,7 +109,7 @@ class CacheHandler {
 	 *
 	 * @var array<string, string|null>
 	 */
-	private array $nameCacheOrganisation = [];
+	private array $nameOrganisations = [];
 
 	/**
 	 * Memoised name-visibility scope for the current request (SEC-CTRL-2 step 2)
@@ -202,6 +202,10 @@ class CacheHandler {
 	 * @param IDBConnection|null $db Database connection for magic table queries
 	 * @param IGroupManager|null $groupManager Group manager for the admin-override arm of the name scope
 	 * @param IAppConfig|null $appConfig App config for the multitenancy switches read by the name scope
+	 *
+	 * @SuppressWarnings(PHPMD.ExcessiveParameterList) Nextcloud constructor injection:
+	 * every parameter is a distinct collaborator resolved by the DI container, and the
+	 * two added by SEC-CTRL-2 step 2 are the same pair Db\MultiTenancyTrait consumes.
 	 *
 	 * @spec openspec/specs/object-lifecycle/spec.md
 	 */
@@ -565,7 +569,7 @@ class CacheHandler {
 	 * @spec openspec/specs/object-lifecycle/spec.md
 	 */
 	private function rememberNameOrganisation(string $key, ?string $organisation): void {
-		$this->nameCacheOrganisation[$key] = $organisation;
+		$this->nameOrganisations[$key] = $organisation;
 	}//end rememberNameOrganisation()
 
 	/**
@@ -985,8 +989,8 @@ class CacheHandler {
 				// Remove from in-memory name cache (name AND its recorded tenancy).
 				unset($this->nameCache[$object->getUuid()]);
 				unset($this->nameCache[(string)$object->getId()]);
-				unset($this->nameCacheOrganisation[$object->getUuid()]);
-				unset($this->nameCacheOrganisation[(string)$object->getId()]);
+				unset($this->nameOrganisations[$object->getUuid()]);
+				unset($this->nameOrganisations[(string)$object->getId()]);
 
 				// Remove from distributed name cache.
 				if ($this->nameDistributedCache !== null) {
@@ -1098,7 +1102,7 @@ class CacheHandler {
 
 		foreach ($keys as $key) {
 			unset($this->nameCache[$key]);
-			unset($this->nameCacheOrganisation[$key]);
+			unset($this->nameOrganisations[$key]);
 
 			if ($this->nameDistributedCache !== null) {
 				try {
@@ -1134,7 +1138,7 @@ class CacheHandler {
 		$this->objectCache = [];
 		$this->inMemoryQueryCache = [];
 		$this->nameCache = [];
-		$this->nameCacheOrganisation = [];
+		$this->nameOrganisations = [];
 		$this->stats = [
 			'hits' => 0,
 			'misses' => 0,
@@ -1295,6 +1299,8 @@ class CacheHandler {
 	 *
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 * @SuppressWarnings(PHPMD.NPathComplexity)
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Three cache layers plus a
+	 * two-source database fallback, each now gated on the caller's organisation.
 	 *
 	 * @spec openspec/specs/object-lifecycle/spec.md
 	 */
@@ -1306,7 +1312,7 @@ class CacheHandler {
 		// is only served to a caller whose organisation may see the entity it
 		// belongs to; an entry with no recorded tenancy is refused.
 		if (($this->nameCache[$key] ?? null) !== null) {
-			if ($this->hasOrganisationAccess($this->nameCacheOrganisation[$key] ?? null) === false) {
+			if ($this->hasOrganisationAccess(organisation: ($this->nameOrganisations[$key] ?? null)) === false) {
 				return null;
 			}
 
@@ -1321,9 +1327,9 @@ class CacheHandler {
 		// Check distributed cache.
 		if ($this->nameDistributedCache !== null) {
 			try {
-				$envelope = $this->readNameEnvelope($this->nameDistributedCache->get('name_' . $key));
+				$envelope = $this->readNameEnvelope(cached: $this->nameDistributedCache->get('name_' . $key));
 				if ($envelope !== null) {
-					if ($this->hasOrganisationAccess($envelope['o']) === false) {
+					if ($this->hasOrganisationAccess(organisation: $envelope['o']) === false) {
 						return null;
 					}
 
@@ -1378,7 +1384,7 @@ class CacheHandler {
 						);
 					}
 
-					if ($this->hasOrganisationAccess($organisation->getUuid()) === false) {
+					if ($this->hasOrganisationAccess(organisation: $organisation->getUuid()) === false) {
 						return null;
 					}
 
@@ -1407,7 +1413,7 @@ class CacheHandler {
 					);
 				}
 
-				if ($this->hasOrganisationAccess($objectOrganisation) === false) {
+				if ($this->hasOrganisationAccess(organisation: $objectOrganisation) === false) {
 					return null;
 				}
 
@@ -1467,11 +1473,11 @@ class CacheHandler {
 		$unrestricted = ($this->resolveNameScope() === null);
 		foreach ($identifiers as $identifier) {
 			$key = (string)$identifier;
-			$cachedOrganisation = $this->nameCacheOrganisation[$key] ?? null;
+			$cachedOrganisation = $this->nameOrganisations[$key] ?? null;
 			if (($this->nameCache[$key] ?? null) !== null
 				&& ($cachedOrganisation !== null || $unrestricted === true)
 			) {
-				if ($this->hasOrganisationAccess($cachedOrganisation) === true) {
+				if ($this->hasOrganisationAccess(organisation: $cachedOrganisation) === true) {
 					$results[$key] = $this->nameCache[$key];
 					$this->stats['name_hits']++;
 				}
@@ -1487,7 +1493,7 @@ class CacheHandler {
 			$decided = [];
 			foreach ($missingIdentifiers as $key) {
 				try {
-					$envelope = $this->readNameEnvelope($this->nameDistributedCache->get('name_' . $key));
+					$envelope = $this->readNameEnvelope(cached: $this->nameDistributedCache->get('name_' . $key));
 					if ($envelope === null) {
 						continue;
 					}
@@ -1503,7 +1509,7 @@ class CacheHandler {
 					$this->rememberNameOrganisation(key: $key, organisation: $envelope['o']);
 					$decided[] = $key;
 
-					if ($this->hasOrganisationAccess($envelope['o']) === true) {
+					if ($this->hasOrganisationAccess(organisation: $envelope['o']) === true) {
 						$results[$key] = $envelope['n'];
 						$this->stats['name_hits']++;
 					}
@@ -1530,7 +1536,7 @@ class CacheHandler {
 					// Cache for future use (UUID only).
 					$this->setObjectName(identifier: $key, name: $name, organisation: $key);
 
-					if ($this->hasOrganisationAccess($key) === true) {
+					if ($this->hasOrganisationAccess(organisation: $key) === true) {
 						$results[$key] = $name;
 					}
 
@@ -1584,7 +1590,7 @@ class CacheHandler {
 							continue;
 						}
 
-						if ($this->hasOrganisationAccess($objectOrganisation) === true) {
+						if ($this->hasOrganisationAccess(organisation: $objectOrganisation) === true) {
 							// Store result with UUID key (for consistent return format).
 							$results[$uuid] = $name;
 						}
@@ -1606,7 +1612,7 @@ class CacheHandler {
 							name: $entry['name'],
 							organisation: $entry['organisation']
 						);
-						if ($this->hasOrganisationAccess($entry['organisation']) === true) {
+						if ($this->hasOrganisationAccess(organisation: $entry['organisation']) === true) {
 							$results[$uuid] = $entry['name'];
 						}
 					}
@@ -1690,7 +1696,7 @@ class CacheHandler {
 					return false;
 				}
 
-				return $this->hasOrganisationAccess($this->nameCacheOrganisation[$key] ?? null);
+				return $this->hasOrganisationAccess(organisation: ($this->nameOrganisations[$key] ?? null));
 			},
 			ARRAY_FILTER_USE_BOTH
 		);
@@ -1927,6 +1933,8 @@ class CacheHandler {
 	 * @return array<string, array{name: string, organisation: string|null}> Map of UUID to name + owning organisation.
 	 *
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity) Batch loading across multiple table types requires branching
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Table discovery, schema bulk-load
+	 * and the per-table batch query, now also carrying each row's owning organisation.
 	 *
 	 * @spec openspec/specs/object-lifecycle/spec.md
 	 */
@@ -2081,10 +2089,14 @@ class CacheHandler {
 					$uuid = $row['_uuid'];
 					$name = $row['name_value'];
 					$rowOrganisation = $row['_organisation'] ?? null;
+					if ($rowOrganisation !== null) {
+						$rowOrganisation = (string)$rowOrganisation;
+					}
+
 					if ($name !== null && trim((string)$name) !== '') {
 						$results[$uuid] = [
 							'name' => (string)$name,
-							'organisation' => ($rowOrganisation === null) ? null : (string)$rowOrganisation,
+							'organisation' => $rowOrganisation,
 						];
 					}
 				}
@@ -2132,7 +2144,7 @@ class CacheHandler {
 					'name_' . $identifier,
 					$this->buildNameEnvelope(
 						name: $name,
-						organisation: ($this->nameCacheOrganisation[(string)$identifier] ?? null)
+						organisation: ($this->nameOrganisations[(string)$identifier] ?? null)
 					),
 					$ttl
 				);
@@ -2203,7 +2215,7 @@ class CacheHandler {
 	public function clearNameCache(): void {
 		// Clear in-memory name cache and the tenancy recorded alongside it.
 		$this->nameCache = [];
-		$this->nameCacheOrganisation = [];
+		$this->nameOrganisations = [];
 
 		// Clear distributed name cache.
 		if ($this->nameDistributedCache !== null) {

--- a/lib/Service/Object/CacheHandler.php
+++ b/lib/Service/Object/CacheHandler.php
@@ -1690,18 +1690,18 @@ class CacheHandler {
 		// tenant's request is handed to the next tenant that asks.
 		$uuidNames = array_filter(
 			$this->nameCache,
-			function ($name, $key) {
+			function ($key) {
 				// Only return entries where key looks like a UUID (contains hyphens).
 				// Cast rather than is_string(): PHP narrows numeric-looking array keys
-				// to int, and phpstan reads the declared key type as string, so an
-				// is_string() test here is always-true dead code.
+				// to int. ARRAY_FILTER_USE_KEY (not USE_BOTH) on purpose — the value is
+				// not needed, and taking it would be an unused formal parameter.
 				if (str_contains((string)$key, '-') === false) {
 					return false;
 				}
 
 				return $this->hasOrganisationAccess(organisation: ($this->nameOrganisations[$key] ?? null));
 			},
-			ARRAY_FILTER_USE_BOTH
+			ARRAY_FILTER_USE_KEY
 		);
 
 		$executionTime = round((microtime(true) - $startTime) * 1000, 2);

--- a/lib/Service/Object/CacheHandler.php
+++ b/lib/Service/Object/CacheHandler.php
@@ -33,8 +33,10 @@ use OCA\OpenRegister\Db\OrganisationMapper;
 use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCP\AppFramework\IAppContainer;
+use OCP\IAppConfig;
 use OCP\ICacheFactory;
 use OCP\IDBConnection;
+use OCP\IGroupManager;
 use OCP\IMemcache;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
@@ -96,6 +98,37 @@ class CacheHandler {
 	 * @var array<string, string>
 	 */
 	private array $nameCache = [];
+
+	/**
+	 * Owning organisation UUID for every entry in $nameCache (SEC-CTRL-2 step 2)
+	 *
+	 * The name cache is shared by every request served by this process, so the
+	 * tenancy of a cached name has to travel WITH the name. Keyed identically to
+	 * $nameCache; an identifier missing from this map has an unknown owner and is
+	 * therefore never served (fail closed).
+	 *
+	 * @var array<string, string|null>
+	 */
+	private array $nameCacheOrganisation = [];
+
+	/**
+	 * Memoised name-visibility scope for the current request (SEC-CTRL-2 step 2)
+	 *
+	 * `null` combined with $nameScopeResolved === true means UNRESTRICTED (multi
+	 * tenancy switched off, or an admin with the override enabled). An array is
+	 * the list of organisation UUIDs whose names the caller may see; an empty
+	 * array means the caller may see none.
+	 *
+	 * @var array<int, string>|null
+	 */
+	private ?array $nameScope = null;
+
+	/**
+	 * Whether $nameScope has been resolved yet for this request
+	 *
+	 * @var bool
+	 */
+	private bool $nameScopeResolved = false;
 
 	/**
 	 * Distributed cache for object names
@@ -167,6 +200,8 @@ class CacheHandler {
 	 * @param RegisterMapper|null $registerMapper Register mapper for magic table queries
 	 * @param SchemaMapper|null $schemaMapper Schema mapper for magic table queries
 	 * @param IDBConnection|null $db Database connection for magic table queries
+	 * @param IGroupManager|null $groupManager Group manager for the admin-override arm of the name scope
+	 * @param IAppConfig|null $appConfig App config for the multitenancy switches read by the name scope
 	 *
 	 * @spec openspec/specs/object-lifecycle/spec.md
 	 */
@@ -179,6 +214,8 @@ class CacheHandler {
 		private readonly ?RegisterMapper $registerMapper = null,
 		private readonly ?SchemaMapper $schemaMapper = null,
 		private readonly ?IDBConnection $db = null,
+		private readonly ?IGroupManager $groupManager = null,
+		private readonly ?IAppConfig $appConfig = null,
 	) {
 		// Initialize query cache if available.
 		if ($cacheFactory !== null) {
@@ -319,6 +356,267 @@ class CacheHandler {
 			return '__no_org__';
 		}
 	}//end getActiveOrganisationCacheScope()
+
+	/**
+	 * Drop the memoised name scope so the next lookup re-reads the caller.
+	 *
+	 * Called at the top of every public name reader. The scope is memoised for
+	 * the duration of ONE call (a bulk lookup checks it once per name and would
+	 * otherwise walk the organisation hierarchy thousands of times), but it must
+	 * never survive between calls: a cron worker or a long-lived process serves
+	 * more than one caller, and a scope carried over is the same cross-tenant
+	 * reuse this change exists to close.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	private function beginNameScope(): void {
+		$this->nameScopeResolved = false;
+		$this->nameScope = null;
+	}//end beginNameScope()
+
+	/**
+	 * Resolve which organisations' names the current caller may see (SEC-CTRL-2 step 2).
+	 *
+	 * Mirrors Db\MultiTenancyTrait::applyOrganisationFilter() so a name is never
+	 * resolvable for an object the caller could not have read in the first place:
+	 *
+	 * - multitenancy switched off in config  -> unrestricted (null)
+	 * - admin with the admin override on     -> unrestricted (null)
+	 * - otherwise                            -> the active organisation plus its
+	 *                                           parents, exactly like the mappers
+	 * - no active organisation at all        -> [] (the trait's `1 = 0` arm)
+	 *
+	 * Memoised for the duration of one public call; see beginNameScope().
+	 *
+	 * @return array<int, string>|null Allowed organisation UUIDs, or null for unrestricted
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	private function resolveNameScope(): ?array {
+		if ($this->nameScopeResolved === true) {
+			return $this->nameScope;
+		}
+
+		$this->nameScopeResolved = true;
+		$this->nameScope = [];
+
+		try {
+			if ($this->isMultiTenancyDisabled() === true || $this->isAdminOverrideActive() === true) {
+				$this->nameScope = null;
+				return $this->nameScope;
+			}
+
+			$activeOrganisation = $this->resolveActiveOrganisationUuid();
+			if ($activeOrganisation === null || $activeOrganisation === '') {
+				return $this->nameScope;
+			}
+
+			$hierarchy = [$activeOrganisation];
+			try {
+				$resolved = $this->organisationMapper->getOrganisationHierarchy($activeOrganisation);
+				if (empty($resolved) === false) {
+					$hierarchy = $resolved;
+				}
+			} catch (\Throwable $e) {
+				// Hierarchy unavailable: fall back to the active organisation alone,
+				// which is the narrower (fail-closed) answer.
+				$this->logger->debug(
+					message: '[CacheHandler] Organisation hierarchy unavailable for name scope',
+					context: ['file' => __FILE__, 'line' => __LINE__, 'error' => $e->getMessage()]
+				);
+			}
+
+			$this->nameScope = array_values(
+				array_filter(
+					array_map(fn ($uuid) => (string)$uuid, $hierarchy),
+					fn (string $uuid) => $uuid !== ''
+				)
+			);
+		} catch (\Throwable $e) {
+			// Never let scope resolution grant more than it should: an error means
+			// no organisation could be established, so nothing is visible.
+			$this->logger->warning(
+				message: '[CacheHandler] Name scope could not be resolved; denying all cached names',
+				context: ['file' => __FILE__, 'line' => __LINE__, 'error' => $e->getMessage()]
+			);
+			$this->nameScope = [];
+		}//end try
+
+		return $this->nameScope;
+	}//end resolveNameScope()
+
+	/**
+	 * Whether multitenancy filtering is switched off instance-wide.
+	 *
+	 * @return bool True when the multitenancy config explicitly disables filtering
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	private function isMultiTenancyDisabled(): bool {
+		if ($this->appConfig === null) {
+			return false;
+		}
+
+		$raw = $this->appConfig->getValueString('openregister', 'multitenancy', '');
+		if ($raw === '') {
+			return false;
+		}
+
+		$decoded = json_decode($raw, true);
+		if (is_array($decoded) === false) {
+			return false;
+		}
+
+		return ($decoded['enabled'] ?? true) === false;
+	}//end isMultiTenancyDisabled()
+
+	/**
+	 * Whether the caller is an admin acting under an enabled cross-tenant override.
+	 *
+	 * SaaS mode always wins and disables the override, mirroring MultiTenancyTrait.
+	 *
+	 * @return bool True when the caller may read names across organisations
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	private function isAdminOverrideActive(): bool {
+		if ($this->appConfig === null || $this->groupManager === null) {
+			return false;
+		}
+
+		$user = $this->userSession?->getUser();
+		if ($user === null) {
+			return false;
+		}
+
+		$raw = $this->appConfig->getValueString('openregister', 'multitenancy', '');
+		if ($raw === '') {
+			return false;
+		}
+
+		$decoded = json_decode($raw, true);
+		if (is_array($decoded) === false) {
+			return false;
+		}
+
+		if (($decoded['saasMode'] ?? false) === true) {
+			return false;
+		}
+
+		if (($decoded['adminOverride'] ?? false) !== true) {
+			return false;
+		}
+
+		return $this->groupManager->isAdmin($user->getUID());
+	}//end isAdminOverrideActive()
+
+	/**
+	 * Resolve the caller's active organisation UUID for name scoping.
+	 *
+	 * @return string|null The active organisation UUID, or null when none applies
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	private function resolveActiveOrganisationUuid(): ?string {
+		$user = $this->userSession?->getUser();
+		if ($user === null) {
+			return $this->organisationMapper->getDefaultOrganisationFromConfig();
+		}
+
+		return $this->organisationMapper->getActiveOrganisationWithFallback($user->getUID());
+	}//end resolveActiveOrganisationUuid()
+
+	/**
+	 * Per-object authorisation predicate for name resolution (SEC-CTRL-2 step 2).
+	 *
+	 * Answers "may THIS caller be told the name of an entity owned by THIS
+	 * organisation?". An entity whose owning organisation is unknown is refused:
+	 * absence of tenancy is not permission to disclose.
+	 *
+	 * @param string|null $organisation The owning organisation UUID of the entity
+	 *
+	 * @return bool True when the caller may see a name owned by that organisation
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	private function hasOrganisationAccess(?string $organisation): bool {
+		$scope = $this->resolveNameScope();
+		if ($scope === null) {
+			return true;
+		}
+
+		if ($organisation === null || $organisation === '') {
+			return false;
+		}
+
+		return in_array($organisation, $scope, true);
+	}//end hasOrganisationAccess()
+
+	/**
+	 * Record the owning organisation of a cached name (SEC-CTRL-2 step 2).
+	 *
+	 * @param string      $key          The name-cache key (object id or uuid)
+	 * @param string|null $organisation The owning organisation UUID, or null when unknown
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	private function rememberNameOrganisation(string $key, ?string $organisation): void {
+		$this->nameCacheOrganisation[$key] = $organisation;
+	}//end rememberNameOrganisation()
+
+	/**
+	 * Wrap a name and its owning organisation for the distributed cache.
+	 *
+	 * The distributed name cache is shared by every tenant on the instance, so the
+	 * tenancy has to be stored WITH the value. Keeping the KEY unchanged is
+	 * deliberate: every existing invalidation site removes `name_<identifier>` and
+	 * keeps working untouched, and a name can never be orphaned under a stale
+	 * organisation prefix when an object moves tenant.
+	 *
+	 * @param string      $name         The cached name
+	 * @param string|null $organisation The owning organisation UUID
+	 *
+	 * @return array{n: string, o: string|null} The envelope stored in the distributed cache
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	private function buildNameEnvelope(string $name, ?string $organisation): array {
+		return ['n' => $name, 'o' => $organisation];
+	}//end buildNameEnvelope()
+
+	/**
+	 * Read a distributed-cache entry as a tenancy-bearing envelope.
+	 *
+	 * A value written before this change is a bare string with no tenancy, so it
+	 * is reported as a MISS rather than served unscoped — the fail-closed
+	 * direction across a deploy.
+	 *
+	 * @param mixed $cached The raw value read from the distributed cache
+	 *
+	 * @return array{n: string, o: string|null}|null The envelope, or null when unusable
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	private function readNameEnvelope(mixed $cached): ?array {
+		if (is_array($cached) === false || array_key_exists('n', $cached) === false) {
+			return null;
+		}
+
+		if (is_string($cached['n']) === false) {
+			return null;
+		}
+
+		$organisation = $cached['o'] ?? null;
+		if ($organisation !== null && is_string($organisation) === false) {
+			return null;
+		}
+
+		return ['n' => $cached['n'], 'o' => $organisation];
+	}//end readNameEnvelope()
 
 	/**
 	 * Bulk preload objects to warm the cache
@@ -667,16 +965,28 @@ class CacheHandler {
 			$this->clearObjectNameFromCache(object: $object);
 
 			if ($operation === 'create' || $operation === 'update') {
-				// Update name cache for the modified object.
+				// Update name cache for the modified object, carrying its tenancy
+				// so the refreshed entry is only served back to that organisation.
 				$name = $object->getName() ?? $object->getUuid();
-				$this->setObjectName(identifier: $object->getUuid(), name: $name);
+				$organisation = $object->getOrganisation();
+				$this->setObjectName(
+					identifier: $object->getUuid(),
+					name: $name,
+					organisation: $organisation
+				);
 				if (($object->getId() !== null) === true && (string)$object->getId() !== $object->getUuid()) {
-					$this->setObjectName(identifier: $object->getId(), name: $name);
+					$this->setObjectName(
+						identifier: $object->getId(),
+						name: $name,
+						organisation: $organisation
+					);
 				}
 			} elseif ($operation === 'delete') {
-				// Remove from in-memory name cache.
+				// Remove from in-memory name cache (name AND its recorded tenancy).
 				unset($this->nameCache[$object->getUuid()]);
 				unset($this->nameCache[(string)$object->getId()]);
+				unset($this->nameCacheOrganisation[$object->getUuid()]);
+				unset($this->nameCacheOrganisation[(string)$object->getId()]);
 
 				// Remove from distributed name cache.
 				if ($this->nameDistributedCache !== null) {
@@ -788,6 +1098,7 @@ class CacheHandler {
 
 		foreach ($keys as $key) {
 			unset($this->nameCache[$key]);
+			unset($this->nameCacheOrganisation[$key]);
 
 			if ($this->nameDistributedCache !== null) {
 				try {
@@ -823,6 +1134,7 @@ class CacheHandler {
 		$this->objectCache = [];
 		$this->inMemoryQueryCache = [];
 		$this->nameCache = [];
+		$this->nameCacheOrganisation = [];
 		$this->stats = [
 			'hits' => 0,
 			'misses' => 0,
@@ -903,24 +1215,32 @@ class CacheHandler {
 	 * @param string|int $identifier Object ID or UUID
 	 * @param string $name Object name to cache
 	 * @param int $ttl Cache TTL in seconds (default: 24 hours)
+	 * @param string|null $organisation Owning organisation UUID (SEC-CTRL-2 step 2)
 	 *
 	 * @return void
 	 *
 	 * @spec openspec/specs/object-lifecycle/spec.md
 	 */
-	public function setObjectName(string|int $identifier, string $name, int $ttl = 86400): void {
+	public function setObjectName(string|int $identifier, string $name, int $ttl = 86400, ?string $organisation = null): void {
 		$key = (string)$identifier;
 
 		// Enforce maximum cache TTL.
 		$ttl = min($ttl, self::MAX_CACHE_TTL);
 
-		// Store in in-memory cache.
+		// Store in in-memory cache, together with the tenancy of the entity the
+		// name belongs to (SEC-CTRL-2 step 2). Without the second map the cache
+		// is a cross-tenant disclosure channel of its own.
 		$this->nameCache[$key] = $name;
+		$this->rememberNameOrganisation(key: $key, organisation: $organisation);
 
 		// Store in distributed cache if available.
 		if ($this->nameDistributedCache !== null) {
 			try {
-				$this->nameDistributedCache->set('name_' . $key, $name, $ttl);
+				$this->nameDistributedCache->set(
+					'name_' . $key,
+					$this->buildNameEnvelope(name: $name, organisation: $organisation),
+					$ttl
+				);
 			} catch (\Exception $e) {
 				$this->logger->warning(
 					message: '[CacheHandler] Failed to cache object name in distributed cache',
@@ -952,22 +1272,22 @@ class CacheHandler {
 	 * Provides ultra-fast name lookup for frontend rendering.
 	 * Falls back to database if not cached.
 	 *
-	 * ⚠️ THIS RESOLVER IS DELIBERATELY UNSCOPED. The database fallback below calls
+	 * ⚠️ THE DATABASE FALLBACK BELOW IS STILL UNSCOPED AT THE QUERY LEVEL: it calls
 	 * `findAcrossAllSources(..., _rbac: false, _multitenancy: false)` and tries
-	 * organisations first, so it will happily return the name of an object in any
-	 * register, any schema, any tenant, to whoever asks. It knows nothing about the
-	 * caller.
+	 * organisations first, so the LOOKUP crosses every register, schema and tenant.
+	 * What SEC-CTRL-2 step 2 adds is the answer: whatever the lookup finds, the
+	 * name is only returned when the entity's owning organisation is inside the
+	 * caller's active-organisation scope — and the same check gates every cache
+	 * hit, so a name warmed by one tenant is never served to another.
 	 *
-	 * DO NOT EXPOSE IT DIRECTLY FROM A CONTROLLER. It used to back
-	 * `GET /api/names/{id}`, which was `#[PublicPage]` — so any anonymous caller
-	 * holding a UUID could read that object's name across tenant boundaries. That
-	 * endpoint was removed (SEC-CTRL-2, gate-7); this method survives only as an
-	 * internal cache primitive.
+	 * It used to back `GET /api/names/{id}`, which was `#[PublicPage]` — any
+	 * anonymous caller holding a UUID could read that object's name across tenant
+	 * boundaries. That endpoint was removed (SEC-CTRL-2, gate-7); this method
+	 * survives only as an internal cache primitive and has no caller in `lib/`.
 	 *
-	 * Any new caller must apply the caller's read permissions and active
-	 * organisation BEFORE calling this, or resolve names through a path that does.
-	 * Note the sibling `getMultipleObjectNames()` carries the same limitation and
-	 * the same open TODO in NamesController::index().
+	 * A new caller still gets a per-object read-permission check for free ONLY on
+	 * the organisation dimension. RBAC (register/schema authorization blocks) is
+	 * NOT evaluated here; if you need it, resolve through ObjectService.
 	 *
 	 * @param string|int $identifier Object ID or UUID
 	 *
@@ -979,10 +1299,17 @@ class CacheHandler {
 	 * @spec openspec/specs/object-lifecycle/spec.md
 	 */
 	public function getSingleObjectName(string|int $identifier): ?string {
+		$this->beginNameScope();
 		$key = (string)$identifier;
 
-		// Check in-memory cache first (fastest).
+		// Check in-memory cache first (fastest). SEC-CTRL-2 step 2: a cached name
+		// is only served to a caller whose organisation may see the entity it
+		// belongs to; an entry with no recorded tenancy is refused.
 		if (($this->nameCache[$key] ?? null) !== null) {
+			if ($this->hasOrganisationAccess($this->nameCacheOrganisation[$key] ?? null) === false) {
+				return null;
+			}
+
 			$this->stats['name_hits']++;
 			$this->logger->debug(
 				message: '[CacheHandler] 🚀 NAME CACHE HIT (in-memory)',
@@ -994,16 +1321,21 @@ class CacheHandler {
 		// Check distributed cache.
 		if ($this->nameDistributedCache !== null) {
 			try {
-				$cachedName = $this->nameDistributedCache->get('name_' . $key);
-				if ($cachedName !== null) {
+				$envelope = $this->readNameEnvelope($this->nameDistributedCache->get('name_' . $key));
+				if ($envelope !== null) {
+					if ($this->hasOrganisationAccess($envelope['o']) === false) {
+						return null;
+					}
+
 					// Store in in-memory cache for faster future access.
-					$this->nameCache[$key] = $cachedName;
+					$this->nameCache[$key] = $envelope['n'];
+					$this->rememberNameOrganisation(key: $key, organisation: $envelope['o']);
 					$this->stats['name_hits']++;
 					$this->logger->debug(
 						message: '[CacheHandler] ⚡ NAME CACHE HIT (distributed)',
 						context: ['file' => __FILE__, 'line' => __LINE__, 'identifier' => $key]
 					);
-					return $cachedName;
+					return $envelope['n'];
 				}
 			} catch (\Exception $e) {
 				$this->logger->warning(
@@ -1035,7 +1367,21 @@ class CacheHandler {
 				$organisation = $this->organisationMapper->findByUuid((string)$identifier);
 				if ($organisation !== null) {
 					$name = $organisation->getName() ?? $organisation->getUuid();
-					$this->setObjectName(identifier: $identifier, name: $name);
+					// An organisation's own tenancy is itself. A row with neither a
+					// name nor a uuid has nothing to cache — setObjectName() takes a
+					// non-nullable string, so guard rather than fatal.
+					if ($name !== null) {
+						$this->setObjectName(
+							identifier: $identifier,
+							name: $name,
+							organisation: $organisation->getUuid()
+						);
+					}
+
+					if ($this->hasOrganisationAccess($organisation->getUuid()) === false) {
+						return null;
+					}
+
 					return $name;
 				}
 			} catch (\Exception $e) {
@@ -1052,7 +1398,19 @@ class CacheHandler {
 			if (($result['object'] ?? null) !== null) {
 				$object = $result['object'];
 				$name = $object->getName() ?? $object->getUuid();
-				$this->setObjectName(identifier: $identifier, name: $name);
+				$objectOrganisation = $object->getOrganisation();
+				if ($name !== null) {
+					$this->setObjectName(
+						identifier: $identifier,
+						name: $name,
+						organisation: $objectOrganisation
+					);
+				}
+
+				if ($this->hasOrganisationAccess($objectOrganisation) === false) {
+					return null;
+				}
+
 				return $name;
 			}
 		} catch (\Exception $e) {
@@ -1097,15 +1455,27 @@ class CacheHandler {
 			return [];
 		}
 
+		$this->beginNameScope();
+
 		$results = [];
 		$missingIdentifiers = [];
 
-		// Check in-memory cache for all identifiers.
+		// Check in-memory cache for all identifiers. SEC-CTRL-2 step 2: a cached
+		// name is only served when the caller's organisation may see the entity it
+		// belongs to. An entry whose tenancy was never recorded is treated as a
+		// MISS (not as a denial) so the database can establish it.
+		$unrestricted = ($this->resolveNameScope() === null);
 		foreach ($identifiers as $identifier) {
 			$key = (string)$identifier;
-			if (($this->nameCache[$key] ?? null) !== null) {
-				$results[$key] = $this->nameCache[$key];
-				$this->stats['name_hits']++;
+			$cachedOrganisation = $this->nameCacheOrganisation[$key] ?? null;
+			if (($this->nameCache[$key] ?? null) !== null
+				&& ($cachedOrganisation !== null || $unrestricted === true)
+			) {
+				if ($this->hasOrganisationAccess($cachedOrganisation) === true) {
+					$results[$key] = $this->nameCache[$key];
+					$this->stats['name_hits']++;
+				}
+
 				continue;
 			}
 
@@ -1114,24 +1484,36 @@ class CacheHandler {
 
 		// Check distributed cache for missing identifiers.
 		if (empty($missingIdentifiers) === false && $this->nameDistributedCache !== null) {
-			$distributedResults = [];
+			$decided = [];
 			foreach ($missingIdentifiers as $key) {
 				try {
-					$cachedName = $this->nameDistributedCache->get('name_' . $key);
-					if ($cachedName !== null) {
-						$distributedResults[$key] = $cachedName;
-						$this->nameCache[$key] = $cachedName;
-						// Store in memory.
+					$envelope = $this->readNameEnvelope($this->nameDistributedCache->get('name_' . $key));
+					if ($envelope === null) {
+						continue;
+					}
+
+					// A stored entry with no tenancy settles nothing while scoping is
+					// in force: fall through to the database, which can establish it.
+					if ($envelope['o'] === null && $unrestricted === false) {
+						continue;
+					}
+
+					// Store in memory together with its tenancy.
+					$this->nameCache[$key] = $envelope['n'];
+					$this->rememberNameOrganisation(key: $key, organisation: $envelope['o']);
+					$decided[] = $key;
+
+					if ($this->hasOrganisationAccess($envelope['o']) === true) {
+						$results[$key] = $envelope['n'];
 						$this->stats['name_hits']++;
 					}
 				} catch (\Exception $e) {
 					// Continue processing other identifiers.
-				}
+				}//end try
 			}
 
-			$results = array_merge($results, $distributedResults);
-			$missingIdentifiers = array_diff($missingIdentifiers, array_keys($distributedResults));
-		}
+			$missingIdentifiers = array_diff($missingIdentifiers, $decided);
+		}//end if
 
 		// Load remaining missing names from database.
 		if (empty($missingIdentifiers) === false) {
@@ -1139,14 +1521,18 @@ class CacheHandler {
 
 			try {
 				// STEP 1: Try to find organisations first (they take priority).
+				// An organisation's own tenancy is itself.
 				$organisations = $this->organisationMapper->findMultipleByUuid($missingIdentifiers);
 				foreach ($organisations as $organisation) {
 					$name = $organisation->getName() ?? $organisation->getUuid();
 					$key = $organisation->getUuid();
-					$results[$key] = $name;
 
 					// Cache for future use (UUID only).
-					$this->setObjectName(identifier: $key, name: $name);
+					$this->setObjectName(identifier: $key, name: $name, organisation: $key);
+
+					if ($this->hasOrganisationAccess($key) === true) {
+						$results[$key] = $name;
+					}
 
 					// Remove from missing list since we found it.
 					$missingIdentifiers = array_diff($missingIdentifiers, [$key]);
@@ -1158,12 +1544,14 @@ class CacheHandler {
 					foreach ($objects as $object) {
 						$name = $object->getName() ?? $object->getUuid();
 						$uuid = $object->getUuid();
-
-						// Store result with UUID key (for consistent return format).
-						$results[$uuid] = $name;
+						$objectOrganisation = $object->getOrganisation();
 
 						// Cache with UUID for future lookups.
-						$this->setObjectName(identifier: $uuid, name: $name);
+						$this->setObjectName(
+							identifier: $uuid,
+							name: $name,
+							organisation: $objectOrganisation
+						);
 
 						// Also cache with original identifier if it differs from UUID.
 						// Find the original identifier that matched this object.
@@ -1174,11 +1562,31 @@ class CacheHandler {
 								|| (string)$originalId === $object->getUri()
 							) {
 								if ((string)$originalId !== $uuid) {
-									$this->setObjectName(identifier: $originalId, name: $name);
+									$this->setObjectName(
+										identifier: $originalId,
+										name: $name,
+										organisation: $objectOrganisation
+									);
 								}
 
 								break;
 							}
+						}
+
+						// An entity read out of a magic table carries no tenancy of its
+						// own (MagicMapper::rowToObjectEntity never populates it), so an
+						// unknown organisation here is NOT a decision while scoping is in
+						// force: leave the identifier in the missing list and let STEP 3's
+						// SQL — which reads the _organisation column — settle it.
+						if (($objectOrganisation === null || $objectOrganisation === '')
+							&& $unrestricted === false
+						) {
+							continue;
+						}
+
+						if ($this->hasOrganisationAccess($objectOrganisation) === true) {
+							// Store result with UUID key (for consistent return format).
+							$results[$uuid] = $name;
 						}
 
 						// Remove from missing list since we found it.
@@ -1187,12 +1595,20 @@ class CacheHandler {
 				}//end if
 
 				// STEP 3: Batch load any still-missing identifiers from magic tables.
-				// This replaces the N+1 individual lookups with batch queries per table.
+				// This replaces the N+1 individual lookups with batch queries per table,
+				// and is the tenancy oracle for every object-backed name: it reads the
+				// _organisation column directly.
 				if (empty($missingIdentifiers) === false) {
 					$batchResults = $this->batchLoadNamesFromMagicTables(uuids: $missingIdentifiers);
-					foreach ($batchResults as $uuid => $name) {
-						$results[$uuid] = $name;
-						$this->setObjectName(identifier: $uuid, name: $name);
+					foreach ($batchResults as $uuid => $entry) {
+						$this->setObjectName(
+							identifier: $uuid,
+							name: $entry['name'],
+							organisation: $entry['organisation']
+						);
+						if ($this->hasOrganisationAccess($entry['organisation']) === true) {
+							$results[$uuid] = $entry['name'];
+						}
 					}
 				}
 			} catch (\Exception $e) {
@@ -1252,6 +1668,7 @@ class CacheHandler {
 	 * @spec openspec/specs/object-lifecycle/spec.md
 	 */
 	public function getAllObjectNames(bool $forceWarmup = false): array {
+		$this->beginNameScope();
 		$startTime = microtime(true);
 
 		// Check if we should trigger warmup.
@@ -1261,14 +1678,21 @@ class CacheHandler {
 			$this->warmupNameCache();
 		}
 
-		// Filter to return only UUID -> name mappings (exclude database IDs).
+		// Filter to return only UUID -> name mappings (exclude database IDs), and
+		// only for organisations this caller may see. SEC-CTRL-2 step 2: the name
+		// cache is process-wide, so without this filter a cache warmed by one
+		// tenant's request is handed to the next tenant that asks.
 		$uuidNames = array_filter(
 			$this->nameCache,
-			function ($key) {
+			function ($name, $key) {
 				// Only return entries where key looks like a UUID (contains hyphens).
-				return is_string($key) && str_contains($key, '-');
+				if (is_string($key) === false || str_contains($key, '-') === false) {
+					return false;
+				}
+
+				return $this->hasOrganisationAccess($this->nameCacheOrganisation[$key] ?? null);
 			},
-			ARRAY_FILTER_USE_KEY
+			ARRAY_FILTER_USE_BOTH
 		);
 
 		$executionTime = round((microtime(true) - $startTime) * 1000, 2);
@@ -1313,9 +1737,14 @@ class CacheHandler {
 			foreach ($organisations as $organisation) {
 				$name = $organisation->getName() ?? $organisation->getUuid();
 
-				// Cache by UUID only (not by database ID).
+				// Cache by UUID only (not by database ID). An organisation's own
+				// tenancy is itself, so that is what is recorded alongside it.
 				if ($organisation->getUuid() !== null && $name !== null) {
 					$this->nameCache[$organisation->getUuid()] = $name;
+					$this->rememberNameOrganisation(
+						key: $organisation->getUuid(),
+						organisation: $organisation->getUuid()
+					);
 					$loadedCount++;
 				}
 			}
@@ -1330,6 +1759,7 @@ class CacheHandler {
 				$uuid = $object->getUuid();
 				if ($uuid !== null && $name !== null && (($this->nameCache[$uuid] ?? null) === null) === true) {
 					$this->nameCache[$uuid] = $name;
+					$this->rememberNameOrganisation(key: $uuid, organisation: $object->getOrganisation());
 					$loadedCount++;
 				}
 			}
@@ -1429,12 +1859,16 @@ class CacheHandler {
 						// Magic table columns have underscore prefix: _id, _name, _deleted, etc.
 						// Note: _id is bigint (internal DB ID), we need _uuid (the UUID) for mapping.
 						// Filter: only exclude deleted objects.
-						$sql = 'SELECT "_uuid", "_name" FROM ' . $tableName . ' WHERE "_deleted" IS NULL';
+						// SEC-CTRL-2 step 2: `_organisation` is selected as well. It is the
+						// tenancy oracle for every object-backed name — the ObjectEntity
+						// produced by MagicMapper::rowToObjectEntity() never carries one.
+						$sql = 'SELECT "_uuid", "_name", "_organisation" FROM ' . $tableName . ' WHERE "_deleted" IS NULL';
 						$result = $this->db->executeQuery($sql);
 
 						while (($row = $result->fetch()) !== false) {
 							$uuid = $row['_uuid'] ?? null;
 							$name = $row['_name'] ?? null;
+							$rowOrganisation = $row['_organisation'] ?? null;
 
 							if ($uuid !== null) {
 								// Use name if available, otherwise fall back to UUID.
@@ -1445,6 +1879,10 @@ class CacheHandler {
 
 								// Overwrite any existing name (magic table has enriched names).
 								$this->nameCache[$uuid] = $effectiveName;
+								$this->rememberNameOrganisation(
+									key: $uuid,
+									organisation: $rowOrganisation
+								);
 								$loadedCount++;
 							}
 						}
@@ -1486,7 +1924,7 @@ class CacheHandler {
 	 *
 	 * @param array $uuids Array of UUIDs to look up.
 	 *
-	 * @return array<string, string> Map of UUID to name.
+	 * @return array<string, array{name: string, organisation: string|null}> Map of UUID to name + owning organisation.
 	 *
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity) Batch loading across multiple table types requires branching
 	 *
@@ -1508,6 +1946,13 @@ class CacheHandler {
 		);
 
 		if (empty($uuidList) === true) {
+			return $results;
+		}
+
+		// The magic-table dependencies are optional constructor arguments. Without
+		// them there is no tenancy oracle, so the honest answer is "nothing
+		// resolved" rather than a fatal on a null mapper.
+		if ($this->registerMapper === null || $this->schemaMapper === null || $this->db === null) {
 			return $results;
 		}
 
@@ -1595,7 +2040,7 @@ class CacheHandler {
 	 * @param string $tableName The table name (with oc_ prefix).
 	 * @param array $uuids Array of UUIDs to look up.
 	 *
-	 * @return array<string, string> Map of UUID to name.
+	 * @return array<string, array{name: string, organisation: string|null}> Map of UUID to name + owning organisation.
 	 *
 	 * @spec openspec/specs/object-lifecycle/spec.md
 	 */
@@ -1614,7 +2059,9 @@ class CacheHandler {
 				// Build placeholders for IN clause.
 				$placeholders = implode(',', array_fill(0, count($uuids), '?'));
 
-				$sql = "SELECT _uuid, {$nameColumn} as name_value
+				// SEC-CTRL-2 step 2: `_organisation` travels with the name so the
+				// caller's tenancy can be checked before the name is disclosed.
+				$sql = "SELECT _uuid, _organisation, {$nameColumn} as name_value
                         FROM {$tableName}
                         WHERE _uuid IN ({$placeholders})
                         AND _deleted IS NULL";
@@ -1633,8 +2080,12 @@ class CacheHandler {
 				while (($row = $stmt->fetch()) !== false) {
 					$uuid = $row['_uuid'];
 					$name = $row['name_value'];
+					$rowOrganisation = $row['_organisation'] ?? null;
 					if ($name !== null && trim((string)$name) !== '') {
-						$results[$uuid] = (string)$name;
+						$results[$uuid] = [
+							'name' => (string)$name,
+							'organisation' => ($rowOrganisation === null) ? null : (string)$rowOrganisation,
+						];
 					}
 				}
 
@@ -1673,7 +2124,18 @@ class CacheHandler {
 
 		foreach ($this->nameCache as $identifier => $name) {
 			try {
-				$this->nameDistributedCache->set('name_' . $identifier, $name, $ttl);
+				// SEC-CTRL-2 step 2: the KEY is deliberately unchanged so every
+				// existing invalidation site keeps matching; the tenancy rides in
+				// the VALUE, which also means an entity that moves organisation can
+				// never leave an orphaned entry under a stale prefix.
+				$this->nameDistributedCache->set(
+					'name_' . $identifier,
+					$this->buildNameEnvelope(
+						name: $name,
+						organisation: ($this->nameCacheOrganisation[(string)$identifier] ?? null)
+					),
+					$ttl
+				);
 				$storedCount++;
 			} catch (\Exception $e) {
 				// Log once per batch, not per entry to avoid log spam.
@@ -1739,8 +2201,9 @@ class CacheHandler {
 	 * @spec openspec/specs/object-lifecycle/spec.md
 	 */
 	public function clearNameCache(): void {
-		// Clear in-memory name cache.
+		// Clear in-memory name cache and the tenancy recorded alongside it.
 		$this->nameCache = [];
+		$this->nameCacheOrganisation = [];
 
 		// Clear distributed name cache.
 		if ($this->nameDistributedCache !== null) {

--- a/lib/Service/Object/CacheHandler.php
+++ b/lib/Service/Object/CacheHandler.php
@@ -490,7 +490,7 @@ class CacheHandler {
 			return false;
 		}
 
-		$user = $this->userSession?->getUser();
+		$user = $this->userSession->getUser();
 		if ($user === null) {
 			return false;
 		}
@@ -524,7 +524,7 @@ class CacheHandler {
 	 * @spec openspec/specs/object-lifecycle/spec.md
 	 */
 	private function resolveActiveOrganisationUuid(): ?string {
-		$user = $this->userSession?->getUser();
+		$user = $this->userSession->getUser();
 		if ($user === null) {
 			return $this->organisationMapper->getDefaultOrganisationFromConfig();
 		}
@@ -1692,7 +1692,10 @@ class CacheHandler {
 			$this->nameCache,
 			function ($name, $key) {
 				// Only return entries where key looks like a UUID (contains hyphens).
-				if (is_string($key) === false || str_contains($key, '-') === false) {
+				// Cast rather than is_string(): PHP narrows numeric-looking array keys
+				// to int, and phpstan reads the declared key type as string, so an
+				// is_string() test here is always-true dead code.
+				if (str_contains((string)$key, '-') === false) {
 					return false;
 				}
 

--- a/lib/Service/Object/SaveObject.php
+++ b/lib/Service/Object/SaveObject.php
@@ -3404,7 +3404,13 @@ class SaveObject {
 		$savedName = $savedEntity->getName();
 		$savedUuid = $savedEntity->getUuid();
 		if ($savedUuid !== null && $savedName !== null && trim($savedName) !== '') {
-			$this->cacheHandler->setObjectName(identifier: $savedUuid, name: $savedName);
+			// SEC-CTRL-2 step 2: the cached name carries the entity's tenancy, so it
+			// is only ever handed back to a caller in that organisation.
+			$this->cacheHandler->setObjectName(
+				identifier: $savedUuid,
+				name: $savedName,
+				organisation: $savedEntity->getOrganisation()
+			);
 		}
 
 		// Process file properties with rollback on failure.
@@ -5233,9 +5239,17 @@ class SaveObject {
 			return;
 		}
 
+		// SEC-CTRL-2 step 2: pre-cached parent names carry their owning organisation
+		// so the shared name cache can never disclose them across tenants.
+		$parentOrganisation = $objectEntity->getOrganisation();
+
 		$name = $objectEntity->getName();
 		if ($name !== null && trim($name) !== '') {
-			$this->cacheHandler->setObjectName(identifier: $uuid, name: $name);
+			$this->cacheHandler->setObjectName(
+				identifier: $uuid,
+				name: $name,
+				organisation: $parentOrganisation
+			);
 		}
 
 		// Also try the 'naam' field as a fallback (common in Dutch schemas).
@@ -5243,7 +5257,11 @@ class SaveObject {
 		if (($name === null || trim($name) === '') && isset($data['naam']) === true) {
 			$name = trim((string)$data['naam']);
 			if ($name !== '') {
-				$this->cacheHandler->setObjectName(identifier: $uuid, name: $name);
+				$this->cacheHandler->setObjectName(
+					identifier: $uuid,
+					name: $name,
+					organisation: $parentOrganisation
+				);
 			}
 		}
 	}//end preCacheParentName()

--- a/tests/Unit/Service/Object/CacheHandlerBranchCoverageTest.php
+++ b/tests/Unit/Service/Object/CacheHandlerBranchCoverageTest.php
@@ -8,6 +8,7 @@ use OCA\OpenRegister\Db\MagicMapper;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\OrganisationMapper;
 use OCA\OpenRegister\Service\Object\CacheHandler;
+use OCP\IAppConfig;
 use OCP\ICacheFactory;
 use OCP\IMemcache;
 use OCP\IUserSession;
@@ -59,12 +60,30 @@ class CacheHandlerBranchCoverageTest extends TestCase {
 				return null;
 			});
 
+		// These branch-coverage tests predate SEC-CTRL-2 step 2 and assert the
+		// resolver with no tenant boundary in force — a real supported
+		// configuration. CacheHandlerTenantScopeTest covers the scoped behaviour.
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getValueString')
+			->willReturnCallback(function (string $app, string $key, string $default = '') {
+				if ($app === 'openregister' && $key === 'multitenancy') {
+					return '{"enabled":false}';
+				}
+
+				return $default;
+			});
+
 		$this->handler = new CacheHandler(
 			$this->organisationMapper,
 			$this->logger,
 			$this->cacheFactory,
 			$this->userSession,
-			$container
+			$container,
+			null,
+			null,
+			null,
+			null,
+			$appConfig
 		);
 	}
 
@@ -191,7 +210,7 @@ class CacheHandlerBranchCoverageTest extends TestCase {
 	public function testSetObjectNameStoresInBothCaches(): void {
 		$this->nameDistCache->expects($this->once())
 			->method('set')
-			->with('name_uuid-123', 'Test Object', $this->anything());
+			->with('name_uuid-123', ['n' => 'Test Object', 'o' => null], $this->anything());
 
 		$this->handler->setObjectName('uuid-123', 'Test Object');
 	}

--- a/tests/Unit/Service/Object/CacheHandlerCoverageTest.php
+++ b/tests/Unit/Service/Object/CacheHandlerCoverageTest.php
@@ -23,6 +23,7 @@ use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Service\Object\CacheHandler;
 use OCP\AppFramework\IAppContainer;
+use OCP\IAppConfig;
 use OCP\ICacheFactory;
 use OCP\IDBConnection;
 use OCP\IMemcache;
@@ -87,6 +88,9 @@ class CacheHandlerCoverageTest extends TestCase {
 	/** @var IDBConnection&MockObject */
 	private IDBConnection $db;
 
+	/** @var IAppConfig&MockObject */
+	private IAppConfig $appConfig;
+
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -112,6 +116,19 @@ class CacheHandlerCoverageTest extends TestCase {
 		$this->registerMapper = $this->createMock(RegisterMapper::class);
 		$this->schemaMapper = $this->createMock(SchemaMapper::class);
 		$this->db = $this->createMock(IDBConnection::class);
+
+		// These coverage tests predate SEC-CTRL-2 step 2 and assert the resolver
+		// with no tenant boundary in force — a real supported configuration.
+		// The tenant-scoped behaviour is covered by CacheHandlerTenantScopeTest.
+		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->appConfig->method('getValueString')
+			->willReturnCallback(function (string $app, string $key, string $default = '') {
+				if ($app === 'openregister' && $key === 'multitenancy') {
+					return '{"enabled":false}';
+				}
+
+				return $default;
+			});
 	}
 
 	/**
@@ -144,7 +161,9 @@ class CacheHandlerCoverageTest extends TestCase {
 			$effectiveContainer,
 			$this->registerMapper,
 			$this->schemaMapper,
-			$this->db
+			$this->db,
+			null,
+			$this->appConfig
 		);
 	}
 
@@ -474,7 +493,7 @@ class CacheHandlerCoverageTest extends TestCase {
 
 		$this->nameDistributedCache->expects($this->once())
 			->method('set')
-			->with('name_uuid-1', 'Test Object', $this->anything());
+			->with('name_uuid-1', ['n' => 'Test Object', 'o' => null], $this->anything());
 
 		$handler->setObjectName('uuid-1', 'Test Object');
 
@@ -507,7 +526,7 @@ class CacheHandlerCoverageTest extends TestCase {
 		// Very high TTL should be clamped to MAX_CACHE_TTL (86400)
 		$this->nameDistributedCache->expects($this->once())
 			->method('set')
-			->with('name_uuid-1', 'Test', 86400);
+			->with('name_uuid-1', ['n' => 'Test', 'o' => null], 86400);
 
 		$handler->setObjectName('uuid-1', 'Test', 999999);
 	}
@@ -527,9 +546,10 @@ class CacheHandlerCoverageTest extends TestCase {
 	public function testGetSingleObjectNameDistributedHit(): void {
 		$handler = $this->createHandler();
 
+		// SEC-CTRL-2 step 2: tenancy-bearing envelope, not a bare string.
 		$this->nameDistributedCache->method('get')
 			->with('name_uuid-1')
-			->willReturn('Distributed Name');
+			->willReturn(['n' => 'Distributed Name', 'o' => null]);
 
 		$result = $handler->getSingleObjectName('uuid-1');
 		$this->assertSame('Distributed Name', $result);

--- a/tests/Unit/Service/Object/CacheHandlerNameScopePolicyTest.php
+++ b/tests/Unit/Service/Object/CacheHandlerNameScopePolicyTest.php
@@ -1,0 +1,677 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * CacheHandler name-scope POLICY tests (SEC-CTRL-2 step 2)
+ *
+ * `CacheHandlerTenantScopeTest` proves the leak is closed on the happy tenant
+ * boundary. This class exercises the DECISION FUNCTION itself — every arm that
+ * decides whether a caller may be told a name. Each one is a place where getting
+ * the answer wrong either re-opens the disclosure (too permissive) or silently
+ * blanks names for legitimate users (too strict), so none of them is filler.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Object
+ * @author   Conduction Development Team <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://github.com/ConductionNL/openregister
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)   One control per policy arm.
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Tests need to mock many dependencies.
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Object;
+
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Organisation;
+use OCA\OpenRegister\Db\OrganisationMapper;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Object\CacheHandler;
+use OCP\AppFramework\IAppContainer;
+use OCP\IAppConfig;
+use OCP\ICacheFactory;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
+use OCP\IMemcache;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionClass;
+
+/**
+ * Policy-arm controls for CacheHandler's name-visibility decision.
+ */
+class CacheHandlerNameScopePolicyTest extends TestCase {
+	private const ORG_A = 'aaaaaaaa-0000-0000-0000-000000000001';
+	private const ORG_B = 'bbbbbbbb-0000-0000-0000-000000000002';
+
+	/** @var MagicMapper */
+	private MagicMapper $objectMapper;
+
+	/** @var OrganisationMapper */
+	private OrganisationMapper $organisationMapper;
+
+	/** @var LoggerInterface */
+	private LoggerInterface $logger;
+
+	/** @var ICacheFactory */
+	private ICacheFactory $cacheFactory;
+
+	/** @var IMemcache */
+	private IMemcache $nameDistributedCache;
+
+	/** @var IMemcache */
+	private IMemcache $queryCache;
+
+	/** @var IUserSession */
+	private IUserSession $userSession;
+
+	/**
+	 * Set up shared doubles. No user by default; tests opt in.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->objectMapper = $this->createMock(MagicMapper::class);
+		$this->organisationMapper = $this->createMock(OrganisationMapper::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->cacheFactory = $this->createMock(ICacheFactory::class);
+		$this->nameDistributedCache = $this->createMock(IMemcache::class);
+		$this->queryCache = $this->createMock(IMemcache::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+
+		$this->cacheFactory->method('createDistributed')
+			->willReturnCallback(function (string $prefix) {
+				if ($prefix === 'openregister_object_names') {
+					return $this->nameDistributedCache;
+				}
+
+				return $this->queryCache;
+			});
+
+		$this->nameDistributedCache->method('get')->willReturn(null);
+		$this->organisationMapper->method('findMultipleByUuid')->willReturn([]);
+		$this->objectMapper->method('findMultiple')->willReturn([]);
+	}
+
+	/**
+	 * Give the session a user with the supplied uid.
+	 *
+	 * @param string $uid The user id
+	 *
+	 * @return void
+	 */
+	private function withUser(string $uid): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$this->userSession->method('getUser')->willReturn($user);
+	}
+
+	/**
+	 * Build an IAppConfig double answering a fixed multitenancy config string.
+	 *
+	 * @param string $multitenancyJson The raw value stored under openregister/multitenancy
+	 *
+	 * @return IAppConfig
+	 */
+	private function appConfigWith(string $multitenancyJson): IAppConfig {
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getValueString')
+			->willReturnCallback(function (string $app, string $key, string $default = '') use ($multitenancyJson) {
+				if ($app === 'openregister' && $key === 'multitenancy') {
+					return $multitenancyJson;
+				}
+
+				return $default;
+			});
+		return $appConfig;
+	}
+
+	/**
+	 * Build a CacheHandler with the supplied optional collaborators.
+	 *
+	 * @param IGroupManager|null  $groupManager   Group manager for the admin-override arm
+	 * @param IAppConfig|null     $appConfig      App config for the multitenancy switches
+	 * @param RegisterMapper|null $registerMapper Register mapper for magic-table queries
+	 * @param SchemaMapper|null   $schemaMapper   Schema mapper for magic-table queries
+	 * @param IDBConnection|null  $db             Database connection for magic-table queries
+	 *
+	 * @return CacheHandler
+	 */
+	private function buildHandler(
+		?IGroupManager $groupManager = null,
+		?IAppConfig $appConfig = null,
+		?RegisterMapper $registerMapper = null,
+		?SchemaMapper $schemaMapper = null,
+		?IDBConnection $db = null,
+	): CacheHandler {
+		$container = $this->createMock(IAppContainer::class);
+		$container->method('get')
+			->willReturnCallback(function (string $class) {
+				if ($class === MagicMapper::class) {
+					return $this->objectMapper;
+				}
+
+				return $this->createMock($class);
+			});
+
+		return new CacheHandler(
+			$this->organisationMapper,
+			$this->logger,
+			$this->cacheFactory,
+			$this->userSession,
+			$container,
+			$registerMapper,
+			$schemaMapper,
+			$db,
+			$groupManager,
+			$appConfig
+		);
+	}
+
+	/**
+	 * Build an ObjectEntity owned by a given organisation.
+	 *
+	 * @param string      $uuid         Object UUID
+	 * @param string      $name         Object name
+	 * @param string|null $organisation Owning organisation UUID
+	 *
+	 * @return ObjectEntity
+	 */
+	private function createObject(string $uuid, string $name, ?string $organisation): ObjectEntity {
+		$object = new ObjectEntity();
+		$object->setUuid($uuid);
+		$object->setName($name);
+		$object->setOrganisation($organisation);
+		return $object;
+	}
+
+	/**
+	 * Read the resolved scope out of the handler.
+	 *
+	 * @param CacheHandler $handler The handler under test
+	 *
+	 * @return array<int, string>|null
+	 */
+	private function resolveScope(CacheHandler $handler): ?array {
+		$ref = new ReflectionClass($handler);
+		$begin = $ref->getMethod('beginNameScope');
+		$begin->setAccessible(true);
+		$begin->invoke($handler);
+
+		$method = $ref->getMethod('resolveNameScope');
+		$method->setAccessible(true);
+		return $method->invoke($handler);
+	}
+
+	// =====================================================================
+	// resolveNameScope() — the four documented outcomes
+	// =====================================================================
+
+	/**
+	 * Multitenancy switched off instance-wide means no boundary at all.
+	 *
+	 * @return void
+	 */
+	public function testMultitenancyDisabledYieldsUnrestrictedScope(): void {
+		$this->withUser('alice');
+		$handler = $this->buildHandler(null, $this->appConfigWith('{"enabled":false}'));
+
+		$this->assertNull($this->resolveScope($handler));
+	}
+
+	/**
+	 * `enabled: true` is filtering ON — the switch must not read as a wildcard.
+	 *
+	 * @return void
+	 */
+	public function testMultitenancyExplicitlyEnabledStillScopes(): void {
+		$this->withUser('alice');
+		$this->organisationMapper->method('getActiveOrganisationWithFallback')->willReturn(self::ORG_B);
+		$this->organisationMapper->method('getOrganisationHierarchy')->willReturn([self::ORG_B]);
+
+		$handler = $this->buildHandler(null, $this->appConfigWith('{"enabled":true}'));
+
+		$this->assertSame([self::ORG_B], $this->resolveScope($handler));
+	}
+
+	/**
+	 * An unparseable multitenancy config must FAIL CLOSED (keep filtering), never
+	 * be read as "disabled".
+	 *
+	 * @return void
+	 */
+	public function testUnparseableMultitenancyConfigKeepsFiltering(): void {
+		$this->withUser('alice');
+		$this->organisationMapper->method('getActiveOrganisationWithFallback')->willReturn(self::ORG_B);
+		$this->organisationMapper->method('getOrganisationHierarchy')->willReturn([self::ORG_B]);
+
+		$handler = $this->buildHandler(null, $this->appConfigWith('not json at all'));
+
+		$this->assertSame([self::ORG_B], $this->resolveScope($handler));
+	}
+
+	/**
+	 * An empty multitenancy config is the default install — filtering stays on.
+	 *
+	 * @return void
+	 */
+	public function testEmptyMultitenancyConfigKeepsFiltering(): void {
+		$this->withUser('alice');
+		$this->organisationMapper->method('getActiveOrganisationWithFallback')->willReturn(self::ORG_B);
+		$this->organisationMapper->method('getOrganisationHierarchy')->willReturn([self::ORG_B]);
+
+		$handler = $this->buildHandler(null, $this->appConfigWith(''));
+
+		$this->assertSame([self::ORG_B], $this->resolveScope($handler));
+	}
+
+	/**
+	 * No active organisation at all is the trait's `1 = 0` arm: nothing visible.
+	 *
+	 * @return void
+	 */
+	public function testNoActiveOrganisationYieldsEmptyScope(): void {
+		$this->withUser('alice');
+		$this->organisationMapper->method('getActiveOrganisationWithFallback')->willReturn(null);
+
+		$handler = $this->buildHandler();
+
+		$this->assertSame([], $this->resolveScope($handler));
+	}
+
+	/**
+	 * With no session the DEFAULT organisation stands in — the same fallback
+	 * Db\MultiTenancyTrait::getActiveOrganisationUuid() applies.
+	 *
+	 * @return void
+	 */
+	public function testAnonymousCallerFallsBackToTheDefaultOrganisation(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->organisationMapper->method('getDefaultOrganisationFromConfig')->willReturn(self::ORG_A);
+		$this->organisationMapper->method('getOrganisationHierarchy')->willReturn([self::ORG_A]);
+
+		$handler = $this->buildHandler();
+
+		$this->assertSame([self::ORG_A], $this->resolveScope($handler));
+	}
+
+	/**
+	 * A caller sees its active organisation AND its parents, exactly like the
+	 * mappers — narrowing this would blank names for hierarchical tenants.
+	 *
+	 * @return void
+	 */
+	public function testScopeIncludesTheParentOrganisations(): void {
+		$this->withUser('alice');
+		$this->organisationMapper->method('getActiveOrganisationWithFallback')->willReturn(self::ORG_B);
+		$this->organisationMapper->method('getOrganisationHierarchy')
+			->willReturn([self::ORG_B, self::ORG_A]);
+
+		$handler = $this->buildHandler();
+
+		$this->assertSame([self::ORG_B, self::ORG_A], $this->resolveScope($handler));
+	}
+
+	/**
+	 * If the hierarchy lookup fails, fall back to the ACTIVE organisation alone —
+	 * the narrower answer, never a wider one.
+	 *
+	 * @return void
+	 */
+	public function testHierarchyFailureFallsBackToTheActiveOrganisationAlone(): void {
+		$this->withUser('alice');
+		$this->organisationMapper->method('getActiveOrganisationWithFallback')->willReturn(self::ORG_B);
+		$this->organisationMapper->method('getOrganisationHierarchy')
+			->willThrowException(new \RuntimeException('hierarchy unavailable'));
+
+		$handler = $this->buildHandler();
+
+		$this->assertSame([self::ORG_B], $this->resolveScope($handler));
+	}
+
+	/**
+	 * If the scope cannot be established at all, nothing is visible.
+	 *
+	 * @return void
+	 */
+	public function testScopeResolutionFailureDeniesEverything(): void {
+		$this->withUser('alice');
+		$this->organisationMapper->method('getActiveOrganisationWithFallback')
+			->willThrowException(new \RuntimeException('mapper down'));
+
+		$handler = $this->buildHandler();
+
+		$this->assertSame([], $this->resolveScope($handler));
+	}
+
+	// =====================================================================
+	// The admin override — the one arm that widens the boundary
+	// =====================================================================
+
+	/**
+	 * An admin with the override enabled reads names across organisations.
+	 *
+	 * @return void
+	 */
+	public function testAdminOverrideEnabledYieldsUnrestrictedScope(): void {
+		$this->withUser('root');
+		$groupManager = $this->createMock(IGroupManager::class);
+		$groupManager->method('isAdmin')->willReturn(true);
+
+		$handler = $this->buildHandler($groupManager, $this->appConfigWith('{"adminOverride":true}'));
+
+		$this->assertNull($this->resolveScope($handler));
+	}
+
+	/**
+	 * SaaS mode revokes the admin override — a hard tenant boundary wins.
+	 *
+	 * @return void
+	 */
+	public function testSaasModeRevokesTheAdminOverride(): void {
+		$this->withUser('root');
+		$this->organisationMapper->method('getActiveOrganisationWithFallback')->willReturn(self::ORG_B);
+		$this->organisationMapper->method('getOrganisationHierarchy')->willReturn([self::ORG_B]);
+		$groupManager = $this->createMock(IGroupManager::class);
+		$groupManager->method('isAdmin')->willReturn(true);
+
+		$handler = $this->buildHandler(
+			$groupManager,
+			$this->appConfigWith('{"adminOverride":true,"saasMode":true}')
+		);
+
+		$this->assertSame([self::ORG_B], $this->resolveScope($handler));
+	}
+
+	/**
+	 * A NON-admin never gets the override, however the config is set.
+	 *
+	 * @return void
+	 */
+	public function testNonAdminNeverGetsTheOverride(): void {
+		$this->withUser('alice');
+		$this->organisationMapper->method('getActiveOrganisationWithFallback')->willReturn(self::ORG_B);
+		$this->organisationMapper->method('getOrganisationHierarchy')->willReturn([self::ORG_B]);
+		$groupManager = $this->createMock(IGroupManager::class);
+		$groupManager->method('isAdmin')->willReturn(false);
+
+		$handler = $this->buildHandler($groupManager, $this->appConfigWith('{"adminOverride":true}'));
+
+		$this->assertSame([self::ORG_B], $this->resolveScope($handler));
+	}
+
+	/**
+	 * An admin WITHOUT the override configured stays inside their organisation.
+	 *
+	 * @return void
+	 */
+	public function testAdminWithoutOverrideConfiguredStaysScoped(): void {
+		$this->withUser('root');
+		$this->organisationMapper->method('getActiveOrganisationWithFallback')->willReturn(self::ORG_B);
+		$this->organisationMapper->method('getOrganisationHierarchy')->willReturn([self::ORG_B]);
+		$groupManager = $this->createMock(IGroupManager::class);
+		$groupManager->method('isAdmin')->willReturn(true);
+
+		$handler = $this->buildHandler($groupManager, $this->appConfigWith('{"enabled":true}'));
+
+		$this->assertSame([self::ORG_B], $this->resolveScope($handler));
+	}
+
+	/**
+	 * The override cannot apply to an anonymous caller — there is no admin.
+	 *
+	 * @return void
+	 */
+	public function testAnonymousCallerNeverGetsTheAdminOverride(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->organisationMapper->method('getDefaultOrganisationFromConfig')->willReturn(self::ORG_A);
+		$this->organisationMapper->method('getOrganisationHierarchy')->willReturn([self::ORG_A]);
+		$groupManager = $this->createMock(IGroupManager::class);
+		$groupManager->method('isAdmin')->willReturn(true);
+
+		$handler = $this->buildHandler($groupManager, $this->appConfigWith('{"adminOverride":true}'));
+
+		$this->assertSame([self::ORG_A], $this->resolveScope($handler));
+	}
+
+	/**
+	 * An unparseable config cannot switch the override on.
+	 *
+	 * @return void
+	 */
+	public function testUnparseableConfigCannotEnableTheOverride(): void {
+		$this->withUser('root');
+		$this->organisationMapper->method('getActiveOrganisationWithFallback')->willReturn(self::ORG_B);
+		$this->organisationMapper->method('getOrganisationHierarchy')->willReturn([self::ORG_B]);
+		$groupManager = $this->createMock(IGroupManager::class);
+		$groupManager->method('isAdmin')->willReturn(true);
+
+		$handler = $this->buildHandler($groupManager, $this->appConfigWith('"a bare string"'));
+
+		$this->assertSame([self::ORG_B], $this->resolveScope($handler));
+	}
+
+	/**
+	 * With no app config at all there is no override and filtering stays on.
+	 *
+	 * @return void
+	 */
+	public function testNoAppConfigMeansNoOverrideAndFilteringStaysOn(): void {
+		$this->withUser('root');
+		$this->organisationMapper->method('getActiveOrganisationWithFallback')->willReturn(self::ORG_B);
+		$this->organisationMapper->method('getOrganisationHierarchy')->willReturn([self::ORG_B]);
+		$groupManager = $this->createMock(IGroupManager::class);
+		$groupManager->method('isAdmin')->willReturn(true);
+
+		$handler = $this->buildHandler($groupManager, null);
+
+		$this->assertSame([self::ORG_B], $this->resolveScope($handler));
+	}
+
+	// =====================================================================
+	// The distributed-cache envelope — the cross-deploy boundary
+	// =====================================================================
+
+	/**
+	 * A value written BEFORE this change is a bare string with no tenancy. It
+	 * must read as a MISS, never be served unscoped.
+	 *
+	 * @return void
+	 */
+	public function testLegacyBareStringCacheValueIsRejected(): void {
+		$handler = $this->buildHandler();
+
+		$ref = new ReflectionClass($handler);
+		$method = $ref->getMethod('readNameEnvelope');
+		$method->setAccessible(true);
+
+		$this->assertNull($method->invoke($handler, 'Legacy Name'));
+		$this->assertNull($method->invoke($handler, null));
+		$this->assertNull($method->invoke($handler, ['o' => self::ORG_A]));
+		$this->assertNull($method->invoke($handler, ['n' => 42, 'o' => null]));
+		$this->assertNull($method->invoke($handler, ['n' => 'Name', 'o' => 7]));
+		$this->assertSame(
+			['n' => 'Name', 'o' => self::ORG_A],
+			$method->invoke($handler, ['n' => 'Name', 'o' => self::ORG_A])
+		);
+	}
+
+	/**
+	 * A distributed entry whose value survives the shape check but carries no
+	 * tenancy settles nothing: the caller must fall through to the database
+	 * rather than be handed an unscoped name.
+	 *
+	 * @return void
+	 */
+	public function testTenancylessDistributedEntryIsNotServedWhileScoping(): void {
+		$this->withUser('alice');
+		$this->organisationMapper->method('getActiveOrganisationWithFallback')->willReturn(self::ORG_B);
+		$this->organisationMapper->method('getOrganisationHierarchy')->willReturn([self::ORG_B]);
+
+		$distributed = $this->createMock(IMemcache::class);
+		$distributed->method('get')->willReturn(['n' => 'Untenanted', 'o' => null]);
+		$cacheFactory = $this->createMock(ICacheFactory::class);
+		$cacheFactory->method('createDistributed')->willReturn($distributed);
+		$this->cacheFactory = $cacheFactory;
+
+		$handler = $this->buildHandler();
+
+		$names = $handler->getMultipleObjectNames(['cccc3333-cccc-3333-cccc-333333333333']);
+
+		$this->assertArrayNotHasKey('cccc3333-cccc-3333-cccc-333333333333', $names);
+	}
+
+	// =====================================================================
+	// getSingleObjectName() — the internal primitive is gated too
+	// =====================================================================
+
+	/**
+	 * An in-memory entry owned by another organisation is not served.
+	 *
+	 * @return void
+	 */
+	public function testSingleNameFromMemoryIsRefusedAcrossTenants(): void {
+		$this->withUser('alice');
+		$this->organisationMapper->method('getActiveOrganisationWithFallback')->willReturn(self::ORG_B);
+		$this->organisationMapper->method('getOrganisationHierarchy')->willReturn([self::ORG_B]);
+		$this->organisationMapper->method('findByUuid')
+			->willThrowException(new \RuntimeException('not an organisation'));
+		$this->objectMapper->method('findAcrossAllSources')->willReturn(['object' => null]);
+
+		$handler = $this->buildHandler();
+		$handler->setObjectName(identifier: 'dddd4444-dddd-4444-dddd-444444444444', name: 'Alpha Name', organisation: self::ORG_A);
+
+		$this->assertNull($handler->getSingleObjectName('dddd4444-dddd-4444-dddd-444444444444'));
+	}
+
+	/**
+	 * An object resolved from the database is refused when it belongs elsewhere,
+	 * and returned when it belongs here.
+	 *
+	 * @return void
+	 */
+	public function testSingleNameFromDatabaseHonoursTheBoundaryBothWays(): void {
+		$this->withUser('alice');
+		$this->organisationMapper->method('getActiveOrganisationWithFallback')->willReturn(self::ORG_B);
+		$this->organisationMapper->method('getOrganisationHierarchy')->willReturn([self::ORG_B]);
+		$this->organisationMapper->method('findByUuid')
+			->willThrowException(new \RuntimeException('not an organisation'));
+		$this->objectMapper->method('findAcrossAllSources')
+			->willReturnCallback(function (string|int $identifier) {
+				if ((string)$identifier === 'eeee5555-eeee-5555-eeee-555555555555') {
+					return ['object' => $this->createObject((string)$identifier, 'Alpha Only', self::ORG_A)];
+				}
+
+				return ['object' => $this->createObject((string)$identifier, 'Beta Only', self::ORG_B)];
+			});
+
+		$handler = $this->buildHandler();
+
+		$this->assertNull($handler->getSingleObjectName('eeee5555-eeee-5555-eeee-555555555555'));
+		$this->assertSame('Beta Only', $handler->getSingleObjectName('ffff6666-ffff-6666-ffff-666666666666'));
+	}
+
+	/**
+	 * An ORGANISATION resolved from the database is refused across tenants and
+	 * returned for the caller's own organisation.
+	 *
+	 * @return void
+	 */
+	public function testSingleOrganisationNameHonoursTheBoundaryBothWays(): void {
+		$this->withUser('alice');
+		$this->organisationMapper->method('getActiveOrganisationWithFallback')->willReturn(self::ORG_B);
+		$this->organisationMapper->method('getOrganisationHierarchy')->willReturn([self::ORG_B]);
+		$this->organisationMapper->method('findByUuid')
+			->willReturnCallback(function (string $uuid) {
+				$organisation = new Organisation();
+				$organisation->setUuid($uuid);
+				$organisation->setName('Org ' . substr($uuid, 0, 4));
+				return $organisation;
+			});
+
+		$handler = $this->buildHandler();
+
+		$this->assertNull($handler->getSingleObjectName(self::ORG_A));
+		$this->assertSame('Org bbbb', $handler->getSingleObjectName(self::ORG_B));
+	}
+
+	// =====================================================================
+	// The magic-table batch loader is the tenancy oracle
+	// =====================================================================
+
+	/**
+	 * `batchLoadNamesFromMagicTables()` carries `_organisation` through, and
+	 * `getMultipleObjectNames()` refuses the rows that belong elsewhere.
+	 *
+	 * @return void
+	 */
+	public function testBatchLoadedMagicTableNamesAreScopedByOrganisation(): void {
+		$this->withUser('alice');
+		$this->organisationMapper->method('getActiveOrganisationWithFallback')->willReturn(self::ORG_B);
+		$this->organisationMapper->method('getOrganisationHierarchy')->willReturn([self::ORG_B]);
+
+		$registerMapper = $this->createMock(RegisterMapper::class);
+		$schemaMapper = $this->createMock(SchemaMapper::class);
+		$db = $this->createMock(IDBConnection::class);
+
+		$register = new Register();
+		$registerRef = new ReflectionClass($register);
+		$idProp = $registerRef->getProperty('id');
+		$idProp->setAccessible(true);
+		$idProp->setValue($register, 1);
+		$register->setSchemas([5]);
+		$register->setConfiguration(['schemas' => ['test-schema' => ['magicMapping' => true]]]);
+		$registerMapper->method('findAll')->willReturn([$register]);
+
+		$schema = new Schema();
+		$schemaRef = new ReflectionClass($schema);
+		$schemaIdProp = $schemaRef->getProperty('id');
+		$schemaIdProp->setAccessible(true);
+		$schemaIdProp->setValue($schema, 5);
+		$schema->setSlug('test-schema');
+		$schemaMapper->method('findMultipleOptimized')->willReturn([5 => $schema]);
+
+		$statement = $this->createMock(\OCP\DB\IPreparedStatement::class);
+		$statement->method('fetch')->willReturnOnConsecutiveCalls(
+			['_uuid' => '11112222-1111-2222-1111-222222222222', '_organisation' => self::ORG_A, 'name_value' => 'Alpha Batch'],
+			['_uuid' => '33334444-3333-4444-3333-444444444444', '_organisation' => self::ORG_B, 'name_value' => 'Beta Batch'],
+			false
+		);
+		$db->method('prepare')->willReturn($statement);
+
+		$handler = $this->buildHandler(null, null, $registerMapper, $schemaMapper, $db);
+
+		$names = $handler->getMultipleObjectNames([
+			'11112222-1111-2222-1111-222222222222',
+			'33334444-3333-4444-3333-444444444444',
+		]);
+
+		$this->assertArrayNotHasKey('11112222-1111-2222-1111-222222222222', $names);
+		$this->assertSame('Beta Batch', $names['33334444-3333-4444-3333-444444444444'] ?? null);
+	}
+
+	/**
+	 * With no magic-table dependencies wired there is no tenancy oracle, so the
+	 * loader returns nothing instead of fataling on a null mapper.
+	 *
+	 * @return void
+	 */
+	public function testBatchLoaderWithoutDependenciesResolvesNothingRatherThanFataling(): void {
+		$handler = $this->buildHandler();
+
+		$ref = new ReflectionClass($handler);
+		$method = $ref->getMethod('batchLoadNamesFromMagicTables');
+		$method->setAccessible(true);
+
+		$this->assertSame([], $method->invoke($handler, ['aaaa0000-aaaa-0000-aaaa-000000000000']));
+	}
+}

--- a/tests/Unit/Service/Object/CacheHandlerTenantScopeTest.php
+++ b/tests/Unit/Service/Object/CacheHandlerTenantScopeTest.php
@@ -1,0 +1,465 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * CacheHandler tenant-scope tests (SEC-CTRL-2 step 2)
+ *
+ * These tests pin the tenancy boundary of the shared object-name cache. Every
+ * one of them is a control: each asserts a name belonging to organisation A is
+ * NOT visible to a caller whose active organisation is B, through each of the
+ * three paths that can produce a name — the organisation mapper, the object
+ * mapper and the magic-table SQL — plus the cache path, which is the arm a
+ * query-only fix would miss (a cache warmed as A must not be served to B).
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Object
+ * @author   Conduction Development Team <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://github.com/ConductionNL/openregister
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)   One control per leaking path.
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Tests need to mock many dependencies.
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Object;
+
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Organisation;
+use OCA\OpenRegister\Db\OrganisationMapper;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Object\CacheHandler;
+use OCP\AppFramework\IAppContainer;
+use OCP\DB\IResult;
+use OCP\ICacheFactory;
+use OCP\IDBConnection;
+use OCP\IMemcache;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionClass;
+
+/**
+ * Cross-tenant disclosure controls for CacheHandler's name resolution.
+ */
+class CacheHandlerTenantScopeTest extends TestCase {
+	private const ORG_A = 'aaaaaaaa-0000-0000-0000-000000000001';
+	private const ORG_B = 'bbbbbbbb-0000-0000-0000-000000000002';
+
+	/** @var MagicMapper */
+	private MagicMapper $objectMapper;
+
+	/** @var OrganisationMapper */
+	private OrganisationMapper $organisationMapper;
+
+	/** @var LoggerInterface */
+	private LoggerInterface $logger;
+
+	/** @var ICacheFactory */
+	private ICacheFactory $cacheFactory;
+
+	/** @var IMemcache */
+	private IMemcache $nameDistributedCache;
+
+	/** @var IMemcache */
+	private IMemcache $queryCache;
+
+	/** @var IUserSession */
+	private IUserSession $userSession;
+
+	/**
+	 * The organisation the current caller is acting in, switched per test.
+	 *
+	 * @var string|null
+	 */
+	private ?string $activeOrganisation = null;
+
+	/**
+	 * Set up shared doubles.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->objectMapper = $this->createMock(MagicMapper::class);
+		$this->organisationMapper = $this->createMock(OrganisationMapper::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->cacheFactory = $this->createMock(ICacheFactory::class);
+		$this->nameDistributedCache = $this->createMock(IMemcache::class);
+		$this->queryCache = $this->createMock(IMemcache::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+
+		$this->cacheFactory->method('createDistributed')
+			->willReturnCallback(function (string $prefix) {
+				if ($prefix === 'openregister_object_names') {
+					return $this->nameDistributedCache;
+				}
+
+				return $this->queryCache;
+			});
+
+		// No distributed hits by default; the in-memory arm is exercised explicitly.
+		$this->nameDistributedCache->method('get')->willReturn(null);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('caller');
+		$this->userSession->method('getUser')->willReturn($user);
+
+		// The active organisation follows $this->activeOrganisation so a single
+		// handler can be read as tenant A and then as tenant B.
+		$this->organisationMapper->method('getActiveOrganisationWithFallback')
+			->willReturnCallback(fn (): ?string => $this->activeOrganisation);
+		$this->organisationMapper->method('getDefaultOrganisationFromConfig')
+			->willReturnCallback(fn (): ?string => $this->activeOrganisation);
+		$this->organisationMapper->method('getOrganisationHierarchy')
+			->willReturnCallback(fn (string $uuid): array => [$uuid]);
+
+		$this->activeOrganisation = self::ORG_B;
+	}
+
+	/**
+	 * Build a CacheHandler with the shared doubles.
+	 *
+	 * @param RegisterMapper|null $registerMapper Register mapper for magic-table queries
+	 * @param SchemaMapper|null   $schemaMapper   Schema mapper for magic-table queries
+	 * @param IDBConnection|null  $db             Database connection for magic-table queries
+	 *
+	 * @return CacheHandler
+	 */
+	private function buildHandler(
+		?RegisterMapper $registerMapper = null,
+		?SchemaMapper $schemaMapper = null,
+		?IDBConnection $db = null,
+	): CacheHandler {
+		$container = $this->createMock(IAppContainer::class);
+		$container->method('get')
+			->willReturnCallback(function (string $class) {
+				if ($class === MagicMapper::class) {
+					return $this->objectMapper;
+				}
+
+				return $this->createMock($class);
+			});
+
+		return new CacheHandler(
+			$this->organisationMapper,
+			$this->logger,
+			$this->cacheFactory,
+			$this->userSession,
+			$container,
+			$registerMapper,
+			$schemaMapper,
+			$db
+		);
+	}
+
+	/**
+	 * Build an ObjectEntity owned by a given organisation.
+	 *
+	 * @param string      $uuid         Object UUID
+	 * @param string      $name         Object name
+	 * @param string|null $organisation Owning organisation UUID
+	 *
+	 * @return ObjectEntity
+	 */
+	private function createObject(string $uuid, string $name, ?string $organisation): ObjectEntity {
+		$object = new ObjectEntity();
+		$object->setUuid($uuid);
+		$object->setName($name);
+		$object->setOrganisation($organisation);
+		return $object;
+	}
+
+	/**
+	 * Build a Register whose schema has magic mapping enabled.
+	 *
+	 * @param int   $id            Register id
+	 * @param array $schemaIds     Schema ids
+	 * @param array $configuration Register configuration
+	 *
+	 * @return Register
+	 */
+	private function createRegister(int $id, array $schemaIds, array $configuration): Register {
+		$register = new Register();
+		$ref = new ReflectionClass($register);
+		$idProp = $ref->getProperty('id');
+		$idProp->setAccessible(true);
+		$idProp->setValue($register, $id);
+		$register->setSchemas($schemaIds);
+		$register->setConfiguration($configuration);
+		return $register;
+	}
+
+	/**
+	 * Build a Schema with a given id and slug.
+	 *
+	 * @param int    $id   Schema id
+	 * @param string $slug Schema slug
+	 *
+	 * @return Schema
+	 */
+	private function createSchema(int $id, string $slug): Schema {
+		$schema = new Schema();
+		$ref = new ReflectionClass($schema);
+		$idProp = $ref->getProperty('id');
+		$idProp->setAccessible(true);
+		$idProp->setValue($schema, $id);
+		$schema->setSlug($slug);
+		return $schema;
+	}
+
+	// =====================================================================
+	// LEAK CONTROLS — each of these fails on the unscoped implementation.
+	// =====================================================================
+
+	/**
+	 * A caller in organisation B must not resolve the name of an object owned
+	 * by organisation A through the object-mapper path.
+	 *
+	 * @return void
+	 */
+	public function testObjectNameFromAnotherOrganisationIsNotDisclosed(): void {
+		$this->organisationMapper->method('findMultipleByUuid')->willReturn([]);
+		$this->objectMapper->method('findMultiple')->willReturn([
+			$this->createObject('11111111-1111-1111-1111-111111111111', 'Alpha Secret Dossier', self::ORG_A),
+		]);
+
+		$handler = $this->buildHandler();
+
+		$names = $handler->getMultipleObjectNames(['11111111-1111-1111-1111-111111111111']);
+
+		$this->assertArrayNotHasKey(
+			'11111111-1111-1111-1111-111111111111',
+			$names,
+			'A caller in organisation B resolved the name of an object owned by organisation A.'
+		);
+	}
+
+	/**
+	 * A caller in organisation B must not resolve the NAME of organisation A.
+	 *
+	 * @return void
+	 */
+	public function testOrganisationNameFromAnotherTenantIsNotDisclosed(): void {
+		$organisation = new Organisation();
+		$organisation->setUuid(self::ORG_A);
+		$organisation->setName('Gemeente Alpha');
+
+		$this->organisationMapper->method('findMultipleByUuid')->willReturn([$organisation]);
+		$this->objectMapper->method('findMultiple')->willReturn([]);
+
+		$handler = $this->buildHandler();
+
+		$names = $handler->getMultipleObjectNames([self::ORG_A]);
+
+		$this->assertArrayNotHasKey(
+			self::ORG_A,
+			$names,
+			'A caller in organisation B resolved organisation A\'s name.'
+		);
+	}
+
+	/**
+	 * THE CACHE ARM. Warm the shared name cache as tenant A, then read as
+	 * tenant B: B must not be served A's names out of the warm cache.
+	 *
+	 * A query-only fix passes every other control in this file and fails here.
+	 *
+	 * @return void
+	 */
+	public function testCacheWarmedAsTenantAIsNotServedToTenantB(): void {
+		$this->organisationMapper->method('findMultipleByUuid')->willReturn([]);
+		$this->objectMapper->method('findMultiple')->willReturn([
+			$this->createObject('22222222-2222-2222-2222-222222222222', 'Alpha Payroll', self::ORG_A),
+		]);
+
+		$handler = $this->buildHandler();
+
+		// Warm as tenant A — A may legitimately see its own object's name.
+		$this->activeOrganisation = self::ORG_A;
+		$warm = $handler->getMultipleObjectNames(['22222222-2222-2222-2222-222222222222']);
+		$this->assertSame(
+			'Alpha Payroll',
+			$warm['22222222-2222-2222-2222-222222222222'] ?? null,
+			'Positive control: tenant A must still resolve its own object name.'
+		);
+
+		// Read as tenant B — the entry is now in the in-memory name cache.
+		$this->activeOrganisation = self::ORG_B;
+		$leaked = $handler->getMultipleObjectNames(['22222222-2222-2222-2222-222222222222']);
+
+		$this->assertArrayNotHasKey(
+			'22222222-2222-2222-2222-222222222222',
+			$leaked,
+			'The warm name cache served organisation A\'s name to a caller in organisation B.'
+		);
+	}
+
+	/**
+	 * getAllObjectNames() must return only the caller's own tenant's names,
+	 * even when the cache was warmed by another tenant's request.
+	 *
+	 * @return void
+	 */
+	public function testGetAllObjectNamesIsScopedToTheCallersOrganisation(): void {
+		$this->organisationMapper->method('findMultipleByUuid')->willReturn([]);
+		$this->objectMapper->method('findMultiple')->willReturn([
+			$this->createObject('33333333-3333-3333-3333-333333333333', 'Alpha Register Row', self::ORG_A),
+			$this->createObject('44444444-4444-4444-4444-444444444444', 'Beta Register Row', self::ORG_B),
+		]);
+
+		$handler = $this->buildHandler();
+
+		// Tenant A warms both entries into the shared cache.
+		$this->activeOrganisation = self::ORG_A;
+		$handler->getMultipleObjectNames([
+			'33333333-3333-3333-3333-333333333333',
+			'44444444-4444-4444-4444-444444444444',
+		]);
+
+		// Tenant B asks for everything the cache holds.
+		$this->activeOrganisation = self::ORG_B;
+		$all = $handler->getAllObjectNames(false);
+
+		$this->assertArrayNotHasKey(
+			'33333333-3333-3333-3333-333333333333',
+			$all,
+			'getAllObjectNames() disclosed an organisation A name to a caller in organisation B.'
+		);
+		$this->assertSame(
+			'Beta Register Row',
+			$all['44444444-4444-4444-4444-444444444444'] ?? null,
+			'Positive control: tenant B must still see its own name.'
+		);
+	}
+
+	/**
+	 * The magic-table warmup must record each name's owning organisation and
+	 * hand back only the caller's own tenant's rows.
+	 *
+	 * @return void
+	 */
+	public function testWarmupFromMagicTablesIsScopedByOrganisationColumn(): void {
+		$registerMapper = $this->createMock(RegisterMapper::class);
+		$schemaMapper = $this->createMock(SchemaMapper::class);
+		$db = $this->createMock(IDBConnection::class);
+
+		$this->organisationMapper->method('findAllWithUserCount')->willReturn([]);
+		$this->objectMapper->method('findAll')->willReturn([]);
+
+		$registerMapper->method('findAll')->willReturn([
+			$this->createRegister(1, [5], ['schemas' => ['test-schema' => ['magicMapping' => true]]]),
+		]);
+		$schemaMapper->method('find')->willReturn($this->createSchema(5, 'test-schema'));
+
+		$queryResult = $this->createMock(IResult::class);
+		$queryResult->method('fetch')->willReturnOnConsecutiveCalls(
+			[
+				'_uuid' => '55555555-5555-5555-5555-555555555555',
+				'_name' => 'Alpha Magic Row',
+				'_organisation' => self::ORG_A,
+			],
+			[
+				'_uuid' => '66666666-6666-6666-6666-666666666666',
+				'_name' => 'Beta Magic Row',
+				'_organisation' => self::ORG_B,
+			],
+			false
+		);
+		$db->method('executeQuery')->willReturn($queryResult);
+
+		$handler = $this->buildHandler($registerMapper, $schemaMapper, $db);
+
+		$this->activeOrganisation = self::ORG_B;
+		$handler->warmupNameCache();
+
+		$all = $handler->getAllObjectNames(false);
+
+		$this->assertArrayNotHasKey(
+			'55555555-5555-5555-5555-555555555555',
+			$all,
+			'A magic-table row owned by organisation A was disclosed to a caller in organisation B.'
+		);
+		$this->assertSame(
+			'Beta Magic Row',
+			$all['66666666-6666-6666-6666-666666666666'] ?? null,
+			'Positive control: the caller\'s own magic-table row must still resolve.'
+		);
+	}
+
+	/**
+	 * A name whose owning organisation cannot be established must not be
+	 * served — the resolver fails closed, it does not guess.
+	 *
+	 * @return void
+	 */
+	public function testNameWithUnknownOrganisationIsNotDisclosed(): void {
+		$this->organisationMapper->method('findMultipleByUuid')->willReturn([]);
+		$this->objectMapper->method('findMultiple')->willReturn([
+			$this->createObject('77777777-7777-7777-7777-777777777777', 'Untenanted Row', null),
+		]);
+
+		$handler = $this->buildHandler();
+
+		$names = $handler->getMultipleObjectNames(['77777777-7777-7777-7777-777777777777']);
+
+		$this->assertArrayNotHasKey(
+			'77777777-7777-7777-7777-777777777777',
+			$names,
+			'A name with no resolvable owning organisation was served to a tenant-scoped caller.'
+		);
+	}
+
+	// =====================================================================
+	// FUNCTIONAL CONTROLS — the shape the six internal callers depend on.
+	// =====================================================================
+
+	/**
+	 * The in-scope path must keep working: a caller resolves names for its own
+	 * organisation's objects and organisations in one call, keyed by UUID.
+	 *
+	 * This is the exact return shape ObjectsController::collectNamesForResponse,
+	 * ObjectService::collectNamesForResults, ExportService, PerformanceHandler,
+	 * MetadataHydrationHandler and MagicFacetHandler consume.
+	 *
+	 * @return void
+	 */
+	public function testInScopeNamesAreStillResolvedForEveryInternalCaller(): void {
+		$organisation = new Organisation();
+		$organisation->setUuid(self::ORG_B);
+		$organisation->setName('Gemeente Beta');
+
+		$this->organisationMapper->method('findMultipleByUuid')->willReturn([$organisation]);
+		$this->objectMapper->method('findMultiple')->willReturn([
+			$this->createObject('88888888-8888-8888-8888-888888888888', 'Beta Dossier', self::ORG_B),
+		]);
+
+		$handler = $this->buildHandler();
+
+		$names = $handler->getMultipleObjectNames([
+			self::ORG_B,
+			'88888888-8888-8888-8888-888888888888',
+		]);
+
+		$this->assertSame('Gemeente Beta', $names[self::ORG_B] ?? null);
+		$this->assertSame('Beta Dossier', $names['88888888-8888-8888-8888-888888888888'] ?? null);
+	}
+
+	/**
+	 * An empty identifier list is still answered with an empty map, without
+	 * touching the database — the contract every caller relies on.
+	 *
+	 * @return void
+	 */
+	public function testEmptyIdentifierListStillReturnsEmptyMap(): void {
+		$handler = $this->buildHandler();
+
+		$this->assertSame([], $handler->getMultipleObjectNames([]));
+	}
+}

--- a/tests/Unit/Service/Object/CacheHandlerTenantScopeTest.php
+++ b/tests/Unit/Service/Object/CacheHandlerTenantScopeTest.php
@@ -462,4 +462,57 @@ class CacheHandlerTenantScopeTest extends TestCase {
 
 		$this->assertSame([], $handler->getMultipleObjectNames([]));
 	}
+
+	/**
+	 * THE CALLER CONTRACT. Scoping makes the answer a PARTIAL map: requested
+	 * identifiers the caller may not see are simply absent, never present with a
+	 * null/empty value and never an exception.
+	 *
+	 * That is the only behaviour change the six internal callers can observe, and
+	 * every one of them already handles an absent key:
+	 *
+	 * - Controller\ObjectsController::collectNamesForResponse() returns the map
+	 *   straight to the client; an absent key renders as the raw UUID.
+	 *   (It only ever asks for UUIDs found inside an object the caller already
+	 *   read, so its identifiers are in scope by construction.)
+	 * - Service\ObjectService::collectNamesForResults() likewise returns the map.
+	 * - Service\ExportService::resolveUuidNameMap() array_merge()s it onto a
+	 *   pre-seeded map.
+	 * - Service\Object\SaveObject\MetadataHydrationHandler tests
+	 *   `empty($names[$uuid]) === false` and falls back to the UUID.
+	 * - Service\Object\PerformanceHandler assigns the map to `relatedNames`.
+	 * - Db\MagicMapper\MagicFacetHandler tests `isset($names[$value])` at both of
+	 *   its single-value sites and falls back to a shortened UUID, and its batch
+	 *   site foreach()es over exactly what came back.
+	 *
+	 * @return void
+	 */
+	public function testPartialMapContractHoldsForCallersThatIndexTheResult(): void {
+		$this->organisationMapper->method('findMultipleByUuid')->willReturn([]);
+		$this->objectMapper->method('findMultiple')->willReturn([
+			$this->createObject('99999999-9999-9999-9999-999999999999', 'Visible Beta', self::ORG_B),
+			$this->createObject('aaaa1111-aaaa-1111-aaaa-111111111111', 'Hidden Alpha', self::ORG_A),
+		]);
+
+		$handler = $this->buildHandler();
+
+		$names = $handler->getMultipleObjectNames([
+			'99999999-9999-9999-9999-999999999999',
+			'aaaa1111-aaaa-1111-aaaa-111111111111',
+			'bbbb2222-bbbb-2222-bbbb-222222222222',
+		]);
+
+		// Present for the in-scope id...
+		$this->assertSame('Visible Beta', $names['99999999-9999-9999-9999-999999999999'] ?? null);
+		// ...and ABSENT — not null, not '' — for the out-of-scope and unknown ones.
+		$this->assertArrayNotHasKey('aaaa1111-aaaa-1111-aaaa-111111111111', $names);
+		$this->assertArrayNotHasKey('bbbb2222-bbbb-2222-bbbb-222222222222', $names);
+
+		// Every value in the map is a non-empty string, which is what the callers
+		// that index it (MetadataHydrationHandler, MagicFacetHandler) rely on.
+		foreach ($names as $uuid => $name) {
+			$this->assertIsString($name, 'Name for ' . $uuid . ' must be a string.');
+			$this->assertNotSame('', $name);
+		}
+	}
 }

--- a/tests/Unit/Service/Object/CacheHandlerTest.php
+++ b/tests/Unit/Service/Object/CacheHandlerTest.php
@@ -31,6 +31,7 @@ use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Service\Object\CacheHandler;
 use OCP\AppFramework\IAppContainer;
 use OCP\DB\IResult;
+use OCP\IAppConfig;
 use OCP\ICacheFactory;
 use OCP\IDBConnection;
 use OCP\IMemcache;
@@ -71,6 +72,19 @@ class CacheHandlerTest extends TestCase {
 	private IUserSession $userSession;
 
 	/**
+	 * App config pinned to multitenancy-OFF for this class.
+	 *
+	 * Every test below predates SEC-CTRL-2 step 2 and asserts the resolver's
+	 * behaviour with no tenant boundary in force, which is a real supported
+	 * configuration (`multitenancy.enabled = false`). Declaring it explicitly is
+	 * the honest way to keep them meaningful: the tenant-scoped behaviour has its
+	 * own controls in CacheHandlerTenantScopeTest, so nothing is left unmeasured.
+	 *
+	 * @var IAppConfig&MockObject
+	 */
+	private IAppConfig $appConfig;
+
+	/**
 	 * Set up test fixtures.
 	 *
 	 * @return void
@@ -85,6 +99,15 @@ class CacheHandlerTest extends TestCase {
 		$this->queryCache = $this->createMock(IMemcache::class);
 		$this->nameDistributedCache = $this->createMock(IMemcache::class);
 		$this->userSession = $this->createMock(IUserSession::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->appConfig->method('getValueString')
+			->willReturnCallback(function (string $app, string $key, string $default = '') {
+				if ($app === 'openregister' && $key === 'multitenancy') {
+					return '{"enabled":false}';
+				}
+
+				return $default;
+			});
 
 		$this->cacheFactory->method('createDistributed')
 			->willReturnCallback(function (string $prefix) {
@@ -111,7 +134,12 @@ class CacheHandlerTest extends TestCase {
 			$this->logger,
 			$this->cacheFactory,
 			$this->userSession,
-			$container
+			$container,
+			null,
+			null,
+			null,
+			null,
+			$this->appConfig
 		);
 	}
 
@@ -224,7 +252,9 @@ class CacheHandlerTest extends TestCase {
 			$container,
 			$registerMapper,
 			$schemaMapper,
-			$db
+			$db,
+			null,
+			$this->appConfig
 		);
 	}
 
@@ -1039,11 +1069,12 @@ class CacheHandlerTest extends TestCase {
 	 * @return void
 	 */
 	public function testGetSingleObjectNameFromDistributedCache(): void {
-		// Not in in-memory cache, but in distributed cache.
+		// Not in in-memory cache, but in distributed cache. SEC-CTRL-2 step 2: the
+		// stored value is a tenancy-bearing envelope, not a bare string.
 		$this->nameDistributedCache->method('get')
 			->willReturnCallback(function (string $key) {
 				if ($key === 'name_uuid-dist') {
-					return 'Distributed Name';
+					return ['n' => 'Distributed Name', 'o' => null];
 				}
 				return null;
 			});
@@ -1156,9 +1187,11 @@ class CacheHandlerTest extends TestCase {
 	 */
 	public function testSetObjectNameEnforcesMaxTtl(): void {
 		// TTL greater than MAX_CACHE_TTL should be clamped.
+		// SEC-CTRL-2 step 2: the KEY is unchanged; the VALUE is a tenancy-bearing
+		// envelope so a shared distributed cache cannot disclose across tenants.
 		$this->nameDistributedCache->expects($this->once())
 			->method('set')
-			->with('name_uuid-1', 'Name', 86400);  // MAX_CACHE_TTL = 86400
+			->with('name_uuid-1', ['n' => 'Name', 'o' => null], 86400);  // MAX_CACHE_TTL = 86400
 
 		$this->handler->setObjectName('uuid-1', 'Name', 999999);
 	}
@@ -1190,7 +1223,7 @@ class CacheHandlerTest extends TestCase {
 	public function testSetObjectNameWithTtlWithinLimit(): void {
 		$this->nameDistributedCache->expects($this->once())
 			->method('set')
-			->with('name_uuid-1', 'Name', 3600);
+			->with('name_uuid-1', ['n' => 'Name', 'o' => null], 3600);
 
 		$this->handler->setObjectName('uuid-1', 'Name', 3600);
 	}
@@ -1277,7 +1310,8 @@ class CacheHandlerTest extends TestCase {
 		$this->nameDistributedCache->method('get')
 			->willReturnCallback(function (string $key) {
 				if ($key === 'name_uuid-2') {
-					return 'Distributed Name';
+					// SEC-CTRL-2 step 2: tenancy-bearing envelope.
+					return ['n' => 'Distributed Name', 'o' => null];
 				}
 				return null;
 			});
@@ -2708,8 +2742,11 @@ class CacheHandlerTest extends TestCase {
 		$this->assertIsArray($result);
 		// At minimum, the method executed without error.
 		// If DB mocking worked correctly, the name is in the result.
+		// SEC-CTRL-2 step 2: each entry is name + owning organisation, because the
+		// _organisation column is the tenancy oracle for object-backed names.
 		if (isset($result['batch-uuid-1'])) {
-			$this->assertSame('Batch Name 1', $result['batch-uuid-1']);
+			$this->assertSame('Batch Name 1', $result['batch-uuid-1']['name']);
+			$this->assertArrayHasKey('organisation', $result['batch-uuid-1']);
 		}
 	}
 
@@ -2824,7 +2861,7 @@ class CacheHandlerTest extends TestCase {
 		// After 2 failures + 1 success, should have found the name.
 		$this->assertIsArray($result);
 		if (isset($result['fallback-uuid-1'])) {
-			$this->assertSame('Fallback Name', $result['fallback-uuid-1']);
+			$this->assertSame('Fallback Name', $result['fallback-uuid-1']['name']);
 		}
 	}
 
@@ -2869,7 +2906,7 @@ class CacheHandlerTest extends TestCase {
 		$this->assertIsArray($result);
 		// If mock worked correctly, name should be resolved.
 		if (isset($result['direct-uuid-1'])) {
-			$this->assertSame('Direct Name', $result['direct-uuid-1']);
+			$this->assertSame('Direct Name', $result['direct-uuid-1']['name']);
 		}
 	}
 


### PR DESCRIPTION
## What this closes

`development`'s last failing gate: **`gate-7 no-admin-idor — 2 method(s)`** (`NamesController::index` and `::create`). The finding is **true**, not a false positive, and it is closed by fixing the defect — no `@no-admin-idor-exempt` tag, and `lib/Controller/NamesController.php` is **byte-identical to `development` apart from two stale `TODO(SEC-CTRL-2)` comments**. The fix lives in the collaborator, which is where the leak was.

This is **SEC-CTRL-2 step 2**, written down in the repo's own `CODE-REVIEW-IMPROVEMENT-PLAN.md`. Step 1 (#2523) removed `show`/`stats`/`warmup` and dropped `@PublicPage`; it left an **authenticated cross-tenant name disclosure** open.

## The defect, measured

`CacheHandler::getMultipleObjectNames()` / `getAllObjectNames()` resolved names through three paths with **no tenant dimension at all** —

* `OrganisationMapper::findMultipleByUuid()` / `findAllWithUserCount()` (every organisation),
* `MagicMapper::findMultiple()` → `findMultipleAcrossAllMagicTables()`, a raw `UNION ALL` over every magic table with no organisation predicate and no flag to switch on,
* `loadNamesFromMagicTables()` / `queryTableForNames()`, which selected `_uuid, _name` and never looked at `_organisation`,

— and then cached the answer in a **process-wide map** that any later caller could read, plus a **distributed cache shared by every tenant on the instance**.

## What this does

1. **A per-object authorisation predicate.** `hasOrganisationAccess()` mirrors `Db\MultiTenancyTrait::applyOrganisationFilter()` exactly: multitenancy switched off, or an admin under an enabled (non-SaaS) override, is unrestricted; otherwise the caller sees the **active organisation plus its parents**; no active organisation means no names (the trait's `1 = 0` arm). **An entity whose owning organisation cannot be established is refused** — absence of tenancy is not permission to disclose.

2. **The magic-table queries now select `_organisation`.** That column is the tenancy oracle for every object-backed name, because — measured while writing this — **`MagicMapper::rowToObjectEntity()` never populates `organisation` on the entities it builds**, so filtering on `$object->getOrganisation()` alone would have filtered on `null` for every row read out of a magic table. Left alone deliberately: populating it would switch on `PermissionHandler::filterUuidsForPermissions()`'s currently-dead organisation branch, which is its own change. Recorded in the plan.

3. **The cache KEY is deliberately unchanged; the tenancy rides in the VALUE.** In memory as a parallel `nameOrganisations` map, in the distributed cache as a `{n, o}` envelope under the same `name_<identifier>` key.

   The dispatch's suggested mechanism was to change the key. This is better and the reason is the failure mode the previous attempt hit: prefixing the key forces **every** invalidation site to learn the prefix, and it **orphans an entry under a stale prefix whenever an object moves organisation** — a stale name servable to the old tenant forever. Keeping the key means all six invalidation sites keep matching untouched:

   | # | site | still correct because |
   |---|---|---|
   | 1 | `invalidateForObjectChange()` create/update | rewrites the same key, now with `organisation:` |
   | 2 | `invalidateForObjectChange()` delete | unsets the same keys, plus the new organisation map |
   | 3 | `clearObjectNameFromCache()` (BUG-OBJ-7) | same keys, plus the organisation map |
   | 4 | `clearAllCaches()` | clears everything, plus the organisation map |
   | 5 | `clearNameCache()` | clears everything, plus the organisation map |
   | 6 | `persistNameCacheToDistributed()` | same keys, now writing envelopes |

   A value written **before** this change is a bare string with no tenancy and is read as a **MISS**, not served unscoped — the fail-closed direction across a deploy.

4. **The scope is memoised for one call and dropped at the top of every public reader**, so a cron worker or any long-lived process serving several callers cannot carry one caller's scope into the next.

Also fixed on the way, both reachable now: `batchLoadNamesFromMagicTables()` fataled on a null `registerMapper`, and `getSingleObjectName()` passed a null name into a non-nullable parameter for an entity with neither name nor uuid.

## RED-then-green control

`tests/Unit/Service/Object/CacheHandlerTenantScopeTest.php`, committed **first**, measured against the pre-fix implementation:

```
Tests: 8, Assertions: 10, Failures: 6      <- before the fix
Tests: 9, Assertions: 15, Failures: 0      <- after
```

The six that were RED: the object-mapper path, the organisation path, **a cache warmed as tenant A served to tenant B**, `getAllObjectNames()` handing over the whole warm cache, the magic-table warmup ignoring `_organisation`, and a name with unresolvable tenancy being served anyway. The two that were GREEN throughout are functional controls (in-scope names must still resolve; an empty request answers empty) — they are what a fix that simply returned nothing would fail.

## Gate-7, before and after

Gate package **`ConductionNL/.github@742f370e`** (today's `main`), the gate's own helper, **139 controller files scanned on both sides**:

```
origin/development @ 1749c1d3b  -> 2 findings   NamesController.php:115 index
                                                NamesController.php:264 create
this branch        @ 969d97c33  -> 0 findings
```

The base count reproduces CI's `gate-7 no-admin-idor — 2 method(s)` exactly, which is the calibration. **Positive control on the same package and tree**: an unguarded `#[NoAdminRequired] show(string $id)` planted in `lib/Controller/` is reported (`1 finding`), removed again → `0`. (The first probe I planted read as clean — it called a `*Mapper`, which Pattern 2 exempts inside this repo. Worth knowing.)

The clearing mechanism is the gate's Pattern 4: `CacheHandler` is a typed collaborator of `NamesController`, and its name readers now call an authorisation predicate the gate reads out of `CacheHandler`'s own source. The controller itself is unchanged.

## Regression evidence

Full unit suite, same container, same command, base vs head:

```
origin/development @ 1749c1d3b   Tests: 16657, Errors: 8, Failures: 0
this branch        @ 969d97c33   Tests: 16665, Errors: 8, Failures: 0
```

The 8 errors are the **identical** pre-existing ones in `IconControllerTest` (3), `GraphQLControllerExplorerTest` (3) and `WebPushControllerTest` (2) — local-environment, present on the base. `+8` tests are the new controls. `phpcs` and `phpmd` are clean on all three changed `lib/` files. `phpstan`/`psalm` cannot run in a worktree here (the vendored quality-config resolves a path that does not exist locally) — CI is the measurement for those.

The pre-existing `CacheHandler` suites are now pinned to `multitenancy.enabled = false` — the configuration they were actually written against — and say so in a docblock. Nothing is left unmeasured: the scoped behaviour has its own nine controls.

## The six internal callers

Every one consumes `array<uuid, string>` and already tolerates an absent key; the only change they can observe is that the map is now **partial**. Pinned by `testPartialMapContractHoldsForCallersThatIndexTheResult`:

| caller | handles absence by |
|---|---|
| `Controller\ObjectsController::collectNamesForResponse` | returns the map; an absent key renders as the raw UUID. Only ever asks for UUIDs inside an object the caller already read, so its ids are in scope by construction |
| `Service\ObjectService::collectNamesForResults` | returns the map |
| `Service\ExportService::resolveUuidNameMap` | `array_merge` onto a pre-seeded map |
| `Service\Object\SaveObject\MetadataHydrationHandler` | `empty($names[$uuid]) === false`, else falls back to the UUID |
| `Service\Object\PerformanceHandler` | assigns the map to `relatedNames` |
| `Db\MagicMapper\MagicFacetHandler` | `isset($names[$value])` at both single-value sites (falls back to a shortened UUID); its batch site `foreach`es over exactly what came back |

Plus the three external `setObjectName()` writers in `SaveObject.php`, all now passing `organisation:`.

## What this does NOT close

* **RBAC is not evaluated.** Only the organisation dimension is. A caller in the right organisation still resolves a name for an object whose register/schema `authorization.read` would refuse them. Closing that needs a `Schema` the name cache does not hold — `PermissionHandler::hasPermission()` requires one — and is a separate change.
* **`getSingleObjectName()`'s database lookup is still `_rbac: false, _multitenancy: false`.** It is the ANSWER that is gated, not the query. The method has no caller in `lib/`; its docblock now says exactly this rather than the old "deliberately unscoped".
* **`MagicMapper::rowToObjectEntity()` still drops `_organisation`.** Recorded, not fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
