### PR TITLE
fix(contract): publish patchObject() and correct updateObject()'s replace-not-merge docblock

### DIFF
--- a/lib/Contract/ObjectServiceInterface.php
+++ b/lib/Contract/ObjectServiceInterface.php
@@ -516,6 +516,19 @@ interface ObjectServiceInterface {
 	 * @return ObjectEntityInterface The patched object.
 	 *
 	 * @see self::updateObject() for the replacing counterpart.
+	 *
+	 * @contract-shift announced — openregister#2543 sweeps every fleet app for
+	 * `implements ObjectServiceInterface` and names the THREE test doubles that
+	 * must declare this method or fatal at class load: pipelinq
+	 * tests/Stubs/Service/ObjectService.php (with its paired
+	 * tests/Stubs/Contract/ObjectServiceInterface.php), and shillinq
+	 * tests/Unit/Service/Support/{InMemoryObjectServiceStub,DuckObjectServiceAdapter}.php.
+	 * docudesk tests/stubs/OpenRegisterStubs.php wants the same for parity but
+	 * implements nothing, so it cannot fatal. All 239 createMock() sites are
+	 * unaffected — a generated mock tracks whatever the interface declares. The
+	 * break lands on a `conduction/hydra-gates` RELEASE carrying this contract,
+	 * not on this merge, because leaf apps read it from vendor/: land those
+	 * three doubles before the release, or pin.
 	 */
 	public function patchObject(
 		string $objectId,

--- a/lib/Contract/ObjectServiceInterface.php
+++ b/lib/Contract/ObjectServiceInterface.php
@@ -55,7 +55,12 @@ use OCP\IUser;
  *
  *     829 consumer classes call 28 distinct methods.
  *
- * This interface declares 25 of them, covering 819 of the 829 classes (98.8%).
+ * This interface declared 25 of them, covering 819 of the 829 classes (98.8%).
+ * `patchObject()` was added afterwards and is the 26th. It is NOT part of that
+ * measurement — no consumer called it, because it was not reachable through
+ * this contract. It is published because `updateObject()` REPLACES, so a
+ * consumer holding a partial payload had no correct method to call and either
+ * hand-rolled read-merge-write or silently erased the fields it omitted.
  * The four it omits are omitted for a reason, and the ten classes they hold
  * back are listed rather than left to be discovered:
  *
@@ -127,7 +132,7 @@ use OCP\IUser;
  *
  * @SuppressWarnings(PHPMD.BooleanArgumentFlag)   RBAC and multitenancy flags — see above.
  * @SuppressWarnings(PHPMD.ExcessiveParameterList) Mirrors ObjectService::saveObject().
- * @SuppressWarnings(PHPMD.ExcessivePublicCount)  25 methods, measured — see Scope above.
+ * @SuppressWarnings(PHPMD.ExcessivePublicCount)  26 methods, measured — see Scope above.
  */
 interface ObjectServiceInterface {
 
@@ -447,20 +452,79 @@ interface ObjectServiceInterface {
 	): array;
 
 	/**
-	 * Apply a partial update to an existing object.
+	 * REPLACE an existing object's data wholesale. This does NOT merge.
+	 *
+	 * `$data` becomes the object's data in full. It is PUT semantics: a property
+	 * that is stored but absent from `$data` is NOT left alone — it is written
+	 * away. Sending `['status' => 'withdrawn']` for an object that also holds a
+	 * title, a summary and three dates stores an object with a status and
+	 * nothing else, and returns successfully while doing it.
+	 *
+	 * This docblock previously read "apply a partial update", which is the
+	 * opposite of what the method does. A caller who migrated a one-key update
+	 * onto that description silently erased every field it did not send. If you
+	 * want partial-update semantics, call `patchObject()` — it reads, merges and
+	 * saves, and it is on this contract for exactly that reason.
+	 *
+	 * Replace semantics are deliberate and unchanged: existing callers pass a
+	 * complete object and depend on an omitted property being cleared.
 	 *
 	 * @param string $objectId      The object UUID.
-	 * @param array  $data          The fields to change.
+	 * @param array  $data          The object's COMPLETE new data. Anything omitted is dropped.
 	 * @param bool   $_rbac         Apply register RBAC.
 	 * @param bool   $_multitenancy Apply organisation scoping.
 	 *
-	 * @return ObjectEntityInterface The updated object.
+	 * @return ObjectEntityInterface The replaced object.
+	 *
+	 * @see self::patchObject() for the merging counterpart.
 	 */
 	public function updateObject(
 		string $objectId,
 		array $data,
 		bool $_rbac=true,
 		bool $_multitenancy=true
+	): ObjectEntityInterface;
+
+	/**
+	 * MERGE a partial payload onto an existing object, leaving the rest intact.
+	 *
+	 * This is the PATCH-semantic counterpart to `updateObject()`, and the one a
+	 * caller holding an incomplete payload wants. The read-merge-save cycle
+	 * lives here, once, rather than being reimplemented by every consumer.
+	 *
+	 * MERGE RULES (RFC 7386 shaped):
+	 *  - a key present with a non-null value overwrites the stored value;
+	 *  - a key ABSENT from the payload leaves the stored value untouched;
+	 *  - a key present with an explicit `null` clears the stored value, so
+	 *    "unset this" stays expressible and distinct from "not mentioned";
+	 *  - two associative arrays merge recursively on the same three rules;
+	 *  - lists (JSON arrays) are replaced wholesale, never element-merged.
+	 *
+	 * The merged result goes through the same save path as `saveObject()`, so
+	 * schema validation, the audit trail and event dispatch all still apply.
+	 *
+	 * @param string          $objectId      Object id, UUID or slug.
+	 * @param array           $data          The partial data to merge. Omitted keys are PRESERVED.
+	 * @param string|int|null $register      Register id, UUID or slug.
+	 * @param string|int|null $schema        Schema id, UUID or slug.
+	 * @param bool            $_rbac         Apply register RBAC.
+	 * @param bool            $_multitenancy Apply organisation scoping.
+	 * @param ?IUser          $currentUser   Explicit acting user; null uses the session.
+	 *                                       Non-HTTP callers (cron, flow runs, imports)
+	 *                                       should pass one to avoid a default-deny.
+	 *
+	 * @return ObjectEntityInterface The patched object.
+	 *
+	 * @see self::updateObject() for the replacing counterpart.
+	 */
+	public function patchObject(
+		string $objectId,
+		array $data,
+		string|int|null $register=null,
+		string|int|null $schema=null,
+		bool $_rbac=true,
+		bool $_multitenancy=true,
+		?IUser $currentUser=null
 	): ObjectEntityInterface;
 
 	/**

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -4400,16 +4400,33 @@ class ObjectService implements ObjectServiceInterface
     }//end createObject()
 
     /**
-     * Update existing object (full update)
+     * REPLACE an existing object's data wholesale. This does NOT merge.
+     *
+     * PUT semantics, inherited from `saveObject()`: `$data` becomes the object's
+     * data in full, so a stored property absent from `$data` is written away
+     * rather than left alone. There is no read of the existing object here — the
+     * commented-out `find()` below is the whole history of that idea — so a
+     * one-key payload stores a one-key object and reports success.
+     *
+     * Callers holding a PARTIAL payload want `patchObject()`, which reads,
+     * merges and then saves. Both are published on `ObjectServiceInterface`;
+     * the contract's docblock for this method used to say "apply a partial
+     * update", which is the opposite of the behaviour and is what sent at least
+     * one consuming app down the erasing path.
+     *
+     * Replace semantics are deliberate and must not change: existing callers
+     * pass a complete object and rely on an omitted property being cleared.
      *
      * @param string $objectId      Object ID or UUID
-     * @param array  $data          New object data
+     * @param array  $data          The object's COMPLETE new data. Anything omitted is dropped.
      * @param bool   $_rbac         Apply RBAC checks
      * @param bool   $_multitenancy Apply multitenancy filtering
      *
-     * @return ObjectEntity Updated object entity
+     * @return ObjectEntity Replaced object entity
      *
      * @throws \Exception If update fails
+     *
+     * @see self::patchObject() for the merging counterpart.
      *
      * @spec exclude Facade delegating to saveObject() with id; update behavior owned by object-interactions / object-lifecycle.
      */

--- a/tests/Unit/Service/ObjectServiceUpdateVersusPatchTest.php
+++ b/tests/Unit/Service/ObjectServiceUpdateVersusPatchTest.php
@@ -1,0 +1,444 @@
+<?php
+
+/**
+ * `updateObject()` REPLACES; `patchObject()` MERGES. Pinned side by side.
+ *
+ * The published contract used to document `updateObject()` as "apply a partial
+ * update" while it was implemented as `$data['id'] = $id; saveObject($data)` —
+ * no read, no merge. Meanwhile the genuinely merging `patchObject()` was not on
+ * `ObjectServiceInterface` at all, so a consumer that migrated a one-key update
+ * onto the contract silently erased every field it did not send AND reported
+ * success. procest's `withdraw()` is the payload modelled below; the obvious
+ * migration would have wiped that publication's title, summary, category and
+ * case reference.
+ *
+ * These tests exist because nothing else can tell the two apart. Both methods
+ * return an object and neither throws, so a functional check passes either way —
+ * the erasure is only visible in the payload each hands to the save pipeline.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service;
+
+use OCA\OpenRegister\Contract\ObjectServiceInterface;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Db\ViewMapper;
+use OCA\OpenRegister\Service\DateTimeNormalizer;
+use OCA\OpenRegister\Service\FileService;
+use OCA\OpenRegister\Service\Object\AuditHandler;
+use OCA\OpenRegister\Service\Object\CacheHandler;
+use OCA\OpenRegister\Service\Object\CascadingHandler;
+use OCA\OpenRegister\Service\Object\DataManipulationHandler;
+use OCA\OpenRegister\Service\Object\DeleteObject;
+use OCA\OpenRegister\Service\Object\FacetHandler;
+use OCA\OpenRegister\Service\Object\GetObject;
+use OCA\OpenRegister\Service\Object\LockHandler;
+use OCA\OpenRegister\Service\Object\MergeHandler;
+use OCA\OpenRegister\Service\Object\MetadataHandler;
+use OCA\OpenRegister\Service\Object\MigrationHandler;
+use OCA\OpenRegister\Service\Object\PerformanceOptimizationHandler;
+use OCA\OpenRegister\Service\Object\PermissionHandler;
+use OCA\OpenRegister\Service\Object\QueryHandler;
+use OCA\OpenRegister\Service\Object\RelationHandler;
+use OCA\OpenRegister\Service\Object\RenderObject;
+use OCA\OpenRegister\Service\Object\RevertHandler;
+use OCA\OpenRegister\Service\Object\SaveObject;
+use OCA\OpenRegister\Service\Object\SaveObjects;
+use OCA\OpenRegister\Service\Object\SearchQueryHandler;
+use OCA\OpenRegister\Service\Object\UtilityHandler;
+use OCA\OpenRegister\Service\Object\ValidateObject;
+use OCA\OpenRegister\Service\Object\ValidationHandler;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\ObjectSource\ObjectSourceRegistry;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCA\OpenRegister\Service\SearchTrailService;
+use OCA\OpenRegister\Service\SettingsService;
+use OCP\AppFramework\IAppContainer;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionClass;
+use ReflectionMethod;
+use Throwable;
+
+/**
+ * The replace/merge distinction, and the contract that publishes both.
+ */
+class ObjectServiceUpdateVersusPatchTest extends TestCase {
+
+	/**
+	 * The stored object. Every key except `status` is one the partial payload
+	 * below does NOT mention, so each is a field that replace semantics destroy.
+	 */
+	private const STORED = [
+		'title'         => 'Quarterly report Q2',
+		'summary'       => 'An overview of the second quarter.',
+		'category'      => 'finance',
+		'caseReference' => 'ZAAK-2026-0042',
+		'publishedAt'   => '2026-04-01',
+		'status'        => 'published',
+	];
+
+	/**
+	 * The one-key payload. This is the shape of procest's `withdraw()`.
+	 */
+	private const PARTIAL = ['status' => 'withdrawn'];
+
+	private ObjectService $service;
+
+	private ReflectionClass $reflection;
+
+	/** @var MockObject&MagicMapper */
+	private $objectMapper;
+
+	/** @var MockObject&CascadingHandler */
+	private $cascadingHandler;
+
+	private Register $register;
+
+	private Schema $schema;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->objectMapper     = $this->createMock(MagicMapper::class);
+		$this->cascadingHandler = $this->createMock(CascadingHandler::class);
+
+		$this->register = new Register();
+		$this->register->setId(1);
+
+		$this->schema = new Schema();
+		$this->schema->setId(2);
+
+		$this->service = new ObjectService(
+			$this->createMock(DataManipulationHandler::class),
+			$this->createMock(DeleteObject::class),
+			$this->createMock(GetObject::class),
+			$this->createMock(PermissionHandler::class),
+			$this->createMock(RenderObject::class),
+			$this->createMock(SaveObject::class),
+			$this->createMock(SaveObjects::class),
+			$this->createMock(SearchQueryHandler::class),
+			$this->createMock(ValidateObject::class),
+			$this->createMock(LockHandler::class),
+			$this->createMock(AuditHandler::class),
+			$this->createMock(RelationHandler::class),
+			$this->createMock(MergeHandler::class),
+			$this->createMock(FacetHandler::class),
+			$this->createMock(MetadataHandler::class),
+			$this->createMock(PerformanceOptimizationHandler::class),
+			$this->createMock(QueryHandler::class),
+			$this->createMock(RevertHandler::class),
+			$this->createMock(UtilityHandler::class),
+			$this->createMock(ValidationHandler::class),
+			$this->cascadingHandler,
+			$this->createMock(MigrationHandler::class),
+			$this->createMock(RegisterMapper::class),
+			$this->createMock(SchemaMapper::class),
+			$this->createMock(ViewMapper::class),
+			$this->objectMapper,
+			$this->createMock(FileService::class),
+			$this->createMock(IUserSession::class),
+			$this->createMock(SearchTrailService::class),
+			$this->createMock(IGroupManager::class),
+			$this->createMock(IUserManager::class),
+			$this->createMock(OrganisationService::class),
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(CacheHandler::class),
+			$this->createMock(SettingsService::class),
+			$this->createMock(DateTimeNormalizer::class),
+			$this->createMock(IAppContainer::class),
+			$this->createMock(ObjectSourceRegistry::class)
+		);
+
+		$this->reflection = new ReflectionClass(ObjectService::class);
+
+		$stored = new ObjectEntity();
+		$stored->setUuid('u-1');
+		$stored->setObject(self::STORED);
+		$this->objectMapper->method('find')->willReturn($stored);
+
+		$this->setProperty('currentRegister', $this->register);
+		$this->setProperty('currentSchema', $this->schema);
+
+	}//end setUp()
+
+	private function setProperty(string $name, mixed $value): void {
+		$property = $this->reflection->getProperty($name);
+		$property->setAccessible(true);
+		$property->setValue($this->service, $value);
+
+	}//end setProperty()
+
+	/**
+	 * Capture the payload that reaches the save pipeline.
+	 *
+	 * `handlePreValidationCascading()` is inside `saveObject()`, which is where
+	 * BOTH methods converge — so it observes the one thing that differs between
+	 * them: what each decided to save. This reads the OBSERVED EFFECT rather
+	 * than a mock's recorded argument list, which matters because a PHPUnit
+	 * mock cannot see named arguments and both call sites use them.
+	 *
+	 * @param callable $call The service call to run.
+	 *
+	 * @return array<string, mixed> The payload handed to the save.
+	 */
+	private function payloadReachingTheSave(callable $call): array {
+		$seen = null;
+		$this->cascadingHandler->method('handlePreValidationCascading')->willReturnCallback(
+			static function (array $object, ?Schema $schema = null, ?string $uuid = null) use (&$seen): array {
+				$seen = $object;
+
+				return [$object, $uuid];
+			}
+		);
+
+		try {
+			$call();
+		} catch (Throwable $e) {
+			// Expected — the rest of the save pipeline is mocked out. The
+			// payload has already been captured by the time anything downstream
+			// complains, and the payload is the entire subject here.
+		}
+
+		$this->assertNotNull($seen, 'the payload never reached the save pipeline — the observation point is wrong, not the behaviour');
+
+		return $seen;
+
+	}//end payloadReachingTheSave()
+
+	// ── The distinction ─────────────────────────────────────────────────
+
+	/**
+	 * `updateObject()` drops every field the partial payload omitted.
+	 *
+	 * This is the defect's blast radius, asserted rather than described.
+	 *
+	 * @return void
+	 */
+	public function testUpdateObjectDropsTheFieldsThePayloadDidNotSend(): void {
+		$saved = $this->payloadReachingTheSave(
+			fn () => $this->service->updateObject(objectId: 'u-1', data: self::PARTIAL)
+		);
+
+		$this->assertSame('withdrawn', $saved['status'], 'the one field that WAS sent is applied');
+
+		foreach (['title', 'summary', 'category', 'caseReference', 'publishedAt'] as $erased) {
+			$this->assertArrayNotHasKey(
+				$erased,
+				$saved,
+				"updateObject() REPLACES: '{$erased}' was stored, was not sent, and must not survive. "
+				. 'If this key is present, updateObject() has started merging — which is a behaviour '
+				. 'change for every caller that passes a complete object and relies on omission clearing.'
+			);
+		}
+
+	}//end testUpdateObjectDropsTheFieldsThePayloadDidNotSend()
+
+	/**
+	 * `patchObject()` preserves every field the same partial payload omitted.
+	 *
+	 * @return void
+	 */
+	public function testPatchObjectPreservesTheFieldsThePayloadDidNotSend(): void {
+		$saved = $this->payloadReachingTheSave(
+			fn () => $this->service->patchObject(objectId: 'u-1', data: self::PARTIAL)
+		);
+
+		$this->assertSame('withdrawn', $saved['status'], 'the field that WAS sent is applied');
+
+		$this->assertSame('Quarterly report Q2', $saved['title'], 'an unmentioned field survives a patch');
+		$this->assertSame('An overview of the second quarter.', $saved['summary']);
+		$this->assertSame('finance', $saved['category']);
+		$this->assertSame('ZAAK-2026-0042', $saved['caseReference']);
+		$this->assertSame('2026-04-01', $saved['publishedAt']);
+
+	}//end testPatchObjectPreservesTheFieldsThePayloadDidNotSend()
+
+	/**
+	 * The two methods disagree on the SAME payload, and that is the point.
+	 *
+	 * Asserting the difference directly means neither half can be quietly
+	 * changed into the other without this failing.
+	 *
+	 * @return void
+	 */
+	public function testTheTwoMethodsDisagreeOnTheIdenticalPayload(): void {
+		$replaced = $this->payloadReachingTheSave(
+			fn () => $this->service->updateObject(objectId: 'u-1', data: self::PARTIAL)
+		);
+		$merged = $this->payloadReachingTheSave(
+			fn () => $this->service->patchObject(objectId: 'u-1', data: self::PARTIAL)
+		);
+
+		$this->assertNotEquals(
+			$replaced,
+			$merged,
+			'updateObject() and patchObject() must not agree on a partial payload — if they do, '
+			. 'one of them is wrong and the contract is lying about at least one of them'
+		);
+
+		$lost = array_diff(array_keys(self::STORED), array_keys($replaced));
+		sort($lost);
+		$this->assertSame(
+			['caseReference', 'category', 'publishedAt', 'summary', 'title'],
+			$lost,
+			'five stored fields are lost by the replacing path'
+		);
+
+		$survived = array_intersect(array_keys(self::STORED), array_keys($merged));
+		sort($survived);
+		$this->assertSame(
+			['caseReference', 'category', 'publishedAt', 'status', 'summary', 'title'],
+			$survived,
+			'all six survive the merging path'
+		);
+
+	}//end testTheTwoMethodsDisagreeOnTheIdenticalPayload()
+
+	// ── The published contract ──────────────────────────────────────────
+
+	/**
+	 * `patchObject()` is reachable through the published contract.
+	 *
+	 * The merging path existing on the concrete class was never the problem —
+	 * it was that a consumer type-hinting the interface could not call it, and
+	 * so reached for `updateObject()` on the strength of its docblock.
+	 *
+	 * @return void
+	 */
+	public function testThePublishedContractDeclaresBothWritePaths(): void {
+		$contract = new ReflectionClass(ObjectServiceInterface::class);
+
+		$this->assertTrue($contract->hasMethod('updateObject'), 'the replacing path stays published');
+		$this->assertTrue(
+			$contract->hasMethod('patchObject'),
+			'the merging path must be reachable through the contract, or every consumer '
+			. 'reimplements read-merge-write or silently erases data'
+		);
+
+	}//end testThePublishedContractDeclaresBothWritePaths()
+
+	/**
+	 * The published signature mirrors the implementation, defaults included.
+	 *
+	 * Parameter NAMES are load-bearing: consumers call these by name, and a
+	 * renamed parameter is a silent break at the call site rather than at
+	 * class load. Defaults are equally part of the signature — a double that
+	 * omits `_rbac=true` tests the unscoped path while looking correct.
+	 *
+	 * @return void
+	 */
+	public function testThePublishedPatchSignatureMirrorsTheImplementation(): void {
+		$published      = new ReflectionMethod(ObjectServiceInterface::class, 'patchObject');
+		$implementation = new ReflectionMethod(ObjectService::class, 'patchObject');
+
+		$names = array_map(
+			static fn ($parameter) => $parameter->getName(),
+			$published->getParameters()
+		);
+		$this->assertSame(
+			['objectId', 'data', 'register', 'schema', '_rbac', '_multitenancy', 'currentUser'],
+			$names,
+			'the contract names the same parameters the implementation does'
+		);
+
+		$this->assertSame(
+			$names,
+			array_map(static fn ($parameter) => $parameter->getName(), $implementation->getParameters()),
+			'contract and implementation must not drift apart on parameter names'
+		);
+
+		$defaults = [];
+		foreach ($published->getParameters() as $parameter) {
+			if ($parameter->isDefaultValueAvailable() === true) {
+				$defaults[$parameter->getName()] = $parameter->getDefaultValue();
+			}
+		}
+
+		$this->assertSame(
+			[
+				'register'      => null,
+				'schema'        => null,
+				'_rbac'         => true,
+				'_multitenancy' => true,
+				'currentUser'   => null,
+			],
+			$defaults,
+			'RBAC and multitenancy default to ON — a contract that defaulted them off '
+			. 'would publish the unscoped path as the easy one'
+		);
+
+		$this->assertSame(
+			'?OCP\IUser',
+			(string) $published->getParameters()[6]->getType(),
+			'a sessionless caller can be attributed through the contract'
+		);
+
+	}//end testThePublishedPatchSignatureMirrorsTheImplementation()
+
+	/**
+	 * The contract no longer describes `updateObject()` as a partial update.
+	 *
+	 * The docblock IS the deliverable here. Three defects in this campaign
+	 * existed only because documentation asserted something the code did not
+	 * do, and the description is what a consuming developer actually reads
+	 * before choosing between two similarly named methods.
+	 *
+	 * @return void
+	 */
+	public function testTheContractDoesNotDescribeUpdateObjectAsAPartialUpdate(): void {
+		$doc = (new ReflectionMethod(ObjectServiceInterface::class, 'updateObject'))->getDocComment();
+
+		$this->assertIsString($doc, 'updateObject() must stay documented on the contract');
+
+		// The SUMMARY line — the first prose line of the block, and the only part
+		// an IDE tooltip or a docs generator shows next to the method name. The
+		// defect lived here: the body can explain the history at length, but the
+		// one line a chooser actually reads must not promise a merge.
+		$summary = '';
+		foreach (explode("\n", $doc) as $line) {
+			$line = trim(ltrim(trim($line), '/*'));
+			if ($line !== '') {
+				$summary = $line;
+				break;
+			}
+		}
+
+		$this->assertNotSame('', $summary, 'updateObject() must carry a summary line');
+
+		$this->assertDoesNotMatchRegularExpression(
+			'/partial update/i',
+			$summary,
+			"the summary line reads '{$summary}' — describing this method as a partial update "
+			. 'is what sent a consumer down the erasing path. updateObject() REPLACES.'
+		);
+
+		$this->assertMatchesRegularExpression(
+			'/REPLACE|does NOT merge/i',
+			$summary,
+			"the summary line reads '{$summary}' — it must say plainly that this method "
+			. 'replaces rather than merges'
+		);
+
+		$this->assertStringContainsString(
+			'patchObject',
+			$doc,
+			'a reader who wants a partial update must be pointed at the method that does one'
+		);
+
+	}//end testTheContractDoesNotDescribeUpdateObjectAsAPartialUpdate()
+}//end class


### PR DESCRIPTION
## The defect

`ObjectServiceInterface::updateObject()` is documented **"Apply a partial update to an existing object"** and implemented as:

```php
$data['id'] = $objectId;
return $this->saveObject(object: $data);
```

No read. No merge. `saveObject()` is PUT-semantic, so a stored property absent from the payload is **written away**.

Any app that migrated a one-key update onto the published contract on the strength of that sentence **silently erased every field it did not send, and reported success.** procest's `withdraw()` sends a one-key payload; the obvious migration would have wiped that publication's title, summary, dates, category, status and case reference. procest worked around it caller-side with read-merge-write and escalated rather than patching here.

Meanwhile the genuinely merging `patchObject()` — read, merge (RFC 7386 shaped), save — was **not on the contract at all**, so a consumer type-hinting the interface could not reach the one method that did what it wanted.

## The fix

Two changes. **Neither alters behaviour.**

**1. Publish `patchObject()`** so the merging path is reachable through the contract:

```php
public function patchObject(
    string $objectId,
    array $data,
    string|int|null $register=null,
    string|int|null $schema=null,
    bool $_rbac=true,
    bool $_multitenancy=true,
    ?IUser $currentUser=null
): ObjectEntityInterface;
```

Parameter names and defaults mirror the implementation exactly. `register`/`schema` are narrowed to `string|int|null` exactly as `saveObject()` and `find()` already are — the file's own "## Types" section is explicit that consumers express identifiers, not OpenRegister entities. The implementation's wider `Register|Schema|string|int|null` stays legal by **parameter contravariance**, verified with a compatibility probe before this shipped:

```
objectId  string           <required>     _rbac          bool        true
data      array            <required>     _multitenancy  bool        true
register  string|int|null  NULL           currentUser    ?OCP\IUser  NULL
schema    string|int|null  NULL
RETURN: ObjectEntityInterface
TOTAL METHODS: 26      CLASS LOADED AND SATISFIES CONTRACT
```

**2. Correct the docblock** on both the contract and the implementation to say plainly that `updateObject()` REPLACES, and to point a reader wanting a partial update at `patchObject()`.

### Why not "make updateObject() merge"

That would silently change behaviour for every existing caller relying on replace semantics — callers pass a complete object and rely on an omitted property being cleared. A fleet-wide audit would have to come first. **`updateObject()`'s body is untouched in this PR.**

### Why not "fix the docblock only"

Callers legitimately need a merge and should not each reimplement read-merge-write. This is the third defect in this campaign that existed only because documentation asserted something the code did not do, so the docblock is treated as a deliverable, not an afterthought — and it is asserted by a test.

## Tests — RED-then-green, both methods

`tests/Unit/Service/ObjectServiceUpdateVersusPatchTest.php`, 6 tests / 30 assertions. Nothing else can tell the two methods apart: both return an object, neither throws, so a functional check passes either way. The payload modelled is procest's `withdraw()`.

Observed at `handlePreValidationCascading()` inside `saveObject()`, where both methods converge — the **observed effect**, not a mock's recorded argument list, because a PHPUnit mock cannot see named arguments and both call sites use them.

Each control was shown RED, and **each reddens only its own method's test**:

| Control | Deliberately wrong implementation | Result |
|---|---|---|
| A | `updateObject()` made to merge | `testUpdateObjectDropsTheFieldsThePayloadDidNotSend` **RED** (+ the disagreement test) |
| B | `patchObject()` made to skip the merge | `testPatchObjectPreservesTheFieldsThePayloadDidNotSend` **RED** (+ the disagreement test) |
| C | `patchObject()` unpublished from the interface | both contract tests **RED** |
| D | docblock summary reverted to the old wording | `testTheContractDoesNotDescribeUpdateObjectAsAPartialUpdate` **RED** |

Full-suite control: on the base tree the three contract/docblock tests are RED (1 error + 2 failures) and go green with this diff, while the behavioural pair passes on both sides — correct, since neither method's behaviour changes.

## Measurements

- **Unit Tests suite: 16695 tests.** Errors **8 before, 8 after** — identical, all pre-existing (`GraphQLControllerExplorerTest` ×3, `IconControllerTest` ×3, `WebPushControllerTest` ×2; `getTime() on null` in the local OCP stub, absent in CI).
- **phpcs** (`lib` only, the configured scope): **20 errors in 13 files, pre-existing; neither changed file appears.**

## ⚠️ This PR CANNOT go green alone — gate-67 needs a paired change

`gate-67 openregister-contract-parity` requires `lib/Contract/*.php` to be **byte-identical** to the copy shipped in `hydra-gates/contracts/`. In CI it compares against the copy travelling with the runner, fetched from `.github@main`.

Measured locally with the gate's own checker:

```
base tree      -> checked 2 file(s)   exit 0   PASS
this branch    -> FAIL lib/Contract/ObjectServiceInterface.php: differs from
                  the copy shipped in hydra-gates/contracts/
                  checked 2 file(s)   exit 1
```

**`ConductionNL/.github` needs the identical file at `hydra-gates/contracts/ObjectServiceInterface.php`.** It is a byte-for-byte copy — no judgement involved. Only openregister owns `lib/Contract/`, so gate-67 SKIPs on every other app and the blast radius of the ordering gap is confined to this repo.

## ⚠️ Downstream: 3 test doubles will fatal once the contract ships

Adding a method to a published interface is a **class-load fatal** for an implementor that lacks it — the suite dies before test 1. Fleet sweep found **exactly 4** classes that `implements ObjectServiceInterface`; one is `ObjectService` itself (already compliant).

**Will fatal (3), all test doubles:**

1. `pipelinq/tests/Stubs/Service/ObjectService.php:61` — must change **together with** `pipelinq/tests/Stubs/Contract/ObjectServiceInterface.php`, pipelinq's own copy of the contract
2. `shillinq/tests/Unit/Service/Support/InMemoryObjectServiceStub.php:60`
3. `shillinq/tests/Unit/Service/Support/DuckObjectServiceAdapter.php:81`

Non-fatal but wants parity: `docudesk/tests/stubs/OpenRegisterStubs.php:2343` (inline interface copy, nothing implements it).

**Safe, no action:** all `createMock(ObjectServiceInterface::class)` sites (239 files — mocks are generated against whatever the interface currently declares) and every duck-typed stub that does not declare the interface (decidesk, openbuild, softwarecatalog, scholiq, hermiq, zaakafhandelapp, opencatalogi, openconnector, petstore). 16 apps never mention the symbol at all.

**Sequencing note:** the leaf-app fatal is triggered by a **`conduction/hydra-gates` package release** carrying the new contract, not by this merge — leaf apps consume the interface from `vendor/`. Landing the three stubs before that release avoids red CI on `development` in pipelinq and shillinq.

## Not merged

Opened for review per the campaign's merge policy. Do not merge before deciding the `.github` ordering.
