### PR TITLE
docs(openspec): flow-engine, messaging, BPMN interchange and i18n proposals

### DIFF
--- a/openspec/changes/calendar-leaf-inbound/.openspec.yaml
+++ b/openspec/changes/calendar-leaf-inbound/.openspec.yaml
@@ -1,0 +1,1 @@
+capability: integration-calendar

--- a/openspec/changes/calendar-leaf-inbound/design.md
+++ b/openspec/changes/calendar-leaf-inbound/design.md
@@ -1,0 +1,47 @@
+# Design: calendar-leaf-inbound
+
+## Context
+
+The leaf's outbound path is solid: `CalendarEventService` hand-assembles tagged VEVENTs into the per-user pinned calendar (`events_calendar_uri`) via `CalDavBackend`, `CalendarLinkService` mirrors linkage into `openregister_calendar_links` with cached display fields, and `getLinkedEvents` unions the link table with the legacy X-OR scan. The inbound path does not exist: no `OCA\DAV\Events` listener anywhere in `lib/`, so Calendar-side edits stale the cache silently; the only cache-repair mechanism (`BackfillCalendarLinksJob`) is a QueuedJob that is registered nowhere and gated off by default; both link write paths insert blindly (duplicates masked only by read-path dedupe); there is no event→objects lookup for any inbound handler to use; and nothing in the calendar path knows what a reminder is. Consumers are starting to need exactly these five (pipelinq `calendar-deepening` is the first).
+
+## Goals / Non-goals
+
+**Goals:** inbound freshness (listen, refresh, delete), reverse lookup, idempotent linking with a unique index, an actually-running backfill, VALARM authoring on create.
+
+**Non-goals:** recurrence, iMIP/attendee round-trip, generic `updateEvent` API, true VEVENT delete via the API, writable virtual calendars, multi-calendar write targets, VTIMEZONE. Each is real, none is needed by current consumers, and each would multiply this change's surface.
+
+## Decisions
+
+### D1 — Listeners over polling
+
+A TimedJob rescan would be simpler but permanently O(all calendars) and up to an interval stale. The DAV events fire in-process on every calendar object write and carry the calendar data, so the listener does string-level `X-OPENREGISTER-OBJECT` prefiltering before any VObject parse — near-zero cost for untagged events, immediate freshness for tagged ones. Listener exceptions are caught and logged: a link-cache refresh must never fail a user's calendar save.
+
+### D2 — Match by tag OR by link row
+
+Tagged events (`taggedWithXor=true`) are matched by their own properties; untagged events that were linked via the link-table path (`linkEvent`) are matched by `findByEventUid`. Both paths are needed — link-table-only links carry no marker inside the VEVENT, which is precisely why the reverse lookup (REQ-CAL-INB-002) is a prerequisite of the listeners, not a nice-to-have.
+
+### D3 — Idempotency at the service, integrity at the database
+
+The service check (`findByObjectAndEvent`-style pre-check returning the existing row) gives friendly semantics; the unique index guarantees them under concurrency (two listeners or a listener racing an API call). The migration dedupes first (keep oldest — its `linkedAt` is the true link time) so index creation cannot fail; the read path already deduplicates, so collapsing rows changes no observable read.
+
+### D4 — Backfill: register and default-on, keep the flag
+
+The job predates the listeners as a one-time Tier-2 migration and is already idempotent (`findByObjectAndEvent` pre-check per event). With listeners handling steady-state, the backfill's remaining role is catching up instances that accumulated tagged events while inbound did not exist — which is every instance, once. Registering it and defaulting the flag to enabled makes upgrade behaviour correct without operator action; the flag flips from "opt-in for a job you must also run by hand" to "kill switch", which is the honest shape for a repair job. QueuedJob stays appropriate: run once, not on an interval.
+
+### D5 — VALARM is authored, never delivered
+
+The leaf writes `ACTION:DISPLAY` + `TRIGGER:-PT{n}M` and stops. The DAV reminders service and every CalDAV client already own alarm delivery; duplicating dispatch in OpenRegister would double-notify. This deliberately splits reminders with consumers: the leaf provides calendar-native alarms; an app-level "nag the assignee in NC notifications" (pipelinq's `FollowUpReminderJob`) is app orchestration on top of leaf reads. One `reminderMinutesBefore` integer, `DISPLAY` only — `EMAIL` alarms and absolute triggers wait for demand.
+
+## Risks / Trade-offs
+
+- **DAV event payload variance across NC versions** — listeners read the calendar data defensively (guarded class references, tolerate absent keys); absence of the event classes degrades to today's behaviour.
+- **Backfill cost on large instances at upgrade** — per-user scan of the pinned calendar only (that is all `getEventsForObject('')` reaches); counts are logged; the kill switch remains for operators who want to schedule the window.
+- **Unique-index migration on a table with unknown duplicate volume** — dedupe runs in the same migration, keep-oldest is deterministic; read behaviour unchanged by construction.
+- **UID reuse across calendars** — the triple includes `calendarUri`; the reverse lookup accepts the optional uri scope for the ambiguous case.
+
+## Migration / Rollout
+
+- Migration (dedupe + unique index) ships first in the change; listeners and idempotent writes assume the index exists.
+- Listener registration and job registration are boot-time; disabling the app removes both cleanly.
+- Rollback: drop the listeners/registration and set `backfill_calendar_links=no`; the index can stay (it enforces a property that was always intended).
+- Consumer sequencing: pipelinq `calendar-deepening` declares `depends_on` on this change for its inbound scenarios; nothing here depends on any consumer.

--- a/openspec/changes/calendar-leaf-inbound/proposal.md
+++ b/openspec/changes/calendar-leaf-inbound/proposal.md
@@ -1,0 +1,26 @@
+# Proposal: calendar-leaf-inbound
+
+## Summary
+
+Close the inbound half of the calendar leaf. Today the leaf is write-and-forget: `CalendarEventService` creates X-OPENREGISTER-tagged VEVENTs and `CalendarLinkService` records rows in `openregister_calendar_links`, but nothing ever flows back. There are zero listeners on `OCA\DAV` calendar-object events, so an event moved, edited, or deleted in Nextcloud Calendar silently stales the cached `summary`/`dtstart`/`dtend`/`location` on its link row; `BackfillCalendarLinksJob` — the only mechanism that turns Calendar-side tagged events into link rows — is unregistered and disabled by default (`backfill_calendar_links` = `no`); repeated link calls duplicate rows because neither link path checks for an existing row; there is no reverse event→objects lookup for a listener to use; and the leaf has no reminder capability (no VALARM anywhere in the calendar path). Consumer apps (pipelinq `calendar-deepening`, and any leaf app rendering the calendar card) need all five.
+
+## Why
+
+Leaf-first (ADR-022) only holds if the leaf is complete enough that apps never route around it. Pipelinq's calendar-deepening change wants follow-up reminders and inbound event visibility; without this change it would either overclaim ("two-way sync") or be tempted to scan CalDAV itself — exactly what the leaf exists to prevent. The stale-cache defect is also a correctness bug in its own right: the link table presents times that the calendar no longer holds.
+
+## What Changes
+
+1. **Inbound listeners** — register `IEventListener`s for `OCA\DAV\Events\CalendarObjectCreatedEvent`, `CalendarObjectUpdatedEvent`, `CalendarObjectMovedEvent`, and `CalendarObjectDeletedEvent`. For VEVENTs carrying `X-OPENREGISTER-*` properties (or matching an existing link row by event UID): refresh the cached link fields on update/move, create the missing link row on create (idempotently), and delete the link row on deletion of the VEVENT.
+2. **Reverse lookup** — `CalendarLinkMapper::findByEventUid(string $eventUid, ?string $calendarUri = null)` plus a service surface `CalendarLinkService::getObjectsForEvent()`, required by the listeners and useful to consumers.
+3. **Idempotent linking** — `linkEvent` / `createAndLinkEvent` return the existing row instead of inserting a duplicate for the same `(objectUuid, eventUid, calendarUri)`; a migration adds the unique index after deduplicating existing rows (keep oldest, the read path already deduplicates so no visible change).
+4. **Backfill activation** — register `BackfillCalendarLinksJob` so it is schedulable, and flip the `backfill_calendar_links` default to enabled for the registered one-shot run on upgrade (the job is already idempotent via `findByObjectAndEvent`); the flag remains the kill switch.
+5. **Reminder support (VALARM)** — `CalendarEventService::createEvent` accepts an optional `reminderMinutesBefore` in `$data` and writes a `VALARM` (ACTION:DISPLAY, `TRIGGER:-PT{n}M`) into the VEVENT; the event array shape exposes it. Alarm delivery stays native to the calendar stack (Calendar app / DAV reminders service) — the leaf authors the alarm, it does not deliver it.
+
+## Out of scope
+
+- Recurrence (RRULE/EXDATE/RECURRENCE-ID) — untouched; recurring events are handled as today (single-instance semantics).
+- Attendee round-trip / scheduling (ORGANIZER, PARTSTAT read-back, iMIP) — the attendee surface stays write-once bare emails.
+- A general `updateEvent()`/PUT route and true VEVENT deletion via the API — `destroy` keeps unlink semantics.
+- Writable virtual schema calendars (`RegisterCalendar` stays `PERMISSION_READ`).
+- Multi-calendar write targets — writes keep landing on the pinned `events_calendar_uri`.
+- VTIMEZONE authoring — UTC stays forced; a timezone pass is its own change.

--- a/openspec/changes/calendar-leaf-inbound/specs/integration-calendar/spec.md
+++ b/openspec/changes/calendar-leaf-inbound/specs/integration-calendar/spec.md
@@ -1,0 +1,118 @@
+## Purpose delta
+
+The integration-calendar leaf gains its inbound half: Calendar-side changes to linked or `X-OPENREGISTER-*`-tagged VEVENTs flow back into the `openregister_calendar_links` table, linking becomes idempotent with a reverse lookup, the legacy backfill job becomes an active registered one-shot, and the leaf can author calendar-native reminders (VALARM) on the events it creates. Consumer apps keep a single rule: never touch CalDAV, the leaf is complete in both directions.
+
+## ADDED Requirements
+
+### Requirement: Inbound calendar changes refresh the link table (REQ-CAL-INB-001)
+
+The system SHALL register event listeners for `OCA\DAV\Events\CalendarObjectCreatedEvent`, `CalendarObjectUpdatedEvent`, `CalendarObjectMovedEvent`, and `CalendarObjectDeletedEvent`. For a VEVENT that carries `X-OPENREGISTER-*` properties or whose UID matches an existing link row: on create the system SHALL ensure a link row exists (idempotently, per REQ-CAL-INB-003); on update or move it SHALL refresh the cached `summary`, `dtstart`, `dtend`, `location`, `calendarId`, `calendarUri`, and `eventUri` fields of every matching link row; on deletion of the VEVENT it SHALL delete the matching link rows. Listener failures SHALL be logged and SHALL never abort the calendar operation itself. VEVENTs with neither tag nor link row SHALL be ignored at negligible cost.
+
+#### Scenario: Meeting moved in Nextcloud Calendar updates the cached times
+
+- **GIVEN** a link row for event UID `E1` cached with `dtstart` 10:00
+- **WHEN** the user drags the event to 14:00 in the Calendar app and the `CalendarObjectUpdatedEvent` fires
+- **THEN** the link row's `dtstart`/`dtend` SHALL reflect the new times
+- **AND** a consumer reading `getLinkedEvents` SHALL see 14:00 without any rescan
+
+`@e2e exclude backend DAV event listener; asserted via PHPUnit listener tests, no UI surface of its own`
+
+#### Scenario: Event deleted in Nextcloud Calendar removes the link
+
+- **GIVEN** a link row for event UID `E1`
+- **WHEN** the VEVENT is deleted in the Calendar app
+- **THEN** the link rows for `E1` SHALL be deleted
+- **AND** the object's events read SHALL no longer include `E1`
+
+`@e2e exclude backend DAV event listener; asserted via PHPUnit listener tests, no UI surface of its own`
+
+#### Scenario: Tagged event created Calendar-side gains a link row
+
+- **GIVEN** a VEVENT created in the Calendar app carrying `X-OPENREGISTER-REGISTER/SCHEMA/OBJECT` properties
+- **WHEN** the `CalendarObjectCreatedEvent` fires
+- **THEN** a link row SHALL exist for that object/event pair without any consumer-app action
+
+`@e2e exclude backend DAV event listener; asserted via PHPUnit listener tests, no UI surface of its own`
+
+---
+
+### Requirement: Reverse event-to-objects lookup (REQ-CAL-INB-002)
+
+The system SHALL provide `CalendarLinkMapper::findByEventUid(string $eventUid, ?string $calendarUri = null): array` and a service surface `CalendarLinkService::getObjectsForEvent(string $eventUid, ?string $calendarUri = null): array` returning the link rows (and thereby object UUIDs) attached to a VEVENT. The inbound listeners SHALL use this lookup; it SHALL be scoped by `calendarUri` when provided to disambiguate UID reuse across calendars.
+
+#### Scenario: Listener resolves the objects behind an updated event
+
+- **GIVEN** two objects linked to event UID `E1`
+- **WHEN** the update listener processes `E1`
+- **THEN** `getObjectsForEvent('E1')` SHALL return both link rows and both SHALL be refreshed
+
+`@e2e exclude mapper/service API; covered by PHPUnit, no UI surface`
+
+---
+
+### Requirement: Linking is idempotent (REQ-CAL-INB-003)
+
+`CalendarLinkService::linkEvent` and `createAndLinkEvent` SHALL NOT create a second row for an identical `(objectUuid, eventUid, calendarUri)` triple: a repeated call SHALL return the existing row unchanged. A migration SHALL deduplicate existing rows (keeping the oldest) and add a unique index on the triple. The HTTP link route (`POST /api/objects/{register}/{schema}/{id}/events/link`) SHALL inherit this behaviour and SHALL respond successfully with the existing link on a repeat.
+
+#### Scenario: Repeated link call returns the existing row
+
+- **GIVEN** an existing link row for object `O1` and event `E1`
+- **WHEN** `linkEvent` is called again for the same pair on the same calendar
+- **THEN** no new row SHALL be inserted
+- **AND** the returned entity SHALL be the existing row
+
+`@e2e exclude service-level idempotency; covered by PHPUnit including the dedup migration`
+
+#### Scenario: Duplicate rows from the past are collapsed by the migration
+
+- **GIVEN** a pre-migration table containing two rows for the same `(objectUuid, eventUid, calendarUri)`
+- **WHEN** the migration runs
+- **THEN** exactly one row (the oldest) SHALL remain and the unique index SHALL be in place
+
+`@e2e exclude one-time migration; covered by a migration PHPUnit test`
+
+---
+
+### Requirement: Backfill job is registered and enabled by default (REQ-CAL-INB-004)
+
+`BackfillCalendarLinksJob` SHALL be registered as a background job so it is schedulable without manual `occ background-job:execute`, and the `backfill_calendar_links` app-config flag SHALL default to enabled, running the backfill once per instance after upgrade (the job's existing `findByObjectAndEvent` pre-check keeps re-runs idempotent). Setting the flag to `no` SHALL remain the kill switch and SHALL be honoured before any scan. The job SHALL keep its per-user scope (`callForSeenUsers`) and SHALL log inserted/skipped counts.
+
+#### Scenario: Upgrade backfills legacy tagged events
+
+- **GIVEN** an instance upgrading with X-OPENREGISTER-tagged VEVENTs that have no link rows
+- **WHEN** the registered backfill job runs after upgrade
+- **THEN** link rows SHALL exist for those events with `linkedBy = 'system:backfill'`
+- **AND** a second run SHALL insert nothing (all skipped)
+
+`@e2e exclude background job; covered by PHPUnit job tests and occ smoke run in dev`
+
+#### Scenario: Kill switch is honoured
+
+- **GIVEN** app-config `backfill_calendar_links` set to `no`
+- **WHEN** the job runs
+- **THEN** it SHALL log the skip and scan nothing
+
+`@e2e exclude background job flag guard; covered by PHPUnit`
+
+---
+
+### Requirement: Created events can carry a reminder (REQ-CAL-INB-005)
+
+`CalendarEventService::createEvent` SHALL accept an optional integer `reminderMinutesBefore` in its `$data` array and, when present and positive, SHALL emit a `VALARM` component (`ACTION:DISPLAY`, `TRIGGER:-PT{n}M`, `DESCRIPTION` = the event summary) inside the created VEVENT. The event array shape returned by the read paths SHALL expose the reminder as `reminderMinutesBefore` when a display alarm is present. Alarm delivery SHALL remain the calendar stack's responsibility; the leaf authors the alarm and SHALL NOT implement its own notification dispatch for it.
+
+#### Scenario: Follow-up created with a reminder rings natively
+
+- **GIVEN** a consumer app creates a follow-up event via the leaf with `reminderMinutesBefore: 30`
+- **WHEN** the VEVENT is stored
+- **THEN** it SHALL contain a `VALARM` with `TRIGGER:-PT30M`
+- **AND** the user's calendar clients SHALL raise the reminder through their native alarm handling
+
+`@e2e exclude VALARM authoring; asserted by PHPUnit on the serialized VEVENT — alarm firing is the calendar stack's, not ours`
+
+#### Scenario: No reminder requested, no alarm written
+
+- **GIVEN** `createEvent` is called without `reminderMinutesBefore`
+- **WHEN** the VEVENT is stored
+- **THEN** it SHALL contain no `VALARM` component
+
+`@e2e exclude VALARM authoring; asserted by PHPUnit on the serialized VEVENT`

--- a/openspec/changes/calendar-leaf-inbound/tasks.md
+++ b/openspec/changes/calendar-leaf-inbound/tasks.md
@@ -1,0 +1,13 @@
+# Tasks: calendar-leaf-inbound
+
+- [ ] `CalendarLinkMapper::findByEventUid(eventUid, ?calendarUri)` — reverse lookup, scoped by calendar uri when given (REQ-CAL-INB-002).
+- [ ] `CalendarLinkService::getObjectsForEvent()` — service surface over the reverse lookup.
+- [ ] Idempotency in `CalendarLinkService::linkEvent` / `createAndLinkEvent` — return the existing row for a duplicate `(objectUuid, eventUid, calendarUri)` instead of inserting (REQ-CAL-INB-003).
+- [ ] Migration — deduplicate existing `openregister_calendar_links` rows (keep oldest) and add the unique index on `(object_uuid, event_uid, calendar_uri)`.
+- [ ] `lib/Listener/CalendarObjectChangedListener.php` — one listener class handling Created/Updated/Moved: parse the VObject from the event payload, match by `X-OPENREGISTER-*` or `findByEventUid`, upsert/refresh cached fields; swallow+log own failures, never abort the DAV operation (REQ-CAL-INB-001).
+- [ ] `lib/Listener/CalendarObjectDeletedListener.php` — delete matching link rows on VEVENT deletion.
+- [ ] Register both listeners in `lib/AppInfo/Application.php` (`registerEventListener`) for the four `OCA\DAV\Events\CalendarObject*Event` classes, guarded so absence of the DAV classes is a no-op.
+- [ ] Register `BackfillCalendarLinksJob` (info.xml background-jobs / boot registration) and flip the `backfill_calendar_links` default read to enabled; keep `no` as the honoured kill switch; remove the stale "not registered / manual only" doc block wording (REQ-CAL-INB-004).
+- [ ] `CalendarEventService::createEvent` — accept `reminderMinutesBefore`, emit `BEGIN:VALARM / ACTION:DISPLAY / TRIGGER:-PT{n}M / DESCRIPTION / END:VALARM`; expose `reminderMinutesBefore` in `veventToArray` when a display alarm is present (REQ-CAL-INB-005).
+- [ ] PHPUnit — listener upsert/refresh/delete paths, reverse lookup, idempotent link (service + repeated HTTP link route), migration dedup, backfill re-run idempotency and kill switch, VALARM serialization and absence.
+- [ ] `composer check:strict` clean on all touched files; hydra gates pass; `openspec validate --strict` on this change.

--- a/openspec/changes/flow-bpmn-interchange/.openspec.yaml
+++ b/openspec/changes/flow-bpmn-interchange/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/flow-bpmn-interchange/design.md
+++ b/openspec/changes/flow-bpmn-interchange/design.md
@@ -1,0 +1,82 @@
+# Design: flow-bpmn-interchange
+
+## Decision 1: own serializer over a schema-validated subset
+
+ADR-065 Decision 7 already surveyed the field: "No package in any category
+supplies BPMN/DMN/CMMN XML ↔ PHP objects. `phpmentors/workflower` has the
+ecosystem's best BPMN importer but is abandoned (released 2019-12-03, last
+push 2023-08-18) — read it as a reference, do not depend on it."
+
+Options:
+
+1. **Depend on workflower anyway.** Rejected — an abandoned dependency at an
+   interchange boundary is a security surface nobody patches, and the fleet
+   already has a rule against agent-vendored/unmaintained libraries.
+2. **Full BPMN 2.0 metamodel in PHP.** Rejected — the metamodel is enormous
+   (choreographies, conversations, compensation) and the engine can express
+   a fraction of it. A full metamodel would be 90% dead code whose only
+   caller is the XSD.
+3. **Own serializer over a declared subset, XSD-validated at the boundary**
+   (chosen). `DOMDocument` + `XMLReader` against the OMG XSD (vendored,
+   version-pinned — the schema files are stable artifacts of the standard,
+   not code). The subset is exactly what the mapping table names, and
+   everything outside it flows into the mapping report by construction:
+   the importer walks known elements and files each unknown one as
+   `refused`, so the subset boundary and the report are the same code path
+   and cannot drift apart. Workflower is consulted as a reference for XSD
+   corner cases, per the ADR.
+
+## Decision 2: the mapping table and its asymmetries
+
+Export is total (every flow exports); import is partial (BPMN is bigger than
+the engine). The table is symmetric where it can be and honest where it
+cannot:
+
+| Flow construct | BPMN (export) | Import accepts additionally |
+| --- | --- | --- |
+| `trigger-manual` | none start event | — |
+| `trigger-schedule` | timer start event | ISO-8601 cycles that map to cron; others → `approximated` |
+| `trigger-object` | conditional start event | message start event → `await-signal`-style note, `approximated` |
+| `switch` / `route` | exclusive gateway + flow conditions | inclusive gateway with default flow → `route`, `mapped` |
+| multi-out node | parallel gateway (diverging) | explicit diverging parallel gateway → plain multi-edge node |
+| `join: true` | parallel gateway (converging) | converging parallel/exclusive gateway |
+| `await-signal` | intermediate message catch | `userTask` → `await-signal`, `mapped` (a user task IS "wait for a person") |
+| `wait` | intermediate timer catch | — |
+| `sub-flow` | call activity | call activity naming an unknown flow → node created, report entry |
+| `end` (`error`) | (error) end event | terminate end event → `end`, `approximated` (the engine ends the RUN either way) |
+| other steps | `serviceTask` + extensionElements | `scriptTask`/`sendTask`/`task` → typeless node, report entry |
+
+Not importable, always `refused`: event sub-processes, boundary events other
+than the timer approximation, compensation, transactions, lanes/pools beyond
+the first participant, multiple processes per file.
+
+**Why refusal drops the element instead of failing the import by default:**
+the primary import user is migrating a diagram they will finish by hand on
+the canvas. A hard fail on the first exotic construct gives them nothing;
+a flow with a named gap plus a report gives them 90% of the redraw. The run
+guard is what keeps this safe — a flow with typeless nodes cannot run, so an
+incomplete import can never silently execute less than the diagram said. The
+`strict` parameter exists for the automation case where a human is not going
+to read the report.
+
+## Decision 3: extension elements make our own round-trip exact
+
+BPMN cannot natively carry `openregister.set-fields`'s config. The standard's
+own answer is `extensionElements` with a foreign namespace, which conformant
+tools must preserve and may ignore. Export writes `type` + `config` (JSON,
+CDATA) there; import prefers it over any inference. This gives three tiers of
+fidelity, each honest:
+
+1. our file → our instance: exact (asserted by the round-trip test);
+2. our file → Camunda and back untouched: exact (extensions preserved);
+3. foreign file → our instance: the mapping report is the contract.
+
+## Decision 4: where the code sits
+
+`lib/Service/Flow/Bpmn/{FlowBpmnExporter,FlowBpmnImporter,BpmnMappingReport}` —
+a sibling namespace to `Nodes/`, not inside the engine services, because
+nothing in the run path may reach into it (the "never an execution semantic"
+requirement is enforced by dependency direction: `Bpmn\*` depends on the flow
+store and node registry, nothing depends on `Bpmn\*`). The registry dependency
+is what lets the importer ask "is this a known type" and the exporter ask for
+roles without hard-coding the node list a second time.

--- a/openspec/changes/flow-bpmn-interchange/proposal.md
+++ b/openspec/changes/flow-bpmn-interchange/proposal.md
@@ -1,0 +1,98 @@
+---
+kind: code
+---
+
+# Proposal: flow-bpmn-interchange
+
+## Summary
+
+Add BPMN 2.0 XML import and export for flows. Export serialises a flow's
+node/edge graph to a standards-conformant `bpmn:process` with diagram
+interchange (BPMN DI), so a flow can be opened in Camunda Modeler,
+bpmn.io, or handed to an auditor. Import reads a BPMN file into a flow
+document, accepting a documented subset and producing a **lossy-mapping
+report** that names every construct it could not express — never importing
+silently less than the file said.
+
+## Why
+
+Three pressures, none served today:
+
+1. **Procurement and audit.** Dutch government buyers ask "can we get our
+   processes out?" BPMN 2.0 is the interchange format that question means.
+   ADR-065 chose symfony/workflow over a BPMN engine deliberately, and its
+   Decision 7 records the consequence: "XML interchange is ours to write on
+   every path" — no maintained PHP package supplies BPMN XML ↔ objects. The
+   decision to own the serializer was made a year ago; this change schedules
+   the work.
+2. **Migration in.** Organisations arriving from Camunda/Zeebe-adjacent
+   tooling have BPMN files. Today the answer is "redraw it by hand on the
+   canvas"; with import the answer is "import it and read the report of what
+   needs attention".
+3. **Documentation out.** A flow's only current representations are the
+   canvas and raw JSON. An exported BPMN diagram is a process picture every
+   BPM-literate reader already knows how to read.
+
+The engine's model makes this tractable: since `or-flow-action-nodes`, a flow
+IS a node/edge graph with behaviour on typed nodes — structurally the same
+shape as a BPMN process (flow nodes joined by sequence flows). The mapping is
+mostly direct; the design documents the corners where it is not.
+
+## What Changes
+
+- **New `FlowBpmnExporter` and `FlowBpmnImporter`** under
+  `lib/Service/Flow/Bpmn/`, plus `GET /api/flows/{id}/bpmn` and
+  `POST /api/flows/import/bpmn` on `FlowController` (guarded by the existing
+  `flow.create` / read rights — export requires read, import creates).
+- **Export mapping** (full table in `design.md`):
+  - `openregister.trigger-manual` → none start event; `trigger-schedule` →
+    timer start event (cron in a `timerEventDefinition`); `trigger-object` →
+    conditional start event carrying the event/register/schema subject;
+  - `switch` / `route` → exclusive gateway with condition expressions on the
+    outgoing sequence flows;
+  - a node with multiple outgoing edges → implicit parallel split, exported
+    as a parallel gateway; a `join: true` node → converging parallel gateway;
+  - `await-signal` → intermediate message catch event; `wait` → intermediate
+    timer catch event;
+  - `sub-flow` → call activity referencing the child flow;
+  - `end` → end event (error end event when `config.error` is true);
+  - every other step → `bpmn:serviceTask`, with the node's `type` and
+    `config` carried in `extensionElements` under an `openregister`
+    namespace so a round-trip through export/import is lossless for our own
+    files.
+- **Import** accepts a schema-validated subset (the constructs above, read in
+  reverse) and produces a lossy-mapping report: every element it mapped
+  approximately, dropped, or refused, each with the BPMN element id and what
+  the author should do about it. Import NEVER guesses behaviour: a
+  `serviceTask` with no openregister extension imports as a node with no
+  `type`, which the builder and preflight already refuse/flag by name — the
+  imported flow is honest about being unfinished.
+- **Diagram interchange.** Export writes BPMN DI from the canvas positions;
+  import reads DI when present and auto-layouts when absent.
+
+## What does NOT change
+
+- The execution engine. BPMN is an interchange FORMAT here, never an
+  execution semantic: symfony/workflow remains the core (ADR-065 Decision 2),
+  and no imported construct executes differently from the same graph drawn
+  on the canvas.
+- The stored flow document. BPMN is produced and consumed at the boundary;
+  nothing BPMN-shaped is persisted.
+- DMN/CMMN. Out of scope (DMN interchange is tracked by openregister#466 per
+  ADR-065; CMMN is deferred by the same ADR).
+
+## Impact
+
+- **Affected specs**: new capability `flow-bpmn-interchange`
+- **Affected code**: new `lib/Service/Flow/Bpmn/`, `FlowController`,
+  `appinfo/routes.php`; UI export/import buttons in the flow detail surface
+  (nextcloud-vue follow-up)
+- **Affected apps**: none — consumers get the endpoints for free
+- **ADRs**: ADR-065 Decision 7 (own serializer — this implements it),
+  Decision 2 (engine unchanged — this respects it)
+
+## Capabilities
+
+### New Capabilities
+- `flow-bpmn-interchange` — BPMN 2.0 XML export and subset import with a
+  lossy-mapping report

--- a/openspec/changes/flow-bpmn-interchange/specs/flow-bpmn-interchange/spec.md
+++ b/openspec/changes/flow-bpmn-interchange/specs/flow-bpmn-interchange/spec.md
@@ -1,0 +1,160 @@
+## ADDED Requirements
+
+### Requirement: A flow exports to conformant BPMN 2.0 XML
+
+`GET /api/flows/{id}/bpmn` SHALL return the flow serialised as a BPMN 2.0 XML
+document containing exactly one `bpmn:process`, validating against the OMG
+BPMN 2.0 XSD. The caller SHALL need read access to the flow and nothing more —
+export is a read.
+
+The mapping SHALL be:
+
+- `openregister.trigger-manual` → none start event;
+- `openregister.trigger-schedule` → timer start event whose
+  `timerEventDefinition` carries the cron expression;
+- `openregister.trigger-object` → conditional start event carrying the
+  event/register/schema subject in its condition;
+- `openregister.switch` and `openregister.route` → exclusive gateway, with
+  each branch's condition on its outgoing `sequenceFlow`;
+- a node with several outgoing edges → diverging parallel gateway (that is
+  what the engine's lowering does with it);
+- a node declaring `join: true` → converging parallel gateway;
+- `openregister.await-signal` → intermediate message catch event;
+- `openregister.wait` → intermediate timer catch event;
+- `openregister.sub-flow` → call activity naming the child flow;
+- `openregister.end` → end event, or error end event when the node's config
+  sets `error`;
+- every other node → `bpmn:serviceTask`.
+
+Every exported element SHALL carry the node's `type` and `config` in
+`extensionElements` under a declared `openregister` XML namespace, so that a
+file exported here and imported here reproduces the flow exactly. A consumer
+that ignores extension elements — which the BPMN spec requires consumers to
+tolerate — still sees the correct process structure.
+
+The export SHALL include BPMN DI (`bpmndi:BPMNDiagram`) derived from the
+canvas positions, so the file opens in Camunda Modeler / bpmn.io looking like
+the canvas, not as an unlaid-out graph.
+
+#### Scenario: An exported flow validates and round-trips
+
+- **GIVEN** a flow using a trigger, a switch, a join, a sub-flow and an end
+- **WHEN** it is exported and the result imported into the same instance
+- **THEN** the exported XML MUST validate against the BPMN 2.0 XSD
+- **AND** the imported flow's nodes and edges MUST be semantically identical
+  to the original (same types, configs, joins and wiring; canvas positions
+  preserved via DI)
+- @e2e exclude covered by a PHPUnit round-trip test asserting on the document,
+  with XSD validation in the same test
+
+#### Scenario: A failing end is an error end event
+
+- **GIVEN** a flow whose end node carries `config.error: true`
+- **WHEN** it is exported
+- **THEN** that node MUST serialise as an error end event, not a plain one
+- @e2e exclude covered by exporter unit tests
+
+#### Scenario: Export requires only read access
+
+- **GIVEN** a user who can read but not edit a flow shared with them
+- **WHEN** they request the BPMN export
+- **THEN** it MUST succeed
+- **AND** a user without read access MUST receive the same refusal the flow
+  read endpoint gives
+- @e2e exclude covered by controller tests against the rights matrix
+
+### Requirement: BPMN import accepts a documented subset and reports every loss
+
+`POST /api/flows/import/bpmn` SHALL create a flow from a BPMN 2.0 file. It is
+guarded by `flow.create`. The importer SHALL accept the constructs the
+exporter emits (read in reverse) and SHALL handle everything else in exactly
+one of three declared ways, each landing in the **mapping report** returned
+alongside the created flow:
+
+- **mapped** — constructs with a faithful equivalent (e.g. a `userTask`
+  becomes `openregister.await-signal`; an inclusive gateway with a default
+  flow becomes `openregister.route`); reported so the author can confirm the
+  reading;
+- **approximated** — constructs imported with reduced semantics (e.g. a
+  boundary timer event becomes a note on the node it was attached to, since
+  the engine has no boundary events); the report SHALL say what was lost;
+- **refused** — constructs with no honest mapping (event sub-processes,
+  compensation, transactions, multiple `bpmn:process` elements in one file,
+  choreography/collaboration content). A refused construct SHALL NOT abort
+  the whole import by default: the element is dropped, the report names it as
+  refused, and the resulting flow is left visibly unfinished at that point. A
+  `strict=true` request parameter SHALL turn any refusal into a failed import
+  with no flow created.
+
+Every report entry SHALL carry the BPMN element id, its element kind, the
+verdict (`mapped` / `approximated` / `refused`), and a human sentence saying
+what to do. An import that loses something and says nothing is the failure
+mode this requirement exists to prevent.
+
+A `serviceTask` without openregister extension elements SHALL import as a
+node with an empty `type`. The engine already refuses to RUN such a flow by
+name; the import report SHALL additionally list each such node as needing a
+type assigned. Import SHALL NOT guess a type from the task's name.
+
+The importer SHALL validate the file against the BPMN 2.0 XSD before mapping,
+and refuse a non-validating file naming the first violation — a mapping
+report over a malformed document would attribute XML problems to process
+constructs.
+
+#### Scenario: An unsupported construct is named, not silently dropped
+
+- **GIVEN** a BPMN file containing an event sub-process
+- **WHEN** it is imported without `strict`
+- **THEN** a flow MUST be created without that construct
+- **AND** the report MUST carry a `refused` entry naming the element id and
+  kind
+- **AND** with `strict=true` the same file MUST create no flow and return the
+  same entries as errors
+- @e2e exclude covered by importer unit tests over fixture files
+
+#### Scenario: A task with no engine type imports honestly
+
+- **GIVEN** a BPMN file authored in Camunda Modeler whose `serviceTask` has
+  no openregister extension elements
+- **WHEN** it is imported
+- **THEN** the created node MUST have no `type`
+- **AND** the report MUST list it as needing a type
+- **AND** running the flow MUST be refused exactly as for any typeless node
+- @e2e exclude covered by importer unit tests
+
+#### Scenario: Diagram positions survive, and absence is laid out
+
+- **GIVEN** one file with BPMN DI and one without
+- **WHEN** both are imported
+- **THEN** the first flow's nodes MUST sit at the DI positions
+- **AND** the second MUST receive an automatic layout with no two nodes
+  overlapping, rather than a pile at the origin
+- @e2e exclude covered by importer unit tests asserting on stored positions
+
+#### Scenario: An invalid file is refused before mapping
+
+- **GIVEN** a file that is XML but does not validate against the BPMN 2.0 XSD
+- **WHEN** it is imported
+- **THEN** no flow MUST be created
+- **AND** the response MUST name the first schema violation
+- @e2e exclude covered by importer unit tests
+
+### Requirement: BPMN is an interchange boundary, never an execution semantic
+
+The engine SHALL NOT execute BPMN. An imported flow SHALL be stored as an
+ordinary flow document and SHALL behave identically to the same graph drawn
+by hand; export SHALL read the stored document and SHALL persist nothing
+BPMN-shaped. No run-time code path SHALL depend on whether a flow was ever
+imported or exported.
+
+This keeps ADR-065 intact: symfony/workflow is the execution core, and BPMN
+support is a serializer at the API boundary — the "ours to write" XML
+interchange of Decision 7, not a second engine.
+
+#### Scenario: An imported flow is indistinguishable at run time
+
+- **GIVEN** a flow imported from BPMN and the identical flow drawn by hand
+- **WHEN** both are lowered and run against the same input
+- **THEN** their definitions MUST be identical
+- **AND** their run logs MUST record the same steps
+- @e2e exclude engine-internal — covered by a definition-equality unit test

--- a/openspec/changes/flow-bpmn-interchange/tasks.md
+++ b/openspec/changes/flow-bpmn-interchange/tasks.md
@@ -1,0 +1,77 @@
+# Tasks: flow-bpmn-interchange
+
+## Groundwork
+
+- [ ] Vendor the OMG BPMN 2.0 XSD set (version-pinned, licence-checked) under
+      `lib/Service/Flow/Bpmn/schema/`; wire `DOMDocument::schemaValidate`
+      behind a helper both directions share.
+- [ ] Declare the `openregister` extension namespace and its two elements
+      (`type`, `config`) in one place both exporter and importer read.
+
+## Export
+
+- [ ] `FlowBpmnExporter::export(Flow): string` implementing the design's
+      mapping table: triggers → start events (none/timer/conditional),
+      switch/route → exclusive gateways with flow conditions, multi-out →
+      diverging parallel gateway, `join: true` → converging parallel gateway,
+      await-signal → intermediate message catch, wait → intermediate timer
+      catch, sub-flow → call activity, end → (error) end event, other steps →
+      `serviceTask`; `type`/`config` into `extensionElements` on every node.
+- [ ] BPMN DI emission from stored canvas positions.
+- [ ] `GET /api/flows/{id}/bpmn` on `FlowController` — read-guarded, returns
+      `application/xml` with a download filename; route registered in
+      `appinfo/routes.php` with its auth posture (gate-5/29).
+- [ ] Exporter unit tests: every mapping row; XSD validation of every
+      fixture's output as part of the test, not a separate step.
+
+## Import
+
+- [ ] `FlowBpmnImporter::import(string $xml, bool $strict): ImportResult`
+      producing the flow document plus a `BpmnMappingReport` of
+      `mapped`/`approximated`/`refused` entries (element id, kind, verdict,
+      action sentence).
+- [ ] XSD validation before mapping; a non-validating file refused naming the
+      first violation.
+- [ ] Reverse mappings incl. the tolerated widenings (userTask →
+      await-signal; inclusive gateway with default → route; terminate end →
+      end; ISO-8601 timer cycles → cron where expressible).
+- [ ] Refusal handling: element dropped + report entry by default; `strict`
+      fails the import with no flow created.
+- [ ] Extension-element preference: a task carrying `openregister:type`
+      imports to that exact node; one without imports typeless and is listed
+      in the report.
+- [ ] BPMN DI consumption; auto-layout (layered, non-overlapping) when DI is
+      absent.
+- [ ] `POST /api/flows/import/bpmn` — `flow.create`-guarded, multipart or
+      raw-XML body, returns the stored flow plus the report.
+- [ ] Importer unit tests over fixture files: every verdict class, the
+      strict/lenient pair, the no-DI layout, the invalid file; each refusal
+      test with a positive control proving the corrected file imports.
+
+## Round-trip and boundary
+
+- [ ] Round-trip test: export → import on a flow exercising every mapping
+      row; assert semantic equality of documents and DEFINITION equality
+      after lowering (the "indistinguishable at run time" scenario).
+- [ ] Dependency-direction check: nothing under `lib/Service/Flow/` outside
+      `Bpmn/` imports from `Bpmn\` (enforce with a small architecture test or
+      Psalm forbidden-import config).
+- [ ] UI follow-up filed against nextcloud-vue: export/import actions on the
+      flow detail surface rendering the mapping report (out of this repo's
+      scope; endpoint contract is this change).
+
+## Acceptance criteria
+
+- Every exported file validates against the BPMN 2.0 XSD.
+- Our own files round-trip exactly, including canvas positions.
+- No construct is ever imported silently below its meaning: every
+  approximation and refusal appears in the report by element id.
+- No run-time path depends on BPMN code.
+
+## Quality checklist
+
+- `composer check:strict` passes (PHPCS, PHPMD, Psalm, PHPStan).
+- `@spec` annotations point at
+  `openspec/specs/flow-bpmn-interchange/spec.md` requirement anchors.
+- References: ADR-065 Decisions 2 and 7; DMN interchange stays with
+  openregister#466, not this change.

--- a/openspec/changes/flow-engine-docs/.openspec.yaml
+++ b/openspec/changes/flow-engine-docs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/flow-engine-docs/proposal.md
+++ b/openspec/changes/flow-engine-docs/proposal.md
@@ -1,0 +1,86 @@
+---
+kind: code
+---
+
+# Proposal: flow-engine-docs
+
+## Summary
+
+Write the user-facing documentation for the flow engine: a new
+`docs/features/flows.md` covering the canvas, triggers, steps, approvals,
+run history, retry/resume, the kill switch, sharing and shipping — plus the
+corrections to `docs/features/README.md`, whose feature table still tells
+users that workflow automation in OpenRegister means n8n/Windmill.
+
+## Why
+
+The fleet's single flow engine (ADR-065) has zero user documentation. The
+engine has a canvas, nineteen node types, a sixteen-event trigger catalogue,
+approval suspension, run history with per-node logs, retry/resume, and
+sharing — and a user searching `docs/features/` finds none of it. Worse than
+absence, the docs that DO mention the word point the wrong way:
+`docs/features/README.md` maps "Workflow Automation" to
+`workflow-automation.md` with the note "n8n, Windmill, BPMN" — the
+EXTERNAL-automation story that predates the native engine, presented as the
+whole story. ADR-094 settled that editorial automation targets or-flow, not
+n8n; the README still recommends what the ADR retired for this purpose.
+
+Undocumented features fail in a specific way here: the config panes are raw
+JSON today (`flow-node-config-forms` fixes that in parallel), so
+documentation is currently the ONLY way an author can learn a node's keys —
+and there is none. The two changes attack the same gap from both ends.
+
+## What Changes
+
+- **New `docs/features/flows.md`** — structure in `tasks.md`. Every factual
+  claim grounded in the engine as shipped: the sixteen trigger events from
+  `EventCatalogService::CATALOG`, the actual node list from the registry,
+  the actual sharing semantics (a shared flow can be READ and RUN, never
+  edited), the actual shipping mechanism (`x-openregister-flows` — flows
+  shipped inside a schema/register configuration and imported on install).
+- **`docs/features/README.md` feature table updated**: a new "Flows
+  (Workflow Automation)" row pointing at `flows.md`, and the existing
+  Workflow Automation row re-scoped to what `workflow-automation.md`
+  actually is — integrating EXTERNAL automation tools — with a cross-link
+  each way. The n8n/Windmill page is corrected, not deleted: external
+  orchestration remains a real integration surface; it is just not the
+  native engine.
+- **Boundary statements written down** where users will look for them:
+  - *Notifications notify; flows orchestrate.* Declarative
+    `x-openregister-notifications` (ADR-031) for "whenever X, tell Y";
+    flow messaging nodes for "at this point in the process, tell Y".
+  - *API calls go through OpenConnector.* A flow calls any external API via
+    `openconnector.source-call` nodes against configured sources (ADR-094);
+    the engine deliberately ships no native HTTP node.
+- **The trigger cutover documented honestly.** The flow-engine spec records
+  that trigger COLUMNS remain authoritative for unconverted flows, with a
+  per-flow nodes-first cutover and a column fallback as the deprecation
+  surface. The docs say so in user terms — which flows fire from nodes,
+  which from legacy columns, and what re-authoring a flow with trigger
+  nodes changes — instead of describing the end state as if the fallback
+  did not exist.
+
+## What does NOT change
+
+- The engine. This change writes no PHP; where writing the docs exposes a
+  behaviour gap, the gap is filed as an issue, never papered over with
+  aspirational prose — a doc that describes the intended behaviour of a
+  broken feature is worse than no doc.
+- `workflow-automation.md`'s subject. External tools keep their page; it
+  stops masquerading as the native story.
+
+## Impact
+
+- **Affected specs**: new capability `flow-engine-docs` (the documentation
+  contract: exists, accurate, maintained)
+- **Affected files**: `docs/features/flows.md` (new),
+  `docs/features/README.md`, `docs/features/workflow-automation.md`
+  (re-scoping note + cross-link)
+- **ADRs referenced**: ADR-065 (the engine and canvas), ADR-031
+  (notifications boundary), ADR-094 (OpenConnector boundary)
+
+## Capabilities
+
+### New Capabilities
+- `flow-engine-docs` — user documentation for the flow engine, accurate to
+  the shipped behaviour

--- a/openspec/changes/flow-engine-docs/specs/flow-engine-docs/spec.md
+++ b/openspec/changes/flow-engine-docs/specs/flow-engine-docs/spec.md
@@ -1,0 +1,110 @@
+## ADDED Requirements
+
+### Requirement: The flow engine has user documentation, and it is accurate
+
+`docs/features/flows.md` SHALL exist and SHALL document, for a flow AUTHOR
+(not an engine developer): the canvas and node palette; the three trigger
+node types and the full event catalogue; the built-in step and end nodes
+with their configuration keys; approvals (`await-signal`) end to end,
+including how the waiting person is told (`flow-messaging-nodes`); run
+history and per-node run logs; retry and resume; the kill switch; sharing;
+and shipping flows with a configuration.
+
+Accuracy SHALL be structural, not aspirational:
+
+- the trigger event list SHALL enumerate exactly the events in
+  `EventCatalogService::CATALOG` — sixteen at time of writing — and SHALL be
+  regenerated or checked against the catalogue, never hand-maintained into
+  drift;
+- the node catalogue SHALL name exactly the types the registry registers;
+- a feature the engine does not have SHALL NOT be described. Where writing
+  the docs exposes a gap between intended and shipped behaviour, the gap is
+  filed as an issue and the docs describe what ships.
+
+#### Scenario: The documented event list is the shipped event list
+
+- **GIVEN** `docs/features/flows.md` and `EventCatalogService::CATALOG`
+- **WHEN** the documented event ids are compared with the catalogue's
+- **THEN** the two sets MUST be identical
+- **AND** the comparison is a test or doc-lint step, so an event added to
+  the catalogue without a docs update fails visibly
+- @e2e exclude a docs-consistency check — covered by a PHPUnit doc-lint test
+
+#### Scenario: The documented node list is the shipped palette
+
+- **GIVEN** the documented step/trigger catalogue and the node registry's
+  built-in registrations
+- **WHEN** the two lists of `openregister.*` type ids are compared
+- **THEN** they MUST be identical
+- @e2e exclude same doc-lint mechanism as the event list
+
+### Requirement: The feature index routes flow automation to the flow engine
+
+`docs/features/README.md` SHALL carry a feature-table row for the native
+flow engine pointing at `flows.md`. The existing "Workflow Automation" row
+SHALL be re-scoped to external-tool integration (n8n, Windmill), and
+`workflow-automation.md` SHALL open by directing readers who want built-in
+automation to `flows.md`. Neither page SHALL present an external tool as
+the way to automate OpenRegister processes — ADR-094 settled that fleet
+automation targets or-flow, and ADR-065 makes the engine the fleet's single
+one.
+
+#### Scenario: A reader looking for automation lands on the engine
+
+- **GIVEN** a reader starting at the `docs/features/README.md` feature table
+- **WHEN** they look for process automation
+- **THEN** they MUST find a row for the native flow engine linking to
+  `flows.md`
+- **AND** the external-tools row MUST describe itself as integration with
+  external automation, cross-linking `flows.md`
+- @e2e exclude prose review — checked in the change's review, plus a
+  doc-lint assertion that `README.md` links `flows.md`
+
+### Requirement: The documentation states the subsystem boundaries
+
+`flows.md` SHALL carry, verbatim in substance, the two boundary statements:
+
+- **Notifications notify; flows orchestrate.** "Whenever X happens, tell Y"
+  belongs to the declarative `x-openregister-notifications` annotation
+  (ADR-031); a flow's messaging nodes are for sends at a point in a
+  process. Each doc section SHALL link the other subsystem's documentation
+  at this fork.
+- **API calls go through OpenConnector.** A flow calls external APIs
+  through `openconnector.source-call` nodes against configured sources
+  (ADR-094). The engine ships no native HTTP node, deliberately: source
+  configuration is where credentials, base URLs and rate limits live once.
+
+#### Scenario: The fork in the road is signposted
+
+- **GIVEN** a reader deciding between a schema notification annotation and
+  a flow with a send node
+- **WHEN** they read the messaging section of `flows.md`
+- **THEN** it MUST state the boundary rule and link the notification
+  documentation
+- **AND** the section on calling APIs MUST name OpenConnector sources as
+  the path and state that no native HTTP node exists
+- @e2e exclude prose review
+
+### Requirement: The trigger cutover is documented as it is, not as it will be
+
+`flows.md` SHALL document the trigger-node cutover honestly, in user terms:
+a flow whose graph carries trigger NODES fires from those nodes alone; a
+flow with no trigger nodes still fires from its legacy trigger COLUMNS (the
+compatibility fallback the flow-engine spec mandates); re-authoring a flow
+with trigger nodes switches it to nodes-first matching, including that
+deleting a trigger node then genuinely unsubscribes it. The docs SHALL name
+the one genuinely blocked case — an unscoped ("any register, any schema")
+object trigger cannot be expressed as a trigger node and keeps its column
+until scoped — and SHALL NOT describe the columns as gone while any flow
+still fires from them.
+
+#### Scenario: An operator can tell which regime a flow is in
+
+- **GIVEN** the cutover section of `flows.md`
+- **WHEN** an operator with one converted and one unconverted flow reads it
+- **THEN** they MUST be able to determine which of their flows fires from
+  nodes and which from columns, and what re-authoring changes
+- **AND** the unscoped-object-trigger limitation MUST be stated with its
+  workaround (one trigger node per register/schema pair)
+- @e2e exclude prose review against the flow-engine spec's cutover
+  requirement

--- a/openspec/changes/flow-engine-docs/tasks.md
+++ b/openspec/changes/flow-engine-docs/tasks.md
@@ -1,0 +1,84 @@
+# Tasks: flow-engine-docs
+
+## docs/features/flows.md (new)
+
+Write the page with this structure, each section grounded in the shipped
+code named beside it:
+
+- [ ] **What flows are, and what they are not** — the fleet's single engine
+      (ADR-065); the two boundary statements up front: notifications notify
+      / flows orchestrate (ADR-031), API calls via OpenConnector sources
+      (ADR-094, `openconnector.source-call`) — with the explicit sentence
+      that no native HTTP node exists and why.
+- [ ] **The canvas** — nodes carry behaviour, edges carry sequence; multiple
+      outgoing edges run branches in parallel; converging edges merge by
+      default and `join: true` synchronises; annotations; the form pane and
+      the JSON pane (coordinate wording with `flow-node-config-forms`).
+- [ ] **Triggers** — the three trigger node types; the full event catalogue
+      enumerated from `EventCatalogService::CATALOG` (16 events: object
+      created/updated/deleted/locked/unlocked/reverted/transitioned, file
+      created/updated/deleted, user created/deleted, share created/deleted,
+      tag assigned/unassigned); one subject per object trigger and why two
+      schemas need two triggers; multiple triggers per flow.
+- [ ] **Steps** — the built-in catalogue from the registry (object-read,
+      object-write, set-fields, map, filter, switch, route, merge, explode,
+      iterate, batch, flow-state, wait, sub-flow, await-signal, end), one
+      paragraph each: what it does, its config keys, a worked example;
+      contributed nodes (openconnector, hermiq) noted as coming from their
+      apps' palettes with their own docs.
+- [ ] **Approvals** — await-signal end to end: the question, who answers,
+      how the answer routes downstream, the heartbeat, what happens when
+      nobody answers (reaped as failed, flow schedulable again); telling
+      the approver via the messaging nodes once `flow-messaging-nodes`
+      lands (until then, document what ships — do not pre-document unshipped
+      nodes).
+- [ ] **Runs** — run history, per-node input/output/log with sampling,
+      statuses incl. suspended and dead_letter, last-run fields on the flow,
+      retry and resume, why a half-wired flow saves with warnings but
+      refuses to run.
+- [ ] **Stopping things** — the kill switch as implemented (verify the
+      actual mechanism in code while writing — stop/disable per flow, stale
+      run handling; document only what exists and file gaps as issues).
+- [ ] **Sharing** — a shared flow can be read and run, never edited; how
+      that interacts with the `flow.*` rights matrix.
+- [ ] **Shipping flows** — `x-openregister-flows`: flows shipped inside a
+      configuration and imported on install (`SchemaFlowImportListener`),
+      when to ship vs author in place.
+- [ ] **The trigger cutover, honestly** — per the spec delta: nodes-first
+      with column fallback, what re-authoring changes, deleting a trigger
+      node unsubscribes, the unscoped object trigger limitation and its
+      workaround. No prose that implies the columns are gone.
+
+## Index and neighbours
+
+- [ ] `docs/features/README.md` — add the "Flows (Workflow Automation)" row
+      linking `flows.md`; re-scope the existing Workflow Automation row to
+      external-tool integration; both rows cross-link.
+- [ ] `docs/features/workflow-automation.md` — opening pointer: "for
+      built-in automation see flows.md"; remove/replace any sentence
+      presenting n8n/Windmill as the way to automate OpenRegister.
+
+## Keeping it true
+
+- [ ] Doc-lint test (PHPUnit): documented event ids == catalogue ids;
+      documented `openregister.*` node ids == registry ids; `README.md`
+      links `flows.md`. Positive control: the test fails when an id is
+      removed from the doc.
+- [ ] Every behaviour claim spot-checked against the live dev instance
+      while writing; each mismatch filed as an issue and the doc worded to
+      the shipped behaviour.
+
+## Acceptance criteria
+
+- A flow author can build, trigger, approve, inspect, retry and share a
+  flow using only these docs.
+- No page in `docs/features/` presents an external tool as the native
+  automation path.
+- The doc-lint test guards the two enumerations against drift.
+
+## Quality checklist
+
+- All content in English (fleet rule); node/config identifiers verbatim
+  from code.
+- References ADR-031, ADR-065, ADR-094 by their actual titles.
+- No PHP changes in this change; issues filed for gaps found while writing.

--- a/openspec/changes/flow-messaging-nodes/.openspec.yaml
+++ b/openspec/changes/flow-messaging-nodes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/flow-messaging-nodes/design.md
+++ b/openspec/changes/flow-messaging-nodes/design.md
@@ -1,0 +1,78 @@
+# Design: flow-messaging-nodes
+
+## Decision 1: extract call-shared channel units, do not call the dispatcher
+
+Two ways to reuse `AnnotationNotificationDispatcher`:
+
+1. **Call the dispatcher with a synthetic annotation.** The flow node
+   fabricates an `x-openregister-notifications` spec at run time and feeds
+   it through the declarative pipeline. Rejected: the dispatcher's pipeline
+   is event-shaped (coalescing, digest windows, schema-rule evaluation are
+   all about event streams), and a synthetic annotation would drag an
+   orchestration send through machinery built for a different question —
+   plus every future dispatcher change would silently change flow-send
+   behaviour through a path nobody can see on the canvas.
+2. **Extract the per-channel SEND units** (the nc-notification push +
+   web-push ride-along, the mail composition/handoff, the Talk post) and the
+   recipient resolver into units both callers invoke (chosen). The
+   dispatcher keeps its pipeline and calls the units at the end; the flow's
+   `FlowMessagingService` calls the same units directly. What is shared is
+   exactly what must not fork — channel mechanics, recipient resolution,
+   rate limiting, kill switches, templating. What is NOT shared is the
+   pipeline that decides WHETHER to send, because the two subsystems answer
+   that question differently by design.
+
+The refactor is behaviour-preserving for the declarative path and is guarded
+by the existing dispatcher tests plus the "same send from both callers"
+equivalence scenario.
+
+## Decision 2: shared rate-limit budget, separate kill switches
+
+The rate limiter bounds "how much this instance messages this person". Two
+parallel budgets would let a flow double every recipient's ceiling — so the
+buckets are shared. Kill switches cut the other way: the reason to pull a
+switch is a runaway SOURCE, and an operator killing a misbehaving flow
+should not silence case-update notifications for the whole instance. So:
+existing subsystem switches apply to everything (they guard the machinery),
+and the flow side needs NO new switch — a runaway sending flow is stopped
+with the levers that already exist there: the flow's own `enabled` flag,
+or the instance flow kill switch when it is many flows at once. Neither
+touches the declarative subsystem, which is exactly the independence an
+operator needs. A new config key would be a third lever duplicating the
+first two (per product-owner decision 2026-08-18: no app-config switch
+for flow messaging).
+
+## Decision 3: acting user, and what happens without one
+
+Sends are attributed to the run's acting user: replies have an addressee,
+audits have an actor, and Talk messages appear from a person who is actually
+in the conversation. A run without a resolvable acting user (e.g. a
+schedule-triggered flow whose owner was deleted) FAILS the step rather than
+falling back to a system identity — the fallback would be an anonymous
+messenger created by an edge case, exactly how "the owner lookup runs as
+Anonymous" class bugs are born. The failure names the missing actor.
+
+Talk specifics: posting as the acting user requires that user to be a
+participant of the target conversation. The node treats "not a participant"
+as a step failure with that reason — it does NOT auto-join the user into a
+conversation, which would be a privacy-relevant side effect performed by a
+messaging convenience.
+
+## Decision 4: three nodes, not one "send" node with a channel picker
+
+A single `openregister.send` with `channel: email|talk|notification` was
+considered and rejected. The three differ in required config shape (subject
+vs conversation token vs title), in failure modes, and in form layout; one
+node would be a union type whose form shows and hides fields by channel —
+a modal pretending to be three modals. Three nodes keep each form flat,
+each `configKeys()` honest, and the palette self-explanatory. The cost —
+three registrations instead of one — is where the cost belongs.
+
+## Recipient resolution shape
+
+Recipients accept either a literal list (user/group ids, the form's select)
+or a template resolving a field on the item (e.g. `{{ item.assignee }}`),
+because the person to tell is usually ON the case object. Resolution reuses
+the notification subsystem's recipient resolver (groups expanded, unknown
+ids reported per recipient in the run log). The recipient bound is applied
+AFTER expansion — bounding the resolved humans, not the config entries.

--- a/openspec/changes/flow-messaging-nodes/proposal.md
+++ b/openspec/changes/flow-messaging-nodes/proposal.md
@@ -1,0 +1,99 @@
+---
+kind: code
+---
+
+# Proposal: flow-messaging-nodes
+
+## Summary
+
+Give flows the ability to send: three new step nodes —
+`openregister.send-notification` (Nextcloud notification),
+`openregister.send-email`, and `openregister.send-talk-message` — implemented
+as thin orchestration-time invokers of the EXISTING ADR-031 notification
+subsystem's channel machinery. A flow gains "tell a person", it does not gain
+a second messaging stack.
+
+## Why
+
+Today the two subsystems cannot meet:
+
+- **Notifications notify.** `x-openregister-notifications` (ADR-031) is
+  declarative and event-driven: a schema annotation says "when an object of
+  this schema changes, tell these people over these channels". Channels
+  `nc-notification`, `email`, `activity`, `webhook`, `talk`, `web-push` are
+  implemented in `AnnotationNotificationDispatcher`, with recipient
+  resolution, preference filtering, delivery windows, coalescing and rate
+  limiting around it.
+- **Flows orchestrate.** The engine can read, write, route, wait for a
+  signal, call any API through OpenConnector (ADR-094) — and cannot send
+  anything. A flow that reaches "now tell the requester their case moved"
+  has no node for it.
+
+The gap is real in every approval-shaped flow: `openregister.await-signal`
+suspends a run until someone answers, but nothing tells that someone they
+are being waited on. Authors work around it with webhook contortions or by
+abusing an object write to fire a schema notification — an orchestration
+step wearing a declarative trigger's clothes, invisible in the flow's own
+run log.
+
+The wrong fix is a flow-owned mailer. The notification subsystem already
+solved templating, recipient resolution, rate limiting, kill switches, and
+per-user channel preferences; a second implementation of any of those is a
+place for the two to disagree — precisely the duplication ADR-065 exists to
+end for engines and ADR-031 for business logic.
+
+## What Changes
+
+- **Three step nodes** in `lib/Service/Flow/Nodes/`, registered like every
+  other built-in, each implementing `IFlowNodeConfigForm`
+  (`flow-node-config-forms` sets that floor):
+  - `openregister.send-notification` — recipients (users/groups or a field
+    on the item), title/message templates;
+  - `openregister.send-email` — recipients, subject/body templates;
+  - `openregister.send-talk-message` — Talk conversation token or lookup,
+    message template.
+- **One shared invoker, not three senders.** A `FlowMessagingService`
+  bridges the node call onto the SAME channel senders, recipient resolver,
+  `RateLimiter`, and kill-switch checks the annotation dispatcher uses —
+  refactoring `AnnotationNotificationDispatcher`'s per-channel send paths
+  into call-shared units where needed, never copying them.
+- **Templating is the notification dialect's**, applied to the flow item —
+  one placeholder syntax for a body whether it is declared on a schema or
+  on a node.
+- **Attribution and guardrails**: sends run as the flow run's acting user
+  and are recorded in the run log per recipient/channel outcome; the
+  notification rate limiter counts flow sends in the same buckets; the
+  subsystem kill switches silence flow sends too; a per-step recipient
+  bound refuses configuration-sized mistakes before they become mail floods.
+
+## What does NOT change
+
+- The declarative subsystem. `x-openregister-notifications` remains the way
+  to say "whenever X happens, notify Y" — the boundary statement stands:
+  **notifications notify; flows orchestrate.** A flow node is for a send at
+  a POINT IN A PROCESS, where "when" is the marking, not an event.
+- The channel set. No new channels; `activity`, `webhook` and `web-push` are
+  NOT exposed as flow nodes — activity is an audit surface not a message,
+  webhooks are OpenConnector's job (ADR-094), web-push rides along with
+  `nc-notification` exactly as it does for the dispatcher.
+- Notification preferences semantics: a user who turned a channel off stays
+  not-messaged on it, flow or no flow.
+
+## Impact
+
+- **Affected specs**: new capability `flow-messaging-nodes`; `flow-engine`
+  untouched (the nodes are ordinary registered steps)
+- **Affected code**: new nodes + `FlowMessagingService`;
+  `AnnotationNotificationDispatcher` refactored to share its channel send
+  units; `FlowNodeRegistrationListener` registers the three types
+- **Affected apps**: consumers gain the nodes through the shared palette;
+  hermiq's sequencer can finally announce its own failures
+- **ADRs**: ADR-031 (subsystem reused, dialect untouched), ADR-065 (nodes
+  join the single engine), ADR-094 (webhook/API sends stay with
+  OpenConnector sources — explicitly not duplicated here)
+
+## Capabilities
+
+### New Capabilities
+- `flow-messaging-nodes` — send-notification, send-email and
+  send-talk-message step nodes reusing the ADR-031 channel machinery

--- a/openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md
+++ b/openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md
@@ -1,0 +1,172 @@
+## ADDED Requirements
+
+### Requirement: Flows send through the notification subsystem, never beside it
+
+The engine SHALL provide three step node types —
+`openregister.send-notification`, `openregister.send-email` and
+`openregister.send-talk-message` — registered through
+`RegisterFlowNodesEvent` like every other built-in, each declaring a config
+form.
+
+Every send SHALL go through the SAME channel machinery the ADR-031
+declarative subsystem uses: the channel senders behind
+`AnnotationNotificationDispatcher` (`nc-notification`, `email`, `talk`), its
+recipient resolution, and its guardrails. The flow node is an
+orchestration-time INVOKER of those units; it SHALL NOT carry its own mailer,
+its own Talk client, or its own recipient resolver. One channel
+implementation, two callers — a schema annotation answering "when X happens"
+and a flow node answering "at this point in the process".
+
+Message templating SHALL use the notification dialect's placeholder syntax,
+evaluated against the flow item, so a body reads the same whether it is
+declared on a schema or on a node. The node SHALL NOT introduce a second
+placeholder syntax for the same job.
+
+A user's notification channel preferences SHALL be honoured for flow sends
+on the per-recipient channels exactly as for declarative ones: a flow does
+not out-rank the recipient's own settings.
+
+#### Scenario: A flow node and a schema annotation produce the same send
+
+- **GIVEN** a schema annotation and a send-notification node configured with
+  the same recipients and the same template
+- **WHEN** each fires against the same object
+- **THEN** the delivered notifications MUST be identical in channel, body and
+  recipients
+- **AND** both MUST have passed through the same channel sender
+- @e2e exclude covered by a unit test dispatching both paths against a
+  recorded sender double
+
+#### Scenario: A recipient's channel preference is respected
+
+- **GIVEN** a user who disabled the email channel in their notification
+  preferences
+- **WHEN** a send-email node lists that user as a recipient
+- **THEN** no email MUST be sent to them
+- **AND** the run log MUST record the recipient as skipped by preference,
+  not as failed
+- @e2e exclude covered by FlowMessagingService unit tests
+
+#### Scenario: Items flow through unchanged
+
+- **GIVEN** a send node between two other steps
+- **WHEN** it executes with three items
+- **THEN** it MUST return the three items unchanged for downstream steps —
+  sending is a side effect, not a transformation
+- @e2e exclude covered by the node's unit tests
+
+### Requirement: Flow sends are attributed, logged and bounded
+
+A send performed by a flow SHALL be attributed to the flow run's ACTING user
+— the user the run executes as — never to a system or service identity that
+would make the message unanswerable and the audit trail anonymous.
+
+The run log SHALL record, per send step: the resolved recipient count, and
+per channel the delivered / skipped-by-preference / failed outcomes, bounded
+by the run log's existing sampling rule. It SHALL NOT record message bodies
+beyond the log's bounded sample — a mail archive is not what a run log is
+for.
+
+Guardrails SHALL apply in this order, each independently sufficient to stop
+a send:
+
+- **Kill switches.** The notification subsystem's kill switches SHALL
+  silence flow sends exactly as they silence declarative ones. No new
+  switch SHALL be introduced for flow-originated sends: the flow side
+  already has its own stop levers — the per-flow `enabled` flag and the
+  instance flow kill switch, checked before every hop — and each side's
+  levers SHALL keep working without silencing the other (killing a flow
+  never silences declarative notifications, and vice versa).
+- **Rate limiting.** Flow sends SHALL count against the SAME `RateLimiter`
+  buckets as declarative sends — a shared budget, because the abuse being
+  bounded is "how much this instance messages this person", not "per
+  subsystem". A rate-limited send is recorded as such in the run log.
+- **Recipient bound.** A single step execution SHALL refuse to send to more
+  than a configured recipient bound (default modest, app-config raisable).
+  Refusal follows the step's `onError` policy and names the count — a
+  recipient template that expands to the whole instance is a configuration
+  error to surface, not a broadcast to perform.
+
+A send failure (a bounced SMTP handoff, an unknown Talk conversation) SHALL
+be a step failure routed through the step's `onError` policy like any other
+node's failure. It SHALL NOT be silently swallowed: a flow that reports
+COMPLETED with zero of its messages delivered is the silent failure this
+engine's specs consistently refuse.
+
+#### Scenario: The subsystem kill switch reaches flow sends
+
+- **GIVEN** a notification-subsystem kill switch set
+- **WHEN** a run reaches a send node
+- **THEN** no message MUST leave on the silenced channel
+- **AND** the run log MUST record the step as skipped by kill switch
+
+#### Scenario: Killing a flow does not silence declarative notifications
+
+- **GIVEN** the instance flow kill switch set (or the sending flow disabled)
+- **WHEN** an object event fires a declarative `x-openregister-notifications` rule
+- **THEN** the declarative notification MUST still be delivered
+- **AND** no flow send MUST occur, because the run never reaches its hop
+- @e2e exclude covered by FlowMessagingService unit tests
+
+#### Scenario: The budget is shared, not parallel
+
+- **GIVEN** a recipient whose rate-limit bucket the declarative subsystem
+  has already filled this window
+- **WHEN** a flow send addresses the same recipient in the same window
+- **THEN** the flow send MUST be rate-limited
+- **AND** the reason MUST be recorded on the run log entry
+- @e2e exclude covered by RateLimiter integration tests
+
+#### Scenario: An exploding recipient list is refused, not sent
+
+- **GIVEN** a send node whose recipient field resolves to more users than
+  the recipient bound
+- **WHEN** the step executes
+- **THEN** no message MUST be sent
+- **AND** the failure MUST name the resolved count and the bound, and follow
+  the step's `onError` policy
+- @e2e exclude covered by the node's unit tests
+
+#### Scenario: A send is attributed to the acting user
+
+- **GIVEN** a run executing as user `alice`
+- **WHEN** its send-talk-message node posts to a conversation
+- **THEN** the message MUST be attributed to `alice`
+- **AND** a run with no resolvable acting user MUST fail the step rather
+  than send anonymously
+- @e2e exclude covered by FlowMessagingService unit tests
+
+### Requirement: The messaging boundary between the two subsystems is stated and enforced
+
+The declarative subsystem answers "WHENEVER this happens, notify these
+people"; a flow send node answers "AT THIS POINT in this process, tell these
+people". The engine SHALL NOT blur that line:
+
+- the flow nodes SHALL NOT accept a schema/event subscription — a node that
+  fires on events is a trigger, and triggering is already spec'd;
+- the declarative dialect SHALL NOT gain an "invoke this flow node" clause;
+  a schema that wants a process reaction declares a flow trigger;
+- `activity`, `webhook` and `web-push` SHALL NOT be flow node types:
+  activity is an audit surface, outbound HTTP is OpenConnector's job
+  (ADR-094 — `openconnector.source-call` against a configured source), and
+  web-push is a delivery detail of `nc-notification`, riding along exactly
+  as it does for the declarative dispatcher.
+
+#### Scenario: Outbound HTTP stays with OpenConnector
+
+- **GIVEN** an author wanting a flow to POST JSON to an external endpoint
+- **WHEN** they search the palette
+- **THEN** no `openregister.send-webhook` node MUST exist
+- **AND** the documented path is an `openconnector.source-call` node against
+  a configured source
+- @e2e exclude a palette composition assertion — covered by
+  FlowNodeRegistryTest
+
+#### Scenario: Web-push rides along with a notification send
+
+- **GIVEN** a send-notification node addressing a user with an active
+  web-push subscription
+- **WHEN** the step executes
+- **THEN** the web-push delivery MUST follow the nc-notification send under
+  the dispatcher's existing rules, with no flow-side configuration
+- @e2e exclude covered by FlowMessagingService unit tests

--- a/openspec/changes/flow-messaging-nodes/tasks.md
+++ b/openspec/changes/flow-messaging-nodes/tasks.md
@@ -1,0 +1,81 @@
+# Tasks: flow-messaging-nodes
+
+## Extraction (behaviour-preserving refactor first)
+
+- [ ] Extract the per-channel send units from
+      `AnnotationNotificationDispatcher` — nc-notification (+ web-push
+      ride-along), email composition/handoff, Talk post — and the recipient
+      resolver into injectable units under `lib/Service/Notification/`;
+      dispatcher re-wired onto them with its existing tests green and
+      unchanged.
+- [ ] Confirm `RateLimiter` bucket keys are caller-agnostic (recipient +
+      channel + window), so both callers share one budget by construction.
+
+## FlowMessagingService
+
+- [ ] `FlowMessagingService` invoking the extracted units; applies, in
+      order: subsystem kill switches → preference filter (per-recipient
+      channels) → recipient bound (post-expansion, default from app config)
+      → rate limiter → send. No flow-messaging-specific switch: stopping a
+      sending flow is the per-flow `enabled` flag or the instance flow kill
+      switch, both of which halt the run before this service is reached.
+- [ ] Acting-user resolution from the run; no resolvable actor = step
+      failure naming the missing actor (never a system-identity fallback).
+- [ ] Templating through the notification dialect's placeholder evaluation
+      against the flow item — reuse the dialect's evaluator, add none.
+- [ ] Per-recipient/channel outcome collection (delivered / skipped-by-
+      preference / skipped-by-kill-switch / rate-limited / failed) returned
+      for the run log, bounded by the log's sampling rule.
+
+## Nodes
+
+- [ ] `SendNotificationNode` (`openregister.send-notification`) — recipients
+      (literal or item-field template), title + message templates;
+      `validateConfig` refuses an empty message and an empty recipient
+      config; `configForm()` per the flow-node-config-forms floor.
+- [ ] `SendEmailNode` (`openregister.send-email`) — recipients, subject +
+      body templates; same validation and form obligations.
+- [ ] `SendTalkMessageNode` (`openregister.send-talk-message`) —
+      conversation token or item-field lookup, message template;
+      "acting user not a participant" is a step failure, never an auto-join.
+- [ ] All three: items returned unchanged; failures routed through the
+      step's `onError` policy; registration in
+      `FlowNodeRegistrationListener`.
+
+## Tests
+
+- [ ] Equivalence test: schema annotation vs flow node, same recipients and
+      template, same object — identical deliveries through a recorded
+      sender double.
+- [ ] Guardrail tests, each with a positive control (the send that DOES go
+      out when the guard is off): flow kill switch (and declarative path
+      unaffected by it), subsystem kill switches, shared rate-limit bucket
+      (declarative fill blocks flow send), recipient bound, preference skip.
+- [ ] Attribution tests: acting user carried onto each channel; missing
+      actor fails the step.
+- [ ] Palette test: exactly these three messaging types; no
+      `openregister.send-webhook` (boundary with ADR-094).
+
+## Documentation
+
+- [ ] Feed the three nodes and the boundary statement ("notifications
+      notify; flows orchestrate; API calls via OpenConnector sources") into
+      `flow-engine-docs`' steps catalogue — one sentence each here, the
+      prose lives there.
+
+## Acceptance criteria
+
+- No second mailer, Talk client, recipient resolver or template syntax
+  exists anywhere under `lib/Service/Flow/`.
+- Every guardrail is enforced in code with a test that can fail, not
+  declared in help text.
+- A COMPLETED run never hides an undelivered message: every non-delivery is
+  in the run log with its reason.
+
+## Quality checklist
+
+- `composer check:strict` passes (PHPCS, PHPMD, Psalm, PHPStan).
+- `@spec` annotations point at
+  `openspec/specs/flow-messaging-nodes/spec.md` anchors.
+- Depends on `flow-node-config-forms` for the form floor (soft — forms can
+  land with the nodes either way); references ADR-031, ADR-065, ADR-094.

--- a/openspec/changes/flow-node-config-forms/.openspec.yaml
+++ b/openspec/changes/flow-node-config-forms/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/flow-node-config-forms/design.md
+++ b/openspec/changes/flow-node-config-forms/design.md
@@ -1,0 +1,67 @@
+# Design: flow-node-config-forms
+
+## Why declaration-only, and where the two real decisions are
+
+Eighteen of the nineteen implementations are mechanical: read `configKeys()`,
+describe each key with the existing field vocabulary. The rendering path is
+proven end to end by `AwaitSignalNode` — `configForm()` → palette →
+`CnFlowSidebar` renders fields. Two places need actual decisions.
+
+## Decision 1: keyed structures get PARTIAL forms, not new field types
+
+`SwitchNode` and `RouterNode` carry branch tables — a keyed structure whose
+keys are the author's own branch names. The field vocabulary (`text`,
+`textarea`, `number`, `boolean`, `select`) cannot describe "a map of
+expressions", and this change does NOT extend it.
+
+Options considered:
+
+1. **Add a `table`/`keyValue` field type.** Rejected here: it changes the
+   editor contract in nextcloud-vue, every consuming app's bundle, and the
+   interface's documented vocabulary — for two nodes. If contributed nodes
+   later demonstrate the same need, that is its own change with its own
+   fleet-wide review.
+2. **Serialise the table into a `textarea`.** Rejected: a JSON blob inside a
+   form field is the raw pane with fewer affordances and a second place to
+   make parse errors.
+3. **Partial form** (chosen): the scalar keys get fields; the branch table
+   stays in the JSON pane, and the form's help text says so explicitly. The
+   interface documents exactly this: "a partial form is more useful than
+   none, and it lets a node describe the two fields worth guiding and leave
+   the rest."
+
+The round-trip requirement is what makes option 3 safe: a partial form that
+dropped unnamed keys would destroy the branch table on every form edit. That
+is why the round-trip invariant is spec'd in the same change as the forms
+that depend on it, not left as editor folklore.
+
+## Decision 2: the empty form is an explicit declaration, not an absence
+
+`TriggerManualNode` accepts no configuration keys at all (spec: "it MUST
+accept no configuration keys"). Today the editor cannot distinguish "this
+node declared nothing" (fall back to raw JSON) from "this node declared it
+needs nothing". Both render as a JSON pane over `{}` — the first correctly,
+the second confusingly.
+
+Implementing the interface with an empty array makes the second case
+expressible: the palette entry carries `form: []`, and the editor renders a
+"no configuration" state. The alternative — a separate marker interface — was
+rejected as a second way to say something the existing return type already
+says.
+
+Consequence for the sweep test: the assertion is "carries a form
+DECLARATION", i.e. the interface is implemented, not "carries at least one
+field". An empty declaration passes; a missing one fails.
+
+## What deliberately does not happen
+
+- **No form registry, no central table.** Each node describes itself; the
+  engine's only role is shipping the declaration on the palette entry it
+  already builds. This is the architecture the spec requirement mandates for
+  contributed nodes, applied uniformly to built-ins.
+- **No validation moved into forms.** `validateConfig()` stays the authority;
+  a form's `required` flag is a hint to the editor, not a second validator
+  that could drift from the node's real refusal.
+- **No obligation on openconnector/hermiq in this change.** The interface
+  crossing repo boundaries is the point of its design; the obligation cannot
+  cross in an openregister change. Follow-ups are filed in those repos.

--- a/openspec/changes/flow-node-config-forms/proposal.md
+++ b/openspec/changes/flow-node-config-forms/proposal.md
@@ -1,0 +1,97 @@
+---
+kind: code
+---
+
+# Proposal: flow-node-config-forms
+
+## Summary
+
+Give every built-in flow node a declarative configuration form. The contract
+already exists — `IFlowNodeConfigForm` is defined, spec'd ("A node type declares
+its own form, and its own run-log actions") and rendered by the editor — but
+exactly ONE of the nineteen built-in types implements it: `AwaitSignalNode`.
+Every other node an author drops on the canvas is configured through the
+raw "Configuration (JSON)" textarea, guessing keys against documentation that
+does not exist (see `flow-engine-docs`).
+
+This change implements `configForm()` on all sixteen step/end types and all
+three trigger types, and pins the editor's contract with two invariants: the
+JSON pane remains available as the honest fallback, and switching between the
+form and the JSON pane round-trips the config losslessly.
+
+## Why
+
+The form interface was designed for contributed nodes — an app that ships a
+node ships its form, so the engine never hard-codes another app's keys. That
+design is right and is not touched here. But it was landed with only the one
+node that motivated it (`AwaitSignalNode`, whose approval question is authored
+by non-technical operators), leaving the engine's OWN nodes on the raw pane.
+
+The cost is concrete:
+
+- `openregister.trigger-object` refuses to default `event`, `register` or
+  `schema` — correctly, per the flow-engine spec ("A trigger with no subject is
+  refused rather than defaulted"). An author typing JSON has to know those three
+  key names and the sixteen-event vocabulary (`EventCatalogService::CATALOG`)
+  by heart. A select fed from the catalogue makes the refusal unreachable
+  instead of merely explained.
+- `openregister.switch` and `openregister.route` configs carry per-branch
+  expressions; a typo in a branch key silently routes nothing, and the JSON
+  pane offers no hint which keys are read. `IFlowNodeConfigKeys` already knows;
+  the knowledge just never reaches the author.
+- The one node WITH a form proves the rendering path works end to end
+  (`CnFlowSidebar` in nextcloud-vue renders the declared fields today), so this
+  change is pure declaration work plus two guard-rail behaviours — no new
+  editor architecture.
+
+## What Changes
+
+- **All 19 built-in node types implement `IFlowNodeConfigForm`.** Sixteen
+  steps/ends (`openregister.object-read`, `object-write`, `set-fields`, `map`,
+  `filter`, `switch`, `route`, `merge`, `explode`, `iterate`, `batch`,
+  `flow-state`, `wait`, `sub-flow`, `await-signal` (exists), `end`) and three
+  triggers (`trigger-object`, `trigger-schedule`, `trigger-manual` — the last
+  declares an EMPTY form, which is itself information: "this node takes no
+  configuration" rendered as such, not as an empty JSON object to puzzle over).
+- **Every field maps to a key the node reads.** The field list is validated
+  against `configKeys()` in a unit test per node — a form field over a key the
+  node ignores looks like it works and changes nothing.
+- **Select fields resolve from live catalogues via `optionsFrom`** — the event
+  list from `EventCatalogService`, registers/schemas from their stores, flows
+  (for `sub-flow`) from the flow store. Never inline snapshots.
+- **The JSON pane stays, and round-trips.** Editing in the form then opening
+  the JSON tab shows exactly the config the form wrote; keys the form does not
+  cover survive a form edit untouched. This is what makes a partial form safe.
+- **Contributed nodes are explicitly out of scope.** openconnector's nodes
+  (`openconnector.source-call` et al., ADR-094) and hermiq's nodes get their
+  forms in their own repos, via the same interface — that is the interface's
+  entire point. This change files no requirement against those repos; it only
+  proves the pattern at full breadth so those repos have nineteen examples.
+
+## What does NOT change
+
+- `IFlowNodeConfigForm` itself. The field vocabulary (`key`, `label`, `type`,
+  `help`, `required`, `optionsFrom`) is sufficient for all nineteen nodes; no
+  new field types are needed, and none are added speculatively.
+- The editor's rendering (`CnFlowSidebar`). It already renders declared forms;
+  the round-trip requirement is a behaviour it must keep, not one it gains.
+- The raw-JSON pane. It is the documented fallback and the power-user surface.
+
+## Impact
+
+- **Affected specs**: `flow-engine` (the form requirement gains built-in
+  coverage and the round-trip invariant)
+- **Affected code**: all 18 not-yet-implementing classes in
+  `lib/Service/Flow/Nodes/`, their unit tests; `FlowNodeRegistry` palette
+  output already ships forms and needs no change
+- **Affected apps**: none directly. openconnector and hermiq inherit worked
+  examples, not obligations — tracked as follow-ups in their own repos.
+- **ADRs**: ADR-065 (the single engine whose editor this serves) — consistent,
+  no change needed.
+
+## Capabilities
+
+### Modified Capabilities
+- `flow-engine` — the node-form requirement is strengthened from "a node MAY
+  declare a form" to "every built-in node DOES", and the form/JSON round-trip
+  becomes a stated invariant

--- a/openspec/changes/flow-node-config-forms/specs/flow-engine/spec.md
+++ b/openspec/changes/flow-node-config-forms/specs/flow-engine/spec.md
@@ -1,0 +1,146 @@
+## MODIFIED Requirements
+
+### Requirement: A node type declares its own form, and its own run-log actions
+
+A node's behaviour is contributed by an app; so is everything an operator needs
+in order to configure it and to understand what it did. The engine SHALL let a
+node type declare both, through optional interfaces alongside `IFlowNode`:
+
+- **A config form.** A declarative field list — key, label, type, help, and
+  where a value comes from (a literal, or a lookup the providing app resolves).
+  A type that declares none keeps the raw-JSON pane, which is the honest
+  fallback rather than a typed pane over guessed keys.
+- **Run-log actions.** Given one log entry, the links that entry earns: for an
+  openconnector call node, the contract or the source it used; for an agent
+  node, the session it created. Each is a label, an href and an icon.
+
+The engine SHALL NOT hard-code any app's fields or links. The reason is the one
+the catalogue already proves: `RegisterFlowNodesEvent` exists so an app can add
+a node without OpenRegister knowing about it, and a form registry that only
+OpenRegister could extend would put the form of every contributed node back
+into the engine.
+
+A form declaration SHALL be data, not markup. A node that shipped a component
+would tie the engine's rendering to that app's build, and a canvas rendered in
+one app would be asked to mount a component from another.
+
+Actions SHALL be derived from a log entry rather than stored on it. An href
+frozen into a log at write time is a link that rots when the target moves, and
+a run log is kept for months.
+
+**Every built-in node type SHALL implement `IFlowNodeConfigForm`.** The
+optional interface stays optional for CONTRIBUTED types — an app may ship a
+node before its form, and the raw pane covers the gap — but the engine's own
+nineteen types set the floor. A built-in node on the raw pane is not a
+fallback, it is the engine declining to describe keys it defined itself.
+
+Every declared field SHALL name a key the node actually reads — one declared
+through `IFlowNodeConfigKeys` — because a field over an ignored key looks like
+it works and changes nothing. A node whose configuration is deliberately empty
+(`openregister.trigger-manual`) SHALL declare an EMPTY form, so the editor can
+say "this node takes no configuration" instead of offering an empty JSON
+object to puzzle over.
+
+A field whose value set is a live catalogue — the event list, registers,
+schemas, flows — SHALL use `optionsFrom` with a reference the engine resolves
+at render time, never an inline snapshot of today's list.
+
+#### Scenario: A node type with no form declaration still configures
+
+- **GIVEN** a CONTRIBUTED node type that declares no config form
+- **WHEN** an operator edits a node of that type
+- **THEN** the raw-JSON configuration pane MUST be offered
+- @e2e exclude covered by the node editor's component tests
+
+#### Scenario: A contributed node's form comes from its own app
+
+- **GIVEN** an app contributing a node type that declares a form
+- **WHEN** the editor renders that node's configuration
+- **THEN** the fields MUST come from the declaration, and the engine MUST NOT
+  carry any knowledge of that app's keys
+- @e2e exclude covered by the registry tests
+
+#### Scenario: A log entry offers the links its node earns
+
+- **GIVEN** a run log entry written by an openconnector call node
+- **WHEN** the entry is displayed
+- **THEN** the actions that node type declares MUST be offered against it
+- **AND** each action's href MUST be resolved at display time, not read from
+  the stored entry
+- @e2e exclude covered by the run-log component tests
+
+#### Scenario: Every built-in type declares a form
+
+- **GIVEN** the palette built from the engine's own registrations
+- **WHEN** each entry whose type id starts with `openregister.` is inspected
+- **THEN** every one MUST carry a form declaration
+- **AND** the assertion enumerates the registry, not a hand-kept list, so a
+  node added later without a form turns this red rather than silently joining
+  the raw-pane set
+- @e2e exclude engine-internal registry sweep — covered by `FlowNodeRegistryTest`
+
+#### Scenario: A form field maps to a key the node reads
+
+- **GIVEN** any built-in node's form declaration
+- **WHEN** its fields are compared against that node's `configKeys()`
+- **THEN** every field's `key` MUST appear in `configKeys()`
+- @e2e exclude engine-internal — covered by a per-node unit test
+
+#### Scenario: An event select is fed by the live catalogue
+
+- **GIVEN** the form for `openregister.trigger-object`
+- **WHEN** its `event` field is rendered
+- **THEN** the options MUST come from the event catalogue via `optionsFrom`
+- **AND** an event added to `EventCatalogService` MUST appear without the
+  node's declaration changing
+- @e2e exclude covered by the editor's component tests with a stubbed catalogue
+
+## ADDED Requirements
+
+### Requirement: The form pane and the JSON pane are two views of one config
+
+The editor SHALL keep the raw-JSON pane available for every node, including
+nodes with a complete form, and the two panes SHALL round-trip losslessly:
+
+- a value written through the form SHALL appear in the JSON pane exactly as
+  the node will read it;
+- a key present in the config but not covered by a form field SHALL survive a
+  form edit unchanged — a partial form edits what it names and touches nothing
+  else;
+- a value written through the JSON pane SHALL populate the corresponding form
+  field on switching back.
+
+This is what makes a partial form safe to ship and the JSON pane an honest
+fallback rather than a divergent second editor. A form that drops unknown keys
+on save would make "improve one node's form" a data-destroying change for
+every flow already using that node's other keys.
+
+The JSON pane SHALL validate that its content is a JSON object before it is
+applied, and refuse otherwise, naming the parse error — a malformed config
+saved raw would surface later as a preflight failure attributed to the node,
+not to the edit that caused it.
+
+#### Scenario: A key outside the form survives a form edit
+
+- **GIVEN** a node whose config carries `{"page": 3}` while its form declares
+  no `page` field
+- **WHEN** the operator changes a form field and saves
+- **THEN** the stored config MUST still carry `"page": 3` unchanged
+- @e2e exclude covered by the node editor's component tests
+
+#### Scenario: The two panes agree
+
+- **GIVEN** an operator who sets a field through the form
+- **WHEN** they switch to the JSON pane
+- **THEN** it MUST show the value the form wrote
+- **AND** editing it there and switching back MUST show the new value in the
+  form field
+- @e2e exclude covered by the node editor's component tests
+
+#### Scenario: Malformed JSON is refused at the pane, not at preflight
+
+- **GIVEN** the JSON pane containing text that does not parse as an object
+- **WHEN** the operator applies it
+- **THEN** the pane MUST refuse, naming the parse error
+- **AND** the node's stored config MUST be unchanged
+- @e2e exclude covered by the node editor's component tests

--- a/openspec/changes/flow-node-config-forms/tasks.md
+++ b/openspec/changes/flow-node-config-forms/tasks.md
@@ -1,0 +1,69 @@
+# Tasks: flow-node-config-forms
+
+## Trigger nodes
+
+- [ ] `TriggerObjectNode::configForm()` — `event` as a select fed from
+      `EventCatalogService` via `optionsFrom` (never an inline copy of the
+      sixteen events); `register` and `schema` as selects fed from their
+      stores; all three `required`, with help text explaining WHY there is no
+      "any" option (the spec's single-subject rule).
+- [ ] `TriggerScheduleNode::configForm()` — `cron` as text, `required`, help
+      naming the five-field format and that semantics are the scheduler's
+      question.
+- [ ] `TriggerManualNode::configForm()` — an EMPTY array, deliberately: the
+      editor renders "this node takes no configuration".
+
+## Step and end nodes (15 remaining — AwaitSignalNode already implements)
+
+- [ ] `ObjectReadNode` / `ObjectWriteNode` — register/schema selects,
+      filter/data fields; mark templated fields' help with the value-template
+      syntax (`FlowValueTemplate`).
+- [ ] `SetFieldsNode`, `MapNode`, `FilterNode` — expression/field-list fields
+      with help pointing at the expression dialect (`FlowExpression`).
+- [ ] `SwitchNode`, `RouterNode` — branch/condition configuration; where the
+      shape is a keyed structure the form covers the scalar keys and the help
+      text says the branch table is edited in the JSON pane (partial form,
+      per the interface's own doc).
+- [ ] `MergeNode`, `ExplodeNode`, `IterateNode`, `LoopNode` (`openregister.batch`),
+      `FlowStateNode`, `WaitNode` — full forms; each key from `configKeys()`
+      either gets a field or is named in a code comment saying why not.
+- [ ] `SubFlowNode` — flow select fed from the flow store via `optionsFrom`.
+- [ ] `EndNode` — `error` boolean with help ("failing is an outcome, not the
+      absence of one").
+
+## Guard rails
+
+- [ ] Registry sweep test: every palette entry whose type id starts with
+      `openregister.` carries a non-null form declaration — enumerating the
+      registry, not a hand-kept list.
+- [ ] Per-node unit test: every declared field's `key` is in that node's
+      `configKeys()`; positive control with a deliberately bogus field proving
+      the assertion can fail.
+- [ ] Editor round-trip (nextcloud-vue, `CnFlowSidebar` component tests):
+      form → JSON shows the written value; JSON → form populates the field;
+      an un-covered key survives a form edit; malformed JSON is refused at the
+      pane naming the parse error. If any of these does not already hold,
+      the fix lands in nextcloud-vue as this change's dependency.
+- [ ] All labels and help strings through `IL10N` — they are shown to
+      operators (AwaitSignalNode is the pattern).
+
+## Out of scope (recorded, not tasked)
+
+- openconnector nodes (`openconnector.source-call` et al., ADR-094) and hermiq
+  nodes implement `IFlowNodeConfigForm` in their own repos. File follow-up
+  issues there referencing this change as the worked example; no requirement
+  in this repo's specs targets those apps.
+
+## Acceptance criteria
+
+- All 19 built-in types implement `IFlowNodeConfigForm`; the registry sweep
+  test proves it and fails on the next form-less built-in.
+- The JSON pane remains reachable for every node and round-trips losslessly.
+- No form field names a key its node does not read.
+
+## Quality checklist
+
+- `composer check:strict` passes (PHPCS, PHPMD, Psalm, PHPStan).
+- `@spec` annotations on the new `configForm()` methods target
+  `openspec/specs/flow-engine/spec.md#requirement-a-node-type-declares-its-own-form-and-its-own-run-log-actions`.
+- Tests run on the container's PHP, not the host.

--- a/openspec/changes/verwerkingsregister-i18n/.openspec.yaml
+++ b/openspec/changes/verwerkingsregister-i18n/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/verwerkingsregister-i18n/design.md
+++ b/openspec/changes/verwerkingsregister-i18n/design.md
@@ -1,0 +1,237 @@
+## Context
+
+`lib/Db/Verwerkingsactiviteit.php` + `lib/Db/VerwerkingsactiviteitMapper.php` back a dedicated
+Postgres table, `oc_openregister_verwerkingsactiviteiten` (created by
+`lib/Migration/Version1Date20260430160000.php`, no later altering migration), with 13 Dutch-named
+columns/properties plus a Dutch-valued `RECHTSGROND_VOCABULARY` enum constant. The table currently
+holds **7 real rows on the shared dev Postgres instance** (confirmed by direct query; the
+`rechtsgrond` values actually in use today are `wettelijke_verplichting` and `publieke_taak`, a
+strict subset of the 6 possible values). `STATUS_VOCABULARY` (`concept`/`published`/`archived`) is
+already English and is unaffected. The same Dutch identifiers propagate through
+`VerwerkingsactiviteitenController`, `AvgRetentionService`, `ProcessingLogService`,
+`appinfo/routes.php`, the operator-importable `lib/Resources/AvgSchemas/avg-bundle.json`, and the
+Vue admin UI. See proposal.md for the "why" (this repo's English-only rule and its narrow
+exemptions, neither of which applies here).
+
+This is a pure rename: no field changes type, validation, cardinality, or semantics. See
+proposal.md's "Bundled bugfix" note for the one intentional behavior change riding along with the
+rename (`ProcessingLogService::fallbackActivityUuid()`'s invalid `'public-task'` legal-basis value).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Rename every Dutch identifier this change's proposal lists (entity fields, enum constant + its
+  values, URL routes, `avg-bundle.json` `verwerker` schema) to English, in lockstep across DB
+  column, PHP property, getter/setter, JSON key, and frontend binding.
+- Preserve all 7 existing rows on the shared dev instance — no data loss, no destructive table
+  recreate.
+- Preserve the two carve-outs (VNG Verwerkingenlogging export field names; Art 30 PDF export's
+  Dutch column labels) exactly as Dutch.
+
+**Non-Goals:**
+- No new fields, no new validation rules, no new API behavior beyond the renamed surface.
+- No change to the `Verwerkingsactiviteit`/`VerwerkingsactiviteitenController` class names, the
+  `oc_openregister_verwerkingsactiviteiten` table name, or the `openregister_verwerkingsactiviteiten`
+  literal used by tests that target the table directly — only the table's *columns* are renamed.
+- No reconciliation of the pre-existing, unrelated drift between the large aspirational
+  `avg-verwerkingsregister` spec (which describes an unbuilt schema-based register, DPIA, and
+  consent modules) and the actual dedicated-table implementation. That drift predates this change
+  and is out of scope for an identifier-rename cleanup.
+- No rewrite of historically-persisted `ObjectEntity.deleted` JSON blobs that already contain the
+  old `bewaartermijn` key (see Decisions below).
+
+## Decisions
+
+### Full rename mapping
+
+**`Verwerkingsactiviteit` entity fields** (DB column ↔ PHP property ↔ getter/setter ↔ JSON key, all
+renamed together):
+
+| Old (Dutch) | New (English) | DB column old → new |
+|---|---|---|
+| `naam` | `name` | `naam` → `name` |
+| `beschrijving` | `description` | `beschrijving` → `description` |
+| `doelbinding` | `purpose` | `doelbinding` → `purpose` |
+| `rechtsgrond` | `legalBasis` | `rechtsgrond` → `legal_basis` |
+| `categorieenBetrokkenen` | `dataSubjectCategories` | `categorieen_betrokkenen` → `data_subject_categories` |
+| `categorieenPersoonsgegevens` | `personalDataCategories` | `categorieen_persoonsgegevens` → `personal_data_categories` |
+| `bewaartermijn` | `retentionPeriod` | `bewaartermijn` → `retention_period` |
+| `ontvangers` | `recipients` | `ontvangers` → `recipients` |
+| `doorgifteBuitenEu` | `internationalTransfers` | `doorgifte_buiten_eu` → `international_transfers` |
+| `technischeMaatregelen` | `technicalMeasures` | `technische_maatregelen` → `technical_measures` |
+| `organisatorischeMaatregelen` | `organisationalMeasures` | `organisatorische_maatregelen` → `organisational_measures` |
+| `verwerkingsverantwoordelijke` | `controller` | `verwerkingsverantwoordelijke` → `controller` |
+| `contactgegevensFg` | `dpoContactDetails` | `contactgegevens_fg` → `dpo_contact_details` |
+
+Unchanged (already English): `code`, `organisationId`, `status`, `uuid`, `created`, `updated`.
+
+**Enum constant + values:**
+
+| Old | New |
+|---|---|
+| `RECHTSGROND_VOCABULARY` (constant name) | `LEGAL_BASIS_VOCABULARY` |
+| `toestemming` | `consent` |
+| `overeenkomst` | `contract` |
+| `wettelijke_verplichting` | `legal_obligation` |
+| `vitaal_belang` | `vital_interests` |
+| `publieke_taak` | `public_task` |
+| `gerechtvaardigd_belang` | `legitimate_interest` |
+
+`STATUS_VOCABULARY` is already `['concept', 'published', 'archived']` — verified, no change.
+
+**URL routes** (`appinfo/routes.php`):
+
+| Old | New |
+|---|---|
+| `/api/avg/verwerkingsactiviteiten[/{id}]` | `/api/avg/processing-activities[/{id}]` |
+| `/api/avg/verantwoording` | `/api/avg/accountability` |
+
+**`avg-bundle.json` `verwerker` schema** (register `avg`) → renamed to `processor`:
+
+| Old | New |
+|---|---|
+| `verwerker` (schema slug/title) | `processor` |
+| `naam` | `name` |
+| `type` enum `anders` | `type` enum `other` (`saas`/`infra`/`support`/`consultancy` unchanged — already English/neutral) |
+| `kvk` | `chamberOfCommerceNumber` |
+| `vestiging` | `establishment` |
+| `vestiging.land` | `establishment.country` |
+| `vestiging.stad` | `establishment.city` |
+| `vestiging.adres` | `establishment.address` |
+| `vestiging.postcode` | `establishment.postalCode` |
+| `contactpersoon` | `contactPerson` |
+| `telefoon` | `phone` |
+| `verwerkersovereenkomstUrl` | `agreementUrl` |
+| `verwerkersovereenkomstDatum` | `agreementDate` |
+| `subVerwerkers` | `subProcessors` |
+| `subVerwerkers[].naam` | `subProcessors[].name` |
+| `subVerwerkers[].land` | `subProcessors[].country` |
+| `subVerwerkers[].doel` | `subProcessors[].purpose` |
+| `doorgifteBuitenEu` | `internationalTransfers` |
+| `doorgifteBuitenEu.ja` | `internationalTransfers.transferred` |
+| `doorgifteBuitenEu.landen` | `internationalTransfers.countries` |
+| `doorgifteBuitenEu.waarborgen` | `internationalTransfers.safeguards` |
+| `status` enum `concept`/`actief`/`beeindigd` | `status` enum `draft`/`active`/`terminated` |
+
+`email` is unchanged (already English). The `consent` and `dpia` schemas in the same bundle are
+**not** touched — out of scope, no Dutch identifiers of theirs were named in the proposal.
+
+### DB migration strategy: expand/contract, not destructive recreate
+
+Two migration files, both guarded by `hasColumn()`/idempotent, run in the same `occ upgrade` pass
+(this app upgrades under Nextcloud maintenance mode — there is no live-traffic window between them,
+but the two-phase split still keeps each step trivially reversible and matches this codebase's
+existing migration idioms for column renames):
+
+1. **Expand** (`changeSchema()` + `postSchemaChange()`, earlier timestamp): for each of the 13
+   fields, `if (!$schema->hasColumn('oc_openregister_verwerkingsactiviteiten', '<new_name>'))`, add
+   the new column nullable with the same type as its old counterpart. In `postSchemaChange()`, copy
+   data row-by-row (trivial at 7 rows) from each old column into its new column via
+   `IDBConnection`; for `legal_basis`, remap through the 6-entry old→new value table above
+   (defensively covering all 6 possible values even though only 2 are in use today), leaving `NULL`
+   values `NULL` and leaving any unrecognized legacy value untouched rather than dropping it
+   silently (so a genuinely unexpected value surfaces instead of being lost — a `WARN`-level log
+   line on an unrecognized value is included in `postSchemaChange()`).
+2. **Contract** (`changeSchema()`, later timestamp, same PR): for each of the 13 fields,
+   `if ($schema->hasColumn('oc_openregister_verwerkingsactiviteiten', '<old_name>'))`, drop the old
+   column. By this point the expand migration has already copied every row's data forward.
+
+Both migrations are safe to run twice (idempotent via the `hasColumn()` guards) and safe against a
+partially-applied prior run. The entity's `addType()` calls, getters/setters, and the mapper's
+`orderBy()`/`validate()` are updated in the same PR to reference only the new column names — so
+the deployed code and the post-contract schema are consistent from the moment the app boots on the
+new version.
+
+### `AvgRetentionService`'s two write paths are handled differently
+
+- The **report-payload dict** (`~lines 149-186`) is a plain in-memory array returned from a service
+  method — its keys (`naam`, `bewaartermijn`, ...) are renamed to the new field names with no
+  migration concern; nothing persists this shape.
+- The **`ObjectEntity::setDeleted()` write** (`~lines 305-311`) persists a `'bewaartermijn'` key
+  into a *different* entity's `deleted` JSON metadata blob — a point-in-time deletion-audit
+  snapshot, not a live queryable record. **Decision**: new writes after this change use the
+  renamed `retentionPeriod` key; already-persisted historical `deleted` blobs are left exactly as
+  they are. These are audit/evidence records — rewriting them would mean mutating historical
+  compliance evidence, which is a worse outcome than a benign old/new key split across a rename
+  boundary. Any future reader of this blob (there is none identified today) needs to accept both
+  key spellings for old vs. new records, the same way any schema evolution of a JSON blob would.
+
+### `ProcessingLogService::fallbackActivityUuid()` bugfix
+
+Folded into the same edit as its Dutch→English setter rename (see proposal.md "Bundled bugfix"):
+`setRechtsgrond('public-task')` → `setLegalBasis('public_task')`. The old call used a hyphenated
+value that was never a member of `RECHTSGROND_VOCABULARY` (which required the underscored
+`publieke_taak`), so the seeded fallback activity's legal basis has been silently invalid since it
+was written. This is a one-line, low-risk fix riding on a line this change already has to touch.
+
+### What stays Dutch, and why
+
+Two carve-outs are **intentionally not renamed** — both are reflected as explicit notes in the
+`avg-verwerkingsregister` spec delta so a future implementer doesn't "fix" them by mistake:
+
+1. **The Art 30 PDF export's Dutch column labels** (`avg-verwerkingsregister` spec, "Export complete
+   Art 30 register as structured document" scenario): `Naam, doel (doelbinding), grondslag, ...`.
+   This is human-readable display text in a citizen-/AP-facing compliance PDF that follows the VNG
+   model verwerkingsregister template — legitimate localized content, not a code identifier. The
+   export itself is not yet built.
+2. **The not-yet-implemented VNG "Verwerkingenlogging" export endpoint** (`avg-verwerkingsregister`
+   spec, "Logging aligns with VNG Verwerkingenlogging API standard" scenario): `actie_id`,
+   `verwerking_id`, `vertrouwelijkheid`, `verwerkende_organisatie`, etc. These field names are
+   mandated verbatim by the external VNG Verwerkingenlogging API standard. When this endpoint is
+   eventually built, it MUST keep these exact Dutch names — translating them would break
+   interoperability with the standard it implements.
+
+Also out of scope, unchanged, and not carve-outs so much as simply not part of this rename's
+target list: `oc_openregister_processing_log` / `ProcessingLogEntry` (verified already fully
+English — `activityId`, `objectUuid`, `subjectIdType`, etc.), Dutch legal/domain proper nouns
+elsewhere in the codebase (BSN, Awb, bezwaarschrift, gemeente, Woo), the
+`entity-relation-grondslagen` openspec directory name (the term appears only in comments/slugs, no
+real identifiers), the `archivering-vernietiging` subsystem, and the `avg-bundle.json` `consent`
+and `dpia` schemas (no Dutch identifiers of theirs were named in the proposal's scope).
+
+### Declarative-vs-imperative decision
+
+Not applicable. This change is a pure identifier rename: it introduces no new lifecycle,
+aggregation, notification, or relation behavior, and no existing behavior of that kind changes
+shape — every renamed field keeps its exact prior semantics, validation, and read/write path. There
+is nothing here for a declarative-vs-imperative choice to apply to.
+
+## Risks / Trade-offs
+
+- **[Risk]** A missed call site among the many Dutch getter/setter/array-key references (controller
+  hydration maps, service call sites, 4 PHPUnit test files, 3 Vue files) leaves a stale reference
+  that only surfaces at runtime (PHP has no compile-time check on dynamic `$entity->{$setter}()`
+  dispatch). → **Mitigation**: `hydrateFromPayload()`'s `stringFields`/`arrayFields` maps and the
+  entity's own `@method` docblock annotations are renamed together in one PR/commit per file
+  (see tasks.md), and the full PHPUnit suite (the 4 listed integration tests) plus a manual
+  smoke-test of `EditActivityDialog.vue` create/edit/save is run before merge.
+- **[Risk]** The two-migration expand/contract split still assumes both migrations land in the same
+  release (per Non-Goals, this app does not support running old code against contracted-but-not-yet-
+  copied schema). → **Mitigation**: both migration files ship in this same change/PR, and
+  `hasColumn()` guards make re-running the whole pair after a partial failure safe.
+- **[Risk]** The `legal_basis` remap table is defensive for all 6 possible old values, but if a row
+  somehow holds a value outside those 6 (e.g. manually inserted), the expand migration leaves it
+  untouched rather than nulling it, which means a genuinely invalid legacy value survives the rename
+  unchanged instead of being caught. → **Trade-off accepted**: silently dropping an unrecognized
+  value would be worse (data loss); the migration logs a warning for operator follow-up instead.
+- **[Trade-off]** `avg-bundle.json`'s rename is a breaking change for any operator who already
+  imported the old `verwerker` schema into their own register — their existing schema keeps the old
+  Dutch keys (the bundle is a one-time import, not a live-synced template) and would only pick up
+  the new names on a fresh re-import. Confirmed via prior investigation that no known live instance
+  has imported this bundle, and it is not auto-imported by any repair step, so this risk is accepted
+  as negligible today.
+
+## Migration Plan
+
+1. Land the DB migration pair (expand, then contract) alongside the entity/mapper/controller/service
+   renames in one PR, so schema and code are never out of sync at boot.
+2. Update `appinfo/routes.php` and the three Vue files in the same PR (no external consumer of the
+   old routes was found, so there is no deprecation-window requirement).
+3. Update the 4 PHPUnit integration test files' call sites in the same PR; run the full suite before
+   merge.
+4. Update `avg-bundle.json` in the same PR (no live-imported instance to migrate).
+5. Update the two spec files (`verwerkingsregister-api`, `avg-verwerkingsregister`) via
+   `openspec sync` after this change is verified and archived, per the normal OpenSpec flow.
+6. No rollback path is needed beyond standard git revert + a follow-up migration pair reversing the
+   column rename, since the expand phase never deletes data before the contract phase's `hasColumn`
+   guard confirms the copy landed.

--- a/openspec/changes/verwerkingsregister-i18n/proposal.md
+++ b/openspec/changes/verwerkingsregister-i18n/proposal.md
@@ -1,0 +1,128 @@
+---
+kind: code
+depends_on: []
+---
+
+## Why
+
+The AVG/GDPR "verwerkingsregister" (processing-activity register) subsystem — the
+`Verwerkingsactiviteit` entity/table, its controller, service call sites, the operator-importable
+`avg-bundle.json` schema, its URL routes, and the Vue admin UI — was built with Dutch identifiers
+throughout: field names (`naam`, `rechtsgrond`, `bewaartermijn`, ...), an enum constant
+(`RECHTSGROND_VOCABULARY`) and its Dutch values, and URL segments
+(`/api/avg/verwerkingsactiviteiten`). This violates this repo's hard rule that ALL code — including
+standardised/domain terms — must be English; the narrow exemptions are untranslatable proper nouns
+(BSN, Awb, gemeente) and external-standard-mandated field names, neither of which applies to these
+identifiers (they are this app's own field names, not something an external API dictates). This is a
+design-language cleanup, not a feature or behavior change: every renamed field keeps its type,
+validation, and semantics exactly as-is.
+
+**Baseline note**: the sibling change `processing-activity-register` (created 2026-06-11) built most
+of this Dutch-named surface; the bulk of its tasks have already landed in `lib/` (its own
+`tasks.md` shows the majority of phases checked off, with a handful of follow-up items still open —
+those follow-ups are unaffected by this rename and are out of scope here). This change treats the
+current `lib/` tree — which already includes that change's landed implementation — as its baseline.
+It does not touch or depend on that change's artifacts; `processing-activity-register` should be
+archived separately (by whoever owns that change) once this rename lands, since archiving is
+orthogonal to this cleanup.
+
+**Bundled bugfix**: while renaming `ProcessingLogService::fallbackActivityUuid()`'s Dutch setter
+calls, this change also fixes a pre-existing latent bug on the same line: it currently calls
+`setRechtsgrond('public-task')` (hyphenated), which is not a member of
+`RECHTSGROND_VOCABULARY` (which expects `'publieke_taak'`, underscored) — so the fallback activity
+has silently carried an invalid legal-basis value since it was written. The rename replaces this
+with the correct call, `setLegalBasis('public_task')`, using the renamed setter and the correct
+renamed enum value. This is called out explicitly here (and again in design.md) rather than being
+buried inside a mechanical rename diff.
+
+## What Changes
+
+- Rename 13 Dutch entity field names (DB column + property + getter/setter + JSON/API key, kept in
+  lockstep) on `Verwerkingsactiviteit`/`VerwerkingsactiviteitMapper`: `naam`→`name`,
+  `beschrijving`→`description`, `doelbinding`→`purpose`, `rechtsgrond`→`legalBasis`,
+  `categorieenBetrokkenen`→`dataSubjectCategories`, `categorieenPersoonsgegevens`→
+  `personalDataCategories`, `bewaartermijn`→`retentionPeriod`, `ontvangers`→`recipients`,
+  `doorgifteBuitenEu`→`internationalTransfers`, `technischeMaatregelen`→`technicalMeasures`,
+  `organisatorischeMaatregelen`→`organisationalMeasures`, `verwerkingsverantwoordelijke`→
+  `controller`, `contactgegevensFg`→`dpoContactDetails`. **BREAKING** for any external API consumer
+  of `/api/avg/verwerkingsactiviteiten*` (see routes below) — confirmed no external consumer exists
+  today (only this app's own frontend calls it).
+- Rename the `RECHTSGROND_VOCABULARY` constant to `LEGAL_BASIS_VOCABULARY` and translate its 6
+  stored values to GDPR Art. 6(1)(a)-(f) English terms (`toestemming`→`consent`,
+  `overeenkomst`→`contract`, `wettelijke_verplichting`→`legal_obligation`,
+  `vitaal_belang`→`vital_interests`, `publieke_taak`→`public_task`,
+  `gerechtvaardigd_belang`→`legitimate_interest`). **BREAKING** for the 7 existing rows on the
+  shared dev Postgres instance (values in use today: `wettelijke_verplichting`,
+  `publieke_taak`) — the DB migration remaps all 6 possible values defensively (see design.md).
+  `STATUS_VOCABULARY` is already English (`concept`/`published`/`archived`) and needs no change.
+- Update `VerwerkingsactiviteitMapper::validate()` error messages and the `findAll()` raw
+  `orderBy('naam', ...)` string literal to the new field names.
+- Update `VerwerkingsactiviteitenController::hydrateFromPayload()`'s `stringFields`/`arrayFields`
+  dispatch maps to the renamed keys/setters.
+- Rename URL route segments in `appinfo/routes.php`: `/api/avg/verwerkingsactiviteiten` →
+  `/api/avg/processing-activities`, `/api/avg/verantwoording` → `/api/avg/accountability`.
+  **BREAKING** in principle, but confirmed no external consumer — only this app's
+  `EditActivityDialog.vue`/`AvgIndex.vue`/`src/store/modules/avg.js` call it, and they are updated
+  in the same change.
+- Update `AvgRetentionService`'s report-payload dict keys (`naam`, `bewaartermijn`, ...) to English.
+  Its `ObjectEntity::setDeleted()` write path also switches to the new `retentionPeriod` key for new
+  writes only — historically-persisted deletion-log payloads are point-in-time snapshots and are
+  deliberately NOT rewritten (see design.md).
+- Fix `ProcessingLogService::fallbackActivityUuid()`'s Dutch setter calls (rename +
+  the `setRechtsgrond('public-task')` bugfix described above under "Why").
+- Rename the `avg-bundle.json` `verwerker` schema (register `avg`) to `processor`, with its Dutch
+  property keys translated to English (see design.md for the full mapping table). This bundle is
+  operator-importable only — confirmed not auto-imported by any PHP repair step or service — so the
+  rename carries no known-live-instance migration risk.
+- Update the Vue admin UI (`EditActivityDialog.vue`, `AvgIndex.vue`, `src/store/modules/avg.js`) to
+  bind to the renamed fields and call the renamed URL segments.
+- Update PHPUnit integration tests that call the renamed getters/setters/array keys
+  (`AvgVerwerkingsregisterIntegrationTest`, `VerwerkingsactiviteitenControllerIntegrationTest`,
+  `AvgRetentionServiceIntegrationTest`, `DsarServiceIntegrationTest`). The
+  `oc_openregister_processing_log` table and the `openregister_verwerkingsactiviteiten` TABLE name
+  (only its columns change) are unaffected.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `verwerkingsregister-api`: the CRUD REST surface's MUST-hydrate field-name list (string fields
+  and array fields) changes from the 13 Dutch identifiers to their English equivalents; the URL
+  path segments change from `verwerkingsactiviteiten`/`verantwoording` to
+  `processing-activities`/`accountability`.
+- `avg-verwerkingsregister`: field-name references across requirements/scenarios that describe the
+  `Verwerkingsactiviteit` entity and the `avg-bundle.json` `verwerker`/`processor` schema move to
+  English, EXCEPT two explicit carve-outs that stay Dutch by design: (1) the Art 30 PDF export's
+  Dutch human-readable column labels (VNG-model-mandated display text for an as-yet-unbuilt export,
+  not a code identifier), and (2) the not-yet-implemented VNG "Verwerkingenlogging" export endpoint,
+  whose literal Dutch field names (`actie_id`, `vertrouwelijkheid`, `verwerkende_organisatie`, ...)
+  are mandated by that external VNG API standard by name. Dutch field names local to the DPIA and
+  consent schemas (not touched by this code change — only the `verwerker`/`processor` schema in
+  `avg-bundle.json` is renamed) and general GDPR-process prose (inzageverzoek, rectificatie,
+  vergetelheid, dataportabiliteit, doelbinding-as-a-legal-concept) are untouched — they are domain
+  vocabulary describing legal processes, not this entity's field identifiers.
+
+## Impact
+
+- **Code**: `lib/Db/Verwerkingsactiviteit.php`, `lib/Db/VerwerkingsactiviteitMapper.php`,
+  `lib/Controller/VerwerkingsactiviteitenController.php`, `lib/Service/AvgRetentionService.php`,
+  `lib/Service/ProcessingLogService.php`, `lib/Resources/AvgSchemas/avg-bundle.json`,
+  `appinfo/routes.php`.
+- **Frontend**: `src/dialogs/avg/EditActivityDialog.vue`, `src/views/avg/AvgIndex.vue`,
+  `src/store/modules/avg.js`.
+- **Database**: new data-preserving migration on `oc_openregister_verwerkingsactiviteiten`
+  (add-copy-drop per column, guarded by `hasColumn()`, remapping the 6 legal-basis enum values) —
+  see design.md. 7 real rows on the shared dev Postgres instance today; none are destroyed.
+- **Tests**: `tests/Service/AvgVerwerkingsregisterIntegrationTest.php`,
+  `tests/Service/VerwerkingsactiviteitenControllerIntegrationTest.php`,
+  `tests/Service/AvgRetentionServiceIntegrationTest.php`,
+  `tests/Service/DsarServiceIntegrationTest.php`.
+- **Specs**: `openregister/openspec/specs/verwerkingsregister-api/spec.md`,
+  `openregister/openspec/specs/avg-verwerkingsregister/spec.md`.
+- **Dependents**: no external consumers of the renamed routes/fields were found (opencatalogi,
+  softwarecatalog do not call this surface); the frontend consumers in this same app are updated in
+  lockstep.

--- a/openspec/changes/verwerkingsregister-i18n/specs/avg-verwerkingsregister/spec.md
+++ b/openspec/changes/verwerkingsregister-i18n/specs/avg-verwerkingsregister/spec.md
@@ -1,0 +1,166 @@
+## MODIFIED Requirements
+
+### Requirement: The system MUST maintain a verwerkingsactiviteiten register as an OpenRegister schema
+A central register of all processing activities (verwerkingsactiviteiten) MUST be maintained as a dedicated OpenRegister register and schema, conforming to GDPR Article 30(1) for controllers and Article 30(2) for processors. Each processing activity record MUST contain all fields mandated by the Autoriteit Persoonsgegevens model verwerkingsregister and the VNG model verwerkingsregister for gemeenten. Field names throughout this requirement use the English identifiers introduced by the `verwerkingsregister-i18n` change (`name`, `purpose`, `legalBasis`, `dataSubjectCategories`, `personalDataCategories`, `recipients`, `retentionPeriod`, `technicalMeasures`/`organisationalMeasures`) — the Dutch labels these fields previously used were the same rename target as the shipped `Verwerkingsactiviteit` entity's columns.
+
+#### Scenario: Create a processing activity with all Art 30 mandatory fields
+- **GIVEN** an administrator or privacy officer (FG/DPO) accesses the verwerkingsregister
+- **WHEN** they create a new verwerkingsactiviteit with:
+  - `name`: `Behandeling bezwaarschrift`
+  - `purpose`: `Uitvoering wettelijke taak bezwaarschriftprocedure conform Algemene wet bestuursrecht`
+  - `legalBasis` (per Art 6): `legal_obligation` (Art 6 lid 1 sub c AVG — Awb art. 7:1)
+  - `dataSubjectCategories`: `["bezwaarmaker", "belanghebbenden", "gemachtigden"]`
+  - `personalDataCategories`: `["NAW-gegevens", "BSN", "contactgegevens", "zaakinhoud", "financiele gegevens"]`
+  - `recipients`: `["behandelend ambtenaar", "bezwaarschriftencommissie", "rechtbank (bij beroep)"]`
+  - `retentionPeriod`: `P10Y` (ISO 8601 duration, 10 years after case closure)
+  - `technicalMeasures`/`organisationalMeasures` (security measures per Art 32): `["versleuteling in rust en transit", "toegangscontrole op basis van rollen", "audit logging", "pseudonimisering waar mogelijk"]`
+  - `controller` (processor/verwerkingsverantwoordelijke): `Eigen organisatie`
+  - `dpiaVereist` (DPIA required — not part of this rename, unbuilt DPIA linkage): `false`
+  - `status`: `published`
+- **THEN** the processing activity MUST be stored as an object in the verwerkingsactiviteiten schema
+- **AND** a UUID MUST be generated for cross-referencing from audit trail entries
+- **AND** the `created` and `updated` timestamps MUST be set automatically
+
+#### Scenario: Reject processing activity without mandatory fields
+- **GIVEN** an administrator attempts to create a verwerkingsactiviteit
+- **WHEN** the `purpose`, `legalBasis`, or `dataSubjectCategories` fields are missing
+- **THEN** the system MUST reject the creation with HTTP 400
+- **AND** the response MUST list which mandatory Art 30 fields are missing
+- **AND** the error message MUST reference the specific GDPR article (e.g., "Art 30 lid 1 sub b vereist het doel van de verwerking")
+
+#### Scenario: List all processing activities with filtering
+- **GIVEN** 25 verwerkingsactiviteiten exist across multiple organisational units
+- **WHEN** a privacy officer queries `GET /api/objects/{register}/{schema}?legalBasis=legal_obligation`
+- **THEN** the system MUST return only activities with the matching legal basis
+- **AND** results MUST include pagination metadata
+- **AND** the query itself MUST NOT be logged as a processing activity on personal data (it queries the register, not personal data)
+
+#### Scenario: Version processing activity changes
+- **GIVEN** verwerkingsactiviteit `Behandeling bezwaarschrift` exists with `retentionPeriod: P10Y`
+- **WHEN** the privacy officer updates the retention period to `P7Y` following a new selectielijst
+- **THEN** the system MUST create an audit trail entry recording the change via the immutable audit trail (see `audit-trail-immutable` spec)
+- **AND** the previous version MUST remain retrievable for compliance evidence
+- **AND** the `updated` timestamp MUST reflect the modification date
+
+#### Scenario: Deactivate a processing activity
+- **GIVEN** verwerkingsactiviteit `Papieren correspondentie archivering` is no longer performed
+- **WHEN** the privacy officer sets its `status` to `archived`
+- **THEN** the activity MUST remain in the register with status `archived` (MUST NOT be deleted per Art 30 accountability principle)
+- **AND** schemas linked to this activity MUST display a warning that the processing activity is inactive
+- **AND** the deactivation MUST be recorded in the audit trail
+
+### Requirement: All access to personal data MUST be logged with processing purpose
+Every read, write, update, or delete operation on objects in schemas marked as containing personal data MUST produce an immutable processing log entry that records the verwerkingsactiviteit, the user, the action, and the timestamp. This implements the accountability principle (verantwoordingsplicht) of Art 5(2) AVG and aligns with the VNG Verwerkingenlogging API standard.
+
+#### Scenario: Log data access with verwerkingsactiviteit reference
+- **GIVEN** schema `inwoners` is marked as containing personal data
+- **AND** it is linked to verwerkingsactiviteit `Uitvoering Wmo-aanvraag`
+- **WHEN** user `medewerker-1` reads object `inwoner-123`
+- **THEN** a processing log entry MUST be created in the immutable audit trail with:
+  - `timestamp`: server-side UTC timestamp
+  - `user`: `medewerker-1`
+  - `action`: `read`
+  - `objectUuid`: UUID of `inwoner-123`
+  - `schemaUuid`: UUID of `inwoners` schema
+  - `verwerkingsactiviteitId`: UUID of `Uitvoering Wmo-aanvraag`
+  - `doelbinding`: the purpose text from the linked activity
+  - `vertrouwelijkheid`: the confidentiality level of the accessed object
+- **AND** the log entry MUST be hash-chained per the `audit-trail-immutable` spec
+
+#### Scenario: Log bulk data operations
+- **GIVEN** an API consumer performs a list query on schema `inwoners` returning 50 objects
+- **WHEN** the query is executed
+- **THEN** a single processing log entry MUST be created recording the bulk access
+- **AND** the entry MUST include `objectCount: 50` and the query parameters used
+- **AND** individual object UUIDs MUST be recorded if the result set is 100 or fewer objects
+
+#### Scenario: Reject access without valid processing purpose (purpose-bound access control)
+- **GIVEN** schema `inwoners` has `requirePurposeBinding: true` enabled
+- **AND** user `medewerker-2` has no role linked to any verwerkingsactiviteit for `inwoners`
+- **WHEN** `medewerker-2` attempts to read `inwoner-123`
+- **THEN** the system MUST return HTTP 403 with body containing: `{"error": "Geen geldige verwerkingsgrondslag voor toegang tot schema 'inwoners'"}`
+- **AND** the denied access attempt MUST be logged in the audit trail with action `access_denied_no_purpose`
+
+#### Scenario: Purpose binding enforced across all access methods
+- **GIVEN** schema `zaken-sociaal-domein` has `requirePurposeBinding: true`
+- **WHEN** access is attempted via REST API, GraphQL, MCP, or public endpoints
+- **THEN** the `PurposeBindingMiddleware` MUST intercept all access methods consistently
+- **AND** the enforcement MUST occur before any data is returned to the caller
+
+#### Scenario: Logging aligns with VNG Verwerkingenlogging API standard
+> **Carve-out — stays Dutch by design.** The VNG "Verwerkingenlogging" API is an external standard
+> that mandates these exact field names on the wire. Future implementers of this not-yet-built
+> export endpoint MUST NOT "fix" this by translating it — doing so would break interoperability
+> with the standard `verwerkingsregister-i18n` deliberately did not touch this scenario's field
+> names for that reason.
+
+- **GIVEN** the municipality uses the VNG Verwerkingenlogging API standard for cross-system logging
+- **WHEN** processing log entries are created
+- **THEN** the entries MUST be exportable in the VNG Verwerkingenlogging format including:
+  - `actie_id` (action identifier), `verwerking_id` (processing ID), `verwerkingsactiviteit_id`
+  - `vertrouwelijkheid` (confidentiality), `bewaartermijn` (retention)
+  - `tijdstip`, `tijdstip_registratie`, `verwerkende_organisatie`
+- **AND** a REST endpoint `GET /api/verwerkingslog/export` MUST provide this format
+
+### Requirement: Third-party processors (verwerkers) MUST be registered with verwerkersovereenkomst tracking
+All third parties that process personal data on behalf of the organisation MUST be registered in the verwerkingsregister with their processor agreement details, conforming to Art 28 AVG. The `avg-bundle.json` `verwerker` schema was renamed to `processor` by the `verwerkingsregister-i18n` change; its property names below use the renamed English keys.
+
+#### Scenario: Register a third-party processor
+- **GIVEN** the organisation uses `CloudHosting B.V.` for document storage
+- **WHEN** the privacy officer registers the processor
+- **THEN** the processor record MUST include:
+  - `name`: `CloudHosting B.V.`
+  - `chamberOfCommerceNumber`: `12345678`
+  - `contactPerson`: `privacy@cloudhosting.nl`
+  - `agreementDate`: `2025-03-01`
+  - `agreementExpiresAt`: `2027-03-01`
+  - `subProcessors`: `["AWS EU-West", "Backup B.V."]`
+  - `internationalTransferDetails`: `Servers in EU, geen doorgifte buiten EER`
+  - `securityCertifications`: `ISO 27001, SOC 2 Type II`
+
+#### Scenario: Alert on expiring processor agreement
+- **GIVEN** processor `CloudHosting B.V.` has an `agreementExpiresAt` of `2027-03-01`
+- **WHEN** the current date is within 90 days of expiration
+- **THEN** the system MUST send a notification to the privacy officer
+- **AND** the processor record MUST display a warning indicator in the UI
+
+#### Scenario: Link processor to processing activities
+- **GIVEN** processor `CloudHosting B.V.` is registered
+- **WHEN** verwerkingsactiviteit `Documentopslag en -verwerking` lists this processor
+- **THEN** the Art 30 export MUST include the processor details alongside the processing activity
+- **AND** if the processor is deactivated, all linked verwerkingsactiviteiten MUST display a compliance warning
+
+### Requirement: The Art 30 register MUST be exportable for the Autoriteit Persoonsgegevens
+The complete verwerkingsregister MUST be exportable in formats suitable for AP supervision, internal audit, and FG/DPO reporting. The export MUST conform to the VNG model verwerkingsregister template structure.
+
+#### Scenario: Export complete Art 30 register as structured document
+> **Carve-out — the PDF's column labels stay Dutch by design.** This is human-readable display text
+> for a citizen-facing/AP-facing compliance document mandated by the VNG model verwerkingsregister
+> template, not a code identifier — `verwerkingsregister-i18n` explicitly did not translate it.
+
+- **GIVEN** 25 verwerkingsactiviteiten are defined with linked schemas, processors, and DPIAs
+- **WHEN** the privacy officer triggers `GET /api/verwerkingsregister/export?format=pdf`
+- **THEN** the system MUST generate a PDF document (via DocuDesk if available) listing all activities with:
+  - Naam, doel (doelbinding), grondslag, categorieën persoonsgegevens, categorieën betrokkenen
+  - Ontvangers, bewaartermijn, beveiligingsmaatregelen, verwerkerinformatie
+  - DPIA status per activity, doorgifte details
+  - Date of generation, organisation name, FG/DPO contact details
+- **AND** the format MUST follow the VNG model verwerkingsregister structure
+
+#### Scenario: Export as machine-readable JSON
+- **GIVEN** the privacy officer requests `GET /api/verwerkingsregister/export?format=json`
+- **THEN** the system MUST return a JSON document conforming to a documented JSON Schema
+- **AND** each verwerkingsactiviteit MUST include all Art 30 mandatory fields plus linked schema UUIDs
+- **AND** the JSON MUST be importable back into OpenRegister for migration or backup purposes
+
+#### Scenario: Export as CSV for spreadsheet analysis
+- **GIVEN** the privacy officer requests `GET /api/verwerkingsregister/export?format=csv`
+- **THEN** the system MUST return a CSV file with one row per verwerkingsactiviteit
+- **AND** multi-value fields (categorieën, ontvangers) MUST be semicolon-separated within their columns
+- **AND** the CSV MUST use UTF-8 encoding with BOM for Excel compatibility
+
+#### Scenario: Incremental export since last AP report
+- **GIVEN** the previous AP export was generated on 2025-06-01
+- **WHEN** the privacy officer requests an incremental export with `?since=2025-06-01`
+- **THEN** the export MUST include only verwerkingsactiviteiten that were created or modified after that date
+- **AND** the export MUST clearly mark which activities are new vs. modified

--- a/openspec/changes/verwerkingsregister-i18n/specs/verwerkingsregister-api/spec.md
+++ b/openspec/changes/verwerkingsregister-i18n/specs/verwerkingsregister-api/spec.md
@@ -1,0 +1,66 @@
+## MODIFIED Requirements
+
+### Requirement: The system MUST provide a CRUD REST surface over the dedicated verwerkingsactiviteiten catalog
+
+Beyond the audit-trail-derived read views, the system MUST expose `VerwerkingsactiviteitenController` as a REST CRUD surface over the dedicated `oc_openregister_verwerkingsactiviteiten` table (distinct from the audit-trail aggregation), reachable under `/api/avg/processing-activities`. `index` MUST list activities with optional `status` and `organisation` query filters, returning `{count, results}`. `show` MUST resolve a path identifier that may be a numeric id, a uuid, or a short readable code, returning HTTP 404 when nothing matches. `create` and `update` MUST hydrate the string fields (`code`, `name`, `description`, `purpose`, `legalBasis`, `retentionPeriod`, `technicalMeasures`, `organisationalMeasures`, `organisationId`, `status`) and array fields (`dataSubjectCategories`, `personalDataCategories`, `recipients`, `internationalTransfers`, `controller`, `dpoContactDetails`) from the payload, returning HTTP 201 on create and HTTP 422 on `InvalidArgumentException`. `destroy` MUST NOT hard-delete — it MUST set `status = 'archived'` and persist, returning HTTP 204, because audit-trail rows reference activities by uuid as a soft foreign key. Create, update, and destroy MUST be restricted to members of the Nextcloud `admin` group (HTTP 403 otherwise); list, show, and the accountability report MUST be available to any authenticated user.
+
+#### Scenario: List with status filter
+- **WHEN** `GET /api/avg/processing-activities?status=published` is requested
+- **THEN** `index` MUST return `{count, results}` containing only activities with `status = published`
+- **AND** each result MUST be the activity's `jsonSerialize()` form
+
+#### Scenario: Resolve by id, uuid, or code
+- **GIVEN** an activity exists with a uuid and a readable code
+- **WHEN** `show` is called with the numeric id, the uuid, or the code
+- **THEN** each form MUST resolve to the same activity
+- **AND** an unmatched identifier MUST return HTTP 404 with `{error, identifier}`
+
+#### Scenario: Writes are admin-gated
+- **GIVEN** a non-admin authenticated user
+- **WHEN** they call `create`, `update`, or `destroy`
+- **THEN** the response MUST be HTTP 403 with `{error}` before any persistence
+- **AND** an admin performing `create` with valid fields MUST receive HTTP 201 with the persisted activity
+
+#### Scenario: Delete soft-archives instead of removing
+- **GIVEN** an existing activity referenced by audit-trail rows
+- **WHEN** an admin calls `destroy`
+- **THEN** the activity's `status` MUST be set to `archived` and persisted
+- **AND** the row MUST remain resolvable by uuid
+- **AND** the response MUST be HTTP 204
+
+### Requirement: The system MUST provide an Art 30 §4 accountability report aggregating audit events per processing activity
+
+`VerwerkingsactiviteitenController::verantwoording` MUST return an accountability report suitable for AP supervisory review, reachable under `/api/avg/accountability`: every verwerkingsactiviteit joined with the count of audit-trail rows attributed to it via `processing_activity_id`, broken down per `action`. The aggregation MUST query `openregister_audit_trails` grouped by `processing_activity_id` and `action`, scoped to the activities' uuids. The response MUST be `{count, activities}` where each activity entry is its serialized form plus an `activity` block `{totalEvents, byAction}`. Activities with no audit rows MUST report `{totalEvents: 0, byAction: []}`. A query failure during aggregation MUST degrade to empty counts rather than failing the whole report.
+
+#### Scenario: Report aggregates audit counts per action
+- **GIVEN** activity `A` (uuid `u1`) has 3 `create`, 2 `update`, and 5 `read` audit rows
+- **WHEN** the accountability report is requested
+- **THEN** the entry for `A` MUST include `activity.byAction = {create: 3, update: 2, read: 5}`
+- **AND** `activity.totalEvents` MUST equal 10
+
+#### Scenario: Activity with no audit rows
+- **GIVEN** activity `B` has no audit-trail rows referencing it
+- **WHEN** the accountability report is requested
+- **THEN** the entry for `B` MUST include `activity = {totalEvents: 0, byAction: []}`
+
+#### Scenario: Aggregation failure degrades gracefully
+- **GIVEN** the audit-trail aggregation query throws
+- **WHEN** the accountability report is requested
+- **THEN** every activity MUST report `{totalEvents: 0, byAction: []}` and the report MUST still return HTTP 200
+
+### Requirement: The system MUST support subject-identifier audit-trail lookup (Art 15 AVG — Dutch: inzageverzoek)
+An API endpoint MUST allow querying all audit trail entries related to a specific data subject, identified by a search term in the `changed` field. `AuditTrailController::subjectAuditTrail` (renamed from `inzageverzoek` by the `verwerkingsregister-i18n` change) is reachable at `GET /api/audit-trails/subject-lookup` (renamed from `/api/audit-trails/inzageverzoek`). This endpoint is distinct in purpose from the `DsarController::access` endpoint (`GET /api/avg/access`) — this one searches audit-trail entries by identifier; `DsarController::access` searches the PII entity index for objects referencing a subject.
+
+#### Scenario: Query audit entries for a data subject
+- **WHEN** a GET request is made to `/api/audit-trails/subject-lookup?identifier=123456789`
+- **THEN** the system MUST search all audit trail entries where the `changed` JSON field contains the identifier
+- **AND** return a JSON response with all matching entries grouped by schema
+- **AND** each group MUST include the schema UUID, schema name (if available), and the list of matching entries
+
+#### Scenario: Subject lookup with no matching entries
+- **WHEN** a GET request is made to `/api/audit-trails/subject-lookup?identifier=nonexistent`
+- **THEN** the system MUST return `{"results": [], "totalEntries": 0}`
+
+#### Scenario: Subject lookup requires identifier parameter
+- **WHEN** a GET request is made to `/api/audit-trails/subject-lookup` without an `identifier` parameter
+- **THEN** the system MUST return HTTP 400 with `{"error": "identifier parameter is required"}`

--- a/openspec/changes/verwerkingsregister-i18n/tasks.md
+++ b/openspec/changes/verwerkingsregister-i18n/tasks.md
@@ -1,0 +1,95 @@
+## 1. Database migration (expand/contract, data-preserving)
+
+- [ ] 1.1 Add expand migration: new nullable columns `name`, `description`, `purpose`,
+  `legal_basis`, `data_subject_categories`, `personal_data_categories`, `retention_period`,
+  `recipients`, `international_transfers`, `technical_measures`, `organisational_measures`,
+  `controller`, `dpo_contact_details` on `oc_openregister_verwerkingsactiviteiten`, each guarded by
+  `hasColumn()`; `postSchemaChange()` copies data from the 13 old Dutch columns into the new ones,
+  remapping all 6 `rechtsgrond` → `legal_basis` values defensively (only `wettelijke_verplichting`/
+  `publieke_taak` are in use on the shared dev instance today), logging a warning on any
+  unrecognized legacy value instead of dropping it.
+- [ ] 1.2 Add contract migration (later timestamp, same PR): drop the 13 old Dutch-named columns,
+  each guarded by `hasColumn()`.
+- [ ] 1.3 Run both migrations against the shared dev Postgres instance and verify all 7 existing
+  rows survive with correctly remapped `legal_basis` values.
+
+## 2. Backend entity, mapper, and vocabulary rename
+
+- [ ] 2.1 Rename all 13 field properties, getters/setters, `@method` docblocks, `addType()` calls,
+  and `jsonSerialize()` keys on `lib/Db/Verwerkingsactiviteit.php` per the design.md mapping table;
+  rename `RECHTSGROND_VOCABULARY` → `LEGAL_BASIS_VOCABULARY` and its 6 values; rename
+  `isValidRechtsgrond()` → `isValidLegalBasis()`; confirm `STATUS_VOCABULARY` needs no change.
+- [ ] 2.2 Update `lib/Db/VerwerkingsactiviteitMapper.php`: rename `findAll()`'s
+  `orderBy('naam', ...)` literal, and update `validate()`'s error messages to reference the new
+  field names (`name`, `purpose`, `legalBasis`) while keeping the same AVG article citations.
+
+## 3. Controller, service, and route rename
+
+- [ ] 3.1 Update `lib/Controller/VerwerkingsactiviteitenController.php`'s `hydrateFromPayload()`
+  `stringFields`/`arrayFields` maps to the renamed keys/setters; leave the entity/table name
+  references in error strings (`"Verwerkingsactiviteit not found"`, etc.) as-is.
+- [ ] 3.2 Rename URL segments in `appinfo/routes.php`: `/api/avg/verwerkingsactiviteiten` →
+  `/api/avg/processing-activities`, `/api/avg/verantwoording` → `/api/avg/accountability`.
+- [ ] 3.3 Update `lib/Service/AvgRetentionService.php`: rename `getBewaartermijn()` call and the
+  report-payload dict keys to English; switch the `ObjectEntity::setDeleted()` write to the new
+  `retentionPeriod` key for new writes only (do not touch historically-persisted `deleted` blobs).
+- [ ] 3.4 Update `lib/Service/ProcessingLogService.php::fallbackActivityUuid()`: rename its Dutch
+  setter calls to `setName`/`setPurpose`/`setLegalBasis`/etc., and fix the pre-existing
+  `setRechtsgrond('public-task')` bug to `setLegalBasis('public_task')` in the same edit.
+
+## 4. avg-bundle.json processor schema rename
+
+- [ ] 4.1 Rename the `verwerker` schema (slug, title, description) to `processor` in
+  `lib/Resources/AvgSchemas/avg-bundle.json`, and rename its properties per the design.md mapping
+  table (`naam`→`name`, `kvk`→`chamberOfCommerceNumber`, `vestiging`→`establishment` with nested
+  `land`/`stad`/`adres`/`postcode`, `contactpersoon`→`contactPerson`, `telefoon`→`phone`,
+  `verwerkersovereenkomstUrl`/`Datum`→`agreementUrl`/`agreementDate`, `subVerwerkers`→
+  `subProcessors` with nested `naam`/`land`/`doel`→`name`/`country`/`purpose`,
+  `doorgifteBuitenEu`→`internationalTransfers` with nested `ja`/`landen`/`waarborgen`→
+  `transferred`/`countries`/`safeguards`, `type` enum `anders`→`other`, `status` enum
+  `concept`/`actief`/`beeindigd`→`draft`/`active`/`terminated`); update the `required` array and
+  the register's `schemas` list to reference `processor`.
+
+## 5. Frontend rename
+
+- [ ] 5.1 Update `src/dialogs/avg/EditActivityDialog.vue`: rename all `form.<dutchField>` v-model
+  bindings and the `data()` initializer's response-object field reads to the new English keys.
+- [ ] 5.2 Update `src/views/avg/AvgIndex.vue`: rename the read-only `a.naam`/`a.rechtsgrond`/
+  `a.bewaartermijn` bindings to `a.name`/`a.legalBasis`/`a.retentionPeriod`.
+- [ ] 5.3 Update `src/store/modules/avg.js`: change the URL segments to
+  `processing-activities`/`accountability` (no field-name-specific code to change here).
+
+## 6. Test updates
+
+- [ ] 6.1 Update `tests/Service/AvgVerwerkingsregisterIntegrationTest.php`,
+  `tests/Service/VerwerkingsactiviteitenControllerIntegrationTest.php`,
+  `tests/Service/AvgRetentionServiceIntegrationTest.php`, and
+  `tests/Service/DsarServiceIntegrationTest.php`: rename all Dutch getter/setter/array-key call
+  sites to the renamed equivalents; verify the `openregister_verwerkingsactiviteiten` table-name
+  literal (delete queries etc.) is left untouched since only columns are renamed.
+- [ ] 6.2 Run the full PHPUnit suite and confirm all 4 updated test files pass against the migrated
+  schema.
+
+## 7. Verification
+
+- [ ] 7.1 Manually smoke-test `EditActivityDialog.vue` create/edit/save and `AvgIndex.vue`'s list
+  view against the shared dev instance to confirm the renamed fields round-trip correctly through
+  the renamed routes.
+- [ ] 7.2 Run `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) and confirm no new findings
+  from the rename.
+
+## Acceptance Criteria
+
+- All 13 `Verwerkingsactiviteit` fields, the `LEGAL_BASIS_VOCABULARY` constant and its 6 values, the
+  two URL routes, and the `avg-bundle.json` `processor` schema use English identifiers with no
+  remaining Dutch field names in code (excluding the two explicit spec carve-outs).
+- The DB migration is data-preserving: all 7 existing rows on the shared dev instance retain their
+  data after both migrations run, with `legal_basis` values correctly remapped.
+- No historically-persisted `ObjectEntity.deleted` JSON blob is rewritten by this change.
+- The `setRechtsgrond('public-task')` bug in `ProcessingLogService::fallbackActivityUuid()` is fixed
+  to `setLegalBasis('public_task')`.
+- The `verwerkingsregister-api` and `avg-verwerkingsregister` spec deltas are synced into the main
+  specs, with the VNG Verwerkingenlogging field names and the Art 30 PDF export's Dutch column
+  labels left untouched.
+- All 4 updated PHPUnit integration test files pass; `composer check:strict` reports no new
+  findings.


### PR DESCRIPTION
OpenSpec change proposals — **artifacts only**. Every task box is unticked; nothing is wired to anything yet, and each change gets picked up by `/opsx-apply` when it is scheduled.

Opened because these were sitting **untracked in the shared dev checkout across the fleet**. An untracked directory is one file-sweep away from being swept into an unrelated commit, and one branch switch away from being gone. These carry the design reasoning, not just a title.
