### PR TITLE
fix(l10n): restore 36-locale parity and formatting after #2553

### DIFF
--- a/src/dialogs/avg/EditActivityDialog.vue
+++ b/src/dialogs/avg/EditActivityDialog.vue
@@ -250,12 +250,10 @@ export default {
 				retentionPeriod: activity?.retentionPeriod ?? '',
 				status: activity?.status ?? 'concept',
 				dataSubjectCategories: activity?.dataSubjectCategories ?? [],
-				personalDataCategories:
-					activity?.personalDataCategories ?? [],
+				personalDataCategories: activity?.personalDataCategories ?? [],
 
 				technicalMeasures: activity?.technicalMeasures ?? '',
-				organisationalMeasures:
-					activity?.organisationalMeasures ?? '',
+				organisationalMeasures: activity?.organisationalMeasures ?? '',
 			}
 		},
 

--- a/src/store/modules/avg.js
+++ b/src/store/modules/avg.js
@@ -537,9 +537,7 @@ export const useAvgStore = defineStore('avg', {
 				return this.dsarSummary
 			} catch (e) {
 				this.error =
-					e.response?.data?.error
-					?? e.message
-					?? 'Failed to run erasure'
+					e.response?.data?.error ?? e.message ?? 'Failed to run erasure'
 				console.error('[avg.runErasure]', e)
 				throw e
 			} finally {

--- a/src/views/avg/AvgIndex.vue
+++ b/src/views/avg/AvgIndex.vue
@@ -172,7 +172,7 @@
 					<NcEmptyContent
 						v-if="!accountability"
 						:name="
-							t('openregister', 'Generate the accountability document')
+							t('openregister', 'Generate the verantwoordingsdocument')
 						"
 						:description="
 							t(
@@ -244,7 +244,7 @@
 						{{
 							t(
 								'openregister',
-								'Locate every object referencing a data subject (Art 15), preview an erasure (Art 17), or export their data (Art 20).',
+								'Locate every object referencing a data subject (Art 15 inzage), preview an erasure (Art 17 vergetelheid), or export their data (Art 20 portabiliteit).',
 							)
 						}}
 					</p>
@@ -275,7 +275,7 @@
 								<template #icon>
 									<Magnify :size="20" />
 								</template>
-								{{ t('openregister', 'Access (Art 15)') }}
+								{{ t('openregister', 'Inzage (Art 15)') }}
 							</NcButton>
 							<NcButton
 								variant="secondary"


### PR DESCRIPTION
`development` went red on `Frontend Check (test:l10n)` and `Frontend Check (format)` immediately after the flow-editor merge.

**test:l10n.** #2553 reworded three AVG strings in `AvgIndex.vue`, replacing Dutch statutory terms with English:

| was (translated in 36 locales) | became (translated in 0) |
| --- | --- |
| `Inzage (Art 15)` | `Access (Art 15)` |
| `Generate the verantwoordingsdocument` | `Generate the accountability document` |
| `…(Art 15 inzage), …(Art 17 vergetelheid), …` | `…(Art 15), …(Art 17), …` |

Each is a **new key**, so l10n-parity failed with 3 missing keys per locale — 108 translations of AVG article text that the rewording silently created.

Reverted to the existing keys. That restores parity instantly and, more to the point, restores the app: for the three-line gain of an English label, **every non-English user was getting untranslated text on the AVG page**.

Adding the 108 translations was the other option and I rejected it for tonight — hand-translating GDPR article wording into 36 languages is not a CI-unblocking task, and machine-translating legal terminology is worse than the red. There is a reasonable argument for the anglicisation (the fleet writes code in English, and these are UI labels rather than statutory wire fields) — it just needs the 36 locales in the same change, not after it.

**format.** `EditActivityDialog.vue` and `src/store/modules/avg.js` were merged unformatted; `prettier --write` on those two, no logic touched.

Verified locally: check-l10n OK, l10n-parity OK across all 36 locales, prettier clean, eslint clean, webpack build exits 0.