### PR TITLE
fix(i18n): re-apply AVG English strings now that all 36 locales have them

### DIFF
--- a/src/views/avg/AvgIndex.vue
+++ b/src/views/avg/AvgIndex.vue
@@ -172,7 +172,7 @@
 					<NcEmptyContent
 						v-if="!accountability"
 						:name="
-							t('openregister', 'Generate the verantwoordingsdocument')
+							t('openregister', 'Generate the accountability document')
 						"
 						:description="
 							t(
@@ -244,7 +244,7 @@
 						{{
 							t(
 								'openregister',
-								'Locate every object referencing a data subject (Art 15 inzage), preview an erasure (Art 17 vergetelheid), or export their data (Art 20 portabiliteit).',
+								'Locate every object referencing a data subject (Art 15), preview an erasure (Art 17), or export their data (Art 20).',
 							)
 						}}
 					</p>
@@ -275,7 +275,7 @@
 								<template #icon>
 									<Magnify :size="20" />
 								</template>
-								{{ t('openregister', 'Inzage (Art 15)') }}
+								{{ t('openregister', 'Access (Art 15)') }}
 							</NcButton>
 							<NcButton
 								variant="secondary"


### PR DESCRIPTION
## Summary
- #2564 reverted three AVG strings from #2553's rewording back to Dutch (Inzage/verantwoordingsdocument/Art 15 inzage-Art 17 vergetelheid-Art 20 portabiliteit) to unblock l10n-parity, since no locale had translations for the English replacements at that time.
- #2562 (this session's earlier PR) already added real translations for these exact strings across all 36 required locales as part of its own l10n-parity fix.
- The parity concern #2564 was working around no longer applies — re-apply the English text.

## Test plan
- [x] `node tests/l10n/check-l10n.js` — OK, both coverage and parity checks pass
- [x] `npm run format` — clean
- [x] `npm run build` — 0 errors
- [x] Local hydra-gates spec-coverage check — count=0