### PR TITLE
chore(deps): nc-vue ^2.6.2 — consolidated flow editor stable, drop transition shims

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2112,9 +2112,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.6.2.tgz",
-      "integrity": "sha512-FWoqW/nn1eht9hlbf9UVEy9LmYEYguxhARIcIRnalz0Kim1CL+c4Xcj5GvDPsda5B4eFW4S72zv+rO1rjVe6og==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.6.3.tgz",
+      "integrity": "sha512-vtPrmkIwXobjjRXS3Zrkp/Xu/ahYBM/h5os4KZTUIVRBOVv208aModBbDeGJeqwcp4S9JlOKj2o3hheeC6cQTw==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
-        "@conduction/nextcloud-vue": "^2.3.0",
+        "@conduction/nextcloud-vue": "^2.6.2",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "^2.6.0",
         "@nextcloud/capabilities": "^1.2.1",
@@ -84,7 +84,7 @@
       },
       "engines": {
         "node": "^22.14 || ^24 || >=26",
-        "npm": "^10.0.0"
+        "npm": "^11.0.0"
       },
       "peerDependencies": {
         "vue": "^3.5.0"
@@ -2112,9 +2112,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.3.0.tgz",
-      "integrity": "sha512-jwQJ5gqcUfWbKMCXUNO8BteRD4yakLVEAIx6Qd+2+BLZaiENLUFDYVnHxARef9AyZmvBAOxQCVHC3Fk8jgDBOA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.6.2.tgz",
+      "integrity": "sha512-FWoqW/nn1eht9hlbf9UVEy9LmYEYguxhARIcIRnalz0Kim1CL+c4Xcj5GvDPsda5B4eFW4S72zv+rO1rjVe6og==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",
@@ -2413,7 +2413,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2430,7 +2429,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2447,7 +2445,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2464,7 +2461,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2481,7 +2477,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2498,7 +2493,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2515,7 +2509,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2532,7 +2525,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2549,7 +2541,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2566,7 +2557,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2583,7 +2573,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2600,7 +2589,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2617,7 +2605,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2634,7 +2621,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2651,7 +2637,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2668,7 +2653,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2685,7 +2669,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2702,7 +2685,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2719,7 +2701,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2736,7 +2717,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2753,7 +2733,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2770,7 +2749,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2787,7 +2765,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2804,7 +2781,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2821,7 +2797,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2838,7 +2813,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4304,7 +4278,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5613,7 +5586,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5627,7 +5599,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5641,7 +5612,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5655,7 +5625,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5669,7 +5638,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5683,7 +5651,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5697,7 +5664,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5711,7 +5677,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5725,7 +5690,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5739,7 +5703,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5753,7 +5716,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5767,7 +5729,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5781,7 +5742,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5795,7 +5755,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5809,7 +5768,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5823,7 +5781,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5837,7 +5794,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5851,7 +5807,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5865,7 +5820,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5879,7 +5833,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5893,7 +5846,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5907,7 +5859,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5921,7 +5872,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5935,7 +5885,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5949,7 +5898,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6530,7 +6478,7 @@
       "version": "5.10.0",
       "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
       "integrity": "sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
@@ -6551,7 +6499,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7189,7 +7137,7 @@
       "version": "8.67.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.67.0.tgz",
       "integrity": "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.67.0",
@@ -7214,7 +7162,7 @@
       "version": "8.67.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
       "integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/tsconfig-utils": "^8.67.0",
@@ -7236,7 +7184,7 @@
       "version": "8.67.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
       "integrity": "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.67.0",
@@ -7254,7 +7202,7 @@
       "version": "8.67.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
       "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7296,7 +7244,7 @@
       "version": "8.67.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
       "integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7310,7 +7258,7 @@
       "version": "8.67.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
       "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/project-service": "8.67.0",
@@ -7338,7 +7286,7 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7375,7 +7323,7 @@
       "version": "8.67.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
       "integrity": "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.67.0",
@@ -7393,7 +7341,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -12679,7 +12627,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -22530,7 +22477,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
       "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.12"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
-        "@conduction/nextcloud-vue": "^2.6.2",
+        "@conduction/nextcloud-vue": "^2.7.0",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "^2.6.0",
         "@nextcloud/capabilities": "^1.2.1",
@@ -2112,9 +2112,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.6.3.tgz",
-      "integrity": "sha512-vtPrmkIwXobjjRXS3Zrkp/Xu/ahYBM/h5os4KZTUIVRBOVv208aModBbDeGJeqwcp4S9JlOKj2o3hheeC6cQTw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.7.0.tgz",
+      "integrity": "sha512-pAQBSaE+s2RjYhiXNJtbkvrj0rzyK300lZcMLuyJSVrUoQGVVHFd/dpM9az6i+Q9CJ+b8lUZ9gA6kPxL7AULHw==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
-        "@conduction/nextcloud-vue": "^2.7.0",
+        "@conduction/nextcloud-vue": "^2.7.1",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "^2.6.0",
         "@nextcloud/capabilities": "^1.2.1",
@@ -2112,9 +2112,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.7.0.tgz",
-      "integrity": "sha512-pAQBSaE+s2RjYhiXNJtbkvrj0rzyK300lZcMLuyJSVrUoQGVVHFd/dpM9az6i+Q9CJ+b8lUZ9gA6kPxL7AULHw==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.7.1.tgz",
+      "integrity": "sha512-Qivd4gNqPu01p7tffIiK0VEZEjkGRi57medKbHWFUzYM0K31GZu4nSCUsvGB0l/Q3SYiQQkxIeDHs9Fu08RpGg==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
-    "@conduction/nextcloud-vue": "^2.6.2",
+    "@conduction/nextcloud-vue": "^2.7.0",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "^2.6.0",
     "@nextcloud/capabilities": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
-    "@conduction/nextcloud-vue": "^2.7.0",
+    "@conduction/nextcloud-vue": "^2.7.1",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "^2.6.0",
     "@nextcloud/capabilities": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
-    "@conduction/nextcloud-vue": "^2.3.0",
+    "@conduction/nextcloud-vue": "^2.6.2",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "^2.6.0",
     "@nextcloud/capabilities": "^1.2.1",

--- a/src/views/flows/FlowDetailSidebar.vue
+++ b/src/views/flows/FlowDetailSidebar.vue
@@ -1,58 +1,21 @@
 <!--
   The flow controls, in Nextcloud's app sidebar. Shares `useFlowStore` with the
-  canvas, which is why neither needs props from the other.
+  canvas, which is why neither needs props from the other. Save/Run live on
+  CnFlowDetail's toolbar; the host page (FlowDetailPage) handles them.
 
   SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
   SPDX-License-Identifier: EUPL-1.2
 -->
 <template>
-	<CnFlowSidebar @save="onSave" @run="onRun" />
+	<CnFlowSidebar />
 </template>
 
 <script>
-import { CnFlowSidebar, useFlowStore } from '@conduction/nextcloud-vue'
+import { CnFlowSidebar } from '@conduction/nextcloud-vue'
 
 export default {
 	name: 'FlowDetailSidebar',
 
 	components: { CnFlowSidebar },
-
-	/**
-	 * Share the one flow store with the save/run handlers.
-	 *
-	 * @return {object} The setup bindings.
-	 * @spec openspec/changes/flow-engine-unification/specs/flow-storage/spec.md
-	 */
-	setup() {
-		return { store: useFlowStore() }
-	},
-
-	// Transition wiring: on @conduction/nextcloud-vue 2.4+ Save/Run live on
-	// CnFlowDetail's toolbar and CnFlowSidebar never emits these, so the
-	// handlers are inert; on 2.3.x the sidebar's buttons are the only Save/Run
-	// there is, and dropping the handlers would leave them dead. Remove once
-	// the fleet's lockfiles are past 2.4.
-	methods: {
-		/**
-		 * @spec openspec/changes/flow-engine-unification/specs/flow-storage/spec.md
-		 * @return {Promise<void>}
-		 */
-		async onSave() {
-			const saved = await this.store.save()
-			// A newly created flow gets its id from the server, so the route has
-			// to catch up or a reload would land back on `new`.
-			if (saved?.id && this.$route.params.id === 'new') {
-				this.$router.replace(`/flows/${saved.id}`)
-			}
-		},
-
-		/**
-		 * @spec openspec/changes/flow-engine-unification/specs/flow-storage/spec.md
-		 * @return {Promise<void>}
-		 */
-		async onRun() {
-			await this.store.run({})
-		},
-	},
 }
 </script>

--- a/src/views/flows/FlowsIndex.vue
+++ b/src/views/flows/FlowsIndex.vue
@@ -35,11 +35,7 @@
 		:actions="rowActions"
 		rowClickToView
 		@rowClick="openFlow">
-		<!-- The `#actions` inline slot, deliberately: it renders on every
-		     shipped @conduction/nextcloud-vue, where `#header-actions` only
-		     renders from 2.4 on. Keeps "New flow" reachable across the
-		     transition window. -->
-		<template #actions>
+		<template #header-actions>
 			<NcButton variant="primary" @click="createFlow">
 				<template #icon>
 					<Plus :size="20" />

--- a/tests/e2e/ci/flow-controls.spec.ts
+++ b/tests/e2e/ci/flow-controls.spec.ts
@@ -211,23 +211,16 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 			"the step palette did not render, so the empty state's own instruction cannot be followed",
 		).toBeVisible()
 
-		// Save and Run moved onto the canvas toolbar in the flow-editor
-		// consolidation (@conduction/nextcloud-vue 2.4). During the transition
-		// window the installed library may still be 2.3.x, whose Save/"Run now"
-		// live in the sidebar's actions block — so the spec drives whichever
-		// editor is actually installed, feature-detected at load. Both paths
-		// assert the same loop; neither is a reduced version of the other.
+		// Save and Run live on the canvas toolbar (flow-editor consolidation):
+		// the actions that concern the graph, on the graph.
 		const toolbar = page.getByRole('toolbar', { name: 'Flow editor' })
-		const actions = page.locator('.cn-flow-sidebar__actions')
+		const saveButton = toolbar.getByRole('button', {
+			name: 'Save',
+			exact: true,
+		})
+		const runButton = toolbar.getByRole('button', { name: 'Run', exact: true })
 
-		const saveButton = NEW_EDITOR
-			? toolbar.getByRole('button', { name: 'Save', exact: true })
-			: actions.getByRole('button', { name: 'Save', exact: true })
-		const runButton = NEW_EDITOR
-			? toolbar.getByRole('button', { name: 'Run', exact: true })
-			: actions.getByRole('button', { name: 'Run now', exact: true })
-
-		await expect(NEW_EDITOR ? toolbar : actions).toBeVisible()
+		await expect(toolbar).toBeVisible()
 		await expect(saveButton).toBeVisible()
 		await expect(runButton).toBeVisible()
 
@@ -301,29 +294,25 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 		const endCard = page.locator('.cn-flow-detail__node', { hasText: 'End' })
 		await expect(endCard, 'the step did not reach the canvas').toBeVisible()
 
-		if (NEW_EDITOR) {
-			// Connect the seeded start node to the End step, or the saved flow
-			// has a dead end and `FlowRunService::queue()` refuses to run it. A
-			// new flow opens with the manual-trigger start node already on the
-			// canvas (flow-editor consolidation), and the canvas's KEYBOARD
-			// connection path (`c` on the source, `c` on the target) is used
-			// because drag-to-connect is exactly the interaction this file
-			// already documents as unreliable. On 2.3.x there is no seeded node:
-			// the flow is the single terminal step above, which is the smallest
-			// flow the app calls valid, so there is nothing to connect.
-			const startCard = page.locator('.cn-flow-detail__node', {
-				hasText: 'When someone runs it',
-			})
-			await expect(startCard, 'the seeded start node is missing').toBeVisible()
-			await startCard.click()
-			await page.keyboard.press('c')
-			await endCard.click()
-			await page.keyboard.press('c')
-			await expect(
-				page.locator('.cn-flow-detail__edge').first(),
-				'the connection did not reach the canvas',
-			).toBeVisible()
-		}
+		// Connect the seeded start node to the End step, or the saved flow has
+		// a dead end and `FlowRunService::queue()` refuses to run it. A new
+		// flow opens with the manual-trigger start node already on the canvas
+		// (flow-editor consolidation), and the canvas's KEYBOARD connection
+		// path (`c` on the source, `c` on the target) is used because
+		// drag-to-connect is exactly the interaction this file already
+		// documents as unreliable.
+		const startCard = page.locator('.cn-flow-detail__node', {
+			hasText: 'When someone runs it',
+		})
+		await expect(startCard, 'the seeded start node is missing').toBeVisible()
+		await startCard.click()
+		await page.keyboard.press('c')
+		await endCard.click()
+		await page.keyboard.press('c')
+		await expect(
+			page.locator('.cn-flow-detail__edge').first(),
+			'the connection did not reach the canvas',
+		).toBeVisible()
 
 		// 3. SAVE PERSISTS.
 		//

--- a/tests/e2e/ci/flow-controls.spec.ts
+++ b/tests/e2e/ci/flow-controls.spec.ts
@@ -161,9 +161,9 @@ async function deleteFlow(
 			headers: {
 				requesttoken:
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-					((window as any).OC && (window as any).OC.requestToken) ||
-					(meta && meta.content) ||
-					'',
+					((window as any).OC && (window as any).OC.requestToken)
+					|| (meta && meta.content)
+					|| '',
 				Accept: 'application/json',
 			},
 		})
@@ -211,8 +211,8 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 		const read = Storage.prototype.getItem
 		Storage.prototype.getItem = function (key: string) {
 			if (
-				typeof key === 'string' &&
-				key.startsWith('cn-support-dialog-shown:')
+				typeof key === 'string'
+				&& key.startsWith('cn-support-dialog-shown:')
 			) {
 				return '1'
 			}
@@ -227,12 +227,8 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 		// Belt and braces: if the dialog still made it through (a server-backed
 		// dismissal mode would not read localStorage), close it rather than
 		// letting it swallow every canvas interaction that follows.
-		const supportDialog = page
-			.getByRole('dialog')
-			.filter({ hasText: 'Support' })
-		if (
-			await supportDialog.isVisible({ timeout: 2_000 }).catch(() => false)
-		) {
+		const supportDialog = page.getByRole('dialog').filter({ hasText: 'Support' })
+		if (await supportDialog.isVisible({ timeout: 2_000 }).catch(() => false)) {
 			await page.keyboard.press('Escape')
 			await expect(supportDialog).toBeHidden({ timeout: 10_000 })
 		}
@@ -307,9 +303,9 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 		// enablement IS the "editor initialised" signal, with no tab click.
 		await expect(
 			saveButton,
-			'the editor never initialised — the flow store is still holding its ' +
-				'blank initial state, whose name is empty, and a flow with no name ' +
-				'is rejected by the server',
+			'the editor never initialised — the flow store is still holding its '
+				+ 'blank initial state, whose name is empty, and a flow with no name '
+				+ 'is rejected by the server',
 		).toBeEnabled()
 
 		// 2. A STEP CAN BE ADDED.
@@ -374,10 +370,7 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 		const startNode = page.locator('.cn-graph-canvas__node', {
 			hasText: 'When someone runs it',
 		})
-		await expect(
-			startNode,
-			'the seeded start node is missing',
-		).toBeVisible()
+		await expect(startNode, 'the seeded start node is missing').toBeVisible()
 		const endNode = page.locator('.cn-graph-canvas__node', {
 			hasText: 'End',
 		})
@@ -410,8 +403,8 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 		// immediately, quoting the server.
 		const created = page.waitForResponse(
 			(response) =>
-				response.request().method() === 'POST' &&
-				new URL(response.url()).pathname.endsWith(
+				response.request().method() === 'POST'
+				&& new URL(response.url()).pathname.endsWith(
 					'/apps/openregister/api/flows',
 				),
 			{ timeout: 10_000 },
@@ -422,8 +415,8 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 		const createResponse = await created
 		expect(
 			createResponse.status(),
-			`the flow was not created — the server answered ${createResponse.status()}: ` +
-				`${(await createResponse.text()).slice(0, 200)}`,
+			`the flow was not created — the server answered ${createResponse.status()}: `
+				+ `${(await createResponse.text()).slice(0, 200)}`,
 		).toBe(201)
 
 		const uuid = String((await createResponse.json())?.id ?? '')
@@ -444,8 +437,8 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 		//    depends on whether the worker has reached it yet.
 		const queued = page.waitForResponse(
 			(response) =>
-				response.request().method() === 'POST' &&
-				response.url().includes(`/api/flows/${uuid}/run`),
+				response.request().method() === 'POST'
+				&& response.url().includes(`/api/flows/${uuid}/run`),
 			{ timeout: 10_000 },
 		)
 
@@ -454,8 +447,8 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 		const runResponse = await queued
 		expect(
 			runResponse.status(),
-			`Run now was refused — the server answered ${runResponse.status()}: ` +
-				`${(await runResponse.text()).slice(0, 200)}`,
+			`Run now was refused — the server answered ${runResponse.status()}: `
+				+ `${(await runResponse.text()).slice(0, 200)}`,
 		).toBe(201)
 
 		// And the run is ATTRIBUTED to this flow — a separate claim from "a run

--- a/tests/e2e/ci/flow-controls.spec.ts
+++ b/tests/e2e/ci/flow-controls.spec.ts
@@ -189,8 +189,46 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 		}
 	})
 
+	// THE SUPPORT DIALOG COVERS THE CANVAS, AND CI ALWAYS GETS IT.
+	//
+	// `CnSupportDialog` is a first-open note from the founder. It records its
+	// dismissal in `localStorage` under `cn-support-dialog-shown:<appSlug>`, so
+	// a human sees it once — but every Playwright context starts with empty
+	// storage, so CI sees it EVERY run, centred over the editor.
+	//
+	// It was never noticed because the sidebar and palette sit outside its
+	// backdrop: adding a step kept working, and the canvas assertions that
+	// would have caught it were gated behind a `NEW_EDITOR` feature-detect that
+	// was false on every installed 2.3.x. The first canvas interaction to
+	// actually run met a modal that traps focus — the click timed out and the
+	// keypress went to the dialog, so no edge was ever drawn.
+	//
+	// Suppressed by the flag the dialog itself reads, matched on the PREFIX so
+	// this does not silently miss if the app's slug differs from its id. This
+	// hides nothing under test: the dialog is not this spec's subject, and a
+	// spec whose subject is the canvas must be able to reach the canvas.
+	await page.addInitScript(() => {
+		const read = Storage.prototype.getItem
+		Storage.prototype.getItem = function (key: string) {
+			if (typeof key === 'string' && key.startsWith('cn-support-dialog-shown:')) {
+				return '1'
+			}
+
+			return read.call(this, key)
+		}
+	})
+
 	try {
 		await page.goto(FLOWS_ROUTE, { waitUntil: 'domcontentloaded' })
+
+		// Belt and braces: if the dialog still made it through (a server-backed
+		// dismissal mode would not read localStorage), close it rather than
+		// letting it swallow every canvas interaction that follows.
+		const supportDialog = page.getByRole('dialog').filter({ hasText: 'Support' })
+		if (await supportDialog.isVisible({ timeout: 2_000 }).catch(() => false)) {
+			await page.keyboard.press('Escape')
+			await expect(supportDialog).toBeHidden({ timeout: 10_000 })
+		}
 
 		// Reach the editor the way a user does. Direct navigation to
 		// `#/flows/new` does not always hydrate the canvas.

--- a/tests/e2e/ci/flow-controls.spec.ts
+++ b/tests/e2e/ci/flow-controls.spec.ts
@@ -101,27 +101,6 @@ const STORAGE_STATE = path.resolve(__dirname, '../.auth/admin.json')
 
 const FLOWS_ROUTE = '/index.php/apps/openregister/#/flows'
 
-// Whether the INSTALLED library carries the consolidated editor (toolbar +
-// seeded start node). Feature-detected on the source the bundle was built
-// from, not on a version number: the transition window installs 2.3.x from
-// npm while dev instances may run a synced pre-release tree, and a version
-// string cannot tell those apart. Self-clears on the lockfile bump.
-const NEW_EDITOR = (() => {
-	try {
-		return fs
-			.readFileSync(
-				path.resolve(
-					__dirname,
-					'../../../node_modules/@conduction/nextcloud-vue/src/components/CnFlowDetail/CnFlowDetail.vue',
-				),
-				'utf8',
-			)
-			.includes('cn-flow-detail__toolbar')
-	} catch {
-		return false
-	}
-})()
-
 test.use(fs.existsSync(STORAGE_STATE) ? { storageState: STORAGE_STATE } : {})
 
 /**

--- a/tests/e2e/ci/flow-controls.spec.ts
+++ b/tests/e2e/ci/flow-controls.spec.ts
@@ -161,9 +161,9 @@ async function deleteFlow(
 			headers: {
 				requesttoken:
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-					((window as any).OC && (window as any).OC.requestToken)
-					|| (meta && meta.content)
-					|| '',
+					((window as any).OC && (window as any).OC.requestToken) ||
+					(meta && meta.content) ||
+					'',
 				Accept: 'application/json',
 			},
 		})
@@ -210,7 +210,10 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 	await page.addInitScript(() => {
 		const read = Storage.prototype.getItem
 		Storage.prototype.getItem = function (key: string) {
-			if (typeof key === 'string' && key.startsWith('cn-support-dialog-shown:')) {
+			if (
+				typeof key === 'string' &&
+				key.startsWith('cn-support-dialog-shown:')
+			) {
 				return '1'
 			}
 
@@ -224,8 +227,12 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 		// Belt and braces: if the dialog still made it through (a server-backed
 		// dismissal mode would not read localStorage), close it rather than
 		// letting it swallow every canvas interaction that follows.
-		const supportDialog = page.getByRole('dialog').filter({ hasText: 'Support' })
-		if (await supportDialog.isVisible({ timeout: 2_000 }).catch(() => false)) {
+		const supportDialog = page
+			.getByRole('dialog')
+			.filter({ hasText: 'Support' })
+		if (
+			await supportDialog.isVisible({ timeout: 2_000 }).catch(() => false)
+		) {
 			await page.keyboard.press('Escape')
 			await expect(supportDialog).toBeHidden({ timeout: 10_000 })
 		}
@@ -256,7 +263,10 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 			name: 'Save',
 			exact: true,
 		})
-		const runButton = toolbar.getByRole('button', { name: 'Run', exact: true })
+		const runButton = toolbar.getByRole('button', {
+			name: 'Run',
+			exact: true,
+		})
 
 		await expect(toolbar).toBeVisible()
 		await expect(saveButton).toBeVisible()
@@ -297,9 +307,9 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 		// enablement IS the "editor initialised" signal, with no tab click.
 		await expect(
 			saveButton,
-			'the editor never initialised — the flow store is still holding its '
-				+ 'blank initial state, whose name is empty, and a flow with no name '
-				+ 'is rejected by the server',
+			'the editor never initialised — the flow store is still holding its ' +
+				'blank initial state, whose name is empty, and a flow with no name ' +
+				'is rejected by the server',
 		).toBeEnabled()
 
 		// 2. A STEP CAN BE ADDED.
@@ -329,7 +339,9 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 		// reason the job went red: `EndNode::getLabel()` returns `t('End')`, and
 		// the palette has carried no entry called "Stop" since that commit.
 		await clickThemed(palette.getByText('End', { exact: true }).first())
-		const endCard = page.locator('.cn-flow-detail__node', { hasText: 'End' })
+		const endCard = page.locator('.cn-flow-detail__node', {
+			hasText: 'End',
+		})
 		await expect(endCard, 'the step did not reach the canvas').toBeVisible()
 
 		// Connect the seeded start node to the End step, or the saved flow has
@@ -362,16 +374,31 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 		const startNode = page.locator('.cn-graph-canvas__node', {
 			hasText: 'When someone runs it',
 		})
-		await expect(startNode, 'the seeded start node is missing').toBeVisible()
-		const endNode = page.locator('.cn-graph-canvas__node', { hasText: 'End' })
+		await expect(
+			startNode,
+			'the seeded start node is missing',
+		).toBeVisible()
+		const endNode = page.locator('.cn-graph-canvas__node', {
+			hasText: 'End',
+		})
 		await expect(endNode, 'the End step is missing').toBeVisible()
 
 		await startNode.press('c')
 		await endNode.press('c')
+
+		// COUNT THE EDGE, DO NOT ASK WHETHER IT IS "VISIBLE".
+		//
+		// The edge is an SVG <path>. Auto-layout stacks these two steps in one
+		// column, so the orthogonal route between them is a STRAIGHT VERTICAL
+		// LINE — a bounding box of zero width. Playwright treats a zero-area
+		// element as not visible, so `toBeVisible()` fails on an edge that is
+		// on screen and plainly drawn (the failure screenshot shows the arrow).
+		// Presence is the honest assertion here, and it is the one that fails
+		// if the connection genuinely never happened.
 		await expect(
-			page.locator('.cn-flow-detail__edge').first(),
+			page.locator('.cn-flow-detail__edge'),
 			'the connection did not reach the canvas',
-		).toBeVisible()
+		).toHaveCount(1)
 
 		// 3. SAVE PERSISTS.
 		//
@@ -383,8 +410,8 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 		// immediately, quoting the server.
 		const created = page.waitForResponse(
 			(response) =>
-				response.request().method() === 'POST'
-				&& new URL(response.url()).pathname.endsWith(
+				response.request().method() === 'POST' &&
+				new URL(response.url()).pathname.endsWith(
 					'/apps/openregister/api/flows',
 				),
 			{ timeout: 10_000 },
@@ -395,8 +422,8 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 		const createResponse = await created
 		expect(
 			createResponse.status(),
-			`the flow was not created — the server answered ${createResponse.status()}: `
-				+ `${(await createResponse.text()).slice(0, 200)}`,
+			`the flow was not created — the server answered ${createResponse.status()}: ` +
+				`${(await createResponse.text()).slice(0, 200)}`,
 		).toBe(201)
 
 		const uuid = String((await createResponse.json())?.id ?? '')
@@ -408,15 +435,17 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 		// The route still has to catch up, or a reload lands back on `new`. With
 		// the create already asserted above this is a pure router assertion with
 		// no round-trip left in it, so it needs a fraction of the old budget.
-		await page.waitForURL(new RegExp(`#/flows/${uuid}$`), { timeout: 5_000 })
+		await page.waitForURL(new RegExp(`#/flows/${uuid}$`), {
+			timeout: 5_000,
+		})
 
 		// 4. RUN NOW CREATES A RUN. Asserted against the API rather than the
 		//    rendered status, because the status a run is DISPLAYED with
 		//    depends on whether the worker has reached it yet.
 		const queued = page.waitForResponse(
 			(response) =>
-				response.request().method() === 'POST'
-				&& response.url().includes(`/api/flows/${uuid}/run`),
+				response.request().method() === 'POST' &&
+				response.url().includes(`/api/flows/${uuid}/run`),
 			{ timeout: 10_000 },
 		)
 
@@ -425,8 +454,8 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 		const runResponse = await queued
 		expect(
 			runResponse.status(),
-			`Run now was refused — the server answered ${runResponse.status()}: `
-				+ `${(await runResponse.text()).slice(0, 200)}`,
+			`Run now was refused — the server answered ${runResponse.status()}: ` +
+				`${(await runResponse.text()).slice(0, 200)}`,
 		).toBe(201)
 
 		// And the run is ATTRIBUTED to this flow — a separate claim from "a run

--- a/tests/e2e/ci/flow-controls.spec.ts
+++ b/tests/e2e/ci/flow-controls.spec.ts
@@ -301,14 +301,35 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 		// path (`c` on the source, `c` on the target) is used because
 		// drag-to-connect is exactly the interaction this file already
 		// documents as unreliable.
-		const startCard = page.locator('.cn-flow-detail__node', {
+		// DRIVE THE ELEMENT THAT OWNS THE HANDLER, NOT THE CARD INSIDE IT.
+		//
+		// `onNodeKeydown` is bound to CnGraphCanvas's `.cn-graph-canvas__node`
+		// wrapper — the element carrying `tabindex="0"`. `.cn-flow-detail__node`
+		// is the card CnFlowDetail renders into that wrapper's slot, and it is
+		// not focusable. Clicking the card and then pressing a key globally
+		// relies on the browser walking up to focus the ancestor, which is
+		// exactly the ambiguity that made this fail: the click landed, the
+		// keydown went to the body, and no edge appeared.
+		//
+		// `locator.press()` focuses its element and dispatches the key there,
+		// so the interaction under test is the one the component implements.
+		// Verified at the unit level in @conduction/nextcloud-vue
+		// (tests/components/CnFlowKeyboardConnect.spec.js): keydown `c` on each
+		// wrapper produces the edge.
+		//
+		// NB this assertion is NEW IN PRACTICE. It has always been written, but
+		// it sat behind a `NEW_EDITOR` feature-detect that read the INSTALLED
+		// library for a 2.4+ marker — false on every 2.3.x — so it never ran
+		// and reported green by not executing.
+		const startNode = page.locator('.cn-graph-canvas__node', {
 			hasText: 'When someone runs it',
 		})
-		await expect(startCard, 'the seeded start node is missing').toBeVisible()
-		await startCard.click()
-		await page.keyboard.press('c')
-		await endCard.click()
-		await page.keyboard.press('c')
+		await expect(startNode, 'the seeded start node is missing').toBeVisible()
+		const endNode = page.locator('.cn-graph-canvas__node', { hasText: 'End' })
+		await expect(endNode, 'the End step is missing').toBeVisible()
+
+		await startNode.press('c')
+		await endNode.press('c')
 		await expect(
 			page.locator('.cn-flow-detail__edge').first(),
 			'the connection did not reach the canvas',

--- a/tests/e2e/flow-engine.spec.ts
+++ b/tests/e2e/flow-engine.spec.ts
@@ -20,7 +20,6 @@
  * @spec openspec/changes/flow-engine-unification/specs/flow-execution-history/spec.md
  */
 import { test, expect, type APIRequestContext } from '@playwright/test'
-import * as fs from 'fs'
 import * as path from 'path'
 // Routes are imported by COMPONENT NAME (see tests/e2e/_page-routes.ts): the
 // binding records which page host each route mounts, which a bare path string
@@ -30,27 +29,6 @@ import { FlowsIndex, FlowDetailPage } from './_page-routes'
 const STORAGE_STATE = path.resolve(__dirname, '.auth/admin.json')
 
 const RUN_ID = `e2e-flow-${Date.now().toString(36)}`
-
-// Whether the INSTALLED library carries the consolidated editor (toolbar +
-// seeded start node). Feature-detected on the source the bundle was built
-// from, not on a version number: the transition window installs 2.3.x from
-// npm while dev instances may run a synced pre-release tree, and a version
-// string cannot tell those apart. Self-clears on the lockfile bump.
-const NEW_EDITOR = (() => {
-	try {
-		return fs
-			.readFileSync(
-				path.resolve(
-					__dirname,
-					'../../node_modules/@conduction/nextcloud-vue/src/components/CnFlowDetail/CnFlowDetail.vue',
-				),
-				'utf8',
-			)
-			.includes('cn-flow-detail__toolbar')
-	} catch {
-		return false
-	}
-})()
 
 // The API describes run with NO session, deliberately.
 //
@@ -322,10 +300,6 @@ test.describe('the Flows page', () => {
 	test('a new flow is the SAME editor holding only a starting point', async ({
 		page,
 	}) => {
-		test.skip(
-			!NEW_EDITOR,
-			'requires the flow-editor consolidation (@conduction/nextcloud-vue ≥ 2.4) — self-clears on the lockfile bump',
-		)
 		await page.goto(`/apps/openregister/#${FlowDetailPage('new')}`, {
 			waitUntil: 'domcontentloaded',
 		})
@@ -360,10 +334,6 @@ test.describe('the Flows page', () => {
 		page,
 		request,
 	}) => {
-		test.skip(
-			!NEW_EDITOR,
-			'requires the flow-editor consolidation (@conduction/nextcloud-vue ≥ 2.4) — self-clears on the lockfile bump',
-		)
 		await page.goto(`/apps/openregister/#${FlowDetailPage('new')}`, {
 			waitUntil: 'domcontentloaded',
 		})


### PR DESCRIPTION
Per the merged `flow-editor-fleet-completion` plan (task 2.1): lockfile past 2.6.2 (consolidated editor + round-2 review fixes: NC sidebar chrome, one-container nodes, per-step edit dialog), shims removed exactly as their in-place markers said (New flow button on the now-implemented `#header-actions` slot, plain FlowDetailSidebar, e2e `NEW_EDITOR` gates dropped — flow-controls.spec collapses to the toolbar path and the new-editor Playwright tests run unconditionally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)