### PR TITLE
feat(flow): object-write bulk mode + configForm (flow-native-synchronization task 1.4)

### DIFF
--- a/lib/Service/Flow/Nodes/ObjectWriteNode.php
+++ b/lib/Service/Flow/Nodes/ObjectWriteNode.php
@@ -45,6 +45,20 @@
  * fourth are enforced when the flow is SAVED, because a flow that could delete
  * unboundedly must not be persistable at all.
  *
+ * BULK MODE (`bulk: true`) trades the per-item service round-trip for ONE
+ * `ObjectService::saveObjects()` call covering the whole page of items. It is
+ * for pipelines whose item count comes from an external source — a
+ * synchronization page of hundreds of rows — where per-item `saveObject()` is
+ * the dominant cost. The trade is explicit and validated at save time:
+ * only `create` and `upsert` qualify (`update` and `delete` keep their
+ * per-item guards), a bulk upsert must match on `uuid` alone and carry
+ * `replace: true` because the bulk path replaces whole objects and cannot
+ * patch, and `onConflict: fail` is refused because the bulk path cannot
+ * arbitrate per-row claims. Per-object lifecycle events are not dispatched —
+ * that is much of what makes it bulk. Attribution and RBAC do not move:
+ * the one call still runs inside `runAs($owner)` and `saveObjects()` applies
+ * its own per-row permission checks.
+ *
  * The delete is SOFT unless `permanent: true` says otherwise, and that default
  * does not move: a tombstone is what makes a mistaken flow recoverable. The
  * opt-out exists for a row that is a CLAIM rather than a record — a lock, a slot,
@@ -83,6 +97,7 @@ use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Service\Flow\FlowItems;
 use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigForm;
 use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\IAppConfig;
@@ -93,6 +108,7 @@ use OCP\IUserManager;
 use OCA\OpenRegister\Exception\SchemaNotInRegisterException;
 use OCP\WorkflowEngine\IManager;
 use RuntimeException;
+use Symfony\Component\Uid\Uuid;
 use Throwable;
 use UnexpectedValueException;
 
@@ -104,7 +120,7 @@ use UnexpectedValueException;
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) One branch per named configuration key and one per operation; collapsing it hides the guards.
  * @SuppressWarnings(PHPMD.TooManyMethods)           One small, named method per guard and per operation; merging them would bury the delete guards.
  */
-class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys {
+class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigForm {
 
 	/**
 	 * Insert a new object; never look for an existing one.
@@ -409,6 +425,7 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys {
 			'fields',
 			'match',
 			'replace',
+			'bulk',
 			'output',
 			'confirmDelete',
 			'permanent',
@@ -419,6 +436,141 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys {
 		];
 
 	}//end configKeys()
+
+	/**
+	 * The fields this node is edited through.
+	 *
+	 * `fields` and `match` are deliberately absent: they are structured values
+	 * whose shape depends on the schema being written, and the editor's JSON
+	 * pane represents them honestly where a flat text field would not.
+	 *
+	 * @return array<int, array<string, mixed>> The field descriptions.
+	 *
+	 * @spec openspec/changes/or-flow-bulk-object-write/specs/flow-object-write-bulk/spec.md
+	 */
+	public function configForm(): array {
+		return array_merge($this->targetConfigForm(), $this->policyConfigForm());
+	}//end configForm()
+
+	/**
+	 * The form fields naming WHAT is written and where.
+	 *
+	 * @return array<int, array<string, mixed>> The field descriptions.
+	 *
+	 * @spec openspec/changes/or-flow-bulk-object-write/specs/flow-object-write-bulk/spec.md
+	 */
+	private function targetConfigForm(): array {
+		return [
+			[
+				'key' => 'register',
+				'label' => $this->l10n->t('Register'),
+				'type' => 'select',
+				'help' => $this->l10n->t('The register the objects are written into.'),
+				'required' => true,
+				'optionsFrom' => '/apps/openregister/api/registers',
+			],
+			[
+				'key' => 'schema',
+				'label' => $this->l10n->t('Schema'),
+				'type' => 'select',
+				'help' => $this->l10n->t(
+					'The schema the objects are validated against. A slug is resolved within the chosen register only.'
+				),
+				'required' => true,
+				'optionsFrom' => '/apps/openregister/api/schemas',
+			],
+			[
+				'key' => 'operation',
+				'label' => $this->l10n->t('Operation'),
+				'type' => 'text',
+				'help' => $this->l10n->t(
+					'One of: create, update, upsert, delete. Update, upsert and delete need at least one match pair.'
+				),
+				'required' => true,
+			],
+			[
+				'key' => 'bulk',
+				'label' => $this->l10n->t('Write the whole page in one call'),
+				'type' => 'boolean',
+				'help' => $this->l10n->t(
+					'Create and upsert only. One bulk save covers every item — much faster for large pages, '
+					.'but per-object lifecycle events are not dispatched, and a bulk upsert must match on "uuid" alone with "replace" on.'
+				),
+			],
+			[
+				'key' => 'replace',
+				'label' => $this->l10n->t('Replace instead of patch'),
+				'type' => 'boolean',
+				'help' => $this->l10n->t(
+					'An update normally patches only the fields named. '
+					.'Replacing writes the payload as the whole object — fields it does not name are gone.'
+				),
+			],
+			[
+				'key' => 'output',
+				'label' => $this->l10n->t('Field to store the written object in'),
+				'type' => 'text',
+				'help' => $this->l10n->t(
+					'With a field name, the incoming item is preserved and the written object is added under it. '
+					.'Empty means the written object replaces the item.'
+				),
+			],
+		];
+	}//end targetConfigForm()
+
+	/**
+	 * The form fields naming HOW capping, conflict and deletion behave.
+	 *
+	 * @return array<int, array<string, mixed>> The field descriptions.
+	 *
+	 * @spec openspec/changes/or-flow-bulk-object-write/specs/flow-object-write-bulk/spec.md
+	 */
+	private function policyConfigForm(): array {
+		return [
+			[
+				'key' => 'maxWrites',
+				'label' => $this->l10n->t('Write cap'),
+				'type' => 'number',
+				'help' => $this->l10n->t('The most writes one step execution may perform. The instance default applies when empty.'),
+			],
+			[
+				'key' => 'onMissing',
+				'label' => $this->l10n->t('When a field value is missing'),
+				'type' => 'text',
+				'help' => $this->l10n->t('"omit" (default) drops the field from the payload; "fail" fails the item.'),
+			],
+			[
+				'key' => 'onConflict',
+				'label' => $this->l10n->t('When a created identifier is taken'),
+				'type' => 'text',
+				'help' => $this->l10n->t(
+					'"overwrite" (default) keeps the historical upsert behaviour; '
+					.'"fail" refuses, for writes that are claims — locks, slots, leases. Not available in bulk.'
+				),
+			],
+			[
+				'key' => 'onNoMatch',
+				'label' => $this->l10n->t('When a delete matches nothing'),
+				'type' => 'text',
+				'help' => $this->l10n->t('"error" (default) fails the item; "skip" passes it through with "deleted": false.'),
+			],
+			[
+				'key' => 'confirmDelete',
+				'label' => $this->l10n->t('Confirm deletion'),
+				'type' => 'boolean',
+				'help' => $this->l10n->t('A delete step will not save without this deliberate second acknowledgement.'),
+			],
+			[
+				'key' => 'permanent',
+				'label' => $this->l10n->t('Destroy instead of tombstone'),
+				'type' => 'boolean',
+				'help' => $this->l10n->t(
+					'Deletes are soft by default, which is what makes a mistaken flow recoverable. '
+					.'Turn this on only for rows that are claims whose identifier must become claimable again.'
+				),
+			],
+		];
+	}//end policyConfigForm()
 
 	/**
 	 * Refuse a configuration the author cannot have meant.
@@ -475,7 +627,93 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys {
 		$this->validateOperationKeys(config: $config, operation: $operation);
 		$this->validateOptionKeys(config: $config);
 
+		if (array_key_exists('bulk', $config) === true) {
+			$this->validateBulkKeys(config: $config, operation: $operation);
+		}
+
 	}//end validateConfig()
+
+	/**
+	 * The save-time half of the bulk guards.
+	 *
+	 * Bulk mode swaps the per-item service round-trip for one
+	 * `saveObjects()` call, and that path genuinely has fewer semantics than
+	 * the single-object one: it replaces rather than patches, it cannot
+	 * arbitrate a per-row claim, and it decides create-versus-update by row
+	 * uuid rather than by a composite match. Every one of those gaps is
+	 * refused HERE, at save time, rather than silently absorbed at 3am —
+	 * the same rule the delete guards follow.
+	 *
+	 * @param array $config The step configuration.
+	 * @param string $operation The configured operation.
+	 *
+	 * @return void
+	 *
+	 * @throws UnexpectedValueException When bulk is combined with semantics the bulk path does not have.
+	 *
+	 * @spec openspec/changes/or-flow-bulk-object-write/specs/flow-object-write-bulk/spec.md
+	 */
+	private function validateBulkKeys(array $config, string $operation): void {
+		// A boolean, strictly — the string "false" is truthy, and this switch
+		// changes which write path a whole page of items goes down.
+		if (is_bool($config['bulk']) === false) {
+			throw new UnexpectedValueException(
+				$this->l10n->t('"bulk" must be true or false, as a boolean.')
+			);
+		}
+
+		if ($config['bulk'] === false) {
+			return;
+		}
+
+		if (in_array($operation, [self::OP_CREATE, self::OP_UPSERT], true) === false) {
+			throw new UnexpectedValueException(
+				$this->l10n->t('"bulk" supports create and upsert only; a "%s" step writes one object at a time, keeping its per-item guards.', [$operation])
+			);
+		}
+
+		// `saveObjects()` upserts silently; there is no per-row failIfExists.
+		// Offering `fail` here would accept the claim semantics and not
+		// deliver them, which is the exact defect ON_CONFLICT_FAIL exists
+		// to prevent.
+		if (($config['onConflict'] ?? null) === self::ON_CONFLICT_FAIL) {
+			throw new UnexpectedValueException(
+				$this->l10n->t(
+					'"onConflict": "fail" is not available in bulk; the bulk path cannot arbitrate per-row claims. '
+					.'Use the single-object path for writes that are claims.'
+				)
+			);
+		}
+
+		if ($operation !== self::OP_UPSERT) {
+			return;
+		}
+
+		// The bulk path is PUT-semantic — MagicMapper writes whole rows and
+		// never consults the stored object first — so a bulk upsert without
+		// `replace: true` would silently null every field the mapping did not
+		// mention. Rule 2 of this node forbids exactly that, so the author
+		// must say the word.
+		if (($config['replace'] ?? null) !== true) {
+			throw new UnexpectedValueException(
+				$this->l10n->t('A bulk upsert must carry "replace": true — the bulk path replaces whole objects and cannot patch.')
+			);
+		}
+
+		// `saveObjects()` decides create-versus-update by the row's uuid, so
+		// the uuid is the ONLY match a bulk upsert can honour. A composite
+		// match accepted here would be evaluated by nothing.
+		$pairs = $this->matchPairs(config: $config);
+		$property = ($pairs[0]['property'] ?? '');
+		if (count($pairs) !== 1
+			|| in_array($property, ['uuid', self::SELF_PREFIX.'uuid'], true) === false
+		) {
+			throw new UnexpectedValueException(
+				$this->l10n->t('A bulk upsert must match on exactly one property, "uuid" (or "@self.uuid"); a composite match needs the single-object path.')
+			);
+		}
+
+	}//end validateBulkKeys()
 
 	/**
 	 * Write one object per item, as the run's owner.
@@ -554,6 +792,23 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys {
 		//
 		// This narrows; it never grants. A run whose owner cannot write is
 		// still refused, and now says so for the right reason.
+		if (($config['bulk'] ?? false) === true) {
+			return $this->objects->runAs(
+				$owner,
+				fn (): array => $this->writeBulk(
+					items: $items,
+					config: $config,
+					operation: $operation,
+					register: $register,
+					schema: $schema,
+					pairs: $pairs,
+					fields: $fields,
+					onMissing: $onMissing,
+					cap: $cap
+				)
+			);
+		}
+
 		return $this->objects->runAs(
 			$owner,
 			fn (): array => $this->writeItems(
@@ -677,6 +932,233 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys {
 
 		return $out;
 	}//end writeItems()
+
+	/**
+	 * Write the whole page of items through ONE `saveObjects()` call.
+	 *
+	 * Every row's uuid is decided CLIENT-SIDE before the call — generated for
+	 * a create, taken from the item's match value for an upsert — because the
+	 * bulk result comes back categorised (`saved` / `updated` / `unchanged`),
+	 * not in input order. Owning the uuid is what lets each output item name
+	 * the row it produced without guessing at a correlation, and it is what a
+	 * downstream contract-commit step reads as the target id.
+	 *
+	 * The cap is enforced against the page size BEFORE anything is written.
+	 * The per-item path stops at the cap mid-page, which is recoverable
+	 * because each write already happened or did not; one bulk call has no
+	 * such midpoint, so the only honest cap is a refusal up front.
+	 *
+	 * @param array $items The input items.
+	 * @param array $config The step configuration.
+	 * @param string $operation The resolved operation (create or upsert).
+	 * @param Register $register The resolved register.
+	 * @param Schema $schema The resolved schema.
+	 * @param array $pairs The match pairs (one uuid pair for an upsert).
+	 * @param array $fields The configured fields.
+	 * @param string $onMissing The missing-field policy.
+	 * @param int $cap The write cap.
+	 *
+	 * @return array One output item per input item.
+	 *
+	 * @throws RuntimeException When the page exceeds the cap, a match value cannot
+	 *                          be resolved, or the bulk save rejected rows.
+	 *
+	 * @SuppressWarnings(PHPMD.ExcessiveParameterList) The parameters execute() already resolved, same as writeItems().
+	 *
+	 * @spec openspec/changes/or-flow-bulk-object-write/specs/flow-object-write-bulk/spec.md
+	 */
+	private function writeBulk(
+		array $items,
+		array $config,
+		string $operation,
+		Register $register,
+		Schema $schema,
+		array $pairs,
+		array $fields,
+		string $onMissing,
+		int $cap,
+	): array {
+		if (count($items) > $cap) {
+			throw new RuntimeException(
+				$this->l10n->t(
+					'This bulk write of %1$s items exceeds the step\'s write cap of %2$s; nothing was written.',
+					[(string)count($items), (string)$cap]
+				)
+			);
+		}
+
+		$rows = [];
+		$ids = [];
+		foreach ($items as $index => $item) {
+			$json = (array)($item[FlowItems::JSON] ?? []);
+			$payload = $this->buildPayload(fields: $fields, json: $json, onMissing: $onMissing);
+			$id = $this->bulkRowId(operation: $operation, pairs: $pairs, json: $json);
+			$payload['id'] = $id;
+			$rows[] = $payload;
+			$ids[$index] = $id;
+		}
+
+		// Validation stays ON to keep parity with the single-object path;
+		// per-object lifecycle events stay OFF because dispatching thousands
+		// of them is precisely the cost bulk mode exists to shed — the
+		// palette help says so in as many words.
+		$result = $this->objects->saveObjects(
+			objects: $rows,
+			register: $register,
+			schema: $schema,
+			validation: true,
+			events: false
+		);
+
+		$this->guardBulkFailures(result: $result);
+		$written = $this->indexBulkResults(result: $result);
+
+		$out = [];
+		$position = 0;
+		foreach ($items as $index => $item) {
+			$id = (string)$ids[$index];
+			$saved = ($written[$id] ?? null);
+
+			// The bulk result carries the serialised row when the id came
+			// back; the sent payload is the fallback so the output never
+			// goes dark.
+			$json = $saved;
+			if (is_array($json) === false) {
+				$json = $rows[$position];
+			}
+
+			$position++;
+
+			unset($json['@self'], $json['id']);
+			$json['uuid'] = $id;
+			$json['register'] = $this->identifierOf(register: $register);
+			$json['schema'] = $this->labelOf(schema: $schema);
+
+			$out[] = FlowItems::item(
+				json: $this->outputJson(
+					incoming: (array)($item[FlowItems::JSON] ?? []),
+					written: $json,
+					config: $config
+				),
+				binary: (array)($item[FlowItems::BINARY] ?? []),
+				fromItemIndex: (int)$index
+			);
+		}//end foreach
+
+		return $out;
+	}//end writeBulk()
+
+	/**
+	 * The uuid one bulk row is written under.
+	 *
+	 * A create generates one — the same v4 form `saveObjects()` itself would
+	 * assign — so the node knows every row's identity without re-reading. An
+	 * upsert resolves the single uuid match pair against the item; a value
+	 * that does not resolve fails the item rather than widening into a
+	 * create, because a match key is never omitted.
+	 *
+	 * @param string $operation The resolved operation.
+	 * @param array $pairs The match pairs.
+	 * @param array $json The item's record.
+	 *
+	 * @return string The row uuid.
+	 *
+	 * @throws RuntimeException When an upsert's match value cannot be resolved.
+	 *
+	 * @spec openspec/changes/or-flow-bulk-object-write/specs/flow-object-write-bulk/spec.md
+	 */
+	private function bulkRowId(string $operation, array $pairs, array $json): string {
+		if ($operation === self::OP_CREATE) {
+			return Uuid::v4()->toRfc4122();
+		}
+
+		$property = (string)($pairs[0]['property'] ?? 'uuid');
+		$resolved = $this->resolveTemplate(value: ($pairs[0]['value'] ?? null), json: $json);
+		$id = '';
+		if ($resolved['resolved'] === true && is_scalar($resolved['value']) === true) {
+			$id = trim((string)$resolved['value']);
+		}
+
+		if ($id === '') {
+			throw new RuntimeException(
+				$this->l10n->t('The match value for "%s" could not be resolved from the item; a match key is never omitted.', [$property])
+			);
+		}
+
+		return $id;
+	}//end bulkRowId()
+
+	/**
+	 * Refuse to report a bulk save that rejected rows as a success.
+	 *
+	 * `saveObjects()` never throws for a rejected row — refusals land in the
+	 * result's `invalid` and `errors` buckets while the accepted rows are
+	 * already written. Folding that into per-item output would be exactly the
+	 * hollow success this node's third rule forbids, so the step fails
+	 * loudly, naming the count, the first reason, and the fact that the
+	 * accepted writes were not rolled back.
+	 *
+	 * @param array $result The bulk save result.
+	 *
+	 * @return void
+	 *
+	 * @throws RuntimeException When any row was rejected.
+	 *
+	 * @spec openspec/changes/or-flow-bulk-object-write/specs/flow-object-write-bulk/spec.md
+	 */
+	private function guardBulkFailures(array $result): void {
+		$invalid = (array)($result['invalid'] ?? []);
+		$errors = (array)($result['errors'] ?? []);
+
+		// `invalid` and `errors` mirror each other for safeguard rejections;
+		// take the larger so a bucket populated by only one path still counts.
+		$failures = max(count($invalid), count($errors));
+		if ($failures === 0) {
+			return;
+		}
+
+		$first = '';
+		foreach (array_merge($invalid, $errors) as $entry) {
+			if (is_array($entry) === true && trim((string)($entry['error'] ?? '')) !== '') {
+				$first = trim((string)$entry['error']);
+				break;
+			}
+		}
+
+		throw new RuntimeException(
+			$this->l10n->t(
+				'The bulk write rejected %1$s of its rows (first reason: %2$s); accepted rows were written and were not rolled back.',
+				[(string)$failures, $first]
+			)
+		);
+
+	}//end guardBulkFailures()
+
+	/**
+	 * Index the bulk result's serialised rows by uuid.
+	 *
+	 * @param array $result The bulk save result.
+	 *
+	 * @return array<string, array<string, mixed>> Serialised rows keyed by uuid.
+	 */
+	private function indexBulkResults(array $result): array {
+		$written = [];
+		foreach (['saved', 'updated', 'unchanged'] as $bucket) {
+			foreach ((array)($result[$bucket] ?? []) as $row) {
+				if (is_array($row) === false) {
+					continue;
+				}
+
+				$self = (array)($row['@self'] ?? []);
+				$uuid = (string)($self['uuid'] ?? $self['id'] ?? $row['uuid'] ?? $row['id'] ?? '');
+				if ($uuid !== '') {
+					$written[$uuid] = $row;
+				}
+			}
+		}
+
+		return $written;
+	}//end indexBulkResults()
 
 	/**
 	 * The json a written item carries onward.

--- a/openspec/changes/or-flow-bulk-object-write/proposal.md
+++ b/openspec/changes/or-flow-bulk-object-write/proposal.md
@@ -1,0 +1,35 @@
+# or-flow-bulk-object-write
+
+## Why
+
+The flow-native synchronization programme (openconnector
+`openspec/changes/flow-native-synchronization/`) decomposes a synchronization
+into page-level flow steps. Its write stage needs one bulk save per page —
+`sync → object-write` pipelines carry hundreds of items per page, and the
+per-item `saveObject()` round-trip is the dominant cost. `ObjectService`
+already has the seam (`saveObjects()`); the flow node cannot reach it.
+
+## What changes
+
+- `openregister.object-write` gains a `bulk: true` configuration key that
+  routes the whole page of items through ONE `ObjectService::saveObjects()`
+  call, inside the same `runAs($owner)` wrapper the per-item path uses.
+- Bulk is refused at save time for every semantic the bulk path does not
+  have: `update`/`delete` operations, `onConflict: fail`, upserts without
+  `replace: true`, and upserts matching on anything but the row uuid.
+- Row uuids are decided client-side (generated for creates, resolved from the
+  uuid match for upserts) so output items name their rows without correlating
+  a categorised bulk result, and so a downstream contract-commit step can
+  read the target id.
+- A bulk result carrying rejected rows fails the step loudly, naming the
+  count and first reason; the write cap is enforced against the page size
+  before anything is written.
+- The node implements `IFlowNodeConfigForm` so the editor renders register /
+  schema pickers and labelled fields instead of a bare JSON pane.
+
+## Impact
+
+- `lib/Service/Flow/Nodes/ObjectWriteNode.php` — bulk branch + configForm.
+- No API, schema, or migration impact. The per-item path is byte-for-byte
+  unchanged for every existing flow (no flow can carry `bulk` today; preflight
+  would have refused the unknown key).

--- a/openspec/changes/or-flow-bulk-object-write/specs/flow-object-write-bulk/spec.md
+++ b/openspec/changes/or-flow-bulk-object-write/specs/flow-object-write-bulk/spec.md
@@ -1,0 +1,64 @@
+# flow-object-write-bulk
+
+## ADDED Requirements
+
+### Requirement: A bulk write is one call, refused wherever its semantics are narrower
+
+`openregister.object-write` with `bulk: true` SHALL write the whole page of
+items through exactly one `ObjectService::saveObjects()` call, executed
+inside the same `runAs($owner)` wrapper as the per-item path.
+
+Bulk mode SHALL be refused at save time when combined with semantics the
+bulk path does not have:
+
+- an operation other than `create` or `upsert`;
+- `onConflict: "fail"` (the bulk path cannot arbitrate per-row claims);
+- an upsert without `replace: true` (the bulk path replaces whole rows and
+  cannot patch);
+- an upsert whose match is not exactly one pair on `uuid` / `@self.uuid`
+  (the bulk path decides create-versus-update by row uuid alone);
+- a non-boolean `bulk` value.
+
+#### Scenario: A bulk update is refused when the flow is saved
+
+- **GIVEN** an object-write step with `operation: "update"` and `bulk: true`
+- **WHEN** the flow is validated
+- **THEN** validation fails naming bulk's create/upsert-only support
+
+#### Scenario: A bulk upsert without replace is refused
+
+- **GIVEN** an object-write step with `operation: "upsert"`, `bulk: true`,
+  a uuid match, and no `replace`
+- **WHEN** the flow is validated
+- **THEN** validation fails saying the bulk path cannot patch
+
+### Requirement: Bulk row identity is decided client-side
+
+In bulk mode the node SHALL assign every row's uuid before the call:
+a fresh v4 uuid for a create, the resolved single uuid match value for an
+upsert. An upsert match value that does not resolve SHALL fail the item
+rather than widen into a create. Every output item SHALL carry its row's
+`uuid`, `register` and `schema`, so a downstream step can name the row
+without re-reading.
+
+#### Scenario: Output items name their rows after a bulk create
+
+- **GIVEN** a bulk create over three items
+- **WHEN** the step executes
+- **THEN** three rows are sent in one `saveObjects()` call, each with a
+  distinct generated `id`, and each output item carries that id as `uuid`
+
+### Requirement: A bulk result with rejected rows fails the step loudly
+
+`saveObjects()` records refusals in its result rather than throwing. The
+node SHALL fail the step when the result carries `invalid` or `errors`
+entries, naming the rejected count, the first reason, and that accepted
+rows were written and not rolled back. The write cap SHALL be enforced
+against the page size before anything is written.
+
+#### Scenario: A page over the cap writes nothing
+
+- **GIVEN** a bulk write of more items than the step's `maxWrites`
+- **WHEN** the step executes
+- **THEN** it fails before calling `saveObjects()` and says nothing was
+  written

--- a/openspec/changes/or-flow-bulk-object-write/tasks.md
+++ b/openspec/changes/or-flow-bulk-object-write/tasks.md
@@ -1,0 +1,14 @@
+# Tasks — or-flow-bulk-object-write
+
+- [x] 1.1 `bulk` in `configKeys()`; `validateBulkKeys()` save-time guards
+      (boolean strictness, create/upsert only, no `onConflict: fail`, upsert
+      requires `replace: true` + single uuid match).
+- [x] 1.2 `writeBulk()`: cap against page size up front, client-side row
+      uuids, one `saveObjects(validation: true, events: false)` inside
+      `runAs($owner)`, categorised-result indexing by uuid, loud failure on
+      rejected rows.
+- [x] 1.3 `configForm()` — register/schema selects (`optionsFrom`), labelled
+      fields for every scalar key; `fields`/`match` stay on the JSON pane.
+- [x] 1.4 Unit tests: vocabulary pin, bulk guard rejections, one-call
+      assertion with row shapes, upsert id resolution, rejected-row failure,
+      cap refusal.

--- a/tests/Unit/Service/Flow/ObjectWriteNodeTest.php
+++ b/tests/Unit/Service/Flow/ObjectWriteNodeTest.php
@@ -1194,4 +1194,318 @@ class ObjectWriteNodeTest extends TestCase {
 		$this->assertSame('uuid-1', $out[0]['json']['uuid']);
 	}
 
+	// ── Bulk mode (or-flow-bulk-object-write) ───────────────────────────
+
+	/**
+	 * The config vocabulary is pinned, `bulk` included.
+	 *
+	 * @return void
+	 */
+	public function testTheConfigVocabularyIsPinnedWithBulk(): void {
+		$this->assertSame(
+			[
+				'register',
+				'schema',
+				'operation',
+				'fields',
+				'match',
+				'replace',
+				'bulk',
+				'output',
+				'confirmDelete',
+				'permanent',
+				'maxWrites',
+				'onConflict',
+				'onMissing',
+				'onNoMatch',
+			],
+			$this->node->configKeys()
+		);
+	}
+
+	/**
+	 * Every form field edits a key the node actually reads, and the
+	 * register / schema fields are pickers fed by a declared URL — never
+	 * bare uuid boxes.
+	 *
+	 * @return void
+	 */
+	public function testTheConfigFormDescribesOnlyKeysTheNodeReads(): void {
+		$form = $this->node->configForm();
+		$keys = $this->node->configKeys();
+
+		$this->assertNotSame([], $form);
+		$byKey = [];
+		foreach ($form as $field) {
+			$this->assertContains($field['key'], $keys);
+			$byKey[$field['key']] = $field;
+		}
+
+		foreach (['register', 'schema'] as $picker) {
+			$this->assertSame('select', $byKey[$picker]['type']);
+			$this->assertNotSame('', (string)($byKey[$picker]['optionsFrom'] ?? ''));
+		}
+	}
+
+	/**
+	 * @return array<string, array{0: array<string, mixed>, 1: string}>
+	 */
+	public static function refusedBulkConfigurations(): array {
+		$upsert = [
+			'operation' => ObjectWriteNode::OP_UPSERT,
+			'match' => ['@self.uuid' => '{{uuid}}'],
+			'replace' => true,
+			'bulk' => true,
+		];
+
+		return [
+			'bulk update keeps its per-item guards' => [
+				['operation' => ObjectWriteNode::OP_UPDATE, 'match' => ['title' => 'x'], 'bulk' => true],
+				'supports create and upsert only',
+			],
+			'bulk delete keeps its per-item guards' => [
+				[
+					'operation' => ObjectWriteNode::OP_DELETE,
+					'match' => ['@self.uuid' => '{{uuid}}'],
+					'confirmDelete' => true,
+					'fields' => null,
+					'bulk' => true,
+				],
+				'supports create and upsert only',
+			],
+			'bulk upsert cannot patch' => [
+				array_merge($upsert, ['replace' => null]),
+				'cannot patch',
+			],
+			'bulk upsert matches on uuid alone' => [
+				array_merge($upsert, ['match' => ['title' => '{{title}}']]),
+				'exactly one property',
+			],
+			'bulk upsert refuses a composite match' => [
+				array_merge($upsert, ['match' => ['@self.uuid' => '{{uuid}}', 'title' => 'x']]),
+				'exactly one property',
+			],
+			'bulk cannot arbitrate per-row claims' => [
+				['operation' => ObjectWriteNode::OP_CREATE, 'onConflict' => 'fail', 'bulk' => true],
+				'cannot arbitrate',
+			],
+			'bulk must be a boolean' => [
+				['operation' => ObjectWriteNode::OP_CREATE, 'bulk' => 'true'],
+				'true or false, as a boolean',
+			],
+		];
+	}
+
+	/**
+	 * Bulk is refused at save time wherever the bulk path's semantics are
+	 * narrower than the per-item path's.
+	 *
+	 * @dataProvider refusedBulkConfigurations
+	 *
+	 * @param array<string, mixed> $overrides Config overrides.
+	 * @param string $because Expected message fragment.
+	 *
+	 * @return void
+	 */
+	public function testBulkIsRefusedWhereItsSemanticsAreNarrower(array $overrides, string $because): void {
+		$config = $this->config($overrides);
+		foreach ($config as $key => $value) {
+			if ($value === null) {
+				unset($config[$key]);
+			}
+		}
+
+		$this->expectException(UnexpectedValueException::class);
+		$this->expectExceptionMessageMatches('/' . preg_quote($because, '/') . '/');
+		$this->node->validateConfig($config);
+	}
+
+	/**
+	 * Build a well-formed empty bulk result the mock can build on.
+	 *
+	 * @param array<string, mixed> $overrides Bucket overrides.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function bulkResult(array $overrides = []): array {
+		return array_merge(
+			[
+				'saved' => [],
+				'updated' => [],
+				'unchanged' => [],
+				'invalid' => [],
+				'errors' => [],
+				'statistics' => [],
+			],
+			$overrides
+		);
+	}
+
+	/**
+	 * A bulk create is ONE `saveObjects()` call carrying one row per item,
+	 * each under its own generated uuid — and each output item names its row.
+	 *
+	 * @return void
+	 */
+	public function testABulkCreateIsOneCallWithOneOwnedRowPerItem(): void {
+		$sent = null;
+		$this->objects->expects($this->never())->method('saveObject');
+		$this->objects->expects($this->once())->method('saveObjects')->willReturnCallback(
+			function (array $objects) use (&$sent): array {
+				$sent = $objects;
+
+				return $this->bulkResult();
+			}
+		);
+
+		$out = $this->node->execute(
+			$this->items([['title' => 'a'], ['title' => 'b'], ['title' => 'c']]),
+			$this->config(['bulk' => true, 'fields' => ['title' => '{{title}}']]),
+			$this->registerContext
+		);
+
+		$this->assertCount(3, $sent);
+		$ids = array_column($sent, 'id');
+		$this->assertCount(3, array_unique($ids));
+		foreach ($ids as $id) {
+			$this->assertMatchesRegularExpression('/^[0-9a-f-]{36}$/', $id);
+		}
+
+		$this->assertCount(3, $out);
+		foreach ($out as $index => $item) {
+			$this->assertSame($ids[$index], $item['json']['uuid']);
+			$this->assertSame('example-hydra-cache', $item['json']['register']);
+		}
+	}
+
+	/**
+	 * A bulk upsert's row ids come from each item's uuid match value, so the
+	 * bulk save updates exactly the rows the page named.
+	 *
+	 * @return void
+	 */
+	public function testABulkUpsertTakesRowIdsFromTheMatchValue(): void {
+		$sent = null;
+		$this->objects->expects($this->once())->method('saveObjects')->willReturnCallback(
+			function (array $objects) use (&$sent): array {
+				$sent = $objects;
+
+				return $this->bulkResult();
+			}
+		);
+
+		$this->node->execute(
+			$this->items([['uuid' => 'row-1', 'title' => 'a'], ['uuid' => 'row-2', 'title' => 'b']]),
+			$this->config([
+				'operation' => ObjectWriteNode::OP_UPSERT,
+				'match' => ['@self.uuid' => '{{uuid}}'],
+				'replace' => true,
+				'bulk' => true,
+				'fields' => ['title' => '{{title}}'],
+			]),
+			$this->registerContext
+		);
+
+		$this->assertSame(['row-1', 'row-2'], array_column($sent, 'id'));
+	}
+
+	/**
+	 * An upsert item whose match value does not resolve fails rather than
+	 * widening into a create — a match key is never omitted.
+	 *
+	 * @return void
+	 */
+	public function testABulkUpsertWithAnUnresolvedMatchValueFailsTheItem(): void {
+		$this->objects->expects($this->never())->method('saveObjects');
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/never omitted/');
+		$this->node->execute(
+			$this->items([['title' => 'no-uuid-here']]),
+			$this->config([
+				'operation' => ObjectWriteNode::OP_UPSERT,
+				'match' => ['@self.uuid' => '{{uuid}}'],
+				'replace' => true,
+				'bulk' => true,
+				'fields' => ['title' => '{{title}}'],
+			]),
+			$this->registerContext
+		);
+	}
+
+	/**
+	 * A page larger than the cap is refused BEFORE the call — one bulk call
+	 * has no honest midpoint to stop at.
+	 *
+	 * @return void
+	 */
+	public function testABulkPageOverTheCapWritesNothing(): void {
+		$this->objects->expects($this->never())->method('saveObjects');
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/nothing was written/');
+		$this->node->execute(
+			$this->items([['title' => 'a'], ['title' => 'b'], ['title' => 'c']]),
+			$this->config(['bulk' => true, 'maxWrites' => 2, 'fields' => ['title' => '{{title}}']]),
+			$this->registerContext
+		);
+	}
+
+	/**
+	 * A bulk result carrying rejected rows fails the step loudly — refusals
+	 * land in the result's buckets, and folding them into per-item output
+	 * would be a hollow success.
+	 *
+	 * @return void
+	 */
+	public function testABulkResultWithRejectedRowsFailsLoudly(): void {
+		$this->objects->method('saveObjects')->willReturn(
+			$this->bulkResult([
+				'invalid' => [['object' => [], 'error' => 'Row 2 failed schema validation']],
+				'errors' => [['error' => 'Row 2 failed schema validation', 'type' => 'ValidationException']],
+			])
+		);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/rejected 1 of its rows.*Row 2 failed schema validation.*not rolled back/');
+		$this->node->execute(
+			$this->items([['title' => 'a']]),
+			$this->config(['bulk' => true, 'fields' => ['title' => '{{title}}']]),
+			$this->registerContext
+		);
+	}
+
+	/**
+	 * When the bulk result carries the serialised row, the output item
+	 * prefers it over the sent payload — server-computed fields included.
+	 *
+	 * @return void
+	 */
+	public function testBulkOutputPrefersTheServersSerialisedRow(): void {
+		$this->objects->method('saveObjects')->willReturnCallback(
+			function (array $objects): array {
+				$row = $objects[0];
+
+				return $this->bulkResult([
+					'saved' => [
+						[
+							'@self' => ['uuid' => $row['id']],
+							'title' => $row['title'],
+							'serverComputed' => 'slug-a',
+						],
+					],
+				]);
+			}
+		);
+
+		$out = $this->node->execute(
+			$this->items([['title' => 'a']]),
+			$this->config(['bulk' => true, 'fields' => ['title' => '{{title}}']]),
+			$this->registerContext
+		);
+
+		$this->assertSame('slug-a', $out[0]['json']['serverComputed']);
+		$this->assertArrayNotHasKey('@self', $out[0]['json']);
+	}
+
 }//end class


### PR DESCRIPTION
## What

- `openregister.object-write` gains `bulk: true`: the whole page of items goes through **one** `ObjectService::saveObjects()` call, inside the same `runAs($owner)` wrapper as the per-item path.
- Save-time guards refuse every semantic the bulk path does not have: create/upsert only, no `onConflict: fail`, bulk upsert requires `replace: true` and a single `uuid` match, `bulk` must be a strict boolean.
- Row uuids are decided client-side (generated for creates, resolved from the uuid match for upserts) so each output item names its row without correlating the categorised bulk result — which is what a downstream `contract-commit` step reads as the target id.
- A bulk result carrying rejected rows fails the step loudly (count + first reason + "not rolled back"); the write cap is enforced against the page size before anything is written.
- The node now implements `IFlowNodeConfigForm`: register/schema **pickers** (`optionsFrom`) and labelled fields — no more bare-uuid JSON editing. `fields`/`match` deliberately stay on the JSON pane.

## Why

Task 1.4 of openconnector `openspec/changes/flow-native-synchronization` — the decomposed synchronization flow's write stage needs one bulk save per page. Spec: `openspec/changes/or-flow-bulk-object-write/`.

## Verified

- 86 ObjectWriteNode tests (14 new bulk tests), 575 flow-suite tests green in the dev container.
- phpcs, phpmd, phpstan, psalm all clean on the changed file.
- Per-item path byte-for-byte unchanged; no existing flow can carry `bulk` (preflight refused the unknown key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)