### PR TITLE
feat(tools): declare subject and action on the tool catalogue

### DIFF
--- a/lib/Mcp/Attribute/McpTool.php
+++ b/lib/Mcp/Attribute/McpTool.php
@@ -90,6 +90,16 @@ final class McpTool {
 	 *                           {@see \OCA\OpenRegister\Service\Mcp\McpAnnotationValidator::SCOPES}
 	 *                           (validated by {@see \OCA\OpenRegister\Mcp\AttributeToolScanner} at
 	 *                           scan time, not here). Omitted (null) when not declared.
+	 * @param string|null $subject The thing this tool acts on, e.g. `document`. Groups the tool in
+	 *                             the agent grant matrix. Omitted (null) when not declared — and an
+	 *                             omission is INVISIBLE, because
+	 *                             {@see \OCA\OpenRegister\Service\Mcp\ToolRegistryFacade::describeTools()}
+	 *                             deliberately returns null rather than inferring one from the id.
+	 *                             Declare it: a consumer cannot tell an inferred subject from a real one.
+	 * @param string|null $action The verb this tool performs on that subject, e.g. `get`. NOT closed
+	 *                            to CRUD — a tool that sends, converts or delegates should say so
+	 *                            rather than be filed under the nearest CRUD verb, since the matrix
+	 *                            grants on this value.
 	 *
 	 * @spec openspec/specs/ai-mcp/spec.md
 	 *   (Requirement: REQ-ATTR-001 — The #[McpTool] service-method attribute)
@@ -103,6 +113,8 @@ final class McpTool {
 		public readonly ?bool $destructiveHint = null,
 		public readonly ?bool $idempotentHint = null,
 		public readonly ?string $scope = null,
+		public readonly ?string $subject = null,
+		public readonly ?string $action = null,
 	) {
 	}//end __construct()
 }//end class

--- a/lib/Mcp/AttributeToolScanner.php
+++ b/lib/Mcp/AttributeToolScanner.php
@@ -252,25 +252,46 @@ final class AttributeToolScanner {
 			$descriptor['scope'] = $attribute->scope;
 		}
 
-		// The grant-matrix taxonomy, forwarded on the same additive terms as
-		// the hints above: present ONLY when the author declared it, never
-		// inferred from the method name. `describeTools()` makes the same
-		// choice downstream, and for the same reason — an inferred subject is
-		// indistinguishable from a declared one, so a consumer given one
-		// cannot know whether to trust it.
-		//
-		// ⚠️ The consequence is that an OMISSION HAS NO SYMPTOM: the tool
-		// simply arrives at the matrix ungroupable. Apps are expected to pin
-		// this with a test, the way hermiq's provider does.
-		foreach (['subject', 'action'] as $taxonomyKey) {
-			$declared = $attribute->{$taxonomyKey};
-			if ($declared !== null && trim($declared) !== '') {
-				$descriptor[$taxonomyKey] = $declared;
-			}
+		return ($descriptor + $this->taxonomyOf(attribute: $attribute));
+	}//end buildDescriptor()
+
+	/**
+	 * The grant-matrix taxonomy an attribute declared, or an empty array.
+	 *
+	 * Forwarded on the same additive terms as the annotation hints: a key is
+	 * present ONLY when the author declared it, never inferred from the method
+	 * name. `ToolRegistryFacade::describeTools()` makes the same choice
+	 * downstream, and for the same reason — an inferred subject is
+	 * indistinguishable from a declared one, so a consumer handed one cannot
+	 * know whether to trust it.
+	 *
+	 * ⚠️ The consequence is that an OMISSION HAS NO SYMPTOM: the tool simply
+	 * arrives at the grant matrix ungroupable, with nothing failing anywhere.
+	 * Apps are expected to pin this with a test, the way hermiq's provider
+	 * does.
+	 *
+	 * Its own method rather than a loop inside `buildDescriptor()`, which was
+	 * already at the cyclomatic-complexity ceiling — two more branches there
+	 * tipped it over.
+	 *
+	 * @param McpTool $attribute The resolved attribute instance.
+	 *
+	 * @return array<string, string> The declared taxonomy keys only.
+	 */
+	private function taxonomyOf(McpTool $attribute): array {
+		$taxonomy = [];
+
+		if ($attribute->subject !== null && trim($attribute->subject) !== '') {
+			$taxonomy['subject'] = $attribute->subject;
 		}
 
-		return $descriptor;
-	}//end buildDescriptor()
+		if ($attribute->action !== null && trim($attribute->action) !== '') {
+			$taxonomy['action'] = $attribute->action;
+		}
+
+		return $taxonomy;
+
+	}//end taxonomyOf()
 
 	/**
 	 * Read one boolean hint property off the attribute by its

--- a/lib/Mcp/AttributeToolScanner.php
+++ b/lib/Mcp/AttributeToolScanner.php
@@ -252,6 +252,23 @@ final class AttributeToolScanner {
 			$descriptor['scope'] = $attribute->scope;
 		}
 
+		// The grant-matrix taxonomy, forwarded on the same additive terms as
+		// the hints above: present ONLY when the author declared it, never
+		// inferred from the method name. `describeTools()` makes the same
+		// choice downstream, and for the same reason — an inferred subject is
+		// indistinguishable from a declared one, so a consumer given one
+		// cannot know whether to trust it.
+		//
+		// ⚠️ The consequence is that an OMISSION HAS NO SYMPTOM: the tool
+		// simply arrives at the matrix ungroupable. Apps are expected to pin
+		// this with a test, the way hermiq's provider does.
+		foreach (['subject', 'action'] as $taxonomyKey) {
+			$declared = $attribute->{$taxonomyKey};
+			if ($declared !== null && trim($declared) !== '') {
+				$descriptor[$taxonomyKey] = $declared;
+			}
+		}
+
 		return $descriptor;
 	}//end buildDescriptor()
 

--- a/lib/Mcp/BuiltIn/AttributeToolProvider.php
+++ b/lib/Mcp/BuiltIn/AttributeToolProvider.php
@@ -150,6 +150,18 @@ class AttributeToolProvider implements IMcpToolProvider {
 				$descriptor['scope'] = $entry['scope'];
 			}
 
+			// 🔴 This method REBUILDS the descriptor from a fixed key list
+			// rather than forwarding the entry, so any key not named here is
+			// silently dropped. That is why `subject`/`action` declared on
+			// `#[McpTool]` reached the scanner and then vanished before the
+			// grant matrix: the attribute, the scanner and the bridge all
+			// carried them, and this one copy step did not.
+			foreach (['subject', 'action'] as $taxonomyKey) {
+				if (array_key_exists($taxonomyKey, $entry) === true) {
+					$descriptor[$taxonomyKey] = $entry[$taxonomyKey];
+				}
+			}
+
 			$tools[] = $descriptor;
 		}//end foreach
 

--- a/lib/Tool/AgentTool.php
+++ b/lib/Tool/AgentTool.php
@@ -117,6 +117,8 @@ class AgentTool extends AbstractTool implements ToolInterface {
 		return [
 			[
 				'name' => 'list_agents',
+				'subject' => 'agent',
+				'action' => 'list',
 				'description' => $listDesc,
 				'parameters' => [
 					'type' => 'object',
@@ -135,6 +137,8 @@ class AgentTool extends AbstractTool implements ToolInterface {
 			],
 			[
 				'name' => 'get_agent',
+				'subject' => 'agent',
+				'action' => 'get',
 				'description' => $getDesc,
 				'parameters' => [
 					'type' => 'object',
@@ -149,6 +153,8 @@ class AgentTool extends AbstractTool implements ToolInterface {
 			],
 			[
 				'name' => 'create_agent',
+				'subject' => 'agent',
+				'action' => 'create',
 				'description' => $createDesc,
 				'parameters' => [
 					'type' => 'object',
@@ -175,6 +181,8 @@ class AgentTool extends AbstractTool implements ToolInterface {
 			],
 			[
 				'name' => 'update_agent',
+				'subject' => 'agent',
+				'action' => 'update',
 				'description' => $updateDesc,
 				'parameters' => [
 					'type' => 'object',
@@ -201,6 +209,8 @@ class AgentTool extends AbstractTool implements ToolInterface {
 			],
 			[
 				'name' => 'delete_agent',
+				'subject' => 'agent',
+				'action' => 'delete',
 				'description' => $deleteDesc,
 				'parameters' => [
 					'type' => 'object',

--- a/lib/Tool/ApplicationTool.php
+++ b/lib/Tool/ApplicationTool.php
@@ -107,6 +107,8 @@ class ApplicationTool extends AbstractTool implements ToolInterface {
 		return [
 			[
 				'name' => 'list_applications',
+				'subject' => 'application',
+				'action' => 'list',
 				'description' => 'List all accessible applications with basic information.',
 				'parameters' => [
 					'type' => 'object',
@@ -125,6 +127,8 @@ class ApplicationTool extends AbstractTool implements ToolInterface {
 			],
 			[
 				'name' => 'get_application',
+				'subject' => 'application',
+				'action' => 'get',
 				'description' => 'Get detailed application information by UUID.',
 				'parameters' => [
 					'type' => 'object',
@@ -139,6 +143,8 @@ class ApplicationTool extends AbstractTool implements ToolInterface {
 			],
 			[
 				'name' => 'create_application',
+				'subject' => 'application',
+				'action' => 'create',
 				'description' => 'Create a new application with unique name.',
 				'parameters' => [
 					'type' => 'object',
@@ -161,6 +167,8 @@ class ApplicationTool extends AbstractTool implements ToolInterface {
 			],
 			[
 				'name' => 'update_application',
+				'subject' => 'application',
+				'action' => 'update',
 				'description' => 'Update application (owner/update permission required). Provide UUID and fields to update.',
 				'parameters' => [
 					'type' => 'object',
@@ -187,6 +195,8 @@ class ApplicationTool extends AbstractTool implements ToolInterface {
 			],
 			[
 				'name' => 'delete_application',
+				'subject' => 'application',
+				'action' => 'delete',
 				'description' => 'Permanently delete application (owner/delete permission required). Cannot be undone.',
 				'parameters' => [
 					'type' => 'object',

--- a/lib/Tool/ApplicationTool.php
+++ b/lib/Tool/ApplicationTool.php
@@ -104,6 +104,16 @@ class ApplicationTool extends AbstractTool implements ToolInterface {
 	 * @spec openspec/specs/object-lifecycle/spec.md
 	 */
 	public function getFunctions(): array {
+		return array_merge(self::readFunctions(), self::writeFunctions());
+
+	}//end getFunctions()
+
+	/**
+	 * The application descriptors that change nothing.
+	 *
+	 * @return array<int, array<string, mixed>> The read descriptors.
+	 */
+	private static function readFunctions(): array {
 		return [
 			[
 				'name' => 'list_applications',
@@ -141,6 +151,23 @@ class ApplicationTool extends AbstractTool implements ToolInterface {
 					'required' => ['uuid'],
 				],
 			],
+		];
+
+	}//end readFunctions()
+
+	/**
+	 * The application descriptors that change state.
+	 *
+	 * Split from the reading half only to keep each method inside the
+	 * ExcessiveMethodLength budget — declaring `subject`/`action` on every
+	 * descriptor pushed the single combined table past it. The read/write line
+	 * is the honest place to cut, since it is the same boundary the grant
+	 * matrix groups on.
+	 *
+	 * @return array<int, array<string, mixed>> The write descriptors.
+	 */
+	private static function writeFunctions(): array {
+		return [
 			[
 				'name' => 'create_application',
 				'subject' => 'application',
@@ -210,7 +237,7 @@ class ApplicationTool extends AbstractTool implements ToolInterface {
 				],
 			],
 		];
-	}//end getFunctions()
+	}//end writeFunctions()
 
 	/**
 	 * List applications

--- a/lib/Tool/ObjectsTool.php
+++ b/lib/Tool/ObjectsTool.php
@@ -110,6 +110,8 @@ class ObjectsTool extends AbstractTool {
 		return [
 			[
 				'name' => 'search_objects',
+				'subject' => 'object',
+				'action' => 'search',
 				'description' => 'Search for objects with optional filters',
 				'parameters' => [
 					'type' => 'object',
@@ -140,6 +142,8 @@ class ObjectsTool extends AbstractTool {
 			],
 			[
 				'name' => 'get_object',
+				'subject' => 'object',
+				'action' => 'get',
 				'description' => 'Get details about a specific object by ID or UUID',
 				'parameters' => [
 					'type' => 'object',
@@ -154,6 +158,8 @@ class ObjectsTool extends AbstractTool {
 			],
 			[
 				'name' => 'create_object',
+				'subject' => 'object',
+				'action' => 'create',
 				'description' => 'Create a new object with data',
 				'parameters' => [
 					'type' => 'object',
@@ -176,6 +182,8 @@ class ObjectsTool extends AbstractTool {
 			],
 			[
 				'name' => 'update_object',
+				'subject' => 'object',
+				'action' => 'update',
 				'description' => 'Update an existing object',
 				'parameters' => [
 					'type' => 'object',
@@ -194,6 +202,8 @@ class ObjectsTool extends AbstractTool {
 			],
 			[
 				'name' => 'delete_object',
+				'subject' => 'object',
+				'action' => 'delete',
 				'description' => 'Delete an object by ID',
 				'parameters' => [
 					'type' => 'object',

--- a/lib/Tool/RegisterTool.php
+++ b/lib/Tool/RegisterTool.php
@@ -104,6 +104,8 @@ class RegisterTool extends AbstractTool {
 		return [
 			[
 				'name' => 'list_registers',
+				'subject' => 'register',
+				'action' => 'list',
 				'description' => 'Get a list of all accessible registers',
 				'parameters' => [
 					'type' => 'object',
@@ -122,6 +124,8 @@ class RegisterTool extends AbstractTool {
 			],
 			[
 				'name' => 'get_register',
+				'subject' => 'register',
+				'action' => 'get',
 				'description' => 'Get details about a specific register by ID or slug',
 				'parameters' => [
 					'type' => 'object',
@@ -136,6 +140,8 @@ class RegisterTool extends AbstractTool {
 			],
 			[
 				'name' => 'create_register',
+				'subject' => 'register',
+				'action' => 'create',
 				'description' => 'Create a new register',
 				'parameters' => [
 					'type' => 'object',
@@ -158,6 +164,8 @@ class RegisterTool extends AbstractTool {
 			],
 			[
 				'name' => 'update_register',
+				'subject' => 'register',
+				'action' => 'update',
 				'description' => 'Update an existing register',
 				'parameters' => [
 					'type' => 'object',
@@ -180,6 +188,8 @@ class RegisterTool extends AbstractTool {
 			],
 			[
 				'name' => 'delete_register',
+				'subject' => 'register',
+				'action' => 'delete',
 				'description' => 'Delete a register (only if it has no objects)',
 				'parameters' => [
 					'type' => 'object',

--- a/lib/Tool/RegisterTool.php
+++ b/lib/Tool/RegisterTool.php
@@ -101,6 +101,16 @@ class RegisterTool extends AbstractTool {
 	 * @spec openspec/specs/object-lifecycle/spec.md
 	 */
 	public function getFunctions(): array {
+		return array_merge(self::readFunctions(), self::writeFunctions());
+
+	}//end getFunctions()
+
+	/**
+	 * The register descriptors that change nothing.
+	 *
+	 * @return array<int, array<string, mixed>> The read descriptors.
+	 */
+	private static function readFunctions(): array {
 		return [
 			[
 				'name' => 'list_registers',
@@ -138,6 +148,23 @@ class RegisterTool extends AbstractTool {
 					'required' => ['id'],
 				],
 			],
+		];
+
+	}//end readFunctions()
+
+	/**
+	 * The register descriptors that change state.
+	 *
+	 * Split from the reading half only to keep each method inside the
+	 * ExcessiveMethodLength budget — declaring `subject`/`action` on every
+	 * descriptor pushed the single combined table past it. The read/write line
+	 * is the honest place to cut, since it is the same boundary the grant
+	 * matrix groups on.
+	 *
+	 * @return array<int, array<string, mixed>> The write descriptors.
+	 */
+	private static function writeFunctions(): array {
+		return [
 			[
 				'name' => 'create_register',
 				'subject' => 'register',
@@ -203,7 +230,7 @@ class RegisterTool extends AbstractTool {
 				],
 			],
 		];
-	}//end getFunctions()
+	}//end writeFunctions()
 
 	/**
 	 * Execute a function

--- a/lib/Tool/SchemaTool.php
+++ b/lib/Tool/SchemaTool.php
@@ -107,6 +107,8 @@ class SchemaTool extends AbstractTool {
 		return [
 			[
 				'name' => 'list_schemas',
+				'subject' => 'schema',
+				'action' => 'list',
 				'description' => 'Get a list of all accessible schemas',
 				'parameters' => [
 					'type' => 'object',
@@ -129,6 +131,8 @@ class SchemaTool extends AbstractTool {
 			],
 			[
 				'name' => 'get_schema',
+				'subject' => 'schema',
+				'action' => 'get',
 				'description' => 'Get details about a specific schema by ID',
 				'parameters' => [
 					'type' => 'object',
@@ -143,6 +147,8 @@ class SchemaTool extends AbstractTool {
 			],
 			[
 				'name' => 'create_schema',
+				'subject' => 'schema',
+				'action' => 'create',
 				'description' => 'Create a new schema with properties definition',
 				'parameters' => [
 					'type' => 'object',
@@ -169,6 +175,8 @@ class SchemaTool extends AbstractTool {
 			],
 			[
 				'name' => 'update_schema',
+				'subject' => 'schema',
+				'action' => 'update',
 				'description' => 'Update an existing schema',
 				'parameters' => [
 					'type' => 'object',
@@ -195,6 +203,8 @@ class SchemaTool extends AbstractTool {
 			],
 			[
 				'name' => 'delete_schema',
+				'subject' => 'schema',
+				'action' => 'delete',
 				'description' => 'Delete a schema (only if it has no objects)',
 				'parameters' => [
 					'type' => 'object',


### PR DESCRIPTION
The other half of the ADR-095 grant work: ADR-095 fixed how grants are **stored**; this declares what they are stored **about**.

Measured live against `/apps/hermiq/api/agents/tools` — **87 of 177 tools declared no subject or action**, so the grant matrix fell back to guessing from the id.

🔴 **An undeclared subject is invisible.** `ToolRegistryFacade::describeTools()` deliberately returns null rather than inferring one — the right call, since a consumer cannot tell an inferred subject from a real one — so a descriptor missing these keys produces no error, no warning and no failing test. That is how 87 went unnoticed.

⚠️ I checked the hazard the facade's own docblock warns about, that descriptors are handed to the LLM as function definitions "which strict provider APIs reject outright". `listTools()` does return them verbatim, but `ToolLoop::buildFunctionInfos()` **reconstructs** rather than forwards — a `FunctionInfo` is built from name, invoker, description and parameters only. These keys cannot reach a provider payload.

Verified live: **87 → 38** undeclared across both PRs. Remaining: docudesk 11, openbuild 8, opencatalogi 7, decidesk 5, pipelinq 3, procest 2, scholiq 2.