### PR TITLE
style(phpcs): clear 20 of the 21 standing errors in lib/

### DIFF
--- a/lib/AppHost/Controller/GenericHealthController.php
+++ b/lib/AppHost/Controller/GenericHealthController.php
@@ -72,13 +72,15 @@ class GenericHealthController extends Controller {
 	 *
 	 * @return JSONResponse `{status, app, version, checks}` with HTTP code per statusCodePolicy.
 	 *
+	 * The rate-limit ceiling is generous on purpose: a health endpoint is polled
+	 * by monitoring on a short interval, and a ceiling that trips on a normal
+	 * probe cadence turns the check itself into the outage it was meant to
+	 * detect.
+	 *
 	 * @spec openspec/specs/apphost-observability/spec.md — Requirement: Declarative Health Execution
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
-	// Generous: a health endpoint is polled by monitoring on a short interval,
-	// and a ceiling that trips on a normal probe cadence turns the check itself
-	// into the outage it was meant to detect.
 	#[AnonRateLimit(limit: 240, period: 60)]
 	public function index(): JSONResponse {
 		$appId = $this->appName;

--- a/lib/Controller/CaseTokenController.php
+++ b/lib/Controller/CaseTokenController.php
@@ -73,6 +73,8 @@ class CaseTokenController extends Controller {
 	 * @param string $appName App name (injected by NC).
 	 * @param IRequest $request Current request.
 	 * @param CaseTokenService $tokenService Case-token mint/resolve/revoke service.
+	 * @param IThrottler $throttler Brute-force throttler for rejected tokens.
+	 * @param LoggerInterface $logger PSR logger.
 	 *
 	 * @return void
 	 */

--- a/lib/Controller/ChatHealthController.php
+++ b/lib/Controller/ChatHealthController.php
@@ -101,15 +101,17 @@ class ChatHealthController extends Controller {
 	 *
 	 * @NoCSRFRequired
 	 *
+	 * The rate-limit ceiling is generous on purpose: a health probe is polled by
+	 * monitoring on a schedule, so the limit exists to stop an unauthenticated
+	 * caller turning a liveness endpoint into a load generator, not to police
+	 * the monitor.
+	 *
 	 * @return JSONResponse 200 or 503 JSON response
 	 *
 	 * @spec openspec/specs/chat-ai/spec.md
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
-	// A health probe is polled by monitoring on a schedule, so the ceiling is
-	// generous — it exists to stop an unauthenticated caller turning a liveness
-	// endpoint into a load generator, not to police the monitor.
 	#[AnonRateLimit(limit: 120, period: 60)]
 	public function health(): JSONResponse {
 		try {

--- a/lib/Controller/FederationController.php
+++ b/lib/Controller/FederationController.php
@@ -118,6 +118,7 @@ class FederationController extends Controller {
 	 * @param FederatedShareMapper $shareMapper Federated-share persistence.
 	 * @param ObjectService $objectService Object read service.
 	 * @param FederationShareService $shareService Share management (list/create/revoke).
+	 * @param IThrottler $throttler Brute-force throttler for rejected tokens.
 	 * @param LoggerInterface $logger Logger.
 	 */
 	public function __construct(

--- a/lib/Controller/IconController.php
+++ b/lib/Controller/IconController.php
@@ -62,12 +62,14 @@ class IconController extends Controller {
 	 *
 	 * @return DataDisplayResponse The SVG image, or a 404 for an unknown icon.
 	 *
+	 * The rate-limit ceiling is deliberately high: icons are fetched
+	 * many-per-page, and set near the data endpoints a single dense screen
+	 * trips it.
+	 *
 	 * @spec openspec/changes/unified-search-index/specs/unified-search-provider/spec.md
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
-	// Icons are fetched many-per-page, so this ceiling is deliberately high —
-	// set it near the data endpoints and a single dense screen trips it.
 	#[AnonRateLimit(limit: 240, period: 60)]
 	public function mdi(string $name): DataDisplayResponse {
 		$svg = MdiIconRenderer::svg(icon: $name);

--- a/lib/Controller/ObjectShareLinkController.php
+++ b/lib/Controller/ObjectShareLinkController.php
@@ -95,6 +95,7 @@ class ObjectShareLinkController extends Controller {
 	 * @param IRequest $request Request.
 	 * @param IManager $shareManager Core share manager — validates the token.
 	 * @param ObjectService $objectService Loads the addressed object.
+	 * @param IThrottler $throttler Brute-force throttler for rejected tokens.
 	 * @param LoggerInterface $logger Logger.
 	 */
 	public function __construct(

--- a/lib/Controller/UserController.php
+++ b/lib/Controller/UserController.php
@@ -229,13 +229,15 @@ class UserController extends Controller {
 	 *
 	 * @return JSONResponse A JSON response containing login result and user information
 	 *
+	 * The `#[AnonRateLimit]` below is a framework ceiling ALONGSIDE the
+	 * app-level limiter, not instead of it. `SecurityService::checkLoginRateLimit()`
+	 * already keys on username + IP with a progressive delay, which is
+	 * finer-grained than anything the framework can do from an attribute. The
+	 * attribute bounds the volume that reaches that logic at all; it is not a
+	 * claim that the login was unprotected.
+	 *
 	 * @spec openspec/specs/auth-system/spec.md
 	 */
-	// A framework ceiling ALONGSIDE the app-level limiter, not instead of it.
-	// SecurityService::checkLoginRateLimit() already keys on username + IP with a
-	// progressive delay, which is finer-grained than anything the framework can
-	// do from an attribute. This bounds the volume that reaches that logic at
-	// all; it is not a claim that the login was unprotected.
 	#[AnonRateLimit(limit: 20, period: 60)]
 	public function login(): JSONResponse {
 		try {

--- a/lib/Controller/VocabularyController.php
+++ b/lib/Controller/VocabularyController.php
@@ -116,12 +116,13 @@ class VocabularyController extends Controller {
 	 *
 	 * @return JSONResponse The concept object, or a 404 standard error shape.
 	 *
+	 * The rate limit is a runaway ceiling rather than a gate: this is published
+	 * vocabulary, and resolution is the point of it.
+	 *
 	 * @spec openspec/changes/skos-concept-registers/specs/skos-concept-registers/spec.md#skos-004
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
-	// Published vocabulary — resolution is the point of it, so these are
-	// runaway ceilings rather than gates.
 	#[AnonRateLimit(limit: 120, period: 60)]
 	public function resolveByUri(): JSONResponse {
 		$uri = trim((string)$this->request->getParam('uri', ''));

--- a/lib/Controller/WebPushController.php
+++ b/lib/Controller/WebPushController.php
@@ -183,10 +183,11 @@ class WebPushController extends Controller {
 	 *   #[AnonRateLimit] above bounds the anonymous render cost.
 	 *
 	 * @spec openspec/changes/openregister-web-push-engine/specs/web-push-delivery/spec.md
+	 * The rate-limit ceiling is high because notification icons are fetched
+	 * per-notification by the browser.
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
-	// Notification icons — fetched per-notification by the browser.
 	#[AnonRateLimit(limit: 240, period: 60)]
 	public function hexIcon(string $app): DataDisplayResponse {
 		$icon = $this->hexIconService->getIcon($app);

--- a/lib/Db/AuditTrailMapper.php
+++ b/lib/Db/AuditTrailMapper.php
@@ -1797,6 +1797,16 @@ class AuditTrailMapper extends QBMapper {
 		return $changed;
 	}//end capChangedPayload()
 
+	/**
+	 * Tombstone every audit-trail entry.
+	 *
+	 * ⚠️ Tombstones rather than deletes: the payload is destroyed but the row and
+	 * its chain links survive, because the hash chain is what makes the trail
+	 * evidence. Deleting rows would break the chain and leave nothing to show
+	 * that anything was ever there.
+	 *
+	 * @return bool True when the tombstone write succeeded.
+	 */
 	public function clearLogs(): bool {
 		try {
 			// Get the query builder for database operations.

--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -7613,6 +7613,9 @@ class MagicMapper extends AbstractObjectMapper {
 	 * @param Register $register Register context
 	 * @param Schema $schema Schema context
 	 * @param string $tableName Target table name
+	 * @param bool $needsPreUpdateState Whether anything downstream will read the
+	 *                                  pre-update rows (audit changeset or update
+	 *                                  event). False narrows the fetch to the uuid.
 	 *
 	 * @return array[] Array of complete objects with object_status field
 	 *
@@ -9203,6 +9206,9 @@ class MagicMapper extends AbstractObjectMapper {
 	 * @param array $updateObjects Objects to update (legacy parameter)
 	 * @param Register|null $register Optional register context
 	 * @param Schema|null $schema Optional schema context
+	 * @param bool $needsPreUpdateState Whether anything downstream will read the
+	 *                                  pre-update rows (audit changeset or update
+	 *                                  event). False narrows the fetch to the uuid.
 	 *
 	 * @return array Array of complete objects with object_status field
 	 *
@@ -9305,6 +9311,9 @@ class MagicMapper extends AbstractObjectMapper {
 	 * @param array $updateObjects Objects to update
 	 * @param Register|null $register Register context
 	 * @param Schema|null $schema Schema context
+	 * @param bool $needsPreUpdateState Whether anything downstream will read the
+	 *                                  pre-update rows (audit changeset or update
+	 *                                  event). False narrows the fetch to the uuid.
 	 *
 	 * @return array Array of complete objects with object_status field
 	 *

--- a/lib/Db/MagicMapper/MagicBulkHandler.php
+++ b/lib/Db/MagicMapper/MagicBulkHandler.php
@@ -360,6 +360,10 @@ class MagicBulkHandler {
 	 * @param Register $register Register context
 	 * @param Schema $schema Schema context
 	 * @param string $tableName Target table name
+	 * @param bool $needsPreUpdateState Whether anything downstream will read the
+	 *                                  pre-update rows (audit changeset or update
+	 *                                  event). False narrows the fetch to the uuid.
+	 *                                  See the SuppressWarnings note below.
 	 *
 	 * @return array Array of complete objects with object_status field
 	 *
@@ -449,6 +453,9 @@ class MagicBulkHandler {
 	 * @param array $chunk Chunk of prepared objects
 	 * @param string $tableName Target table name
 	 * @param int $chunkNumber Chunk number for logging
+	 * @param bool $needsPreUpdateState Whether anything downstream will read the
+	 *                                  pre-update rows. False narrows the fetch
+	 *                                  to the uuid. See the SuppressWarnings note.
 	 *
 	 * @return array Array of complete objects with object_status
 	 *
@@ -592,9 +599,16 @@ class MagicBulkHandler {
 			// built above and consumed by the INSERT further down. Shadowing it
 			// with a string turned `implode()` into a TypeError — a 500 on every
 			// bulk save, from a variable name.
+			// Written as plain assignments rather than a ternary or an
+			// if/else: phpcs forbids the inline IF and phpmd forbids the
+			// else, so the narrowest form that satisfies both is to state
+			// the default and then override it.
 			$existsColumns = '*';
 			if ($needsPreUpdateState === false) {
-				$existsColumns = ($isPostgres === true) ? '"_uuid"' : '`_uuid`';
+				$existsColumns = '`_uuid`';
+				if ($isPostgres === true) {
+					$existsColumns = '"_uuid"';
+				}
 			}
 
 			$existsSql = "SELECT {$existsColumns} FROM `{$fullTableName}` WHERE `_uuid` IN ({$placeholders})";

--- a/lib/Db/MagicMapper/MagicBulkHandler.php
+++ b/lib/Db/MagicMapper/MagicBulkHandler.php
@@ -599,16 +599,18 @@ class MagicBulkHandler {
 			// built above and consumed by the INSERT further down. Shadowing it
 			// with a string turned `implode()` into a TypeError — a 500 on every
 			// bulk save, from a variable name.
-			// Written as plain assignments rather than a ternary or an
-			// if/else: phpcs forbids the inline IF and phpmd forbids the
-			// else, so the narrowest form that satisfies both is to state
-			// the default and then override it.
+			// A `match`, not a ternary and not an if/else: phpcs forbids the
+			// inline IF and phpmd forbids the else. ⚠️ It also has to stay ONE
+			// statement — the earlier if/if form added two, and since this
+			// method needs a live magic table to execute, both were uncovered
+			// and the changed-files coverage ratchet failed the PR on a 0.008%
+			// "drop" for a comment-only change.
 			$existsColumns = '*';
 			if ($needsPreUpdateState === false) {
-				$existsColumns = '`_uuid`';
-				if ($isPostgres === true) {
-					$existsColumns = '"_uuid"';
-				}
+				$existsColumns = match (true) {
+					$isPostgres === true => '"_uuid"',
+					default => '`_uuid`',
+				};
 			}
 
 			$existsSql = "SELECT {$existsColumns} FROM `{$fullTableName}` WHERE `_uuid` IN ({$placeholders})";

--- a/lib/Db/MagicMapper/MagicBulkHandler.php
+++ b/lib/Db/MagicMapper/MagicBulkHandler.php
@@ -599,18 +599,19 @@ class MagicBulkHandler {
 			// built above and consumed by the INSERT further down. Shadowing it
 			// with a string turned `implode()` into a TypeError — a 500 on every
 			// bulk save, from a variable name.
-			// A `match`, not a ternary and not an if/else: phpcs forbids the
-			// inline IF and phpmd forbids the else. ⚠️ It also has to stay ONE
-			// statement — the earlier if/if form added two, and since this
-			// method needs a live magic table to execute, both were uncovered
-			// and the changed-files coverage ratchet failed the PR on a 0.008%
-			// "drop" for a comment-only change.
+			// ⚠️ KNOWN phpcs debt, left deliberately: Squiz.PHP.DisallowInlineIf
+			// flags the ternary below, and it is NOT fixable inside a
+			// comment-only change. Every alternative ADDS STATEMENTS to a method
+			// that needs a live magic table to execute, so the new lines are born
+			// uncovered and the changed-files coverage ratchet fails the PR:
+			//   if/else  -> phpmd ElseExpression
+			//   if/if    -> +2 statements, ratchet "dropped by 0%"   (8850 -> 8852)
+			//   match    -> +3 statements, ratchet "dropped by 0.01%" (8850 -> 8853)
+			// Fixing it properly means covering this branch with an integration
+			// test against a real table — its own change, not a docblock sweep.
 			$existsColumns = '*';
 			if ($needsPreUpdateState === false) {
-				$existsColumns = match (true) {
-					$isPostgres === true => '"_uuid"',
-					default => '`_uuid`',
-				};
+				$existsColumns = ($isPostgres === true) ? '"_uuid"' : '`_uuid`';
 			}
 
 			$existsSql = "SELECT {$existsColumns} FROM `{$fullTableName}` WHERE `_uuid` IN ({$placeholders})";

--- a/lib/Db/Schema.php
+++ b/lib/Db/Schema.php
@@ -978,6 +978,21 @@ class Schema extends Entity implements JsonSerializable {
 		return $names;
 	}//end declaredActionNames()
 
+	/**
+	 * Reject an authorization block that names an action the vocabulary does not know.
+	 *
+	 * The vocabulary is CLOSED by default and EXTENSIBLE by declaration — see the
+	 * body for how a schema adds one. The gate is the feature rather than a rail
+	 * bolted onto it: an open vocabulary lets a typo save cleanly as a permission
+	 * that is never granted and never errors.
+	 *
+	 * @param array|null $authorization The authorization block to check, or null.
+	 * @param string $context Human-readable location, used in the refusal message.
+	 *
+	 * @return void
+	 *
+	 * @throws \InvalidArgumentException When an action is not in the vocabulary.
+	 */
 	private function validateAuthorizationRules(?array $authorization, string $context): void {
 		if (empty($authorization) === true) {
 			return;

--- a/lib/Service/Object/SaveObjects.php
+++ b/lib/Service/Object/SaveObjects.php
@@ -2066,6 +2066,10 @@ class SaveObjects {
 	 * @param array $transformedObjects Valid objects ready for database operations
 	 * @param Register|string|int|null $register Caller-supplied register context (forwarded to mapper)
 	 * @param Schema|string|int|null $schema Caller-supplied schema context (forwarded to mapper)
+	 * @param bool $needsPreUpdateState Whether the mapper must read each row's pre-update
+	 *                                  state. Only events and audit need it, so the caller
+	 *                                  passes false when neither is enabled — that skips a
+	 *                                  read per row, which is the point of the bulk path.
 	 *
 	 * @return mixed The bulk operation result from the mapper
 	 *


### PR DESCRIPTION
Repo-wide phpcs was at **21 errors**; this clears **20**. CI never showed them because the gates are diff-scoped (ADR-020) — only a full-tree run surfaces this.

Two shapes:

**Six "must use /** style" errors.** A `//` rationale block sat BETWEEN attributes, so phpcs read it as the function comment. The rationale was the valuable part — why each rate-limit ceiling is set where it is — so it moved into the existing docblock rather than being deleted. No `#[AnonRateLimit]` value changed.

**Fourteen missing `@param` tags**, mostly `$needsPreUpdateState` threading through the bulk-save path plus `$throttler`/`$logger` on four controllers.

## ⚠️ The 21st is left, deliberately, with the measurement

`MagicBulkHandler` has one `Squiz.PHP.DisallowInlineIf`. It is **not fixable inside a comment-only change** — `executeUpsertChunk()` needs a live magic table to execute, so every statement an alternative adds is born uncovered and the changed-files coverage ratchet fails the PR:

| form | statements | ratchet |
|---|---|---|
| `if/else` | — | phpmd `ElseExpression` (different gate) |
| `if/if` | +2 | 8850 → 8852, *"dropped by 0%"* |
| `match` | +3 | 8850 → 8853, *"dropped by 0.01%"* |

🔑 **Covered stayed at 3173 in all three** — the denominator is the whole story. There is no zero-statement form, so no version of this fix fits here.

Fixing it properly means covering that branch with an integration test against a real table — worth doing, and its own change. Writing that test purely to let a docblock sweep through would be the filler-test failure mode the ratchet exists to prevent. The three measurements are recorded in a comment at the site so nobody re-runs the experiment.

**This PR's diff is now comment-only.** The remaining error is pre-existing and outside the diff, so diff-scoped gates do not flag it.

Verified locally: phpcs 21 → 1, phpmd clean on every file touched, psalm 0, `php -l` clean, 16831 tests unchanged.