### PR TITLE
fix(credential-broker): surface real upstream failure reason, trim secrets on write

### DIFF
--- a/lib/Controller/CredentialController.php
+++ b/lib/Controller/CredentialController.php
@@ -348,6 +348,16 @@ class CredentialController extends Controller {
 		}
 
 		$secret = $this->request->getParam('secret');
+		if (is_string($secret) === true) {
+			// Garbage-in prevention: this rotation path writes straight to the
+			// vault and does NOT go through CredentialBrokerService::mint(), so
+			// it needs its own trim (credential-broker-upstream-diagnostics D3)
+			// — a copy-pasted secret with a trailing newline previously reached
+			// the vault byte-for-byte and later failed header injection at call
+			// time with no usable diagnostic.
+			$secret = trim($secret);
+		}
+
 		if (is_string($secret) === true && $secret !== '') {
 			$this->credentialStore->put($id, $secret, $scope);
 		}

--- a/lib/Service/Credential/CredentialBrokerService.php
+++ b/lib/Service/Credential/CredentialBrokerService.php
@@ -254,7 +254,8 @@ class CredentialBrokerService {
 			url: $resolvedUrl,
 			headers: $requestHeaders,
 			body: $body,
-			credentialId: $credentialId
+			credentialId: $credentialId,
+			secret: (string)$secret
 		);
 	}//end request()
 
@@ -402,6 +403,15 @@ class CredentialBrokerService {
 			throw new InvalidArgumentException(message: 'A credential requires a name and a provider');
 		}
 
+		// Garbage-in prevention: a copy-pasted secret can carry a trailing
+		// newline or stray whitespace that later fails header injection at
+		// call time (openregister broker-error-swallow incident). Trim it
+		// once, here, so every mint (HTTP create + any in-process minter)
+		// stores the same normalised value. An all-whitespace secret trims
+		// to '', which the empty-secret branch below already treats as
+		// "metadata only, no vault write".
+		$secret = $this->trimmedSecret(secret: $secret);
+
 		$data = [
 			'name' => $name,
 			'provider' => $provider,
@@ -485,6 +495,28 @@ class CredentialBrokerService {
 			);
 		}
 	}//end discardOrphanedCredential()
+
+	/**
+	 * Trim leading/trailing whitespace (including newlines) from an incoming secret.
+	 *
+	 * A `null` secret ("metadata only, no vault write") passes through unchanged.
+	 * An all-whitespace secret trims to `''`, which the caller's existing
+	 * empty-secret check already treats as "no secret supplied" — introducing
+	 * no new edge case.
+	 *
+	 * @param string|null $secret The raw, caller-supplied secret, or null.
+	 *
+	 * @return string|null The trimmed secret, or null unchanged.
+	 *
+	 * @spec openspec/changes/credential-broker-upstream-diagnostics/specs/credential-broker/spec.md#requirement-a-credential-secret-is-trimmed-of-surrounding-whitespace-before-storage
+	 */
+	private function trimmedSecret(?string $secret): ?string {
+		if ($secret === null) {
+			return null;
+		}
+
+		return trim($secret);
+	}//end trimmedSecret()
 
 	/**
 	 * Whether a resolved provider entry is inject-only (app-side injection, never proxied).
@@ -1115,14 +1147,16 @@ class CredentialBrokerService {
 	 * @param array<string, string> $headers The final request headers (auth injected).
 	 * @param string|null $body The optional raw request body.
 	 * @param string $credentialId The credential UUID (for logging).
+	 * @param string $secret The raw secret injected into this call's headers, redacted out of any
+	 *                       transport failure's message before it is logged or re-thrown (design D1).
 	 *
 	 * @return array{status: int, headers: array<string, mixed>, body: string} The upstream response.
 	 *
 	 * @throws CredentialUpstreamException When the call fails at the transport level.
 	 *
-	 * @spec openspec/specs/credential-broker/spec.md
+	 * @spec openspec/changes/credential-broker-upstream-diagnostics/specs/credential-broker/spec.md#requirement-upstream-transport-failures-carry-a-secret-free-real-reason
 	 */
-	private function performCall(string $method, string $url, array $headers, ?string $body, string $credentialId): array {
+	private function performCall(string $method, string $url, array $headers, ?string $body, string $credentialId, string $secret): array {
 		$options = [
 			'headers' => $headers,
 			'http_errors' => false,
@@ -1135,11 +1169,18 @@ class CredentialBrokerService {
 			$client = $this->clientService->newClient();
 			$response = $client->request($method, $url, $options);
 		} catch (Throwable $e) {
+			// The secret was just injected into these headers a few lines above,
+			// so a transport exception's OWN message can embed it verbatim (e.g.
+			// NC's HTTP client rejects an invalid header value by quoting the
+			// value it rejected — openregister broker-error-swallow incident,
+			// where the rejected value WAS the header carrying the secret).
+			// Redact before this reaches a log line or an exception object.
+			$reason = $this->describeUpstreamFailure(exception: $e, secret: $secret);
 			$this->logger->error(
 				'[CredentialBrokerService] upstream call failed',
-				['credential' => $credentialId, 'error' => $e->getMessage()]
+				['credential' => $credentialId, 'error' => $reason]
 			);
-			throw new CredentialUpstreamException(message: 'Upstream request failed');
+			throw new CredentialUpstreamException(message: 'Upstream request failed: ' . $reason);
 		}
 
 		$rawBody = $response->getBody();
@@ -1153,6 +1194,47 @@ class CredentialBrokerService {
 			'body' => (string)$rawBody,
 		];
 	}//end performCall()
+
+	/**
+	 * Describe a transport failure with the credential's secret redacted.
+	 *
+	 * Redacts by exact substring rather than by heuristic: the broker already
+	 * knows the precise secret value injected into this call, so removing
+	 * exactly that string (and its trimmed variant, in case a transport layer
+	 * normalises whitespace before surfacing the value) cannot under- or
+	 * over-redact the way a generic "looks like a token" pattern could. The
+	 * exception's class name is kept — it is real diagnostic signal (a header
+	 * rejection vs. a DNS failure vs. a timeout look nothing alike) and cannot
+	 * itself carry a secret.
+	 *
+	 * This description is used for the server-side log line and the
+	 * `CredentialUpstreamException` thrown to in-process callers. It is
+	 * deliberately NOT surfaced in the HTTP API response — the controller
+	 * maps every `CredentialUpstreamException` to a single static generic
+	 * message regardless of its content (design D2), so a redaction bug here
+	 * can never become a cross-app disclosure over HTTP.
+	 *
+	 * @param Throwable $exception The transport-level exception.
+	 * @param string $secret The exact secret value injected into this call's headers.
+	 *
+	 * @return string A secret-redacted `ClassName: message` description.
+	 *
+	 * @spec openspec/changes/credential-broker-upstream-diagnostics/specs/credential-broker/spec.md#requirement-upstream-transport-failures-carry-a-secret-free-real-reason
+	 */
+	private function describeUpstreamFailure(Throwable $exception, string $secret): string {
+		$message = $exception->getMessage();
+
+		if ($secret !== '') {
+			$message = str_replace($secret, '[redacted]', $message);
+
+			$trimmedSecret = trim($secret);
+			if ($trimmedSecret !== '' && $trimmedSecret !== $secret) {
+				$message = str_replace($trimmedSecret, '[redacted]', $message);
+			}
+		}
+
+		return get_class($exception) . ': ' . $message;
+	}//end describeUpstreamFailure()
 
 	/**
 	 * Normalise and validate a caller-supplied path (reject `..`, require a single leading `/`).

--- a/openspec/changes/archive/2026-08-19-credential-broker-upstream-diagnostics/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-19-credential-broker-upstream-diagnostics/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-19

--- a/openspec/changes/archive/2026-08-19-credential-broker-upstream-diagnostics/design.md
+++ b/openspec/changes/archive/2026-08-19-credential-broker-upstream-diagnostics/design.md
@@ -1,0 +1,106 @@
+# Design — credential broker upstream diagnostics
+
+## Context
+
+`CredentialBrokerService::performCall()` is the single place the broker
+performs the outbound HTTP call after all four guards and secret injection
+have passed (`credential-broker/design.md` D4). Its `catch (Throwable $e)`
+block is the last point in-process that ever sees the real transport
+exception; today it discards it in two different ways (see proposal.md).
+
+Tonight's concrete trigger: `NC's IClientService` (Guzzle underneath) rejects
+a header value containing a raw `\n` before the request ever leaves the
+process. The exception it throws embeds the offending header value verbatim
+in its own message — `"token gho_...\n" is not valid header value` — which
+means the secret is present in `$e->getMessage()` for this specific failure
+class. Not every transport failure carries the secret (a DNS failure or a
+timeout does not), but the fix has to assume any transport exception MIGHT,
+because the header-injection guard is exactly the kind of failure this
+broker's own secret injection can trigger.
+
+## D1 — Redact by exact substring, not by heuristic
+
+Considered a generic "looks like a token" heuristic (e.g. regex for
+high-entropy strings) — rejected. It is unreliable in both directions: it can
+miss a low-entropy secret and can also eat unrelated diagnostic text that
+happens to look token-like (a commit SHA, a request id). The broker already
+knows the EXACT secret value for this call (it just injected it into the
+headers a few lines above `performCall()`), so the correct redaction is
+`str_replace($secret, '[redacted]', $message)` — it removes precisely the
+string that must never leak and nothing else. The trimmed variant of the
+secret is also redacted, in case a future transport layer normalises
+whitespace before it surfaces the value in its own message (defence in depth,
+cheap to add, matches D3's trim-on-write making the two variants usually
+identical anyway).
+
+`describeUpstreamFailure(Throwable $exception, string $secret): string`
+returns `get_class($exception) . ': ' . $message` — the exception class name
+carries real signal (`InvalidArgumentException` vs. a Guzzle connect
+exception vs. a timeout) that the generic literal threw away entirely, and
+it is not the sort of thing that can carry a secret.
+
+## D2 — Keep the HTTP response static; improve the exception, not the controller
+
+`CredentialController::brokerRequest()` / `sessionBrokerRequest()` already
+map `CredentialUpstreamException` to a hardcoded `{"message": "Upstream
+request failed"}` / 502, ignoring `$e->getMessage()` — this is intentional
+per `CredentialUpstreamException`'s own docblock ("this exception maps to a
+single static client error ... the real cause is logged server-side") and is
+pinned by the existing `testUpstreamFailureMapsTo502` test, which asserts the
+literal response body. The broker is reachable by less-privileged in-process
+callers across app boundaries (any app in `allowedApps`), so the HTTP/API
+surface must stay generic regardless of how good the redaction is — a
+redaction bug would otherwise become a cross-app information-disclosure bug.
+This change does not touch the controller's catch blocks or that test.
+
+What DOES change is who can see the improved message: the exception object
+now carries it, so (a) the log line callers grep is no longer the only
+place, (b) any in-process caller that catches `CredentialUpstreamException`
+directly (background jobs, `resolveInjectable()`'s siblings, tests) sees it
+too, and (c) an operator reading `nextcloud.log`'s `error` context field
+(the thing that was actually grepped tonight) sees the real, sanitised
+reason instead of either nothing or a raw secret.
+
+## D3 — Trim on write too (both places a secret enters storage)
+
+Two places accept a raw secret from request input and hand it to the vault:
+
+- `CredentialBrokerService::mint()` (`POST /api/credentials` via
+  `CredentialController::create()`, and any in-process minter).
+- `CredentialController::update()`'s direct `$this->credentialStore->put($id,
+  $secret, $scope)` (`PUT /api/credentials/{id}`) — this is the ROTATION
+  path, and specifically the one that produced tonight's incident. It
+  bypasses `mint()` entirely (an existing credential's metadata object is
+  already persisted; only the vault write happens), so trimming inside
+  `mint()` alone would not have caught this.
+
+Both now `trim()` the incoming secret before it reaches
+`CredentialStore::put()`. `trim()`'s default character list
+(`" \t\n\r\0\x0B"`) covers the reported case (`\n`) and the adjacent ones
+(`\r`, tabs, stray spaces from a copy-paste) without touching the meaningful
+byte content of the secret. An all-whitespace secret trims to `''`, which
+both call sites already treat as "no secret supplied" (mint: skip the vault
+write; update: skip the `put()` call) — no new edge case introduced.
+
+This is deliberately BOTH a write-side fix (D3) and a read-side fix (D1/D2):
+D3 prevents the exact reproduced scenario from recurring, but does nothing
+for every OTHER transport failure the broker can hit (wrong `baseUrl`, TLS,
+timeout, provider outage) — those still need D1/D2's better diagnosis. D1/D2
+alone would leave the vault silently storing a malformed secret forever.
+Doing only one leaves a real gap; doing both is the same size of change and
+closes both.
+
+## Non-goals
+
+- Not changing `CredentialStore`'s interface or either leaf implementation
+  (`NextcloudVaultCredentialStore`, `DoriathCredentialStore`) — trimming is
+  an application-level input-normalisation concern, not a storage-leaf
+  concern, and touching the interface would ripple into every leaf for no
+  additional benefit (both existing call sites already funnel through the
+  two places D3 touches).
+- Not adding a general secret-scrub helper shared across the codebase — the
+  grep for `scrub`/`redact`/`sanitize` found only unrelated per-domain
+  helpers (GDPR data-subject scrub, SQL identifier sanitizers, file-metadata
+  scrubbers, etc.); none apply to "redact one already-known exact string from
+  a free-text exception message", so a small local helper is the right size
+  and avoids a speculative shared abstraction with no second caller yet.

--- a/openspec/changes/archive/2026-08-19-credential-broker-upstream-diagnostics/proposal.md
+++ b/openspec/changes/archive/2026-08-19-credential-broker-upstream-diagnostics/proposal.md
@@ -1,0 +1,65 @@
+---
+kind: fix
+depends_on: []
+adr: openspec/architecture/adr-004-credential-broker-custody.md
+---
+
+## Why
+
+Reproduced live tonight via a real credential rotation: a stored secret was
+rotated to a token string with an embedded trailing newline (`"gho_...\n"`).
+Nextcloud's HTTP client (`IClientService`) rejected the resulting
+`Authorization: token {secret}\n` header as invalid (header-injection
+protection — a `\n` in a header value is illegal). The caller learned nothing
+beyond a static "Upstream request failed" / `broker_denied`-style response.
+
+`CredentialBrokerService::performCall()` (`lib/Service/Credential/CredentialBrokerService.php:1125-1155`)
+catches every transport-level `Throwable` from the outbound call and:
+
+1. Logs `$e->getMessage()` **verbatim** into the `error` log context. For this
+   exact failure mode the underlying exception's message embeds the actual
+   rejected header VALUE — i.e. the secret itself — so today's code writes the
+   raw secret into `nextcloud.log` on every header-format failure. This is a
+   live secret-disclosure bug, not just a diagnostics gap.
+2. Throws `new CredentialUpstreamException(message: 'Upstream request failed')`
+   — a hardcoded literal that discards the real exception entirely. Nothing
+   about the actual cause (`"... is not valid header value"`, a DNS failure, a
+   TLS error, a timeout) is recoverable from the exception object itself, only
+   from grepping `nextcloud.log`'s context field — which, per point 1, may
+   itself contain the secret.
+
+Separately, neither of the two places a credential secret is written
+(`CredentialBrokerService::mint()`, used by `POST /api/credentials`, and
+`CredentialController::update()`'s direct `credentialStore->put()`, used by
+`PUT /api/credentials/{id}` for rotation) trims the incoming value, so a
+copy-pasted secret with trailing whitespace/newline is stored and later
+injected into a header byte-for-byte.
+
+## What Changes
+
+- `CredentialBrokerService::performCall()` redacts the known secret (and its
+  trimmed variant) out of the transport exception's message before it touches
+  a log line or an exception object, via a new `describeUpstreamFailure()`
+  helper. The redacted `"ClassName: message"` description replaces both the
+  log line's raw `$e->getMessage()` (fixing the current leak) and the
+  generic literal in `CredentialUpstreamException` (fixing the swallowing).
+- The HTTP-facing response stays a static, generic message
+  (`CredentialController::brokerRequest()` / `sessionBrokerRequest()` are
+  unchanged) — ADR-004's fail-closed non-disclosure posture across the HTTP
+  trust boundary is preserved. The improved detail lands in the exception
+  object and the log line, which is what in-process callers (openconnector,
+  background jobs, tests) and operators actually consume.
+- `CredentialBrokerService::mint()` and `CredentialController::update()` both
+  `trim()` an incoming secret before it reaches the vault — garbage-in
+  prevention for the exact scenario that triggered this, applied at both
+  places a secret enters storage.
+
+## Impact
+
+- Affected: `lib/Service/Credential/CredentialBrokerService.php`,
+  `lib/Controller/CredentialController.php`.
+- No API/response-shape change; no new dependency.
+- Risk: low. The redaction only ever removes an exact substring (the actual
+  secret value); it cannot make a message MORE revealing than before, and the
+  static HTTP response is untouched (pinned by the existing
+  `testUpstreamFailureMapsTo502` test).

--- a/openspec/changes/archive/2026-08-19-credential-broker-upstream-diagnostics/specs/credential-broker/spec.md
+++ b/openspec/changes/archive/2026-08-19-credential-broker-upstream-diagnostics/specs/credential-broker/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Upstream transport failures carry a secret-free real reason
+
+When the broker's outbound call fails at the transport level (after all four
+guards passed and the secret was injected), the `CredentialUpstreamException`
+thrown to in-process callers, and the corresponding server-side log line,
+SHALL both carry the underlying exception's class and a redacted description
+of its message — with the credential's own secret value removed — rather than
+a single hardcoded generic string. The HTTP API response for the same failure
+SHALL remain a static, generic message; this requirement governs only the
+exception object and the log line, not the response returned across the HTTP
+trust boundary.
+
+#### Scenario: A header-format failure's real cause reaches the exception, not just the log
+
+- **WHEN** the outbound HTTP client rejects the request because the injected
+  auth header value is invalid (e.g. it contains a raw newline)
+- **AND** the underlying transport exception's own message embeds the
+  rejected header value, which contains the secret
+- **THEN** the `CredentialUpstreamException` thrown by the broker contains
+  the real failure reason (e.g. "is not valid header value") with the secret
+  value redacted
+- **AND** the log line the broker writes for this failure contains the same
+  redacted reason, never the raw secret
+
+#### Scenario: The HTTP response stays generic regardless of the improved diagnosis
+
+- **WHEN** a brokered call made over `POST /api/credentials/{id}/request` or
+  `.../session-request` fails at the transport level
+- **THEN** the JSON response is the static `{"message": "Upstream request
+  failed"}` body with HTTP 502, unchanged by how much diagnostic detail the
+  exception object itself now carries
+
+### Requirement: A credential secret is trimmed of surrounding whitespace before storage
+
+Both places a caller-supplied secret is written to the credential vault
+(minting a new credential, and rotating an existing credential's secret)
+SHALL trim leading and trailing whitespace (including newlines) from the
+secret before it is passed to `CredentialStore::put()`. A secret that trims
+to an empty string SHALL be treated as no secret supplied.
+
+#### Scenario: A secret rotated with a trailing newline is stored trimmed
+
+- **WHEN** a credential's secret is rotated via `PUT /api/credentials/{id}`
+  with a value ending in `"\n"`
+- **THEN** the value stored in the vault has the trailing newline removed
+- **AND** a subsequent brokered call injects the trimmed value into the
+  outbound header, which is a valid header value

--- a/openspec/changes/archive/2026-08-19-credential-broker-upstream-diagnostics/tasks.md
+++ b/openspec/changes/archive/2026-08-19-credential-broker-upstream-diagnostics/tasks.md
@@ -1,0 +1,41 @@
+# Tasks — credential broker upstream diagnostics
+
+## Redact + surface the real transport failure (D1, D2)
+
+- [x] 1.1 Add `CredentialBrokerService::describeUpstreamFailure(Throwable $exception, string $secret): string` — redacts the exact secret (and its trimmed variant) from `$exception->getMessage()`, returns `ClassName: sanitised message`.
+- [x] 1.2 Add a `string $secret` parameter to `performCall()`; pass it from `request()`'s call site.
+- [x] 1.3 In `performCall()`'s catch block, use `describeUpstreamFailure()` for both the `logger->error()` context (`error` key — fixes the current raw-secret-into-log leak) and the thrown `CredentialUpstreamException`'s message (fixes the swallowed generic literal).
+- [x] 1.4 Confirm `CredentialController::brokerRequest()` / `sessionBrokerRequest()` are untouched — the HTTP response stays the static generic message (D2); do not read `$e->getMessage()` there.
+
+## Trim on write (D3)
+
+- [x] 2.1 `CredentialBrokerService::mint()`: `trim()` a non-null `$secret` before the null/empty check and the vault write.
+- [x] 2.2 `CredentialController::update()`: `trim()` the `secret` request param before the `!== ''` check and the direct `credentialStore->put()` call.
+
+## Tests
+
+- [x] 3.1 Unit test: a transport `Throwable` whose message embeds the injected secret → the thrown `CredentialUpstreamException`'s message contains the real reason text but NOT the secret.
+- [x] 3.2 Unit test: the same case → `LoggerInterface::error()` is called with an `error` context value that does NOT contain the secret.
+- [x] 3.3 Unit test: `mint()` with a secret carrying a trailing `"\n"` stores the trimmed value (assert the exact string passed to `CredentialStore::put()`).
+- [x] 3.4 Unit test: `CredentialController::update()` with a whitespace-padded secret stores the trimmed value.
+- [x] 3.5 Confirm the existing `testUpstreamFailureMapsTo502` and `testSecretNeverAppearsInResponse` controller tests still pass unmodified (pins D2).
+
+## Verification
+
+- [x] 4.1 `composer check:strict` gates run directly (`vendor/bin/phpcs`, `phpmd`, `psalm`, `phpstan` scoped to the two changed files — the composer wrapper's full-project `phpcs`/`phpmd` passes were also run and show no new findings) — all clean.
+- [x] 4.2 Full PHPUnit suite for `tests/Unit/Service/Credential/` (including `CredentialControllerOrganisationTest.php`) and `tests/Unit/Controller/CredentialControllerTest.php` green — 153 tests, 794 assertions.
+
+## Acceptance criteria
+
+- A transport-level upstream failure's real cause (exception class + a
+  secret-redacted message) is present on the `CredentialUpstreamException`
+  object and in the server-side log line — never only in a raw log field that
+  itself might carry the secret.
+- The secret value is provably absent from both the thrown exception's
+  message and the log line, even when the underlying transport exception's
+  own message embedded it.
+- A secret rotated or minted with leading/trailing whitespace/newlines is
+  stored trimmed, at both entry points (`mint()`, `update()`'s direct vault
+  write).
+- The HTTP API response shape for an upstream failure is unchanged (still the
+  static generic 502 body).

--- a/openspec/specs/credential-broker/spec.md
+++ b/openspec/specs/credential-broker/spec.md
@@ -25,7 +25,9 @@ status: in-progress
 
 ## Purpose
 TBD - created by archiving change harden-credential-token-binding. Update Purpose after archive.
+
 ## Requirements
+
 ### Requirement: Brokered credentials never expose the private key on disk
 
 Loading a signing key for authorization SHALL NOT write the private key to a
@@ -57,3 +59,50 @@ SHALL be rejected, even within its TTL.
 - **WHEN** a token bound to `GET /repos/x` is used for exactly that call
 - **THEN** the broker authorises it (subject to the four allow-rule guards)
 
+### Requirement: Upstream transport failures carry a secret-free real reason
+
+When the broker's outbound call fails at the transport level (after all four
+guards passed and the secret was injected), the `CredentialUpstreamException`
+thrown to in-process callers, and the corresponding server-side log line,
+SHALL both carry the underlying exception's class and a redacted description
+of its message — with the credential's own secret value removed — rather than
+a single hardcoded generic string. The HTTP API response for the same failure
+SHALL remain a static, generic message; this requirement governs only the
+exception object and the log line, not the response returned across the HTTP
+trust boundary.
+
+#### Scenario: A header-format failure's real cause reaches the exception, not just the log
+
+- **WHEN** the outbound HTTP client rejects the request because the injected
+  auth header value is invalid (e.g. it contains a raw newline)
+- **AND** the underlying transport exception's own message embeds the
+  rejected header value, which contains the secret
+- **THEN** the `CredentialUpstreamException` thrown by the broker contains
+  the real failure reason (e.g. "is not valid header value") with the secret
+  value redacted
+- **AND** the log line the broker writes for this failure contains the same
+  redacted reason, never the raw secret
+
+#### Scenario: The HTTP response stays generic regardless of the improved diagnosis
+
+- **WHEN** a brokered call made over `POST /api/credentials/{id}/request` or
+  `.../session-request` fails at the transport level
+- **THEN** the JSON response is the static `{"message": "Upstream request
+  failed"}` body with HTTP 502, unchanged by how much diagnostic detail the
+  exception object itself now carries
+
+### Requirement: A credential secret is trimmed of surrounding whitespace before storage
+
+Both places a caller-supplied secret is written to the credential vault
+(minting a new credential, and rotating an existing credential's secret)
+SHALL trim leading and trailing whitespace (including newlines) from the
+secret before it is passed to `CredentialStore::put()`. A secret that trims
+to an empty string SHALL be treated as no secret supplied.
+
+#### Scenario: A secret rotated with a trailing newline is stored trimmed
+
+- **WHEN** a credential's secret is rotated via `PUT /api/credentials/{id}`
+  with a value ending in `"\n"`
+- **THEN** the value stored in the vault has the trailing newline removed
+- **AND** a subsequent brokered call injects the trimmed value into the
+  outbound header, which is a valid header value

--- a/tests/Unit/Controller/CredentialControllerTest.php
+++ b/tests/Unit/Controller/CredentialControllerTest.php
@@ -327,4 +327,112 @@ class CredentialControllerTest extends TestCase {
 		$this->assertIsString($encoded);
 		$this->assertStringNotContainsString('SUPERSECRETTOKEN', $encoded);
 	}//end testSecretNeverAppearsInResponse()
+
+	/**
+	 * PUT /api/credentials/{id} is the ROTATION path — it writes to the vault
+	 * directly, bypassing CredentialBrokerService::mint() entirely, so it needs
+	 * its own trim (credential-broker-upstream-diagnostics D3). Pins the exact
+	 * incident: a secret rotated with a trailing newline must reach the vault
+	 * trimmed, not byte-for-byte.
+	 */
+	public function testUpdateTrimsTrailingWhitespaceFromARotatedSecret(): void {
+		$capturedSecret = null;
+		$store = $this->createMock(CredentialStore::class);
+		$store->method('put')->willReturnCallback(
+			function (string $uuid, string $secret, string $scope) use (&$capturedSecret) {
+				$capturedSecret = $secret;
+			}
+		);
+
+		$controller = $this->makeUpdateController(
+			ownerUid: 'alice',
+			credData: ['name' => 'My GitHub', 'provider' => 'github', 'allowedApps' => ['hermiq']],
+			params: ['secret' => "gho_rotated\n"],
+			store: $store
+		);
+
+		$response = $controller->update('cred-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame('gho_rotated', $capturedSecret);
+	}//end testUpdateTrimsTrailingWhitespaceFromARotatedSecret()
+
+	/**
+	 * A whitespace-only rotated secret trims to '' and is treated as "no
+	 * rotation requested" — the vault is never touched.
+	 */
+	public function testUpdateWithWhitespaceOnlySecretNeverTouchesTheVault(): void {
+		$store = $this->createMock(CredentialStore::class);
+		$store->expects($this->never())->method('put');
+
+		$controller = $this->makeUpdateController(
+			ownerUid: 'alice',
+			credData: ['name' => 'My GitHub', 'provider' => 'github', 'allowedApps' => ['hermiq']],
+			params: ['secret' => "  \n\t "],
+			store: $store
+		);
+
+		$response = $controller->update('cred-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}//end testUpdateWithWhitespaceOnlySecretNeverTouchesTheVault()
+
+	/**
+	 * Build a CredentialController for exercising update() — an owned personal
+	 * credential, a stub saveObject() that echoes the merged property bag back,
+	 * and a caller-supplied CredentialStore mock to assert the vault write.
+	 *
+	 * @param string $ownerUid The session/owner uid (owner guard passes).
+	 * @param array<string, mixed> $credData The existing credential's property bag.
+	 * @param array<string, mixed> $params The request body params (e.g. `secret`).
+	 * @param CredentialStore&\PHPUnit\Framework\MockObject\MockObject $store The vault mock.
+	 *
+	 * @return CredentialController The wired controller.
+	 */
+	private function makeUpdateController(
+		string $ownerUid,
+		array $credData,
+		array $params,
+		CredentialStore $store,
+	): CredentialController {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($ownerUid);
+		$session = $this->createMock(IUserSession::class);
+		$session->method('getUser')->willReturn($user);
+
+		$entity = new ObjectEntity();
+		$entity->setOwner($ownerUid);
+		$entity->setObject($credData);
+
+		$objectService = $this->createMock(ObjectService::class);
+		$objectService->method('find')->willReturn($entity);
+		$objectService->method('saveObject')->willReturnCallback(
+			function (array $object, ...$rest) {
+				$saved = new ObjectEntity();
+				$saved->setObject($object);
+				return $saved;
+			}
+		);
+
+		$request = $this->createMock(IRequest::class);
+		$request->method('getParam')->willReturnCallback(
+			static function (string $key, $default = null) use ($params) {
+				return array_key_exists($key, $params) ? $params[$key] : $default;
+			}
+		);
+
+		return new CredentialController(
+			'openregister',
+			$request,
+			$session,
+			$this->createMock(IGroupManager::class),
+			$objectService,
+			$store,
+			$this->createMock(ProviderCatalogue::class),
+			$this->createMock(CredentialBrokerService::class),
+			$this->createMock(CredentialAppTokenService::class),
+			$this->createMock(OrganisationService::class),
+			new SharePrincipalDeriver()
+		);
+	}//end makeUpdateController()
 }//end class

--- a/tests/Unit/Service/Credential/CredentialBrokerMintTest.php
+++ b/tests/Unit/Service/Credential/CredentialBrokerMintTest.php
@@ -157,6 +157,40 @@ class CredentialBrokerMintTest extends TestCase {
 		$this->assertSame('metadata-only', $entity->getUuid());
 	}
 
+	/**
+	 * A copy-pasted secret with a trailing newline is stored TRIMMED — garbage-in
+	 * prevention for the header-injection failure this reproduces
+	 * (credential-broker-upstream-diagnostics D3).
+	 */
+	public function testMintTrimsTrailingWhitespaceFromTheSecret(): void {
+		$this->stubSaveObject(uuid: 'minted-uuid');
+		$this->store->expects($this->once())->method('put')
+			->with('minted-uuid', 'gho_hunter2', 'personal');
+
+		$this->makeBroker()->mint(
+			name: 'My GitHub',
+			provider: 'github',
+			owner: 'alice',
+			secret: "gho_hunter2\n"
+		);
+	}
+
+	/**
+	 * A secret that is ENTIRELY whitespace trims to '' and is treated as no
+	 * secret supplied — metadata-only mint, vault untouched.
+	 */
+	public function testMintWithWhitespaceOnlySecretNeverTouchesTheVault(): void {
+		$this->stubSaveObject(uuid: 'metadata-only');
+		$this->store->expects($this->never())->method('put');
+
+		$this->makeBroker()->mint(
+			name: 'Metadata only',
+			provider: 'github',
+			owner: 'alice',
+			secret: "  \n\t "
+		);
+	}
+
 	public function testMintWithEmptySecretNeverTouchesTheVault(): void {
 		$this->stubSaveObject(uuid: 'metadata-only');
 		$this->store->expects($this->never())->method('put');

--- a/tests/Unit/Service/Credential/CredentialBrokerServiceTest.php
+++ b/tests/Unit/Service/Credential/CredentialBrokerServiceTest.php
@@ -20,10 +20,12 @@ declare(strict_types=1);
 
 namespace Unit\Service\Credential;
 
+use InvalidArgumentException;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Service\Credential\CredentialAccessDeniedException;
 use OCA\OpenRegister\Service\Credential\CredentialBrokerService;
 use OCA\OpenRegister\Service\Credential\CredentialStore;
+use OCA\OpenRegister\Service\Credential\CredentialUpstreamException;
 use OCA\OpenRegister\Service\Credential\ProviderCatalogue;
 use OCA\OpenRegister\Service\ObjectService;
 use OCA\OpenRegister\Service\OrganisationService;
@@ -115,6 +117,104 @@ class CredentialBrokerServiceTest extends TestCase {
 			$this->createMock(LoggerInterface::class),
 			$this->createMock(OrganisationService::class)
 		);
+	}
+
+	/** @var array<string, mixed>|null Captured logger->error() context. */
+	private ?array $capturedLogContext = null;
+
+	/**
+	 * Wire a broker whose outbound client throws a transport-level exception,
+	 * with a logger mock that captures the context passed to error().
+	 *
+	 * @param \Throwable $transportException The exception the client throws.
+	 */
+	private function makeServiceWithTransportFailure(\Throwable $transportException): CredentialBrokerService {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$session = $this->createMock(IUserSession::class);
+		$session->method('getUser')->willReturn($user);
+
+		$entity = new ObjectEntity();
+		$entity->setOwner('alice');
+		$entity->setObject(['provider' => 'github', 'allowedApps' => ['hermiq']]);
+
+		$objectService = $this->createMock(ObjectService::class);
+		$objectService->method('find')->willReturn($entity);
+
+		$catalogue = $this->createMock(ProviderCatalogue::class);
+		$catalogue->method('get')->willReturn($this->githubProvider());
+
+		$store = $this->createMock(CredentialStore::class);
+		$store->method('get')->willReturn('SUPERSECRETTOKEN' . "\n");
+
+		$client = $this->createMock(IClient::class);
+		$client->method('request')->willThrowException($transportException);
+		$clientService = $this->createMock(IClientService::class);
+		$clientService->method('newClient')->willReturn($client);
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->method('error')->willReturnCallback(
+			function (string $message, array $context = []) {
+				$this->capturedLogContext = $context;
+			}
+		);
+
+		return new CredentialBrokerService(
+			$objectService,
+			$store,
+			$catalogue,
+			$session,
+			$clientService,
+			$logger,
+			$this->createMock(OrganisationService::class)
+		);
+	}
+
+	/**
+	 * The thrown exception carries the real, secret-free reason — not the
+	 * hardcoded generic literal the broker used to throw.
+	 */
+	public function testUpstreamFailureExceptionCarriesRedactedRealReason(): void {
+		$secret = 'SUPERSECRETTOKEN' . "\n";
+		$transportException = new InvalidArgumentException(
+			'"token ' . $secret . '" is not valid header value'
+		);
+		$service = $this->makeServiceWithTransportFailure($transportException);
+
+		try {
+			$service->request('cred-1', 'hermiq', 'GET', '/repos/Conduction/openregister');
+			$this->fail('Expected CredentialUpstreamException');
+		} catch (CredentialUpstreamException $e) {
+			// The real reason survives...
+			$this->assertStringContainsString('is not valid header value', $e->getMessage());
+			$this->assertStringContainsString(InvalidArgumentException::class, $e->getMessage());
+			// ...but the secret never appears in the exception message.
+			$this->assertStringNotContainsString('SUPERSECRETTOKEN', $e->getMessage());
+		}
+	}
+
+	/**
+	 * The server-side log line carries the same redacted reason — never the raw
+	 * secret, even when the underlying transport exception's own message
+	 * embedded it (the exact openregister broker-error-swallow scenario).
+	 */
+	public function testUpstreamFailureLogLineNeverContainsTheRawSecret(): void {
+		$secret = 'SUPERSECRETTOKEN' . "\n";
+		$transportException = new InvalidArgumentException(
+			'"token ' . $secret . '" is not valid header value'
+		);
+		$service = $this->makeServiceWithTransportFailure($transportException);
+
+		try {
+			$service->request('cred-1', 'hermiq', 'GET', '/repos/Conduction/openregister');
+		} catch (CredentialUpstreamException $e) {
+			// Expected — assert the log capture below.
+		}
+
+		$this->assertNotNull($this->capturedLogContext);
+		$logged = (string)json_encode($this->capturedLogContext);
+		$this->assertStringNotContainsString('SUPERSECRETTOKEN', $logged);
+		$this->assertStringContainsString('is not valid header value', $logged);
 	}
 
 	public function testOwnerGuardRejectsNonOwner(): void {


### PR DESCRIPTION
## Summary

Reproduced live tonight via a real credential rotation: a stored secret was
rotated to a token with an embedded trailing newline (`"gho_...\n"`).
Nextcloud's HTTP client rejected the resulting `Authorization` header as
invalid (header-injection protection). The caller learned nothing beyond a
static "Upstream request failed" — the real cause was recoverable only by
grepping `nextcloud.log`, and (per the actual exception message on this
failure class) that log line itself embedded the raw secret.

- `CredentialBrokerService::performCall()` now redacts the exact secret out
  of the transport exception's message via a new `describeUpstreamFailure()`
  helper, and uses the redacted `ClassName: reason` description for both the
  `logger->error()` context (fixing the current raw-secret-into-log leak) and
  the thrown `CredentialUpstreamException`'s message (previously a hardcoded
  generic literal that discarded the real cause entirely).
- The HTTP API response is unchanged — `CredentialController` still maps any
  `CredentialUpstreamException` to a static generic 502 body, preserving the
  fail-closed non-disclosure posture across the HTTP trust boundary (pinned
  by the pre-existing `testUpstreamFailureMapsTo502` test).
- `CredentialBrokerService::mint()` and `CredentialController::update()`'s
  direct vault write (the credential ROTATION path, which bypasses `mint()`
  entirely) both now `trim()` an incoming secret before it reaches the
  vault — garbage-in prevention for the exact reproduced scenario.
- OpenSpec change `credential-broker-upstream-diagnostics` created, applied,
  archived, and folded into `openspec/specs/credential-broker/spec.md`.

## Test plan

- [x] New unit tests: the thrown exception carries the real, secret-redacted
      reason; the log line never contains the raw secret; `mint()` and
      `update()` store a trailing-newline secret trimmed; a whitespace-only
      secret is treated as none supplied.
- [x] Existing `testUpstreamFailureMapsTo502` / `testSecretNeverAppearsInResponse`
      still pass unmodified — the HTTP response shape is untouched.
- [x] `tests/Unit/Service/Credential/` + `tests/Unit/Controller/CredentialControllerTest.php`
      + `CredentialControllerOrganisationTest.php`: 153 tests / 794 assertions, green.
- [x] `vendor/bin/phpcs`, `phpmd` (both rulesets), `psalm`, `phpstan` on the
      two changed lib files: clean, no new findings.