### PR TITLE
fix(flow): preflight silently accepted every broken TRIGGER config

### DIFF
--- a/lib/Service/Flow/FlowNodePreflight.php
+++ b/lib/Service/Flow/FlowNodePreflight.php
@@ -89,6 +89,7 @@ namespace OCA\OpenRegister\Service\Flow;
 use OCP\App\IAppManager;
 use Psr\Log\LoggerInterface;
 use Throwable;
+use InvalidArgumentException;
 use UnexpectedValueException;
 
 /**
@@ -677,8 +678,29 @@ class FlowNodePreflight {
 	 *
 	 * A node that throws for a reason of its own (a broken translation, a
 	 * missing collaborator) must not block the save — that would turn one bad
-	 * node into an unsavable instance. Only the node's own refusal counts, and
-	 * `UnexpectedValueException` is what every implementation in-tree raises.
+	 * node into an unsavable instance. Only the node's own refusal counts.
+	 *
+	 * BOTH SPL "bad argument" exceptions count as a refusal. This used to catch
+	 * `UnexpectedValueException` alone, on the stated grounds that it "is what
+	 * every implementation in-tree raises". That was untrue:
+	 * `TriggerScheduleNode`, `TriggerObjectNode` and `FlowStateNode` all raise
+	 * `InvalidArgumentException`, so their refusals were swallowed into the
+	 * warning below and the flow saved clean.
+	 *
+	 * The consequence was the worst shape a validator can have — silent
+	 * acceptance of exactly the configs it exists to catch. Measured against a
+	 * live instance: a `trigger-schedule` carrying `cron: "@hourly"` (not a
+	 * five-field expression) and a `trigger-object` naming a register that does
+	 * not exist BOTH returned `{"valid":true,"blocking":[],"warnings":[]}`. The
+	 * first flow would never fire; the second would subscribe to nothing.
+	 * Neither failure is visible anywhere until someone wonders why a flow has
+	 * not run.
+	 *
+	 * Discriminating on the SPL subclass was always fragile: both mean "this
+	 * argument is wrong", the choice between them is a matter of taste, and
+	 * third-party nodes (openconnector, hermiq) pick whichever they like. The
+	 * distinction that actually matters — the node REFUSED the config, versus
+	 * the node BROKE — is preserved by keeping the `Throwable` arm below.
 	 *
 	 * @param IFlowNode $node The resolved node.
 	 * @param array $edge The edge declaring the step.
@@ -695,7 +717,7 @@ class FlowNodePreflight {
 
 		try {
 			$node->validateConfig($config);
-		} catch (UnexpectedValueException $e) {
+		} catch (UnexpectedValueException | InvalidArgumentException $e) {
 			return $e->getMessage();
 		} catch (Throwable $e) {
 			$this->logger->warning(

--- a/tests/Unit/Service/Flow/FlowNodePreflightTriggerRefusalTest.php
+++ b/tests/Unit/Service/Flow/FlowNodePreflightTriggerRefusalTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use InvalidArgumentException;
+use OCA\OpenRegister\Service\Flow\FlowNodePreflight;
+use OCA\OpenRegister\Service\Flow\FlowNodeRegistry;
+use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCP\App\IAppManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use UnexpectedValueException;
+
+/**
+ * A node's refusal must block the save whichever SPL exception it chose.
+ *
+ * The preflight used to catch `UnexpectedValueException` alone, on the stated
+ * grounds that it was "what every implementation in-tree raises". It was not:
+ * TriggerScheduleNode, TriggerObjectNode and FlowStateNode all raise
+ * `InvalidArgumentException`, so their refusals were logged as "failed for its
+ * own reasons" and the flow saved clean.
+ *
+ * Measured live before the fix: `cron: "@hourly"` and a trigger naming a
+ * register that does not exist both returned `valid: true`. The first flow
+ * never fires; the second subscribes to nothing.
+ */
+class FlowNodePreflightTriggerRefusalTest extends TestCase {
+
+	/**
+	 * A preflight whose single known node refuses with the given exception.
+	 *
+	 * @param \Throwable $refusal What the node throws from validateConfig().
+	 *
+	 * @return FlowNodePreflight
+	 */
+	private function preflightRefusingWith(\Throwable $refusal): FlowNodePreflight {
+		$node = $this->createMock(IFlowNode::class);
+		$node->method('validateConfig')->willThrowException($refusal);
+
+		$registry = $this->createMock(FlowNodeRegistry::class);
+		$registry->method('get')->willReturn($node);
+
+		$appManager = $this->createMock(IAppManager::class);
+		$appManager->method('isEnabledForUser')->willReturn(true);
+
+		return new FlowNodePreflight($registry, $appManager, $this->createMock(LoggerInterface::class));
+	}
+
+	/**
+	 * @return array<string, mixed> The flow document.
+	 */
+	private function flow(): array {
+		return [
+			'name' => 'trigger-flow',
+			'nodes' => [['id' => 'a', 'type' => 'openregister.trigger-schedule'], ['id' => 'b']],
+			'edges' => [['id' => 'e1', 'from' => 'a', 'to' => 'b']],
+		];
+	}
+
+	/**
+	 * The regression: an InvalidArgumentException refusal must BLOCK.
+	 *
+	 * @return void
+	 */
+	public function testAnInvalidArgumentRefusalBlocksTheSave(): void {
+		$preflight = $this->preflightRefusingWith(
+			new InvalidArgumentException('A cron expression has five fields.')
+		);
+
+		$this->expectException(UnexpectedValueException::class);
+		$this->expectExceptionMessageMatches('/five fields/');
+		$preflight->assertRunnable(flow: $this->flow());
+
+	}//end testAnInvalidArgumentRefusalBlocksTheSave()
+
+	/**
+	 * The behaviour that already worked keeps working.
+	 *
+	 * @return void
+	 */
+	public function testAnUnexpectedValueRefusalStillBlocksTheSave(): void {
+		$preflight = $this->preflightRefusingWith(
+			new UnexpectedValueException('This step needs a register.')
+		);
+
+		$this->expectException(UnexpectedValueException::class);
+		$this->expectExceptionMessageMatches('/needs a register/');
+		$preflight->assertRunnable(flow: $this->flow());
+
+	}//end testAnUnexpectedValueRefusalStillBlocksTheSave()
+
+	/**
+	 * A node that BROKE — as opposed to refusing — must not make the instance
+	 * unsavable. This is the distinction the change deliberately preserves.
+	 *
+	 * @return void
+	 */
+	public function testANodeThatBreaksForItsOwnReasonsDoesNotBlock(): void {
+		$preflight = $this->preflightRefusingWith(
+			new RuntimeException('A collaborator this node needs is missing.')
+		);
+
+		$preflight->assertRunnable(flow: $this->flow());
+		$this->addToAssertionCount(1);
+
+	}//end testANodeThatBreaksForItsOwnReasonsDoesNotBlock()
+}//end class


### PR DESCRIPTION
configRejection() caught UnexpectedValueException alone, on the stated grounds that it is what every implementation in-tree raises. It is not: TriggerScheduleNode, TriggerObjectNode and FlowStateNode all raise InvalidArgumentException. Their refusals fell through to the Throwable arm, were logged as 'failed for its own reasons, not blocking', and the flow saved clean.

MEASURED ON A LIVE INSTANCE. Both of these returned valid:true with empty blocking and warnings:
- trigger-schedule with cron '@hourly' (not a five-field expression) — the flow NEVER FIRES.
- trigger-object naming a register that does not exist — it SUBSCRIBES TO NOTHING.

Neither failure is visible anywhere until somebody wonders why a flow has not run. This is the worst shape a validator can have: silent acceptance of exactly the configs it exists to catch.

It also quietly limited every valid:true this endpoint has returned. Negative controls written against STEP nodes pass, because those raise the caught type, so the check looked trustworthy while being blind to a whole node role.

THE FIX: catch both SPL bad-argument exceptions. Discriminating on the subclass was always fragile — both mean 'this argument is wrong', the choice is taste, and third-party nodes pick whichever they like. The distinction that matters — the node REFUSED versus the node BROKE — is preserved: the Throwable arm still logs and does not block, so one broken node cannot make the instance unsavable.

VERIFICATION: three tests — an InvalidArgumentException refusal blocks, an UnexpectedValueException refusal still blocks, and a node that genuinely broke still does not. Positive control: with the old single catch restored the new test FAILS; with the fix it passes. 18 preflight tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)