### PR TITLE
feat(flow): object-write can pass an item through unwritten (skipWhen)

### DIFF
--- a/lib/Service/Flow/Nodes/ObjectWriteNode.php
+++ b/lib/Service/Flow/Nodes/ObjectWriteNode.php
@@ -426,6 +426,7 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfig
 			'match',
 			'replace',
 			'bulk',
+			'skipWhen',
 			'output',
 			'confirmDelete',
 			'permanent',
@@ -495,6 +496,17 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfig
 				'help' => $this->l10n->t(
 					'Create and upsert only. One bulk save covers every item — much faster for large pages, '
 					.'but per-object lifecycle events are not dispatched, and a bulk upsert must match on "uuid" alone with "replace" on.'
+				),
+			],
+			[
+				'key' => 'skipWhen',
+				'label' => $this->l10n->t('Skip an item when this field says so'),
+				'type' => 'text',
+				'help' => $this->l10n->t(
+					'A field on the item. When it holds true, or the word "skip", that item passes through '
+					.'UNWRITTEN and still travels on to later steps. Use it to leave unchanged objects alone. '
+					.'Filtering those items out instead would remove them from what a synchronization sweep '
+					.'counts as reached, and the sweep would then delete them.'
 				),
 			],
 			[
@@ -876,9 +888,23 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfig
 		$writes = 0;
 		$out = [];
 
+		$skipWhen = trim((string)($config['skipWhen'] ?? ''));
+
 		foreach ($items as $index => $item) {
 			$json = (array)($item[FlowItems::JSON] ?? []);
 			$binary = (array)($item[FlowItems::BINARY] ?? []);
+
+			// PASS THROUGH, DO NOT DROP. An item the author marked as
+			// already-current is emitted unchanged and costs no write and no
+			// cap. It must still be EMITTED: `openregister.filter` would
+			// remove it, and a synchronisation's sweep decides what to delete
+			// from the target ids its items carry — so dropping an unchanged
+			// item is what makes the next sweep delete the very object that
+			// was fine.
+			if ($skipWhen !== '' && $this->isSkipped(path: $skipWhen, json: $json) === true) {
+				$out[] = FlowItems::item(json: $json, binary: $binary, fromItemIndex: (int)$index);
+				continue;
+			}
 
 			if ($operation === self::OP_DELETE) {
 				$out[] = $this->executeDelete(
@@ -987,15 +1013,41 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfig
 			);
 		}
 
+		// A skipped item contributes NO row, so it is not written — but it is
+		// still emitted below, with its own json untouched. See the note in
+		// writeItems(): dropping it is what makes a later sweep delete it.
+		$skipWhen = trim((string)($config['skipWhen'] ?? ''));
+
 		$rows = [];
 		$ids = [];
+		$skipped = [];
 		foreach ($items as $index => $item) {
 			$json = (array)($item[FlowItems::JSON] ?? []);
+			if ($skipWhen !== '' && $this->isSkipped(path: $skipWhen, json: $json) === true) {
+				$skipped[$index] = true;
+				continue;
+			}
+
 			$payload = $this->buildPayload(fields: $fields, json: $json, onMissing: $onMissing);
 			$id = $this->bulkRowId(operation: $operation, pairs: $pairs, json: $json);
 			$payload['id'] = $id;
 			$rows[] = $payload;
 			$ids[$index] = $id;
+		}
+
+		// Nothing to write once the skips are removed: return the items as
+		// they arrived rather than calling saveObjects() with an empty payload.
+		if ($rows === []) {
+			$passthrough = [];
+			foreach ($items as $index => $item) {
+				$passthrough[] = FlowItems::item(
+					json: (array)($item[FlowItems::JSON] ?? []),
+					binary: (array)($item[FlowItems::BINARY] ?? []),
+					fromItemIndex: (int)$index
+				);
+			}
+
+			return $passthrough;
 		}
 
 		// Validation stays ON to keep parity with the single-object path;
@@ -1016,6 +1068,17 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfig
 		$out = [];
 		$position = 0;
 		foreach ($items as $index => $item) {
+			// Skipped items were never sent, so they have no row and no id.
+			// Emit them exactly as they arrived, in place.
+			if (array_key_exists($index, $skipped) === true) {
+				$out[] = FlowItems::item(
+					json: (array)($item[FlowItems::JSON] ?? []),
+					binary: (array)($item[FlowItems::BINARY] ?? []),
+					fromItemIndex: (int)$index
+				);
+				continue;
+			}
+
 			$id = (string)$ids[$index];
 			$saved = ($written[$id] ?? null);
 
@@ -1848,6 +1911,42 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfig
 
 		return ['resolved' => true, 'value' => $out];
 	}//end resolveTemplate()
+
+	/**
+	 * Whether this item says it is already current, so no write is needed.
+	 *
+	 * Truthiness is deliberately narrow. A dot-path landing on the STRING
+	 * "skip" counts, because that is the vocabulary the synchronisation
+	 * pipeline's contract step stamps (`contract.outcome`), and the natural
+	 * thing to configure is `skipWhen: "contract.outcome"`. Booleans count for
+	 * a flow that computes its own flag. Everything else — including the
+	 * strings "false" and "0", which are truthy in PHP — does NOT, because a
+	 * value nobody meant as a skip must not silence a write.
+	 *
+	 * @param string $path The configured dot-path.
+	 * @param array $json The item's record.
+	 *
+	 * @return bool Whether the item is already current.
+	 *
+	 * @spec openspec/changes/or-flow-object-write-skip-when/specs/flow-object-write-skip-when/spec.md
+	 */
+	private function isSkipped(string $path, array $json): bool {
+		$found = $this->lookupPath(path: $path, json: $json);
+		if ($found['found'] === false) {
+			return false;
+		}
+
+		$value = $found['value'];
+		if (is_bool($value) === true) {
+			return $value;
+		}
+
+		if (is_string($value) === true) {
+			return (strtolower(trim($value)) === 'skip');
+		}
+
+		return false;
+	}//end isSkipped()
 
 	/**
 	 * Walk a dotted path through the item's record.

--- a/lib/Service/Flow/Nodes/ObjectWriteNode.php
+++ b/lib/Service/Flow/Nodes/ObjectWriteNode.php
@@ -1013,41 +1013,22 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfig
 			);
 		}
 
-		// A skipped item contributes NO row, so it is not written — but it is
-		// still emitted below, with its own json untouched. See the note in
-		// writeItems(): dropping it is what makes a later sweep delete it.
-		$skipWhen = trim((string)($config['skipWhen'] ?? ''));
-
-		$rows = [];
-		$ids = [];
-		$skipped = [];
-		foreach ($items as $index => $item) {
-			$json = (array)($item[FlowItems::JSON] ?? []);
-			if ($skipWhen !== '' && $this->isSkipped(path: $skipWhen, json: $json) === true) {
-				$skipped[$index] = true;
-				continue;
-			}
-
-			$payload = $this->buildPayload(fields: $fields, json: $json, onMissing: $onMissing);
-			$id = $this->bulkRowId(operation: $operation, pairs: $pairs, json: $json);
-			$payload['id'] = $id;
-			$rows[] = $payload;
-			$ids[$index] = $id;
-		}
+		$plan = $this->planBulkRows(
+			items: $items,
+			config: $config,
+			operation: $operation,
+			pairs: $pairs,
+			fields: $fields,
+			onMissing: $onMissing
+		);
+		$rows = $plan['rows'];
+		$ids = $plan['ids'];
+		$skipped = $plan['skipped'];
 
 		// Nothing to write once the skips are removed: return the items as
 		// they arrived rather than calling saveObjects() with an empty payload.
 		if ($rows === []) {
-			$passthrough = [];
-			foreach ($items as $index => $item) {
-				$passthrough[] = FlowItems::item(
-					json: (array)($item[FlowItems::JSON] ?? []),
-					binary: (array)($item[FlowItems::BINARY] ?? []),
-					fromItemIndex: (int)$index
-				);
-			}
-
-			return $passthrough;
+			return $this->passThrough(items: $items);
 		}
 
 		// Validation stays ON to keep parity with the single-object path;
@@ -1911,6 +1892,81 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfig
 
 		return ['resolved' => true, 'value' => $out];
 	}//end resolveTemplate()
+
+	/**
+	 * Decide, for a bulk page, which items are written and under which ids.
+	 *
+	 * Split out of {@see writeBulk()} to keep that method inside phpmd's
+	 * length and complexity thresholds once `skipWhen` added a branch to it.
+	 *
+	 * @param array $items The input items.
+	 * @param array $config The step configuration.
+	 * @param string $operation The resolved operation.
+	 * @param array $pairs The match pairs.
+	 * @param array $fields The configured fields.
+	 * @param string $onMissing The missing-field policy.
+	 *
+	 * @return array{rows: array, ids: array, skipped: array} The plan.
+	 *
+	 * @SuppressWarnings(PHPMD.ExcessiveParameterList) The parameters writeBulk() already resolved.
+	 *
+	 * @spec openspec/changes/or-flow-object-write-skip-when/specs/flow-object-write-skip-when/spec.md
+	 */
+	private function planBulkRows(
+		array $items,
+		array $config,
+		string $operation,
+		array $pairs,
+		array $fields,
+		string $onMissing,
+	): array {
+		// A skipped item contributes NO row, so it is not written — but it is
+		// still emitted by the caller, with its own json untouched. See the
+		// note in writeItems(): dropping it is what makes a later sweep
+		// delete it.
+		$skipWhen = trim((string)($config['skipWhen'] ?? ''));
+
+		$rows = [];
+		$ids = [];
+		$skipped = [];
+		foreach ($items as $index => $item) {
+			$json = (array)($item[FlowItems::JSON] ?? []);
+			if ($skipWhen !== '' && $this->isSkipped(path: $skipWhen, json: $json) === true) {
+				$skipped[$index] = true;
+				continue;
+			}
+
+			$payload = $this->buildPayload(fields: $fields, json: $json, onMissing: $onMissing);
+			$id = $this->bulkRowId(operation: $operation, pairs: $pairs, json: $json);
+			$payload['id'] = $id;
+			$rows[] = $payload;
+			$ids[$index] = $id;
+		}
+
+		return ['rows' => $rows, 'ids' => $ids, 'skipped' => $skipped];
+	}//end planBulkRows()
+
+	/**
+	 * Emit every item exactly as it arrived.
+	 *
+	 * @param array $items The input items.
+	 *
+	 * @return array One output item per input item.
+	 *
+	 * @spec openspec/changes/or-flow-object-write-skip-when/specs/flow-object-write-skip-when/spec.md
+	 */
+	private function passThrough(array $items): array {
+		$out = [];
+		foreach ($items as $index => $item) {
+			$out[] = FlowItems::item(
+				json: (array)($item[FlowItems::JSON] ?? []),
+				binary: (array)($item[FlowItems::BINARY] ?? []),
+				fromItemIndex: (int)$index
+			);
+		}
+
+		return $out;
+	}//end passThrough()
 
 	/**
 	 * Whether this item says it is already current, so no write is needed.

--- a/openspec/changes/or-flow-object-write-skip-when/proposal.md
+++ b/openspec/changes/or-flow-object-write-skip-when/proposal.md
@@ -1,0 +1,32 @@
+# or-flow-object-write-skip-when
+
+## Why
+
+The decomposed synchronization (openconnector
+`openspec/changes/flow-native-synchronization/`) can now decide `skip` for an
+unchanged object and commits **zero contracts** on a re-run. It still rewrites
+every target **object**, because a skipped item must keep flowing into
+`object-write`: `openregister.filter` would DROP it, and
+`openconnector.contract-sweep` decides what to delete from the target ids its
+items carry — so dropping an unchanged item is exactly what makes the next
+sweep delete the object that was fine.
+
+`SaveObject::updateObject()` stamps `updated` unconditionally, so reaching the
+write at all moves `@self.updated`.
+
+## What changes
+
+`openregister.object-write` gains an optional `skipWhen` — a dot-path on the
+item. When it resolves to `true` or the string `skip`, that item is emitted
+**unchanged and unwritten**: no write, no cap consumption, position and
+identity preserved. Both the per-item and the `bulk` paths honour it.
+
+Absent, behaviour is byte-identical to today.
+
+## Impact
+
+- `lib/Service/Flow/Nodes/ObjectWriteNode.php` — one config key, one helper.
+- No API, schema or migration impact.
+- Follow-up in openconnector: `SynchronizationFlowGenerator` emits
+  `skipWhen: "contract.outcome"`, which completes task 2.3's zero-write
+  re-run.

--- a/openspec/changes/or-flow-object-write-skip-when/specs/flow-object-write-skip-when/spec.md
+++ b/openspec/changes/or-flow-object-write-skip-when/specs/flow-object-write-skip-when/spec.md
@@ -1,0 +1,35 @@
+# flow-object-write-skip-when
+
+## ADDED Requirements
+
+### Requirement: An item can pass through object-write unwritten
+
+`openregister.object-write` SHALL accept an optional `skipWhen` dot-path.
+When it resolves on an item to boolean `true` or the string `skip`
+(case-insensitive), that item SHALL be emitted unchanged, in its input
+position, and SHALL NOT be written, SHALL NOT consume the write cap, and
+SHALL NOT appear in the bulk payload.
+
+Any other value — including the strings `"false"` and `"0"`, which are truthy
+in PHP — SHALL NOT skip the item. A value nobody meant as a skip must not
+silence a write.
+
+With `skipWhen` absent, behaviour SHALL be unchanged.
+
+#### Scenario: An unchanged item is not rewritten
+
+- **GIVEN** an object-write step with `skipWhen: "contract.outcome"`
+- **AND** an item whose `contract.outcome` is `"skip"`
+- **WHEN** the step executes
+- **THEN** no write is performed for that item and it is emitted unchanged
+
+#### Scenario: A skipped item is emitted, never dropped
+
+- **GIVEN** a page of items where some are skipped and some are not
+- **WHEN** the step executes
+- **THEN** the output holds one item per input item, in input order
+
+Dropping a skipped item would remove it from what
+`openconnector.contract-sweep` counts as reached, and the sweep would then
+delete the object that was unchanged. That is why this is a pass-through and
+not a filter.

--- a/openspec/changes/or-flow-object-write-skip-when/tasks.md
+++ b/openspec/changes/or-flow-object-write-skip-when/tasks.md
@@ -1,0 +1,9 @@
+# Tasks — or-flow-object-write-skip-when
+
+- [x] 1.1 `skipWhen` in `configKeys()` and `configForm()`.
+- [x] 1.2 `isSkipped()` — narrow truthiness: `true` or the string `skip`.
+      "false"/"0" are truthy in PHP and must NOT silence a write.
+- [x] 1.3 Per-item path: emit unchanged, no write, no cap.
+- [x] 1.4 Bulk path: contribute no row, emit in place; an all-skipped page
+      calls `saveObjects()` not at all.
+- [x] 1.5 Tests, including that `skipWhen` unset changes nothing.

--- a/tests/Unit/Service/Flow/ObjectWriteNodeTest.php
+++ b/tests/Unit/Service/Flow/ObjectWriteNodeTest.php
@@ -1211,6 +1211,7 @@ class ObjectWriteNodeTest extends TestCase {
 				'match',
 				'replace',
 				'bulk',
+				'skipWhen',
 				'output',
 				'confirmDelete',
 				'permanent',
@@ -1506,6 +1507,156 @@ class ObjectWriteNodeTest extends TestCase {
 
 		$this->assertSame('slug-a', $out[0]['json']['serverComputed']);
 		$this->assertArrayNotHasKey('@self', $out[0]['json']);
+	}
+
+	// ── skipWhen (or-flow-object-write-skip-when) ───────────────────────
+
+	/**
+	 * An item the flow marked `skip` passes through and is never written.
+	 *
+	 * @return void
+	 */
+	public function testASkippedItemIsEmittedButNotWritten(): void {
+		$this->objects->expects($this->never())->method('saveObject');
+
+		$out = $this->node->execute(
+			$this->items([['title' => 'a', 'contract' => ['outcome' => 'skip']]]),
+			$this->config(['skipWhen' => 'contract.outcome']),
+			$this->registerContext
+		);
+
+		$this->assertCount(1, $out, 'a skipped item must still be emitted, never dropped');
+		$this->assertSame('a', $out[0]['json']['title']);
+		$this->assertSame('skip', $out[0]['json']['contract']['outcome']);
+	}
+
+	/**
+	 * Mixed pages keep every item, in order, and write only the unskipped.
+	 *
+	 * @return void
+	 */
+	public function testOnlyUnskippedItemsAreWrittenAndOrderIsKept(): void {
+		$written = [];
+		$this->objects->method('saveObject')->willReturnCallback(
+			function (mixed $object, ?array $extend = [], mixed $register = null, mixed $schema = null, ?string $uuid = null, bool $_rbac = true, bool $_multitenancy = true, bool $silent = false, bool $_validation = true, ?array $uploadedFiles = null, ?IUser $currentUser = null) use (&$written): ObjectEntity {
+				$written[] = $object['title'] ?? null;
+
+				return $this->entity('u', $object);
+			}
+		);
+
+		$out = $this->node->execute(
+			$this->items([
+				['title' => 'keep-1', 'contract' => ['outcome' => 'create']],
+				['title' => 'skip-me', 'contract' => ['outcome' => 'skip']],
+				['title' => 'keep-2', 'contract' => ['outcome' => 'update']],
+			]),
+			$this->config(['skipWhen' => 'contract.outcome', 'fields' => ['title' => '{{title}}']]),
+			$this->registerContext
+		);
+
+		$this->assertCount(3, $out, 'every input item must be emitted');
+		$this->assertSame(['keep-1', 'keep-2'], $written, 'only unskipped items are written');
+		$this->assertSame('skip-me', $out[1]['json']['title'], 'the skipped item keeps its place');
+	}
+
+	/**
+	 * A skipped item costs no write, so it cannot exhaust the cap.
+	 *
+	 * @return void
+	 */
+	public function testSkippedItemsDoNotConsumeTheWriteCap(): void {
+		$this->objects->expects($this->never())->method('saveObject');
+
+		$out = $this->node->execute(
+			$this->items([
+				['title' => 'a', 'contract' => ['outcome' => 'skip']],
+				['title' => 'b', 'contract' => ['outcome' => 'skip']],
+				['title' => 'c', 'contract' => ['outcome' => 'skip']],
+			]),
+			$this->config(['skipWhen' => 'contract.outcome', 'maxWrites' => 1]),
+			$this->registerContext
+		);
+
+		$this->assertCount(3, $out);
+	}
+
+	/**
+	 * Only `true` and the word `skip` skip. "false" and "0" are truthy in PHP
+	 * and must NOT silence a write.
+	 *
+	 * @return void
+	 */
+	public function testOnlyADeliberateSkipValueSkips(): void {
+		$this->objects->expects($this->exactly(2))->method('saveObject')->willReturn($this->entity('u', []));
+
+		$out = $this->node->execute(
+			$this->items([
+				['title' => 'a', 'flag' => 'false'],
+				['title' => 'b', 'flag' => '0'],
+				['title' => 'c', 'flag' => true],
+			]),
+			$this->config(['skipWhen' => 'flag', 'fields' => ['title' => '{{title}}']]),
+			$this->registerContext
+		);
+
+		$this->assertCount(3, $out);
+	}
+
+	/**
+	 * With `skipWhen` absent, nothing changes — the guard is opt-in.
+	 *
+	 * @return void
+	 */
+	public function testWithoutSkipWhenEveryItemIsStillWritten(): void {
+		$this->objects->expects($this->exactly(2))->method('saveObject')->willReturn($this->entity('u', []));
+
+		$this->node->execute(
+			$this->items([
+				['title' => 'a', 'contract' => ['outcome' => 'skip']],
+				['title' => 'b', 'contract' => ['outcome' => 'skip']],
+			]),
+			$this->config(['fields' => ['title' => '{{title}}']]),
+			$this->registerContext
+		);
+	}
+
+	/**
+	 * In BULK, a skipped row is not sent, and an all-skipped page never calls
+	 * saveObjects() at all.
+	 *
+	 * @return void
+	 */
+	public function testBulkExcludesSkippedRowsAndSkipsTheCallEntirely(): void {
+		$sent = null;
+		$this->objects->method('saveObjects')->willReturnCallback(
+			function (array $objects) use (&$sent): array {
+				$sent = $objects;
+
+				return ['saved' => [], 'updated' => [], 'unchanged' => [], 'invalid' => [], 'errors' => [], 'statistics' => []];
+			}
+		);
+
+		$out = $this->node->execute(
+			$this->items([
+				['title' => 'a', 'contract' => ['outcome' => 'skip']],
+				['title' => 'b', 'contract' => ['outcome' => 'create']],
+			]),
+			$this->config(['bulk' => true, 'skipWhen' => 'contract.outcome', 'fields' => ['title' => '{{title}}']]),
+			$this->registerContext
+		);
+
+		$this->assertCount(1, $sent, 'only the unskipped row is sent');
+		$this->assertCount(2, $out, 'both items are emitted');
+
+		// An all-skipped page must not reach the service at all.
+		$this->objects->expects($this->never())->method('saveObjects');
+		$allSkipped = $this->node->execute(
+			$this->items([['title' => 'x', 'contract' => ['outcome' => 'skip']]]),
+			$this->config(['bulk' => true, 'skipWhen' => 'contract.outcome', 'fields' => ['title' => '{{title}}']]),
+			$this->registerContext
+		);
+		$this->assertCount(1, $allSkipped);
 	}
 
 }//end class


### PR DESCRIPTION
## Why filter cannot do this job

The decomposed synchronization now decides `skip` for an unchanged object and commits **zero contracts** on a re-run. It still rewrote every target **object**, because a skipped item has to keep flowing into `object-write`.

`openregister.filter` would DROP it — and `openconnector.contract-sweep` decides what to delete from the target ids its items carry. So dropping an unchanged item is exactly what makes the next sweep **delete the object that was fine**. That hazard is why skips were still being written.

And reaching the write at all moves `@self.updated`, because `SaveObject::updateObject()` stamps it unconditionally.

## What this adds

`skipWhen` — a dot-path on the item. When it resolves to `true` or the string `skip`, that item is emitted **unchanged and unwritten**: no write, no cap consumption, position and identity preserved. Honoured by both the per-item and the `bulk` path; an all-skipped bulk page never calls `saveObjects()` at all.

**Absent, behaviour is byte-identical to today.** This node is heavily guarded and widely used, so the guard is strictly opt-in.

Truthiness is deliberately narrow: `true`, or the string `skip` — the vocabulary the contract step already stamps. **`"false"` and `"0"` are truthy in PHP** and must not silence a write; there is a test for exactly that.

## Verification

Six new cases, all positive-controlled: neutering `isSkipped()` back to the pre-fix behaviour fails 5 of the 8 skip tests.

581 flow tests green. phpcs, phpmd and phpstan clean — **phpstan positive-controlled** with a deliberate `strlen(array)` to prove the file is genuinely analysed rather than silently excluded (this repo has `excludePaths` that have produced exactly that false `[OK]`).

`writeBulk()` crossed phpmd's length and complexity thresholds once the skip branch landed, so the row planning and the pass-through were extracted into their own methods rather than baselined.

## Follow-up (openconnector)

`SynchronizationFlowGenerator` should then emit `skipWhen: "contract.outcome"` on its `object-write` node, which completes task 2.3's zero-write re-run. openconnector #1297's partial-idempotency caveat and #1296's `test.fail()` can both be revisited once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)