### PR TITLE
chore(deps): nc-vue ^2.8.0 — flow editor nodes are reachable again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
-        "@conduction/nextcloud-vue": "^2.7.1",
+        "@conduction/nextcloud-vue": "^2.8.0",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "^2.6.0",
         "@nextcloud/capabilities": "^1.2.1",
@@ -2112,9 +2112,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.7.1.tgz",
-      "integrity": "sha512-Qivd4gNqPu01p7tffIiK0VEZEjkGRi57medKbHWFUzYM0K31GZu4nSCUsvGB0l/Q3SYiQQkxIeDHs9Fu08RpGg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.8.0.tgz",
+      "integrity": "sha512-YIxFC1mNFo5RzVu/Cn9JX24X9IDETMTOpQRplrcvqDK9XUnS58qfOtMyStwGY051sjHgiv87Oz0djNmS52z6eQ==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
-    "@conduction/nextcloud-vue": "^2.7.1",
+    "@conduction/nextcloud-vue": "^2.8.0",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "^2.6.0",
     "@nextcloud/capabilities": "^1.2.1",


### PR DESCRIPTION
2.7.x auto-layout parked nodes **under the floating toolbar**, which swallows the pointer — a node there could not be clicked, double-clicked to open its editor, or dragged out from under itself. Found by opening the real editor on a live instance; no unit test has geometry.

2.8.0 starts the first row clear of it, and corrects the `canvasEdges` docblock that still described the pre-fix edge dialect.

Verified in the **installed bytes**, not just the lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)