### PR TITLE
docs(openspec): propose aggregation-dialect-repair — the declarative dialect is silently discarded

### DIFF
--- a/openspec/changes/aggregation-dialect-repair/.openspec.yaml
+++ b/openspec/changes/aggregation-dialect-repair/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-19

--- a/openspec/changes/aggregation-dialect-repair/design.md
+++ b/openspec/changes/aggregation-dialect-repair/design.md
@@ -1,0 +1,217 @@
+## Context
+
+Diagnosed live, 2026-08-19, during decidesk's organisation-goals apply (Back to Six programme):
+declaring `x-openregister-aggregations`/`x-openregister-calculations` on a schema produces no
+computed fields, and Meeting's own `quorumPercentage`/`actionItemCount` — the pattern cited as
+"already proven in production" in decidesk design docs — fails identically. The only observable
+signal is a `nextcloud.log` warning line matching `annotation on schema`, emitted by
+`SchemaMapper::validate*Annotation()`'s degrade-to-warning-and-continue pattern
+(`lib/Db/SchemaMapper.php:1044-1249`), which never reaches a schema author working through a normal
+config-import or admin-UI schema save. A cited-as-proven declarative pattern was dead platform-wide
+with zero PHPUnit test failing.
+
+Reading the code confirms three distinct, independently-triggerable defects (see proposal.md's
+"Why" for exact file:line citations):
+
+1. `AggregationAnnotationValidator`'s field-existence check only exempts a spec carrying a literal
+   top-level `from` key (`AggregationAnnotationValidator.php:116-123`); any other way of addressing a
+   related schema's field is checked against the declaring schema's own `properties`
+   (`SchemaMapper.php:1044-1056` supplies only the declaring schema's shape) and rejected.
+2. `CalculationAnnotationValidator`'s v1 operator vocabulary (`CalculationAnnotationValidator.php:60-93`)
+   has no `mul`/`add`/`sub`/`div` aliases, only the bare arithmetic symbols.
+3. Nothing requires a calculation's declared name to also be a schema property, so a calculation
+   that validates cleanly and evaluates correctly still evaporates at `MagicMapper::reportDroppedProperties()`
+   (`MagicMapper.php:3855-3905`) because its output key isn't in `properties`.
+
+All three share one shape: a validator (or the persistence layer) makes an implicit assumption about
+where a name lives, the assumption doesn't hold for a legitimate authoring pattern, and the failure
+mode is silent discard rather than a clear, author-visible rejection. That shared shape is why this
+change adds a fourth, cross-cutting fix (loud discard) rather than three point-fixes: fixing the
+three known triggers without also fixing the surfacing gap leaves every *next* undiscovered trigger
+of the same discard shape equally invisible.
+
+Two adjacent defects surfaced in the same investigation wave (appointment-decision-type apply) share
+enough of the "declared correctly, silently wrong at runtime" shape to fold into this repair:
+seed-imported `$ref` values landing as raw slugs, and a nested `$ref` inside an array-of-objects
+403ing on direct writes.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `AggregationAnnotationValidator` validates a filter/groupBy field against the schema that actually
+  owns it, so a cross-schema-shaped aggregation (Meeting's own quorum/actionItem pattern) validates
+  and runs.
+- `CalculationAnnotationValidator` and `CalculationEvaluator` agree on an operator vocabulary that
+  includes `mul`/`add`/`sub`/`div` as aliases, without removing the existing symbol forms.
+- A calculation's declared name is guaranteed materialisable — either the validator requires it to
+  be a declared property, or the property is implicitly added — closing the "valid annotation, empty
+  column" gap.
+- A discarded `x-openregister-*` annotation (any of the seven families sharing the discard shape) is
+  visible in the schema-save API response, not only in `nextcloud.log`.
+- Seed-imported `$ref` values resolve to the target UUID.
+- A nested `$ref` inside an array-of-objects property validates a valid UUID on direct writes.
+
+**Non-Goals:**
+- No change to the `x-openregister-aggregations`/`-calculations` DSL shape itself beyond what's
+  needed for these fixes — no new operators, no new aggregation metrics.
+- No re-materialisation of already-discarded annotations on existing schemas — an operator re-saves
+  the schema (or re-imports) to pick up corrected validation; `occ
+  openregister:rematerialise-calculations` (existing `computed-fields` capability) then backfills
+  values on existing objects.
+- Retiring `lib/Settings/ori_register.json` — tracked as a task, not executed here (procest still
+  depends on it; decidesk's own ORI adoption isn't complete).
+- Any change to `row-field-level-security`, `deprecate-published-metadata`, or the
+  `confidentiality-classification` primitive (same wave, separate change) — unrelated capabilities.
+
+## Decisions
+
+### Fix 1 — cross-schema field resolution (ADR-011: fix the real gap, not the symptom)
+
+The correct-by-design escape hatch already exists: `validateCrossSchemaSpec()`
+(`AggregationAnnotationValidator.php:221-259`) deliberately skips field-existence checks for a spec
+carrying a `from` key, because the target schema isn't loaded at annotation-save time. The actual
+defect is narrower than "the validator checks the wrong schema" — it is **"the validator has no way
+to recognise a cross-schema-shaped spec that doesn't spell `from`."** Two authoring patterns need to
+both reach the lighter cross-schema validation path:
+
+1. **Explicit `from`** — already correct; keep as-is.
+2. **Implicit cross-schema via a relation/aggregate-reference field** — Meeting's own aggregations
+   reference fields that live on a related schema reached through a declared relation (per the
+   proposal's evidence: filter keys like `goal`, `meeting`, `lifecycle`). The fix extends field
+   resolution so that when a filter/groupBy field is NOT in the declaring schema's `propKeys` but IS
+   a name the schema's own relation/`$ref` declarations resolve through (mirroring how
+   `CalculationAnnotationValidator` already resolves `@ref.<name>.<field>` tokens against
+   `x-openregister-references`, `CalculationAnnotationValidator.php:146-153`), the field is treated
+   as valid rather than rejected outright.
+
+This keeps the validator's job (catch a genuinely unknown field, e.g. a typo) while no longer
+rejecting a field that legitimately lives on a related schema. Task 1 requires reproducing Meeting's
+actual aggregation spec shape as a fixture first — the exact DSL variant Meeting uses (does it use
+`from`, or reference a relation field directly?) determines whether the fix is "recognise more shapes
+as cross-schema" or "extend the cross-schema resolution to actually load the target schema and check
+against it" (the literal framing in the diagnosis). Both converge on the same externally observable
+behavior (spec.md is written at that level); the task list below front-loads the reproduction step so
+the implementation targets the actual defect, not a fixture I authored from the diagnosis note alone.
+
+### Fix 2 — operator aliases (consistency with the existing alias idiom)
+
+`AggregationAnnotationValidator` already aliases `metric`/`select` and `filter`/`where`
+(`AggregationAnnotationValidator.php:130`, `:169`) — accepting a more natural-language key alongside
+the terse one is an established idiom in this file family, not a new pattern. `mul`/`add`/`sub`/`div`
+become aliases resolved to `*`/`+`/`-`/`/` at both validation time (`VALID_OPS` membership) and
+evaluation time (`CalculationEvaluator`'s operator dispatch) — both sides MUST agree, or a
+calculation could validate under the alias and then fail evaluation, reproducing the same
+validate-vs-runtime mismatch this whole change exists to close.
+
+### Fix 3 — calculation-output materialisability (fail validation, don't silently drop)
+
+Two candidate fixes were considered:
+
+- **(a) Reject at validation time**: `CalculationAnnotationValidator` adds a check that every
+  calculation name in `calcNames` is also present in `propKeys`, emitting a new
+  `calculation-output-not-in-properties` error when it isn't.
+- **(b) Auto-add the property**: the schema-save path silently synthesises a matching property
+  (typed from the calculation's `type`) for every calculation name not already declared.
+
+**Chosen: (a), reject at validation time.** (b) would silently mutate the schema's `properties` list
+the author didn't write, which is its own kind of invisible behavior — the exact failure mode this
+change is repairing elsewhere. Rejecting with a clear, specific error message ("calculation `total`'s
+output property is not declared — add `total` to `properties` with type `number`") is symptomatic of
+the loud-discard philosophy (Fix 4) applied one level earlier: catch the author's mistake at
+save-time with an actionable message, rather than validating successfully and discarding silently at
+persist-time three layers away in `MagicMapper`.
+
+### Fix 4 — loud discard (cross-cutting)
+
+The `SchemaMapper::validate*Annotation()` family (`SchemaMapper.php:1044-1249`) is a single shared
+shape repeated seven times (`lifecycle`, `aggregations`, `calculations`, `quality`, `dedup`,
+`survivorship`, `merge`): validate, and on error, `logger->warning()` + continue. This change does
+not remove the "continue" half — an advisory annotation genuinely should not abort a schema import,
+and that design choice predates this change and is out of scope to reverse. What it fixes is the
+**surfacing** half: the schema-save response (whatever entry point calls
+`SchemaMapper::save()`/`update()` — the REST schema controller, the config-import pipeline) must
+collect the accumulated validator errors across all seven families for the schema being saved and
+return them as a structured `warnings` array on the response, keyed by annotation family and schema
+slug.
+
+This is deliberately additive and non-breaking: a caller that ignores the new `warnings` field sees
+identical behavior to today (schema still imports, computed features still don't run when
+misdeclared). A caller that reads it — a schema-authoring UI, an `occ` command's output, an import
+script checking its own result — gets the signal that was previously log-only. The `confidentiality-
+classification-primitive` change (same wave) explicitly depends on this warnings surface for its own
+loud-discard requirement, rather than inventing a second one — see that change's design.md Open
+Questions.
+
+### Adjacent repair A — seed `$ref` resolution
+
+`ImportHandler::importSeedDataObjects()` deliberately bypasses `ObjectService`/`SaveObject`
+("Use MagicMapper directly for seedData objects to avoid complex ObjectService dependencies... don't
+require cascading or complex validation", `ImportHandler.php:5095-5096`) and writes
+`$objectData` verbatim via `$objectEntity->setObject($objectData)` (`ImportHandler.php:5114`). The
+fix adds a narrow, seed-import-scoped `$ref` resolution pass — walk the target schema's declared
+`$ref` properties (scalar and array-of-`$ref`), and for each one whose value is a slug rather than a
+UUID, resolve it against the schemas/objects already imported in this run (mirroring the existing
+`schemasMap`/`registersMap` slug-keyed lookup pattern already used elsewhere in this method) before
+constructing the `ObjectEntity`. This deliberately stays narrower than routing seed import through
+the full `ObjectService` write path (which the method's own comment says was avoided for good
+reason — complexity and dependency surface) — it borrows only the resolution step, not the full
+validation/cascade pipeline.
+
+### Adjacent repair B — nested `$ref` in array-of-objects
+
+`ValidateObject.php`'s array-items handling (`lines 547-591`) already recurses into
+`transformObjectPropertyForOpenRegister()` for an item schema of `type: object`
+(line 588-589). The reported failure (`candidates[].person` → `"Unresolved reference:
+schema:///Person#"`) means that recursive call is not stripping the nested `person` property's own
+`$ref` before Opis JSON Schema validates it — either the recursion doesn't reach nested properties at
+all, or it reaches them but the per-property `$ref`-stripping branch (`lines 598-608`, scalar
+`$ref`-on-`string`-type) isn't triggered from within the nested call for some structural reason (e.g.
+the nested property's schema arrives as a plain array rather than the `stdClass` the top-level walk
+normalises, mirroring the exact `items`-object-cast issue already fixed once for array items at
+`lines 551-558`). Task 2 requires reproducing the exact failing shape as a fixture first, for the
+same reason as Fix 1: the diagnosis names the symptom precisely but not the exact code path, and
+guessing the wrong mechanism risks a fix that passes a narrower fixture than the real bug.
+
+## Risks / Trade-offs
+
+- **[Fix 1's "which shapes count as cross-schema" heuristic could over- or under-match]** →
+  Mitigation: reproduce Meeting's actual spec as the first task (below), so the implementation is
+  driven by a real fixture rather than a guess; spec.md's scenarios are written at the observable-
+  behavior level so the exact heuristic can be adjusted without a spec change.
+- **[Operator aliases could mask a genuine typo]** (e.g. `mult` half-matching `mul`) → Mitigation:
+  aliases are an exact-match allowlist addition (`mul`/`add`/`sub`/`div`), not a fuzzy match; an
+  unrecognised operator still fails validation exactly as today.
+- **[Fix 3 is stricter than today]** — a calculation whose name isn't a declared property currently
+  validates "successfully" (and silently loses its output); after this change it fails validation.
+  This is an intentional behavior change for a schema that was never actually working. Flagged
+  explicitly here because a strict reading of "no breaking change" could miss it: no *currently
+  functional* schema is affected, but a schema that appeared to validate while being silently
+  non-functional will now show a validation error on next save.
+- **[Fix 4 changes response shape]** → Mitigation: purely additive (`warnings` field, new and
+  optional); no existing response field is renamed or removed.
+- **[Seed $ref resolution (Adjacent A) could resolve to the wrong object on a slug collision]** →
+  Mitigation: resolution is scoped to schemas/objects imported in the same run first (the existing
+  `schemasMap`/`registersMap` pattern), falling back to a database lookup only when not found in-run,
+  matching the existing schema-slug resolution precedent a few lines above in the same method
+  (`ImportHandler.php:4812-4851`).
+
+## Migration Plan
+
+No database migration. No new OR schema. Existing schemas with a currently-valid
+aggregations/calculations annotation are unaffected by Fixes 1-3 (they already validate; the fixes
+only change outcomes for specs that currently fail validation). A schema whose calculation output
+was silently dropped (Fix 3's new rejection) requires an author action — add the missing property —
+on next save; this is a deliberate, visible failure replacing a silent one, not a regression.
+Rollback for each fix is independent (they touch different methods); Fix 4's `warnings` field can be
+dropped without affecting Fixes 1-3's validation behavior.
+
+## Open Questions
+
+- Fix 1's exact resolution mechanism (recognise more shapes as `from`-equivalent vs. actually
+  resolving and loading the target schema at validation time) is deferred to task 1's reproduction
+  step — see tasks.md.
+- Adjacent repair B's exact failing code path (recursion not reached vs. object-cast gap) is
+  similarly deferred to task 2's reproduction step.
+- Whether `occ openregister:rematerialise-calculations` should gain a `--reason` flag noting "this
+  object's calculation was previously silently dropped" for operator visibility during the fleet-wide
+  rollout of Fix 3 — deferred as a nice-to-have, not blocking.

--- a/openspec/changes/aggregation-dialect-repair/proposal.md
+++ b/openspec/changes/aggregation-dialect-repair/proposal.md
@@ -1,0 +1,141 @@
+---
+kind: code
+---
+
+## Why
+
+Declaring `x-openregister-aggregations`/`x-openregister-calculations` on a schema silently produces
+no computed fields on the current build. This was diagnosed live (2026-08-19, decidesk
+organisation-goals apply): **even Meeting's own `quorumPercentage`/`actionItemCount`
+aggregations — the pattern every design doc cites as "already proven in production" — fail
+identically**, with the only tell being a `nextcloud.log` warning line (`grep "annotation on schema"`)
+that never reaches the schema author. A cited-as-proven declarative pattern can be dead
+platform-wide with zero PHPUnit test failing, because the discard path is a log line, not a
+save-time rejection or an API-visible warning.
+
+Root-caused to three defects, all in `openregister/`:
+
+1. **`AggregationAnnotationValidator` validates a filter/groupBy field against the wrong schema's
+   `properties`.** `lib/Service/Aggregation/AggregationAnnotationValidator.php:91-95` builds its
+   allow-list (`$propKeys`) exclusively from the schema shape `SchemaMapper::validateAggregationsAnnotation()`
+   passes in — the **declaring** schema's own `properties`
+   (`lib/Db/SchemaMapper.php:1044-1056`). The validator's only escape hatch from that allow-list is a
+   top-level `from` key on the aggregation spec (lines 116-123, delegating to
+   `validateCrossSchemaSpec()` at lines 221-259, which correctly skips field-existence checks
+   because — per its own docblock, lines 42-48 — "the target schema is not available at
+   annotation-save time"). Any aggregation whose `filter`/`groupBy` addresses a field that lives on
+   a *related* schema (a relation/aggregate-reference target) without using that exact `from`-keyed
+   cross-schema DSL — which is how Meeting's own `quorumPercentage`/`actionItemCount` are
+   authored — is validated against the declaring schema's own property list and rejected as
+   `aggregation-filter-field-unknown` / `aggregation-groupby-field-unknown`
+   (lines 156-165, 176-187, 190-206). The whole annotation is then discarded.
+2. **`CalculationAnnotationValidator` rejects the `mul` operator.** The v1 operator vocabulary at
+   `lib/Service/Calculation/CalculationAnnotationValidator.php:60-93` lists the arithmetic symbol
+   `*` but not the natural-language alias `mul` (nor `add`/`sub`/`div` for `+`/`-`/`/`). A
+   calculation authored with `{"mul": [...]}`  — the form decidesk's design docs use — fails
+   `calculation-bad-operator` (message built at line ~273) and discards the whole
+   `x-openregister-calculations` block, exactly like defect 1.
+3. **`MagicMapper` silently discards a calculation's output when its name isn't also a schema
+   property.** `CalculationAnnotationValidator::validate()` (lines 137-144) computes `propKeys` and
+   `calcNames` separately and only merges them to make cross-calc `prop` references resolvable — it
+   never requires a calculation's own name to be a declared property. At persist time,
+   `MagicMapper::reportDroppedProperties()` (`lib/Db/MagicMapper.php:3855-3905`) treats any payload
+   key absent from `properties` as unknown and drops it (now logged, per the earlier
+   `or-silent-field-loss` change, but still dropped: "They are NOT stored anywhere" —
+   `MagicMapper.php:3891`). A calculation whose output name was never mirrored into `properties`
+   evaporates on every save even when the calculation itself evaluates successfully.
+
+None of these three failures abort the schema save — `SchemaMapper::validate*Annotation()`
+(`lib/Db/SchemaMapper.php:1044-1109`) treats aggregations/calculations as "ADVISORY metadata" and
+degrades every validator error to a `logger->warning()` call, importing the schema anyway. That
+degrade-and-continue design is reasonable for a genuinely optional feature — it is not reasonable
+when the practical effect, for two of the three defects above, is "the annotation you just declared
+does nothing, and the only way to find out is grepping `nextcloud.log` after the fact."
+
+## What Changes
+
+- **Fix 1 — cross-schema field resolution**: `AggregationAnnotationValidator` MUST validate a
+  filter/groupBy field against the schema that actually owns it — the target schema when the spec
+  is (or should be recognised as) cross-schema, the declaring schema otherwise — instead of always
+  falling back to the declaring schema's `properties`.
+- **Fix 2 — `mul`/`add`/`sub`/`div` operator aliases**: `CalculationAnnotationValidator`'s (and the
+  paired `CalculationEvaluator`'s) operator vocabulary MUST accept `mul`, `add`, `sub`, `div` as
+  aliases for `*`, `+`, `-`, `/` respectively — matching the existing alias idiom already used
+  elsewhere in the same file family (`AggregationAnnotationValidator` already aliases
+  `metric`/`select` and `filter`/`where`).
+- **Fix 3 — calculation-output materialisability**: `CalculationAnnotationValidator` MUST reject (or
+  the schema-save path MUST otherwise refuse) a calculation whose declared name is not also present
+  in the schema's `properties`, so a calculation that passes validation is guaranteed storable by
+  `MagicMapper` — closing the gap between "annotation is valid" and "output is persisted."
+- **Fix 4 (new, cross-cutting) — loud discard**: the `SchemaMapper::validate*Annotation()` degrade-
+  to-`warning`-and-continue pattern (covering `lifecycle`, `aggregations`, `calculations`, `quality`,
+  `dedup`, `survivorship`, `merge` — seven annotation families sharing one discard shape) MUST stop
+  being invisible outside `nextcloud.log`. A discarded declaration MUST surface in the schema-save
+  API response itself (a structured warnings list), so "the save succeeded" and "your annotation was
+  silently ignored" are never conflated in the caller's own view of the result.
+- **Adjacent repair A — seed importer resolves `$ref` to UUID, not raw slug**: `ImportHandler::importSeedDataObjects()`
+  writes seed object payloads verbatim via `MagicMapper`/`objectEntityMapper->insert()`
+  (`lib/Service/Configuration/ImportHandler.php:5095-5126`), bypassing the `$ref`-resolution step the
+  normal `ObjectService`/`SaveObject` write path performs — by design, per the method's own comment
+  ("Use MagicMapper directly for seedData objects to avoid complex ObjectService dependencies").
+  The effect: a seed object's `$ref`-typed property (e.g. `amends: "motie-duurzaamheid-2025"`) is
+  stored as the raw slug string it was authored with, not the resolved target UUID, register-wide.
+  Any consumer expecting a UUID (relation expansion, UI reference pickers) sees a raw slug for
+  seeded data.
+- **Adjacent repair B — nested `$ref` inside array-of-objects on direct writes**: a schema property
+  shaped as an array of objects, where a nested property of each item is itself a `$ref` (e.g.
+  `candidates[].person`), fails direct object writes with `"Unresolved reference:
+  schema:///Person#"` even when the nested value is a valid UUID — observed live, inherited
+  unchanged from an existing schema pattern (Voordracht.kandidaten), not a new regression.
+  `lib/Service/Object/ValidateObject.php`'s `$ref`-stripping logic (`dropUnusableRef()` /
+  `transformObjectPropertyForOpenRegister()`, the array-items handling around lines 547-591) already
+  strips a `$ref` on an array item that is itself a `$ref` string (line 574-587) and on a top-level
+  object property (line 594-596); this repair confirms and closes the gap for a nested property
+  *inside* an array item's object schema, which appears not to receive the same recursive
+  transformation before Opis JSON Schema validates it.
+- **Task-only — orphaned `ori_register.json`**: `lib/Settings/ori_register.json` (the ORI mock
+  register, `openspec/specs/mock-registers/`) becomes retirement-eligible once decidesk's ORI
+  adoption (via the leaf-app openconnector integration path, decidesk Back to Six programme)
+  completes. Not retired by this change — procest still declares the same six ORI slugs in its own
+  operational register — but tracked as a follow-up task so it is not forgotten once decidesk no
+  longer needs the mock.
+
+## Capabilities
+
+### New Capabilities
+- `nested-reference-validation`: a schema property shaped as an array of objects whose nested
+  property is itself a `$ref` MUST validate a valid UUID successfully on direct object writes,
+  matching the existing support for a top-level `$ref` property and for an array item that is
+  itself a `$ref`.
+- `annotation-validation-surfacing`: a schema-save response MUST include a structured warnings list
+  naming every `x-openregister-*` advisory annotation that failed validation and was discarded, so
+  discard is visible in the API response, not only in `nextcloud.log`.
+
+### Modified Capabilities
+- `aggregation-api`: the named-annotation surface (`x-openregister-aggregations`) MUST validate a
+  filter/groupBy field against the schema that owns it, not unconditionally against the declaring
+  schema.
+- `computed-fields`: the JSON-AST calculation operator vocabulary gains `mul`/`add`/`sub`/`div`
+  aliases; a calculation's declared name MUST also be a declared schema property for the annotation
+  to validate.
+- `import-resilient-per-entity-and-no-user-context`: seed-data object import MUST resolve `$ref`
+  property values to their target UUID rather than persisting the raw seed-authored slug.
+
+## Impact
+
+- **Changed code**: `AggregationAnnotationValidator`, `CalculationAnnotationValidator`,
+  `CalculationEvaluator` (operator dispatch), `SchemaMapper::validate*Annotation()` family (warnings
+  surfacing), `ImportHandler::importSeedDataObjects()` ($ref resolution), `ValidateObject.php`
+  (nested array-of-objects `$ref` stripping).
+- **No new OR schema.** No database migration. No breaking change to a schema that already validates
+  cleanly today — every fix widens acceptance (aliases, correct target-schema resolution) or adds a
+  new rejection only for a shape that was already silently non-functional (calc name not in
+  properties).
+- **Consumers**: decidesk's Meeting quorum/actionItem aggregations, and any other app that declared
+  `x-openregister-aggregations`/`-calculations` and silently got nothing, become functional once
+  this ships — a re-import (or a schema re-save) is required to pick up the corrected validation;
+  this change does not retroactively re-materialise already-discarded annotations on existing
+  schemas (that is an operator action, `occ openregister:rematerialise-calculations` per the existing
+  `computed-fields` capability, once the schema itself is re-saved with a now-valid annotation).
+- **Downstream**: decidesk's Back to Six programme depends on this landing before Meeting's
+  organisation-goal aggregations can be verified live.

--- a/openspec/changes/aggregation-dialect-repair/specs/aggregation-api/spec.md
+++ b/openspec/changes/aggregation-dialect-repair/specs/aggregation-api/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: The named-annotation aggregation surface MUST validate filter/groupBy fields against the schema that owns them
+`AggregationAnnotationValidator::validate()` MUST resolve a `filter`/`where`/`groupBy.field`
+reference against the schema that actually declares that field — the target schema when the
+aggregation addresses a related schema (whether via an explicit `from` key or via a field reached
+through the declaring schema's own relation/reference declarations), and the declaring schema's own
+`properties` otherwise. A field that lives on a related schema MUST NOT be rejected as unknown
+merely because it is absent from the declaring schema's own `properties`.
+
+#### Scenario: A filter field on a related schema is accepted
+- **GIVEN** schema `meeting` declares an aggregation referencing a filter field that lives on a
+  schema `meeting` has a relation to (not a property of `meeting` itself)
+- **WHEN** the schema is saved
+- **THEN** the aggregation MUST be accepted with no `aggregation-filter-field-unknown` error
+
+#### Scenario: A genuinely unknown field is still rejected
+- **GIVEN** schema `meeting` declares an aggregation whose filter references a field that is neither
+  a property of `meeting` nor of any schema `meeting` relates to (a typo)
+- **WHEN** the schema is saved
+- **THEN** the aggregation MUST be rejected with an `aggregation-filter-field-unknown` error
+
+#### Scenario: An explicit cross-schema `from` spec continues to validate as before
+- **GIVEN** an aggregation spec carrying a top-level `from` key naming a foreign schema slug
+- **WHEN** the schema is saved
+- **THEN** field-existence checks MUST continue to be skipped for that spec's filter/groupBy fields,
+  unchanged from current behavior
+
+#### Scenario: A previously-silently-discarded aggregation now runs
+- **GIVEN** schema `meeting` declares `quorumPercentage`/`actionItemCount` aggregations referencing
+  fields on a related schema, previously discarded with an `annotation on schema "meeting" is
+  invalid` warning
+- **WHEN** the schema is saved after this fix
+- **THEN** the aggregation MUST validate successfully and MUST be resolvable via
+  `/api/objects/aggregations/{register}/meeting/{name}`

--- a/openspec/changes/aggregation-dialect-repair/specs/annotation-validation-surfacing/spec.md
+++ b/openspec/changes/aggregation-dialect-repair/specs/annotation-validation-surfacing/spec.md
@@ -1,0 +1,41 @@
+## Purpose
+
+Makes a discarded `x-openregister-*` advisory-annotation declaration visible in the schema-save API
+response, so a schema author cannot mistake "the save succeeded" for "the annotated feature works" —
+closing a discard path that previously surfaced only as a `nextcloud.log` warning line.
+
+## ADDED Requirements
+
+### Requirement: A schema-save response MUST surface every discarded advisory-annotation validation error
+When any of the schema-save annotation validators (`lifecycle`, `aggregations`, `calculations`,
+`quality`, `dedup`, `survivorship`, `merge`) returns one or more validation errors for a schema being
+saved, the schema-save response MUST include a `warnings` list entry for each discarded annotation,
+naming the annotation family, the schema slug, and the validator's error messages. The schema import
+MUST continue exactly as it does today (an advisory annotation failing validation MUST NOT abort the
+save) — this requirement changes only what is surfaced in the response, not whether the save
+succeeds.
+
+#### Scenario: A discarded aggregations annotation appears in the save response warnings
+- **GIVEN** a schema is saved with an `x-openregister-aggregations` block that fails validation
+- **WHEN** the save completes
+- **THEN** the response MUST include a `warnings` entry with `family: "aggregations"`, the schema
+  slug, and the validator's error message(s)
+- **AND** the schema MUST still be saved (the save MUST NOT fail)
+
+#### Scenario: A schema with no annotation problems has an empty warnings list
+- **GIVEN** a schema is saved with valid (or absent) `x-openregister-*` annotations
+- **WHEN** the save completes
+- **THEN** the response's `warnings` list MUST be empty
+
+#### Scenario: Multiple discarded annotation families are each reported
+- **GIVEN** a schema's save has both an invalid `x-openregister-calculations` block and an invalid
+  `x-openregister-quality` block
+- **WHEN** the save completes
+- **THEN** the response MUST include two separate `warnings` entries, one per family, each with its
+  own error messages
+
+#### Scenario: A discarded annotation is still logged, unchanged
+- **GIVEN** a schema save triggers a discarded annotation
+- **WHEN** the save completes
+- **THEN** a `nextcloud.log` warning MUST still be recorded naming the schema and annotation family,
+  in addition to (not instead of) the response `warnings` entry

--- a/openspec/changes/aggregation-dialect-repair/specs/computed-fields/spec.md
+++ b/openspec/changes/aggregation-dialect-repair/specs/computed-fields/spec.md
@@ -1,0 +1,100 @@
+## MODIFIED Requirements
+
+### Requirement: JSON-AST calculation expressions MUST be evaluated by a pure-function evaluator
+
+OpenRegister MUST provide a second derivation engine, distinct from the Twig-based
+`ComputedFieldHandler`, that evaluates calculations expressed as a single-key JSON
+expression AST. `CalculationEvaluator::evaluate(array $object, mixed $expression)`
+MUST accept either a bare scalar literal (resolved through the shared
+`PlaceholderResolver`) or a single-key array of the form `{ "<op>": <args> }`, and MUST
+dispatch on the operator key. The recognised v1 vocabulary is: `prop`, `lit`, `concat`,
+`if`, `not`, `and`, `or`, the arithmetic operators `+ - * / %`, the natural-language
+arithmetic aliases `add` (alias of `+`), `sub` (alias of `-`), `mul` (alias of `*`), `div`
+(alias of `/`), the comparison operators `eq ne lt lte gt gte`, and the date operators
+`now`, `diffDays`, `formatDate`, `dateDiff`. An alias MUST be accepted identically to its
+symbol form at both validation time and evaluation time — the two MUST NOT disagree on
+which operator names are valid. The evaluator MUST be side-effect-free: no I/O, no
+database access. Any malformed expression, unknown operator, non-numeric arithmetic
+operand, zero divisor, or unknown `dateDiff` unit MUST raise an `EvaluationException`
+rather than returning a silent default.
+
+#### Scenario: Single-key dispatch on a known operator
+- **GIVEN** the expression `{ "+": [{ "prop": "aantal" }, 1] }` and an object `{ "aantal": 4 }`
+- **WHEN** `evaluate()` is called
+- **THEN** the result MUST be `5`
+
+#### Scenario: The mul alias dispatches identically to the * operator
+- **GIVEN** the expression `{ "mul": [{ "prop": "aantal" }, 3] }` and an object `{ "aantal": 4 }`
+- **WHEN** `evaluate()` is called
+- **THEN** the result MUST be `12`, identical to `{ "*": [{ "prop": "aantal" }, 3] }`
+
+#### Scenario: add/sub/div aliases dispatch identically to their symbol forms
+- **GIVEN** the expressions `{ "add": [2, 3] }`, `{ "sub": [5, 2] }`, `{ "div": [10, 2] }`
+- **WHEN** each is evaluated
+- **THEN** the results MUST be `5`, `3`, `5` respectively, identical to `+`/`-`/`/`
+
+#### Scenario: Bare scalar resolves through the placeholder resolver
+- **GIVEN** the expression is the string `"$now"` (a placeholder, not an array)
+- **WHEN** `evaluate()` is called
+- **THEN** the value MUST be resolved by the shared `PlaceholderResolver` and returned as-is for non-placeholder scalars
+
+#### Scenario: Dotted-path and @self property resolution
+- **GIVEN** an object whose `@self` metadata was injected by the on-save listener
+- **WHEN** the expression `{ "prop": "@self.created" }` is evaluated
+- **THEN** the value at the dotted path MUST be returned
+- **AND** a path that does not exist MUST resolve to null rather than raising
+
+#### Scenario: Expression with more than one top-level key is rejected
+- **GIVEN** the expression `{ "+": [1, 2], "-": [3] }` (two keys)
+- **WHEN** `evaluate()` is called
+- **THEN** an `EvaluationException` MUST be raised stating the expression must be a single-key object
+
+#### Scenario: Arithmetic guards reject non-numeric and zero-divisor operands
+- **GIVEN** the expression `{ "/": [{ "prop": "a" }, { "prop": "b" }] }`
+- **WHEN** `b` resolves to `0`
+- **THEN** an `EvaluationException` MUST be raised requiring non-zero numeric operands
+- **AND** when any operand of `+ - * %` (or their aliases) is non-numeric an `EvaluationException` MUST be raised
+
+#### Scenario: Comparison normalises ISO-date operands before ordering
+- **GIVEN** the expression `{ "lt": [{ "prop": "start" }, { "prop": "end" }] }` with ISO-8601 date strings
+- **WHEN** `evaluate()` is called
+- **THEN** both operands MUST be coerced to integer timestamps before the `<` comparison
+- **AND** an ordering comparison against a null operand MUST yield false
+
+#### Scenario: dateDiff computes a signed integer difference in the requested unit
+- **GIVEN** the expression `{ "dateDiff": { "from": "now", "to": { "prop": "@self.dueDate" }, "unit": "days" } }`
+- **WHEN** `to` is after `from`
+- **THEN** the result MUST be a positive integer day count
+- **AND** when `to` is before `from` the result MUST be negative
+- **AND** an unsupported `unit` MUST raise an `EvaluationException`
+- **AND** an unparseable `from` or `to` MUST yield null
+
+## ADDED Requirements
+
+### Requirement: A materialised calculation's declared name MUST also be a declared schema property
+`CalculationAnnotationValidator::validate()` MUST reject a calculation whose declared name is not
+also present in the schema's `properties`, with a `calculation-output-not-in-properties` error
+naming the calculation and stating that a matching property must be added. This closes the gap
+between "the annotation validates" and "the computed value is actually persisted": `MagicMapper`
+only writes payload keys present in `properties`, so a calculation output whose name was never
+mirrored into `properties` evaluates correctly but is silently dropped at save time with no
+indication in the validation result.
+
+#### Scenario: A calculation whose name has no matching property is rejected
+- **GIVEN** a schema declares `x-openregister-calculations: { "total": { "type": "number",
+  "expression": {...} } }` and `properties` does NOT contain a `total` key
+- **WHEN** the schema is saved
+- **THEN** validation MUST fail with a `calculation-output-not-in-properties` error naming `total`
+
+#### Scenario: A calculation whose name matches a declared property validates
+- **GIVEN** the same calculation as above, and `properties` DOES contain a `total` key (type
+  `number`, matching the calculation's declared `type`)
+- **WHEN** the schema is saved
+- **THEN** validation MUST succeed and the calculated value MUST be persisted on save
+
+#### Scenario: A previously-silently-dropped calculation output is now caught at save time
+- **GIVEN** a schema whose calculation `total` was previously validating successfully while its
+  output was silently dropped by `MagicMapper` (no matching property)
+- **WHEN** the schema is re-saved after this fix
+- **THEN** the save MUST surface the `calculation-output-not-in-properties` error instead of
+  succeeding silently, so the author is prompted to add the missing property

--- a/openspec/changes/aggregation-dialect-repair/specs/import-resilient-per-entity-and-no-user-context/spec.md
+++ b/openspec/changes/aggregation-dialect-repair/specs/import-resilient-per-entity-and-no-user-context/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Seed-data `$ref` properties MUST resolve to the target UUID, not the raw seed slug
+`ImportHandler::importSeedDataObjects()` MUST resolve a seed object's `$ref`-typed property value
+(scalar or array-of-`$ref`) to the target object's UUID before persisting the seed object, when the
+authored value is a slug rather than an already-resolved UUID. Resolution MUST first check the
+schemas/objects already imported in the current run (the same slug-keyed maps used elsewhere in
+`importFromJson()`), falling back to a database lookup scoped to the target schema when not found
+in-run. A `$ref` value that cannot be resolved MUST be left as-authored and MUST log a warning
+naming the property and the unresolved slug — it MUST NOT abort the seed object's import (per-entity
+resilience, unchanged).
+
+#### Scenario: A seed object's $ref slug resolves to a UUID
+- **GIVEN** seed data for schema `motie` includes an object with property `amends: "motie-duurzaamheid-2025"`
+  (a slug, not a UUID), and a seed object with that slug was already imported earlier in the same run
+- **WHEN** the referencing seed object is imported
+- **THEN** the persisted `amends` value MUST be the earlier-imported object's UUID, not the raw slug
+
+#### Scenario: An unresolvable $ref slug is left as-authored with a warning
+- **GIVEN** a seed object's `$ref` property names a slug that does not resolve to any object imported
+  in this run or found in the database
+- **WHEN** the seed object is imported
+- **THEN** the import MUST continue with the raw slug value persisted as-authored
+- **AND** a warning MUST be logged naming the property and the unresolved slug
+
+#### Scenario: An already-resolved UUID value is left unchanged
+- **GIVEN** a seed object's `$ref` property value is already a valid UUID (not a slug)
+- **WHEN** the seed object is imported
+- **THEN** the value MUST be persisted unchanged, with no resolution lookup performed

--- a/openspec/changes/aggregation-dialect-repair/specs/nested-reference-validation/spec.md
+++ b/openspec/changes/aggregation-dialect-repair/specs/nested-reference-validation/spec.md
@@ -1,0 +1,36 @@
+## Purpose
+
+Ensures a `$ref` reference nested inside an array-of-objects property validates a valid UUID on
+direct object writes, closing a gap between the existing support for top-level `$ref` properties and
+array items that are themselves `$ref` strings.
+
+## ADDED Requirements
+
+### Requirement: A nested `$ref` property inside an array-of-objects item MUST validate a valid UUID
+When a schema property is an array whose items are objects, and one of those item objects' own
+properties is declared with `$ref` (referencing another schema), a direct object write supplying a
+valid UUID for that nested property MUST validate successfully. This MUST hold identically to how a
+top-level scalar `$ref` property and an array item that is itself a `$ref` string already validate.
+
+#### Scenario: A valid UUID in a nested array-of-objects $ref property is accepted
+- **GIVEN** a schema `voordracht` with property `candidates` (array of objects), where each item
+  object has a property `person` declared `{"type": "string", "$ref": "person-schema-slug",
+  "format": "uuid"}`
+- **AND** a `person` object with a valid UUID exists
+- **WHEN** an object is directly written with `candidates: [{"person": "<valid-person-uuid>", ...}]`
+- **THEN** the write MUST succeed
+- **AND** MUST NOT raise `"Unresolved reference: schema:///Person#"`
+
+#### Scenario: The same nested shape continues to work for a second-level array (regression guard)
+- **GIVEN** the same schema `voordracht`, with `candidates` containing two items each with a
+  `person` UUID
+- **WHEN** the object is written
+- **THEN** both nested `person` references MUST validate independently
+- **AND** an invalid (non-UUID, non-existent) value on either MUST be rejected without affecting
+  validation of the other
+
+#### Scenario: Existing single-level $ref support is unaffected
+- **GIVEN** a schema with a top-level scalar `$ref` property, and a separate schema with an array
+  property whose items are themselves `$ref` strings (not objects)
+- **WHEN** either is validated
+- **THEN** both MUST continue to validate exactly as before this change

--- a/openspec/changes/aggregation-dialect-repair/tasks.md
+++ b/openspec/changes/aggregation-dialect-repair/tasks.md
@@ -1,0 +1,81 @@
+# Tasks — aggregation-dialect-repair (kind: code)
+
+Repairs three defects that silently discard `x-openregister-aggregations`/`-calculations`
+annotations (diagnosed live 2026-08-19 — even Meeting's own quorum/actionItem aggregations fail),
+adds a fourth cross-cutting loud-discard fix, folds in two adjacent silent-failure repairs (seed
+`$ref` slugs, nested `$ref` in array-of-objects), and tracks the orphaned ORI mock register.
+
+## 1. Reproduce before fixing (aggregation cross-schema)
+
+- [ ] 1.1 Reproduce Meeting's actual `quorumPercentage`/`actionItemCount` aggregation spec as a PHPUnit fixture against the current `AggregationAnnotationValidator`, confirming the exact `aggregation-filter-field-unknown`/`aggregation-groupby-field-unknown` failure and which DSL shape (explicit `from` vs. an implicit relation-field reference) triggers it.
+
+## 2. Fix 1 — cross-schema field resolution
+
+- [ ] 2.1 Extend `AggregationAnnotationValidator` field resolution so a filter/groupBy field addressing a related schema (via `from` or via the declaring schema's own relation/reference declarations) validates against the field's owning schema, not unconditionally against the declaring schema's `properties`.
+- [ ] 2.2 Ensure a field that is genuinely unknown on both the declaring schema and any related schema still produces `aggregation-filter-field-unknown`/`aggregation-groupby-field-unknown`.
+
+## 3. Fix 2 — operator aliases
+
+- [ ] 3.1 Add `mul`/`add`/`sub`/`div` to `CalculationAnnotationValidator::VALID_OPS` as aliases of `*`/`+`/`-`/`/`.
+- [ ] 3.2 Add matching dispatch in `CalculationEvaluator` so the aliases evaluate identically to their symbol forms — validation and evaluation MUST agree on the vocabulary.
+
+## 4. Fix 3 — calculation-output materialisability
+
+- [ ] 4.1 Add a `calculation-output-not-in-properties` check to `CalculationAnnotationValidator`: every calculation name in the annotation MUST also be a key in the schema's `properties`.
+- [ ] 4.2 Confirm `MagicMapper::reportDroppedProperties()` no longer needs to warn about a calculation output once the property is required — the property now exists, so the payload key is recognised.
+
+## 5. Fix 4 — loud discard (cross-cutting)
+
+- [ ] 5.1 Add a `warnings` collection point in the schema-save path that aggregates the validation errors from all seven `SchemaMapper::validate*Annotation()` families (`lifecycle`, `aggregations`, `calculations`, `quality`, `dedup`, `survivorship`, `merge`) for the schema being saved, without changing the existing warn-and-continue import behavior.
+- [ ] 5.2 Surface the aggregated `warnings` list on the schema-save API response (REST schema controller and the config-import pipeline's result structure), keyed by annotation family and schema slug.
+- [ ] 5.3 Keep the existing `nextcloud.log` warning emission unchanged (additive, not a replacement).
+
+## 6. Adjacent repair A — seed $ref resolution
+
+- [ ] 6.1 Add a `$ref`-value resolution pass in `ImportHandler::importSeedDataObjects()` that resolves a seed object's `$ref`-typed property (scalar or array-of-`$ref`) from a slug to the target UUID, checking the current run's slug-keyed maps first, then a scoped database lookup.
+- [ ] 6.2 Leave an unresolvable `$ref` slug as-authored with a logged warning naming the property and slug — do not abort the seed object's import (per-entity resilience unchanged).
+
+## 7. Adjacent repair B — nested $ref in array-of-objects
+
+- [ ] 7.1 Reproduce the `candidates[].person` → `"Unresolved reference: schema:///Person#"` failure as a PHPUnit fixture against `ValidateObject`, confirming whether the recursive `transformObjectPropertyForOpenRegister()` call for array-of-object items reaches nested `$ref` properties at all, or reaches them without the object-cast normalisation already applied to top-level `items`.
+- [ ] 7.2 Fix the identified gap so a nested `$ref` property inside an array-of-objects item is stripped/transformed the same way a top-level scalar `$ref` property already is, before Opis JSON Schema validation runs.
+
+## 8. Housekeeping — orphaned ORI mock register
+
+- [ ] 8.1 Add a tracking note (code comment in `lib/Settings/ori_register.json`'s `x-openregister` block, and/or a line in `mock-registers`' spec Purpose) flagging that the ORI mock register becomes retirement-eligible once decidesk's ORI adoption (via the openconnector leaf-app path) completes — do not remove it now (procest still depends on the same six slugs).
+
+## 9. Tests
+
+- [ ] 9.1 Add PHPUnit tests for Fixes 1-2 covering: a related-schema filter field is accepted, a genuinely unknown field is still rejected, an explicit `from` spec is unaffected, and `mul`/`add`/`sub`/`div` evaluate identically to `*`/`+`/`-`/`/` at both validation and evaluation.
+- [ ] 9.2 Add PHPUnit tests for Fixes 3-4 covering: a calculation name absent from `properties` is rejected and present-and-matching validates/persists; a discarded annotation appears in the save response `warnings` (and a clean schema's list is empty, multiple families each report separately, the log warning still fires).
+- [ ] 9.3 Add PHPUnit tests for Adjacent A-B covering: an in-run seed `$ref` slug resolves to a UUID and an unresolvable one is left as-authored with a warning; a valid nested array-of-objects `$ref` UUID validates and existing single-level `$ref` support is unaffected (regression guard).
+
+## 10. Verification
+
+- [ ] 10.1 Run `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) and the Hydra mechanical gates; fix any pre-existing issues touched.
+- [ ] 10.2 Run `openspec validate --change aggregation-dialect-repair --strict`; resolve any errors.
+
+## Acceptance Criteria
+
+- Meeting's own `quorumPercentage`/`actionItemCount` aggregations validate and resolve via the API
+  once re-saved.
+- A calculation authored with `mul`/`add`/`sub`/`div` validates and evaluates identically to its
+  symbol-form equivalent.
+- A calculation whose output name is not a declared property is rejected at save time with a clear,
+  actionable error — not silently dropped at persist time.
+- A schema-save response's `warnings` list names every discarded annotation family with its error
+  messages, without changing the underlying warn-and-continue import behavior.
+- A seed object's `$ref` property resolves to a UUID when the target was imported in the same run.
+- A nested `$ref` property inside an array-of-objects item validates a valid UUID on direct writes.
+- `ori_register.json` carries a tracking note; it is not removed by this change.
+
+## Quality Checklist
+
+- Every fix cites its exact file:line locus in proposal.md/design.md — no fix proceeds without a
+  reproducing fixture first (tasks 1.1, 7.1) per the "an expression of a pattern matches the pattern"
+  lesson: guessing the mechanism from a symptom risks fixing a narrower bug than the one reported.
+- Fix 4 (`annotation-validation-surfacing`) is additive only — no existing response field renamed or
+  removed, no change to whether an advisory annotation aborts a save.
+- SPDX + `@license`/`@copyright` docblock headers on every new/modified PHP file (EUPL-1.2).
+- No jurisdiction-specific behavior added — this is a platform-wide correctness repair, not a
+  decidesk-specific one, even though decidesk's live instance is where it was diagnosed.


### PR DESCRIPTION
Authored during the decidesk **Back to Six** programme (2026-08-19/20). Proposal only — no code changes.

**The finding:** `x-openregister-aggregations`/`-calculations` produce no computed fields on the current build. The annotation is dropped at register-load with only a `nextcloud.log` warning. Even Meeting's own quorum aggregations — the pattern app design docs cite as "already proven in production" — never run.

Three root causes, each cited to file:line in the proposal:
1. `AggregationAnnotationValidator` validates filter field names against the **declaring** schema instead of the **target** schema, discarding every cross-schema aggregation
2. `CalculationAnnotationValidator` does not recognise the `mul` operator
3. `MagicMapper` silently discards computed fields not also declared under `properties`

Plus a fourth item with the same shape: **a discarded declaration must not look like a working one** — the discard path should fail validation loudly rather than warn-and-continue.

Two adjacent repairs folded in, both hit repeatedly while building on this platform:
- the seed importer stores `$ref` values as raw **slugs** instead of resolved UUIDs (this silently empties any UUID-filtered widget — cost us two real bugs downstream)
- a nested `$ref` inside an array-of-objects fails direct writes with `Unresolved reference: schema:///Person#`

Where my own reading of the current code diverged from the original diagnosis, the proposal narrows the claim and adds **reproduce-before-fix** tasks rather than guessing the mechanism from the symptom.

Needs this repo's owners to review before implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)