### PR TITLE
docs(openspec): propose confidentiality-classification-primitive

### DIFF
--- a/openspec/changes/confidentiality-classification-primitive/.openspec.yaml
+++ b/openspec/changes/confidentiality-classification-primitive/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-19

--- a/openspec/changes/confidentiality-classification-primitive/design.md
+++ b/openspec/changes/confidentiality-classification-primitive/design.md
@@ -1,0 +1,244 @@
+## Context
+
+decidesk classifies confidentiality in five independent places (evidence gathered live,
+2026-08-19, decidesk Back to Six programme): `AgendaItem.confidentiality` (ad hoc enum),
+`Decision.isPublished` (boolean, no legal grounding), a hand-maintained public-publication
+deny-list, `commissievergaderingen`'s `besloten-onderdeel` flag, and the `Geheimhouding` register
+(grounds + `bekrachtiging`/`opheffing` per Gemeentewet art. 25/55/86). None of the five share a
+property name, an enforcement path, or a tier vocabulary. This is the same drift ADR-045/047 exist
+to prevent, one abstraction earlier: a data-classification capability every register touching
+sensitive data eventually needs, currently reinvented per app.
+
+OpenRegister already ships the two building blocks a classification primitive needs:
+
+- **`row-field-level-security`**: `MagicRbacHandler` (SQL) and `ConditionMatcher`/
+  `PermissionHandler` (PHP) already evaluate conditional per-object rules with MongoDB-style
+  operators, including `{"vertrouwelijkheid": {"$lte": N}}`-shaped comparisons, owner bypass, admin
+  bypass, and `public`/`authenticated` pseudo-groups (`openspec/specs/row-field-level-security/`).
+- **`deprecate-published-metadata`**: replaced the old `published`/`depublished` object columns
+  with a `$now` dynamic variable resolved identically by `MagicRbacHandler::resolveDynamicValue()`
+  (SQL datetime) and `ConditionMatcher::resolveDynamicValue()` (ISO 8601), so a rule like
+  `{"publicatieDatum": {"$lte": "$now"}}` is a working timed-release gate with zero new
+  infrastructure (`openspec/specs/deprecate-published-metadata/`).
+
+Neither building block is *wrong* for confidentiality — decidesk's `Geheimhouding` grounds and tier
+could, in principle, already be expressed as a hand-authored RLS rule plus a `$now` release
+condition. What is missing is the **standard shape**: a schema-declarative annotation that
+generates the rule from schema metadata (as `x-openregister-quality`/`-dedup`/`-survivorship`
+already do for scoring/dedup/golden-record), so every consuming app gets the same tier vocabulary
+convention, the same legal-ground field convention, and the same timed-release behavior for free,
+instead of hand-rolling match conditions per schema and drifting on property names.
+
+Stakeholders: the OR team (owns the annotation + validator + derived-rule contract), decidesk
+(first and motivating consumer — Gemeentewet workflow stays app-side, declares against this
+primitive), procest/zaakafhandelapp (plausible future consumers for zaaktype vertrouwelijkheid,
+not scoped here).
+
+## Goals / Non-Goals
+
+**Goals:**
+- A schema-declarative `x-openregister-confidentiality` annotation naming: an ordered tier
+  vocabulary, the property holding an object's tier, an optional property holding a legal-ground
+  reference, an optional property holding a release date/time, and a clearance map from tier to
+  required RBAC group.
+- Save-time shape validation (`ConfidentialityAnnotationValidator`), following the existing
+  `SchemaMapper::validate*Annotation()` warn-not-reject pattern for consistency with quality/dedup/
+  survivorship/lifecycle/aggregations/calculations/merge.
+- A derived read-enforcement rule, generated from the annotation and injected into the same
+  evaluation chain authored RLS rules already use, requiring tier clearance OR a met release
+  condition (via the existing `$now` mechanism).
+- Render-time exposure of the resolved classification under `@self.confidentiality` so consuming
+  apps and their UIs can display "why is this hidden / when does it open" without re-deriving the
+  rule.
+- A visible, non-silent failure path when the annotation is malformed (see "Loud discard" below) —
+  the aggregation-dialect-repair change (same wave) established that a warning that only reaches
+  `nextcloud.log` is not a sufficient signal for a schema author; this primitive should not repeat
+  that mistake on day one.
+
+**Non-Goals:**
+- The Gemeentewet workflow itself: grounds vocabulary, `bekrachtiging`/`opheffing` approval,
+  council-decision-triggered declassification. Stays in decidesk, declared against this primitive.
+- Any UI for authoring the annotation. Schemas remain JSON-edited, same as every other
+  `x-openregister-*` annotation today.
+- Migrating decidesk's five existing mechanisms onto the primitive. Tracked as decidesk-side
+  follow-up, not part of this OR change.
+- Changing `row-field-level-security`'s authored-rule contract, or `deprecate-published-metadata`'s
+  `$now` resolution contract. Both are consumed unchanged.
+- A generic "clearance level" system independent of confidentiality (e.g. arbitrary numeric ACL
+  tiers for non-confidentiality purposes) — scoped strictly to the classification-with-legal-ground-
+  and-timed-release shape decidesk's evidence describes.
+
+## Decisions
+
+### Reuse before build (ADR-011)
+
+Searched `lib/Service/`, `lib/Db/MagicMapper/`, `lib/Service/Aggregation/`,
+`openspec/specs/row-field-level-security/`, `openspec/specs/deprecate-published-metadata/` before
+proposing anything new:
+
+- **`MagicRbacHandler::resolveDynamicValue('$now')` / `ConditionMatcher::resolveDynamicValue('$now')`**
+  — reused verbatim for the timed-release condition. No second `$now`/embargo implementation.
+- **The conditional-rule shape `{"group": ..., "match": {...}}`** — the derived rule is expressed in
+  exactly this shape so it flows through `MagicRbacHandler::applyRbacFilters()` /
+  `PermissionHandler::hasPermission()` / `ConditionMatcher::objectMatchesConditions()` unchanged;
+  those three enforcement points are not modified, only given an additional rule source.
+  `MagicRbacHandler::propertyToColumnName()` (camelCase → snake_case) applies to the derived rule's
+  property references exactly as it does to authored ones.
+- **The `SchemaMapper::validate*Annotation()` / `logDroppedAnnotationKeys()` pattern** — the new
+  validator plugs into the same private-method family as `validateQualityAnnotation()` /
+  `validateDedupAnnotation()` / `validateSurvivorshipAnnotation()` (`lib/Db/SchemaMapper.php:1118-
+  1214`), not a bespoke validation path.
+- **`Schema::ANNOTATION_VOCABULARY`** — extended with the new key rather than left to fall through
+  `logDroppedAnnotationKeys()`'s "unknown key" warning.
+- **`@self.relations` / write-only mirror pattern** (`row-field-level-security` §"writeOnly stripping")
+  — the `@self.confidentiality` render mirror follows the same "materialise at the render choke
+  point, strip/compute unconditionally" precedent rather than inventing a new render hook.
+
+### Annotation shape
+
+```json
+"x-openregister-confidentiality": {
+  "tiers": ["public", "internal", "confidential", "secret"],
+  "tierProperty": "confidentialityTier",
+  "groundProperty": "confidentialityGround",
+  "releaseAtProperty": "confidentialityReleaseAt",
+  "clearance": {
+    "confidential": "raadsleden",
+    "secret": "college"
+  }
+}
+```
+
+- `tiers`: REQUIRED, non-empty, ordered least → most restrictive. The first tier is the implicit
+  default requiring no clearance (equivalent to `public`/`authenticated` pseudo-groups already in
+  RLS).
+- `tierProperty`: REQUIRED, MUST name a declared schema property whose value MUST be one of `tiers`.
+- `groundProperty`: OPTIONAL. When present MUST name a declared schema property. OR does not
+  interpret its value — free text, enum, or `$ref` to a grounds-vocabulary register are all valid;
+  this is deliberately where jurisdiction-specific wording (Gemeentewet, or any other statute) lives
+  as data, per ADR-047's "jurisdiction is data, not code."
+- `releaseAtProperty`: OPTIONAL. When present MUST name a declared schema property of `format:
+  date-time`. When the object's value is set and `<= $now`, the derived rule treats the object as
+  released regardless of tier (an embargo, not a permanent classification).
+- `clearance`: REQUIRED (MAY be empty only if `tiers` has exactly one entry — trivial case). Maps
+  every tier named in `tiers` other than the first to an RBAC group name required to read at that
+  tier or above. A tier absent from `clearance` inherits the next-less-restrictive tier's
+  requirement (so a schema need only declare clearance at the tiers where it changes).
+
+### Derived read-enforcement
+
+At the same seam `MagicRbacHandler::applyRbacFilters()` (SQL) and
+`ConditionMatcher::objectMatchesConditions()` / `PermissionHandler::hasPermission()` (PHP) already
+consult authored `authorization.read` rules, a schema declaring
+`x-openregister-confidentiality` contributes one additional derived rule, logically:
+
+```
+FOR the object's tier T (read from tierProperty, defaulting to tiers[0] if unset/invalid):
+  ALLOW read IF caller's group satisfies clearance[T] (walking up from T to tiers[0])
+  ALLOW read IF releaseAtProperty is declared AND object[releaseAtProperty] <= $now
+  (owner bypass and admin bypass apply exactly as they do to every other RLS rule)
+```
+
+This is additive: it is evaluated with OR semantics against any authored rules the schema also
+declares (mirroring "Multiple authorization rules evaluated with OR logic" in
+`row-field-level-security`), so a schema author can still add narrower hand-authored rules on top.
+SQL-level evaluation keeps the ADR "RLS MUST happen at the SQL query level" guarantee — the derived
+rule generates a `WHERE` fragment via `MagicRbacHandler`, not a post-fetch PHP filter, so pagination
+counts and facet counts stay correct for confidentiality-filtered lists exactly as they do for
+authored RLS rules today.
+
+### Loud discard (the fourth item from the same wave's aggregation-dialect-repair change)
+
+The existing `x-openregister-quality`/`-dedup`/`-survivorship`/`-aggregations`/`-calculations`
+pattern degrades a malformed annotation to a `logger->warning()` call and imports the schema anyway
+(`lib/Db/SchemaMapper.php:1044-1249`). `aggregation-dialect-repair` (same wave, `openregister/
+openspec/changes/aggregation-dialect-repair/`) diagnosed that this pattern is not loud enough in
+practice: a `nextcloud.log` line with no surfacing in the save response reads, from the schema
+author's side, as success. Because a malformed confidentiality annotation is a **security-relevant**
+failure mode (a broken tier/clearance mapping silently means "enforcement rule not applied" — the
+strictest possible failure direction is fail-closed, but the current pattern's failure direction for
+*other* advisory annotations is fail-open-to-"feature simply doesn't run"), this change does NOT
+reuse the warn-and-continue behavior unmodified:
+
+- `ConfidentialityAnnotationValidator` errors are still collected the same way as the other
+  validators (consistency, `SchemaMapper.php:1044-1070` shape).
+- But `SchemaMapper::validateConfidentialityAnnotation()` (the new sibling method) additionally
+  appends validation errors to the schema-save response's existing warnings surface (whatever
+  `aggregation-dialect-repair` task 4 establishes as the shared "annotation validation warnings"
+  response field — this change consumes that mechanism rather than inventing a second one; see
+  `depends_on` note in Open Questions) so a schema author seeing "saved successfully" also sees
+  "confidentiality annotation ignored: <reason>" in the same response, not only in a log file they
+  may never read.
+- Until that shared mechanism lands, this change's validator at minimum logs at `error` (not
+  `warning`) level with a message naming the schema and the specific defect, and the derived
+  enforcement rule for a schema with an invalid annotation MUST NOT be silently treated as "no
+  rule" — it MUST be treated as "read denied by default for the declared tier property until fixed"
+  (fail-closed), which is the opposite default from quality/dedup/survivorship (fail-open-to-
+  "feature doesn't run") precisely because this feature's job is access control.
+
+### Object / access-control patterns (ADR-001, ADR-005, ADR-023)
+
+All classified objects remain ordinary OR objects; reads/writes flow through `ObjectService`
+unchanged. The derived rule is enforced inside the existing RLS chain, not a new authorization
+layer bolted on top — there is no second "is this object secret" check elsewhere in the request
+path to keep in sync. Fail-closed on validator error (above) follows the same CWE-863 discipline
+already normative for `row-field-level-security`'s "Unresolvable dynamic variable denies access
+safely" and `PropertyRbacHandler`'s write-only strip.
+
+## Risks / Trade-offs
+
+- **[A derived rule with the wrong clearance mapping fails closed]** → Mitigation: deliberate design
+  choice (see "Loud discard" above) — the safer failure direction for an access-control primitive is
+  "nobody can read the confidential object" over "everybody can", even though this differs from the
+  existing quality/dedup fail-open convention. Documented explicitly so a future maintainer does not
+  "fix" it back to fail-open for consistency.
+- **[Tier vocabulary drift across schemas]** → Each schema declares its own `tiers` list; OR does not
+  enforce a single fleet-wide vocabulary. Mitigation: this is deliberate (a college/gemeenteraad
+  tier set differs from a generic internal/external one), but is flagged as an Open Question below
+  for whether a shared vocabulary convention doc is worth writing once 2+ apps adopt this.
+- **[Performance: an extra WHERE clause on every read of a classified schema]** → Mitigation: SQL-
+  level generation via the existing `MagicRbacHandler` fragment builder, same cost class as any
+  other authored RLS rule; no N+1, no post-fetch filtering.
+- **[`releaseAtProperty` embargo timing depends on server clock]** → Same trust boundary
+  `deprecate-published-metadata`'s `$now` already accepts; not a new risk surface.
+- **[A schema declares `groundProperty` pointing at a `$ref`]** → OR does not validate the
+  referenced object exists at annotation-save time (mirrors how `x-openregister-references` targets
+  are not existence-checked until read); a dangling ground reference degrades to "ground shown as
+  raw UUID" in the `@self.confidentiality` mirror, not a hard failure.
+
+## Migration Plan
+
+Additive only: a new annotation key, a new validator class, a new derived-rule source consumed by
+existing enforcement points, and a new `@self.confidentiality` render key. No new OR schema, no
+database migration, no change to any schema that does not declare the annotation. Rollback is
+removing the validator registration and the derived-rule generator; schemas that declared the
+annotation would then fall through `logDroppedAnnotationKeys()`'s generic "unknown key" warning
+(safe — the annotation was advisory metadata, not a storage requirement, except for the fail-closed
+enforcement behavior specified above, which also simply stops applying on rollback).
+
+## Seed Data
+
+No new OR schema is introduced by this change, so there is no register-level seed-data task. The
+capability is exercised entirely by PHPUnit unit/integration tests against the validator and the
+derived-rule generator using inline schema fixtures (mirroring how
+`row-field-level-security`/`deprecate-published-metadata` are tested — no live Nextcloud, php:8.3-cli
++ OCP stubs). A worked example belongs in this design for reviewer clarity:
+
+- Schema `besluit` (municipal decision), `tiers: ["public", "confidential"]`,
+  `tierProperty: "confidentialityTier"`, `groundProperty: "confidentialityGround"`,
+  `releaseAtProperty: "confidentialityReleaseUntil"`, `clearance: {"confidential": "raadsleden"}`.
+  Example object: `{"confidentialityTier": "confidential", "confidentialityGround":
+  "Gemeentewet art. 25", "confidentialityReleaseUntil": "2027-01-01T00:00:00+00:00"}` — unreadable
+  by a caller outside group `raadsleden` until 2027-01-01, after which it is readable by anyone with
+  ordinary schema-level access regardless of group.
+
+## Open Questions
+
+- Which shared mechanism `aggregation-dialect-repair`'s task 4 (loud annotation-failure surfacing)
+  actually lands as — a response `warnings` array, a distinct validation-errors endpoint, or
+  something else — determines the exact wiring of this change's "Loud discard" section. Not a
+  blocker (the fail-closed enforcement behavior and `error`-level logging stand on their own), but
+  the response-surfacing wiring should be revisited once that change ships.
+- Whether a fleet-wide shared confidentiality-tier vocabulary convention (beyond "each schema
+  declares its own `tiers`") is worth documenting once a second consumer (procest/zaakafhandelapp)
+  adopts this primitive — deferred until there is a second real consumer to generalise from.

--- a/openspec/changes/confidentiality-classification-primitive/proposal.md
+++ b/openspec/changes/confidentiality-classification-primitive/proposal.md
@@ -1,0 +1,110 @@
+---
+kind: code
+---
+
+## Why
+
+decidesk classifies confidentiality in **five separate places** because OpenRegister has no
+primitive for it: `AgendaItem.confidentiality` (an ad hoc enum), `Decision.isPublished` (a boolean
+with no legal grounding), a hand-maintained public-publication deny-list, `commissievergaderingen`'s
+`besloten-onderdeel` flag, and the `Geheimhouding` register (grounds + `bekrachtiging`/`opheffing`
+per Gemeentewet art. 25/55/86). Each reinvents the same shape — a tier, a legal basis, and a
+possible timed release — with its own property names, its own enforcement code, and no shared
+guarantee that "confidential" means the same thing twice in the same app.
+
+This is the ADR-022 drift pattern one layer up from ADR-045 (MDM surface) and ADR-047 (AVG/DSAR
+workflow): a data-classification capability that every register touching government or otherwise
+sensitive data will eventually need (decidesk today; procest, zaakafhandelapp, opencatalogi are the
+next obvious candidates for zaaktype vertrouwelijkheid). Left app-side, every consumer grows its own
+copy and drifts, exactly as pipelinq's MDM and AVG surfaces did before ADR-045/047.
+
+OpenRegister already has half the enforcement machinery: `row-field-level-security` (RLS) supports
+conditional per-object matching including a `vertrouwelijkheid`-style int comparison
+(`{"$lte": N}`), and `deprecate-published-metadata` established the canonical timed-release pattern
+— a `$now` dynamic variable resolved by both `MagicRbacHandler` (SQL) and `ConditionMatcher` (PHP)
+so a match condition like `{"publicatieDatum": {"$lte": "$now"}}` becomes a working embargo with no
+new column, no cron job, and no service. What is missing is not a new enforcement engine — it is a
+**standard, schema-declarative shape** for "this object has a confidentiality tier, a legal ground,
+and an optional release condition", generated once per schema instead of hand-authored per app, the
+same way `x-openregister-quality`/`x-openregister-dedup` turned bespoke scoring/dedup code into
+config.
+
+## What Changes
+
+- **New schema annotation `x-openregister-confidentiality`** (validated at schema-save time,
+  mirroring the `x-openregister-quality`/`-dedup`/`-survivorship` pattern): declares the ordered
+  tier vocabulary (least → most restrictive), which property holds the object's tier, which
+  property (if any) holds a legal-ground reference, which property (if any) holds a release
+  date/time, and which RBAC group is required to read at-or-above each tier.
+- **A `ConfidentialityAnnotationValidator`** (`lib/Service/Confidentiality/`) validating the
+  annotation shape at schema save — tier vocabulary is a non-empty ordered list, the declared
+  tier/ground/release properties exist on the schema, and every tier named in the clearance map is
+  in the tier vocabulary. Malformed annotations degrade to a non-fatal warning at save time
+  (matching the existing quality/dedup/survivorship pattern) — but see the loud-failure requirement
+  below.
+- **Derived read-enforcement**, additive to the existing RLS/RBAC evaluation chain
+  (`MagicRbacHandler` for SQL, `ConditionMatcher`/`PermissionHandler` for PHP-level checks): for any
+  schema declaring the annotation, a rule is derived at evaluation time (not authored by hand) that
+  denies read unless (a) the caller's group clears the object's tier per the annotation's clearance
+  map, **or** (b) a declared release property is present and its value is `<= $now` (reusing the
+  exact `$now` resolution path `deprecate-published-metadata` already ships) — an embargoed object
+  becomes readable the instant its release condition is met, with no write, no job, and no
+  materialisation step required.
+- **A legal-ground reference field convention**: the annotation's `groundProperty` names an
+  ordinary schema property (string or `$ref`); OpenRegister does not interpret its content — the
+  declaring schema is free to use a free-text ground, an enum, or a `$ref` to a grounds-vocabulary
+  register (e.g. decidesk's own Gemeentewet articles). This keeps jurisdiction-specific legal
+  wording out of OR core, matching ADR-047's "jurisdiction is data, not code" pattern.
+- **Read-time visibility of the resolved classification**: the object's effective tier, ground, and
+  release status are exposed under `@self.confidentiality` on render (mirroring the
+  `@self.relations` mirror pattern), so a UI can show "Confidential until 2027-01-01 (Gemeentewet
+  art. 25)" without re-deriving the logic client-side.
+
+**Explicitly out of scope:**
+- The Gemeentewet-specific workflow (grounds vocabulary, `bekrachtiging`/`opheffing` approval flow,
+  council-decision-triggered declassification) stays in decidesk. This change ships the primitive
+  the workflow will declare against, not the workflow itself — the same split ADR-047 drew between
+  OR's case-engine spine and pipelinq's NL policy pack.
+- No UI. No admin management screen for authoring the annotation (schemas are still edited as JSON,
+  same as quality/dedup/survivorship today).
+- No migration of decidesk's five existing mechanisms — that is separate, decidesk-side follow-up
+  work once this primitive lands (tracked in decidesk's Back to Six programme).
+- No change to `row-field-level-security`'s authored-rule contract — the derived rule is a new
+  input into the same evaluation chain, not a change to how hand-authored RLS rules behave.
+
+## Capabilities
+
+### New Capabilities
+- `confidentiality-classification`: the `x-openregister-confidentiality` schema annotation, its
+  save-time validator, the derived read-enforcement rule (tier clearance + timed release via
+  `$now`), and the `@self.confidentiality` render mirror.
+
+### Modified Capabilities
+<!-- None. This change adds a new rule SOURCE that plugs into the existing RLS/RBAC evaluation
+     chain (MagicRbacHandler / ConditionMatcher / PermissionHandler) and reuses the `$now`
+     dynamic-variable resolution `deprecate-published-metadata` already ships. It does not alter
+     the behavior or contract of row-field-level-security's hand-authored conditional rules, and it
+     does not touch deprecate-published-metadata's requirements — both are consumed unchanged. -->
+
+## Impact
+
+- **New code**: `ConfidentialityAnnotationValidator`; a derived-rule generator invoked from the same
+  seam `MagicRbacHandler::applyRbacFilters()` / `PermissionHandler::hasPermission()` /
+  `ConditionMatcher::objectMatchesConditions()` already use for authored RLS rules; a render-time
+  mirror writer for `@self.confidentiality` alongside the existing `RenderObject` choke point.
+  `Schema::ANNOTATION_VOCABULARY` gains `x-openregister-confidentiality`.
+- **Consumes (unchanged)**: `MagicRbacHandler` SQL-level filtering + `$now`/`$organisation`/`$userId`
+  dynamic-variable resolution, `ConditionMatcher` PHP-level evaluation, `PermissionHandler` schema-
+  level checks, the admin/system-context bypass conventions already governing `_rbac`/
+  `SystemOperationContext`, and the `SchemaMapper::validate*Annotation()` warn-not-reject pattern.
+- **APIs**: no new endpoints. Existing REST/GraphQL/search/export read paths gain the derived
+  enforcement automatically wherever the annotation is declared, the same way declaring
+  `x-openregister-quality` today materialises a score with no new endpoint.
+- **No breaking change**: a schema that does not declare `x-openregister-confidentiality` is
+  unaffected. Existing `vertrouvelijkheid`/`vertrouwelijkheid`-style hand-authored RLS rules (see
+  `row-field-level-security`'s own scenarios) continue to work unchanged; this annotation is an
+  alternative to hand-authoring that class of rule, not a replacement requirement.
+- **Downstream**: decidesk's `Geheimhouding`/`AgendaItem.confidentiality`/`Decision.isPublished`/
+  `besloten-onderdeel`/deny-list consolidation is separate, tracked follow-up work once this
+  primitive is available (decidesk Back to Six programme). procest/zaakafhandelapp zaaktype
+  vertrouwelijkheid is a plausible second consumer, not scoped here.

--- a/openspec/changes/confidentiality-classification-primitive/specs/confidentiality-classification/spec.md
+++ b/openspec/changes/confidentiality-classification-primitive/specs/confidentiality-classification/spec.md
@@ -1,0 +1,155 @@
+## Purpose
+
+A schema-declarative confidentiality classification primitive: a per-object tier, an optional
+legal-ground reference, and an optional timed release, enforced through OpenRegister's existing
+row-level-security evaluation chain instead of app-hand-rolled access checks.
+
+## ADDED Requirements
+
+### Requirement: Schemas MUST be able to declare a confidentiality classification via `x-openregister-confidentiality`
+A schema MUST be able to declare `x-openregister-confidentiality` with a non-empty ordered `tiers`
+array (least → most restrictive), a `tierProperty` naming a declared schema property, and a
+`clearance` map from tier name to a required RBAC group. `tierProperty` MUST name a property already
+declared under the schema's `properties`. Every tier key in `clearance` MUST be a member of `tiers`.
+A tier not present in `clearance` MUST inherit the requirement of the next-less-restrictive tier
+that does declare one; the first (least restrictive) tier in `tiers` MUST require no clearance when
+absent from `clearance`.
+
+#### Scenario: Valid annotation is accepted
+- **GIVEN** a schema `besluit` with property `confidentialityTier` (string) and
+  `x-openregister-confidentiality: {"tiers": ["public", "confidential"], "tierProperty":
+  "confidentialityTier", "clearance": {"confidential": "raadsleden"}}`
+- **WHEN** the schema is saved
+- **THEN** the annotation MUST be accepted with no validation error
+
+#### Scenario: tierProperty must reference a declared property
+- **GIVEN** a schema whose `x-openregister-confidentiality.tierProperty` names a property not
+  present in the schema's `properties`
+- **WHEN** the schema is saved
+- **THEN** the annotation MUST be rejected with an error naming the undeclared property
+
+#### Scenario: clearance tier must be a member of tiers
+- **GIVEN** a schema whose `clearance` map contains a key not present in `tiers`
+- **WHEN** the schema is saved
+- **THEN** the annotation MUST be rejected with an error naming the unknown tier
+
+#### Scenario: A tier absent from clearance inherits the next-less-restrictive requirement
+- **GIVEN** `tiers: ["public", "internal", "confidential"]` and `clearance: {"confidential":
+  "raadsleden"}` (no entry for `internal`)
+- **WHEN** the derived rule is evaluated for an object at tier `internal`
+- **THEN** the effective clearance requirement for `internal` MUST be the same as `public`'s (no
+  clearance required), because `internal` has no explicit entry and inherits from the
+  next-less-restrictive tier
+
+### Requirement: Schemas MUST be able to declare an optional legal-ground reference and timed release
+`x-openregister-confidentiality` MAY declare `groundProperty` and `releaseAtProperty`, each naming a
+declared schema property. `groundProperty`'s value MUST NOT be interpreted or validated by
+OpenRegister beyond existence of the property — its content (free text, enum, or `$ref`) is the
+declaring schema's concern. `releaseAtProperty`, when declared, MUST name a property of `format:
+date-time`.
+
+#### Scenario: groundProperty content is opaque to OpenRegister
+- **GIVEN** schema `besluit` declares `groundProperty: "confidentialityGround"` and an object has
+  `confidentialityGround: "Gemeentewet art. 25"`
+- **WHEN** the object is validated and saved
+- **THEN** OpenRegister MUST accept the value without interpreting or constraining its content
+
+#### Scenario: releaseAtProperty must be a date-time property
+- **GIVEN** a schema declares `releaseAtProperty: "confidentialityReleaseAt"` naming a property of
+  type `string` with no `date-time` format
+- **WHEN** the schema is saved
+- **THEN** the annotation MUST be rejected with an error naming the property and the required format
+
+### Requirement: Read access to a classified object MUST require tier clearance or a met release condition
+For a schema declaring `x-openregister-confidentiality`, a read of an object MUST be denied unless
+at least one of the following holds: (a) the caller's group satisfies the effective clearance
+requirement for the object's tier (read from `tierProperty`, defaulting to the least-restrictive
+tier when unset or not a member of `tiers`), (b) a `releaseAtProperty` is declared and the object's
+value for it is present and less-than-or-equal-to the current time, or (c) the caller is the
+object's owner or an admin (existing owner/admin bypass, unchanged). This rule MUST be evaluated at
+the SQL query level for list/search access (via the same mechanism `row-field-level-security`'s
+authored conditional rules use), not as post-fetch PHP filtering, and MUST be combined with OR
+against any authored `authorization.read` rules the schema also declares.
+
+#### Scenario: Read denied below clearance and before release
+- **GIVEN** schema `besluit` as in the valid-annotation scenario, and object `besluit-1` with
+  `confidentialityTier: "confidential"` and no `confidentialityReleaseUntil` set
+- **AND** user `pieter` is NOT in group `raadsleden`
+- **WHEN** `pieter` reads or lists `besluit-1`
+- **THEN** `besluit-1` MUST NOT be visible to `pieter`
+
+#### Scenario: Read allowed with sufficient clearance
+- **GIVEN** the same object as above
+- **AND** user `jan` IS in group `raadsleden`
+- **WHEN** `jan` reads or lists `besluit-1`
+- **THEN** `besluit-1` MUST be visible to `jan`
+
+#### Scenario: Read allowed once the release condition is met, regardless of clearance
+- **GIVEN** schema `besluit` additionally declares `releaseAtProperty: "confidentialityReleaseUntil"`
+- **AND** object `besluit-2` has `confidentialityTier: "confidential"` and
+  `confidentialityReleaseUntil` set to a timestamp in the past
+- **AND** user `pieter` is NOT in group `raadsleden`
+- **WHEN** `pieter` reads or lists `besluit-2`
+- **THEN** `besluit-2` MUST be visible to `pieter` (the release condition satisfied the rule
+  regardless of clearance)
+
+#### Scenario: An unmet future release condition does not grant access
+- **GIVEN** object `besluit-3` has `confidentialityTier: "confidential"` and
+  `confidentialityReleaseUntil` set to a timestamp in the future
+- **AND** user `pieter` is NOT in group `raadsleden`
+- **WHEN** `pieter` reads or lists `besluit-3`
+- **THEN** `besluit-3` MUST NOT be visible to `pieter`
+
+#### Scenario: Owner and admin bypass apply unchanged
+- **GIVEN** object `besluit-1` (tier `confidential`, no release set)
+- **WHEN** the object's owner, or a Nextcloud admin-group user, reads `besluit-1`
+- **THEN** `besluit-1` MUST be visible regardless of the caller's group clearance
+
+#### Scenario: List/search pagination reflects only classification-accessible objects
+- **GIVEN** 10 `besluit` objects at tier `confidential`, of which 3 have a past `releaseAtProperty`
+  value and 7 do not
+- **AND** user `pieter` is NOT in group `raadsleden`
+- **WHEN** `pieter` lists `besluit` objects
+- **THEN** exactly the 3 released objects MUST appear
+- **AND** the pagination `total` MUST reflect 3, not 10, and no post-fetch PHP filtering MUST be
+  used to reach that count
+
+### Requirement: A malformed confidentiality annotation MUST fail closed, not silently permit access
+Unlike other advisory `x-openregister-*` annotations (quality, dedup, survivorship), a schema whose
+`x-openregister-confidentiality` fails validation MUST NOT be treated as "no confidentiality rule
+applied" (which would leave the schema's objects fully readable). It MUST instead be treated as "read
+denied by default for every object carrying a non-empty `tierProperty` value" until the annotation is
+corrected, and the validation failure MUST be logged at `error` level naming the schema and the
+specific defect — not merely `warning` level as the other advisory annotations use.
+
+#### Scenario: An invalid annotation denies read rather than granting it
+- **GIVEN** a schema declares `x-openregister-confidentiality` with a `clearance` key not present in
+  `tiers` (an invalid annotation)
+- **WHEN** an object on that schema with a non-empty `tierProperty` value is read by a caller who is
+  neither the owner nor an admin
+- **THEN** the read MUST be denied
+- **AND** an `error`-level log entry MUST record the schema slug and the specific validation defect
+
+#### Scenario: A schema with no confidentiality annotation is unaffected
+- **GIVEN** a schema that does not declare `x-openregister-confidentiality`
+- **WHEN** any object on that schema is read
+- **THEN** this capability MUST NOT alter the read outcome in any way
+
+### Requirement: The resolved classification MUST be exposed on render as `@self.confidentiality`
+When a schema declares `x-openregister-confidentiality`, a rendered object accessible to the caller
+MUST include `@self.confidentiality` containing the object's resolved `tier`, `ground` (the raw value
+of `groundProperty` when declared), `releaseAt` (the raw value of `releaseAtProperty` when declared),
+and a computed `released` boolean (true when a release condition is declared and met). This mirror
+MUST be present for every caller who can see the object (there is no read-restriction on the mirror
+itself beyond the object-level read gate already enforced).
+
+#### Scenario: Render mirror reflects an unreleased classified object
+- **GIVEN** object `besluit-1` (tier `confidential`, ground `"Gemeentewet art. 25"`, no release set)
+- **WHEN** user `jan` (group `raadsleden`) reads `besluit-1`
+- **THEN** the rendered response MUST include `@self.confidentiality: {"tier": "confidential",
+  "ground": "Gemeentewet art. 25", "releaseAt": null, "released": false}`
+
+#### Scenario: Render mirror reflects a released object
+- **GIVEN** object `besluit-2` (tier `confidential`, `releaseAtProperty` in the past)
+- **WHEN** any caller with read access renders `besluit-2`
+- **THEN** `@self.confidentiality.released` MUST be `true`

--- a/openspec/changes/confidentiality-classification-primitive/tasks.md
+++ b/openspec/changes/confidentiality-classification-primitive/tasks.md
@@ -1,0 +1,58 @@
+# Tasks — confidentiality-classification-primitive (kind: code)
+
+A generic per-object confidentiality tier + legal ground + timed release, declared via
+`x-openregister-confidentiality` and enforced through the existing RLS/RBAC evaluation chain.
+Reuses `MagicRbacHandler`/`ConditionMatcher`'s `$now` dynamic variable
+(`deprecate-published-metadata`) and the `SchemaMapper::validate*Annotation()` pattern
+(`quality`/`dedup`/`survivorship`). No new OR schema.
+
+## 1. Annotation + validation
+
+- [ ] 1.1 Add `x-openregister-confidentiality` to `Schema::ANNOTATION_VOCABULARY` (`lib/Db/Schema.php`).
+- [ ] 1.2 Add `ConfidentialityAnnotationValidator` (`lib/Service/Confidentiality/`) validating: non-empty ordered `tiers`; `tierProperty` exists in schema `properties`; every `clearance` key is a member of `tiers`; `groundProperty` (if present) exists in `properties`; `releaseAtProperty` (if present) exists in `properties` and is `format: date-time`.
+- [ ] 1.3 Add `SchemaMapper::validateConfidentialityAnnotation()` wired the same way as `validateQualityAnnotation()` (`lib/Db/SchemaMapper.php:1118-1144`), but per the design's "Loud discard" decision: log at `error` (not `warning`) level and mark the schema so the derived-rule generator treats it as fail-closed rather than "no rule" (see task 2.4).
+
+## 2. Derived read-enforcement
+
+- [ ] 2.1 Add a derived-rule generator that reads a schema's `x-openregister-confidentiality` and produces a conditional rule in the existing `{"group": ..., "match": {...}}` shape `MagicRbacHandler`/`ConditionMatcher` already consume, walking `clearance` inheritance from the object's tier down to the first tier that declares a requirement.
+- [ ] 2.2 Wire the derived rule into `MagicRbacHandler::applyRbacFilters()` as an additional OR-combined rule source for schemas declaring the annotation (SQL-level, list/search/export/facet paths) — no post-fetch PHP filtering.
+- [ ] 2.3 Wire the same derived rule into `ConditionMatcher::objectMatchesConditions()` / `PermissionHandler::hasPermission()` for the single-object read path, reusing `$now` resolution for `releaseAtProperty` exactly as `deprecate-published-metadata` resolves it for `publicatieDatum`-style rules.
+- [ ] 2.4 Implement the fail-closed behavior for a schema whose annotation failed validation (task 1.3): every object with a non-empty `tierProperty` value is denied read to non-owner/non-admin callers until the annotation is corrected.
+- [ ] 2.5 Confirm owner bypass and admin bypass apply to the derived rule identically to authored RLS rules (no new bypass logic — reuse the existing bypass evaluated in the same handler).
+
+## 3. Render mirror
+
+- [ ] 3.1 Add `@self.confidentiality` materialisation (`tier`, `ground`, `releaseAt`, `released`) at the `RenderObject` choke point for schemas declaring the annotation, following the same "materialise unconditionally at the render boundary" precedent as the `@self.relations` mirror.
+
+## 4. Tests
+
+- [ ] 4.1 Add PHPUnit unit tests for `ConfidentialityAnnotationValidator` covering: valid annotation, undeclared `tierProperty`, unknown `clearance` tier, non-date-time `releaseAtProperty`, clearance-inheritance resolution.
+- [ ] 4.2 Add PHPUnit tests for the derived-rule generator + `MagicRbacHandler`/`ConditionMatcher` integration covering every scenario in `specs/confidentiality-classification/spec.md`: denied below clearance, allowed with clearance, allowed once released, future release does not grant access, owner/admin bypass, pagination count reflects only accessible objects, fail-closed on invalid annotation, unaffected schema without the annotation.
+- [ ] 4.3 Add a render test asserting `@self.confidentiality` content for an unreleased and a released object.
+
+## 5. Verification
+
+- [ ] 5.1 Run `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) and the Hydra mechanical gates (spdx-headers, unsafe-auth-resolver, orphan-auth); fix any pre-existing issues touched.
+- [ ] 5.2 Run `openspec validate --change confidentiality-classification-primitive --strict`; resolve any errors.
+
+## Acceptance Criteria
+
+- A schema declaring a valid `x-openregister-confidentiality` gets tier-clearance + timed-release
+  read enforcement with zero additional app code, evaluated at the SQL level for list/search.
+- An invalid annotation fails closed (denies read) rather than silently granting access, and logs at
+  `error` level.
+- A schema without the annotation is provably unaffected (existing RLS/RBAC test suite stays green).
+- `@self.confidentiality` reflects the resolved tier/ground/release state for every caller who can
+  read the object.
+- No change to `row-field-level-security`'s or `deprecate-published-metadata`'s existing contracts —
+  their own test suites stay green unmodified.
+
+## Quality Checklist
+
+- Reused `MagicRbacHandler`/`ConditionMatcher`'s `$now` resolution and the authored-rule shape rather
+  than building a parallel enforcement engine (ADR-011).
+- SPDX + `@license`/`@copyright` docblock headers on every new PHP file (EUPL-1.2).
+- Fail-closed behavior on validator error is deliberate and documented in design.md — do not
+  "simplify" it to match the quality/dedup/survivorship fail-open convention.
+- No jurisdiction-specific wording (Gemeentewet or otherwise) added to OR core; `groundProperty`
+  content stays opaque to OpenRegister.


### PR DESCRIPTION
Authored during the decidesk **Back to Six** programme (2026-08-19/20). Proposal only — no code changes.

**Why here and not in the consuming app:** decidesk classifies confidentiality in FIVE places (`AgendaItem.confidentiality`, `Decision.isPublished`, a public-publication deny-list, commissievergaderingen besloten-onderdeel, and the Gemeentewet `Geheimhouding` register) precisely because no platform primitive exists. That fragmentation is the tell. Hydra ADR-047 gives this repo the AVG/DSAR domain and ADR-045 the MDM surface; a per-object confidentiality tier with timed release is the same shape.

**Deliberately narrow.** This repo already ships the pieces: the `$now` dynamic variable for timed release, and the RLS evaluation chain. The new work is only the schema-declarative shape (`x-openregister-confidentiality`: tiers, tier property, legal-ground property, release property, clearance map) plus a derived-rule generator feeding the existing `MagicRbacHandler`/`ConditionMatcher` chain — **not** a new enforcement engine.

**Deliberately fail-closed** on a malformed annotation — the opposite of the quality/dedup fail-open convention here, and flagged explicitly so a future maintainer doesn't "fix" it back for consistency.

Out of scope by design: the Gemeentewet workflow (grounds, bekrachtiging, opheffing) stays in decidesk.

Needs this repo's owners to review before implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)