### PR TITLE
fix(beta): remove the orphaned inheritFromPublicDefault RBAC control

### DIFF
--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -62,12 +62,6 @@ export const useSettingsStore = defineStore('settings', {
 			defaultNewUserGroup: 'viewer',
 			defaultObjectOwner: '',
 			adminOverride: true,
-			// Tenant-wide default for the schema-level inheritFromPublic flag.
-			// When true (default — pre-change behaviour), authenticated users
-			// qualify for any rule targeting the `public` group on schemas that
-			// don't override this. When false, authenticated users only qualify
-			// via their own group memberships.
-			inheritFromPublicDefault: true,
 		},
 
 		multitenancyOptions: {

--- a/src/views/settings/sections/RbacConfiguration.vue
+++ b/src/views/settings/sections/RbacConfiguration.vue
@@ -102,24 +102,6 @@
 					Allow administrators to bypass all RBAC restrictions
 				</p>
 
-				<!-- Inherit-from-public default -->
-				<NcCheckboxRadioSwitch
-					:checked.sync="rbacOptions.inheritFromPublicDefault"
-					:disabled="saving"
-					type="switch">
-					{{ rbacOptions.inheritFromPublicDefault
-						? 'Authenticated users inherit public group rights (default)'
-						: 'Authenticated users do NOT inherit public group rights (default)' }}
-				</NcCheckboxRadioSwitch>
-				<p class="option-description">
-					Tenant-wide default for the schema-level <code>inheritFromPublic</code> flag.
-					When on (default), authenticated users qualify for any rule that targets the
-					<code>public</code> group across all schemas — unless an individual schema or
-					register opts out via its <code>inheritFromPublic</code> field. When off,
-					authenticated users must qualify via their own group memberships everywhere
-					the flag is not explicitly set. Anonymous users are unaffected either way.
-				</p>
-
 				<h4>Default User Groups</h4>
 				<p class="option-description">
 					Configure which Nextcloud groups different types of users are


### PR DESCRIPTION
Fixes a defect introduced by the development -> beta sync (#2636).

**What broke:** old beta carried `inheritFromPublicDefault` in four places — two backend (`ConfigurationSettingsController`, `ConfigurationSettingsHandler`) and two frontend (`store/settings.js`, `RbacConfiguration.vue`). The sync resolved the two **backend** files to development's version — development grafted `inheritFromPublic` but deliberately never took the `Default` setting (0 references anywhere) — while the two **frontend** files merged cleanly and kept beta's content.

The result was a settings UI bound to a backend that no longer exists: a checkbox on `rbacOptions.inheritFromPublicDefault`, defaulted `true` in the store, sitting in the **RBAC settings panel**. An admin toggling it would believe they had changed an access-control default; nothing would persist. A silent no-op control in a security surface is worse than no control.

**Fix:** align the two frontend files with development, which is what the rest of the sync did. Beta now has zero references to `inheritFromPublicDefault` in `lib/` or `src/`, matching development exactly.

**How it was found, and the lesson:** the check I ran straight after the sync compared *files* — "824 removed, 0 of which exist on development, therefore nothing lost". That was true and insufficient. No file disappeared; content *inside* files resolved to development's version did. Comparing symbol counts across old-beta / beta-now / development is what surfaced it (18 -> 3 -> 0).

**If the flag is actually wanted**, the right move is the opposite direction — graft `inheritFromPublicDefault` onto development first, then let it flow to beta — not to restore it on beta alone, which would re-diverge the branches.