### PR TITLE
fix(autoload): declare our own Contract prefix, so a vendored copy cannot win

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
 	],
 	"autoload": {
 		"psr-4": {
+			"OCA\\OpenRegister\\Contract\\": "lib/Contract/",
 			"OCA\\OpenRegister\\": "lib/"
 		}
 	},


### PR DESCRIPTION
One line. It removes — for this repository — the mechanism behind the contract shadowing in ConductionNL/.github#514.

## The problem

`hydra-gates` claims **our** namespace in its runtime autoload:

```json
"autoload": { "psr-4": { "OCA\\OpenRegister\\Contract\\": "hydra-gates/contracts/" } }
```

That prefix is *longer* than our own `OCA\OpenRegister\` → `lib/`, and PSR-4 is longest-prefix-wins. So the gate package's copy of **our** interface beat the real one, in our own repository — our generated `autoload_classmap.php` pointed at it explicitly:

```
'OCA\OpenRegister\Contract\ObjectServiceInterface'
    => $vendorDir . '/conduction/hydra-gates/hydra-gates/contracts/ObjectServiceInterface.php'
```

That is how `ObjectServiceUpdateVersusPatchTest` went red: v1.8.0 shipped an `ObjectServiceInterface` **without `patchObject()`**, and reflection resolved to the vendored copy rather than `lib/Contract/`. Cutting v1.8.1 cleared the symptom; this removes the mechanism.

## Why one line is enough

Composer puts the **root package's** paths first for a shared prefix. Verified on a fixture with a real vendor package claiming the identical prefix:

```
'OCA\OpenRegister\Contract\' => array($baseDir.'/lib/Contract',
                                      $vendorDir.'/…/contracts')

resolves: lib/Contract/ObjectServiceInterface.php     patchObject: YES
```

Without the line, the same fixture resolves to the vendored copy with `patchObject: NO`.

## It is a preference, not an exclusion

The vendored path stays **second** in the array, so anything present there and absent from `lib/Contract/` still resolves exactly as before. Nothing is hidden; the real definition simply wins. gate-67 keeps the two byte-identical either way.

## Scope

This fixes **this repository**. It does not help leaf apps, where openregister is not the root package and the vendored copy legitimately supplies the interface under PHPUnit. The general case — and the measured cost of fixing it fleet-wide (14 apps need a guarded bootstrap) — is written up in ConductionNL/.github#531, along with the correction that the shadowing cannot reach production, because hydra-gates is `require-dev` and releases install `--no-dev`.

## Verification

The mechanism is proven in the fixture above. For this repo, **`ObjectServiceUpdateVersusPatchTest` is itself the detector** — it is the test that caught the shadowing in the first place, so CI passing here is the check that matters.

Diff is one line; `composer validate` is clean (the `ddn/sapp` commit-ref warning is pre-existing).
