### PR TITLE
chore(deps): refresh the shared Conduction locks

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -7048,16 +7048,16 @@
         },
         {
             "name": "conduction/hydra-gates",
-            "version": "v1.8.1",
+            "version": "v1.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ConductionNL/.github.git",
-                "reference": "8e0e9857e54d6c680e157939e78a468e58d3751a"
+                "reference": "3dfcd1e56d27bd06eaa98a9a66e377e7e14fe491"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/8e0e9857e54d6c680e157939e78a468e58d3751a",
-                "reference": "8e0e9857e54d6c680e157939e78a468e58d3751a",
+                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/3dfcd1e56d27bd06eaa98a9a66e377e7e14fe491",
+                "reference": "3dfcd1e56d27bd06eaa98a9a66e377e7e14fe491",
                 "shasum": ""
             },
             "require": {
@@ -7101,9 +7101,9 @@
             "support": {
                 "docs": "https://github.com/ConductionNL/.github/blob/main/hydra-gates/README.md",
                 "issues": "https://github.com/ConductionNL/.github/issues",
-                "source": "https://github.com/ConductionNL/.github/tree/v1.8.1"
+                "source": "https://github.com/ConductionNL/.github/tree/v1.8.2"
             },
-            "time": "2026-08-20T05:07:22+00:00"
+            "time": "2026-08-20T09:37:12+00:00"
         },
         {
             "name": "consolidation/annotated-command",

--- a/lib/Controller/NamesController.php
+++ b/lib/Controller/NamesController.php
@@ -154,7 +154,11 @@ class NamesController extends Controller {
 					}
 				}
 
-				if (is_string($requestedIds) === false && is_array($requestedIds) === false) {
+				// Not `is_string() === false && ...`: every path above turns a
+				// string into an array (explode/array_map, or json_decode of a
+				// '['-prefixed string), and a non-string never enters that block,
+				// so the string test here can only ever be true.
+				if (is_array($requestedIds) === false) {
 					$requestedIds = [(string)$requestedIds];
 				}
 

--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -930,7 +930,13 @@ class ObjectsController extends Controller {
 		// NOT gate the writeOnly strip (#460): `$query['_rbac']` is false for an ADMIN here,
 		// and an admin is not exempt from the writeOnly render boundary (#389).
 		$renderHandler = \OC::$server->get(\OCA\OpenRegister\Service\Object\RenderObject::class);
-		$renderHandler->redactWriteOnlyFromRows(rows: $results, _rbac: $query['_rbac'] ?? true);
+		// No `?? true` on THIS path: `_rbac` is assigned unconditionally above and
+		// the unset() in between does not remove it, so the fallback was dead --
+		// and had it ever fired it would have forced the RBAC strip on exactly the
+		// admin case the comment above says is false. The sibling call further down
+		// keeps its `??` because there `$query` comes straight from
+		// buildSearchQuery() with no `_rbac` assignment.
+		$renderHandler->redactWriteOnlyFromRows(rows: $results, _rbac: $query['_rbac']);
 
 		// Serialize results.
 		$serializedResults = [];

--- a/lib/Service/Object/SearchQueryHandler.php
+++ b/lib/Service/Object/SearchQueryHandler.php
@@ -441,10 +441,21 @@ class SearchQueryHandler {
 					}
 
 					// Merge with existing search if present.
-					$query['_search'] = $searchTerms;
-					if (isset($query['_search']) === true && empty($query['_search']) === false) {
-						$query['_search'] .= ' ' . $searchTerms;
+					//
+					// This previously assigned $query['_search'] FIRST and then
+					// appended $searchTerms to it, so the isset() guard could only
+					// ever see the value just written. Two things went wrong: the
+					// caller's own `_search` was discarded (the merge this comment
+					// describes never happened), and the view's terms were appended
+					// to themselves, producing "foo foo". Mirrors the `schemas`
+					// merge above: read what is there, then combine.
+					$existingSearch = ($query['_search'] ?? '');
+					$searchPrefix = '';
+					if (is_string($existingSearch) === true && $existingSearch !== '') {
+						$searchPrefix = $existingSearch . ' ';
 					}
+
+					$query['_search'] = $searchPrefix . $searchTerms;
 				}//end if
 
 				$this->logger->debug(

--- a/package-lock.json
+++ b/package-lock.json
@@ -2112,9 +2112,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.9.2.tgz",
-      "integrity": "sha512-79AFgzsNiTU9ltg4bEquumR0CFm7b4ed/jW5qEncPPSPWO82HEDwIIe0zm6x38oOegE2ESADiRDn02TW/qXeIQ==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.10.1.tgz",
+      "integrity": "sha512-4S2X+Bv6mGzQMfxZW8XJheJ8iFis+iJdrl3+hlchYl50qQ77TDWy2xsp9Dog+ggfOikfngzmJseF5kz2MHZt4A==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2112,9 +2112,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.8.2.tgz",
-      "integrity": "sha512-kqzqQ2uFyzpHUL6VxzNsfJ5iDOsy/S1iQ9UVn7W0w3CdlVb4RxWz5AFym/onB1eKewF2WtF+9vzBM5CHWsaHTQ==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.9.2.tgz",
+      "integrity": "sha512-79AFgzsNiTU9ltg4bEquumR0CFm7b4ed/jW5qEncPPSPWO82HEDwIIe0zm6x38oOegE2ESADiRDn02TW/qXeIQ==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -45,6 +45,23 @@ parameters:
         - vendor-bin
 
     ignoreErrors:
+        # FilesSidebarListener guards on an OPTIONAL app's event class.
+        #
+        # The listener is registered for 'OCA\Files\Event\LoadAdditionalScriptsEvent'
+        # (AppInfo/Application.php) and re-checks the class by NAME so OpenRegister
+        # carries no hard dependency on the Files app. That class ships with Files,
+        # not with nextcloud/ocp, so the analyser cannot resolve it: it types
+        # get_class($event) as class-string<Event>, decides the comparison can never
+        # match, and concludes the early return always fires — making the body dead.
+        # It is not dead at runtime, where Files is installed and dispatches it.
+        #
+        # Surfaced by hydra-gates v1.8.2's `treatPhpDocTypesAsCertain: false`.
+        # Deleting the "unreachable" body would remove the sidebar; narrowing with
+        # instanceof would reintroduce the hard dependency the string check avoids.
+        -
+            message: '#Unreachable statement - code above always terminates#'
+            path: lib/Listener/FilesSidebarListener.php
+
         # ConductionNL/sapp fork uses lowercase pseudo-classes `obj` /
         # `value` / `pdfentry` / `buffer` / `bytes` etc. in `@return`
         # PHPDocs (upstream typo — fictitious classes that PHPStan can't

--- a/tests/Unit/Service/Object/SearchQueryHandlerViewSearchMergeTest.php
+++ b/tests/Unit/Service/Object/SearchQueryHandlerViewSearchMergeTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit\Service\Object;
+
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Db\View;
+use OCA\OpenRegister\Db\ViewMapper;
+use OCA\OpenRegister\Service\Object\SearchQueryHandler;
+use OCA\OpenRegister\Service\SearchTrailService;
+use OCA\OpenRegister\Service\SettingsService;
+use OCP\IRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Guards the `_search` merge in SearchQueryHandler::applyViewsToQuery().
+ *
+ * The block is commented "Merge with existing search if present", but it used to
+ * assign `$query['_search'] = $searchTerms` FIRST and only then test
+ * `isset($query['_search'])` — a condition that could only ever see the value it
+ * had just written. Two defects fell out of that ordering:
+ *
+ *   1. the caller's own `_search` was overwritten, so the merge never happened;
+ *   2. the view's terms were appended to themselves, yielding "invoice invoice".
+ *
+ * PHPStan surfaced it only as "Offset '_search' … always exists", which reads
+ * like a redundant-isset nit rather than a search returning the wrong rows.
+ *
+ * Both tests below fail against the pre-fix code — 1 on the discarded caller
+ * term, 2 on the doubled view term.
+ */
+class SearchQueryHandlerViewSearchMergeTest extends TestCase {
+
+	/**
+	 * A handler whose ViewMapper returns one view carrying the given query.
+	 *
+	 * @param array<string, mixed> $viewQuery The view's stored query.
+	 *
+	 * @return SearchQueryHandler
+	 */
+	private function makeHandler(array $viewQuery): SearchQueryHandler {
+		// A real View, not a mock: getQuery() is an Entity magic accessor, and
+		// PHPUnit cannot configure it — mocking it errors with "method ... does
+		// not exist", which would make these tests LOOK like they fail against
+		// the unfixed code while actually proving nothing.
+		$view = new View();
+		$view->setQuery($viewQuery);
+
+		$viewMapper = $this->createMock(ViewMapper::class);
+		$viewMapper->method('find')->willReturn($view);
+
+		return new SearchQueryHandler(
+			$viewMapper,
+			$this->createMock(SchemaMapper::class),
+			$this->createMock(SettingsService::class),
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(IRequest::class),
+			$this->createMock(SearchTrailService::class)
+		);
+
+	}//end makeHandler()
+
+	/**
+	 * The caller's own search term must survive the view being applied.
+	 *
+	 * @return void
+	 */
+	public function testExistingSearchTermIsMergedNotDiscarded(): void {
+		$result = $this->makeHandler(['searchTerms' => 'invoice'])
+			->applyViewsToQuery(['_search' => 'urgent'], [1]);
+
+		$this->assertStringContainsString(
+			'urgent',
+			$result['_search'],
+			"the caller's existing _search must not be discarded by the view"
+		);
+		$this->assertStringContainsString(
+			'invoice',
+			$result['_search'],
+			"the view's own search terms must still be applied"
+		);
+
+	}//end testExistingSearchTermIsMergedNotDiscarded()
+
+	/**
+	 * A view's terms must appear once, not be appended to themselves.
+	 *
+	 * @return void
+	 */
+	public function testViewSearchTermIsNotDuplicated(): void {
+		$result = $this->makeHandler(['searchTerms' => 'invoice'])
+			->applyViewsToQuery([], [1]);
+
+		$this->assertSame(
+			'invoice',
+			$result['_search'],
+			'a view search term must be applied exactly once'
+		);
+		$this->assertSame(
+			1,
+			substr_count($result['_search'], 'invoice'),
+			'the term must not be appended to itself'
+		);
+
+	}//end testViewSearchTermIsNotDuplicated()
+
+	/**
+	 * An array of view terms is joined, and still merged with the caller's.
+	 *
+	 * @return void
+	 */
+	public function testArrayViewTermsAreJoinedAndMerged(): void {
+		$result = $this->makeHandler(['searchTerms' => ['alpha', 'beta']])
+			->applyViewsToQuery(['_search' => 'gamma'], [1]);
+
+		foreach (['gamma', 'alpha', 'beta'] as $term) {
+			$this->assertStringContainsString(
+				$term,
+				$result['_search'],
+				"'{$term}' must survive the merge"
+			);
+			$this->assertSame(1, substr_count($result['_search'], $term), "'{$term}' must appear once");
+		}
+
+	}//end testArrayViewTermsAreJoinedAndMerged()
+}//end class

--- a/tests/stubs/NextcloudInternalStubs.php
+++ b/tests/stubs/NextcloudInternalStubs.php
@@ -199,6 +199,14 @@ if (class_exists(\OC::class) === false) {
             public function getServerProtocol(): string { return "HTTP/1.1"; }
             public function getServerHost(): string { return "localhost"; }
             public function getInsecureServerHost(): string { return "localhost"; }
+            // Added in newer OCP (present in v34). A double that is MISSING an
+            // interface method is a FATAL -- PHP refuses to declare the class and
+            // the suite dies mid-run rather than reporting a failed assertion --
+            // whereas a double carrying a method an older OCP does not declare is
+            // simply an extra method. So these are safe on every version in the
+            // matrix, and their absence was not.
+            public function throwDecodingExceptionIfAny(): void {}
+            public function getFormat(): ?string { return null; }
         };
         return $req;
     });


### PR DESCRIPTION
Weekly refresh of the two shared Conduction packages. **Lock-only** - both are
already declared with caret ranges that permit these versions, so what this app
*accepts* is unchanged; only what it currently resolves to moves.

| package | was | now |
|---|---|---|
| conduction/hydra-gates | v1.8.1 | v1.8.2 |
| @conduction/nextcloud-vue | 2.8.2 | 2.9.2 |

**Why this is automated.** Nothing here was ever pinned on purpose. The caret
always allowed the newer release; the lockfile is what froze it, and nobody
re-resolves a lock unless they happen to be touching dependencies. Measured
across the fleet on 2026-08-20: every app sat on hydra-gates v1.8.0 while
v1.8.1 was out, and fourteen sat below nc-vue 2.7.0 - twelve of them on 2.3.0.
Neither number was a decision.

**Why it is a PR and not a push.** Because a shared bump is not always safe and
this repository's suite is what knows. Taking hydra-gates v1.8.1 added
patchObject() to a published interface, which is a load-time fatal for any
concrete test double implementing it without the method - the suite dies before
a single test runs. Two apps needed stub updates first.

**If this PR is red, fix it on this branch.** While it stays open the weekly run
skips this app entirely and will not touch your commits - it never force-pushes
and never reuses a branch.

Opened by fleet-shared-dep-bump.yml in ConductionNL/.github.
