### PR TITLE
feat(flow): object-write can write an item WHOLE via payloadFrom

### DIFF
--- a/lib/Service/Flow/Nodes/ObjectWriteNode.php
+++ b/lib/Service/Flow/Nodes/ObjectWriteNode.php
@@ -423,6 +423,7 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfig
 			'schema',
 			'operation',
 			'fields',
+			'payloadFrom',
 			'match',
 			'replace',
 			'bulk',
@@ -488,6 +489,17 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfig
 					'One of: create, update, upsert, delete. Update, upsert and delete need at least one match pair.'
 				),
 				'required' => true,
+			],
+			[
+				'key' => 'payloadFrom',
+				'label' => $this->l10n->t('Write object at path'),
+				'type' => 'text',
+				'help' => $this->l10n->t(
+					'Write the object found at this path WHOLE, instead of listing properties in "fields". '
+					. 'Use it when the properties are not known up front — a synchronization with no mapping, '
+					. 'for example. Configure this or "fields", never both.'
+				),
+				'required' => false,
 			],
 			[
 				'key' => 'bulk',
@@ -889,6 +901,7 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfig
 		$out = [];
 
 		$skipWhen = trim((string)($config['skipWhen'] ?? ''));
+		$payloadFrom = trim((string)($config['payloadFrom'] ?? ''));
 
 		foreach ($items as $index => $item) {
 			$json = (array)($item[FlowItems::JSON] ?? []);
@@ -921,7 +934,12 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfig
 				continue;
 			}
 
-			$payload = $this->buildPayload(fields: $fields, json: $json, onMissing: $onMissing);
+			$payload = $this->buildPayload(
+				fields: $fields,
+				json: $json,
+				onMissing: $onMissing,
+				payloadFrom: $payloadFrom
+			);
 			$matched = null;
 			if ($operation !== self::OP_CREATE) {
 				$matched = $this->findMatch(pairs: $pairs, json: $json, register: $register, schema: $schema, owner: $owner);
@@ -1807,12 +1825,46 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfig
 	 * @param array $fields The configured mapping.
 	 * @param array $json The item's record.
 	 * @param string $onMissing What an unresolvable value means.
+	 * @param string|null $payloadFrom Path whose resolved object IS the payload, when the
+	 *                                 properties are not known up front. Alternative to `$fields`.
 	 *
 	 * @return array The payload to write.
 	 *
 	 * @throws RuntimeException When a value is unresolvable and `onMissing` is `fail`.
 	 */
-	private function buildPayload(array $fields, array $json, string $onMissing): array {
+	private function buildPayload(
+		array $fields,
+		array $json,
+		string $onMissing,
+		?string $payloadFrom = null
+	): array {
+		// WRITING AN ITEM WHOLE. `fields` enumerates the properties to write, which
+		// requires knowing them up front — a synchronization with no mapping has no
+		// such list, and that single gap refused 98 of 99 unmigratable
+		// synchronizations measured on the dev instance. `payloadFrom` names a path
+		// whose resolved value IS the payload.
+		//
+		// An unresolvable path THROWS regardless of `onMissing`, deliberately.
+		// `onMissing: omit` is a per-field rule — it drops one property and writes
+		// the rest. There is no "rest" here: omitting a whole payload would write a
+		// BLANK object, which is the same hazard the field loop's own comment warns
+		// about, one level up.
+		if ($payloadFrom !== null && trim($payloadFrom) !== '') {
+			$found = $this->lookupPath(path: trim($payloadFrom), json: $json);
+
+			if ($found['found'] === false || is_array($found['value']) === false) {
+				throw new RuntimeException(
+					$this->l10n->t(
+						'"payloadFrom" path "%s" did not resolve to an object on this item, so there is '
+						. 'nothing to write. Writing an empty object instead would create a blank record.',
+						[trim($payloadFrom)]
+					)
+				);
+			}
+
+			return $found['value'];
+		}
+
 		$payload = [];
 
 		foreach ($fields as $key => $value) {
@@ -1925,6 +1977,7 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfig
 		// note in writeItems(): dropping it is what makes a later sweep
 		// delete it.
 		$skipWhen = trim((string)($config['skipWhen'] ?? ''));
+		$payloadFrom = trim((string)($config['payloadFrom'] ?? ''));
 
 		$rows = [];
 		$ids = [];
@@ -1936,7 +1989,12 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfig
 				continue;
 			}
 
-			$payload = $this->buildPayload(fields: $fields, json: $json, onMissing: $onMissing);
+			$payload = $this->buildPayload(
+				fields: $fields,
+				json: $json,
+				onMissing: $onMissing,
+				payloadFrom: $payloadFrom
+			);
 			$id = $this->bulkRowId(operation: $operation, pairs: $pairs, json: $json);
 			$payload['id'] = $id;
 			$rows[] = $payload;
@@ -2169,9 +2227,28 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfig
 			);
 		}
 
-		if ((array)($config['fields'] ?? []) === []) {
+		$hasFields = ((array)($config['fields'] ?? []) !== []);
+		$hasPayloadFrom = (trim((string)($config['payloadFrom'] ?? '')) !== '');
+
+		// The two are alternatives, not layers: `fields` enumerates properties,
+		// `payloadFrom` writes an object whole. Accepting both would leave the
+		// author unable to tell which one produced the record that was written.
+		if ($hasFields === true && $hasPayloadFrom === true) {
 			throw new UnexpectedValueException(
-				$this->l10n->t('An object-write step with operation "%s" needs at least one field to write.', [$operation])
+				$this->l10n->t(
+					'"fields" and "payloadFrom" are alternatives: "fields" lists the properties to write, '
+					. '"payloadFrom" writes the object at a path whole. Configure one, not both.'
+				)
+			);
+		}
+
+		if ($hasFields === false && $hasPayloadFrom === false) {
+			throw new UnexpectedValueException(
+				$this->l10n->t(
+					'An object-write step with operation "%s" needs either at least one field to write, '
+					. 'or a "payloadFrom" path naming the object to write whole.',
+					[$operation]
+				)
 			);
 		}
 
@@ -2198,6 +2275,15 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfig
 		if (array_key_exists('fields', $config) === true) {
 			throw new UnexpectedValueException(
 				$this->l10n->t('"fields" has no meaning for a delete step.')
+			);
+		}
+
+		// Same reasoning as `fields`: a delete names WHICH object goes, never what
+		// to write into it. Accepting the key would let an author believe the
+		// payload mattered.
+		if (array_key_exists('payloadFrom', $config) === true) {
+			throw new UnexpectedValueException(
+				$this->l10n->t('"payloadFrom" has no meaning for a delete step.')
 			);
 		}
 

--- a/tests/Unit/Service/Flow/ObjectWriteNodeTest.php
+++ b/tests/Unit/Service/Flow/ObjectWriteNodeTest.php
@@ -1208,6 +1208,10 @@ class ObjectWriteNodeTest extends TestCase {
 				'schema',
 				'operation',
 				'fields',
+				// `payloadFrom` writes the object at a path WHOLE, for the case where
+				// the properties are not known up front — a synchronization with no
+				// mapping. It is an alternative to `fields`, never a companion.
+				'payloadFrom',
 				'match',
 				'replace',
 				'bulk',

--- a/tests/Unit/Service/Flow/ObjectWritePayloadFromTest.php
+++ b/tests/Unit/Service/Flow/ObjectWritePayloadFromTest.php
@@ -1,0 +1,349 @@
+<?php
+
+/**
+ * WRITING AN ITEM WHOLE.
+ *
+ * `fields` enumerates the properties to write, which requires knowing them up
+ * front. A synchronization with no `sourceTargetMapping` has no such list, and
+ * that single gap is what refuses migration for most synchronizations: measured
+ * across 119 cleanly-judged synchronizations on the dev instance, 98 of the 99
+ * refusals were "sourceTargetMapping is not set".
+ *
+ * `payloadFrom` names a path whose resolved value IS the payload.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\Nodes\ObjectWriteNode;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\IAppConfig;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use UnexpectedValueException;
+
+/**
+ * Tests for object-write's whole-object payload path.
+ */
+class ObjectWritePayloadFromTest extends TestCase {
+
+	/**
+	 * @var ObjectService|MockObject
+	 */
+	private $objects;
+
+	/**
+	 * @var IUserManager|MockObject
+	 */
+	private $userManager;
+
+	/**
+	 * @var IAppConfig|MockObject
+	 */
+	private $appConfig;
+
+	/**
+	 * @var ObjectWriteNode
+	 */
+	private ObjectWriteNode $node;
+
+	/**
+	 * @var Register
+	 */
+	private Register $register;
+
+	/**
+	 * @var Schema
+	 */
+	private Schema $schema;
+
+	/**
+	 * @var array<string, mixed>
+	 */
+	private array $registerContext;
+
+	/**
+	 * Set up the node with mocked collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->objects = $this->createMock(ObjectService::class);
+		// `runAs()` scopes the acting user around a read. The double must RUN the
+		// callable, or every lookup silently returns null.
+		$this->objects->method('runAs')->willReturnCallback(
+			static fn (IUser $user, callable $operation) => $operation()
+		);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('admin');
+		$this->userManager->method('get')->willReturn($user);
+		$this->userManager->method('search')->willReturn([$user]);
+
+		$this->register = new Register();
+		$this->register->setId(1);
+		$this->register->setSlug('example-hydra-cache');
+
+		$this->schema = new Schema();
+		$this->schema->setId(2);
+		$this->schema->setSlug('example-cache-entry');
+
+		$registers = $this->createMock(RegisterMapper::class);
+		$registers->method('find')->willReturn($this->register);
+		$schemas = $this->createMock(SchemaMapper::class);
+		// Slug resolution goes through findBySlugInIds(); without it the register
+		// reports "carries no schemas at all" and nothing under test is reached.
+		$schemas->method('findBySlugInIds')->willReturn($this->schema);
+		$schemas->method('find')->willReturn($this->schema);
+
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnCallback(
+			static function (string $text, array $parameters = []): string {
+				if ($parameters === []) {
+					return $text;
+				}
+
+				return vsprintf($text, $parameters);
+			}
+		);
+
+		$urls = $this->createMock(IURLGenerator::class);
+		$urls->method('imagePath')->willReturnCallback(
+			static fn (string $app, string $file): string => '/' . $app . '/img/' . $file
+		);
+
+		$this->node = new ObjectWriteNode(
+			$this->objects,
+			$registers,
+			$schemas,
+			$this->userManager,
+			$this->appConfig,
+			$l10n,
+			$urls
+		);
+
+		$this->registerContext = ['triggeredBy' => 'admin'];
+
+	}//end setUp()
+
+	/**
+	 * Wrap records as flow items.
+	 *
+	 * @param array<int, array<string, mixed>> $records The item records.
+	 *
+	 * @return array<int, array<string, mixed>> The items.
+	 */
+	private function items(array $records): array {
+		return array_map(static fn (array $r): array => FlowItems::item(json: $r), $records);
+	}//end items()
+
+	/**
+	 * Build a config for a whole-object write.
+	 *
+	 * @param array $overrides Config overrides.
+	 *
+	 * @return array The config.
+	 */
+	private function config(array $overrides = []): array {
+		return array_merge(
+			[
+				'register' => 'example-hydra-cache',
+				'schema' => 'example-cache-entry',
+				'operation' => ObjectWriteNode::OP_CREATE,
+				'payloadFrom' => 'source',
+			],
+			$overrides
+		);
+
+	}//end config()
+
+	/**
+	 * Build a saved entity.
+	 *
+	 * @param string $uuid The uuid.
+	 * @param array  $data The object data.
+	 *
+	 * @return ObjectEntity The entity.
+	 */
+	private function entity(string $uuid, array $data = []): ObjectEntity {
+		$entity = new ObjectEntity();
+		$entity->setUuid($uuid);
+		$entity->setObject($data);
+
+		return $entity;
+	}//end entity()
+
+	/**
+	 * THE POINT OF THE FEATURE. The object at the path is written whole, with every
+	 * property it carries — no `fields` list, nothing enumerated up front.
+	 *
+	 * @return void
+	 */
+	public function testWritesTheObjectAtThePathWhole(): void {
+		$seen = null;
+		$this->objects->method('saveObject')->willReturnCallback(
+			function (mixed $object, ?array $extend = [], mixed $register = null, mixed $schema = null, ?string $uuid = null, bool $_rbac = true, bool $_multitenancy = true, bool $silent = false, bool $_validation = true, ?array $uploadedFiles = null, ?IUser $currentUser = null) use (&$seen): ObjectEntity {
+				$seen = $object;
+
+				return $this->entity('uuid-1', (array)$object);
+			}
+		);
+
+		$this->node->execute(
+			$this->items([['source' => ['name' => 'a', 'title' => 'A', 'nested' => ['x' => 1]]]]),
+			$this->config(),
+			$this->registerContext
+		);
+
+		$this->assertSame(
+			['name' => 'a', 'title' => 'A', 'nested' => ['x' => 1]],
+			$seen,
+			'every property of the object at the path is written, including nested structure'
+		);
+	}//end testWritesTheObjectAtThePathWhole()
+
+	/**
+	 * A path that resolves to nothing THROWS rather than writing an empty object.
+	 * `onMissing: omit` is a per-field rule — it drops one property and writes the
+	 * rest. There is no "rest" for a whole payload, so omitting would create a
+	 * blank record.
+	 *
+	 * @return void
+	 */
+	public function testAnUnresolvablePathThrowsRatherThanWritingBlank(): void {
+		$this->objects->expects($this->never())->method('saveObject');
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/payloadFrom/');
+
+		$this->node->execute(
+			$this->items([['somethingElse' => ['name' => 'a']]]),
+			$this->config(),
+			$this->registerContext
+		);
+	}//end testAnUnresolvablePathThrowsRatherThanWritingBlank()
+
+	/**
+	 * ...and the same when the path resolves to a scalar rather than an object.
+	 * A string is not a record.
+	 *
+	 * @return void
+	 */
+	public function testAScalarAtThePathThrows(): void {
+		$this->objects->expects($this->never())->method('saveObject');
+
+		$this->expectException(RuntimeException::class);
+
+		$this->node->execute(
+			$this->items([['source' => 'not-an-object']]),
+			$this->config(),
+			$this->registerContext
+		);
+	}//end testAScalarAtThePathThrows()
+
+	/**
+	 * `fields` and `payloadFrom` are alternatives. Accepting both would leave the
+	 * author unable to tell which produced the record.
+	 *
+	 * @return void
+	 */
+	public function testFieldsAndPayloadFromTogetherAreRefused(): void {
+		$this->expectException(UnexpectedValueException::class);
+		$this->expectExceptionMessageMatches('/alternatives/');
+
+		$this->node->execute(
+			$this->items([['source' => ['name' => 'a']]]),
+			$this->config(['fields' => ['title' => '{{source.name}}']]),
+			$this->registerContext
+		);
+	}//end testFieldsAndPayloadFromTogetherAreRefused()
+
+	/**
+	 * Neither one configured is still refused — that guard existed for `fields`
+	 * alone and must not have been widened into accepting nothing.
+	 *
+	 * @return void
+	 */
+	public function testNeitherFieldsNorPayloadFromIsRefused(): void {
+		$config = $this->config();
+		unset($config['payloadFrom']);
+
+		$this->expectException(UnexpectedValueException::class);
+
+		$this->node->execute(
+			$this->items([['source' => ['name' => 'a']]]),
+			$config,
+			$this->registerContext
+		);
+	}//end testNeitherFieldsNorPayloadFromIsRefused()
+
+	/**
+	 * A delete names WHICH object goes, never what to write into it.
+	 *
+	 * @return void
+	 */
+	public function testPayloadFromIsMeaninglessForADelete(): void {
+		$this->expectException(UnexpectedValueException::class);
+		$this->expectExceptionMessageMatches('/payloadFrom/');
+
+		$this->node->execute(
+			$this->items([['source' => ['name' => 'a']]]),
+			$this->config(
+				[
+					'operation' => ObjectWriteNode::OP_DELETE,
+					'match' => [['property' => 'name', 'value' => '{{source.name}}']],
+					'confirmDelete' => true,
+				]
+			),
+			$this->registerContext
+		);
+	}//end testPayloadFromIsMeaninglessForADelete()
+
+	/**
+	 * The key is accepted by the preflight vocabulary. A node that reads a key it
+	 * does not declare is a step whose config is silently ignored — the failure
+	 * mode the preflight exists to catch.
+	 *
+	 * @return void
+	 */
+	public function testPayloadFromIsADeclaredConfigKey(): void {
+		$this->assertContains('payloadFrom', $this->node->configKeys());
+	}//end testPayloadFromIsADeclaredConfigKey()
+
+	/**
+	 * ...and is offered in the editor, since unlike `fields` it is a flat path.
+	 *
+	 * @return void
+	 */
+	public function testPayloadFromIsOfferedInTheConfigForm(): void {
+		$keys = array_column($this->node->configForm(), 'key');
+
+		$this->assertContains('payloadFrom', $keys);
+	}//end testPayloadFromIsOfferedInTheConfigForm()
+}//end class


### PR DESCRIPTION
Unblocks the single largest barrier to migrating synchronizations onto flows.

## The measurement that motivated it

I ran the flow generator against every synchronization on the dev instance. Of **119 cleanly-judged** synchronizations, **20 accepted / 99 refused** — and **98 of those 99 refusals were the same one line**:

> `sourceTargetMapping is not set: with no mapping the written properties cannot be enumerated, and "openregister.object-write" has no shorthand for writing an item whole.`

The refusal text named its own cause. This adds the shorthand.

## What it does

`payloadFrom` names a path whose resolved value **is** the payload:

```json
{ "type": "openregister.object-write",
  "config": { "register": "…", "schema": "…", "operation": "upsert",
              "payloadFrom": "source" } }
```

## Three decisions worth reviewing

**An unresolvable path THROWS, regardless of `onMissing`.** `onMissing: omit` is a *per-field* rule — it drops one property and writes the rest. There is no "rest" for a whole payload, so omitting would write a **blank record**. That's the same hazard the field loop's own comment already warns about, one level up. A scalar at the path throws for the same reason: a string is not a record.

**`fields` and `payloadFrom` are alternatives, not layers.** Configuring both is refused — otherwise an author can't tell which produced the record. Configuring *neither* is still refused, so widening the old "needs at least one field" guard has **not** become "accepts nothing".

**It's offered in the editor.** Unlike `fields` (a structured value the config form deliberately omits), this is a flat path.

`payloadFrom` is meaningless for a delete, like `fields`, and refused there too.

## Verification

- **8 new tests**, with the control being those tests against the reverted node: **6 of 8 fail** without the feature.
- The existing vocabulary pin `testTheConfigVocabularyIsPinnedWithBulk` **caught the new key** — updated deliberately rather than loosened. That pin doing its job is why it exists.
- Full flow suite **592 tests green**.
- phpcs back to base parity (0 errors, 1 pre-existing warning); phpstan clean; **phpmd byte-identical to base** (7 pre-existing `StaticAccess` findings, exit 2 on both — I compared rather than assumed, after catching that my first "exit=0" was `$?` reading a pipe).
- gate-16 0, gate-46 clean at the `origin/beta` merge scope.

## Sequencing — please merge and deploy this BEFORE the openconnector side

openconnector's generator will emit `payloadFrom`, and preflight **refuses** a flow whose config keys the deployed node doesn't read. That's precisely what blocked task 2.2 when `skipWhen` was ahead of the box. openregister first, then openconnector.