### PR TITLE
feat(lifecycle): accept declared transition inputs on the transition endpoint

### DIFF
--- a/lib/Controller/TransitionController.php
+++ b/lib/Controller/TransitionController.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Controller;
 
 use OCA\OpenRegister\Exception\HookStoppedException;
+use OCA\OpenRegister\Exception\InvalidTransitionInputException;
 use OCA\OpenRegister\Exception\NotAuthorizedException;
 use OCA\OpenRegister\Service\Lifecycle\TransitionEngine;
 use OCP\AppFramework\Controller;
@@ -58,6 +59,10 @@ class TransitionController extends Controller {
 	 * the same endpoint covers every transition declared on the schema —
 	 * apps don't need a route per action.
 	 *
+	 * An optional `data` object carries input values for the transition's
+	 * declared `inputs` (see the engine); an undeclared key, a missing
+	 * required input, or a non-object `data` value is a 400.
+	 *
 	 * @param string $id Object id/uuid/slug.
 	 *
 	 * @return JSONResponse JSON response with the transitioned object or an error.
@@ -67,6 +72,7 @@ class TransitionController extends Controller {
 	 * @NoCSRFRequired
 	 *
 	 * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-misc/tasks.md#task-6
+	 * @spec openspec/specs/object-lifecycle/spec.md
 	 */
 	public function transition(string $id): JSONResponse {
 		$action = (string)($this->request->getParam('action') ?? '');
@@ -77,8 +83,28 @@ class TransitionController extends Controller {
 			);
 		}
 
+		$data = $this->request->getParam('data') ?? [];
+		if (is_array($data) === false) {
+			return new JSONResponse(
+				['error' => 'Field "data" must be an object of input values.'],
+				Http::STATUS_BAD_REQUEST
+			);
+		}
+
 		try {
-			$object = $this->engine->transition(objectId: $id, action: $action);
+			$object = $this->engine->transition(objectId: $id, action: $action, data: $data);
+		} catch (InvalidTransitionInputException $e) {
+			// The payload violates the transition's declared `inputs`
+			// allowlist (undeclared key, or missing required input). The
+			// request itself is malformed → 400, with the offending field
+			// names machine-readable next to the human message.
+			return new JSONResponse(
+				[
+					'error' => $e->getMessage(),
+					'fields' => $e->getFields(),
+				],
+				Http::STATUS_BAD_REQUEST
+			);
 		} catch (NotAuthorizedException $e) {
 			// Caller lacks `update` permission on the object. Surface
 			// as 403 so clients can distinguish "not allowed" from

--- a/lib/Exception/InvalidTransitionInputException.php
+++ b/lib/Exception/InvalidTransitionInputException.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * OpenRegister InvalidTransitionInputException
+ *
+ * Exception thrown when the `data` payload of a lifecycle transition
+ * does not satisfy the transition's declared `inputs` contract.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Exception
+ * @package  OCA\OpenRegister\Exception
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+namespace OCA\OpenRegister\Exception;
+
+use Exception;
+use Throwable;
+
+/**
+ * Exception thrown when transition input data violates the declared `inputs` allowlist.
+ *
+ * Raised for keys that are not declared on the transition, and for declared
+ * `required` inputs that are absent (or empty-string) from the payload. Maps
+ * to HTTP 400 in the TransitionController: the request itself is malformed,
+ * as opposed to a transition that is refused (422) or unauthorized (403).
+ */
+class InvalidTransitionInputException extends Exception {
+
+	/**
+	 * The offending field names (unknown keys, or missing required inputs).
+	 *
+	 * @var array<int, string>
+	 */
+	private readonly array $fields;
+
+	/**
+	 * Constructor for InvalidTransitionInputException
+	 *
+	 * @param string $message Error message naming the offending field(s)
+	 * @param array<int, string> $fields Offending field names
+	 * @param int $code Error code
+	 * @param Throwable|null $previous Previous exception
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		string $message = 'Invalid transition input data',
+		array $fields = [],
+		int $code = 0,
+		?Throwable $previous = null,
+	) {
+		$this->fields = $fields;
+		parent::__construct(message: $message, code: $code, previous: $previous);
+	}//end __construct()
+
+	/**
+	 * Get the offending field names
+	 *
+	 * @return array<int, string>
+	 */
+	public function getFields(): array {
+		return $this->fields;
+	}//end getFields()
+}//end class

--- a/lib/Service/Lifecycle/TransitionEngine.php
+++ b/lib/Service/Lifecycle/TransitionEngine.php
@@ -33,6 +33,7 @@ use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Event\ObjectTransitionedEvent;
+use OCA\OpenRegister\Exception\InvalidTransitionInputException;
 use OCA\OpenRegister\Exception\NotAuthorizedException;
 use OCA\OpenRegister\Service\Object\PermissionHandler;
 use OCA\OpenRegister\Service\ObjectService;
@@ -229,21 +230,31 @@ class TransitionEngine {
 	/**
 	 * Apply a named transition to an object.
 	 *
+	 * When the transition declares `inputs`, the (optional) `$data` payload is
+	 * validated against that allowlist and the accepted values are merged into
+	 * the SAME write that flips the lifecycle field — so pre-save listeners
+	 * (ObjectUpdatingEvent) observe the status change and the inputs together,
+	 * and the normal schema validation / readOnly enforcement applies to them.
+	 *
 	 * @param string $objectId Object id/uuid/slug.
 	 * @param string $action Transition action name.
+	 * @param array<string, mixed> $data Optional input values for the transition's declared `inputs`.
 	 *
 	 * @return ObjectEntity The saved object after the transition.
 	 *
 	 * @throws RuntimeException When the object/schema/transition is missing,
 	 *                          the action is not allowed from the current
 	 *                          state, or the underlying save is rejected.
+	 * @throws InvalidTransitionInputException When `$data` contains a key the
+	 *                          transition does not declare, or a `required`
+	 *                          input is absent or empty-string.
 	 *
 	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Linear resolve→guard→mutate→save flow; splitting would obscure the transition contract.
 	 *
 	 * @spec openspec/specs/object-lifecycle/spec.md
 	 * @spec openspec/changes/fk-graph-lifecycle-transitions/specs/object-lifecycle/spec.md
 	 */
-	public function transition(string $objectId, string $action): ObjectEntity {
+	public function transition(string $objectId, string $action, array $data = []): ObjectEntity {
 		$object = $this->objectService->find(id: $objectId);
 		if ($object === null) {
 			throw new RuntimeException(sprintf('Object "%s" not found.', $objectId));
@@ -301,7 +312,8 @@ class TransitionEngine {
 					object: $object,
 					graph: $graph,
 					field: $field,
-					action: $action
+					action: $action,
+					data: $data
 				);
 			}
 		}
@@ -316,8 +328,8 @@ class TransitionEngine {
 		$targetState = (string)($spec['to'] ?? '');
 		$from = (array)($spec['from'] ?? []);
 
-		$data = $object->getObject() ?? [];
-		$currentValue = (string)($data[$field] ?? '');
+		$objectData = $object->getObject() ?? [];
+		$currentValue = (string)($objectData[$field] ?? '');
 
 		if (in_array($currentValue, $from, true) === false) {
 			throw new RuntimeException(
@@ -329,9 +341,19 @@ class TransitionEngine {
 			);
 		}
 
+		// Validate the payload against the transition's `inputs` allowlist and
+		// merge the accepted values BEFORE flipping the lifecycle field, so the
+		// status write always wins and both land in the same save.
+		$accepted = $this->resolveTransitionInputs(
+			inputs: (array)($spec['inputs'] ?? []),
+			data: $data,
+			action: $action
+		);
+		$objectData = array_merge($objectData, $accepted);
+
 		// Mutate the lifecycle field. The validator listener will re-check
 		// the transition on save; the guard (if any) will run there too.
-		$data[$field] = $targetState;
+		$objectData[$field] = $targetState;
 
 		// Snapshot the session user at the transition boundary and forward it
 		// explicitly to the save path, so the @self.folder check uses the SAME
@@ -341,7 +363,7 @@ class TransitionEngine {
 		$actingUser = $this->userSession->getUser();
 
 		$saved = $this->objectService->saveObject(
-			object: $data,
+			object: $objectData,
 			register: $object->getRegister(),
 			schema: $object->getSchema(),
 			uuid: $object->getUuid(),
@@ -650,6 +672,104 @@ class TransitionEngine {
 	}//end buildGraphAction()
 
 	/**
+	 * Validate a transition `data` payload against the declared `inputs` allowlist.
+	 *
+	 * A transition may declare `inputs: [{"field": "<propertyName>", "required": true|false}, ...]`
+	 * on its `x-openregister-lifecycle.transitions.<action>` block. Only declared
+	 * fields are accepted from the payload; anything else is rejected — a
+	 * transition with no `inputs` therefore rejects ANY payload, keeping today's
+	 * behaviour for schemas that never opted in. The accepted values are NOT
+	 * validated here against the property definitions: they are merged into the
+	 * carrying object write, so the standard save-path validation (and readOnly
+	 * enforcement) applies to them exactly like any other object write.
+	 *
+	 * @param array<int, mixed> $inputs The transition's declared `inputs` list.
+	 * @param array<string, mixed> $data The caller-supplied payload.
+	 * @param string $action The transition action name, for error messages.
+	 *
+	 * @return array<string, mixed> The accepted field => value pairs to merge into the write.
+	 *
+	 * @throws InvalidTransitionInputException When `$data` contains an undeclared
+	 *                          key, or a `required` input is absent or empty-string.
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	private function resolveTransitionInputs(array $inputs, array $data, string $action): array {
+		$declared = $this->normaliseDeclaredInputs(inputs: $inputs);
+
+		// Reject any payload key the transition does not declare.
+		$unknown = array_diff(array_keys($data), array_keys($declared));
+		if ($unknown !== []) {
+			$unknown = array_values(array_map('strval', $unknown));
+			throw new InvalidTransitionInputException(
+				message: sprintf(
+					'Transition "%s" does not accept input field(s): %s.',
+					$action,
+					'"'.implode('", "', $unknown).'"'
+				),
+				fields: $unknown
+			);
+		}
+
+		// Reject when a required input is absent or empty-string.
+		$missing = [];
+		foreach ($declared as $fieldName => $required) {
+			if ($required === false) {
+				continue;
+			}
+
+			if (array_key_exists($fieldName, $data) === false || $data[$fieldName] === '') {
+				$missing[] = $fieldName;
+			}
+		}
+
+		if ($missing !== []) {
+			throw new InvalidTransitionInputException(
+				message: sprintf(
+					'Transition "%s" is missing required input field(s): %s.',
+					$action,
+					'"'.implode('", "', $missing).'"'
+				),
+				fields: $missing
+			);
+		}
+
+		// Everything present is declared — merge it all.
+		return $data;
+	}//end resolveTransitionInputs()
+
+	/**
+	 * Normalise a transition's `inputs` declaration into fieldName => required.
+	 *
+	 * Malformed entries (non-arrays, or entries without a `field` name) are
+	 * skipped rather than fatal: a broken declaration must not take the whole
+	 * transition down, it simply allowlists nothing.
+	 *
+	 * @param array<int, mixed> $inputs The transition's declared `inputs` list.
+	 *
+	 * @return array<string, bool> Map of declared field name to its `required` flag.
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	private function normaliseDeclaredInputs(array $inputs): array {
+		$declared = [];
+		foreach ($inputs as $input) {
+			if (is_array($input) === false) {
+				continue;
+			}
+
+			$fieldName = (string)($input['field'] ?? '');
+			if ($fieldName === '') {
+				continue;
+			}
+
+			$declared[$fieldName] = (bool)($input['required'] ?? false);
+		}
+
+		return $declared;
+	}//end normaliseDeclaredInputs()
+
+	/**
 	 * Apply a graph-mode transition.
 	 *
 	 * Re-runs the SAME derivation as `availableActions()`, accepts the posted
@@ -661,10 +781,13 @@ class TransitionEngine {
 	 * @param array<string, mixed> $graph The `graph` block off the annotation.
 	 * @param string $field The lifecycle field name on the object.
 	 * @param string $action The requested `move-to-<uuid>` action.
+	 * @param array<string, mixed> $data Caller-supplied input payload; graph-derived
+	 *                                   actions declare no `inputs`, so any payload is rejected.
 	 *
 	 * @return ObjectEntity The saved object after the transition.
 	 *
 	 * @throws RuntimeException When the action is not a current candidate.
+	 * @throws InvalidTransitionInputException When `$data` is non-empty.
 	 *
 	 * @spec openspec/changes/fk-graph-lifecycle-transitions/specs/object-lifecycle/spec.md
 	 */
@@ -673,7 +796,13 @@ class TransitionEngine {
 		array $graph,
 		string $field,
 		string $action,
+		array $data = [],
 	): ObjectEntity {
+		// Graph-derived actions carry no `inputs` declaration, so nothing is
+		// allowlisted: a non-empty payload is rejected just like an undeclared
+		// key on a static transition.
+		$this->resolveTransitionInputs(inputs: [], data: $data, action: $action);
+
 		$candidates = $this->deriveGraphActions(object: $object, graph: $graph, field: $field);
 
 		$match = null;
@@ -691,17 +820,17 @@ class TransitionEngine {
 		}
 
 		$targetState = (string)$match['to'];
-		$data = $object->getObject() ?? [];
-		$from = (string)($data[$field] ?? '');
+		$objectData = $object->getObject() ?? [];
+		$from = (string)($objectData[$field] ?? '');
 
-		$data[$field] = $targetState;
+		$objectData[$field] = $targetState;
 
 		// Snapshot the session user at the transition boundary and forward it
 		// explicitly to the save path, mirroring the static-mode contract.
 		$actingUser = $this->userSession->getUser();
 
 		$saved = $this->objectService->saveObject(
-			object: $data,
+			object: $objectData,
 			register: $object->getRegister(),
 			schema: $object->getSchema(),
 			uuid: $object->getUuid(),

--- a/tests/Unit/Controller/TransitionControllerTest.php
+++ b/tests/Unit/Controller/TransitionControllerTest.php
@@ -25,6 +25,7 @@ namespace Unit\Controller;
 
 use OCA\OpenRegister\Controller\TransitionController;
 use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Exception\InvalidTransitionInputException;
 use OCA\OpenRegister\Exception\NotAuthorizedException;
 use OCA\OpenRegister\Service\Lifecycle\TransitionEngine;
 use OCP\AppFramework\Http;
@@ -58,12 +59,27 @@ class TransitionControllerTest extends TestCase {
 	}//end setUp()
 
 	/**
+	 * Stub the request body params (the controller reads `action` and `data`).
+	 *
+	 * @param array<string, mixed> $params Body params by name.
+	 *
+	 * @return void
+	 */
+	private function stubParams(array $params): void {
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key) use ($params) {
+				return $params[$key] ?? null;
+			}
+		);
+	}//end stubParams()
+
+	/**
 	 * Happy path — engine returns the saved object, controller returns 200.
 	 *
 	 * @return void
 	 */
 	public function testTransitionReturnsOk(): void {
-		$this->request->method('getParam')->with('action')->willReturn('open');
+		$this->stubParams(['action' => 'open']);
 		$object = $this->createMock(ObjectEntity::class);
 		$object->method('jsonSerialize')->willReturn(['uuid' => 'u-1', 'state' => 'open']);
 		$this->engine->method('transition')->willReturn($object);
@@ -79,7 +95,7 @@ class TransitionControllerTest extends TestCase {
 	 * @return void
 	 */
 	public function testTransitionReturns400WhenActionMissing(): void {
-		$this->request->method('getParam')->with('action')->willReturn(null);
+		$this->stubParams([]);
 
 		$response = $this->controller->transition('obj-1');
 
@@ -92,7 +108,7 @@ class TransitionControllerTest extends TestCase {
 	 * @return void
 	 */
 	public function testTransitionReturnsForbiddenOnPermissionDenied(): void {
-		$this->request->method('getParam')->with('action')->willReturn('open');
+		$this->stubParams(['action' => 'open']);
 		$this->engine->method('transition')->willThrowException(
 			new NotAuthorizedException(message: 'You do not have permission to transition object "obj-1".')
 		);
@@ -114,7 +130,7 @@ class TransitionControllerTest extends TestCase {
 	 * @return void
 	 */
 	public function testTransitionReturns422OnRuntimeError(): void {
-		$this->request->method('getParam')->with('action')->willReturn('open');
+		$this->stubParams(['action' => 'open']);
 		$this->engine->method('transition')->willThrowException(
 			new RuntimeException('Transition "open" is not allowed from current state "closed".')
 		);
@@ -123,6 +139,68 @@ class TransitionControllerTest extends TestCase {
 
 		$this->assertSame(Http::STATUS_UNPROCESSABLE_ENTITY, $response->getStatus());
 	}//end testTransitionReturns422OnRuntimeError()
+
+	/**
+	 * The optional `data` body param is forwarded to the engine untouched.
+	 *
+	 * @return void
+	 */
+	public function testTransitionForwardsDataToEngine(): void {
+		$this->stubParams(['action' => 'submit', 'data' => ['hours' => 8]]);
+		$object = $this->createMock(ObjectEntity::class);
+		$object->method('jsonSerialize')->willReturn(['uuid' => 'u-1']);
+		$this->engine->expects($this->once())
+			->method('transition')
+			->with('obj-1', 'submit', ['hours' => 8])
+			->willReturn($object);
+
+		$response = $this->controller->transition('obj-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}//end testTransitionForwardsDataToEngine()
+
+	/**
+	 * A `data` value that is not an object/array is a client error, rejected
+	 * before the engine is ever consulted.
+	 *
+	 * @return void
+	 */
+	public function testTransitionReturns400WhenDataIsNotAnObject(): void {
+		$this->stubParams(['action' => 'submit', 'data' => 'not-an-object']);
+		$this->engine->expects($this->never())->method('transition');
+
+		$response = $this->controller->transition('obj-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+	}//end testTransitionReturns400WhenDataIsNotAnObject()
+
+	/**
+	 * Engine rejecting the payload against the transition's `inputs`
+	 * allowlist maps to 400 with the offending fields machine-readable,
+	 * distinct from the 422 used for a refused transition.
+	 *
+	 * @return void
+	 */
+	public function testTransitionReturns400OnInvalidTransitionInput(): void {
+		$this->stubParams(['action' => 'submit', 'data' => ['bogus' => 1]]);
+		$this->engine->method('transition')->willThrowException(
+			new InvalidTransitionInputException(
+				message: 'Transition "submit" does not accept input field(s): "bogus".',
+				fields: ['bogus']
+			)
+		);
+
+		$response = $this->controller->transition('obj-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$body = $response->getData();
+		$this->assertIsArray($body);
+		$this->assertSame(
+			'Transition "submit" does not accept input field(s): "bogus".',
+			$body['error'] ?? null
+		);
+		$this->assertSame(['bogus'], $body['fields'] ?? null);
+	}//end testTransitionReturns400OnInvalidTransitionInput()
 
 	/**
 	 * R08 / F03 contract: availableActions also surfaces 403 on denial.

--- a/tests/Unit/Service/Lifecycle/TransitionEngineInputsTest.php
+++ b/tests/Unit/Service/Lifecycle/TransitionEngineInputsTest.php
@@ -1,0 +1,393 @@
+<?php
+
+/**
+ * OpenRegister TransitionEngine transition-inputs tests
+ *
+ * Covers the `inputs` allowlist on static lifecycle transitions: declared
+ * values merge into the SAME write that flips the status field, undeclared
+ * payload keys are rejected, required inputs missing (or empty-string) are
+ * rejected, a transition without `inputs` rejects any payload (today's exact
+ * behaviour preserved), and graph-mode transitions reject payloads outright.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Lifecycle
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Lifecycle;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Exception\InvalidTransitionInputException;
+use OCA\OpenRegister\Service\Lifecycle\TransitionEngine;
+use OCA\OpenRegister\Service\Object\PermissionHandler;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IAppConfig;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @coversDefaultClass \OCA\OpenRegister\Service\Lifecycle\TransitionEngine
+ */
+class TransitionEngineInputsTest extends TestCase {
+	private const OBJ = '00000000-0000-0000-0000-0000000000ee';
+
+	private ObjectService&MockObject $objectService;
+
+	private SchemaMapper&MockObject $schemaMapper;
+
+	private IEventDispatcher&MockObject $dispatcher;
+
+	private IUserSession&MockObject $userSession;
+
+	private PermissionHandler&MockObject $permission;
+
+	private RegisterMapper&MockObject $registerMapper;
+
+	private IAppConfig&MockObject $appConfig;
+
+	private LoggerInterface&MockObject $logger;
+
+	private TransitionEngine $engine;
+
+	protected function setUp(): void {
+		$this->objectService = $this->createMock(ObjectService::class);
+		$this->schemaMapper = $this->createMock(SchemaMapper::class);
+		$this->dispatcher = $this->createMock(IEventDispatcher::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->permission = $this->createMock(PermissionHandler::class);
+		$this->permission->method('hasPermission')->willReturn(true);
+		$this->registerMapper = $this->createMock(RegisterMapper::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		// The slug contract ships DEFAULT OFF; pin the flag to its default.
+		$this->appConfig->method('getValueString')
+			->willReturnCallback(
+				static function (string $app, string $key, string $default = '') {
+					return $default;
+				}
+			);
+
+		$this->engine = new TransitionEngine(
+			$this->objectService,
+			$this->schemaMapper,
+			$this->dispatcher,
+			$this->userSession,
+			$this->permission,
+			$this->registerMapper,
+			$this->appConfig,
+			$this->logger
+		);
+	}//end setUp()
+
+	/**
+	 * Build the timesheet object in `draft` state.
+	 */
+	private function timesheet(): ObjectEntity {
+		$entity = new ObjectEntity();
+		$entity->setUuid(self::OBJ);
+		$entity->setSchema('timesheet');
+		$entity->setRegister('1');
+		$entity->setObject(['status' => 'draft', 'employee' => 'e-1']);
+		return $entity;
+	}//end timesheet()
+
+	/**
+	 * Static annotation with a single `submit` transition.
+	 *
+	 * @param array<int, array<string, mixed>>|null $inputs The `inputs` list, or null to omit the key.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function annotation(?array $inputs = null): array {
+		$transition = [
+			'from' => ['draft'],
+			'to' => 'submitted',
+		];
+		if ($inputs !== null) {
+			$transition['inputs'] = $inputs;
+		}
+
+		return [
+			'field' => 'status',
+			'transitions' => ['submit' => $transition],
+		];
+	}//end annotation()
+
+	/**
+	 * Wire find()/schema for the given object + annotation.
+	 */
+	private function wire(ObjectEntity $object, array $annotation): void {
+		$this->objectService->method('find')->willReturn($object);
+		$schema = $this->createMock(Schema::class);
+		$schema->method('getConfiguration')->willReturn(['x-openregister-lifecycle' => $annotation]);
+		$this->schemaMapper->method('find')->willReturn($schema);
+	}//end wire()
+
+	/**
+	 * Declared input values land in the SAME saveObject() write that flips
+	 * the status field — one write, observed together by pre-save listeners.
+	 *
+	 * @return void
+	 */
+	public function testDeclaredInputsMergeIntoTheSameWrite(): void {
+		$this->wire(
+			$this->timesheet(),
+			$this->annotation(
+				[
+					['field' => 'hours', 'required' => true],
+					['field' => 'note', 'required' => false],
+				]
+			)
+		);
+
+		$captured = null;
+		$this->objectService->expects($this->once())
+			->method('saveObject')
+			->willReturnCallback(
+				function (array $object) use (&$captured): ObjectEntity {
+					$captured = $object;
+					return $this->timesheet();
+				}
+			);
+
+		$this->engine->transition(self::OBJ, 'submit', ['hours' => 8, 'note' => 'week 33']);
+
+		$this->assertIsArray($captured);
+		$this->assertSame('submitted', $captured['status']);
+		$this->assertSame(8, $captured['hours']);
+		$this->assertSame('week 33', $captured['note']);
+		// Untouched existing fields survive the merge.
+		$this->assertSame('e-1', $captured['employee']);
+	}//end testDeclaredInputsMergeIntoTheSameWrite()
+
+	/**
+	 * An optional (`required: false`) input may be omitted from the payload.
+	 *
+	 * @return void
+	 */
+	public function testOptionalInputMayBeOmitted(): void {
+		$this->wire(
+			$this->timesheet(),
+			$this->annotation(
+				[
+					['field' => 'hours', 'required' => true],
+					['field' => 'note', 'required' => false],
+				]
+			)
+		);
+
+		$captured = null;
+		$this->objectService->expects($this->once())
+			->method('saveObject')
+			->willReturnCallback(
+				function (array $object) use (&$captured): ObjectEntity {
+					$captured = $object;
+					return $this->timesheet();
+				}
+			);
+
+		$this->engine->transition(self::OBJ, 'submit', ['hours' => 8]);
+
+		$this->assertIsArray($captured);
+		$this->assertSame('submitted', $captured['status']);
+		$this->assertSame(8, $captured['hours']);
+		$this->assertArrayNotHasKey('note', $captured);
+	}//end testOptionalInputMayBeOmitted()
+
+	/**
+	 * A payload key the transition does not declare is rejected with the
+	 * offending key named, and nothing is saved or dispatched.
+	 *
+	 * @return void
+	 */
+	public function testUnknownKeyIsRejectedAndNothingSaved(): void {
+		$this->wire(
+			$this->timesheet(),
+			$this->annotation([['field' => 'hours', 'required' => true]])
+		);
+
+		$this->objectService->expects($this->never())->method('saveObject');
+		$this->dispatcher->expects($this->never())->method('dispatchTyped');
+
+		try {
+			$this->engine->transition(self::OBJ, 'submit', ['hours' => 8, 'salary' => 99999]);
+			$this->fail('Expected InvalidTransitionInputException was not thrown.');
+		} catch (InvalidTransitionInputException $e) {
+			$this->assertStringContainsString('"salary"', $e->getMessage());
+			$this->assertSame(['salary'], $e->getFields());
+		}
+	}//end testUnknownKeyIsRejectedAndNothingSaved()
+
+	/**
+	 * A `required: true` input absent from the payload is rejected with the
+	 * missing field named, and nothing is saved.
+	 *
+	 * @return void
+	 */
+	public function testMissingRequiredInputIsRejected(): void {
+		$this->wire(
+			$this->timesheet(),
+			$this->annotation([['field' => 'hours', 'required' => true]])
+		);
+
+		$this->objectService->expects($this->never())->method('saveObject');
+
+		try {
+			$this->engine->transition(self::OBJ, 'submit', []);
+			$this->fail('Expected InvalidTransitionInputException was not thrown.');
+		} catch (InvalidTransitionInputException $e) {
+			$this->assertStringContainsString('"hours"', $e->getMessage());
+			$this->assertSame(['hours'], $e->getFields());
+		}
+	}//end testMissingRequiredInputIsRejected()
+
+	/**
+	 * An empty-string value for a `required: true` input counts as missing.
+	 *
+	 * @return void
+	 */
+	public function testEmptyStringRequiredInputIsRejected(): void {
+		$this->wire(
+			$this->timesheet(),
+			$this->annotation([['field' => 'hours', 'required' => true]])
+		);
+
+		$this->objectService->expects($this->never())->method('saveObject');
+
+		try {
+			$this->engine->transition(self::OBJ, 'submit', ['hours' => '']);
+			$this->fail('Expected InvalidTransitionInputException was not thrown.');
+		} catch (InvalidTransitionInputException $e) {
+			$this->assertSame(['hours'], $e->getFields());
+		}
+	}//end testEmptyStringRequiredInputIsRejected()
+
+	/**
+	 * A transition that declares no `inputs` rejects ANY payload — nothing is
+	 * allowlisted, so today's exact behaviour is preserved for schemas that
+	 * never opted in.
+	 *
+	 * @return void
+	 */
+	public function testNoInputsDeclaredRejectsAnyPayload(): void {
+		$this->wire($this->timesheet(), $this->annotation());
+
+		$this->objectService->expects($this->never())->method('saveObject');
+
+		try {
+			$this->engine->transition(self::OBJ, 'submit', ['note' => 'hi']);
+			$this->fail('Expected InvalidTransitionInputException was not thrown.');
+		} catch (InvalidTransitionInputException $e) {
+			$this->assertSame(['note'], $e->getFields());
+		}
+	}//end testNoInputsDeclaredRejectsAnyPayload()
+
+	/**
+	 * Without a payload, a transition that declares no `inputs` behaves
+	 * exactly as before: the write carries only the flipped status field.
+	 *
+	 * @return void
+	 */
+	public function testNoInputsWithoutPayloadKeepsTodayBehaviour(): void {
+		$this->wire($this->timesheet(), $this->annotation());
+
+		$captured = null;
+		$this->objectService->expects($this->once())
+			->method('saveObject')
+			->willReturnCallback(
+				function (array $object) use (&$captured): ObjectEntity {
+					$captured = $object;
+					return $this->timesheet();
+				}
+			);
+
+		$this->engine->transition(self::OBJ, 'submit');
+
+		$this->assertIsArray($captured);
+		$this->assertSame('submitted', $captured['status']);
+		$this->assertSame('e-1', $captured['employee']);
+		// No stray keys beyond what getObject() already carried (the entity
+		// mirrors its uuid into `id`) plus the flipped status field.
+		$this->assertSame([], array_diff(array_keys($captured), ['id', 'status', 'employee']));
+	}//end testNoInputsWithoutPayloadKeepsTodayBehaviour()
+
+	/**
+	 * A declared input naming the lifecycle field itself cannot override the
+	 * transition target: the status flip is applied AFTER the merge.
+	 *
+	 * @return void
+	 */
+	public function testInputCannotOverrideTheLifecycleField(): void {
+		$this->wire(
+			$this->timesheet(),
+			$this->annotation([['field' => 'status', 'required' => false]])
+		);
+
+		$captured = null;
+		$this->objectService->expects($this->once())
+			->method('saveObject')
+			->willReturnCallback(
+				function (array $object) use (&$captured): ObjectEntity {
+					$captured = $object;
+					return $this->timesheet();
+				}
+			);
+
+		$this->engine->transition(self::OBJ, 'submit', ['status' => 'hacked']);
+
+		$this->assertIsArray($captured);
+		$this->assertSame('submitted', $captured['status']);
+	}//end testInputCannotOverrideTheLifecycleField()
+
+	/**
+	 * Graph-derived actions declare no `inputs`, so a graph-mode transition
+	 * rejects any payload before even fetching siblings.
+	 *
+	 * @return void
+	 */
+	public function testGraphModeRejectsAnyPayload(): void {
+		$object = $this->timesheet();
+		$object->setObject(['caseType' => 'p-1', 'status' => 's-1']);
+		$this->wire(
+			$object,
+			[
+				'field' => 'status',
+				'graph' => [
+					'schema' => 'statustype',
+					'parentField' => 'caseType',
+					'parentFrom' => 'caseType',
+					'orderField' => 'order',
+					'finalField' => 'isFinal',
+					'allowedMoves' => 'forward',
+				],
+			]
+		);
+
+		$this->objectService->expects($this->never())->method('findAll');
+		$this->objectService->expects($this->never())->method('saveObject');
+
+		try {
+			$this->engine->transition(self::OBJ, 'move-to-s-2', ['note' => 'hi']);
+			$this->fail('Expected InvalidTransitionInputException was not thrown.');
+		} catch (InvalidTransitionInputException $e) {
+			$this->assertSame(['note'], $e->getFields());
+		}
+	}//end testGraphModeRejectsAnyPayload()
+}//end class


### PR DESCRIPTION
Adds the `inputs` contract to lifecycle transitions (first consumer: hrmq's timesheet rejection-reason capture; pairs with nextcloud-vue#723):

- A schema's `x-openregister-lifecycle.transitions.<action>` block may declare `inputs: [{"field": "...", "required": true|false}]`
- `POST /api/objects/{id}/transition` accepts an optional `data` object; only declared keys merge into the carrying write (undeclared key → 400 naming it), `required` enforced (absent/empty → 400), no-`inputs` transitions reject any `data`
- Accepted values ride the SAME `saveObject()` write that flips the status — one ObjectUpdatingEvent sees both; schema validation + readOnly enforcement apply via the existing save path (no parallel validation)
- An input named `status` cannot override the target state (flip applied after merge — tested); graph-path and other engine callers unaffected

Tests: 12 new (engine 9 + controller 3); lifecycle neighbourhood 99 tests / 192 assertions OK. lint/phpcs/phpmd/psalm/phpstan all 0.

Note: the full PHPUnit suite cannot run in a standalone clone (pre-existing `tests/stubs/NextcloudInternalStubs.php` IRequest stub lacks `throwDecodingExceptionIfAny()`/`getFormat()` — reproduced identically on clean development; CI runs inside a Nextcloud checkout and is unaffected). Follow-up issue to be filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)