### PR TITLE
docs(openspec): dedupe-shared-schemas change proposal (repair for openregister#2689)

### DIFF
--- a/openspec/changes/dedupe-shared-schemas/proposal.md
+++ b/openspec/changes/dedupe-shared-schemas/proposal.md
@@ -1,0 +1,68 @@
+---
+kind: code
+---
+
+# Proposal: dedupe-shared-schemas
+
+## Why
+
+The slug-collision family is being closed on two fronts: resolution scoping
+(`register-scoped-schema-slug-resolution`, `register-scoped-slug-resolution`,
+`schema-slug-cross-app-scoping`) and the import side (the per-register
+slug-uniqueness fix in `ImportHandler`, which stops NEW cross-register reuse).
+
+Neither front repairs the damage already done. Registers that came to share a
+schema entity in the pre-fix era keep co-owning its definition: every register
+import that touches the shared entity rewrites it for all referencing registers
+— last import wins, instance-wide. `occ openregister:registers:relink-schemas`
+ADDS lost linkage but has no counterpart that SPLITS wrongly shared entities.
+
+Observed on the shared dev instance (2026-08-21, openregister#2689): the
+`planix` (19) and `pipelinq` (16) registers both referenced schema entities
+task=74, project=159, timeEntry=161. Schema 161 held planix's 6-property
+timeEntry; pipelinq's own definition (hours, billingCategory, client, project,
+WIP/billing-sync — the model its billing features depend on) was gone from the
+instance. A planix schema extension transparently changed pipelinq's `task`
+definition. `relink-schemas` reported 47 registers with recoverable linkage on
+the same instance — the same era of drift.
+
+## What Changes
+
+A repair command, `occ openregister:registers:dedupe-shared-schemas`, mirroring
+`relink-schemas` in shape (dry-run by default, `--write`, `--register`):
+
+1. **Detect**: every schema id referenced by more than one register.
+2. **Attribute**: for each shared schema, determine the canonical owner — the
+   register whose app configuration (register.json / register.d) declares a
+   definition matching the current entity content; when no configuration
+   matches (or several do), report and require an explicit
+   `--keep <registerId>` per schema rather than guessing.
+3. **Split**: every non-canonical register gets its own new schema entity,
+   built from that register's own app configuration when available (the
+   import-side fix then keeps it isolated forever), else cloned from the
+   current entity content.
+4. **Relink**: rewrite the register's schema linkage to the new id.
+5. **Migrate data**: move the register's magic-table rows from
+   `table_{reg}_{oldId}` to `table_{reg}_{newId}` with column mapping per the
+   restored definition; report columns that have no destination instead of
+   dropping them silently.
+6. **Report**: per register/schema, what was split, what moved, what needs a
+   follow-up app reimport.
+
+## Validation of the algorithm
+
+Steps 1–4 were executed manually on the shared dev instance for the
+planix/pipelinq pair (step 5 was unnecessary — the affected rows were demo
+seeds): unlinking 74/159/161 from register 16 and re-running pipelinq's
+configuration import produced three new, correctly-defined, register-private
+schemas (9463/9464/9465) with planix untouched — confirming the import-side
+fix makes the split durable and the repair is mechanical.
+
+## Impact
+
+- New command class alongside `RelinkRegisterSchemasCommand`; no behaviour
+  change for healthy instances (dry-run reports nothing).
+- Instances repaired this way stop exhibiting cross-app schema bleed; app
+  register imports become safe to re-run.
+- Relates to: openregister#2689, the three resolution-scoping changes, and the
+  ImportHandler per-register slug-uniqueness fix.

--- a/openspec/changes/dedupe-shared-schemas/tasks.md
+++ b/openspec/changes/dedupe-shared-schemas/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: dedupe-shared-schemas
+
+## 1. Detection & attribution
+
+- [ ] 1.1 Query building: find every schema id referenced by >1 register (registers.schemas JSON arrays).
+- [ ] 1.2 Canonical-owner attribution: match each referencing register's app configuration
+      (register.json / register.d fragments, resolved the same way SettingsService merges them)
+      against the current schema entity content; classify per schema: exactly-one-match /
+      no-match / multi-match.
+- [ ] 1.3 `--keep <registerId>` override for no-match / multi-match schemas; refuse `--write`
+      for unattributed shared schemas without it.
+
+## 2. Split & relink
+
+- [ ] 2.1 Clone path A (preferred): create the non-canonical register's schema from its OWN app
+      configuration definition, reusing the ImportHandler create path so the per-register
+      slug-uniqueness behaviour applies.
+- [ ] 2.2 Clone path B (fallback, no configuration available): copy the current entity content
+      into a new schema row.
+- [ ] 2.3 Rewrite register.schemas linkage old id → new id, preserving order.
+
+## 3. Data migration
+
+- [ ] 3.1 Move rows `table_{reg}_{oldId}` → `table_{reg}_{newId}` (create target table via the
+      magic-table DDL for the restored definition; INSERT-SELECT with column mapping).
+- [ ] 3.2 Report source columns without a destination column; never drop silently. `--strict`
+      turns unmapped columns into a refusal.
+- [ ] 3.3 Update object rows' `_schema` metadata and any denormalised schema references
+      (folders, uri) the codebase keeps.
+
+## 4. Command surface & safety
+
+- [ ] 4.1 `occ openregister:registers:dedupe-shared-schemas` — dry-run default, `--write`,
+      `--register`, `--keep`, `--strict`; output format mirroring relink-schemas.
+- [ ] 4.2 Must-PASS control: instance with a shared schema pair → dry-run lists it, `--write`
+      splits it, app reimport after the split does NOT re-share (regression guard on the
+      ImportHandler fix).
+- [ ] 4.3 Must-FAIL control: healthy instance → dry-run reports nothing and `--write` changes
+      nothing (idempotence: second run is a no-op).
+- [ ] 4.4 Unit tests for attribution matrix (one-match / no-match / multi-match) and column
+      mapping edge cases.
+
+## 5. Docs
+
+- [ ] 5.1 Admin docs page next to relink-schemas: when drift happens, how to read the dry-run,
+      the planix/pipelinq case as the worked example (openregister#2689).


### PR DESCRIPTION
## What

Openspec change proposal for `occ openregister:registers:dedupe-shared-schemas` — the repair counterpart to `relink-schemas`, closing the gap described in #2689.

The resolution-scoping changes (`register-scoped-schema-slug-resolution`, `register-scoped-slug-resolution`, `schema-slug-cross-app-scoping`) and the ImportHandler per-register slug-uniqueness fix prevent **new** cross-register schema sharing. Nothing repairs registers that **already** share entities from the pre-fix era — they keep co-owning definitions, last import wins (planix/pipelinq shared task/project/timeEntry on dev; pipelinq's timeEntry definition was gone from the instance).

Docs-only: proposal + tasks. The split/relink algorithm was validated manually on the shared dev instance (unlink + reimport produced correctly isolated schemas 9463/9464/9465 with the other register untouched), so the command is a mechanisation of a proven procedure — the genuinely new engineering is attribution (canonical-owner matching) and the magic-table row migration.

Closes nothing yet; implements #2689 when picked up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)