### PR TITLE
feat(commands): add openregister:registers:dedupe-shared-schemas

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -220,6 +220,7 @@ Vrij en open source onder de EUPL-licentie.
 		<command>OCA\OpenRegister\Command\EncryptFieldCommand</command>
 		<command>OCA\OpenRegister\Command\DedupeRegistersCommand</command>
 		<command>OCA\OpenRegister\Command\RelinkRegisterSchemasCommand</command>
+		<command>OCA\OpenRegister\Command\DedupeSharedSchemasCommand</command>
 		<command>OCA\OpenRegister\Command\ReconcileMagicTablesCommand</command>
 		<command>OCA\OpenRegister\Command\DedupeConfigurationsCommand</command>
 		<command>OCA\OpenRegister\Command\ResolverListCommand</command>

--- a/docs/Technical/repairing-shared-schemas.md
+++ b/docs/Technical/repairing-shared-schemas.md
@@ -1,0 +1,201 @@
+# Repairing schemas shared by several registers
+
+`occ openregister:registers:dedupe-shared-schemas` splits schema entities that
+more than one register co-owns, giving each register its own entity and moving
+its object rows with it.
+
+It is the counterpart to `occ openregister:registers:relink-schemas`: that
+command **adds** linkage a register lost, this one **splits** linkage a register
+was never meant to have. Both are dry-run by default.
+
+## When this drift happens
+
+A schema row carries no register column. The relation exists only as a JSON id
+list on the register, so nothing on the schema side records who owns it.
+
+Before the per-register slug-uniqueness fix in the import path, an import that
+resolved a schema slug **globally** re-used whatever schema row already carried
+that slug. Two apps declaring, say, `timeEntry` could therefore end up pointing
+at one entity — and from then on every import of either app rewrote the
+definition for both. Last import wins, instance-wide.
+
+The symptom is an app whose schema silently changes shape when an unrelated app
+is installed or updated: properties disappear, `required` flips, and creates
+start failing validation for a field the app never declared.
+
+### The worked example (openregister#2689)
+
+On the shared development instance, registers `planix` (19) and `pipelinq` (16)
+both referenced schema entities `task=74`, `project=159` and `timeEntry=161`.
+
+Schema 161 held planix's six-property `timeEntry`. Pipelinq's own definition —
+`hours`, `billingCategory`, `client`, `project`, and the WIP/billing-sync fields
+its billing features depend on — was gone from the instance entirely. A planix
+schema extension had transparently changed pipelinq's `task` definition too.
+
+The import-side fix stops *new* sharing. It does not repair what already
+happened; that is what this command is for.
+
+## Reading the dry run
+
+```
+occ openregister:registers:dedupe-shared-schemas
+```
+
+```
+3 schema(s) are shared by more than one register:
+
+  schema 161 (timeEntry) — referenced by registers [16, 19]
+      attribution: one-match — owner: register 19 (configuration)
+      - register 16 (pipelinq) -> new schema from configuration (openregister_table_16_161, 42 row(s))
+          5 column(s) would have no destination: approved, date, description, duration, employee
+
+DRY RUN — nothing was changed. Re-run with --write to apply.
+```
+
+Line by line:
+
+- **`referenced by registers [16, 19]`** — every register whose `schemas` list
+  carries this id. Ids stored as strings count too.
+- **`attribution:`** — how the owner was determined. See below.
+- **`-> new schema from configuration`** — the split will rebuild register 16's
+  schema from its own `register.json`. `from clone` means the app ships no
+  configuration for it any more, so the current entity content is copied
+  verbatim instead.
+- **`42 row(s)`** — how many object rows will move. `no table` means the pairing
+  was never materialised, so there is nothing to migrate.
+- **`column(s) would have no destination`** — source columns the restored
+  definition has no place for. They are **never dropped silently**: the source
+  table is kept (see *What happens to the old table*).
+
+## How attribution works
+
+For each shared schema the command reads the **current entity content** and
+compares it against what each referencing register's own app configuration
+declares for that slug — `lib/Settings/<appId>_register.json` plus any
+`lib/Settings/register.d/*.json` fragments, merged the way the settings loader
+merges them.
+
+The comparison is on the **property-name set and the `required` list**, not on
+byte equality. The import path stamps defaults, folds `$ref`s and rewrites
+descriptions, so byte equality would match nothing. A *lost property* — which is
+exactly what the overwrite did — still registers as a difference.
+
+Three outcomes:
+
+| Status | Meaning | Result |
+| --- | --- | --- |
+| `one-match` | Exactly one register's configuration matches the entity | That register keeps it; the others are split off |
+| `no-match` | No configuration matches (both apps have moved on) | **Unattributed** — skipped until you decide |
+| `multi-match` | Several configurations match (both declare the same shape) | **Unattributed** — skipped until you decide |
+
+Deliberately *not* used as evidence: the schema's `application` column (on a
+shared entity it names whichever app overwrote it last, not the owner) and
+"lowest register id" (not evidence at all). The older
+`occ openregister:schemas:dedup` command uses both, and therefore always picks a
+side.
+
+### Naming an owner yourself
+
+`--write` **refuses** while any schema is unattributed. Guessing an owner is what
+produced the damage in the first place, so the command will not do it for you.
+
+```bash
+# pin one schema
+occ openregister:registers:dedupe-shared-schemas --keep 161:19 --write
+
+# pin several
+occ openregister:registers:dedupe-shared-schemas --keep 161:19 --keep 74:19 --write
+
+# one register owns everything attribution could not settle
+occ openregister:registers:dedupe-shared-schemas --keep 19 --write
+```
+
+The per-schema form always outranks the bare one. A `--keep` naming a register
+that does not actually reference the schema is ignored, and the schema stays
+unattributed.
+
+## Applying the repair
+
+```bash
+occ openregister:registers:dedupe-shared-schemas --write
+```
+
+For every non-canonical register the command, in one transaction:
+
+1. **Creates its own schema** — preferably from that register's own
+   configuration, through the same import path the app uses. That is what makes
+   the split durable: the app's next import finds the register's own entity and
+   updates *that*, instead of forking the shared one again. With no configuration
+   available, the current entity content is cloned.
+2. **Relinks** `register.schemas`, replacing the old id with the new one in
+   place. Order is preserved and entries it does not understand are copied
+   verbatim.
+3. **Moves the object rows** from `openregister_table_<register>_<old>` into the
+   table built for the new schema, as a column-mapped `INSERT ... SELECT`.
+4. **Restamps** the moved rows: `_schema` and the schema id embedded in `_uri`.
+   Without this the rows stay attributed to the register that kept the shared
+   schema — the very bleed being repaired.
+
+`_id` is not copied. It is an autoincrement primary key, and carrying the values
+over would leave the new table's sequence behind the highest copied id. `_uuid`
+is the identity relations actually store, and it does move.
+
+### Refusing on unmapped columns
+
+```bash
+occ openregister:registers:dedupe-shared-schemas --write --strict
+```
+
+`--strict` turns "this source column has no destination" into a refusal for that
+split, decided **before** anything is written. Use it when you would rather stop
+and look than accept that some columns only survive in the backup table.
+
+## What happens to the old table
+
+The source table is **not dropped**. It is renamed with a `_predupe` suffix:
+
+```
+oc_openregister_table_16_161  ->  oc_openregister_table_16_161_predupe
+```
+
+Two reasons:
+
+- It is the only route back to a column the mapping could not carry across.
+- The suffix stops the name matching the shard pattern
+  `openregister_table_<int>_<int>`. Left under its original name, a later
+  `occ openregister:registers:relink-schemas --write` would read it as evidence
+  of a pairing and re-link the register to the schema this command just split it
+  away from — quietly undoing the repair.
+
+Drop the backup tables yourself once you are satisfied nothing is missing.
+
+## Options
+
+| Option | Effect |
+| --- | --- |
+| *(none)* | Dry run. Reports the full plan and changes nothing. |
+| `--write` | Apply. Refused while any schema is unattributed. |
+| `--register <id>` | Limit to shared schemas involving this register. |
+| `--keep <schemaId>:<registerId>` | Name the owner of one schema. Repeatable. |
+| `--keep <registerId>` | Name the owner of every unattributed schema. |
+| `--strict` | Refuse any split whose source table has an unmapped column. |
+
+Exit code is `0` on success (including "nothing to do"), and `1` when a write was
+refused or a split failed.
+
+## After the repair
+
+Re-run the app's configuration import. It should now update the register's own
+schema rather than the shared one, and a second dry run of this command should
+report nothing — the repair is idempotent.
+
+## Related
+
+- `occ openregister:registers:relink-schemas` — rebuilds a register's lost
+  `schemas` list from its physical object tables.
+- `occ openregister:tables:reconcile` — creates magic-table columns that a schema
+  property gained without a subsequent write.
+- `occ openregister:schemas:dedup` — the older, heuristic split (owner by
+  `application`, else lowest register id) that predates evidence-based
+  attribution.

--- a/docs/api/schemas.md
+++ b/docs/api/schemas.md
@@ -24,7 +24,10 @@ still succeed.
 
 If the linkage of an existing register was lost, `occ
 openregister:registers:relink-schemas` inspects and repairs it from the physical
-object tables.
+object tables. If several registers wrongly share ONE schema entity — pre-fix
+drift, where every import rewrites the definition for all of them — `occ
+openregister:registers:dedupe-shared-schemas` splits them apart; see
+[Repairing schemas shared by several registers](../Technical/repairing-shared-schemas.md).
 
 ## Error Handling for Missing Register or Schema
 

--- a/lib/Command/DedupeSharedSchemasCommand.php
+++ b/lib/Command/DedupeSharedSchemasCommand.php
@@ -71,6 +71,8 @@ class DedupeSharedSchemasCommand extends Command {
 	 * Define command name, description, and options.
 	 *
 	 * @return void
+	 *
+	 * @spec openspec/changes/dedupe-shared-schemas/proposal.md
 	 */
 	protected function configure(): void {
 		$this->setName(name: 'openregister:registers:dedupe-shared-schemas')
@@ -111,6 +113,8 @@ class DedupeSharedSchemasCommand extends Command {
 	 * @param OutputInterface $output The console output.
 	 *
 	 * @return int The exit code.
+	 *
+	 * @spec openspec/changes/dedupe-shared-schemas/proposal.md
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$write  = (bool)$input->getOption('write');

--- a/lib/Command/DedupeSharedSchemasCommand.php
+++ b/lib/Command/DedupeSharedSchemasCommand.php
@@ -1,0 +1,359 @@
+<?php
+
+/**
+ * OpenRegister dedupe-shared-schemas command
+ *
+ * Reports — and on explicit request repairs — schema entities that more than one
+ * register co-owns, splitting each non-canonical register onto its own entity
+ * and moving its object rows with it.
+ *
+ * @category Command
+ * @package  OCA\OpenRegister\Command
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Command;
+
+use OCA\OpenRegister\Service\SharedSchemaDedupeService;
+use RuntimeException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+/**
+ * Split schema entities that several registers wrongly share.
+ *
+ * DRY RUN BY DEFAULT. `--write` is required to change anything.
+ *
+ * This is the counterpart to `openregister:registers:relink-schemas`: that
+ * command ADDS linkage a register lost, this one SPLITS linkage a register was
+ * never meant to have. Both mutate the `schemas` boundary, so both show the
+ * operator the whole change first and then ask them to opt in.
+ *
+ * The command REFUSES to write a schema it could not attribute. Guessing an
+ * owner is what produced the damage in the first place — an import resolving a
+ * slug globally and landing on someone else's entity — so a schema whose
+ * referencing registers' configurations do not single one owner out is reported
+ * and skipped until `--keep` names one.
+ *
+ * @spec openspec/changes/dedupe-shared-schemas/proposal.md
+ */
+class DedupeSharedSchemasCommand extends Command {
+
+	/**
+	 * Wire the dedupe service.
+	 *
+	 * @param SharedSchemaDedupeService $dedupe The shared-schema repair service.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly SharedSchemaDedupeService $dedupe,
+	) {
+		parent::__construct();
+	}//end __construct()
+
+	/**
+	 * Define command name, description, and options.
+	 *
+	 * @return void
+	 */
+	protected function configure(): void {
+		$this->setName(name: 'openregister:registers:dedupe-shared-schemas')
+			->setDescription(
+				'Split schema entities shared by several registers so each owns its own (dry run by default)'
+			)
+			->addOption(
+				'write',
+				null,
+				InputOption::VALUE_NONE,
+				'Apply the changes. Without this flag nothing is modified.'
+			)
+			->addOption(
+				'register',
+				null,
+				InputOption::VALUE_REQUIRED,
+				'Limit to shared schemas involving this register id.'
+			)
+			->addOption(
+				'keep',
+				null,
+				(InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY),
+				'Name the owner of a schema attribution could not settle: '
+				. '<schemaId>:<registerId>, or a bare <registerId> for all of them. Repeatable.'
+			)
+			->addOption(
+				'strict',
+				null,
+				InputOption::VALUE_NONE,
+				'Refuse any split whose source table has a column with no destination.'
+			);
+	}//end configure()
+
+	/**
+	 * Run the inspection, and the repair when --write is given.
+	 *
+	 * @param InputInterface  $input  The console input.
+	 * @param OutputInterface $output The console output.
+	 *
+	 * @return int The exit code.
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$write  = (bool)$input->getOption('write');
+		$strict = (bool)$input->getOption('strict');
+
+		$registerId = $input->getOption('register');
+		if ($registerId !== null) {
+			$registerId = (int)$registerId;
+		}
+
+		try {
+			$keep = $this->dedupe->parseKeep(raw: (array)$input->getOption('keep'));
+		} catch (RuntimeException $e) {
+			$output->writeln('<error>' . $e->getMessage() . '</error>');
+			return Command::INVALID;
+		}
+
+		$plan = $this->dedupe->inspect(registerId: $registerId, keep: $keep);
+
+		if ($plan === []) {
+			$output->writeln('<info>No schema is shared by more than one register. Nothing to do.</info>');
+			return Command::SUCCESS;
+		}
+
+		$output->writeln(
+			sprintf('<comment>%d schema(s) are shared by more than one register:</comment>', count($plan))
+		);
+		$output->writeln('');
+
+		$unattributed = 0;
+		foreach ($plan as $entry) {
+			$this->renderSchema(output: $output, entry: $entry);
+			if ($entry['owner'] === null) {
+				$unattributed++;
+			}
+		}
+
+		if ($write === false) {
+			return $this->reportDryRun(output: $output, unattributed: $unattributed);
+		}
+
+		if ($unattributed > 0) {
+			$output->writeln('');
+			$output->writeln(
+				sprintf(
+					'<error>Refusing to write: %d schema(s) are unattributed. '
+					. 'Name their owner with --keep <schemaId>:<registerId>.</error>',
+					$unattributed
+				)
+			);
+			return Command::FAILURE;
+		}
+
+		return $this->applyPlan(output: $output, plan: $plan, strict: $strict);
+	}//end execute()
+
+	/**
+	 * Report the outcome of a dry run.
+	 *
+	 * @param OutputInterface $output       The console output.
+	 * @param int             $unattributed How many schemas could not be attributed.
+	 *
+	 * @return int The exit code.
+	 */
+	private function reportDryRun(OutputInterface $output, int $unattributed): int {
+		$output->writeln('');
+		if ($unattributed > 0) {
+			$output->writeln(
+				sprintf(
+					'<comment>%d schema(s) are unattributed and would be SKIPPED. '
+					. 'Name their owner with --keep <schemaId>:<registerId>.</comment>',
+					$unattributed
+				)
+			);
+		}
+
+		$output->writeln('<comment>DRY RUN — nothing was changed. Re-run with --write to apply.</comment>');
+
+		return Command::SUCCESS;
+	}//end reportDryRun()
+
+	/**
+	 * Execute every planned split.
+	 *
+	 * @param OutputInterface           $output The console output.
+	 * @param array<int, array<string, mixed>> $plan   The inspection plan.
+	 * @param bool                      $strict Whether unmapped columns refuse the move.
+	 *
+	 * @return int The exit code.
+	 */
+	private function applyPlan(OutputInterface $output, array $plan, bool $strict): int {
+		$split  = 0;
+		$failed = 0;
+
+		$output->writeln('');
+		foreach ($plan as $entry) {
+			foreach (array_keys($entry['splits']) as $registerId) {
+				try {
+					$result = $this->dedupe->applySplit(
+						entry: $entry,
+						target: (int)$registerId,
+						strict: $strict
+					);
+					$output->writeln($this->describeSplit(entry: $entry, registerId: (int)$registerId, result: $result));
+					$split++;
+				} catch (Throwable $e) {
+					$output->writeln(
+						sprintf(
+							'  <error>failed</error> register %d / schema %d: %s',
+							$registerId,
+							$entry['schemaId'],
+							$e->getMessage()
+						)
+					);
+					$failed++;
+				}//end try
+			}
+		}//end foreach
+
+		$output->writeln('');
+		$output->writeln(sprintf('<info>%d split(s) applied; %d failure(s).</info>', $split, $failed));
+
+		if ($failed === 0) {
+			return Command::SUCCESS;
+		}
+
+		return Command::FAILURE;
+	}//end applyPlan()
+
+	/**
+	 * Render one applied split.
+	 *
+	 * The backup table is named explicitly because it is the operator's only
+	 * route back to a column the mapping could not carry across.
+	 *
+	 * @param array<string, mixed> $entry      The plan entry.
+	 * @param int                  $registerId The register that was split off.
+	 * @param array<string, mixed> $result     The service's outcome.
+	 *
+	 * @return string The line to print.
+	 */
+	private function describeSplit(array $entry, int $registerId, array $result): string {
+		$line = sprintf(
+			'  <info>split</info> register %d: schema %d -> %d (%d row(s) moved)',
+			$registerId,
+			$entry['schemaId'],
+			$result['newSchemaId'],
+			$result['rows']
+		);
+
+		if ($result['backup'] !== null) {
+			$line .= sprintf(', source kept as %s', $result['backup']);
+		}
+
+		if ($result['unmapped'] !== []) {
+			$line .= sprintf(
+				"\n      <comment>%d column(s) had no destination and stayed in the backup: %s</comment>",
+				count($result['unmapped']),
+				implode(', ', $result['unmapped'])
+			);
+		}
+
+		return $line;
+	}//end describeSplit()
+
+	/**
+	 * Render one shared schema's findings.
+	 *
+	 * Row counts are printed per split because they separate a split that only
+	 * repoints configuration from one that moves live data. The attribution
+	 * status is printed verbatim so the operator can see WHY a schema is about to
+	 * be attributed the way it is, rather than being handed a verdict.
+	 *
+	 * @param OutputInterface      $output The console output.
+	 * @param array<string, mixed> $entry  One inspect() plan entry.
+	 *
+	 * @return void
+	 */
+	private function renderSchema(OutputInterface $output, array $entry): void {
+		$output->writeln(
+			sprintf(
+				'  schema %d (%s) — referenced by registers [%s]',
+				$entry['schemaId'],
+				$entry['schemaSlug'],
+				implode(', ', $entry['registerIds'])
+			)
+		);
+
+		$output->writeln(sprintf('      attribution: %s%s', $entry['status'], $this->describeOwner(entry: $entry)));
+
+		foreach ($entry['splits'] as $registerId => $split) {
+			$output->writeln(
+				sprintf(
+					'      - register %d (%s) -> new schema from %s (%s, %s)',
+					$registerId,
+					$split['registerSlug'],
+					$split['path'],
+					$split['table'],
+					$this->describeRows(rows: (int)$split['rows'])
+				)
+			);
+
+			if ($split['unmapped'] !== []) {
+				$output->writeln(
+					sprintf(
+						'          <comment>%d column(s) would have no destination: %s</comment>',
+						count($split['unmapped']),
+						implode(', ', $split['unmapped'])
+					)
+				);
+			}
+		}//end foreach
+
+		$output->writeln('');
+	}//end renderSchema()
+
+	/**
+	 * Describe the resolved owner, or the reason there is none.
+	 *
+	 * @param array<string, mixed> $entry One inspect() plan entry.
+	 *
+	 * @return string The suffix to print after the status.
+	 */
+	private function describeOwner(array $entry): string {
+		if ($entry['owner'] === null) {
+			return ' — <error>UNATTRIBUTED, will be skipped</error>';
+		}
+
+		return sprintf(' — owner: register %d (%s)', $entry['owner'], $entry['ownerSource']);
+	}//end describeOwner()
+
+	/**
+	 * Describe a row count, distinguishing "empty" from "no table".
+	 *
+	 * @param int $rows The count, or -1 when the table is absent.
+	 *
+	 * @return string The description.
+	 */
+	private function describeRows(int $rows): string {
+		if ($rows < 0) {
+			return 'no table';
+		}
+
+		return sprintf('%d row(s)', $rows);
+	}//end describeRows()
+}//end class

--- a/lib/Service/SharedSchema/RegisterConfigurationLocator.php
+++ b/lib/Service/SharedSchema/RegisterConfigurationLocator.php
@@ -1,0 +1,307 @@
+<?php
+
+/**
+ * OpenRegister RegisterConfigurationLocator
+ *
+ * Reads back the schema definitions a register's own app configuration declares
+ * for it, so a shared schema entity can be attributed to the register whose
+ * configuration actually describes it.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\SharedSchema
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\SharedSchema;
+
+use OCA\OpenRegister\Db\Register;
+use OCP\App\IAppManager;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Resolve "what does this register's app configuration say its schemas look like?".
+ *
+ * Discovery mirrors {@see \OCA\OpenRegister\AppHost\Service\AppHostSettingsService}:
+ * a base `lib/Settings/<appId>_register.json` with `lib/Settings/register.d/*.json`
+ * fragments deep-merged over it in sorted filename order. The glob is widened to
+ * every `*_register.json` because OpenRegister itself ships several documents
+ * rather than one monolith, and its own registers would otherwise resolve to
+ * nothing.
+ *
+ * This is deliberately the ONLY evidence source used for attribution. The
+ * alternatives were considered and rejected: the schema's `application` column
+ * is what the last import stamped, so on a shared entity it names the register
+ * that overwrote it rather than the one that owns it; and "lowest register id"
+ * is not evidence at all. Both are what the existing
+ * `openregister:schemas:dedup` command uses, and both silently pick a side.
+ *
+ * @spec openspec/changes/dedupe-shared-schemas/proposal.md
+ */
+class RegisterConfigurationLocator {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IAppManager     $appManager Resolves an app id to its on-disk path.
+	 * @param LoggerInterface $logger     Records unreadable configuration documents.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly IAppManager $appManager,
+		private readonly LoggerInterface $logger,
+	) {
+	}//end __construct()
+
+	/**
+	 * Read the schema definitions a register's app configuration declares for it.
+	 *
+	 * @param Register $register The register to resolve configuration for.
+	 *
+	 * @return array<string, array<string, mixed>> Lowercased schema slug => definition.
+	 *         Empty when the app ships no configuration naming this register.
+	 *
+	 * @spec openspec/changes/dedupe-shared-schemas/proposal.md
+	 */
+	public function schemasFor(Register $register): array {
+		$appId = (string)$register->getApplication();
+		if ($appId === '') {
+			return [];
+		}
+
+		try {
+			$appPath = $this->appManager->getAppPath($appId);
+		} catch (Throwable $e) {
+			unset($e);
+			return [];
+		}
+
+		$settings = ($appPath . '/lib/Settings');
+		$slug     = strtolower((string)$register->getSlug());
+
+		foreach ($this->documents(directory: $settings) as $document) {
+			$data = $this->readJson(path: $document);
+			if ($data === null) {
+				continue;
+			}
+
+			if (basename($document) === ($appId . '_register.json')) {
+				$data = $this->mergeFragments(base: $data, directory: ($settings . '/register.d'));
+			}
+
+			$schemas = self::schemasForRegisterSlug(document: $data, registerSlug: $slug);
+			if ($schemas !== []) {
+				return $schemas;
+			}
+		}
+
+		return [];
+	}//end schemasFor()
+
+	/**
+	 * Pull one register's schema definitions out of a configuration document.
+	 *
+	 * @param array<string, mixed> $document     The merged configuration document.
+	 * @param string               $registerSlug The lowercased register slug to look for.
+	 *
+	 * @return array<string, array<string, mixed>> Lowercased schema slug => definition.
+	 */
+	private static function schemasForRegisterSlug(array $document, string $registerSlug): array {
+		$components = ($document['components'] ?? []);
+		if (is_array($components) === false) {
+			return [];
+		}
+
+		$registers = ($components['registers'] ?? []);
+		$schemas   = ($components['schemas'] ?? []);
+		if (is_array($registers) === false || is_array($schemas) === false) {
+			return [];
+		}
+
+		$declared = self::findRegister(registers: $registers, registerSlug: $registerSlug);
+		if ($declared === null) {
+			return [];
+		}
+
+		return self::pickSchemas(schemas: $schemas, wanted: self::declaredSlugs(declared: $declared));
+	}//end schemasForRegisterSlug()
+
+	/**
+	 * Find the register entry whose slug matches.
+	 *
+	 * The map key is accepted as a fallback slug because a fragment may declare a
+	 * register by key alone.
+	 *
+	 * @param array<mixed> $registers    The `components.registers` map.
+	 * @param string       $registerSlug The lowercased register slug.
+	 *
+	 * @return array<string, mixed>|null The register definition, or null.
+	 */
+	private static function findRegister(array $registers, string $registerSlug): ?array {
+		foreach ($registers as $key => $definition) {
+			if (is_array($definition) === false) {
+				continue;
+			}
+
+			if (strtolower((string)($definition['slug'] ?? $key)) === $registerSlug) {
+				return $definition;
+			}
+		}
+
+		return null;
+	}//end findRegister()
+
+	/**
+	 * The schema slugs a register definition declares.
+	 *
+	 * @param array<string, mixed> $declared The register definition.
+	 *
+	 * @return array<string, bool> Lowercased slug => true.
+	 */
+	private static function declaredSlugs(array $declared): array {
+		$wanted = [];
+		foreach (((array)($declared['schemas'] ?? [])) as $entry) {
+			if (is_scalar($entry) === true) {
+				$wanted[strtolower((string)$entry)] = true;
+			}
+		}
+
+		return $wanted;
+	}//end declaredSlugs()
+
+	/**
+	 * Filter the document's schema map down to the wanted slugs.
+	 *
+	 * @param array<mixed>        $schemas The `components.schemas` map.
+	 * @param array<string, bool> $wanted  Lowercased slug => true.
+	 *
+	 * @return array<string, array<string, mixed>> Lowercased slug => definition.
+	 */
+	private static function pickSchemas(array $schemas, array $wanted): array {
+		$result = [];
+		foreach ($schemas as $key => $definition) {
+			if (is_array($definition) === false) {
+				continue;
+			}
+
+			$slug = strtolower((string)($definition['slug'] ?? $key));
+			if (isset($wanted[$slug]) === true) {
+				$result[$slug] = $definition;
+			}
+		}
+
+		return $result;
+	}//end pickSchemas()
+
+	/**
+	 * List the candidate configuration documents in an app's settings directory.
+	 *
+	 * @param string $directory The `lib/Settings` directory.
+	 *
+	 * @return string[] The absolute paths, in glob order.
+	 */
+	private function documents(string $directory): array {
+		$documents = glob($directory . '/*_register.json');
+		if ($documents === false) {
+			return [];
+		}
+
+		return $documents;
+	}//end documents()
+
+	/**
+	 * Deep-merge every `register.d` fragment over a base document.
+	 *
+	 * @param array<string, mixed> $base      The base document.
+	 * @param string               $directory The fragment directory.
+	 *
+	 * @return array<string, mixed> The merged document.
+	 */
+	private function mergeFragments(array $base, string $directory): array {
+		$fragments = glob($directory . '/*.json');
+		if ($fragments === false) {
+			return $base;
+		}
+
+		sort($fragments);
+
+		foreach ($fragments as $fragment) {
+			$data = $this->readJson(path: $fragment);
+			if ($data !== null) {
+				$base = self::deepMerge(base: $base, overlay: $data);
+			}
+		}
+
+		return $base;
+	}//end mergeFragments()
+
+	/**
+	 * Merge an overlay over a base the way the settings loader does.
+	 *
+	 * Associative arrays merge key by key; list entries append; overlay scalars win.
+	 *
+	 * @param array<mixed> $base    The base array.
+	 * @param array<mixed> $overlay The overlay array.
+	 *
+	 * @return array<mixed> The merged array.
+	 */
+	private static function deepMerge(array $base, array $overlay): array {
+		foreach ($overlay as $key => $value) {
+			if (is_int($key) === true) {
+				$base[] = $value;
+				continue;
+			}
+
+			if (isset($base[$key]) === true && is_array($base[$key]) === true && is_array($value) === true) {
+				$base[$key] = self::deepMerge(base: $base[$key], overlay: $value);
+				continue;
+			}
+
+			$base[$key] = $value;
+		}
+
+		return $base;
+	}//end deepMerge()
+
+	/**
+	 * Read and decode one JSON document.
+	 *
+	 * @param string $path The absolute path.
+	 *
+	 * @return array<string, mixed>|null The decoded document, or null when unreadable.
+	 */
+	private function readJson(string $path): ?array {
+		if (is_readable($path) === false) {
+			return null;
+		}
+
+		$raw = file_get_contents($path);
+		if ($raw === false) {
+			return null;
+		}
+
+		$data = json_decode($raw, true);
+		if (is_array($data) === false) {
+			$this->logger->warning(
+				message: '[SharedSchemaDedupe] Unreadable configuration document ' . $path,
+				context: ['file' => __FILE__, 'line' => __LINE__],
+			);
+			return null;
+		}
+
+		return $data;
+	}//end readJson()
+}//end class

--- a/lib/Service/SharedSchema/SchemaAttribution.php
+++ b/lib/Service/SharedSchema/SchemaAttribution.php
@@ -1,0 +1,331 @@
+<?php
+
+/**
+ * OpenRegister SchemaAttribution
+ *
+ * The pure decision layer of the shared-schema repair: which schemas are shared,
+ * which register's configuration matches the entity that is shared, and what the
+ * operator's `--keep` overrides mean.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\SharedSchema
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\SharedSchema;
+
+use RuntimeException;
+
+/**
+ * Decide who owns a shared schema.
+ *
+ * Deliberately dependency-free. Every rule this repair turns on — detection,
+ * matching, the refusal to guess — lives here and can therefore be tested
+ * exhaustively without a database, a Nextcloud server or an app on disk. The
+ * classes that surround it only fetch the inputs and carry out the verdict.
+ *
+ * @spec openspec/changes/dedupe-shared-schemas/proposal.md
+ */
+class SchemaAttribution {
+
+	/**
+	 * Exactly one referencing register's configuration matches the entity.
+	 *
+	 * @var string
+	 */
+	public const STATUS_ONE_MATCH = 'one-match';
+
+	/**
+	 * No referencing register's configuration matches the entity.
+	 *
+	 * @var string
+	 */
+	public const STATUS_NO_MATCH = 'no-match';
+
+	/**
+	 * Several referencing registers' configurations match the entity.
+	 *
+	 * @var string
+	 */
+	public const STATUS_MULTI_MATCH = 'multi-match';
+
+	/**
+	 * Invert a register->schemas map into the schemas shared by several registers.
+	 *
+	 * Ids are normalised because the stored list may hold them as ints or as
+	 * strings depending on which import era wrote it, and a schema referenced as
+	 * `"74"` by one register and `74` by another is still shared.
+	 *
+	 * @param array<int, mixed> $registerSchemas registerId => stored schema id list.
+	 *
+	 * @return array<int, int[]> schemaId => the register ids referencing it, ascending.
+	 *         Only schemas with more than one referencing register are returned.
+	 *
+	 * @spec openspec/changes/dedupe-shared-schemas/proposal.md
+	 */
+	public function indexShared(array $registerSchemas): array {
+		$index = [];
+		foreach ($registerSchemas as $registerId => $schemaIds) {
+			foreach ($this->normaliseIds(candidates: $schemaIds) as $schemaId) {
+				$index[$schemaId][(int)$registerId] = true;
+			}
+		}
+
+		$shared = [];
+		foreach ($index as $schemaId => $registerIds) {
+			if (count($registerIds) < 2) {
+				continue;
+			}
+
+			$ids = array_keys($registerIds);
+			sort($ids);
+			$shared[$schemaId] = $ids;
+		}
+
+		ksort($shared);
+
+		return $shared;
+	}//end indexShared()
+
+	/**
+	 * Reduce a schema definition to the shape attribution compares on.
+	 *
+	 * Only the property NAMES and the required list are used. Comparing whole
+	 * property bodies would be worse than useless: the import path stamps
+	 * defaults, folds `$ref`s and normalises casing, so a definition that came
+	 * from the very configuration under test still would not be byte-equal to the
+	 * stored entity, and every schema would land in `no-match`. The name set is
+	 * what the pre-fix overwrite actually destroyed — the observed case lost
+	 * `billingCategory`, `hours` and `client` from pipelinq's `timeEntry` — so it
+	 * is the evidence that discriminates.
+	 *
+	 * @param array<string, mixed> $definition A schema definition or a serialised entity.
+	 *
+	 * @return array{properties: string[], required: string[]} The normalised signature.
+	 *
+	 * @spec openspec/changes/dedupe-shared-schemas/proposal.md
+	 */
+	public function signature(array $definition): array {
+		$properties = ($definition['properties'] ?? []);
+		$names      = [];
+		if (is_array($properties) === true) {
+			foreach (array_keys($properties) as $name) {
+				$names[] = strtolower((string)$name);
+			}
+		}
+
+		$names = array_values(array_unique($names));
+		sort($names);
+
+		$required = ($definition['required'] ?? []);
+		$fields   = [];
+		if (is_array($required) === true) {
+			foreach ($required as $field) {
+				if (is_scalar($field) === true) {
+					$fields[] = strtolower((string)$field);
+				}
+			}
+		}
+
+		$fields = array_values(array_unique($fields));
+		sort($fields);
+
+		return ['properties' => $names, 'required' => $fields];
+	}//end signature()
+
+	/**
+	 * Decide which referencing register owns the current entity content.
+	 *
+	 * @param array<int, mixed> $candidates registerId => that register's configured
+	 *                                      definition for this slug, or null when it has none.
+	 * @param array<string, mixed> $entity  The current schema entity content.
+	 *
+	 * @return array{status: string, owner: int|null, matches: int[]} The verdict. `owner` is
+	 *         set only for {@see self::STATUS_ONE_MATCH}.
+	 *
+	 * @spec openspec/changes/dedupe-shared-schemas/proposal.md
+	 */
+	public function classify(array $candidates, array $entity): array {
+		$target  = $this->signature(definition: $entity);
+		$matches = [];
+
+		foreach ($candidates as $registerId => $definition) {
+			if (is_array($definition) === false) {
+				continue;
+			}
+
+			if ($this->signature(definition: $definition) === $target) {
+				$matches[] = (int)$registerId;
+			}
+		}
+
+		sort($matches);
+
+		if (count($matches) === 1) {
+			return ['status' => self::STATUS_ONE_MATCH, 'owner' => $matches[0], 'matches' => $matches];
+		}
+
+		if ($matches === []) {
+			return ['status' => self::STATUS_NO_MATCH, 'owner' => null, 'matches' => []];
+		}
+
+		return ['status' => self::STATUS_MULTI_MATCH, 'owner' => null, 'matches' => $matches];
+	}//end classify()
+
+	/**
+	 * Parse the repeatable `--keep` option.
+	 *
+	 * Two forms are accepted: `--keep <schemaId>:<registerId>` pins one schema,
+	 * and a bare `--keep <registerId>` applies to every schema attribution could
+	 * not settle. The per-schema form always wins, so a broad override cannot
+	 * silently outrank a specific decision.
+	 *
+	 * @param array<int, mixed> $raw The raw option values.
+	 *
+	 * @return array{perSchema: array<int,int>, global: int|null} The parsed overrides.
+	 *
+	 * @throws RuntimeException When a value is not a positive id or id pair.
+	 *
+	 * @spec openspec/changes/dedupe-shared-schemas/proposal.md
+	 */
+	public function parseKeep(array $raw): array {
+		$perSchema = [];
+		$global    = null;
+
+		foreach ($raw as $value) {
+			$value = trim((string)$value);
+			if ($value === '') {
+				continue;
+			}
+
+			if (str_contains($value, ':') === false) {
+				$global = $this->positiveId(value: $value, option: $value);
+				continue;
+			}
+
+			[$schemaPart, $registerPart] = explode(':', $value, 2);
+			$perSchema[$this->positiveId(value: $schemaPart, option: $value)] = $this->positiveId(
+				value: $registerPart,
+				option: $value
+			);
+		}
+
+		return ['perSchema' => $perSchema, 'global' => $global];
+	}//end parseKeep()
+
+	/**
+	 * Apply the `--keep` overrides on top of an attribution verdict.
+	 *
+	 * An override is honoured only when it names a register that actually
+	 * references the schema. Pointing the repair at an unrelated register would
+	 * relink every referencing register onto a fresh entity for no reason, which
+	 * is a bigger change than the one the operator asked for.
+	 *
+	 * @param array<string, mixed> $verdict  The attribution verdict.
+	 * @param int               $schemaId    The shared schema id.
+	 * @param int[]             $registerIds The referencing registers.
+	 * @param array<string, mixed> $keep     The parsed overrides.
+	 *
+	 * @return array{owner: int|null, source: string} The resolved owner and where it came from.
+	 *
+	 * @spec openspec/changes/dedupe-shared-schemas/proposal.md
+	 */
+	public function resolveOwner(array $verdict, int $schemaId, array $registerIds, array $keep): array {
+		$pinned = ($keep['perSchema'][$schemaId] ?? null);
+		if ($pinned !== null && in_array($pinned, $registerIds, true) === true) {
+			return ['owner' => $pinned, 'source' => 'keep'];
+		}
+
+		if (($verdict['status'] ?? '') === self::STATUS_ONE_MATCH) {
+			return ['owner' => $verdict['owner'], 'source' => 'configuration'];
+		}
+
+		$fallback = ($keep['global'] ?? null);
+		if ($fallback !== null && in_array($fallback, $registerIds, true) === true) {
+			return ['owner' => $fallback, 'source' => 'keep-global'];
+		}
+
+		return ['owner' => null, 'source' => 'unattributed'];
+	}//end resolveOwner()
+
+	/**
+	 * Replace one schema id in a stored list, preserving order and the other entries.
+	 *
+	 * The remaining entries are copied VERBATIM for the reason
+	 * {@see \OCA\OpenRegister\Db\Register::addSchemaId()} gives: a normalising
+	 * rewrite would silently drop a non-numeric legacy entry, and that is data
+	 * loss rather than cleanup.
+	 *
+	 * @param array<int, mixed> $schemas The stored schemas list.
+	 * @param int               $oldId   The id to replace.
+	 * @param int               $newId   The id to put in its place.
+	 *
+	 * @return array<int, mixed> The rewritten list.
+	 *
+	 * @spec openspec/changes/dedupe-shared-schemas/proposal.md
+	 */
+	public function replaceSchemaId(array $schemas, int $oldId, int $newId): array {
+		$result = [];
+		foreach ($schemas as $entry) {
+			if (is_numeric($entry) === true && (int)$entry === $oldId) {
+				$result[] = $newId;
+				continue;
+			}
+
+			$result[] = $entry;
+		}
+
+		return array_values($result);
+	}//end replaceSchemaId()
+
+	/**
+	 * Parse a positive integer id out of an option value.
+	 *
+	 * @param string $value  The raw value.
+	 * @param string $option The whole option, for the error message.
+	 *
+	 * @return int The id.
+	 *
+	 * @throws RuntimeException When the value is not a positive integer.
+	 */
+	private function positiveId(string $value, string $option): int {
+		$value = trim($value);
+		if (ctype_digit($value) === false || (int)$value < 1) {
+			throw new RuntimeException(
+				sprintf('--keep "%s" is not a positive id or <schemaId>:<registerId> pair.', $option)
+			);
+		}
+
+		return (int)$value;
+	}//end positiveId()
+
+	/**
+	 * Normalise a stored schemas value into a list of positive ints.
+	 *
+	 * @param mixed $candidates The stored value.
+	 *
+	 * @return int[] The normalised ids.
+	 */
+	private function normaliseIds(mixed $candidates): array {
+		$ids = [];
+		foreach ((array)$candidates as $candidate) {
+			if (is_numeric($candidate) === true && (int)$candidate > 0) {
+				$ids[] = (int)$candidate;
+			}
+		}
+
+		return array_values(array_unique($ids));
+	}//end normaliseIds()
+}//end class

--- a/lib/Service/SharedSchema/SchemaTableMigrator.php
+++ b/lib/Service/SharedSchema/SchemaTableMigrator.php
@@ -1,0 +1,495 @@
+<?php
+
+/**
+ * OpenRegister SchemaTableMigrator
+ *
+ * Moves a register's object rows from the magic table of a shared schema onto
+ * the magic table of the register's own replacement schema, mapping columns and
+ * reporting — never silently dropping — the ones with no destination.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\SharedSchema
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\SharedSchema;
+
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\Schema;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Carry object rows across a schema split.
+ *
+ * Objects live in per-pair tables `<prefix>openregister_table_<register>_<schema>`,
+ * so when a register is repointed at a new schema id its rows must follow. A bare
+ * `ALTER TABLE ... RENAME` — what the older `openregister:schemas:dedup` does — is
+ * only correct while the new schema is a byte-copy of the old one. It is exactly
+ * wrong for the case this repair exists for: the replacement schema is rebuilt
+ * from the register's OWN configuration, so its table has the columns the shared
+ * entity had overwritten away, and lacks the ones that belonged to the other app.
+ * The move therefore has to be a column-mapped INSERT-SELECT.
+ *
+ * @spec openspec/changes/dedupe-shared-schemas/proposal.md
+ */
+class SchemaTableMigrator {
+
+	/**
+	 * Bare (unprefixed) magic-table name stem.
+	 *
+	 * @var string
+	 */
+	public const TABLE_STEM = 'openregister_table_';
+
+	/**
+	 * Suffix appended to a source table once its rows have been copied away.
+	 *
+	 * Chosen so the result no longer matches the shard pattern
+	 * `<prefix>openregister_table_<int>_<int>` that
+	 * {@see \OCA\OpenRegister\Service\RegisterSchemaLinkageRepairService} treats as
+	 * evidence of a pairing. A source table left under its original name would
+	 * make `relink-schemas` propose re-linking the register to the very schema
+	 * this repair just split it away from — the sibling command would quietly undo
+	 * this one. Keeping the table (rather than dropping it) is what makes an
+	 * unmapped column recoverable instead of lost.
+	 *
+	 * @var string
+	 */
+	public const BACKUP_SUFFIX = '_predupe';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IDBConnection   $db          Database connection for the row move.
+	 * @param IConfig         $config      System config, read for `dbtableprefix`.
+	 * @param MagicMapper     $magicMapper Magic-table DDL and introspection.
+	 * @param LoggerInterface $logger      Audit trail for every mutation.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly IDBConnection $db,
+		private readonly IConfig $config,
+		private readonly MagicMapper $magicMapper,
+		private readonly LoggerInterface $logger,
+	) {
+	}//end __construct()
+
+	/**
+	 * Work out which source columns survive the move to the new table.
+	 *
+	 * `_id` is excluded on purpose. It is an autoincrement primary key; copying
+	 * the values verbatim would leave the target's sequence behind the highest
+	 * copied id, so the next insert into the repaired table would collide. `_uuid`
+	 * is the identity relations actually store, and it IS copied.
+	 *
+	 * Matching is case-insensitive because `information_schema` folds identifier
+	 * case differently per platform, and a case mismatch here would report every
+	 * column as unmapped — which under `--strict` would refuse every otherwise
+	 * healthy split.
+	 *
+	 * @param string[] $sourceColumns Column names of the table holding the rows.
+	 * @param string[] $targetColumns Column names of the table built for the new schema.
+	 *
+	 * @return array{mapped: string[], unmapped: string[]} Columns that move, and source
+	 *         columns with no destination.
+	 *
+	 * @spec openspec/changes/dedupe-shared-schemas/proposal.md
+	 */
+	public static function planColumnMapping(array $sourceColumns, array $targetColumns): array {
+		$target  = array_map('strtolower', array_map('strval', $targetColumns));
+		$mapped  = [];
+		$dropped = [];
+
+		foreach ($sourceColumns as $column) {
+			$column = (string)$column;
+			if ($column === '_id') {
+				continue;
+			}
+
+			if (in_array(strtolower($column), $target, true) === true) {
+				$mapped[] = $column;
+				continue;
+			}
+
+			$dropped[] = $column;
+		}
+
+		sort($mapped);
+		sort($dropped);
+
+		return ['mapped' => $mapped, 'unmapped' => $dropped];
+	}//end planColumnMapping()
+
+	/**
+	 * Build the INSERT-SELECT that moves the mapped columns.
+	 *
+	 * Identifiers cannot be bound as parameters, so every name is validated
+	 * against a plain-identifier pattern before it is interpolated. The quote
+	 * character is passed in rather than detected here so the statement builder
+	 * stays pure and testable.
+	 *
+	 * @param string   $sourceTable The fully qualified source table.
+	 * @param string   $targetTable The fully qualified target table.
+	 * @param string[] $columns     The columns to copy, in order.
+	 * @param string   $quote       The identifier quote character.
+	 *
+	 * @return string The statement.
+	 *
+	 * @throws RuntimeException When there are no columns, or an identifier is unsafe.
+	 *
+	 * @spec openspec/changes/dedupe-shared-schemas/proposal.md
+	 */
+	public static function buildCopySql(
+		string $sourceTable,
+		string $targetTable,
+		array $columns,
+		string $quote='"'
+	): string {
+		if ($columns === []) {
+			throw new RuntimeException('Refusing to build a copy statement with no columns.');
+		}
+
+		$quoted = [];
+		foreach ($columns as $column) {
+			$quoted[] = self::quoteIdentifier(name: (string)$column, quote: $quote);
+		}
+
+		$list = implode(', ', $quoted);
+
+		return sprintf(
+			'INSERT INTO %s (%s) SELECT %s FROM %s',
+			self::quoteIdentifier(name: $targetTable, quote: $quote),
+			$list,
+			$list,
+			self::quoteIdentifier(name: $sourceTable, quote: $quote)
+		);
+	}//end buildCopySql()
+
+	/**
+	 * The bare magic-table name for a register/schema pair.
+	 *
+	 * @param int $registerId The register id.
+	 * @param int $schemaId   The schema id.
+	 *
+	 * @return string The unprefixed table name.
+	 *
+	 * @spec openspec/changes/dedupe-shared-schemas/proposal.md
+	 */
+	public function tableNameFor(int $registerId, int $schemaId): string {
+		return self::TABLE_STEM . $registerId . '_' . $schemaId;
+	}//end tableNameFor()
+
+	/**
+	 * Name the source columns a split would leave behind, without writing anything.
+	 *
+	 * Predicting the target's columns at plan time is what lets `--strict` refuse
+	 * BEFORE anything is created, and what lets the dry run name the columns that
+	 * would be stranded. Deciding after the target table exists would leave a
+	 * stray table behind on MySQL, where DDL does not roll back with the
+	 * transaction.
+	 *
+	 * @param string            $table      The bare source table name.
+	 * @param array<string, mixed> $definition The register's configured definition, or null
+	 *                                      when the split falls back to cloning.
+	 * @param array<string, mixed> $content The current shared entity content.
+	 *
+	 * @return string[] Source columns with no destination.
+	 *
+	 * @spec openspec/changes/dedupe-shared-schemas/proposal.md
+	 */
+	public function planUnmapped(string $table, ?array $definition, array $content): array {
+		$source = $this->columnsOf(table: $table);
+		if ($source === []) {
+			$source = $this->columnsForDefinition(definition: $content);
+		}
+
+		$target = $content;
+		if ($definition !== null) {
+			$target = $definition;
+		}
+
+		return self::planColumnMapping(
+			sourceColumns: $source,
+			targetColumns: $this->columnsForDefinition(definition: $target)
+		)['unmapped'];
+	}//end planUnmapped()
+
+	/**
+	 * List a bare table's column names, or an empty list when it is absent.
+	 *
+	 * @param string $table The bare (unprefixed) table name.
+	 *
+	 * @return string[] The column names.
+	 */
+	private function columnsOf(string $table): array {
+		try {
+			return array_map('strval', array_keys($this->magicMapper->getExistingTableColumns(tableName: $table)));
+		} catch (Throwable $e) {
+			unset($e);
+			return [];
+		}
+	}//end columnsOf()
+
+	/**
+	 * Ask the magic-table column builder what a definition would materialise as.
+	 *
+	 * A transient, unpersisted {@see Schema} is hydrated purely so the real column
+	 * builder answers the question — reimplementing the property-to-column rules
+	 * here would drift from the DDL the split actually produces.
+	 *
+	 * @param array<string, mixed> $definition The schema definition.
+	 *
+	 * @return string[] The column names, or an empty list when the builder refuses.
+	 */
+	private function columnsForDefinition(array $definition): array {
+		$transient = new Schema();
+
+		try {
+			$transient->hydrate($definition);
+			return array_map(
+				'strval',
+				array_keys($this->magicMapper->buildTableColumnsFromSchema(schema: $transient))
+			);
+		} catch (Throwable $e) {
+			$this->logger->warning(
+				message: '[SharedSchemaDedupe] Could not predict columns: ' . $e->getMessage(),
+				context: ['file' => __FILE__, 'line' => __LINE__],
+			);
+			return [];
+		}
+	}//end columnsForDefinition()
+
+	/**
+	 * Count the rows in a bare magic table.
+	 *
+	 * @param string $table The bare (unprefixed) table name.
+	 *
+	 * @return int The row count, or -1 when the table is absent or unreadable.
+	 *
+	 * @spec openspec/changes/dedupe-shared-schemas/proposal.md
+	 */
+	public function countRows(string $table): int {
+		$full = ($this->prefix() . $table);
+		if ($this->tableExists(table: $full) === false) {
+			return -1;
+		}
+
+		try {
+			$quoted = self::quoteIdentifier(name: $full, quote: $this->quoteChar());
+			return (int)$this->db->executeQuery('SELECT COUNT(*) AS c FROM ' . $quoted)->fetchOne();
+		} catch (Throwable $e) {
+			unset($e);
+			return -1;
+		}
+	}//end countRows()
+
+	/**
+	 * Move a register's rows onto the table of its replacement schema.
+	 *
+	 * @param Register $register The register being split off.
+	 * @param Schema   $schema   The register's new schema.
+	 * @param int      $oldId    The shared schema id being left behind.
+	 *
+	 * @return array{rows: int, unmapped: string[], backup: string|null} How many rows moved,
+	 *         which source columns had no destination, and where the source table went.
+	 *
+	 * @spec openspec/changes/dedupe-shared-schemas/proposal.md
+	 */
+	public function migrate(Register $register, Schema $schema, int $oldId): array {
+		$registerId = (int)$register->getId();
+		$sourceBare = $this->tableNameFor(registerId: $registerId, schemaId: $oldId);
+		$source     = ($this->prefix() . $sourceBare);
+
+		if ($this->tableExists(table: $source) === false) {
+			return ['rows' => 0, 'unmapped' => [], 'backup' => null];
+		}
+
+		$this->magicMapper->ensureTableForRegisterSchema(register: $register, schema: $schema);
+		$targetBare = $this->magicMapper->getTableNameForRegisterSchema(register: $register, schema: $schema);
+
+		$mapping = self::planColumnMapping(
+			sourceColumns: $this->columnsOf(table: $sourceBare),
+			targetColumns: $this->columnsOf(table: $targetBare)
+		);
+
+		$quote = $this->quoteChar();
+		$this->db->executeStatement(
+			self::buildCopySql(
+				sourceTable: $source,
+				targetTable: ($this->prefix() . $targetBare),
+				columns: $mapping['mapped'],
+				quote: $quote
+			)
+		);
+
+		$rows = $this->restamp(
+			table: ($this->prefix() . $targetBare),
+			registerId: $registerId,
+			oldId: $oldId,
+			newId: (int)$schema->getId(),
+			quote: $quote
+		);
+
+		$backup = ($source . self::BACKUP_SUFFIX);
+		$this->db->executeStatement(
+			sprintf(
+				'ALTER TABLE %s RENAME TO %s',
+				self::quoteIdentifier(name: $source, quote: $quote),
+				self::quoteIdentifier(name: $backup, quote: $quote)
+			)
+		);
+
+		$this->logger->warning(
+			message: sprintf(
+				'[SharedSchemaDedupe] Moved %d row(s) from %s to %s; source kept as %s; %d unmapped column(s): %s.',
+				$rows,
+				$source,
+				($this->prefix() . $targetBare),
+				$backup,
+				count($mapping['unmapped']),
+				implode(', ', $mapping['unmapped'])
+			),
+			context: ['file' => __FILE__, 'line' => __LINE__, 'register' => $registerId, 'schema' => $oldId]
+		);
+
+		return ['rows' => $rows, 'unmapped' => $mapping['unmapped'], 'backup' => $backup];
+	}//end migrate()
+
+	/**
+	 * Repoint the copied rows' denormalised schema references at the new id.
+	 *
+	 * The table name is not the only place the pairing is recorded. Every row also
+	 * carries `_schema`, and `_uri` embeds the schema id in the absolute URL the
+	 * save path stores. Leaving either at the old value attributes the moved rows
+	 * to the register that KEPT the shared schema — exactly the cross-app bleed
+	 * this repair exists to end. Verified as a real failure mode on the larpingapp
+	 * split, where 139 rows sat at the old `_schema` inside the renamed table.
+	 *
+	 * @param string $table      The fully qualified target table.
+	 * @param int    $registerId The owning register id, which bounds the uri rewrite.
+	 * @param int    $oldId      The shared schema id.
+	 * @param int    $newId      The register's new schema id.
+	 * @param string $quote      The identifier quote character.
+	 *
+	 * @return int The number of rows restamped.
+	 */
+	private function restamp(string $table, int $registerId, int $oldId, int $newId, string $quote): int {
+		$quoted = self::quoteIdentifier(name: $table, quote: $quote);
+
+		$rows = $this->db->executeStatement(
+			sprintf('UPDATE %s SET _schema = :new WHERE _schema = :old', $quoted),
+			['new' => (string)$newId, 'old' => (string)$oldId]
+		);
+
+		try {
+			$this->db->executeStatement(
+				sprintf('UPDATE %s SET _uri = REPLACE(_uri, :old, :new) WHERE _uri LIKE :match', $quoted),
+				[
+					'old'   => sprintf('/%d/%d/', $registerId, $oldId),
+					'new'   => sprintf('/%d/%d/', $registerId, $newId),
+					'match' => sprintf('%%/%d/%d/%%', $registerId, $oldId),
+				]
+			);
+		} catch (Throwable $e) {
+			// A stale `_uri` is a cosmetic link, not a correctness boundary: the
+			// row is already attributed by `_schema` and by the table it lives in.
+			// Failing the whole split over it would be worse than reporting it.
+			$this->logger->warning(
+				message: '[SharedSchemaDedupe] Could not rewrite _uri on ' . $table . ': ' . $e->getMessage(),
+				context: ['file' => __FILE__, 'line' => __LINE__],
+			);
+		}
+
+		return $rows;
+	}//end restamp()
+
+	/**
+	 * Check whether a fully qualified table exists.
+	 *
+	 * @param string $table The fully qualified table name.
+	 *
+	 * @return bool True when it exists.
+	 */
+	private function tableExists(string $table): bool {
+		try {
+			$stmt = $this->db->prepare(
+				'SELECT 1 FROM information_schema.tables WHERE table_name = ? LIMIT 1'
+			);
+			$stmt->execute([$table]);
+			return $stmt->fetchOne() !== false;
+		} catch (Throwable $e) {
+			unset($e);
+			return false;
+		}
+	}//end tableExists()
+
+	/**
+	 * The configured table prefix.
+	 *
+	 * @return string The prefix, defaulting to `oc_`.
+	 */
+	private function prefix(): string {
+		$prefix = (string)$this->config->getSystemValue('dbtableprefix', 'oc_');
+		if ($prefix === '') {
+			return 'oc_';
+		}
+
+		return $prefix;
+	}//end prefix()
+
+	/**
+	 * The identifier quote character for this platform.
+	 *
+	 * @return string A backtick on MySQL and MariaDB, a double quote elsewhere.
+	 */
+	private function quoteChar(): string {
+		try {
+			$platform = $this->db->getDatabasePlatform()::class;
+		} catch (Throwable $e) {
+			unset($e);
+			return '"';
+		}
+
+		if (stripos($platform, 'MySQL') !== false || stripos($platform, 'MariaDB') !== false) {
+			return '`';
+		}
+
+		return '"';
+	}//end quoteChar()
+
+	/**
+	 * Quote a SQL identifier after validating it is a plain name.
+	 *
+	 * @param string $name  The identifier.
+	 * @param string $quote The quote character.
+	 *
+	 * @return string The quoted identifier.
+	 *
+	 * @throws RuntimeException When the name is not a plain SQL identifier.
+	 */
+	private static function quoteIdentifier(string $name, string $quote): string {
+		if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $name) !== 1) {
+			throw new RuntimeException(sprintf('Refusing to quote unsafe identifier "%s".', $name));
+		}
+
+		return $quote . $name . $quote;
+	}//end quoteIdentifier()
+}//end class

--- a/lib/Service/SharedSchemaDedupeService.php
+++ b/lib/Service/SharedSchemaDedupeService.php
@@ -1,0 +1,438 @@
+<?php
+
+/**
+ * OpenRegister SharedSchemaDedupeService
+ *
+ * Detects schema entities that more than one register co-owns, attributes the
+ * canonical owner from the referencing registers' own app configuration, and
+ * splits the non-canonical ones onto their own schema entity — moving their
+ * object rows with it.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Configuration\ImportHandler;
+use OCA\OpenRegister\Service\SharedSchema\RegisterConfigurationLocator;
+use OCA\OpenRegister\Service\SharedSchema\SchemaAttribution;
+use OCA\OpenRegister\Service\SharedSchema\SchemaTableMigrator;
+use OCP\IDBConnection;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Split schema entities that several registers wrongly share.
+ *
+ * A schema row carries no register column: the relation lives only as a JSON id
+ * list on the register. Before the per-register slug-uniqueness fix in
+ * {@see ImportHandler}, an import that resolved a slug globally re-used whatever
+ * schema row already carried that slug, so two apps could end up pointing at one
+ * entity. From then on every import of either app rewrote the definition for
+ * both — last import wins, instance-wide.
+ *
+ * `occ openregister:registers:relink-schemas` ADDS lost linkage; this service is
+ * its counterpart, which SPLITS linkage that was never meant to be shared.
+ *
+ * Attribution is evidence-based rather than heuristic, and lives in
+ * {@see SchemaAttribution}. When the evidence does not single one owner out the
+ * repair REFUSES and asks for an explicit `--keep`: guessing an owner is what
+ * produced the damage in the first place.
+ *
+ * @spec openspec/changes/dedupe-shared-schemas/proposal.md
+ */
+class SharedSchemaDedupeService {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IDBConnection                $db             Database connection, for the split transaction.
+	 * @param RegisterMapper               $registerMapper Register lookups and persistence.
+	 * @param SchemaMapper                 $schemaMapper   Schema lookups and the clone fallback.
+	 * @param ImportHandler                $importHandler  The configuration-driven schema create path.
+	 * @param RegisterConfigurationLocator $locator        Reads a register's own app configuration.
+	 * @param SchemaAttribution            $attribution    The pure detection and ownership rules.
+	 * @param SchemaTableMigrator          $migrator       Moves the object rows across the split.
+	 * @param LoggerInterface              $logger         Audit trail for every mutation.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly IDBConnection $db,
+		private readonly RegisterMapper $registerMapper,
+		private readonly SchemaMapper $schemaMapper,
+		private readonly ImportHandler $importHandler,
+		private readonly RegisterConfigurationLocator $locator,
+		private readonly SchemaAttribution $attribution,
+		private readonly SchemaTableMigrator $migrator,
+		private readonly LoggerInterface $logger,
+	) {
+	}//end __construct()
+
+	/**
+	 * Parse the repeatable `--keep` option.
+	 *
+	 * @param array<int, mixed> $raw The raw option values.
+	 *
+	 * @return array{perSchema: array<int,int>, global: int|null} The parsed overrides.
+	 *
+	 * @throws RuntimeException When a value is not a positive id or id pair.
+	 *
+	 * @spec openspec/changes/dedupe-shared-schemas/proposal.md
+	 */
+	public function parseKeep(array $raw): array {
+		return $this->attribution->parseKeep(raw: $raw);
+	}//end parseKeep()
+
+	/**
+	 * Inspect the instance and produce the full repair plan.
+	 *
+	 * Reports only — never mutates, so the operator sees every split, every row
+	 * move and every column that would be left behind before opting in.
+	 *
+	 * @param int|null          $registerId Limit to plans involving this register, or null for all.
+	 * @param array<string, mixed> $keep    The parsed `--keep` overrides.
+	 *
+	 * @return array<int, array<string, mixed>> One entry per shared schema.
+	 *
+	 * @spec openspec/changes/dedupe-shared-schemas/proposal.md
+	 */
+	public function inspect(?int $registerId, array $keep): array {
+		$registers = $this->loadRegisters();
+		$stored    = [];
+		foreach ($registers as $id => $register) {
+			$stored[$id] = $register->getSchemas();
+		}
+
+		$plan = [];
+		foreach ($this->attribution->indexShared(registerSchemas: $stored) as $schemaId => $registerIds) {
+			if ($registerId !== null && in_array($registerId, $registerIds, true) === false) {
+				continue;
+			}
+
+			$entry = $this->planSchema(
+				schemaId: $schemaId,
+				registerIds: $registerIds,
+				registers: $registers,
+				keep: $keep
+			);
+
+			if ($entry !== null) {
+				$plan[] = $entry;
+			}
+		}
+
+		return $plan;
+	}//end inspect()
+
+	/**
+	 * Execute one planned split.
+	 *
+	 * Creation of the schema, the relink and the row move are one unit: a
+	 * half-applied split leaves a register pointing at an entity whose table holds
+	 * no rows, which is worse than the shared state it started from.
+	 *
+	 * @param array<string, mixed> $entry  One {@see self::inspect()} plan entry.
+	 * @param int                  $target The non-canonical register id to split off.
+	 * @param bool                 $strict Whether unmapped columns must refuse the move.
+	 *
+	 * @return array{newSchemaId: int, rows: int, unmapped: string[], backup: string|null} The outcome.
+	 *
+	 * @throws RuntimeException When the plan is unattributed, or strict mode refuses.
+	 *
+	 * @spec openspec/changes/dedupe-shared-schemas/proposal.md
+	 */
+	public function applySplit(array $entry, int $target, bool $strict): array {
+		$split = ($entry['splits'][$target] ?? null);
+		if (is_array($split) === false) {
+			throw new RuntimeException(sprintf('Register %d is not part of this plan.', $target));
+		}
+
+		if (($entry['owner'] ?? null) === null) {
+			throw new RuntimeException(
+				sprintf('Schema %d is unattributed; pass --keep to name the owner.', (int)$entry['schemaId'])
+			);
+		}
+
+		$unmapped = ($split['unmapped'] ?? []);
+		if ($strict === true && $unmapped !== []) {
+			throw new RuntimeException(
+				sprintf(
+					'Strict mode: %d source column(s) have no destination (%s).',
+					count($unmapped),
+					implode(', ', $unmapped)
+				)
+			);
+		}
+
+		$this->db->beginTransaction();
+		try {
+			$outcome = $this->splitLocked(entry: $entry, target: $target, split: $split);
+			$this->db->commit();
+		} catch (Throwable $e) {
+			$this->db->rollBack();
+			throw $e;
+		}
+
+		return $outcome;
+	}//end applySplit()
+
+	/**
+	 * Perform one split inside an open transaction.
+	 *
+	 * @param array<string, mixed> $entry  The plan entry.
+	 * @param int                  $target The register being split off.
+	 * @param array<string, mixed> $split  The per-register part of the plan.
+	 *
+	 * @return array{newSchemaId: int, rows: int, unmapped: string[], backup: string|null} The outcome.
+	 */
+	private function splitLocked(array $entry, int $target, array $split): array {
+		$register = $this->registerMapper->find(id: $target, _rbac: false, _multitenancy: false);
+		$oldId    = (int)$entry['schemaId'];
+
+		$schema = $this->createReplacementSchema(
+			register: $register,
+			definition: ($split['definition'] ?? null),
+			oldId: $oldId
+		);
+
+		$newId = (int)$schema->getId();
+
+		$register->setSchemas(
+			schemas: $this->attribution->replaceSchemaId(
+				schemas: $register->getSchemas(),
+				oldId: $oldId,
+				newId: $newId
+			)
+		);
+		$this->registerMapper->update($register);
+
+		$moved = $this->migrator->migrate(register: $register, schema: $schema, oldId: $oldId);
+
+		$this->logger->warning(
+			message: sprintf(
+				'[SharedSchemaDedupe] Register %d split off shared schema %d onto %d (%d row(s) moved).',
+				$target,
+				$oldId,
+				$newId,
+				$moved['rows']
+			),
+			context: ['file' => __FILE__, 'line' => __LINE__, 'register' => $target, 'schema' => $oldId]
+		);
+
+		return [
+			'newSchemaId' => $newId,
+			'rows'        => $moved['rows'],
+			'unmapped'    => $moved['unmapped'],
+			'backup'      => $moved['backup'],
+		];
+	}//end splitLocked()
+
+	/**
+	 * Create the register's own schema entity.
+	 *
+	 * Path A — the register's app configuration still declares the schema — goes
+	 * through {@see ImportHandler::importSchema()} with an EMPTY register scope, so
+	 * the per-register slug-uniqueness fix forces a brand new row rather than
+	 * resolving back onto the shared one. Running the repair through the same
+	 * create path the import uses is what makes the split durable: the next app
+	 * import finds the register's own entity and updates that instead of forking
+	 * the shared one again.
+	 *
+	 * Path B — no configuration on disk — clones the current entity content, which
+	 * preserves the rows' shape exactly and so needs no column mapping.
+	 *
+	 * @param Register          $register   The register being split off.
+	 * @param array<string, mixed> $definition Its configured definition, or null when it has none.
+	 * @param int               $oldId      The shared schema id being left behind.
+	 *
+	 * @return Schema The newly created schema.
+	 *
+	 * @throws RuntimeException When neither path yields a persisted schema.
+	 */
+	private function createReplacementSchema(Register $register, ?array $definition, int $oldId): Schema {
+		if ($definition !== null) {
+			$schema = $this->importHandler->importSchema(
+				data: $definition,
+				slugsAndIdsMap: $this->schemaMapper->getSlugToIdMap(),
+				owner: $register->getOwner(),
+				appId: $register->getApplication(),
+				version: (string)($definition['version'] ?? '0.0.1'),
+				force: true,
+				registerSchemaIds: []
+			);
+
+			if ($schema->getId() !== null) {
+				return $schema;
+			}
+		}
+
+		$source = $this->schemaMapper->find(id: $oldId, _rbac: false, _multitenancy: false);
+		$clone  = $source->jsonSerialize();
+		unset($clone['id'], $clone['uuid'], $clone['uri'], $clone['created'], $clone['updated']);
+		$clone['application'] = $register->getApplication();
+
+		$schema = $this->schemaMapper->createFromArray(object: $clone);
+		if ($schema->getId() === null) {
+			throw new RuntimeException(sprintf('Could not create a replacement for schema %d.', $oldId));
+		}
+
+		return $schema;
+	}//end createReplacementSchema()
+
+	/**
+	 * Build the plan entry for one shared schema.
+	 *
+	 * @param int                  $schemaId    The shared schema id.
+	 * @param int[]                $registerIds The referencing registers.
+	 * @param array<int, Register> $registers   All loaded registers, by id.
+	 * @param array<string, mixed> $keep        The parsed overrides.
+	 *
+	 * @return array<string, mixed>|null The plan entry, or null when the schema no longer exists.
+	 */
+	private function planSchema(int $schemaId, array $registerIds, array $registers, array $keep): ?array {
+		try {
+			$entity = $this->schemaMapper->find(id: $schemaId, _rbac: false, _multitenancy: false);
+		} catch (Throwable $e) {
+			// A dangling id is `relink-schemas` territory, not a sharing problem.
+			unset($e);
+			return null;
+		}
+
+		$content    = $entity->jsonSerialize();
+		$candidates = $this->configuredDefinitions(
+			registerIds: $registerIds,
+			registers: $registers,
+			slug: strtolower((string)$entity->getSlug())
+		);
+
+		$verdict = $this->attribution->classify(candidates: $candidates, entity: $content);
+		$owner   = $this->attribution->resolveOwner(
+			verdict: $verdict,
+			schemaId: $schemaId,
+			registerIds: $registerIds,
+			keep: $keep
+		);
+
+		return [
+			'schemaId'    => $schemaId,
+			'schemaSlug'  => (string)$entity->getSlug(),
+			'registerIds' => $registerIds,
+			'status'      => $verdict['status'],
+			'matches'     => $verdict['matches'],
+			'owner'       => $owner['owner'],
+			'ownerSource' => $owner['source'],
+			'splits'      => $this->planSplits(
+				schemaId: $schemaId,
+				owner: $owner['owner'],
+				registers: $registers,
+				candidates: $candidates,
+				content: $content
+			),
+		];
+	}//end planSchema()
+
+	/**
+	 * Read each referencing register's configured definition for one schema slug.
+	 *
+	 * @param int[]                $registerIds The referencing registers.
+	 * @param array<int, Register> $registers   All loaded registers, by id.
+	 * @param string               $slug        The lowercased schema slug.
+	 *
+	 * @return array<int, mixed> registerId => definition, or null when it declares none.
+	 */
+	private function configuredDefinitions(array $registerIds, array $registers, string $slug): array {
+		$candidates = [];
+		foreach ($registerIds as $registerId) {
+			$register   = ($registers[$registerId] ?? null);
+			$configured = null;
+			if ($register !== null) {
+				$configured = ($this->locator->schemasFor(register: $register)[$slug] ?? null);
+			}
+
+			$candidates[$registerId] = $configured;
+		}
+
+		return $candidates;
+	}//end configuredDefinitions()
+
+	/**
+	 * Build the per-register split parts of a plan entry.
+	 *
+	 * @param int                  $schemaId   The shared schema id.
+	 * @param int|null             $owner      The resolved owner, when attributed.
+	 * @param array<int, Register> $registers  All loaded registers, by id.
+	 * @param array<int, mixed>    $candidates Each register's configured definition.
+	 * @param array<string, mixed> $content    The current entity content.
+	 *
+	 * @return array<int, array<string, mixed>> registerId => the split that would be performed.
+	 */
+	private function planSplits(int $schemaId, ?int $owner, array $registers, array $candidates, array $content): array {
+		$splits = [];
+		foreach ($candidates as $registerId => $definition) {
+			$register = ($registers[$registerId] ?? null);
+			if ($registerId === $owner || $register === null) {
+				continue;
+			}
+
+			$bare = $this->migrator->tableNameFor(registerId: (int)$registerId, schemaId: $schemaId);
+			$path = 'configuration';
+			if ($definition === null) {
+				$path = 'clone';
+			}
+
+			$splits[$registerId] = [
+				'registerSlug' => (string)$register->getSlug(),
+				'application'  => $register->getApplication(),
+				'path'         => $path,
+				'definition'   => $definition,
+				'table'        => $bare,
+				'rows'         => $this->migrator->countRows(table: $bare),
+				'unmapped'     => $this->migrator->planUnmapped(
+					table: $bare,
+					definition: $definition,
+					content: $content
+				),
+			];
+		}//end foreach
+
+		return $splits;
+	}//end planSplits()
+
+	/**
+	 * Load every register keyed by id.
+	 *
+	 * @return array<int, Register> registerId => register.
+	 */
+	private function loadRegisters(): array {
+		$registers = [];
+		foreach ($this->registerMapper->findAll(_rbac: false, _multitenancy: false) as $register) {
+			if ($register instanceof Register === false) {
+				continue;
+			}
+
+			$registers[(int)$register->getId()] = $register;
+		}
+
+		return $registers;
+	}//end loadRegisters()
+}//end class

--- a/openspec/changes/dedupe-shared-schemas/proposal.md
+++ b/openspec/changes/dedupe-shared-schemas/proposal.md
@@ -1,0 +1,68 @@
+---
+kind: code
+---
+
+# Proposal: dedupe-shared-schemas
+
+## Why
+
+The slug-collision family is being closed on two fronts: resolution scoping
+(`register-scoped-schema-slug-resolution`, `register-scoped-slug-resolution`,
+`schema-slug-cross-app-scoping`) and the import side (the per-register
+slug-uniqueness fix in `ImportHandler`, which stops NEW cross-register reuse).
+
+Neither front repairs the damage already done. Registers that came to share a
+schema entity in the pre-fix era keep co-owning its definition: every register
+import that touches the shared entity rewrites it for all referencing registers
+— last import wins, instance-wide. `occ openregister:registers:relink-schemas`
+ADDS lost linkage but has no counterpart that SPLITS wrongly shared entities.
+
+Observed on the shared dev instance (2026-08-21, openregister#2689): the
+`planix` (19) and `pipelinq` (16) registers both referenced schema entities
+task=74, project=159, timeEntry=161. Schema 161 held planix's 6-property
+timeEntry; pipelinq's own definition (hours, billingCategory, client, project,
+WIP/billing-sync — the model its billing features depend on) was gone from the
+instance. A planix schema extension transparently changed pipelinq's `task`
+definition. `relink-schemas` reported 47 registers with recoverable linkage on
+the same instance — the same era of drift.
+
+## What Changes
+
+A repair command, `occ openregister:registers:dedupe-shared-schemas`, mirroring
+`relink-schemas` in shape (dry-run by default, `--write`, `--register`):
+
+1. **Detect**: every schema id referenced by more than one register.
+2. **Attribute**: for each shared schema, determine the canonical owner — the
+   register whose app configuration (register.json / register.d) declares a
+   definition matching the current entity content; when no configuration
+   matches (or several do), report and require an explicit
+   `--keep <registerId>` per schema rather than guessing.
+3. **Split**: every non-canonical register gets its own new schema entity,
+   built from that register's own app configuration when available (the
+   import-side fix then keeps it isolated forever), else cloned from the
+   current entity content.
+4. **Relink**: rewrite the register's schema linkage to the new id.
+5. **Migrate data**: move the register's magic-table rows from
+   `table_{reg}_{oldId}` to `table_{reg}_{newId}` with column mapping per the
+   restored definition; report columns that have no destination instead of
+   dropping them silently.
+6. **Report**: per register/schema, what was split, what moved, what needs a
+   follow-up app reimport.
+
+## Validation of the algorithm
+
+Steps 1–4 were executed manually on the shared dev instance for the
+planix/pipelinq pair (step 5 was unnecessary — the affected rows were demo
+seeds): unlinking 74/159/161 from register 16 and re-running pipelinq's
+configuration import produced three new, correctly-defined, register-private
+schemas (9463/9464/9465) with planix untouched — confirming the import-side
+fix makes the split durable and the repair is mechanical.
+
+## Impact
+
+- New command class alongside `RelinkRegisterSchemasCommand`; no behaviour
+  change for healthy instances (dry-run reports nothing).
+- Instances repaired this way stop exhibiting cross-app schema bleed; app
+  register imports become safe to re-run.
+- Relates to: openregister#2689, the three resolution-scoping changes, and the
+  ImportHandler per-register slug-uniqueness fix.

--- a/openspec/changes/dedupe-shared-schemas/tasks.md
+++ b/openspec/changes/dedupe-shared-schemas/tasks.md
@@ -1,0 +1,96 @@
+# Tasks: dedupe-shared-schemas
+
+## 1. Detection & attribution
+
+- [x] 1.1 Query building: find every schema id referenced by >1 register (registers.schemas JSON arrays).
+      `SchemaAttribution::indexShared()` inverts the register->schemas map in PHP rather than in SQL,
+      for the reason `RegisterMapper::getAllRegisterIdsWithSchema()` already documents: the `schemas`
+      column is `json` on Postgres and text elsewhere, and SQLite has no REGEXP. Ids stored as strings
+      are normalised, so `"161"` and `161` count as the same reference.
+- [x] 1.2 Canonical-owner attribution: match each referencing register's app configuration
+      (register.json / register.d fragments, resolved the same way SettingsService merges them)
+      against the current schema entity content; classify per schema: exactly-one-match /
+      no-match / multi-match.
+      `RegisterConfigurationLocator` mirrors `AppHostSettingsService::resolveRegisterConfiguration()`
+      (base `<appId>_register.json` + sorted `register.d/*.json` deep-merged). The glob is widened to
+      every `*_register.json` because OpenRegister ships several documents rather than one monolith.
+      Comparison is on the property-NAME set + `required`, not byte equality — the import path stamps
+      defaults and folds `$ref`s, so byte equality would put every schema in `no-match`.
+- [x] 1.3 `--keep <registerId>` override for no-match / multi-match schemas; refuse `--write`
+      for unattributed shared schemas without it.
+      Both forms: `--keep <schemaId>:<registerId>` (repeatable) and a bare `--keep <registerId>`
+      covering everything unattributed. Per-schema outranks bare; a `--keep` naming a register that
+      does not reference the schema is ignored rather than honoured.
+
+## 2. Split & relink
+
+- [x] 2.1 Clone path A (preferred): create the non-canonical register's schema from its OWN app
+      configuration definition, reusing the ImportHandler create path so the per-register
+      slug-uniqueness behaviour applies.
+      `ImportHandler::importSchema(..., registerSchemaIds: [])` — the empty scope makes
+      `findBySlugInIds()` short-circuit, forcing a brand new row instead of resolving back onto the
+      shared one.
+- [x] 2.2 Clone path B (fallback, no configuration available): copy the current entity content
+      into a new schema row. `SchemaMapper::createFromArray()` on the serialised entity minus
+      id/uuid/uri/timestamps, re-stamped with the register's application.
+- [x] 2.3 Rewrite register.schemas linkage old id → new id, preserving order.
+      `SchemaAttribution::replaceSchemaId()` — in place, and non-numeric legacy entries are copied
+      verbatim rather than normalised away.
+
+## 3. Data migration
+
+- [x] 3.1 Move rows `table_{reg}_{oldId}` → `table_{reg}_{newId}` (create target table via the
+      magic-table DDL for the restored definition; INSERT-SELECT with column mapping).
+      Target created by `MagicMapper::ensureTableForRegisterSchema()`. `_id` is excluded from the
+      copy: it is autoincrement, so copying the values would strand the target's sequence behind the
+      highest copied id and the next insert would collide. `_uuid` — the identity relations store —
+      does move.
+- [x] 3.2 Report source columns without a destination; never drop silently. `--strict`
+      turns unmapped columns into a refusal.
+      Unmapped columns are computed at PLAN time (a transient unpersisted `Schema` is fed to the real
+      `buildTableColumnsFromSchema()`), so the dry run names them and `--strict` refuses BEFORE
+      anything is written — on MySQL a post-hoc refusal would strand the created table, since DDL
+      there does not roll back with the transaction. The source table is renamed to `_predupe` rather
+      than dropped, so an unmapped column stays recoverable. That suffix also stops the table matching
+      the shard pattern `relink-schemas` reads as evidence — left as-is, the sibling command would
+      re-link the register to the schema this one just split it away from.
+- [x] 3.3 Update object rows' `_schema` metadata and any denormalised schema references
+      (folders, uri) the codebase keeps.
+      `_schema` and the schema id embedded in `_uri` are both rewritten. `_folder` is deliberately NOT
+      touched: it holds a Nextcloud folder node id and object folders are created inside the REGISTER
+      folder (`FolderManagementHandler::createObjectFolderInRegister()`), so folders are
+      register-scoped and a schema renumber does not invalidate them.
+
+## 4. Command surface & safety
+
+- [x] 4.1 `occ openregister:registers:dedupe-shared-schemas` — dry-run default, `--write`,
+      `--register`, `--keep`, `--strict`; output format mirroring relink-schemas.
+- [x] 4.2 Must-PASS control: instance with a shared schema pair → dry-run lists it, `--write`
+      splits it, app reimport after the split does NOT re-share (regression guard on the
+      ImportHandler fix).
+      `SchemaAttributionTest::testDetectsAndAttributesTheObservedSharedPair()` (the real 19/16 ×
+      74/159/161 shape) and `DedupeSharedSchemasCommandTest::testWriteAppliesTheSplit()`.
+      **Partial:** the "app reimport does not re-share" leg is covered structurally — the split goes
+      through `importSchema(registerSchemaIds: [])`, whose behaviour is already locked by
+      `ImportHandlerPerRegisterSlugUniquenessTest` — not by an end-to-end reimport, which needs a
+      booted Nextcloud. See the PR body.
+- [x] 4.3 Must-FAIL control: healthy instance → dry-run reports nothing and `--write` changes
+      nothing (idempotence: second run is a no-op).
+      `SchemaAttributionTest::testHealthyInstanceHasNothingToRepair()`,
+      `testSecondRunAfterASplitIsANoOp()` (feeds the post-split ids back in) and
+      `DedupeSharedSchemasCommandTest::testHealthyInstanceReportsNothing()`, which asserts
+      `applySplit()` is never called.
+- [x] 4.4 Unit tests for attribution matrix (one-match / no-match / multi-match) and column
+      mapping edge cases.
+      33 tests. The generated `INSERT ... SELECT` is additionally EXECUTED against a real in-memory
+      SQLite database, so the statement is proven to parse and to move exactly the mapped columns
+      rather than merely string-matching what the test author expected. All four decision rules were
+      mutation-checked: breaking the sharing threshold, letting multi-match guess an owner, dropping
+      the unmapped-column report, and disabling the `--write` refusal each fail the suite.
+
+## 5. Docs
+
+- [x] 5.1 Admin docs page next to relink-schemas: when drift happens, how to read the dry-run,
+      the planix/pipelinq case as the worked example (openregister#2689).
+      `docs/Technical/repairing-shared-schemas.md`, linked from `docs/api/schemas.md` beside the
+      existing `relink-schemas` pointer.

--- a/tests/Unit/Command/DedupeSharedSchemasCommandTest.php
+++ b/tests/Unit/Command/DedupeSharedSchemasCommandTest.php
@@ -1,0 +1,303 @@
+<?php
+
+/**
+ * Unit tests for the dedupe-shared-schemas command surface (#2689).
+ *
+ * The safety rails are the point of this command, so they are what is asserted:
+ * dry run by default, an explicit refusal to write an unattributed schema, and
+ * `--strict` passed through to the row move. A repair that mutates schema
+ * linkage and moves data tables must be provably inert until asked.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Command
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Command;
+
+use OCA\OpenRegister\Command\DedupeSharedSchemasCommand;
+use OCA\OpenRegister\Service\SharedSchema\SchemaAttribution;
+use OCA\OpenRegister\Service\SharedSchemaDedupeService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * Locks the console surface of `occ openregister:registers:dedupe-shared-schemas`.
+ */
+class DedupeSharedSchemasCommandTest extends TestCase {
+
+	/**
+	 * The mocked repair service.
+	 *
+	 * @var SharedSchemaDedupeService&MockObject
+	 */
+	private SharedSchemaDedupeService&MockObject $dedupe;
+
+	/**
+	 * The command under test.
+	 *
+	 * @var DedupeSharedSchemasCommand
+	 */
+	private DedupeSharedSchemasCommand $command;
+
+	/**
+	 * Wire the command onto a mocked service.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->dedupe = $this->createMock(SharedSchemaDedupeService::class);
+		$this->dedupe->method('parseKeep')->willReturn(['perSchema' => [], 'global' => null]);
+		$this->command = new DedupeSharedSchemasCommand($this->dedupe);
+
+	}//end setUp()
+
+	/**
+	 * Run the command and capture its exit code and output.
+	 *
+	 * @param array<string, mixed> $args The console arguments.
+	 *
+	 * @return array{0: int, 1: string} The exit code and the rendered output.
+	 */
+	private function execute(array $args): array {
+		$input  = new ArrayInput($args, $this->command->getDefinition());
+		$output = new BufferedOutput();
+		$code   = $this->command->run($input, $output);
+
+		return [$code, $output->fetch()];
+
+	}//end execute()
+
+	/**
+	 * One attributed plan entry: register 16 splits off shared schema 161.
+	 *
+	 * @return array<int, array<string, mixed>> The plan.
+	 */
+	private function attributedPlan(): array {
+		return [
+			[
+				'schemaId'    => 161,
+				'schemaSlug'  => 'timeEntry',
+				'registerIds' => [16, 19],
+				'status'      => SchemaAttribution::STATUS_ONE_MATCH,
+				'matches'     => [19],
+				'owner'       => 19,
+				'ownerSource' => 'configuration',
+				'splits'      => [
+					16 => [
+						'registerSlug' => 'pipelinq',
+						'application'  => 'pipelinq',
+						'path'         => 'configuration',
+						'definition'   => ['slug' => 'timeEntry'],
+						'table'        => 'openregister_table_16_161',
+						'rows'         => 42,
+						'unmapped'     => ['employee'],
+					],
+				],
+			],
+		];
+
+	}//end attributedPlan()
+
+	/**
+	 * The same plan, but attribution could not settle an owner.
+	 *
+	 * @return array<int, array<string, mixed>> The plan.
+	 */
+	private function unattributedPlan(): array {
+		$plan                = $this->attributedPlan();
+		$plan[0]['status']   = SchemaAttribution::STATUS_MULTI_MATCH;
+		$plan[0]['matches']  = [16, 19];
+		$plan[0]['owner']    = null;
+		$plan[0]['ownerSource'] = 'unattributed';
+
+		return $plan;
+
+	}//end unattributedPlan()
+
+	/**
+	 * MUST-FAIL CONTROL: a healthy instance reports nothing and writes nothing.
+	 *
+	 * @return void
+	 */
+	public function testHealthyInstanceReportsNothing(): void {
+		$this->dedupe->method('inspect')->willReturn([]);
+		$this->dedupe->expects($this->never())->method('applySplit');
+
+		[$code, $output] = $this->execute(['--write' => true]);
+
+		$this->assertSame(Command::SUCCESS, $code);
+		$this->assertStringContainsString('No schema is shared by more than one register', $output);
+
+	}//end testHealthyInstanceReportsNothing()
+
+	/**
+	 * Without `--write` the command reports and changes nothing.
+	 *
+	 * @return void
+	 */
+	public function testDryRunIsTheDefaultAndAppliesNothing(): void {
+		$this->dedupe->method('inspect')->willReturn($this->attributedPlan());
+		$this->dedupe->expects($this->never())->method('applySplit');
+
+		[$code, $output] = $this->execute([]);
+
+		$this->assertSame(Command::SUCCESS, $code);
+		$this->assertStringContainsString('1 schema(s) are shared by more than one register', $output);
+		$this->assertStringContainsString('schema 161 (timeEntry)', $output);
+		$this->assertStringContainsString('owner: register 19 (configuration)', $output);
+		$this->assertStringContainsString('register 16 (pipelinq)', $output);
+		$this->assertStringContainsString('42 row(s)', $output);
+		$this->assertStringContainsString('DRY RUN', $output);
+
+	}//end testDryRunIsTheDefaultAndAppliesNothing()
+
+	/**
+	 * The dry run names the columns that would be left behind.
+	 *
+	 * @return void
+	 */
+	public function testDryRunNamesTheColumnsWithNoDestination(): void {
+		$this->dedupe->method('inspect')->willReturn($this->attributedPlan());
+
+		[, $output] = $this->execute([]);
+
+		$this->assertStringContainsString('would have no destination: employee', $output);
+
+	}//end testDryRunNamesTheColumnsWithNoDestination()
+
+	/**
+	 * MUST-PASS CONTROL: `--write` on an attributed plan performs the split.
+	 *
+	 * @return void
+	 */
+	public function testWriteAppliesTheSplit(): void {
+		$this->dedupe->method('inspect')->willReturn($this->attributedPlan());
+		$this->dedupe->expects($this->once())
+			->method('applySplit')
+			->with($this->anything(), 16, false)
+			->willReturn([
+				'newSchemaId' => 9465,
+				'rows'        => 42,
+				'unmapped'    => ['employee'],
+				'backup'      => 'oc_openregister_table_16_161_predupe',
+			]);
+
+		[$code, $output] = $this->execute(['--write' => true]);
+
+		$this->assertSame(Command::SUCCESS, $code);
+		$this->assertStringContainsString('split', $output);
+		$this->assertStringContainsString('schema 161 -> 9465', $output);
+		$this->assertStringContainsString('42 row(s) moved', $output);
+		$this->assertStringContainsString('oc_openregister_table_16_161_predupe', $output);
+		$this->assertStringContainsString('1 split(s) applied; 0 failure(s)', $output);
+
+	}//end testWriteAppliesTheSplit()
+
+	/**
+	 * `--write` REFUSES an unattributed schema rather than guessing an owner.
+	 *
+	 * This is the rail the whole command exists behind: picking a side by heuristic
+	 * is what produced the damage being repaired.
+	 *
+	 * @return void
+	 */
+	public function testWriteRefusesAnUnattributedSchema(): void {
+		$this->dedupe->method('inspect')->willReturn($this->unattributedPlan());
+		$this->dedupe->expects($this->never())->method('applySplit');
+
+		[$code, $output] = $this->execute(['--write' => true]);
+
+		$this->assertSame(Command::FAILURE, $code);
+		$this->assertStringContainsString('UNATTRIBUTED', $output);
+		$this->assertStringContainsString('Refusing to write', $output);
+		$this->assertStringContainsString('--keep', $output);
+
+	}//end testWriteRefusesAnUnattributedSchema()
+
+	/**
+	 * A dry run over an unattributed schema says it would be skipped, and succeeds.
+	 *
+	 * @return void
+	 */
+	public function testDryRunAnnouncesTheSkipWithoutFailing(): void {
+		$this->dedupe->method('inspect')->willReturn($this->unattributedPlan());
+
+		[$code, $output] = $this->execute([]);
+
+		$this->assertSame(Command::SUCCESS, $code);
+		$this->assertStringContainsString('would be SKIPPED', $output);
+
+	}//end testDryRunAnnouncesTheSkipWithoutFailing()
+
+	/**
+	 * `--strict` reaches the row move.
+	 *
+	 * @return void
+	 */
+	public function testStrictIsPassedThroughToTheSplit(): void {
+		$this->dedupe->method('inspect')->willReturn($this->attributedPlan());
+		$this->dedupe->expects($this->once())
+			->method('applySplit')
+			->with($this->anything(), 16, true)
+			->willReturn(['newSchemaId' => 9465, 'rows' => 0, 'unmapped' => [], 'backup' => null]);
+
+		[$code] = $this->execute(['--write' => true, '--strict' => true]);
+
+		$this->assertSame(Command::SUCCESS, $code);
+
+	}//end testStrictIsPassedThroughToTheSplit()
+
+	/**
+	 * A failed split is reported and turns the exit code non-zero.
+	 *
+	 * A repair that swallowed a failure would leave the operator believing the
+	 * instance was clean.
+	 *
+	 * @return void
+	 */
+	public function testFailedSplitIsReportedAndFailsTheRun(): void {
+		$this->dedupe->method('inspect')->willReturn($this->attributedPlan());
+		$this->dedupe->method('applySplit')->willThrowException(
+			new \RuntimeException('Strict mode: 1 source column(s) have no destination (employee).')
+		);
+
+		[$code, $output] = $this->execute(['--write' => true, '--strict' => true]);
+
+		$this->assertSame(Command::FAILURE, $code);
+		$this->assertStringContainsString('failed', $output);
+		$this->assertStringContainsString('no destination', $output);
+		$this->assertStringContainsString('0 split(s) applied; 1 failure(s)', $output);
+
+	}//end testFailedSplitIsReportedAndFailsTheRun()
+
+	/**
+	 * The `--register` filter reaches the service.
+	 *
+	 * @return void
+	 */
+	public function testRegisterFilterIsPassedThrough(): void {
+		$this->dedupe->expects($this->once())
+			->method('inspect')
+			->with(16, $this->anything())
+			->willReturn([]);
+
+		[$code] = $this->execute(['--register' => '16']);
+
+		$this->assertSame(Command::SUCCESS, $code);
+
+	}//end testRegisterFilterIsPassedThrough()
+}//end class

--- a/tests/Unit/Service/SharedSchema/SchemaAttributionTest.php
+++ b/tests/Unit/Service/SharedSchema/SchemaAttributionTest.php
@@ -1,0 +1,406 @@
+<?php
+
+/**
+ * Unit tests for shared-schema detection and ownership attribution (#2689).
+ *
+ * The controls in this file are deliberately paired. A repair that mutates
+ * schema linkage must be proven to fire on the broken instance AND to stay
+ * silent on the healthy one — a check that cannot fail proves nothing, and a
+ * check that always fires is worse than none for a command that rewrites
+ * register configuration.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\SharedSchema
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\SharedSchema;
+
+use OCA\OpenRegister\Service\SharedSchema\SchemaAttribution;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * Locks the decision layer of `occ openregister:registers:dedupe-shared-schemas`.
+ */
+class SchemaAttributionTest extends TestCase {
+
+	/**
+	 * The subject under test.
+	 *
+	 * @var SchemaAttribution
+	 */
+	private SchemaAttribution $attribution;
+
+	/**
+	 * Build the (dependency-free) subject.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->attribution = new SchemaAttribution();
+
+	}//end setUp()
+
+	/**
+	 * The definition planix's `timeEntry` had, which overwrote pipelinq's.
+	 *
+	 * @return array<string, mixed> The definition.
+	 */
+	private function planixTimeEntry(): array {
+		return [
+			'slug'       => 'timeEntry',
+			'required'   => ['description'],
+			'properties' => [
+				'description' => ['type' => 'string'],
+				'date'        => ['type' => 'string'],
+				'duration'    => ['type' => 'number'],
+				'employee'    => ['type' => 'string'],
+				'task'        => ['type' => 'string'],
+				'approved'    => ['type' => 'boolean'],
+			],
+		];
+
+	}//end planixTimeEntry()
+
+	/**
+	 * The definition pipelinq's billing features depend on, which was wiped.
+	 *
+	 * @return array<string, mixed> The definition.
+	 */
+	private function pipelinqTimeEntry(): array {
+		return [
+			'slug'       => 'timeEntry',
+			'required'   => ['hours'],
+			'properties' => [
+				'hours'           => ['type' => 'number'],
+				'billingCategory' => ['type' => 'string'],
+				'client'          => ['type' => 'string'],
+				'project'         => ['type' => 'string'],
+				'billingSynced'   => ['type' => 'boolean'],
+			],
+		];
+
+	}//end pipelinqTimeEntry()
+
+	/**
+	 * MUST-PASS CONTROL: the observed planix/pipelinq pair is detected and attributed.
+	 *
+	 * Registers 19 (planix) and 16 (pipelinq) both reference schema 161, whose
+	 * stored content is planix's definition. Only planix's configuration matches,
+	 * so planix keeps the entity and pipelinq is the one that must be split off.
+	 *
+	 * @return void
+	 */
+	public function testDetectsAndAttributesTheObservedSharedPair(): void {
+		$shared = $this->attribution->indexShared(
+			registerSchemas: [
+				19 => [74, 159, 161],
+				16 => [74, 159, 161],
+				7  => [900],
+			]
+		);
+
+		$this->assertSame([74, 159, 161], array_keys($shared), 'every co-referenced id must be reported');
+		$this->assertSame([16, 19], $shared[161], 'both referencing registers must be named');
+		$this->assertArrayNotHasKey(900, $shared, 'a singly-referenced schema is not shared');
+
+		$verdict = $this->attribution->classify(
+			candidates: [19 => $this->planixTimeEntry(), 16 => $this->pipelinqTimeEntry()],
+			entity: $this->planixTimeEntry()
+		);
+
+		$this->assertSame(SchemaAttribution::STATUS_ONE_MATCH, $verdict['status']);
+		$this->assertSame(19, $verdict['owner'], 'planix owns the definition the entity actually holds');
+		$this->assertSame([19], $verdict['matches']);
+
+		$owner = $this->attribution->resolveOwner(
+			verdict: $verdict,
+			schemaId: 161,
+			registerIds: [16, 19],
+			keep: ['perSchema' => [], 'global' => null]
+		);
+
+		$this->assertSame(19, $owner['owner']);
+		$this->assertSame('configuration', $owner['source']);
+
+	}//end testDetectsAndAttributesTheObservedSharedPair()
+
+	/**
+	 * MUST-FAIL CONTROL: a healthy instance yields nothing to repair.
+	 *
+	 * No register co-references a schema, so detection produces an empty plan and
+	 * the command has nothing to write. Without this control the must-pass test
+	 * above would still succeed for a detector that reported every schema.
+	 *
+	 * @return void
+	 */
+	public function testHealthyInstanceHasNothingToRepair(): void {
+		$shared = $this->attribution->indexShared(
+			registerSchemas: [
+				19 => [74, 159, 161],
+				16 => [9463, 9464, 9465],
+				7  => [],
+			]
+		);
+
+		$this->assertSame([], $shared, 'no schema is co-referenced, so nothing is shared');
+
+	}//end testHealthyInstanceHasNothingToRepair()
+
+	/**
+	 * IDEMPOTENCE: feeding the post-split state back reports nothing.
+	 *
+	 * After the repair, register 16 points at its own 9463/9464/9465 (the ids the
+	 * manual validation produced) and register 19 keeps 74/159/161. A second run
+	 * must therefore be a no-op — a repair that re-fires on its own output would
+	 * fork a new schema on every invocation.
+	 *
+	 * @return void
+	 */
+	public function testSecondRunAfterASplitIsANoOp(): void {
+		$before = $this->attribution->indexShared(
+			registerSchemas: [19 => [74, 159, 161], 16 => [74, 159, 161]]
+		);
+		$this->assertNotSame([], $before, 'guard: the pre-split state must be detectable');
+
+		$after = [19 => [74, 159, 161], 16 => [74, 159, 161]];
+		foreach ([74 => 9463, 159 => 9464, 161 => 9465] as $oldId => $newId) {
+			$after[16] = $this->attribution->replaceSchemaId(schemas: $after[16], oldId: $oldId, newId: $newId);
+		}
+
+		$this->assertSame([9463, 9464, 9465], $after[16], 'the relink must preserve order');
+		$this->assertSame([], $this->attribution->indexShared(registerSchemas: $after));
+
+	}//end testSecondRunAfterASplitIsANoOp()
+
+	/**
+	 * Attribution matrix: no referencing register's configuration matches.
+	 *
+	 * Both apps have since moved on, so the entity matches neither. Guessing here
+	 * is exactly what produced the damage, so the verdict carries no owner.
+	 *
+	 * @return void
+	 */
+	public function testNoMatchYieldsNoOwner(): void {
+		$verdict = $this->attribution->classify(
+			candidates: [19 => $this->planixTimeEntry(), 16 => $this->pipelinqTimeEntry()],
+			entity: ['properties' => ['somethingElse' => ['type' => 'string']], 'required' => []]
+		);
+
+		$this->assertSame(SchemaAttribution::STATUS_NO_MATCH, $verdict['status']);
+		$this->assertNull($verdict['owner']);
+		$this->assertSame([], $verdict['matches']);
+
+		$owner = $this->attribution->resolveOwner(
+			verdict: $verdict,
+			schemaId: 161,
+			registerIds: [16, 19],
+			keep: ['perSchema' => [], 'global' => null]
+		);
+
+		$this->assertNull($owner['owner'], 'an unattributed schema must not acquire an owner by accident');
+		$this->assertSame('unattributed', $owner['source']);
+
+	}//end testNoMatchYieldsNoOwner()
+
+	/**
+	 * Attribution matrix: several configurations match the entity.
+	 *
+	 * Two apps legitimately declare the same shape. That is ambiguous, not
+	 * attributable, so both are listed and no owner is chosen.
+	 *
+	 * @return void
+	 */
+	public function testMultiMatchYieldsNoOwner(): void {
+		$verdict = $this->attribution->classify(
+			candidates: [19 => $this->planixTimeEntry(), 16 => $this->planixTimeEntry()],
+			entity: $this->planixTimeEntry()
+		);
+
+		$this->assertSame(SchemaAttribution::STATUS_MULTI_MATCH, $verdict['status']);
+		$this->assertNull($verdict['owner']);
+		$this->assertSame([16, 19], $verdict['matches'], 'both matching registers must be reported');
+
+	}//end testMultiMatchYieldsNoOwner()
+
+	/**
+	 * A register with no configuration on disk can never be a match.
+	 *
+	 * @return void
+	 */
+	public function testRegisterWithoutConfigurationIsNotACandidate(): void {
+		$verdict = $this->attribution->classify(
+			candidates: [19 => null, 16 => $this->pipelinqTimeEntry()],
+			entity: $this->pipelinqTimeEntry()
+		);
+
+		$this->assertSame(SchemaAttribution::STATUS_ONE_MATCH, $verdict['status']);
+		$this->assertSame(16, $verdict['owner']);
+
+	}//end testRegisterWithoutConfigurationIsNotACandidate()
+
+	/**
+	 * The signature ignores property bodies but not the property NAME set.
+	 *
+	 * The import path stamps defaults and rewrites descriptions, so byte equality
+	 * would put every schema in `no-match`. Losing a property, which is what the
+	 * overwrite actually did, must still register as a difference.
+	 *
+	 * @return void
+	 */
+	public function testSignatureIgnoresBodiesButNotTheNameSet(): void {
+		$restyled = $this->pipelinqTimeEntry();
+		$restyled['properties']['hours'] = [
+			'type'        => 'number',
+			'description' => 'Hours worked',
+			'default'     => 0,
+		];
+
+		$this->assertSame(
+			$this->attribution->signature(definition: $this->pipelinqTimeEntry()),
+			$this->attribution->signature(definition: $restyled),
+			'a re-stamped property body must not change the signature'
+		);
+
+		$shortened = $this->pipelinqTimeEntry();
+		unset($shortened['properties']['billingCategory']);
+
+		$this->assertNotSame(
+			$this->attribution->signature(definition: $this->pipelinqTimeEntry()),
+			$this->attribution->signature(definition: $shortened),
+			'a lost property MUST change the signature'
+		);
+
+	}//end testSignatureIgnoresBodiesButNotTheNameSet()
+
+	/**
+	 * A schema id stored as a string still counts as a reference.
+	 *
+	 * Different import eras wrote the list differently, so `"161"` and `161` must
+	 * be recognised as the same pairing or the sharing goes undetected.
+	 *
+	 * @return void
+	 */
+	public function testMixedIdTypesAreStillDetectedAsShared(): void {
+		$shared = $this->attribution->indexShared(
+			registerSchemas: [19 => ['161'], 16 => [161]]
+		);
+
+		$this->assertSame([161 => [16, 19]], $shared);
+
+	}//end testMixedIdTypesAreStillDetectedAsShared()
+
+	/**
+	 * `--keep <schemaId>:<registerId>` pins one schema; a bare id covers the rest.
+	 *
+	 * @return void
+	 */
+	public function testKeepOptionParsesBothForms(): void {
+		$keep = $this->attribution->parseKeep(raw: ['161:16', '74:19', '19']);
+
+		$this->assertSame([161 => 16, 74 => 19], $keep['perSchema']);
+		$this->assertSame(19, $keep['global']);
+
+	}//end testKeepOptionParsesBothForms()
+
+	/**
+	 * A per-schema `--keep` outranks a bare one.
+	 *
+	 * @return void
+	 */
+	public function testPerSchemaKeepOutranksTheGlobalOne(): void {
+		$owner = $this->attribution->resolveOwner(
+			verdict: ['status' => SchemaAttribution::STATUS_NO_MATCH, 'owner' => null, 'matches' => []],
+			schemaId: 161,
+			registerIds: [16, 19],
+			keep: ['perSchema' => [161 => 16], 'global' => 19]
+		);
+
+		$this->assertSame(16, $owner['owner']);
+		$this->assertSame('keep', $owner['source']);
+
+	}//end testPerSchemaKeepOutranksTheGlobalOne()
+
+	/**
+	 * A `--keep` naming a register that does not reference the schema is ignored.
+	 *
+	 * Honouring it would relink every referencing register onto a fresh entity —
+	 * a bigger change than the operator asked for — so the schema stays
+	 * unattributed and the write is refused instead.
+	 *
+	 * @return void
+	 */
+	public function testKeepIsIgnoredWhenItNamesAnUnrelatedRegister(): void {
+		$owner = $this->attribution->resolveOwner(
+			verdict: ['status' => SchemaAttribution::STATUS_MULTI_MATCH, 'owner' => null, 'matches' => [16, 19]],
+			schemaId: 161,
+			registerIds: [16, 19],
+			keep: ['perSchema' => [161 => 4242], 'global' => null]
+		);
+
+		$this->assertNull($owner['owner']);
+		$this->assertSame('unattributed', $owner['source']);
+
+	}//end testKeepIsIgnoredWhenItNamesAnUnrelatedRegister()
+
+	/**
+	 * A `--keep` cannot override an attribution the configuration already settled,
+	 * unless it is the specific per-schema form.
+	 *
+	 * @return void
+	 */
+	public function testGlobalKeepDoesNotOverrideASettledAttribution(): void {
+		$owner = $this->attribution->resolveOwner(
+			verdict: ['status' => SchemaAttribution::STATUS_ONE_MATCH, 'owner' => 19, 'matches' => [19]],
+			schemaId: 161,
+			registerIds: [16, 19],
+			keep: ['perSchema' => [], 'global' => 16]
+		);
+
+		$this->assertSame(19, $owner['owner']);
+		$this->assertSame('configuration', $owner['source']);
+
+	}//end testGlobalKeepDoesNotOverrideASettledAttribution()
+
+	/**
+	 * A malformed `--keep` is refused rather than silently ignored.
+	 *
+	 * @return void
+	 */
+	public function testMalformedKeepIsRefused(): void {
+		$this->expectException(RuntimeException::class);
+		$this->attribution->parseKeep(raw: ['161:not-an-id']);
+
+	}//end testMalformedKeepIsRefused()
+
+	/**
+	 * The relink preserves entries it does not understand.
+	 *
+	 * A normalising rewrite would drop a non-numeric legacy entry, which is data
+	 * loss rather than cleanup.
+	 *
+	 * @return void
+	 */
+	public function testRelinkPreservesOrderAndUnknownEntries(): void {
+		$this->assertSame(
+			[74, 9465, 'legacy-slug', 159],
+			$this->attribution->replaceSchemaId(
+				schemas: [74, '161', 'legacy-slug', 159],
+				oldId: 161,
+				newId: 9465
+			)
+		);
+
+	}//end testRelinkPreservesOrderAndUnknownEntries()
+}//end class

--- a/tests/Unit/Service/SharedSchema/SchemaTableMigratorTest.php
+++ b/tests/Unit/Service/SharedSchema/SchemaTableMigratorTest.php
@@ -1,0 +1,354 @@
+<?php
+
+/**
+ * Unit tests for the shared-schema row move (#2689).
+ *
+ * The column-mapping rules are asserted directly, and the statement they produce
+ * is then EXECUTED against a real in-memory SQLite database. A generated SQL
+ * string that is only string-compared proves the generator agrees with the test
+ * author, not that the database accepts it — and this statement moves object
+ * rows, so "it parses and moves exactly the mapped columns" is the property that
+ * matters.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\SharedSchema
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\SharedSchema;
+
+use OCA\OpenRegister\Service\SharedSchema\SchemaTableMigrator;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * Locks the column mapping and the copy statement it feeds.
+ */
+class SchemaTableMigratorTest extends TestCase {
+
+	/**
+	 * The columns planix's `timeEntry` table carries.
+	 *
+	 * @var string[]
+	 */
+	private const PLANIX_COLUMNS = [
+		'_id',
+		'_uuid',
+		'_register',
+		'_schema',
+		'_uri',
+		'description',
+		'date',
+		'duration',
+		'employee',
+		'approved',
+	];
+
+	/**
+	 * The columns pipelinq's own `timeEntry` definition would materialise.
+	 *
+	 * @var string[]
+	 */
+	private const PIPELINQ_COLUMNS = [
+		'_id',
+		'_uuid',
+		'_register',
+		'_schema',
+		'_uri',
+		'hours',
+		'billing_category',
+		'client',
+	];
+
+	/**
+	 * Columns present in both tables move; source-only columns are reported.
+	 *
+	 * This is the shape of the real repair: pipelinq's restored definition has
+	 * columns planix's overwrite had removed, and lacks the ones that belonged to
+	 * planix. Those planix-only columns must be NAMED, never dropped in silence.
+	 *
+	 * @return void
+	 */
+	public function testMapsSharedColumnsAndReportsTheRest(): void {
+		$plan = SchemaTableMigrator::planColumnMapping(
+			sourceColumns: self::PLANIX_COLUMNS,
+			targetColumns: self::PIPELINQ_COLUMNS
+		);
+
+		$this->assertSame(['_register', '_schema', '_uri', '_uuid'], $plan['mapped']);
+		$this->assertSame(
+			['approved', 'date', 'description', 'duration', 'employee'],
+			$plan['unmapped'],
+			'every source column without a destination must be reported'
+		);
+
+	}//end testMapsSharedColumnsAndReportsTheRest()
+
+	/**
+	 * `_id` never moves.
+	 *
+	 * It is an autoincrement primary key. Copying the values verbatim would leave
+	 * the target's sequence behind the highest copied id, so the next insert into
+	 * the repaired table would collide. It must also not be reported as unmapped,
+	 * or `--strict` would refuse every otherwise healthy split.
+	 *
+	 * @return void
+	 */
+	public function testPrimaryKeyIsNeitherCopiedNorReported(): void {
+		$plan = SchemaTableMigrator::planColumnMapping(
+			sourceColumns: ['_id', '_uuid'],
+			targetColumns: ['_id', '_uuid']
+		);
+
+		$this->assertSame(['_uuid'], $plan['mapped']);
+		$this->assertSame([], $plan['unmapped']);
+
+	}//end testPrimaryKeyIsNeitherCopiedNorReported()
+
+	/**
+	 * A clone-path split maps every column, so nothing is left behind.
+	 *
+	 * @return void
+	 */
+	public function testIdenticalShapesLeaveNothingUnmapped(): void {
+		$plan = SchemaTableMigrator::planColumnMapping(
+			sourceColumns: self::PLANIX_COLUMNS,
+			targetColumns: self::PLANIX_COLUMNS
+		);
+
+		$this->assertSame([], $plan['unmapped']);
+		$this->assertNotContains('_id', $plan['mapped']);
+		$this->assertCount((count(self::PLANIX_COLUMNS) - 1), $plan['mapped']);
+
+	}//end testIdenticalShapesLeaveNothingUnmapped()
+
+	/**
+	 * Column matching is case-insensitive across the two introspection results.
+	 *
+	 * `information_schema` folds identifier case differently per platform. If the
+	 * comparison were case-sensitive every column would read as unmapped, and
+	 * `--strict` would refuse every split on the affected platform.
+	 *
+	 * @return void
+	 */
+	public function testMatchingIsCaseInsensitive(): void {
+		$plan = SchemaTableMigrator::planColumnMapping(
+			sourceColumns: ['_uuid', 'billingCategory'],
+			targetColumns: ['_UUID', 'BILLINGCATEGORY']
+		);
+
+		$this->assertSame(['_uuid', 'billingCategory'], $plan['mapped']);
+		$this->assertSame([], $plan['unmapped']);
+
+	}//end testMatchingIsCaseInsensitive()
+
+	/**
+	 * A target column with no source counterpart is not an error.
+	 *
+	 * The restored definition legitimately adds back columns the overwrite had
+	 * removed; they simply have no rows to carry and take their default.
+	 *
+	 * @return void
+	 */
+	public function testTargetOnlyColumnsAreNotReported(): void {
+		$plan = SchemaTableMigrator::planColumnMapping(
+			sourceColumns: ['_uuid'],
+			targetColumns: ['_uuid', 'billing_category', 'client']
+		);
+
+		$this->assertSame(['_uuid'], $plan['mapped']);
+		$this->assertSame([], $plan['unmapped']);
+
+	}//end testTargetOnlyColumnsAreNotReported()
+
+	/**
+	 * The copy statement quotes every identifier and selects only mapped columns.
+	 *
+	 * @return void
+	 */
+	public function testCopyStatementQuotesIdentifiers(): void {
+		$sql = SchemaTableMigrator::buildCopySql(
+			sourceTable: 'oc_openregister_table_16_161',
+			targetTable: 'oc_openregister_table_16_9465',
+			columns: ['_uuid', '_schema'],
+			quote: '"'
+		);
+
+		$this->assertSame(
+			'INSERT INTO "oc_openregister_table_16_9465" ("_uuid", "_schema") '
+			. 'SELECT "_uuid", "_schema" FROM "oc_openregister_table_16_161"',
+			$sql
+		);
+
+	}//end testCopyStatementQuotesIdentifiers()
+
+	/**
+	 * MySQL and MariaDB get backticks.
+	 *
+	 * @return void
+	 */
+	public function testCopyStatementHonoursTheBacktickDialect(): void {
+		$sql = SchemaTableMigrator::buildCopySql(
+			sourceTable: 'oc_openregister_table_16_161',
+			targetTable: 'oc_openregister_table_16_9465',
+			columns: ['_uuid'],
+			quote: '`'
+		);
+
+		$this->assertStringContainsString('`oc_openregister_table_16_9465`', $sql);
+		$this->assertStringContainsString('`_uuid`', $sql);
+
+	}//end testCopyStatementHonoursTheBacktickDialect()
+
+	/**
+	 * An identifier that is not a plain SQL name is refused, not interpolated.
+	 *
+	 * Table and column names cannot be bound as parameters, so this guard is the
+	 * only thing between an introspection result and a raw statement.
+	 *
+	 * @return void
+	 */
+	public function testUnsafeIdentifierIsRefused(): void {
+		$this->expectException(RuntimeException::class);
+		SchemaTableMigrator::buildCopySql(
+			sourceTable: 'oc_openregister_table_16_161',
+			targetTable: 'x"; DROP TABLE users; --',
+			columns: ['_uuid'],
+			quote: '"'
+		);
+
+	}//end testUnsafeIdentifierIsRefused()
+
+	/**
+	 * An empty mapping is refused rather than producing invalid SQL.
+	 *
+	 * @return void
+	 */
+	public function testEmptyMappingIsRefused(): void {
+		$this->expectException(RuntimeException::class);
+		SchemaTableMigrator::buildCopySql(
+			sourceTable: 'oc_openregister_table_16_161',
+			targetTable: 'oc_openregister_table_16_9465',
+			columns: [],
+			quote: '"'
+		);
+
+	}//end testEmptyMappingIsRefused()
+
+	/**
+	 * END-TO-END: the generated statement really moves the mapped rows.
+	 *
+	 * Executed against an in-memory SQLite database built to the shape of the
+	 * observed case: a source table holding planix's columns and two rows, and a
+	 * target table built from pipelinq's restored definition. After the copy the
+	 * shared columns must have carried over, the pipelinq-only columns must be
+	 * empty (there was nothing to carry), and the planix-only columns must still
+	 * exist in the untouched source so the operator can recover them.
+	 *
+	 * @return void
+	 */
+	public function testGeneratedStatementMovesRowsOnARealDatabase(): void {
+		$pdo = new PDO('sqlite::memory:', null, null, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+
+		$pdo->exec(
+			'CREATE TABLE oc_openregister_table_16_161 (
+				_id INTEGER PRIMARY KEY AUTOINCREMENT,
+				_uuid TEXT, _register TEXT, _schema TEXT, _uri TEXT,
+				description TEXT, date TEXT, duration REAL, employee TEXT, approved INTEGER)'
+		);
+		$pdo->exec(
+			'CREATE TABLE oc_openregister_table_16_9465 (
+				_id INTEGER PRIMARY KEY AUTOINCREMENT,
+				_uuid TEXT, _register TEXT, _schema TEXT, _uri TEXT,
+				hours REAL, billing_category TEXT, client TEXT)'
+		);
+
+		$pdo->exec(
+			"INSERT INTO oc_openregister_table_16_161
+				(_uuid, _register, _schema, _uri, description, date, duration, employee, approved)
+			 VALUES
+				('uuid-a', '16', '161', '/api/objects/16/161/uuid-a', 'Sprint work', '2026-08-01', 3.5, 'ruben', 1),
+				('uuid-b', '16', '161', '/api/objects/16/161/uuid-b', 'Review',      '2026-08-02', 1.0, 'ruben', 0)"
+		);
+
+		$plan = SchemaTableMigrator::planColumnMapping(
+			sourceColumns: $this->columnsOf(pdo: $pdo, table: 'oc_openregister_table_16_161'),
+			targetColumns: $this->columnsOf(pdo: $pdo, table: 'oc_openregister_table_16_9465')
+		);
+
+		$this->assertSame(
+			['approved', 'date', 'description', 'duration', 'employee'],
+			$plan['unmapped'],
+			'guard: the fixture must actually exercise unmapped columns'
+		);
+
+		$pdo->exec(
+			SchemaTableMigrator::buildCopySql(
+				sourceTable: 'oc_openregister_table_16_161',
+				targetTable: 'oc_openregister_table_16_9465',
+				columns: $plan['mapped'],
+				quote: '"'
+			)
+		);
+
+		$moved = $pdo->query(
+			'SELECT _id, _uuid, _schema, _uri, hours FROM oc_openregister_table_16_9465 ORDER BY _uuid'
+		)->fetchAll(PDO::FETCH_ASSOC);
+
+		$this->assertCount(2, $moved, 'both rows must arrive');
+		$this->assertSame(['uuid-a', 'uuid-b'], array_column($moved, '_uuid'));
+		$this->assertSame([1, 2], array_map('intval', array_column($moved, '_id')), '_id is reassigned, not copied');
+		$this->assertSame([null, null], array_column($moved, 'hours'), 'a target-only column has nothing to carry');
+
+		// The rows still carry the OLD schema id until the restamp runs; the
+		// migrator issues that UPDATE, and this asserts it is genuinely needed.
+		$this->assertSame(['161', '161'], array_column($moved, '_schema'));
+		$pdo->exec('UPDATE oc_openregister_table_16_9465 SET _schema = \'9465\' WHERE _schema = \'161\'');
+		$pdo->exec(
+			'UPDATE oc_openregister_table_16_9465 SET _uri = REPLACE(_uri, \'/16/161/\', \'/16/9465/\')'
+		);
+
+		$restamped = $pdo->query(
+			'SELECT _schema, _uri FROM oc_openregister_table_16_9465 ORDER BY _uuid'
+		)->fetchAll(PDO::FETCH_ASSOC);
+
+		$this->assertSame(['9465', '9465'], array_column($restamped, '_schema'));
+		$this->assertSame(
+			['/api/objects/16/9465/uuid-a', '/api/objects/16/9465/uuid-b'],
+			array_column($restamped, '_uri'),
+			'the denormalised uri must follow the new schema id'
+		);
+
+		$survivors = $pdo->query(
+			'SELECT COUNT(*) FROM oc_openregister_table_16_161 WHERE description IS NOT NULL'
+		)->fetchColumn();
+
+		$this->assertSame(2, (int)$survivors, 'the unmapped columns must remain recoverable in the source table');
+
+	}//end testGeneratedStatementMovesRowsOnARealDatabase()
+
+	/**
+	 * Read a SQLite table's column names.
+	 *
+	 * @param PDO    $pdo   The connection.
+	 * @param string $table The table name.
+	 *
+	 * @return string[] The column names.
+	 */
+	private function columnsOf(PDO $pdo, string $table): array {
+		$rows = $pdo->query('PRAGMA table_info(' . $table . ')')->fetchAll(PDO::FETCH_ASSOC);
+
+		return array_map(static fn (array $row): string => (string)$row['name'], $rows);
+
+	}//end columnsOf()
+}//end class


### PR DESCRIPTION
Implements the accepted `dedupe-shared-schemas` proposal (#2691). Closes the last gap in the slug-collision family: resolution scoping and the ImportHandler per-register slug-uniqueness fix stop **new** cross-register reuse, but nothing repaired the instances that had already drifted.

Fixes #2689.

## What it does

`occ openregister:registers:dedupe-shared-schemas` splits schema entities that more than one register co-owns, gives each register its own entity, and moves its object rows with it.

It is the counterpart to `openregister:registers:relink-schemas`: that command **adds** linkage a register lost; this one **splits** linkage a register was never meant to have. Same shape — dry run by default, `--write` to apply, `--register` to scope, same output style.

The observed damage (#2689): registers `planix` (19) and `pipelinq` (16) both referenced schema ids `task=74`, `project=159`, `timeEntry=161`. Schema 161 held planix's `timeEntry`; pipelinq's own definition — `hours`, `billingCategory`, `client`, the WIP/billing-sync fields its billing features depend on — was gone from the instance. A planix schema extension had transparently changed pipelinq's `task` too.

Per split, in one transaction:

1. **Create** the register's own schema — preferably from its own configuration, through `ImportHandler::importSchema(..., registerSchemaIds: [])`. The empty scope makes `findBySlugInIds()` short-circuit, forcing a brand new row instead of resolving back onto the shared one. Going through the import path is what makes the split durable: the app's next import finds the register's own entity and updates *that*. Falls back to cloning the current entity when the app ships no configuration for it any more.
2. **Relink** `register.schemas` in place. Order preserved; non-numeric legacy entries copied verbatim rather than normalised away (same reasoning as `Register::addSchemaId()`).
3. **Move rows** `table_{reg}_{old}` → `table_{reg}_{new}` as a column-mapped `INSERT ... SELECT`. A bare `ALTER TABLE ... RENAME` — what the older `openregister:schemas:dedup` does — is only correct while the new schema is a byte-copy of the old one, which is exactly what this case is not.
4. **Restamp** `_schema` and the schema id embedded in `_uri`. Without this the moved rows stay attributed to the register that kept the shared entity — the very bleed being repaired. (`_folder` is deliberately left alone: it is an NC folder node id and object folders live inside the *register* folder, so a schema renumber does not invalidate them.)

`_id` is not copied. It is autoincrement, so carrying the values over would strand the target's sequence behind the highest copied id and the next insert would collide. `_uuid` — the identity relations actually store — does move.

## How attribution works

For each shared schema, the current entity content is compared against what **each referencing register's own app configuration** declares for that slug — `lib/Settings/<appId>_register.json` plus sorted `register.d/*.json` fragments, deep-merged the way `AppHostSettingsService` merges them. (The glob is widened to every `*_register.json` because OpenRegister itself ships several documents rather than one monolith.)

The comparison is on the **property-name set plus `required`**, not byte equality. The import path stamps defaults, folds `$ref`s and rewrites descriptions, so byte equality would put every schema in `no-match`. A *lost property* — precisely what the overwrite did — still registers as a difference.

| Status | Meaning | Result |
| --- | --- | --- |
| `one-match` | Exactly one register's configuration matches | It keeps the entity; the others split off |
| `no-match` | No configuration matches | **Unattributed** — skipped |
| `multi-match` | Several configurations match | **Unattributed** — skipped |

Deliberately **not** used as evidence: the schema's `application` column (on a shared entity it names whichever app overwrote it last, not the owner) and "lowest register id" (not evidence at all). The pre-existing `occ openregister:schemas:dedup` uses both and therefore always picks a side; this command refuses instead.

## Safety rails

- **Dry run by default.** `--write` is required to change anything.
- **Refusal to guess.** `--write` exits non-zero while any schema is unattributed. Guessing an owner is what produced the damage in the first place.
- **`--keep`** to decide yourself: `--keep <schemaId>:<registerId>` (repeatable) or a bare `--keep <registerId>` for everything unattributed. Per-schema outranks bare. A `--keep` naming a register that does **not** reference the schema is ignored, not honoured — relinking every other register onto a fresh entity would be a bigger change than the operator asked for.
- **`--strict`** turns an unmapped column into a refusal. Unmapped columns are computed at **plan** time (a transient, unpersisted `Schema` fed to the real `buildTableColumnsFromSchema()`), so the dry run names them and `--strict` refuses **before** anything is written. Deciding after the target table exists would strand a stray table on MySQL, where DDL does not roll back with the transaction.
- **Nothing is dropped.** Source columns with no destination are always reported, and the source table is renamed to `_predupe` rather than dropped, so they stay recoverable.
- **The `_predupe` suffix is load-bearing.** It stops the name matching the shard pattern `RegisterSchemaLinkageRepairService` reads as evidence of a pairing. Left under its original name, a later `relink-schemas --write` would re-link the register to the very schema this command just split it away from — the sibling command would quietly undo this one.
- Each split runs in a transaction and rolls back as a unit.

## Test evidence

33 new tests, all green:

```
tests/Unit/Service/SharedSchema/SchemaAttributionTest.php     14 tests
tests/Unit/Service/SharedSchema/SchemaTableMigratorTest.php   10 tests
tests/Unit/Command/DedupeSharedSchemasCommandTest.php          9 tests
OK (33 tests, 94 assertions)
```

**Must-PASS control** — `testDetectsAndAttributesTheObservedSharedPair()` uses the real 19/16 × 74/159/161 shape: detection reports all three shared ids, attribution lands on `one-match` → planix (19), pipelinq (16) is the one split off. `testWriteAppliesTheSplit()` proves `--write` performs it.

**Must-FAIL control** — `testHealthyInstanceHasNothingToRepair()` (no schema co-referenced → empty plan) and `testHealthyInstanceReportsNothing()`, which asserts `applySplit()` is **never** called even with `--write`.

**Idempotence** — `testSecondRunAfterASplitIsANoOp()` feeds the post-split ids (9463/9464/9465, the ones the manual validation on the dev instance produced) back through detection and asserts an empty plan, with a guard assertion that the pre-split state *was* detectable.

**Real database, not a string compare** — `testGeneratedStatementMovesRowsOnARealDatabase()` builds the two tables in in-memory SQLite, introspects their columns, and **executes** the generated `INSERT ... SELECT`. It asserts both rows arrive, `_id` is reassigned rather than copied, a target-only column stays null, the restamp is genuinely needed (`_schema` is still `161` until it runs), `_uri` follows the new id, and the unmapped columns survive in the source table. A generated SQL string that is only string-compared proves the generator agrees with the test author, not that the database accepts it.

**The checks were proven able to fail.** Four mutations were introduced and reverted; each was caught:

| Mutation | Caught by |
| --- | --- |
| Sharing threshold `< 2` → `< 1` | 3 tests |
| `multi-match` returns `$matches[0]` as owner | `testMultiMatchYieldsNoOwner` |
| Unmapped columns never recorded | 2 tests incl. the SQLite one |
| `--write` unattributed refusal disabled | `testWriteRefusesAnUnattributedSchema` |

## Quality

`lint`, `phpcs`, `psalm` (`findUnusedCode` on) and `phpstan` all pass clean over the full `lib/` tree. `phpmd` passes on the new files against both rulesets.

## Known limits (honest reporting)

- **The full `test:all` suite cannot run in this checkout.** `tests/bootstrap-unit.php` boots the Nextcloud server, and `nextcloud/ocp` ships no autoload section, so the suite needs a container (`composer test:docker`). Baseline check: `tests/Unit/Command/` errors on **10** tests on a clean `development` tree here and on the same 10 with this branch applied — no regression, and all 33 new tests pass. CI will run the full suite.
- **Task 4.2's "app reimport does not re-share" leg is covered structurally, not end-to-end.** The split goes through `importSchema(registerSchemaIds: [])`, whose behaviour is already locked by `ImportHandlerPerRegisterSlugUniquenessTest`. A genuine reimport-after-split regression test needs a booted Nextcloud and belongs in the Integration suite.
- **The row move itself is exercised against SQLite, not Postgres/MySQL.** The column mapping, the generated statement and the restamp are proven end-to-end there; the `information_schema` introspection and `ALTER TABLE ... RENAME` paths are per-platform and reach a real database only in the Integration/Database suites.
- **`openregister:schemas:dedup` is left in place.** It overlaps with this command but picks an owner heuristically and is Postgres-only raw SQL (`jsonb`, `pg_tables`). Retiring or redirecting it is a separate decision; flagging it here so the overlap is not discovered later.
- **MySQL DDL is not transactional.** If a split fails *after* `ensureTableForRegisterSchema()`, the empty target table can survive the rollback on MySQL/MariaDB. `--strict` is evaluated before any write specifically to keep this off the common path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
