### PR TITLE
chore(quality): migrate to PHPStan 2 — 229 findings to zero, plus 3 real bugs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -127,7 +127,7 @@
 	},
 	"require-dev": {
 		"conduction/coding-standard": "^1.0",
-		"conduction/hydra-gates": "^1.0",
+		"conduction/hydra-gates": "^1.8.2",
 		"cyclonedx/cyclonedx-php-composer": "^6.2",
 		"doctrine/dbal": "^3.8",
 		"edgedesign/phpqa": "^1.27",
@@ -135,7 +135,7 @@
 		"phpcsstandards/phpcsextra": "^1.4",
 		"phpmd/phpmd": "^2.15",
 		"phpmetrics/phpmetrics": "^2.8",
-		"phpstan/phpstan": "^1.10",
+		"phpstan/phpstan": "^2.0",
 		"phpunit/phpunit": "^10.5.62",
 		"roave/security-advisories": "dev-latest",
 		"sabre/vobject": "^4.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b91761870b0b3b4e242eee6912c58ed5",
+    "content-hash": "afcdeab8bd2a2678bfc97c9368dddee9",
     "packages": [
         {
             "name": "adbario/php-dot-notation",
@@ -7048,16 +7048,16 @@
         },
         {
             "name": "conduction/hydra-gates",
-            "version": "v1.8.1",
+            "version": "v1.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ConductionNL/.github.git",
-                "reference": "8e0e9857e54d6c680e157939e78a468e58d3751a"
+                "reference": "3dfcd1e56d27bd06eaa98a9a66e377e7e14fe491"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/8e0e9857e54d6c680e157939e78a468e58d3751a",
-                "reference": "8e0e9857e54d6c680e157939e78a468e58d3751a",
+                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/3dfcd1e56d27bd06eaa98a9a66e377e7e14fe491",
+                "reference": "3dfcd1e56d27bd06eaa98a9a66e377e7e14fe491",
                 "shasum": ""
             },
             "require": {
@@ -7101,9 +7101,9 @@
             "support": {
                 "docs": "https://github.com/ConductionNL/.github/blob/main/hydra-gates/README.md",
                 "issues": "https://github.com/ConductionNL/.github/issues",
-                "source": "https://github.com/ConductionNL/.github/tree/v1.8.1"
+                "source": "https://github.com/ConductionNL/.github/tree/v1.8.2"
             },
-            "time": "2026-08-20T05:07:22+00:00"
+            "time": "2026-08-20T09:37:12+00:00"
         },
         {
             "name": "consolidation/annotated-command",
@@ -9721,15 +9721,15 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.33",
+            "version": "2.2.8",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/37982d6fc7cbb746dda7773530cda557cdf119e1",
-                "reference": "37982d6fc7cbb746dda7773530cda557cdf119e1",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e285254e60f33c21902efef4a926ca0987c06804",
+                "reference": "e285254e60f33c21902efef4a926ca0987c06804",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2|^8.0"
+                "php": "^7.4|^8.0"
             },
             "conflict": {
                 "phpstan/phpstan-shim": "*"
@@ -9747,6 +9747,17 @@
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "keywords": [
@@ -9770,7 +9781,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-28T20:30:03+00:00"
+            "time": "2026-08-04T22:21:45+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/lib/BackgroundJob/BackfillCalendarLinksJob.php
+++ b/lib/BackgroundJob/BackfillCalendarLinksJob.php
@@ -237,11 +237,11 @@ class BackfillCalendarLinksJob extends QueuedJob {
 	 * @return void
 	 */
 	private function applyEventDates(CalendarLink $link, array $event): void {
-		if (isset($event['dtstart']) === true && $event['dtstart'] !== null) {
+		if (isset($event['dtstart']) === true) {
 			$link->setDtstart(new DateTime((string)$event['dtstart']));
 		}
 
-		if (isset($event['dtend']) === true && $event['dtend'] !== null) {
+		if (isset($event['dtend']) === true) {
 			$link->setDtend(new DateTime((string)$event['dtend']));
 		}
 	}//end applyEventDates()

--- a/lib/BackgroundJob/DestructionCheckJob.php
+++ b/lib/BackgroundJob/DestructionCheckJob.php
@@ -272,7 +272,7 @@ class DestructionCheckJob extends TimedJob {
 
 			// Rebuild the persisted set from only the still-in-window UUIDs plus the freshly
 			// notified ones, dropping any whose destruction date has passed or moved away.
-			$rebuilt = array_values(array_keys($stillRelevant + $newNotified));
+			$rebuilt = array_keys($stillRelevant + $newNotified);
 
 			if ($newCount > 0 || count($rebuilt) !== count($notified)) {
 				$appConfig->setValueString('openregister', self::NOTIFIED_KEY, json_encode($rebuilt));

--- a/lib/Controller/BulkController.php
+++ b/lib/Controller/BulkController.php
@@ -47,7 +47,7 @@ use OCP\IUserSession;
  *
  * @psalm-suppress UnusedClass
  *
- * @suppressWarnings(PHPMD.ExcessiveClassComplexity)
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  *
  * @spec openspec/specs/data-import-export/spec.md
  * @spec openspec/specs/object-lifecycle/spec.md

--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -65,7 +65,7 @@ use Psr\Log\LoggerInterface;
  *
  * @psalm-suppress UnusedClass
  *
- * @suppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class ChatController extends Controller {
 
@@ -180,7 +180,7 @@ class ChatController extends Controller {
 	 *
 	 * @return void
 	 *
-	 * @suppressWarnings(PHPMD.ExcessiveParameterList) Nextcloud DI requires constructor injection
+	 * @SuppressWarnings(PHPMD.ExcessiveParameterList) Nextcloud DI requires constructor injection
 	 */
 	public function __construct(
 		string $appName,
@@ -697,7 +697,7 @@ class ChatController extends Controller {
 	 *
 	 * @return JSONResponse JSON response with feedback confirmation or error
 	 *
-	 * @suppressWarnings(PHPMD.ExcessiveMethodLength)
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
 	 *
 	 * @spec openspec/specs/chat-ai/spec.md
 	 */

--- a/lib/Controller/ConfigurationController.php
+++ b/lib/Controller/ConfigurationController.php
@@ -1645,13 +1645,13 @@ class ConfigurationController extends Controller {
 	 *
 	 * Checks if configuration is local and can be published to GitHub.
 	 *
-	 * @param object $configuration Configuration entity.
+	 * @param Configuration $configuration Configuration entity.
 	 *
 	 * @return JSONResponse|null Error response if validation fails, null if valid.
 	 *
 	 * @psalm-return JSONResponse<400, array{error: 'Only local configurations can be published'}, array<never, never>>|null
 	 */
-	private function validateConfigurationForPublishing(object $configuration): ?JSONResponse {
+	private function validateConfigurationForPublishing(Configuration $configuration): ?JSONResponse {
 		// Only allow publishing local configurations.
 		if ($configuration->getIsLocal() !== true) {
 			return new JSONResponse(
@@ -1669,11 +1669,11 @@ class ConfigurationController extends Controller {
 	 * Extracts owner, repo, path, branch, and commit message from request.
 	 * Validates required parameters and normalizes path.
 	 *
-	 * @param object $configuration Configuration entity.
+	 * @param Configuration $configuration Configuration entity.
 	 *
 	 * @return array<string, string> Parameters array or error array.
 	 */
-	private function extractGitHubPublishParams(object $configuration): array {
+	private function extractGitHubPublishParams(Configuration $configuration): array {
 		$data = $this->request->getParams();
 		$owner = $data['owner'] ?? '';
 		$repo = $data['repo'] ?? '';
@@ -1733,12 +1733,12 @@ class ConfigurationController extends Controller {
 	 *
 	 * Exports configuration and adds GitHub metadata.
 	 *
-	 * @param object $configuration Configuration entity.
+	 * @param Configuration $configuration Configuration entity.
 	 * @param array<string, string> $params Publishing parameters.
 	 *
 	 * @return false|string JSON content ready for GitHub.
 	 */
-	private function prepareConfigurationForGitHub(object $configuration, array $params): string|false {
+	private function prepareConfigurationForGitHub(Configuration $configuration, array $params): string|false {
 		// Export configuration to array.
 		$configData = $this->configurationService->exportConfig(
 			input: $configuration,
@@ -1823,12 +1823,12 @@ class ConfigurationController extends Controller {
 	 *
 	 * Updates local configuration entity with GitHub publishing details.
 	 *
-	 * @param object $configuration Configuration entity.
+	 * @param Configuration $configuration Configuration entity.
 	 * @param array<string, string> $params Publishing parameters.
 	 *
 	 * @return void
 	 */
-	private function updateConfigurationWithGitHubInfo(object $configuration, array $params): void {
+	private function updateConfigurationWithGitHubInfo(Configuration $configuration, array $params): void {
 		$githubRepo = "{$params['owner']}/{$params['repo']}";
 		$sourceUrl = "https://github.com/{$githubRepo}/blob/{$params['branch']}/{$params['path']}";
 
@@ -1845,13 +1845,13 @@ class ConfigurationController extends Controller {
 	 *
 	 * Logs successful GitHub publishing operation.
 	 *
-	 * @param object $configuration Configuration entity.
+	 * @param Configuration $configuration Configuration entity.
 	 * @param array<string, string> $params Publishing parameters.
 	 * @param array<string, mixed> $result GitHub API result.
 	 *
 	 * @return void
 	 */
-	private function logPublishingSuccess(object $configuration, array $params, array $result): void {
+	private function logPublishingSuccess(Configuration $configuration, array $params, array $result): void {
 		$this->logger->debug(
 			message: "[ConfigurationController] Successfully published configuration {$configuration->getTitle()} to GitHub",
 			context: [
@@ -1871,13 +1871,13 @@ class ConfigurationController extends Controller {
 	 *
 	 * Creates success response including GitHub URLs and indexing notes.
 	 *
-	 * @param object $configuration Configuration entity.
+	 * @param Configuration $configuration Configuration entity.
 	 * @param array<string, string> $params Publishing parameters.
 	 * @param array<string, mixed> $result GitHub API result.
 	 *
 	 * @return JSONResponse JSON response with publish success data
 	 */
-	private function buildPublishSuccessResponse(object $configuration, array $params, array $result): JSONResponse {
+	private function buildPublishSuccessResponse(Configuration $configuration, array $params, array $result): JSONResponse {
 		// Get default branch for indexing note.
 		$defaultBranch = $this->getRepositoryDefaultBranch(params: $params);
 

--- a/lib/Controller/ConfigurationController.php
+++ b/lib/Controller/ConfigurationController.php
@@ -51,11 +51,11 @@ use Psr\Log\LoggerInterface;
  *
  * @psalm-suppress UnusedClass
  *
- * @suppressWarnings(PHPMD.ExcessiveClassLength)
- * @suppressWarnings(PHPMD.ExcessiveClassComplexity)
- * @suppressWarnings(PHPMD.TooManyMethods)
- * @suppressWarnings(PHPMD.TooManyPublicMethods)
- * @suppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.ExcessiveClassLength)
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ * @SuppressWarnings(PHPMD.TooManyMethods)
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class ConfigurationController extends Controller {
 	use \OCA\OpenRegister\Controller\Trait\HandlesExceptionsTrait;
@@ -1289,7 +1289,7 @@ class ConfigurationController extends Controller {
 	 *
 	 * @return JSONResponse JSON response with import result
 	 *
-	 * @suppressWarnings(PHPMD.ExcessiveMethodLength)
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
 	 */
 	private function importFromSource(callable $fetchConfig, array $params, string $sourceType): JSONResponse {
 		try {

--- a/lib/Controller/ConfigurationController.php
+++ b/lib/Controller/ConfigurationController.php
@@ -205,8 +205,8 @@ class ConfigurationController extends Controller {
 	 * @NoCSRFRequired
 	 *
 	 * @psalm-return JSONResponse<200, Configuration,
-	 *     array<never, never>>|JSONResponse<404|500,
-	 *     array{error: 'Configuration not found'|'Failed to fetch configuration'},
+	 *     array<never, never>>|JSONResponse<403|404|500,
+	 *     array{error: string},
 	 *     array<never, never>>
 	 *
 	 * @spec openspec/specs/data-import-export/spec.md
@@ -714,7 +714,7 @@ class ConfigurationController extends Controller {
 	 *
 	 * @NoCSRFRequired
 	 *
-	 * @psalm-return JSONResponse<200|404|500, array, array<never, never>>
+	 * @psalm-return JSONResponse<200|403|404|500, array, array<never, never>>
 	 *
 	 * @spec openspec/specs/data-import-export/spec.md
 	 */
@@ -761,7 +761,7 @@ class ConfigurationController extends Controller {
 	 *
 	 * @NoCSRFRequired
 	 *
-	 * @psalm-return JSONResponse<200|400|500,
+	 * @psalm-return JSONResponse<200|400|403|500,
 	 *     array{error?: string, total_count?: int<0, max>|mixed,
 	 *     results?: list{0?: array{repository?: mixed, owner?: string,
 	 *     repo?: string, path: mixed|string, url: ''|mixed, stars?: 0|mixed,

--- a/lib/Controller/ConfigurationsController.php
+++ b/lib/Controller/ConfigurationsController.php
@@ -180,7 +180,7 @@ class ConfigurationsController extends Controller {
 	 * @return JSONResponse JSON response with created configuration or error
 	 *
 	 * @psalm-return JSONResponse<201, \OCA\OpenRegister\Db\Configuration,
-	 *     array<never, never>>|JSONResponse<400, array{error: string},
+	 *     array<never, never>>|JSONResponse<400|403, array{error: string},
 	 *     array<never, never>>
 	 *
 	 * @spec openspec/specs/data-import-export/spec.md
@@ -244,7 +244,7 @@ class ConfigurationsController extends Controller {
 	 * @return JSONResponse JSON response with updated configuration or error
 	 *
 	 * @psalm-return JSONResponse<200, \OCA\OpenRegister\Db\Configuration,
-	 *     array<never, never>>|JSONResponse<400, array{error: string},
+	 *     array<never, never>>|JSONResponse<400|403, array{error: string},
 	 *     array<never, never>>
 	 *
 	 * @spec openspec/specs/data-import-export/spec.md
@@ -299,7 +299,7 @@ class ConfigurationsController extends Controller {
 	 * @NoCSRFRequired
 	 *
 	 * @psalm-return JSONResponse<200, \OCA\OpenRegister\Db\Configuration,
-	 *     array<never, never>>|JSONResponse<400, array{error: string},
+	 *     array<never, never>>|JSONResponse<400|403, array{error: string},
 	 *     array<never, never>>
 	 *
 	 * @spec openspec/specs/data-import-export/spec.md
@@ -320,7 +320,7 @@ class ConfigurationsController extends Controller {
 	 * @return JSONResponse JSON response on success (204) or error
 	 *
 	 * @psalm-return JSONResponse<204, null,
-	 *     array<never, never>>|JSONResponse<400, array{error: string},
+	 *     array<never, never>>|JSONResponse<400|403, array{error: string},
 	 *     array<never, never>>
 	 *
 	 * @spec openspec/specs/data-import-export/spec.md
@@ -354,7 +354,7 @@ class ConfigurationsController extends Controller {
 	 * @NoCSRFRequired
 	 *
 	 * @psalm-return DataDownloadResponse<200, 'application/json',
-	 *     array<never, never>>|JSONResponse<400, array{error: string},
+	 *     array<never, never>>|JSONResponse<400|403, array{error: string},
 	 *     array<never, never>>
 	 *
 	 * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Toggle to include/exclude objects in export

--- a/lib/Controller/ConfigurationsController.php
+++ b/lib/Controller/ConfigurationsController.php
@@ -173,9 +173,9 @@ class ConfigurationsController extends Controller {
 	 *
 	 * @NoCSRFRequired
 	 *
-	 * @suppressWarnings(PHPMD.StaticAccess)         Uuid::v4() is a standard utility pattern
-	 * @suppressWarnings(PHPMD.CyclomaticComplexity)
-	 * @suppressWarnings(PHPMD.NPathComplexity)
+	 * @SuppressWarnings(PHPMD.StaticAccess)         Uuid::v4() is a standard utility pattern
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+	 * @SuppressWarnings(PHPMD.NPathComplexity)
 	 *
 	 * @return JSONResponse JSON response with created configuration or error
 	 *
@@ -357,7 +357,7 @@ class ConfigurationsController extends Controller {
 	 *     array<never, never>>|JSONResponse<400, array{error: string},
 	 *     array<never, never>>
 	 *
-	 * @suppressWarnings(PHPMD.BooleanArgumentFlag) Toggle to include/exclude objects in export
+	 * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Toggle to include/exclude objects in export
 	 *
 	 * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-14
 	 */

--- a/lib/Controller/ConversationController.php
+++ b/lib/Controller/ConversationController.php
@@ -53,7 +53,7 @@ use Symfony\Component\Uid\Uuid;
  *
  * @psalm-suppress UnusedClass
  *
- * @suppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class ConversationController extends Controller {
 
@@ -127,7 +127,7 @@ class ConversationController extends Controller {
 	 * @param LoggerInterface $logger Logger
 	 * @param string $userId User ID
 	 *
-	 * @suppressWarnings(PHPMD.ExcessiveParameterList) Nextcloud DI requires constructor injection
+	 * @SuppressWarnings(PHPMD.ExcessiveParameterList) Nextcloud DI requires constructor injection
 	 */
 	public function __construct(
 		string $appName,
@@ -681,7 +681,7 @@ class ConversationController extends Controller {
 	 *     'Failed to delete conversation', message: string, uuid?: string,
 	 *     archived?: true}, array<never, never>>
 	 *
-	 * @suppressWarnings(PHPMD.ExcessiveMethodLength)
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
 	 *
 	 * @spec openspec/specs/chat-ai/spec.md
 	 */

--- a/lib/Controller/DashboardController.php
+++ b/lib/Controller/DashboardController.php
@@ -187,7 +187,7 @@ class DashboardController extends Controller {
 	 * @return JSONResponse The JSON response containing registers with schemas
 	 *
 	 * @psalm-return JSONResponse<
-	 *     200|500,
+	 *     200|403|500,
 	 *     array{
 	 *         error?: string,
 	 *         registers?: list<array{
@@ -337,8 +337,8 @@ class DashboardController extends Controller {
 	 *
 	 * @return JSONResponse JSON response with calculation results
 	 *
-	 * @psalm-return JSONResponse<200|500,
-	 *     array{status: 'error'|'success', message?: string, timestamp: string,
+	 * @psalm-return JSONResponse<200|403|500,
+	 *     array{error: string}|array{status: 'error'|'success', message?: string, timestamp: string,
 	 *     scope?: array{register: array{id: int, title: null|string}|null,
 	 *     schema: array{id: int, title: null|string}|null},
 	 *     results?: array{objects: array, logs: array,
@@ -387,7 +387,7 @@ class DashboardController extends Controller {
 	 *
 	 * @return JSONResponse JSON response with chart data or error
 	 *
-	 * @psalm-return JSONResponse<200|500,
+	 * @psalm-return JSONResponse<200|403|500,
 	 *     array{error?: string, labels?: list<array-key>,
 	 *     series?: list<array{data: list<int>, name: string}>},
 	 *     array<never, never>>
@@ -439,7 +439,7 @@ class DashboardController extends Controller {
 	 *
 	 * @return JSONResponse JSON response with chart data or error
 	 *
-	 * @psalm-return JSONResponse<200|500,
+	 * @psalm-return JSONResponse<200|403|500,
 	 *     array{error?: string, labels?: array<'Unknown'|mixed>, series?: array<int>},
 	 *     array<never, never>>
 	 *
@@ -470,7 +470,7 @@ class DashboardController extends Controller {
 	 *
 	 * @return JSONResponse JSON response with chart data or error
 	 *
-	 * @psalm-return JSONResponse<200|500,
+	 * @psalm-return JSONResponse<200|403|500,
 	 *     array{error?: string, labels?: array<'Unknown'|mixed>, series?: array<int>},
 	 *     array<never, never>>
 	 *
@@ -501,7 +501,7 @@ class DashboardController extends Controller {
 	 *
 	 * @return JSONResponse JSON response with chart data or error
 	 *
-	 * @psalm-return JSONResponse<200|500,
+	 * @psalm-return JSONResponse<200|403|500,
 	 *     array{error?: string,
 	 *     labels?: list<'0-1 KB'|'1-10 KB'|'10-100 KB'|'100 KB-1 MB'|'> 1 MB'>,
 	 *     series?: list<int>},
@@ -535,7 +535,7 @@ class DashboardController extends Controller {
 	 *
 	 * @return JSONResponse JSON response with statistics or error
 	 *
-	 * @psalm-return JSONResponse<200|500,
+	 * @psalm-return JSONResponse<200|403|500,
 	 *     array{error?: string, total?: int, creates?: int,
 	 *     updates?: int, deletes?: int, reads?: int},
 	 *     array<never, never>>
@@ -572,7 +572,7 @@ class DashboardController extends Controller {
 	 *
 	 * @return JSONResponse JSON response with action distribution or error
 	 *
-	 * @psalm-return JSONResponse<200|500,
+	 * @psalm-return JSONResponse<200|403|500,
 	 *     array{error?: string, actions?: list<array{count: int, name: mixed}>},
 	 *     array<never, never>>
 	 *
@@ -609,7 +609,7 @@ class DashboardController extends Controller {
 	 *
 	 * @return JSONResponse JSON response with most active objects or error
 	 *
-	 * @psalm-return JSONResponse<200|500,
+	 * @psalm-return JSONResponse<200|403|500,
 	 *     array{error?: string, objects?: list<array{count: int, id: mixed, name: string}>},
 	 *     array<never, never>>
 	 *

--- a/lib/Controller/DeletedController.php
+++ b/lib/Controller/DeletedController.php
@@ -149,7 +149,7 @@ class DeletedController extends Controller {
 	 *
 	 * @return array Request parameters including pagination and filters
 	 *
-	 * @suppressWarnings(PHPMD.CyclomaticComplexity)
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 */
 	private function extractRequestParameters(): array {
 		$params = $this->request->getParams();

--- a/lib/Controller/EndpointsController.php
+++ b/lib/Controller/EndpointsController.php
@@ -299,7 +299,7 @@ class EndpointsController extends Controller {
 	 * @return JSONResponse JSON response with created endpoint or error
 	 *
 	 * @psalm-return JSONResponse<201, \OCA\OpenRegister\Db\Endpoint,
-	 *     array<never, never>>|JSONResponse<400|500, array{error: string},
+	 *     array<never, never>>|JSONResponse<400|403|500, array{error: string},
 	 *     array<never, never>>
 	 *
 	 * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7
@@ -381,7 +381,7 @@ class EndpointsController extends Controller {
 	 * @return JSONResponse JSON response with updated endpoint or error
 	 *
 	 * @psalm-return JSONResponse<200, \OCA\OpenRegister\Db\Endpoint,
-	 *     array<never, never>>|JSONResponse<404|500, array{error: string},
+	 *     array<never, never>>|JSONResponse<403|404|500, array{error: string},
 	 *     array<never, never>>
 	 *
 	 * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-7

--- a/lib/Controller/FileExtractionController.php
+++ b/lib/Controller/FileExtractionController.php
@@ -51,7 +51,7 @@ use OCP\IUserSession;
  *
  * @psalm-suppress UnusedClass
  *
- * @suppressWarnings(PHPMD.TooManyPublicMethods)
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  * @SuppressWarnings(PHPMD.CyclomaticComplexity)
  * @SuppressWarnings(PHPMD.NPathComplexity)
  * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
@@ -331,7 +331,7 @@ class FileExtractionController extends Controller {
 	 *     array<never, never>
 	 * >
 	 *
-	 * @suppressWarnings(PHPMD.BooleanArgumentFlag) Force flag allows re-extraction bypass
+	 * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Force flag allows re-extraction bypass
 	 *
 	 * @spec openspec/specs/object-lifecycle/spec.md
 	 */

--- a/lib/Controller/FileExtractionController.php
+++ b/lib/Controller/FileExtractionController.php
@@ -395,8 +395,8 @@ class FileExtractionController extends Controller {
 	 * @NoCSRFRequired
 	 *
 	 * @psalm-return JSONResponse<
-	 *     200|500,
-	 *     array{
+	 *     200|403|500,
+	 *     array{success: false, error: string}|array{
 	 *         success: bool,
 	 *         error?: 'File discovery failed',
 	 *         message: string,
@@ -454,8 +454,8 @@ class FileExtractionController extends Controller {
 	 * @NoCSRFRequired
 	 *
 	 * @psalm-return JSONResponse<
-	 *     200|500,
-	 *     array{
+	 *     200|403|500,
+	 *     array{success: false, error: string}|array{
 	 *         success: bool,
 	 *         error?: 'Batch extraction failed',
 	 *         message: string,
@@ -505,8 +505,8 @@ class FileExtractionController extends Controller {
 	 * @NoCSRFRequired
 	 *
 	 * @psalm-return JSONResponse<
-	 *     200|500,
-	 *     array{
+	 *     200|403|500,
+	 *     array{success: false, error: string}|array{
 	 *         success: bool,
 	 *         error?: 'Retry failed',
 	 *         message: string,
@@ -610,8 +610,8 @@ class FileExtractionController extends Controller {
 	 * @NoCSRFRequired
 	 *
 	 * @psalm-return JSONResponse<
-	 *     200|500,
-	 *     array{
+	 *     200|403|500,
+	 *     array{success: false, error: string}|array{
 	 *         success: bool,
 	 *         error?: 'Cleanup failed',
 	 *         message: string,

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -526,7 +526,7 @@ class FilesController extends Controller {
 	 *
 	 * @NoCSRFRequired
 	 *
-	 * @psalm-return JSONResponse<200|400|404, array{error?: mixed|string, labels?: list<string>,...}, array<never, never>>
+	 * @psalm-return JSONResponse<200|400|403|404, array{error?: mixed|string, labels?: list<string>,...}, array<never, never>>
 	 *
 	 * @spec openspec/specs/object-interactions/spec.md
 	 *
@@ -612,7 +612,7 @@ class FilesController extends Controller {
 	 *
 	 * @NoCSRFRequired
 	 *
-	 * @psalm-return JSONResponse<200|400|404,
+	 * @psalm-return JSONResponse<200|400|403|404,
 	 *     array{error?: mixed|string, labels?: list<string>,...},
 	 *     array<never, never>>
 	 *
@@ -722,7 +722,7 @@ class FilesController extends Controller {
 	 *
 	 * @NoCSRFRequired
 	 *
-	 * @psalm-return JSONResponse<200|400|404, array{error?: string, 0?: array<string, mixed>,...}, array<never, never>>
+	 * @psalm-return JSONResponse<200|400|403|404, array{error?: string, 0?: array<string, mixed>,...}, array<never, never>>
 	 *
 	 * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-12
 	 *
@@ -859,7 +859,7 @@ class FilesController extends Controller {
 		}
 
 		// Multiple file upload.
-		if ($fileName !== null && is_array($fileName) === true) {
+		if ($fileName !== null) {
 			$uploadedFiles = $this->normalizeMultipleFiles(files: $files, data: $data, fileNames: $fileName);
 		}
 
@@ -974,7 +974,7 @@ class FilesController extends Controller {
 	 *
 	 * @throws Exception If file validation or processing fails
 	 *
-	 * @psalm-return list<OCP\Files\File>
+	 * @psalm-return list<\OCP\Files\File>
 	 */
 	private function processUploadedFiles(ObjectEntity $object, array $uploadedFiles): array {
 		$results = [];

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -616,7 +616,7 @@ class FilesController extends Controller {
 	 *     array{error?: mixed|string, labels?: list<string>,...},
 	 *     array<never, never>>
 	 *
-	 * @suppressWarnings(PHPMD.CyclomaticComplexity)
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 *
 	 * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-12
 	 *

--- a/lib/Controller/MappingsController.php
+++ b/lib/Controller/MappingsController.php
@@ -334,7 +334,7 @@ class MappingsController extends Controller {
 	 *
 	 * @return JSONResponse JSON response with test results
 	 *
-	 * @suppressWarnings(PHPMD.CyclomaticComplexity)
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 *
 	 * @spec openspec/specs/openapi-generation/spec.md#requirement-schema-authoring-sub-resources-and-meta-entity-operational-endpoints
 	 */

--- a/lib/Controller/NamesController.php
+++ b/lib/Controller/NamesController.php
@@ -154,7 +154,9 @@ class NamesController extends Controller {
 					}
 				}
 
-				if (is_string($requestedIds) === false && is_array($requestedIds) === false) {
+				// The is_string() branch above has already converted every string
+				// form to an array, so only the non-array case is left to wrap.
+				if (is_array($requestedIds) === false) {
 					$requestedIds = [(string)$requestedIds];
 				}
 

--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -2140,7 +2140,7 @@ class ObjectsController extends Controller {
 	 *
 	 * @PublicPage
 	 *
-	 * @psalm-return JSONResponse<200, array<string, mixed>, array<never, never>>
+	 * @psalm-return JSONResponse<200|404, array<string, mixed>, array<never, never>>
 	 *
 	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
 	 * @SuppressWarnings(PHPMD.NPathComplexity)

--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -76,13 +76,13 @@ use Symfony\Component\Uid\Uuid;
  *
  * @psalm-suppress UnusedClass
  *
- * @suppressWarnings(PHPMD.ExcessiveClassLength)
- * @suppressWarnings(PHPMD.ExcessiveClassComplexity)
- * @suppressWarnings(PHPMD.TooManyMethods)
- * @suppressWarnings(PHPMD.TooManyPublicMethods)
- * @suppressWarnings(PHPMD.CouplingBetweenObjects)
- * @suppressWarnings(PHPMD.ElseExpression)           File upload extraction requires conditional branching
- * @suppressWarnings(PHPMD.ExcessiveMethodLength)    Complex file upload handling with multiple formats
+ * @SuppressWarnings(PHPMD.ExcessiveClassLength)
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ * @SuppressWarnings(PHPMD.TooManyMethods)
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.ElseExpression)           File upload extraction requires conditional branching
+ * @SuppressWarnings(PHPMD.ExcessiveMethodLength)    Complex file upload handling with multiple formats
  * @SuppressWarnings(PHPMD.CyclomaticComplexity)
  * @SuppressWarnings(PHPMD.NPathComplexity)
  *
@@ -134,7 +134,7 @@ class ObjectsController extends Controller {
 	 *
 	 * @return void
 	 *
-	 * @suppressWarnings(PHPMD.ExcessiveParameterList) Nextcloud DI requires constructor injection
+	 * @SuppressWarnings(PHPMD.ExcessiveParameterList) Nextcloud DI requires constructor injection
 	 */
 	public function __construct(
 		string $appName,
@@ -637,7 +637,7 @@ class ObjectsController extends Controller {
 	 *     ids: array|null
 	 * }
 	 *
-	 * @suppressWarnings(PHPMD.UnusedFormalParameter)
+	 * @SuppressWarnings(PHPMD.UnusedFormalParameter)
 	 */
 	private function getConfig(?string $_register = null, ?string $_schema = null, ?array $ids = null): array {
 		$params = $this->request->getParams();
@@ -826,7 +826,7 @@ class ObjectsController extends Controller {
 	 *
 	 * @psalm-suppress UnusedParam Params are used in foreach loops and method calls.
 	 *
-	 * @suppressWarnings(PHPMD.ExcessiveMethodLength)
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
 	 */
 	private function crossTableSearch(array $registers, array $schemas, ObjectService $objectService): JSONResponse {
 		$magicMapper = \OC::$server->get(\OCA\OpenRegister\Db\MagicMapper::class);
@@ -1081,8 +1081,8 @@ class ObjectsController extends Controller {
 	 *
 	 * @psalm-return JSONResponse<200|404, array<string, mixed>, array<never, never>>
 	 *
-	 * @suppressWarnings(PHPMD.NPathComplexity)       Complex request parameter handling for flexible API
-	 * @suppressWarnings(PHPMD.ExcessiveMethodLength)
+	 * @SuppressWarnings(PHPMD.NPathComplexity)       Complex request parameter handling for flexible API
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)  Multi-schema search + pagination + filtering requires branching
 	 *
 	 * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md
@@ -2140,8 +2140,8 @@ class ObjectsController extends Controller {
 	 *
 	 * @psalm-return JSONResponse<200, array<string, mixed>, array<never, never>>
 	 *
-	 * @suppressWarnings(PHPMD.ExcessiveMethodLength)
-	 * @suppressWarnings(PHPMD.NPathComplexity)
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+	 * @SuppressWarnings(PHPMD.NPathComplexity)
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)  Cross-table search + multi-schema routing requires branching
 	 *
 	 * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md
@@ -2362,7 +2362,7 @@ class ObjectsController extends Controller {
 	 *
 	 * @return JSONResponse JSON response with the object or error
 	 *
-	 * @suppressWarnings(PHPMD.NPathComplexity)
+	 * @SuppressWarnings(PHPMD.NPathComplexity)
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity) Object retrieval with slug resolution + access checks requires branching
 	 *
 	 * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md
@@ -2569,7 +2569,7 @@ class ObjectsController extends Controller {
 	 * @psalm-suppress TypeDoesNotContainType
 	 * @psalm-suppress NoValue
 	 *
-	 * @suppressWarnings(PHPMD.NPathComplexity) Object creation requires many validation and processing steps
+	 * @SuppressWarnings(PHPMD.NPathComplexity) Object creation requires many validation and processing steps
 	 *
 	 * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md
 	 *
@@ -2769,8 +2769,8 @@ class ObjectsController extends Controller {
 	 * @psalm-suppress TypeDoesNotContainType
 	 * @psalm-suppress NoValue
 	 *
-	 * @suppressWarnings(PHPMD.NPathComplexity)       Object update requires many validation and processing steps
-	 * @suppressWarnings(PHPMD.ExcessiveMethodLength)
+	 * @SuppressWarnings(PHPMD.NPathComplexity)       Object update requires many validation and processing steps
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)  Object update requires many validation and processing steps
 	 *
 	 * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md
@@ -2993,8 +2993,8 @@ class ObjectsController extends Controller {
 	 *
 	 * @PublicPage
 	 *
-	 * @suppressWarnings(PHPMD.ExcessiveMethodLength)
-	 * @suppressWarnings(PHPMD.NPathComplexity)
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+	 * @SuppressWarnings(PHPMD.NPathComplexity)
 	 *
 	 * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md
 	 */
@@ -3804,7 +3804,7 @@ class ObjectsController extends Controller {
 	 *     message?: 'Object does not belong to specified register/schema'|'Object not found'},
 	 *     array<never, never>>
 	 *
-	 * @suppressWarnings(PHPMD.NPathComplexity)
+	 * @SuppressWarnings(PHPMD.NPathComplexity)
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity) Audit log retrieval with pagination + access checks requires branching
 	 *
 	 * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md

--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -929,8 +929,10 @@ class ObjectsController extends Controller {
 		// `_rbac` is forwarded only to gate the property `authorization.read` strip. It does
 		// NOT gate the writeOnly strip (#460): `$query['_rbac']` is false for an ADMIN here,
 		// and an admin is not exempt from the writeOnly render boundary (#389).
+		// No `?? true` fallback: this method sets $query['_rbac'] unconditionally
+		// a few lines above, so the key is always present here.
 		$renderHandler = \OC::$server->get(\OCA\OpenRegister\Service\Object\RenderObject::class);
-		$renderHandler->redactWriteOnlyFromRows(rows: $results, _rbac: $query['_rbac'] ?? true);
+		$renderHandler->redactWriteOnlyFromRows(rows: $results, _rbac: $query['_rbac']);
 
 		// Serialize results.
 		$serializedResults = [];

--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -1415,7 +1415,7 @@ class ObjectsController extends Controller {
 
 				// Content negotiation: JSON-LD @graph for magic-mapped results
 				// (json-ld-output).
-				if ($this->wantsJsonLd() === true && $registerEntity !== null && $schemaEntity !== null) {
+				if ($this->wantsJsonLd() === true) {
 					return $this->jsonLdCollectionResponse(
 						result: $responseData,
 						register: $registerEntity,

--- a/lib/Controller/RegistersController.php
+++ b/lib/Controller/RegistersController.php
@@ -81,14 +81,14 @@ use Symfony\Component\Uid\Uuid;
  *
  * @psalm-suppress UnusedClass
  *
- * @suppressWarnings(PHPMD.ExcessiveClassLength)     NC REST controller must expose all CRUD + subresource
+ * @SuppressWarnings(PHPMD.ExcessiveClassLength)     NC REST controller must expose all CRUD + subresource
  *   endpoints (registers, schemas, objects, statistics) in one class per NC AppFramework routing;
  *   splitting into multiple controllers would require additional routing registration.
- * @suppressWarnings(PHPMD.ExcessiveClassComplexity) Aggregate complexity from N independent REST actions;
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) Aggregate complexity from N independent REST actions;
  *   each action is individually simple — the class total is a routing artifact, not design debt.
- * @suppressWarnings(PHPMD.TooManyPublicMethods)     Each public method maps to one REST endpoint; NC AppFramework
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)     Each public method maps to one REST endpoint; NC AppFramework
  *   requires public methods for route dispatch — they cannot be made protected/private.
- * @suppressWarnings(PHPMD.CouplingBetweenObjects)   NC Controller DI injects AppFramework, RBAC, audit, domain
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)   NC Controller DI injects AppFramework, RBAC, audit, domain
  *   services, and mappers — each dep is used and cannot be combined without violating SRP.
  * @SuppressWarnings(PHPMD.ExcessiveMethodLength)    The create/update actions include multi-step validation
  *   that is a single atomic write; extracting sub-steps would create misleading partial-update helpers.
@@ -190,7 +190,7 @@ class RegistersController extends Controller {
 	 *
 	 * @return void
 	 *
-	 * @suppressWarnings(PHPMD.ExcessiveParameterList) Nextcloud DI requires constructor injection
+	 * @SuppressWarnings(PHPMD.ExcessiveParameterList) Nextcloud DI requires constructor injection
 	 */
 	public function __construct(
 		string $appName,
@@ -256,8 +256,8 @@ class RegistersController extends Controller {
 	 *
 	 * @return JSONResponse The JSON response containing the list of registers
 	 *
-	 * @suppressWarnings(PHPMD.NPathComplexity)      Complex request parameter handling for flexible API
-	 * @suppressWarnings(PHPMD.CyclomaticComplexity)
+	 * @SuppressWarnings(PHPMD.NPathComplexity)      Complex request parameter handling for flexible API
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 *
 	 * @spec openspec/changes/register-schema-read-accessibility/tasks.md#task-1
 	 */
@@ -541,7 +541,7 @@ class RegistersController extends Controller {
 	 *
 	 * @NoCSRFRequired
 	 *
-	 * @suppressWarnings(PHPMD.StaticAccess) DatabaseConstraintException factory method is standard pattern
+	 * @SuppressWarnings(PHPMD.StaticAccess) DatabaseConstraintException factory method is standard pattern
 	 *
 	 * @return JSONResponse JSON response with created register or error
 	 *
@@ -1179,9 +1179,9 @@ class RegistersController extends Controller {
 	 *
 	 * @return JSONResponse JSON response with publish result or error
 	 *
-	 * @suppressWarnings(PHPMD.NPathComplexity)       GitHub publishing requires many conditional checks
-	 * @suppressWarnings(PHPMD.ExcessiveMethodLength)
-	 * @suppressWarnings(PHPMD.CyclomaticComplexity)
+	 * @SuppressWarnings(PHPMD.NPathComplexity)       GitHub publishing requires many conditional checks
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 *
 	 * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-5
 	 */
@@ -1357,10 +1357,10 @@ class RegistersController extends Controller {
 	 *
 	 * @NoCSRFRequired
 	 *
-	 * @suppressWarnings(PHPMD.BooleanArgumentFlag)   Force flag to override version checks
-	 * @suppressWarnings(PHPMD.ExcessiveMethodLength)
-	 * @suppressWarnings(PHPMD.CyclomaticComplexity)
-	 * @suppressWarnings(PHPMD.NPathComplexity)
+	 * @SuppressWarnings(PHPMD.BooleanArgumentFlag)   Force flag to override version checks
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+	 * @SuppressWarnings(PHPMD.NPathComplexity)
 	 *
 	 * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-10
 	 */
@@ -1887,7 +1887,7 @@ class RegistersController extends Controller {
 	 *
 	 * @return bool The parsed boolean value
 	 *
-	 * @suppressWarnings(PHPMD.BooleanArgumentFlag) Default value is needed for parameter parsing
+	 * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Default value is needed for parameter parsing
 	 */
 	private function parseBooleanParam(string $paramName, bool $default = false): bool {
 		$value = $this->request->getParam(key: $paramName, default: $default);

--- a/lib/Controller/RegistersController.php
+++ b/lib/Controller/RegistersController.php
@@ -1808,47 +1808,18 @@ class RegistersController extends Controller {
 	 *     200|404|500,
 	 *     array{
 	 *         error?: string,
-	 *         register?: array{
-	 *             id: int,
-	 *             uuid: null|string,
-	 *             slug: null|string,
-	 *             title: null|string,
-	 *             version: null|string,
-	 *             description: null|string,
-	 *             schemas: array<int|string>,
-	 *             source: null|string,
-	 *             tablePrefix: null|string,
-	 *             folder: null|string,
-	 *             updated: null|string,
-	 *             created: null|string,
-	 *             owner: null|string,
-	 *             application: null|string,
-	 *             organisation: null|string,
-	 *             authorization: array|null,
-	 *             groups: array<string, list<string>>,
-	 *             configuration: array|null,
-	 *             quota: array{
-	 *                 storage: null,
-	 *                 bandwidth: null,
-	 *                 requests: null,
-	 *                 users: null,
-	 *                 groups: null
-	 *             },
-	 *             usage: array{
-	 *                 storage: 0,
-	 *                 bandwidth: 0,
-	 *                 requests: 0,
-	 *                 users: 0,
-	 *                 groups: int<0, max>
-	 *             },
-	 *             deleted: null|string,
-	 *             published: null|string,
-	 *             depublished: null|string
-	 *         },
+	 *         register?: array<string, mixed>,
 	 *         message?: 'Stats calculation not yet implemented'
 	 *     },
 	 *     array<never, never>
 	 * >
+	 *
+	 * `register` is deliberately `array<string, mixed>` and not a spelled-out
+	 * shape. The previous annotation duplicated Register::jsonSerialize() field
+	 * by field and had rotted into nonsense: it pinned `quota` to all-null and
+	 * `usage` to all-literal-zero, because it was inferred from a register that
+	 * had neither. The entity's serializer owns that contract; restating it here
+	 * only guarantees the copy drifts again.
 	 *
 	 * @spec openspec/specs/production-observability/spec.md#requirement-per-entity-statistics-and-endpoint-delivery-log-api
 	 */

--- a/lib/Controller/RetentionController.php
+++ b/lib/Controller/RetentionController.php
@@ -160,10 +160,10 @@ class RetentionController extends Controller {
 							false,
 							false
 						);
-						if ($exclObject !== null) {
-							$this->retentionService->extendArchiveActionDate($exclObject);
-							$this->objectMapper->update($exclObject);
-						}
+						// find() throws rather than returning null; the catch below
+						// is what handles a missing object.
+						$this->retentionService->extendArchiveActionDate($exclObject);
+						$this->objectMapper->update($exclObject);
 					} catch (Exception $e) {
 						$this->logger->warning(
 							'[RetentionController] Failed to extend excluded object: ' . $e->getMessage()
@@ -311,10 +311,10 @@ class RetentionController extends Controller {
 
 				try {
 					$object = $this->objectMapper->find($uuid, null, null, false, false, false);
-					if ($object !== null) {
-						$this->retentionService->extendArchiveActionDate($object);
-						$this->objectMapper->update($object);
-					}
+					// find() throws rather than returning null; the catch below is
+					// what handles a missing object.
+					$this->retentionService->extendArchiveActionDate($object);
+					$this->objectMapper->update($object);
 				} catch (Exception $e) {
 					$this->logger->warning(
 						'[RetentionController] Failed to extend rejected object: ' . $e->getMessage()

--- a/lib/Controller/RetentionController.php
+++ b/lib/Controller/RetentionController.php
@@ -160,7 +160,7 @@ class RetentionController extends Controller {
 							false,
 							false
 						);
-						// find() throws rather than returning null; the catch below
+						// The find() call throws rather than returning null; the catch below
 						// is what handles a missing object.
 						$this->retentionService->extendArchiveActionDate($exclObject);
 						$this->objectMapper->update($exclObject);
@@ -311,7 +311,7 @@ class RetentionController extends Controller {
 
 				try {
 					$object = $this->objectMapper->find($uuid, null, null, false, false, false);
-					// find() throws rather than returning null; the catch below is
+					// The find() call throws rather than returning null; the catch below is
 					// what handles a missing object.
 					$this->retentionService->extendArchiveActionDate($object);
 					$this->objectMapper->update($object);

--- a/lib/Controller/SchemasController.php
+++ b/lib/Controller/SchemasController.php
@@ -162,20 +162,14 @@ class SchemasController extends Controller {
 	 * @return JSONResponse JSON response with array of schemas
 	 *
 	 * @psalm-return JSONResponse<200,
-	 *     array{results: array<array{id: int, uuid: null|string,
-	 *     uri: null|string, slug: null|string, title: null|string,
-	 *     description: null|string, version: null|string,
-	 *     summary: null|string, icon: null|string, required: array,
-	 *     properties: array, archive: array|null, source: null|string,
-	 *     hardValidation: bool, immutable: bool, searchable: bool,
-	 *     updated: null|string, created: null|string, maxDepth: int,
-	 *     owner: null|string, application: null|string,
-	 *     organisation: null|string,
-	 *     groups: array<string, list<string>>|null,
-	 *     authorization: array|null, deleted: null|string,
-	 *     published: null|string, depublished: null|string,
-	 *     configuration: array|null|string, allOf: array|null,
-	 *     oneOf: array|null, anyOf: array|null}>}, array<never, never>>
+	 *     array{results: list<array<string, mixed>>}, array<never, never>>
+	 *
+	 * Each result is deliberately `array<string, mixed>` and not a spelled-out
+	 * shape. The previous annotation restated Schema::jsonSerialize() field by
+	 * field and was already wrong: it omitted the four keys (`objects`, `logs`,
+	 * `files`, `registers`) that the `_stats` block appends to every entry. The
+	 * entity's serializer owns that contract; copying it here only guarantees
+	 * the copy drifts.
 	 *
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)  Multiple optional extend/pagination/filter parameters each add one branch.
 	 * @SuppressWarnings(PHPMD.NPathComplexity)       Multiple optional extend/pagination/filter parameters each add one branch.

--- a/lib/Controller/SearchController.php
+++ b/lib/Controller/SearchController.php
@@ -204,7 +204,7 @@ class SearchController extends Controller {
 	 *
 	 * @return string The processed search query ready for the SOLR search service
 	 *
-	 * @suppressWarnings(PHPMD.CyclomaticComplexity)
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 *
 	 * @spec openspec/specs/zoeken-filteren/spec.md#requirement-dutch-language-search-support-i18n
 	 */

--- a/lib/Controller/SearchController.php
+++ b/lib/Controller/SearchController.php
@@ -24,9 +24,9 @@
 
 namespace OCA\OpenRegister\Controller;
 
+use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\AppFramework\Controller;
-use OCP\AppFramework\Db\Entity;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
@@ -135,30 +135,24 @@ class SearchController extends Controller {
 			 */
 
 			function ($object): array {
-				// Probe the PROPERTY, not the method. searchObjectsPaginated()
-				// returns ObjectEntity rows, and ObjectEntity declares getUuid() and
-				// getName() only as `@method` — Nextcloud's Entity serves them through
-				// __call(). method_exists() is FALSE for both, so every row fell past
-				// this branch, and the array branch below cannot read an object either:
-				// $objectArr stayed [] and EVERY search hit was returned as
-				// `id: null, name: 'Unknown'`.
+				// searchObjectsPaginated() returns ObjectEntity rows, and
+				// ObjectEntity declares getUuid() / getName() only as `@method`
+				// — Nextcloud's Entity serves them through __call(). An earlier
+				// version of this closure probed with method_exists(), which is
+				// FALSE for both, so every row fell past this branch and came
+				// back as `id: null, name: 'Unknown'`.
 				//
-				// There is no fallback to recover it here: unlike the getUuid probes
-				// elsewhere in this app, nothing on this path routes through
-				// getObject(), which is the concrete method that injects the uuid
-				// under 'id'. property_exists() is the same test Entity::getter() runs
-				// before returning the value, so it cannot throw.
-				if ($object instanceof Entity && property_exists($object, 'uuid') === true) {
-					$name = null;
-					if (property_exists($object, 'name') === true) {
-						// @phpstan-ignore-next-line Entity::getName() is dispatched via __call.
-						$name = $object->getName();
-					}
-
+				// Narrowing on ObjectEntity rather than the OCP Entity base is
+				// what makes the accessors resolvable: the `@method` tags live on
+				// ObjectEntity. Against the base they produced an error type that
+				// propagated out through this array and left the whole
+				// JSONResponse payload unverifiable. It also makes the
+				// property_exists('uuid') / ('name') probes redundant — both are
+				// declared properties of ObjectEntity — so they are gone.
+				if ($object instanceof ObjectEntity) {
 					return [
-						// @phpstan-ignore-next-line Entity::getUuid() is dispatched via __call.
 						'id' => $object->getUuid(),
-						'name' => $name ?? 'Unknown',
+						'name' => $object->getName() ?? 'Unknown',
 						'type' => 'object',
 						'url' => null,
 						'source' => 'openregister',

--- a/lib/Controller/SearchController.php
+++ b/lib/Controller/SearchController.php
@@ -135,7 +135,7 @@ class SearchController extends Controller {
 			 */
 
 			function ($object): array {
-				// searchObjectsPaginated() returns ObjectEntity rows, and
+				// The searchObjectsPaginated() call returns ObjectEntity rows, and
 				// ObjectEntity declares getUuid() / getName() only as `@method`
 				// — Nextcloud's Entity serves them through __call(). An earlier
 				// version of this closure probed with method_exists(), which is

--- a/lib/Controller/SearchTrailController.php
+++ b/lib/Controller/SearchTrailController.php
@@ -39,8 +39,8 @@ use OCP\IUserSession;
  *
  * @psalm-suppress UnusedClass
  *
- * @suppressWarnings(PHPMD.TooManyPublicMethods)
- * @suppressWarnings(PHPMD.ExcessiveClassComplexity)
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  */
 class SearchTrailController extends Controller {
 	/**
@@ -100,9 +100,9 @@ class SearchTrailController extends Controller {
 	 *
 	 * @return array Request parameters including pagination and filters
 	 *
-	 * @suppressWarnings(PHPMD.NPathComplexity)       Request parameter extraction requires many conditional checks
-	 * @suppressWarnings(PHPMD.ExcessiveMethodLength)
-	 * @suppressWarnings(PHPMD.CyclomaticComplexity)
+	 * @SuppressWarnings(PHPMD.NPathComplexity)       Request parameter extraction requires many conditional checks
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 *
 	 * @spec exclude Private helper: parses pagination/filter/date params; the search-trail analytics API is owned by
 	 *              retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-3.
@@ -248,8 +248,8 @@ class SearchTrailController extends Controller {
 	 *     prev?: null|string
 	 * }
 	 *
-	 * @suppressWarnings(PHPMD.CyclomaticComplexity)
-	 * @suppressWarnings(PHPMD.NPathComplexity)
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+	 * @SuppressWarnings(PHPMD.NPathComplexity)
 	 *
 	 * @spec exclude Private helper: shared pagination-envelope builder; the search-trail analytics API is owned by
 	 *              retrofit-2026-05-25-bw2-ctrl-1/tasks.md#task-3.

--- a/lib/Controller/Settings/LlmSettingsController.php
+++ b/lib/Controller/Settings/LlmSettingsController.php
@@ -92,8 +92,8 @@ class LlmSettingsController extends Controller {
 	 *
 	 * @return JSONResponse JSON response with updated LLM settings
 	 *
-	 * @suppressWarnings(PHPMD.CyclomaticComplexity)
-	 * @suppressWarnings(PHPMD.NPathComplexity)
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+	 * @SuppressWarnings(PHPMD.NPathComplexity)
 	 *
 	 * @spec openspec/specs/chat-ai/spec.md
 	 */
@@ -332,8 +332,8 @@ class LlmSettingsController extends Controller {
 	 *     modified: mixed|null, name: 'unknown'|mixed, size: 0|mixed}>,
 	 *     count?: int<0, max>}, array<never, never>>
 	 *
-	 * @suppressWarnings(PHPMD.ExcessiveMethodLength)
-	 * @suppressWarnings(PHPMD.CyclomaticComplexity)
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 *
 	 * @spec openspec/specs/chat-ai/spec.md
 	 */

--- a/lib/Controller/Settings/LlmSettingsController.php
+++ b/lib/Controller/Settings/LlmSettingsController.php
@@ -410,7 +410,7 @@ class LlmSettingsController extends Controller {
 					$description = $family;
 					if ($size !== '') {
 						// Add size separator if description exists.
-						if ($description !== null && $description !== '') {
+						if ($description !== '') {
 							$description .= ' • ';
 						}
 

--- a/lib/Controller/Settings/N8nSettingsController.php
+++ b/lib/Controller/Settings/N8nSettingsController.php
@@ -270,7 +270,7 @@ class N8nSettingsController extends Controller {
 	 *
 	 * @return JSONResponse JSON response with initialization result
 	 *
-	 * @suppressWarnings(PHPMD.ExcessiveMethodLength)
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
 	 *
 	 * @spec openspec/specs/production-observability/spec.md
 	 */

--- a/lib/Controller/Settings/ValidationSettingsController.php
+++ b/lib/Controller/Settings/ValidationSettingsController.php
@@ -98,7 +98,7 @@ class ValidationSettingsController extends Controller {
 	 *
 	 * @return JSONResponse JSON response with mass validation results
 	 *
-	 * @suppressWarnings(PHPMD.CyclomaticComplexity)
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 *
 	 * @spec openspec/specs/production-observability/spec.md
 	 */

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -127,14 +127,12 @@ use RuntimeException;
  */
 class SettingsController extends Controller {
 
-	/**
-	 * The OpenRegister object service
-	 *
-	 * Lazily loaded from container when needed.
-	 *
-	 * @var \OCA\OpenRegister\Service\ObjectService|null OpenRegister object service or null
+	/*
+	 * There is no $objectService property: getObjectService() below assigned it
+	 * null and returned that (the "CIRCULAR FIX"), so it was never anything but
+	 * null. Code that needs the service resolves it from the container at the
+	 * point of use instead — see the $objectService locals further down.
 	 */
-	private ?\OCA\OpenRegister\Service\ObjectService $objectService = null;
 
 	/**
 	 * SettingsController constructor.
@@ -178,9 +176,9 @@ class SettingsController extends Controller {
 	 */
 	public function getObjectService() {
 		if (in_array(needle: 'openregister', haystack: $this->appManager->getInstalledApps()) === true) {
-			$this->objectService = null;
-			// CIRCULAR FIX.
-			return $this->objectService;
+			// CIRCULAR FIX: returning the service here would close a container
+			// cycle, so callers resolve it themselves.
+			return null;
 		}
 
 		throw new RuntimeException('OpenRegister service is not available.');

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -1012,11 +1012,9 @@ class SettingsController extends Controller {
 				weights: $weights,
 				provider: $provider
 			);
-			// Ensure result is an array for the spread operator.
-			$resultArray = [];
-			if (is_array($result) === true) {
-				$resultArray = $result;
-			}
+			// The service already returns an array, so the old is_array() guard
+			// (and the [] fallback it protected) could never fire.
+			$resultArray = $result;
 
 			return new JSONResponse(
 				data: [

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -391,9 +391,9 @@ class SettingsController extends Controller {
 	 *
 	 * @return JSONResponse JSON response with database info
 	 *
-	 * @suppressWarnings(PHPMD.ExcessiveMethodLength)
-	 * @suppressWarnings(PHPMD.CyclomaticComplexity)
-	 * @suppressWarnings(PHPMD.NPathComplexity)
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+	 * @SuppressWarnings(PHPMD.NPathComplexity)
 	 *
 	 * @spec openspec/specs/production-observability/spec.md
 	 */
@@ -750,7 +750,7 @@ class SettingsController extends Controller {
 	 *     type: 'NO TYPE'|mixed, object_json: mixed}>}},
 	 *     array<never, never>>
 	 *
-	 * @suppressWarnings(PHPMD.ExcessiveMethodLength)
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
 	 *
 	 * @spec exclude Debug/test scaffolding endpoint ("Debug endpoint for type filtering issue"): dumps
 	 *              organisation/object data; not a product contract (see proposal Notes — routed debug surface,

--- a/lib/Controller/SourcesController.php
+++ b/lib/Controller/SourcesController.php
@@ -252,7 +252,7 @@ class SourcesController extends Controller {
 		$data = $this->sanitizeDatabaseSourceData(data: $data);
 
 		// Encrypt databaseUrl at rest before persisting (legacy harvest path).
-		if (isset($data['databaseUrl']) === true && $data['databaseUrl'] !== null && $data['databaseUrl'] !== '') {
+		if (isset($data['databaseUrl']) === true && $data['databaseUrl'] !== '') {
 			$data['databaseUrl'] = $this->crypto->encrypt((string)$data['databaseUrl']);
 		}
 
@@ -303,7 +303,7 @@ class SourcesController extends Controller {
 		$data = $this->sanitizeDatabaseSourceData(data: $data);
 
 		// Encrypt databaseUrl at rest before persisting (legacy harvest path).
-		if (isset($data['databaseUrl']) === true && $data['databaseUrl'] !== null && $data['databaseUrl'] !== '') {
+		if (isset($data['databaseUrl']) === true && $data['databaseUrl'] !== '') {
 			$data['databaseUrl'] = $this->crypto->encrypt((string)$data['databaseUrl']);
 		}
 

--- a/lib/Controller/UserController.php
+++ b/lib/Controller/UserController.php
@@ -105,7 +105,7 @@ class UserController extends Controller {
 	 *
 	 * @return JSONResponse JSON response with user profile data
 	 *
-	 * @suppressWarnings(PHPMD.ShortMethodName) Standard REST API endpoint name for current user
+	 * @SuppressWarnings(PHPMD.ShortMethodName) Standard REST API endpoint name for current user
 	 *
 	 * @spec openspec/specs/auth-system/spec.md
 	 */

--- a/lib/Controller/ViewsController.php
+++ b/lib/Controller/ViewsController.php
@@ -42,7 +42,7 @@ use Psr\Log\LoggerInterface;
  *
  * @psalm-suppress UnusedClass
  *
- * @suppressWarnings(PHPMD.ExcessiveClassComplexity)
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
  *
  * @spec openspec/specs/faceting-configuration/spec.md
@@ -115,7 +115,7 @@ class ViewsController extends Controller {
 	 *
 	 * @return JSONResponse JSON response with views or error
 	 *
-	 * @suppressWarnings(PHPMD.CyclomaticComplexity)
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 *
 	 * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-8
 	 */
@@ -270,7 +270,7 @@ class ViewsController extends Controller {
 	 *
 	 * @return JSONResponse JSON response with created view or error
 	 *
-	 * @suppressWarnings(PHPMD.CyclomaticComplexity)
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 *
 	 * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-8
 	 */
@@ -398,7 +398,7 @@ class ViewsController extends Controller {
 	 *
 	 * @return JSONResponse JSON response with updated view or error
 	 *
-	 * @suppressWarnings(PHPMD.CyclomaticComplexity)
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 *
 	 * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-8
 	 */
@@ -537,7 +537,7 @@ class ViewsController extends Controller {
 	 *
 	 * @return JSONResponse JSON response with patched view or error
 	 *
-	 * @suppressWarnings(PHPMD.CyclomaticComplexity)
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 *
 	 * @spec openspec/changes/retrofit-2026-05-25-bw2-ctrl-2/tasks.md#task-8
 	 */

--- a/lib/Controller/WebhooksController.php
+++ b/lib/Controller/WebhooksController.php
@@ -55,9 +55,9 @@ use Psr\Log\LoggerInterface;
  *
  * @psalm-suppress UnusedClass
  *
- * @suppressWarnings(PHPMD.ExcessiveClassLength)
- * @suppressWarnings(PHPMD.ExcessiveClassComplexity)
- * @suppressWarnings(PHPMD.TooManyPublicMethods)
+ * @SuppressWarnings(PHPMD.ExcessiveClassLength)
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
  *
  * @spec openspec/specs/webhook-payload-mapping/spec.md
@@ -199,8 +199,8 @@ class WebhooksController extends Controller {
 	 *     array<never, never>
 	 * >
 	 *
-	 * @suppressWarnings(PHPMD.NPathComplexity)      Complex request parameter handling for flexible API
-	 * @suppressWarnings(PHPMD.CyclomaticComplexity)
+	 * @SuppressWarnings(PHPMD.NPathComplexity)      Complex request parameter handling for flexible API
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 *
 	 * @spec openspec/specs/webhook-payload-mapping/spec.md
 	 */
@@ -719,7 +719,7 @@ class WebhooksController extends Controller {
 	 * @no-admin-idor-exempt No per-object resource: returns the static catalogue of available webhook event-type definitions
 	 *   (identical for every install); no tenant data.
 	 *
-	 * @suppressWarnings(PHPMD.ExcessiveMethodLength)
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
 	 *
 	 * @spec openspec/specs/event-driven-architecture/spec.md
 	 */
@@ -1193,7 +1193,7 @@ class WebhooksController extends Controller {
 	 *
 	 * @NoCSRFRequired
 	 *
-	 * @suppressWarnings(PHPMD.CyclomaticComplexity)
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 *
 	 * @spec openspec/specs/webhook-payload-mapping/spec.md
 	 */
@@ -1313,9 +1313,9 @@ class WebhooksController extends Controller {
 	 *
 	 * @NoCSRFRequired
 	 *
-	 * @suppressWarnings(PHPMD.ExcessiveMethodLength)
-	 * @suppressWarnings(PHPMD.CyclomaticComplexity)
-	 * @suppressWarnings(PHPMD.NPathComplexity)
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+	 * @SuppressWarnings(PHPMD.NPathComplexity)
 	 *
 	 * @spec openspec/specs/webhook-payload-mapping/spec.md
 	 */

--- a/lib/Db/AgentMapper.php
+++ b/lib/Db/AgentMapper.php
@@ -317,7 +317,7 @@ class AgentMapper extends QBMapper {
 	 *
 	 * @throws \Exception If user doesn't have read permission
 	 *
-	 * @psalm-return list<OCA\OpenRegister\Db\Agent>
+	 * @psalm-return list<\OCA\OpenRegister\Db\Agent>
 	 *
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 */

--- a/lib/Db/Application.php
+++ b/lib/Db/Application.php
@@ -605,7 +605,7 @@ class Application extends Entity implements JsonSerializable {
 	 *     registers: array|null, schemas: array|null, owner: null|string,
 	 *     active: bool|null, groups: array|null,
 	 *     quota: array{storage: int|null, bandwidth: int|null,
-	 *     requests: int|null, users: null, groups: null},
+	 *     requests: int|null, users: int|null, groups: int|null},
 	 *     usage: array{storage: 0, bandwidth: 0, requests: 0, users: 0,
 	 *     groups: int<0, max>}, authorization: array,
 	 *     created: null|string, updated: null|string,

--- a/lib/Db/EndpointLogMapper.php
+++ b/lib/Db/EndpointLogMapper.php
@@ -87,7 +87,7 @@ class EndpointLogMapper extends QBMapper {
 	 *
 	 * @return EndpointLog[]
 	 *
-	 * @psalm-return list<OCA\OpenRegister\Db\EndpointLog>
+	 * @psalm-return list<\OCA\OpenRegister\Db\EndpointLog>
 	 */
 	public function findAll(?int $limit = null, ?int $offset = null): array {
 		// Step 1: Get query builder instance.

--- a/lib/Db/EndpointMapper.php
+++ b/lib/Db/EndpointMapper.php
@@ -124,7 +124,7 @@ class EndpointMapper extends QBMapper {
 	 *
 	 * @return Endpoint[]
 	 *
-	 * @psalm-return list<OCA\OpenRegister\Db\Endpoint>
+	 * @psalm-return list<\OCA\OpenRegister\Db\Endpoint>
 	 */
 	public function findAll(?int $limit = null, ?int $offset = null): array {
 		// Step 1: Get query builder instance.

--- a/lib/Db/EntityRelationMapper.php
+++ b/lib/Db/EntityRelationMapper.php
@@ -593,7 +593,9 @@ class EntityRelationMapper extends QBMapper {
 	 * honoured (skipped rows untouched).
 	 *
 	 * @param int $fileId The file ID.
-	 * @param array<string, string> $placeholderByEntityId Map of (stringified) entity id → the
+	 * @param array<int|string, string> $placeholderByEntityId Keys are int|string,
+	 *        not string: a stringified entity id is a canonical numeric string,
+	 *        which PHP coerces to an int array key. Map of entity id → the
 	 *                                                     exact placeholder emitted for it
 	 *                                                     (e.g. "7" => "[PERSOON: 1]").
 	 *

--- a/lib/Db/FileMapper.php
+++ b/lib/Db/FileMapper.php
@@ -483,10 +483,12 @@ class FileMapper extends QBMapper {
 	 *
 	 * @param array $fileIds List of file ids (int|string) to load
 	 *
-	 * @return array<string, array> Map of (string) fileid => file record
+	 * @return array<int|string, array> Map of fileid => file record. The key type
+	 *         is int|string, not string: a stringified fileid is a canonical
+	 *         numeric string, which PHP coerces to an int array key.
 	 *
 	 * @phpstan-param  array<int, int|string> $fileIds
-	 * @phpstan-return array<string, File>
+	 * @phpstan-return array<int|string, File>
 	 */
 	public function getFilesByIds(array $fileIds): array {
 		// Normalise to unique positive integers; ignore non-numeric entries.

--- a/lib/Db/Flow.php
+++ b/lib/Db/Flow.php
@@ -86,6 +86,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setOrganisation(?string $organisation)
  * @method string|null getNotes()
  * @method void setNotes(?string $notes)
+ * @method string|null getComment()
+ * @method void setComment(?string $comment)
  * @method DateTime|null getCreated()
  * @method void setCreated(?DateTime $created)
  * @method DateTime|null getUpdated()

--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -8384,7 +8384,7 @@ class MagicMapper extends AbstractObjectMapper {
 				$columnToPropertyMap = $this->rowColumnToPropertyCache[$schemaIdForMap];
 			} else {
 				try {
-					// find() throws when the schema is missing; the catch below is
+					// The find() call throws when the schema is missing; the catch below is
 					// the "not found" path, so no null test is needed here.
 					$schema = $this->schemaMapper->find($schemaIdForMap);
 

--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -2522,7 +2522,7 @@ class MagicMapper extends AbstractObjectMapper {
 			case 'boolean':
 				// Determine default value.
 				$defaultValue = null;
-				if (is_array($propertyConfig) === true && array_key_exists('default', $propertyConfig) === true) {
+				if (array_key_exists('default', $propertyConfig) === true) {
 					$defaultValue = $propertyConfig['default'];
 				}
 
@@ -2788,7 +2788,7 @@ class MagicMapper extends AbstractObjectMapper {
 
 		// Determine default value.
 		$defaultValue = null;
-		if (is_array($propertyConfig) === true && array_key_exists('default', $propertyConfig) === true) {
+		if (array_key_exists('default', $propertyConfig) === true) {
 			$defaultValue = $propertyConfig['default'];
 		}
 
@@ -2827,7 +2827,7 @@ class MagicMapper extends AbstractObjectMapper {
 
 		// Determine default value.
 		$defaultValue = null;
-		if (is_array($propertyConfig) === true && array_key_exists('default', $propertyConfig) === true) {
+		if (array_key_exists('default', $propertyConfig) === true) {
 			$defaultValue = $propertyConfig['default'];
 		}
 

--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -2169,34 +2169,35 @@ class MagicMapper extends AbstractObjectMapper {
 				// Note: Schema properties do NOT conflict with metadata columns.
 				// Metadata columns have '_' prefix, schema properties don't.
 				// Both '_name' (metadata) and 'name' (schema property) can coexist.
+				// mapSchemaPropertyToColumn() returns a non-nullable array, so the
+				// emptiness guard that used to wrap this block was always true.
 				$column = $this->mapSchemaPropertyToColumn(propertyName: $propertyName, propertyConfig: $propertyConfig);
-				if ($column !== '') {
-					// BUG-DB-8: disambiguate column-name collisions deterministically.
-					if (isset($usedColumnNames[$column['name']]) === true) {
-						$base = $column['name'];
-						$suffix = 1;
+
+				// BUG-DB-8: disambiguate column-name collisions deterministically.
+				if (isset($usedColumnNames[$column['name']]) === true) {
+					$base = $column['name'];
+					$suffix = 1;
+					$candidate = $base . '_' . $suffix;
+					while (isset($usedColumnNames[$candidate]) === true) {
+						$suffix++;
 						$candidate = $base . '_' . $suffix;
-						while (isset($usedColumnNames[$candidate]) === true) {
-							$suffix++;
-							$candidate = $base . '_' . $suffix;
-						}
+					}
 
-						$this->logger->warning(
-							message: '[MagicMapper] Column name collision after sanitisation; disambiguating',
-							context: [
-								'file' => __FILE__,
-								'line' => __LINE__,
-								'propertyName' => $propertyName,
-								'collidingColumn' => $base,
-								'resolvedColumn' => $candidate,
-							]
-						);
-						$column['name'] = $candidate;
-					}//end if
-
-					$usedColumnNames[$column['name']] = true;
-					$columns[$propertyName] = $column;
+					$this->logger->warning(
+						message: '[MagicMapper] Column name collision after sanitisation; disambiguating',
+						context: [
+							'file' => __FILE__,
+							'line' => __LINE__,
+							'propertyName' => $propertyName,
+							'collidingColumn' => $base,
+							'resolvedColumn' => $candidate,
+						]
+					);
+					$column['name'] = $candidate;
 				}//end if
+
+				$usedColumnNames[$column['name']] = true;
+				$columns[$propertyName] = $column;
 			}//end foreach
 		}//end if
 
@@ -3657,7 +3658,7 @@ class MagicMapper extends AbstractObjectMapper {
 		// LINKED_TYPE_COLUMN_MAP values are column names with _ prefix (e.g., '_mail'),
 		// but the metadata loop adds its own prefix, so we use the linkedType key directly.
 		foreach ($schema->getLinkedTypes() as $linkedType) {
-			if (isset(self::LINKED_TYPE_COLUMN_MAP[$linkedType]) === true && $linkedType !== 'files') {
+			if (isset(self::LINKED_TYPE_COLUMN_MAP[$linkedType]) === true) {
 				$metadataFields[] = $linkedType;
 			}
 		}
@@ -3698,7 +3699,7 @@ class MagicMapper extends AbstractObjectMapper {
 			];
 			// Add active linked type fields as JSON fields.
 			foreach ($schema->getLinkedTypes() as $linkedType) {
-				if (isset(self::LINKED_TYPE_COLUMN_MAP[$linkedType]) === true && $linkedType !== 'files') {
+				if (isset(self::LINKED_TYPE_COLUMN_MAP[$linkedType]) === true) {
 					$jsonFields[] = $linkedType;
 				}
 			}
@@ -8383,21 +8384,22 @@ class MagicMapper extends AbstractObjectMapper {
 				$columnToPropertyMap = $this->rowColumnToPropertyCache[$schemaIdForMap];
 			} else {
 				try {
+					// find() throws when the schema is missing; the catch below is
+					// the "not found" path, so no null test is needed here.
 					$schema = $this->schemaMapper->find($schemaIdForMap);
-					if ($schema !== null) {
-						// BUG-DB-8: use the same disambiguated column names the write
-						// path produces (buildTableColumnsFromSchema), keyed by
-						// property name, so collision-resolved columns round-trip
-						// back to their original property instead of being lost.
-						foreach ($this->buildTableColumnsFromSchema(schema: $schema) as $propertyName => $columnDef) {
-							// Skip metadata columns (handled separately above).
-							if (str_starts_with($propertyName, '_') === true) {
-								continue;
-							}
 
-							$physicalColumn = $columnDef['name'] ?? $this->sanitizeColumnName(name: $propertyName);
-							$columnToPropertyMap[$physicalColumn] = $propertyName;
+					// BUG-DB-8: use the same disambiguated column names the write
+					// path produces (buildTableColumnsFromSchema), keyed by
+					// property name, so collision-resolved columns round-trip
+					// back to their original property instead of being lost.
+					foreach ($this->buildTableColumnsFromSchema(schema: $schema) as $propertyName => $columnDef) {
+						// Skip metadata columns (handled separately above).
+						if (str_starts_with($propertyName, '_') === true) {
+							continue;
 						}
+
+						$physicalColumn = $columnDef['name'] ?? $this->sanitizeColumnName(name: $propertyName);
+						$columnToPropertyMap[$physicalColumn] = $propertyName;
 					}
 
 					$this->rowColumnToPropertyCache[$schemaIdForMap] = $columnToPropertyMap;
@@ -9258,7 +9260,7 @@ class MagicMapper extends AbstractObjectMapper {
 					$groupRegister = $register;
 					$groupSchema = null;
 
-					if ($groupRegister === null && $groupRegisterId !== null) {
+					if ($groupRegister === null) {
 						try {
 							$groupRegister = $this->registerMapper->find(id: (int)$groupRegisterId, _multitenancy: false);
 						} catch (\Exception $e) {
@@ -9269,15 +9271,15 @@ class MagicMapper extends AbstractObjectMapper {
 						}
 					}
 
-					if ($groupSchemaId !== null) {
-						try {
-							$groupSchema = $this->schemaMapper->find(id: (int)$groupSchemaId, _multitenancy: false);
-						} catch (\Exception $e) {
-							$this->logger->warning(
-								message: '[MagicMapper] Failed to resolve schema for group',
-								context: ['file' => __FILE__, 'line' => __LINE__, 'id' => $groupSchemaId]
-							);
-						}
+					// $groupSchemaId comes from explode() on the group key, so it is
+					// always a string — the null guard here could never skip.
+					try {
+						$groupSchema = $this->schemaMapper->find(id: (int)$groupSchemaId, _multitenancy: false);
+					} catch (\Exception $e) {
+						$this->logger->warning(
+							message: '[MagicMapper] Failed to resolve schema for group',
+							context: ['file' => __FILE__, 'line' => __LINE__, 'id' => $groupSchemaId]
+						);
 					}
 
 					$groupResults = $this->ultraFastBulkSaveSingleSchema(

--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -777,7 +777,7 @@ class MagicMapper extends AbstractObjectMapper {
 					schema: $schema,
 					tableName: $tableName
 				);
-				if ($uuid !== null && $uuid !== '') {
+				if ($uuid !== '') {
 					$savedUuids[] = $uuid;
 				}
 			}
@@ -2170,7 +2170,7 @@ class MagicMapper extends AbstractObjectMapper {
 				// Metadata columns have '_' prefix, schema properties don't.
 				// Both '_name' (metadata) and 'name' (schema property) can coexist.
 				$column = $this->mapSchemaPropertyToColumn(propertyName: $propertyName, propertyConfig: $propertyConfig);
-				if ($column !== null && $column !== '') {
+				if ($column !== '') {
 					// BUG-DB-8: disambiguate column-name collisions deterministically.
 					if (isset($usedColumnNames[$column['name']]) === true) {
 						$base = $column['name'];

--- a/lib/Db/MagicMapper/MagicFacetHandler.php
+++ b/lib/Db/MagicMapper/MagicFacetHandler.php
@@ -388,7 +388,7 @@ class MagicFacetHandler {
 			}
 
 			// Add schema property title if available.
-			if (isset($config['title']) === true && $config['title'] !== null) {
+			if (isset($config['title']) === true) {
 				$facets[$field]['title'] = $config['title'];
 			}
 
@@ -512,7 +512,7 @@ class MagicFacetHandler {
 			}//end if
 
 			// Add schema property title if available.
-			if (isset($config['title']) === true && $config['title'] !== null) {
+			if (isset($config['title']) === true) {
 				$facets[$field]['title'] = $config['title'];
 			}
 

--- a/lib/Db/MagicMapper/MagicSearchHandler.php
+++ b/lib/Db/MagicMapper/MagicSearchHandler.php
@@ -727,11 +727,9 @@ class MagicSearchHandler {
 			$searchConditions[] = "similarity(_name::text, {$quotedTerm}) > 0.1";
 		}
 
-		if (empty($searchConditions) === false) {
-			return '(' . implode(' OR ', $searchConditions) . ')';
-		}
-
-		return null;
+		// Both branches above push three conditions, so $searchConditions is
+		// never empty here and the old null return was unreachable.
+		return '(' . implode(' OR ', $searchConditions) . ')';
 	}//end buildSearchConditionSql()
 
 	/**

--- a/lib/Db/MagicMapper/MagicStatisticsHandler.php
+++ b/lib/Db/MagicMapper/MagicStatisticsHandler.php
@@ -714,14 +714,14 @@ class MagicStatisticsHandler {
 
 			// CRITICAL FIX: Explicitly set ID and UUID to ensure they are never null.
 			// These are essential for audit trails, rendering, and API responses.
-			if (isset($metadata['id']) === true && $metadata['id'] !== null) {
+			if (isset($metadata['id']) === true) {
 				$idValue = $metadata['id'];
 				if (is_numeric($idValue) === true) {
 					$objectEntity->setId((int)$idValue);
 				}
 			}
 
-			if (isset($metadata['uuid']) === true && $metadata['uuid'] !== null) {
+			if (isset($metadata['uuid']) === true) {
 				$objectEntity->setUuid($metadata['uuid']);
 			}
 

--- a/lib/Db/Mapping.php
+++ b/lib/Db/Mapping.php
@@ -303,7 +303,7 @@ class Mapping extends Entity implements JsonSerializable {
 
 		// Safe fallback if empty.
 		$prefix = 'mapping';
-		if (isset($this->id) === true && (string)$this->id !== '') {
+		if ((string)$this->id !== '') {
 			return $prefix . '-' . (string)$this->id;
 		}
 

--- a/lib/Db/MappingMapper.php
+++ b/lib/Db/MappingMapper.php
@@ -152,7 +152,7 @@ class MappingMapper extends QBMapper {
 	 *
 	 * @return Mapping[]
 	 *
-	 * @psalm-return list<OCA\OpenRegister\Db\Mapping>
+	 * @psalm-return list<\OCA\OpenRegister\Db\Mapping>
 	 */
 	public function findAll(?int $limit = null, ?int $offset = null): array {
 		// Step 1: Get query builder instance.

--- a/lib/Db/MultiTenancyTrait.php
+++ b/lib/Db/MultiTenancyTrait.php
@@ -359,7 +359,7 @@ trait MultiTenancyTrait {
 	 * @return string Qualified column name
 	 */
 	private function buildQualifiedColumnName(string $columnName, string $tableAlias): string {
-		if ($tableAlias !== null && $tableAlias !== '') {
+		if ($tableAlias !== '') {
 			return $tableAlias . '.' . $columnName;
 		}
 

--- a/lib/Db/NotificationSubscriptionMapper.php
+++ b/lib/Db/NotificationSubscriptionMapper.php
@@ -147,10 +147,11 @@ class NotificationSubscriptionMapper extends QBMapper {
 			)
 			->orderBy('created', 'DESC');
 
-		/*
-		 * @var NotificationSubscription[] $rows
-		 */
-
+		// findEntities() is typed Entity[] on the parent; this mapper's generic
+		// binding narrows it to NotificationSubscription at runtime. The
+		// annotation has to be a /** */ docblock to be honoured — the /* */ one
+		// that used to sit here was inert.
+		/** @var NotificationSubscription[] $rows */
 		$rows = $this->findEntities(query: $qb);
 		return $rows;
 	}//end findByUser()

--- a/lib/Db/NotificationSubscriptionMapper.php
+++ b/lib/Db/NotificationSubscriptionMapper.php
@@ -147,10 +147,13 @@ class NotificationSubscriptionMapper extends QBMapper {
 			)
 			->orderBy('created', 'DESC');
 
-		// findEntities() is typed Entity[] on the parent; this mapper's generic
-		// binding narrows it to NotificationSubscription at runtime. The
-		// annotation has to be a /** */ docblock to be honoured — the /* */ one
-		// that used to sit here was inert.
+		// The findEntities() helper is typed Entity[] on the parent; this mapper's
+		// generic binding narrows it to NotificationSubscription at runtime. The
+		// annotation has to be a `/** */` docblock for PHPStan to honour it — the
+		// `/* */` one that used to sit here was inert — which is why the inline
+		// doc-block sniff is silenced for this single line rather than the type
+		// being left wrong.
+		// phpcs:ignore Squiz.Commenting.InlineComment.DocBlock -- PHPStan only reads @var from a /** */ block.
 		/** @var NotificationSubscription[] $rows */
 		$rows = $this->findEntities(query: $qb);
 		return $rows;

--- a/lib/Db/RegisterMapper.php
+++ b/lib/Db/RegisterMapper.php
@@ -719,9 +719,12 @@ class RegisterMapper extends QBMapper {
 		// Capture: major.minor.patch followed by an optional -prerelease/+build suffix.
 		if (preg_match('/^(\d+)(?:\.(\d+))?(?:\.(\d+))?(.*)$/', trim($version), $matches) === 1) {
 			$major = (int)$matches[1];
-			$minor = (int)($matches[2] ?? 0);
-			$patch = (int)($matches[3] ?? 0);
-			$suffix = $matches[4] ?? '';
+			// Groups 2-4 are always present: the trailing `(.*)` always matches,
+			// so PHP fills the earlier optional groups with '' rather than
+			// omitting them. (int)'' is 0, so the old `?? 0` was a no-op.
+			$minor = (int)$matches[2];
+			$patch = (int)$matches[3];
+			$suffix = $matches[4];
 
 			return $major . '.' . $minor . '.' . ($patch + 1) . $suffix;
 		}

--- a/lib/Db/Schema.php
+++ b/lib/Db/Schema.php
@@ -2845,7 +2845,7 @@ class Schema extends Entity implements JsonSerializable {
 			// Determine appropriate facet type based on property configuration.
 			$facetType = $this->determineFacetType(property: $property);
 
-			// determineFacetType() is declared `: string`, so there is no null
+			// The determineFacetType() helper is declared `: string`, so there is no null
 			// case to guard against.
 			$facetConfig['object_fields'][$propertyKey] = [
 				'type' => $facetType,

--- a/lib/Db/Schema.php
+++ b/lib/Db/Schema.php
@@ -2176,6 +2176,9 @@ class Schema extends Entity implements JsonSerializable {
 	 * @param array<int, string> $boolFields Bool-typed config fields.
 	 * @param array<int, string> $passThrough Keys stored without validation.
 	 * @param array<string, mixed> $validatedConfig Accumulator, passed by reference.
+	 * @param-out array<int|string, mixed> $validatedConfig A config key that is a canonical
+	 *         numeric string ("12") gets an INT key from PHP's array-key coercion, so the
+	 *         accumulator that comes back out is not key-narrowable to string.
 	 *
 	 * @throws \InvalidArgumentException If the value is invalid for the key.
 	 *

--- a/lib/Db/Schema.php
+++ b/lib/Db/Schema.php
@@ -1738,24 +1738,24 @@ class Schema extends Entity implements JsonSerializable {
 				$nestedProperty->title = $property['title'];
 				$nestedProperty->required = [];
 
-				if (($property['properties'] ?? null) !== null) {
-					foreach ($property['properties'] as $subName => $subProperty) {
-						$isRequired = (($subProperty['required'] ?? null) !== null);
-						if ($isRequired === true && ($subProperty['required'] === true) === true) {
-							$nestedProperty->required[] = $subName;
-						}
-
-						$nestedProp = new stdClass();
-						foreach ($subProperty as $key => $value) {
-							if ($key === 'oneOf' && empty($value) === true) {
-								continue;
-							}
-
-							$nestedProp->{$key} = $value;
-						}
-
-						$nestedProperties->{$subName} = $nestedProp;
+				// No null guard on $property['properties']: this arm is only
+				// entered for a nested object, which always carries one.
+				foreach ($property['properties'] as $subName => $subProperty) {
+					$isRequired = (($subProperty['required'] ?? null) !== null);
+					if ($isRequired === true && ($subProperty['required'] === true) === true) {
+						$nestedProperty->required[] = $subName;
 					}
+
+					$nestedProp = new stdClass();
+					foreach ($subProperty as $key => $value) {
+						if ($key === 'oneOf' && empty($value) === true) {
+							continue;
+						}
+
+						$nestedProp->{$key} = $value;
+					}
+
+					$nestedProperties->{$subName} = $nestedProp;
 				}
 
 				$nestedProperty->properties = $nestedProperties;
@@ -2845,24 +2845,24 @@ class Schema extends Entity implements JsonSerializable {
 			// Determine appropriate facet type based on property configuration.
 			$facetType = $this->determineFacetType(property: $property);
 
-			if ($facetType !== null) {
-				$facetConfig['object_fields'][$propertyKey] = [
-					'type' => $facetType,
-					'title' => $property['title'] ?? $propertyKey,
-					'description' => $property['description'] ?? null,
-					'data_type' => $property['type'] ?? 'string',
-					'queryParameter' => $propertyKey,
-				];
+			// determineFacetType() is declared `: string`, so there is no null
+			// case to guard against.
+			$facetConfig['object_fields'][$propertyKey] = [
+				'type' => $facetType,
+				'title' => $property['title'] ?? $propertyKey,
+				'description' => $property['description'] ?? null,
+				'data_type' => $property['type'] ?? 'string',
+				'queryParameter' => $propertyKey,
+			];
 
-				// Add type-specific configuration.
-				if ($facetType === 'date_histogram') {
-					$facetConfig['object_fields'][$propertyKey]['default_interval'] = 'month';
-					$facetConfig['object_fields'][$propertyKey]['supported_intervals'] = ['day', 'week', 'month', 'year'];
-				} elseif ($facetType === 'range') {
-					$facetConfig['object_fields'][$propertyKey]['supports_custom_ranges'] = true;
-				} elseif ($facetType === 'terms' && (($property['enum'] ?? null) !== null)) {
-					$facetConfig['object_fields'][$propertyKey]['predefined_values'] = $property['enum'];
-				}
+			// Add type-specific configuration.
+			if ($facetType === 'date_histogram') {
+				$facetConfig['object_fields'][$propertyKey]['default_interval'] = 'month';
+				$facetConfig['object_fields'][$propertyKey]['supported_intervals'] = ['day', 'week', 'month', 'year'];
+			} elseif ($facetType === 'range') {
+				$facetConfig['object_fields'][$propertyKey]['supports_custom_ranges'] = true;
+			} elseif ($facetType === 'terms' && (($property['enum'] ?? null) !== null)) {
+				$facetConfig['object_fields'][$propertyKey]['predefined_values'] = $property['enum'];
 			}
 		}//end foreach
 

--- a/lib/Db/SchemaMapper.php
+++ b/lib/Db/SchemaMapper.php
@@ -1583,7 +1583,8 @@ class SchemaMapper extends QBMapper {
 		if (strpos($fieldValue, '{{') !== false && strpos($fieldValue, '}}') !== false) {
 			// Extract property names from template: {{ propName }}.
 			preg_match_all('/\{\{\s*([a-zA-Z0-9_-]+)\s*\}\}/', $fieldValue, $matches);
-			$templateProps = $matches[1] ?? [];
+			// preg_match_all always populates group 1, so no `?? []` fallback.
+			$templateProps = $matches[1];
 
 			if (empty($templateProps) === true) {
 				// Template syntax but no valid property references found.

--- a/lib/Db/SchemaMapper.php
+++ b/lib/Db/SchemaMapper.php
@@ -1761,7 +1761,13 @@ class SchemaMapper extends QBMapper {
 				} elseif (is_object($property['$ref']) === true && (($property['$ref']->id ?? null) !== null)) {
 					$property['$ref'] = $property['$ref']->id;
 				} elseif (is_int($property['$ref']) === true) {
-				} elseif (is_string($property['$ref']) === false && $property['$ref'] !== '') {
+					// The `!== ''` clause that used to sit here was dead: `is_string()
+					// === false` has already excluded every string, so an empty-string
+					// $ref never reaches this branch and is NOT rejected today, despite
+					// what the message below says. Left as-is deliberately — tightening
+					// it would reject schemas that currently import, so it belongs in a
+					// behaviour change, not a lint migration.
+				} elseif (is_string($property['$ref']) === false) {
 					$refValue = json_encode($property['$ref']);
 					$msg = "Schema property '$key' has a \$ref that is not a string or empty: " . $refValue;
 					throw new Exception($msg);

--- a/lib/Db/SchemaMapper.php
+++ b/lib/Db/SchemaMapper.php
@@ -1583,7 +1583,7 @@ class SchemaMapper extends QBMapper {
 		if (strpos($fieldValue, '{{') !== false && strpos($fieldValue, '}}') !== false) {
 			// Extract property names from template: {{ propName }}.
 			preg_match_all('/\{\{\s*([a-zA-Z0-9_-]+)\s*\}\}/', $fieldValue, $matches);
-			// preg_match_all always populates group 1, so no `?? []` fallback.
+			// Group 1 is always populated by preg_match_all, so no `?? []` fallback.
 			$templateProps = $matches[1];
 
 			if (empty($templateProps) === true) {

--- a/lib/Db/TranslationMapper.php
+++ b/lib/Db/TranslationMapper.php
@@ -306,7 +306,9 @@ class TranslationMapper extends QBMapper {
 	 * register. Used by the
 	 * `openregister:translations:backfill-source-language` console command.
 	 *
-	 * @param array<string, string> $registerDefaults Map of `register_id => default_language`.
+	 * @param array<int|string, string> $registerDefaults Map of `register_id =>
+	 *        default_language`. Keys are int|string, not string: register ids are
+	 *        canonical numeric strings, which PHP coerces to int array keys.
 	 * @param int $batchSize Maximum rows updated per pass.
 	 *
 	 * @return int Number of rows updated across all batches.

--- a/lib/Db/WebhookLogMapper.php
+++ b/lib/Db/WebhookLogMapper.php
@@ -114,7 +114,7 @@ class WebhookLogMapper extends QBMapper {
 	 *
 	 * @return WebhookLog[]
 	 *
-	 * @psalm-return list<OCA\OpenRegister\Db\WebhookLog>
+	 * @psalm-return list<\OCA\OpenRegister\Db\WebhookLog>
 	 */
 	public function findAll(?int $limit = null, ?int $offset = null): array {
 		$qb = $this->db->getQueryBuilder();

--- a/lib/Db/WebhookMapper.php
+++ b/lib/Db/WebhookMapper.php
@@ -164,7 +164,7 @@ class WebhookMapper extends QBMapper {
 	 *
 	 * @return Webhook[]
 	 *
-	 * @psalm-return list<OCA\OpenRegister\Db\Webhook>
+	 * @psalm-return list<\OCA\OpenRegister\Db\Webhook>
 	 */
 	public function findAll(?int $limit = null, ?int $offset = null, ?array $filters = []): array {
 		// Check if table exists before querying (migrations might not have run yet).

--- a/lib/Listener/ActionListener.php
+++ b/lib/Listener/ActionListener.php
@@ -70,7 +70,7 @@ class ActionListener implements IEventListener {
 	 */
 	public function handle(Event $event): void {
 		// Respect propagation stop from inline hooks or previous listeners.
-		if (method_exists($event, 'isPropagationStopped') === true && $event->isPropagationStopped() === true) {
+		if ($event->isPropagationStopped() === true) {
 			$this->logger->debug(
 				message: '[ActionListener] Propagation already stopped, skipping action execution'
 			);

--- a/lib/Listener/ApprovalChainAdvanceListener.php
+++ b/lib/Listener/ApprovalChainAdvanceListener.php
@@ -84,10 +84,8 @@ class ApprovalChainAdvanceListener implements IEventListener {
 			return;
 		}
 
-		if (($schema instanceof Schema) === false) {
-			return;
-		}
-
+		// No instanceof re-check: the lookup above is declared to return Schema
+		// and throws otherwise, which the catch already handles.
 		$config = ($schema->getConfiguration() ?? []);
 		$chains = ($config['x-openregister-approval-chains'] ?? null);
 		if (is_array($chains) === false) {

--- a/lib/Listener/LifecycleInitialStateListener.php
+++ b/lib/Listener/LifecycleInitialStateListener.php
@@ -125,7 +125,7 @@ class LifecycleInitialStateListener implements IEventListener {
 		// Caller already set a value — leave it alone (validator covers it).
 		// Resolve the (possibly dynamic) initial value only AFTER this guard so
 		// we never read a related object when the caller already chose.
-		if (isset($data[$field]) === true && $data[$field] !== null && $data[$field] !== '') {
+		if (isset($data[$field]) === true && $data[$field] !== '') {
 			return;
 		}
 

--- a/lib/Listener/MailAppScriptListener.php
+++ b/lib/Listener/MailAppScriptListener.php
@@ -83,11 +83,9 @@ class MailAppScriptListener implements IEventListener {
 			return;
 		}
 
+		// getResponse() is declared to return TemplateResponse, so the
+		// instanceof bail-out that used to sit here was unreachable.
 		$response = $event->getResponse();
-		if ($response instanceof TemplateResponse === false) {
-			return;
-		}
-
 		if ($response->getApp() !== 'mail') {
 			return;
 		}

--- a/lib/Listener/MailAppScriptListener.php
+++ b/lib/Listener/MailAppScriptListener.php
@@ -83,7 +83,7 @@ class MailAppScriptListener implements IEventListener {
 			return;
 		}
 
-		// getResponse() is declared to return TemplateResponse, so the
+		// The getResponse() accessor is declared to return TemplateResponse, so the
 		// instanceof bail-out that used to sit here was unreachable.
 		$response = $event->getResponse();
 		if ($response->getApp() !== 'mail') {

--- a/lib/Listener/NotificationDedupeAnnotationSyncListener.php
+++ b/lib/Listener/NotificationDedupeAnnotationSyncListener.php
@@ -105,21 +105,14 @@ final class NotificationDedupeAnnotationSyncListener implements IEventListener {
 	 */
 	private function resolveSchema(Event $event): ?Schema {
 		if ($event instanceof SchemaCreatedEvent) {
-			$schema = $event->getSchema();
-			if ($schema instanceof Schema) {
-				return $schema;
-			}
-
-			return null;
+			// getSchema() is declared to return Schema, so the instanceof
+			// re-check and its null fallback were both unreachable.
+			return $event->getSchema();
 		}
 
 		if ($event instanceof SchemaUpdatedEvent) {
-			$schema = $event->getNewSchema();
-			if ($schema instanceof Schema) {
-				return $schema;
-			}
-
-			return null;
+			// getNewSchema() is declared to return Schema; see above.
+			return $event->getNewSchema();
 		}
 
 		return null;

--- a/lib/Listener/NotificationDedupeAnnotationSyncListener.php
+++ b/lib/Listener/NotificationDedupeAnnotationSyncListener.php
@@ -105,13 +105,13 @@ final class NotificationDedupeAnnotationSyncListener implements IEventListener {
 	 */
 	private function resolveSchema(Event $event): ?Schema {
 		if ($event instanceof SchemaCreatedEvent) {
-			// getSchema() is declared to return Schema, so the instanceof
+			// The getSchema() accessor is declared to return Schema, so the instanceof
 			// re-check and its null fallback were both unreachable.
 			return $event->getSchema();
 		}
 
 		if ($event instanceof SchemaUpdatedEvent) {
-			// getNewSchema() is declared to return Schema; see above.
+			// The getNewSchema() accessor is declared to return Schema; see above.
 			return $event->getNewSchema();
 		}
 

--- a/lib/Listener/SystemEntityNotificationListener.php
+++ b/lib/Listener/SystemEntityNotificationListener.php
@@ -149,10 +149,10 @@ class SystemEntityNotificationListener implements IEventListener {
 
 		if ($event instanceof RegisterUpdatedEvent) {
 			$old = $event->getOldRegister();
-			$oldData = null;
-			if ($old instanceof \JsonSerializable) {
-				$oldData = $old->jsonSerialize();
-			}
+			// Every Db entity extends OCP Entity, which implements
+			// JsonSerializable, so the instanceof guard that used to wrap this
+			// was always true and the null default unreachable.
+			$oldData = $old->jsonSerialize();
 
 			return [$event->getNewRegister(), SystemSchemaRules::SLUG_REGISTER, 'updated', $oldData];
 		}
@@ -163,10 +163,10 @@ class SystemEntityNotificationListener implements IEventListener {
 
 		if ($event instanceof SchemaUpdatedEvent) {
 			$old = $event->getOldSchema();
-			$oldData = null;
-			if ($old instanceof \JsonSerializable) {
-				$oldData = $old->jsonSerialize();
-			}
+			// Every Db entity extends OCP Entity, which implements
+			// JsonSerializable, so the instanceof guard that used to wrap this
+			// was always true and the null default unreachable.
+			$oldData = $old->jsonSerialize();
 
 			return [$event->getNewSchema(), SystemSchemaRules::SLUG_SCHEMA, 'updated', $oldData];
 		}
@@ -177,10 +177,10 @@ class SystemEntityNotificationListener implements IEventListener {
 
 		if ($event instanceof ConfigurationUpdatedEvent) {
 			$old = $event->getOldConfiguration();
-			$oldData = null;
-			if ($old instanceof \JsonSerializable) {
-				$oldData = $old->jsonSerialize();
-			}
+			// Every Db entity extends OCP Entity, which implements
+			// JsonSerializable, so the instanceof guard that used to wrap this
+			// was always true and the null default unreachable.
+			$oldData = $old->jsonSerialize();
 
 			return [$event->getNewConfiguration(), SystemSchemaRules::SLUG_CONFIGURATION, 'updated', $oldData];
 		}
@@ -191,10 +191,10 @@ class SystemEntityNotificationListener implements IEventListener {
 
 		if ($event instanceof SourceUpdatedEvent) {
 			$old = $event->getOldSource();
-			$oldData = null;
-			if ($old instanceof \JsonSerializable) {
-				$oldData = $old->jsonSerialize();
-			}
+			// Every Db entity extends OCP Entity, which implements
+			// JsonSerializable, so the instanceof guard that used to wrap this
+			// was always true and the null default unreachable.
+			$oldData = $old->jsonSerialize();
 
 			return [$event->getNewSource(), SystemSchemaRules::SLUG_SOURCE, 'updated', $oldData];
 		}
@@ -205,10 +205,10 @@ class SystemEntityNotificationListener implements IEventListener {
 
 		if ($event instanceof AgentUpdatedEvent) {
 			$old = $event->getOldAgent();
-			$oldData = null;
-			if ($old instanceof \JsonSerializable) {
-				$oldData = $old->jsonSerialize();
-			}
+			// Every Db entity extends OCP Entity, which implements
+			// JsonSerializable, so the instanceof guard that used to wrap this
+			// was always true and the null default unreachable.
+			$oldData = $old->jsonSerialize();
 
 			return [$event->getNewAgent(), SystemSchemaRules::SLUG_AGENT, 'updated', $oldData];
 		}

--- a/lib/Listener/SystemEntityNotificationListener.php
+++ b/lib/Listener/SystemEntityNotificationListener.php
@@ -112,7 +112,7 @@ class SystemEntityNotificationListener implements IEventListener {
 				$newData = $entity->jsonSerialize();
 			}
 
-			if (is_array($newData) === true && is_array($oldData) === true) {
+			if (is_array($newData) === true) {
 				$context['_newData'] = $newData;
 				$context['_oldData'] = $oldData;
 			}

--- a/lib/Middleware/LanguageMiddleware.php
+++ b/lib/Middleware/LanguageMiddleware.php
@@ -108,7 +108,7 @@ class LanguageMiddleware extends Middleware {
 
 		// 2. Accept-Language header is the next priority.
 		$acceptLanguage = $this->request->getHeader('Accept-Language');
-		if ($acceptLanguage !== '' && $acceptLanguage !== null) {
+		if ($acceptLanguage !== '') {
 			$acceptedLanguages = LanguageService::parseAcceptLanguageHeader($acceptLanguage);
 			$this->languageService->setAcceptedLanguages($acceptedLanguages);
 
@@ -129,7 +129,7 @@ class LanguageMiddleware extends Middleware {
 		$method = strtoupper((string)$this->request->getMethod());
 		if (in_array($method, ['POST', 'PUT', 'PATCH'], true) === true) {
 			$targetHeader = $this->request->getHeader('X-Translation-Target-Language');
-			if ($targetHeader !== '' && $targetHeader !== null) {
+			if ($targetHeader !== '') {
 				$targetTrim = trim($targetHeader);
 				if (preg_match(self::BCP47_PATTERN, $targetTrim) === 1) {
 					$this->languageService->setTargetLanguage($targetTrim);

--- a/lib/Service/ActionExecutor.php
+++ b/lib/Service/ActionExecutor.php
@@ -88,7 +88,7 @@ class ActionExecutor {
 	public function executeActions(array $actions, Event $event, array $payload, string $eventType): void {
 		foreach ($actions as $action) {
 			// Check if propagation was stopped by a previous action or inline hook.
-			if (method_exists($event, 'isPropagationStopped') === true && $event->isPropagationStopped() === true) {
+			if ($event->isPropagationStopped() === true) {
 				$this->logger->debug(
 					message: '[ActionExecutor] Propagation stopped, skipping remaining actions',
 					context: ['skippedAction' => $action->getName()]
@@ -251,10 +251,10 @@ class ActionExecutor {
 				context: ['actionName' => $action->getName()]
 			);
 
-			// Stop propagation for pre-mutation events.
-			if (method_exists($event, 'stopPropagation') === true) {
-				$event->stopPropagation();
-			}
+			// Stop propagation for pre-mutation events. OCP\EventDispatcher\Event
+			// declares stopPropagation(), so no method_exists() probe is needed —
+			// unlike setErrors() below, which is not on the base class.
+			$event->stopPropagation();
 
 			if (method_exists($event, 'setErrors') === true) {
 				$event->setErrors($result->getErrors());

--- a/lib/Service/ApprovalService.php
+++ b/lib/Service/ApprovalService.php
@@ -380,10 +380,8 @@ class ApprovalService {
 			return false;
 		}
 
-		if (($schema instanceof Schema) === false) {
-			return false;
-		}
-
+		// No instanceof re-check: the lookup above is declared to return Schema
+		// and throws otherwise, which the catch already handles.
 		$config = ($schema->getConfiguration() ?? []);
 		$chains = ($config['x-openregister-approval-chains'] ?? null);
 		if (is_array($chains) === false) {

--- a/lib/Service/CalendarLinkService.php
+++ b/lib/Service/CalendarLinkService.php
@@ -383,7 +383,7 @@ class CalendarLinkService {
 			// Already present from link-table; mark as both and refresh free-text fields.
 			$merged[$key]['source'] = 'both';
 			foreach (['summary', 'dtstart', 'dtend', 'location', 'description', 'attendees', 'status'] as $field) {
-				if (isset($event[$field]) === true && $event[$field] !== null && $event[$field] !== '') {
+				if (isset($event[$field]) === true && $event[$field] !== '') {
 					$merged[$key][$field] = $event[$field];
 				}
 			}

--- a/lib/Service/Chat/ContextRetrievalHandler.php
+++ b/lib/Service/Chat/ContextRetrievalHandler.php
@@ -245,11 +245,9 @@ class ContextRetrievalHandler {
 				$results = [];
 			}
 
-			// Determine raw results count for logging.
-			$rawResultsCount = gettype($results);
-			if (is_array($results) === true) {
-				$rawResultsCount = count($results);
-			}
+			// Determine raw results count for logging. $results is always an
+			// array here, so the old gettype() fallback was unreachable.
+			$rawResultsCount = count($results);
 
 			// Filter and build context - track file and object counts separately.
 			$fileSourceCount = 0;

--- a/lib/Service/Chat/ResponseGenerationHandler.php
+++ b/lib/Service/Chat/ResponseGenerationHandler.php
@@ -581,7 +581,6 @@ class ResponseGenerationHandler {
 
 		if ($channel !== null
 			&& $ollamaWithTools === false
-			&& method_exists($chat, 'generateStreamOfText') === true
 		) {
 			try {
 				return $this->streamChat(chat: $chat, messageHistory: $messageHistory, channel: $channel);

--- a/lib/Service/Configuration/ExportHandler.php
+++ b/lib/Service/Configuration/ExportHandler.php
@@ -371,7 +371,7 @@ class ExportHandler {
 		}//end foreach
 
 		// Export mappings associated with this configuration.
-		if (isset($configuration) === true && $configuration instanceof Configuration) {
+		if (isset($configuration) === true) {
 			$mappingIds = $configuration->getMappings() ?? [];
 			foreach ($mappingIds as $mappingId) {
 				try {

--- a/lib/Service/Configuration/GitHubHandler.php
+++ b/lib/Service/Configuration/GitHubHandler.php
@@ -1763,10 +1763,9 @@ class GitHubHandler {
 			return 0;
 		}
 
-		// The class is confirmed by the is_a() check above, so getResponse() is safe.
-		if (method_exists($exception, 'getResponse') === false) {
-			return 0;
-		}
+		// The class is confirmed by the is_a() check above, so getResponse() is
+		// safe — the method_exists() bail-out that used to sit here could never
+		// be reached.
 
 		// BadResponseException always carries a response (it is required by its constructor),
 		// so getResponse() is non-null here.

--- a/lib/Service/Configuration/GitHubHandler.php
+++ b/lib/Service/Configuration/GitHubHandler.php
@@ -1555,7 +1555,7 @@ class GitHubHandler {
 	 *
 	 * @spec openspec/changes/add-features-roadmap-menu/tasks.md#task-2
 	 */
-	private function resolveCreateIssueToken(string $userId, ?bool &$useServerPat): string {
+	private function resolveCreateIssueToken(string $userId, bool &$useServerPat): string {
 		$userToken = $this->getUserToken(userId: $userId) ?? '';
 		$useServerPat = $userToken === '';
 		if ($useServerPat === false) {

--- a/lib/Service/Configuration/GitHubHandler.php
+++ b/lib/Service/Configuration/GitHubHandler.php
@@ -993,7 +993,9 @@ class GitHubHandler {
 						'file' => __FILE__,
 						'line' => __LINE__,
 						'status_code' => $statusCode,
-						'has_token' => (empty($token) === false),
+						// Always true: $token is a non-empty-string by this point, so
+						// the only way into this branch is the 401.
+						'has_token' => true,
 					]
 				);
 				return [];

--- a/lib/Service/Configuration/ImportHandler.php
+++ b/lib/Service/Configuration/ImportHandler.php
@@ -2573,11 +2573,11 @@ class ImportHandler {
 						version: $version,
 						force: $force
 					);
-					if ($register !== null) {
-						// Store register in map by slug for reference.
-						$this->registersMap[$slug] = $register;
-						$result['registers'][] = $register;
-					}
+					// Store register in map by slug for reference. The import call
+					// above is declared non-nullable and throws on failure, which
+					// the catch below handles.
+					$this->registersMap[$slug] = $register;
+					$result['registers'][] = $register;
 				} catch (\Throwable $e) {
 					$result['skipped']['registers']++;
 					$this->logger->warning(

--- a/lib/Service/Configuration/ImportHandler.php
+++ b/lib/Service/Configuration/ImportHandler.php
@@ -4306,7 +4306,7 @@ class ImportHandler {
 		// circuits when the table already exists (see MagicTableHandler
 		// line 109-112). The seed-objects loop further down still calls
 		// the same method as a defensive no-op.
-		if ($this->magicMapper !== null && $register !== null) {
+		if ($this->magicMapper !== null) {
 			foreach ($schemas as $schema) {
 				if ($schema instanceof Schema === false) {
 					continue;

--- a/lib/Service/Configuration/ImportHandler.php
+++ b/lib/Service/Configuration/ImportHandler.php
@@ -3409,10 +3409,11 @@ class ImportHandler {
 	 * @param array<int, array<string, mixed>> $workflows Workflow entries from import JSON
 	 * @param array<string, mixed> $result Current import result array
 	 * @param array<string, DeployedWorkflow> $deployedWorkflows Map populated by reference
+	 * @param string $importSource Import source identifier
+	 *
 	 * @param-out array<int|string, DeployedWorkflow> $deployedWorkflows A workflow named
 	 *         with a canonical numeric string ("12") gets an INT key from PHP's array-key
 	 *         coercion, so the map that comes back out is not key-narrowable to string.
-	 * @param string $importSource Import source identifier
 	 *
 	 * @return array<string, mixed> Updated result array
 	 *

--- a/lib/Service/Configuration/ImportHandler.php
+++ b/lib/Service/Configuration/ImportHandler.php
@@ -3409,6 +3409,9 @@ class ImportHandler {
 	 * @param array<int, array<string, mixed>> $workflows Workflow entries from import JSON
 	 * @param array<string, mixed> $result Current import result array
 	 * @param array<string, DeployedWorkflow> $deployedWorkflows Map populated by reference
+	 * @param-out array<int|string, DeployedWorkflow> $deployedWorkflows A workflow named
+	 *         with a canonical numeric string ("12") gets an INT key from PHP's array-key
+	 *         coercion, so the map that comes back out is not key-narrowable to string.
 	 * @param string $importSource Import source identifier
 	 *
 	 * @return array<string, mixed> Updated result array

--- a/lib/Service/CospendLinkService.php
+++ b/lib/Service/CospendLinkService.php
@@ -495,7 +495,7 @@ class CospendLinkService {
 			if ($projectId !== '') {
 				$billId = ($row['billId'] ?? '');
 				$billPath = '';
-				if ($billId !== '' && $billId !== null) {
+				if ($billId !== '') {
 					$billPath = '/b/' . rawurlencode((string)$billId);
 				}
 

--- a/lib/Service/Dbal/DbalConnectionFactory.php
+++ b/lib/Service/Dbal/DbalConnectionFactory.php
@@ -219,7 +219,7 @@ class DbalConnectionFactory {
 			'user' => (string)($config['user'] ?? ''),
 		];
 
-		if (isset($config['port']) === true && $config['port'] !== null && $config['port'] !== '') {
+		if (isset($config['port']) === true && $config['port'] !== '') {
 			$params['port'] = (int)$config['port'];
 		}
 

--- a/lib/Service/DeepLinkRegistryService.php
+++ b/lib/Service/DeepLinkRegistryService.php
@@ -57,19 +57,12 @@ class DeepLinkRegistryService {
 	 */
 	private static array $registrations = [];
 
-	/**
-	 * Cached slug→ID map for registers. Null means not yet loaded.
-	 *
-	 * @var array<string, int>|null
+	/*
+	 * There are no $registerSlugMap / $schemaSlugMap properties: the forward
+	 * slug→ID direction was declared and reset but never populated or read, so
+	 * both were permanently null. Only the reverse ID→slug maps below are used
+	 * (by ensureIdMaps() and resolveDeepLink()).
 	 */
-	private static ?array $registerSlugMap = null;
-
-	/**
-	 * Cached slug→ID map for schemas. Null means not yet loaded.
-	 *
-	 * @var array<string, int>|null
-	 */
-	private static ?array $schemaSlugMap = null;
 
 	/**
 	 * Cached reverse map: ID→slug for registers.
@@ -361,8 +354,6 @@ class DeepLinkRegistryService {
 	 */
 	public static function reset(): void {
 		self::$registrations = [];
-		self::$registerSlugMap = null;
-		self::$schemaSlugMap = null;
 		self::$registerIdMap = null;
 		self::$schemaIdMap = null;
 	}//end reset()

--- a/lib/Service/EmailLinkService.php
+++ b/lib/Service/EmailLinkService.php
@@ -631,7 +631,7 @@ class EmailLinkService {
 		foreach ($rows as $row) {
 			$id = (int)($row['id'] ?? 0);
 			$sentAt = null;
-			if (isset($row['sent_at']) === true && $row['sent_at'] !== null) {
+			if (isset($row['sent_at']) === true) {
 				$sentAt = date('c', (int)$row['sent_at']);
 			}
 
@@ -793,7 +793,7 @@ class EmailLinkService {
 		}
 
 		$sentAt = null;
-		if (isset($row['sent_at']) === true && $row['sent_at'] !== null) {
+		if (isset($row['sent_at']) === true) {
 			$sentAt = date('c', (int)$row['sent_at']);
 		}
 

--- a/lib/Service/EmailService.php
+++ b/lib/Service/EmailService.php
@@ -208,7 +208,7 @@ class EmailService {
 		$link->setLinkedBy($user->getUID());
 		$link->setLinkedAt(new DateTime());
 
-		if (isset($messageData['date']) === true && $messageData['date'] !== null) {
+		if (isset($messageData['date']) === true) {
 			$link->setMailDate(new DateTime($messageData['date']));
 		}
 
@@ -408,7 +408,7 @@ class EmailService {
 			}
 
 			$sentAt = null;
-			if (isset($row['sent_at']) === true && $row['sent_at'] !== null) {
+			if (isset($row['sent_at']) === true) {
 				$sentAt = date('c', (int)$row['sent_at']);
 			}
 

--- a/lib/Service/File/DocumentProcessingHandler.php
+++ b/lib/Service/File/DocumentProcessingHandler.php
@@ -373,11 +373,10 @@ class DocumentProcessingHandler {
 		// Resolve the source file id once — the substitution placeholder
 		// format and the post-redaction audit flag both key off it.
 		$fileId = 0;
-		if (method_exists($node, 'getId') === true) {
-			$candidate = $node->getId();
-			if (is_int($candidate) === true && $candidate > 0) {
-				$fileId = $candidate;
-			}
+		// OCP\Files\Node declares getId(): int, so no method_exists() probe.
+		$candidate = $node->getId();
+		if ($candidate > 0) {
+			$fileId = $candidate;
 		}
 
 		// Defensive filter — per the `entity-relation-grondslagen` change,

--- a/lib/Service/File/DocumentProcessingHandler.php
+++ b/lib/Service/File/DocumentProcessingHandler.php
@@ -142,7 +142,10 @@ class DocumentProcessingHandler {
 	 * `[<TYPE>: <entity_id>]` from the global id. Empty when the last run
 	 * matched no catalogue entity.
 	 *
-	 * @var array<string, string>
+	 * Keys are int|string, not string: entity ids are canonical numeric strings,
+	 * which PHP coerces to int array keys.
+	 *
+	 * @var array<int|string, string>
 	 */
 	private array $lastPlaceholderMap = [];
 

--- a/lib/Service/File/DocumentProcessingHandler.php
+++ b/lib/Service/File/DocumentProcessingHandler.php
@@ -1147,7 +1147,7 @@ class DocumentProcessingHandler {
 			return $newFile;
 		} catch (Exception $e) {
 			// Clean up temp file if it exists.
-			if (isset($tempFile) === true && file_exists($tempFile) === true) {
+			if (file_exists($tempFile) === true) {
 				unlink($tempFile);
 			}
 

--- a/lib/Service/File/ReadFileHandler.php
+++ b/lib/Service/File/ReadFileHandler.php
@@ -138,7 +138,7 @@ class ReadFileHandler {
 		$folder = $this->folderMgmtHandler->getObjectFolder($object);
 
 		// If $file is an integer or a string that is an integer, treat as file ID.
-		if (is_int($file) === true || (is_string($file) === true && ctype_digit($file) === true) === true) {
+		if (is_int($file) === true || ctype_digit($file) === true) {
 			// Try to get the file by ID.
 			try {
 				$nodes = $folder->getById((int)$file);

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -1534,8 +1534,9 @@ class FileService {
 		);
 
 		// Return sorted array of tag names.
+		// sort() already reindexes to a list, so no array_values().
 		sort($tagNames);
-		return array_values($tagNames);
+		return $tagNames;
 	}//end getAllTags()
 
 	/**

--- a/lib/Service/GraphQL/QueryComplexityAnalyzer.php
+++ b/lib/Service/GraphQL/QueryComplexityAnalyzer.php
@@ -200,15 +200,14 @@ class QueryComplexityAnalyzer {
 					$totalCost += ($childResult['cost'] * $multiplier);
 				}
 			} elseif ($selection instanceof InlineFragmentNode) {
-				if ($selection->selectionSet !== null) {
-					$result = $this->analyzeSelectionSet(
-						selectionSet: $selection->selectionSet,
-						currentDepth: $currentDepth,
-						variables: $variables
-					);
-					$maxDepth = max($maxDepth, $result['depth']);
-					$totalCost += $result['cost'];
-				}
+				// InlineFragmentNode::$selectionSet is non-nullable.
+				$result = $this->analyzeSelectionSet(
+					selectionSet: $selection->selectionSet,
+					currentDepth: $currentDepth,
+					variables: $variables
+				);
+				$maxDepth = max($maxDepth, $result['depth']);
+				$totalCost += $result['cost'];
 			}//end if
 		}//end foreach
 

--- a/lib/Service/GraphQL/SchemaGenerator.php
+++ b/lib/Service/GraphQL/SchemaGenerator.php
@@ -515,11 +515,12 @@ class SchemaGenerator {
 			// to append to, and a property with no description must NOT come
 			// out as ". Requires ...".
 			if (isset($authInfo[$name]) === true) {
-				if ($description === null) {
-					$description = $authInfo[$name];
-				} else {
-					$description = $description . '. ' . $authInfo[$name];
+				$prefix = '';
+				if ($description !== null) {
+					$prefix = $description . '. ';
 				}
+
+				$description = $prefix . $authInfo[$name];
 			}
 
 			$fields[$fieldName] = [

--- a/lib/Service/GraphQL/SchemaGenerator.php
+++ b/lib/Service/GraphQL/SchemaGenerator.php
@@ -510,7 +510,7 @@ class SchemaGenerator {
 			}
 
 			// Annotate authorization requirements in description.
-			if (isset($authInfo[$name]) === true && $description !== null && $description !== '') {
+			if (isset($authInfo[$name]) === true && $description !== '') {
 				$description = $description . '. ' . $authInfo[$name];
 			} elseif (isset($authInfo[$name]) === true) {
 				$description = $authInfo[$name];

--- a/lib/Service/GraphQL/SchemaGenerator.php
+++ b/lib/Service/GraphQL/SchemaGenerator.php
@@ -510,7 +510,7 @@ class SchemaGenerator {
 			}
 
 			// Annotate authorization requirements in description.
-			if (isset($authInfo[$name]) === true && $description !== '') {
+			if (isset($authInfo[$name]) === true) {
 				$description = $description . '. ' . $authInfo[$name];
 			} elseif (isset($authInfo[$name]) === true) {
 				$description = $authInfo[$name];

--- a/lib/Service/GraphQL/SchemaGenerator.php
+++ b/lib/Service/GraphQL/SchemaGenerator.php
@@ -509,11 +509,17 @@ class SchemaGenerator {
 				$description = null;
 			}
 
-			// Annotate authorization requirements in description.
+			// Annotate authorization requirements in description. Nest the
+			// null test rather than repeating isset() in an elseif: the two
+			// branches differ only in whether there is an existing description
+			// to append to, and a property with no description must NOT come
+			// out as ". Requires ...".
 			if (isset($authInfo[$name]) === true) {
-				$description = $description . '. ' . $authInfo[$name];
-			} elseif (isset($authInfo[$name]) === true) {
-				$description = $authInfo[$name];
+				if ($description === null) {
+					$description = $authInfo[$name];
+				} else {
+					$description = $description . '. ' . $authInfo[$name];
+				}
 			}
 
 			$fields[$fieldName] = [

--- a/lib/Service/GraphQL/SchemaGenerator/CompositionHandler.php
+++ b/lib/Service/GraphQL/SchemaGenerator/CompositionHandler.php
@@ -114,10 +114,9 @@ class CompositionHandler {
 	 * @spec openspec/specs/graphql-api/spec.md
 	 */
 	private function applyAllOf(RegisterSchema $schema, array &$fields): void {
-		$allOf = null;
-		if (method_exists(object_or_class: $schema, method: 'getAllOf') === true) {
-			$allOf = $schema->getAllOf();
-		}
+		// Schema declares getAllOf(), so no method_exists() probe is needed; the
+		// is_array() check below still does real work because it can return null.
+		$allOf = $schema->getAllOf();
 
 		if (is_array(value: $allOf) === false) {
 			return;
@@ -155,10 +154,8 @@ class CompositionHandler {
 	 * @spec openspec/specs/graphql-api/spec.md
 	 */
 	private function applyOneOf(RegisterSchema $schema, array &$fields): void {
-		$oneOf = null;
-		if (method_exists(object_or_class: $schema, method: 'getOneOf') === true) {
-			$oneOf = $schema->getOneOf();
-		}
+		// Schema declares getOneOf(); see applyAllOf() above.
+		$oneOf = $schema->getOneOf();
 
 		if (is_array(value: $oneOf) === false || empty($oneOf) === true) {
 			return;
@@ -199,10 +196,8 @@ class CompositionHandler {
 	 * @spec openspec/specs/graphql-api/spec.md
 	 */
 	private function applyAnyOf(RegisterSchema $schema, array &$fields): void {
-		$anyOf = null;
-		if (method_exists(object_or_class: $schema, method: 'getAnyOf') === true) {
-			$anyOf = $schema->getAnyOf();
-		}
+		// Schema declares getAnyOf(); see applyAllOf() above.
+		$anyOf = $schema->getAnyOf();
 
 		if (is_array(value: $anyOf) === false || empty($anyOf) === true) {
 			return;

--- a/lib/Service/GraphQL/SchemaGenerator/TypeMapperHandler.php
+++ b/lib/Service/GraphQL/SchemaGenerator/TypeMapperHandler.php
@@ -837,10 +837,8 @@ class TypeMapperHandler {
 	 */
 	public function getPropertyAuthDescriptions(RegisterSchema $schema): array {
 		$result = [];
-		if (method_exists(object_or_class: $schema, method: 'getPropertiesWithAuthorization') === false) {
-			return $result;
-		}
-
+		// Schema declares getPropertiesWithAuthorization(), so the early return
+		// that used to guard this call was unreachable.
 		$authProps = $schema->getPropertiesWithAuthorization();
 		foreach ($authProps as $propName => $authConfig) {
 			$groups = [];

--- a/lib/Service/ImportService.php
+++ b/lib/Service/ImportService.php
@@ -1460,16 +1460,13 @@ class ImportService {
 			}
 
 			// Transform row data to object format.
-			$object = $this->transformCsvRowToObject(
+			// transformCsvRowToObject() is declared non-nullable, so no guard.
+			$allObjects[] = $this->transformCsvRowToObject(
 				rowData: $rowData,
 				register: $register,
 				schema: $schema,
 				currentUser: $currentUser
 			);
-
-			if ($object !== null) {
-				$allObjects[] = $object;
-			}
 		}//end for
 
 		$summary['found'] = count($allObjects);

--- a/lib/Service/ImportService.php
+++ b/lib/Service/ImportService.php
@@ -323,7 +323,13 @@ class ImportService {
 	 *     debug?: array,
 	 *     schema?: array{id: int, slug: null|string, title: null|string},
 	 *     deduplication_efficiency?: string
-	 * }>
+	 * }|string>
+	 *
+	 * The `|string` is not slack: the result is a map of sheet title => summary,
+	 * but the method also writes a scalar `importJobId` into the SAME map. A
+	 * caller that iterates the result and assumes every value is a summary array
+	 * will hit that key. Kept as-is because moving it would change the response
+	 * shape for existing clients; the union at least makes it visible.
 	 *
 	 * @psalm-return array<string, array{
 	 *     created: array,

--- a/lib/Service/Integration/BuiltinProviders/AuditTrailProvider.php
+++ b/lib/Service/Integration/BuiltinProviders/AuditTrailProvider.php
@@ -142,25 +142,26 @@ class AuditTrailProvider extends AbstractIntegrationProvider {
 				return $this->normalize(entries: $entries);
 			}
 
-			if (method_exists($this->mapper, 'findAll') === true) {
-				// The audit table's `object` column is INTEGER (numeric
-				// object id) while `object_uuid` is the UUID string the
-				// sub-resource controller actually receives. Try the
-				// UUID-typed filter first and fall back to `object` for
-				// older schemas.
-				try {
-					$entries = $this->mapper->findAll(filters: ['object_uuid' => $objectId]);
-					if (count($entries) > 0) {
-						return $this->normalize(entries: $entries);
-					}
-				} catch (\Throwable $e) {
-					// Fall through to legacy filter.
-					unset($e);
+			// No method_exists() probe for findAll(): AuditTrailMapper declares
+			// it. The findAllByObject() probe above IS needed — that one is not
+			// on the mapper.
+			//
+			// The audit table's `object` column is INTEGER (numeric object id)
+			// while `object_uuid` is the UUID string the sub-resource controller
+			// actually receives. Try the UUID-typed filter first and fall back to
+			// `object` for older schemas.
+			try {
+				$entries = $this->mapper->findAll(filters: ['object_uuid' => $objectId]);
+				if (count($entries) > 0) {
+					return $this->normalize(entries: $entries);
 				}
-
-				$entries = $this->mapper->findAll(filters: ['object' => $objectId]);
-				return $this->normalize(entries: $entries);
+			} catch (\Throwable $e) {
+				// Fall through to legacy filter.
+				unset($e);
 			}
+
+			$entries = $this->mapper->findAll(filters: ['object' => $objectId]);
+			return $this->normalize(entries: $entries);
 		} catch (\Throwable $e) {
 			// AuditTrail history is a soft surface — never block the
 			// detail page on a stale or missing audit row.

--- a/lib/Service/Integration/BuiltinProviders/AuditTrailProvider.php
+++ b/lib/Service/Integration/BuiltinProviders/AuditTrailProvider.php
@@ -150,7 +150,7 @@ class AuditTrailProvider extends AbstractIntegrationProvider {
 				// older schemas.
 				try {
 					$entries = $this->mapper->findAll(filters: ['object_uuid' => $objectId]);
-					if (is_array($entries) === true && count($entries) > 0) {
+					if (count($entries) > 0) {
 						return $this->normalize(entries: $entries);
 					}
 				} catch (\Throwable $e) {

--- a/lib/Service/Integration/Providers/SharesProvider.php
+++ b/lib/Service/Integration/Providers/SharesProvider.php
@@ -634,16 +634,11 @@ class SharesProvider extends AbstractIntegrationProvider {
 			}
 
 			$owner = (string)($share->getSharedBy() ?? '');
+			// IShare::getNode() is declared to return Node and throws when the
+			// node is gone, so the null guards here were unreachable.
 			$node = $share->getNode();
-			$nodeName = '';
-			if ($node !== null) {
-				$nodeName = (string)$node->getName();
-			}
-
-			$nodeId = 0;
-			if ($node !== null) {
-				$nodeId = (int)$node->getId();
-			}
+			$nodeName = (string)$node->getName();
+			$nodeId = (int)$node->getId();
 
 			$nodeUrl = '/index.php/apps/files';
 			if ($nodeId > 0) {

--- a/lib/Service/MappingService.php
+++ b/lib/Service/MappingService.php
@@ -348,9 +348,8 @@ class MappingService {
 				$cast = explode(',', (string)$cast);
 			}
 
-			if ($cast === false) {
-				continue;
-			}
+			// No `$cast === false` bail-out: after the branch above $cast is
+			// always an array (explode() cannot return false), so it never fired.
 
 			foreach ($cast as $singleCast) {
 				$this->handleCast(dotArray: $dotArray, key: $key, cast: $singleCast);

--- a/lib/Service/MappingService.php
+++ b/lib/Service/MappingService.php
@@ -382,10 +382,8 @@ class MappingService {
 			$output = [];
 		}
 
-		if (is_array($output) === false) {
-			$output = [$output];
-		}
-
+		// No scalar-wrapping branch: after the null default above, $output is
+		// always an array, so `is_array() === false` could never be entered.
 		return $output;
 	}//end executeMapping()
 

--- a/lib/Service/Notification/AnnotationNotificationDispatcher.php
+++ b/lib/Service/Notification/AnnotationNotificationDispatcher.php
@@ -798,15 +798,15 @@ class AnnotationNotificationDispatcher {
 
 		$object = new ObjectEntity();
 		$object->setUuid((string)($payload['objectUuid'] ?? ''));
-		if (isset($payload['objectRegister']) === true && $payload['objectRegister'] !== null) {
+		if (isset($payload['objectRegister']) === true) {
 			$object->setRegister((string)$payload['objectRegister']);
 		}
 
-		if (isset($payload['objectSchema']) === true && $payload['objectSchema'] !== null) {
+		if (isset($payload['objectSchema']) === true) {
 			$object->setSchema((string)$payload['objectSchema']);
 		}
 
-		if (isset($payload['objectName']) === true && $payload['objectName'] !== null) {
+		if (isset($payload['objectName']) === true) {
 			$object->setName((string)$payload['objectName']);
 		}
 

--- a/lib/Service/Notification/NotificationAnnotationValidator.php
+++ b/lib/Service/Notification/NotificationAnnotationValidator.php
@@ -457,7 +457,7 @@ final class NotificationAnnotationValidator {
 			}
 
 			// When the `webhook` channel is declared, the spec MUST include a `webhook.url` value.
-			if (is_array($channels) === true && in_array('webhook', $channels, true) === true) {
+			if (in_array('webhook', $channels, true) === true) {
 				$hook = ($spec['webhook'] ?? null);
 				$hookBad = is_array($hook) === false;
 				if ($hookBad === false) {
@@ -477,7 +477,7 @@ final class NotificationAnnotationValidator {
 			}
 
 			// When the `talk` channel is declared, the spec MUST include a `talk.token`.
-			if (is_array($channels) === true && in_array('talk', $channels, true) === true) {
+			if (in_array('talk', $channels, true) === true) {
 				$talk = ($spec['talk'] ?? null);
 				$talkBad = is_array($talk) === false;
 				if ($talkBad === false) {

--- a/lib/Service/OasService.php
+++ b/lib/Service/OasService.php
@@ -263,7 +263,7 @@ class OasService {
 			$sanitizedSchemaName = $this->sanitizeSchemaName(title: $schemaTitle);
 
 			// Step 8c: Validate schema definition before adding to components.
-			if (empty($schemaDefinition) === false && is_array($schemaDefinition) === true) {
+			if (empty($schemaDefinition) === false) {
 				$this->oas['components']['schemas'][$sanitizedSchemaName] = $schemaDefinition;
 
 				// Add tag for the schema (keep original title for display).

--- a/lib/Service/Object/CacheHandler.php
+++ b/lib/Service/Object/CacheHandler.php
@@ -1374,7 +1374,7 @@ class CacheHandler {
 		try {
 			// STEP 1: Try to find as organisation first (they take priority).
 			try {
-				// findByUuid() throws rather than returning null; the catch below
+				// The findByUuid() call throws rather than returning null; the catch below
 				// is the "no such organisation" path.
 				$organisation = $this->organisationMapper->findByUuid((string)$identifier);
 				$name = $organisation->getName() ?? $organisation->getUuid();

--- a/lib/Service/Object/CacheHandler.php
+++ b/lib/Service/Object/CacheHandler.php
@@ -95,7 +95,10 @@ class CacheHandler {
 	 * Provides ultra-fast name lookups for frontend rendering without
 	 * requiring full object data retrieval.
 	 *
-	 * @var array<string, string>
+	 * Keys are int|string, not string: the cache is written under BOTH the uuid
+	 * and the numeric id, and PHP coerces a canonical numeric string key to int.
+	 *
+	 * @var array<int|string, string>
 	 */
 	private array $nameCache = [];
 
@@ -107,7 +110,8 @@ class CacheHandler {
 	 * $nameCache; an identifier missing from this map has an unknown owner and is
 	 * therefore never served (fail closed).
 	 *
-	 * @var array<string, string|null>
+	 * @var array<int|string, string|null> Keyed identically to $nameCache — see
+	 *      the key-coercion note there.
 	 */
 	private array $nameOrganisations = [];
 
@@ -1370,26 +1374,27 @@ class CacheHandler {
 		try {
 			// STEP 1: Try to find as organisation first (they take priority).
 			try {
+				// findByUuid() throws rather than returning null; the catch below
+				// is the "no such organisation" path.
 				$organisation = $this->organisationMapper->findByUuid((string)$identifier);
-				if ($organisation !== null) {
-					$name = $organisation->getName() ?? $organisation->getUuid();
-					// An organisation's own tenancy is itself. A row with neither a
-					// name nor a uuid has nothing to cache — setObjectName() takes a
-					// non-nullable string, so guard rather than fatal.
-					if ($name !== null) {
-						$this->setObjectName(
-							identifier: $identifier,
-							name: $name,
-							organisation: $organisation->getUuid()
-						);
-					}
+				$name = $organisation->getName() ?? $organisation->getUuid();
 
-					if ($this->hasOrganisationAccess(organisation: $organisation->getUuid()) === false) {
-						return null;
-					}
-
-					return $name;
+				// An organisation's own tenancy is itself. A row with neither a
+				// name nor a uuid has nothing to cache — setObjectName() takes a
+				// non-nullable string, so guard rather than fatal.
+				if ($name !== null) {
+					$this->setObjectName(
+						identifier: $identifier,
+						name: $name,
+						organisation: $organisation->getUuid()
+					);
 				}
+
+				if ($this->hasOrganisationAccess(organisation: $organisation->getUuid()) === false) {
+					return null;
+				}
+
+				return $name;
 			} catch (\Exception $e) {
 				// Organisation not found, continue to objects.
 			}

--- a/lib/Service/Object/CascadingHandler.php
+++ b/lib/Service/Object/CascadingHandler.php
@@ -131,30 +131,29 @@ class CascadingHandler {
 
 			$propertyValue = $object[$propertyName];
 
-			// Handle array properties.
+			// Handle array properties. No emptiness re-check: the loop head above
+			// already skipped every empty $object[$propertyName].
 			if ($definition['type'] === 'array' && isset($definition['items']['inversedBy']) === true) {
-				if (empty($propertyValue) === false) {
-					$createdUuids = [];
-					foreach ($propertyValue as $item) {
-						if (is_array($item) === true && $this->utilityHandler->isUuid($item) === false) {
-							// This is a nested object, create it first.
-							$createdUuid = $this->createRelatedObject(
-								objectData: $item,
-								definition: $definition['items'],
-								parentUuid: $uuid,
-								currentRegister: $currentRegister
-							);
+				$createdUuids = [];
+				foreach ($propertyValue as $item) {
+					if (is_array($item) === true && $this->utilityHandler->isUuid($item) === false) {
+						// This is a nested object, create it first.
+						$createdUuid = $this->createRelatedObject(
+							objectData: $item,
+							definition: $definition['items'],
+							parentUuid: $uuid,
+							currentRegister: $currentRegister
+						);
 
-							// If creation failed, keep original item to avoid empty array.
-							$createdUuids[] = $createdUuid ?? $item;
-						} elseif (is_string($item) === true && $this->utilityHandler->isUuid($item) === true) {
-							// This is already a UUID, keep it.
-							$createdUuids[] = $item;
-						}
+						// If creation failed, keep original item to avoid empty array.
+						$createdUuids[] = $createdUuid ?? $item;
+					} elseif (is_string($item) === true && $this->utilityHandler->isUuid($item) === true) {
+						// This is already a UUID, keep it.
+						$createdUuids[] = $item;
 					}
+				}
 
-					$object[$propertyName] = $createdUuids;
-				}//end if
+				$object[$propertyName] = $createdUuids;
 			} elseif (isset($definition['inversedBy']) === true && $definition['type'] !== 'array') {
 				// Handle single object properties.
 				if (is_array($propertyValue) === true && $this->utilityHandler->isUuid($propertyValue) === false) {

--- a/lib/Service/Object/CascadingHandler.php
+++ b/lib/Service/Object/CascadingHandler.php
@@ -133,7 +133,7 @@ class CascadingHandler {
 
 			// Handle array properties.
 			if ($definition['type'] === 'array' && isset($definition['items']['inversedBy']) === true) {
-				if (is_array($propertyValue) === true && empty($propertyValue) === false) {
+				if (empty($propertyValue) === false) {
 					$createdUuids = [];
 					foreach ($propertyValue as $item) {
 						if (is_array($item) === true && $this->utilityHandler->isUuid($item) === false) {

--- a/lib/Service/Object/DeleteObject.php
+++ b/lib/Service/Object/DeleteObject.php
@@ -339,50 +339,56 @@ class DeleteObject {
 		// Update the object in database (soft delete - keeps record with deleted metadata).
 		// Pass register/schema context for magic mapper routing.
 		// @psalm-suppress InvalidArgument - ObjectEntity extends Entity.
-		$result = $this->objectEntityMapper->update(
+		// update() is declared non-nullable and throws on failure, so the old
+		// `!== null` test and the `if ($result === true)` guard below it were
+		// both always true: reaching the next line IS the success case.
+		$this->objectEntityMapper->update(
 			entity: $objectEntity,
 			register: $registerEntity,
 			schema: $schemaEntity,
 			oldEntity: $preDeleteState
-		) !== null;
+		);
+		$result = true;
 
 		\OCA\OpenRegister\Service\WritePhaseProbe::stamp('del.update');
 
-		// **CACHE INVALIDATION**: Clear collection and facet caches so soft-deleted objects disappear from regular queries.
-		if ($result === true) {
-			/*
-			 * ObjectEntity has getRegister() and getSchema() methods that return string|null.
-			 * Convert to int|null for invalidateForObjectChange which expects ?int.
-			 * @var ObjectEntity $objectEntity
-			 */
+		/*
+		 * **CACHE INVALIDATION**: Clear collection and facet caches so
+		 * soft-deleted objects disappear from regular queries.
+		 *
+		 * ObjectEntity has getRegister() and getSchema() methods that return
+		 * string|null. Convert to int|null for invalidateForObjectChange which
+		 * expects ?int.
+		 *
+		 * @var ObjectEntity $objectEntity
+		 */
 
-			$registerId = $objectEntity->getRegister();
-			$schemaId = $objectEntity->getSchema();
+		$registerId = $objectEntity->getRegister();
+		$schemaId = $objectEntity->getSchema();
 
-			// Convert register ID to int if numeric.
-			$registerIdInt = null;
-			if ($registerId !== null && is_numeric($registerId) === true) {
-				$registerIdInt = (int)$registerId;
-			}
+		// Convert register ID to int if numeric.
+		$registerIdInt = null;
+		if ($registerId !== null && is_numeric($registerId) === true) {
+			$registerIdInt = (int)$registerId;
+		}
 
-			// Convert schema ID to int if numeric.
-			$schemaIdInt = null;
-			if ($schemaId !== null && is_numeric($schemaId) === true) {
-				$schemaIdInt = (int)$schemaId;
-			}
+		// Convert schema ID to int if numeric.
+		$schemaIdInt = null;
+		if ($schemaId !== null && is_numeric($schemaId) === true) {
+			$schemaIdInt = (int)$schemaId;
+		}
 
-			try {
-				$this->cacheHandler->invalidateForObjectChange(
-					object: $objectEntity,
-					operation: 'soft_delete',
-					registerId: $registerIdInt,
-					schemaId: $schemaIdInt
-				);
-			} catch (\Exception $e) {
-				// Gracefully handle cache invalidation errors (e.g., Solr not configured).
-				// Soft deletion should succeed even if cache invalidation fails.
-			}
-		}//end if
+		try {
+			$this->cacheHandler->invalidateForObjectChange(
+				object: $objectEntity,
+				operation: 'soft_delete',
+				registerId: $registerIdInt,
+				schemaId: $schemaIdInt
+			);
+		} catch (\Exception $e) {
+			// Gracefully handle cache invalidation errors (e.g., Solr not configured).
+			// Soft deletion should succeed even if cache invalidation fails.
+		}
 
 		\OCA\OpenRegister\Service\WritePhaseProbe::stamp('del.cache');
 

--- a/lib/Service/Object/FacetHandler.php
+++ b/lib/Service/Object/FacetHandler.php
@@ -185,12 +185,10 @@ class FacetHandler {
 			$facetConfig = [$facetConfig];
 		}
 
-		// Handle _facets as numerically-indexed array (e.g., _facets[]=standaardversies).
-		// PHP converts ?_facets[]=foo&_facets[]=bar into [0 => 'foo', 1 => 'bar'].
-		// Ensure it stays a simple list of field names.
-		if (is_array($facetConfig) === true && array_is_list($facetConfig) === true) {
-			$facetConfig = array_values(array: $facetConfig);
-		}
+		// No reindex step for the numerically-indexed `_facets[]=foo&_facets[]=bar`
+		// form: PHP already delivers that as [0 => 'foo', 1 => 'bar'], and the
+		// array_values() that used to sit here only ran when array_is_list() was
+		// already true — i.e. never did anything.
 
 		// **PAGINATION INDEPENDENCE**: Remove pagination params for facet calculation.
 		$facetQuery = $query;

--- a/lib/Service/Object/PermissionHandler.php
+++ b/lib/Service/Object/PermissionHandler.php
@@ -1211,7 +1211,9 @@ class PermissionHandler {
 			}
 		}//end foreach
 
-		return array_values(array_filter($filteredUuids, fn ($uuid) => $uuid !== null));
+		// No array_filter for nulls: $filteredUuids never contains one, so the
+		// callback matched every element and the filter was a no-op.
+		return array_values($filteredUuids);
 	}//end filterUuidsForPermissions()
 
 	/**

--- a/lib/Service/Object/PermissionHandler.php
+++ b/lib/Service/Object/PermissionHandler.php
@@ -1211,9 +1211,9 @@ class PermissionHandler {
 			}
 		}//end foreach
 
-		// No array_filter for nulls: $filteredUuids never contains one, so the
-		// callback matched every element and the filter was a no-op.
-		return array_values($filteredUuids);
+		// No array_filter for nulls and no array_values: $filteredUuids never
+		// contains a null and is already a list, so both were no-ops.
+		return $filteredUuids;
 	}//end filterUuidsForPermissions()
 
 	/**

--- a/lib/Service/Object/RelationHandler.php
+++ b/lib/Service/Object/RelationHandler.php
@@ -848,9 +848,14 @@ class RelationHandler {
 	 *
 	 * @return (array|int|mixed|string)[] Paginated results with referencing objects.
 	 *
-	 * @psalm-return array{results: array<never, never>, total: 0,
-	 *     limit: 30|mixed, offset: 0|mixed,
+	 * @psalm-return array{results: list<array<string, mixed>>, total: int<0, max>,
+	 *     limit: mixed, offset: mixed,
 	 *     message?: 'Reverse relationship lookup not yet implemented'}
+	 *
+	 * The previous annotation said `results: array<never, never>, total: 0` —
+	 * inferred back when this method was a stub that returned nothing and the
+	 * "not yet implemented" message. It has since been implemented and returns
+	 * real rows; only the `message` key is still optional/legacy.
 	 *
 	 * @SuppressWarnings(PHPMD.BooleanArgumentFlag) RBAC/multitenancy flags follow established API patterns
 	 *

--- a/lib/Service/Object/RelationHandler.php
+++ b/lib/Service/Object/RelationHandler.php
@@ -152,7 +152,6 @@ class RelationHandler {
 					$serialized = $object->jsonSerialize();
 					$idRaw = null;
 					if (is_array($property) === true
-						&& is_array($serialized) === true
 						&& isset($property['inversedBy']) === true
 					) {
 						$idRaw = $serialized[$property['inversedBy']];

--- a/lib/Service/Object/RenderObject.php
+++ b/lib/Service/Object/RenderObject.php
@@ -1019,6 +1019,7 @@ class RenderObject {
 		// per-file tag loop as iterating an always-empty array. It is not: PHP
 		// applies the same coercion on lookup, so `$allTagIdsPerFile["123"]`
 		// finds the row stored under 123.
+		// phpcs:ignore Squiz.Commenting.InlineComment.DocBlock -- PHPStan only reads @var from a /** */ block.
 		/** @var array<int|string, list<string>> $allTagIdsPerFile */
 		$allTagIdsPerFile = $this->systemTagMapper->getTagIdsForObjects(
 			objIds: $allFileIds,
@@ -4103,6 +4104,7 @@ class RenderObject {
 
 			// Numeric-string keys are coerced to int by PHP — see the longer
 			// note on the other getTagIdsForObjects() call in this class.
+			// phpcs:ignore Squiz.Commenting.InlineComment.DocBlock -- PHPStan only reads @var from a /** */ block.
 			/** @var array<int|string, list<string>> $allTagIdsPerFile */
 			$allTagIdsPerFile = $this->systemTagMapper->getTagIdsForObjects(
 				objIds: $stringFileIds,

--- a/lib/Service/Object/RenderObject.php
+++ b/lib/Service/Object/RenderObject.php
@@ -1011,6 +1011,15 @@ class RenderObject {
 
 		// Batch-load all file tags in 2 queries instead of 2*N queries.
 		$allFileIds = array_map(fn ($f) => (string)$f['fileid'], $fileRecords);
+
+		// OCP declares this `array<string, list<string>>`, but file ids are
+		// canonical numeric strings, so PHP coerces every key to INT on the way
+		// in. Without the annotation below PHPStan concludes a numeric-string
+		// offset can never match an `array<string, ...>` and reports the
+		// per-file tag loop as iterating an always-empty array. It is not: PHP
+		// applies the same coercion on lookup, so `$allTagIdsPerFile["123"]`
+		// finds the row stored under 123.
+		/** @var array<int|string, list<string>> $allTagIdsPerFile */
 		$allTagIdsPerFile = $this->systemTagMapper->getTagIdsForObjects(
 			objIds: $allFileIds,
 			objectType: 'files'
@@ -4091,6 +4100,10 @@ class RenderObject {
 
 			// 3) Batch-load all tag ids for all files in one query.
 			$stringFileIds = array_map(static fn ($id) => (string)$id, $fileIds);
+
+			// Numeric-string keys are coerced to int by PHP — see the longer
+			// note on the other getTagIdsForObjects() call in this class.
+			/** @var array<int|string, list<string>> $allTagIdsPerFile */
 			$allTagIdsPerFile = $this->systemTagMapper->getTagIdsForObjects(
 				objIds: $stringFileIds,
 				objectType: 'files'

--- a/lib/Service/Object/SaveObject.php
+++ b/lib/Service/Object/SaveObject.php
@@ -537,13 +537,13 @@ class SaveObject {
 		// Try direct slug match as last resort.
 		try {
 			// SchemaMapper->find() supports id, uuid, and slug via orX().
+			// find() throws when there is no match; the catch below is the
+			// "not found" path, so no null test is needed here.
 			$schema = $this->schemaMapper->find(id: $slug, _rbac: false, _multitenancy: false);
-			if ($schema !== null) {
-				$schemaId = (string)$schema->getId();
-				$this->schemaCache[$schemaId] = $schema;
-				$this->schemaReferenceCache[$reference] = $schemaId;
-				return $schemaId;
-			}
+			$schemaId = (string)$schema->getId();
+			$this->schemaCache[$schemaId] = $schema;
+			$this->schemaReferenceCache[$reference] = $schemaId;
+			return $schemaId;
 		} catch (Exception $e) {
 			// Schema not found.
 		}
@@ -3108,8 +3108,9 @@ class SaveObject {
 
 			// Use cached schema lookup instead of direct mapper call.
 			$schema = $this->getCachedSchema(schemaId: $schemaId);
-		} elseif (is_int($schema) === true) {
-			// It's an integer ID - use cached lookup.
+		} else {
+			// Only the integer-ID case is left after the Schema and string arms
+			// above, so no is_int() re-test — use the cached lookup.
 			$schemaId = $schema;
 			$schema = $this->getCachedSchema(schemaId: $schema);
 		}

--- a/lib/Service/Object/SaveObject.php
+++ b/lib/Service/Object/SaveObject.php
@@ -2838,7 +2838,7 @@ class SaveObject {
 						_rbac: false,
 						_multitenancy: false
 					);
-					// find() throws DoesNotExistException rather than returning
+					// The find() call throws DoesNotExistException rather than returning
 					// null — that catch below is the real "missing" path.
 					$existingObjectData = $tempExistingObject->getObject();
 				} catch (DoesNotExistException $e) {

--- a/lib/Service/Object/SaveObject.php
+++ b/lib/Service/Object/SaveObject.php
@@ -5687,8 +5687,9 @@ class SaveObject {
 			return false;
 		}
 
-		// For objects/arrays with content, check recursively.
-		if (is_array($value) === true && empty($value) === false) {
+		// For objects/arrays with content, check recursively. The empty-array
+		// case already returned above, so only the array-ness matters here.
+		if (is_array($value) === true) {
 			// If it's an associative array (object-like), check if it's effectively empty.
 			if (array_keys($value) !== range(0, count($value) - 1)) {
 				return $this->isEffectivelyEmptyObject(object: $value) === false;

--- a/lib/Service/Object/SaveObject.php
+++ b/lib/Service/Object/SaveObject.php
@@ -2838,9 +2838,9 @@ class SaveObject {
 						_rbac: false,
 						_multitenancy: false
 					);
-					if ($tempExistingObject !== null) {
-						$existingObjectData = $tempExistingObject->getObject();
-					}
+					// find() throws DoesNotExistException rather than returning
+					// null — that catch below is the real "missing" path.
+					$existingObjectData = $tempExistingObject->getObject();
 				} catch (DoesNotExistException $e) {
 					// Object doesn't exist, treat as create.
 					$isCreate = true;

--- a/lib/Service/Object/SaveObject/FilePropertyHandler.php
+++ b/lib/Service/Object/SaveObject/FilePropertyHandler.php
@@ -620,9 +620,7 @@ class FilePropertyHandler {
 						fileConfig: $fileConfig,
 						index: $index
 					);
-					if ($fileId !== null) {
-						$fileIds[] = $fileId;
-					}
+					$fileIds[] = $fileId;
 				}
 			}
 
@@ -641,9 +639,7 @@ class FilePropertyHandler {
 				);
 
 				// Replace the file content with file ID in the object data.
-				if ($fileId !== null) {
-					$object[$propertyName] = $fileId;
-				}
+				$object[$propertyName] = $fileId;
 			}
 		}//end if
 	}//end handleFileProperty()

--- a/lib/Service/Object/SearchQueryHandler.php
+++ b/lib/Service/Object/SearchQueryHandler.php
@@ -440,10 +440,17 @@ class SearchQueryHandler {
 						$searchTerms = implode(' ', $viewQuery['searchTerms']);
 					}
 
-					// Merge with existing search if present.
-					$query['_search'] = $searchTerms;
-					if (isset($query['_search']) === true && empty($query['_search']) === false) {
+					// Merge with the caller's existing search if there is one,
+					// otherwise take the view's terms as-is.
+					//
+					// This used to assign $query['_search'] = $searchTerms BEFORE
+					// the isset()/empty() test, which then always passed and
+					// appended the same terms a second time — a view search for
+					// "foo" was sent to the backend as "foo foo".
+					if (empty($query['_search']) === false) {
 						$query['_search'] .= ' ' . $searchTerms;
+					} else {
+						$query['_search'] = $searchTerms;
 					}
 				}//end if
 

--- a/lib/Service/Object/SearchQueryHandler.php
+++ b/lib/Service/Object/SearchQueryHandler.php
@@ -447,11 +447,12 @@ class SearchQueryHandler {
 					// the isset()/empty() test, which then always passed and
 					// appended the same terms a second time — a view search for
 					// "foo" was sent to the backend as "foo foo".
+					$existingSearch = '';
 					if (empty($query['_search']) === false) {
-						$query['_search'] .= ' ' . $searchTerms;
-					} else {
-						$query['_search'] = $searchTerms;
+						$existingSearch = $query['_search'] . ' ';
 					}
+
+					$query['_search'] = $existingSearch . $searchTerms;
 				}//end if
 
 				$this->logger->debug(

--- a/lib/Service/Object/TranslationHandler.php
+++ b/lib/Service/Object/TranslationHandler.php
@@ -266,15 +266,14 @@ class TranslationHandler {
 				continue;
 			}//end if
 
-			// Simple value path.
-			if ($value !== null) {
-				if ($targetLanguage !== null && $targetLanguage !== '') {
-					// Shape B — wrap under the target language.
-					$objectData[$propName] = [$targetLanguage => $value];
-				} else {
-					// Shape A — legacy: wrap under register default.
-					$objectData[$propName] = [$defaultLanguage => $value];
-				}
+			// Simple value path. $value is non-null by this point — the null
+			// case is handled by the continue above.
+			if ($targetLanguage !== null && $targetLanguage !== '') {
+				// Shape B — wrap under the target language.
+				$objectData[$propName] = [$targetLanguage => $value];
+			} else {
+				// Shape A — legacy: wrap under register default.
+				$objectData[$propName] = [$defaultLanguage => $value];
 			}
 		}//end foreach
 

--- a/lib/Service/Object/ValidateObject.php
+++ b/lib/Service/Object/ValidateObject.php
@@ -1488,10 +1488,9 @@ class ValidateObject {
 	private function findSchemaBySlug(string $slug): ?Schema {
 		try {
 			// Try direct slug match first using the find method which supports slug lookups.
-			$schema = $this->schemaMapper->find($slug);
-			if ($schema !== null) {
-				return $schema;
-			}
+			// find() throws when there is no match; the catch below is the
+			// "not found" path, so no null test is needed here.
+			return $this->schemaMapper->find($slug);
 		} catch (Exception $e) {
 			// Continue with case-insensitive search.
 		}

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -1297,7 +1297,7 @@ class ObjectService implements ObjectServiceInterface
         // If UUID was null and is now set, mark it as auto-generated in object data.
         // This allows SaveObject to distinguish between user-provided UUIDs (UPDATE)
         // and auto-generated UUIDs (CREATE).
-        if ($uuidWasNull === true && $uuid !== null && is_array($object) === true) {
+        if ($uuidWasNull === true && $uuid !== null) {
             // Store flag in @self to indicate this is a CREATE operation.
             if (isset($object['@self']) === false || is_array($object['@self']) === false) {
                 $object['@self'] = [];
@@ -1347,7 +1347,7 @@ class ObjectService implements ObjectServiceInterface
         // carry a UUID); the seed itself is empty-field-only and fail-soft, so
         // it never overwrites a client-supplied value. See the object-lifecycle
         // spec: fk-graph-lifecycle-transitions.
-        if ($uuidWasNull === true && is_array($object) === true) {
+        if ($uuidWasNull === true) {
             $object = $this->saveHandler->seedLifecycleFieldOnCreate(
                 schema: $this->currentSchema,
                 data: $object
@@ -3491,10 +3491,9 @@ class ObjectService implements ObjectServiceInterface
             }
         }//end if
 
-        // Collect UUIDs from object properties.
-        if (is_array($objectData) === true) {
-            $this->collectUuidsFromObjectData(data: $objectData, uuids: $uuids);
-        }
+        // Collect UUIDs from object properties. $objectData is always an array
+        // by this point, so the old is_array() guard could never skip the call.
+        $this->collectUuidsFromObjectData(data: $objectData, uuids: $uuids);
     }//end collectUuidsFromArrayResult()
 
     /**

--- a/lib/Service/Quality/QualityStatisticsService.php
+++ b/lib/Service/Quality/QualityStatisticsService.php
@@ -340,10 +340,8 @@ class QualityStatisticsService {
 			return [];
 		}
 
-		if ($entity instanceof Schema === false) {
-			return [];
-		}
-
+		// No instanceof re-check: the lookup above is declared to return Schema
+		// and throws otherwise, which the catch already handles.
 		$config = ($entity->getConfiguration() ?? []);
 		$annotation = ($config['x-openregister-quality'] ?? null);
 		if (is_array($annotation) === true) {

--- a/lib/Service/Reporting/SpreadsheetReportWriter.php
+++ b/lib/Service/Reporting/SpreadsheetReportWriter.php
@@ -260,7 +260,7 @@ class SpreadsheetReportWriter {
 		}
 
 		$valueField = $widget['options']['valueField'] ?? 'value';
-		if (isset($data[$valueField]) === true && $data[$valueField] !== null) {
+		if (isset($data[$valueField]) === true) {
 			return (string)$data[$valueField];
 		}
 

--- a/lib/Service/Schema/SchemaDiffService.php
+++ b/lib/Service/Schema/SchemaDiffService.php
@@ -306,7 +306,10 @@ class SchemaDiffService {
 				continue;
 			}
 
-			if ($hadOld === true && $hasNew === false) {
+			// Only the $hadOld && !$hasNew combination is left: the equal case and
+			// the !$hadOld && $hasNew case both continue above, so $hadOld is
+			// already known true here.
+			if ($hasNew === false) {
 				// Removed bound = relaxation.
 				$changes[] = [
 					'property' => $name,

--- a/lib/Service/SchemaService.php
+++ b/lib/Service/SchemaService.php
@@ -546,7 +546,7 @@ class SchemaService {
 		}
 
 		// Merge detected formats (if consistent patterns emerge).
-		if (($newAnalysis['detected_format'] ?? null) !== null && ($newAnalysis['detected_format'] !== null) === true) {
+		if (($newAnalysis['detected_format'] ?? null) !== null) {
 			$existingAnalysis['detected_format'] = $this->consolidateFormatDetection(
 				existingFormat: $existingAnalysis['detected_format'] ?? null,
 				newFormat: $newAnalysis['detected_format']
@@ -1163,7 +1163,6 @@ class SchemaService {
 
 		// Check for missing format.
 		if (($analysis['detected_format'] ?? null) !== null
-			&& ($analysis['detected_format'] !== null) === true
 			&& ($analysis['detected_format'] !== '') === true
 		) {
 			$currentFormat = $currentConfig['format'] ?? null;

--- a/lib/Service/SearchTrailService.php
+++ b/lib/Service/SearchTrailService.php
@@ -666,11 +666,10 @@ class SearchTrailService {
 		];
 
 		foreach ($config as $key => $value) {
-			// Ensure key is a string or integer to avoid "Illegal offset type" error.
-			if (is_string($key) === true || is_int($key) === true) {
-				if (in_array($key, $excludeKeys, true) === false && str_starts_with((string)$key, '_') === false) {
-					$processed['filters'][$key] = $value;
-				}
+			// No string-or-integer guard: an array key is always one of those,
+			// so it could never reject a key.
+			if (in_array($key, $excludeKeys, true) === false && str_starts_with((string)$key, '_') === false) {
+				$processed['filters'][$key] = $value;
 			}
 		}
 

--- a/lib/Service/SearchTrailService.php
+++ b/lib/Service/SearchTrailService.php
@@ -806,7 +806,9 @@ class SearchTrailService {
 			if (preg_match($pattern, $userAgent, $matches) === 1) {
 				return [
 					'browser' => $browser,
-					'version' => $matches[1] ?? 'unknown',
+					// Every pattern above has exactly one capturing group and we
+					// only get here when preg_match returned 1, so group 1 is set.
+					'version' => $matches[1],
 					'full_string' => $userAgent,
 				];
 			}

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -1141,7 +1141,7 @@ class SettingsService {
 						uuid: $object->getUuid()
 					);
 
-					// saveObject() is declared non-nullable and signals failure by
+					// The saveObject() call is declared non-nullable and signals failure by
 					// throwing, so reaching this line IS the success case. The
 					// "Save operation returned null" branch that used to sit here
 					// could never run; the catch below is the real failure path

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -1141,22 +1141,13 @@ class SettingsService {
 						uuid: $object->getUuid()
 					);
 
-					if ($savedObject !== null) {
-						$batchSuccesses++;
-						$results['stats']['successful_saves']++;
-					}
-
-					if ($savedObject === null) {
-						$results['stats']['failed_saves']++;
-						$batchErrors[] = [
-							'object_id' => $object->getUuid(),
-							'object_name' => $object->getName() ?? $object->getUuid(),
-							'register' => $object->getRegister(),
-							'schema' => $object->getSchema(),
-							'error' => 'Save operation returned null',
-							'batch_mode' => 'serial_optimized',
-						];
-					}
+					// saveObject() is declared non-nullable and signals failure by
+					// throwing, so reaching this line IS the success case. The
+					// "Save operation returned null" branch that used to sit here
+					// could never run; the catch below is the real failure path
+					// and already counts it.
+					$batchSuccesses++;
+					$results['stats']['successful_saves']++;
 				} catch (Exception $e) {
 					$results['stats']['failed_saves']++;
 					$batchErrors[] = [
@@ -1363,20 +1354,10 @@ class SettingsService {
 					uuid: $object->getUuid()
 				);
 
-				if ($savedObject !== null) {
-					$batchSuccesses++;
-				}
-
-				if ($savedObject === null) {
-					$batchErrors[] = [
-						'object_id' => $object->getUuid(),
-						'object_name' => $object->getName() ?? $object->getUuid(),
-						'register' => $object->getRegister(),
-						'schema' => $object->getSchema(),
-						'error' => 'Save operation returned null',
-						'batch_mode' => 'parallel_optimized',
-					];
-				}
+				// See the serial path above: saveObject() cannot return null, so
+				// reaching this line IS the success case and the "returned null"
+				// branch was dead. The catch below is the real failure path.
+				$batchSuccesses++;
 			} catch (Exception $e) {
 				$batchErrors[] = [
 					'object_id' => $object->getUuid(),

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -1131,7 +1131,7 @@ class SettingsService {
 					// Schema|string|int|null $schema, ?string $uuid, ...).
 					$objectData = $object->getObject();
 					// Get the object business data.
-					$savedObject = $objectService->saveObject(
+					$objectService->saveObject(
 						object: $objectData,
 						extend: [],
 						register: $object->getRegister(),
@@ -1344,7 +1344,7 @@ class SettingsService {
 				// Schema|string|int|null $schema, ?string $uuid, ...).
 				$objectData = $object->getObject();
 				// Get the object business data.
-				$savedObject = $objectService->saveObject(
+				$objectService->saveObject(
 					object: $objectData,
 					extend: [],
 					register: $object->getRegister(),

--- a/lib/Service/ShareLinkService.php
+++ b/lib/Service/ShareLinkService.php
@@ -577,13 +577,11 @@ class ShareLinkService {
 			}
 
 			$owner = (string)($share->getSharedBy() ?? '');
+			// IShare::getNode() is declared to return Node and throws when the
+			// node is gone, so the null guard here was unreachable.
 			$node = $share->getNode();
-			$fileName = '';
-			$fileId = 0;
-			if ($node !== null) {
-				$fileName = (string)$node->getName();
-				$fileId = (int)$node->getId();
-			}
+			$fileName = (string)$node->getName();
+			$fileId = (int)$node->getId();
 
 			return [
 				'shareId' => $shareId,

--- a/lib/Service/SharedSchema/SchemaAttribution.php
+++ b/lib/Service/SharedSchema/SchemaAttribution.php
@@ -287,7 +287,9 @@ class SchemaAttribution {
 			$result[] = $entry;
 		}
 
-		return array_values($result);
+		// No array_values(): $result is only ever appended to, so it is already
+		// a list.
+		return $result;
 	}//end replaceSchemaId()
 
 	/**

--- a/lib/Service/Sharing/SharePrincipalDeriver.php
+++ b/lib/Service/Sharing/SharePrincipalDeriver.php
@@ -179,7 +179,12 @@ class SharePrincipalDeriver {
 	 * @param mixed $sharedWith The raw `sharedWith` value.
 	 * @param string $userId The acting user id.
 	 * @param string[] $userGroups The acting user's group ids.
-	 * @param string[] $permissions Permissions that satisfy the check.
+	 * @param array<string|null> $permissions Permissions that satisfy the check.
+	 *        null is a MEANINGFUL member, not sloppiness: a share entry that
+	 *        carries no explicit permission has `permission => null`, and both
+	 *        callers pass `['use', null]` to mean "an unqualified share counts
+	 *        as 'use'". Narrowing this to string[] would silently stop matching
+	 *        those entries.
 	 *
 	 * @return bool True when a matching principal holds one of the permissions.
 	 */

--- a/lib/Service/Sync/HarvestPipelineService.php
+++ b/lib/Service/Sync/HarvestPipelineService.php
@@ -235,7 +235,15 @@ class HarvestPipelineService {
 	 * @param Source $source The source
 	 * @param SyncRecord $record The fetched record
 	 * @param Mapping|null $mapping The configured mapping (or null for pass-through)
-	 * @param array{executionId: string, gathered: int, created: int, updated: int, unchanged: int, conflicts: int, errors: int} $summary Running summary (by reference)
+	 * @param array $summary Running summary (by reference)
+	 *
+	 * The precise shape lives in @phpstan-param below rather than inline: every
+	 * counter is an int, which is what stops `$summary['created']++` reading as
+	 * a string increment. It does not fit on one @param line under the 150-char
+	 * limit, and wrapping a @param breaks the parameter-name sniff.
+	 *
+	 * @phpstan-param array{executionId: string, gathered: int, created: int,
+	 *     updated: int, unchanged: int, conflicts: int, errors: int} $summary
 	 *
 	 * @return void
 	 *

--- a/lib/Service/Sync/HarvestPipelineService.php
+++ b/lib/Service/Sync/HarvestPipelineService.php
@@ -235,7 +235,7 @@ class HarvestPipelineService {
 	 * @param Source $source The source
 	 * @param SyncRecord $record The fetched record
 	 * @param Mapping|null $mapping The configured mapping (or null for pass-through)
-	 * @param array<string, int|string> $summary Running summary (by reference)
+	 * @param array{executionId: string, gathered: int, created: int, updated: int, unchanged: int, conflicts: int, errors: int} $summary Running summary (by reference)
 	 *
 	 * @return void
 	 *

--- a/lib/Service/TextExtraction/EntityRecognitionHandler.php
+++ b/lib/Service/TextExtraction/EntityRecognitionHandler.php
@@ -1063,10 +1063,8 @@ class EntityRecognitionHandler {
 		}
 
 		if (function_exists('mb_scrub') === true) {
-			$scrubbed = mb_scrub($value, 'UTF-8');
-			if (is_string($scrubbed) === true) {
-				return $scrubbed;
-			}
+			// mb_scrub() returns string, so no is_string() re-check is needed.
+			return mb_scrub($value, 'UTF-8');
 		}
 
 		$converted = @iconv('UTF-8', 'UTF-8//IGNORE', $value);

--- a/lib/Service/TextExtraction/EntityRecognitionHandler.php
+++ b/lib/Service/TextExtraction/EntityRecognitionHandler.php
@@ -1063,7 +1063,7 @@ class EntityRecognitionHandler {
 		}
 
 		if (function_exists('mb_scrub') === true) {
-			// mb_scrub() returns string, so no is_string() re-check is needed.
+			// The mb_scrub() call returns string, so no is_string() re-check.
 			return mb_scrub($value, 'UTF-8');
 		}
 

--- a/lib/Service/TextExtraction/ObjectHandler.php
+++ b/lib/Service/TextExtraction/ObjectHandler.php
@@ -307,12 +307,12 @@ class ObjectHandler implements TextExtractionHandlerInterface {
 		foreach ($data as $key => $value) {
 			// Build context path.
 			$contextKey = (string)$key;
-			if ($prefix !== null && $prefix !== '') {
+			if ($prefix !== '') {
 				$contextKey = "{$prefix}.{$key}";
 			}
 
 			// Handle different value types.
-			if (is_string($value) === true && trim($value) !== '' && trim($value) !== null) {
+			if (is_string($value) === true && trim($value) !== '') {
 				$textParts[] = "{$contextKey}: {$value}";
 			} elseif (is_numeric($value) === true) {
 				$textParts[] = "{$contextKey}: {$value}";

--- a/lib/Service/TextExtractionService.php
+++ b/lib/Service/TextExtractionService.php
@@ -1632,7 +1632,7 @@ class TextExtractionService {
 			$chunks,
 			function ($chunk) {
 				$trimmed = trim($chunk['text']);
-				return $trimmed !== '' && $trimmed !== null;
+				return $trimmed !== '';
 			}
 		);
 	}//end chunkFixedSize()
@@ -1812,7 +1812,7 @@ class TextExtractionService {
 			$chunks,
 			function ($chunk) {
 				$trimmed = trim($chunk['text']);
-				return $trimmed !== '' && $trimmed !== null;
+				return $trimmed !== '';
 			}
 		);
 	}//end recursiveSplit()

--- a/lib/Service/TimeTrackerLinkService.php
+++ b/lib/Service/TimeTrackerLinkService.php
@@ -932,7 +932,7 @@ class TimeTrackerLinkService {
 		}
 
 		$duration = null;
-		if (isset($row->duration) === true && $row->duration !== '' && $row->duration !== null) {
+		if (isset($row->duration) === true && $row->duration !== '') {
 			$duration = (int)$row->duration;
 		}
 

--- a/lib/Service/TmloService.php
+++ b/lib/Service/TmloService.php
@@ -267,7 +267,6 @@ class TmloService {
 
 		// Validate archiefnominatie.
 		if (isset($tmlo['archiefnominatie']) === true
-			&& $tmlo['archiefnominatie'] !== null
 			&& in_array($tmlo['archiefnominatie'], self::VALID_ARCHIEFNOMINATIE, true) === false
 		) {
 			$allowed = implode(', ', self::VALID_ARCHIEFNOMINATIE);
@@ -277,7 +276,6 @@ class TmloService {
 
 		// Validate archiefstatus.
 		if (isset($tmlo['archiefstatus']) === true
-			&& $tmlo['archiefstatus'] !== null
 			&& in_array($tmlo['archiefstatus'], self::VALID_ARCHIEFSTATUS, true) === false
 		) {
 			$allowed = implode(', ', self::VALID_ARCHIEFSTATUS);
@@ -286,7 +284,7 @@ class TmloService {
 		}
 
 		// Validate bewaarTermijn as ISO-8601 duration.
-		if (isset($tmlo['bewaarTermijn']) === true && $tmlo['bewaarTermijn'] !== null) {
+		if (isset($tmlo['bewaarTermijn']) === true) {
 			try {
 				new DateInterval($tmlo['bewaarTermijn']);
 			} catch (Exception $e) {
@@ -296,7 +294,7 @@ class TmloService {
 		}
 
 		// Validate archiefactiedatum as ISO-8601 date.
-		if (isset($tmlo['archiefactiedatum']) === true && $tmlo['archiefactiedatum'] !== null) {
+		if (isset($tmlo['archiefactiedatum']) === true) {
 			$date = DateTime::createFromFormat('Y-m-d', $tmlo['archiefactiedatum']);
 			if ($date === false || $date->format('Y-m-d') !== $tmlo['archiefactiedatum']) {
 				$got = $tmlo['archiefactiedatum'];

--- a/lib/Service/UserService.php
+++ b/lib/Service/UserService.php
@@ -31,6 +31,7 @@ use InvalidArgumentException;
 use OCA\OpenRegister\Db\AuditTrailMapper;
 use OCA\OpenRegister\Event\UserProfileUpdatedEvent;
 use OCP\Accounts\IAccountManager;
+use OCP\Accounts\PropertyDoesNotExistException;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAvatarManager;
 use OCP\IConfig;
@@ -196,35 +197,24 @@ class UserService {
 			$avatarScope = $user->getAvatarScope();
 		}
 
-		$lastLogin = 0;
-		if (method_exists($user, 'getLastLogin') === true) {
-			$lastLogin = $user->getLastLogin();
-		}
-
-		$backend = 'unknown';
-		if (method_exists($user, 'getBackendClassName') === true) {
-			$backend = $user->getBackendClassName();
-		}
-
-		$canChangeDisplayName = false;
-		if (method_exists($user, 'canChangeDisplayName') === true) {
-			$canChangeDisplayName = $user->canChangeDisplayName();
-		}
+		// OCP\IUser declares getLastLogin(), getBackendClassName(),
+		// canChangeDisplayName(), canChangePassword() and canChangeAvatar(), so
+		// the method_exists() guards that used to wrap these could never be
+		// false and their defaults were unreachable. The two guards that remain
+		// (getAvatarScope above, canChangeMailAddress below) are NOT decoration:
+		// those methods are absent from the interface and only present on some
+		// implementations.
+		$lastLogin = $user->getLastLogin();
+		$backend = $user->getBackendClassName();
+		$canChangeDisplayName = $user->canChangeDisplayName();
 
 		$canChangeEmail = false;
 		if (method_exists($user, 'canChangeMailAddress') === true) {
 			$canChangeEmail = $user->canChangeMailAddress();
 		}
 
-		$canChangePassword = false;
-		if (method_exists($user, 'canChangePassword') === true) {
-			$canChangePassword = $user->canChangePassword();
-		}
-
-		$canChangeAvatar = false;
-		if (method_exists($user, 'canChangeAvatar') === true) {
-			$canChangeAvatar = $user->canChangeAvatar();
-		}
+		$canChangePassword = $user->canChangePassword();
+		$canChangeAvatar = $user->canChangeAvatar();
 
 		$result = [
 			'uid' => $user->getUID(),
@@ -478,10 +468,8 @@ class UserService {
 	 */
 	private function buildQuotaInformation(IUser $user): array {
 		try {
-			$userQuota = 'none';
-			if (method_exists($user, 'getQuota') === true) {
-				$userQuota = $user->getQuota();
-			}
+			// OCP\IUser declares getQuota(), so the 'none' default was dead.
+			$userQuota = $user->getQuota();
 
 			$usedSpace = 0;
 
@@ -741,12 +729,11 @@ class UserService {
 
 		foreach ($neededProperties as $propertyName => $apiField) {
 			try {
-				$property = $account->getProperty($propertyName);
-				if ($property !== null) {
-					$value = $property->getValue();
-					if (empty($value) === false) {
-						$additionalInfo[$apiField] = $value;
-					}
+				// No `!== null` check: getProperty() throws rather than returning
+				// null, and the surrounding catch already handles that.
+				$value = $account->getProperty($propertyName)->getValue();
+				if (empty($value) === false) {
+					$additionalInfo[$apiField] = $value;
 				}
 			} catch (\Exception $e) {
 				$this->logger->debug(
@@ -774,7 +761,6 @@ class UserService {
 	 */
 	private function updateStandardUserProperties(IUser $user, array $data): void {
 		if (isset($data['displayName']) === true
-			&& method_exists($user, 'canChangeDisplayName') === true
 			&& $user->canChangeDisplayName() === true
 		) {
 			$user->setDisplayName($data['displayName']);
@@ -788,7 +774,6 @@ class UserService {
 		}
 
 		if (isset($data['password']) === true
-			&& method_exists($user, 'canChangePassword') === true
 			&& $user->canChangePassword() === true
 		) {
 			$user->setPassword($data['password']);
@@ -838,7 +823,14 @@ class UserService {
 
 				$value = (string)$data[$apiField];
 
-				if ($account->getProperty($accountProperty) !== null) {
+				// IAccount::getProperty() THROWS PropertyDoesNotExistException when
+				// the property is absent — it never returns null. The `!== null`
+				// test that used to guard this block was therefore always true,
+				// which made the create-it fallback below UNREACHABLE: an unknown
+				// property escaped to the outer catch and abandoned the whole
+				// account update with a warning instead of being created. Catching
+				// the exception here is what actually reaches that fallback.
+				try {
 					$property = $account->getProperty($accountProperty);
 					if ($property->getValue() !== $value) {
 						$property->setValue($value);
@@ -846,6 +838,8 @@ class UserService {
 					}
 
 					continue;
+				} catch (PropertyDoesNotExistException $e) {
+					// Fall through to the create path below.
 				}
 
 				// Property doesn't exist, create it.
@@ -936,7 +930,7 @@ class UserService {
 	 */
 	public function changePassword(IUser $user, string $currentPassword, string $newPassword): array {
 		// Check backend capability.
-		if (method_exists($user, 'canChangePassword') === true && $user->canChangePassword() === false) {
+		if ($user->canChangePassword() === false) {
 			throw new RuntimeException(
 				'Password changes are not supported by your authentication backend',
 				409
@@ -982,7 +976,7 @@ class UserService {
 	 */
 	public function uploadAvatar(IUser $user, string $data, string $mimeType, int $size): array {
 		// Check backend capability.
-		if (method_exists($user, 'canChangeAvatar') === true && $user->canChangeAvatar() === false) {
+		if ($user->canChangeAvatar() === false) {
 			throw new RuntimeException(
 				'Avatar changes are not supported by your authentication backend',
 				409
@@ -1027,7 +1021,7 @@ class UserService {
 	 */
 	public function deleteAvatar(IUser $user): array {
 		// Check backend capability.
-		if (method_exists($user, 'canChangeAvatar') === true && $user->canChangeAvatar() === false) {
+		if ($user->canChangeAvatar() === false) {
 			throw new RuntimeException(
 				'Avatar changes are not supported by your authentication backend',
 				409

--- a/lib/Service/Vectorization/Handlers/EmbeddingGeneratorHandler.php
+++ b/lib/Service/Vectorization/Handlers/EmbeddingGeneratorHandler.php
@@ -290,7 +290,7 @@ class EmbeddingGeneratorHandler {
 				$error = curl_error($ch);
 				// No curl_close(): deprecated since PHP 8.0 and a no-op — the
 				// CurlHandle object is freed when it goes out of scope.
-				if ($error !== null && $error !== '') {
+				if ($error !== '') {
 					throw new Exception("Fireworks API request failed: {$error}");
 				}
 

--- a/lib/Service/Vectorization/Strategies/ObjectVectorizationStrategy.php
+++ b/lib/Service/Vectorization/Strategies/ObjectVectorizationStrategy.php
@@ -244,8 +244,9 @@ class ObjectVectorizationStrategy implements VectorizationStrategyInterface {
 			$description = $objectData['beschrijving'] ?? $objectData['summary'] ?? $objectData['_summary'] ?? '';
 		}
 
-		// Extract @self keys for logging.
-		$this->extractSelfKeys(objectData: $objectData);
+		// No "extract @self keys for logging" call here: extractSelfKeys() is
+		// pure, nothing consumed its result, and the metadata builder above
+		// already calls it for the '@self_keys' field that is actually stored.
 
 		// Extract register and schema IDs from multiple possible locations.
 		$selfData = $objectData['@self'] ?? [];

--- a/lib/Service/VectorizationService.php
+++ b/lib/Service/VectorizationService.php
@@ -304,8 +304,7 @@ class VectorizationService {
 						$embeddingData = $embeddings[$index] ?? null;
 
 						$hasEmbedding = $embeddingData !== null
-							&& (($embeddingData['embedding'] ?? null) !== null)
-							&& $embeddingData['embedding'] !== null;
+							&& (($embeddingData['embedding'] ?? null) !== null);
 						if ($hasEmbedding === true) {
 							$this->storeVector(
 								entity: $entity,

--- a/lib/Service/ViewPresentationService.php
+++ b/lib/Service/ViewPresentationService.php
@@ -383,7 +383,7 @@ class ViewPresentationService {
 				}
 			}
 
-			if (property_exists($object, 'id') === true && $object->getId() !== null) {
+			if ($object->getId() !== null) {
 				return (string)$object->getId();
 			}
 		}

--- a/lib/Tool/AbstractTool.php
+++ b/lib/Tool/AbstractTool.php
@@ -388,7 +388,7 @@ abstract class AbstractTool implements ToolInterface {
 					// Step 5c: Type-cast argument to match method signature.
 					// This ensures type safety when LLM provides loosely-typed values.
 					$type = $param->getType();
-					if ($type !== null && $type instanceof \ReflectionNamedType) {
+					if ($type instanceof \ReflectionNamedType) {
 						$typeName = $type->getName();
 
 						if ($typeName === 'int') {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -57,3 +57,19 @@ parameters:
         - '#should return [^ ]+ but returns ddn\\sapp\\(obj|value|pdfentry|buffer|bytes|str)\b#'
         - '#Parameter \$pdf_object of method ddn\\sapp\\PDFDoc::add_object\(\) expects ddn\\sapp\\PDFObject, ddn\\sapp\\obj given#'
         - '#Strict comparison using === between ddn\\sapp\\(obj|value|pdfentry) and false will always evaluate to false#'
+        # MultiTenancyTrait guards every log call with `isset($this->logger)`
+        # because a TRAIT cannot require a property — PHP has no abstract
+        # properties. Both classes using it today (SchemaMapper, MappingMapper)
+        # declare a non-nullable `LoggerInterface $logger`, so PHPStan resolves
+        # the guard per-using-class and calls it always-true (16 reports, 8 per
+        # class).
+        #
+        # The guard is NOT redundant in the trait's own terms: a future class
+        # using MultiTenancyTrait without declaring $logger would hit an
+        # undefined property, and isset() is what keeps that a skipped log line
+        # rather than a fatal. Scoped to the trait so it cannot mask the same
+        # shape anywhere else.
+        -
+            message: '#Property .+::\$logger \(Psr\\Log\\LoggerInterface\) in isset\(\) is not nullable#'
+            identifier: isset.property
+            path: lib/Db/MultiTenancyTrait.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -20,18 +20,6 @@ includes:
     - phpstan-baseline-nc34-ocp.neon
 
 parameters:
-    typeAliases:
-        # OCP declares `@psalm-type DataResponseType = ...` in the DataResponse
-        # class docblock and immediately uses it as a @template bound. PHPStan
-        # does not pick the alias up from that position and resolves the bound
-        # to a non-existent class `OCP\AppFramework\Http\DataResponseType`, so
-        # any `new JSONResponse(...)` whose payload it cannot fully verify is
-        # reported as argument.unresolvableType. This is a verbatim copy of the
-        # OCP alias, not a widening — it makes the generic bound resolvable
-        # instead of silencing the rule. Same entry procest carries; belongs in
-        # the shared base once a third app needs it.
-        DataResponseType: 'array|int|float|string|bool|object|null|\stdClass|\JsonSerializable'
-
     # App-specific only. The base already sets level, paths, bootstrapFiles,
     # excludePaths, scanDirectories and every fleet-wide ignore.
     excludePaths:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -20,6 +20,18 @@ includes:
     - phpstan-baseline-nc34-ocp.neon
 
 parameters:
+    typeAliases:
+        # OCP declares `@psalm-type DataResponseType = ...` in the DataResponse
+        # class docblock and immediately uses it as a @template bound. PHPStan
+        # does not pick the alias up from that position and resolves the bound
+        # to a non-existent class `OCP\AppFramework\Http\DataResponseType`, so
+        # any `new JSONResponse(...)` whose payload it cannot fully verify is
+        # reported as argument.unresolvableType. This is a verbatim copy of the
+        # OCP alias, not a widening — it makes the generic bound resolvable
+        # instead of silencing the rule. Same entry procest carries; belongs in
+        # the shared base once a third app needs it.
+        DataResponseType: 'array|int|float|string|bool|object|null|\stdClass|\JsonSerializable'
+
     # App-specific only. The base already sets level, paths, bootstrapFiles,
     # excludePaths, scanDirectories and every fleet-wide ignore.
     excludePaths:
@@ -104,3 +116,50 @@ parameters:
             message: '#Unreachable statement - code above always terminates#'
             identifier: deadCode.unreachable
             path: lib/Listener/FilesSidebarListener.php
+
+        # FlowNodePreflight catches BOTH UnexpectedValueException and
+        # InvalidArgumentException from a third-party node's validateConfig().
+        # The docblock at the call site sets out why: either is a defensible
+        # spelling of "this argument is wrong", and third-party nodes
+        # (openconnector, hermiq) pick whichever they like. Those node classes
+        # are not on the analysis path, so PHPStan only sees the in-tree nodes
+        # and concludes InvalidArgumentException is never thrown. Dropping the
+        # arm would reclassify a third-party node's REFUSAL as a crash.
+        -
+            message: '#Dead catch - InvalidArgumentException is never thrown in the try block#'
+            identifier: catch.neverThrown
+            path: lib/Service/Flow/FlowNodePreflight.php
+
+        # ConfigurationMapper::invalidateConfigurationCache() is an INTENTIONAL
+        # no-op: organisation lookup was pulled out of the mapper (services do
+        # not belong in mappers) and invalidation now happens in the service
+        # layer. The method and its three call sites are kept so the seam stays
+        # visible; PHPStan correctly observes the body has no side effects.
+        # Delete the method, its calls AND this ignore together if the seam is
+        # ever removed for good.
+        -
+            message: '#Method .+ConfigurationMapper::invalidateConfigurationCache\(\) returns void but does not have any side effects#'
+            identifier: void.pure
+            path: lib/Db/ConfigurationMapper.php
+
+        # SystemEntityObjectAdapter is a VIRTUAL ObjectEntity: it is only ever
+        # built by `new SystemEntityObjectAdapter(entity:, systemSlug:)` in
+        # SystemEntityNotificationListener, never hydrated from a database row.
+        # PHPStan flags its required constructor parameters because the parent
+        # (OCP Entity, via ObjectEntity) exposes fromRow()/fromParams() static
+        # factories that do `new static()` — a path this subclass never takes.
+        # Giving the parameters defaults would let a caller build a meaningless
+        # adapter with no entity and no slug, which is worse than the warning.
+        -
+            message: '#Parameter \#[12] \$(entity|systemSlug) of method .+SystemEntityObjectAdapter::__construct\(\) is not optional#'
+            identifier: parameter.notOptional
+            path: lib/Service/Notification/SystemEntityObjectAdapter.php
+
+        # OCP types IDBConnection::executeQuery()'s $params as `string[]`, but
+        # bound parameters are legitimately int/float/null too — the narrow stub
+        # does not describe the real contract. Belongs in the shared base the
+        # moment a second fleet app hits it; openregister is the only one today.
+        -
+            message: '#Parameter \#2 \$params of method OCP\\IDBConnection::executeQuery\(\) expects array<string>#'
+            identifier: argument.type
+            path: lib/Service/Vectorization/Handlers/VectorSearchHandler.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -73,3 +73,34 @@ parameters:
             message: '#Property .+::\$logger \(Psr\\Log\\LoggerInterface\) in isset\(\) is not nullable#'
             identifier: isset.property
             path: lib/Db/MultiTenancyTrait.php
+
+        # Same shape as the isset() guard above, reached through `?? null`
+        # instead of isset(): the trait cannot require the property, both using
+        # classes declare it non-nullable, so PHPStan resolves the coalesce
+        # per-using-class and calls the left side always-set.
+        -
+            message: '#Property .+::\$logger \(Psr\\Log\\LoggerInterface\) on left side of \?\? is not nullable#'
+            identifier: nullCoalesce.property
+            path: lib/Db/MultiTenancyTrait.php
+
+        # FilesSidebarListener is registered for OCA\Files\Event\LoadAdditional-
+        # ScriptsEvent and compares get_class($event) against that class-string
+        # DELIBERATELY, so the app carries no hard dependency on the Files app
+        # (see the comment at the call site). The class ships with an optional
+        # Nextcloud app and is therefore absent during analysis, so PHPStan
+        # narrows get_class() to class-string<Event>, concludes the comparison
+        # can never match, and then reports everything after the early return as
+        # unreachable.
+        #
+        # At runtime the comparison DOES match — the listener only ever fires for
+        # that event. Replacing the string compare with an instanceof would be a
+        # compile-time reference to the absent class, i.e. exactly the dependency
+        # the string compare exists to avoid. Scoped to this one file.
+        -
+            message: '#Strict comparison using !== between class-string and .OCA\\\\Files\\\\Event\\\\LoadAdditionalScriptsEvent. will always evaluate to true#'
+            identifier: notIdentical.alwaysTrue
+            path: lib/Listener/FilesSidebarListener.php
+        -
+            message: '#Unreachable statement - code above always terminates#'
+            identifier: deadCode.unreachable
+            path: lib/Listener/FilesSidebarListener.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -94,11 +94,6 @@
       <code><![CDATA[Uuid::v4()]]></code>
     </ImplicitToStringCast>
   </file>
-  <file src="lib/Db/Mapping.php">
-    <RedundantPropertyInitializationCheck>
-      <code><![CDATA[isset($this->id) === true]]></code>
-    </RedundantPropertyInitializationCheck>
-  </file>
   <file src="lib/Db/MultiTenancyTrait.php">
     <RedundantPropertyInitializationCheck>
       <code><![CDATA[$entity->getOrganisation() === null && isset($this->appConfig) === true]]></code>
@@ -385,19 +380,6 @@
       <code><![CDATA[?SetupHandler]]></code>
       <code><![CDATA[SetupHandler|null]]></code>
     </UndefinedClass>
-  </file>
-  <file src="lib/Service/Sync/HarvestPipelineService.php">
-    <StringIncrement>
-      <code><![CDATA[$summary['conflicts']]]></code>
-      <code><![CDATA[$summary['created']]]></code>
-      <code><![CDATA[$summary['errors']]]></code>
-      <code><![CDATA[$summary['unchanged']]]></code>
-      <code><![CDATA[$summary['unchanged']]]></code>
-      <code><![CDATA[$summary['updated']]]></code>
-    </StringIncrement>
-    <UnusedParam>
-      <code><![CDATA[$summary]]></code>
-    </UnusedParam>
   </file>
   <file src="lib/Service/TaskService.php">
     <UndefinedClass>

--- a/scripts/coverage-guard.php
+++ b/scripts/coverage-guard.php
@@ -5,6 +5,8 @@
  *
  * Usage:
  *   php scripts/coverage-guard.php <clover.xml> [--against=<clover.xml>]
+ *   php scripts/coverage-guard.php <clover.xml> --against=<clover.xml> --changed-files=<list>
+ *   php scripts/coverage-guard.php <clover.xml> --against=<clover.xml> --changed-files=<list> --deletion-neutral
  *   php scripts/coverage-guard.php <clover.xml> [--update-baseline]
  *   php scripts/coverage-guard.php --capabilities
  *
@@ -53,7 +55,16 @@ const CG_INPUT   = 2;
  * check that did not run looking exactly like one that passed. The probe turns
  * that into a loud failure.
  */
-const CG_CAPABILITIES = ['against', 'update-baseline', 'capabilities', 'changed-files'];
+const CG_CAPABILITIES = ['against', 'update-baseline', 'capabilities', 'changed-files', 'deletion-neutral'];
+
+/**
+ * Bucket key used for statements that could not be attributed to a method.
+ *
+ * It is a real key, present on both sides, so a file that falls back is compared
+ * exactly as it is today — conservatively, deletions included. It is never a way
+ * for a file to disappear from the comparison.
+ */
+const CG_WHOLE_FILE = '<whole file>';
 
 /**
  * Sum clover metrics for a named subset of files.
@@ -137,6 +148,242 @@ function cgMeasureFiles(string $file, string $label, array $only): array
 
     return [$statements, $covered, $percentage];
 }
+
+/**
+ * Attribute every statement in the named files to the METHOD it sits in.
+ *
+ * WHY BY METHOD NAME, AND WHY NOT BY LINE NUMBER.
+ *
+ * Clover identifies a statement only by its `num` — the line it sits on — and a
+ * deletion shifts every line after the cut. On launchpad#128's file, 117 of the
+ * 254 surviving statements (46%) sit at or after the deletion site, so matching
+ * base statement `num=310` to head statement `num=310` compares two unrelated
+ * lines across half the file and returns a confident, meaningless verdict. The
+ * test suite measures that directly on its fixture: a line-number intersection
+ * there reports 182/234 head against 189/234 base, i.e. a fabricated regression,
+ * where method-name attribution reconciles exactly at 183/254 on both sides.
+ * Method names survive the shift; line numbers do not.
+ *
+ * THE SHAPE CLOVER ACTUALLY EMITS, verified against 2 608 file entries in four
+ * real PHPUnit artifacts from this fleet:
+ *
+ *     <file name="/abs/path/Foo.php">
+ *       <class name="Foo"><metrics .../></class>
+ *       <line num="44" type="method" name="__construct" count="6"/>
+ *       <line num="48" type="stmt" count="6"/>
+ *       ...
+ *       <metrics statements="9" coveredstatements="9" methods="7" .../>
+ *     </file>
+ *
+ * `<line>` elements are FLAT and in document order; a `type="method"` line opens
+ * a method and every `type="stmt"` line after it belongs to that method until the
+ * next one. `metrics/@statements` counts the `stmt` lines only — methods are
+ * counted separately and `elements` is their sum — so summing attributed
+ * statements reproduces the file metric wherever the line data is complete.
+ *
+ * The bucket key is the REPO-RELATIVE path that matched, never the clover
+ * `name`. The two reports are produced from two different checkouts and their
+ * absolute paths differ, so keying on `name` would put every head bucket and
+ * every base bucket in disjoint namespaces and the intersection would be empty —
+ * which reads as "nothing to compare", i.e. a pass.
+ *
+ * TWO DEGENERATE SHAPES, BOTH HANDLED FAIL-CLOSED:
+ *
+ *  - A file whose metrics declare statements but which carries NO usable line
+ *    data (the `processUncoveredFiles` shape: PHPUnit counts a file it never
+ *    loaded). Attribution would measure it as 0/0 — an invisible pass on exactly
+ *    the file most likely to be untested. Such a file falls back to a single
+ *    CG_WHOLE_FILE bucket carrying its file-level metrics, the fallback is
+ *    printed by name, and cgCollapseFiles() then puts BOTH sides on the same
+ *    footing so the fallback cannot be mistaken for a deletion.
+ *  - Two methods of the same name in one file (two classes in one file, in
+ *    principle). Their statements are SUMMED into one bucket rather than
+ *    disambiguated by ordinal, because ordinals shift when one of them is
+ *    deleted. Summing keeps the bucket in the intersection, so deleting one of a
+ *    same-named pair is still charged against the change. Not seen in any of the
+ *    2 608 entries surveyed; handled so it cannot become a silent hole.
+ *
+ * @param string            $file  Clover report to read.
+ * @param string            $label Human label for error messages.
+ * @param array<int,string> $only  Repo-relative paths to include.
+ *
+ * @return array{0: array<string,array{0:int,1:int}>, 1: array<int,string>, 2: array<int,string>}
+ *         buckets keyed "<path>::<method>", the repo-relative paths this report
+ *         matched, and the paths that had to fall back to file-level metrics.
+ */
+function cgAttributeMethods(string $file, string $label, array $only): array
+{
+    if (file_exists($file) === false) {
+        fwrite(STDERR, "Error: {$label} clover file not found: {$file}\n");
+        exit(CG_INPUT);
+    }
+
+    $xml = @simplexml_load_file($file);
+    if ($xml === false) {
+        fwrite(STDERR, "Error: could not parse {$label} report {$file}\n");
+        exit(CG_INPUT);
+    }
+
+    $buckets  = [];
+    $matched  = [];
+    $fellBack = [];
+
+    foreach ($xml->xpath('//file') as $entry) {
+        $name = (string) $entry['name'];
+        if ($name === '') {
+            continue;
+        }
+
+        $path = null;
+        foreach ($only as $wanted) {
+            if (str_ends_with($name, $wanted) === true) {
+                $path = $wanted;
+                break;
+            }
+        }
+
+        if ($path === null) {
+            continue;
+        }
+
+        $matched[] = $path;
+
+        $method     = CG_WHOLE_FILE;
+        $statements = 0;
+        $covered    = 0;
+        $local      = [];
+
+        foreach ($entry->line as $line) {
+            $type = (string) $line['type'];
+
+            if ($type === 'method') {
+                $named  = (string) $line['name'];
+                $method = ($named === '' ? CG_WHOLE_FILE : $named);
+                continue;
+            }
+
+            if ($type !== 'stmt') {
+                continue;
+            }
+
+            $key = ($path . '::' . $method);
+            if (isset($local[$key]) === false) {
+                $local[$key] = [0, 0];
+            }
+
+            $local[$key][0]++;
+            $statements++;
+
+            if (((int) $line['count']) > 0) {
+                $local[$key][1]++;
+                $covered++;
+            }
+        }
+
+        $declared = (int) $entry->metrics['statements'];
+
+        if ($statements === 0 && $declared > 0) {
+            // No usable line data. Measuring 0/0 here would drop the file out of
+            // the comparison entirely, so fall back to the file metric and say so.
+            $fellBack[] = $path;
+            $local      = [
+                ($path . '::' . CG_WHOLE_FILE) => [$declared, (int) $entry->metrics['coveredstatements']],
+            ];
+            echo "    note: {$label} report carries no line data for {$path}; "
+                . "falling back to its file-level metric ({$entry->metrics['coveredstatements']}/{$declared}).\n";
+        } else if ($statements !== $declared) {
+            echo "    note: {$label} report declares {$declared} statement(s) for {$path} but emits "
+                . "{$statements} attributable line(s); the attributable ones are what is compared.\n";
+        }
+
+        foreach ($local as $key => $pair) {
+            if (isset($buckets[$key]) === false) {
+                $buckets[$key] = [0, 0];
+            }
+
+            $buckets[$key][0] += $pair[0];
+            $buckets[$key][1] += $pair[1];
+        }
+    }//end foreach
+
+    return [$buckets, array_values(array_unique($matched)), array_values(array_unique($fellBack))];
+}//end cgAttributeMethods()
+
+/**
+ * Collapse every bucket belonging to the named files into one per file.
+ *
+ * THIS IS THE HOLE THAT WRITING THE TESTS FOUND, and it is worth naming because
+ * it is the invisible-pass shape in its purest form. If one side of the
+ * comparison cannot be attributed to methods it falls back to a single
+ * CG_WHOLE_FILE bucket — but that bucket's key then exists on ONE side only, so
+ * the asymmetric rule classifies the entire base-side file as "deleted", drops
+ * it, finds nothing left to compare, and reports:
+ *
+ *     OK: none of the changed PHP existed at the merge base
+ *
+ * A file the guard could not read would have passed every possible drop. So when
+ * EITHER side falls back for a file, BOTH sides are collapsed to that file's
+ * single bucket: the key then exists on both sides, the file is compared exactly
+ * as the file-scoped mode compares it today, and the deletion penalty applies to
+ * it. Conservative, and visible in the output.
+ *
+ * @param array<string,array{0:int,1:int}> $buckets
+ * @param array<int,string>                $paths
+ *
+ * @return array<string,array{0:int,1:int}>
+ */
+function cgCollapseFiles(array $buckets, array $paths): array
+{
+    if (empty($paths) === true) {
+        return $buckets;
+    }
+
+    $collapse = array_fill_keys($paths, true);
+    $out      = [];
+
+    foreach ($buckets as $key => $pair) {
+        $split = strrpos($key, '::');
+        $path  = ($split === false ? $key : substr($key, 0, $split));
+
+        if (isset($collapse[$path]) === true) {
+            $key = ($path . '::' . CG_WHOLE_FILE);
+        }
+
+        if (isset($out[$key]) === false) {
+            $out[$key] = [0, 0];
+        }
+
+        $out[$key][0] += $pair[0];
+        $out[$key][1] += $pair[1];
+    }
+
+    return $out;
+}//end cgCollapseFiles()
+
+/**
+ * Sum a bucket map, optionally restricted to a set of keys.
+ *
+ * @param array<string,array{0:int,1:int}> $buckets
+ * @param array<string,bool>|null          $keep    Keys to include, or null for all.
+ *
+ * @return array{0:int,1:int} statements, covered
+ */
+function cgSumBuckets(array $buckets, ?array $keep = null): array
+{
+    $statements = 0;
+    $covered    = 0;
+
+    foreach ($buckets as $key => $pair) {
+        if ($keep !== null && isset($keep[$key]) === false) {
+            continue;
+        }
+
+        $statements += $pair[0];
+        $covered    += $pair[1];
+    }
+
+    return [$statements, $covered];
+}//end cgSumBuckets()
 
 /**
  * Read the changed-file list, keeping only PHP files the guard can measure.
@@ -299,6 +546,15 @@ $cloverFile   = ($positional[0] ?? 'coverage/clover.xml');
 $baselineFile = (__DIR__ . '/../.coverage-baseline');
 $against      = ($options['against'] ?? null);
 $changedList  = ($options['changed-files'] ?? null);
+$deletionFree = isset($options['deletion-neutral']);
+
+// A flag that is accepted and ignored is the silent-downgrade shape this script's
+// `--capabilities` probe exists to prevent, so refuse rather than fall through to
+// a comparison the caller did not ask for.
+if ($deletionFree === true && (is_string($changedList) === false || $changedList === '')) {
+    fwrite(STDERR, "Error: --deletion-neutral requires --changed-files (and therefore --against). It refines the file-scoped comparison; it has no meaning against the whole project.\n");
+    exit(CG_INPUT);
+}
 
 // ── scoped mode: compare ONLY the PHP the change touched ────────────────────
 //
@@ -320,6 +576,153 @@ if (is_string($changedList) === true && $changedList !== '') {
     }
 
     echo 'Scoped to ' . count($changed) . " changed PHP file(s).\n";
+
+    // ── deletion-neutral mode ───────────────────────────────────────────────
+    //
+    // WHAT THIS FIXES. `cgRatioDropped()` is a single integer cross-product with
+    // no tolerance, so the file-scoped ratchet demands, exactly:
+    //
+    //     the code you touched must be at least as well covered as the code you
+    //     did not.
+    //
+    // For ADDITIONS that is right, and it earns its keep: openconnector#1265
+    // covered 27 of 54 new statements against a 61.86% floor, needed 34, and
+    // writing the missing seven is what exposed a cascade that deleted nothing
+    // and reported success.
+    //
+    // For DELETIONS it INVERTS. Removing `d` statements of which `c` were covered
+    // lowers the ratio whenever c/d exceeds the ratio of what remains — i.e.
+    // whenever the deleted code was better tested than average. And dead code is
+    // dead because nothing CALLS it, not because nothing TESTED it: gate-57
+    // (orphaned-write-capability) exists to find precisely that code, so gate-57
+    // and this ratchet are in arithmetic opposition, not tension. Such a pull
+    // request cannot satisfy the ratchet from inside its own subject at all —
+    // the only moves are delete less, add filler, or delete additional
+    // *uncovered* statements until it balances. The gate can be satisfied by
+    // deleting more code and cannot be satisfied by testing anything.
+    //
+    // Measured, both blocked by the file-scoped rule:
+    //   opencatalogi#895  head 112/115 (97.39%)  base 148/151 (98.01%)  -0.62%
+    //   launchpad#128     head 183/254 (72.05%)  base 220/304 (72.37%)  -0.32%
+    //
+    // THE RULE, AND IT IS ASYMMETRIC ON PURPOSE:
+    //
+    //     drop BASE-ONLY methods (deletions) from the base side;
+    //     KEEP HEAD-ONLY methods (additions) on the head side.
+    //
+    // The symmetric version — "compare over statements present in both reports" —
+    // is the obvious one and it is broken. It also drops head-only statements, so
+    // a change adding 40 new statements with 0 of them covered compares an empty
+    // set to an empty set and PASSES. That is the openconnector#1265 shape, and
+    // the symmetric rule would have retired the half of this ratchet that works.
+    // A mutant reintroducing it is in the test suite and must stay there.
+    //
+    // Consequences, all four measured in quality-config/tests/test-coverage-guard.py:
+    //   pure deletion (opencatalogi) PASS  112/115 vs 112/115 — exactly neutral
+    //   pure deletion (launchpad)    PASS  183/254 vs 183/254
+    //   regression in survivors      FAIL  180/254 vs 183/254
+    //   new untested code            FAIL  183/294 (62.24%) vs 183/254 (72.05%)
+    //
+    // KNOWN RESIDUAL, stated rather than discovered: a RENAME reads as a delete
+    // plus an add. The old name leaves the base side, the new name arrives on the
+    // head side and must be covered. That is the right incentive — a renamed
+    // method is new code as far as the test suite is concerned — but it means a
+    // pure rename of a well-covered method is not free, and an author who did not
+    // expect it will read the failure as noise. It is documented here and in the
+    // failure message so it is legible when it happens.
+    if ($deletionFree === true) {
+        [$headBuckets, $headFiles, $headFellBack] = cgAttributeMethods($cloverFile, 'current', $changed);
+        [$baseBuckets, $baseFiles, $baseFellBack] = cgAttributeMethods($against, 'merge-base', $changed);
+
+        // Either side falling back forces BOTH sides to file level for that file —
+        // see cgCollapseFiles() for why anything else is an invisible pass.
+        $collapse = array_values(array_unique(array_merge($headFellBack, $baseFellBack)));
+        if (empty($collapse) === false) {
+            echo 'Falling back to file-level metrics on both sides for: ' . implode(', ', $collapse) . "\n";
+            $headBuckets = cgCollapseFiles($headBuckets, $collapse);
+            $baseBuckets = cgCollapseFiles($baseBuckets, $collapse);
+        }
+
+        echo 'Deletion-neutral: attributed by method name (head ' . count($headFiles) . ' file(s), '
+            . 'base ' . count($baseFiles) . ' file(s), ' . count($headBuckets) . ' head method(s), '
+            . count($baseBuckets) . " base method(s)).\n";
+
+        // A changed file the base measured and the head did not is normally a
+        // DELETED file, and treating it as deleted is the point of this mode. But
+        // it is also what an accidental coverage exclusion looks like, and the two
+        // are indistinguishable from here — so it is said out loud rather than
+        // absorbed silently.
+        $goneFiles = array_values(array_diff($baseFiles, $headFiles));
+        if (empty($goneFiles) === false) {
+            echo 'Measured at the merge base and absent from the head report: '
+                . implode(', ', $goneFiles) . "\n";
+            echo "    Treated as deleted. If one of those files still exists, it has been dropped from\n";
+            echo "    coverage measurement and that is the thing to fix, not this guard.\n";
+        }
+
+        if (empty($headBuckets) === true && empty($baseBuckets) === true) {
+            echo "OK: none of the changed PHP files appear in either coverage report.\n";
+            echo "    Nothing was measured, so nothing is claimed about them.\n";
+            exit(CG_OK);
+        }
+
+        $keep = [];
+        foreach ($headBuckets as $key => $unused) {
+            $keep[$key] = true;
+        }
+
+        $dropped = [];
+        foreach ($baseBuckets as $key => $pair) {
+            if (isset($keep[$key]) === false) {
+                $dropped[$key] = $pair;
+            }
+        }
+
+        [$statements, $covered]         = cgSumBuckets($headBuckets);
+        [$baseStatements, $baseCovered] = cgSumBuckets($baseBuckets, $keep);
+
+        $current = ($statements > 0 ? round((($covered / $statements) * 100), 2) : 0.0);
+        $base    = ($baseStatements > 0 ? round((($baseCovered / $baseStatements) * 100), 2) : 0.0);
+
+        if (empty($dropped) === false) {
+            [$droppedStatements, $droppedCovered] = cgSumBuckets($dropped);
+            echo 'Removed from the base side: ' . count($dropped)
+                . " method(s) absent from head, {$droppedCovered}/{$droppedStatements} statements.\n";
+            echo "    A method that no longer exists is not a coverage regression; it is deleted code.\n";
+        }
+
+        cgReport('Surviving code, head:', $statements, $covered, $current);
+        cgReport('Surviving code, base:', $baseStatements, $baseCovered, $base);
+
+        if ($baseStatements === 0) {
+            echo "OK: none of the changed PHP existed at the merge base, so there is no prior figure to drop below.\n";
+            exit(CG_OK);
+        }
+
+        if (cgRatioDropped($covered, $statements, $baseCovered, $baseStatements) === true) {
+            $delta = round(($base - $current), 2);
+            echo($delta > 0
+                ? "FAIL: coverage of the code this change KEEPS or ADDS dropped by {$delta}%.\n"
+                : "FAIL: coverage of the code this change KEEPS or ADDS dropped by less than 0.01% — too "
+                . "little to show in the percentage, but a real loss in the counts below.\n");
+            echo "      base {$baseCovered}/{$baseStatements} -> head {$covered}/{$statements} statements, "
+                . "comparing only methods that exist on BOTH sides plus everything new on this branch.\n";
+
+            if ($statements > $baseStatements) {
+                $added = ($statements - $baseStatements);
+                echo "      This change adds {$added} statements to those files. Adding code without tests drops coverage.\n";
+            }
+
+            echo "      Deleted methods were already excluded, so this is not a deletion penalty. If you\n";
+            echo "      RENAMED a method, note that a rename reads as a delete plus an add: the new name is\n";
+            echo "      new code here and has to be covered.\n";
+
+            exit(CG_DROPPED);
+        }
+
+        echo "OK: coverage of the surviving and added code did not drop.\n";
+        exit(CG_OK);
+    }//end if
 
     [$statements, $covered, $current]             = cgMeasureFiles($cloverFile, 'current', $changed);
     [$baseStatements, $baseCovered, $base]        = cgMeasureFiles($against, 'merge-base', $changed);

--- a/tests/Unit/Service/UserServiceAccountPropertyCreationTest.php
+++ b/tests/Unit/Service/UserServiceAccountPropertyCreationTest.php
@@ -1,0 +1,227 @@
+<?php
+
+/**
+ * UserService account-property creation tests.
+ *
+ * Covers the branch in updateProfileProperties() that CREATES an account
+ * property the user has never set before. That path was unreachable until
+ * openregister#2697: the code guarded on `$account->getProperty($p) !== null`,
+ * but IAccount::getProperty() is declared `: IAccountProperty` and signals a
+ * missing property by THROWING PropertyDoesNotExistException — so the guard
+ * was always true, the `continue` always ran, and the create call below it
+ * never executed. The exception escaped to the method's outer catch, which
+ * logged a warning and abandoned the WHOLE account update, silently dropping
+ * the other fields in the same request.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service;
+
+use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCA\OpenRegister\Service\UserService;
+use OCP\Accounts\IAccount;
+use OCP\Accounts\IAccountManager;
+use OCP\Accounts\IAccountProperty;
+use OCP\Accounts\PropertyDoesNotExistException;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IAvatarManager;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use OCP\L10N\IFactory;
+use OCP\Security\ISecureRandom;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests that a never-before-set profile field is created rather than dropped.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) UserService takes 13 collaborators.
+ * @SuppressWarnings(PHPMD.TooManyFields)          One property per collaborator.
+ */
+class UserServiceAccountPropertyCreationTest extends TestCase {
+	private UserService $service;
+	private IUserManager&MockObject $userManager;
+	private IUserSession&MockObject $userSession;
+	private IConfig&MockObject $config;
+	private IGroupManager&MockObject $groupManager;
+	private IAccountManager&MockObject $accountManager;
+	private LoggerInterface&MockObject $logger;
+
+	/**
+	 * Wire UserService with mocked collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->accountManager = $this->createMock(IAccountManager::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		// updateUserProperties() snapshots the user via buildUserDataArray()
+		// before it touches anything, which reads the group list.
+		$this->groupManager->method('getUserGroups')->willReturn([]);
+
+		$this->service = new UserService(
+			$this->userManager,
+			$this->userSession,
+			$this->config,
+			$this->groupManager,
+			$this->accountManager,
+			$this->logger,
+			$this->createMock(OrganisationService::class),
+			$this->createMock(IEventDispatcher::class),
+			$this->createMock(IAvatarManager::class),
+			$this->createMock(AuditTrailMapper::class),
+			$this->createMock(ISecureRandom::class),
+			$this->createMock(IDBConnection::class),
+			$this->createMock(IFactory::class)
+		);
+	}//end setUp()
+
+	/**
+	 * Build a user whose display name and password are not being changed.
+	 *
+	 * @return IUser&MockObject The user under test.
+	 */
+	private function user(): IUser&MockObject {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('jan');
+		$user->method('canChangeDisplayName')->willReturn(false);
+		$user->method('canChangePassword')->willReturn(false);
+
+		return $user;
+	}//end user()
+
+	/**
+	 * A profile field the user has never set before is CREATED.
+	 *
+	 * This is the regression test for the unreachable create path: with the old
+	 * `!== null` guard the account manager received no setProperty() call at all
+	 * and updateAccount() was never reached.
+	 *
+	 * @return void
+	 */
+	public function testAProfileFieldTheUserHasNeverSetIsCreated(): void {
+		$user = $this->user();
+
+		$account = $this->createMock(IAccount::class);
+		// The property does not exist yet — the real IAccount throws here.
+		$account->method('getProperty')
+			->willThrowException(new PropertyDoesNotExistException('phone'));
+
+		$account->expects($this->once())
+			->method('setProperty')
+			->with(
+				IAccountManager::PROPERTY_PHONE,
+				'+31 6 12345678',
+				$this->anything(),
+				IAccountManager::NOT_VERIFIED
+			);
+
+		$this->accountManager->method('getAccount')->willReturn($account);
+		$this->accountManager->expects($this->once())->method('updateAccount')->with($account);
+
+		$result = $this->service->updateUserProperties($user, ['phone' => '+31 6 12345678']);
+
+		$this->assertTrue($result['success'], 'Creating a new profile property must report success');
+	}//end testAProfileFieldTheUserHasNeverSetIsCreated()
+
+	/**
+	 * A field the user already has is UPDATED in place, not re-created.
+	 *
+	 * The must-FAIL control for the test above: if the create path ran
+	 * unconditionally, setProperty() would fire here too.
+	 *
+	 * @return void
+	 */
+	public function testAnExistingProfileFieldIsUpdatedInPlace(): void {
+		$user = $this->user();
+
+		$property = $this->createMock(IAccountProperty::class);
+		$property->method('getValue')->willReturn('old value');
+		$property->expects($this->once())->method('setValue')->with('new value');
+
+		$account = $this->createMock(IAccount::class);
+		$account->method('getProperty')->willReturn($property);
+		$account->expects($this->never())->method('setProperty');
+
+		$this->accountManager->method('getAccount')->willReturn($account);
+		$this->accountManager->expects($this->once())->method('updateAccount')->with($account);
+
+		$result = $this->service->updateUserProperties($user, ['phone' => 'new value']);
+
+		$this->assertTrue($result['success']);
+	}//end testAnExistingProfileFieldIsUpdatedInPlace()
+
+	/**
+	 * One missing property does not abandon the other fields in the request.
+	 *
+	 * This is the user-visible half of the bug: the escaping exception aborted
+	 * the whole loop, so a request setting three fields persisted none of them
+	 * as soon as one of them was new.
+	 *
+	 * @return void
+	 */
+	public function testAMissingPropertyDoesNotDiscardTheOtherFieldsInTheSameRequest(): void {
+		$user = $this->user();
+
+		$existing = $this->createMock(IAccountProperty::class);
+		$existing->method('getValue')->willReturn('old');
+		$existing->expects($this->once())->method('setValue')->with('https://example.org');
+
+		$account = $this->createMock(IAccount::class);
+		// `phone` is new (throws); `website` already exists (returns).
+		$account->method('getProperty')->willReturnCallback(
+			static function (string $property) use ($existing): IAccountProperty {
+				if ($property === IAccountManager::PROPERTY_PHONE) {
+					throw new PropertyDoesNotExistException($property);
+				}
+
+				return $existing;
+			}
+		);
+
+		$account->expects($this->once())
+			->method('setProperty')
+			->with(IAccountManager::PROPERTY_PHONE, '+31 6 12345678', $this->anything(), IAccountManager::NOT_VERIFIED);
+
+		$this->accountManager->method('getAccount')->willReturn($account);
+		$this->accountManager->expects($this->once())->method('updateAccount')->with($account);
+
+		$result = $this->service->updateUserProperties(
+			$user,
+			[
+				'phone' => '+31 6 12345678',
+				'website' => 'https://example.org',
+			]
+		);
+
+		$this->assertTrue($result['success']);
+	}//end testAMissingPropertyDoesNotDiscardTheOtherFieldsInTheSameRequest()
+}//end class

--- a/tests/stubs/NextcloudInternalStubs.php
+++ b/tests/stubs/NextcloudInternalStubs.php
@@ -199,8 +199,42 @@ if (class_exists(\OC::class) === false) {
             public function getServerProtocol(): string { return "HTTP/1.1"; }
             public function getServerHost(): string { return "localhost"; }
             public function getInsecureServerHost(): string { return "localhost"; }
+            // Added to OCP\IRequest in Nextcloud 34. Without them the anonymous
+            // class is abstract and instantiating it is a FATAL that aborts the
+            // whole unit run partway through, which reads as a hang rather than
+            // as a failing test.
+            public function throwDecodingExceptionIfAny(): void { }
+            public function getFormat(): ?string { return null; }
         };
         return $req;
+    });
+
+    // Nextcloud 34 made Response::getHeaders() resolve IUserSession from the
+    // container to stamp an X-User-Id header, and Response::cacheFor() resolve
+    // ITimeFactory. Neither was registered here, so ANY test that read a
+    // response header or set a cache lifetime died on "getUser()/getTime() on
+    // null" — 30 of them. Anonymous classes rather than interface
+    // implementations, matching the note above: the stub must survive a
+    // signature change in either interface.
+    OC::$server->registerService(\OCP\IUserSession::class, function() {
+        return new class {
+            /** @return mixed Always null: unit tests run unauthenticated. */
+            public function getUser() { return null; }
+            public function isLoggedIn(): bool { return false; }
+        };
+    });
+
+    OC::$server->registerService(\OCP\AppFramework\Utility\ITimeFactory::class, function() {
+        return new class {
+            public function getTime(): int { return 1700000000; }
+            public function getDateTime(string $type = "now", ?\DateTimeZone $timezone = null): \DateTime {
+                return new \DateTime("@1700000000");
+            }
+            public function now(): \DateTimeImmutable { return new \DateTimeImmutable("@1700000000"); }
+            public function getTimeZone(?string $timezone = null): \DateTimeZone {
+                return new \DateTimeZone($timezone ?? "UTC");
+            }
+        };
     });
 
     // Pre-register a minimal IFactory (L10N factory) so OCP\Util::addInitScript()
@@ -305,6 +339,46 @@ if (interface_exists(\OC\Authentication\Token\IToken::class) === false) {
 if (class_exists(\OC\AppFramework\Http\Request::class) === false) {
 	eval('namespace OC\AppFramework\Http;
     class Request {}');
+}//end if
+
+// -----------------------------------------------------------------
+// OC\Security\CSP\ContentSecurityPolicyNonceManager
+//
+// GraphQLController type-hints this internal server class to obtain the CSP
+// nonce for the GraphiQL shell. It is not part of nextcloud/ocp, so
+// createMock() on it threw UnknownTypeException and the three explorer tests
+// could never run.
+// -----------------------------------------------------------------
+if (class_exists(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class) === false) {
+	eval('namespace OC\Security\CSP;
+    class ContentSecurityPolicyNonceManager {
+        public function getNonce(): string { return ""; }
+    }');
+}//end if
+
+// -----------------------------------------------------------------
+// OC\Security\CSRF\CsrfToken + CsrfTokenManager
+//
+// Same story as the nonce manager above: GraphQLController type-hints these
+// internal server classes to stamp a request token into the GraphiQL fetcher.
+// -----------------------------------------------------------------
+if (class_exists(\OC\Security\CSRF\CsrfToken::class) === false) {
+	eval('namespace OC\Security\CSRF;
+    class CsrfToken {
+        public function getName(): string { return ""; }
+        public function getValue(): string { return ""; }
+        public function getEncryptedValue(): string { return ""; }
+    }');
+}//end if
+
+if (class_exists(\OC\Security\CSRF\CsrfTokenManager::class) === false) {
+	eval('namespace OC\Security\CSRF;
+    class CsrfTokenManager {
+        public function getToken(): CsrfToken { return new CsrfToken(); }
+        public function refreshToken(): CsrfToken { return new CsrfToken(); }
+        public function removeToken(): void { }
+        public function isTokenValid(CsrfToken $token): bool { return true; }
+    }');
 }//end if
 
 // -----------------------------------------------------------------


### PR DESCRIPTION
Migrates openregister to PHPStan 2 (`phpstan/phpstan: ^2.0`, `conduction/hydra-gates: ^1.8.2`) and takes the resulting findings from **229 to 0**.

Seven commits, each independently verified. Unit suite goes from **aborting at 531 tests** to **16,854 passing**.

## Three real bugs the lint work uncovered

**1. A saved view's search term was sent to the backend twice.** `SearchQueryHandler` assigned `$query['_search'] = $searchTerms` *above* its own `isset()/empty()` guard, so the guard always passed and appended the same terms again. A view searching for `invoice` queried for `invoice invoice`.

**2. Profile fields that had never been set could not be created.** `UserService::updateAccountManagerProperties()` guarded on `$account->getProperty($p) !== null`. `IAccount::getProperty()` is declared `: IAccountProperty` and *throws* when the property is absent — it never returns null. So the guard was always true and the "create it" fallback below was unreachable: an unknown property escaped to the method's outer catch, which logged a warning and abandoned the **entire** account update, silently dropping the other fields in the same request.

**3. `Flow::setComment()` was a call to an undefined method** as far as static analysis was concerned. `Db\Flow` declares 46 `@method` pairs for its magic accessors, but `comment` was added as a property without one. Runtime was fine; the annotation was missing.

## The local unit suite was dead

Running it aborted at 531 of 16,854 tests with a fatal: NC 34 added two methods to `OCP\IRequest` that the anonymous test stub did not implement. NC 34 also made `Response::getHeaders()` resolve `IUserSession` and `cacheFor()` resolve `ITimeFactory`, neither of which `tests/stubs` registered, and three more tests could not construct mocks of internal server classes absent from `nextcloud/ocp`.

This was local-only — the whole stub block sits behind `class_exists(\OC::class) === false`, so CI (which boots a real server) never saw it. That is exactly the divergence worth closing: **16,323 tests were unverifiable on a developer machine.** Every stub added is itself guarded by `class_exists()`, so it stays inert where the real class is present.

## 25 endpoints were missing their 403 from the published API spec

`composer.json` wires `openapi` to `generate-spec` and `openapi.json` is committed, so the `@psalm-return` annotations are not decoration. Twenty-five admin-guarded endpoints return `403 {"error": "Admin privileges required"}` that their annotation never listed — the spec has been missing it since the SEC-CTRL guards were added. Two sibling endpoints that share the same annotation shape but have **no** admin guard were deliberately left alone rather than bulk-edited, so the spec does not advertise a 403 that cannot occur.

## The rest

- **~150 provably-dead guards removed.** `isset($x) && $x !== null` (isset is already false for null), `!== null` on values the callee's signature forbids from being null, `method_exists()` on interface methods, `instanceof` re-checks after a typed return. The probes that *do* protect something are kept and now say so — `getAvatarScope` and `canChangeMailAddress` are genuinely absent from `OCP\IUser`, `setErrors` from `Event`, `findAllByObject` from `AuditTrailMapper`. Those sat next to the dead ones, which is why the block read as uniformly defensive.
- **7 docblocks pointed at classes that do not exist.** `@psalm-return list<OCA\OpenRegister\Db\Agent>` has no leading backslash, so inside `namespace OCA\OpenRegister\Db` it resolved to `OCA\OpenRegister\Db\OCA\OpenRegister\Db\Agent`. The `@return` line directly above each was correctly backslashed, which is why it went unnoticed.
- **Stale generated shapes re-derived, or deliberately loosened.** `RelationHandler::getUsedBy()` still declared `total: 0` from when it was a stub. Two controllers restated an entity's `jsonSerialize()` field by field and had drifted; those now declare `array<string, mixed>` with the reason recorded, because copying an entity contract into a controller docblock guarantees the copy rots again.
- **Key-type corrections.** Several maps documented as `array<string, …>` are really `array<int|string, …>` — PHP coerces canonical numeric-string keys to int. In `RenderObject` this had PHPStan reporting the per-file tag loop as iterating an always-empty array; it does not, because PHP applies the same coercion on lookup.
- **Two dead properties removed** and **six `object` type hints narrowed** to the entity they actually receive.

## Six scoped ignores, each with its reason written next to it

`FilesSidebarListener`'s `get_class()` comparison (deliberate, to avoid a hard dependency on the optional Files app — an `instanceof` would be exactly the dependency it exists to avoid), `FlowNodePreflight`'s `InvalidArgumentException` arm (third-party nodes are off the analysis path), `ConfigurationMapper`'s intentional no-op cache seam, OCP's too-narrow `executeQuery()` `$params` stub, `SystemEntityObjectAdapter`'s required constructor args, and the `??` sibling of the existing `MultiTenancyTrait` `$logger` ignore.

## Verification

- `phpstan`: 229 → **0**
- `phpcs`: clean
- Unit suite: **16,854 pass**, 0 errors, 0 failures
- One deliberate must-FAIL control run during the work: flipping a predicate to fail-open turned the relevant test red, confirming the suite can detect the regression it claims to cover.