### PR TITLE
feat(flow): a `reference` config field, and a form that widens rather than narrows

### DIFF
--- a/lib/Service/Flow/FlowNodePreflight.php
+++ b/lib/Service/Flow/FlowNodePreflight.php
@@ -821,6 +821,12 @@ class FlowNodePreflight {
 	 */
 	private function declaredKeys(IFlowNode $node): ?array {
 		if (($node instanceof IFlowNodeConfigKeys) === false) {
+			// A node that describes a FORM but declares no vocabulary stays
+			// unchecked. A form may be partial by design
+			// ({@see IFlowNodeConfigForm}), so its field list is a subset of
+			// what the node reads, and treating a subset as the whole would
+			// reject keys the node handles perfectly well. Only configKeys()
+			// claims completeness, so only configKeys() can gate.
 			return null;
 		}
 
@@ -837,8 +843,60 @@ class FlowNodePreflight {
 			return null;
 		}
 
-		return array_map(static fn ($key): string => (string)$key, (array)$known);
+		$keys = array_map(static fn ($key): string => (string)$key, (array)$known);
+
+		// UNION with the node's own form, never a substitute for it.
+		//
+		// The two declarations can disagree: a node that grows a form field
+		// and forgets the matching configKeys() entry would have the EDITOR
+		// writing a key the PREFLIGHT then refuses — the dialog and the save
+		// contradicting each other over the same node, with the operator in
+		// between and nothing on screen explaining why. Whichever of the two
+		// the author got wrong, refusing a key the node's own form offers is
+		// the worse failure, so the form widens the vocabulary and never
+		// narrows it.
+		return array_values(array_unique(array_merge($keys, $this->formKeys(node: $node))));
 	}//end declaredKeys()
+
+	/**
+	 * The config keys a node's own edit form writes, if it describes one.
+	 *
+	 * @param IFlowNode $node The resolved node.
+	 *
+	 * @return array<int, string> The keys, empty when there is no form.
+	 *
+	 * @spec openspec/specs/flow-engine/spec.md#requirement-a-node-type-declares-its-own-form-and-its-own-run-log-actions
+	 */
+	private function formKeys(IFlowNode $node): array {
+		if (($node instanceof IFlowNodeConfigForm) === false) {
+			return [];
+		}
+
+		try {
+			$fields = $node->configForm();
+		} catch (Throwable $e) {
+			// Same rule as configKeys() above: one node whose metadata throws
+			// cannot be allowed to make the instance unsavable.
+			$this->logger->warning(
+				message: '[FlowNodePreflight] A node\'s configForm() failed, ignoring it for the dialect check: '
+					. $e->getMessage(),
+				context: ['file' => __FILE__, 'line' => __LINE__, 'node' => get_class($node)]
+			);
+			return [];
+		}
+
+		$keys = [];
+		foreach ((array)$fields as $field) {
+			$key = trim((string)(((array)$field)['key'] ?? ''));
+			if ($key === '') {
+				continue;
+			}
+
+			$keys[] = $key;
+		}
+
+		return $keys;
+	}//end formKeys()
 
 	/**
 	 * Split a step's config keys into the ones nothing will read.

--- a/lib/Service/Flow/IFlowNodeConfigForm.php
+++ b/lib/Service/Flow/IFlowNodeConfigForm.php
@@ -57,7 +57,8 @@ interface IFlowNodeConfigForm {
 	 *                       actually reads — a field over a key the node
 	 *                       ignores looks like it works and changes nothing.
 	 *   label       string  Translated, because it is shown to an operator.
-	 *   type        string  `text`, `textarea`, `number`, `boolean`, `select`.
+	 *   type        string  `text`, `textarea`, `number`, `boolean`, `select`,
+	 *                       `reference`.
 	 *   help        string  Optional. What the value means, not what it is.
 	 *   required    bool    Optional. Whether the node needs it to run.
 	 *   optionsFrom string  Optional. A REFERENCE the providing app resolves —
@@ -66,12 +67,42 @@ interface IFlowNodeConfigForm {
 	 *                       and changes without the node being redeployed, and
 	 *                       baking today's list into the node's declaration
 	 *                       would freeze it there.
+	 *   reference   array   Required when `type` is `reference`, meaningless
+	 *                       otherwise. `['register' => …, 'schema' => …]`,
+	 *                       each a slug or id. See below.
+	 *
+	 * THE `reference` TYPE, AND WHY IT IS NOT JUST ANOTHER `optionsFrom`
+	 * -----------------------------------------------------------------
+	 * `optionsFrom` names an ENDPOINT that lists a catalogue — the registers,
+	 * the sources. It answers "which of the app's own things is this?" and the
+	 * editor only has to fetch the URL it was handed.
+	 *
+	 * `reference` names an OBJECT inside a register/schema pair. The value
+	 * stored is that object's id, and the list to choose it from is the
+	 * objects of that schema — a query the editor can only build once it knows
+	 * BOTH halves, which is why they travel together in one entry instead of
+	 * as two loose strings.
+	 *
+	 * The distinction is worth the extra type because of what it removes: a
+	 * key whose value is an object id has, until now, been drawn as a bare
+	 * text box. An operator pasting a uuid into it has no way to tell a typo
+	 * from a correct value, and neither does the save — the node fails at RUN
+	 * time, in a log, long after the dialog closed. A field that knows which
+	 * schema its value comes from can offer the objects that exist.
 	 *
 	 * A key with no field is still editable through the raw-JSON pane. That is
 	 * deliberate: a partial form is more useful than none, and it lets a node
 	 * describe the two fields worth guiding and leave the rest.
 	 *
+	 * ⚠️ BECAUSE A FORM MAY BE PARTIAL, IT IS NOT A VOCABULARY. `configKeys()`
+	 * says which keys a node reads; this says how some of them are edited.
+	 * `FlowNodePreflight` unions the two rather than substituting one for the
+	 * other, precisely so that describing two fields out of six cannot start
+	 * rejecting the other four.
+	 *
 	 * @return array<int, array<string, mixed>> The field descriptions.
+	 *
+	 * @spec openspec/specs/flow-engine/spec.md#requirement-a-node-type-declares-its-own-form-and-its-own-run-log-actions
 	 */
 	public function configForm(): array;
 }//end interface

--- a/tests/Unit/Service/Flow/FlowNodeConfigFormReferenceTest.php
+++ b/tests/Unit/Service/Flow/FlowNodeConfigFormReferenceTest.php
@@ -1,0 +1,436 @@
+<?php
+
+/**
+ * The `reference` field type, and what a node's FORM may and may not do to its
+ * preflight.
+ *
+ * TWO DECLARATIONS, ONE NODE. `configKeys()` says which keys a node reads and
+ * claims to be COMPLETE — the preflight refuses anything outside it.
+ * `configForm()` says how some of them are edited and is explicitly allowed to
+ * be PARTIAL. Everything here is about keeping the second from being read as
+ * the first, in either direction:
+ *
+ *   - a partial form must not narrow the vocabulary, or describing two fields
+ *     out of six would start rejecting the other four;
+ *   - a form field the vocabulary forgot must not be refused, or the dialog
+ *     writes a key the save then rejects and the operator sees two halves of
+ *     the same node disagreeing with no way to tell which is wrong;
+ *   - a form alone still cannot gate, because a subset is not a whitelist.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/flow-engine/spec.md#requirement-a-node-type-declares-its-own-form-and-its-own-run-log-actions
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Flow;
+
+use OCA\OpenRegister\Service\Flow\FlowNodePreflight;
+use OCA\OpenRegister\Service\Flow\FlowNodeRegistry;
+use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigForm;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
+use OCA\OpenRegister\Service\Flow\RegisterFlowNodesEvent;
+use OCP\App\IAppManager;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventDispatcher;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Preflight behaviour around {@see IFlowNodeConfigForm}.
+ *
+ * @spec openspec/specs/flow-engine/spec.md#requirement-a-node-type-declares-its-own-form-and-its-own-run-log-actions
+ */
+class FlowNodeConfigFormReferenceTest extends TestCase {
+
+	/**
+	 * A preflight over exactly the nodes handed in.
+	 *
+	 * @param array<int, IFlowNode> $nodes The nodes to register.
+	 *
+	 * @return FlowNodePreflight The subject.
+	 */
+	private function preflightOver(array $nodes): FlowNodePreflight {
+		$dispatcher = $this->createMock(IEventDispatcher::class);
+		$dispatcher->method('dispatchTyped')->willReturnCallback(
+			static function (Event $event) use ($nodes): void {
+				if (($event instanceof RegisterFlowNodesEvent) === false) {
+					return;
+				}
+
+				foreach ($nodes as $node) {
+					$event->registerNode($node);
+				}
+			}
+		);
+
+		$appManager = $this->createMock(IAppManager::class);
+		$appManager->method('isEnabledForUser')->willReturnCallback(
+			static fn (string $app): bool => ($app === 'openregister')
+		);
+
+		return new FlowNodePreflight(
+			new FlowNodeRegistry($dispatcher, $this->createMock(LoggerInterface::class)),
+			$appManager,
+			$this->createMock(LoggerInterface::class)
+		);
+
+	}//end preflightOver()
+
+	/**
+	 * The smallest complete document carrying one node's config.
+	 *
+	 * @param array $config The config under test.
+	 *
+	 * @return array The flow document.
+	 */
+	private function flowWithConfig(array $config): array {
+		return [
+			'name' => 'test-flow',
+			'nodes' => [
+				[
+					'id' => 'a',
+					'type' => 'test.formy',
+					'exit' => true,
+					'config' => $config,
+				],
+			],
+			'edges' => [],
+		];
+
+	}//end flowWithConfig()
+
+	/**
+	 * A PARTIAL form does not narrow the vocabulary.
+	 *
+	 * The node reads four keys and describes one. Every one of the four must
+	 * still pass: the form is a guide to editing, not a whitelist.
+	 *
+	 * @return void
+	 */
+	public function testAPartialFormDoesNotNarrowTheVocabulary(): void {
+		$node = new class implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigForm {
+			use FormNodeStub;
+
+			/**
+			 * The four keys this node reads.
+			 *
+			 * @return array<int, string>
+			 */
+			public function configKeys(): array {
+				return ['register', 'schema', 'mappingId', 'onMissing'];
+			}
+
+			/**
+			 * One of them described.
+			 *
+			 * @return array<int, array<string, mixed>>
+			 */
+			public function configForm(): array {
+				return [['key' => 'mappingId', 'label' => 'Mapping', 'type' => 'text']];
+			}
+		};
+
+		$report = $this->preflightOver([$node])->inspect(
+			flow: $this->flowWithConfig(
+				[
+					'register' => 'r',
+					'schema' => 's',
+					'mappingId' => 'm',
+					'onMissing' => 'skip',
+				]
+			)
+		);
+
+		$this->assertSame(
+			[],
+			$report['blocking'],
+			'A form describing one of four keys must not turn the other three into unknown keys.'
+		);
+
+	}//end testAPartialFormDoesNotNarrowTheVocabulary()
+
+	/**
+	 * A form field the vocabulary FORGOT is accepted, not refused.
+	 *
+	 * This is the disagreement case. The node's own dialog offers `mappingId`
+	 * and its `configKeys()` does not list it. Refusing the save would mean
+	 * the editor writes a value the engine then rejects, over one node, with
+	 * nothing on screen saying which half is wrong. The union resolves it in
+	 * the direction that keeps the operator working.
+	 *
+	 * @return void
+	 */
+	public function testAFormFieldMissingFromTheVocabularyIsStillAccepted(): void {
+		$node = new class implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigForm {
+			use FormNodeStub;
+
+			/**
+			 * The vocabulary, missing the key its own form offers.
+			 *
+			 * @return array<int, string>
+			 */
+			public function configKeys(): array {
+				return ['register'];
+			}
+
+			/**
+			 * A reference field over a key configKeys() forgot.
+			 *
+			 * @return array<int, array<string, mixed>>
+			 */
+			public function configForm(): array {
+				return [
+					[
+						'key' => 'mappingId',
+						'label' => 'Mapping',
+						'type' => 'reference',
+						'reference' => ['register' => 'openconnector', 'schema' => 'mapping'],
+					],
+				];
+			}
+		};
+
+		$report = $this->preflightOver([$node])->inspect(
+			flow: $this->flowWithConfig(['register' => 'r', 'mappingId' => 'm'])
+		);
+
+		$this->assertSame(
+			[],
+			$report['blocking'],
+			'The node offers this key in its own dialog; the save must not then refuse it.'
+		);
+
+	}//end testAFormFieldMissingFromTheVocabularyIsStillAccepted()
+
+	/**
+	 * The union WIDENS — it does not disable the check.
+	 *
+	 * The negative control for the two tests above. If the union were
+	 * implemented as "any key passes once a form exists", every assertion here
+	 * would still be green while the dialect check did nothing at all.
+	 *
+	 * @return void
+	 */
+	public function testAKeyInNeitherDeclarationIsStillRefused(): void {
+		$node = new class implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigForm {
+			use FormNodeStub;
+
+			/**
+			 * The vocabulary.
+			 *
+			 * @return array<int, string>
+			 */
+			public function configKeys(): array {
+				return ['register'];
+			}
+
+			/**
+			 * The form.
+			 *
+			 * @return array<int, array<string, mixed>>
+			 */
+			public function configForm(): array {
+				return [['key' => 'mappingId', 'label' => 'Mapping', 'type' => 'text']];
+			}
+		};
+
+		$report = $this->preflightOver([$node])->inspect(
+			flow: $this->flowWithConfig(['register' => 'r', 'notAKeyAnywhere' => 'x'])
+		);
+
+		$this->assertCount(1, $report['blocking'], 'One step, one finding.');
+		$this->assertSame(
+			FlowNodePreflight::REASON_CONFIG_UNKNOWN_KEY,
+			$report['blocking'][0]['reason']
+		);
+		$this->assertStringContainsString('notAKeyAnywhere', $report['blocking'][0]['detail']);
+
+	}//end testAKeyInNeitherDeclarationIsStillRefused()
+
+	/**
+	 * A form WITHOUT a vocabulary still gates nothing.
+	 *
+	 * A node describing only a form has said how some keys are edited and
+	 * nothing about which keys it reads. Treating that subset as complete
+	 * would refuse keys the node handles, so it stays unchecked — the same
+	 * answer every node predating the contract gets.
+	 *
+	 * @return void
+	 */
+	public function testAFormWithoutAVocabularyGatesNothing(): void {
+		$node = new class implements IFlowNode, IFlowNodeConfigForm {
+			use FormNodeStub;
+
+			/**
+			 * A form, and deliberately no configKeys().
+			 *
+			 * @return array<int, array<string, mixed>>
+			 */
+			public function configForm(): array {
+				return [['key' => 'mappingId', 'label' => 'Mapping', 'type' => 'text']];
+			}
+		};
+
+		$report = $this->preflightOver([$node])->inspect(
+			flow: $this->flowWithConfig(['anything' => 'at all'])
+		);
+
+		$this->assertSame(
+			[],
+			$report['blocking'],
+			'A partial form is not a whitelist, so it cannot be used as one.'
+		);
+
+	}//end testAFormWithoutAVocabularyGatesNothing()
+
+	/**
+	 * A form that THROWS does not make the instance unsavable.
+	 *
+	 * Same rule the vocabulary lookup already follows. One node with broken
+	 * metadata must cost its own guidance, not everybody's save button.
+	 *
+	 * @return void
+	 */
+	public function testAThrowingFormFallsBackToTheVocabularyAlone(): void {
+		$node = new class implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigForm {
+			use FormNodeStub;
+
+			/**
+			 * The vocabulary still answers.
+			 *
+			 * @return array<int, string>
+			 */
+			public function configKeys(): array {
+				return ['register'];
+			}
+
+			/**
+			 * Broken metadata.
+			 *
+			 * @return array<int, array<string, mixed>>
+			 */
+			public function configForm(): array {
+				throw new \RuntimeException('a missing translation');
+			}
+		};
+
+		$preflight = $this->preflightOver([$node]);
+
+		$this->assertSame(
+			[],
+			$preflight->inspect(flow: $this->flowWithConfig(['register' => 'r']))['blocking'],
+			'The vocabulary still answers, so a valid config still saves.'
+		);
+		$this->assertCount(
+			1,
+			$preflight->inspect(flow: $this->flowWithConfig(['nope' => 'x']))['blocking'],
+			'And the check is still running rather than silently disabled.'
+		);
+
+	}//end testAThrowingFormFallsBackToTheVocabularyAlone()
+}//end class
+
+/**
+ * The parts of IFlowNode none of these tests exercise.
+ *
+ * Only `getId()`, `configKeys()`, `configForm()` and `validateConfig()` are
+ * reached by the preflight; the rest is here so the anonymous classes above can
+ * state the one thing each is about and nothing else.
+ *
+ * @spec openspec/specs/flow-engine/spec.md#requirement-a-node-type-declares-its-own-form-and-its-own-run-log-actions
+ */
+trait FormNodeStub {
+
+	/**
+	 * The node id every fixture document refers to.
+	 *
+	 * @return string The id.
+	 */
+	public function getId(): string {
+		return 'test.formy';
+
+	}//end getId()
+
+	/**
+	 * The palette label.
+	 *
+	 * @return string The label.
+	 */
+	public function getDisplayName(): string {
+		return 'Formy';
+
+	}//end getDisplayName()
+
+	/**
+	 * Available everywhere, so no fixture is filtered out of the registry.
+	 *
+	 * @param int $scope The scope being asked about.
+	 *
+	 * @return bool Always true.
+	 */
+	public function isAvailableForScope(int $scope): bool {
+		return true;
+
+	}//end isAvailableForScope()
+
+	/**
+	 * The palette description.
+	 *
+	 * @return string The description.
+	 */
+	public function getDescription(): string {
+		return 'A node that exists to be preflighted.';
+
+	}//end getDescription()
+
+	/**
+	 * The palette icon.
+	 *
+	 * @return string The icon.
+	 */
+	public function getIcon(): string {
+		return 'cog';
+
+	}//end getIcon()
+
+	/**
+	 * Config validation, which these tests deliberately leave silent so the
+	 * only finding possible is the dialect one.
+	 *
+	 * @param array $config The step's config.
+	 *
+	 * @return void
+	 */
+	public function validateConfig(array $config): void {
+
+	}//end validateConfig()
+
+	/**
+	 * Never reached: nothing here runs a flow.
+	 *
+	 * @param array $items   The items entering the node.
+	 * @param array $config  The step's config.
+	 * @param array $context The execution context.
+	 *
+	 * @return array The result.
+	 */
+	public function execute(array $items, array $config, array $context): array {
+		return $items;
+
+	}//end execute()
+}//end trait


### PR DESCRIPTION
Task **0.2** of `flow-native-synchronization`. First of three (openregister →
nextcloud-vue → integriq).

## Why this is not called `configFields`

0.2 asks for a `configFields` catalogue `{key, type, reference?}` *"alongside
configKeys"*. OpenRegister already ships `IFlowNodeConfigForm::configForm()`,
which returns exactly that shape, is already exposed by `FlowNodeRegistry`, and
is already rendered by the editor.

A third declaration next to `configKeys` and `configForm` would be the precise
thing `FlowNodeRegistry`'s own comment warns about — a second hand-maintained
table of keys *"is only ever correct until the next node ships a key"*. So the
new type goes **into** the existing contract. I raised this before building and
it was the chosen option.

## What `reference` is for

| | answers | editor needs |
|---|---|---|
| `optionsFrom` | "which of the app's own things is this?" | one URL to fetch |
| `reference` | "which OBJECT of this schema is this?" | **both** register and schema |

The value stored under a `reference` field is an object's id, and the list to
choose it from is that schema's objects — a query that can only be built
knowing both halves, which is why they travel together in one entry instead of
as two loose strings.

The distinction earns its keep by what it removes: such a key has until now
been drawn as a **bare text box**. An operator pasting a uuid into one cannot
tell a typo from a correct value — and neither can the save. The node fails at
**run** time, in a log, long after the dialog closed.

## The part that needed care

0.2 also says *"preflight keeps accepting both"*, and the obvious reading — let
a form declare a node's keys — is a trap.

The interface **explicitly permits a partial form**: *"a partial form is more
useful than none, and it lets a node describe the two fields worth guiding and
leave the rest."* A field list is therefore a **subset** of what the node
reads. Treating a subset as a vocabulary would mean describing two fields out
of six starts **rejecting the other four**.

So the form unions and never substitutes:

- `configKeys` present → `configKeys ∪ formKeys`
- `configKeys` absent → **unchecked**, exactly as before

The union also closes a latent contradiction: a node that grows a form field
and forgets the matching `configKeys` entry has its own **editor** writing a
key its own **preflight** then refuses — the two halves of one node
disagreeing, with the operator in between and nothing on screen saying which is
wrong. Whichever half the author got wrong, refusing a key the node's own
dialog offers is the worse failure.

## Verification

- **5 new tests**, including the negative control that the union *widens*
  rather than disabling the check — without it every other assertion here would
  stay green while the dialect check did nothing at all
- one of them (`testAFormFieldMissingFromTheVocabularyIsStillAccepted`)
  **failed against the pre-change code** and passes now, so the change is
  load-bearing rather than decorative
- full `tests/Unit/Service/Flow/` suite: **597 passed**
- phpcs, phpmd, psalm, phpstan: clean on the changed files

⚠️ A note on how I nearly shipped this untested: my first run had `vendor`
symlinked from the shared checkout, and PHP resolves `__FILE__` through
symlinks — so `$baseDir` pointed at the **other** checkout and PHPUnit was
testing code I had not changed. The one test that should have failed did fail,
which is the only reason I noticed. Same shape as the occ defect fixed in
integriq#1478: an instrument that is present and wired somewhere else.

## Not in this PR

Rendering the field (0.3, nextcloud-vue) and declaring `reference` fields on
the synchronization nodes (1.7, integriq). This PR only makes the type sayable
and keeps the preflight honest about it.