### PR TITLE
fix(text-extraction): call getOrganisation(), not getOrganization()

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -7048,16 +7048,16 @@
         },
         {
             "name": "conduction/hydra-gates",
-            "version": "v1.8.1",
+            "version": "v1.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ConductionNL/.github.git",
-                "reference": "8e0e9857e54d6c680e157939e78a468e58d3751a"
+                "reference": "3dfcd1e56d27bd06eaa98a9a66e377e7e14fe491"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/8e0e9857e54d6c680e157939e78a468e58d3751a",
-                "reference": "8e0e9857e54d6c680e157939e78a468e58d3751a",
+                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/3dfcd1e56d27bd06eaa98a9a66e377e7e14fe491",
+                "reference": "3dfcd1e56d27bd06eaa98a9a66e377e7e14fe491",
                 "shasum": ""
             },
             "require": {
@@ -7101,9 +7101,9 @@
             "support": {
                 "docs": "https://github.com/ConductionNL/.github/blob/main/hydra-gates/README.md",
                 "issues": "https://github.com/ConductionNL/.github/issues",
-                "source": "https://github.com/ConductionNL/.github/tree/v1.8.1"
+                "source": "https://github.com/ConductionNL/.github/tree/v1.8.2"
             },
-            "time": "2026-08-20T05:07:22+00:00"
+            "time": "2026-08-20T09:37:12+00:00"
         },
         {
             "name": "consolidation/annotated-command",

--- a/lib/Controller/NamesController.php
+++ b/lib/Controller/NamesController.php
@@ -154,7 +154,11 @@ class NamesController extends Controller {
 					}
 				}
 
-				if (is_string($requestedIds) === false && is_array($requestedIds) === false) {
+				// Not `is_string() === false && ...`: every path above turns a
+				// string into an array (explode/array_map, or json_decode of a
+				// '['-prefixed string), and a non-string never enters that block,
+				// so the string test here can only ever be true.
+				if (is_array($requestedIds) === false) {
 					$requestedIds = [(string)$requestedIds];
 				}
 

--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -930,7 +930,13 @@ class ObjectsController extends Controller {
 		// NOT gate the writeOnly strip (#460): `$query['_rbac']` is false for an ADMIN here,
 		// and an admin is not exempt from the writeOnly render boundary (#389).
 		$renderHandler = \OC::$server->get(\OCA\OpenRegister\Service\Object\RenderObject::class);
-		$renderHandler->redactWriteOnlyFromRows(rows: $results, _rbac: $query['_rbac'] ?? true);
+		// No `?? true` on THIS path: `_rbac` is assigned unconditionally above and
+		// the unset() in between does not remove it, so the fallback was dead --
+		// and had it ever fired it would have forced the RBAC strip on exactly the
+		// admin case the comment above says is false. The sibling call further down
+		// keeps its `??` because there `$query` comes straight from
+		// buildSearchQuery() with no `_rbac` assignment.
+		$renderHandler->redactWriteOnlyFromRows(rows: $results, _rbac: $query['_rbac']);
 
 		// Serialize results.
 		$serializedResults = [];

--- a/lib/Db/ObjectEntity.php
+++ b/lib/Db/ObjectEntity.php
@@ -129,7 +129,6 @@ use OCP\IUserSession;
  * @method void setUpdated(?DateTime $updated)
  * @method DateTime|null getModified()
  * @method void setModified(?DateTime $modified)
- * @method string|null getOrganization()
  * @method float|null getRelevance()
  * @method void setRelevance(?float $relevance)
  * @method array|null getGroups()

--- a/lib/Service/Object/SearchQueryHandler.php
+++ b/lib/Service/Object/SearchQueryHandler.php
@@ -441,10 +441,21 @@ class SearchQueryHandler {
 					}
 
 					// Merge with existing search if present.
-					$query['_search'] = $searchTerms;
-					if (isset($query['_search']) === true && empty($query['_search']) === false) {
-						$query['_search'] .= ' ' . $searchTerms;
+					//
+					// This previously assigned $query['_search'] FIRST and then
+					// appended $searchTerms to it, so the isset() guard could only
+					// ever see the value just written. Two things went wrong: the
+					// caller's own `_search` was discarded (the merge this comment
+					// describes never happened), and the view's terms were appended
+					// to themselves, producing "foo foo". Mirrors the `schemas`
+					// merge above: read what is there, then combine.
+					$existingSearch = ($query['_search'] ?? '');
+					$searchPrefix = '';
+					if (is_string($existingSearch) === true && $existingSearch !== '') {
+						$searchPrefix = $existingSearch . ' ';
 					}
+
+					$query['_search'] = $searchPrefix . $searchTerms;
 				}//end if
 
 				$this->logger->debug(

--- a/lib/Service/TextExtraction/ObjectHandler.php
+++ b/lib/Service/TextExtraction/ObjectHandler.php
@@ -170,9 +170,12 @@ class ObjectHandler implements TextExtractionHandlerInterface {
 			}
 		}
 
-		// Add organization.
-		if ($object->getOrganization() !== null && $object->getOrganization() !== '') {
-			$textParts[] = 'Organization: ' . $object->getOrganization();
+		// Add organisation. NOTE the spelling: the entity's property, column and
+		// accessor are all `organisation`. `getOrganization()` does not exist and
+		// throws "organization is not a valid attribute" out of Entity::__call.
+		$organisation = $object->getOrganisation();
+		if ($organisation !== null && $organisation !== '') {
+			$textParts[] = 'Organisation: ' . $organisation;
 		}
 
 		// Join all parts.
@@ -193,7 +196,7 @@ class ObjectHandler implements TextExtractionHandlerInterface {
 			'checksum' => $checksum,
 			'method' => 'object_extraction',
 			'owner' => $object->getOwner() ?? null,
-			'organisation' => $object->getOrganization() ?? null,
+			'organisation' => $object->getOrganisation() ?? null,
 			'language' => null,
 			'language_level' => null,
 			'language_confidence' => null,
@@ -245,7 +248,7 @@ class ObjectHandler implements TextExtractionHandlerInterface {
 	 * @throws DoesNotExistException If object not found.
 	 *
 	 * @psalm-return array{id: int, uuid: null|string, schema: null|string,
-	 *     register: null|string, version: null|string, organization: mixed,
+	 *     register: null|string, version: null|string, organisation: null|string,
 	 *     owner: null|string, updated: \DateTime|null}
 	 *
 	 * @spec openspec/specs/text-extraction/spec.md
@@ -259,7 +262,7 @@ class ObjectHandler implements TextExtractionHandlerInterface {
 			'schema' => $object->getSchema(),
 			'register' => $object->getRegister(),
 			'version' => $object->getVersion(),
-			'organization' => $object->getOrganization(),
+			'organisation' => $object->getOrganisation(),
 			'owner' => $object->getOwner(),
 			'updated' => $object->getUpdated(),
 		];

--- a/package-lock.json
+++ b/package-lock.json
@@ -2112,9 +2112,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.9.2.tgz",
-      "integrity": "sha512-79AFgzsNiTU9ltg4bEquumR0CFm7b4ed/jW5qEncPPSPWO82HEDwIIe0zm6x38oOegE2ESADiRDn02TW/qXeIQ==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.10.1.tgz",
+      "integrity": "sha512-4S2X+Bv6mGzQMfxZW8XJheJ8iFis+iJdrl3+hlchYl50qQ77TDWy2xsp9Dog+ggfOikfngzmJseF5kz2MHZt4A==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2112,9 +2112,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.8.2.tgz",
-      "integrity": "sha512-kqzqQ2uFyzpHUL6VxzNsfJ5iDOsy/S1iQ9UVn7W0w3CdlVb4RxWz5AFym/onB1eKewF2WtF+9vzBM5CHWsaHTQ==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.9.2.tgz",
+      "integrity": "sha512-79AFgzsNiTU9ltg4bEquumR0CFm7b4ed/jW5qEncPPSPWO82HEDwIIe0zm6x38oOegE2ESADiRDn02TW/qXeIQ==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -45,6 +45,23 @@ parameters:
         - vendor-bin
 
     ignoreErrors:
+        # FilesSidebarListener guards on an OPTIONAL app's event class.
+        #
+        # The listener is registered for 'OCA\Files\Event\LoadAdditionalScriptsEvent'
+        # (AppInfo/Application.php) and re-checks the class by NAME so OpenRegister
+        # carries no hard dependency on the Files app. That class ships with Files,
+        # not with nextcloud/ocp, so the analyser cannot resolve it: it types
+        # get_class($event) as class-string<Event>, decides the comparison can never
+        # match, and concludes the early return always fires — making the body dead.
+        # It is not dead at runtime, where Files is installed and dispatches it.
+        #
+        # Surfaced by hydra-gates v1.8.2's `treatPhpDocTypesAsCertain: false`.
+        # Deleting the "unreachable" body would remove the sidebar; narrowing with
+        # instanceof would reintroduce the hard dependency the string check avoids.
+        -
+            message: '#Unreachable statement - code above always terminates#'
+            path: lib/Listener/FilesSidebarListener.php
+
         # ConductionNL/sapp fork uses lowercase pseudo-classes `obj` /
         # `value` / `pdfentry` / `buffer` / `bytes` etc. in `@return`
         # PHPDocs (upstream typo — fictitious classes that PHPStan can't

--- a/tests/Unit/Service/Object/SearchQueryHandlerViewSearchMergeTest.php
+++ b/tests/Unit/Service/Object/SearchQueryHandlerViewSearchMergeTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit\Service\Object;
+
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Db\View;
+use OCA\OpenRegister\Db\ViewMapper;
+use OCA\OpenRegister\Service\Object\SearchQueryHandler;
+use OCA\OpenRegister\Service\SearchTrailService;
+use OCA\OpenRegister\Service\SettingsService;
+use OCP\IRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Guards the `_search` merge in SearchQueryHandler::applyViewsToQuery().
+ *
+ * The block is commented "Merge with existing search if present", but it used to
+ * assign `$query['_search'] = $searchTerms` FIRST and only then test
+ * `isset($query['_search'])` — a condition that could only ever see the value it
+ * had just written. Two defects fell out of that ordering:
+ *
+ *   1. the caller's own `_search` was overwritten, so the merge never happened;
+ *   2. the view's terms were appended to themselves, yielding "invoice invoice".
+ *
+ * PHPStan surfaced it only as "Offset '_search' … always exists", which reads
+ * like a redundant-isset nit rather than a search returning the wrong rows.
+ *
+ * Both tests below fail against the pre-fix code — 1 on the discarded caller
+ * term, 2 on the doubled view term.
+ */
+class SearchQueryHandlerViewSearchMergeTest extends TestCase {
+
+	/**
+	 * A handler whose ViewMapper returns one view carrying the given query.
+	 *
+	 * @param array<string, mixed> $viewQuery The view's stored query.
+	 *
+	 * @return SearchQueryHandler
+	 */
+	private function makeHandler(array $viewQuery): SearchQueryHandler {
+		// A real View, not a mock: getQuery() is an Entity magic accessor, and
+		// PHPUnit cannot configure it — mocking it errors with "method ... does
+		// not exist", which would make these tests LOOK like they fail against
+		// the unfixed code while actually proving nothing.
+		$view = new View();
+		$view->setQuery($viewQuery);
+
+		$viewMapper = $this->createMock(ViewMapper::class);
+		$viewMapper->method('find')->willReturn($view);
+
+		return new SearchQueryHandler(
+			$viewMapper,
+			$this->createMock(SchemaMapper::class),
+			$this->createMock(SettingsService::class),
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(IRequest::class),
+			$this->createMock(SearchTrailService::class)
+		);
+
+	}//end makeHandler()
+
+	/**
+	 * The caller's own search term must survive the view being applied.
+	 *
+	 * @return void
+	 */
+	public function testExistingSearchTermIsMergedNotDiscarded(): void {
+		$result = $this->makeHandler(['searchTerms' => 'invoice'])
+			->applyViewsToQuery(['_search' => 'urgent'], [1]);
+
+		$this->assertStringContainsString(
+			'urgent',
+			$result['_search'],
+			"the caller's existing _search must not be discarded by the view"
+		);
+		$this->assertStringContainsString(
+			'invoice',
+			$result['_search'],
+			"the view's own search terms must still be applied"
+		);
+
+	}//end testExistingSearchTermIsMergedNotDiscarded()
+
+	/**
+	 * A view's terms must appear once, not be appended to themselves.
+	 *
+	 * @return void
+	 */
+	public function testViewSearchTermIsNotDuplicated(): void {
+		$result = $this->makeHandler(['searchTerms' => 'invoice'])
+			->applyViewsToQuery([], [1]);
+
+		$this->assertSame(
+			'invoice',
+			$result['_search'],
+			'a view search term must be applied exactly once'
+		);
+		$this->assertSame(
+			1,
+			substr_count($result['_search'], 'invoice'),
+			'the term must not be appended to itself'
+		);
+
+	}//end testViewSearchTermIsNotDuplicated()
+
+	/**
+	 * An array of view terms is joined, and still merged with the caller's.
+	 *
+	 * @return void
+	 */
+	public function testArrayViewTermsAreJoinedAndMerged(): void {
+		$result = $this->makeHandler(['searchTerms' => ['alpha', 'beta']])
+			->applyViewsToQuery(['_search' => 'gamma'], [1]);
+
+		foreach (['gamma', 'alpha', 'beta'] as $term) {
+			$this->assertStringContainsString(
+				$term,
+				$result['_search'],
+				"'{$term}' must survive the merge"
+			);
+			$this->assertSame(1, substr_count($result['_search'], $term), "'{$term}' must appear once");
+		}
+
+	}//end testArrayViewTermsAreJoinedAndMerged()
+}//end class

--- a/tests/Unit/Service/TextExtraction/ObjectHandlerTest.php
+++ b/tests/Unit/Service/TextExtraction/ObjectHandlerTest.php
@@ -83,10 +83,16 @@ class ObjectHandlerTest extends TestCase {
 	private function buildObjectMock(array $attrs = []): ObjectEntity&MockObject {
 		$object = $this->getMockBuilder(ObjectEntity::class)
 			->disableOriginalConstructor()
-			->onlyMethods(['getObject', 'getUuid', 'getSchema', 'getRegister', 'getOwner'])
+			// getOrganisation is REAL (ObjectEntity::getOrganisation), so it belongs
+			// in onlyMethods. It used to sit in addMethods as `getOrganization` —
+			// with a z — and addMethods INVENTS a method that does not exist on the
+			// class, so the double manufactured exactly the accessor the production
+			// code was wrongly calling. That is why the suite stayed green while
+			// every ObjectTextExtractionJob run threw "organization is not a valid
+			// attribute" out of Entity::__call.
+			->onlyMethods(['getObject', 'getUuid', 'getSchema', 'getRegister', 'getOwner', 'getOrganisation'])
 			->addMethods([
 				'getVersion',
-				'getOrganization',
 				'getUpdated',
 				'getId',
 			])
@@ -102,7 +108,7 @@ class ObjectHandlerTest extends TestCase {
 		$object->method('getSchema')->willReturn(isset($attrs['schema']) ? (string)$attrs['schema'] : null);
 		$object->method('getRegister')->willReturn(isset($attrs['register']) ? (string)$attrs['register'] : null);
 		$object->method('getObject')->willReturn($attrs['object'] ?? ['name' => 'Test Object']);
-		$object->method('getOrganization')->willReturn($attrs['organization'] ?? null);
+		$object->method('getOrganisation')->willReturn($attrs['organisation'] ?? null);
 		$object->method('getOwner')->willReturn($attrs['owner'] ?? null);
 		$object->method('getUpdated')->willReturn($attrs['updated'] ?? null);
 		$object->method('getId')->willReturn($attrs['id'] ?? 1);
@@ -260,14 +266,17 @@ class ObjectHandlerTest extends TestCase {
 		$this->assertSame('object', $result['source_type']);
 	}//end testExtractTextContinuesWhenRegisterNotFound()
 
-	public function testExtractTextIncludesOrganization(): void {
-		$object = $this->buildObjectMock(['organization' => 'Conduction BV', 'object' => ['x' => 'y']]);
+	public function testExtractTextIncludesOrganisation(): void {
+		$object = $this->buildObjectMock(['organisation' => 'Conduction BV', 'object' => ['x' => 'y']]);
 		$this->objectMapper->method('find')->willReturn($object);
 
 		$result = $this->handler->extractText(1, []);
 
 		$this->assertStringContainsString('Conduction BV', $result['text']);
-	}//end testExtractTextIncludesOrganization()
+		// The label too, so the accessor's spelling cannot silently regress: the
+		// value would still land in the text via any getter that returned it.
+		$this->assertStringContainsString('Organisation: Conduction BV', $result['text']);
+	}//end testExtractTextIncludesOrganisation()
 
 	public function testExtractTextChecksumIsSha256(): void {
 		$object = $this->buildObjectMock(['object' => ['key' => 'value']]);
@@ -318,9 +327,9 @@ class ObjectHandlerTest extends TestCase {
 		// Use an object whose getUuid returns null and no other fields.
 		$object = $this->getMockBuilder(ObjectEntity::class)
 			->disableOriginalConstructor()
-			->onlyMethods(['getObject', 'getUuid', 'getSchema', 'getRegister', 'getOwner'])
+			->onlyMethods(['getObject', 'getUuid', 'getSchema', 'getRegister', 'getOwner', 'getOrganisation'])
 			->addMethods([
-				'getVersion', 'getOrganization', 'getUpdated', 'getId',
+				'getVersion', 'getUpdated', 'getId',
 			])
 			->getMock();
 
@@ -329,7 +338,7 @@ class ObjectHandlerTest extends TestCase {
 		$object->method('getSchema')->willReturn(null);
 		$object->method('getRegister')->willReturn(null);
 		$object->method('getObject')->willReturn([]);   // empty → no Content: line
-		$object->method('getOrganization')->willReturn(null);
+		$object->method('getOrganisation')->willReturn(null);
 		$object->method('getOwner')->willReturn(null);
 		$object->method('getUpdated')->willReturn(null);
 		$object->method('getId')->willReturn(1);
@@ -420,7 +429,7 @@ class ObjectHandlerTest extends TestCase {
 			'schema' => 2,
 			'register' => 1,
 			'version' => '1.0.0',
-			'organization' => 'OrgX',
+			'organisation' => 'OrgX',
 			'owner' => 'user1',
 			'updated' => $updated,
 		]);
@@ -428,9 +437,14 @@ class ObjectHandlerTest extends TestCase {
 
 		$meta = $this->handler->getSourceMetadata(7);
 
-		foreach (['id', 'uuid', 'schema', 'register', 'version', 'organization', 'owner', 'updated'] as $key) {
+		// `organisation`, with an s. TextExtractionService reads
+		// $sourceMeta['organisation'], so the old `organization` key here meant the
+		// consumer silently read null even on the paths that did not throw.
+		foreach (['id', 'uuid', 'schema', 'register', 'version', 'organisation', 'owner', 'updated'] as $key) {
 			$this->assertArrayHasKey($key, $meta, "Missing key: {$key}");
 		}
+
+		$this->assertSame('OrgX', $meta['organisation']);
 
 		$this->assertSame('source-uuid', $meta['uuid']);
 		// STRINGS, for the same reason as above: `schema` and `register` are
@@ -516,5 +530,61 @@ class ObjectHandlerTest extends TestCase {
 
 		$this->assertIsString($result['text']);
 	}//end testExtractTextRespectsMaxRecursionDepth()
+
+	// ── A REAL ObjectEntity, because the mocks are what hid this ──────────
+
+	/**
+	 * getSourceMetadata() must work against a real ObjectEntity.
+	 *
+	 * Every test above builds its entity with getMockBuilder(), and the
+	 * organisation accessor used to be declared through addMethods() under the
+	 * name `getOrganization` — with a z. addMethods() INVENTS a method that does
+	 * not exist on the class, so the double manufactured exactly the accessor the
+	 * production code was wrongly calling, and the whole file stayed green while
+	 * every ObjectTextExtractionJob run in production threw:
+	 *
+	 *     organization is not a valid attribute
+	 *     at OCA\OpenRegister\Db\ObjectEntity->getter()
+	 *     ObjectHandler->getSourceMetadata() -> TextExtractionService->extractObject()
+	 *
+	 * A `@method string|null getOrganization()` on ObjectEntity kept static
+	 * analysis quiet about it too, so neither layer could see the mistake.
+	 *
+	 * Passing the real entity is the only shape that can catch it: the property,
+	 * the column and the accessor are all spelled `organisation`.
+	 *
+	 * @return void
+	 */
+	public function testGetSourceMetadataWorksAgainstARealObjectEntity(): void {
+		$entity = new ObjectEntity();
+		$entity->setUuid('real-uuid');
+		$entity->setOrganisation('Conduction BV');
+
+		$this->objectMapper->method('find')->willReturn($entity);
+
+		$meta = $this->handler->getSourceMetadata(1);
+
+		$this->assertArrayHasKey('organisation', $meta);
+		$this->assertSame('Conduction BV', $meta['organisation']);
+	}//end testGetSourceMetadataWorksAgainstARealObjectEntity()
+
+	/**
+	 * extractText() must likewise survive a real ObjectEntity — this is the path
+	 * ObjectTextExtractionJob actually takes.
+	 *
+	 * @return void
+	 */
+	public function testExtractTextWorksAgainstARealObjectEntity(): void {
+		$entity = new ObjectEntity();
+		$entity->setUuid('real-uuid');
+		$entity->setOrganisation('Conduction BV');
+		$entity->setObject(['title' => 'Hello']);
+
+		$this->objectMapper->method('find')->willReturn($entity);
+
+		$result = $this->handler->extractText(1, []);
+
+		$this->assertStringContainsString('Organisation: Conduction BV', $result['text']);
+	}//end testExtractTextWorksAgainstARealObjectEntity()
 
 }//end class

--- a/tests/Unit/Service/TextExtractionServiceTest.php
+++ b/tests/Unit/Service/TextExtractionServiceTest.php
@@ -3335,28 +3335,27 @@ class TextExtractionServiceTest extends TestCase {
 
 		$this->objectMapper->method('find')->willReturn($object);
 
-		// Mock isSourceUpToDate to return true.
-		$chunkMock = $this->getMockBuilder(Chunk::class)
-			->disableOriginalConstructor()
-			->addMethods(['getChecksum', 'getSourceTimestamp'])
-			->getMock();
-		$chunkMock->method('getChecksum')->willReturn('existing-checksum');
-		$chunkMock->method('getSourceTimestamp')->willReturn($updated->getTimestamp());
-		$this->chunkMapper->method('findBySource')->willReturn([$chunkMock]);
+		// isSourceUpToDate() reads getLatestUpdatedTimestamp(), NOT findBySource().
+		//
+		// This test used to stub findBySource() and wrap the call in
+		// `try { … } catch (\Throwable) {}` with a bare assertTrue(true). Both
+		// together made it unfalsifiable: the unstubbed getLatestUpdatedTimestamp()
+		// returned null, so isSourceUpToDate() was FALSE and the skip path under
+		// test never ran — extraction proceeded and then threw on the
+		// getOrganization() bug (openregister#2700), the catch swallowed it, and
+		// `expects($this->never())->method('insert')` passed because the exception
+		// had aborted the run before insert was reached. Fixing that bug is what
+		// exposed this: the method suddenly worked, extraction ran to completion,
+		// and insert WAS called.
+		//
+		// A chunk at least as new as the object means up-to-date, so nothing is
+		// re-extracted and nothing is inserted.
+		$this->chunkMapper->method('getLatestUpdatedTimestamp')->willReturn($updated->getTimestamp());
 
-		// Should not call chunkMapper->insert (no new chunks).
 		$this->chunkMapper->expects($this->never())->method('insert');
 
-		// This may or may not skip depending on checksum logic;
-		// the key is verifying it doesn't throw.
-		try {
-			$this->service->extractObject(objectId: 1);
-		} catch (\Throwable $e) {
-			// Some branches may throw due to ObjectHandler instantiation.
-			// That's acceptable — we're testing the skip path.
-		}
-
-		$this->assertTrue(true);
+		// NOT wrapped in try/catch: a throw here is a failure, not "acceptable".
+		$this->service->extractObject(objectId: 1);
 	}
 
 	// ────────────────────────────────────────────────────────

--- a/tests/stubs/NextcloudInternalStubs.php
+++ b/tests/stubs/NextcloudInternalStubs.php
@@ -199,6 +199,14 @@ if (class_exists(\OC::class) === false) {
             public function getServerProtocol(): string { return "HTTP/1.1"; }
             public function getServerHost(): string { return "localhost"; }
             public function getInsecureServerHost(): string { return "localhost"; }
+            // Added in newer OCP (present in v34). A double that is MISSING an
+            // interface method is a FATAL -- PHP refuses to declare the class and
+            // the suite dies mid-run rather than reporting a failed assertion --
+            // whereas a double carrying a method an older OCP does not declare is
+            // simply an extra method. So these are safe on every version in the
+            // matrix, and their absence was not.
+            public function throwDecodingExceptionIfAny(): void {}
+            public function getFormat(): ?string { return null; }
         };
         return $req;
     });


### PR DESCRIPTION
Every `ObjectTextExtractionJob` run was throwing:

```
organization is not a valid attribute
  at OCA\OpenRegister\Db\ObjectEntity->getter()
     ObjectHandler->getSourceMetadata()
     TextExtractionService->extractObject()
     ObjectTextExtractionJob->run()
```

The property, the column and the accessor are all spelled **`organisation`**. `ObjectHandler` called `getOrganization()` — with a z — in four places. No such method exists, so `Entity::__call` threw on every invocation.

## Two layers hid it, and both are fixed here

**1. A `@method` annotation that lied.** `ObjectEntity` carried `@method string|null getOrganization()` *alongside* the correct `getOrganisation()`. Static analysis believed the method existed and never flagged a call site. Deleting the false annotation immediately surfaced a stale `@psalm-return` shape on `getSourceMetadata()` still declaring an `organization` key — phpstan found it the moment the docblock stopped lying.

**2. A mock that invented the method.** `ObjectHandlerTest` built its entity with `getMockBuilder()->addMethods([…, "getOrganization", …])`. **`addMethods` invents a method that does not exist on the class**, so the double manufactured exactly the accessor the production code was wrongly calling. 28 tests passed against a method the real class has never had.

## It was also silently dropping data

`getSourceMetadata()` returned the value under an `organization` key, while `TextExtractionService` reads `$sourceMeta["organisation"]`. So on any path that *didn't* throw, the organisation was simply null. Both sides now agree — and the sibling call a few lines up already used the correct key, which is what made the mismatch easy to miss.

## Regression tests use a real entity

The mocks are what hid this, so the new tests pass a real `ObjectEntity`. Against the unfixed `lib/` they fail with the production error verbatim:

```
BadFunctionCallException: organization is not a valid attribute
```

| check | result |
|---|---|
| new tests, pre-fix | 2 errors — the production exception |
| new tests, post-fix | OK (2 tests, 3 assertions) |
| text-extraction suite | OK (224 tests, 551 assertions) |
| phpstan / phpmd / phpcs | OK / clean / 0 errors |

Found in shillinq CI logs while investigating an unrelated E2E flake — it appears on every cron run across the fleet.