### PR TITLE
fix(scope): make the pending schema ref single-use so it cannot leak between operations

### DIFF
--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -502,9 +502,23 @@ class ObjectService implements ObjectServiceInterface
         // round the two setters are called, in ONE place, instead of requiring
         // every call site to remember an ordering nothing enforces.
         if ($this->currentSchemaRef !== null) {
+            // SINGLE USE. The pending ref belongs to the setSchema() call that
+            // created it, and is consumed by the FIRST setRegister() that
+            // follows. Clearing it here is what keeps this instance-level state
+            // from leaking across unrelated operations: ObjectService is reused
+            // for many calls in one process, so a ref left behind by an
+            // operation that set a schema and never set a register would be
+            // re-resolved against the NEXT caller's register and refuse it.
+            // Measured on the shared instance after this scoping landed: a
+            // pipelinq repair step seeding `trustConfiguration` was told
+            // `posJournalEntryOutbound` is not carried by its register — a slug
+            // from an entirely different operation.
+            $pendingRef             = $this->currentSchemaRef;
+            $this->currentSchemaRef = null;
+
             $this->currentSchema = $this->scopedSchemaResolver->resolveSchemaWithin(
                 register: $register,
-                schemaRef: $this->currentSchemaRef
+                schemaRef: $pendingRef
             );
         }
 

--- a/tests/Unit/Service/ObjectServiceTest.php
+++ b/tests/Unit/Service/ObjectServiceTest.php
@@ -322,6 +322,54 @@ class ObjectServiceTest extends TestCase {
 	}
 
 	/**
+	 * The pending schema ref is SINGLE USE: consumed by the first
+	 * setRegister() that follows, then cleared.
+	 *
+	 * ObjectService is reused for many operations in one process. A ref left
+	 * behind by an operation that set a schema and never set a register would
+	 * be re-resolved against the NEXT caller's register and refuse it —
+	 * measured on the shared instance as a pipelinq repair step seeding
+	 * `trustConfiguration` being told `posJournalEntryOutbound` is not carried
+	 * by its register, a slug from an entirely unrelated operation.
+	 */
+	public function testPendingSchemaRefIsClearedOnceConsumed(): void {
+		// The register must actually carry the schema, or the scoped resolve
+		// refuses for the RIGHT reason and hides what this test is about.
+		$this->register->setSchemas([2]);
+		$this->schemaMapper->method('find')->willReturn($this->schema);
+		$this->schemaMapper->method('findInIds')->willReturn($this->schema);
+		$this->registerMapper->method('find')->willReturn($this->register);
+
+		$this->service->setSchema(schema: 'my-schema');
+		$this->assertSame('my-schema', $this->getProperty('currentSchemaRef'));
+
+		$this->service->setRegister(register: 1);
+
+		$this->assertNull(
+			$this->getProperty('currentSchemaRef'),
+			'The pending ref must not survive the setRegister() that consumed it.'
+		);
+	}
+
+	/**
+	 * A setRegister() with no pending ref must not re-resolve anything — the
+	 * leak this guards against is a stale ref from an earlier operation.
+	 */
+	public function testSetRegisterWithoutAPendingRefDoesNotRescope(): void {
+		$this->registerMapper->method('find')->willReturn($this->register);
+		$this->setProperty('currentSchemaRef', null);
+		$this->setProperty('currentSchema', $this->schema);
+
+		$this->service->setRegister(register: 1);
+
+		$this->assertSame(
+			$this->schema,
+			$this->getProperty('currentSchema'),
+			'An already-resolved schema must survive a later setRegister() untouched.'
+		);
+	}
+
+	/**
 	 * Test setSchema with string slug uses mapper find.
 	 */
 	public function testSetSchemaWithSlugUsesMapperFind(): void {


### PR DESCRIPTION
Follow-up to #2774, fixing a regression it introduced.

`ObjectService::setSchema()` records the raw ref so a later `setRegister()` can re-resolve it inside the register the caller names — that is what made the boundary hold regardless of the order the two setters are called in. But the ref was **never cleared after being consumed**, and ObjectService is reused for many operations in one process. A ref left behind by an operation that set a schema and never set a register was therefore re-resolved against the *next* caller's register, and refused it.

**Measured on the shared dev instance minutes after #2774 landed**, during `occ upgrade`: a pipelinq repair step seeding `trustConfiguration` was told *"Schema slug posJournalEntryOutbound is not carried by register trust-configuration"* — a slug from an entirely unrelated operation. Four repair steps across two apps failed that way; the error text was accurate about the boundary and wrong about which schema anyone had asked for, which is what gave the leak away.

The pending ref is now **consumed and cleared** by the first `setRegister()` that follows. Order-independence for the `setSchema`/`setRegister` pair is unchanged; the state is simply confined to the operation that created it.

Two regression tests: the ref is cleared once consumed, and a `setRegister()` with no pending ref leaves an already-resolved schema untouched. Must-fail control: the first fails against the leaking version and passes against this one. ObjectServiceTest 141 green; lint/phpcs/psalm/phpstan exit 0; phpmd's 16 findings are byte-identical to clean development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)