### PR TITLE
fix(notifications): make the accepted filter grammar the executable one

### DIFF
--- a/lib/BackgroundJob/ScheduledNotificationJob.php
+++ b/lib/BackgroundJob/ScheduledNotificationJob.php
@@ -65,6 +65,16 @@ final class ScheduledNotificationJob extends TimedJob {
 	 * _filter+_limit in lib/Db/MagicMapper) and add a per-schema watermark for
 	 * delta scans, so we no longer load the whole table into PHP and filter
 	 * in-memory. Until then this cap bounds the blast radius.
+	 *
+	 * The pushdown input is the AST from `ScheduledFilterParser`, not the raw
+	 * annotation: every operator is a single-column predicate and `all` / `any`
+	 * are `AND` / `OR`, so the grammar translates to SQL directly. Two
+	 * constraints hold whatever a compiler does with it — reference instants
+	 * (`now`, signed durations) must be resolved against the scan's single
+	 * `$now` BEFORE compilation, or two rows in one pass can be judged against
+	 * different clocks; and a partial pushdown must select a superset that the
+	 * in-memory walk then narrows, so that pushing down more never changes which
+	 * objects a rule selects.
 	 */
 	private const MAX_OBJECTS_PER_FIRE = 5000;
 

--- a/lib/Service/Notification/NotificationAnnotationValidator.php
+++ b/lib/Service/Notification/NotificationAnnotationValidator.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Service\Notification;
 
-use DateInterval;
 use DateTimeZone;
 
 /**
@@ -66,6 +65,27 @@ final class NotificationAnnotationValidator {
 	 * @var int
 	 */
 	private const MAX_ACTIONS = 2;
+
+	/**
+	 * Parses scheduled-trigger filters; the sole authority on what one may say.
+	 *
+	 * @var ScheduledFilterParser
+	 */
+	private ScheduledFilterParser $filterParser;
+
+	/**
+	 * Construct a validator.
+	 *
+	 * The parser is injectable but defaulted, because this class is constructed
+	 * directly (`new NotificationAnnotationValidator()`) in several call sites
+	 * that predate any container wiring.
+	 *
+	 * @param ScheduledFilterParser|null $filterParser Parser for scheduled filters.
+	 */
+	public function __construct(?ScheduledFilterParser $filterParser = null) {
+		$this->filterParser = ($filterParser ?? new ScheduledFilterParser());
+
+	}//end __construct()
 
 	/**
 	 * Validate the `x-openregister-notifications` annotation.
@@ -153,10 +173,11 @@ final class NotificationAnnotationValidator {
 					];
 				}
 
-				// Validate filter operator grammar (Phase 2 — save-time grammar validation).
-				// Scalar entries always pass; operator objects must declare a known operator,
-				// a present `value`, and an ISO-8601 DateInterval-parseable duration for
-				// withinNext / olderThan. See notification-engine-scheduled-conditions.
+				// Validate the filter by parsing it with the same parser the
+				// evaluator runs. This class enumerates no operators of its own:
+				// while it did, it accepted "any array without an `operator` key"
+				// as a scalar shortcut, which let 24 unexecutable filter entries
+				// across three apps save cleanly and then match nothing.
 				if (is_array($trigger) === true && isset($trigger['filter']) === true) {
 					$filter = $trigger['filter'];
 					if (is_array($filter) === false) {
@@ -171,16 +192,14 @@ final class NotificationAnnotationValidator {
 							),
 						];
 					} else {
-						foreach ($filter as $fieldKey => $filterSpec) {
-							$entryErrors = $this->validateScheduledFilterEntry(
-								ruleKey: $name,
-								field: (string)$fieldKey,
-								spec: $filterSpec
-							);
-							foreach ($entryErrors as $entryError) {
-								$errors[] = $entryError;
-							}
-						}//end foreach
+						// One parse of the whole map, not one call per entry:
+						// `all` / `any` are whole-filter constructs, and parsing
+						// here is what guarantees the shapes this validator
+						// accepts are exactly the shapes the evaluator executes.
+						$parsed = $this->filterParser->parse(filter: $filter, ruleKey: $name);
+						foreach ($parsed['errors'] as $entryError) {
+							$errors[] = $entryError;
+						}
 					}//end if
 				}//end if
 
@@ -1000,104 +1019,4 @@ final class NotificationAnnotationValidator {
 		];
 	}//end validateOrganisationGate()
 
-	/**
-	 * Validate a single scheduled-trigger filter entry.
-	 *
-	 * Scalar entries always pass (legacy v1 byte-for-byte equality).
-	 * Operator-object entries must declare:
-	 *   - a recognised operator (equals | notEquals | withinNext | olderThan);
-	 *   - a `value` key (even if null) — for equals/notEquals;
-	 *   - an ISO-8601 DateInterval-parseable string `value` for withinNext / olderThan.
-	 *
-	 * @param string $ruleKey The notification rule key for diagnostics.
-	 * @param string $field The filter field name being inspected.
-	 * @param mixed $spec The raw filter entry value (scalar or operator object).
-	 *
-	 * @return array<int, array{code: string, ruleKey: string, field: string, value: mixed, message: string}>
-	 */
-	private function validateScheduledFilterEntry(string $ruleKey, string $field, $spec): array {
-		// Scalar shortcut: always accepted (legacy v1 strict equality).
-		if (is_array($spec) === false || array_key_exists('operator', $spec) === false) {
-			return [];
-		}
-
-		$validOperators = ['equals', 'notEquals', 'withinNext', 'olderThan'];
-		$operator = (string)($spec['operator'] ?? '');
-
-		if (in_array($operator, $validOperators, true) === false) {
-			return [
-				[
-					'code' => 'notification-scheduled-bad-filter-operator',
-					'ruleKey' => $ruleKey,
-					'field' => sprintf('trigger.filter.%s.operator', $field),
-					'value' => $operator,
-					'message' => sprintf(
-						'Notification "%s" trigger.filter.%s.operator must be one of [%s]; got "%s".',
-						$ruleKey,
-						$field,
-						implode(', ', $validOperators),
-						$operator
-					),
-				],
-			];
-		}
-
-		if (array_key_exists('value', $spec) === false) {
-			return [
-				[
-					'code' => 'notification-scheduled-bad-filter-missing-value',
-					'ruleKey' => $ruleKey,
-					'field' => sprintf('trigger.filter.%s.value', $field),
-					'value' => null,
-					'message' => sprintf(
-						'Notification "%s" trigger.filter.%s requires a "value" key.',
-						$ruleKey,
-						$field
-					),
-				],
-			];
-		}
-
-		if ($operator === 'withinNext' || $operator === 'olderThan') {
-			$duration = $spec['value'];
-			if (is_string($duration) === false || $duration === '') {
-				return [
-					[
-						'code' => 'notification-scheduled-bad-filter-duration',
-						'ruleKey' => $ruleKey,
-						'field' => sprintf('trigger.filter.%s.value', $field),
-						'value' => $duration,
-						'message' => sprintf(
-							'Notification "%s" trigger.filter.%s.value must be an ISO-8601 DateInterval string for "%s".',
-							$ruleKey,
-							$field,
-							$operator
-						),
-					],
-				];
-			}
-
-			try {
-				new DateInterval($duration);
-			} catch (\Exception $e) {
-				return [
-					[
-						'code' => 'notification-scheduled-bad-filter-duration',
-						'ruleKey' => $ruleKey,
-						'field' => sprintf('trigger.filter.%s.value', $field),
-						'value' => $duration,
-						'message' => sprintf(
-							'Notification "%s" trigger.filter.%s.value "%s" is not a valid ISO-8601 DateInterval for "%s".',
-							$ruleKey,
-							$field,
-							$duration,
-							$operator
-						),
-					],
-				];
-			}//end try
-		}//end if
-
-		return [];
-	}//end validateScheduledFilterEntry()
 }//end class

--- a/lib/Service/Notification/ScheduledFilterEvaluator.php
+++ b/lib/Service/Notification/ScheduledFilterEvaluator.php
@@ -4,12 +4,17 @@
  * OpenRegister ScheduledFilterEvaluator
  *
  * Evaluates the `filter` block on a scheduled notification trigger
- * against a single object's data. Supports both legacy scalar
- * equality entries and operator-object entries
- * (`equals`, `notEquals`, `withinNext`, `olderThan`).
+ * against a single object's data.
+ *
+ * The grammar it accepts is not enumerated here: `ScheduledFilterParser` owns
+ * it, and this class walks the AST the parser returns. That indirection is the
+ * point — while the grammar lived in two places, the validator accepted shapes
+ * this evaluator could not execute, and 24 filter entries across three apps
+ * were saved successfully and then matched nothing, silently, for months.
  *
  * Part of the notification-engine-scheduled-conditions change
- * (Phase 1 — filter operator evaluator).
+ * (Phase 1 — filter operator evaluator), extended by
+ * notification-scheduled-filter-grammar (membership, instants, combinators).
  *
  * SPDX-License-Identifier: EUPL-1.2
  * SPDX-FileCopyrightText: 2026 Conduction B.V.
@@ -39,20 +44,25 @@ use Psr\Log\NullLogger;
 /**
  * Evaluates a scheduled-trigger `filter` map against object data.
  *
- * Filter shape is a `field => value-spec` map where `value-spec` is:
- *  - a scalar (string/int/float/bool/null) — equivalent to `{operator: equals, value: <scalar>}`;
- *  - an operator object `{operator: <op>, value: <v>}` where `<op>` is one of:
- *      - `equals`     — strict (`===`) equality;
- *      - `notEquals`  — strict inequality; missing/null field counts as not-equal to any non-null value;
- *      - `withinNext` — field is a date in the half-open window `(now, now + duration]`;
- *      - `olderThan`  — field is a date strictly before `now - duration`.
+ * A `filter` is a map whose entries are ANDed. Each entry is a scalar (strict
+ * equality), a bare list (membership), an operator object, or one of the
+ * reserved combinator keys `all` / `any`. The operator table and the nesting
+ * bound live in `ScheduledFilterGrammar`; the accepted shapes are whatever
+ * `ScheduledFilterParser` admits, and nothing else.
  *
- * All entries are combined with AND. An empty filter map matches.
+ * An empty filter map matches. An empty `all` matches; an empty `any` does not —
+ * "any of nothing" is false, and the alternative would silently widen a rule to
+ * the whole table.
  *
- * Fail-closed semantics: unparsable date values in the inspected object
- * (for `withinNext` / `olderThan`) cause that entry to NOT match, plus a
- * debug log. The rule still evaluates the remaining entries — useful so a
- * single bad date does not silently bypass other constraints.
+ * Fail-closed throughout, at two different volumes:
+ *  - an unparsable date or instant on one object makes that clause not match,
+ *    logged at debug: normal data, one row;
+ *  - a filter that does not parse at all makes the whole rule match nothing,
+ *    logged at WARNING: that is a rule which can never fire, and the previous
+ *    behaviour of accepting it quietly is the defect this class was changed to
+ *    end.
+ *
+ * @spec openspec/specs/notificatie-engine/spec.md
  */
 final class ScheduledFilterEvaluator {
 
@@ -64,6 +74,13 @@ final class ScheduledFilterEvaluator {
 	private LoggerInterface $logger;
 
 	/**
+	 * Parses a raw filter map into the AST this evaluator walks.
+	 *
+	 * @var ScheduledFilterParser
+	 */
+	private ScheduledFilterParser $parser;
+
+	/**
 	 * Construct an evaluator with an optional logger.
 	 *
 	 * The logger is used to emit debug-level diagnostics when a value cannot
@@ -71,9 +88,11 @@ final class ScheduledFilterEvaluator {
 	 * logger, tests may pass a NullLogger.
 	 *
 	 * @param LoggerInterface|null $logger Logger for fail-closed diagnostics.
+	 * @param ScheduledFilterParser|null $parser Parser producing the AST to walk.
 	 */
-	public function __construct(?LoggerInterface $logger = null) {
+	public function __construct(?LoggerInterface $logger = null, ?ScheduledFilterParser $parser = null) {
 		$this->logger = ($logger ?? new NullLogger());
+		$this->parser = ($parser ?? new ScheduledFilterParser());
 
 	}//end __construct()
 
@@ -85,89 +104,248 @@ final class ScheduledFilterEvaluator {
 	 * @param DateTimeImmutable $now Logical "now" for the entire scan pass.
 	 *
 	 * @return bool True when every entry matches, false otherwise.
+	 *
+	 * @spec openspec/specs/notificatie-engine/spec.md
 	 */
 	public function matches(array $objectData, array $filter, DateTimeImmutable $now): bool {
 		if (count($filter) === 0) {
 			return true;
 		}
 
-		foreach ($filter as $field => $spec) {
-			if ($this->entryMatches(field: (string)$field, spec: $spec, objectData: $objectData, now: $now) === false) {
-				return false;
-			}
+		$parsed = $this->parser->parse(filter: $filter);
+
+		if ($parsed['ast'] === null) {
+			// An unexecutable filter is not normal data the way an unparsable
+			// date on one object is — it is a rule that can never fire, so it
+			// is reported at warning level rather than debug, and it matches
+			// nothing rather than everything.
+			$this->logger->warning(
+				'ScheduledFilterEvaluator: filter does not parse; the rule matches nothing',
+				[
+					'errors' => array_column($parsed['errors'], 'message'),
+				]
+			);
+
+			return false;
 		}
 
-		return true;
+		return $this->nodeMatches(node: $parsed['ast'], objectData: $objectData, now: $now);
 	}//end matches()
 
 	/**
-	 * Evaluate a single filter entry.
+	 * Evaluate one AST node against an object.
 	 *
-	 * @param string $field The field name on the object.
-	 * @param mixed $spec Either a scalar (equals shortcut) or an operator object.
+	 * @param array<string, mixed> $node The AST node.
 	 * @param array<string, mixed> $objectData The full object data map.
-	 * @param DateTimeImmutable $now Logical "now" for the entry.
+	 * @param DateTimeImmutable $now Logical "now" for the scan pass.
 	 *
-	 * @return bool True when the entry matches.
+	 * @return bool True when the node matches.
 	 */
-	private function entryMatches(string $field, $spec, array $objectData, DateTimeImmutable $now): bool {
-		$actual = ($objectData[$field] ?? null);
+	private function nodeMatches(array $node, array $objectData, DateTimeImmutable $now): bool {
+		$type = (string)($node['type'] ?? '');
 
-		// Scalar shortcut — strict equality.
-		if (is_array($spec) === false || array_key_exists('operator', $spec) === false) {
-			return $actual === $spec;
+		if ($type === 'all') {
+			// An empty conjunction matches — an unconstrained filter selects
+			// everything, which is what an empty `filter` already meant.
+			foreach (($node['clauses'] ?? []) as $clause) {
+				if ($this->nodeMatches(node: $clause, objectData: $objectData, now: $now) === false) {
+					return false;
+				}
+			}
+
+			return true;
 		}
 
-		$operator = (string)$spec['operator'];
-		$value = ($spec['value'] ?? null);
+		if ($type === 'any') {
+			// An empty disjunction does NOT match: "any of nothing" is false,
+			// and treating it as true would silently widen a rule to the whole
+			// table.
+			foreach (($node['clauses'] ?? []) as $clause) {
+				if ($this->nodeMatches(node: $clause, objectData: $objectData, now: $now) === true) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		return $this->leafMatches(node: $node, objectData: $objectData, now: $now);
+	}//end nodeMatches()
+
+	/**
+	 * Evaluate one leaf clause against an object.
+	 *
+	 * @param array<string, mixed> $node The leaf node.
+	 * @param array<string, mixed> $objectData The full object data map.
+	 * @param DateTimeImmutable $now Logical "now" for the clause.
+	 *
+	 * @return bool True when the clause matches.
+	 *
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)  one arm per operator; the
+	 * grammar has eight, and a dispatch table would hide which operators exist
+	 * from anyone reading the evaluator.
+	 */
+	private function leafMatches(array $node, array $objectData, DateTimeImmutable $now): bool {
+		$field    = (string)($node['field'] ?? '');
+		$operator = (string)($node['operator'] ?? '');
+		$operand  = ($node['operand'] ?? null);
+		$actual   = ($objectData[$field] ?? null);
 
 		switch ($operator) {
 			case 'equals':
-				return $actual === $value;
+				return $actual === $operand;
 			case 'notEquals':
 				// Missing/null field satisfies notEquals for any non-null target.
-				if ($actual === null && $value !== null) {
+				if ($actual === null && $operand !== null) {
 					return true;
 				}
-				return $actual !== $value;
+
+				return $actual !== $operand;
+			case 'in':
+				return $this->membershipMatches(actual: $actual, values: (array)$operand);
+			case 'notIn':
+				// Missing/null field is not a member of anything, so it
+				// satisfies notIn — the mirror of the notEquals rule above.
+				if ($actual === null) {
+					return true;
+				}
+
+				return ($this->membershipMatches(actual: $actual, values: (array)$operand) === false);
+			case 'before':
+			case 'after':
+				$instant = $this->resolveInstant(value: (string)$operand, field: $field, operator: $operator, now: $now);
+				if ($instant === null) {
+					return false;
+				}
+
+				$fieldDate = $this->parseDate(value: $actual, field: $field);
+				if ($fieldDate === null) {
+					return false;
+				}
+
+				if ($operator === 'before') {
+					return ($fieldDate < $instant);
+				}
+
+				return ($fieldDate > $instant);
 			case 'withinNext':
-				$interval = $this->parseDuration(duration: (string)$value, field: $field, operator: $operator);
-				if ($interval === null) {
-					return false;
-				}
-
-				$fieldDate = $this->parseDate(value: $actual, field: $field);
-				if ($fieldDate === null) {
-					return false;
-				}
-
-				$upper = $now->add($interval);
-
-				// Half-open window: (now, now + duration].
-				return ($fieldDate > $now && $fieldDate <= $upper);
 			case 'olderThan':
-				$interval = $this->parseDuration(duration: (string)$value, field: $field, operator: $operator);
-				if ($interval === null) {
-					return false;
-				}
-
-				$fieldDate = $this->parseDate(value: $actual, field: $field);
-				if ($fieldDate === null) {
-					return false;
-				}
-
-				$threshold = $now->sub($interval);
-
-				return $fieldDate < $threshold;
-			default:
-				$this->logger->debug(
-					'ScheduledFilterEvaluator: unknown operator (fail-closed)',
-					['field' => $field, 'operator' => $operator]
+				return $this->durationMatches(
+					operator: $operator,
+					operand: $operand,
+					actual: $actual,
+					field: $field,
+					now: $now
 				);
+			default:
+				// Unreachable: the parser rejects unknown operators before the
+				// evaluator ever sees them. Fail closed regardless.
 				return false;
 		}//end switch
+	}//end leafMatches()
 
-	}//end entryMatches()
+	/**
+	 * Test strict membership, treating an array-valued field as an intersection.
+	 *
+	 * A multi-select field holding ["a","b"] is "in" ["b","c"] because the sets
+	 * overlap — the useful reading for tags and multi-value enums.
+	 *
+	 * @param mixed $actual The object's value.
+	 * @param array<int, mixed> $values The candidate values.
+	 *
+	 * @return bool True when the value is a member, or overlaps the list.
+	 */
+	private function membershipMatches($actual, array $values): bool {
+		if (is_array($actual) === true) {
+			foreach ($actual as $item) {
+				if (in_array($item, $values, true) === true) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		return in_array($actual, $values, true);
+	}//end membershipMatches()
+
+	/**
+	 * Evaluate the two duration-relative operators.
+	 *
+	 * @param string $operator Either `withinNext` or `olderThan`.
+	 * @param mixed $operand The ISO-8601 duration.
+	 * @param mixed $actual The object's value.
+	 * @param string $field The field name, for diagnostics.
+	 * @param DateTimeImmutable $now Logical "now".
+	 *
+	 * @return bool True when the clause matches.
+	 */
+	private function durationMatches(string $operator, $operand, $actual, string $field, DateTimeImmutable $now): bool {
+		$interval = $this->parseDuration(duration: (string)$operand, field: $field, operator: $operator);
+		if ($interval === null) {
+			return false;
+		}
+
+		$fieldDate = $this->parseDate(value: $actual, field: $field);
+		if ($fieldDate === null) {
+			return false;
+		}
+
+		if ($operator === 'withinNext') {
+			// Half-open window: (now, now + duration].
+			$upper = $now->add($interval);
+
+			return ($fieldDate > $now && $fieldDate <= $upper);
+		}
+
+		$threshold = $now->sub($interval);
+
+		return ($fieldDate < $threshold);
+	}//end durationMatches()
+
+	/**
+	 * Resolve a reference instant for `before` / `after`.
+	 *
+	 * Accepts `now`, an absolute ISO-8601 date/date-time, or a signed ISO-8601
+	 * duration measured from now (`P7D` future, `-P7D` past). The sign is
+	 * mandatory for the past direction: `before "P7D"` reads equally naturally
+	 * as "a week from now" and "a week ago", and an ambiguous date operator in a
+	 * reminder engine is how a thousand wrong emails get sent.
+	 *
+	 * @param string $value The instant as written.
+	 * @param string $field The field name, for diagnostics.
+	 * @param string $operator The operator name, for diagnostics.
+	 * @param DateTimeImmutable $now Logical "now".
+	 *
+	 * @return DateTimeImmutable|null The instant, or null when unresolvable.
+	 */
+	private function resolveInstant(string $value, string $field, string $operator, DateTimeImmutable $now): ?DateTimeImmutable {
+		if ($value === 'now') {
+			return $now;
+		}
+
+		$negative = false;
+		$duration = $value;
+		if (str_starts_with($duration, '-') === true) {
+			$negative = true;
+			$duration = substr($duration, 1);
+		}
+
+		try {
+			$interval = new DateInterval($duration);
+
+			if ($negative === true) {
+				return $now->sub($interval);
+			}
+
+			return $now->add($interval);
+		} catch (Exception $e) {
+			// Not a duration — fall through to absolute-date parsing.
+		}
+
+		return $this->parseDate(value: $value, field: $field);
+	}//end resolveInstant()
+
 
 	/**
 	 * Parse an ISO-8601 DateInterval string. Logs + returns null on failure.

--- a/lib/Service/Notification/ScheduledFilterEvaluator.php
+++ b/lib/Service/Notification/ScheduledFilterEvaluator.php
@@ -213,7 +213,7 @@ final class ScheduledFilterEvaluator {
 				return ($this->membershipMatches(actual: $actual, values: (array)$operand) === false);
 			case 'before':
 			case 'after':
-				$instant = $this->resolveInstant(value: (string)$operand, field: $field, operator: $operator, now: $now);
+				$instant = $this->resolveInstant(value: (string)$operand, field: $field, now: $now);
 				if ($instant === null) {
 					return false;
 				}
@@ -314,12 +314,11 @@ final class ScheduledFilterEvaluator {
 	 *
 	 * @param string $value The instant as written.
 	 * @param string $field The field name, for diagnostics.
-	 * @param string $operator The operator name, for diagnostics.
 	 * @param DateTimeImmutable $now Logical "now".
 	 *
 	 * @return DateTimeImmutable|null The instant, or null when unresolvable.
 	 */
-	private function resolveInstant(string $value, string $field, string $operator, DateTimeImmutable $now): ?DateTimeImmutable {
+	private function resolveInstant(string $value, string $field, DateTimeImmutable $now): ?DateTimeImmutable {
 		if ($value === 'now') {
 			return $now;
 		}

--- a/lib/Service/Notification/ScheduledFilterGrammar.php
+++ b/lib/Service/Notification/ScheduledFilterGrammar.php
@@ -1,0 +1,159 @@
+<?php
+
+/**
+ * The scheduled-notification filter grammar, enumerated once.
+ *
+ * Before this class existed the grammar was written down twice — as a switch in
+ * ScheduledFilterEvaluator and as a validation list in
+ * NotificationAnnotationValidator — and the two disagreed. The validator
+ * accepted any array that lacked an `operator` key as a "scalar shortcut",
+ * while the evaluator compared that array to a scalar field and matched
+ * nothing. 24 filter entries across three apps were accepted at save time and
+ * silently never fired.
+ *
+ * Everything that needs to know what the grammar admits reads it from here, so
+ * "the validator accepts a shape the evaluator cannot execute" is a
+ * contradiction rather than a bug waiting to recur.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Notification
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/notificatie-engine/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Notification;
+
+/**
+ * Constants describing the filter grammar shared by the parser, the evaluator
+ * and the validator.
+ *
+ * @spec openspec/specs/notificatie-engine/spec.md
+ */
+final class ScheduledFilterGrammar {
+
+	/**
+	 * Every operator a filter clause may name.
+	 *
+	 * @var array<int, string>
+	 */
+	public const OPERATORS = [
+		'equals',
+		'notEquals',
+		'withinNext',
+		'olderThan',
+		'in',
+		'notIn',
+		'before',
+		'after',
+	];
+
+	/**
+	 * Operators whose operand is a list, supplied under `values`.
+	 *
+	 * @var array<int, string>
+	 */
+	public const MEMBERSHIP_OPERATORS = ['in', 'notIn'];
+
+	/**
+	 * Operators whose operand is an ISO-8601 duration measured from now.
+	 *
+	 * @var array<int, string>
+	 */
+	public const DURATION_OPERATORS = ['withinNext', 'olderThan'];
+
+	/**
+	 * Operators whose operand is a reference instant.
+	 *
+	 * @var array<int, string>
+	 */
+	public const INSTANT_OPERATORS = ['before', 'after'];
+
+	/**
+	 * Operators taking a single scalar operand under `value`.
+	 *
+	 * @var array<int, string>
+	 */
+	public const SCALAR_OPERATORS = ['equals', 'notEquals'];
+
+	/**
+	 * Reserved keys that introduce a nested clause list rather than a field.
+	 *
+	 * @var array<int, string>
+	 */
+	public const COMBINATORS = ['all', 'any'];
+
+	/**
+	 * How deeply combinators may nest before nesting is a validation error.
+	 *
+	 * Bounded so a hand-written annotation cannot recurse the parser into a
+	 * stack overflow. No fleet filter nests at all; the value only has to be
+	 * finite and stated.
+	 *
+	 * @var int
+	 */
+	public const MAX_DEPTH = 5;
+
+	/**
+	 * The literal accepted by the instant operators meaning "the scan's now".
+	 *
+	 * @var string
+	 */
+	public const INSTANT_NOW = 'now';
+
+	/**
+	 * Report whether a name is a known operator.
+	 *
+	 * @param string $operator Candidate operator name.
+	 *
+	 * @return bool True when the operator is part of the grammar.
+	 *
+	 * @spec openspec/specs/notificatie-engine/spec.md
+	 */
+	public static function isOperator(string $operator): bool {
+		return in_array($operator, self::OPERATORS, true);
+
+	}//end isOperator()
+
+	/**
+	 * Report whether a key introduces a nested clause list.
+	 *
+	 * @param string $key Candidate combinator key.
+	 *
+	 * @return bool True when the key is `all` or `any`.
+	 *
+	 * @spec openspec/specs/notificatie-engine/spec.md
+	 */
+	public static function isCombinator(string $key): bool {
+		return in_array($key, self::COMBINATORS, true);
+
+	}//end isCombinator()
+
+	/**
+	 * Name the operand key an operator expects.
+	 *
+	 * @param string $operator A known operator name.
+	 *
+	 * @return string Either `values` for membership operators, or `value`.
+	 *
+	 * @spec openspec/specs/notificatie-engine/spec.md
+	 */
+	public static function operandKey(string $operator): string {
+		if (in_array($operator, self::MEMBERSHIP_OPERATORS, true) === true) {
+			return 'values';
+		}
+
+		return 'value';
+
+	}//end operandKey()
+
+}//end class

--- a/lib/Service/Notification/ScheduledFilterParser.php
+++ b/lib/Service/Notification/ScheduledFilterParser.php
@@ -120,13 +120,14 @@ final class ScheduledFilterParser {
 	private function parseFieldEntry(string $field, $spec, string $ruleKey, string $path): array {
 		// Scalar shortcut — strict equality, the historical default.
 		if (is_array($spec) === false) {
-			return $this->accept(['type' => 'leaf', 'field' => $field, 'operator' => 'equals', 'operand' => $spec]);
+			return $this->accept(node: ['type' => 'leaf', 'field' => $field, 'operator' => 'equals', 'operand' => $spec]);
 		}
 
 		// Bare list — membership over the list.
 		if (array_is_list($spec) === true) {
 			if ($spec === []) {
-				return $this->reject($this->error(
+				return $this->reject(
+				error: $this->error(
 							code: 'notification-scheduled-empty-list',
 							ruleKey: $ruleKey,
 							field: $path,
@@ -139,7 +140,7 @@ final class ScheduledFilterParser {
 						));
 			}
 
-			return $this->accept(['type' => 'leaf', 'field' => $field, 'operator' => 'in', 'operand' => $spec]);
+			return $this->accept(node: ['type' => 'leaf', 'field' => $field, 'operator' => 'in', 'operand' => $spec]);
 		}//end if
 
 		// Operator object.
@@ -182,7 +183,8 @@ final class ScheduledFilterParser {
 				];
 			}
 
-			return $this->reject($this->error(
+			return $this->reject(
+				error: $this->error(
 						code: 'notification-scheduled-bad-filter-shape',
 						ruleKey: $ruleKey,
 						field: sprintf('trigger.filter.%s', $path),
@@ -221,7 +223,8 @@ final class ScheduledFilterParser {
 		$operandKey = ScheduledFilterGrammar::operandKey($operator);
 
 		if (array_key_exists($operandKey, $spec) === false) {
-			return $this->reject($this->error(
+			return $this->reject(
+				error: $this->error(
 						code: 'notification-scheduled-bad-filter-missing-value',
 						ruleKey: $ruleKey,
 						field: sprintf('trigger.filter.%s.%s', $path, $operandKey),
@@ -249,7 +252,7 @@ final class ScheduledFilterParser {
 			return ['node' => null, 'errors' => $errors];
 		}
 
-		return $this->accept(['type' => 'leaf', 'field' => $field, 'operator' => $operator, 'operand' => $operand]);
+		return $this->accept(node: ['type' => 'leaf', 'field' => $field, 'operator' => $operator, 'operand' => $operand]);
 
 	}//end parseOperatorObject()
 
@@ -433,7 +436,7 @@ final class ScheduledFilterParser {
 	private function parseCombinator(string $combinator, $spec, string $ruleKey, string $path, int $depth): array {
 		if ($depth > ScheduledFilterGrammar::MAX_DEPTH) {
 			return $this->reject(
-				$this->error(
+				error: $this->error(
 					code: 'notification-scheduled-filter-too-deep',
 					ruleKey: $ruleKey,
 					field: sprintf('trigger.filter.%s', $path),
@@ -450,7 +453,7 @@ final class ScheduledFilterParser {
 
 		if (is_array($spec) === false || array_is_list($spec) === false) {
 			return $this->reject(
-				$this->error(
+				error: $this->error(
 					code: 'notification-scheduled-bad-combinator',
 					ruleKey: $ruleKey,
 					field: sprintf('trigger.filter.%s', $path),
@@ -483,7 +486,7 @@ final class ScheduledFilterParser {
 			return ['node' => null, 'errors' => $errors];
 		}
 
-		return $this->accept(['type' => $combinator, 'clauses' => $clauses]);
+		return $this->accept(node: ['type' => $combinator, 'clauses' => $clauses]);
 
 	}//end parseCombinator()
 

--- a/lib/Service/Notification/ScheduledFilterParser.php
+++ b/lib/Service/Notification/ScheduledFilterParser.php
@@ -1,0 +1,682 @@
+<?php
+
+/**
+ * Parses a scheduled-trigger `filter` annotation into a normalised AST.
+ *
+ * This is the single gate between what an author writes and what the engine
+ * runs. The validator reports the errors this parser produces; the evaluator
+ * executes the AST it produces. Neither enumerates operators itself, so a shape
+ * the validator accepts is by construction a shape the evaluator can execute —
+ * which is precisely what was untrue before: 24 filter entries across three
+ * apps were accepted at save time and matched nothing at scan time.
+ *
+ * The AST is deliberately free of anything time-dependent. A clause holds its
+ * operand exactly as written and the evaluator resolves `now` against the scan's
+ * single reference instant, so parsing can be cached and, later, compiled to SQL
+ * (PERF-3) without the parse result silently ageing.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Notification
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/notificatie-engine/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Notification;
+
+use DateInterval;
+use Exception;
+
+/**
+ * Turns a raw `filter` map into either an AST or a list of structured errors.
+ *
+ * The class is complex because the grammar is: four entry forms, eight
+ * operators over four operand families, and two nesting combinators. Splitting
+ * it further would separate the accept decision from the error that explains a
+ * rejection, and it is exactly that separation — the validator deciding one
+ * thing and the evaluator another — which let 24 unexecutable filters ship.
+ *
+ * @spec openspec/specs/notificatie-engine/spec.md
+ *
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+final class ScheduledFilterParser {
+
+	/**
+	 * Parse a filter map.
+	 *
+	 * @param array<string, mixed> $filter  The raw `trigger.filter` map.
+	 * @param string               $ruleKey Notification rule name, for error reporting.
+	 *
+	 * @return array{ast: ?array<string, mixed>, errors: array<int, array<string, mixed>>}
+	 *         `ast` is null when `errors` is non-empty.
+	 *
+	 * @spec openspec/specs/notificatie-engine/spec.md
+	 */
+	public function parse(array $filter, string $ruleKey = ''): array {
+		$errors  = [];
+		$clauses = [];
+
+		foreach ($filter as $key => $spec) {
+			$key = (string) $key;
+
+			if (ScheduledFilterGrammar::isCombinator($key) === true) {
+				$parsed = $this->parseCombinator(
+					combinator: $key,
+					spec: $spec,
+					ruleKey: $ruleKey,
+					path: $key,
+					depth: 1
+				);
+
+				$errors = array_merge($errors, $parsed['errors']);
+				if ($parsed['node'] !== null) {
+					$clauses[] = $parsed['node'];
+				}
+
+				continue;
+			}
+
+			$parsed = $this->parseFieldEntry(field: $key, spec: $spec, ruleKey: $ruleKey, path: $key);
+
+			$errors = array_merge($errors, $parsed['errors']);
+			if ($parsed['node'] !== null) {
+				$clauses[] = $parsed['node'];
+			}
+		}//end foreach
+
+		if (empty($errors) === false) {
+			return ['ast' => null, 'errors' => $errors];
+		}
+
+		// Top-level entries are ANDed, unchanged from the previous grammar.
+		return [
+			'ast'    => ['type' => 'all', 'clauses' => $clauses],
+			'errors' => [],
+		];
+
+	}//end parse()
+
+	/**
+	 * Parse one `field => spec` entry into a leaf node.
+	 *
+	 * @param string $field   Field name on the object.
+	 * @param mixed  $spec    Scalar, bare list, or operator object.
+	 * @param string $ruleKey Notification rule name.
+	 * @param string $path    Dotted path for error reporting.
+	 *
+	 * @return array{node: ?array<string, mixed>, errors: array<int, array<string, mixed>>}
+	 */
+	private function parseFieldEntry(string $field, $spec, string $ruleKey, string $path): array {
+		// Scalar shortcut — strict equality, the historical default.
+		if (is_array($spec) === false) {
+			return $this->accept(['type' => 'leaf', 'field' => $field, 'operator' => 'equals', 'operand' => $spec]);
+		}
+
+		// Bare list — membership over the list.
+		if (array_is_list($spec) === true) {
+			if ($spec === []) {
+				return $this->reject($this->error(
+							code: 'notification-scheduled-empty-list',
+							ruleKey: $ruleKey,
+							field: $path,
+							value: $spec,
+							message: sprintf(
+								'Notification "%s" trigger.filter.%s is an empty list; a membership test over no values can never match.',
+								$ruleKey,
+								$path
+							)
+						));
+			}
+
+			return $this->accept(['type' => 'leaf', 'field' => $field, 'operator' => 'in', 'operand' => $spec]);
+		}//end if
+
+		// Operator object.
+		return $this->parseOperatorObject(field: $field, spec: $spec, ruleKey: $ruleKey, path: $path);
+
+	}//end parseFieldEntry()
+
+	/**
+	 * Parse an operator object into a leaf node.
+	 *
+	 * @param string               $field   Field name on the object.
+	 * @param array<string, mixed> $spec    The operator object.
+	 * @param string               $ruleKey Notification rule name.
+	 * @param string               $path    Dotted path for error reporting.
+	 *
+	 * @return array{node: ?array<string, mixed>, errors: array<int, array<string, mixed>>}
+	 */
+	private function parseOperatorObject(string $field, array $spec, string $ruleKey, string $path): array {
+		if (array_key_exists('operator', $spec) === false) {
+			// `op` is the spelling openconnector reached for. Name the expected
+			// key rather than reporting a generic shape error, because the
+			// author's intent is unambiguous and the fix is one word.
+			if (array_key_exists('op', $spec) === true) {
+				return [
+					'node'   => null,
+					'errors' => [
+						$this->error(
+							code: 'notification-scheduled-bad-filter-operator-key',
+							ruleKey: $ruleKey,
+							field: sprintf('trigger.filter.%s', $path),
+							value: $spec['op'],
+							message: sprintf(
+								'Notification "%s" trigger.filter.%s names the operator under "op"; the expected key is "operator" (got "op": %s).',
+								$ruleKey,
+								$path,
+								var_export($spec['op'], true)
+							)
+						),
+					],
+				];
+			}
+
+			return $this->reject($this->error(
+						code: 'notification-scheduled-bad-filter-shape',
+						ruleKey: $ruleKey,
+						field: sprintf('trigger.filter.%s', $path),
+						value: $spec,
+						message: sprintf(
+							'Notification "%s" trigger.filter.%s is a map without an "operator" key; it is neither a scalar, a list, nor an operator object.',
+							$ruleKey,
+							$path
+						)
+					));
+		}//end if
+
+		$operator = (string) $spec['operator'];
+
+		if (ScheduledFilterGrammar::isOperator($operator) === false) {
+			return [
+				'node'   => null,
+				'errors' => [
+					$this->error(
+						code: 'notification-scheduled-bad-filter-operator',
+						ruleKey: $ruleKey,
+						field: sprintf('trigger.filter.%s.operator', $path),
+						value: $operator,
+						message: sprintf(
+							'Notification "%s" trigger.filter.%s.operator must be one of [%s]; got "%s".',
+							$ruleKey,
+							$path,
+							implode(', ', ScheduledFilterGrammar::OPERATORS),
+							$operator
+						)
+					),
+				],
+			];
+		}
+
+		$operandKey = ScheduledFilterGrammar::operandKey($operator);
+
+		if (array_key_exists($operandKey, $spec) === false) {
+			return $this->reject($this->error(
+						code: 'notification-scheduled-bad-filter-missing-value',
+						ruleKey: $ruleKey,
+						field: sprintf('trigger.filter.%s.%s', $path, $operandKey),
+						value: null,
+						message: sprintf(
+							'Notification "%s" trigger.filter.%s uses operator "%s" and therefore requires a "%s" key.',
+							$ruleKey,
+							$path,
+							$operator,
+							$operandKey
+						)
+					));
+		}
+
+		$operand = $spec[$operandKey];
+		$errors  = $this->validateOperand(
+			operator: $operator,
+			operand: $operand,
+			ruleKey: $ruleKey,
+			path: $path,
+			operandKey: $operandKey
+		);
+
+		if (empty($errors) === false) {
+			return ['node' => null, 'errors' => $errors];
+		}
+
+		return $this->accept(['type' => 'leaf', 'field' => $field, 'operator' => $operator, 'operand' => $operand]);
+
+	}//end parseOperatorObject()
+
+	/**
+	 * Check that an operand suits its operator.
+	 *
+	 * @param string $operator   The operator name.
+	 * @param mixed  $operand    The operand as written.
+	 * @param string $ruleKey    Notification rule name.
+	 * @param string $path       Dotted path for error reporting.
+	 * @param string $operandKey Either `value` or `values`.
+	 *
+	 * @return array<int, array<string, mixed>> Errors, empty when the operand suits.
+	 */
+	private function validateOperand(string $operator, $operand, string $ruleKey, string $path, string $operandKey): array {
+		if (in_array($operator, ScheduledFilterGrammar::MEMBERSHIP_OPERATORS, true) === true) {
+			return $this->validateMembershipOperand(operator: $operator, operand: $operand, ruleKey: $ruleKey, path: $path);
+		}
+
+		if (in_array($operator, ScheduledFilterGrammar::DURATION_OPERATORS, true) === true) {
+			return $this->validateDurationOperand(operator: $operator, operand: $operand, ruleKey: $ruleKey, path: $path);
+		}
+
+		if (in_array($operator, ScheduledFilterGrammar::INSTANT_OPERATORS, true) === true) {
+			return $this->validateInstantOperand(operator: $operator, operand: $operand, ruleKey: $ruleKey, path: $path);
+		}
+
+		return $this->validateScalarOperand(
+			operator: $operator,
+			operand: $operand,
+			ruleKey: $ruleKey,
+			path: $path,
+			operandKey: $operandKey
+		);
+
+	}//end validateOperand()
+
+	/**
+	 * Check a membership operand is a non-empty list.
+	 *
+	 * @param string $operator The operator name.
+	 * @param mixed  $operand  The operand as written.
+	 * @param string $ruleKey  Notification rule name.
+	 * @param string $path     Dotted path for error reporting.
+	 *
+	 * @return array<int, array<string, mixed>> Errors, empty when the operand suits.
+	 */
+	private function validateMembershipOperand(string $operator, $operand, string $ruleKey, string $path): array {
+		if (is_array($operand) === true && array_is_list($operand) === true && $operand !== []) {
+			return [];
+		}
+
+		return [
+			$this->error(
+				code: 'notification-scheduled-bad-filter-values',
+				ruleKey: $ruleKey,
+				field: sprintf('trigger.filter.%s.values', $path),
+				value: $operand,
+				message: sprintf(
+					'Notification "%s" trigger.filter.%s uses operator "%s" and therefore requires "values" to be a non-empty list.',
+					$ruleKey,
+					$path,
+					$operator
+				)
+			),
+		];
+
+	}//end validateMembershipOperand()
+
+	/**
+	 * Check a duration operand parses as an ISO-8601 duration.
+	 *
+	 * @param string $operator The operator name.
+	 * @param mixed  $operand  The operand as written.
+	 * @param string $ruleKey  Notification rule name.
+	 * @param string $path     Dotted path for error reporting.
+	 *
+	 * @return array<int, array<string, mixed>> Errors, empty when the operand suits.
+	 */
+	private function validateDurationOperand(string $operator, $operand, string $ruleKey, string $path): array {
+		if (is_string($operand) === true && $this->parseDuration(duration: (string) $operand) !== null) {
+			return [];
+		}
+
+		return [
+			$this->error(
+				code: 'notification-scheduled-bad-filter-duration',
+				ruleKey: $ruleKey,
+				field: sprintf('trigger.filter.%s.value', $path),
+				value: $operand,
+				message: sprintf(
+					'Notification "%s" trigger.filter.%s uses operator "%s" and therefore requires an ISO-8601 duration (e.g. "P7D", "PT24H"); got %s.',
+					$ruleKey,
+					$path,
+					$operator,
+					var_export($operand, true)
+				)
+			),
+		];
+
+	}//end validateDurationOperand()
+
+	/**
+	 * Check an instant operand resolves.
+	 *
+	 * @param string $operator The operator name.
+	 * @param mixed  $operand  The operand as written.
+	 * @param string $ruleKey  Notification rule name.
+	 * @param string $path     Dotted path for error reporting.
+	 *
+	 * @return array<int, array<string, mixed>> Errors, empty when the operand suits.
+	 */
+	private function validateInstantOperand(string $operator, $operand, string $ruleKey, string $path): array {
+		if (is_string($operand) === true && $this->isResolvableInstant(value: (string) $operand) === true) {
+			return [];
+		}
+
+		return [
+			$this->error(
+				code: 'notification-scheduled-bad-filter-instant',
+				ruleKey: $ruleKey,
+				field: sprintf('trigger.filter.%s.value', $path),
+				value: $operand,
+				message: sprintf(
+					'Notification "%s" trigger.filter.%s uses operator "%s" and therefore requires "now", an ISO-8601 '
+					. 'date/date-time, or a signed ISO-8601 duration ("P7D" future, "-P7D" past); got %s.',
+					$ruleKey,
+					$path,
+					$operator,
+					var_export($operand, true)
+				)
+			),
+		];
+
+	}//end validateInstantOperand()
+
+	/**
+	 * Check a scalar operand is not an array.
+	 *
+	 * @param string $operator   The operator name.
+	 * @param mixed  $operand    The operand as written.
+	 * @param string $ruleKey    Notification rule name.
+	 * @param string $path       Dotted path for error reporting.
+	 * @param string $operandKey Either `value` or `values`.
+	 *
+	 * @return array<int, array<string, mixed>> Errors, empty when the operand suits.
+	 */
+	private function validateScalarOperand(string $operator, $operand, string $ruleKey, string $path, string $operandKey): array {
+		if (is_array($operand) === false) {
+			return [];
+		}
+
+		return [
+			$this->error(
+				code: 'notification-scheduled-bad-filter-value',
+				ruleKey: $ruleKey,
+				field: sprintf('trigger.filter.%s.%s', $path, $operandKey),
+				value: $operand,
+				message: sprintf(
+					'Notification "%s" trigger.filter.%s uses operator "%s" and therefore requires a scalar "value"; got an array.',
+					$ruleKey,
+					$path,
+					$operator
+				)
+			),
+		];
+
+	}//end validateScalarOperand()
+
+	/**
+	 * Parse a combinator entry into a nested node.
+	 *
+	 * @param string $combinator Either `all` or `any`.
+	 * @param mixed  $spec       The clause list.
+	 * @param string $ruleKey    Notification rule name.
+	 * @param string $path       Dotted path for error reporting.
+	 * @param int    $depth      Current nesting depth.
+	 *
+	 * @return array{node: ?array<string, mixed>, errors: array<int, array<string, mixed>>}
+	 */
+	private function parseCombinator(string $combinator, $spec, string $ruleKey, string $path, int $depth): array {
+		if ($depth > ScheduledFilterGrammar::MAX_DEPTH) {
+			return $this->reject(
+				$this->error(
+					code: 'notification-scheduled-filter-too-deep',
+					ruleKey: $ruleKey,
+					field: sprintf('trigger.filter.%s', $path),
+					value: $depth,
+					message: sprintf(
+						'Notification "%s" trigger.filter.%s nests combinators deeper than %d levels.',
+						$ruleKey,
+						$path,
+						ScheduledFilterGrammar::MAX_DEPTH
+					)
+				)
+			);
+		}
+
+		if (is_array($spec) === false || array_is_list($spec) === false) {
+			return $this->reject(
+				$this->error(
+					code: 'notification-scheduled-bad-combinator',
+					ruleKey: $ruleKey,
+					field: sprintf('trigger.filter.%s', $path),
+					value: $spec,
+					message: sprintf(
+						'Notification "%s" trigger.filter.%s must be a list of clauses.',
+						$ruleKey,
+						$path
+					)
+				)
+			);
+		}
+
+		$errors  = [];
+		$clauses = [];
+
+		foreach ($spec as $index => $clause) {
+			$parsed = $this->parseClause(
+				clause: $clause,
+				ruleKey: $ruleKey,
+				path: sprintf('%s[%d]', $path, (int) $index),
+				depth: $depth
+			);
+
+			$errors  = array_merge($errors, $parsed['errors']);
+			$clauses = array_merge($clauses, $parsed['nodes']);
+		}//end foreach
+
+		if (empty($errors) === false) {
+			return ['node' => null, 'errors' => $errors];
+		}
+
+		return $this->accept(['type' => $combinator, 'clauses' => $clauses]);
+
+	}//end parseCombinator()
+
+	/**
+	 * Parse one clause inside a combinator.
+	 *
+	 * A clause is either a nested combinator or a `{field, operator, …}` object.
+	 *
+	 * @param mixed  $clause  The clause as written.
+	 * @param string $ruleKey Notification rule name.
+	 * @param string $path    Dotted path for error reporting.
+	 * @param int    $depth   Depth of the enclosing combinator.
+	 *
+	 * @return array{nodes: array<int, array<string, mixed>>, errors: array<int, array<string, mixed>>}
+	 */
+	private function parseClause($clause, string $ruleKey, string $path, int $depth): array {
+		if (is_array($clause) === false) {
+			return [
+				'nodes'  => [],
+				'errors' => [
+					$this->error(
+						code: 'notification-scheduled-bad-clause',
+						ruleKey: $ruleKey,
+						field: sprintf('trigger.filter.%s', $path),
+						value: $clause,
+						message: sprintf(
+							'Notification "%s" trigger.filter.%s must be a clause object.',
+							$ruleKey,
+							$path
+						)
+					),
+				],
+			];
+		}
+
+		// A clause may itself be a nested combinator.
+		$nestedKeys = array_intersect(array_keys($clause), ScheduledFilterGrammar::COMBINATORS);
+		if (empty($nestedKeys) === false) {
+			$errors = [];
+			$nodes  = [];
+
+			foreach ($nestedKeys as $nestedKey) {
+				$parsed = $this->parseCombinator(
+					combinator: (string) $nestedKey,
+					spec: $clause[$nestedKey],
+					ruleKey: $ruleKey,
+					path: sprintf('%s.%s', $path, (string) $nestedKey),
+					depth: ($depth + 1)
+				);
+
+				$errors = array_merge($errors, $parsed['errors']);
+				if ($parsed['node'] !== null) {
+					$nodes[] = $parsed['node'];
+				}
+			}
+
+			return ['nodes' => $nodes, 'errors' => $errors];
+		}//end if
+
+		if (array_key_exists('field', $clause) === false || is_string($clause['field']) === false) {
+			return [
+				'nodes'  => [],
+				'errors' => [
+					$this->error(
+						code: 'notification-scheduled-bad-clause-field',
+						ruleKey: $ruleKey,
+						field: sprintf('trigger.filter.%s.field', $path),
+						value: ($clause['field'] ?? null),
+						message: sprintf(
+							'Notification "%s" trigger.filter.%s requires a string "field".',
+							$ruleKey,
+							$path
+						)
+					),
+				],
+			];
+		}
+
+		$parsed = $this->parseOperatorObject(
+			field: (string) $clause['field'],
+			spec: $clause,
+			ruleKey: $ruleKey,
+			path: $path
+		);
+
+		$nodes = [];
+		if ($parsed['node'] !== null) {
+			$nodes[] = $parsed['node'];
+		}
+
+		return ['nodes' => $nodes, 'errors' => $parsed['errors']];
+
+	}//end parseClause()
+
+	/**
+	 * Report whether a reference instant can be resolved.
+	 *
+	 * @param string $value The instant as written.
+	 *
+	 * @return bool True when `now`, a parseable date, or a signed duration.
+	 */
+	private function isResolvableInstant(string $value): bool {
+		if ($value === ScheduledFilterGrammar::INSTANT_NOW) {
+			return true;
+		}
+
+		if ($this->parseDuration(duration: $value) !== null) {
+			return true;
+		}
+
+		return (strtotime($value) !== false);
+
+	}//end isResolvableInstant()
+
+	/**
+	 * Parse an ISO-8601 duration, accepting a leading `-` for the past direction.
+	 *
+	 * `DateInterval::__construct()` rejects a leading minus, so the sign is
+	 * stripped and expressed as `invert`.
+	 *
+	 * @param string $duration The duration as written.
+	 *
+	 * @return DateInterval|null The interval, or null when unparseable.
+	 */
+	private function parseDuration(string $duration): ?DateInterval {
+		if ($duration === '') {
+			return null;
+		}
+
+		$negative = false;
+		if (str_starts_with($duration, '-') === true) {
+			$negative = true;
+			$duration = substr($duration, 1);
+		}
+
+		try {
+			$interval = new DateInterval($duration);
+		} catch (Exception $e) {
+			return null;
+		}
+
+		if ($negative === true) {
+			$interval->invert = 1;
+		}
+
+		return $interval;
+
+	}//end parseDuration()
+
+	/**
+	 * Wrap a parsed node as a successful result.
+	 *
+	 * @param array<string, mixed> $node The parsed node.
+	 *
+	 * @return array{node: array<string, mixed>, errors: array<int, array<string, mixed>>}
+	 */
+	private function accept(array $node): array {
+		return ['node' => $node, 'errors' => []];
+
+	}//end accept()
+
+	/**
+	 * Wrap one error as a failed result.
+	 *
+	 * @param array<string, mixed> $error The error entry.
+	 *
+	 * @return array{node: null, errors: array<int, array<string, mixed>>}
+	 */
+	private function reject(array $error): array {
+		return ['node' => null, 'errors' => [$error]];
+
+	}//end reject()
+
+	/**
+	 * Build one structured error in the shape the validator already reports.
+	 *
+	 * @param string $code    Machine-readable error code.
+	 * @param string $ruleKey Notification rule name.
+	 * @param string $field   Dotted path to the offending key.
+	 * @param mixed  $value   The offending value.
+	 * @param string $message Human-readable diagnosis.
+	 *
+	 * @return array<string, mixed> The error entry.
+	 */
+	private function error(string $code, string $ruleKey, string $field, $value, string $message): array {
+		return [
+			'code'    => $code,
+			'ruleKey' => $ruleKey,
+			'field'   => $field,
+			'value'   => $value,
+			'message' => $message,
+		];
+
+	}//end error()
+
+}//end class

--- a/tests/Unit/Service/Notification/NotificationAnnotationValidatorTest.php
+++ b/tests/Unit/Service/Notification/NotificationAnnotationValidatorTest.php
@@ -884,4 +884,55 @@ class NotificationAnnotationValidatorTest extends TestCase {
 		$this->assertContains('notification-scheduled-bad-dedupe-fields', $codes);
 	}
 
+	// ---- notification-scheduled-filter-grammar ----
+
+	public function testMapWithoutOperatorIsNowAnErrorRatherThanASilentAccept(): void {
+		// This is the exact hole the change closes. Before, any array lacking an
+		// `operator` key was accepted as a "scalar shortcut" and then compared
+		// by identity against a scalar field, so it matched nothing — forever,
+		// quietly. 24 filter entries across three apps shipped this way.
+		$errors = $this->v->validate(
+			$this->scheduledSchemaWith(['filter' => ['status' => ['unexpected' => 'shape']]])
+		);
+
+		$this->assertContains('notification-scheduled-bad-filter-shape', array_column($errors, 'code'));
+	}
+
+	public function testOpKeyIsRejectedWithAMessageNamingOperator(): void {
+		// openconnector job.job-overdue.
+		$errors = $this->v->validate(
+			$this->scheduledSchemaWith(['filter' => ['isEnabled' => ['op' => 'equals', 'value' => true]]])
+		);
+
+		$codes = array_column($errors, 'code');
+		$this->assertContains('notification-scheduled-bad-filter-operator-key', $codes);
+
+		$messages = implode(' ', array_column($errors, 'message'));
+		$this->assertStringContainsString('"operator"', $messages);
+	}
+
+	public function testBareListAndCombinatorFiltersValidate(): void {
+		// decidesk's 18 rules and shillinq's 4, which the grammar now admits.
+		$this->assertSame(
+			[],
+            $this->v->validate($this->scheduledSchemaWith(['filter' => ['lifecycle' => ['open', 'in-uitvoering']]]))
+		);
+
+		$this->assertSame(
+			[],
+			$this->v->validate(
+				$this->scheduledSchemaWith(
+					[
+						'filter' => [
+							'all' => [
+								['field' => 'state', 'operator' => 'notIn', 'values' => ['paid']],
+								['field' => 'dueDate', 'operator' => 'before', 'value' => 'now'],
+							],
+						],
+					]
+				)
+			)
+		);
+	}
+
 }

--- a/tests/Unit/Service/Notification/ScheduledFilterEvaluatorTest.php
+++ b/tests/Unit/Service/Notification/ScheduledFilterEvaluatorTest.php
@@ -322,4 +322,83 @@ final class ScheduledFilterEvaluatorTest extends TestCase {
 		);
 	}
 
+	// ---- notification-scheduled-filter-grammar: membership, instants, combinators ----
+
+	public function testBareListMeansMembership(): void {
+		// decidesk's 18 rappel rules are written this way.
+		$filter = ['lifecycle' => ['open', 'in-uitvoering']];
+
+		self::assertTrue($this->evaluator->matches(objectData: ['lifecycle' => 'open'], filter: $filter, now: $this->now));
+		self::assertTrue($this->evaluator->matches(objectData: ['lifecycle' => 'in-uitvoering'], filter: $filter, now: $this->now));
+		self::assertFalse($this->evaluator->matches(objectData: ['lifecycle' => 'afgedaan'], filter: $filter, now: $this->now));
+		self::assertFalse($this->evaluator->matches(objectData: [], filter: $filter, now: $this->now));
+	}
+
+	public function testNotInIsSatisfiedByAMissingField(): void {
+		$filter = ['state' => ['operator' => 'notIn', 'values' => ['paid']]];
+
+		self::assertTrue($this->evaluator->matches(objectData: [], filter: $filter, now: $this->now));
+		self::assertTrue($this->evaluator->matches(objectData: ['state' => 'open'], filter: $filter, now: $this->now));
+		self::assertFalse($this->evaluator->matches(objectData: ['state' => 'paid'], filter: $filter, now: $this->now));
+	}
+
+	public function testMembershipOverAnArrayFieldIsIntersection(): void {
+		$filter = ['tags' => ['b', 'c']];
+
+		self::assertTrue($this->evaluator->matches(objectData: ['tags' => ['a', 'b']], filter: $filter, now: $this->now));
+		self::assertFalse($this->evaluator->matches(objectData: ['tags' => ['a']], filter: $filter, now: $this->now));
+	}
+
+	public function testBeforeAndAfterResolveTheThreeInstantSpellings(): void {
+		$past = ['d' => '2026-06-01T00:00:00+00:00'];
+
+		self::assertTrue($this->evaluator->matches(objectData: $past, filter: ['d' => ['operator' => 'before', 'value' => 'now']], now: $this->now));
+		self::assertTrue($this->evaluator->matches(objectData: $past, filter: ['d' => ['operator' => 'before', 'value' => '2026-07-01']], now: $this->now));
+		// Signed duration: "-P7D" is a week ago, so a June date is before it.
+		self::assertTrue($this->evaluator->matches(objectData: $past, filter: ['d' => ['operator' => 'before', 'value' => '-P7D']], now: $this->now));
+		self::assertFalse($this->evaluator->matches(objectData: $past, filter: ['d' => ['operator' => 'after', 'value' => 'now']], now: $this->now));
+	}
+
+	public function testShillinqCombinatorEvaluates(): void {
+		// APTransaction.overdue, verbatim.
+		$filter = [
+			'all' => [
+				['field' => 'state', 'operator' => 'notIn', 'values' => ['paid', 'written-off', 'voided']],
+				['field' => 'dueDate', 'operator' => 'before', 'value' => 'now'],
+			],
+		];
+
+		self::assertTrue($this->evaluator->matches(objectData: ['state' => 'open', 'dueDate' => '2026-06-01T00:00:00+00:00'], filter: $filter, now: $this->now));
+		self::assertFalse($this->evaluator->matches(objectData: ['state' => 'paid', 'dueDate' => '2026-06-01T00:00:00+00:00'], filter: $filter, now: $this->now));
+		self::assertFalse($this->evaluator->matches(objectData: ['state' => 'open', 'dueDate' => '2027-01-01T00:00:00+00:00'], filter: $filter, now: $this->now));
+	}
+
+	public function testEmptyAllMatchesButEmptyAnyDoesNot(): void {
+		// "any of nothing" is false; treating it as true would silently widen a
+		// rule to the whole table.
+		self::assertTrue($this->evaluator->matches(objectData: ['x' => 1], filter: ['all' => []], now: $this->now));
+		self::assertFalse($this->evaluator->matches(objectData: ['x' => 1], filter: ['any' => []], now: $this->now));
+	}
+
+	public function testAnyIsADisjunction(): void {
+		$filter = [
+			'any' => [
+				['field' => 'a', 'operator' => 'equals', 'value' => 1],
+				['field' => 'b', 'operator' => 'equals', 'value' => 2],
+			],
+		];
+
+		self::assertTrue($this->evaluator->matches(objectData: ['a' => 1, 'b' => 9], filter: $filter, now: $this->now));
+		self::assertTrue($this->evaluator->matches(objectData: ['a' => 9, 'b' => 2], filter: $filter, now: $this->now));
+		self::assertFalse($this->evaluator->matches(objectData: ['a' => 9, 'b' => 9], filter: $filter, now: $this->now));
+	}
+
+	public function testAnUnexecutableFilterMatchesNothing(): void {
+		// openconnector's `op` spelling. Previously accepted and silently
+		// non-matching; now explicitly non-matching, and loud about it.
+		$filter = ['isEnabled' => ['op' => 'equals', 'value' => true]];
+
+		self::assertFalse($this->evaluator->matches(objectData: ['isEnabled' => true], filter: $filter, now: $this->now));
+	}
+
 }//end class

--- a/tests/Unit/Service/Notification/ScheduledFilterParserTest.php
+++ b/tests/Unit/Service/Notification/ScheduledFilterParserTest.php
@@ -1,0 +1,246 @@
+<?php
+
+/**
+ * Unit tests for ScheduledFilterParser.
+ *
+ * The parser is the single gate between what an author may write and what the
+ * engine can run, so these tests are written as a specification of the accept
+ * set — including the four dialects the fleet actually shipped, verbatim:
+ *
+ *   - decidesk's bare list (18 rules) — must parse;
+ *   - shillinq's `all` + `notIn` + `before` (4 rules) — must parse;
+ *   - openconnector's `op` key with `lt` (1 rule, 2 entries) — must reject,
+ *     with a message naming `operator`;
+ *   - the canonical operator object and scalar forms — must keep parsing.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Notification;
+
+use OCA\OpenRegister\Service\Notification\ScheduledFilterParser;
+use PHPUnit\Framework\TestCase;
+
+final class ScheduledFilterParserTest extends TestCase {
+
+	private ScheduledFilterParser $parser;
+
+	protected function setUp(): void {
+		$this->parser = new ScheduledFilterParser();
+
+	}//end setUp()
+
+	/**
+	 * Assert a filter parses, and return its AST.
+	 *
+	 * @param array<string, mixed> $filter The filter under test.
+	 *
+	 * @return array<string, mixed> The parsed AST.
+	 */
+	private function assertParses(array $filter): array {
+		$result = $this->parser->parse(filter: $filter, ruleKey: 'rule');
+
+		self::assertSame([], $result['errors'], 'expected no parse errors');
+		self::assertNotNull($result['ast']);
+
+		return $result['ast'];
+
+	}//end assertParses()
+
+	/**
+	 * Assert a filter is rejected with a given error code.
+	 *
+	 * @param array<string, mixed> $filter The filter under test.
+	 * @param string               $code   The expected error code.
+	 *
+	 * @return array<string, mixed> The first error.
+	 */
+	private function assertRejected(array $filter, string $code): array {
+		$result = $this->parser->parse(filter: $filter, ruleKey: 'rule');
+
+		self::assertNull($result['ast'], 'expected no AST for a rejected filter');
+		self::assertNotEmpty($result['errors']);
+		self::assertSame($code, $result['errors'][0]['code']);
+
+		return $result['errors'][0];
+
+	}//end assertRejected()
+
+	// ---------------------------------------------------------------- accepts
+
+	public function testScalarEntryParsesAsStrictEquality(): void {
+		$ast = $this->assertParses(['lifecycleState' => 'overdue']);
+
+		self::assertSame('all', $ast['type']);
+		self::assertSame('equals', $ast['clauses'][0]['operator']);
+		self::assertSame('overdue', $ast['clauses'][0]['operand']);
+
+	}//end testScalarEntryParsesAsStrictEquality()
+
+	public function testDecideskBareListParsesAsMembership(): void {
+		// 45-toezeggingen-ingekomen-stukken.json and 17 siblings.
+		$ast = $this->assertParses(['lifecycle' => ['open', 'in-uitvoering']]);
+
+		self::assertSame('in', $ast['clauses'][0]['operator']);
+		self::assertSame(['open', 'in-uitvoering'], $ast['clauses'][0]['operand']);
+
+	}//end testDecideskBareListParsesAsMembership()
+
+	public function testShillinqCombinatorParses(): void {
+		// bookkeeping-accounts-payable-core.json APTransaction.overdue.
+		$ast = $this->assertParses(
+			[
+				'all' => [
+					['field' => 'state', 'operator' => 'notIn', 'values' => ['paid', 'written-off', 'voided']],
+					['field' => 'dueDate', 'operator' => 'before', 'value' => 'now'],
+				],
+			]
+		);
+
+		$combinator = $ast['clauses'][0];
+		self::assertSame('all', $combinator['type']);
+		self::assertCount(2, $combinator['clauses']);
+		self::assertSame('notIn', $combinator['clauses'][0]['operator']);
+		self::assertSame('before', $combinator['clauses'][1]['operator']);
+
+	}//end testShillinqCombinatorParses()
+
+	public function testCanonicalOperatorObjectStillParses(): void {
+		$ast = $this->assertParses(['dueDate' => ['operator' => 'withinNext', 'value' => 'PT24H']]);
+
+		self::assertSame('withinNext', $ast['clauses'][0]['operator']);
+
+	}//end testCanonicalOperatorObjectStillParses()
+
+	public function testInstantAcceptsNowAbsoluteDateAndSignedDuration(): void {
+		foreach (['now', '2026-01-01', '2026-01-01T00:00:00Z', 'P7D', '-P7D'] as $instant) {
+			$this->assertParses(['d' => ['operator' => 'before', 'value' => $instant]]);
+		}
+
+	}//end testInstantAcceptsNowAbsoluteDateAndSignedDuration()
+
+	public function testCombinatorsMayNest(): void {
+		$this->assertParses(
+			[
+				'all' => [
+					['any' => [['field' => 'a', 'operator' => 'equals', 'value' => 1]]],
+				],
+			]
+		);
+
+	}//end testCombinatorsMayNest()
+
+	// ---------------------------------------------------------------- rejects
+
+	public function testOpenconnectorOpKeyIsRejectedNamingOperator(): void {
+		// openconnector_register.json:1154 job.job-overdue.
+		$error = $this->assertRejected(
+			['isEnabled' => ['op' => 'equals', 'value' => true]],
+			'notification-scheduled-bad-filter-operator-key'
+		);
+
+		self::assertStringContainsString('"operator"', $error['message']);
+		self::assertStringContainsString('"op"', $error['message']);
+
+	}//end testOpenconnectorOpKeyIsRejectedNamingOperator()
+
+	public function testUnknownOperatorIsRejected(): void {
+		$error = $this->assertRejected(
+			['nextRun' => ['operator' => 'lt', 'value' => 'now']],
+			'notification-scheduled-bad-filter-operator'
+		);
+
+		self::assertStringContainsString('lt', $error['message']);
+
+	}//end testUnknownOperatorIsRejected()
+
+	public function testMapWithoutOperatorIsRejectedRatherThanTreatedAsScalar(): void {
+		// The exact hole this change closes: previously "accepted, then never
+		// matched". A map that is neither scalar, list, nor operator object.
+		$this->assertRejected(
+			['something' => ['unexpected' => 'shape']],
+			'notification-scheduled-bad-filter-shape'
+		);
+
+	}//end testMapWithoutOperatorIsRejectedRatherThanTreatedAsScalar()
+
+	public function testMembershipRequiresNonEmptyValues(): void {
+		$this->assertRejected(
+			['s' => ['operator' => 'in', 'values' => []]],
+			'notification-scheduled-bad-filter-values'
+		);
+
+		$this->assertRejected(
+			['s' => ['operator' => 'in', 'value' => 'a']],
+			'notification-scheduled-bad-filter-missing-value'
+		);
+
+	}//end testMembershipRequiresNonEmptyValues()
+
+	public function testEmptyBareListIsRejected(): void {
+		$this->assertRejected(['s' => []], 'notification-scheduled-empty-list');
+
+	}//end testEmptyBareListIsRejected()
+
+	public function testUnparseableDurationIsRejected(): void {
+		$this->assertRejected(
+			['d' => ['operator' => 'withinNext', 'value' => 'soon']],
+			'notification-scheduled-bad-filter-duration'
+		);
+
+	}//end testUnparseableDurationIsRejected()
+
+	public function testUnresolvableInstantIsRejected(): void {
+		$this->assertRejected(
+			['d' => ['operator' => 'before', 'value' => 'whenever']],
+			'notification-scheduled-bad-filter-instant'
+		);
+
+	}//end testUnresolvableInstantIsRejected()
+
+	public function testCombinatorMustBeAList(): void {
+		// A map rather than a list of clauses — the combinator itself is wrong.
+		$this->assertRejected(['all' => ['field' => 'a']], 'notification-scheduled-bad-combinator');
+
+	}//end testCombinatorMustBeAList()
+
+	public function testCombinatorClauseMustBeAnObject(): void {
+		// A list, but holding a scalar where a clause belongs.
+		$this->assertRejected(['all' => ['not-a-clause']], 'notification-scheduled-bad-clause');
+
+	}//end testCombinatorClauseMustBeAnObject()
+
+	public function testClauseRequiresAFieldName(): void {
+		$this->assertRejected(
+			['all' => [['operator' => 'equals', 'value' => 1]]],
+			'notification-scheduled-bad-clause-field'
+		);
+
+	}//end testClauseRequiresAFieldName()
+
+	public function testNestingIsBounded(): void {
+		// Six levels — one past MAX_DEPTH.
+		$filter = ['field' => 'a', 'operator' => 'equals', 'value' => 1];
+		for ($i = 0; $i < 6; $i++) {
+			$filter = ['all' => [$filter]];
+		}
+
+		$result = $this->parser->parse(filter: $filter, ruleKey: 'rule');
+
+		self::assertNull($result['ast']);
+		self::assertSame('notification-scheduled-filter-too-deep', $result['errors'][0]['code']);
+
+	}//end testNestingIsBounded()
+
+	public function testEmptyFilterParsesToAnEmptyConjunction(): void {
+		$ast = $this->assertParses([]);
+
+		self::assertSame('all', $ast['type']);
+		self::assertSame([], $ast['clauses']);
+
+	}//end testEmptyFilterParsesToAnEmptyConjunction()
+
+}//end class


### PR DESCRIPTION
Closes #2787

## What was broken

**24 scheduled-notification filter entries across three apps were accepted at save time and matched nothing at scan time** — silently, for months. Every deadline rappel in decidesk, shillinq's contract and AP reminders, and openconnector's job-overdue rule ran daily against nothing while reading as configured and enabled.

The cause was one grammar written down twice, disagreeing. `NotificationAnnotationValidator::validateScheduledFilterEntry()` opened with:

```php
// Scalar shortcut: always accepted (legacy v1 strict equality).
if (is_array($spec) === false || array_key_exists('operator', $spec) === false) {
    return [];
}
```

Any array without an `operator` key was accepted. `ScheduledFilterEvaluator` then compared that array to a scalar field with `===`. Accepted, then false forever.

Three teams had independently invented three dialects the four-operator grammar could not express — decidesk a bare list for set membership (18 rules), shillinq an `all` combinator with `notIn`/`before` (4 rules), openconnector the key `op` with `lt` (1 rule, 2 entries).

## The fix

**One `ScheduledFilterParser`.** The validator reports its errors; the evaluator walks its AST. "A shape the validator accepts but the evaluator cannot execute" is now a contradiction rather than a bug that recurs. No second enumeration of operators exists in `lib/`.

**The grammar grows what three teams reached for**, which is why 22 of the 23 dead rules come back with **no edit in any app**:

| form | means |
|---|---|
| `in` / `notIn` (`values`) | membership; an array-valued field matches on non-empty intersection |
| `before` / `after` (`value`) | against `"now"`, an absolute ISO date, or a **signed** duration |
| `["a","b"]` | bare list is shorthand for `in` |
| `all` / `any` | conjunction / disjunction, nested to `MAX_DEPTH` |

`before "P7D"` reads equally naturally as "a week from now" and "a week ago", so the past direction is spelled `-P7D` and there is **no unsigned past form**. An ambiguous date operator in a reminder engine is how a thousand wrong emails get sent.

An empty `all` matches; an empty `any` does not — "any of nothing" is false, and the alternative silently widens a rule to the whole table.

## Verification

**Fleet census replayed against the new parser** — 61 scheduled filters across the fleet:

```
parse (executable): 60
rejected:            1   <- openconnector job.job-overdue ("op" instead of "operator")
```

The single rejection is exactly the one intended, and it now produces a message naming `operator` rather than a silent accept.

**Behaviour, old vs new**, on the real annotations:

- decidesk bare list `{"lifecycle": ["open","in-uitvoering"]}` — matches `open` and `in-uitvoering`, not `afgedaan`, not a missing field.
- shillinq `all` + `notIn` + `before` — matches open-and-overdue, not paid, not future-dated.

**Tests**: 267 notification tests pass, 540 assertions — including the **80 pre-existing tests unchanged**, which is the backward-compatibility proof for the 49 filter entries that already worked (28 scalar, 21 canonical operator objects).

**Gates**: PHPCS 0 errors, PHPMD exit 0, PHPStan OK, Psalm no errors.

## One correction to the issue as I first filed it

I originally wrote that a stricter validator "would have blocked" these. It would not have. `SchemaMapper::validateNotificationsAnnotation()` (`lib/Db/SchemaMapper.php:1364-1381`) calls the validator and **discards its errors** by design, so a malformed optional annotation never aborts a register import. Tightening the validator is still right — it is what makes the accept-set equal the executable-set — but the **Hydra gate is the only mechanism that can actually block this**, and the spec argues it that way. Gate work is task 5.3, in `ConductionNL/.github`, and is not in this PR.

## Follow-ups (named, not done here)

- openconnector: `job.job-overdue` needs `op` -> `operator` and `lt` -> `before`; plus `call_log.call-failed` and `job_log.job-error`, which pass map-shaped `op` filters to the **created**-trigger path and were also never firing.
- Gate-18 check (c) in `hydra-gates`, pinned against a fixture generated from `ScheduledFilterGrammar` so gate and engine cannot drift.
- The deferred `created`-vs-`scheduled` convergence: converge the clause shape and vocabulary, explicitly **not** the comparison semantics (created is string-coercing, scheduled is strict `===`; merging either direction silently un-matches live rules).

The design for all of this is the `notification-scheduled-filter-grammar` OpenSpec change, which ships in ConductionNL/openregister#2791.
