### PR TITLE
refactor(files): one source of truth for executable-content detection (closes #2776 on both paths)

### DIFF
--- a/lib/Service/File/ExecutableContentDetector.php
+++ b/lib/Service/File/ExecutableContentDetector.php
@@ -1,0 +1,370 @@
+<?php
+
+/**
+ * ExecutableContentDetector
+ *
+ * This file is part of the OpenRegister app for Nextcloud.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category  Service
+ * @package   OCA\OpenRegister
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link      https://github.com/ConductionNL/openregister
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\File;
+
+/**
+ * The single source of truth for "do these bytes look executable?".
+ *
+ * WHY THIS CLASS EXISTS. The same three checks — an offset-0 executable
+ * signature, a script shebang, an embedded PHP tag — were implemented TWICE,
+ * byte-identically: once in {@see FileValidationHandler} (the `/files`
+ * endpoints) and once in
+ * {@see \OCA\OpenRegister\Service\Object\SaveObject\FilePropertyHandler} (the
+ * object-save file-property path). openregister#2776 was a defect in that
+ * logic, so it was a defect in BOTH copies, and fixing only the one the issue
+ * happened to name would have left the same legitimate PNG rejected through
+ * the other route. A byte-identical duplicate is precisely how a defect comes
+ * to exist in two places; there is now one copy.
+ *
+ * This class DETECTS and REPORTS. It deliberately does not throw and does not
+ * log: the two callers have different, caller-facing message shapes (`File
+ * 'x.png' ...` versus `File at document ...`) and log under their own class
+ * prefixes, and preserving those is what makes this extraction behaviour-
+ * preserving rather than a rewrite.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister
+ * @author   Conduction <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://github.com/ConductionNL/openregister
+ * @version  1.0.0
+ */
+class ExecutableContentDetector {
+
+	/**
+	 * How many leading bytes are examined for shebangs and embedded PHP tags.
+	 *
+	 * @var int
+	 */
+	public const SCAN_PREFIX_LENGTH = 1024;
+
+	/**
+	 * Offset-0 signatures that identify an executable payload.
+	 *
+	 * These are matched at offset 0 ONLY, and this check is universal: it runs
+	 * on every upload regardless of name or sniffed type.
+	 *
+	 * @var array<string, string>
+	 */
+	private const EXECUTABLE_SIGNATURES = [
+		'MZ' => 'Windows executable (PE/EXE)',
+		"\x7FELF" => 'Linux/Unix executable (ELF)',
+		'#!/bin/sh' => 'Shell script',
+		'#!/bin/bash' => 'Bash script',
+		'#!/usr/bin/env' => 'Script with env shebang',
+		'<?php' => 'PHP script',
+		"\xCA\xFE\xBA\xBE" => 'Java class file',
+	];
+
+	/**
+	 * Leading byte signatures of container formats that are unambiguously binary.
+	 *
+	 * A positive match here means the payload is a real image / audio / video /
+	 * archive / document container, so a `<?php` or `<?=` byte pair found inside
+	 * its compressed body is noise, not source code. Used ONLY to scope the
+	 * embedded-PHP-tag scan in {@see containsEmbeddedPhpTag()}; the executable
+	 * signature and shebang checks still run on these files.
+	 *
+	 * This is a WHITELIST on purpose: anything that does not positively identify
+	 * as one of these formats keeps the full, unchanged scan.
+	 *
+	 * @var array<string, string>
+	 */
+	private const BINARY_CONTENT_SIGNATURES = [
+		// Images.
+		"\x89PNG\r\n\x1A\n" => 'image/png',
+		"\xFF\xD8\xFF" => 'image/jpeg',
+		'GIF87a' => 'image/gif',
+		'GIF89a' => 'image/gif',
+		"II*\x00" => 'image/tiff',
+		"MM\x00*" => 'image/tiff',
+		"\x00\x00\x01\x00" => 'image/vnd.microsoft.icon',
+		'8BPS' => 'image/vnd.adobe.photoshop',
+		// RIFF containers: webp, wav, avi.
+		'RIFF' => 'application/x-riff',
+		// Documents.
+		'%PDF-' => 'application/pdf',
+		"\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1" => 'application/x-ole-storage',
+		// Archives and zip-based office formats (docx/xlsx/pptx/odt).
+		"PK\x03\x04" => 'application/zip',
+		"PK\x05\x06" => 'application/zip',
+		"PK\x07\x08" => 'application/zip',
+		"\x1F\x8B" => 'application/gzip',
+		'BZh' => 'application/x-bzip2',
+		"\xFD7zXZ\x00" => 'application/x-xz',
+		"7z\xBC\xAF\x27\x1C" => 'application/x-7z-compressed',
+		"Rar!\x1A\x07" => 'application/vnd.rar',
+		// Audio and video.
+		'ID3' => 'audio/mpeg',
+		'OggS' => 'application/ogg',
+		'fLaC' => 'audio/flac',
+		"\x1A\x45\xDF\xA3" => 'video/x-matroska',
+		"FLV\x01" => 'video/x-flv',
+		// Data.
+		"SQLite format 3\x00" => 'application/vnd.sqlite3',
+	];
+
+	/**
+	 * Filename extensions that are ALWAYS scanned for embedded PHP tags.
+	 *
+	 * These are the extensions under which a server or a browser may hand the
+	 * bytes to an interpreter or a markup parser, so a PHP tag inside them is
+	 * meaningful regardless of what the leading bytes look like. A polyglot that
+	 * opens with PNG magic but is named `x.html` still gets the full scan.
+	 *
+	 * @var array<string>
+	 */
+	private const ALWAYS_SCANNED_EXTENSIONS = [
+		'txt',
+		'text',
+		'log',
+		'md',
+		'markdown',
+		'csv',
+		'tsv',
+		'htm',
+		'html',
+		'xhtml',
+		'shtml',
+		'xml',
+		'xsl',
+		'xslt',
+		'svg',
+		'svgz',
+		'json',
+		'yaml',
+		'yml',
+		'ini',
+		'conf',
+		'cfg',
+		'env',
+		'htaccess',
+		'htpasswd',
+		'tpl',
+		'twig',
+		'mustache',
+		'hbs',
+		'ejs',
+		'erb',
+		'jsp',
+		'asp',
+		'aspx',
+		'cshtml',
+		'css',
+		'scss',
+		'less',
+		'sql',
+		'sh',
+		'bash',
+		'php',
+		'phtml',
+		'php3',
+		'php4',
+		'php5',
+		'phps',
+		'phar',
+		'inc',
+		'module',
+		'install',
+	];
+
+	/**
+	 * Match the content's leading bytes against the executable signature table.
+	 *
+	 * Universal: applies to every upload, whatever its name or sniffed type.
+	 *
+	 * @param string $content The file content to check.
+	 *
+	 * @return string|null A human-readable description of the matched executable
+	 *                     format, or null when no signature matches.
+	 *
+	 * @psalm-return   string|null
+	 * @phpstan-return string|null
+	 *
+	 * @spec openspec/specs/file-actions/spec.md
+	 */
+	public function matchExecutableSignature(string $content): ?string {
+		foreach (self::EXECUTABLE_SIGNATURES as $signature => $description) {
+			if (strpos($content, (string)$signature) === 0) {
+				return $description;
+			}
+		}
+
+		return null;
+	}//end matchExecutableSignature()
+
+	/**
+	 * Check for a script shebang within the scanned prefix.
+	 *
+	 * Universal: applies to every upload, whatever its name or sniffed type.
+	 *
+	 * @param string $content The file content to check.
+	 *
+	 * @return bool True when a shebang line is present.
+	 *
+	 * @psalm-return   bool
+	 * @phpstan-return bool
+	 *
+	 * @spec openspec/specs/file-actions/spec.md
+	 */
+	public function hasScriptShebang(string $content): bool {
+		$firstLines = substr($content, 0, self::SCAN_PREFIX_LENGTH);
+
+		return preg_match('/^#!.*\/(sh|bash|zsh|ksh|csh|python|perl|ruby|php|node)/m', $firstLines) === 1;
+	}//end hasScriptShebang()
+
+	/**
+	 * Check for an embedded PHP tag — TEXT-ISH PAYLOADS ONLY.
+	 *
+	 * Scoped by openregister#2776. This scan used to run over the first kilobyte
+	 * of EVERY upload, including compressed binary bodies where a `<?` byte pair
+	 * carries no meaning. A genuine 1283x926 PNG screenshot was reported as
+	 * "contains PHP code" because its deflate stream happened to contain `<?=`.
+	 *
+	 * The scan is skipped only when {@see shouldScanForEmbeddedPhp()} says the
+	 * payload is a positively-identified binary container with a name no
+	 * interpreter would claim. Everything else — plain text, HTML, XML/SVG,
+	 * unknown byte streams, files with no extension — is scanned exactly as
+	 * before.
+	 *
+	 * @param string $content The file content to check.
+	 * @param string $fileName The filename, used for its extension only.
+	 *
+	 * @return bool True when a PHP tag is present in a payload that is scanned.
+	 *
+	 * @psalm-return   bool
+	 * @phpstan-return bool
+	 *
+	 * @spec openspec/specs/file-actions/spec.md
+	 */
+	public function containsEmbeddedPhpTag(string $content, string $fileName): bool {
+		if ($this->shouldScanForEmbeddedPhp(content: $content, fileName: $fileName) === false) {
+			return false;
+		}
+
+		$firstLines = substr($content, 0, self::SCAN_PREFIX_LENGTH);
+
+		return preg_match('/<\?php|<\?=|<script\s+language\s*=\s*["\']php/i', $firstLines) === 1;
+	}//end containsEmbeddedPhpTag()
+
+	/**
+	 * Decide whether the embedded-PHP-tag scan applies to this payload.
+	 *
+	 * Returns false ONLY when both of the following hold:
+	 *  1. the content's leading bytes positively match a known binary container
+	 *     signature ({@see BINARY_CONTENT_SIGNATURES}) — an image, audio, video,
+	 *     archive or binary document format whose body is compressed or encoded,
+	 *     so an embedded `<?` byte pair is statistically expected noise; and
+	 *  2. the filename does NOT carry an extension under which a server or a
+	 *     browser would hand the bytes to an interpreter or a markup parser
+	 *     ({@see ALWAYS_SCANNED_EXTENSIONS}).
+	 *
+	 * Both conditions are required so that a polyglot — PNG magic bytes followed
+	 * by PHP source, saved as `payload.html` or `payload.phtml` — is still
+	 * scanned. Note that such a file is already rejected by the callers'
+	 * dangerous-extension blocklists; this is defence in depth, not the primary
+	 * control.
+	 *
+	 * @param string $content The file content whose leading bytes are sniffed.
+	 * @param string $fileName The filename, used for its extension only.
+	 *
+	 * @return bool True when the embedded-PHP-tag scan must run (the default).
+	 *
+	 * @psalm-return   bool
+	 * @phpstan-return bool
+	 *
+	 * @spec openspec/specs/file-actions/spec.md
+	 */
+	public function shouldScanForEmbeddedPhp(string $content, string $fileName): bool {
+		if ($this->sniffBinaryContentType(content: $content) === null) {
+			// Not a recognised binary container — scan, as before.
+			return true;
+		}
+
+		return $this->hasAlwaysScannedExtension(fileName: $fileName);
+	}//end shouldScanForEmbeddedPhp()
+
+	/**
+	 * Sniff the content's leading bytes against the known binary container list.
+	 *
+	 * ISO base media files (mp4/mov/m4a/heic) are special-cased because their
+	 * `ftyp` box marker sits at offset 4, not offset 0.
+	 *
+	 * The declared MIME type from the request is deliberately NOT consulted: it
+	 * is client-supplied and would let a caller opt out of the scan by lying.
+	 * Only the bytes decide.
+	 *
+	 * @param string $content The file content to sniff.
+	 *
+	 * @return string|null The matched container MIME type, or null when the
+	 *                     content is not a recognised binary container.
+	 *
+	 * @psalm-return   string|null
+	 * @phpstan-return string|null
+	 *
+	 * @spec openspec/specs/file-actions/spec.md
+	 */
+	public function sniffBinaryContentType(string $content): ?string {
+		if ($content === '') {
+			return null;
+		}
+
+		foreach (self::BINARY_CONTENT_SIGNATURES as $signature => $mimeType) {
+			if (str_starts_with($content, (string)$signature) === true) {
+				return $mimeType;
+			}
+		}
+
+		// ISO base media file format (mp4, m4a, mov, 3gp, heic): 4-byte box
+		// length, then the literal 'ftyp' brand marker at offset 4.
+		if (strlen($content) >= 12 && substr($content, 4, 4) === 'ftyp') {
+			return 'video/mp4';
+		}
+
+		return null;
+	}//end sniffBinaryContentType()
+
+	/**
+	 * Check whether the filename carries an extension that is always scanned.
+	 *
+	 * A file with NO extension is treated as text-ish and scanned: an
+	 * extension-less upload is the least identifiable, and strictness there
+	 * costs nothing for the formats this scoping exists to unblock.
+	 *
+	 * @param string $fileName The filename to inspect.
+	 *
+	 * @return bool True when the extension is in the always-scanned list.
+	 *
+	 * @psalm-return   bool
+	 * @phpstan-return bool
+	 *
+	 * @spec openspec/specs/file-actions/spec.md
+	 */
+	public function hasAlwaysScannedExtension(string $fileName): bool {
+		$extension = strtolower(pathinfo($fileName, PATHINFO_EXTENSION));
+
+		if ($extension === '') {
+			return true;
+		}
+
+		return in_array($extension, self::ALWAYS_SCANNED_EXTENSIONS, true);
+	}//end hasAlwaysScannedExtension()
+}//end class

--- a/lib/Service/File/FileValidationHandler.php
+++ b/lib/Service/File/FileValidationHandler.php
@@ -45,131 +45,19 @@ use Psr\Log\LoggerInterface;
  * @version  1.0.0
  */
 class FileValidationHandler {
-
-	/**
-	 * Leading byte signatures of container formats that are unambiguously binary.
-	 *
-	 * A positive match here means the payload is a real image / audio / video /
-	 * archive / document container, so a `<?php` or `<?=` byte pair found inside
-	 * its compressed body is noise, not source code. Used ONLY to scope the
-	 * embedded-PHP-tag scan in {@see detectExecutableMagicBytes()}; every other
-	 * check in this class still runs on these files.
-	 *
-	 * This is a WHITELIST on purpose: anything that does not positively identify
-	 * as one of these formats keeps the full, unchanged scan.
-	 *
-	 * @var array<string, string>
-	 */
-	private const BINARY_CONTENT_SIGNATURES = [
-		// Images.
-		"\x89PNG\r\n\x1A\n" => 'image/png',
-		"\xFF\xD8\xFF" => 'image/jpeg',
-		'GIF87a' => 'image/gif',
-		'GIF89a' => 'image/gif',
-		"II*\x00" => 'image/tiff',
-		"MM\x00*" => 'image/tiff',
-		"\x00\x00\x01\x00" => 'image/vnd.microsoft.icon',
-		'8BPS' => 'image/vnd.adobe.photoshop',
-		// RIFF containers: webp, wav, avi.
-		'RIFF' => 'application/x-riff',
-		// Documents.
-		'%PDF-' => 'application/pdf',
-		"\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1" => 'application/x-ole-storage',
-		// Archives and zip-based office formats (docx/xlsx/pptx/odt).
-		"PK\x03\x04" => 'application/zip',
-		"PK\x05\x06" => 'application/zip',
-		"PK\x07\x08" => 'application/zip',
-		"\x1F\x8B" => 'application/gzip',
-		'BZh' => 'application/x-bzip2',
-		"\xFD7zXZ\x00" => 'application/x-xz',
-		"7z\xBC\xAF\x27\x1C" => 'application/x-7z-compressed',
-		"Rar!\x1A\x07" => 'application/vnd.rar',
-		// Audio and video.
-		'ID3' => 'audio/mpeg',
-		'OggS' => 'application/ogg',
-		'fLaC' => 'audio/flac',
-		"\x1A\x45\xDF\xA3" => 'video/x-matroska',
-		"FLV\x01" => 'video/x-flv',
-		// Data.
-		"SQLite format 3\x00" => 'application/vnd.sqlite3',
-	];
-
-	/**
-	 * Filename extensions that are ALWAYS scanned for embedded PHP tags.
-	 *
-	 * These are the extensions under which a server or a browser may hand the
-	 * bytes to an interpreter or a markup parser, so a PHP tag inside them is
-	 * meaningful regardless of what the leading bytes look like. A polyglot that
-	 * opens with PNG magic but is named `x.html` still gets the full scan.
-	 *
-	 * @var array<string>
-	 */
-	private const ALWAYS_SCANNED_EXTENSIONS = [
-		'txt',
-		'text',
-		'log',
-		'md',
-		'markdown',
-		'csv',
-		'tsv',
-		'htm',
-		'html',
-		'xhtml',
-		'shtml',
-		'xml',
-		'xsl',
-		'xslt',
-		'svg',
-		'svgz',
-		'json',
-		'yaml',
-		'yml',
-		'ini',
-		'conf',
-		'cfg',
-		'env',
-		'htaccess',
-		'htpasswd',
-		'tpl',
-		'twig',
-		'twig.html',
-		'mustache',
-		'hbs',
-		'ejs',
-		'erb',
-		'jsp',
-		'asp',
-		'aspx',
-		'cshtml',
-		'css',
-		'scss',
-		'less',
-		'sql',
-		'sh',
-		'bash',
-		'php',
-		'phtml',
-		'php3',
-		'php4',
-		'php5',
-		'phps',
-		'phar',
-		'inc',
-		'module',
-		'install',
-	];
-
 	/**
 	 * Constructor for FileValidationHandler.
 	 *
 	 * @param FileMapper $fileMapper File mapper for ownership operations.
 	 * @param IUserSession $userSession User session for user context.
 	 * @param LoggerInterface $logger Logger for logging operations.
+	 * @param ExecutableContentDetector $executableDetector Shared executable-content detection.
 	 */
 	public function __construct(
 		private readonly FileMapper $fileMapper,
 		private readonly IUserSession $userSession,
 		private readonly LoggerInterface $logger,
+		private readonly ExecutableContentDetector $executableDetector = new ExecutableContentDetector(),
 	) {
 	}//end __construct()
 
@@ -294,6 +182,12 @@ class FileValidationHandler {
 	 * Magic bytes are signatures at the start of files that identify the file type.
 	 * This provides defense-in-depth against renamed executables.
 	 *
+	 * The three checks themselves live in {@see ExecutableContentDetector}, the
+	 * single source of truth shared with
+	 * {@see \OCA\OpenRegister\Service\Object\SaveObject\FilePropertyHandler}.
+	 * This method owns only the caller-facing message shapes and the logging,
+	 * which differ between the two call sites and are asserted on by tests.
+	 *
 	 * @param string $content The file content to check.
 	 * @param string $fileName The filename for error messages.
 	 *
@@ -307,62 +201,33 @@ class FileValidationHandler {
 	 * @spec openspec/specs/file-actions/spec.md
 	 */
 	public function detectExecutableMagicBytes(string $content, string $fileName): void {
-		// Common executable magic bytes.
-		$magicBytes = [
-			'MZ' => 'Windows executable (PE/EXE)',
-			"\x7FELF" => 'Linux/Unix executable (ELF)',
-			'#!/bin/sh' => 'Shell script',
-			'#!/bin/bash' => 'Bash script',
-			'#!/usr/bin/env' => 'Script with env shebang',
-			'<?php' => 'PHP script',
-			"\xCA\xFE\xBA\xBE" => 'Java class file',
-		];
+		// Offset-0 executable signatures — universal, every upload.
+		$description = $this->executableDetector->matchExecutableSignature(content: $content);
+		if ($description !== null) {
+			$this->logger->warning(
+				message: '[FileValidationHandler] Executable magic bytes detected',
+				context: [
+					'file' => __FILE__,
+					'line' => __LINE__,
+					'app' => 'openregister',
+					'filename' => $fileName,
+					'type' => $description,
+				]
+			);
 
-		foreach ($magicBytes as $signature => $description) {
-			if (strpos($content, $signature) === 0) {
-				$this->logger->warning(
-					message: '[FileValidationHandler] Executable magic bytes detected',
-					context: [
-						'file' => __FILE__,
-						'line' => __LINE__,
-						'app' => 'openregister',
-						'filename' => $fileName,
-						'type' => $description,
-					]
-				);
-
-				$execMsg = "File '$fileName' contains executable code ($description). ";
-				throw new Exception($execMsg . 'Executable files are blocked for security.');
-			}
+			$execMsg = "File '$fileName' contains executable code ($description). ";
+			throw new Exception($execMsg . 'Executable files are blocked for security.');
 		}
 
-		// Check for script shebangs anywhere in first 4 lines.
-		$firstLines = substr($content, 0, 1024);
-		if (preg_match('/^#!.*\/(sh|bash|zsh|ksh|csh|python|perl|ruby|php|node)/m', $firstLines) === 1) {
+		// Script shebangs — universal, every upload.
+		if ($this->executableDetector->hasScriptShebang(content: $content) === true) {
 			throw new Exception(
 				"File '$fileName' contains script shebang. Script files are blocked for security reasons."
 			);
 		}
 
-		// Check for embedded PHP tags — TEXT-ISH PAYLOADS ONLY.
-		//
-		// openregister#2776: this scan used to run over the first kilobyte of
-		// EVERY upload, including compressed binary bodies where a `<?` byte pair
-		// carries no meaning. A genuine 1283x926 PNG screenshot was rejected as
-		// "contains PHP code" because its deflate stream happened to contain
-		// `<?=`, and the hard 400 took 284 storable files down with it.
-		//
-		// The scan is now skipped only when the payload POSITIVELY identifies as
-		// a known binary container by its leading bytes AND is not named with an
-		// extension a server or browser would hand to an interpreter. Everything
-		// else — plain text, HTML, XML/SVG, unknown byte streams — is scanned
-		// exactly as before, and every other check in this method is unchanged
-		// and still universal.
-		if ($this->shouldScanForEmbeddedPhp(content: $content, fileName: $fileName) === false) {
-			return;
-		}
-
-		if (preg_match('/<\?php|<\?=|<script\s+language\s*=\s*["\']php/i', $firstLines) === 1) {
+		// Embedded PHP tags — text-ish payloads only, see openregister#2776.
+		if ($this->executableDetector->containsEmbeddedPhpTag(content: $content, fileName: $fileName) === true) {
 			throw new Exception(
 				"File '$fileName' contains PHP code. PHP files are blocked for security reasons."
 			);
@@ -370,22 +235,10 @@ class FileValidationHandler {
 	}//end detectExecutableMagicBytes()
 
 	/**
-	 * Decide whether the embedded-PHP-tag scan applies to this payload.
+	 * Whether the embedded-PHP-tag scan applies to this payload.
 	 *
-	 * Returns false ONLY when both of the following hold:
-	 *  1. the content's leading bytes positively match a known binary container
-	 *     signature ({@see BINARY_CONTENT_SIGNATURES}) — an image, audio, video,
-	 *     archive or binary document format whose body is compressed or encoded,
-	 *     so an embedded `<?` byte pair is statistically expected noise; and
-	 *  2. the filename does NOT carry an extension under which a server or a
-	 *     browser would hand the bytes to an interpreter or a markup parser
-	 *     ({@see ALWAYS_SCANNED_EXTENSIONS}).
-	 *
-	 * Both conditions are required so that a polyglot — PNG magic bytes followed
-	 * by PHP source, saved as `payload.html` or `payload.phtml` — is still
-	 * scanned. Note that such a file is already rejected earlier by
-	 * {@see blockExecutableFile()}'s extension blocklist; this is defence in
-	 * depth, not the primary control.
+	 * Thin delegation to {@see ExecutableContentDetector::shouldScanForEmbeddedPhp()},
+	 * kept on this class because it is part of the handler's published surface.
 	 *
 	 * @param string $content The file content whose leading bytes are sniffed.
 	 * @param string $fileName The filename, used for its extension only.
@@ -398,28 +251,17 @@ class FileValidationHandler {
 	 * @spec openspec/specs/file-actions/spec.md
 	 */
 	public function shouldScanForEmbeddedPhp(string $content, string $fileName): bool {
-		if ($this->sniffBinaryContentType(content: $content) === null) {
-			// Not a recognised binary container — scan, as before.
-			return true;
-		}
-
-		return $this->hasAlwaysScannedExtension(fileName: $fileName);
+		return $this->executableDetector->shouldScanForEmbeddedPhp(content: $content, fileName: $fileName);
 	}//end shouldScanForEmbeddedPhp()
 
 	/**
 	 * Sniff the content's leading bytes against the known binary container list.
 	 *
-	 * ISO base media files (mp4/mov/m4a/heic) are special-cased because their
-	 * `ftyp` box marker sits at offset 4, not offset 0.
-	 *
-	 * The declared MIME type from the request is deliberately NOT consulted: it
-	 * is client-supplied and would let a caller opt out of the scan by lying.
-	 * Only the bytes decide.
+	 * Thin delegation to {@see ExecutableContentDetector::sniffBinaryContentType()}.
 	 *
 	 * @param string $content The file content to sniff.
 	 *
-	 * @return string|null The matched container MIME type, or null when the
-	 *                     content is not a recognised binary container.
+	 * @return string|null The matched container MIME type, or null.
 	 *
 	 * @psalm-return   string|null
 	 * @phpstan-return string|null
@@ -427,27 +269,13 @@ class FileValidationHandler {
 	 * @spec openspec/specs/file-actions/spec.md
 	 */
 	public function sniffBinaryContentType(string $content): ?string {
-		if ($content === '') {
-			return null;
-		}
-
-		foreach (self::BINARY_CONTENT_SIGNATURES as $signature => $mimeType) {
-			if (str_starts_with($content, (string)$signature) === true) {
-				return $mimeType;
-			}
-		}
-
-		// ISO base media file format (mp4, m4a, mov, 3gp, heic): 4-byte box
-		// length, then the literal 'ftyp' brand marker at offset 4.
-		if (strlen($content) >= 12 && substr($content, 4, 4) === 'ftyp') {
-			return 'video/mp4';
-		}
-
-		return null;
+		return $this->executableDetector->sniffBinaryContentType(content: $content);
 	}//end sniffBinaryContentType()
 
 	/**
 	 * Check whether the filename carries an extension that is always scanned.
+	 *
+	 * Thin delegation to {@see ExecutableContentDetector::hasAlwaysScannedExtension()}.
 	 *
 	 * @param string $fileName The filename to inspect.
 	 *
@@ -459,14 +287,7 @@ class FileValidationHandler {
 	 * @spec openspec/specs/file-actions/spec.md
 	 */
 	public function hasAlwaysScannedExtension(string $fileName): bool {
-		$extension = strtolower(pathinfo($fileName, PATHINFO_EXTENSION));
-
-		if ($extension === '') {
-			// A file with no extension at all is treated as text-ish and scanned.
-			return true;
-		}
-
-		return in_array($extension, self::ALWAYS_SCANNED_EXTENSIONS, true);
+		return $this->executableDetector->hasAlwaysScannedExtension(fileName: $fileName);
 	}//end hasAlwaysScannedExtension()
 
 	/**

--- a/lib/Service/Object/SaveObject/FilePropertyHandler.php
+++ b/lib/Service/Object/SaveObject/FilePropertyHandler.php
@@ -22,6 +22,7 @@ use Exception;
 use finfo;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Service\File\ExecutableContentDetector;
 use OCA\OpenRegister\Service\FileService;
 use OCA\OpenRegister\Service\SecurityService;
 use OCP\Files\File;
@@ -55,12 +56,14 @@ class FilePropertyHandler {
 	 *
 	 * @param LoggerInterface $logger Logger for logging operations
 	 * @param FileService $fileService File service for file operations
+	 * @param ExecutableContentDetector $executableDetector Shared executable-content detection
 	 *
 	 * @spec openspec/specs/content-versioning/spec.md
 	 */
 	public function __construct(
 		private readonly LoggerInterface $logger,
 		private readonly FileService $fileService,
+		private readonly ExecutableContentDetector $executableDetector = new ExecutableContentDetector(),
 	) {
 	}//end __construct()
 
@@ -1172,9 +1175,16 @@ class FilePropertyHandler {
 			}
 		}//end if
 
-		// Check magic bytes (file signatures) in content.
+		// Check magic bytes (file signatures) in content. The filename is passed
+		// through because the embedded-PHP-tag scan is scoped by extension as
+		// well as by sniffed content type — see openregister#2776. An absent
+		// filename yields '', which is treated as text-ish and always scanned.
 		if (($fileData['content'] ?? null) !== null && empty($fileData['content']) === false) {
-			$this->detectExecutableMagicBytes(content: $fileData['content'], errorPrefix: $errorPrefix);
+			$this->detectExecutableMagicBytes(
+				content: $fileData['content'],
+				errorPrefix: $errorPrefix,
+				fileName: (string)($fileData['filename'] ?? '')
+			);
 		}
 
 		// Check MIME types for executables.
@@ -1204,13 +1214,28 @@ class FilePropertyHandler {
 	 * Magic bytes are signatures at the start of files that identify the file type.
 	 * This provides defense-in-depth against renamed executables.
 	 *
+	 * The three checks themselves live in {@see ExecutableContentDetector}, the
+	 * single source of truth shared with {@see \OCA\OpenRegister\Service\File\FileValidationHandler}.
+	 * This method used to carry a byte-identical COPY of them, which is why
+	 * openregister#2776 — a legitimate PNG rejected as "contains PHP code" —
+	 * was a defect on this path too, not only on the `/files` endpoints. This
+	 * method now owns only its caller-facing message shape and its logging.
+	 *
+	 * The removed copy also carried a disabled `PK\x03\x04` (ZIP) entry, skipped
+	 * via a `false` description with a note that JARs are ZIPs and need deeper
+	 * inspection. It never matched anything, so dropping it changes nothing;
+	 * ZIP containers are handled by the shared binary-container sniff instead.
+	 *
 	 * @param string $content The file content to check.
 	 * @param string $errorPrefix The error message prefix.
+	 * @param string $fileName The filename, used for its extension only; '' when unknown.
 	 *
 	 * @psalm-param   string $content
 	 * @psalm-param   string $errorPrefix
+	 * @psalm-param   string $fileName
 	 * @phpstan-param string $content
 	 * @phpstan-param string $errorPrefix
+	 * @phpstan-param string $fileName
 	 *
 	 * @return void
 	 *
@@ -1221,53 +1246,33 @@ class FilePropertyHandler {
 	 *
 	 * @spec openspec/specs/content-versioning/spec.md
 	 */
-	private function detectExecutableMagicBytes(string $content, string $errorPrefix): void {
-		// Common executable magic bytes.
-		$magicBytes = [
-			'MZ' => 'Windows executable (PE/EXE)',
-			"\x7FELF" => 'Linux/Unix executable (ELF)',
-			'#!/bin/sh' => 'Shell script',
-			'#!/bin/bash' => 'Bash script',
-			'#!/usr/bin/env' => 'Script with env shebang',
-			'<?php' => 'PHP script',
-			"\xCA\xFE\xBA\xBE" => 'Java class file',
-			"PK\x03\x04" => false,
-			// ZIP - need deeper inspection as JARs are ZIPs.
-			// Note: "\x50\x4B\x03\x04" is the same as "PK\x03\x04" (PK in hex), so removed duplicate.
-		];
+	private function detectExecutableMagicBytes(string $content, string $errorPrefix, string $fileName = ''): void {
+		// Offset-0 executable signatures — universal, every file property.
+		$description = $this->executableDetector->matchExecutableSignature(content: $content);
+		if ($description !== null) {
+			$this->logger->warning(
+				message: '[FilePropertyHandler] Executable magic bytes detected',
+				context: [
+					'file' => __FILE__,
+					'line' => __LINE__,
+					'app' => 'openregister',
+					'type' => $description,
+				]
+			);
 
-		foreach ($magicBytes as $signature => $description) {
-			if ($description === false) {
-				continue;
-				// Skip patterns that need deeper inspection.
-			}
+			$msg = "$errorPrefix contains executable code ($description). ";
+			throw new Exception($msg . 'Executable files are blocked for security reasons.');
+		}
 
-			if (strpos($content, $signature) === 0) {
-				$this->logger->warning(
-					message: '[FilePropertyHandler] Executable magic bytes detected',
-					context: [
-						'file' => __FILE__,
-						'line' => __LINE__,
-						'app' => 'openregister',
-						'type' => $description,
-					]
-				);
-
-				$msg = "$errorPrefix contains executable code ($description). ";
-				throw new Exception($msg . 'Executable files are blocked for security reasons.');
-			}
-		}//end foreach
-
-		// Check for script shebangs anywhere in first 4 lines.
-		$firstLines = substr($content, 0, 1024);
-		if (preg_match('/^#!.*\/(sh|bash|zsh|ksh|csh|python|perl|ruby|php|node)/m', $firstLines) === 1) {
+		// Script shebangs — universal, every file property.
+		if ($this->executableDetector->hasScriptShebang(content: $content) === true) {
 			throw new Exception(
 				"$errorPrefix contains script shebang. Script files are blocked for security reasons."
 			);
 		}
 
-		// Check for embedded PHP tags.
-		if (preg_match('/<\?php|<\?=|<script\s+language\s*=\s*["\']php/i', $firstLines) === 1) {
+		// Embedded PHP tags — text-ish payloads only, see openregister#2776.
+		if ($this->executableDetector->containsEmbeddedPhpTag(content: $content, fileName: $fileName) === true) {
 			throw new Exception(
 				"$errorPrefix contains PHP code. PHP files are blocked for security reasons."
 			);

--- a/tests/Unit/Controller/FilesControllerTest.php
+++ b/tests/Unit/Controller/FilesControllerTest.php
@@ -83,12 +83,26 @@ class FilesControllerTest extends TestCase {
 	// ObjectService::setSchema() resolves a schema SLUG register-scoped only
 	// when a register is ALREADY set; with no register context it falls back
 	// to a global LOWER(slug) match across every register on the instance.
-	// The controller used to call setSchema() first, so an upload addressed
-	// to planix/task resolved to openbuild's `task` schema and 500'd with a
+	// The controller called setSchema() first, so an upload addressed to
+	// planix/task resolved to openbuild's `task` schema and 500'd with a
 	// message naming a register the caller never mentioned.
 	//
-	// The fake below reproduces exactly that resolution behaviour, so these
-	// tests fail against the old ordering and pass against the new one.
+	// TWO LAYERS NOW GUARD THIS, DELIBERATELY.
+	//   1. ObjectService, since #2774 (merged after this branch was cut):
+	//      setRegister() re-resolves a pending schema ref, so the boundary
+	//      holds whichever order the two setters are called in. That is the
+	//      backstop for the ~24 call sites nobody has reordered yet.
+	//   2. This controller: it asks for the context in the correct order in
+	//      the first place, through one helper.
+	//
+	// Layer 2 is not redundant. #2774's own comment names FilesController as
+	// the shape of the problem, and a backstop that silently repairs a wrong
+	// call order leaves the call order wrong — every future reader still has
+	// to know that setSchema-then-setRegister only works by rescue. These
+	// tests pin the controller's ordering contract directly, which is why the
+	// fake below reproduces the resolution semantics AS THEY WERE when #2779
+	// was filed: that is the behaviour layer 2 has to be correct against, and
+	// it is what makes these tests fail if the ordering ever regresses.
 	// =====================================================================
 
 	/**

--- a/tests/Unit/Service/File/ExecutableContentDetectorTest.php
+++ b/tests/Unit/Service/File/ExecutableContentDetectorTest.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * ExecutableContentDetector Unit Tests
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service\File
+ * @author   Conduction <info@conduction.nl>
+ * @license  EUPL-1.2
+ * @link     https://github.com/ConductionNL/openregister
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Service\File;
+
+use OCA\OpenRegister\Service\File\ExecutableContentDetector;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for ExecutableContentDetector — the single source of truth for
+ * executable-content detection, shared by FileValidationHandler (the `/files`
+ * endpoints) and FilePropertyHandler (the object-save path).
+ *
+ * The two callers each have their own tests covering their message shapes and
+ * logging. These tests cover the detection rules themselves, once.
+ */
+class ExecutableContentDetectorTest extends TestCase {
+
+	private ExecutableContentDetector $detector;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->detector = new ExecutableContentDetector();
+	}//end setUp()
+
+	/**
+	 * The reproducer from the Jira attachment migration: a real 1283x926 PNG
+	 * screenshot whose first 1024 bytes contain `<?=` at offset 710.
+	 *
+	 * @return string
+	 */
+	private function falsePositivePngPath(): string {
+		return __DIR__ . '/../../../fixtures/files/php-tag-false-positive.png';
+	}//end falsePositivePngPath()
+
+	// =========================================================================
+	// matchExecutableSignature — universal, unchanged by the #2776 scoping
+	// =========================================================================
+
+	/**
+	 * @dataProvider executableSignatureProvider
+	 */
+	public function testMatchExecutableSignature(string $content, ?string $expected): void {
+		$this->assertSame($expected, $this->detector->matchExecutableSignature($content));
+	}//end testMatchExecutableSignature()
+
+	/**
+	 * @return array<string, array{string, string|null}>
+	 */
+	public static function executableSignatureProvider(): array {
+		return [
+			'pe/exe' => ['MZ' . str_repeat("\x00", 32), 'Windows executable (PE/EXE)'],
+			'elf' => ["\x7FELF" . str_repeat("\x00", 32), 'Linux/Unix executable (ELF)'],
+			'sh shebang' => ["#!/bin/sh\necho hi", 'Shell script'],
+			'bash shebang' => ["#!/bin/bash\necho hi", 'Bash script'],
+			'env shebang' => ["#!/usr/bin/env python\n", 'Script with env shebang'],
+			'php open tag' => ["<?php echo 1;", 'PHP script'],
+			'java class' => ["\xCA\xFE\xBA\xBE" . str_repeat("\x00", 32), 'Java class file'],
+			'plain text' => ['Hello, world.', null],
+			// Offset 0 only: the same bytes later in the stream are not a match.
+			'MZ not at offset 0' => ['some text then MZ more text', null],
+			'empty' => ['', null],
+		];
+	}//end executableSignatureProvider()
+
+	// =========================================================================
+	// hasScriptShebang — universal, unchanged by the #2776 scoping
+	// =========================================================================
+
+	public function testHasScriptShebangDetectsInterpreterLine(): void {
+		$this->assertTrue($this->detector->hasScriptShebang("#!/usr/bin/perl\nprint 1;\n"));
+	}//end testHasScriptShebangDetectsInterpreterLine()
+
+	public function testHasScriptShebangIgnoresOrdinaryText(): void {
+		$this->assertFalse($this->detector->hasScriptShebang("A readme.\nNothing to see.\n"));
+	}//end testHasScriptShebangIgnoresOrdinaryText()
+
+	public function testHasScriptShebangIsNotSuppressedForBinaryContent(): void {
+		// The scoping narrows the PHP-tag scan ONLY. A shebang in something
+		// named like an image is still detected.
+		$this->assertTrue($this->detector->hasScriptShebang("#!/bin/bash\nrm -rf /\n"));
+	}//end testHasScriptShebangIsNotSuppressedForBinaryContent()
+
+	// =========================================================================
+	// sniffBinaryContentType
+	// =========================================================================
+
+	/**
+	 * @dataProvider sniffProvider
+	 */
+	public function testSniffBinaryContentType(string $content, ?string $expected): void {
+		$this->assertSame($expected, $this->detector->sniffBinaryContentType($content));
+	}//end testSniffBinaryContentType()
+
+	/**
+	 * @return array<string, array{string, string|null}>
+	 */
+	public static function sniffProvider(): array {
+		return [
+			'png' => ["\x89PNG\r\n\x1A\n....", 'image/png'],
+			'jpeg' => ["\xFF\xD8\xFF\xE0....", 'image/jpeg'],
+			'gif87' => ['GIF87a....', 'image/gif'],
+			'gif89' => ['GIF89a....', 'image/gif'],
+			'tiff le' => ["II*\x00....", 'image/tiff'],
+			'tiff be' => ["MM\x00*....", 'image/tiff'],
+			'ico' => ["\x00\x00\x01\x00....", 'image/vnd.microsoft.icon'],
+			'psd' => ['8BPS....', 'image/vnd.adobe.photoshop'],
+			'riff' => ['RIFF....WEBP', 'application/x-riff'],
+			'pdf' => ['%PDF-1.7....', 'application/pdf'],
+			'ole' => ["\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1....", 'application/x-ole-storage'],
+			'zip' => ["PK\x03\x04....", 'application/zip'],
+			'gzip' => ["\x1F\x8B\x08....", 'application/gzip'],
+			'bzip2' => ['BZh9....', 'application/x-bzip2'],
+			'xz' => ["\xFD7zXZ\x00....", 'application/x-xz'],
+			'7z' => ["7z\xBC\xAF\x27\x1C....", 'application/x-7z-compressed'],
+			'rar' => ["Rar!\x1A\x07....", 'application/vnd.rar'],
+			'mp3' => ['ID3....', 'audio/mpeg'],
+			'ogg' => ['OggS....', 'application/ogg'],
+			'flac' => ['fLaC....', 'audio/flac'],
+			'matroska' => ["\x1A\x45\xDF\xA3....", 'video/x-matroska'],
+			'flv' => ["FLV\x01....", 'video/x-flv'],
+			'sqlite' => ["SQLite format 3\x00....", 'application/vnd.sqlite3'],
+			'mp4 ftyp at offset 4' => ["\x00\x00\x00\x20ftypisom....", 'video/mp4'],
+			// Negative cases — these keep the full scan.
+			'plain text' => ['Dear customer,', null],
+			'html' => ['<!doctype html>', null],
+			'empty' => ['', null],
+			'unknown bytes' => ["\x01\x02\x03\x04\x05", null],
+			// Too short for the ftyp probe.
+			'short ftyp-like' => ["\x00\x00\x00\x20ftyp", null],
+		];
+	}//end sniffProvider()
+
+	public function testSniffIdentifiesTheRealPngReproducer(): void {
+		$content = (string)file_get_contents($this->falsePositivePngPath());
+
+		$this->assertSame('image/png', $this->detector->sniffBinaryContentType($content));
+	}//end testSniffIdentifiesTheRealPngReproducer()
+
+	// =========================================================================
+	// hasAlwaysScannedExtension
+	// =========================================================================
+
+	/**
+	 * @dataProvider extensionProvider
+	 */
+	public function testHasAlwaysScannedExtension(string $fileName, bool $expected): void {
+		$this->assertSame($expected, $this->detector->hasAlwaysScannedExtension($fileName));
+	}//end testHasAlwaysScannedExtension()
+
+	/**
+	 * @return array<string, array{string, bool}>
+	 */
+	public static function extensionProvider(): array {
+		return [
+			'html' => ['page.html', true],
+			'HTML uppercase' => ['PAGE.HTML', true],
+			'phtml' => ['x.phtml', true],
+			'svg' => ['logo.svg', true],
+			'xml' => ['feed.xml', true],
+			'txt' => ['notes.txt', true],
+			'json' => ['data.json', true],
+			'htaccess' => ['.htaccess', true],
+			'no extension' => ['attachment', true],
+			'png' => ['photo.png', false],
+			'pdf' => ['report.pdf', false],
+			'docx' => ['contract.docx', false],
+			'mp4' => ['clip.mp4', false],
+			'unknown binary-ish' => ['blob.dat', false],
+		];
+	}//end extensionProvider()
+
+	// =========================================================================
+	// containsEmbeddedPhpTag — the scoped check, both directions
+	// =========================================================================
+
+	public function testRealPngReproducerIsNotFlagged(): void {
+		$content = (string)file_get_contents($this->falsePositivePngPath());
+
+		// Guard the guard: the bytes that tripped the old universal rule must
+		// still be present, or this test proves nothing.
+		$this->assertStringContainsString('<?=', substr($content, 0, 1024));
+		$this->assertFalse($this->detector->containsEmbeddedPhpTag($content, 'Gegevens weergeven.PNG'));
+	}//end testRealPngReproducerIsNotFlagged()
+
+	/**
+	 * @dataProvider embeddedPhpProvider
+	 */
+	public function testContainsEmbeddedPhpTag(string $content, string $fileName, bool $expected): void {
+		$this->assertSame($expected, $this->detector->containsEmbeddedPhpTag($content, $fileName));
+	}//end testContainsEmbeddedPhpTag()
+
+	/**
+	 * @return array<string, array{string, string, bool}>
+	 */
+	public static function embeddedPhpProvider(): array {
+		$php = "<?php system(\$_GET['c']); ?>";
+
+		return [
+			// Skipped: positively-sniffed binary container, non-interpreted name.
+			'png' => ["\x89PNG\r\n\x1A\n$php", 'shot.png', false],
+			'pdf' => ["%PDF-1.7$php", 'report.pdf', false],
+			'docx' => ["PK\x03\x04$php", 'contract.docx', false],
+			'mp4' => ["\x00\x00\x00\x20ftypisom$php", 'clip.mp4', false],
+
+			// Scanned: text-ish or unidentified content.
+			'plain text' => ["notes\n$php", 'notes.txt', true],
+			'html' => ["<html>$php</html>", 'page.html', true],
+			'xml short echo' => ["<root><?= 'x' ?></root>", 'feed.xml', true],
+			'svg' => ["<svg>$php</svg>", 'logo.svg', true],
+			'script language tag' => ['<script language="php">echo 1;</script>', 'page.html', true],
+			'no extension' => ["notes\n$php", 'attachment', true],
+			'unknown byte stream' => ["\x01\x02\x03\x04$php", 'blob.dat', true],
+
+			// Polyglots: binary magic under an interpreted or markup name.
+			'png magic as .phtml' => ["\x89PNG\r\n\x1A\n$php", 'polyglot.phtml', true],
+			'png magic as .html' => ["\x89PNG\r\n\x1A\n$php", 'polyglot.html', true],
+			'png magic as .svg' => ["\x89PNG\r\n\x1A\n$php", 'polyglot.svg', true],
+			'pdf magic as .txt' => ["%PDF-1.7$php", 'polyglot.txt', true],
+
+			// Clean content is clean whatever it is named.
+			'clean text' => ['Just a readme.', 'readme.txt', false],
+		];
+	}//end embeddedPhpProvider()
+
+	public function testTagBeyondTheScannedPrefixIsNotFlagged(): void {
+		// Documented, pre-existing bound: only the first 1024 bytes are scanned.
+		// Pinned here so a change to SCAN_PREFIX_LENGTH is a deliberate decision.
+		$content = str_repeat('a', ExecutableContentDetector::SCAN_PREFIX_LENGTH) . '<?php echo 1;';
+
+		$this->assertFalse($this->detector->containsEmbeddedPhpTag($content, 'notes.txt'));
+	}//end testTagBeyondTheScannedPrefixIsNotFlagged()
+
+	public function testTagAtTheEndOfTheScannedPrefixIsFlagged(): void {
+		$tag = '<?php';
+		$padding = str_repeat('a', (ExecutableContentDetector::SCAN_PREFIX_LENGTH - strlen($tag)));
+
+		$this->assertTrue($this->detector->containsEmbeddedPhpTag($padding . $tag, 'notes.txt'));
+	}//end testTagAtTheEndOfTheScannedPrefixIsFlagged()
+}//end class

--- a/tests/Unit/Service/File/FileValidationHandlerTest.php
+++ b/tests/Unit/Service/File/FileValidationHandlerTest.php
@@ -789,4 +789,51 @@ class FileValidationHandlerTest extends TestCase {
 		$this->handler->detectExecutableMagicBytes($content, 'safe.txt');
 		$this->assertTrue(true);
 	}//end testDetectMagicBytesShebangBeyond1024BytesNotDetected()
+
+	/**
+	 * A text-ish extension is reported as always-scanned.
+	 *
+	 * This is the seam the ExecutableContentDetector extraction created: the
+	 * handler no longer owns the extension list, it delegates. The delegation
+	 * itself is what is asserted here — an extraction that forwards to the
+	 * wrong collaborator, or forgets to forward at all, is invisible to the
+	 * tests for the list's contents because those exercise the detector
+	 * directly and never travel through this method.
+	 *
+	 * @return void
+	 */
+	public function testHasAlwaysScannedExtensionAcceptsATextExtension(): void {
+		$this->assertTrue($this->handler->hasAlwaysScannedExtension('notes.txt'));
+	}//end testHasAlwaysScannedExtensionAcceptsATextExtension()
+
+	/**
+	 * The check is case-insensitive, and a binary extension is not in the list.
+	 *
+	 * Both directions are asserted in one place on purpose: a delegation that
+	 * always returned true would satisfy the positive case above on its own.
+	 *
+	 * @return void
+	 */
+	public function testHasAlwaysScannedExtensionIsCaseInsensitiveAndRejectsBinaries(): void {
+		$this->assertTrue(
+			$this->handler->hasAlwaysScannedExtension('CONFIG.YML'),
+			'the list is matched after lowercasing, so an upper-case extension still counts'
+		);
+		$this->assertFalse(
+			$this->handler->hasAlwaysScannedExtension('photo.jpg'),
+			'a binary format is not in the always-scanned list'
+		);
+	}//end testHasAlwaysScannedExtensionIsCaseInsensitiveAndRejectsBinaries()
+
+	/**
+	 * A file with no extension at all is always scanned.
+	 *
+	 * This is the deliberate fail-closed branch: an unnamed extension carries
+	 * no signal about the content, so it is scanned rather than trusted.
+	 *
+	 * @return void
+	 */
+	public function testHasAlwaysScannedExtensionScansAnExtensionlessFile(): void {
+		$this->assertTrue($this->handler->hasAlwaysScannedExtension('Makefile'));
+	}//end testHasAlwaysScannedExtensionScansAnExtensionlessFile()
 }//end class

--- a/tests/Unit/Service/Object/SaveObject/FilePropertyHandlerTest.php
+++ b/tests/Unit/Service/Object/SaveObject/FilePropertyHandlerTest.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Tests\Unit\Service\Object\SaveObject;
 
 use Exception;
+use InvalidArgumentException;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Service\FileService;
@@ -2398,5 +2399,71 @@ class FilePropertyHandlerTest extends TestCase {
 		$schema->method('getProperties')->willReturn([]);
 
 		$this->assertFalse($this->handler->isFileProperty('anything', $schema, 'document'));
+	}
+
+	/**
+	 * A URL pointing at loopback is refused before any request is made.
+	 *
+	 * SEC-SVC-2 guards this path against read-SSRF, and it had no test at all:
+	 * the guard could have been deleted outright and every existing assertion
+	 * would still have passed. A literal IP is used rather than a hostname so
+	 * the refusal comes from the address check itself and not from DNS — the
+	 * test then needs no network and cannot go green for the wrong reason.
+	 *
+	 * @return void
+	 */
+	public function testFetchFileFromUrlRefusesALoopbackAddress(): void {
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('non-public address');
+		$this->invokePrivateMethod('fetchFileFromUrl', ['http://127.0.0.1/secret']);
+	}
+
+	/**
+	 * A URL in a private RFC-1918 range is refused.
+	 *
+	 * Loopback alone would be satisfied by a guard that only special-cased
+	 * 127/8; the cloud-metadata and internal-service cases this control exists
+	 * for live in the private and reserved ranges instead.
+	 *
+	 * @return void
+	 */
+	public function testFetchFileFromUrlRefusesAPrivateAddress(): void {
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('non-public address');
+		$this->invokePrivateMethod('fetchFileFromUrl', ['http://169.254.169.254/latest/meta-data/']);
+	}
+
+	/**
+	 * A non-http(s) scheme is refused before the address check runs.
+	 *
+	 * ftp:// is used rather than file:// because the two are rejected by
+	 * different branches, and only this one reaches the scheme test: a
+	 * file:/// URL has no host at all, so it is already gone as malformed by
+	 * the time the scheme is looked at. Asserting the message is what makes
+	 * that distinction hold — without it both inputs pass this test while
+	 * leaving the scheme branch unexercised. No lookup happens either way,
+	 * since the scheme is checked before any resolution.
+	 *
+	 * @return void
+	 */
+	public function testFetchFileFromUrlRefusesANonHttpScheme(): void {
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Only http and https URLs are allowed.');
+		$this->invokePrivateMethod('fetchFileFromUrl', ['ftp://example.com/payload.bin']);
+	}
+
+	/**
+	 * A file:// URL is refused as malformed, closing arbitrary local-file read.
+	 *
+	 * Kept alongside the scheme case because it is the input that matters in
+	 * practice and it exits through a different branch — a future refactor
+	 * that made the scheme check the first thing to run would keep this
+	 * passing, which is the point.
+	 *
+	 * @return void
+	 */
+	public function testFetchFileFromUrlRefusesAFileUrl(): void {
+		$this->expectException(InvalidArgumentException::class);
+		$this->invokePrivateMethod('fetchFileFromUrl', ['file:///etc/passwd']);
 	}
 }

--- a/tests/Unit/Service/Object/SaveObject/FilePropertyHandlerTest.php
+++ b/tests/Unit/Service/Object/SaveObject/FilePropertyHandlerTest.php
@@ -851,6 +851,158 @@ class FilePropertyHandlerTest extends TestCase {
 	}
 
 	// =========================================================================
+	// Binary MIME scoping on the OBJECT-SAVE path — openregister#2776
+	//
+	// This handler carried a byte-identical COPY of the executable-content
+	// checks, so the same legitimate PNG that the `/files` endpoints rejected
+	// was also rejected here. Both call sites now share
+	// ExecutableContentDetector; these tests pin BOTH directions on THIS path
+	// so the two can never drift apart again.
+	// =========================================================================
+
+	/**
+	 * The reproducer from the Jira attachment migration: a real 1283x926 PNG
+	 * screenshot whose first 1024 bytes contain `<?=` at offset 710.
+	 *
+	 * @return string
+	 */
+	private function falsePositivePngPath(): string {
+		return __DIR__ . '/../../../../fixtures/files/php-tag-false-positive.png';
+	}//end falsePositivePngPath()
+
+	public function testFilePropertyPathAcceptsTheRealPngReproducer(): void {
+		$content = (string)file_get_contents($this->falsePositivePngPath());
+
+		// Guard the guard: the fixture must still trip the OLD universal rule,
+		// otherwise this test would pass vacuously.
+		$this->assertStringContainsString('<?=', substr($content, 0, 1024));
+
+		$fileData = [
+			'filename' => 'Gegevens weergeven.PNG',
+			'mimeType' => 'image/png',
+			'content' => $content,
+		];
+
+		$this->handler->blockExecutableFiles($fileData, 'File at attachment');
+
+		$this->assertTrue(true, 'a genuine PNG must not be rejected as PHP on the object-save path');
+	}//end testFilePropertyPathAcceptsTheRealPngReproducer()
+
+	/**
+	 * @dataProvider filePropertyBinaryContainerProvider
+	 */
+	public function testFilePropertyPathSkipsPhpScanForBinaryContainers(string $magic, string $fileName, string $mime): void {
+		$fileData = [
+			'filename' => $fileName,
+			'mimeType' => $mime,
+			'content' => $magic . str_repeat("\x00", 32) . "<?php system('whoami'); ?>",
+		];
+
+		$this->handler->blockExecutableFiles($fileData, 'File at attachment');
+
+		$this->assertTrue(true, "{$fileName} must not be scanned for PHP tags");
+	}//end testFilePropertyPathSkipsPhpScanForBinaryContainers()
+
+	/**
+	 * @return array<string, array{string, string, string}>
+	 */
+	public static function filePropertyBinaryContainerProvider(): array {
+		return [
+			'png' => ["\x89PNG\r\n\x1A\n", 'screenshot.png', 'image/png'],
+			'jpeg' => ["\xFF\xD8\xFF\xE0", 'photo.jpg', 'image/jpeg'],
+			'pdf' => ['%PDF-1.7', 'report.pdf', 'application/pdf'],
+			'docx' => ["PK\x03\x04", 'contract.docx', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
+		];
+	}//end filePropertyBinaryContainerProvider()
+
+	// --- MUST-FAIL side: the protection survives on this path too. ---
+
+	/**
+	 * @dataProvider filePropertyStillRejectedProvider
+	 */
+	public function testFilePropertyPathStillRejectsPhpPayloads(string $content, string $fileName, string $mime): void {
+		$fileData = [
+			'filename' => $fileName,
+			'mimeType' => $mime,
+			'content' => $content,
+		];
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('PHP code');
+
+		$this->handler->blockExecutableFiles($fileData, 'File at attachment');
+	}//end testFilePropertyPathStillRejectsPhpPayloads()
+
+	/**
+	 * Note: a `.php`/`.phtml` name is refused by the extension blocklist BEFORE
+	 * content is read, with a different message, so those cases are covered by
+	 * the existing extension tests rather than here. These all reach the
+	 * content scan and must still be refused by it.
+	 *
+	 * @return array<string, array{string, string, string}>
+	 */
+	public static function filePropertyStillRejectedProvider(): array {
+		$php = "<?php system(\$_GET['c']); ?>";
+
+		return [
+			'php source as .txt' => ["notes\n$php", 'notes.txt', 'text/plain'],
+			'php in html' => ["<html><body>$php</body></html>", 'page.html', 'text/html'],
+			'php short echo in xml' => ["<root><?= 'x' ?></root>", 'feed.xml', 'application/xml'],
+			'php inside svg' => ["<svg xmlns='http://www.w3.org/2000/svg'>$php</svg>", 'logo.svg', 'image/svg+xml'],
+			'script language=php' => ["<html><script language=\"php\">echo 1;</script>", 'page.html', 'text/html'],
+			'no extension at all' => ["notes\n$php", 'attachment', 'application/octet-stream'],
+			'unrecognised byte stream' => ["\x01\x02\x03\x04$php", 'blob.dat', 'application/octet-stream'],
+			// Polyglots: real PNG magic bytes under an interpreted/markup name.
+			'png magic saved as .html' => ["\x89PNG\r\n\x1A\n$php", 'polyglot.html', 'text/html'],
+			'png magic saved as .svg' => ["\x89PNG\r\n\x1A\n$php", 'polyglot.svg', 'image/svg+xml'],
+		];
+	}//end filePropertyStillRejectedProvider()
+
+	public function testFilePropertyPathStillRejectsExecutableBytesUnderAnImageName(): void {
+		// The MIME scoping narrows ONLY the embedded-PHP-tag scan. The offset-0
+		// signature table is untouched and still universal on this path.
+		$fileData = [
+			'filename' => 'innocent.png',
+			'mimeType' => 'image/png',
+			'content' => 'MZ' . str_repeat("\x00", 64),
+		];
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('executable code');
+
+		$this->handler->blockExecutableFiles($fileData, 'File at attachment');
+	}//end testFilePropertyPathStillRejectsExecutableBytesUnderAnImageName()
+
+	public function testFilePropertyPathStillRejectsShebangUnderAnImageName(): void {
+		$fileData = [
+			'filename' => 'data.png',
+			'mimeType' => 'image/png',
+			'content' => "#!/usr/bin/env python\nprint(1)\n",
+		];
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('shebang');
+
+		$this->handler->blockExecutableFiles($fileData, 'File at attachment');
+	}//end testFilePropertyPathStillRejectsShebangUnderAnImageName()
+
+	public function testFilePropertyPathStillRejectsPhpSourceUnderAPhpName(): void {
+		// The dangerous-extension blocklist is the primary control and runs
+		// before content is even read — a .php upload is refused whatever its
+		// bytes look like, including a PNG-magic polyglot.
+		$fileData = [
+			'filename' => 'polyglot.phtml',
+			'mimeType' => 'image/png',
+			'content' => "\x89PNG\r\n\x1A\n<?php echo 1;",
+		];
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('executable file');
+
+		$this->handler->blockExecutableFiles($fileData, 'File at attachment');
+	}//end testFilePropertyPathStillRejectsPhpSourceUnderAPhpName()
+
+	// =========================================================================
 	// blockExecutableFiles
 	// =========================================================================
 


### PR DESCRIPTION
## Why this exists

#2784 fixed the embedded-PHP-tag false positive in `FileValidationHandler` (the `/files` endpoints). It did not close #2776, because **the same logic existed a second time, byte-identically**, in `FilePropertyHandler` (the object-save file-property path). The identical real PNG was still rejected through that route after the first fix.

That is a byte-identical duplicate earning its keep as a bug factory: one defect, two copies, one fix.

## What changed

`ExecutableContentDetector` becomes the single implementation of all three checks — the offset-0 signature table, the shebang regex, and the embedded-PHP-tag scan with its binary-sniff/extension cross-check.

It **detects and reports; it does not throw and does not log.** That is deliberate: the two callers have different caller-facing message shapes (`File 'x.png' …` vs `File at document …`) and log under their own class prefixes. Keeping those in the callers is what makes this behaviour-preserving rather than a rewrite.

Also drops the removed copy's disabled `"PK\x03\x04" => false` ZIP entry, which sat behind a `continue` and never matched anything.

## Security posture — unchanged

Nothing became more permissive. The scan is still skipped only when content **positively sniffs** as a known binary container **and** the filename is not an interpreted/markup extension; the declared MIME is still ignored because it is client-controlled. Everything else keeps the original scan: text/HTML/XML/SVG/JSON/config, files with **no extension**, unrecognised byte streams, and polyglots named `.phtml`/`.html`/`.svg`.

## Evidence

- **536 tests pass** across `ExecutableContentDetector`, `FilePropertyHandler`, `FilesController` and `FileValidationHandler` (897 assertions).
- Both directions covered, including the must-FAIL side: `testHasScriptShebangIsNotSuppressedForBinaryContent`, `testTagAtTheEndOfTheScannedPrefixIsFlagged`, plus the polyglot/`MZ`-named-`.png` cases inherited from #2784.
- The real reproducer is pinned in two tests: `testSniffIdentifiesTheRealPngReproducer` and `testRealPngReproducerIsNotFlagged` — the PNG whose deflate stream carries `<?=` at byte 710.
- `phpcs`, `psalm` and `phpstan` clean (`[OK] No errors` on the full project).

Closes #2776 on the object-save path as well as the `/files` path.

Follow-up already filed: #2786 — the same schema-before-register ordering exists in 13 other controllers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
