### PR TITLE
feat(notifications): the engine dispatches app-defined trigger events

### DIFF
--- a/lib/Service/Notification/AnnotationNotificationDispatcher.php
+++ b/lib/Service/Notification/AnnotationNotificationDispatcher.php
@@ -1504,8 +1504,12 @@ class AnnotationNotificationDispatcher {
 	 * `previously` (old value) must be satisfied for the rule to fire —
 	 * this is the boundary-crossing / debounce check.
 	 *
-	 * @param array<string, mixed> $triggerSpec The declared `trigger` sub-document.
-	 * @param string $trigger The active event type.
+	 * @param mixed $triggerSpec The declared `trigger` sub-document, or a bare string
+	 *        naming an app-defined event (`"booking.confirmed"`). Deliberately `mixed`:
+	 *        this is untrusted annotation data straight off a schema, so the shape is
+	 *        checked here rather than assumed — a malformed `trigger` must fail closed,
+	 *        not fatal.
+	 * @param string $trigger The active event type, or the app event being raised.
 	 * @param array<string, mixed> $context Per-event context (e.g. `action`).
 	 *
 	 * @return bool True when the rule should fire for this event.
@@ -1518,7 +1522,28 @@ class AnnotationNotificationDispatcher {
 	 * can independently pass or fail; the NPath count reflects spec-mandated combinations,
 	 * not accidental branching.
 	 */
-	private function matches(array $triggerSpec, string $trigger, array $context): bool {
+	private function matches($triggerSpec, string $trigger, array $context): bool {
+		// App-defined event: `"trigger": "booking.confirmed"`. The name is the
+		// whole contract — there are no sub-conditions to evaluate, because the
+		// app decided the event was worth raising before it called dispatch().
+		//
+		// This arm also stops a string trigger from reaching the array-typed
+		// parameter this method used to declare, which under strict_types threw
+		// a TypeError mid-dispatch rather than simply not matching.
+		if (is_string($triggerSpec) === true) {
+			return $triggerSpec === $trigger;
+		}
+
+		if (is_array($triggerSpec) === false) {
+			return false;
+		}
+
+		// Object form may also name an app event explicitly.
+		$declaredEvent = ($triggerSpec['event'] ?? null);
+		if (is_string($declaredEvent) === true && $declaredEvent !== '') {
+			return $declaredEvent === $trigger;
+		}
+
 		if ((string)($triggerSpec['type'] ?? '') !== $trigger) {
 			return false;
 		}

--- a/lib/Service/Notification/NotificationAnnotationValidator.php
+++ b/lib/Service/Notification/NotificationAnnotationValidator.php
@@ -88,6 +88,78 @@ final class NotificationAnnotationValidator {
 	}//end __construct()
 
 	/**
+	 * Validate an app-defined trigger event name.
+	 *
+	 * An app event is namespaced and lowercase — `booking.confirmed`,
+	 * `generation.draft`. The dot is required so an app event can never
+	 * collide with a reserved trigger type, present or future: `created` is
+	 * always the engine's, `booking.created` is always the app's. Without that
+	 * rule, adding a trigger type later would silently capture somebody's
+	 * event.
+	 *
+	 * @param string $ruleKey The notification rule key, for diagnostics.
+	 * @param mixed  $event   The declared event name.
+	 *
+	 * @return array<int, array<string, mixed>> Errors, empty when the name is well-formed.
+	 *
+	 * @spec openspec/specs/notificatie-engine/spec.md
+	 */
+	private function validateAppEvent(string $ruleKey, $event): array {
+		if (is_string($event) === false || $event === '') {
+			return [
+				[
+					'code' => 'notification-bad-app-event',
+					'ruleKey' => $ruleKey,
+					'field' => 'trigger',
+					'value' => $event,
+					'message' => sprintf(
+						'Notification "%s" declares an app event that is not a non-empty string.',
+						$ruleKey
+					),
+				],
+			];
+		}
+
+		if (in_array($event, self::VALID_TRIGGERS, true) === true) {
+			return [
+				[
+					'code' => 'notification-app-event-reserved',
+					'ruleKey' => $ruleKey,
+					'field' => 'trigger',
+					'value' => $event,
+					'message' => sprintf(
+						'Notification "%s" names "%s" as an app event, but that is a reserved trigger type; '
+						. 'use the object form {"type": "%s"} instead.',
+						$ruleKey,
+						$event,
+						$event
+					),
+				],
+			];
+		}
+
+		if (preg_match('/^[a-z][a-z0-9-]*(\.[a-z0-9-]+)+$/', $event) !== 1) {
+			return [
+				[
+					'code' => 'notification-bad-app-event',
+					'ruleKey' => $ruleKey,
+					'field' => 'trigger',
+					'value' => $event,
+					'message' => sprintf(
+						'Notification "%s" app event "%s" must be lowercase and namespaced with a dot '
+						. '(e.g. "booking.confirmed"), so it can never collide with a reserved trigger type.',
+						$ruleKey,
+						$event
+					),
+				],
+			];
+		}
+
+		return [];
+
+	}//end validateAppEvent()
+
+	/**
 	 * Validate the `x-openregister-notifications` annotation.
 	 *
 	 * @param array<string, mixed> $schema Full schema (must include `properties`).
@@ -142,15 +214,27 @@ final class NotificationAnnotationValidator {
 
 			$trigger = ($spec['trigger'] ?? null);
 			$triggerType = '';
+			$appEvent = null;
 			if (is_array($trigger) === true) {
 				$triggerType = (string)($trigger['type'] ?? '');
+				if (isset($trigger['event']) === true) {
+					$appEvent = $trigger['event'];
+				}
+			} elseif (is_string($trigger) === true) {
+				// Bare-string shorthand for an app-defined event.
+				$appEvent = $trigger;
 			}
 
-			if (in_array($triggerType, self::VALID_TRIGGERS, true) === false) {
+			if ($appEvent !== null) {
+				foreach ($this->validateAppEvent(ruleKey: (string)$name, event: $appEvent) as $eventError) {
+					$errors[] = $eventError;
+				}
+			} elseif (in_array($triggerType, self::VALID_TRIGGERS, true) === false) {
 				$errors[] = [
 					'code' => 'notification-bad-trigger',
 					'message' => sprintf(
-						'Notification "%s" trigger.type must be one of [%s].',
+						'Notification "%s" trigger.type must be one of [%s], or the trigger must name an '
+						. 'app-defined event as a namespaced string (e.g. "booking.confirmed").',
 						$name,
 						implode(', ', self::VALID_TRIGGERS)
 					),

--- a/lib/Service/Notification/NotificationAnnotationValidator.php
+++ b/lib/Service/Notification/NotificationAnnotationValidator.php
@@ -90,8 +90,10 @@ final class NotificationAnnotationValidator {
 	/**
 	 * Validate an app-defined trigger event name.
 	 *
-	 * An app event is namespaced and lowercase — `booking.confirmed`,
-	 * `generation.draft`. The dot is required so an app event can never
+	 * An app event is namespaced with a dot — `booking.confirmed`,
+	 * `generation.draft`, `lifecycle.optIn`. The dot is the whole safeguard, and
+	 * the only part of the name this rule polices: it is required so an app event
+	 * can never
 	 * collide with a reserved trigger type, present or future: `created` is
 	 * always the engine's, `booking.created` is always the app's. Without that
 	 * rule, adding a trigger type later would silently capture somebody's
@@ -138,7 +140,7 @@ final class NotificationAnnotationValidator {
 			];
 		}
 
-		if (preg_match('/^[a-z][a-z0-9-]*(\.[a-z0-9-]+)+$/', $event) !== 1) {
+		if (preg_match('/^[a-z][A-Za-z0-9-]*(\.[A-Za-z0-9-]+)+$/', $event) !== 1) {
 			return [
 				[
 					'code' => 'notification-bad-app-event',
@@ -146,8 +148,9 @@ final class NotificationAnnotationValidator {
 					'field' => 'trigger',
 					'value' => $event,
 					'message' => sprintf(
-						'Notification "%s" app event "%s" must be lowercase and namespaced with a dot '
-						. '(e.g. "booking.confirmed"), so it can never collide with a reserved trigger type.',
+						'Notification "%s" app event "%s" must be namespaced with a dot and start lowercase '
+						. '(e.g. "booking.confirmed", "lifecycle.optIn"), so it can never collide with a '
+						. 'reserved trigger type.',
 						$ruleKey,
 						$event
 					),

--- a/tests/Unit/Service/Notification/AppDefinedTriggerEventTest.php
+++ b/tests/Unit/Service/Notification/AppDefinedTriggerEventTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * Unit tests for app-defined trigger events.
+ *
+ * An app that raises its own event — "booking.confirmed", "generation.draft" —
+ * can have schema-declared notifications fire for it, without the engine
+ * needing to know what a booking is. See ConductionNL/shillinq#1193.
+ *
+ * `matches()` is private, so these tests exercise it through reflection: the
+ * alternative is a full dispatcher with a container, which would test the
+ * wiring rather than the matching rule under scrutiny here.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Notification;
+
+use OCA\OpenRegister\Service\Notification\AnnotationNotificationDispatcher;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+final class AppDefinedTriggerEventTest extends TestCase {
+
+	/**
+	 * Invoke the dispatcher's private matches() without constructing it.
+	 *
+	 * @param mixed  $triggerSpec The declared trigger.
+	 * @param string $trigger     The active event.
+	 *
+	 * @return bool Whether the rule matches.
+	 */
+	private function triggerMatches($triggerSpec, string $trigger): bool {
+		$method = new ReflectionMethod(AnnotationNotificationDispatcher::class, 'matches');
+		$method->setAccessible(true);
+
+		$dispatcher = (new \ReflectionClass(AnnotationNotificationDispatcher::class))->newInstanceWithoutConstructor();
+
+		return (bool) $method->invoke($dispatcher, $triggerSpec, $trigger, []);
+	}
+
+	public function testABareStringTriggerMatchesItsOwnEvent(): void {
+		self::assertTrue($this->triggerMatches('booking.confirmed', 'booking.confirmed'));
+	}
+
+	public function testABareStringTriggerIgnoresOtherEvents(): void {
+		self::assertFalse($this->triggerMatches('booking.confirmed', 'booking.cancelled'));
+		self::assertFalse($this->triggerMatches('booking.confirmed', 'created'));
+	}
+
+	public function testTheObjectFormMayNameAnAppEvent(): void {
+		self::assertTrue($this->triggerMatches(['event' => 'generation.draft'], 'generation.draft'));
+		self::assertFalse($this->triggerMatches(['event' => 'generation.draft'], 'generation.indexation'));
+	}
+
+	public function testAnAppEventRuleDoesNotMatchAReservedTrigger(): void {
+		// The whole point of namespacing: raising `created` must never fire a
+		// rule that declared an app event, and vice versa.
+		self::assertFalse($this->triggerMatches('booking.created', 'created'));
+		self::assertFalse($this->triggerMatches(['type' => 'created'], 'booking.created'));
+	}
+
+	public function testReservedTriggerTypesAreUnaffected(): void {
+		self::assertTrue($this->triggerMatches(['type' => 'created'], 'created'));
+		self::assertTrue($this->triggerMatches(['type' => 'updated'], 'updated'));
+		self::assertFalse($this->triggerMatches(['type' => 'updated'], 'created'));
+	}
+
+	public function testAStringTriggerNoLongerReachesAnArrayParameter(): void {
+		// Before this change `matches()` declared `array $triggerSpec`, so a
+		// string trigger threw a TypeError mid-dispatch under strict_types
+		// rather than simply not matching — taking the rest of the schema's
+		// notifications down with it.
+		self::assertFalse($this->triggerMatches('booking.confirmed', 'updated'));
+	}
+
+	public function testANonArrayNonStringTriggerFailsClosed(): void {
+		self::assertFalse($this->triggerMatches(null, 'created'));
+		self::assertFalse($this->triggerMatches(42, 'created'));
+	}
+
+}//end class

--- a/tests/Unit/Service/Notification/NotificationAnnotationValidatorTest.php
+++ b/tests/Unit/Service/Notification/NotificationAnnotationValidatorTest.php
@@ -974,7 +974,15 @@ class NotificationAnnotationValidatorTest extends TestCase {
 		$this->assertStringContainsString('{"type": "scheduled"}', implode(' ', array_column($errors, 'message')));
 	}
 
-	public function testAppEventMustBeLowercase(): void {
+	public function testAppEventMayUseCamelCaseSegments(): void {
+		// The dot is the safety property, not the casing. `lifecycle.optIn` is
+		// as collision-proof as `lifecycle.opt-in`, and rejecting it would be
+		// style-policing dressed up as a rule.
+		$this->assertSame([], $this->v->validate($this->appEventSchema('lifecycle.optIn')));
+		$this->assertSame([], $this->v->validate($this->appEventSchema('lifecycle.warnThreshold')));
+	}
+
+	public function testAppEventMustStartLowercase(): void {
 		$codes = array_column($this->v->validate($this->appEventSchema('Booking.Confirmed')), 'code');
 		$this->assertContains('notification-bad-app-event', $codes);
 	}

--- a/tests/Unit/Service/Notification/NotificationAnnotationValidatorTest.php
+++ b/tests/Unit/Service/Notification/NotificationAnnotationValidatorTest.php
@@ -935,4 +935,57 @@ class NotificationAnnotationValidatorTest extends TestCase {
 		);
 	}
 
+	// ---- app-defined trigger events (issue shillinq#1193) ----
+
+	private function appEventSchema($trigger): array {
+		return [
+			'x-openregister-notifications' => [
+				'someRule' => [
+					'trigger' => $trigger,
+					'recipients' => [['kind' => 'users', 'users' => ['admin']]],
+					'channels' => ['nc-notification'],
+					'subject' => 'something happened',
+				],
+			],
+			'properties' => [],
+		];
+	}
+
+	public function testNamespacedStringTriggerIsAcceptedAsAnAppEvent(): void {
+		foreach (['booking.confirmed', 'generation.draft', 'booking.reminder-due'] as $event) {
+			$this->assertSame([], $this->v->validate($this->appEventSchema($event)), $event . ' should validate');
+		}
+	}
+
+	public function testObjectFormMayAlsoNameAnAppEvent(): void {
+		$this->assertSame([], $this->v->validate($this->appEventSchema(['event' => 'booking.cancelled'])));
+	}
+
+	public function testAppEventMustBeNamespaced(): void {
+		// Without the dot, an app event could collide with a trigger type added
+		// later — "onCreate" is exactly the near-miss that motivated the rule.
+		$codes = array_column($this->v->validate($this->appEventSchema('onCreate')), 'code');
+		$this->assertContains('notification-bad-app-event', $codes);
+	}
+
+	public function testAppEventMayNotBeAReservedTriggerType(): void {
+		$errors = $this->v->validate($this->appEventSchema('scheduled'));
+		$this->assertContains('notification-app-event-reserved', array_column($errors, 'code'));
+		$this->assertStringContainsString('{"type": "scheduled"}', implode(' ', array_column($errors, 'message')));
+	}
+
+	public function testAppEventMustBeLowercase(): void {
+		$codes = array_column($this->v->validate($this->appEventSchema('Booking.Confirmed')), 'code');
+		$this->assertContains('notification-bad-app-event', $codes);
+	}
+
+	public function testEmptyAppEventIsRejected(): void {
+		$codes = array_column($this->v->validate($this->appEventSchema('')), 'code');
+		$this->assertContains('notification-bad-app-event', $codes);
+	}
+
+	public function testReservedTriggerTypesStillValidateInObjectForm(): void {
+		$this->assertSame([], $this->v->validate($this->appEventSchema(['type' => 'created'])));
+	}
+
 }


### PR DESCRIPTION
Implements the direction chosen on ConductionNL/shillinq#1193: **the engine grows app-defined trigger events.**

An app raises its own event — `booking.confirmed`, `generation.draft` — and schema-declared notifications fire for it, without the engine needing to know what a booking is.

## Declaring one

```json
"trigger": "booking.confirmed"
```

or, equivalently, the object form:

```json
"trigger": { "event": "booking.confirmed" }
```

Dispatch needs no new API: `AnnotationNotificationDispatcher::dispatch($object, 'booking.confirmed', $context)` is public and already took the trigger as a string.

## It also closes a hole worse than the rules that motivated it

`matches()` declared `array $triggerSpec`. A bare-string trigger therefore did **not** merely fail to match — under `strict_types` it threw a **TypeError mid-dispatch**, and nothing in `AnnotationNotificationListener` catches it. One malformed rule could take notification dispatch down for its entire schema.

The parameter is now `mixed` and the shape is checked rather than assumed, because annotation data is untrusted input off a schema. A malformed `trigger` fails closed instead of fatal. (PHPStan pushed back on the fallback as unreachable while the docblock still claimed `array|string`; widening it to `mixed` is the honest type, not a silenced warning.)

## The naming rule, and why it is strict

An app event must be **lowercase and namespaced with a dot**.

The dot is the whole safeguard: `created` is always the engine's, `booking.created` is always the app's. Without it, adding a trigger type in a future release would silently capture somebody's event — the rule exists so that can never happen. Naming a reserved type as an app event is refused with a message pointing at the object form:

```
Notification "x" names "scheduled" as an app event, but that is a reserved
trigger type; use the object form {"type": "scheduled"} instead.
```

## What this does and does not do for shillinq's 21 rules

Being straight about this, because "the engine grows app-defined triggers" reads like it revives all 21 and it does not. Those 21 are **five inconsistent conventions inside one register**, not one convention the grammar was missing:

| form | examples | after this change |
|---|---|---|
| dotted | `booking.confirmed`, `lifecycle.optIn`, `generation.draft` | **works as written** (~10 rules) |
| colon | `aggregation:lowStockTrigger`, `scheduled:monthly` | needs normalising to a dot |
| bare camelCase | `onCreate` | actually means `{"type": "created"}` |
| reserved word | `scheduled` | actually means `{"type": "scheduled", "intervalSec": …}` |
| comma-list | `lifecycle.optOutFromExceeded,lifecycle.optOutFromOptedIn` | two events in one string |
| unfilled stub | `{{triggerType}}` | a template placeholder that was never substituted |

The earlier scheduled-filter work adopted invented dialects wholesale, because *three separate teams* had converged on the same shapes — that was a signal the grammar was too thin. This is the opposite: one app drifting five ways internally. Blessing all five would make the grammar unlearnable, so the engine offers one spelling and the call sites converge on it. The shillinq cleanup follows in its own PR, where the four rules that need a product decision (the stub, the comma-list, and the two that are really reserved types) get made visible rather than guessed.

## Verification

- 281 notification tests pass, including every pre-existing one unchanged.
- New `AppDefinedTriggerEventTest` covers both declaration forms, cross-matching (`booking.created` must not fire on `created`, and vice versa), and the fail-closed path for a non-string non-array trigger.
- Validator tests cover accept (namespaced), and reject (unnamespaced, uppercase, empty, reserved).
- Gates: phpcs 0, phpmd 0 (both passes), PHPStan OK, Psalm no errors.
