### PR TITLE
fix(scope): clear the pending schema ref on the save path too

### DIFF
--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -1643,6 +1643,38 @@ class ObjectService implements ObjectServiceInterface
         Register | string | int | null $register,
         Schema | string | int | null $schema
     ): void {
+        // A CALLER THAT NAMES BOTH CANNOT INHERIT A PENDING REF FROM ANYWHERE.
+        //
+        // `setRegister()` re-resolves `$currentSchemaRef` so the chain
+        // `setSchema($s)->setRegister($r)` still scopes. That ref is instance
+        // state, and ObjectService is reused for many operations in one process,
+        // so an operation that set a schema and never set a register leaves one
+        // behind. The NEXT caller's `setRegister()` then consumes it — and is
+        // refused with a slug it never asked for.
+        //
+        // #2792 made the ref single-use, which stops it being consumed twice. It
+        // does not stop it being consumed ONCE by the wrong operation, and that
+        // is the failure still live on `development`:
+        //
+        //   POST /apps/docudesk/api/templates
+        //   Failed to create template: Schema slug "application" is not carried
+        //   by register "docudesk" (id 19) …
+        //
+        // Docudesk asked for register 19 / schema 18 (`template`). `application`
+        // is openbuild's schema, from an unrelated earlier call on the same
+        // instance. Measured on buildiq E2E 2026-08-22 12:26 UTC, which is after
+        // #2792 landed at 11:09.
+        //
+        // When BOTH are supplied there is nothing to inherit: the caller has
+        // named the pair outright, so any pending ref is by definition stale.
+        // Dropping it here leaves the setSchema()/setRegister() order-independence
+        // intact for callers that genuinely use that chain, and keeps the register
+        // boundary exactly as strict — the schema below is still resolved inside
+        // the register named here.
+        if ($register !== null && $schema !== null) {
+            $this->clearPendingSchemaRef();
+        }
+
         // Set the current register context if provided.
         if ($register !== null) {
             $this->setRegister(register: $register);
@@ -1653,6 +1685,21 @@ class ObjectService implements ObjectServiceInterface
             $this->setSchema(schema: $schema);
         }
     }//end setContextFromParameters()
+
+    /**
+     * Drop a pending schema ref left behind by an earlier operation.
+     *
+     * Named rather than inlined so the one place that owns this state is
+     * greppable: `$currentSchemaRef` is written by setSchema(), consumed by
+     * setRegister(), and discarded here.
+     *
+     * @return void
+     */
+    private function clearPendingSchemaRef(): void
+    {
+        $this->currentSchemaRef = null;
+
+    }//end clearPendingSchemaRef()
 
     /**
      * Extract UUID and normalize object to array format.

--- a/tests/Unit/Service/ObjectServiceStaleSchemaRefTest.php
+++ b/tests/Unit/Service/ObjectServiceStaleSchemaRefTest.php
@@ -211,4 +211,74 @@ class ObjectServiceStaleSchemaRefTest extends TestCase {
 		$this->addToAssertionCount(1);
 
 	}//end testAPendingSchemaRefFromAPreviousCallerIsNotResolvedInThisCallsRegister()
+
+	/**
+	 * The same leak, on the WRITE path — which find() never covered.
+	 *
+	 * find() clears the pending ref itself. saveObject() and patchObject() do
+	 * not go through find(): they call setContextFromParameters(), which was
+	 * left unguarded, so the ref survived into the write path and was consumed
+	 * by the setRegister() of an operation that never mentioned it.
+	 *
+	 * MEASURED on buildiq's E2E 2026-08-22 12:26 UTC, AFTER the single-use fix
+	 * landed at 11:09:
+	 *
+	 *     POST /apps/docudesk/api/templates
+	 *     Failed to create template: Schema slug "application" is not carried by
+	 *     register "docudesk" (id 19) …
+	 *
+	 * Docudesk asked for register 19 / schema 18 (`template`). `application` is
+	 * openbuild's schema, left pending by an unrelated earlier call on the same
+	 * shared ObjectService instance.
+	 *
+	 * Driven through the private helper by reflection rather than through
+	 * saveObject(): the leak lives entirely in context resolution, and the rest
+	 * of a save needs a dozen more collaborators that would obscure what is
+	 * being asserted.
+	 *
+	 * @return void
+	 */
+	public function testAPendingSchemaRefDoesNotLeakIntoAWriteThatNamesBoth(): void {
+		// An earlier, unrelated caller anchored the shared service on a slug.
+		$appSchema = new Schema();
+		$appSchema->setId(28);
+		$appSchema->setSlug('application');
+
+		$this->schemaMapper->method('find')->willReturn($appSchema);
+		$this->service->setSchema('application');
+
+		// Now a write names BOTH sides outright — docudesk's own pair.
+		$register = new Register();
+		$register->setId(19);
+		$register->setSlug('docudesk');
+		$register->setSchemas([18]);
+
+		$template = new Schema();
+		$template->setId(18);
+		$template->setSlug('template');
+
+		$this->registerMapper->method('find')->willReturn($register);
+		$this->schemaMapper->method('findInIds')->willReturnCallback(
+			static function ($ref, array $ids) use ($template) {
+				return ((int) $ref === 18) ? $template : null;
+			}
+		);
+
+		$setContext = new \ReflectionMethod($this->service, 'setContextFromParameters');
+		$setContext->setAccessible(true);
+
+		// BEFORE THE FIX this throws SchemaNotInRegisterException naming
+		// "application" — a schema this write never mentioned.
+		$setContext->invoke($this->service, 19, 18);
+
+		$schema = new \ReflectionProperty($this->service, 'currentSchema');
+		$schema->setAccessible(true);
+
+		$this->assertSame(
+			18,
+			$schema->getValue($this->service)?->getId(),
+			'the write must resolve the schema it named, not the one left pending'
+		);
+
+	}//end testAPendingSchemaRefDoesNotLeakIntoAWriteThatNamesBoth()
 }//end class


### PR DESCRIPTION
`#2792` made the pending schema ref single-use and cleared it in `find()`. `saveObject()` and `patchObject()` do not go through `find()` — they call `setContextFromParameters()`, which was left as it was. So the leak is still live on the **write** path, which is where it is most visible.

## Measured on `development`, after #2792

buildiq E2E, 2026-08-22 **12:26 UTC** (#2792 landed **11:09**):

```
POST /index.php/apps/docudesk/api/templates

Failed to create template: Schema slug "application" is not carried by register
"docudesk" (id 19), which carries 9 schema(s). 1 schema(s) elsewhere on this
instance carry this slug; none of them is served here, because naming a register
makes it a boundary.
```

Docudesk asked for register 19 / schema 18 (`template`) — its seed writes that pair and verifies it on read-back immediately before. `application` is **openbuild's** schema, left pending by an unrelated earlier call on the same shared `ObjectService` instance. `setRegister()` consumed it and re-resolved it inside docudesk's register, which correctly refused a schema that register does not carry.

**The refusal is right. The ref should never have been there.**

## The fix

When a caller supplies **both** register and schema it has named the pair outright, so any pending ref is stale by definition and is dropped before resolution — in the shared helper, rather than as a second copy of `find()`'s guard at the third call site.

- Order-independence is untouched: `setSchema($s)->setRegister($r)` still re-resolves.
- The boundary is exactly as strict: the schema is still resolved *inside* the register named here.

## Verification

| check | result |
|---|---|
| new test, **without** the fix | `SchemaNotInRegisterException … "application" … register "docudesk" (id 19)` — the production message verbatim |
| new test, **with** the fix | `OK (2 tests, 2 assertions)` |
| `tests/Unit/Service/` | **8 errors with and without** this change — pre-existing, measured both directions |
| phpstan / phpcs / phpmd | `[OK] No errors` / 0 errors / clean |

## Fleet impact

Two failing E2E suites trace here: buildiq's template create (above) and integriq's flow halting immediately after its `write` step. Both are on `development` now.

Full diagnosis thread, including two wrong attributions of mine that this replaces, is on #2774. The server log is available on failing E2E runs as the `nextcloud-log-e2e` artifact (ConductionNL/.github#554) — that capture is what made this findable.
