### PR TITLE
fix(scope): a pending schema ref belongs to its own chain, not to the next caller

### DIFF
--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -609,6 +609,39 @@ class ObjectService implements ObjectServiceInterface
     }//end setSchema()
 
     /**
+     * Drop any schema ref still pending from an earlier, unrelated call.
+     *
+     * WHY EVERY OPERATION MUST DO THIS FIRST.
+     *
+     * `setSchema()` leaves a raw ref so a LATER `setRegister()` can re-resolve
+     * it inside the register the caller names. That makes the two setters
+     * order-independent, which is the point — but the ref is instance state on
+     * a service reused for many calls in one process, so it outlives the chain
+     * that created it.
+     *
+     * Making it SINGLE-USE (#2792) bounded the damage to one victim instead of
+     * many; it did not remove the victim. The ref is still handed to the FIRST
+     * `setRegister()` that follows, whoever that turns out to be. Measured on
+     * development 2026-08-22: a leaked `synchronization_contract` ref was
+     * re-resolved inside a flow's own target register — a register that had
+     * never heard of it — and failed `object-write` mid-run.
+     *
+     * A pending ref belongs to the fluent chain that created it. An operation
+     * that supplies its own scope through its arguments is by definition a new
+     * chain, so it starts by discarding whatever was left behind. Callers that
+     * really do chain (`setSchema($s)->setRegister($r)`) are unaffected: no
+     * operation runs between the two setters.
+     *
+     * @return void
+     *
+     * @spec exclude Context hygiene shared by every entry point; no business rule of its own.
+     */
+    private function discardPendingSchemaRef(): void
+    {
+        $this->currentSchemaRef = null;
+    }//end discardPendingSchemaRef()
+
+    /**
      * Get the register entity resolved by the last setRegister() call.
      *
      * Exposes the already-resolved entity so callers (e.g. controllers that
@@ -764,7 +797,7 @@ class ObjectService implements ObjectServiceInterface
         // on the way IN is the same rule applied at the other end: find()
         // supplies its own scope through its arguments and must never inherit
         // a pending one.
-        $this->currentSchemaRef = null;
+        $this->discardPendingSchemaRef();
 
         try {
             $callRegister = null;
@@ -1036,6 +1069,7 @@ class ObjectService implements ObjectServiceInterface
         bool $_rbac=true,
         bool $_multitenancy=true
     ): ObjectEntity {
+        $this->discardPendingSchemaRef();
         // Check if a register is provided and set the current register context.
         if ($register !== null) {
             $this->setRegister(register: $register);
@@ -1092,6 +1126,7 @@ class ObjectService implements ObjectServiceInterface
      */
     public function findAll(array $config=[], bool $_rbac=true, bool $_multitenancy=true): array
     {
+        $this->discardPendingSchemaRef();
         // Prepare configuration and set context.
         $config = $this->prepareFindAllConfig(config: $config);
 
@@ -1191,6 +1226,7 @@ class ObjectService implements ObjectServiceInterface
     public function count(
         array $config=[]
     ): int {
+        $this->discardPendingSchemaRef();
         // Scope the count to the current register/schema context (set via
         // setRegister()/setSchema()) by passing them to the mapper as typed
         // params. Without them MagicMapper::countAll() sums EVERY register/schema
@@ -1341,6 +1377,7 @@ class ObjectService implements ObjectServiceInterface
         bool $failIfExists=false,
         bool $_unowned=false
     ): ObjectEntity {
+        $this->discardPendingSchemaRef();
         // Bound the folder-access revalidation cache to this single save call
         // (not the whole FileService/request lifetime), so a cascade save that
         // moves or trashes a folder mid-request can't be waved through on a
@@ -2162,6 +2199,7 @@ class ObjectService implements ObjectServiceInterface
         ?IUser $currentUser=null,
         bool $permanent=false
     ): bool {
+        $this->discardPendingSchemaRef();
         // Explicit acting user for the permission check; null keeps today's
         // session-resolved behaviour for every existing caller.
         $actingUserId = $currentUser?->getUID();
@@ -3831,6 +3869,7 @@ class ObjectService implements ObjectServiceInterface
         bool $enrich=true,
         bool $_audit=true
     ): array {
+        $this->discardPendingSchemaRef();
 
         // Bound the folder-access revalidation cache to this bulk-save call
         // (see saveObject) so mid-request folder mutations are re-validated.
@@ -4029,6 +4068,7 @@ class ObjectService implements ObjectServiceInterface
      */
     public function deleteObjects(array $uuids=[], bool $_rbac=true, bool $_multitenancy=true): array
     {
+        $this->discardPendingSchemaRef();
         if (empty($uuids) === true) {
             return ['deleted_uuids' => [], 'skipped_uuids' => [], 'cascade_count' => 0];
         }

--- a/tests/Unit/Service/ObjectServiceStaleSchemaRefTest.php
+++ b/tests/Unit/Service/ObjectServiceStaleSchemaRefTest.php
@@ -211,4 +211,63 @@ class ObjectServiceStaleSchemaRefTest extends TestCase {
 		$this->addToAssertionCount(1);
 
 	}//end testAPendingSchemaRefFromAPreviousCallerIsNotResolvedInThisCallsRegister()
+
+	/**
+	 * THE SAME LEAK, VIA findAll() — the shape that broke a flow run.
+	 *
+	 * `find()` was guarded first (#2790) and the ref was made single-use
+	 * (#2792), but single-use only means the leaked ref claims ONE victim
+	 * instead of many: it is still handed to the FIRST `setRegister()` that
+	 * follows, whoever that is.
+	 *
+	 * Measured on development 2026-08-22: an unrelated operation left a
+	 * `synchronization_contract` ref behind, and a flow's `object-write` — which
+	 * names its OWN register and schema — was refused with
+	 * `Schema slug "synchronization_contract" is not carried by register
+	 * "fns-…-reg"`. A register that had never heard of that slug, named in an
+	 * error for a call that never mentioned it.
+	 *
+	 * @return void
+	 */
+	public function testALeakedRefDoesNotRefuseAnOperationThatNamesItsOwnScope(): void {
+		$contract = new Schema();
+		$contract->setId(222);
+		$contract->setSlug('synchronization_contract');
+
+		$this->schemaMapper->method('find')->willReturn($contract);
+		// An unrelated operation anchors on a schema by slug and never sets a
+		// register — exactly what leaves a ref pending.
+		$this->service->setSchema('synchronization_contract');
+
+		// A flow now writes into ITS OWN register, naming both halves.
+		$flowRegister = new Register();
+		$flowRegister->setId(15);
+		$flowRegister->setSlug('fns-run-reg');
+		$flowRegister->setSchemas([9001]);
+
+		$target = new Schema();
+		$target->setId(9001);
+		$target->setSlug('target');
+
+		$this->registerMapper->method('find')->willReturn($flowRegister);
+		$this->schemaMapper->method('findBySlugInIds')->willReturnCallback(
+			static fn (string $slug, array $ids) => ($slug === 'target') ? $target : null
+		);
+		$this->schemaMapper->method('findInIds')->willReturnCallback(
+			static fn ($ref, array $ids) => ($ref === 'target' || $ref === 9001) ? $target : null
+		);
+
+		// BEFORE THIS FIX: SchemaNotInRegisterException naming
+		// "synchronization_contract" inside "fns-run-reg". findAll() is the
+		// lighter of the two paths and is the one openconnector's contract
+		// lookup actually takes (SynchronizationService passes register+schema
+		// inside `filters`, which prepareFindAllConfig turns into
+		// setRegister()->setSchema()).
+		$this->service->findAll(
+			config: ['filters' => ['register' => 'fns-run-reg', 'schema' => 'target']]
+		);
+
+		$this->addToAssertionCount(1);
+
+	}//end testALeakedRefDoesNotRefuseAnOperationThatNamesItsOwnScope()
 }//end class


### PR DESCRIPTION
Fixes the deterministic red e2e on `integriq` development, and closes the third pass at one mechanism. Written up in full as #2801.

## Single-use bounded the damage; it did not remove it

#2792 made the pending schema ref single-use. Its own comment names the failure mode exactly:

> *"a ref left behind by an operation that set a schema and never set a register would be re-resolved against the NEXT caller's register and refuse it."*

Consuming it once means the leak claims **one** victim instead of many. There is still a victim, and it is whoever calls `setRegister()` next.

## Measured, not inferred

On development today that victim was a flow's `object-write`, which names its **own** register and schema and had never heard of the leaked slug:

```
Schema slug "synchronization_contract" is not carried by register
"fns-mt4du8ca-62fj-reg" (id 15), which carries 2 schema(s)
```

`fns-…-reg` is a register the e2e creates for itself. The step failed and took the pipeline with it — `synced-id`, `commit`, `sweep` and `end` never ran.

Bisected to #2774 by job timestamps: the same spec passed **07:48–08:07 UTC** and failed **08:46–09:05 UTC**, and #2774 is the only behavioural change in that window. (Not #2790 — that merged at 10:57, two hours after the first failure.)

## The rule

**A pending ref belongs to the fluent chain that created it.** An operation that supplies its own scope through its *arguments* is by definition a new chain, so it starts by discarding whatever was left behind.

`find()` already did this (#2790). `discardPendingSchemaRef()` makes it the rule at every entry point that consumes context: `findSilent`, `findAll`, `count`, `saveObject`, `saveObjects`, `deleteObject`, `deleteObjects`.

## What is deliberately NOT changed

- **Genuine chains.** `setSchema($s)->setRegister($r)` still scopes `$s` inside `$r` — no operation runs between the two setters, so nothing is discarded.
- **The register boundary.** A caller naming a register still cannot be served a schema from outside it; the scoping that stopped `TimeEntry` resolving into the wrong app is untouched. What changes is only *whose* ref the boundary judges.

## Verification

- the test reproduces the CI message exactly, and **fails with the guard disabled** — verified in both directions rather than assumed
- `tests/Unit/Service/`: **10675 tests / 7 errors** against a development baseline of **10674 / 7** — one test added, no new failures
- phpcs, phpmd (with baseline), psalm: clean

## Worth one person's attention

This is the **third** pass at the same mechanism — #2790, #2792, and this. Each was correct about what it saw; none of the three had the whole picture. #2801 also records two further symptoms from the same scoping work that are *not* fixed here, including `GET /api/objects/{register}/…` answering `Register not found` by slug **and** id while `GET /api/registers/65` resolves the same register fine.
