### PR TITLE
feat(command): openregister:migrate-application — repair app-id renames

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -205,6 +205,9 @@ Vrij en open source onder de EUPL-licentie.
 		<!-- Annotation-related commands have light DI graphs (mappers + evaluator). -->
 		<command>OCA\OpenRegister\Command\RematerialiseCalculationsCommand</command>
 		<command>OCA\OpenRegister\Command\BackfillSystemOwnerCommand</command>
+		<!-- App-rename repair: re-points registers and schemas at a new owning
+		     app id. Only a DB connection, so the DI graph stays light. -->
+		<command>OCA\OpenRegister\Command\MigrateSchemaApplicationCommand</command>
 		<command>OCA\OpenRegister\Command\RechainAuditTrailCommand</command>
 		<!-- Read-only report: which RBAC groups this instance declares, and whether
 		     anyone belongs to them. Provisioning guarantees a declared group EXISTS;

--- a/lib/Command/MigrateSchemaApplicationCommand.php
+++ b/lib/Command/MigrateSchemaApplicationCommand.php
@@ -46,6 +46,8 @@ class MigrateSchemaApplicationCommand extends Command {
 	 * Constructor.
 	 *
 	 * @param SchemaApplicationMigrator $migrator The migration service.
+	 *
+	 * @spec openspec/specs/data-import-export/spec.md
 	 */
 	public function __construct(private readonly SchemaApplicationMigrator $migrator) {
 		parent::__construct();
@@ -57,6 +59,8 @@ class MigrateSchemaApplicationCommand extends Command {
 	 * Configure the command.
 	 *
 	 * @return void
+	 *
+	 * @spec openspec/specs/data-import-export/spec.md
 	 */
 	protected function configure(): void {
 		$this->setName(name: 'openregister:migrate-application')
@@ -75,6 +79,8 @@ class MigrateSchemaApplicationCommand extends Command {
 	 * @param OutputInterface $output The console output.
 	 *
 	 * @return int 0 on success, 1 on refusal.
+	 *
+	 * @spec openspec/specs/data-import-export/spec.md
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$from = (string)$input->getArgument('from');
@@ -144,6 +150,8 @@ class MigrateSchemaApplicationCommand extends Command {
 	 * @param int             $registers Registers owned by `from`.
 	 *
 	 * @return int 0 when the real run would proceed, 1 when it would refuse.
+	 *
+	 * @spec openspec/specs/data-import-export/spec.md
 	 */
 	private function dryRun(OutputInterface $output, string $from, string $to, int $schemas, int $registers): int {
 		$collisions = $this->migrator->collidingSlugs(from: $from, to: $to);
@@ -175,6 +183,8 @@ class MigrateSchemaApplicationCommand extends Command {
 	 * @param bool            $wouldRefuse True when reporting a dry run.
 	 *
 	 * @return void
+	 *
+	 * @spec openspec/specs/data-import-export/spec.md
 	 */
 	private function reportRefusal(OutputInterface $output, array $collisions, bool $wouldRefuse): void {
 		$lead = 'Refusing:';

--- a/lib/Command/MigrateSchemaApplicationCommand.php
+++ b/lib/Command/MigrateSchemaApplicationCommand.php
@@ -1,0 +1,287 @@
+<?php
+
+/**
+ * OpenRegister migrate-application command
+ *
+ * Re-points registers and schemas from one owning application id to another,
+ * for use when a fleet app's `<id>` changes (procest -> dossiq, nldesign ->
+ * thematiq, and the rest of the 2026 rename programme).
+ *
+ * WHY THIS HAS TO EXIST. An app declares its register through an OAS file whose
+ * `x-openregister.app` names the owning application. On import, ImportHandler
+ * resolves the two halves DIFFERENTLY:
+ *
+ *   - a register is matched by SLUG alone (`registerMapper->find($data['slug'])`)
+ *     and then has `setApplication($appId)` applied, so it follows a rename on
+ *     its own;
+ *   - a schema is matched by `findByApplicationAndSlug($slug, $appId)`, i.e. by
+ *     the PAIR.
+ *
+ * So when the app id changes, every schema lookup misses. The import does not
+ * fail and does not warn: it takes the "not found, will create new one" branch
+ * and builds a second, empty set of schemas under the new application id, while
+ * the originals — and every object stored against them — stay behind under the
+ * old one. The UI then renders empty collections and the API 404s for
+ * `<oldapp>-<schema>`, which reads as missing data rather than as a rename that
+ * was never finished.
+ *
+ * Run this BEFORE the first import under the new id, or after one to repair.
+ *
+ * @category Command
+ * @package  OCA\OpenRegister\Command
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Command;
+
+use OCP\IDBConnection;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Move registers and schemas from one owning application id to another.
+ */
+class MigrateSchemaApplicationCommand extends Command {
+	/**
+	 * Constructor.
+	 *
+	 * @param IDBConnection $db The database connection.
+	 */
+	public function __construct(private readonly IDBConnection $db) {
+		parent::__construct();
+
+	}//end __construct()
+
+
+	/**
+	 * Configure the command.
+	 *
+	 * @return void
+	 */
+	protected function configure(): void {
+		$this->setName(name: 'openregister:migrate-application')
+			->setDescription('Re-point registers and schemas from one owning app id to another (app rename)')
+			->addArgument('from', InputArgument::REQUIRED, 'The current application id, e.g. procest')
+			->addArgument('to', InputArgument::REQUIRED, 'The new application id, e.g. dossiq')
+			->addOption('dry-run', null, InputOption::VALUE_NONE, 'Report what would change without writing');
+
+	}//end configure()
+
+
+	/**
+	 * Execute the command.
+	 *
+	 * @param InputInterface  $input  The console input.
+	 * @param OutputInterface $output The console output.
+	 *
+	 * @return int 0 on success, 1 on refusal.
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$from  = (string)$input->getArgument('from');
+		$to    = (string)$input->getArgument('to');
+		$dry   = (bool)$input->getOption('dry-run');
+
+		if ($from === '' || $to === '') {
+			$output->writeln('<error>Both `from` and `to` must be non-empty.</error>');
+			return 1;
+		}
+
+		if ($from === $to) {
+			$output->writeln('<error>`from` and `to` are the same id; nothing to do.</error>');
+			return 1;
+		}
+
+		$schemas   = $this->countFor(table: 'openregister_schemas', application: $from);
+		$registers = $this->countFor(table: 'openregister_registers', application: $from);
+
+		$output->writeln(sprintf('Application "%s" currently owns %d schema(s) and %d register(s).', $from, $schemas, $registers));
+
+		if (($schemas + $registers) === 0) {
+			// Nothing under the old id is the expected state on a re-run, and
+			// also the state after someone has already imported under the new
+			// id. Those are not the same thing, so say which one this is
+			// rather than reporting a bare success.
+			$already = $this->countFor(table: 'openregister_schemas', application: $to);
+			$output->writeln(sprintf('<info>Nothing owned by "%s". "%s" owns %d schema(s).</info>', $from, $to, $already));
+			return 0;
+		}
+
+		// A slug already present under the target id means an import has run
+		// under the new name and forked the schema. Moving the original on top
+		// of it would leave two rows with the same (slug, application) and no
+		// way to tell which one the objects belong to. Refuse and name them.
+		$collisions = $this->collidingSlugs(from: $from, to: $to);
+		if (empty($collisions) === false) {
+			$output->writeln('<error>Refusing: these slugs already exist under the target application id.</error>');
+			foreach ($collisions as $slug) {
+				$output->writeln('  - ' . $slug);
+			}
+
+			$output->writeln('An import has already forked these schemas. Resolve the duplicates first (see openregister:schemas:dedup).');
+			return 1;
+		}
+
+		if ($dry === true) {
+			$output->writeln(
+				sprintf(
+					'<comment>Dry run: would move %d schema(s) and %d register(s) from "%s" to "%s".</comment>',
+					$schemas,
+					$registers,
+					$from,
+					$to
+				)
+			);
+			return 0;
+		}
+
+		$movedSchemas   = $this->moveApplication(table: 'openregister_schemas', from: $from, to: $to);
+		$movedRegisters = $this->moveApplication(table: 'openregister_registers', from: $from, to: $to);
+
+		$output->writeln(sprintf('<info>Moved %d schema(s) and %d register(s) from "%s" to "%s".</info>', $movedSchemas, $movedRegisters, $from, $to));
+		$output->writeln('Objects are unaffected: they reference their schema by id, which does not change here.');
+
+		return 0;
+
+	}//end execute()
+
+
+	/**
+	 * Count rows owned by an application id.
+	 *
+	 * @param string $table       The table to count in.
+	 * @param string $application The owning application id.
+	 *
+	 * @return int The row count.
+	 */
+	private function countFor(string $table, string $application): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select($qb->func()->count('*', 'c'))
+			->from($table)
+			->where($qb->expr()->eq('application', $qb->createNamedParameter($application)));
+
+		$result = $qb->executeQuery();
+		$row    = $result->fetch();
+		$result->closeCursor();
+
+		return (int)($row['c'] ?? 0);
+
+	}//end countFor()
+
+
+	/**
+	 * Find slugs that exist under BOTH application ids.
+	 *
+	 * @param string $from The current application id.
+	 * @param string $to   The new application id.
+	 *
+	 * @return string[] The colliding slugs.
+	 */
+	private function collidingSlugs(string $from, string $to): array {
+		return self::planCollisions(
+			fromSlugs: $this->slugsFor(application: $from),
+			toSlugs: $this->slugsFor(application: $to)
+		);
+
+	}//end collidingSlugs()
+
+
+	/**
+	 * Which slugs appear under BOTH application ids.
+	 *
+	 * Pure and static so the refusal rule can be tested without a database —
+	 * it is the part that must not be wrong. Matching is case-insensitive
+	 * because that is how findByApplicationAndSlug() looks schemas up
+	 * (`lower(slug)`); comparing case-sensitively here would report "no
+	 * collision" for a pair the importer would nevertheless treat as the same
+	 * schema.
+	 *
+	 * @param string[] $fromSlugs Slugs owned by the current application id.
+	 * @param string[] $toSlugs   Slugs owned by the new application id.
+	 *
+	 * @return string[] The colliding slugs, lower-cased and unique.
+	 */
+	public static function planCollisions(array $fromSlugs, array $toSlugs): array {
+		$target = [];
+		foreach ($toSlugs as $slug) {
+			$target[strtolower((string)$slug)] = true;
+		}
+
+		if (empty($target) === true) {
+			return [];
+		}
+
+		$hits = [];
+		foreach ($fromSlugs as $slug) {
+			$lower = strtolower((string)$slug);
+			if (isset($target[$lower]) === true) {
+				$hits[$lower] = true;
+			}
+		}
+
+		return array_keys($hits);
+
+	}//end planCollisions()
+
+
+	/**
+	 * Read every schema slug owned by an application id.
+	 *
+	 * @param string $application The owning application id.
+	 *
+	 * @return string[] The slugs.
+	 */
+	private function slugsFor(string $application): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('slug')
+			->from('openregister_schemas')
+			->where($qb->expr()->eq('application', $qb->createNamedParameter($application)));
+
+		$result = $qb->executeQuery();
+		$slugs  = [];
+		while (($row = $result->fetch()) !== false) {
+			$slugs[] = (string)$row['slug'];
+		}
+
+		$result->closeCursor();
+
+		return $slugs;
+
+	}//end slugsFor()
+
+
+	/**
+	 * Re-point every row owned by `from` at `to`.
+	 *
+	 * @param string $table The table to update.
+	 * @param string $from  The current application id.
+	 * @param string $to    The new application id.
+	 *
+	 * @return int The number of rows updated.
+	 */
+	private function moveApplication(string $table, string $from, string $to): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->update($table)
+			->set('application', $qb->createNamedParameter($to))
+			->where($qb->expr()->eq('application', $qb->createNamedParameter($from)));
+
+		return (int)$qb->executeStatement();
+
+	}//end moveApplication()
+
+
+}//end class

--- a/lib/Command/MigrateSchemaApplicationCommand.php
+++ b/lib/Command/MigrateSchemaApplicationCommand.php
@@ -3,29 +3,14 @@
 /**
  * OpenRegister migrate-application command
  *
- * Re-points registers and schemas from one owning application id to another,
- * for use when a fleet app's `<id>` changes (procest -> dossiq, nldesign ->
- * thematiq, and the rest of the 2026 rename programme).
+ * Console entry point for SchemaApplicationMigrator: re-points registers and
+ * schemas at a new owning application id when a fleet app's `<id>` changes
+ * (procest -> dossiq, nldesign -> thematiq, and the rest of the 2026 rename
+ * programme).
  *
- * WHY THIS HAS TO EXIST. An app declares its register through an OAS file whose
- * `x-openregister.app` names the owning application. On import, ImportHandler
- * resolves the two halves DIFFERENTLY:
- *
- *   - a register is matched by SLUG alone (`registerMapper->find($data['slug'])`)
- *     and then has `setApplication($appId)` applied, so it follows a rename on
- *     its own;
- *   - a schema is matched by `findByApplicationAndSlug($slug, $appId)`, i.e. by
- *     the PAIR.
- *
- * So when the app id changes, every schema lookup misses. The import does not
- * fail and does not warn: it takes the "not found, will create new one" branch
- * and builds a second, empty set of schemas under the new application id, while
- * the originals — and every object stored against them — stay behind under the
- * old one. The UI then renders empty collections and the API 404s for
- * `<oldapp>-<schema>`, which reads as missing data rather than as a rename that
- * was never finished.
- *
- * Run this BEFORE the first import under the new id, or after one to repair.
+ * The rule itself lives in the service so that this command and an app's own
+ * repair step run the SAME code — see SchemaApplicationMigrator for why the
+ * migration is needed at all.
  *
  * @category Command
  * @package  OCA\OpenRegister\Command
@@ -46,7 +31,7 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Command;
 
-use OCP\IDBConnection;
+use OCA\OpenRegister\Service\SchemaApplicationMigrator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -60,9 +45,9 @@ class MigrateSchemaApplicationCommand extends Command {
 	/**
 	 * Constructor.
 	 *
-	 * @param IDBConnection $db The database connection.
+	 * @param SchemaApplicationMigrator $migrator The migration service.
 	 */
-	public function __construct(private readonly IDBConnection $db) {
+	public function __construct(private readonly SchemaApplicationMigrator $migrator) {
 		parent::__construct();
 
 	}//end __construct()
@@ -92,51 +77,43 @@ class MigrateSchemaApplicationCommand extends Command {
 	 * @return int 0 on success, 1 on refusal.
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		$from  = (string)$input->getArgument('from');
-		$to    = (string)$input->getArgument('to');
-		$dry   = (bool)$input->getOption('dry-run');
+		$from = (string)$input->getArgument('from');
+		$to   = (string)$input->getArgument('to');
 
-		if ($from === '' || $to === '') {
-			$output->writeln('<error>Both `from` and `to` must be non-empty.</error>');
+		if ($from === '' || $to === '' || $from === $to) {
+			$output->writeln('<error>`from` and `to` must both be given and must differ.</error>');
 			return 1;
 		}
 
-		if ($from === $to) {
-			$output->writeln('<error>`from` and `to` are the same id; nothing to do.</error>');
-			return 1;
-		}
+		$schemas   = $this->migrator->countFor(table: 'openregister_schemas', application: $from);
+		$registers = $this->migrator->countFor(table: 'openregister_registers', application: $from);
 
-		$schemas   = $this->countFor(table: 'openregister_schemas', application: $from);
-		$registers = $this->countFor(table: 'openregister_registers', application: $from);
-
-		$output->writeln(sprintf('Application "%s" currently owns %d schema(s) and %d register(s).', $from, $schemas, $registers));
+		$output->writeln(
+			sprintf('Application "%s" currently owns %d schema(s) and %d register(s).', $from, $schemas, $registers)
+		);
 
 		if (($schemas + $registers) === 0) {
 			// Nothing under the old id is the expected state on a re-run, and
-			// also the state after someone has already imported under the new
-			// id. Those are not the same thing, so say which one this is
-			// rather than reporting a bare success.
-			$already = $this->countFor(table: 'openregister_schemas', application: $to);
-			$output->writeln(sprintf('<info>Nothing owned by "%s". "%s" owns %d schema(s).</info>', $from, $to, $already));
+			// also the state when the rename was never applied here at all.
+			// Those are different answers to the same number, so say which.
+			$already = $this->migrator->countFor(table: 'openregister_schemas', application: $to);
+			$output->writeln(
+				sprintf('<info>Nothing owned by "%s". "%s" owns %d schema(s).</info>', $from, $to, $already)
+			);
 			return 0;
 		}
 
-		// A slug already present under the target id means an import has run
-		// under the new name and forked the schema. Moving the original on top
-		// of it would leave two rows with the same (slug, application) and no
-		// way to tell which one the objects belong to. Refuse and name them.
-		$collisions = $this->collidingSlugs(from: $from, to: $to);
-		if (empty($collisions) === false) {
-			$output->writeln('<error>Refusing: these slugs already exist under the target application id.</error>');
-			foreach ($collisions as $slug) {
-				$output->writeln('  - ' . $slug);
+		if ((bool)$input->getOption('dry-run') === true) {
+			$collisions = $this->migrator->collidingSlugs(from: $from, to: $to);
+			if (empty($collisions) === false) {
+				$output->writeln('<error>Would refuse: these slugs already exist under the target application id.</error>');
+				foreach ($collisions as $slug) {
+					$output->writeln('  - ' . $slug);
+				}
+
+				return 1;
 			}
 
-			$output->writeln('An import has already forked these schemas. Resolve the duplicates first (see openregister:schemas:dedup).');
-			return 1;
-		}
-
-		if ($dry === true) {
 			$output->writeln(
 				sprintf(
 					'<comment>Dry run: would move %d schema(s) and %d register(s) from "%s" to "%s".</comment>',
@@ -149,139 +126,32 @@ class MigrateSchemaApplicationCommand extends Command {
 			return 0;
 		}
 
-		$movedSchemas   = $this->moveApplication(table: 'openregister_schemas', from: $from, to: $to);
-		$movedRegisters = $this->moveApplication(table: 'openregister_registers', from: $from, to: $to);
+		$result = $this->migrator->migrate(from: $from, to: $to);
 
-		$output->writeln(sprintf('<info>Moved %d schema(s) and %d register(s) from "%s" to "%s".</info>', $movedSchemas, $movedRegisters, $from, $to));
+		if ($result['ok'] === false) {
+			$output->writeln('<error>Refusing: these slugs already exist under the target application id.</error>');
+			foreach ($result['collisions'] as $slug) {
+				$output->writeln('  - ' . $slug);
+			}
+
+			$output->writeln('An import has already forked these schemas. Resolve the duplicates first (see openregister:schemas:dedup).');
+			return 1;
+		}
+
+		$output->writeln(
+			sprintf(
+				'<info>Moved %d schema(s) and %d register(s) from "%s" to "%s".</info>',
+				$result['schemas'],
+				$result['registers'],
+				$from,
+				$to
+			)
+		);
 		$output->writeln('Objects are unaffected: they reference their schema by id, which does not change here.');
 
 		return 0;
 
 	}//end execute()
-
-
-	/**
-	 * Count rows owned by an application id.
-	 *
-	 * @param string $table       The table to count in.
-	 * @param string $application The owning application id.
-	 *
-	 * @return int The row count.
-	 */
-	private function countFor(string $table, string $application): int {
-		$qb = $this->db->getQueryBuilder();
-		$qb->select($qb->func()->count('*', 'c'))
-			->from($table)
-			->where($qb->expr()->eq('application', $qb->createNamedParameter($application)));
-
-		$result = $qb->executeQuery();
-		$row    = $result->fetch();
-		$result->closeCursor();
-
-		return (int)($row['c'] ?? 0);
-
-	}//end countFor()
-
-
-	/**
-	 * Find slugs that exist under BOTH application ids.
-	 *
-	 * @param string $from The current application id.
-	 * @param string $to   The new application id.
-	 *
-	 * @return string[] The colliding slugs.
-	 */
-	private function collidingSlugs(string $from, string $to): array {
-		return self::planCollisions(
-			fromSlugs: $this->slugsFor(application: $from),
-			toSlugs: $this->slugsFor(application: $to)
-		);
-
-	}//end collidingSlugs()
-
-
-	/**
-	 * Which slugs appear under BOTH application ids.
-	 *
-	 * Pure and static so the refusal rule can be tested without a database —
-	 * it is the part that must not be wrong. Matching is case-insensitive
-	 * because that is how findByApplicationAndSlug() looks schemas up
-	 * (`lower(slug)`); comparing case-sensitively here would report "no
-	 * collision" for a pair the importer would nevertheless treat as the same
-	 * schema.
-	 *
-	 * @param string[] $fromSlugs Slugs owned by the current application id.
-	 * @param string[] $toSlugs   Slugs owned by the new application id.
-	 *
-	 * @return string[] The colliding slugs, lower-cased and unique.
-	 */
-	public static function planCollisions(array $fromSlugs, array $toSlugs): array {
-		$target = [];
-		foreach ($toSlugs as $slug) {
-			$target[strtolower((string)$slug)] = true;
-		}
-
-		if (empty($target) === true) {
-			return [];
-		}
-
-		$hits = [];
-		foreach ($fromSlugs as $slug) {
-			$lower = strtolower((string)$slug);
-			if (isset($target[$lower]) === true) {
-				$hits[$lower] = true;
-			}
-		}
-
-		return array_keys($hits);
-
-	}//end planCollisions()
-
-
-	/**
-	 * Read every schema slug owned by an application id.
-	 *
-	 * @param string $application The owning application id.
-	 *
-	 * @return string[] The slugs.
-	 */
-	private function slugsFor(string $application): array {
-		$qb = $this->db->getQueryBuilder();
-		$qb->select('slug')
-			->from('openregister_schemas')
-			->where($qb->expr()->eq('application', $qb->createNamedParameter($application)));
-
-		$result = $qb->executeQuery();
-		$slugs  = [];
-		while (($row = $result->fetch()) !== false) {
-			$slugs[] = (string)$row['slug'];
-		}
-
-		$result->closeCursor();
-
-		return $slugs;
-
-	}//end slugsFor()
-
-
-	/**
-	 * Re-point every row owned by `from` at `to`.
-	 *
-	 * @param string $table The table to update.
-	 * @param string $from  The current application id.
-	 * @param string $to    The new application id.
-	 *
-	 * @return int The number of rows updated.
-	 */
-	private function moveApplication(string $table, string $from, string $to): int {
-		$qb = $this->db->getQueryBuilder();
-		$qb->update($table)
-			->set('application', $qb->createNamedParameter($to))
-			->where($qb->expr()->eq('application', $qb->createNamedParameter($from)));
-
-		return (int)$qb->executeStatement();
-
-	}//end moveApplication()
 
 
 }//end class

--- a/lib/Command/MigrateSchemaApplicationCommand.php
+++ b/lib/Command/MigrateSchemaApplicationCommand.php
@@ -104,37 +104,13 @@ class MigrateSchemaApplicationCommand extends Command {
 		}
 
 		if ((bool)$input->getOption('dry-run') === true) {
-			$collisions = $this->migrator->collidingSlugs(from: $from, to: $to);
-			if (empty($collisions) === false) {
-				$output->writeln('<error>Would refuse: these slugs already exist under the target application id.</error>');
-				foreach ($collisions as $slug) {
-					$output->writeln('  - ' . $slug);
-				}
-
-				return 1;
-			}
-
-			$output->writeln(
-				sprintf(
-					'<comment>Dry run: would move %d schema(s) and %d register(s) from "%s" to "%s".</comment>',
-					$schemas,
-					$registers,
-					$from,
-					$to
-				)
-			);
-			return 0;
+			return $this->dryRun(output: $output, from: $from, to: $to, schemas: $schemas, registers: $registers);
 		}
 
 		$result = $this->migrator->migrate(from: $from, to: $to);
 
 		if ($result['ok'] === false) {
-			$output->writeln('<error>Refusing: these slugs already exist under the target application id.</error>');
-			foreach ($result['collisions'] as $slug) {
-				$output->writeln('  - ' . $slug);
-			}
-
-			$output->writeln('An import has already forked these schemas. Resolve the duplicates first (see openregister:schemas:dedup).');
+			$this->reportRefusal(output: $output, collisions: $result['collisions'], wouldRefuse: false);
 			return 1;
 		}
 
@@ -152,6 +128,70 @@ class MigrateSchemaApplicationCommand extends Command {
 		return 0;
 
 	}//end execute()
+
+
+	/**
+	 * Report what a real run would do, including whether it would refuse.
+	 *
+	 * The collision check runs here too, deliberately. A dry run that reports
+	 * what it "would move" without checking whether the real run would refuse
+	 * is worse than no dry run, because it reads as a green light.
+	 *
+	 * @param OutputInterface $output    The console output.
+	 * @param string          $from      The current application id.
+	 * @param string          $to        The new application id.
+	 * @param int             $schemas   Schemas owned by `from`.
+	 * @param int             $registers Registers owned by `from`.
+	 *
+	 * @return int 0 when the real run would proceed, 1 when it would refuse.
+	 */
+	private function dryRun(OutputInterface $output, string $from, string $to, int $schemas, int $registers): int {
+		$collisions = $this->migrator->collidingSlugs(from: $from, to: $to);
+		if (empty($collisions) === false) {
+			$this->reportRefusal(output: $output, collisions: $collisions, wouldRefuse: true);
+			return 1;
+		}
+
+		$output->writeln(
+			sprintf(
+				'<comment>Dry run: would move %d schema(s) and %d register(s) from "%s" to "%s".</comment>',
+				$schemas,
+				$registers,
+				$from,
+				$to
+			)
+		);
+
+		return 0;
+
+	}//end dryRun()
+
+
+	/**
+	 * Print the refusal and the slugs that caused it.
+	 *
+	 * @param OutputInterface $output      The console output.
+	 * @param string[]        $collisions  The colliding slugs.
+	 * @param bool            $wouldRefuse True when reporting a dry run.
+	 *
+	 * @return void
+	 */
+	private function reportRefusal(OutputInterface $output, array $collisions, bool $wouldRefuse): void {
+		$lead = 'Refusing:';
+		if ($wouldRefuse === true) {
+			$lead = 'Would refuse:';
+		}
+
+		$output->writeln('<error>' . $lead . ' these slugs already exist under the target application id.</error>');
+		foreach ($collisions as $slug) {
+			$output->writeln('  - ' . $slug);
+		}
+
+		$output->writeln(
+			'An import has already forked these schemas. Resolve the duplicates first (see openregister:schemas:dedup).'
+		);
+
+	}//end reportRefusal()
 
 
 }//end class

--- a/lib/Service/SchemaApplicationMigrator.php
+++ b/lib/Service/SchemaApplicationMigrator.php
@@ -1,0 +1,226 @@
+<?php
+
+/**
+ * OpenRegister schema-application migrator
+ *
+ * Re-points registers and schemas from one owning application id to another
+ * when a fleet app's `<id>` changes.
+ *
+ * WHY THIS EXISTS. ImportHandler resolves an app's register and its schemas by
+ * different keys: a register is matched by SLUG alone and then has
+ * setApplication() applied, so it follows a rename by itself, while a schema is
+ * matched by findByApplicationAndSlug() — the PAIR, on lower(slug). When the
+ * app id changes, every schema lookup therefore misses, and the import neither
+ * fails nor warns: it takes the "not found, will create new one" branch and
+ * builds a second, EMPTY set of schemas under the new id while the originals
+ * and their objects stay behind under the old one.
+ *
+ * This is a service rather than logic inside the command so that the console
+ * entry point and an app's own repair step run the SAME code. Two copies of a
+ * migration rule drift, and the second one to drift is the one nobody runs
+ * interactively.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+use OCP\IDBConnection;
+
+/**
+ * Move registers and schemas from one owning application id to another.
+ */
+class SchemaApplicationMigrator {
+	/**
+	 * Constructor.
+	 *
+	 * @param IDBConnection $db The database connection.
+	 */
+	public function __construct(private readonly IDBConnection $db) {
+
+	}//end __construct()
+
+
+	/**
+	 * Which slugs appear under BOTH application ids.
+	 *
+	 * Pure and static so the refusal rule can be tested without a database —
+	 * it is the part that must not be wrong. Matching is case-insensitive
+	 * because that is how findByApplicationAndSlug() looks schemas up
+	 * (`lower(slug)`); comparing case-sensitively here would report "no
+	 * collision" for a pair the importer nevertheless treats as one schema,
+	 * skipping the refusal precisely when it was needed.
+	 *
+	 * @param string[] $fromSlugs Slugs owned by the current application id.
+	 * @param string[] $toSlugs   Slugs owned by the new application id.
+	 *
+	 * @return string[] The colliding slugs, lower-cased and unique.
+	 */
+	public static function planCollisions(array $fromSlugs, array $toSlugs): array {
+		$target = [];
+		foreach ($toSlugs as $slug) {
+			$target[strtolower((string)$slug)] = true;
+		}
+
+		if (empty($target) === true) {
+			return [];
+		}
+
+		$hits = [];
+		foreach ($fromSlugs as $slug) {
+			$lower = strtolower((string)$slug);
+			if (isset($target[$lower]) === true) {
+				$hits[$lower] = true;
+			}
+		}
+
+		return array_keys($hits);
+
+	}//end planCollisions()
+
+
+	/**
+	 * Count rows owned by an application id.
+	 *
+	 * @param string $table       The table to count in.
+	 * @param string $application The owning application id.
+	 *
+	 * @return int The row count.
+	 */
+	public function countFor(string $table, string $application): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select($qb->func()->count('*', 'c'))
+			->from($table)
+			->where($qb->expr()->eq('application', $qb->createNamedParameter($application)));
+
+		$result = $qb->executeQuery();
+		$row    = $result->fetch();
+		$result->closeCursor();
+
+		return (int)($row['c'] ?? 0);
+
+	}//end countFor()
+
+
+	/**
+	 * Read every schema slug owned by an application id.
+	 *
+	 * @param string $application The owning application id.
+	 *
+	 * @return string[] The slugs.
+	 */
+	public function slugsFor(string $application): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('slug')
+			->from('openregister_schemas')
+			->where($qb->expr()->eq('application', $qb->createNamedParameter($application)));
+
+		$result = $qb->executeQuery();
+		$slugs  = [];
+		while (($row = $result->fetch()) !== false) {
+			$slugs[] = (string)$row['slug'];
+		}
+
+		$result->closeCursor();
+
+		return $slugs;
+
+	}//end slugsFor()
+
+
+	/**
+	 * Find slugs that exist under BOTH application ids.
+	 *
+	 * @param string $from The current application id.
+	 * @param string $to   The new application id.
+	 *
+	 * @return string[] The colliding slugs.
+	 */
+	public function collidingSlugs(string $from, string $to): array {
+		return self::planCollisions(
+			fromSlugs: $this->slugsFor(application: $from),
+			toSlugs: $this->slugsFor(application: $to)
+		);
+
+	}//end collidingSlugs()
+
+
+	/**
+	 * Re-point every row owned by `from` at `to`.
+	 *
+	 * @param string $table The table to update.
+	 * @param string $from  The current application id.
+	 * @param string $to    The new application id.
+	 *
+	 * @return int The number of rows updated.
+	 */
+	public function moveApplication(string $table, string $from, string $to): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->update($table)
+			->set('application', $qb->createNamedParameter($to))
+			->where($qb->expr()->eq('application', $qb->createNamedParameter($from)));
+
+		return (int)$qb->executeStatement();
+
+	}//end moveApplication()
+
+
+	/**
+	 * Perform the migration, refusing when it would create duplicates.
+	 *
+	 * Idempotent: a second run finds nothing under the old id and reports
+	 * `moved` counts of zero rather than failing.
+	 *
+	 * @param string $from The current application id.
+	 * @param string $to   The new application id.
+	 *
+	 * @return array{ok: bool, reason: string, collisions: string[], schemas: int, registers: int}
+	 *     The outcome. `ok` false with a non-empty `collisions` means an import
+	 *     already forked those schemas and the caller must resolve them first.
+	 */
+	public function migrate(string $from, string $to): array {
+		$result = [
+			'ok'         => false,
+			'reason'     => '',
+			'collisions' => [],
+			'schemas'    => 0,
+			'registers'  => 0,
+		];
+
+		if ($from === '' || $to === '' || $from === $to) {
+			$result['reason'] = 'invalid-arguments';
+			return $result;
+		}
+
+		$collisions = $this->collidingSlugs(from: $from, to: $to);
+		if (empty($collisions) === false) {
+			$result['reason']     = 'collisions';
+			$result['collisions'] = $collisions;
+			return $result;
+		}
+
+		$result['schemas']   = $this->moveApplication(table: 'openregister_schemas', from: $from, to: $to);
+		$result['registers'] = $this->moveApplication(table: 'openregister_registers', from: $from, to: $to);
+		$result['ok']        = true;
+		$result['reason']    = 'migrated';
+
+		return $result;
+
+	}//end migrate()
+
+
+}//end class

--- a/lib/Service/SchemaApplicationMigrator.php
+++ b/lib/Service/SchemaApplicationMigrator.php
@@ -49,6 +49,8 @@ class SchemaApplicationMigrator {
 	 * Constructor.
 	 *
 	 * @param IDBConnection $db The database connection.
+	 *
+	 * @spec openspec/specs/data-import-export/spec.md
 	 */
 	public function __construct(private readonly IDBConnection $db) {
 
@@ -69,6 +71,8 @@ class SchemaApplicationMigrator {
 	 * @param string[] $toSlugs   Slugs owned by the new application id.
 	 *
 	 * @return string[] The colliding slugs, lower-cased and unique.
+	 *
+	 * @spec openspec/specs/data-import-export/spec.md
 	 */
 	public static function planCollisions(array $fromSlugs, array $toSlugs): array {
 		$target = [];
@@ -100,6 +104,8 @@ class SchemaApplicationMigrator {
 	 * @param string $application The owning application id.
 	 *
 	 * @return int The row count.
+	 *
+	 * @spec openspec/specs/data-import-export/spec.md
 	 */
 	public function countFor(string $table, string $application): int {
 		$qb = $this->db->getQueryBuilder();
@@ -122,6 +128,8 @@ class SchemaApplicationMigrator {
 	 * @param string $application The owning application id.
 	 *
 	 * @return string[] The slugs.
+	 *
+	 * @spec openspec/specs/data-import-export/spec.md
 	 */
 	public function slugsFor(string $application): array {
 		$qb = $this->db->getQueryBuilder();
@@ -149,6 +157,8 @@ class SchemaApplicationMigrator {
 	 * @param string $to   The new application id.
 	 *
 	 * @return string[] The colliding slugs.
+	 *
+	 * @spec openspec/specs/data-import-export/spec.md
 	 */
 	public function collidingSlugs(string $from, string $to): array {
 		return self::planCollisions(
@@ -167,6 +177,8 @@ class SchemaApplicationMigrator {
 	 * @param string $to    The new application id.
 	 *
 	 * @return int The number of rows updated.
+	 *
+	 * @spec openspec/specs/data-import-export/spec.md
 	 */
 	public function moveApplication(string $table, string $from, string $to): int {
 		$qb = $this->db->getQueryBuilder();
@@ -191,6 +203,8 @@ class SchemaApplicationMigrator {
 	 * @return array{ok: bool, reason: string, collisions: string[], schemas: int, registers: int}
 	 *     The outcome. `ok` false with a non-empty `collisions` means an import
 	 *     already forked those schemas and the caller must resolve them first.
+	 *
+	 * @spec openspec/specs/data-import-export/spec.md
 	 */
 	public function migrate(string $from, string $to): array {
 		$result = [

--- a/tests/Unit/Command/MigrateSchemaApplicationCommandTest.php
+++ b/tests/Unit/Command/MigrateSchemaApplicationCommandTest.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * MigrateSchemaApplicationCommand unit tests
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Command
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Command;
+
+use OCA\OpenRegister\Command\MigrateSchemaApplicationCommand;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Locks planCollisions(): the rule that decides whether an app-id migration is
+ * safe to perform or has to be refused.
+ */
+class MigrateSchemaApplicationCommandTest extends TestCase {
+
+	/**
+	 * Nothing under the target id means nothing can collide.
+	 *
+	 * This is the ordinary case — the rename has not been imported yet, which
+	 * is exactly when this command should run.
+	 *
+	 * @return void
+	 */
+	public function testNoTargetSlugsMeansNoCollisions(): void {
+		$this->assertSame(
+			[],
+			MigrateSchemaApplicationCommand::planCollisions(
+				fromSlugs: ['case', 'caseType', 'bezwaar'],
+				toSlugs: []
+			)
+		);
+
+	}//end testNoTargetSlugsMeansNoCollisions()
+
+
+	/**
+	 * Disjoint slugs do not collide.
+	 *
+	 * @return void
+	 */
+	public function testDisjointSlugsDoNotCollide(): void {
+		$this->assertSame(
+			[],
+			MigrateSchemaApplicationCommand::planCollisions(
+				fromSlugs: ['case', 'caseType'],
+				toSlugs: ['invoice', 'contract']
+			)
+		);
+
+	}//end testDisjointSlugsDoNotCollide()
+
+
+	/**
+	 * A slug present under both ids is reported.
+	 *
+	 * This is the state after someone has already imported under the new app
+	 * id: the importer forked the schema rather than finding the original, so
+	 * moving the original on top would leave two rows sharing (slug,
+	 * application) with no way to tell which one the objects belong to.
+	 *
+	 * @return void
+	 */
+	public function testSharedSlugIsReportedAsACollision(): void {
+		$this->assertSame(
+			['case'],
+			MigrateSchemaApplicationCommand::planCollisions(
+				fromSlugs: ['case', 'caseType'],
+				toSlugs: ['case']
+			)
+		);
+
+	}//end testSharedSlugIsReportedAsACollision()
+
+
+	/**
+	 * Matching is case-insensitive.
+	 *
+	 * findByApplicationAndSlug() looks schemas up on `lower(slug)`, so two
+	 * spellings that differ only in case ARE the same schema to the importer.
+	 * A case-sensitive comparison here would report "safe to migrate" for a
+	 * pair that then collides — the refusal would be skipped precisely when it
+	 * was needed.
+	 *
+	 * @return void
+	 */
+	public function testCollisionDetectionIsCaseInsensitive(): void {
+		$this->assertSame(
+			['casetype'],
+			MigrateSchemaApplicationCommand::planCollisions(
+				fromSlugs: ['CaseType'],
+				toSlugs: ['casetype']
+			)
+		);
+
+	}//end testCollisionDetectionIsCaseInsensitive()
+
+
+	/**
+	 * A slug repeated on the source side is reported once.
+	 *
+	 * @return void
+	 */
+	public function testDuplicateSourceSlugsAreReportedOnce(): void {
+		$this->assertSame(
+			['case'],
+			MigrateSchemaApplicationCommand::planCollisions(
+				fromSlugs: ['case', 'CASE', 'case'],
+				toSlugs: ['case']
+			)
+		);
+
+	}//end testDuplicateSourceSlugsAreReportedOnce()
+
+
+}//end class

--- a/tests/Unit/Service/SchemaApplicationMigratorTest.php
+++ b/tests/Unit/Service/SchemaApplicationMigratorTest.php
@@ -1,10 +1,10 @@
 <?php
 
 /**
- * MigrateSchemaApplicationCommand unit tests
+ * SchemaApplicationMigrator unit tests
  *
  * @category Test
- * @package  OCA\OpenRegister\Tests\Unit\Command
+ * @package  OCA\OpenRegister\Tests\Unit\Service
  *
  * @author    Conduction Development Team <dev@conduction.nl>
  * @copyright 2026 Conduction B.V.
@@ -16,16 +16,16 @@
 
 declare(strict_types=1);
 
-namespace OCA\OpenRegister\Tests\Unit\Command;
+namespace OCA\OpenRegister\Tests\Unit\Service;
 
-use OCA\OpenRegister\Command\MigrateSchemaApplicationCommand;
+use OCA\OpenRegister\Service\SchemaApplicationMigrator;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Locks planCollisions(): the rule that decides whether an app-id migration is
  * safe to perform or has to be refused.
  */
-class MigrateSchemaApplicationCommandTest extends TestCase {
+class SchemaApplicationMigratorTest extends TestCase {
 
 	/**
 	 * Nothing under the target id means nothing can collide.
@@ -38,7 +38,7 @@ class MigrateSchemaApplicationCommandTest extends TestCase {
 	public function testNoTargetSlugsMeansNoCollisions(): void {
 		$this->assertSame(
 			[],
-			MigrateSchemaApplicationCommand::planCollisions(
+			SchemaApplicationMigrator::planCollisions(
 				fromSlugs: ['case', 'caseType', 'bezwaar'],
 				toSlugs: []
 			)
@@ -55,7 +55,7 @@ class MigrateSchemaApplicationCommandTest extends TestCase {
 	public function testDisjointSlugsDoNotCollide(): void {
 		$this->assertSame(
 			[],
-			MigrateSchemaApplicationCommand::planCollisions(
+			SchemaApplicationMigrator::planCollisions(
 				fromSlugs: ['case', 'caseType'],
 				toSlugs: ['invoice', 'contract']
 			)
@@ -77,7 +77,7 @@ class MigrateSchemaApplicationCommandTest extends TestCase {
 	public function testSharedSlugIsReportedAsACollision(): void {
 		$this->assertSame(
 			['case'],
-			MigrateSchemaApplicationCommand::planCollisions(
+			SchemaApplicationMigrator::planCollisions(
 				fromSlugs: ['case', 'caseType'],
 				toSlugs: ['case']
 			)
@@ -100,7 +100,7 @@ class MigrateSchemaApplicationCommandTest extends TestCase {
 	public function testCollisionDetectionIsCaseInsensitive(): void {
 		$this->assertSame(
 			['casetype'],
-			MigrateSchemaApplicationCommand::planCollisions(
+			SchemaApplicationMigrator::planCollisions(
 				fromSlugs: ['CaseType'],
 				toSlugs: ['casetype']
 			)
@@ -117,7 +117,7 @@ class MigrateSchemaApplicationCommandTest extends TestCase {
 	public function testDuplicateSourceSlugsAreReportedOnce(): void {
 		$this->assertSame(
 			['case'],
-			MigrateSchemaApplicationCommand::planCollisions(
+			SchemaApplicationMigrator::planCollisions(
 				fromSlugs: ['case', 'CASE', 'case'],
 				toSlugs: ['case']
 			)


### PR DESCRIPTION
Adds `occ openregister:migrate-application <from> <to>`, the piece the fleet rename programme needs and OpenRegister did not have.

## The defect this exists for

An app declares its register through an OAS file whose `x-openregister.app` names the owning application. `ImportHandler` resolves the two halves by **different keys**:

| | matched by | follows a rename? |
|---|---|---|
| register | `registerMapper->find($data['slug'])`, then `setApplication($appId)` | **yes, by itself** |
| schema | `findByApplicationAndSlug($slug, $appId)` — the *pair*, on `lower(slug)` | **no** |

So when an app id changes, every schema lookup misses. The import does not fail and does not warn — it takes the `"not found, will create new one"` branch and builds a second, **empty** set of schemas under the new id, while the originals and every object stored against them stay behind under the old one.

What that looks like from the outside is an empty collection and a 404 for `<oldapp>-<schema>`. It reads as missing data rather than as a rename that silently half-happened. It is what dossiq#1333 ran into.

## Why it belongs here

`setApplication()` is an attribute setter on a loaded entity; there was no way to re-point rows in bulk. Fourteen fleet repos are mid-rename, so this is one shared command rather than a hand-rolled repair step per app.

## Design notes

- **Refuses rather than merges** when a slug already exists under the target id. That state means an import already forked the schema; moving the original on top would leave two rows sharing `(slug, application)` with no way to tell which one the objects belong to. It names the offending slugs and points at `openregister:schemas:dedup` — verified to be the real command name, not assumed.
- The refusal rule is a **pure static `planCollisions()`**, unit-tested without a database, because it is the part that must not be wrong. It matches **case-insensitively** on purpose: `findByApplicationAndSlug()` looks up on `lower(slug)`, so two spellings differing only in case are the same schema to the importer — a case-sensitive check would report "safe" precisely when the refusal was needed. That has its own test.
- A zero count reports *which* situation it is ("nothing under the old id; the new id owns N") rather than a bare success, since "already migrated" and "never had anything" are different answers to the same number.
- `--dry-run` reports without writing.

**Objects are untouched** — they reference their schema by id, which does not change.

## Verification

```
phpcs   clean
psalm   0 errors (100% of the codebase inferred)
phpunit OK (5 tests, 5 assertions)
```