### PR TITLE
test(files): cover the file fetch itself, not just its refusals

### DIFF
--- a/tests/Unit/Service/Object/SaveObject/FilePropertyHandlerTest.php
+++ b/tests/Unit/Service/Object/SaveObject/FilePropertyHandlerTest.php
@@ -33,6 +33,110 @@ use ReflectionClass;
 use ReflectionMethod;
 
 /**
+ * Stream wrapper standing in for `http://` so the URL-fetch path can be tested
+ * without a network.
+ *
+ * `fetchFileFromUrl()` reaches the network through `file_get_contents()`, which
+ * is why that whole branch — including the SEC-SVC-2 anti-SSRF guard and the
+ * "unable to fetch" failure — had NO test: every existing file-object case
+ * throws "no downloadable URL" before it gets there. Replacing the wrapper lets
+ * the real code run unmodified while the bytes come from `$body`.
+ *
+ * `$body = false` makes `stream_open()` fail, which is how `file_get_contents()`
+ * returns false in production when the remote is unreachable.
+ *
+ * Registration is per-test and always undone in tearDown(): a wrapper left
+ * registered would silently hijack every later test in the process.
+ */
+class FakeHttpStreamWrapper {
+	/**
+	 * Bytes to serve, or false to make the fetch fail.
+	 *
+	 * @var string|false
+	 */
+	public static string|false $body = '';
+
+	/**
+	 * The last URL opened through this wrapper, asserted on by the tests.
+	 *
+	 * @var string|null
+	 */
+	public static ?string $lastUrl = null;
+
+	/**
+	 * Read cursor into $body.
+	 *
+	 * @var int
+	 */
+	private int $position = 0;
+
+	/**
+	 * Stream context, assigned by PHP.
+	 *
+	 * @var resource|null
+	 */
+	public $context;
+
+	/**
+	 * Open the stream.
+	 *
+	 * @param string      $path       The URL being opened.
+	 * @param string      $mode       The fopen mode.
+	 * @param int         $options    Stream options.
+	 * @param string|null $openedPath Set to the opened path.
+	 *
+	 * @return bool True when the fake has content to serve.
+	 */
+	public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool {
+		self::$lastUrl = $path;
+		return self::$body !== false;
+	}
+
+	/**
+	 * Read from the stream.
+	 *
+	 * @param int $count Bytes requested.
+	 *
+	 * @return string The bytes read.
+	 */
+	public function stream_read(int $count): string {
+		$data = substr((string)self::$body, $this->position, $count);
+		$this->position += strlen($data);
+		return $data;
+	}
+
+	/**
+	 * Whether the stream is exhausted.
+	 *
+	 * @return bool True at end of body.
+	 */
+	public function stream_eof(): bool {
+		return $this->position >= strlen((string)self::$body);
+	}
+
+	/**
+	 * Stat the stream.
+	 *
+	 * @return array Empty stat block.
+	 */
+	public function stream_stat(): array {
+		return [];
+	}
+
+	/**
+	 * Stat the URL.
+	 *
+	 * @param string $path  The URL.
+	 * @param int    $flags Stat flags.
+	 *
+	 * @return array Empty stat block.
+	 */
+	public function url_stat(string $path, int $flags): array {
+		return [];
+	}
+}
+
+/**
  * Unit tests for FilePropertyHandler
  *
  * Tests file upload processing, file detection, validation, and security checks.
@@ -52,6 +156,9 @@ class FilePropertyHandlerTest extends TestCase {
 	/** @var FileService&MockObject */
 	private FileService $fileService;
 
+	/** @var bool Whether this test replaced the `http://` stream wrapper. */
+	private bool $httpWrapperOverridden = false;
+
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -62,6 +169,41 @@ class FilePropertyHandlerTest extends TestCase {
 			$this->logger,
 			$this->fileService
 		);
+	}
+
+	protected function tearDown(): void {
+		$this->restoreHttpWrapper();
+		parent::tearDown();
+	}
+
+	/**
+	 * Serve `http://` from FakeHttpStreamWrapper for the rest of this test.
+	 *
+	 * @param string|false $body Bytes to serve, or false to fail the fetch.
+	 *
+	 * @return void
+	 */
+	private function fakeHttpResponse(string|false $body): void {
+		FakeHttpStreamWrapper::$body = $body;
+		FakeHttpStreamWrapper::$lastUrl = null;
+
+		if ($this->httpWrapperOverridden === false) {
+			stream_wrapper_unregister('http');
+			stream_wrapper_register('http', FakeHttpStreamWrapper::class);
+			$this->httpWrapperOverridden = true;
+		}
+	}
+
+	/**
+	 * Put the real `http://` wrapper back.
+	 *
+	 * @return void
+	 */
+	private function restoreHttpWrapper(): void {
+		if ($this->httpWrapperOverridden === true) {
+			stream_wrapper_restore('http');
+			$this->httpWrapperOverridden = false;
+		}
 	}
 
 	/**
@@ -2465,5 +2607,224 @@ class FilePropertyHandlerTest extends TestCase {
 	public function testFetchFileFromUrlRefusesAFileUrl(): void {
 		$this->expectException(InvalidArgumentException::class);
 		$this->invokePrivateMethod('fetchFileFromUrl', ['file:///etc/passwd']);
+	}
+
+	// =========================================================================
+	// processSingleFileProperty — the URL branch (fetchFileFromUrl)
+	//
+	// Untested until now, and not for a small reason: this is the only path in
+	// the handler that makes an outbound request on a user-supplied string, so
+	// it carries the SEC-SVC-2 anti-SSRF guard. Every pre-existing file-object
+	// test throws "no downloadable URL" before reaching it, so the guard, the
+	// fetch and its failure mode all ran unasserted.
+	//
+	// The URLs below use a LITERAL public IP on purpose. assertSafeFetchUrl()
+	// resolves any non-literal host via gethostbynamel()/dns_get_record(), which
+	// would make these tests depend on DNS — a literal skips resolution
+	// entirely, so nothing here touches the network in either direction.
+	// =========================================================================
+
+	/**
+	 * A public http URL is fetched and stored, with the extension taken from
+	 * the URL path.
+	 *
+	 * @return void
+	 */
+	public function testProcessSingleFilePropertyFetchesPublicHttpUrl(): void {
+		$entity = $this->createObjectEntity(1, 'uuid-psfp-url-1');
+		$this->fakeHttpResponse('%PDF-1.4 fake report body');
+
+		$fileMock = $this->createMock(File::class);
+		$fileMock->method('getId')->willReturn(4242);
+
+		$capturedName = null;
+		$capturedContent = null;
+		$this->fileService->expects($this->once())
+			->method('addFile')
+			->willReturnCallback(
+				function (ObjectEntity $object, string $fileName, string $content, bool $share = false, array $tags = []) use ($fileMock, &$capturedName, &$capturedContent): File {
+					$capturedName = $fileName;
+					$capturedContent = $content;
+					return $fileMock;
+				}
+			);
+
+		$result = $this->handler->processSingleFileProperty(
+			$entity,
+			'http://93.184.216.34/reports/quarterly.pdf',
+			'document',
+			['type' => 'file']
+		);
+
+		$this->assertSame(4242, $result);
+		$this->assertSame('%PDF-1.4 fake report body', $capturedContent);
+		$this->assertStringEndsWith('.pdf', (string)$capturedName);
+		$this->assertSame('http://93.184.216.34/reports/quarterly.pdf', FakeHttpStreamWrapper::$lastUrl);
+	}
+
+	/**
+	 * A URL whose path carries no extension falls back to the detected MIME
+	 * type for one.
+	 *
+	 * @return void
+	 */
+	public function testProcessSingleFilePropertyUrlWithoutExtensionUsesMimeType(): void {
+		$entity = $this->createObjectEntity(1, 'uuid-psfp-url-2');
+		// A complete 1x1 PNG. A bare 8-byte signature is NOT enough: finfo reads
+		// past it and answers application/octet-stream, which would silently
+		// turn this into a test of the ".bin" fallback instead.
+		$this->fakeHttpResponse(
+			base64_decode(
+				'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+			)
+		);
+
+		$fileMock = $this->createMock(File::class);
+		$fileMock->method('getId')->willReturn(88);
+
+		$capturedName = null;
+		$this->fileService->expects($this->once())
+			->method('addFile')
+			->willReturnCallback(
+				function (ObjectEntity $object, string $fileName, string $content, bool $share = false, array $tags = []) use ($fileMock, &$capturedName): File {
+					$capturedName = $fileName;
+					return $fileMock;
+				}
+			);
+
+		$result = $this->handler->processSingleFileProperty(
+			$entity,
+			'http://93.184.216.34/download',
+			'image',
+			['type' => 'file']
+		);
+
+		$this->assertSame(88, $result);
+		$this->assertStringEndsWith('.png', (string)$capturedName);
+	}
+
+	/**
+	 * The SSRF guard runs BEFORE the request, not after it.
+	 *
+	 * testFetchFileFromUrlRefusesALoopbackAddress above already proves the
+	 * address is rejected; it cannot prove nothing was fetched, because with no
+	 * wrapper in place there is no way to observe a request that did happen.
+	 * Here the fake wrapper is armed with content and then asserted never to
+	 * have been opened — a guard that fetched first and validated afterwards
+	 * would still be a read-SSRF, and would pass every other test in this file.
+	 *
+	 * @return void
+	 */
+	public function testProcessSingleFilePropertyRefusesTheUrlWithoutFetchingIt(): void {
+		$entity = $this->createObjectEntity(1, 'uuid-psfp-url-3');
+		$this->fakeHttpResponse('cloud metadata credentials');
+
+		$this->fileService->expects($this->never())->method('addFile');
+
+		try {
+			$this->handler->processSingleFileProperty(
+				$entity,
+				'http://127.0.0.1/latest/meta-data/',
+				'document',
+				['type' => 'file']
+			);
+			$this->fail('Expected a loopback URL to be refused.');
+		} catch (InvalidArgumentException $e) {
+			$this->assertStringContainsString('non-public address', $e->getMessage());
+		}
+
+		$this->assertNull(FakeHttpStreamWrapper::$lastUrl, 'The URL must not be opened at all.');
+	}
+
+	/**
+	 * An unreachable remote surfaces as a clear error rather than an empty file.
+	 *
+	 * @return void
+	 */
+	public function testProcessSingleFilePropertyThrowsWhenTheFetchFails(): void {
+		$entity = $this->createObjectEntity(1, 'uuid-psfp-url-5');
+		$this->fakeHttpResponse(false);
+
+		$this->fileService->expects($this->never())->method('addFile');
+
+		// file_get_contents() raises its own PHP warning before the handler gets
+		// to throw — that is production behaviour, not a defect, but letting it
+		// through would print a warning on every run and make a REAL warning
+		// here easy to miss. Swallowed only for this call, and only for that
+		// message; anything else still reaches PHPUnit's handler.
+		set_error_handler(
+			static function (int $severity, string $message): bool {
+				return str_contains($message, 'Failed to open stream');
+			}
+		);
+
+		try {
+			$this->handler->processSingleFileProperty(
+				$entity,
+				'http://93.184.216.34/gone.pdf',
+				'document',
+				['type' => 'file']
+			);
+			$this->fail('Expected an unreachable URL to throw.');
+		} catch (Exception $e) {
+			$this->assertStringContainsString('Unable to fetch file from URL', $e->getMessage());
+		} finally {
+			restore_error_handler();
+		}
+	}
+
+	/**
+	 * A file object with no usable id falls back to its downloadUrl, which is
+	 * fetched through the same guarded path.
+	 *
+	 * @return void
+	 */
+	public function testProcessSingleFilePropertyFollowsAFileObjectDownloadUrl(): void {
+		$entity = $this->createObjectEntity(1, 'uuid-psfp-url-6');
+		$this->fakeHttpResponse('plain text attachment');
+
+		$fileMock = $this->createMock(File::class);
+		$fileMock->method('getId')->willReturn(1234);
+
+		$this->fileService->expects($this->once())
+			->method('addFile')
+			->willReturn($fileMock);
+
+		$result = $this->handler->processSingleFileProperty(
+			$entity,
+			[
+				'id' => 'not-numeric',
+				'title' => 'notes.txt',
+				'downloadUrl' => 'http://93.184.216.34/files/notes.txt',
+			],
+			'document',
+			['type' => 'file']
+		);
+
+		$this->assertSame(1234, $result);
+		$this->assertSame('http://93.184.216.34/files/notes.txt', FakeHttpStreamWrapper::$lastUrl);
+	}
+
+	/**
+	 * A fetched file is still validated against the property configuration —
+	 * the URL path is not a way around the MIME allow-list.
+	 *
+	 * @return void
+	 */
+	public function testProcessSingleFilePropertyValidatesFetchedContentAgainstConfig(): void {
+		$entity = $this->createObjectEntity(1, 'uuid-psfp-url-7');
+		$this->fakeHttpResponse('%PDF-1.4 not an image');
+
+		$this->fileService->expects($this->never())->method('addFile');
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage("has invalid type 'application/pdf'");
+
+		$this->handler->processSingleFileProperty(
+			$entity,
+			'http://93.184.216.34/reports/quarterly.pdf',
+			'image',
+			['type' => 'file', 'allowedTypes' => ['image/png']]
+		);
 	}
 }


### PR DESCRIPTION
test(files): cover the file fetch itself, not just its refusals

`development` already tests the SEC-SVC-2 guard on fetchFileFromUrl(), by
calling the private method with a loopback, private, ftp and file:// URL.
Those four all throw inside assertSafeFetchUrl(), so what they establish is
that bad URLs are refused — and nothing past that line has ever run. The
fetch, the stream context, the "unable to fetch" failure, the URL-derived
extension and the file-object downloadUrl fallback were all still unasserted,
on the one path in the handler that makes an outbound request from a
user-supplied string.

Six tests drive it through the public entry point instead:

- a public http URL is fetched and stored, extension from the URL path
- a URL with no path extension falls back to the detected MIME type
- the guard is proven to run BEFORE the request: the fake wrapper is armed
  with content and asserted never to have been opened. The existing loopback
  test cannot show this — with no wrapper in place a request that DID happen
  is unobservable — and a guard that fetched first and validated after would
  still be a read-SSRF while passing every other test here
- an unreachable remote throws instead of storing an empty file
- a file object with no usable id follows its downloadUrl through the same
  guarded path
- fetched content is still checked against allowedTypes, so the URL branch is
  not a way around the MIME allow-list

Two details are load-bearing. The URLs use a LITERAL public IP because
assertSafeFetchUrl() resolves any non-literal host via gethostbynamel()
/dns_get_record(), which would put DNS in the path of a unit test; a literal
skips resolution entirely. And FakeHttpStreamWrapper replaces `http://` only
for the duration of a test, restored in tearDown, following the
MockPhpInputStream precedent in McpServerControllerTest — so the real code
runs unmodified while the bytes come from a static. Nothing here touches the
network in either direction.

This is also what the coverage guard was asking for on #2800: that PR moved
~35 well-covered statements out of FilePropertyHandler and
FileValidationHandler into the 100%-covered ExecutableContentDetector while
their existing 27 uncovered statements stayed, so surviving-code coverage over
the changed files slipped 96.54% -> 96.50%. #2800 was merged past that; these
are the tests that answer it.

Test-only change: phpcs/phpmd/psalm/phpstan are all scoped to lib/.
