### PR TITLE
fix(bulk): a declared schema property is no longer eaten by the column of the same name

### DIFF
--- a/lib/Service/Object/SaveObjects.php
+++ b/lib/Service/Object/SaveObjects.php
@@ -2737,10 +2737,8 @@ class SaveObjects {
 			// handed over as-is: extractBusinessData() decides what counts as a
 			// usable schema, so a cache miss or an unexpected value is judged in
 			// ONE place instead of at every call site (openregister#2781).
-			$businessData = $this->extractBusinessData(
-				object: $object,
-				schema: ($schemaCache[$selfData['schema']] ?? null)
-			);
+			$objectSchema = ($schemaCache[$selfData['schema']] ?? null);
+			$businessData = $this->extractBusinessData(object: $object, schema: $objectSchema);
 
 			// RELATIONS EXTRACTION: Scan the business data for relations (UUIDs and URLs).
 			// ONLY scan if relations weren't already set during preparation phase.

--- a/lib/Service/Object/SaveObjects.php
+++ b/lib/Service/Object/SaveObjects.php
@@ -2733,15 +2733,14 @@ class SaveObjects {
 				]
 			);
 
-			// Extract business data and scan for relations. Resolve this object's
-			// schema from the cache so a declared property is not stripped as a
-			// metadata column of the same name (openregister#2781).
-			$objectSchema = $schemaCache[$selfData['schema']] ?? null;
-			if (($objectSchema instanceof Schema) === false) {
-				$objectSchema = null;
-			}
-
-			$businessData = $this->extractBusinessData(object: $object, schema: $objectSchema);
+			// Extract business data and scan for relations. The cache entry is
+			// handed over as-is: extractBusinessData() decides what counts as a
+			// usable schema, so a cache miss or an unexpected value is judged in
+			// ONE place instead of at every call site (openregister#2781).
+			$businessData = $this->extractBusinessData(
+				object: $object,
+				schema: ($schemaCache[$selfData['schema']] ?? null)
+			);
 
 			// RELATIONS EXTRACTION: Scan the business data for relations (UUIDs and URLs).
 			// ONLY scan if relations weren't already set during preparation phase.
@@ -2916,16 +2915,21 @@ class SaveObjects {
 	 * Supports both new structure (object property contains business data) and
 	 * legacy structure (metadata fields mixed with business data).
 	 *
-	 * @param array       $object The full object data
-	 * @param Schema|null $schema The schema this object is saved against, used to
-	 *                            tell a declared property from a metadata column
-	 *                            of the same name. Null keeps the old behaviour.
+	 * @param array $object The full object data
+	 * @param mixed $schema The schema this object is saved against, used to tell
+	 *                      a declared property from a metadata column of the same
+	 *                      name. Deliberately untyped: callers pass a schema-cache
+	 *                      lookup straight through, and anything that is not a
+	 *                      Schema — a miss, a null, a stale entry — means "no
+	 *                      declaration information", which is the pre-existing
+	 *                      behaviour. Judging that here keeps one rule in one
+	 *                      place rather than an `instanceof` at every call site.
 	 *
 	 * @return array The extracted business data
 	 *
 	 * @spec openspec/specs/object-lifecycle/spec.md
 	 */
-	private function extractBusinessData(array $object, ?Schema $schema = null): array {
+	private function extractBusinessData(array $object, mixed $schema = null): array {
 		if (isset($object['object']) === true && is_array($object['object']) === true) {
 			// NEW STRUCTURE: object property contains business data.
 			$this->logger->debug('[SaveObjects] Using object property for business data (mixed)');
@@ -2950,7 +2954,7 @@ class SaveObjects {
 		// so the value ends up in both places, which is what the magic table is
 		// for.
 		$declared = [];
-		if ($schema !== null) {
+		if ($schema instanceof Schema) {
 			$declared = array_keys($schema->getProperties() ?? []);
 		}
 

--- a/lib/Service/Object/SaveObjects.php
+++ b/lib/Service/Object/SaveObjects.php
@@ -85,6 +85,8 @@ use Symfony\Component\Uid\Uuid;
  * handling for batch object operations. Reduced from 2,717 to 1,815 lines via
  * dead code removal and extract-method decomposition (21 focused helpers).
  *
+ * @spec openspec/specs/object-lifecycle/spec.md
+ *
  * @SuppressWarnings(PHPMD.ExcessiveClassLength)     Bulk save coordination requires many steps
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) Inherent complexity of bulk operations
  * @SuppressWarnings(PHPMD.TooManyMethods)           Methods are small focused helpers extracted from complex methods
@@ -108,6 +110,45 @@ class SaveObjects {
 	 * @var int
 	 */
 	private const AUDIT_INSERT_CHUNK_SIZE = 100;
+
+	/**
+	 * Envelope keys that are never business data, whatever a schema declares.
+	 *
+	 * These identify or locate the object rather than describe it, so a schema
+	 * property of the same name would be a collision with the storage envelope
+	 * itself and is not something this method can honour.
+	 *
+	 * @var string[]
+	 */
+	private const STRUCTURAL_METADATA_FIELDS = [
+		'@self',
+		'register',
+		'schema',
+		'organisation',
+		'uuid',
+		'owner',
+		'created',
+		'updated',
+		'id',
+	];
+
+	/**
+	 * Magic-table display columns that are ALSO legal schema property names.
+	 *
+	 * `name`, `description`, `summary`, `image` and `slug` each have a column on
+	 * the magic table, and are among the most ordinary property names a schema
+	 * can declare. When the schema declares one, the incoming value is business
+	 * data and must survive; only an undeclared one is metadata.
+	 *
+	 * @var string[]
+	 */
+	private const OVERLAPPING_METADATA_FIELDS = [
+		'name',
+		'description',
+		'summary',
+		'image',
+		'slug',
+	];
 
 	/**
 	 * Static schema cache to avoid repeated database lookups
@@ -1582,8 +1623,10 @@ class SaveObjects {
 			]
 		);
 
-		// Extract business data.
-		$businessData = $this->extractBusinessData(object: $object);
+		// Extract business data. The schema is passed so a declared `name` /
+		// `description` / `summary` / `image` / `slug` property is not mistaken
+		// for the magic-table column of the same name (openregister#2781).
+		$businessData = $this->extractBusinessData(object: $object, schema: $schemaObj);
 
 		// RELATIONS EXTRACTION: Scan the business data for relations (UUIDs and URLs).
 		$relations = $this->scanForRelations(data: $businessData, prefix: '', schema: $schemaObj);
@@ -2690,8 +2733,15 @@ class SaveObjects {
 				]
 			);
 
-			// Extract business data and scan for relations.
-			$businessData = $this->extractBusinessData(object: $object);
+			// Extract business data and scan for relations. Resolve this object's
+			// schema from the cache so a declared property is not stripped as a
+			// metadata column of the same name (openregister#2781).
+			$objectSchema = $schemaCache[$selfData['schema']] ?? null;
+			if (($objectSchema instanceof Schema) === false) {
+				$objectSchema = null;
+			}
+
+			$businessData = $this->extractBusinessData(object: $object, schema: $objectSchema);
 
 			// RELATIONS EXTRACTION: Scan the business data for relations (UUIDs and URLs).
 			// ONLY scan if relations weren't already set during preparation phase.
@@ -2866,13 +2916,16 @@ class SaveObjects {
 	 * Supports both new structure (object property contains business data) and
 	 * legacy structure (metadata fields mixed with business data).
 	 *
-	 * @param array $object The full object data
+	 * @param array       $object The full object data
+	 * @param Schema|null $schema The schema this object is saved against, used to
+	 *                            tell a declared property from a metadata column
+	 *                            of the same name. Null keeps the old behaviour.
 	 *
 	 * @return array The extracted business data
 	 *
 	 * @spec openspec/specs/object-lifecycle/spec.md
 	 */
-	private function extractBusinessData(array $object): array {
+	private function extractBusinessData(array $object, ?Schema $schema = null): array {
 		if (isset($object['object']) === true && is_array($object['object']) === true) {
 			// NEW STRUCTURE: object property contains business data.
 			$this->logger->debug('[SaveObjects] Using object property for business data (mixed)');
@@ -2881,24 +2934,35 @@ class SaveObjects {
 
 		// LEGACY STRUCTURE: Remove metadata fields to isolate business data.
 		$businessData = $object;
-		$metadataFields = [
-			'@self',
-			'name',
-			'description',
-			'summary',
-			'image',
-			'slug',
-			'register',
-			'schema',
-			'organisation',
-			'uuid',
-			'owner',
-			'created',
-			'updated',
-			'id',
-		];
+		$metadataFields = array_merge(self::STRUCTURAL_METADATA_FIELDS, self::OVERLAPPING_METADATA_FIELDS);
 
+		// The five OVERLAPPING names are magic-table columns AND perfectly legal
+		// schema property names. Stripping them unconditionally silently threw
+		// away the caller's value, and when the property was `required` the
+		// object then failed validation for "the required property (name) is
+		// missing" -- refusing the whole batch over a field that WAS supplied.
+		// The single-object path never stripped them, so the same payload
+		// behaved differently depending on which endpoint received it
+		// (openregister#2781).
+		//
+		// A declared property wins: it stays in the business data. The metadata
+		// column is still populated separately from objectNameField and friends,
+		// so the value ends up in both places, which is what the magic table is
+		// for.
+		$declared = [];
+		if ($schema !== null) {
+			$declared = array_keys($schema->getProperties() ?? []);
+		}
+
+		$kept = [];
 		foreach ($metadataFields as $field) {
+			if (
+				in_array($field, self::OVERLAPPING_METADATA_FIELDS, true) === true
+				&& in_array($field, $declared, true) === true
+			) {
+				$kept[] = $field;
+				continue;
+			}
 			unset($businessData[$field]);
 		}
 
@@ -2906,7 +2970,10 @@ class SaveObjects {
 		$this->logger->debug(
 			'[SaveObjects] Metadata removal applied (mixed)',
 			[
-				'removed_fields' => array_intersect($metadataFields, array_keys($object)),
+				'removed_fields' => array_values(
+					array_diff(array_intersect($metadataFields, array_keys($object)), $kept)
+				),
+				'kept_as_schema_properties' => array_values(array_intersect($kept, array_keys($object))),
 				'remaining_keys' => array_keys($businessData),
 				'business_data_sample' => array_slice($businessData, 0, 3, true),
 			]

--- a/tests/Unit/Service/Object/SaveObjectsMetadataCollisionTest.php
+++ b/tests/Unit/Service/Object/SaveObjectsMetadataCollisionTest.php
@@ -69,7 +69,7 @@ class SaveObjectsMetadataCollisionTest extends TestCase {
 	 *
 	 * @return array The extracted business data.
 	 */
-	private function extract(array $object, ?Schema $schema = null): array {
+	private function extract(array $object, mixed $schema = null): array {
 		$method = new ReflectionMethod(SaveObjects::class, 'extractBusinessData');
 		$method->setAccessible(true);
 		return $method->invoke($this->service, $object, $schema);
@@ -241,6 +241,40 @@ class SaveObjectsMetadataCollisionTest extends TestCase {
 		);
 
 		$this->assertSame(['name' => 'inner', 'uuid' => 'kept-inside'], $business);
+	}
+
+	/**
+	 * A schema-cache MISS is treated as "no declaration information".
+	 *
+	 * The mixed-schema call site passes `$schemaCache[$id] ?? null` straight
+	 * through rather than guarding with `instanceof` itself, so this method has
+	 * to judge it. A miss must fall back to the old stripping, never fatal on a
+	 * method call against null.
+	 *
+	 * @return void
+	 */
+	public function testACacheMissIsTreatedAsNoSchema(): void {
+		$business = $this->extract(['name' => 'x', 'age' => 4], null);
+
+		$this->assertArrayNotHasKey('name', $business);
+		$this->assertSame(4, $business['age'] ?? null);
+	}
+
+	/**
+	 * A stale or unexpected cache value is refused, not called.
+	 *
+	 * `$schemaCache` is keyed by whatever `$selfData['schema']` holds, so an
+	 * unexpected entry is reachable. Anything that is not a Schema must degrade
+	 * to the old behaviour rather than reach getProperties() on it.
+	 *
+	 * @return void
+	 */
+	public function testANonSchemaCacheValueDoesNotReachGetProperties(): void {
+		foreach ([['not' => 'a schema'], 'planix', 42, new \stdClass()] as $value) {
+			$business = $this->extract(['name' => 'x', 'age' => 5], $value);
+			$this->assertArrayNotHasKey('name', $business);
+			$this->assertSame(5, $business['age'] ?? null);
+		}
 	}
 
 	/**

--- a/tests/Unit/Service/Object/SaveObjectsMetadataCollisionTest.php
+++ b/tests/Unit/Service/Object/SaveObjectsMetadataCollisionTest.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Bulk save: a schema property must not be eaten by the magic-table column of
+ * the same name.
+ *
+ * openregister#2781. `extractBusinessData()` stripped `name`, `description`,
+ * `summary`, `image` and `slug` from every legacy-structure payload before
+ * validation, on the assumption that those keys are always metadata. They are
+ * also five of the most ordinary property names a schema can declare, and when
+ * one was declared its incoming value was silently dropped -- then, if the
+ * property was `required`, validation refused the WHOLE batch for "the required
+ * property (name) is missing", over a field the caller had supplied.
+ *
+ * The single-object endpoint never stripped them, so the same payload behaved
+ * differently depending on which endpoint received it. That asymmetry is what
+ * these tests pin.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Object
+ * @author   Conduction Development Team <dev@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://OpenRegister.app
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Object;
+
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Object\SaveObject;
+use OCA\OpenRegister\Service\Object\SaveObjects;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionMethod;
+
+/**
+ * Unit tests for the metadata/business-data split in bulk save.
+ */
+class SaveObjectsMetadataCollisionTest extends TestCase {
+	/** @var SaveObjects */
+	private SaveObjects $service;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->service = new SaveObjects(
+			$this->createMock(MagicMapper::class),
+			$this->createMock(SchemaMapper::class),
+			$this->createMock(RegisterMapper::class),
+			$this->createMock(SaveObject::class),
+			$this->createMock(IUserSession::class),
+			$this->createMock(OrganisationService::class),
+			$this->createMock(LoggerInterface::class)
+		);
+	}
+
+	/**
+	 * Invoke the private splitter.
+	 *
+	 * @param array       $object The payload.
+	 * @param Schema|null $schema The schema, or null for the old behaviour.
+	 *
+	 * @return array The extracted business data.
+	 */
+	private function extract(array $object, ?Schema $schema = null): array {
+		$method = new ReflectionMethod(SaveObjects::class, 'extractBusinessData');
+		$method->setAccessible(true);
+		return $method->invoke($this->service, $object, $schema);
+	}
+
+	/**
+	 * A schema declaring the given property names.
+	 *
+	 * @param string[] $names Property names to declare.
+	 *
+	 * @return Schema&MockObject
+	 */
+	private function schemaDeclaring(array $names): Schema {
+		$schema = $this->createMock(Schema::class);
+		$properties = [];
+		foreach ($names as $name) {
+			$properties[$name] = ['type' => 'string'];
+		}
+		$schema->method('getProperties')->willReturn($properties);
+		return $schema;
+	}
+
+	/**
+	 * The regression: a declared `name` survives instead of being stripped.
+	 *
+	 * @return void
+	 */
+	public function testADeclaredNamePropertySurvives(): void {
+		$business = $this->extract(
+			[
+				'uuid' => 'u-1',
+				'name' => 'Ada Lovelace',
+				'age' => 36,
+			],
+			$this->schemaDeclaring(['name', 'age'])
+		);
+
+		$this->assertSame('Ada Lovelace', $business['name'] ?? null);
+		$this->assertSame(36, $business['age'] ?? null);
+		// Still not business data: it locates the object, it does not describe it.
+		$this->assertArrayNotHasKey('uuid', $business);
+	}
+
+	/**
+	 * Every overlapping column name is honoured, not just `name`.
+	 *
+	 * @return void
+	 */
+	public function testAllFiveOverlappingNamesSurviveWhenDeclared(): void {
+		$payload = [
+			'name' => 'n',
+			'description' => 'd',
+			'summary' => 's',
+			'image' => 'i',
+			'slug' => 'sl',
+		];
+
+		$business = $this->extract(
+			$payload + ['uuid' => 'u-2'],
+			$this->schemaDeclaring(array_keys($payload))
+		);
+
+		foreach ($payload as $key => $value) {
+			$this->assertSame($value, $business[$key] ?? null, "property '$key' was dropped");
+		}
+	}
+
+	/**
+	 * An UNDECLARED overlapping name is still metadata and still stripped.
+	 *
+	 * This is the half of the old behaviour that was correct, and it has to stay
+	 * -- otherwise a plain `{"name": ...}` payload would start writing a stray
+	 * business field on every schema that does not declare one.
+	 *
+	 * @return void
+	 */
+	public function testAnUndeclaredOverlappingNameIsStillStripped(): void {
+		$business = $this->extract(
+			['name' => 'display only', 'age' => 1],
+			$this->schemaDeclaring(['age'])
+		);
+
+		$this->assertArrayNotHasKey('name', $business);
+		$this->assertSame(1, $business['age'] ?? null);
+	}
+
+	/**
+	 * A schema declaring only some of them splits them correctly.
+	 *
+	 * @return void
+	 */
+	public function testAPartiallyDeclaredSchemaSplitsPerProperty(): void {
+		$business = $this->extract(
+			[
+				'name' => 'kept',
+				'description' => 'dropped',
+				'slug' => 'kept-too',
+			],
+			$this->schemaDeclaring(['name', 'slug'])
+		);
+
+		$this->assertSame('kept', $business['name'] ?? null);
+		$this->assertSame('kept-too', $business['slug'] ?? null);
+		$this->assertArrayNotHasKey('description', $business);
+	}
+
+	/**
+	 * Structural envelope keys are stripped even if a schema declares them.
+	 *
+	 * These identify or locate the object rather than describe it, so honouring
+	 * a same-named property would collide with the storage envelope itself.
+	 *
+	 * @return void
+	 */
+	public function testStructuralFieldsAreStrippedEvenWhenDeclared(): void {
+		$structural = [
+			'@self' => ['x' => 1],
+			'register' => 1,
+			'schema' => 2,
+			'organisation' => 'org',
+			'uuid' => 'u-3',
+			'owner' => 'admin',
+			'created' => '2026-01-01T00:00:00+00:00',
+			'updated' => '2026-01-02T00:00:00+00:00',
+			'id' => 99,
+		];
+
+		$business = $this->extract(
+			$structural + ['real' => 'value'],
+			$this->schemaDeclaring(array_keys($structural))
+		);
+
+		foreach (array_keys($structural) as $key) {
+			$this->assertArrayNotHasKey($key, $business, "structural '$key' leaked into business data");
+		}
+		$this->assertSame('value', $business['real'] ?? null);
+	}
+
+	/**
+	 * With no schema the previous behaviour is unchanged.
+	 *
+	 * Callers that cannot resolve a schema must not start behaving differently;
+	 * the fix adds information, it does not change the default.
+	 *
+	 * @return void
+	 */
+	public function testWithoutASchemaTheOldStrippingStands(): void {
+		$business = $this->extract(['name' => 'x', 'age' => 2]);
+
+		$this->assertArrayNotHasKey('name', $business);
+		$this->assertSame(2, $business['age'] ?? null);
+	}
+
+	/**
+	 * The new-structure payload is passed through untouched.
+	 *
+	 * When business data arrives under `object`, there is no ambiguity to
+	 * resolve and nothing should be stripped from it.
+	 *
+	 * @return void
+	 */
+	public function testTheObjectPropertyStructureIsReturnedAsIs(): void {
+		$business = $this->extract(
+			[
+				'@self' => ['uuid' => 'u-4'],
+				'object' => ['name' => 'inner', 'uuid' => 'kept-inside'],
+			],
+			$this->schemaDeclaring(['name'])
+		);
+
+		$this->assertSame(['name' => 'inner', 'uuid' => 'kept-inside'], $business);
+	}
+
+	/**
+	 * A schema with no properties at all does not crash the splitter.
+	 *
+	 * @return void
+	 */
+	public function testASchemaWithNoPropertiesFallsBackToStripping(): void {
+		$business = $this->extract(['name' => 'x', 'age' => 3], $this->schemaDeclaring([]));
+
+		$this->assertArrayNotHasKey('name', $business);
+		$this->assertSame(3, $business['age'] ?? null);
+	}
+}

--- a/tests/Unit/Service/Object/SaveObjectsResultClassificationTest.php
+++ b/tests/Unit/Service/Object/SaveObjectsResultClassificationTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Bulk save: classification of database-computed results.
+ *
+ * `classifyDatabaseComputedResults()` is what turns the magic table's
+ * `object_status` column into the saved/updated/unchanged buckets and the
+ * statistics a caller reads to decide whether a batch succeeded. It had **no
+ * tests at all**, which is a poor place for that gap: this programme has already
+ * been bitten twice by a bulk save reporting success over objects it did not
+ * write (openregister#2778, #2781), and every one of those reports is assembled
+ * here.
+ *
+ * These tests drive it directly with rows carrying no `_register`/`_schema`, so
+ * entity conversion short-circuits to null and the classification logic is
+ * exercised on its own, without a mapper in the way.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Object
+ * @author   Conduction Development Team <dev@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://OpenRegister.app
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Object;
+
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Object\SaveObject;
+use OCA\OpenRegister\Service\Object\SaveObjects;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionMethod;
+
+/**
+ * Unit tests for the bulk result classification.
+ */
+class SaveObjectsResultClassificationTest extends TestCase {
+	/** @var SaveObjects */
+	private SaveObjects $service;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->service = new SaveObjects(
+			$this->createMock(MagicMapper::class),
+			$this->createMock(SchemaMapper::class),
+			$this->createMock(RegisterMapper::class),
+			$this->createMock(SaveObject::class),
+			$this->createMock(IUserSession::class),
+			$this->createMock(OrganisationService::class),
+			$this->createMock(LoggerInterface::class)
+		);
+	}
+
+	/**
+	 * An empty result skeleton in the shape the classifier mutates.
+	 *
+	 * @return array the skeleton
+	 */
+	private function emptyResult(): array {
+		return [
+			'saved' => [],
+			'updated' => [],
+			'unchanged' => [],
+			'statistics' => ['saved' => 0, 'updated' => 0, 'unchanged' => 0],
+		];
+	}
+
+	/**
+	 * Invoke the private classifier.
+	 *
+	 * @param array $rows   the bulk rows
+	 * @param array $result the result skeleton, mutated in place
+	 *
+	 * @return array the side effects returned by the classifier
+	 */
+	private function classify(array $rows, array &$result): array {
+		$method = new ReflectionMethod(SaveObjects::class, 'classifyDatabaseComputedResults');
+		$method->setAccessible(true);
+		return $method->invokeArgs($this->service, [$rows, &$result]);
+	}
+
+	/**
+	 * Each status lands in its own bucket, with statistics to match.
+	 *
+	 * @return void
+	 */
+	public function testEachStatusLandsInItsOwnBucket(): void {
+		$result = $this->emptyResult();
+		$this->classify(
+			[
+				['_uuid' => 'a', 'object_status' => 'created'],
+				['_uuid' => 'b', 'object_status' => 'updated'],
+				['_uuid' => 'c', 'object_status' => 'unchanged'],
+				['_uuid' => 'd', 'object_status' => 'created'],
+			],
+			$result
+		);
+
+		$this->assertCount(2, $result['saved']);
+		$this->assertCount(1, $result['updated']);
+		$this->assertCount(1, $result['unchanged']);
+		$this->assertSame(2, $result['statistics']['saved']);
+		$this->assertSame(1, $result['statistics']['updated']);
+		$this->assertSame(1, $result['statistics']['unchanged']);
+	}
+
+	/**
+	 * Internal bookkeeping columns never reach the caller's payload.
+	 *
+	 * `object_status`, `operation_start_time` and `_pre_update_row` are how the
+	 * SQL and this method talk to each other. Leaking them would put a private
+	 * pre-update copy of the row — the audit diff source — into an API response.
+	 *
+	 * @return void
+	 */
+	public function testInternalBookkeepingColumnsAreStripped(): void {
+		$result = $this->emptyResult();
+		$this->classify(
+			[
+				[
+					'_uuid' => 'a',
+					'object_status' => 'created',
+					'operation_start_time' => '2026-01-01 00:00:00',
+					'_pre_update_row' => ['_uuid' => 'a', 'secret' => 'previous value'],
+					'title' => 'kept',
+				],
+			],
+			$result
+		);
+
+		$saved = $result['saved'][0];
+		$this->assertSame('kept', $saved['title'] ?? null);
+		$this->assertArrayNotHasKey('object_status', $saved);
+		$this->assertArrayNotHasKey('operation_start_time', $saved);
+		$this->assertArrayNotHasKey('_pre_update_row', $saved);
+	}
+
+	/**
+	 * An unrecognised status is counted, not dropped.
+	 *
+	 * Silently discarding a row here would be the exact failure this programme
+	 * keeps hitting: a batch that reports success while objects went missing.
+	 * The row is bucketed as unchanged and warned about, so the totals still
+	 * add up to what was submitted.
+	 *
+	 * @return void
+	 */
+	public function testAnUnexpectedStatusIsCountedRatherThanDropped(): void {
+		$result = $this->emptyResult();
+		$this->classify(
+			[
+				['_uuid' => 'a', 'object_status' => 'exploded'],
+				['_uuid' => 'b'],
+			],
+			$result
+		);
+
+		$total = count($result['saved']) + count($result['updated']) + count($result['unchanged']);
+		$this->assertSame(2, $total, 'every submitted row must appear in some bucket');
+		$this->assertSame(2, $result['statistics']['unchanged']);
+	}
+
+	/**
+	 * With no resolvable entity there are no side effects to emit.
+	 *
+	 * @return void
+	 */
+	public function testNoSideEffectsWithoutResolvableEntities(): void {
+		$result = $this->emptyResult();
+		$sideEffects = $this->classify(
+			[
+				['_uuid' => 'a', 'object_status' => 'created'],
+				['_uuid' => 'b', 'object_status' => 'updated'],
+			],
+			$result
+		);
+
+		$this->assertSame([], $sideEffects['created']);
+		$this->assertSame([], $sideEffects['updated']);
+	}
+
+	/**
+	 * An empty batch classifies to an empty result rather than failing.
+	 *
+	 * @return void
+	 */
+	public function testAnEmptyBatchIsHandled(): void {
+		$result = $this->emptyResult();
+		$sideEffects = $this->classify([], $result);
+
+		$this->assertSame([], $result['saved']);
+		$this->assertSame(0, $result['statistics']['saved']);
+		$this->assertSame(['created' => [], 'updated' => []], $sideEffects);
+	}
+
+	/**
+	 * A row with no register/schema converts to no entity instead of throwing.
+	 *
+	 * @return void
+	 */
+	public function testARowWithoutRegisterOrSchemaYieldsNoEntity(): void {
+		$method = new ReflectionMethod(SaveObjects::class, 'convertBulkRowToEntity');
+		$method->setAccessible(true);
+
+		$this->assertNull($method->invoke($this->service, ['_uuid' => 'a']));
+		$this->assertNull($method->invoke($this->service, ['_uuid' => 'a', '_register' => 1]));
+		$this->assertNull($method->invoke($this->service, ['_uuid' => 'a', '_schema' => 2]));
+	}
+
+	/**
+	 * The safeguard group key pairs a register with a schema.
+	 *
+	 * One line, previously untested, and it is the key bulk safeguards are
+	 * grouped by — a wrong pairing would apply one schema's safeguard to
+	 * another's rows.
+	 *
+	 * @return void
+	 */
+	public function testSafeguardGroupKeyPairsRegisterAndSchema(): void {
+		$register = new \OCA\OpenRegister\Db\Register();
+		$register->setId(19);
+		$schema = new \OCA\OpenRegister\Db\Schema();
+		$schema->setId(9475);
+
+		$method = new ReflectionMethod(SaveObjects::class, 'safeguardGroupKey');
+		$method->setAccessible(true);
+
+		$this->assertSame('19/9475', $method->invoke($this->service, $register, $schema));
+	}
+}


### PR DESCRIPTION
fix(bulk): a declared schema property is no longer eaten by the column of the same name

`extractBusinessData()` stripped `name`, `description`, `summary`, `image` and
`slug` from every legacy-structure bulk payload before validation, on the
assumption that those keys are always magic-table metadata. They are also five
of the most ordinary property names a schema can declare.

When a schema declared one, the incoming value was silently discarded. When the
property was also `required`, validation then refused the WHOLE batch for "The
required property (name) is missing" — over a field the caller had supplied and
the code had just deleted. The single-object endpoint never stripped them, so
the same payload succeeded or failed depending only on which endpoint received
it.

The split is now made against the schema:

- **Structural** keys (`@self`, `register`, `schema`, `organisation`, `uuid`,
  `owner`, `created`, `updated`, `id`) are always stripped. They identify or
  locate the object rather than describe it, so honouring a same-named property
  would collide with the storage envelope itself.
- **Overlapping** keys (`name`, `description`, `summary`, `image`, `slug`) are
  metadata only when the schema does NOT declare a property by that name. A
  declared one stays in the business data; the metadata column is still
  populated separately from `objectNameField` and friends, so the value lands in
  both places — which is what the magic table is for.

Both call sites now pass the schema: the single-schema path already had
`$schemaObj` in scope, and the mixed path resolves it from `$schemaCache` by
`$selfData['schema']`, falling back to null. **With no schema the previous
behaviour is unchanged** — this adds information, it does not change the
default.

Eight tests in `SaveObjectsMetadataCollisionTest` pin both halves: that a
declared property survives (all five, and per-property when only some are
declared), and that an undeclared one is still stripped — otherwise a plain
`{"name": ...}` payload would start writing a stray business field on every
schema that does not declare one. Mutation-checked: forcing the exemption to
false kills three of the eight, so the survival assertions are real.

139 SaveObjects unit tests green. phpcs, phpmd, psalm and phpstan clean on the
changed file — including a pre-existing missing class-level `@spec` tag, fixed
here since the file was already being touched.

Closes #2781
