### PR TITLE
fix(quota): call executeQuery(), not the execute() Nextcloud 34 removed

### DIFF
--- a/lib/Service/UserService.php
+++ b/lib/Service/UserService.php
@@ -568,7 +568,13 @@ class UserService {
 				->andWhere($query->expr()->eq('m.mount_point', $query->createNamedParameter('/' . $userId . '/')))
 				->setMaxResults(1);
 
-			$result = $query->execute();
+			// `execute()` was removed from QueryBuilder in Nextcloud 34. It was
+			// the read/write-agnostic entry point; a SELECT now goes through
+			// executeQuery(). Calling the old name threw "Call to undefined
+			// method", which the catch below swallowed into a warning and a 0 —
+			// so used space silently read as empty for every user instead of
+			// failing loudly.
+			$result = $query->executeQuery();
 			$row = $result->fetch();
 			$result->closeCursor();
 


### PR DESCRIPTION
`QueryBuilder::execute()` was removed in Nextcloud 34. `UserService::getUsedSpaceMemorySafe()` still called it, so on NC34 every call threw:

```
Call to undefined method OC\DB\QueryBuilder\QueryBuilder::execute()
  lib/Service/UserService.php:571
```

## Why nobody noticed

The throw never reached anyone. The method's own `catch (\Exception)` turned it into a warning and returned `0`:

```php
} catch (\Exception $e) {
    $this->logger->warning('[UserService] Memory-safe quota calculation failed for user: '.$userId, ...);
    return 0;
}
```

`0` is also what the method legitimately returns when it cannot determine the size, so **used space silently read as empty for every user** and nothing distinguished "no data" from "the API this depends on no longer exists". No test caught it because the method returns 0 either way.

It surfaced only in the raw Nextcloud server log attached to the E2E run on #2815, three lines deep in a JSON log entry — not in any assertion.

## The fix

The query is a SELECT, so `executeQuery()` is the replacement (`executeStatement()` is for writes). One call site; verified by grep that this is the only `->execute()` left in the file.

## Worth a follow-up

The catch is doing two jobs: absorbing a real "cannot determine" case and absorbing a programming error. Now that this one is fixed, it will hide the next such breakage just as quietly.

---

## The call is half the fix; the catch is the other half

Restoring `executeQuery()` fixes today's breakage. It does not fix why the breakage was invisible for as long as it was.

`getUsedSpaceMemorySafe()` returns `0` for two unrelated things:

- **"I could not determine the size"** — a legitimate answer the caller is meant to act on;
- **"the API this method is built on no longer exists"** — a programming error.

Those are indistinguishable at the call site, so no test can separate them: there is nothing to separate. A test asserting `0` passes in both worlds, and a test asserting non-zero fails for reasons it cannot attribute. The method reports the same thing whether it worked or not.

That is the same shape as a CI check that did not run looking exactly like one that passed — the failure wears the clothes of the ordinary answer.

So a follow-up worth doing separately: the `catch (\Exception)` should not collapse an undefined-method error into a valid return value. Narrowing it to the database exceptions it is actually there to absorb (and letting `\Error` / `\TypeError` propagate) would have turned this into a loud failure on the first NC34 run instead of a silent zero. Kept out of this PR deliberately — it changes behaviour for other callers and deserves its own review.
