### PR TITLE
fix(db): wire RegisterMapper's logger, which was never injected

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -750,7 +750,12 @@ class Application extends App implements IBootstrap {
 					organisationMapper: $container->get(OrganisationMapper::class),
 					userSession: $container->get('OCP\IUserSession'),
 					groupManager: $container->get('OCP\IGroupManager'),
-					appConfig: $container->get('OCP\IAppConfig')
+					appConfig: $container->get('OCP\IAppConfig'),
+					// Explicitly wired: this factory overrides autowiring, so an
+					// argument omitted here is never supplied at all. That is how
+					// RegisterMapper ran with four dead logging branches
+					// (openregister#2820).
+					logger: $container->get('Psr\Log\LoggerInterface')
 				);
 			}
 		);

--- a/lib/Db/RegisterMapper.php
+++ b/lib/Db/RegisterMapper.php
@@ -251,18 +251,22 @@ class RegisterMapper extends QBMapper {
 		}
 
 		// Log search attempt for debugging.
-		if (isset($this->logger) === true) {
-			$this->logger->info(
-				message: '[RegisterMapper] Searching for register',
-				context: [
-					'file' => __FILE__,
-					'line' => __LINE__,
-					'identifier' => $id,
-					'rbac' => $_rbac,
-					'multi' => $_multitenancy,
-				]
-			);
-		}
+		//
+		// The `isset($this->logger)` guard that used to wrap this (and the three
+		// below) is gone: it only ever existed because the property was never
+		// injected, and with the logger wired it is always true. phpstan says so
+		// outright — "Property ::$logger in isset() is not nullable nor
+		// uninitialized" — and a guard that cannot be false is not a guard.
+		$this->logger->info(
+			message: '[RegisterMapper] Searching for register',
+			context: [
+				'file' => __FILE__,
+				'line' => __LINE__,
+				'identifier' => $id,
+				'rbac' => $_rbac,
+				'multi' => $_multitenancy,
+			]
+		);
 
 		// Verify RBAC permission to read registers if RBAC is enabled.
 		if ($_rbac === true) {
@@ -304,29 +308,25 @@ class RegisterMapper extends QBMapper {
 		try {
 			$testResult = $this->findEntity(query: $qbBeforeFilter);
 			$existsBeforeFilter = true;
-			if (isset($this->logger) === true) {
-				$this->logger->debug(
-					message: '[RegisterMapper] Register exists before filters',
-					context: [
-						'file' => __FILE__,
-						'line' => __LINE__,
-						'identifier' => $id,
-						'registerId' => $testResult->getId(),
-						'organisation' => $testResult->getOrganisation(),
-					]
-				);
-			}
+			$this->logger->debug(
+				message: '[RegisterMapper] Register exists before filters',
+				context: [
+					'file' => __FILE__,
+					'line' => __LINE__,
+					'identifier' => $id,
+					'registerId' => $testResult->getId(),
+					'organisation' => $testResult->getOrganisation(),
+				]
+			);
 		} catch (\OCP\AppFramework\Db\DoesNotExistException|\OCP\AppFramework\Db\MultipleObjectsReturnedException $e) {
-			if (isset($this->logger) === true) {
-				$this->logger->warning(
-					message: '[RegisterMapper] Register does not exist (or is duplicated) before filters',
-					context: [
-						'file' => __FILE__,
-						'line' => __LINE__,
-						'identifier' => $id,
-					]
-				);
-			}
+			$this->logger->warning(
+				message: '[RegisterMapper] Register does not exist (or is duplicated) before filters',
+				context: [
+					'file' => __FILE__,
+					'line' => __LINE__,
+					'identifier' => $id,
+				]
+			);
 		}//end try
 
 		// Apply organisation filter.
@@ -377,21 +377,21 @@ class RegisterMapper extends QBMapper {
 
 			return $register;
 		} catch (\OCP\AppFramework\Db\DoesNotExistException $e) {
-			// Log detailed error information.
-			if (isset($this->logger) === true) {
-				$this->logger->error(
-					message: '[RegisterMapper] Register not found after filters',
-					context: [
-						'file' => __FILE__,
-						'line' => __LINE__,
-						'identifier' => $id,
-						'existsBeforeFilter' => $existsBeforeFilter,
-						'multiEnabled' => $_multitenancy,
-						'rbacEnabled' => $_rbac,
-						'error' => $e->getMessage(),
-					]
-				);
-			}
+			// Log detailed error information. `existsBeforeFilter` is the whole
+			// point: it separates "no such row" from "the row matched and then a
+			// filter removed it" — a bad identifier versus a scoping bug.
+			$this->logger->error(
+				message: '[RegisterMapper] Register not found after filters',
+				context: [
+					'file' => __FILE__,
+					'line' => __LINE__,
+					'identifier' => $id,
+					'existsBeforeFilter' => $existsBeforeFilter,
+					'multiEnabled' => $_multitenancy,
+					'rbacEnabled' => $_rbac,
+					'error' => $e->getMessage(),
+				]
+			);
 
 			throw $e;
 		}//end try

--- a/lib/Db/RegisterMapper.php
+++ b/lib/Db/RegisterMapper.php
@@ -35,6 +35,7 @@ use OCP\IAppConfig;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
 use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Uid\Uuid;
 
 /**
@@ -168,6 +169,21 @@ class RegisterMapper extends QBMapper {
 	 * @param IUserSession $userSession User session for current user context
 	 * @param IGroupManager $groupManager Group manager for RBAC checks
 	 * @param IAppConfig $appConfig App configuration for multitenancy settings
+	 * @param LoggerInterface $logger Structured logger for the resolution diagnostics.
+	 *
+	 * This class carried four `if (isset($this->logger))` logging sites, plus the
+	 * ones it inherits from {@see MultiTenancyTrait}, and never declared or
+	 * received a logger — the trait's own docblock says "classes should define
+	 * this property themselves" and this one did not. `isset()` on an
+	 * undeclared property is always false, so every one of those branches was
+	 * dead code that read as working instrumentation.
+	 *
+	 * The cost was concrete: find() answers `DoesNotExistException` for a
+	 * register whose row exists, the endpoint turns that into
+	 * "Register not found: '19'", and the error-level line that would have said
+	 * WHY — "Register not found after filters", carrying `existsBeforeFilter`,
+	 * i.e. "the row matched, then a filter removed it" — silently did not fire.
+	 * openregister#2820.
 	 *
 	 * @return void
 	 */
@@ -180,6 +196,7 @@ class RegisterMapper extends QBMapper {
 		IUserSession $userSession,
 		IGroupManager $groupManager,
 		IAppConfig $appConfig,
+		private readonly LoggerInterface $logger,
 	) {
 		// Initialize parent mapper with table name and entity class.
 		parent::__construct(db: $db, tableName: 'openregister_registers', entityClass: Register::class);

--- a/tests/Unit/Db/RegisterMapperDeterministicFindTest.php
+++ b/tests/Unit/Db/RegisterMapperDeterministicFindTest.php
@@ -35,6 +35,7 @@ use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Env churn can leave several `openregister_registers` rows sharing a slug.
@@ -79,7 +80,8 @@ class RegisterMapperDeterministicFindTest extends TestCase {
 			$this->createMock(OrganisationMapper::class),
 			$this->createMock(IUserSession::class),
 			$this->createMock(IGroupManager::class),
-			$this->createMock(IAppConfig::class)
+			$this->createMock(IAppConfig::class),
+			$this->createMock(LoggerInterface::class)
 		);
 	}//end setUp()
 

--- a/tests/Unit/Db/RegisterMapperDiagnosticsTest.php
+++ b/tests/Unit/Db/RegisterMapperDiagnosticsTest.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * RegisterMapper resolution diagnostics.
+ *
+ * openregister#2820. RegisterMapper carried four `if (isset($this->logger))`
+ * logging sites — plus the ones it inherits from MultiTenancyTrait — and never
+ * declared or received a logger. `isset()` on an undeclared property is always
+ * false, so every one of those branches was dead code that read as working
+ * instrumentation.
+ *
+ * It mattered: find() answers DoesNotExistException for a register whose row
+ * exists, the objects endpoint turns that into `Register not found: '19'`, and
+ * the error-level line that would have said WHY — "Register not found after
+ * filters", carrying `existsBeforeFilter`, i.e. "the row matched, then a filter
+ * removed it" — silently did not fire. Diagnosing it took a database session
+ * and a code read that the log line alone would have settled.
+ *
+ * These tests assert the diagnostics actually emit. Without them the fix is
+ * only a moved dependency: the branches would still never run and nothing would
+ * fail.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Db
+ * @author   Conduction Development Team <dev@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://OpenRegister.app
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Db;
+
+use OCA\OpenRegister\Db\OrganisationMapper;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\DB\IResult;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
+use OCP\DB\QueryBuilder\IFunctionBuilder;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\DB\QueryBuilder\IQueryFunction;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IAppConfig;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Proves the resolution diagnostics are wired and fire.
+ */
+class RegisterMapperDiagnosticsTest extends TestCase {
+	/** @var IDBConnection&MockObject */
+	private IDBConnection $db;
+
+	/** @var LoggerInterface&MockObject */
+	private LoggerInterface $logger;
+
+	/** @var array<int,array{level:string,message:string,context:array}> */
+	private array $logged = [];
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->db = $this->createMock(IDBConnection::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		foreach (['info', 'debug', 'warning', 'error'] as $level) {
+			$this->logger->method($level)->willReturnCallback(
+				function (string $message, array $context = []) use ($level): void {
+					$this->logged[] = ['level' => $level, 'message' => $message, 'context' => $context];
+				}
+			);
+		}
+	}
+
+	/**
+	 * Build the mapper over a query builder that finds nothing.
+	 *
+	 * @return RegisterMapper the mapper under test
+	 */
+	private function mapperFindingNothing(): RegisterMapper {
+		$this->db->method('getQueryBuilder')->willReturnCallback(fn () => $this->emptyQueryBuilder());
+
+		return new RegisterMapper(
+			$this->db,
+			$this->createMock(SchemaMapper::class),
+			$this->createMock(IEventDispatcher::class),
+			$this->createMock(ContainerInterface::class),
+			$this->createMock(OrganisationMapper::class),
+			$this->createMock(IUserSession::class),
+			$this->createMock(IGroupManager::class),
+			$this->createMock(IAppConfig::class),
+			$this->logger
+		);
+	}
+
+	/**
+	 * A query builder whose every execution yields zero rows.
+	 *
+	 * @return IQueryBuilder&MockObject the mocked builder
+	 */
+	private function emptyQueryBuilder(): IQueryBuilder {
+		$expr = $this->createMock(IExpressionBuilder::class);
+		$expr->method('orX')->willReturnCallback(
+			function () {
+				$comp = $this->createMock(\OCP\DB\QueryBuilder\ICompositeExpression::class);
+				$comp->method('add')->willReturnSelf();
+				return $comp;
+			}
+		);
+		$expr->method('eq')->willReturn('eq');
+
+		$func = $this->createMock(IFunctionBuilder::class);
+		$func->method('lower')->willReturn($this->createMock(IQueryFunction::class));
+
+		$qb = $this->createMock(IQueryBuilder::class);
+		$qb->method('expr')->willReturn($expr);
+		$qb->method('func')->willReturn($func);
+		$qb->method('createNamedParameter')->willReturn('p');
+		foreach (['select', 'from', 'where', 'andWhere', 'orderBy', 'setMaxResults'] as $chain) {
+			$qb->method($chain)->willReturnSelf();
+		}
+
+		$qb->method('executeQuery')->willReturnCallback(
+			function (): IResult {
+				$result = $this->createMock(IResult::class);
+				$result->method('fetch')->willReturn(false);
+				$result->method('closeCursor')->willReturn(true);
+				return $result;
+			}
+		);
+
+		return $qb;
+	}
+
+	/**
+	 * Messages logged at a given level.
+	 *
+	 * @param string $level the psr-3 level
+	 *
+	 * @return string[] the messages
+	 */
+	private function messagesAt(string $level): array {
+		$out = [];
+		foreach ($this->logged as $entry) {
+			if ($entry['level'] === $level) {
+				$out[] = $entry['message'];
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * The lookup attempt is announced, so a failing resolve can be traced.
+	 *
+	 * @return void
+	 */
+	public function testTheSearchAttemptIsLogged(): void {
+		$mapper = $this->mapperFindingNothing();
+
+		try {
+			$mapper->find(id: '19', _rbac: false, _multitenancy: false);
+		} catch (DoesNotExistException) {
+			// The miss is the point; the logging is what is under test.
+		}
+
+		$this->assertNotSame(
+			[],
+			$this->logged,
+			'RegisterMapper emitted nothing at all — the logger is not wired.'
+		);
+		$this->assertStringContainsString(
+			'Searching for register',
+			implode(' | ', $this->messagesAt('info'))
+		);
+	}
+
+	/**
+	 * The miss is reported at error level WITH `existsBeforeFilter`.
+	 *
+	 * That flag is the whole diagnostic: it distinguishes "no such row" from
+	 * "the row matched and then a filter removed it", which is the difference
+	 * between a bad identifier and a scoping bug. #2820 was the second, and
+	 * presented as the first.
+	 *
+	 * @return void
+	 */
+	public function testTheMissIsReportedWithWhetherTheRowExistedBeforeFilters(): void {
+		$mapper = $this->mapperFindingNothing();
+
+		try {
+			$mapper->find(id: '19', _rbac: false, _multitenancy: false);
+			$this->fail('expected the lookup to miss');
+		} catch (DoesNotExistException) {
+			// Expected.
+		}
+
+		$errors = [];
+		foreach ($this->logged as $entry) {
+			if ($entry['level'] === 'error') {
+				$errors[] = $entry;
+			}
+		}
+
+		$this->assertNotSame([], $errors, 'the not-found diagnostic did not fire');
+
+		$found = null;
+		foreach ($errors as $entry) {
+			if (str_contains($entry['message'], 'Register not found after filters') === true) {
+				$found = $entry;
+			}
+		}
+
+		$this->assertNotNull($found, 'the "after filters" diagnostic did not fire');
+		$this->assertArrayHasKey(
+			'existsBeforeFilter',
+			$found['context'],
+			'the diagnostic must say whether the row existed before filtering'
+		);
+		$this->assertSame('19', (string)($found['context']['identifier'] ?? ''));
+	}
+}

--- a/tests/Unit/Db/RegisterMapperTest.php
+++ b/tests/Unit/Db/RegisterMapperTest.php
@@ -13,6 +13,7 @@ use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Unit tests for RegisterMapper
@@ -31,6 +32,7 @@ class RegisterMapperTest extends TestCase {
 	private IUserSession&MockObject $userSession;
 	private IGroupManager&MockObject $groupManager;
 	private IAppConfig&MockObject $appConfig;
+	private LoggerInterface&MockObject $logger;
 	private RegisterMapper $mapper;
 
 	protected function setUp(): void {
@@ -42,6 +44,7 @@ class RegisterMapperTest extends TestCase {
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 
 		$this->mapper = new RegisterMapper(
 			$this->db,
@@ -51,7 +54,8 @@ class RegisterMapperTest extends TestCase {
 			$this->organisationMapper,
 			$this->userSession,
 			$this->groupManager,
-			$this->appConfig
+			$this->appConfig,
+			$this->logger
 		);
 	}
 

--- a/tests/Unit/Db/RegisterSchemaRbacTest.php
+++ b/tests/Unit/Db/RegisterSchemaRbacTest.php
@@ -93,6 +93,7 @@ class RegisterSchemaRbacTest extends TestCase {
 					$this->userSession,
 					$this->groupManager,
 					$this->appConfig,
+					$this->logger,
 				]
 			)
 			->getMock();


### PR DESCRIPTION
fix(db): wire RegisterMapper's logger, which was never injected

`RegisterMapper` carries four logging call sites — an `info` on every lookup, a
`debug` and a `warning` around the pre-filter existence probe, and an `error`
for the miss — each guarded by `if (isset($this->logger))`. It also inherits
more from `MultiTenancyTrait`, whose docblock says outright: *"The trait does
not declare the $appConfig and $logger properties... Classes should define this
property themselves if needed."*

`RegisterMapper` never did. `logger` is not a constructor parameter, not a
declared property, and never assigned, so `isset()` is always false and **every
one of those branches is dead code that reads as working instrumentation.**

`Application.php` registers the mapper through an explicit `registerService`
factory, which overrides autowiring — so an argument omitted there is never
supplied at all, and nothing complains. That is why this survived.

## Why it matters

While diagnosing #2820 — `GET /api/objects/{register}/{schema}` answering
`Register not found: '19'` for 14 of 16 registers whose rows are intact — the
one instrument that would have answered it immediately is the dead `error`
branch:

```
[RegisterMapper] Register not found after filters
  identifier: 19, existsBeforeFilter: true, multiEnabled: false, rbacEnabled: false
```

`existsBeforeFilter` is the whole diagnostic: it separates *"no such row"* from
*"the row matched and then a filter removed it"* — a bad identifier versus a
scoping bug. #2820 is the second and presents as the first. Instead of one log
line it took a psql session, a column-type check and a code read, and I still
posted a wrong inference from the silence before catching it.

## The change

`private readonly LoggerInterface $logger` on the constructor, matching
`SchemaMapper`'s existing shape, plus the argument in the DI factory with a note
about why an omission there is invisible.

`RegisterMapperDiagnosticsTest` asserts the diagnostics actually emit — that the
search attempt is logged, and that the miss is reported at error level **with**
`existsBeforeFilter` and the identifier. Without those, this would only be a
moved dependency: the branches would still never run and nothing would fail.
Mutation-checked — removing the constructor argument again fails both tests
with "the not-found diagnostic did not fire".

Three existing test classes construct the mapper directly and now pass the
logger; `RegisterSchemaRbacTest` already had a suitable mock for `SchemaMapper`.

1,455 `tests/Unit/Db` tests pass, except 5 `ChunkMapperLiveQueryTest` cases that
need a real database and fail identically on unmodified `development` here.
phpcs, phpmd and phpstan clean on both changed lib files.

Refs #2820
