### PR TITLE
fix(keepiq): the credential-store probe named a namespace that no longer exists

### DIFF
--- a/lib/Service/Credential/CredentialStoreResolver.php
+++ b/lib/Service/Credential/CredentialStoreResolver.php
@@ -57,23 +57,45 @@ class CredentialStoreResolver {
 	public const DORIATH_APP_ID = 'doriath';
 
 	/**
-	 * Doriath service classes the leaf calls — ALL must exist for eligibility.
+	 * Credential-app namespaces to probe, NEWEST FIRST.
+	 *
+	 * The credential app renamed from OCA\Doriath to OCA\Keepiq with no
+	 * compatibility alias, and this resolver named only the old one — so every
+	 * probe missed and the credential store silently read as unavailable.
+	 * Nothing reported it, because "all four classes absent" is exactly what an
+	 * uninstalled optional app looks like, which is the case these probes exist
+	 * for. Measured on a running instance: every OCA\Keepiq\Service\* class
+	 * EXISTS while every OCA\Doriath\Service\* class is MISSING.
+	 *
+	 * A NAMESPACE rather than a flat class list, because eligibility requires
+	 * ALL FOUR services — a half-resolved set spanning both spellings would be
+	 * a store that exists on paper and fails on the first call.
 	 *
 	 * @var array<int, string>
 	 */
-	private const DORIATH_SERVICE_CLASSES = [
-		'OCA\\Doriath\\Service\\ApplicationService',
-		'OCA\\Doriath\\Service\\SecretService',
-		'OCA\\Doriath\\Service\\EncryptService',
-		'OCA\\Doriath\\Service\\DecryptService',
+	private const CREDENTIAL_APP_NAMESPACES = [
+		'OCA\\Keepiq\\Service\\',
+		'OCA\\Doriath\\Service\\',
 	];
 
 	/**
-	 * The Doriath service class carrying the application-scoped seam methods.
+	 * Service class names the leaf calls — ALL must exist for eligibility.
+	 *
+	 * @var array<int, string>
+	 */
+	private const SERVICE_NAMES = [
+		'ApplicationService',
+		'SecretService',
+		'EncryptService',
+		'DecryptService',
+	];
+
+	/**
+	 * The service carrying the application-scoped seam methods.
 	 *
 	 * @var string
 	 */
-	private const SECRET_SERVICE_CLASS = 'OCA\\Doriath\\Service\\SecretService';
+	private const SECRET_SERVICE_NAME = 'SecretService';
 
 	/**
 	 * Application-scoped seam methods that must exist on the secret service.
@@ -192,8 +214,51 @@ class CredentialStoreResolver {
 	 * @spec openspec/specs/credential-broker/spec.md
 	 */
 	protected function doriathServiceClasses(): array {
-		return self::DORIATH_SERVICE_CLASSES;
+		return $this->classesForNamespace(namespace: $this->resolveNamespace());
 	}//end doriathServiceClasses()
+
+	/**
+	 * The credential-app namespace whose FULL service set is installed.
+	 *
+	 * Falls back to the FIRST candidate when none resolves, so the caller still
+	 * gets a coherent set of names to report as missing rather than an empty
+	 * list that would read as "nothing required".
+	 *
+	 * @return string The namespace prefix.
+	 */
+	private function resolveNamespace(): string {
+		foreach (self::CREDENTIAL_APP_NAMESPACES as $namespace) {
+			$complete = true;
+			foreach (self::SERVICE_NAMES as $name) {
+				if (class_exists($namespace . $name) === false) {
+					$complete = false;
+					break;
+				}
+			}
+
+			if ($complete === true) {
+				return $namespace;
+			}
+		}
+
+		return self::CREDENTIAL_APP_NAMESPACES[0];
+	}//end resolveNamespace()
+
+	/**
+	 * The four service FQCNs under one namespace.
+	 *
+	 * @param string $namespace The namespace prefix.
+	 *
+	 * @return array<int, string> The FQCNs.
+	 */
+	private function classesForNamespace(string $namespace): array {
+		$classes = [];
+		foreach (self::SERVICE_NAMES as $name) {
+			$classes[] = $namespace . $name;
+		}
+
+		return $classes;
+	}//end classesForNamespace()
 
 	/**
 	 * The secret-service class probed for the application-scoped seam methods.
@@ -205,6 +270,6 @@ class CredentialStoreResolver {
 	 * @spec openspec/specs/credential-broker/spec.md
 	 */
 	protected function secretServiceClass(): string {
-		return self::SECRET_SERVICE_CLASS;
+		return $this->resolveNamespace() . self::SECRET_SERVICE_NAME;
 	}//end secretServiceClass()
 }//end class

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -168,3 +168,24 @@ parameters:
             message: '#Parameter \#2 \$params of method OCP\\IDBConnection::executeQuery\(\) expects array<string>#'
             identifier: argument.type
             path: lib/Service/Vectorization/Handlers/VectorSearchHandler.php
+
+        # CredentialStoreResolver probes the credential app's service classes by
+        # name, under BOTH namespaces it has shipped (OCA\Keepiq, formerly
+        # OCA\Doriath). Neither is on this app's analysis path — that is the
+        # point of probing them as strings — so PHPStan proves class_exists()
+        # always false and reports the probe as dead code.
+        #
+        # At runtime the app is installed and the classes resolve; measured on a
+        # running instance, every OCA\Keepiq\Service\* class EXISTS. The list
+        # spans both spellings BECAUSE pinning one is what broke this: the app
+        # renamed without an alias and the credential store silently read as
+        # unavailable.
+        #
+        # An ignore rather than stubs: this app's tests override the protected
+        # probe accessors to point at contract fixtures, so there are no stub
+        # classes to scan. Scoped to the one file — an impossible class_exists
+        # anywhere else is still a real finding.
+        -
+            message: '#Call to function class_exists\(\) with .OCA..Doriath..Service…...OCA..Keepiq..Service…. will always evaluate to false#'
+            identifier: function.impossibleType
+            path: lib/Service/Credential/CredentialStoreResolver.php

--- a/tests/Unit/Service/Credential/CredentialStoreResolverTest.php
+++ b/tests/Unit/Service/Credential/CredentialStoreResolverTest.php
@@ -118,6 +118,123 @@ class CredentialStoreResolverTest extends TestCase {
 		$this->assertSame($this->vaultStore, $resolver->resolve());
 	}
 
+
+	/**
+	 * The probed class list never mixes namespaces.
+	 *
+	 * This is the invariant the namespace resolution exists for. Eligibility
+	 * requires ALL FOUR services, so a per-class fallback could assemble a set
+	 * spanning both spellings — a credential store that exists on paper and
+	 * fails on the first call. The set must come from ONE namespace.
+	 */
+	public function testProbedClassesAllShareOneNamespace(): void {
+		$resolver = new CredentialStoreResolver(
+			$this->createMock(IAppManager::class),
+			$this->createMock(IAppConfig::class),
+			$this->doriathStore,
+			$this->vaultStore,
+			$this->createMock(LoggerInterface::class),
+		);
+
+		$classes = $this->readProbedClasses($resolver);
+
+		$this->assertCount(4, $classes);
+		$namespaces = array_unique(
+			array_map(static fn (string $fqcn): string => substr($fqcn, 0, (int)strrpos($fqcn, '\\')), $classes)
+		);
+		$this->assertCount(1, $namespaces, 'A half-resolved set spanning both spellings would fail on first use.');
+	}
+
+	/**
+	 * The secret-service probe uses the SAME namespace as the class list.
+	 *
+	 * Aimed at a different namespace, the seam-method probe would be asking
+	 * about a class the eligibility check never approved.
+	 */
+	public function testSecretServiceShareTheResolvedNamespace(): void {
+		$resolver = new CredentialStoreResolver(
+			$this->createMock(IAppManager::class),
+			$this->createMock(IAppConfig::class),
+			$this->doriathStore,
+			$this->vaultStore,
+			$this->createMock(LoggerInterface::class),
+		);
+
+		$classes = $this->readProbedClasses($resolver);
+		$secret = $this->readSecretServiceClass($resolver);
+
+		$this->assertContains($secret, $classes);
+	}
+
+	/**
+	 * The resolved namespace is one of the declared candidates, newest first.
+	 *
+	 * The unit runtime loads DoriathStubs.php, which defines a COMPLETE
+	 * `OCA\Doriath\Service\*` set — so the resolver legitimately selects it here,
+	 * and that is the behaviour under test: pick the first candidate whose whole
+	 * set is present. What must hold regardless of which app is installed is
+	 * that the choice comes from the declared list and that the current
+	 * namespace is tried BEFORE the legacy one.
+	 */
+	public function testTheResolvedNamespaceComesFromTheDeclaredCandidates(): void {
+		$resolver = new CredentialStoreResolver(
+			$this->createMock(IAppManager::class),
+			$this->createMock(IAppConfig::class),
+			$this->doriathStore,
+			$this->vaultStore,
+			$this->createMock(LoggerInterface::class),
+		);
+
+		// getReflectionConstant(), not getConstant(): the candidate list is
+		// PRIVATE, and getConstant() answers null for a private constant — a null
+		// that reads exactly like "the constant does not exist".
+		$constant = (new \ReflectionClass(CredentialStoreResolver::class))
+			->getReflectionConstant('CREDENTIAL_APP_NAMESPACES');
+		$this->assertNotFalse($constant, 'CREDENTIAL_APP_NAMESPACES must exist.');
+		$candidates = $constant->getValue();
+
+		$this->assertStringContainsString('Keepiq', $candidates[0], 'The current namespace must be tried first.');
+		$this->assertStringContainsString('Doriath', implode(' ', $candidates), 'The legacy namespace must stay listed.');
+
+		$chosen = $this->readProbedClasses($resolver)[0];
+		$this->assertTrue(
+			array_reduce(
+				$candidates,
+				static fn (bool $carry, string $ns): bool => ($carry || str_starts_with($chosen, $ns)),
+				false
+			),
+			'The resolved namespace must be one of the declared candidates, not an invented one.'
+		);
+	}
+
+	/**
+	 * Read the protected class-list accessor.
+	 *
+	 * @param CredentialStoreResolver $resolver The resolver.
+	 *
+	 * @return array<int, string> The probed FQCNs.
+	 */
+	private function readProbedClasses(CredentialStoreResolver $resolver): array {
+		$method = new \ReflectionMethod($resolver, 'doriathServiceClasses');
+		$method->setAccessible(true);
+
+		return $method->invoke($resolver);
+	}
+
+	/**
+	 * Read the protected secret-service accessor.
+	 *
+	 * @param CredentialStoreResolver $resolver The resolver.
+	 *
+	 * @return string The probed FQCN.
+	 */
+	private function readSecretServiceClass(CredentialStoreResolver $resolver): string {
+		$method = new \ReflectionMethod($resolver, 'secretServiceClass');
+		$method->setAccessible(true);
+
+		return $method->invoke($resolver);
+	}
+
 	/**
 	 * Build a resolver whose class probes point at the test fixtures.
 	 *


### PR DESCRIPTION
`CredentialStoreResolver` probed four `OCA\Doriath\Service\*` classes and required **all** of them for eligibility. The credential app renamed to `OCA\Keepiq` **with no compatibility alias**, so every probe missed and the brokered credential store silently read as unavailable.

**Nothing reported it.** "All four classes absent" is exactly what an uninstalled optional app looks like — the case these probes exist for — so the integration going dead is indistinguishable from it never having been set up.

Measured on a running instance:

```
OCA\Doriath\Service\ApplicationService   MISSING    OCA\Keepiq\Service\ApplicationService   EXISTS
OCA\Doriath\Service\SecretService        MISSING    OCA\Keepiq\Service\SecretService        EXISTS
```

## Why by namespace, not by class

Eligibility requires **all four** services. A per-class fallback could resolve a half-set spanning both spellings — a store that exists on paper and fails on the first call.

`resolveNamespace()` accepts a namespace only when its **complete** set is present, newest first, and falls back to the first candidate so the caller still reports a coherent set of missing names rather than an empty list that would read as *"nothing required"*.

`secretServiceClass()` follows the same resolution, so the seam-method probe can never be aimed at a different namespace than the eligibility check.

## Fleet context

Found by a sweep after the same defect was confirmed in dossiq. Four apps carried it, each fixed in its own repo:

| App | Stale reference | Effect |
|---|---|---|
| dossiq | `OCA\Decidesk\Event\*` | listener never registered; ZGW Besluit stopped materialising |
| stackiq | `OCA\Decidesk\Event\*` | contract approvals stopped delegating |
| **openregister** (this) | `OCA\Doriath\Service\*` | brokered credential store read as unavailable |
| decidiq | `OCA\Docudesk\Service\*` | PDF delegation silently fell back |

## Verification

- suite **17178** green · phpcs 0 errors · phpstan clean on the touched file
- the 5 phpstan errors this repo reports are pre-existing and in files this PR does not touch (`BulkSaveOutcome`, `FlowRunService`, `SharedSchemaDedupeService`)
- committed with `git commit -o <path>` — this checkout also held another session's in-flight flow work, which is untouched and was left on its own branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)