### PR TITLE
fix(spec): pdf-anonymisation required a composer repository entry that isn't there

### DIFF
--- a/openspec/specs/pdf-anonymisation/spec.md
+++ b/openspec/specs/pdf-anonymisation/spec.md
@@ -217,15 +217,16 @@ The dispatch in `anonymizeDocument` for DOCX, ODT, and plain-text inputs MUST be
 - **WHEN** the same ODT is processed on the post-change code path
 - **THEN** the output is semantically identical to the pre-change output
 
-### Requirement: Composer dependency on `Conduction/sapp` MUST be explicit and tracked
+### Requirement: Composer dependency on `ConductionNL/sapp` MUST be explicit and tracked
 
-The `composer.json` repository entry pointing at `Conduction/sapp` MUST be visible in the dependency manifest and called out in `CHANGELOG.md` under `### Dependencies` (or equivalent). When upstream `dealfonso/sapp` merges the work, the repositories entry is removed and the version constraint switches to a normal range; the spec describes this transition explicitly so future maintainers know the fork dependency is provisional, not permanent.
+The `composer.json` repository entry pointing at `ConductionNL/sapp` MUST be visible in the dependency manifest and called out in `CHANGELOG.md` under `### Dependencies` (or equivalent). When upstream `dealfonso/sapp` merges the work, the repositories entry is removed and the version constraint switches to a normal range; the spec describes this transition explicitly so future maintainers know the fork dependency is provisional, not permanent.
 
 #### Scenario: Composer manifest carries the fork repository
 
 - **GIVEN** the `pdf-anonymisation` change has shipped
 - **WHEN** a maintainer reads `composer.json`
-- **THEN** they see a `repositories` entry for `https://codeberg.org/Conduction/sapp`
-- **AND** the `ddn/sapp` constraint resolves to a `work/text-replacement`-branch dev-version
+- **THEN** they see a `repositories` entry for `https://github.com/ConductionNL/sapp`
+- **AND** the `ddn/sapp` constraint resolves to a commit-pinned dev-version of the fork branch
+  carrying the chained filter / text-replacement work
 - **AND** the CHANGELOG entry documents the fork dependency + the upstream PR series tracking it
 


### PR DESCRIPTION
A **live** spec requirement asserted something false about the shipped code.

`openspec/specs/pdf-anonymisation/spec.md`, scenario *"Composer manifest carries the fork repository"*:

> **THEN** they see a `repositories` entry for `https://codeberg.org/Conduction/sapp`

`composer.json` on `development` actually says:

```json
{ "type": "vcs", "url": "https://github.com/ConductionNL/sapp" }
```

### Two facts were stale, not one

The same scenario also required the `ddn/sapp` constraint to resolve to a **`work/text-replacement`**-branch dev-version. The real constraint is:

```json
"ddn/sapp": "dev-feat/chained-filter-text-replace#5c406e91254d6936f44372db35f1cc15e5a06c56"
```

Different branch, and commit-pinned.

### Why the replacement is worded loosely

The new wording says the constraint must be *"a commit-pinned dev-version of the fork branch carrying the chained filter / text-replacement work"* rather than naming a branch and sha. Naming an exact sha would re-break on the next bump — a requirement that goes stale silently is precisely how this one ended up asserting a dead host.

The requirement heading and body also still said `Conduction/sapp`; the org is `ConductionNL`.

### Scope

This is the one **live** spec left holding a `codeberg.org` URL in openregister. The other remaining hits are all under `openspec/changes/archive/**` — historical records, deliberately untouched.

Verified against `origin/development`'s `composer.json` rather than from memory.