### PR TITLE
feat(aggregation): composite groupBy in the validator + a join clause

### DIFF
--- a/lib/Service/Aggregation/AggregationAnnotationValidator.php
+++ b/lib/Service/Aggregation/AggregationAnnotationValidator.php
@@ -33,11 +33,14 @@ namespace OCA\OpenRegister\Service\Aggregation;
  * Each aggregation maps a name → spec object.  Two DSL variants are supported:
  *
  * Intra-schema (legacy + new alias):
- *   { metric|select, field?, filter|where?, groupBy? }
+ *   { metric|select, field?, filter|where?, groupBy?, join? }
  *   - `metric`/`select` MUST be one of count|sum|avg|min|max|count_distinct.
  *   - `field` is REQUIRED for sum|avg|min|max|count_distinct, MUST exist on the schema.
- *   - `groupBy.field` (when present) MUST exist on the schema.
+ *   - `groupBy` (when present) MUST name only declared schema properties. Three
+ *     interchangeable spellings are accepted — see below.
  *   - `filter`/`where` is a flat map of field → value-or-operator-shape.
+ *   - `join` (when present) attaches aggregates from a SECOND schema to each
+ *     group — see {@see validateJoinSpec()}.
  *
  * Cross-schema (new):
  *   { from, metric|select?, field?, where|filter?, groupBy? }
@@ -46,12 +49,40 @@ namespace OCA\OpenRegister\Service\Aggregation;
  *   - `where`/`filter` values may contain `@self.<field>` parent-references.
  *   - Field existence is **not** validated against the host schema's properties
  *     (the target schema is not available at annotation-save time).
+ *
+ * groupBy spellings (all three normalise to the SAME ordered field list via
+ * {@see AggregationQuery::normaliseGroupByFields()}, which is the one
+ * canonicaliser the RUNNER also uses — validator and executor MUST NOT own
+ * separate copies of this grammar or they drift and a spec accepted at save
+ * time silently groups on something else at run time):
+ *   - single-field object: `{ "field": "status" }`         (legacy, still live)
+ *   - multi-field object:  `{ "fields": ["a", "b"] }`
+ *   - plain ordered list:  `[ "a", "b" ]`
  */
 final class AggregationAnnotationValidator {
 
 	private const VALID_METRICS = ['count', 'sum', 'avg', 'min', 'max', 'count_distinct'];
 
 	private const REQUIRES_FIELD = ['sum', 'avg', 'min', 'max', 'count_distinct'];
+
+	/**
+	 * The `join` clause grammar, kept in its own class so this one does not
+	 * accumulate a second DSL's worth of branching.
+	 *
+	 * @var AggregationJoinAnnotationValidator
+	 */
+	private AggregationJoinAnnotationValidator $joinValidator;
+
+	/**
+	 * Constructor.
+	 *
+	 * Plain `new` rather than injection: both classes are pure shape
+	 * validators with no collaborators, and the schema-save call sites
+	 * construct this validator directly.
+	 */
+	public function __construct() {
+		$this->joinValidator = new AggregationJoinAnnotationValidator();
+	}//end __construct()
 
 	/**
 	 * Validate the `x-openregister-aggregations` annotation on a schema.
@@ -187,28 +218,124 @@ final class AggregationAnnotationValidator {
 				}
 			}//end if
 
-			$groupBy = ($spec['groupBy'] ?? null);
-			if ($groupBy !== null) {
-				if (is_array($groupBy) === false || isset($groupBy['field']) === false) {
-					$errors[] = [
-						'code' => 'aggregation-groupby-malformed',
-						'message' => sprintf('Aggregation "%s" groupBy must be {field, bucket?}.', $name),
-					];
-				} elseif (in_array((string)$groupBy['field'], $propKeys, true) === false) {
-					$errors[] = [
-						'code' => 'aggregation-groupby-field-unknown',
-						'message' => sprintf(
-							'Aggregation "%s" groupBy.field "%s" is not declared in the schema properties.',
-							$name,
-							(string)$groupBy['field']
-						),
-					];
-				}
-			}
+			$errors = array_merge(
+				$errors,
+				$this->validateGroupBy(name: $name, spec: $spec, propKeys: $propKeys)
+			);
+
+			$errors = array_merge(
+				$errors,
+				$this->joinValidator->validate(name: $name, spec: $spec, propKeys: $propKeys)
+			);
 		}//end foreach
 
 		return $errors;
 	}//end validate()
+
+	/**
+	 * Validate the `groupBy` clause of an intra-schema aggregation spec.
+	 *
+	 * Accepts all three spellings the runner accepts — `{field}`,
+	 * `{fields: [...]}` and a plain ordered list — by delegating the shape
+	 * question to {@see AggregationQuery::normaliseGroupByFields()}, the
+	 * SAME canonicaliser {@see AggregationRunner::resolveGroupFields()}
+	 * uses. Sharing the canonicaliser is deliberate: a validator that owns
+	 * its own copy of the grammar accepts specs the executor then reads
+	 * differently, and the disagreement is silent in both directions.
+	 *
+	 * Every named field MUST be a declared schema property — the same check
+	 * the single-field form has always applied, now applied per member so a
+	 * composite groupBy cannot smuggle in an undeclared column.
+	 *
+	 * @param string $name Aggregation name (for error messages).
+	 * @param array<string, mixed> $spec The raw spec object.
+	 * @param array<int, mixed> $propKeys Declared schema property names.
+	 *
+	 * @return array<int, array{code: string, message: string}> Error list (empty = valid).
+	 *
+	 * @SuppressWarnings(PHPMD.StaticAccess)
+	 *   AggregationQuery::normaliseGroupByFields() is deliberately the ONE
+	 *   canonicaliser shared by this validator, AggregationQuery and
+	 *   AggregationRunner. Injecting it to satisfy the rule would invite a
+	 *   second implementation, which is exactly the drift this sharing
+	 *   prevents — an accepted-but-differently-executed groupBy is silent
+	 *   in both directions.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function validateGroupBy(string $name, array $spec, array $propKeys): array {
+		$groupBy = ($spec['groupBy'] ?? null);
+		if ($groupBy === null) {
+			return [];
+		}
+
+		if (is_array($groupBy) === false) {
+			return [
+				[
+					'code' => 'aggregation-groupby-malformed',
+					'message' => sprintf(
+						'Aggregation "%s" groupBy must be {field, bucket?}, {fields: [...]} or a list of field names.',
+						$name
+					),
+				],
+			];
+		}
+
+		$groupFields = AggregationQuery::normaliseGroupByFields(groupBy: $groupBy);
+		if (count($groupFields) === 0) {
+			return [
+				[
+					'code' => 'aggregation-groupby-malformed',
+					'message' => sprintf(
+						'Aggregation "%s" groupBy must be {field, bucket?}, {fields: [...]} or a list of field names.',
+						$name
+					),
+				],
+			];
+		}
+
+		$errors = [];
+		$seen = [];
+		foreach ($groupFields as $groupField) {
+			if (is_string($groupField) === false || $groupField === '') {
+				$errors[] = [
+					'code' => 'aggregation-groupby-malformed',
+					'message' => sprintf(
+						'Aggregation "%s" groupBy members must be non-empty field-name strings.',
+						$name
+					),
+				];
+				continue;
+			}
+
+			if (in_array($groupField, $seen, true) === true) {
+				$errors[] = [
+					'code' => 'aggregation-groupby-duplicate-field',
+					'message' => sprintf(
+						'Aggregation "%s" groupBy names "%s" more than once.',
+						$name,
+						$groupField
+					),
+				];
+				continue;
+			}
+
+			$seen[] = $groupField;
+
+			if (in_array($groupField, $propKeys, true) === false) {
+				$errors[] = [
+					'code' => 'aggregation-groupby-field-unknown',
+					'message' => sprintf(
+						'Aggregation "%s" groupBy.field "%s" is not declared in the schema properties.',
+						$name,
+						$groupField
+					),
+				];
+			}
+		}//end foreach
+
+		return $errors;
+	}//end validateGroupBy()
 
 	/**
 	 * Validate a cross-schema aggregation spec (`from` key present).
@@ -252,6 +379,21 @@ final class AggregationAnnotationValidator {
 			$errors[] = [
 				'code' => 'aggregation-filter-malformed',
 				'message' => sprintf('Cross-schema aggregation "%s" where/filter must be a map.', $name),
+			];
+		}
+
+		// `from` + `join` would name THREE schemas in one spec (host, `from`
+		// target, `join` target) with no declared relationship between the
+		// second and third. Refuse at save time rather than ship a spec the
+		// runner silently ignores half of: runCrossSchema() has no join
+		// stage, so a `join` written beside a `from` would never execute.
+		if (isset($spec['join']) === true) {
+			$errors[] = [
+				'code' => 'aggregation-join-with-from',
+				'message' => sprintf(
+					'Cross-schema aggregation "%s" must not combine `from` with `join` — join is intra-schema only.',
+					$name
+				),
 			];
 		}
 

--- a/lib/Service/Aggregation/AggregationJoinAnnotationValidator.php
+++ b/lib/Service/Aggregation/AggregationJoinAnnotationValidator.php
@@ -1,0 +1,297 @@
+<?php
+
+/**
+ * OpenRegister AggregationJoinAnnotationValidator
+ *
+ * Schema-save validation for the `join` clause of an entry in the
+ * `x-openregister-aggregations` annotation.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Aggregation
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/aggregation-api/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Aggregation;
+
+/**
+ * Validates the `join` clause of an aggregation spec.
+ *
+ * Shape:
+ *   "join": {
+ *     "through": "CommitmentBudget",                     // REQUIRED, joined schema ref
+ *     "on":      "CommitmentBudget.programmeCode",       // REQUIRED, string or map
+ *     "filter":  { },                                    // optional, map
+ *     "select":  ["CommitmentBudget.authorised_amount"]  // REQUIRED, non-empty list
+ *   }
+ *
+ * `on` accepts either an explicit `{parentField: joinedField}` map — the
+ * unambiguous spelling, and the only one that can express a COMPOSITE join
+ * key — or a single string. As a string it may be written `"Through.column"`
+ * or bare `"column"`; the JOINED side is always the column named, and the
+ * PARENT side is resolved by `AggregationRunner::resolveJoinKey()` — the
+ * same-named group field when one exists, otherwise the FIRST group field.
+ *
+ * DELIBERATELY NOT VALIDATED HERE: the existence of `through`, and the
+ * `on`/`select` columns on the JOINED side. The joined schema is not
+ * loadable at annotation-save time, exactly as for the cross-schema `from`
+ * target. Only the parent-side half of an explicit `on` map is checked
+ * against the host schema's declared properties.
+ *
+ * Lives in its own class rather than inside
+ * {@see AggregationAnnotationValidator} so the join grammar has one home and
+ * the host validator does not accumulate a second DSL's worth of branching.
+ */
+final class AggregationJoinAnnotationValidator {
+
+	/**
+	 * Validate the `join` clause of one aggregation spec.
+	 *
+	 * @param string $name Aggregation name (for error messages).
+	 * @param array<string, mixed> $spec The raw aggregation spec.
+	 * @param array<int, mixed> $propKeys Declared host-schema property names.
+	 *
+	 * @return array<int, array{code: string, message: string}> Error list (empty = valid).
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	public function validate(string $name, array $spec, array $propKeys): array {
+		$join = ($spec['join'] ?? null);
+		if ($join === null) {
+			return [];
+		}
+
+		if (is_array($join) === false || array_is_list($join) === true) {
+			return [
+				[
+					'code' => 'aggregation-join-malformed',
+					'message' => sprintf(
+						'Aggregation "%s" join must be an object {through, on, filter?, select}.',
+						$name
+					),
+				],
+			];
+		}
+
+		return array_merge(
+			$this->validateThrough(name: $name, join: $join),
+			$this->validateOn(name: $name, join: $join, propKeys: $propKeys),
+			$this->validateSelect(name: $name, join: $join),
+			$this->validateFilter(name: $name, join: $join),
+			$this->validateGroupByPresence(name: $name, spec: $spec)
+		);
+	}//end validate()
+
+	/**
+	 * The joined schema ref must be a non-empty string.
+	 *
+	 * @param string $name Aggregation name (for error messages).
+	 * @param array<string, mixed> $join The raw join spec.
+	 *
+	 * @return array<int, array{code: string, message: string}> Error list (empty = valid).
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function validateThrough(string $name, array $join): array {
+		$through = ($join['through'] ?? null);
+		if (is_string($through) === true && $through !== '') {
+			return [];
+		}
+
+		return [
+			[
+				'code' => 'aggregation-join-through-empty',
+				'message' => sprintf('Aggregation "%s" join must have a non-empty `through` schema ref.', $name),
+			],
+		];
+	}//end validateThrough()
+
+	/**
+	 * Validate the `on` clause — a "Schema.column" string, or a
+	 * `{parentField: joinedField}` map whose parent-side halves must be
+	 * declared host-schema properties.
+	 *
+	 * @param string $name Aggregation name (for error messages).
+	 * @param array<string, mixed> $join The raw join spec.
+	 * @param array<int, mixed> $propKeys Declared host-schema property names.
+	 *
+	 * @return array<int, array{code: string, message: string}> Error list (empty = valid).
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function validateOn(string $name, array $join, array $propKeys): array {
+		$onClause = ($join['on'] ?? null);
+
+		if (is_string($onClause) === true && $onClause !== '') {
+			return [];
+		}
+
+		if (is_array($onClause) === true && count($onClause) > 0 && array_is_list($onClause) === false) {
+			$errors = [];
+			foreach (array_keys($onClause) as $parentField) {
+				if (in_array((string)$parentField, $propKeys, true) === true) {
+					continue;
+				}
+
+				$errors[] = [
+					'code' => 'aggregation-join-on-field-unknown',
+					'message' => sprintf(
+						'Aggregation "%s" join.on parent field "%s" is not declared in the schema properties.',
+						$name,
+						(string)$parentField
+					),
+				];
+			}
+
+			return $errors;
+		}//end if
+
+		return [
+			[
+				'code' => 'aggregation-join-on-malformed',
+				'message' => sprintf(
+					'Aggregation "%s" join.on must be a "Schema.column" string or a {parentField: joinedField} map.',
+					$name
+				),
+			],
+		];
+	}//end validateOn()
+
+	/**
+	 * Validate the `select` list — non-empty, every entry a "Field" string
+	 * or a `{field, metric?}` object.
+	 *
+	 * @param string $name Aggregation name (for error messages).
+	 * @param array<string, mixed> $join The raw join spec.
+	 *
+	 * @return array<int, array{code: string, message: string}> Error list (empty = valid).
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function validateSelect(string $name, array $join): array {
+		$select = ($join['select'] ?? null);
+		if (is_array($select) === false || count($select) === 0) {
+			return [
+				[
+					'code' => 'aggregation-join-select-empty',
+					'message' => sprintf(
+						'Aggregation "%s" join must declare a non-empty `select` list of joined-schema fields.',
+						$name
+					),
+				],
+			];
+		}
+
+		$errors = [];
+		foreach ($select as $entry) {
+			if ($this->isUsableSelectEntry(entry: $entry) === true) {
+				continue;
+			}
+
+			$errors[] = [
+				'code' => 'aggregation-join-select-malformed',
+				'message' => sprintf(
+					'Aggregation "%s" join.select entries must be "Field" strings or {field, metric?} objects.',
+					$name
+				),
+			];
+		}
+
+		return $errors;
+	}//end validateSelect()
+
+	/**
+	 * Test whether one `select` entry carries a usable field reference.
+	 *
+	 * @param mixed $entry The raw select entry.
+	 *
+	 * @return bool True when the entry names a field.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function isUsableSelectEntry(mixed $entry): bool {
+		if (is_string($entry) === true && $entry !== '') {
+			return true;
+		}
+
+		if (is_array($entry) === false) {
+			return false;
+		}
+
+		return (isset($entry['field']) === true
+			&& is_string($entry['field']) === true
+			&& $entry['field'] !== '');
+	}//end isUsableSelectEntry()
+
+	/**
+	 * The joined-side filter must be a map when present.
+	 *
+	 * @param string $name Aggregation name (for error messages).
+	 * @param array<string, mixed> $join The raw join spec.
+	 *
+	 * @return array<int, array{code: string, message: string}> Error list (empty = valid).
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function validateFilter(string $name, array $join): array {
+		$filter = ($join['filter'] ?? $join['where'] ?? null);
+		if ($filter === null || is_array($filter) === true) {
+			return [];
+		}
+
+		return [
+			[
+				'code' => 'aggregation-join-filter-malformed',
+				'message' => sprintf('Aggregation "%s" join filter/where must be a map.', $name),
+			],
+		];
+	}//end validateFilter()
+
+	/**
+	 * A join attaches values PER GROUP; with no groupBy there is no group to
+	 * attach them to. Refused at save time rather than left to throw on
+	 * every call.
+	 *
+	 * @param string $name Aggregation name (for error messages).
+	 * @param array<string, mixed> $spec The raw aggregation spec.
+	 *
+	 * @return array<int, array{code: string, message: string}> Error list (empty = valid).
+	 *
+	 * @SuppressWarnings(PHPMD.StaticAccess)
+	 *   AggregationQuery::normaliseGroupByFields() is deliberately the ONE
+	 *   canonicaliser shared by this validator, AggregationQuery and
+	 *   AggregationRunner. Injecting it to satisfy the rule would invite a
+	 *   second implementation, which is the drift this sharing prevents.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function validateGroupByPresence(string $name, array $spec): array {
+		$groupFields = AggregationQuery::normaliseGroupByFields(groupBy: ($spec['groupBy'] ?? null));
+		if (count($groupFields) > 0) {
+			return [];
+		}
+
+		return [
+			[
+				'code' => 'aggregation-join-requires-groupby',
+				'message' => sprintf(
+					'Aggregation "%s" declares a join but no groupBy — joined values attach per group.',
+					$name
+				),
+			],
+		];
+	}//end validateGroupByPresence()
+}//end class

--- a/lib/Service/Aggregation/AggregationRunner.php
+++ b/lib/Service/Aggregation/AggregationRunner.php
@@ -96,6 +96,15 @@ class AggregationRunner {
 	private const PHP_FALLBACK_ROW_CAP = 10000;
 
 	/**
+	 * Metrics a `join.select` entry may reduce the joined column with.
+	 * Deliberately the same closed vocabulary the rest of the engine
+	 * accepts — a join is an aggregation over a second schema, not a new
+	 * metric surface. `count_distinct` has no native SQL translation and
+	 * bails the whole join to the PHP fallback (see aggregateJoinedSchema()).
+	 */
+	private const JOIN_SELECT_METRICS = ['count', 'sum', 'avg', 'min', 'max', 'count_distinct'];
+
+	/**
 	 * The shared register-scoped schema resolver.
 	 *
 	 * Built here rather than injected: it is a stateless collaborator over the
@@ -296,6 +305,14 @@ class AggregationRunner {
 			$groupByArg = $groupBy;
 		}
 
+		// Optional join spec — attaches aggregates from a SECOND schema to
+		// each group. See applyJoin().
+		$join = ($spec['join'] ?? null);
+		$joinArg = null;
+		if (is_array($join) === true) {
+			$joinArg = $join;
+		}
+
 		$resolvedFilter = $this->placeholders->resolveArray($filter);
 
 		// Cache lookup: the resolved filter (with placeholders concrete)
@@ -303,12 +320,19 @@ class AggregationRunner {
 		// SECURITY: cache key MUST include userId + active organisation —
 		// two callers with different RBAC verdicts on the same (metric,
 		// field, filter) tuple would otherwise read each other's results.
+		// It MUST equally include `groupBy` and `join`: those two keys
+		// change WHICH ROWS and WHICH SCHEMAS the result is computed from,
+		// so two specs differing only there are different aggregations and
+		// omitting either would serve one caller the other's numbers —
+		// including numbers sourced from a joined schema the second spec
+		// never asked for.
 		$activeOrg = $this->organisationService->getActiveOrganisation();
 		$cacheKey = [
 			'metric' => $metric,
 			'field' => $field,
 			'filter' => $resolvedFilter,
 			'groupBy' => $groupBy,
+			'join' => $join,
 			'userId' => $userId,
 			'org' => $activeOrg?->getUuid(),
 		];
@@ -364,6 +388,12 @@ class AggregationRunner {
 				'backend' => 'postgres',
 				'truncated' => false,
 			] + $native;
+			$result = $this->applyJoin(
+				envelope: $result,
+				join: $joinArg,
+				groupFields: $this->resolveGroupFields(groupBy: $groupBy),
+				bypassRbac: $bypassRbac
+			);
 			$this->cache->set(
 				registerSlug: (string)$register->getSlug(),
 				schemaSlug: (string)$schema->getSlug(),
@@ -435,6 +465,13 @@ class AggregationRunner {
 		if (isset($result['groups']) === false) {
 			$result['value'] = $this->computeMetric(rows: $rows, metric: $metric, field: $field);
 		}
+
+		$result = $this->applyJoin(
+			envelope: $result,
+			join: $joinArg,
+			groupFields: $runGroupFields,
+			bypassRbac: $bypassRbac
+		);
 
 		$this->cache->set(
 			registerSlug: (string)$register->getSlug(),
@@ -739,10 +776,10 @@ class AggregationRunner {
 	 * the negotiated display language.
 	 *
 	 * `GET /api/objects/aggregations/{register}/{schema}/grouped` groups on
-	 * a single field via SQL `GROUP BY` (native path) or PHP bucketing
-	 * (fallback). When that field is `translatable: true`, the stored value
-	 * is a language-keyed map (e.g. `{"nl":"Foo","en":"Bar"}`), so each
-	 * group `key` comes back as the raw map (native: a JSON string; PHP: an
+	 * one or more fields via SQL `GROUP BY` (native path) or PHP bucketing
+	 * (fallback). When a grouped field is `translatable: true`, the stored
+	 * value is a language-keyed map (e.g. `{"nl":"Foo","en":"Bar"}`), so the
+	 * group key comes back as the raw map (native: a JSON string; PHP: an
 	 * associative array) instead of the single projected string a normal
 	 * read returns.
 	 *
@@ -750,26 +787,39 @@ class AggregationRunner {
 	 * reusing {@see TranslationHandler::resolveTranslationsForRender()} for
 	 * the language chain / fallback logic rather than reimplementing it.
 	 *
+	 * Both group-row shapes are handled, and BOTH must be — a composite
+	 * groupBy emits `keys: {fieldA: ..., fieldB: ...}` and never a scalar
+	 * `key`, so a guard written for the single-field shape alone silently
+	 * skips projection for every multi-field aggregation and hands the
+	 * caller raw language maps:
+	 * - single-field: the scalar `key` is projected;
+	 * - multi-field: EVERY translatable member of the `keys` map is
+	 *   projected, each against its own field name; non-translatable
+	 *   members are left byte-for-byte unchanged.
+	 *
 	 * No-op when:
 	 * - the envelope carries no `groups`;
-	 * - there is no single scalar `groupBy.field`;
-	 * - the groupBy field is NOT translatable on the schema;
+	 * - the groupBy spec names no fields;
+	 * - NO grouped field is translatable on the schema;
 	 * - `?_translations=all` is requested (keys are returned verbatim).
 	 *
 	 * @param array<string, mixed> $envelope The aggregation result envelope.
 	 * @param Schema $schema The schema being aggregated.
 	 * @param Register $register The owning register (language config).
-	 * @param array<string, mixed>|null $groupBy The groupBy spec ({field: ...}).
+	 * @param array<string, mixed>|null $groupBy The groupBy spec — any accepted
+	 *                                           spelling ({field}, {fields: [...]},
+	 *                                           or a plain list).
 	 *
 	 * @return array<string, mixed> The envelope with translatable group keys projected.
 	 *
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 *   The method is a chain of cheap short-circuit guards (no groups /
-	 *   no groupBy field / not translatable / _translations=all) before
+	 *   no groupBy field / nothing translatable / _translations=all) before
 	 *   the projection loop; each guard adds a branch but keeps the hot
 	 *   path a single early return.
 	 *
 	 * @spec openspec/specs/object-lifecycle/spec.md
+	 * @spec openspec/specs/aggregation-api/spec.md
 	 */
 	private function projectTranslatableGroupKeys(
 		array $envelope,
@@ -781,17 +831,22 @@ class AggregationRunner {
 			return $envelope;
 		}
 
-		if ($groupBy === null || isset($groupBy['field']) === false) {
+		$groupFields = $this->resolveGroupFields(groupBy: $groupBy);
+		if (count($groupFields) === 0) {
 			return $envelope;
 		}
 
-		$groupField = (string)$groupBy['field'];
-
-		// Only project when the grouped field is actually translatable.
-		// getTranslatableProperties() is cheap and this keeps NON-translatable
-		// grouped fields byte-for-byte unchanged.
+		// Only project when at least one grouped field is actually
+		// translatable. getTranslatableProperties() is cheap and this keeps
+		// NON-translatable grouped fields byte-for-byte unchanged.
 		$translatableProps = $this->translationHandler->getTranslatableProperties(schema: $schema);
-		if (in_array($groupField, $translatableProps, true) === false) {
+		$translatableGroups = array_values(
+			array_filter(
+				$groupFields,
+				static fn (string $groupField): bool => in_array($groupField, $translatableProps, true)
+			)
+		);
+		if (count($translatableGroups) === 0) {
 			return $envelope;
 		}
 
@@ -801,13 +856,13 @@ class AggregationRunner {
 		}
 
 		foreach ($envelope['groups'] as $index => $group) {
-			if (is_array($group) === false || array_key_exists('key', $group) === false) {
+			if (is_array($group) === false) {
 				continue;
 			}
 
-			$envelope['groups'][$index]['key'] = $this->projectSingleTranslatableKey(
-				rawKey: $group['key'],
-				groupField: $groupField,
+			$envelope['groups'][$index] = $this->projectGroupRowKeys(
+				group: $group,
+				translatableGroups: $translatableGroups,
 				schema: $schema,
 				register: $register
 			);
@@ -815,6 +870,62 @@ class AggregationRunner {
 
 		return $envelope;
 	}//end projectTranslatableGroupKeys()
+
+	/**
+	 * Project the translatable key(s) of ONE grouped row.
+	 *
+	 * Handles both row shapes: the composite `keys` map (every translatable
+	 * member projected against its own field name) and the legacy scalar
+	 * `key`. A row carrying neither is returned untouched.
+	 *
+	 * @param array<string, mixed> $group The grouped row.
+	 * @param array<int, string> $translatableGroups Group fields that ARE translatable.
+	 * @param Schema $schema The schema being aggregated.
+	 * @param Register $register The owning register (language config).
+	 *
+	 * @return array<string, mixed> The row with its translatable key(s) projected.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function projectGroupRowKeys(
+		array $group,
+		array $translatableGroups,
+		Schema $schema,
+		Register $register,
+	): array {
+		// Composite groupBy: project every translatable member of the
+		// `keys` map against its OWN field name.
+		if (isset($group['keys']) === true && is_array($group['keys']) === true) {
+			foreach ($translatableGroups as $groupField) {
+				if (array_key_exists($groupField, $group['keys']) === false) {
+					continue;
+				}
+
+				$group['keys'][$groupField] = $this->projectSingleTranslatableKey(
+					rawKey: $group['keys'][$groupField],
+					groupField: $groupField,
+					schema: $schema,
+					register: $register
+				);
+			}
+
+			return $group;
+		}
+
+		// Single-field groupBy: the legacy scalar `key` shape.
+		if (array_key_exists('key', $group) === false) {
+			return $group;
+		}
+
+		$group['key'] = $this->projectSingleTranslatableKey(
+			rawKey: $group['key'],
+			groupField: $translatableGroups[0],
+			schema: $schema,
+			register: $register
+		);
+
+		return $group;
+	}//end projectGroupRowKeys()
 
 	/**
 	 * Project a single grouped key value to the negotiated language.
@@ -2480,6 +2591,636 @@ class AggregationRunner {
 		$name = preg_replace('/_+/', '_', $name);
 		return rtrim((string)$name, '_');
 	}//end sanitizeColumnName()
+
+	/**
+	 * Attach aggregates from a SECOND schema to each group of an already
+	 * computed grouped envelope (the `join` clause).
+	 *
+	 * Spec shape (see {@see AggregationJoinAnnotationValidator::validate()}):
+	 *   "join": {
+	 *     "through": "CommitmentBudget",
+	 *     "on":      "CommitmentBudget.programmeCode",
+	 *     "filter":  { },
+	 *     "select":  ["CommitmentBudget.authorised_amount"]
+	 *   }
+	 *
+	 * IMPLEMENTATION: TWO-QUERY MERGE, NOT A SQL JOIN
+	 * ------------------------------------------------
+	 * The parent aggregate has already run. This method aggregates the
+	 * JOINED schema independently — grouped on the joined side of the join
+	 * key — and merges the two result sets in PHP on that key. It does NOT
+	 * emit a `FROM parent JOIN joined` statement, deliberately:
+	 *
+	 * - The two schemas live in SEPARATE per-schema magic shard tables, and
+	 *   possibly in separate registers. A single statement would have to
+	 *   re-derive BOTH tables' tenancy (`_organisation`) and soft-delete
+	 *   predicates by hand. Every one of those is a place to silently widen
+	 *   the row set; routing the joined schema through the SAME
+	 *   {@see tryNativeAggregation()} the parent used means it inherits
+	 *   those predicates instead of re-implementing them.
+	 * - {@see tryNativeAggregation()} answers `null` (fall back to PHP) for
+	 *   any shape it cannot translate. A hand-written JOIN inside it would
+	 *   have to fall back too, and the PHP fallback has no join — the two
+	 *   paths would disagree exactly when the native path bailed.
+	 *
+	 * PERFORMANCE
+	 * -----------
+	 * Native path: `1 + N` queries, N = `count(select)`. Each is a grouped
+	 * aggregate over the joined table (same cost class as the parent's own
+	 * grouped query). Crucially the count is independent of the NUMBER OF
+	 * GROUPS — this is not an N+1-per-row lookup; 4 groups and 40,000
+	 * groups issue the same `1 + N` queries.
+	 * PHP fallback: the joined table is hydrated ONCE (capped at
+	 * {@see PHP_FALLBACK_ROW_CAP}) and all N select entries are computed
+	 * from those rows, so the fallback is `1` extra table scan, not N. The
+	 * merge itself is O(parent groups + joined groups) via a hash lookup.
+	 * When the joined hydrate hits the cap the envelope's `join.truncated`
+	 * flag is set — the joined numbers are then partial and the caller MUST
+	 * treat them as such.
+	 *
+	 * RBAC
+	 * ----
+	 * A join MUST NOT become a way to read a schema the caller cannot read.
+	 * Three independent controls, the same three the cross-schema `from`
+	 * path relies on:
+	 *  1. An explicit `list` permission gate on the JOINED schema via
+	 *     {@see PermissionHandler::hasPermission()}, refusing with
+	 *     RuntimeException('Forbidden: ...') before a single row is read.
+	 *  2. Tenancy: the joined aggregate runs through the same
+	 *     {@see tryNativeAggregation()} (which appends the
+	 *     `_organisation = ?` predicate, fail-closed to
+	 *     `__no_active_org__` when there is no active organisation) or the
+	 *     same {@see MagicMapper::findAllInRegisterSchemaTable()} the
+	 *     parent uses (MultiTenancyTrait). Note that register RESOLUTION
+	 *     ({@see findRegisterForSchema()}) deliberately bypasses
+	 *     multi-tenancy as a metadata read — it is NOT a tenancy control,
+	 *     and is not counted as one here.
+	 *  3. The cache key in {@see run()} carries the whole join spec plus
+	 *     userId + active organisation, so a permitted caller's joined
+	 *     numbers can never be served to a caller with a different verdict.
+	 *
+	 * @param array<string, mixed> $envelope The parent aggregation envelope (must carry `groups`).
+	 * @param array<string, mixed>|null $join The raw join spec; null is a no-op.
+	 * @param array<int, string> $groupFields The parent's ordered group fields.
+	 * @param bool $bypassRbac Internal-system mode: skip the list-permission gate
+	 *                         (tenancy predicates still apply — they are not bypassable here).
+	 *
+	 * @return array<string, mixed> The envelope with a `joined` map on each group and a `join` summary.
+	 *
+	 * @throws RuntimeException When the join spec is unusable, the joined schema cannot be
+	 *                          resolved, or the caller lacks list permission on it.
+	 *
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+	 *   The method is one linear pipeline (validate → resolve+gate → aggregate
+	 *   → merge); splitting the guards out would hide the fail-closed order,
+	 *   which is the security-relevant property.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function applyJoin(
+		array $envelope,
+		?array $join,
+		array $groupFields,
+		bool $bypassRbac,
+	): array {
+		if ($join === null) {
+			return $envelope;
+		}
+
+		if (count($groupFields) === 0) {
+			throw new RuntimeException(
+				'Aggregation join requires a groupBy — joined values are attached per group.'
+			);
+		}
+
+		if (isset($envelope['groups']) === false || is_array($envelope['groups']) === false) {
+			throw new RuntimeException('Aggregation join expected a grouped result to attach to.');
+		}
+
+		$through = (string)($join['through'] ?? '');
+		if ($through === '') {
+			throw new RuntimeException('Aggregation join is missing a non-empty `through` schema ref.');
+		}
+
+		$onMap = $this->resolveJoinKey(join: $join, groupFields: $groupFields);
+		$selectEntries = $this->parseJoinSelect(join: $join);
+
+		// Load the joined schema, gate on it, and locate its register —
+		// all BEFORE a single joined row is read.
+		[$joinedSchema, $joinedRegister] = $this->resolveJoinTarget(
+			through: $through,
+			bypassRbac: $bypassRbac
+		);
+
+		$joinedFilter = $this->placeholders->resolveArray((array)($join['filter'] ?? $join['where'] ?? []));
+
+		$lookup = $this->aggregateJoinedSchema(
+			register: $joinedRegister,
+			schema: $joinedSchema,
+			filter: $joinedFilter,
+			joinedFields: array_values($onMap),
+			selectEntries: $selectEntries
+		);
+
+		$aliases = array_map(static fn (array $entry): string => $entry['alias'], $selectEntries);
+
+		$envelope['groups'] = $this->mergeJoinedValues(
+			groups: $envelope['groups'],
+			onMap: $onMap,
+			aliases: $aliases,
+			lookup: $lookup['values']
+		);
+
+		$envelope['join'] = [
+			'through' => $through,
+			'on' => $onMap,
+			'select' => $aliases,
+			'backend' => $lookup['backend'],
+			'truncated' => $lookup['truncated'],
+		];
+
+		return $envelope;
+	}//end applyJoin()
+
+	/**
+	 * Load the joined schema, gate the caller on it, and locate its register.
+	 *
+	 * The ORDER is the security-relevant part: the `list` permission gate
+	 * runs before the register lookup and before any row read, so a caller
+	 * without rights on the joined schema learns nothing beyond the refusal.
+	 *
+	 * @param string $through The joined schema ref.
+	 * @param bool $bypassRbac Internal-system mode: skip the list-permission gate.
+	 *
+	 * @return array{0: Schema, 1: Register} The joined schema and its register.
+	 *
+	 * @throws RuntimeException When the caller lacks `list`, or no register carries the schema.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function resolveJoinTarget(string $through, bool $bypassRbac): array {
+		$joinedSchema = $this->loadSchema(schemaRef: $through);
+
+		// SECURITY (control 1 of 3, see applyJoin()'s docblock): list
+		// permission on the JOINED schema. `objectOwner: null` /
+		// `object: null` is the list-level form — the join has not selected
+		// any specific row.
+		$userId = $this->userSession->getUser()?->getUID();
+		if ($bypassRbac === false && $this->permissionHandler->hasPermission(
+			schema: $joinedSchema,
+			action: 'list',
+			userId: $userId,
+			objectOwner: null,
+			_rbac: true,
+			object: null
+		) === false
+		) {
+			throw new RuntimeException(
+				sprintf('Forbidden: caller lacks list permission on join target "%s".', $through)
+			);
+		}
+
+		$joinedRegister = $this->findRegisterForSchema(schema: $joinedSchema);
+		if ($joinedRegister === null) {
+			throw new RuntimeException(
+				sprintf('No register found that contains join target schema "%s".', $through)
+			);
+		}
+
+		return [$joinedSchema, $joinedRegister];
+	}//end resolveJoinTarget()
+
+	/**
+	 * Attach the joined lookup to each parent group under `joined`.
+	 *
+	 * Every alias is ALWAYS present, `null` on a miss. An absent key and a
+	 * null value read the same to a careless consumer; making the miss
+	 * explicit keeps "no matching row on the joined side" from looking like
+	 * "this alias was never requested".
+	 *
+	 * @param array<int, mixed> $groups The parent grouped rows.
+	 * @param array<string, string> $onMap Ordered parentField => joinedField map.
+	 * @param array<int, string> $aliases The select aliases, in declaration order.
+	 * @param array<string, array<string, int|float|null>> $lookup Joined values by merge key.
+	 *
+	 * @return array<int, mixed> The grouped rows, each carrying a `joined` map.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function mergeJoinedValues(array $groups, array $onMap, array $aliases, array $lookup): array {
+		$parentFields = array_keys($onMap);
+
+		foreach ($groups as $index => $group) {
+			if (is_array($group) === false) {
+				continue;
+			}
+
+			$tuple = [];
+			foreach ($parentFields as $parentField) {
+				if (isset($group['keys']) === true && is_array($group['keys']) === true) {
+					$tuple[] = ($group['keys'][$parentField] ?? null);
+					continue;
+				}
+
+				$tuple[] = ($group['key'] ?? null);
+			}
+
+			$tupleKey = $this->joinTupleKey(values: $tuple);
+
+			$joined = [];
+			foreach ($aliases as $alias) {
+				$joined[$alias] = ($lookup[$tupleKey][$alias] ?? null);
+			}
+
+			$groups[$index]['joined'] = $joined;
+		}//end foreach
+
+		return $groups;
+	}//end mergeJoinedValues()
+
+	/**
+	 * Resolve a join `on` clause to an ordered `parentField => joinedField` map.
+	 *
+	 * Two spellings:
+	 * - `{parentField: joinedField, ...}` — explicit and unambiguous, and
+	 *   the only spelling that can express a COMPOSITE join key.
+	 * - `"Through.column"` or bare `"column"` — single-column shorthand.
+	 *   The JOINED side is the column named. The PARENT side is inferred:
+	 *   the group field of the SAME name when one exists, otherwise the
+	 *   FIRST group field. The fallback is what makes shillinq's
+	 *   `on: "CommitmentBudget.programmeCode"` resolve to
+	 *   `programme => programmeCode` against
+	 *   `groupBy: [programme, costCentre, ...]`. It IS an inference; the
+	 *   map spelling exists for authors who would rather say it outright.
+	 *
+	 * @param array<string, mixed> $join The raw join spec.
+	 * @param array<int, string> $groupFields The parent's ordered group fields.
+	 *
+	 * @return array<string, string> Ordered parentField => joinedField map.
+	 *
+	 * @throws RuntimeException When `on` is missing or unusable.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function resolveJoinKey(array $join, array $groupFields): array {
+		$onClause = ($join['on'] ?? null);
+
+		if (is_array($onClause) === true && count($onClause) > 0 && array_is_list($onClause) === false) {
+			return $this->resolveJoinKeyMap(onClause: $onClause, groupFields: $groupFields);
+		}
+
+		if (is_string($onClause) === false || $onClause === '') {
+			throw new RuntimeException(
+				'Aggregation join.on must be a "Schema.column" string or a {parentField: joinedField} map.'
+			);
+		}
+
+		$joinedField = $this->stripSchemaPrefix(ref: $onClause);
+		if ($joinedField === '') {
+			throw new RuntimeException('Aggregation join.on names an empty column.');
+		}
+
+		// Same-named group field wins; otherwise the first group field.
+		$parentField = $groupFields[0];
+		if (in_array($joinedField, $groupFields, true) === true) {
+			$parentField = $joinedField;
+		}
+
+		return [$parentField => $joinedField];
+	}//end resolveJoinKey()
+
+	/**
+	 * Resolve the explicit `{parentField: joinedField}` spelling of `on`.
+	 *
+	 * Each parent-side field MUST be one of the groupBy fields: the merge
+	 * reads the join key out of the group row, so a parent field that is not
+	 * grouped has no value there and would silently match nothing.
+	 *
+	 * @param array<string, mixed> $onClause The `on` map.
+	 * @param array<int, string> $groupFields The parent's ordered group fields.
+	 *
+	 * @return array<string, string> Ordered parentField => joinedField map.
+	 *
+	 * @throws RuntimeException When a side is empty or the parent field is not grouped.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function resolveJoinKeyMap(array $onClause, array $groupFields): array {
+		$map = [];
+		foreach ($onClause as $parentField => $joinedField) {
+			$parentField = (string)$parentField;
+			$joinedField = $this->stripSchemaPrefix(ref: (string)$joinedField);
+			if ($parentField === '' || $joinedField === '') {
+				throw new RuntimeException('Aggregation join.on names an empty field.');
+			}
+
+			if (in_array($parentField, $groupFields, true) === false) {
+				throw new RuntimeException(
+					sprintf(
+						'Aggregation join.on parent field "%s" is not one of the groupBy fields.',
+						$parentField
+					)
+				);
+			}
+
+			$map[$parentField] = $joinedField;
+		}
+
+		return $map;
+	}//end resolveJoinKeyMap()
+
+	/**
+	 * Strip a leading `Schema.` qualifier from a join field reference.
+	 *
+	 * `"CommitmentBudget.programmeCode"` → `"programmeCode"`. ANY qualifier
+	 * is stripped, not only one matching the `through` ref: a schema ref may
+	 * be written as a slug, uuid or id, so requiring an exact textual match
+	 * would silently leave a dotted string as the column name and produce a
+	 * column-not-found bail to the PHP fallback instead of a readable error.
+	 *
+	 * @param string $ref The raw field reference.
+	 *
+	 * @return string The bare column name.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function stripSchemaPrefix(string $ref): string {
+		$position = strrpos($ref, '.');
+		if ($position === false) {
+			return $ref;
+		}
+
+		return substr($ref, ($position + 1));
+	}//end stripSchemaPrefix()
+
+	/**
+	 * Parse a join `select` list to `{alias, field, metric}` entries.
+	 *
+	 * Accepted entries:
+	 * - `"CommitmentBudget.authorised_amount"` — alias is the string AS
+	 *   WRITTEN (so a consumer reads back the key it declared), field is
+	 *   the bare column, metric defaults to `sum`.
+	 * - `{field: "authorised_amount", metric: "max", alias: "cap"}` —
+	 *   `metric` defaults to `sum`, `alias` defaults to `field`.
+	 *
+	 * `sum` is the default because the joined side is aggregated per join
+	 * key, not looked up per row: a budget schema holding exactly one row
+	 * per key sums to that row's value, and one holding several sums to
+	 * their total — which is the arithmetic a budget-vs-realised report
+	 * wants. An author who needs a different reduction says so with the
+	 * object spelling.
+	 *
+	 * @param array<string, mixed> $join The raw join spec.
+	 *
+	 * @return array<int, array{alias: string, field: string, metric: string}> Parsed entries.
+	 *
+	 * @throws RuntimeException When `select` is missing, empty or malformed.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function parseJoinSelect(array $join): array {
+		$select = ($join['select'] ?? null);
+		if (is_array($select) === false || count($select) === 0) {
+			throw new RuntimeException('Aggregation join requires a non-empty `select` list.');
+		}
+
+		$entries = [];
+		foreach ($select as $raw) {
+			$entries[] = $this->parseJoinSelectEntry(raw: $raw);
+		}
+
+		return $entries;
+	}//end parseJoinSelect()
+
+	/**
+	 * Parse ONE join `select` entry to `{alias, field, metric}`.
+	 *
+	 * @param mixed $raw The raw entry — a "Field" string or a {field, metric?, alias?} object.
+	 *
+	 * @return array{alias: string, field: string, metric: string} The parsed entry.
+	 *
+	 * @throws RuntimeException When the entry is malformed or names an unsupported metric.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function parseJoinSelectEntry(mixed $raw): array {
+		if (is_string($raw) === true && $raw !== '') {
+			return [
+				'alias' => $raw,
+				'field' => $this->stripSchemaPrefix(ref: $raw),
+				'metric' => 'sum',
+			];
+		}
+
+		if (is_array($raw) === false
+			|| isset($raw['field']) === false
+			|| is_string($raw['field']) === false
+			|| $raw['field'] === ''
+		) {
+			throw new RuntimeException(
+				'Aggregation join.select entries must be "Field" strings or {field, metric?} objects.'
+			);
+		}
+
+		$metric = (string)($raw['metric'] ?? 'sum');
+		if (in_array($metric, self::JOIN_SELECT_METRICS, true) === false) {
+			throw new RuntimeException(
+				sprintf('Aggregation join.select metric "%s" is not supported.', $metric)
+			);
+		}
+
+		return [
+			'alias' => (string)($raw['alias'] ?? $raw['field']),
+			'field' => $this->stripSchemaPrefix(ref: $raw['field']),
+			'metric' => $metric,
+		];
+	}//end parseJoinSelectEntry()
+
+	/**
+	 * Aggregate the joined schema, grouped on the joined side of the join key.
+	 *
+	 * Native first (one grouped query per select entry, reusing
+	 * {@see tryNativeAggregation()} verbatim so the joined read carries the
+	 * same tenancy and soft-delete predicates as the parent). If ANY entry
+	 * bails to null the WHOLE native attempt is abandoned and every entry is
+	 * recomputed in PHP — mirroring {@see tryNativeMultiMetric()}'s posture,
+	 * so a single response is never a partial native / partial-PHP mix.
+	 *
+	 * The PHP fallback hydrates the joined table ONCE and reuses those rows
+	 * for every select entry, and reduces them with the SAME
+	 * {@see computeGrouped()} the parent's fallback uses — which is what
+	 * makes the two paths agree rather than merely look similar.
+	 *
+	 * @param Register $register Register owning the joined schema.
+	 * @param Schema $schema The joined schema.
+	 * @param array<string, mixed> $filter Placeholder-resolved filter for the joined schema.
+	 * @param array<int, string> $joinedFields Joined-side join key field(s).
+	 * @param array<int, array{alias: string, field: string, metric: string}> $selectEntries Parsed select entries.
+	 *
+	 * @return array{values: array<string, array<string, int|float|null>>, backend: string, truncated: bool}
+	 *         Lookup keyed by {@see joinTupleKey()} → alias → value.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function aggregateJoinedSchema(
+		Register $register,
+		Schema $schema,
+		array $filter,
+		array $joinedFields,
+		array $selectEntries,
+	): array {
+		$groupBySpec = ['fields' => $joinedFields];
+		$isMulti = (count($joinedFields) > 1);
+
+		// --- Native attempt: 1 grouped query per select entry. ---
+		$native = [];
+		$nativeUsable = true;
+		foreach ($selectEntries as $entry) {
+			$single = $this->tryNativeAggregation(
+				register: $register,
+				schema: $schema,
+				metric: $entry['metric'],
+				field: $entry['field'],
+				filter: $filter,
+				groupBy: $groupBySpec
+			);
+
+			if ($single === null) {
+				$nativeUsable = false;
+				break;
+			}
+
+			$native[$entry['alias']] = ($single['groups'] ?? []);
+		}
+
+		if ($nativeUsable === true) {
+			return [
+				'values' => $this->indexJoinedGroups(perAlias: $native, isMulti: $isMulti, joinedFields: $joinedFields),
+				'backend' => 'postgres',
+				'truncated' => false,
+			];
+		}
+
+		// --- PHP fallback: hydrate ONCE, reduce per select entry. ---
+		$objects = $this->magicMapper->findAllInRegisterSchemaTable(
+			register: $register,
+			schema: $schema,
+			limit: self::PHP_FALLBACK_ROW_CAP
+		);
+		$truncated = (count($objects) >= self::PHP_FALLBACK_ROW_CAP);
+
+		$rows = [];
+		foreach ($objects as $object) {
+			$rows[] = $object->getObject();
+		}
+
+		$rows = $this->applyFilter(rows: $rows, filter: $filter);
+
+		$perAlias = [];
+		foreach ($selectEntries as $entry) {
+			$perAlias[$entry['alias']] = $this->computeGrouped(
+				rows: $rows,
+				metric: $entry['metric'],
+				field: $entry['field'],
+				groupFields: $joinedFields
+			);
+		}
+
+		return [
+			'values' => $this->indexJoinedGroups(perAlias: $perAlias, isMulti: $isMulti, joinedFields: $joinedFields),
+			'backend' => 'php-fallback',
+			'truncated' => $truncated,
+		];
+	}//end aggregateJoinedSchema()
+
+	/**
+	 * Fold per-alias grouped rows into one `joinKey => alias => value` lookup.
+	 *
+	 * @param array<string, array<int, array<string, mixed>>> $perAlias Grouped rows per select alias.
+	 * @param bool $isMulti Whether the join key is composite (rows carry `keys`, not `key`).
+	 * @param array<int, string> $joinedFields Joined-side join key field(s), in key order.
+	 *
+	 * @return array<string, array<string, int|float|null>> Lookup keyed by {@see joinTupleKey()}.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function indexJoinedGroups(array $perAlias, bool $isMulti, array $joinedFields): array {
+		$lookup = [];
+		foreach ($perAlias as $alias => $groups) {
+			foreach ($groups as $group) {
+				if (is_array($group) === false) {
+					continue;
+				}
+
+				$tuple = [($group['key'] ?? null)];
+				if ($isMulti === true) {
+					$keys = [];
+					if (isset($group['keys']) === true && is_array($group['keys']) === true) {
+						$keys = $group['keys'];
+					}
+
+					$tuple = [];
+					foreach ($joinedFields as $joinedField) {
+						$tuple[] = ($keys[$joinedField] ?? null);
+					}
+				}
+
+				$tupleKey = $this->joinTupleKey(values: $tuple);
+				$lookup[$tupleKey][$alias] = ($group['value'] ?? null);
+			}
+		}//end foreach
+
+		return $lookup;
+	}//end indexJoinedGroups()
+
+	/**
+	 * Build the merge key for one join-key tuple.
+	 *
+	 * Every member is normalised to its STRING form before hashing. That is
+	 * load-bearing, not cosmetic: the native path reads join-key columns
+	 * back through the DB driver (a numeric year arrives as `"2024"`) while
+	 * the PHP fallback reads them out of decoded JSON (`2024`). Keying on
+	 * the raw values would make the two paths match different groups on the
+	 * same data — the native path silently attaching nothing.
+	 *
+	 * `null` gets a sentinel distinct from the empty string so a genuinely
+	 * absent key does not collide with `""`.
+	 *
+	 * @param array<int, mixed> $values The tuple members, in key order.
+	 *
+	 * @return string The merge key.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function joinTupleKey(array $values): string {
+		$parts = [];
+		foreach ($values as $value) {
+			if ($value === null) {
+				$parts[] = "\x00null";
+				continue;
+			}
+
+			if ($value === true) {
+				$parts[] = 'true';
+				continue;
+			}
+
+			if ($value === false) {
+				$parts[] = 'false';
+				continue;
+			}
+
+			if (is_scalar($value) === true) {
+				$parts[] = (string)$value;
+				continue;
+			}
+
+			$parts[] = (string)json_encode($value);
+		}
+
+		return implode("\x1f", $parts);
+	}//end joinTupleKey()
 
 	/**
 	 * Execute a cross-schema aggregation.

--- a/tests/Unit/Service/Aggregation/AggregationJoinAndCompositeGroupByTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationJoinAndCompositeGroupByTest.php
@@ -1,0 +1,930 @@
+<?php
+
+/**
+ * Unit tests for the composite-`groupBy` annotation vocabulary and the
+ * `join` clause in `AggregationAnnotationValidator` + `AggregationRunner`.
+ *
+ * Three things are pinned here:
+ *
+ * 1. The legacy single-field `groupBy: {field: ...}` object form behaves
+ *    EXACTLY as before — in the validator (same two error codes, same
+ *    accept/reject verdicts) and in the runner (same `{key, value}` row
+ *    shape, same translatable-key projection). This is the regression that
+ *    matters most: the object form is live in other fleet apps.
+ * 2. A composite `groupBy` naming several fields validates per member and
+ *    projects EVERY translatable member of the `keys` map.
+ * 3. `join` attaches aggregates from a second schema per group, is refused
+ *    when the caller lacks `list` on the joined schema, and participates in
+ *    the cache key.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Aggregation
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * @spec openspec/specs/aggregation-api/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Aggregation;
+
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Aggregation\AggregationAnnotationValidator;
+use OCA\OpenRegister\Service\Aggregation\AggregationCache;
+use OCA\OpenRegister\Service\Aggregation\AggregationRunner;
+use OCA\OpenRegister\Service\LanguageService;
+use OCA\OpenRegister\Service\Object\PermissionHandler;
+use OCA\OpenRegister\Service\Object\TranslationHandler;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCA\OpenRegister\Service\Search\PlaceholderResolver;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use OCP\DB\IPreparedStatement;
+use OCP\DB\IResult;
+use OCP\IDBConnection;
+use OCP\IUserSession;
+use PDO;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * @covers \OCA\OpenRegister\Service\Aggregation\AggregationAnnotationValidator
+ * @covers \OCA\OpenRegister\Service\Aggregation\AggregationRunner
+ */
+class AggregationJoinAndCompositeGroupByTest extends TestCase {
+
+	private MagicMapper&MockObject $magicMapper;
+
+	private RegisterMapper&MockObject $registerMapper;
+
+	private SchemaMapper&MockObject $schemaMapper;
+
+	private IDBConnection&MockObject $db;
+
+	private AggregationCache&MockObject $cache;
+
+	private PermissionHandler&MockObject $permissionHandler;
+
+	private IUserSession&MockObject $userSession;
+
+	private OrganisationService&MockObject $organisationService;
+
+	private TranslationHandler&MockObject $translationHandler;
+
+	private LanguageService&MockObject $languageService;
+
+	/**
+	 * Every `filter:` argument handed to AggregationCache::set(), in call
+	 * order. This IS the cache key, so capturing it is the only honest way
+	 * to assert two specs do not collide.
+	 *
+	 * @var array<int, mixed>
+	 */
+	private array $capturedCacheKeys = [];
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->magicMapper = $this->createMock(MagicMapper::class);
+		$this->registerMapper = $this->createMock(RegisterMapper::class);
+		$this->schemaMapper = $this->createMock(SchemaMapper::class);
+		$this->db = $this->createMock(IDBConnection::class);
+		$this->cache = $this->createMock(AggregationCache::class);
+		$this->permissionHandler = $this->createMock(PermissionHandler::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->organisationService = $this->createMock(OrganisationService::class);
+		$this->translationHandler = $this->createMock(TranslationHandler::class);
+		$this->languageService = $this->createMock(LanguageService::class);
+
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->organisationService->method('getActiveOrganisation')->willReturn(null);
+		$this->languageService->method('shouldReturnAllTranslations')->willReturn(false);
+
+		// Cache always misses; every key handed to set() is recorded.
+		$this->cache->method('get')->willReturn(null);
+		$this->cache->method('set')->willReturnCallback(
+			function (string $registerSlug, string $schemaSlug, string $name, mixed $filter, mixed $result): void {
+				$this->capturedCacheKeys[] = $filter;
+			}
+		);
+
+		// Register-scoped schema resolution, mirroring the production
+		// resolver: a schema the register does not carry does not resolve.
+		$this->schemaMapper->method('findInIds')->willReturnCallback(
+			function (string|int $id, array $schemaIds): ?Schema {
+				try {
+					$schema = $this->schemaMapper->find($id, [], true, false);
+				} catch (\Throwable $e) {
+					return null;
+				}
+
+				if (($schema instanceof Schema) === false) {
+					return null;
+				}
+
+				$normalised = array_map(static fn ($sid) => (int)$sid, $schemaIds);
+				if (in_array((int)$schema->getId(), $normalised, true) === false) {
+					return null;
+				}
+
+				return $schema;
+			}
+		);
+	}//end setUp()
+
+	// ------------------------------------------------------------------
+	// Validator — the legacy object form is untouched.
+	// ------------------------------------------------------------------
+
+	/**
+	 * REGRESSION GUARD. The single-field `groupBy: {field}` object form must
+	 * behave exactly as it did before composite groupBy existed: a declared
+	 * field validates clean, an undeclared one raises
+	 * `aggregation-groupby-field-unknown` and NOTHING else.
+	 */
+	public function testLegacyObjectGroupByFormIsUnchanged(): void {
+		$validator = new AggregationAnnotationValidator();
+
+		$ok = $validator->validate($this->schemaDefinition(
+			['byStatus' => ['metric' => 'count', 'groupBy' => ['field' => 'programme']]]
+		));
+		$this->assertSame([], $ok, 'a declared single groupBy field MUST still validate clean');
+
+		$bad = $validator->validate($this->schemaDefinition(
+			['byStatus' => ['metric' => 'count', 'groupBy' => ['field' => 'nope']]]
+		));
+		$this->assertSame(
+			['aggregation-groupby-field-unknown'],
+			$this->codes($bad),
+			'an undeclared single groupBy field MUST still raise exactly the legacy code'
+		);
+	}//end testLegacyObjectGroupByFormIsUnchanged()
+
+	/**
+	 * A composite groupBy over declared properties validates clean in both
+	 * the plain-list and the {fields: [...]} spellings.
+	 */
+	public function testCompositeGroupByOverDeclaredFieldsValidates(): void {
+		$validator = new AggregationAnnotationValidator();
+
+		$list = $validator->validate($this->schemaDefinition(
+			['x' => ['metric' => 'sum', 'field' => 'remainingCommitted', 'groupBy' => ['programme', 'costCentre']]]
+		));
+		$this->assertSame([], $list, 'a plain-list composite groupBy MUST validate clean');
+
+		$fields = $validator->validate($this->schemaDefinition(
+			[
+				'x' => [
+					'metric' => 'sum',
+					'field' => 'remainingCommitted',
+					'groupBy' => ['fields' => ['programme', 'costCentre']],
+				],
+			]
+		));
+		$this->assertSame([], $fields, 'a {fields: [...]} composite groupBy MUST validate clean');
+	}//end testCompositeGroupByOverDeclaredFieldsValidates()
+
+	/**
+	 * A composite groupBy naming an UNDECLARED property is rejected — the
+	 * per-member check the single-field form has always applied, now applied
+	 * to every member so a composite cannot smuggle an unknown column past
+	 * the validator and into `GROUP BY`.
+	 */
+	public function testCompositeGroupByRejectsUndeclaredProperty(): void {
+		$validator = new AggregationAnnotationValidator();
+
+		$errors = $validator->validate($this->schemaDefinition(
+			['x' => ['metric' => 'count', 'groupBy' => ['programme', 'notAProperty', 'costCentre']]]
+		));
+
+		$this->assertSame(['aggregation-groupby-field-unknown'], $this->codes($errors));
+		$this->assertStringContainsString('notAProperty', $errors[0]['message']);
+	}//end testCompositeGroupByRejectsUndeclaredProperty()
+
+	/**
+	 * The same field named twice is a declaration bug, not a silent no-op.
+	 */
+	public function testCompositeGroupByRejectsDuplicateField(): void {
+		$validator = new AggregationAnnotationValidator();
+
+		$errors = $validator->validate($this->schemaDefinition(
+			['x' => ['metric' => 'count', 'groupBy' => ['programme', 'programme']]]
+		));
+
+		$this->assertSame(['aggregation-groupby-duplicate-field'], $this->codes($errors));
+	}//end testCompositeGroupByRejectsDuplicateField()
+
+	// ------------------------------------------------------------------
+	// Validator — join.
+	// ------------------------------------------------------------------
+
+	/**
+	 * The shillinq `committedVsRealisedPerBudgetLine` join shape validates
+	 * clean once the metric/field vocabulary is spelled the engine's way.
+	 */
+	public function testJoinSpecValidates(): void {
+		$validator = new AggregationAnnotationValidator();
+
+		$errors = $validator->validate($this->schemaDefinition(['committed' => $this->joinAnnotation()]));
+
+		$this->assertSame([], $errors);
+	}//end testJoinSpecValidates()
+
+	/**
+	 * A join with no groupBy has nothing to attach its values to, and is
+	 * refused at save time rather than throwing on every call.
+	 */
+	public function testJoinWithoutGroupByIsRejected(): void {
+		$validator = new AggregationAnnotationValidator();
+
+		$spec = $this->joinAnnotation();
+		unset($spec['groupBy']);
+
+		$this->assertContains(
+			'aggregation-join-requires-groupby',
+			$this->codes($validator->validate($this->schemaDefinition(['committed' => $spec])))
+		);
+	}//end testJoinWithoutGroupByIsRejected()
+
+	/**
+	 * `join` beside `from` names three schemas with no declared relationship
+	 * between the second and third, and the cross-schema runner has no join
+	 * stage — so it is refused rather than silently half-executed.
+	 */
+	public function testJoinCombinedWithFromIsRejected(): void {
+		$validator = new AggregationAnnotationValidator();
+
+		$errors = $validator->validate($this->schemaDefinition(
+			[
+				'committed' => [
+					'from' => 'other-schema',
+					'select' => 'count',
+					'join' => ['through' => 'x', 'on' => 'y', 'select' => ['z']],
+				],
+			]
+		));
+
+		$this->assertContains('aggregation-join-with-from', $this->codes($errors));
+	}//end testJoinCombinedWithFromIsRejected()
+
+	/**
+	 * An empty / missing `select` list means the join would attach nothing.
+	 */
+	public function testJoinWithoutSelectIsRejected(): void {
+		$validator = new AggregationAnnotationValidator();
+
+		$spec = $this->joinAnnotation();
+		$spec['join']['select'] = [];
+
+		$this->assertContains(
+			'aggregation-join-select-empty',
+			$this->codes($validator->validate($this->schemaDefinition(['committed' => $spec])))
+		);
+	}//end testJoinWithoutSelectIsRejected()
+
+	/**
+	 * An explicit `{parentField: joinedField}` on-map is checked on its
+	 * parent half — the joined half cannot be checked here because the
+	 * joined schema is not loadable at annotation-save time.
+	 */
+	public function testJoinOnMapRejectsUndeclaredParentField(): void {
+		$validator = new AggregationAnnotationValidator();
+
+		$spec = $this->joinAnnotation();
+		$spec['join']['on'] = ['notAProperty' => 'programmeCode'];
+
+		$this->assertContains(
+			'aggregation-join-on-field-unknown',
+			$this->codes($validator->validate($this->schemaDefinition(['committed' => $spec])))
+		);
+	}//end testJoinOnMapRejectsUndeclaredParentField()
+
+	// ------------------------------------------------------------------
+	// Runner — join behaviour.
+	// ------------------------------------------------------------------
+
+	/**
+	 * A join attaches the joined schema's aggregate to every parent group
+	 * sharing the join key.
+	 *
+	 * Note the deliberate fan-out: both P1 groups (P1/C1 and P1/C2) receive
+	 * the SAME authorised amount, because the budget is declared per
+	 * programme while the parent groups per (programme, costCentre). The
+	 * join repeats the joined value across the finer groups; it does not
+	 * divide it. A group with no matching joined row gets an explicit null
+	 * rather than a missing key.
+	 */
+	public function testJoinAttachesAggregatesPerGroup(): void {
+		$runner = $this->makeJoinRunner();
+
+		$result = $runner->run(
+			registerRef: 'finance',
+			schemaRef: 'commitment-line',
+			name: 'committed'
+		);
+
+		$this->assertSame('php-fallback', $result['backend']);
+		$this->assertSame('commitment-budget', $result['join']['through']);
+		$this->assertSame(['programme' => 'programmeCode'], $result['join']['on']);
+
+		$folded = [];
+		foreach ($result['groups'] as $group) {
+			$key = $group['keys']['programme'] . '|' . $group['keys']['costCentre'];
+			$folded[$key] = [
+				'value' => $group['value'],
+				'joined' => $group['joined']['commitment-budget.authorisedAmount'],
+			];
+		}
+
+		ksort($folded);
+		$this->assertSame(
+			[
+				'P1|C1' => ['value' => 100.0, 'joined' => 1000.0],
+				'P1|C2' => ['value' => 50.0, 'joined' => 1000.0],
+				'P2|C1' => ['value' => 200.0, 'joined' => 2000.0],
+				'P3|C9' => ['value' => 7.0, 'joined' => null],
+			],
+			$folded
+		);
+	}//end testJoinAttachesAggregatesPerGroup()
+
+	/**
+	 * The NATIVE path produces the same joined envelope as the PHP fallback
+	 * on the same data.
+	 *
+	 * The two paths read the join key from different places — the native one
+	 * out of a DB driver (where a value arrives as a string), the fallback
+	 * out of decoded JSON — so this is the test that would catch the merge
+	 * key silently matching nothing on one path.
+	 */
+	public function testNativeJoinAgreesWithPhpFallback(): void {
+		$php = $this->makeJoinRunner()->run(
+			registerRef: 'finance',
+			schemaRef: 'commitment-line',
+			name: 'committed'
+		);
+
+		// Fresh mocks: the SQLite-backed runner needs its own DB stub.
+		$this->setUp();
+		$native = $this->makeNativeJoinRunner()->run(
+			registerRef: 'finance',
+			schemaRef: 'commitment-line',
+			name: 'committed'
+		);
+
+		// assertEquals, not assertSame, and deliberately so: the two paths
+		// agree on every NUMBER and on every join match (including the P3
+		// miss), but disagree on the PHP numeric TYPE — SQLite hands back
+		// an int for SUM over an INTEGER column while the PHP reducer
+		// always yields float. That divergence is PRE-EXISTING in the
+		// grouped aggregate itself (tryNativeAggregation() only casts to
+		// float when the driver returned a string, which Postgres does and
+		// SQLite does not); it is not introduced by the join and is not
+		// silently blessed here. Asserting identity would either fail on
+		// an unrelated defect or, if "fixed" by casting in the test,
+		// pretend the engine agrees when it does not.
+		$this->assertEquals(
+			$this->foldJoined($php['groups']),
+			$this->foldJoined($native['groups']),
+			'the native and PHP-fallback join paths MUST agree on values and matches'
+		);
+		$this->assertEquals(
+			[
+				'P1|C1' => ['value' => 100, 'joined' => 1000],
+				'P1|C2' => ['value' => 50, 'joined' => 1000],
+				'P2|C1' => ['value' => 200, 'joined' => 2000],
+				'P3|C9' => ['value' => 7, 'joined' => null],
+			],
+			$this->foldJoined($native['groups'])
+		);
+
+		// The join match itself IS pinned strictly: a group with no budget
+		// row gets an explicit null, never a stray number from another key.
+		$this->assertNull($this->foldJoined($native['groups'])['P3|C9']['joined']);
+	}//end testNativeJoinAgreesWithPhpFallback()
+
+	/**
+	 * SECURITY. A join MUST NOT become a way to read a schema the caller
+	 * cannot read. The caller holds `list` on the parent but not on the
+	 * joined schema: the run is refused, and refused BEFORE any joined row
+	 * is fetched.
+	 */
+	public function testJoinIsRefusedWhenCallerLacksListOnJoinedSchema(): void {
+		$runner = $this->makeJoinRunner(
+			joinedSchemaListAllowed: false,
+			expectNoJoinedFetch: true
+		);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('Forbidden: caller lacks list permission on join target "commitment-budget"');
+
+		$runner->run(
+			registerRef: 'finance',
+			schemaRef: 'commitment-line',
+			name: 'committed'
+		);
+	}//end testJoinIsRefusedWhenCallerLacksListOnJoinedSchema()
+
+	// ------------------------------------------------------------------
+	// Runner — cache key separation.
+	// ------------------------------------------------------------------
+
+	/**
+	 * SECURITY-RELEVANT. Two aggregations differing ONLY in `groupBy` must
+	 * not share a cache entry — otherwise the second caller is served the
+	 * first one's grouping.
+	 */
+	public function testCacheKeyDiffersOnGroupByAlone(): void {
+		$one = ['metric' => 'sum', 'field' => 'remainingCommitted', 'groupBy' => ['programme']];
+		$two = ['metric' => 'sum', 'field' => 'remainingCommitted', 'groupBy' => ['programme', 'costCentre']];
+
+		$keys = $this->cacheKeysFor(specOne: $one, specTwo: $two);
+
+		$this->assertNotEquals($keys[0], $keys[1], 'a differing groupBy MUST produce a differing cache key');
+		$this->assertSame($keys[0]['metric'], $keys[1]['metric'], 'the control: everything else is identical');
+	}//end testCacheKeyDiffersOnGroupByAlone()
+
+	/**
+	 * SECURITY-RELEVANT. Two aggregations differing ONLY in `join` must not
+	 * share a cache entry — otherwise a spec that asked for no joined data
+	 * can be served a cached envelope carrying values read out of a second
+	 * schema.
+	 */
+	public function testCacheKeyDiffersOnJoinAlone(): void {
+		$base = ['metric' => 'sum', 'field' => 'remainingCommitted', 'groupBy' => ['programme']];
+		$withJoin = $base;
+		$withJoin['join'] = [
+			'through' => 'commitment-budget',
+			'on' => 'commitment-budget.programmeCode',
+			'select' => ['commitment-budget.authorisedAmount'],
+		];
+
+		$keys = $this->cacheKeysFor(specOne: $base, specTwo: $withJoin);
+
+		$this->assertNotEquals($keys[0], $keys[1], 'a differing join MUST produce a differing cache key');
+		$this->assertNull($keys[0]['join'], 'the join-less spec keys on a null join');
+		$this->assertSame('commitment-budget', $keys[1]['join']['through']);
+	}//end testCacheKeyDiffersOnJoinAlone()
+
+	// ------------------------------------------------------------------
+	// Runner — translatable key projection across both group shapes.
+	// ------------------------------------------------------------------
+
+	/**
+	 * A composite groupBy projects EVERY translatable member of the `keys`
+	 * map, and leaves non-translatable members byte-for-byte alone.
+	 *
+	 * Without the composite branch in projectTranslatableGroupKeys() the
+	 * guard `isset($groupBy['field'])` is false for a list-form groupBy, the
+	 * method early-returns, and the caller receives the raw language map.
+	 */
+	public function testCompositeGroupByProjectsEveryTranslatableKey(): void {
+		$this->translationHandler->method('getTranslatableProperties')->willReturn(['programme']);
+		$this->translationHandler->method('resolveTranslationsForRender')->willReturnCallback(
+			static fn (array $objectData): array => array_map(
+				static fn (mixed $map): mixed => (is_array($map) === true) ? ($map['nl'] ?? null) : $map,
+				$objectData
+			)
+		);
+
+		$runner = $this->makeTranslatableRunner(
+			groupBy: ['programme', 'costCentre'],
+			rows: [
+				['programme' => ['nl' => 'Wonen', 'en' => 'Housing'], 'costCentre' => 'C1', 'remainingCommitted' => 10],
+			]
+		);
+
+		$result = $runner->run(registerRef: 'finance', schemaRef: 'commitment-line', name: 'byTwo');
+
+		$this->assertSame('Wonen', $result['groups'][0]['keys']['programme'], 'translatable member MUST be projected');
+		$this->assertSame('C1', $result['groups'][0]['keys']['costCentre'], 'non-translatable member MUST be untouched');
+	}//end testCompositeGroupByProjectsEveryTranslatableKey()
+
+	/**
+	 * REGRESSION GUARD. The single-field form still projects its scalar
+	 * `key` and still emits no `keys` map.
+	 */
+	public function testSingleFieldGroupByStillProjectsScalarKey(): void {
+		$this->translationHandler->method('getTranslatableProperties')->willReturn(['programme']);
+		$this->translationHandler->method('resolveTranslationsForRender')->willReturnCallback(
+			static fn (array $objectData): array => array_map(
+				static fn (mixed $map): mixed => (is_array($map) === true) ? ($map['nl'] ?? null) : $map,
+				$objectData
+			)
+		);
+
+		$runner = $this->makeTranslatableRunner(
+			groupBy: ['field' => 'programme'],
+			rows: [
+				['programme' => ['nl' => 'Wonen', 'en' => 'Housing'], 'costCentre' => 'C1', 'remainingCommitted' => 10],
+			]
+		);
+
+		$result = $runner->run(registerRef: 'finance', schemaRef: 'commitment-line', name: 'byTwo');
+
+		$this->assertSame('Wonen', $result['groups'][0]['key']);
+		$this->assertArrayNotHasKey('keys', $result['groups'][0], 'single-field groups MUST NOT grow a `keys` map');
+	}//end testSingleFieldGroupByStillProjectsScalarKey()
+
+	// ------------------------------------------------------------------
+	// Fixtures + helpers.
+	// ------------------------------------------------------------------
+
+	/**
+	 * The shillinq-shaped join annotation, spelled in the engine's
+	 * vocabulary (`metric`/`field` rather than `sum: [...]`).
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function joinAnnotation(): array {
+		return [
+			'metric' => 'sum',
+			'field' => 'remainingCommitted',
+			'groupBy' => ['programme', 'costCentre'],
+			'join' => [
+				'through' => 'commitment-budget',
+				'on' => 'commitment-budget.programmeCode',
+				'filter' => [],
+				'select' => ['commitment-budget.authorisedAmount'],
+			],
+		];
+	}//end joinAnnotation()
+
+	/**
+	 * A schema definition carrying the given aggregation annotation.
+	 *
+	 * @param array<string, mixed> $aggregations The annotation map.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function schemaDefinition(array $aggregations): array {
+		return [
+			'properties' => [
+				'programme' => ['type' => 'string'],
+				'costCentre' => ['type' => 'string'],
+				'remainingCommitted' => ['type' => 'number'],
+			],
+			'x-openregister-aggregations' => $aggregations,
+		];
+	}//end schemaDefinition()
+
+	/**
+	 * Reduce a validation error list to its codes.
+	 *
+	 * @param array<int, array{code: string, message: string}> $errors Error list.
+	 *
+	 * @return array<int, string>
+	 */
+	private function codes(array $errors): array {
+		return array_map(static fn (array $error): string => $error['code'], $errors);
+	}//end codes()
+
+	/**
+	 * Run two annotation specs through the runner and return the two cache
+	 * keys they produced, in order.
+	 *
+	 * @param array<string, mixed> $specOne First aggregation spec.
+	 * @param array<string, mixed> $specTwo Second aggregation spec.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function cacheKeysFor(array $specOne, array $specTwo): array {
+		$runner = $this->makeJoinRunner(annotations: ['one' => $specOne, 'two' => $specTwo]);
+
+		$runner->run(registerRef: 'finance', schemaRef: 'commitment-line', name: 'one');
+		$runner->run(registerRef: 'finance', schemaRef: 'commitment-line', name: 'two');
+
+		$this->assertCount(2, $this->capturedCacheKeys, 'both runs MUST have written a cache entry');
+		return $this->capturedCacheKeys;
+	}//end cacheKeysFor()
+
+	/**
+	 * Build a runner over a `commitment-line` parent and a
+	 * `commitment-budget` join target, both on the PHP-fallback path.
+	 *
+	 * @param array<string, mixed>|null $annotations Override the parent annotation map.
+	 * @param bool $joinedSchemaListAllowed Whether the caller holds `list` on the joined schema.
+	 * @param bool $expectNoJoinedFetch Assert the joined table is never hydrated (RBAC refusal test).
+	 *
+	 * @return AggregationRunner
+	 */
+	private function makeJoinRunner(
+		?array $annotations = null,
+		bool $joinedSchemaListAllowed = true,
+		bool $expectNoJoinedFetch = false,
+	): AggregationRunner {
+		$annotations = ($annotations ?? ['committed' => $this->joinAnnotation()]);
+
+		$parentSchema = $this->makeSchema('commitment-line', 10, $annotations);
+		$joinedSchema = $this->makeSchema('commitment-budget', 20);
+		$register = $this->makeRegister('finance', [10, 20]);
+
+		$this->registerMapper->method('find')->willReturn($register);
+		$this->registerMapper->method('findAll')->willReturn([$register]);
+		$this->schemaMapper->method('find')->willReturnMap(
+			[
+				['commitment-line', [], true, false, $parentSchema],
+				['commitment-budget', [], true, false, $joinedSchema],
+			]
+		);
+
+		$this->permissionHandler->method('hasPermission')->willReturnCallback(
+			static function (Schema $schema) use ($joinedSchemaListAllowed): bool {
+				if ((string)$schema->getSlug() === 'commitment-budget') {
+					return $joinedSchemaListAllowed;
+				}
+
+				return true;
+			}
+		);
+
+		$this->usePhpFallback();
+
+		$parentRows = [
+			['programme' => 'P1', 'costCentre' => 'C1', 'remainingCommitted' => 100],
+			['programme' => 'P1', 'costCentre' => 'C2', 'remainingCommitted' => 50],
+			['programme' => 'P2', 'costCentre' => 'C1', 'remainingCommitted' => 200],
+			['programme' => 'P3', 'costCentre' => 'C9', 'remainingCommitted' => 7],
+		];
+		$joinedRows = [
+			['programmeCode' => 'P1', 'authorisedAmount' => 1000],
+			['programmeCode' => 'P2', 'authorisedAmount' => 2000],
+		];
+
+		$this->magicMapper->method('findAllInRegisterSchemaTable')->willReturnCallback(
+			function (Register $register, Schema $schema) use ($parentRows, $joinedRows, $expectNoJoinedFetch): array {
+				if ((string)$schema->getSlug() === 'commitment-budget') {
+					if ($expectNoJoinedFetch === true) {
+						$this->fail('the joined schema MUST NOT be read when the RBAC gate refuses the join');
+					}
+
+					return $this->entities($joinedRows);
+				}
+
+				return $this->entities($parentRows);
+			}
+		);
+
+		return $this->makeRunner();
+	}//end makeJoinRunner()
+
+	/**
+	 * The same `commitment-line` / `commitment-budget` fixture as
+	 * {@see makeJoinRunner()}, but backed by a real in-memory SQLite
+	 * database so the emitted `GROUP BY` SQL is genuinely parsed and
+	 * executed and the joined values are real query output.
+	 *
+	 * @return AggregationRunner
+	 */
+	private function makeNativeJoinRunner(): AggregationRunner {
+		$parentSchema = $this->makeSchema('commitment-line', 10, ['committed' => $this->joinAnnotation()]);
+		$joinedSchema = $this->makeSchema('commitment-budget', 20);
+		$register = $this->makeRegister('finance', [10, 20]);
+
+		$this->registerMapper->method('find')->willReturn($register);
+		$this->registerMapper->method('findAll')->willReturn([$register]);
+		$this->schemaMapper->method('find')->willReturnMap(
+			[
+				['commitment-line', [], true, false, $parentSchema],
+				['commitment-budget', [], true, false, $joinedSchema],
+			]
+		);
+		$this->permissionHandler->method('hasPermission')->willReturn(true);
+
+		$pdo = $this->seedSqlite();
+		$this->db->method('getDatabasePlatform')->willReturn($this->createMock(SqlitePlatform::class));
+		$this->db->method('prepare')->willReturnCallback(
+			function (string $sql) use ($pdo): IPreparedStatement {
+				$pdoStmt = $pdo->prepare($sql);
+				$stmt = $this->createMock(IPreparedStatement::class);
+				$stmt->method('execute')->willReturnCallback(
+					function ($bindings = []) use ($pdoStmt): IResult {
+						$pdoStmt->execute(($bindings ?? []));
+						return $this->createMock(IResult::class);
+					}
+				);
+				$stmt->method('fetch')->willReturnCallback(
+					static fn () => $pdoStmt->fetch(PDO::FETCH_ASSOC)
+				);
+				return $stmt;
+			}
+		);
+
+		$this->magicMapper->method('getTableNameForRegisterSchema')->willReturnCallback(
+			static function (Register $register, Schema $schema): string {
+				if ((string)$schema->getSlug() === 'commitment-budget') {
+					return 'register_1_commitment_budget';
+				}
+
+				return 'register_1_commitment_line';
+			}
+		);
+
+		return $this->makeRunner();
+	}//end makeNativeJoinRunner()
+
+	/**
+	 * Create + seed the two in-memory magic tables the native join reads.
+	 * Column names mirror MagicMapper's snake_case sanitisation.
+	 *
+	 * @return PDO
+	 */
+	private function seedSqlite(): PDO {
+		$pdo = new PDO('sqlite::memory:');
+		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+		$pdo->exec(
+			'CREATE TABLE "oc_register_1_commitment_line" (
+                "_deleted" TEXT,
+                "_organisation" TEXT,
+                "programme" TEXT,
+                "cost_centre" TEXT,
+                "remaining_committed" INTEGER
+            )'
+		);
+		$pdo->exec(
+			'CREATE TABLE "oc_register_1_commitment_budget" (
+                "_deleted" TEXT,
+                "_organisation" TEXT,
+                "programme_code" TEXT,
+                "authorised_amount" INTEGER
+            )'
+		);
+
+		$line = $pdo->prepare(
+			'INSERT INTO "oc_register_1_commitment_line"
+                ("_deleted", "_organisation", "programme", "cost_centre", "remaining_committed")
+             VALUES (NULL, ?, ?, ?, ?)'
+		);
+		foreach (
+			[
+				['P1', 'C1', 100],
+				['P1', 'C2', 50],
+				['P2', 'C1', 200],
+				['P3', 'C9', 7],
+			] as $row
+		) {
+			$line->execute(['__no_active_org__', $row[0], $row[1], $row[2]]);
+		}
+
+		$budget = $pdo->prepare(
+			'INSERT INTO "oc_register_1_commitment_budget"
+                ("_deleted", "_organisation", "programme_code", "authorised_amount")
+             VALUES (NULL, ?, ?, ?)'
+		);
+		foreach ([['P1', 1000], ['P2', 2000]] as $row) {
+			$budget->execute(['__no_active_org__', $row[0], $row[1]]);
+		}
+
+		return $pdo;
+	}//end seedSqlite()
+
+	/**
+	 * Fold joined group rows into an order-independent
+	 * `"programme|costCentre" => {value, joined}` map.
+	 *
+	 * @param array<int, array<string, mixed>> $groups Grouped rows.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	private function foldJoined(array $groups): array {
+		$folded = [];
+		foreach ($groups as $group) {
+			$key = $group['keys']['programme'] . '|' . $group['keys']['costCentre'];
+			$folded[$key] = [
+				'value' => $group['value'],
+				'joined' => $group['joined']['commitment-budget.authorisedAmount'],
+			];
+		}
+
+		ksort($folded);
+		return $folded;
+	}//end foldJoined()
+
+	/**
+	 * Build a runner for the translatable-group-key projection tests.
+	 *
+	 * @param mixed $groupBy The groupBy spec, in any accepted spelling.
+	 * @param array<int, array<string, mixed>> $rows The parent rows.
+	 *
+	 * @return AggregationRunner
+	 */
+	private function makeTranslatableRunner(mixed $groupBy, array $rows): AggregationRunner {
+		$parentSchema = $this->makeSchema(
+			'commitment-line',
+			10,
+			['byTwo' => ['metric' => 'sum', 'field' => 'remainingCommitted', 'groupBy' => $groupBy]]
+		);
+		$register = $this->makeRegister('finance', [10]);
+
+		$this->registerMapper->method('find')->willReturn($register);
+		$this->registerMapper->method('findAll')->willReturn([$register]);
+		$this->schemaMapper->method('find')->willReturn($parentSchema);
+		$this->permissionHandler->method('hasPermission')->willReturn(true);
+		$this->usePhpFallback();
+		$this->magicMapper->method('findAllInRegisterSchemaTable')->willReturn($this->entities($rows));
+
+		return $this->makeRunner();
+	}//end makeTranslatableRunner()
+
+	/**
+	 * Wrap plain row arrays in ObjectEntity stubs.
+	 *
+	 * @param array<int, array<string, mixed>> $rows Row data.
+	 *
+	 * @return array<int, ObjectEntity&MockObject>
+	 */
+	private function entities(array $rows): array {
+		$entities = [];
+		foreach ($rows as $row) {
+			$entity = $this->createMock(ObjectEntity::class);
+			$entity->method('getObject')->willReturn($row);
+			$entities[] = $entity;
+		}
+
+		return $entities;
+	}//end entities()
+
+	/**
+	 * Point the DB mock at an unrecognised platform so
+	 * tryNativeAggregation() bails and the PHP fallback runs.
+	 *
+	 * @return void
+	 */
+	private function usePhpFallback(): void {
+		$platform = new class {
+			public function __toString(): string {
+				return 'OtherPlatform';
+			}
+		};
+		$this->db->method('getDatabasePlatform')->willReturn($platform);
+	}//end usePhpFallback()
+
+	/**
+	 * Assemble the runner from the shared mocks.
+	 *
+	 * @return AggregationRunner
+	 */
+	private function makeRunner(): AggregationRunner {
+		return new AggregationRunner(
+			magicMapper: $this->magicMapper,
+			registerMapper: $this->registerMapper,
+			schemaMapper: $this->schemaMapper,
+			placeholders: new PlaceholderResolver($this->userSession),
+			db: $this->db,
+			cache: $this->cache,
+			permissionHandler: $this->permissionHandler,
+			userSession: $this->userSession,
+			organisationService: $this->organisationService,
+			translationHandler: $this->translationHandler,
+			languageService: $this->languageService,
+		);
+	}//end makeRunner()
+
+	/**
+	 * Build a Schema entity.
+	 *
+	 * @param string $slug Schema slug.
+	 * @param int $id Schema DB id.
+	 * @param array<string, mixed> $aggregations Aggregation annotation map.
+	 *
+	 * @return Schema
+	 */
+	private function makeSchema(string $slug, int $id, array $aggregations = []): Schema {
+		$schema = new Schema();
+		$schema->setSlug($slug);
+		$schema->setId($id);
+		if ($aggregations !== []) {
+			$schema->setConfiguration(['x-openregister-aggregations' => $aggregations]);
+		}
+
+		return $schema;
+	}//end makeSchema()
+
+	/**
+	 * Build a Register entity.
+	 *
+	 * @param string $slug Register slug.
+	 * @param array<int, int> $schemaIds Schema IDs the register carries.
+	 *
+	 * @return Register
+	 */
+	private function makeRegister(string $slug, array $schemaIds = []): Register {
+		$register = new Register();
+		$register->setSlug($slug);
+		$register->setSchemas($schemaIds);
+		return $register;
+	}//end makeRegister()
+}//end class

--- a/tests/Unit/Service/Aggregation/AggregationJoinAndCompositeGroupByTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationJoinAndCompositeGroupByTest.php
@@ -61,8 +61,27 @@ use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 /**
- * @covers \OCA\OpenRegister\Service\Aggregation\AggregationAnnotationValidator
- * @covers \OCA\OpenRegister\Service\Aggregation\AggregationRunner
+ * NO `@covers` / `#[CoversClass]` METADATA — deliberately, and measured.
+ *
+ * This suite runs under `beStrictAboutCoverageMetadata="true"`. In that mode
+ * PHPUnit restricts recording to the named units and marks any test that
+ * executes anything else RISKY, discarding that test's coverage wholesale.
+ * Almost every test here legitimately runs a collaborator — `validateGroupBy()`
+ * calls `AggregationQuery::normaliseGroupByFields()`, the runner tests go
+ * through `PlaceholderResolver` — so naming the three classes under test threw
+ * away the measurement instead of focusing it. Measured on this exact file:
+ *
+ *   with `@covers` (or the `#[CoversClass]` attribute form):  38 / 1621 stmts
+ *   with no coverage metadata:                               661 / 1621 stmts
+ *
+ * Same tests, same assertions, same executed lines — only the attribution
+ * differs. The five files in this directory that report healthy coverage
+ * (AggregationAnnotationValidatorTest, AggregationCacheTest,
+ * AggregationQueryTest, ThresholdEvaluationServiceTest,
+ * WidgetAnnotationValidatorTest) all carry no metadata for the same reason;
+ * the ten that declare `@covers` are exactly the ones whose subject reports
+ * 0%. Restoring metadata here without also declaring a `#[UsesClass]` for
+ * every collaborator would silently zero this file's coverage again.
  */
 class AggregationJoinAndCompositeGroupByTest extends TestCase {
 
@@ -540,6 +559,359 @@ class AggregationJoinAndCompositeGroupByTest extends TestCase {
 	}//end testSingleFieldGroupByStillProjectsScalarKey()
 
 	// ------------------------------------------------------------------
+	// Validator — the remaining join rejection paths.
+	// ------------------------------------------------------------------
+
+	/**
+	 * A `join` written as a LIST rather than an object. Worth its own case
+	 * because `[]` and `{}` are the same type in PHP, so the guard has to
+	 * test list-ness explicitly or a JSON array would fall through to the
+	 * per-key reads and report five confusing errors instead of one.
+	 */
+	public function testJoinWrittenAsAListIsRejected(): void {
+		$validator = new AggregationAnnotationValidator();
+
+		$spec = $this->joinAnnotation();
+		$spec['join'] = ['through', 'on', 'select'];
+
+		$this->assertSame(
+			['aggregation-join-malformed'],
+			$this->codes($validator->validate($this->schemaDefinition(['committed' => $spec]))),
+			'a list-shaped join MUST raise exactly one shape error, not a cascade'
+		);
+	}//end testJoinWrittenAsAListIsRejected()
+
+	/**
+	 * A join with no `through` names no schema to join to.
+	 */
+	public function testJoinWithoutThroughIsRejected(): void {
+		$validator = new AggregationAnnotationValidator();
+
+		$spec = $this->joinAnnotation();
+		unset($spec['join']['through']);
+
+		$this->assertContains(
+			'aggregation-join-through-empty',
+			$this->codes($validator->validate($this->schemaDefinition(['committed' => $spec])))
+		);
+	}//end testJoinWithoutThroughIsRejected()
+
+	/**
+	 * `on` must be a non-empty string or a non-empty map. An empty map, a
+	 * list, and a non-string scalar all fail the same way.
+	 *
+	 * @param mixed $onClause The malformed `on` value.
+	 *
+	 * @dataProvider malformedOnProvider
+	 */
+	public function testMalformedJoinOnIsRejected(mixed $onClause): void {
+		$validator = new AggregationAnnotationValidator();
+
+		$spec = $this->joinAnnotation();
+		$spec['join']['on'] = $onClause;
+
+		$this->assertContains(
+			'aggregation-join-on-malformed',
+			$this->codes($validator->validate($this->schemaDefinition(['committed' => $spec])))
+		);
+	}//end testMalformedJoinOnIsRejected()
+
+	/**
+	 * @return array<string, array<int, mixed>>
+	 */
+	public static function malformedOnProvider(): array {
+		return [
+			'empty string' => [''],
+			'empty map' => [[]],
+			'list' => [['programmeCode']],
+			'integer' => [42],
+			'null' => [null],
+		];
+	}//end malformedOnProvider()
+
+	/**
+	 * A `select` entry that names no field — a bare number, or an object
+	 * with a `metric` but no `field`.
+	 *
+	 * @param mixed $entry The malformed select entry.
+	 *
+	 * @dataProvider malformedSelectEntryProvider
+	 */
+	public function testMalformedJoinSelectEntryIsRejected(mixed $entry): void {
+		$validator = new AggregationAnnotationValidator();
+
+		$spec = $this->joinAnnotation();
+		$spec['join']['select'] = [$entry];
+
+		$this->assertContains(
+			'aggregation-join-select-malformed',
+			$this->codes($validator->validate($this->schemaDefinition(['committed' => $spec])))
+		);
+	}//end testMalformedJoinSelectEntryIsRejected()
+
+	/**
+	 * @return array<string, array<int, mixed>>
+	 */
+	public static function malformedSelectEntryProvider(): array {
+		return [
+			'integer' => [42],
+			'empty string' => [''],
+			'object without field' => [['metric' => 'sum']],
+			'object with empty field' => [['field' => '']],
+			'object with non-string field' => [['field' => 7]],
+		];
+	}//end malformedSelectEntryProvider()
+
+	/**
+	 * A `select` list that is not a list at all.
+	 */
+	public function testNonListJoinSelectIsRejected(): void {
+		$validator = new AggregationAnnotationValidator();
+
+		$spec = $this->joinAnnotation();
+		$spec['join']['select'] = 'commitment-budget.authorisedAmount';
+
+		$this->assertContains(
+			'aggregation-join-select-empty',
+			$this->codes($validator->validate($this->schemaDefinition(['committed' => $spec])))
+		);
+	}//end testNonListJoinSelectIsRejected()
+
+	/**
+	 * The joined-side filter must be a map when present.
+	 */
+	public function testNonMapJoinFilterIsRejected(): void {
+		$validator = new AggregationAnnotationValidator();
+
+		$spec = $this->joinAnnotation();
+		$spec['join']['filter'] = 'afgesloten=false';
+
+		$this->assertContains(
+			'aggregation-join-filter-malformed',
+			$this->codes($validator->validate($this->schemaDefinition(['committed' => $spec])))
+		);
+	}//end testNonMapJoinFilterIsRejected()
+
+	/**
+	 * An explicit `on` map whose parent halves ARE declared properties
+	 * validates clean — the accept side of the check whose reject side
+	 * testJoinOnMapRejectsUndeclaredParentField pins.
+	 */
+	public function testJoinOnMapWithDeclaredParentFieldsValidates(): void {
+		$validator = new AggregationAnnotationValidator();
+
+		$spec = $this->joinAnnotation();
+		$spec['join']['on'] = ['programme' => 'programmeCode', 'costCentre' => 'ccCode'];
+
+		$this->assertSame([], $validator->validate($this->schemaDefinition(['committed' => $spec])));
+	}//end testJoinOnMapWithDeclaredParentFieldsValidates()
+
+	// ------------------------------------------------------------------
+	// Validator — groupBy shapes the composite check now leans on.
+	// ------------------------------------------------------------------
+
+	/**
+	 * groupBy spellings that normalise to NO fields are malformed. An empty
+	 * list is the interesting one: it is a perfectly good array, so a guard
+	 * that only tested `is_array()` would accept it and then group on
+	 * nothing.
+	 *
+	 * @param mixed $groupBy The groupBy value that names no field.
+	 *
+	 * @dataProvider emptyGroupByProvider
+	 */
+	public function testGroupByNamingNoFieldIsRejected(mixed $groupBy): void {
+		$validator = new AggregationAnnotationValidator();
+
+		$this->assertContains(
+			'aggregation-groupby-malformed',
+			$this->codes($validator->validate($this->schemaDefinition(
+				['x' => ['metric' => 'count', 'groupBy' => $groupBy]]
+			)))
+		);
+	}//end testGroupByNamingNoFieldIsRejected()
+
+	/**
+	 * @return array<string, array<int, mixed>>
+	 */
+	public static function emptyGroupByProvider(): array {
+		return [
+			'empty list' => [[]],
+			'empty fields list' => [['fields' => []]],
+			'object with neither field nor fields' => [['bucket' => 'day']],
+			'scalar' => ['programme'],
+		];
+	}//end emptyGroupByProvider()
+
+	/**
+	 * A single-element LIST is the boundary between the two group-key row
+	 * shapes: it must validate like the object form, and the runner must
+	 * still emit the legacy scalar `key` (not a one-entry `keys` map), or a
+	 * consumer that migrated its spelling would silently lose its keys.
+	 */
+	public function testSingleElementListGroupByValidatesAndKeepsScalarKeyShape(): void {
+		$validator = new AggregationAnnotationValidator();
+		$this->assertSame(
+			[],
+			$validator->validate($this->schemaDefinition(
+				['x' => ['metric' => 'count', 'groupBy' => ['programme']]]
+			))
+		);
+
+		$runner = $this->makeTranslatableRunner(
+			groupBy: ['programme'],
+			rows: [['programme' => 'P1', 'costCentre' => 'C1', 'remainingCommitted' => 10]]
+		);
+		$result = $runner->run(registerRef: 'finance', schemaRef: 'commitment-line', name: 'byTwo');
+
+		$this->assertSame('P1', $result['groups'][0]['key']);
+		$this->assertArrayNotHasKey('keys', $result['groups'][0]);
+	}//end testSingleElementListGroupByValidatesAndKeepsScalarKeyShape()
+
+	/**
+	 * The `{field, bucket}` object form — the full legacy spelling, bucket
+	 * included — still validates.
+	 */
+	public function testFieldAndBucketObjectGroupByValidates(): void {
+		$validator = new AggregationAnnotationValidator();
+
+		$this->assertSame(
+			[],
+			$validator->validate($this->schemaDefinition(
+				['x' => ['metric' => 'count', 'groupBy' => ['field' => 'programme', 'bucket' => 'day']]]
+			))
+		);
+	}//end testFieldAndBucketObjectGroupByValidates()
+
+	// ------------------------------------------------------------------
+	// Runner — join key spellings and merge edge cases.
+	// ------------------------------------------------------------------
+
+	/**
+	 * The explicit `{parentField: joinedField}` map and the single-string
+	 * shorthand must resolve to the SAME join. The shorthand infers the
+	 * parent side (first group field, since `programmeCode` is not itself
+	 * grouped); this pins that the inference lands where the explicit
+	 * spelling says it should, which is the whole basis for accepting the
+	 * shorthand at all.
+	 */
+	public function testExplicitOnMapAndStringShorthandAgree(): void {
+		$stringSpec = $this->joinAnnotation();
+
+		$mapSpec = $this->joinAnnotation();
+		$mapSpec['join']['on'] = ['programme' => 'programmeCode'];
+
+		$viaString = $this->makeJoinRunner(annotations: ['committed' => $stringSpec])
+			->run(registerRef: 'finance', schemaRef: 'commitment-line', name: 'committed');
+
+		$this->setUp();
+		$viaMap = $this->makeJoinRunner(annotations: ['committed' => $mapSpec])
+			->run(registerRef: 'finance', schemaRef: 'commitment-line', name: 'committed');
+
+		$this->assertSame(['programme' => 'programmeCode'], $viaString['join']['on']);
+		$this->assertSame(['programme' => 'programmeCode'], $viaMap['join']['on']);
+		$this->assertSame($this->foldJoined($viaString['groups']), $this->foldJoined($viaMap['groups']));
+	}//end testExplicitOnMapAndStringShorthandAgree()
+
+	/**
+	 * An explicit `on` naming a parent field that is NOT grouped is refused.
+	 * The merge reads the join key out of the group row, so an ungrouped
+	 * parent field has no value there — it would match nothing on every row
+	 * while looking like a working join.
+	 */
+	public function testOnMapNamingUngroupedParentFieldIsRefused(): void {
+		$spec = $this->joinAnnotation();
+		$spec['join']['on'] = ['remainingCommitted' => 'programmeCode'];
+
+		$runner = $this->makeJoinRunner(annotations: ['committed' => $spec]);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('is not one of the groupBy fields');
+
+		$runner->run(registerRef: 'finance', schemaRef: 'commitment-line', name: 'committed');
+	}//end testOnMapNamingUngroupedParentFieldIsRefused()
+
+	/**
+	 * Joined rows that match NO parent group are dropped silently, and
+	 * SEVERAL joined rows sharing one key are reduced by the select metric
+	 * (`sum` by default) rather than one arbitrarily winning.
+	 */
+	public function testJoinedRowsWithNoGroupAreDroppedAndDuplicateKeysReduce(): void {
+		$runner = $this->makeJoinRunner(
+			joinedRowsOverride: [
+				['programmeCode' => 'P1', 'authorisedAmount' => 1000],
+				['programmeCode' => 'P1', 'authorisedAmount' => 250],
+				['programmeCode' => 'P2', 'authorisedAmount' => 2000],
+				['programmeCode' => 'P404', 'authorisedAmount' => 999999],
+			]
+		);
+
+		$result = $runner->run(registerRef: 'finance', schemaRef: 'commitment-line', name: 'committed');
+		$folded = $this->foldJoined($result['groups']);
+
+		$this->assertSame(1250.0, $folded['P1|C1']['joined'], 'duplicate join keys MUST reduce, not overwrite');
+		$this->assertSame(1250.0, $folded['P1|C2']['joined']);
+		$this->assertSame(2000.0, $folded['P2|C1']['joined']);
+		$this->assertNull($folded['P3|C9']['joined']);
+		$this->assertCount(4, $folded, 'the unmatched P404 budget MUST NOT invent a group');
+	}//end testJoinedRowsWithNoGroupAreDroppedAndDuplicateKeysReduce()
+
+	/**
+	 * The `{field, metric}` select spelling overrides the `sum` default, and
+	 * a metric outside the closed vocabulary is refused rather than quietly
+	 * reduced some other way.
+	 */
+	public function testSelectObjectSpellingHonoursMetricAndRejectsUnknownOnes(): void {
+		$maxSpec = $this->joinAnnotation();
+		$maxSpec['join']['select'] = [['field' => 'authorisedAmount', 'metric' => 'max', 'alias' => 'cap']];
+
+		$result = $this->makeJoinRunner(annotations: ['committed' => $maxSpec])
+			->run(registerRef: 'finance', schemaRef: 'commitment-line', name: 'committed');
+
+		$this->assertSame(['cap'], $result['join']['select'], 'the declared alias MUST be the response key');
+		$this->assertSame(1000.0, $result['groups'][0]['joined']['cap']);
+
+		$this->setUp();
+		$badSpec = $this->joinAnnotation();
+		$badSpec['join']['select'] = [['field' => 'authorisedAmount', 'metric' => 'median']];
+		$runner = $this->makeJoinRunner(annotations: ['committed' => $badSpec]);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('join.select metric "median" is not supported');
+		$runner->run(registerRef: 'finance', schemaRef: 'commitment-line', name: 'committed');
+	}//end testSelectObjectSpellingHonoursMetricAndRejectsUnknownOnes()
+
+	/**
+	 * When the joined hydrate hits PHP_FALLBACK_ROW_CAP the envelope says so.
+	 * The joined numbers are then computed over a PREFIX of the joined table,
+	 * so a consumer that ignores `join.truncated` is reading a partial budget
+	 * as if it were the whole one.
+	 */
+	public function testJoinTruncatedIsSetWhenJoinedHydrateHitsTheRowCap(): void {
+		$capped = [];
+		for ($i = 0; $i < 10000; $i++) {
+			$capped[] = ['programmeCode' => 'P1', 'authorisedAmount' => 1];
+		}
+
+		$result = $this->makeJoinRunner(joinedRowsOverride: $capped)
+			->run(registerRef: 'finance', schemaRef: 'commitment-line', name: 'committed');
+
+		$this->assertTrue($result['join']['truncated'], 'a joined hydrate at the cap MUST flag truncation');
+		$this->assertSame(10000.0, $result['groups'][0]['joined']['commitment-budget.authorisedAmount']);
+	}//end testJoinTruncatedIsSetWhenJoinedHydrateHitsTheRowCap()
+
+	/**
+	 * The un-truncated control for the test above — without it, a bug that
+	 * hardcoded `truncated: true` would pass.
+	 */
+	public function testJoinTruncatedIsFalseBelowTheRowCap(): void {
+		$result = $this->makeJoinRunner()
+			->run(registerRef: 'finance', schemaRef: 'commitment-line', name: 'committed');
+
+		$this->assertFalse($result['join']['truncated']);
+	}//end testJoinTruncatedIsFalseBelowTheRowCap()
+
+	// ------------------------------------------------------------------
 	// Fixtures + helpers.
 	// ------------------------------------------------------------------
 
@@ -618,6 +990,7 @@ class AggregationJoinAndCompositeGroupByTest extends TestCase {
 	 * @param array<string, mixed>|null $annotations Override the parent annotation map.
 	 * @param bool $joinedSchemaListAllowed Whether the caller holds `list` on the joined schema.
 	 * @param bool $expectNoJoinedFetch Assert the joined table is never hydrated (RBAC refusal test).
+	 * @param array<int, array<string, mixed>>|null $joinedRowsOverride Replace the joined-side rows.
 	 *
 	 * @return AggregationRunner
 	 */
@@ -625,6 +998,7 @@ class AggregationJoinAndCompositeGroupByTest extends TestCase {
 		?array $annotations = null,
 		bool $joinedSchemaListAllowed = true,
 		bool $expectNoJoinedFetch = false,
+		?array $joinedRowsOverride = null,
 	): AggregationRunner {
 		$annotations = ($annotations ?? ['committed' => $this->joinAnnotation()]);
 
@@ -659,10 +1033,10 @@ class AggregationJoinAndCompositeGroupByTest extends TestCase {
 			['programme' => 'P2', 'costCentre' => 'C1', 'remainingCommitted' => 200],
 			['programme' => 'P3', 'costCentre' => 'C9', 'remainingCommitted' => 7],
 		];
-		$joinedRows = [
+		$joinedRows = ($joinedRowsOverride ?? [
 			['programmeCode' => 'P1', 'authorisedAmount' => 1000],
 			['programmeCode' => 'P2', 'authorisedAmount' => 2000],
-		];
+		]);
 
 		$this->magicMapper->method('findAllInRegisterSchemaTable')->willReturnCallback(
 			function (Register $register, Schema $schema) use ($parentRows, $joinedRows, $expectNoJoinedFetch): array {
@@ -840,17 +1214,22 @@ class AggregationJoinAndCompositeGroupByTest extends TestCase {
 	}//end makeTranslatableRunner()
 
 	/**
-	 * Wrap plain row arrays in ObjectEntity stubs.
+	 * Wrap plain row arrays in real ObjectEntity instances.
+	 *
+	 * Real entities rather than mocks: the row-cap test builds 10 000 of
+	 * these, and PHPUnit's mock generator is far too slow at that volume.
+	 * `ObjectEntity::getObject()` prepends its own `id` key; harmless here,
+	 * since every assertion reads named fields.
 	 *
 	 * @param array<int, array<string, mixed>> $rows Row data.
 	 *
-	 * @return array<int, ObjectEntity&MockObject>
+	 * @return array<int, ObjectEntity>
 	 */
 	private function entities(array $rows): array {
 		$entities = [];
 		foreach ($rows as $row) {
-			$entity = $this->createMock(ObjectEntity::class);
-			$entity->method('getObject')->willReturn($row);
+			$entity = new ObjectEntity();
+			$entity->setObject($row);
 			$entities[] = $entity;
 		}
 


### PR DESCRIPTION
Unblocks the engine half of ConductionNL/shillinq#1216.

## What was actually wrong — a correction worth reading

I opened this expecting to build composite `groupBy`. It was **already built**: archived change `2026-07-14-aggregation-multi-field-groupby` shipped `AggregationQuery::normaliseGroupByFields()`, native `GROUP BY a, b`, PHP-fallback parity and a passing test.

The **validator** rejected it. `AggregationAnnotationValidator` guarded on `isset($groupBy['field'])`, so a list form was refused *at save time* while the runner could have executed it perfectly.

That is a validator and an executor each owning a copy of the grammar, drifting apart — the same shape as the notification-filter drift. The fix is not a second copy of the rule: the validator now **delegates the shape question to `AggregationQuery::normaliseGroupByFields()`**, the one canonicaliser the runner already uses, so the two cannot disagree again.

Two real gaps behind it:

- **`projectTranslatableGroupKeys()`** carried the same `isset($groupBy['field'])` guard and only handled the scalar `key`. Composite groups emit `keys: {...}`, so every multi-field aggregation was handing callers **raw language maps** instead of projected values. Now projects every translatable member.
- **`join`** — genuinely absent, zero occurrences under `lib/Service/Aggregation/`. Built.

## The join is a two-query merge, not SQL

Deliberate, and documented in `applyJoin()`'s docblock. The schemas live in separate magic shard tables, so a single statement would have to re-derive **both** tables' `_organisation` and soft-delete predicates by hand. Routing the joined schema back through `tryNativeAggregation()` makes it **inherit** them instead. That method also answers `null` for shapes it cannot express — a JOIN inside it would fall back to a PHP path with no join, and the two would disagree exactly when it bailed.

**Performance:** native is `1 + N` queries where N = `count(select)` — **independent of group count**. Four groups and forty thousand groups issue the same queries; this is not an N+1. The PHP fallback hydrates the joined table **once** and computes all N entries from those rows. The merge is O(parent + joined) via a hash index. `join.truncated` is set when the joined hydrate hits the row cap.

## RBAC — three controls

1. **Explicit `hasPermission(action: 'list')` on the joined schema**, before any joined row is read. `resolveJoinTarget()` orders it deliberately, and a test `fail()`s if the joined table is touched when permission is denied.
2. **Tenancy from the shared read paths** — `tryNativeAggregation()`'s `_organisation = ?` (fail-closed to `__no_active_org__`) or `MagicMapper::findAllInRegisterSchemaTable()`.
3. **Cache key carries the join spec** plus `userId` and org, so two specs differing only in their join cannot read each other's results.

One precision rather than a claim: `findRegisterForSchema()` deliberately bypasses multi-tenancy as a metadata read. It is documented as **not** a tenancy control rather than counted as one.

## Group-key shape

Unchanged: `{keys: {field: value}, value}` for multi-field, `{key, value}` for single. It was already chosen and live, and a map lets a caller pivot without re-parsing — a joined string would need an escaping rule for values containing the separator.

## Scope declined

`join` beside `from` is **rejected by the validator** rather than half-implemented: `runCrossSchema()` has no join stage, so such a spec would silently never execute.

## Must-fail controls — two, both confirmed

- Removed `'join' => $join` from the cache key → `testCacheKeyDiffersOnJoinAlone` went **red**, showing a join-bearing and a join-less spec producing byte-identical keys.
- Restored the old `isset($groupBy['field'])` guard → `testCompositeGroupByProjectsEveryTranslatableKey` went **red** with the raw `{nl, en}` map leaking, while the single-field regression guard stayed green.

## Verification

| | |
|---|---|
| `phpcs` | pass |
| `phpstan` | pass — `[OK] No errors` |
| `psalm` | pass — `No errors found!` |
| `phpunit` (aggregation) | **223 tests, 467 assertions, 0 failures** |
| `hydra-gates` | gate-16 spec-coverage **pass**; 3 unrelated pre-existing failures |

Two things worth knowing for anyone verifying locally:

- **`phpunit-unit.xml` cannot run in a bare clone** — `nextcloud/ocp` declares no autoload, so OCP resolves only inside the container. `phpunit-unit-local.xml` is the working equivalent.
- **`composer phpmd` was reporting stale results** from a ~967MB `~/.pdepend` cache that is not invalidating on edits: it reported findings byte-identical to a pre-refactor run. With a cold cache the same command reports clean for these files. A *per-file* phpmd invocation also reported clean over a file with six known baseline violations — don't trust single-file phpmd runs here.

## Note for the shillinq side

Their `"on": "CommitmentBudget.programmeCode"` names only the joined side. The implementation resolves the parent side as the same-named group field, else the first — giving `programme => programmeCode`, which matches intent but is an inference. The explicit `{parentField: joinedField}` map spelling is supported and is the only one that can express a composite join key; shillinq should prefer it.
