### PR TITLE
feat(aggregation): let an annotation declare several metrics over one grouping

### DIFF
--- a/lib/Service/Aggregation/AggregationAnnotationValidator.php
+++ b/lib/Service/Aggregation/AggregationAnnotationValidator.php
@@ -158,6 +158,34 @@ final class AggregationAnnotationValidator {
 			// schema author passing an array) must not reach the string cast —
 			// PHP emits "Array to string conversion" — so they collapse to ''
 			// and fail the metric check with a proper validation error.
+			// `metrics`: several figures over one grouping. Validated BEFORE the
+			// single-metric check because a spec carrying `metrics` satisfies
+			// the "what am I computing" question through that key instead, and
+			// would otherwise be rejected for a missing `metric` it does not
+			// need. Each entry is held to exactly the rules a single metric is:
+			// a metric from the closed vocabulary, and a field that the schema
+			// actually declares when the metric needs one. A `metrics` list the
+			// runner cannot execute must fail here rather than at read time,
+			// where it would surface as an empty envelope.
+			$metricsSpec = ($spec['metrics'] ?? null);
+			if ($metricsSpec !== null) {
+				$metricsErrors = $this->validateMetricsList(
+					name: $name,
+					metrics: $metricsSpec,
+					propKeys: $propKeys
+				);
+				$errors = array_merge($errors, $metricsErrors);
+				if ($metricsErrors !== []) {
+					continue;
+				}
+
+				$errors = array_merge(
+					$errors,
+					$this->validateGroupBy(name: $name, spec: $spec, propKeys: $propKeys)
+				);
+				continue;
+			}
+
 			$metric = ($spec['metric'] ?? $spec['select'] ?? '');
 			if (is_scalar($metric) === false) {
 				$metric = '';
@@ -399,4 +427,109 @@ final class AggregationAnnotationValidator {
 
 		return $errors;
 	}//end validateCrossSchemaSpec()
+
+	/**
+	 * Validate a `metrics` list — several figures over one grouping.
+	 *
+	 * Holds every entry to exactly the rules a single `metric` is held to: a
+	 * metric drawn from the closed vocabulary, and a field the schema actually
+	 * declares whenever the metric needs one. The point is that an entry the
+	 * runner cannot execute fails HERE, at save time, rather than at read time
+	 * where a rejected metric shows up as a missing figure in an otherwise
+	 * well-formed envelope — indistinguishable from a genuine zero.
+	 *
+	 * A single-entry list is accepted rather than rewritten to `metric`: the
+	 * runner treats `count($metrics) > 1` as the multi path and falls back to
+	 * the scalar shape below that, so one entry behaves exactly like the
+	 * single-metric spelling without the author having to know which to use.
+	 *
+	 * @param string             $name     The aggregation name, for messages.
+	 * @param mixed              $metrics  The declared `metrics` value.
+	 * @param array<int, string> $propKeys Property names the schema declares.
+	 *
+	 * @return array<int, array{code: string, message: string}> Validation errors.
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	private function validateMetricsList(string $name, mixed $metrics, array $propKeys): array {
+		if (is_array($metrics) === false || $metrics === [] || array_is_list($metrics) === false) {
+			return [
+				[
+					'code' => 'aggregation-metrics-malformed',
+					'message' => sprintf(
+						'Aggregation "%s" metrics must be a non-empty list of {metric, field?} objects.',
+						$name
+					),
+				],
+			];
+		}
+
+		$errors = [];
+		foreach ($metrics as $index => $entry) {
+			if (is_array($entry) === false) {
+				$errors[] = [
+					'code' => 'aggregation-metrics-entry-malformed',
+					'message' => sprintf('Aggregation "%s" metrics[%d] must be an object.', $name, $index),
+				];
+				continue;
+			}
+
+			$entryMetric = ($entry['metric'] ?? '');
+			if (is_scalar($entryMetric) === false) {
+				$entryMetric = '';
+			}
+
+			$entryMetric = (string)$entryMetric;
+			if (in_array($entryMetric, self::VALID_METRICS, true) === false) {
+				$errors[] = [
+					'code' => 'aggregation-metrics-bad-metric',
+					'message' => sprintf(
+						'Aggregation "%s" metrics[%d] metric "%s" is not in [%s].',
+						$name,
+						$index,
+						$entryMetric,
+						implode(', ', self::VALID_METRICS)
+					),
+				];
+				continue;
+			}
+
+			if (in_array($entryMetric, self::REQUIRES_FIELD, true) === false) {
+				continue;
+			}
+
+			$entryField = ($entry['field'] ?? '');
+			if (is_scalar($entryField) === false) {
+				$entryField = '';
+			}
+
+			$entryField = (string)$entryField;
+			if ($entryField === '') {
+				$errors[] = [
+					'code' => 'aggregation-metrics-field-missing',
+					'message' => sprintf(
+						'Aggregation "%s" metrics[%d] with metric "%s" requires a field.',
+						$name,
+						$index,
+						$entryMetric
+					),
+				];
+				continue;
+			}
+
+			if (in_array($entryField, $propKeys, true) === false) {
+				$errors[] = [
+					'code' => 'aggregation-metrics-field-not-in-schema',
+					'message' => sprintf(
+						'Aggregation "%s" metrics[%d] field "%s" is not declared in the schema properties.',
+						$name,
+						$index,
+						$entryField
+					),
+				];
+			}
+		}//end foreach
+
+		return $errors;
+	}//end validateMetricsList()
 }//end class

--- a/lib/Service/Aggregation/AggregationAnnotationValidator.php
+++ b/lib/Service/Aggregation/AggregationAnnotationValidator.php
@@ -74,14 +74,26 @@ final class AggregationAnnotationValidator {
 	private AggregationJoinAnnotationValidator $joinValidator;
 
 	/**
+	 * Validator for the `metrics` clause.
+	 *
+	 * Split out for the same reason as the join validator: the per-entry
+	 * checks are a small decision tree, and inlining them pushed this class
+	 * past its complexity threshold.
+	 *
+	 * @var AggregationMetricsAnnotationValidator
+	 */
+	private AggregationMetricsAnnotationValidator $metricsValidator;
+
+	/**
 	 * Constructor.
 	 *
-	 * Plain `new` rather than injection: both classes are pure shape
+	 * Plain `new` rather than injection: all three classes are pure shape
 	 * validators with no collaborators, and the schema-save call sites
 	 * construct this validator directly.
 	 */
 	public function __construct() {
 		$this->joinValidator = new AggregationJoinAnnotationValidator();
+		$this->metricsValidator = new AggregationMetricsAnnotationValidator();
 	}//end __construct()
 
 	/**
@@ -169,7 +181,7 @@ final class AggregationAnnotationValidator {
 			// where it would surface as an empty envelope.
 			$metricsSpec = ($spec['metrics'] ?? null);
 			if ($metricsSpec !== null) {
-				$metricsErrors = $this->validateMetricsList(
+				$metricsErrors = $this->metricsValidator->validate(
 					name: $name,
 					metrics: $metricsSpec,
 					propKeys: $propKeys
@@ -428,108 +440,4 @@ final class AggregationAnnotationValidator {
 		return $errors;
 	}//end validateCrossSchemaSpec()
 
-	/**
-	 * Validate a `metrics` list — several figures over one grouping.
-	 *
-	 * Holds every entry to exactly the rules a single `metric` is held to: a
-	 * metric drawn from the closed vocabulary, and a field the schema actually
-	 * declares whenever the metric needs one. The point is that an entry the
-	 * runner cannot execute fails HERE, at save time, rather than at read time
-	 * where a rejected metric shows up as a missing figure in an otherwise
-	 * well-formed envelope — indistinguishable from a genuine zero.
-	 *
-	 * A single-entry list is accepted rather than rewritten to `metric`: the
-	 * runner treats `count($metrics) > 1` as the multi path and falls back to
-	 * the scalar shape below that, so one entry behaves exactly like the
-	 * single-metric spelling without the author having to know which to use.
-	 *
-	 * @param string             $name     The aggregation name, for messages.
-	 * @param mixed              $metrics  The declared `metrics` value.
-	 * @param array<int, string> $propKeys Property names the schema declares.
-	 *
-	 * @return array<int, array{code: string, message: string}> Validation errors.
-	 *
-	 * @spec openspec/specs/object-lifecycle/spec.md
-	 */
-	private function validateMetricsList(string $name, mixed $metrics, array $propKeys): array {
-		if (is_array($metrics) === false || $metrics === [] || array_is_list($metrics) === false) {
-			return [
-				[
-					'code' => 'aggregation-metrics-malformed',
-					'message' => sprintf(
-						'Aggregation "%s" metrics must be a non-empty list of {metric, field?} objects.',
-						$name
-					),
-				],
-			];
-		}
-
-		$errors = [];
-		foreach ($metrics as $index => $entry) {
-			if (is_array($entry) === false) {
-				$errors[] = [
-					'code' => 'aggregation-metrics-entry-malformed',
-					'message' => sprintf('Aggregation "%s" metrics[%d] must be an object.', $name, $index),
-				];
-				continue;
-			}
-
-			$entryMetric = ($entry['metric'] ?? '');
-			if (is_scalar($entryMetric) === false) {
-				$entryMetric = '';
-			}
-
-			$entryMetric = (string)$entryMetric;
-			if (in_array($entryMetric, self::VALID_METRICS, true) === false) {
-				$errors[] = [
-					'code' => 'aggregation-metrics-bad-metric',
-					'message' => sprintf(
-						'Aggregation "%s" metrics[%d] metric "%s" is not in [%s].',
-						$name,
-						$index,
-						$entryMetric,
-						implode(', ', self::VALID_METRICS)
-					),
-				];
-				continue;
-			}
-
-			if (in_array($entryMetric, self::REQUIRES_FIELD, true) === false) {
-				continue;
-			}
-
-			$entryField = ($entry['field'] ?? '');
-			if (is_scalar($entryField) === false) {
-				$entryField = '';
-			}
-
-			$entryField = (string)$entryField;
-			if ($entryField === '') {
-				$errors[] = [
-					'code' => 'aggregation-metrics-field-missing',
-					'message' => sprintf(
-						'Aggregation "%s" metrics[%d] with metric "%s" requires a field.',
-						$name,
-						$index,
-						$entryMetric
-					),
-				];
-				continue;
-			}
-
-			if (in_array($entryField, $propKeys, true) === false) {
-				$errors[] = [
-					'code' => 'aggregation-metrics-field-not-in-schema',
-					'message' => sprintf(
-						'Aggregation "%s" metrics[%d] field "%s" is not declared in the schema properties.',
-						$name,
-						$index,
-						$entryField
-					),
-				];
-			}
-		}//end foreach
-
-		return $errors;
-	}//end validateMetricsList()
 }//end class

--- a/lib/Service/Aggregation/AggregationMetricsAnnotationValidator.php
+++ b/lib/Service/Aggregation/AggregationMetricsAnnotationValidator.php
@@ -1,0 +1,227 @@
+<?php
+
+/**
+ * OpenRegister AggregationMetricsAnnotationValidator
+ *
+ * Schema-save validation for the `metrics` clause of an entry in the
+ * `x-openregister-aggregations` annotation — several figures over ONE
+ * grouping, e.g. a budget line needing sum(committed) AND sum(invoiced) per
+ * coding combination.
+ *
+ * WHY VALIDATION HERE MATTERS MORE THAN IT LOOKS. A `metrics` entry the runner
+ * cannot execute does not throw at read time: it comes back as a missing
+ * figure inside an otherwise well-formed envelope, which is indistinguishable
+ * from a genuine zero. Refusing it at SAVE time is the only point at which the
+ * author can still be told.
+ *
+ * Each entry is held to exactly the rules a single `metric` is — a metric from
+ * the closed vocabulary, and a field the schema actually declares whenever the
+ * metric needs one — so the two spellings cannot diverge in what they accept.
+ *
+ * Lives in its own class rather than as a method on
+ * {@see AggregationAnnotationValidator}, mirroring
+ * {@see AggregationJoinAnnotationValidator}: the per-entry checks are a small
+ * decision tree, and inlining them pushed that class past its complexity
+ * threshold. Splitting keeps each validator readable and independently
+ * testable.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Aggregation
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Aggregation;
+
+/**
+ * Validates the `metrics` list of an aggregation annotation.
+ *
+ * @spec openspec/specs/object-lifecycle/spec.md
+ */
+class AggregationMetricsAnnotationValidator {
+
+	/**
+	 * Metrics the aggregation engine can execute.
+	 *
+	 * @var array<int, string>
+	 */
+	private const VALID_METRICS = ['count', 'sum', 'avg', 'min', 'max', 'count_distinct'];
+
+	/**
+	 * Metrics that are meaningless without a field to aggregate.
+	 *
+	 * @var array<int, string>
+	 */
+	private const REQUIRES_FIELD = ['sum', 'avg', 'min', 'max', 'count_distinct'];
+
+	/**
+	 * Validate a declared `metrics` list.
+	 *
+	 * Reports EVERY bad entry rather than stopping at the first: a validator
+	 * that short-circuits turns one fix-and-retry cycle into several, and each
+	 * message names the entry's index because "some field is wrong" is not
+	 * actionable across a list.
+	 *
+	 * @param string             $name     The aggregation name, for messages.
+	 * @param mixed              $metrics  The declared `metrics` value.
+	 * @param array<int, string> $propKeys Property names the schema declares.
+	 *
+	 * @return array<int, array{code: string, message: string}> Validation errors.
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	public function validate(string $name, mixed $metrics, array $propKeys): array {
+		if (is_array($metrics) === false || $metrics === [] || array_is_list($metrics) === false) {
+			return [
+				[
+					'code' => 'aggregation-metrics-malformed',
+					'message' => sprintf(
+						'Aggregation "%s" metrics must be a non-empty list of {metric, field?} objects.',
+						$name
+					),
+				],
+			];
+		}
+
+		$errors = [];
+		foreach ($metrics as $index => $entry) {
+			$entryErrors = $this->validateEntry(
+				name: $name,
+				index: (int)$index,
+				entry: $entry,
+				propKeys: $propKeys
+			);
+			$errors = array_merge($errors, $entryErrors);
+		}
+
+		return $errors;
+	}//end validate()
+
+	/**
+	 * Validate one `{metric, field?}` entry.
+	 *
+	 * @param string             $name     The aggregation name, for messages.
+	 * @param int                $index    The entry's position in the list.
+	 * @param mixed              $entry    The entry itself.
+	 * @param array<int, string> $propKeys Property names the schema declares.
+	 *
+	 * @return array<int, array{code: string, message: string}> Validation errors.
+	 */
+	private function validateEntry(string $name, int $index, mixed $entry, array $propKeys): array {
+		if (is_array($entry) === false) {
+			return [
+				[
+					'code' => 'aggregation-metrics-entry-malformed',
+					'message' => sprintf('Aggregation "%s" metrics[%d] must be an object.', $name, $index),
+				],
+			];
+		}
+
+		$metric = $this->asString(value: ($entry['metric'] ?? ''));
+		if (in_array($metric, self::VALID_METRICS, true) === false) {
+			return [
+				[
+					'code' => 'aggregation-metrics-bad-metric',
+					'message' => sprintf(
+						'Aggregation "%s" metrics[%d] metric "%s" is not in [%s].',
+						$name,
+						$index,
+						$metric,
+						implode(', ', self::VALID_METRICS)
+					),
+				],
+			];
+		}
+
+		if (in_array($metric, self::REQUIRES_FIELD, true) === false) {
+			return [];
+		}
+
+		return $this->validateField(
+			name: $name,
+			index: $index,
+			metric: $metric,
+			field: $this->asString(value: ($entry['field'] ?? '')),
+			propKeys: $propKeys
+		);
+	}//end validateEntry()
+
+	/**
+	 * Validate the field of a metric that requires one.
+	 *
+	 * @param string             $name     The aggregation name, for messages.
+	 * @param int                $index    The entry's position in the list.
+	 * @param string             $metric   The entry's metric.
+	 * @param string             $field    The entry's field.
+	 * @param array<int, string> $propKeys Property names the schema declares.
+	 *
+	 * @return array<int, array{code: string, message: string}> Validation errors.
+	 */
+	private function validateField(
+		string $name,
+		int $index,
+		string $metric,
+		string $field,
+		array $propKeys,
+	): array {
+		if ($field === '') {
+			return [
+				[
+					'code' => 'aggregation-metrics-field-missing',
+					'message' => sprintf(
+						'Aggregation "%s" metrics[%d] with metric "%s" requires a field.',
+						$name,
+						$index,
+						$metric
+					),
+				],
+			];
+		}
+
+		if (in_array($field, $propKeys, true) === false) {
+			return [
+				[
+					'code' => 'aggregation-metrics-field-not-in-schema',
+					'message' => sprintf(
+						'Aggregation "%s" metrics[%d] field "%s" is not declared in the schema properties.',
+						$name,
+						$index,
+						$field
+					),
+				],
+			];
+		}
+
+		return [];
+	}//end validateField()
+
+	/**
+	 * Coerce a declared value to a string without tripping on arrays.
+	 *
+	 * A schema author passing an array must not reach a bare string cast —
+	 * PHP emits "Array to string conversion" — so it collapses to '' and fails
+	 * the vocabulary check with a proper validation error instead.
+	 *
+	 * @param mixed $value The declared value.
+	 *
+	 * @return string The value as a string, or '' when it is not scalar.
+	 */
+	private function asString(mixed $value): string {
+		if (is_scalar($value) === false) {
+			return '';
+		}
+
+		return (string)$value;
+	}//end asString()
+}//end class

--- a/lib/Service/Aggregation/AggregationRunner.php
+++ b/lib/Service/Aggregation/AggregationRunner.php
@@ -294,6 +294,23 @@ class AggregationRunner {
 		// `where` as an alias for `filter` (new DSL) so callers can
 		// use either vocabulary on intra-schema specs too.
 		$metric = (string)($spec['metric'] ?? $spec['select'] ?? '');
+
+		// `metrics`: several figures over ONE grouping, e.g. a budget line that
+		// needs both sum(committed) and sum(invoiced) per coding combination.
+		//
+		// The whole multi-metric path already existed — AggregationQuery::
+		// $metrics, tryNativeMultiMetric(), computeMetrics() and the grouped
+		// computeGrouped(metrics:) branch are all live and reached by the
+		// ad-hoc controller. Only the ANNOTATION path never read the key, so a
+		// declaration could not ask for what the engine could already compute.
+		// Declaring a second aggregation instead is not equivalent: it groups
+		// and scans the table again, and the two results can disagree if a row
+		// is written between the calls.
+		$specMetrics = ($spec['metrics'] ?? null);
+		$metrics = null;
+		if (is_array($specMetrics) === true && $specMetrics !== []) {
+			$metrics = $specMetrics;
+		}
 		$field = ($spec['field'] ?? null);
 		$filter = (array)($spec['filter'] ?? $spec['where'] ?? []);
 		$groupBy = ($spec['groupBy'] ?? null);
@@ -329,6 +346,11 @@ class AggregationRunner {
 		$activeOrg = $this->organisationService->getActiveOrganisation();
 		$cacheKey = [
 			'metric' => $metric,
+			// `metrics` changes WHICH FIGURES the envelope carries, so two
+			// specs differing only here are different aggregations. Omitting
+			// it would serve a two-sum caller the single-sum result, or worse
+			// the reverse — a `values` map where the caller reads `value`.
+			'metrics' => $metrics,
 			'field' => $field,
 			'filter' => $resolvedFilter,
 			'groupBy' => $groupBy,
@@ -369,7 +391,8 @@ class AggregationRunner {
 			metric: $metric,
 			field: $nativeFieldArg,
 			filter: $resolvedFilter,
-			groupBy: $nativeGroupByArg
+			groupBy: $nativeGroupByArg,
+			metrics: $metrics
 		);
 		if ($native !== null) {
 			// R05: native Postgres aggregates over the full set, so
@@ -458,12 +481,21 @@ class AggregationRunner {
 				rows: $rows,
 				metric: $metric,
 				field: $field,
-				groupFields: $runGroupFields
+				groupFields: $runGroupFields,
+				metrics: $metrics
 			);
 		}
 
 		if (isset($result['groups']) === false) {
-			$result['value'] = $this->computeMetric(rows: $rows, metric: $metric, field: $field);
+			// Ungrouped multi-metric yields `values` (a map), single-metric
+			// yields `value` (a scalar). Emitting the scalar for a `metrics`
+			// spec would hand the caller one figure where it asked for several,
+			// and it would look like a working answer.
+			if ($metrics !== null && count($metrics) > 1) {
+				$result['values'] = $this->computeMetrics(rows: $rows, metrics: $metrics);
+			} else {
+				$result['value'] = $this->computeMetric(rows: $rows, metric: $metric, field: $field);
+			}
 		}
 
 		$result = $this->applyJoin(

--- a/tests/Unit/Service/Aggregation/AggregationAnnotationMetricsTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationAnnotationMetricsTest.php
@@ -1,0 +1,227 @@
+<?php
+
+/**
+ * Unit tests for `metrics` on an ANNOTATION.
+ *
+ * The multi-metric machinery — AggregationQuery::$metrics,
+ * tryNativeMultiMetric(), computeMetrics() and the grouped
+ * computeGrouped(metrics:) branch — already existed and is reached by the
+ * ad-hoc controller. The annotation path simply never read the key, so a
+ * schema could not ask for what the engine could already compute.
+ *
+ * These tests pin the validator half: an entry the runner cannot execute must
+ * be refused at SAVE time. That matters more than it looks. A rejected metric
+ * that slips through does not throw at read time — it comes back as a missing
+ * figure in an otherwise well-formed envelope, which is indistinguishable from
+ * a genuine zero.
+ *
+ * NOTE ON COVERAGE METADATA: deliberately none. This suite runs with
+ * `beStrictAboutCoverageMetadata="true"`, under which a test whose @covers
+ * names some classes but which touches any other unit is marked risky and has
+ * its coverage DISCARDED WHOLESALE. Measured on the sibling aggregation file:
+ * 38/1621 statements with @covers, 661/1621 with none. See issue #2847.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Aggregation
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/specs/object-lifecycle/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Aggregation;
+
+use OCA\OpenRegister\Service\Aggregation\AggregationAnnotationValidator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Validation of the `metrics` annotation key.
+ *
+ * @spec openspec/specs/object-lifecycle/spec.md
+ */
+final class AggregationAnnotationMetricsTest extends TestCase {
+
+	/**
+	 * Validate one aggregation spec against a schema declaring `amount_a`,
+	 * `amount_b` and `programme`.
+	 *
+	 * @param array<string, mixed> $spec The aggregation body.
+	 *
+	 * @return array<int, string> The error codes raised, in order.
+	 */
+	private function codesFor(array $spec): array {
+		$schema = [
+			'properties' => [
+				'amount_a' => ['type' => 'number'],
+				'amount_b' => ['type' => 'number'],
+				'programme' => ['type' => 'string'],
+			],
+			'x-openregister-aggregations' => ['agg' => $spec],
+		];
+
+		$errors = (new AggregationAnnotationValidator())->validate(schema: $schema);
+		return array_map(static fn (array $e): string => (string)$e['code'], $errors);
+
+	}//end codesFor()
+
+	/**
+	 * Two sums over one grouping validate — the shape that motivated this.
+	 *
+	 * @return void
+	 */
+	public function testTwoSumsOverOneGroupingValidate(): void {
+		self::assertSame([], $this->codesFor([
+			'metrics' => [
+				['metric' => 'sum', 'field' => 'amount_a'],
+				['metric' => 'sum', 'field' => 'amount_b'],
+			],
+			'groupBy' => ['programme'],
+		]));
+
+	}//end testTwoSumsOverOneGroupingValidate()
+
+	/**
+	 * A `metrics` spec needs no `metric`, and is not failed for lacking one.
+	 *
+	 * Without the early branch this reports `aggregation-bad-metric` for a
+	 * spec that is entirely well formed.
+	 *
+	 * @return void
+	 */
+	public function testMetricsSpecIsNotFailedForMissingSingularMetric(): void {
+		$codes = $this->codesFor([
+			'metrics' => [['metric' => 'count']],
+		]);
+
+		self::assertNotContains('aggregation-bad-metric', $codes);
+		self::assertSame([], $codes);
+
+	}//end testMetricsSpecIsNotFailedForMissingSingularMetric()
+
+	/**
+	 * `count` needs no field; the field-requiring metrics do.
+	 *
+	 * @return void
+	 */
+	public function testFieldIsRequiredOnlyForMetricsThatNeedOne(): void {
+		self::assertSame([], $this->codesFor(['metrics' => [['metric' => 'count']]]));
+
+		self::assertSame(
+			['aggregation-metrics-field-missing'],
+			$this->codesFor(['metrics' => [['metric' => 'sum']]])
+		);
+
+	}//end testFieldIsRequiredOnlyForMetricsThatNeedOne()
+
+	/**
+	 * A field the schema does not declare is refused, naming its index.
+	 *
+	 * The index matters: with several entries, "some field is wrong" is not
+	 * an actionable message.
+	 *
+	 * @return void
+	 */
+	public function testUndeclaredFieldIsRefused(): void {
+		self::assertSame(
+			['aggregation-metrics-field-not-in-schema'],
+			$this->codesFor([
+				'metrics' => [
+					['metric' => 'sum', 'field' => 'amount_a'],
+					['metric' => 'sum', 'field' => 'no_such_property'],
+				],
+			])
+		);
+
+	}//end testUndeclaredFieldIsRefused()
+
+	/**
+	 * A metric outside the closed vocabulary is refused.
+	 *
+	 * @return void
+	 */
+	public function testMetricOutsideTheVocabularyIsRefused(): void {
+		self::assertSame(
+			['aggregation-metrics-bad-metric'],
+			$this->codesFor(['metrics' => [['metric' => 'median', 'field' => 'amount_a']]])
+		);
+
+	}//end testMetricOutsideTheVocabularyIsRefused()
+
+	/**
+	 * Shapes that are not a non-empty list are refused.
+	 *
+	 * @return void
+	 */
+	public function testMalformedMetricsShapesAreRefused(): void {
+		foreach ([[], 'sum', ['metric' => 'sum'], 5] as $shape) {
+			self::assertSame(
+				['aggregation-metrics-malformed'],
+				$this->codesFor(['metrics' => $shape]),
+				'shape: ' . var_export($shape, true)
+			);
+		}
+
+	}//end testMalformedMetricsShapesAreRefused()
+
+	/**
+	 * A non-object entry inside the list is refused.
+	 *
+	 * @return void
+	 */
+	public function testNonObjectEntryIsRefused(): void {
+		self::assertSame(
+			['aggregation-metrics-entry-malformed'],
+			$this->codesFor(['metrics' => [['metric' => 'count'], 'sum']])
+		);
+
+	}//end testNonObjectEntryIsRefused()
+
+	/**
+	 * groupBy is still validated on a `metrics` spec.
+	 *
+	 * The early branch must not become a way to smuggle an invalid grouping
+	 * past the checker.
+	 *
+	 * @return void
+	 */
+	public function testGroupByIsStillValidatedOnAMetricsSpec(): void {
+		self::assertSame(
+			['aggregation-groupby-field-unknown'],
+			$this->codesFor([
+				'metrics' => [['metric' => 'sum', 'field' => 'amount_a']],
+				'groupBy' => ['no_such_property'],
+			])
+		);
+
+	}//end testGroupByIsStillValidatedOnAMetricsSpec()
+
+	/**
+	 * Every entry is reported, not just the first.
+	 *
+	 * A validator that stops at the first bad entry turns one fix-and-retry
+	 * cycle into several.
+	 *
+	 * @return void
+	 */
+	public function testEveryBadEntryIsReported(): void {
+		self::assertSame(
+			['aggregation-metrics-bad-metric', 'aggregation-metrics-field-not-in-schema'],
+			$this->codesFor([
+				'metrics' => [
+					['metric' => 'median', 'field' => 'amount_a'],
+					['metric' => 'sum', 'field' => 'nope'],
+				],
+			])
+		);
+
+	}//end testEveryBadEntryIsReported()
+}//end class


### PR DESCRIPTION
Completes the annotation vocabulary shillinq#1216 needs. #2846 gave annotations a composite `groupBy` and a `join`; this adds `metrics`, so a declaration can ask for **two sums over the same grouping** — a budget line needing `sum(committed)` *and* `sum(invoiced)` per coding combination.

## Almost nothing new was built

The multi-metric machinery already exists and is live: `AggregationQuery::$metrics`, `tryNativeMultiMetric()`, `computeMetrics()`, and `computeGrouped()`'s `metrics:` branch — all reached today by the ad-hoc controller path.

**The annotation path simply never read the key.** The engine could compute it; a schema could not ask for it.

Three wiring points:

- `run()` reads `$spec['metrics']` and passes it to `tryNativeAggregation()`, which already accepts it and already routes `>1` metric to `tryNativeMultiMetric()`.
- The PHP fallback passes it to `computeGrouped()`, and for the ungrouped case emits **`values`** (a map) rather than **`value`** (a scalar). Emitting the scalar for a `metrics` spec would hand the caller one figure where it asked for several — and it would look like a working answer.
- The **cache key** carries `metrics`. Two specs differing only there are different aggregations; without it a two-sum caller can be served the single-sum result, or the reverse — a `values` map where the caller reads `value`.

## The validator is the point

Each entry is held to exactly the rules a single `metric` is: a metric from the closed vocabulary, and a field the schema actually declares whenever the metric needs one.

A `metrics` list the runner cannot execute **has to fail at save time**. At read time a rejected metric is not an error — it is a missing figure in an otherwise well-formed envelope, indistinguishable from a genuine zero.

Two details worth stating:

- The `metrics` branch is checked **before** the singular `metric` check. Such a spec answers *"what am I computing"* through that key instead, and would otherwise be rejected for lacking a `metric` it does not need.
- `groupBy` is **still validated** on that path. The early branch must not become a way to smuggle an invalid grouping past the checker — there is a test for exactly that.

A single-entry list is accepted rather than rewritten to `metric`: the runner treats `count($metrics) > 1` as the multi path and falls through to the scalar shape below it, so one entry behaves exactly like the singular spelling without the author having to know which to use.

## Tests

Nine. Every bad entry is reported rather than just the first — a validator that stops at entry one turns a single fix-and-retry cycle into several — and each message names the index, because *"some field is wrong"* is not actionable across a list.

**Must-fail control:** disabling the branch turns all 9 red; restoring it turns all 9 green.

No coverage metadata on the new file, deliberately: under `beStrictAboutCoverageMetadata` a test touching any un-named collaborator has its coverage **discarded wholesale**. See #2847.

## Verification

`phpcs`, `phpstan`, `psalm` — all pass. `phpunit -c phpunit-unit-local.xml tests/Unit/Service/Aggregation` — **223 tests, 446 assertions, 0 failures**.
