### PR TITLE
feat(aggregation): let a caller NARROW a declared aggregation, never relax it

### DIFF
--- a/lib/Controller/AggregationController.php
+++ b/lib/Controller/AggregationController.php
@@ -96,7 +96,26 @@ class AggregationController extends Controller {
 	 */
 	public function aggregate(string $register, string $schema, string $name): JSONResponse {
 		try {
-			$result = $this->runner->run(registerRef: $register, schemaRef: $schema, name: $name);
+			// `filter[...]` NARROWS a declared aggregation; it can never relax
+			// it. The runner refuses any key the declaration already
+			// constrains, so this cannot be used to widen a scoping filter —
+			// see AggregationRunner::mergeNarrowingFilter().
+			//
+			// It exists because an annotation has no way to name the caller's
+			// context: `$currentUser` is the only placeholder the resolver
+			// knows, so a per-tenant figure declared once could not be asked
+			// for per tenant.
+			$extraFilter = $this->request->getParam('filter', []);
+			if (is_array($extraFilter) === false) {
+				$extraFilter = [];
+			}
+
+			$result = $this->runner->run(
+				registerRef: $register,
+				schemaRef: $schema,
+				name: $name,
+				extraFilter: $extraFilter
+			);
 		} catch (NotAuthorizedException $e) {
 			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_FORBIDDEN);
 		} catch (RuntimeException $e) {

--- a/lib/Service/Aggregation/AggregationRunner.php
+++ b/lib/Service/Aggregation/AggregationRunner.php
@@ -186,6 +186,11 @@ class AggregationRunner {
 	 *                                        references in a cross-schema `where` clause.  Pass the
 	 *                                        plain object array from the parent read path.  Ignored when
 	 *                                        the aggregation spec has no `from` key.
+	 * @param array<string, mixed> $extraFilter Caller-supplied constraints that NARROW the declared
+	 *                                          filter. A key the declaration already constrains is
+	 *                                          refused, not overwritten, and only scalar equality is
+	 *                                          accepted — so this can add a constraint but never relax
+	 *                                          a declared scoping one. See mergeNarrowingFilter().
 	 *
 	 * @return array{
 	 *   name: string,
@@ -211,6 +216,7 @@ class AggregationRunner {
 		string $name,
 		bool $bypassRbac = false,
 		array $parentRow = [],
+		array $extraFilter = [],
 	): array {
 		// REGISTER-SCOPED RESOLUTION. The register is the boundary and is
 		// resolved FIRST; the schema ref is then matched only among the schemas
@@ -331,6 +337,31 @@ class AggregationRunner {
 		}
 
 		$resolvedFilter = $this->placeholders->resolveArray($filter);
+
+		// CALLER-SUPPLIED NARROWING. A declared aggregation's filter is its
+		// contract, so a caller may ADD constraints and may never relax one.
+		// Everything about this is deliberately one-directional:
+		//
+		//   - a key the declaration already constrains is REFUSED, not
+		//     overwritten. Letting a request replace `administrationId` would
+		//     turn a scoping filter into a caller-chosen one, which is the
+		//     whole risk this method exists to avoid;
+		//   - only equality on scalars is accepted. An operator filter could
+		//     express `!=` or `>`, and "add a constraint" that widens the set
+		//     is not narrowing;
+		//   - the merged result, not the declared one, is what reaches the
+		//     query AND the cache key below, so two callers narrowing
+		//     differently cannot read each other's numbers.
+		//
+		// The motivating case: shillinq's per-budget-line rollup is declared
+		// once but must answer per administration, and an annotation has no
+		// way to name the caller's active one — `$currentUser` is the only
+		// placeholder the resolver knows.
+		$resolvedFilter = $this->mergeNarrowingFilter(
+			declared: $resolvedFilter,
+			extra: $extraFilter,
+			name: $name
+		);
 
 		// Cache lookup: the resolved filter (with placeholders concrete)
 		// is the cache key together with the user's RBAC scope. 60s TTL.
@@ -2774,6 +2805,71 @@ class AggregationRunner {
 
 		return $envelope;
 	}//end applyJoin()
+
+	/**
+	 * Merge caller-supplied constraints into a declared filter, narrowing only.
+	 *
+	 * A declared aggregation's filter is part of its contract. A caller may ADD
+	 * a constraint; it may never relax, replace or remove one. That asymmetry
+	 * is the entire point — a declared `administrationId` is a scoping filter,
+	 * and a request that could overwrite it would turn tenancy into a
+	 * caller-chosen parameter.
+	 *
+	 * Refusals are SILENT drops rather than exceptions, deliberately: this runs
+	 * on a read path reached from a URL, and a 500 on a stray query parameter
+	 * would make the page fail rather than the parameter. A dropped key leaves
+	 * the declared constraint in force, so the failure mode is "your narrowing
+	 * did not apply", never "you saw more than you should".
+	 *
+	 * Three rules:
+	 *   1. a key the declaration already constrains is dropped — the
+	 *      declaration wins, always;
+	 *   2. only scalars are accepted. An array is an operator filter, and
+	 *      `!=` / `>` / `in` can widen a set rather than narrow it;
+	 *   3. an empty-string value is dropped, because a caller omitting a
+	 *      parameter should not silently become a filter on ''.
+	 *
+	 * @param array<string, mixed> $declared The declared, placeholder-resolved filter.
+	 * @param array<string, mixed> $extra    Caller-supplied constraints.
+	 * @param string               $name     Aggregation name, for the debug log.
+	 *
+	 * @return array<string, mixed> The merged filter.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function mergeNarrowingFilter(array $declared, array $extra, string $name): array {
+		if ($extra === []) {
+			return $declared;
+		}
+
+		$merged = $declared;
+		foreach ($extra as $key => $value) {
+			if (is_string($key) === false || $key === '') {
+				continue;
+			}
+
+			if (array_key_exists($key, $declared) === true) {
+				// `?->` because the logger is an OPTIONAL constructor argument
+				// here (`?LoggerInterface $logger = null`). A bare `->debug()`
+				// is a fatal whenever it was not injected — and a fatal on a
+				// read path, thrown from the branch that ENFORCES the scoping
+				// rule, would be the worst possible place for one.
+				$this->logger?->debug(
+					'Aggregation: refusing a request filter that would relax a declared one.',
+					['aggregation' => $name, 'key' => $key]
+				);
+				continue;
+			}
+
+			if (is_scalar($value) === false || $value === '') {
+				continue;
+			}
+
+			$merged[$key] = $value;
+		}
+
+		return $merged;
+	}//end mergeNarrowingFilter()
 
 	/**
 	 * Load the joined schema, gate the caller on it, and locate its register.

--- a/tests/Unit/Service/Aggregation/AggregationNarrowingFilterTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationNarrowingFilterTest.php
@@ -1,0 +1,242 @@
+<?php
+
+/**
+ * Unit tests for caller-supplied NARROWING of a declared aggregation filter.
+ *
+ * A declared aggregation's filter is its contract. A caller may ADD a
+ * constraint; it may never relax, replace or remove one. That asymmetry is the
+ * whole security property: a declared `administrationId` is a scoping filter,
+ * and a request able to overwrite it would turn tenancy into a caller-chosen
+ * parameter.
+ *
+ * These tests exist to make that one-directional. The interesting cases are
+ * not "does narrowing work" but "does every attempt to WIDEN get refused",
+ * which is why most of what follows asserts a declared value survives.
+ *
+ * NOTE ON COVERAGE METADATA: deliberately none — under
+ * `beStrictAboutCoverageMetadata="true"` a test touching any un-named
+ * collaborator has its coverage discarded wholesale. See issue #2847.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Aggregation
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/specs/aggregation-api/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Aggregation;
+
+use OCA\OpenRegister\Service\Aggregation\AggregationRunner;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * The narrowing-only merge of caller filters into a declared filter.
+ *
+ * @spec openspec/specs/aggregation-api/spec.md
+ */
+final class AggregationNarrowingFilterTest extends TestCase {
+
+	/**
+	 * Invoke the private merge without constructing the whole runner.
+	 *
+	 * The method is pure — declared array in, merged array out, with one
+	 * optional logger call — so reflection is cheaper and more honest here
+	 * than mocking a dozen collaborators the logic never touches.
+	 *
+	 * @param array<string, mixed> $declared The declared filter.
+	 * @param array<string, mixed> $extra    Caller-supplied constraints.
+	 *
+	 * @return array<string, mixed> The merged filter.
+	 */
+	private function merge(array $declared, array $extra): array {
+		$reflection = new ReflectionClass(AggregationRunner::class);
+		$runner = $reflection->newInstanceWithoutConstructor();
+
+		// `$logger` is a promoted constructor parameter (`?LoggerInterface
+		// $logger = null`), so in production it is ALWAYS initialised — to null
+		// when nothing was injected. newInstanceWithoutConstructor() leaves it
+		// merely declared, and reading an uninitialised typed property throws
+		// regardless of `?->`, which guards null and not uninitialised. Setting
+		// it explicitly models the real "no logger injected" state rather than
+		// a state the class can never actually be in.
+		$loggerProperty = $reflection->getProperty('logger');
+		$loggerProperty->setAccessible(true);
+		$loggerProperty->setValue($runner, null);
+
+		$method = $reflection->getMethod('mergeNarrowingFilter');
+		$method->setAccessible(true);
+
+		return $method->invoke($runner, $declared, $extra, 'testAggregation');
+
+	}//end merge()
+
+	/**
+	 * A new key is added — the narrowing case that motivated this.
+	 *
+	 * @return void
+	 */
+	public function testANewConstraintIsAdded(): void {
+		self::assertSame(
+			['afgesloten' => false, 'administrationId' => 'adm-demo'],
+			$this->merge(['afgesloten' => false], ['administrationId' => 'adm-demo'])
+		);
+
+	}//end testANewConstraintIsAdded()
+
+	/**
+	 * A declared key is NOT overwritten. This is the security property.
+	 *
+	 * If this ever passes with the caller's value winning, a declared scoping
+	 * filter has become a request parameter.
+	 *
+	 * @return void
+	 */
+	public function testADeclaredKeyCannotBeOverwritten(): void {
+		$merged = $this->merge(
+			['administrationId' => 'adm-owned'],
+			['administrationId' => 'adm-someone-elses']
+		);
+
+		self::assertSame(['administrationId' => 'adm-owned'], $merged);
+
+	}//end testADeclaredKeyCannotBeOverwritten()
+
+	/**
+	 * A declared key cannot be relaxed by sending an empty value either.
+	 *
+	 * The obvious bypass attempt: if '' were accepted as "no constraint",
+	 * a caller could blank the scoping filter.
+	 *
+	 * @return void
+	 */
+	public function testADeclaredKeyCannotBeBlanked(): void {
+		self::assertSame(
+			['administrationId' => 'adm-owned'],
+			$this->merge(['administrationId' => 'adm-owned'], ['administrationId' => ''])
+		);
+
+	}//end testADeclaredKeyCannotBeBlanked()
+
+	/**
+	 * An operator filter is refused — it can widen rather than narrow.
+	 *
+	 * `['ne' => 'x']` or `['gt' => 0]` express "everything except" and
+	 * "more than", neither of which is a narrowing of an unconstrained set.
+	 *
+	 * @return void
+	 */
+	public function testOperatorFiltersAreRefused(): void {
+		self::assertSame(
+			['afgesloten' => false],
+			$this->merge(['afgesloten' => false], ['amount' => ['gt' => 0]])
+		);
+		self::assertSame(
+			['afgesloten' => false],
+			$this->merge(['afgesloten' => false], ['status' => ['ne' => 'closed']])
+		);
+
+	}//end testOperatorFiltersAreRefused()
+
+	/**
+	 * An empty caller value on a NEW key is dropped.
+	 *
+	 * A caller omitting a query parameter must not silently become a filter
+	 * on the empty string, which would match nothing and look like "no data".
+	 *
+	 * @return void
+	 */
+	public function testEmptyValueOnANewKeyIsDropped(): void {
+		self::assertSame(
+			['afgesloten' => false],
+			$this->merge(['afgesloten' => false], ['administrationId' => ''])
+		);
+
+	}//end testEmptyValueOnANewKeyIsDropped()
+
+	/**
+	 * A non-string key is ignored.
+	 *
+	 * `?filter[]=x` arrives as a list, and a numeric key is not a property.
+	 *
+	 * @return void
+	 */
+	public function testNonStringKeysAreIgnored(): void {
+		self::assertSame(
+			['afgesloten' => false],
+			$this->merge(['afgesloten' => false], ['bare-value'])
+		);
+
+	}//end testNonStringKeysAreIgnored()
+
+	/**
+	 * No caller filter leaves the declared filter byte-identical.
+	 *
+	 * The overwhelmingly common path must not be perturbed.
+	 *
+	 * @return void
+	 */
+	public function testNoCallerFilterIsAPassthrough(): void {
+		$declared = ['afgesloten' => false, 'administrationId' => 'adm-demo'];
+
+		self::assertSame($declared, $this->merge($declared, []));
+
+	}//end testNoCallerFilterIsAPassthrough()
+
+	/**
+	 * Several constraints narrow together, and a refused one does not block
+	 * the accepted ones.
+	 *
+	 * A caller sending one bad key alongside good ones should still get the
+	 * good ones — silently dropping the whole request would be its own
+	 * confusing failure.
+	 *
+	 * @return void
+	 */
+	public function testAcceptedAndRefusedKeysAreHandledIndependently(): void {
+		self::assertSame(
+			[
+				'afgesloten' => false,
+				'administrationId' => 'adm-demo',
+				'financialYear' => 2026,
+			],
+			$this->merge(
+				['afgesloten' => false],
+				[
+					'administrationId' => 'adm-demo',
+					'afgesloten' => true,
+					'financialYear' => 2026,
+				]
+			)
+		);
+
+	}//end testAcceptedAndRefusedKeysAreHandledIndependently()
+
+	/**
+	 * The merge does not require a logger.
+	 *
+	 * The runner takes `?LoggerInterface $logger = null`, and the refusal
+	 * branch logs. A bare `->debug()` would fatal whenever no logger was
+	 * injected — on the path that ENFORCES the scoping rule, which is the
+	 * worst place for a fatal. The helper sets the property to null
+	 * explicitly, so removing the null-safe call turns this red.
+	 *
+	 * @return void
+	 */
+	public function testRefusalDoesNotRequireALogger(): void {
+		$merged = $this->merge(['administrationId' => 'a'], ['administrationId' => 'b']);
+
+		self::assertSame(['administrationId' => 'a'], $merged);
+
+	}//end testRefusalDoesNotRequireALogger()
+}//end class


### PR DESCRIPTION
The last thing shillinq#1216 needs, and the one with a security edge.

## The problem

A declared aggregation's filter is fixed at schema-save time, and the only placeholder the resolver knows is `$currentUser`. So an aggregation that must answer **per tenant** has no way to say so.

shillinq's per-budget-line rollup declared `administrationId: "@self.administrationId"` — which is **not a placeholder at all**. It was left literal, matched nothing, and the page rendered an empty state over live data.

Removing that filter makes the aggregation work — and makes it span **every administration**, because request filters were ignored on this path. Going from *"shows nothing"* to *"shows other tenants' budget figures"* is not a fix.

## The rule

`filter[...]` on the request now merges into the declared filter, **narrowing only**. Every part of it is one-directional:

- **A key the declaration already constrains is refused, not overwritten.** This is the property that matters: letting a request replace `administrationId` turns a scoping filter into a caller-chosen parameter.
- **Only scalar equality is accepted.** An operator filter can express `ne` or `gt`, and "add a constraint" that widens the set is not narrowing.
- **An empty value is dropped** — on a declared key *and* a new one. Otherwise a caller could blank a scoping filter, or an omitted query parameter would silently become a filter on `''` that matches nothing and looks like "no data".
- **The merged filter, not the declared one, feeds both the query and the cache key**, so two callers narrowing differently cannot read each other's numbers.

Refusals are **silent drops rather than exceptions**, deliberately. This runs on a read path reached from a URL; a 500 on a stray query parameter would make the page fail rather than the parameter. A dropped key leaves the declared constraint in force, so the failure mode is *"your narrowing did not apply"*, never *"you saw more than you should"*.

`$this->logger?->debug()`, not `->debug()`: the logger is an **optional** constructor argument here, and a fatal thrown from the branch that *enforces* the scoping rule would be the worst possible place for one.

## Tests

Nine — and most assert a **refusal** rather than a success. The interesting question is not "does narrowing work" but "does every attempt to widen get refused":

- a declared key cannot be overwritten
- a declared key cannot be **blanked** (the obvious bypass)
- operator filters (`gt`, `ne`) are refused
- an empty value on a new key is dropped
- accepted and refused keys are handled independently, so one bad key does not discard the good ones

**Must-fail control:** disabling the declared-key refusal turns 3 of 9 red.

One test found something worth keeping: **`?->` guards `null`, not *uninitialised*.** `newInstanceWithoutConstructor()` leaves a promoted property merely declared, which throws regardless of the null-safe operator. The helper now sets it to `null` explicitly, modelling the real "no logger injected" state rather than one the class can never be in.

## Verification

Cold-cache — the default 300s composer timeout is not enough for phpmd on this repo, and a warm `~/.pdepend` reports stale results:

`phpcs`, `phpstan`, `psalm`, `phpmd` all clean. **232 aggregation tests, 456 assertions, 0 failures.**
