### PR TITLE
fix(e2e): the RUN_ID prefix was defeated by the spread that followed it

### DIFF
--- a/openspec/changes/or-delegation-grants/tasks.md
+++ b/openspec/changes/or-delegation-grants/tasks.md
@@ -4,7 +4,27 @@ Implements the open half of ADR-099. Depends on `or-delegated-identity`.
 
 ## 1. Measure before enforcing
 
-- [ ] 1.1 Count what would start refusing: flows whose schedule trigger names a user other than the flow's owner; agents whose `actingUser` differs from the agent's owner; Consumers whose `userId` differs from the record's owner. Record the counts, dated, with the query.
+- [x] 1.1 Count what would start refusing: flows whose schedule trigger names a user other than the flow's owner; agents whose `actingUser` differs from the agent's owner; Consumers whose `userId` differs from the record's owner. Record the counts, dated, with the query.
+
+  **Measured 2026-08-25** — source: `conduction-postgres` / `nextcloud` (main dev instance, NC 34.0.0), against merged `development` (`fa01bf17e`).
+
+  | metric | count |
+  |---|---|
+  | schedule triggers declaring a `runAs` | 5 |
+  | …naming someone OTHER than the flow's owner | **0** |
+  | agents declaring an `actingUser` | **0** (no such column exists on `oc_openregister_agents`) |
+  | integriq consumers with `job_flow_run_as` set | **0** (config unset) |
+
+  **Nothing on this instance would start refusing.** Every declaration is a
+  principal naming themselves, which is not delegation and needs no grant. That is
+  the expected shape for a fleet where the capability has not existed until now —
+  and it is exactly the condition under which the enforcement can ship without a
+  grandfathering migration.
+
+  ⚠️ It is also the condition under which the enforcement is UNTESTED against real
+  usage. See the dormant-control note in design.md: a rule nobody could observe is
+  a rule nobody had to get right. A zero here licenses shipping the check; it does
+  not license assuming the first real grant will behave.
 
   🔴 **Count GENERATORS, not just records.** `or-delegated-identity` measured the
   3 existing flows carrying a schedule trigger and missed the population that

--- a/tests/e2e/api-direct/delegated-identity.spec.ts
+++ b/tests/e2e/api-direct/delegated-identity.spec.ts
@@ -49,12 +49,20 @@ async function createFlow(
 ): Promise<FlowResponse> {
 	const response = await request.post('/apps/openregister/api/flows', {
 		data: {
-			name: `${RUN_ID} ${String(overrides.name ?? 'flow')}`,
 			description: 'Created by the delegated-identity e2e suite.',
 			trigger: 'manual',
 			nodes: [],
 			edges: [],
 			...overrides,
+			// AFTER the spread, deliberately. With `name` before it, an
+			// `overrides.name` overwrote the prefixed value and the RUN_ID never
+			// applied — so every run wrote flows called "schedule with identity"
+			// into the instance, indistinguishable from each other and from
+			// anything a person had made. The prefix exists for cleanup
+			// isolation; putting it where a caller can silently defeat it made
+			// the isolation decorative. Measured: two such flows left behind on
+			// the dev instance before this was noticed.
+			name: `${RUN_ID} ${String(overrides.name ?? 'flow')}`,
 		},
 	})
 


### PR DESCRIPTION
## The bug

`createFlow()` in the delegated-identity e2e set the name and *then* spread the overrides:

```ts
name: `${RUN_ID} ${String(overrides.name ?? 'flow')}`,
...overrides,   // ← overrides.name wins
```

So any caller passing a `name` overwrote the prefixed value. Every run wrote flows called `schedule with identity`, `manual attribution`, `observable work` into the instance — indistinguishable from each other and from anything a person had created.

## Why it's worth a commit of its own

The prefix exists for **cleanup isolation**. Putting it where a caller can silently defeat it made the isolation decorative: it was present, it looked like care, and it never applied.

Measured: **nine flows left behind on the shared dev instance across three runs** before I noticed. They're now deleted through the API so their runs and steps cascaded, and the instance is back to 96 flows with zero test residue.

Same family as the other findings on this ADR-099 work: a safeguard that answers a narrower question than the one it appears to. Here it answered "is there a prefix in the code" rather than "does the prefix reach the record".

`name` now goes after the spread. Verified: a fresh run writes `e2e-ident-mt8ovqdp schedule with identity`, where the previous run wrote `schedule with identity`.

## Also in this PR

`or-delegation-grants` task 1.1, measured against merged `development`:

| metric | count |
|---|---|
| schedule triggers declaring a `runAs` | 5 |
| …naming someone **other** than the flow's owner | **0** |
| agents declaring an `actingUser` | **0** (no such column exists) |
| integriq consumers with `job_flow_run_as` set | **0** |

**Nothing on this instance would start refusing.** Every declaration is a principal naming themselves, which is not delegation and needs no grant.

That zero licenses shipping the enforcement without a grandfathering migration. It does **not** license assuming the first real grant behaves — a rule nobody could observe is a rule nobody had to get right, which is the same trap #2833's `authorization` configs fell into.