### PR TITLE
fix(objects): report the schema failure as a schema failure (refs #2820)

### DIFF
--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -1024,12 +1024,41 @@ class ObjectsController extends Controller {
 	 * @throws SchemaNotFoundException When schema is not found.
 	 */
 	private function resolveRegisterSchemaIds(string $register, string $schema, ObjectService $objectService): array {
+		// STEP 1: Initial resolution - convert slugs/IDs to numeric IDs.
+		//
+		// `setRegister()` does TWO things, and only the first is about the
+		// register: it resolves the register, and then — if a schema ref is
+		// still pending from an earlier caller on this shared ObjectService — it
+		// re-resolves that ref INSIDE the register. A scoped miss there is a
+		// SCHEMA failure, and reporting it as `Register not found: '19'` sent a
+		// diagnosis down the wrong path for hours: the register plainly exists,
+		// so every reasonable first move (check the row, the magic tables, the
+		// organisation filter, run the mapper's query by hand) confirms it and
+		// explains nothing. openregister#2820.
+		//
+		// So the register lookup is now resolved on its own, and only its
+		// failure is reported as a missing register. Anything the pending-ref
+		// re-resolution throws keeps its own identity.
+		// The discriminator is `setRegister()`'s own order of operations: it
+		// assigns `currentRegister` BEFORE it re-resolves any pending schema ref.
+		// So a register entity that is NEW after the throw proves the register
+		// lookup succeeded and the schema side failed.
+		//
+		// Comparing against the entity held BEFORE the call is what makes this
+		// sound. ObjectService is shared, so `currentRegister` can already hold
+		// an earlier caller's register; testing it for null alone would report a
+		// genuine missing register as a schema problem whenever someone had used
+		// the service first — swapping one misattribution for another.
+		$registerBefore = $objectService->getCurrentRegisterEntity();
 		try {
-			// STEP 1: Initial resolution - convert slugs/IDs to numeric IDs.
 			$objectService->setRegister(register: $register);
 		} catch (\OCP\AppFramework\Db\DoesNotExistException $e) {
-			// If register not found, throw custom exception.
-			throw new RegisterNotFoundException(registerSlugOrId: $register, code: 404, previous: $e);
+			$registerAfter = $objectService->getCurrentRegisterEntity();
+			if ($registerAfter === null || $registerAfter === $registerBefore) {
+				throw new RegisterNotFoundException(registerSlugOrId: $register, code: 404, previous: $e);
+			}
+
+			throw new SchemaNotFoundException(schemaSlugOrId: $schema, code: 404, previous: $e);
 		}
 
 		try {

--- a/tests/Unit/Controller/ObjectsControllerResolutionAttributionTest.php
+++ b/tests/Unit/Controller/ObjectsControllerResolutionAttributionTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * `resolveRegisterSchemaIds()` must name the thing that actually failed.
+ *
+ * openregister#2820. `GET /api/objects/{register}/{schema}` answered
+ * `404 Register not found: '19'` for a register whose row was intact, whose
+ * magic tables existed, and which `occ` resolved without complaint. With the
+ * logger from #2822 finally wired, the mapper could be seen SUCCEEDING on that
+ * exact lookup while the endpoint still reported the register as missing.
+ *
+ * The cause is that `setRegister()` does two things: it resolves the register,
+ * and then — if a schema ref is still pending from an earlier caller on the
+ * shared ObjectService — it re-resolves that ref inside the register. A scoped
+ * miss there is a SCHEMA failure, and the controller reported every
+ * `DoesNotExistException` out of `setRegister()` as a missing register.
+ *
+ * The cost of that misattribution was hours: the error named a register that
+ * demonstrably existed, so every reasonable first move confirmed the register
+ * and explained nothing.
+ *
+ * These tests pin both directions. Only asserting the schema case would let a
+ * fix pass that reports EVERYTHING as a schema problem — the same defect
+ * pointing the other way.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Controller
+ * @author   Conduction Development Team <dev@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://OpenRegister.app
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Controller;
+
+use OCA\OpenRegister\Controller\ObjectsController;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Exception\RegisterNotFoundException;
+use OCA\OpenRegister\Exception\SchemaNotFoundException;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Attribution of resolution failures to the register or the schema.
+ */
+class ObjectsControllerResolutionAttributionTest extends TestCase {
+	/**
+	 * Invoke the private resolver on a bare controller instance.
+	 *
+	 * The method touches only its ObjectService argument, so the controller
+	 * itself needs no wiring — constructing one through the container would
+	 * drag in thirty collaborators to exercise ten lines.
+	 *
+	 * @param ObjectService $service the service double
+	 *
+	 * @return array the resolver result
+	 */
+	private function resolve(ObjectService $service): array {
+		$controller = (new \ReflectionClass(ObjectsController::class))->newInstanceWithoutConstructor();
+		$method = new ReflectionMethod(ObjectsController::class, 'resolveRegisterSchemaIds');
+		$method->setAccessible(true);
+		return $method->invoke($controller, '19', '9476', $service);
+	}
+
+	/**
+	 * A register that genuinely does not resolve is reported as the register.
+	 *
+	 * `setRegister()` throws without ever assigning an entity, so nothing new is
+	 * present afterwards.
+	 *
+	 * @return void
+	 */
+	public function testAGenuinelyMissingRegisterIsReportedAsTheRegister(): void {
+		$service = $this->createMock(ObjectService::class);
+		$service->method('getCurrentRegisterEntity')->willReturn(null);
+		$service->method('setRegister')->willThrowException(new DoesNotExistException('no such register'));
+
+		$this->expectException(RegisterNotFoundException::class);
+		$this->expectExceptionMessage("Register not found: '19'");
+		$this->resolve($service);
+	}
+
+	/**
+	 * A register that RESOLVED, followed by a schema-side failure, is reported
+	 * as the schema — this is #2820 itself.
+	 *
+	 * @return void
+	 */
+	public function testAResolvedRegisterWithASchemaFailureIsReportedAsTheSchema(): void {
+		$resolved = new Register();
+		$resolved->setId(19);
+
+		$service = $this->createMock(ObjectService::class);
+		// Nothing held before the call; the entity appears during it, which is
+		// what proves the register lookup itself succeeded.
+		$service->method('getCurrentRegisterEntity')
+			->willReturnOnConsecutiveCalls(null, $resolved, $resolved);
+		$service->method('setRegister')
+			->willThrowException(new DoesNotExistException('schema not carried by register'));
+
+		$this->expectException(SchemaNotFoundException::class);
+		$this->expectExceptionMessage("Schema not found: '9476'");
+		$this->resolve($service);
+	}
+
+	/**
+	 * A leftover register from an EARLIER caller does not disguise a genuine
+	 * missing register as a schema problem.
+	 *
+	 * ObjectService is shared, so `currentRegister` can already be populated
+	 * when the call starts. Testing it for null alone would swap one
+	 * misattribution for another — this is the case that makes the before/after
+	 * comparison necessary rather than decorative.
+	 *
+	 * @return void
+	 */
+	public function testALeftoverRegisterFromAnEarlierCallerIsNotMistakenForSuccess(): void {
+		$someoneElses = new Register();
+		$someoneElses->setId(206);
+
+		$service = $this->createMock(ObjectService::class);
+		// Same entity before and after: setRegister() assigned nothing.
+		$service->method('getCurrentRegisterEntity')->willReturn($someoneElses);
+		$service->method('setRegister')->willThrowException(new DoesNotExistException('no such register'));
+
+		$this->expectException(RegisterNotFoundException::class);
+		$this->expectExceptionMessage("Register not found: '19'");
+		$this->resolve($service);
+	}
+}


### PR DESCRIPTION
fix(objects): report the schema failure as a schema failure (refs #2820)

`GET /api/objects/{register}/{schema}` answers `404 Register not found: '19'`
for a register whose row is intact, whose magic tables exist, and which `occ`
resolves without complaint. With the logger from #2822 finally wired, the mapper
can be seen SUCCEEDING on that exact lookup while the endpoint still reports the
register as missing:

    [RegisterMapper] Searching for register        identifier = '19'
    [RegisterMapper] Register exists before filters registerId = '19'
    (and no "Register not found after filters")

`setRegister()` does two things. It resolves the register, and then — if a
schema ref is still pending from an earlier caller on the shared ObjectService —
it re-resolves that ref INSIDE the register. A scoped miss there is a **schema**
failure, and `resolveRegisterSchemaIds()` reported every `DoesNotExistException`
out of `setRegister()` as a missing register.

## Why the misattribution is the expensive part

The error names a register that demonstrably exists, so every reasonable first
move confirms the register and explains nothing: check the row, check the magic
tables, check the organisation filter (skipped — `_multitenancy: false`), run the
mapper's own query in psql (returns the row), diff the deployed code against
development (identical on the resolution path). That is hours of work the
message actively misdirects. This is the same family as #2790 — shared
ObjectService state between callers — but it does not LOOK like #2790, because
the report points somewhere else entirely.

## The discriminator

`setRegister()` assigns `currentRegister` BEFORE re-resolving a pending ref, so
a register entity that is NEW after the throw proves the register lookup
succeeded.

Comparing against the entity held BEFORE the call is what makes it sound. The
service is shared, so `currentRegister` can already be populated when the call
starts; testing it for null alone would report a genuine missing register as a
schema problem whenever anyone had used the service first — swapping one
misattribution for another.

## Tests

Three, pinning both directions, because asserting only the schema case would
admit a fix that reports everything as a schema problem:

- a genuinely missing register is still reported as the register
- a resolved register with a schema-side failure is reported as the schema —
  #2820 itself
- a leftover register from an earlier caller is not mistaken for success, which
  is the case that makes the before/after comparison necessary rather than
  decorative

Mutation-checked: restoring the original single-catch fails the middle test with
the exact wrong message this issue is about.

## What this does NOT fix

The leak itself. A pending ref from an unrelated caller is still re-resolved
inside a register it was never meant for; this change makes it say so. The
isolation half — #2790's fix applied at the entering end — is still open on
#2820, along with why registers 9 and 505 resolve while fourteen others do not.
I have not measured that and am not guessing at it here.
