### PR TITLE
fix(objects): clear leaked resolution context before resolving (closes #2820)

### DIFF
--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -1039,6 +1039,22 @@ class ObjectsController extends Controller {
 		// So the register lookup is now resolved on its own, and only its
 		// failure is reported as a missing register. Anything the pending-ref
 		// re-resolution throws keeps its own identity.
+		// Start from a clean context — this is the other half of #2820.
+		//
+		// #2858 made this endpoint report a leaked-ref failure honestly, as a
+		// schema failure. It did not stop the leak: `setRegister()` re-resolves
+		// whatever schema ref is still pending on the SHARED ObjectService, and
+		// a ref left behind by an unrelated earlier caller then gets resolved
+		// inside a register it was never meant for. On the dev instance a
+		// preload resolves register `buildiq` moments before the request's own
+		// lookup, which is how a plain `GET /objects/19/9476` failed.
+		//
+		// Nothing pending can ever be legitimate here: this method is handed
+		// BOTH the register and the schema explicitly, so it has no use for a
+		// ref it did not receive. #2790 added the same isolation on LEAVING
+		// find(); this is the entering end.
+		$objectService->clearCurrents();
+
 		// The discriminator is `setRegister()`'s own order of operations: it
 		// assigns `currentRegister` BEFORE it re-resolves any pending schema ref.
 		// So a register entity that is NEW after the throw proves the register

--- a/tests/Unit/Controller/ObjectsControllerResolutionAttributionTest.php
+++ b/tests/Unit/Controller/ObjectsControllerResolutionAttributionTest.php
@@ -66,6 +66,31 @@ class ObjectsControllerResolutionAttributionTest extends TestCase {
 	}
 
 	/**
+	 * A leaked schema ref from an earlier caller is cleared before resolving.
+	 *
+	 * This is the other half of #2820. #2858 made the failure REPORT honestly;
+	 * this stops it happening. `setRegister()` re-resolves whatever ref is
+	 * pending on the shared service, so a ref left by an unrelated caller was
+	 * being resolved inside a register it was never meant for — which is how a
+	 * plain `GET /objects/19/9476` failed on an instance where a preload had
+	 * just touched a different register.
+	 *
+	 * @return void
+	 */
+	public function testLeakedContextIsClearedBeforeResolving(): void {
+		$register = new Register();
+		$register->setId(19);
+
+		$service = $this->createMock(ObjectService::class);
+		$service->expects($this->once())->method('clearCurrents');
+		$service->method('getCurrentRegisterEntity')->willReturn($register);
+		$service->method('getRegister')->willReturn(19);
+		$service->method('getSchema')->willReturn(9476);
+
+		$this->resolve($service);
+	}
+
+	/**
 	 * A register that genuinely does not resolve is reported as the register.
 	 *
 	 * `setRegister()` throws without ever assigning an entity, so nothing new is


### PR DESCRIPTION
fix(objects): clear leaked resolution context before resolving (closes #2820)

The other half of #2820. #2858 made this endpoint report a leaked-ref failure
honestly — as a schema failure rather than a phantom missing register. It did
not stop the leak.

`setRegister()` re-resolves whatever schema ref is still pending on the SHARED
ObjectService. A ref left behind by an unrelated earlier caller therefore gets
resolved inside a register it was never meant for, and the request dies on a
schema it never asked for. On the dev instance a preload resolves register
`buildiq` moments before the request's own lookup — visible in the log now that
#2822 wired the mapper's logger — which is how a plain
`GET /api/objects/19/9476` failed while `RegisterMapper::find(19)` succeeded.

`resolveRegisterSchemaIds()` now calls the existing `clearCurrents()` first.
Nothing pending can ever be legitimate there: the method is handed BOTH the
register and the schema explicitly, so it has no use for a ref it did not
receive. #2790 added exactly this isolation on LEAVING `find()`; this is the
entering end, which is where it was missing.

Test asserts `clearCurrents()` is called before resolution, mutation-checked —
removing the call fails it with "expected 1 time, actually called 0 times".
The three attribution tests from #2858 still pass alongside it, so the honest
reporting is not traded away for the fix.

64 tests across the four ObjectsController suites; phpcs and phpstan clean.

## Still not measured

Why registers 9 (learniq) and 505 (hrmq) resolved while fourteen others did not.
The likely explanation is that the leaked slug happens to exist in those two
registers, but I have not measured it and will not assert it. If the 404s
persist on a deployed build after this, that is the thread to pull.
