### PR TITLE
fix(bulk): one resolution implementation, because #2820 survived its own fix

### DIFF
--- a/lib/Controller/BulkController.php
+++ b/lib/Controller/BulkController.php
@@ -33,6 +33,7 @@ use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Dto\BulkSaveOutcome;
+use OCA\OpenRegister\Controller\Trait\ResolvesRegisterAndSchemaTrait;
 use OCA\OpenRegister\Exception\RegisterNotFoundException;
 use OCA\OpenRegister\Exception\SchemaNotFoundException;
 use OCA\OpenRegister\Service\ObjectService;
@@ -54,6 +55,8 @@ use OCP\IUserSession;
  * @spec openspec/specs/object-lifecycle/spec.md
  */
 class BulkController extends Controller {
+	use ResolvesRegisterAndSchemaTrait;
+
 	/**
 	 * Constructor for the BulkController
 	 *
@@ -192,49 +195,40 @@ class BulkController extends Controller {
 	}//end checkRegisterManagePermission()
 
 	/**
-	 * Resolve register and schema slugs/IDs to numeric IDs.
+	 * Resolve a register/schema path pair to numeric ids.
 	 *
-	 * This method handles both slugs and numeric IDs by attempting to set them
-	 * in the ObjectService, which will resolve slugs to IDs.
+	 * This method used to hold its own copy of the resolution logic. That copy
+	 * was identical to ObjectsController's until #2858 and #2860 fixed the
+	 * other one — after which `GET /api/objects/19/9476` succeeded while
+	 * `POST /api/bulk/19/9475/save` still answered
+	 * `404 Register not found: '19'` for the same register. openregister#2820
+	 * had survived its own fix, in the copy nobody edited.
 	 *
-	 * @param string $register The register slug or ID
-	 * @param string $schema The schema slug or ID
-	 * @param ObjectService $objectService The object service
+	 * @param string        $register      Register slug, uuid or numeric id.
+	 * @param string        $schema        Schema slug, uuid or numeric id.
+	 * @param ObjectService $objectService The request's object service.
 	 *
-	 * @return array{register: int, schema: int} Resolved numeric IDs
+	 * @return array The resolved ids.
 	 *
-	 * @throws RegisterNotFoundException If register not found
-	 * @throws SchemaNotFoundException If schema not found
+	 * @throws RegisterNotFoundException When the register does not resolve.
+	 * @throws SchemaNotFoundException   When the schema does not resolve.
 	 *
-	 * @psalm-return   array{register: int, schema: int}
-	 * @phpstan-return array{register: int, schema: int}
+	 * @spec openspec/specs/register-scoped-slug-resolution/spec.md
 	 */
 	private function resolveRegisterSchemaIds(string $register, string $schema, ObjectService $objectService): array {
-		try {
-			// Resolve register slug/ID to numeric ID.
-			$objectService->setRegister(register: $register);
-		} catch (\OCP\AppFramework\Db\DoesNotExistException $e) {
-			throw new RegisterNotFoundException(registerSlugOrId: $register, code: 404, previous: $e);
-		}
+		$resolved = $this->resolveRegisterAndSchema(
+			register: $register,
+			schema: $schema,
+			objectService: $objectService
+		);
 
-		try {
-			// Resolve schema slug/ID to numeric ID.
-			$objectService->setSchema(schema: $schema);
-		} catch (\OCP\AppFramework\Db\DoesNotExistException $e) {
-			throw new SchemaNotFoundException(schemaSlugOrId: $schema, code: 404, previous: $e);
-		}
+		// Re-anchor on the resolved NUMERIC ids, as this controller did before:
+		// downstream bulk handlers read the service's current register/schema
+		// rather than the returned array.
+		$objectService->setRegister(register: (string)$resolved['register'])
+			->setSchema(schema: (string)$resolved['schema']);
 
-		// Get resolved numeric IDs.
-		$resolvedRegisterId = $objectService->getRegister();
-		$resolvedSchemaId = $objectService->getSchema();
-
-		// Reset ObjectService with resolved numeric IDs for consistency.
-		$objectService->setRegister(register: (string)$resolvedRegisterId)->setSchema(schema: (string)$resolvedSchemaId);
-
-		return [
-			'register' => $resolvedRegisterId,
-			'schema' => $resolvedSchemaId,
-		];
+		return ['register' => $resolved['register'], 'schema' => $resolved['schema']];
 	}//end resolveRegisterSchemaIds()
 
 	/**

--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -42,6 +42,7 @@ use OCA\OpenRegister\Exception\ExportTooLargeException;
 use OCA\OpenRegister\Exception\FolderAccessDeniedException;
 use OCA\OpenRegister\Exception\NotAuthorizedException;
 use OCA\OpenRegister\Exception\ReferentialIntegrityException;
+use OCA\OpenRegister\Controller\Trait\ResolvesRegisterAndSchemaTrait;
 use OCA\OpenRegister\Exception\RegisterNotFoundException;
 use OCA\OpenRegister\Exception\SchemaNotFoundException;
 use OCA\OpenRegister\Exception\TranslationTargetConflictException;
@@ -90,6 +91,7 @@ use Symfony\Component\Uid\Uuid;
  */
 class ObjectsController extends Controller {
 	use \OCA\OpenRegister\Controller\Trait\HandlesExceptionsTrait;
+	use ResolvesRegisterAndSchemaTrait;
 
 	/**
 	 * Export service for handling data exports
@@ -1012,91 +1014,31 @@ class ObjectsController extends Controller {
 	}//end crossTableSearch()
 
 	/**
-	 * Resolve register and schema IDs from slugs or IDs.
+	 * Resolve a register/schema path pair to numeric ids.
 	 *
-	 * @param string $register Register ID or slug.
-	 * @param string $schema Schema ID or slug.
-	 * @param ObjectService $objectService Object service for resolution.
+	 * Delegates to ResolvesRegisterAndSchemaTrait so this controller and
+	 * BulkController share ONE implementation. They previously each held a
+	 * private copy; #2858 and #2860 fixed this one and the bulk copy kept the
+	 * bug, so `GET /api/objects/19/9476` worked while
+	 * `POST /api/bulk/19/9475/save` still 404'd on the same register.
 	 *
-	 * @return array Resolved register and schema information.
+	 * @param string        $register      Register slug, uuid or numeric id.
+	 * @param string        $schema        Schema slug, uuid or numeric id.
+	 * @param ObjectService $objectService The request's object service.
 	 *
-	 * @throws RegisterNotFoundException When register is not found.
-	 * @throws SchemaNotFoundException When schema is not found.
+	 * @return array The resolved ids and entities.
+	 *
+	 * @throws RegisterNotFoundException When the register does not resolve.
+	 * @throws SchemaNotFoundException   When the schema does not resolve.
+	 *
+	 * @spec openspec/specs/register-scoped-slug-resolution/spec.md
 	 */
 	private function resolveRegisterSchemaIds(string $register, string $schema, ObjectService $objectService): array {
-		// STEP 1: Initial resolution - convert slugs/IDs to numeric IDs.
-		//
-		// `setRegister()` does TWO things, and only the first is about the
-		// register: it resolves the register, and then — if a schema ref is
-		// still pending from an earlier caller on this shared ObjectService — it
-		// re-resolves that ref INSIDE the register. A scoped miss there is a
-		// SCHEMA failure, and reporting it as `Register not found: '19'` sent a
-		// diagnosis down the wrong path for hours: the register plainly exists,
-		// so every reasonable first move (check the row, the magic tables, the
-		// organisation filter, run the mapper's query by hand) confirms it and
-		// explains nothing. openregister#2820.
-		//
-		// So the register lookup is now resolved on its own, and only its
-		// failure is reported as a missing register. Anything the pending-ref
-		// re-resolution throws keeps its own identity.
-		// Start from a clean context — this is the other half of #2820.
-		//
-		// #2858 made this endpoint report a leaked-ref failure honestly, as a
-		// schema failure. It did not stop the leak: `setRegister()` re-resolves
-		// whatever schema ref is still pending on the SHARED ObjectService, and
-		// a ref left behind by an unrelated earlier caller then gets resolved
-		// inside a register it was never meant for. On the dev instance a
-		// preload resolves register `buildiq` moments before the request's own
-		// lookup, which is how a plain `GET /objects/19/9476` failed.
-		//
-		// Nothing pending can ever be legitimate here: this method is handed
-		// BOTH the register and the schema explicitly, so it has no use for a
-		// ref it did not receive. #2790 added the same isolation on LEAVING
-		// find(); this is the entering end.
-		$objectService->clearCurrents();
-
-		// The discriminator is `setRegister()`'s own order of operations: it
-		// assigns `currentRegister` BEFORE it re-resolves any pending schema ref.
-		// So a register entity that is NEW after the throw proves the register
-		// lookup succeeded and the schema side failed.
-		//
-		// Comparing against the entity held BEFORE the call is what makes this
-		// sound. ObjectService is shared, so `currentRegister` can already hold
-		// an earlier caller's register; testing it for null alone would report a
-		// genuine missing register as a schema problem whenever someone had used
-		// the service first — swapping one misattribution for another.
-		$registerBefore = $objectService->getCurrentRegisterEntity();
-		try {
-			$objectService->setRegister(register: $register);
-		} catch (\OCP\AppFramework\Db\DoesNotExistException $e) {
-			$registerAfter = $objectService->getCurrentRegisterEntity();
-			if ($registerAfter === null || $registerAfter === $registerBefore) {
-				throw new RegisterNotFoundException(registerSlugOrId: $register, code: 404, previous: $e);
-			}
-
-			throw new SchemaNotFoundException(schemaSlugOrId: $schema, code: 404, previous: $e);
-		}
-
-		try {
-			$objectService->setSchema(schema: $schema);
-		} catch (\OCP\AppFramework\Db\DoesNotExistException $e) {
-			// If schema not found, throw custom exception.
-			throw new SchemaNotFoundException(schemaSlugOrId: $schema, code: 404, previous: $e);
-		}
-
-		// STEP 2: Get resolved numeric IDs.
-		$resolvedRegisterId = $objectService->getRegister();
-		$resolvedSchemaId = $objectService->getSchema();
-
-		// STEP 3: Reuse the entities already resolved by setRegister()/setSchema()
-		// above — re-fetching them via the mappers would resolve the same
-		// register and schema twice per request.
-		return [
-			'register' => $resolvedRegisterId,
-			'schema' => $resolvedSchemaId,
-			'registerEntity' => $objectService->getCurrentRegisterEntity(),
-			'schemaEntity' => $objectService->getCurrentSchemaEntity(),
-		];
+		return $this->resolveRegisterAndSchema(
+			register: $register,
+			schema: $schema,
+			objectService: $objectService
+		);
 	}//end resolveRegisterSchemaIds()
 
 	/**

--- a/lib/Controller/Trait/ResolvesRegisterAndSchemaTrait.php
+++ b/lib/Controller/Trait/ResolvesRegisterAndSchemaTrait.php
@@ -10,6 +10,7 @@
  * @package  OCA\OpenRegister\Controller\Trait
  *
  * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @link https://OpenRegister.app

--- a/lib/Controller/Trait/ResolvesRegisterAndSchemaTrait.php
+++ b/lib/Controller/Trait/ResolvesRegisterAndSchemaTrait.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * One implementation of `{register}/{schema}` path resolution.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller\Trait
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Controller\Trait;
+
+use OCA\OpenRegister\Exception\RegisterNotFoundException;
+use OCA\OpenRegister\Exception\SchemaNotFoundException;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\AppFramework\Db\DoesNotExistException;
+
+/**
+ * Resolves a `{register}/{schema}` path pair to numeric ids.
+ *
+ * WHY THIS IS A TRAIT AND NOT A THIRD COPY
+ *
+ * `ObjectsController` and `BulkController` each carried their own private
+ * `resolveRegisterSchemaIds()`. They were identical until #2858 and #2860 fixed
+ * one of them, and then they were not — so `GET /api/objects/19/9476` started
+ * working while `POST /api/bulk/19/9475/save` kept answering
+ * `404 Register not found: '19'` for a register that plainly exists.
+ *
+ * That is openregister#2820 surviving its own fix in the copy nobody edited.
+ * Fixing the second copy would leave the same trap set for the third, so the
+ * implementation now has one home and both controllers use it.
+ *
+ * Two things it must keep doing, both of them load-bearing:
+ *
+ * 1. `clearCurrents()` FIRST. `ObjectService` is shared within a request, and a
+ *    schema ref left pending by an earlier caller is otherwise re-resolved
+ *    inside whichever register THIS call names — a register it was never meant
+ *    for. That is the #2820 leak.
+ *
+ * 2. Report a schema failure as a SCHEMA failure. `setRegister()` assigns
+ *    `currentRegister` BEFORE re-resolving any pending ref, so if the entity
+ *    changed the register resolved fine and the throw came from the schema
+ *    side. Without that discriminator the endpoint blames a register that
+ *    demonstrably exists, which is what made #2820 cost hours to find: every
+ *    reasonable first move — check the row, the magic tables, the organisation
+ *    filter, run the query in psql — investigates the wrong thing.
+ */
+trait ResolvesRegisterAndSchemaTrait {
+	/**
+	 * Resolve a register/schema path pair to numeric ids.
+	 *
+	 * @param string        $register      Register slug, uuid or numeric id.
+	 * @param string        $schema        Schema slug, uuid or numeric id.
+	 * @param ObjectService $objectService The request's object service.
+	 *
+	 * @return array{register: mixed, schema: mixed, registerEntity: mixed, schemaEntity: mixed}
+	 *
+	 * @throws RegisterNotFoundException When the register itself does not resolve.
+	 * @throws SchemaNotFoundException   When the schema does not resolve in it.
+	 *
+	 * @spec openspec/specs/register-scoped-slug-resolution/spec.md
+	 */
+	protected function resolveRegisterAndSchema(
+		string $register,
+		string $schema,
+		ObjectService $objectService,
+	): array {
+		// (1) Drop anything an earlier caller left on the shared service.
+		$objectService->clearCurrents();
+
+		$registerBefore = $objectService->getCurrentRegisterEntity();
+
+		try {
+			$objectService->setRegister(register: $register);
+		} catch (DoesNotExistException $e) {
+			// (2) Did the register resolve before the throw? If the current
+			// entity moved, it did, and this is a schema failure wearing a
+			// register's name.
+			$registerAfter = $objectService->getCurrentRegisterEntity();
+			if ($registerAfter === null || $registerAfter === $registerBefore) {
+				throw new RegisterNotFoundException(
+					registerSlugOrId: $register,
+					code: 404,
+					previous: $e
+				);
+			}
+
+			throw new SchemaNotFoundException(schemaSlugOrId: $schema, code: 404, previous: $e);
+		}
+
+		try {
+			$objectService->setSchema(schema: $schema);
+		} catch (DoesNotExistException $e) {
+			throw new SchemaNotFoundException(schemaSlugOrId: $schema, code: 404, previous: $e);
+		}
+
+		return [
+			'register' => $objectService->getRegister(),
+			'schema' => $objectService->getSchema(),
+			'registerEntity' => $objectService->getCurrentRegisterEntity(),
+			'schemaEntity' => $objectService->getCurrentSchemaEntity(),
+		];
+	}//end resolveRegisterAndSchema()
+}//end trait

--- a/tests/Unit/Controller/RegisterSchemaResolutionParityTest.php
+++ b/tests/Unit/Controller/RegisterSchemaResolutionParityTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Register/schema resolution must behave identically in every controller.
+ *
+ * openregister#2820 was fixed in `ObjectsController` (#2858, #2860) and stayed
+ * broken in `BulkController`, because each held a private copy of the same
+ * helper and only one was edited. The symptom: `GET /api/objects/19/9476`
+ * returned 200 while `POST /api/bulk/19/9475/save` answered
+ * `404 Register not found: '19'` for that same register — the bug surviving its
+ * own fix in the copy nobody touched.
+ *
+ * These tests assert the shared trait exists and that BOTH controllers route
+ * through it. A future third controller that pastes its own copy fails here,
+ * which is the only durable defence: fixing the second copy would have left the
+ * same trap set for the third.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Controller
+ * @author   Conduction Development Team <dev@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://OpenRegister.app
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Controller;
+
+use OCA\OpenRegister\Controller\BulkController;
+use OCA\OpenRegister\Controller\ObjectsController;
+use OCA\OpenRegister\Controller\Trait\ResolvesRegisterAndSchemaTrait;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * Parity of the `{register}/{schema}` resolution across controllers.
+ */
+class RegisterSchemaResolutionParityTest extends TestCase {
+	/**
+	 * Controllers that resolve a `{register}/{schema}` path pair.
+	 *
+	 * @return array<string, array{0: class-string}>
+	 */
+	public static function controllerProvider(): array {
+		return [
+			'ObjectsController' => [ObjectsController::class],
+			'BulkController' => [BulkController::class],
+		];
+	}
+
+	/**
+	 * Every such controller uses the shared trait.
+	 *
+	 * @param string $controller the controller class
+	 *
+	 * @dataProvider controllerProvider
+	 *
+	 * @return void
+	 */
+	public function testEveryResolvingControllerUsesTheSharedTrait(string $controller): void {
+		$traits = [];
+		for ($class = new ReflectionClass($controller); $class !== false; $class = $class->getParentClass()) {
+			$traits = array_merge($traits, $class->getTraitNames());
+		}
+
+		$this->assertContains(
+			ResolvesRegisterAndSchemaTrait::class,
+			$traits,
+			$controller . ' resolves register/schema without the shared trait — that is how '
+			. 'openregister#2820 survived its own fix in BulkController.'
+		);
+	}
+
+	/**
+	 * No controller keeps a private copy of the resolution logic.
+	 *
+	 * The tell is `clearCurrents()` appearing in a controller body: that call is
+	 * the leak fix, and it belongs to exactly one implementation. If it shows up
+	 * in a controller file, someone has pasted the helper again — and the next
+	 * fix will once more reach only one of the copies.
+	 *
+	 * @return void
+	 */
+	public function testNoControllerHoldsItsOwnCopyOfTheResolution(): void {
+		$dir = dirname(__DIR__, 3) . '/lib/Controller';
+		$offenders = [];
+
+		foreach (glob($dir . '/*.php') ?: [] as $file) {
+			$source = file_get_contents($file);
+			if ($source !== false && str_contains($source, 'clearCurrents(') === true) {
+				$offenders[] = basename($file);
+			}
+		}
+
+		$this->assertSame(
+			[],
+			$offenders,
+			'These controllers carry their own resolution copy instead of the trait: '
+			. implode(', ', $offenders)
+		);
+	}
+
+	/**
+	 * The trait actually implements the two load-bearing behaviours.
+	 *
+	 * Asserted on the trait's source rather than by driving ObjectService,
+	 * which needs the full container. Crude, but it fails if either behaviour is
+	 * deleted, and both are the reason #2820 took a day to find:
+	 * `clearCurrents()` stops the leak, and the entity comparison stops a schema
+	 * failure being reported as a missing register.
+	 *
+	 * @return void
+	 */
+	public function testTheTraitKeepsBothLoadBearingBehaviours(): void {
+		$file = (new ReflectionClass(ResolvesRegisterAndSchemaTrait::class))->getFileName();
+		$this->assertIsString($file);
+		$source = file_get_contents((string)$file);
+		$this->assertIsString($source);
+
+		$this->assertStringContainsString(
+			'clearCurrents()',
+			$source,
+			'the leaked-context clear is gone — an earlier caller\'s pending schema ref '
+			. 'will be re-resolved inside this call\'s register again'
+		);
+		$this->assertStringContainsString(
+			'SchemaNotFoundException',
+			$source,
+			'the discriminator is gone — a schema failure will be reported as a missing '
+			. 'register, which is what made #2820 cost hours'
+		);
+	}
+}


### PR DESCRIPTION
fix(bulk): one resolution implementation, because #2820 survived its own fix

Deploying #2858 and #2860 took the objects API from 2 of 16 registers working to
16 of 16. The archived-corpus import still failed on its first project:

    POST /api/bulk/19/9475/save
    404 {"error": "Register not found: '19'"}

for the same register `GET /api/objects/19/9476` had just served. `BulkController`
held its **own private copy** of `resolveRegisterSchemaIds()`, identical to
`ObjectsController`'s until I fixed one of them — after which they were not
identical, and the bug lived on in the copy nobody edited.

Fixing the second copy would have left the same trap set for the third, so the
logic now has one home: `ResolvesRegisterAndSchemaTrait`, used by both.

Two behaviours it must keep, both load-bearing and both learned the hard way:

- **`clearCurrents()` first.** `ObjectService` is shared within a request, so a
  schema ref left pending by an earlier caller is otherwise re-resolved inside
  whichever register THIS call names.
- **Report a schema failure as a schema failure.** `setRegister()` assigns
  `currentRegister` before re-resolving a pending ref, so a changed entity means
  the register resolved and the throw came from the schema side. Without that,
  the endpoint blames a register that demonstrably exists — which is what made
  #2820 cost a day: every reasonable first move (check the row, the magic
  tables, the organisation filter, run the query in psql) investigates the wrong
  thing.

`BulkController` keeps its re-anchor on the resolved numeric ids, because its
downstream handlers read the service's current register/schema rather than the
returned array. That is behaviour-preserving, not incidental.

## The test is the point

`RegisterSchemaResolutionParityTest` asserts both controllers route through the
trait, and that **no controller file contains `clearCurrents(`** — the tell of a
pasted copy. A future third controller that duplicates the helper fails here.
Mutation-checked: removing the trait from `BulkController` fails with
*"BulkController resolves register/schema without the shared trait — that is how
openregister#2820 survived its own fix"*.

That guard matters more than this fix. The defect was never the logic; it was
having two of it.

phpcs, phpstan clean on all three changed lib files; 8 tests across the parity
and attribution suites.

Refs #2820
