### PR TITLE
feat(walkthrough): give OpenRegister a getting-started tour

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -666,5 +666,124 @@
         }
       }
     ]
+  },
+  "walkthrough": {
+    "enabled": true,
+    "version": 1,
+    "completionConfigKey": "walkthrough_seen_version",
+    "tours": [
+      {
+        "id": "openregister:getting-started",
+        "title": "Getting started",
+        "trigger": "first-visit",
+        "minAppVersion": "1.1.5",
+        "steps": [
+          {
+            "id": "welcome",
+            "sinceVersion": "1.1.5",
+            "placement": "center",
+            "title": "Welcome to OpenRegister",
+            "body": "OpenRegister is the data foundation the other apps build on. Everything they store lives here, in registers you define. This tour walks the three ideas that make it work: a register, a schema, and the objects that result.",
+            "target": {
+              "kind": "page",
+              "ref": "dashboard"
+            },
+            "advanceOn": {
+              "type": "manual"
+            }
+          },
+          {
+            "id": "open-registers",
+            "sinceVersion": "1.1.5",
+            "placement": "right",
+            "body": "A register is a container with a purpose, like a filing cabinet for one domain. Apps address one by its slug, so the slug is a contract other apps depend on.",
+            "task": "Open Registers",
+            "target": {
+              "kind": "nav-item",
+              "ref": "Registers"
+            },
+            "advanceOn": {
+              "type": "route-match",
+              "route": "registers"
+            }
+          },
+          {
+            "id": "create-register",
+            "sinceVersion": "1.1.5",
+            "placement": "center",
+            "body": "Create one and give it a slug you will not want to change later. Renaming a register slug breaks every app that addresses it by name, so it is worth a moment of thought now.",
+            "task": "Create a register",
+            "allowManualNext": true,
+            "target": {
+              "kind": "page",
+              "ref": "registers"
+            },
+            "advanceOn": {
+              "type": "manual"
+            }
+          },
+          {
+            "id": "open-schemas",
+            "sinceVersion": "1.1.5",
+            "placement": "right",
+            "body": "A schema is the shape of one kind of thing inside a register. It is JSON Schema, so validation, defaults and required fields all come from the same definition.",
+            "task": "Open Schemas",
+            "target": {
+              "kind": "nav-item",
+              "ref": "Schemas"
+            },
+            "advanceOn": {
+              "type": "route-match",
+              "route": "schemas"
+            }
+          },
+          {
+            "id": "create-schema",
+            "sinceVersion": "1.1.5",
+            "placement": "center",
+            "body": "Add a schema to the register you just made. Once it exists, every object stored against it is validated on write, which is why bad data tends not to reach the other apps.",
+            "task": "Create a schema",
+            "allowManualNext": true,
+            "target": {
+              "kind": "page",
+              "ref": "schemas"
+            },
+            "advanceOn": {
+              "type": "manual"
+            }
+          },
+          {
+            "id": "open-tables",
+            "sinceVersion": "1.1.5",
+            "placement": "right",
+            "body": "Search and views read across registers and schemas at once. This is where the objects your apps write actually surface, and where you check that a write landed the way you expected.",
+            "task": "Open Search / views",
+            "target": {
+              "kind": "nav-item",
+              "ref": "Tables"
+            },
+            "advanceOn": {
+              "type": "route-match",
+              "route": "tables"
+            }
+          },
+          {
+            "id": "done",
+            "sinceVersion": "1.1.5",
+            "placement": "center",
+            "title": "That is the foundation",
+            "body": "Register, schema, objects: define the container, define the shape, and every app on the stack can read and write it through the same API. The rest of OpenRegister, from audit trails to data quality, hangs off those three.",
+            "task": "Open the documentation to keep going",
+            "target": {
+              "kind": "nav-item",
+              "ref": "Documentation"
+            },
+            "advanceOn": {
+              "type": "manual"
+            }
+          }
+        ]
+      }
+    ]
   }
 }

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -204,6 +204,31 @@ export default async function globalSetup(config: FullConfig): Promise<void> {
 		timeout: 20_000,
 	})
 
+	// Suppress the openregister product walkthrough for automated runs. On
+	// first visit it mounts a modal spotlight tour whose full dim layer
+	// intercepts pointer events, so every left-navigation click times out. The
+	// "seen" marker is browser-local (`cn-walkthrough-seen:<appId>`), and a
+	// fresh Playwright context re-triggers the tour every run.
+	//
+	// Seeding the marker with a high sentinel version is what dossiq and
+	// shillinq already do: every step's `sinceVersion` sorts below it, so the
+	// tour composes to an empty step set and never mounts.
+	try {
+		await page.goto('/apps/openregister/', {
+			waitUntil: 'domcontentloaded',
+			timeout: 60_000,
+		})
+		await page.evaluate(() => {
+			try {
+				window.localStorage.setItem('cn-walkthrough-seen:openregister', '999.0.0')
+			} catch (e) {
+				// localStorage unavailable — the tour then dismisses via helper clicks.
+			}
+		})
+	} catch {
+		// App origin unreachable here is non-fatal; specs still run.
+	}
+
 	await context.storageState({ path: STORAGE_STATE })
 	await browser.close()
 

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -24,6 +24,7 @@ import * as path from 'path'
 import * as fs from 'fs'
 import { seedMdm } from './mdm-seed'
 import { resolveBaseUrl } from './base-url'
+import { seedFirstVisitOverlaysSeen } from '@conduction/nextcloud-vue/testing/playwright'
 
 const AUTH_DIR = path.resolve(__dirname, '.auth')
 const STORAGE_STATE = path.join(AUTH_DIR, 'admin.json')
@@ -204,30 +205,25 @@ export default async function globalSetup(config: FullConfig): Promise<void> {
 		timeout: 20_000,
 	})
 
-	// Suppress the openregister product walkthrough for automated runs. On
-	// first visit it mounts a modal spotlight tour whose full dim layer
-	// intercepts pointer events, so every left-navigation click times out. The
-	// "seen" marker is browser-local (`cn-walkthrough-seen:<appId>`), and a
-	// fresh Playwright context re-triggers the tour every run.
+	// Suppress the product walkthrough this PR adds. On first visit it mounts a
+	// modal spotlight tour whose full dim layer intercepts pointer events, so
+	// every left-navigation click times out. A fresh Playwright context has no
+	// "seen" marker, so the tour re-triggers on every run.
 	//
-	// Seeding the marker with a high sentinel version is what dossiq and
-	// shillinq already do: every step's `sinceVersion` sorts below it, so the
-	// tour composes to an empty step set and never mounts.
-	try {
-		await page.goto('/apps/openregister/', {
-			waitUntil: 'domcontentloaded',
-			timeout: 60_000,
-		})
-		await page.evaluate(() => {
-			try {
-				window.localStorage.setItem('cn-walkthrough-seen:openregister', '999.0.0')
-			} catch (e) {
-				// localStorage unavailable — the tour then dismisses via helper clicks.
-			}
-		})
-	} catch {
-		// App origin unreachable here is non-fatal; specs still run.
-	}
+	// Uses the library helper rather than writing localStorage by hand. The key
+	// name and the sentinel version are the library's to define, and
+	// `seedWalkthroughSeen` already writes exactly the pair `useWalkthrough`
+	// reads. Hand-rolling it duplicates a contract that can move underneath us,
+	// and both halves fail SILENTLY when wrong: a mistyped key reads back as
+	// "never seen", so the tour mounts and the suppression looks present while
+	// doing nothing.
+	//
+	// The `/index.php/` prefix is deliberate. CI serves Nextcloud with `php -S`
+	// and no router script, where `/apps/openregister/` is a directory with no
+	// index.php and 404s. A 404 shares the origin, so a seed written there
+	// would appear to succeed.
+	await page.goto('/index.php/apps/openregister/')
+	await seedFirstVisitOverlaysSeen(page, 'openregister')
 
 	await context.storageState({ path: STORAGE_STATE })
 	await browser.close()


### PR DESCRIPTION
OpenRegister is the foundation every other app stores through, and it had **no walkthrough at all**. A new admin landed on the dashboard facing 36 pages with no route through them.

Seven first-visit steps over the three ideas the rest of the product depends on: **a register is the container, a schema is the shape, search/views is where the objects surface.**

## Two deliberate constraints

### No element targets

The house convention for "click the add button" is `{"kind":"element","ref":"index-add"}`, which works in apps whose pages are `type: index`.

**Every OpenRegister page is `type: custom.`** A grep for `index-add` — and for any `data-testid` containing "add" — across `src/` returns nothing.

A step pointing at an element id that does not exist highlights nothing and reports no error. So the creation steps use `allowManualNext` with a page target rather than pretending to anchor on a button that isn't there.

### Nav ids come from `children`, not top-level entries

This menu is grouped. `DataGroup`, `IntegrationGroup` and friends carry the real items as `children`:

```
DataGroup → Registers, Schemas, Templates, Tables, Files
```

`Registers`, `Schemas` and `Tables` are **child** ids. A validator that only walked top-level `menu[].id` would have declared all three broken — which is exactly the false-positive my first fleet sweep produced elsewhere.

## Verified against this manifest

| | |
|---|---|
| page targets | `dashboard`, `registers`, `schemas` all in `pages[]` |
| nav targets | `Registers`, `Schemas`, `Tables`, `Documentation` all in the flattened menu+children list |
| route-match | `registers`, `schemas`, `tables` are real route names |
| final CTA | has a `task`, points at the `Documentation` nav entry |

`check:manifest` **passes**. No em-dashes. Diff is **119 insertions, 0 deletions** — nothing else in the manifest moved.

Part of a fleet sweep: of the apps declaring a walkthrough, nine were verified correct; ten declared none. This is the first of those ten.