### PR TITLE
fix(aggregation): the caller's narrowing filter must scope the join too

### DIFF
--- a/lib/Service/Aggregation/AggregationRunner.php
+++ b/lib/Service/Aggregation/AggregationRunner.php
@@ -357,11 +357,27 @@ class AggregationRunner {
 		// once but must answer per administration, and an annotation has no
 		// way to name the caller's active one — `$currentUser` is the only
 		// placeholder the resolver knows.
+		$declaredOnlyFilter = $resolvedFilter;
 		$resolvedFilter = $this->mergeNarrowingFilter(
 			declared: $resolvedFilter,
 			extra: $extraFilter,
 			name: $name
 		);
+
+		// The caller constraints that ACTUALLY took effect on the parent — not
+		// the ones that were asked for. applyJoin() forwards these to the joined
+		// aggregate so both sides describe the same population.
+		//
+		// Deriving it from the merge result rather than reusing $extraFilter is
+		// the difference between a fix and a second hole. mergeNarrowingFilter()
+		// drops a key the declaration already constrains, so a caller passing
+		// `administrationId: B` against a declaration pinning `A` leaves the
+		// parent on A — and forwarding the raw request would have scoped the
+		// JOIN to B while the parent stayed A, which is the same
+		// population-mismatch bug pointed the other way. Worse, the dropped key
+		// never reaches the cache key, so that mismatch would have been cached
+		// and served to the next caller.
+		$appliedExtraFilter = array_diff_key($resolvedFilter, $declaredOnlyFilter);
 
 		// Cache lookup: the resolved filter (with placeholders concrete)
 		// is the cache key together with the user's RBAC scope. 60s TTL.
@@ -446,7 +462,8 @@ class AggregationRunner {
 				envelope: $result,
 				join: $joinArg,
 				groupFields: $this->resolveGroupFields(groupBy: $groupBy),
-				bypassRbac: $bypassRbac
+				bypassRbac: $bypassRbac,
+				extraFilter: $appliedExtraFilter
 			);
 			$this->cache->set(
 				registerSlug: (string)$register->getSlug(),
@@ -533,7 +550,8 @@ class AggregationRunner {
 			envelope: $result,
 			join: $joinArg,
 			groupFields: $runGroupFields,
-			bypassRbac: $bypassRbac
+			bypassRbac: $bypassRbac,
+			extraFilter: $appliedExtraFilter
 		);
 
 		$this->cache->set(
@@ -2703,9 +2721,10 @@ class AggregationRunner {
 	 *
 	 * RBAC
 	 * ----
-	 * A join MUST NOT become a way to read a schema the caller cannot read.
-	 * Three independent controls, the same three the cross-schema `from`
-	 * path relies on:
+	 * A join MUST NOT become a way to read a schema the caller cannot read,
+	 * NOR a way around the scoping the caller asked for. Four controls — the
+	 * first three are the ones the cross-schema `from` path relies on; the
+	 * fourth was missing and cost a cross-tenant read (see $extraFilter below):
 	 *  1. An explicit `list` permission gate on the JOINED schema via
 	 *     {@see PermissionHandler::hasPermission()}, refusing with
 	 *     RuntimeException('Forbidden: ...') before a single row is read.
@@ -2727,6 +2746,12 @@ class AggregationRunner {
 	 * @param array<int, string> $groupFields The parent's ordered group fields.
 	 * @param bool $bypassRbac Internal-system mode: skip the list-permission gate
 	 *                         (tenancy predicates still apply — they are not bypassable here).
+	 * @param array<string, mixed> $extraFilter The caller's narrowing constraints, applied to the
+	 *                         JOINED aggregate as well as the parent — restricted to keys the
+	 *                         joined schema declares, and never overriding the declared
+	 *                         `join.filter`. Control 4: without it the parent was scoped to one
+	 *                         administration while the joined figures were computed across all
+	 *                         of them.
 	 *
 	 * @return array<string, mixed> The envelope with a `joined` map on each group and a `join` summary.
 	 *
@@ -2746,6 +2771,7 @@ class AggregationRunner {
 		?array $join,
 		array $groupFields,
 		bool $bypassRbac,
+		array $extraFilter = [],
 	): array {
 		if ($join === null) {
 			return $envelope;
@@ -2777,6 +2803,53 @@ class AggregationRunner {
 		);
 
 		$joinedFilter = $this->placeholders->resolveArray((array)($join['filter'] ?? $join['where'] ?? []));
+
+		// SECURITY (control 4): the caller's NARROWING filter must reach the
+		// joined side too.
+		//
+		// It did not, and the result was a cross-tenant read. The parent rows
+		// were correctly narrowed to one administration while the joined
+		// aggregate was computed over EVERY administration, so the joined
+		// figures described a different population than the groups they were
+		// attached to. Measured on a live instance: CommitmentLine narrowed to
+		// `ADM-001` returned the right sums, and the joined
+		// `CommitmentBudget.authorised_amount` came back 160,000,000 — the
+		// ADM-001 budget (80,000,000) plus both of `adm-demo`'s (50,000,000 +
+		// 30,000,000), because the join matches on `programmeCode` alone. The
+		// page rendered another tenant's money as this tenant's authorised
+		// budget, with no error and a perfectly plausible number.
+		//
+		// mergeNarrowingFilter()'s docblock promises the failure mode is never
+		// "you saw more than you should". On the parent that held; the join
+		// bypassed it entirely.
+		//
+		// Restricted to keys the joined schema DECLARES. A filter on a property
+		// a schema does not have is not an error in this stack — it matches
+		// nothing and returns an empty set — so forwarding an unknown key would
+		// silently zero the join instead of narrowing it, trading a figure that
+		// is too big for one that is always zero. Keys the joined schema does
+		// not declare are dropped and logged; the join then stays as wide as it
+		// was, which is the pre-existing behaviour rather than a new one.
+		$joinedProperties = array_keys(($joinedSchema->getProperties() ?? []));
+		$applicable = array_intersect_key($extraFilter, array_flip($joinedProperties));
+		$ignored = array_keys(array_diff_key($extraFilter, $applicable));
+		if ($ignored !== []) {
+			$this->logger?->debug(
+				'Aggregation join: caller filter keys not declared by the joined schema were dropped.',
+				[
+					'through' => $through,
+					'ignored' => $ignored,
+				]
+			);
+		}
+
+		if ($applicable !== []) {
+			$joinedFilter = $this->mergeNarrowingFilter(
+				declared: $joinedFilter,
+				extra: $applicable,
+				name: $through . ' (join)'
+			);
+		}
 
 		$lookup = $this->aggregateJoinedSchema(
 			register: $joinedRegister,

--- a/tests/Unit/Service/Aggregation/AggregationJoinAndCompositeGroupByTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationJoinAndCompositeGroupByTest.php
@@ -389,6 +389,172 @@ class AggregationJoinAndCompositeGroupByTest extends TestCase {
 	 * out of decoded JSON — so this is the test that would catch the merge
 	 * key silently matching nothing on one path.
 	 */
+	/**
+	 * REGRESSION: the caller's narrowing filter must scope the JOINED
+	 * aggregate, not only the parent rows.
+	 *
+	 * This is a cross-tenant read, and it shipped. The parent was correctly
+	 * narrowed to one administration while the join was computed over every
+	 * administration, so a group's `joined` figures described a population the
+	 * caller is not allowed to see. Measured on a live instance before the fix:
+	 * CommitmentLine narrowed to ADM-001 returned the right sums while
+	 * `CommitmentBudget.authorised_amount` came back 160,000,000 — ADM-001's
+	 * own 80,000,000 plus both of adm-demo's (50,000,000 + 30,000,000), because
+	 * the join matches on `programmeCode` alone.
+	 *
+	 * Nothing errored. The page showed another tenant's money as this tenant's
+	 * authorised budget, and the number looked entirely reasonable.
+	 *
+	 * The fixture mirrors that shape: tenant `A` holds 1000 for P1, tenant `B`
+	 * holds 400 for the same P1. Unfiltered the join is 1400; scoped to `A` it
+	 * must be 1000. A run of this test against the unfixed runner reports 1400.
+	 */
+	public function testJoinHonoursTheCallersNarrowingFilter(): void {
+		$runner = $this->makeTenantJoinRunner();
+
+		$result = $runner->run(
+			registerRef: 'finance',
+			schemaRef: 'commitment-line',
+			name: 'committed',
+			extraFilter: ['administrationId' => 'A']
+		);
+
+		$joined = [];
+		foreach ($result['groups'] as $group) {
+			$joined[$group['keys']['programme']] = $group['joined']['commitment-budget.authorisedAmount'];
+		}
+
+		$this->assertSame(
+			1000.0,
+			$joined['P1'],
+			'the joined figure must cover tenant A only; 1400 means tenant B leaked in'
+		);
+	}//end testJoinHonoursTheCallersNarrowingFilter()
+
+	/**
+	 * The un-narrowed call is unchanged — the fix scopes, it does not clamp.
+	 *
+	 * Without this, a join that always returned the caller's own tenant would
+	 * pass the test above for the wrong reason.
+	 */
+	public function testJoinWithoutACallerFilterStillSeesEveryTenant(): void {
+		$result = $this->makeTenantJoinRunner()->run(
+			registerRef: 'finance',
+			schemaRef: 'commitment-line',
+			name: 'committed'
+		);
+
+		$joined = [];
+		foreach ($result['groups'] as $group) {
+			$joined[$group['keys']['programme']] = $group['joined']['commitment-budget.authorisedAmount'];
+		}
+
+		$this->assertSame(1400.0, $joined['P1']);
+	}//end testJoinWithoutACallerFilterStillSeesEveryTenant()
+
+	/**
+	 * A caller filter naming a property the JOINED schema does not declare is
+	 * dropped rather than forwarded.
+	 *
+	 * Forwarding it would not raise: a filter on a property a schema does not
+	 * have matches nothing and returns an empty set, so the join would silently
+	 * become zero — trading a figure that is too big for one that is always
+	 * wrong, and in the direction that looks like "no budget yet".
+	 *
+	 * `costCentre` is a PARENT property here and absent from
+	 * `commitment-budget`, which is exactly the realistic case: the page sends
+	 * one filter map and only some of its keys mean anything on the joined side.
+	 */
+	public function testJoinDropsACallerFilterTheJoinedSchemaDoesNotDeclare(): void {
+		$result = $this->makeTenantJoinRunner()->run(
+			registerRef: 'finance',
+			schemaRef: 'commitment-line',
+			name: 'committed',
+			extraFilter: ['costCentre' => 'C1']
+		);
+
+		$joined = [];
+		foreach ($result['groups'] as $group) {
+			$joined[$group['keys']['programme']] = $group['joined']['commitment-budget.authorisedAmount'];
+		}
+
+		$this->assertSame(
+			1400.0,
+			$joined['P1'],
+			'an undeclared key must leave the join as wide as it was, not zero it'
+		);
+	}//end testJoinDropsACallerFilterTheJoinedSchemaDoesNotDeclare()
+
+	/**
+	 * A caller may not relax what the join declares.
+	 *
+	 * Same asymmetry as {@see AggregationRunner::mergeNarrowingFilter()} on the
+	 * parent: the declaration wins. Here the join declares
+	 * `administrationId: A`, and a caller asking for `B` must not widen or
+	 * switch it — otherwise a declared scoping filter becomes a request
+	 * parameter, which is the whole thing that rule exists to prevent.
+	 */
+	public function testCallerCannotOverrideADeclaredJoinFilter(): void {
+		$annotation = $this->joinAnnotation();
+		$annotation['join']['filter'] = ['administrationId' => 'A'];
+
+		$result = $this->makeTenantJoinRunner($annotation)->run(
+			registerRef: 'finance',
+			schemaRef: 'commitment-line',
+			name: 'committed',
+			extraFilter: ['administrationId' => 'B']
+		);
+
+		$joined = [];
+		foreach ($result['groups'] as $group) {
+			$joined[$group['keys']['programme']] = $group['joined']['commitment-budget.authorisedAmount'];
+		}
+
+		$this->assertSame(
+			1000.0,
+			$joined['P1'],
+			"the declared administrationId 'A' must stand; 400 means the caller switched tenants"
+		);
+	}//end testCallerCannotOverrideADeclaredJoinFilter()
+
+	/**
+	 * A caller constraint the PARENT declaration drops must not reach the join
+	 * either.
+	 *
+	 * This is the hole the obvious version of the fix opens. The parent
+	 * declaration pins `administrationId: A`; a caller asking for `B` is
+	 * refused there and the parent stays on A. Forwarding the RAW request to
+	 * the join would then scope the joined figures to B while the parent rows
+	 * are A — the same population mismatch as the original bug, pointed the
+	 * other way, and arguably worse: the dropped key never reaches the cache
+	 * key, so the mismatched envelope would be cached and served on.
+	 *
+	 * Hence applyJoin() receives what actually took effect on the parent
+	 * (`array_diff_key` against the pre-merge filter), never `$extraFilter`.
+	 */
+	public function testACallerKeyTheParentDeclarationDropsDoesNotReachTheJoin(): void {
+		$annotation = $this->joinAnnotation();
+		$annotation['filter'] = ['administrationId' => 'A'];
+
+		$result = $this->makeTenantJoinRunner($annotation)->run(
+			registerRef: 'finance',
+			schemaRef: 'commitment-line',
+			name: 'committed',
+			extraFilter: ['administrationId' => 'B']
+		);
+
+		$joined = [];
+		foreach ($result['groups'] as $group) {
+			$joined[$group['keys']['programme']] = $group['joined']['commitment-budget.authorisedAmount'];
+		}
+
+		$this->assertSame(
+			1400.0,
+			$joined['P1'],
+			'the refused key must not scope the join; 400 means the parent stayed on A while the join followed the caller to B'
+		);
+	}//end testACallerKeyTheParentDeclarationDropsDoesNotReachTheJoin()
+
 	public function testNativeJoinAgreesWithPhpFallback(): void {
 		$php = $this->makeJoinRunner()->run(
 			registerRef: 'finance',
@@ -1056,6 +1222,81 @@ class AggregationJoinAndCompositeGroupByTest extends TestCase {
 	}//end makeJoinRunner()
 
 	/**
+	 * A `commitment-line` / `commitment-budget` fixture whose rows span two
+	 * administrations, for the join-scoping tests.
+	 *
+	 * Differs from {@see makeJoinRunner()} in the two things those tests need:
+	 * the joined schema DECLARES `administrationId` (the narrowing filter is
+	 * restricted to declared keys, so a schema without it would drop the filter
+	 * and the test would pass without exercising anything), and both sides
+	 * carry rows for tenants `A` and `B` over the same programme `P1`.
+	 *
+	 * P1 authorised: A=1000, B=400. Unscoped the join reports 1400.
+	 *
+	 * @param array<string, mixed>|null $annotation Override the aggregation annotation.
+	 *
+	 * @return AggregationRunner
+	 */
+	private function makeTenantJoinRunner(?array $annotation = null): AggregationRunner {
+		$annotations = ['committed' => ($annotation ?? $this->joinAnnotation())];
+
+		$parentSchema = $this->makeSchema(
+			'commitment-line',
+			10,
+			$annotations,
+			[
+				'programme' => ['type' => 'string'],
+				'costCentre' => ['type' => 'string'],
+				'administrationId' => ['type' => 'string'],
+				'remainingCommitted' => ['type' => 'number'],
+			]
+		);
+		$joinedSchema = $this->makeSchema(
+			'commitment-budget',
+			20,
+			[],
+			[
+				'programmeCode' => ['type' => 'string'],
+				'administrationId' => ['type' => 'string'],
+				'authorisedAmount' => ['type' => 'number'],
+			]
+		);
+		$register = $this->makeRegister('finance', [10, 20]);
+
+		$this->registerMapper->method('find')->willReturn($register);
+		$this->registerMapper->method('findAll')->willReturn([$register]);
+		$this->schemaMapper->method('find')->willReturnMap(
+			[
+				['commitment-line', [], true, false, $parentSchema],
+				['commitment-budget', [], true, false, $joinedSchema],
+			]
+		);
+		$this->permissionHandler->method('hasPermission')->willReturn(true);
+		$this->usePhpFallback();
+
+		$parentRows = [
+			['programme' => 'P1', 'costCentre' => 'C1', 'administrationId' => 'A', 'remainingCommitted' => 100],
+			['programme' => 'P1', 'costCentre' => 'C1', 'administrationId' => 'B', 'remainingCommitted' => 60],
+		];
+		$joinedRows = [
+			['programmeCode' => 'P1', 'administrationId' => 'A', 'authorisedAmount' => 1000],
+			['programmeCode' => 'P1', 'administrationId' => 'B', 'authorisedAmount' => 400],
+		];
+
+		$this->magicMapper->method('findAllInRegisterSchemaTable')->willReturnCallback(
+			function (Register $register, Schema $schema) use ($parentRows, $joinedRows): array {
+				if ((string)$schema->getSlug() === 'commitment-budget') {
+					return $this->entities($joinedRows);
+				}
+
+				return $this->entities($parentRows);
+			}
+		);
+
+		return $this->makeRunner();
+	}//end makeTenantJoinRunner()
+
+	/**
 	 * The same `commitment-line` / `commitment-budget` fixture as
 	 * {@see makeJoinRunner()}, but backed by a real in-memory SQLite
 	 * database so the emitted `GROUP BY` SQL is genuinely parsed and
@@ -1278,15 +1519,22 @@ class AggregationJoinAndCompositeGroupByTest extends TestCase {
 	 * @param string $slug Schema slug.
 	 * @param int $id Schema DB id.
 	 * @param array<string, mixed> $aggregations Aggregation annotation map.
+	 * @param array<string, mixed> $properties Declared properties. The join's narrowing filter is
+	 *                                         restricted to keys the joined schema declares, so a
+	 *                                         fixture testing that path must set them.
 	 *
 	 * @return Schema
 	 */
-	private function makeSchema(string $slug, int $id, array $aggregations = []): Schema {
+	private function makeSchema(string $slug, int $id, array $aggregations = [], array $properties = []): Schema {
 		$schema = new Schema();
 		$schema->setSlug($slug);
 		$schema->setId($id);
 		if ($aggregations !== []) {
 			$schema->setConfiguration(['x-openregister-aggregations' => $aggregations]);
+		}
+
+		if ($properties !== []) {
+			$schema->setProperties($properties);
 		}
 
 		return $schema;

--- a/tests/Unit/Service/Flow/FlowNodeRegistryTest.php
+++ b/tests/Unit/Service/Flow/FlowNodeRegistryTest.php
@@ -72,8 +72,22 @@ class TaggingNode implements IFlowNode {
  * A node that reliably outlives a one-second ceiling.
  *
  * It sleeps rather than reporting a fake duration, because what is under test is
- * the dispatcher measuring a real call. 1.2s buys enough margin that a loaded
- * machine cannot make this flap the other way.
+ * the dispatcher measuring a real call.
+ *
+ * WAITS ON THE CLOCK, NOT ON ONE usleep() CALL. This was a single
+ * `usleep(1_200_000)`, and the comment above it argued that 1.2s against a 1s
+ * ceiling "buys enough margin that a loaded machine cannot make this flap".
+ * That reasons about the wrong direction: load makes a sleep LONGER, which is
+ * the safe way to be wrong. What actually happens is that `usleep()` can return
+ * EARLY when a signal arrives — likely on a busy box with many child processes
+ * — and then the node finishes inside its ceiling, the dispatcher is right not
+ * to raise, and the test fails claiming the timeout is broken.
+ *
+ * Observed 2026-08-26: green in isolation three times over, red inside the full
+ * suite while phpcs and phpmd were saturating the machine.
+ *
+ * Looping until hrtime() says the target has genuinely elapsed makes the node
+ * outlive its ceiling whatever the sleep does.
  */
 class SlowNode extends TaggingNode {
 	public function __construct() {
@@ -81,7 +95,13 @@ class SlowNode extends TaggingNode {
 	}
 
 	public function execute(array $items, array $config, array $context): array {
-		usleep(1_200_000);
+		$deadline = (hrtime(true) + 1_200_000_000);
+		while (hrtime(true) < $deadline) {
+			$remaining = (int)(($deadline - hrtime(true)) / 1_000);
+			if ($remaining > 0) {
+				usleep($remaining);
+			}
+		}
 
 		return $items;
 	}


### PR DESCRIPTION
## A join is a second query, and the caller's filter only reached the first one

`applyJoin()` built its filter from the declared `join.filter` alone. So the
parent rows were narrowed to one tenant while the joined aggregate was computed
over **all** of them, and the two halves of one envelope described different
populations.

Measured on a live instance — `CommitmentLine` narrowed to `ADM-001`:

| | |
|---|---|
| parent sums | correct, ADM-001 only |
| `CommitmentBudget.authorised_amount` | **160,000,000** |
| what ADM-001 actually holds | 80,000,000 |
| the rest | `adm-demo`'s 50,000,000 + 30,000,000 |

That join matches on `programmeCode` alone, so every administration's budget for
programme 5.1 was summed in. **The page rendered another administration's money
as this one's.** Nothing raised, and 160 million reads as plausibly as 80.

`mergeNarrowingFilter()`'s docblock promises the failure mode is never *"you saw
more than you should"*. That held on the parent. The join walked straight past
it — and the same docblock enumerates **three** security controls, which is part
of why a missing fourth stayed invisible.

## Two things this gets right that the obvious fix does not

**Restricted to keys the joined schema declares.** A filter on a property a
schema does not have is not an error here — it matches nothing. Forwarding an
unknown key would silently *zero* the join rather than narrow it, trading a
figure that is too big for one that is always wrong, in the direction that looks
like "no budget yet".

**Forwards what took effect on the parent, not what was asked for.** Reusing
`$extraFilter` opens the mirror-image hole: `mergeNarrowingFilter()` drops a key
the declaration already constrains, so a caller passing `administrationId: B`
against a declaration pinning `A` leaves the parent on A while the join follows
the caller to B. And because a dropped key never reaches the cache key, that
mismatched envelope would be **cached and served on**.

## Verified

Both failure modes have a test and both were confirmed to go red without the fix:

- `testJoinHonoursTheCallersNarrowingFilter` → `1400.0`, required `1000.0`
- `testACallerKeyTheParentDeclarationDropsDoesNotReachTheJoin` → `400.0`, required `1400.0`

Plus two that pin the unchanged behaviour, so the first cannot pass for the wrong
reason: an un-narrowed call still sees every tenant, and an undeclared caller key
leaves the join as wide as it was.

Live decisive control: adding a 7,000,000 budget to `adm-demo` moved **adm-demo
80,000,000 → 87,000,000** while **ADM-001 held at 80,000,000**. Before the fix
ADM-001 would have read 167,000,000.

> ⚠️ My first attempt at that control looked fine and proved nothing: aggregation
> results cache for 60s, and the two administrations coincidentally both totalled
> 80,000,000 with identical realised amounts. Symmetric fixture data hides a
> scoping bug.

`phpcs`, `phpmd`, `psalm`, `phpstan` all green. Full suite 17,300 tests, 0
failures.

## Second commit: a genuinely flaky test

`FlowNodeRegistryTest::testAStepThatOverrunsItsCeilingIsStopped` went red inside
the full suite while phpcs and phpmd saturated the machine, and green three times
in isolation. `SlowNode` slept once for 1.2s against a 1s ceiling, and the
comment argued the margin meant *"a loaded machine cannot make this flap"* — which
reasons about the wrong direction. Load makes a sleep longer, the safe way to be
wrong. What bites is `usleep()` returning **early** on a signal, after which the
node finishes inside its ceiling and the test blames the timeout. Now it waits on
`hrtime()`. Verified green with every core pinned.

## Blast radius

45 aggregations in shillinq declare a join, so this was not one page's problem.
Two related findings measured while verifying this, filed separately rather than
folded in here.
