### PR TITLE
fix(dependabot): target development, not the default branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    target-branch: "development"
     open-pull-requests-limit: 10
     cooldown:
       default-days: 1
@@ -29,6 +30,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    target-branch: "development"
     open-pull-requests-limit: 10
     cooldown:
       default-days: 2


### PR DESCRIPTION
Without `target-branch`, dependabot opens against the repository's **default** branch (`main`). Branch protection refuses any PR to `main` that does not come from `beta` or a `hotfix/*` branch, so those PRs are **unmergeable by construction** and simply accumulate — every one fails `branch-protection / check-branch`.

Measured across the fleet before changing anything: **15 repos set no `target-branch` at all**, and their open dependabot PRs all sit against `main`. The repos that do set it (humaniq, thematiq, dossiq, shillinq, decidiq, buildiq) open against `development` and merge normally.

Cooldown windows and `open-pull-requests-limit` are untouched.

The inserted key is anchored on `directory:` rather than on `interval:` — some schedule blocks carry a `day:` as well, and inserting after `interval:` orphaned it and produced invalid YAML. Each result was parsed and checked (every update entry has `target-branch: development`, entry count unchanged) before anything was written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)