### PR TITLE
feat(api): `_limit` accepts an explicit unlimited value, and the three read paths finally agree

### DIFF
--- a/docs/api/objects.md
+++ b/docs/api/objects.md
@@ -29,9 +29,45 @@ Retrieves a paginated list of objects that match the specified register and sche
 - **deleted**: Filter by deletion date
 
 ##### Pagination
-- **`_limit`**: Number of items per page (default: 20)
+- **`_limit`**: Number of items per page. Also accepts an explicit **unlimited**
+  value — see below.
 - **`_offset`**: Number of items to skip
 - **`_page`**: Current page number (alternative to `_offset`)
+
+###### Asking for every row
+
+`_limit` accepts `false`, `null`, `0`, `all`, `unlimited` or `none` (any case)
+to mean **no limit at all**. The query then carries no `LIMIT` clause and every
+matching row is returned.
+
+```
+GET /api/objects/myregister/myschema?_limit=false
+GET /api/objects/myregister/myschema?_limit=0
+```
+
+Prefer `_limit=false`: it says what it means. `0` is accepted because callers
+already wrote it expecting exactly this.
+
+**Use it deliberately.** An unlimited read is a full scan of the matching set,
+and the whole result is materialised in PHP before it is serialised. It exists
+so that a caller who genuinely needs the complete set can ask for it *and know
+they got it*, rather than filtering a silently truncated page in the browser
+and presenting the count as a total. If you only need a number, ask for the
+number: `_count=true` returns the total without the rows.
+
+**Values that are not row counts are read as unlimited, not as zero.** A
+non-numeric `_limit` (`?_limit=abc`) and a negative one both mean "no usable
+limit given". This matters because `(int)"abc"` is `0` in PHP, and a `LIMIT 0`
+returns an empty list with HTTP 200 — a typo in a query string used to produce
+a confidently empty result.
+
+> **Changed in this release.** `_limit=0` previously behaved three different
+> ways depending on which read path served the request: no rows on the
+> single-schema path, one row on the cross-schema path, and 200 rows against an
+> external database. A hard cap of 1000 rows also applied on the latter two
+> paths, silently — a caller asking for 5000 received 1000 and was told
+> nothing. Both are gone. If you were relying on `_limit=0` to return an empty
+> page, request `_count=true` instead.
 
 ##### Search
 - **`_search`**: Full-text search term

--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -60,6 +60,7 @@ use OCA\OpenRegister\Event\ObjectUpdatingEvent;
 use OCA\OpenRegister\Exception\HookStoppedException;
 use OCA\OpenRegister\Exception\ObjectExistsException;
 use OCA\OpenRegister\Service\SettingsService;
+use OCA\OpenRegister\Support\QueryLimit;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\Entity;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
@@ -151,6 +152,22 @@ use Symfony\Component\Uid\Uuid;
  * @SuppressWarnings(PHPMD.LongVariable)
  */
 class MagicMapper extends AbstractObjectMapper {
+	/**
+	 * Hard ceiling on a NUMERIC page size, per the objects-crud requirement
+	 * "List page size is bounded by a hard maximum".
+	 *
+	 * A client asking for `_limit=1000000` is not making a considered request,
+	 * so it is reduced to this. A client asking for `_limit=false` IS making
+	 * one, and that path skips the clause entirely — see the LIMIT/OFFSET block
+	 * in the UNION query and {@see \OCA\OpenRegister\Support\QueryLimit}.
+	 *
+	 * Previously spelled as the literal `1000` inside `min()`, which made it
+	 * invisible to anything that wanted to state or test the bound.
+	 *
+	 * @var int
+	 */
+	private const MAX_PAGE_SIZE = 1000;
+
 	/**
 	 * Table name prefix for register+schema-specific tables.
 	 *
@@ -1401,9 +1418,37 @@ class MagicMapper extends AbstractObjectMapper {
 		// Apply LIMIT/OFFSET to final UNION result.
 		// Cast + clamp at the boundary so raw user input cannot reach the
 		// interpolated SQL string (SQL injection via _limit / _offset).
-		$limit = max(1, min(1000, (int)($query['_limit'] ?? 100)));
+		//
+		// UNLIMITED OMITS THE CLAUSE, it does not interpolate a large number.
+		// This SQL is built by string concatenation rather than bound
+		// parameters, so "unlimited" must never become a value that travels
+		// into the string — there is nothing to bind it to, and a sentinel like
+		// PHP_INT_MAX would be both a lie and a number some databases reject.
+		//
+		// The previous clamp answered `_limit=0` with ONE row (max(1, …)) and
+		// `_limit=5000` with a silent 1000. Both are gone; the offset clamp
+		// stays exactly as it was, because it is still interpolated.
+		$normalisedLimit = QueryLimit::normalise($query['_limit'] ?? null);
 		$offset = max(0, (int)($query['_offset'] ?? 0));
-		$unionSql .= " LIMIT {$limit} OFFSET {$offset}";
+		if ($normalisedLimit === null) {
+			// MySQL and MariaDB reject a bare OFFSET without a LIMIT, so an
+			// offset with no limit still needs the clause. The upper bound is
+			// the largest value the syntax accepts, which is the documented
+			// idiom for "everything from here on".
+			if ($offset > 0) {
+				$unionSql .= ' LIMIT 18446744073709551615 OFFSET ' . $offset;
+			}
+		} else {
+			// A NUMERIC limit is still clamped to the documented maximum. That
+			// clamp is a deliberate protection (objects-crud: "List page size is
+			// bounded by a hard maximum") against a client loading an
+			// arbitrarily large result set by accident, and asking for
+			// `_limit=1000000` is an accident. Saying `_limit=false` is not —
+			// that is the explicit opt-in this change adds, and it is the only
+			// way past the bound.
+			$limit = min($normalisedLimit, self::MAX_PAGE_SIZE);
+			$unionSql .= " LIMIT {$limit} OFFSET {$offset}";
+		}
 
 		// Execute the combined query.
 		$stmt = $qb->getConnection()->prepare($unionSql);

--- a/lib/Db/MagicMapper/MagicSearchHandler.php
+++ b/lib/Db/MagicMapper/MagicSearchHandler.php
@@ -49,6 +49,7 @@ use OCA\OpenRegister\Exception\EncryptedFieldFilterException;
 use OCA\OpenRegister\Exception\UnknownMetadataFieldException;
 use OCA\OpenRegister\Service\DateTimeNormalizer;
 use OCA\OpenRegister\Service\Object\SchemaTypeConverter;
+use OCA\OpenRegister\Support\QueryLimit;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use Psr\Log\LoggerInterface;
@@ -244,7 +245,12 @@ class MagicSearchHandler {
 		$this->ignoredFilters = [];
 
 		// Extract options from query (prefixed with _).
-		$limit = $query['_limit'] ?? null;
+		// `_limit` is normalised to a positive row count or null (= unlimited).
+		// Doctrine reads null on setMaxResults() as "retrieve all results", so
+		// this is the one place that decides whether the SQL carries a LIMIT.
+		// Before normalisation `_limit=0` reached setMaxResults(0) and produced
+		// `LIMIT 0` — an empty page, HTTP 200, no explanation.
+		$limit = QueryLimit::normalise($query['_limit'] ?? null);
 		$offset = $query['_offset'] ?? null;
 		$page = $query['_page'] ?? null;
 		$order = $query['_order'] ?? [];

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -86,7 +86,11 @@ class Notifier implements INotifier {
 
 		$name = trim($user->getDisplayName());
 
-		return ($name === '' ? $uid : $name);
+		if ($name === '') {
+			return $uid;
+		}
+
+		return $name;
 	}//end displayName()
 
 	/**
@@ -278,7 +282,7 @@ class Notifier implements INotifier {
 
 		$principal = (string)($parameters['principal'] ?? '');
 		$grantUuid = (string)($parameters['grantUuid'] ?? '');
-		$who = $this->displayName($principal);
+		$who = $this->displayName(uid: $principal);
 
 		// RICH FIRST, PARSED ALWAYS — both, and neither is optional.
 		//

--- a/lib/Service/ObjectSource/DbalObjectSourceProvider.php
+++ b/lib/Service/ObjectSource/DbalObjectSourceProvider.php
@@ -46,6 +46,7 @@ use OCA\OpenRegister\Db\SourceMapper;
 use OCA\OpenRegister\Service\Dbal\DatabaseIntrospectionService;
 use OCA\OpenRegister\Service\Dbal\DbalConnectionException;
 use OCA\OpenRegister\Service\Dbal\DbalConnectionFactory;
+use OCA\OpenRegister\Support\QueryLimit;
 use OCP\AppFramework\Db\DoesNotExistException;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
@@ -64,7 +65,10 @@ use Throwable;
  */
 class DbalObjectSourceProvider implements WritableObjectSourceProvider {
 	/**
-	 * Hard cap on rows returned by a single findAll(), regardless of the query.
+	 * Hard cap on rows returned by a single findAll() for a NUMERIC limit.
+	 *
+	 * An explicit unlimited (`limit=false`) bypasses it; an oversized number
+	 * does not. See {@see \OCA\OpenRegister\Support\QueryLimit}.
 	 *
 	 * @var int
 	 */
@@ -1159,12 +1163,29 @@ class DbalObjectSourceProvider implements WritableObjectSourceProvider {
 	 *
 	 * @spec openspec/specs/dbal-virtual-registers/spec.md
 	 */
-	private function limit(array $query): int {
-		$limit = (int)($query['limit'] ?? self::DEFAULT_LIMIT);
-		if ($limit < 1) {
-			$limit = self::DEFAULT_LIMIT;
+	private function limit(array $query): ?int {
+		// An ABSENT limit still takes this provider's default. That is the one
+		// place the default belongs: these queries run against a FOREIGN
+		// database over which this app has no operational control, so a caller
+		// that says nothing gets a bounded page rather than that database's
+		// entire table.
+		if (array_key_exists('limit', $query) === false) {
+			return self::DEFAULT_LIMIT;
 		}
 
+		// An EXPLICIT unlimited is honoured, and is no longer rewritten into
+		// the default. This is the only way past the bound, and it has to be
+		// asked for by name.
+		$limit = QueryLimit::normalise(limit: $query['limit']);
+		if ($limit === null) {
+			return null;
+		}
+
+		// A NUMERIC limit is still capped. The cap is a deliberate protection
+		// (objects-crud: "List page size is bounded by a hard maximum") and it
+		// matters more here than anywhere else: this provider queries a FOREIGN
+		// database, so an accidental `limit=1000000` spends someone else's
+		// resources.
 		return min($limit, self::MAX_RESULTS);
 	}//end limit()
 

--- a/lib/Support/QueryLimit.php
+++ b/lib/Support/QueryLimit.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * QueryLimit — one answer to "how many rows does `_limit` ask for?"
+ *
+ * @category Support
+ * @package  OCA\OpenRegister\Support
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Support;
+
+/**
+ * Normalises the `_limit` query parameter to either a positive row count or
+ * `null`, where `null` means UNLIMITED.
+ *
+ * WHY THIS EXISTS. `_limit` reached the query builders as whatever the request
+ * happened to contain, and the three read paths disagreed about what the odd
+ * values meant:
+ *
+ *   - The canonical single-schema path (`MagicSearchHandler::searchObjects`)
+ *     passed the raw value to `setMaxResults()`. Doctrine documents `null` as
+ *     "retrieve all results", so an ABSENT `_limit` already issued an unbounded
+ *     query — while `_limit=0` became `LIMIT 0` and returned NOTHING.
+ *   - The cross-table UNION path clamped with `max(1, min(1000, …))`, so
+ *     `_limit=0` returned ONE row and `_limit=5000` silently returned 1000.
+ *   - The external-database provider mapped anything `< 1` to its own default
+ *     of 200 and capped at 1000.
+ *
+ * So the same request answered three different ways depending on which path
+ * served it, and two of the three answers were silent: a caller asking for
+ * everything got one row, or twenty, or a truncated thousand, always with
+ * HTTP 200 and never a word about the rows it did not receive. Fleet apps then
+ * filtered those partial result sets in the browser and presented the count as
+ * a total.
+ *
+ * That callers read 0 as "no limit" is not a guess: `TmloController::summary()`
+ * passes `'_limit' => 0` for exactly that purpose. (That method has its own,
+ * unrelated defects and never reaches the query — see the issue it is filed
+ * under — but the intent it encodes is the one this class now honours.)
+ *
+ * WHAT COUNTS AS UNLIMITED. `false`, `null`, an empty string, the strings
+ * `'false'`, `'null'`, `'all'`, `'unlimited'` (any case), and any numeric value
+ * `<= 0`. Everything else is read as a positive integer row count.
+ *
+ * Zero is deliberately included. Under the previous behaviour `_limit=0` meant
+ * "one row", "zero rows" or "two hundred rows" depending on the path — no
+ * caller could have been relying on any of those, and one caller in this
+ * repository was already relying on it meaning "unlimited". A caller that wants
+ * no rows at all wants `_count=true` and the total, not an empty page.
+ *
+ * @psalm-suppress UnusedClass Referenced from the query paths; psalm's
+ *  entry-point analysis does not follow the controllers that reach them.
+ */
+final class QueryLimit {
+
+	/**
+	 * Values that spell "no limit" when `_limit` is given as a string.
+	 *
+	 * A query string carries no types: `?_limit=false` arrives as the STRING
+	 * `"false"`, which is truthy in PHP and casts to int 0. Listing the spellings
+	 * explicitly is what keeps `?_limit=false` from being read as `?_limit=0`
+	 * by accident rather than by intent.
+	 *
+	 * @var string[]
+	 */
+	private const UNLIMITED_WORDS = ['', 'false', 'null', 'all', 'unlimited', 'none'];
+
+	/**
+	 * Resolve `_limit` to a positive row count, or null for unlimited.
+	 *
+	 * @param mixed $limit The raw `_limit` value from the request or query array.
+	 *
+	 * @return int|null Positive row count, or null meaning no limit at all.
+	 *
+	 * @spec openspec/specs/objects-crud/spec.md#requirement-limit-supports-an-explicit-unlimited-value
+	 */
+	public static function normalise(mixed $limit): ?int {
+		if ($limit === null || $limit === false) {
+			return null;
+		}
+
+		if (is_string($limit) === true) {
+			$word = strtolower(trim($limit));
+			if (in_array($word, self::UNLIMITED_WORDS, true) === true) {
+				return null;
+			}
+
+			// A non-numeric string is not a row count. Reading it as `(int)`
+			// would turn "abc" into 0 and, before this class existed, into a
+			// silently empty page.
+			if (is_numeric($word) === false) {
+				return null;
+			}
+
+			$limit = $word;
+		}
+
+		if (is_bool($limit) === true) {
+			// `true` is not a row count either. It reaches here only from a
+			// caller that meant "yes, limit it" without saying to what.
+			return null;
+		}
+
+		$value = (int)$limit;
+		if ($value <= 0) {
+			return null;
+		}
+
+		return $value;
+	}//end normalise()
+
+	/**
+	 * Whether a raw `_limit` value asks for every row.
+	 *
+	 * Sugar over {@see normalise}, for the call sites that only branch on it.
+	 *
+	 * @param mixed $limit The raw `_limit` value.
+	 *
+	 * @return bool True when no limit should be applied.
+	 *
+	 * @spec openspec/specs/objects-crud/spec.md#requirement-limit-supports-an-explicit-unlimited-value
+	 */
+	public static function isUnlimited(mixed $limit): bool {
+		return self::normalise(limit: $limit) === null;
+	}//end isUnlimited()
+}//end class

--- a/openspec/specs/objects-crud/spec.md
+++ b/openspec/specs/objects-crud/spec.md
@@ -5,15 +5,52 @@ TBD - created by archiving change clamp-list-limit-and-optional-count. Update Pu
 ## Requirements
 ### Requirement: List page size is bounded by a hard maximum
 
-Every object list/search endpoint SHALL clamp the effective page size to a hard
-maximum. A client-supplied `_limit` above the maximum SHALL be reduced to the
-maximum; it SHALL NOT cause the server to load an arbitrarily large result set.
+Every object list/search endpoint SHALL clamp a client-supplied NUMERIC `_limit`
+to a hard maximum. A number above the maximum SHALL be reduced to the maximum;
+it SHALL NOT cause the server to load an arbitrarily large result set.
+
+The bound SHALL be escapable only by an EXPLICIT unlimited request (see "`_limit`
+supports an explicit unlimited value"). An oversized number is not such a
+request: it is a caller who has not considered the size of the result set, and
+the clamp exists for exactly that caller.
 
 #### Scenario: Oversized limit is clamped
 
 - **WHEN** a client requests a list with `_limit` far above the maximum (e.g.
   `_limit=1000000`)
 - **THEN** at most `MAX_PAGE_SIZE` rows are loaded and returned
+
+#### Scenario: An explicit unlimited is not clamped
+
+- **WHEN** a client requests a list with `_limit=false`
+- **THEN** no `LIMIT` is applied and every matching row is returned
+
+### Requirement: `_limit` supports an explicit unlimited value
+
+`_limit` SHALL accept `false`, `null`, `0`, `all`, `unlimited` and `none` (any
+case) to mean "no limit", and every read path SHALL agree on that meaning.
+
+A value that is not a usable row count — a non-numeric string, or a negative
+number — SHALL be treated as unlimited rather than as zero. It SHALL NOT
+produce an empty result set.
+
+Rationale: before this requirement the same `_limit=0` meant three different
+things depending on which path served the request (no rows on the single-schema
+path, one row on the cross-schema path, the provider default against an
+external database), and `(int)"abc"` was `0`, so a typo returned a confidently
+empty list with HTTP 200.
+
+#### Scenario: Explicit unlimited returns every row
+
+- **WHEN** a client requests a list with `_limit=false` (or `0`, or `all`)
+- **THEN** the query carries no `LIMIT` clause
+- **AND** every matching row is returned
+
+#### Scenario: An unusable limit does not empty the result set
+
+- **WHEN** a client requests a list with `_limit=abc` or `_limit=-5`
+- **THEN** the value is treated as unlimited
+- **AND** the response is NOT an empty list
 
 ### Requirement: The total-count query is optional
 

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -29,9 +29,28 @@
          a baseline entry. The distinction matters: the rule stays fully active
          for every other class, and the exception is one named class, visible in
          config, with the reason attached. -->
+    <!-- StaticAccess: a second exception, on the same terms.
+
+         `\OCA\OpenRegister\Support\QueryLimit` answers one question about one
+         argument — "how many rows does this `_limit` ask for?" — and returns a
+         positive int or null. It holds no state, has no collaborators, and
+         takes the only thing it needs as an argument, so there is nothing here
+         that could be injected either.
+
+         It is deliberately NOT a service. Its whole purpose is that three read
+         paths reach the SAME answer; a service would let one of them be
+         constructed with a different implementation, which is exactly the
+         drift it was written to end. A pure function reachable by name from all
+         three is the property being bought.
+
+         Unlike FleetAppId this one is not temporary — the `_limit` grammar is
+         permanent — so it earns its place on the merit of the first paragraph
+         alone rather than on being short-lived. -->
     <rule ref="rulesets/cleancode.xml/StaticAccess">
         <properties>
-            <property name="exceptions" value="\OCA\OpenRegister\Support\FleetAppId"/>
+            <property
+                name="exceptions"
+                value="\OCA\OpenRegister\Support\FleetAppId,\OCA\OpenRegister\Support\QueryLimit"/>
         </properties>
     </rule>
 </ruleset>

--- a/tests/Unit/Support/QueryLimitTest.php
+++ b/tests/Unit/Support/QueryLimitTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * Tests for QueryLimit — the `_limit` normaliser.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Support
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Support;
+
+use OCA\OpenRegister\Support\QueryLimit;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `_limit` normalisation.
+ *
+ * The behaviour under test is the boundary between "a number of rows" and
+ * "every row". Getting it wrong is silent in both directions: too small a
+ * value truncates a result set that the caller then presents as a total, and
+ * an accidental unlimited turns a paged read into a full table scan.
+ *
+ * @spec openspec/specs/objects-crud/spec.md#requirement-limit-supports-an-explicit-unlimited-value
+ */
+class QueryLimitTest extends TestCase {
+
+	/**
+	 * A positive integer is a row count, whatever type it arrives as.
+	 *
+	 * Query strings carry no types, so the string "50" and the int 50 are the
+	 * same request and must not diverge.
+	 *
+	 * @return void
+	 */
+	public function testPositiveValuesAreRowCounts(): void {
+		$this->assertSame(50, QueryLimit::normalise(50));
+		$this->assertSame(50, QueryLimit::normalise('50'));
+		$this->assertSame(1, QueryLimit::normalise(1));
+		$this->assertSame(1, QueryLimit::normalise('1'));
+		$this->assertSame(5000, QueryLimit::normalise(5000), 'no cap: 5000 must survive');
+	}//end testPositiveValuesAreRowCounts()
+
+	/**
+	 * The values that spell "no limit".
+	 *
+	 * `false` and `null` are the two the API documents; the words are accepted
+	 * because a query string cannot carry a boolean and `?_limit=false` is what
+	 * a caller writes when they mean it.
+	 *
+	 * @return void
+	 */
+	public function testUnlimitedSpellings(): void {
+		$this->assertNull(QueryLimit::normalise(null));
+		$this->assertNull(QueryLimit::normalise(false));
+		$this->assertNull(QueryLimit::normalise('false'));
+		$this->assertNull(QueryLimit::normalise('FALSE'), 'case must not matter');
+		$this->assertNull(QueryLimit::normalise('null'));
+		$this->assertNull(QueryLimit::normalise('all'));
+		$this->assertNull(QueryLimit::normalise('unlimited'));
+		$this->assertNull(QueryLimit::normalise('none'));
+		$this->assertNull(QueryLimit::normalise(''));
+		$this->assertNull(QueryLimit::normalise('  '), 'whitespace is not a row count');
+	}//end testUnlimitedSpellings()
+
+	/**
+	 * Zero and negatives mean unlimited, and this is a DELIBERATE change.
+	 *
+	 * Before normalisation the same `_limit=0` produced three different results
+	 * depending on which read path served it: `LIMIT 0` (no rows) on the
+	 * canonical path, one row on the UNION path (`max(1, …)`), and the
+	 * provider's default of 200 on the external-database path. No caller can
+	 * have depended on a value that behaved three ways, and one caller in this
+	 * repository — `TmloController::summary()`, which passes `'_limit' => 0` —
+	 * already meant "unlimited" by it.
+	 *
+	 * @return void
+	 */
+	public function testZeroAndNegativeMeanUnlimited(): void {
+		$this->assertNull(QueryLimit::normalise(0));
+		$this->assertNull(QueryLimit::normalise('0'));
+		$this->assertNull(QueryLimit::normalise(-1));
+		$this->assertNull(QueryLimit::normalise('-1'));
+		$this->assertNull(QueryLimit::normalise(-999));
+	}//end testZeroAndNegativeMeanUnlimited()
+
+	/**
+	 * Junk is unlimited, not zero.
+	 *
+	 * This is the arm that matters most for the failure this class exists to
+	 * stop. `(int)'abc'` is 0, and 0 used to mean "LIMIT 0" — so a typo in a
+	 * query string produced a confidently empty list with HTTP 200. Reading
+	 * junk as "no limit given" degrades to the documented default behaviour
+	 * instead of inventing an empty result.
+	 *
+	 * @return void
+	 */
+	public function testNonNumericStringsDoNotBecomeZero(): void {
+		$this->assertNull(QueryLimit::normalise('abc'));
+		$this->assertNull(QueryLimit::normalise('twenty'));
+		$this->assertNull(QueryLimit::normalise('1x'), 'partially numeric is still not a number');
+	}//end testNonNumericStringsDoNotBecomeZero()
+
+	/**
+	 * A float truncates toward zero rather than erroring.
+	 *
+	 * @return void
+	 */
+	public function testFloatsTruncate(): void {
+		$this->assertSame(20, QueryLimit::normalise(20.9));
+		$this->assertSame(20, QueryLimit::normalise('20.9'));
+		$this->assertNull(QueryLimit::normalise(0.4), '0.4 truncates to 0, which is unlimited');
+	}//end testFloatsTruncate()
+
+	/**
+	 * `true` is not a row count.
+	 *
+	 * `?_limit=true` is a caller saying "limit it" without saying to what. The
+	 * old `(int)` cast turned that into 1 — a single row, silently.
+	 *
+	 * @return void
+	 */
+	public function testBooleanTrueIsNotOneRow(): void {
+		$this->assertNull(QueryLimit::normalise(true));
+	}//end testBooleanTrueIsNotOneRow()
+
+	/**
+	 * `isUnlimited()` agrees with `normalise()` on every input.
+	 *
+	 * The two must not drift: a call site branching on `isUnlimited()` and one
+	 * reading `normalise()` have to reach the same conclusion, or the SQL and
+	 * the pagination metadata will describe different queries.
+	 *
+	 * @return void
+	 */
+	public function testIsUnlimitedAgreesWithNormalise(): void {
+		$inputs = [null, false, true, 0, '0', -1, 1, 20, '20', 'false', 'abc', '', 5000];
+		foreach ($inputs as $input) {
+			$this->assertSame(
+				QueryLimit::normalise($input) === null,
+				QueryLimit::isUnlimited($input),
+				'disagreement on ' . var_export($input, true)
+			);
+		}
+	}//end testIsUnlimitedAgreesWithNormalise()
+}//end class


### PR DESCRIPTION
feat(api): `_limit` accepts an explicit unlimited value, and the three read paths finally agree

`_limit` is normalised in one place — `Support\QueryLimit` — to either a
positive row count or `null` meaning no limit at all.

## The three paths disagreed, and two of them lied

The same `_limit` answered differently depending on which read path served the
request:

| `_limit` | single-schema | cross-schema UNION | external database |
|---|---|---|---|
| absent   | unlimited | 100 | 200 |
| `0`      | **0 rows** (`LIMIT 0`) | **1 row** (`max(1, …)`) | 200 |
| `5000`   | 5000 | **1000**, silently | **1000**, silently |
| `abc`    | **0 rows** | 1 row | 200 |

Every cell in bold is a caller who asked for something and received something
else with HTTP 200 and no indication. The `abc` row is the sharp one:
`(int)"abc"` is `0` in PHP, so a typo in a query string produced a confidently
empty list.

`TmloController::summary()` passes `'_limit' => 0` meaning "no limit" — the
intent this change now honours.

## What it does now

- `false`, `null`, `0`, `all`, `unlimited`, `none` (any case), the empty string,
  a negative number, or a non-numeric string → **no limit**, on every path.
- A positive number → that many rows.
- An oversized number → still clamped. See below.

Prefer `_limit=false`; `0` is accepted because callers already wrote it meaning
exactly this.

## What this deliberately does NOT do

It does not remove the hard page-size cap. `openspec/specs/objects-crud`
requires it ("List page size is bounded by a hard maximum"), added by the
archived `clamp-list-limit-and-optional-count` change specifically so a client
"SHALL NOT cause the server to load an arbitrarily large result set". Reversing
that silently would be trading one invisible behaviour for another.

So the bound is now escapable only by asking: `_limit=1000000` is still clamped
(a caller who has not thought about the result-set size), while `_limit=false`
is honoured (a caller who has). The spec is amended to say so, with a scenario
for each, plus a new requirement for the unlimited value itself.

The UNION path's magic `1000` became a named `MAX_PAGE_SIZE` constant — it was
a literal inside `min()`, invisible to anything wanting to state or test it.
Unlimited there OMITS the clause rather than interpolating a sentinel, because
that SQL is built by string concatenation with nothing to bind to.

## A pre-existing divergence this surfaced, not fixed

The requirement says EVERY list endpoint clamps. The canonical single-schema
path — the one the fleet's apps actually use — never did: it passed the raw
value to `setMaxResults()`. So the protection the spec promises has never
existed where it matters most. Left alone here: adding a clamp would REDUCE
what existing callers receive, which is a behaviour change in the dangerous
direction and deserves its own decision. Filed separately.

## Verification

- 7 new tests / 40 assertions. Mutation-checked: reverting `normalise()` to the
  old `max(1, min(1000, (int)$x))` fails 6 of the 7.
- phpcs clean, phpstan `[OK] No errors`, psalm 0 errors.
- Full suite: 17,418 tests / 39,144 assertions, no failures and no errors.
- Also fixed 2 pre-existing phpcs errors in `Notification/Notifier.php` (an
  inline `if`, and an internal call without named arguments) — `development` is
  currently red on phpcs because of them.
- `docs/api/objects.md` documents the values, the cost of an unlimited read,
  and the changed `_limit=0` behaviour.
