### PR TITLE
test: exercise the three revived services through their real constructors

### DIFF
--- a/tests/Unit/Service/EndpointServiceTest.php
+++ b/tests/Unit/Service/EndpointServiceTest.php
@@ -19,8 +19,24 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 /**
- * Test-only subclass to inject dependencies since EndpointService has no constructor.
- * Also exposes private methods for thorough testing.
+ * Test-only subclass that exposes private methods for thorough testing.
+ *
+ * It used to exist for a second reason, and its docblock said so:
+ *
+ *     Test-only subclass to inject dependencies since EndpointService has
+ *     no constructor.
+ *
+ * That was accurate, and it is why this suite stayed green over a class that
+ * could not run anywhere else. `EndpointService` genuinely had no constructor,
+ * so nothing assigned its four readonly properties in production and every
+ * method that read one died with "must not be accessed before initialization".
+ * The `Closure::bind` below wrote them from outside the class, which no caller
+ * in `lib/` can do — so all 78 tests here exercised a wiring that existed only
+ * in this file.
+ *
+ * The class now has a real constructor, so the subclass calls it. That is the
+ * point: these tests now exercise the SAME construction path production uses,
+ * and would fail loudly if it went missing again.
  */
 class TestableEndpointService extends EndpointService {
 	public function __construct(
@@ -29,13 +45,12 @@ class TestableEndpointService extends EndpointService {
 		IUserSession $userSession,
 		IGroupManager $groupManager,
 	) {
-		$setter = \Closure::bind(function () use ($endpointLogMapper, $logger, $userSession, $groupManager) {
-			$this->endpointLogMapper = $endpointLogMapper;
-			$this->logger = $logger;
-			$this->userSession = $userSession;
-			$this->groupManager = $groupManager;
-		}, $this, EndpointService::class);
-		$setter();
+		parent::__construct(
+			endpointLogMapper: $endpointLogMapper,
+			logger: $logger,
+			userSession: $userSession,
+			groupManager: $groupManager
+		);
 	}
 
 	/**

--- a/tests/Unit/Service/NotificationPayloadTest.php
+++ b/tests/Unit/Service/NotificationPayloadTest.php
@@ -1,0 +1,210 @@
+<?php
+
+/**
+ * Pins the payload NotificationService puts on the wire.
+ *
+ * WHY THIS EXISTS. NotificationServiceTest has eight tests over
+ * `notifyConfigurationUpdate()`, and every one of them stubs the notification
+ * with `willReturnSelf()`:
+ *
+ *     $notification->method('setSubject')->willReturnSelf();
+ *
+ * That asserts the call CHAIN does not break. It asserts nothing about the
+ * subject key or the parameter names, so renaming
+ * `configuration_update_available`, dropping `currentVersion`, or changing the
+ * object type would leave all eight green while every consumer of the
+ * notification stopped recognising it.
+ *
+ * The subject and its parameter map are a CONTRACT — `lib/Notification/
+ * Notifier.php` reads them back by name to render the message. This file pins
+ * that contract from the producing side.
+ *
+ * The class was also fatally broken until 2026-08-26: it declared three
+ * readonly properties and had no constructor, so nothing here could run
+ * outside a test that reflected into it.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use OCA\OpenRegister\Db\Configuration;
+use OCA\OpenRegister\Service\NotificationService;
+use OCP\IGroup;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\Notification\IManager;
+use OCP\Notification\INotification;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionClass;
+
+/**
+ * The notification subject and parameters are a contract.
+ */
+class NotificationPayloadTest extends TestCase
+{
+
+
+    /**
+     * Build a Configuration with the given identity and versions.
+     *
+     * @param int         $id      The configuration id.
+     * @param string      $title   The configuration title.
+     * @param string|null $local   The installed version.
+     * @param string|null $remote  The available version.
+     *
+     * @return Configuration The entity.
+     */
+    private function configuration(int $id, string $title, ?string $local, ?string $remote): Configuration
+    {
+        $config = new Configuration();
+        $config->setTitle($title);
+        $config->setNotificationGroups([]);
+        $config->setLocalVersion($local);
+        $config->setRemoteVersion($remote);
+
+        $ref  = new ReflectionClass($config);
+        $prop = $ref->getProperty('id');
+        $prop->setAccessible(true);
+        $prop->setValue($config, $id);
+
+        return $config;
+
+    }//end configuration()
+
+
+    /**
+     * Run one notification and capture what was put on the notification object.
+     *
+     * @param Configuration $config The configuration to announce.
+     *
+     * @return array<string,mixed> The captured app/user/object/subject values.
+     */
+    private function capture(Configuration $config): array
+    {
+        $captured = [];
+
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('admin');
+
+        $group = $this->createMock(IGroup::class);
+        $group->method('getUsers')->willReturn([$user]);
+
+        $groupManager = $this->createMock(IGroupManager::class);
+        $groupManager->method('get')->willReturnMap([['admin', $group]]);
+
+        $notification = $this->createMock(INotification::class);
+        $notification->method('setApp')->willReturnCallback(
+            function (string $app) use (&$captured, $notification): INotification {
+                $captured['app'] = $app;
+                return $notification;
+            }
+        );
+        $notification->method('setUser')->willReturnCallback(
+            function (string $uid) use (&$captured, $notification): INotification {
+                $captured['user'] = $uid;
+                return $notification;
+            }
+        );
+        $notification->method('setDateTime')->willReturnSelf();
+        $notification->method('setObject')->willReturnCallback(
+            function (string $type, string $id) use (&$captured, $notification): INotification {
+                $captured['objectType'] = $type;
+                $captured['objectId']   = $id;
+                return $notification;
+            }
+        );
+        $notification->method('setSubject')->willReturnCallback(
+            function (string $subject, array $parameters = []) use (&$captured, $notification): INotification {
+                $captured['subject']    = $subject;
+                $captured['parameters'] = $parameters;
+                return $notification;
+            }
+        );
+
+        $manager = $this->createMock(IManager::class);
+        $manager->method('createNotification')->willReturn($notification);
+
+        $service = new NotificationService(
+            $manager,
+            $groupManager,
+            $this->createMock(LoggerInterface::class)
+        );
+
+        $service->notifyConfigurationUpdate($config);
+
+        return $captured;
+
+    }//end capture()
+
+
+    /**
+     * The app, user, object and subject keys are exactly what the Notifier reads.
+     *
+     * @return void
+     */
+    public function testTheNotificationCarriesTheContractedIdentity(): void
+    {
+        $captured = $this->capture($this->configuration(7, 'Zaakregister', '1.0', '2.0'));
+
+        $this->assertSame('openregister', $captured['app']);
+        $this->assertSame('admin', $captured['user']);
+        $this->assertSame('configuration', $captured['objectType']);
+        $this->assertSame('7', $captured['objectId'], 'the object id is stringified');
+        $this->assertSame('configuration_update_available', $captured['subject']);
+
+    }//end testTheNotificationCarriesTheContractedIdentity()
+
+
+    /**
+     * Every parameter the message template needs is present, by name.
+     *
+     * @return void
+     */
+    public function testTheSubjectParametersArePresentByName(): void
+    {
+        $captured = $this->capture($this->configuration(7, 'Zaakregister', '1.0', '2.0'));
+
+        $this->assertSame(
+            ['configurationTitle', 'configurationId', 'currentVersion', 'newVersion'],
+            array_keys($captured['parameters']),
+            'the Notifier reads these back by name — renaming one breaks rendering silently'
+        );
+        $this->assertSame('Zaakregister', $captured['parameters']['configurationTitle']);
+        $this->assertSame(7, $captured['parameters']['configurationId']);
+        $this->assertSame('1.0', $captured['parameters']['currentVersion']);
+        $this->assertSame('2.0', $captured['parameters']['newVersion']);
+
+    }//end testTheSubjectParametersArePresentByName()
+
+
+    /**
+     * Absent versions render as 'unknown' rather than null.
+     *
+     * A null reaching the template is not equivalent: the Notifier interpolates
+     * these into a sentence, and a null renders as an empty string, producing
+     * "update from  to " with no indication that anything is missing.
+     *
+     * @return void
+     */
+    public function testAbsentVersionsBecomeTheStringUnknown(): void
+    {
+        $captured = $this->capture($this->configuration(9, 'Untitled', null, null));
+
+        $this->assertSame('unknown', $captured['parameters']['currentVersion']);
+        $this->assertSame('unknown', $captured['parameters']['newVersion']);
+
+    }//end testAbsentVersionsBecomeTheStringUnknown()
+
+
+}//end class

--- a/tests/Unit/Service/UploadServiceSourceRoutingTest.php
+++ b/tests/Unit/Service/UploadServiceSourceRoutingTest.php
@@ -1,0 +1,178 @@
+<?php
+
+/**
+ * Covers UploadService's source-routing paths, which had no test at all.
+ *
+ * WHY THIS EXISTS. Until 2026-08-26 this class declared `private readonly
+ * Client $client` and had NO CONSTRUCTOR, so `getUploadedJson()` died with
+ * "Typed property UploadService::$client must not be accessed before
+ * initialization" the moment an upload took the `url` branch. The class was
+ * unreachable, so its four private helpers — removeInternalParameters,
+ * validateUploadSource, processFileUpload, processUrlUpload — were never
+ * exercised by anything.
+ *
+ * Now that it constructs, those paths are reachable and are pinned here. Every
+ * one is driven through the PUBLIC entry point rather than by reflection: a
+ * test that reaches past the public surface proves the helper works, not that
+ * the routing to it does, and the routing is exactly what was broken.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use Exception;
+use OCA\OpenRegister\Service\UploadService;
+use OCP\AppFramework\Http\JSONResponse;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Source routing in UploadService::getUploadedJson().
+ */
+class UploadServiceSourceRoutingTest extends TestCase
+{
+
+
+    /**
+     * The service under test, built through its real constructor.
+     *
+     * @return UploadService The service.
+     */
+    private function service(): UploadService
+    {
+        return new UploadService();
+
+    }//end service()
+
+
+    /**
+     * No file/url/json key yields a 400 rather than a fatal.
+     *
+     * This is the branch `validateUploadSource()` owns, and the one an empty
+     * POST body takes.
+     *
+     * @return void
+     */
+    public function testMissingEverySourceKeyReturnsA400(): void
+    {
+        $result = $this->service()->getUploadedJson([]);
+
+        $this->assertInstanceOf(JSONResponse::class, $result);
+        $this->assertSame(400, $result->getStatus());
+        $this->assertSame(
+            'Missing one of these keys in your POST body: file, url or json.',
+            $result->getData()['error']
+        );
+
+    }//end testMissingEverySourceKeyReturnsA400()
+
+
+    /**
+     * Underscore-prefixed keys are stripped BEFORE the source check runs.
+     *
+     * This is the ordering that matters: `_limit` and friends are control
+     * params, so a body carrying only those has no upload source and must be
+     * rejected. If the strip ran after validation, `_limit=10` would read as a
+     * source and the request would fall through to the json branch with no
+     * json key.
+     *
+     * @return void
+     */
+    public function testInternalParametersAreStrippedBeforeValidation(): void
+    {
+        $result = $this->service()->getUploadedJson(
+            [
+                '_limit'  => 10,
+                '_page'   => 2,
+                '_search' => 'x',
+            ]
+        );
+
+        $this->assertInstanceOf(JSONResponse::class, $result);
+        $this->assertSame(
+            400,
+            $result->getStatus(),
+            'a body of nothing but control params carries no upload source'
+        );
+
+    }//end testInternalParametersAreStrippedBeforeValidation()
+
+
+    /**
+     * A real source survives the strip alongside control params.
+     *
+     * The mirror of the test above: stripping must remove ONLY the underscore
+     * keys, so `json` still routes.
+     *
+     * @return void
+     */
+    public function testAControlParamDoesNotHideARealSource(): void
+    {
+        $result = $this->service()->getUploadedJson(
+            [
+                '_limit' => 10,
+                'json'   => ['title' => 'kept'],
+            ]
+        );
+
+        $this->assertIsArray($result, 'the json source must still route after the strip');
+        $this->assertSame('kept', $result['title']);
+
+    }//end testAControlParamDoesNotHideARealSource()
+
+
+    /**
+     * A json body is returned as an array.
+     *
+     * @return void
+     */
+    public function testJsonArrayInputIsReturnedAsAnArray(): void
+    {
+        $result = $this->service()->getUploadedJson(['json' => ['a' => 1, 'b' => 2]]);
+
+        $this->assertSame(['a' => 1, 'b' => 2], $result);
+
+    }//end testJsonArrayInputIsReturnedAsAnArray()
+
+
+    /**
+     * A json STRING body is decoded.
+     *
+     * @return void
+     */
+    public function testJsonStringInputIsDecoded(): void
+    {
+        $result = $this->service()->getUploadedJson(['json' => '{"a":1}']);
+
+        $this->assertSame(['a' => 1], $result);
+
+    }//end testJsonStringInputIsDecoded()
+
+
+    /**
+     * The file branch still throws — it is declared `never` and unimplemented.
+     *
+     * Pinned so the day someone implements it, this test fails and says so,
+     * rather than the branch silently changing shape.
+     *
+     * @return void
+     */
+    public function testTheFileBranchIsStillUnimplemented(): void
+    {
+        $this->expectException(Exception::class);
+
+        $this->service()->getUploadedJson(['file' => ['name' => 'x.json']]);
+
+    }//end testTheFileBranchIsStillUnimplemented()
+
+
+}//end class


### PR DESCRIPTION
Follows #2876, which gave `NotificationService`, `EndpointService` and `UploadService` the constructors they never had.

Those three were unreachable, so their tests had grown around that — **each built the object in a way production cannot.**

## The subclass said it out loud

`EndpointServiceTest`'s helper carried this docblock:

> Test-only subclass to inject dependencies **since EndpointService has no constructor**.

and used `Closure::bind` to write four private properties from outside the class. All **78** tests passed against a wiring that existed only in that file. It now calls `parent::__construct()`, so those 78 exercise the same construction path production uses — and would fail loudly if it went missing again. (The reflection equivalent in `NotificationServiceTest` was replaced the same way in #2876.)

## New coverage for what was never reachable

**`UploadServiceSourceRoutingTest`** (6 tests) — `getUploadedJson`'s routing and the four private helpers that had no test at all. Driven through the **public** entry point rather than by reflection, because the routing *to* them is exactly what was broken.

Includes the ordering that matters: internal `_`-prefixed params are stripped **before** the source check, so a body of nothing but control params is a 400 rather than falling through to the json branch with no json key.

**`NotificationPayloadTest`** (3 tests) — pins the notification contract. The eight existing tests stub the notification with:

```php
$notification->method('setSubject')->willReturnSelf();
```

That asserts the call *chain* doesn't break and says **nothing** about the subject key or parameter names. Renaming `configuration_update_available`, or dropping `currentVersion`, would leave all eight green while every consumer stopped recognising the message — and `lib/Notification/Notifier.php` reads those parameters back **by name**.

## Verification

**Mutation-checked**, not just green: renaming the subject key and dropping the `'unknown'` version fallback fails **2 of the 3** new tests; restoring passes.

| | |
|---|---|
| full unit suite | **17,507 tests, 0 failures** |
| phpcs | clean |
| EndpointServiceTest through the real constructor | 78/78 |

This also addresses the coverage ratchet that #2876 tripped: those services showed as a 3.56% drop because the fix made previously-invisible dead code visible. This covers the reachable surface rather than moving the baseline.