### PR TITLE
test(aggregation): remove the coverage metadata that was discarding coverage

### DIFF
--- a/tests/Unit/Service/Aggregation/AggregationRegisterScopeTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRegisterScopeTest.php
@@ -60,8 +60,11 @@ use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 /**
- * @covers \OCA\OpenRegister\Service\Aggregation\AggregationRunner
- * @covers \OCA\OpenRegister\Service\RegisterScopedSchemaResolver
+ * No `@covers` metadata, deliberately — `beStrictAboutCoverageMetadata="true"`
+ * discards the coverage of any test that touches a collaborator it did not
+ * name. Naming two classes here did not help: the tests also run
+ * AggregationQuery and the Db entities. See
+ * {@see AggregationJoinAndCompositeGroupByTest} and #2847.
  */
 class AggregationRegisterScopeTest extends TestCase {
 

--- a/tests/Unit/Service/Aggregation/AggregationRegisterScopeTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRegisterScopeTest.php
@@ -60,7 +60,7 @@ use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 /**
- * No `@covers` metadata, deliberately — `beStrictAboutCoverageMetadata="true"`
+ * No `covers` metadata, deliberately — `beStrictAboutCoverageMetadata="true"`
  * discards the coverage of any test that touches a collaborator it did not
  * name. Naming two classes here did not help: the tests also run
  * AggregationQuery and the Db entities. See

--- a/tests/Unit/Service/Aggregation/AggregationRunnerAdhocCacheTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRunnerAdhocCacheTest.php
@@ -43,7 +43,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
- * No `@covers` metadata, deliberately — `beStrictAboutCoverageMetadata="true"`
+ * No `covers` metadata, deliberately — `beStrictAboutCoverageMetadata="true"`
  * discards the coverage of any test that touches a collaborator it did not
  * name. See {@see AggregationJoinAndCompositeGroupByTest} and #2847.
  */

--- a/tests/Unit/Service/Aggregation/AggregationRunnerAdhocCacheTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRunnerAdhocCacheTest.php
@@ -43,7 +43,9 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \OCA\OpenRegister\Service\Aggregation\AggregationRunner
+ * No `@covers` metadata, deliberately — `beStrictAboutCoverageMetadata="true"`
+ * discards the coverage of any test that touches a collaborator it did not
+ * name. See {@see AggregationJoinAndCompositeGroupByTest} and #2847.
  */
 class AggregationRunnerAdhocCacheTest extends TestCase {
 

--- a/tests/Unit/Service/Aggregation/AggregationRunnerCumulativeTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRunnerCumulativeTest.php
@@ -64,8 +64,10 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \OCA\OpenRegister\Service\Aggregation\AggregationRunner
- * @covers \OCA\OpenRegister\Service\Aggregation\AggregationQuery
+ * No `@covers` metadata, deliberately — `beStrictAboutCoverageMetadata="true"`
+ * discards the coverage of any test that touches a collaborator it did not
+ * name, and naming two was still not enough. See
+ * {@see AggregationJoinAndCompositeGroupByTest} and #2847.
  */
 class AggregationRunnerCumulativeTest extends TestCase {
 

--- a/tests/Unit/Service/Aggregation/AggregationRunnerCumulativeTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRunnerCumulativeTest.php
@@ -64,7 +64,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
- * No `@covers` metadata, deliberately — `beStrictAboutCoverageMetadata="true"`
+ * No `covers` metadata, deliberately — `beStrictAboutCoverageMetadata="true"`
  * discards the coverage of any test that touches a collaborator it did not
  * name, and naming two was still not enough. See
  * {@see AggregationJoinAndCompositeGroupByTest} and #2847.

--- a/tests/Unit/Service/Aggregation/AggregationRunnerMultiFieldGroupByTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRunnerMultiFieldGroupByTest.php
@@ -54,7 +54,7 @@ use PDO;
 use PHPUnit\Framework\TestCase;
 
 /**
- * No `@covers` metadata, deliberately — `beStrictAboutCoverageMetadata="true"`
+ * No `covers` metadata, deliberately — `beStrictAboutCoverageMetadata="true"`
  * discards the coverage of any test that touches a collaborator it did not
  * name, and naming two was still not enough. See
  * {@see AggregationJoinAndCompositeGroupByTest} and #2847.

--- a/tests/Unit/Service/Aggregation/AggregationRunnerMultiFieldGroupByTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRunnerMultiFieldGroupByTest.php
@@ -54,8 +54,10 @@ use PDO;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \OCA\OpenRegister\Service\Aggregation\AggregationRunner
- * @covers \OCA\OpenRegister\Service\Aggregation\AggregationQuery
+ * No `@covers` metadata, deliberately — `beStrictAboutCoverageMetadata="true"`
+ * discards the coverage of any test that touches a collaborator it did not
+ * name, and naming two was still not enough. See
+ * {@see AggregationJoinAndCompositeGroupByTest} and #2847.
  */
 class AggregationRunnerMultiFieldGroupByTest extends TestCase {
 

--- a/tests/Unit/Service/Aggregation/AggregationRunnerMultiMetricTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRunnerMultiMetricTest.php
@@ -51,8 +51,10 @@ use PDO;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \OCA\OpenRegister\Service\Aggregation\AggregationRunner
- * @covers \OCA\OpenRegister\Service\Aggregation\AggregationQuery
+ * No `@covers` metadata, deliberately — `beStrictAboutCoverageMetadata="true"`
+ * discards the coverage of any test that touches a collaborator it did not
+ * name, and naming two was still not enough. See
+ * {@see AggregationJoinAndCompositeGroupByTest} and #2847.
  */
 class AggregationRunnerMultiMetricTest extends TestCase {
 

--- a/tests/Unit/Service/Aggregation/AggregationRunnerMultiMetricTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRunnerMultiMetricTest.php
@@ -51,7 +51,7 @@ use PDO;
 use PHPUnit\Framework\TestCase;
 
 /**
- * No `@covers` metadata, deliberately — `beStrictAboutCoverageMetadata="true"`
+ * No `covers` metadata, deliberately — `beStrictAboutCoverageMetadata="true"`
  * discards the coverage of any test that touches a collaborator it did not
  * name, and naming two was still not enough. See
  * {@see AggregationJoinAndCompositeGroupByTest} and #2847.

--- a/tests/Unit/Service/Aggregation/AggregationRunnerMultiValueFilterTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRunnerMultiValueFilterTest.php
@@ -65,7 +65,7 @@ use PDO;
 use PHPUnit\Framework\TestCase;
 
 /**
- * No `@covers` metadata, deliberately — `beStrictAboutCoverageMetadata="true"`
+ * No `covers` metadata, deliberately — `beStrictAboutCoverageMetadata="true"`
  * discards the coverage of any test that touches a collaborator it did not
  * name. See {@see AggregationJoinAndCompositeGroupByTest} and #2847.
  */

--- a/tests/Unit/Service/Aggregation/AggregationRunnerMultiValueFilterTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRunnerMultiValueFilterTest.php
@@ -65,7 +65,9 @@ use PDO;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \OCA\OpenRegister\Service\Aggregation\AggregationRunner
+ * No `@covers` metadata, deliberately — `beStrictAboutCoverageMetadata="true"`
+ * discards the coverage of any test that touches a collaborator it did not
+ * name. See {@see AggregationJoinAndCompositeGroupByTest} and #2847.
  */
 class AggregationRunnerMultiValueFilterTest extends TestCase {
 

--- a/tests/Unit/Service/Aggregation/AggregationRunnerNativeBucketTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRunnerNativeBucketTest.php
@@ -48,7 +48,9 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \OCA\OpenRegister\Service\Aggregation\AggregationRunner
+ * No `@covers` metadata, deliberately — `beStrictAboutCoverageMetadata="true"`
+ * discards the coverage of any test that touches a collaborator it did not
+ * name. See {@see AggregationJoinAndCompositeGroupByTest} and #2847.
  */
 class AggregationRunnerNativeBucketTest extends TestCase {
 

--- a/tests/Unit/Service/Aggregation/AggregationRunnerNativeBucketTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRunnerNativeBucketTest.php
@@ -48,7 +48,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
- * No `@covers` metadata, deliberately — `beStrictAboutCoverageMetadata="true"`
+ * No `covers` metadata, deliberately — `beStrictAboutCoverageMetadata="true"`
  * discards the coverage of any test that touches a collaborator it did not
  * name. See {@see AggregationJoinAndCompositeGroupByTest} and #2847.
  */

--- a/tests/Unit/Service/Aggregation/AggregationRunnerTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRunnerTest.php
@@ -48,7 +48,15 @@ use ReflectionMethod;
 use RuntimeException;
 
 /**
- * @covers \OCA\OpenRegister\Service\Aggregation\AggregationRunner
+ * No `@covers` metadata, deliberately — see
+ * {@see AggregationJoinAndCompositeGroupByTest} for the measurement.
+ *
+ * Under `beStrictAboutCoverageMetadata="true"`, naming the class under test
+ * makes PHPUnit mark every test that also touches a collaborator RISKY and
+ * DISCARD that test's coverage wholesale. Almost every test here legitimately
+ * runs one — AggregationQuery, PlaceholderResolver, the Db entities — so the
+ * annotation threw the measurement away instead of focusing it, and the
+ * subject reported 0%. #2847
  */
 class AggregationRunnerTest extends TestCase {
 

--- a/tests/Unit/Service/Aggregation/AggregationRunnerTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRunnerTest.php
@@ -48,7 +48,7 @@ use ReflectionMethod;
 use RuntimeException;
 
 /**
- * No `@covers` metadata, deliberately — see
+ * No `covers` metadata, deliberately — see
  * {@see AggregationJoinAndCompositeGroupByTest} for the measurement.
  *
  * Under `beStrictAboutCoverageMetadata="true"`, naming the class under test

--- a/tests/Unit/Service/Aggregation/CrossSchemaAggregationRunnerTest.php
+++ b/tests/Unit/Service/Aggregation/CrossSchemaAggregationRunnerTest.php
@@ -56,7 +56,7 @@ use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 /**
- * No `@covers` metadata, deliberately — `beStrictAboutCoverageMetadata="true"`
+ * No `covers` metadata, deliberately — `beStrictAboutCoverageMetadata="true"`
  * discards the coverage of any test that touches a collaborator it did not
  * name. See {@see AggregationJoinAndCompositeGroupByTest} and #2847.
  */

--- a/tests/Unit/Service/Aggregation/CrossSchemaAggregationRunnerTest.php
+++ b/tests/Unit/Service/Aggregation/CrossSchemaAggregationRunnerTest.php
@@ -56,7 +56,9 @@ use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 /**
- * @covers \OCA\OpenRegister\Service\Aggregation\AggregationRunner
+ * No `@covers` metadata, deliberately — `beStrictAboutCoverageMetadata="true"`
+ * discards the coverage of any test that touches a collaborator it did not
+ * name. See {@see AggregationJoinAndCompositeGroupByTest} and #2847.
  */
 class CrossSchemaAggregationRunnerTest extends TestCase {
 

--- a/tests/Unit/Service/Aggregation/TimeseriesRequestValidatorTest.php
+++ b/tests/Unit/Service/Aggregation/TimeseriesRequestValidatorTest.php
@@ -31,11 +31,17 @@ use OCA\OpenRegister\Service\Aggregation\TimeseriesRequestValidator;
 use PHPUnit\Framework\TestCase;
 
 /**
- * No coverage metadata, deliberately. `@coversDefaultClass` was here without a
- * single `@covers ::method` to pair with it, so it named a default nothing
+ * No coverage metadata, deliberately. `coversDefaultClass` was here without a
+ * single per-method `covers` to pair with it, so it named a default nothing
  * used — and under `beStrictAboutCoverageMetadata="true"` it still restricted
  * recording, discarding this file's coverage. See
  * {@see AggregationJoinAndCompositeGroupByTest} and #2847.
+ *
+ * THE ANNOTATION NAMES HERE CARRY NO LEADING AT-SIGN, ON PURPOSE. PHPUnit
+ * parses this class docblock, so spelling one out re-declares the very metadata
+ * the file exists to remove. Written literally, the method-scoped form was read
+ * as a real annotation and CI failed all six PHPUnit cells with "is invalid" —
+ * a comment about the bug becoming the bug.
  */
 class TimeseriesRequestValidatorTest extends TestCase {
 

--- a/tests/Unit/Service/Aggregation/TimeseriesRequestValidatorTest.php
+++ b/tests/Unit/Service/Aggregation/TimeseriesRequestValidatorTest.php
@@ -31,7 +31,11 @@ use OCA\OpenRegister\Service\Aggregation\TimeseriesRequestValidator;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @coversDefaultClass \OCA\OpenRegister\Service\Aggregation\TimeseriesRequestValidator
+ * No coverage metadata, deliberately. `@coversDefaultClass` was here without a
+ * single `@covers ::method` to pair with it, so it named a default nothing
+ * used — and under `beStrictAboutCoverageMetadata="true"` it still restricted
+ * recording, discarding this file's coverage. See
+ * {@see AggregationJoinAndCompositeGroupByTest} and #2847.
  */
 class TimeseriesRequestValidatorTest extends TestCase {
 


### PR DESCRIPTION
Closes #2847.

## `@covers` was not focusing the measurement, it was deleting it

Under `beStrictAboutCoverageMetadata="true"`, PHPUnit does not merely restrict
recording to the units a test names — it marks any test that executes anything
else **risky** and throws that test's coverage away entirely. The message says
so once you look for it:

```
This test executed code that is not listed as code to be covered or used:
- OCA\OpenRegister\Db\Register
- OCA\OpenRegister\Db\Schema
- OCA\OpenRegister\Service\Aggregation\AggregationQuery
```

Almost every test in this directory legitimately runs a collaborator —
`AggregationQuery`, `PlaceholderResolver`, the Db entities — so naming the class
under test discarded the whole file's measurement.

## Measured

Locally with pcov, **identical scope both runs** (237 tests, 461 assertions):

| | with `@covers` | without |
|---|---|---|
| `AggregationRunner` lines | 44.39% (613/1381) | **80.30% (1109/1381)** |
| `AggregationRunner` methods | 9.80% (5/51) | **33.33% (17/51)** |
| statements recorded in scope | 1618 | **2137** |
| **Risky tests** | **33** | **0** |

Same tests, same assertions, same executed lines. Only the attribution differs.

> ⚠️ **These are pcov numbers.** `coverage-guard.php`'s own docblock records that
> CI measures with xdebug and the two do not count statements identically. Treat
> the *direction* as the result and let CI's `--against` measurement be the
> authority.

`.coverage-baseline` is deliberately **untouched** — the guard treats a
measurement above the floor as good news and exits 0, and this only moves it up.

## Also

`TimeseriesRequestValidatorTest` carried `@coversDefaultClass` with **not one**
`@covers ::method` to pair with it: naming a default nothing used, while still
restricting recording.

The reasoning already existed — measured — in
`AggregationJoinAndCompositeGroupByTest`'s docblock. The other ten files simply
never had it applied. Each now carries a short note pointing there, so the
annotation is not helpfully restored later by someone tidying up.

## Verified

- full suite **17336 tests, 0 failures** (the 3 risky remaining are pre-existing
  `TextExtractionServiceTest` no-assertion tests, untouched here)
- `phpcs.xml` scans `lib` only, so these files are not in its scope
- tests-only change; no `lib/` code touched
