### PR TITLE
fix(flow): enforce the assignee that AwaitSignalNode already recorded

### DIFF
--- a/lib/Controller/FlowRunController.php
+++ b/lib/Controller/FlowRunController.php
@@ -32,6 +32,7 @@ use OCA\OpenRegister\Db\FlowRun;
 use OCA\OpenRegister\Db\FlowRunMapper;
 use OCA\OpenRegister\Service\Flow\FlowItems;
 use OCA\OpenRegister\Service\Flow\FlowLocator;
+use OCA\OpenRegister\Service\Flow\FlowResumeState;
 use OCA\OpenRegister\Service\Flow\FlowRunService;
 use OCA\OpenRegister\Service\Flow\FlowService;
 use OCA\OpenRegister\Service\OrganisationService;
@@ -434,6 +435,11 @@ class FlowRunController extends Controller {
 			return $refusal;
 		}
 
+		$refusal = $this->refuseUnlessAssignee(run: $run);
+		if ($refusal !== null) {
+			return $refusal;
+		}
+
 		$payload = $this->request->getParams();
 		// Routing artefacts, not part of what the signaller is telling the run.
 		unset($payload['uuid'], $payload['_route']);
@@ -488,6 +494,92 @@ class FlowRunController extends Controller {
 
 		return null;
 	}//end refuseUnlessRunnable()
+
+	/**
+	 * Refuse when the awaiting step names an assignee and the caller is not it.
+	 *
+	 * WHY THIS EXISTS. `AwaitSignalNode` has always RECORDED an `assignee` on
+	 * the suspension, and nothing ever read it back. The run-level check above
+	 * asks "may you run this flow?", which is a different question from "is
+	 * this decision yours to make": everyone who could run the flow could
+	 * approve a step assigned to someone else, and the recorded assignee made
+	 * it look otherwise. ADR-098 names this gap — "no task authz — anyone
+	 * reaching the resume endpoint can decide".
+	 *
+	 * Scope, stated honestly: this closes the WHO of an already-recorded
+	 * assignment. It is not the task entity, inbox or definition versioning
+	 * ADR-098 describes, and a step with no assignee is unchanged — silence
+	 * still means anyone, because tightening that would break every existing
+	 * webhook and child-run signal, which are not human decisions at all.
+	 *
+	 * @param FlowRun $run The suspended run.
+	 *
+	 * @return JSONResponse|null A 403 when the caller is not the assignee.
+	 */
+	private function refuseUnlessAssignee(FlowRun $run): ?JSONResponse {
+		$assignee = $this->recordedAssignee(run: $run);
+		if ($assignee === '') {
+			return null;
+		}
+
+		$uid = $this->callerUid();
+		if ($uid === null) {
+			// Fail CLOSED: an assigned decision is never anonymous.
+			return new JSONResponse(
+				['error' => 'This step is assigned; sign in as the assignee to answer it.'],
+				Http::STATUS_FORBIDDEN
+			);
+		}
+
+		if ($uid === $assignee) {
+			return null;
+		}
+
+		if ($this->groupManager !== null && $this->groupManager->isInGroup($uid, $assignee) === true) {
+			return null;
+		}
+
+		return new JSONResponse(
+			['error' => 'This step is assigned to someone else.'],
+			Http::STATUS_FORBIDDEN
+		);
+	}//end refuseUnlessAssignee()
+
+	/**
+	 * The assignee recorded by whichever step is currently awaiting a signal.
+	 *
+	 * Reads the per-node resume slots the node wrote. A run can carry slots for
+	 * several nodes across its life, so the one that matters is a slot that
+	 * asked (`askedAt`) and has not been answered.
+	 *
+	 * @param FlowRun $run The suspended run.
+	 *
+	 * @return string The assignee uid or group id, '' when unassigned.
+	 */
+	private function recordedAssignee(FlowRun $run): string {
+		$context = ($run->getContext() ?? []);
+		$slots = ($context[FlowResumeState::CONTEXT_KEY] ?? []);
+		if (is_array($slots) === false) {
+			return '';
+		}
+
+		foreach ($slots as $slot) {
+			if (is_array($slot) === false) {
+				continue;
+			}
+
+			if (isset($slot['askedAt']) === false) {
+				continue;
+			}
+
+			$assignee = trim((string)($slot['assignee'] ?? ''));
+			if ($assignee !== '') {
+				return $assignee;
+			}
+		}
+
+		return '';
+	}//end recordedAssignee()
 
 	/**
 	 * The current caller's uid, or null when anonymous.

--- a/tests/Unit/Controller/FlowRunControllerTest.php
+++ b/tests/Unit/Controller/FlowRunControllerTest.php
@@ -20,6 +20,7 @@ use OCA\OpenRegister\Service\Flow\FlowLocator;
 use OCA\OpenRegister\Service\Flow\FlowRunService;
 use OCA\OpenRegister\Service\OrganisationService;
 use OCP\AppFramework\Http;
+use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -534,5 +535,229 @@ class FlowRunControllerTest extends TestCase {
 
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
 	}//end testResumeStillAllowsAnyoneWhenNoAssigneeWasRecorded()
+
+	/**
+	 * Build a suspended run carrying the given resume slots.
+	 *
+	 * @param mixed $resumeState The resumeState value to store on the context.
+	 *
+	 * @return FlowRun The suspended run.
+	 */
+	private function suspendedRunWithResumeState(mixed $resumeState): FlowRun {
+		$run = new FlowRun();
+		$run->setUuid('run-1');
+		$run->setFlowId('flow-1');
+		$run->setStatus(FlowRun::STATUS_SUSPENDED);
+		$run->setContext(['resumeState' => $resumeState]);
+
+		return $run;
+	}//end suspendedRunWithResumeState()
+
+	/**
+	 * Build the controller with a specific session and group manager.
+	 *
+	 * @param IUserSession       $session      The session to use.
+	 * @param IGroupManager|null $groupManager The group manager, or null.
+	 *
+	 * @return FlowRunController The controller.
+	 */
+	private function controllerWith(
+		IUserSession $session,
+		?IGroupManager $groupManager = null,
+	): FlowRunController {
+		return new FlowRunController(
+			appName: 'openregister',
+			request: $this->request,
+			mapper: $this->mapper,
+			runner: $this->runner,
+			resolvers: $this->resolvers,
+			userSession: $session,
+			organisationService: $this->organisations,
+			groupManager: $groupManager,
+			flows: $this->flows
+		);
+	}//end controllerWith()
+
+	/**
+	 * An assigned step is never answerable anonymously.
+	 *
+	 * This is the fail-CLOSED half of the guard, and it is the half that is
+	 * easy to get backwards: the unassigned case deliberately allows anyone
+	 * through, so an implementation that treated "no uid" the same way would
+	 * pass every other test in this file while leaving an assigned decision
+	 * open to an unauthenticated caller.
+	 *
+	 * @return void
+	 */
+	public function testResumeRefusesAnAssignedStepWithoutASession(): void {
+		$run = $this->suspendedRunWithResumeState(
+			['approval' => ['askedAt' => '2026-08-27T00:00:00+00:00', 'assignee' => 'bob']]
+		);
+
+		$this->mapper->method('findByUuid')->with('run-1')->willReturn($run);
+		$this->flows->method('find')->with('flow-1');
+		$this->runner->expects($this->never())->method('signal');
+
+		$session = $this->createMock(IUserSession::class);
+		$session->method('getUser')->willReturn(null);
+
+		$response = $this->controllerWith(session: $session)->resume('run-1');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertStringContainsString('sign in', $response->getData()['error']);
+	}//end testResumeRefusesAnAssignedStepWithoutASession()
+
+	/**
+	 * An assignee may be a GROUP, and a member of it may answer.
+	 *
+	 * AwaitSignalNode records a single `assignee` string without saying whether
+	 * it names a person or a group, so the guard has to try both. Without this
+	 * every group-assigned step would refuse its own intended audience — a
+	 * regression that reads as "the guard works" because refusing is what a
+	 * guard does.
+	 *
+	 * @return void
+	 */
+	public function testResumeAllowsAMemberOfAnAssignedGroup(): void {
+		$run = $this->suspendedRunWithResumeState(
+			['approval' => ['askedAt' => '2026-08-27T00:00:00+00:00', 'assignee' => 'reviewers']]
+		);
+
+		$signalled = new FlowRun();
+		$signalled->setUuid('run-1');
+		$signalled->setStatus(FlowRun::STATUS_SUSPENDED);
+
+		$this->mapper->method('findByUuid')->with('run-1')->willReturn($run);
+		$this->flows->method('find')->with('flow-1');
+		$this->request->method('getParams')->willReturn(['decision' => 'approved']);
+		$this->runner->expects($this->once())->method('signal')->willReturn($signalled);
+
+		$groups = $this->createMock(IGroupManager::class);
+		$groups->expects($this->once())
+			->method('isInGroup')
+			->with('alice', 'reviewers')
+			->willReturn(true);
+
+		$response = $this->controllerWith(
+			session: $this->userSession,
+			groupManager: $groups
+		)->resume('run-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}//end testResumeAllowsAMemberOfAnAssignedGroup()
+
+	/**
+	 * A non-member of an assigned group is still refused.
+	 *
+	 * The companion to the test above: it is what makes the group lookup a
+	 * check rather than a rubber stamp.
+	 *
+	 * @return void
+	 */
+	public function testResumeRefusesANonMemberOfAnAssignedGroup(): void {
+		$run = $this->suspendedRunWithResumeState(
+			['approval' => ['askedAt' => '2026-08-27T00:00:00+00:00', 'assignee' => 'reviewers']]
+		);
+
+		$this->mapper->method('findByUuid')->with('run-1')->willReturn($run);
+		$this->flows->method('find')->with('flow-1');
+		$this->runner->expects($this->never())->method('signal');
+
+		$groups = $this->createMock(IGroupManager::class);
+		$groups->method('isInGroup')->with('alice', 'reviewers')->willReturn(false);
+
+		$response = $this->controllerWith(
+			session: $this->userSession,
+			groupManager: $groups
+		)->resume('run-1');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertStringContainsString('someone else', $response->getData()['error']);
+	}//end testResumeRefusesANonMemberOfAnAssignedGroup()
+
+	/**
+	 * A slot that has not asked yet does not assign anybody.
+	 *
+	 * A run accumulates a slot per node across its life. Only a slot that
+	 * actually asked (`askedAt`) is awaiting an answer, so an assignee sitting
+	 * on a not-yet-asked slot must not gate the step that IS asking — that
+	 * would refuse the right person on the strength of a future step.
+	 *
+	 * @return void
+	 */
+	public function testAnAssigneeOnASlotThatHasNotAskedDoesNotGate(): void {
+		$run = $this->suspendedRunWithResumeState(
+			[
+				'webhook' => ['askedAt' => '2026-08-27T00:00:00+00:00'],
+				'later'   => ['assignee' => 'bob'],
+			]
+		);
+
+		$signalled = new FlowRun();
+		$signalled->setUuid('run-1');
+		$signalled->setStatus(FlowRun::STATUS_SUSPENDED);
+
+		$this->mapper->method('findByUuid')->with('run-1')->willReturn($run);
+		$this->flows->method('find')->with('flow-1');
+		$this->request->method('getParams')->willReturn(['ok' => true]);
+		$this->runner->expects($this->once())->method('signal')->willReturn($signalled);
+
+		$response = $this->controller->resume('run-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}//end testAnAssigneeOnASlotThatHasNotAskedDoesNotGate()
+
+	/**
+	 * A malformed resumeState is read as unassigned, not as a crash.
+	 *
+	 * The context is stored JSON that older runs wrote under earlier shapes, so
+	 * the guard must survive a scalar or a non-array slot where it expects a
+	 * map. Refusing here would strand in-flight runs; throwing would 500 them.
+	 *
+	 * @return void
+	 */
+	public function testAMalformedResumeStateIsTreatedAsUnassigned(): void {
+		$run = $this->suspendedRunWithResumeState('not-a-map');
+
+		$signalled = new FlowRun();
+		$signalled->setUuid('run-1');
+		$signalled->setStatus(FlowRun::STATUS_SUSPENDED);
+
+		$this->mapper->method('findByUuid')->with('run-1')->willReturn($run);
+		$this->flows->method('find')->with('flow-1');
+		$this->request->method('getParams')->willReturn(['ok' => true]);
+		$this->runner->expects($this->once())->method('signal')->willReturn($signalled);
+
+		$response = $this->controller->resume('run-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}//end testAMalformedResumeStateIsTreatedAsUnassigned()
+
+	/**
+	 * A non-array slot inside a well-formed map is skipped, not read.
+	 *
+	 * @return void
+	 */
+	public function testANonArraySlotIsSkipped(): void {
+		$run = $this->suspendedRunWithResumeState(
+			[
+				'legacy'   => 'a bare string a previous shape wrote',
+				'approval' => ['askedAt' => '2026-08-27T00:00:00+00:00', 'assignee' => 'alice'],
+			]
+		);
+
+		$signalled = new FlowRun();
+		$signalled->setUuid('run-1');
+		$signalled->setStatus(FlowRun::STATUS_SUSPENDED);
+
+		$this->mapper->method('findByUuid')->with('run-1')->willReturn($run);
+		$this->flows->method('find')->with('flow-1');
+		$this->request->method('getParams')->willReturn(['ok' => true]);
+		$this->runner->expects($this->once())->method('signal')->willReturn($signalled);
+
+		$response = $this->controller->resume('run-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}//end testANonArraySlotIsSkipped()
 
 }//end class

--- a/tests/Unit/Controller/FlowRunControllerTest.php
+++ b/tests/Unit/Controller/FlowRunControllerTest.php
@@ -443,4 +443,96 @@ class FlowRunControllerTest extends TestCase {
 		$this->assertSame(Http::STATUS_CONFLICT, $response->getStatus());
 		$this->assertStringContainsString('running', $response->getData()['error']);
 	}//end testResumeConflictsWhenTheRunIsNotSuspended()
+
+	/**
+	 * A step assigned to someone else must not be answerable by the caller.
+	 *
+	 * THE POINT OF THE WHOLE GUARD. AwaitSignalNode has always recorded an
+	 * `assignee` and nothing read it back, so the recorded assignment looked
+	 * like authorization and was not: everyone who could run the flow could
+	 * approve a step assigned to another person. ADR-098 names this gap.
+	 *
+	 * @return void
+	 */
+	public function testResumeRefusesWhenTheStepIsAssignedToSomebodyElse(): void {
+		$run = new FlowRun();
+		$run->setUuid('run-1');
+		$run->setFlowId('flow-1');
+		$run->setStatus(FlowRun::STATUS_SUSPENDED);
+		$run->setContext([
+			'resumeState' => ['approval' => ['askedAt' => '2026-08-27T00:00:00+00:00', 'assignee' => 'bob']],
+		]);
+
+		$this->mapper->method('findByUuid')->with('run-1')->willReturn($run);
+		$this->flows->method('find')->with('flow-1');
+
+		// It must refuse BEFORE signalling — a 403 that still woke the run
+		// would be a refusal in name only.
+		$this->runner->expects($this->never())->method('signal');
+
+		$response = $this->controller->resume('run-1');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+	}//end testResumeRefusesWhenTheStepIsAssignedToSomebodyElse()
+
+	/**
+	 * The assignee themselves may answer.
+	 *
+	 * @return void
+	 */
+	public function testResumeAllowsTheNamedAssignee(): void {
+		$run = new FlowRun();
+		$run->setUuid('run-1');
+		$run->setFlowId('flow-1');
+		$run->setStatus(FlowRun::STATUS_SUSPENDED);
+		$run->setContext([
+			'resumeState' => ['approval' => ['askedAt' => '2026-08-27T00:00:00+00:00', 'assignee' => 'alice']],
+		]);
+
+		$signalled = new FlowRun();
+		$signalled->setUuid('run-1');
+		$signalled->setStatus(FlowRun::STATUS_SUSPENDED);
+
+		$this->mapper->method('findByUuid')->with('run-1')->willReturn($run);
+		$this->flows->method('find')->with('flow-1');
+		$this->request->method('getParams')->willReturn(['decision' => 'approved']);
+		$this->runner->expects($this->once())->method('signal')->willReturn($signalled);
+
+		$response = $this->controller->resume('run-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}//end testResumeAllowsTheNamedAssignee()
+
+	/**
+	 * An unassigned step is unchanged — silence still means anyone.
+	 *
+	 * Deliberate: a webhook or a child-run signal is not a human decision, and
+	 * tightening the unassigned case would break every one of them. Asserted so
+	 * that the scope of the guard is visible rather than assumed.
+	 *
+	 * @return void
+	 */
+	public function testResumeStillAllowsAnyoneWhenNoAssigneeWasRecorded(): void {
+		$run = new FlowRun();
+		$run->setUuid('run-1');
+		$run->setFlowId('flow-1');
+		$run->setStatus(FlowRun::STATUS_SUSPENDED);
+		$run->setContext([
+			'resumeState' => ['webhook' => ['askedAt' => '2026-08-27T00:00:00+00:00']],
+		]);
+
+		$signalled = new FlowRun();
+		$signalled->setUuid('run-1');
+		$signalled->setStatus(FlowRun::STATUS_SUSPENDED);
+
+		$this->mapper->method('findByUuid')->with('run-1')->willReturn($run);
+		$this->flows->method('find')->with('flow-1');
+		$this->request->method('getParams')->willReturn(['ok' => true]);
+		$this->runner->expects($this->once())->method('signal')->willReturn($signalled);
+
+		$response = $this->controller->resume('run-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}//end testResumeStillAllowsAnyoneWhenNoAssigneeWasRecorded()
+
 }//end class


### PR DESCRIPTION
Wave 4's prerequisite, and the smallest correct piece of it.

## The gap, concretely

ADR-098 names it: *"no task authz — anyone reaching the resume endpoint can decide."*

`AwaitSignalNode` has **always recorded an `assignee`** on the suspension (`recordRequest()` writes it alongside `askedAt` and `question`). Nothing ever read it back. The only guard on `POST /api/flow-runs/{uuid}/resume` was `refuseUnlessRunnable()`, which asks *"may you run this flow?"* — a different question from *"is this decision yours to make"*.

So everyone who could run the flow could approve a step assigned to someone else, **while the recorded assignee made it look otherwise**. A field that looks like authorization and isn't is worse than no field at all.

## What this does

The resume endpoint now refuses when the awaiting step names an assignee and the caller is neither that uid nor a member of that group. Anonymous is refused outright — an assigned decision is never anonymous. The refusal happens **before** signalling; a 403 that still woke the run would be a refusal in name only, and there's a test asserting `signal()` is never reached.

## Scope — deliberately narrow

This closes the **who** of an already-recorded assignment. It is **not** the task entity, inbox, or definition versioning ADR-098 describes; those remain unbuilt, and Wave 4's workflow-definitions/parafeerroutes consolidation still depends on them.

A step with **no** assignee is unchanged: silence still means anyone. Most await-signal suspensions are webhooks and child-run completions rather than human decisions, and tightening the unassigned case would break every one of them. That's asserted by a test rather than left implicit, so the scope is visible.

## Mutation-checked

A security guard that cannot fail is the worst kind. Replacing the assignee lookup with an unconditional allow makes the suite fail (1 failure); restoring it returns to green.

18 tests, phpstan clean, phpcs clean.
