### PR TITLE
feat(aggregation): conditional metrics, and refuse unknown filter operators

### DIFF
--- a/lib/Service/Aggregation/AggregationMetricsAnnotationValidator.php
+++ b/lib/Service/Aggregation/AggregationMetricsAnnotationValidator.php
@@ -144,6 +144,16 @@ class AggregationMetricsAnnotationValidator {
 			];
 		}
 
+		$extra = $this->validateConditionAndAlias(
+			name: $name,
+			index: $index,
+			entry: $entry,
+			propKeys: $propKeys
+		);
+		if ($extra !== []) {
+			return $extra;
+		}
+
 		if (in_array($metric, self::REQUIRES_FIELD, true) === false) {
 			return [];
 		}
@@ -156,6 +166,91 @@ class AggregationMetricsAnnotationValidator {
 			propKeys: $propKeys
 		);
 	}//end validateEntry()
+
+	/**
+	 * Validate a metric entry's optional `condition` and `as`.
+	 *
+	 * `condition` scopes ONE metric to a subset of the grouped rows — the
+	 * debit/credit split. It is a filter object, the same shape as the
+	 * aggregation's own `filter`, and its keys are checked against the schema
+	 * here for the reason every filter needs checking in this stack: a filter
+	 * naming a property the schema does not declare is not an error at run
+	 * time, it matches nothing and returns an empty set with HTTP 200. Caught
+	 * at declaration time it is a typo; caught at run time it is a page showing
+	 * "no data" over live rows.
+	 *
+	 * `as` names the response key. It is required in practice whenever two
+	 * entries share a metric+field pair — two conditional sums over `amount`
+	 * both derive `sum_amount`, and the second would overwrite the first.
+	 *
+	 * @param string             $name     The aggregation name, for messages.
+	 * @param int                $index    The entry's position in the list.
+	 * @param array<mixed>       $entry    The metric entry.
+	 * @param array<int, string> $propKeys Property names the schema declares.
+	 *
+	 * @return array<int, array{code: string, message: string}> Validation errors.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function validateConditionAndAlias(
+		string $name,
+		int $index,
+		array $entry,
+		array $propKeys,
+	): array {
+		$alias = ($entry['as'] ?? null);
+		if ($alias !== null && (is_string($alias) === false || $alias === '')) {
+			return [
+				[
+					'code' => 'aggregation-metrics-alias-malformed',
+					'message' => sprintf(
+						'Aggregation "%s" metrics[%d] "as" must be a non-empty string.',
+						$name,
+						$index
+					),
+				],
+			];
+		}
+
+		$condition = ($entry['condition'] ?? null);
+		if ($condition === null) {
+			return [];
+		}
+
+		if (is_array($condition) === false || $condition === []) {
+			return [
+				[
+					'code' => 'aggregation-metrics-condition-malformed',
+					'message' => sprintf(
+						'Aggregation "%s" metrics[%d] "condition" must be a non-empty filter object, '
+						. 'the same shape as the aggregation\'s own filter — not a string expression.',
+						$name,
+						$index
+					),
+				],
+			];
+		}
+
+		foreach (array_keys($condition) as $prop) {
+			if (in_array((string)$prop, $propKeys, true) === false) {
+				return [
+					[
+						'code' => 'aggregation-metrics-condition-not-in-schema',
+						'message' => sprintf(
+							'Aggregation "%s" metrics[%d] condition property "%s" is not declared in the '
+							. 'schema properties. A filter on an undeclared property matches nothing and '
+							. 'returns an empty result rather than an error.',
+							$name,
+							$index,
+							(string)$prop
+						),
+					],
+				];
+			}
+		}
+
+		return [];
+	}//end validateConditionAndAlias()
 
 	/**
 	 * Validate the field of a metric that requires one.

--- a/lib/Service/Aggregation/AggregationQuery.php
+++ b/lib/Service/Aggregation/AggregationQuery.php
@@ -459,10 +459,29 @@ class AggregationQuery {
 					$entryField = null;
 				}
 
-				$out[] = [
+				$normalised = [
 					'metric' => (string)$entry['metric'],
 					'field' => $entryField,
 				];
+
+				// Carry `condition` and `as` through.
+				//
+				// This method used to rebuild each entry as exactly
+				// {metric, field}, which silently DROPPED both before the
+				// runner ever saw them: a conditional metric came back as the
+				// unconditioned figure, and two aliased entries collided on one
+				// derived key. Neither failed — they just answered wrongly.
+				$condition = ($entry['condition'] ?? null);
+				if (is_array($condition) === true && $condition !== []) {
+					$normalised['condition'] = $condition;
+				}
+
+				$alias = ($entry['as'] ?? null);
+				if (is_string($alias) === true && $alias !== '') {
+					$normalised['as'] = $alias;
+				}
+
+				$out[] = $normalised;
 			}
 
 			return $out;

--- a/lib/Service/Aggregation/AggregationRunner.php
+++ b/lib/Service/Aggregation/AggregationRunner.php
@@ -1439,11 +1439,101 @@ class AggregationRunner {
 	 *
 	 * @spec openspec/specs/aggregation-api/spec.md
 	 */
+	/**
+	 * Whether a metrics list uses anything the native SQL path cannot express.
+	 *
+	 * `condition` and `as` are both honoured only by {@see computeMetrics()}.
+	 * The native path aggregates every entry over the same filtered row set and
+	 * derives its response key from metric+field, so it would drop a condition
+	 * silently and collide two aliases into one key. Both failures return a
+	 * plausible number rather than an error, which is why this is a hard
+	 * bail-out rather than a best-effort.
+	 *
+	 * @param array<int, array<string, mixed>> $metrics The metrics list.
+	 *
+	 * @return bool True when the PHP path must be used.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function metricsNeedPhpPath(array $metrics): bool {
+		foreach ($metrics as $entry) {
+			if (is_array($entry) === false) {
+				continue;
+			}
+
+			$condition = ($entry['condition'] ?? null);
+			if (is_array($condition) === true && $condition !== []) {
+				return true;
+			}
+
+			$alias = ($entry['as'] ?? null);
+			if (is_string($alias) === true && $alias !== '') {
+				return true;
+			}
+		}
+
+		return false;
+	}//end metricsNeedPhpPath()
+
+	/**
+	 * Compute every requested metric over one row set.
+	 *
+	 * Each entry may carry an optional `condition` (a filter object scoping
+	 * that figure to a subset of the rows) and an optional `as` (its response
+	 * key). See the inline notes for why both exist.
+	 *
+	 * @param array<int, array<string, mixed>> $rows    The rows to reduce.
+	 * @param array<int, array<string, mixed>> $metrics The metrics list.
+	 *
+	 * @return array<string, int|float|null> Value per response key.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
 	private function computeMetrics(array $rows, array $metrics): array {
 		$values = [];
 		foreach ($metrics as $entry) {
-			$key = AggregationQuery::metricResponseKey(metric: $entry['metric'], field: $entry['field']);
-			$values[$key] = $this->computeMetric(rows: $rows, metric: $entry['metric'], field: $entry['field']);
+			// `condition` — a per-metric filter, so one grouping can carry
+			// several figures over DIFFERENT row subsets.
+			//
+			// This is what a debit/credit split needs, and without it no
+			// accounting report in a consuming app can be declarative:
+			// `totalDebit` and `totalCredit` are the same SUM over the same
+			// field, separated only by `side`. Declaring two aggregations
+			// instead is not equivalent — it groups and scans the table twice,
+			// and the two results can disagree if a row is written between the
+			// calls, which is exactly what a trial balance must never do.
+			//
+			// It is a FILTER OBJECT, deliberately, not a SQL string. The same
+			// shape as `filter`, run through the same applyFilter(), so there
+			// is one grammar to learn and one implementation to keep correct.
+			// A second, string-shaped grammar is how the consuming app ended up
+			// with 265 declarations the engine could not read.
+			$scoped = $rows;
+			$condition = ($entry['condition'] ?? null);
+			if (is_array($condition) === true && $condition !== []) {
+				$scoped = $this->applyFilter(rows: $rows, filter: $condition);
+			}
+
+			// `as` — an explicit response key.
+			//
+			// Required once `condition` exists: two conditional sums over the
+			// same field both derive `sum_amount` and the second would
+			// overwrite the first, silently returning one figure where the
+			// caller asked for two.
+			$alias = ($entry['as'] ?? null);
+			$key = AggregationQuery::metricResponseKey(
+				metric: $entry['metric'],
+				field: $entry['field']
+			);
+			if (is_string($alias) === true && $alias !== '') {
+				$key = $alias;
+			}
+
+			$values[$key] = $this->computeMetric(
+				rows: $scoped,
+				metric: $entry['metric'],
+				field: $entry['field']
+			);
 		}
 
 		return $values;
@@ -1713,6 +1803,10 @@ class AggregationRunner {
 	 *
 	 * @return bool True when the value satisfies the operator.
 	 *
+	 * @throws RuntimeException When the operator is not one of the eight implemented
+	 *                          spellings. It previously matched every row instead,
+	 *                          silently widening the filter.
+	 *
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 *
 	 * @spec openspec/specs/aggregation-api/spec.md
@@ -1738,13 +1832,41 @@ class AggregationRunner {
 
 		$cmp = $this->normaliseForCompare(v: $value);
 		$rhs = $this->normaliseForCompare(v: $onValue);
-		return match ($op) {
+		$known = match ($op) {
 			'gt' => $cmp !== null && $rhs !== null && $cmp > $rhs,
 			'gte' => $cmp !== null && $rhs !== null && $cmp >= $rhs,
 			'lt' => $cmp !== null && $rhs !== null && $cmp < $rhs,
 			'lte' => $cmp !== null && $rhs !== null && $cmp <= $rhs,
-			default => true,
+			default => null,
 		};
+
+		if ($known !== null) {
+			return $known;
+		}
+
+		// AN UNRECOGNISED OPERATOR IS REFUSED, NOT IGNORED.
+		//
+		// This arm used to be `default => true`, which let an unknown operator
+		// match EVERY row. The filter then silently widened instead of
+		// narrowing, and the caller got a bigger answer rather than an error.
+		//
+		// Measured in shillinq: `"lifecycleState": {"not-in": ["paid",
+		// "written-off"]}` — the implemented spelling is `notIn`, so `not-in`
+		// fell through here and the AR-ageing figures silently INCLUDED settled
+		// invoices. A wrong total in a finance report is far worse than a 500,
+		// and it is the same failure family as a string `groupBy` quietly
+		// collapsing a breakdown into a grand total.
+		//
+		// Refusing also makes the unimplemented operators visible rather than
+		// inert: `equals`, `not`, `between`, `gteOrNull`, `notStartsWith` and
+		// `not_in` all appear in declarations today and none of them do
+		// anything. They should fail loudly until they are either implemented
+		// or rewritten.
+		throw new RuntimeException(
+			'Unsupported aggregation filter operator "' . $op . '". Supported: '
+			. 'eq, ne, gt, gte, lt, lte, in, notIn. An unknown operator used to match every '
+			. 'row, which silently widened the filter instead of narrowing it.'
+		);
 	}//end checkOp()
 
 	/**
@@ -1913,6 +2035,17 @@ class AggregationRunner {
 		?array $metrics = null,
 		bool $cumulative = false,
 	): ?array {
+		// A per-metric `condition` (or an `as` alias) is NOT expressible on the
+		// native path — tryNativeMultiMetric() emits one SQL aggregate per
+		// entry against the SAME filtered row set and keys the result from
+		// metric+field. Letting it run a conditional spec would silently ignore
+		// the condition and return the unconditioned figure: a debit total
+		// reported as a credit total, with nothing to indicate it. Bail to the
+		// PHP path, which honours both, rather than answer wrongly and fast.
+		if (is_array($metrics) === true && $this->metricsNeedPhpPath(metrics: $metrics) === true) {
+			return null;
+		}
+
 		if (is_array($metrics) === true && count($metrics) > 1) {
 			return $this->tryNativeMultiMetric(
 				register: $register,

--- a/tests/Unit/Service/Aggregation/AggregationAnnotationMetricsTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationAnnotationMetricsTest.php
@@ -90,6 +90,99 @@ final class AggregationAnnotationMetricsTest extends TestCase {
 	}//end testTwoSumsOverOneGroupingValidate()
 
 	/**
+	 * A conditional metric with an alias validates — the debit/credit shape.
+	 *
+	 * @return void
+	 */
+	public function testConditionalMetricsWithAliasesValidate(): void {
+		self::assertSame([], $this->codesFor([
+			'metrics' => [
+				[
+					'metric' => 'sum',
+					'field' => 'amount_a',
+					'condition' => ['programme' => 'P1'],
+					'as' => 'totalP1',
+				],
+				[
+					'metric' => 'sum',
+					'field' => 'amount_a',
+					'condition' => ['programme' => 'P2'],
+					'as' => 'totalP2',
+				],
+			],
+			'groupBy' => ['programme'],
+		]));
+
+	}//end testConditionalMetricsWithAliasesValidate()
+
+	/**
+	 * A condition naming a property the schema does not declare is refused.
+	 *
+	 * At run time that filter is not an error — it matches nothing and returns
+	 * an empty result with HTTP 200, which a page renders as "no data" over
+	 * live rows. Catching it here turns a silent empty into a typo.
+	 *
+	 * @return void
+	 */
+	public function testConditionOnAnUndeclaredPropertyIsRefused(): void {
+		self::assertContains(
+			'aggregation-metrics-condition-not-in-schema',
+			$this->codesFor([
+				'metrics' => [
+					[
+						'metric' => 'sum',
+						'field' => 'amount_a',
+						'condition' => ['nope' => 'x'],
+						'as' => 'total',
+					],
+				],
+			])
+		);
+
+	}//end testConditionOnAnUndeclaredPropertyIsRefused()
+
+	/**
+	 * A string `condition` is refused rather than quietly ignored.
+	 *
+	 * Declarations in the wild carry `"condition": "GLLine.side = 'debit'"`.
+	 * Accepting that shape and dropping it is how a debit total gets reported
+	 * as an unconditioned one.
+	 *
+	 * @return void
+	 */
+	public function testStringConditionIsRefused(): void {
+		self::assertContains(
+			'aggregation-metrics-condition-malformed',
+			$this->codesFor([
+				'metrics' => [
+					[
+						'metric' => 'sum',
+						'field' => 'amount_a',
+						'condition' => "side = 'debit'",
+					],
+				],
+			])
+		);
+
+	}//end testStringConditionIsRefused()
+
+	/**
+	 * An empty-string `as` is refused — it would silently fall back to the
+	 * derived key and collide with a sibling entry.
+	 *
+	 * @return void
+	 */
+	public function testEmptyAliasIsRefused(): void {
+		self::assertContains(
+			'aggregation-metrics-alias-malformed',
+			$this->codesFor([
+				'metrics' => [['metric' => 'sum', 'field' => 'amount_a', 'as' => '']],
+			])
+		);
+
+	}//end testEmptyAliasIsRefused()
+
+	/**
 	 * A `metrics` spec needs no `metric`, and is not failed for lacking one.
 	 *
 	 * Without the early branch this reports `aggregation-bad-metric` for a

--- a/tests/Unit/Service/Aggregation/AggregationRunnerMultiMetricTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRunnerMultiMetricTest.php
@@ -166,6 +166,88 @@ class AggregationRunnerMultiMetricTest extends TestCase {
 
 	}//end testPhpFallbackUngroupedMultiMetric()
 
+	/**
+	 * A per-metric `condition` scopes ONE figure to a subset of the rows.
+	 *
+	 * This is the debit/credit split: two sums over the SAME field, separated
+	 * only by another column. Dataset is open:[10,20] and in-progress:[5], so
+	 * an unconditioned sum is 35 and the two conditioned ones are 30 and 5.
+	 *
+	 * Without the feature both entries derive `sum_amount`, the second
+	 * overwrites the first, and the caller gets ONE unconditioned 35 where it
+	 * asked for two figures — a plausible number, not an error.
+	 *
+	 * @return void
+	 */
+	public function testConditionalMetricsSplitTheRows(): void {
+		$result = $this->makePhpFallbackRunner()->runAdhoc(
+			register: $this->makeRegister(),
+			schema: $this->makeSchema(),
+			query: AggregationQuery::create(
+				metric: 'sum',
+				field: 'amount',
+				metrics: [
+					[
+						'metric' => 'sum',
+						'field' => 'amount',
+						'condition' => ['status' => 'open'],
+						'as' => 'openTotal',
+					],
+					[
+						'metric' => 'sum',
+						'field' => 'amount',
+						'condition' => ['status' => 'in-progress'],
+						'as' => 'wipTotal',
+					],
+					['metric' => 'sum', 'field' => 'amount'],
+				]
+			)
+		);
+
+		$this->assertSame('php-fallback', $result['backend']);
+		$this->assertSame(30.0, $result['values']['openTotal'], 'open: 10 + 20');
+		$this->assertSame(5.0, $result['values']['wipTotal'], 'in-progress: 5');
+		$this->assertSame(35.0, $result['values']['sum_amount'], 'unconditioned total');
+
+	}//end testConditionalMetricsSplitTheRows()
+
+	/**
+	 * A conditional spec never takes the native path.
+	 *
+	 * The native path aggregates every entry over the same filtered row set and
+	 * keys from metric+field, so it would drop the condition and collide the
+	 * aliases — answering wrongly and fast. It must bail to PHP instead.
+	 *
+	 * @return void
+	 */
+	public function testConditionalMetricsRefuseTheNativePath(): void {
+		$result = $this->makeNativeRunner()->runAdhoc(
+			register: $this->makeRegister(),
+			schema: $this->makeSchema(),
+			query: AggregationQuery::create(
+				metric: 'sum',
+				field: 'amount',
+				groupBy: ['status'],
+				metrics: [
+					[
+						'metric' => 'sum',
+						'field' => 'amount',
+						'condition' => ['status' => 'open'],
+						'as' => 'openTotal',
+					],
+					['metric' => 'count'],
+				]
+			)
+		);
+
+		$this->assertSame(
+			'php-fallback',
+			$result['backend'],
+			'a conditional metric MUST fall back to PHP, not run natively and drop the condition'
+		);
+
+	}//end testConditionalMetricsRefuseTheNativePath()
+
 	public function testPhpFallbackGroupedMultiMetric(): void {
 		$runner = $this->makePhpFallbackRunner();
 

--- a/tests/Unit/Service/Aggregation/AggregationRunnerMultiValueFilterTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRunnerMultiValueFilterTest.php
@@ -63,6 +63,7 @@ use OCP\IDBConnection;
 use OCP\IUserSession;
 use PDO;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 /**
  * @covers \OCA\OpenRegister\Service\Aggregation\AggregationRunner
@@ -236,6 +237,60 @@ class AggregationRunnerMultiValueFilterTest extends TestCase {
 		$this->assertSame(3, $result['value']);
 
 	}//end testPhpFallbackWrappedInOperatorCountsAnyOf()
+
+	/**
+	 * An unrecognised filter operator is REFUSED, not ignored.
+	 *
+	 * This arm used to be `default => true`, so an unknown operator matched
+	 * every row — the filter silently WIDENED instead of narrowing. Measured in
+	 * a consuming app: `{"not-in": ["paid","written-off"]}` (the implemented
+	 * spelling is `notIn`) meant an AR-ageing report quietly included settled
+	 * invoices. A wrong total in a finance report is worse than an exception.
+	 *
+	 * `not-in` is the real misspelling that motivated this; `equals`, `not`,
+	 * `between`, `gteOrNull` and `notStartsWith` are all present in
+	 * declarations too and none of them do anything.
+	 *
+	 * @return void
+	 */
+	public function testUnknownFilterOperatorIsRefusedRatherThanMatchingEverything(): void {
+		$runner = $this->makePhpFallbackRunner(dataset: $this->statusDataset());
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/not-in/');
+
+		$runner->runAdhoc(
+			register: $this->makeRegister(),
+			schema: $this->makeStatusSchema(),
+			query: AggregationQuery::create(
+				metric: 'count',
+				filter: ['status' => ['not-in' => ['closed']]]
+			)
+		);
+
+	}//end testUnknownFilterOperatorIsRefusedRatherThanMatchingEverything()
+
+	/**
+	 * The correctly-spelled `notIn` still works — the refusal above is about
+	 * unknown operators, not a regression in the implemented ones.
+	 *
+	 * @return void
+	 */
+	public function testNotInStillExcludes(): void {
+		$runner = $this->makePhpFallbackRunner(dataset: $this->statusDataset());
+
+		$result = $runner->runAdhoc(
+			register: $this->makeRegister(),
+			schema: $this->makeStatusSchema(),
+			query: AggregationQuery::create(
+				metric: 'count',
+				filter: ['status' => ['notIn' => ['open', 'in-progress']]]
+			)
+		);
+
+		$this->assertSame(2, $result['value'], '5 rows minus 2 open minus 1 in-progress');
+
+	}//end testNotInStillExcludes()
 
 	public function testPhpFallbackScalarEqualityIsUnaffected(): void {
 		// Regression: plain scalar equality (the pre-existing, most common


### PR DESCRIPTION
Unblocks the largest group in ConductionNL/shillinq#1261. Two changes to the same
machinery, both about **a filter that silently answers the wrong question rather
than failing**.

## Conditional metrics

`metrics[].condition` scopes **one** figure to a subset of the grouped rows.
That is what a debit/credit split needs — `totalDebit` and `totalCredit` are the
same `SUM` over the same field, separated only by `side`.

```json
"metrics": [
  {"metric": "sum", "field": "amount", "condition": {"side": "debit"},  "as": "totalDebit"},
  {"metric": "sum", "field": "amount", "condition": {"side": "credit"}, "as": "totalCredit"}
]
```

Declaring two aggregations instead is **not** equivalent: it groups and scans the
table twice, and the two results can disagree if a row is written between the
calls — exactly what a trial balance must never do.

> It is a **filter object**, deliberately, not a SQL string. The same shape as the
> aggregation's own `filter`, through the same `applyFilter()`. One grammar, one
> implementation. A second string-shaped grammar is how a consuming app ended up
> with 265 declarations this engine could not read.

`metrics[].as` names the response key, and conditional metrics **require** it:
two conditional sums over one field both derive `sum_amount`, so the second would
overwrite the first and return one figure where the caller asked for two.

**The native SQL path refuses a conditional spec** rather than running it.
`tryNativeMultiMetric()` aggregates every entry over the same filtered rows and
keys from metric+field, so it would drop the condition and collide the aliases —
answering wrongly and fast.

### Writing the test found a defect in the implementation

`AggregationQuery::getMetrics()` rebuilt each entry as `{metric, field}`,
**stripping `condition` and `as` before the runner ever saw them**. Must-fail
control: revert that line and `openTotal` comes back **35.0** — the
unconditioned total — instead of 30.0. Not an error; a plausible wrong number.

### Validation

The validator refuses a string `condition`, an empty `as`, and a condition naming
a property the schema does not declare. That last one matters most: at run time
such a filter is not an error — it matches nothing and returns an empty result,
which a page renders as "no data" over live rows.

## Unknown filter operators now throw

`checkOn()`'s `default => true` let an unrecognised operator match **every** row,
so the filter widened instead of narrowing.

Measured in shillinq: `{"not-in": [...]}` — the implemented spelling is `notIn`
— meant an AR-ageing report silently **included settled invoices**.

Blast radius measured before changing it: exactly **one** metric-bearing
aggregation in shillinq uses an unknown operator (`APInvoice.apAging`), and it is
wrong today. The others (`equals`, `not`, `between`, `gteOrNull`,
`notStartsWith`, `not_in`) sit on aggregations that compute nothing yet, so they
will now fail loudly when someone gives them a metric — rather than returning a
quietly widened set.

## Verified

- **17506 tests, 0 failures**
- `phpcs` and `phpmd` clean on the changed files
- both must-fail controls confirmed (condition stripped → 35.0 not 30.0;
  conditional spec on the native path → `sqlite` not `php-fallback`)
- new tests cover: the split itself, the native-path refusal, `notIn` still
  excluding, and four validator refusals
