### PR TITLE
feat(graphql): filtered groups, and declared aggregations by name

### DIFF
--- a/lib/Service/GraphQL/GraphQLResolver.php
+++ b/lib/Service/GraphQL/GraphQLResolver.php
@@ -27,6 +27,7 @@ namespace OCA\OpenRegister\Service\GraphQL;
 use GraphQL\Deferred;
 use GraphQL\Error\Error;
 use InvalidArgumentException;
+use RuntimeException;
 use OCA\OpenRegister\Db\AuditTrailMapper;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\Register;
@@ -284,12 +285,80 @@ class GraphQLResolver {
 			$connection['groups'] = $this->resolveGroupBy(
 				schema: $schema,
 				register: $register,
-				rawArgs: $groupBy
+				rawArgs: $groupBy,
+				filter: $this->propertyFilterFromArgs(args: $args)
+			);
+		}
+
+		// Optional DECLARED aggregation, by name.
+		$aggregationName = ($args['aggregation'] ?? null);
+		if (is_string($aggregationName) === true && $aggregationName !== '') {
+			$connection['aggregation'] = $this->resolveNamedAggregation(
+				schema: $schema,
+				register: $register,
+				name: $aggregationName,
+				filter: $this->propertyFilterFromArgs(args: $args)
 			);
 		}
 
 		return $connection;
 	}//end resolveList()
+
+	/**
+	 * Resolve a DECLARED aggregation by name.
+	 *
+	 * `groupBy` is ad-hoc — the caller describes the aggregation. This runs one
+	 * the schema declares in `x-openregister-aggregations`, which was reachable
+	 * only over REST, so a page wanting a declared figure had to hand-build a
+	 * URL alongside its GraphQL query.
+	 *
+	 * The query's own property filter is passed as a NARROWING constraint. That
+	 * is safe by construction: the engine refuses any request key the
+	 * declaration already pins, so a caller can add a constraint and can never
+	 * relax a declared scoping one.
+	 *
+	 * The envelope is returned as-is — the same JSON the REST endpoint emits —
+	 * because its shape varies with what the aggregation declares (a scalar
+	 * `value`, a `values` map, `groups[].keys`, `joined`).
+	 *
+	 * @param Schema                $schema   The schema being aggregated.
+	 * @param Register|null         $register The register; null when the schema is unbound.
+	 * @param string                $name     The declared aggregation's name.
+	 * @param array<string, mixed>  $filter   The query's property filter, as a narrowing constraint.
+	 *
+	 * @return array<string, mixed>|null The result envelope, or null when unbound.
+	 *
+	 * @throws Error When the aggregation is unknown, malformed, or RBAC denies it.
+	 *
+	 * @spec openspec/specs/graphql-api/spec.md
+	 */
+	private function resolveNamedAggregation(
+		Schema $schema,
+		?Register $register,
+		string $name,
+		array $filter = [],
+	): ?array {
+		if ($register === null) {
+			return null;
+		}
+
+		try {
+			return $this->aggregationRunner->run(
+				registerRef: (string)$register->getSlug(),
+				schemaRef: (string)$schema->getSlug(),
+				name: $name,
+				extraFilter: $filter
+			);
+		} catch (NotAuthorizedException $e) {
+			throw new Error($e->getMessage());
+		} catch (RuntimeException $e) {
+			// An unknown name, an unusable spec, or an unsupported filter
+			// operator. Surfaced as a GraphQL field error so the rest of the
+			// connection still resolves — the caller gets its rows and a named
+			// error, rather than a failed query with no data.
+			throw new Error($e->getMessage());
+		}
+	}//end resolveNamedAggregation()
 
 	/**
 	 * Resolve the optional `groupBy` argument by dispatching to
@@ -302,6 +371,9 @@ class GraphQLResolver {
 	 * @param Schema $schema The schema being aggregated.
 	 * @param Register|null $register The register (may be null if the schema isn't bound — defensive).
 	 * @param array $rawArgs The raw groupBy arg map from the GraphQL request.
+	 * @param array<string, mixed> $filter The list query's property filter, so the groups
+	 *                                     describe the same rows the edges do. Was hardcoded
+	 *                                     empty, which reported totals over the whole schema.
 	 *
 	 * @return array<int, array{key: string, value: int|float}>|null Bucket array, or null when register/runner missing.
 	 *
@@ -309,7 +381,12 @@ class GraphQLResolver {
 	 *
 	 * @spec openspec/specs/graphql-api/spec.md
 	 */
-	private function resolveGroupBy(Schema $schema, ?Register $register, array $rawArgs): ?array {
+	private function resolveGroupBy(
+		Schema $schema,
+		?Register $register,
+		array $rawArgs,
+		array $filter = [],
+	): ?array {
 		if ($register === null) {
 			// Defensive: a schema without a register has nothing to
 			// aggregate against. Return null so the field stays
@@ -327,7 +404,14 @@ class GraphQLResolver {
 			'to' => ($rawArgs['to'] ?? null),
 			'metric' => strtolower((string)($rawArgs['metric'] ?? 'count')),
 			'metricField' => ($rawArgs['metricField'] ?? null),
-			'filter' => [],
+			// THE QUERY'S OWN FILTER, not an empty array.
+			//
+			// This was hardcoded `[]`, so a filtered list returned group totals
+			// computed over the WHOLE schema: the edges honoured the filter and
+			// the groups silently did not. Nothing errored — the caller simply
+			// got a bigger number than the rows it was shown, which is the
+			// hardest kind of wrong answer to notice on a dashboard.
+			'filter' => $filter,
 		];
 
 		try {
@@ -692,6 +776,48 @@ class GraphQLResolver {
 	 *
 	 * @return array<string, mixed> The query array
 	 */
+
+	/**
+	 * The PROPERTY filter a list query carried, for reuse by its aggregation.
+	 *
+	 * Only `filter` — the property-value map. Deliberately NOT `search`,
+	 * `sort`, `first`/`offset` or `selfFilter`:
+	 *
+	 *  - paging must not reach the aggregation. A group total over "the first
+	 *    20 rows" is not a total, and it would change as the user paged;
+	 *  - `search` is a free-text relevance query the aggregation engine does
+	 *    not implement, so forwarding it would filter on a property named
+	 *    `_search` and match nothing — an empty result, not an error;
+	 *  - `selfFilter` addresses `@self` metadata columns, a different
+	 *    namespace from the schema properties the aggregation filters on.
+	 *
+	 * Anything omitted here means the groups describe a WIDER population than
+	 * the rows. That is the defect this method exists to fix, so each omission
+	 * above is a deliberate call and not an oversight.
+	 *
+	 * @param array<string, mixed> $args The GraphQL arguments.
+	 *
+	 * @return array<string, mixed> Property filters, or an empty array.
+	 *
+	 * @spec openspec/specs/graphql-api/spec.md
+	 */
+	private function propertyFilterFromArgs(array $args): array {
+		$filter = ($args['filter'] ?? null);
+		if (is_array($filter) === false) {
+			return [];
+		}
+
+		$out = [];
+		foreach ($filter as $field => $value) {
+			if (is_string($field) === false || $field === '') {
+				continue;
+			}
+
+			$out[$field] = $value;
+		}
+
+		return $out;
+	}//end propertyFilterFromArgs()
 
 	/**
 	 * Convert GraphQL args to HTTP request params format for ObjectService.buildSearchQuery().

--- a/lib/Service/GraphQL/SchemaGenerator/TypeMapperHandler.php
+++ b/lib/Service/GraphQL/SchemaGenerator/TypeMapperHandler.php
@@ -534,6 +534,24 @@ class TypeMapperHandler {
 						'type' => Type::listOf(Type::nonNull($this->getGroupBucketType())),
 						'description' => 'Ad-hoc bucket aggregation result; null unless `groupBy` was supplied.',
 					],
+					// JSON rather than a typed shape, deliberately.
+					//
+					// A declared aggregation's envelope varies with what it
+					// declares: a scalar `value`, a `values` map for `metrics`,
+					// `groups[].keys` for a composite groupBy, `joined` when it
+					// joins. Typing that today would either flatten it — the
+					// mistake GroupBucket already makes, where `value: Float!`
+					// cannot carry a values map and a null key coerces to "" —
+					// or invent a union per declaration shape.
+					//
+					// JSON keeps the envelope identical to the REST one, which
+					// every existing consumer already parses. A typed
+					// AggregationResult is the right next step once a consumer
+					// needs introspection over it.
+					'aggregation' => [
+						'type' => $this->scalars['JSON'],
+						'description' => 'Declared-aggregation result envelope; null unless `aggregation` was supplied.',
+					],
 				],
 			]
 		);
@@ -762,6 +780,24 @@ class TypeMapperHandler {
 			'groupBy' => [
 				'type' => $this->getGroupByInputType(),
 				'description' => 'Optional ad-hoc aggregation; when supplied, the connection emits a `groups` field.',
+			],
+			// A DECLARED aggregation, by name.
+			//
+			// `groupBy` above is ad-hoc: the caller describes the aggregation.
+			// This one names one the SCHEMA declares in
+			// `x-openregister-aggregations`, which until now was reachable only
+			// over REST — so a page wanting a declared figure had to hand-build
+			// a URL alongside its GraphQL query.
+			//
+			// The name is the whole input: the declaration already carries the
+			// metric, grouping, filter and join, and has been validated at save
+			// time. The query's own `filter` is applied on top as a NARROWING
+			// constraint, which the engine accepts but can never use to relax
+			// what the declaration pins.
+			'aggregation' => [
+				'type' => Type::string(),
+				'description' => 'Name of a declared aggregation on this schema '
+					. '(x-openregister-aggregations); emits an `aggregation` field on the connection.',
 			],
 		];
 

--- a/tests/Unit/Service/GraphQL/GraphQLAggregationFilterTest.php
+++ b/tests/Unit/Service/GraphQL/GraphQLAggregationFilterTest.php
@@ -1,0 +1,287 @@
+<?php
+
+/**
+ * Unit tests for the filter a GraphQL list query hands to its aggregation.
+ *
+ * A list query may carry BOTH a `filter` and a `groupBy`. The rows it returns
+ * are filtered; the group totals must describe the same rows. They did not:
+ * resolveGroupBy() built its aggregation input with `'filter' => []` hardcoded,
+ * so a filtered list reported group totals computed over the WHOLE schema.
+ *
+ * Nothing errored. The caller was simply shown a bigger number than the rows it
+ * was given — the hardest kind of wrong answer to notice on a dashboard, and
+ * the reason these assertions look at the query handed to the runner rather
+ * than at whether a response came back.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\GraphQL
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * @spec openspec/specs/graphql-api/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\GraphQL;
+
+use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Service\Aggregation\AggregationQuery;
+use OCA\OpenRegister\Service\Aggregation\AggregationRunner;
+use OCA\OpenRegister\Service\Aggregation\TimeseriesRequestValidator;
+use OCA\OpenRegister\Service\GraphQL\GraphQLResolver;
+use OCA\OpenRegister\Service\Object\GetObject;
+use OCA\OpenRegister\Service\Object\PermissionHandler;
+use OCA\OpenRegister\Service\Object\RelationHandler;
+use OCA\OpenRegister\Service\PropertyRbacHandler;
+use OCA\OpenRegister\Service\Object\TranslationHandler;
+use OCA\OpenRegister\Service\ObjectService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * The property filter must reach the aggregation, not just the row list.
+ *
+ * @spec openspec/specs/graphql-api/spec.md
+ */
+final class GraphQLAggregationFilterTest extends TestCase {
+
+	/**
+	 * The AggregationQuery the runner was handed, captured for assertion.
+	 *
+	 * @var AggregationQuery|null
+	 */
+	private ?AggregationQuery $captured = null;
+
+	/**
+	 * Build a resolver whose AggregationRunner records the query it receives.
+	 *
+	 * @return GraphQLResolver The resolver under test.
+	 */
+	private function makeResolver(?AggregationRunner $runner = null): GraphQLResolver {
+		$objectService = $this->createMock(ObjectService::class);
+		$objectService->method('buildSearchQuery')->willReturn([]);
+		$objectService->method('searchObjectsPaginated')->willReturn(
+			['results' => [], 'total' => 0, 'limit' => 20, 'offset' => 0]
+		);
+
+		$permissionHandler = $this->createMock(PermissionHandler::class);
+		$permissionHandler->method('hasPermission')->willReturn(true);
+
+		$registerMapper = $this->createMock(RegisterMapper::class);
+		$register = new Register();
+		$register->setId(1);
+		$register->setSlug('finance');
+		// findRegisterForSchema() matches on the register's schema-id LIST, so
+		// a register without it resolves to null and the aggregation is skipped
+		// entirely — the tests below would then pass for the wrong reason.
+		$register->setSchemas([1]);
+		$registerMapper->method('findAll')->willReturn([$register]);
+
+		if ($runner === null) {
+			$runner = $this->createMock(AggregationRunner::class);
+			$runner->method('runAdhoc')->willReturnCallback(
+				function (Register $r, Schema $s, AggregationQuery $query): array {
+					$this->captured = $query;
+					return ['groups' => []];
+				}
+			);
+		}
+
+		return new GraphQLResolver(
+			$this->createMock(GetObject::class),
+			$objectService,
+			$permissionHandler,
+			$this->createMock(PropertyRbacHandler::class),
+			$this->createMock(RelationHandler::class),
+			$this->createMock(AuditTrailMapper::class),
+			$registerMapper,
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(TranslationHandler::class),
+			$runner,
+			new TimeseriesRequestValidator()
+		);
+	}
+
+	/**
+	 * A schema declaring the properties the queries below use.
+	 *
+	 * @return Schema The schema under test.
+	 */
+	private function makeSchema(): Schema {
+		$schema = new Schema();
+		$schema->setId(1);
+		$schema->setSlug('gl-line');
+		$schema->setProperties(
+			[
+				'accountNumber' => ['type' => 'string'],
+				'amount' => ['type' => 'number'],
+				'eliminationFlag' => ['type' => 'boolean'],
+			]
+		);
+		return $schema;
+	}
+
+	/**
+	 * REGRESSION: the list's property filter must reach the aggregation.
+	 *
+	 * Before the fix this asserts an empty filter — the groups were computed
+	 * over every row in the schema while the edges honoured
+	 * `eliminationFlag: false`.
+	 *
+	 * @return void
+	 */
+	public function testListFilterReachesTheAggregation(): void {
+		$this->makeResolver()->resolveList(
+			schema: $this->makeSchema(),
+			root: null,
+			args: [
+				'filter' => ['eliminationFlag' => false],
+				'groupBy' => [
+					'field' => 'accountNumber',
+					'metric' => 'SUM',
+					'metricField' => 'amount',
+				],
+			]
+		);
+
+		self::assertNotNull($this->captured, 'the aggregation runner was never reached');
+		self::assertSame(
+			['eliminationFlag' => false],
+			$this->captured->filter,
+			'the groups must describe the same rows the edges do'
+		);
+	}
+
+	/**
+	 * An unfiltered list still aggregates over everything.
+	 *
+	 * Without this the test above could pass by always forwarding something.
+	 *
+	 * @return void
+	 */
+	public function testUnfilteredListAggregatesOverEverything(): void {
+		$this->makeResolver()->resolveList(
+			schema: $this->makeSchema(),
+			root: null,
+			args: [
+				'groupBy' => [
+					'field' => 'accountNumber',
+					'metric' => 'SUM',
+					'metricField' => 'amount',
+				],
+			]
+		);
+
+		self::assertNotNull($this->captured);
+		self::assertSame([], $this->captured->filter);
+	}
+
+	/**
+	 * A DECLARED aggregation is reachable by name, with the query's filter
+	 * passed as a narrowing constraint.
+	 *
+	 * Until now these were REST-only, so a page wanting a declared figure had
+	 * to hand-build a URL alongside its GraphQL query.
+	 *
+	 * @return void
+	 */
+	public function testDeclaredAggregationIsReachableByName(): void {
+		$seen = [];
+		$runner = $this->createMock(AggregationRunner::class);
+		$runner->method('run')->willReturnCallback(
+			function (
+				string $registerRef,
+				string $schemaRef,
+				string $name,
+				bool $bypassRbac = false,
+				array $parentRow = [],
+				array $extraFilter = [],
+			) use (&$seen): array {
+				$seen = compact('registerRef', 'schemaRef', 'name', 'extraFilter');
+				return ['name' => $name, 'metric' => 'sum', 'groups' => []];
+			}
+		);
+
+		$result = $this->makeResolver(runner: $runner)->resolveList(
+			schema: $this->makeSchema(),
+			root: null,
+			args: [
+				'filter' => ['eliminationFlag' => false],
+				'aggregation' => 'consolidatedTrialBalance',
+			]
+		);
+
+		self::assertSame('finance', $seen['registerRef']);
+		self::assertSame('gl-line', $seen['schemaRef']);
+		self::assertSame('consolidatedTrialBalance', $seen['name']);
+		self::assertSame(
+			['eliminationFlag' => false],
+			$seen['extraFilter'],
+			'the query filter must narrow the declared aggregation'
+		);
+		self::assertSame('consolidatedTrialBalance', $result['aggregation']['name']);
+
+	}//end testDeclaredAggregationIsReachableByName()
+
+	/**
+	 * Without the argument, no declared aggregation runs and the connection
+	 * carries no `aggregation` field.
+	 *
+	 * @return void
+	 */
+	public function testNoDeclaredAggregationWithoutTheArgument(): void {
+		$runner = $this->createMock(AggregationRunner::class);
+		$runner->expects(self::never())->method('run');
+
+		$result = $this->makeResolver(runner: $runner)->resolveList(
+			schema: $this->makeSchema(),
+			root: null,
+			args: ['filter' => ['eliminationFlag' => false]]
+		);
+
+		self::assertArrayNotHasKey('aggregation', $result);
+
+	}//end testNoDeclaredAggregationWithoutTheArgument()
+
+	/**
+	 * Paging and free-text search MUST NOT reach the aggregation.
+	 *
+	 * A group total over "the first 20 rows" is not a total, and it would change
+	 * as the user paged. `search` is a relevance query the aggregation engine
+	 * does not implement — forwarding it would filter on a property named
+	 * `_search`, match nothing, and return an empty result rather than an error.
+	 *
+	 * @return void
+	 */
+	public function testPagingAndSearchDoNotReachTheAggregation(): void {
+		$this->makeResolver()->resolveList(
+			schema: $this->makeSchema(),
+			root: null,
+			args: [
+				'first' => 5,
+				'offset' => 10,
+				'search' => 'rent',
+				'filter' => ['eliminationFlag' => false],
+				'groupBy' => [
+					'field' => 'accountNumber',
+					'metric' => 'SUM',
+					'metricField' => 'amount',
+				],
+			]
+		);
+
+		self::assertNotNull($this->captured);
+		self::assertSame(['eliminationFlag' => false], $this->captured->filter);
+	}
+}//end class


### PR DESCRIPTION
Two changes to the GraphQL aggregation surface, from investigating how the
recent engine work (composite groupBy, `metrics[]`, conditional metrics, joins,
narrowing filters) meets GraphQL.

## 1. 🔴 A filtered list returned unfiltered group totals

`resolveList()` maps the query's `filter` into the row list.
`resolveGroupBy()` built its aggregation input with **`'filter' => []` hardcoded**
— so the edges honoured the filter and the groups silently did not.

```graphql
gLLines(filter: {eliminationFlag: false},
        groupBy: {field: "accountNumber", metric: SUM, metricField: "amount"}) {
  edges { node { amount } }   # filtered
  groups { key value }        # NOT filtered — every GLLine
}
```

Nothing errored. The caller was shown a **bigger number than the rows it was
given** — the hardest kind of wrong answer to notice on a dashboard, and
launchpad widgets read these over runtime GraphQL.

### Only the property filter forwards, and the omissions are deliberate

| not forwarded | why |
|---|---|
| `first` / `offset` | a total over "the first 20 rows" is not a total, and it would change as the user pages |
| `search` | a relevance query the aggregation engine does not implement — forwarding it would filter on a property named `_search`, match nothing, and return an empty result rather than an error |
| `selfFilter` | addresses `@self` metadata, a different namespace from schema properties |

Anything left out means the groups describe a **wider** population than the rows,
which is the defect being fixed — so each omission is documented in the method
rather than left as an accident.

## 2. Declared aggregations are now reachable from GraphQL

`groupBy` is ad-hoc — the caller describes the aggregation. A schema's
`x-openregister-aggregations` were **REST-only**, so a page wanting a declared
figure had to hand-build a URL alongside its GraphQL query.

```graphql
gLLines(filter: {eliminationFlag: false}, aggregation: "consolidatedTrialBalance") {
  edges { node { amount } }
  aggregation          # JSON envelope, identical to REST
}
```

The **name is the whole input**: the declaration already carries the metric,
grouping, filter and join, and was validated at save time. The query's filter is
passed as a **narrowing** constraint — safe by construction, since #2852 refuses
any request key the declaration already pins, so a caller can add a constraint
and can never relax a declared tenant scope.

### Why JSON and not a typed result

A declared aggregation's envelope varies with what it declares: a scalar `value`,
a `values` map for `metrics`, `groups[].keys` for a composite groupBy, `joined`
when it joins.

Typing it now would repeat the mistake `GroupBucket` already makes — `value:
Float!` cannot carry a values map, and a null group key coerces to `""`,
indistinguishable from a genuine empty key. JSON keeps the envelope identical to
the REST one that every existing consumer already parses. A typed
`AggregationResult` is the right next step once a consumer needs introspection
over it.

## What GraphQL still cannot express

Recorded here so it is a known boundary rather than a surprise: composite
`groupBy`, `metrics[]`, and per-metric `condition`/`as` remain ad-hoc-unreachable,
because `GroupBucket { key: String!, value: Float! }` cannot carry the engine's
`keys`/`values` maps. Declared aggregations using them are reachable via
`aggregation(name:)` above, which returns the full envelope.

## Verified

- **17520 tests, 0 failures**; `phpcs` 0 errors; `phpmd` clean
- the filter fix has a **must-fail control**: reverting it reddens the two
  filtered tests while `testUnfilteredListAggregatesOverEverything` correctly
  stays green — so the non-discriminating control does not discriminate
- 5 new tests: filter reaches the aggregation, unfiltered stays unfiltered,
  paging/search do not leak in, declared aggregation resolves by name with the
  narrowing filter, and no declared aggregation runs without the argument
