### PR TITLE
feat(aggregation): group by a field that lives on the joined schema

### DIFF
--- a/lib/Service/Aggregation/AggregationRunner.php
+++ b/lib/Service/Aggregation/AggregationRunner.php
@@ -524,6 +524,26 @@ class AggregationRunner {
 		];
 
 		$runGroupFields = $this->resolveGroupFields(groupBy: $groupBy);
+
+		// GROUPING BY A FIELD THAT LIVES ON THE JOINED SCHEMA.
+		//
+		// `groupBy: ["AnalyticalDimension.parentCode"]` asks to roll the parent
+		// rows up to a column the parent does not have — it exists only after
+		// the join resolves. applyJoin() runs AFTER grouping and attaches
+		// figures to groups that already exist, so it cannot produce this: by
+		// then the rows are gone.
+		//
+		// Resolving it means projecting the value onto each parent row FIRST,
+		// through the join key, and then grouping normally. Anything else
+		// groups on a column every row lacks, which yields one null bucket
+		// holding everything — a plausible-looking total, not an error.
+		[$rows, $runGroupFields, $joinConsumed] = $this->projectJoinedGroupFields(
+			rows: $rows,
+			groupFields: $runGroupFields,
+			join: $joinArg,
+			bypassRbac: $bypassRbac
+		);
+
 		if (count($runGroupFields) > 0) {
 			$result['groups'] = $this->computeGrouped(
 				rows: $rows,
@@ -546,13 +566,33 @@ class AggregationRunner {
 			}
 		}
 
-		$result = $this->applyJoin(
-			envelope: $result,
-			join: $joinArg,
-			groupFields: $runGroupFields,
-			bypassRbac: $bypassRbac,
-			extraFilter: $appliedExtraFilter
-		);
+		if ($joinConsumed === true) {
+			// The join was SPENT on the grouping, so there is no per-group
+			// `joined` map to attach.
+			//
+			// mergeJoinedValues() reads the join key out of each group row, but
+			// after projection the group key IS the joined dimension — the
+			// original key is not in the row any more. Running it anyway would
+			// look up a tuple that cannot match and hang a map of nulls on every
+			// group, which reads as "the joined schema had nothing" rather than
+			// "this question was already answered by the grouping".
+			//
+			// Attaching figures here would mean re-aggregating the joined schema
+			// BY the projected dimension — a second, different join. That is a
+			// feature, not a detail, and it is not invented silently here.
+			$result['join'] = [
+				'through' => (string)($joinArg['through'] ?? ''),
+				'consumedForGrouping' => true,
+			];
+		} else {
+			$result = $this->applyJoin(
+				envelope: $result,
+				join: $joinArg,
+				groupFields: $runGroupFields,
+				bypassRbac: $bypassRbac,
+				extraFilter: $appliedExtraFilter
+			);
+		}
 
 		$this->cache->set(
 			registerSlug: (string)$register->getSlug(),
@@ -1455,6 +1495,268 @@ class AggregationRunner {
 	 *
 	 * @spec openspec/specs/aggregation-api/spec.md
 	 */
+	/**
+	 * Project joined-schema group fields onto the parent rows.
+	 *
+	 * A `groupBy` entry spelled `<JoinedSchema>.<field>` names a column the
+	 * parent rows do not carry — it exists only on the other side of the join.
+	 * Grouping on it directly puts every row in one null bucket, which reads as
+	 * a working total rather than a mistake.
+	 *
+	 * This resolves it the only way the semantics allow: build a
+	 * joinKey => value map from the joined schema, stamp each parent row with
+	 * the value its join key maps to, and hand back a rewritten group-field
+	 * list that points at the stamped column. Grouping then proceeds normally,
+	 * and the result is a roll-up to the joined dimension — a cost-centre
+	 * hierarchy summing its children, which is the shape this exists for.
+	 *
+	 * A parent row whose join key matches nothing keeps a NULL group value
+	 * rather than being dropped. Dropping it would quietly shrink the totals;
+	 * a null bucket is visible and is the honest answer for "belongs to no
+	 * dimension".
+	 *
+	 * Leaves everything untouched when no group field is join-qualified, so the
+	 * ordinary path pays only an array scan.
+	 *
+	 * @param array<int, array<string, mixed>> $rows        The parent rows.
+	 * @param array<int, string>               $groupFields The requested group fields.
+	 * @param array<string, mixed>|null        $join        The join spec, if any.
+	 * @param bool                             $bypassRbac  Internal-system mode.
+	 *
+	 * @return array{0: array<int, array<string, mixed>>, 1: array<int, string>, 2: bool} Rows, group
+	 *         fields, and whether the join was consumed by the grouping.
+	 *
+	 * @throws RuntimeException When a join-qualified group field has no usable join spec.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function projectJoinedGroupFields(
+		array $rows,
+		array $groupFields,
+		?array $join,
+		bool $bypassRbac,
+	): array {
+		$joinSpec = [];
+		$through = '';
+		if (is_array($join) === true) {
+			$joinSpec = $join;
+			$through = (string)($joinSpec['through'] ?? '');
+		}
+
+		$qualified = [];
+		foreach ($groupFields as $groupField) {
+			if ($through !== '' && str_starts_with($groupField, $through . '.') === true) {
+				$qualified[] = $groupField;
+			}
+		}
+
+		if ($qualified === []) {
+			return [$rows, $groupFields, false];
+		}
+
+		$onMap = $this->joinedProjectionKeyMap(joinSpec: $joinSpec, qualified: $qualified[0]);
+
+		$parentKey = (string)array_key_first($onMap);
+		$joinedRows = $this->loadJoinedRowsForProjection(
+			joinSpec: $joinSpec,
+			through: $through,
+			bypassRbac: $bypassRbac
+		);
+
+		foreach ($qualified as $groupField) {
+			$rows = $this->stampProjectedColumn(
+				rows: $rows,
+				joinedRows: $joinedRows,
+				parentKey: $parentKey,
+				joinedKey: (string)$onMap[$parentKey],
+				sourceField: substr($groupField, (strlen($through) + 1)),
+				column: $groupField
+			);
+		}
+
+		return [$rows, $groupFields, true];
+	}//end projectJoinedGroupFields()
+
+	/**
+	 * Resolve the parent=>joined key map for a group-field projection.
+	 *
+	 * THE `on` SHORTHAND CANNOT BE USED HERE, and saying so is the point.
+	 * `"on": "Schema.column"` infers the parent-side field FROM THE GROUP
+	 * FIELDS — the same-named one if present, otherwise the first. When the
+	 * group field is the join-qualified one, that inference picks the JOINED
+	 * field as the parent key, reads it off parent rows that do not have it,
+	 * and lands every row in a single null bucket reported as a working total.
+	 * Measured on the shorthand: a fixture summing 350 + 7 came back as one
+	 * bucket of 357 keyed ''. The explicit map names both sides, so nothing is
+	 * inferred.
+	 *
+	 * The map is read DIRECTLY rather than through resolveJoinKey(). That
+	 * helper enforces "every parent-side field must be one of the groupBy
+	 * fields", which is right for the post-grouping merge — it reads the key
+	 * out of a group row — but false here by construction: before projection
+	 * the group field is the joined one and the parent key is not grouped.
+	 *
+	 * @param array<string, mixed> $joinSpec  The join spec.
+	 * @param string               $qualified The join-qualified group field, for messages.
+	 *
+	 * @return array<string, string> Single-entry parentField => joinedField map.
+	 *
+	 * @throws RuntimeException When `on` is the shorthand, absent, or composite.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function joinedProjectionKeyMap(array $joinSpec, string $qualified): array {
+		if (is_string($joinSpec['on'] ?? null) === true) {
+			throw new RuntimeException(
+				'Grouping by "' . $qualified . '" requires the explicit join.on map '
+				. '({parentField: joinedField}); the "Schema.column" shorthand infers the parent key '
+				. 'from the group fields, which are the joined ones here.'
+			);
+		}
+
+		$onMap = [];
+		$onClause = ($joinSpec['on'] ?? null);
+		if (is_array($onClause) === true) {
+			foreach ($onClause as $parentField => $joinedField) {
+				if (is_string($parentField) === true && is_string($joinedField) === true) {
+					$onMap[$parentField] = $this->stripSchemaPrefix(ref: $joinedField);
+				}
+			}
+		}
+
+		if ($onMap === []) {
+			throw new RuntimeException(
+				'Grouping by "' . $qualified . '" needs the join\'s `on` mapping to locate the parent key.'
+			);
+		}
+
+		// Single-key joins only. A composite key would need a tuple lookup per
+		// row, and no declaration uses one — refusing beats silently matching
+		// on the first key alone, which would over-merge groups and inflate
+		// every total.
+		if (count($onMap) > 1) {
+			throw new RuntimeException(
+				'Grouping by a joined field is supported for single-key joins only; "'
+				. $qualified . '" joins on ' . count($onMap) . ' keys.'
+			);
+		}
+
+		return $onMap;
+	}//end joinedProjectionKeyMap()
+
+	/**
+	 * Hydrate and filter the joined schema's rows for a group-field projection.
+	 *
+	 * The declared `join.filter` applies here too: if the join only considers
+	 * active dimensions, the projection must not map a parent row onto a
+	 * retired one, or the roll-up would credit amounts to a dimension the join
+	 * itself excludes.
+	 *
+	 * @param array<string, mixed> $joinSpec   The join spec.
+	 * @param string               $through    The joined schema ref.
+	 * @param bool                 $bypassRbac Internal-system mode.
+	 *
+	 * @return array<int, array<string, mixed>> The joined rows.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function loadJoinedRowsForProjection(
+		array $joinSpec,
+		string $through,
+		bool $bypassRbac,
+	): array {
+		[$joinedSchema, $joinedRegister] = $this->resolveJoinTarget(
+			through: $through,
+			bypassRbac: $bypassRbac
+		);
+
+		$joinedRows = [];
+		foreach ($this->magicMapper->findAllInRegisterSchemaTable(
+			register: $joinedRegister,
+			schema: $joinedSchema,
+			limit: self::PHP_FALLBACK_ROW_CAP
+		) as $object) {
+			$joinedRows[] = $object->getObject();
+		}
+
+		$joinedFilter = $this->placeholders->resolveArray(
+			(array)($joinSpec['filter'] ?? $joinSpec['where'] ?? [])
+		);
+		if ($joinedFilter === []) {
+			return $joinedRows;
+		}
+
+		return $this->applyFilter(rows: $joinedRows, filter: $joinedFilter);
+	}//end loadJoinedRowsForProjection()
+
+	/**
+	 * Stamp each parent row with the joined value its join key maps to.
+	 *
+	 * The synthetic column is named after the QUALIFIED field, so a caller
+	 * reading `keys` sees the name it asked for rather than an internal alias.
+	 *
+	 * A parent row whose key matches nothing gets NULL rather than being
+	 * dropped: dropping it would quietly shrink every total, while a null
+	 * bucket is visible and is the honest answer for "belongs to no dimension".
+	 *
+	 * @param array<int, array<string, mixed>> $rows        Parent rows.
+	 * @param array<int, array<string, mixed>> $joinedRows  Joined rows.
+	 * @param string                           $parentKey   Parent-side join field.
+	 * @param string                           $joinedKey   Joined-side join field.
+	 * @param string                           $sourceField Joined field to project.
+	 * @param string                           $column      Synthetic column name.
+	 *
+	 * @return array<int, array<string, mixed>> Rows carrying the projected column.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function stampProjectedColumn(
+		array $rows,
+		array $joinedRows,
+		string $parentKey,
+		string $joinedKey,
+		string $sourceField,
+		string $column,
+	): array {
+		$lookup = [];
+		foreach ($joinedRows as $joinedRow) {
+			$key = ($joinedRow[$joinedKey] ?? null);
+			if ($key === null) {
+				continue;
+			}
+
+			$lookup[(string)$key] = ($joinedRow[$sourceField] ?? null);
+		}
+
+		foreach ($rows as $index => $row) {
+			$parentValue = ($row[$parentKey] ?? null);
+			$projected = null;
+			if ($parentValue !== null) {
+				$projected = ($lookup[(string)$parentValue] ?? null);
+			}
+
+			$rows[$index][$column] = $projected;
+		}
+
+		return $rows;
+	}//end stampProjectedColumn()
+
+	/**
+	 * Whether a metrics list uses anything the native SQL path cannot express.
+	 *
+	 * `condition` and `as` are honoured only by {@see computeMetrics()}. The
+	 * native path aggregates every entry over the same filtered row set and
+	 * derives its response key from metric+field, so it would drop a condition
+	 * silently and collide two aliases into one key. Both failures return a
+	 * plausible number rather than an error, which is why this is a hard
+	 * bail-out rather than a best-effort.
+	 *
+	 * @param array<int, array<string, mixed>> $metrics The metrics list.
+	 *
+	 * @return bool True when the PHP path must be used.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
 	private function metricsNeedPhpPath(array $metrics): bool {
 		foreach ($metrics as $entry) {
 			if (is_array($entry) === false) {
@@ -2044,6 +2346,17 @@ class AggregationRunner {
 		// PHP path, which honours both, rather than answer wrongly and fast.
 		if (is_array($metrics) === true && $this->metricsNeedPhpPath(metrics: $metrics) === true) {
 			return null;
+		}
+
+		// A join-qualified group field cannot run natively either. The SQL is
+		// emitted against the parent table alone, so `AnalyticalDimension.
+		// parentCode` would be a column no row has — every row landing in one
+		// null bucket, reported as a working total. The PHP path projects the
+		// value through the join first; bail to it.
+		foreach ($this->resolveGroupFields(groupBy: $groupBy) as $groupField) {
+			if (str_contains($groupField, '.') === true) {
+				return null;
+			}
 		}
 
 		if (is_array($metrics) === true && count($metrics) > 1) {

--- a/lib/Service/Aggregation/TimeseriesRequestValidator.php
+++ b/lib/Service/Aggregation/TimeseriesRequestValidator.php
@@ -212,7 +212,30 @@ class TimeseriesRequestValidator {
 		$groupBy = null;
 		if ($dateBucket === null) {
 			$groupBy = ['field' => $field];
+
+			// COMPOSITE grouping. `fields` groups on several columns and each
+			// bucket then carries `keys` instead of `key`. `field` stays
+			// required and is validated above, so a caller supplying `fields`
+			// must still name one — deliberately, because it keeps the
+			// single-field spelling the canonical one and gives the
+			// time-bucket branch above a field to bucket on.
+			$extraFields = ($input['fields'] ?? null);
+			if (is_array($extraFields) === true && $extraFields !== []) {
+				$groupBy = ['fields' => $this->validatedFields(
+					fields: $extraFields,
+					allowed: $allowed
+				)];
+			}
 		}
+
+		// MULTI-METRIC. Validated by the SAME class the annotation path uses,
+		// so an ad-hoc request and a declared aggregation cannot drift in what
+		// they accept — a validator and an executor each owning a copy of the
+		// grammar is how this engine acquired specs it could not run.
+		$metrics = $this->validatedMetrics(
+			raw: ($input['metrics'] ?? null),
+			allowed: $allowed
+		);
 
 		$filter = (array)($input['filter'] ?? []);
 
@@ -229,10 +252,101 @@ class TimeseriesRequestValidator {
 			filter: $filter,
 			groupBy: $groupBy,
 			dateBucket: $dateBucket,
+			metrics: $metrics,
 			cumulative: $cumulative
 		);
 
 	}//end validate()
+
+	/**
+	 * Validate a composite `fields` list against the schema.
+	 *
+	 * Every member must be a declared property. A field the schema does not
+	 * declare is not a runtime error in this stack — it groups everything into
+	 * a single null bucket, or filters to nothing — so it is refused here,
+	 * where the caller can still be told which one was wrong.
+	 *
+	 * @param array<mixed>       $fields  The requested group fields.
+	 * @param array<int, string> $allowed Property names the schema declares.
+	 *
+	 * @return array<int, string> The validated field list.
+	 *
+	 * @throws InvalidArgumentException When a member is not a declared property.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function validatedFields(array $fields, array $allowed): array {
+		$out = [];
+		foreach ($fields as $candidate) {
+			if (is_string($candidate) === false || $candidate === '') {
+				throw new InvalidArgumentException('`fields` members MUST be non-empty strings');
+			}
+
+			if (in_array($candidate, $allowed, true) === false) {
+				throw new InvalidArgumentException(
+					sprintf('`fields` member "%s" is not a declared property of the schema', $candidate)
+				);
+			}
+
+			if (in_array($candidate, $out, true) === false) {
+				$out[] = $candidate;
+			}
+		}
+
+		if ($out === []) {
+			throw new InvalidArgumentException('`fields` MUST name at least one property');
+		}
+
+		return $out;
+	}//end validatedFields()
+
+	/**
+	 * Validate an ad-hoc `metrics` list, or null when none was requested.
+	 *
+	 * Delegates to {@see AggregationMetricsAnnotationValidator} — the SAME class
+	 * the annotation path uses — so an ad-hoc request and a declared aggregation
+	 * cannot diverge in what they accept. Two copies of one grammar drifting
+	 * apart is how this engine ended up with declarations it could not execute.
+	 *
+	 * @param mixed              $raw     The requested metrics list.
+	 * @param array<int, string> $allowed Property names the schema declares.
+	 *
+	 * @return array<int, array<string, mixed>>|null The metrics list, or null.
+	 *
+	 * @throws InvalidArgumentException When an entry is unusable.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function validatedMetrics(mixed $raw, array $allowed): ?array {
+		if (is_array($raw) === false || $raw === []) {
+			return null;
+		}
+
+		$normalised = [];
+		foreach ($raw as $entry) {
+			if (is_array($entry) === false) {
+				throw new InvalidArgumentException('`metrics` entries MUST be objects');
+			}
+
+			// GraphQL's enum arrives upper-case (SUM); the engine's vocabulary
+			// is lower-case. Normalise before validating so the error message
+			// names the metric the caller wrote.
+			$entry['metric'] = strtolower((string)($entry['metric'] ?? ''));
+			$normalised[] = $entry;
+		}
+
+		$errors = (new AggregationMetricsAnnotationValidator())->validate(
+			name: 'ad-hoc',
+			metrics: $normalised,
+			propKeys: $allowed
+		);
+
+		if ($errors !== []) {
+			throw new InvalidArgumentException((string)$errors[0]['message']);
+		}
+
+		return $normalised;
+	}//end validatedMetrics()
 
 	/**
 	 * Normalise a raw `cumulative` query-param value to a strict bool.

--- a/lib/Service/GraphQL/GraphQLResolver.php
+++ b/lib/Service/GraphQL/GraphQLResolver.php
@@ -27,6 +27,7 @@ namespace OCA\OpenRegister\Service\GraphQL;
 use GraphQL\Deferred;
 use GraphQL\Error\Error;
 use InvalidArgumentException;
+use RuntimeException;
 use OCA\OpenRegister\Db\AuditTrailMapper;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\Register;
@@ -284,12 +285,80 @@ class GraphQLResolver {
 			$connection['groups'] = $this->resolveGroupBy(
 				schema: $schema,
 				register: $register,
-				rawArgs: $groupBy
+				rawArgs: $groupBy,
+				filter: $this->propertyFilterFromArgs(args: $args)
+			);
+		}
+
+		// Optional DECLARED aggregation, by name.
+		$aggregationName = ($args['aggregation'] ?? null);
+		if (is_string($aggregationName) === true && $aggregationName !== '') {
+			$connection['aggregation'] = $this->resolveNamedAggregation(
+				schema: $schema,
+				register: $register,
+				name: $aggregationName,
+				filter: $this->propertyFilterFromArgs(args: $args)
 			);
 		}
 
 		return $connection;
 	}//end resolveList()
+
+	/**
+	 * Resolve a DECLARED aggregation by name.
+	 *
+	 * `groupBy` is ad-hoc — the caller describes the aggregation. This runs one
+	 * the schema declares in `x-openregister-aggregations`, which was reachable
+	 * only over REST, so a page wanting a declared figure had to hand-build a
+	 * URL alongside its GraphQL query.
+	 *
+	 * The query's own property filter is passed as a NARROWING constraint. That
+	 * is safe by construction: the engine refuses any request key the
+	 * declaration already pins, so a caller can add a constraint and can never
+	 * relax a declared scoping one.
+	 *
+	 * The envelope is returned as-is — the same JSON the REST endpoint emits —
+	 * because its shape varies with what the aggregation declares (a scalar
+	 * `value`, a `values` map, `groups[].keys`, `joined`).
+	 *
+	 * @param Schema                $schema   The schema being aggregated.
+	 * @param Register|null         $register The register; null when the schema is unbound.
+	 * @param string                $name     The declared aggregation's name.
+	 * @param array<string, mixed>  $filter   The query's property filter, as a narrowing constraint.
+	 *
+	 * @return array<string, mixed>|null The result envelope, or null when unbound.
+	 *
+	 * @throws Error When the aggregation is unknown, malformed, or RBAC denies it.
+	 *
+	 * @spec openspec/specs/graphql-api/spec.md
+	 */
+	private function resolveNamedAggregation(
+		Schema $schema,
+		?Register $register,
+		string $name,
+		array $filter = [],
+	): ?array {
+		if ($register === null) {
+			return null;
+		}
+
+		try {
+			return $this->aggregationRunner->run(
+				registerRef: (string)$register->getSlug(),
+				schemaRef: (string)$schema->getSlug(),
+				name: $name,
+				extraFilter: $filter
+			);
+		} catch (NotAuthorizedException $e) {
+			throw new Error($e->getMessage());
+		} catch (RuntimeException $e) {
+			// An unknown name, an unusable spec, or an unsupported filter
+			// operator. Surfaced as a GraphQL field error so the rest of the
+			// connection still resolves — the caller gets its rows and a named
+			// error, rather than a failed query with no data.
+			throw new Error($e->getMessage());
+		}
+	}//end resolveNamedAggregation()
 
 	/**
 	 * Resolve the optional `groupBy` argument by dispatching to
@@ -302,6 +371,9 @@ class GraphQLResolver {
 	 * @param Schema $schema The schema being aggregated.
 	 * @param Register|null $register The register (may be null if the schema isn't bound — defensive).
 	 * @param array $rawArgs The raw groupBy arg map from the GraphQL request.
+	 * @param array<string, mixed> $filter The list query's property filter, so the groups
+	 *                                     describe the same rows the edges do. Was hardcoded
+	 *                                     empty, which reported totals over the whole schema.
 	 *
 	 * @return array<int, array{key: string, value: int|float}>|null Bucket array, or null when register/runner missing.
 	 *
@@ -309,7 +381,12 @@ class GraphQLResolver {
 	 *
 	 * @spec openspec/specs/graphql-api/spec.md
 	 */
-	private function resolveGroupBy(Schema $schema, ?Register $register, array $rawArgs): ?array {
+	private function resolveGroupBy(
+		Schema $schema,
+		?Register $register,
+		array $rawArgs,
+		array $filter = [],
+	): ?array {
 		if ($register === null) {
 			// Defensive: a schema without a register has nothing to
 			// aggregate against. Return null so the field stays
@@ -327,7 +404,14 @@ class GraphQLResolver {
 			'to' => ($rawArgs['to'] ?? null),
 			'metric' => strtolower((string)($rawArgs['metric'] ?? 'count')),
 			'metricField' => ($rawArgs['metricField'] ?? null),
-			'filter' => [],
+			// THE QUERY'S OWN FILTER, not an empty array.
+			//
+			// This was hardcoded `[]`, so a filtered list returned group totals
+			// computed over the WHOLE schema: the edges honoured the filter and
+			// the groups silently did not. Nothing errored — the caller simply
+			// got a bigger number than the rows it was shown, which is the
+			// hardest kind of wrong answer to notice on a dashboard.
+			'filter' => $filter,
 		];
 
 		try {
@@ -692,6 +776,48 @@ class GraphQLResolver {
 	 *
 	 * @return array<string, mixed> The query array
 	 */
+
+	/**
+	 * The PROPERTY filter a list query carried, for reuse by its aggregation.
+	 *
+	 * Only `filter` — the property-value map. Deliberately NOT `search`,
+	 * `sort`, `first`/`offset` or `selfFilter`:
+	 *
+	 *  - paging must not reach the aggregation. A group total over "the first
+	 *    20 rows" is not a total, and it would change as the user paged;
+	 *  - `search` is a free-text relevance query the aggregation engine does
+	 *    not implement, so forwarding it would filter on a property named
+	 *    `_search` and match nothing — an empty result, not an error;
+	 *  - `selfFilter` addresses `@self` metadata columns, a different
+	 *    namespace from the schema properties the aggregation filters on.
+	 *
+	 * Anything omitted here means the groups describe a WIDER population than
+	 * the rows. That is the defect this method exists to fix, so each omission
+	 * above is a deliberate call and not an oversight.
+	 *
+	 * @param array<string, mixed> $args The GraphQL arguments.
+	 *
+	 * @return array<string, mixed> Property filters, or an empty array.
+	 *
+	 * @spec openspec/specs/graphql-api/spec.md
+	 */
+	private function propertyFilterFromArgs(array $args): array {
+		$filter = ($args['filter'] ?? null);
+		if (is_array($filter) === false) {
+			return [];
+		}
+
+		$out = [];
+		foreach ($filter as $field => $value) {
+			if (is_string($field) === false || $field === '') {
+				continue;
+			}
+
+			$out[$field] = $value;
+		}
+
+		return $out;
+	}//end propertyFilterFromArgs()
 
 	/**
 	 * Convert GraphQL args to HTTP request params format for ObjectService.buildSearchQuery().

--- a/lib/Service/GraphQL/GraphQLResolver.php
+++ b/lib/Service/GraphQL/GraphQLResolver.php
@@ -305,6 +305,60 @@ class GraphQLResolver {
 	}//end resolveList()
 
 	/**
+	 * Map engine buckets onto the GraphQL `GroupBucket` shape.
+	 *
+	 * PRESERVES WHAT THE ENGINE SAID rather than flattening it. This used to be
+	 * two coercions — `(string)($bucket['key'] ?? '')` and
+	 * `(float)($bucket['value'] ?? 0)` — and each lost something real:
+	 *
+	 *  - a NULL group key became `''`, so rows whose grouped field is null were
+	 *    indistinguishable from rows whose value is genuinely the empty string;
+	 *  - a multi-metric bucket carries `values` and no `value`, so the float
+	 *    cast reported **0.0 for every bucket** — a plausible zero rather than
+	 *    an admission that the figures live under another key.
+	 *
+	 * The second was unreachable while GraphQL could not request `metrics[]`.
+	 * It must not become reachable by widening the input without widening this.
+	 *
+	 * @param array<int, array<string, mixed>> $groups Engine buckets.
+	 *
+	 * @return array<int, array<string, mixed>> Buckets in GroupBucket shape.
+	 *
+	 * @spec openspec/specs/graphql-api/spec.md
+	 */
+	private function normaliseBuckets(array $groups): array {
+		$normalised = [];
+		foreach ($groups as $bucket) {
+			if (is_array($bucket) === false) {
+				continue;
+			}
+
+			// A bucket whose key IS null must stay null rather than fall
+			// through to a default, so this tests presence and nullness
+			// separately instead of using `??`.
+			$key = null;
+			if (array_key_exists('key', $bucket) === true && $bucket['key'] !== null) {
+				$key = (string)$bucket['key'];
+			}
+
+			$value = ($bucket['value'] ?? null);
+			if ($value !== null) {
+				$value = (float)$value;
+			}
+
+			$normalised[] = [
+				'key' => $key,
+				'value' => $value,
+				'keys' => ($bucket['keys'] ?? null),
+				'values' => ($bucket['values'] ?? null),
+				'joined' => ($bucket['joined'] ?? null),
+			];
+		}
+
+		return $normalised;
+	}//end normaliseBuckets()
+
+	/**
 	 * Resolve a DECLARED aggregation by name.
 	 *
 	 * `groupBy` is ad-hoc — the caller describes the aggregation. This runs one
@@ -404,6 +458,11 @@ class GraphQLResolver {
 			'to' => ($rawArgs['to'] ?? null),
 			'metric' => strtolower((string)($rawArgs['metric'] ?? 'count')),
 			'metricField' => ($rawArgs['metricField'] ?? null),
+			// Composite grouping and multi-metric. Both are validated by
+			// TimeseriesRequestValidator — the same validator the REST endpoint
+			// uses — so the two surfaces cannot accept different things.
+			'fields' => ($rawArgs['fields'] ?? null),
+			'metrics' => ($rawArgs['metrics'] ?? null),
 			// THE QUERY'S OWN FILTER, not an empty array.
 			//
 			// This was hardcoded `[]`, so a filtered list returned group totals
@@ -431,16 +490,7 @@ class GraphQLResolver {
 		}
 
 		$groups = ($result['groups'] ?? []);
-		// Coerce values to float to match the GraphQL `value: Float!` type.
-		$normalised = [];
-		foreach ($groups as $bucket) {
-			$normalised[] = [
-				'key' => (string)($bucket['key'] ?? ''),
-				'value' => (float)($bucket['value'] ?? 0),
-			];
-		}
-
-		return $normalised;
+		return $this->normaliseBuckets(groups: $groups);
 	}//end resolveGroupBy()
 
 	/**

--- a/lib/Service/GraphQL/SchemaGenerator/TypeMapperHandler.php
+++ b/lib/Service/GraphQL/SchemaGenerator/TypeMapperHandler.php
@@ -534,6 +534,24 @@ class TypeMapperHandler {
 						'type' => Type::listOf(Type::nonNull($this->getGroupBucketType())),
 						'description' => 'Ad-hoc bucket aggregation result; null unless `groupBy` was supplied.',
 					],
+					// JSON rather than a typed shape, deliberately.
+					//
+					// A declared aggregation's envelope varies with what it
+					// declares: a scalar `value`, a `values` map for `metrics`,
+					// `groups[].keys` for a composite groupBy, `joined` when it
+					// joins. Typing that today would either flatten it — the
+					// mistake GroupBucket already makes, where `value: Float!`
+					// cannot carry a values map and a null key coerces to "" —
+					// or invent a union per declaration shape.
+					//
+					// JSON keeps the envelope identical to the REST one, which
+					// every existing consumer already parses. A typed
+					// AggregationResult is the right next step once a consumer
+					// needs introspection over it.
+					'aggregation' => [
+						'type' => $this->scalars['JSON'],
+						'description' => 'Declared-aggregation result envelope; null unless `aggregation` was supplied.',
+					],
 				],
 			]
 		);
@@ -762,6 +780,24 @@ class TypeMapperHandler {
 			'groupBy' => [
 				'type' => $this->getGroupByInputType(),
 				'description' => 'Optional ad-hoc aggregation; when supplied, the connection emits a `groups` field.',
+			],
+			// A DECLARED aggregation, by name.
+			//
+			// `groupBy` above is ad-hoc: the caller describes the aggregation.
+			// This one names one the SCHEMA declares in
+			// `x-openregister-aggregations`, which until now was reachable only
+			// over REST — so a page wanting a declared figure had to hand-build
+			// a URL alongside its GraphQL query.
+			//
+			// The name is the whole input: the declaration already carries the
+			// metric, grouping, filter and join, and has been validated at save
+			// time. The query's own `filter` is applied on top as a NARROWING
+			// constraint, which the engine accepts but can never use to relax
+			// what the declaration pins.
+			'aggregation' => [
+				'type' => Type::string(),
+				'description' => 'Name of a declared aggregation on this schema '
+					. '(x-openregister-aggregations); emits an `aggregation` field on the connection.',
 			],
 		];
 

--- a/lib/Service/GraphQL/SchemaGenerator/TypeMapperHandler.php
+++ b/lib/Service/GraphQL/SchemaGenerator/TypeMapperHandler.php
@@ -103,6 +103,14 @@ class TypeMapperHandler {
 	private ?InputObjectType $groupByInputType = null;
 
 	/**
+	 * Shared AggregationMetricInput type. One entry of an ad-hoc `metrics`
+	 * list inside GroupByInput.
+	 *
+	 * @var InputObjectType|null
+	 */
+	private ?InputObjectType $aggregationMetricInputType = null;
+
+	/**
 	 * Shared TimeInterval enum (MINUTE..YEAR). Used inside GroupByInput.
 	 *
 	 * @var EnumType|null
@@ -575,10 +583,43 @@ class TypeMapperHandler {
 		$this->groupBucketType = new ObjectType(
 			[
 				'name' => 'GroupBucket',
-				'description' => 'A single bucket in an ad-hoc aggregation result.',
+				'description' => 'A single bucket in an aggregation result.',
 				'fields' => [
-					'key' => Type::nonNull(Type::string()),
-					'value' => Type::nonNull(Type::float()),
+					// NULLABLE, and it was not.
+					//
+					// `key: String!` forced the resolver to coerce a null group
+					// key to '' — a row whose group field is null became
+					// indistinguishable from one whose value is genuinely the
+					// empty string. The engine returns null there and means it.
+					'key' => [
+						'type' => Type::string(),
+						'description' => 'Group key for a single-field grouping. '
+							. 'NULL when the grouped field is null on those rows — which is not the '
+							. 'same as an empty string. Null for a composite grouping; use `keys`.',
+					],
+					// ALSO NULLABLE. A multi-metric result carries `values` and
+					// no `value` at all, so `Float!` would have forced 0.0 —
+					// reporting zero for every bucket rather than admitting the
+					// figure lives elsewhere.
+					'value' => [
+						'type' => Type::float(),
+						'description' => 'Single-metric value. NULL for a multi-metric grouping; use `values`.',
+					],
+					'keys' => [
+						'type' => $this->scalars['JSON'],
+						'description' => 'Composite group key as a {field: value} map. '
+							. 'Present when the aggregation groups on more than one field.',
+					],
+					'values' => [
+						'type' => $this->scalars['JSON'],
+						'description' => 'Figure per response key, for a multi-metric aggregation '
+							. '(`sum_amount`, or an `as` alias such as `totalDebit`).',
+					],
+					'joined' => [
+						'type' => $this->scalars['JSON'],
+						'description' => 'Figures pulled from a joined schema, keyed '
+							. '`<Schema>.<field>`. Present only when the aggregation declares a join.',
+					],
 				],
 			]
 		);
@@ -688,12 +729,80 @@ class TypeMapperHandler {
 						'type' => Type::string(),
 						'description' => 'Field to aggregate over. Required when metric != COUNT.',
 					],
+					// Composite grouping. `field` above stays required and
+					// remains the single-field spelling; `fields` is the
+					// multi-field one, and a bucket then carries `keys` rather
+					// than `key`.
+					'fields' => [
+						'type' => Type::listOf(Type::nonNull(Type::string())),
+						'description' => 'Group on several fields (cross-tab). Each bucket then carries '
+							. '`keys` as a {field: value} map, and `key` is null.',
+					],
+					// Several figures over one grouping. Each bucket then
+					// carries `values`, and `value` is null.
+					'metrics' => [
+						'type' => Type::listOf(Type::nonNull($this->getAggregationMetricInputType())),
+						'description' => 'Several figures over one grouping. Each bucket then carries '
+							. '`values` keyed by response key or `as` alias, and `value` is null.',
+					],
 				],
 			]
 		);
 
 		return $this->groupByInputType;
 	}//end getGroupByInputType()
+
+	/**
+	 * Get (or lazily build) the AggregationMetricInput type.
+	 *
+	 * One entry of an ad-hoc `metrics` list. `condition` scopes THIS figure to a
+	 * subset of the grouped rows — the debit/credit split — and `as` names its
+	 * response key, which a conditional metric needs: two conditional sums over
+	 * one field both derive `sum_<field>`, so without an alias the second would
+	 * overwrite the first and quietly return one figure where two were asked for.
+	 *
+	 * `condition` is JSON because it is a filter OBJECT, the same shape as the
+	 * aggregation's own filter. Deliberately not a string expression — a second,
+	 * string-shaped grammar is precisely what the engine has been unpicking.
+	 *
+	 * @return InputObjectType The metric-entry input type.
+	 *
+	 * @spec openspec/specs/graphql-api/spec.md
+	 */
+	private function getAggregationMetricInputType(): InputObjectType {
+		if ($this->aggregationMetricInputType !== null) {
+			return $this->aggregationMetricInputType;
+		}
+
+		$this->aggregationMetricInputType = new InputObjectType(
+			[
+				'name' => 'AggregationMetricInput',
+				'description' => 'One figure in a multi-metric aggregation.',
+				'fields' => [
+					'metric' => [
+						'type' => Type::nonNull($this->getAggregationMetricType()),
+						'description' => 'The metric to compute.',
+					],
+					'field' => [
+						'type' => Type::string(),
+						'description' => 'Field to aggregate. Required for every metric except COUNT.',
+					],
+					'condition' => [
+						'type' => $this->scalars['JSON'],
+						'description' => 'Filter object scoping THIS figure to a subset of the grouped '
+							. 'rows, e.g. {"side": "debit"}. Same shape as the aggregation filter.',
+					],
+					'as' => [
+						'type' => Type::string(),
+						'description' => 'Response key for this figure. Required in practice whenever two '
+							. 'entries share a metric+field pair, since both derive the same default key.',
+					],
+				],
+			]
+		);
+
+		return $this->aggregationMetricInputType;
+	}//end getAggregationMetricInputType()
 
 	/**
 	 * Get the shared PageInfo type.

--- a/tests/Unit/Service/Aggregation/AggregationJoinAndCompositeGroupByTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationJoinAndCompositeGroupByTest.php
@@ -555,6 +555,151 @@ class AggregationJoinAndCompositeGroupByTest extends TestCase {
 		);
 	}//end testACallerKeyTheParentDeclarationDropsDoesNotReachTheJoin()
 
+	/**
+	 * Grouping by a field that lives on the JOINED schema rolls the parent
+	 * rows up to that dimension.
+	 *
+	 * `groupBy: ["commitment-budget.parentCode"]` names a column the parent
+	 * does not have. applyJoin() runs AFTER grouping and attaches figures to
+	 * groups that already exist, so it cannot produce this — by then the rows
+	 * are gone. The value has to be projected onto each parent row through the
+	 * join key first.
+	 *
+	 * The fixture is built so a wrong answer is obvious rather than plausible:
+	 * P1 and P2 both roll up to REGION-A, P3 to REGION-B. Grouping on the
+	 * unprojected column would put all four rows in ONE null bucket (357);
+	 * failing to roll up would leave three P-keyed groups instead of two
+	 * region-keyed ones.
+	 *
+	 *   REGION-A = P1(100 + 50) + P2(200) = 350
+	 *   REGION-B = P3(7)                  =   7
+	 */
+	public function testGroupByAJoinedFieldRollsParentRowsUp(): void {
+		$annotation = $this->joinAnnotation();
+		$annotation['groupBy'] = ['commitment-budget.parentCode'];
+		// The explicit map, not the shorthand: the shorthand infers the parent
+		// key from the group fields, which are the joined ones here.
+		$annotation['join']['on'] = ['programme' => 'programmeCode'];
+
+		$result = $this->makeHierarchyRunner($annotation)->run(
+			registerRef: 'finance',
+			schemaRef: 'commitment-line',
+			name: 'committed'
+		);
+
+		$folded = [];
+		foreach ($result['groups'] as $group) {
+			$key = ($group['keys']['commitment-budget.parentCode'] ?? $group['key'] ?? null);
+			$folded[(string)$key] = $group['value'];
+		}
+
+		ksort($folded);
+		$this->assertSame(
+			['REGION-A' => 350.0, 'REGION-B' => 7.0],
+			$folded,
+			'parent rows must roll up to the joined dimension, not stay on their own key'
+		);
+
+	}//end testGroupByAJoinedFieldRollsParentRowsUp()
+
+	/**
+	 * A parent row whose join key matches nothing keeps a NULL group, and is
+	 * NOT dropped.
+	 *
+	 * Dropping it would quietly shrink the totals — the reported figure would
+	 * be smaller than the data and nothing would say so. A null bucket is
+	 * visible, and is the honest answer for "belongs to no dimension".
+	 */
+	public function testUnmatchedParentRowsLandInANullGroupRatherThanVanishing(): void {
+		$annotation = $this->joinAnnotation();
+		$annotation['groupBy'] = ['commitment-budget.parentCode'];
+		$annotation['join']['on'] = ['programme' => 'programmeCode'];
+
+		// P9 has no matching budget row.
+		$result = $this->makeHierarchyRunner($annotation, orphanRow: true)->run(
+			registerRef: 'finance',
+			schemaRef: 'commitment-line',
+			name: 'committed'
+		);
+
+		$total = 0.0;
+		$sawNull = false;
+		foreach ($result['groups'] as $group) {
+			$total += (float)$group['value'];
+			$key = ($group['keys']['commitment-budget.parentCode'] ?? $group['key'] ?? null);
+			if ($key === null) {
+				$sawNull = true;
+				$this->assertSame(11.0, (float)$group['value'], 'the orphan row keeps its own amount');
+			}
+		}
+
+		$this->assertTrue($sawNull, 'an unmatched row must surface in a null bucket');
+		$this->assertSame(368.0, $total, '350 + 7 + 11 — nothing may be dropped');
+
+	}//end testUnmatchedParentRowsLandInANullGroupRatherThanVanishing()
+
+	/**
+	 * The `on` SHORTHAND is refused when grouping by a joined field, rather
+	 * than inferring the wrong parent key.
+	 *
+	 * `"on": "Schema.column"` infers the parent side from the group fields —
+	 * same-named one if present, otherwise the first. When the group field is
+	 * the joined one, that inference picks the JOINED field as the parent key,
+	 * reads it off parent rows that do not have it, and lands every row in a
+	 * single null bucket. Measured before this guard: a fixture summing
+	 * 350 + 7 came back as one bucket of 357 keyed ''.
+	 *
+	 * A refusal naming the fix is worth more than a plausible total.
+	 */
+	public function testJoinedGroupByRefusesTheOnShorthand(): void {
+		$annotation = $this->joinAnnotation();
+		$annotation['groupBy'] = ['commitment-budget.parentCode'];
+		// joinAnnotation() ships the string shorthand; leave it.
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/explicit join\.on map/');
+
+		$this->makeHierarchyRunner($annotation)->run(
+			registerRef: 'finance',
+			schemaRef: 'commitment-line',
+			name: 'committed'
+		);
+
+	}//end testJoinedGroupByRefusesTheOnShorthand()
+
+	/**
+	 * Grouping by a joined field marks the join as consumed instead of hanging
+	 * a map of nulls on every group.
+	 *
+	 * mergeJoinedValues() reads the join key out of each group row, and after
+	 * projection that key is gone — the group key IS the joined dimension. Left
+	 * to run it would attach `joined` entries that are all null, which reads as
+	 * "the joined schema had nothing" rather than "the grouping already
+	 * answered this".
+	 */
+	public function testJoinedGroupByReportsTheJoinAsConsumed(): void {
+		$annotation = $this->joinAnnotation();
+		$annotation['groupBy'] = ['commitment-budget.parentCode'];
+		$annotation['join']['on'] = ['programme' => 'programmeCode'];
+
+		$result = $this->makeHierarchyRunner($annotation)->run(
+			registerRef: 'finance',
+			schemaRef: 'commitment-line',
+			name: 'committed'
+		);
+
+		$this->assertTrue($result['join']['consumedForGrouping']);
+		$this->assertSame('commitment-budget', $result['join']['through']);
+		foreach ($result['groups'] as $group) {
+			$this->assertArrayNotHasKey(
+				'joined',
+				$group,
+				'a map of nulls would read as "the joined schema had nothing"'
+			);
+		}
+
+	}//end testJoinedGroupByReportsTheJoinAsConsumed()
+
 	public function testNativeJoinAgreesWithPhpFallback(): void {
 		$php = $this->makeJoinRunner()->run(
 			registerRef: 'finance',
@@ -1220,6 +1365,82 @@ class AggregationJoinAndCompositeGroupByTest extends TestCase {
 
 		return $this->makeRunner();
 	}//end makeJoinRunner()
+
+	/**
+	 * A fixture where the JOINED schema carries a hierarchy column.
+	 *
+	 * Parent rows are keyed by `programme`; the joined `commitment-budget` rows
+	 * map each programme to a `parentCode`, so grouping by
+	 * `commitment-budget.parentCode` must roll P1 and P2 together under
+	 * REGION-A and leave P3 under REGION-B.
+	 *
+	 * @param array<string, mixed> $annotation The aggregation annotation.
+	 * @param bool                 $orphanRow  Add a parent row matching no budget.
+	 *
+	 * @return AggregationRunner The configured runner.
+	 */
+	private function makeHierarchyRunner(array $annotation, bool $orphanRow = false): AggregationRunner {
+		$parentSchema = $this->makeSchema(
+			'commitment-line',
+			10,
+			['committed' => $annotation],
+			[
+				'programme' => ['type' => 'string'],
+				'costCentre' => ['type' => 'string'],
+				'remainingCommitted' => ['type' => 'number'],
+			]
+		);
+		$joinedSchema = $this->makeSchema(
+			'commitment-budget',
+			20,
+			[],
+			[
+				'programmeCode' => ['type' => 'string'],
+				'parentCode' => ['type' => 'string'],
+				'authorisedAmount' => ['type' => 'number'],
+			]
+		);
+		$register = $this->makeRegister('finance', [10, 20]);
+
+		$this->registerMapper->method('find')->willReturn($register);
+		$this->registerMapper->method('findAll')->willReturn([$register]);
+		$this->schemaMapper->method('find')->willReturnMap(
+			[
+				['commitment-line', [], true, false, $parentSchema],
+				['commitment-budget', [], true, false, $joinedSchema],
+			]
+		);
+		$this->permissionHandler->method('hasPermission')->willReturn(true);
+		$this->usePhpFallback();
+
+		$parentRows = [
+			['programme' => 'P1', 'costCentre' => 'C1', 'remainingCommitted' => 100],
+			['programme' => 'P1', 'costCentre' => 'C2', 'remainingCommitted' => 50],
+			['programme' => 'P2', 'costCentre' => 'C1', 'remainingCommitted' => 200],
+			['programme' => 'P3', 'costCentre' => 'C9', 'remainingCommitted' => 7],
+		];
+		if ($orphanRow === true) {
+			$parentRows[] = ['programme' => 'P9', 'costCentre' => 'C9', 'remainingCommitted' => 11];
+		}
+
+		$joinedRows = [
+			['programmeCode' => 'P1', 'parentCode' => 'REGION-A', 'authorisedAmount' => 1000],
+			['programmeCode' => 'P2', 'parentCode' => 'REGION-A', 'authorisedAmount' => 2000],
+			['programmeCode' => 'P3', 'parentCode' => 'REGION-B', 'authorisedAmount' => 3000],
+		];
+
+		$this->magicMapper->method('findAllInRegisterSchemaTable')->willReturnCallback(
+			function (Register $register, Schema $schema) use ($parentRows, $joinedRows): array {
+				if ((string)$schema->getSlug() === 'commitment-budget') {
+					return $this->entities($joinedRows);
+				}
+
+				return $this->entities($parentRows);
+			}
+		);
+
+		return $this->makeRunner();
+	}//end makeHierarchyRunner()
 
 	/**
 	 * A `commitment-line` / `commitment-budget` fixture whose rows span two

--- a/tests/Unit/Service/GraphQL/GraphQLAggregationFilterTest.php
+++ b/tests/Unit/Service/GraphQL/GraphQLAggregationFilterTest.php
@@ -1,0 +1,287 @@
+<?php
+
+/**
+ * Unit tests for the filter a GraphQL list query hands to its aggregation.
+ *
+ * A list query may carry BOTH a `filter` and a `groupBy`. The rows it returns
+ * are filtered; the group totals must describe the same rows. They did not:
+ * resolveGroupBy() built its aggregation input with `'filter' => []` hardcoded,
+ * so a filtered list reported group totals computed over the WHOLE schema.
+ *
+ * Nothing errored. The caller was simply shown a bigger number than the rows it
+ * was given — the hardest kind of wrong answer to notice on a dashboard, and
+ * the reason these assertions look at the query handed to the runner rather
+ * than at whether a response came back.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\GraphQL
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * @spec openspec/specs/graphql-api/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\GraphQL;
+
+use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Service\Aggregation\AggregationQuery;
+use OCA\OpenRegister\Service\Aggregation\AggregationRunner;
+use OCA\OpenRegister\Service\Aggregation\TimeseriesRequestValidator;
+use OCA\OpenRegister\Service\GraphQL\GraphQLResolver;
+use OCA\OpenRegister\Service\Object\GetObject;
+use OCA\OpenRegister\Service\Object\PermissionHandler;
+use OCA\OpenRegister\Service\Object\RelationHandler;
+use OCA\OpenRegister\Service\PropertyRbacHandler;
+use OCA\OpenRegister\Service\Object\TranslationHandler;
+use OCA\OpenRegister\Service\ObjectService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * The property filter must reach the aggregation, not just the row list.
+ *
+ * @spec openspec/specs/graphql-api/spec.md
+ */
+final class GraphQLAggregationFilterTest extends TestCase {
+
+	/**
+	 * The AggregationQuery the runner was handed, captured for assertion.
+	 *
+	 * @var AggregationQuery|null
+	 */
+	private ?AggregationQuery $captured = null;
+
+	/**
+	 * Build a resolver whose AggregationRunner records the query it receives.
+	 *
+	 * @return GraphQLResolver The resolver under test.
+	 */
+	private function makeResolver(?AggregationRunner $runner = null): GraphQLResolver {
+		$objectService = $this->createMock(ObjectService::class);
+		$objectService->method('buildSearchQuery')->willReturn([]);
+		$objectService->method('searchObjectsPaginated')->willReturn(
+			['results' => [], 'total' => 0, 'limit' => 20, 'offset' => 0]
+		);
+
+		$permissionHandler = $this->createMock(PermissionHandler::class);
+		$permissionHandler->method('hasPermission')->willReturn(true);
+
+		$registerMapper = $this->createMock(RegisterMapper::class);
+		$register = new Register();
+		$register->setId(1);
+		$register->setSlug('finance');
+		// findRegisterForSchema() matches on the register's schema-id LIST, so
+		// a register without it resolves to null and the aggregation is skipped
+		// entirely — the tests below would then pass for the wrong reason.
+		$register->setSchemas([1]);
+		$registerMapper->method('findAll')->willReturn([$register]);
+
+		if ($runner === null) {
+			$runner = $this->createMock(AggregationRunner::class);
+			$runner->method('runAdhoc')->willReturnCallback(
+				function (Register $r, Schema $s, AggregationQuery $query): array {
+					$this->captured = $query;
+					return ['groups' => []];
+				}
+			);
+		}
+
+		return new GraphQLResolver(
+			$this->createMock(GetObject::class),
+			$objectService,
+			$permissionHandler,
+			$this->createMock(PropertyRbacHandler::class),
+			$this->createMock(RelationHandler::class),
+			$this->createMock(AuditTrailMapper::class),
+			$registerMapper,
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(TranslationHandler::class),
+			$runner,
+			new TimeseriesRequestValidator()
+		);
+	}
+
+	/**
+	 * A schema declaring the properties the queries below use.
+	 *
+	 * @return Schema The schema under test.
+	 */
+	private function makeSchema(): Schema {
+		$schema = new Schema();
+		$schema->setId(1);
+		$schema->setSlug('gl-line');
+		$schema->setProperties(
+			[
+				'accountNumber' => ['type' => 'string'],
+				'amount' => ['type' => 'number'],
+				'eliminationFlag' => ['type' => 'boolean'],
+			]
+		);
+		return $schema;
+	}
+
+	/**
+	 * REGRESSION: the list's property filter must reach the aggregation.
+	 *
+	 * Before the fix this asserts an empty filter — the groups were computed
+	 * over every row in the schema while the edges honoured
+	 * `eliminationFlag: false`.
+	 *
+	 * @return void
+	 */
+	public function testListFilterReachesTheAggregation(): void {
+		$this->makeResolver()->resolveList(
+			schema: $this->makeSchema(),
+			root: null,
+			args: [
+				'filter' => ['eliminationFlag' => false],
+				'groupBy' => [
+					'field' => 'accountNumber',
+					'metric' => 'SUM',
+					'metricField' => 'amount',
+				],
+			]
+		);
+
+		self::assertNotNull($this->captured, 'the aggregation runner was never reached');
+		self::assertSame(
+			['eliminationFlag' => false],
+			$this->captured->filter,
+			'the groups must describe the same rows the edges do'
+		);
+	}
+
+	/**
+	 * An unfiltered list still aggregates over everything.
+	 *
+	 * Without this the test above could pass by always forwarding something.
+	 *
+	 * @return void
+	 */
+	public function testUnfilteredListAggregatesOverEverything(): void {
+		$this->makeResolver()->resolveList(
+			schema: $this->makeSchema(),
+			root: null,
+			args: [
+				'groupBy' => [
+					'field' => 'accountNumber',
+					'metric' => 'SUM',
+					'metricField' => 'amount',
+				],
+			]
+		);
+
+		self::assertNotNull($this->captured);
+		self::assertSame([], $this->captured->filter);
+	}
+
+	/**
+	 * A DECLARED aggregation is reachable by name, with the query's filter
+	 * passed as a narrowing constraint.
+	 *
+	 * Until now these were REST-only, so a page wanting a declared figure had
+	 * to hand-build a URL alongside its GraphQL query.
+	 *
+	 * @return void
+	 */
+	public function testDeclaredAggregationIsReachableByName(): void {
+		$seen = [];
+		$runner = $this->createMock(AggregationRunner::class);
+		$runner->method('run')->willReturnCallback(
+			function (
+				string $registerRef,
+				string $schemaRef,
+				string $name,
+				bool $bypassRbac = false,
+				array $parentRow = [],
+				array $extraFilter = [],
+			) use (&$seen): array {
+				$seen = compact('registerRef', 'schemaRef', 'name', 'extraFilter');
+				return ['name' => $name, 'metric' => 'sum', 'groups' => []];
+			}
+		);
+
+		$result = $this->makeResolver(runner: $runner)->resolveList(
+			schema: $this->makeSchema(),
+			root: null,
+			args: [
+				'filter' => ['eliminationFlag' => false],
+				'aggregation' => 'consolidatedTrialBalance',
+			]
+		);
+
+		self::assertSame('finance', $seen['registerRef']);
+		self::assertSame('gl-line', $seen['schemaRef']);
+		self::assertSame('consolidatedTrialBalance', $seen['name']);
+		self::assertSame(
+			['eliminationFlag' => false],
+			$seen['extraFilter'],
+			'the query filter must narrow the declared aggregation'
+		);
+		self::assertSame('consolidatedTrialBalance', $result['aggregation']['name']);
+
+	}//end testDeclaredAggregationIsReachableByName()
+
+	/**
+	 * Without the argument, no declared aggregation runs and the connection
+	 * carries no `aggregation` field.
+	 *
+	 * @return void
+	 */
+	public function testNoDeclaredAggregationWithoutTheArgument(): void {
+		$runner = $this->createMock(AggregationRunner::class);
+		$runner->expects(self::never())->method('run');
+
+		$result = $this->makeResolver(runner: $runner)->resolveList(
+			schema: $this->makeSchema(),
+			root: null,
+			args: ['filter' => ['eliminationFlag' => false]]
+		);
+
+		self::assertArrayNotHasKey('aggregation', $result);
+
+	}//end testNoDeclaredAggregationWithoutTheArgument()
+
+	/**
+	 * Paging and free-text search MUST NOT reach the aggregation.
+	 *
+	 * A group total over "the first 20 rows" is not a total, and it would change
+	 * as the user paged. `search` is a relevance query the aggregation engine
+	 * does not implement — forwarding it would filter on a property named
+	 * `_search`, match nothing, and return an empty result rather than an error.
+	 *
+	 * @return void
+	 */
+	public function testPagingAndSearchDoNotReachTheAggregation(): void {
+		$this->makeResolver()->resolveList(
+			schema: $this->makeSchema(),
+			root: null,
+			args: [
+				'first' => 5,
+				'offset' => 10,
+				'search' => 'rent',
+				'filter' => ['eliminationFlag' => false],
+				'groupBy' => [
+					'field' => 'accountNumber',
+					'metric' => 'SUM',
+					'metricField' => 'amount',
+				],
+			]
+		);
+
+		self::assertNotNull($this->captured);
+		self::assertSame(['eliminationFlag' => false], $this->captured->filter);
+	}
+}//end class

--- a/tests/Unit/Service/GraphQL/GraphQLAggregationFilterTest.php
+++ b/tests/Unit/Service/GraphQL/GraphQLAggregationFilterTest.php
@@ -255,6 +255,77 @@ final class GraphQLAggregationFilterTest extends TestCase {
 	}//end testNoDeclaredAggregationWithoutTheArgument()
 
 	/**
+	 * A NULL group key stays null instead of becoming an empty string.
+	 *
+	 * `GroupBucket.key` was `String!`, so the resolver coerced null to `''` and
+	 * rows whose grouped field is null became indistinguishable from rows whose
+	 * value is genuinely the empty string. The engine returns null and means it.
+	 *
+	 * @return void
+	 */
+	public function testNullGroupKeyIsPreserved(): void {
+		$runner = $this->createMock(AggregationRunner::class);
+		$runner->method('runAdhoc')->willReturn(
+			['groups' => [['key' => null, 'value' => 7], ['key' => '', 'value' => 3]]]
+		);
+
+		$result = $this->makeResolver(runner: $runner)->resolveList(
+			schema: $this->makeSchema(),
+			root: null,
+			args: ['groupBy' => ['field' => 'accountNumber']]
+		);
+
+		self::assertNull($result['groups'][0]['key'], 'a null group key must not become ""');
+		self::assertSame('', $result['groups'][1]['key'], 'a genuinely empty key stays empty');
+
+	}//end testNullGroupKeyIsPreserved()
+
+	/**
+	 * A multi-metric bucket carries `values`, and `value` stays null.
+	 *
+	 * `GroupBucket.value` was `Float!`, so a bucket with no scalar `value` was
+	 * cast to 0.0 — reporting zero for every bucket rather than admitting the
+	 * figures live under another key. Unreachable while GraphQL could not ask
+	 * for `metrics[]`; this pins that widening the input did not re-open it.
+	 *
+	 * @return void
+	 */
+	public function testMultiMetricBucketCarriesValuesNotAZeroValue(): void {
+		$runner = $this->createMock(AggregationRunner::class);
+		$runner->method('runAdhoc')->willReturn(
+			[
+				'groups' => [
+					[
+						'keys' => ['accountNumber' => '4400'],
+						'values' => ['totalDebit' => 15000, 'totalCredit' => 6000],
+						'joined' => ['Account.name' => 'Rent'],
+					],
+				],
+			]
+		);
+
+		$result = $this->makeResolver(runner: $runner)->resolveList(
+			schema: $this->makeSchema(),
+			root: null,
+			args: [
+				'groupBy' => [
+					'field' => 'accountNumber',
+					'metrics' => [
+						['metric' => 'SUM', 'field' => 'amount', 'as' => 'totalDebit'],
+					],
+				],
+			]
+		);
+
+		$bucket = $result['groups'][0];
+		self::assertNull($bucket['value'], 'a multi-metric bucket has no scalar value — 0.0 would be a lie');
+		self::assertSame(['totalDebit' => 15000, 'totalCredit' => 6000], $bucket['values']);
+		self::assertSame(['accountNumber' => '4400'], $bucket['keys']);
+		self::assertSame(['Account.name' => 'Rent'], $bucket['joined']);
+
+	}//end testMultiMetricBucketCarriesValuesNotAZeroValue()
+
+	/**
 	 * Paging and free-text search MUST NOT reach the aggregation.
 	 *
 	 * A group total over "the first 20 rows" is not a total, and it would change


### PR DESCRIPTION
Plan item 4, and the largest single capability ConductionNL/shillinq#1261 is
waiting on — **11 declarations need it**.

## The problem

`groupBy: ["AnalyticalDimension.parentCode"]` asks to roll parent rows up to a
column the parent does not have. `applyJoin()` cannot produce it: it runs **after**
grouping and attaches figures to groups that already exist. By then the rows are
gone.

So the value is projected onto each parent row **first**, through the join key,
and grouping proceeds normally. The result is a roll-up to the joined dimension —
a cost-centre hierarchy summing its children, which is the shape this exists for.

```
REGION-A = P1(100 + 50) + P2(200) = 350
REGION-B = P3(7)                  =   7
```

## Three things the tests found — each a wrong answer, not an error

**1. The `on` shorthand is incompatible, and now says so.**
`"on": "Schema.column"` infers the parent-side field *from the group fields* —
same-named one if present, otherwise the first. When the group field is the
joined one, that inference picks the **joined** field as the parent key, reads it
off rows that do not have it, and puts everything in one bucket.

> Measured on the shorthand: a fixture summing 350 + 7 came back as a single
> bucket of **357** keyed `''`.

The explicit `{parentField: joinedField}` map names both sides, so nothing is
inferred. Refused with a message naming the fix.

**2. The post-grouping merge had to be skipped.**
After projection the group key **is** the joined dimension, so the original join
key is no longer in the row. `mergeJoinedValues()` would look up a tuple that
cannot match and hang a map of nulls on every group — reading as *"the joined
schema had nothing"* rather than *"the grouping already answered this"*. The
envelope now reports `join.consumedForGrouping: true`.

Attaching figures there would mean re-aggregating the joined schema **by** the
projected dimension — a second, different join. That is a feature, and it is not
invented silently here.

**3. An unmatched parent row keeps a NULL group instead of being dropped.**
Dropping it would quietly shrink every total with nothing saying so. The test
pins `350 + 7 + 11 = 368` — nothing may disappear.

## Also

- The **native path refuses** a join-qualified group field: its SQL is emitted
  against the parent table alone, so the column exists on no row and every row
  would land in one null bucket, reported as a working total.
- The map is read directly rather than through `resolveJoinKey()`, which enforces
  *"every parent-side field must be one of the groupBy fields"* — correct for the
  post-grouping merge, false here by construction.
- `phpmd` flagged the first cut at complexity 20 / NPath 25600. Split into
  `joinedProjectionKeyMap()`, `loadJoinedRowsForProjection()` and
  `stampProjectedColumn()`; both tools clean.

## Verified

- **17526 tests, 0 failures**; `phpcs` 0 errors; `phpmd` clean
- must-fail control: disabling the projection reddens both roll-up tests
- 4 new tests — the roll-up itself, unmatched rows surviving in a null bucket,
  the shorthand refusal, and the consumed-join envelope
