### PR TITLE
fix(federation): an installed flow must belong to the installer, not to nobody

### DIFF
--- a/lib/Service/Config/Types/FlowShareableConfigType.php
+++ b/lib/Service/Config/Types/FlowShareableConfigType.php
@@ -34,6 +34,7 @@ use OCA\OpenRegister\Db\Flow;
 use OCA\OpenRegister\Db\FlowMapper;
 use OCA\OpenRegister\Service\Config\IShareableConfigType;
 use OCA\OpenRegister\Service\Flow\FlowService;
+use OCP\AppFramework\Db\DoesNotExistException;
 use Throwable;
 
 /**
@@ -176,15 +177,37 @@ class FlowShareableConfigType implements IShareableConfigType {
 			$flow->setEdges((array)($portable['edges'] ?? []));
 			$flow->setLimits((array)($portable['limits'] ?? []));
 
-			// An imported flow lands DISABLED and OWNERLESS, whatever the
-			// bundle said. `owner` and `organisation` are not portable fields —
-			// they name an identity on the SENDING instance that means nothing
-			// here — and a flow with no owner cannot dispatch. So a bundle can
-			// never arrive and start executing against the receiving tenant's
-			// data before a local person has adopted it and switched it on.
+			// An imported flow lands DISABLED, whatever the bundle said, so a
+			// bundle can never arrive and start executing against the receiving
+			// tenant's data before a local person switches it on. `enabled`
+			// alone carries that property.
 			$flow->setEnabled(false);
-			$flow->setOwner(null);
-			$flow->setOrganisation(null);
+
+			// 🔴 OWNED BY THE INSTALLER, NOT BY NOBODY.
+			//
+			// This used to set owner and organisation to null, on the correct
+			// reasoning that the SENDER's identity means nothing here. But null
+			// is not the absence of the sender's identity — it is the absence of
+			// any, and `FlowMapper` scopes every read with
+			// `eq('organisation', …)`, which `NULL` can never satisfy. The row
+			// inserted, `install` returned its uuid, and the flow was invisible
+			// to index(), to find(), and to the run path, with no adopt route to
+			// rescue it. Five permanent orphans on one dev instance.
+			//
+			// `FlowService::flowToSave()` already refuses this exact write, in a
+			// comment describing this exact outcome — the rule was fixed on the
+			// create path and never reached this one. Both now read the same
+			// method, so there is one place that decides ownership.
+			['owner' => $owner, 'organisation' => $organisation] = $this->flows->callerOwnership();
+			if ($owner === null || $organisation === null) {
+				throw new DoesNotExistException(
+					'Installing a flow needs a signed-in owner and an active organisation; '
+					. 'refusing to store one that belongs to nobody — it could never be seen again.'
+				);
+			}
+
+			$flow->setOwner($owner);
+			$flow->setOrganisation($organisation);
 
 			$stored = $this->mapper->insert($flow);
 			$installed[] = (string)$stored->getUuid();

--- a/lib/Service/Flow/FlowService.php
+++ b/lib/Service/Flow/FlowService.php
@@ -305,8 +305,7 @@ class FlowService {
 			return $this->find(uuid: $uuid);
 		}
 
-		$owner = $this->actingUser();
-		$organisation = $this->activeOrganisation();
+		['owner' => $owner, 'organisation' => $organisation] = $this->callerOwnership();
 
 		// REFUSE rather than stamp nulls. `Flow::belongsTo()` is fail-closed on
 		// both sides, so a flow with no organisation belongs to nobody: it does
@@ -547,6 +546,28 @@ class FlowService {
 		// swallows for the opposite reason — one bad run must not stop a queue.
 		return $this->advancer->advance(run: $run, rethrow: true);
 	}//end run()
+
+	/**
+	 * The owner and organisation a flow written by THIS caller must carry.
+	 *
+	 * 🔴 PUBLIC BECAUSE IT HAS A SECOND WRITER. `flowToSave()` is not the only
+	 * path that inserts a Flow: `FlowShareableConfigType::deserialise()` writes
+	 * one when a federated bundle is installed, and it used to stamp nulls —
+	 * reproducing, on that path, the permanent orphan the refusal below exists
+	 * to prevent. Two writers each deriving ownership their own way is how the
+	 * rule came to hold on one of them and not the other; this is the one place
+	 * that decides it.
+	 *
+	 * @return array{owner: string|null, organisation: string|null} The caller's ownership, either field null when it does not resolve.
+	 *
+	 * @spec openspec/changes/flow-engine-unification/specs/flow-storage/spec.md
+	 */
+	public function callerOwnership(): array {
+		return [
+			'owner'        => $this->actingUser(),
+			'organisation' => $this->activeOrganisation(),
+		];
+	}//end callerOwnership()
 
 	/**
 	 * The acting user's uid, or null when there is no session.

--- a/tests/Unit/Service/Config/FlowShareableConfigTypeTest.php
+++ b/tests/Unit/Service/Config/FlowShareableConfigTypeTest.php
@@ -13,6 +13,7 @@ use OCA\OpenRegister\Db\Flow;
 use OCA\OpenRegister\Db\FlowMapper;
 use OCA\OpenRegister\Service\Config\Types\FlowShareableConfigType;
 use OCA\OpenRegister\Service\Flow\FlowService;
+use OCP\AppFramework\Db\DoesNotExistException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -33,6 +34,10 @@ class FlowShareableConfigTypeTest extends TestCase {
 	protected function setUp(): void {
 		$this->mapper = $this->createMock(FlowMapper::class);
 		$this->flows = $this->createMock(FlowService::class);
+		// deserialise() now REFUSES to store a flow that belongs to nobody, so
+		// every install test needs a caller. Individual tests override this.
+		$this->flows->method('callerOwnership')
+			->willReturn(['owner' => 'installer', 'organisation' => 'org-here']);
 		$this->type = new FlowShareableConfigType($this->mapper, $this->flows);
 	}//end setUp()
 
@@ -159,11 +164,22 @@ class FlowShareableConfigTypeTest extends TestCase {
 
 	/**
 	 * THE SECURITY PROPERTY. A bundle must not be able to arrive and start
-	 * executing against the receiving tenant's data. An imported flow lands
-	 * disabled and ownerless whatever the bundle claimed, and an ownerless flow
-	 * cannot dispatch.
+	 * executing against the receiving tenant's data, and it must not carry the
+	 * SENDER's identity into this instance.
+	 *
+	 * 🔴 THIS TEST USED TO REQUIRE THE DEFECT. It asserted the imported flow
+	 * landed OWNERLESS, which is how the orphan got in: `FlowMapper` scopes
+	 * every read with `eq('organisation', …)`, and NULL satisfies no equality,
+	 * so the row inserted, `install` returned its uuid, and nothing could ever
+	 * see the flow again. Five permanent orphans on one dev instance, and no
+	 * adopt route to rescue them.
+	 *
+	 * The security property survives intact, because it never depended on the
+	 * null: `canDispatch()` requires `enabled === true` AND an owner, so
+	 * `enabled = false` alone already refuses dispatch. What the null added was
+	 * not safety — it was unreachability.
 	 */
-	public function testAnImportedFlowLandsDisabledAndOwnerless(): void {
+	public function testAnImportedFlowLandsDisabledAndOwnedByTheInstaller(): void {
 		$captured = null;
 		$this->mapper->method('insert')->willReturnCallback(
 			function (Flow $flow) use (&$captured): Flow {
@@ -190,10 +206,37 @@ class FlowShareableConfigTypeTest extends TestCase {
 
 		$this->assertNotNull($captured);
 		$this->assertFalse((bool)$captured->getEnabled(), 'an imported flow must not arrive enabled');
-		$this->assertNull($captured->getOwner(), 'an imported flow must not adopt the sender\'s owner');
-		$this->assertNull($captured->getOrganisation());
 		$this->assertFalse($captured->canDispatch(), 'and it must therefore not be dispatchable');
-	}//end testAnImportedFlowLandsDisabledAndOwnerless()
+
+		// The sender's claim is rejected — that was always the point.
+		$this->assertNotSame('victim', $captured->getOwner(), 'the sender does not choose the owner');
+		$this->assertNotSame('their-org', $captured->getOrganisation());
+
+		// And the INSTALLER owns it, so it is visible to the person who
+		// installed it. Without this the flow is stored and unreachable.
+		$this->assertSame('installer', $captured->getOwner());
+		$this->assertSame('org-here', $captured->getOrganisation());
+	}//end testAnImportedFlowLandsDisabledAndOwnedByTheInstaller()
+
+	/**
+	 * 🔴 REFUSED, NOT STAMPED WITH NULLS. `FlowService::flowToSave()` already
+	 * refuses this exact write on the create path, in a comment describing this
+	 * exact outcome — "Accepting the write produced a permanent orphan and
+	 * reported success". The rule was fixed there and never reached this writer.
+	 */
+	public function testInstallRefusesWhenTheCallerHasNoOwnership(): void {
+		$flows = $this->createMock(FlowService::class);
+		$flows->method('callerOwnership')
+			->willReturn(['owner' => null, 'organisation' => null]);
+		$type = new FlowShareableConfigType($this->mapper, $flows);
+
+		$this->mapper->expects($this->never())->method('insert');
+		$this->expectException(DoesNotExistException::class);
+
+		$type->deserialise(
+			['flows' => [['name' => 'Orphan', 'trigger' => 'manual', 'nodes' => [], 'edges' => []]]]
+		);
+	}//end testInstallRefusesWhenTheCallerHasNoOwnership()
 
 	/**
 	 * A fresh id per import: two instances that both installed the same bundle


### PR DESCRIPTION
Refs #2905.

## The defect

`FlowShareableConfigType::deserialise()` stored an imported flow with `owner = null` and `organisation = null`, on reasoning that is correct as far as it goes — the **sender's** identity means nothing on this instance:

```php
// `owner` and `organisation` are not portable fields — they name an identity on
// the SENDING instance that means nothing here
$flow->setOwner(null);
$flow->setOrganisation(null);
```

But null is not "the absence of the sender's identity". It is the absence of **any**, and `FlowMapper` scopes every read with an **equality** predicate:

```php
$qb->andWhere($qb->expr()->eq('organisation', $qb->createNamedParameter($organisation)));
```

`NULL = 'anything'` is never true in SQL. The row inserted, `install` returned its uuid with HTTP 200, and the flow was excluded from `flow#index`, `flow#show` and the run path **by construction** — with no adopt route to rescue it, and `flow#update` unable to help because it has to find the row first.

**Install was a one-way door.** Five permanent orphans on one dev instance.

## The rule was already fixed — on the other writer

`FlowService::flowToSave()` refuses this exact write, and its comment describes this exact outcome:

> REFUSE rather than stamp nulls. […] a flow with no organisation belongs to nobody: it does not appear in index(), find() refuses it, and it can never be run or edited again. **Accepting the write produced a permanent orphan and reported success** — the caller had no way to tell that from a flow that saved.

Two writers each deriving ownership their own way is how the rule came to hold on one and not the other. Both now read `FlowService::callerOwnership()`, so there is one place that decides it, and `deserialise()` refuses rather than stamping nulls.

## The security property is unchanged, and never depended on the null

`Flow::canDispatch()` requires `enabled === true` **and** a non-empty owner:

```php
if ($this->enabled !== true) { return false; }
return $this->owner !== null && trim($this->owner) !== '';
```

So `enabled = false` alone already refuses dispatch. A bundle still cannot arrive and start executing against the receiving tenant's data, and the sender's claimed `owner`/`organisation` are still discarded. What the null added was not safety — it was unreachability.

## A test required the defect

`testAnImportedFlowLandsDisabledAndOwnerless` asserted `getOwner() === null`, pinning the orphan as a requirement. It is now `testAnImportedFlowLandsDisabledAndOwnedByTheInstaller` and asserts **both** halves — the sender's claim is rejected (`not 'victim'`, `not 'their-org'`) *and* the installer owns it. A second test pins the refusal when no caller resolves, with `insert` expected never.

## Evidence

The claim "the flow exists nowhere" in #2905's original report was **wrong**, and I corrected it there. The row is in the table:

```sql
SELECT uuid, owner IS NULL AS ownerless, organisation IS NULL AS orgless, enabled
  FROM oc_openregister_flows WHERE uuid='af100293-…';

 af100293-… | t | t | f
```

The control that isolates the cause: **85 rows are `enabled = false` and owned, and they list fine.** Only the 5 ownerless rows are invisible. It is the null ownership, not the disabled flag.

```
FlowShareableConfigTypeTest    10 tests, 33 assertions, OK
phpcs                          clean on both changed lib files
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
