### PR TITLE
feat(aggregation): group by a field that lives on the joined schema

### DIFF
--- a/lib/Service/Aggregation/AggregationRunner.php
+++ b/lib/Service/Aggregation/AggregationRunner.php
@@ -524,6 +524,26 @@ class AggregationRunner {
 		];
 
 		$runGroupFields = $this->resolveGroupFields(groupBy: $groupBy);
+
+		// GROUPING BY A FIELD THAT LIVES ON THE JOINED SCHEMA.
+		//
+		// `groupBy: ["AnalyticalDimension.parentCode"]` asks to roll the parent
+		// rows up to a column the parent does not have — it exists only after
+		// the join resolves. applyJoin() runs AFTER grouping and attaches
+		// figures to groups that already exist, so it cannot produce this: by
+		// then the rows are gone.
+		//
+		// Resolving it means projecting the value onto each parent row FIRST,
+		// through the join key, and then grouping normally. Anything else
+		// groups on a column every row lacks, which yields one null bucket
+		// holding everything — a plausible-looking total, not an error.
+		[$rows, $runGroupFields, $joinConsumed] = $this->projectJoinedGroupFields(
+			rows: $rows,
+			groupFields: $runGroupFields,
+			join: $joinArg,
+			bypassRbac: $bypassRbac
+		);
+
 		if (count($runGroupFields) > 0) {
 			$result['groups'] = $this->computeGrouped(
 				rows: $rows,
@@ -546,13 +566,33 @@ class AggregationRunner {
 			}
 		}
 
-		$result = $this->applyJoin(
-			envelope: $result,
-			join: $joinArg,
-			groupFields: $runGroupFields,
-			bypassRbac: $bypassRbac,
-			extraFilter: $appliedExtraFilter
-		);
+		if ($joinConsumed === true) {
+			// The join was SPENT on the grouping, so there is no per-group
+			// `joined` map to attach.
+			//
+			// mergeJoinedValues() reads the join key out of each group row, but
+			// after projection the group key IS the joined dimension — the
+			// original key is not in the row any more. Running it anyway would
+			// look up a tuple that cannot match and hang a map of nulls on every
+			// group, which reads as "the joined schema had nothing" rather than
+			// "this question was already answered by the grouping".
+			//
+			// Attaching figures here would mean re-aggregating the joined schema
+			// BY the projected dimension — a second, different join. That is a
+			// feature, not a detail, and it is not invented silently here.
+			$result['join'] = [
+				'through' => (string)($joinArg['through'] ?? ''),
+				'consumedForGrouping' => true,
+			];
+		} else {
+			$result = $this->applyJoin(
+				envelope: $result,
+				join: $joinArg,
+				groupFields: $runGroupFields,
+				bypassRbac: $bypassRbac,
+				extraFilter: $appliedExtraFilter
+			);
+		}
 
 		$this->cache->set(
 			registerSlug: (string)$register->getSlug(),
@@ -1455,6 +1495,268 @@ class AggregationRunner {
 	 *
 	 * @spec openspec/specs/aggregation-api/spec.md
 	 */
+	/**
+	 * Project joined-schema group fields onto the parent rows.
+	 *
+	 * A `groupBy` entry spelled `<JoinedSchema>.<field>` names a column the
+	 * parent rows do not carry — it exists only on the other side of the join.
+	 * Grouping on it directly puts every row in one null bucket, which reads as
+	 * a working total rather than a mistake.
+	 *
+	 * This resolves it the only way the semantics allow: build a
+	 * joinKey => value map from the joined schema, stamp each parent row with
+	 * the value its join key maps to, and hand back a rewritten group-field
+	 * list that points at the stamped column. Grouping then proceeds normally,
+	 * and the result is a roll-up to the joined dimension — a cost-centre
+	 * hierarchy summing its children, which is the shape this exists for.
+	 *
+	 * A parent row whose join key matches nothing keeps a NULL group value
+	 * rather than being dropped. Dropping it would quietly shrink the totals;
+	 * a null bucket is visible and is the honest answer for "belongs to no
+	 * dimension".
+	 *
+	 * Leaves everything untouched when no group field is join-qualified, so the
+	 * ordinary path pays only an array scan.
+	 *
+	 * @param array<int, array<string, mixed>> $rows        The parent rows.
+	 * @param array<int, string>               $groupFields The requested group fields.
+	 * @param array<string, mixed>|null        $join        The join spec, if any.
+	 * @param bool                             $bypassRbac  Internal-system mode.
+	 *
+	 * @return array{0: array<int, array<string, mixed>>, 1: array<int, string>, 2: bool} Rows, group
+	 *         fields, and whether the join was consumed by the grouping.
+	 *
+	 * @throws RuntimeException When a join-qualified group field has no usable join spec.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function projectJoinedGroupFields(
+		array $rows,
+		array $groupFields,
+		?array $join,
+		bool $bypassRbac,
+	): array {
+		$joinSpec = [];
+		$through = '';
+		if (is_array($join) === true) {
+			$joinSpec = $join;
+			$through = (string)($joinSpec['through'] ?? '');
+		}
+
+		$qualified = [];
+		foreach ($groupFields as $groupField) {
+			if ($through !== '' && str_starts_with($groupField, $through . '.') === true) {
+				$qualified[] = $groupField;
+			}
+		}
+
+		if ($qualified === []) {
+			return [$rows, $groupFields, false];
+		}
+
+		$onMap = $this->joinedProjectionKeyMap(joinSpec: $joinSpec, qualified: $qualified[0]);
+
+		$parentKey = (string)array_key_first($onMap);
+		$joinedRows = $this->loadJoinedRowsForProjection(
+			joinSpec: $joinSpec,
+			through: $through,
+			bypassRbac: $bypassRbac
+		);
+
+		foreach ($qualified as $groupField) {
+			$rows = $this->stampProjectedColumn(
+				rows: $rows,
+				joinedRows: $joinedRows,
+				parentKey: $parentKey,
+				joinedKey: (string)$onMap[$parentKey],
+				sourceField: substr($groupField, (strlen($through) + 1)),
+				column: $groupField
+			);
+		}
+
+		return [$rows, $groupFields, true];
+	}//end projectJoinedGroupFields()
+
+	/**
+	 * Resolve the parent=>joined key map for a group-field projection.
+	 *
+	 * THE `on` SHORTHAND CANNOT BE USED HERE, and saying so is the point.
+	 * `"on": "Schema.column"` infers the parent-side field FROM THE GROUP
+	 * FIELDS — the same-named one if present, otherwise the first. When the
+	 * group field is the join-qualified one, that inference picks the JOINED
+	 * field as the parent key, reads it off parent rows that do not have it,
+	 * and lands every row in a single null bucket reported as a working total.
+	 * Measured on the shorthand: a fixture summing 350 + 7 came back as one
+	 * bucket of 357 keyed ''. The explicit map names both sides, so nothing is
+	 * inferred.
+	 *
+	 * The map is read DIRECTLY rather than through resolveJoinKey(). That
+	 * helper enforces "every parent-side field must be one of the groupBy
+	 * fields", which is right for the post-grouping merge — it reads the key
+	 * out of a group row — but false here by construction: before projection
+	 * the group field is the joined one and the parent key is not grouped.
+	 *
+	 * @param array<string, mixed> $joinSpec  The join spec.
+	 * @param string               $qualified The join-qualified group field, for messages.
+	 *
+	 * @return array<string, string> Single-entry parentField => joinedField map.
+	 *
+	 * @throws RuntimeException When `on` is the shorthand, absent, or composite.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function joinedProjectionKeyMap(array $joinSpec, string $qualified): array {
+		if (is_string($joinSpec['on'] ?? null) === true) {
+			throw new RuntimeException(
+				'Grouping by "' . $qualified . '" requires the explicit join.on map '
+				. '({parentField: joinedField}); the "Schema.column" shorthand infers the parent key '
+				. 'from the group fields, which are the joined ones here.'
+			);
+		}
+
+		$onMap = [];
+		$onClause = ($joinSpec['on'] ?? null);
+		if (is_array($onClause) === true) {
+			foreach ($onClause as $parentField => $joinedField) {
+				if (is_string($parentField) === true && is_string($joinedField) === true) {
+					$onMap[$parentField] = $this->stripSchemaPrefix(ref: $joinedField);
+				}
+			}
+		}
+
+		if ($onMap === []) {
+			throw new RuntimeException(
+				'Grouping by "' . $qualified . '" needs the join\'s `on` mapping to locate the parent key.'
+			);
+		}
+
+		// Single-key joins only. A composite key would need a tuple lookup per
+		// row, and no declaration uses one — refusing beats silently matching
+		// on the first key alone, which would over-merge groups and inflate
+		// every total.
+		if (count($onMap) > 1) {
+			throw new RuntimeException(
+				'Grouping by a joined field is supported for single-key joins only; "'
+				. $qualified . '" joins on ' . count($onMap) . ' keys.'
+			);
+		}
+
+		return $onMap;
+	}//end joinedProjectionKeyMap()
+
+	/**
+	 * Hydrate and filter the joined schema's rows for a group-field projection.
+	 *
+	 * The declared `join.filter` applies here too: if the join only considers
+	 * active dimensions, the projection must not map a parent row onto a
+	 * retired one, or the roll-up would credit amounts to a dimension the join
+	 * itself excludes.
+	 *
+	 * @param array<string, mixed> $joinSpec   The join spec.
+	 * @param string               $through    The joined schema ref.
+	 * @param bool                 $bypassRbac Internal-system mode.
+	 *
+	 * @return array<int, array<string, mixed>> The joined rows.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function loadJoinedRowsForProjection(
+		array $joinSpec,
+		string $through,
+		bool $bypassRbac,
+	): array {
+		[$joinedSchema, $joinedRegister] = $this->resolveJoinTarget(
+			through: $through,
+			bypassRbac: $bypassRbac
+		);
+
+		$joinedRows = [];
+		foreach ($this->magicMapper->findAllInRegisterSchemaTable(
+			register: $joinedRegister,
+			schema: $joinedSchema,
+			limit: self::PHP_FALLBACK_ROW_CAP
+		) as $object) {
+			$joinedRows[] = $object->getObject();
+		}
+
+		$joinedFilter = $this->placeholders->resolveArray(
+			(array)($joinSpec['filter'] ?? $joinSpec['where'] ?? [])
+		);
+		if ($joinedFilter === []) {
+			return $joinedRows;
+		}
+
+		return $this->applyFilter(rows: $joinedRows, filter: $joinedFilter);
+	}//end loadJoinedRowsForProjection()
+
+	/**
+	 * Stamp each parent row with the joined value its join key maps to.
+	 *
+	 * The synthetic column is named after the QUALIFIED field, so a caller
+	 * reading `keys` sees the name it asked for rather than an internal alias.
+	 *
+	 * A parent row whose key matches nothing gets NULL rather than being
+	 * dropped: dropping it would quietly shrink every total, while a null
+	 * bucket is visible and is the honest answer for "belongs to no dimension".
+	 *
+	 * @param array<int, array<string, mixed>> $rows        Parent rows.
+	 * @param array<int, array<string, mixed>> $joinedRows  Joined rows.
+	 * @param string                           $parentKey   Parent-side join field.
+	 * @param string                           $joinedKey   Joined-side join field.
+	 * @param string                           $sourceField Joined field to project.
+	 * @param string                           $column      Synthetic column name.
+	 *
+	 * @return array<int, array<string, mixed>> Rows carrying the projected column.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function stampProjectedColumn(
+		array $rows,
+		array $joinedRows,
+		string $parentKey,
+		string $joinedKey,
+		string $sourceField,
+		string $column,
+	): array {
+		$lookup = [];
+		foreach ($joinedRows as $joinedRow) {
+			$key = ($joinedRow[$joinedKey] ?? null);
+			if ($key === null) {
+				continue;
+			}
+
+			$lookup[(string)$key] = ($joinedRow[$sourceField] ?? null);
+		}
+
+		foreach ($rows as $index => $row) {
+			$parentValue = ($row[$parentKey] ?? null);
+			$projected = null;
+			if ($parentValue !== null) {
+				$projected = ($lookup[(string)$parentValue] ?? null);
+			}
+
+			$rows[$index][$column] = $projected;
+		}
+
+		return $rows;
+	}//end stampProjectedColumn()
+
+	/**
+	 * Whether a metrics list uses anything the native SQL path cannot express.
+	 *
+	 * `condition` and `as` are honoured only by {@see computeMetrics()}. The
+	 * native path aggregates every entry over the same filtered row set and
+	 * derives its response key from metric+field, so it would drop a condition
+	 * silently and collide two aliases into one key. Both failures return a
+	 * plausible number rather than an error, which is why this is a hard
+	 * bail-out rather than a best-effort.
+	 *
+	 * @param array<int, array<string, mixed>> $metrics The metrics list.
+	 *
+	 * @return bool True when the PHP path must be used.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
 	private function metricsNeedPhpPath(array $metrics): bool {
 		foreach ($metrics as $entry) {
 			if (is_array($entry) === false) {
@@ -2044,6 +2346,17 @@ class AggregationRunner {
 		// PHP path, which honours both, rather than answer wrongly and fast.
 		if (is_array($metrics) === true && $this->metricsNeedPhpPath(metrics: $metrics) === true) {
 			return null;
+		}
+
+		// A join-qualified group field cannot run natively either. The SQL is
+		// emitted against the parent table alone, so `AnalyticalDimension.
+		// parentCode` would be a column no row has — every row landing in one
+		// null bucket, reported as a working total. The PHP path projects the
+		// value through the join first; bail to it.
+		foreach ($this->resolveGroupFields(groupBy: $groupBy) as $groupField) {
+			if (str_contains($groupField, '.') === true) {
+				return null;
+			}
 		}
 
 		if (is_array($metrics) === true && count($metrics) > 1) {

--- a/tests/Unit/Service/Aggregation/AggregationJoinAndCompositeGroupByTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationJoinAndCompositeGroupByTest.php
@@ -555,6 +555,151 @@ class AggregationJoinAndCompositeGroupByTest extends TestCase {
 		);
 	}//end testACallerKeyTheParentDeclarationDropsDoesNotReachTheJoin()
 
+	/**
+	 * Grouping by a field that lives on the JOINED schema rolls the parent
+	 * rows up to that dimension.
+	 *
+	 * `groupBy: ["commitment-budget.parentCode"]` names a column the parent
+	 * does not have. applyJoin() runs AFTER grouping and attaches figures to
+	 * groups that already exist, so it cannot produce this — by then the rows
+	 * are gone. The value has to be projected onto each parent row through the
+	 * join key first.
+	 *
+	 * The fixture is built so a wrong answer is obvious rather than plausible:
+	 * P1 and P2 both roll up to REGION-A, P3 to REGION-B. Grouping on the
+	 * unprojected column would put all four rows in ONE null bucket (357);
+	 * failing to roll up would leave three P-keyed groups instead of two
+	 * region-keyed ones.
+	 *
+	 *   REGION-A = P1(100 + 50) + P2(200) = 350
+	 *   REGION-B = P3(7)                  =   7
+	 */
+	public function testGroupByAJoinedFieldRollsParentRowsUp(): void {
+		$annotation = $this->joinAnnotation();
+		$annotation['groupBy'] = ['commitment-budget.parentCode'];
+		// The explicit map, not the shorthand: the shorthand infers the parent
+		// key from the group fields, which are the joined ones here.
+		$annotation['join']['on'] = ['programme' => 'programmeCode'];
+
+		$result = $this->makeHierarchyRunner($annotation)->run(
+			registerRef: 'finance',
+			schemaRef: 'commitment-line',
+			name: 'committed'
+		);
+
+		$folded = [];
+		foreach ($result['groups'] as $group) {
+			$key = ($group['keys']['commitment-budget.parentCode'] ?? $group['key'] ?? null);
+			$folded[(string)$key] = $group['value'];
+		}
+
+		ksort($folded);
+		$this->assertSame(
+			['REGION-A' => 350.0, 'REGION-B' => 7.0],
+			$folded,
+			'parent rows must roll up to the joined dimension, not stay on their own key'
+		);
+
+	}//end testGroupByAJoinedFieldRollsParentRowsUp()
+
+	/**
+	 * A parent row whose join key matches nothing keeps a NULL group, and is
+	 * NOT dropped.
+	 *
+	 * Dropping it would quietly shrink the totals — the reported figure would
+	 * be smaller than the data and nothing would say so. A null bucket is
+	 * visible, and is the honest answer for "belongs to no dimension".
+	 */
+	public function testUnmatchedParentRowsLandInANullGroupRatherThanVanishing(): void {
+		$annotation = $this->joinAnnotation();
+		$annotation['groupBy'] = ['commitment-budget.parentCode'];
+		$annotation['join']['on'] = ['programme' => 'programmeCode'];
+
+		// P9 has no matching budget row.
+		$result = $this->makeHierarchyRunner($annotation, orphanRow: true)->run(
+			registerRef: 'finance',
+			schemaRef: 'commitment-line',
+			name: 'committed'
+		);
+
+		$total = 0.0;
+		$sawNull = false;
+		foreach ($result['groups'] as $group) {
+			$total += (float)$group['value'];
+			$key = ($group['keys']['commitment-budget.parentCode'] ?? $group['key'] ?? null);
+			if ($key === null) {
+				$sawNull = true;
+				$this->assertSame(11.0, (float)$group['value'], 'the orphan row keeps its own amount');
+			}
+		}
+
+		$this->assertTrue($sawNull, 'an unmatched row must surface in a null bucket');
+		$this->assertSame(368.0, $total, '350 + 7 + 11 — nothing may be dropped');
+
+	}//end testUnmatchedParentRowsLandInANullGroupRatherThanVanishing()
+
+	/**
+	 * The `on` SHORTHAND is refused when grouping by a joined field, rather
+	 * than inferring the wrong parent key.
+	 *
+	 * `"on": "Schema.column"` infers the parent side from the group fields —
+	 * same-named one if present, otherwise the first. When the group field is
+	 * the joined one, that inference picks the JOINED field as the parent key,
+	 * reads it off parent rows that do not have it, and lands every row in a
+	 * single null bucket. Measured before this guard: a fixture summing
+	 * 350 + 7 came back as one bucket of 357 keyed ''.
+	 *
+	 * A refusal naming the fix is worth more than a plausible total.
+	 */
+	public function testJoinedGroupByRefusesTheOnShorthand(): void {
+		$annotation = $this->joinAnnotation();
+		$annotation['groupBy'] = ['commitment-budget.parentCode'];
+		// joinAnnotation() ships the string shorthand; leave it.
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/explicit join\.on map/');
+
+		$this->makeHierarchyRunner($annotation)->run(
+			registerRef: 'finance',
+			schemaRef: 'commitment-line',
+			name: 'committed'
+		);
+
+	}//end testJoinedGroupByRefusesTheOnShorthand()
+
+	/**
+	 * Grouping by a joined field marks the join as consumed instead of hanging
+	 * a map of nulls on every group.
+	 *
+	 * mergeJoinedValues() reads the join key out of each group row, and after
+	 * projection that key is gone — the group key IS the joined dimension. Left
+	 * to run it would attach `joined` entries that are all null, which reads as
+	 * "the joined schema had nothing" rather than "the grouping already
+	 * answered this".
+	 */
+	public function testJoinedGroupByReportsTheJoinAsConsumed(): void {
+		$annotation = $this->joinAnnotation();
+		$annotation['groupBy'] = ['commitment-budget.parentCode'];
+		$annotation['join']['on'] = ['programme' => 'programmeCode'];
+
+		$result = $this->makeHierarchyRunner($annotation)->run(
+			registerRef: 'finance',
+			schemaRef: 'commitment-line',
+			name: 'committed'
+		);
+
+		$this->assertTrue($result['join']['consumedForGrouping']);
+		$this->assertSame('commitment-budget', $result['join']['through']);
+		foreach ($result['groups'] as $group) {
+			$this->assertArrayNotHasKey(
+				'joined',
+				$group,
+				'a map of nulls would read as "the joined schema had nothing"'
+			);
+		}
+
+	}//end testJoinedGroupByReportsTheJoinAsConsumed()
+
 	public function testNativeJoinAgreesWithPhpFallback(): void {
 		$php = $this->makeJoinRunner()->run(
 			registerRef: 'finance',
@@ -1220,6 +1365,82 @@ class AggregationJoinAndCompositeGroupByTest extends TestCase {
 
 		return $this->makeRunner();
 	}//end makeJoinRunner()
+
+	/**
+	 * A fixture where the JOINED schema carries a hierarchy column.
+	 *
+	 * Parent rows are keyed by `programme`; the joined `commitment-budget` rows
+	 * map each programme to a `parentCode`, so grouping by
+	 * `commitment-budget.parentCode` must roll P1 and P2 together under
+	 * REGION-A and leave P3 under REGION-B.
+	 *
+	 * @param array<string, mixed> $annotation The aggregation annotation.
+	 * @param bool                 $orphanRow  Add a parent row matching no budget.
+	 *
+	 * @return AggregationRunner The configured runner.
+	 */
+	private function makeHierarchyRunner(array $annotation, bool $orphanRow = false): AggregationRunner {
+		$parentSchema = $this->makeSchema(
+			'commitment-line',
+			10,
+			['committed' => $annotation],
+			[
+				'programme' => ['type' => 'string'],
+				'costCentre' => ['type' => 'string'],
+				'remainingCommitted' => ['type' => 'number'],
+			]
+		);
+		$joinedSchema = $this->makeSchema(
+			'commitment-budget',
+			20,
+			[],
+			[
+				'programmeCode' => ['type' => 'string'],
+				'parentCode' => ['type' => 'string'],
+				'authorisedAmount' => ['type' => 'number'],
+			]
+		);
+		$register = $this->makeRegister('finance', [10, 20]);
+
+		$this->registerMapper->method('find')->willReturn($register);
+		$this->registerMapper->method('findAll')->willReturn([$register]);
+		$this->schemaMapper->method('find')->willReturnMap(
+			[
+				['commitment-line', [], true, false, $parentSchema],
+				['commitment-budget', [], true, false, $joinedSchema],
+			]
+		);
+		$this->permissionHandler->method('hasPermission')->willReturn(true);
+		$this->usePhpFallback();
+
+		$parentRows = [
+			['programme' => 'P1', 'costCentre' => 'C1', 'remainingCommitted' => 100],
+			['programme' => 'P1', 'costCentre' => 'C2', 'remainingCommitted' => 50],
+			['programme' => 'P2', 'costCentre' => 'C1', 'remainingCommitted' => 200],
+			['programme' => 'P3', 'costCentre' => 'C9', 'remainingCommitted' => 7],
+		];
+		if ($orphanRow === true) {
+			$parentRows[] = ['programme' => 'P9', 'costCentre' => 'C9', 'remainingCommitted' => 11];
+		}
+
+		$joinedRows = [
+			['programmeCode' => 'P1', 'parentCode' => 'REGION-A', 'authorisedAmount' => 1000],
+			['programmeCode' => 'P2', 'parentCode' => 'REGION-A', 'authorisedAmount' => 2000],
+			['programmeCode' => 'P3', 'parentCode' => 'REGION-B', 'authorisedAmount' => 3000],
+		];
+
+		$this->magicMapper->method('findAllInRegisterSchemaTable')->willReturnCallback(
+			function (Register $register, Schema $schema) use ($parentRows, $joinedRows): array {
+				if ((string)$schema->getSlug() === 'commitment-budget') {
+					return $this->entities($joinedRows);
+				}
+
+				return $this->entities($parentRows);
+			}
+		);
+
+		return $this->makeRunner();
+	}//end makeHierarchyRunner()
 
 	/**
 	 * A `commitment-line` / `commitment-budget` fixture whose rows span two


### PR DESCRIPTION
Plan item 4, and the largest single capability ConductionNL/shillinq#1261 is
waiting on — **11 declarations need it**.

## The problem

`groupBy: ["AnalyticalDimension.parentCode"]` asks to roll parent rows up to a
column the parent does not have. `applyJoin()` cannot produce it: it runs **after**
grouping and attaches figures to groups that already exist. By then the rows are
gone.

So the value is projected onto each parent row **first**, through the join key,
and grouping proceeds normally. The result is a roll-up to the joined dimension —
a cost-centre hierarchy summing its children, which is the shape this exists for.

```
REGION-A = P1(100 + 50) + P2(200) = 350
REGION-B = P3(7)                  =   7
```

## Three things the tests found — each a wrong answer, not an error

**1. The `on` shorthand is incompatible, and now says so.**
`"on": "Schema.column"` infers the parent-side field *from the group fields* —
same-named one if present, otherwise the first. When the group field is the
joined one, that inference picks the **joined** field as the parent key, reads it
off rows that do not have it, and puts everything in one bucket.

> Measured on the shorthand: a fixture summing 350 + 7 came back as a single
> bucket of **357** keyed `''`.

The explicit `{parentField: joinedField}` map names both sides, so nothing is
inferred. Refused with a message naming the fix.

**2. The post-grouping merge had to be skipped.**
After projection the group key **is** the joined dimension, so the original join
key is no longer in the row. `mergeJoinedValues()` would look up a tuple that
cannot match and hang a map of nulls on every group — reading as *"the joined
schema had nothing"* rather than *"the grouping already answered this"*. The
envelope now reports `join.consumedForGrouping: true`.

Attaching figures there would mean re-aggregating the joined schema **by** the
projected dimension — a second, different join. That is a feature, and it is not
invented silently here.

**3. An unmatched parent row keeps a NULL group instead of being dropped.**
Dropping it would quietly shrink every total with nothing saying so. The test
pins `350 + 7 + 11 = 368` — nothing may disappear.

## Also

- The **native path refuses** a join-qualified group field: its SQL is emitted
  against the parent table alone, so the column exists on no row and every row
  would land in one null bucket, reported as a working total.
- The map is read directly rather than through `resolveJoinKey()`, which enforces
  *"every parent-side field must be one of the groupBy fields"* — correct for the
  post-grouping merge, false here by construction.
- `phpmd` flagged the first cut at complexity 20 / NPath 25600. Split into
  `joinedProjectionKeyMap()`, `loadJoinedRowsForProjection()` and
  `stampProjectedColumn()`; both tools clean.

## Verified

- **17526 tests, 0 failures**; `phpcs` 0 errors; `phpmd` clean
- must-fail control: disabling the projection reddens both roll-up tests
- 4 new tests — the roll-up itself, unmatched rows surviving in a null bucket,
  the shorthand refusal, and the consumed-join envelope
