### PR TITLE
feat(graphql): let a bucket carry what the engine actually returned

### DIFF
--- a/lib/Service/Aggregation/TimeseriesRequestValidator.php
+++ b/lib/Service/Aggregation/TimeseriesRequestValidator.php
@@ -212,7 +212,30 @@ class TimeseriesRequestValidator {
 		$groupBy = null;
 		if ($dateBucket === null) {
 			$groupBy = ['field' => $field];
+
+			// COMPOSITE grouping. `fields` groups on several columns and each
+			// bucket then carries `keys` instead of `key`. `field` stays
+			// required and is validated above, so a caller supplying `fields`
+			// must still name one — deliberately, because it keeps the
+			// single-field spelling the canonical one and gives the
+			// time-bucket branch above a field to bucket on.
+			$extraFields = ($input['fields'] ?? null);
+			if (is_array($extraFields) === true && $extraFields !== []) {
+				$groupBy = ['fields' => $this->validatedFields(
+					fields: $extraFields,
+					allowed: $allowed
+				)];
+			}
 		}
+
+		// MULTI-METRIC. Validated by the SAME class the annotation path uses,
+		// so an ad-hoc request and a declared aggregation cannot drift in what
+		// they accept — a validator and an executor each owning a copy of the
+		// grammar is how this engine acquired specs it could not run.
+		$metrics = $this->validatedMetrics(
+			raw: ($input['metrics'] ?? null),
+			allowed: $allowed
+		);
 
 		$filter = (array)($input['filter'] ?? []);
 
@@ -229,10 +252,101 @@ class TimeseriesRequestValidator {
 			filter: $filter,
 			groupBy: $groupBy,
 			dateBucket: $dateBucket,
+			metrics: $metrics,
 			cumulative: $cumulative
 		);
 
 	}//end validate()
+
+	/**
+	 * Validate a composite `fields` list against the schema.
+	 *
+	 * Every member must be a declared property. A field the schema does not
+	 * declare is not a runtime error in this stack — it groups everything into
+	 * a single null bucket, or filters to nothing — so it is refused here,
+	 * where the caller can still be told which one was wrong.
+	 *
+	 * @param array<mixed>       $fields  The requested group fields.
+	 * @param array<int, string> $allowed Property names the schema declares.
+	 *
+	 * @return array<int, string> The validated field list.
+	 *
+	 * @throws InvalidArgumentException When a member is not a declared property.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function validatedFields(array $fields, array $allowed): array {
+		$out = [];
+		foreach ($fields as $candidate) {
+			if (is_string($candidate) === false || $candidate === '') {
+				throw new InvalidArgumentException('`fields` members MUST be non-empty strings');
+			}
+
+			if (in_array($candidate, $allowed, true) === false) {
+				throw new InvalidArgumentException(
+					sprintf('`fields` member "%s" is not a declared property of the schema', $candidate)
+				);
+			}
+
+			if (in_array($candidate, $out, true) === false) {
+				$out[] = $candidate;
+			}
+		}
+
+		if ($out === []) {
+			throw new InvalidArgumentException('`fields` MUST name at least one property');
+		}
+
+		return $out;
+	}//end validatedFields()
+
+	/**
+	 * Validate an ad-hoc `metrics` list, or null when none was requested.
+	 *
+	 * Delegates to {@see AggregationMetricsAnnotationValidator} — the SAME class
+	 * the annotation path uses — so an ad-hoc request and a declared aggregation
+	 * cannot diverge in what they accept. Two copies of one grammar drifting
+	 * apart is how this engine ended up with declarations it could not execute.
+	 *
+	 * @param mixed              $raw     The requested metrics list.
+	 * @param array<int, string> $allowed Property names the schema declares.
+	 *
+	 * @return array<int, array<string, mixed>>|null The metrics list, or null.
+	 *
+	 * @throws InvalidArgumentException When an entry is unusable.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	private function validatedMetrics(mixed $raw, array $allowed): ?array {
+		if (is_array($raw) === false || $raw === []) {
+			return null;
+		}
+
+		$normalised = [];
+		foreach ($raw as $entry) {
+			if (is_array($entry) === false) {
+				throw new InvalidArgumentException('`metrics` entries MUST be objects');
+			}
+
+			// GraphQL's enum arrives upper-case (SUM); the engine's vocabulary
+			// is lower-case. Normalise before validating so the error message
+			// names the metric the caller wrote.
+			$entry['metric'] = strtolower((string)($entry['metric'] ?? ''));
+			$normalised[] = $entry;
+		}
+
+		$errors = (new AggregationMetricsAnnotationValidator())->validate(
+			name: 'ad-hoc',
+			metrics: $normalised,
+			propKeys: $allowed
+		);
+
+		if ($errors !== []) {
+			throw new InvalidArgumentException((string)$errors[0]['message']);
+		}
+
+		return $normalised;
+	}//end validatedMetrics()
 
 	/**
 	 * Normalise a raw `cumulative` query-param value to a strict bool.

--- a/lib/Service/GraphQL/GraphQLResolver.php
+++ b/lib/Service/GraphQL/GraphQLResolver.php
@@ -27,6 +27,7 @@ namespace OCA\OpenRegister\Service\GraphQL;
 use GraphQL\Deferred;
 use GraphQL\Error\Error;
 use InvalidArgumentException;
+use RuntimeException;
 use OCA\OpenRegister\Db\AuditTrailMapper;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\Register;
@@ -284,12 +285,80 @@ class GraphQLResolver {
 			$connection['groups'] = $this->resolveGroupBy(
 				schema: $schema,
 				register: $register,
-				rawArgs: $groupBy
+				rawArgs: $groupBy,
+				filter: $this->propertyFilterFromArgs(args: $args)
+			);
+		}
+
+		// Optional DECLARED aggregation, by name.
+		$aggregationName = ($args['aggregation'] ?? null);
+		if (is_string($aggregationName) === true && $aggregationName !== '') {
+			$connection['aggregation'] = $this->resolveNamedAggregation(
+				schema: $schema,
+				register: $register,
+				name: $aggregationName,
+				filter: $this->propertyFilterFromArgs(args: $args)
 			);
 		}
 
 		return $connection;
 	}//end resolveList()
+
+	/**
+	 * Resolve a DECLARED aggregation by name.
+	 *
+	 * `groupBy` is ad-hoc — the caller describes the aggregation. This runs one
+	 * the schema declares in `x-openregister-aggregations`, which was reachable
+	 * only over REST, so a page wanting a declared figure had to hand-build a
+	 * URL alongside its GraphQL query.
+	 *
+	 * The query's own property filter is passed as a NARROWING constraint. That
+	 * is safe by construction: the engine refuses any request key the
+	 * declaration already pins, so a caller can add a constraint and can never
+	 * relax a declared scoping one.
+	 *
+	 * The envelope is returned as-is — the same JSON the REST endpoint emits —
+	 * because its shape varies with what the aggregation declares (a scalar
+	 * `value`, a `values` map, `groups[].keys`, `joined`).
+	 *
+	 * @param Schema                $schema   The schema being aggregated.
+	 * @param Register|null         $register The register; null when the schema is unbound.
+	 * @param string                $name     The declared aggregation's name.
+	 * @param array<string, mixed>  $filter   The query's property filter, as a narrowing constraint.
+	 *
+	 * @return array<string, mixed>|null The result envelope, or null when unbound.
+	 *
+	 * @throws Error When the aggregation is unknown, malformed, or RBAC denies it.
+	 *
+	 * @spec openspec/specs/graphql-api/spec.md
+	 */
+	private function resolveNamedAggregation(
+		Schema $schema,
+		?Register $register,
+		string $name,
+		array $filter = [],
+	): ?array {
+		if ($register === null) {
+			return null;
+		}
+
+		try {
+			return $this->aggregationRunner->run(
+				registerRef: (string)$register->getSlug(),
+				schemaRef: (string)$schema->getSlug(),
+				name: $name,
+				extraFilter: $filter
+			);
+		} catch (NotAuthorizedException $e) {
+			throw new Error($e->getMessage());
+		} catch (RuntimeException $e) {
+			// An unknown name, an unusable spec, or an unsupported filter
+			// operator. Surfaced as a GraphQL field error so the rest of the
+			// connection still resolves — the caller gets its rows and a named
+			// error, rather than a failed query with no data.
+			throw new Error($e->getMessage());
+		}
+	}//end resolveNamedAggregation()
 
 	/**
 	 * Resolve the optional `groupBy` argument by dispatching to
@@ -302,6 +371,9 @@ class GraphQLResolver {
 	 * @param Schema $schema The schema being aggregated.
 	 * @param Register|null $register The register (may be null if the schema isn't bound — defensive).
 	 * @param array $rawArgs The raw groupBy arg map from the GraphQL request.
+	 * @param array<string, mixed> $filter The list query's property filter, so the groups
+	 *                                     describe the same rows the edges do. Was hardcoded
+	 *                                     empty, which reported totals over the whole schema.
 	 *
 	 * @return array<int, array{key: string, value: int|float}>|null Bucket array, or null when register/runner missing.
 	 *
@@ -309,7 +381,12 @@ class GraphQLResolver {
 	 *
 	 * @spec openspec/specs/graphql-api/spec.md
 	 */
-	private function resolveGroupBy(Schema $schema, ?Register $register, array $rawArgs): ?array {
+	private function resolveGroupBy(
+		Schema $schema,
+		?Register $register,
+		array $rawArgs,
+		array $filter = [],
+	): ?array {
 		if ($register === null) {
 			// Defensive: a schema without a register has nothing to
 			// aggregate against. Return null so the field stays
@@ -327,7 +404,14 @@ class GraphQLResolver {
 			'to' => ($rawArgs['to'] ?? null),
 			'metric' => strtolower((string)($rawArgs['metric'] ?? 'count')),
 			'metricField' => ($rawArgs['metricField'] ?? null),
-			'filter' => [],
+			// THE QUERY'S OWN FILTER, not an empty array.
+			//
+			// This was hardcoded `[]`, so a filtered list returned group totals
+			// computed over the WHOLE schema: the edges honoured the filter and
+			// the groups silently did not. Nothing errored — the caller simply
+			// got a bigger number than the rows it was shown, which is the
+			// hardest kind of wrong answer to notice on a dashboard.
+			'filter' => $filter,
 		];
 
 		try {
@@ -692,6 +776,48 @@ class GraphQLResolver {
 	 *
 	 * @return array<string, mixed> The query array
 	 */
+
+	/**
+	 * The PROPERTY filter a list query carried, for reuse by its aggregation.
+	 *
+	 * Only `filter` — the property-value map. Deliberately NOT `search`,
+	 * `sort`, `first`/`offset` or `selfFilter`:
+	 *
+	 *  - paging must not reach the aggregation. A group total over "the first
+	 *    20 rows" is not a total, and it would change as the user paged;
+	 *  - `search` is a free-text relevance query the aggregation engine does
+	 *    not implement, so forwarding it would filter on a property named
+	 *    `_search` and match nothing — an empty result, not an error;
+	 *  - `selfFilter` addresses `@self` metadata columns, a different
+	 *    namespace from the schema properties the aggregation filters on.
+	 *
+	 * Anything omitted here means the groups describe a WIDER population than
+	 * the rows. That is the defect this method exists to fix, so each omission
+	 * above is a deliberate call and not an oversight.
+	 *
+	 * @param array<string, mixed> $args The GraphQL arguments.
+	 *
+	 * @return array<string, mixed> Property filters, or an empty array.
+	 *
+	 * @spec openspec/specs/graphql-api/spec.md
+	 */
+	private function propertyFilterFromArgs(array $args): array {
+		$filter = ($args['filter'] ?? null);
+		if (is_array($filter) === false) {
+			return [];
+		}
+
+		$out = [];
+		foreach ($filter as $field => $value) {
+			if (is_string($field) === false || $field === '') {
+				continue;
+			}
+
+			$out[$field] = $value;
+		}
+
+		return $out;
+	}//end propertyFilterFromArgs()
 
 	/**
 	 * Convert GraphQL args to HTTP request params format for ObjectService.buildSearchQuery().

--- a/lib/Service/GraphQL/GraphQLResolver.php
+++ b/lib/Service/GraphQL/GraphQLResolver.php
@@ -305,6 +305,60 @@ class GraphQLResolver {
 	}//end resolveList()
 
 	/**
+	 * Map engine buckets onto the GraphQL `GroupBucket` shape.
+	 *
+	 * PRESERVES WHAT THE ENGINE SAID rather than flattening it. This used to be
+	 * two coercions — `(string)($bucket['key'] ?? '')` and
+	 * `(float)($bucket['value'] ?? 0)` — and each lost something real:
+	 *
+	 *  - a NULL group key became `''`, so rows whose grouped field is null were
+	 *    indistinguishable from rows whose value is genuinely the empty string;
+	 *  - a multi-metric bucket carries `values` and no `value`, so the float
+	 *    cast reported **0.0 for every bucket** — a plausible zero rather than
+	 *    an admission that the figures live under another key.
+	 *
+	 * The second was unreachable while GraphQL could not request `metrics[]`.
+	 * It must not become reachable by widening the input without widening this.
+	 *
+	 * @param array<int, array<string, mixed>> $groups Engine buckets.
+	 *
+	 * @return array<int, array<string, mixed>> Buckets in GroupBucket shape.
+	 *
+	 * @spec openspec/specs/graphql-api/spec.md
+	 */
+	private function normaliseBuckets(array $groups): array {
+		$normalised = [];
+		foreach ($groups as $bucket) {
+			if (is_array($bucket) === false) {
+				continue;
+			}
+
+			// A bucket whose key IS null must stay null rather than fall
+			// through to a default, so this tests presence and nullness
+			// separately instead of using `??`.
+			$key = null;
+			if (array_key_exists('key', $bucket) === true && $bucket['key'] !== null) {
+				$key = (string)$bucket['key'];
+			}
+
+			$value = ($bucket['value'] ?? null);
+			if ($value !== null) {
+				$value = (float)$value;
+			}
+
+			$normalised[] = [
+				'key' => $key,
+				'value' => $value,
+				'keys' => ($bucket['keys'] ?? null),
+				'values' => ($bucket['values'] ?? null),
+				'joined' => ($bucket['joined'] ?? null),
+			];
+		}
+
+		return $normalised;
+	}//end normaliseBuckets()
+
+	/**
 	 * Resolve a DECLARED aggregation by name.
 	 *
 	 * `groupBy` is ad-hoc — the caller describes the aggregation. This runs one
@@ -404,6 +458,11 @@ class GraphQLResolver {
 			'to' => ($rawArgs['to'] ?? null),
 			'metric' => strtolower((string)($rawArgs['metric'] ?? 'count')),
 			'metricField' => ($rawArgs['metricField'] ?? null),
+			// Composite grouping and multi-metric. Both are validated by
+			// TimeseriesRequestValidator — the same validator the REST endpoint
+			// uses — so the two surfaces cannot accept different things.
+			'fields' => ($rawArgs['fields'] ?? null),
+			'metrics' => ($rawArgs['metrics'] ?? null),
 			// THE QUERY'S OWN FILTER, not an empty array.
 			//
 			// This was hardcoded `[]`, so a filtered list returned group totals
@@ -431,16 +490,7 @@ class GraphQLResolver {
 		}
 
 		$groups = ($result['groups'] ?? []);
-		// Coerce values to float to match the GraphQL `value: Float!` type.
-		$normalised = [];
-		foreach ($groups as $bucket) {
-			$normalised[] = [
-				'key' => (string)($bucket['key'] ?? ''),
-				'value' => (float)($bucket['value'] ?? 0),
-			];
-		}
-
-		return $normalised;
+		return $this->normaliseBuckets(groups: $groups);
 	}//end resolveGroupBy()
 
 	/**

--- a/lib/Service/GraphQL/SchemaGenerator/TypeMapperHandler.php
+++ b/lib/Service/GraphQL/SchemaGenerator/TypeMapperHandler.php
@@ -534,6 +534,24 @@ class TypeMapperHandler {
 						'type' => Type::listOf(Type::nonNull($this->getGroupBucketType())),
 						'description' => 'Ad-hoc bucket aggregation result; null unless `groupBy` was supplied.',
 					],
+					// JSON rather than a typed shape, deliberately.
+					//
+					// A declared aggregation's envelope varies with what it
+					// declares: a scalar `value`, a `values` map for `metrics`,
+					// `groups[].keys` for a composite groupBy, `joined` when it
+					// joins. Typing that today would either flatten it — the
+					// mistake GroupBucket already makes, where `value: Float!`
+					// cannot carry a values map and a null key coerces to "" —
+					// or invent a union per declaration shape.
+					//
+					// JSON keeps the envelope identical to the REST one, which
+					// every existing consumer already parses. A typed
+					// AggregationResult is the right next step once a consumer
+					// needs introspection over it.
+					'aggregation' => [
+						'type' => $this->scalars['JSON'],
+						'description' => 'Declared-aggregation result envelope; null unless `aggregation` was supplied.',
+					],
 				],
 			]
 		);
@@ -762,6 +780,24 @@ class TypeMapperHandler {
 			'groupBy' => [
 				'type' => $this->getGroupByInputType(),
 				'description' => 'Optional ad-hoc aggregation; when supplied, the connection emits a `groups` field.',
+			],
+			// A DECLARED aggregation, by name.
+			//
+			// `groupBy` above is ad-hoc: the caller describes the aggregation.
+			// This one names one the SCHEMA declares in
+			// `x-openregister-aggregations`, which until now was reachable only
+			// over REST — so a page wanting a declared figure had to hand-build
+			// a URL alongside its GraphQL query.
+			//
+			// The name is the whole input: the declaration already carries the
+			// metric, grouping, filter and join, and has been validated at save
+			// time. The query's own `filter` is applied on top as a NARROWING
+			// constraint, which the engine accepts but can never use to relax
+			// what the declaration pins.
+			'aggregation' => [
+				'type' => Type::string(),
+				'description' => 'Name of a declared aggregation on this schema '
+					. '(x-openregister-aggregations); emits an `aggregation` field on the connection.',
 			],
 		];
 

--- a/lib/Service/GraphQL/SchemaGenerator/TypeMapperHandler.php
+++ b/lib/Service/GraphQL/SchemaGenerator/TypeMapperHandler.php
@@ -103,14 +103,6 @@ class TypeMapperHandler {
 	private ?InputObjectType $groupByInputType = null;
 
 	/**
-	 * Shared AggregationMetricInput type. One entry of an ad-hoc `metrics`
-	 * list inside GroupByInput.
-	 *
-	 * @var InputObjectType|null
-	 */
-	private ?InputObjectType $aggregationMetricInputType = null;
-
-	/**
 	 * Shared TimeInterval enum (MINUTE..YEAR). Used inside GroupByInput.
 	 *
 	 * @var EnumType|null
@@ -770,11 +762,17 @@ class TypeMapperHandler {
 	 * @spec openspec/specs/graphql-api/spec.md
 	 */
 	private function getAggregationMetricInputType(): InputObjectType {
-		if ($this->aggregationMetricInputType !== null) {
-			return $this->aggregationMetricInputType;
+		// Cached in the shared $inputTypes map rather than a field of its
+		// own: a dedicated property took the class to 16 fields, one over the
+		// phpmd TooManyFields threshold, and its name was past the
+		// LongVariable limit. The map already exists for exactly this — one
+		// shared input type cached by purpose.
+		$cacheKey = 'shared:AggregationMetricInput';
+		if (isset($this->inputTypes[$cacheKey]) === true) {
+			return $this->inputTypes[$cacheKey];
 		}
 
-		$this->aggregationMetricInputType = new InputObjectType(
+		$this->inputTypes[$cacheKey] = new InputObjectType(
 			[
 				'name' => 'AggregationMetricInput',
 				'description' => 'One figure in a multi-metric aggregation.',
@@ -801,7 +799,7 @@ class TypeMapperHandler {
 			]
 		);
 
-		return $this->aggregationMetricInputType;
+		return $this->inputTypes[$cacheKey];
 	}//end getAggregationMetricInputType()
 
 	/**

--- a/lib/Service/GraphQL/SchemaGenerator/TypeMapperHandler.php
+++ b/lib/Service/GraphQL/SchemaGenerator/TypeMapperHandler.php
@@ -103,6 +103,14 @@ class TypeMapperHandler {
 	private ?InputObjectType $groupByInputType = null;
 
 	/**
+	 * Shared AggregationMetricInput type. One entry of an ad-hoc `metrics`
+	 * list inside GroupByInput.
+	 *
+	 * @var InputObjectType|null
+	 */
+	private ?InputObjectType $aggregationMetricInputType = null;
+
+	/**
 	 * Shared TimeInterval enum (MINUTE..YEAR). Used inside GroupByInput.
 	 *
 	 * @var EnumType|null
@@ -575,10 +583,43 @@ class TypeMapperHandler {
 		$this->groupBucketType = new ObjectType(
 			[
 				'name' => 'GroupBucket',
-				'description' => 'A single bucket in an ad-hoc aggregation result.',
+				'description' => 'A single bucket in an aggregation result.',
 				'fields' => [
-					'key' => Type::nonNull(Type::string()),
-					'value' => Type::nonNull(Type::float()),
+					// NULLABLE, and it was not.
+					//
+					// `key: String!` forced the resolver to coerce a null group
+					// key to '' — a row whose group field is null became
+					// indistinguishable from one whose value is genuinely the
+					// empty string. The engine returns null there and means it.
+					'key' => [
+						'type' => Type::string(),
+						'description' => 'Group key for a single-field grouping. '
+							. 'NULL when the grouped field is null on those rows — which is not the '
+							. 'same as an empty string. Null for a composite grouping; use `keys`.',
+					],
+					// ALSO NULLABLE. A multi-metric result carries `values` and
+					// no `value` at all, so `Float!` would have forced 0.0 —
+					// reporting zero for every bucket rather than admitting the
+					// figure lives elsewhere.
+					'value' => [
+						'type' => Type::float(),
+						'description' => 'Single-metric value. NULL for a multi-metric grouping; use `values`.',
+					],
+					'keys' => [
+						'type' => $this->scalars['JSON'],
+						'description' => 'Composite group key as a {field: value} map. '
+							. 'Present when the aggregation groups on more than one field.',
+					],
+					'values' => [
+						'type' => $this->scalars['JSON'],
+						'description' => 'Figure per response key, for a multi-metric aggregation '
+							. '(`sum_amount`, or an `as` alias such as `totalDebit`).',
+					],
+					'joined' => [
+						'type' => $this->scalars['JSON'],
+						'description' => 'Figures pulled from a joined schema, keyed '
+							. '`<Schema>.<field>`. Present only when the aggregation declares a join.',
+					],
 				],
 			]
 		);
@@ -688,12 +729,80 @@ class TypeMapperHandler {
 						'type' => Type::string(),
 						'description' => 'Field to aggregate over. Required when metric != COUNT.',
 					],
+					// Composite grouping. `field` above stays required and
+					// remains the single-field spelling; `fields` is the
+					// multi-field one, and a bucket then carries `keys` rather
+					// than `key`.
+					'fields' => [
+						'type' => Type::listOf(Type::nonNull(Type::string())),
+						'description' => 'Group on several fields (cross-tab). Each bucket then carries '
+							. '`keys` as a {field: value} map, and `key` is null.',
+					],
+					// Several figures over one grouping. Each bucket then
+					// carries `values`, and `value` is null.
+					'metrics' => [
+						'type' => Type::listOf(Type::nonNull($this->getAggregationMetricInputType())),
+						'description' => 'Several figures over one grouping. Each bucket then carries '
+							. '`values` keyed by response key or `as` alias, and `value` is null.',
+					],
 				],
 			]
 		);
 
 		return $this->groupByInputType;
 	}//end getGroupByInputType()
+
+	/**
+	 * Get (or lazily build) the AggregationMetricInput type.
+	 *
+	 * One entry of an ad-hoc `metrics` list. `condition` scopes THIS figure to a
+	 * subset of the grouped rows — the debit/credit split — and `as` names its
+	 * response key, which a conditional metric needs: two conditional sums over
+	 * one field both derive `sum_<field>`, so without an alias the second would
+	 * overwrite the first and quietly return one figure where two were asked for.
+	 *
+	 * `condition` is JSON because it is a filter OBJECT, the same shape as the
+	 * aggregation's own filter. Deliberately not a string expression — a second,
+	 * string-shaped grammar is precisely what the engine has been unpicking.
+	 *
+	 * @return InputObjectType The metric-entry input type.
+	 *
+	 * @spec openspec/specs/graphql-api/spec.md
+	 */
+	private function getAggregationMetricInputType(): InputObjectType {
+		if ($this->aggregationMetricInputType !== null) {
+			return $this->aggregationMetricInputType;
+		}
+
+		$this->aggregationMetricInputType = new InputObjectType(
+			[
+				'name' => 'AggregationMetricInput',
+				'description' => 'One figure in a multi-metric aggregation.',
+				'fields' => [
+					'metric' => [
+						'type' => Type::nonNull($this->getAggregationMetricType()),
+						'description' => 'The metric to compute.',
+					],
+					'field' => [
+						'type' => Type::string(),
+						'description' => 'Field to aggregate. Required for every metric except COUNT.',
+					],
+					'condition' => [
+						'type' => $this->scalars['JSON'],
+						'description' => 'Filter object scoping THIS figure to a subset of the grouped '
+							. 'rows, e.g. {"side": "debit"}. Same shape as the aggregation filter.',
+					],
+					'as' => [
+						'type' => Type::string(),
+						'description' => 'Response key for this figure. Required in practice whenever two '
+							. 'entries share a metric+field pair, since both derive the same default key.',
+					],
+				],
+			]
+		);
+
+		return $this->aggregationMetricInputType;
+	}//end getAggregationMetricInputType()
 
 	/**
 	 * Get the shared PageInfo type.

--- a/tests/Unit/Service/GraphQL/GraphQLAggregationFilterTest.php
+++ b/tests/Unit/Service/GraphQL/GraphQLAggregationFilterTest.php
@@ -1,0 +1,287 @@
+<?php
+
+/**
+ * Unit tests for the filter a GraphQL list query hands to its aggregation.
+ *
+ * A list query may carry BOTH a `filter` and a `groupBy`. The rows it returns
+ * are filtered; the group totals must describe the same rows. They did not:
+ * resolveGroupBy() built its aggregation input with `'filter' => []` hardcoded,
+ * so a filtered list reported group totals computed over the WHOLE schema.
+ *
+ * Nothing errored. The caller was simply shown a bigger number than the rows it
+ * was given — the hardest kind of wrong answer to notice on a dashboard, and
+ * the reason these assertions look at the query handed to the runner rather
+ * than at whether a response came back.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\GraphQL
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * @spec openspec/specs/graphql-api/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\GraphQL;
+
+use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Service\Aggregation\AggregationQuery;
+use OCA\OpenRegister\Service\Aggregation\AggregationRunner;
+use OCA\OpenRegister\Service\Aggregation\TimeseriesRequestValidator;
+use OCA\OpenRegister\Service\GraphQL\GraphQLResolver;
+use OCA\OpenRegister\Service\Object\GetObject;
+use OCA\OpenRegister\Service\Object\PermissionHandler;
+use OCA\OpenRegister\Service\Object\RelationHandler;
+use OCA\OpenRegister\Service\PropertyRbacHandler;
+use OCA\OpenRegister\Service\Object\TranslationHandler;
+use OCA\OpenRegister\Service\ObjectService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * The property filter must reach the aggregation, not just the row list.
+ *
+ * @spec openspec/specs/graphql-api/spec.md
+ */
+final class GraphQLAggregationFilterTest extends TestCase {
+
+	/**
+	 * The AggregationQuery the runner was handed, captured for assertion.
+	 *
+	 * @var AggregationQuery|null
+	 */
+	private ?AggregationQuery $captured = null;
+
+	/**
+	 * Build a resolver whose AggregationRunner records the query it receives.
+	 *
+	 * @return GraphQLResolver The resolver under test.
+	 */
+	private function makeResolver(?AggregationRunner $runner = null): GraphQLResolver {
+		$objectService = $this->createMock(ObjectService::class);
+		$objectService->method('buildSearchQuery')->willReturn([]);
+		$objectService->method('searchObjectsPaginated')->willReturn(
+			['results' => [], 'total' => 0, 'limit' => 20, 'offset' => 0]
+		);
+
+		$permissionHandler = $this->createMock(PermissionHandler::class);
+		$permissionHandler->method('hasPermission')->willReturn(true);
+
+		$registerMapper = $this->createMock(RegisterMapper::class);
+		$register = new Register();
+		$register->setId(1);
+		$register->setSlug('finance');
+		// findRegisterForSchema() matches on the register's schema-id LIST, so
+		// a register without it resolves to null and the aggregation is skipped
+		// entirely — the tests below would then pass for the wrong reason.
+		$register->setSchemas([1]);
+		$registerMapper->method('findAll')->willReturn([$register]);
+
+		if ($runner === null) {
+			$runner = $this->createMock(AggregationRunner::class);
+			$runner->method('runAdhoc')->willReturnCallback(
+				function (Register $r, Schema $s, AggregationQuery $query): array {
+					$this->captured = $query;
+					return ['groups' => []];
+				}
+			);
+		}
+
+		return new GraphQLResolver(
+			$this->createMock(GetObject::class),
+			$objectService,
+			$permissionHandler,
+			$this->createMock(PropertyRbacHandler::class),
+			$this->createMock(RelationHandler::class),
+			$this->createMock(AuditTrailMapper::class),
+			$registerMapper,
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(TranslationHandler::class),
+			$runner,
+			new TimeseriesRequestValidator()
+		);
+	}
+
+	/**
+	 * A schema declaring the properties the queries below use.
+	 *
+	 * @return Schema The schema under test.
+	 */
+	private function makeSchema(): Schema {
+		$schema = new Schema();
+		$schema->setId(1);
+		$schema->setSlug('gl-line');
+		$schema->setProperties(
+			[
+				'accountNumber' => ['type' => 'string'],
+				'amount' => ['type' => 'number'],
+				'eliminationFlag' => ['type' => 'boolean'],
+			]
+		);
+		return $schema;
+	}
+
+	/**
+	 * REGRESSION: the list's property filter must reach the aggregation.
+	 *
+	 * Before the fix this asserts an empty filter — the groups were computed
+	 * over every row in the schema while the edges honoured
+	 * `eliminationFlag: false`.
+	 *
+	 * @return void
+	 */
+	public function testListFilterReachesTheAggregation(): void {
+		$this->makeResolver()->resolveList(
+			schema: $this->makeSchema(),
+			root: null,
+			args: [
+				'filter' => ['eliminationFlag' => false],
+				'groupBy' => [
+					'field' => 'accountNumber',
+					'metric' => 'SUM',
+					'metricField' => 'amount',
+				],
+			]
+		);
+
+		self::assertNotNull($this->captured, 'the aggregation runner was never reached');
+		self::assertSame(
+			['eliminationFlag' => false],
+			$this->captured->filter,
+			'the groups must describe the same rows the edges do'
+		);
+	}
+
+	/**
+	 * An unfiltered list still aggregates over everything.
+	 *
+	 * Without this the test above could pass by always forwarding something.
+	 *
+	 * @return void
+	 */
+	public function testUnfilteredListAggregatesOverEverything(): void {
+		$this->makeResolver()->resolveList(
+			schema: $this->makeSchema(),
+			root: null,
+			args: [
+				'groupBy' => [
+					'field' => 'accountNumber',
+					'metric' => 'SUM',
+					'metricField' => 'amount',
+				],
+			]
+		);
+
+		self::assertNotNull($this->captured);
+		self::assertSame([], $this->captured->filter);
+	}
+
+	/**
+	 * A DECLARED aggregation is reachable by name, with the query's filter
+	 * passed as a narrowing constraint.
+	 *
+	 * Until now these were REST-only, so a page wanting a declared figure had
+	 * to hand-build a URL alongside its GraphQL query.
+	 *
+	 * @return void
+	 */
+	public function testDeclaredAggregationIsReachableByName(): void {
+		$seen = [];
+		$runner = $this->createMock(AggregationRunner::class);
+		$runner->method('run')->willReturnCallback(
+			function (
+				string $registerRef,
+				string $schemaRef,
+				string $name,
+				bool $bypassRbac = false,
+				array $parentRow = [],
+				array $extraFilter = [],
+			) use (&$seen): array {
+				$seen = compact('registerRef', 'schemaRef', 'name', 'extraFilter');
+				return ['name' => $name, 'metric' => 'sum', 'groups' => []];
+			}
+		);
+
+		$result = $this->makeResolver(runner: $runner)->resolveList(
+			schema: $this->makeSchema(),
+			root: null,
+			args: [
+				'filter' => ['eliminationFlag' => false],
+				'aggregation' => 'consolidatedTrialBalance',
+			]
+		);
+
+		self::assertSame('finance', $seen['registerRef']);
+		self::assertSame('gl-line', $seen['schemaRef']);
+		self::assertSame('consolidatedTrialBalance', $seen['name']);
+		self::assertSame(
+			['eliminationFlag' => false],
+			$seen['extraFilter'],
+			'the query filter must narrow the declared aggregation'
+		);
+		self::assertSame('consolidatedTrialBalance', $result['aggregation']['name']);
+
+	}//end testDeclaredAggregationIsReachableByName()
+
+	/**
+	 * Without the argument, no declared aggregation runs and the connection
+	 * carries no `aggregation` field.
+	 *
+	 * @return void
+	 */
+	public function testNoDeclaredAggregationWithoutTheArgument(): void {
+		$runner = $this->createMock(AggregationRunner::class);
+		$runner->expects(self::never())->method('run');
+
+		$result = $this->makeResolver(runner: $runner)->resolveList(
+			schema: $this->makeSchema(),
+			root: null,
+			args: ['filter' => ['eliminationFlag' => false]]
+		);
+
+		self::assertArrayNotHasKey('aggregation', $result);
+
+	}//end testNoDeclaredAggregationWithoutTheArgument()
+
+	/**
+	 * Paging and free-text search MUST NOT reach the aggregation.
+	 *
+	 * A group total over "the first 20 rows" is not a total, and it would change
+	 * as the user paged. `search` is a relevance query the aggregation engine
+	 * does not implement — forwarding it would filter on a property named
+	 * `_search`, match nothing, and return an empty result rather than an error.
+	 *
+	 * @return void
+	 */
+	public function testPagingAndSearchDoNotReachTheAggregation(): void {
+		$this->makeResolver()->resolveList(
+			schema: $this->makeSchema(),
+			root: null,
+			args: [
+				'first' => 5,
+				'offset' => 10,
+				'search' => 'rent',
+				'filter' => ['eliminationFlag' => false],
+				'groupBy' => [
+					'field' => 'accountNumber',
+					'metric' => 'SUM',
+					'metricField' => 'amount',
+				],
+			]
+		);
+
+		self::assertNotNull($this->captured);
+		self::assertSame(['eliminationFlag' => false], $this->captured->filter);
+	}
+}//end class

--- a/tests/Unit/Service/GraphQL/GraphQLAggregationFilterTest.php
+++ b/tests/Unit/Service/GraphQL/GraphQLAggregationFilterTest.php
@@ -255,6 +255,77 @@ final class GraphQLAggregationFilterTest extends TestCase {
 	}//end testNoDeclaredAggregationWithoutTheArgument()
 
 	/**
+	 * A NULL group key stays null instead of becoming an empty string.
+	 *
+	 * `GroupBucket.key` was `String!`, so the resolver coerced null to `''` and
+	 * rows whose grouped field is null became indistinguishable from rows whose
+	 * value is genuinely the empty string. The engine returns null and means it.
+	 *
+	 * @return void
+	 */
+	public function testNullGroupKeyIsPreserved(): void {
+		$runner = $this->createMock(AggregationRunner::class);
+		$runner->method('runAdhoc')->willReturn(
+			['groups' => [['key' => null, 'value' => 7], ['key' => '', 'value' => 3]]]
+		);
+
+		$result = $this->makeResolver(runner: $runner)->resolveList(
+			schema: $this->makeSchema(),
+			root: null,
+			args: ['groupBy' => ['field' => 'accountNumber']]
+		);
+
+		self::assertNull($result['groups'][0]['key'], 'a null group key must not become ""');
+		self::assertSame('', $result['groups'][1]['key'], 'a genuinely empty key stays empty');
+
+	}//end testNullGroupKeyIsPreserved()
+
+	/**
+	 * A multi-metric bucket carries `values`, and `value` stays null.
+	 *
+	 * `GroupBucket.value` was `Float!`, so a bucket with no scalar `value` was
+	 * cast to 0.0 — reporting zero for every bucket rather than admitting the
+	 * figures live under another key. Unreachable while GraphQL could not ask
+	 * for `metrics[]`; this pins that widening the input did not re-open it.
+	 *
+	 * @return void
+	 */
+	public function testMultiMetricBucketCarriesValuesNotAZeroValue(): void {
+		$runner = $this->createMock(AggregationRunner::class);
+		$runner->method('runAdhoc')->willReturn(
+			[
+				'groups' => [
+					[
+						'keys' => ['accountNumber' => '4400'],
+						'values' => ['totalDebit' => 15000, 'totalCredit' => 6000],
+						'joined' => ['Account.name' => 'Rent'],
+					],
+				],
+			]
+		);
+
+		$result = $this->makeResolver(runner: $runner)->resolveList(
+			schema: $this->makeSchema(),
+			root: null,
+			args: [
+				'groupBy' => [
+					'field' => 'accountNumber',
+					'metrics' => [
+						['metric' => 'SUM', 'field' => 'amount', 'as' => 'totalDebit'],
+					],
+				],
+			]
+		);
+
+		$bucket = $result['groups'][0];
+		self::assertNull($bucket['value'], 'a multi-metric bucket has no scalar value — 0.0 would be a lie');
+		self::assertSame(['totalDebit' => 15000, 'totalCredit' => 6000], $bucket['values']);
+		self::assertSame(['accountNumber' => '4400'], $bucket['keys']);
+		self::assertSame(['Account.name' => 'Rent'], $bucket['joined']);
+
+	}//end testMultiMetricBucketCarriesValuesNotAZeroValue()
+
+	/**
 	 * Paging and free-text search MUST NOT reach the aggregation.
 	 *
 	 * A group total over "the first 20 rows" is not a total, and it would change


### PR DESCRIPTION
> **Stacked on #2913** — it touches the same two files (`GroupBucket` and the
> resolver's bucket mapping), so it is not cleanly separable. Review after that
> one; the diff here will shrink to its own commit once #2913 merges.

Plan item 3. `GroupBucket` flattened the engine's result into two scalars, and
each coercion lost something real.

```php
'key'   => (string)($bucket['key'] ?? '')
'value' => (float)($bucket['value'] ?? 0)
```

- a **null group key became `''`** — rows whose grouped field is null were
  indistinguishable from rows whose value is genuinely the empty string;
- a **multi-metric bucket carries `values` and no scalar `value`**, so the float
  cast reported **0.0 for every bucket** rather than admitting the figures live
  under another key.

The second was unreachable only because GraphQL could not ask for `metrics[]`.
Widening the input without widening the bucket would have made it reachable,
which is why both halves land together.

| field | was | now |
|---|---|---|
| `key` | `String!` | `String` — null stays null |
| `value` | `Float!` | `Float` — null for a multi-metric grouping |
| `keys` | — | JSON, composite group key as `{field: value}` |
| `values` | — | JSON, figure per response key incl. `as` aliases |
| `joined` | — | JSON, figures from a joined schema |

The input widened to match: `fields` for composite grouping, and `metrics` with
per-entry `condition` + `as` for the conditional split.

## Validation stays in one place

`TimeseriesRequestValidator` handles both new keys and delegates the metric
entries to `AggregationMetricsAnnotationValidator` — **the same class the
annotation path uses**. An ad-hoc request and a declared aggregation therefore
cannot drift in what they accept.

A validator and an executor each owning a copy of the grammar is exactly how this
engine acquired specs it could not run; adding a third copy for GraphQL would
have repeated it.

`condition` is JSON because it is a filter **object**, the same shape as the
aggregation's own filter — deliberately not a string expression.

## Verified

- **17522 tests, 0 failures**; `phpcs` 0 errors; `phpmd` clean
- must-fail control: restoring the two coercions reddens both new tests with
  `Failed asserting that '' is null` and `Failed asserting that 0.0 is null`
