### PR TITLE
fix(scope): clear the pending schema ref on the read path too

### DIFF
--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -618,6 +618,37 @@ class ObjectService implements ObjectServiceInterface
                     schemaRef: $schema
                 );
 
+                // THE PENDING REF HAS ALREADY DONE ITS JOB — DROP IT HERE.
+                //
+                // It exists for exactly one case: `setSchema($s)` called before any
+                // register is known, so that the LATER `setRegister($r)` can
+                // re-resolve $s inside $r. On this branch a register was already
+                // set, the resolution above was scoped by it, and there is nothing
+                // left for a later setRegister() to consume.
+                //
+                // Leaving it set is what makes this instance-level state leak
+                // across unrelated operations. ObjectService is shared for the
+                // whole request, so the ref outlives the chain that created it and
+                // the NEXT caller's setRegister() re-resolves a finished
+                // operation's slug inside a register that has never heard of it —
+                // and refuses that caller.
+                //
+                // Measured 2026-08-27 on a fresh instance: buildiq registers its
+                // navigation entries from Application::boot(), which runs on EVERY
+                // request and calls findAll() -> prepareFindAllConfig(), which calls
+                // setRegister() and then setSchema('application'). Every request
+                // therefore ended with `application` pending. Portaliq's
+                // PortalResolver — typically the first caller afterwards to name its
+                // own register — was told `Schema slug "application" is not carried
+                // by register "portaliq"`. It fails closed by design, so every
+                // public portal page 404'd with no error attributable to portaliq
+                // at all. The same leak reached buildiq (`automation`) and hermiq
+                // (`job_log`) on the cron path.
+                //
+                // #2803 cleared the ref on the save path. This is the read path,
+                // which it did not cover.
+                $this->currentSchemaRef = null;
+
                 return $this;
             }
 

--- a/tests/Unit/Service/ObjectServiceStaleSchemaRefTest.php
+++ b/tests/Unit/Service/ObjectServiceStaleSchemaRefTest.php
@@ -403,4 +403,79 @@ class ObjectServiceStaleSchemaRefTest extends TestCase {
 			'schema-before-register must resolve within the register, not globally'
 		);
 	}//end testSchemaSetBeforeRegisterStillResolvesInsideThatRegister()
+
+
+	/**
+	 * A COMPLETED register+schema chain must not leave a ref behind at all.
+	 *
+	 * Every case above starts from `setSchema($s)` with NO register set — the
+	 * ref is pending precisely because it could not be resolved yet. This one
+	 * starts from the opposite and far more common order, `setRegister($r)`
+	 * THEN `setSchema($s)`, which is what `prepareFindAllConfig()` does on
+	 * every `findAll()`. That path resolves the schema immediately inside the
+	 * register and returns early — and used to return with the ref still set,
+	 * even though nothing was left to resolve.
+	 *
+	 * The consequence is not theoretical. Measured 2026-08-27 on a fresh
+	 * instance: buildiq registers its navigation entries from
+	 * `Application::boot()`, so this exact chain ran on EVERY request with
+	 * `application`, and every request ended with that ref pending. The next
+	 * caller to name its own register — portaliq's PortalResolver — was refused
+	 * with `Schema slug "application" is not carried by register "portaliq"`,
+	 * fails closed by design, and every public portal page 404'd.
+	 *
+	 * #2803 cleared the ref on the save path; this is the read path.
+	 *
+	 * @return void
+	 */
+	public function testACompletedRegisterThenSchemaChainLeavesNoPendingRef(): void {
+		$buildiq = new Register();
+		$buildiq->setId(20);
+		$buildiq->setSlug('buildiq');
+		$buildiq->setSchemas([193]);
+
+		$application = new Schema();
+		$application->setId(193);
+		$application->setSlug('application');
+
+		$portaliq = new Register();
+		$portaliq->setId(35);
+		$portaliq->setSlug('portaliq');
+		// Deliberately does NOT carry `application` — that is the whole point.
+		$portaliq->setSchemas([705]);
+
+		$this->registerMapper->method('find')->willReturnCallback(
+			static function ($ref) use ($buildiq, $portaliq) {
+				return ($ref === 'portaliq' || $ref === 35) ? $portaliq : $buildiq;
+			}
+		);
+		$this->schemaMapper->method('findInIds')->willReturnCallback(
+			static function ($ref, array $ids) use ($application) {
+				return (in_array(193, $ids, true) === true && ($ref === 'application' || $ref === 193))
+					? $application
+					: null;
+			}
+		);
+
+		// The chain prepareFindAllConfig() runs: register first, then schema.
+		$this->service->setRegister('buildiq');
+		$this->service->setSchema('application');
+
+		$pendingRef = new \ReflectionProperty(ObjectService::class, 'currentSchemaRef');
+		$pendingRef->setAccessible(true);
+
+		$this->assertNull(
+			$pendingRef->getValue($this->service),
+			'a schema resolved inside an already-set register leaves nothing to re-resolve, '
+			. 'so the pending ref must not survive the call'
+		);
+
+		// BEFORE THE FIX this throws SchemaNotInRegisterException naming
+		// "application" — a slug this caller never mentioned, belonging to a
+		// register it has nothing to do with.
+		$this->service->setRegister('portaliq');
+
+		$this->addToAssertionCount(1);
+
+	}//end testACompletedRegisterThenSchemaChainLeavesNoPendingRef()
 }//end class


### PR DESCRIPTION
## The defect

`setSchema()` stores a pending ref so a **later** `setRegister()` can re-resolve the slug inside the register the caller names. When a register is **already** set, `setSchema()` resolves immediately and returns early — and left the ref set anyway, with nothing remaining to resolve.

`ObjectService` is shared for the whole request, so that ref outlives the chain that created it. The next caller's `setRegister()` re-resolves a finished operation's slug inside a register that has never heard of it, and refuses that caller.

## How it presented

Measured 2026-08-27 on a fresh instance. buildiq registers its navigation entries from `Application::boot()`, which runs on **every request** and calls `findAll()` → `prepareFindAllConfig()`, which calls `setRegister()` and then `setSchema('application')`. Every request therefore ended with `application` pending.

Portaliq's `PortalResolver` — typically the first caller afterwards to name its own register — was told:

```
Schema slug "application" is not carried by register "portaliq" (id 35)
```

`PortalResolver` fails closed by design (a "default portal" fallback is how a multi-tenant host serves one tenant's content under another's domain), so it returned an empty portal list and **every public portal page 404'd** — with nothing in the error attributable to portaliq, and the real producer several frames below OpenRegister's own `findAll()`.

The producer was not guessed. I instrumented `setSchema()` to record its caller and read the trace back:

```
#0 ObjectService.php(1257): ObjectService->setSchema('application')
#1 ObjectService.php(1192): ObjectService->prepareFindAllConfig(Array)
#2 buildiq/lib/Service/AppNavigationService.php(372): ObjectService->findAll(...)
#4 buildiq/lib/AppInfo/Application.php(668): ->registerNavEntries(...)
#5 Coordinator.php(167): OCA\Buildiq\AppInfo\Application->boot(...)
#8 lib/base.php(1157): OC\App\AppManager->loadApps()
```

The same leak reached buildiq (`automation`) and hermiq (`job_log`) on the cron path.

## Relationship to #2803

#2803 cleared the ref on the **save** path. This is the **read** path, which it did not cover — checked against `origin/development` before writing anything, rather than assumed.

## Test

Added to `ObjectServiceStaleSchemaRefTest`. Every existing case in that file starts from `setSchema($s)` with **no** register set; this one starts from the opposite and far more common order (`setRegister()` then `setSchema()`), which is the branch that was leaking. It asserts the ref is null after the chain, then performs the unrelated `setRegister()` that previously threw.

## Verification

Live, not asserted: with the fix applied on a running instance, the previously-404ing demo portal renders in a browser — heading, search hero, menus, footer — with no other change made.