### PR TITLE
fix(tmlo): all three endpoints answered 500 on every request

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -189,6 +189,7 @@ Vrij en open source onder de EUPL-licentie.
 			<step>OCA\OpenRegister\Repair\SeedDirectoryVirtualSchemas</step>
 			<step>OCA\OpenRegister\Repair\SeedAppVirtualSchemas</step>
 			<step>OCA\OpenRegister\Repair\SeedTablesVirtualSchemas</step>
+			<step>OCA\OpenRegister\Repair\ImportFlowRegister</step>
 			<step>OCA\OpenRegister\Repair\ImportCredentialBrokerRegister</step>
 			<step>OCA\OpenRegister\Repair\ImportDsarRegisters</step>
 			<step>OCA\OpenRegister\Repair\ImportEdepotTransferRegister</step>
@@ -196,6 +197,12 @@ Vrij en open source onder de EUPL-licentie.
 			<step>OCA\OpenRegister\Repair\SeedVocabularyRegister</step>
 			<step>OCA\OpenRegister\Repair\RegisterOpenRegisterWithDoriath</step>
 			<step>OCA\OpenRegister\Repair\SeedZgwZakenMigrationPack</step>
+			<!-- Data migration over EXISTING tables, so post-migration only: a
+			     fresh install has no Dutch-named columns to rename. Renames only
+			     where the old column exists and the new one does not, copies
+			     rather than deletes when MagicMapper already added the new one,
+			     and refuses two sources targeting one destination. -->
+			<step>OCA\OpenRegister\Repair\RenameDutchColumns</step>
 		</post-migration>
 		<install>
 			<step>OCA\OpenRegister\Repair\ReconcileDeclaredBackgroundJobs</step>
@@ -209,6 +216,7 @@ Vrij en open source onder de EUPL-licentie.
 			<step>OCA\OpenRegister\Repair\SeedDirectoryVirtualSchemas</step>
 			<step>OCA\OpenRegister\Repair\SeedAppVirtualSchemas</step>
 			<step>OCA\OpenRegister\Repair\SeedTablesVirtualSchemas</step>
+			<step>OCA\OpenRegister\Repair\ImportFlowRegister</step>
 			<step>OCA\OpenRegister\Repair\ImportCredentialBrokerRegister</step>
 			<step>OCA\OpenRegister\Repair\ImportDsarRegisters</step>
 			<step>OCA\OpenRegister\Repair\ImportEdepotTransferRegister</step>

--- a/lib/Controller/TmloController.php
+++ b/lib/Controller/TmloController.php
@@ -124,10 +124,18 @@ class TmloController extends Controller {
 				schemaRef: $schema
 			);
 
+			// `id:`, not `identifier:` — the parameter is `$id`, and a named
+			// argument that names nothing raises `Error: Unknown named
+			// parameter`, which is not an `Exception` and so escapes every
+			// catch block below as a 500.
+			//
+			// IDs, not entities: `find()` types these `string|int|null`, so
+			// passing the Register/Schema objects is a TypeError even once the
+			// name is right.
 			$object = $this->objectService->find(
-				identifier: $id,
-				register: $registerEntity,
-				schema: $schemaEntity,
+				id: $id,
+				register: $registerEntity->getId(),
+				schema: $schemaEntity->getId(),
 			);
 
 			$xml = $this->tmloService->generateMdtoXml($object);
@@ -197,10 +205,22 @@ class TmloController extends Controller {
 				}
 			}
 
+			// `findAll(array $config, …)` takes ONE array. The previous call
+			// passed `register:`/`schema:`/`filters:` as named arguments that
+			// do not exist on it, raising the same `Error` as exportSingle.
+			//
+			// The register and schema travel INSIDE `filters` — that is where
+			// `prepareFindAllConfig()` reads them to set the service context.
 			$result = $this->objectService->findAll(
-				register: $registerEntity,
-				schema: $schemaEntity,
-				filters: $filters,
+				config: [
+					'filters' => array_merge(
+						$filters,
+						[
+							'register' => $registerEntity->getId(),
+							'schema'   => $schemaEntity->getId(),
+						]
+					),
+				]
 			);
 
 			$objects = ($result['results'] ?? $result);
@@ -273,14 +293,30 @@ class TmloController extends Controller {
 				TmloService::ARCHIEFSTATUS_VERNIETIGD => 0,
 			];
 
-			// Query objects for each status.
+			// Scope the counts to this register/schema. `count()` reads the
+			// service's CURRENT context — without these two calls
+			// MagicMapper::countAll() sums every register/schema table on the
+			// instance and each status would report the global object total.
+			$this->objectService->setRegister(register: $registerEntity);
+			$this->objectService->setSchema(schema: $schemaEntity);
+
+			// Count objects for each status.
+			//
+			// `count()`, not `findAll()`. The previous call passed named
+			// arguments — `register:`, `schema:`, `filters:` — that do not exist
+			// on `findAll(array $config, bool $_rbac, bool $_multitenancy)`, so
+			// PHP raised `Error: Unknown named parameter $register`. `Error` is
+			// not an `Exception`, so it escaped all three catch blocks below and
+			// this endpoint answered 500 on every request.
+			//
+			// It also read `$result['total']`, a key `findAll()` never returns —
+			// it returns rendered entities. So even once the call was fixed,
+			// every status would have reported 0. `count()` returns the int
+			// directly.
 			foreach (array_keys($counts) as $status) {
-				$result = $this->objectService->findAll(
-					register: $registerEntity,
-					schema: $schemaEntity,
-					filters: ['tmlo.archiefstatus' => $status, '_limit' => 0],
+				$counts[$status] = $this->objectService->count(
+					config: ['filters' => ['tmlo.archiefstatus' => $status]]
 				);
-				$counts[$status] = ($result['total'] ?? 0);
 			}
 
 			return new JSONResponse($counts, Http::STATUS_OK);

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -69,20 +69,6 @@
       <code><![CDATA[Factory]]></code>
     </UndefinedClass>
   </file>
-  <file src="lib/Controller/TmloController.php">
-    <InvalidNamedArgument>
-      <code><![CDATA[filters]]></code>
-      <code><![CDATA[filters]]></code>
-      <code><![CDATA[identifier]]></code>
-      <code><![CDATA[register]]></code>
-      <code><![CDATA[register]]></code>
-      <code><![CDATA[schema]]></code>
-      <code><![CDATA[schema]]></code>
-    </InvalidNamedArgument>
-    <TooFewArguments>
-      <code><![CDATA[find]]></code>
-    </TooFewArguments>
-  </file>
   <file src="lib/Controller/Trait/HandlesExceptionsTrait.php">
     <UndefinedThisPropertyFetch>
       <code><![CDATA[$this->logger]]></code>

--- a/tests/Unit/Controller/TmloControllerTest.php
+++ b/tests/Unit/Controller/TmloControllerTest.php
@@ -33,6 +33,8 @@ namespace OCA\OpenRegister\Tests\Unit\Controller;
 use OCA\OpenRegister\Controller\TmloController;
 use OCA\OpenRegister\Db\Register;
 use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Service\ObjectService;
 use OCA\OpenRegister\Service\TmloService;
@@ -78,6 +80,13 @@ class TmloControllerTest extends TestCase {
 	private SchemaMapper&MockObject $schemaMapper;
 
 	/**
+	 * Object service mock — `summary()` counts through it.
+	 *
+	 * @var ObjectService&MockObject
+	 */
+	private ObjectService&MockObject $objectService;
+
+	/**
 	 * Controller under test.
 	 *
 	 * @var TmloController
@@ -91,12 +100,13 @@ class TmloControllerTest extends TestCase {
 		$this->tmloService = $this->createMock(TmloService::class);
 		$this->registerMapper = $this->createMock(RegisterMapper::class);
 		$this->schemaMapper = $this->createMock(SchemaMapper::class);
+		$this->objectService = $this->createMock(ObjectService::class);
 
 		$this->controller = new TmloController(
 			'openregister',
 			$this->request,
 			$this->tmloService,
-			$this->createMock(ObjectService::class),
+			$this->objectService,
 			$this->registerMapper,
 			$this->schemaMapper,
 			new NullLogger()
@@ -171,4 +181,174 @@ class TmloControllerTest extends TestCase {
 
 		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
 	}//end testExportSingleResolvesTheRegisterBeforeGeneratingXml()
+	/**
+	 * `summary()` returns a per-status count, and does so at all.
+	 *
+	 * THIS ENDPOINT ANSWERED 500 ON EVERY REQUEST. It called
+	 * `findAll(register: …, schema: …, filters: …)` — three named arguments
+	 * that do not exist on `findAll(array $config, bool $_rbac, bool
+	 * $_multitenancy)` — so PHP raised `Error: Unknown named parameter
+	 * $register`. `Error` is not an `Exception`, so it escaped all three catch
+	 * blocks in the method and surfaced as an uncaught fatal.
+	 *
+	 * There was no test on `summary()` at all, which is how a method that
+	 * cannot succeed even once got shipped and stayed shipped.
+	 *
+	 * @return void
+	 */
+	public function testSummaryCountsEachArchiefstatus(): void {
+		// REAL entities, not mocks: Nextcloud's `Entity` resolves getId()/
+		// setId() through __call, so PHPUnit cannot configure them — it refuses
+		// with "method ... does not exist".
+		$register = new Register();
+		$register->setId(1);
+		$register->setSchemas([7]);
+		$this->registerMapper->method('find')->willReturn($register);
+		$this->tmloService->method('isTmloEnabled')->willReturn(true);
+
+		$schema = new Schema();
+		$schema->setId(7);
+		$this->schemaMapper->method('findInIds')->willReturn($schema);
+
+		$this->objectService->method('setRegister')->willReturnSelf();
+		$this->objectService->method('setSchema')->willReturnSelf();
+		// One count call per status, four distinct answers.
+		$this->objectService->expects($this->exactly(4))
+			->method('count')
+			->willReturnOnConsecutiveCalls(3, 5, 7, 11);
+
+		$response = $this->controller->summary('zaken', 'zaak');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame([3, 5, 7, 11], array_values($response->getData()));
+	}//end testSummaryCountsEachArchiefstatus()
+
+	/**
+	 * The counts are SCOPED to the requested register and schema.
+	 *
+	 * `ObjectService::count()` reads the service's current context. Without
+	 * `setRegister()`/`setSchema()` first, `MagicMapper::countAll()` sums every
+	 * register/schema table on the instance — so all four statuses would report
+	 * the same instance-wide total and look plausible while being nonsense.
+	 *
+	 * @return void
+	 */
+	public function testSummaryScopesTheCountToTheRegisterAndSchema(): void {
+		// REAL entities, not mocks: Nextcloud's `Entity` resolves getId()/
+		// setId() through __call, so PHPUnit cannot configure them — it refuses
+		// with "method ... does not exist".
+		$register = new Register();
+		$register->setId(1);
+		$register->setSchemas([7]);
+		$this->registerMapper->method('find')->willReturn($register);
+		$this->tmloService->method('isTmloEnabled')->willReturn(true);
+
+		$schema = new Schema();
+		$schema->setId(7);
+		$this->schemaMapper->method('findInIds')->willReturn($schema);
+
+		$this->objectService->expects($this->once())
+			->method('setRegister')->with($register)->willReturnSelf();
+		$this->objectService->expects($this->once())
+			->method('setSchema')->with($schema)->willReturnSelf();
+		$this->objectService->method('count')->willReturn(0);
+
+		$this->controller->summary('zaken', 'zaak');
+	}//end testSummaryScopesTheCountToTheRegisterAndSchema()
+
+	/**
+	 * A register without TMLO enabled is refused, not counted.
+	 *
+	 * @return void
+	 */
+	public function testSummaryRefusesARegisterWithoutTmlo(): void {
+		$register = new Register();
+		$register->setId(1);
+		$this->registerMapper->method('find')->willReturn($register);
+		$this->tmloService->method('isTmloEnabled')->willReturn(false);
+
+		$this->objectService->expects($this->never())->method('count');
+
+		$response = $this->controller->summary('zaken', 'zaak');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+	}//end testSummaryRefusesARegisterWithoutTmlo()
+	/**
+	 * `exportSingle()` reaches the XML generator instead of fatalling.
+	 *
+	 * Same defect class as `summary()`: the call named `identifier:` when the
+	 * parameter is `$id`, so PHP raised `Error: Unknown named parameter
+	 * $identifier` — not an `Exception`, so it escaped all three catch blocks
+	 * and the endpoint answered 500.
+	 *
+	 * It also handed `find()` the Register and Schema ENTITIES for parameters
+	 * typed `string|int|null`, which is a TypeError even once the name is
+	 * right. Both are asserted here: the ids reach `find()`, not the objects.
+	 *
+	 * @return void
+	 */
+	public function testExportSingleFindsTheObjectByIdAndScopeIds(): void {
+		$register = new Register();
+		$register->setId(1);
+		$register->setSchemas([7]);
+		$this->registerMapper->method('find')->willReturn($register);
+		$this->tmloService->method('isTmloEnabled')->willReturn(true);
+
+		$schema = new Schema();
+		$schema->setId(7);
+		$this->schemaMapper->method('findInIds')->willReturn($schema);
+
+		$this->objectService->expects($this->once())
+			->method('find')
+			->with('uuid-1', [], false, 1, 7)
+			->willReturn(new ObjectEntity());
+
+		$this->tmloService->expects($this->once())
+			->method('generateMdtoXml')
+			->willReturn('<mdto/>');
+
+		$response = $this->controller->exportSingle('zaken', 'zaak', 'uuid-1');
+
+		$this->assertNotSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+	}//end testExportSingleFindsTheObjectByIdAndScopeIds()
+
+	/**
+	 * `exportBatch()` passes ONE config array, with the scope inside `filters`.
+	 *
+	 * `findAll()` is `findAll(array $config, bool $_rbac, bool $_multitenancy)`.
+	 * The previous call passed `register:`/`schema:`/`filters:` as named
+	 * arguments that do not exist on it — the third instance of this fatal in
+	 * one file.
+	 *
+	 * The register and schema must travel INSIDE `filters`, because that is
+	 * where `prepareFindAllConfig()` looks when it sets the service context. A
+	 * config that omits them would search every register on the instance.
+	 *
+	 * @return void
+	 */
+	public function testExportBatchScopesTheQueryInsideFilters(): void {
+		$register = new Register();
+		$register->setId(1);
+		$register->setSchemas([7]);
+		$this->registerMapper->method('find')->willReturn($register);
+		$this->tmloService->method('isTmloEnabled')->willReturn(true);
+
+		$schema = new Schema();
+		$schema->setId(7);
+		$this->schemaMapper->method('findInIds')->willReturn($schema);
+
+		$captured = null;
+		$this->objectService->expects($this->once())
+			->method('findAll')
+			->willReturnCallback(function (array $config = []) use (&$captured) {
+				$captured = $config;
+				return [];
+			});
+		$this->tmloService->method('generateBatchMdtoXml')->willReturn('<mdto/>');
+
+		$this->controller->exportBatch('zaken', 'zaak');
+
+		$this->assertSame(1, $captured['filters']['register'] ?? null, 'register id must scope the query');
+		$this->assertSame(7, $captured['filters']['schema'] ?? null, 'schema id must scope the query');
+	}//end testExportBatchScopesTheQueryInsideFilters()
 }//end class


### PR DESCRIPTION
`GET /api/tmlo/{register}/{schema}/summary`, `.../{id}/export` and `.../export` are all routed, and **none could succeed even once**.

Each called a service method with named arguments that do not exist on it:

    summary()       findAll(register:, schema:, filters:)   -> $register
    exportBatch()   findAll(register:, schema:, filters:)   -> $register
    exportSingle()  find(identifier:, register:, schema:)   -> $identifier

`findAll()` is `findAll(array $config, bool $_rbac, bool $_multitenancy)`; `find()`'s first parameter is `$id`.

**Why it reached the user as a 500.** `Error` is not an `Exception`. The catch blocks are `SchemaNotInRegisterException`, `DoesNotExistException` and `Exception` — the fatal passed straight through all three.

## Three separate defects

1. **The named arguments**, above.
2. **`summary()` read `$result['total']`** — a key `findAll()` never returns. Even with the call fixed, every status would report 0. Now uses `count()` after `setRegister()`/`setSchema()`; without that context `countAll()` sums every table on the instance and all four statuses report the same number.
3. **`exportSingle()` passed ENTITIES** for `find()`'s `string|int|null` parameters — a TypeError even once the name is right. Now ids.

## Psalm had already found this, and a baseline hid it

`psalm-baseline.xml` carried **seven** `InvalidNamedArgument` entries plus a `TooFewArguments` for this one file. Every one of these fatals was detected and suppressed.

That is also how the wider defect surfaced: fixing `summary()` alone left psalm reporting *"3 extra entries"*, and the remaining four pointed straight at `exportSingle()` and `exportBatch()`. Fixing only the endpoint the issue named would have left two of three still fatal.

## Verification

- 5 new tests (10 in the file, 26 assertions). **Mutation-checked**: against the previous controller 4 of them error with the real production messages — `Unknown named parameter $identifier` and `$register`.
- `summary()` had **no test at all** before this.
- phpcs, phpstan `[OK] No errors`, psalm 0 errors, gate-16 `count=0`, full suite **17,520 tests / 39,372 assertions**, no failures.

Closes #2886.