### PR TITLE
fix(aggregation): read `metrics` on the cross-schema path, and refuse an unanswerable @self

### DIFF
--- a/lib/Service/Aggregation/AggregationRunner.php
+++ b/lib/Service/Aggregation/AggregationRunner.php
@@ -3605,6 +3605,19 @@ class AggregationRunner {
 
 		// Resolve `select` / `metric` alias.
 		$metric = (string)($spec['metric'] ?? $spec['select'] ?? 'count');
+
+		// `metrics` — several figures over ONE grouping. This path read only
+		// the SINGULAR key, so a cross-schema spec asking for a debit/credit
+		// split silently degraded to the default `count`. The intra-schema
+		// path has honoured `metrics` since #2917; two paths reading different
+		// halves of the same declaration is drift that answers wrongly rather
+		// than erroring, so both now read the same keys.
+		$crossSpecMetrics = ($spec['metrics'] ?? null);
+		$metrics = null;
+		if (is_array($crossSpecMetrics) === true && $crossSpecMetrics !== []) {
+			$metrics = $crossSpecMetrics;
+		}
+
 		$field = ($spec['field'] ?? null);
 		// Resolve `where` / `filter` alias.
 		$rawWhere = (array)($spec['where'] ?? $spec['filter'] ?? []);
@@ -3667,6 +3680,7 @@ class AggregationRunner {
 			'cross' => true,
 			'from' => $fromRef,
 			'metric' => $metric,
+			'metrics' => $metrics,
 			'field' => $field,
 			'where' => $resolvedWhere,
 			'groupBy' => $groupBy,
@@ -3696,14 +3710,22 @@ class AggregationRunner {
 			$crossGroupByArg = $groupBy;
 		}
 
-		$native = $this->tryNativeAggregation(
-			register: $targetRegister,
-			schema: $targetSchema,
-			metric: $metric,
-			field: $crossFieldArg,
-			filter: $resolvedWhere,
-			groupBy: $crossGroupByArg
-		);
+		// A `metrics` spec is computed in PHP so that per-entry `condition`
+		// and `as` are honoured — tryNativeAggregation() takes a single
+		// metric/field pair and has nowhere to put them. Letting it run would
+		// return one unconditioned figure for a spec that asked for several.
+		// The row cap still applies and is reported through `truncated`.
+		$native = null;
+		if ($metrics === null) {
+			$native = $this->tryNativeAggregation(
+				register: $targetRegister,
+				schema: $targetSchema,
+				metric: $metric,
+				field: $crossFieldArg,
+				filter: $resolvedWhere,
+				groupBy: $crossGroupByArg
+			);
+		}
 
 		if ($native !== null) {
 			$crossNativeField = null;
@@ -3761,18 +3783,32 @@ class AggregationRunner {
 			'truncated' => $truncated,
 		];
 
+		if ($metrics !== null) {
+			$result['metrics'] = $metrics;
+		}
+
 		$crossGroupFields = $this->resolveGroupFields(groupBy: $groupBy);
 		if (count($crossGroupFields) > 0) {
 			$result['groups'] = $this->computeGrouped(
 				rows: $rows,
 				metric: $metric,
 				field: $field,
-				groupFields: $crossGroupFields
+				groupFields: $crossGroupFields,
+				metrics: $metrics
 			);
 		}
 
 		if (isset($result['groups']) === false) {
-			$result['value'] = $this->computeMetric(rows: $rows, metric: $metric, field: $field);
+			// Ungrouped: a `metrics` spec yields `values` (a map keyed by alias).
+			// Falling through to computeMetric() here would hand back a single
+			// figure derived from $metric — which is the DEFAULT 'count' when
+			// the spec declared only `metrics` — for a request that named
+			// several conditioned sums.
+			if ($metrics !== null) {
+				$result['values'] = $this->computeMetrics(rows: $rows, metrics: $metrics);
+			} else {
+				$result['value'] = $this->computeMetric(rows: $rows, metric: $metric, field: $field);
+			}
 		}
 
 		$this->cache->set(
@@ -3817,7 +3853,38 @@ class AggregationRunner {
 			if (is_string($value) === true && str_starts_with($value, '@self.') === true) {
 				// Strip the leading '@self.' prefix (6 characters) to get the field name.
 				$fieldName = substr($value, 6);
-				$resolved[$key] = ($parentRow[$fieldName] ?? null);
+
+				// AN UNANSWERABLE CORRELATION IS AN ERROR, NOT AN EMPTY FILTER.
+				//
+				// This used to resolve to null and was described as failing
+				// closed. It does not: the null is applied as a real filter
+				// VALUE, so the aggregation returns the target rows whose own
+				// field is null. For a segment P&L keyed on `@self.code` that
+				// is the unassigned-cost-centre total — returned confidently,
+				// under HTTP 200, identically for every parent record, with
+				// nothing in the envelope naming what went wrong.
+				//
+				// No production caller supplies a parent row today (the REST
+				// controller, ReportRenderService and ThresholdEvaluationService
+				// all call run() without one), so silence here means every such
+				// declaration answers wrongly rather than visibly.
+				//
+				// A key PRESENT but null is left alone: correlating on null is a
+				// legitimate query. It is the ABSENT key — no parent row, or a
+				// typo in the field name — that is refused.
+				if (array_key_exists($fieldName, $parentRow) === false) {
+					throw new RuntimeException(
+						sprintf(
+							'Cannot resolve "%s": the parent row supplies no "%s" field. '
+							.'A cross-schema aggregation correlating on @self requires the '
+							.'caller to pass the parent object as parentRow.',
+							$value,
+							$fieldName
+						)
+					);
+				}
+
+				$resolved[$key] = $parentRow[$fieldName];
 				continue;
 			}
 

--- a/tests/Unit/Service/Aggregation/CrossSchemaAggregationRunnerTest.php
+++ b/tests/Unit/Service/Aggregation/CrossSchemaAggregationRunnerTest.php
@@ -268,10 +268,19 @@ class CrossSchemaAggregationRunnerTest extends TestCase {
 
 	/**
 	 * @test
-	 * An `@self.<field>` reference to a field absent in the parent row
-	 * resolves to null — the filter matches nothing (fail-closed).
+	 * An `@self.<field>` reference to a field absent in the parent row is
+	 * REFUSED.
+	 *
+	 * This test previously asserted that the reference resolved to null and
+	 * called that fail-closed. It is not: the null is applied as a real filter
+	 * value, so the aggregation returns the target rows whose own field is
+	 * null. The single row here happens to have `parentId => 'something'`, so
+	 * the count came back 0 and the fixture agreed with the claim — a
+	 * different fixture, one row with a null parentId, would have returned 1
+	 * under exactly the same code. The assertion was pinning the fixture, not
+	 * the behaviour.
 	 */
-	public function testAtSelfMissingFieldResolvesToNull(): void {
+	public function testAtSelfMissingFieldIsRefused(): void {
 		$parentSchema = $this->makeSchema('regulation', 10, [
 			'orphanCount' => [
 				'from' => 'scholiq-enrolment',
@@ -292,11 +301,16 @@ class CrossSchemaAggregationRunnerTest extends TestCase {
 		$this->permissionHandler->method('hasPermission')->willReturn(true);
 		$this->usePhpFallback();
 
-		// Row whose parentId is 'something' — null !== 'something' → filtered out.
+		// A row whose parentId IS null — the case the old null-resolution
+		// behaviour would have counted as a match, turning an unanswerable
+		// correlation into a confident wrong number.
 		$this->magicMapper->method('findAllInRegisterSchemaTable')
-			->willReturn([$this->makeEntityStub(['parentId' => 'something'])]);
+			->willReturn([$this->makeEntityStub(['parentId' => null])]);
 
-		$result = $this->runner->run(
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/@self\.nonExistentField/');
+
+		$this->runner->run(
 			registerRef: 'scholiq',
 			schemaRef: 'regulation',
 			name: 'orphanCount',
@@ -304,9 +318,7 @@ class CrossSchemaAggregationRunnerTest extends TestCase {
 			parentRow: []
 		);
 
-		$this->assertSame(0, $result['value']);
-
-	}//end testAtSelfMissingFieldResolvesToNull()
+	}//end testAtSelfMissingFieldIsRefused()
 
 	// -----------------------------------------------------------------------
 	// Tests: select/where aliases
@@ -542,5 +554,182 @@ class CrossSchemaAggregationRunnerTest extends TestCase {
 		$this->runner->run('scholiq', 'regulation', 'enrolCount', bypassRbac: false);
 
 	}//end testCrossSchemaRbacGateOnTargetSchema()
+
+	// -----------------------------------------------------------------------
+	// Tests: the cross-schema path must read the same spec keys as the
+	// intra-schema one
+	// -----------------------------------------------------------------------
+
+	/**
+	 * @test
+	 * A cross-schema aggregation declaring `metrics` must compute them.
+	 *
+	 * runCrossSchema() resolved only `metric`/`select`, so a spec asking for
+	 * several conditioned figures fell back to the default `count`. That is
+	 * the worst failure shape available: a debit/credit split came back as a
+	 * ROW COUNT under an HTTP 200, with no key in the response naming what had
+	 * been dropped. The intra-schema path has honoured `metrics` since #2917;
+	 * the two paths reading different halves of the same declaration is the
+	 * drift this pins shut.
+	 */
+	public function testCrossSchemaHonoursMetricsArray(): void {
+		$parentSchema = $this->makeSchema('project', 10, [
+			'segmentPnl' => [
+				'from' => 'gl-line',
+				'where' => ['eliminationFlag' => false],
+				'groupBy' => ['accountNumber'],
+				'metrics' => [
+					[
+						'metric' => 'sum',
+						'field' => 'amount',
+						'condition' => ['side' => 'debit'],
+						'as' => 'totalDebit',
+					],
+					[
+						'metric' => 'sum',
+						'field' => 'amount',
+						'condition' => ['side' => 'credit'],
+						'as' => 'totalCredit',
+					],
+				],
+			],
+		]);
+		$targetSchema = $this->makeSchema('gl-line', 20);
+		$parentRegister = $this->makeRegister('shillinq', [10]);
+		$targetRegister = $this->makeRegister('shillinq', [20]);
+
+		$this->registerMapper->method('find')->willReturn($parentRegister);
+		$this->schemaMapper->method('find')
+			->willReturnMap([
+				['project', [], true, false, $parentSchema],
+				['gl-line', [], true, false, $targetSchema],
+			]);
+		$this->registerMapper->method('findAll')->willReturn([$parentRegister, $targetRegister]);
+		$this->permissionHandler->method('hasPermission')->willReturn(true);
+		$this->usePhpFallback();
+
+		// One account, one eliminated row that must not count toward either
+		// figure, and an asymmetric debit/credit split so a swapped or shared
+		// condition cannot produce the expected pair by accident.
+		$this->magicMapper->method('findAllInRegisterSchemaTable')
+			->willReturn([
+				$this->makeEntityStub(['accountNumber' => '4000', 'side' => 'debit', 'amount' => 100, 'eliminationFlag' => false]),
+				$this->makeEntityStub(['accountNumber' => '4000', 'side' => 'debit', 'amount' => 25, 'eliminationFlag' => false]),
+				$this->makeEntityStub(['accountNumber' => '4000', 'side' => 'credit', 'amount' => 40, 'eliminationFlag' => false]),
+				$this->makeEntityStub(['accountNumber' => '4000', 'side' => 'debit', 'amount' => 999, 'eliminationFlag' => true]),
+			]);
+
+		$result = $this->runner->run(
+			registerRef: 'shillinq',
+			schemaRef: 'project',
+			name: 'segmentPnl',
+			bypassRbac: true
+		);
+
+		$groups = ($result['groups'] ?? []);
+		$this->assertCount(1, $groups, 'One accountNumber bucket expected');
+
+		$bucket = $groups[0];
+		$this->assertSame('4000', (string)($bucket['key'] ?? null));
+
+		$values = ($bucket['values'] ?? null);
+		$this->assertIsArray($values, 'A `metrics` spec must yield per-group `values`');
+
+		// 100 + 25 = 125 debit; 40 credit. The eliminated 999 is excluded by
+		// `where`, so a totalDebit of 1124 would mean the where clause was
+		// dropped, and 4 would mean the whole spec degraded to `count`.
+		$this->assertEqualsWithDelta(125.0, (float)$values['totalDebit'], 0.001);
+		$this->assertEqualsWithDelta(40.0, (float)$values['totalCredit'], 0.001);
+	}//end testCrossSchemaHonoursMetricsArray()
+
+	/**
+	 * @test
+	 * An `@self.<field>` reference the parent row cannot answer must throw.
+	 *
+	 * Resolving it to null did not fail closed as intended: the null was then
+	 * applied as a real filter value, so the aggregation returned the rows
+	 * whose own field is null. For a segment P&L keyed on `@self.code` that is
+	 * the unassigned-cost-centre total, returned confidently for EVERY parent
+	 * record. Nothing in the envelope distinguishes it from a real answer.
+	 *
+	 * A field PRESENT but null stays legitimate (correlating on null is a real
+	 * query); it is the ABSENT key — no parent row supplied, or a typo in the
+	 * field name — that is refused.
+	 */
+	public function testCrossSchemaUnresolvableAtSelfThrows(): void {
+		$parentSchema = $this->makeSchema('project', 10, [
+			'segmentPnl' => [
+				'from' => 'gl-line',
+				'where' => ['projectCode' => '@self.code'],
+			],
+		]);
+		$targetSchema = $this->makeSchema('gl-line', 20);
+		$parentRegister = $this->makeRegister('shillinq', [10]);
+		$targetRegister = $this->makeRegister('shillinq', [20]);
+
+		$this->registerMapper->method('find')->willReturn($parentRegister);
+		$this->schemaMapper->method('find')
+			->willReturnMap([
+				['project', [], true, false, $parentSchema],
+				['gl-line', [], true, false, $targetSchema],
+			]);
+		$this->registerMapper->method('findAll')->willReturn([$parentRegister, $targetRegister]);
+		$this->permissionHandler->method('hasPermission')->willReturn(true);
+		$this->usePhpFallback();
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/@self\.code/');
+
+		// No parentRow — exactly what every production caller supplies today.
+		$this->runner->run(
+			registerRef: 'shillinq',
+			schemaRef: 'project',
+			name: 'segmentPnl',
+			bypassRbac: true
+		);
+	}//end testCrossSchemaUnresolvableAtSelfThrows()
+
+	/**
+	 * @test
+	 * A parent row that HAS the field with a null value still correlates on
+	 * null, rather than being swept up by the guard above.
+	 */
+	public function testCrossSchemaAtSelfPresentButNullStillResolves(): void {
+		$parentSchema = $this->makeSchema('project', 10, [
+			'orphanCount' => [
+				'from' => 'gl-line',
+				'where' => ['projectCode' => '@self.code'],
+			],
+		]);
+		$targetSchema = $this->makeSchema('gl-line', 20);
+		$parentRegister = $this->makeRegister('shillinq', [10]);
+		$targetRegister = $this->makeRegister('shillinq', [20]);
+
+		$this->registerMapper->method('find')->willReturn($parentRegister);
+		$this->schemaMapper->method('find')
+			->willReturnMap([
+				['project', [], true, false, $parentSchema],
+				['gl-line', [], true, false, $targetSchema],
+			]);
+		$this->registerMapper->method('findAll')->willReturn([$parentRegister, $targetRegister]);
+		$this->permissionHandler->method('hasPermission')->willReturn(true);
+		$this->usePhpFallback();
+
+		$this->magicMapper->method('findAllInRegisterSchemaTable')
+			->willReturn([
+				$this->makeEntityStub(['projectCode' => null]),
+				$this->makeEntityStub(['projectCode' => 'P-1']),
+			]);
+
+		$result = $this->runner->run(
+			registerRef: 'shillinq',
+			schemaRef: 'project',
+			name: 'orphanCount',
+			bypassRbac: true,
+			parentRow: ['code' => null]
+		);
+
+		$this->assertSame(1, $result['value']);
+	}//end testCrossSchemaAtSelfPresentButNullStillResolves()
 
 }//end class


### PR DESCRIPTION
Two ways a cross-schema aggregation returned a **plausible wrong number**. Neither errored; both answered HTTP 200.

## 1. `metrics` was never read when `from` was set

`runCrossSchema()` resolved only the **singular** `metric`/`select`:

```php
$metric = (string)($spec['metric'] ?? $spec['select'] ?? 'count');
```

So a spec asking for several conditioned figures fell through to the default `count`. A debit/credit segment P&L came back as a **row count**, with nothing in the envelope naming what had been dropped.

The intra-schema path has honoured `metrics` since #2917. Two paths reading different halves of the same declaration is drift that answers wrongly rather than erroring.

The cross-schema path now:
- extracts `metrics` and includes it in the cache key (so two specs differing only in `metrics` cannot collide);
- **skips the native path** when `metrics` is present — `tryNativeAggregation()` takes one metric/field pair and has nowhere to put per-entry `condition`/`as`, so letting it run returns one unconditioned figure for a spec that asked for several. The row cap still applies and is reported through `truncated`;
- passes `metrics` to the `computeGrouped(metrics:)` branch **that already existed**;
- yields `values` rather than a scalar when ungrouped — emitting the scalar would hand back a figure derived from `$metric`, which is the *default* `'count'` when the spec declared only `metrics`.

## 2. An `@self.<field>` the parent row cannot answer resolved to `null`

The docblock called this fail-closed. It is not. The null is applied as a real filter **value**, so the aggregation returns the target rows whose own field is null. For a segment P&L keyed on `@self.code` that is *the unassigned-cost-centre total* — returned confidently, identically, for **every** parent record.

And nothing supplies a parent row. All three call sites in `lib/` invoke `run()` without one:

| call site | passes `parentRow`? |
|---|---|
| `Controller/AggregationController.php:113` | no |
| `Service/Reporting/ReportRenderService.php:186` | no |
| `Service/Aggregation/ThresholdEvaluationService.php:190` | no |

So every such declaration answered wrongly rather than visibly.

An **absent** key now raises and names the reference. A key **present but null** still correlates on null — that is a legitimate query, and it is covered by its own test.

### The test that pinned the old behaviour was pinning its fixture

`testAtSelfMissingFieldResolvesToNull` asserted `0` against a fixture whose single row had `parentId => 'something'`. A row with a **null** `parentId` returns `1` under exactly the same code. The assertion never described the behaviour it claimed to.

It is now `testAtSelfMissingFieldIsRefused`, with that fixture inverted to the null case so it cannot pass for the old reason.

## Verification

- `vendor/bin/phpunit` — **17,522 tests, 0 failures** (3 risky, pre-existing in `TextExtractionServiceTest`)
- `CrossSchemaAggregationRunnerTest` — 12 tests, 23 assertions, green
- Both new tests were confirmed to **fail first**, for the predicted reasons: `values` came back `null`, and no exception was thrown
- phpcs / phpmd / psalm / phpstan clean on `AggregationRunner.php` (psalm names the file zero times; phpstan `[OK] No errors`)

Refs ConductionNL/shillinq#1261