### PR TITLE
fix(repair): register ImportFlowRegister and RenameDutchColumns

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -180,6 +180,11 @@ Vrij en open source onder de EUPL-licentie.
 			<step>OCA\OpenRegister\Repair\RemoveRetiredCronJobs</step>
 			<step>OCA\OpenRegister\Repair\RegisterRiskLevelMetadata</step>
 			<step>OCA\OpenRegister\Repair\LogDanglingLinkedTypes</step>
+			<!-- The flows register must EXIST before any step reads flows.
+			     ImportFlowRegister was written, and named here zero times, so
+			     the `flows` register was never created and every flow step
+			     below it silently operated on nothing. -->
+			<step>OCA\OpenRegister\Repair\ImportFlowRegister</step>
 			<!-- Rewrite before the index is derived: the index is built FROM node
 			     types, so the types should already be the current ones. -->
 			<step>OCA\OpenRegister\Repair\MigrateRenamedFlowNodeTypes</step>
@@ -196,11 +201,23 @@ Vrij en open source onder de EUPL-licentie.
 			<step>OCA\OpenRegister\Repair\SeedVocabularyRegister</step>
 			<step>OCA\OpenRegister\Repair\RegisterOpenRegisterWithDoriath</step>
 			<step>OCA\OpenRegister\Repair\SeedZgwZakenMigrationPack</step>
+			<!-- Post-migration ONLY: a fresh install has no Dutch columns to
+			     move, so listing this under <install> would be a guaranteed
+			     no-op. MagicMapper ADDS a column for a renamed property and
+			     never renames, so without this step the data stays in the old
+			     column while every read looks at the new one and finds null —
+			     no error, no data loss, invisible to the suite. -->
+			<step>OCA\OpenRegister\Repair\RenameDutchColumns</step>
 		</post-migration>
 		<install>
 			<step>OCA\OpenRegister\Repair\ReconcileDeclaredBackgroundJobs</step>
 			<step>OCA\OpenRegister\Repair\RegisterRiskLevelMetadata</step>
 			<step>OCA\OpenRegister\Repair\LogDanglingLinkedTypes</step>
+			<!-- The flows register must EXIST before any step reads flows.
+			     ImportFlowRegister was written, and named here zero times, so
+			     the `flows` register was never created and every flow step
+			     below it silently operated on nothing. -->
+			<step>OCA\OpenRegister\Repair\ImportFlowRegister</step>
 			<!-- Rewrite before the index is derived: the index is built FROM node
 			     types, so the types should already be the current ones. -->
 			<step>OCA\OpenRegister\Repair\MigrateRenamedFlowNodeTypes</step>


### PR DESCRIPTION
Both classes are fully written, implement `IRepairStep`, and are named **zero times** in `appinfo/info.xml`. Nextcloud runs only what the manifest declares, so neither has ever executed.

`gate-98 repair-step-registration` catches it:

> FAIL — 2 repair step(s) written but never registered in appinfo/info.xml, so Nextcloud will not run them

**A class that exists is not a class that runs**, and neither failure is visible.

## `ImportFlowRegister`

Creates the `flows` register and flow schema. Without it that register was never created — so every flow step listed *below* it (`MigrateRenamedFlowNodeTypes`, `BackfillFlowTriggerIndex`, `InitializeFlowActions`) silently operated on nothing.

Registered **above** them, in both `<post-migration>` and `<install>`.

## `RenameDutchColumns`

Moves stored data from the Dutch columns to the English ones the register now declares.

MagicMapper **adds** a column when a snake_cased property is absent and **never renames** — there is not a single `RENAME COLUMN` in the app. So a renamed property leaves the data in the old column while every read looks at the new one and finds `null`. No error, no data loss, and invisible to a suite that asserts against fixtures rather than migrated rows. For shillinq those columns carry invoice, subsidy, payroll and tax amounts.

Its own docblock documents the step as non-destructive and idempotent:

- renames only when the **old** column exists and the **new** one does not;
- where the new column already exists, copies across and **leaves the old column in place** — reversible, and a re-run is a no-op;
- two sources targeting one destination are **refused**, not merged;
- nothing is deleted.

Registered under `<post-migration>` **only** — a fresh install has no Dutch columns to move, so listing it under `<install>` would be a guaranteed no-op.

## Scope

Pre-existing on `development`: `git show origin/development:appinfo/info.xml` matches neither name. Not introduced by any open PR. gate-98 is full-tree, so it reddens **every** branch until this lands — currently #2913, and #2916/#2917/#2922 behind it.

## Verification

- `appinfo/info.xml` parses (`xml.dom.minidom`)
- Every one of the 20 classes in `lib/Repair/` now resolves to a `<step>` entry — **zero orphans**
- That check was run against a deliberate fake (`NotARealStep`) first and reported it, so the clean result is not a check that examined nothing

## Note for the next release

Repair steps run on upgrade, so these two first execute on the next version bump.