### PR TITLE
fix(repair): register RenameDutchColumns — written, never run

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -186,6 +186,29 @@ Vrij en open source onder de EUPL-licentie.
 			<step>OCA\OpenRegister\Repair\BackfillFlowTriggerIndex</step>
 			<step>OCA\OpenRegister\Repair\InitializeFlowActions</step>
 			<step>OCA\OpenRegister\Repair\MigrateNotificationSubscriptionsToUserConfig</step>
+			<!--
+				A WRITTEN REPAIR STEP THAT NOTHING NAMES HERE NEVER RUNS.
+
+				RenameDutchColumns was fully implemented and registered nowhere, so
+				it had never executed on any instance. What it does is move stored
+				data out of the Dutch columns into the English ones the register now
+				declares — and OpenRegister stores each schema property as a real
+				column, with no RENAME COLUMN anywhere in the codebase. MagicMapper
+				ADDS the English column on schema sync and leaves the Dutch one
+				populated, so every read looks at the new column and finds null.
+
+				For the owning app those columns are money: invoice, subsidy,
+				payroll and tax amounts. The failure is silent — no error, no data
+				loss, and invisible to a suite that asserts against fixtures rather
+				than migrated rows.
+
+				post-migration only, matching the sibling steps above and the same
+				decision taken for opencatalogi's RenameDutchPublicationColumns: on
+				a fresh install there is nothing to rename. The step is idempotent
+				and non-destructive (it refuses two sources targeting one
+				destination, and never deletes), so a re-run is a no-op.
+			-->
+			<step>OCA\OpenRegister\Repair\RenameDutchColumns</step>
 			<step>OCA\OpenRegister\Repair\SeedDirectoryVirtualSchemas</step>
 			<step>OCA\OpenRegister\Repair\SeedAppVirtualSchemas</step>
 			<step>OCA\OpenRegister\Repair\SeedTablesVirtualSchemas</step>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -212,6 +212,20 @@ Vrij en open source onder de EUPL-licentie.
 			<step>OCA\OpenRegister\Repair\SeedDirectoryVirtualSchemas</step>
 			<step>OCA\OpenRegister\Repair\SeedAppVirtualSchemas</step>
 			<step>OCA\OpenRegister\Repair\SeedTablesVirtualSchemas</step>
+			<!--
+				ImportFlowRegister creates the `flows` register that the flow engine
+				reads. It was implemented and named in NEITHER phase, so the register
+				it exists to create has never been created by an install or an
+				upgrade — gate-98 flags it alongside RenameDutchColumns.
+
+				Registered in BOTH phases because it is baseline-CREATING, exactly
+				like the sibling Import*/Seed* steps around it: <install> is the only
+				hook a first install runs (Nextcloud runs migrateSchemaOnly() then,
+				so neither pre- nor post-migration fire), while <post-migration>
+				covers instances that already exist. The import is idempotent, so
+				appearing in both is a no-op on the second pass.
+			-->
+			<step>OCA\OpenRegister\Repair\ImportFlowRegister</step>
 			<step>OCA\OpenRegister\Repair\ImportCredentialBrokerRegister</step>
 			<step>OCA\OpenRegister\Repair\ImportDsarRegisters</step>
 			<step>OCA\OpenRegister\Repair\ImportEdepotTransferRegister</step>
@@ -232,6 +246,7 @@ Vrij en open source onder de EUPL-licentie.
 			<step>OCA\OpenRegister\Repair\SeedDirectoryVirtualSchemas</step>
 			<step>OCA\OpenRegister\Repair\SeedAppVirtualSchemas</step>
 			<step>OCA\OpenRegister\Repair\SeedTablesVirtualSchemas</step>
+			<step>OCA\OpenRegister\Repair\ImportFlowRegister</step>
 			<step>OCA\OpenRegister\Repair\ImportCredentialBrokerRegister</step>
 			<step>OCA\OpenRegister\Repair\ImportDsarRegisters</step>
 			<step>OCA\OpenRegister\Repair\ImportEdepotTransferRegister</step>


### PR DESCRIPTION
## What gate-98 found

`quality / Hydra Gates` fails on `development` with:

```
[gate-98] repair-step-registration: FAIL — 2 repair step(s) written but never
registered in appinfo/info.xml, so Nextcloud will not run them
```

The two are `ImportFlowRegister` and `RenameDutchColumns`. **#2910 already covers `ImportFlowRegister`** — this PR is the other one, which that PR does not touch, so the two do not collide.

## Why it matters

A repair step Nextcloud is never told about does not run. `RenameDutchColumns` has therefore never executed on any instance.

It moves stored data out of the Dutch columns into the English ones the register now declares. That matters because OpenRegister does not store an object as a JSON blob — each schema property is a real, snake_cased column in the per-schema shard table. `MagicMapper` **adds** a column when the snake_cased property name is absent and it **never renames**; there is not a single `RENAME COLUMN` in the codebase.

So renaming `bedrag` to `amount` in the register leaves the money in `bedrag` while every read looks at `amount` and finds null. No error, no data loss, and invisible to a suite that asserts against fixtures rather than migrated rows.

For the owning app those columns carry **invoice, subsidy, payroll and tax amounts**.

## Placement

`post-migration` only, matching every sibling step in that block and the same decision taken for opencatalogi's `RenameDutchPublicationColumns`: on a fresh install there is nothing to rename.

The step is idempotent and non-destructive by construction — it renames only when the old column exists and the new one does not, copies rather than moves where MagicMapper already added an empty column, refuses two sources targeting one destination, and deletes nothing. A re-run is a no-op.

## Verification

Registration confirmed by parsing the XML rather than by a grep count:

```
post-migration steps: 19
RenameDutchColumns registered: True
ImportFlowRegister registered: False   ← #2910's
```