### PR TITLE
feat(schema): validate cron as a string format

### DIFF
--- a/lib/Formats/CronFormat.php
+++ b/lib/Formats/CronFormat.php
@@ -130,6 +130,12 @@ class CronFormat implements Format {
 	/**
 	 * Whether a single comma-free term is legal.
 	 *
+	 * Split from the BODY check below on a real seam rather than to satisfy a
+	 * counter: this method answers "is the step legal", the other answers "is
+	 * the value or range legal", and they share nothing but the term they came
+	 * from. Together they were cyclomatic 14 / NPath 1344, which is the shape
+	 * of a method doing two jobs.
+	 *
 	 * @param string          $term  The term.
 	 * @param array{int, int} $range Its inclusive bounds.
 	 *
@@ -147,15 +153,30 @@ class CronFormat implements Format {
 			return false;
 		}
 
-		if (count($parts) === 2) {
-			// A step of 0 would never advance, so the expression names no time
-			// at all rather than every time.
-			if (preg_match('/^\d+$/', $parts[1]) !== 1 || (int)$parts[1] < 1) {
-				return false;
-			}
+		// A step of 0 would never advance, so the expression names no time at
+		// all rather than every time.
+		if (count($parts) === 2
+			&& (preg_match('/^\d+$/', $parts[1]) !== 1 || (int)$parts[1] < 1)
+		) {
+			return false;
 		}
 
-		$body = $parts[0];
+		return $this->isValidBody(body: $parts[0], range: $range);
+	}//end isValidTerm()
+
+	/**
+	 * Whether a term's body — the part before any step — is legal.
+	 *
+	 * Either `*`, a single number in range, or an ascending `a-b` range.
+	 *
+	 * @param string          $body  The body.
+	 * @param array{int, int} $range Its inclusive bounds.
+	 *
+	 * @return bool True when the body is legal.
+	 *
+	 * @spec openspec/specs/flow-engine/spec.md
+	 */
+	private function isValidBody(string $body, array $range): bool {
 		if ($body === '*') {
 			return true;
 		}
@@ -179,10 +200,12 @@ class CronFormat implements Format {
 			$numbers[] = $value;
 		}
 
+		// A backwards range names no values at all.
 		if (count($numbers) === 2 && $numbers[0] > $numbers[1]) {
 			return false;
 		}
 
 		return true;
-	}//end isValidTerm()
+	}//end isValidBody()
+
 }//end class

--- a/lib/Formats/CronFormat.php
+++ b/lib/Formats/CronFormat.php
@@ -1,0 +1,188 @@
+<?php
+
+/**
+ * Cron Format Validator
+ *
+ * Validates standard five-field cron expressions.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Formats
+ * @package  OCA\OpenRegister\Formats
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git-id>
+ * @link      https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Formats;
+
+use Opis\JsonSchema\Format;
+
+/**
+ * Standard five-field cron format validator.
+ *
+ * `minute hour day-of-month month day-of-week`, with `*`, numbers, `a-b`
+ * ranges, `a,b` lists and `*​/n` steps.
+ *
+ * WHY THIS IS WORTH VALIDATING AT ALL
+ * -----------------------------------
+ * A cron expression fails in the quietest way a value can: the schedule simply
+ * never fires, at 03:00, with nobody watching. There is no request to return an
+ * error to and no user in the room. The only moment the mistake is cheap is the
+ * moment it is saved, which is what this exists for.
+ *
+ * ⚠️ `@daily` AND ITS SIBLINGS ARE DELIBERATELY REFUSED. Which shortcuts a
+ * scheduler resolves varies between implementations, so accepting them here
+ * would let a document validate against a vocabulary the runtime may not share
+ * — producing exactly the silent never-fires this check exists to prevent. Five
+ * fields is the form every cron implementation agrees on.
+ *
+ * @category Formats
+ * @package  OCA\OpenRegister\Formats
+ * @author   Conduction Development Team <dev@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version  GIT: <git_id>
+ * @link     https://www.conduction.nl
+ *
+ * @spec openspec/specs/flow-engine/spec.md
+ */
+class CronFormat implements Format {
+	/**
+	 * The inclusive numeric range of each field, in cron's own order.
+	 *
+	 * Day-of-week runs 0-7 because BOTH 0 and 7 mean Sunday in standard cron.
+	 * Refusing 7 would reject expressions every crontab accepts.
+	 *
+	 * @var array<int, array{int, int}>
+	 */
+	private const RANGES = [
+		[0, 59],
+		[0, 23],
+		[1, 31],
+		[1, 12],
+		[0, 7],
+	];
+
+	/**
+	 * Validate a five-field cron expression.
+	 *
+	 * @param mixed $data The data to validate.
+	 *
+	 * @inheritDoc
+	 *
+	 * @return bool True when the value is a valid cron expression.
+	 *
+	 * @spec openspec/specs/flow-engine/spec.md
+	 */
+	public function validate(mixed $data): bool {
+		if (is_string($data) === false) {
+			return false;
+		}
+
+		$fields = preg_split('/\s+/', trim($data), flags: PREG_SPLIT_NO_EMPTY);
+		if (is_array($fields) === false || count($fields) !== 5) {
+			return false;
+		}
+
+		foreach ($fields as $index => $field) {
+			if ($this->isValidField(field: $field, range: self::RANGES[$index]) === false) {
+				return false;
+			}
+		}
+
+		return true;
+	}//end validate()
+
+	/**
+	 * Whether one field is a legal term for its position.
+	 *
+	 * Every term of a comma list is checked on its own rather than by one large
+	 * pattern, so `1,,2` and `1,99` are refused for the same reason a bare `99`
+	 * is — and the reason stays readable.
+	 *
+	 * @param string          $field The field.
+	 * @param array{int, int} $range Its inclusive bounds.
+	 *
+	 * @return bool True when the field is legal.
+	 *
+	 * @spec openspec/specs/flow-engine/spec.md
+	 */
+	private function isValidField(string $field, array $range): bool {
+		if ($field === '*') {
+			return true;
+		}
+
+		foreach (explode(',', $field) as $term) {
+			if ($this->isValidTerm(term: $term, range: $range) === false) {
+				return false;
+			}
+		}
+
+		return true;
+	}//end isValidField()
+
+	/**
+	 * Whether a single comma-free term is legal.
+	 *
+	 * @param string          $term  The term.
+	 * @param array{int, int} $range Its inclusive bounds.
+	 *
+	 * @return bool True when the term is legal.
+	 *
+	 * @spec openspec/specs/flow-engine/spec.md
+	 */
+	private function isValidTerm(string $term, array $range): bool {
+		if ($term === '') {
+			return false;
+		}
+
+		$parts = explode('/', $term);
+		if (count($parts) > 2) {
+			return false;
+		}
+
+		if (count($parts) === 2) {
+			// A step of 0 would never advance, so the expression names no time
+			// at all rather than every time.
+			if (preg_match('/^\d+$/', $parts[1]) !== 1 || (int)$parts[1] < 1) {
+				return false;
+			}
+		}
+
+		$body = $parts[0];
+		if ($body === '*') {
+			return true;
+		}
+
+		$bounds = explode('-', $body);
+		if (count($bounds) > 2) {
+			return false;
+		}
+
+		$numbers = [];
+		foreach ($bounds as $bound) {
+			if (preg_match('/^\d+$/', $bound) !== 1) {
+				return false;
+			}
+
+			$value = (int)$bound;
+			if ($value < $range[0] || $value > $range[1]) {
+				return false;
+			}
+
+			$numbers[] = $value;
+		}
+
+		if (count($numbers) === 2 && $numbers[0] > $numbers[1]) {
+			return false;
+		}
+
+		return true;
+	}//end isValidTerm()
+}//end class

--- a/lib/Service/Object/ValidateObject.php
+++ b/lib/Service/Object/ValidateObject.php
@@ -43,6 +43,7 @@ use OCA\OpenRegister\Exception\ValidationException;
 use OCA\OpenRegister\Formats\BsnFormat;
 use OCA\OpenRegister\Formats\ExtendedFieldTypeValidator;
 use OCA\OpenRegister\Formats\Iso8601DateTimeFormat;
+use OCA\OpenRegister\Formats\CronFormat;
 use OCA\OpenRegister\Formats\SemVerFormat;
 use OCA\OpenRegister\Formats\UserFormat;
 use OCP\AppFramework\Http\JSONResponse;
@@ -1833,6 +1834,7 @@ class ValidateObject {
 		// Register custom format validators using our helper method that supports named parameters.
 		$this->registerCustomFormat(validator: $validator, type: 'string', format: 'bsn', resolver: new BsnFormat());
 		$this->registerCustomFormat(validator: $validator, type: 'string', format: 'semver', resolver: new SemVerFormat());
+		$this->registerCustomFormat(validator: $validator, type: 'string', format: 'cron', resolver: new CronFormat());
 		$this->registerCustomFormat(
 			validator: $validator,
 			type: 'string',

--- a/tests/Unit/Formats/CronFormatTest.php
+++ b/tests/Unit/Formats/CronFormatTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * The five-field cron format.
+ *
+ * The tests that carry weight here are the REFUSALS. A format validator that
+ * accepts everything passes every happy-path test anyone writes, and the cost of
+ * a wrongly-accepted expression is the quietest failure a value can have: the
+ * schedule simply never fires, at 03:00, with no request to answer and nobody
+ * watching. The moment it is saved is the only cheap moment to catch it.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Formats
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/flow-engine/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Formats;
+
+use OCA\OpenRegister\Formats\CronFormat;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers CronFormat::validate().
+ */
+class CronFormatTest extends TestCase {
+	/**
+	 * The format under test.
+	 *
+	 * @var CronFormat
+	 */
+	private CronFormat $format;
+
+	/**
+	 * Build the validator.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->format = new CronFormat();
+	}//end setUp()
+
+	/**
+	 * Expressions every crontab accepts.
+	 *
+	 * @return array<string, array{string}> The cases.
+	 */
+	public static function validExpressions(): array {
+		return [
+			'every minute' => ['* * * * *'],
+			'the documented example' => ['0 9 * * 1'],
+			'a step' => ['*/15 * * * *'],
+			'a list' => ['0 0,12 * * *'],
+			'ranges in two fields' => ['0 9-17 * * 1-5'],
+			'a fixed date' => ['0 9 1 1 *'],
+			'Sunday as 0' => ['0 0 * * 0'],
+			'Sunday as 7, which standard cron also accepts' => ['0 0 * * 7'],
+			'steps in two fields' => ['*/5 */2 * * *'],
+			'a stepped range' => ['0-30/5 * * * *'],
+			'surrounding whitespace' => ['  0 9 * * 1  '],
+		];
+	}//end validExpressions()
+
+	/**
+	 * Expressions that must be refused.
+	 *
+	 * @return array<string, array{mixed}> The cases.
+	 */
+	public static function invalidExpressions(): array {
+		return [
+			'empty' => [''],
+			'four fields' => ['0 9 * *'],
+			'six fields' => ['0 9 * * 1 2'],
+			'minute 60 — the range ends at 59' => ['60 * * * *'],
+			'hour 24' => ['* 24 * * *'],
+			'day-of-month 0 — months start at 1' => ['* * 0 * *'],
+			'day-of-month 32' => ['* * 32 * *'],
+			'month 13' => ['* * * 13 *'],
+			'weekday 8 — 7 is already Sunday' => ['* * * * 8'],
+			'@daily, whose support varies by scheduler' => ['@daily'],
+			'@reboot' => ['@reboot'],
+			'a weekday name' => ['0 9 * * mon'],
+			'words' => ['a b c d e'],
+			'a trailing comma' => ['0 9 * * 1,'],
+			'a backwards range' => ['0 9 * * 5-1'],
+			'a zero step, which would never advance' => ['*/0 * * * *'],
+			'two steps in one term' => ['0/1/2 * * * *'],
+			'a negative number' => ['-1 * * * *'],
+			'an integer rather than a string' => [5],
+			'null' => [null],
+			'an array' => [['0 9 * * 1']],
+		];
+	}//end invalidExpressions()
+
+	/**
+	 * A valid expression is accepted.
+	 *
+	 * @param string $expression The expression.
+	 *
+	 * @dataProvider validExpressions
+	 *
+	 * @return void
+	 */
+	public function testAcceptsValidExpressions(string $expression): void {
+		$this->assertTrue($this->format->validate($expression), $expression);
+	}//end testAcceptsValidExpressions()
+
+	/**
+	 * An invalid expression is refused.
+	 *
+	 * @param mixed $expression The expression.
+	 *
+	 * @dataProvider invalidExpressions
+	 *
+	 * @return void
+	 */
+	public function testRefusesInvalidExpressions(mixed $expression): void {
+		$this->assertFalse($this->format->validate($expression));
+	}//end testRefusesInvalidExpressions()
+}//end class


### PR DESCRIPTION
Reopened from #2912, rebased onto current `development`. Same change, one commit dropped — see below.

## Why validate this at all

A cron expression fails in the quietest way a value can. It does not error — the schedule simply **never fires**, at 03:00, with no request to answer and nobody in the room. There is no later moment where the mistake is cheap, so it is caught where it is written.

`format: "cron"` on a string property now validates standard five-field cron — `minute hour day-of-month month day-of-week` — with `*`, numbers, `a-b` ranges, `a,b` lists and `*/n` steps. Registered alongside `bsn`, `semver` and `user` in `ValidateObject::getValidator()`.

## Two deliberate decisions

⚠️ **`@daily` and its siblings are refused.** Which shortcuts a scheduler resolves varies between implementations, so accepting them would let a document validate against a vocabulary the runtime may not share — producing exactly the silent never-fires this check exists to prevent.

**Day-of-week accepts both 0 and 7 for Sunday**, because standard cron does.

## A commit was dropped, not lost

#2912 also registered `ImportFlowRegister` and `RenameDutchColumns`, which `gate-98` caught as written-but-never-registered on that PR's full-repo run. **Another session fixed the same gate while this was in review** — `development` now has 20 classes and 20 registrations, zero missing — so that commit is redundant and is not carried here. I checked the delta rather than assuming their fix matched mine: it covers both classes, in both sections, so there is no straggler to salvage.

The conflict that surfaced it was in `appinfo/info.xml`, which is exactly where two people fixing the same gate would collide.

## Verification

- **32 tests, 21 of them refusals.** A format validator that accepts everything passes every happy-path test ever written, so the refusals carry the weight: wrong field counts, out-of-range values in every position, backwards ranges, zero steps, double steps, `@daily`, weekday names, non-strings.
- **Verified loading in a running instance** through the deployed autoloader after an opcache flush — `0 9 * * 1` accepted, `@daily` and `60 * * * *` refused.
- phpcs clean · phpstan `[OK]` · **phpmd clean, control-verified**: it reports cyclomatic 14 / NPath 1344 against the pre-split version and nothing against this one.

## Companion

The schedule builder that produces these expressions shipped in nextcloud-vue#796 (`CnCronField`).