### PR TITLE
feat(aggregation): derived metrics — arithmetic over the metrics beside them

### DIFF
--- a/lib/Service/Aggregation/AggregationMetricsAnnotationValidator.php
+++ b/lib/Service/Aggregation/AggregationMetricsAnnotationValidator.php
@@ -56,7 +56,19 @@ class AggregationMetricsAnnotationValidator {
 	 *
 	 * @var array<int, string>
 	 */
-	private const VALID_METRICS = ['count', 'sum', 'avg', 'min', 'max', 'count_distinct'];
+	private const VALID_METRICS = ['count', 'sum', 'avg', 'min', 'max', 'count_distinct', 'expression'];
+
+	/**
+	 * The DERIVED metric: arithmetic over the aliases of the metrics beside it,
+	 * rather than an aggregate over rows.
+	 *
+	 * It takes no `field` — there is nothing to aggregate — and it MUST carry
+	 * both an `expression` and an `as`, because its value has no metric+field
+	 * pair to derive a response key from.
+	 *
+	 * @var string
+	 */
+	private const METRIC_EXPRESSION = 'expression';
 
 	/**
 	 * Metrics that are meaningless without a field to aggregate.
@@ -142,6 +154,57 @@ class AggregationMetricsAnnotationValidator {
 					),
 				],
 			];
+		}
+
+		if ($metric === self::METRIC_EXPRESSION) {
+			// A derived metric is validated on different terms: it reads the
+			// figures beside it, so it has no field, and without `as` its value
+			// has no response key at all.
+			$expression = $this->asString(value: ($entry['expression'] ?? ''));
+			if (trim($expression) === '') {
+				return [
+					[
+						'code' => 'aggregation-metrics-expression-empty',
+						'message' => sprintf(
+							'Aggregation "%s" metrics[%d] declares metric "expression" with no '
+							.'`expression` to evaluate.',
+							$name,
+							$index
+						),
+					],
+				];
+			}
+
+			$alias = $this->asString(value: ($entry['as'] ?? ''));
+			if (trim($alias) === '') {
+				return [
+					[
+						'code' => 'aggregation-metrics-expression-unnamed',
+						'message' => sprintf(
+							'Aggregation "%s" metrics[%d] is a derived metric and must declare `as`: '
+							.'it has no field or metric name to derive a response key from.',
+							$name,
+							$index
+						),
+					],
+				];
+			}
+
+			if (isset($entry['field']) === true) {
+				return [
+					[
+						'code' => 'aggregation-metrics-expression-has-field',
+						'message' => sprintf(
+							'Aggregation "%s" metrics[%d] is a derived metric and takes no `field`: '
+							.'it reads the aliases of the metrics beside it, not the rows.',
+							$name,
+							$index
+						),
+					],
+				];
+			}
+
+			return [];
 		}
 
 		$extra = $this->validateConditionAndAlias(

--- a/lib/Service/Aggregation/AggregationRunner.php
+++ b/lib/Service/Aggregation/AggregationRunner.php
@@ -118,6 +118,18 @@ class AggregationRunner {
 	private readonly RegisterScopedSchemaResolver $scopedResolver;
 
 	/**
+	 * Evaluates derived (`metric: expression`) metrics over the aliases of the
+	 * metrics computed alongside them.
+	 *
+	 * Constructed here rather than injected: it is a pure evaluator with no
+	 * collaborators, and adding a required constructor argument would change
+	 * the signature every existing caller and test already builds.
+	 *
+	 * @var MetricExpressionEvaluator
+	 */
+	private readonly MetricExpressionEvaluator $expressions;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param MagicMapper $magicMapper Magic-table mapper used for the PHP fallback path.
@@ -161,6 +173,7 @@ class AggregationRunner {
 			registerMapper: $registerMapper,
 			schemaMapper: $schemaMapper
 		);
+		$this->expressions = new MetricExpressionEvaluator();
 	}//end __construct()
 
 
@@ -1763,6 +1776,16 @@ class AggregationRunner {
 				continue;
 			}
 
+			// A DERIVED metric has no SQL form at all: it is arithmetic over the
+			// other metrics' results, which do not exist until they have been
+			// computed. Stated explicitly rather than relying on the `as` check
+			// below to catch it, so removing `as` could never route an
+			// expression at the native path and have it silently compute
+			// nothing.
+			if (($entry['metric'] ?? null) === 'expression') {
+				return true;
+			}
+
 			$condition = ($entry['condition'] ?? null);
 			if (is_array($condition) === true && $condition !== []) {
 				return true;
@@ -1794,6 +1817,33 @@ class AggregationRunner {
 	private function computeMetrics(array $rows, array $metrics): array {
 		$values = [];
 		foreach ($metrics as $entry) {
+			// A DERIVED metric reads the figures this aggregation has already
+			// produced, rather than the rows. `vatBalance = totalVATPaid -
+			// totalVATCollected` is arithmetic between two sums just computed;
+			// declaring a second aggregation to subtract them scans the table
+			// again, and the two results can disagree if a row is written
+			// between the calls — which a trial balance must never do.
+			//
+			// It reads only aliases computed BEFORE it, so the order of the
+			// `metrics` list is the dependency order. An alias that is not there
+			// yet raises and names what IS available, because resolving it to 0
+			// would turn a typo into a plausible number.
+			if (($entry['metric'] ?? null) === 'expression') {
+				$derivedAlias = ($entry['as'] ?? null);
+				if (is_string($derivedAlias) === false || $derivedAlias === '') {
+					throw new RuntimeException(
+						'A derived metric must declare `as`: it has no field or metric name to '
+						.'derive a response key from.'
+					);
+				}
+
+				$values[$derivedAlias] = $this->expressions->evaluate(
+					expression: (string)($entry['expression'] ?? ''),
+					scope: $values
+				);
+				continue;
+			}
+
 			// `condition` — a per-metric filter, so one grouping can carry
 			// several figures over DIFFERENT row subsets.
 			//

--- a/lib/Service/Aggregation/MetricExpressionEvaluator.php
+++ b/lib/Service/Aggregation/MetricExpressionEvaluator.php
@@ -1,0 +1,356 @@
+<?php
+
+/**
+ * OpenRegister MetricExpressionEvaluator
+ *
+ * Evaluates a DERIVED metric: a small arithmetic expression over the aliases of
+ * the other metrics computed in the same aggregation.
+ *
+ * ## Why this exists
+ *
+ * A trial balance needs `vatBalance = totalVATPaid - totalVATCollected`, and a
+ * revenue waterfall needs `remaining = transactionPriceAllocated -
+ * cumulativeRecognised`. Both figures are already computed by the aggregation;
+ * only the arithmetic between them was missing, so 41 declarations across the
+ * shillinq registers carried an `expression` key the engine never read. They
+ * did not fail — they simply produced nothing for that figure.
+ *
+ * Declaring a second aggregation to do the subtraction is not equivalent: it
+ * scans the table again, and the two results can disagree if a row is written
+ * between the calls. A derived metric reads the numbers this aggregation just
+ * produced, so it cannot disagree with them.
+ *
+ * ## Why a parser and not eval()
+ *
+ * These expressions come from register descriptors, which are data. `eval()` on
+ * data is arbitrary code execution, and no amount of "we control the registers"
+ * survives the first app that imports a descriptor from somewhere else. This is
+ * a recursive-descent parser over a closed grammar:
+ *
+ *     expr    := term (('+' | '-') term)*
+ *     term    := factor (('*' | '/') factor)*
+ *     factor  := NUMBER | IDENT | '(' expr ')' | ('min'|'max') '(' expr ',' expr ')'
+ *              | '-' factor
+ *
+ * Anything outside it is refused by name. There is no variable assignment, no
+ * function call beyond min/max, no property access and no string literal.
+ *
+ * ## What it refuses, and why refusing is the point
+ *
+ * - An IDENTIFIER THAT NAMES NO ALIAS throws. Resolving it to 0 would turn a
+ *   typo into a plausible number — `a - typo` would silently return `a`, which
+ *   is exactly the failure mode this whole effort removes.
+ * - DIVISION BY ZERO yields null rather than INF or NAN. A JSON-encoded INF is
+ *   not valid JSON, and NAN compares false against everything, so both travel
+ *   further than they should before anyone notices.
+ * - A NON-NUMERIC alias value throws, naming the alias.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Aggregation
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Aggregation;
+
+use RuntimeException;
+
+/**
+ * Evaluates arithmetic over the aliases of already-computed metrics.
+ */
+class MetricExpressionEvaluator {
+
+	/**
+	 * The token list for the expression currently being evaluated.
+	 *
+	 * @var array<int, array{type: string, value: string}>
+	 */
+	private array $tokens = [];
+
+	/**
+	 * Read position within {@see $tokens}.
+	 *
+	 * @var int
+	 */
+	private int $pos = 0;
+
+	/**
+	 * Number of tokens, cached so the parse loops do not call count() per turn.
+	 *
+	 * @var int
+	 */
+	private int $count = 0;
+
+	/**
+	 * Alias => value for the metrics already computed in this aggregation.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private array $scope = [];
+
+	/**
+	 * Turns the source into tokens. Split out so the lexer's character-level
+	 * branching does not count against the parser's complexity budget — they
+	 * are genuinely different jobs and phpmd was right to say so.
+	 *
+	 * @var MetricExpressionLexer
+	 */
+	private readonly MetricExpressionLexer $lexer;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->lexer = new MetricExpressionLexer();
+	}//end __construct()
+
+	/**
+	 * Evaluate one expression against the already-computed metric values.
+	 *
+	 * @param string               $expression The expression source.
+	 * @param array<string, mixed> $scope      Alias => value of the metrics computed so far.
+	 *
+	 * @return float|null The result, or null when a division by zero made it undefined.
+	 *
+	 * @throws RuntimeException When the expression is malformed or names an unknown alias.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	public function evaluate(string $expression, array $scope): ?float {
+		$this->tokens = $this->lexer->tokenise($expression);
+		$this->pos    = 0;
+		$this->count  = count($this->tokens);
+		$this->scope  = $scope;
+
+		if ($this->tokens === []) {
+			throw new RuntimeException('Metric expression is empty.');
+		}
+
+		$value = $this->parseExpression();
+
+		if ($this->pos < $this->count) {
+			$leftover = $this->tokens[$this->pos]['value'];
+			throw new RuntimeException(
+				sprintf(
+					'Unexpected "%s" in metric expression "%s". The grammar is arithmetic over '
+					.'metric aliases: + - * / parentheses, and min()/max() of two arguments.',
+					$leftover,
+					$expression
+				)
+			);
+		}
+
+		return $value;
+	}//end evaluate()
+
+
+	/**
+	 * expr := term (('+' | '-') term)*
+	 *
+	 * @return float|null The value, or null once a division by zero poisoned it.
+	 */
+	private function parseExpression(): ?float {
+		$value = $this->parseTerm();
+
+		while ($this->pos < $this->count
+			&& ($this->tokens[$this->pos]['type'] === '+' || $this->tokens[$this->pos]['type'] === '-')
+		) {
+			$op = $this->tokens[$this->pos]['type'];
+			$this->pos++;
+			$rhs = $this->parseTerm();
+
+			if ($value === null || $rhs === null) {
+				$value = null;
+				continue;
+			}
+
+			$value = ($op === '+') ? ($value + $rhs) : ($value - $rhs);
+		}
+
+		return $value;
+	}//end parseExpression()
+
+	/**
+	 * term := factor (('*' | '/') factor)*
+	 *
+	 * @return float|null The value, or null on a division by zero.
+	 */
+	private function parseTerm(): ?float {
+		$value = $this->parseFactor();
+
+		while ($this->pos < $this->count
+			&& ($this->tokens[$this->pos]['type'] === '*' || $this->tokens[$this->pos]['type'] === '/')
+		) {
+			$op = $this->tokens[$this->pos]['type'];
+			$this->pos++;
+			$rhs = $this->parseFactor();
+
+			if ($value === null || $rhs === null) {
+				$value = null;
+				continue;
+			}
+
+			if ($op === '*') {
+				$value = ($value * $rhs);
+				continue;
+			}
+
+			// DIVISION BY ZERO YIELDS NULL, not INF and not NAN. json_encode()
+			// refuses INF outright, and NAN compares false against everything,
+			// so either one travels a long way before anybody notices.
+			if ($rhs === 0.0) {
+				$value = null;
+				continue;
+			}
+
+			$value = ($value / $rhs);
+		}//end while
+
+		return $value;
+	}//end parseTerm()
+
+	/**
+	 * factor := NUMBER | IDENT | '(' expr ')' | ('min'|'max') '(' expr ',' expr ')' | '-' factor
+	 *
+	 * @return float|null The value.
+	 *
+	 * @throws RuntimeException On a malformed factor or an unknown alias.
+	 */
+	private function parseFactor(): ?float {
+		if ($this->pos >= $this->count) {
+			throw new RuntimeException('Metric expression ended where a value was expected.');
+		}
+
+		$token = $this->tokens[$this->pos];
+
+		if ($token['type'] === '-') {
+			$this->pos++;
+			$inner = $this->parseFactor();
+			return ($inner === null) ? null : (0 - $inner);
+		}
+
+		if ($token['type'] === 'number') {
+			$this->pos++;
+			return (float)$token['value'];
+		}
+
+		if ($token['type'] === '(') {
+			$this->pos++;
+			$inner = $this->parseExpression();
+			$this->expect(')');
+			return $inner;
+		}
+
+		if ($token['type'] === 'ident') {
+			$name = $token['value'];
+
+			if ($name === 'min' || $name === 'max') {
+				return $this->parseMinMax(name: $name);
+			}
+
+			$this->pos++;
+			return $this->resolveAlias(name: $name);
+		}
+
+		throw new RuntimeException(
+			sprintf('Unexpected "%s" where a value was expected in a metric expression.', $token['value'])
+		);
+	}//end parseFactor()
+
+	/**
+	 * ('min'|'max') '(' expr ',' expr ')'
+	 *
+	 * @param string $name Either `min` or `max`.
+	 *
+	 * @return float|null The chosen value, or null when either argument is null.
+	 */
+	private function parseMinMax(string $name): ?float {
+		$this->pos++;
+		$this->expect('(');
+		$left = $this->parseExpression();
+		$this->expect(',');
+		$right = $this->parseExpression();
+		$this->expect(')');
+
+		if ($left === null || $right === null) {
+			return null;
+		}
+
+		return ($name === 'min') ? min($left, $right) : max($left, $right);
+	}//end parseMinMax()
+
+	/**
+	 * Resolve an identifier against the already-computed metric aliases.
+	 *
+	 * An unknown alias THROWS. Resolving it to 0 would turn a typo into a
+	 * plausible number: `a - typo` would quietly return `a`.
+	 *
+	 * @param string $name The alias.
+	 *
+	 * @return float|null The alias value, or null when the alias itself is null.
+	 *
+	 * @throws RuntimeException When the alias is unknown or not numeric.
+	 */
+	private function resolveAlias(string $name): ?float {
+		if (array_key_exists($name, $this->scope) === false) {
+			$known = array_keys($this->scope);
+			sort($known);
+			throw new RuntimeException(
+				sprintf(
+					'Metric expression references "%s", which is not a metric in this aggregation. '
+					.'Available: %s. A derived metric can only read figures computed BEFORE it, so '
+					.'order the `metrics` list accordingly.',
+					$name,
+					($known === [] ? '(none)' : implode(', ', $known))
+				)
+			);
+		}
+
+		$value = $this->scope[$name];
+
+		if ($value === null) {
+			return null;
+		}
+
+		if (is_int($value) === false && is_float($value) === false) {
+			throw new RuntimeException(
+				sprintf(
+					'Metric expression references "%s", whose value is %s rather than a number.',
+					$name,
+					get_debug_type($value)
+				)
+			);
+		}
+
+		return (float)$value;
+	}//end resolveAlias()
+
+	/**
+	 * Consume the expected token type or refuse.
+	 *
+	 * @param string $type The token type expected next.
+	 *
+	 * @return void
+	 *
+	 * @throws RuntimeException When the next token is not the expected one.
+	 */
+	private function expect(string $type): void {
+		if ($this->pos >= $this->count || $this->tokens[$this->pos]['type'] !== $type) {
+			$found = ($this->pos < $this->count) ? $this->tokens[$this->pos]['value'] : 'end of expression';
+			throw new RuntimeException(
+				sprintf('Expected "%s" in a metric expression, found "%s".', $type, $found)
+			);
+		}
+
+		$this->pos++;
+	}//end expect()
+}//end class

--- a/lib/Service/Aggregation/MetricExpressionLexer.php
+++ b/lib/Service/Aggregation/MetricExpressionLexer.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * OpenRegister MetricExpressionLexer
+ *
+ * Turns a derived-metric expression into tokens, refusing any character outside
+ * the grammar {@see MetricExpressionEvaluator} parses.
+ *
+ * Separate from the evaluator because lexing and parsing are different jobs and
+ * the combined class exceeded phpmd's complexity budget — the split is the fix
+ * phpmd was asking for, not a way around it.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Aggregation
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Aggregation;
+
+use RuntimeException;
+
+/**
+ * Tokenises a derived-metric expression.
+ */
+class MetricExpressionLexer {
+
+	/**
+	 * Split the source into tokens, refusing any character outside the grammar.
+	 *
+	 * @param string $expression The expression source.
+	 *
+	 * @return array<int, array{type: string, value: string}> The tokens.
+	 *
+	 * @throws RuntimeException On a character the grammar does not contain.
+	 *
+	 * @spec openspec/specs/aggregation-api/spec.md
+	 */
+	public function tokenise(string $expression): array {
+		$tokens = [];
+		$len    = strlen($expression);
+		$pos    = 0;
+
+		while ($pos < $len) {
+			$ch = $expression[$pos];
+
+			if (trim($ch) === '') {
+				$pos++;
+				continue;
+			}
+
+			if (str_contains('+-*/(),', $ch) === true) {
+				$tokens[] = ['type' => $ch, 'value' => $ch];
+				$pos++;
+				continue;
+			}
+
+			if (ctype_digit($ch) === true || $ch === '.') {
+				$end      = $this->scanNumber(expression: $expression, from: $pos, len: $len);
+				$tokens[] = ['type' => 'number', 'value' => substr($expression, $pos, ($end - $pos))];
+				$pos      = $end;
+				continue;
+			}
+
+			if (ctype_alpha($ch) === true || $ch === '_') {
+				$end      = $this->scanIdentifier(expression: $expression, from: $pos, len: $len);
+				$tokens[] = ['type' => 'ident', 'value' => substr($expression, $pos, ($end - $pos))];
+				$pos      = $end;
+				continue;
+			}
+
+			throw new RuntimeException(
+				sprintf(
+					'Metric expression contains "%s", which is not part of the grammar. '
+					.'Allowed: metric aliases, numbers, + - * / ( ) and min()/max().',
+					$ch
+				)
+			);
+		}//end while
+
+		return $tokens;
+	}//end tokenise()
+
+	/**
+	 * Advance past a numeric literal and return the end offset.
+	 *
+	 * @param string $expression The source.
+	 * @param int    $from       Offset of the first digit or dot.
+	 * @param int    $len        Length of the source.
+	 *
+	 * @return int Offset one past the literal.
+	 */
+	private function scanNumber(string $expression, int $from, int $len): int {
+		$end = $from;
+		while ($end < $len && (ctype_digit($expression[$end]) === true || $expression[$end] === '.')) {
+			$end++;
+		}
+
+		return $end;
+	}//end scanNumber()
+
+	/**
+	 * Advance past an identifier and return the end offset.
+	 *
+	 * @param string $expression The source.
+	 * @param int    $from       Offset of the first character.
+	 * @param int    $len        Length of the source.
+	 *
+	 * @return int Offset one past the identifier.
+	 */
+	private function scanIdentifier(string $expression, int $from, int $len): int {
+		$end = $from;
+		while ($end < $len && (ctype_alnum($expression[$end]) === true || $expression[$end] === '_')) {
+			$end++;
+		}
+
+		return $end;
+	}//end scanIdentifier()
+}//end class

--- a/tests/Unit/Service/Aggregation/CrossSchemaAggregationRunnerTest.php
+++ b/tests/Unit/Service/Aggregation/CrossSchemaAggregationRunnerTest.php
@@ -732,4 +732,132 @@ class CrossSchemaAggregationRunnerTest extends TestCase {
 		$this->assertSame(1, $result['value']);
 	}//end testCrossSchemaAtSelfPresentButNullStillResolves()
 
+	/**
+	 * @test
+	 * A DERIVED metric computes from the aliases beside it, end to end.
+	 *
+	 * This is the shape 41 declarations across the shillinq registers carried in
+	 * an `expression` key the engine never read: a debit/credit split plus the
+	 * balance between them. The balance is arithmetic over two figures this
+	 * aggregation already produced, so it cannot disagree with them — which a
+	 * second aggregation doing the subtraction could, if a row were written
+	 * between the two calls.
+	 */
+	public function testDerivedMetricComputesFromItsSiblings(): void {
+		$parentSchema = $this->makeSchema('vat-return', 10, [
+			'totalsByReturn' => [
+				'from' => 'vat-line',
+				'metrics' => [
+					[
+						'metric' => 'sum',
+						'field' => 'vatAmount',
+						'condition' => ['type' => 'collected'],
+						'as' => 'totalVATCollected',
+					],
+					[
+						'metric' => 'sum',
+						'field' => 'vatAmount',
+						'condition' => ['type' => 'paid'],
+						'as' => 'totalVATPaid',
+					],
+					[
+						'metric' => 'expression',
+						'expression' => 'totalVATPaid - totalVATCollected',
+						'as' => 'vatBalance',
+					],
+				],
+			],
+		]);
+		$targetSchema = $this->makeSchema('vat-line', 20);
+		$parentRegister = $this->makeRegister('shillinq', [10]);
+		$targetRegister = $this->makeRegister('shillinq', [20]);
+
+		$this->registerMapper->method('find')->willReturn($parentRegister);
+		$this->schemaMapper->method('find')
+			->willReturnMap([
+				['vat-return', [], true, false, $parentSchema],
+				['vat-line', [], true, false, $targetSchema],
+			]);
+		$this->registerMapper->method('findAll')->willReturn([$parentRegister, $targetRegister]);
+		$this->permissionHandler->method('hasPermission')->willReturn(true);
+		$this->usePhpFallback();
+
+		// Asymmetric on purpose: a swapped condition, or a balance computed the
+		// other way round, cannot produce 55 by accident.
+		$this->magicMapper->method('findAllInRegisterSchemaTable')
+			->willReturn([
+				$this->makeEntityStub(['type' => 'collected', 'vatAmount' => 100]),
+				$this->makeEntityStub(['type' => 'collected', 'vatAmount' => 25]),
+				$this->makeEntityStub(['type' => 'paid', 'vatAmount' => 180]),
+			]);
+
+		$result = $this->runner->run(
+			registerRef: 'shillinq',
+			schemaRef: 'vat-return',
+			name: 'totalsByReturn',
+			bypassRbac: true
+		);
+
+		$values = ($result['values'] ?? null);
+		$this->assertIsArray($values, 'a `metrics` spec must yield `values`');
+		$this->assertEqualsWithDelta(125.0, (float)$values['totalVATCollected'], 0.001);
+		$this->assertEqualsWithDelta(180.0, (float)$values['totalVATPaid'], 0.001);
+
+		// 180 - 125. Not 55 by coincidence: reversing the subtraction gives -55,
+		// and dropping either condition changes both operands.
+		$this->assertEqualsWithDelta(55.0, (float)$values['vatBalance'], 0.001);
+	}//end testDerivedMetricComputesFromItsSiblings()
+
+	/**
+	 * @test
+	 * A derived metric that reads an alias defined AFTER it is refused.
+	 *
+	 * The `metrics` list is the dependency order. Returning null here would look
+	 * like "no data" for a figure that is simply declared in the wrong order.
+	 */
+	public function testDerivedMetricCannotReadALaterAlias(): void {
+		$parentSchema = $this->makeSchema('vat-return', 10, [
+			'badOrder' => [
+				'from' => 'vat-line',
+				'metrics' => [
+					[
+						'metric' => 'expression',
+						'expression' => 'later - 1',
+						'as' => 'tooEarly',
+					],
+					[
+						'metric' => 'sum',
+						'field' => 'vatAmount',
+						'as' => 'later',
+					],
+				],
+			],
+		]);
+		$targetSchema = $this->makeSchema('vat-line', 20);
+		$parentRegister = $this->makeRegister('shillinq', [10]);
+		$targetRegister = $this->makeRegister('shillinq', [20]);
+
+		$this->registerMapper->method('find')->willReturn($parentRegister);
+		$this->schemaMapper->method('find')
+			->willReturnMap([
+				['vat-return', [], true, false, $parentSchema],
+				['vat-line', [], true, false, $targetSchema],
+			]);
+		$this->registerMapper->method('findAll')->willReturn([$parentRegister, $targetRegister]);
+		$this->permissionHandler->method('hasPermission')->willReturn(true);
+		$this->usePhpFallback();
+		$this->magicMapper->method('findAllInRegisterSchemaTable')
+			->willReturn([$this->makeEntityStub(['vatAmount' => 10])]);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/later/');
+
+		$this->runner->run(
+			registerRef: 'shillinq',
+			schemaRef: 'vat-return',
+			name: 'badOrder',
+			bypassRbac: true
+		);
+	}//end testDerivedMetricCannotReadALaterAlias()
+
 }//end class

--- a/tests/Unit/Service/Aggregation/MetricExpressionEvaluatorTest.php
+++ b/tests/Unit/Service/Aggregation/MetricExpressionEvaluatorTest.php
@@ -1,0 +1,201 @@
+<?php
+
+/**
+ * Unit tests for MetricExpressionEvaluator.
+ *
+ * The evaluator is pure, so these exercise the real parser rather than a
+ * fixture that agrees with it.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Aggregation
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Aggregation;
+
+use OCA\OpenRegister\Service\Aggregation\MetricExpressionEvaluator;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * No `covers` metadata, deliberately — `beStrictAboutCoverageMetadata="true"`
+ * discards the coverage of any test that touches a collaborator it did not name.
+ */
+class MetricExpressionEvaluatorTest extends TestCase {
+
+	private MetricExpressionEvaluator $evaluator;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->evaluator = new MetricExpressionEvaluator();
+	}
+
+	/**
+	 * @test
+	 * The shapes the shillinq registers actually declare.
+	 */
+	public function testEvaluatesTheDeclaredShapes(): void {
+		$scope = [
+			'totalVATPaid' => 300.0,
+			'totalVATCollected' => 125.0,
+			'openingBalanceRj' => 1000,
+			'adjustmentTotal' => -250.5,
+		];
+
+		// vatBalance = totalVATPaid - totalVATCollected
+		$this->assertEqualsWithDelta(
+			175.0,
+			$this->evaluator->evaluate('totalVATPaid - totalVATCollected', $scope),
+			0.001
+		);
+
+		// openingBalanceRj + adjustmentTotal — an int alias and a negative one.
+		$this->assertEqualsWithDelta(
+			749.5,
+			$this->evaluator->evaluate('openingBalanceRj + adjustmentTotal', $scope),
+			0.001
+		);
+	}
+
+	/**
+	 * @test
+	 * Precedence and parentheses, so `a - b * c` is not `(a - b) * c`.
+	 */
+	public function testPrecedenceAndParentheses(): void {
+		$scope = ['a' => 10.0, 'b' => 2.0, 'c' => 3.0];
+
+		$this->assertEqualsWithDelta(4.0, $this->evaluator->evaluate('a - b * c', $scope), 0.001);
+		$this->assertEqualsWithDelta(24.0, $this->evaluator->evaluate('(a - b) * c', $scope), 0.001);
+		$this->assertEqualsWithDelta(-4.0, $this->evaluator->evaluate('-a + b * c', $scope), 0.001);
+	}
+
+	/**
+	 * @test
+	 * The nested min() the innovatiebox nexus fraction needs.
+	 *
+	 * min(min(1.3 * (eigen + uitbesteed), totale) / totale, 1.0)
+	 */
+	public function testNestedMinWithDivision(): void {
+		$scope = ['eigen' => 100.0, 'uitbesteed' => 100.0, 'totale' => 500.0];
+
+		// 1.3 * 200 = 260; min(260, 500) = 260; 260/500 = 0.52; min(0.52, 1.0) = 0.52
+		$this->assertEqualsWithDelta(
+			0.52,
+			$this->evaluator->evaluate('min(min(1.3 * (eigen + uitbesteed), totale) / totale, 1.0)', $scope),
+			0.0001
+		);
+
+		// The cap must actually bind: 1.3 * 900 = 1170; min(1170, 500) = 500;
+		// 500/500 = 1.0; min(1.0, 1.0) = 1.0
+		$capped = ['eigen' => 500.0, 'uitbesteed' => 400.0, 'totale' => 500.0];
+		$this->assertEqualsWithDelta(
+			1.0,
+			$this->evaluator->evaluate('min(min(1.3 * (eigen + uitbesteed), totale) / totale, 1.0)', $capped),
+			0.0001
+		);
+	}
+
+	/**
+	 * @test
+	 * An unknown alias RAISES, and names what is available.
+	 *
+	 * Resolving it to 0 would turn a typo into a plausible number: `a - typo`
+	 * would quietly return `a`, which is exactly the failure this engine work
+	 * exists to remove.
+	 */
+	public function testUnknownAliasThrowsAndNamesTheAvailableOnes(): void {
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/totalVATCollectd.*Available.*totalVATPaid/s');
+
+		$this->evaluator->evaluate(
+			'totalVATPaid - totalVATCollectd',
+			['totalVATPaid' => 300.0]
+		);
+	}
+
+	/**
+	 * @test
+	 * Division by zero yields null, not INF and not NAN.
+	 *
+	 * json_encode() refuses INF outright, and NAN compares false against
+	 * everything — both travel a long way before anyone notices.
+	 */
+	public function testDivisionByZeroIsNullNotInfinity(): void {
+		$result = $this->evaluator->evaluate('a / b', ['a' => 5.0, 'b' => 0.0]);
+
+		$this->assertNull($result);
+		$this->assertNotSame(INF, $result);
+	}
+
+	/**
+	 * @test
+	 * A null alias propagates as null rather than counting as zero.
+	 */
+	public function testNullAliasPropagates(): void {
+		$this->assertNull($this->evaluator->evaluate('a + b', ['a' => 5.0, 'b' => null]));
+		$this->assertNull($this->evaluator->evaluate('min(a, b)', ['a' => 5.0, 'b' => null]));
+	}
+
+	/**
+	 * @test
+	 * Anything outside the grammar is refused by name — there is no eval() here.
+	 *
+	 * These expressions come from register descriptors, which are DATA. eval()
+	 * on data is arbitrary code execution.
+	 */
+	public function testRefusesEverythingOutsideTheGrammar(): void {
+		$scope = ['a' => 1.0];
+
+		foreach ([
+			'phpinfo()',
+			'a; system("id")',
+			'$a + 1',
+			'a->b',
+			"a . 'x'",
+			'a ** 2',
+		] as $hostile) {
+			try {
+				$this->evaluator->evaluate($hostile, $scope);
+				$this->fail(sprintf('Expected "%s" to be refused', $hostile));
+			} catch (RuntimeException $e) {
+				$this->assertNotSame('', $e->getMessage());
+			}
+		}
+	}
+
+	/**
+	 * @test
+	 * A non-numeric alias value raises rather than being coerced.
+	 */
+	public function testNonNumericAliasThrows(): void {
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/rather than a number/');
+
+		$this->evaluator->evaluate('a + 1', ['a' => 'twelve']);
+	}
+
+	/**
+	 * @test
+	 * An empty or truncated expression raises rather than returning 0.
+	 */
+	public function testEmptyAndTruncatedExpressionsThrow(): void {
+		foreach (['', '   ', 'a +', '(a', 'min(a)'] as $bad) {
+			try {
+				$this->evaluator->evaluate($bad, ['a' => 1.0]);
+				$this->fail(sprintf('Expected "%s" to be refused', $bad));
+			} catch (RuntimeException $e) {
+				$this->assertNotSame('', $e->getMessage());
+			}
+		}
+	}
+}//end class


### PR DESCRIPTION
**41 declarations** across the shillinq registers carry an `expression` key the engine never read. They did not fail — they produced nothing for that figure, which is the shape ConductionNL/shillinq#1261 keeps finding.

```json
"vatBalance": { "operation": "expression",
                "expression": "totalVATPaid - totalVATCollected" }
```

Both operands are already computed by the same aggregation. Only the arithmetic between them was missing.

## Why not just declare a second aggregation

It scans the table again, and the two results **can disagree** if a row is written between the calls — which a trial balance must never do. A derived metric reads the numbers this aggregation just produced, so it cannot disagree with them.

## Why a parser and not `eval()`

These expressions come from register descriptors, which are **data**. `eval()` on data is arbitrary code execution, and "we control the registers" does not survive the first app that imports a descriptor from elsewhere.

`MetricExpressionLexer` + `MetricExpressionEvaluator` implement a recursive-descent parser over a closed grammar:

```
expr   := term (('+'|'-') term)*
term   := factor (('*'|'/') factor)*
factor := NUMBER | IDENT | '(' expr ')'
        | ('min'|'max') '(' expr ',' expr ')' | '-' factor
```

No assignment, no property access, no string literals, no function beyond `min`/`max`. Everything else is refused **by name**. The test feeds it `phpinfo()`, `a; system("id")`, `$a + 1`, `a->b`, `a . 'x'` and `a ** 2`.

## What it refuses, deliberately

| case | behaviour | why |
|---|---|---|
| identifier naming no alias | **throws**, listing the aliases that exist | resolving to 0 turns a typo into a plausible number — `a - typo` would quietly return `a` |
| division by zero | **null** | `json_encode()` refuses INF outright, and NAN compares false against everything; both travel far before anyone notices |
| non-numeric alias | **throws** | coercion invents a figure |
| null alias | propagates **null** | not zero — absent is not the same as none |

A derived metric reads only aliases computed **before** it, so the `metrics` list is the dependency order; reading a later one raises and says so.

## Wiring

- `computeMetrics()` gains the branch. It cannot reach the native path: `metricsNeedPhpPath()` now names `expression` **explicitly** rather than relying on the `as` check, so removing `as` could never route one at SQL and have it silently compute nothing.
- The annotation validator accepts `metric: expression`, and refuses one with no `expression`, no `as`, or a `field` (it aggregates nothing).
- The evaluator is constructed internally, like `RegisterScopedSchemaResolver` — it has no collaborators, and a new required constructor argument would change the signature every existing caller and test already builds.

## Verification

- **9 evaluator tests + 2 end-to-end** through `AggregationRunner`
- **Mutation control**: making an unknown alias resolve to 0, and division by zero return INF, each makes the suite fail; reverting restores green — so the tests can detect what they claim
- Full suite **17,588 tests, 0 failures**
- phpcs 0 errors, phpmd clean, phpstan `[OK] No errors`
- Hydra gates run locally with `origin/development` as an explicit delta base: **gate-16 PASS**, gate-98 PASS. `gate-57` (7 orphaned write-capability methods) fails, but every one is in a file this PR does not touch — it is full-tree, pre-existing debt.

Refs ConductionNL/shillinq#1261
