### PR TITLE
fix(phpcs): MetricExpressionEvaluator reddens phpcs on every branch

### DIFF
--- a/lib/Service/Aggregation/MetricExpressionEvaluator.php
+++ b/lib/Service/Aggregation/MetricExpressionEvaluator.php
@@ -66,6 +66,8 @@ use RuntimeException;
 
 /**
  * Evaluates arithmetic over the aliases of already-computed metrics.
+ *
+ * @spec openspec/specs/aggregation-api/spec.md
  */
 class MetricExpressionEvaluator {
 
@@ -173,7 +175,11 @@ class MetricExpressionEvaluator {
 				continue;
 			}
 
-			$value = ($op === '+') ? ($value + $rhs) : ($value - $rhs);
+			if ($op === '+') {
+				$value = ($value + $rhs);
+			} else {
+				$value = ($value - $rhs);
+			}
 		}
 
 		return $value;
@@ -235,7 +241,11 @@ class MetricExpressionEvaluator {
 		if ($token['type'] === '-') {
 			$this->pos++;
 			$inner = $this->parseFactor();
-			return ($inner === null) ? null : (0 - $inner);
+			if ($inner === null) {
+				return null;
+			}
+
+			return (0 - $inner);
 		}
 
 		if ($token['type'] === 'number') {
@@ -246,7 +256,7 @@ class MetricExpressionEvaluator {
 		if ($token['type'] === '(') {
 			$this->pos++;
 			$inner = $this->parseExpression();
-			$this->expect(')');
+			$this->expect(type: ')');
 			return $inner;
 		}
 
@@ -275,17 +285,21 @@ class MetricExpressionEvaluator {
 	 */
 	private function parseMinMax(string $name): ?float {
 		$this->pos++;
-		$this->expect('(');
+		$this->expect(type: '(');
 		$left = $this->parseExpression();
-		$this->expect(',');
+		$this->expect(type: ',');
 		$right = $this->parseExpression();
-		$this->expect(')');
+		$this->expect(type: ')');
 
 		if ($left === null || $right === null) {
 			return null;
 		}
 
-		return ($name === 'min') ? min($left, $right) : max($left, $right);
+		if ($name === 'min') {
+			return min($left, $right);
+		}
+
+		return max($left, $right);
 	}//end parseMinMax()
 
 	/**
@@ -304,13 +318,17 @@ class MetricExpressionEvaluator {
 		if (array_key_exists($name, $this->scope) === false) {
 			$known = array_keys($this->scope);
 			sort($known);
+			$available = '(none)';
+			if ($known !== []) {
+				$available = implode(', ', $known);
+			}
 			throw new RuntimeException(
 				sprintf(
 					'Metric expression references "%s", which is not a metric in this aggregation. '
 					.'Available: %s. A derived metric can only read figures computed BEFORE it, so '
 					.'order the `metrics` list accordingly.',
 					$name,
-					($known === [] ? '(none)' : implode(', ', $known))
+					$available
 				)
 			);
 		}
@@ -345,7 +363,10 @@ class MetricExpressionEvaluator {
 	 */
 	private function expect(string $type): void {
 		if ($this->pos >= $this->count || $this->tokens[$this->pos]['type'] !== $type) {
-			$found = ($this->pos < $this->count) ? $this->tokens[$this->pos]['value'] : 'end of expression';
+			$found = 'end of expression';
+			if ($this->pos < $this->count) {
+				$found = $this->tokens[$this->pos]['value'];
+			}
 			throw new RuntimeException(
 				sprintf('Expected "%s" in a metric expression, found "%s".', $type, $found)
 			);


### PR DESCRIPTION
`MetricExpressionEvaluator` landed on `development` today with **#2941**, carrying **nine phpcs errors**. phpcs scans `lib`, so `development` itself is red and **every branch cut from it inherits the failure** — it is not the fault of whichever PR happens to report it. Mine surfaced on #2943, which touches neither this file nor this area.

```
FOUND 9 ERRORS AFFECTING 9 LINES
 176 | ERROR | Inline IF statements are not allowed
 238 | ERROR | Inline IF statements are not allowed
 249 | ERROR | All arguments in calls to internal code must use named parameters
 278 | ERROR | ...
 288 | ERROR | Inline IF statements are not allowed
 313 | ERROR | Inline IF statements are not allowed
 348 | ERROR | Inline IF statements are not allowed
```

## What changed

- **Five inline IFs** expanded to blocks. The nested ternary inside the `sprintf` at 313 becomes a named `$available` local — the only one that was genuinely hard to read.
- **Four `$this->expect(...)` calls** given the named parameter the standard requires for calls to internal code.
- The **`@spec` tag** the class was missing, pointing at `openspec/specs/aggregation-api/spec.md` — the target its siblings in this directory already use, and a file that exists.

## Verified behaviour-neutral by A/B, not by reading

The refactor restructures control flow, so reading it is not enough:

| | tests | assertions |
|---|---|---|
| aggregation suite, **original** file | 263 | 524 |
| aggregation suite, **fixed** file | 263 | 524 |

The evaluator's own suite is 9 tests / 26 assertions, green, with a reflection check confirming the class under test is the edited file rather than another checkout's copy.

phpcs 9 → 0, confirmed against a control run of the *original* through the same command — an earlier attempt had silently registered **no sniffs at all** and reported the untouched file as clean, which is why the control is here.