### PR TITLE
fix(quality): drop the else in parseExpression

### DIFF
--- a/lib/Service/Aggregation/MetricExpressionEvaluator.php
+++ b/lib/Service/Aggregation/MetricExpressionEvaluator.php
@@ -177,9 +177,10 @@ class MetricExpressionEvaluator {
 
 			if ($op === '+') {
 				$value = ($value + $rhs);
-			} else {
-				$value = ($value - $rhs);
+				continue;
 			}
+
+			$value = ($value - $rhs);
 		}
 
 		return $value;


### PR DESCRIPTION
Fixes the `PHP Quality (phpmd)` failure on `development` — a single violation:

```
lib/Service/Aggregation/MetricExpressionEvaluator.php:180  ElseExpression
  The method parseExpression uses an else expression.
```

## The change

```diff
 			if ($op === '+') {
 				$value = ($value + $rhs);
-			} else {
-				$value = ($value - $rhs);
+				continue;
 			}
+
+			$value = ($value - $rhs);
```

## Why this shape

`parseTerm`, directly below it in the same file, already handles its two operators with a guard and a `continue` rather than `if/else` — and is clean. This makes `parseExpression` match its sibling rather than introducing a third style (a ternary would also have satisfied phpmd, but nothing else in the file reads that way).

The phpmd baseline carries no entry for this file, so `parseTerm` genuinely complies rather than being suppressed.

## Behaviour

Identical. The `while` condition admits only `+` and `-`, so the guard plus the fall-through cover exactly the two branches the `else` did.

Verified: `php -l` clean; no `else` remains in `parseExpression`.

Surfaced by ConductionNL/.github#597 — `development` had not produced a completed CI verdict in months because every run was cancelled.
