### PR TITLE
chore(deps): hydra-gates 1.10, so the E2E skip-discipline gate can run

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -7048,16 +7048,16 @@
         },
         {
             "name": "conduction/hydra-gates",
-            "version": "v1.9.0",
+            "version": "v1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ConductionNL/.github.git",
-                "reference": "9801ffdbff17d05f0934742190742d733ac912b4"
+                "reference": "d143bc27aecbb44a66c843dba89d374628bf9eef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/9801ffdbff17d05f0934742190742d733ac912b4",
-                "reference": "9801ffdbff17d05f0934742190742d733ac912b4",
+                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/d143bc27aecbb44a66c843dba89d374628bf9eef",
+                "reference": "d143bc27aecbb44a66c843dba89d374628bf9eef",
                 "shasum": ""
             },
             "require": {
@@ -7096,9 +7096,9 @@
             "support": {
                 "docs": "https://github.com/ConductionNL/.github/blob/main/hydra-gates/README.md",
                 "issues": "https://github.com/ConductionNL/.github/issues",
-                "source": "https://github.com/ConductionNL/.github/tree/v1.9.0"
+                "source": "https://github.com/ConductionNL/.github/tree/v1.10.0"
             },
-            "time": "2026-08-22T00:30:18+00:00"
+            "time": "2026-08-27T16:18:04+00:00"
         },
         {
             "name": "consolidation/annotated-command",


### PR DESCRIPTION
## Why

`conduction/hydra-gates` v1.10.0 contains `check_e2e_skips.py`, which the shared quality workflow needs to run the **E2E skip-discipline** check. On v1.9.0 that script does not exist, so the step reports

```
::warning::check_e2e_skips.py not found (hydra-gates not vendored here yet)
— skip discipline NOT measured on this run.
```

and the job goes green having measured nothing. Today that is the state of **20 of 21 fleet apps** — only launchpad, which was bumped in ConductionNL/launchpad#359, produces a verdict at all.

A skip is counted as a pass, and the Playwright report is the only place a runtime `test.skip(cond, reason)` records its reason — the CI log prints counts without reasons. So until this lands, an app cannot tell a legitimate skip from a fixture that silently never ran. Context in ConductionNL/.github#609.

## Lock-only

`composer.json` already allows this — the constraint is `^1.8.2` and 1.10.0 satisfies it. Only `composer.lock` moves.

## Blast radius, measured before opening this

v1.10.0 adds six gate scripts over v1.9.0:

```
check_adr_number_collision   check_manifest_copy_style   check_retired_git_host
check_e2e_skips              check_repair_registration   check_system_elevation
```

So this is not a no-op bump, and it is deliberately opened as a **PR rather than pushed**: the gates run here and report before anything can redden `development`.

`gate-99 manifest-l10n-coverage` was run locally against every fleet app first, because that is the gate that caught launchpad when it was bumped. **18 of 20 are clean**; this app is one of them. The exception is zaakafhandelapp (59 manifest strings with no `nl.json` key), which needs its l10n gap closed before it can take this bump.
