### PR TITLE
chore(deps): bump @conduction/nextcloud-vue to ^2.21.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
-        "@conduction/nextcloud-vue": "^2.20.0",
+        "@conduction/nextcloud-vue": "^2.21.0",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "^2.6.0",
         "@nextcloud/capabilities": "^1.2.1",
@@ -2112,9 +2112,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.20.0.tgz",
-      "integrity": "sha512-qVhDLOpIIdsHnoHMM/TUdo6xlzrO/1kB0aU0DhWE1TVwyrrHwA84KluW1S0UfqCWfodS1Tp4CO+FBXjTBy0HTQ==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.21.0.tgz",
+      "integrity": "sha512-5HjI4X8k2IYxUeBdHa2OK/MnLhOFf4HxkF5dUGl42dWmYPDaPHjvawDMZcUcyP6wsP+rk0QzmPov4FGu/4Rn7Q==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
-    "@conduction/nextcloud-vue": "^2.20.0",
+    "@conduction/nextcloud-vue": "^2.21.0",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "^2.6.0",
     "@nextcloud/capabilities": "^1.2.1",


### PR DESCRIPTION
The flow-page migration is already merged into `development` here, but the lockfile still pins an
older `@conduction/nextcloud-vue`. That combination is the broken one.

2.20 **declares** a named index source's `columns`, `addLabel` and `rowActions` and reads none of
them (`nextcloud-vue#810`, `#818`). So a `type: "index"` page with `config.entitySource` renders a
**columnless table with no working create button** — and a columnless table reads as an empty list,
not as a misconfigured page, so nothing looks broken.

## Why the caret was not enough

The range already allowed 2.21.0. CI installs with `npm ci`, which honours `package-lock.json` and
ignores how permissive the range is, so the pin is what decides. Bumping the range alone would have
changed nothing about what actually installs.

## Verified

Against the published tarball, not the source tree: 2.21.0 ships manifest schema 2.26.0 (which has
`flow` and `config.entitySource`) and its `dist/` carries the row-actions wiring.
