### PR TITLE
fix(descriptors): the demo-data import seeded nothing and reported success

### DIFF
--- a/lib/Command/DescriptorListCommand.php
+++ b/lib/Command/DescriptorListCommand.php
@@ -39,6 +39,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Lists every app-declared register descriptor and whether it landed.
+ *
+ * @spec openspec/changes/register-descriptor-admin/specs/register-descriptor-admin/spec.md
  */
 class DescriptorListCommand extends Command {
 	/**
@@ -163,6 +165,27 @@ class DescriptorListCommand extends Command {
 		if ($result['outcome'] === 'failed') {
 			$output->writeln('<error>' . $result['reason'] . '</error>');
 			return 1;
+		}
+
+		// 🔴 THE COUNTS, ALWAYS — the same rule the repair steps follow.
+		// `register "larpinq" imported.` was returned by an import that created
+		// the register's schemas and none of its 30 demo objects, and the
+		// sentence could not be told apart from a run that seeded everything.
+		$counts = ($result['counts'] ?? null);
+		if (is_array($counts) === true && $counts['declared'] > 0) {
+			$output->writeln(
+				sprintf(
+					'<info>%s: register "%s" %s — %d of %d demo object(s) imported, %d skipped.</info>',
+					$appId,
+					$slug,
+					$result['outcome'],
+					$counts['imported'],
+					$counts['declared'],
+					$counts['skipped']
+				)
+			);
+
+			return 0;
 		}
 
 		$output->writeln(sprintf('<info>%s: register "%s" %s.</info>', $appId, $slug, $result['outcome']));

--- a/lib/Service/RegisterDescriptorService.php
+++ b/lib/Service/RegisterDescriptorService.php
@@ -50,6 +50,8 @@ use Throwable;
 
 /**
  * Inventories app-shipped register descriptors and re-imports them on demand.
+ *
+ * @spec openspec/changes/register-descriptor-admin/specs/register-descriptor-admin/spec.md
  */
 class RegisterDescriptorService {
 	/**
@@ -190,7 +192,10 @@ class RegisterDescriptorService {
 	 * @param string $appId The app that ships the descriptor.
 	 * @param string $slug  The register slug within it.
 	 *
-	 * @return array{outcome: string, reason: string|null} `imported`, `unchanged` or `failed`.
+	 * `counts` reports what actually landed, so `imported` cannot be said over a
+	 * no-op.
+	 *
+	 * @return array{outcome: string, reason: string|null, counts?: array{declared: int, imported: int, skipped: int}}
 	 *
 	 * @spec openspec/changes/register-descriptor-admin/specs/register-descriptor-admin/spec.md
 	 */
@@ -203,9 +208,35 @@ class RegisterDescriptorService {
 			];
 		}
 
+		$declaredObjects = count(($descriptor['data']['components']['objects'] ?? []));
+
 		try {
-			$this->configurationService->importFromApp(
-				appId: $appId,
+			// 🔴 A MOCK IMPORTS UNDER ITS OWN CONFIGURATION IDENTITY.
+			//
+			// `importFromApp` stamps `imported_config_<appId>_version` and a
+			// content hash. A mock descriptor declares the SAME register slug as
+			// the app's real one — larpinq ships `larpinq_register.json` and
+			// `larpinq_mock_register.json`, both declaring `larpinq` — so
+			// importing the mock under the plain app id writes over the real
+			// descriptor's stamp and reads its hash. Measured on a live instance:
+			// the command reported `register "larpinq" imported.` and the
+			// register ended up with the REAL descriptor's 11 schemas and ZERO of
+			// the mock's 30 objects.
+			//
+			// This is the same rule ImportMergeOperationRegister already applies
+			// with its own `openregister.merge-operation` id, and for the same
+			// reason: a version gate shared between two descriptors masks one of
+			// them.
+			// Default-then-override: phpcs bans the inline ternary and phpmd bans
+			// the else, so this is the shape that satisfies both.
+			$isMock = (($descriptor['data']['x-openregister']['type'] ?? '') === 'mock');
+			$configId = $appId;
+			if ($isMock === true) {
+				$configId = $appId . '.mock';
+			}
+
+			$result = $this->configurationService->importFromApp(
+				appId: $configId,
 				data: $descriptor['data'],
 				version: (string)($descriptor['data']['info']['version'] ?? '0.0.1'),
 				force: true
@@ -228,7 +259,35 @@ class RegisterDescriptorService {
 			];
 		}
 
-		return ['outcome' => 'imported', 'reason' => null];
+		// 🔴 COUNT WHAT LANDED, and fail when a descriptor that declares objects
+		// seeded none of them.
+		//
+		// The old post-check asked only whether a config version existed for the
+		// slug. For a mock that is already true — the app's own descriptor
+		// stamped it at install — so `outcome: imported` was returned over an
+		// import that created nothing. "Imported" that cannot be told apart from
+		// "did nothing" is the failure this whole command exists to surface.
+		$imported = count(($result['objects'] ?? []));
+		$skipped = (int)(($result['skipped']['objects'] ?? 0) + ($result['skipped']['seedObjects'] ?? 0));
+
+		if ($declaredObjects > 0 && $imported === 0) {
+			return [
+				'outcome' => 'failed',
+				'reason'  => sprintf(
+					'%s declares %d demo object(s) but none were imported (%d skipped). The register and its schemas may have landed; the data did not.',
+					$descriptor['file'],
+					$declaredObjects,
+					$skipped
+				),
+				'counts'  => ['declared' => $declaredObjects, 'imported' => 0, 'skipped' => $skipped],
+			];
+		}
+
+		return [
+			'outcome' => 'imported',
+			'reason'  => null,
+			'counts'  => ['declared' => $declaredObjects, 'imported' => $imported, 'skipped' => $skipped],
+		];
 	}//end reimport()
 
 	/**

--- a/tests/Unit/Command/DescriptorListCommandTest.php
+++ b/tests/Unit/Command/DescriptorListCommandTest.php
@@ -119,6 +119,75 @@ class DescriptorListCommandTest extends TestCase {
 	}
 
 	/**
+	 * 🔴 THE COUNTS REACH THE OPERATOR, not just the return value.
+	 *
+	 * `register "larpinq" imported.` was printed by an import that created the
+	 * register's schemas and none of its 30 demo objects. The sentence could not
+	 * be told apart from a run that seeded everything, which is why the defect
+	 * survived a live run and a green unit suite.
+	 */
+	public function testTheImportPrintsHowManyDemoObjectsLanded(): void {
+		$this->descriptors->method('reimport')
+			->willReturn(
+				[
+					'outcome' => 'imported',
+					'reason'  => null,
+					'counts'  => ['declared' => 30, 'imported' => 30, 'skipped' => 0],
+				]
+			);
+
+		$this->assertSame(0, $this->tester->execute(['--import' => 'flows', '--app' => 'openregister']));
+
+		$display = $this->tester->getDisplay();
+		$this->assertStringContainsString('30 of 30', $display);
+		$this->assertStringContainsString('0 skipped', $display);
+	}
+
+	/**
+	 * A PARTIAL seed is stated as such. 29 of 30 is not the same event as 30 of
+	 * 30, and an operator deciding whether the demo is usable needs the
+	 * difference.
+	 */
+	public function testAPartialSeedNamesBothNumbers(): void {
+		$this->descriptors->method('reimport')
+			->willReturn(
+				[
+					'outcome' => 'imported',
+					'reason'  => null,
+					'counts'  => ['declared' => 30, 'imported' => 29, 'skipped' => 1],
+				]
+			);
+
+		$this->tester->execute(['--import' => 'flows', '--app' => 'openregister']);
+
+		$display = $this->tester->getDisplay();
+		$this->assertStringContainsString('29 of 30', $display);
+		$this->assertStringContainsString('1 skipped', $display);
+	}
+
+	/**
+	 * A descriptor that declares NO objects keeps the short sentence. Every real
+	 * register descriptor is in this case, and padding them with "0 of 0 demo
+	 * object(s)" would make the common line noisier to no purpose.
+	 */
+	public function testADescriptorWithNoObjectsKeepsTheShortMessage(): void {
+		$this->descriptors->method('reimport')
+			->willReturn(
+				[
+					'outcome' => 'imported',
+					'reason'  => null,
+					'counts'  => ['declared' => 0, 'imported' => 0, 'skipped' => 0],
+				]
+			);
+
+		$this->tester->execute(['--import' => 'flows', '--app' => 'openregister']);
+
+		$display = $this->tester->getDisplay();
+		$this->assertStringContainsString('imported', $display);
+		$this->assertStringNotContainsString('demo object', $display);
+	}
+
+	/**
 	 * A FAILED re-import exits non-zero, unlike a listing: here the caller asked
 	 * for something to happen and it did not.
 	 */

--- a/tests/Unit/Service/RegisterDescriptorServiceTest.php
+++ b/tests/Unit/Service/RegisterDescriptorServiceTest.php
@@ -90,7 +90,8 @@ class RegisterDescriptorServiceTest extends TestCase {
 		string $slug,
 		string $version,
 		?string $type = null,
-		?string $app = null
+		?string $app = null,
+		int $objects = 0
 	): void {
 		$descriptor = [
 			'openapi'    => '3.0.0',
@@ -99,6 +100,16 @@ class RegisterDescriptorServiceTest extends TestCase {
 				'registers' => [$slug => ['slug' => $slug, 'title' => ucfirst($slug), 'version' => $version]],
 			],
 		];
+
+		if ($objects > 0) {
+			$descriptor['components']['objects'] = array_map(
+				static fn (int $i): array => [
+					'@self' => ['register' => $slug, 'schema' => 'thing', 'slug' => 'thing-' . $i],
+					'name'  => 'Voorbeeld ' . $i,
+				],
+				range(1, $objects)
+			);
+		}
 
 		$marker = [];
 		if ($type !== null) {
@@ -294,6 +305,97 @@ class RegisterDescriptorServiceTest extends TestCase {
 		$result = $this->service->reimport(appId: 'fixtureapp', slug: 'flows');
 
 		$this->assertSame('imported', $result['outcome']);
+	}
+
+	/**
+	 * 🔴 A MOCK IMPORTS UNDER ITS OWN CONFIGURATION IDENTITY.
+	 *
+	 * `importFromApp` stamps `imported_config_<appId>_version` plus a content
+	 * hash. A mock declares the SAME register slug as the app's real descriptor —
+	 * larpinq ships `larpinq_register.json` and `larpinq_mock_register.json`,
+	 * both declaring `larpinq` — so importing the mock under the plain app id
+	 * writes over the real descriptor's stamp and reads its hash.
+	 *
+	 * Measured on a live instance before this fix: the command printed
+	 * `register "larpinq" imported.` while the register ended up with the REAL
+	 * descriptor's 11 schemas and ZERO of the mock's 30 objects.
+	 */
+	public function testAMockImportsUnderItsOwnConfigurationIdentity(): void {
+		$this->writeDescriptor(
+			file: 'a_mock_register.json',
+			slug: 'flows',
+			version: '1.0.0',
+			type: 'mock',
+			objects: 3
+		);
+		$this->expectApp('fixtureapp');
+		$this->registerMapper->method('findAll')->willReturn([$this->register('flows', '1.0.0')]);
+
+		$this->configurationService->expects($this->once())
+			->method('importFromApp')
+			->with(
+				// NOT 'fixtureapp' — that identity belongs to the real descriptor.
+				$this->equalTo('fixtureapp.mock'),
+				$this->anything(),
+				$this->equalTo('1.0.0'),
+				$this->isTrue()
+			)
+			->willReturn(['objects' => [1, 2, 3], 'skipped' => []]);
+
+		$result = $this->service->reimport(appId: 'fixtureapp', slug: 'flows');
+
+		$this->assertSame('imported', $result['outcome']);
+		$this->assertSame(3, $result['counts']['imported']);
+	}
+
+	/**
+	 * 🔴 "IMPORTED" MUST NOT BE SAYABLE OVER A NO-OP.
+	 *
+	 * The old post-check asked only whether a config version existed for the
+	 * slug. For a mock that is already true — the app's own descriptor stamped it
+	 * at install — so the service returned `imported` for an import that created
+	 * nothing at all. A success message that cannot be told apart from silence is
+	 * the exact failure this command was built to surface.
+	 */
+	public function testADescriptorThatSeedsNoneOfItsObjectsIsAFailure(): void {
+		$this->writeDescriptor(
+			file: 'a_mock_register.json',
+			slug: 'flows',
+			version: '1.0.0',
+			type: 'mock',
+			objects: 30
+		);
+		$this->expectApp('fixtureapp');
+		$this->registerMapper->method('findAll')->willReturn([$this->register('flows', '1.0.0')]);
+
+		// The register lands, the data does not — exactly what was measured live.
+		$this->configurationService->method('importFromApp')
+			->willReturn(['objects' => [], 'skipped' => ['objects' => 30, 'seedObjects' => 0]]);
+
+		$result = $this->service->reimport(appId: 'fixtureapp', slug: 'flows');
+
+		$this->assertSame('failed', $result['outcome']);
+		$this->assertStringContainsString('30', (string)$result['reason']);
+		$this->assertStringContainsString('none were imported', (string)$result['reason']);
+		$this->assertSame(0, $result['counts']['imported']);
+	}
+
+	/**
+	 * A descriptor that declares NO objects — every real register descriptor —
+	 * must still report success. The rule above is about a descriptor that
+	 * promised data and delivered none, not about registers that never carried
+	 * any.
+	 */
+	public function testARegisterDescriptorWithNoObjectsStillSucceeds(): void {
+		$this->writeDescriptor(file: 'a_register.json', slug: 'flows', version: '1.3.0');
+		$this->expectApp('fixtureapp');
+		$this->registerMapper->method('findAll')->willReturn([$this->register('flows', '1.3.0')]);
+		$this->configurationService->method('importFromApp')->willReturn([]);
+
+		$result = $this->service->reimport(appId: 'fixtureapp', slug: 'flows');
+
+		$this->assertSame('imported', $result['outcome']);
+		$this->assertSame(0, $result['counts']['declared']);
 	}
 
 	/**


### PR DESCRIPTION
Found by running the ADR-111 flow on a **live instance** rather than trusting the unit tests.

```
$ occ openregister:descriptors:list --app=larpinq --import=larpinq
larpinq: register "larpinq" imported.
```

Zero of the descriptor's **30 demo objects** were seeded. The register ended up carrying the *real* descriptor's 11 schemas rather than the mock's 10, and `oc_openregister_objects` stayed empty.

## Two defects, both mine

**1. A mock imported under the app's own configuration identity.**

`importFromApp` stamps `imported_config_<appId>_version` plus a content hash. larpinq ships **both** `larpinq_register.json` and `larpinq_mock_register.json`, and both declare the register slug `larpinq` — so importing the mock under the plain app id writes over the real descriptor's stamp and reads its hash.

A mock now imports under `<appId>.mock`. This is the rule `ImportMergeOperationRegister` already states in its own docblock, for exactly this reason: *a version gate shared between two descriptors masks one of them*. I applied that discipline there and not here.

**2. The post-check could not see a no-op.**

It asked only whether a config version existed for the slug. For a mock that is already true — the app's own descriptor stamped it at install — so `outcome: imported` was returned over an import that created nothing.

A descriptor that declares objects and seeds none is now a **failure that names the numbers**, and the command prints `N of M demo object(s) imported, K skipped` instead of a bare `imported`. Same "state the counts, always" rule the repair steps follow — and what would have made this diagnosis immediate.

## Verification

Three new tests, each verified by control: reinstating either defect produces **2 failures**.

⚠️ The control itself had to be fixed first. Running the suite from a worktree with a symlinked `vendor/` resolves these classes out of the **main checkout**, so the tests were green over a file I had not edited. The bootstrap now preloads the worktree copy.

phpcs / phpmd / phpstan / psalm all clean; **31 tests, 92 assertions**.