### PR TITLE
fix(e2e): make the flows spec report WHY the button is absent

### DIFF
--- a/tests/e2e/ci/flow-controls.spec.ts
+++ b/tests/e2e/ci/flow-controls.spec.ts
@@ -222,6 +222,17 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 	})
 
 	try {
+		// Collected for the failure message below; the resolver's own warning
+		// about an unknown named source is the single fact this spec has been
+		// unable to report.
+		const consoleLines: string[] = []
+		page.on('console', (msg) => {
+			const type = msg.type()
+			if (type === 'warning' || type === 'error') {
+				consoleLines.push(`[${type}] ${msg.text()}`)
+			}
+		})
+
 		await page.goto(FLOWS_ROUTE, { waitUntil: 'domcontentloaded' })
 
 		// Belt and braces: if the dialog still made it through (a server-backed
@@ -235,7 +246,38 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 
 		// Reach the editor the way a user does. Direct navigation to
 		// `#/flows/new` does not always hydrate the canvas.
-		await clickThemed(page.getByRole('button', { name: 'New flow' }))
+		//
+		// If the button is absent, say WHY rather than just that it is missing.
+		// This assertion has been failing on development (#2957) and the bare
+		// "element(s) not found" told us nothing: the label is correct, the
+		// package ships the registry, and showAdd defaults true — all verified.
+		// What could not be seen from outside a failing run is whether
+		// `resolveIndexSource('flows')` returned the source or null, and the
+		// resolver announces that on the console. So capture it and put it in
+		// the failure.
+		const addButton = page.getByRole('button', { name: 'New flow' })
+		if (!(await addButton.isVisible().catch(() => false))) {
+			const primary = page.locator('[data-testid="cn-cta-primary"]')
+			const primaryText = (await primary.count())
+				? await primary
+						.first()
+						.innerText()
+						.catch(() => '<unreadable>')
+				: '<no cn-cta-primary button on the page>'
+			throw new Error(
+				'The "New flow" button never rendered on the flows index.\n'
+					+ `  primary CTA present: ${await primary.count()} `
+					+ `(text: ${primaryText})\n`
+					+ '  A named source supplies this label; an unresolved one degrades to\n'
+					+ '  an ordinary index whose CTA reads "Add {type}". The text above\n'
+					+ '  distinguishes those two cases.\n'
+					+ '  console (warn/error):\n'
+					+ (consoleLines.length
+						? consoleLines.map((l) => `    ${l}`).join('\n')
+						: '    <nothing captured>'),
+			)
+		}
+		await clickThemed(addButton)
 
 		// 1. THE CONTROLS EXIST. This is the assertion the original defect
 		//    would have failed: before the fix `.cn-flow-sidebar` was absent


### PR DESCRIPTION
fix(e2e): make the flows spec report WHY the button is absent

`flow-controls.spec.ts:173` has been failing on development with

    Locator: getByRole('button', { name: 'New flow' })
    Error: element(s) not found

which says nothing useful. Chasing it (#2957) ruled out five hypotheses
without touching the actual cause:

  - the label is correct -- "New flow" is what nextcloud-vue 2.20.0
    declares for the `flows` named index source
  - the version is correct -- package.json ^2.20.0, lock pins 2.20.0
  - the published artifact is complete -- indexSources.js and
    useNamedSource.js are both in the npm tarball's dist/
  - the control is a real button -- CnActionsBar renders NcButton with
    data-testid="cn-cta-primary", not an overflow menu item
  - showAdd is not suppressed -- defaults true on both components

The one fact unobservable from outside a failing run is whether
`resolveIndexSource('flows')` returned the source or null. The resolver
announces that on the console, and nothing was capturing it.

So this captures console warn/error for the duration of the test and,
when the button is missing, fails with:

  - whether ANY primary CTA rendered, and its text. A named source
    supplies "New flow"; an unresolved one degrades to an ordinary index
    whose CTA reads "Add {type}". That single string separates the two
    cases.
  - the collected console lines, including the resolver's warning.

No change to what the test asserts -- it still requires the button. It
just stops throwing away the evidence when it does not appear.

Verified: npm run lint rc=0, prettier clean, `playwright test --list`
compiles the file.

Refs #2957
