### PR TITLE
fix(scope): a foreign pending schema ref must not fail setRegister()

### DIFF
--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -561,10 +561,56 @@ class ObjectService implements ObjectServiceInterface
             $pendingRef             = $this->currentSchemaRef;
             $this->currentSchemaRef = null;
 
-            $this->currentSchema = $this->scopedSchemaResolver->resolveSchemaWithin(
-                register: $register,
-                schemaRef: $pendingRef
-            );
+            // A REF THAT DOES NOT BELONG HERE MUST NOT TAKE THIS CALLER DOWN.
+            //
+            // Single use bounded the damage to ONE victim. It did not stop the
+            // victim being an app that never touched the ref: the pending slug
+            // is handed to the first setRegister() that follows, whoever that
+            // is, and re-resolving it inside a register that has never heard of
+            // it THREW — out of a method whose caller only asked to name its own
+            // register.
+            //
+            // Measured on the development instance 2026-08-27: every public
+            // read of a portaliq portal failed with `Schema slug "application"
+            // is not carried by register "portaliq"`. The portal served its
+            // shell and answered 404 for its own site, menus, pages and
+            // glossary — a whole app's public surface down, over a slug it does
+            // not own and never asked for. The same failure is recorded above
+            // for openconnector and for a pipelinq repair step, so this is the
+            // third app to be taken out by a fourth app's leftovers.
+            //
+            // So a ref that cannot be resolved inside THIS register is dropped
+            // rather than thrown on. What is NOT dropped is the consequence: the
+            // schema context is cleared with it, so a caller that really did
+            // chain `setSchema('typo')->setRegister($r)` still fails — at its
+            // operation, with "no schema context", instead of silently reading
+            // whichever table a stale context last pointed at. Substituting a
+            // wrong-but-plausible schema is the one outcome worse than throwing.
+            try {
+                $this->currentSchema = $this->scopedSchemaResolver->resolveSchemaWithin(
+                    register: $register,
+                    schemaRef: $pendingRef
+                );
+            } catch (\Throwable $e) {
+                $this->currentSchema = null;
+
+                $refForLog = gettype($pendingRef);
+                if (is_scalar($pendingRef) === true) {
+                    $refForLog = (string) $pendingRef;
+                }
+
+                $this->logger->warning(
+                    message: '[ObjectService] Discarded a pending schema ref that this register does not carry',
+                    context: [
+                        'pendingSchemaRef' => $refForLog,
+                        'register'         => ($register->getSlug() ?? (string) $register->getId()),
+                        'reason'           => $e->getMessage(),
+                        'note'             => 'The ref was left on this shared service by an earlier, unrelated call. '
+                            .'If YOUR call chained setSchema()->setRegister(), the schema is now unset and your '
+                            .'operation will fail with a missing schema context rather than read the wrong table.',
+                    ]
+                );
+            }//end try
         }
 
         return $this;

--- a/tests/Unit/Service/ObjectServiceStaleSchemaRefTest.php
+++ b/tests/Unit/Service/ObjectServiceStaleSchemaRefTest.php
@@ -406,6 +406,90 @@ class ObjectServiceStaleSchemaRefTest extends TestCase {
 
 
 	/**
+	 * A BARE setRegister() must survive a ref that belongs to somebody else.
+	 *
+	 * Every guard before this one protects an OPERATION — `find()`, `findAll()`,
+	 * a save — by discarding the pending ref as it enters. `setRegister()` is
+	 * not an operation, so it has no such guard: it takes whatever ref is
+	 * pending, re-resolves it inside the register the caller just named, and a
+	 * miss THROWS out of a method whose caller only asked to name its register.
+	 *
+	 * Measured on the development instance 2026-08-27, WITH #2918 (the read-path
+	 * clear) already merged and running: every public read of a portaliq portal
+	 * failed with `Schema slug "application" is not carried by register
+	 * "portaliq"`. `PortalResolver` calls `setRegister('portaliq')` first and
+	 * `setSchema('portal')` after — the correct order — and never mentions
+	 * `application` at all. The portal served its shell and answered 404 for its
+	 * own site, menus, pages and glossary: a whole app's public surface down,
+	 * over a slug it does not own.
+	 *
+	 * So the ref is DROPPED here rather than thrown on. The schema context is
+	 * cleared with it, which is the half that keeps this honest: a caller that
+	 * genuinely chained `setSchema('typo')->setRegister($r)` still fails, at its
+	 * operation, with a missing schema context — rather than quietly reading
+	 * whichever table a stale context last pointed at.
+	 *
+	 * @return void
+	 */
+	public function testABareSetRegisterSurvivesAForeignPendingRef(): void {
+		// Left behind by an unrelated caller — buildiq registers navigation from
+		// Application::boot(), so this ref is pending on EVERY request.
+		$application = new Schema();
+		$application->setId(193);
+		$application->setSlug('application');
+		$this->schemaMapper->method('find')->willReturn($application);
+		$this->service->setSchema('application');
+
+		// A different app now names its OWN register. It does not carry
+		// `application`, and it never asked for it.
+		$portaliq = new Register();
+		$portaliq->setId(35);
+		$portaliq->setSlug('portaliq');
+		$portaliq->setSchemas([501]);
+
+		$portal = new Schema();
+		$portal->setId(501);
+		$portal->setSlug('portal');
+
+		$this->registerMapper->method('find')->willReturn($portaliq);
+		$this->schemaMapper->method('findBySlugInIds')->willReturnCallback(
+			static fn (string $slug, array $ids) => ($slug === 'portal' ? $portal : null)
+		);
+		$this->schemaMapper->method('findInIds')->willReturnCallback(
+			static fn ($ref, array $ids) => (($ref === 'portal' || $ref === 501) ? $portal : null)
+		);
+
+		// BEFORE THE FIX this throws SchemaNotInRegisterException naming
+		// "application" — and took every public page of the portal with it.
+		$this->service->setRegister('portaliq');
+
+		$schema = new \ReflectionProperty(ObjectService::class, 'currentSchema');
+		$schema->setAccessible(true);
+		$this->assertNull(
+			$schema->getValue($this->service),
+			'a ref that could not be resolved must leave NO schema context — substituting a '
+			.'wrong-but-plausible schema is the one outcome worse than throwing'
+		);
+
+		// And the caller's own chain still works, which is the whole point:
+		// this is the order PortalResolver and CmsReader use.
+		$this->service->setSchema('portal');
+		$this->assertSame(
+			501,
+			$schema->getValue($this->service)?->getId(),
+			'the caller naming its own register and schema must be served its own schema'
+		);
+
+		$ref = new \ReflectionProperty(ObjectService::class, 'currentSchemaRef');
+		$ref->setAccessible(true);
+		$this->assertNull(
+			$ref->getValue($this->service),
+			'the foreign ref must be consumed, not left pending for the NEXT caller'
+		);
+	}//end testABareSetRegisterSurvivesAForeignPendingRef()
+
+
+	/**
 	 * A COMPLETED register+schema chain must not leave a ref behind at all.
 	 *
 	 * Every case above starts from `setSchema($s)` with NO register set — the


### PR DESCRIPTION
## The failure

Measured on the development instance on 2026-08-27, with #2918 (the read-path clear) already merged and running:

```
Schema slug "application" is not carried by register "portaliq" (id 35),
which carries 13 schema(s).
```

Every public read of a portaliq portal failed this way. `PortalResolver` calls `setRegister('portaliq')` first and `setSchema('portal')` after — the correct order — and never mentions `application` at all. That slug belongs to **buildiq**, which registers navigation from `Application::boot()`, so the ref is pending on essentially every request.

The portal served its shell and answered `not_found` for its own site, menus, pages and glossary: a whole app's public surface down, over a slug it does not own and never asked for.

## Why the existing guards did not catch it

Each earlier fix protects an **operation** by discarding the pending ref as it enters — `find()` (#2790), the save path (#2803), the read path (#2918), plus single-use (#2792). `setRegister()` is not an operation, so it has no such guard: it takes whatever ref is pending, re-resolves it inside the register the caller just named, and a miss throws out of a method whose caller only asked to name its register.

This file's own comments already record openconnector and a pipelinq repair step as victims of the same shape. Portaliq is the third.

## The change

A ref that cannot be resolved inside *this* register is discarded rather than thrown on — and the schema context is cleared with it.

That second half is the part worth reviewing. A caller that genuinely chained `setSchema('typo')->setRegister($r)` still fails, at its operation, with a missing schema context. It does **not** silently proceed against whichever table a stale context last pointed at: substituting a wrong-but-plausible schema is the one outcome worse than throwing. The discard is logged with the ref, the register, and a note telling the reader which of the two situations they are in.

## Verification

The regression test (`testABareSetRegisterSurvivesAForeignPendingRef`) was observed **failing** against `development` with the exact production message above, and passing with this change. It also asserts the caller's own `setRegister()->setSchema()` chain still resolves its own schema, and that the foreign ref is consumed rather than left pending for the next caller.

- `ObjectServiceStaleSchemaRefTest`: 6 passed.
- `ObjectServiceTest` + `ObjectServiceSearchBySlugTest`: 145 passed.
- `phpcs` on the changed file: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
