### PR TITLE
fix(phpstan): drop the unreachable is_scalar branch in ObjectService

### DIFF
--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -594,10 +594,12 @@ class ObjectService implements ObjectServiceInterface
             } catch (\Throwable $e) {
                 $this->currentSchema = null;
 
-                $refForLog = gettype($pendingRef);
-                if (is_scalar($pendingRef) === true) {
-                    $refForLog = (string) $pendingRef;
-                }
+                // `$pendingRef` is `int|string` here — `$currentSchemaRef` is
+                // `int|string|null` and the null is already excluded above — so
+                // the scalar test could only ever be true and the gettype()
+                // fallback was unreachable. A defaulted read that can never
+                // default reads as a handled edge case that does not exist.
+                $refForLog = (string) $pendingRef;
 
                 $this->logger->warning(
                     message: '[ObjectService] Discarded a pending schema ref that this register does not carry',


### PR DESCRIPTION
phpstan analyses the **whole tree**, so this pre-existing error surfaced on an unrelated l10n pull request (#2634) that does not touch this file:

```
Call to function is_scalar() with int|string will always evaluate to true.
  Line   Service/ObjectService.php
 [ERROR] Found 1 error
```

`$currentSchemaRef` is `int|string|null` and the null is already excluded before this point, so `$pendingRef` is `int|string` here — the scalar test could only ever be true, and the `gettype()` fallback was unreachable.

**Dropped rather than suppressed.** A defaulted read that can never default reads as a handled edge case that does not exist, and hides the day the type actually widens.

## Verification

- `php -l` clean
- `./vendor/bin/phpstan analyse --memory-limit=1G` over all 1504 files: **`[OK] No errors`** — the exact command CI runs