### PR TITLE
fix(scope): drop a scalar check PHPStan proves is always true

### DIFF
--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -594,15 +594,10 @@ class ObjectService implements ObjectServiceInterface
             } catch (\Throwable $e) {
                 $this->currentSchema = null;
 
-                $refForLog = gettype($pendingRef);
-                if (is_scalar($pendingRef) === true) {
-                    $refForLog = (string) $pendingRef;
-                }
-
                 $this->logger->warning(
                     message: '[ObjectService] Discarded a pending schema ref that this register does not carry',
                     context: [
-                        'pendingSchemaRef' => $refForLog,
+                        'pendingSchemaRef' => (string) $pendingRef,
                         'register'         => ($register->getSlug() ?? (string) $register->getId()),
                         'reason'           => $e->getMessage(),
                         'note'             => 'The ref was left on this shared service by an earlier, unrelated call. '


### PR DESCRIPTION
`$pendingRef` is typed `string|int`, so the `is_scalar()` guard around the log value can never be false — phpstan's `function.alreadyNarrowedType`, and it is right. The cast alone says the same thing.

This is the tail of #2963, which merged while the follow-up commit was still on its branch, so `development` is currently failing the phpstan leg on this one line.

Verified locally: `phpstan analyse lib/Service/ObjectService.php` → OK, `phpcs` → 0 errors, `ObjectServiceStaleSchemaRefTest` → 6 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)