### PR TITLE
feat(walkthrough): show where flows live, without making anyone build one

### DIFF
--- a/l10n/be.js
+++ b/l10n/be.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Дэскрыптары рэестраў",
         "ships v{shipped}": "пастаўляе v{shipped}",
         "State": "Стан",
-        "v{installed} → ships v{shipped}": "v{installed} → пастаўляе v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → пастаўляе v{shipped}",
+        "Where the automation lives": "Дзе жыве аўтаматызацыя",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Патокі — гэта тое, што адбываецца без націскаў: аб'ект, які пазначаецца пры захаванні, праграма, якую апавяшчаюць пры змене запісу. Тут вы іх чытаеце і рэдагуеце. Зараз нічога будаваць не трэба.",
+        "Open Flows in the menu": "Адкрыйце Патокі ў меню"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/be.json
+++ b/l10n/be.json
@@ -2726,7 +2726,10 @@
         "Register descriptors": "Дэскрыптары рэестраў",
         "ships v{shipped}": "пастаўляе v{shipped}",
         "State": "Стан",
-        "v{installed} → ships v{shipped}": "v{installed} → пастаўляе v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → пастаўляе v{shipped}",
+        "Where the automation lives": "Дзе жыве аўтаматызацыя",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Патокі — гэта тое, што адбываецца без націскаў: аб'ект, які пазначаецца пры захаванні, праграма, якую апавяшчаюць пры змене запісу. Тут вы іх чытаеце і рэдагуеце. Зараз нічога будаваць не трэба.",
+        "Open Flows in the menu": "Адкрыйце Патокі ў меню"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/bg.js
+++ b/l10n/bg.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Дескриптори на регистри",
         "ships v{shipped}": "доставя v{shipped}",
         "State": "Състояние",
-        "v{installed} → ships v{shipped}": "v{installed} → доставя v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → доставя v{shipped}",
+        "Where the automation lives": "Къде живее автоматизацията",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Потоците са това, което се случва без някой да кликне: обект, подпечатан при запис, приложение, уведомено при промяна на запис. Тук ги четете и редактирате. Сега няма какво да се изгражда.",
+        "Open Flows in the menu": "Отворете Потоци в менюто"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/bg.json
+++ b/l10n/bg.json
@@ -2725,7 +2725,10 @@
         "Register descriptors": "Дескриптори на регистри",
         "ships v{shipped}": "доставя v{shipped}",
         "State": "Състояние",
-        "v{installed} → ships v{shipped}": "v{installed} → доставя v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → доставя v{shipped}",
+        "Where the automation lives": "Къде живее автоматизацията",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Потоците са това, което се случва без някой да кликне: обект, подпечатан при запис, приложение, уведомено при промяна на запис. Тук ги четете и редактирате. Сега няма какво да се изгражда.",
+        "Open Flows in the menu": "Отворете Потоци в менюто"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/bs.js
+++ b/l10n/bs.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Deskriptori registara",
         "ships v{shipped}": "isporučuje v{shipped}",
         "State": "Stanje",
-        "v{installed} → ships v{shipped}": "v{installed} → isporučuje v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → isporučuje v{shipped}",
+        "Where the automation lives": "Gdje živi automatizacija",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Tokovi su ono što se dešava bez klika: objekat označen pri spremanju, aplikacija obaviještena kad se zapis promijeni. Ovdje ih čitate i uređujete. Sada nema šta graditi.",
+        "Open Flows in the menu": "Otvorite Tokove u meniju"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/bs.json
+++ b/l10n/bs.json
@@ -2726,7 +2726,10 @@
         "Register descriptors": "Deskriptori registara",
         "ships v{shipped}": "isporučuje v{shipped}",
         "State": "Stanje",
-        "v{installed} → ships v{shipped}": "v{installed} → isporučuje v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → isporučuje v{shipped}",
+        "Where the automation lives": "Gdje živi automatizacija",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Tokovi su ono što se dešava bez klika: objekat označen pri spremanju, aplikacija obaviještena kad se zapis promijeni. Ovdje ih čitate i uređujete. Sada nema šta graditi.",
+        "Open Flows in the menu": "Otvorite Tokove u meniju"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/ca.js
+++ b/l10n/ca.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Descriptors de registre",
         "ships v{shipped}": "lliura v{shipped}",
         "State": "Estat",
-        "v{installed} → ships v{shipped}": "v{installed} → lliura v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → lliura v{shipped}",
+        "Where the automation lives": "On viu l'automatització",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Els fluxos són el que passa sense que ningú faci clic: un objecte segellat en desar, una aplicació avisada quan canvia un registre. Aquí els llegiu i els editeu. Ara no cal construir res.",
+        "Open Flows in the menu": "Obriu Fluxos al menú"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/ca.json
+++ b/l10n/ca.json
@@ -2725,7 +2725,10 @@
         "Register descriptors": "Descriptors de registre",
         "ships v{shipped}": "lliura v{shipped}",
         "State": "Estat",
-        "v{installed} → ships v{shipped}": "v{installed} → lliura v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → lliura v{shipped}",
+        "Where the automation lives": "On viu l'automatització",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Els fluxos són el que passa sense que ningú faci clic: un objecte segellat en desar, una aplicació avisada quan canvia un registre. Aquí els llegiu i els editeu. Ara no cal construir res.",
+        "Open Flows in the menu": "Obriu Fluxos al menú"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/cs.js
+++ b/l10n/cs.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Deskriptory registrů",
         "ships v{shipped}": "dodává v{shipped}",
         "State": "Stav",
-        "v{installed} → ships v{shipped}": "v{installed} → dodává v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → dodává v{shipped}",
+        "Where the automation lives": "Kde žije automatizace",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Toky jsou to, co se děje bez kliknutí: objekt označený při uložení, aplikace informovaná při změně záznamu. Zde je čtete a upravujete. Nyní není třeba nic stavět.",
+        "Open Flows in the menu": "Otevřete Toky v nabídce"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/cs.json
+++ b/l10n/cs.json
@@ -2726,7 +2726,10 @@
         "Register descriptors": "Deskriptory registrů",
         "ships v{shipped}": "dodává v{shipped}",
         "State": "Stav",
-        "v{installed} → ships v{shipped}": "v{installed} → dodává v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → dodává v{shipped}",
+        "Where the automation lives": "Kde žije automatizace",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Toky jsou to, co se děje bez kliknutí: objekt označený při uložení, aplikace informovaná při změně záznamu. Zde je čtete a upravujete. Nyní není třeba nic stavět.",
+        "Open Flows in the menu": "Otevřete Toky v nabídce"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/da.js
+++ b/l10n/da.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Register-deskriptorer",
         "ships v{shipped}": "leverer v{shipped}",
         "State": "Status",
-        "v{installed} → ships v{shipped}": "v{installed} → leverer v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → leverer v{shipped}",
+        "Where the automation lives": "Hvor automatiseringen bor",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Flows er det, der sker uden at nogen klikker: et objekt der stemples ved gem, en app der får besked når en post ændres. Her læser og redigerer du dem. Der er intet at bygge nu.",
+        "Open Flows in the menu": "Åbn Flows i menuen"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/da.json
+++ b/l10n/da.json
@@ -2725,7 +2725,10 @@
         "Register descriptors": "Register-deskriptorer",
         "ships v{shipped}": "leverer v{shipped}",
         "State": "Status",
-        "v{installed} → ships v{shipped}": "v{installed} → leverer v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → leverer v{shipped}",
+        "Where the automation lives": "Hvor automatiseringen bor",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Flows er det, der sker uden at nogen klikker: et objekt der stemples ved gem, en app der får besked når en post ændres. Her læser og redigerer du dem. Der er intet at bygge nu.",
+        "Open Flows in the menu": "Åbn Flows i menuen"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/de.js
+++ b/l10n/de.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Register-Deskriptoren",
         "ships v{shipped}": "liefert v{shipped}",
         "State": "Status",
-        "v{installed} → ships v{shipped}": "v{installed} → liefert v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → liefert v{shipped}",
+        "Where the automation lives": "Wo die Automatisierung lebt",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Flows sind das, was ohne Klick passiert: ein Objekt, das beim Speichern gestempelt wird, eine nachgelagerte App, die bei einer Änderung benachrichtigt wird. Hier lesen und bearbeiten Sie sie. Jetzt ist nichts zu bauen.",
+        "Open Flows in the menu": "Flows im Menü öffnen"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -2725,7 +2725,10 @@
         "Register descriptors": "Register-Deskriptoren",
         "ships v{shipped}": "liefert v{shipped}",
         "State": "Status",
-        "v{installed} → ships v{shipped}": "v{installed} → liefert v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → liefert v{shipped}",
+        "Where the automation lives": "Wo die Automatisierung lebt",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Flows sind das, was ohne Klick passiert: ein Objekt, das beim Speichern gestempelt wird, eine nachgelagerte App, die bei einer Änderung benachrichtigt wird. Hier lesen und bearbeiten Sie sie. Jetzt ist nichts zu bauen.",
+        "Open Flows in the menu": "Flows im Menü öffnen"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/el.js
+++ b/l10n/el.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Περιγραφείς μητρώων",
         "ships v{shipped}": "παρέχει v{shipped}",
         "State": "Κατάσταση",
-        "v{installed} → ships v{shipped}": "v{installed} → παρέχει v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → παρέχει v{shipped}",
+        "Where the automation lives": "Πού ζει ο αυτοματισμός",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Οι ροές είναι ό,τι συμβαίνει χωρίς να κάνει κανείς κλικ: ένα αντικείμενο που σφραγίζεται κατά την αποθήκευση, μια εφαρμογή που ειδοποιείται όταν αλλάζει μια εγγραφή. Εδώ τις διαβάζετε και τις επεξεργάζεστε. Δεν χρειάζεται να φτιάξετε τίποτα τώρα.",
+        "Open Flows in the menu": "Ανοίξτε τις Ροές στο μενού"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/el.json
+++ b/l10n/el.json
@@ -2725,7 +2725,10 @@
         "Register descriptors": "Περιγραφείς μητρώων",
         "ships v{shipped}": "παρέχει v{shipped}",
         "State": "Κατάσταση",
-        "v{installed} → ships v{shipped}": "v{installed} → παρέχει v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → παρέχει v{shipped}",
+        "Where the automation lives": "Πού ζει ο αυτοματισμός",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Οι ροές είναι ό,τι συμβαίνει χωρίς να κάνει κανείς κλικ: ένα αντικείμενο που σφραγίζεται κατά την αποθήκευση, μια εφαρμογή που ειδοποιείται όταν αλλάζει μια εγγραφή. Εδώ τις διαβάζετε και τις επεξεργάζεστε. Δεν χρειάζεται να φτιάξετε τίποτα τώρα.",
+        "Open Flows in the menu": "Ανοίξτε τις Ροές στο μενού"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/en.js
+++ b/l10n/en.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Register descriptors",
         "ships v{shipped}": "ships v{shipped}",
         "State": "State",
-        "v{installed} → ships v{shipped}": "v{installed} → ships v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → ships v{shipped}",
+        "Where the automation lives": "Where the automation lives",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.",
+        "Open Flows in the menu": "Open Flows in the menu"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -2725,7 +2725,10 @@
         "Register descriptors": "Register descriptors",
         "ships v{shipped}": "ships v{shipped}",
         "State": "State",
-        "v{installed} → ships v{shipped}": "v{installed} → ships v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → ships v{shipped}",
+        "Where the automation lives": "Where the automation lives",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.",
+        "Open Flows in the menu": "Open Flows in the menu"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/es.js
+++ b/l10n/es.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Descriptores de registro",
         "ships v{shipped}": "entrega v{shipped}",
         "State": "Estado",
-        "v{installed} → ships v{shipped}": "v{installed} → entrega v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → entrega v{shipped}",
+        "Where the automation lives": "Dónde vive la automatización",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Los flujos son lo que ocurre sin que nadie haga clic: un objeto que se sella al guardar, una aplicación avisada cuando cambia un registro. Aquí los lees y los editas. No hay nada que construir ahora.",
+        "Open Flows in the menu": "Abrir Flujos en el menú"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/es.json
+++ b/l10n/es.json
@@ -2725,7 +2725,10 @@
         "Register descriptors": "Descriptores de registro",
         "ships v{shipped}": "entrega v{shipped}",
         "State": "Estado",
-        "v{installed} → ships v{shipped}": "v{installed} → entrega v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → entrega v{shipped}",
+        "Where the automation lives": "Dónde vive la automatización",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Los flujos son lo que ocurre sin que nadie haga clic: un objeto que se sella al guardar, una aplicación avisada cuando cambia un registro. Aquí los lees y los editas. No hay nada que construir ahora.",
+        "Open Flows in the menu": "Abrir Flujos en el menú"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/et.js
+++ b/l10n/et.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Registrikirjeldajad",
         "ships v{shipped}": "tarnib v{shipped}",
         "State": "Olek",
-        "v{installed} → ships v{shipped}": "v{installed} → tarnib v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → tarnib v{shipped}",
+        "Where the automation lives": "Kus automatiseerimine elab",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Vood on see, mis juhtub ilma klõpsamata: salvestamisel tembeldatud objekt, rakendus, keda teavitatakse kirje muutumisel. Siin loete ja muudate neid. Praegu pole midagi ehitada.",
+        "Open Flows in the menu": "Avage Vood menüüs"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/et.json
+++ b/l10n/et.json
@@ -2725,7 +2725,10 @@
         "Register descriptors": "Registrikirjeldajad",
         "ships v{shipped}": "tarnib v{shipped}",
         "State": "Olek",
-        "v{installed} → ships v{shipped}": "v{installed} → tarnib v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → tarnib v{shipped}",
+        "Where the automation lives": "Kus automatiseerimine elab",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Vood on see, mis juhtub ilma klõpsamata: salvestamisel tembeldatud objekt, rakendus, keda teavitatakse kirje muutumisel. Siin loete ja muudate neid. Praegu pole midagi ehitada.",
+        "Open Flows in the menu": "Avage Vood menüüs"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/fi.js
+++ b/l10n/fi.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Rekisterikuvaukset",
         "ships v{shipped}": "toimittaa v{shipped}",
         "State": "Tila",
-        "v{installed} → ships v{shipped}": "v{installed} → toimittaa v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → toimittaa v{shipped}",
+        "Where the automation lives": "Missä automaatio asuu",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Vuot ovat sitä, mitä tapahtuu ilman että kukaan klikkaa: tallennettaessa leimattava objekti, sovellus jolle kerrotaan kun tietue muuttuu. Täällä luet ja muokkaat niitä. Nyt ei tarvitse rakentaa mitään.",
+        "Open Flows in the menu": "Avaa Vuot valikosta"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/fi.json
+++ b/l10n/fi.json
@@ -2725,7 +2725,10 @@
         "Register descriptors": "Rekisterikuvaukset",
         "ships v{shipped}": "toimittaa v{shipped}",
         "State": "Tila",
-        "v{installed} → ships v{shipped}": "v{installed} → toimittaa v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → toimittaa v{shipped}",
+        "Where the automation lives": "Missä automaatio asuu",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Vuot ovat sitä, mitä tapahtuu ilman että kukaan klikkaa: tallennettaessa leimattava objekti, sovellus jolle kerrotaan kun tietue muuttuu. Täällä luet ja muokkaat niitä. Nyt ei tarvitse rakentaa mitään.",
+        "Open Flows in the menu": "Avaa Vuot valikosta"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Descripteurs de registre",
         "ships v{shipped}": "fournit v{shipped}",
         "State": "État",
-        "v{installed} → ships v{shipped}": "v{installed} → fournit v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → fournit v{shipped}",
+        "Where the automation lives": "Où vit l'automatisation",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Les flux sont ce qui se produit sans que personne ne clique : un objet horodaté à l'enregistrement, une application avertie quand un enregistrement change. C'est ici que vous les consultez et les modifiez. Rien à construire maintenant.",
+        "Open Flows in the menu": "Ouvrir Flux dans le menu"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/fr.json
+++ b/l10n/fr.json
@@ -2725,7 +2725,10 @@
         "Register descriptors": "Descripteurs de registre",
         "ships v{shipped}": "fournit v{shipped}",
         "State": "État",
-        "v{installed} → ships v{shipped}": "v{installed} → fournit v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → fournit v{shipped}",
+        "Where the automation lives": "Où vit l'automatisation",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Les flux sont ce qui se produit sans que personne ne clique : un objet horodaté à l'enregistrement, une application avertie quand un enregistrement change. C'est ici que vous les consultez et les modifiez. Rien à construire maintenant.",
+        "Open Flows in the menu": "Ouvrir Flux dans le menu"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/ga.js
+++ b/l10n/ga.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Tuairisceoirí clár",
         "ships v{shipped}": "soláthraíonn sé v{shipped}",
         "State": "Staid",
-        "v{installed} → ships v{shipped}": "v{installed} → soláthraíonn sé v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → soláthraíonn sé v{shipped}",
+        "Where the automation lives": "Áit a mhaireann an uathoibriú",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Is éard atá i sruthanna ná an rud a tharlaíonn gan aon chliceáil: réad a stampáiltear ar shábháil, aip a chuirtear ar an eolas nuair a athraíonn taifead. Is anseo a léann tú agus a chuireann tú in eagar iad. Níl aon rud le tógáil anois.",
+        "Open Flows in the menu": "Oscail Sruthanna sa roghchlár"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/ga.json
+++ b/l10n/ga.json
@@ -2728,7 +2728,10 @@
         "Register descriptors": "Tuairisceoirí clár",
         "ships v{shipped}": "soláthraíonn sé v{shipped}",
         "State": "Staid",
-        "v{installed} → ships v{shipped}": "v{installed} → soláthraíonn sé v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → soláthraíonn sé v{shipped}",
+        "Where the automation lives": "Áit a mhaireann an uathoibriú",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Is éard atá i sruthanna ná an rud a tharlaíonn gan aon chliceáil: réad a stampáiltear ar shábháil, aip a chuirtear ar an eolas nuair a athraíonn taifead. Is anseo a léann tú agus a chuireann tú in eagar iad. Níl aon rud le tógáil anois.",
+        "Open Flows in the menu": "Oscail Sruthanna sa roghchlár"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/hr.js
+++ b/l10n/hr.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Deskriptori registara",
         "ships v{shipped}": "isporučuje v{shipped}",
         "State": "Stanje",
-        "v{installed} → ships v{shipped}": "v{installed} → isporučuje v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → isporučuje v{shipped}",
+        "Where the automation lives": "Gdje živi automatizacija",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Tokovi su ono što se događa bez klika: objekt označen pri spremanju, aplikacija obaviještena kad se zapis promijeni. Ovdje ih čitate i uređujete. Sada nema što graditi.",
+        "Open Flows in the menu": "Otvorite Tokove u izborniku"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/hr.json
+++ b/l10n/hr.json
@@ -2726,7 +2726,10 @@
         "Register descriptors": "Deskriptori registara",
         "ships v{shipped}": "isporučuje v{shipped}",
         "State": "Stanje",
-        "v{installed} → ships v{shipped}": "v{installed} → isporučuje v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → isporučuje v{shipped}",
+        "Where the automation lives": "Gdje živi automatizacija",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Tokovi su ono što se događa bez klika: objekt označen pri spremanju, aplikacija obaviještena kad se zapis promijeni. Ovdje ih čitate i uređujete. Sada nema što graditi.",
+        "Open Flows in the menu": "Otvorite Tokove u izborniku"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/hu.js
+++ b/l10n/hu.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Regiszterleírók",
         "ships v{shipped}": "szállítja: v{shipped}",
         "State": "Állapot",
-        "v{installed} → ships v{shipped}": "v{installed} → szállítja: v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → szállítja: v{shipped}",
+        "Where the automation lives": "Ahol az automatizálás lakik",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "A folyamatok azok, amik kattintás nélkül történnek: mentéskor bélyegzett objektum, értesített alkalmazás rekordváltozáskor. Itt olvashatja és szerkesztheti őket. Most nincs mit építeni.",
+        "Open Flows in the menu": "Nyissa meg a Folyamatokat a menüben"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/hu.json
+++ b/l10n/hu.json
@@ -2725,7 +2725,10 @@
         "Register descriptors": "Regiszterleírók",
         "ships v{shipped}": "szállítja: v{shipped}",
         "State": "Állapot",
-        "v{installed} → ships v{shipped}": "v{installed} → szállítja: v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → szállítja: v{shipped}",
+        "Where the automation lives": "Ahol az automatizálás lakik",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "A folyamatok azok, amik kattintás nélkül történnek: mentéskor bélyegzett objektum, értesített alkalmazás rekordváltozáskor. Itt olvashatja és szerkesztheti őket. Most nincs mit építeni.",
+        "Open Flows in the menu": "Nyissa meg a Folyamatokat a menüben"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/is.js
+++ b/l10n/is.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Skrárlýsingar",
         "ships v{shipped}": "skilar v{shipped}",
         "State": "Staða",
-        "v{installed} → ships v{shipped}": "v{installed} → skilar v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → skilar v{shipped}",
+        "Where the automation lives": "Þar sem sjálfvirknin býr",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Flæði er það sem gerist án þess að nokkur smelli: hlutur sem er stimplaður við vistun, forrit sem fær boð þegar færsla breytist. Hér lestu og breytir þeim. Ekkert að byggja núna.",
+        "Open Flows in the menu": "Opnaðu Flæði í valmyndinni"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/is.json
+++ b/l10n/is.json
@@ -2725,7 +2725,10 @@
         "Register descriptors": "Skrárlýsingar",
         "ships v{shipped}": "skilar v{shipped}",
         "State": "Staða",
-        "v{installed} → ships v{shipped}": "v{installed} → skilar v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → skilar v{shipped}",
+        "Where the automation lives": "Þar sem sjálfvirknin býr",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Flæði er það sem gerist án þess að nokkur smelli: hlutur sem er stimplaður við vistun, forrit sem fær boð þegar færsla breytist. Hér lestu og breytir þeim. Ekkert að byggja núna.",
+        "Open Flows in the menu": "Opnaðu Flæði í valmyndinni"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/it.js
+++ b/l10n/it.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Descrittori di registro",
         "ships v{shipped}": "fornisce v{shipped}",
         "State": "Stato",
-        "v{installed} → ships v{shipped}": "v{installed} → fornisce v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → fornisce v{shipped}",
+        "Where the automation lives": "Dove vive l'automazione",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "I flussi sono ciò che accade senza che nessuno clicchi: un oggetto marcato al salvataggio, un'app avvisata quando un record cambia. Qui li leggi e li modifichi. Nulla da costruire ora.",
+        "Open Flows in the menu": "Apri Flussi nel menu"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/it.json
+++ b/l10n/it.json
@@ -2725,7 +2725,10 @@
         "Register descriptors": "Descrittori di registro",
         "ships v{shipped}": "fornisce v{shipped}",
         "State": "Stato",
-        "v{installed} → ships v{shipped}": "v{installed} → fornisce v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → fornisce v{shipped}",
+        "Where the automation lives": "Dove vive l'automazione",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "I flussi sono ciò che accade senza che nessuno clicchi: un oggetto marcato al salvataggio, un'app avvisata quando un record cambia. Qui li leggi e li modifichi. Nulla da costruire ora.",
+        "Open Flows in the menu": "Apri Flussi nel menu"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/lb.js
+++ b/l10n/lb.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Register-Deskriptoren",
         "ships v{shipped}": "liwwert v{shipped}",
         "State": "Status",
-        "v{installed} → ships v{shipped}": "v{installed} → liwwert v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → liwwert v{shipped}",
+        "Where the automation lives": "Wou d'Automatisatioun wunnt",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Flows sinn dat, wat ouni Klick geschitt: en Objet dee beim Späichere gestempelt gëtt, eng App déi Bescheed kritt wann e Record ännert. Hei liest an ännert Dir se. Elo ass näischt ze bauen.",
+        "Open Flows in the menu": "Flows am Menü opmaachen"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/lb.json
+++ b/l10n/lb.json
@@ -2725,7 +2725,10 @@
         "Register descriptors": "Register-Deskriptoren",
         "ships v{shipped}": "liwwert v{shipped}",
         "State": "Status",
-        "v{installed} → ships v{shipped}": "v{installed} → liwwert v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → liwwert v{shipped}",
+        "Where the automation lives": "Wou d'Automatisatioun wunnt",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Flows sinn dat, wat ouni Klick geschitt: en Objet dee beim Späichere gestempelt gëtt, eng App déi Bescheed kritt wann e Record ännert. Hei liest an ännert Dir se. Elo ass näischt ze bauen.",
+        "Open Flows in the menu": "Flows am Menü opmaachen"
     },
     "pluralForm": "nplurals=2; plural=(n != 1);",
     "plurals": {

--- a/l10n/lt.js
+++ b/l10n/lt.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Registrų deskriptoriai",
         "ships v{shipped}": "pateikia v{shipped}",
         "State": "Būsena",
-        "v{installed} → ships v{shipped}": "v{installed} → pateikia v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → pateikia v{shipped}",
+        "Where the automation lives": "Kur gyvena automatizavimas",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Srautai yra tai, kas vyksta niekam nespaudžiant: objektas, pažymimas išsaugant, programa, informuojama pasikeitus įrašui. Čia juos skaitote ir redaguojate. Dabar nieko kurti nereikia.",
+        "Open Flows in the menu": "Atidarykite Srautus meniu"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/lt.json
+++ b/l10n/lt.json
@@ -2726,7 +2726,10 @@
         "Register descriptors": "Registrų deskriptoriai",
         "ships v{shipped}": "pateikia v{shipped}",
         "State": "Būsena",
-        "v{installed} → ships v{shipped}": "v{installed} → pateikia v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → pateikia v{shipped}",
+        "Where the automation lives": "Kur gyvena automatizavimas",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Srautai yra tai, kas vyksta niekam nespaudžiant: objektas, pažymimas išsaugant, programa, informuojama pasikeitus įrašui. Čia juos skaitote ir redaguojate. Dabar nieko kurti nereikia.",
+        "Open Flows in the menu": "Atidarykite Srautus meniu"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/lv.js
+++ b/l10n/lv.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Reģistru deskriptori",
         "ships v{shipped}": "piegādā v{shipped}",
         "State": "Stāvoklis",
-        "v{installed} → ships v{shipped}": "v{installed} → piegādā v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → piegādā v{shipped}",
+        "Where the automation lives": "Kur dzīvo automatizācija",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Plūsmas ir tas, kas notiek bez klikšķa: objekts, kas tiek zīmogots saglabājot, lietotne, kurai paziņo, kad ieraksts mainās. Šeit tās lasāt un rediģējat. Tagad nav jāveido nekas.",
+        "Open Flows in the menu": "Atveriet Plūsmas izvēlnē"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/lv.json
+++ b/l10n/lv.json
@@ -2726,7 +2726,10 @@
         "Register descriptors": "Reģistru deskriptori",
         "ships v{shipped}": "piegādā v{shipped}",
         "State": "Stāvoklis",
-        "v{installed} → ships v{shipped}": "v{installed} → piegādā v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → piegādā v{shipped}",
+        "Where the automation lives": "Kur dzīvo automatizācija",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Plūsmas ir tas, kas notiek bez klikšķa: objekts, kas tiek zīmogots saglabājot, lietotne, kurai paziņo, kad ieraksts mainās. Šeit tās lasāt un rediģējat. Tagad nav jāveido nekas.",
+        "Open Flows in the menu": "Atveriet Plūsmas izvēlnē"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/mk.js
+++ b/l10n/mk.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Дескриптори на регистри",
         "ships v{shipped}": "испорачува v{shipped}",
         "State": "Состојба",
-        "v{installed} → ships v{shipped}": "v{installed} → испорачува v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → испорачува v{shipped}",
+        "Where the automation lives": "Каде живее автоматизацијата",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Текови се тоа што се случува без некој да кликне: објект означен при зачувување, апликација известена кога запис ќе се промени. Тука ги читате и уредувате. Сега нема што да се гради.",
+        "Open Flows in the menu": "Отворете Текови во менито"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/mk.json
+++ b/l10n/mk.json
@@ -2725,7 +2725,10 @@
         "Register descriptors": "Дескриптори на регистри",
         "ships v{shipped}": "испорачува v{shipped}",
         "State": "Состојба",
-        "v{installed} → ships v{shipped}": "v{installed} → испорачува v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → испорачува v{shipped}",
+        "Where the automation lives": "Каде живее автоматизацијата",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Текови се тоа што се случува без некој да кликне: објект означен при зачувување, апликација известена кога запис ќе се промени. Тука ги читате и уредувате. Сега нема што да се гради.",
+        "Open Flows in the menu": "Отворете Текови во менито"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/mt.js
+++ b/l10n/mt.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Deskritturi tar-reġistri",
         "ships v{shipped}": "iwassal v{shipped}",
         "State": "Stat",
-        "v{installed} → ships v{shipped}": "v{installed} → iwassal v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → iwassal v{shipped}",
+        "Where the automation lives": "Fejn tgħix l-awtomazzjoni",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Il-flussi huma dak li jiġri mingħajr ma xi ħadd jikklikkja: oġġett ittimbrat mal-iffrankar, applikazzjoni mgħarrfa meta jinbidel rekord. Hawn taqrahom u teditjahom. M'hemm xejn x'tibni issa.",
+        "Open Flows in the menu": "Iftaħ Flussi fil-menu"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/mt.json
+++ b/l10n/mt.json
@@ -2727,7 +2727,10 @@
         "Register descriptors": "Deskritturi tar-reġistri",
         "ships v{shipped}": "iwassal v{shipped}",
         "State": "Stat",
-        "v{installed} → ships v{shipped}": "v{installed} → iwassal v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → iwassal v{shipped}",
+        "Where the automation lives": "Fejn tgħix l-awtomazzjoni",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Il-flussi huma dak li jiġri mingħajr ma xi ħadd jikklikkja: oġġett ittimbrat mal-iffrankar, applikazzjoni mgħarrfa meta jinbidel rekord. Hawn taqrahom u teditjahom. M'hemm xejn x'tibni issa.",
+        "Open Flows in the menu": "Iftaħ Flussi fil-menu"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/nb.js
+++ b/l10n/nb.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Registerdeskriptorer",
         "ships v{shipped}": "leverer v{shipped}",
         "State": "Status",
-        "v{installed} → ships v{shipped}": "v{installed} → leverer v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → leverer v{shipped}",
+        "Where the automation lives": "Der automatiseringen bor",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Flyter er det som skjer uten at noen klikker: et objekt som stemples ved lagring, en app som varsles når en post endres. Her leser og redigerer du dem. Ingenting å bygge nå.",
+        "Open Flows in the menu": "Åpne Flyter i menyen"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/nb.json
+++ b/l10n/nb.json
@@ -2725,7 +2725,10 @@
         "Register descriptors": "Registerdeskriptorer",
         "ships v{shipped}": "leverer v{shipped}",
         "State": "Status",
-        "v{installed} → ships v{shipped}": "v{installed} → leverer v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → leverer v{shipped}",
+        "Where the automation lives": "Der automatiseringen bor",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Flyter er det som skjer uten at noen klikker: et objekt som stemples ved lagring, en app som varsles når en post endres. Her leser og redigerer du dem. Ingenting å bygge nå.",
+        "Open Flows in the menu": "Åpne Flyter i menyen"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/nl.js
+++ b/l10n/nl.js
@@ -2775,7 +2775,10 @@ OC.L10N.register(
         "Register descriptors": "Register-descriptors",
         "ships v{shipped}": "levert v{shipped}",
         "State": "Status",
-        "v{installed} → ships v{shipped}": "v{installed} → levert v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → levert v{shipped}",
+        "Where the automation lives": "Waar de automatisering zit",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Flows zijn wat er gebeurt zonder dat iemand klikt: een object dat bij opslaan wordt gestempeld, een afnemende app die bericht krijgt wanneer een record verandert. Hier leest en bewerkt u ze. U hoeft nu niets te bouwen.",
+        "Open Flows in the menu": "Open Flows in het menu"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -2777,7 +2777,10 @@
         "Register descriptors": "Register-descriptors",
         "ships v{shipped}": "levert v{shipped}",
         "State": "Status",
-        "v{installed} → ships v{shipped}": "v{installed} → levert v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → levert v{shipped}",
+        "Where the automation lives": "Waar de automatisering zit",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Flows zijn wat er gebeurt zonder dat iemand klikt: een object dat bij opslaan wordt gestempeld, een afnemende app die bericht krijgt wanneer een record verandert. Hier leest en bewerkt u ze. U hoeft nu niets te bouwen.",
+        "Open Flows in the menu": "Open Flows in het menu"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/pl.js
+++ b/l10n/pl.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Deskryptory rejestrów",
         "ships v{shipped}": "dostarcza v{shipped}",
         "State": "Stan",
-        "v{installed} → ships v{shipped}": "v{installed} → dostarcza v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → dostarcza v{shipped}",
+        "Where the automation lives": "Gdzie mieszka automatyzacja",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Przepływy to co dzieje się bez kliknięcia: obiekt stemplowany przy zapisie, aplikacja powiadamiana gdy rekord się zmienia. Tutaj je czytasz i edytujesz. Teraz nic nie trzeba budować.",
+        "Open Flows in the menu": "Otwórz Przepływy w menu"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/pl.json
+++ b/l10n/pl.json
@@ -2726,7 +2726,10 @@
         "Register descriptors": "Deskryptory rejestrów",
         "ships v{shipped}": "dostarcza v{shipped}",
         "State": "Stan",
-        "v{installed} → ships v{shipped}": "v{installed} → dostarcza v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → dostarcza v{shipped}",
+        "Where the automation lives": "Gdzie mieszka automatyzacja",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Przepływy to co dzieje się bez kliknięcia: obiekt stemplowany przy zapisie, aplikacja powiadamiana gdy rekord się zmienia. Tutaj je czytasz i edytujesz. Teraz nic nie trzeba budować.",
+        "Open Flows in the menu": "Otwórz Przepływy w menu"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/pt.js
+++ b/l10n/pt.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Descritores de registo",
         "ships v{shipped}": "fornece v{shipped}",
         "State": "Estado",
-        "v{installed} → ships v{shipped}": "v{installed} → fornece v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → fornece v{shipped}",
+        "Where the automation lives": "Onde vive a automação",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Os fluxos são o que acontece sem ninguém clicar: um objeto carimbado ao guardar, uma aplicação avisada quando um registo muda. É aqui que os lê e edita. Nada a construir agora.",
+        "Open Flows in the menu": "Abrir Fluxos no menu"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/pt.json
+++ b/l10n/pt.json
@@ -2725,7 +2725,10 @@
         "Register descriptors": "Descritores de registo",
         "ships v{shipped}": "fornece v{shipped}",
         "State": "Estado",
-        "v{installed} → ships v{shipped}": "v{installed} → fornece v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → fornece v{shipped}",
+        "Where the automation lives": "Onde vive a automação",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Os fluxos são o que acontece sem ninguém clicar: um objeto carimbado ao guardar, uma aplicação avisada quando um registo muda. É aqui que os lê e edita. Nada a construir agora.",
+        "Open Flows in the menu": "Abrir Fluxos no menu"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/rm.js
+++ b/l10n/rm.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Descripturs da register",
         "ships v{shipped}": "furnescha v{shipped}",
         "State": "Status",
-        "v{installed} → ships v{shipped}": "v{installed} → furnescha v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → furnescha v{shipped}",
+        "Where the automation lives": "Nua che l'automatisaziun viva",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Flussins èn quai che capita senza che insatgi cliccheschia: in object che vegn stampà cun memorisar, ina app che vegn infurmada cura ch'ina endataziun mida. Qua als legias e modifitgeschas. Uss n'è nagut da construir.",
+        "Open Flows in the menu": "Avrir Flussins en il menu"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/rm.json
+++ b/l10n/rm.json
@@ -2725,7 +2725,10 @@
         "Register descriptors": "Descripturs da register",
         "ships v{shipped}": "furnescha v{shipped}",
         "State": "Status",
-        "v{installed} → ships v{shipped}": "v{installed} → furnescha v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → furnescha v{shipped}",
+        "Where the automation lives": "Nua che l'automatisaziun viva",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Flussins èn quai che capita senza che insatgi cliccheschia: in object che vegn stampà cun memorisar, ina app che vegn infurmada cura ch'ina endataziun mida. Qua als legias e modifitgeschas. Uss n'è nagut da construir.",
+        "Open Flows in the menu": "Avrir Flussins en il menu"
     },
     "pluralForm": "nplurals=2; plural=(n != 1);",
     "plurals": {

--- a/l10n/ro.js
+++ b/l10n/ro.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Descriptori de registru",
         "ships v{shipped}": "livrează v{shipped}",
         "State": "Stare",
-        "v{installed} → ships v{shipped}": "v{installed} → livrează v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → livrează v{shipped}",
+        "Where the automation lives": "Unde trăiește automatizarea",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Fluxurile sunt ce se întâmplă fără ca cineva să dea clic: un obiect ștampilat la salvare, o aplicație anunțată când un înregistrare se schimbă. Aici le citiți și le editați. Nu e nimic de construit acum.",
+        "Open Flows in the menu": "Deschideți Fluxuri în meniu"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/ro.json
+++ b/l10n/ro.json
@@ -2726,7 +2726,10 @@
         "Register descriptors": "Descriptori de registru",
         "ships v{shipped}": "livrează v{shipped}",
         "State": "Stare",
-        "v{installed} → ships v{shipped}": "v{installed} → livrează v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → livrează v{shipped}",
+        "Where the automation lives": "Unde trăiește automatizarea",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Fluxurile sunt ce se întâmplă fără ca cineva să dea clic: un obiect ștampilat la salvare, o aplicație anunțată când un înregistrare se schimbă. Aici le citiți și le editați. Nu e nimic de construit acum.",
+        "Open Flows in the menu": "Deschideți Fluxuri în meniu"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/ru.js
+++ b/l10n/ru.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Дескрипторы реестров",
         "ships v{shipped}": "поставляет v{shipped}",
         "State": "Состояние",
-        "v{installed} → ships v{shipped}": "v{installed} → поставляет v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → поставляет v{shipped}",
+        "Where the automation lives": "Где живёт автоматизация",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Потоки — это то, что происходит без нажатий: объект, помечаемый при сохранении, приложение, уведомляемое при изменении записи. Здесь вы их читаете и редактируете. Сейчас ничего строить не нужно.",
+        "Open Flows in the menu": "Откройте Потоки в меню"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/ru.json
+++ b/l10n/ru.json
@@ -2726,7 +2726,10 @@
         "Register descriptors": "Дескрипторы реестров",
         "ships v{shipped}": "поставляет v{shipped}",
         "State": "Состояние",
-        "v{installed} → ships v{shipped}": "v{installed} → поставляет v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → поставляет v{shipped}",
+        "Where the automation lives": "Где живёт автоматизация",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Потоки — это то, что происходит без нажатий: объект, помечаемый при сохранении, приложение, уведомляемое при изменении записи. Здесь вы их читаете и редактируете. Сейчас ничего строить не нужно.",
+        "Open Flows in the menu": "Откройте Потоки в меню"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/sk.js
+++ b/l10n/sk.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Deskriptory registrov",
         "ships v{shipped}": "dodáva v{shipped}",
         "State": "Stav",
-        "v{installed} → ships v{shipped}": "v{installed} → dodáva v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → dodáva v{shipped}",
+        "Where the automation lives": "Kde žije automatizácia",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Toky sú to, čo sa deje bez kliknutia: objekt označený pri uložení, aplikácia informovaná pri zmene záznamu. Tu ich čítate a upravujete. Teraz netreba nič stavať.",
+        "Open Flows in the menu": "Otvorte Toky v ponuke"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/sk.json
+++ b/l10n/sk.json
@@ -2726,6 +2726,9 @@
         "Register descriptors": "Deskriptory registrov",
         "ships v{shipped}": "dodáva v{shipped}",
         "State": "Stav",
-        "v{installed} → ships v{shipped}": "v{installed} → dodáva v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → dodáva v{shipped}",
+        "Where the automation lives": "Kde žije automatizácia",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Toky sú to, čo sa deje bez kliknutia: objekt označený pri uložení, aplikácia informovaná pri zmene záznamu. Tu ich čítate a upravujete. Teraz netreba nič stavať.",
+        "Open Flows in the menu": "Otvorte Toky v ponuke"
     }
 }

--- a/l10n/sl.js
+++ b/l10n/sl.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Deskriptorji registrov",
         "ships v{shipped}": "dobavlja v{shipped}",
         "State": "Stanje",
-        "v{installed} → ships v{shipped}": "v{installed} → dobavlja v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → dobavlja v{shipped}",
+        "Where the automation lives": "Kje živi avtomatizacija",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Tokovi so tisto, kar se zgodi brez klika: predmet, žigosan ob shranjevanju, aplikacija, obveščena ob spremembi zapisa. Tu jih berete in urejate. Zdaj ni treba ničesar graditi.",
+        "Open Flows in the menu": "Odprite Tokove v meniju"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/sl.json
+++ b/l10n/sl.json
@@ -2727,7 +2727,10 @@
         "Register descriptors": "Deskriptorji registrov",
         "ships v{shipped}": "dobavlja v{shipped}",
         "State": "Stanje",
-        "v{installed} → ships v{shipped}": "v{installed} → dobavlja v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → dobavlja v{shipped}",
+        "Where the automation lives": "Kje živi avtomatizacija",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Tokovi so tisto, kar se zgodi brez klika: predmet, žigosan ob shranjevanju, aplikacija, obveščena ob spremembi zapisa. Tu jih berete in urejate. Zdaj ni treba ničesar graditi.",
+        "Open Flows in the menu": "Odprite Tokove v meniju"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/sq.js
+++ b/l10n/sq.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Përshkrues regjistrash",
         "ships v{shipped}": "jep v{shipped}",
         "State": "Gjendja",
-        "v{installed} → ships v{shipped}": "v{installed} → jep v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → jep v{shipped}",
+        "Where the automation lives": "Ku jeton automatizimi",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Rrjedhat janë ajo që ndodh pa klikuar askush: një objekt i vulosur në ruajtje, një aplikacion i njoftuar kur ndryshon një regjistrim. Këtu i lexoni dhe i redaktoni. Tani nuk ka gjë për të ndërtuar.",
+        "Open Flows in the menu": "Hapni Rrjedhat në meny"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/sq.json
+++ b/l10n/sq.json
@@ -2725,7 +2725,10 @@
         "Register descriptors": "Përshkrues regjistrash",
         "ships v{shipped}": "jep v{shipped}",
         "State": "Gjendja",
-        "v{installed} → ships v{shipped}": "v{installed} → jep v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → jep v{shipped}",
+        "Where the automation lives": "Ku jeton automatizimi",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Rrjedhat janë ajo që ndodh pa klikuar askush: një objekt i vulosur në ruajtje, një aplikacion i njoftuar kur ndryshon një regjistrim. Këtu i lexoni dhe i redaktoni. Tani nuk ka gjë për të ndërtuar.",
+        "Open Flows in the menu": "Hapni Rrjedhat në meny"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/sr.js
+++ b/l10n/sr.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Дескриптори регистара",
         "ships v{shipped}": "испоручује v{shipped}",
         "State": "Стање",
-        "v{installed} → ships v{shipped}": "v{installed} → испоручује v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → испоручује v{shipped}",
+        "Where the automation lives": "Где живи аутоматизација",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Токови су оно што се дешава без клика: објекат означен при чувању, апликација обавештена када се запис промени. Овде их читате и уређујете. Сада нема шта да се гради.",
+        "Open Flows in the menu": "Отворите Токове у менију"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/sr.json
+++ b/l10n/sr.json
@@ -2726,7 +2726,10 @@
         "Register descriptors": "Дескриптори регистара",
         "ships v{shipped}": "испоручује v{shipped}",
         "State": "Стање",
-        "v{installed} → ships v{shipped}": "v{installed} → испоручује v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → испоручује v{shipped}",
+        "Where the automation lives": "Где живи аутоматизација",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Токови су оно што се дешава без клика: објекат означен при чувању, апликација обавештена када се запис промени. Овде их читате и уређујете. Сада нема шта да се гради.",
+        "Open Flows in the menu": "Отворите Токове у менију"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/sv.js
+++ b/l10n/sv.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Registerdeskriptorer",
         "ships v{shipped}": "levererar v{shipped}",
         "State": "Status",
-        "v{installed} → ships v{shipped}": "v{installed} → levererar v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → levererar v{shipped}",
+        "Where the automation lives": "Där automatiseringen bor",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Flöden är det som händer utan att någon klickar: ett objekt som stämplas vid sparande, en app som meddelas när en post ändras. Här läser och redigerar du dem. Inget att bygga nu.",
+        "Open Flows in the menu": "Öppna Flöden i menyn"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/sv.json
+++ b/l10n/sv.json
@@ -2725,7 +2725,10 @@
         "Register descriptors": "Registerdeskriptorer",
         "ships v{shipped}": "levererar v{shipped}",
         "State": "Status",
-        "v{installed} → ships v{shipped}": "v{installed} → levererar v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → levererar v{shipped}",
+        "Where the automation lives": "Där automatiseringen bor",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Flöden är det som händer utan att någon klickar: ett objekt som stämplas vid sparande, en app som meddelas när en post ändras. Här läser och redigerar du dem. Inget att bygga nu.",
+        "Open Flows in the menu": "Öppna Flöden i menyn"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/tr.js
+++ b/l10n/tr.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Kayıt tanımlayıcıları",
         "ships v{shipped}": "v{shipped} sunuyor",
         "State": "Durum",
-        "v{installed} → ships v{shipped}": "v{installed} → v{shipped} sunuyor"
+        "v{installed} → ships v{shipped}": "v{installed} → v{shipped} sunuyor",
+        "Where the automation lives": "Otomasyonun yaşadığı yer",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Akışlar kimse tıklamadan olan şeylerdir: kaydederken damgalanan bir nesne, bir kayıt değiştiğinde haber verilen bir uygulama. Bunları burada okur ve düzenlersiniz. Şimdi inşa edilecek bir şey yok.",
+        "Open Flows in the menu": "Menüden Akışlar'ı açın"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/tr.json
+++ b/l10n/tr.json
@@ -2725,7 +2725,10 @@
         "Register descriptors": "Kayıt tanımlayıcıları",
         "ships v{shipped}": "v{shipped} sunuyor",
         "State": "Durum",
-        "v{installed} → ships v{shipped}": "v{installed} → v{shipped} sunuyor"
+        "v{installed} → ships v{shipped}": "v{installed} → v{shipped} sunuyor",
+        "Where the automation lives": "Otomasyonun yaşadığı yer",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Akışlar kimse tıklamadan olan şeylerdir: kaydederken damgalanan bir nesne, bir kayıt değiştiğinde haber verilen bir uygulama. Bunları burada okur ve düzenlersiniz. Şimdi inşa edilecek bir şey yok.",
+        "Open Flows in the menu": "Menüden Akışlar'ı açın"
     },
     "plurals": {
         "{count} email": [

--- a/l10n/uk.js
+++ b/l10n/uk.js
@@ -2723,7 +2723,10 @@ OC.L10N.register(
         "Register descriptors": "Дескриптори реєстрів",
         "ships v{shipped}": "постачає v{shipped}",
         "State": "Стан",
-        "v{installed} → ships v{shipped}": "v{installed} → постачає v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → постачає v{shipped}",
+        "Where the automation lives": "Де живе автоматизація",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Потоки — це те, що відбувається без кліків: об'єкт, що позначається під час збереження, застосунок, сповіщений про зміну запису. Тут ви їх читаєте та редагуєте. Зараз нічого будувати не потрібно.",
+        "Open Flows in the menu": "Відкрийте Потоки в меню"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/uk.json
+++ b/l10n/uk.json
@@ -2726,7 +2726,10 @@
         "Register descriptors": "Дескриптори реєстрів",
         "ships v{shipped}": "постачає v{shipped}",
         "State": "Стан",
-        "v{installed} → ships v{shipped}": "v{installed} → постачає v{shipped}"
+        "v{installed} → ships v{shipped}": "v{installed} → постачає v{shipped}",
+        "Where the automation lives": "Де живе автоматизація",
+        "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.": "Потоки — це те, що відбувається без кліків: об'єкт, що позначається під час збереження, застосунок, сповіщений про зміну запису. Тут ви їх читаєте та редагуєте. Зараз нічого будувати не потрібно.",
+        "Open Flows in the menu": "Відкрийте Потоки в меню"
     },
     "plurals": {
         "{count} email": [

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest-v2.schema.json",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "nav": {
     "includePersonalSettings": false
   },
@@ -793,6 +793,24 @@
             "advanceOn": {
               "type": "route-match",
               "route": "tables"
+            }
+          },
+          {
+            "id": "see-flows",
+            "sinceVersion": "1.1.0",
+            "placement": "right",
+            "optional": true,
+            "allowManualNext": true,
+            "title": "Where the automation lives",
+            "body": "Flows are what happens without anyone clicking: an object that gets stamped on save, a downstream app told when a record changes. This is where you read and edit them. Nothing to build now.",
+            "task": "Open Flows in the menu",
+            "target": {
+              "kind": "nav-item",
+              "ref": "flows"
+            },
+            "advanceOn": {
+              "type": "route-match",
+              "route": "flows"
             }
           },
           {


### PR DESCRIPTION
feat(walkthrough): show where flows live, without making anyone build one

openregister ships a flows surface (the `flows` index at /flows, in the
main menu) and its tour never mentioned it, so the automation was
discoverable only to someone who already knew it was there.

Found by widening gate 70's flows-page predicate, which matched only
`type: "flows"` — a type exactly one fleet app declares. openregister ships
its surface as an ordinary `type: "index"` page, so the gate reported NOT
APPLICABLE: it read as covered while covering nothing.

The step is `optional` with `allowManualNext`: showing where flows are
edited must not become "author an automation before you may finish the
tour".

It targets `flows` — the ROUTE, lowercase, as the menu entry declares it.
`data-cn-route` carries `item.route`, and that is what
CnWalkthrough.resolveTarget() looks up. The menu entry's ID here is `Flows`
with a capital F; targeting that would look right in review and resolve to
nothing at runtime, and an optional step whose target is absent is SKIPPED
silently. (The neighbouring `open-tables` step has exactly that shape — it
targets the menu id `Tables` while advancing on route `tables` — which is
worth a separate look.)

All 36 required locales are translated, not just en/nl: this repo enforces
full parity, and `test:l10n` fails on any missing or empty value.

Verified: gate-70 0 findings, gate-96 rc=0, l10n parity OK across 36
locales, check:l10n-js rc=0.
