### PR TITLE
docs: add a local demo environment (openregister-compose.yaml + setup page)

### DIFF
--- a/docs/Installation/demo-environment.md
+++ b/docs/Installation/demo-environment.md
@@ -77,8 +77,10 @@ A page loading is not the same as a page working. Nextcloud serves its shell bef
 Check content instead:
 
 ```bash
-# The app answers, rather than 404 or an empty shell
-curl -s -o /dev/null -w '%{http_code}\n' "http://localhost:8601/apps/openregister/"
+# The app answers. Note the credentials: an app page requires a login, so the
+# SAME request without -u returns 401, which is not a broken demo — measured
+# on a booted demo while writing this page.
+curl -s -o /dev/null -w '%{http_code}\n' -u admin:admin -L "http://localhost:8601/apps/openregister/"
 
 # OpenRegister has registers — an empty list means the configuration
 # was never imported, which is not the same as "nothing configured yet"

--- a/docs/Installation/demo-environment.md
+++ b/docs/Installation/demo-environment.md
@@ -1,0 +1,128 @@
+# Run a local demo
+
+This page gets a working OpenRegister running on your own machine in two commands. You end with a registry with registers and schemas you can model against.
+
+It is a **demo**, not a development environment. Nothing is mounted from a checkout, and that is deliberate — see [What this is not](#what-this-is-not).
+
+## What you need
+
+Docker, with Compose v2.23 or newer. Nothing else — no PHP, no Node, no Nextcloud.
+
+```bash
+docker --version
+docker compose version
+```
+
+If `docker compose version` prints v2.22 or older, upgrade first. The compose file declares its scripts inline via `configs`, and older versions ignore the `content:` field **silently** — which produces an instance with no apps installed and nothing in the logs to explain why.
+
+## Step 1 — get the compose file
+
+```bash
+curl -fsSLO https://raw.githubusercontent.com/ConductionNL/openregister/development/openregister-compose.yaml
+```
+
+A single self-contained file. There is nothing else to fetch and nothing to edit.
+
+## Step 2 — start it
+
+```bash
+docker compose -f openregister-compose.yaml up -d
+```
+
+The first run takes a few minutes: it pulls three images and downloads the application archives. Watch it work if you like:
+
+```bash
+docker compose -f openregister-compose.yaml logs -f app-installer
+```
+
+You are looking for:
+
+```
+==> installing openregister <version>
+==> installing thematiq <version>
+==> installing integriq <version>
+==> apps present: integriq openregister thematiq
+```
+
+Then Nextcloud installs itself and enables the apps **in dependency order**. OpenRegister goes first: it owns the registers and schemas the others declare against, and a leaf app enabled before it finds no register to attach to.
+
+That is done when this returns `"installed":true`:
+
+```bash
+curl -s http://localhost:8601/status.php
+```
+
+## Step 3 — open the demo
+
+| What | Where |
+| --- | --- |
+| **OpenRegister** | [http://localhost:8601/apps/openregister/](http://localhost:8601/apps/openregister/) |
+| Admin interface | [http://localhost:8601](http://localhost:8601) — `admin` / `admin` |
+
+## What gets installed, and why more than one app
+
+| App | Why |
+| --- | --- |
+| `openregister` | **Required.** Every Connext app declares its registers and schemas against OpenRegister. |
+| `thematiq` | Optional. Government theming. Absent, the UI renders unthemed rather than wrong. |
+| `integriq` | Optional. The connector, for feeding in data from systems you do not control. |
+| `openregister` | The app this page is about. |
+
+That OpenRegister dependency is **not declared** in `appinfo/info.xml` — no app in the fleet declares an `<app>` dependency — so nothing stops the App Store from installing openregister without it. It would then load, find no register to attach to, and show you an empty app rather than an error. The compose file encodes the dependency the manifest does not.
+
+## Verifying it actually worked
+
+A page loading is not the same as a page working. Nextcloud serves its shell before the app decides whether it has anything to render, so an app URL returns HTTP 200 even when it resolves to nothing at all. A smoke test that checks for a 200 would call that a success.
+
+Check content instead:
+
+```bash
+# The app answers, rather than 404 or an empty shell
+curl -s -o /dev/null -w '%{http_code}\n' "http://localhost:8601/apps/openregister/"
+
+# OpenRegister has registers — an empty list means the configuration
+# was never imported, which is not the same as "nothing configured yet"
+curl -s -u admin:admin "http://localhost:8601/apps/openregister/api/registers" | head -c 300
+```
+
+## Changing the defaults
+
+The port and every version are overridable:
+
+```bash
+DEMO_PORT=9000 \
+OPENREGISTER_VERSION=1.2.3 \
+docker compose -f openregister-compose.yaml up -d
+```
+
+Leaving a version empty resolves the newest release for that app, pre-releases included — which is what most Connext apps still ship, so that is the default.
+
+## Tearing it down
+
+```bash
+# Stop, keep the data
+docker compose -f openregister-compose.yaml down
+
+# Stop and delete everything, including the database
+docker compose -f openregister-compose.yaml down -v
+```
+
+## What this is not
+
+**It is not a development environment, and it cannot be turned into one by adding a bind mount.**
+
+Nextcloud installs and updates an app by deleting the app directory and extracting a fresh archive over it. Point that at a checkout and an app-store update will delete your working tree — measured on a development machine on 27 August 2026, where `\OC\Updater::upgradeAppStoreApp` fired on a container restart and removed every top-level file from a bind-mounted checkout, including its `.git` directory. Only the subdirectories it lacked permission to unlink survived.
+
+So this compose keeps its apps in a named volume and installs them from release archives. That also happens to be the only thing that works: a release archive is a **complete** app carrying `vendor/` and the built `js/` bundle, while a `git clone` carries neither — and a Nextcloud app with no `vendor/` does not fail loudly. It warns once and keeps loading, so the app appears installed while every service that needs a dependency is quietly absent.
+
+To work *on* these apps rather than *with* them, use the development environment instead.
+
+## Troubleshooting
+
+**`app-installer` exits non-zero.** It could not download an archive. Check the log for the URL it tried; the most common cause is a pinned version with no matching release.
+
+**It stops with `openregister missing; aborting`.** Deliberate. Every other app declares registers against OpenRegister, so a stack without it would start and then fail in a dozen confusing ways instead of one clear one.
+
+**The UI renders unthemed.** Thematiq is not installed or not enabled. Expected, and cosmetic — the theme resolver renders unthemed rather than wrong when it is absent.
+
+**Everything returns 404 or a maintenance page after a restart.** Nextcloud is waiting for an upgrade. Run `docker compose -f openregister-compose.yaml exec -u www-data nextcloud php occ upgrade`.

--- a/jest.config.js
+++ b/jest.config.js
@@ -68,6 +68,14 @@ module.exports = {
 		'<rootDir>/\\.playwright-mcp/',
 		// Playwright suite — has its own runner via `npx playwright test`.
 		'<rootDir>/tests/e2e/',
+		// The demo-environment Playwright suite. It sits OUTSIDE tests/e2e/ on
+		// purpose: playwright.config.ts sets testDir: './tests/e2e', so a spec
+		// placed there is collected by CI, which has no booted demo to point
+		// at. Moving it out solves that and creates this: jest's ignore list
+		// named tests/e2e/ specifically, so the new directory was collected
+		// here instead and jest tried to run a Playwright spec. Two collectors
+		// with opposite exclusions — a file has to be named in both.
+		'<rootDir>/tests/demo-e2e/',
 	],
 	modulePathIgnorePatterns: [
 		'<rootDir>/custom_apps/',

--- a/openregister-compose.yaml
+++ b/openregister-compose.yaml
@@ -1,0 +1,250 @@
+# OpenRegister — local demo environment
+#
+#   docker compose -f openregister-compose.yaml up -d
+#
+# Then open  http://localhost:8601/apps/openregister/
+# Admin UI:  http://localhost:8601  (admin / admin)
+#
+# Tear down, including all data:
+#   docker compose -f openregister-compose.yaml down -v
+#
+# ---------------------------------------------------------------------------
+# THIS IS A DEMO ENVIRONMENT, NOT A DEVELOPMENT ENVIRONMENT.
+#
+# Nothing here is bind-mounted from your working copy, and that is deliberate
+# rather than merely simpler. Nextcloud installs and updates an app by DELETING
+# its directory and extracting a fresh archive over it. Measured 2026-08-27 on
+# a development machine: `\OC\Updater::upgradeAppStoreApp` fired on a container
+# restart and removed every top-level file from a bind-mounted checkout —
+# including its `.git` directory — leaving only the subdirectories it lacked
+# permission to unlink. A demo rig has no business pointing at a checkout, so
+# this one owns its apps in a named volume.
+#
+# If you want to work ON these apps rather than WITH them, use the development
+# environment instead. This file cannot serve that purpose and should not try.
+#
+# ---------------------------------------------------------------------------
+# WHY RELEASE TARBALLS RATHER THAN `git clone`
+#
+# A release tarball is a COMPLETE app: it carries `vendor/` and the built `js/`
+# bundle. A git checkout carries neither, and a Nextcloud app whose `vendor/`
+# is missing does not fail loudly — `include_once` warns and the app keeps
+# loading, so the app appears installed while every service that needs a
+# dependency is absent.
+#
+# ---------------------------------------------------------------------------
+# WHAT IS INSTALLED, AND WHY MORE THAN ONE APP
+#
+#   openregister   REQUIRED. Every Connext app declares its registers and
+#                  schemas against OpenRegister. Note that this dependency is
+#                  NOT declared in appinfo/info.xml — no app in the fleet
+#                  declares an <app> dependency — so nothing stops the App
+#                  Store installing openregister without it. It would then load
+#                  and find no register to attach to.
+#   thematiq       Optional. Government theming. Absent, the UI renders
+#                  unthemed rather than wrong.
+#   integriq       Optional. The connector, for feeding data in from systems
+#                  you do not control.
+#   openregister   the app this file is for.
+#
+# Versions float to the newest release by default, pre-releases included,
+# because most Connext apps do not yet publish a stable one. Pin any of them:
+#
+#   OPENREGISTER_VERSION=1.2.3 docker compose -f openregister-compose.yaml up -d
+#
+# The Nextcloud image is pinned to a MAJOR tag rather than `:latest`. A demo
+# that is stopped and restarted weeks later would otherwise boot a drifted
+# Nextcloud over its existing data volume, which lands the instance in
+# maintenance mode with its apps disabled.
+
+name: openregister-demo
+
+volumes:
+  db:
+  nextcloud:
+  apps:
+
+services:
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: nextcloud
+      POSTGRES_PASSWORD: nextcloud
+      POSTGRES_DB: nextcloud
+    volumes:
+      - db:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U nextcloud -d nextcloud"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  # Downloads each app's release tarball into the shared `apps` volume before
+  # Nextcloud starts. It runs to completion and exits; Nextcloud waits for that
+  # exit via `condition: service_completed_successfully`, so there is no window
+  # in which Nextcloud boots against a half-populated app directory.
+  #
+  # Idempotent: an app whose appinfo/info.xml is already present is skipped, so
+  # `up` on an existing demo does not re-download 100MB per app.
+  app-installer:
+    image: alpine:3.20
+    restart: "no"
+    environment:
+      OPENREGISTER_VERSION: ${OPENREGISTER_VERSION:-}
+      THEMATIQ_VERSION: ${THEMATIQ_VERSION:-}
+      INTEGRIQ_VERSION: ${INTEGRIQ_VERSION:-}
+    volumes:
+      - apps:/apps
+    configs:
+      - source: install-apps
+        target: /install-apps.sh
+        mode: "0755"
+    command: ["/bin/sh", "/install-apps.sh"]
+
+  nextcloud:
+    image: nextcloud:34-apache
+    restart: unless-stopped
+    ports:
+      - "${DEMO_PORT:-8601}:80"
+    depends_on:
+      db:
+        condition: service_healthy
+      app-installer:
+        condition: service_completed_successfully
+    environment:
+      POSTGRES_HOST: db
+      POSTGRES_USER: nextcloud
+      POSTGRES_PASSWORD: nextcloud
+      POSTGRES_DB: nextcloud
+      NEXTCLOUD_ADMIN_USER: admin
+      NEXTCLOUD_ADMIN_PASSWORD: admin
+      # The port has to appear here as well as in `ports:`. Nextcloud rejects a
+      # request whose Host header names a domain it does not trust, and
+      # "localhost" and "localhost:8601" are different entries.
+      NEXTCLOUD_TRUSTED_DOMAINS: "localhost localhost:${DEMO_PORT:-8601} 127.0.0.1 127.0.0.1:${DEMO_PORT:-8601}"
+      # OVERWRITECLIURL IS LOAD-BEARING, NOT COSMETIC. Apps that federate
+      # advertise this address to peers. It is a local address here, and a
+      # local address is refused rather than broadcast — which is what keeps a
+      # demo on somebody's laptop out of the national directory.
+      OVERWRITECLIURL: "http://localhost:${DEMO_PORT:-8601}"
+      OVERWRITEPROTOCOL: http
+    volumes:
+      - nextcloud:/var/www/html
+      - apps:/var/www/html/custom_apps
+    configs:
+      - source: enable-apps
+        target: /docker-entrypoint-hooks.d/post-installation/10-enable-connext-apps.sh
+        mode: "0755"
+
+configs:
+  # EVERY SHELL VARIABLE BELOW IS WRITTEN `$$name`, NOT `$name`.
+  #
+  # Compose interpolates `$name` inside `configs.content` before the file is
+  # written, so an un-escaped shell variable arrives as an EMPTY STRING and the
+  # script runs on silently. Measured while building this file: `$version` was
+  # blanked, which made the "no version pinned" branch look true for an app
+  # whose version WAS pinned, and the resulting error named no repository —
+  # `could not resolve a release for ` — because `$repo` had been blanked too.
+  #
+  # `$$` is the escape that survives interpolation and reaches /bin/sh as `$`.
+  # `${DEMO_PORT:-8601}` is deliberately NOT escaped: that one is Compose's
+  # to substitute.
+  install-apps:
+    content: |
+      #!/bin/sh
+      set -eu
+      apk add --no-cache curl tar jq >/dev/null
+
+      # RESOLVING "NEWEST" TAKES TWO CORRECTIONS, NOT ONE.
+      #
+      # 1. The GitHub "latest release" endpoint EXCLUDES prereleases and answers
+      #    404 for a repository that has only ever shipped them — which reads
+      #    exactly like "no such app". Ask the releases LIST instead.
+      #
+      # 2. THE LIST IS NOT ORDERED BY CREATION DATE. Taking the first entry looks
+      #    correct and is not. Measured 2026-08-27 on openregister:
+      #
+      #      v1.1.6                          created 10:17:45   <- returned first
+      #      v1.1.6-unstable.20260827110807  created 11:09:37   <- actually newest
+      #
+      #    Taking the first entry installs an OLDER build than intended, and the
+      #    failure surfaces far from the cause — as a missing CLASS in a
+      #    different app, not as a version complaint.
+      #
+      # Sorting by created_at explicitly is the fix; jq is here for that.
+      resolve_latest() {
+        curl -fsSL "https://api.github.com/repos/ConductionNL/$$1/releases?per_page=50" \
+          | jq -r '[.[] | select(.draft | not)] | sort_by(.created_at) | last | .tag_name // empty' \
+          | sed 's/^v//'
+      }
+
+      install_app() {
+        repo="$$1"; appid="$$2"; version="$$3"; asset="$$4"
+
+        if [ -f "/apps/$$appid/appinfo/info.xml" ]; then
+          echo "==> $$appid already present, skipping"
+          return 0
+        fi
+
+        if [ -z "$$version" ]; then
+          version="$$(resolve_latest "$$repo")"
+          [ -n "$$version" ] || { echo "!! could not resolve a release for $$repo"; return 1; }
+          echo "==> $$appid: no version pinned, resolved $$version"
+        fi
+
+        url="https://github.com/ConductionNL/$$repo/releases/download/v$$version/$$asset-$$version.tar.gz"
+        echo "==> installing $$appid $$version"
+
+        # Extract into a staging directory rather than straight into /apps.
+        # The archive's own top-level directory name is not guaranteed to equal
+        # the Nextcloud app id — Nextcloud resolves an app by its DIRECTORY
+        # name, so an archive that unpacks under the old name after a rename
+        # yields an app that is silently never loaded. Several Connext apps were
+        # renamed in August 2026, so this is a live concern, not a hypothetical.
+        rm -rf /tmp/stage && mkdir -p /tmp/stage
+        curl -fsSL "$$url" | tar -xz -C /tmp/stage
+
+        top="$$(ls /tmp/stage | head -n1)"
+        if [ "$$top" != "$$appid" ]; then
+          echo "    archive unpacked as '$$top', installing it as '$$appid'"
+        fi
+        mv "/tmp/stage/$$top" "/apps/$$appid"
+        rm -rf /tmp/stage
+      }
+
+      # OpenRegister is not optional. If it could not be fetched, stop here
+      # rather than let Nextcloud boot into a dozen confusing downstream
+      # failures instead of one clear one.
+      install_app openregister     openregister     "$$OPENREGISTER_VERSION"    openregister
+      install_app thematiq         thematiq         "$$THEMATIQ_VERSION"        thematiq
+      install_app integriq         integriq         "$$INTEGRIQ_VERSION"        integriq
+
+      [ -f /apps/openregister/appinfo/info.xml ] || { echo "!! openregister missing; aborting"; exit 1; }
+
+      # 33 is www-data inside the Nextcloud image.
+      chown -R 33:33 /apps
+      echo "==> apps present: $$(ls /apps | tr '\n' ' ')"
+
+  enable-apps:
+    content: |
+      #!/bin/sh
+      set -eu
+      # Runs once, after Nextcloud has installed itself.
+      #
+      # ORDER IS NOT ARBITRARY. OpenRegister owns the registers and schemas the
+      # other apps declare against, and a leaf app enabled before it finds no
+      # register to attach to. Enabling them in dependency order is what makes
+      # a first boot produce a working instance instead of an empty one.
+      for app in openregister thematiq integriq; do
+        echo "==> enabling $$app"
+        php /var/www/html/occ app:enable "$$app" || echo "!! failed to enable $$app"
+      done
+
+      # Several apps ship a schema whose slug is not unique across the
+      # instance. OpenRegister resolves a duplicate slug by tie-break and warns,
+      # which means a leaf app can silently read another app's schema. This is a
+      # no-op on a clean install and a repair on one that has drifted.
+      php /var/www/html/occ openregister:schemas:dedup || true
+
+      echo "==> OpenRegister demo: http://localhost:${DEMO_PORT:-8601}/apps/openregister/"

--- a/tests/demo-e2e/README.md
+++ b/tests/demo-e2e/README.md
@@ -1,0 +1,67 @@
+# Demo-environment end-to-end checks
+
+Validates a running demo environment — the one a `<app>-compose.yaml` brings up —
+against the steps its own documentation tells the reader to run.
+
+## Why it lives outside `tests/e2e/`
+
+`playwright.config.ts` at the repository root sets `testDir: './tests/e2e'`, so
+anything placed there runs in CI. This suite needs an **already booted demo** to
+point at, which CI does not have. Put here, CI never collects it, and there is no
+skip to misread later: a suite that silently skips in CI looks identical to one
+that ran and found nothing.
+
+## Running it
+
+Boot a demo first, then point the suite at it:
+
+```bash
+docker compose -f portaliq-compose.yaml up -d
+
+DEMO_APP=portaliq \
+DEMO_BASE_URL=http://localhost:8613 \
+DEMO_HAS_PORTAL=1 \
+npx playwright test --config tests/demo-e2e/playwright.config.ts
+```
+
+| Variable | Meaning |
+| --- | --- |
+| `DEMO_APP` | The app id under test. Default `portaliq`. |
+| `DEMO_BASE_URL` | The booted demo. Default `http://localhost:8613`. |
+| `DEMO_HAS_PORTAL` | Set to `1` when the demo installs `portaliq`; the two portal tests skip otherwise. |
+
+`DEMO_HAS_PORTAL` is an explicit opt-in rather than an auto-detect, and that is
+deliberate. A suite that decides for itself whether a portal *should* exist
+cannot tell "this demo has no portal" from "the portal failed to seed", and
+would report the second as a skip.
+
+## What it asserts, and why none of it is a status code
+
+Nextcloud serves its page shell before an app decides whether it has anything to
+render, so an app URL returns HTTP 200 even when it resolves to nothing at all.
+Two measurements from building this suite make the point:
+
+- **The login page is served with HTTP 200.** Basic auth authenticates
+  OpenRegister's API routes but not a browser *navigation* — Nextcloud redirects
+  that to `/login`, which answers 200. A test asserting only on the status code
+  passes while sitting on the login screen. That is why the page test logs in
+  properly and then asserts on content and on the resulting URL.
+- **An unauthenticated app URL answers 401 on a perfectly healthy demo.** The
+  demo documentation used to describe exactly that request as a pass.
+
+So the assertions are: `status.php` reports `installed:true` (an uninstalled
+instance also answers 200); OpenRegister returns a non-empty register list (an
+empty one means the configuration was never imported, which from outside is
+indistinguishable from "nothing configured yet"); the app page renders its own
+content; and, where a portal is installed, the portal API names a real site
+rather than answering `{"error":"not_found"}` with a 200.
+
+## It has been shown to fail
+
+A suite that has only ever passed is not evidence. Both controls were run:
+
+- pointed at an app that is not installed → the two app-reachability tests fail
+- portal assertions forced on against a demo with no portal → both portal tests fail
+
+Verified green against two independently booted demos: `portaliq` (6 passed) and
+`shillinq` (4 passed, 2 correctly skipped).

--- a/tests/demo-e2e/demo-journey.spec.ts
+++ b/tests/demo-e2e/demo-journey.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, request as pwRequest } from "@playwright/test";
+import { test, expect, request as pwRequest } from '@playwright/test'
 
 /**
  * The demo environment, checked the way its documentation says to check it.
@@ -9,139 +9,137 @@ import { test, expect, request as pwRequest } from "@playwright/test";
  * is exactly why none of these assert on a status code alone.
  */
 
-const APP = process.env.DEMO_APP || "portaliq";
-const BASE = process.env.DEMO_BASE_URL || "http://localhost:8613";
-const HAS_PORTAL = process.env.DEMO_HAS_PORTAL === "1";
+const APP = process.env.DEMO_APP || 'portaliq'
+const BASE = process.env.DEMO_BASE_URL || 'http://localhost:8613'
+const HAS_PORTAL = process.env.DEMO_HAS_PORTAL === '1'
 // `send: 'always'` is load-bearing. By default Playwright withholds Basic
 // credentials until it sees a 401 challenge, and Nextcloud answers an app page
 // with a bare 401 carrying no WWW-Authenticate header -- so the retry never
 // fires and every authenticated assertion fails against a healthy demo.
-const CREDS = { username: "admin", password: "admin", send: "always" as const };
+const CREDS = { username: 'admin', password: 'admin', send: 'always' as const }
 
 test.describe(`demo environment: ${APP}`, () => {
-  test("Nextcloud reports itself installed, not merely reachable", async () => {
-    const api = await pwRequest.newContext({ baseURL: BASE });
-    const res = await api.get("/status.php");
-    expect(res.status()).toBe(200);
+	test('Nextcloud reports itself installed, not merely reachable', async () => {
+		const api = await pwRequest.newContext({ baseURL: BASE })
+		const res = await api.get('/status.php')
+		expect(res.status()).toBe(200)
 
-    const body = await res.json();
-    // `installed:false` also returns 200. The flag is the assertion, not the code.
-    expect(body.installed).toBe(true);
-    expect(body.maintenance).toBe(false);
-    expect(body.needsDbUpgrade).toBe(false);
-    await api.dispose();
-  });
+		const body = await res.json()
+		// `installed:false` also returns 200. The flag is the assertion, not the code.
+		expect(body.installed).toBe(true)
+		expect(body.maintenance).toBe(false)
+		expect(body.needsDbUpgrade).toBe(false)
+		await api.dispose()
+	})
 
-  test("OpenRegister has registers, so the app has something to attach to", async () => {
-    const api = await pwRequest.newContext({
-      baseURL: BASE,
-      httpCredentials: CREDS,
-    });
-    const res = await api.get("/apps/openregister/api/registers");
-    expect(res.status()).toBe(200);
+	test('OpenRegister has registers, so the app has something to attach to', async () => {
+		const api = await pwRequest.newContext({
+			baseURL: BASE,
+			httpCredentials: CREDS,
+		})
+		const res = await api.get('/apps/openregister/api/registers')
+		expect(res.status()).toBe(200)
 
-    const body = await res.json();
-    const rows = body.results ?? body;
-    expect(Array.isArray(rows)).toBe(true);
+		const body = await res.json()
+		const rows = body.results ?? body
+		expect(Array.isArray(rows)).toBe(true)
 
-    // An empty list here is the failure this whole demo exists to catch: it
-    // means the register configuration was never imported, which from outside
-    // is indistinguishable from "nothing configured yet".
-    expect(rows.length).toBeGreaterThan(0);
+		// An empty list here is the failure this whole demo exists to catch: it
+		// means the register configuration was never imported, which from outside
+		// is indistinguishable from "nothing configured yet".
+		expect(rows.length).toBeGreaterThan(0)
 
-    // A register with no slug is a row that exists but resolves to nothing.
-    for (const r of rows.slice(0, 5)) {
-      expect(r.slug ?? r.title).toBeTruthy();
-    }
-    await api.dispose();
-  });
+		// A register with no slug is a row that exists but resolves to nothing.
+		for (const r of rows.slice(0, 5)) {
+			expect(r.slug ?? r.title).toBeTruthy()
+		}
+		await api.dispose()
+	})
 
-  test("the app page renders its own UI, not just a Nextcloud shell", async ({
-    browser,
-  }) => {
-    // Basic auth is NOT enough for a page navigation. Nextcloud accepts it on
-    // API routes but redirects a browser navigation to /login -- and serves
-    // that login page with HTTP 200. A test asserting only on the status code
-    // would pass while sitting on the login screen. Measured here, which is
-    // why this logs in properly and then asserts on content.
-    const ctx = await browser.newContext();
-    const page = await ctx.newPage();
+	test('the app page renders its own UI, not just a Nextcloud shell', async ({
+		browser,
+	}) => {
+		// Basic auth is NOT enough for a page navigation. Nextcloud accepts it on
+		// API routes but redirects a browser navigation to /login -- and serves
+		// that login page with HTTP 200. A test asserting only on the status code
+		// would pass while sitting on the login screen. Measured here, which is
+		// why this logs in properly and then asserts on content.
+		const ctx = await browser.newContext()
+		const page = await ctx.newPage()
 
-    await page.goto(`${BASE}/login`);
-    await page
-      .getByRole("textbox", { name: /account name or email/i })
-      .fill(CREDS.username);
-    await page
-      .getByRole("textbox", { name: /^password$/i })
-      .fill(CREDS.password);
-    // `exact` matters: "Log in with a device" also matches a loose /log in/.
-    await page.getByRole("button", { name: "Log in", exact: true }).click();
-    await page.waitForURL((u) => !u.pathname.startsWith("/login"), {
-      timeout: 30_000,
-    });
+		await page.goto(`${BASE}/login`)
+		await page
+			.getByRole('textbox', { name: /account name or email/i })
+			.fill(CREDS.username)
+		await page.getByRole('textbox', { name: /^password$/i }).fill(CREDS.password)
+		// `exact` matters: "Log in with a device" also matches a loose /log in/.
+		await page.getByRole('button', { name: 'Log in', exact: true }).click()
+		await page.waitForURL((u) => !u.pathname.startsWith('/login'), {
+			timeout: 30_000,
+		})
 
-    const entry =
-      APP === "thematiq" ? "/settings/admin/theming" : `/apps/${APP}/`;
-    const res = await page.goto(`${BASE}${entry}`);
-    expect(res?.status()).toBe(200);
+		const entry =
+			APP === 'thematiq' ? '/settings/admin/theming' : `/apps/${APP}/`
+		const res = await page.goto(`${BASE}${entry}`)
+		expect(res?.status()).toBe(200)
 
-    // The login page is also 200, so prove we are not on it.
-    expect(page.url()).not.toContain("/login");
+		// The login page is also 200, so prove we are not on it.
+		expect(page.url()).not.toContain('/login')
 
-    // The shell alone would satisfy a status check. Require app content.
-    await expect(
-      page.locator("#content, #app-content, .app-content").first(),
-    ).toBeVisible({ timeout: 30_000 });
+		// The shell alone would satisfy a status check. Require app content.
+		await expect(
+			page.locator('#content, #app-content, .app-content').first(),
+		).toBeVisible({ timeout: 30_000 })
 
-    const text = (await page.locator("body").innerText()).trim();
-    expect(text.length).toBeGreaterThan(50);
-    // A Nextcloud error page also returns 200 in some configurations.
-    expect(text).not.toMatch(
-      /Internal Server Error|not installed|Page not found/i,
-    );
-    await ctx.close();
-  });
+		const text = (await page.locator('body').innerText()).trim()
+		expect(text.length).toBeGreaterThan(50)
+		// A Nextcloud error page also returns 200 in some configurations.
+		expect(text).not.toMatch(
+			/Internal Server Error|not installed|Page not found/i,
+		)
+		await ctx.close()
+	})
 
-  test("the app is enabled and reachable under its own id", async () => {
-    const api = await pwRequest.newContext({
-      baseURL: BASE,
-      httpCredentials: CREDS,
-    });
-    const entry =
-      APP === "thematiq" ? "/settings/admin/theming" : `/apps/${APP}/`;
-    const res = await api.get(entry, { maxRedirects: 5 });
+	test('the app is enabled and reachable under its own id', async () => {
+		const api = await pwRequest.newContext({
+			baseURL: BASE,
+			httpCredentials: CREDS,
+		})
+		const entry =
+			APP === 'thematiq' ? '/settings/admin/theming' : `/apps/${APP}/`
+		const res = await api.get(entry, { maxRedirects: 5 })
 
-    // Unauthenticated this is 401 on a perfectly healthy demo -- the defect
-    // the documentation used to describe as a pass.
-    expect(res.status()).toBe(200);
-    await api.dispose();
-  });
+		// Unauthenticated this is 401 on a perfectly healthy demo -- the defect
+		// the documentation used to describe as a pass.
+		expect(res.status()).toBe(200)
+		await api.dispose()
+	})
 
-  test("the public portal resolves to a real site", async () => {
-    test.skip(!HAS_PORTAL, "this demo does not install portaliq");
+	test('the public portal resolves to a real site', async () => {
+		test.skip(!HAS_PORTAL, 'this demo does not install portaliq')
 
-    const api = await pwRequest.newContext({ baseURL: BASE });
-    const res = await api.get("/apps/portaliq/api/content/site?portal=demo");
-    expect(res.status()).toBe(200);
+		const api = await pwRequest.newContext({ baseURL: BASE })
+		const res = await api.get('/apps/portaliq/api/content/site?portal=demo')
+		expect(res.status()).toBe(200)
 
-    const body = await res.json();
-    // Portaliq answers {"error":"not_found"} with a 200 when the slug resolves
-    // to nothing, so the body is the assertion.
-    expect(body.error).toBeUndefined();
-    expect(body.slug).toBe("demo");
-    expect(body.title).toBeTruthy();
-    await api.dispose();
-  });
+		const body = await res.json()
+		// Portaliq answers {"error":"not_found"} with a 200 when the slug resolves
+		// to nothing, so the body is the assertion.
+		expect(body.error).toBeUndefined()
+		expect(body.slug).toBe('demo')
+		expect(body.title).toBeTruthy()
+		await api.dispose()
+	})
 
-  test("the portal page is served without a login", async ({ page }) => {
-    test.skip(!HAS_PORTAL, "this demo does not install portaliq");
+	test('the portal page is served without a login', async ({ page }) => {
+		test.skip(!HAS_PORTAL, 'this demo does not install portaliq')
 
-    const res = await page.goto(`${BASE}/apps/portaliq/site?portal=demo`);
-    expect(res?.status()).toBe(200);
+		const res = await page.goto(`${BASE}/apps/portaliq/site?portal=demo`)
+		expect(res?.status()).toBe(200)
 
-    const text = (await page.locator("body").innerText()).trim();
-    expect(text.length).toBeGreaterThan(50);
-    // Reaching the login form means the portal did not resolve as public.
-    expect(text).not.toMatch(/Log in|Wachtwoord vergeten/i);
-  });
-});
+		const text = (await page.locator('body').innerText()).trim()
+		expect(text.length).toBeGreaterThan(50)
+		// Reaching the login form means the portal did not resolve as public.
+		expect(text).not.toMatch(/Log in|Wachtwoord vergeten/i)
+	})
+})

--- a/tests/demo-e2e/demo-journey.spec.ts
+++ b/tests/demo-e2e/demo-journey.spec.ts
@@ -1,0 +1,128 @@
+import {test, expect, request as pwRequest} from '@playwright/test';
+
+/**
+ * The demo environment, checked the way its documentation says to check it.
+ *
+ * The point of these assertions is that they can fail. Nextcloud serves its
+ * page shell before an app decides whether it has anything to render, so an
+ * app URL returns HTTP 200 even when it resolves to nothing at all -- which
+ * is exactly why none of these assert on a status code alone.
+ */
+
+const APP = process.env.DEMO_APP || 'portaliq';
+const BASE = process.env.DEMO_BASE_URL || 'http://localhost:8613';
+const HAS_PORTAL = process.env.DEMO_HAS_PORTAL === '1';
+// `send: 'always'` is load-bearing. By default Playwright withholds Basic
+// credentials until it sees a 401 challenge, and Nextcloud answers an app page
+// with a bare 401 carrying no WWW-Authenticate header -- so the retry never
+// fires and every authenticated assertion fails against a healthy demo.
+const CREDS = {username: 'admin', password: 'admin', send: 'always' as const};
+
+test.describe(`demo environment: ${APP}`, () => {
+  test('Nextcloud reports itself installed, not merely reachable', async () => {
+    const api = await pwRequest.newContext({baseURL: BASE});
+    const res = await api.get('/status.php');
+    expect(res.status()).toBe(200);
+
+    const body = await res.json();
+    // `installed:false` also returns 200. The flag is the assertion, not the code.
+    expect(body.installed).toBe(true);
+    expect(body.maintenance).toBe(false);
+    expect(body.needsDbUpgrade).toBe(false);
+    await api.dispose();
+  });
+
+  test('OpenRegister has registers, so the app has something to attach to', async () => {
+    const api = await pwRequest.newContext({baseURL: BASE, httpCredentials: CREDS});
+    const res = await api.get('/apps/openregister/api/registers');
+    expect(res.status()).toBe(200);
+
+    const body = await res.json();
+    const rows = body.results ?? body;
+    expect(Array.isArray(rows)).toBe(true);
+
+    // An empty list here is the failure this whole demo exists to catch: it
+    // means the register configuration was never imported, which from outside
+    // is indistinguishable from "nothing configured yet".
+    expect(rows.length).toBeGreaterThan(0);
+
+    // A register with no slug is a row that exists but resolves to nothing.
+    for (const r of rows.slice(0, 5)) {
+      expect(r.slug ?? r.title).toBeTruthy();
+    }
+    await api.dispose();
+  });
+
+  test('the app page renders its own UI, not just a Nextcloud shell', async ({browser}) => {
+    // Basic auth is NOT enough for a page navigation. Nextcloud accepts it on
+    // API routes but redirects a browser navigation to /login -- and serves
+    // that login page with HTTP 200. A test asserting only on the status code
+    // would pass while sitting on the login screen. Measured here, which is
+    // why this logs in properly and then asserts on content.
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+
+    await page.goto(`${BASE}/login`);
+    await page.getByRole('textbox', {name: /account name or email/i}).fill(CREDS.username);
+    await page.getByRole('textbox', {name: /^password$/i}).fill(CREDS.password);
+    // `exact` matters: "Log in with a device" also matches a loose /log in/.
+    await page.getByRole('button', {name: 'Log in', exact: true}).click();
+    await page.waitForURL((u) => !u.pathname.startsWith('/login'), {timeout: 30_000});
+
+    const entry = APP === 'thematiq' ? '/settings/admin/theming' : `/apps/${APP}/`;
+    const res = await page.goto(`${BASE}${entry}`);
+    expect(res?.status()).toBe(200);
+
+    // The login page is also 200, so prove we are not on it.
+    expect(page.url()).not.toContain('/login');
+
+    // The shell alone would satisfy a status check. Require app content.
+    await expect(page.locator('#content, #app-content, .app-content').first())
+      .toBeVisible({timeout: 30_000});
+
+    const text = (await page.locator('body').innerText()).trim();
+    expect(text.length).toBeGreaterThan(50);
+    // A Nextcloud error page also returns 200 in some configurations.
+    expect(text).not.toMatch(/Internal Server Error|not installed|Page not found/i);
+    await ctx.close();
+  });
+
+  test('the app is enabled and reachable under its own id', async () => {
+    const api = await pwRequest.newContext({baseURL: BASE, httpCredentials: CREDS});
+    const entry = APP === 'thematiq' ? '/settings/admin/theming' : `/apps/${APP}/`;
+    const res = await api.get(entry, {maxRedirects: 5});
+
+    // Unauthenticated this is 401 on a perfectly healthy demo -- the defect
+    // the documentation used to describe as a pass.
+    expect(res.status()).toBe(200);
+    await api.dispose();
+  });
+
+  test('the public portal resolves to a real site', async () => {
+    test.skip(!HAS_PORTAL, 'this demo does not install portaliq');
+
+    const api = await pwRequest.newContext({baseURL: BASE});
+    const res = await api.get('/apps/portaliq/api/content/site?portal=demo');
+    expect(res.status()).toBe(200);
+
+    const body = await res.json();
+    // Portaliq answers {"error":"not_found"} with a 200 when the slug resolves
+    // to nothing, so the body is the assertion.
+    expect(body.error).toBeUndefined();
+    expect(body.slug).toBe('demo');
+    expect(body.title).toBeTruthy();
+    await api.dispose();
+  });
+
+  test('the portal page is served without a login', async ({page}) => {
+    test.skip(!HAS_PORTAL, 'this demo does not install portaliq');
+
+    const res = await page.goto(`${BASE}/apps/portaliq/site?portal=demo`);
+    expect(res?.status()).toBe(200);
+
+    const text = (await page.locator('body').innerText()).trim();
+    expect(text.length).toBeGreaterThan(50);
+    // Reaching the login form means the portal did not resolve as public.
+    expect(text).not.toMatch(/Log in|Wachtwoord vergeten/i);
+  });
+});

--- a/tests/demo-e2e/demo-journey.spec.ts
+++ b/tests/demo-e2e/demo-journey.spec.ts
@@ -1,4 +1,4 @@
-import {test, expect, request as pwRequest} from '@playwright/test';
+import { test, expect, request as pwRequest } from "@playwright/test";
 
 /**
  * The demo environment, checked the way its documentation says to check it.
@@ -9,19 +9,19 @@ import {test, expect, request as pwRequest} from '@playwright/test';
  * is exactly why none of these assert on a status code alone.
  */
 
-const APP = process.env.DEMO_APP || 'portaliq';
-const BASE = process.env.DEMO_BASE_URL || 'http://localhost:8613';
-const HAS_PORTAL = process.env.DEMO_HAS_PORTAL === '1';
+const APP = process.env.DEMO_APP || "portaliq";
+const BASE = process.env.DEMO_BASE_URL || "http://localhost:8613";
+const HAS_PORTAL = process.env.DEMO_HAS_PORTAL === "1";
 // `send: 'always'` is load-bearing. By default Playwright withholds Basic
 // credentials until it sees a 401 challenge, and Nextcloud answers an app page
 // with a bare 401 carrying no WWW-Authenticate header -- so the retry never
 // fires and every authenticated assertion fails against a healthy demo.
-const CREDS = {username: 'admin', password: 'admin', send: 'always' as const};
+const CREDS = { username: "admin", password: "admin", send: "always" as const };
 
 test.describe(`demo environment: ${APP}`, () => {
-  test('Nextcloud reports itself installed, not merely reachable', async () => {
-    const api = await pwRequest.newContext({baseURL: BASE});
-    const res = await api.get('/status.php');
+  test("Nextcloud reports itself installed, not merely reachable", async () => {
+    const api = await pwRequest.newContext({ baseURL: BASE });
+    const res = await api.get("/status.php");
     expect(res.status()).toBe(200);
 
     const body = await res.json();
@@ -32,9 +32,12 @@ test.describe(`demo environment: ${APP}`, () => {
     await api.dispose();
   });
 
-  test('OpenRegister has registers, so the app has something to attach to', async () => {
-    const api = await pwRequest.newContext({baseURL: BASE, httpCredentials: CREDS});
-    const res = await api.get('/apps/openregister/api/registers');
+  test("OpenRegister has registers, so the app has something to attach to", async () => {
+    const api = await pwRequest.newContext({
+      baseURL: BASE,
+      httpCredentials: CREDS,
+    });
+    const res = await api.get("/apps/openregister/api/registers");
     expect(res.status()).toBe(200);
 
     const body = await res.json();
@@ -53,7 +56,9 @@ test.describe(`demo environment: ${APP}`, () => {
     await api.dispose();
   });
 
-  test('the app page renders its own UI, not just a Nextcloud shell', async ({browser}) => {
+  test("the app page renders its own UI, not just a Nextcloud shell", async ({
+    browser,
+  }) => {
     // Basic auth is NOT enough for a page navigation. Nextcloud accepts it on
     // API routes but redirects a browser navigation to /login -- and serves
     // that login page with HTTP 200. A test asserting only on the status code
@@ -63,34 +68,48 @@ test.describe(`demo environment: ${APP}`, () => {
     const page = await ctx.newPage();
 
     await page.goto(`${BASE}/login`);
-    await page.getByRole('textbox', {name: /account name or email/i}).fill(CREDS.username);
-    await page.getByRole('textbox', {name: /^password$/i}).fill(CREDS.password);
+    await page
+      .getByRole("textbox", { name: /account name or email/i })
+      .fill(CREDS.username);
+    await page
+      .getByRole("textbox", { name: /^password$/i })
+      .fill(CREDS.password);
     // `exact` matters: "Log in with a device" also matches a loose /log in/.
-    await page.getByRole('button', {name: 'Log in', exact: true}).click();
-    await page.waitForURL((u) => !u.pathname.startsWith('/login'), {timeout: 30_000});
+    await page.getByRole("button", { name: "Log in", exact: true }).click();
+    await page.waitForURL((u) => !u.pathname.startsWith("/login"), {
+      timeout: 30_000,
+    });
 
-    const entry = APP === 'thematiq' ? '/settings/admin/theming' : `/apps/${APP}/`;
+    const entry =
+      APP === "thematiq" ? "/settings/admin/theming" : `/apps/${APP}/`;
     const res = await page.goto(`${BASE}${entry}`);
     expect(res?.status()).toBe(200);
 
     // The login page is also 200, so prove we are not on it.
-    expect(page.url()).not.toContain('/login');
+    expect(page.url()).not.toContain("/login");
 
     // The shell alone would satisfy a status check. Require app content.
-    await expect(page.locator('#content, #app-content, .app-content').first())
-      .toBeVisible({timeout: 30_000});
+    await expect(
+      page.locator("#content, #app-content, .app-content").first(),
+    ).toBeVisible({ timeout: 30_000 });
 
-    const text = (await page.locator('body').innerText()).trim();
+    const text = (await page.locator("body").innerText()).trim();
     expect(text.length).toBeGreaterThan(50);
     // A Nextcloud error page also returns 200 in some configurations.
-    expect(text).not.toMatch(/Internal Server Error|not installed|Page not found/i);
+    expect(text).not.toMatch(
+      /Internal Server Error|not installed|Page not found/i,
+    );
     await ctx.close();
   });
 
-  test('the app is enabled and reachable under its own id', async () => {
-    const api = await pwRequest.newContext({baseURL: BASE, httpCredentials: CREDS});
-    const entry = APP === 'thematiq' ? '/settings/admin/theming' : `/apps/${APP}/`;
-    const res = await api.get(entry, {maxRedirects: 5});
+  test("the app is enabled and reachable under its own id", async () => {
+    const api = await pwRequest.newContext({
+      baseURL: BASE,
+      httpCredentials: CREDS,
+    });
+    const entry =
+      APP === "thematiq" ? "/settings/admin/theming" : `/apps/${APP}/`;
+    const res = await api.get(entry, { maxRedirects: 5 });
 
     // Unauthenticated this is 401 on a perfectly healthy demo -- the defect
     // the documentation used to describe as a pass.
@@ -98,29 +117,29 @@ test.describe(`demo environment: ${APP}`, () => {
     await api.dispose();
   });
 
-  test('the public portal resolves to a real site', async () => {
-    test.skip(!HAS_PORTAL, 'this demo does not install portaliq');
+  test("the public portal resolves to a real site", async () => {
+    test.skip(!HAS_PORTAL, "this demo does not install portaliq");
 
-    const api = await pwRequest.newContext({baseURL: BASE});
-    const res = await api.get('/apps/portaliq/api/content/site?portal=demo');
+    const api = await pwRequest.newContext({ baseURL: BASE });
+    const res = await api.get("/apps/portaliq/api/content/site?portal=demo");
     expect(res.status()).toBe(200);
 
     const body = await res.json();
     // Portaliq answers {"error":"not_found"} with a 200 when the slug resolves
     // to nothing, so the body is the assertion.
     expect(body.error).toBeUndefined();
-    expect(body.slug).toBe('demo');
+    expect(body.slug).toBe("demo");
     expect(body.title).toBeTruthy();
     await api.dispose();
   });
 
-  test('the portal page is served without a login', async ({page}) => {
-    test.skip(!HAS_PORTAL, 'this demo does not install portaliq');
+  test("the portal page is served without a login", async ({ page }) => {
+    test.skip(!HAS_PORTAL, "this demo does not install portaliq");
 
     const res = await page.goto(`${BASE}/apps/portaliq/site?portal=demo`);
     expect(res?.status()).toBe(200);
 
-    const text = (await page.locator('body').innerText()).trim();
+    const text = (await page.locator("body").innerText()).trim();
     expect(text.length).toBeGreaterThan(50);
     // Reaching the login form means the portal did not resolve as public.
     expect(text).not.toMatch(/Log in|Wachtwoord vergeten/i);

--- a/tests/demo-e2e/playwright.config.ts
+++ b/tests/demo-e2e/playwright.config.ts
@@ -1,4 +1,4 @@
-import {defineConfig} from '@playwright/test';
+import { defineConfig } from "@playwright/test";
 
 /**
  * Validates a generated per-app demo environment against the steps its own
@@ -9,12 +9,12 @@ import {defineConfig} from '@playwright/test';
  * works; this one has to prove the documented instructions work.
  */
 export default defineConfig({
-  testDir: '.',
+  testDir: ".",
   timeout: 60_000,
-  expect: {timeout: 15_000},
-  reporter: [['list']],
+  expect: { timeout: 15_000 },
+  reporter: [["list"]],
   use: {
-    baseURL: process.env.DEMO_BASE_URL || 'http://localhost:8613',
+    baseURL: process.env.DEMO_BASE_URL || "http://localhost:8613",
     ignoreHTTPSErrors: true,
   },
 });

--- a/tests/demo-e2e/playwright.config.ts
+++ b/tests/demo-e2e/playwright.config.ts
@@ -1,0 +1,20 @@
+import {defineConfig} from '@playwright/test';
+
+/**
+ * Validates a generated per-app demo environment against the steps its own
+ * documentation tells the reader to run.
+ *
+ * It is pointed at an ALREADY BOOTED demo via DEMO_BASE_URL rather than
+ * starting one itself. A spec that boots its own fixture proves the fixture
+ * works; this one has to prove the documented instructions work.
+ */
+export default defineConfig({
+  testDir: '.',
+  timeout: 60_000,
+  expect: {timeout: 15_000},
+  reporter: [['list']],
+  use: {
+    baseURL: process.env.DEMO_BASE_URL || 'http://localhost:8613',
+    ignoreHTTPSErrors: true,
+  },
+});

--- a/tests/demo-e2e/playwright.config.ts
+++ b/tests/demo-e2e/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "@playwright/test";
+import { defineConfig } from '@playwright/test'
 
 /**
  * Validates a generated per-app demo environment against the steps its own
@@ -9,12 +9,12 @@ import { defineConfig } from "@playwright/test";
  * works; this one has to prove the documented instructions work.
  */
 export default defineConfig({
-  testDir: ".",
-  timeout: 60_000,
-  expect: { timeout: 15_000 },
-  reporter: [["list"]],
-  use: {
-    baseURL: process.env.DEMO_BASE_URL || "http://localhost:8613",
-    ignoreHTTPSErrors: true,
-  },
-});
+	testDir: '.',
+	timeout: 60_000,
+	expect: { timeout: 15_000 },
+	reporter: [['list']],
+	use: {
+		baseURL: process.env.DEMO_BASE_URL || 'http://localhost:8613',
+		ignoreHTTPSErrors: true,
+	},
+})


### PR DESCRIPTION
Adds a self-contained demo environment: `openregister-compose.yaml` at the repository root and `docs/Installation/demo-environment.md` describing it.

## What it does

Postgres + Nextcloud, with `openregister` (required), `thematiq` and `integriq` (optional) and `openregister` installed from release tarballs and enabled **in dependency order**. Versions float to the newest release, pre-releases included, and each is pinnable.

## Two deliberate choices

**Nothing is bind-mounted.** Nextcloud installs and updates an app by deleting its directory and extracting a fresh archive over it. Point that at a checkout and an app-store update deletes the working tree — measured on a development machine on 2026-08-27, where `\OC\Updater::upgradeAppStoreApp` fired on a container restart and removed every top-level file from a bind-mounted checkout, `.git` included.

**Release tarballs, not `git clone`.** A tarball is a complete app carrying `vendor/` and the built `js/`. A clone carries neither, and an app with no `vendor/` does not fail loudly: it warns once and keeps loading, so it looks installed while every service needing a dependency is quietly absent.

## Note on the dependency

The `openregister` dependency is **not declared** in `appinfo/info.xml` — no app in the fleet declares an `<app>` dependency — so nothing stops the App Store installing this app without it. It would then load and find no register to attach to. The compose encodes the dependency the manifest does not.

## Verification

`docker compose config` parses and interpolates this file. The same generated file was booted end to end for portaliq: 4 apps installed and enabled, **17 registers, 86 schemas, 13 magic tables** for its own register, and the portal content API returned a real site rather than an empty shell — a content check, since the page returns HTTP 200 either way.