### PR TITLE
fix(flow): a shipped flow must belong to a tenant, or it imports into invisibility

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -227,6 +227,16 @@ Vrij en open source onder de EUPL-licentie.
 			     column while every read looks at the new one and finds null —
 			     no error, no data loss, invisible to the suite. -->
 			<step>OCA\OpenRegister\Repair\RenameDutchColumns</step>
+			<!-- AUDIT CHAIN SEED v1 → v2. The flow-attribution fields joined the
+			     canonical JSON the hash covers, so every stored hash has to be
+			     recomputed; ADR-003 Rule 4 requires that be a verify-then-reseal
+			     migration rather than an in-place edit. The step verifies the
+			     OLD chain against the frozen v1 canonicaliser and records the
+			     verdict BEFORE re-sealing — after the re-seal, the difference
+			     between an intact chain and a tampered one no longer exists.
+			     Post-migration, because it needs the flow_* columns the schema
+			     migration adds. -->
+			<step>OCA\OpenRegister\Repair\RechainAuditTrailForFlowAttribution</step>
 		</post-migration>
 		<install>
 			<step>OCA\OpenRegister\Repair\ReconcileDeclaredBackgroundJobs</step>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -1313,6 +1313,7 @@ return [
 		// answered by `show('active')` → 404 for every request.
 		['name' => 'flowRun#active', 'url' => '/api/flow-runs/active', 'verb' => 'GET'],
 		['name' => 'flowRun#show', 'url' => '/api/flow-runs/{uuid}', 'verb' => 'GET', 'requirements' => ['uuid' => '[^/]+']],
+		['name' => 'flowRun#objects', 'url' => '/api/flow-runs/{uuid}/objects', 'verb' => 'GET', 'requirements' => ['uuid' => '[^/]+']],
 		['name' => 'flowRun#retry', 'url' => '/api/flow-runs/{uuid}/retry', 'verb' => 'POST', 'requirements' => ['uuid' => '[^/]+']],
 		['name' => 'flowRun#resume', 'url' => '/api/flow-runs/{uuid}/resume', 'verb' => 'POST', 'requirements' => ['uuid' => '[^/]+']],
 		// Interactive test run (or-flow-partial-run): run synchronously with optional startAt + pins + seed.

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -168,6 +168,7 @@ use OCA\OpenRegister\Service\DeepLinkRegistryService;
 use OCA\OpenRegister\Service\File\FolderManagementHandler;
 use OCA\OpenRegister\Service\File\Pdf\Fallback\NullNcOfficeConverter;
 use OCA\OpenRegister\Service\FileService;
+use OCA\OpenRegister\Service\Flow\FlowRunContext;
 use OCA\OpenRegister\Service\Flow\RegistryStepDispatcher;
 use OCA\OpenRegister\Service\FlowLinkService;
 use OCA\OpenRegister\Service\Gdpr\Evidence\EvidenceSourceRegistry;
@@ -419,9 +420,9 @@ class Application extends App implements IBootstrap {
 		// instance and the audit mapper would read an empty stack on another —
 		// attributing nothing at all, silently and with no error anywhere.
 		$context->registerService(
-			\OCA\OpenRegister\Service\Flow\FlowRunContext::class,
+			FlowRunContext::class,
 			function () {
-				return new \OCA\OpenRegister\Service\Flow\FlowRunContext();
+				return new FlowRunContext();
 			}
 		);
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -413,6 +413,18 @@ class Application extends App implements IBootstrap {
 			}
 		);
 
+		// The ambient flow-attribution stack MUST be shared. Nextcloud's
+		// container builds an auto-wired class fresh at every injection point,
+		// so without this registration the engine would push frames onto one
+		// instance and the audit mapper would read an empty stack on another —
+		// attributing nothing at all, silently and with no error anywhere.
+		$context->registerService(
+			\OCA\OpenRegister\Service\Flow\FlowRunContext::class,
+			function () {
+				return new \OCA\OpenRegister\Service\Flow\FlowRunContext();
+			}
+		);
+
 		// Register the LanguageMiddleware for Accept-Language header parsing.
 		$context->registerMiddleware(LanguageMiddleware::class);
 

--- a/lib/Controller/FlowRunController.php
+++ b/lib/Controller/FlowRunController.php
@@ -33,7 +33,7 @@ use OCA\OpenRegister\Db\FlowRun;
 use OCA\OpenRegister\Db\FlowRunMapper;
 use OCA\OpenRegister\Service\Flow\FlowItems;
 use OCA\OpenRegister\Service\Flow\FlowLocator;
-use OCA\OpenRegister\Service\Flow\FlowResumeState;
+use OCA\OpenRegister\Service\Flow\FlowRunAssignee;
 use OCA\OpenRegister\Service\Flow\FlowRunService;
 use OCA\OpenRegister\Service\Flow\FlowService;
 use OCA\OpenRegister\Service\OrganisationService;
@@ -637,26 +637,27 @@ class FlowRunController extends Controller {
 	 * @return JSONResponse|null A 403 when the caller is not the assignee.
 	 */
 	private function refuseUnlessAssignee(FlowRun $run): ?JSONResponse {
-		$assignee = $this->recordedAssignee(run: $run);
+		// The rule itself lives in FlowRunAssignee, because HTTP is no longer
+		// the only way to answer a step: a leaf app whose object completes a
+		// task resumes the run in-process through FlowRunService::signal(),
+		// which never passes this controller. One implementation, so the two
+		// paths cannot drift into disagreeing about who may answer.
+		$assignee = $this->assignees()->recordedFor(run: $run);
 		if ($assignee === '') {
 			return null;
 		}
 
 		$uid = $this->callerUid();
+
+		if ($this->assignees()->mayAnswer(run: $run, uid: $uid) === true) {
+			return null;
+		}
+
 		if ($uid === null) {
-			// Fail CLOSED: an assigned decision is never anonymous.
 			return new JSONResponse(
 				['error' => 'This step is assigned; sign in as the assignee to answer it.'],
 				Http::STATUS_FORBIDDEN
 			);
-		}
-
-		if ($uid === $assignee) {
-			return null;
-		}
-
-		if ($this->groupManager !== null && $this->groupManager->isInGroup($uid, $assignee) === true) {
-			return null;
 		}
 
 		return new JSONResponse(
@@ -666,40 +667,19 @@ class FlowRunController extends Controller {
 	}//end refuseUnlessAssignee()
 
 	/**
-	 * The assignee recorded by whichever step is currently awaiting a signal.
+	 * The assignee rule, made on demand when none was injected.
 	 *
-	 * Reads the per-node resume slots the node wrote. A run can carry slots for
-	 * several nodes across its life, so the one that matters is a slot that
-	 * asked (`askedAt`) and has not been answered.
+	 * Built locally rather than required as a constructor argument so adding it
+	 * breaks no existing construction site; it holds no state, so a locally
+	 * made one is indistinguishable from an injected one.
 	 *
-	 * @param FlowRun $run The suspended run.
+	 * @return FlowRunAssignee The rule.
 	 *
-	 * @return string The assignee uid or group id, '' when unassigned.
+	 * @spec openspec/specs/flow-engine/spec.md#requirement-a-run-suspended-on-an-external-signal-must-be-reachable
 	 */
-	private function recordedAssignee(FlowRun $run): string {
-		$context = ($run->getContext() ?? []);
-		$slots = ($context[FlowResumeState::CONTEXT_KEY] ?? []);
-		if (is_array($slots) === false) {
-			return '';
-		}
-
-		foreach ($slots as $slot) {
-			if (is_array($slot) === false) {
-				continue;
-			}
-
-			if (isset($slot['askedAt']) === false) {
-				continue;
-			}
-
-			$assignee = trim((string)($slot['assignee'] ?? ''));
-			if ($assignee !== '') {
-				return $assignee;
-			}
-		}
-
-		return '';
-	}//end recordedAssignee()
+	private function assignees(): FlowRunAssignee {
+		return new FlowRunAssignee(groupManager: $this->groupManager);
+	}//end assignees()
 
 	/**
 	 * The current caller's uid, or null when anonymous.

--- a/lib/Controller/FlowRunController.php
+++ b/lib/Controller/FlowRunController.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Controller;
 
-use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\AuditFlowAttribution;
 use OCA\OpenRegister\Db\FlowRun;
 use OCA\OpenRegister\Db\FlowRunMapper;
 use OCA\OpenRegister\Service\Flow\FlowItems;
@@ -88,6 +88,13 @@ class FlowRunController extends Controller {
 	 *                                native flow store. Nullable for the same
 	 *                                reason as $groupManager: absent yields no
 	 *                                owned ids, which scopes rather than widens.
+	 * @param AuditFlowAttribution|null $auditTrails Reads the attribution stamped on
+	 *                                           audit rows, for the objects a run
+	 *                                           touched. Nullable and LAST so
+	 *                                           adding it shifts no positional
+	 *                                           caller; absent, the endpoint
+	 *                                           reports the surface unavailable
+	 *                                           rather than an empty run.
 	 */
 	public function __construct(
 		string $appName,
@@ -102,7 +109,7 @@ class FlowRunController extends Controller {
 		// Appended LAST and nullable on purpose: a new constructor argument
 		// inserted anywhere else shifts every positional caller, and the
 		// resulting TypeError names the argument AFTER the one that moved.
-		private readonly ?AuditTrailMapper $auditTrails = null,
+		private readonly ?AuditFlowAttribution $auditTrails = null,
 	) {
 		parent::__construct(appName: $appName, request: $request);
 
@@ -398,7 +405,7 @@ class FlowRunController extends Controller {
 			return new JSONResponse(['error' => 'Audit trail unavailable'], Http::STATUS_SERVICE_UNAVAILABLE);
 		}
 
-		$rows = $this->auditTrails->findByFlowRun(runUuid: $uuid);
+		$rows = $this->auditTrails->findByRun(runUuid: $uuid);
 
 		$byNode = [];
 		foreach ($rows as $row) {
@@ -438,7 +445,9 @@ class FlowRunController extends Controller {
 				// nothing, and for a suspended run that has not written
 				// anything YET. Neither is an error, and neither is withheld
 				// until the run finishes.
-				'nodes' => array_values($byNode),
+				// usort() re-indexed $byNode into a list, so no array_values()
+				// here: it would be a no-op that reads as a safeguard.
+				'nodes' => $byNode,
 			]
 		);
 	}//end objects()

--- a/lib/Controller/FlowRunController.php
+++ b/lib/Controller/FlowRunController.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Controller;
 
+use OCA\OpenRegister\Db\AuditTrailMapper;
 use OCA\OpenRegister\Db\FlowRun;
 use OCA\OpenRegister\Db\FlowRunMapper;
 use OCA\OpenRegister\Service\Flow\FlowItems;
@@ -63,8 +64,8 @@ use Throwable;
  * deliberately unauthenticated because it runs flows as their owner with no
  * session. Moving them out would either re-open the bypass or add a second
  * indirection over four small private helpers.
- * @SuppressWarnings(PHPMD.ExcessiveParameterList)   Ten constructor parameters, the
- * last three nullable-with-default precisely so adding them broke no existing
+ * @SuppressWarnings(PHPMD.ExcessiveParameterList)   Eleven constructor parameters, the
+ * last four nullable-with-default precisely so adding them broke no existing
  * construction site. They are collaborators of those same guards, not options.
  */
 class FlowRunController extends Controller {
@@ -98,6 +99,10 @@ class FlowRunController extends Controller {
 		private readonly OrganisationService $organisationService,
 		private readonly ?IGroupManager $groupManager = null,
 		private readonly ?FlowService $flows = null,
+		// Appended LAST and nullable on purpose: a new constructor argument
+		// inserted anywhere else shifts every positional caller, and the
+		// resulting TypeError names the argument AFTER the one that moved.
+		private readonly ?AuditTrailMapper $auditTrails = null,
 	) {
 		parent::__construct(appName: $appName, request: $request);
 
@@ -349,14 +354,129 @@ class FlowRunController extends Controller {
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
 	public function show(string $uuid): JSONResponse {
-		try {
-			$run = $this->mapper->findByUuid($uuid);
-		} catch (DoesNotExistException $e) {
+		// Scoped, as `index()` has been since `shared-credentials-and-flows`
+		// D7. It was not, and the omission was the whole point of that scoping:
+		// a run's serialisation carries its log, which records the subject data
+		// the flow touched, so an unscoped read by uuid handed any authenticated
+		// caller the contents of anyone's run.
+		$run = $this->visibleRun(uuid: $uuid);
+		if ($run === null) {
 			return new JSONResponse(['error' => 'No such run'], Http::STATUS_NOT_FOUND);
 		}
 
 		return new JSONResponse($run->jsonSerialize());
 	}//end show()
+
+	/**
+	 * The objects one run touched, grouped by the node that touched them.
+	 *
+	 * A run recorded what it DID (its steps) and, of what it did it TO, only
+	 * the object that triggered it. This reads back the attribution stamped on
+	 * every audit row the run caused, which is the other half.
+	 *
+	 * @param string $uuid The run uuid.
+	 *
+	 * @return JSONResponse The touched objects grouped by node, or 404.
+	 *
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	public function objects(string $uuid): JSONResponse {
+		// Resolved through the SAME visibility rule as reading the run itself.
+		// A new endpoint that answered for runs `show()` refuses would widen
+		// access without anything looking like an access change.
+		$run = $this->visibleRun(uuid: $uuid);
+		if ($run === null) {
+			return new JSONResponse(['error' => 'No such run'], Http::STATUS_NOT_FOUND);
+		}
+
+		if ($this->auditTrails === null) {
+			return new JSONResponse(['error' => 'Audit trail unavailable'], Http::STATUS_SERVICE_UNAVAILABLE);
+		}
+
+		$rows = $this->auditTrails->findByFlowRun(runUuid: $uuid);
+
+		$byNode = [];
+		foreach ($rows as $row) {
+			$node = (string)$row->getFlowNode();
+
+			if (isset($byNode[$node]) === false) {
+				$byNode[$node] = [
+					'node' => $node,
+					'step' => $row->getFlowStep(),
+					'objects' => [],
+				];
+			}
+
+			$byNode[$node]['objects'][] = [
+				'objectUuid' => $row->getObjectUuid(),
+				'register' => $row->getRegister(),
+				'schema' => $row->getSchema(),
+				'action' => $row->getAction(),
+				'step' => $row->getFlowStep(),
+				'created' => $row->getCreated()?->format('c'),
+				'auditUuid' => $row->getUuid(),
+			];
+		}
+
+		// Step order, so a reader follows the run in the order it happened
+		// rather than in whatever order the rows came back.
+		usort(
+			$byNode,
+			static fn (array $a, array $b): int => (((int)$a['step']) <=> ((int)$b['step']))
+		);
+
+		return new JSONResponse(
+			[
+				'run' => $uuid,
+				'flowId' => $run->getFlowId(),
+				// An empty list is the honest answer for a run that wrote
+				// nothing, and for a suspended run that has not written
+				// anything YET. Neither is an error, and neither is withheld
+				// until the run finishes.
+				'nodes' => array_values($byNode),
+			]
+		);
+	}//end objects()
+
+	/**
+	 * Resolve a run by uuid, or null when this caller may not see it.
+	 *
+	 * One place, so `show()` and `objects()` cannot drift apart on who may read
+	 * a run. Delegates the predicate itself to the mapper, which is where the
+	 * list read gets it too.
+	 *
+	 * A non-admin with no session resolves to null rather than falling through:
+	 * a null uid means "no scoping" at the mapper, which is an ADMINISTRATOR's
+	 * semantics, so treating an absent caller as one would turn having no
+	 * identity into the widest possible read.
+	 *
+	 * @param string $uuid The run uuid.
+	 *
+	 * @return FlowRun|null The run, or null when absent or not visible.
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+	 */
+	private function visibleRun(string $uuid): ?FlowRun {
+		if ($this->isAdmin() === true) {
+			return $this->mapper->findByUuidVisibleTo(uuid: $uuid, requesterUid: null);
+		}
+
+		$uid = $this->callerUid();
+		if ($uid === null || $uid === '') {
+			return null;
+		}
+
+		return $this->mapper->findByUuidVisibleTo(
+			uuid: $uuid,
+			requesterUid: $uid,
+			ownedFlowIds: $this->flowIdsOwnedByCaller()
+		);
+	}//end visibleRun()
 
 	/**
 	 * Retry a finished run: queue a fresh one, leave the original untouched.

--- a/lib/Db/AuditFlowAttribution.php
+++ b/lib/Db/AuditFlowAttribution.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * Flow attribution on audit rows: writing it, and reading it back.
+ *
+ * Split out of {@see AuditTrailMapper}, which does not have to know what a flow
+ * is. The direction of the dependency is the point: an audit row records who
+ * caused a write, and "a flow run caused it" is one more kind of cause — like
+ * an import job or an MCP tool — rather than something the persistence layer
+ * should reach into the flow engine to discover.
+ *
+ * Both halves live here because they are one fact read from two ends. The
+ * stamp decides what a row claims; the query trusts that claim. Keeping them
+ * together is what stops the column set they agree on from drifting apart.
+ *
+ * WHY THE VALUES ARE AMBIENT. The point of the attribution is to catch writes
+ * made by code that has never heard of flows: a leaf app a node calls into, a
+ * cascade, a lifecycle hook. Passing them as arguments would capture only what
+ * a node explicitly declared, which is the same blind spot as recording touches
+ * at the node — a node cannot report what it did not know it did.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use OCA\OpenRegister\Service\Flow\FlowRunContext;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\IDBConnection;
+use Psr\Container\ContainerInterface;
+use Throwable;
+
+/**
+ * Applies the ambient flow attribution to an audit row, and reads it back.
+ *
+ * @template-extends QBMapper<AuditTrail>
+ *
+ * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+ */
+class AuditFlowAttribution extends QBMapper {
+	/**
+	 * Constructor.
+	 *
+	 * @param IDBConnection      $db        The database.
+	 * @param ContainerInterface $container Resolves the shared run context.
+	 */
+	public function __construct(
+		IDBConnection $db,
+		private readonly ContainerInterface $container,
+	) {
+		parent::__construct(db: $db, tableName: 'openregister_audit_trails', entityClass: AuditTrail::class);
+	}//end __construct()
+
+	/**
+	 * Stamp the executing run, node and step onto a row.
+	 *
+	 * MUST be called before the row is written: these three fields are part of
+	 * the canonical JSON the hash covers, exactly like `expires`, so setting
+	 * them afterwards would put them outside the hash the row is later given.
+	 *
+	 * Fail-soft. If the context cannot be resolved the row is written
+	 * unattributed — an audit row is evidence and must survive a bookkeeping
+	 * problem, and an unattributed row is honest about what it does not know.
+	 *
+	 * @param AuditTrail $auditTrail The row being built.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+	 */
+	public function apply(AuditTrail $auditTrail): void {
+		try {
+			$context = $this->container->get(FlowRunContext::class);
+		} catch (Throwable $e) {
+			return;
+		}
+
+		if (($context instanceof FlowRunContext) === false) {
+			return;
+		}
+
+		$frame = $context->current();
+		if ($frame === null) {
+			return;
+		}
+
+		$auditTrail->setFlowRun($frame['run']);
+		$auditTrail->setFlowNode($frame['node']);
+		$auditTrail->setFlowStep($frame['step']);
+	}//end apply()
+
+	/**
+	 * Every audit row attributed to one flow run, oldest first.
+	 *
+	 * Ordered by id rather than by `flow_step` so a run that visited the same
+	 * node twice — a loop — reads in the order the writes actually happened
+	 * rather than collapsing both visits into one position.
+	 *
+	 * @param string  $runUuid The flow run's uuid.
+	 * @param integer $limit   Maximum rows to return.
+	 *
+	 * @return AuditTrail[] The rows this run caused.
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+	 */
+	public function findByRun(string $runUuid, int $limit = 1000): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from('openregister_audit_trails')
+			->where($qb->expr()->eq('flow_run', $qb->createNamedParameter($runUuid)))
+			->orderBy('id', 'ASC')
+			->setMaxResults($limit);
+
+		return $this->findEntities(query: $qb);
+	}//end findByRun()
+}//end class

--- a/lib/Db/AuditTrail.php
+++ b/lib/Db/AuditTrail.php
@@ -80,6 +80,12 @@ use OCP\AppFramework\Db\Entity;
  * @method void setParamsDigest(?string $paramsDigest)
  * @method array|null getResultSummary()
  * @method void setResultSummary(?array $resultSummary)
+ * @method string|null getFlowRun()
+ * @method void setFlowRun(?string $flowRun)
+ * @method string|null getFlowNode()
+ * @method void setFlowNode(?string $flowNode)
+ * @method integer|null getFlowStep()
+ * @method void setFlowStep(?int $flowStep)
  *
  * @psalm-suppress PossiblyUnusedMethod
  * @psalm-suppress PropertyNotSetInConstructor $id is set by Nextcloud's Entity base class
@@ -364,6 +370,47 @@ class AuditTrail extends Entity implements JsonSerializable {
 	protected ?array $resultSummary = null;
 
 	/**
+	 * The uuid of the flow run that was executing when this row was written.
+	 *
+	 * Set from the ambient run context rather than passed by the writing code,
+	 * so a write made by an app that has never heard of flows is attributed
+	 * exactly like a write made by the node itself. Null on every row written
+	 * outside a run — and null is the ONLY way to say "no run", because a run
+	 * uuid is never an empty string.
+	 *
+	 * Stored as a plain stamp with no foreign key: flow-run retention prunes
+	 * runs, and an audit row is immutable, so a reference that could be
+	 * invalidated by retention must not be one the reader depends on
+	 * resolving.
+	 *
+	 * @var string|null Uuid of the attributing flow run.
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+	 */
+	protected ?string $flowRun = null;
+
+	/**
+	 * The id, within the flow graph, of the node that was executing.
+	 *
+	 * @var string|null Node id of the attributing step.
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+	 */
+	protected ?string $flowNode = null;
+
+	/**
+	 * The sequence number of the step that was executing.
+	 *
+	 * Steps are appended across a resume and never renumbered, so this orders
+	 * a run's writes even when the run suspended and continued days later.
+	 *
+	 * @var integer|null Step sequence of the attributing step.
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+	 */
+	protected ?int $flowStep = null;
+
+	/**
 	 * Constructor for the AuditTrail class
 	 *
 	 * Sets up field types for all properties
@@ -401,6 +448,9 @@ class AuditTrail extends Entity implements JsonSerializable {
 		$this->addType(fieldName: 'paramsDigest', type: 'string');
 		$this->addType(fieldName: 'resultSummary', type: 'json');
 		$this->addType(fieldName: 'purgedAt', type: 'datetime');
+		$this->addType(fieldName: 'flowRun', type: 'string');
+		$this->addType(fieldName: 'flowNode', type: 'string');
+		$this->addType(fieldName: 'flowStep', type: 'integer');
 	}//end __construct()
 
 	/**
@@ -508,7 +558,10 @@ class AuditTrail extends Entity implements JsonSerializable {
 	 *     previousHash: null|string,
 	 *     toolId: null|string,
 	 *     paramsDigest: null|string,
-	 *     resultSummary: array|null
+	 *     resultSummary: array|null,
+	 *     flowRun: null|string,
+	 *     flowNode: null|string,
+	 *     flowStep: int|null
 	 * }
 	 */
 	public function jsonSerialize(): array {
@@ -554,6 +607,18 @@ class AuditTrail extends Entity implements JsonSerializable {
 			'toolId' => $this->toolId,
 			'paramsDigest' => $this->paramsDigest,
 			'resultSummary' => $this->resultSummary,
+			// ⚠️ These three are COVERED BY THE HASH CHAIN. They are part of the
+			// canonical JSON that AuditHashService seals, which is what makes
+			// re-pointing a row at a different run detectable rather than
+			// merely unlikely. That coverage is also why adding them was a
+			// genesis-seed migration (v1 → v2, ADR-003 Rule 4) rather than a
+			// column addition: any key added here changes the canonical form of
+			// every row ever written. Do not add a key to this array without
+			// reading that ADR — and note that `purgedAt` is deliberately
+			// ABSENT for exactly this reason.
+			'flowRun' => $this->flowRun,
+			'flowNode' => $this->flowNode,
+			'flowStep' => $this->flowStep,
 		];
 	}//end jsonSerialize()
 

--- a/lib/Db/AuditTrail.php
+++ b/lib/Db/AuditTrail.php
@@ -384,8 +384,6 @@ class AuditTrail extends Entity implements JsonSerializable {
 	 * resolving.
 	 *
 	 * @var string|null Uuid of the attributing flow run.
-	 *
-	 * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
 	 */
 	protected ?string $flowRun = null;
 
@@ -393,8 +391,6 @@ class AuditTrail extends Entity implements JsonSerializable {
 	 * The id, within the flow graph, of the node that was executing.
 	 *
 	 * @var string|null Node id of the attributing step.
-	 *
-	 * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
 	 */
 	protected ?string $flowNode = null;
 
@@ -405,8 +401,6 @@ class AuditTrail extends Entity implements JsonSerializable {
 	 * a run's writes even when the run suspended and continued days later.
 	 *
 	 * @var integer|null Step sequence of the attributing step.
-	 *
-	 * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
 	 */
 	protected ?int $flowStep = null;
 

--- a/lib/Db/AuditTrailMapper.php
+++ b/lib/Db/AuditTrailMapper.php
@@ -111,79 +111,8 @@ class AuditTrailMapper extends QBMapper {
 		parent::__construct(db: $db, tableName: 'openregister_audit_trails', entityClass: AuditTrail::class);
 	}//end __construct()
 
-	/**
-	 * Every audit row attributed to one flow run, oldest first.
-	 *
-	 * Ordered by id rather than by `flow_step` so a run that visited the same
-	 * node twice — a loop — reads in the order the writes actually happened
-	 * rather than collapsing both visits into one position.
-	 *
-	 * @param string  $runUuid The flow run's uuid.
-	 * @param integer $limit   Maximum rows to return.
-	 *
-	 * @return AuditTrail[] The rows this run caused.
-	 *
-	 * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
-	 */
-	public function findByFlowRun(string $runUuid, int $limit = 1000): array {
-		$qb = $this->db->getQueryBuilder();
-		$qb->select('*')
-			->from('openregister_audit_trails')
-			->where($qb->expr()->eq('flow_run', $qb->createNamedParameter($runUuid)))
-			->orderBy('id', 'ASC')
-			->setMaxResults($limit);
 
-		return $this->findEntities(query: $qb);
-	}//end findByFlowRun()
 
-	/**
-	 * Stamp the executing flow run, node and step onto a row before it is sealed.
-	 *
-	 * Reads the ambient context rather than taking the values as arguments,
-	 * which is the entire reason this works: a write performed by another app
-	 * that a node called into is attributed identically to a write the node
-	 * performed itself, and neither has to know a flow is running.
-	 *
-	 * Resolved through the container rather than injected. Adding a constructor
-	 * argument to a mapper this widely constructed breaks positional callers —
-	 * and does so ONE SLOT LATER, so the TypeError names the wrong parameter.
-	 * {@see \OCA\OpenRegister\Service\Flow\FlowRunAttribution} resolves its own
-	 * collaborators the same way for the same reason.
-	 *
-	 * MUST be called before the row is sealed: these three fields are part of
-	 * the canonical JSON the hash covers, exactly like `expires`, so stamping
-	 * them after sealing would invalidate the hash it just computed.
-	 *
-	 * Fail-soft. If the context cannot be resolved the row is written
-	 * unattributed — an audit row is evidence and must survive a bookkeeping
-	 * problem, and an unattributed row is honest about what it does not know.
-	 *
-	 * @param AuditTrail $auditTrail The row being built.
-	 *
-	 * @return void
-	 *
-	 * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
-	 */
-	private function applyFlowAttribution(AuditTrail $auditTrail): void {
-		try {
-			$context = $this->container->get(\OCA\OpenRegister\Service\Flow\FlowRunContext::class);
-		} catch (\Throwable $e) {
-			return;
-		}
-
-		if ($context instanceof \OCA\OpenRegister\Service\Flow\FlowRunContext === false) {
-			return;
-		}
-
-		$frame = $context->current();
-		if ($frame === null) {
-			return;
-		}
-
-		$auditTrail->setFlowRun($frame['run']);
-		$auditTrail->setFlowNode($frame['node']);
-		$auditTrail->setFlowStep($frame['step']);
-	}//end applyFlowAttribution()
 
 	/**
 	 * Insert an audit-trail entry sealed into the SHA-256 hash chain.
@@ -235,7 +164,7 @@ class AuditTrailMapper extends QBMapper {
 		// It must happen before the row is INSERTED, not merely before it is
 		// sealed: the sweep seals whatever is in the row, so a field added
 		// after insert would be outside the hash it is later given.
-		$this->applyFlowAttribution(auditTrail: $auditTrail);
+		(new AuditFlowAttribution($this->db, $this->container))->apply(auditTrail: $auditTrail);
 
 		return $this->insert(entity: $auditTrail);
 	}//end insertHashChained()
@@ -679,7 +608,7 @@ class AuditTrailMapper extends QBMapper {
 		// methods: `insertAuditTrails()` (the batched path) builds its rows
 		// through this same method, and stamping the inserts instead would have
 		// left every bulk write in a flow silently unattributed.
-		$this->applyFlowAttribution(auditTrail: $auditTrail);
+		(new AuditFlowAttribution($this->db, $this->container))->apply(auditTrail: $auditTrail);
 
 		// Set the size to the byte size of the serialized object, with a minimum default of 14 bytes.
 		$serializedSize = strlen(serialize($objectEntity->jsonSerialize()));

--- a/lib/Db/AuditTrailMapper.php
+++ b/lib/Db/AuditTrailMapper.php
@@ -112,6 +112,80 @@ class AuditTrailMapper extends QBMapper {
 	}//end __construct()
 
 	/**
+	 * Every audit row attributed to one flow run, oldest first.
+	 *
+	 * Ordered by id rather than by `flow_step` so a run that visited the same
+	 * node twice — a loop — reads in the order the writes actually happened
+	 * rather than collapsing both visits into one position.
+	 *
+	 * @param string  $runUuid The flow run's uuid.
+	 * @param integer $limit   Maximum rows to return.
+	 *
+	 * @return AuditTrail[] The rows this run caused.
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+	 */
+	public function findByFlowRun(string $runUuid, int $limit = 1000): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from('openregister_audit_trails')
+			->where($qb->expr()->eq('flow_run', $qb->createNamedParameter($runUuid)))
+			->orderBy('id', 'ASC')
+			->setMaxResults($limit);
+
+		return $this->findEntities(query: $qb);
+	}//end findByFlowRun()
+
+	/**
+	 * Stamp the executing flow run, node and step onto a row before it is sealed.
+	 *
+	 * Reads the ambient context rather than taking the values as arguments,
+	 * which is the entire reason this works: a write performed by another app
+	 * that a node called into is attributed identically to a write the node
+	 * performed itself, and neither has to know a flow is running.
+	 *
+	 * Resolved through the container rather than injected. Adding a constructor
+	 * argument to a mapper this widely constructed breaks positional callers —
+	 * and does so ONE SLOT LATER, so the TypeError names the wrong parameter.
+	 * {@see \OCA\OpenRegister\Service\Flow\FlowRunAttribution} resolves its own
+	 * collaborators the same way for the same reason.
+	 *
+	 * MUST be called before the row is sealed: these three fields are part of
+	 * the canonical JSON the hash covers, exactly like `expires`, so stamping
+	 * them after sealing would invalidate the hash it just computed.
+	 *
+	 * Fail-soft. If the context cannot be resolved the row is written
+	 * unattributed — an audit row is evidence and must survive a bookkeeping
+	 * problem, and an unattributed row is honest about what it does not know.
+	 *
+	 * @param AuditTrail $auditTrail The row being built.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+	 */
+	private function applyFlowAttribution(AuditTrail $auditTrail): void {
+		try {
+			$context = $this->container->get(\OCA\OpenRegister\Service\Flow\FlowRunContext::class);
+		} catch (\Throwable $e) {
+			return;
+		}
+
+		if ($context instanceof \OCA\OpenRegister\Service\Flow\FlowRunContext === false) {
+			return;
+		}
+
+		$frame = $context->current();
+		if ($frame === null) {
+			return;
+		}
+
+		$auditTrail->setFlowRun($frame['run']);
+		$auditTrail->setFlowNode($frame['node']);
+		$auditTrail->setFlowStep($frame['step']);
+	}//end applyFlowAttribution()
+
+	/**
 	 * Insert an audit-trail entry sealed into the SHA-256 hash chain.
 	 *
 	 * Captures the current chain head as `previousHash`, inserts to obtain the
@@ -150,6 +224,19 @@ class AuditTrailMapper extends QBMapper {
 		// minutes). verifyChain() skips unsealed rows and carries the last
 		// sealed hash forward, so a tail of them is a smaller claim, never a
 		// false alarm.
+		//
+		// Attribution is applied here as well as in buildAuditTrail(), which
+		// covers the entry points that do NOT build their row there —
+		// createAuditTrailEntry() (archival/retention) and
+		// createToolInvocationEntry() (MCP). Both can be reached from inside a
+		// flow. Re-applying to a row the builder already stamped is idempotent:
+		// it reads the same ambient frame and writes the same three values.
+		//
+		// It must happen before the row is INSERTED, not merely before it is
+		// sealed: the sweep seals whatever is in the row, so a field added
+		// after insert would be outside the hash it is later given.
+		$this->applyFlowAttribution(auditTrail: $auditTrail);
+
 		return $this->insert(entity: $auditTrail);
 	}//end insertHashChained()
 
@@ -288,6 +375,14 @@ class AuditTrailMapper extends QBMapper {
 					'ip_address',
 					'version',
 					'created',
+					// Flow attribution. Absent from this allowlist a filter is
+					// not rejected — it is silently DROPPED by the `continue`
+					// below, so `?flow_run=<uuid>` would return the whole
+					// unfiltered audit trail with a 200 and read as a run that
+					// had touched everything on the instance.
+					'flow_run',
+					'flow_node',
+					'flow_step',
 				]
 			) === false
 			) {
@@ -344,6 +439,11 @@ class AuditTrailMapper extends QBMapper {
 					'ip_address',
 					'version',
 					'created',
+					// Sortable for the same reason they are filterable: a run's
+					// writes are read in step order.
+					'flow_run',
+					'flow_node',
+					'flow_step',
 				]
 			) === false
 			) {
@@ -573,6 +673,13 @@ class AuditTrailMapper extends QBMapper {
 		if ($importJobId !== null) {
 			$auditTrail->setImportJobId($importJobId);
 		}
+
+		// Flow attribution — which run, node and step caused this write.
+		// Applied HERE, in the shared builder, and not in the two insert
+		// methods: `insertAuditTrails()` (the batched path) builds its rows
+		// through this same method, and stamping the inserts instead would have
+		// left every bulk write in a flow silently unattributed.
+		$this->applyFlowAttribution(auditTrail: $auditTrail);
 
 		// Set the size to the byte size of the serialized object, with a minimum default of 14 bytes.
 		$serializedSize = strlen(serialize($objectEntity->jsonSerialize()));

--- a/lib/Db/FlowRunMapper.php
+++ b/lib/Db/FlowRunMapper.php
@@ -133,25 +133,85 @@ class FlowRunMapper extends QBMapper {
 			$qb->andWhere($qb->expr()->eq('status', $qb->createNamedParameter($status)));
 		}
 
-		if ($requesterUid !== null) {
-			$visible = $qb->expr()->orX(
-				$qb->expr()->eq('triggered_by', $qb->createNamedParameter($requesterUid))
-			);
-
-			if (empty($ownedFlowIds) === false) {
-				$visible->add(
-					$qb->expr()->in(
-						'flow_id',
-						$qb->createNamedParameter($ownedFlowIds, IQueryBuilder::PARAM_STR_ARRAY)
-					)
-				);
-			}
-
-			$qb->andWhere($visible);
-		}
+		$this->scopeToVisible(qb: $qb, requesterUid: $requesterUid, ownedFlowIds: $ownedFlowIds);
 
 		return $this->findEntities(query: $qb);
 	}//end findAllRuns()
+
+	/**
+	 * Narrow a run query to what one caller may see.
+	 *
+	 * Extracted so the LIST and the SINGLE-RUN reads apply the same predicate
+	 * rather than each carrying its own copy. Two copies of one access rule do
+	 * not stay identical, and the copy that drifts is the one nobody is looking
+	 * at — a divergence here does not throw, it just answers with somebody
+	 * else's run, correctly formatted, HTTP 200.
+	 *
+	 * A null `$requesterUid` applies NO scoping. That is an administrator's
+	 * semantics and must never be reached by falling through from a missing
+	 * session; callers resolve "no identity" to a refusal before calling.
+	 *
+	 * @param IQueryBuilder      $qb           The query being built.
+	 * @param string|null        $requesterUid The caller, or null for no scoping.
+	 * @param array<int, string> $ownedFlowIds Flow ids the caller owns.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+	 */
+	private function scopeToVisible(IQueryBuilder $qb, ?string $requesterUid, array $ownedFlowIds): void {
+		if ($requesterUid === null) {
+			return;
+		}
+
+		$visible = $qb->expr()->orX(
+			$qb->expr()->eq('triggered_by', $qb->createNamedParameter($requesterUid))
+		);
+
+		if (empty($ownedFlowIds) === false) {
+			$visible->add(
+				$qb->expr()->in(
+					'flow_id',
+					$qb->createNamedParameter($ownedFlowIds, IQueryBuilder::PARAM_STR_ARRAY)
+				)
+			);
+		}
+
+		$qb->andWhere($visible);
+	}//end scopeToVisible()
+
+	/**
+	 * Find one run by uuid, but only if this caller may see it.
+	 *
+	 * Returns null both when the run does not exist and when it exists but is
+	 * not the caller's, so the caller cannot distinguish the two — the absence
+	 * of a run and the absence of permission look identical from outside, which
+	 * is what stops the endpoint being a probe for which runs exist.
+	 *
+	 * @param string             $uuid         The run uuid.
+	 * @param string|null        $requesterUid The caller, or null for an administrator.
+	 * @param array<int, string> $ownedFlowIds Flow ids the caller owns.
+	 *
+	 * @return FlowRun|null The run, or null when it does not exist or is not visible.
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+	 */
+	public function findByUuidVisibleTo(string $uuid, ?string $requesterUid, array $ownedFlowIds = []): ?FlowRun {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('uuid', $qb->createNamedParameter($uuid)))
+			->setMaxResults(1);
+
+		$this->scopeToVisible(qb: $qb, requesterUid: $requesterUid, ownedFlowIds: $ownedFlowIds);
+
+		$found = $this->findEntities(query: $qb);
+		if ($found === []) {
+			return null;
+		}
+
+		return $found[0];
+	}//end findByUuidVisibleTo()
 
 	/**
 	 * Delete terminal runs older than a cutoff, optionally for one flow only.

--- a/lib/Db/FlowRunMapper.php
+++ b/lib/Db/FlowRunMapper.php
@@ -181,6 +181,44 @@ class FlowRunMapper extends QBMapper {
 	}//end scopeToVisible()
 
 	/**
+	 * The suspended runs whose subject is this object.
+	 *
+	 * "Which run is waiting on this thing" is the question a leaf app asks when
+	 * something outside the engine finishes — a decision concluded, a document
+	 * signed — and needs to wake whatever was waiting for it.
+	 *
+	 * Deliberately narrowed to SUSPENDED. A completed or failed run is not
+	 * waiting for anything, and signalling one would be a no-op at best and a
+	 * second advance of a finished run at worst.
+	 *
+	 * This does NOT scope by caller: it is an engine-side lookup used to route
+	 * an external outcome, not a user-facing read. Callers that expose anything
+	 * derived from it must apply their own visibility rule.
+	 *
+	 * @param string  $subjectUuid The subject object's uuid.
+	 * @param integer $limit       Maximum runs to return.
+	 *
+	 * @return FlowRun[] The suspended runs for that subject, oldest first.
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+	 */
+	public function findSuspendedBySubject(string $subjectUuid, int $limit = 25): array {
+		if (trim($subjectUuid) === '') {
+			return [];
+		}
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('subject_uuid', $qb->createNamedParameter($subjectUuid)))
+			->andWhere($qb->expr()->eq('status', $qb->createNamedParameter(FlowRun::STATUS_SUSPENDED)))
+			->orderBy('id', 'ASC')
+			->setMaxResults($limit);
+
+		return $this->findEntities(query: $qb);
+	}//end findSuspendedBySubject()
+
+	/**
 	 * Find one run by uuid, but only if this caller may see it.
 	 *
 	 * Returns null both when the run does not exist and when it exists but is

--- a/lib/Listener/SchemaFlowImportListener.php
+++ b/lib/Listener/SchemaFlowImportListener.php
@@ -72,6 +72,11 @@ class SchemaFlowImportListener implements IEventListener {
 	 *
 	 * @param FlowMapper $flows The flow store.
 	 * @param LoggerInterface $logger Records what was imported, and what could not be.
+	 * @param ContainerInterface|null $container Resolves the organisation a declared flow
+	 *                                           belongs to. Nullable and LAST so adding it
+	 *                                           shifts no positional caller; absent, the
+	 *                                           flow still imports but stays unlisted,
+	 *                                           which is logged rather than silent.
 	 */
 	public function __construct(
 		private readonly FlowMapper $flows,

--- a/lib/Listener/SchemaFlowImportListener.php
+++ b/lib/Listener/SchemaFlowImportListener.php
@@ -43,6 +43,7 @@ use DateTime;
 use InvalidArgumentException;
 use OCA\OpenRegister\Db\Flow;
 use OCA\OpenRegister\Db\FlowMapper;
+use Psr\Container\ContainerInterface;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Event\SchemaCreatedEvent;
 use OCA\OpenRegister\Event\SchemaUpdatedEvent;
@@ -75,6 +76,7 @@ class SchemaFlowImportListener implements IEventListener {
 	public function __construct(
 		private readonly FlowMapper $flows,
 		private readonly LoggerInterface $logger,
+		private readonly ?ContainerInterface $container = null,
 	) {
 
 	}//end __construct()
@@ -192,6 +194,17 @@ class SchemaFlowImportListener implements IEventListener {
 			// Inert until adopted. See the class docblock.
 			$flow->setEnabled(false);
 			$flow->setOwner(null);
+
+			// 🔴 AND IT MUST BELONG TO A TENANT, or it is imported into
+			// invisibility. Every flow READ is organisation-scoped
+			// (`FlowService::findAll()`), so a flow stored with no organisation
+			// is returned by nothing: it does not appear in the flows list, so
+			// it cannot be opened, so it can never be adopted — while sitting
+			// perfectly intact in the table. Measured 2026-08-28: the first
+			// shipped `x-openregister-flows` declaration imported with
+			// organisation NULL and was invisible to the API that lists it,
+			// next to two seeded flows that carried one and showed up fine.
+			$flow->setOrganisation($this->activeOrganisation());
 		}
 
 		$flow->setDescription(($declaration['description'] ?? null));
@@ -216,6 +229,42 @@ class SchemaFlowImportListener implements IEventListener {
 		$this->flows->update($flow);
 
 	}//end upsert()
+
+	/**
+	 * The organisation a newly imported flow belongs to.
+	 *
+	 * Resolved through the container rather than injected so this listener
+	 * stays constructible where OrganisationService is not registered — a
+	 * declared flow should still import on such an instance, even though a
+	 * null organisation leaves it unlisted.
+	 *
+	 * @return string|null The organisation uuid, or null when unresolvable.
+	 *
+	 * @spec openspec/changes/flow-engine-unification/specs/flow-storage/spec.md
+	 */
+	private function activeOrganisation(): ?string {
+		if ($this->container === null) {
+			return null;
+		}
+
+		try {
+			$uuid = $this->container
+				->get('OCA\OpenRegister\Service\OrganisationService')
+				->getActiveOrganisation()?->getUuid();
+		} catch (Throwable $e) {
+			$this->logger->warning(
+				message: '[SchemaFlowImport] Could not resolve an organisation for a declared flow; '
+					. 'it will import but stay unlisted: ' . $e->getMessage()
+			);
+			return null;
+		}
+
+		if ($uuid === null || (string)$uuid === '') {
+			return null;
+		}
+
+		return (string)$uuid;
+	}//end activeOrganisation()
 
 	/**
 	 * Mint a v4 uuid.

--- a/lib/Migration/Version1Date20260828120000.php
+++ b/lib/Migration/Version1Date20260828120000.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * Flow attribution columns on the audit trail.
+ *
+ * A flow run recorded exactly one object — the one that TRIGGERED it — so
+ * everything a run went on to touch was attributable to nothing. These three
+ * columns are what let an audit row name the run, node and step that caused it,
+ * and therefore what lets a run report the objects it changed.
+ *
+ * `flow_run` is a plain stamp and deliberately NOT a foreign key. Flow-run
+ * retention prunes runs, and an audit row is immutable — a constraint here
+ * would either block a lawful prune or reach into rows that must never change.
+ * A stamp naming a run that no longer exists stays readable as history.
+ *
+ * Schema only. The chain re-seal that the new canonical form requires lives in
+ * {@see \OCA\OpenRegister\Migration\RechainAuditTrailForFlowAttribution}, a
+ * repair step, because it verifies and rewrites rows rather than shaping the
+ * table — and because it must run AFTER these columns exist.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\Types;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Add flow_run / flow_node / flow_step to openregister_audit_trails.
+ *
+ * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+ */
+class Version1Date20260828120000 extends SimpleMigrationStep {
+	/**
+	 * Add the attribution columns and the run index.
+	 *
+	 * @param IOutput $output Output for the migration process.
+	 * @param Closure $schemaClosure The schema closure.
+	 * @param array<array-key, mixed> $options Migration options.
+	 *
+	 * @return ISchemaWrapper|null The modified schema, or null when nothing changed.
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/*
+		 * @var ISchemaWrapper $schema
+		 */
+
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('openregister_audit_trails') === false) {
+			return null;
+		}
+
+		$table = $schema->getTable('openregister_audit_trails');
+		$changed = false;
+
+		// Every column is added independently and guarded on its own presence.
+		// A single "if the first column is missing, add all three" guard is the
+		// shape that leaves a half-migrated table permanently half-migrated
+		// after one interrupted upgrade.
+		if ($table->hasColumn('flow_run') === false) {
+			$table->addColumn('flow_run', Types::STRING, [
+				'notnull' => false,
+				'length' => 64,
+			]);
+			$changed = true;
+		}
+
+		if ($table->hasColumn('flow_node') === false) {
+			$table->addColumn('flow_node', Types::STRING, [
+				'notnull' => false,
+				'length' => 255,
+			]);
+			$changed = true;
+		}
+
+		if ($table->hasColumn('flow_step') === false) {
+			$table->addColumn('flow_step', Types::INTEGER, [
+				'notnull' => false,
+			]);
+			$changed = true;
+		}
+
+		// The run direction ("what did this run touch") is the one that needs
+		// help; the object direction is already served by the existing
+		// object_uuid index. No composite until a query asks for one — a
+		// speculative index on this table is a write cost on every audited
+		// mutation forever (ADR-009).
+		if ($table->hasIndex('idx_audit_flow_run') === false) {
+			$table->addIndex(['flow_run'], 'idx_audit_flow_run');
+			$changed = true;
+		}
+
+		if ($changed === false) {
+			return null;
+		}
+
+		$output->info('Added flow_run / flow_node / flow_step and idx_audit_flow_run to openregister_audit_trails');
+
+		return $schema;
+	}//end changeSchema()
+}//end class

--- a/lib/Repair/RechainAuditTrailForFlowAttribution.php
+++ b/lib/Repair/RechainAuditTrailForFlowAttribution.php
@@ -154,28 +154,7 @@ class RechainAuditTrailForFlowAttribution implements IRepairStep {
 			return;
 		}
 
-		if ($verdict['valid'] === false) {
-			$output->warning(
-				sprintf(
-					'The audit chain did NOT verify under seed v1 before re-sealing '
-					. '(first break at row id %s, %d row(s) verified). '
-					. 'This is recorded under app-config `%s`. The re-seal below will make the '
-					. 'chain verify again — it does NOT repair the cause, and after it runs the '
-					. 'break is no longer detectable. Investigate using the stored verdict.',
-					var_export($verdict['brokenAt'], true),
-					$verdict['entriesVerified'],
-					self::VERDICT_KEY
-				)
-			);
-		} else {
-			$output->info(
-				sprintf(
-					'Audit chain verified intact under seed v1 (%d row(s), %d tombstone(s)). Re-sealing under v2.',
-					$verdict['entriesVerified'],
-					$verdict['purgedTombstones']
-				)
-			);
-		}
+		$this->reportVerdict(verdict: $verdict, output: $output);
 
 		$result = $this->hashes->rechainAll();
 
@@ -191,6 +170,48 @@ class RechainAuditTrailForFlowAttribution implements IRepairStep {
 	}//end run()
 
 	/**
+	 * Say what the pre-check found, in the register an operator will actually read.
+	 *
+	 * A broken chain is a WARNING and not a refusal: an operator whose chain is
+	 * already broken still needs their instance to upgrade, and refusing would
+	 * strand them. What must not happen is the re-seal going by unremarked,
+	 * because afterwards the break is no longer detectable.
+	 *
+	 * @param array   $verdict The pre-verification result.
+	 * @param IOutput $output  Progress output.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/audit-hash-chain/spec.md
+	 */
+	private function reportVerdict(array $verdict, IOutput $output): void {
+		if ($verdict['valid'] === true) {
+			$output->info(
+				sprintf(
+					'Audit chain verified intact under seed v1 (%d row(s), %d tombstone(s)). Re-sealing under v2.',
+					$verdict['entriesVerified'],
+					$verdict['purgedTombstones']
+				)
+			);
+
+			return;
+		}
+
+		$output->warning(
+			sprintf(
+				'The audit chain did NOT verify under seed v1 before re-sealing '
+				. '(first break at row id %s, %d row(s) verified). '
+				. 'This is recorded under app-config `%s`. The re-seal below will make the '
+				. 'chain verify again — it does NOT repair the cause, and after it runs the '
+				. 'break is no longer detectable. Investigate using the stored verdict.',
+				var_export($verdict['brokenAt'], true),
+				$verdict['entriesVerified'],
+				self::VERDICT_KEY
+			)
+		);
+	}//end reportVerdict()
+
+	/**
 	 * Walk the chain using the FROZEN v1 canonical form.
 	 *
 	 * Mirrors the live verifier's tombstone rule: a purged row's content no
@@ -203,6 +224,12 @@ class RechainAuditTrailForFlowAttribution implements IRepairStep {
 	 * smaller claim, never a false alarm.
 	 *
 	 * @return array{valid: bool, entriesVerified: int, brokenAt: int|null, skippedNullHashes: int, purgedTombstones: int}
+	 *
+	 * @SuppressWarnings(PHPMD.StaticAccess) AuditCanonicalV1 is deliberately static and
+	 * deliberately FROZEN. Injecting it would present it as a collaborator that could be
+	 * swapped or updated, which is the one thing it must never be: it describes the audit
+	 * entity as it WAS, and a substituted implementation would silently invalidate the
+	 * only check that can still tell an intact v1 chain from a tampered one.
 	 *
 	 * @spec openspec/changes/flow-object-attribution/specs/audit-hash-chain/spec.md
 	 */
@@ -292,7 +319,7 @@ class RechainAuditTrailForFlowAttribution implements IRepairStep {
 	private function hydrate(array $row): AuditTrail {
 		$mapped = [];
 		foreach ($row as $key => $value) {
-			// snake_case → camelCase, character for character as the verifier does.
+			// Snake_case to camelCase, character for character as the verifier does.
 			$camelKey = lcfirst(str_replace('_', '', ucwords((string)$key, '_')));
 			$mapped[$camelKey] = $value;
 		}

--- a/lib/Repair/RechainAuditTrailForFlowAttribution.php
+++ b/lib/Repair/RechainAuditTrailForFlowAttribution.php
@@ -1,0 +1,350 @@
+<?php
+
+/**
+ * Verify the v1 audit chain, record what it found, then re-seal under v2.
+ *
+ * The flow-attribution fields joined the canonical JSON the hash chain covers,
+ * so a row's run/node/step can no longer be altered without breaking
+ * verification. ADR-003 Rule 4 makes that a migration event rather than an edit:
+ * the seed moves v1 → v2 and every stored hash has to be recomputed, because a
+ * hash sealed over the old field set can never again be re-derived from the new
+ * one.
+ *
+ * 🔴 THE ORDER IS THE WHOLE POINT, AND IT IS NOT COSMETIC.
+ *
+ * A re-chain recomputes every hash from current row content. That means it
+ * cannot distinguish a chain that was intact from one that had been tampered
+ * with — it makes both verify afterwards. Whatever the chain's true state was
+ * at this moment, it is not recoverable after this step runs.
+ *
+ * So this step verifies FIRST, against {@see AuditCanonicalV1} — the frozen old
+ * form — and writes that verdict down before it rewrites anything. Verifying
+ * with the CURRENT canonicaliser would have been worthless: it includes the new
+ * keys, so every v1 row mismatches whether or not it was ever touched, the
+ * verdict reads "broken" unconditionally, and the one fact worth preserving is
+ * destroyed by the very step that was supposed to check it.
+ *
+ * The step does not REFUSE on a broken chain. An operator whose chain is
+ * already broken still needs their instance to upgrade, and refusing would
+ * strand them with no path forward. It records, loudly and durably, and
+ * continues — the difference between a silent overwrite and an accountable one.
+ *
+ * It DOES refuse if it cannot record the verdict at all, because a re-chain
+ * with no surviving account of what preceded it is the one outcome with no
+ * remedy.
+ *
+ * @category Repair
+ * @package  OCA\OpenRegister\Repair
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-object-attribution/specs/audit-hash-chain/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Repair;
+
+use DateTime;
+use OCA\OpenRegister\Db\AuditTrail;
+use OCA\OpenRegister\Service\AuditCanonicalV1;
+use OCA\OpenRegister\Service\AuditHashService;
+use OCP\IAppConfig;
+use OCP\IDBConnection;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Pre-verifies the v1 chain and re-seals the audit trail under the v2 seed.
+ *
+ * @spec openspec/changes/flow-object-attribution/specs/audit-hash-chain/spec.md
+ */
+class RechainAuditTrailForFlowAttribution implements IRepairStep {
+	/**
+	 * App-config key recording that the v1 → v2 re-chain has been performed.
+	 *
+	 * Presence is what makes the step idempotent: a re-chain is expensive and,
+	 * far more importantly, its pre-verification is only meaningful ONCE. After
+	 * the first pass every row is sealed under v2, so a second pre-verify would
+	 * compare v2 rows against the v1 form and report a false break — recording
+	 * a scary, meaningless verdict over the real one.
+	 *
+	 * @var string
+	 */
+	public const DONE_KEY = 'audit_chain_seed_v2_rechained_at';
+
+	/**
+	 * App-config key holding the pre-migration verdict, as JSON.
+	 *
+	 * @var string
+	 */
+	public const VERDICT_KEY = 'audit_chain_seed_v2_preverify';
+
+	/**
+	 * How many rows to verify per query window.
+	 *
+	 * @var integer
+	 */
+	private const WINDOW = 500;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IDBConnection    $db     Reads the audit rows to verify.
+	 * @param IAppConfig       $config Stores the verdict and the done-marker.
+	 * @param AuditHashService $hashes Performs the re-seal.
+	 * @param LoggerInterface  $logger Records the verdict in the log as well.
+	 */
+	public function __construct(
+		private readonly IDBConnection $db,
+		private readonly IAppConfig $config,
+		private readonly AuditHashService $hashes,
+		private readonly LoggerInterface $logger,
+	) {
+	}//end __construct()
+
+	/**
+	 * The step's name, as shown by `occ maintenance:repair`.
+	 *
+	 * @return string The human-readable name.
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/audit-hash-chain/spec.md
+	 */
+	public function getName(): string {
+		return 'Verify and re-seal the OpenRegister audit chain for flow attribution (seed v1 → v2)';
+	}//end getName()
+
+	/**
+	 * Verify under v1, record the verdict, then re-chain under v2.
+	 *
+	 * @param IOutput $output Progress output.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/audit-hash-chain/spec.md
+	 */
+	public function run(IOutput $output): void {
+		if ($this->config->getValueString('openregister', self::DONE_KEY, '') !== '') {
+			$output->info('Audit chain already re-sealed under seed v2; nothing to do.');
+			return;
+		}
+
+		$verdict = $this->verifyUnderV1();
+
+		// Refuse before touching a single row if the account of what we are
+		// about to overwrite cannot be kept. A re-chain is not reversible, so
+		// "it ran but we do not know what it ran over" is strictly worse than
+		// "it has not run yet".
+		if ($this->recordVerdict(verdict: $verdict, output: $output) === false) {
+			$output->warning(
+				'REFUSING to re-chain: the pre-verification verdict could not be stored. '
+				. 'A re-chain that leaves no record of the chain state it replaced is not recoverable. '
+				. 'Fix app-config writes and re-run `occ maintenance:repair`.'
+			);
+			return;
+		}
+
+		if ($verdict['valid'] === false) {
+			$output->warning(
+				sprintf(
+					'The audit chain did NOT verify under seed v1 before re-sealing '
+					. '(first break at row id %s, %d row(s) verified). '
+					. 'This is recorded under app-config `%s`. The re-seal below will make the '
+					. 'chain verify again — it does NOT repair the cause, and after it runs the '
+					. 'break is no longer detectable. Investigate using the stored verdict.',
+					var_export($verdict['brokenAt'], true),
+					$verdict['entriesVerified'],
+					self::VERDICT_KEY
+				)
+			);
+		} else {
+			$output->info(
+				sprintf(
+					'Audit chain verified intact under seed v1 (%d row(s), %d tombstone(s)). Re-sealing under v2.',
+					$verdict['entriesVerified'],
+					$verdict['purgedTombstones']
+				)
+			);
+		}
+
+		$result = $this->hashes->rechainAll();
+
+		$this->config->setValueString('openregister', self::DONE_KEY, (new DateTime())->format('c'));
+
+		$output->info(
+			sprintf(
+				'Re-sealed %d audit row(s) under seed v2; %d retention tombstone(s) carried forward.',
+				(int)($result['rechained'] ?? 0),
+				(int)($result['tombstonesPreserved'] ?? 0)
+			)
+		);
+	}//end run()
+
+	/**
+	 * Walk the chain using the FROZEN v1 canonical form.
+	 *
+	 * Mirrors the live verifier's tombstone rule: a purged row's content no
+	 * longer re-hashes to its stored value by design, but that stored value is
+	 * still the link the next row committed to, so the chain is carried across
+	 * it rather than reported as a break.
+	 *
+	 * Unsealed rows (null hash) are skipped and carry the previous hash
+	 * forward, exactly as the live verifier does — a tail of unsealed rows is a
+	 * smaller claim, never a false alarm.
+	 *
+	 * @return array{valid: bool, entriesVerified: int, brokenAt: int|null, skippedNullHashes: int, purgedTombstones: int}
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/audit-hash-chain/spec.md
+	 */
+	private function verifyUnderV1(): array {
+		$previousHash = AuditCanonicalV1::genesisHash();
+		$entriesVerified = 0;
+		$skippedNullHashes = 0;
+		$purgedTombstones = 0;
+		$brokenAt = null;
+		$afterId = 0;
+
+		while ($brokenAt === null) {
+			$qb = $this->db->getQueryBuilder();
+			$qb->select('*')
+				->from('openregister_audit_trails')
+				->where($qb->expr()->gt('id', $qb->createNamedParameter($afterId, IQueryBuilder::PARAM_INT)))
+				->orderBy('id', 'ASC')
+				->setMaxResults(self::WINDOW);
+
+			$result = $qb->executeQuery();
+			$rows = $result->fetchAll();
+			$result->closeCursor();
+
+			if ($rows === []) {
+				break;
+			}
+
+			foreach ($rows as $row) {
+				$afterId = (int)$row['id'];
+
+				$entity = $this->hydrate(row: $row);
+				$storedHash = $entity->getHash();
+
+				if ($storedHash === null || $storedHash === '') {
+					$skippedNullHashes++;
+					continue;
+				}
+
+				if ($entity->isPurged() === true) {
+					// A declared tombstone: carry its stored hash forward as
+					// the chain link without re-deriving its blanked content.
+					$purgedTombstones++;
+					$previousHash = $storedHash;
+					continue;
+				}
+
+				$expected = AuditCanonicalV1::computeHash(entry: $entity, previousHash: $previousHash);
+
+				if (hash_equals($expected, $storedHash) === false) {
+					$brokenAt = (int)$row['id'];
+					break;
+				}
+
+				$entriesVerified++;
+				$previousHash = $storedHash;
+			}//end foreach
+		}//end while
+
+		return [
+			'valid' => ($brokenAt === null),
+			'entriesVerified' => $entriesVerified,
+			'brokenAt' => $brokenAt,
+			'skippedNullHashes' => $skippedNullHashes,
+			'purgedTombstones' => $purgedTombstones,
+		];
+	}//end verifyUnderV1()
+
+	/**
+	 * Hydrate a raw row exactly the way the live verifier does.
+	 *
+	 * 🔑 This deliberately mirrors `AuditHashService::mapRowToEntity()` +
+	 * `AuditTrail::hydrate()` rather than using `Entity::fromRow()`. The two are
+	 * very nearly equivalent, and "very nearly" is worth nothing here: this
+	 * method feeds the one comparison whose job is to tell an intact chain from
+	 * a tampered one. Any difference in how a date is parsed or a JSON column is
+	 * decoded would change the canonical JSON, mismatch every row, and report a
+	 * healthy chain as broken — the precise false verdict this whole step is
+	 * built to avoid. `hydrate()` also ignores unknown properties, where
+	 * `fromRow()` would throw on a column the entity does not declare.
+	 *
+	 * @param array<string, mixed> $row The raw database row.
+	 *
+	 * @return AuditTrail The hydrated entity.
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/audit-hash-chain/spec.md
+	 */
+	private function hydrate(array $row): AuditTrail {
+		$mapped = [];
+		foreach ($row as $key => $value) {
+			// snake_case → camelCase, character for character as the verifier does.
+			$camelKey = lcfirst(str_replace('_', '', ucwords((string)$key, '_')));
+			$mapped[$camelKey] = $value;
+		}
+
+		$entity = new AuditTrail();
+		$entity->hydrate(object: $mapped);
+
+		return $entity;
+	}//end hydrate()
+
+	/**
+	 * Persist the verdict, and say whether it actually landed.
+	 *
+	 * The boolean is load-bearing: {@see run()} refuses to re-chain on false.
+	 * It is verified by READING BACK what was written rather than by the write
+	 * not throwing — a config backend that silently drops a write would
+	 * otherwise report success and leave no record at all.
+	 *
+	 * @param array   $verdict The pre-verification result.
+	 * @param IOutput $output  Progress output.
+	 *
+	 * @return boolean True when the verdict is durably stored.
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/audit-hash-chain/spec.md
+	 */
+	private function recordVerdict(array $verdict, IOutput $output): bool {
+		$payload = json_encode(
+			array_merge($verdict, [
+				'seedFrom' => AuditCanonicalV1::GENESIS_SEED,
+				'seedTo' => 'openregister-genesis-v2',
+				'verifiedAt' => (new DateTime())->format('c'),
+			])
+		);
+
+		if ($payload === false) {
+			return false;
+		}
+
+		$this->logger->warning(
+			message: '[RechainAuditTrailForFlowAttribution] Pre-re-chain audit chain verdict: ' . $payload,
+			context: ['file' => __FILE__, 'line' => __LINE__, 'app' => 'openregister']
+		);
+
+		try {
+			$this->config->setValueString('openregister', self::VERDICT_KEY, $payload);
+		} catch (Throwable $e) {
+			$output->warning('Could not store the pre-verification verdict: ' . $e->getMessage());
+			return false;
+		}
+
+		// Read it back. "The setter did not throw" is not evidence the value is
+		// there, and this is the one fact the whole step exists to preserve.
+		return ($this->config->getValueString('openregister', self::VERDICT_KEY, '') === $payload);
+	}//end recordVerdict()
+}//end class

--- a/lib/Service/AuditCanonicalV1.php
+++ b/lib/Service/AuditCanonicalV1.php
@@ -1,0 +1,162 @@
+<?php
+
+/**
+ * The audit chain's v1 canonical form, frozen.
+ *
+ * ⚠️ THIS FILE IS FROZEN. Nothing may be added to {@see FIELDS}, ever. It is not
+ * a description of the AuditTrail entity — it is a description of the entity AS
+ * IT WAS when the rows sealed under `openregister-genesis-v1` were written.
+ * Updating it to match a newer entity would silently destroy the only means of
+ * checking those rows.
+ *
+ * WHY IT EXISTS. Adding the flow-attribution fields to the canonical JSON
+ * changed the chain's identity, which ADR-003 Rule 4 defines as a migration
+ * event: verify, then re-seal under a new seed. The verify half is the part
+ * that is easy to get wrong and worthless when wrong.
+ *
+ * If the pre-migration verification canonicalises with the CURRENT code, it
+ * includes the new keys, so every row sealed under v1 mismatches — whether that
+ * row was tampered with or was perfectly intact. The verdict comes back
+ * "broken" either way, the re-chain overwrites the hashes either way, and the
+ * difference between a healthy chain and a compromised one is destroyed with no
+ * record that it ever existed. The check would run, produce output, and mean
+ * nothing.
+ *
+ * So the check reads the old form from here. An intact v1 chain verifies as
+ * intact; a tampered one names the row it broke at; and that verdict is
+ * recorded before anything is rewritten.
+ *
+ * The field list is an ALLOWLIST rather than a denylist of the new keys. A
+ * denylist would have to be updated every time a field is added to the entity —
+ * which is to say it would be wrong the first time somebody forgot, and wrong
+ * silently.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-object-attribution/specs/audit-hash-chain/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+use OCA\OpenRegister\Db\AuditTrail;
+
+/**
+ * Canonicalises an audit row the way the v1 chain did.
+ *
+ * @spec openspec/changes/flow-object-attribution/specs/audit-hash-chain/spec.md
+ */
+final class AuditCanonicalV1 {
+	/**
+	 * The genesis seed the v1 chain was built from.
+	 *
+	 * @var string
+	 */
+	public const GENESIS_SEED = 'openregister-genesis-v1';
+
+	/**
+	 * Every key the v1 canonical JSON contained, `hash` and `previousHash`
+	 * excluded as they always were.
+	 *
+	 * 🔴 FROZEN. Adding an entry here changes what a v1 row is claimed to have
+	 * been sealed over, which makes intact rows read as tampered.
+	 *
+	 * @var string[]
+	 */
+	private const FIELDS = [
+		'id',
+		'uuid',
+		'schema',
+		'register',
+		'object',
+		'objectUuid',
+		'registerUuid',
+		'schemaUuid',
+		'action',
+		'changed',
+		'user',
+		'userName',
+		'session',
+		'request',
+		'ipAddress',
+		'version',
+		'created',
+		'organisationId',
+		'organisationIdType',
+		'processingActivityId',
+		'processingActivityUrl',
+		'processingId',
+		'confidentiality',
+		'retentionPeriod',
+		'size',
+		'expires',
+		'toolId',
+		'paramsDigest',
+		'resultSummary',
+	];
+
+	/**
+	 * The v1 genesis hash.
+	 *
+	 * @return string SHA-256 of the v1 seed.
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/audit-hash-chain/spec.md
+	 */
+	public static function genesisHash(): string {
+		return hash('sha256', self::GENESIS_SEED);
+	}//end genesisHash()
+
+	/**
+	 * The canonical JSON a v1 row was sealed over.
+	 *
+	 * Same rules the v1 canonicaliser used: the allowlisted fields only, sorted
+	 * keys, compact form.
+	 *
+	 * @param AuditTrail $entry The row to canonicalise.
+	 *
+	 * @return string The v1 canonical JSON.
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/audit-hash-chain/spec.md
+	 */
+	public static function canonicalJson(AuditTrail $entry): string {
+		$serialized = $entry->jsonSerialize();
+
+		$data = [];
+		foreach (self::FIELDS as $field) {
+			// Present-but-null and absent are different canonical forms, and
+			// every v1 field was always PRESENT — jsonSerialize() emitted the
+			// whole array unconditionally. So a missing key is filled with null
+			// rather than skipped.
+			$data[$field] = ($serialized[$field] ?? null);
+		}
+
+		ksort($data);
+
+		return json_encode($data, (JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+	}//end canonicalJson()
+
+	/**
+	 * The hash a v1 row should carry, given its predecessor.
+	 *
+	 * @param AuditTrail $entry        The row.
+	 * @param string     $previousHash The hash of the row before it.
+	 *
+	 * @return string The expected v1 hash.
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/audit-hash-chain/spec.md
+	 */
+	public static function computeHash(AuditTrail $entry, string $previousHash): string {
+		return hash('sha256', ($previousHash . self::canonicalJson(entry: $entry)));
+	}//end computeHash()
+}//end class

--- a/lib/Service/AuditHashService.php
+++ b/lib/Service/AuditHashService.php
@@ -73,9 +73,23 @@ class AuditHashService {
 	/**
 	 * The genesis seed used for the first entry in the hash chain.
 	 *
+	 * ⚠️ VERSIONED, and versioned TOGETHER WITH the canonical form. The seed and
+	 * the set of fields {@see getCanonicalJson()} covers are jointly the chain's
+	 * identity: change either and every previously stored hash stops being
+	 * re-derivable. ADR-003 Rule 4 therefore treats a change to either as a
+	 * migration event — verify under the outgoing form, record the verdict,
+	 * then re-seal — never an in-place edit.
+	 *
+	 * v1 → v2 (2026-08-28): the flow attribution fields joined the canonical
+	 * form so that re-pointing an audit row at a different flow run breaks
+	 * verification instead of going unnoticed. The v1 form is preserved in
+	 * {@see AuditCanonicalV1} solely so the migration could verify what it was
+	 * about to overwrite; see
+	 * {@see \OCA\OpenRegister\Migration\RechainAuditTrailForFlowAttribution}.
+	 *
 	 * @var string
 	 */
-	private const GENESIS_SEED = 'openregister-genesis-v1';
+	private const GENESIS_SEED = 'openregister-genesis-v2';
 
 	/**
 	 * Well-known advisory lock key serializing ALL seal passes.

--- a/lib/Service/Flow/FlowEngine.php
+++ b/lib/Service/Flow/FlowEngine.php
@@ -119,6 +119,10 @@ class FlowEngine {
 	 *                                              exactly as an empty registry does.
 	 * @param FlowTokenRouter|null $router Decides which exit a token takes.
 	 * @param FlowItemPlacement|null $placement Decides which items sit on which place.
+	 * @param FlowRunContext|null $runContext The ambient attribution stack. Nullable
+	 *                                       so the engine stays unit-testable without
+	 *                                       a container; absent, writes are simply
+	 *                                       unattributed rather than mis-attributed.
 	 */
 	public function __construct(
 		private readonly FlowDefinitionBuilder $builder,
@@ -130,6 +134,33 @@ class FlowEngine {
 	) {
 
 	}//end __construct()
+
+	/**
+	 * Open an attribution frame for the hop about to run.
+	 *
+	 * Split out of run() so the walk reads as the walk. The arithmetic is the
+	 * part worth keeping together: the step number is the run's sequence BASE
+	 * plus this hop's index in the segment log, and `recordSteps()` numbers the
+	 * same entries from the same base in the same order — so an attributed audit
+	 * row and its FlowRunStep row carry the same number. Deriving it from a
+	 * dispatch counter instead desynchronises the moment a step is PINNED, since
+	 * a pin logs an entry without ever reaching the dispatcher.
+	 *
+	 * @param array   $context The run context, carrying the run uuid and base.
+	 * @param string  $name    The node about to run.
+	 * @param integer $index   This hop's index within the segment's log.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/flow-engine/spec.md
+	 */
+	private function enterHop(array $context, string $name, int $index): void {
+		$this->runContext?->push(
+			runUuid: ($context[FlowRunContext::CONTEXT_RUN] ?? null),
+			nodeId: $name,
+			sequence: ((int)($context[FlowRunContext::CONTEXT_BASE] ?? 0) + $index)
+		);
+	}//end enterHop()
 
 	/**
 	 * The token router, made on demand when none was injected.
@@ -262,6 +293,16 @@ class FlowEngine {
 	 * @param string|null $startAt Node to start from; defaults to the flow's own start.
 	 *
 	 * @return array The run result: `{status, log: [], context: [], items: []}`.
+	 *
+	 * @SuppressWarnings(PHPMD.NPathComplexity) 226 against a threshold of 200, and the
+	 * 26 came from adding a `finally` to the hop. That `finally` is the attribution
+	 * safety property, not a convenience: every other exit from a hop is a `return`
+	 * inside a catch — a stop, a suspension, a terminally-failed step — so a pop on the
+	 * success path would leave the frame standing and attribute LATER writes, in a LATER
+	 * run advanced by the same worker, to a run that had already finished. That failure
+	 * is silent and produces well-formed rows. Restructuring the walk to win the metric
+	 * would trade a real correctness guarantee for a number; the branches themselves are
+	 * each one clearly-labelled outcome of a hop.
 	 *
 	 * @spec openspec/changes/or-flow-engine/specs/flow-engine/spec.md
 	 */
@@ -433,11 +474,7 @@ class FlowEngine {
 			// pinned step is not executed at all: it produces no writes, so it
 			// needs no frame, and skipping it costs nothing since the index is
 			// read from the log rather than counted per push.
-			$this->runContext?->push(
-				runUuid: ($context[FlowRunContext::CONTEXT_RUN] ?? null),
-				nodeId: $name,
-				sequence: ((int)($context[FlowRunContext::CONTEXT_BASE] ?? 0) + count($log))
-			);
+			$this->enterHop(context: $context, name: $name, index: count($log));
 
 			try {
 				// OVERSIGHT, before the hop. A veto is raised as a FlowStop so it

--- a/lib/Service/Flow/FlowEngine.php
+++ b/lib/Service/Flow/FlowEngine.php
@@ -126,6 +126,7 @@ class FlowEngine {
 		private readonly ?FlowOversightRegistry $oversight = null,
 		private readonly ?FlowTokenRouter $router = null,
 		private readonly ?FlowItemPlacement $placement = null,
+		private readonly ?FlowRunContext $runContext = null,
 	) {
 
 	}//end __construct()
@@ -416,6 +417,28 @@ class FlowEngine {
 				continue;
 			}//end if
 
+			// ATTRIBUTION, around the hop. Everything written from here until the
+			// matching pop is filed under this run and node — including writes
+			// made by code that has no idea a flow is running, which is the
+			// whole point (a node cannot report what it did not know it did).
+			//
+			// The step number is `base + count($log)`, and that is not an
+			// approximation: `recordSteps()` numbers this segment's entries from
+			// the same base in the same order, so an attributed audit row and
+			// its `FlowRunStep` row carry the SAME sequence. Deriving it from a
+			// dispatch counter instead would desynchronise the moment a step is
+			// PINNED — a pin logs an entry without ever reaching the dispatcher.
+			//
+			// Pushed here rather than around the pinned branch above because a
+			// pinned step is not executed at all: it produces no writes, so it
+			// needs no frame, and skipping it costs nothing since the index is
+			// read from the log rather than counted per push.
+			$this->runContext?->push(
+				runUuid: ($context[FlowRunContext::CONTEXT_RUN] ?? null),
+				nodeId: $name,
+				sequence: ((int)($context[FlowRunContext::CONTEXT_BASE] ?? 0) + count($log))
+			);
+
 			try {
 				// OVERSIGHT, before the hop. A veto is raised as a FlowStop so it
 				// travels the same path as an author's Stop step: the run ENDS.
@@ -514,6 +537,16 @@ class FlowEngine {
 				if ($outcome !== null) {
 					return $outcome;
 				}
+			} finally {
+				// 🔴 UNCONDITIONAL, and structurally so. Every other exit from
+				// this hop is a `return` inside a catch — a stop, a suspension,
+				// a failed step whose policy is terminal. A pop placed on the
+				// success path would leave the frame standing on all three, and
+				// the next write in the process — a LATER run advanced by the
+				// same worker — would be filed under a run that had already
+				// finished. Nothing about that row looks wrong, which is why it
+				// has to be impossible rather than merely remembered.
+				$this->runContext?->pop();
 			}//end try
 
 			// Which single exit this firing takes. A token is unique and

--- a/lib/Service/Flow/FlowNodeResumeState.php
+++ b/lib/Service/Flow/FlowNodeResumeState.php
@@ -65,6 +65,25 @@ final class FlowNodeResumeState {
 	}//end __construct()
 
 	/**
+	 * Which node this slot belongs to.
+	 *
+	 * A node is handed its own slot but was never told its own NAME, which is
+	 * fine while the only thing it does with the slot is read and write it.
+	 * It stops being fine as soon as a node has to hand its identity to
+	 * something OUTSIDE the run — a task record that must later resume this
+	 * exact node, for instance. A run accumulates one awaiting slot per node,
+	 * so "resume this run" is not an answer: the resumer has to name the node,
+	 * and it can only do that if the node could name itself.
+	 *
+	 * @return string This node's id within the flow graph.
+	 *
+	 * @spec openspec/specs/flow-engine/spec.md#requirement-a-node-must-be-able-to-resume-from-where-it-stopped
+	 */
+	public function nodeId(): string {
+		return $this->nodeId;
+	}//end nodeId()
+
+	/**
 	 * Whether this node has progress stored from an earlier pass.
 	 *
 	 * The question a resumed node should ask INSTEAD of `$context['resuming']`.

--- a/lib/Service/Flow/FlowRunAssignee.php
+++ b/lib/Service/Flow/FlowRunAssignee.php
@@ -1,0 +1,145 @@
+<?php
+
+/**
+ * Whose decision a suspended run is waiting on, and whether a given user is it.
+ *
+ * WHY THIS IS A SERVICE AND NOT A CONTROLLER METHOD. It began as one, guarding
+ * the HTTP resume endpoint, and that was enough while HTTP was the only way to
+ * answer a step. It is not: a leaf app whose own object completes a task resumes
+ * the run IN-PROCESS, through `FlowRunService::signal()`, which never passes the
+ * controller. Left where it was, every such caller would have to re-implement
+ * the rule.
+ *
+ * 🔴 AND RE-IMPLEMENTING IT IS THE FAILURE MODE. Two copies of one access rule
+ * do not stay identical, and the copy that drifts is the one nobody looks at. A
+ * divergence here does not throw — it lets the wrong person answer somebody
+ * else's question, correctly formatted, HTTP 200. Notably, the GROUP branch is
+ * the half a hand-written copy tends to forget, and forgetting it refuses the
+ * step's own intended audience while still reading as "the guard works",
+ * because refusing is what a guard does.
+ *
+ * SCOPE, STATED HONESTLY. This answers the WHO of an already-recorded
+ * assignment. It is not ADR-098's task entity, inbox or definition versioning.
+ * A step that records NO assignee is deliberately answerable by anyone —
+ * tightening that would break webhook and child-run signals, which are not
+ * human decisions at all — and callers must treat "unassigned" as permitted
+ * rather than as a missing check.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/flow-engine/spec.md#requirement-a-run-suspended-on-an-external-signal-must-be-reachable
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+use OCA\OpenRegister\Db\FlowRun;
+use OCP\IGroupManager;
+
+/**
+ * Reads a suspended run's recorded assignee and decides who may answer it.
+ *
+ * @spec openspec/specs/flow-engine/spec.md#requirement-a-run-suspended-on-an-external-signal-must-be-reachable
+ */
+class FlowRunAssignee {
+	/**
+	 * Constructor.
+	 *
+	 * @param IGroupManager|null $groupManager Resolves group membership. Nullable so the
+	 *                                         service stays constructible without a
+	 *                                         container; absent, a group assignment
+	 *                                         REFUSES rather than admits — the
+	 *                                         fail-closed direction.
+	 */
+	public function __construct(
+		private readonly ?IGroupManager $groupManager = null,
+	) {
+	}//end __construct()
+
+	/**
+	 * The assignee recorded by whichever step is currently awaiting an answer.
+	 *
+	 * Reads the per-node resume slots the node wrote. A run carries slots for
+	 * several nodes across its life, so the one that matters is a slot that
+	 * ASKED (`askedAt`) and has not been answered.
+	 *
+	 * @param FlowRun $run The suspended run.
+	 *
+	 * @return string The assignee uid or group id; '' when the step is unassigned.
+	 *
+	 * @spec openspec/specs/flow-engine/spec.md#requirement-a-run-suspended-on-an-external-signal-must-be-reachable
+	 */
+	public function recordedFor(FlowRun $run): string {
+		$context = ($run->getContext() ?? []);
+		$slots = ($context[FlowResumeState::CONTEXT_KEY] ?? []);
+		if (is_array($slots) === false) {
+			return '';
+		}
+
+		foreach ($slots as $slot) {
+			if (is_array($slot) === false) {
+				continue;
+			}
+
+			if (isset($slot['askedAt']) === false) {
+				continue;
+			}
+
+			$assignee = trim((string)($slot['assignee'] ?? ''));
+			if ($assignee !== '') {
+				return $assignee;
+			}
+		}
+
+		return '';
+	}//end recordedFor()
+
+	/**
+	 * Whether this user may answer the step the run is waiting on.
+	 *
+	 * @param FlowRun     $run The suspended run.
+	 * @param string|null $uid The acting user, or null when there is no session.
+	 *
+	 * @return boolean True when the answer may be accepted.
+	 *
+	 * @spec openspec/specs/flow-engine/spec.md#requirement-a-run-suspended-on-an-external-signal-must-be-reachable
+	 */
+	public function mayAnswer(FlowRun $run, ?string $uid): bool {
+		$assignee = $this->recordedFor(run: $run);
+
+		// Unassigned is deliberately open — see the class docblock. This is the
+		// one branch that must NOT be tightened without changing the spec.
+		if ($assignee === '') {
+			return true;
+		}
+
+		// Fail CLOSED: an assigned decision is never anonymous.
+		if ($uid === null || trim($uid) === '') {
+			return false;
+		}
+
+		if ($uid === $assignee) {
+			return true;
+		}
+
+		// The group branch. Absent a group manager this refuses rather than
+		// admits, which is the safe direction — and is why its absence must be
+		// visible in tests rather than inferred from a passing suite.
+		if ($this->groupManager !== null && $this->groupManager->isInGroup($uid, $assignee) === true) {
+			return true;
+		}
+
+		return false;
+	}//end mayAnswer()
+}//end class

--- a/lib/Service/Flow/FlowRunContext.php
+++ b/lib/Service/Flow/FlowRunContext.php
@@ -1,0 +1,177 @@
+<?php
+
+/**
+ * Which flow run, node and step is executing right now.
+ *
+ * A run already records what it DID, step by step ({@see \OCA\OpenRegister\Db\FlowRunStep}).
+ * It did not record what it did it TO: `FlowRun::$subjectUuid` names the object
+ * that TRIGGERED the run, and nothing named the objects the run went on to
+ * touch. This class is the missing half — it makes the executing step
+ * discoverable at the moment a write happens, so the audit row can name it.
+ *
+ * WHY AMBIENT RATHER THAN A PARAMETER. The point is to attribute writes made by
+ * code that has never heard of flows: a leaf app a node calls into, a cascade,
+ * a lifecycle hook. Threading attribution through `ObjectService` would capture
+ * only what a node explicitly passed, which is the same blind spot as recording
+ * touches at the node — the node cannot report what it did not know it did.
+ *
+ * WHY A STACK RATHER THAN A SCALAR. A sub-flow node dispatches a nested run.
+ * Popping to EMPTY at the end of that nested walk would leave the parent's
+ * remaining steps in the same dispatch unattributed — silently, because an
+ * unattributed row is well-formed and looks exactly like an ordinary one.
+ * Popping to the enclosing frame keeps both runs correctly attributed.
+ *
+ * 🔴 THE FAILURE MODE THIS CLASS HAS. A frame that is pushed and not popped
+ * attributes every LATER write in the process to a run that has already
+ * finished. `FlowRunWorker` advances several runs per process, so the damage
+ * crosses runs, not just steps. It produces no error and no wrong-looking row.
+ * That is why {@see \OCA\OpenRegister\Service\Flow\RegistryStepDispatcher}
+ * pops in a `finally` rather than on the success path, and why the test that
+ * matters asserts the LEAK direction — a non-flow write AFTER a run must be
+ * unattributed. A test that only checks the happy path passes with the leak
+ * present.
+ *
+ * This service MUST be registered as a shared instance. An auto-wired class in
+ * Nextcloud's container is constructed fresh per injection point, which would
+ * give the dispatcher and the audit mapper two different stacks and quietly
+ * attribute nothing at all.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+/**
+ * Holds the ambient attribution frame for the step currently being dispatched.
+ *
+ * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+ */
+class FlowRunContext {
+	/**
+	 * The context key carrying the executing run's uuid into the engine.
+	 *
+	 * @var string
+	 */
+	public const CONTEXT_RUN = 'x-openregister-attribution-run';
+
+	/**
+	 * The context key carrying the run's step-sequence base into the engine.
+	 *
+	 * Steps are numbered continuously across a resume, so a segment that starts
+	 * after a suspension must begin where the previous one stopped rather than
+	 * at zero. The base is read once before the walk and the engine adds each
+	 * hop's index to it, which is what makes an attributed audit row's step
+	 * number the SAME number the matching `FlowRunStep` row is given.
+	 *
+	 * @var string
+	 */
+	public const CONTEXT_BASE = 'x-openregister-attribution-base';
+
+	/**
+	 * The stack of attribution frames, innermost last.
+	 *
+	 * A frame is `['run' => string, 'node' => string, 'step' => int]`, or NULL
+	 * for a hop that is not attributable (see {@see push()}).
+	 *
+	 * @var array<int, array{run: string, node: string, step: int}|null>
+	 */
+	private array $frames = [];
+
+	/**
+	 * Enter a step: everything written from here until the matching pop is
+	 * attributed to this run, node and step.
+	 *
+	 * A null or empty `$runUuid` pushes an explicit NON-attributing frame
+	 * rather than pushing nothing. Two reasons, both about failure modes:
+	 *
+	 * - It keeps push and pop unconditionally paired, so the caller cannot
+	 *   unbalance the stack by taking a different branch on the way out than
+	 *   it took on the way in.
+	 * - It stops an unattributable inner hop from silently inheriting the
+	 *   ENCLOSING run's attribution, which would file a sub-flow's writes
+	 *   under its parent — wrong, and wrong in a way that reads as correct.
+	 *
+	 * @param string|null $runUuid  The uuid of the executing run, or null when the caller has no run (the flow tester, node unit tests).
+	 * @param string      $nodeId   The id of the node being dispatched.
+	 * @param integer     $sequence The step's sequence number within the run.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+	 */
+	public function push(?string $runUuid, string $nodeId, int $sequence): void {
+		if ($runUuid === null || trim($runUuid) === '') {
+			$this->frames[] = null;
+			return;
+		}
+
+		$this->frames[] = [
+			'run' => $runUuid,
+			'node' => $nodeId,
+			'step' => $sequence,
+		];
+	}//end push()
+
+	/**
+	 * Leave the innermost step, restoring the enclosing one if there is one.
+	 *
+	 * Popping an empty stack is deliberately NOT an error. This is called from
+	 * a `finally`, and a `finally` that can itself throw would replace the
+	 * exception the step actually failed with — turning a diagnosable node
+	 * failure into a confusing context-bookkeeping error.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+	 */
+	public function pop(): void {
+		array_pop($this->frames);
+	}//end pop()
+
+	/**
+	 * The frame to attribute a write to, or null when nothing is executing.
+	 *
+	 * @return array{run: string, node: string, step: int}|null The innermost frame, or null outside any run.
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+	 */
+	public function current(): ?array {
+		if ($this->frames === []) {
+			return null;
+		}
+
+		// The INNERMOST frame, even when it is null. A null innermost frame
+		// means "the hop currently executing is not attributable", and must not
+		// fall through to an enclosing run's frame.
+		return $this->frames[(count($this->frames) - 1)];
+	}//end current()
+
+	/**
+	 * How deep the stack is. Test and diagnostic use only.
+	 *
+	 * Exposed so a test can assert the stack is EMPTY after a step rather than
+	 * inferring it from an attribution being absent — an assertion that would
+	 * also pass if attribution were broken for some unrelated reason.
+	 *
+	 * @return integer The number of frames currently held.
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+	 */
+	public function depth(): int {
+		return count($this->frames);
+	}//end depth()
+}//end class

--- a/lib/Service/Flow/FlowRunService.php
+++ b/lib/Service/Flow/FlowRunService.php
@@ -267,10 +267,58 @@ class FlowRunService {
 		$context[FlowResumeState::CONTEXT_KEY] = FlowResumeState::fromArray(($context[FlowResumeState::CONTEXT_KEY] ?? null));
 		$context[FlowRunGuard::CONTEXT_KEY] = $guard;
 
+		// ATTRIBUTION. The engine files every write a hop causes under this run
+		// and node; these two values are what it needs to do it.
+		//
+		// The BASE is read here, BEFORE the walk, rather than in recordSteps()
+		// after it. Both have to arrive at the same number for an attributed
+		// audit row to line up with its FlowRunStep row, and only the pre-walk
+		// value is available while the writes are actually happening. Reading it
+		// twice is safe because a run advances in one worker at a time — the
+		// guard is what makes that true — so nothing appends steps to this run
+		// in between.
+		$context[FlowRunContext::CONTEXT_RUN] = (string)$run->getUuid();
+		$context[FlowRunContext::CONTEXT_BASE] = $this->stepSequenceBase(run: $run);
+
 		$this->flowState->attach(run: $run, context: $context);
 
 		return $context;
 	}//end nodeContextFor()
+
+	/**
+	 * The sequence number this walk's first recorded step will be given.
+	 *
+	 * Mirrors the arithmetic in {@see recordSteps()} deliberately: that method
+	 * numbers a segment from `highestSequence + 1`, so a hop's number is that
+	 * base plus its index within the segment's log. Attribution has to predict
+	 * the number rather than read it, because the audit rows are written DURING
+	 * the walk and the step rows only after it.
+	 *
+	 * A failure to read the base is not a reason to fail the run: attribution
+	 * degrades to numbering from zero, which is wrong only in its offset and
+	 * still orders a run's writes correctly.
+	 *
+	 * @param FlowRun $run The run about to be walked.
+	 *
+	 * @return integer The sequence the first step of this segment will carry.
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+	 */
+	private function stepSequenceBase(FlowRun $run): int {
+		if ($this->steps === null) {
+			return 0;
+		}
+
+		try {
+			return ($this->steps->highestSequence(runUuid: (string)$run->getUuid()) + 1);
+		} catch (Throwable $e) {
+			$this->logger->warning(
+				message: '[FlowRunService] Could not read the step sequence base for attribution: ' . $e->getMessage(),
+				context: ['file' => __FILE__, 'line' => __LINE__]
+			);
+			return 0;
+		}
+	}//end stepSequenceBase()
 
 
 	/**

--- a/lib/Service/Flow/FlowRunService.php
+++ b/lib/Service/Flow/FlowRunService.php
@@ -126,6 +126,22 @@ class FlowRunService {
 	}//end __construct()
 
 	/**
+	 * The run's step history — its numbering, and its recording.
+	 *
+	 * Made on demand rather than injected: this constructor is called explicitly
+	 * by three test suites, and inserting a parameter would silently shift every
+	 * later slot for them. It holds no state beyond the collaborators this
+	 * service already has.
+	 *
+	 * @return FlowStepHistory The history recorder.
+	 *
+	 * @spec openspec/changes/flow-engine-unification/specs/flow-execution-history/spec.md
+	 */
+	private function stepHistory(): FlowStepHistory {
+		return new FlowStepHistory(steps: $this->steps, logger: $this->logger);
+	}//end stepHistory()
+
+	/**
 	 * Make an unattributed refusal visible on the flow, and stop a dead schedule.
 	 *
 	 * A logged warning is not a control surface. `FlowDeadEnd` already learned
@@ -267,58 +283,16 @@ class FlowRunService {
 		$context[FlowResumeState::CONTEXT_KEY] = FlowResumeState::fromArray(($context[FlowResumeState::CONTEXT_KEY] ?? null));
 		$context[FlowRunGuard::CONTEXT_KEY] = $guard;
 
-		// ATTRIBUTION. The engine files every write a hop causes under this run
-		// and node; these two values are what it needs to do it.
-		//
-		// The BASE is read here, BEFORE the walk, rather than in recordSteps()
-		// after it. Both have to arrive at the same number for an attributed
-		// audit row to line up with its FlowRunStep row, and only the pre-walk
-		// value is available while the writes are actually happening. Reading it
-		// twice is safe because a run advances in one worker at a time — the
-		// guard is what makes that true — so nothing appends steps to this run
-		// in between.
+		// ATTRIBUTION. Read BEFORE the walk: the audit rows are written during
+		// it, so the base has to be predicted. See {@see FlowStepHistory}.
 		$context[FlowRunContext::CONTEXT_RUN] = (string)$run->getUuid();
-		$context[FlowRunContext::CONTEXT_BASE] = $this->stepSequenceBase(run: $run);
+		$context[FlowRunContext::CONTEXT_BASE] = $this->stepHistory()->baseFor(runUuid: (string)$run->getUuid());
 
 		$this->flowState->attach(run: $run, context: $context);
 
 		return $context;
 	}//end nodeContextFor()
 
-	/**
-	 * The sequence number this walk's first recorded step will be given.
-	 *
-	 * Mirrors the arithmetic in {@see recordSteps()} deliberately: that method
-	 * numbers a segment from `highestSequence + 1`, so a hop's number is that
-	 * base plus its index within the segment's log. Attribution has to predict
-	 * the number rather than read it, because the audit rows are written DURING
-	 * the walk and the step rows only after it.
-	 *
-	 * A failure to read the base is not a reason to fail the run: attribution
-	 * degrades to numbering from zero, which is wrong only in its offset and
-	 * still orders a run's writes correctly.
-	 *
-	 * @param FlowRun $run The run about to be walked.
-	 *
-	 * @return integer The sequence the first step of this segment will carry.
-	 *
-	 * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
-	 */
-	private function stepSequenceBase(FlowRun $run): int {
-		if ($this->steps === null) {
-			return 0;
-		}
-
-		try {
-			return ($this->steps->highestSequence(runUuid: (string)$run->getUuid()) + 1);
-		} catch (Throwable $e) {
-			$this->logger->warning(
-				message: '[FlowRunService] Could not read the step sequence base for attribution: ' . $e->getMessage(),
-				context: ['file' => __FILE__, 'line' => __LINE__]
-			);
-			return 0;
-		}
-	}//end stepSequenceBase()
 
 
 	/**
@@ -841,93 +815,6 @@ class FlowRunService {
 	 * @spec openspec/changes/or-flow-runs/specs/flow-runs/spec.md
 	 */
 
-	/**
-	 * Write one step row per node execution in this segment.
-	 *
-	 * The aggregate `log` column answers "what happened in this run" and
-	 * nothing else — "which node type fails", "every failed step for this
-	 * flow", "what did node X output" all require loading and walking every
-	 * run's blob. One row per hop makes those queryable, and gives retention
-	 * something it can prune per flow.
-	 *
-	 * Sequence CONTINUES from the highest already recorded rather than
-	 * restarting at zero, so a run that suspends on a wait node and resumes
-	 * later reads as one ordered history instead of two interleaved ones.
-	 *
-	 * Failing to record history must never fail the run itself: the run is the
-	 * work, the rows are the account of it.
-	 *
-	 * @param FlowRun $run The run these steps belong to.
-	 * @param array<int, mixed> $entries The engine log entries for this segment.
-	 *
-	 * @return void
-	 *
-	 * @spec openspec/changes/flow-engine-unification/specs/flow-execution-history/spec.md
-	 */
-	private function recordSteps(FlowRun $run, array $entries): void {
-		if ($this->steps === null || empty($entries) === true) {
-			return;
-		}
-
-		$runUuid = (string)$run->getUuid();
-
-		try {
-			$sequence = ($this->steps->highestSequence(runUuid: $runUuid) + 1);
-		} catch (Throwable $e) {
-			$this->logger->warning(
-				message: '[FlowRunService] Could not read the step sequence for run ' . $runUuid . ': ' . $e->getMessage(),
-				context: ['file' => __FILE__, 'line' => __LINE__]
-			);
-			return;
-		}
-
-		foreach ($entries as $entry) {
-			if (is_array($entry) === false) {
-				continue;
-			}
-
-			$step = new FlowRunStep();
-			$step->setRunUuid($runUuid);
-			$step->setFlowId((string)$run->getFlowId());
-			$step->setNodeId((string)($entry['transition'] ?? ''));
-			$step->setNodeType(($entry['type'] ?? null));
-			$step->setSequence($sequence);
-			$step->setStatus((string)($entry['status'] ?? 'unknown'));
-			$step->setDurationMs(($entry['durationMs'] ?? null));
-			$step->setCreated(new DateTime());
-			$step->setFinished(new DateTime());
-
-			// `error` and `reason` are distinct outcomes that both belong in
-			// the error column: a thrown step and a deliberately stopped one
-			// are each something a person needs to read back.
-			$step->setError(($entry['error'] ?? ($entry['reason'] ?? null)));
-
-			// What the node produced, minus the items themselves — a step row
-			// is an index into the run, not a second copy of its data.
-			$step->setOutput(
-				array_filter(
-					[
-						'itemsIn' => ($entry['itemsIn'] ?? null),
-						'itemsOut' => ($entry['itemsOut'] ?? null),
-						'checkId' => ($entry['checkId'] ?? null),
-					],
-					static fn ($v): bool => $v !== null
-				)
-			);
-
-			try {
-				$this->steps->insert($step);
-			} catch (Throwable $e) {
-				$this->logger->warning(
-					message: '[FlowRunService] Could not record a step row for run ' . $runUuid . ': ' . $e->getMessage(),
-					context: ['file' => __FILE__, 'line' => __LINE__]
-				);
-			}
-
-			$sequence++;
-		}//end foreach
-
-	}//end recordSteps()
 
 	/**
 	 * Write back what a walk produced.
@@ -949,7 +836,7 @@ class FlowRunService {
 		// Promote THIS segment's entries to step rows. Only the new entries —
 		// `$result['log']`, not the merged `$log` — or every resume would
 		// re-record the whole history it had already written.
-		$this->recordSteps(run: $run, entries: (array)($result['log'] ?? []));
+		$this->stepHistory()->record(run: $run, entries: (array)($result['log'] ?? []));
 
 		// The token travels as an object so steps can write to it; the column
 		// holds JSON. Serialising here — on the suspended path as much as the

--- a/lib/Service/Flow/FlowStepHistory.php
+++ b/lib/Service/Flow/FlowStepHistory.php
@@ -1,0 +1,187 @@
+<?php
+
+/**
+ * A run's step history: what number each step gets, and the rows themselves.
+ *
+ * Attribution has to PREDICT the step number rather than read it. Audit rows are
+ * written DURING the walk, while the step rows are recorded only after it — so
+ * by the time `recordSteps()` knows a step's sequence, every row that step
+ * caused has already been sealed.
+ *
+ * This mirrors the arithmetic in {@see FlowRunService::recordSteps()} on
+ * purpose: that method numbers a segment from `highestSequence + 1`, so a hop's
+ * number is that base plus its index within the segment's log. Both sides must
+ * arrive at the same value or an attributed audit row and its `FlowRunStep` row
+ * describe different steps — which is worse than no attribution, because it
+ * looks correct.
+ *
+ * Split out of FlowRunService when adding it pushed that class past its length
+ * and complexity ceilings. The better reason is that this is a rule worth
+ * testing directly, and it was not reachable from a test while it lived as a
+ * private method behind a full run.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+use DateTime;
+use OCA\OpenRegister\Db\FlowRun;
+use OCA\OpenRegister\Db\FlowRunStep;
+use OCA\OpenRegister\Db\FlowRunStepMapper;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Computes the step-sequence base for a walk about to start.
+ *
+ * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+ */
+class FlowStepHistory {
+	/**
+	 * Constructor.
+	 *
+	 * @param FlowRunStepMapper|null $steps  Reads the highest sequence already recorded.
+	 *                                       Null where history is not being recorded at
+	 *                                       all, in which case numbering starts at zero.
+	 * @param LoggerInterface|null   $logger Records a failed read.
+	 */
+	public function __construct(
+		private readonly ?FlowRunStepMapper $steps = null,
+		private readonly ?LoggerInterface $logger = null,
+	) {
+	}//end __construct()
+
+	/**
+	 * The sequence the first step of this segment will carry.
+	 *
+	 * Continues from the highest already recorded, so a run that suspended and
+	 * resumed days later reads as ONE ordered history rather than two
+	 * interleaved ones starting at zero.
+	 *
+	 * A failure to read is not a reason to fail the run: the work is the run,
+	 * and the numbering is the account of it. Attribution degrades to numbering
+	 * from zero — wrong only in its offset, and still correctly ordering the
+	 * run's writes among themselves.
+	 *
+	 * @param string $runUuid The run about to be walked.
+	 *
+	 * @return integer The base sequence.
+	 *
+	 * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+	 */
+	public function baseFor(string $runUuid): int {
+		if ($this->steps === null || trim($runUuid) === '') {
+			return 0;
+		}
+
+		try {
+			return ($this->steps->highestSequence(runUuid: $runUuid) + 1);
+		} catch (Throwable $e) {
+			$this->logger?->warning(
+				message: '[FlowStepHistory] Could not read the step sequence base for attribution: '
+					. $e->getMessage(),
+				context: ['file' => __FILE__, 'line' => __LINE__]
+			);
+
+			return 0;
+		}
+	}//end baseFor()
+
+	/**
+	 * Write one step row per node execution in this segment.
+	 *
+	 * The aggregate `log` column answers "what happened in this run" and
+	 * nothing else — "which node type fails", "every failed step for this
+	 * flow", "what did node X output" all require loading and walking every
+	 * run's blob. One row per hop makes those queryable, and gives retention
+	 * something it can prune per flow.
+	 *
+	 * Sequence CONTINUES from the highest already recorded rather than
+	 * restarting at zero, so a run that suspends on a wait node and resumes
+	 * later reads as one ordered history instead of two interleaved ones.
+	 *
+	 * Failing to record history must never fail the run itself: the run is the
+	 * work, the rows are the account of it.
+	 *
+	 * @param FlowRun $run The run these steps belong to.
+	 * @param array<int, mixed> $entries The engine log entries for this segment.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-engine-unification/specs/flow-execution-history/spec.md
+	 */
+	public function record(FlowRun $run, array $entries): void {
+		if ($this->steps === null || empty($entries) === true) {
+			return;
+		}
+
+		$runUuid = (string)$run->getUuid();
+
+		// The SAME computation the attribution used before the walk. One method,
+		// so the number an audit row was stamped with and the number its step row
+		// is given cannot drift apart.
+		$sequence = $this->baseFor(runUuid: $runUuid);
+
+		foreach ($entries as $entry) {
+			if (is_array($entry) === false) {
+				continue;
+			}
+
+			$step = new FlowRunStep();
+			$step->setRunUuid($runUuid);
+			$step->setFlowId((string)$run->getFlowId());
+			$step->setNodeId((string)($entry['transition'] ?? ''));
+			$step->setNodeType(($entry['type'] ?? null));
+			$step->setSequence($sequence);
+			$step->setStatus((string)($entry['status'] ?? 'unknown'));
+			$step->setDurationMs(($entry['durationMs'] ?? null));
+			$step->setCreated(new DateTime());
+			$step->setFinished(new DateTime());
+
+			// `error` and `reason` are distinct outcomes that both belong in
+			// the error column: a thrown step and a deliberately stopped one
+			// are each something a person needs to read back.
+			$step->setError(($entry['error'] ?? ($entry['reason'] ?? null)));
+
+			// What the node produced, minus the items themselves — a step row
+			// is an index into the run, not a second copy of its data.
+			$step->setOutput(
+				array_filter(
+					[
+						'itemsIn' => ($entry['itemsIn'] ?? null),
+						'itemsOut' => ($entry['itemsOut'] ?? null),
+						'checkId' => ($entry['checkId'] ?? null),
+					],
+					static fn ($v): bool => $v !== null
+				)
+			);
+
+			try {
+				$this->steps->insert($step);
+			} catch (Throwable $e) {
+				$this->logger->warning(
+					message: '[FlowStepHistory] Could not record a step row for run ' . $runUuid . ': ' . $e->getMessage(),
+					context: ['file' => __FILE__, 'line' => __LINE__]
+				);
+			}
+
+			$sequence++;
+		}//end foreach
+
+	}//end record()
+}//end class

--- a/openspec/changes/flow-object-attribution/.openspec.yaml
+++ b/openspec/changes/flow-object-attribution/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-28

--- a/openspec/changes/flow-object-attribution/design.md
+++ b/openspec/changes/flow-object-attribution/design.md
@@ -1,0 +1,103 @@
+## Context
+
+See `proposal.md — Why`. The constraints that shape the approach:
+
+- **The audit trail is hash-chained (ADR-003).** `AuditHashService::getCanonicalJson()` hashes `AuditTrail::jsonSerialize()` minus `hash`/`previousHash`. Adding a key to that serialisation changes the canonical form of every row ever written. This is the reason `purgedAt` was deliberately left OUT of the hash, with the residual weakness documented in `AuditHashService` (~line 1074).
+- **Both audit insert paths share one builder.** `createAuditTrail()` and the batched `insertAuditTrails()` both go through `buildAuditTrail()`. A stamp applied to the insert methods rather than the builder would silently miss every batched write.
+- **`FlowRun` already carries `subjectUuid`** — the trigger's object. It is not a record of what the run touched and must not be confused with one.
+- **`AuditHashService` already has what a re-seal needs**: `rechainAll()` (batched), `sealRows()`, an advisory lock serialising seal passes, and tombstone-aware verification.
+- **A run is not one process.** `FlowRunWorker` advances several runs in sequence, and a suspended run resumes in a later process entirely. Anything process-global must be scoped per step, not per request.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Attribution that captures writes made by code that has never heard of flows.
+- One place that decides whether a write is attributed, so the answer cannot differ per call site.
+- A seed migration that cannot silently convert a tampered chain into a verified one.
+
+**Non-Goals:**
+- Re-attributing history. Rows written before this change stay unattributed; there is no inference pass.
+- Attribution for non-OpenRegister side effects (an email sent, a webhook posted). Those are `FlowRunStep.output`'s job.
+- The dossiq flow itself, and the human-task model — companion change `case-flow-human-steps`.
+- Making `purgedAt` hash-covered. It stays out; this change does not reopen it.
+
+## Decisions
+
+### D1 — Ambient context, not a parameter
+
+A `FlowRunContext` service holds the current `(runUuid, nodeId, sequence)`. `RegistryStepDispatcher::dispatch()` pushes before the step and pops in a `finally`.
+
+*Why:* the whole point is to catch writes the writing code does not know are part of a flow — a leaf app called by a node, a cascade, a lifecycle hook. Threading a parameter through `ObjectService` would attribute only what a node explicitly passed, which is the same blind spot as the link-table option that was rejected.
+
+*Alternative rejected:* passing attribution down `SaveObject`/`DeleteObject` signatures. Wider blast radius (every caller of a changed signature — and a new argument breaks positional callers one slot later), and still blind to leaf-app writes.
+
+*Shape:* a **stack**, not a scalar. A sub-flow node dispatches a nested run; popping must restore the parent's frame rather than clear to empty, or the parent's remaining steps in that same dispatch go unattributed.
+
+### D2 — Stamp in `buildAuditTrail()`
+
+One read of the context, in the shared builder, so single and batched inserts are identical. `createAuditTrailEntry()` (archival/retention entries) and `createToolInvocationEntry()` (MCP) get the same treatment for consistency.
+
+*Consequence, accepted:* `GetObject` writes a `read` audit row, so reads performed during a run are attributed too. This is more truthful than filtering them out — the run did touch the object. The read surface exposes `action`, so a caller wanting writes only can say so.
+
+### D3 — Inside the hash, with a v2 seed and a full re-chain
+
+Per the decision recorded on this change: the three fields join the canonical JSON, `GENESIS_SEED` becomes `openregister-genesis-v2`, and `rechainAll()` re-seals the table. Attribution is therefore tamper-evident — re-pointing a row at a different run breaks verification.
+
+*Alternatives rejected:* excluding the keys from the canonical form (the `purgedAt` precedent) would ship with zero risk to the existing chain but leaves attribution unprotected; emitting the keys only when set would preserve old rows byte-identically but introduces an omit-when-null rule in the canonicaliser.
+
+### D4 — The pre-migration check uses a FROZEN v1 canonicaliser
+
+This is the decision that makes D3 safe, and it is the one that is easy to get wrong.
+
+The migration must verify the chain **before** re-sealing it. If that verification canonicalises with the new code, it includes the new keys, every pre-existing row mismatches, and the verdict is "broken" whether the chain was healthy or compromised. The re-chain then overwrites the evidence either way. The check would run, produce output, and be worthless.
+
+So the migration carries `AuditCanonicalV1` — a frozen, private copy of the v1 key list and canonicalisation rules, never updated again. The pre-check verifies against it, and its verdict is written as an audit row (action `audit.rechain.preverify`, sealed under v1 as the last v1 row) recording `valid`, `entriesVerified`, `brokenAt`, and the seed version moved from/to.
+
+**Test the check by breaking the thing it checks**: seed a chain, tamper with one row, run the migration, and assert the recorded verdict names that row. A test that only seeds a healthy chain passes identically when the pre-check is a stub returning `valid: true`.
+
+### D5 — A stamp, not a foreign key
+
+`flow_run` is a plain string column with no referential link. `FlowRunRetentionJob` prunes runs; a FK would either block pruning or cascade into immutable audit rows. Reading an object's history must not fail because the run has been pruned — the identifiers are the historical fact, and resolving them to a live run is best-effort.
+
+### D6 — Index for the run direction
+
+`(flow_run)` alone is enough for "what did this run touch"; the object direction is already served by the existing `object_uuid` index. No composite index until a query needs one — ADR-009 treats speculative indexes on the audit hot path as a cost, not a hedge.
+
+## Declarative-vs-imperative decision (ADR-031)
+
+| Behaviour | Path | Rationale |
+|---|---|---|
+| Stamping attribution onto audit rows | **imperative** | Engine and persistence internals in OpenRegister core. There is no app schema here and no `x-openregister-*` extension that expresses "attribute the ambient run onto the audit row" — this is the mechanism such declarations would be recorded BY. |
+| Canonicalisation and re-seal | **imperative** | Cryptographic integrity operation, migration-time. |
+| Read surfaces (run → objects, object → runs) | **imperative** | A query filter and a controller endpoint over a native (non-OR-object) table; `flow_runs` and `audit_trails` are native tables by design (`flow-storage`). |
+
+No part of this change introduces or modifies an OpenRegister schema, so it declares no lifecycle, aggregation, calculation, notification, relation or widget.
+
+## Seed Data (ADR-001)
+
+**None.** This change adds no OpenRegister schemas and no register objects, so there is no `_registers.json` entry to generate. Attribution rows are produced by running a flow, not by seeding. The demonstrable data for this change is a flow run in the companion dossiq change; a seeded audit row would be a fabricated record of something that never happened, which is precisely what an immutable audit trail must not contain.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| **A context left in place attributes later, unrelated writes to a finished run.** Silent: the rows are well-formed and plausible. | Push/pop in `finally`. The test that matters asserts the LEAK direction — perform a non-flow write after a run and require the columns to be null. A happy-path test passes with the leak present. |
+| **The re-chain re-blesses history.** Once re-sealed under v2, any tampering that predates the migration is undetectable, permanently. | Accepted deliberately (D3). D4's pre-check plus its persisted verdict is the compensating control: the state of the chain at migration time survives the migration that erases the ability to re-derive it. |
+| **Rollback is not available.** Reverting the code does not restore v1 hashes; the v1 values are overwritten in place. | Treat as a one-way migration. Require a database backup before the release, state it in the upgrade note, and make the migration refuse to start if it cannot write its pre-verify verdict. |
+| **Mixed code versions during a rolling deploy** would seal some rows under v1 and some under v2, interleaved. | The existing advisory seal lock serialises seal passes; the migration runs to completion within one release step, and the seed version is read from one constant rather than per-row. |
+| **A long re-chain on a large audit table** blocks the upgrade. | `rechainAll()` already batches; the migration is resumable and idempotent (spec scenario) so an interrupted upgrade continues rather than restarts. |
+| **Attribution widens what an audit row discloses** — it names a run and node a reader might not otherwise see. | Attribution is returned only on rows the caller may already read; the run→objects endpoint reuses the run visibility rule that `resume()` applies rather than inventing a second one. A validator and an executor each owning a copy of the same rule is how they drift apart. |
+| **`FlowRunWorker` advances several runs per process**, so a leak crosses runs, not just steps. | Same `finally`; plus a test that runs two runs in sequence in one process and asserts the second's writes carry the second's run uuid. |
+
+## Migration Plan
+
+1. **Schema migration** — add `flow_run`, `flow_node`, `flow_step` to `oc_openregister_audit_trails`, plus the `flow_run` index. Nullable; no backfill.
+2. **Repair step, registered in `appinfo/info.xml` in the same commit.** (A repair step written but never registered does nothing and reports nothing — four apps in the fleet were found in that state.) In order: pre-verify against `AuditCanonicalV1` → persist the verdict as a v1-sealed audit row → `rechainAll()` under the v2 seed.
+3. **Code cutover** — `jsonSerialize()` emits the three keys; `GENESIS_SEED` is `openregister-genesis-v2`.
+4. **Post-check** — `verifyChain()` under v2 returns `valid: true` over the full table.
+
+**Rollback:** none for step 2/3 (see Risks). Steps 1 and 4 are reversible; the re-seal is not.
+
+## Open Questions
+
+- Whether the run→objects endpoint should page. Deferred: it does not change the specs, the approach or the task breakdown, and the shape of real runs will answer it. The first consumer (a case flow with ~12 nodes) is far below any page boundary.

--- a/openspec/changes/flow-object-attribution/proposal.md
+++ b/openspec/changes/flow-object-attribution/proposal.md
@@ -1,0 +1,46 @@
+---
+kind: code
+---
+
+## Why
+
+A flow run records exactly one object: `FlowRun.subjectUuid`, the thing that triggered it. Everything the run goes on to touch — the objects it creates, the ones its nodes update, the ones a leaf app writes on its behalf — is recorded nowhere. So neither of the two questions people actually ask can be answered today:
+
+- **From the object:** "which run, and which node of it, last touched this case?"
+- **From the run:** "what did this run actually change?"
+
+`FlowRunStep` already answers *what happened* per node. It does not answer *what it happened to*. That gap is why a flow that spans a case, its tasks, its decisions and its documents is unauditable in practice: the history exists, and it points at nothing.
+
+## What Changes
+
+- Every audit-trail row written while a flow run is executing is stamped with the run uuid, the node id and the step sequence that caused it. The stamp is set from an **ambient run context** established by the step dispatcher, so it captures writes made by code that has never heard of flows — including leaf apps a node calls into. A node-level record would see only what the node itself knew it wrote.
+- Two read directions: `GET /api/flow-runs/{uuid}/objects` (objects touched, grouped by node) and a `flowRun` filter plus the three new fields on the existing audit-trail query.
+- **BREAKING (audit chain):** the three keys join the canonical JSON that the hash chain covers, so the stamp is tamper-evident. Per ADR-003 Rule 4 this is a migration event: the genesis seed moves to `v2` and the table is re-sealed by the existing `AuditHashService::rechainAll()`.
+- The re-chain is **verify-then-rechain**. The migration first verifies the existing chain against a *frozen copy* of the v1 canonicaliser and persists that verdict, then re-seals under v2. Without the frozen copy the pre-check would canonicalise under v2, report every row broken, and the re-chain would bless it anyway — a check that cannot distinguish a healthy chain from a tampered one is not a check.
+- UI: the objects a run touched on the run detail, and the runs that touched an object in its sidebar.
+
+## Capabilities
+
+### New Capabilities
+- `flow-object-attribution`: what a flow run records about the objects it touches — the ambient run context and its lifecycle, what a stamped row means, and how the attribution is read back from either end.
+
+### Modified Capabilities
+- `audit-hash-chain`: the canonical JSON gains three flow keys and the genesis seed is versioned; adds the requirement that a seed change is a verify-then-rechain migration with the outgoing canonicaliser frozen for the verification.
+- `flow-engine`: the step dispatcher establishes and unconditionally clears the run context around every step, and a run can report the objects it touched.
+
+## Impact
+
+| Area | Change |
+|---|---|
+| `lib/Db/AuditTrail.php` | three fields + `jsonSerialize()` keys (hash-covered) |
+| `lib/Db/AuditTrailMapper.php` | both insert paths read the ambient context; `flowRun` query filter |
+| `lib/Service/AuditHashService.php` | seed becomes `v2`; frozen `v1` canonicaliser retained for migration verification |
+| `lib/Service/Flow/RegistryStepDispatcher.php` | establishes / clears the context per step |
+| `lib/Service/Flow/FlowRunContext.php` | new — the ambient holder |
+| `lib/Controller/FlowRunController.php` | `objects` endpoint |
+| `lib/Migration/` | columns + index; verify-then-rechain repair step |
+| Frontend | run detail "objects touched"; object sidebar "flow runs" |
+
+**Risk owned by this change:** a context that is not cleared attributes later, unrelated writes to a finished run. It is silent — the rows look correct. The clear is `finally`-bound and asserted by a test that performs a non-flow write *after* a run and requires the columns to be null.
+
+**Consumers:** dossiq is the first, via the companion `case-flow-human-steps` change. Nothing in this change is dossiq-specific.

--- a/openspec/changes/flow-object-attribution/specs/audit-hash-chain/spec.md
+++ b/openspec/changes/flow-object-attribution/specs/audit-hash-chain/spec.md
@@ -1,0 +1,68 @@
+## MODIFIED Requirements
+
+### Requirement: Every audit trail entry MUST include a SHA-256 hash chained to the previous entry
+Each audit trail entry MUST contain a `hash` field computed as `SHA-256(previous_hash + canonical_json(entry_data))`. The `previous_hash` field links to the preceding entry's hash, forming a tamper-evident chain.
+
+The genesis seed is versioned. The current seed is `openregister-genesis-v2`, which supersedes `openregister-genesis-v1`; the version reflects the canonical form the chain commits to, and the two MUST move together.
+
+The canonical form covers the flow attribution fields — the run, node and step that caused the row — so that re-pointing a row at a different run, or stripping its attribution, breaks verification exactly as altering any other field does.
+
+#### Scenario: First audit entry uses genesis hash
+- **WHEN** the first audit trail entry is created in the system (no previous entries exist)
+- **THEN** the entry MUST have `previousHash` set to `SHA-256("openregister-genesis-v2")`
+- **AND** the entry MUST have `hash` set to `SHA-256(genesis_hash + canonical_json(entry_data))`
+
+#### Scenario: Subsequent entries chain to previous hash
+- **WHEN** audit trail entry N is created after entry N-1 with hash `abc123...`
+- **THEN** entry N MUST have `previousHash` set to `abc123...`
+- **AND** entry N MUST have `hash` set to `SHA-256("abc123..." + canonical_json(entry_data_N))`
+
+#### Scenario: Canonical JSON excludes hash fields
+- **WHEN** computing the hash for an audit trail entry
+- **THEN** the canonical JSON MUST include all entry fields except `hash` and `previousHash`
+- **AND** the JSON MUST use sorted keys and no whitespace (compact canonical form)
+
+#### Scenario: Flow attribution is covered by the hash
+- **WHEN** a row's recorded run, node or step is altered directly in the database
+- **AND** the chain is verified
+- **THEN** verification MUST report the chain as broken at that row
+
+## ADDED Requirements
+
+### Requirement: Changing the canonical form is a verify-then-rechain migration @e2e exclude migration-time integrity operation with no user-facing surface; asserted by migration tests over seeded chains
+
+A change to the canonical form or the genesis seed SHALL be performed as a single migration that, in order:
+
+1. verifies the existing chain **against the canonical form the existing rows were sealed under**, not the incoming one;
+2. durably records that verdict — whether the chain was intact, and if not, where it first broke — before any row is altered;
+3. re-seals every row under the new seed and canonical form.
+
+The verification in step 1 SHALL use a frozen copy of the outgoing canonicaliser retained in the codebase for that purpose. Verifying with the incoming canonicaliser would report every pre-existing row as broken regardless of whether it had been tampered with, making the verdict indistinguishable between a healthy chain and a compromised one — and a re-chain then permanently conceals the difference.
+
+The recorded verdict SHALL be readable after the migration completes. A re-chain over a chain that did not verify is permitted, but SHALL NOT be silent.
+
+#### Scenario: An intact chain is re-sealed and recorded as intact
+- **WHEN** the migration runs against a chain that verifies under the outgoing canonical form
+- **THEN** the verdict recorded before re-sealing states the chain was intact and names the number of rows verified
+- **AND** every row is afterwards sealed under the new seed
+- **AND** verification under the new canonical form succeeds
+
+#### Scenario: A broken chain is recorded before it is re-sealed over
+- **WHEN** the migration runs against a chain that does NOT verify under the outgoing canonical form
+- **THEN** the recorded verdict states the chain was broken and identifies where
+- **AND** that verdict remains readable after the re-seal has made the break undetectable
+
+#### Scenario: The pre-check uses the outgoing canonical form
+- **WHEN** the pre-migration verification runs
+- **THEN** it computes canonical JSON without the fields the migration is introducing
+- **AND** a chain sealed before the migration verifies as intact
+
+#### Scenario: Re-sealing is resumable and idempotent
+- **WHEN** the migration is interrupted part-way and re-run
+- **THEN** it completes the re-seal without double-sealing rows already migrated
+- **AND** the final chain verifies end to end
+
+#### Scenario: Tombstoned rows survive the re-seal as tombstones
+- **WHEN** the chain being re-sealed contains rows purged under retention
+- **THEN** those rows are carried forward as declared tombstones
+- **AND** the re-sealed chain does not report them as breaks

--- a/openspec/changes/flow-object-attribution/specs/flow-engine/spec.md
+++ b/openspec/changes/flow-object-attribution/specs/flow-engine/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: The dispatcher establishes and unconditionally clears the run context around every step @e2e exclude engine-internal execution context; asserted by dispatcher unit tests including the leak-direction test
+
+Before dispatching a step, the engine SHALL establish an ambient context naming the executing run, the node being dispatched, and the step's sequence number. After the step ends the engine SHALL clear that context, and SHALL do so whether the step completed, stopped, suspended, or threw.
+
+A context left in place after a step attributes later, unrelated writes to a run that is no longer executing. This failure is silent — the resulting rows are well-formed and look correct — so the clear SHALL be structurally unconditional rather than placed on the success path.
+
+Nested dispatch SHALL restore the enclosing context rather than clearing it: a sub-flow's steps are attributed to the sub-flow's run, and the parent run's remaining steps are attributed to the parent.
+
+#### Scenario: The context names the step being dispatched
+- **WHEN** the engine dispatches a node
+- **THEN** the ambient context names that run, that node id, and that step's sequence
+
+#### Scenario: A throwing step still clears the context
+- **WHEN** a dispatched node throws
+- **THEN** the context is cleared before control leaves the dispatcher
+- **AND** a write performed afterwards outside any run is unattributed
+
+#### Scenario: A suspended step clears the context
+- **WHEN** a node suspends the run to await a signal or a time
+- **THEN** the context is cleared
+- **AND** the run's later resumption establishes a fresh context for the step it resumes into
+
+#### Scenario: A sub-flow does not leak into its parent
+- **WHEN** a node dispatches a sub-flow run and that sub-flow completes
+- **THEN** writes during the sub-flow are attributed to the sub-flow's run and nodes
+- **AND** the parent run's subsequent steps are attributed to the parent run
+
+### Requirement: A run's history names what each step touched @e2e exclude read model asserted by controller and store tests
+
+The objects a run touched SHALL be readable alongside the run's step history, so that a reader following a run can see, per node, both what the node did and what it did it to. The step history SHALL remain the record of execution; the attribution SHALL be joined to it by run, node and step rather than duplicated into it.
+
+#### Scenario: A step's entry can be expanded to the objects it touched
+- **WHEN** a reader views a run's step history
+- **THEN** each step can be related to the objects attributed to that run and node
+- **AND** a step that touched nothing is shown as such rather than omitted
+
+#### Scenario: The step history remains authoritative for execution
+- **WHEN** attribution for a step is absent because no write occurred
+- **THEN** the step is still present in the history with its own status and timing

--- a/openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+++ b/openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
@@ -1,0 +1,90 @@
+## Purpose
+
+Defines what a flow run records about the objects it touches. A run already records what it DID, step by step; this capability makes it record what it did it TO, so an object can name the run and node that changed it and a run can list everything it changed.
+
+## ADDED Requirements
+
+### Requirement: Every object write caused by a flow run is attributed to that run, node and step @e2e exclude write-path attribution asserted by AuditTrailMapper + dispatcher integration tests; no user-facing surface performs the write
+
+While a flow run is executing a step, every audit-trail row produced by any write SHALL carry the executing run's uuid, the node id, and the step sequence number. The attribution SHALL be ambient — derived from the executing run rather than passed by the writing code — so that a write performed by code with no knowledge of flows, including another app called into by a node, is attributed identically to a write performed by the node itself.
+
+A row written outside any flow run SHALL carry no attribution: the three values SHALL be absent, and absence SHALL be distinguishable from a run whose identifiers are empty strings.
+
+#### Scenario: A node's own write is attributed
+- **WHEN** a flow run executes a node that writes an object
+- **THEN** the resulting audit-trail row names the run uuid, that node's id, and that step's sequence number
+
+#### Scenario: A write made by another app during the step is attributed
+- **WHEN** a node calls into another app, and that app writes an object during the step
+- **THEN** the resulting audit-trail row carries the same run, node and step as the node's own writes
+- **AND** the writing app is not required to know it is running inside a flow
+
+#### Scenario: A write outside any run is unattributed
+- **WHEN** an object is written by a user action, an import, or a background job with no flow run executing
+- **THEN** the resulting audit-trail row has no run, node or step value
+
+#### Scenario: Attribution does not survive the step that established it
+- **WHEN** a flow run finishes, fails, or suspends
+- **AND** any object is subsequently written in the same process
+- **THEN** that write is unattributed
+- **AND** this holds when the step ended by throwing, not only when it ended normally
+
+#### Scenario: Two runs writing the same object are separately attributed
+- **WHEN** two different flow runs each write the same object
+- **THEN** each write produces its own audit-trail row naming its own run and node
+- **AND** neither row's attribution is overwritten by the other
+
+### Requirement: A run reports the objects it touched, grouped by node @e2e exclude read surface covered by controller tests; the UI consuming it is specified under flow-engine
+
+The system SHALL expose the objects a run touched, addressed by run uuid, grouped by the node that touched each. Each entry SHALL name the object, the action performed on it, the node, and the step sequence, so a reader can reconstruct the order in which the run changed things.
+
+The response SHALL be scoped by the same visibility rule that governs reading the run itself. A caller who may not read a run SHALL NOT learn what it touched.
+
+#### Scenario: A completed run lists what it changed
+- **WHEN** a caller who may read a run requests the objects it touched
+- **THEN** the response lists every object the run wrote, grouped by node, in step order
+
+#### Scenario: A run that touched nothing returns an empty result
+- **WHEN** a run completed without writing any object
+- **THEN** the response is an empty collection and not an error
+
+#### Scenario: Visibility is not widened by the new surface
+- **WHEN** a caller who may NOT read a run requests the objects it touched
+- **THEN** the request is refused
+- **AND** the refusal does not reveal whether the run exists or what it touched
+
+#### Scenario: A suspended run reports what it has touched so far
+- **WHEN** a run is suspended awaiting a signal
+- **THEN** the objects touched by the steps already executed are reported
+- **AND** the result is not withheld until the run completes
+
+### Requirement: An object reports the flow runs that touched it @e2e exclude query-layer filter; asserted by audit-trail query tests
+
+The audit-trail query SHALL accept a run uuid as a filter, and audit-trail records SHALL expose their run, node and step values to readers permitted to read them. Reading the history of a single object SHALL therefore answer which run and which node caused each change, without a separate lookup.
+
+#### Scenario: An object's history names the responsible node
+- **WHEN** an object's audit history is read after a flow run changed it
+- **THEN** each row caused by the run names that run, the node, and the step
+
+#### Scenario: Filtering by run returns only that run's writes
+- **WHEN** the audit trail is queried filtered by a run uuid
+- **THEN** only rows attributed to that run are returned
+
+#### Scenario: Attribution is visible only to readers of the row
+- **WHEN** a caller reads an audit-trail record they are permitted to read
+- **THEN** the run, node and step values are present
+- **AND** no attribution is disclosed for records the caller may not read
+
+### Requirement: Attribution outlives the run record but never claims more than it knows @e2e exclude retention interaction; asserted by retention job tests
+
+The attribution SHALL be stored as a plain identifier stamp rather than a referential link, so that pruning a run under retention does not alter, delete, or invalidate the audit rows it caused. A stamp naming a run that no longer exists SHALL remain readable as a historical fact.
+
+#### Scenario: Pruning a run leaves its attribution intact
+- **WHEN** flow-run retention deletes a run and its steps
+- **THEN** audit rows attributed to that run keep their run, node and step values
+- **AND** the hash chain over those rows still verifies
+
+#### Scenario: A dangling run reference reads as history, not as an error
+- **WHEN** an object's history names a run that has since been pruned
+- **THEN** the reader is shown the recorded identifiers
+- **AND** the response does not fail because the run cannot be resolved

--- a/openspec/changes/flow-object-attribution/tasks.md
+++ b/openspec/changes/flow-object-attribution/tasks.md
@@ -1,0 +1,51 @@
+## 1. Storage
+
+- [ ] 1.1 Add `flow_run`, `flow_node`, `flow_step` (nullable) plus a `flow_run` index to `oc_openregister_audit_trails` in a new `lib/Migration/Version1Date*.php`; verify `occ migrations:execute` applies and the columns exist on MySQL, PostgreSQL and SQLite
+- [ ] 1.2 Add the three fields to `AuditTrail` with getters/setters and `addType()` registration; verify a hydrated row round-trips the values through the mapper
+
+## 2. Ambient run context
+
+- [ ] 2.1 Add `lib/Service/Flow/FlowRunContext.php` holding a STACK of `(runUuid, nodeId, sequence)` frames with `push()`, `pop()` and `current()`; verify unit tests cover empty, single and nested frames
+- [ ] 2.2 Push in `RegistryStepDispatcher::dispatch()` before the step and pop in a `finally`; verify a test asserts the context is empty after a step that THROWS, not only after one that succeeds
+- [ ] 2.3 Verify the leak direction end to end: run a flow, then perform a non-flow object write in the same process, and assert the resulting audit row's three columns are null — this test must fail if the `finally` is removed
+- [ ] 2.4 Verify the two cross-run isolation cases: a sub-flow restores its parent frame (its writes name the sub-flow, the parent's next step names the parent), and two runs advanced sequentially by one `FlowRunWorker` process each attribute to their own run uuid
+
+## 3. Stamping
+
+- [ ] 3.1 Read `FlowRunContext::current()` in `AuditTrailMapper::buildAuditTrail()` and stamp the three fields; verify BOTH `createAuditTrail()` and the batched `insertAuditTrails()` produce stamped rows from the one change
+- [ ] 3.2 Apply the same stamp in `createAuditTrailEntry()` and `createToolInvocationEntry()`; verify a retention entry written during a run is attributed, and that a write made by a leaf app called from inside a node is stamped identically to the node's own write without that app referencing any flow API
+
+## 4. Hash chain (ADR-003 Rule 4)
+
+- [ ] 4.1 Add the three keys to `AuditTrail::jsonSerialize()` and move `GENESIS_SEED` to `openregister-genesis-v2`; verify a freshly seeded chain verifies end to end under v2
+- [ ] 4.2 Add `AuditCanonicalV1` — a frozen private copy of the v1 key list and canonicalisation rules, marked never-to-be-updated; verify it reproduces the stored hash of a row sealed before this change
+- [ ] 4.3 Verify tampering with `flow_run`, `flow_node` or `flow_step` on a sealed row makes `verifyChain()` report a break at that row
+
+## 5. Verify-then-rechain migration
+
+- [ ] 5.1 Add the repair step (pre-verify against `AuditCanonicalV1` → persist verdict as a v1-sealed `audit.rechain.preverify` row → `rechainAll()` under v2) AND register it in `appinfo/info.xml` in the same commit; verify `occ maintenance:repair` runs it and the registration is present
+- [ ] 5.2 Verify the pre-check discriminates: seed a chain, tamper with one row, run the migration, and assert the persisted verdict names that row — the test must fail if the pre-check is stubbed to return valid
+- [ ] 5.3 Verify the migration's three safety properties: it refuses to start when it cannot persist its verdict, it is resumable and idempotent when interrupted mid-re-seal, and a chain containing retention tombstones re-seals with those rows carried forward as tombstones rather than reported as breaks
+
+## 6. Read surfaces
+
+- [ ] 6.1 Add `GET /api/flow-runs/{uuid}/objects` returning objects grouped by node with action and step, reusing the visibility rule `FlowRunController::resume()` applies; verify a caller who may not read the run is refused without learning the run exists, a suspended run reports what it has touched so far, and a run that wrote nothing returns an empty collection rather than an error
+- [ ] 6.2 Add a `flowRun` filter to the audit-trail query and expose the three fields in the audit-trail serialisation; verify filtering returns only that run's rows and a pruned run's rows still read
+
+## 7. Frontend
+
+- [ ] 7.1 Show both directions — the objects a run touched on the run detail (grouped by node, joined to the existing step history) and the runs that touched an object in its sidebar; verify a step that touched nothing still renders with its status and timing, and a pruned run renders its recorded identifiers instead of failing
+
+## 8. Quality
+
+- [ ] 8.1 Run `composer check:strict` and `npm run lint`, and fix any pre-existing findings touched by these files
+- [ ] 8.2 Mutation-check the two guards that fail silently — the `finally` pop (2.3) and the pre-verify discrimination (5.2): disable each, confirm the suite goes red, restore, confirm the source is byte-identical
+
+**Acceptance criteria**
+
+- Every audit row written during a run names the run, node and step; every row written outside one names none.
+- A write by an app that has never heard of flows is attributed identically to a node's own write.
+- `verifyChain()` returns `valid: true` over the full table after the migration, and `valid: false` when any attribution value is altered.
+- The pre-migration verdict is readable after the re-seal, and states where the chain stood before it.
+- No `@spec` tag is missing on a changed method; `@e2e exclude` reasons are carried on the backend-only scenarios.
+- i18n: new frontend strings go through `t()`; no hardcoded user-facing text.

--- a/openspec/specs/audit-hash-chain/spec.md
+++ b/openspec/specs/audit-hash-chain/spec.md
@@ -1,5 +1,5 @@
 ---
-status: done
+status: in-progress
 ---
 
 # audit-hash-chain Specification
@@ -22,6 +22,13 @@ Cryptographic SHA-256 hash chaining on audit trail entries with genesis hash, ve
   than one per row, never re-hashing an already-sealed row. Adds a partial index
   for the backlog cursor and a cutover marker so `verifyChain()` stops reporting
   `valid: true` over rows it silently skipped.
+
+- `flow-object-attribution` (active) — the canonical form gains the three flow
+  attribution fields so a row's run/node/step is hash-covered, the genesis seed
+  moves to `openregister-genesis-v2`, and a seed change is defined as a
+  verify-then-rechain migration: the outgoing canonicaliser is frozen in the
+  codebase and used for the pre-check, whose verdict is persisted before the
+  re-seal makes the prior state underivable.
 
 ## Requirements
 ### Requirement: Every audit trail entry MUST include a SHA-256 hash chained to the previous entry

--- a/openspec/specs/flow-engine/spec.md
+++ b/openspec/specs/flow-engine/spec.md
@@ -9,6 +9,8 @@ status: in-progress
 
 - `or-delegation-grants` (active) — turns a DECLARED acting identity into an AUTHORIZED one: a delegation grant record with a consent lifecycle, refusal at save and at every fire when the author holds no grant for the user they named, and an `awaiting_consent` run state deduped on (principal, actingAs, scope) (ADR-099).
 
+- `flow-object-attribution` (active) — the dispatcher establishes an ambient run context before every step and clears it unconditionally afterwards, including when the step throws or suspends, so every write caused by a step is attributed to that run and node; a sub-flow restores its parent's frame rather than clearing it; and a run can report the objects it touched alongside its step history.
+
 ## Purpose
 Defines how OpenRegister reads a flow document and turns it into a run: what carries behaviour (the node), what carries sequence (the edge), when converging paths merge versus synchronise, how a path is allowed to end, and what a flow records about its own runnability and its last run. This is the fleet's single flow engine (ADR-065) — openconnector and hermiq contribute node types to it and do not implement their own.
 

--- a/tests/Unit/Db/AuditFlowAttributionTest.php
+++ b/tests/Unit/Db/AuditFlowAttributionTest.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * Unit tests for AuditFlowAttribution — the stamp half.
+ *
+ * These are about what the stamper does when things are NOT normal, because the
+ * normal case is one line. An audit row is evidence: it must be written even
+ * when the attribution cannot be worked out, and it must never carry an
+ * attribution that was not actually executing.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+ */
+
+namespace Unit\Db;
+
+use OCA\OpenRegister\Db\AuditFlowAttribution;
+use OCA\OpenRegister\Db\AuditTrail;
+use OCA\OpenRegister\Service\Flow\FlowRunContext;
+use OCP\IDBConnection;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use RuntimeException;
+
+class AuditFlowAttributionTest extends TestCase {
+
+	/**
+	 * A stamper whose container yields whatever is given.
+	 *
+	 * @param mixed $resolved What the container returns for FlowRunContext,
+	 *                        or an exception instance to throw.
+	 *
+	 * @return AuditFlowAttribution The stamper.
+	 */
+	private function stamper(mixed $resolved): AuditFlowAttribution {
+		$container = $this->createMock(ContainerInterface::class);
+
+		if ($resolved instanceof \Throwable) {
+			$container->method('get')->willThrowException($resolved);
+		} else {
+			$container->method('get')->willReturn($resolved);
+		}
+
+		return new AuditFlowAttribution($this->createMock(IDBConnection::class), $container);
+	}//end stamper()
+
+	public function testAnExecutingStepIsStampedOntoTheRow(): void {
+		$context = new FlowRunContext();
+		$context->push(runUuid: 'run-abc', nodeId: 'node-1', sequence: 7);
+
+		$row = new AuditTrail();
+		$this->stamper($context)->apply(auditTrail: $row);
+
+		$this->assertSame('run-abc', $row->getFlowRun());
+		$this->assertSame('node-1', $row->getFlowNode());
+		$this->assertSame(7, $row->getFlowStep());
+	}//end testAnExecutingStepIsStampedOntoTheRow()
+
+	/**
+	 * 🔴 Outside a run the row carries NO attribution.
+	 *
+	 * Null is the only way to say "no run" — a run uuid is never an empty
+	 * string, so an empty one would be a claim rather than an absence.
+	 */
+	public function testARowWrittenOutsideAnyRunIsUnattributed(): void {
+		$row = new AuditTrail();
+		$this->stamper(new FlowRunContext())->apply(auditTrail: $row);
+
+		$this->assertNull($row->getFlowRun());
+		$this->assertNull($row->getFlowNode());
+		$this->assertNull($row->getFlowStep());
+	}//end testARowWrittenOutsideAnyRunIsUnattributed()
+
+	/**
+	 * An unresolvable context leaves the row unattributed rather than failing.
+	 *
+	 * An audit row is evidence and must survive a bookkeeping problem; an
+	 * unattributed row is honest about what it does not know.
+	 */
+	public function testAnUnresolvableContextDoesNotPreventTheRow(): void {
+		$row = new AuditTrail();
+		$this->stamper(new RuntimeException('no such service'))->apply(auditTrail: $row);
+
+		$this->assertNull($row->getFlowRun());
+	}//end testAnUnresolvableContextDoesNotPreventTheRow()
+
+	/**
+	 * Something that is not a run context is not trusted to be one.
+	 */
+	public function testAWrongTypeFromTheContainerIsIgnored(): void {
+		$row = new AuditTrail();
+		$this->stamper(new \stdClass())->apply(auditTrail: $row);
+
+		$this->assertNull($row->getFlowRun());
+	}//end testAWrongTypeFromTheContainerIsIgnored()
+
+	/**
+	 * The INNERMOST frame wins, so a sub-flow's writes are its own.
+	 */
+	public function testTheInnermostFrameIsTheOneStamped(): void {
+		$context = new FlowRunContext();
+		$context->push(runUuid: 'parent', nodeId: 'call-sub', sequence: 1);
+		$context->push(runUuid: 'child', nodeId: 'child-node', sequence: 0);
+
+		$row = new AuditTrail();
+		$this->stamper($context)->apply(auditTrail: $row);
+
+		$this->assertSame('child', $row->getFlowRun());
+	}//end testTheInnermostFrameIsTheOneStamped()
+
+	/**
+	 * Stamping twice is idempotent — the builder and the insert path both call
+	 * it, and they must not disagree.
+	 */
+	public function testStampingTwiceWritesTheSameValues(): void {
+		$context = new FlowRunContext();
+		$context->push(runUuid: 'run-1', nodeId: 'n', sequence: 3);
+
+		$stamper = $this->stamper($context);
+		$row = new AuditTrail();
+
+		$stamper->apply(auditTrail: $row);
+		$stamper->apply(auditTrail: $row);
+
+		$this->assertSame('run-1', $row->getFlowRun());
+		$this->assertSame(3, $row->getFlowStep());
+	}//end testStampingTwiceWritesTheSameValues()
+}//end class

--- a/tests/Unit/Listener/SchemaFlowImportListenerTest.php
+++ b/tests/Unit/Listener/SchemaFlowImportListenerTest.php
@@ -15,6 +15,7 @@ use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Event\SchemaCreatedEvent;
 use OCA\OpenRegister\Listener\SchemaFlowImportListener;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 
 /**
  * `x-openregister-flows` materialises into the flow store on schema save.
@@ -39,7 +40,7 @@ class SchemaFlowImportListenerTest extends TestCase {
 	 *
 	 * @return SchemaFlowImportListener The listener.
 	 */
-	private function listener(array $existing = []): SchemaFlowImportListener {
+	private function listener(array $existing = [], ?ContainerInterface $container = null): SchemaFlowImportListener {
 		$this->inserted = [];
 		$this->updated = [];
 
@@ -54,7 +55,52 @@ class SchemaFlowImportListenerTest extends TestCase {
 			return $f;
 		});
 
-		return new SchemaFlowImportListener($mapper, new \Psr\Log\NullLogger());
+		return new SchemaFlowImportListener($mapper, new \Psr\Log\NullLogger(), $container);
+	}
+
+	/**
+	 * A container whose OrganisationService answers with $uuid.
+	 *
+	 * @param string|null $uuid  The active organisation's uuid, or null for
+	 *                           "there is an OrganisationService but no active
+	 *                           organisation".
+	 * @param boolean     $blows Whether resolving it throws, which models an
+	 *                           instance where the service is not registered.
+	 *
+	 * @return ContainerInterface The container.
+	 */
+	private function container(?string $uuid, bool $blows = false): ContainerInterface {
+		$container = $this->createMock(ContainerInterface::class);
+
+		if ($blows === true) {
+			$container->method('get')->willThrowException(new \RuntimeException('not registered'));
+			return $container;
+		}
+
+		$organisation = null;
+		if ($uuid !== null) {
+			$organisation = new class($uuid) {
+				public function __construct(private string $uuid) {
+				}
+
+				public function getUuid(): string {
+					return $this->uuid;
+				}
+			};
+		}
+
+		$service = new class($organisation) {
+			public function __construct(private ?object $organisation) {
+			}
+
+			public function getActiveOrganisation(): ?object {
+				return $this->organisation;
+			}
+		};
+
+		$container->method('get')->willReturn($service);
+
+		return $container;
 	}
 
 	/**
@@ -173,5 +219,104 @@ class SchemaFlowImportListenerTest extends TestCase {
 
 		$this->assertCount(1, $this->inserted);
 		$this->assertSame('Good', $this->inserted[0]->getName());
+	}
+
+	/**
+	 * 🔴 AN IMPORTED FLOW MUST BELONG TO A TENANT.
+	 *
+	 * Every flow READ is organisation-scoped, so a flow stored with a null
+	 * organisation is returned by nothing: it never appears in the flows list,
+	 * so it can never be opened, so it can never be adopted — while sitting
+	 * perfectly intact in the table. Measured 2026-08-28 against a live
+	 * instance: the first shipped `x-openregister-flows` declaration was
+	 * invisible to `/api/flows`, next to two seeded flows that carried an
+	 * organisation and listed fine.
+	 */
+	public function testAnImportedFlowIsStampedWithTheActiveOrganisation(): void {
+		$listener = $this->listener([], $this->container('org-1'));
+		$this->fire($listener, $this->schema([
+			['name' => 'Triage', 'nodes' => [], 'edges' => []],
+		]));
+
+		$this->assertSame('org-1', $this->inserted[0]->getOrganisation());
+	}
+
+	/**
+	 * With no container the flow still imports.
+	 *
+	 * The listener must stay constructible on an instance where
+	 * OrganisationService is not registered: refusing the import would turn a
+	 * missing optional service into a failed schema save.
+	 */
+	public function testWithNoContainerTheFlowStillImportsWithoutAnOrganisation(): void {
+		$listener = $this->listener();
+		$this->fire($listener, $this->schema([
+			['name' => 'Triage', 'nodes' => [], 'edges' => []],
+		]));
+
+		$this->assertCount(1, $this->inserted);
+		$this->assertNull($this->inserted[0]->getOrganisation());
+	}
+
+	/**
+	 * A container that cannot resolve the service is not fatal either.
+	 */
+	public function testAnUnresolvableOrganisationServiceIsNotFatal(): void {
+		$listener = $this->listener([], $this->container(null, blows: true));
+		$this->fire($listener, $this->schema([
+			['name' => 'Triage', 'nodes' => [], 'edges' => []],
+		]));
+
+		$this->assertCount(1, $this->inserted);
+		$this->assertNull($this->inserted[0]->getOrganisation());
+	}
+
+	/**
+	 * A registered service with NO active organisation resolves to null rather
+	 * than to the empty string, which would be a real-looking tenant that owns
+	 * nothing.
+	 */
+	public function testNoActiveOrganisationResolvesToNullNotAnEmptyString(): void {
+		$listener = $this->listener([], $this->container(null));
+		$this->fire($listener, $this->schema([
+			['name' => 'Triage', 'nodes' => [], 'edges' => []],
+		]));
+
+		$this->assertNull($this->inserted[0]->getOrganisation());
+	}
+
+	/**
+	 * An empty uuid is treated as no organisation for the same reason.
+	 */
+	public function testAnEmptyUuidResolvesToNull(): void {
+		$listener = $this->listener([], $this->container(''));
+		$this->fire($listener, $this->schema([
+			['name' => 'Triage', 'nodes' => [], 'edges' => []],
+		]));
+
+		$this->assertNull($this->inserted[0]->getOrganisation());
+	}
+
+	/**
+	 * 🔴 A RE-IMPORT MUST NOT RE-STAMP THE ORGANISATION.
+	 *
+	 * The stamp sits in the create branch beside `enabled`/`owner` precisely so
+	 * an upgrade running as a different tenant cannot move an already-adopted
+	 * flow out from under the organisation using it.
+	 */
+	public function testAReimportDoesNotMoveAnExistingFlowToAnotherOrganisation(): void {
+		$existing = new Flow();
+		$existing->setUuid('u1');
+		$existing->setApp('openregister');
+		$existing->setName('Triage');
+		$existing->setTriggerSchema('case');
+		$existing->setOrganisation('org-owner');
+
+		$listener = $this->listener([$existing], $this->container('org-upgrader'));
+		$this->fire($listener, $this->schema([
+			['name' => 'Triage', 'nodes' => [], 'edges' => []],
+		]));
+
+		$this->assertSame('org-owner', $this->updated[0]->getOrganisation());
 	}
 }

--- a/tests/Unit/Repair/RechainAuditTrailForFlowAttributionTest.php
+++ b/tests/Unit/Repair/RechainAuditTrailForFlowAttributionTest.php
@@ -1,0 +1,233 @@
+<?php
+
+/**
+ * Unit tests for the v1 → v2 audit chain migration.
+ *
+ * 🔴 THIS IS THE RISKIEST CODE IN THE CHANGE, because it is the only part that
+ * cannot be undone. A re-chain recomputes every hash from current row content,
+ * so afterwards an intact chain and a tampered one look identical — and the v1
+ * hashes that could have told them apart are gone.
+ *
+ * Everything below therefore tests the ORDER and the REFUSALS, not the happy
+ * path:
+ *
+ *   - the verdict is recorded BEFORE anything is re-sealed;
+ *   - a chain that cannot be verdicted is not re-sealed at all;
+ *   - a second run does not re-verify (a v2 chain checked against the v1 form
+ *     would report a false break and overwrite the real verdict with it).
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @spec openspec/changes/flow-object-attribution/specs/audit-hash-chain/spec.md
+ */
+
+namespace Unit\Repair;
+
+use OCA\OpenRegister\Repair\RechainAuditTrailForFlowAttribution;
+use OCA\OpenRegister\Service\AuditHashService;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IAppConfig;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use RuntimeException;
+
+class RechainAuditTrailForFlowAttributionTest extends TestCase {
+
+	/**
+	 * An app-config double backed by a plain array.
+	 *
+	 * @param boolean $writable Whether writes are kept. False models a config
+	 *                          backend that silently drops them.
+	 *
+	 * @return IAppConfig The config double.
+	 */
+	private function config(bool $writable = true, array &$store = []): IAppConfig {
+		$config = $this->createMock(IAppConfig::class);
+
+		// A regular closure with `use (&$store)`, NOT an arrow function: `fn`
+		// captures by VALUE at definition time, so the read-back would see the
+		// store as it was before any write. That mistake made this double report
+		// a dropped write on every call — which is exactly what the code under
+		// test refuses on, so the first run of these tests failed for a reason
+		// that had nothing to do with the code.
+		$config->method('getValueString')->willReturnCallback(
+			function (string $app, string $key, string $default = '') use (&$store): string {
+				return ($store[$key] ?? $default);
+			}
+		);
+
+		$config->method('setValueString')->willReturnCallback(
+			static function (string $app, string $key, string $value) use (&$store, $writable): bool {
+				if ($writable === true) {
+					$store[$key] = $value;
+				}
+
+				return true;
+			}
+		);
+
+		return $config;
+	}//end config()
+
+	/**
+	 * A database double whose audit-trail query returns no rows.
+	 *
+	 * An empty table is the right fixture for these tests: the ORDERING and the
+	 * REFUSALS are what is under test, and they do not depend on there being
+	 * rows. Chain-walking itself is covered by the AuditHashService suites.
+	 *
+	 * @return IDBConnection The database double.
+	 */
+	private function emptyDb(): IDBConnection {
+		$result = $this->createMock(\OCP\DB\IResult::class);
+		$result->method('fetchAll')->willReturn([]);
+
+		$expr = $this->createMock(\OCP\DB\QueryBuilder\IExpressionBuilder::class);
+
+		$qb = $this->createMock(IQueryBuilder::class);
+		$qb->method('select')->willReturnSelf();
+		$qb->method('from')->willReturnSelf();
+		$qb->method('where')->willReturnSelf();
+		$qb->method('andWhere')->willReturnSelf();
+		$qb->method('orderBy')->willReturnSelf();
+		$qb->method('setMaxResults')->willReturnSelf();
+		$qb->method('expr')->willReturn($expr);
+		$qb->method('createNamedParameter')->willReturn(':p');
+		$qb->method('executeQuery')->willReturn($result);
+
+		$db = $this->createMock(IDBConnection::class);
+		$db->method('getQueryBuilder')->willReturn($qb);
+
+		return $db;
+	}//end emptyDb()
+
+	public function testItRecordsAVerdictAndThenReSeals(): void {
+		$store = [];
+		$hashes = $this->createMock(AuditHashService::class);
+		$hashes->expects($this->once())->method('rechainAll')
+			->willReturn(['rechained' => 3, 'tombstonesPreserved' => 1]);
+
+		$step = new RechainAuditTrailForFlowAttribution(
+			$this->emptyDb(),
+			$this->config(store: $store),
+			$hashes,
+			new NullLogger()
+		);
+
+		$step->run($this->createMock(IOutput::class));
+
+		$this->assertArrayHasKey(
+			RechainAuditTrailForFlowAttribution::VERDICT_KEY,
+			$store,
+			'The state of the chain before the re-seal is the one fact the re-seal destroys.'
+		);
+		$this->assertArrayHasKey(RechainAuditTrailForFlowAttribution::DONE_KEY, $store);
+
+		$verdict = json_decode($store[RechainAuditTrailForFlowAttribution::VERDICT_KEY], true);
+		$this->assertSame('openregister-genesis-v1', $verdict['seedFrom']);
+		$this->assertSame('openregister-genesis-v2', $verdict['seedTo']);
+	}//end testItRecordsAVerdictAndThenReSeals()
+
+	/**
+	 * 🔴 NO VERDICT, NO RE-CHAIN.
+	 *
+	 * A re-chain that leaves no account of the chain it replaced has no remedy,
+	 * so this is the one refusal that must hold even at the cost of blocking an
+	 * upgrade.
+	 */
+	public function testItRefusesToReSealWhenTheVerdictCannotBeStored(): void {
+		$store = [];
+		$hashes = $this->createMock(AuditHashService::class);
+		$hashes->expects($this->never())->method('rechainAll');
+
+		$step = new RechainAuditTrailForFlowAttribution(
+			$this->emptyDb(),
+			$this->config(writable: false, store: $store),
+			$hashes,
+			new NullLogger()
+		);
+
+		$output = $this->createMock(IOutput::class);
+		$output->expects($this->atLeastOnce())->method('warning');
+
+		$step->run($output);
+
+		$this->assertArrayNotHasKey(RechainAuditTrailForFlowAttribution::DONE_KEY, $store);
+	}//end testItRefusesToReSealWhenTheVerdictCannotBeStored()
+
+	/**
+	 * 🔴 It does not run twice.
+	 *
+	 * After the first pass every row is sealed under v2, so a second pre-verify
+	 * would compare v2 rows against the v1 form, report a false break, and
+	 * overwrite the real verdict with a meaningless one.
+	 */
+	public function testASecondRunIsANoOp(): void {
+		$store = [RechainAuditTrailForFlowAttribution::DONE_KEY => '2026-08-28T00:00:00+00:00'];
+
+		$hashes = $this->createMock(AuditHashService::class);
+		$hashes->expects($this->never())->method('rechainAll');
+
+		$step = new RechainAuditTrailForFlowAttribution(
+			$this->emptyDb(),
+			$this->config(store: $store),
+			$hashes,
+			new NullLogger()
+		);
+
+		$output = $this->createMock(IOutput::class);
+		$output->expects($this->once())->method('info');
+
+		$step->run($output);
+	}//end testASecondRunIsANoOp()
+
+	/**
+	 * A failure inside the re-seal must not leave the step marked done.
+	 *
+	 * Otherwise the next `occ maintenance:repair` skips it, and the table is
+	 * left half-sealed with nothing left to finish it.
+	 */
+	public function testAFailedReSealDoesNotMarkTheStepDone(): void {
+		$store = [];
+		$hashes = $this->createMock(AuditHashService::class);
+		$hashes->method('rechainAll')->willThrowException(new RuntimeException('lock unavailable'));
+
+		$step = new RechainAuditTrailForFlowAttribution(
+			$this->emptyDb(),
+			$this->config(store: $store),
+			$hashes,
+			new NullLogger()
+		);
+
+		try {
+			$step->run($this->createMock(IOutput::class));
+		} catch (RuntimeException $e) {
+			// The step does not swallow it; maintenance:repair reports it.
+		}
+
+		$this->assertArrayNotHasKey(
+			RechainAuditTrailForFlowAttribution::DONE_KEY,
+			$store,
+			'A half-finished re-seal must not look complete.'
+		);
+		$this->assertArrayHasKey(
+			RechainAuditTrailForFlowAttribution::VERDICT_KEY,
+			$store,
+			'The verdict is written first and survives the failure.'
+		);
+	}//end testAFailedReSealDoesNotMarkTheStepDone()
+
+	public function testItNamesItselfForTheRepairRunner(): void {
+		$step = new RechainAuditTrailForFlowAttribution(
+			$this->emptyDb(),
+			$this->config(),
+			$this->createMock(AuditHashService::class),
+			new NullLogger()
+		);
+
+		$this->assertStringContainsString('audit chain', strtolower($step->getName()));
+	}//end testItNamesItselfForTheRepairRunner()
+}//end class

--- a/tests/Unit/Service/AuditCanonicalV1Test.php
+++ b/tests/Unit/Service/AuditCanonicalV1Test.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * Unit tests for the FROZEN v1 audit canonicaliser.
+ *
+ * This class exists for exactly one job: to let the v1 → v2 migration check
+ * what it is about to overwrite. A re-chain rewrites every stored hash, so it
+ * makes an intact chain and a tampered one verify identically afterwards —
+ * the pre-check is the only moment the difference is still knowable.
+ *
+ * Which means a canonicaliser that has quietly DRIFTED does not fail loudly. It
+ * reports every row broken, the operator sees a scary warning that is really
+ * just drift, the re-chain proceeds, and a genuine tamper is buried under a
+ * false one. These tests are what keep it frozen.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @spec openspec/changes/flow-object-attribution/specs/audit-hash-chain/spec.md
+ */
+
+namespace Unit\Service;
+
+use OCA\OpenRegister\Db\AuditTrail;
+use OCA\OpenRegister\Service\AuditCanonicalV1;
+use PHPUnit\Framework\TestCase;
+
+class AuditCanonicalV1Test extends TestCase {
+
+	/**
+	 * A row with a couple of fields set and everything else at its default.
+	 */
+	private function row(): AuditTrail {
+		$entry = new AuditTrail();
+		$entry->setId(42);
+		$entry->setAction('create');
+
+		return $entry;
+	}//end row()
+
+	/**
+	 * 🔒 THE FREEZE. The exact bytes a v1 row was hashed over.
+	 *
+	 * If this assertion fails, the v1 form has moved and every hash sealed under
+	 * seed v1 has become unverifiable. The correct response is to restore the
+	 * old behaviour, NOT to update the expectation — updating it is how the
+	 * check silently stops meaning anything.
+	 */
+	public function testTheV1CanonicalFormIsFrozen(): void {
+		$expected = '{"action":"create","changed":null,"confidentiality":null,"created":null,'
+			. '"expires":null,"id":42,"ipAddress":null,"object":null,"objectUuid":null,'
+			. '"organisationId":null,"organisationIdType":null,"paramsDigest":null,'
+			. '"processingActivityId":null,"processingActivityUrl":null,"processingId":null,'
+			. '"register":null,"registerUuid":null,"request":null,"resultSummary":null,'
+			. '"retentionPeriod":null,"schema":null,"schemaUuid":null,"session":null,'
+			. '"size":null,"toolId":null,"user":null,"userName":null,"uuid":null,"version":null}';
+
+		$this->assertSame($expected, AuditCanonicalV1::canonicalJson(entry: $this->row()));
+	}//end testTheV1CanonicalFormIsFrozen()
+
+	/**
+	 * The v1 form does not contain the fields v2 added.
+	 *
+	 * Stated separately from the freeze above because it is the specific
+	 * regression this class was written to prevent, and a separate failure
+	 * message says so directly.
+	 */
+	public function testTheV1FormExcludesTheFlowAttributionFields(): void {
+		$canonical = AuditCanonicalV1::canonicalJson(entry: $this->row());
+
+		$this->assertStringNotContainsString('flowRun', $canonical);
+		$this->assertStringNotContainsString('flowNode', $canonical);
+		$this->assertStringNotContainsString('flowStep', $canonical);
+	}//end testTheV1FormExcludesTheFlowAttributionFields()
+
+	/**
+	 * 🔑 THE PROPERTY THE MIGRATION DEPENDS ON.
+	 *
+	 * Two rows differing ONLY in flow attribution must canonicalise identically
+	 * under v1. That is what makes a pre-existing row — which has no attribution
+	 * — verify against a hash sealed before the columns existed.
+	 */
+	public function testAttributionDoesNotChangeTheV1Form(): void {
+		$without = $this->row();
+
+		$with = $this->row();
+		$with->setFlowRun('run-abc');
+		$with->setFlowNode('node-1');
+		$with->setFlowStep(3);
+
+		$this->assertSame(
+			AuditCanonicalV1::canonicalJson(entry: $without),
+			AuditCanonicalV1::canonicalJson(entry: $with),
+			'The v1 form must be blind to fields v2 introduced, or no pre-existing row can verify.'
+		);
+	}//end testAttributionDoesNotChangeTheV1Form()
+
+	/**
+	 * A change to any v1 field DOES change the form — the canonicaliser is
+	 * blind to the new fields, not blind in general.
+	 */
+	public function testAV1FieldStillChangesTheForm(): void {
+		$before = AuditCanonicalV1::canonicalJson(entry: $this->row());
+
+		$changed = $this->row();
+		$changed->setAction('delete');
+
+		$this->assertNotSame($before, AuditCanonicalV1::canonicalJson(entry: $changed));
+	}//end testAV1FieldStillChangesTheForm()
+
+	/**
+	 * The v1 genesis seed is the v1 seed, not the current one.
+	 */
+	public function testTheGenesisHashIsTheV1Seed(): void {
+		$this->assertSame('openregister-genesis-v1', AuditCanonicalV1::GENESIS_SEED);
+		$this->assertSame(
+			hash('sha256', 'openregister-genesis-v1'),
+			AuditCanonicalV1::genesisHash()
+		);
+	}//end testTheGenesisHashIsTheV1Seed()
+
+	/**
+	 * Hashing chains the predecessor in, so the same row after a different
+	 * predecessor hashes differently.
+	 */
+	public function testTheHashChainsThePredecessor(): void {
+		$row = $this->row();
+
+		$this->assertNotSame(
+			AuditCanonicalV1::computeHash(entry: $row, previousHash: 'aaa'),
+			AuditCanonicalV1::computeHash(entry: $row, previousHash: 'bbb')
+		);
+	}//end testTheHashChainsThePredecessor()
+}//end class

--- a/tests/Unit/Service/AuditHashServiceTest.php
+++ b/tests/Unit/Service/AuditHashServiceTest.php
@@ -36,12 +36,26 @@ class AuditHashServiceTest extends TestCase {
 		);
 	}
 
+	/**
+	 * The chain's seed is v2.
+	 *
+	 * Moved from v1 when the flow-attribution fields joined the canonical JSON
+	 * (ADR-003 Rule 4: the seed and the canonical form are one identity and are
+	 * versioned together). The v1 value is asserted to be DIFFERENT rather than
+	 * simply dropped, so a revert of the seed — which would silently make every
+	 * re-sealed row unverifiable — fails here instead of in production.
+	 */
 	public function testGetGenesisHash(): void {
-		$expected = hash('sha256', 'openregister-genesis-v1');
+		$expected = hash('sha256', 'openregister-genesis-v2');
 		$result = $this->service->getGenesisHash();
 
 		$this->assertSame($expected, $result);
 		$this->assertSame(64, strlen($result));
+		$this->assertNotSame(
+			hash('sha256', 'openregister-genesis-v1'),
+			$result,
+			'The seed must not fall back to v1: rows re-sealed under v2 would stop verifying.'
+		);
 	}
 
 	public function testGetGenesisHashIsConsistent(): void {

--- a/tests/Unit/Service/Flow/FlowEngineAttributionTest.php
+++ b/tests/Unit/Service/Flow/FlowEngineAttributionTest.php
@@ -1,0 +1,275 @@
+<?php
+
+/**
+ * Unit tests for the engine's flow-attribution frames.
+ *
+ * The engine pushes an attribution frame around each hop so every write the hop
+ * causes is filed under that run and node. What these tests are really about is
+ * the POP: a frame left standing attributes later writes — including a
+ * different run's, since one worker advances several — to a run that has
+ * already finished, and produces rows that look entirely correct.
+ *
+ * So the assertions that matter here are the ones taken AFTER a run ends, and
+ * especially after one ends BADLY. A test that only checks the frame is right
+ * during a successful step passes just as happily with the `finally` deleted.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @spec openspec/changes/flow-object-attribution/specs/flow-engine/spec.md
+ */
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Service\Flow\FlowDefinitionBuilder;
+use OCA\OpenRegister\Service\Flow\FlowEngine;
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\FlowRunContext;
+use OCA\OpenRegister\Service\Flow\FlowStepDispatcher;
+use OCA\OpenRegister\Service\Flow\FlowStop;
+use OCA\OpenRegister\Service\Flow\FlowSuspension;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Symfony\Component\Workflow\MarkingStore\MethodMarkingStore;
+
+/**
+ * A subject whose marking is a plain property.
+ */
+class AttributionSubject {
+
+	public $marking = [];
+}//end class
+
+/**
+ * Reads the ambient frame at the moment each step runs, then optionally fails.
+ *
+ * Sampling INSIDE the step is the point: the frame has to be correct while the
+ * write would be happening, not merely at some point during the run.
+ */
+class AttributionSamplingDispatcher implements FlowStepDispatcher {
+
+	/**
+	 * The frame observed during each step, keyed by step id.
+	 */
+	public array $frames = [];
+
+	public function __construct(
+		private readonly FlowRunContext $context,
+		private readonly ?string $failOn = null,
+		private readonly ?string $throwKind = null,
+	) {
+	}//end __construct()
+
+	public function dispatch(array $step, array $items, array $context): array {
+		$name = (string)($step['id'] ?? '');
+		$this->frames[$name] = $this->context->current();
+
+		if ($this->failOn !== null && $name === $this->failOn) {
+			if ($this->throwKind === 'stop') {
+				throw new FlowStop('stopped on purpose');
+			}
+
+			if ($this->throwKind === 'suspend') {
+				// Named argument: the first positional parameter is the resume
+				// DateTime, not the reason.
+				throw new FlowSuspension(reason: 'waiting on purpose');
+			}
+
+			throw new RuntimeException('step blew up');
+		}
+
+		$out = [];
+		foreach ($items as $index => $item) {
+			$out[] = FlowItems::item(json: (array)($item['json'] ?? []), binary: [], fromItemIndex: $index);
+		}
+
+		return $out;
+	}//end dispatch()
+}//end class
+
+class FlowEngineAttributionTest extends TestCase {
+
+	private FlowRunContext $context;
+
+	private FlowEngine $engine;
+
+	protected function setUp(): void {
+		$this->context = new FlowRunContext();
+		$this->engine = new FlowEngine(
+			new FlowDefinitionBuilder(),
+			$this->createMock(LoggerInterface::class),
+			null,
+			null,
+			null,
+			$this->context
+		);
+	}//end setUp()
+
+	/**
+	 * A two-node flow.
+	 */
+	private function linearFlow(): array {
+		return [
+			'id' => 'linear',
+			'nodes' => [
+				['id' => 'first', 'type' => 'test.step'],
+				['id' => 'second', 'type' => 'test.step'],
+			],
+			'edges' => [['id' => 'first-second', 'from' => 'first', 'to' => 'second']],
+		];
+	}//end linearFlow()
+
+	private function runFlow(array $flow, FlowStepDispatcher $dispatcher, array $context = []): array {
+		return $this->engine->run(
+			$flow,
+			new MethodMarkingStore(false, 'marking'),
+			new AttributionSubject(),
+			$dispatcher,
+			$context
+		);
+	}//end runFlow()
+
+	/**
+	 * The attribution context the engine is handed for a run.
+	 */
+	private function attributionContext(string $run = 'run-abc', int $base = 0): array {
+		return [
+			FlowRunContext::CONTEXT_RUN => $run,
+			FlowRunContext::CONTEXT_BASE => $base,
+		];
+	}//end attributionContext()
+
+	/**
+	 * Each step sees its OWN node id and its own step number.
+	 */
+	public function testEachStepSeesItsOwnFrame(): void {
+		$dispatcher = new AttributionSamplingDispatcher(context: $this->context);
+
+		$this->runFlow($this->linearFlow(), $dispatcher, $this->attributionContext());
+
+		$this->assertSame(
+			['run' => 'run-abc', 'node' => 'first', 'step' => 0],
+			$dispatcher->frames['first']
+		);
+		$this->assertSame(
+			['run' => 'run-abc', 'node' => 'second', 'step' => 1],
+			$dispatcher->frames['second']
+		);
+	}//end testEachStepSeesItsOwnFrame()
+
+	/**
+	 * The step number continues from the base, so a resumed run keeps numbering
+	 * where it stopped instead of restarting and colliding with its own history.
+	 */
+	public function testStepNumbersContinueFromTheBase(): void {
+		$dispatcher = new AttributionSamplingDispatcher(context: $this->context);
+
+		$this->runFlow($this->linearFlow(), $dispatcher, $this->attributionContext(base: 12));
+
+		$this->assertSame(12, $dispatcher->frames['first']['step']);
+		$this->assertSame(13, $dispatcher->frames['second']['step']);
+	}//end testStepNumbersContinueFromTheBase()
+
+	/**
+	 * 🔴 THE LEAK TEST. Nothing is attributed once the run is over.
+	 *
+	 * Delete the `finally` in FlowEngine and this is the assertion that goes
+	 * red. Every other test in this file still passes.
+	 */
+	public function testNothingIsAttributedAfterASuccessfulRun(): void {
+		$dispatcher = new AttributionSamplingDispatcher(context: $this->context);
+
+		$this->runFlow($this->linearFlow(), $dispatcher, $this->attributionContext());
+
+		$this->assertNull(
+			$this->context->current(),
+			'A write after the run must be unattributed; a standing frame files it under a finished run.'
+		);
+		$this->assertSame(0, $this->context->depth());
+	}//end testNothingIsAttributedAfterASuccessfulRun()
+
+	/**
+	 * 🔴 A THROWING step still clears its frame.
+	 *
+	 * The failure path is the one where a success-path pop would have been
+	 * skipped, so this is where a leak would actually happen in production.
+	 */
+	public function testAThrowingStepStillClearsItsFrame(): void {
+		$dispatcher = new AttributionSamplingDispatcher(
+			context: $this->context,
+			failOn: 'first'
+		);
+
+		$this->runFlow($this->linearFlow(), $dispatcher, $this->attributionContext());
+
+		$this->assertNull($this->context->current());
+		$this->assertSame(0, $this->context->depth());
+	}//end testAThrowingStepStillClearsItsFrame()
+
+	/**
+	 * 🔴 A stopped run leaves nothing behind. A Stop returns from INSIDE the
+	 * catch, so only a `finally` pops it.
+	 */
+	public function testAStoppedRunClearsItsFrame(): void {
+		$dispatcher = new AttributionSamplingDispatcher(
+			context: $this->context,
+			failOn: 'first',
+			throwKind: 'stop'
+		);
+
+		$result = $this->runFlow($this->linearFlow(), $dispatcher, $this->attributionContext());
+
+		$this->assertSame(FlowEngine::STATUS_STOPPED, $result['status']);
+		$this->assertNull($this->context->current());
+		$this->assertSame(0, $this->context->depth());
+	}//end testAStoppedRunClearsItsFrame()
+
+	/**
+	 * 🔴 A suspended run leaves nothing behind either — and this is the one that
+	 * matters most in practice, because a suspended run is precisely the one
+	 * whose process goes on to do other things.
+	 */
+	public function testASuspendedRunClearsItsFrame(): void {
+		$dispatcher = new AttributionSamplingDispatcher(
+			context: $this->context,
+			failOn: 'first',
+			throwKind: 'suspend'
+		);
+
+		$result = $this->runFlow($this->linearFlow(), $dispatcher, $this->attributionContext());
+
+		$this->assertSame(FlowEngine::STATUS_SUSPENDED, $result['status']);
+		$this->assertNull($this->context->current());
+		$this->assertSame(0, $this->context->depth());
+	}//end testASuspendedRunClearsItsFrame()
+
+	/**
+	 * Two runs walked in sequence — as FlowRunWorker does — attribute to
+	 * themselves and not to their predecessor.
+	 */
+	public function testASecondRunIsNotAttributedToTheFirst(): void {
+		$first = new AttributionSamplingDispatcher(context: $this->context);
+		$this->runFlow($this->linearFlow(), $first, $this->attributionContext(run: 'run-1'));
+
+		$second = new AttributionSamplingDispatcher(context: $this->context);
+		$this->runFlow($this->linearFlow(), $second, $this->attributionContext(run: 'run-2'));
+
+		$this->assertSame('run-1', $first->frames['first']['run']);
+		$this->assertSame('run-2', $second->frames['first']['run']);
+		$this->assertNull($this->context->current());
+	}//end testASecondRunIsNotAttributedToTheFirst()
+
+	/**
+	 * A run with no attribution context attributes nothing — the flow tester and
+	 * the node unit tests dispatch this way, and must not crash or invent a run.
+	 */
+	public function testARunWithoutAttributionContextAttributesNothing(): void {
+		$dispatcher = new AttributionSamplingDispatcher(context: $this->context);
+
+		$this->runFlow($this->linearFlow(), $dispatcher);
+
+		$this->assertNull($dispatcher->frames['first']);
+		$this->assertNull($this->context->current());
+	}//end testARunWithoutAttributionContextAttributesNothing()
+}//end class

--- a/tests/Unit/Service/Flow/FlowRunAssigneeTest.php
+++ b/tests/Unit/Service/Flow/FlowRunAssigneeTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * Unit tests for FlowRunAssignee — who may answer a suspended step.
+ *
+ * The rule was extracted from FlowRunController so an in-process resume (a leaf
+ * app whose object completes a task) applies the SAME rule as the HTTP endpoint
+ * rather than a second copy of it. These tests exist to keep the one copy
+ * honest.
+ *
+ * Three directions matter more than the happy path, and each has a way of
+ * passing while broken:
+ *
+ *   - the GROUP branch — a broken group lookup refuses the step's own intended
+ *     audience, and reads as "the guard works", because refusing is what a
+ *     guard does;
+ *   - the UNASSIGNED case — deliberately open, so an implementation that
+ *     treated "no assignee" like "no uid" would pass every other test here
+ *     while leaving assigned steps answerable by anyone;
+ *   - the ANONYMOUS case — must fail closed.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @spec openspec/specs/flow-engine/spec.md#requirement-a-run-suspended-on-an-external-signal-must-be-reachable
+ */
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Db\FlowRun;
+use OCA\OpenRegister\Service\Flow\FlowResumeState;
+use OCA\OpenRegister\Service\Flow\FlowRunAssignee;
+use OCP\IGroupManager;
+use PHPUnit\Framework\TestCase;
+
+class FlowRunAssigneeTest extends TestCase {
+
+	/**
+	 * A run whose resume slots are exactly as given.
+	 *
+	 * @param array $slots The per-node resume slots.
+	 *
+	 * @return FlowRun The run.
+	 */
+	private function runWithSlots(array $slots): FlowRun {
+		$run = new FlowRun();
+		$run->setContext([FlowResumeState::CONTEXT_KEY => $slots]);
+
+		return $run;
+	}//end runWithSlots()
+
+	public function testAnUnaskedSlotNamesNobody(): void {
+		// A slot with no askedAt has not asked anything, so its assignee is not
+		// the person currently being waited on.
+		$run = $this->runWithSlots(['node-a' => ['assignee' => 'alice']]);
+
+		$this->assertSame('', (new FlowRunAssignee())->recordedFor(run: $run));
+	}//end testAnUnaskedSlotNamesNobody()
+
+	public function testTheAskingSlotNamesItsAssignee(): void {
+		$run = $this->runWithSlots([
+			'node-a' => ['assignee' => 'alice'],
+			'node-b' => ['askedAt' => '2026-08-28T10:00:00+00:00', 'assignee' => 'bob'],
+		]);
+
+		$this->assertSame('bob', (new FlowRunAssignee())->recordedFor(run: $run));
+	}//end testTheAskingSlotNamesItsAssignee()
+
+	public function testTheAssigneeMayAnswer(): void {
+		$run = $this->runWithSlots(['n' => ['askedAt' => 'now', 'assignee' => 'bob']]);
+
+		$this->assertTrue((new FlowRunAssignee())->mayAnswer(run: $run, uid: 'bob'));
+	}//end testTheAssigneeMayAnswer()
+
+	public function testSomebodyElseMayNot(): void {
+		$run = $this->runWithSlots(['n' => ['askedAt' => 'now', 'assignee' => 'bob']]);
+
+		$this->assertFalse((new FlowRunAssignee())->mayAnswer(run: $run, uid: 'carol'));
+	}//end testSomebodyElseMayNot()
+
+	/**
+	 * 🔴 The unassigned case is deliberately OPEN.
+	 *
+	 * Webhook and child-run signals are not human decisions and record no
+	 * assignee. An implementation that fails closed here would break every one
+	 * of them — and would do it while looking more secure.
+	 */
+	public function testAnUnassignedStepIsAnswerableByAnyone(): void {
+		$run = $this->runWithSlots(['n' => ['askedAt' => 'now']]);
+
+		$assignee = new FlowRunAssignee();
+
+		$this->assertTrue($assignee->mayAnswer(run: $run, uid: 'anyone'));
+		$this->assertTrue($assignee->mayAnswer(run: $run, uid: null));
+	}//end testAnUnassignedStepIsAnswerableByAnyone()
+
+	/**
+	 * 🔴 An ASSIGNED step is never anonymous.
+	 */
+	public function testAnAssignedStepRefusesAnAnonymousCaller(): void {
+		$run = $this->runWithSlots(['n' => ['askedAt' => 'now', 'assignee' => 'bob']]);
+
+		$assignee = new FlowRunAssignee();
+
+		$this->assertFalse($assignee->mayAnswer(run: $run, uid: null));
+		$this->assertFalse($assignee->mayAnswer(run: $run, uid: ''));
+	}//end testAnAssignedStepRefusesAnAnonymousCaller()
+
+	/**
+	 * 🔴 THE GROUP BRANCH. A group-assigned step admits its members.
+	 */
+	public function testAGroupMemberMayAnswerAGroupAssignedStep(): void {
+		$run = $this->runWithSlots(['n' => ['askedAt' => 'now', 'assignee' => 'behandelaars']]);
+
+		$groups = $this->createMock(IGroupManager::class);
+		$groups->method('isInGroup')->with('carol', 'behandelaars')->willReturn(true);
+
+		$this->assertTrue(
+			(new FlowRunAssignee(groupManager: $groups))->mayAnswer(run: $run, uid: 'carol')
+		);
+	}//end testAGroupMemberMayAnswerAGroupAssignedStep()
+
+	public function testANonMemberMayNot(): void {
+		$run = $this->runWithSlots(['n' => ['askedAt' => 'now', 'assignee' => 'behandelaars']]);
+
+		$groups = $this->createMock(IGroupManager::class);
+		$groups->method('isInGroup')->willReturn(false);
+
+		$this->assertFalse(
+			(new FlowRunAssignee(groupManager: $groups))->mayAnswer(run: $run, uid: 'carol')
+		);
+	}//end testANonMemberMayNot()
+
+	/**
+	 * With no group manager the group branch REFUSES rather than admits.
+	 *
+	 * Asserted explicitly so the fail-closed direction is a stated property
+	 * rather than something inferred from a passing suite elsewhere.
+	 */
+	public function testWithoutAGroupManagerAGroupAssignmentRefuses(): void {
+		$run = $this->runWithSlots(['n' => ['askedAt' => 'now', 'assignee' => 'behandelaars']]);
+
+		$this->assertFalse((new FlowRunAssignee())->mayAnswer(run: $run, uid: 'carol'));
+	}//end testWithoutAGroupManagerAGroupAssignmentRefuses()
+
+	public function testARunWithNoSlotsNamesNobodyAndIsOpen(): void {
+		$run = new FlowRun();
+
+		$assignee = new FlowRunAssignee();
+
+		$this->assertSame('', $assignee->recordedFor(run: $run));
+		$this->assertTrue($assignee->mayAnswer(run: $run, uid: 'anyone'));
+	}//end testARunWithNoSlotsNamesNobodyAndIsOpen()
+}//end class

--- a/tests/Unit/Service/Flow/FlowRunContextTest.php
+++ b/tests/Unit/Service/Flow/FlowRunContextTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * Unit tests for FlowRunContext — the ambient attribution stack.
+ *
+ * The class is small; the failure it guards against is not. An unbalanced stack
+ * attributes later writes to a run that already finished, and produces rows
+ * that look entirely correct while doing it. So these tests are weighted
+ * towards the LEAK direction — what the stack says AFTER something ends — and
+ * not towards the happy path, which passes either way.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+ */
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Service\Flow\FlowRunContext;
+use PHPUnit\Framework\TestCase;
+
+class FlowRunContextTest extends TestCase {
+
+	private FlowRunContext $context;
+
+	protected function setUp(): void {
+		$this->context = new FlowRunContext();
+	}//end setUp()
+
+	/**
+	 * Outside any run there is nothing to attribute to.
+	 */
+	public function testEmptyStackAttributesNothing(): void {
+		$this->assertNull($this->context->current());
+		$this->assertSame(0, $this->context->depth());
+	}//end testEmptyStackAttributesNothing()
+
+	/**
+	 * A pushed frame is what a write is filed under.
+	 */
+	public function testCurrentReturnsThePushedFrame(): void {
+		$this->context->push(runUuid: 'run-a', nodeId: 'node-1', sequence: 7);
+
+		$this->assertSame(
+			['run' => 'run-a', 'node' => 'node-1', 'step' => 7],
+			$this->context->current()
+		);
+	}//end testCurrentReturnsThePushedFrame()
+
+	/**
+	 * Popping restores the ENCLOSING frame, not emptiness.
+	 *
+	 * This is the sub-flow case. If pop cleared instead of restoring, a parent
+	 * run's remaining steps would silently stop being attributed the moment it
+	 * called a sub-flow — and nothing about the resulting rows would look wrong.
+	 */
+	public function testNestedPopRestoresTheParentFrame(): void {
+		$this->context->push(runUuid: 'parent', nodeId: 'call-subflow', sequence: 2);
+		$this->context->push(runUuid: 'child', nodeId: 'child-node', sequence: 0);
+
+		$this->assertSame('child', $this->context->current()['run']);
+
+		$this->context->pop();
+
+		$this->assertSame(
+			'parent',
+			$this->context->current()['run'],
+			'A sub-flow returning must hand the parent run back its own attribution.'
+		);
+	}//end testNestedPopRestoresTheParentFrame()
+
+	/**
+	 * A run that is not attributable does not INHERIT the enclosing one.
+	 *
+	 * The wrong behaviour here files a child's writes under its parent: still a
+	 * plausible-looking row, attributed to a run that never performed it.
+	 */
+	public function testUnattributableFrameDoesNotInheritTheParent(): void {
+		$this->context->push(runUuid: 'parent', nodeId: 'outer', sequence: 1);
+		$this->context->push(runUuid: null, nodeId: 'inner', sequence: 0);
+
+		$this->assertNull(
+			$this->context->current(),
+			'An inner hop with no run must attribute to nothing, not to the run outside it.'
+		);
+
+		$this->context->pop();
+
+		$this->assertSame('parent', $this->context->current()['run']);
+	}//end testUnattributableFrameDoesNotInheritTheParent()
+
+	/**
+	 * An empty run uuid is the same as none. A run uuid is never blank, so a
+	 * blank one is a bug upstream and must not become an attribution of "".
+	 */
+	public function testBlankRunUuidIsNotAnAttribution(): void {
+		$this->context->push(runUuid: '   ', nodeId: 'node', sequence: 0);
+
+		$this->assertNull($this->context->current());
+		$this->assertSame(1, $this->context->depth(), 'It still occupies a frame, so pop stays paired.');
+	}//end testBlankRunUuidIsNotAnAttribution()
+
+	/**
+	 * Popping more than was pushed must not throw.
+	 *
+	 * pop() is called from a `finally`. A `finally` that throws REPLACES the
+	 * exception the step actually failed with, turning a diagnosable node
+	 * failure into a bookkeeping error about the context.
+	 */
+	public function testPoppingAnEmptyStackIsHarmless(): void {
+		$this->context->pop();
+		$this->context->pop();
+
+		$this->assertNull($this->context->current());
+		$this->assertSame(0, $this->context->depth());
+	}//end testPoppingAnEmptyStackIsHarmless()
+
+	/**
+	 * Two sequential runs do not bleed into one another.
+	 *
+	 * FlowRunWorker advances several runs per process, so a leak here crosses
+	 * runs rather than merely steps.
+	 */
+	public function testSequentialRunsDoNotBleed(): void {
+		$this->context->push(runUuid: 'run-1', nodeId: 'n', sequence: 0);
+		$this->context->pop();
+
+		$this->assertNull($this->context->current(), 'A finished run must leave nothing behind.');
+
+		$this->context->push(runUuid: 'run-2', nodeId: 'n', sequence: 0);
+
+		$this->assertSame('run-2', $this->context->current()['run']);
+	}//end testSequentialRunsDoNotBleed()
+}//end class

--- a/tests/Unit/Service/Flow/FlowStepHistoryTest.php
+++ b/tests/Unit/Service/Flow/FlowStepHistoryTest.php
@@ -1,0 +1,222 @@
+<?php
+
+/**
+ * Unit tests for FlowStepHistory — how a run's steps are numbered and recorded.
+ *
+ * The numbering is the part that matters most and is hardest to see. An audit
+ * row is stamped with a step number DURING the walk; the step row is written
+ * after it. Both sides compute that number independently, and if they disagree
+ * the attributed row and its step row describe different steps — which is worse
+ * than no attribution, because it looks correct.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @spec openspec/changes/flow-object-attribution/specs/flow-object-attribution/spec.md
+ */
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Db\FlowRun;
+use OCA\OpenRegister\Db\FlowRunStep;
+use OCA\OpenRegister\Db\FlowRunStepMapper;
+use OCA\OpenRegister\Service\Flow\FlowStepHistory;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+class FlowStepHistoryTest extends TestCase {
+
+	/**
+	 * A run with a uuid.
+	 *
+	 * @param string $uuid The uuid.
+	 *
+	 * @return FlowRun The run.
+	 *
+	 * Named aRun(), not run(): PHPUnit's TestCase::run() is final.
+	 */
+	private function aRun(string $uuid = 'run-1'): FlowRun {
+		$run = new FlowRun();
+		$run->setUuid($uuid);
+		$run->setFlowId('flow-1');
+
+		return $run;
+	}//end aRun()
+
+	public function testWithNoStepMapperNumberingStartsAtZero(): void {
+		$history = new FlowStepHistory();
+
+		$this->assertSame(0, $history->baseFor(runUuid: 'run-1'));
+	}//end testWithNoStepMapperNumberingStartsAtZero()
+
+	public function testAnEmptyRunUuidNumbersFromZero(): void {
+		$steps = $this->createMock(FlowRunStepMapper::class);
+		$steps->expects($this->never())->method('highestSequence');
+
+		$this->assertSame(0, (new FlowStepHistory(steps: $steps))->baseFor(runUuid: '  '));
+	}//end testAnEmptyRunUuidNumbersFromZero()
+
+	/**
+	 * The base CONTINUES from what is already recorded.
+	 *
+	 * A run that suspends and resumes days later must read as one ordered
+	 * history, not two starting at zero.
+	 */
+	public function testTheBaseContinuesFromTheHighestRecordedSequence(): void {
+		$steps = $this->createMock(FlowRunStepMapper::class);
+		$steps->method('highestSequence')->with('run-1')->willReturn(11);
+
+		$this->assertSame(12, (new FlowStepHistory(steps: $steps))->baseFor(runUuid: 'run-1'));
+	}//end testTheBaseContinuesFromTheHighestRecordedSequence()
+
+	/**
+	 * A failed read degrades to zero rather than failing the run.
+	 *
+	 * The work is the run; the numbering is the account of it. Wrong only in
+	 * its offset, and still ordering the run's writes among themselves.
+	 */
+	public function testAFailedReadDegradesToZeroAndIsLogged(): void {
+		$steps = $this->createMock(FlowRunStepMapper::class);
+		$steps->method('highestSequence')->willThrowException(new RuntimeException('db gone'));
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->once())->method('warning');
+
+		$history = new FlowStepHistory(steps: $steps, logger: $logger);
+
+		$this->assertSame(0, $history->baseFor(runUuid: 'run-1'));
+	}//end testAFailedReadDegradesToZeroAndIsLogged()
+
+	public function testRecordingWithoutAStepMapperIsANoOp(): void {
+		$history = new FlowStepHistory();
+
+		$history->record(run: $this->aRun(), entries: [['transition' => 'a', 'status' => 'completed']]);
+
+		$this->addToAssertionCount(1);
+	}//end testRecordingWithoutAStepMapperIsANoOp()
+
+	public function testNoEntriesRecordsNothing(): void {
+		$steps = $this->createMock(FlowRunStepMapper::class);
+		$steps->expects($this->never())->method('insert');
+
+		(new FlowStepHistory(steps: $steps))->record(run: $this->aRun(), entries: []);
+	}//end testNoEntriesRecordsNothing()
+
+	/**
+	 * 🔑 THE NUMBERS THE ROWS GET ARE THE NUMBERS ATTRIBUTION PREDICTED.
+	 *
+	 * `baseFor()` is what the engine stamped onto audit rows before the walk;
+	 * these are the rows written after it. Asserted together, in one test,
+	 * because their agreement is the property — checking either alone would
+	 * pass while they disagreed.
+	 */
+	public function testRecordedSequencesContinueFromTheSameBaseAttributionUsed(): void {
+		$steps = $this->createMock(FlowRunStepMapper::class);
+		$steps->method('highestSequence')->willReturn(4);
+
+		$recorded = [];
+		$steps->method('insert')->willReturnCallback(
+			function (FlowRunStep $step) use (&$recorded) {
+				$recorded[] = [$step->getNodeId(), $step->getSequence()];
+
+				return $step;
+			}
+		);
+
+		$history = new FlowStepHistory(steps: $steps);
+
+		$this->assertSame(5, $history->baseFor(runUuid: 'run-1'));
+
+		$history->record(
+			run: $this->aRun(),
+			entries: [
+				['transition' => 'first', 'status' => 'completed'],
+				['transition' => 'second', 'status' => 'completed'],
+			]
+		);
+
+		$this->assertSame([['first', 5], ['second', 6]], $recorded);
+	}//end testRecordedSequencesContinueFromTheSameBaseAttributionUsed()
+
+	public function testAFailedInsertDoesNotStopTheRemainingSteps(): void {
+		$steps = $this->createMock(FlowRunStepMapper::class);
+		$steps->method('highestSequence')->willReturn(0);
+
+		$seen = [];
+		$steps->method('insert')->willReturnCallback(
+			function (FlowRunStep $step) use (&$seen) {
+				$seen[] = $step->getNodeId();
+				if ($step->getNodeId() === 'first') {
+					throw new RuntimeException('write failed');
+				}
+
+				return $step;
+			}
+		);
+
+		(new FlowStepHistory(steps: $steps, logger: $this->createMock(LoggerInterface::class)))->record(
+			run: $this->aRun(),
+			entries: [
+				['transition' => 'first', 'status' => 'completed'],
+				['transition' => 'second', 'status' => 'completed'],
+			]
+		);
+
+		$this->assertSame(['first', 'second'], $seen, 'One unwritable row must not cost the rest their history.');
+	}//end testAFailedInsertDoesNotStopTheRemainingSteps()
+
+	/**
+	 * A non-array entry is skipped rather than crashing the recorder.
+	 */
+	public function testMalformedEntriesAreSkipped(): void {
+		$steps = $this->createMock(FlowRunStepMapper::class);
+		$steps->method('highestSequence')->willReturn(0);
+
+		$count = 0;
+		$steps->method('insert')->willReturnCallback(
+			function (FlowRunStep $step) use (&$count) {
+				$count++;
+
+				return $step;
+			}
+		);
+
+		(new FlowStepHistory(steps: $steps))->record(
+			run: $this->aRun(),
+			entries: ['not an array', ['transition' => 'real', 'status' => 'completed']]
+		);
+
+		$this->assertSame(1, $count);
+	}//end testMalformedEntriesAreSkipped()
+
+	/**
+	 * A stopped step's REASON lands in the error column.
+	 *
+	 * A thrown step and a deliberately stopped one are each something a person
+	 * needs to read back, and they arrive under different keys.
+	 */
+	public function testAStopReasonIsRecordedAsTheStepsError(): void {
+		$steps = $this->createMock(FlowRunStepMapper::class);
+		$steps->method('highestSequence')->willReturn(0);
+
+		$errors = [];
+		$steps->method('insert')->willReturnCallback(
+			function (FlowRunStep $step) use (&$errors) {
+				$errors[] = $step->getError();
+
+				return $step;
+			}
+		);
+
+		(new FlowStepHistory(steps: $steps))->record(
+			run: $this->aRun(),
+			entries: [
+				['transition' => 'a', 'status' => 'failed', 'error' => 'it threw'],
+				['transition' => 'b', 'status' => 'stopped', 'reason' => 'author stopped it'],
+			]
+		);
+
+		$this->assertSame(['it threw', 'author stopped it'], $errors);
+	}//end testAStopReasonIsRecordedAsTheStepsError()
+}//end class


### PR DESCRIPTION
fix(flow): a shipped flow must belong to a tenant, or it imports into invisibility

Found by running the e2e for the first time, against a real instance.

Every flow READ is organisation-scoped (`FlowService::findAll()` refuses outright
when no tenant resolves). `SchemaFlowImportListener` never set one, so a flow
declared through `x-openregister-flows` was stored with `organisation` NULL and
returned by NOTHING: absent from the flows list, therefore impossible to open,
therefore impossible to ADOPT — while sitting perfectly intact in the table.

Measured on a clean instance: the declared `Case behandeling` flow was present in
`oc_openregister_flows` with 18 nodes and invisible to `/api/flows`, next to two
seeded flows that carried an organisation and listed fine. Backfilling the column
made it appear immediately, with `enabled=false` and `owner=NULL` intact.

Pre-existing: the importer has always done this. Nothing had noticed because this
is the first shipped flow declaration in the fleet — the two example flows are
seeded through a different path that sets the tenant.

The resolver is container-based and returns null rather than throwing, so a
declared flow still imports where OrganisationService is unavailable; it just
stays unlisted, and now says so in a warning instead of silently.
