### PR TITLE
fix(flow): a session-less schema import must fall back to the default organisation

### DIFF
--- a/lib/Listener/SchemaFlowImportListener.php
+++ b/lib/Listener/SchemaFlowImportListener.php
@@ -253,9 +253,18 @@ class SchemaFlowImportListener implements IEventListener {
 		}
 
 		try {
+			// 🔴 `getOrganisationForNewEntity()`, NOT `getActiveOrganisation()`.
+			// A schema import runs during install and during
+			// `occ maintenance:repair` — with NO user session, so there is no
+			// ACTIVE organisation to find and the flow imported ownerless and
+			// invisible all over again. This is the same call every ordinary
+			// object save makes, and it falls back to the DEFAULT organisation
+			// exactly for callers with no session. Measured 2026-08-28: the fix
+			// that resolved the active organisation passed on a dev stack that
+			// happened to have one, and failed in CI, which does not.
 			$uuid = $this->container
 				->get('OCA\OpenRegister\Service\OrganisationService')
-				->getActiveOrganisation()?->getUuid();
+				->getOrganisationForNewEntity();
 		} catch (Throwable $e) {
 			$this->logger->warning(
 				message: '[SchemaFlowImport] Could not resolve an organisation for a declared flow; '

--- a/tests/Unit/Listener/SchemaFlowImportListenerTest.php
+++ b/tests/Unit/Listener/SchemaFlowImportListenerTest.php
@@ -61,9 +61,9 @@ class SchemaFlowImportListenerTest extends TestCase {
 	/**
 	 * A container whose OrganisationService answers with $uuid.
 	 *
-	 * @param string|null $uuid  The active organisation's uuid, or null for
-	 *                           "there is an OrganisationService but no active
-	 *                           organisation".
+	 * @param string|null $uuid  What `getOrganisationForNewEntity()` resolves
+	 *                           to, or null for an instance that can resolve
+	 *                           no organisation at all.
 	 * @param boolean     $blows Whether resolving it throws, which models an
 	 *                           instance where the service is not registered.
 	 *
@@ -77,24 +77,30 @@ class SchemaFlowImportListenerTest extends TestCase {
 			return $container;
 		}
 
-		$organisation = null;
-		if ($uuid !== null) {
-			$organisation = new class($uuid) {
-				public function __construct(private string $uuid) {
-				}
-
-				public function getUuid(): string {
-					return $this->uuid;
-				}
-			};
-		}
-
-		$service = new class($organisation) {
-			public function __construct(private ?object $organisation) {
+		$service = new class($uuid) {
+			public function __construct(private ?string $uuid) {
 			}
 
+			/**
+			 * The call the listener MUST make.
+			 *
+			 * Not `getActiveOrganisation()`: this one falls back to the DEFAULT
+			 * organisation when there is no session, which is the situation a
+			 * schema import actually runs in.
+			 */
+			public function getOrganisationForNewEntity(): ?string {
+				return $this->uuid;
+			}
+
+			/**
+			 * Present, and deliberately answering NOTHING.
+			 *
+			 * A session-less import is exactly where this returns null, so a
+			 * listener that reached for it would stamp no organisation — and
+			 * every test here would still pass if this returned a real value.
+			 */
 			public function getActiveOrganisation(): ?object {
-				return $this->organisation;
+				return null;
 			}
 		};
 
@@ -232,7 +238,7 @@ class SchemaFlowImportListenerTest extends TestCase {
 	 * invisible to `/api/flows`, next to two seeded flows that carried an
 	 * organisation and listed fine.
 	 */
-	public function testAnImportedFlowIsStampedWithTheActiveOrganisation(): void {
+	public function testAnImportedFlowIsStampedWithAnOrganisation(): void {
 		$listener = $this->listener([], $this->container('org-1'));
 		$this->fire($listener, $this->schema([
 			['name' => 'Triage', 'nodes' => [], 'edges' => []],
@@ -319,4 +325,29 @@ class SchemaFlowImportListenerTest extends TestCase {
 
 		$this->assertSame('org-owner', $this->updated[0]->getOrganisation());
 	}
-}
+
+	/**
+	 * 🔴 IT MUST ASK FOR "AN ORGANISATION FOR A NEW ENTITY", NOT THE ACTIVE ONE.
+	 *
+	 * A schema import runs during install and during `occ maintenance:repair`,
+	 * with no user session — so there IS no active organisation, and a listener
+	 * that asked for one stamped null and the flow was invisible again. The
+	 * double above answers null from `getActiveOrganisation()` precisely so that
+	 * regression cannot pass.
+	 *
+	 * Measured 2026-08-28: the active-organisation version went green on a dev
+	 * stack that happened to have one, and failed in CI, which does not.
+	 */
+	public function testItResolvesTheOrganisationTheWayEveryOtherNewEntityDoes(): void {
+		$listener = $this->listener([], $this->container('org-default'));
+		$this->fire($listener, $this->schema([
+			['name' => 'Triage', 'nodes' => [], 'edges' => []],
+		]));
+
+		$this->assertSame(
+			'org-default',
+			$this->inserted[0]->getOrganisation(),
+			'the default organisation is what a session-less import must fall back to'
+		);
+	}//end testItResolvesTheOrganisationTheWayEveryOtherNewEntityDoes()
+}//end class


### PR DESCRIPTION
## The defect

A schema import runs during install and during `occ maintenance:repair` — **with no user session**. `getActiveOrganisation()` therefore returns null, the declared flow is stored with `organisation = NULL`, and since every flow read is organisation-scoped it is invisible in `/api/flows`: it cannot be opened, so it can never be adopted, while sitting perfectly intact in the table.

This is the same defect #3005 set out to fix. That fix was **half a fix** — it resolved the *active* organisation, which exists on a developer's stack and does not exist on a CI runner.

## How it was found

dossiq's case-flow e2e, which asserts the shipped flow is present in the store:

```
Error: The case flow was not found in the flow store. It is declared as
x-openregister-flows on the case schema, so its absence means the register
import did not run or the declaration was rejected.
```

🔑 **It passed locally and failed in CI, and the difference was the fixture, not the code.** The isolated stack I verified on happened to have an active organisation.

## The fix

`getOrganisationForNewEntity()` — the call every ordinary object save already makes, which falls back to the **default** organisation exactly for callers with no session.

## Why the tests could not have caught it before, and can now

The old double answered a real value from `getActiveOrganisation()`, so both spellings passed. It now answers **null** from that method, so a listener reaching for it stamps nothing. Reverting the call turns two tests red — verified.