### PR TITLE
chore(deps): take @conduction/nextcloud-vue 2.22.0 — the flow objects panel reaches users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
-        "@conduction/nextcloud-vue": "^2.21.0",
+        "@conduction/nextcloud-vue": "^2.22.0",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "^2.6.0",
         "@nextcloud/capabilities": "^1.2.1",
@@ -2112,9 +2112,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.21.0.tgz",
-      "integrity": "sha512-5HjI4X8k2IYxUeBdHa2OK/MnLhOFf4HxkF5dUGl42dWmYPDaPHjvawDMZcUcyP6wsP+rk0QzmPov4FGu/4Rn7Q==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.22.0.tgz",
+      "integrity": "sha512-fSownvGfPJdaQlbEMHCFu4YsSD4EoZ3DsAGQjs2YlvIaB+7elN7calVeNyzQHs0e3uxyMbmEEIM5AjdB5U1X+Q==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
-    "@conduction/nextcloud-vue": "^2.21.0",
+    "@conduction/nextcloud-vue": "^2.22.0",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "^2.6.0",
     "@nextcloud/capabilities": "^1.2.1",


### PR DESCRIPTION
Last step of the run/node object-attribution work. The panel showing **which objects a run touched** has existed in nc-vue since #834 and has reached nobody, because openregister's lockfile was pinned to 2.21.0 — and the lockfile decides, not the range.

## The change

Two files, four lines each way:

- `package.json`: `^2.21.0` → `^2.22.0`
- `package-lock.json`: `2.21.0` → `2.22.0` (+ integrity)

**Exactly one package changed in the lockfile.** No collateral churn.

### Why the range moves too

`^2.21.0` already admits 2.22.0, so bumping the floor is not strictly required — it is deliberate. A floor of `^2.21.0` keeps resolving a version *without* the panel perfectly happily: the app builds, boots, and renders an empty sidebar. That silent-empty outcome is the exact failure this change removes, so the floor should encode what the code actually needs.

## Resolved with npm 11, on purpose

`.npmrc` sets `min-release-age=2` and its own comment records that **npm 10 does not implement it**; `engines.npm` is `^11.0.0` for that reason. 2.22.0 published today, so the cooldown is in scope — it resolved *forward* regardless, because `min-release-age-exclude[]` covers `@conduction/*`. That exclusion exists precisely for first-party releases, and this confirms it works.

## Verified, not assumed

| check | result |
|---|---|
| `npm ci` | exit 0 — lock and manifest agree, which is what CI runs |
| installed `package.json` | `2.22.0` on disk |
| `npm run build` | exit 0 |
| `grep` in built `js/` | vendor bundle contains `loadRunObjects`, `runObjects`, and the path `flow-runs/\${f}/objects` |

That last row is the one that matters. The built frontend calls `flow-runs/{uuid}/objects`, and #2979 added exactly that route on the server — **the two halves now name the same endpoint**, which is the thing a passing install would not have told us.

openregister renders `<CnFlowSidebar />` in `src/views/flows/FlowDetailSidebar.vue`, so the panel arrives with the component rather than needing any call-site change here.