### PR TITLE
fix(import): a register import must not unlink schemas it cannot see

### DIFF
--- a/lib/Service/Configuration/ImportHandler.php
+++ b/lib/Service/Configuration/ImportHandler.php
@@ -885,6 +885,39 @@ class ImportHandler {
 					return $existingRegister;
 				}
 
+				// NEVER DROP A SCHEMA LINK THIS IMPORT COULD NOT RE-ESTABLISH.
+				//
+				// The caller builds `$data['schemas']` purely from `schemasMap`,
+				// which holds only the schemas THIS run processed — the schema
+				// pass does `if ($schema === null) { continue; }` before
+				// populating it, so a schema that already existed and was skipped
+				// or rejected never enters the map. The id list arriving here is
+				// then missing it, and this update REPLACES the register's list,
+				// unlinking a schema the register still owns.
+				//
+				// Nothing fails when that happens. The schema keeps its table and
+				// its rows; the register simply stops listing it. Every
+				// register-scoped read then returns an empty collection for data
+				// that is present — indistinguishable from a working-but-empty
+				// install, which is exactly how #2935 presented: 60 of dossiq's
+				// schemas unlinked, 11 of them holding rows, reported as "the
+				// config import silently writes zero objects".
+				//
+				// Union rather than replace: a link this run can prove stays, and
+				// a link it merely cannot see is left alone. The failure direction
+				// becomes a STALE link, which `occ
+				// openregister:registers:relink-schemas` already reports and
+				// repairs; the opposite direction loses reachable data with no
+				// error anywhere.
+				if (isset($data['schemas']) === true && is_array($data['schemas']) === true) {
+					$existingSchemaIds = $existingRegister->getSchemas();
+					if (is_array($existingSchemaIds) === true && $existingSchemaIds !== []) {
+						$data['schemas'] = array_values(
+							array_unique(array_merge($existingSchemaIds, $data['schemas']))
+						);
+					}
+				}
+
 				// Update existing register.
 				$existingRegister = $this->registerMapper->updateFromArray(id: $existingRegister->getId(), object: $data);
 				if ($owner !== null) {


### PR DESCRIPTION
Fixes the mechanism behind #2935.

## What breaks

`ImportHandler` builds a register's schema-id list purely from `schemasMap`, then **replaces** the register's list with it:

```php
if ($schema === null) { continue; }                 // skipped OR rejected — never enters the map
$this->schemasMap[$schema->getSlug()] = $schema;
...
foreach ($registerData['schemas'] as $schemaSlug) {
    if (($this->schemasMap[$schemaSlug] ?? null) !== null) { $schemaIds[] = ...; continue; }
    // warns: "This register will be created without this schema reference."
}
$registerData['schemas'] = $schemaIds;              // REPLACE
```

`schemasMap` holds only what the current run processed. An existing schema that is skipped or rejected never enters it, so the list reaching `updateFromArray()` is short and the link is replaced away.

**Nothing fails.** The schema keeps its table and its rows. The register just stops listing it. Every register-scoped read then reports an empty collection for data that is present — which is indistinguishable from a working-but-empty install.

## What that looked like in the field

Measured on a live instance for #2935 — dossiq, NC 34.0.0.12, openregister 1.1.5:

```
occ openregister:registers:relink-schemas --register=14
  → 60 schemas belong to this register and were not listed
     id=102 brpPerson       10 rows     id=112 kccQuickAction  5 rows
     id=103 kvkCompany      10 rows     id=113 belplan         2 rows
     id=104 beschikking      3 rows     ...
```

`--write` restored the links. **No re-import, no data change** — and objects that had read as `total: 0` for weeks became readable again. That is what identifies the linkage, not the objects, as the defect.

## The change

Union rather than replace, in `importRegister()` where the existing register is already in hand:

```php
$existingSchemaIds = $existingRegister->getSchemas();
if (is_array($existingSchemaIds) === true && $existingSchemaIds !== []) {
    $data['schemas'] = array_values(array_unique(array_merge($existingSchemaIds, $data['schemas'])));
}
```

A link this run can prove stays; a link it merely cannot see is left alone. The failure direction becomes a **stale** link, which `relink-schemas` already reports and repairs. The current direction loses reachable data with no error anywhere.

## What I verified, and what I did not

**Verified — no regression.** Applied to a live instance, forced a dossiq register re-import: **150 linked schemas before, 150 after.** Reverted to stock, repeated: also 150. `php -l` clean.

**Not verified — the benefit.** I could not reproduce the original loss on demand. A *forced* import processes every schema into `schemasMap`, so that path cannot drop anything, patched or not. The historical loss came from some other path — a non-forced import, a partial run, an upgrade — that I could not recreate.

So this is reasoned from the code and shown harmless, not shown curative. I am flagging that prominently rather than burying it: earlier in the same investigation I proposed a one-line change that was valid JSON Schema, matched the property's own documentation, and had green CI — and it broke schema creation outright, caught only by running it against a real instance. Please weigh this with that in mind. If you would rather fix the skip path that leaves `schemasMap` incomplete, that addresses the same defect closer to its cause.
