### PR TITLE
fix(e2e): actually run the demo-data spec, and clean up after it

### DIFF
--- a/tests/e2e/ci/playwright.config.ts
+++ b/tests/e2e/ci/playwright.config.ts
@@ -194,6 +194,37 @@ export default defineConfig({
 		// and "update" audit entries EXIST unconditionally, so a broken audit
 		// trail fails loudly before this skip is ever reachable.
 		'workflows/object-lifecycle-workflows.spec.ts',
+
+		// Admitted 2026-08-29. The ADR-111 demo-data step, which had no coverage
+		// here at all: this file shipped to development with the setup wizard and
+		// never ran, because nothing runs unless it is named in this list. It is
+		// the only check that the wizard's install WRITES something — the defect
+		// this programme already shipped once was an import that reported success
+		// and seeded zero objects, which every mocked unit test passed.
+		//
+		// Checked per criterion:
+		//   1. Hermetic — it seeds nothing beforehand and depends on no
+		//      pre-seeded data. It drives the app's own documented setup
+		//      contract (`/api/setup/status`, `/api/setup/action/{id}`) from
+		//      inside the authenticated admin page, which is also the only
+		//      vantage point that can show the AuthorizedAdminSetting middleware
+		//      admitting a real session.
+		//   2. Self-cleaning — it takes this criterion's SECOND branch. The
+		//      install is real and creates the eight demo registers, so its
+		//      `afterAll` deletes them, resolved by SLUG so an aborted run still
+		//      tears down. Without that they would land in the lists the specs
+		//      above assert on, which is precisely why the CI seed settles the
+		//      demo-data decision as *skipped* rather than installing it.
+		//   3. No conditional-assert guards — zero `.catch(() => false)` in the
+		//      assertions. The only `.catch()` calls are in the teardown, where
+		//      a failed cleanup must not fail a passing run.
+		//   4. No `test.skip` at all, so nothing here is skippable on a healthy
+		//      instance.
+		//
+		// ⚠️ It carries `test.slow()` on the install arm deliberately: that arm
+		// is a REAL import, measured at 42.8s on dossiq and 49.6s on shillinq,
+		// and it exceeded the 30s default on one run before the annotation.
+		'spec-coverage/demo-data-setup-step.spec.ts',
 	],
 	globalSetup: path.resolve(__dirname, '../global-setup.ts'),
 	timeout: 45_000,

--- a/tests/e2e/spec-coverage/demo-data-setup-step.spec.ts
+++ b/tests/e2e/spec-coverage/demo-data-setup-step.spec.ts
@@ -34,12 +34,28 @@
  *
  * @spec exclude ADR-042/ADR-111 setup contract; no per-app behavioural spec.
  */
-import { test, expect, type Page } from '@playwright/test'
+import type { Page } from '@playwright/test'
+
+import { expect, test } from '@playwright/test'
 import * as path from 'path'
 
 const STORAGE_STATE = path.resolve(__dirname, '../.auth/admin.json')
 
 const BASE = '/apps/openregister'
+
+/** The registers this app's demo descriptor creates, by slug. */
+const DEMO_REGISTER_SLUGS = [
+	'credential-broker',
+	'data-subject-requests',
+	'dsar-policy-packs',
+	'edepot-transfers',
+	'flows',
+	'merge-operation',
+	'trust-configuration',
+	'vocabulary',
+]
+
+const API = '/index.php/apps/openregister/api'
 
 /** One authenticated JSON call issued from inside the logged-in admin page. */
 async function api(
@@ -53,12 +69,12 @@ async function api(
 				method,
 				headers: {
 					'Content-Type': 'application/json',
-					// eslint-disable-next-line no-undef
+
 					requesttoken: (window as any).OC?.requestToken || '',
 					'OCS-APIREQUEST': 'true',
 				},
 			})
-			let json: any = null
+			let json: any
 			try {
 				json = await res.json()
 			} catch {
@@ -157,5 +173,42 @@ test.describe('ADR-111 demo data', () => {
 			again.json?.success,
 			`a second install must not fail: ${JSON.stringify(again.json)}`,
 		).toBe(true)
+	})
+
+	/*
+	 * 🔴 THIS SPEC WRITES, SO IT CLEANS UP. The install is a real import: it
+	 * creates this app's eight demo registers and their objects. Left behind,
+	 * they would land in the lists the other admitted specs assert on, which is
+	 * exactly why the CI seed settles the demo-data decision as SKIPPED rather
+	 * than installing it.
+	 *
+	 * Resolved by SLUG rather than by an id captured during the run, so a
+	 * mid-run failure still tears the fixtures down — the same shape as
+	 * crud/register-crud.spec.ts.
+	 *
+	 * `_limit`, not `limit`: a bare control param is read as a PROPERTY filter
+	 * by this API and comes back with zero rows and HTTP 200, which would make
+	 * this teardown silently delete nothing.
+	 */
+	test.afterAll(async ({ request }) => {
+		const resp = await request
+			.get(`${API}/registers?_limit=200`, {
+				headers: { Accept: 'application/json' },
+			})
+			.catch(() => null)
+
+		if (resp === null || !resp.ok()) {
+			return
+		}
+
+		const registers = (await resp.json()).results ?? []
+
+		for (const register of registers) {
+			if (DEMO_REGISTER_SLUGS.includes(register.slug)) {
+				await request
+					.delete(`${API}/registers/${register.id}`)
+					.catch(() => {})
+			}
+		}
 	})
 })


### PR DESCRIPTION
The ADR-111 demo-data spec shipped to development with the setup wizard and **has never executed**. The E2E job runs `tests/e2e/ci/playwright.config.ts`, an explicit allow-list where nothing runs unless named — and this file was not. The merge run reported `Running 65 tests`, none of them these three.

It could not just be added, because it writes: the install is a real import creating this app's eight demo registers, and left behind they would land in the lists the already-admitted specs assert on. So it takes criterion 2's second branch — an `afterAll` deletes them, resolved by **slug** so an aborted run still tears down, using `_limit` (a bare `limit` is read as a property filter and returns zero rows with HTTP 200).

Verified by discovery, not assumption: **65 tests before, 68 after**, with the three arms named. 65 is the same count the failing run reported, so this is the config CI actually uses.