### PR TITLE
feat(release): allow a release to be dispatched by hand

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,13 @@ name: Release
 on:
   push:
     branches: [main, beta, development]
+  # Lets a human force a release without pushing — the shared workflow already
+  # expects this: its skip guard is written `github.event_name != 'push' || …`
+  # precisely so a dispatch is "deliberately never skipped … including of a
+  # commit this guard would refuse". 18 of the 21 fleet apps already declare it;
+  # this repo was one of the three that did not, so the only way to trigger a
+  # release here was to push.
+  workflow_dispatch:
 
 jobs:
   unstable:


### PR DESCRIPTION
Lets a release be triggered by hand instead of only by a push.

## Why this is a gap rather than a new idea

The **shared** workflow already expects a dispatch. Its skip guard is written:

```yaml
if: >-
  github.event_name != 'push'
  || !( startsWith(github.event.head_commit.message, 'chore(release):') || … )
```

with the comment:

> `workflow_dispatch` is deliberately never skipped, so a human can always force a release by hand — including of a commit this guard would refuse.

So the capability was designed for; the caller here just never declared the trigger.

**18 of the 21 fleet apps already declare it.** This repo is one of the three that did not — the others being the other two in this batch. Measured across all 21 rather than assumed.

## What it does not change

The per-branch job conditions are untouched. `github.ref` is the branch the dispatch runs on, so:

| dispatched on | job selected |
|---|---|
| `development` | `unstable` |
| `beta` | `beta` |
| `main` | `stable` |

A dispatch cannot release a branch the workflow would not otherwise release.

## Why it matters right now

With no dispatch trigger, the only way to test a release — for instance to verify an App Store token actually publishes — is to push to `beta`, which promotes real code and publishes to the public store. That is a heavy way to answer a small question.

Verified: YAML parses on all three, `on:` now carries both `push` and `workflow_dispatch`, 3 jobs intact; pushed file byte-identical to the intended patch.
