### PR TITLE
style(e2e): run prettier over tests/e2e/global-setup.ts

### DIFF
--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -250,7 +250,10 @@ export default async function globalSetup(config: FullConfig): Promise<void> {
 	try {
 		await page.evaluate(() => {
 			try {
-				window.localStorage.setItem('cn-walkthrough-seen:openregister', '999.0.0')
+				window.localStorage.setItem(
+					'cn-walkthrough-seen:openregister',
+					'999.0.0',
+				)
 			} catch (e) {
 				// localStorage unavailable — specs fall back to dismissing by hand.
 			}


### PR DESCRIPTION
Fixes **Frontend Check (format)** on `development`.

```
[warn] tests/e2e/global-setup.ts
[warn] Code style issues found in the above file. Run Prettier with --write to fix.
##[error]Process completed with exit code 1
```

## Reproduced with this repo's own config, not a bare prettier

This matters: running prettier in a scratch directory without the repo's configuration answers a different question and can be wrong in either direction. I reproduced it with

- this repo's `package.json` `prettier` key → `@nextcloud/prettier-config`
- this repo's `.prettierignore`
- prettier `3.9.6`, matching the declared devDependency

…and got the same `[warn]` CI reports. After `--write`, `--check` passes.

## Formatting only

No statement changes. This is exactly the `--write` the checker's own message asks for. The typical change is a long line wrapped:

```diff
-window.localStorage.setItem('cn-walkthrough-seen:openregister', '999.0.0')
+window.localStorage.setItem(
+  'cn-walkthrough-seen:openregister',
+  '999.0.0',
+)
```

## Swept the fleet, not just the red apps

Two apps were red on this today. I checked **all 21** rather than fixing those two, and **eight** carry the unformatted file:

`openregister`, `opencatalogi`, `zaakafhandelapp`, `pipelinq`, `learniq`, `buildiq`, `humaniq`, `planninq`

The other six were going to go red as soon as their format check next ran — they simply had not run it yet, or were red for something else first. Fixing only the visible two would have left the same defect to resurface app by app next week.

Two of the eight (`humaniq`, `planninq`) have much larger diffs — several hundred lines — because their copy had never been formatted at all, not just the recent walkthrough addition. The check requires the whole file to pass, so `--write` is the fix in every case.
