### PR TITLE
style(e2e): wrap the seeded setItem call to satisfy prettier

### DIFF
--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -250,7 +250,10 @@ export default async function globalSetup(config: FullConfig): Promise<void> {
 	try {
 		await page.evaluate(() => {
 			try {
-				window.localStorage.setItem('cn-walkthrough-seen:openregister', '999.0.0')
+				window.localStorage.setItem(
+					'cn-walkthrough-seen:openregister',
+					'999.0.0',
+				)
 			} catch (e) {
 				// localStorage unavailable — specs fall back to dismissing by hand.
 			}


### PR DESCRIPTION
`prettier --check` fails on the walkthrough marker seeded earlier today. Purely a line-width wrap — the marker and its behaviour are unchanged.

Length-dependent, which is why the identical insertion passed in shorter-named apps: `cn-walkthrough-seen:openregister` pushes the `setItem` call past the print width where a shorter app id does not. Every app that seeded the marker was checked against its own prettier config, not a scratch-dir copy, and the diff here is asserted to touch only the seeded call.