### PR TITLE
test(e2e): let the seed disable Nextcloud's first-run wizard

### DIFF
--- a/tests/e2e/ci/seed.sh
+++ b/tests/e2e/ci/seed.sh
@@ -65,6 +65,25 @@ else
 	echo "e2e-other already in $GROUP (or could not be added) — the specs will verify"
 fi
 
+# NEXTCLOUD'S OWN FIRST-RUN WIZARD BLOCKS THE ACCOUNTS THIS SCRIPT JUST MADE.
+#
+# `firstrunwizard` opens a modal on a new account's first page load -- the
+# "A collaboration platform that puts you in control" panel. Its mask sits over
+# the app, so every click the specs make is swallowed. It is not the app's own
+# setup wizard, and the specs' Escape-based dismissal does not close it:
+# object-shares-tab reported `a modal is still covering the page after three
+# Escapes`, and flow-controls reported the connection never reaching the canvas
+# -- two unrelated-looking failures with one cause.
+#
+# The accounts above are created fresh every time, so they always meet it. The
+# app is disabled instance-wide rather than per-user because there is no
+# per-user "mark seen" that occ exposes, and a test instance has no use for it.
+if php occ app:disable firstrunwizard; then
+	echo 'disabled firstrunwizard'
+else
+	echo 'firstrunwizard already disabled (or not installed)'
+fi
+
 echo 'e2e seed complete'
 
 # ── Settle the demo-data decision ────────────────────────────────────────────


### PR DESCRIPTION
`tests/e2e/ci/seed.sh` creates `e2e-owner` and `e2e-other` fresh on every run — and a fresh Nextcloud account meets the **firstrunwizard** modal on its first page load, the *"A collaboration platform that puts you in control"* panel. Its mask covers the app, so every click the specs make is swallowed.

### Why it doesn't look like one bug

It surfaces as two unrelated failures:

| spec | message |
|---|---|
| `object-shares-tab` | `a modal is still covering the page after three Escapes` |
| `flow-controls` | `the connection did not reach the canvas` (`.vue-flow__edge` count 0, expected 1) |

Neither mentions a wizard. The flow one in particular reads as a broken drag-and-drop or a flaky selector — the element resolves, is reported *visible, enabled and stable*, and the click still does nothing.

It is also **not** the app's own setup wizard, which the seed already handles with `skip-demo-data`. That one reports `completed: true` while this one is still on screen. Worth noting: openregister's `/api/setup/status` is admin-only, so a non-admin account cannot query or complete a wizard at all — chasing that endpoint is a dead end for these accounts.

### Evidence

Local instance against `development`, same build, same seeded accounts, only this variable changed:

```
firstrunwizard enabled    flow-controls FAILED
firstrunwizard disabled   flow-controls PASSED
```

### The change

One idempotent block in `seed.sh`, in the same style as the user and group seeding above it, tolerating the app being absent or already disabled. Disabled instance-wide rather than per-user because `occ` exposes no per-user "mark seen", and a test instance has no use for the wizard.

`bash -n tests/e2e/ci/seed.sh` parses clean. Note the file's own header warning: the shared workflow runs this through an **unquoted** `eval`, so everything stays inside the script where it is parsed exactly once — this change adds no new shell metacharacters to the invocation.
