### PR TITLE
chore(deps): bump zod from 3.25.76 to 4.4.3 and migrate call sites

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "vue-material-design-icons": "^5.2.0",
         "vue-router": "^5.2.0",
         "vue3-apexcharts": "~1.8.0",
-        "zod": "^3.22.4"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@babel/core": "^7.23.9",
@@ -2431,6 +2431,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2447,6 +2448,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2463,6 +2465,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2479,6 +2482,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2495,6 +2499,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2511,6 +2516,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2527,6 +2533,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2543,6 +2550,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2559,6 +2567,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2575,6 +2584,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2591,6 +2601,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2607,6 +2618,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2623,6 +2635,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2639,6 +2652,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2655,6 +2669,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2671,6 +2686,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2687,6 +2703,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2703,6 +2720,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2719,6 +2737,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2735,6 +2754,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2751,6 +2771,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2767,6 +2788,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2783,6 +2805,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2799,6 +2822,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2815,6 +2839,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2831,6 +2856,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4296,6 +4322,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5607,6 +5634,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5620,6 +5648,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5633,6 +5662,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5646,6 +5676,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5659,6 +5690,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5672,6 +5704,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5685,6 +5718,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5698,6 +5732,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5711,6 +5746,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5724,6 +5760,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5737,6 +5774,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5750,6 +5788,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5763,6 +5802,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5776,6 +5816,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5789,6 +5830,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5802,6 +5844,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5815,6 +5858,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5828,6 +5872,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5841,6 +5886,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5854,6 +5900,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5867,6 +5914,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5880,6 +5928,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5893,6 +5942,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5906,6 +5956,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5919,6 +5970,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6499,7 +6551,7 @@
       "version": "5.10.0",
       "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
       "integrity": "sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
@@ -6520,7 +6572,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7158,7 +7210,7 @@
       "version": "8.67.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.67.0.tgz",
       "integrity": "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.67.0",
@@ -7183,7 +7235,7 @@
       "version": "8.67.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
       "integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/tsconfig-utils": "^8.67.0",
@@ -7205,7 +7257,7 @@
       "version": "8.67.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
       "integrity": "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.67.0",
@@ -7223,7 +7275,7 @@
       "version": "8.67.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
       "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7265,7 +7317,7 @@
       "version": "8.67.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
       "integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7279,7 +7331,7 @@
       "version": "8.67.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
       "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/project-service": "8.67.0",
@@ -7307,7 +7359,7 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7344,7 +7396,7 @@
       "version": "8.67.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
       "integrity": "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.67.0",
@@ -7362,7 +7414,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -12853,6 +12905,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -22703,7 +22756,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
       "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.12"
@@ -24984,9 +25037,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "vue-material-design-icons": "^5.2.0",
     "vue-router": "^5.2.0",
     "vue3-apexcharts": "~1.8.0",
-    "zod": "^3.22.4"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@babel/core": "^7.23.9",

--- a/src/entities/application/application.ts
+++ b/src/entities/application/application.ts
@@ -1,4 +1,4 @@
-import type { SafeParseReturnType } from 'zod'
+import type { ZodSafeParseResult } from 'zod'
 import type { TApplication } from './application.types'
 
 import { z } from 'zod'
@@ -77,7 +77,7 @@ export class Application implements TApplication {
 		this.updated = application.updated || ''
 	}
 
-	public validate(): SafeParseReturnType<TApplication, unknown> {
+	public validate(): ZodSafeParseResult<unknown> {
 		const schema = z.object({
 			id: z.number().optional(),
 			uuid: z.string().optional(),

--- a/src/entities/auditTrail/auditTrail.ts
+++ b/src/entities/auditTrail/auditTrail.ts
@@ -1,4 +1,4 @@
-import type { SafeParseReturnType } from 'zod'
+import type { ZodSafeParseResult } from 'zod'
 import type { TAuditTrail } from './auditTrail.types'
 
 import { z } from 'zod'
@@ -62,7 +62,7 @@ export class AuditTrail implements TAuditTrail {
 		this.size = auditTrail.size || 0
 	}
 
-	public validate(): SafeParseReturnType<TAuditTrail, unknown> {
+	public validate(): ZodSafeParseResult<unknown> {
 		const schema = z.object({
 			id: z.number(),
 			uuid: z.string().uuid(),

--- a/src/entities/configuration/configuration.ts
+++ b/src/entities/configuration/configuration.ts
@@ -1,4 +1,4 @@
-import type { SafeParseReturnType } from 'zod'
+import type { ZodSafeParseResult } from 'zod'
 import type { TConfiguration } from './configuration.types'
 
 import { z } from 'zod'
@@ -69,7 +69,7 @@ export class ConfigurationEntity implements TConfiguration {
 	/**
 	 * Validates the configuration against a schema
 	 */
-	public validate(): SafeParseReturnType<TConfiguration, unknown> {
+	public validate(): ZodSafeParseResult<unknown> {
 		const schema = z.object({
 			id: z.string().min(1),
 			title: z.string().min(1),

--- a/src/entities/database/database.ts
+++ b/src/entities/database/database.ts
@@ -1,4 +1,4 @@
-import type { SafeParseReturnType } from 'zod'
+import type { ZodSafeParseResult } from 'zod'
 import type { TDatabase } from './database.types'
 
 import { z } from 'zod'
@@ -20,7 +20,7 @@ export class Database implements TDatabase {
 		this.tablePrefix = database.tablePrefix || ''
 	}
 
-	public validate(): SafeParseReturnType<TDatabase, unknown> {
+	public validate(): ZodSafeParseResult<unknown> {
 		const schema = z.object({
 			id: z.string().min(1),
 			name: z.string().min(1),

--- a/src/entities/object/object.spec.ts
+++ b/src/entities/object/object.spec.ts
@@ -103,10 +103,16 @@ describe('Object Entity', () => {
 		expect(validation.success).toBe(false)
 
 		if (!validation.success) {
+			// zod 4 reworded the built-in `too_small` message: zod 3 emitted
+			// "String must contain at least 1 character(s)". The constraint
+			// itself (`z.string().min(1)` on `@self.id`) is unchanged, so the
+			// issue is additionally pinned by `code` to keep this assertion
+			// anchored on the rule rather than on zod's wording.
 			expect(validation.error.issues).toContainEqual(
 				expect.objectContaining({
 					path: ['@self', 'id'],
-					message: 'String must contain at least 1 character(s)',
+					code: 'too_small',
+					message: 'Too small: expected string to have >=1 characters',
 				}),
 			)
 		}

--- a/src/entities/object/object.ts
+++ b/src/entities/object/object.ts
@@ -1,4 +1,4 @@
-import type { SafeParseReturnType } from 'zod'
+import type { ZodSafeParseResult } from 'zod'
 import type { TObject } from './object.types'
 
 import { z } from 'zod'
@@ -83,7 +83,7 @@ export class ObjectEntity implements TObject {
 	/**
 	 * Validates the object against a schema
 	 */
-	public validate(): SafeParseReturnType<TObject, unknown> {
+	public validate(): ZodSafeParseResult<unknown> {
 		const schema = z
 			.object({
 				'@self': z.object({

--- a/src/entities/organisation/organisation.ts
+++ b/src/entities/organisation/organisation.ts
@@ -1,4 +1,4 @@
-import type { SafeParseReturnType } from 'zod'
+import type { ZodSafeParseResult } from 'zod'
 import type { TOrganisation } from './organisation.types'
 
 import { z } from 'zod'
@@ -84,7 +84,7 @@ export class Organisation implements TOrganisation {
 		this.updated = organisation.updated || ''
 	}
 
-	public validate(): SafeParseReturnType<TOrganisation, unknown> {
+	public validate(): ZodSafeParseResult<unknown> {
 		const crudSchema = z.object({
 			create: z.array(z.string()).optional(),
 			read: z.array(z.string()).optional(),

--- a/src/entities/register/register.ts
+++ b/src/entities/register/register.ts
@@ -1,4 +1,4 @@
-import type { SafeParseReturnType } from 'zod'
+import type { ZodSafeParseResult } from 'zod'
 import type { TRegister } from './register.types'
 
 import { z } from 'zod'
@@ -54,7 +54,7 @@ export class Register implements TRegister {
 		this.stats = register.stats
 	}
 
-	public validate(): SafeParseReturnType<TRegister, unknown> {
+	public validate(): ZodSafeParseResult<unknown> {
 		const schema = z.object({
 			id: z.string().min(1),
 			title: z.string().min(1),

--- a/src/entities/schema/schema.ts
+++ b/src/entities/schema/schema.ts
@@ -1,4 +1,4 @@
-import type { SafeParseReturnType } from 'zod'
+import type { ZodSafeParseResult } from 'zod'
 import type { TSchema } from './schema.types'
 
 import { z } from 'zod'
@@ -74,7 +74,7 @@ export class Schema implements TSchema {
 		this.stats = schema.stats
 	}
 
-	public validate(): SafeParseReturnType<TSchema, unknown> {
+	public validate(): ZodSafeParseResult<unknown> {
 		const schema = z.object({
 			id: z.string().min(1),
 			title: z.string().min(1),
@@ -97,7 +97,7 @@ export class Schema implements TSchema {
 				.optional(),
 			hardValidation: z.boolean(),
 			maxDepth: z.number().int().min(0),
-			authorization: z.record(z.array(z.string())).optional(),
+			authorization: z.record(z.string(), z.array(z.string())).optional(),
 		})
 
 		return schema.safeParse(this)

--- a/src/entities/source/source.ts
+++ b/src/entities/source/source.ts
@@ -1,4 +1,4 @@
-import type { SafeParseReturnType } from 'zod'
+import type { ZodSafeParseResult } from 'zod'
 import type { TSource } from './source.types'
 
 import { z } from 'zod'
@@ -28,7 +28,7 @@ export class Source implements TSource {
 		this.created = source.created || ''
 	}
 
-	public validate(): SafeParseReturnType<TSource, unknown> {
+	public validate(): ZodSafeParseResult<unknown> {
 		const schema = z.object({
 			id: z.union([z.string(), z.number()]),
 			title: z.string().min(1),

--- a/src/entities/view/view.ts
+++ b/src/entities/view/view.ts
@@ -8,7 +8,7 @@
  * @version  1.0.0
  */
 
-import type { SafeParseReturnType } from 'zod'
+import type { ZodSafeParseResult } from 'zod'
 import type { TView } from './view.types'
 
 import { z } from 'zod'
@@ -60,7 +60,7 @@ export class View implements TView {
 		this.updated = view.updated || ''
 	}
 
-	public validate(): SafeParseReturnType<TView, unknown> {
+	public validate(): ZodSafeParseResult<unknown> {
 		const schema = z.object({
 			id: z.number().optional(),
 			uuid: z.string().optional(),
@@ -69,7 +69,7 @@ export class View implements TView {
 			owner: z.string().optional(),
 			isPublic: z.boolean().optional(),
 			isDefault: z.boolean().optional(),
-			query: z.record(z.any()).optional(),
+			query: z.record(z.string(), z.any()).optional(),
 			favoredBy: z.array(z.string()).optional(),
 			quota: z
 				.object({


### PR DESCRIPTION
Supersedes #2987. That PR bumps the dependency only, so `quality / Frontend Tests (unit)` goes red and the derived `Quality Report` fails with it. This branch carries the same bump **plus** the zod 4 migration.

## What actually broke

Reproduced locally against zod 4.4.3 before changing any code:

| instrument | zod 3 baseline (`development`) | zod 4, before migration | zod 4, after migration |
| --- | --- | --- | --- |
| `npx jest --silent` | exit 0 — 35 suites / 304 tests | **exit 1** — 1 suite / 1 test | exit 0 — 35 suites / 304 tests |
| `npx tsc --noEmit` | exit 2 — 8 errors | exit 2 — **21** errors | exit 2 — 8 errors (byte-identical to baseline) |
| `npm run build` | — | — | exit 0 |
| `npm run lint` | — | — | exit 0 (817 pre-existing warnings, 0 errors) |
| `npm run format` | — | — | exit 0 |

The 8 remaining `tsc` errors (`src/reference/init.ts`, `src/store/modules/endpoints.ts`) are pre-existing and unrelated to zod — measured in a separate `git worktree` checked out at `development` with its own `npm ci`, so the two trees were never confused.

## Changes

**`package.json` / `package-lock.json`** — `zod` `^3.22.4` → `^4.4.3`, lock pinned at 4.4.3 (the version #2987 proposed).

**Ten entity files** (`application`, `auditTrail`, `configuration`, `database`, `object`, `organisation`, `register`, `schema`, `source`, `view`) — zod 4 no longer exports `SafeParseReturnType`. Its replacement takes one type parameter, so `SafeParseReturnType<TFoo, unknown>` becomes `ZodSafeParseResult<unknown>`. In zod 3 that declaration typed `data` as `unknown` and `error` as `ZodError<TFoo>`; `ZodSafeParseResult<unknown>` keeps `data: unknown` unchanged, and `ZodError`'s type parameter does not affect `.issues`, which is all any caller reads. This is an `import type` change — zero runtime effect.

**`src/entities/schema/schema.ts`** — `z.record(z.array(z.string()))` → `z.record(z.string(), z.array(z.string()))`. zod 4 made the key schema mandatory; `z.string()` is exactly what zod 3 inferred, so the constraint is unchanged.

**`src/entities/view/view.ts`** — same fix for `z.record(z.any())` → `z.record(z.string(), z.any())`.

## The one assertion that changed

`src/entities/object/object.spec.ts` — "should fail validation with invalid @self data" asserted zod 3's built-in wording:

```
'String must contain at least 1 character(s)'
```

zod 4 reworded that message to `'Too small: expected string to have >=1 characters'`. The rule itself — `z.string().min(1)` on `@self.id` — is untouched, and the issue is still raised on the same path. The assertion is updated to the new message and additionally pins `code: 'too_small'`, so it is anchored on the validation rule rather than on zod's prose.

No other test asserts a zod message. No test was deleted or skipped.

## Evidence that nothing was loosened

No schema was weakened and no validation was replaced with `z.any()`. To prove that rather than assert it, all ten validators were run over **4,325 mutated inputs** (every top-level key and every key one level deeper, crossed with 13 mutations: omit / null / empty string / number / string / boolean / empty array / empty object / array-of-number / object variants) in both trees — the `development` worktree on zod 3.25.76 and this branch on zod 4.4.3 — and the results diffed.

**Accept/reject verdict disagreements: 0 out of 4,325.**

The only deltas are cosmetic, and all are zod 4's new issue taxonomy:

- `invalid_string` → `invalid_format` (34 cases, all the `.uuid()` / `.url()` checks)
- `invalid_enum_value` → `invalid_value` (1 case)
- where a `z.string().min(1)` field receives a non-string, zod 4 reports `invalid_type` **and** a companion `too_small`, whereas zod 3 short-circuited after `invalid_type` (12 cases). An extra issue on the same path, same verdict.

## Not merging this myself

Leaving the merge to a human. #2987 can be closed once this lands.
