### PR TITLE
chore(deps): @conduction/nextcloud-vue 2.22.1 -> 2.24.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
-        "@conduction/nextcloud-vue": "^2.22.1",
+        "@conduction/nextcloud-vue": "^2.24.1",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "^2.6.0",
         "@nextcloud/capabilities": "^1.2.1",
@@ -2112,9 +2112,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.22.1.tgz",
-      "integrity": "sha512-Dw19XXFYkLntKjv/0Fb3N4WBw6SzYn8hG5YbjEyor3DW1E/bNCA+6PO88xknyOIklhy5urcSmouVzPQQromb5Q==",
+      "version": "2.24.1",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.24.1.tgz",
+      "integrity": "sha512-SErJI0x5814WtsqGIy0i+bIEW/sDfvTGRXGidqenH/DB2khsV44qAxh860BKvLX9Mb8YGg5Z1C5xaYlBT0gaqw==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
-    "@conduction/nextcloud-vue": "^2.22.1",
+    "@conduction/nextcloud-vue": "^2.24.1",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "^2.6.0",
     "@nextcloud/capabilities": "^1.2.1",


### PR DESCRIPTION
## What

Bumps `@conduction/nextcloud-vue` from **2.22.1** to **2.24.1**.

The `package.json` range was already `^2.22.1`, which *accepts* 2.24.1 — but `npm ci` honours the **lockfile**, which pinned 2.22.1 exactly. The meaningful change here is therefore the lockfile.

## Why this matters — silent data loss

2.24.1 fixes a bug that **silently discarded user edits**:

- `CnDetailPage` mounted its edit dialog as soon as the *schema* arrived, before the *record* had loaded.
- The dialog therefore opened blank.
- When the record finally landed, `CnFormDialog`'s watcher re-seeded `formData` and **threw away whatever the user had typed**.
- Save then PUT the pristine, unedited record and the server answered **HTTP 200**.

So the edit vanished with no error in the UI, no error in the console, and no error in the logs. The user believed they had saved. The bug has been present since 2.20.1, and this app has been shipping it.

## Verification

- Lockfile read back and confirmed at `2.24.1`.
- `npm run build` — exit 0.
- `npm test` — exit 0 (35 suites, 304 tests passed).

2.24.1 also carries widget/KPI changes between 2.22.1 and 2.24.1 (a shared `--cn-kpi-*` scale, coloured widget title icons, flush tables, widget empty states), which is why the build was re-verified rather than assumed.