### PR TITLE
fix(flow): the editor's Run now is the documented draft exception

### DIFF
--- a/lib/Controller/FlowController.php
+++ b/lib/Controller/FlowController.php
@@ -45,6 +45,7 @@ use OCA\OpenRegister\Service\Flow\FlowDeadEnd;
 use OCA\OpenRegister\Service\Flow\FlowLifecycleRefused;
 use OCA\OpenRegister\Service\Flow\FlowNodePreflight;
 use OCA\OpenRegister\Service\Flow\FlowNodeRegistry;
+use OCA\OpenRegister\Service\Flow\FlowRunVersionPin;
 use OCA\OpenRegister\Service\Flow\FlowService;
 use OCA\OpenRegister\Service\Flow\FlowVersionService;
 use OCP\AppFramework\Controller;
@@ -787,12 +788,29 @@ class FlowController extends Controller {
 		$sync = ($syncParam === true || $syncParam === 'true' || $syncParam === '1' || $syncParam === 1);
 
 		try {
+			// THIS ENDPOINT IS THE EDITOR'S "RUN NOW", and that is the
+			// interactive draft test run — the one documented exception to "a
+			// draft cannot back a run" (`FlowPublishedGraph::overlayOnto`).
+			//
+			// Versioning (#3047) made every other trigger require a published
+			// version, correctly. But this path queued as MANUAL, so pressing
+			// Run in the editor on a flow that had never been published was
+			// refused — the exception the design carves out could not be
+			// reached from the only screen that needs it. Naming the trigger
+			// here is what connects the two.
 			$flowRun = $this->flows->run(
 				uuid: $id,
 				subject: (array)$subject,
 				context: (array)$context,
-				sync: $sync
+				sync: $sync,
+				trigger: FlowRunVersionPin::TRIGGER_TEST
 			);
+		} catch (FlowLifecycleRefused $e) {
+			// A REFUSAL, not a fault. It carries `reason` and `lifecycleStatus`
+			// precisely so the editor can offer the right button; letting it
+			// escape as a 500 threw that away and told the author only that
+			// something broke.
+			return $this->refusal(refusal: $e);
 		} catch (DoesNotExistException $e) {
 			return new JSONResponse(['error' => 'No such flow'], Http::STATUS_NOT_FOUND);
 		} catch (FlowDeadEnd $e) {

--- a/lib/Service/Flow/FlowService.php
+++ b/lib/Service/Flow/FlowService.php
@@ -557,11 +557,19 @@ class FlowService {
 	 * @param array<string, mixed> $subject `{uuid, register, schema}` of the object.
 	 * @param array<string, mixed> $context Run-level metadata.
 	 * @param boolean $sync Execute inline and return the finished run.
+	 * @param string $trigger The dispatch trigger recorded on the run.
+	 *
+	 * `$trigger` is what the version pin reads to decide whether this run may
+	 * walk a DRAFT. `FlowRunVersionPin::TRIGGER_TEST` is the interactive
+	 * draft test run — the one documented exception to "a draft cannot back a
+	 * run" (see `FlowPublishedGraph::overlayOnto`). Every other trigger
+	 * requires a published version, which is the point of versioning.
 	 *
 	 * @return FlowRun The queued run, or the finished run when $sync is true.
 	 *
 	 * @throws DoesNotExistException When no such flow exists, or it is not the caller's.
 	 * @throws FlowDeadEnd When a node's token has nowhere to go, so the run is refused.
+	 * @throws FlowLifecycleRefused When the trigger requires a published version and there is none.
 	 *
 	 * @SuppressWarnings(PHPMD.BooleanArgumentFlag) $sync chooses WHO advances the
 	 * run, not what running means: the same run row is queued either way, and
@@ -570,13 +578,19 @@ class FlowService {
 	 *
 	 * @spec openspec/changes/flow-engine-unification/specs/flow-storage/spec.md
 	 */
-	public function run(string $uuid, array $subject = [], array $context = [], bool $sync = false): FlowRun {
+	public function run(
+		string $uuid,
+		array $subject = [],
+		array $context = [],
+		bool $sync = false,
+		string $trigger = Flow::TRIGGER_MANUAL
+	): FlowRun {
 		$flow = $this->find(uuid: $uuid);
 
 		$run = $this->runner->queue(
 			flowId: (string)$flow->getUuid(),
 			subject: $subject,
-			trigger: Flow::TRIGGER_MANUAL,
+			trigger: $trigger,
 			context: $context,
 			user: $this->actingUser()
 		);

--- a/tests/Unit/Controller/FlowLifecycleControllerTest.php
+++ b/tests/Unit/Controller/FlowLifecycleControllerTest.php
@@ -284,4 +284,66 @@ class FlowLifecycleControllerTest extends TestCase {
 			$this->controller->version(id: 'flow-1', version: 99)->getStatus()
 		);
 	}//end testAnUnknownVersionNumberIs404()
+
+	/**
+	 * 🔴 THE EDITOR'S "RUN NOW" IS THE DOCUMENTED DRAFT EXCEPTION.
+	 *
+	 * Versioning made every dispatch require a published version, with one
+	 * carve-out spelled out in `FlowPublishedGraph::overlayOnto`: "an unpinned
+	 * run is the interactive draft test run — the one documented exception to
+	 * 'a draft cannot back a run'".
+	 *
+	 * `flow#run` is the endpoint the editor's Run button posts to, so it IS
+	 * that interactive run. It queued as MANUAL, which is not exempt, so a flow
+	 * that had never been published could not be run from the only screen the
+	 * exception exists for. This pins the trigger it must pass.
+	 *
+	 * @return void
+	 */
+	public function testTheEditorRunEndpointQueuesAsTheInteractiveTestRun(): void {
+		$captured = null;
+		$this->flows->method('run')->willReturnCallback(
+			function (string $uuid, array $subject, array $context, bool $sync, string $trigger) use (&$captured) {
+				$captured = $trigger;
+				return new \OCA\OpenRegister\Db\FlowRun();
+			}
+		);
+
+		$this->controller->run(id: 'flow-1');
+
+		$this->assertSame(
+			\OCA\OpenRegister\Service\Flow\FlowRunVersionPin::TRIGGER_TEST,
+			$captured,
+			'Run now must queue as the interactive test run, or the draft exception cannot be reached.'
+		);
+	}//end testTheEditorRunEndpointQueuesAsTheInteractiveTestRun()
+
+	/**
+	 * 🔴 A LIFECYCLE REFUSAL FROM THE RUN ENDPOINT IS A 409, NOT A 500.
+	 *
+	 * The refusal carries `reason` and `lifecycleStatus` so the editor can
+	 * offer the right button. Letting it escape uncaught threw that away and
+	 * told the author only that the server broke — which is what a 500 means,
+	 * and this is not one.
+	 *
+	 * @return void
+	 */
+	public function testARefusedRunAnswers409WithAReason(): void {
+		$this->flows->method('run')->willThrowException(
+			new FlowLifecycleRefused(
+				reason: FlowLifecycleRefused::REASON_NO_PUBLISHED_VERSION,
+				flowId: 'flow-1',
+				state: FlowVersion::STATUS_DRAFT
+			)
+		);
+
+		$response = $this->controller->run(id: 'flow-1');
+
+		$this->assertSame(Http::STATUS_CONFLICT, $response->getStatus());
+		$this->assertSame(
+			FlowLifecycleRefused::REASON_NO_PUBLISHED_VERSION,
+			$response->getData()['reason']
+		);
+	}//end testARefusedRunAnswers409WithAReason()
+
 }//end class


### PR DESCRIPTION
Fixes the red `flow-controls.spec.ts` on `development`: *"Run now was refused — the server answered 500"*. The server log names it:

```
This flow has no published version, so it cannot back a run. Publish a version first.
```

**Two defects, one path — and the first is a gap in #3047's own design, not a disagreement with it.**

Versioning correctly made every dispatch require a published version. It also carves out exactly one case, in `FlowPublishedGraph::overlayOnto`:

> An unpinned run is the interactive draft test run — the one documented exception to "a draft cannot back a run".

`FlowRunVersionPin::requirePublishedAndSound()` implements that exemption for `trigger === 'test'`, and `FlowRunController` passes it. But the editor's Run button posts to `flow#run` → `FlowService::run()`, which queued as `MANUAL` — so **the exception could not be reached from the only screen it exists for**. `FlowService::run()` now takes the trigger; the editor endpoint names itself as the interactive run.

**Second: the refusal escaped as a 500.** `FlowLifecycleRefused` was uncaught in `FlowController::run()`. That exception carries `reason` and `lifecycleStatus` *precisely* so the editor can offer the right button — its own docblock says so — and a 500 threw all of it away and told the author only that the server broke. It now returns the 409 the exception was designed for, through the same `refusal()` helper the other three call sites already use.

**Verification, not assertion:** both new tests **error with the source change reverted**. Flow suite 1218 tests green; phpcs and phpstan clean on the changed files.

Flagging for the #3047 author: if you intended Run now to require publishing even from the editor, then the carve-out in `FlowPublishedGraph` and `FlowRunVersionPin` is the thing to remove instead — but as it stands the code documents an exception it cannot reach.