### PR TITLE
chore(deps): @conduction/nextcloud-vue 2.24.1 -> 2.24.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
-        "@conduction/nextcloud-vue": "^2.24.1",
+        "@conduction/nextcloud-vue": "^2.24.2",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "^2.6.0",
         "@nextcloud/capabilities": "^1.2.1",
@@ -2112,9 +2112,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.24.1",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.24.1.tgz",
-      "integrity": "sha512-SErJI0x5814WtsqGIy0i+bIEW/sDfvTGRXGidqenH/DB2khsV44qAxh860BKvLX9Mb8YGg5Z1C5xaYlBT0gaqw==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.24.2.tgz",
+      "integrity": "sha512-BGvyJpRhzvLraZuyRB3ETJ6IESV27XZvL5vdvLd5kEvettFo+QWIo6JcHJhQk9np8QYGHBQ9gRHCp3v6y7Y2gw==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
-    "@conduction/nextcloud-vue": "^2.24.1",
+    "@conduction/nextcloud-vue": "^2.24.2",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "^2.6.0",
     "@nextcloud/capabilities": "^1.2.1",


### PR DESCRIPTION
Bumps `@conduction/nextcloud-vue` from **2.24.1** to **2.24.2**.

## Why: WCAG 2.1 AA contrast failure, currently live

2.24.1 shipped a KPI card restyle that painted the card's **number** with Nextcloud's `--color-success` / `--color-warning` / `--color-error`. Those are **fill** colours, meant to sit *behind* content — not foreground text colours. Rendered as text on a light card, axe-core measured:

```
color-contrast, serious, WCAG 2 AA (1.4.3)
foreground #d8f3da on background #f5f5f5 — contrast 1.08, required 3:1
.cn-kpi-card--success > .cn-kpi-card__body > .cn-kpi-card__value-row > .cn-kpi-card__value
```

A contrast ratio of **1.08:1 against a required 3:1** — the number is very nearly invisible.

This was caught by filinq's `gate-33 axe-core` (run 33261801989). Only the `success` variant happened to be on screen there; `warning` and `error` carry the same defect, unrendered. 2.24.2 fixes it by painting the accent with the `-text` tokens instead (ConductionNL/nextcloud-vue#853).

## Change

`package.json` already allowed 2.24.2 via caret, but `npm ci` honours the **lockfile**, so the lockfile is the meaningful edit. Both files move.

## Verification

- `package-lock.json` read back and confirmed at `2.24.2`
- `npm run build` — exit 0
- unit suite — exit 0
