### PR TITLE
fix(validation): return the 400 instead of 500-ing on a message-only rejection

### DIFF
--- a/lib/Service/Object/ValidateObject.php
+++ b/lib/Service/Object/ValidateObject.php
@@ -2227,10 +2227,22 @@ class ValidateObject {
 			$property = $exception->getProperty();
 		}
 
+		// `getErrors()` is typed `?ValidationError` and IS null for every
+		// ValidationException thrown with a message alone — readOnly enforcement
+		// on update is one such path, and says so where it throws. Formatting
+		// that null is a TypeError, so the 400 this method exists to return
+		// became a 500 with the reason nowhere in the response: the caller saw
+		// "server error" instead of "cannot modify readOnly property X".
+		$formatted = [];
+		$validationError = $exception->getErrors();
+		if ($validationError !== null) {
+			$formatted = (new ErrorFormatter())->format($validationError);
+		}
+
 		$errors[] = [
 			'property' => $property,
 			'message' => $exception->getMessage(),
-			'errors' => (new ErrorFormatter())->format($exception->getErrors()),
+			'errors' => $formatted,
 		];
 
 		return new JSONResponse(

--- a/tests/Unit/Service/Object/ValidateObjectCoverageTest.php
+++ b/tests/Unit/Service/Object/ValidateObjectCoverageTest.php
@@ -692,6 +692,31 @@ class ValidateObjectCoverageTest extends TestCase {
 		$this->assertSame('Validation failed', $data['message']);
 	}
 
+	public function testHandleValidationExceptionWithNoOpisErrorStillReturns400(): void {
+		// 🔴 THE REGRESSION THIS GUARDS. `ValidationException::getErrors()` is
+		// typed `?ValidationError` and IS null whenever the exception is thrown
+		// with a message alone — readOnly enforcement on update does exactly
+		// that, and says so where it throws. Passing that null to
+		// `ErrorFormatter::format()` is a TypeError, so the 400 this method
+		// exists to produce became a 500 with the reason nowhere in it.
+		//
+		// Measured on dossiq: every case edit answered 500, the server log
+		// carrying `ErrorFormatter::format(): Argument #1 ($error) must be of
+		// type ValidationError, null given`, and the edit silently never saved.
+		$exception = new ValidationException(message: 'Cannot modify readOnly property: reference');
+
+		$response = $this->handler->handleValidationException($exception);
+
+		$this->assertInstanceOf(JSONResponse::class, $response);
+		$this->assertSame(400, $response->getStatus());
+		$data = $response->getData();
+		$this->assertSame('error', $data['status']);
+		// The REASON must survive into the response — that is the whole point
+		// of the 400, and what the TypeError was destroying.
+		$this->assertStringContainsString('readOnly', $data['errors'][0]['message']);
+		$this->assertSame([], $data['errors'][0]['errors']);
+	}
+
 	// =========================================================================
 	// generateErrorMessage
 	// =========================================================================


### PR DESCRIPTION
`handleValidationException()` formats `$exception->getErrors()` unconditionally. That getter is typed `?ValidationError` and **is null** for every `ValidationException` thrown with a message alone — `enforceReadOnlyOnUpdate()` is one such path and says so where it throws.

So `ErrorFormatter::format(null)` is a TypeError, and the 400 this method exists to return became a **500 carrying none of the reason**. Observed in dossiq's server log for every case edit:

```
ErrorFormatter::format(): Argument #1 ($error) must be of type ValidationError,
null given, called in .../ValidateObject.php on line 2233
```

The caller saw *server error* where the server had a precise sentence for it — "Cannot modify readOnly property: X".

**Mutation-verified**: removing the guard reproduces that TypeError verbatim in the new test, which otherwise asserts a 400 whose message still names the violated property. phpstan clean, phpcs 0 errors.