### PR TITLE
fix(calc): a sequence-bearing identifier must survive an update

### DIFF
--- a/lib/Command/RematerialiseCalculationsCommand.php
+++ b/lib/Command/RematerialiseCalculationsCommand.php
@@ -210,6 +210,15 @@ class RematerialiseCalculationsCommand extends Command {
 					continue;
 				}
 
+				// A `sequence` reserves exactly once, on create. This command has no
+				// SequenceContext, so re-evaluating would resolve the node to null and
+				// `concat` would render it as "", replacing every assigned number with
+				// a truncated stub ("2026-0013" -> "2026-"). Never rewrite those.
+				// openregister#3072.
+				if ($this->evaluator->expressionUsesSequence($spec['expression'] ?? null) === true) {
+					continue;
+				}
+
 				try {
 					$value = $this->evaluator->evaluate($payload, $spec['expression'] ?? null);
 					if ($value instanceof DateTimeInterface) {

--- a/lib/Command/RematerialiseCalculationsCommand.php
+++ b/lib/Command/RematerialiseCalculationsCommand.php
@@ -214,7 +214,7 @@ class RematerialiseCalculationsCommand extends Command {
 				// SequenceContext, so re-evaluating would resolve the node to null and
 				// `concat` would render it as "", replacing every assigned number with
 				// a truncated stub ("2026-0013" -> "2026-"). Never rewrite those.
-				// openregister#3072.
+				// openregister#3075.
 				if ($this->evaluator->expressionUsesSequence($spec['expression'] ?? null) === true) {
 					continue;
 				}

--- a/lib/Listener/CalculationOnSaveListener.php
+++ b/lib/Listener/CalculationOnSaveListener.php
@@ -170,7 +170,7 @@ class CalculationOnSaveListener implements IEventListener {
 			// null — but the evaluator then resolves the `sequence` node to null and
 			// `concat` renders that as "", so re-materialising would OVERWRITE the
 			// number assigned at create ("2026-0013" -> "2026-"). Skip the field and
-			// leave the stored value untouched. openregister#3072.
+			// leave the stored value untouched. openregister#3075.
 			if ($sequenceContext === null
 				&& $this->evaluator->expressionUsesSequence($spec['expression'] ?? null) === true
 			) {

--- a/lib/Listener/CalculationOnSaveListener.php
+++ b/lib/Listener/CalculationOnSaveListener.php
@@ -165,6 +165,18 @@ class CalculationOnSaveListener implements IEventListener {
 				continue;
 			}
 
+			// A `sequence` reserves its number exactly once, on create, through the
+			// SequenceContext built above. On update the context is deliberately
+			// null — but the evaluator then resolves the `sequence` node to null and
+			// `concat` renders that as "", so re-materialising would OVERWRITE the
+			// number assigned at create ("2026-0013" -> "2026-"). Skip the field and
+			// leave the stored value untouched. openregister#3072.
+			if ($sequenceContext === null
+				&& $this->evaluator->expressionUsesSequence($spec['expression'] ?? null) === true
+			) {
+				continue;
+			}
+
 			try {
 				$value = $this->evaluator->evaluate($data, $spec['expression'] ?? null, $sequenceContext);
 			} catch (EvaluationException $e) {

--- a/lib/Service/Calculation/CalculationEvaluator.php
+++ b/lib/Service/Calculation/CalculationEvaluator.php
@@ -952,7 +952,7 @@ class CalculationEvaluator {
 	 *
 	 * Every caller that materialises a calculation must therefore skip a
 	 * sequence-bearing expression while no context is active, leaving the
-	 * stored value untouched. See openregister#3072.
+	 * stored value untouched. See openregister#3075.
 	 *
 	 * @param mixed $expression Expression AST (any node).
 	 *

--- a/lib/Service/Calculation/CalculationEvaluator.php
+++ b/lib/Service/Calculation/CalculationEvaluator.php
@@ -940,6 +940,45 @@ class CalculationEvaluator {
 	}//end sequence()
 
 	/**
+	 * Whether an expression tree contains a `sequence` node.
+	 *
+	 * A `sequence` reserves its running number exactly once, on create, through
+	 * the per-save SequenceContext. Off that path {@see self::sequence()}
+	 * deliberately returns null — which is correct for the evaluator but
+	 * catastrophic for a caller that PERSISTS the result: `concat` renders the
+	 * null as an empty string, so a declared identifier such as
+	 * `concat(year(startDate), "-", sequence(...))` recomputes to "2026-" and
+	 * overwrites the number assigned at create.
+	 *
+	 * Every caller that materialises a calculation must therefore skip a
+	 * sequence-bearing expression while no context is active, leaving the
+	 * stored value untouched. See openregister#3072.
+	 *
+	 * @param mixed $expression Expression AST (any node).
+	 *
+	 * @return bool True when a `sequence` operator appears anywhere in the tree.
+	 *
+	 * @spec openspec/specs/computed-fields/spec.md#requirement-save-time-evaluation
+	 */
+	public function expressionUsesSequence(mixed $expression): bool {
+		if (is_array($expression) === false) {
+			return false;
+		}
+
+		foreach ($expression as $key => $value) {
+			if ($key === 'sequence') {
+				return true;
+			}
+
+			if ($this->expressionUsesSequence(expression: $value) === true) {
+				return true;
+			}
+		}
+
+		return false;
+	}//end expressionUsesSequence()
+
+	/**
 	 * Coerce a value to DateTimeImmutable when possible.
 	 *
 	 * @param mixed $v The value to coerce.

--- a/lib/Service/Calculation/TemporalCalculationSweepService.php
+++ b/lib/Service/Calculation/TemporalCalculationSweepService.php
@@ -266,7 +266,7 @@ class TemporalCalculationSweepService {
 			// A `sequence` only resolves on the create path, where a
 			// SequenceContext is active; the sweep never has one. Recomputing here
 			// would render the node as "" and report a spurious change on every
-			// pass (and, before openregister#3072, persist the truncated value).
+			// pass (and, before openregister#3075, persist the truncated value).
 			if ($this->evaluator->expressionUsesSequence($spec['expression'] ?? null) === true) {
 				continue;
 			}

--- a/lib/Service/Calculation/TemporalCalculationSweepService.php
+++ b/lib/Service/Calculation/TemporalCalculationSweepService.php
@@ -263,6 +263,14 @@ class TemporalCalculationSweepService {
 		$changed = false;
 
 		foreach ($calcs as $name => $spec) {
+			// A `sequence` only resolves on the create path, where a
+			// SequenceContext is active; the sweep never has one. Recomputing here
+			// would render the node as "" and report a spurious change on every
+			// pass (and, before openregister#3072, persist the truncated value).
+			if ($this->evaluator->expressionUsesSequence($spec['expression'] ?? null) === true) {
+				continue;
+			}
+
 			try {
 				$value = $this->evaluator->evaluate($payload, $spec['expression'] ?? null);
 			} catch (EvaluationException $e) {

--- a/tests/Unit/Listener/CalculationOnSaveListenerSequenceTest.php
+++ b/tests/Unit/Listener/CalculationOnSaveListenerSequenceTest.php
@@ -3,7 +3,7 @@
 /**
  * OpenRegister CalculationOnSaveListenerSequenceTest
  *
- * Regression cover for openregister#3072: a materialised calculation that
+ * Regression cover for openregister#3075: a materialised calculation that
  * contains a `sequence` node must NOT be recomputed on the update path, where
  * no SequenceContext exists. Re-evaluating there resolves the node to null,
  * `concat` renders it as an empty string, and the number assigned at create is
@@ -160,7 +160,7 @@ class CalculationOnSaveListenerSequenceTest extends TestCase {
 	}//end objectWith()
 
 	/**
-	 * openregister#3072 — on UPDATE the assigned running number survives.
+	 * openregister#3075 — on UPDATE the assigned running number survives.
 	 *
 	 * Before the fix the evaluator resolved the context-less `sequence` node to
 	 * null, `concat` rendered "2026-", and the listener wrote that over the

--- a/tests/Unit/Listener/CalculationOnSaveListenerSequenceTest.php
+++ b/tests/Unit/Listener/CalculationOnSaveListenerSequenceTest.php
@@ -1,0 +1,235 @@
+<?php
+
+/**
+ * OpenRegister CalculationOnSaveListenerSequenceTest
+ *
+ * Regression cover for openregister#3072: a materialised calculation that
+ * contains a `sequence` node must NOT be recomputed on the update path, where
+ * no SequenceContext exists. Re-evaluating there resolves the node to null,
+ * `concat` renders it as an empty string, and the number assigned at create is
+ * silently overwritten with a truncated stub ("2026-0013" -> "2026-").
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Listener
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Listener;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Event\ObjectCreatingEvent;
+use OCA\OpenRegister\Event\ObjectUpdatingEvent;
+use OCA\OpenRegister\Listener\CalculationOnSaveListener;
+use OCA\OpenRegister\Service\Calculation\CalculationEvaluator;
+use OCA\OpenRegister\Service\Calculation\CalculationPayloadBuilder;
+use OCA\OpenRegister\Service\Search\PlaceholderResolver;
+use OCA\OpenRegister\Service\SequenceService;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Sequence-bearing calculations survive an update.
+ */
+class CalculationOnSaveListenerSequenceTest extends TestCase {
+
+	/**
+	 * The dossiq `case.identifier` calculation, verbatim: the year of
+	 * `startDate`, a dash, and a yearly running number.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private const IDENTIFIER_CALC = [
+		'type' => 'string',
+		'materialise' => true,
+		'expression' => [
+			'concat' => [
+				['year' => ['prop' => 'startDate']],
+				'-',
+				['sequence' => ['scope' => 'yearly', 'pad' => 4]],
+			],
+		],
+	];
+
+	/**
+	 * A materialised calculation with no `sequence` node — it must keep
+	 * recomputing on update, so the guard is not over-broad.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private const SLUG_CALC = [
+		'type' => 'string',
+		'materialise' => true,
+		'expression' => ['concat' => [['prop' => 'title'], '!']],
+	];
+
+	/** @var SchemaMapper&\PHPUnit\Framework\MockObject\MockObject */
+	private $schemaMapper;
+
+	/** @var RegisterMapper&\PHPUnit\Framework\MockObject\MockObject */
+	private $registerMapper;
+
+	/** @var CalculationPayloadBuilder&\PHPUnit\Framework\MockObject\MockObject */
+	private $payloadBuilder;
+
+	/** @var SequenceService&\PHPUnit\Framework\MockObject\MockObject */
+	private $sequences;
+
+	private CalculationOnSaveListener $listener;
+
+	/**
+	 * Wire the listener with a REAL evaluator and mocked collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$userSession = $this->createMock(IUserSession::class);
+		$userSession->method('getUser')->willReturn(null);
+
+		$this->schemaMapper = $this->createMock(SchemaMapper::class);
+		$this->registerMapper = $this->createMock(RegisterMapper::class);
+		$this->payloadBuilder = $this->createMock(CalculationPayloadBuilder::class);
+		$this->sequences = $this->createMock(SequenceService::class);
+
+		// The payload builder only injects/strips the synthetic @self/@ref/
+		// @aggregate keys; none of the calculations under test use them.
+		$this->payloadBuilder->method('build')
+			->willReturnCallback(static fn (ObjectEntity $o): array => $o->getObject());
+		$this->payloadBuilder->method('stripSyntheticKeys')
+			->willReturnCallback(static fn (array $d): array => $d);
+
+		$register = new Register();
+		$register->setId(16);
+		$this->registerMapper->method('find')->willReturn($register);
+
+		$this->listener = new CalculationOnSaveListener(
+			$this->schemaMapper,
+			$this->registerMapper,
+			new CalculationEvaluator(new PlaceholderResolver($userSession)),
+			$this->payloadBuilder,
+			$this->sequences,
+			$this->createMock(LoggerInterface::class)
+		);
+
+	}//end setUp()
+
+	/**
+	 * Build a schema declaring the given calculations.
+	 *
+	 * @param array<string, mixed> $calcs The calculations block.
+	 *
+	 * @return Schema
+	 */
+	private function schemaWith(array $calcs): Schema {
+		$schema = new Schema();
+		$schema->setId(26);
+		$schema->setConfiguration(['x-openregister-calculations' => $calcs]);
+		$this->schemaMapper->method('find')->willReturn($schema);
+
+		return $schema;
+	}//end schemaWith()
+
+	/**
+	 * Build an object carrying the given business data.
+	 *
+	 * @param array<string, mixed> $data The stored object data.
+	 *
+	 * @return ObjectEntity
+	 */
+	private function objectWith(array $data): ObjectEntity {
+		$object = new ObjectEntity();
+		$object->setUuid('ce4b0570-3bf4-4133-a08b-3a9b03b2cc20');
+		$object->setRegister('16');
+		$object->setSchema('26');
+		$object->setObject($data);
+
+		return $object;
+	}//end objectWith()
+
+	/**
+	 * openregister#3072 — on UPDATE the assigned running number survives.
+	 *
+	 * Before the fix the evaluator resolved the context-less `sequence` node to
+	 * null, `concat` rendered "2026-", and the listener wrote that over the
+	 * stored "2026-0013". Any app whose identifier is readOnly then had every
+	 * subsequent edit rejected with "Cannot modify readOnly property".
+	 *
+	 * @return void
+	 */
+	public function testUpdateDoesNotOverwriteAnAssignedSequenceIdentifier(): void {
+		$this->schemaWith(['identifier' => self::IDENTIFIER_CALC]);
+		$this->sequences->expects($this->never())->method('reserveNext');
+
+		$object = $this->objectWith(
+			['title' => 'Editable case', 'startDate' => '2026-08-29', 'identifier' => '2026-0013']
+		);
+
+		$this->listener->handle(new ObjectUpdatingEvent($object));
+
+		$this->assertSame('2026-0013', $object->getObject()['identifier']);
+
+	}//end testUpdateDoesNotOverwriteAnAssignedSequenceIdentifier()
+
+	/**
+	 * The guard is scoped to sequence-bearing expressions: every other
+	 * materialised calculation still recomputes on update.
+	 *
+	 * @return void
+	 */
+	public function testUpdateStillRecomputesCalculationsWithoutASequence(): void {
+		$this->schemaWith(
+			['identifier' => self::IDENTIFIER_CALC, 'slug' => self::SLUG_CALC]
+		);
+
+		$object = $this->objectWith(
+			[
+				'title' => 'Edited case',
+				'startDate' => '2026-08-29',
+				'identifier' => '2026-0013',
+				'slug' => 'stale',
+			]
+		);
+
+		$this->listener->handle(new ObjectUpdatingEvent($object));
+
+		$data = $object->getObject();
+		$this->assertSame('Edited case!', $data['slug'], 'non-sequence calculation still recomputes');
+		$this->assertSame('2026-0013', $data['identifier'], 'sequence-bearing calculation is left alone');
+
+	}//end testUpdateStillRecomputesCalculationsWithoutASequence()
+
+	/**
+	 * CREATE is unchanged: the sequence reserves exactly one number and the
+	 * identifier is materialised from it.
+	 *
+	 * @return void
+	 */
+	public function testCreateStillReservesAndMaterialisesTheIdentifier(): void {
+		$this->schemaWith(['identifier' => self::IDENTIFIER_CALC]);
+		$this->sequences->expects($this->once())
+			->method('reserveNext')
+			->with(16, 26, date('Y'))
+			->willReturn(13);
+
+		$object = $this->objectWith(['title' => 'New case', 'startDate' => '2026-08-29']);
+
+		$this->listener->handle(new ObjectCreatingEvent($object));
+
+		$this->assertSame('2026-0013', $object->getObject()['identifier']);
+
+	}//end testCreateStillReservesAndMaterialisesTheIdentifier()
+
+}//end class


### PR DESCRIPTION
## The defect

`CalculationOnSaveListener` re-materialises **every** `materialise: true` calculation on both create and update. A `sequence` node, by design, only reserves a number on the create path — off it the evaluator returns `null` (`SequenceContext` is deliberately absent). `concat` then renders that null as `""`.

So an identifier declared as `concat(year(startDate), "-", sequence(yearly, pad 4))` recomputes to `"2026-"` on the next save, and the listener **writes it over** the number assigned at create:

```
stored "2026-0013"  ->  update  ->  stored "2026-"
```

The existing comment says the null context means "a re-materialise never burns a fresh number". It does achieve that — but the intent was to *preserve* the assigned number, and the code *destroys* it instead.

## Why it is user-visible

dossiq's `case.identifier` is the statutory zaaknummer: `readOnly: true` **and** sequence-calculated. Once the stored value is truncated, the edit form (which round-trips the value it was rendered with) trips readOnly enforcement:

```
PUT /apps/openregister/api/objects/dossiq/case/{id}   -> 400
{"status":"error","message":"Validation failed",
 "errors":[{"message":"Cannot modify readOnly property: identifier"}]}
```

**No case could be edited at all.** This is the sole remaining red test on dossiq's `development` (`tests/e2e/workflows/cases-crud.spec.ts:172`, "editing a case persists the change"); dossiq's E2E job installs `ConductionNL/openregister@development`, so this fix reaches it directly with no dossiq change.

Beyond the failing test, this is silent data loss: an Archiefwet case number is overwritten on an ordinary edit.

## The fix

Add `CalculationEvaluator::expressionUsesSequence()` and skip re-materialising a sequence-bearing calculation whenever no `SequenceContext` is active — leaving the stored value untouched.

Applied to all three paths that **persist** a recomputation:

| path | consequence before |
| --- | --- |
| `CalculationOnSaveListener` (update) | the corruption above |
| `TemporalCalculationSweepService` | spurious "changed" on every pass, re-saving every object nightly |
| `occ openregister:rematerialise-calculations` | rewrites **every** identifier in a register — and dossiq's schema descriptions tell admins to run it |

The two read-time paths (`RenderObject::applyVirtualCalculations`, `ManifestService::applyCalculations`) already skip materialised calculations, so they were never affected.

On create the behaviour is unchanged. If `buildSequenceContext()` cannot resolve the scope, the field is now left unset rather than written as a truncated stub — that case was already logged as a warning.

## Verification

`tests/Unit/Listener/CalculationOnSaveListenerSequenceTest.php` uses dossiq's `case.identifier` expression verbatim.

Against the **unpatched** `lib/` it reproduces production exactly:

```
Tests: 3, Assertions: 5, Failures: 2      (exit 1)
-'2026-0013'
+'2026-'
```

With the fix: `OK (3 tests, 6 assertions)` — exit 0. Third test asserts create still reserves and materialises; second asserts a non-sequence calculation still recomputes on update, so the guard is not over-broad.

Also run (real exit codes, no piping through `tail`):

- `phpunit tests/Unit/Service/Calculation + the new test` — OK, 123 tests, exit 0
- `phpunit tests/Unit/Listener tests/Unit/Command` — OK, 299 tests, exit 0
- `phpcs --standard=phpcs.xml --warning-severity=0` (4 changed lib files) — exit 0
- `psalm` (4 changed files) — No errors, exit 0
- `phpstan --memory-limit=1G` (4 changed files) — No errors, exit 0
- `phpmd` with the repo baseline (4 changed files) — exit 0

Not verified against a live instance: an isolated Nextcloud was not stood up, and the only running instance is shared, so the end-to-end argument rests on the failing run's `playwright-traces` bytes (dossiq run 33271947820) plus the unit reproduction above.