### PR TITLE
fix(flow): sweep version rows orphaned before the delete cascade existed

### DIFF
--- a/lib/Db/FlowVersionMapper.php
+++ b/lib/Db/FlowVersionMapper.php
@@ -190,4 +190,34 @@ class FlowVersionMapper extends QBMapper {
 		return (int)$qb->executeStatement();
 
 	}//end deleteByFlow()
+
+	/**
+	 * Delete version rows whose flow no longer exists.
+	 *
+	 * 🔑 A ONE-OFF SWEEP FOR INSTANCES UPGRADED MID-FLIGHT. `FlowService::delete()`
+	 * now cascades to this table, so no NEW orphan can appear — but any
+	 * instance that deleted a flow between the version table landing and that
+	 * cascade landing kept the rows. Measured on the dev instance: 38, growing
+	 * with every flow anyone removed.
+	 *
+	 * Safe on the same terms as the cascade: `delete()` removes a flow's RUNS
+	 * as well, so a version row whose flow is gone has no run left that could
+	 * be pinned to it.
+	 *
+	 * @return integer The number of orphaned rows removed.
+	 *
+	 * @spec openspec/changes/flow-definition-versioning/specs/flow-definition-versioning/spec.md
+	 */
+	public function deleteOrphaned(): int {
+		$qb = $this->db->getQueryBuilder();
+		$sub = $this->db->getQueryBuilder();
+
+		$sub->select('uuid')->from('openregister_flows');
+
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->notIn('flow_uuid', $qb->createFunction('(' . $sub->getSQL() . ')')));
+
+		return (int)$qb->executeStatement();
+
+	}//end deleteOrphaned()
 }//end class

--- a/lib/Repair/BackfillFlowVersions.php
+++ b/lib/Repair/BackfillFlowVersions.php
@@ -153,6 +153,20 @@ class BackfillFlowVersions implements IRepairStep {
 			)
 		);
 
+		// Sweep version rows whose flow is gone. `FlowService::delete()` now
+		// cascades to them, so no NEW orphan can appear — but an instance that
+		// deleted a flow between the version table landing and that cascade
+		// landing kept the rows, unreachable through any read path because
+		// every version read is keyed by flow.
+		try {
+			$orphans = $this->container->get(FlowVersionMapper::class)->deleteOrphaned();
+			if ($orphans > 0) {
+				$output->info(sprintf('Flow versions: removed %d orphaned version row(s).', $orphans));
+			}
+		} catch (Throwable $e) {
+			$output->warning('Orphaned flow versions could not be swept: ' . $e->getMessage());
+		}
+
 	}//end run()
 
 	/**

--- a/tests/Unit/Db/FlowVersionMapperDeleteTest.php
+++ b/tests/Unit/Db/FlowVersionMapperDeleteTest.php
@@ -91,4 +91,45 @@ class FlowVersionMapperDeleteTest extends TestCase {
 
 		$this->assertSame(0, (new FlowVersionMapper($db))->deleteByFlow(flowUuid: 'never-versioned'));
 	}//end testDeleteByFlowReportsZeroWhenThereWasNothingToRemove()
+
+	/**
+	 * The orphan sweep deletes only rows whose flow is GONE.
+	 *
+	 * 🔴 THE `notIn` IS THE WHOLE SAFETY PROPERTY. Without the predicate this
+	 * empties the table — every version of every live flow — which would strand
+	 * every in-flight run on the instance. So the test asserts the predicate is
+	 * built against the flows table, not merely that a delete ran.
+	 *
+	 * @return void
+	 */
+	public function testDeleteOrphanedOnlyRemovesRowsWhoseFlowIsGone(): void {
+		$expr = $this->createMock(IExpressionBuilder::class);
+		$expr->expects($this->once())
+			->method('notIn')
+			->with('flow_uuid', $this->anything())
+			->willReturn('flow_uuid NOT IN (...)');
+
+		$sub = $this->createMock(IQueryBuilder::class);
+		$sub->method('select')->willReturnSelf();
+		$sub->method('from')->willReturnSelf();
+		$sub->method('getSQL')->willReturn('SELECT uuid FROM oc_openregister_flows');
+
+		$qb = $this->createMock(IQueryBuilder::class);
+		$qb->method('expr')->willReturn($expr);
+		$qb->method('createFunction')->willReturnArgument(0);
+		$qb->expects($this->once())
+			->method('delete')
+			->with('openregister_flow_versions')
+			->willReturnSelf();
+		$qb->expects($this->once())
+			->method('where')
+			->with('flow_uuid NOT IN (...)')
+			->willReturnSelf();
+		$qb->expects($this->once())->method('executeStatement')->willReturn(38);
+
+		$db = $this->createMock(IDBConnection::class);
+		$db->method('getQueryBuilder')->willReturnOnConsecutiveCalls($qb, $sub);
+
+		$this->assertSame(38, (new FlowVersionMapper($db))->deleteOrphaned());
+	}//end testDeleteOrphanedOnlyRemovesRowsWhoseFlowIsGone()
 }//end class


### PR DESCRIPTION
## What was left behind

#3080 made `FlowService::delete()` cascade to `openregister_flow_versions`, so
no **new** orphan can appear. It did nothing about the rows already stranded.

Any instance that deleted a flow between the version table landing (#3047) and
that cascade landing kept those rows — unreachable through any read path the
app has, because every version read is keyed by flow. Measured here: **38**,
and the count grows with every flow anyone removes.

## Where the sweep lives

In the existing `BackfillFlowVersions` repair step, which already runs on
install and upgrade — rather than a new step nobody would think to invoke.

Safe on the same terms as the cascade: `delete()` removes a flow's **runs** as
well, so a version row whose flow is gone has no run left that could be pinned
to it.

## Verified on a live instance, not reasoned about

```
before: 38 orphans
occ maintenance:repair
  - Flow versions: published version 1 for 0 flow(s), 196 already versioned
  - Flow versions: removed 38 orphaned version row(s).
after:  0 orphans · 196 flows · 196 version rows · 0 unversioned non-drafts
```

That final line is the invariant this whole programme rests on: every flow that
can back a run has a version, and every version belongs to a flow.

## Testing

Dropping the `notIn` predicate — which would empty the table and strand every
in-flight run on the instance — turns the new test red. Db and Repair suites
green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
