### PR TITLE
chore(deps): bump cweagans/composer-patches from 1.7.3 to 2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,7 @@
 		"php": "^8.3",
 		"adbario/php-dot-notation": "^3.3.0",
 		"bamarni/composer-bin-plugin": "^1.8",
-		"cweagans/composer-patches": "^1.7",
+		"cweagans/composer-patches": "^2.0",
 		"ddn/sapp": "dev-feat/chained-filter-text-replace#5c406e91254d6936f44372db35f1cc15e5a06c56",
 		"dompdf/dompdf": "^3.1",
 		"dragonmantank/cron-expression": "^3.3",
@@ -163,7 +163,6 @@
 		}
 	},
 	"extra": {
-		"composer-exit-on-patch-failure": true,
 		"patches": {
 			"theodo-group/llphant": {
 				"Forward think:false + keep_alive:-1 to the Ollama API (qwen3 ~5x speedup, no idle-unload wedge) \u2014 drop when LLPhant adds a per-call keep_alive/think model option": "patches/llphant-ollama-think-keepalive.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c54554a5f7c891978d85cc5fa0611a00",
+    "content-hash": "4abcbc072574135787945c30bae5064a",
     "packages": [
         {
             "name": "adbario/php-dot-notation",
@@ -256,30 +256,99 @@
             "time": "2024-11-12T16:29:46+00:00"
         },
         {
-            "name": "cweagans/composer-patches",
-            "version": "1.7.3",
+            "name": "cweagans/composer-configurable-plugin",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/cweagans/composer-patches.git",
-                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db"
+                "url": "https://github.com/cweagans/composer-configurable-plugin.git",
+                "reference": "15433906511a108a1806710e988629fd24b89974"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
-                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
+                "url": "https://api.github.com/repos/cweagans/composer-configurable-plugin/zipball/15433906511a108a1806710e988629fd24b89974",
+                "reference": "15433906511a108a1806710e988629fd24b89974",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "require-dev": {
-                "composer/composer": "~1.0 || ~2.0",
-                "phpunit/phpunit": "~4.6"
+                "codeception/codeception": "~4.0",
+                "codeception/module-asserts": "^2.0",
+                "composer/composer": "~2.0",
+                "php-coveralls/php-coveralls": "~2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.0.0",
+                "phpro/grumphp": "^1.8.0",
+                "sebastian/phpcpd": "^6.0",
+                "squizlabs/php_codesniffer": "^3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "cweagans\\Composer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Cameron Eagans",
+                    "email": "me@cweagans.net"
+                }
+            ],
+            "description": "Provides a lightweight configuration system for Composer plugins.",
+            "support": {
+                "issues": "https://github.com/cweagans/composer-configurable-plugin/issues",
+                "source": "https://github.com/cweagans/composer-configurable-plugin/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/cweagans",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-12T04:58:58+00:00"
+        },
+        {
+            "name": "cweagans/composer-patches",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweagans/composer-patches.git",
+                "reference": "bfa6018a5f864653d9ed899b902ea72f858a2cf7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/bfa6018a5f864653d9ed899b902ea72f858a2cf7",
+                "reference": "bfa6018a5f864653d9ed899b902ea72f858a2cf7",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "cweagans/composer-configurable-plugin": "^2.0",
+                "ext-json": "*",
+                "php": ">=8.0.0"
+            },
+            "require-dev": {
+                "codeception/codeception": "~4.0",
+                "codeception/module-asserts": "^2.0",
+                "codeception/module-cli": "^2.0",
+                "codeception/module-filesystem": "^2.0",
+                "composer/composer": "~2.0",
+                "php-coveralls/php-coveralls": "~2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.0.0",
+                "phpro/grumphp": "^1.8.0",
+                "sebastian/phpcpd": "^6.0",
+                "squizlabs/php_codesniffer": "^4.0"
             },
             "type": "composer-plugin",
             "extra": {
-                "class": "cweagans\\Composer\\Patches"
+                "_": "The following two lines ensure that composer-patches is loaded as early as possible.",
+                "class": "cweagans\\Composer\\Plugin\\Patches",
+                "plugin-modifies-downloads": true,
+                "plugin-modifies-install-path": true
             },
             "autoload": {
                 "psr-4": {
@@ -299,16 +368,22 @@
             "description": "Provides a way to patch Composer packages.",
             "support": {
                 "issues": "https://github.com/cweagans/composer-patches/issues",
-                "source": "https://github.com/cweagans/composer-patches/tree/1.7.3"
+                "source": "https://github.com/cweagans/composer-patches/tree/2.0.0"
             },
-            "time": "2022-12-20T22:53:13+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/cweagans",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-10-30T23:44:22+00:00"
         },
         {
             "name": "ddn/sapp",
             "version": "dev-feat/chained-filter-text-replace",
             "source": {
                 "type": "git",
-                "url": "git@github.com:ConductionNL/sapp.git",
+                "url": "https://github.com/ConductionNL/sapp.git",
                 "reference": "5c406e91254d6936f44372db35f1cc15e5a06c56"
             },
             "dist": {

--- a/patches.lock.json
+++ b/patches.lock.json
@@ -1,0 +1,39 @@
+{
+    "_hash": "5b9460f40bf82e1a0b771c97b3618aef2b9b2119fe4138243229d56a130afb91",
+    "patches": {
+        "theodo-group/llphant": [
+            {
+                "package": "theodo-group/llphant",
+                "description": "Forward think:false + keep_alive:-1 to the Ollama API (qwen3 ~5x speedup, no idle-unload wedge) — drop when LLPhant adds a per-call keep_alive/think model option",
+                "url": "patches/llphant-ollama-think-keepalive.patch",
+                "sha256": "7685459dac5466f34157370df89fa951878e780e36a9056f6a2bbc2316313abc",
+                "depth": 1,
+                "extra": {
+                    "provenance": "root"
+                }
+            },
+            {
+                "package": "theodo-group/llphant",
+                "description": "Capture Ollama token/latency usage on OllamaChat::$lastUsage so ChatService can record per-run cost (run-analytics) — drop when LLPhant exposes response usage",
+                "url": "patches/llphant-ollama-usage-capture.patch",
+                "sha256": "6f8b48e7d40c566083eee7fc653c7efd96c584a6e4ab036d685d5048b81ce8b6",
+                "depth": 1,
+                "extra": {
+                    "provenance": "root"
+                }
+            }
+        ],
+        "phpoffice/phpspreadsheet": [
+            {
+                "package": "phpoffice/phpspreadsheet",
+                "description": "Prefer ZipStream3 when zipstream-php v3 is installed — a co-installed app's leaked zipstream v2 Option\\Archive otherwise mis-selects the v2 shim and 500s every .xlsx export on the shared Nextcloud autoloader",
+                "url": "patches/phpspreadsheet-zipstream3-prefer.patch",
+                "sha256": "4db2040bf84051d0285d9ea79ee5afb96d244d48a499215ac86806047bc1fc0d",
+                "depth": 1,
+                "extra": {
+                    "provenance": "root"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Supersedes #2993 — dependabot's branch cannot be pushed to, so this replaces it. Close #2993 when this merges.

## Why #2993 was red

Its two failures were **not** caused by the bump:

- `quality / Frontend Check (format)` — `prettier --check` on `tests/e2e/global-setup.ts`, a stale-base artifact. Nothing to do with composer.
- `quality / Quality Report` — the aggregator over that failure.

The bump itself was fine; it just needed the extra v2 config that dependabot cannot write.

## What this changes beyond the version

**`patches.lock.json` is new** and is committed next to `composer.lock`. v2 pins every patch by sha256 there, so an edited patch file becomes a lock mismatch instead of a quiet re-apply.

**`extra.composer-exit-on-patch-failure` is removed.** It is v1-only config — v2 has no equivalent setting because it *always* throws. Verified rather than assumed: with a deliberately corrupted hunk, `composer install` exits **1** from `Plugin/Patches.php:288` ("No available patcher was able to apply patch"). Behaviour is unchanged; the flag was already what v2 does unconditionally.

## The fuzz question

v2 drops the GNU `patch` backend and applies via `git apply`, which honours **offsets but not fuzz**. Any patch that had been silently applying with fuzz under v1 would have started failing here.

**None did.** All three patches (2× llphant, 1× phpspreadsheet) apply exactly against their current pins, and the patched content was verified present in `vendor/` after a from-empty install — not just inferred from the "Patching …" log line.

## One environmental change worth knowing

v2 needs `git` on `PATH` (`GitPatcher` / `GitInitPatcher`); v1 only needed `patch`. CI runners have it. `GitInitPatcher` creates a temporary `.git` inside the package directory and removes it afterwards — verified **0** leftover `.git` directories under `vendor/` after a clean install, so nothing extra reaches the release tarball.

## Local verification (real exit codes, base `development` @ 8a5eef382)

| check | exit |
|---|---|
| `composer install` from an empty `vendor/` | **0** (3/3 patches applied, content verified) |
| `composer install --no-dev --dry-run` | **0** |
| `composer patches-doctor` | **0** |
| lint / phpcs / phpmd / psalm / phpstan | **all pass** |
| `vendor/bin/phpunit` | 17774 tests, **0 failures, 0 errors** |

`composer check:strict` exits **1** here *and* on clean `development` — same cause both sides: no coverage driver is installed locally, so PHPUnit ends on "OK, but there were issues!". The warning/risky profile is identical to the baseline (1 runner warning, 10 warnings, 43 skipped, 3 risky). The 3-test delta vs the baseline's 17771 is the newer base commit, not this change.

Nothing was skipped, weakened, or baselined.