### PR TITLE
chore(deps): bump theodo-group/llphant from 0.9.12 to 1.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -124,7 +124,7 @@
 		"symfony/uid": "^6.4",
 		"symfony/workflow": "^6.4",
 		"symfony/yaml": "^6.4 || ^7.0",
-		"theodo-group/llphant": "^0.9.3",
+		"theodo-group/llphant": "^1.0",
 		"twig/twig": "^3.27.0",
 		"web-token/jwt-library": "^4.1.9",
 		"webonyx/graphql-php": "^15.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c54554a5f7c891978d85cc5fa0611a00",
+    "content-hash": "bf6060d97953405ef44d4abb2268f5ff",
     "packages": [
         {
             "name": "adbario/php-dot-notation",
@@ -683,22 +683,22 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.15.2",
+            "version": "7.15.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "744101956d78b7c1384d0cbf379db13e859167bf"
+                "reference": "ee80339fd9177ba44c49cdb653ff02a4d1106b9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/744101956d78b7c1384d0cbf379db13e859167bf",
-                "reference": "744101956d78b7c1384d0cbf379db13e859167bf",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ee80339fd9177ba44c49cdb653ff02a4d1106b9a",
+                "reference": "ee80339fd9177ba44c49cdb653ff02a4d1106b9a",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.5.1",
-                "guzzlehttp/psr7": "^2.13",
+                "guzzlehttp/promises": "^2.5.3",
+                "guzzlehttp/psr7": "^2.13.1",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
@@ -791,7 +791,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.15.2"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.5"
             },
             "funding": [
                 {
@@ -807,20 +807,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-26T23:23:20+00:00"
+            "time": "2026-08-24T09:21:06+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.5.1",
+            "version": "2.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29"
+                "reference": "cde49999552d185d64715fe9c1f77a2aadd2f9f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/9ad1e4fc607446a055b95870c7f668e93b5cff29",
-                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/cde49999552d185d64715fe9c1f77a2aadd2f9f1",
+                "reference": "cde49999552d185d64715fe9c1f77a2aadd2f9f1",
                 "shasum": ""
             },
             "require": {
@@ -875,7 +875,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.5.1"
+                "source": "https://github.com/guzzle/promises/tree/2.5.3"
             },
             "funding": [
                 {
@@ -891,20 +891,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-08T15:48:39+00:00"
+            "time": "2026-08-24T09:11:28+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.13.0",
+            "version": "2.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4"
+                "reference": "95e7828100de18b4e269fb1703be530082d5166d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dad89620b7a6edb60c15858442eb2e408b45d8f4",
-                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/95e7828100de18b4e269fb1703be530082d5166d",
+                "reference": "95e7828100de18b4e269fb1703be530082d5166d",
                 "shasum": ""
             },
             "require": {
@@ -994,7 +994,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.13.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.13.1"
             },
             "funding": [
                 {
@@ -1010,7 +1010,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-16T22:23:49+00:00"
+            "time": "2026-08-24T09:13:11+00:00"
         },
         {
             "name": "jwadhams/json-logic-php",
@@ -1644,16 +1644,16 @@
         },
         {
             "name": "openai-php/client",
-            "version": "v0.13.0",
+            "version": "v0.19.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/openai-php/client.git",
-                "reference": "399229860cea244843753bf1d9c28aee0e74c3a6"
+                "reference": "12e3513527e22d5657f4f9809796f8fe254fd0a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/openai-php/client/zipball/399229860cea244843753bf1d9c28aee0e74c3a6",
-                "reference": "399229860cea244843753bf1d9c28aee0e74c3a6",
+                "url": "https://api.github.com/repos/openai-php/client/zipball/12e3513527e22d5657f4f9809796f8fe254fd0a9",
+                "reference": "12e3513527e22d5657f4f9809796f8fe254fd0a9",
                 "shasum": ""
             },
             "require": {
@@ -1666,16 +1666,16 @@
                 "psr/http-message": "^1.1.0|^2.0.0"
             },
             "require-dev": {
-                "guzzlehttp/guzzle": "^7.9.3",
-                "guzzlehttp/psr7": "^2.7.1",
-                "laravel/pint": "^1.22.0",
+                "guzzlehttp/guzzle": "^7.10.0",
+                "guzzlehttp/psr7": "^2.8.0",
+                "laravel/pint": "^1.25.1",
                 "mockery/mockery": "^1.6.12",
-                "nunomaduro/collision": "^8.8.0",
-                "pestphp/pest": "^3.8.2|^4.0.0",
+                "nunomaduro/collision": "^8.8.3",
+                "pestphp/pest": "^3.8.2|^4.1.4",
                 "pestphp/pest-plugin-arch": "^3.1.1|^4.0.0",
                 "pestphp/pest-plugin-type-coverage": "^3.5.1|^4.0.0",
-                "phpstan/phpstan": "^1.12.25",
-                "symfony/var-dumper": "^7.2.6"
+                "phpstan/phpstan": "^1.12.32",
+                "symfony/var-dumper": "^7.3.5"
             },
             "type": "library",
             "autoload": {
@@ -1715,7 +1715,7 @@
             ],
             "support": {
                 "issues": "https://github.com/openai-php/client/issues",
-                "source": "https://github.com/openai-php/client/tree/v0.13.0"
+                "source": "https://github.com/openai-php/client/tree/v0.19.2"
             },
             "funding": [
                 {
@@ -1731,7 +1731,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-14T21:43:59+00:00"
+            "time": "2026-04-19T20:35:01+00:00"
         },
         {
             "name": "opis/json-schema",
@@ -5707,53 +5707,64 @@
         },
         {
             "name": "theodo-group/llphant",
-            "version": "0.9.12",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/LLPhant/LLPhant.git",
-                "reference": "2b37713fd93909564d72e40b62a4059fc9bdd551"
+                "reference": "0d90d8b8ba7983ee8c8b09acbb695239c3dc4b74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/LLPhant/LLPhant/zipball/2b37713fd93909564d72e40b62a4059fc9bdd551",
-                "reference": "2b37713fd93909564d72e40b62a4059fc9bdd551",
+                "url": "https://api.github.com/repos/LLPhant/LLPhant/zipball/0d90d8b8ba7983ee8c8b09acbb695239c3dc4b74",
+                "reference": "0d90d8b8ba7983ee8c8b09acbb695239c3dc4b74",
                 "shasum": ""
             },
             "require": {
                 "guzzlehttp/guzzle": "^7.4.5",
                 "guzzlehttp/psr7": "^2.7",
-                "openai-php/client": "^v0.13.0",
+                "openai-php/client": "^v0.19.2",
                 "php": "^8.1.0",
+                "php-http/discovery": "^1.20.0",
+                "php-http/multipart-stream-builder": "^1.4.2",
                 "phpoffice/phpword": "^1.4.0",
-                "psr/http-message": "^2.0",
+                "psr/http-client": "^1.0.3",
+                "psr/http-message": "^1.0 || ^2.0",
                 "psr/log": "^3.0",
-                "smalot/pdfparser": "^2.11"
+                "smalot/pdfparser": "^2.11",
+                "yethee/tiktoken": "^0.10.0"
             },
             "require-dev": {
-                "codewithkyrian/chromadb-php": "^0.3.0",
-                "doctrine/orm": "^2.20.0",
+                "codewithkyrian/chromadb-php": "1.0.0",
+                "doctrine/dbal": "^4",
+                "doctrine/mongodb-odm": "^2.16.1",
+                "doctrine/orm": "^3",
                 "elasticsearch/elasticsearch": "^8.15",
+                "ext-mongodb": "*",
                 "hkulekci/qdrant": "^v0.5.7",
                 "laravel/pint": "v1.15.3",
                 "mockery/mockery": "^1.6.12",
+                "mongodb/mongodb": "^2.1",
                 "opensearch-project/opensearch-php": "^2.3",
-                "pestphp/pest": "^v2.36.0",
-                "pestphp/pest-plugin-arch": "^2.7.0",
-                "pestphp/pest-plugin-type-coverage": "2.8.0",
-                "phpstan/phpstan": "1.10.55",
+                "pestphp/pest": "^3.0",
+                "pestphp/pest-plugin-arch": "^3.0",
+                "pestphp/pest-plugin-type-coverage": "^3.0",
+                "phpstan/phpstan": "^2",
                 "predis/predis": "^2.2",
-                "rector/rector": "^0.16.0",
+                "rector/rector": "^2",
+                "scotteuser/pinecone-php": "^1.0.4",
                 "symfony/cache": "^7.2",
                 "symfony/process": "^v7.1.8",
                 "symfony/var-dumper": "^7.2"
             },
             "suggest": {
                 "codewithkyrian/chromadb-php": "This is required for the ChromaDBVectorStore.",
+                "doctrine/mongodb-odm": "This is required for the DoctrineODMVectoreStore. This should be working with any version ^2.16.1",
                 "doctrine/orm": "This is required for the DoctrineVectoreStore. This should be working with any version ^2.13.0",
                 "elasticsearch/elasticsearch": "This is required for the ElasticsearchVectoreStore.",
                 "hkulekci/qdrant": "This is required for the QdrantVectoreStore.",
                 "opensearch-project/opensearch-php": "This is required for the OpenSearchVectorStore.",
                 "predis/predis": "This is required for the RedisVectoreStore.",
+                "probots-io/pinecone-php": "This is required for the PineconeVectorStore. Use scotteuser/pinecone-php for <= PHP 8.2",
                 "symfony/cache": "This is one of the possible types of psr/cache needed by doctrine/orm"
             },
             "type": "library",
@@ -5779,14 +5790,8 @@
                 "fix-lint": [
                     "pint -v --repair src tests"
                 ],
-                "refactor": [
-                    "rector --debug"
-                ],
                 "test:lint": [
-                    "pint --test -v"
-                ],
-                "test:refactor": [
-                    "rector --dry-run "
+                    "pint --test -v src tests"
                 ],
                 "test:types": [
                     "phpstan analyse --ansi --memory-limit 4G"
@@ -5802,7 +5807,12 @@
                 ],
                 "test": [
                     "@test:lint",
-                    "@test:refactor",
+                    "@test:types",
+                    "@test:type-coverage",
+                    "@test:unit"
+                ],
+                "quality": [
+                    "@fix-lint",
                     "@test:types",
                     "@test:type-coverage",
                     "@test:unit"
@@ -5830,10 +5840,10 @@
                 "vectorstore"
             ],
             "support": {
-                "source": "https://github.com/LLPhant/LLPhant/tree/0.10.2",
+                "source": "https://github.com/LLPhant/LLPhant/tree/1.0.1",
                 "issues": "https://github.com/LLPhant/LLPhant/issues"
             },
-            "time": "2025-06-13T10:20:04+00:00"
+            "time": "2026-07-26T08:26:01+00:00"
         },
         {
             "name": "twig/twig",
@@ -6083,6 +6093,60 @@
                 }
             ],
             "time": "2026-08-14T06:29:42+00:00"
+        },
+        {
+            "name": "yethee/tiktoken",
+            "version": "0.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/yethee/tiktoken-php.git",
+                "reference": "59a93e34b90469021a4b8ed3a98765e8dc23f3cc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/yethee/tiktoken-php/zipball/59a93e34b90469021a4b8ed3a98765e8dc23f3cc",
+                "reference": "59a93e34b90469021a4b8ed3a98765e8dc23f3cc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1",
+                "symfony/service-contracts": "^2.5 || ^3.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^13",
+                "mikey179/vfsstream": "^1.6.11",
+                "phpbench/phpbench": "^1.2",
+                "phpunit/phpunit": "^10.5.45",
+                "psalm/plugin-phpunit": "^0.19.2",
+                "vimeo/psalm": "6.10.0"
+            },
+            "suggest": {
+                "ext-ffi": "To allow use LibEncoder"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Yethee\\Tiktoken\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHP version of tiktoken",
+            "keywords": [
+                "bpe",
+                "decode",
+                "encode",
+                "openai",
+                "tiktoken",
+                "tokenizer"
+            ],
+            "support": {
+                "issues": "https://github.com/yethee/tiktoken-php/issues",
+                "source": "https://github.com/yethee/tiktoken-php/tree/0.10.0"
+            },
+            "time": "2025-04-19T13:47:00+00:00"
         },
         {
             "name": "zbateson/mail-mime-parser",

--- a/patches.lock.json
+++ b/patches.lock.json
@@ -1,12 +1,12 @@
 {
-    "_hash": "5b9460f40bf82e1a0b771c97b3618aef2b9b2119fe4138243229d56a130afb91",
+    "_hash": "cdc3807f243c7fcd3cc1dfe309c6a41b32bdae7a133a8d9d9f74965598929aa0",
     "patches": {
         "theodo-group/llphant": [
             {
                 "package": "theodo-group/llphant",
                 "description": "Forward think:false + keep_alive:-1 to the Ollama API (qwen3 ~5x speedup, no idle-unload wedge) — drop when LLPhant adds a per-call keep_alive/think model option",
                 "url": "patches/llphant-ollama-think-keepalive.patch",
-                "sha256": "7685459dac5466f34157370df89fa951878e780e36a9056f6a2bbc2316313abc",
+                "sha256": "c52322dc441b2cbe00f8984b1aeb879af3091b37867080e6f0dee51eb5a9fae7",
                 "depth": 1,
                 "extra": {
                     "provenance": "root"
@@ -16,7 +16,7 @@
                 "package": "theodo-group/llphant",
                 "description": "Capture Ollama token/latency usage on OllamaChat::$lastUsage so ChatService can record per-run cost (run-analytics) — drop when LLPhant exposes response usage",
                 "url": "patches/llphant-ollama-usage-capture.patch",
-                "sha256": "6f8b48e7d40c566083eee7fc653c7efd96c584a6e4ab036d685d5048b81ce8b6",
+                "sha256": "dbaf29562f2a256f6a523c8cfe43f7edc8249b38c873daa311c4ebaecca0d742",
                 "depth": 1,
                 "extra": {
                     "provenance": "root"

--- a/patches/llphant-ollama-think-keepalive.patch
+++ b/patches/llphant-ollama-think-keepalive.patch
@@ -1,6 +1,6 @@
 --- a/src/Chat/OllamaChat.php
 +++ b/src/Chat/OllamaChat.php
-@@ -257,6 +257,13 @@
+@@ -269,6 +269,13 @@ class OllamaChat implements ChatInterface
       */
      protected function sendRequest(string $method, string $path, array $json): ResponseInterface
      {

--- a/patches/llphant-ollama-usage-capture.patch
+++ b/patches/llphant-ollama-usage-capture.patch
@@ -1,6 +1,6 @@
 --- a/src/Chat/OllamaChat.php
 +++ b/src/Chat/OllamaChat.php
-@@ -43,6 +43,14 @@
+@@ -42,6 +42,14 @@ class OllamaChat implements ChatInterface
      /** @var CalledFunction[] */
      public array $functionsCalled = [];
  
@@ -12,11 +12,11 @@
 +     */
 +    public array $lastUsage = ['promptTokens' => 0, 'completionTokens' => 0, 'totalDurationMs' => 0];
 +
-     public function __construct(protected OllamaConfig $config, ?LoggerInterface $logger = null)
+     public function __construct(protected OllamaConfig $config, private readonly LoggerInterface $logger = new NullLogger())
      {
          if (! isset($config->model)) {
-@@ -174,6 +182,13 @@
-         $contents = $response->getBody()->getContents();
+@@ -183,6 +191,13 @@ class OllamaChat implements ChatInterface
+         $this->logger->debug($contents);
          $json = Utility::decodeJson($contents);
  
 +        // Accumulate token/latency usage across the tool-call recursion so OpenRegister can

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -196,9 +196,6 @@
       <code><![CDATA[$config->temperature]]></code>
       <code><![CDATA[$config->temperature]]></code>
     </UndefinedPropertyAssignment>
-    <UndefinedPropertyFetch>
-      <code><![CDATA[$config->apiKey]]></code>
-    </UndefinedPropertyFetch>
   </file>
   <file src="lib/Service/Chat/ResponseGenerationHandler.php">
     <UndefinedPropertyAssignment>


### PR DESCRIPTION
Supersedes #2986 — dependabot's branch cannot be pushed to, so this replaces it. Close #2986 when this merges.

## Why #2986 had 14 red checks

**One real failure, which killed the other thirteen.**

`patches/llphant-ollama-usage-capture.patch` does not apply to 1.0.1. With `extra.composer-exit-on-patch-failure: true`, that aborts `composer install` outright:

```
Could not apply patch! Skipping. The error was: Cannot apply patch patches/llphant-ollama-usage-capture.patch
##[error]Process completed with exit code 1.
```

So `vendor/` never existed, and lint, phpcs, phpmd, phpmetrics, psalm, phpstan, PHPUnit, License (composer) and Security (composer) all died on a missing autoloader rather than on anything they were meant to measure. (`Frontend Check (format)` was separate and unrelated — a stale-base prettier failure on `tests/e2e/global-setup.ts`, present on all three of this week's dependabot PRs.)

## The patches, re-anchored

**`llphant-ollama-think-keepalive.patch`** — context unchanged, hunk moved 257 → 269.

**`llphant-ollama-usage-capture.patch`** — this is the one that broke:

- *Hunk 1 failed outright.* The constructor signature changed:
  `?LoggerInterface $logger = null` → `private readonly LoggerInterface $logger = new NullLogger()`.
- *Hunk 2 was applying with **fuzz 1***. It moved into the new `generateChatRecursive()` and picked up a `$this->logger->debug($contents)` line above it. GNU `patch` would have taken it; that is not a pass, it is a near-miss that happens to land. The rewritten hunk is exact.

The new hunk 2 is anchored on the `/** @var Message[] $toolsOutput */` line *below* the insertion point, because 1.0.1 has **two** identical `Utility::decodeJson($contents)` sites — one in `generateChatOrReturnFunctionToCall()` and one in `generateChatRecursive()` — and only the recursive one should accumulate usage across tool calls.

## How much of the app actually breaks: none of it

Measured rather than assumed. With the llphant patches deliberately left **off** and 1.0.1 installed:

- psalm: 1 error — `OllamaChat::$lastUsage is not defined`
- phpstan: 1 error — the same property

That is the whole blast radius. 1.0.0's renamed `ChatInterface` methods (`generateTextOrReturnFunctionCalled` → `...ToCall`) are not called anywhere in this repo.

## One suppression retired

`psalm-baseline.xml` **loses** an entry rather than gaining one. `OllamaConfig` now genuinely declares `$apiKey` (it did not in 0.9.12), so the baselined `UndefinedPropertyFetch` for `$config->apiKey` in `ConversationManagementHandler` is stale — psalm fails on `UnusedBaselineEntry` until it is deleted.

## Transitive

`openai-php/client` v0.13.0 → v0.19.2, guzzle 7.15.2 → 7.15.5, plus new `yethee/tiktoken` 0.10.0. All MIT. Nothing in `lib/` or `tests/` touches the OpenAI SDK directly — it is reached only through llphant.

## Local verification (real exit codes, base `development` @ 0131ef736)

| check | exit |
|---|---|
| `composer install` from an empty `vendor/` | **0** (3/3 patches applied, content verified in vendor/) |
| `composer audit --locked` | **0** — no advisories |
| lint / phpcs / phpmd / phpstan | **all pass** |
| psalm | **0** — "No errors found!" |
| `vendor/bin/phpunit` | 17775 tests, **0 failures, 0 errors** |

`composer check:strict` exits **1** here *and* on clean `development` — same cause both sides: no coverage driver locally, so PHPUnit ends on "OK, but there were issues!". Identical warning/risky profile to the baseline (1 runner warning, 10 warnings, 43 skipped, 3 risky).

No test was skipped, no assertion weakened, no baseline entry added.