### PR TITLE
fix(tests): implement registerGlobalScaleService in RecordingRegistrationContext

### DIFF
--- a/tests/Unit/AppHost/RecordingRegistrationContext.php
+++ b/tests/Unit/AppHost/RecordingRegistrationContext.php
@@ -119,5 +119,7 @@ final class RecordingRegistrationContext implements IRegistrationContext {
 	}
 	public function registerConfigLexicon(string $configLexiconClass): void {
 	}
+	public function registerGlobalScaleService(string $globalScaleServiceClass): void {
+	}
 }
 // phpcs:enable


### PR DESCRIPTION
Nextcloud added `IRegistrationContext::registerGlobalScaleService` (`@since 34.0.3`) and backported it onto `stable33`. Our test helper is a *concrete* implementation of that interface, so the new method turned it into an implicitly-abstract class and PHPUnit aborted with a fatal before running a single test:

```
PHP Fatal error: Class ...\RecordingRegistrationContext contains 1 abstract
method and must therefore be declared abstract or implement the remaining
methods (IRegistrationContext::registerGlobalScaleService)
```

**This is why `development` went red with no change of ours.** The PR that merged was green across 39 checks; the `stable33` branch tip moved underneath it. Both failing cells were NC stable33 (PHP 8.3 + 8.4, pgsql), exit code 255 on *Run PHPUnit tests* — a fatal, not test failures. Quality Report failed downstream of it.

Adds the no-op recorder method, matching the other 37.

Verified the helper now covers the **full interface surface** on `stable33` (38 methods), `stable34` (38) and `master` (39) — so no further drift is pending, including the one extra method already on master.