### PR TITLE
fix(deps): align dexie on 4.4.5 so only one copy loads per page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@vueuse/core": "^14.3.0",
         "apexcharts": "^7.0.0",
         "css-loader": "^7.1.1",
-        "dexie": "^4.0.8",
+        "dexie": "^4.4.5",
         "dompurify": "^3.4.14",
         "gridstack": "^13.2.0",
         "marked": "^12.0.0",
@@ -11105,9 +11105,9 @@
       }
     },
     "node_modules/dexie": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.4.4.tgz",
-      "integrity": "sha512-jIwsYI8Os2hgnqc6O49YwFDKGc5v5QjGx0wPVp543ip1F53VFAKMLthV2pQosQcVTv3eAskTWYspOx195PM0FQ==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.4.5.tgz",
+      "integrity": "sha512-wWCHdihT3dmlUSuNhn5mMZDWSpG0suxjAni7YjjiZdzabZcKmy3uNZGZ7AeYYXBoLbpSXX35fikPLkPC44Osiw==",
       "license": "Apache-2.0"
     },
     "node_modules/diff-sequences": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@vueuse/core": "^14.3.0",
     "apexcharts": "^7.0.0",
     "css-loader": "^7.1.1",
-    "dexie": "^4.0.8",
+    "dexie": "^4.4.5",
     "dompurify": "^3.4.14",
     "gridstack": "^13.2.0",
     "marked": "^12.0.0",


### PR DESCRIPTION
## What broke

Dexie refuses to run twice in one page. It throws:

```
Error: Two different versions of Dexie loaded in the same app: 4.4.4 and 4.4.5
```

Nextcloud loads openregister's global integration script and hermiq's agent leaf on **every** page, alongside whichever leaf app you are in. So all three bundles have to agree on one dexie, and after the dependabot sweep on 2026-08-30 they did not: openregister resolved 4.4.4 while hermiq resolved 4.4.5.

The throw happened before the leaf app mounted, so app pages rendered as bare Nextcloud chrome with no navigation and no content. Nothing in CI catches this, because each app builds and passes on its own.

## What this does

Pins the dexie floor at `^4.4.5` and regenerates the lock, matching the apps that already resolved there.

## Verified

In the browser against the dev instance: the Dexie error is gone from the console, and app pages render their navigation and content again.