### PR TITLE
fix(sidebar): render the manifest page's sidebar alongside our own

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
-        "@conduction/nextcloud-vue": "^2.24.2",
+        "@conduction/nextcloud-vue": "^2.24.3",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "^2.6.0",
         "@nextcloud/capabilities": "^1.2.1",
@@ -2173,9 +2173,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.24.2",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.24.2.tgz",
-      "integrity": "sha512-BGvyJpRhzvLraZuyRB3ETJ6IESV27XZvL5vdvLd5kEvettFo+QWIo6JcHJhQk9np8QYGHBQ9gRHCp3v6y7Y2gw==",
+      "version": "2.24.3",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.24.3.tgz",
+      "integrity": "sha512-Hflys+AxGNNSkDxuMf04RdFzijhWDKtcRJAHtmtYLj6ntwoIT51k0rfRju6S5GuTNF+daJDUv9tHDVVXb9ZIWw==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
-    "@conduction/nextcloud-vue": "^2.24.2",
+    "@conduction/nextcloud-vue": "^2.24.3",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "^2.6.0",
     "@nextcloud/capabilities": "^1.2.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -25,7 +25,7 @@
 			path: it reads OCA.OpenRegister.integrations and renders one inner
 			tab per provider (built-ins + xwiki + the bespoke leaves). See ADR-019.
 		-->
-		<template #sidebar>
+		<template #sidebar="{ pageSidebarComponent }">
 			<SideBars />
 			<CnObjectSidebar
 				v-if="objectSidebarState.active"
@@ -39,6 +39,12 @@
 				:hiddenTabs="objectSidebarState.hiddenTabs"
 				:open="objectSidebarState.open"
 				@update:open="objectSidebarState.open = $event" />
+			<!-- The manifest page's own sidebar (pages[].sidebarComponent). Passed in
+			     as a slot prop because filling this slot suppresses CnAppRoot's
+			     fallback, which is what hid the flow sidebar. -->
+			<component
+				:is="pageSidebarComponent"
+				v-if="pageSidebarComponent" />
 		</template>
 		<!-- Global modal and dialog hosts, mounted below the router-view. -->
 		<template #footer>


### PR DESCRIPTION
## What broke

`pages[].sidebarComponent` never rendered in this app. The manifest declared it, `registry.js` registered the component, and it was present in the bundle. Nothing warned, nothing errored, and no sidebar appeared.

The cause is a slot mechanic. `CnAppRoot` renders the resolved component as the `#sidebar` slot's **fallback**, and Vue only uses a fallback when the slot is **absent**. This app fills that slot with its own rail, so it silently suppressed the manifest's sidebar.

Nine fleet apps fill the slot and all nine lost their ADR-110 flow sidebar. The five that do not fill it rendered it correctly the whole time, which is what identified the cause rather than guesswork.

## Why the app could not fix this alone

Slot content compiles in the parent's scope, and `inject` resolves up the component chain. An app shell mounting `CnAppRoot` cannot reach the holder `CnPageRenderer` provides beneath it. Conditionally dropping the slot does not help either, since the fallback only returns when the slot is absent entirely.

So the fix went into the library first: nextcloud-vue#857 passes the resolved component to the slot, released as **2.24.3**.

## What this does

- Bumps `@conduction/nextcloud-vue` to `^2.24.3`
- Renders both in the `#sidebar` slot: this app's own rail, and whatever the routed manifest page declares

## Verified

`npm ci` and `npm run build` exit 0. Confirmed in a browser against the dev instance on filinq: `/apps/filinq/flows/<id>` renders the flow rail (Flow, Steps, Runs, Version, Publish, trigger list) beside the canvas, with the app's own sidebar still mounting.