### PR TITLE
style: run Prettier over the sidebar change

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -42,9 +42,7 @@
 			<!-- The manifest page's own sidebar (pages[].sidebarComponent). Passed in
 			     as a slot prop because filling this slot suppresses CnAppRoot's
 			     fallback, which is what hid the flow sidebar. -->
-			<component
-				:is="pageSidebarComponent"
-				v-if="pageSidebarComponent" />
+			<component :is="pageSidebarComponent" v-if="pageSidebarComponent" />
 		</template>
 		<!-- Global modal and dialog hosts, mounted below the router-view. -->
 		<template #footer>


### PR DESCRIPTION
The *"render the manifest page's sidebar alongside our own"* commit landed unformatted, and `quality / Frontend Check (format)` has been **red on `development`** ever since:

```
prettier --check "**/*.{js,ts,vue,css,scss}"
[warn] src/App.vue
[warn] Code style issues found in the above file.
```

**Eight apps took that change and eight went red together** — openregister, filinq, stackiq, larpinq, dossiq, pipelinq, shillinq and portaliq. It also blocks every `development → beta` promotion, since the promotion runs the same check.

This is `prettier --write` over the affected file and nothing else — one file, no behavioural change.

Verified: `npm run format` exits **0**.