### PR TITLE
fix(sidebar): render the flow sidebar once, not twice

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -42,9 +42,7 @@
 			<!-- The manifest page's own sidebar (pages[].sidebarComponent). Passed in
 			     as a slot prop because filling this slot suppresses CnAppRoot's
 			     fallback, which is what hid the flow sidebar. -->
-			<component
-				:is="pageSidebarComponent"
-				v-if="pageSidebarComponent" />
+			<component :is="pageSidebarComponent" v-if="pageSidebarComponent" />
 		</template>
 		<!-- Global modal and dialog hosts, mounted below the router-view. -->
 		<template #footer>

--- a/src/sidebars/SideBars.vue
+++ b/src/sidebars/SideBars.vue
@@ -8,23 +8,24 @@
 	<AuditTrailSideBar v-else-if="$route.path.startsWith('/audit-trails')" />
 	<SearchTrailSideBar v-else-if="$route.path.startsWith('/search-trails')" />
 	<!--
-		The flow canvas's controls — step palette, Save, Run, run history.
+		The flow canvas's controls are NOT listed here. They are declared on the
+		manifest page as `sidebarComponent: FlowDetailSidebar`, and #3103 made
+		CnAppRoot hand that component to this app through the #sidebar slot
+		prop, so App.vue renders it directly.
 
-		These are declared on the manifest page as `sidebarComponent:
-		FlowDetailSidebar`, and CnAppRoot does resolve that key. It could never
-		render here, though: CnAppRoot only falls back to it as the DEFAULT
-		content of its #sidebar slot, and this app fills that slot itself, so
-		consumer content wins by Vue's ordinary slot mechanic. The manifest key
-		was live config that rendered nothing.
+		A hardcoded <FlowDetailSidebar> used to sit here as a workaround from
+		when the manifest key rendered nothing. Once #3103 made the manifest
+		route work, BOTH rendered, and the e2e caught it exactly as it should:
 
-		The symptom was a flow page with no way to save, run, or add a step —
-		while its own empty state said "Add a step from the sidebar".
+		  strict mode violation: locator('.cn-flow-sidebar') resolved to 2 elements
+
+		The manifest is the single source of truth for a page's sidebar. Adding
+		a route here for a page that declares `sidebarComponent` will duplicate
+		it again.
 	-->
-	<FlowDetailSidebar v-else-if="/^\/flows\/.+/.test($route.path)" />
 </template>
 
 <script>
-import FlowDetailSidebar from '../views/flows/FlowDetailSidebar.vue'
 import DashboardSideBar from './dashboard/DashboardSideBar.vue'
 import DeletedSideBar from './deleted/DeletedSideBar.vue'
 import EntitiesSideBar from './entities/EntitiesSideBar.vue'
@@ -45,7 +46,6 @@ export default {
 		EntitiesSideBar,
 		AuditTrailSideBar,
 		SearchTrailSideBar,
-		FlowDetailSidebar,
 	},
 }
 </script>


### PR DESCRIPTION
E2E went red on `development`:

```
1) [chromium] › tests/e2e/ci/flow-controls.spec.ts:181:5
   Error: the flow sidebar did not render — the controls are unreachable again
   Error: strict mode violation: locator('.cn-flow-sidebar') resolved to 2 elements
```

## This deletes a workaround, not a fix

#3103 fixed the real problem. `CnAppRoot` only offered the manifest's `sidebarComponent` as the **default** content of its `#sidebar` slot, and this app fills that slot — so by Vue's ordinary slot mechanic the consumer won and *the manifest key was live config that rendered nothing*. #3103 passes the component through as a slot prop so `App.vue` can render it.

What it did not do is remove the workaround that existed **because** the manifest key rendered nothing: a hardcoded `<FlowDetailSidebar>` in `SideBars.vue`, whose own comment says exactly that —

> *"These are declared on the manifest page as `sidebarComponent: FlowDetailSidebar` … It could never render here, though … The manifest key was live config that rendered nothing."*

With the manifest route working, **both** rendered. The E2E caught it precisely as it should.

So the workaround goes, and the comment left in its place records that the manifest is now the single source of truth — because adding a route back here for a page that declares `sidebarComponent` will duplicate it again.

The unused `import` and `components` entry go with it: a registration left behind after its template use is removed is the next reader's puzzle.

`src/App.vue` is Prettier-formatted here too — the same one-file fix is in #3107, and whichever lands first makes the other a no-op.

## Verification

```
eslint            exit 0
webpack build     compiled (warnings only, no errors)
npm run format    exit 0
```