### PR TITLE
chore(dependabot): hold back vue-router 5 as well

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,13 @@ updates:
     ignore:
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
+      # vue-router 5 peers `vite: ^7.3.0 || ^8.0.0` and expects a Vite
+      # toolchain. These apps build with webpack, which cannot resolve it at
+      # all: the build dies on `Can't resolve 'vue-router'`. Adopting it is a
+      # Vite migration, not a bump. versioniq is already on Vite and is the
+      # natural pilot.
+      - dependency-name: "vue-router"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "webpack-cli"
         update-types: ["version-update:semver-major"]
       - dependency-name: "@babel/core"


### PR DESCRIPTION
vue-router 5 peers `vite: ^7.3.0 || ^8.0.0` and expects a Vite toolchain. These apps build with **webpack**, which cannot resolve it at all — the build dies on `Can't resolve 'vue-router'` from `src` and from `@nextcloud/vue`'s own chunks. Adopting it is a Vite migration, not a version bump.

Dependabot proposed it across **8 repositories in a single run**, and merging any one takes that app's build from green to red with no code change in the repository that can fix it.

versioniq already builds with Vite and is the natural pilot if the fleet does move. Lift this when an app's toolchain can actually take it.