### PR TITLE
docs(dependabot): correct the vue-router holdback to what was measured

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,8 +27,11 @@ updates:
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
       # vue-router 5 peers `vite: ^7.3.0 || ^8.0.0` and expects a Vite
-      # toolchain. These apps build with webpack, which cannot resolve it at
-      # all: the build dies on `Can't resolve 'vue-router'`. Adopting it is a
+      # toolchain. Measured, not assumed, and the result is SPLIT: integriq and
+      # zaakafhandelapp fail their build on `Can't resolve 'vue-router'`, while
+      # openregister and learniq build clean on 5.3.0. Held because a bump that
+      # breaks some apps and not others cannot be merged unattended, and the
+      # difference is not yet understood. Adopting it fleet-wide is a
       # Vite migration, not a bump. versioniq is already on Vite and is the
       # natural pilot.
       - dependency-name: "vue-router"


### PR DESCRIPTION
The previous comment claimed these apps "cannot resolve it at all". **That is not what the evidence shows**, and an overstated comment is worse than none: the next person reads it, tries vue-router 5 somewhere it works, and stops trusting the file.

## What was actually measured

| App | vue-router 5.3.0 |
|---|---|
| integriq | build **fails** on `Can't resolve 'vue-router'` |
| zaakafhandelapp | build **fails**, same error |
| openregister | `npm ci` and build **clean** |
| learniq | `npm ci` and build **clean** |

## The holdback stands, for the honest reason

A major that breaks some apps and not others cannot be merged unattended, and the difference between them is not yet understood. That is a better reason to hold it than a claim that turns out to be false in half the fleet.

**No behaviour change** — the ignore rule is untouched, only the reasoning.