### PR TITLE
fix(aggregation): count the objects that have no organisation

### DIFF
--- a/lib/Db/MagicMapper/MagicOrganizationHandler.php
+++ b/lib/Db/MagicMapper/MagicOrganizationHandler.php
@@ -56,6 +56,36 @@ use Psr\Log\LoggerInterface;
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class MagicOrganizationHandler {
+
+	/**
+	 * Every row is visible — a trusted system context, or an admin with the
+	 * bypass enabled outside SaaS mode.
+	 */
+	public const SCOPE_ALL = 'all';
+
+	/**
+	 * No row is visible — a non-admin with no active organisation.
+	 */
+	public const SCOPE_NONE = 'none';
+
+	/**
+	 * Only rows with NO organisation — an admin with no active organisation.
+	 */
+	public const SCOPE_NULL_ONLY = 'null-only';
+
+	/**
+	 * Rows in the caller's active organisation(s).
+	 */
+	public const SCOPE_IN = 'in';
+
+	/**
+	 * Rows in the caller's active organisation(s), PLUS rows with no
+	 * organisation at all. Admins only. This is the mode the aggregation API
+	 * used to get wrong: it rendered only the `IN` half, and SQL `=` / `IN`
+	 * never match NULL, so org-less rows vanished from every KPI.
+	 */
+	public const SCOPE_IN_OR_NULL = 'in-or-null';
+
 	/**
 	 * Constructor for MagicOrganizationHandler.
 	 *
@@ -96,25 +126,96 @@ class MagicOrganizationHandler {
 		IQueryBuilder $qb,
 		bool $adminBypassEnabled = false,
 	): void {
+		$scope = $this->resolveOrganizationScope(adminBypassEnabled: $adminBypassEnabled);
+
+		if ($scope['mode'] === self::SCOPE_ALL) {
+			return;
+		}
+
+		if ($scope['mode'] === self::SCOPE_NONE) {
+			$qb->andWhere('1 = 0');
+			return;
+		}
+
+		if ($scope['mode'] === self::SCOPE_NULL_ONLY) {
+			$qb->andWhere($qb->expr()->isNull('t._organisation'));
+			return;
+		}
+
+		// Condition 1: objects belonging to the caller's active organisation(s).
+		$conditions = [];
+		$conditions[] = $qb->expr()->in(
+			't._organisation',
+			$qb->createNamedParameter($scope['uuids'], IQueryBuilder::PARAM_STR_ARRAY)
+		);
+		if (count($scope['uuids']) === 1) {
+			array_pop($conditions);
+			$conditions[] = $qb->expr()->eq(
+				't._organisation',
+				$qb->createNamedParameter($scope['uuids'][0])
+			);
+		}
+
+		// Condition 2: objects with no organisation — ONLY for admin users.
+		if ($scope['mode'] === self::SCOPE_IN_OR_NULL) {
+			$conditions[] = $qb->expr()->isNull('t._organisation');
+		}
+
+		$qb->andWhere($qb->expr()->orX(...$conditions));
+
+	}//end applyOrganizationFilter()
+
+	/**
+	 * Decide WHICH rows the current caller may see, without building any SQL.
+	 *
+	 * This is the single source of truth for the organisation boundary. It was
+	 * extracted from {@see applyOrganizationFilter()} because a SECOND
+	 * implementation had grown in `AggregationRunner::tryNativeAggregation()`,
+	 * where the whole rule had been flattened to a bare
+	 * `_organisation = :activeOrg`. SQL `=` never matches NULL, so every object
+	 * with no organisation was invisible to the aggregation API while the list
+	 * API returned it — measured 2026-08-30 on decidiq/meeting: four meetings
+	 * listed, one of them org-less, `count` answered 3, and
+	 * `filter[lifecycle]=closed` answered 0 for a meeting that plainly exists.
+	 * Every KPI tile in the fleet reads that endpoint, so each one silently
+	 * under-reported.
+	 *
+	 * Returning a DECISION rather than a query fragment is the point: a caller
+	 * that cannot render one of these modes must refuse to run rather than
+	 * approximate it, and the rule itself now lives in exactly one place.
+	 *
+	 * @param bool $adminBypassEnabled Whether the caller honours the admin bypass (disabled in SaaS mode).
+	 *
+	 * @return array{mode: string, uuids: array<int, string>} `mode` is one of the SCOPE_* constants.
+	 *
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+	 * @SuppressWarnings(PHPMD.NPathComplexity)
+	 * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+	 *   Moved here with the code they were written for: this method IS the
+	 *   branchy decision that used to sit inline in applyOrganizationFilter,
+	 *   which has carried these three suppressions since it was written. The
+	 *   branches are the tenancy rule itself (system context, admin, bypass,
+	 *   SaaS, active-org set) and collapsing them would hide it.
+	 */
+	public function resolveOrganizationScope(bool $adminBypassEnabled = false): array {
 		$user = $this->userSession->getUser();
 
 		// CLI / no-session system context (occ commands, repair steps, cron
 		// jobs, background calculations, system listeners) is a trusted system
 		// operation and must see all org-owned rows. See isSystemContext().
 		if ($this->isSystemContext(user: $user) === true) {
-			return;
+			return ['mode' => self::SCOPE_ALL, 'uuids' => []];
 		}
 
-		// Check if user is admin - admins can see all objects including those with null organization.
+		// Admins can see all objects, including those with no organisation.
 		$isAdmin = false;
 		if ($user !== null) {
 			$userGroups = $this->groupManager->getUserGroupIds($user);
 			$isAdmin = in_array('admin', $userGroups, true);
 		}
 
-		// Check if admin bypass is enabled (disabled in SaaS mode).
 		if ($adminBypassEnabled === true && $isAdmin === true) {
-			// In SaaS mode, never bypass organisation boundary.
+			// In SaaS mode, never bypass the organisation boundary.
 			$saasMode = $this->isSaasModeEnabled();
 			if ($saasMode === true) {
 				$this->logger->debug(
@@ -124,49 +225,33 @@ class MagicOrganizationHandler {
 			}
 
 			if ($saasMode !== true) {
-				return;
+				return ['mode' => self::SCOPE_ALL, 'uuids' => []];
 			}
 		}
 
-		// Get the active organization UUID(s) for the current user.
 		$activeOrgUuids = $this->getActiveOrganizationUuids();
 
 		if (empty($activeOrgUuids) === true) {
-			// No active organization - admins can see null-org objects, others get no results.
-			if ($isAdmin !== true) {
-				$qb->andWhere('1 = 0');
-				return;
+			// No active organisation: admins still see org-less rows, others see nothing.
+			$emptyMode = self::SCOPE_NONE;
+			if ($isAdmin === true) {
+				$emptyMode = self::SCOPE_NULL_ONLY;
 			}
 
-			$qb->andWhere($qb->expr()->isNull('t._organisation'));
-			return;
-		}//end if
-
-		// Build conditions for organization filtering.
-		$conditions = [];
-
-		// Condition 1: Objects belonging to the user's active organization(s).
-		$conditions[] = $qb->expr()->in(
-			't._organisation',
-			$qb->createNamedParameter($activeOrgUuids, IQueryBuilder::PARAM_STR_ARRAY)
-		);
-		if (count($activeOrgUuids) === 1) {
-			array_pop($conditions);
-			$conditions[] = $qb->expr()->eq(
-				't._organisation',
-				$qb->createNamedParameter($activeOrgUuids[0])
-			);
+			return ['mode' => $emptyMode, 'uuids' => []];
 		}
 
-		// Condition 2: Objects with null organization - ONLY for admin users.
+		$scopedMode = self::SCOPE_IN;
 		if ($isAdmin === true) {
-			$conditions[] = $qb->expr()->isNull('t._organisation');
+			$scopedMode = self::SCOPE_IN_OR_NULL;
 		}
 
-		// Apply OR of all conditions.
-		$qb->andWhere($qb->expr()->orX(...$conditions));
+		return [
+			'mode' => $scopedMode,
+			'uuids' => array_values($activeOrgUuids),
+		];
 
-	}//end applyOrganizationFilter()
+	}//end resolveOrganizationScope()
 
 	/**
 	 * Determine whether the current call is a trusted system (CLI/no-session)

--- a/lib/Service/Aggregation/AggregationRunner.php
+++ b/lib/Service/Aggregation/AggregationRunner.php
@@ -39,6 +39,7 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
 use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\MagicMapper\MagicOrganizationHandler;
 use OCA\OpenRegister\Db\Register;
 use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
@@ -141,6 +142,7 @@ class AggregationRunner {
 	 * @param PermissionHandler $permissionHandler RBAC verdict on the schema's `list` action.
 	 * @param IUserSession $userSession Active session, for the RBAC + cache-key user scope.
 	 * @param OrganisationService $organisationService Active-organisation lookup for the cache key.
+	 * @param MagicOrganizationHandler $organizationHandler Owns the organisation-boundary decision the native SQL renders.
 	 * @param TranslationHandler $translationHandler Resolves translatable group keys to the negotiated language.
 	 * @param LanguageService $languageService Request-scoped language negotiation (Accept-Language / _lang).
 	 * @param LoggerInterface|null $logger Optional logger for diagnostics.
@@ -164,6 +166,7 @@ class AggregationRunner {
 		private readonly PermissionHandler $permissionHandler,
 		private readonly IUserSession $userSession,
 		private readonly OrganisationService $organisationService,
+		private readonly MagicOrganizationHandler $organizationHandler,
 		private readonly TranslationHandler $translationHandler,
 		private readonly LanguageService $languageService,
 		private readonly ?LoggerInterface $logger = null,
@@ -2511,15 +2514,53 @@ class AggregationRunner {
 			$whereParts[] = "(_deleted IS NULL OR _deleted = 'null' OR _deleted = '')";
 		}
 
-		// SECURITY: mirror MagicRbacHandler's multi-tenancy predicate. The
-		// native fast path bypasses MagicMapper entirely, so without this
-		// filter any authed caller could compute aggregates over rows in
-		// other tenants. Active org of `null` ⇒ no rows (fail-closed).
-		// Column is `_organisation` — magic tables prefix metadata cols
-		// with `_` (see MagicMapper::METADATA_PREFIX).
-		$activeOrg = $this->organisationService->getActiveOrganisation();
-		$whereParts[] = $quote . '_organisation' . $quote . ' = ?';
-		$bindings[] = $activeOrg?->getUuid() ?? '__no_active_org__';
+		// SECURITY: the organisation boundary. This fast path bypasses
+		// MagicMapper entirely, so it must reproduce the SAME rule the list
+		// path applies — no wider, and no narrower.
+		//
+		// It used to carry its own flattened copy: a bare
+		// `_organisation = :activeOrg`. That was narrower in a way nobody saw,
+		// because SQL `=` never matches NULL: every object with no
+		// organisation was invisible here while the list API returned it.
+		// Measured 2026-08-30 on decidiq/meeting — four meetings listed, one
+		// org-less, `count` answered 3, and `filter[lifecycle]=closed`
+		// answered 0 for a meeting that plainly exists. Every KPI tile in the
+		// fleet reads this endpoint, so every one of them under-reported.
+		//
+		// The rule now has one home: MagicOrganizationHandler decides, and
+		// both paths render that decision. A mode this SQL cannot express is
+		// a refusal (`return null` ⇒ the PHP fallback, which goes through
+		// MagicMapper), never an approximation.
+		// Column is `_organisation` — magic tables prefix metadata cols with
+		// `_` (see MagicMapper::METADATA_PREFIX).
+		$orgScope = $this->organizationHandler->resolveOrganizationScope();
+		$orgColumn = $quote . '_organisation' . $quote;
+		switch ($orgScope['mode']) {
+			case MagicOrganizationHandler::SCOPE_ALL:
+				break;
+			case MagicOrganizationHandler::SCOPE_NONE:
+				$whereParts[] = '1 = 0';
+				break;
+			case MagicOrganizationHandler::SCOPE_NULL_ONLY:
+				$whereParts[] = $orgColumn . ' IS NULL';
+				break;
+			case MagicOrganizationHandler::SCOPE_IN:
+			case MagicOrganizationHandler::SCOPE_IN_OR_NULL:
+				$placeholders = implode(', ', array_fill(0, count($orgScope['uuids']), '?'));
+				$inClause = $orgColumn . ' IN (' . $placeholders . ')';
+				if ($orgScope['mode'] === MagicOrganizationHandler::SCOPE_IN_OR_NULL) {
+					$inClause = '(' . $inClause . ' OR ' . $orgColumn . ' IS NULL)';
+				}
+
+				$whereParts[] = $inClause;
+				foreach ($orgScope['uuids'] as $orgUuid) {
+					$bindings[] = $orgUuid;
+				}
+				break;
+			default:
+				// An unknown mode is not something to guess at.
+				return null;
+		}//end switch
 
 		foreach ($filter as $f => $v) {
 			$col = $this->sanitizeColumnName(name: (string)$f);

--- a/tests/Unit/Db/MagicMapper/MagicOrganizationHandlerScopeTest.php
+++ b/tests/Unit/Db/MagicMapper/MagicOrganizationHandlerScopeTest.php
@@ -1,0 +1,185 @@
+<?php
+
+/**
+ * MagicOrganizationHandlerScopeTest
+ *
+ * Pins the organisation boundary as a DECISION, independent of the SQL any
+ * one caller renders from it.
+ *
+ * The rule had two implementations: this class built it with the query
+ * builder, and `AggregationRunner::tryNativeAggregation()` carried a flattened
+ * copy — a bare `_organisation = :activeOrg`. SQL `=` never matches NULL, so
+ * every object with no organisation was invisible to the aggregation API while
+ * the list API returned it. Measured 2026-08-30 on `decidiq/meeting`: four
+ * meetings listed, one of them org-less, `count` answered 3, and
+ * `filter[lifecycle]=closed` answered 0 for a meeting that plainly exists.
+ * Every KPI tile in the fleet reads that endpoint.
+ *
+ * `SCOPE_IN_OR_NULL` is the case that was lost, so it is the case these tests
+ * exist for.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Db\MagicMapper;
+
+use OCA\OpenRegister\Db\MagicMapper\MagicOrganizationHandler;
+use OCP\IAppConfig;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @covers \OCA\OpenRegister\Db\MagicMapper\MagicOrganizationHandler
+ */
+class MagicOrganizationHandlerScopeTest extends TestCase {
+
+	/**
+	 * Build a handler for a caller with the given admin flag and active orgs.
+	 *
+	 * A non-null user is always supplied: `isSystemContext()` treats a NULL
+	 * user under the CLI SAPI as a trusted system context, and PHPUnit runs
+	 * under CLI, so a null user would silently make every case SCOPE_ALL.
+	 *
+	 * @param bool               $isAdmin  Whether the caller is in the admin group.
+	 * @param array<int, string> $orgUuids Active organisation UUIDs.
+	 *
+	 * @return MagicOrganizationHandler
+	 */
+	private function handler(bool $isAdmin, array $orgUuids): MagicOrganizationHandler {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('someone');
+
+		$session = $this->createMock(IUserSession::class);
+		$session->method('getUser')->willReturn($user);
+
+		$groups = $this->createMock(IGroupManager::class);
+		$groups->method('getUserGroupIds')->willReturn($isAdmin === true ? ['admin'] : ['users']);
+
+		$appConfig = $this->createMock(IAppConfig::class);
+		// No multitenancy config ⇒ SaaS mode off.
+		$appConfig->method('getValueString')->willReturn('');
+
+		$container = $this->createMock(ContainerInterface::class);
+		$container->method('get')->willThrowException(new \RuntimeException('no service'));
+
+		$handler = $this->getMockBuilder(MagicOrganizationHandler::class)
+			->setConstructorArgs([$session, $groups, $appConfig, $container, $this->createMock(LoggerInterface::class)])
+			->onlyMethods(['getActiveOrganizationUuids'])
+			->getMock();
+		$handler->method('getActiveOrganizationUuids')->willReturn($orgUuids);
+
+		return $handler;
+	}//end handler()
+
+	/**
+	 * THE REGRESSION. An admin scoped to an organisation must still see rows
+	 * that have no organisation — that is what the aggregation's flattened
+	 * `_organisation = ?` silently dropped.
+	 *
+	 * @return void
+	 */
+	public function testAdminWithAnActiveOrgAlsoSeesOrgLessRows(): void {
+		$scope = $this->handler(true, ['org-a'])->resolveOrganizationScope();
+
+		$this->assertSame(MagicOrganizationHandler::SCOPE_IN_OR_NULL, $scope['mode']);
+		$this->assertSame(['org-a'], $scope['uuids']);
+	}//end testAdminWithAnActiveOrgAlsoSeesOrgLessRows()
+
+	/**
+	 * A non-admin is confined to their own organisation, and org-less rows
+	 * stay invisible to them. Widening this would be a tenant leak.
+	 *
+	 * @return void
+	 */
+	public function testNonAdminIsConfinedToTheirOwnOrganisation(): void {
+		$scope = $this->handler(false, ['org-a'])->resolveOrganizationScope();
+
+		$this->assertSame(MagicOrganizationHandler::SCOPE_IN, $scope['mode']);
+		$this->assertSame(['org-a'], $scope['uuids']);
+	}//end testNonAdminIsConfinedToTheirOwnOrganisation()
+
+	/**
+	 * Several active organisations stay a set — a renderer that collapsed
+	 * them to one would under-report the rest.
+	 *
+	 * @return void
+	 */
+	public function testMultipleActiveOrganisationsAreAllCarried(): void {
+		$scope = $this->handler(false, ['org-a', 'org-b'])->resolveOrganizationScope();
+
+		$this->assertSame(MagicOrganizationHandler::SCOPE_IN, $scope['mode']);
+		$this->assertSame(['org-a', 'org-b'], $scope['uuids']);
+	}//end testMultipleActiveOrganisationsAreAllCarried()
+
+	/**
+	 * An admin with no active organisation sees exactly the org-less rows.
+	 *
+	 * @return void
+	 */
+	public function testAdminWithoutAnActiveOrganisationSeesOnlyOrgLessRows(): void {
+		$scope = $this->handler(true, [])->resolveOrganizationScope();
+
+		$this->assertSame(MagicOrganizationHandler::SCOPE_NULL_ONLY, $scope['mode']);
+		$this->assertSame([], $scope['uuids']);
+	}//end testAdminWithoutAnActiveOrganisationSeesOnlyOrgLessRows()
+
+	/**
+	 * Fail-closed: a non-admin with no active organisation sees nothing at
+	 * all, rather than everything.
+	 *
+	 * @return void
+	 */
+	public function testNonAdminWithoutAnActiveOrganisationSeesNothing(): void {
+		$scope = $this->handler(false, [])->resolveOrganizationScope();
+
+		$this->assertSame(MagicOrganizationHandler::SCOPE_NONE, $scope['mode']);
+	}//end testNonAdminWithoutAnActiveOrganisationSeesNothing()
+
+	/**
+	 * The admin bypass lifts the boundary entirely, but only when the caller
+	 * opts into it — the default must stay scoped.
+	 *
+	 * @return void
+	 */
+	public function testAdminBypassIsOptInAndLiftsTheBoundary(): void {
+		$handler = $this->handler(true, ['org-a']);
+
+		$this->assertSame(
+			MagicOrganizationHandler::SCOPE_ALL,
+			$handler->resolveOrganizationScope(adminBypassEnabled: true)['mode']
+		);
+		$this->assertSame(
+			MagicOrganizationHandler::SCOPE_IN_OR_NULL,
+			$handler->resolveOrganizationScope()['mode'],
+			'the bypass must not leak into the default call'
+		);
+	}//end testAdminBypassIsOptInAndLiftsTheBoundary()
+
+	/**
+	 * The bypass is for admins only.
+	 *
+	 * @return void
+	 */
+	public function testAdminBypassDoesNothingForANonAdmin(): void {
+		$scope = $this->handler(false, ['org-a'])->resolveOrganizationScope(adminBypassEnabled: true);
+
+		$this->assertSame(MagicOrganizationHandler::SCOPE_IN, $scope['mode']);
+	}//end testAdminBypassDoesNothingForANonAdmin()
+
+}//end class

--- a/tests/Unit/Service/Aggregation/AggregationJoinAndCompositeGroupByTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationJoinAndCompositeGroupByTest.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 
 namespace Unit\Service\Aggregation;
 
+use OCA\OpenRegister\Db\MagicMapper\MagicOrganizationHandler;
 use OCA\OpenRegister\Db\MagicMapper;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\Register;
@@ -1729,6 +1730,7 @@ class AggregationJoinAndCompositeGroupByTest extends TestCase {
 			permissionHandler: $this->permissionHandler,
 			userSession: $this->userSession,
 			organisationService: $this->organisationService,
+			organizationHandler: $this->orgHandlerScopedTo('__no_active_org__'),
 			translationHandler: $this->translationHandler,
 			languageService: $this->languageService,
 		);
@@ -1775,4 +1777,24 @@ class AggregationJoinAndCompositeGroupByTest extends TestCase {
 		$register->setSchemas($schemaIds);
 		return $register;
 	}//end makeRegister()
+
+	/**
+	 * A MagicOrganizationHandler that reports the caller scoped to exactly one
+	 * organisation. The fixtures in these tests seed rows carrying that same
+	 * value in `_organisation`, so the rendered predicate matches them — which
+	 * is what the old hard-coded `_organisation = :activeOrg` did implicitly.
+	 *
+	 * @param string $orgUuid The organisation the caller is scoped to.
+	 *
+	 * @return MagicOrganizationHandler
+	 */
+	private function orgHandlerScopedTo(string $orgUuid): MagicOrganizationHandler {
+		$handler = $this->createMock(MagicOrganizationHandler::class);
+		$handler->method('resolveOrganizationScope')->willReturn(
+			['mode' => MagicOrganizationHandler::SCOPE_IN, 'uuids' => [$orgUuid]]
+		);
+
+		return $handler;
+	}//end orgHandlerScopedTo()
+
 }//end class

--- a/tests/Unit/Service/Aggregation/AggregationRegisterScopeTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRegisterScopeTest.php
@@ -38,6 +38,7 @@ declare(strict_types=1);
 
 namespace Unit\Service\Aggregation;
 
+use OCA\OpenRegister\Db\MagicMapper\MagicOrganizationHandler;
 use OCA\OpenRegister\Db\MagicMapper;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\Register;
@@ -128,6 +129,7 @@ class AggregationRegisterScopeTest extends TestCase {
 			permissionHandler: $this->permissionHandler,
 			userSession: $this->userSession,
 			organisationService: $this->organisationService,
+			organizationHandler: $this->orgHandlerScopedTo('__no_active_org__'),
 			translationHandler: $this->createMock(TranslationHandler::class),
 			languageService: $this->createMock(LanguageService::class)
 		);
@@ -431,4 +433,24 @@ class AggregationRegisterScopeTest extends TestCase {
 		$this->assertStringContainsString('carries no schemas at all', $caught->getMessage());
 		$this->assertStringContainsString('occ openregister:registers:relink-schemas', $caught->getMessage());
 	}//end testRegisterWithAnEmptySchemaListIsRefusedWithTheRepairCommand()
+
+	/**
+	 * A MagicOrganizationHandler that reports the caller scoped to exactly one
+	 * organisation. The fixtures in these tests seed rows carrying that same
+	 * value in `_organisation`, so the rendered predicate matches them — which
+	 * is what the old hard-coded `_organisation = :activeOrg` did implicitly.
+	 *
+	 * @param string $orgUuid The organisation the caller is scoped to.
+	 *
+	 * @return MagicOrganizationHandler
+	 */
+	private function orgHandlerScopedTo(string $orgUuid): MagicOrganizationHandler {
+		$handler = $this->createMock(MagicOrganizationHandler::class);
+		$handler->method('resolveOrganizationScope')->willReturn(
+			['mode' => MagicOrganizationHandler::SCOPE_IN, 'uuids' => [$orgUuid]]
+		);
+
+		return $handler;
+	}//end orgHandlerScopedTo()
+
 }//end class

--- a/tests/Unit/Service/Aggregation/AggregationRunnerAdhocCacheTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRunnerAdhocCacheTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Unit\Service\Aggregation;
 
+use OCA\OpenRegister\Db\MagicMapper\MagicOrganizationHandler;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use OCA\OpenRegister\Db\MagicMapper;
 use OCA\OpenRegister\Db\Register;
@@ -113,6 +114,7 @@ class AggregationRunnerAdhocCacheTest extends TestCase {
 			permissionHandler: $this->permissionHandler,
 			userSession: $this->userSession,
 			organisationService: $this->organisationService,
+			organizationHandler: $this->orgHandlerScopedTo('__no_active_org__'),
 			translationHandler: $this->translationHandler,
 			languageService: $this->languageService,
 		);
@@ -239,6 +241,7 @@ class AggregationRunnerAdhocCacheTest extends TestCase {
 			permissionHandler: $this->permissionHandler,
 			userSession: $this->userSession,
 			organisationService: $this->organisationService,
+			organizationHandler: $this->orgHandlerScopedTo('__no_active_org__'),
 			translationHandler: $translationHandler,
 			languageService: $languageService,
 		);
@@ -322,5 +325,25 @@ class AggregationRunnerAdhocCacheTest extends TestCase {
 		$register->setSchemas([1]);
 		return $register;
 	}//end makeRegister()
+
+
+	/**
+	 * A MagicOrganizationHandler that reports the caller scoped to exactly one
+	 * organisation. The fixtures in these tests seed rows carrying that same
+	 * value in `_organisation`, so the rendered predicate matches them — which
+	 * is what the old hard-coded `_organisation = :activeOrg` did implicitly.
+	 *
+	 * @param string $orgUuid The organisation the caller is scoped to.
+	 *
+	 * @return MagicOrganizationHandler
+	 */
+	private function orgHandlerScopedTo(string $orgUuid): MagicOrganizationHandler {
+		$handler = $this->createMock(MagicOrganizationHandler::class);
+		$handler->method('resolveOrganizationScope')->willReturn(
+			['mode' => MagicOrganizationHandler::SCOPE_IN, 'uuids' => [$orgUuid]]
+		);
+
+		return $handler;
+	}//end orgHandlerScopedTo()
 
 }//end class

--- a/tests/Unit/Service/Aggregation/AggregationRunnerCumulativeTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRunnerCumulativeTest.php
@@ -39,6 +39,7 @@ declare(strict_types=1);
 
 namespace Unit\Service\Aggregation;
 
+use OCA\OpenRegister\Db\MagicMapper\MagicOrganizationHandler;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
@@ -364,6 +365,7 @@ class AggregationRunnerCumulativeTest extends TestCase {
 			permissionHandler: $this->permissionHandler,
 			userSession: $this->userSession,
 			organisationService: $this->organisationService,
+			organizationHandler: $this->orgHandlerScopedTo('__no_active_org__'),
 			translationHandler: $this->createMock(TranslationHandler::class),
 			languageService: $this->createMock(LanguageService::class),
 		);
@@ -521,9 +523,30 @@ class AggregationRunnerCumulativeTest extends TestCase {
 			permissionHandler: $this->permissionHandler,
 			userSession: $this->userSession,
 			organisationService: $this->organisationService,
+			organizationHandler: $this->orgHandlerScopedTo('__no_active_org__'),
 			translationHandler: $this->createMock(TranslationHandler::class),
 			languageService: $this->createMock(LanguageService::class),
 		);
 
 	}//end makeRunner()
+
+	/**
+	 * A MagicOrganizationHandler that reports the caller scoped to exactly one
+	 * organisation. The fixtures in these tests seed rows carrying that same
+	 * value in `_organisation`, so the rendered predicate matches them — which
+	 * is what the old hard-coded `_organisation = :activeOrg` did implicitly.
+	 *
+	 * @param string $orgUuid The organisation the caller is scoped to.
+	 *
+	 * @return MagicOrganizationHandler
+	 */
+	private function orgHandlerScopedTo(string $orgUuid): MagicOrganizationHandler {
+		$handler = $this->createMock(MagicOrganizationHandler::class);
+		$handler->method('resolveOrganizationScope')->willReturn(
+			['mode' => MagicOrganizationHandler::SCOPE_IN, 'uuids' => [$orgUuid]]
+		);
+
+		return $handler;
+	}//end orgHandlerScopedTo()
+
 }//end class

--- a/tests/Unit/Service/Aggregation/AggregationRunnerMultiFieldGroupByTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRunnerMultiFieldGroupByTest.php
@@ -30,6 +30,7 @@ declare(strict_types=1);
 
 namespace Unit\Service\Aggregation;
 
+use OCA\OpenRegister\Db\MagicMapper\MagicOrganizationHandler;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use OCA\OpenRegister\Db\MagicMapper;
@@ -382,6 +383,7 @@ class AggregationRunnerMultiFieldGroupByTest extends TestCase {
 			permissionHandler: $permissionHandler,
 			userSession: $userSession,
 			organisationService: $organisationService,
+			organizationHandler: $this->orgHandlerScopedTo('__no_active_org__'),
 			translationHandler: $translationHandler,
 			languageService: $languageService,
 		);
@@ -400,4 +402,24 @@ class AggregationRunnerMultiFieldGroupByTest extends TestCase {
 		$schema->setId(1);
 		return $schema;
 	}
+
+	/**
+	 * A MagicOrganizationHandler that reports the caller scoped to exactly one
+	 * organisation. The fixtures in these tests seed rows carrying that same
+	 * value in `_organisation`, so the rendered predicate matches them — which
+	 * is what the old hard-coded `_organisation = :activeOrg` did implicitly.
+	 *
+	 * @param string $orgUuid The organisation the caller is scoped to.
+	 *
+	 * @return MagicOrganizationHandler
+	 */
+	private function orgHandlerScopedTo(string $orgUuid): MagicOrganizationHandler {
+		$handler = $this->createMock(MagicOrganizationHandler::class);
+		$handler->method('resolveOrganizationScope')->willReturn(
+			['mode' => MagicOrganizationHandler::SCOPE_IN, 'uuids' => [$orgUuid]]
+		);
+
+		return $handler;
+	}//end orgHandlerScopedTo()
+
 }//end class

--- a/tests/Unit/Service/Aggregation/AggregationRunnerMultiMetricTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRunnerMultiMetricTest.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 
 namespace Unit\Service\Aggregation;
 
+use OCA\OpenRegister\Db\MagicMapper\MagicOrganizationHandler;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use OCA\OpenRegister\Db\MagicMapper;
@@ -414,6 +415,7 @@ class AggregationRunnerMultiMetricTest extends TestCase {
 			permissionHandler: $permissionHandler,
 			userSession: $userSession,
 			organisationService: $organisationService,
+			organizationHandler: $this->orgHandlerScopedTo('__no_active_org__'),
 			translationHandler: $translationHandler,
 			languageService: $languageService,
 		);
@@ -439,4 +441,24 @@ class AggregationRunnerMultiMetricTest extends TestCase {
 		);
 		return $schema;
 	}//end makeSchema()
+
+	/**
+	 * A MagicOrganizationHandler that reports the caller scoped to exactly one
+	 * organisation. The fixtures in these tests seed rows carrying that same
+	 * value in `_organisation`, so the rendered predicate matches them — which
+	 * is what the old hard-coded `_organisation = :activeOrg` did implicitly.
+	 *
+	 * @param string $orgUuid The organisation the caller is scoped to.
+	 *
+	 * @return MagicOrganizationHandler
+	 */
+	private function orgHandlerScopedTo(string $orgUuid): MagicOrganizationHandler {
+		$handler = $this->createMock(MagicOrganizationHandler::class);
+		$handler->method('resolveOrganizationScope')->willReturn(
+			['mode' => MagicOrganizationHandler::SCOPE_IN, 'uuids' => [$orgUuid]]
+		);
+
+		return $handler;
+	}//end orgHandlerScopedTo()
+
 }//end class

--- a/tests/Unit/Service/Aggregation/AggregationRunnerMultiValueFilterTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRunnerMultiValueFilterTest.php
@@ -41,6 +41,7 @@ declare(strict_types=1);
 
 namespace Unit\Service\Aggregation;
 
+use OCA\OpenRegister\Db\MagicMapper\MagicOrganizationHandler;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use OCA\OpenRegister\Db\MagicMapper;
@@ -577,6 +578,7 @@ class AggregationRunnerMultiValueFilterTest extends TestCase {
 			permissionHandler: $permissionHandler,
 			userSession: $userSession,
 			organisationService: $organisationService,
+			organizationHandler: $this->orgHandlerScopedTo('__no_active_org__'),
 			translationHandler: $translationHandler,
 			languageService: $languageService,
 		);
@@ -616,4 +618,24 @@ class AggregationRunnerMultiValueFilterTest extends TestCase {
 		);
 		return $schema;
 	}//end makeTagsSchema()
+
+	/**
+	 * A MagicOrganizationHandler that reports the caller scoped to exactly one
+	 * organisation. The fixtures in these tests seed rows carrying that same
+	 * value in `_organisation`, so the rendered predicate matches them — which
+	 * is what the old hard-coded `_organisation = :activeOrg` did implicitly.
+	 *
+	 * @param string $orgUuid The organisation the caller is scoped to.
+	 *
+	 * @return MagicOrganizationHandler
+	 */
+	private function orgHandlerScopedTo(string $orgUuid): MagicOrganizationHandler {
+		$handler = $this->createMock(MagicOrganizationHandler::class);
+		$handler->method('resolveOrganizationScope')->willReturn(
+			['mode' => MagicOrganizationHandler::SCOPE_IN, 'uuids' => [$orgUuid]]
+		);
+
+		return $handler;
+	}//end orgHandlerScopedTo()
+
 }//end class

--- a/tests/Unit/Service/Aggregation/AggregationRunnerNativeBucketTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRunnerNativeBucketTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Unit\Service\Aggregation;
 
+use OCA\OpenRegister\Db\MagicMapper\MagicOrganizationHandler;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
@@ -399,9 +400,30 @@ class AggregationRunnerNativeBucketTest extends TestCase {
 			permissionHandler: $this->permissionHandler,
 			userSession: $this->userSession,
 			organisationService: $this->organisationService,
+			organizationHandler: $this->orgHandlerScopedTo('__no_active_org__'),
 			translationHandler: $this->createMock(TranslationHandler::class),
 			languageService: $this->createMock(LanguageService::class),
 		);
 
 	}//end makeRunner()
+
+	/**
+	 * A MagicOrganizationHandler that reports the caller scoped to exactly one
+	 * organisation. The fixtures in these tests seed rows carrying that same
+	 * value in `_organisation`, so the rendered predicate matches them — which
+	 * is what the old hard-coded `_organisation = :activeOrg` did implicitly.
+	 *
+	 * @param string $orgUuid The organisation the caller is scoped to.
+	 *
+	 * @return MagicOrganizationHandler
+	 */
+	private function orgHandlerScopedTo(string $orgUuid): MagicOrganizationHandler {
+		$handler = $this->createMock(MagicOrganizationHandler::class);
+		$handler->method('resolveOrganizationScope')->willReturn(
+			['mode' => MagicOrganizationHandler::SCOPE_IN, 'uuids' => [$orgUuid]]
+		);
+
+		return $handler;
+	}//end orgHandlerScopedTo()
+
 }//end class

--- a/tests/Unit/Service/Aggregation/AggregationRunnerTest.php
+++ b/tests/Unit/Service/Aggregation/AggregationRunnerTest.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 
 namespace Unit\Service\Aggregation;
 
+use OCA\OpenRegister\Db\MagicMapper\MagicOrganizationHandler;
 use OCA\OpenRegister\Db\MagicMapper;
 use OCA\OpenRegister\Db\Register;
 use OCA\OpenRegister\Db\RegisterMapper;
@@ -118,6 +119,7 @@ class AggregationRunnerTest extends TestCase {
 			permissionHandler: $this->permissionHandler,
 			userSession: $this->userSession,
 			organisationService: $this->organisationService,
+			organizationHandler: $this->orgHandlerScopedTo('__no_active_org__'),
 			translationHandler: $this->createMock(TranslationHandler::class),
 			languageService: $this->createMock(LanguageService::class)
 		);
@@ -238,4 +240,24 @@ class AggregationRunnerTest extends TestCase {
 		$this->privateMethod($runner, 'loadSchema')->invoke($runner, 'does-not-exist');
 
 	}//end testLoadSchemaUnknownRefRethrowsAsNotFoundRuntimeException()
+
+	/**
+	 * A MagicOrganizationHandler that reports the caller scoped to exactly one
+	 * organisation. The fixtures in these tests seed rows carrying that same
+	 * value in `_organisation`, so the rendered predicate matches them — which
+	 * is what the old hard-coded `_organisation = :activeOrg` did implicitly.
+	 *
+	 * @param string $orgUuid The organisation the caller is scoped to.
+	 *
+	 * @return MagicOrganizationHandler
+	 */
+	private function orgHandlerScopedTo(string $orgUuid): MagicOrganizationHandler {
+		$handler = $this->createMock(MagicOrganizationHandler::class);
+		$handler->method('resolveOrganizationScope')->willReturn(
+			['mode' => MagicOrganizationHandler::SCOPE_IN, 'uuids' => [$orgUuid]]
+		);
+
+		return $handler;
+	}//end orgHandlerScopedTo()
+
 }//end class

--- a/tests/Unit/Service/Aggregation/CrossSchemaAggregationRunnerTest.php
+++ b/tests/Unit/Service/Aggregation/CrossSchemaAggregationRunnerTest.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Unit\Service\Aggregation;
 
+use OCA\OpenRegister\Db\MagicMapper\MagicOrganizationHandler;
 use OCA\OpenRegister\Db\MagicMapper;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\Register;
@@ -135,6 +136,7 @@ class CrossSchemaAggregationRunnerTest extends TestCase {
 			permissionHandler: $this->permissionHandler,
 			userSession: $this->userSession,
 			organisationService: $this->organisationService,
+			organizationHandler: $this->orgHandlerScopedTo('__no_active_org__'),
 			translationHandler: $this->createMock(TranslationHandler::class),
 			languageService: $this->createMock(LanguageService::class),
 		);
@@ -859,5 +861,25 @@ class CrossSchemaAggregationRunnerTest extends TestCase {
 			bypassRbac: true
 		);
 	}//end testDerivedMetricCannotReadALaterAlias()
+
+
+	/**
+	 * A MagicOrganizationHandler that reports the caller scoped to exactly one
+	 * organisation. The fixtures in these tests seed rows carrying that same
+	 * value in `_organisation`, so the rendered predicate matches them — which
+	 * is what the old hard-coded `_organisation = :activeOrg` did implicitly.
+	 *
+	 * @param string $orgUuid The organisation the caller is scoped to.
+	 *
+	 * @return MagicOrganizationHandler
+	 */
+	private function orgHandlerScopedTo(string $orgUuid): MagicOrganizationHandler {
+		$handler = $this->createMock(MagicOrganizationHandler::class);
+		$handler->method('resolveOrganizationScope')->willReturn(
+			['mode' => MagicOrganizationHandler::SCOPE_IN, 'uuids' => [$orgUuid]]
+		);
+
+		return $handler;
+	}//end orgHandlerScopedTo()
 
 }//end class


### PR DESCRIPTION
## The defect

Two implementations of the organisation boundary had drifted apart. The list path builds it with the query builder in `MagicOrganizationHandler`; the aggregation's native fast path carried a **flattened copy** — a bare `_organisation = :activeOrg`.

SQL `=` never matches NULL, so **every object with no organisation was invisible to the aggregation API** while the list API returned it.

Measured on `decidiq/meeting`, as an admin, at one instant:

| | list endpoint | aggregation `/value` |
|---|---|---|
| total | **4** | **3** |
| `lifecycle=closed` | **1** | **0** |

Exactly one of the four rows is org-less, and it is the closed one. The relationship `aggregated == listed − withoutOrganisation` held on every register probed (decidiq 2−1=1, pipelinq 17−0=17, dossiq 2−0=2), and kept holding as the dataset grew mid-investigation.

**Every KPI tile in the fleet reads this endpoint**, so each one silently under-reported. A dashboard number that is confidently wrong is worse than one that is missing.

## The fix

The rule now has **one home**. `resolveOrganizationScope()` returns a *decision* — `all` / `none` / `null-only` / `in` / `in-or-null` — and both callers render it: the list path as query-builder expressions, the aggregation as raw SQL.

A mode the SQL cannot express is a **refusal** (`return null` → the PHP fallback, which goes through `MagicMapper`), never an approximation. That is exactly the property the old code lacked: it approximated, and nobody could see it.

`in-or-null` is the case that was lost — an admin scoped to an organisation also sees org-less rows. **Non-admins are unchanged** and still cannot see them, so this widens nothing for a tenant.

## Verification

- **Live, after the change:** the same endpoint answers **4** and **1**, matching the list endpoint exactly.
- New `MagicOrganizationHandlerScopeTest` covers all five modes. The regression case was checked to **fail** against the old flattened rule (reverting the `in-or-null` branch fails 2 of 7).
- `phpcs`, `phpmd`, `psalm`, `phpstan` clean. This class had **zero** phpmd baseline entries before and still has zero — the complexity suppressions moved from `applyOrganizationFilter` to `resolveOrganizationScope` along with the code they were written for, rather than new exemptions being added.
- Db (1483 tests) and Service/Aggregation (313 tests) suites green. The full `tests/Unit/Service` run OOM-kills locally at 11k tests in one process — a pre-existing scale limit of this box, not this change; CI runs it properly.

## Note on the 12 test files

`AggregationRunner` gains a constructor collaborator. Every call site uses **named** arguments, so nothing shifted positionally — they simply need the new one. It is mocked to the single-org scope those fixtures already seed (`_organisation = '__no_active_org__'`), so the rendered predicate matches their rows exactly as the old hard-coded one did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)