### PR TITLE
feat(organisation): let an organisation be a federated counterparty, not a tenant

### DIFF
--- a/lib/BackgroundJob/TenantDeprovisionJob.php
+++ b/lib/BackgroundJob/TenantDeprovisionJob.php
@@ -74,7 +74,10 @@ class TenantDeprovisionJob extends TimedJob {
 		$this->logger->info('[TenantDeprovisionJob] Starting deprovisioning check');
 
 		try {
-			$organisations = $this->organisationMapper->findAll(
+			// Tenant-scoped read, not findAll: a federated counterparty is an
+			// organisation in this table but NOT a tenant of this installation, and
+			// selecting on status alone would sweep it up with the tenants.
+			$organisations = $this->organisationMapper->findLocalTenants(
 				filters: ['status' => TenantLifecycleService::STATUS_DEPROVISIONING]
 			);
 		} catch (\Exception $e) {

--- a/lib/BackgroundJob/TenantPurgeJob.php
+++ b/lib/BackgroundJob/TenantPurgeJob.php
@@ -92,7 +92,10 @@ class TenantPurgeJob extends TimedJob {
 		$cutoffDate->sub(new DateInterval("P{$retentionDays}D"));
 
 		try {
-			$organisations = $this->organisationMapper->findAll(
+			// Tenant-scoped read, not findAll: a federated counterparty is an
+			// organisation in this table but NOT a tenant of this installation, and
+			// selecting on status alone would sweep it up with the tenants.
+			$organisations = $this->organisationMapper->findLocalTenants(
 				filters: ['status' => TenantLifecycleService::STATUS_ARCHIVED]
 			);
 		} catch (\Exception $e) {

--- a/lib/BackgroundJob/TenantUsageSyncJob.php
+++ b/lib/BackgroundJob/TenantUsageSyncJob.php
@@ -82,7 +82,10 @@ class TenantUsageSyncJob extends TimedJob {
 		$this->logger->debug('[TenantUsageSyncJob] Starting usage sync');
 
 		try {
-			$organisations = $this->organisationMapper->findAll(
+			// Tenant-scoped read, not findAll: a federated counterparty is an
+			// organisation in this table but NOT a tenant of this installation, and
+			// selecting on status alone would sweep it up with the tenants.
+			$organisations = $this->organisationMapper->findLocalTenants(
 				filters: ['status' => TenantLifecycleService::STATUS_ACTIVE]
 			);
 		} catch (\Exception $e) {

--- a/lib/Db/Organisation.php
+++ b/lib/Db/Organisation.php
@@ -77,6 +77,10 @@ use Symfony\Component\Uid\Uuid;
  * @method void setDeprovisionedAt(?DateTime $deprovisionedAt)
  * @method string|null getType()
  * @method void setType(?string $type)
+ * @method bool|null getIsLocalTenant()
+ * @method void setIsLocalTenant(?bool $isLocalTenant)
+ * @method string|null getRemoteInstanceUrl()
+ * @method void setRemoteInstanceUrl(?string $remoteInstanceUrl)
  * @method string|null getSummary()
  * @method void setSummary(?string $summary)
  * @method string|null getOin()
@@ -302,6 +306,40 @@ class Organisation extends Entity implements JsonSerializable {
 	protected ?string $type = 'organisation';
 
 	/**
+	 * Whether this organisation is a tenant OF THIS INSTALLATION.
+	 *
+	 * 🔴 THIS ONE IS AN AUTHORIZATION AND LIFECYCLE INPUT, unlike `type` above,
+	 * which is deliberately not. It answers a question `type` cannot: a row may
+	 * be a perfectly real organisation — a ketenpartner, a supplier, a
+	 * municipality we exchange cases with — and still not be a tenant here.
+	 *
+	 * It exists because the tenant BACKGROUND JOBS select on `status` alone,
+	 * and one of them (TenantPurgeJob) permanently DELETES what it selects.
+	 * Without this flag an archived counterparty is indistinguishable from an
+	 * archived tenant, and is deleted with it. Every tenant enumeration filters
+	 * on this; see TenantJobsScopeTest.
+	 *
+	 * Defaults to TRUE so every existing row keeps its present meaning.
+	 *
+	 * @var boolean|null True for a tenant of this installation.
+	 */
+	protected ?bool $isLocalTenant = true;
+
+	/**
+	 * Base URL of the OpenRegister instance this organisation is a tenant of.
+	 *
+	 * Set only on a counterparty — an organisation that is a tenant somewhere
+	 * ELSE and interacts with us across the federation. It is the same value
+	 * `FederatedShare.remoteInstanceUrl` carries, which is what lets a share
+	 * and the organisation it is with be resolved to each other.
+	 *
+	 * Empty for a local tenant, which is the ordinary case.
+	 *
+	 * @var string|null The peer instance base URL.
+	 */
+	protected ?string $remoteInstanceUrl = null;
+
+	/**
 	 * Short summary for overview pages (OpenCatalogi `summary`).
 	 *
 	 * @var string|null
@@ -501,6 +539,8 @@ class Organisation extends Entity implements JsonSerializable {
 		// Identity facet (ADR-022 §3): the statutory identifiers a leaf app
 		// used to keep in its own publisher/vendor record.
 		$this->addType(fieldName: 'type', type: 'string');
+		$this->addType(fieldName: 'isLocalTenant', type: 'boolean');
+		$this->addType(fieldName: 'remoteInstanceUrl', type: 'string');
 		$this->addType(fieldName: 'summary', type: 'string');
 		$this->addType(fieldName: 'oin', type: 'string');
 		$this->addType(fieldName: 'tooi', type: 'string');
@@ -948,6 +988,8 @@ class Organisation extends Entity implements JsonSerializable {
 			'status' => $this->status ?? 'active',
 			'environment' => $this->environment ?? 'production',
 			'type' => $this->type ?? 'organisation',
+			'isLocalTenant' => ($this->isLocalTenant ?? true),
+			'remoteInstanceUrl' => $this->remoteInstanceUrl,
 			'summary' => $this->summary,
 			'oin' => $this->oin,
 			'tooi' => $this->tooi,

--- a/lib/Db/OrganisationMapper.php
+++ b/lib/Db/OrganisationMapper.php
@@ -441,6 +441,66 @@ class OrganisationMapper extends QBMapper {
 	 */
 
 	/**
+	 * Find organisations that are tenants OF THIS INSTALLATION.
+	 *
+	 * A named method rather than one more filter every caller must remember,
+	 * because forgetting it is destructive: the tenant background jobs select on
+	 * `status` alone and TenantPurgeJob PERMANENTLY DELETES what it selects, so
+	 * a federated counterparty that happens to be archived would be deleted as
+	 * though it were a spent tenant. The name is the guarantee, and it is
+	 * greppable.
+	 *
+	 * 🔴 A NULL counts as a tenant. `is_local_tenant` was added by migration and
+	 * every row written before it holds NULL, so a plain `= true` would make
+	 * every pre-existing tenant invisible to all three jobs at once — tenants
+	 * would stop being deprovisioned, purged and metered, and nothing would
+	 * report it. Only a row explicitly marked false is excluded.
+	 *
+	 * @param int   $limit   Maximum number of results.
+	 * @param int   $offset  Number of results to skip.
+	 * @param array $filters Column => value equality filters.
+	 *
+	 * @return Organisation[]
+	 *
+	 * @psalm-return list<\OCA\OpenRegister\Db\Organisation>
+	 *
+	 * @spec openspec/changes/organisation-as-federated-counterparty/specs/organisation-tenancy-scope/spec.md
+	 */
+	public function findLocalTenants(int $limit = 50, int $offset = 0, ?array $filters = []): array {
+		$qb = $this->db->getQueryBuilder();
+
+		$qb->select('*')
+			->from($this->getTableName())
+			->orderBy('name', 'ASC')
+			->setMaxResults($limit)
+			->setFirstResult($offset);
+
+		$qb->andWhere(
+			$qb->expr()->orX(
+				$qb->expr()->isNull('is_local_tenant'),
+				$qb->expr()->eq('is_local_tenant', $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL))
+			)
+		);
+
+		foreach ($filters ?? [] as $filter => $value) {
+			if ($value === 'IS NOT NULL') {
+				$qb->andWhere($qb->expr()->isNotNull($filter));
+				continue;
+			}
+
+			if ($value === 'IS NULL') {
+				$qb->andWhere($qb->expr()->isNull($filter));
+				continue;
+			}
+
+			$qb->andWhere($qb->expr()->eq($filter, $qb->createNamedParameter($value)));
+		}
+
+		return $this->findEntities(query: $qb);
+
+	}//end findLocalTenants()
+
+	/**
 	 * Find all organisations with pagination and optional column filters
 	 *
 	 * The `$filters` parameter is NOT optional sugar: three tenant-lifecycle

--- a/lib/Migration/Version1Date20260831020000.php
+++ b/lib/Migration/Version1Date20260831020000.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Give an organisation a way to say it is NOT a tenant of this installation.
+ *
+ * `Organisation` already carried a `type` discriminator, and that one is
+ * deliberately NOT an authorization input (ADR-002 Rule 1: the UUID is the only
+ * tenant key). So there was no field anything could safely consult to tell a
+ * tenant from a counterparty — an organisation that is a tenant somewhere ELSE
+ * and interacts with us across the federation.
+ *
+ * 🔴 That gap is destructive, not cosmetic. The three tenant background jobs
+ * select organisations by `status` alone, and TenantPurgeJob PERMANENTLY
+ * DELETES what it selects. An archived ketenpartner in the same table is
+ * indistinguishable from an archived tenant and is deleted with it.
+ *
+ * `is_local_tenant` defaults to TRUE so every existing row keeps exactly the
+ * meaning it has today; only rows explicitly marked otherwise change behaviour.
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/specs/tenant-lifecycle/spec.md#requirement-database-migration-must-add-lifecycle-fields-to-organisation-entity
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use Doctrine\DBAL\Types\Types;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Adds the counterparty discriminator and its federation link.
+ *
+ * @spec openspec/specs/tenant-lifecycle/spec.md#requirement-database-migration-must-add-lifecycle-fields-to-organisation-entity
+ */
+class Version1Date20260831020000 extends SimpleMigrationStep {
+
+	/**
+	 * The table this migration changes.
+	 */
+	private const TABLE = 'openregister_organisations';
+
+	/**
+	 * The columns this migration adds.
+	 *
+	 * @return array<int, array{name: string, type: string, options: array<string, mixed>}> The specifications.
+	 */
+	private function columnSpecifications(): array {
+		return [
+			[
+				'name' => 'is_local_tenant',
+				'type' => Types::BOOLEAN,
+				'options' => [
+					'notnull' => false,
+					'default' => true,
+					'comment' => 'True when this organisation is a tenant of THIS installation; '
+						. 'false for a federated counterparty. Unlike `type`, this IS '
+						. 'consulted by tenancy and by the purge job.',
+				],
+			],
+			[
+				'name' => 'remote_instance_url',
+				'type' => Types::STRING,
+				'options' => [
+					'notnull' => false,
+					'length' => 512,
+					'comment' => 'Base URL of the OpenRegister instance a counterparty is a '
+						. 'tenant of; matches FederatedShare.remote_instance_url. '
+						. 'Empty for a local tenant.',
+				],
+			],
+		];
+
+	}//end columnSpecifications()
+
+	/**
+	 * Add the columns.
+	 *
+	 * @param IOutput  $output        Migration output.
+	 * @param Closure  $schemaClosure The schema closure.
+	 * @param array    $options       Migration options.
+	 *
+	 * @return ISchemaWrapper|null The changed schema, or null when nothing changed.
+	 *
+	 * @spec openspec/changes/organisation-as-federated-counterparty/specs/organisation-tenancy-scope/spec.md
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/* @var ISchemaWrapper $schema The schema wrapper. */
+		$schema = $schemaClosure();
+
+		// This class sorts AFTER the one that creates the table, so the guard is
+		// the ordinary "already ran" check and not a permanent skip — the trap
+		// Version1Date20250102000000 fell into and documents.
+		if ($schema->hasTable(self::TABLE) === false) {
+			$output->warning(message: 'openregister_organisations is absent; skipping the counterparty columns');
+
+			return null;
+		}
+
+		$table = $schema->getTable(self::TABLE);
+		$added = [];
+
+		foreach ($this->columnSpecifications() as $column) {
+			if ($table->hasColumn($column['name']) === true) {
+				continue;
+			}
+
+			$table->addColumn($column['name'], $column['type'], $column['options']);
+			$added[] = $column['name'];
+		}
+
+		if ($added === []) {
+			return null;
+		}
+
+		$output->info(message: 'openregister_organisations: added ' . implode(', ', $added));
+
+		return $schema;
+
+	}//end changeSchema()
+
+}//end class

--- a/openspec/changes/organisation-as-federated-counterparty/proposal.md
+++ b/openspec/changes/organisation-as-federated-counterparty/proposal.md
@@ -1,0 +1,90 @@
+---
+kind: code
+---
+
+# Proposal: organisation-as-federated-counterparty
+
+## Summary
+
+Let an `Organisation` say that it is **not** a tenant of this installation — that
+it is a counterparty, a tenant somewhere else, reachable across the federation.
+Then make every tenant enumeration consult that, so the tenant background jobs
+stop being able to see one.
+
+## Motivation
+
+Consuming apps want to put their partner organisations here. dossiq carries a
+`partnerOrganization` schema — name, slug, oin, contactEmail, groupId, isActive
+— every field of which `Organisation` already has, plus a `type` discriminator
+whose values include `collaboration` and `vendor`. A ketenpartner obviously IS
+an organisation.
+
+The reason it cannot simply move is that this table is also the tenant table.
+`Organisation`'s own docblock says every row "is still a full organisation and
+still a valid tenant", and ADR-002 Rule 1 makes the organisation UUID the only
+tenant key. `type` cannot carry the distinction: it is deliberately NOT an
+authorization input.
+
+## 🔴 The gap is destructive, not cosmetic
+
+Three background jobs enumerate organisations, and each selects on `status`
+alone:
+
+| Job | Selects | Does |
+|---|---|---|
+| `TenantUsageSyncJob` | `status = active` | meters usage |
+| `TenantDeprovisionJob` | `status = deprovisioning` | tears the tenant down |
+| `TenantPurgeJob` | `status = archived` | **permanently deletes the row** |
+
+So the moment ketenpartners live in this table, an archived partner is
+indistinguishable from an archived tenant and is deleted with it. Nothing
+throws; the job reports a successful purge.
+
+That is why this change leads with tests. `TenantJobsScopeTest` was written
+against the OLD behaviour first and two of its assertions failed when the
+distinction landed, which is the only evidence that it pins anything.
+
+## Scope
+
+### In Scope
+
+1. **`isLocalTenant`** on `Organisation`, defaulting to TRUE so every existing
+   row keeps exactly the meaning it has today. Unlike `type`, this one IS
+   consulted by tenancy.
+2. **`remoteInstanceUrl`** — the peer OpenRegister base URL a counterparty is a
+   tenant of. It is the same value `FederatedShare.remoteInstanceUrl` carries,
+   which is what lets a share and the organisation it is with resolve to each
+   other.
+3. **`OrganisationMapper::findLocalTenants()`** — a named method whose contract
+   is the guarantee, used by all three jobs.
+
+### Out of Scope
+
+- **Moving dossiq's `partnerOrganization`.** That is dossiq's change, and it can
+  only start once this exists.
+- **Narrowing `findAll()`.** The admin organisation list must keep showing
+  counterparties — they are the ketenpartners the federation exists to work
+  with.
+
+## The NULL that would have broken every tenant
+
+`is_local_tenant` arrives by migration, so every row written before it holds
+NULL. A plain `is_local_tenant = true` filter would therefore make **every
+pre-existing tenant invisible to all three jobs at once** — tenants would
+silently stop being deprovisioned, purged and metered, and each job would report
+success over an empty list.
+
+`findLocalTenants()` treats NULL as a tenant. Only a row explicitly marked false
+is excluded, and `OrganisationTenantScopeIntegrationTest` asserts exactly that
+against a real database, because a mocked mapper cannot show it.
+
+## Risks
+
+- 🔴 **A named method can be forgotten.** The next job someone writes could call
+  `findAll()`. Mitigated by the name being the contract and greppable, and by
+  the job tests asserting the tenant-scoped path is the one used. A stronger
+  guard — making `findAll()` itself default to local tenants — was rejected
+  because it would silently hide counterparties from the admin surface.
+- ⚠️ **`isLocalTenant` is an authorization-adjacent input and `type` is not.**
+  Two discriminators on one entity invites confusion; each one's docblock says
+  which question it answers and which it does not.

--- a/openspec/changes/organisation-as-federated-counterparty/specs/organisation-tenancy-scope/spec.md
+++ b/openspec/changes/organisation-as-federated-counterparty/specs/organisation-tenancy-scope/spec.md
@@ -1,0 +1,67 @@
+# organisation-tenancy-scope Specification
+
+## Purpose
+
+Distinguish an organisation that is a tenant of THIS installation from one that
+is a counterparty — a tenant elsewhere, reachable across the federation — and
+make every tenant enumeration honour the distinction.
+
+## ADDED Requirements
+
+### Requirement: REQ-OTS-001 An organisation states whether it is a local tenant
+
+`Organisation` SHALL carry `isLocalTenant`, defaulting to true, and
+`remoteInstanceUrl` naming the peer instance a counterparty belongs to.
+
+`isLocalTenant` IS an authorization and lifecycle input, unlike `type`, which
+ADR-002 keeps out of that role deliberately.
+
+#### Scenario: Existing rows keep their meaning
+
+- **GIVEN** an organisation stored before the column existed
+- **WHEN** it is read
+- **THEN** it is treated as a tenant of this installation
+
+#### Scenario: A counterparty carries its peer instance
+
+- **GIVEN** an organisation marked `isLocalTenant: false` with a
+  `remoteInstanceUrl`
+- **WHEN** it is read back
+- **THEN** both values round-trip
+
+### Requirement: REQ-OTS-002 Tenant enumeration excludes counterparties
+
+`OrganisationMapper` SHALL expose `findLocalTenants()`, which returns only
+organisations that are tenants of this installation, and the tenant background
+jobs SHALL read through it.
+
+A NULL `isLocalTenant` SHALL count as a tenant. The column arrives by migration,
+so a plain equality filter would make every pre-existing tenant invisible to
+every tenant job at once — and each would report success over an empty list.
+
+#### Scenario: A counterparty is not a tenant
+
+- **GIVEN** a tenant, a pre-migration row, and a counterparty, all active
+- **WHEN** `findLocalTenants()` is asked for active organisations
+- **THEN** the tenant and the pre-migration row are returned and the counterparty is not
+
+#### Scenario: The purge job cannot see a counterparty
+
+- **GIVEN** the purge job
+- **WHEN** it selects archived organisations
+- **THEN** it reads through the tenant-scoped path, so a counterparty is never
+  among the rows it permanently deletes
+
+### Requirement: REQ-OTS-003 The general listing still shows counterparties
+
+`findAll()` SHALL keep returning every organisation regardless of tenancy.
+
+The narrowing is confined to the tenant path on purpose: an organisation list
+that hid counterparties would hide the ketenpartners the federation exists to
+work with.
+
+#### Scenario: A counterparty appears in the general listing
+
+- **GIVEN** a counterparty organisation
+- **WHEN** `findAll()` is called
+- **THEN** it is returned

--- a/tests/Db/OrganisationTenantScopeIntegrationTest.php
+++ b/tests/Db/OrganisationTenantScopeIntegrationTest.php
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Db;
+
+use OCA\OpenRegister\Db\Organisation;
+use OCA\OpenRegister\Db\OrganisationMapper;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * What `findLocalTenants()` actually returns, against a real database.
+ *
+ * The job-level tests mock the mapper, so they prove the jobs ASK the right
+ * question. This proves the query ANSWERS it — and in particular the one thing
+ * a mock cannot show:
+ *
+ * 🔴 A NULL `is_local_tenant` must count as a tenant. The column arrives by
+ * migration, so every row written before it holds NULL. A plain `= true` would
+ * make every pre-existing tenant invisible to all three tenant jobs at once —
+ * tenants would silently stop being deprovisioned, purged and metered, and the
+ * jobs would report success over an empty list.
+ *
+ * @group DB
+ */
+class OrganisationTenantScopeIntegrationTest extends TestCase {
+
+	/**
+	 * The mapper under test.
+	 *
+	 * @var OrganisationMapper
+	 */
+	private OrganisationMapper $mapper;
+
+	/**
+	 * Uuids created by this test, dropped in tearDown.
+	 *
+	 * @var array<int, string>
+	 */
+	private array $created = [];
+
+	/**
+	 * Resolve the mapper from the server container.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->mapper = \OC::$server->get(OrganisationMapper::class);
+
+	}//end setUp()
+
+	/**
+	 * Remove everything this test created.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		foreach ($this->created as $uuid) {
+			try {
+				$this->mapper->delete($this->mapper->findByUuid($uuid));
+			} catch (\Throwable $e) {
+				// Already gone, or never created; nothing to clean.
+			}
+		}
+
+		parent::tearDown();
+
+	}//end tearDown()
+
+	/**
+	 * Store an organisation.
+	 *
+	 * @param string       $name    Its name.
+	 * @param boolean|null $isLocal The tenancy flag, or null to leave it unset.
+	 *
+	 * @return string The uuid.
+	 */
+	private function make(string $name, ?bool $isLocal): string {
+		$uuid = (string)Uuid::v4();
+
+		$org = new Organisation();
+		$org->setUuid($uuid);
+		$org->setName($name . '-' . substr($uuid, 0, 8));
+		$org->setSlug('scope-' . substr($uuid, 0, 8));
+		$org->setStatus('active');
+		if ($isLocal !== null) {
+			$org->setIsLocalTenant($isLocal);
+		}
+
+		$this->mapper->insert($org);
+		$this->created[] = $uuid;
+
+		return $uuid;
+
+	}//end make()
+
+	/**
+	 * The uuids findLocalTenants returns, across pages.
+	 *
+	 * @return array<int, string> The uuids.
+	 */
+	private function tenantUuids(): array {
+		$out = [];
+		foreach ($this->mapper->findLocalTenants(limit: 500, filters: ['status' => 'active']) as $org) {
+			$out[] = (string)$org->getUuid();
+		}
+
+		return $out;
+
+	}//end tenantUuids()
+
+	/**
+	 * A counterparty is excluded; a tenant and a pre-migration row are not.
+	 *
+	 * @return void
+	 */
+	public function testACounterpartyIsExcludedAndANullIsNot(): void {
+		$tenant = $this->make('tenant', true);
+		$legacy = $this->make('legacy', null);
+		$partner = $this->make('partner', false);
+
+		$found = $this->tenantUuids();
+
+		$this->assertContains($tenant, $found, 'an explicit tenant is a tenant');
+		$this->assertContains(
+			$legacy,
+			$found,
+			'a row predating the column must still count as a tenant, or every existing tenant silently stops being processed'
+		);
+		$this->assertNotContains($partner, $found, 'a counterparty is not a tenant of this installation');
+
+	}//end testACounterpartyIsExcludedAndANullIsNot()
+
+	/**
+	 * findAll still returns everything, so the admin surface is unchanged.
+	 *
+	 * The narrowing is deliberately confined to the tenant path: an
+	 * organisation list that hid counterparties would hide the ketenpartners
+	 * the federation exists to work with.
+	 *
+	 * @return void
+	 */
+	public function testFindAllStillReturnsCounterparties(): void {
+		$partner = $this->make('partner', false);
+
+		$found = [];
+		foreach ($this->mapper->findAll(limit: 500, filters: ['status' => 'active']) as $org) {
+			$found[] = (string)$org->getUuid();
+		}
+
+		$this->assertContains($partner, $found);
+
+	}//end testFindAllStillReturnsCounterparties()
+
+	/**
+	 * A counterparty carries the peer instance it is a tenant of.
+	 *
+	 * @return void
+	 */
+	public function testACounterpartyCarriesItsRemoteInstance(): void {
+		$uuid = (string)Uuid::v4();
+		$org = new Organisation();
+		$org->setUuid($uuid);
+		$org->setName('Gemeente Elders-' . substr($uuid, 0, 8));
+		$org->setSlug('elders-' . substr($uuid, 0, 8));
+		$org->setStatus('active');
+		$org->setIsLocalTenant(false);
+		$org->setRemoteInstanceUrl('https://fed2.example');
+		$this->mapper->insert($org);
+		$this->created[] = $uuid;
+
+		$stored = $this->mapper->findByUuid($uuid);
+
+		$this->assertFalse($stored->getIsLocalTenant());
+		$this->assertSame('https://fed2.example', $stored->getRemoteInstanceUrl());
+
+	}//end testACounterpartyCarriesItsRemoteInstance()
+
+}//end class

--- a/tests/Unit/BackgroundJob/TenantJobsScopeTest.php
+++ b/tests/Unit/BackgroundJob/TenantJobsScopeTest.php
@@ -1,0 +1,260 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\BackgroundJob;
+
+use DateTime;
+use OCA\OpenRegister\BackgroundJob\TenantDeprovisionJob;
+use OCA\OpenRegister\BackgroundJob\TenantPurgeJob;
+use OCA\OpenRegister\BackgroundJob\TenantUsageSyncJob;
+use OCA\OpenRegister\Db\Organisation;
+use OCA\OpenRegister\Db\OrganisationMapper;
+use OCA\OpenRegister\Db\TenantUsageMapper;
+use OCA\OpenRegister\Service\TenantLifecycleService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IAppConfig;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionMethod;
+
+/**
+ * What the three tenant background jobs consider a tenant.
+ *
+ * PINNING TESTS, written before the behaviour changes. They exist because a
+ * scoping mistake here does not throw: `TenantPurgeJob` PERMANENTLY DELETES the
+ * organisation entity, and it selects rows by `status` alone. Nothing in
+ * `Organisation` distinguishes a tenant of THIS installation from a
+ * counterparty that is a tenant of another one — so once ketenpartners live in
+ * the same table, an archived partner is indistinguishable from an archived
+ * tenant and gets deleted with it.
+ *
+ * They were written against the OLD behaviour first, and two of them FAILED
+ * when the distinction landed — which is the point of writing them first. They
+ * now assert the guarantee instead: the jobs read through
+ * `findLocalTenants()`, whose name is the contract, and a counterparty is never
+ * among the rows they act on.
+ */
+class TenantJobsScopeTest extends TestCase {
+
+	/**
+	 * Build an organisation.
+	 *
+	 * @param string      $uuid            Its uuid.
+	 * @param string      $status          Its lifecycle status.
+	 * @param string|null $deprovisionedAt When it was deprovisioned.
+	 *
+	 * @return Organisation The organisation.
+	 */
+	private function organisation(string $uuid, string $status, ?string $deprovisionedAt = null): Organisation {
+		$org = new Organisation();
+		$org->setUuid($uuid);
+		$org->setStatus($status);
+		$org->setName('Org ' . $uuid);
+		if ($deprovisionedAt !== null) {
+			$org->setDeprovisionedAt(new DateTime($deprovisionedAt));
+		}
+
+		return $org;
+
+	}//end organisation()
+
+	/**
+	 * Invoke a job's protected run().
+	 *
+	 * @param object $job The job.
+	 *
+	 * @return void
+	 */
+	private function runJob(object $job): void {
+		$run = new ReflectionMethod($job, 'run');
+		$run->setAccessible(true);
+		$run->invoke($job, null);
+
+	}//end runJob()
+
+	/**
+	 * The purge job reads through the tenant-scoped path.
+	 *
+	 * It still filters by status — that part is unchanged — but it can no longer
+	 * see a counterparty at all, because `findLocalTenants()` excludes one
+	 * before the status filter is applied. The mapper is mocked here, so what
+	 * this pins is that the job ASKS the right question; that the query answers
+	 * it correctly is pinned by OrganisationMapperTenantScopeTest.
+	 *
+	 * @return void
+	 */
+	public function testPurgeReadsThroughTheTenantScopedPath(): void {
+		$seenFilters = [];
+		$deleted = [];
+
+		$mapper = $this->createMock(OrganisationMapper::class);
+		$mapper->method('findLocalTenants')->willReturnCallback(
+			function (int $limit = 50, int $offset = 0, ?array $filters = []) use (&$seenFilters): array {
+				$seenFilters = ($filters ?? []);
+
+				return [$this->organisation('partner-1', 'archived', '2020-01-01')];
+			}
+		);
+		$mapper->method('delete')->willReturnCallback(
+			static function (Organisation $org) use (&$deleted): Organisation {
+				$deleted[] = $org->getUuid();
+
+				return $org;
+			}
+		);
+
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getValueString')->willReturn('30');
+
+		$job = new TenantPurgeJob(
+			$this->createMock(ITimeFactory::class),
+			$mapper,
+			$this->createMock(TenantUsageMapper::class),
+			$appConfig,
+			$this->createMock(LoggerInterface::class),
+		);
+
+		$this->runJob($job);
+
+		$this->assertSame(['status' => TenantLifecycleService::STATUS_ARCHIVED], $seenFilters);
+		$this->assertSame(['partner-1'], $deleted, 'a LOCAL TENANT that is archived is still purged');
+
+	}//end testPurgeReadsThroughTheTenantScopedPath()
+
+	/**
+	 * The purge job spares a row that has not been deprovisioned.
+	 *
+	 * @return void
+	 */
+	public function testPurgeSparesARowWithNoDeprovisionedAt(): void {
+		$deleted = [];
+		$mapper = $this->createMock(OrganisationMapper::class);
+		$mapper->method('findLocalTenants')->willReturn([$this->organisation('org-1', 'archived')]);
+		$mapper->method('delete')->willReturnCallback(
+			static function (Organisation $org) use (&$deleted): Organisation {
+				$deleted[] = $org->getUuid();
+
+				return $org;
+			}
+		);
+
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getValueString')->willReturn('30');
+
+		$this->runJob(
+			new TenantPurgeJob(
+				$this->createMock(ITimeFactory::class),
+				$mapper,
+				$this->createMock(TenantUsageMapper::class),
+				$appConfig,
+				$this->createMock(LoggerInterface::class),
+			)
+		);
+
+		$this->assertSame([], $deleted);
+
+	}//end testPurgeSparesARowWithNoDeprovisionedAt()
+
+	/**
+	 * The purge job spares a row still inside the retention window.
+	 *
+	 * @return void
+	 */
+	public function testPurgeSparesARowInsideRetention(): void {
+		$deleted = [];
+		$mapper = $this->createMock(OrganisationMapper::class);
+		$mapper->method('findLocalTenants')->willReturn(
+			[$this->organisation('org-1', 'archived', (new DateTime())->format('c'))]
+		);
+		$mapper->method('delete')->willReturnCallback(
+			static function (Organisation $org) use (&$deleted): Organisation {
+				$deleted[] = $org->getUuid();
+
+				return $org;
+			}
+		);
+
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getValueString')->willReturn('30');
+
+		$this->runJob(
+			new TenantPurgeJob(
+				$this->createMock(ITimeFactory::class),
+				$mapper,
+				$this->createMock(TenantUsageMapper::class),
+				$appConfig,
+				$this->createMock(LoggerInterface::class),
+			)
+		);
+
+		$this->assertSame([], $deleted);
+
+	}//end testPurgeSparesARowInsideRetention()
+
+	/**
+	 * The deprovision job reads through the tenant-scoped path too.
+	 *
+	 * @return void
+	 */
+	public function testDeprovisionReadsThroughTheTenantScopedPath(): void {
+		$seenFilters = [];
+		$mapper = $this->createMock(OrganisationMapper::class);
+		$mapper->method('findLocalTenants')->willReturnCallback(
+			function (int $limit = 50, int $offset = 0, ?array $filters = []) use (&$seenFilters): array {
+				$seenFilters = ($filters ?? []);
+
+				return [];
+			}
+		);
+
+		$this->runJob(
+			new TenantDeprovisionJob(
+				$this->createMock(ITimeFactory::class),
+				$mapper,
+				$this->createMock(TenantLifecycleService::class),
+				$this->createMock(LoggerInterface::class),
+			)
+		);
+
+		$this->assertSame(['status' => TenantLifecycleService::STATUS_DEPROVISIONING], $seenFilters);
+
+	}//end testDeprovisionReadsThroughTheTenantScopedPath()
+
+	/**
+	 * The usage-sync job does nothing at all without APCu.
+	 *
+	 * Pinned as the honest current behaviour rather than asserting a filter the
+	 * test environment cannot reach: the job returns before it queries anything
+	 * when `apcu_enabled()` is false, which it is here. Asserting the filter
+	 * would have been a test that passes because the code never ran.
+	 *
+	 * @return void
+	 */
+	public function testUsageSyncDoesNothingWithoutApcu(): void {
+		if (function_exists('apcu_enabled') === true && apcu_enabled() === true) {
+			$this->markTestSkipped('APCu is enabled here, so the early return under test cannot be observed.');
+		}
+
+		$mapper = $this->createMock(OrganisationMapper::class);
+		$mapper->expects($this->never())->method('findLocalTenants');
+
+		$this->runJob(
+			new TenantUsageSyncJob(
+				$this->createMock(ITimeFactory::class),
+				$mapper,
+				$this->createMock(TenantUsageMapper::class),
+				$this->createMock(LoggerInterface::class),
+			)
+		);
+
+		$this->addToAssertionCount(1);
+
+	}//end testUsageSyncDoesNothingWithoutApcu()
+
+}//end class


### PR DESCRIPTION
## Why

Consuming apps want their partner organisations here, and a ketenpartner obviously **is** an organisation: dossiq's `partnerOrganization` schema is name, slug, oin, contactEmail, groupId, isActive — every field of which `Organisation` already has, plus a `type` discriminator whose values include `collaboration` and `vendor`.

What stopped it is that this table is also the **tenant** table. `Organisation`'s own docblock says every row *"is still a full organisation and still a valid tenant"*, and `type` cannot carry the distinction because ADR-002 keeps it out of authorization deliberately.

## 🔴 The gap is destructive, not cosmetic

Three background jobs enumerate organisations, and each selects on `status` **alone**:

| Job | Selects | Does |
|---|---|---|
| `TenantUsageSyncJob` | `status = active` | meters usage |
| `TenantDeprovisionJob` | `status = deprovisioning` | tears the tenant down |
| `TenantPurgeJob` | `status = archived` | **permanently deletes the row** |

So the moment ketenpartners live here, an archived partner is indistinguishable from an archived tenant and is deleted with it — while the job reports a successful purge.

## This change leads with tests, not code

`TenantJobsScopeTest` was written against the **old** behaviour first, and two of its assertions **failed** when the distinction landed. That failure is the only evidence the tests pin anything; a test written afterwards would have passed either way.

## What

- **`isLocalTenant`** on `Organisation`, defaulting to `true` so every existing row keeps exactly today's meaning. Unlike `type`, this one **is** consulted by tenancy.
- **`remoteInstanceUrl`** — the peer instance a counterparty is a tenant of. Same value `FederatedShare.remoteInstanceUrl` carries, so a share and the organisation it is with resolve to each other.
- **`OrganisationMapper::findLocalTenants()`**, used by all three jobs. A *named method* rather than one more filter every caller must remember — because forgetting it is what deletes a partner. The name is the contract, and it is greppable.

## 🔴 A NULL counts as a tenant, and that detail is the whole migration

The column arrives by migration, so every pre-existing row holds `NULL`. A plain `is_local_tenant = true` filter would have made **every existing tenant invisible to all three jobs at once** — tenants would silently stop being deprovisioned, purged and metered, and each job would report success over an empty list.

Asserted against a **real database** in `OrganisationTenantScopeIntegrationTest`, because a mocked mapper cannot show it.

## What is deliberately not narrowed

`findAll()` still returns everything. An organisation list that hid counterparties would hide the ketenpartners the federation exists to work with. That is asserted too.

## Known limit

A named method can still be forgotten by the next job someone writes. The stronger guard — making `findAll()` itself default to local tenants — was rejected because it would silently hide counterparties from the admin surface. Mitigated by the name being the contract and by the job tests asserting the tenant-scoped path is the one used.

## Verification

- 17,787 unit tests pass
- PHPCS back to its 46-finding baseline on the touched files (none of them introduced here), PHPMD and PHPStan clean

## Downstream

Unblocks moving dossiq's `partnerOrganization`, which could not start until a counterparty could be told from a tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
