### PR TITLE
feat(dmn): give the fleet one decision-table evaluator

### DIFF
--- a/lib/Service/Dmn/DecisionEvaluationException.php
+++ b/lib/Service/Dmn/DecisionEvaluationException.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * OpenRegister DMN Decision Evaluation Exception
+ *
+ * Typed exception carrying a stable `errorCode` for every way a decision
+ * evaluation can fail. Callers (the REST controller, the workflow action
+ * handler) MUST branch on `errorCode`, never on the message text.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Dmn
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/shared-decision-table-evaluator/specs/shared-decision-tables/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Dmn;
+
+use RuntimeException;
+
+/**
+ * Typed evaluation failure with a stable machine-readable error code.
+ *
+ * @spec openspec/changes/shared-decision-table-evaluator/specs/shared-decision-tables/spec.md
+ */
+class DecisionEvaluationException extends RuntimeException {
+	/**
+	 * Constructor.
+	 *
+	 * @param string $errorCode Stable machine-readable error code.
+	 * @param array<string, mixed> $details Optional structured details (e.g. offending key/expression).
+	 */
+	public function __construct(
+		private readonly string $errorCode,
+		private readonly array $details = [],
+	) {
+		parent::__construct(message: $errorCode);
+	}//end __construct()
+
+	/**
+	 * The stable error code.
+	 *
+	 * @return string
+	 *
+	 * @spec openspec/changes/shared-decision-table-evaluator/specs/shared-decision-tables/spec.md
+	 */
+	public function getErrorCode(): string {
+		return $this->errorCode;
+	}//end getErrorCode()
+
+	/**
+	 * Structured details for logging/debugging (never shown raw to end users).
+	 *
+	 * @return array<string, mixed>
+	 *
+	 * @spec openspec/changes/shared-decision-table-evaluator/specs/shared-decision-tables/spec.md
+	 */
+	public function getDetails(): array {
+		return $this->details;
+	}//end getDetails()
+}//end class

--- a/lib/Service/Dmn/DecisionTableEvaluator.php
+++ b/lib/Service/Dmn/DecisionTableEvaluator.php
@@ -1,0 +1,397 @@
+<?php
+
+/**
+ * OpenRegister DMN Decision Engine
+ *
+ * Pure evaluation of a decision-table definition against an inputs map.
+ * No OpenRegister, HTTP, or database dependency — a deterministic function
+ * of (decisionTable, inputs) -> outputs. Never silently defaults: every
+ * ambiguous or invalid situation surfaces as a typed
+ * {@see DecisionEvaluationException}.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Dmn
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/shared-decision-table-evaluator/specs/shared-decision-tables/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Dmn;
+
+/**
+ * Evaluates a decisionTable definition against a runtime inputs map.
+ *
+ * @spec openspec/changes/shared-decision-table-evaluator/specs/shared-decision-tables/spec.md
+ */
+class DecisionTableEvaluator {
+
+	/**
+	 * Hit policies fully implemented by this engine.
+	 *
+	 * @var string[]
+	 */
+	/**
+	 * The hit policies this evaluator implements.
+	 *
+	 * PRIORITY is here because openbuild's evaluator had it and dossiq's did
+	 * not. ADR-065 names that explicitly: consolidating without it would be a
+	 * capability REGRESSION dressed up as a consolidation, since openbuild's
+	 * tables can already use it. This list is the union of the two, not the
+	 * intersection.
+	 *
+	 * @var array<int, string>
+	 */
+	private const IMPLEMENTED_HIT_POLICIES = ['UNIQUE', 'FIRST', 'COLLECT', 'PRIORITY', 'ANY'];
+
+	/**
+	 * Constructor.
+	 *
+	 * The evaluator is a pure, stateless collaborator; the default keeps the
+	 * engine directly constructible (`new DecisionEngine()`) while the
+	 * Nextcloud container autowires the concrete class when resolved via DI.
+	 *
+	 * @param UnaryTestEvaluator $evaluator The rule-cell expression evaluator.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly UnaryTestEvaluator $evaluator = new UnaryTestEvaluator(),
+	) {
+	}//end __construct()
+
+	/**
+	 * Evaluate a decision table.
+	 *
+	 * @param array<string, mixed> $decisionTable The decision table definition
+	 *                                            (`inputs`, `outputs`, `rules`, `hitPolicy`).
+	 * @param array<string, mixed> $inputs Caller-supplied input values, keyed by input name.
+	 *
+	 * @return array{outputs: array<string, mixed>, matchedRuleIds: array<int, string>, hitPolicy: string}
+	 *
+	 * @throws DecisionEvaluationException `unknown_input`, `missing_input`, `type_mismatch`,
+	 *                                     `invalid_expression`, `no_rule_matched`,
+	 *                                     `hit_policy_violation`, `hit_policy_not_implemented`.
+	 *
+	 * @spec openspec/changes/shared-decision-table-evaluator/specs/shared-decision-tables/spec.md
+	 */
+	public function evaluate(array $decisionTable, array $inputs): array {
+		$declaredInputs = self::normaliseFields(fields: ($decisionTable['inputs'] ?? []));
+		$declaredOutputs = self::normaliseFields(fields: ($decisionTable['outputs'] ?? []));
+		$hitPolicy = strtoupper((string)($decisionTable['hitPolicy'] ?? 'UNIQUE'));
+
+		$rules = [];
+		if (is_array($decisionTable['rules'] ?? null) === true) {
+			$rules = $decisionTable['rules'];
+		}
+
+		if (in_array($hitPolicy, self::IMPLEMENTED_HIT_POLICIES, true) === false) {
+			throw new DecisionEvaluationException(errorCode: 'hit_policy_not_implemented', details: ['hitPolicy' => $hitPolicy]);
+		}
+
+		$coercedInputs = $this->resolveInputs(declaredInputs: $declaredInputs, inputs: $inputs);
+
+		$matchedRules = [];
+		foreach ($rules as $index => $rule) {
+			if (is_array($rule) === false) {
+				continue;
+			}
+
+			if ($this->ruleMatches(rule: $rule, declaredInputs: $declaredInputs, coercedInputs: $coercedInputs, ruleIndex: $index) === true) {
+				$matchedRules[] = $rule;
+			}
+		}
+
+		return $this->applyHitPolicy(
+			hitPolicy: $hitPolicy,
+			matchedRules: $matchedRules,
+			declaredOutputs: $declaredOutputs,
+		);
+	}//end evaluate()
+
+	/**
+	 * Validate the caller's inputs against the declared inputs and coerce
+	 * each to its declared type.
+	 *
+	 * @param array<int, array{name: string, type: string}> $declaredInputs Declared inputs.
+	 * @param array<string, mixed> $inputs Caller-supplied values.
+	 *
+	 * @return array<string, mixed> Coerced values keyed by input name.
+	 *
+	 * @throws DecisionEvaluationException `unknown_input`, `missing_input`, `type_mismatch`.
+	 */
+	private function resolveInputs(array $declaredInputs, array $inputs): array {
+		$declaredNames = array_map(static fn (array $input): string => $input['name'], $declaredInputs);
+
+		foreach (array_keys($inputs) as $key) {
+			if (in_array($key, $declaredNames, true) === false) {
+				throw new DecisionEvaluationException(errorCode: 'unknown_input', details: ['key' => $key]);
+			}
+		}
+
+		$coerced = [];
+		foreach ($declaredInputs as $declared) {
+			$name = $declared['name'];
+			if (array_key_exists($name, $inputs) === false) {
+				throw new DecisionEvaluationException(errorCode: 'missing_input', details: ['name' => $name]);
+			}
+
+			$coerced[$name] = $this->evaluator->coerce(value: $inputs[$name], type: $declared['type']);
+		}
+
+		return $coerced;
+	}//end resolveInputs()
+
+	/**
+	 * Check whether every input entry on a rule matches the coerced inputs.
+	 *
+	 * @param array<string, mixed> $rule The rule row.
+	 * @param array<int, array{name: string, type: string}> $declaredInputs Declared inputs, positionally aligned.
+	 * @param array<string, mixed> $coercedInputs Coerced runtime values, keyed by name.
+	 * @param int|string $ruleIndex Rule position (for error context).
+	 *
+	 * @return bool
+	 *
+	 * @throws DecisionEvaluationException `invalid_expression`/`type_mismatch` (re-thrown with rule context).
+	 */
+	private function ruleMatches(array $rule, array $declaredInputs, array $coercedInputs, int|string $ruleIndex): bool {
+		$entries = [];
+		if (is_array($rule['inputEntries'] ?? null) === true) {
+			$entries = $rule['inputEntries'];
+		}
+
+		foreach ($declaredInputs as $position => $declared) {
+			$expression = (string)($entries[$position] ?? '-');
+			$value = $coercedInputs[$declared['name']];
+
+			try {
+				if ($this->evaluator->matches(expression: $expression, value: $value, type: $declared['type']) === false) {
+					return false;
+				}
+			} catch (DecisionEvaluationException $e) {
+				throw new DecisionEvaluationException(
+					errorCode: $e->getErrorCode(),
+					details: array_merge($e->getDetails(), ['ruleId' => ($rule['id'] ?? $ruleIndex), 'input' => $declared['name']]),
+				);
+			}
+		}
+
+		return true;
+	}//end ruleMatches()
+
+	/**
+	 * Refuse an ANY table whose matching rules disagree.
+	 *
+	 * @param array<int, array<string, mixed>> $matchedRules   The matching rules.
+	 * @param array<int, array{name: string, type: string}> $declaredOutputs The declared outputs.
+	 * @param array<int, string> $matchedIds The matching rule ids, for the error.
+	 *
+	 * @return void
+	 *
+	 * @throws DecisionEvaluationException `hit_policy_violation` when they differ.
+	 *
+	 * @spec openspec/changes/shared-decision-table-evaluator/specs/shared-decision-tables/spec.md
+	 */
+	private function assertAllOutputsAgree(array $matchedRules, array $declaredOutputs, array $matchedIds): void {
+		$first = null;
+		foreach ($matchedRules as $rule) {
+			$outputs = [];
+			foreach ($declaredOutputs as $position => $declared) {
+				$outputs[$declared['name']] = ($rule['outputEntries'][$position] ?? null);
+			}
+
+			if ($first === null) {
+				$first = $outputs;
+				continue;
+			}
+
+			if ($outputs !== $first) {
+				throw new DecisionEvaluationException(
+					errorCode: 'hit_policy_violation',
+					details: ['hitPolicy' => 'ANY', 'matchedRuleIds' => $matchedIds],
+				);
+			}
+		}
+
+	}//end assertAllOutputsAgree()
+
+	/**
+	 * Every matching rule's value, per declared output.
+	 *
+	 * COLLECT is the one policy whose result is a LIST rather than a value, so
+	 * it is built apart from the single-winner path instead of inside it.
+	 *
+	 * @param array<int, array<string, mixed>> $matchedRules The matching rules.
+	 * @param array<int, array{name: string, type: string}> $declaredOutputs The declared outputs.
+	 *
+	 * @return array<string, array<int, mixed>> The collected outputs.
+	 *
+	 * @spec openspec/changes/shared-decision-table-evaluator/specs/shared-decision-tables/spec.md
+	 */
+	private function collectOutputs(array $matchedRules, array $declaredOutputs): array {
+		$outputs = [];
+		foreach ($declaredOutputs as $position => $declared) {
+			$outputs[$declared['name']] = array_map(
+				static fn (array $rule): mixed => ($rule['outputEntries'][$position] ?? null),
+				$matchedRules,
+			);
+		}
+
+		return $outputs;
+
+	}//end collectOutputs()
+
+	/**
+	 * Which matching rule wins, for the single-winner policies.
+	 *
+	 * PRIORITY takes the highest `priority`; everything else takes the first in
+	 * declaration order. Ties are not an error under PRIORITY — DMN says the
+	 * output with the highest priority is taken, and two rules may legitimately
+	 * share one — so declaration order breaks them, which makes the outcome
+	 * deterministic rather than dependent on array iteration.
+	 *
+	 * @param string $hitPolicy The hit policy.
+	 * @param array<int, array<string, mixed>> $matchedRules The matching rules, in declaration order.
+	 *
+	 * @return array<string, mixed> The winning rule.
+	 *
+	 * @spec openspec/changes/shared-decision-table-evaluator/specs/shared-decision-tables/spec.md
+	 */
+	private function selectWinner(string $hitPolicy, array $matchedRules): array {
+		if ($hitPolicy === 'PRIORITY') {
+			return $this->highestPriority(matchedRules: $matchedRules);
+		}
+
+		return $matchedRules[0];
+
+	}//end selectWinner()
+
+	/**
+	 * The matched rule with the highest `priority`, ties broken by order.
+	 *
+	 * A rule that declares no priority is treated as 0, so a table that mixes
+	 * prioritised and unprioritised rules behaves predictably instead of
+	 * depending on whether the key happens to exist.
+	 *
+	 * @param array<int, array<string, mixed>> $matchedRules The matching rules, in declaration order.
+	 *
+	 * @return array<string, mixed> The winning rule.
+	 *
+	 * @spec openspec/changes/shared-decision-table-evaluator/specs/shared-decision-tables/spec.md
+	 */
+	private function highestPriority(array $matchedRules): array {
+		$winner = $matchedRules[0];
+		$best = (int) ($winner['priority'] ?? 0);
+
+		foreach ($matchedRules as $rule) {
+			$priority = (int) ($rule['priority'] ?? 0);
+			// STRICTLY greater, so an equal priority leaves the earlier rule in
+			// place and declaration order is the tie-break.
+			if ($priority > $best) {
+				$winner = $rule;
+				$best = $priority;
+			}
+		}
+
+		return $winner;
+
+	}//end highestPriority()
+
+	/**
+	 * Apply the hit policy to the set of matched rules and build the outputs.
+	 *
+	 * @param string $hitPolicy UNIQUE|FIRST|COLLECT.
+	 * @param array<int, array<string, mixed>> $matchedRules Rules that matched, in declaration order.
+	 * @param array<int, array{name: string, type: string}> $declaredOutputs Declared outputs, positionally aligned.
+	 *
+	 * @return array{outputs: array<string, mixed>, matchedRuleIds: array<int, string>, hitPolicy: string}
+	 *
+	 * @throws DecisionEvaluationException `no_rule_matched`, `hit_policy_violation`.
+	 */
+	private function applyHitPolicy(string $hitPolicy, array $matchedRules, array $declaredOutputs): array {
+		$matchedIds = [];
+		foreach ($matchedRules as $position => $rule) {
+			$matchedIds[] = (string)($rule['id'] ?? $position);
+		}
+
+		if ($hitPolicy === 'COLLECT') {
+			return [
+				'outputs' => $this->collectOutputs(matchedRules: $matchedRules, declaredOutputs: $declaredOutputs),
+				'matchedRuleIds' => $matchedIds,
+				'hitPolicy' => $hitPolicy,
+			];
+		}
+
+		if (count($matchedRules) === 0) {
+			throw new DecisionEvaluationException(errorCode: 'no_rule_matched');
+		}
+
+		if ($hitPolicy === 'UNIQUE' && count($matchedRules) > 1) {
+			throw new DecisionEvaluationException(errorCode: 'hit_policy_violation', details: ['matchedRuleIds' => $matchedIds]);
+		}
+
+		// ANY: every matching rule must agree. DMN says a table declaring ANY
+		// asserts that overlapping rules produce the SAME output, so a
+		// disagreement is a fault in the table, not a choice to make silently.
+		// openbuild's evaluator treated `any` as `collect` and returned a list;
+		// that is a different answer of a different shape, and consolidating it
+		// unexamined would have been the quiet regression this whole exercise
+		// exists to avoid.
+		if ($hitPolicy === 'ANY') {
+			$this->assertAllOutputsAgree(matchedRules: $matchedRules, declaredOutputs: $declaredOutputs, matchedIds: $matchedIds);
+		}
+
+		$winner = $this->selectWinner(hitPolicy: $hitPolicy, matchedRules: $matchedRules);
+
+		$outputs = [];
+		foreach ($declaredOutputs as $position => $declared) {
+			$outputs[$declared['name']] = ($winner['outputEntries'][$position] ?? null);
+		}
+
+		$winnerId = (string)($winner['id'] ?? 0);
+
+		return ['outputs' => $outputs, 'matchedRuleIds' => [$winnerId], 'hitPolicy' => $hitPolicy];
+	}//end applyHitPolicy()
+
+	/**
+	 * Normalise a decision table's `inputs`/`outputs` array into a clean
+	 * positional list of `{name, type}`.
+	 *
+	 * @param array<int, mixed> $fields Raw `inputs`/`outputs` array.
+	 *
+	 * @return array<int, array{name: string, type: string}>
+	 */
+	private static function normaliseFields(array $fields): array {
+		$result = [];
+		foreach ($fields as $field) {
+			if (is_array($field) === false) {
+				continue;
+			}
+
+			$name = (string)($field['name'] ?? '');
+			if ($name === '') {
+				continue;
+			}
+
+			$type = (string)($field['type'] ?? 'string');
+			if (in_array($type, UnaryTestEvaluator::VALID_TYPES, true) === false) {
+				$type = 'string';
+			}
+
+			$result[] = ['name' => $name, 'type' => $type];
+		}
+
+		return $result;
+	}//end normaliseFields()
+}//end class

--- a/lib/Service/Dmn/UnaryTestEvaluator.php
+++ b/lib/Service/Dmn/UnaryTestEvaluator.php
@@ -1,0 +1,408 @@
+<?php
+
+/**
+ * OpenRegister DMN Expression Evaluator
+ *
+ * A pure, closed, bounded evaluator for DMN-style "input entry" cell
+ * expressions — comparisons, ranges, set membership, and bare-literal
+ * equality. Every branch below is a fixed parse followed by a plain PHP
+ * comparison; there is NO `eval()`, NO reflection, and NO dynamic code
+ * execution of any kind, so rule authoring (which end users can do through
+ * the settings UI) can never become a code-injection vector.
+ *
+ * Grammar (see openspec/changes/archive/2026-07-14-dmn-decision-tables/design.md Decision 2):
+ *   ''  or  '-'          wildcard — always matches
+ *   '"literal"'          explicit quoted literal (escapes wildcard collision)
+ *   '< X' '<= X' '> X' '>= X' '= X' '!= X'   comparison, X coerced to type
+ *   '[A..B]' '(A..B)' '[A..B)' '(A..B]'      inclusive/exclusive range
+ *   'in (a,b,c)'         set membership (members may be quoted)
+ *   'literal'            bare-literal equality
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Dmn
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/shared-decision-table-evaluator/specs/shared-decision-tables/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Dmn;
+
+use DateTimeImmutable;
+use Throwable;
+
+/**
+ * DMN unary tests: does one rule cell match one input value.
+ *
+ * MOVED, not rewritten. This is dossiq's ExpressionEvaluator, ported verbatim
+ * apart from its namespace and name, because ADR-065 Decision 6 says decision
+ * tables consolidate HERE and the fleet had already built the grammar twice —
+ * openbuild on 2026-06-05 and dossiq on 2026-07-15, six weeks apart, neither
+ * knowing the other existed. Retyping it would have been a third.
+ *
+ * dossiq's is the stronger of the two dialects: it carries typed coercion
+ * (string / number / boolean / date), inclusive and exclusive ranges, set
+ * membership and the quoted-literal escape that lets a rule match a literal
+ * "-" rather than reading it as the wildcard. openbuild's contributes the
+ * `priority` hit policy, which the table evaluator beside this class takes.
+ *
+ * Renamed from ExpressionEvaluator because it does NOT evaluate expressions in
+ * the general sense: it decides whether a value satisfies one unary test, which
+ * is a closed, bounded grammar with no code execution in it. The old name
+ * invited someone to reach for it as a general evaluator.
+ *
+ * @spec openspec/changes/shared-decision-table-evaluator/specs/shared-decision-tables/spec.md
+ *
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) — a closed grammar parser is
+ * branchy by nature; every branch is a fixed, tested form. Carried over with the
+ * class: adding a second docblock above the original detached this tag from the
+ * class and the rule fired on a file nobody had changed a line of.
+ */
+class UnaryTestEvaluator {
+
+	/**
+	 * Declared input/output types this evaluator understands.
+	 *
+	 * @var string[]
+	 */
+	public const VALID_TYPES = ['string', 'number', 'boolean', 'date'];
+
+	/**
+	 * Check whether a rule cell expression matches an already-coerced value.
+	 *
+	 * @param string $expression The raw cell text (e.g. `'[0..25000]'`, `'-'`, `'in (a,b)'`).
+	 * @param mixed $value The runtime value, already coerced via {@see coerce()} for `$type`.
+	 * @param string $type One of {@see VALID_TYPES}.
+	 *
+	 * @return bool True when the expression matches the value.
+	 *
+	 * @throws DecisionEvaluationException `invalid_expression` on malformed grammar,
+	 *                                     `type_mismatch` when a literal in the expression
+	 *                                     cannot be coerced to `$type`.
+	 *
+	 * @spec openspec/changes/shared-decision-table-evaluator/specs/shared-decision-tables/spec.md
+	 *
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity) — one dispatch per grammar form; splitting hides the grammar
+	 * @SuppressWarnings(PHPMD.NPathComplexity)      — same: the branches are a flat form-dispatch, not nested logic
+	 */
+	public function matches(string $expression, mixed $value, string $type): bool {
+		$trimmed = trim($expression);
+
+		// Explicit quoted literal — bypasses the wildcard shortcut so a rule
+		// author can match the literal string "-" by writing `"-"`.
+		if (strlen($trimmed) >= 2 && $trimmed[0] === '"' && str_ends_with($trimmed, '"') === true) {
+			$literal = $this->unquote(raw: $trimmed);
+			return $this->equals(left: $value, right: $this->coerce(value: $literal, type: $type), type: $type);
+		}
+
+		if ($trimmed === '' || $trimmed === '-') {
+			return true;
+		}
+
+		if (preg_match('/^in\s*\((.*)\)$/is', $trimmed, $setMatch) === 1) {
+			$members = $this->parseSetMembers(inner: $setMatch[1]);
+			foreach ($members as $member) {
+				if ($this->equals(left: $value, right: $this->coerce(value: $member, type: $type), type: $type) === true) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		if (preg_match('/^([\[(])\s*(.*?)\s*\.\.\s*(.*?)\s*([\])])$/s', $trimmed, $rangeMatch) === 1) {
+			return $this->matchesRange(match: $rangeMatch, value: $value, type: $type);
+		}
+
+		// Two-character operators BEFORE single-character ones (`<=` before `<`).
+		foreach (['<=', '>=', '!='] as $operator) {
+			if (str_starts_with($trimmed, $operator) === true) {
+				return $this->matchesComparison(operator: $operator, remainder: substr($trimmed, 2), value: $value, type: $type);
+			}
+		}
+
+		foreach (['<', '>', '='] as $operator) {
+			if (str_starts_with($trimmed, $operator) === true) {
+				return $this->matchesComparison(operator: $operator, remainder: substr($trimmed, 1), value: $value, type: $type);
+			}
+		}
+
+		// Bare literal — plain equality.
+		return $this->equals(left: $value, right: $this->coerce(value: $trimmed, type: $type), type: $type);
+	}//end matches()
+
+	/**
+	 * Coerce a raw scalar (runtime input or rule-cell literal) to `$type`.
+	 *
+	 * @param mixed $value The raw value.
+	 * @param string $type One of {@see VALID_TYPES}.
+	 *
+	 * @return string|float|bool|int The coerced value (int for `date`, a Unix timestamp).
+	 *
+	 * @throws DecisionEvaluationException `type_mismatch` when coercion fails.
+	 *
+	 * @spec openspec/changes/shared-decision-table-evaluator/specs/shared-decision-tables/spec.md
+	 */
+	public function coerce(mixed $value, string $type): string|float|bool|int {
+		return match ($type) {
+			'string' => $this->coerceString(value: $value),
+			'number' => $this->coerceNumber(value: $value),
+			'boolean' => $this->coerceBoolean(value: $value),
+			'date' => $this->coerceDate(value: $value),
+			default => throw new DecisionEvaluationException(errorCode: 'type_mismatch', details: ['reason' => 'unsupported_type', 'type' => $type]),
+		};
+	}//end coerce()
+
+	/**
+	 * Coerce to string.
+	 *
+	 * @param mixed $value Raw value.
+	 *
+	 * @return string
+	 *
+	 * @throws DecisionEvaluationException `type_mismatch` for non-scalar input.
+	 */
+	private function coerceString(mixed $value): string {
+		if (is_scalar($value) === false) {
+			throw new DecisionEvaluationException(errorCode: 'type_mismatch', details: ['expected' => 'string']);
+		}
+
+		return (string)$value;
+	}//end coerceString()
+
+	/**
+	 * Coerce to a float.
+	 *
+	 * @param mixed $value Raw value.
+	 *
+	 * @return float
+	 *
+	 * @throws DecisionEvaluationException `type_mismatch` for non-numeric input.
+	 */
+	private function coerceNumber(mixed $value): float {
+		if (is_int($value) === true || is_float($value) === true) {
+			return (float)$value;
+		}
+
+		if (is_string($value) === true && is_numeric(trim($value)) === true) {
+			return (float)trim($value);
+		}
+
+		throw new DecisionEvaluationException(errorCode: 'type_mismatch', details: ['expected' => 'number', 'value' => $value]);
+	}//end coerceNumber()
+
+	/**
+	 * Coerce to a bool.
+	 *
+	 * @param mixed $value Raw value.
+	 *
+	 * @return bool
+	 *
+	 * @throws DecisionEvaluationException `type_mismatch` for unrecognised input.
+	 */
+	private function coerceBoolean(mixed $value): bool {
+		if (is_bool($value) === true) {
+			return $value;
+		}
+
+		if (is_int($value) === true && ($value === 0 || $value === 1)) {
+			return ($value === 1);
+		}
+
+		if (is_string($value) === true) {
+			$lower = strtolower(trim($value));
+			if ($lower === 'true') {
+				return true;
+			}
+
+			if ($lower === 'false') {
+				return false;
+			}
+		}
+
+		throw new DecisionEvaluationException(errorCode: 'type_mismatch', details: ['expected' => 'boolean', 'value' => $value]);
+	}//end coerceBoolean()
+
+	/**
+	 * Coerce to a Unix timestamp (int).
+	 *
+	 * @param mixed $value Raw value.
+	 *
+	 * @return int
+	 *
+	 * @throws DecisionEvaluationException `type_mismatch` for unparsable input.
+	 */
+	private function coerceDate(mixed $value): int {
+		if ($value instanceof \DateTimeInterface) {
+			return $value->getTimestamp();
+		}
+
+		if (is_string($value) === true && trim($value) !== '') {
+			try {
+				return (new DateTimeImmutable(trim($value)))->getTimestamp();
+			} catch (Throwable $e) {
+				throw new DecisionEvaluationException(errorCode: 'type_mismatch', details: ['expected' => 'date', 'value' => $value]);
+			}
+		}
+
+		throw new DecisionEvaluationException(errorCode: 'type_mismatch', details: ['expected' => 'date', 'value' => $value]);
+	}//end coerceDate()
+
+	/**
+	 * Evaluate a parsed range match against a coerced value.
+	 *
+	 * @param array<int, string> $match Regex capture groups: [0]=full, [1]=open bracket, [2]=low, [3]=high, [4]=close bracket.
+	 * @param mixed $value The already-coerced runtime value.
+	 * @param string $type Declared type.
+	 *
+	 * @return bool
+	 *
+	 * @throws DecisionEvaluationException `invalid_expression` on a missing bound, `type_mismatch` on an unparsable bound.
+	 */
+	private function matchesRange(array $match, mixed $value, string $type): bool {
+		[, $open, $lowRaw, $highRaw, $close] = $match;
+		if ($lowRaw === '' || $highRaw === '') {
+			throw new DecisionEvaluationException(errorCode: 'invalid_expression', details: ['reason' => 'missing_range_bound']);
+		}
+
+		$low = $this->coerce(value: $lowRaw, type: $type);
+		$high = $this->coerce(value: $highRaw, type: $type);
+
+		$lowOk = ($value > $low);
+		if ($open === '[') {
+			$lowOk = ($value >= $low);
+		}
+
+		$highOk = ($value < $high);
+		if ($close === ']') {
+			$highOk = ($value <= $high);
+		}
+
+		return ($lowOk === true && $highOk === true);
+	}//end matchesRange()
+
+	/**
+	 * Evaluate a comparison operator against a coerced value.
+	 *
+	 * @param string $operator One of `< > <= >= = !=`.
+	 * @param string $remainder The raw operand text (before the leading whitespace is trimmed).
+	 * @param mixed $value The already-coerced runtime value.
+	 * @param string $type Declared type.
+	 *
+	 * @return bool
+	 *
+	 * @throws DecisionEvaluationException `invalid_expression` when the operand is empty, `type_mismatch` when it cannot be coerced.
+	 */
+	private function matchesComparison(string $operator, string $remainder, mixed $value, string $type): bool {
+		$operand = trim($remainder);
+		if ($operand === '') {
+			throw new DecisionEvaluationException(errorCode: 'invalid_expression', details: ['reason' => 'missing_operand', 'operator' => $operator]);
+		}
+
+		if (strlen($operand) >= 2 && $operand[0] === '"' && str_ends_with($operand, '"') === true) {
+			$operand = $this->unquote(raw: $operand);
+		}
+
+		$coerced = $this->coerce(value: $operand, type: $type);
+
+		return match ($operator) {
+			'<' => ($value < $coerced),
+			'<=' => ($value <= $coerced),
+			'>' => ($value > $coerced),
+			'>=' => ($value >= $coerced),
+			'=' => $this->equals(left: $value, right: $coerced, type: $type),
+			'!=' => ($this->equals(left: $value, right: $coerced, type: $type) === false),
+			default => throw new DecisionEvaluationException(
+				errorCode: 'invalid_expression',
+				details: ['reason' => 'unknown_operator', 'operator' => $operator],
+			),
+		};
+	}//end matchesComparison()
+
+	/**
+	 * Type-aware equality.
+	 *
+	 * @param mixed $left Left operand (already coerced).
+	 * @param mixed $right Right operand (already coerced).
+	 * @param string $type Declared type.
+	 *
+	 * @return bool
+	 */
+	private function equals(mixed $left, mixed $right, string $type): bool {
+		if ($type === 'number' || $type === 'date') {
+			return (abs(((float)$left) - ((float)$right)) < 1.0e-9);
+		}
+
+		return ($left === $right);
+	}//end equals()
+
+	/**
+	 * Split the inner text of `in (...)` into raw member strings, respecting
+	 * double-quoted members that may themselves contain commas.
+	 *
+	 * @param string $inner The text between the parentheses.
+	 *
+	 * @return array<int, string> Raw (still-quoted) member strings.
+	 */
+	private function parseSetMembers(string $inner): array {
+		$members = [];
+		$buffer = '';
+		$inQuotes = false;
+		$length = strlen($inner);
+
+		for ($i = 0; $i < $length; $i++) {
+			$char = $inner[$i];
+			if ($char === '"') {
+				$inQuotes = !$inQuotes;
+				$buffer .= $char;
+				continue;
+			}
+
+			if ($char === ',' && $inQuotes === false) {
+				$members[] = trim($buffer);
+				$buffer = '';
+				continue;
+			}
+
+			$buffer .= $char;
+		}
+
+		if (trim($buffer) !== '') {
+			$members[] = trim($buffer);
+		}
+
+		return array_map(
+			function (string $member): string {
+				if (strlen($member) >= 2 && $member[0] === '"' && str_ends_with($member, '"') === true) {
+					return $this->unquote(raw: $member);
+				}
+
+				return $member;
+			},
+			$members,
+		);
+	}//end parseSetMembers()
+
+	/**
+	 * Strip one layer of surrounding double quotes and unescape `\"`.
+	 *
+	 * @param string $raw The quoted raw text, e.g. `'"a b"'`.
+	 *
+	 * @return string
+	 */
+	private function unquote(string $raw): string {
+		$inner = substr($raw, 1, -1);
+		return str_replace('\\"', '"', $inner);
+	}//end unquote()
+}//end class

--- a/openspec/changes/shared-decision-table-evaluator/proposal.md
+++ b/openspec/changes/shared-decision-table-evaluator/proposal.md
@@ -1,0 +1,85 @@
+---
+kind: code
+---
+
+# Proposal: shared-decision-table-evaluator
+
+## Summary
+
+Give the fleet one place to evaluate a DMN decision table. OpenRegister gets the
+evaluator; the two apps that each built their own become consumers.
+
+## Motivation
+
+ADR-065 Decision 6 states this outright, and states why it is not a matter of
+taste:
+
+> the fleet has already built it twice, independently, and neither
+> implementation knows the other exists
+
+| App | File | Lines | Hit policies | Built |
+|---|---|---|---|---|
+| openbuild | `DecisionTableEvaluator` | 422 | any, collect, first, **priority**, unique | 2026-06-05 |
+| dossiq | `Service/Dmn/*` | ~1,070 | collect, first, unique | 2026-07-15 |
+
+Six weeks apart, and **the newer one is the less capable**. dossiq's archived
+change references OpenRegister only as object storage; it never mentions
+openbuild's evaluator, which had been shipping for six weeks.
+
+The ADR calls that "the ADR's own thesis happening in real time", and it is the
+single strongest argument for OpenRegister owning the abstraction: without a
+shared home, the third implementation is a matter of time.
+
+Measured again today, before writing anything: OpenRegister still has no
+decision-table service, so nothing has changed since the ADR was written.
+
+## Scope
+
+### In Scope
+
+1. **`UnaryTestEvaluator`** — dossiq's grammar, MOVED rather than rewritten.
+2. **`DecisionTableEvaluator`** — the table engine, taking the UNION of the two
+   dialects' hit policies.
+3. **`DecisionEvaluationException`** — the typed error codes, moved with it.
+
+### Out of Scope
+
+- **Retiring either app's copy.** Each consumes this in its own change, with
+  parity tests against its own shipped tables. Deleting a working evaluator on
+  the strength of a new one that has not yet run its data would be the same
+  mistake in the other direction.
+- **A conformant FEEL implementation.** ADR-065 rules it out: unary tests cover
+  the overwhelming majority of real tables and full FEEL is not worth the cost.
+- **DMN XML interchange.** No package supplies it; the ADR records that as ours
+  to write later, and it does not block the engine.
+
+## What "reconcile the dialects" actually meant
+
+The ADR warned this "must reconcile two dialects rather than simply relocate
+one". Three places where that mattered:
+
+**The grammar is dossiq's, moved verbatim.** It is the stronger of the two —
+typed coercion (string / number / boolean / date), inclusive and exclusive
+ranges, set membership, and a quoted-literal escape so a rule can match a
+literal `"-"` rather than having it read as the wildcard. Retyping it would have
+been a third implementation.
+
+**`PRIORITY` is openbuild's, and its absence would have been a regression.**
+dossiq's engine did not implement it; openbuild's tables can already use it.
+Consolidating on dossiq's set alone would have silently broken them.
+
+**`ANY` meant different things, and neither was DMN's.** openbuild treated it as
+`collect` and returned a LIST — a different answer of a different shape. DMN says
+a table declaring ANY asserts that its overlapping rules produce the same output,
+so a disagreement is a fault in the table. It is implemented that way here, and
+the test that pins it fails if it degrades to `first`.
+
+## Risks
+
+- 🔴 **A consumer's shipped tables may rely on the old ANY.** openbuild's tables
+  declaring `any` got a list and now get a single value or an error. That is why
+  retiring the app-side copies is out of scope: each app adopts this with parity
+  tests over its own data, not on the strength of this PR.
+- ⚠️ **`UNIQUE` throws on no match.** Inherited from dossiq deliberately: a
+  decision table that matched nothing has not decided anything, and returning an
+  empty output invites the caller to treat it as a decision.

--- a/openspec/changes/shared-decision-table-evaluator/specs/shared-decision-tables/spec.md
+++ b/openspec/changes/shared-decision-table-evaluator/specs/shared-decision-tables/spec.md
@@ -1,0 +1,91 @@
+# shared-decision-tables Specification
+
+## Purpose
+
+One home for DMN decision-table evaluation, so the fleet stops building it per
+app. Per ADR-065 Decision 6.
+
+## ADDED Requirements
+
+### Requirement: REQ-SDT-001 One evaluator, the union of both dialects
+
+OpenRegister SHALL provide a decision-table evaluator implementing at least
+`UNIQUE`, `FIRST`, `COLLECT`, `PRIORITY` and `ANY`, and SHALL refuse any hit
+policy it does not implement rather than silently treating it as `FIRST`.
+
+`PRIORITY` is required: openbuild's evaluator has it and dossiq's does not, so
+omitting it would make the consolidation a capability regression.
+
+#### Scenario: An unimplemented policy is refused
+
+- **WHEN** a table declares a hit policy the evaluator does not implement
+- **THEN** it raises `hit_policy_not_implemented` and decides nothing
+
+#### Scenario: PRIORITY takes the highest
+
+- **GIVEN** matching rules with priorities 1, 10 and 5
+- **WHEN** the table is evaluated
+- **THEN** the rule with priority 10 wins
+
+#### Scenario: PRIORITY is deterministic on a tie
+
+- **GIVEN** two matching rules of equal priority
+- **THEN** the earlier one in declaration order wins
+
+#### Scenario: An absent priority counts as zero
+
+- **GIVEN** one rule declaring no priority and one declaring 3
+- **THEN** the one declaring 3 wins
+
+### Requirement: REQ-SDT-002 ANY asserts agreement
+
+Under `ANY` the system SHALL require every matching rule to produce the same
+output, and SHALL raise `hit_policy_violation` when they differ.
+
+A table declaring ANY asserts that its overlapping rules agree; a disagreement
+is a fault in the table, not a choice for the engine. openbuild's evaluator
+treated `any` as `collect` and returned a list, which is a different answer of a
+different shape.
+
+#### Scenario: Disagreeing rules are refused
+
+- **GIVEN** two matching rules with different outputs under ANY
+- **THEN** evaluation raises `hit_policy_violation`
+
+#### Scenario: Agreeing rules return the shared output
+
+- **GIVEN** two matching rules with the same output under ANY
+- **THEN** that output is returned
+
+### Requirement: REQ-SDT-003 The unary-test grammar is preserved intact
+
+The evaluator SHALL support the grammar it inherits: wildcards, typed equality,
+comparison operators, inclusive and exclusive ranges, set membership, and a
+quoted literal that escapes the wildcard.
+
+It SHALL NOT execute arbitrary code for any expression.
+
+#### Scenario: Ranges keep their boundary semantics
+
+- **GIVEN** `[0..25000]` and `(25000..100000]`
+- **THEN** 25000 matches the first and 25001 the second
+
+#### Scenario: Set membership matches any listed value
+
+- **GIVEN** `in (gering, aanzienlijk)`
+- **THEN** `aanzienlijk` matches and `ernstig` does not
+
+### Requirement: REQ-SDT-004 A three-axis matrix is expressible as a table
+
+A dense lookup over three inputs SHALL evaluate to its single matching rule
+under `UNIQUE`.
+
+This is the shape dossiq's Landelijke Handhavingsstrategie matrix takes:
+(ernst x gedrag x actorType) to one intervention. It is a decision table, and it
+belongs on this engine rather than in a bespoke matrix service.
+
+#### Scenario: The LHS matrix shape evaluates
+
+- **GIVEN** a table over severity, behaviour and actorType
+- **WHEN** evaluated with a triple matching exactly one rule
+- **THEN** that rule's intervention is returned with its id

--- a/openspec/changes/shared-decision-table-evaluator/tasks.md
+++ b/openspec/changes/shared-decision-table-evaluator/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: shared-decision-table-evaluator
+
+## Implementation Tasks
+
+### Task 1: Move the grammar
+- **spec_ref**: `openspec/changes/shared-decision-table-evaluator/specs/shared-decision-tables/spec.md#requirement-req-sdt-003-the-unary-test-grammar-is-preserved-intact`
+- **files**: `lib/Service/Dmn/UnaryTestEvaluator.php`, `lib/Service/Dmn/DecisionEvaluationException.php`
+- **acceptance_criteria**:
+  - GIVEN the ported grammar THEN ranges, sets, comparisons and the quoted-literal escape behave as they did in dossiq
+  - GIVEN the move THEN it is a MOVE: the file is dossiq's, renamed and re-namespaced, not retyped
+- [x] Implement
+- [x] Test
+
+### Task 2: The consolidated table evaluator
+- **spec_ref**: `.../spec.md#requirement-req-sdt-001-one-evaluator-the-union-of-both-dialects` (+ REQ-SDT-002)
+- **files**: `lib/Service/Dmn/DecisionTableEvaluator.php`
+- **acceptance_criteria**:
+  - GIVEN the hit policies THEN the list is the UNION of both apps', including openbuild's PRIORITY
+  - GIVEN PRIORITY THEN the highest wins, ties break by declaration order, and an absent priority is zero
+  - GIVEN ANY THEN disagreeing rules are refused and agreeing ones return the shared output
+  - GIVEN an unimplemented policy THEN it is refused, never treated as FIRST
+- [x] Implement
+- [x] Test — mutation-checked: dropping PRIORITY, degrading ANY to FIRST, and making the tie non-deterministic each turn the suite red
+
+### Task 3: The consumers adopt it
+- **spec_ref**: deferred
+- **acceptance_criteria**:
+  - Deliberately out of scope. openbuild and dossiq each adopt this in their own change, with parity tests over their own shipped tables — openbuild's `any` tables in particular change shape. Deleting a working evaluator on the strength of a new one that has not yet run its data would be the same mistake in the other direction.
+- [ ] Implement
+- [ ] Test

--- a/tests/Unit/Service/Dmn/DecisionTableEvaluatorTest.php
+++ b/tests/Unit/Service/Dmn/DecisionTableEvaluatorTest.php
@@ -1,0 +1,330 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Dmn;
+
+use OCA\OpenRegister\Service\Dmn\DecisionEvaluationException;
+use OCA\OpenRegister\Service\Dmn\DecisionTableEvaluator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The consolidated decision-table evaluator.
+ *
+ * The fleet built decision tables TWICE — openbuild 2026-06-05, dossiq
+ * 2026-07-15, six weeks apart, neither knowing the other existed — and the
+ * newer one shipped FEWER hit policies. ADR-065 Decision 6 consolidates them
+ * here, and says the consolidation must take openbuild's `priority` because
+ * dropping it would be a capability regression.
+ *
+ * So these tests are mostly about the seams between the two dialects: the
+ * policies that came from one side, and the ones whose meaning differed.
+ */
+class DecisionTableEvaluatorTest extends TestCase {
+
+	/**
+	 * The evaluator under test.
+	 *
+	 * @return DecisionTableEvaluator The evaluator.
+	 */
+	private function evaluator(): DecisionTableEvaluator {
+		return new DecisionTableEvaluator();
+
+	}//end evaluator()
+
+	/**
+	 * A table over one string input and one string output.
+	 *
+	 * @param string                      $hitPolicy The hit policy.
+	 * @param array<int, array<string, mixed>> $rules The rules.
+	 *
+	 * @return array<string, mixed> The table.
+	 */
+	private function table(string $hitPolicy, array $rules): array {
+		return [
+			'hitPolicy' => $hitPolicy,
+			'inputs' => [['name' => 'severity', 'type' => 'string']],
+			'outputs' => [['name' => 'intervention', 'type' => 'string']],
+			'rules' => $rules,
+		];
+
+	}//end table()
+
+	/**
+	 * A single rule.
+	 *
+	 * @param string       $id       Its id.
+	 * @param string       $match    The unary test.
+	 * @param string       $output   The output value.
+	 * @param integer|null $priority Its priority, or null to omit the key.
+	 *
+	 * @return array<string, mixed> The rule.
+	 */
+	private function rule(string $id, string $match, string $output, ?int $priority = null): array {
+		$rule = ['id' => $id, 'inputEntries' => [$match], 'outputEntries' => [$output]];
+		if ($priority !== null) {
+			$rule['priority'] = $priority;
+		}
+
+		return $rule;
+
+	}//end rule()
+
+	/**
+	 * FIRST takes the earliest matching rule.
+	 *
+	 * @return void
+	 */
+	public function testFirstTakesTheEarliestMatch(): void {
+		$table = $this->table('FIRST', [
+			$this->rule('a', 'ernstig', 'bestuursdwang'),
+			$this->rule('b', '-', 'waarschuwing'),
+		]);
+
+		$out = $this->evaluator()->evaluate($table, ['severity' => 'ernstig']);
+
+		$this->assertSame('bestuursdwang', $out['outputs']['intervention']);
+		$this->assertSame(['a'], $out['matchedRuleIds']);
+
+	}//end testFirstTakesTheEarliestMatch()
+
+	/**
+	 * UNIQUE refuses an overlap rather than picking one.
+	 *
+	 * @return void
+	 */
+	public function testUniqueRefusesAnOverlap(): void {
+		$table = $this->table('UNIQUE', [
+			$this->rule('a', 'ernstig', 'bestuursdwang'),
+			$this->rule('b', '-', 'waarschuwing'),
+		]);
+
+		$this->expectException(DecisionEvaluationException::class);
+
+		$this->evaluator()->evaluate($table, ['severity' => 'ernstig']);
+
+	}//end testUniqueRefusesAnOverlap()
+
+	/**
+	 * COLLECT returns every matching rule's output.
+	 *
+	 * @return void
+	 */
+	public function testCollectReturnsEveryMatch(): void {
+		$table = $this->table('COLLECT', [
+			$this->rule('a', 'ernstig', 'bestuursdwang'),
+			$this->rule('b', '-', 'waarschuwing'),
+		]);
+
+		$out = $this->evaluator()->evaluate($table, ['severity' => 'ernstig']);
+
+		$this->assertSame(['bestuursdwang', 'waarschuwing'], $out['outputs']['intervention']);
+
+	}//end testCollectReturnsEveryMatch()
+
+	/**
+	 * 🔴 PRIORITY is openbuild's capability, and the reason this is a
+	 * consolidation rather than a relocation. dossiq's engine did not have it.
+	 *
+	 * @return void
+	 */
+	public function testPriorityTakesTheHighest(): void {
+		$table = $this->table('PRIORITY', [
+			$this->rule('low', '-', 'waarschuwing', 1),
+			$this->rule('high', 'ernstig', 'bestuursdwang', 10),
+			$this->rule('mid', '-', 'herstelactie', 5),
+		]);
+
+		$out = $this->evaluator()->evaluate($table, ['severity' => 'ernstig']);
+
+		$this->assertSame('bestuursdwang', $out['outputs']['intervention']);
+		$this->assertSame(['high'], $out['matchedRuleIds']);
+
+	}//end testPriorityTakesTheHighest()
+
+	/**
+	 * PRIORITY breaks a tie by declaration order, deterministically.
+	 *
+	 * @return void
+	 */
+	public function testPriorityBreaksTiesByDeclarationOrder(): void {
+		$table = $this->table('PRIORITY', [
+			$this->rule('first', '-', 'waarschuwing', 5),
+			$this->rule('second', '-', 'herstelactie', 5),
+		]);
+
+		$out = $this->evaluator()->evaluate($table, ['severity' => 'gering']);
+
+		$this->assertSame('waarschuwing', $out['outputs']['intervention']);
+
+	}//end testPriorityBreaksTiesByDeclarationOrder()
+
+	/**
+	 * A rule with no priority counts as zero rather than as undefined.
+	 *
+	 * @return void
+	 */
+	public function testAnAbsentPriorityCountsAsZero(): void {
+		$table = $this->table('PRIORITY', [
+			$this->rule('unset', '-', 'waarschuwing'),
+			$this->rule('set', '-', 'bestuursdwang', 3),
+		]);
+
+		$out = $this->evaluator()->evaluate($table, ['severity' => 'gering']);
+
+		$this->assertSame('bestuursdwang', $out['outputs']['intervention']);
+
+	}//end testAnAbsentPriorityCountsAsZero()
+
+	/**
+	 * 🔴 ANY requires the matching rules to AGREE.
+	 *
+	 * openbuild's evaluator treated `any` as `collect` and returned a list —
+	 * a different answer of a different shape. DMN says a table declaring ANY
+	 * asserts its overlapping rules produce the same output, so a disagreement
+	 * is a fault in the table rather than a choice to make silently.
+	 *
+	 * @return void
+	 */
+	public function testAnyRefusesDisagreeingRules(): void {
+		$table = $this->table('ANY', [
+			$this->rule('a', '-', 'waarschuwing'),
+			$this->rule('b', '-', 'bestuursdwang'),
+		]);
+
+		$this->expectException(DecisionEvaluationException::class);
+
+		$this->evaluator()->evaluate($table, ['severity' => 'gering']);
+
+	}//end testAnyRefusesDisagreeingRules()
+
+	/**
+	 * ANY accepts agreeing rules and returns the shared output.
+	 *
+	 * @return void
+	 */
+	public function testAnyAcceptsAgreeingRules(): void {
+		$table = $this->table('ANY', [
+			$this->rule('a', '-', 'waarschuwing'),
+			$this->rule('b', 'gering', 'waarschuwing'),
+		]);
+
+		$out = $this->evaluator()->evaluate($table, ['severity' => 'gering']);
+
+		$this->assertSame('waarschuwing', $out['outputs']['intervention']);
+
+	}//end testAnyAcceptsAgreeingRules()
+
+	/**
+	 * An unimplemented hit policy is refused rather than treated as FIRST.
+	 *
+	 * @return void
+	 */
+	public function testAnUnknownHitPolicyIsRefused(): void {
+		$table = $this->table('OUTPUT-ORDER', [$this->rule('a', '-', 'waarschuwing')]);
+
+		$this->expectException(DecisionEvaluationException::class);
+
+		$this->evaluator()->evaluate($table, ['severity' => 'gering']);
+
+	}//end testAnUnknownHitPolicyIsRefused()
+
+	/**
+	 * The LHS matrix shape: three axes, one intervention, UNIQUE.
+	 *
+	 * This is the table dossiq's Landelijke Handhavingsstrategie becomes — a
+	 * dense (ernst x gedrag x actorType) lookup — expressed in the shared
+	 * vocabulary rather than in a bespoke matrix service.
+	 *
+	 * @return void
+	 */
+	public function testTheLhsMatrixShapeEvaluates(): void {
+		$table = [
+			'hitPolicy' => 'UNIQUE',
+			'inputs' => [
+				['name' => 'severity', 'type' => 'string'],
+				['name' => 'behaviour', 'type' => 'string'],
+				['name' => 'actorType', 'type' => 'string'],
+			],
+			'outputs' => [['name' => 'intervention', 'type' => 'string']],
+			'rules' => [
+				[
+					'id' => 'gering-goedwillend-burger',
+					'inputEntries' => ['gering', 'goedwillend', 'burger'],
+					'outputEntries' => ['waarschuwing'],
+				],
+				[
+					'id' => 'ernstig-crimineel-bedrijf',
+					'inputEntries' => ['ernstig', 'crimineel', 'bedrijf'],
+					'outputEntries' => ['bestuursdwang'],
+				],
+			],
+		];
+
+		$out = $this->evaluator()->evaluate(
+			$table,
+			['severity' => 'ernstig', 'behaviour' => 'crimineel', 'actorType' => 'bedrijf']
+		);
+
+		$this->assertSame('bestuursdwang', $out['outputs']['intervention']);
+		$this->assertSame(['ernstig-crimineel-bedrijf'], $out['matchedRuleIds']);
+
+	}//end testTheLhsMatrixShapeEvaluates()
+
+	/**
+	 * A numeric range still works, so the ported grammar came across intact.
+	 *
+	 * @return void
+	 */
+	public function testTheRangeGrammarSurvivedThePort(): void {
+		$table = [
+			'hitPolicy' => 'FIRST',
+			'inputs' => [['name' => 'amount', 'type' => 'number']],
+			'outputs' => [['name' => 'band', 'type' => 'string']],
+			'rules' => [
+				['id' => 'low', 'inputEntries' => ['[0..25000]'], 'outputEntries' => ['low']],
+				['id' => 'high', 'inputEntries' => ['(25000..100000]'], 'outputEntries' => ['high']],
+			],
+		];
+
+		$this->assertSame('low', $this->evaluator()->evaluate($table, ['amount' => 25000])['outputs']['band']);
+		$this->assertSame('high', $this->evaluator()->evaluate($table, ['amount' => 25001])['outputs']['band']);
+
+	}//end testTheRangeGrammarSurvivedThePort()
+
+	/**
+	 * Set membership survived the port too.
+	 *
+	 * @return void
+	 */
+	public function testSetMembershipSurvivedThePort(): void {
+		$table = $this->table('FIRST', [
+			$this->rule('set', 'in (gering, aanzienlijk)', 'licht'),
+			$this->rule('rest', '-', 'zwaar'),
+		]);
+
+		$this->assertSame('licht', $this->evaluator()->evaluate($table, ['severity' => 'aanzienlijk'])['outputs']['intervention']);
+		$this->assertSame('zwaar', $this->evaluator()->evaluate($table, ['severity' => 'ernstig'])['outputs']['intervention']);
+
+	}//end testSetMembershipSurvivedThePort()
+
+	/**
+	 * No matching rule is an error, not an empty answer.
+	 *
+	 * @return void
+	 */
+	public function testNoMatchIsAnError(): void {
+		$table = $this->table('UNIQUE', [$this->rule('a', 'ernstig', 'bestuursdwang')]);
+
+		$this->expectException(DecisionEvaluationException::class);
+
+		$this->evaluator()->evaluate($table, ['severity' => 'gering']);
+
+	}//end testNoMatchIsAnError()
+
+}//end class


### PR DESCRIPTION
## Why

ADR-065 Decision 6 states this outright, and states why it is not a matter of taste:

> the fleet has already built it twice, independently, and neither implementation knows the other exists

| App | File | Lines | Hit policies | Built |
|---|---|---|---|---|
| openbuild | `DecisionTableEvaluator` | 422 | any, collect, first, **priority**, unique | 2026-06-05 |
| dossiq | `Service/Dmn/*` | ~1,070 | collect, first, unique | 2026-07-15 |

Six weeks apart, and **the newer one is the less capable**. dossiq's archived change references OpenRegister only as object storage; it never mentions openbuild's evaluator, which had been shipping for six weeks.

Measured again before writing anything: OpenRegister still had no decision-table service. Nothing had changed since the ADR was written.

## What "reconcile two dialects" actually meant

The ADR warned this *"must reconcile two dialects rather than simply relocate one"*. Three places where that was the real work:

**The grammar is MOVED, not rewritten.** `UnaryTestEvaluator` is dossiq's `ExpressionEvaluator`, ported verbatim apart from namespace and name. It is the stronger dialect — typed coercion, inclusive and exclusive ranges, set membership, and the quoted-literal escape that lets a rule match a literal `"-"` instead of reading it as the wildcard. Retyping it would have been a third implementation. Renamed because it does not evaluate expressions in the general sense; it decides whether a value satisfies one unary test, and the old name invited someone to reach for it as a general evaluator.

**`PRIORITY` is openbuild's**, and leaving it out would have made this a capability *regression* dressed as a consolidation — openbuild's tables can already use it. The hit-policy list is the union, not the intersection.

**`ANY` meant different things, and neither was DMN's.** openbuild treated it as `collect` and returned a **list** — a different answer of a different shape. DMN says a table declaring ANY asserts its overlapping rules produce the same output, so a disagreement is a fault in the table. Implemented that way, and the test fails if it degrades to `first`.

## Scope: the consumers do not adopt it here

Retiring either app's copy is deliberately out of scope. Each adopts this in its own change, with parity tests over its own shipped tables — **openbuild's `any` tables in particular change shape**. Deleting a working evaluator on the strength of a new one that has not yet run its data would be the same mistake in the other direction.

## Verification

- 17,800 unit tests pass
- PHPCS / PHPMD / PHPStan clean on all three files
- **Mutation-checked**, each turning the suite red: dropping `PRIORITY`, degrading `ANY` to `FIRST`, and making the priority tie non-deterministic

## One thing worth recording

Porting the grammar file initially made PHPMD fire `ExcessiveClassComplexity` on code **nobody had changed a line of**. The cause was that the new class docblock was inserted *above* the original, detaching its `@SuppressWarnings` from the class. The tag is now folded into the single docblock with a note saying why — a suppression that silently stops applying is worse than never having had one.

## Downstream

This is the missing home for dossiq's Landelijke Handhavingsstrategie matrix, which is a dense (ernst × gedrag × actorType) lookup — a decision table, not a bespoke matrix service. A test pins that shape evaluating here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
