### PR TITLE
fix(dmn): alias declared column types onto the evaluator's vocabulary

### DIFF
--- a/lib/Service/Dmn/DecisionTableEvaluator.php
+++ b/lib/Service/Dmn/DecisionTableEvaluator.php
@@ -56,6 +56,42 @@ class DecisionTableEvaluator {
 	private const IMPLEMENTED_HIT_POLICIES = ['UNIQUE', 'FIRST', 'COLLECT', 'PRIORITY', 'ANY'];
 
 	/**
+	 * Common spellings of the declared column types, mapped onto this
+	 * evaluator's own vocabulary.
+	 *
+	 * The fleet's tables were authored against two different vocabularies:
+	 * openbuild's shipped credit-approval table declares `integer` for
+	 * `applicantAge`, which is not one of {@see UnaryTestEvaluator::VALID_TYPES},
+	 * so it falls back to `string`.
+	 *
+	 * Measured, that fallback costs nothing for numbers or dates — the unary-test
+	 * grammar parses its operand and compares numerically, so `>=18` against 25
+	 * matches under either type, and ISO dates compare correctly as strings. The
+	 * numeric and date aliases below are therefore alignment, not a bug fix.
+	 *
+	 * The boolean alias IS a bug fix: a real PHP `true` coerced to a string
+	 * becomes `"1"`, which does not match a cell reading `true`, so a column
+	 * declaring `bool` rather than `boolean` silently stops matching. That is the
+	 * one case where the fallback changes the answer instead of the spelling.
+	 *
+	 * Aliasing is additive: a type this map does not know still falls back to
+	 * `string` exactly as before.
+	 *
+	 * @var array<string, string>
+	 */
+	private const TYPE_ALIASES = [
+		'int'       => 'number',
+		'integer'   => 'number',
+		'long'      => 'number',
+		'float'     => 'number',
+		'double'    => 'number',
+		'decimal'   => 'number',
+		'bool'      => 'boolean',
+		'datetime'  => 'date',
+		'timestamp' => 'date',
+	];
+
+	/**
 	 * Constructor.
 	 *
 	 * The evaluator is a pure, stateless collaborator; the default keeps the
@@ -384,7 +420,8 @@ class DecisionTableEvaluator {
 				continue;
 			}
 
-			$type = (string)($field['type'] ?? 'string');
+			$type = strtolower((string)($field['type'] ?? 'string'));
+			$type = (self::TYPE_ALIASES[$type] ?? $type);
 			if (in_array($type, UnaryTestEvaluator::VALID_TYPES, true) === false) {
 				$type = 'string';
 			}

--- a/openspec/changes/shared-decision-table-evaluator/specs/shared-decision-tables/spec.md
+++ b/openspec/changes/shared-decision-table-evaluator/specs/shared-decision-tables/spec.md
@@ -89,3 +89,35 @@ belongs on this engine rather than in a bespoke matrix service.
 - **GIVEN** a table over severity, behaviour and actorType
 - **WHEN** evaluated with a triple matching exactly one rule
 - **THEN** that rule's intervention is returned with its id
+
+### Requirement: REQ-SDT-005 A declared type is aliased onto the evaluator's own vocabulary
+
+Decision tables in the fleet were authored against two type vocabularies. openbuild's shipped
+credit-approval table declares `integer`; this evaluator's own vocabulary is
+`string | number | boolean | date`, and an unrecognised type falls back to `string`.
+
+Measured, that fallback is harmless for numbers and dates: the unary-test grammar parses its operand
+and compares numerically, so `>=18` against 25 matches whether the column was called `number` or
+`string`, and ISO dates compare correctly either way. It is NOT harmless for booleans. A real PHP
+`true` coerced to a string becomes `"1"`, which does not match a cell reading `true`, so a column
+declaring `bool` rather than `boolean` silently stops matching.
+
+The evaluator SHALL map the common spellings of its types onto them. The boolean alias closes the
+silent mismatch above; the numeric and date aliases align the vocabularies so a table means the same
+thing in either dialect, and are defensive rather than corrective.
+
+#### Scenario: A `bool` column matches a real boolean
+
+- **GIVEN** an input column declaring `bool` and the value `true`
+- **WHEN** it is evaluated against a cell reading `true`
+- **THEN** the rule matches, where before the value was stringified to `"1"` and did not
+
+#### Scenario: The alias set covers the spellings actually in use
+
+- **GIVEN** columns declaring `int`, `integer`, `long`, `float`, `double` or `decimal`
+- **THEN** each is evaluated as `number`
+
+#### Scenario: An unrecognised type still falls back to string
+
+- **GIVEN** a column declaring a type in neither vocabulary
+- **THEN** it is evaluated as `string`, as before this change

--- a/tests/Unit/Service/Dmn/DecisionTableEvaluatorTest.php
+++ b/tests/Unit/Service/Dmn/DecisionTableEvaluatorTest.php
@@ -327,4 +327,75 @@ class DecisionTableEvaluatorTest extends TestCase {
 
 	}//end testNoMatchIsAnError()
 
+	/**
+	 * A `bool` column matches a real boolean.
+	 *
+	 * This is the one alias that changes an answer rather than a spelling.
+	 * Without the map `bool` falls back to `string`, PHP `true` is coerced to
+	 * `"1"`, and a cell reading `true` silently stops matching.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/shared-decision-table-evaluator/specs/shared-decision-tables/spec.md
+	 */
+	public function testABoolColumnMatchesARealBoolean(): void {
+		$table = [
+			'hitPolicy' => 'FIRST',
+			'inputs' => [['name' => 'consented', 'type' => 'bool']],
+			'outputs' => [['name' => 'decision', 'type' => 'string']],
+			'rules' => [['id' => 'yes', 'inputEntries' => ['true'], 'outputEntries' => ['proceed']]],
+		];
+
+		$result = $this->evaluator()->evaluate($table, ['consented' => true]);
+
+		$this->assertSame('proceed', $result['outputs']['decision']);
+
+	}//end testABoolColumnMatchesARealBoolean()
+
+	/**
+	 * Every numeric spelling in fleet use maps onto `number`.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/shared-decision-table-evaluator/specs/shared-decision-tables/spec.md
+	 */
+	public function testEveryNumericAliasIsTreatedAsANumber(): void {
+		foreach (['int', 'integer', 'long', 'float', 'double', 'decimal', 'INTEGER'] as $declared) {
+			$table = [
+				'hitPolicy' => 'FIRST',
+				'inputs' => [['name' => 'score', 'type' => $declared]],
+				'outputs' => [['name' => 'band', 'type' => 'string']],
+				'rules' => [['id' => 'high', 'inputEntries' => ['>=600'], 'outputEntries' => ['ok']]],
+			];
+
+			$result = $this->evaluator()->evaluate($table, ['score' => 700]);
+
+			$this->assertSame('ok', $result['outputs']['band'], 'type ' . $declared . ' should compare numerically');
+		}
+
+	}//end testEveryNumericAliasIsTreatedAsANumber()
+
+	/**
+	 * A type in neither vocabulary still falls back to `string`.
+	 *
+	 * The alias map is additive; it must not turn an unknown type into an error.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/shared-decision-table-evaluator/specs/shared-decision-tables/spec.md
+	 */
+	public function testAnUnrecognisedTypeStillFallsBackToString(): void {
+		$table = [
+			'hitPolicy' => 'FIRST',
+			'inputs' => [['name' => 'severity', 'type' => 'wingdings']],
+			'outputs' => [['name' => 'intervention', 'type' => 'string']],
+			'rules' => [['id' => 'a', 'inputEntries' => ['gering'], 'outputEntries' => ['brief']]],
+		];
+
+		$result = $this->evaluator()->evaluate($table, ['severity' => 'gering']);
+
+		$this->assertSame('brief', $result['outputs']['intervention']);
+
+	}//end testAnUnrecognisedTypeStillFallsBackToString()
+
 }//end class

--- a/tests/Unit/Service/Dmn/UnaryTestEvaluatorTest.php
+++ b/tests/Unit/Service/Dmn/UnaryTestEvaluatorTest.php
@@ -1,0 +1,364 @@
+<?php
+
+/**
+ * UnaryTestEvaluator Unit Tests
+ *
+ * Grammar matrix: every operator, ranges (inclusive/exclusive/mixed), sets
+ * (quoted/unquoted), wildcard, booleans, type coercion for all four types,
+ * and malformed expressions.
+ *
+ * @category Tests
+ * @package  Unit\Service\Dmn
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/shared-decision-table-evaluator/specs/shared-decision-tables/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Dmn;
+
+use OCA\OpenRegister\Service\Dmn\DecisionEvaluationException;
+use OCA\OpenRegister\Service\Dmn\UnaryTestEvaluator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \OCA\OpenRegister\Service\Dmn\UnaryTestEvaluator
+ *
+ * @uses \OCA\OpenRegister\Service\Dmn\DecisionEvaluationException
+ */
+class UnaryTestEvaluatorTest extends TestCase {
+
+	/**
+	 * The evaluator under test.
+	 *
+	 * @var UnaryTestEvaluator
+	 */
+	private UnaryTestEvaluator $evaluator;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->evaluator = new UnaryTestEvaluator();
+	}//end setUp()
+
+	// ------------------------------------------------------------------
+	// Wildcard
+	// ------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testEmptyExpressionIsWildcard(): void {
+		self::assertTrue($this->evaluator->matches(expression: '', value: 'anything', type: 'string'));
+	}//end testEmptyExpressionIsWildcard()
+
+	/**
+	 * @return void
+	 */
+	public function testDashExpressionIsWildcard(): void {
+		self::assertTrue($this->evaluator->matches(expression: '-', value: 12345.0, type: 'number'));
+	}//end testDashExpressionIsWildcard()
+
+	/**
+	 * @return void
+	 */
+	public function testQuotedDashIsLiteralNotWildcard(): void {
+		self::assertTrue($this->evaluator->matches(expression: '"-"', value: '-', type: 'string'));
+		self::assertFalse($this->evaluator->matches(expression: '"-"', value: 'anything-else', type: 'string'));
+	}//end testQuotedDashIsLiteralNotWildcard()
+
+	// ------------------------------------------------------------------
+	// Comparison operators
+	// ------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testLessThan(): void {
+		self::assertTrue($this->evaluator->matches(expression: '< 10', value: 5.0, type: 'number'));
+		self::assertFalse($this->evaluator->matches(expression: '< 10', value: 10.0, type: 'number'));
+	}//end testLessThan()
+
+	/**
+	 * @return void
+	 */
+	public function testLessThanOrEqual(): void {
+		self::assertTrue($this->evaluator->matches(expression: '<= 10', value: 10.0, type: 'number'));
+		self::assertFalse($this->evaluator->matches(expression: '<= 10', value: 10.5, type: 'number'));
+	}//end testLessThanOrEqual()
+
+	/**
+	 * @return void
+	 */
+	public function testGreaterThan(): void {
+		self::assertTrue($this->evaluator->matches(expression: '> 10', value: 11.0, type: 'number'));
+		self::assertFalse($this->evaluator->matches(expression: '> 10', value: 10.0, type: 'number'));
+	}//end testGreaterThan()
+
+	/**
+	 * @return void
+	 */
+	public function testGreaterThanOrEqual(): void {
+		self::assertTrue($this->evaluator->matches(expression: '>= 10', value: 10.0, type: 'number'));
+		self::assertFalse($this->evaluator->matches(expression: '>= 10', value: 9.999, type: 'number'));
+	}//end testGreaterThanOrEqual()
+
+	/**
+	 * @return void
+	 */
+	public function testEquals(): void {
+		self::assertTrue($this->evaluator->matches(expression: '= gold', value: 'gold', type: 'string'));
+		self::assertFalse($this->evaluator->matches(expression: '= gold', value: 'silver', type: 'string'));
+	}//end testEquals()
+
+	/**
+	 * @return void
+	 */
+	public function testNotEquals(): void {
+		self::assertTrue($this->evaluator->matches(expression: '!= gold', value: 'silver', type: 'string'));
+		self::assertFalse($this->evaluator->matches(expression: '!= gold', value: 'gold', type: 'string'));
+	}//end testNotEquals()
+
+	/**
+	 * @return void
+	 */
+	public function testOperatorWithNoOperandIsInvalidExpression(): void {
+		$this->expectException(DecisionEvaluationException::class);
+		try {
+			$this->evaluator->matches(expression: '>=   ', value: 1.0, type: 'number');
+		} catch (DecisionEvaluationException $e) {
+			self::assertSame('invalid_expression', $e->getErrorCode());
+			throw $e;
+		}
+	}//end testOperatorWithNoOperandIsInvalidExpression()
+
+	// ------------------------------------------------------------------
+	// Ranges
+	// ------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testInclusiveRangeBoundsMatch(): void {
+		self::assertTrue($this->evaluator->matches(expression: '[0..25000]', value: 0.0, type: 'number'));
+		self::assertTrue($this->evaluator->matches(expression: '[0..25000]', value: 25000.0, type: 'number'));
+		self::assertTrue($this->evaluator->matches(expression: '[0..25000]', value: 12500.0, type: 'number'));
+		self::assertFalse($this->evaluator->matches(expression: '[0..25000]', value: 25000.01, type: 'number'));
+	}//end testInclusiveRangeBoundsMatch()
+
+	/**
+	 * @return void
+	 */
+	public function testExclusiveRangeBoundsDoNotMatch(): void {
+		self::assertFalse($this->evaluator->matches(expression: '(25000..40000)', value: 25000.0, type: 'number'));
+		self::assertFalse($this->evaluator->matches(expression: '(25000..40000)', value: 40000.0, type: 'number'));
+		self::assertTrue($this->evaluator->matches(expression: '(25000..40000)', value: 30000.0, type: 'number'));
+	}//end testExclusiveRangeBoundsDoNotMatch()
+
+	/**
+	 * @return void
+	 */
+	public function testMixedRangeBoundaries(): void {
+		self::assertFalse($this->evaluator->matches(expression: '(25000..40000]', value: 25000.0, type: 'number'));
+		self::assertTrue($this->evaluator->matches(expression: '(25000..40000]', value: 40000.0, type: 'number'));
+		self::assertTrue($this->evaluator->matches(expression: '[25000..40000)', value: 25000.0, type: 'number'));
+		self::assertFalse($this->evaluator->matches(expression: '[25000..40000)', value: 40000.0, type: 'number'));
+	}//end testMixedRangeBoundaries()
+
+	/**
+	 * @return void
+	 */
+	public function testUnbalancedRangeIsInvalidExpression(): void {
+		$this->expectException(DecisionEvaluationException::class);
+		try {
+			$this->evaluator->matches(expression: '[1..', value: 5.0, type: 'number');
+		} catch (DecisionEvaluationException $e) {
+			// No `..` match at all falls through to bare-literal coercion,
+			// which for a non-numeric literal like "[1.." on a number type
+			// surfaces as type_mismatch — still a clear, typed error, never
+			// a silent match/non-match.
+			self::assertContains($e->getErrorCode(), ['invalid_expression', 'type_mismatch']);
+			throw $e;
+		}
+	}//end testUnbalancedRangeIsInvalidExpression()
+
+	/**
+	 * @return void
+	 */
+	public function testMissingRangeBoundIsInvalidExpression(): void {
+		$this->expectException(DecisionEvaluationException::class);
+		try {
+			$this->evaluator->matches(expression: '[1..]', value: 5.0, type: 'number');
+		} catch (DecisionEvaluationException $e) {
+			self::assertSame('invalid_expression', $e->getErrorCode());
+			throw $e;
+		}
+	}//end testMissingRangeBoundIsInvalidExpression()
+
+	/**
+	 * @return void
+	 */
+	public function testNonNumericRangeBoundIsTypeMismatch(): void {
+		$this->expectException(DecisionEvaluationException::class);
+		try {
+			$this->evaluator->matches(expression: '[abc..100]', value: 5.0, type: 'number');
+		} catch (DecisionEvaluationException $e) {
+			self::assertSame('type_mismatch', $e->getErrorCode());
+			throw $e;
+		}
+	}//end testNonNumericRangeBoundIsTypeMismatch()
+
+	// ------------------------------------------------------------------
+	// Sets
+	// ------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testSetMembershipUnquoted(): void {
+		self::assertTrue($this->evaluator->matches(expression: 'in (gold, silver, bronze)', value: 'silver', type: 'string'));
+		self::assertFalse($this->evaluator->matches(expression: 'in (gold, silver, bronze)', value: 'platinum', type: 'string'));
+	}//end testSetMembershipUnquoted()
+
+	/**
+	 * @return void
+	 */
+	public function testSetMembershipQuotedWithCommas(): void {
+		self::assertTrue($this->evaluator->matches(expression: 'in ("a b", "c,d")', value: 'c,d', type: 'string'));
+		self::assertTrue($this->evaluator->matches(expression: 'in ("a b", "c,d")', value: 'a b', type: 'string'));
+	}//end testSetMembershipQuotedWithCommas()
+
+	/**
+	 * @return void
+	 */
+	public function testSetMembershipCaseInsensitivePrefix(): void {
+		self::assertTrue($this->evaluator->matches(expression: 'IN (1, 2, 3)', value: 2.0, type: 'number'));
+	}//end testSetMembershipCaseInsensitivePrefix()
+
+	// ------------------------------------------------------------------
+	// Bare literal
+	// ------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testBareLiteralString(): void {
+		self::assertTrue($this->evaluator->matches(expression: 'gold', value: 'gold', type: 'string'));
+		self::assertFalse($this->evaluator->matches(expression: 'gold', value: 'silver', type: 'string'));
+	}//end testBareLiteralString()
+
+	/**
+	 * @return void
+	 */
+	public function testBareLiteralNumber(): void {
+		self::assertTrue($this->evaluator->matches(expression: '42', value: 42.0, type: 'number'));
+	}//end testBareLiteralNumber()
+
+	/**
+	 * @return void
+	 */
+	public function testBareLiteralBooleanTrue(): void {
+		self::assertTrue($this->evaluator->matches(expression: 'true', value: true, type: 'boolean'));
+		self::assertFalse($this->evaluator->matches(expression: 'true', value: false, type: 'boolean'));
+	}//end testBareLiteralBooleanTrue()
+
+	/**
+	 * @return void
+	 */
+	public function testBareLiteralBooleanFalse(): void {
+		self::assertTrue($this->evaluator->matches(expression: 'false', value: false, type: 'boolean'));
+	}//end testBareLiteralBooleanFalse()
+
+	// ------------------------------------------------------------------
+	// coerce() — type coercion matrix
+	// ------------------------------------------------------------------
+
+	/**
+	 * @return void
+	 */
+	public function testCoerceString(): void {
+		self::assertSame('42', $this->evaluator->coerce(value: 42, type: 'string'));
+	}//end testCoerceString()
+
+	/**
+	 * @return void
+	 */
+	public function testCoerceNumberFromString(): void {
+		self::assertSame(42.5, $this->evaluator->coerce(value: '42.5', type: 'number'));
+	}//end testCoerceNumberFromString()
+
+	/**
+	 * @return void
+	 */
+	public function testCoerceNumberRejectsNonNumeric(): void {
+		$this->expectException(DecisionEvaluationException::class);
+		try {
+			$this->evaluator->coerce(value: 'not-a-number', type: 'number');
+		} catch (DecisionEvaluationException $e) {
+			self::assertSame('type_mismatch', $e->getErrorCode());
+			throw $e;
+		}
+	}//end testCoerceNumberRejectsNonNumeric()
+
+	/**
+	 * @return void
+	 */
+	public function testCoerceBooleanFromString(): void {
+		self::assertTrue($this->evaluator->coerce(value: 'true', type: 'boolean'));
+		self::assertFalse($this->evaluator->coerce(value: 'false', type: 'boolean'));
+	}//end testCoerceBooleanFromString()
+
+	/**
+	 * @return void
+	 */
+	public function testCoerceBooleanRejectsGarbage(): void {
+		$this->expectException(DecisionEvaluationException::class);
+		try {
+			$this->evaluator->coerce(value: 'maybe', type: 'boolean');
+		} catch (DecisionEvaluationException $e) {
+			self::assertSame('type_mismatch', $e->getErrorCode());
+			throw $e;
+		}
+	}//end testCoerceBooleanRejectsGarbage()
+
+	/**
+	 * @return void
+	 */
+	public function testCoerceDateFromIsoString(): void {
+		$timestamp = $this->evaluator->coerce(value: '2026-01-01T00:00:00+00:00', type: 'date');
+		self::assertIsInt($timestamp);
+	}//end testCoerceDateFromIsoString()
+
+	/**
+	 * @return void
+	 */
+	public function testCoerceDateRejectsUnparsable(): void {
+		$this->expectException(DecisionEvaluationException::class);
+		try {
+			$this->evaluator->coerce(value: 'not-a-date', type: 'date');
+		} catch (DecisionEvaluationException $e) {
+			self::assertSame('type_mismatch', $e->getErrorCode());
+			throw $e;
+		}
+	}//end testCoerceDateRejectsUnparsable()
+
+	/**
+	 * @return void
+	 */
+	public function testDateRangeComparison(): void {
+		$value = $this->evaluator->coerce(value: '2026-06-15', type: 'date');
+		self::assertTrue($this->evaluator->matches(expression: '[2026-01-01..2026-12-31]', value: $value, type: 'date'));
+		self::assertFalse($this->evaluator->matches(expression: '[2027-01-01..2027-12-31]', value: $value, type: 'date'));
+	}//end testDateRangeComparison()
+}//end class


### PR DESCRIPTION
Groundwork for buildiq and dossiq consuming the shared DMN evaluator (follow-up to #3186).

## What

Decision tables in the fleet were authored against two type vocabularies. openbuild's shipped credit table declares `integer`, which is not one of `UnaryTestEvaluator::VALID_TYPES`, so `normaliseFields` fell back to `string`. This adds an alias map so a table means the same thing in either dialect.

## What I expected to find, and what was actually true

I opened this expecting the `integer` → `string` fallback to be a live defect: 25 coerced to `"25"` before a `>=18` test ran, on a credit-approval table. **That is not what happens.** The unary-test grammar parses its operand and compares numerically regardless of the declared type, so every numeric case I probed gives an identical verdict under `number` and `string`, and ISO dates compare correctly as strings too.

The one real divergence is **boolean**. A PHP `true` coerced to a string becomes `"1"`, which does not match a cell reading `true` — so a column declaring `bool` rather than `boolean` silently stops matching.

So the commit is honest about which half is which: the boolean alias fixes a silent mismatch, the numeric and date aliases are vocabulary alignment. Unrecognised types still fall back to `string`, unchanged.

## Tests

`testABoolColumnMatchesARealBoolean` fails without the alias map and passes with it — verified by reverting the two changed lines and re-running. The numeric case deliberately gets **no** test of its own: it passes either way, so it would be evidence of nothing.

One process note worth recording: my first verification run was worthless. I had symlinked `vendor/` from the main checkout, whose composer autoloader resolves `OCA\OpenRegister\` to the main tree's `lib/` — so "with fix" and "without fix" both executed unmodified code and agreed. The stack trace's file path is what gave it away. The worktree now has its own dumped autoloader, and `ReflectionClass::getFileName()` confirms the class resolves into the worktree before any assertion is trusted.

## Verification

- `phpunit tests/Unit/Service/Dmn/` — 16/16, and 15/16 with the fix reverted
- `phpcs`, `phpmd`, `phpstan` on `lib/Service/Dmn/` — all clean