### PR TITLE
chore(deps): take @conduction/nextcloud-vue 2.27.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2289,9 +2289,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.25.1",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.25.1.tgz",
-      "integrity": "sha512-c5sY4XnHrfGUIUEatJEIT5jK78k9REj2UCqXylbHiDPkv1HpUx7Sf3XtfDxAd4xPjn/kbO094rNqShK4tPnY7w==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.27.0.tgz",
+      "integrity": "sha512-64IS6VrAp4c+Hr9AAS9/z6AzznmaPfbO4GrZtmOX57dLCpJORkn5M/wSKpAC6ZG+gUHTJeXDUiabut9bV0kRnQ==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",


### PR DESCRIPTION
Takes `@conduction/nextcloud-vue@2.27.0`.

**Why:** it carries the two KPI-card fixes this app's dashboard reads —

1. The canonical KPI card is flat and horizontal, so the dashboard stops drawing a grey box inside the white card `CnWidgetWrapper` already draws.
2. A calendar-aligned date range now follows the **reader's** calendar rather than UTC. "Current month" previously resolved its end to `23:59:59.999Z` on today's UTC date, which in CEST on 31 August displayed as **1 September** and leaked two hours of September into an August total.

The caret range already allowed it; only the lockfile pinned this app back, so `npm ci` kept installing the old one.

**Lockfile only**, and npm pruned nothing — the package set is byte-for-byte the same apart from the one version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)