### PR TITLE
test(entity-drift): regression coverage for appendOnly, smartPickerEnabled, type (WOO-546)

### DIFF
--- a/tests/Unit/Db/RegisterTest.php
+++ b/tests/Unit/Db/RegisterTest.php
@@ -39,6 +39,10 @@ class RegisterTest extends TestCase {
 		$this->assertSame('json', $fieldTypes['groups']);
 		$this->assertSame('datetime', $fieldTypes['deleted']);
 		$this->assertSame('json', $fieldTypes['configuration']);
+		// Guards WOO-546 — the migration in beta introduced the `type` DB
+		// column; the Entity property + addType must be present or
+		// RegisterMapper row hydration throws "not a valid attribute".
+		$this->assertSame('string', $fieldTypes['type']);
 	}
 
 	public function testConstructorDefaultValues(): void {
@@ -102,6 +106,15 @@ class RegisterTest extends TestCase {
 	public function testSetAndGetFolder(): void {
 		$this->register->setFolder('/Documents/Registers');
 		$this->assertSame('/Documents/Registers', $this->register->getFolder());
+	}
+
+	public function testSetAndGetType(): void {
+		$this->register->setType('mock');
+		$this->assertSame('mock', $this->register->getType());
+	}
+
+	public function testTypeDefaultNull(): void {
+		$this->assertNull($this->register->getType());
 	}
 
 	public function testSetAndGetOwner(): void {

--- a/tests/Unit/Db/SchemaTest.php
+++ b/tests/Unit/Db/SchemaTest.php
@@ -34,7 +34,9 @@ class SchemaTest extends TestCase {
 		$this->assertSame('string', $types['source']);
 		$this->assertSame('boolean', $types['hardValidation']);
 		$this->assertSame('boolean', $types['immutable']);
+		$this->assertSame('boolean', $types['appendOnly']);
 		$this->assertSame('boolean', $types['searchable']);
+		$this->assertSame('boolean', $types['smartPickerEnabled']);
 		$this->assertSame('datetime', $types['updated']);
 		$this->assertSame('datetime', $types['created']);
 		$this->assertSame('integer', $types['maxDepth']);
@@ -547,6 +549,33 @@ class SchemaTest extends TestCase {
 	public function testSetSearchableFalse(): void {
 		$this->schema->setSearchable(false);
 		$this->assertFalse($this->schema->isSearchable());
+	}
+
+	// --- AppendOnly ---
+	// Guards WOO-546 — the migration Version1Date20260511110000 introduced
+	// the `append_only` DB column; the Entity property + addType must exist
+	// or SchemaMapper row hydration throws "not a valid attribute".
+
+	public function testIsAppendOnlyDefaultFalse(): void {
+		$this->assertFalse($this->schema->isAppendOnly());
+	}
+
+	public function testSetAppendOnlyTrue(): void {
+		$this->schema->setAppendOnly(true);
+		$this->assertTrue($this->schema->isAppendOnly());
+	}
+
+	// --- SmartPickerEnabled ---
+	// Guards WOO-546 — the migration Version1Date20260817120000 introduced
+	// the `smart_picker_enabled` DB column; same round-trip contract.
+
+	public function testIsSmartPickerEnabledDefaultFalse(): void {
+		$this->assertFalse($this->schema->isSmartPickerEnabled());
+	}
+
+	public function testSetSmartPickerEnabledTrue(): void {
+		$this->schema->setSmartPickerEnabled(true);
+		$this->assertTrue($this->schema->isSmartPickerEnabled());
 	}
 
 	// --- __toString ---

--- a/tests/Unit/Db/SchemaTest.php
+++ b/tests/Unit/Db/SchemaTest.php
@@ -565,6 +565,12 @@ class SchemaTest extends TestCase {
 		$this->assertTrue($this->schema->isAppendOnly());
 	}
 
+	public function testSetAppendOnlyFalse(): void {
+		$this->schema->setAppendOnly(true);
+		$this->schema->setAppendOnly(false);
+		$this->assertFalse($this->schema->isAppendOnly());
+	}
+
 	// --- SmartPickerEnabled ---
 	// Guards WOO-546 — the migration Version1Date20260817120000 introduced
 	// the `smart_picker_enabled` DB column; same round-trip contract.
@@ -576,6 +582,12 @@ class SchemaTest extends TestCase {
 	public function testSetSmartPickerEnabledTrue(): void {
 		$this->schema->setSmartPickerEnabled(true);
 		$this->assertTrue($this->schema->isSmartPickerEnabled());
+	}
+
+	public function testSetSmartPickerEnabledFalse(): void {
+		$this->schema->setSmartPickerEnabled(true);
+		$this->schema->setSmartPickerEnabled(false);
+		$this->assertFalse($this->schema->isSmartPickerEnabled());
 	}
 
 	// --- __toString ---


### PR DESCRIPTION
## Summary

Regression test coverage for the three Entity/DB-schema drifts caught during WOO-536 Fase 7 smoke testing on 2026-08-28:

- `Schema.appendOnly` (migration `Version1Date20260511110000`)
- `Schema.smartPickerEnabled` (migration `Version1Date20260817120000`)
- `Register.type`

All three DB columns existed but the corresponding Entity properties + `addType()` registrations were missing on the sub-task's reference commit, causing `SchemaMapper::findAll()` / `RegisterMapper::findAll()` to throw `BadFunctionCallException("...is not a valid attribute")` on every row hydration.

**Wilco applied local shims (never committed) to unblock the WOO-536 Fase 4 repair-migration end-to-end test.**

## Current state on main

Beta releases since 2026-08-27 have landed the three Entity properties + `addType` calls on main:

- `71baf7629 feat(schema): add appendOnly schema flag`
- `c13871c11 feat(smart-picker): schema-scoped Smart Picker + search provider base classes`
- `9b23b0d95 feat(mock-registers Phase 1): persist x-openregister.type + filter API + integration test`

So the code drift is resolved. **What remains is the test-coverage gap that would have caught this on CI in the first place.**

## What this PR adds

- Two assertions in `SchemaTest::testConstructorFieldTypes` for the two boolean field types (`appendOnly`, `smartPickerEnabled`).
- Four getter/setter tests exercising the hand-rolled `isAppendOnly()` / `setAppendOnly()` and `isSmartPickerEnabled()` / `setSmartPickerEnabled()`.
- One assertion in `RegisterTest::testConstructorRegistersFieldTypes` for `type`.
- Two getter/setter tests exercising `setType()` / `getType()` via the `__call` magic (default-null + set-and-get).

## Test results

```
PHPUnit 10.5.63
tests/Unit/Db/SchemaTest.php + tests/Unit/Db/RegisterTest.php
OK (205 tests, 395 assertions)
```

## References

- Parent: [WOO-546](https://conduction.atlassian.net/browse/WOO-546)
- Grand-parent: [WOO-536](https://conduction.atlassian.net/browse/WOO-536)
- Sibling PR: openregister#2855 (`_rbac_as_public` primitive — the smoke-test parent)

## Test plan

- [x] `vendor/bin/phpunit tests/Unit/Db/SchemaTest.php tests/Unit/Db/RegisterTest.php` — 205/205 green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WOO-546]: https://conduction.atlassian.net/browse/WOO-546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ