### PR TITLE
test(mariadb-portability): regression coverage for buildSearchConditionSql platform branch (WOO-544)

### DIFF
--- a/tests/Unit/Db/MagicSearchHandlerTest.php
+++ b/tests/Unit/Db/MagicSearchHandlerTest.php
@@ -305,6 +305,10 @@ class MagicSearchHandlerTest extends TestCase {
 	 * @param string $search Free-text search term.
 	 * @param array $properties Schema properties (field => ['type' => ...]).
 	 * @param bool $isPostgres Whether to render the PostgreSQL or MySQL flavour.
+	 * @param array $query Optional query dict (e.g. `['_fuzzy' => true]`) — the
+	 *                     production method reads `_fuzzy` from this dict, so
+	 *                     tests that exercise the fuzzy branch pass it here
+	 *                     instead of re-inlining the reflection call.
 	 *
 	 * @return string|null Generated SQL condition string (or null when empty).
 	 */
@@ -312,6 +316,7 @@ class MagicSearchHandlerTest extends TestCase {
 		string $search,
 		array $properties,
 		bool $isPostgres,
+		array $query = [],
 	): ?string {
 		$schema = $this->createMock(Schema::class);
 		$schema->method('getProperties')->willReturn($properties);
@@ -323,7 +328,7 @@ class MagicSearchHandlerTest extends TestCase {
 			$this->handler,
 			$search,
 			$schema,
-			[],
+			$query,
 			$this->makeConnection(),
 			$isPostgres,
 			null
@@ -439,20 +444,11 @@ class MagicSearchHandlerTest extends TestCase {
 		$hasPgTrgmProp->setAccessible(true);
 		$hasPgTrgmProp->setValue($this->handler, false);
 
-		$schema = $this->createMock(Schema::class);
-		$schema->method('getProperties')->willReturn(['title' => ['type' => 'string']]);
-
-		$method = new ReflectionMethod(MagicSearchHandler::class, 'buildSearchConditionSql');
-		$method->setAccessible(true);
-
-		$sql = $method->invoke(
-			$this->handler,
-			'foo',
-			$schema,
-			['_fuzzy' => true],
-			$this->makeConnection(),
-			false,
-			null
+		$sql = $this->invokeBuildSearchConditionSql(
+			search: 'foo',
+			properties: ['title' => ['type' => 'string']],
+			isPostgres: false,
+			query: ['_fuzzy' => true]
 		);
 
 		$this->assertNotNull($sql);

--- a/tests/Unit/Db/MagicSearchHandlerTest.php
+++ b/tests/Unit/Db/MagicSearchHandlerTest.php
@@ -374,6 +374,93 @@ class MagicSearchHandlerTest extends TestCase {
 	}//end testBuildSearchConditionSqlQuotesEveryStringPropertyOnPostgres()
 
 	// -------------------------------------------------------------------------
+	// WOO-544 regression guards: buildSearchConditionSql() must never emit
+	// PostgreSQL-specific syntax (`::text ILIKE`, `similarity()`) on the MariaDB
+	// / MySQL flavour, or the entire arm of a multi-schema search silently
+	// swallows a syntax error and returns an empty resultset.
+	// -------------------------------------------------------------------------
+
+	public function testBuildSearchConditionSqlNeverEmitsPgTextCastOnMySql(): void {
+		$sql = $this->invokeBuildSearchConditionSql(
+			search: 'foo',
+			properties: [
+				'title' => ['type' => 'string'],
+				'description' => ['type' => 'string'],
+			],
+			isPostgres: false
+		);
+
+		$this->assertNotNull($sql);
+		// Neither the schema-property casts nor the metadata-field casts may use
+		// PostgreSQL's `::text` syntax on the MariaDB path — that is the exact
+		// silent-empty-resultset defect WOO-544 was filed to catch.
+		$this->assertStringNotContainsString('::text', $sql);
+		$this->assertStringNotContainsString('ILIKE', $sql);
+	}//end testBuildSearchConditionSqlNeverEmitsPgTextCastOnMySql()
+
+	public function testBuildSearchConditionSqlEmitsLowerCastForMetadataOnMySql(): void {
+		$sql = $this->invokeBuildSearchConditionSql(
+			search: 'foo',
+			properties: [],
+			isPostgres: false
+		);
+
+		$this->assertNotNull($sql);
+		// MariaDB path wraps each metadata column and the pattern in LOWER()
+		// so it stays case-insensitive regardless of collation.
+		$this->assertStringContainsString('LOWER(CAST(_name AS CHAR)) LIKE LOWER(', $sql);
+		$this->assertStringContainsString('LOWER(CAST(_description AS CHAR)) LIKE LOWER(', $sql);
+		$this->assertStringContainsString('LOWER(CAST(_summary AS CHAR)) LIKE LOWER(', $sql);
+	}//end testBuildSearchConditionSqlEmitsLowerCastForMetadataOnMySql()
+
+	public function testBuildSearchConditionSqlEmitsPgTextCastForMetadataOnPostgres(): void {
+		$sql = $this->invokeBuildSearchConditionSql(
+			search: 'foo',
+			properties: [],
+			isPostgres: true
+		);
+
+		$this->assertNotNull($sql);
+		// PostgreSQL path keeps `_name::text ILIKE` because ILIKE is
+		// case-insensitive natively; the platform-branch must not regress.
+		$this->assertStringContainsString('_name::text ILIKE', $sql);
+		$this->assertStringContainsString('_description::text ILIKE', $sql);
+		$this->assertStringContainsString('_summary::text ILIKE', $sql);
+	}//end testBuildSearchConditionSqlEmitsPgTextCastForMetadataOnPostgres()
+
+	public function testBuildSearchConditionSqlWithFuzzyOnMySqlDoesNotEmitSimilarity(): void {
+		// The `_fuzzy=true` param is honoured only when pg_trgm is available.
+		// hasPgTrgmExtension() short-circuits to false on non-PostgreSQL, so
+		// even a client-supplied _fuzzy MUST NOT emit similarity() on MariaDB.
+		// We prime the cached hasPgTrgm=false directly so the test doesn't need
+		// a full IDBConnection platform mock — the platform-branch semantics in
+		// buildSearchConditionSql are the SUT here, not the pg_trgm probe.
+		$hasPgTrgmProp = new \ReflectionProperty(MagicSearchHandler::class, 'hasPgTrgm');
+		$hasPgTrgmProp->setAccessible(true);
+		$hasPgTrgmProp->setValue($this->handler, false);
+
+		$schema = $this->createMock(Schema::class);
+		$schema->method('getProperties')->willReturn(['title' => ['type' => 'string']]);
+
+		$method = new ReflectionMethod(MagicSearchHandler::class, 'buildSearchConditionSql');
+		$method->setAccessible(true);
+
+		$sql = $method->invoke(
+			$this->handler,
+			'foo',
+			$schema,
+			['_fuzzy' => true],
+			$this->makeConnection(),
+			false,
+			null
+		);
+
+		$this->assertNotNull($sql);
+		$this->assertStringNotContainsString('similarity(', $sql);
+		$this->assertStringNotContainsString('::text', $sql);
+	}//end testBuildSearchConditionSqlWithFuzzyOnMySqlDoesNotEmitSimilarity()
+
+	// -------------------------------------------------------------------------
 	// Regression: `format: date-time` must round-trip as ISO-8601.
 	//
 	// A date-time property lives in a DATETIME column, so the driver hands it


### PR DESCRIPTION
## Summary

Regression test coverage for the PostgreSQL / MariaDB platform branching in `MagicSearchHandler::buildSearchConditionSql()`.

WOO-544 flagged that the method previously emitted PostgreSQL-only `::text ILIKE` / `similarity()` unconditionally, causing multi-schema search on MariaDB to silently return an empty resultset (the syntax error is swallowed by `searchAcrossMultipleTablesSequential()`).

## Current state on main

Commit `df2c027cd` (2026-06-18) *fix(db): guard all ::text casts behind PostgreSQL platform check* resolved the code path — `buildSearchConditionSql` now branches on `$isPostgres` for both schema-property casts (lines 707/715) and metadata-field casts (lines 720/724). `hasPgTrgmExtension()` short-circuits fuzzy on non-PostgreSQL.

**What remained is the test-coverage gap that would have caught this class of regression on CI.**

## What this PR adds

Four new tests in `tests/Unit/Db/MagicSearchHandlerTest.php`:

- `testBuildSearchConditionSqlNeverEmitsPgTextCastOnMySql` — canary that asserts NEITHER `::text` NOR `ILIKE` appears in the MariaDB flavour of the generated SQL, covering both schema-property and metadata-field paths.
- `testBuildSearchConditionSqlEmitsLowerCastForMetadataOnMySql` — positive assertion of `LOWER(CAST(_name AS CHAR)) LIKE LOWER(...)` on MariaDB.
- `testBuildSearchConditionSqlEmitsPgTextCastForMetadataOnPostgres` — PostgreSQL baseline (`_name::text ILIKE`).
- `testBuildSearchConditionSqlWithFuzzyOnMySqlDoesNotEmitSimilarity` — even client-supplied `_fuzzy=true` must not emit `similarity()` on MariaDB. Primes `hasPgTrgm=false` via reflection to isolate the platform-branch from the DB probe.

## Test results

```
PHPUnit 10.5.63
tests/Unit/Db/MagicSearchHandlerTest.php
OK (25 tests, 61 assertions)
```

## Follow-up flagged during this work

Three neighbouring methods still emit PostgreSQL-only `jsonb_typeof(...)`, `jsonb_each_text(...)`, `to_jsonb(?::text)` without a platform branch:

- `applyRelationsContainsFilter` (~L1834)
- `applyRelationFieldFilter` (~L1901)
- `buildRelationFilterConditionsSql` (~L1931)

These are consumed by [WOO-536](https://conduction.atlassian.net/browse/WOO-536) Stap 5a (relation-based document→publication linkage), so a MariaDB WOO installation would silently drop document rows on `/api/search`. Out-of-scope for WOO-544's `buildSearchConditionSql` charter — recommend a new sub-task once WOO-536 lands on beta / development.

## References

- Parent: [WOO-544](https://conduction.atlassian.net/browse/WOO-544)
- Grand-parent: [WOO-536](https://conduction.atlassian.net/browse/WOO-536)
- Sibling PR: openregister#3196 (WOO-546 test coverage)

## Test plan

- [x] `vendor/bin/phpunit tests/Unit/Db/MagicSearchHandlerTest.php` — 25/25 green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WOO-536]: https://conduction.atlassian.net/browse/WOO-536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ