### PR TITLE
test(rbac): regression coverage for findInRegisterSchemaTable access-control wire (WOO-545)

### DIFF
--- a/tests/Unit/Db/MagicMapper/MagicMapperFindInRegisterSchemaTableAccessControlTest.php
+++ b/tests/Unit/Db/MagicMapper/MagicMapperFindInRegisterSchemaTableAccessControlTest.php
@@ -223,7 +223,7 @@ class MagicMapperFindInRegisterSchemaTableAccessControlTest extends TestCase {
 				_multitenancy: true
 			);
 			$this->fail('empty DB result should have raised DoesNotExistException');
-		} catch (DoesNotExistException $e) {
+		} catch (DoesNotExistException) {
 			// Expected — assertion is about the seam call, not the return.
 		}
 
@@ -250,7 +250,7 @@ class MagicMapperFindInRegisterSchemaTableAccessControlTest extends TestCase {
 				_multitenancy: true
 			);
 			$this->fail('empty DB result should have raised DoesNotExistException');
-		} catch (DoesNotExistException $e) {
+		} catch (DoesNotExistException) {
 			// Expected.
 		}
 
@@ -277,7 +277,7 @@ class MagicMapperFindInRegisterSchemaTableAccessControlTest extends TestCase {
 				_multitenancy: false
 			);
 			$this->fail('empty DB result should have raised DoesNotExistException');
-		} catch (DoesNotExistException $e) {
+		} catch (DoesNotExistException) {
 			// Expected.
 		}
 
@@ -299,7 +299,7 @@ class MagicMapperFindInRegisterSchemaTableAccessControlTest extends TestCase {
 				schema: $this->makeSchema(id: 5)
 			);
 			$this->fail('empty DB result should have raised DoesNotExistException');
-		} catch (DoesNotExistException $e) {
+		} catch (DoesNotExistException) {
 			// Expected.
 		}
 

--- a/tests/Unit/Db/MagicMapper/MagicMapperFindInRegisterSchemaTableAccessControlTest.php
+++ b/tests/Unit/Db/MagicMapper/MagicMapperFindInRegisterSchemaTableAccessControlTest.php
@@ -1,0 +1,311 @@
+<?php
+
+/**
+ * Regression tests for MagicMapper::findInRegisterSchemaTable() RBAC wire-up.
+ *
+ * WOO-545 flagged a comment-only placeholder in this method where RBAC
+ * filtering used to be skipped:
+ *
+ *     // Apply RBAC filtering if enabled.
+ *     if ($_rbac === true) {
+ *         // Add RBAC filtering logic here if needed.
+ *         // Currently skipped as owner/authorization logic is complex.
+ *     }
+ *
+ * Commit 71c6b7e47 (2026-06-11) "fix(rbac): close cross-org single-GET IDOR"
+ * replaced that placeholder with a proper delegation to
+ * `MagicSearchHandler::applyAccessControlToQuery()`, so the scoped
+ * single-object read now enforces the same isolation as the list/search path.
+ *
+ * These unit tests pin the resulting contract at the class boundary — a
+ * sibling to the existing `MagicMapperFindAcrossAllMagicTablesAccessControlTest`
+ * (which covers the cross-schema fallback path) and complement the
+ * `MagicMapperIntegrationTest` scenarios that exercise the same call against a
+ * real database.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Db\MagicMapper;
+
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\MagicMapper\MagicSearchHandler;
+use OCA\OpenRegister\Db\MagicMapper\MagicTableHandler;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\DB\IResult;
+use OCP\DB\QueryBuilder\ICompositeExpression;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IAppConfig;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+class MagicMapperFindInRegisterSchemaTableAccessControlTest extends TestCase {
+
+	private IDBConnection&MockObject $db;
+
+	private SchemaMapper&MockObject $schemaMapper;
+
+	private RegisterMapper&MockObject $registerMapper;
+
+	private MagicSearchHandler&MockObject $searchHandler;
+
+	private MagicTableHandler&MockObject $tableHandler;
+
+	/**
+	 * @var array<int, array{schemaId: int|null, _rbac: bool, _multitenancy: bool}>
+	 */
+	private array $accessControlCalls = [];
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->db = $this->createMock(IDBConnection::class);
+		$this->schemaMapper = $this->createMock(SchemaMapper::class);
+		$this->registerMapper = $this->createMock(RegisterMapper::class);
+		$this->searchHandler = $this->createMock(MagicSearchHandler::class);
+		$this->tableHandler = $this->createMock(MagicTableHandler::class);
+		$this->accessControlCalls = [];
+
+		// Record every applyAccessControlToQuery() call so tests can assert
+		// the seam was consulted (or NOT consulted, in the bypass case) with
+		// the expected _rbac / _multitenancy arguments.
+		$this->searchHandler->method('applyAccessControlToQuery')->willReturnCallback(
+			function (IQueryBuilder $qb, Schema $schema, bool $_rbac = true, bool $_multitenancy = true): void {
+				$this->accessControlCalls[] = [
+					'schemaId' => $schema->getId(),
+					'_rbac' => $_rbac,
+					'_multitenancy' => $_multitenancy,
+				];
+			}
+		);
+	}//end setUp()
+
+	/**
+	 * Build a MagicMapper wired with the mocked table + search handlers.
+	 *
+	 * `applyAccessControlToQuery` is a void mutator on the real class — the
+	 * mock does not need to actually modify the query builder. It just
+	 * records that the call was (or wasn't) made. The DB driver is stubbed
+	 * to return an EMPTY result so the method throws DoesNotExistException,
+	 * which the assertions below expect.
+	 */
+	private function makeMapper(): MagicMapper {
+		$config = $this->createMock(IConfig::class);
+
+		// The MagicMapper constructor eagerly boots MagicRbacHandler +
+		// dependents via the container. Route the minimum handful of
+		// container resolves to mocks so the constructor doesn't blow up
+		// on missing typed args (ConditionMatcher, etc.).
+		$container = $this->createMock(ContainerInterface::class);
+		$container->method('get')->willReturnCallback(
+			function (string $id) {
+				return match ($id) {
+					\OCA\OpenRegister\Service\DateTimeNormalizer::class => $this->createMock(
+						\OCA\OpenRegister\Service\DateTimeNormalizer::class
+					),
+					\OCA\OpenRegister\Service\ConditionMatcher::class => $this->createMock(
+						\OCA\OpenRegister\Service\ConditionMatcher::class
+					),
+					\OCA\OpenRegister\Service\Object\SchemaTypeConverter::class => $this->createMock(
+						\OCA\OpenRegister\Service\Object\SchemaTypeConverter::class
+					),
+					default => null,
+				};
+			}
+		);
+
+		$mapper = new MagicMapper(
+			$this->db,
+			$this->schemaMapper,
+			$this->registerMapper,
+			$config,
+			$this->createMock(IEventDispatcher::class),
+			$this->createMock(IUserSession::class),
+			$this->createMock(IGroupManager::class),
+			$this->createMock(IUserManager::class),
+			$this->createMock(IAppConfig::class),
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(\OCA\OpenRegister\Service\SettingsService::class),
+			$container
+		);
+
+		// Route the two tableHandler probes findInRegisterSchemaTable calls
+		// (existsTableForRegisterSchema + getTableNameForRegisterSchema) at a
+		// stubbed handler so we don't need a real table setup.
+		$this->tableHandler->method('existsTableForRegisterSchema')->willReturn(true);
+		$this->tableHandler->method('getTableNameForRegisterSchema')->willReturn('oc_openregister_table_1_2');
+
+		$tableHandlerProperty = new \ReflectionProperty(MagicMapper::class, 'tableHandler');
+		$tableHandlerProperty->setAccessible(true);
+		$tableHandlerProperty->setValue($mapper, $this->tableHandler);
+
+		$searchProperty = new \ReflectionProperty(MagicMapper::class, 'searchHandler');
+		$searchProperty->setAccessible(true);
+		$searchProperty->setValue($mapper, $this->searchHandler);
+
+		// Empty result → row === false → DoesNotExistException. This lets us
+		// exercise the RBAC-wire branch without also stubbing the row
+		// conversion pipeline.
+		$this->db->method('getQueryBuilder')->willReturnCallback(fn () => $this->makeEmptyQueryBuilder());
+
+		return $mapper;
+	}//end makeMapper()
+
+	private function makeEmptyQueryBuilder(): IQueryBuilder {
+		$expr = $this->createMock(IExpressionBuilder::class);
+		$expr->method('eq')->willReturn('eq');
+		$expr->method('isNull')->willReturn('isNull');
+		$expr->method('orX')->willReturn($this->createMock(ICompositeExpression::class));
+
+		$qb = $this->createMock(IQueryBuilder::class);
+		$qb->method('expr')->willReturn($expr);
+		$qb->method('select')->willReturnSelf();
+		$qb->method('from')->willReturnSelf();
+		$qb->method('where')->willReturnSelf();
+		$qb->method('andWhere')->willReturnSelf();
+		$qb->method('createNamedParameter')->willReturn(':param');
+
+		$result = $this->createMock(IResult::class);
+		$result->method('fetch')->willReturn(false);
+		$qb->method('executeQuery')->willReturn($result);
+
+		return $qb;
+	}//end makeEmptyQueryBuilder()
+
+	private function makeSchema(int $id): Schema {
+		$schema = new Schema();
+		$schema->setId($id);
+		return $schema;
+	}//end makeSchema()
+
+	private function makeRegister(int $id): Register {
+		$register = new Register();
+		$register->setId($id);
+		return $register;
+	}//end makeRegister()
+
+	/*
+	 * ------------------------------------------------------------------- tests
+	 */
+
+	/**
+	 * THE FIX: `_rbac: true` (the default) must consult
+	 * `applyAccessControlToQuery()` with the SAME `_rbac`/`_multitenancy` flags
+	 * so the scoped single-object read enforces schema-level RBAC + org
+	 * isolation. Prior to commit 71c6b7e47 this was a comment-only placeholder
+	 * (WOO-545 was filed against that shape).
+	 */
+	public function testRbacTrueInvokesAccessControlSeam(): void {
+		$mapper = $this->makeMapper();
+
+		try {
+			$mapper->findInRegisterSchemaTable(
+				identifier: 'uuid-authorized',
+				register: $this->makeRegister(id: 1),
+				schema: $this->makeSchema(id: 2),
+				_rbac: true,
+				_multitenancy: true
+			);
+			$this->fail('empty DB result should have raised DoesNotExistException');
+		} catch (DoesNotExistException $e) {
+			// Expected — assertion is about the seam call, not the return.
+		}
+
+		$this->assertCount(1, $this->accessControlCalls, 'the access-control seam MUST be consulted when _rbac is true');
+		$this->assertSame(2, $this->accessControlCalls[0]['schemaId']);
+		$this->assertTrue($this->accessControlCalls[0]['_rbac']);
+		$this->assertTrue($this->accessControlCalls[0]['_multitenancy']);
+	}//end testRbacTrueInvokesAccessControlSeam()
+
+	/**
+	 * `_rbac: false` alone still consults the seam — multitenancy is a
+	 * separate axis (org isolation) that must still be enforced for
+	 * non-admin sessions.
+	 */
+	public function testRbacFalseButMultitenancyTrueStillInvokesSeam(): void {
+		$mapper = $this->makeMapper();
+
+		try {
+			$mapper->findInRegisterSchemaTable(
+				identifier: 'uuid-something',
+				register: $this->makeRegister(id: 1),
+				schema: $this->makeSchema(id: 3),
+				_rbac: false,
+				_multitenancy: true
+			);
+			$this->fail('empty DB result should have raised DoesNotExistException');
+		} catch (DoesNotExistException $e) {
+			// Expected.
+		}
+
+		$this->assertCount(1, $this->accessControlCalls);
+		$this->assertFalse($this->accessControlCalls[0]['_rbac']);
+		$this->assertTrue($this->accessControlCalls[0]['_multitenancy']);
+	}//end testRbacFalseButMultitenancyTrueStillInvokesSeam()
+
+	/**
+	 * Both `_rbac: false` AND `_multitenancy: false` — the admin/system-context
+	 * bypass — MUST skip the access-control seam entirely, matching the
+	 * long-standing contract for internal callers (e.g. LockHandler,
+	 * WOO536RepairReadRules::run).
+	 */
+	public function testFullBypassSkipsAccessControlSeam(): void {
+		$mapper = $this->makeMapper();
+
+		try {
+			$mapper->findInRegisterSchemaTable(
+				identifier: 'uuid-admin-context',
+				register: $this->makeRegister(id: 1),
+				schema: $this->makeSchema(id: 4),
+				_rbac: false,
+				_multitenancy: false
+			);
+			$this->fail('empty DB result should have raised DoesNotExistException');
+		} catch (DoesNotExistException $e) {
+			// Expected.
+		}
+
+		$this->assertSame([], $this->accessControlCalls, 'the access-control seam MUST NOT be consulted when both flags are false');
+	}//end testFullBypassSkipsAccessControlSeam()
+
+	/**
+	 * The default parameter values (both true) must exercise the seam — a
+	 * caller that omits the flags entirely must NOT accidentally get the
+	 * admin bypass path.
+	 */
+	public function testDefaultFlagsInvokeAccessControlSeam(): void {
+		$mapper = $this->makeMapper();
+
+		try {
+			$mapper->findInRegisterSchemaTable(
+				identifier: 'uuid-defaults',
+				register: $this->makeRegister(id: 1),
+				schema: $this->makeSchema(id: 5)
+			);
+			$this->fail('empty DB result should have raised DoesNotExistException');
+		} catch (DoesNotExistException $e) {
+			// Expected.
+		}
+
+		$this->assertCount(1, $this->accessControlCalls);
+		$this->assertTrue($this->accessControlCalls[0]['_rbac']);
+		$this->assertTrue($this->accessControlCalls[0]['_multitenancy']);
+	}//end testDefaultFlagsInvokeAccessControlSeam()
+
+}//end class


### PR DESCRIPTION
## Summary

Regression test coverage for the RBAC + multitenancy wire in `MagicMapper::findInRegisterSchemaTable()`.

WOO-545 flagged a comment-only placeholder at lines 4327-4331:

```php
// Apply RBAC filtering if enabled.
if ($_rbac === true) {
    // Add RBAC filtering logic here if needed.
    // Currently skipped as owner/authorization logic is complex.
}
```

## Current state on main

- Commit `71c6b7e47` (2026-06-11) *fix(rbac): close cross-org single-GET IDOR + persist owner on magic-mapper create* replaced the placeholder with a proper delegation to `MagicSearchHandler::applyAccessControlToQuery()`. Scoped single-object read now enforces the same schema-level RBAC + org isolation as the list/search path.
- Commit `31687c6f3` *feat(rbac): graft inheritFromPublic onto dev RBAC* superseded the `_rbac_as_public` primitive (originally shipped by [openregister#2855](https://github.com/ConductionNL/openregister/pull/2855), the WOO-536 precursor) with a more general per-schema `authenticatedInheritsPublic` mechanism during the beta-to-main promotion. The WOO-545 request to *"thread `_rbacAsPublic` through the find() path"* now presents as the `inheritFromPublic` cascade inside `MagicRbacHandler::applyRbacFilters()` — reached transparently via `applyAccessControlToQuery` → `applyAccessControlFilters` → `applyRbacFilters`.

**So the code drift is resolved.** What remained is a unit-test gap.

## The gap this PR closes

While the code path is exercised by:
- integration tests (`MagicMapperIntegrationTest.php`) — slow, environment-dependent
- the sibling method's dedicated regression test (`MagicMapperFindAcrossAllMagicTablesAccessControlTest.php`, 630 lines) — covers a different method

...there was NO dedicated unit-test coverage for `findInRegisterSchemaTable` itself. A regression that accidentally removed the `applyAccessControlToQuery` delegation would only be caught by integration tests.

## What this PR adds

`tests/Unit/Db/MagicMapper/MagicMapperFindInRegisterSchemaTableAccessControlTest.php` — 4 tests / 11 assertions:

- `testRbacTrueInvokesAccessControlSeam` — primary guard; asserts the seam call with the right schema + flags
- `testRbacFalseButMultitenancyTrueStillInvokesSeam` — org isolation is a separate axis
- `testFullBypassSkipsAccessControlSeam` — admin/system context (`_rbac=false` AND `_multitenancy=false`) MUST skip the seam entirely, preserving the internal-caller contract (LockHandler, WOO536RepairReadRules etc.)
- `testDefaultFlagsInvokeAccessControlSeam` — default params must not accidentally hand out the admin bypass

## Test results

```
PHPUnit 10.5.63

tests/Unit/Db/MagicMapper/MagicMapperFindInRegisterSchemaTableAccessControlTest.php
OK (4 tests, 11 assertions)

tests/Unit/Db/MagicMapper/ (whole dir — regression sweep)
OK (86 tests, 207 assertions)
```

## References

- Parent: [WOO-545](https://conduction.atlassian.net/browse/WOO-545)
- Grand-parent: [WOO-536](https://conduction.atlassian.net/browse/WOO-536)
- Related fix commit: `71c6b7e47`
- Related graft commit: `31687c6f3`
- Sibling test: `MagicMapperFindAcrossAllMagicTablesAccessControlTest.php` (identical fixture shape, different method)
- Sibling PRs in this WOO-536 batch: openregister#3196 (WOO-546), openregister#3197 (WOO-544)

## Test plan

- [x] `vendor/bin/phpunit tests/Unit/Db/MagicMapper/MagicMapperFindInRegisterSchemaTableAccessControlTest.php` — 4/4 green
- [x] `vendor/bin/phpunit tests/Unit/Db/MagicMapper/` regression sweep — 86/86 green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WOO-545]: https://conduction.atlassian.net/browse/WOO-545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ