### PR TITLE
fix(composer): declare ext-xsl so dependabot can resolve

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -159,7 +159,8 @@
 		"optimize-autoloader": true,
 		"sort-packages": true,
 		"platform": {
-			"php": "8.3"
+			"php": "8.3",
+			"ext-xsl": "1"
 		}
 	},
 	"extra": {


### PR DESCRIPTION
Dependabot cannot propose composer updates for this app. Its updater fails with:

```
Your requirements could not be resolved to an installable set of packages.
  - edgedesign/phpqa[v1.27.0, ..., v1.27.2] require ext-xsl * ->
    it is missing from your system. Install or enable PHP's xsl extension.
```

`config.platform` pins `"php": "8.3"` so composer resolves against a known PHP version, but says nothing about extensions. `edgedesign/phpqa` requires `ext-xsl`, and the resolving environment does not have it — so the resolve fails before any bump can be computed.

**CI is unaffected and that is why this went unnoticed.** `composer install` replays the committed `composer.lock` and never re-resolves, so the pipeline stays green while Dependabot — which *does* re-resolve — fails every time. The shared `quality.yml` installs no `xsl` extension anywhere, and never invokes phpqa.

### The fix

One line: declare `ext-xsl` beside the `php` pin, so resolution assumes exactly what the committed lockfile already assumes.

```diff
 "platform": {
-    "php": "8.3"
+    "php": "8.3",
+    "ext-xsl": "1"
 }
```

No runtime behaviour changes, no CI behaviour changes, and `phpqa` is left in place — it is deliberately configured here (`phpqa.yml`, `.phpqa.yml`, and the `phpqa` / `phpqa:full` / `phpqa:ci` / `qa:check` / `qa:full` scripts), so it is a tool someone chose rather than dead weight.

### Verification

Measured in a clean `composer:2` container, without `--ignore-platform-reqs`:

| | result |
| --- | --- |
| before | `Your requirements could not be resolved` (ext-xsl missing) |
| after | `exit 0` — `Lock file operations: 103 installs`, lock written |

The same file fails without the line and succeeds with it, so the check would still fail if the fix were wrong.

Part of a fleet-wide sweep: 18 apps carry `edgedesign/phpqa` with no `ext-xsl` in `config.platform`.
