### PR TITLE
chore(deps): take @conduction/nextcloud-vue 2.27.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2289,9 +2289,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.27.0.tgz",
-      "integrity": "sha512-64IS6VrAp4c+Hr9AAS9/z6AzznmaPfbO4GrZtmOX57dLCpJORkn5M/wSKpAC6ZG+gUHTJeXDUiabut9bV0kRnQ==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.27.2.tgz",
+      "integrity": "sha512-FhDF3FvM+ee0Jx7z70Lki7o7Mm4DeX/GsOqHo33hOcdylzXR63UXLRbxKMedodEiIqgOFUAI6GTox735iyL8Dw==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",


### PR DESCRIPTION
Levels this app with the fleet. `2.27.2` adds two fixes the earlier `2.27.0` pin does not carry:

1. **Headerless is no longer chromeless** — a flat KPI card inside a borderless wrapper had no card, border or background at all. Measured on buildiq: three tiles rendering as bare text.
2. **A stat `variant` paints from the `-text` tokens** rather than the fill tokens, which failed WCAG AA at **1.08:1** as a foreground colour. The KPI colour cleanup converted hardcoded `valueColor` values to `variant`, so this is what makes those conversions contrast-safe.

Lockfile only, and npm pruned nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)