### PR TITLE
docs(license): state the apexcharts licence accurately in the override

### DIFF
--- a/.license-overrides.json
+++ b/.license-overrides.json
@@ -1,6 +1,6 @@
 {
 	"@fortawesome/free-solid-svg-icons": "License is (CC-BY-4.0 AND MIT) — both are approved open-source licenses, compound AND expression not parsed by checker",
 	"smalot/pdfparser": "License is LGPL-3.0 — equivalent to LGPL-3.0-only which is on the allowlist, SPDX identifier variation not recognized by checker",
-	"apexcharts": "License is MIT — license-checker misreads logo URL as custom license, see https://github.com/apexcharts/apexcharts.js/blob/main/LICENSE",
+	"apexcharts": "License is NOT MIT from 6.0.0 onward and this override is a deliberate acceptance, not a checker correction. 4.7.0 and 5.0.0 are MIT; 6.0.0+ ship a dual-license (SEE LICENSE IN LICENSE): free under a Community License for organisations below USD 2M annual revenue, paid above it, and sublicensing under different terms is not permitted. Conduction confirmed 2026-08-31 that it is below that threshold and so qualifies. NOTE for redistribution: the Community License binds the ORGANISATION USING the software, so an installing tenant above USD 2M needs its own commercial license -- this app is distributed via the Nextcloud App Store. Revisit if that becomes a problem; apexcharts 5.x is the last MIT release.",
 	"dompdf/dompdf": "License is LGPL-2.1 — equivalent to LGPL-2.1-or-later which is on the allowlist; configured hermetically (isRemoteEnabled=false / isPhpEnabled=false) at the single instantiation site PdfReportWriter:69"
 }


### PR DESCRIPTION
The override read:

> `"apexcharts": "License is MIT — license-checker misreads logo URL as custom license"`

**That was true once and is not true now.** apexcharts stopped being MIT at **6.0.0**:

| version | licence |
| --- | --- |
| 4.7.0, 5.0.0 | `MIT` |
| 6.0.0, 7.0.0 | `SEE LICENSE IN LICENSE` |

This app declares `apexcharts: ^7.0.0` and locks **7.0.0**. So the checker flagging it is **correct**, and the override was suppressing a true finding rather than correcting a false one — the licence gate has been reporting green on a dependency that is not open source.

### What changes

Nothing about the dependency. apexcharts 7 stays. What changes is that the file now says what is actually true:

- 6.0.0+ ship a **dual licence**: free under a Community License for organisations below **USD 2M** annual revenue, paid above it, and sublicensing under different terms is not permitted.
- Conduction confirmed **2026-08-31** that it is below that threshold and so qualifies under the Community License.
- The override is therefore a **deliberate acceptance — dated and attributed** — not a claim that the checker is wrong.

### The redistribution question, recorded not decided

The Community License binds the organisation **using** the software, not only the one shipping it, and this app is distributed through the Nextcloud App Store. An installing tenant above USD 2M would need its own commercial licence. That is flagged in the note for a decision; it is not decided here.

### Context

dossiq is on apexcharts **4.7.0 (MIT)** with no override, and its bump to 7.0.0 was closed today on exactly these grounds (dossiq#1527). apexcharts **5.x is the last MIT release** if the fleet ever needs to return to one.

An override that states a falsehood is worse than no override: it makes the gate assert something the maintainers would not agree with if asked. This makes the file honest either way the licence decision eventually goes.
