### PR TITLE
chore(sync): carry main back into beta

### DIFF
--- a/tests/Unit/Db/MagicMapper/MagicMapperFindInRegisterSchemaTableAccessControlTest.php
+++ b/tests/Unit/Db/MagicMapper/MagicMapperFindInRegisterSchemaTableAccessControlTest.php
@@ -223,7 +223,7 @@ class MagicMapperFindInRegisterSchemaTableAccessControlTest extends TestCase {
 				_multitenancy: true
 			);
 			$this->fail('empty DB result should have raised DoesNotExistException');
-		} catch (DoesNotExistException $e) {
+		} catch (DoesNotExistException) {
 			// Expected — assertion is about the seam call, not the return.
 		}
 
@@ -250,7 +250,7 @@ class MagicMapperFindInRegisterSchemaTableAccessControlTest extends TestCase {
 				_multitenancy: true
 			);
 			$this->fail('empty DB result should have raised DoesNotExistException');
-		} catch (DoesNotExistException $e) {
+		} catch (DoesNotExistException) {
 			// Expected.
 		}
 
@@ -277,7 +277,7 @@ class MagicMapperFindInRegisterSchemaTableAccessControlTest extends TestCase {
 				_multitenancy: false
 			);
 			$this->fail('empty DB result should have raised DoesNotExistException');
-		} catch (DoesNotExistException $e) {
+		} catch (DoesNotExistException) {
 			// Expected.
 		}
 
@@ -299,7 +299,7 @@ class MagicMapperFindInRegisterSchemaTableAccessControlTest extends TestCase {
 				schema: $this->makeSchema(id: 5)
 			);
 			$this->fail('empty DB result should have raised DoesNotExistException');
-		} catch (DoesNotExistException $e) {
+		} catch (DoesNotExistException) {
 			// Expected.
 		}
 

--- a/tests/Unit/Db/MagicMapper/MagicMapperFindInRegisterSchemaTableAccessControlTest.php
+++ b/tests/Unit/Db/MagicMapper/MagicMapperFindInRegisterSchemaTableAccessControlTest.php
@@ -1,0 +1,311 @@
+<?php
+
+/**
+ * Regression tests for MagicMapper::findInRegisterSchemaTable() RBAC wire-up.
+ *
+ * WOO-545 flagged a comment-only placeholder in this method where RBAC
+ * filtering used to be skipped:
+ *
+ *     // Apply RBAC filtering if enabled.
+ *     if ($_rbac === true) {
+ *         // Add RBAC filtering logic here if needed.
+ *         // Currently skipped as owner/authorization logic is complex.
+ *     }
+ *
+ * Commit 71c6b7e47 (2026-06-11) "fix(rbac): close cross-org single-GET IDOR"
+ * replaced that placeholder with a proper delegation to
+ * `MagicSearchHandler::applyAccessControlToQuery()`, so the scoped
+ * single-object read now enforces the same isolation as the list/search path.
+ *
+ * These unit tests pin the resulting contract at the class boundary — a
+ * sibling to the existing `MagicMapperFindAcrossAllMagicTablesAccessControlTest`
+ * (which covers the cross-schema fallback path) and complement the
+ * `MagicMapperIntegrationTest` scenarios that exercise the same call against a
+ * real database.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Db\MagicMapper;
+
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\MagicMapper\MagicSearchHandler;
+use OCA\OpenRegister\Db\MagicMapper\MagicTableHandler;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\DB\IResult;
+use OCP\DB\QueryBuilder\ICompositeExpression;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IAppConfig;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+class MagicMapperFindInRegisterSchemaTableAccessControlTest extends TestCase {
+
+	private IDBConnection&MockObject $db;
+
+	private SchemaMapper&MockObject $schemaMapper;
+
+	private RegisterMapper&MockObject $registerMapper;
+
+	private MagicSearchHandler&MockObject $searchHandler;
+
+	private MagicTableHandler&MockObject $tableHandler;
+
+	/**
+	 * @var array<int, array{schemaId: int|null, _rbac: bool, _multitenancy: bool}>
+	 */
+	private array $accessControlCalls = [];
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->db = $this->createMock(IDBConnection::class);
+		$this->schemaMapper = $this->createMock(SchemaMapper::class);
+		$this->registerMapper = $this->createMock(RegisterMapper::class);
+		$this->searchHandler = $this->createMock(MagicSearchHandler::class);
+		$this->tableHandler = $this->createMock(MagicTableHandler::class);
+		$this->accessControlCalls = [];
+
+		// Record every applyAccessControlToQuery() call so tests can assert
+		// the seam was consulted (or NOT consulted, in the bypass case) with
+		// the expected _rbac / _multitenancy arguments.
+		$this->searchHandler->method('applyAccessControlToQuery')->willReturnCallback(
+			function (IQueryBuilder $qb, Schema $schema, bool $_rbac = true, bool $_multitenancy = true): void {
+				$this->accessControlCalls[] = [
+					'schemaId' => $schema->getId(),
+					'_rbac' => $_rbac,
+					'_multitenancy' => $_multitenancy,
+				];
+			}
+		);
+	}//end setUp()
+
+	/**
+	 * Build a MagicMapper wired with the mocked table + search handlers.
+	 *
+	 * `applyAccessControlToQuery` is a void mutator on the real class — the
+	 * mock does not need to actually modify the query builder. It just
+	 * records that the call was (or wasn't) made. The DB driver is stubbed
+	 * to return an EMPTY result so the method throws DoesNotExistException,
+	 * which the assertions below expect.
+	 */
+	private function makeMapper(): MagicMapper {
+		$config = $this->createMock(IConfig::class);
+
+		// The MagicMapper constructor eagerly boots MagicRbacHandler +
+		// dependents via the container. Route the minimum handful of
+		// container resolves to mocks so the constructor doesn't blow up
+		// on missing typed args (ConditionMatcher, etc.).
+		$container = $this->createMock(ContainerInterface::class);
+		$container->method('get')->willReturnCallback(
+			function (string $id) {
+				return match ($id) {
+					\OCA\OpenRegister\Service\DateTimeNormalizer::class => $this->createMock(
+						\OCA\OpenRegister\Service\DateTimeNormalizer::class
+					),
+					\OCA\OpenRegister\Service\ConditionMatcher::class => $this->createMock(
+						\OCA\OpenRegister\Service\ConditionMatcher::class
+					),
+					\OCA\OpenRegister\Service\Object\SchemaTypeConverter::class => $this->createMock(
+						\OCA\OpenRegister\Service\Object\SchemaTypeConverter::class
+					),
+					default => null,
+				};
+			}
+		);
+
+		$mapper = new MagicMapper(
+			$this->db,
+			$this->schemaMapper,
+			$this->registerMapper,
+			$config,
+			$this->createMock(IEventDispatcher::class),
+			$this->createMock(IUserSession::class),
+			$this->createMock(IGroupManager::class),
+			$this->createMock(IUserManager::class),
+			$this->createMock(IAppConfig::class),
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(\OCA\OpenRegister\Service\SettingsService::class),
+			$container
+		);
+
+		// Route the two tableHandler probes findInRegisterSchemaTable calls
+		// (existsTableForRegisterSchema + getTableNameForRegisterSchema) at a
+		// stubbed handler so we don't need a real table setup.
+		$this->tableHandler->method('existsTableForRegisterSchema')->willReturn(true);
+		$this->tableHandler->method('getTableNameForRegisterSchema')->willReturn('oc_openregister_table_1_2');
+
+		$tableHandlerProperty = new \ReflectionProperty(MagicMapper::class, 'tableHandler');
+		$tableHandlerProperty->setAccessible(true);
+		$tableHandlerProperty->setValue($mapper, $this->tableHandler);
+
+		$searchProperty = new \ReflectionProperty(MagicMapper::class, 'searchHandler');
+		$searchProperty->setAccessible(true);
+		$searchProperty->setValue($mapper, $this->searchHandler);
+
+		// Empty result → row === false → DoesNotExistException. This lets us
+		// exercise the RBAC-wire branch without also stubbing the row
+		// conversion pipeline.
+		$this->db->method('getQueryBuilder')->willReturnCallback(fn () => $this->makeEmptyQueryBuilder());
+
+		return $mapper;
+	}//end makeMapper()
+
+	private function makeEmptyQueryBuilder(): IQueryBuilder {
+		$expr = $this->createMock(IExpressionBuilder::class);
+		$expr->method('eq')->willReturn('eq');
+		$expr->method('isNull')->willReturn('isNull');
+		$expr->method('orX')->willReturn($this->createMock(ICompositeExpression::class));
+
+		$qb = $this->createMock(IQueryBuilder::class);
+		$qb->method('expr')->willReturn($expr);
+		$qb->method('select')->willReturnSelf();
+		$qb->method('from')->willReturnSelf();
+		$qb->method('where')->willReturnSelf();
+		$qb->method('andWhere')->willReturnSelf();
+		$qb->method('createNamedParameter')->willReturn(':param');
+
+		$result = $this->createMock(IResult::class);
+		$result->method('fetch')->willReturn(false);
+		$qb->method('executeQuery')->willReturn($result);
+
+		return $qb;
+	}//end makeEmptyQueryBuilder()
+
+	private function makeSchema(int $id): Schema {
+		$schema = new Schema();
+		$schema->setId($id);
+		return $schema;
+	}//end makeSchema()
+
+	private function makeRegister(int $id): Register {
+		$register = new Register();
+		$register->setId($id);
+		return $register;
+	}//end makeRegister()
+
+	/*
+	 * ------------------------------------------------------------------- tests
+	 */
+
+	/**
+	 * THE FIX: `_rbac: true` (the default) must consult
+	 * `applyAccessControlToQuery()` with the SAME `_rbac`/`_multitenancy` flags
+	 * so the scoped single-object read enforces schema-level RBAC + org
+	 * isolation. Prior to commit 71c6b7e47 this was a comment-only placeholder
+	 * (WOO-545 was filed against that shape).
+	 */
+	public function testRbacTrueInvokesAccessControlSeam(): void {
+		$mapper = $this->makeMapper();
+
+		try {
+			$mapper->findInRegisterSchemaTable(
+				identifier: 'uuid-authorized',
+				register: $this->makeRegister(id: 1),
+				schema: $this->makeSchema(id: 2),
+				_rbac: true,
+				_multitenancy: true
+			);
+			$this->fail('empty DB result should have raised DoesNotExistException');
+		} catch (DoesNotExistException $e) {
+			// Expected — assertion is about the seam call, not the return.
+		}
+
+		$this->assertCount(1, $this->accessControlCalls, 'the access-control seam MUST be consulted when _rbac is true');
+		$this->assertSame(2, $this->accessControlCalls[0]['schemaId']);
+		$this->assertTrue($this->accessControlCalls[0]['_rbac']);
+		$this->assertTrue($this->accessControlCalls[0]['_multitenancy']);
+	}//end testRbacTrueInvokesAccessControlSeam()
+
+	/**
+	 * `_rbac: false` alone still consults the seam — multitenancy is a
+	 * separate axis (org isolation) that must still be enforced for
+	 * non-admin sessions.
+	 */
+	public function testRbacFalseButMultitenancyTrueStillInvokesSeam(): void {
+		$mapper = $this->makeMapper();
+
+		try {
+			$mapper->findInRegisterSchemaTable(
+				identifier: 'uuid-something',
+				register: $this->makeRegister(id: 1),
+				schema: $this->makeSchema(id: 3),
+				_rbac: false,
+				_multitenancy: true
+			);
+			$this->fail('empty DB result should have raised DoesNotExistException');
+		} catch (DoesNotExistException $e) {
+			// Expected.
+		}
+
+		$this->assertCount(1, $this->accessControlCalls);
+		$this->assertFalse($this->accessControlCalls[0]['_rbac']);
+		$this->assertTrue($this->accessControlCalls[0]['_multitenancy']);
+	}//end testRbacFalseButMultitenancyTrueStillInvokesSeam()
+
+	/**
+	 * Both `_rbac: false` AND `_multitenancy: false` — the admin/system-context
+	 * bypass — MUST skip the access-control seam entirely, matching the
+	 * long-standing contract for internal callers (e.g. LockHandler,
+	 * WOO536RepairReadRules::run).
+	 */
+	public function testFullBypassSkipsAccessControlSeam(): void {
+		$mapper = $this->makeMapper();
+
+		try {
+			$mapper->findInRegisterSchemaTable(
+				identifier: 'uuid-admin-context',
+				register: $this->makeRegister(id: 1),
+				schema: $this->makeSchema(id: 4),
+				_rbac: false,
+				_multitenancy: false
+			);
+			$this->fail('empty DB result should have raised DoesNotExistException');
+		} catch (DoesNotExistException $e) {
+			// Expected.
+		}
+
+		$this->assertSame([], $this->accessControlCalls, 'the access-control seam MUST NOT be consulted when both flags are false');
+	}//end testFullBypassSkipsAccessControlSeam()
+
+	/**
+	 * The default parameter values (both true) must exercise the seam — a
+	 * caller that omits the flags entirely must NOT accidentally get the
+	 * admin bypass path.
+	 */
+	public function testDefaultFlagsInvokeAccessControlSeam(): void {
+		$mapper = $this->makeMapper();
+
+		try {
+			$mapper->findInRegisterSchemaTable(
+				identifier: 'uuid-defaults',
+				register: $this->makeRegister(id: 1),
+				schema: $this->makeSchema(id: 5)
+			);
+			$this->fail('empty DB result should have raised DoesNotExistException');
+		} catch (DoesNotExistException $e) {
+			// Expected.
+		}
+
+		$this->assertCount(1, $this->accessControlCalls);
+		$this->assertTrue($this->accessControlCalls[0]['_rbac']);
+		$this->assertTrue($this->accessControlCalls[0]['_multitenancy']);
+	}//end testDefaultFlagsInvokeAccessControlSeam()
+
+}//end class

--- a/tests/Unit/Db/MagicSearchHandlerTest.php
+++ b/tests/Unit/Db/MagicSearchHandlerTest.php
@@ -305,6 +305,10 @@ class MagicSearchHandlerTest extends TestCase {
 	 * @param string $search Free-text search term.
 	 * @param array $properties Schema properties (field => ['type' => ...]).
 	 * @param bool $isPostgres Whether to render the PostgreSQL or MySQL flavour.
+	 * @param array $query Optional query dict (e.g. `['_fuzzy' => true]`) — the
+	 *                     production method reads `_fuzzy` from this dict, so
+	 *                     tests that exercise the fuzzy branch pass it here
+	 *                     instead of re-inlining the reflection call.
 	 *
 	 * @return string|null Generated SQL condition string (or null when empty).
 	 */
@@ -312,6 +316,7 @@ class MagicSearchHandlerTest extends TestCase {
 		string $search,
 		array $properties,
 		bool $isPostgres,
+		array $query = [],
 	): ?string {
 		$schema = $this->createMock(Schema::class);
 		$schema->method('getProperties')->willReturn($properties);
@@ -323,7 +328,7 @@ class MagicSearchHandlerTest extends TestCase {
 			$this->handler,
 			$search,
 			$schema,
-			[],
+			$query,
 			$this->makeConnection(),
 			$isPostgres,
 			null
@@ -439,20 +444,11 @@ class MagicSearchHandlerTest extends TestCase {
 		$hasPgTrgmProp->setAccessible(true);
 		$hasPgTrgmProp->setValue($this->handler, false);
 
-		$schema = $this->createMock(Schema::class);
-		$schema->method('getProperties')->willReturn(['title' => ['type' => 'string']]);
-
-		$method = new ReflectionMethod(MagicSearchHandler::class, 'buildSearchConditionSql');
-		$method->setAccessible(true);
-
-		$sql = $method->invoke(
-			$this->handler,
-			'foo',
-			$schema,
-			['_fuzzy' => true],
-			$this->makeConnection(),
-			false,
-			null
+		$sql = $this->invokeBuildSearchConditionSql(
+			search: 'foo',
+			properties: ['title' => ['type' => 'string']],
+			isPostgres: false,
+			query: ['_fuzzy' => true]
 		);
 
 		$this->assertNotNull($sql);

--- a/tests/Unit/Db/MagicSearchHandlerTest.php
+++ b/tests/Unit/Db/MagicSearchHandlerTest.php
@@ -374,6 +374,93 @@ class MagicSearchHandlerTest extends TestCase {
 	}//end testBuildSearchConditionSqlQuotesEveryStringPropertyOnPostgres()
 
 	// -------------------------------------------------------------------------
+	// WOO-544 regression guards: buildSearchConditionSql() must never emit
+	// PostgreSQL-specific syntax (`::text ILIKE`, `similarity()`) on the MariaDB
+	// / MySQL flavour, or the entire arm of a multi-schema search silently
+	// swallows a syntax error and returns an empty resultset.
+	// -------------------------------------------------------------------------
+
+	public function testBuildSearchConditionSqlNeverEmitsPgTextCastOnMySql(): void {
+		$sql = $this->invokeBuildSearchConditionSql(
+			search: 'foo',
+			properties: [
+				'title' => ['type' => 'string'],
+				'description' => ['type' => 'string'],
+			],
+			isPostgres: false
+		);
+
+		$this->assertNotNull($sql);
+		// Neither the schema-property casts nor the metadata-field casts may use
+		// PostgreSQL's `::text` syntax on the MariaDB path — that is the exact
+		// silent-empty-resultset defect WOO-544 was filed to catch.
+		$this->assertStringNotContainsString('::text', $sql);
+		$this->assertStringNotContainsString('ILIKE', $sql);
+	}//end testBuildSearchConditionSqlNeverEmitsPgTextCastOnMySql()
+
+	public function testBuildSearchConditionSqlEmitsLowerCastForMetadataOnMySql(): void {
+		$sql = $this->invokeBuildSearchConditionSql(
+			search: 'foo',
+			properties: [],
+			isPostgres: false
+		);
+
+		$this->assertNotNull($sql);
+		// MariaDB path wraps each metadata column and the pattern in LOWER()
+		// so it stays case-insensitive regardless of collation.
+		$this->assertStringContainsString('LOWER(CAST(_name AS CHAR)) LIKE LOWER(', $sql);
+		$this->assertStringContainsString('LOWER(CAST(_description AS CHAR)) LIKE LOWER(', $sql);
+		$this->assertStringContainsString('LOWER(CAST(_summary AS CHAR)) LIKE LOWER(', $sql);
+	}//end testBuildSearchConditionSqlEmitsLowerCastForMetadataOnMySql()
+
+	public function testBuildSearchConditionSqlEmitsPgTextCastForMetadataOnPostgres(): void {
+		$sql = $this->invokeBuildSearchConditionSql(
+			search: 'foo',
+			properties: [],
+			isPostgres: true
+		);
+
+		$this->assertNotNull($sql);
+		// PostgreSQL path keeps `_name::text ILIKE` because ILIKE is
+		// case-insensitive natively; the platform-branch must not regress.
+		$this->assertStringContainsString('_name::text ILIKE', $sql);
+		$this->assertStringContainsString('_description::text ILIKE', $sql);
+		$this->assertStringContainsString('_summary::text ILIKE', $sql);
+	}//end testBuildSearchConditionSqlEmitsPgTextCastForMetadataOnPostgres()
+
+	public function testBuildSearchConditionSqlWithFuzzyOnMySqlDoesNotEmitSimilarity(): void {
+		// The `_fuzzy=true` param is honoured only when pg_trgm is available.
+		// hasPgTrgmExtension() short-circuits to false on non-PostgreSQL, so
+		// even a client-supplied _fuzzy MUST NOT emit similarity() on MariaDB.
+		// We prime the cached hasPgTrgm=false directly so the test doesn't need
+		// a full IDBConnection platform mock — the platform-branch semantics in
+		// buildSearchConditionSql are the SUT here, not the pg_trgm probe.
+		$hasPgTrgmProp = new \ReflectionProperty(MagicSearchHandler::class, 'hasPgTrgm');
+		$hasPgTrgmProp->setAccessible(true);
+		$hasPgTrgmProp->setValue($this->handler, false);
+
+		$schema = $this->createMock(Schema::class);
+		$schema->method('getProperties')->willReturn(['title' => ['type' => 'string']]);
+
+		$method = new ReflectionMethod(MagicSearchHandler::class, 'buildSearchConditionSql');
+		$method->setAccessible(true);
+
+		$sql = $method->invoke(
+			$this->handler,
+			'foo',
+			$schema,
+			['_fuzzy' => true],
+			$this->makeConnection(),
+			false,
+			null
+		);
+
+		$this->assertNotNull($sql);
+		$this->assertStringNotContainsString('similarity(', $sql);
+		$this->assertStringNotContainsString('::text', $sql);
+	}//end testBuildSearchConditionSqlWithFuzzyOnMySqlDoesNotEmitSimilarity()
+
+	// -------------------------------------------------------------------------
 	// Regression: `format: date-time` must round-trip as ISO-8601.
 	//
 	// A date-time property lives in a DATETIME column, so the driver hands it

--- a/tests/Unit/Db/RegisterTest.php
+++ b/tests/Unit/Db/RegisterTest.php
@@ -39,6 +39,10 @@ class RegisterTest extends TestCase {
 		$this->assertSame('json', $fieldTypes['groups']);
 		$this->assertSame('datetime', $fieldTypes['deleted']);
 		$this->assertSame('json', $fieldTypes['configuration']);
+		// Guards WOO-546 — the migration in beta introduced the `type` DB
+		// column; the Entity property + addType must be present or
+		// RegisterMapper row hydration throws "not a valid attribute".
+		$this->assertSame('string', $fieldTypes['type']);
 	}
 
 	public function testConstructorDefaultValues(): void {
@@ -102,6 +106,15 @@ class RegisterTest extends TestCase {
 	public function testSetAndGetFolder(): void {
 		$this->register->setFolder('/Documents/Registers');
 		$this->assertSame('/Documents/Registers', $this->register->getFolder());
+	}
+
+	public function testSetAndGetType(): void {
+		$this->register->setType('mock');
+		$this->assertSame('mock', $this->register->getType());
+	}
+
+	public function testTypeDefaultNull(): void {
+		$this->assertNull($this->register->getType());
 	}
 
 	public function testSetAndGetOwner(): void {

--- a/tests/Unit/Db/SchemaTest.php
+++ b/tests/Unit/Db/SchemaTest.php
@@ -34,7 +34,9 @@ class SchemaTest extends TestCase {
 		$this->assertSame('string', $types['source']);
 		$this->assertSame('boolean', $types['hardValidation']);
 		$this->assertSame('boolean', $types['immutable']);
+		$this->assertSame('boolean', $types['appendOnly']);
 		$this->assertSame('boolean', $types['searchable']);
+		$this->assertSame('boolean', $types['smartPickerEnabled']);
 		$this->assertSame('datetime', $types['updated']);
 		$this->assertSame('datetime', $types['created']);
 		$this->assertSame('integer', $types['maxDepth']);
@@ -547,6 +549,33 @@ class SchemaTest extends TestCase {
 	public function testSetSearchableFalse(): void {
 		$this->schema->setSearchable(false);
 		$this->assertFalse($this->schema->isSearchable());
+	}
+
+	// --- AppendOnly ---
+	// Guards WOO-546 — the migration Version1Date20260511110000 introduced
+	// the `append_only` DB column; the Entity property + addType must exist
+	// or SchemaMapper row hydration throws "not a valid attribute".
+
+	public function testIsAppendOnlyDefaultFalse(): void {
+		$this->assertFalse($this->schema->isAppendOnly());
+	}
+
+	public function testSetAppendOnlyTrue(): void {
+		$this->schema->setAppendOnly(true);
+		$this->assertTrue($this->schema->isAppendOnly());
+	}
+
+	// --- SmartPickerEnabled ---
+	// Guards WOO-546 — the migration Version1Date20260817120000 introduced
+	// the `smart_picker_enabled` DB column; same round-trip contract.
+
+	public function testIsSmartPickerEnabledDefaultFalse(): void {
+		$this->assertFalse($this->schema->isSmartPickerEnabled());
+	}
+
+	public function testSetSmartPickerEnabledTrue(): void {
+		$this->schema->setSmartPickerEnabled(true);
+		$this->assertTrue($this->schema->isSmartPickerEnabled());
 	}
 
 	// --- __toString ---

--- a/tests/Unit/Db/SchemaTest.php
+++ b/tests/Unit/Db/SchemaTest.php
@@ -565,6 +565,12 @@ class SchemaTest extends TestCase {
 		$this->assertTrue($this->schema->isAppendOnly());
 	}
 
+	public function testSetAppendOnlyFalse(): void {
+		$this->schema->setAppendOnly(true);
+		$this->schema->setAppendOnly(false);
+		$this->assertFalse($this->schema->isAppendOnly());
+	}
+
 	// --- SmartPickerEnabled ---
 	// Guards WOO-546 — the migration Version1Date20260817120000 introduced
 	// the `smart_picker_enabled` DB column; same round-trip contract.
@@ -576,6 +582,12 @@ class SchemaTest extends TestCase {
 	public function testSetSmartPickerEnabledTrue(): void {
 		$this->schema->setSmartPickerEnabled(true);
 		$this->assertTrue($this->schema->isSmartPickerEnabled());
+	}
+
+	public function testSetSmartPickerEnabledFalse(): void {
+		$this->schema->setSmartPickerEnabled(true);
+		$this->schema->setSmartPickerEnabled(false);
+		$this->assertFalse($this->schema->isSmartPickerEnabled());
 	}
 
 	// --- __toString ---


### PR DESCRIPTION
`main` held 9 commit(s) `beta` did not — release version bumps committed onto the branch the release ran from, and anything else that arrived out of band. Left unreconciled, both branches change the version file independently and the next `beta` → `main` promotion conflicts on it.

**4 file(s) change.** A 0-file result is the normal and correct outcome once the content has already reached `beta` by other means — recording the ancestry *is* the payload. Without it the merge base never moves and the next promotion conflicts exactly as before.

Version files were resolved to `beta`'s side, whose line is ahead of the released one, so this never moves a version backwards. Any conflict outside them aborts the merge for a human instead.

Opened by fleet-back-merge.yml, using the algorithm `release.yml` already applies to its own `sync/*-to-development` pull requests.