### PR TITLE
fix(db): remove an impossible lastInsertId fallback and a duplicate getter

### DIFF
--- a/lib/Db/CaseToken.php
+++ b/lib/Db/CaseToken.php
@@ -43,7 +43,6 @@ use OCP\AppFramework\Db\Entity;
  * Class CaseToken
  *
  * @method string|null getToken()
- * @method void getToken(?string $token)
  * @method void setToken(?string $token)
  * @method string|null getObjectUuid()
  * @method void setObjectUuid(?string $objectUuid)

--- a/lib/Service/PollLinkService.php
+++ b/lib/Service/PollLinkService.php
@@ -425,11 +425,13 @@ class PollLinkService {
 				);
 			$insert->executeStatement();
 
+			// OCP\IDBConnection::lastInsertId(string $table) REQUIRES the table.
+			// The old fallback called it with no argument, so on exactly the
+			// drivers it was written for it raised ArgumentCountError, which the
+			// catch below reported as "Failed to create poll", a message that
+			// blames the insert rather than the retrieval. A zero here now falls
+			// through to the explicit throw, which says what actually happened.
 			$pollId = (int)$this->db->lastInsertId('oc_polls_polls_id_seq');
-			if ($pollId === 0) {
-				// Fallback for drivers without sequence support.
-				$pollId = (int)$this->db->lastInsertId();
-			}
 
 			if ($pollId === 0) {
 				throw new Exception('Failed to retrieve created poll id', 500);

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -182,12 +182,6 @@
       <code><![CDATA[CalDavBackend]]></code>
     </UndefinedClass>
   </file>
-  <file src="lib/Service/CaseTokenService.php">
-    <TooFewArguments>
-      <code><![CDATA[$row->getToken()]]></code>
-      <code><![CDATA[$row->getToken()]]></code>
-    </TooFewArguments>
-  </file>
   <file src="lib/Service/Chat/ConversationManagementHandler.php">
     <UndefinedPropertyAssignment>
       <code><![CDATA[$config->temperature]]></code>
@@ -336,12 +330,6 @@
       <code><![CDATA[$e]]></code>
       <code><![CDATA[\OC\DB\Exceptions\DbalException]]></code>
     </UndefinedClass>
-  </file>
-  <file src="lib/Service/PollLinkService.php">
-    <TooFewArguments>
-      <code><![CDATA[lastInsertId]]></code>
-      <code><![CDATA[lastInsertId]]></code>
-    </TooFewArguments>
   </file>
   <file src="lib/Service/RegisterResolverService.php">
     <UnusedParam>


### PR DESCRIPTION
Two more baseline entries that turned out to be real defects. **184 -> 180.**

### A fallback that could never run

```php
$pollId = (int)$this->db->lastInsertId("oc_polls_polls_id_seq");
if ($pollId === 0) {
    // Fallback for drivers without sequence support.
    $pollId = (int)$this->db->lastInsertId();
}
```

`OCP\IDBConnection::lastInsertId(string $table): int` takes a **required** argument. The no-arg call raises `ArgumentCountError` on precisely the drivers the fallback existed for, and the surrounding `catch (Throwable)` reported it as `Failed to create poll` — blaming the insert rather than the id retrieval. A zero now falls through to the explicit throw that was already there.

I checked the other four `lastInsertId` call sites: `MagicMapper` and `DedupCollidedSchemasCommand` pass a table; `DbalObjectSourceProvider` calls it with no argument but on a DBAL `Connection`, where the parameter is optional. Psalm flagged only the one that was wrong.

### A getter declared twice

```
@method string|null getToken()
@method void getToken(?string $token)   <- copy-paste of the setter
@method void setToken(?string $token)
```

Psalm binds to the second declaration, which is why two perfectly correct `$row->getToken()` calls read as *Too few arguments*. Removed; `setToken` on the next line was already correct. I swept all of `lib/Db` for the same slip and this was the only instance.

### Verification

`vendor/bin/psalm` 5.26.1 on PHP 8.3: all four `TooFewArguments` gone, errors with the baseline emptied went **184 -> 180**, regenerated baseline green.

PHPUnit **not** run locally (needs the server bootstrap). No constructor signatures changed here, so there is no positional-argument shift to check this time.