### PR TITLE
fix(archival): call a mapper method that exists, and correct a @throws

### DIFF
--- a/lib/Controller/ArchivalController.php
+++ b/lib/Controller/ArchivalController.php
@@ -184,7 +184,7 @@ class ArchivalController extends Controller {
 		}
 
 		try {
-			$object = $this->objectMapper->findByUuid($id);
+			$object = $this->objectMapper->find($id);
 			return new JSONResponse(
 				data: $object->jsonSerialize(),
 				statusCode: Http::STATUS_OK
@@ -221,7 +221,7 @@ class ArchivalController extends Controller {
 		$exclusionReasons = $params['exclusionReasons'] ?? [];
 
 		try {
-			$object = $this->objectMapper->findByUuid($id);
+			$object = $this->objectMapper->find($id);
 			$destructionList = $object->getObject() ?? [];
 
 			// Check for dual-approval requirement based on schema config.
@@ -304,7 +304,7 @@ class ArchivalController extends Controller {
 		}
 
 		try {
-			$object = $this->objectMapper->findByUuid($id);
+			$object = $this->objectMapper->find($id);
 			$destructionList = $object->getObject() ?? [];
 
 			$result = $this->destructionService->rejectList($destructionList, $reason);
@@ -389,7 +389,7 @@ class ArchivalController extends Controller {
 				);
 			}
 
-			$object = $this->objectMapper->findByUuid($objectId);
+			$object = $this->objectMapper->find($objectId);
 			$result = $this->legalHoldService->placeHold($object, $reason);
 
 			return new JSONResponse(
@@ -445,7 +445,7 @@ class ArchivalController extends Controller {
 		}
 
 		try {
-			$object = $this->objectMapper->findByUuid($id);
+			$object = $this->objectMapper->find($id);
 			$result = $this->legalHoldService->releaseHold($object, $reason);
 
 			return new JSONResponse(

--- a/lib/Service/Archival/DestructionService.php
+++ b/lib/Service/Archival/DestructionService.php
@@ -505,7 +505,7 @@ class DestructionService {
 	 */
 	private function extendArchiveActionDate(string $uuid, string $extensionPeriod, string $reason): void {
 		try {
-			$object = $this->objectMapper->findByUuid($uuid);
+			$object = $this->objectMapper->find($uuid);
 			$retention = $object->getRetention() ?? [];
 
 			$currentDate = $retention['archiefactiedatum'] ?? null;

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -2519,7 +2519,8 @@ class ObjectService implements ObjectServiceInterface
      *
      * @return void
      *
-     * @throws \OCP\AppFramework\Http\ContentSecurityPolicy
+     * @throws \OCP\AppFramework\Db\DoesNotExistException When the object has been
+     *         transferred to e-Depot and is therefore read-only.
      *
      * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md
      */

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -38,15 +38,6 @@
       <code><![CDATA[array]]></code>
     </LessSpecificImplementedReturnType>
   </file>
-  <file src="lib/Controller/ArchivalController.php">
-    <UndefinedMethod>
-      <code><![CDATA[findByUuid]]></code>
-      <code><![CDATA[findByUuid]]></code>
-      <code><![CDATA[findByUuid]]></code>
-      <code><![CDATA[findByUuid]]></code>
-      <code><![CDATA[findByUuid]]></code>
-    </UndefinedMethod>
-  </file>
   <file src="lib/Controller/GraphQLController.php">
     <UndefinedClass>
       <code><![CDATA[$this->csrfManager]]></code>
@@ -131,11 +122,6 @@
   <file src="lib/Service/ActionExecutor.php">
     <UndefinedMethod>
       <code><![CDATA[getModifiedData]]></code>
-    </UndefinedMethod>
-  </file>
-  <file src="lib/Service/Archival/DestructionService.php">
-    <UndefinedMethod>
-      <code><![CDATA[findByUuid]]></code>
     </UndefinedMethod>
   </file>
   <file src="lib/Service/AuthorizationService.php">
@@ -305,11 +291,6 @@
     <UnusedParam>
       <code><![CDATA[$schemaType]]></code>
     </UnusedParam>
-  </file>
-  <file src="lib/Service/ObjectService.php">
-    <InvalidThrow>
-      <code><![CDATA[\OCP\AppFramework\Http\ContentSecurityPolicy]]></code>
-    </InvalidThrow>
   </file>
   <file src="lib/Service/ObjectSource/DbalObjectSourceProvider.php">
     <TooManyArguments>

--- a/tests/Unit/Controller/ArchivalControllerTest.php
+++ b/tests/Unit/Controller/ArchivalControllerTest.php
@@ -54,8 +54,11 @@ class ArchivalControllerTest extends TestCase {
 		// list (openregister#393 D3). Without it the real MagicMapper::update() runs.
 		$this->objectMapper = $this->getMockBuilder(MagicMapper::class)
 			->disableOriginalConstructor()
-			->onlyMethods(['update'])
-			->addMethods(['findByUuid'])
+			// `find` is stubbed with onlyMethods, NOT addMethods. addMethods
+			// invents a method the class does not have, which is how
+			// `findByUuid` passed here for so long while production raised
+			// `Call to undefined method` on every archival endpoint.
+			->onlyMethods(['update', 'find'])
 			->getMock();
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
@@ -230,7 +233,7 @@ class ArchivalControllerTest extends TestCase {
 		$object->method('jsonSerialize')->willReturn(['uuid' => 'dl-1', 'status' => 'in_review']);
 
 		$this->objectMapper
-			->method('findByUuid')
+			->method('find')
 			->with('dl-1')
 			->willReturn($object);
 
@@ -247,7 +250,7 @@ class ArchivalControllerTest extends TestCase {
 		$this->setUpArchivist();
 
 		$this->objectMapper
-			->method('findByUuid')
+			->method('find')
 			->willThrowException(new \Exception('Not found'));
 
 		$response = $this->controller->getDestructionList('non-existent');
@@ -273,7 +276,7 @@ class ArchivalControllerTest extends TestCase {
 		]);
 
 		$this->objectMapper
-			->method('findByUuid')
+			->method('find')
 			->with('dl-1')
 			->willReturn($object);
 
@@ -315,7 +318,7 @@ class ArchivalControllerTest extends TestCase {
 		]);
 
 		$this->objectMapper
-			->method('findByUuid')
+			->method('find')
 			->with('dl-1')
 			->willReturn($object);
 
@@ -349,7 +352,7 @@ class ArchivalControllerTest extends TestCase {
 		]);
 
 		$this->objectMapper
-			->method('findByUuid')
+			->method('find')
 			->with('dl-1')
 			->willReturn($object);
 
@@ -375,7 +378,7 @@ class ArchivalControllerTest extends TestCase {
 		$this->setUpArchivist();
 
 		$this->objectMapper
-			->method('findByUuid')
+			->method('find')
 			->willThrowException(new \Exception('Not found'));
 
 		$this->request->method('getParams')->willReturn([]);
@@ -402,7 +405,7 @@ class ArchivalControllerTest extends TestCase {
 		]);
 
 		$this->objectMapper
-			->method('findByUuid')
+			->method('find')
 			->with('dl-1')
 			->willReturn($object);
 
@@ -463,7 +466,7 @@ class ArchivalControllerTest extends TestCase {
 		]);
 
 		$this->objectMapper
-			->method('findByUuid')
+			->method('find')
 			->willThrowException(new \Exception('Not found'));
 
 		$response = $this->controller->rejectDestructionList('non-existent');
@@ -494,7 +497,7 @@ class ArchivalControllerTest extends TestCase {
 		]);
 
 		$this->objectMapper
-			->method('findByUuid')
+			->method('find')
 			->with('obj-1')
 			->willReturn($object);
 
@@ -589,7 +592,7 @@ class ArchivalControllerTest extends TestCase {
 		]);
 
 		$this->objectMapper
-			->method('findByUuid')
+			->method('find')
 			->willThrowException(new \Exception('Object not found'));
 
 		$response = $this->controller->createLegalHold();
@@ -619,7 +622,7 @@ class ArchivalControllerTest extends TestCase {
 		]);
 
 		$this->objectMapper
-			->method('findByUuid')
+			->method('find')
 			->with('obj-1')
 			->willReturn($object);
 
@@ -660,7 +663,7 @@ class ArchivalControllerTest extends TestCase {
 		]);
 
 		$this->objectMapper
-			->method('findByUuid')
+			->method('find')
 			->willThrowException(new \Exception('Object not found'));
 
 		$response = $this->controller->releaseLegalHold('obj-1');

--- a/tests/Unit/Service/Archival/DestructionCertificateContentTest.php
+++ b/tests/Unit/Service/Archival/DestructionCertificateContentTest.php
@@ -80,7 +80,6 @@ class DestructionCertificateContentTest extends TestCase {
 		$objectMapper = $this->getMockBuilder(MagicMapper::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['update'])
-			->addMethods(['findByUuid'])
 			->getMock();
 
 		$this->destructionService = new DestructionService(

--- a/tests/Unit/Service/Archival/DestructionServiceTest.php
+++ b/tests/Unit/Service/Archival/DestructionServiceTest.php
@@ -45,8 +45,7 @@ class DestructionServiceTest extends TestCase {
 
 		$this->objectMapper = $this->getMockBuilder(MagicMapper::class)
 			->disableOriginalConstructor()
-			->onlyMethods(['update'])
-			->addMethods(['findByUuid'])
+			->onlyMethods(['update', 'find'])
 			->getMock();
 		$this->legalHoldService = $this->createMock(LegalHoldService::class);
 		$this->appConfig = $this->createMock(IAppConfig::class);
@@ -151,7 +150,7 @@ class DestructionServiceTest extends TestCase {
 			'archiefactiedatum' => '2025-01-01',
 		]);
 		$mockObject->expects($this->once())->method('setRetention');
-		$this->objectMapper->method('findByUuid')->willReturn($mockObject);
+		$this->objectMapper->method('find')->willReturn($mockObject);
 		$this->objectMapper->method('update')->willReturn($mockObject);
 
 		$list = [
@@ -190,7 +189,7 @@ class DestructionServiceTest extends TestCase {
 			->getMock();
 		$mockObject->method('getRetention')->willReturn(['archiefactiedatum' => '2025-01-01']);
 		$mockObject->expects($this->once())->method('setRetention');
-		$this->objectMapper->method('findByUuid')->willReturn($mockObject);
+		$this->objectMapper->method('find')->willReturn($mockObject);
 		$this->objectMapper->method('update')->willReturn($mockObject);
 
 		$list = [

--- a/tests/Unit/Service/Archival/LegalHoldServiceTest.php
+++ b/tests/Unit/Service/Archival/LegalHoldServiceTest.php
@@ -43,7 +43,6 @@ class LegalHoldServiceTest extends TestCase {
 		$this->objectMapper = $this->getMockBuilder(MagicMapper::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['update'])
-			->addMethods(['findByUuid'])
 			->getMock();
 		$this->auditTrailMapper = $this->createMock(AuditTrailMapper::class);
 		$this->userSession = $this->createMock(IUserSession::class);


### PR DESCRIPTION
Six calls to `MagicMapper::findByUuid()` — a method `MagicMapper` does not have.

Fourteen *other* mappers define `findByUuid`, which is exactly what makes the call look correct at a glance. `MagicMapper` is not one of them; `AbstractObjectMapper` only declares abstract `find` / `findAll` / `findMultiple` / `findBySchema`; and neither has `__call` or a trait supplying it.

### The failure mode is worse than a 404

`Call to undefined method` raises a PHP **`Error`**, and `Error` does not extend `Exception`. So the

```php
} catch (\Exception $e) {
    return new JSONResponse(["error" => "... not found"], 404);
```

wrapped around every one of these never catches it. Five archival endpoints and one destruction path answer with an **uncaught fatal** instead of the 404 they were written to return.

### The fix

`MagicMapper::find(string|int $identifier, ...)` is the method meant here. Its own docblock says the identifier may be an *"ID, UUID, slug, or URI"*, it returns `ObjectEntity`, and it throws `DoesNotExistException` when absent — which is precisely what these call sites expect and already catch.

Also corrected a `@throws` in `ObjectService::rejectIfTransferred` that named `\OCP\AppFramework\Http\ContentSecurityPolicy`, a CSP class rather than an exception. The method throws `DoesNotExistException`.

### Verification

`vendor/bin/psalm` 5.26.1 on PHP 8.3: errors with the baseline emptied went **180 -> 173**, regenerated baseline green. PHPUnit not run locally (needs the server bootstrap).