### PR TITLE
fix(chat): send temperature through modelOptions, where LLPhant reads it

### DIFF
--- a/lib/Service/Chat/ConversationManagementHandler.php
+++ b/lib/Service/Chat/ConversationManagementHandler.php
@@ -190,7 +190,7 @@ class ConversationManagementHandler {
 				$config->apiKey = $openaiConfig['apiKey'];
 				$config->model = 'gpt-4o-mini';
 
-				// modelOptions, NOT a property: OpenAIChat reads
+				// Through modelOptions, NOT a property: OpenAIChat reads
 				// $config->modelOptions and nothing in LLPhant reads a
 				// temperature property, so the old form was discarded silently.
 				$config->modelOptions['temperature'] = 0.7;
@@ -211,7 +211,7 @@ class ConversationManagementHandler {
 
 				$config->url = $baseUrl;
 
-				// modelOptions, NOT a property: OpenAIChat reads
+				// Through modelOptions, NOT a property: OpenAIChat reads
 				// $config->modelOptions and nothing in LLPhant reads a
 				// temperature property, so the old form was discarded silently.
 				$config->modelOptions['temperature'] = 0.7;

--- a/lib/Service/Chat/ConversationManagementHandler.php
+++ b/lib/Service/Chat/ConversationManagementHandler.php
@@ -190,8 +190,10 @@ class ConversationManagementHandler {
 				$config->apiKey = $openaiConfig['apiKey'];
 				$config->model = 'gpt-4o-mini';
 
-				// @psalm-suppress UndefinedPropertyAssignment LLPhant dynamic properties.
-				$config->temperature = 0.7;
+				// modelOptions, NOT a property: OpenAIChat reads
+				// $config->modelOptions and nothing in LLPhant reads a
+				// temperature property, so the old form was discarded silently.
+				$config->modelOptions['temperature'] = 0.7;
 			} elseif ($chatProvider === 'fireworks') {
 				$fireworksConfig = $llmConfig['fireworksConfig'] ?? [];
 				if (empty($fireworksConfig['apiKey']) === true) {
@@ -209,8 +211,10 @@ class ConversationManagementHandler {
 
 				$config->url = $baseUrl;
 
-				// @psalm-suppress UndefinedPropertyAssignment LLPhant dynamic properties.
-				$config->temperature = 0.7;
+				// modelOptions, NOT a property: OpenAIChat reads
+				// $config->modelOptions and nothing in LLPhant reads a
+				// temperature property, so the old form was discarded silently.
+				$config->modelOptions['temperature'] = 0.7;
 			}//end if
 
 			if ($chatProvider !== 'ollama' && $chatProvider !== 'openai' && $chatProvider !== 'fireworks') {

--- a/lib/Service/Chat/ResponseGenerationHandler.php
+++ b/lib/Service/Chat/ResponseGenerationHandler.php
@@ -270,21 +270,20 @@ class ResponseGenerationHandler {
 					$config->model = $agentModel;
 				}
 
-				if (empty($openaiConfig['organizationId']) === false) {
-					/*
-					 * @psalm-suppress UndefinedPropertyAssignment LLPhant dynamic properties
-					 */
-
-					$config->organizationId = $openaiConfig['organizationId'];
-				}
+				// organizationId is NOT set here. LLPhant has no organization
+				// support of any kind, so the previous assignment created a
+				// dynamic property nothing ever read. Dropping it removes the
+				// pretence rather than the behaviour: there was none.
 
 				// Set temperature from agent or default (OpenAI).
 				if ($agent?->getTemperature() !== null) {
-					/*
-					 * @psalm-suppress UndefinedPropertyAssignment LLPhant dynamic properties
-					 */
-
-					$config->temperature = $agent->getTemperature();
+					// modelOptions, NOT a property. OpenAIChat reads
+					// $config->modelOptions and sends it as the API arguments;
+					// nothing in LLPhant ever reads a temperature property, so
+					// the old assignment created a dynamic property that was
+					// silently discarded and the agent's temperature never
+					// reached the model.
+					$config->modelOptions['temperature'] = $agent->getTemperature();
 				}
 			} elseif ($chatProvider === 'fireworks') {
 				// Fireworks uses OpenAIConfig.
@@ -313,11 +312,13 @@ class ResponseGenerationHandler {
 
 				// Set temperature from agent or default (Fireworks).
 				if ($agent?->getTemperature() !== null) {
-					/*
-					 * @psalm-suppress UndefinedPropertyAssignment LLPhant dynamic properties
-					 */
-
-					$config->temperature = $agent->getTemperature();
+					// modelOptions, NOT a property. OpenAIChat reads
+					// $config->modelOptions and sends it as the API arguments;
+					// nothing in LLPhant ever reads a temperature property, so
+					// the old assignment created a dynamic property that was
+					// silently discarded and the agent's temperature never
+					// reached the model.
+					$config->modelOptions['temperature'] = $agent->getTemperature();
 				}
 			}//end if
 

--- a/lib/Service/Chat/ResponseGenerationHandler.php
+++ b/lib/Service/Chat/ResponseGenerationHandler.php
@@ -270,14 +270,14 @@ class ResponseGenerationHandler {
 					$config->model = $agentModel;
 				}
 
-				// organizationId is NOT set here. LLPhant has no organization
+				// OrganizationId is NOT set here. LLPhant has no organization
 				// support of any kind, so the previous assignment created a
 				// dynamic property nothing ever read. Dropping it removes the
 				// pretence rather than the behaviour: there was none.
 
 				// Set temperature from agent or default (OpenAI).
 				if ($agent?->getTemperature() !== null) {
-					// modelOptions, NOT a property. OpenAIChat reads
+					// Through modelOptions, NOT a property. OpenAIChat reads
 					// $config->modelOptions and sends it as the API arguments;
 					// nothing in LLPhant ever reads a temperature property, so
 					// the old assignment created a dynamic property that was
@@ -312,7 +312,7 @@ class ResponseGenerationHandler {
 
 				// Set temperature from agent or default (Fireworks).
 				if ($agent?->getTemperature() !== null) {
-					// modelOptions, NOT a property. OpenAIChat reads
+					// Through modelOptions, NOT a property. OpenAIChat reads
 					// $config->modelOptions and sends it as the API arguments;
 					// nothing in LLPhant ever reads a temperature property, so
 					// the old assignment created a dynamic property that was

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -168,18 +168,7 @@
       <code><![CDATA[CalDavBackend]]></code>
     </UndefinedClass>
   </file>
-  <file src="lib/Service/Chat/ConversationManagementHandler.php">
-    <UndefinedPropertyAssignment>
-      <code><![CDATA[$config->temperature]]></code>
-      <code><![CDATA[$config->temperature]]></code>
-    </UndefinedPropertyAssignment>
-  </file>
   <file src="lib/Service/Chat/ResponseGenerationHandler.php">
-    <UndefinedPropertyAssignment>
-      <code><![CDATA[$config->organizationId]]></code>
-      <code><![CDATA[$config->temperature]]></code>
-      <code><![CDATA[$config->temperature]]></code>
-    </UndefinedPropertyAssignment>
     <UnusedMethodCall>
       <code><![CDATA[setAccessible]]></code>
     </UnusedMethodCall>


### PR DESCRIPTION
Four assignments of `$config->temperature` and one of `$config->organizationId` on `LLPhant\OpenAIConfig`. **Neither is a property of that class**, so each created a dynamic property that nothing ever read. An agent temperature configured in the UI never reached the model.

The suppressions sitting above them said as much, and had been read the wrong way round:

```php
@psalm-suppress UndefinedPropertyAssignment LLPhant dynamic properties
```

LLPhant does not use dynamic properties. It reads `modelOptions`:

```
OpenAIChat.php:89   $this->modelOptions = $config->modelOptions;
OpenAIChat.php:368  $openAiArgs = $this->modelOptions;
```

and `OpenAIConfig`s own docblock lists `temperature` inside the `ModelOptions` **array shape**, not among its properties. Nothing in the library reads a `temperature` property anywhere. Temperature now goes to `$config->modelOptions["temperature"]`, which is what actually reaches the API.

`organizationId` is **removed** rather than relocated: LLPhant has no organization support of any kind, so there is nowhere for it to go. That drops the pretence, not the behaviour, because there was none.

Worth noting PHP 8.2 deprecated dynamic property creation, so this was heading for deprecation notices and then hard failure regardless.

### Verification

`vendor/bin/psalm` 5.26.1 on PHP 8.3: errors with the baseline emptied went **173 -> 168**, regenerated baseline green. PHPUnit not run locally (needs the server bootstrap).