### PR TITLE
docs(cache): declare the warmup_breakdown key the stats array actually holds

### DIFF
--- a/lib/Service/Object/CacheHandler.php
+++ b/lib/Service/Object/CacheHandler.php
@@ -144,8 +144,16 @@ class CacheHandler {
 	/**
 	 * Cache hit statistics
 	 *
+	 * `warmup_breakdown` is written by the name-cache warm-up for diagnostics
+	 * and is absent until that has run, so it is optional here. It was missing
+	 * from this shape entirely, which is why assigning it read as
+	 * InvalidPropertyAssignmentValue: the declaration described eight int keys
+	 * and the code stored a ninth holding an array.
+	 *
 	 * @var array{hits: int, misses: int, preloads: int, query_hits: int,
-	 *            query_misses: int, name_hits: int, name_misses: int, name_warmups: int}
+	 *            query_misses: int, name_hits: int, name_misses: int, name_warmups: int,
+	 *            warmup_breakdown?: array{organisations: int, objects_table: int,
+	 *                                     magic_tables: int, total_unique: int}}
 	 */
 	private array $stats = [
 		'hits' => 0,

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -258,11 +258,6 @@
       <code><![CDATA[$operation = &$this->oas['paths'][$pathName][$method]]]></code>
     </UnsupportedPropertyReferenceUsage>
   </file>
-  <file src="lib/Service/Object/CacheHandler.php">
-    <InvalidPropertyAssignmentValue>
-      <code><![CDATA[$this->stats]]></code>
-    </InvalidPropertyAssignmentValue>
-  </file>
   <file src="lib/Service/Object/LockHandler.php">
     <UnusedReturnValue>
       <code><![CDATA[bool]]></code>


### PR DESCRIPTION
`$this->stats` was documented as eight `int` keys. The name-cache warm-up stores a ninth, `warmup_breakdown`, holding an array. That mismatch is what Psalm reported as `InvalidPropertyAssignmentValue`, and it had been baselined rather than reconciled.

The runtime behaviour was never wrong — PHP arrays take the key regardless. What was wrong is that the declaration described a narrower shape than the class actually keeps, so anything reading the annotation (a person, an IDE, or the analyser) was told the key cannot be there.

Declared optional, since it is absent until the warm-up has run.

Verified: `vendor/bin/psalm` 5.26.1 on PHP 8.3, **168 -> 167** with the baseline emptied, regenerated baseline green, phpcs clean on the touched file.