### PR TITLE
feat(organisation): carry the four chain-partner fields it lacked

### DIFF
--- a/lib/Db/Organisation.php
+++ b/lib/Db/Organisation.php
@@ -89,12 +89,6 @@ use Symfony\Component\Uid\Uuid;
  * @method void setQualityScore(?int $qualityScore)
  * @method string|null getQualityStatus()
  * @method void setQualityStatus(?string $qualityStatus)
- *
- * @SuppressWarnings(PHPMD.LongVariable) `defaultPermissionLevel` is 22 characters
- * because Entity maps a property to its column by name: it resolves a setter to
- * lcfirst(substr($method, 3)) and looks THAT up, so the property must be the
- * camelCase of `default_permission_level`. A shorter name silently stops
- * mapping rather than failing.
  * @method string|null getSummary()
  * @method void setSummary(?string $summary)
  * @method string|null getOin()
@@ -133,6 +127,7 @@ use Symfony\Component\Uid\Uuid;
  * @method void setDeck(?array $deck)
  *
  * @SuppressWarnings(PHPMD.TooManyFields)
+ * @SuppressWarnings(PHPMD.LongVariable)
  *
  * @psalm-suppress PropertyNotSetInConstructor $id is set by Nextcloud's Entity base class
  */
@@ -368,8 +363,15 @@ class Organisation extends Entity implements JsonSerializable {
 	 *
 	 * 🔴 A DEFAULT, never an authorization decision. ADR-002 Rule 1 keeps the
 	 * organisation UUID as the only tenant key, and nothing may read this to
-	 * decide whether an actor MAY act — only to decide what a new share is
+	 * decide whether an actor MAY act, only to decide what a new share is
 	 * proposed at. The same trap `type` was kept out of.
+	 *
+	 * The name is 22 characters and has to be: Entity maps a property to its
+	 * column BY NAME, resolving a setter to lcfirst(substr($method, 3)) and
+	 * looking that up, so this must be the camelCase of
+	 * `default_permission_level`. Shortening it to satisfy PHPMD.LongVariable
+	 * would stop the mapping silently rather than failing, which is why the
+	 * class-level suppression exists.
 	 *
 	 * @var string|null The proposed starting level.
 	 */

--- a/lib/Db/Organisation.php
+++ b/lib/Db/Organisation.php
@@ -81,6 +81,20 @@ use Symfony\Component\Uid\Uuid;
  * @method void setIsLocalTenant(?bool $isLocalTenant)
  * @method string|null getRemoteInstanceUrl()
  * @method void setRemoteInstanceUrl(?string $remoteInstanceUrl)
+ * @method string|null getContactEmail()
+ * @method void setContactEmail(?string $contactEmail)
+ * @method string|null getDefaultPermissionLevel()
+ * @method void setDefaultPermissionLevel(?string $defaultPermissionLevel)
+ * @method int|null getQualityScore()
+ * @method void setQualityScore(?int $qualityScore)
+ * @method string|null getQualityStatus()
+ * @method void setQualityStatus(?string $qualityStatus)
+ *
+ * @SuppressWarnings(PHPMD.LongVariable) `defaultPermissionLevel` is 22 characters
+ * because Entity maps a property to its column by name: it resolves a setter to
+ * lcfirst(substr($method, 3)) and looks THAT up, so the property must be the
+ * camelCase of `default_permission_level`. A shorter name silently stops
+ * mapping rather than failing.
  * @method string|null getSummary()
  * @method void setSummary(?string $summary)
  * @method string|null getOin()
@@ -340,6 +354,45 @@ class Organisation extends Entity implements JsonSerializable {
 	protected ?string $remoteInstanceUrl = null;
 
 	/**
+	 * Where to reach this organisation about the work.
+	 *
+	 * The organisation's own address, as opposed to any individual user account
+	 * inside it. A chain partner is corresponded with as a body.
+	 *
+	 * @var string|null The contact address.
+	 */
+	protected ?string $contactEmail = null;
+
+	/**
+	 * The access level a share with this organisation starts at.
+	 *
+	 * 🔴 A DEFAULT, never an authorization decision. ADR-002 Rule 1 keeps the
+	 * organisation UUID as the only tenant key, and nothing may read this to
+	 * decide whether an actor MAY act — only to decide what a new share is
+	 * proposed at. The same trap `type` was kept out of.
+	 *
+	 * @var string|null The proposed starting level.
+	 */
+	protected ?string $defaultPermissionLevel = null;
+
+	/**
+	 * Chain-partner quality score, as scored by the installation working with them.
+	 *
+	 * Null rather than zero when unscored: a zero reads as "scored badly", which
+	 * is a different claim from "never assessed".
+	 *
+	 * @var integer|null The score.
+	 */
+	protected ?int $qualityScore = null;
+
+	/**
+	 * The qualitative reading of {@see $qualityScore}.
+	 *
+	 * @var string|null The status.
+	 */
+	protected ?string $qualityStatus = null;
+
+	/**
 	 * Short summary for overview pages (OpenCatalogi `summary`).
 	 *
 	 * @var string|null
@@ -541,6 +594,10 @@ class Organisation extends Entity implements JsonSerializable {
 		$this->addType(fieldName: 'type', type: 'string');
 		$this->addType(fieldName: 'isLocalTenant', type: 'boolean');
 		$this->addType(fieldName: 'remoteInstanceUrl', type: 'string');
+		$this->addType(fieldName: 'contactEmail', type: 'string');
+		$this->addType(fieldName: 'defaultPermissionLevel', type: 'string');
+		$this->addType(fieldName: 'qualityScore', type: 'integer');
+		$this->addType(fieldName: 'qualityStatus', type: 'string');
 		$this->addType(fieldName: 'summary', type: 'string');
 		$this->addType(fieldName: 'oin', type: 'string');
 		$this->addType(fieldName: 'tooi', type: 'string');
@@ -990,6 +1047,10 @@ class Organisation extends Entity implements JsonSerializable {
 			'type' => $this->type ?? 'organisation',
 			'isLocalTenant' => ($this->isLocalTenant ?? true),
 			'remoteInstanceUrl' => $this->remoteInstanceUrl,
+			'contactEmail' => $this->contactEmail,
+			'defaultPermissionLevel' => $this->defaultPermissionLevel,
+			'qualityScore' => $this->qualityScore,
+			'qualityStatus' => $this->qualityStatus,
 			'summary' => $this->summary,
 			'oin' => $this->oin,
 			'tooi' => $this->tooi,

--- a/lib/Migration/Version1Date20260901090000.php
+++ b/lib/Migration/Version1Date20260901090000.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Give an organisation the four chain-partner fields it did not already have.
+ *
+ * Version1Date20260831020000 made an organisation able to say it is a tenant
+ * somewhere ELSE (`is_local_tenant`, `remote_instance_url`). That settled WHERE
+ * a counterparty lives. It did not settle WHO it is.
+ *
+ * dossiq carried that separately, in its own `partnerOrganization` schema, and
+ * folding partners into Organisation would have dropped whatever this table
+ * could not hold. Measured against the live table rather than assumed: of that
+ * schema's nine properties, `name`, `slug`, `isActive` and `groupId` already
+ * map onto columns here, and `oin` ALREADY EXISTS (alongside `tooi`) — the
+ * Organisatie-identificatienummer, how a Dutch government body is named across
+ * installations, was added before this. Four properties had nowhere to go, and
+ * those four are what this migration adds.
+ *
+ * All four are nullable with NO default. An organisation that is this
+ * installation's own tenant has no chain-partner contact address and has never
+ * been scored, and writing a zero onto it would read as "scored badly" rather
+ * than "not scored".
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ * @author   Conduction Development Team <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link     https://github.com/ConductionNL/openregister
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Adds the chain-partner identity columns to `openregister_organisations`.
+ */
+final class Version1Date20260901090000 extends SimpleMigrationStep {
+
+	/**
+	 * The table this migration widens.
+	 *
+	 * @var string
+	 */
+	private const TABLE = 'openregister_organisations';
+
+	/**
+	 * Add the columns when they are absent.
+	 *
+	 * @param IOutput                   $output        Migration output.
+	 * @param Closure(): ISchemaWrapper $schemaClosure The schema closure.
+	 * @param array<string, mixed>      $options       Migration options.
+	 *
+	 * @return ISchemaWrapper|null The changed schema, or null when nothing changed.
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/* @var ISchemaWrapper $schema The schema wrapper. */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable(self::TABLE) === false) {
+			$output->warning(message: 'openregister_organisations is absent; skipping the chain-partner columns');
+
+			return null;
+		}
+
+		$table = $schema->getTable(self::TABLE);
+		$added = [];
+
+		foreach ($this->columnSpecifications() as $column) {
+			if ($table->hasColumn($column['name']) === true) {
+				continue;
+			}
+
+			$table->addColumn($column['name'], $column['type'], $column['options']);
+			$added[] = $column['name'];
+		}
+
+		if ($added === []) {
+			return null;
+		}
+
+		$output->info(message: 'openregister_organisations: added ' . implode(', ', $added));
+
+		return $schema;
+
+	}//end changeSchema()
+
+	/**
+	 * The columns this migration adds.
+	 *
+	 * @return array<int, array<string, mixed>> The specifications.
+	 */
+	private function columnSpecifications(): array {
+		return [
+			[
+				'name' => 'contact_email',
+				'type' => Types::STRING,
+				'options' => [
+					'notnull' => false,
+					'length' => 255,
+					'comment' => 'Where to reach this organisation about the work, as opposed '
+						. 'to any individual user account inside it.',
+				],
+			],
+			[
+				'name' => 'default_permission_level',
+				'type' => Types::STRING,
+				'options' => [
+					'notnull' => false,
+					'length' => 64,
+					'comment' => 'The access level a share with this organisation starts at. '
+						. 'A DEFAULT, never an authorization decision: ADR-002 Rule 1 keeps '
+						. 'the organisation UUID as the only tenant key, and nothing may '
+						. 'read this column to decide whether an actor may act.',
+				],
+			],
+			[
+				'name' => 'quality_score',
+				'type' => Types::INTEGER,
+				'options' => [
+					'notnull' => false,
+					'comment' => 'Chain-partner quality score, as scored by the installation '
+						. 'that works with them. Nullable with no default: a zero would '
+						. 'read as "scored badly" rather than "not scored".',
+				],
+			],
+			[
+				'name' => 'quality_status',
+				'type' => Types::STRING,
+				'options' => [
+					'notnull' => false,
+					'length' => 64,
+					'comment' => 'The qualitative reading of quality_score.',
+				],
+			],
+		];
+
+	}//end columnSpecifications()
+
+}//end class

--- a/lib/Migration/Version1Date20260901090000.php
+++ b/lib/Migration/Version1Date20260901090000.php
@@ -24,11 +24,12 @@
  * been scored, and writing a zero onto it would read as "scored badly" rather
  * than "not scored".
  *
- * @category Migration
- * @package  OCA\OpenRegister\Migration
- * @author   Conduction Development Team <info@conduction.nl>
- * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
- * @link     https://github.com/ConductionNL/openregister
+ * @category  Migration
+ * @package   OCA\OpenRegister\Migration
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link      https://github.com/ConductionNL/openregister
  */
 
 declare(strict_types=1);

--- a/tests/Unit/Db/OrganisationTest.php
+++ b/tests/Unit/Db/OrganisationTest.php
@@ -614,4 +614,60 @@ class OrganisationTest extends TestCase {
 		$result2 = (string)$this->organisation;
 		$this->assertSame($result1, $result2);
 	}
+
+	/**
+	 * The chain-partner fields register their types under the PROPERTY name.
+	 *
+	 * Entity::__call() resolves a setter to lcfirst(substr($method, 3)) and
+	 * looks THAT up in _fieldTypes, so registering a snake_case column name
+	 * matches nothing and the cast silently never runs — qualityScore would
+	 * come back from the database as a string.
+	 *
+	 * @return void
+	 */
+	public function testChainPartnerFieldTypesAreRegistered(): void {
+		$fieldTypes = $this->organisation->getFieldTypes();
+
+		$this->assertSame('string', $fieldTypes['contactEmail']);
+		$this->assertSame('string', $fieldTypes['defaultPermissionLevel']);
+		$this->assertSame('integer', $fieldTypes['qualityScore']);
+		$this->assertSame('string', $fieldTypes['qualityStatus']);
+	}
+
+	/**
+	 * An unscored partner serialises as null, never as zero.
+	 *
+	 * A zero reads as "scored badly", which is a different claim from "never
+	 * assessed", and a chain-partner dashboard cannot tell them apart after
+	 * the fact.
+	 *
+	 * @return void
+	 */
+	public function testAnUnscoredPartnerSerialisesAsNullNotZero(): void {
+		$serialised = $this->organisation->jsonSerialize();
+
+		$this->assertNull($serialised['qualityScore']);
+		$this->assertNull($serialised['qualityStatus']);
+		$this->assertNull($serialised['contactEmail']);
+		$this->assertNull($serialised['defaultPermissionLevel']);
+	}
+
+	/**
+	 * The chain-partner fields round-trip through jsonSerialize.
+	 *
+	 * @return void
+	 */
+	public function testChainPartnerFieldsRoundTrip(): void {
+		$this->organisation->setContactEmail('post@gemeente.nl');
+		$this->organisation->setDefaultPermissionLevel('read');
+		$this->organisation->setQualityScore(72);
+		$this->organisation->setQualityStatus('adequate');
+
+		$serialised = $this->organisation->jsonSerialize();
+
+		$this->assertSame('post@gemeente.nl', $serialised['contactEmail']);
+		$this->assertSame('read', $serialised['defaultPermissionLevel']);
+		$this->assertSame(72, $serialised['qualityScore']);
+		$this->assertSame('adequate', $serialised['qualityStatus']);
+	}
 }


### PR DESCRIPTION
Unblocks folding dossiq's `partnerOrganization` schema into `Organisation`, so a ketenpartner is an external tenant rather than a separate dossiq entity.

#3183 made an organisation able to say it is a tenant somewhere **else**. That settled *where* a counterparty lives. It did not settle *who it is*.

## A correction I owe the reviewer

I reported that `Organisation` had no field for `oin`, and that OIN — the identifier a Dutch government body is known by across installations — was the missing piece that decided whether partners could move here.

**That was wrong.** Measured against the live table rather than the property list I skimmed, `oin` already exists, alongside `tooi`.

Of `partnerOrganization`'s nine properties: `name`, `slug`, `isActive` and `groupId` already map onto columns here; `oin` already exists. **Four** genuinely had nowhere to go, and those four are what this adds:

| field | type | why nullable |
|---|---|---|
| `contactEmail` | string | a tenant of this installation has no chain-partner address |
| `defaultPermissionLevel` | string | only meaningful for a counterparty |
| `qualityScore` | integer | see below |
| `qualityStatus` | string | ditto |

## Two things the code refuses to do

**No default on `qualityScore`.** A zero reads as *"scored badly"*, which is a different claim from *"never assessed"* — and a partner dashboard cannot tell them apart after the fact. `testAnUnscoredPartnerSerialisesAsNullNotZero` pins it.

**`defaultPermissionLevel` is a default, never an authorization input.** ADR-002 Rule 1 keeps the organisation UUID as the only tenant key. Nothing may read this column to decide whether an actor *may act* — only what a **new** share is proposed at. That is precisely the trap `type` was kept out of, and the docblock says so at the place someone would otherwise reach for it.

## One subtlety worth the test

Field types register under the **property** name, not the column name. `Entity::__call()` resolves a setter to `lcfirst(substr(, 3))` and looks *that* up in `_fieldTypes`, so a snake_case registration matches nothing and the integer cast silently never runs — `qualityScore` would come back from the database as a string. `testChainPartnerFieldTypesAreRegistered` asserts the registration.

## Verification

- `OrganisationTest`: 70 tests, 236 assertions (was 67)
- `phpcs`, `phpstan`: clean. `phpmd` needed one suppression — `defaultPermissionLevel` is 22 characters and must be, because the property name IS the column mapping; a shorter name stops mapping silently rather than failing. The reason is in the docblock, not just the annotation.
- **Pre-existing, flagged not fixed:** `OrganisationTest` reports 3 PHP warnings from inside Nextcloud's own `Entity.php`. 3 before this change, 3 after.