### PR TITLE
spec(flow-portal-task): a portal-task node that asks a party outside the instance

### DIFF
--- a/openspec/changes/flow-portal-task/design.md
+++ b/openspec/changes/flow-portal-task/design.md
@@ -1,0 +1,236 @@
+# Design: flow-portal-task
+
+## Context
+
+See proposal.md for the motivation. What the approach stands on, measured:
+
+- **The suspend/resume machinery is proven and per-node.**
+  `FlowNodeResumeState` scopes state to one node
+  (`lib/Service/Flow/FlowNodeResumeState.php:39-65`), `FlowSuspension` is
+  thrown with a non-null heartbeat by both shipped waiters
+  (`WaitNode.php:192`, `AwaitSignalNode.php:266`), and
+  `flow-user-task-node` specifies continuation on TASK terminality rather
+  than the run's signal slot. This node changes none of that; it changes
+  who the performer is and how the ask travels.
+- **The reaper defines the floor.** `findAbandonedSignals()` matches
+  `resume_at IS NULL` (`lib/Db/FlowRunMapper.php:589-605`) and the worker
+  fails matches at 14 days (`lib/BackgroundJob/FlowRunWorker.php:94`,
+  `:311-349`). A hersteltermijn of six weeks parked on null would be
+  FAILED mid-term. Non-null `resumeAt` is therefore a correctness rule
+  here, not a style preference.
+- **Portaliq's boundary is structural.** Contributions are descriptors,
+  never data (ADR-046 rule 3); data reaches a visitor only through
+  subject-scoped readers; actions forward server-to-server under a signed
+  `X-Portal-Subject` assertion
+  (`portaliq/lib/Contribution/IPortalContributionProvider.php`). The
+  portal task rides these rails; it adds no new edge surface.
+- **The case object already owns files.**
+  `FileService::addFile()` writes into the object's own folder
+  (`lib/Service/FileService.php:1480`). The 2026-08-31 decision makes that
+  the ONLY landing place for a resident's upload.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One node that asks a party outside the instance and holds the run open
+  until they answer, with the same graph semantics as
+  `flow-user-task-node`.
+- Matching, visibility and completion authorization that are fail-closed
+  against the CASE's own data, so a portal subject can never see or answer
+  work that is not theirs.
+- An upload path whose result is a case-object file attachment, so the
+  case sees its own evidence without a sync.
+- A re-ask loop an author can draw in the graph, with the reason carried
+  to the party.
+
+**Non-Goals:**
+
+- Rendering anything. The portal page, the upload form and their styling
+  are portaliq's follow-up change.
+- Notifying Nextcloud users. The caseworker's review step is an ordinary
+  `openregister.user-task`; this node's delivery goes outward only.
+- Timers. Reminder cadence, business-day arithmetic and expiry enforcement
+  are `flow-business-timers`' rules; this node stores two timestamps and
+  names two rungs.
+- Identity brokering. DigiD, eHerkenning and eIDAS terminate at
+  portaliq's edge (ADR-046, ADR-108); OpenRegister sees a resolved,
+  server-derived subject and nothing upstream of it.
+
+## Decisions
+
+### D-1: A separate node, not an external mode on `openregister.user-task`
+
+The one-line version: the performer resolution, the delivery channel and
+the completion payload all differ, and a mode would make half of each
+node's config keys invalid depending on the mode.
+
+The longer version, in the order that decided it:
+
+1. **The config vocabularies are disjoint.** `user-task` speaks candidate
+   users, groups, roles, routing strategies and fallbacks. This node
+   speaks a party role on the case, delivery addresses and upload
+   constraints. Under a mode flag, `validateConfig()` becomes a two-branch
+   validator where every key's validity depends on the flag, which is
+   precisely the shape that ships a config the author believed was
+   checked and the validator never read.
+2. **The verb sets differ.** External tasks refuse `claim`, `unclaim` and
+   `delegate` (specs/flow-tasks delta). A mode would put refusable verbs
+   and poolable candidates one flag away from each other in the same node,
+   and the flag is exactly what a copy-pasted flow definition gets wrong.
+3. **The delivery seams must not meet.**
+   `flow-task-inbox-projections` projects Nextcloud tasks into
+   notifications and VTODO; the portal seam is subject-scoped and outward.
+   Two nodes keep the seams apart by construction; a mode keeps them apart
+   by an `if`.
+4. **The palette is the author's contract.** `flow-user-task-node` D-9
+   already pairs the waiters with one line each. This node extends the set
+   to three: a signal is for a system that will call back; a user task is
+   for a performer in the organisation; a portal task is for a party
+   outside it.
+
+The cost is a third waiting node in the palette and some shared mechanics.
+The mechanics are shared by reusing `flow-user-task-node`'s bridge
+(suspension, terminality read, outcome placement, cancellation
+propagation), not by copying it; only performer resolution, delivery and
+completion handling are node-specific.
+
+### D-2: Declarative-vs-imperative (ADR-031)
+
+Same verdict as `flow-user-task-node` D-1, inherited deliberately: the
+node is imperative because a node is the imperative half of the platform,
+and everything it points at stays declarative. The party role is data on
+the case schema; the delivery message content is a portal notification
+key, not PHP; the reminder and escalation are declarative timer rungs; the
+upload constraints are validated config, not code. The fence carries over
+verbatim: no branch in `PortalTaskNode` may be about what a specific app's
+case MEANS.
+
+### D-3: The match is frozen at creation
+
+The node resolves the party role against the case object once, when the
+task is created, and stores the resolved party reference on the task. It
+is not re-resolved at completion.
+
+A re-resolving match would let an edit to the case's initiator silently
+transfer an open ask to a different person, with the audit showing neither
+the transfer nor who authorized it. Frozen, the correction has one honest
+path: cancel or re-ask, which creates a new task with a new match and a
+new audit entry. The completion check compares the acting portal subject
+to the STORED reference, fail-closed: no stored reference, no resolvable
+subject, no match, all deny.
+
+### D-4: The heartbeat is non-null, inherited as a rule
+
+`flow-user-task-node` D-3 already argued this against the same two facts
+(`findAbandonedSignals()` matching only null, the 14-day failure) and this
+node's waits are LONGER: a hersteltermijn is measured in weeks. Same
+default (15 minutes), same floor (5 minutes), same consequence stated
+honestly: a run holding an open portal task is never reaped as abandoned,
+and the thing that ends an unanswered ask is `expires_at` enforcement in
+`flow-business-timers`.
+
+### D-5: The upload is a case-object file attachment, and the completion references it
+
+Files are stored through the file service onto the case object's own
+folder before the task completion is recorded; the completion carries the
+stored file references, not the bytes. Order matters: a completion that
+records first and stores second can be interrupted into a completed task
+whose evidence does not exist. Storing first degrades the other way, an
+orphaned file on the right case, which is recoverable and visible.
+
+Node config declares whether an upload is required, how many files are
+accepted, and the accepted types and maximum size; violations refuse the
+completion naming the constraint. Any dossier folder view of the file is a
+projection of the attachment (decision 2026-08-31), one-directional per
+ADR-098 Decision 2; nothing in this change writes a second file store.
+
+### D-6: Re-ask is graph re-entry, and a reason is mandatory
+
+The loop lives in the graph, where the author can see it: a caseworker
+review step (an ordinary user task) routes its rejection edge back into
+the portal-task node. On re-entry the node finds its slot task TERMINAL
+and creates a new task; on a heartbeat wake it finds its slot task OPEN
+and suspends again. Terminality of the slot task is what distinguishes a
+re-ask from a duplicate, so idempotence and looping use one mechanism
+instead of two flags.
+
+The re-ask reason is read from a configured item field and is MANDATORY:
+a firing that re-enters with no reason fails validation of the firing, not
+silently. Asking a resident the same thing twice with no explanation is
+the behaviour every complaint procedure exists to punish. The cycle count
+and the previous task's uuid are recorded on the new task, so "asked
+three times" is a query, not an archaeology.
+
+### D-7: Delivery is a contract with portaliq, owned here as a seam only
+
+This change specifies WHAT crosses the seam: a subject-scoped read that
+lists a portal subject's open portal tasks with their case context, and a
+delivery request (portal inbox message plus mail) recorded at creation and
+at re-ask. It deliberately does not specify how portaliq renders either;
+that is portaliq's follow-up change, and tasks.md carries exactly one
+pointer line for it (one canonical home per spec).
+
+Fail-open is refused on both sides of the seam: a task whose delivery
+request cannot be recorded still exists and still suspends the run (the
+ask outlives a mail outage), and the delivery state is queryable so the
+caseworker sees "not yet delivered" instead of silence.
+
+### D-8: The overdue path names timer rungs and owns nothing else
+
+The node passes `due_at` and `expires_at` references to the task, and the
+flow author attaches an escalation ladder from `flow-business-timers`: a
+`preBreach` rung addressed to the party (delivered through the same portal
+seam as the ask) is the reminder; a `slaBreached` rung addressed to the
+caseworker role is the escalation; expiry enforcement transitions the task
+terminally there. This node contains no sweep, no cadence and no
+business-day arithmetic, and its spec asserts that absence.
+
+## Risks / Trade-offs
+
+- **The portaliq follow-up can lag, leaving tasks undeliverable.**
+  → The delivery state is recorded and queryable, the task and suspension
+  are correct without the portal, and the seam is specified here so the
+  portaliq change implements against a contract instead of guessing.
+- **Party matching is only as good as the case's party data.** A case
+  whose initiator reference is stale asks the wrong person.
+  → The match is frozen and audited (D-3), so the error is visible and
+  recoverable through re-ask; and a case naming nobody fails the firing
+  loudly instead of creating an unperformable task.
+- **Long-lived heartbeats accumulate.** A six-week hersteltermijn at a
+  15-minute heartbeat is ~4,000 no-op wakes.
+  → The same trade `AwaitSignalNode` documents and the platform already
+  pays; the interval is configurable per node.
+- **A three-waiter palette can confuse authors.**
+  → D-1 point 4: three one-line descriptions written as a set; and using
+  the wrong node fails visibly (a user task for a resident has no
+  performable candidate; a portal task for an employee never reaches an
+  inbox).
+- **Uploads are attack surface.** Type and size constraints are validated
+  fail-closed (D-5), the file lands under the case object's ordinary OR
+  permissions, and the portal edge's existing throttling (ADR-082) fronts
+  the endpoint. Anti-virus scanning is the instance's existing NC file
+  pipeline, not re-specified here.
+
+## Migration Plan
+
+Additive: one node registration, one performer-type extension on an
+entity that is being implemented in parallel and has no shipped consumers
+to migrate. Deploy order is the dependency chain:
+`flow-task-entity` → `flow-user-task-node` → this change → portaliq's
+contribution change. Rollback is removing the registration; open external
+tasks are then terminated through the ordinary run-cancellation
+propagation.
+
+## Open Questions
+
+- **Does one portal task ever address several parties?** A case with two
+  applicants may owe both an ask. Provisionally: one task, one matched
+  party; a multi-party ask is modelled in the graph (a fan-out over the
+  party list), which `flow-parallel-streams` serves better than a
+  multi-match here would.
+- **Does the caseworker need a "complete on behalf of the resident at the
+  desk" path?** Today: no; the desk scenario is the caseworker uploading
+  to the case directly and cancelling the portal task with a reason. If
+  practice demands more, it arrives as a delegation rule on the `external`
+  performer type in `flow-tasks`, not as a bypass in this node.

--- a/openspec/changes/flow-portal-task/proposal.md
+++ b/openspec/changes/flow-portal-task/proposal.md
@@ -1,0 +1,170 @@
+---
+kind: code
+depends_on: [flow-task-entity, flow-user-task-node]
+---
+
+# Proposal: flow-portal-task
+
+## Summary
+
+Ask a person who has no account. A new node type `openregister.portal-task`
+creates a task for an EXTERNAL party (ADR-098 Decision 3 as amended
+2026-08-31: performer type `external`), matched from the subject case
+object's party role (default: the initiator), and suspends the run
+heartbeat-safe until that party answers. The task reaches the party through
+portaliq's contribution surface (ADR-046): a portal inbox message plus a
+mail, never a Nextcloud notification. The answer can carry an upload, and
+that file lands as an OpenRegister file attachment on the case object
+(ADR-022); any dossier folder view is a projection of that attachment. Only
+the matched party may complete. A caseworker who is not satisfied routes the
+flow back into the node with a reason, and the party is asked again. The
+overdue path (reminder, escalation, enforcement) is consumed from
+`flow-business-timers`, not rebuilt here.
+
+## Why
+
+**The engine can now ask a person with an account. Dutch case handling
+mostly waits on a person without one.** `flow-user-task-node` gives the
+graph a performer who can be found, told and allowed to say no, but its
+performer model resolves against Nextcloud: a uid, a group, a role, an
+agent. The hersteltermijn (ADR-098 Context: wait-on-citizen is the
+CMMN-shaped core of Dutch case handling) is addressed to a resident who
+authenticates with DigiD at the portal's edge and will never hold a
+Nextcloud account. Today that resident is unreachable from the graph, so
+every "send the applicant a letter and wait" step stays manual.
+
+**The projection alternative was measured and rejected on 2026-08-31.** A
+portaliq-side mirror of tasks would be a second store that can drift, the
+`agentflow` defect class ADR-098 Decision 2 forbids, and it could not
+suspend a run on the resident's answer. Residents become first-class
+performers by EXTENDING the performer model instead. That amendment is
+recorded in ADR-098 Decision 3.
+
+**The delivery surface already exists and already enforces the boundary.**
+Portaliq discovers a leaf app's `PortalContributionProvider` by convention
+(ADR-046), aggregates DESCRIPTORS never data, and serves rows through
+subject-scoped readers; its endpoint actions forward server-to-server with a
+signed `X-Portal-Subject` assertion, never the client bearer
+(`portaliq/lib/Contribution/IPortalContributionProvider.php`). A portal task
+that rides this contract inherits the tenant boundary instead of
+re-implementing it. What portaliq renders is portaliq's change to make; this
+change specifies the OpenRegister half of the seam.
+
+**The upload has exactly one correct home.** OpenRegister already attaches
+files to an object's own folder (`lib/Service/FileService.php`,
+`addFile()`). Decided 2026-08-31: a resident's uploaded file lands as an OR
+file attachment on the CASE object, and any dossier folder view of it is a
+projection. A file held in a portal-private store is evidence the case
+cannot see.
+
+**And the suspension discipline is measured, not optional.**
+`FlowRunMapper::findAbandonedSignals()` matches `resume_at IS NULL`
+(`lib/Db/FlowRunMapper.php:589-605`) and `FlowRunWorker` FAILS those runs at
+14 days (`lib/BackgroundJob/FlowRunWorker.php:94`, `:311-349`). A
+hersteltermijn is routinely longer than 14 days. A portal-task node that
+parked on a null `resumeAt` would hand the reaper its first input and fail
+exactly the waiting-on-citizen runs this node exists to hold open. The node
+copies `AwaitSignalNode`'s non-null heartbeat discipline verbatim.
+
+## What Changes
+
+- **A new node, `openregister.portal-task`**, in `lib/Service/Flow/Nodes/`,
+  implementing `IFlowNode`, `IFlowNodeConfigKeys` and `IFlowNodeConfigForm`,
+  registered through `lib/Listener/FlowNodeRegistrationListener.php`. A
+  SEPARATE node, not an external-performer mode of
+  `openregister.user-task`; design.md D-1 argues the choice. In one line:
+  the performer resolution, the delivery channel and the completion payload
+  all differ, and a mode would make half of each node's config keys invalid
+  depending on the mode.
+- **The `external` performer type on the task entity** (Modified capability
+  `flow-tasks`): performer reference is a party reference resolved to a
+  portal subject, such tasks appear in NO Nextcloud inbox or candidate
+  pool, `claim`/`unclaim`/`delegate` are refused for them, and completion
+  authorization matches the acting portal subject to the stored party
+  reference, fail-closed.
+- **Party matching from the case, not from config.** The node names a party
+  ROLE on the subject case object (default `initiator`); the concrete party
+  is resolved at task creation, frozen on the task, and recorded in the
+  audit. A case that names nobody for that role fails the firing loudly.
+- **Suspend and resume exactly as `flow-user-task-node`**: one task per
+  node per run via the node's own resume slot, continuation on task
+  terminality, outcome written onto every item, non-null heartbeat
+  `resumeAt` (15-minute default, 5-minute floor, matching
+  `AwaitSignalNode.php:87`, `:98`).
+- **Delivery through portaliq**: the task is exposed subject-scoped to the
+  portal contribution seam, and its creation requests a portal inbox
+  message plus a mail to the party. Nothing is delivered through
+  `INotificationManager` or the VTODO projection; an external performer has
+  neither.
+- **Upload completion onto the case**: a completion may carry one or more
+  files; each is stored as an OR file attachment on the case object via the
+  file service, and the task's completion record references the stored
+  files. Node config declares whether an upload is required and constrains
+  type and size.
+- **Re-ask as graph re-entry**: when the flow routes back into the node
+  after its task went terminal, the node creates a NEW task carrying a
+  mandatory reason, increments the cycle count, and delivers again. The
+  previous task and its audit survive untouched.
+- **The overdue path consumes `flow-business-timers`**: the node passes
+  `due_at`/`expires_at` references to the task; a `preBreach` escalation
+  rung is the resident's reminder (through the portal delivery seam), a
+  `slaBreached` rung escalates to the caseworker role, and expiry
+  enforcement transitions the task there, never here. The node owns no
+  clock.
+
+## What does NOT change
+
+- **`flow-task-entity` and `flow-user-task-node`** own everything they
+  already specify: table, lifecycle, verbs, authorization, inbox, the
+  user-task node's mechanics. This change adds one performer type to the
+  entity's model and one sibling node; it redefines nothing.
+- **Portaliq's own surface.** The contribution that renders the portal task
+  and its upload form is a follow-up change in portaliq's repository. One
+  canonical home per spec: this change specifies the OpenRegister seam it
+  will consume, and tasks.md carries exactly one pointer line for it.
+- **`flow-business-timers`** owns reminders, escalation ladders,
+  opschorting and expiry enforcement. This change names the rungs it
+  consumes and stores the two timestamps.
+- **`flow-task-inbox-projections`** stays Nextcloud-facing. External tasks
+  are explicitly outside its notification and VTODO scope.
+- **`AwaitSignalNode`, `POST /api/flow-runs/{uuid}/resume`** and every
+  existing node and endpoint are untouched. The resume endpoint cannot
+  complete a portal task, exactly as it cannot complete a user task.
+
+## Capabilities
+
+### New Capabilities
+
+- `flow-portal-task`: the `openregister.portal-task` step node: party
+  matching from the case, external task creation, heartbeat-safe
+  suspension, portal delivery contract, upload-to-case completion,
+  matched-party-only completion, re-ask cycles, and the timer consumption
+  contract.
+
+### Modified Capabilities
+
+- `flow-tasks`: gains the `external` performer type (ADR-098 D3 amendment
+  2026-08-31) with portal-scoped visibility and authorization; delta in
+  `specs/flow-tasks/spec.md`.
+
+## Impact
+
+- **Affected specs**: new `flow-portal-task`; delta on `flow-tasks`.
+- **Affected code**: new `lib/Service/Flow/Nodes/PortalTaskNode.php`; a
+  party-matching resolver against the subject object; the external-performer
+  branch in `flow-task-entity`'s authorization service; a portal delivery
+  seam (subject-scoped task read plus a delivery request record) consumed
+  by portaliq; completion handling that stores uploads through
+  `FileService::addFile()` onto the case object.
+- **Affected apps**: portaliq (follow-up change in its own repo renders the
+  contribution); dossiq consumes the node in its hersteltermijn flow, in
+  its own change.
+- **Depends on**: `flow-task-entity` (the task, its lifecycle and audit)
+  and `flow-user-task-node` (the suspend/resume, outcome placement and
+  cancellation mechanics this node reuses).
+- **ADRs**: ADR-098 D3 as amended 2026-08-31 (`external` performer; upload
+  lands on the case object), D2 (no second store), D4 (the case object is
+  the anchor); ADR-046 (portal contribution contract); ADR-108 (public
+  surface placement belongs to portaliq); ADR-022 (apps consume OR
+  abstractions; the file attachment IS the record); ADR-005 (fail-closed
+  authorization); ADR-031 (declarative-vs-imperative, argued in design.md).

--- a/openspec/changes/flow-portal-task/specs/flow-portal-task/spec.md
+++ b/openspec/changes/flow-portal-task/specs/flow-portal-task/spec.md
@@ -1,0 +1,340 @@
+## Purpose
+
+One step type that asks a party OUTSIDE the Nextcloud instance to do
+something: it matches the party from the case, creates an external task,
+parks the run heartbeat-safe, delivers the ask through the portal, accepts
+an answer whose files land on the case object, refuses everyone but the
+matched party, and can ask again with a reason.
+
+## ADDED Requirements
+
+### Requirement: A portal-task step creates one external task and suspends the run
+
+The system SHALL provide a step node type `openregister.portal-task`. On
+its first firing with items, the node SHALL create ONE task through the
+`flow-tasks` task service with performer type `external`, carrying the
+run's uuid and this node's id as provenance, and SHALL then suspend the
+run.
+
+Whether a task already exists for this firing SHALL be determined from
+this node's own resume slot, exactly as `flow-user-task-node` specifies: a
+heartbeat wake, a lost delivery or a duplicated worker pass MUST NOT
+produce a second ask.
+
+A firing that carries no items SHALL create no task and SHALL NOT suspend
+the run.
+
+The node SHALL delegate task creation in full to the task service. It
+SHALL NOT define a task field, a lifecycle state or an authorization rule
+of its own.
+
+#### Scenario: The first firing produces an external task and a suspended run
+
+- **GIVEN** a flow whose graph contains one `openregister.portal-task` node
+  and a subject case object naming an initiator
+- **WHEN** the run reaches that node carrying one item
+- **THEN** exactly one task MUST exist with performer type `external`,
+  carrying the run's uuid and the node's id
+- **AND** the run MUST be suspended
+- @e2e a flow with a portal task suspends and the task reaches the portal
+  subject
+
+#### Scenario: A heartbeat wake does not ask twice
+
+- **GIVEN** a run suspended on a portal-task node whose task is still open
+- **WHEN** the worker wakes it on its heartbeat and the node fires again
+- **THEN** the task count for that run and node MUST still be one
+- **AND** the run MUST suspend again
+- @e2e exclude covered by PortalTaskNode unit tests over a resumed context
+
+#### Scenario: An empty branch creates nothing
+
+- **GIVEN** a routing node that sent every item down a sibling branch
+- **WHEN** the portal-task node on the empty branch fires with no items
+- **THEN** no task MUST be created
+- **AND** the run MUST NOT suspend
+- @e2e exclude engine-internal suspend rule, covered by PortalTaskNode unit
+  tests
+
+### Requirement: The matched party comes from the case and is frozen at creation
+
+The node's configuration SHALL name a party ROLE on the subject case
+object, defaulting to `initiator`. At task creation the system SHALL
+resolve that role against the case object to a party reference, SHALL
+store the resolved reference on the task, and SHALL record the resolution
+in the task audit.
+
+The stored reference SHALL NOT be re-resolved afterwards. A later edit to
+the case's party data SHALL NOT transfer an open task; correcting a wrong
+match SHALL be done by cancelling or re-asking, which creates a new task
+with a new match and a new audit entry.
+
+A firing whose case names NO party for the configured role SHALL fail the
+firing with an error naming the role and the case, and SHALL NOT create a
+task. An unperformable ask parked in a suspended run buries the mistake.
+
+#### Scenario: The initiator is matched and recorded
+
+- **GIVEN** a portal-task node with the default party role and a case whose
+  initiator is a known party
+- **WHEN** the node fires
+- **THEN** the created task MUST store that party's reference
+- **AND** the audit MUST record the role and the resolved reference
+- @e2e exclude covered by party-matching unit tests
+
+#### Scenario: A case with no initiator fails loudly
+
+- **GIVEN** a portal-task node whose subject case object names no party for
+  the configured role
+- **WHEN** the node fires with items
+- **THEN** the firing MUST fail with an error naming the role
+- **AND** no task MUST be created
+- @e2e exclude covered by party-matching unit tests
+
+#### Scenario: Editing the case does not move an open ask
+
+- **GIVEN** an open portal task matched to party A
+- **WHEN** the case's initiator is changed to party B
+- **THEN** the task's stored party reference MUST still be party A
+- **AND** party B MUST NOT be able to complete it
+- @e2e exclude covered by completion-authorization unit tests
+
+### Requirement: The suspension is heartbeat-safe and continues on task terminality
+
+The node SHALL suspend with a non-null heartbeat `resumeAt`, defaulting to
+15 minutes and clamped to a 5-minute floor, matching the shipped waiters.
+It SHALL NEVER suspend with a null `resumeAt`: that is the only shape
+`findAbandonedSignals` reaps, and the 14-day failure it drives is shorter
+than an ordinary hersteltermijn.
+
+A suspended portal-task node SHALL continue the run only when its task has
+reached a terminal state, read from the TASK, never from the run context's
+signal slot. While the task is non-terminal the node SHALL suspend again
+without restamping its recorded creation time.
+
+When the node continues, it SHALL write the task's result onto EVERY item
+it passes on, under a configurable key defaulting to `portalTask`,
+carrying at minimum the outcome, the submitted answer fields, the stored
+file references, and the matched party reference. A task that went
+terminal WITHOUT a completion (terminated, expired) SHALL be
+distinguishable downstream from a completed one.
+
+#### Scenario: A suspended portal task is reachable by the clock
+
+- **GIVEN** a run suspended on a portal-task node
+- **WHEN** its persisted resume time is read
+- **THEN** it MUST NOT be null
+- @e2e exclude covered by a unit test asserting the thrown suspension
+
+#### Scenario: Completing the task advances the run with the answer on the items
+
+- **GIVEN** a run suspended on a portal-task node
+- **WHEN** the matched party completes the task
+- **THEN** the run MUST become due and continue past the node
+- **AND** every item leaving the node MUST carry the outcome and the file
+  references under the configured key
+- @e2e a resident's completed portal task advances the case flow
+
+#### Scenario: An expired ask is not an answer
+
+- **GIVEN** a portal task transitioned terminally by expiry enforcement
+- **WHEN** the run continues past the node
+- **THEN** the item payload MUST distinguish the expiry from a completion
+- @e2e exclude covered by PortalTaskNode unit tests over a terminated task
+
+### Requirement: Delivery rides the portal contribution surface and nothing else
+
+Creating an external task, and every re-ask, SHALL record a delivery
+request for a portal inbox message and a mail to the matched party. The
+delivery state SHALL be queryable, so an undelivered ask reads as "not
+yet delivered" rather than as silence.
+
+The system SHALL expose a subject-scoped read listing a portal subject's
+open portal tasks with their case context, shaped for consumption through
+the ADR-046 contribution contract: descriptors aggregate, rows stay behind
+subject-scoped readers, and one subject's read MUST NOT return or count
+another subject's tasks.
+
+An external task SHALL NOT be delivered through `INotificationManager`,
+SHALL NOT be projected to CalDAV, and SHALL NOT appear in any Nextcloud
+user's or group's inbox. The rendering of the portal task and its upload
+form is portaliq's own change and is NOT specified here.
+
+A delivery request that cannot be recorded SHALL NOT roll back the task or
+the suspension: the ask outlives a delivery outage, and the queryable
+delivery state is what makes the outage visible.
+
+#### Scenario: The task is visible to its matched subject and to nobody else
+
+- **GIVEN** an open portal task matched to subject A, and portal subjects A
+  and B
+- **WHEN** each subject's portal task list is read
+- **THEN** subject A's list MUST contain the task with its case context
+- **AND** subject B's list MUST NOT contain it and MUST NOT count it
+- @e2e a portal task is listed for its matched subject and hidden from
+  another subject
+
+#### Scenario: No Nextcloud channel carries the ask
+
+- **GIVEN** a portal task created for an external party
+- **WHEN** delivery runs
+- **THEN** no Nextcloud notification MUST be sent
+- **AND** no VTODO projection MUST be written
+- @e2e exclude covered by delivery-seam unit tests
+
+#### Scenario: A failed delivery leaves the ask standing and visible
+
+- **GIVEN** a portal task whose delivery request cannot be recorded
+- **WHEN** the firing finishes
+- **THEN** the task MUST exist and the run MUST be suspended
+- **AND** the delivery state MUST read as not delivered
+- @e2e exclude covered by delivery-seam unit tests
+
+### Requirement: An upload completion lands as a file attachment on the case object
+
+A completion MAY carry files, and the node's configuration SHALL declare
+whether at least one file is REQUIRED, how many are accepted, and the
+accepted types and maximum size. A completion violating a constraint SHALL
+be refused naming the constraint, and the task SHALL remain open.
+
+Each accepted file SHALL be stored as an OpenRegister file attachment on
+the CASE object, through the file service, BEFORE the completion is
+recorded; the completion SHALL reference the stored files rather than
+carrying bytes. Any dossier folder view of the file is a projection of
+that attachment (decision 2026-08-31); no portal-private file store SHALL
+be written.
+
+#### Scenario: The uploaded file is on the case
+
+- **GIVEN** a portal task requiring one file
+- **WHEN** the matched party completes it with a valid file
+- **THEN** the file MUST exist as a file attachment on the case object
+- **AND** the completion MUST reference it
+- @e2e a resident's upload appears as a file on the case object
+
+#### Scenario: A required upload cannot be skipped
+
+- **GIVEN** a portal task requiring one file
+- **WHEN** the matched party submits a completion with no file
+- **THEN** the completion MUST be refused naming the requirement
+- **AND** the task MUST remain open
+- @e2e exclude covered by completion-validation unit tests
+
+#### Scenario: An oversized file is refused before anything is stored
+
+- **GIVEN** a portal task with a configured maximum file size
+- **WHEN** the matched party submits a larger file
+- **THEN** the completion MUST be refused naming the limit
+- **AND** no file MUST be stored on the case
+- @e2e exclude covered by completion-validation unit tests
+
+### Requirement: Only the matched party completes, fail-closed
+
+Completion of an external task SHALL be authorized by comparing the acting
+portal subject to the task's STORED party reference. Any other caller
+SHALL be denied: another portal subject, any authenticated Nextcloud user
+including administrators acting through the portal seam, and any caller
+whose subject cannot be resolved. When the comparison cannot be evaluated,
+the answer SHALL be denial, never a skipped check.
+
+`POST /api/flow-runs/{uuid}/resume` SHALL NOT be able to complete a portal
+task, for the same reason it cannot complete a user task: it authorizes
+running the flow, not answering for a performer.
+
+A caseworker who needs the ask withdrawn SHALL cancel or re-ask through
+the flow; there SHALL be no completion-on-behalf path for external tasks.
+
+#### Scenario: Another subject who knows the task cannot answer it
+
+- **GIVEN** an open portal task matched to subject A
+- **WHEN** authenticated portal subject B attempts to complete it
+- **THEN** the completion MUST be denied
+- **AND** the task state MUST be unchanged
+- @e2e another portal subject cannot complete a task that is not theirs
+
+#### Scenario: The resume endpoint cannot answer for the resident
+
+- **GIVEN** a run suspended on a portal-task node, and a Nextcloud user who
+  may run the flow
+- **WHEN** that user posts a decision to the run's resume endpoint
+- **THEN** the task MUST remain non-terminal
+- **AND** the run MUST remain suspended
+- @e2e exclude same contract as flow-user-task-node, covered by its e2e plus
+  PortalTaskNode unit tests
+
+#### Scenario: An unresolvable subject is denied
+
+- **GIVEN** an open portal task and a completion whose acting subject cannot
+  be resolved
+- **WHEN** completion is attempted
+- **THEN** it MUST be denied with a reason
+- **AND** the denial MUST be recorded in the task audit
+- @e2e exclude covered by completion-authorization unit tests
+
+### Requirement: A re-ask creates a new task carrying a mandatory reason
+
+When the flow routes back into a portal-task node whose slot task is
+TERMINAL, the node SHALL create a NEW external task: matched afresh from
+the case, carrying a re-ask reason, recording the cycle number and the
+previous task's uuid, and delivered like a first ask.
+
+The reason SHALL be read from a configured item field and SHALL be
+MANDATORY on re-entry: a re-entering firing with no reason SHALL fail the
+firing rather than ask the party the same thing with no explanation.
+
+The previous task and its audit SHALL remain untouched. The cycle count
+SHALL be queryable, so "how often has this party been asked" is a read,
+not a reconstruction.
+
+#### Scenario: A rejected submission goes back with the reason
+
+- **GIVEN** a flow where a caseworker review step routes its rejection edge
+  back into the portal-task node, and a completed first ask
+- **WHEN** the reviewer rejects with a reason and the node fires again
+- **THEN** a second task MUST exist carrying the reason, cycle number 2 and
+  the first task's uuid
+- **AND** the first task MUST be unchanged
+- @e2e a rejected submission returns to the resident with the reason
+
+#### Scenario: A re-ask without a reason is refused
+
+- **GIVEN** a portal-task node re-entered after its task went terminal, with
+  no reason on the configured item field
+- **WHEN** the node fires
+- **THEN** the firing MUST fail naming the missing reason
+- **AND** no new task MUST be created
+- @e2e exclude covered by PortalTaskNode re-entry unit tests
+
+### Requirement: The overdue path is consumed from flow-business-timers, never rebuilt
+
+The node SHALL pass `due_at` and `expires_at` references through to the
+task and SHALL implement no sweep, no cadence and no business-day
+arithmetic of its own.
+
+The reminder and escalation contract SHALL be expressed as
+`flow-business-timers` escalation rungs: a `preBreach` rung addressed to
+the PARTY is delivered through the same portal delivery seam as the ask,
+and a `slaBreached` rung addressed to the caseworker role escalates
+inside the organisation. Expiry enforcement transitioning the task is
+that capability's rule; this node only guarantees that an
+expiry-terminated task continues the run distinguishably (see the
+suspension requirement).
+
+#### Scenario: A reminder reaches the party without this node owning a clock
+
+- **GIVEN** a portal task with a due date and a preBreach reminder rung
+- **WHEN** the rung fires
+- **THEN** the reminder MUST be delivered through the portal delivery seam
+  to the matched party
+- **AND** no timer logic MUST exist in the portal-task node
+- @e2e exclude timer firing is flow-business-timers' surface; the seam is
+  covered by delivery-seam unit tests
+
+#### Scenario: A breach escalates inward, not to the party
+
+- **GIVEN** a portal task with a slaBreached escalation rung naming the
+  caseworker role
+- **WHEN** the rung fires
+- **THEN** the escalation MUST be addressed to the caseworker role
+- **AND** the party MUST NOT receive it
+- @e2e exclude covered by flow-business-timers rung-addressing unit tests

--- a/openspec/changes/flow-portal-task/specs/flow-tasks/spec.md
+++ b/openspec/changes/flow-portal-task/specs/flow-tasks/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: The external performer type is portal-scoped and never pooled
+
+The performer model SHALL additionally accept `performer_type: external`
+(ADR-098 Decision 3 as amended 2026-08-31): a party outside the Nextcloud
+instance, referenced by a party reference that resolves to a portal
+subject, never by a Nextcloud uid, group or role.
+
+An external task SHALL always be ASSIGNED to its stored party reference at
+creation. The verbs `claim`, `unclaim` and `delegate` SHALL be refused for
+external tasks with an error naming the performer type: there is no
+candidate pool to claim from and no mandate model for parties outside the
+instance.
+
+An external task SHALL NOT appear in any Nextcloud user's or group's inbox
+query, SHALL NOT be counted in any inbox total, and SHALL NOT be projected
+by the Nextcloud-facing notification or calendar projections. Its
+visibility inside the instance is through the task's subject object
+(tasks anchored to a case remain readable to the case's authorized
+caseworkers); its visibility outside the instance is the portal seam
+specified by `flow-portal-task`.
+
+Completion authorization for an external task SHALL compare the acting
+portal subject to the stored party reference and SHALL deny when the
+comparison cannot be evaluated. The audit SHALL record performer type
+`external` and the acting subject reference on every verb, exactly as it
+records the other performer types.
+
+#### Scenario: An external task is absent from every Nextcloud inbox
+
+- **GIVEN** an external task anchored to a case
+- **WHEN** any Nextcloud user requests their inbox
+- **THEN** the task MUST NOT appear
+- **AND** it MUST NOT be counted in the total
+- @e2e exclude covered by TaskInboxService unit tests over an external task
+
+#### Scenario: Claim and delegate are refused on an external task
+
+- **GIVEN** an external task
+- **WHEN** claim or delegate is called by any caller
+- **THEN** the verb MUST be refused with an error naming the performer type
+- @e2e exclude covered by TaskService verb unit tests
+
+#### Scenario: The caseworker still sees the ask on the case
+
+- **GIVEN** an external task anchored to a case and a caseworker authorized
+  on that case
+- **WHEN** the caseworker requests the tasks anchored to that object
+- **THEN** the external task MUST appear with its delivery state
+- @e2e the case detail lists the outstanding portal task for the caseworker
+
+#### Scenario: The audit names the external performer
+
+- **GIVEN** an external task completed by its matched portal subject
+- **WHEN** the audit is read
+- **THEN** the completion entry MUST record performer type `external` and
+  the acting subject reference
+- @e2e exclude covered by task-audit unit tests

--- a/openspec/changes/flow-portal-task/tasks.md
+++ b/openspec/changes/flow-portal-task/tasks.md
@@ -1,0 +1,144 @@
+# Tasks: flow-portal-task
+
+## 1. The node
+
+- [ ] 1.1 `lib/Service/Flow/Nodes/PortalTaskNode.php` implementing
+      `IFlowNode`, `IFlowNodeConfigKeys` and `IFlowNodeConfigForm`. Follow
+      `UserTaskNode` for shape: EUPL-1.2 header, `@spec` on every method, a
+      file docblock stating the three-waiter division of labour (signal:
+      a system that calls back; user task: a performer in the organisation;
+      portal task: a party outside it). `getId()` returns
+      `openregister.portal-task`.
+- [ ] 1.2 `configForm()` + `configKeys()`: title/description templates,
+      party role (default `initiator`), upload requirements (required,
+      count, types, max size), `outcomeKey` (default `portalTask`),
+      re-ask reason item field, `dueAt`/`expiresAt` references,
+      `heartbeatMinutes`, `advance`. Register the node in
+      `lib/Listener/FlowNodeRegistrationListener.php`.
+- [ ] 1.3 `validateConfig()`: refuse a config with no party role; refuse
+      `advance: null` exactly as `UserTaskNode` does. The mandatory re-ask
+      reason cannot be checked statically (whether a firing is a re-entry
+      is runtime knowledge), so it is validated at fire time per section 6.
+
+## 2. Party matching
+
+- [ ] 2.1 Party resolver: resolve the configured role against the subject
+      case object at creation, freeze the reference on the task, record
+      role and reference in the audit; fail the firing loudly when the case
+      names nobody for the role.
+- [ ] 2.2 No re-resolution anywhere: completion authorization reads the
+      STORED reference only; add the case-edit scenario as a regression
+      test.
+
+## 3. Suspend, resume, outcome
+
+- [ ] 3.1 Reuse `flow-user-task-node`'s bridge for suspension and
+      continuation: one task per node per run via the resume slot,
+      non-null heartbeat `resumeAt` (15-minute default, 5-minute floor,
+      never null: `FlowRunMapper::findAbandonedSignals()` matches
+      `resume_at IS NULL` and `FlowRunWorker` fails matches at 14 days),
+      continuation on task terminality read from the task.
+- [ ] 3.2 Outcome placement onto every item under `outcomeKey`: outcome,
+      answer fields, stored file references, matched party reference;
+      expiry/termination distinguishable from completion.
+
+## 4. The portal delivery seam
+
+- [ ] 4.1 Subject-scoped portal-task read: list one portal subject's open
+      external tasks with case context, shaped for ADR-046 consumption
+      (descriptor aggregate, subject-scoped rows, no cross-subject rows or
+      counts).
+- [ ] 4.2 Delivery request record (portal inbox message + mail) written at
+      creation and re-ask, queryable delivery state, failure leaves the
+      task and suspension standing.
+
+## 5. Completion
+
+- [ ] 5.1 Completion endpoint on the portal seam: validate upload
+      constraints fail-closed, store each accepted file via
+      `FileService::addFile()` onto the CASE object BEFORE recording the
+      completion, reference the stored files from the completion.
+- [ ] 5.2 Completion authorization: acting portal subject vs stored party
+      reference, deny on any mismatch or unresolvable comparison, audit
+      every denial; no completion-on-behalf path.
+- [ ] 5.3 Keep `POST /api/flow-runs/{uuid}/resume` unable to touch an
+      external task (same contract as `flow-user-task-node`); regression
+      test it.
+
+## 6. Re-ask
+
+- [ ] 6.1 Re-entry path: slot task terminal + reason present → new task
+      (fresh match, reason, cycle number, previous task uuid) + delivery;
+      slot task terminal + reason absent → fail the firing naming the
+      missing reason; slot task open → suspend again (heartbeat case).
+
+## 7. The external performer type (flow-tasks delta)
+
+- [ ] 7.1 Extend the task entity/service with `performer_type: external`
+      and the party-reference performer shape; refuse `claim`, `unclaim`
+      and `delegate` for it naming the performer type.
+- [ ] 7.2 Exclude external tasks from every Nextcloud inbox query, count
+      and projection; keep them readable on their anchored object for
+      authorized caseworkers, with delivery state.
+
+## 8. Timers
+
+- [ ] 8.1 Pass `due_at`/`expires_at` references through to the task; wire
+      the preBreach (party reminder via the portal seam) and slaBreached
+      (caseworker escalation) rung addressing as consumption of
+      `flow-business-timers`; add no clock, sweep or business-day code
+      here.
+
+## 9. Follow-up (not in this change)
+
+- [ ] 9.1 portaliq: a follow-up change IN PORTALIQ'S REPO contributes the
+      portal-task collection and completion action (rendering the task,
+      the upload form and the inbox message) against the seam of section
+      4. One canonical home per spec; nothing of it is specified here.
+
+## 10. Tests
+
+- [ ] 10.1 Node unit tests: idempotence across a heartbeat wake, empty
+      firing, frozen match incl. the case-edit regression, re-ask cycle
+      and mandatory reason, expiry-vs-completion distinguishability,
+      non-null `resumeAt`.
+- [ ] 10.2 Authorization and validation tables: wrong subject,
+      unresolvable subject, missing required upload, oversized file, and
+      the refused verbs (`claim`/`unclaim`/`delegate`) on an external
+      task.
+- [ ] 10.3 Playwright coverage for the six `@e2e`-marked scenarios across
+      `specs/flow-portal-task/spec.md` and `specs/flow-tasks/spec.md`,
+      including the negative one: another portal subject cannot complete
+      a task that is not theirs.
+
+## Acceptance criteria
+
+- A flow containing a portal-task node matches the case's initiator,
+  creates exactly one external task, suspends with a non-null `resumeAt`,
+  and continues only on task terminality, verified across a heartbeat
+  wake.
+- The uploaded file exists as an OR file attachment on the case object
+  before the completion is recorded; no portal-private file store exists.
+- Completion is denied to every caller but the matched portal subject,
+  fail-closed, including through the run resume endpoint.
+- A re-ask produces a new task with a mandatory reason, a cycle number and
+  the previous task's uuid; the previous task is untouched.
+- External tasks appear in no Nextcloud inbox and no notification or
+  VTODO projection, and remain visible with delivery state on their
+  anchored case.
+- No timer logic exists in this change; reminder and escalation are
+  expressed as `flow-business-timers` rungs.
+- `AwaitSignalNode`, `UserTaskNode`, `FlowRunController::resume()` and all
+  existing endpoints are unchanged.
+
+## Quality checklist
+
+- `composer check:strict` passes (PHPCS, PHPMD, Psalm, PHPStan).
+- Every new PHP file carries `@license EUPL-1.2` and
+  `@copyright 2026 Conduction B.V.`; every public/protected method carries
+  a `@spec openspec/changes/flow-portal-task/...` anchor.
+- Depends on `flow-task-entity` and `flow-user-task-node`; deploy order is
+  that chain, then this change, then portaliq's contribution change.
+- References ADR-098 D3 as amended 2026-08-31 (`external` performer;
+  upload lands on the case object), ADR-046, ADR-108, ADR-022, ADR-005,
+  ADR-031 (design.md D-2).


### PR DESCRIPTION
## What

A new openspec change, `openspec/changes/flow-portal-task/` (kind: code, depends on `flow-task-entity` and `flow-user-task-node`). Spec only, no implementation code.

It specifies `openregister.portal-task`: a step node that asks a party outside the Nextcloud instance, for the dossiq hersteltermijn shape and everything like it.

- **A separate node, not an external mode of user-task.** The performer resolution, the delivery channel and the completion payload all differ; a mode would make half of each node's config keys invalid depending on the mode. Argued in design.md D-1.
- **Matching from the case**: the party comes from the subject case object's party role (default the initiator), frozen at creation and audited. A case naming nobody fails the firing loudly.
- **External performer type** (ADR-098 D3 as amended 2026-08-31): delta on the `flow-tasks` capability. Never pooled, never claimable or delegable, absent from every Nextcloud inbox, completion matched to the stored party reference fail-closed.
- **Heartbeat-safe suspension**: non-null `resumeAt` always, copying AwaitSignalNode's discipline. `findAbandonedSignals()` matches `resume_at IS NULL` and the 14-day reaper must never see a hersteltermijn.
- **Delivery through portaliq's contribution surface** (ADR-046): portal inbox message plus mail, descriptors aggregate, rows subject-scoped. The rendering is a follow-up change in portaliq's repo; tasks.md carries exactly one pointer line for it.
- **Upload lands on the case object** as an OR file attachment (ADR-022, decision 2026-08-31), stored before the completion is recorded; dossier folder views are projections.
- **Re-ask is graph re-entry** with a mandatory reason, a cycle count and the previous task's uuid.
- **The overdue path consumes `flow-business-timers`** (preBreach reminder to the party, slaBreached escalation to the caseworker role); the node owns no clock.

## Structure

Mirrors `flow-user-task-node` (proposal, design, specs, tasks; tasks capped at 20). Every scenario carries an `@e2e` reference or a reason-bearing exclude. The openspec CLI is not available in this environment, so the structure was mirrored file for file instead of CLI-validated.

## Relation to in-flight work

`flow-task-entity` and `flow-user-task-node` are being implemented in parallel; this change references their surface (TaskService verbs, resume-slot idempotence, outcome placement, cancellation propagation) and contradicts none of it. The companion ADR amendment is ConductionNL/hydra#641; the sibling read-surface change is the `flow-runs-subject-scope` PR.