### PR TITLE
spec(flow-runs-subject-scope): the case page's view of the engine

### DIFF
--- a/openspec/changes/flow-runs-subject-scope/design.md
+++ b/openspec/changes/flow-runs-subject-scope/design.md
@@ -1,0 +1,116 @@
+# Design: flow-runs-subject-scope
+
+## Context
+
+Measured, in the shipped code:
+
+- `FlowRun` stores the subject anchor (`lib/Db/FlowRun.php:241-255`:
+  `subjectUuid`, `subjectRegister`, `subjectSchema`) and defines the
+  status sets (`ACTIVE` at `:159`, `TERMINAL` at `:142`).
+- `FlowRunController::active()` (`lib/Controller/FlowRunController.php:225`)
+  resolves the caller's organisation, returns empty without querying when
+  none resolves, caps the limit at 50, and reduces each run through
+  `summarise()` (`:277-299`), which already carries uuid, flowName,
+  status, subject block, step and created.
+- `FlowRunMapper::findActive()`/`countActive()`
+  (`lib/Db/FlowRunMapper.php:477`, `:565`) filter on status set and
+  organisation only.
+- The `or-flow-active-runs` capability pins the boundary: strict per-org
+  scoping, unattributed runs returned to nobody, honest totals, and "the
+  run history surface is unchanged".
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One datastore-filtered read for "live runs on this subject" and one for
+  "finished runs on this subject", both inside the existing org scope.
+- A row contract a case-detail widget can render without a second request
+  per row.
+
+**Non-Goals:**
+
+- Any change to the org-wide dashboard behaviour, the history endpoint,
+  or run visibility rules.
+- Cross-subject or cross-org aggregation, free-text search, or filtering
+  on register/schema (the uuid identifies the case; the widget already
+  knows which case it is on).
+- The widget itself (nc-vue follow-up).
+
+## Decisions
+
+### D-1: The live filter is a parameter on the existing endpoint, not a new route
+
+`flow-runs/active` already has the organisation resolution, the limit
+cap, the summarise shape and a consumer. A `subject` parameter narrows
+it; a parallel `/active-for-subject` route would duplicate all four and
+drift. The parameter is optional and absent means bit-identical behaviour
+to today, which keeps the existing widget untouched.
+
+### D-2: The filter narrows in the datastore, after the organisation predicate
+
+The mapper gains an optional subject argument added as an `AND` predicate
+next to the existing organisation predicate. Order of evaluation is a
+correctness statement, not an optimisation: the organisation scope is
+applied unconditionally first, so a guessed subject uuid from another
+tenant matches zero rows rather than leaking one. Client-side filtering
+is refused for the same reason the task inbox spec refuses it: a filter
+over a server-paginated page silently drops rows the page did not
+contain. The `total` is counted with the same predicates as the rows.
+
+### D-3: The completed read is a new, subject-REQUIRED surface
+
+The existing capability forbids widening the history endpoint, so case
+history gets its own read with a deliberately narrow contract: the
+subject uuid is REQUIRED (there is no org-wide "all finished runs" here;
+that is what the history endpoint already serves to its audience),
+status is the `FlowRun::TERMINAL` set, ordering is newest first, and the
+result is bounded with an honest total. It reuses `summarise()`
+unchanged: a finished run's row needs nothing a live run's row lacks,
+and one shape means the widget renders one list.
+
+### D-4: The row contract names the widget's five fields and freezes the exclusions
+
+What a case-detail widget needs is run uuid, flow name, current step,
+status and started at; the shipped `summarise()` already carries all five
+(started at is served by `created`) plus the subject block. The spec
+therefore pins the CONTRACT rather than inventing a shape: those fields
+present on every row, and the marking, items and step log absent, for the
+same reason `or-flow-active-runs` gives: kilobytes per row a list never
+renders, and items can hold the record data itself. The single-run
+endpoint stays the place to ask for a run's contents.
+
+### D-5: One supporting index
+
+The live read today scans on `(status, organisation)` shapes; adding the
+subject predicate makes `(organisation, subject_uuid, status)` the
+selective path for both new reads. One migration, one composite index; no
+schema change to the entity.
+
+## Risks / Trade-offs
+
+- **A subject uuid is not secret.** Mitigated structurally: the
+  organisation predicate is unconditional, so knowing a uuid from another
+  tenant yields an empty result, indistinguishable from a case with no
+  runs.
+- **Two reads can drift in shape.** Mitigated by sharing `summarise()`;
+  the spec makes the shared row a requirement, so a divergence is a spec
+  violation rather than a taste question.
+- **Unbounded history growth on busy cases.** The completed read is
+  bounded with the same cap discipline as the live read and ordered
+  newest first; "everything ever" stays on the history surface where its
+  existing audience and filters live.
+
+## Migration Plan
+
+Additive: one parameter, one route, two mapper methods, one index
+migration. No consumer changes behaviour until it passes `subject`.
+Rollback is dropping the route and parameter; the index is harmless to
+leave.
+
+## Open Questions
+
+- **Does the widget also want counts per status** (2 live, 14 finished)
+  for a badge? The honest totals of the two reads already provide both
+  numbers at one request each; a combined count endpoint is deferred
+  until a consumer measures the two requests as a problem.

--- a/openspec/changes/flow-runs-subject-scope/proposal.md
+++ b/openspec/changes/flow-runs-subject-scope/proposal.md
@@ -1,0 +1,112 @@
+---
+kind: code
+---
+
+# Proposal: flow-runs-subject-scope
+
+## Summary
+
+Let a case page ask "what is running on THIS case, and what already ran".
+The live-runs read (`GET /api/flow-runs/active`) accepts an optional
+`subject` filter matching `FlowRun.subject_uuid`, applied INSIDE the
+caller's existing organisation scope. A new completed-runs read answers
+the history half for the same subject. Both reads return the row a
+case-detail widget needs (run uuid, flow name, current step, status,
+started at) and nothing heavier. The nc-vue widget consumption is a
+follow-up change in nc-vue; tasks.md carries one pointer line for it.
+
+## Why
+
+**The anchor exists; no read uses it.** `FlowRun` carries
+`subject_uuid`, `subject_register` and `subject_schema`
+(`lib/Db/FlowRun.php:241-255`), and the active endpoint's own
+`summarise()` already returns the subject block per row
+(`lib/Controller/FlowRunController.php:288-292`). But
+`FlowRunMapper::findActive()` and `countActive()` filter on organisation
+and nothing else (`lib/Db/FlowRunMapper.php:477`, `:565`), so the ONLY
+consumer today is the org-wide dashboard widget. A case detail page that
+wants "runs on this case" has to fetch the org-wide list and filter
+client-side, which silently drops any matching run outside the fetched
+page. The dossiq flow proof needs exactly that view: a hersteltermijn run
+suspended on a resident is invisible from the case it is about.
+
+**The history half has the same gap with an extra constraint.** The
+`or-flow-active-runs` capability requires that "the run history surface is
+unchanged": widening run visibility must not be done by widening the
+existing history endpoint. So a case page's "what already ran here" needs
+its own bounded, subject-required read rather than a loosened
+`flowRun#index`.
+
+**The tenant boundary must be unmovable by the new filter.** The
+live-runs read is strictly scoped to one organisation, an unattributed run
+is returned to nobody, and a caller with no organisation reads nothing
+without a query being issued (all three are existing `flow-active-runs`
+requirements). A subject filter must only ever NARROW that result: a
+subject uuid is guessable, and a filter that widened by subject would turn
+the case anchor into a cross-tenant read primitive.
+
+## What Changes
+
+- **`GET /api/flow-runs/active` accepts `subject`** (a subject object
+  uuid). The filter is applied in the datastore inside the organisation
+  scope; the returned `total` counts the filtered set.
+- **A completed-runs read for a subject**: terminal runs
+  (`FlowRun::TERMINAL`: completed, stopped, dead_letter, failed) for a
+  REQUIRED subject uuid, inside the caller's organisation scope, newest
+  first, bounded with an honest total. It reuses the existing summarise
+  row shape; it does not touch `flowRun#index`.
+- **The row contract is stated once for both reads**: uuid, flow name
+  (id fallback), current step (null when none), status, started at, and
+  the subject block; never the marking, the items or the step log.
+- **A supporting index** on the runs table so the subject reads are a
+  range scan, not a table walk.
+- **nc-vue follow-up (one task line)**: `CnFlowRunsWidget` gains a
+  `subject` option and a run deep link, in its own nc-vue change.
+
+## What does NOT change
+
+- **The org-wide behaviour of `flow-runs/active`.** No `subject` means
+  exactly today's read; every existing `flow-active-runs` requirement
+  (strict org scope, unattributed runs returned to nobody, bounded list,
+  honest total, name fallback, step derivation) holds unchanged with and
+  without the filter.
+- **`flowRun#index`, `flowRun#show` and every other run endpoint.** The
+  history surface keeps its current filters, shape and visibility, as the
+  existing capability requires.
+- **RBAC and organisation resolution.** The reads use the same
+  organisation resolution the active endpoint already uses; this change
+  adds no new authorization model.
+- **The widget itself.** nc-vue's `CnFlowRunsWidget` changes in nc-vue.
+
+## Capabilities
+
+### New Capabilities
+
+- `flow-runs-subject-scope`: the subject filter on the live-runs read,
+  the subject-required completed-runs read, and the shared case-widget
+  row contract.
+
+### Modified Capabilities
+
+<!-- None. flow-active-runs' requirements all hold unchanged; the subject
+     filter only narrows a result that capability already scopes, and the
+     completed read is a new surface, which is exactly what its
+     "run history surface is unchanged" requirement demands. -->
+
+## Impact
+
+- **Affected specs**: new `flow-runs-subject-scope`.
+- **Affected code**: `lib/Controller/FlowRunController.php` (`active()`
+  gains the parameter; one new controller method + route for the
+  completed read); `lib/Db/FlowRunMapper.php` (`findActive`/`countActive`
+  gain an optional subject argument; `findCompletedForSubject` +
+  `countCompletedForSubject`); one migration for the supporting index.
+- **Affected apps**: dossiq's case detail page and any app whose detail
+  page anchors runs to an object become consumers, through the nc-vue
+  widget follow-up.
+- **Depends on**: nothing beyond what exists. The subject columns,
+  the active endpoint and the summarise shape are all shipped.
+- **ADRs**: ADR-098 D4 (the case anchor is the OR object; this read is
+  that anchor's view of the engine), ADR-022 (apps consume OR
+  abstractions: the widget consumes this read instead of each app
+  building a run query), ADR-005 (fail-closed scoping).

--- a/openspec/changes/flow-runs-subject-scope/specs/flow-runs-subject-scope/spec.md
+++ b/openspec/changes/flow-runs-subject-scope/specs/flow-runs-subject-scope/spec.md
@@ -1,0 +1,130 @@
+## Purpose
+
+A case page's view of the engine: the live-runs read narrowed to one
+subject object, a completed-runs read for the same subject, and the row
+contract a case-detail widget renders. Everything stays inside the
+caller's existing organisation scope; the subject filter can only ever
+narrow.
+
+## ADDED Requirements
+
+### Requirement: The live-runs read accepts a subject filter that only narrows
+
+The live-runs read SHALL accept an optional `subject` parameter holding a
+subject object uuid. When present, only runs whose `subject_uuid` equals
+it SHALL be returned; when absent, the read SHALL behave exactly as it
+does today.
+
+The filter SHALL be applied in the datastore, as a predicate alongside
+the existing organisation predicate, with the organisation scope applied
+unconditionally. A run belonging to another organisation SHALL NOT be
+returned or counted even when its subject uuid matches: a subject uuid is
+guessable, and matching it grants nothing.
+
+A caller whose organisation cannot be resolved SHALL receive an empty
+result with no query issued, exactly as the unfiltered read already
+requires. The reported total SHALL count the FILTERED set, so a case
+widget can state what it could not fit.
+
+Filtering SHALL NOT be performed client-side over a paginated result: a
+page-then-filter read silently drops matching runs the page did not
+contain.
+
+#### Scenario: A case page lists only its own case's live runs
+
+- **GIVEN** three live runs in the caller's organisation, two anchored to
+  case X and one to case Y
+- **WHEN** the live runs are read with `subject` = case X's uuid
+- **THEN** exactly the two case X runs MUST be returned
+- **AND** the reported total MUST be 2
+- @e2e the case detail widget lists only the case's own runs
+
+#### Scenario: A matching subject in another organisation stays invisible
+
+- **GIVEN** a live run in organisation B anchored to a subject uuid known
+  to a caller in organisation A
+- **WHEN** the caller in organisation A reads the live runs with that
+  `subject`
+- **THEN** the result MUST be empty
+- **AND** the total MUST be 0
+- @e2e exclude covered by mapper unit tests over two organisations
+
+#### Scenario: No subject means today's read
+
+- **GIVEN** live runs across several subjects in the caller's organisation
+- **WHEN** the live runs are read without `subject`
+- **THEN** the result MUST equal the unfiltered org-scoped read
+- @e2e exclude regression covered by the existing active-runs tests
+
+### Requirement: A completed-runs read answers what already ran on this subject
+
+The system SHALL expose a completed-runs read that returns terminal runs
+(the run entity's terminal status set: completed, stopped, dead_letter,
+failed) anchored to a REQUIRED subject uuid, inside the caller's
+organisation scope.
+
+The subject SHALL be required: a request without one SHALL be refused,
+not treated as an org-wide history. The existing run history surface
+SHALL keep its current filters, shape and visibility; this read is a new
+surface beside it, not a widening of it.
+
+Rows SHALL be ordered newest first, bounded by a capped limit, and
+accompanied by an honest total counted with the same predicates. The
+organisation and no-organisation rules of the live read SHALL apply
+identically.
+
+#### Scenario: A finished run shows up in the case's history
+
+- **GIVEN** a run anchored to case X that has completed, and a live run on
+  the same case
+- **WHEN** the completed runs are read with `subject` = case X's uuid
+- **THEN** the completed run MUST be returned with its terminal status
+- **AND** the live run MUST NOT be in this result
+- @e2e a finished flow appears in the case detail's run history
+
+#### Scenario: History without a subject is refused
+
+- **GIVEN** an authenticated caller
+- **WHEN** the completed-runs read is requested without a subject
+- **THEN** the request MUST be refused with an error naming the missing
+  parameter
+- @e2e exclude covered by controller unit tests
+
+#### Scenario: A failed run is history too
+
+- **GIVEN** a run anchored to case X that ended in `failed`
+- **WHEN** the completed runs are read for case X
+- **THEN** the failed run MUST be returned with status `failed`
+- @e2e exclude covered by mapper unit tests over the terminal set
+
+### Requirement: Both reads return the case-widget row and nothing heavier
+
+Every row returned by the subject-filtered live read and by the
+completed-runs read SHALL carry at minimum: the run's uuid, the flow's
+human name (falling back to the flow id when no app claims it), the
+current step or null when the run has no marking, the status, the
+started-at timestamp, and the subject block (uuid, register, schema).
+
+The two reads SHALL share one row shape, so a widget renders live and
+finished runs as one list.
+
+A row SHALL NOT carry the run's marking, its item list or its step log.
+Those are kilobytes per run that a list never renders, and the item list
+can hold the subject's own record data; the single-run read remains the
+place to ask for a run's contents, and the run uuid in the row is the
+deep link to it.
+
+#### Scenario: The row carries the five widget fields
+
+- **GIVEN** a live run anchored to a case
+- **WHEN** the subject-filtered live runs are read
+- **THEN** its row MUST carry uuid, flow name, step, status and the
+  started-at timestamp
+- @e2e exclude covered by controller unit tests over the summarised shape
+
+#### Scenario: The row stays light
+
+- **GIVEN** a completed run with items and a step log
+- **WHEN** the completed runs are read for its subject
+- **THEN** its row MUST NOT contain the marking, the items or the step log
+- @e2e exclude covered by controller unit tests over the summarised shape

--- a/openspec/changes/flow-runs-subject-scope/tasks.md
+++ b/openspec/changes/flow-runs-subject-scope/tasks.md
@@ -1,0 +1,80 @@
+# Tasks: flow-runs-subject-scope
+
+## 1. The subject filter on the live read
+
+- [ ] 1.1 `FlowRunMapper::findActive()` and `countActive()` gain an
+      optional `subject` argument, added as an `AND` predicate on
+      `subject_uuid` next to the unconditional organisation predicate
+      (`lib/Db/FlowRunMapper.php:477`, `:565`). Rows and total share the
+      predicates.
+- [ ] 1.2 `FlowRunController::active()` reads the `subject` request
+      parameter and passes it through
+      (`lib/Controller/FlowRunController.php:225`). Absent parameter is
+      bit-identical to today; the no-organisation early return stays
+      before any query.
+
+## 2. The completed-runs read
+
+- [ ] 2.1 `FlowRunMapper::findCompletedForSubject()` +
+      `countCompletedForSubject()`: `FlowRun::TERMINAL` statuses
+      (`lib/Db/FlowRun.php:142`), required subject uuid, organisation
+      predicate, newest first, capped limit.
+- [ ] 2.2 `FlowRunController::completedForSubject()` + route
+      `GET /api/flow-runs/completed` in `appinfo/routes.php`, refusing a
+      request without `subject` and reusing `summarise()` unchanged. The
+      existing `flowRun#index` history endpoint is not touched.
+
+## 3. The index
+
+- [ ] 3.1 Migration adding a composite index over
+      `(organisation, subject_uuid, status)` on the runs table.
+
+## 4. Follow-up (not in this change)
+
+- [ ] 4.1 nc-vue: a follow-up change in nc-vue gives `CnFlowRunsWidget` a
+      `subject` option (rendering the case-scoped list on detail pages)
+      and a per-row deep link to the run, consuming these two reads.
+      Nothing of it is specified here.
+
+## 5. Tests
+
+- [ ] 5.1 Mapper unit tests: subject narrowing with honest totals; a
+      matching subject uuid in another organisation returns and counts
+      nothing; the terminal set drives the completed read (including
+      `failed`); newest-first ordering.
+- [ ] 5.2 Controller unit tests: absent `subject` equals today's read;
+      missing subject on the completed read is refused naming the
+      parameter; both reads return the summarised row (uuid, flow name,
+      step, status, started at, subject block) and never marking, items
+      or step log.
+- [ ] 5.3 Playwright coverage for the two `@e2e`-marked scenarios in
+      `specs/flow-runs-subject-scope/spec.md`: the case detail widget
+      lists only the case's own runs, and a finished flow appears in the
+      case detail's run history.
+
+## Acceptance criteria
+
+- `GET /api/flow-runs/active?subject=<uuid>` returns only that subject's
+  live runs inside the caller's organisation, with a total counting the
+  filtered set; without `subject` the response is unchanged from today.
+- A subject uuid from another organisation returns an empty result and a
+  zero total, with the organisation predicate applied in the datastore.
+- The completed-runs read requires a subject, serves the terminal status
+  set newest first with a capped limit and honest total, and leaves
+  `flowRun#index` untouched.
+- Both reads share the summarise row shape; no row carries marking, items
+  or a step log.
+- A caller with no resolvable organisation gets an empty result from both
+  reads with no query issued.
+
+## Quality checklist
+
+- `composer check:strict` passes (PHPCS, PHPMD, Psalm, PHPStan).
+- Every touched method carries a
+  `@spec openspec/changes/flow-runs-subject-scope/...` anchor; new code
+  carries `@license EUPL-1.2` and `@copyright 2026 Conduction B.V.`.
+- No dependency beyond shipped code: the subject columns, the active
+  endpoint and `summarise()` all exist on development.
+- References ADR-098 D4 (the case anchor), ADR-022 (widget consumes the
+  OR read), ADR-005 (fail-closed scoping); honours `or-flow-active-runs`'
+  "run history surface is unchanged" requirement.


### PR DESCRIPTION
## What

A new openspec change, `openspec/changes/flow-runs-subject-scope/` (kind: code, no dependencies beyond shipped code). Spec only, no implementation code.

A case detail page needs to answer "what is running on this case, and what already ran". The anchor exists (`FlowRun.subject_uuid`, already returned per row by the active endpoint's `summarise()`), but no read filters on it, so a case page would have to filter the org-wide list client-side and silently drop rows outside the fetched page.

- **`GET /api/flow-runs/active` gains an optional `subject` filter**, applied in the datastore inside the caller's existing organisation scope. The filter only narrows: a guessed subject uuid from another tenant matches zero rows, and the total counts the filtered set. Absent parameter is bit-identical to today.
- **A completed-runs read for a required subject**: `FlowRun::TERMINAL` statuses, newest first, bounded, honest total. A new surface beside `flowRun#index`, honouring `or-flow-active-runs`' requirement that the run history surface stays unchanged.
- **One row contract for both reads**: run uuid, flow name, current step, status, started at, subject block; never the marking, items or step log. Reuses `summarise()` so live and finished runs render as one widget list.
- **nc-vue consumption is one follow-up task line**: `CnFlowRunsWidget` gains a `subject` option and a run deep link in its own nc-vue change.

## Structure

Mirrors the flow-* change structure (proposal, design, specs, tasks). Every scenario carries an `@e2e` reference or a reason-bearing exclude. The openspec CLI is not available in this environment, so the structure was mirrored instead of CLI-validated.

## Relation

Sibling of the `flow-portal-task` spec PR (#3249) and the ADR-098 amendment ConductionNL/hydra#641; together they are the spec set for the dossiq flow proof.