### PR TITLE
feat(flow): send-notification, send-email and send-talk-message nodes through the notification subsystem

### DIFF
--- a/lib/Listener/FlowNodeRegistrationListener.php
+++ b/lib/Listener/FlowNodeRegistrationListener.php
@@ -40,6 +40,9 @@ use OCA\OpenRegister\Service\Flow\Nodes\MergeNode;
 use OCA\OpenRegister\Service\Flow\Nodes\ObjectReadNode;
 use OCA\OpenRegister\Service\Flow\Nodes\ObjectWriteNode;
 use OCA\OpenRegister\Service\Flow\Nodes\RouterNode;
+use OCA\OpenRegister\Service\Flow\Nodes\SendEmailNode;
+use OCA\OpenRegister\Service\Flow\Nodes\SendNotificationNode;
+use OCA\OpenRegister\Service\Flow\Nodes\SendTalkMessageNode;
 use OCA\OpenRegister\Service\Flow\Nodes\SetFieldsNode;
 use OCA\OpenRegister\Service\Flow\Nodes\SubFlowNode;
 use OCA\OpenRegister\Service\Flow\Nodes\SwitchNode;
@@ -76,6 +79,9 @@ class FlowNodeRegistrationListener implements IEventListener {
 	 * @param FlowStateNode $flowState The built-in "Flow state" node.
 	 * @param MapNode $map The built-in "Map" node.
 	 * @param IterateNode $iterate The built-in "Repeat until done" node.
+	 * @param SendNotificationNode $sendNotification The built-in "Send a notification" node.
+	 * @param SendEmailNode $sendEmail The built-in "Send an email" node.
+	 * @param SendTalkMessageNode $sendTalkMessage The built-in "Send a Talk message" node.
 	 * @param TriggerObjectNode $triggerObject The "When an object changes" entry point.
 	 * @param TriggerScheduleNode $triggerSchedule The "On a schedule" entry point.
 	 * @param TriggerManualNode $triggerManual The "When someone runs it" entry point.
@@ -97,6 +103,9 @@ class FlowNodeRegistrationListener implements IEventListener {
 		private readonly FlowStateNode $flowState,
 		private readonly MapNode $map,
 		private readonly IterateNode $iterate,
+		private readonly SendNotificationNode $sendNotification,
+		private readonly SendEmailNode $sendEmail,
+		private readonly SendTalkMessageNode $sendTalkMessage,
 		private readonly TriggerObjectNode $triggerObject,
 		private readonly TriggerScheduleNode $triggerSchedule,
 		private readonly TriggerManualNode $triggerManual,
@@ -134,6 +143,16 @@ class FlowNodeRegistrationListener implements IEventListener {
 		$event->registerNode(node: $this->flowState);
 		$event->registerNode(node: $this->map);
 		$event->registerNode(node: $this->iterate);
+
+		// Messaging. Three nodes, not one "send" with a channel picker: the
+		// three differ in config shape and failure modes, so three flat forms
+		// beat one union form. Deliberately NO send-webhook — outbound HTTP is
+		// OpenConnector's job (ADR-094), and `activity`/`web-push` are not
+		// channels here either: activity is an audit surface, web-push rides
+		// along with send-notification exactly as it does declaratively.
+		$event->registerNode(node: $this->sendNotification);
+		$event->registerNode(node: $this->sendEmail);
+		$event->registerNode(node: $this->sendTalkMessage);
 
 		// Entry points. Registered like any other node so the palette can offer
 		// them and the preflight can check their config — a trigger is where a

--- a/lib/Notification/AnnotationNotifier.php
+++ b/lib/Notification/AnnotationNotifier.php
@@ -126,7 +126,15 @@ class AnnotationNotifier implements INotifier {
 		// localised string with the object title + register name substituted.
 		$objectTitle = (string)($params['objectTitle'] ?? $l->t('object'));
 		$registerName = (string)($params['registerName'] ?? ($params['registerId'] ?? ''));
-		$parsedSubject = $l->t(self::SUBJECT_TEMPLATES[$subject], [$objectTitle, $registerName]);
+		// Only a canonical object subject has a template; a custom subject
+		// (e.g. a flow send's `flow_message`) reaches this point purely on its
+		// `_text`, and indexing SUBJECT_TEMPLATES with it would be an
+		// undefined-key error that killed the render.
+		$parsedSubject = '';
+		if ($isObject === true) {
+			$parsedSubject = $l->t(self::SUBJECT_TEMPLATES[$subject], [$objectTitle, $registerName]);
+		}
+
 		if ($hasText === true) {
 			$parsedSubject = $text;
 		}

--- a/lib/Service/Flow/FlowEngine.php
+++ b/lib/Service/Flow/FlowEngine.php
@@ -486,7 +486,7 @@ class FlowEngine {
 
 				$produced = $dispatcher->dispatch(step: $step, items: $itemsIn, context: $context);
 				$items = FlowItems::normalise(value: $produced);
-				$log[] = [
+				$entry = [
 					'transition' => $name,
 					'type' => $stepType,
 					'status' => 'completed',
@@ -501,6 +501,17 @@ class FlowEngine {
 					'output' => $this->sampleItems(items: $items),
 					'durationMs' => (int)round((microtime(true) - $startedAt) * 1000),
 				];
+
+				// What the step LOGGED, beyond its items: a side-effect node's
+				// own report (a send node's per-recipient outcomes, say). The
+				// report handle travels in the context and is drained per hop,
+				// so a node's detail lands on ITS entry and no other.
+				$report = $this->stepReport(context: $context);
+				if ($report !== []) {
+					$entry['report'] = $report;
+				}
+
+				$log[] = $entry;
 			} catch (FlowStop $stop) {
 				// A deliberate end, requested by a Stop step. Caught before the
 				// generic Throwable so it is never treated as a step failure and
@@ -552,13 +563,23 @@ class FlowEngine {
 					'resumeAt' => $suspension->getResumeAt(),
 				];
 			} catch (Throwable $e) {
-				$log[] = [
+				$entry = [
 					'transition' => $name,
 					'type' => $stepType,
 					'status' => 'failed',
 					'error' => $e->getMessage(),
 					'durationMs' => (int)round((microtime(true) - $startedAt) * 1000),
 				];
+
+				// A failing step's report is worth MORE than a completing one's:
+				// a send node that delivered to two recipients and failed on the
+				// third records exactly which sends went out before the throw.
+				$report = $this->stepReport(context: $context);
+				if ($report !== []) {
+					$entry['report'] = $report;
+				}
+
+				$log[] = $entry;
 				$outcome = $this->outcomeForFailedStep(
 					step: $step,
 					error: $e,
@@ -693,6 +714,28 @@ class FlowEngine {
 
 		return null;
 	}//end outcomeForFailedStep()
+
+	/**
+	 * Drain the hop's step report from the context, when one travels there.
+	 *
+	 * Taking (rather than reading) is what scopes a report to one hop: the
+	 * handle is cleared by the read, so a node's detail can never bleed onto a
+	 * later step's log entry.
+	 *
+	 * @param array $context The run context.
+	 *
+	 * @return array<string, mixed> The report detail, or an empty array.
+	 *
+	 * @spec openspec/specs/flow-engine/spec.md#requirement-a-run-records-what-each-node-received-returned-and-logged
+	 */
+	private function stepReport(array $context): array {
+		$report = ($context[FlowStepReport::CONTEXT_KEY] ?? null);
+		if (($report instanceof FlowStepReport) === false) {
+			return [];
+		}
+
+		return $report->take();
+	}//end stepReport()
 
 	/**
 	 * A bounded, honest sample of an item list, for the run log.

--- a/lib/Service/Flow/FlowMessagingService.php
+++ b/lib/Service/Flow/FlowMessagingService.php
@@ -1,0 +1,842 @@
+<?php
+
+/**
+ * The bridge from a flow's send nodes onto the notification subsystem.
+ *
+ * A flow gains "tell a person"; it does not gain a second messaging stack.
+ * This service is an orchestration-time INVOKER of the ADR-031 subsystem's
+ * call-shared units — the channel senders, the recipient resolver, the
+ * dialect's placeholder evaluator, the RateLimiter, the per-channel kill
+ * switches. It carries no mailer, no Talk client, no recipient resolver and
+ * no template syntax of its own; everything that must not fork lives in
+ * `lib/Service/Notification/` and is invoked from here.
+ *
+ * Guards apply in order, each independently sufficient to stop a send:
+ * subsystem kill switches, then the recipient's own channel preference, then
+ * the post-expansion recipient bound, then the shared rate-limit budget.
+ * There is deliberately NO flow-messaging kill switch: stopping a sending
+ * flow is the per-flow `enabled` flag or the instance flow kill switch, both
+ * of which halt the run before this service is reached.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\Notification\EmailSender;
+use OCA\OpenRegister\Service\Notification\NcNotificationSender;
+use OCA\OpenRegister\Service\Notification\NotificationChannelPolicy;
+use OCA\OpenRegister\Service\Notification\NotificationPreferenceService;
+use OCA\OpenRegister\Service\Notification\NotificationRecipientResolver;
+use OCA\OpenRegister\Service\Notification\NotificationTemplating;
+use OCA\OpenRegister\Service\Notification\RateLimiter;
+use OCA\OpenRegister\Service\Notification\TalkSender;
+use OCA\OpenRegister\Service\Notification\TalkSendException;
+use OCP\IAppConfig;
+use OCP\IUserManager;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Sends on behalf of a flow run, through the notification subsystem.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) The service exists to wire the
+ * subsystem's units together for the flow caller; each dependency IS one of the
+ * shared units the spec obliges it to reuse rather than duplicate.
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) One guard chain in the spec's
+ * order plus per-channel delivery; PHPMD sums every guard's branches into the
+ * class total, and splitting the chain would hide the order it exists to state.
+ */
+class FlowMessagingService {
+
+	/**
+	 * The preference scope flow sends resolve under. Flow sends have no
+	 * schema, so their preference overrides live under this pseudo-slug and
+	 * the `send` key — one lever per user, honoured through the SAME
+	 * override store and resolver the declarative subsystem uses.
+	 */
+	public const PREFERENCE_SLUG = 'flow';
+
+	public const PREFERENCE_KEY = 'send';
+
+	/**
+	 * App-config key for the per-step recipient bound, and its default.
+	 * Modest on purpose: a recipient template that expands to the whole
+	 * instance is a configuration error to surface, not a broadcast to
+	 * perform. Raisable per instance via app config.
+	 */
+	public const CONFIG_RECIPIENT_BOUND = 'flow_messaging_recipient_bound';
+
+	public const DEFAULT_RECIPIENT_BOUND = 25;
+
+	/**
+	 * How many entries each outcome list in the report keeps. The run log's
+	 * existing sampling rule, applied to recipients.
+	 */
+	public const REPORT_SAMPLE = FlowEngine::LOG_ITEM_SAMPLE;
+
+	/**
+	 * Constructor. Every dependency is one of the subsystem's call-shared
+	 * units — the same objects the declarative dispatcher invokes.
+	 *
+	 * @param NotificationChannelPolicy $channelPolicy The subsystem's per-channel kill switches.
+	 * @param NotificationRecipientResolver $recipientResolver The subsystem's recipient resolver.
+	 * @param NotificationTemplating $templating The dialect's placeholder evaluator.
+	 * @param NcNotificationSender $ncSender The nc-notification channel sender (web-push rides along).
+	 * @param EmailSender $emailSender The email channel sender.
+	 * @param TalkSender $talkSender The Talk channel sender.
+	 * @param RateLimiter $rateLimiter The subsystem's rate limiter (shared per-recipient budget).
+	 * @param NotificationPreferenceService $preferences The recipient preference resolver.
+	 * @param IUserManager $userManager Resolves the acting user.
+	 * @param IAppConfig $appConfig App config for the recipient bound.
+	 * @param LoggerInterface $logger Logger for send diagnostics.
+	 *
+	 * @SuppressWarnings(PHPMD.ExcessiveParameterList) DI-injected shared units.
+	 */
+	public function __construct(
+		private readonly NotificationChannelPolicy $channelPolicy,
+		private readonly NotificationRecipientResolver $recipientResolver,
+		private readonly NotificationTemplating $templating,
+		private readonly NcNotificationSender $ncSender,
+		private readonly EmailSender $emailSender,
+		private readonly TalkSender $talkSender,
+		private readonly RateLimiter $rateLimiter,
+		private readonly NotificationPreferenceService $preferences,
+		private readonly IUserManager $userManager,
+		private readonly IAppConfig $appConfig,
+		private readonly LoggerInterface $logger,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * Send an in-app Nextcloud notification (web-push riding along) per item.
+	 *
+	 * @param array $config The step configuration (`recipients`, `title`, `message`).
+	 * @param array $items The flow items; one send per recipient per item.
+	 * @param array $context The run context (acting user, report handle).
+	 * @param string $stepName The step's type id, used as the send's rule identity.
+	 *
+	 * @return array The outcome report also written to the run log.
+	 *
+	 * @throws RuntimeException When there is no resolvable acting user, the
+	 *                          recipient bound is exceeded, or a send failed.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
+	 */
+	public function sendNotification(array $config, array $items, array $context, string $stepName): array {
+		return $this->sendPerRecipient(
+			channel: 'nc-notification',
+			config: $config,
+			items: $items,
+			context: $context,
+			stepName: $stepName,
+			titleKey: 'title',
+			bodyKey: 'message'
+		);
+	}//end sendNotification()
+
+	/**
+	 * Send an email per recipient per item.
+	 *
+	 * @param array $config The step configuration (`recipients`, `subject`, `body`).
+	 * @param array $items The flow items; one send per recipient per item.
+	 * @param array $context The run context (acting user, report handle).
+	 * @param string $stepName The step's type id, used as the send's rule identity.
+	 *
+	 * @return array The outcome report also written to the run log.
+	 *
+	 * @throws RuntimeException When there is no resolvable acting user, the
+	 *                          recipient bound is exceeded, or a send failed.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
+	 */
+	public function sendEmail(array $config, array $items, array $context, string $stepName): array {
+		return $this->sendPerRecipient(
+			channel: 'email',
+			config: $config,
+			items: $items,
+			context: $context,
+			stepName: $stepName,
+			titleKey: 'subject',
+			bodyKey: 'body'
+		);
+	}//end sendEmail()
+
+	/**
+	 * Post a Talk chat message as the run's acting user, per item.
+	 *
+	 * The conversation is a token or an item-field template. The acting user
+	 * MUST be a participant; "not a participant" is a step failure with that
+	 * reason, never an auto-join.
+	 *
+	 * @param array $config The step configuration (`conversation`, `message`).
+	 * @param array $items The flow items; one post per item.
+	 * @param array $context The run context (acting user, report handle).
+	 * @param string $stepName The step's type id, used as the send's rule identity.
+	 *
+	 * @return array The outcome report also written to the run log.
+	 *
+	 * @throws RuntimeException When there is no resolvable acting user or a post failed.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flow-sends-are-attributed-logged-and-bounded
+	 */
+	public function sendTalkMessage(array $config, array $items, array $context, string $stepName): array {
+		$actor = $this->resolveActingUser(context: $context);
+
+		$outcomes = $this->emptyOutcomes();
+		$failures = [];
+
+		foreach ($items as $item) {
+			$json = (array)($item[FlowItems::JSON] ?? []);
+			$token = $this->resolveScalarConfig(value: (string)($config['conversation'] ?? ''), json: $json, context: $context);
+			$message = $this->templating->interpolate(
+				template: (string)($config['message'] ?? ''),
+				data: $json,
+				context: $this->scalarContext(context: $context)
+			);
+
+			if ($token === '') {
+				$failures[] = 'No Talk conversation resolved for an item; nothing was posted for it.';
+				$this->addOutcome(outcomes: $outcomes, bucket: 'failed', recipient: $token);
+				continue;
+			}
+
+			// The conversation is not a person: the rate bucket key uses the
+			// broadcast pseudo-recipient convention, outside the shared
+			// per-recipient budget.
+			if ($this->rateLimiter->tryConsume(ruleId: $stepName, recipient: '__talk__:' . $token) === false) {
+				$this->addOutcome(outcomes: $outcomes, bucket: 'rateLimited', recipient: $token);
+				continue;
+			}
+
+			try {
+				$outcome = $this->talkSender->postAsUser(token: $token, message: $message, actorUid: $actor);
+			} catch (TalkSendException $e) {
+				$failures[] = $e->getMessage();
+				$this->addOutcome(outcomes: $outcomes, bucket: 'failed', recipient: $token);
+				continue;
+			}
+
+			if ($outcome === TalkSender::OUTCOME_KILL_SWITCH) {
+				$this->addOutcome(outcomes: $outcomes, bucket: 'skippedByKillSwitch', recipient: $token);
+				continue;
+			}
+
+			$this->addOutcome(outcomes: $outcomes, bucket: 'delivered', recipient: $token);
+		}//end foreach
+
+		$report = $this->buildReport(
+			channel: 'talk',
+			actor: $actor,
+			recipients: 0,
+			outcomes: $outcomes,
+			unknown: []
+		);
+		$this->writeReport(context: $context, report: $report);
+
+		if ($failures !== []) {
+			throw new RuntimeException(
+				sprintf('%d of %d Talk posts failed: %s', count($failures), count($items), implode(' | ', array_slice($failures, 0, 3)))
+			);
+		}
+
+		return $report;
+	}//end sendTalkMessage()
+
+	/**
+	 * The shared per-recipient pipeline for nc-notification and email.
+	 *
+	 * Order of guards, each sufficient alone: channel kill switch, the
+	 * recipient's preference, the post-expansion recipient bound, the shared
+	 * rate-limit budget — then the send, through the subsystem's own sender.
+	 *
+	 * @param string $channel The channel (`nc-notification` or `email`).
+	 * @param array $config The step configuration.
+	 * @param array $items The flow items.
+	 * @param array $context The run context.
+	 * @param string $stepName The step's type id.
+	 * @param string $titleKey The config key holding the title/subject template.
+	 * @param string $bodyKey The config key holding the body template.
+	 *
+	 * @return array The outcome report.
+	 *
+	 * @throws RuntimeException Missing actor, exceeded bound, or failed sends.
+	 *
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity) The guard chain is the spec's own
+	 * order; each branch is one guard with its own outcome bucket.
+	 * @SuppressWarnings(PHPMD.NPathComplexity) Guards multiply; all are required.
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength) The chain reads top to bottom in
+	 * the order the spec states it; splitting it would hide the order.
+	 */
+	private function sendPerRecipient(
+		string $channel,
+		array $config,
+		array $items,
+		array $context,
+		string $stepName,
+		string $titleKey,
+		string $bodyKey,
+	): array {
+		$actor = $this->resolveActingUser(context: $context);
+
+		// Resolve recipients per item, post-expansion, before anything sends.
+		$perItem = [];
+		$unknown = [];
+		$distinct = [];
+		foreach ($items as $index => $item) {
+			$json = (array)($item[FlowItems::JSON] ?? []);
+			$resolved = $this->resolveRecipients(recipients: ($config['recipients'] ?? []), json: $json);
+			$perItem[$index] = ['json' => $json, 'uids' => $resolved['uids']];
+			foreach ($resolved['uids'] as $uid) {
+				$distinct[$uid] = true;
+			}
+
+			foreach ($resolved['unknown'] as $bad) {
+				$unknown[$bad] = true;
+			}
+		}
+
+		if ($unknown !== []) {
+			$this->logger->info(
+				sprintf(
+					'[FlowMessagingService] %d recipient entries did not resolve to a user or group: %s',
+					count($unknown),
+					implode(', ', array_slice(array_keys($unknown), 0, self::REPORT_SAMPLE))
+				)
+			);
+		}
+
+		$outcomes = $this->emptyOutcomes();
+		$failures = [];
+
+		// KILL SWITCH, first and channel-wide: a silenced channel is a skip
+		// recorded per recipient, never a failure and never a silent no-op.
+		if ($this->channelPolicy->isChannelEnabled(channel: $channel) === false) {
+			foreach (array_keys($distinct) as $uid) {
+				$this->addOutcome(outcomes: $outcomes, bucket: 'skippedByKillSwitch', recipient: (string)$uid);
+			}
+
+			$report = $this->buildReport(
+				channel: $channel,
+				actor: $actor,
+				recipients: count($distinct),
+				outcomes: $outcomes,
+				unknown: array_keys($unknown)
+			);
+			$this->writeReport(context: $context, report: $report);
+
+			return $report;
+		}
+
+		// PREFERENCE, per recipient: a user who turned the channel off stays
+		// not-messaged on it, flow or no flow. Applied before the bound so a
+		// preference-skipped user still counts toward the resolved total the
+		// bound judges (the config addressed them; their settings vetoed it).
+		$sendable = [];
+		foreach (array_keys($distinct) as $uid) {
+			if ($this->preferenceAllows(uid: (string)$uid, channel: $channel) === false) {
+				$this->addOutcome(outcomes: $outcomes, bucket: 'skippedByPreference', recipient: (string)$uid);
+				continue;
+			}
+
+			$sendable[(string)$uid] = true;
+		}
+
+		// RECIPIENT BOUND, post-expansion: bounding the resolved humans, not
+		// the config entries. Refusal is a step failure naming the count and
+		// the bound, routed through the step's `onError` policy — and nothing
+		// has been sent yet.
+		$bound = $this->recipientBound();
+		if (count($distinct) > $bound) {
+			$report = $this->buildReport(
+				channel: $channel,
+				actor: $actor,
+				recipients: count($distinct),
+				outcomes: $outcomes,
+				unknown: array_keys($unknown)
+			);
+			$this->writeReport(context: $context, report: $report);
+
+			throw new RuntimeException(
+				sprintf(
+					'The recipient list resolved to %d users, above the bound of %d; nothing was sent. Narrow the recipients, or raise "%s" in app config.',
+					count($distinct),
+					$bound,
+					self::CONFIG_RECIPIENT_BOUND
+				)
+			);
+		}
+
+		// RATE LIMIT then SEND, per recipient per item. The limiter's buckets
+		// are the subsystem's own — a shared budget with declarative sends.
+		foreach ($perItem as $entry) {
+			$title = $this->templating->interpolate(
+				template: (string)($config[$titleKey] ?? ''),
+				data: $entry['json'],
+				context: $this->scalarContext(context: $context)
+			);
+			$body = $this->templating->interpolate(
+				template: (string)($config[$bodyKey] ?? ''),
+				data: $entry['json'],
+				context: $this->scalarContext(context: $context)
+			);
+
+			$deliveredThisItem = [];
+			foreach ($entry['uids'] as $uid) {
+				if (isset($sendable[$uid]) === false) {
+					continue;
+				}
+
+				if ($this->rateLimiter->tryConsume(ruleId: $stepName, recipient: $uid) === false) {
+					$this->addOutcome(outcomes: $outcomes, bucket: 'rateLimited', recipient: $uid);
+					continue;
+				}
+
+				$outcome = $this->deliver(
+					channel: $channel,
+					uid: $uid,
+					title: $title,
+					body: $body,
+					json: $entry['json'],
+					stepName: $stepName
+				);
+
+				if ($outcome === 'dispatched') {
+					$this->addOutcome(outcomes: $outcomes, bucket: 'delivered', recipient: $uid);
+					$deliveredThisItem[] = $uid;
+					continue;
+				}
+
+				if ($outcome === 'kill-switch') {
+					$this->addOutcome(outcomes: $outcomes, bucket: 'skippedByKillSwitch', recipient: $uid);
+					continue;
+				}
+
+				$this->addOutcome(outcomes: $outcomes, bucket: 'failed', recipient: $uid);
+				$failures[] = sprintf('%s to "%s" failed (%s)', $channel, $uid, $outcome);
+			}//end foreach
+
+			// WEB-PUSH rides along with the nc-notification send under the
+			// dispatcher's existing rules, with no flow-side configuration:
+			// the job re-resolves each recipient to their stored
+			// subscriptions, so a user without one simply gets nothing.
+			if ($channel === 'nc-notification' && $deliveredThisItem !== []) {
+				$this->ncSender->enqueueWebPush(
+					recipients: $deliveredThisItem,
+					ruleId: $stepName,
+					originApp: 'openregister',
+					subject: $title,
+					message: $body,
+					actions: [],
+					object: $this->objectFromItem(json: $entry['json'])
+				);
+			}
+		}//end foreach
+
+		$report = $this->buildReport(
+			channel: $channel,
+			actor: $actor,
+			recipients: count($distinct),
+			outcomes: $outcomes,
+			unknown: array_keys($unknown)
+		);
+		$this->writeReport(context: $context, report: $report);
+
+		if ($failures !== []) {
+			throw new RuntimeException(
+				sprintf('%d %s send(s) failed: %s', count($failures), $channel, implode(' | ', array_slice($failures, 0, 3)))
+			);
+		}
+
+		return $report;
+	}//end sendPerRecipient()
+
+	/**
+	 * Deliver one message to one recipient over one channel, via the
+	 * subsystem's own sender.
+	 *
+	 * @param string $channel The channel.
+	 * @param string $uid The recipient.
+	 * @param string $title The rendered title/subject.
+	 * @param string $body The rendered body.
+	 * @param array $json The item's json, for the notification's object reference.
+	 * @param string $stepName The step's type id.
+	 *
+	 * @return string The sender's outcome.
+	 */
+	private function deliver(string $channel, string $uid, string $title, string $body, array $json, string $stepName): string {
+		if ($channel === 'email') {
+			return $this->emailSender->send(uid: $uid, subject: $title, body: $body);
+		}
+
+		return $this->ncSender->send(
+			uid: $uid,
+			object: $this->objectFromItem(json: $json),
+			subjectKey: 'flow_message',
+			name: $stepName,
+			subject: $title,
+			message: $body,
+			context: [],
+			originApp: 'openregister',
+			actions: [],
+			// Web-push rides along (enqueued after this item's sends), so the
+			// foreground popup is suppressed for the tag exactly as the
+			// declarative dispatcher suppresses it.
+			webPushActive: true
+		);
+	}//end deliver()
+
+	/**
+	 * The acting user the run executes as — never a system identity.
+	 *
+	 * A run without a resolvable acting user FAILS the step rather than
+	 * sending anonymously: the fallback would be an anonymous messenger
+	 * created by an edge case. The failure names the missing actor.
+	 *
+	 * @param array $context The run context.
+	 *
+	 * @return string The acting user's uid.
+	 *
+	 * @throws RuntimeException When no enabled acting user resolves.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flow-sends-are-attributed-logged-and-bounded
+	 */
+	private function resolveActingUser(array $context): string {
+		$uid = ($context['runAs'] ?? null);
+		if (is_string($uid) === false || trim($uid) === '') {
+			throw new RuntimeException(
+				'This flow run has no acting identity (runAs); a message must have a sender, so nothing was sent.'
+			);
+		}
+
+		$uid = trim($uid);
+		$user = $this->userManager->get($uid);
+		if ($user === null) {
+			throw new RuntimeException(
+				sprintf('This flow run\'s acting identity "%s" (runAs) is not a user account; nothing was sent.', $uid)
+			);
+		}
+
+		if ($user->isEnabled() === false) {
+			throw new RuntimeException(
+				sprintf('This flow run\'s acting identity "%s" (runAs) is a disabled account; nothing was sent on their behalf.', $uid)
+			);
+		}
+
+		return $uid;
+	}//end resolveActingUser()
+
+	/**
+	 * Resolve a node's recipients config against one item.
+	 *
+	 * Entries are literal user or group ids, or a template resolving a field
+	 * on the item (`{{ assignee }}` / `{{ item.assignee }}`). Resolution goes
+	 * through the subsystem's recipient resolver — groups expanded, every uid
+	 * verified — and unknown ids are returned for the run log rather than
+	 * silently dropped.
+	 *
+	 * @param mixed $recipients The config value.
+	 * @param array $json The item's json.
+	 *
+	 * @return array{uids: array<int, string>, unknown: array<int, string>}
+	 *
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity) Three entry shapes (template, user, group)
+	 * each with its own verification and unknown-reporting branch.
+	 */
+	private function resolveRecipients(mixed $recipients, array $json): array {
+		$uids = [];
+		$unknown = [];
+
+		if (is_string($recipients) === true) {
+			$recipients = [$recipients];
+		}
+
+		foreach ((array)$recipients as $entry) {
+			if (is_string($entry) === false || trim($entry) === '') {
+				continue;
+			}
+
+			$entry = trim($entry);
+
+			$matches = [];
+			if (preg_match('/^\{\{\s*(?:item\.)?([a-zA-Z0-9_.-]+)\s*\}\}$/', $entry, $matches) === 1) {
+				$field = $matches[1];
+				$resolved = $this->recipientResolver->resolve(
+					recipientsSpec: [
+						[
+							'kind' => 'relation',
+							'relation' => $field,
+						],
+					],
+					data: $json,
+					object: null,
+					context: []
+				);
+				$candidates = $this->recipientResolver->extractUidsFromRelation(value: ($json[$field] ?? null));
+				foreach (array_diff($candidates, $resolved) as $bad) {
+					$unknown[] = $bad;
+				}
+
+				foreach ($resolved as $uid) {
+					$uids[] = $uid;
+				}
+
+				continue;
+			}//end if
+
+			if ($this->recipientResolver->userExists(uid: $entry) === true) {
+				$uids[] = $entry;
+				continue;
+			}
+
+			if ($this->recipientResolver->groupExists(gid: $entry) === true) {
+				$members = $this->recipientResolver->resolve(
+					recipientsSpec: [
+						[
+							'kind' => 'groups',
+							'groups' => [$entry],
+						],
+					],
+					data: [],
+					object: null,
+					context: []
+				);
+				foreach ($members as $uid) {
+					$uids[] = $uid;
+				}
+
+				continue;
+			}
+
+			$unknown[] = $entry;
+		}//end foreach
+
+		return [
+			'uids' => array_values(array_unique($uids)),
+			'unknown' => array_values(array_unique($unknown)),
+		];
+	}//end resolveRecipients()
+
+	/**
+	 * Whether the recipient's own preference allows this channel.
+	 *
+	 * Resolved through the subsystem's preference service under the flow
+	 * scope, so an override stored there restricts flow sends the same way a
+	 * schema-scoped override restricts declarative ones.
+	 *
+	 * @param string $uid The recipient.
+	 * @param string $channel The channel.
+	 *
+	 * @return bool True when the send may proceed.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
+	 */
+	private function preferenceAllows(string $uid, string $channel): bool {
+		$effective = $this->preferences->resolveEffective(
+			schemaDefault: [
+				'enabled' => true,
+				'channels' => [$channel],
+			],
+			userId: $uid,
+			schemaSlug: self::PREFERENCE_SLUG,
+			notificationKey: self::PREFERENCE_KEY
+		);
+
+		if ($effective['enabled'] === false) {
+			return false;
+		}
+
+		if ($effective['channels'] !== null && in_array($channel, $effective['channels'], true) === false) {
+			return false;
+		}
+
+		return true;
+	}//end preferenceAllows()
+
+	/**
+	 * The per-step recipient bound: app-config raisable, never below one.
+	 *
+	 * @return int The bound.
+	 */
+	private function recipientBound(): int {
+		try {
+			$configured = (int)$this->appConfig->getValueInt(
+				NotificationChannelPolicy::APP_ID,
+				self::CONFIG_RECIPIENT_BOUND,
+				self::DEFAULT_RECIPIENT_BOUND
+			);
+		} catch (\Throwable $e) {
+			return self::DEFAULT_RECIPIENT_BOUND;
+		}
+
+		return max(1, $configured);
+	}//end recipientBound()
+
+	/**
+	 * A lightweight object reference for an item, for the notification's
+	 * object link. An item read from a register carries its uuid; an item
+	 * built mid-flow may not, and then the notification simply carries no
+	 * object deeplink.
+	 *
+	 * @param array $json The item's json.
+	 *
+	 * @return ObjectEntity The reference.
+	 */
+	private function objectFromItem(array $json): ObjectEntity {
+		$object = new ObjectEntity();
+		$uuid = ($json['uuid'] ?? ($json['id'] ?? null));
+		if (is_string($uuid) === true && $uuid !== '') {
+			$object->setUuid($uuid);
+		}
+
+		$name = ($json['name'] ?? ($json['title'] ?? null));
+		if (is_string($name) === true && $name !== '') {
+			$object->setName($name);
+		}
+
+		return $object;
+	}//end objectFromItem()
+
+	/**
+	 * The context's scalar values, for template interpolation. The node
+	 * context carries handles (the guard, the report); the dialect evaluator
+	 * only ever renders scalars, and handing it the full context would put
+	 * objects where it expects values.
+	 *
+	 * @param array $context The run context.
+	 *
+	 * @return array<string, mixed> The scalar entries only.
+	 */
+	private function scalarContext(array $context): array {
+		return array_filter($context, static fn (mixed $value): bool => is_scalar($value) === true);
+	}//end scalarContext()
+
+	/**
+	 * The empty outcome buckets.
+	 *
+	 * @return array<string, array<int, string>>
+	 */
+	private function emptyOutcomes(): array {
+		return [
+			'delivered' => [],
+			'skippedByPreference' => [],
+			'skippedByKillSwitch' => [],
+			'rateLimited' => [],
+			'failed' => [],
+		];
+	}//end emptyOutcomes()
+
+	/**
+	 * Record one outcome.
+	 *
+	 * @param array<string, array<int, string>> $outcomes The buckets, by reference.
+	 * @param string $bucket The outcome bucket.
+	 * @param string $recipient The recipient (or conversation token).
+	 *
+	 * @return void
+	 */
+	private function addOutcome(array &$outcomes, string $bucket, string $recipient): void {
+		$outcomes[$bucket][] = $recipient;
+	}//end addOutcome()
+
+	/**
+	 * The bounded outcome report for the run log.
+	 *
+	 * Bounded by the log's sampling rule: each bucket carries its true count
+	 * and at most REPORT_SAMPLE entries — a mail archive is not what a run
+	 * log is for, and neither is a recipient directory.
+	 *
+	 * @param string $channel The channel.
+	 * @param string $actor The acting user.
+	 * @param int $recipients The resolved distinct recipient count.
+	 * @param array<string, array<int, string>> $outcomes The outcome buckets.
+	 * @param array<int, string> $unknown Unresolvable recipient entries.
+	 *
+	 * @return array The report.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flow-sends-are-attributed-logged-and-bounded
+	 */
+	private function buildReport(string $channel, string $actor, int $recipients, array $outcomes, array $unknown): array {
+		$report = [
+			'channel' => $channel,
+			'actor' => $actor,
+			'recipients' => $recipients,
+		];
+
+		$truncated = false;
+		foreach ($outcomes as $bucket => $entries) {
+			$report[$bucket] = [
+				'count' => count($entries),
+				'sample' => array_slice(array_values($entries), 0, self::REPORT_SAMPLE),
+			];
+			if (count($entries) > self::REPORT_SAMPLE) {
+				$truncated = true;
+			}
+		}
+
+		if ($unknown !== []) {
+			$report['unknownRecipients'] = [
+				'count' => count($unknown),
+				'sample' => array_slice(array_values($unknown), 0, self::REPORT_SAMPLE),
+			];
+			if (count($unknown) > self::REPORT_SAMPLE) {
+				$truncated = true;
+			}
+		}
+
+		$report['truncated'] = $truncated;
+
+		return $report;
+	}//end buildReport()
+
+	/**
+	 * Write the report onto the run log via the context's report handle.
+	 *
+	 * @param array $context The run context.
+	 * @param array $report The report.
+	 *
+	 * @return void
+	 */
+	private function writeReport(array $context, array $report): void {
+		$handle = ($context[FlowStepReport::CONTEXT_KEY] ?? null);
+		if (($handle instanceof FlowStepReport) === false) {
+			return;
+		}
+
+		$handle->put(key: 'messaging', value: $report);
+	}//end writeReport()
+
+	/**
+	 * Resolve a config value that is a literal or a single-field template.
+	 *
+	 * @param string $value The config value.
+	 * @param array $json The item's json.
+	 * @param array $context The run context.
+	 *
+	 * @return string The resolved value.
+	 */
+	private function resolveScalarConfig(string $value, array $json, array $context): string {
+		$value = trim($value);
+		if (str_contains($value, '{{') === false) {
+			return $value;
+		}
+
+		return trim($this->templating->interpolate(template: $value, data: $json, context: $this->scalarContext(context: $context)));
+	}//end resolveScalarConfig()
+}//end class

--- a/lib/Service/Flow/FlowRunService.php
+++ b/lib/Service/Flow/FlowRunService.php
@@ -282,6 +282,7 @@ class FlowRunService {
 		$context[FlowToken::CONTEXT_KEY] = FlowToken::fromArray(($context[FlowToken::CONTEXT_KEY] ?? null));
 		$context[FlowResumeState::CONTEXT_KEY] = FlowResumeState::fromArray(($context[FlowResumeState::CONTEXT_KEY] ?? null));
 		$context[FlowRunGuard::CONTEXT_KEY] = $guard;
+		$context[FlowStepReport::CONTEXT_KEY] = new FlowStepReport();
 
 		// ATTRIBUTION. Read BEFORE the walk: the audit rows are written during
 		// it, so the base has to be predicted. See {@see FlowStepHistory}.

--- a/lib/Service/Flow/FlowStepReport.php
+++ b/lib/Service/Flow/FlowStepReport.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * A step's own report into the run log, carried through the node context.
+ *
+ * The run log records what a node RECEIVED and RETURNED; a node whose work is
+ * a side effect — a send, a call — has more to say than its pass-through items
+ * can carry. This handle travels in the context like the token, the resume
+ * state and the guard do (`IFlowNode::execute()` takes `$context` by value, so
+ * only an object survives the copy), and the engine drains it onto the step's
+ * own log entry after each hop.
+ *
+ * The report is per HOP: the engine takes it after each dispatch, so an entry
+ * a node wrote can never leak onto a later step's log line.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/flow-engine/spec.md#requirement-a-run-records-what-each-node-received-returned-and-logged
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+/**
+ * Collects a node's own log detail for the current hop.
+ */
+class FlowStepReport {
+
+	/**
+	 * The context key this handle travels under.
+	 */
+	public const CONTEXT_KEY = '_stepReport';
+
+	/**
+	 * The detail written by the current hop's node.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private array $detail = [];
+
+	/**
+	 * Record one piece of detail for the current step's log entry.
+	 *
+	 * A node MUST keep its report bounded itself — the run log is kept for
+	 * months, and the engine does not re-sample what a node chose to write.
+	 *
+	 * @param string $key The detail's name within the entry's `report` map.
+	 * @param mixed $value The detail; must be JSON-serialisable.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/flow-engine/spec.md#requirement-a-run-records-what-each-node-received-returned-and-logged
+	 */
+	public function put(string $key, mixed $value): void {
+		$this->detail[$key] = $value;
+	}//end put()
+
+	/**
+	 * Return and clear the current hop's detail.
+	 *
+	 * Clearing on read is what scopes the report to one hop: the engine takes
+	 * it while writing the step's log entry, and the next node starts blank.
+	 *
+	 * @return array<string, mixed> The detail written since the last take.
+	 *
+	 * @spec openspec/specs/flow-engine/spec.md#requirement-a-run-records-what-each-node-received-returned-and-logged
+	 */
+	public function take(): array {
+		$detail = $this->detail;
+		$this->detail = [];
+
+		return $detail;
+	}//end take()
+}//end class

--- a/lib/Service/Flow/Nodes/SendEmailNode.php
+++ b/lib/Service/Flow/Nodes/SendEmailNode.php
@@ -1,0 +1,214 @@
+<?php
+
+/**
+ * Sends an email at this point in the process.
+ *
+ * A thin invoker of the ADR-031 notification subsystem, through
+ * FlowMessagingService: the same mail composition/handoff, recipient
+ * resolver, templating, rate limiter and kill switches a schema annotation's
+ * email channel uses. No second mailer exists on the flow side.
+ *
+ * Sending is a side effect, not a transformation: items pass through
+ * unchanged. A bounced handoff is a step failure routed through `onError` —
+ * a COMPLETED run never hides an undelivered message.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow\Nodes
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow\Nodes;
+
+use OCA\OpenRegister\Service\Flow\FlowMessagingService;
+use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigForm;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\WorkflowEngine\IManager;
+use UnexpectedValueException;
+
+/**
+ * The "Send an email" step.
+ */
+class SendEmailNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigForm {
+
+	/**
+	 * The step type this node answers to.
+	 */
+	public const TYPE = 'openregister.send-email';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param FlowMessagingService $messaging The bridge onto the notification subsystem.
+	 * @param IL10N $l10n Translations.
+	 * @param IURLGenerator $urls For the palette icon.
+	 */
+	public function __construct(
+		private readonly FlowMessagingService $messaging,
+		private readonly IL10N $l10n,
+		private readonly IURLGenerator $urls,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * The step type.
+	 *
+	 * @return string The id.
+	 */
+	public function getId(): string {
+		return self::TYPE;
+	}//end getId()
+
+	/**
+	 * Palette name.
+	 *
+	 * @return string The display name.
+	 */
+	public function getDisplayName(): string {
+		return $this->l10n->t('Send an email');
+	}//end getDisplayName()
+
+	/**
+	 * Palette description.
+	 *
+	 * @return string The description.
+	 */
+	public function getDescription(): string {
+		return $this->l10n->t('Send an email to people, at this point in the flow.');
+	}//end getDescription()
+
+	/**
+	 * Palette icon.
+	 *
+	 * @return string The icon URL.
+	 */
+	public function getIcon(): string {
+		return $this->urls->imagePath('core', 'actions/mail.svg');
+	}//end getIcon()
+
+	/**
+	 * Messaging people is not privileged beyond the run's own identity, so
+	 * both scopes get it; every guardrail applies either way.
+	 *
+	 * @param int $scope The scope constant.
+	 *
+	 * @return boolean Whether it is available.
+	 */
+	public function isAvailableForScope(int $scope): bool {
+		return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
+	}//end isAvailableForScope()
+
+	/**
+	 * The config vocabulary of a send-email step.
+	 *
+	 * @return array<int, string> The accepted config keys.
+	 *
+	 * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+	 */
+	public function configKeys(): array {
+		return ['recipients', 'subject', 'body'];
+	}//end configKeys()
+
+	/**
+	 * Reject a mail with nothing to say or nobody to send it to.
+	 *
+	 * @param array $config The step configuration.
+	 *
+	 * @return void
+	 *
+	 * @throws UnexpectedValueException When the body or the recipients are empty.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
+	 */
+	public function validateConfig(array $config): void {
+		if (trim((string)($config['body'] ?? '')) === '') {
+			throw new UnexpectedValueException($this->l10n->t('An email needs a body.'));
+		}
+
+		$recipients = ($config['recipients'] ?? []);
+		if (is_string($recipients) === true) {
+			$recipients = [$recipients];
+		}
+
+		$recipients = array_filter(
+			(array)$recipients,
+			static fn (mixed $entry): bool => is_string($entry) === true && trim($entry) !== ''
+		);
+		if ($recipients === []) {
+			throw new UnexpectedValueException($this->l10n->t('An email needs at least one recipient.'));
+		}
+	}//end validateConfig()
+
+	/**
+	 * The fields this node's configuration is edited through.
+	 *
+	 * @return array<int, array<string, mixed>> The field descriptions.
+	 *
+	 * @spec openspec/changes/flow-node-config-forms/specs/flow-node-config-forms/spec.md
+	 */
+	public function configForm(): array {
+		return [
+			[
+				'key' => 'recipients',
+				'label' => $this->l10n->t('Who to mail'),
+				'type' => 'text',
+				'help' => $this->l10n->t('User or group ids, or a field on the item such as {{ assignee }}. Groups are expanded.'),
+				'required' => true,
+			],
+			[
+				'key' => 'subject',
+				'label' => $this->l10n->t('Subject'),
+				'type' => 'text',
+				'help' => $this->l10n->t('Placeholders such as {{ name }} read fields from the item, the same syntax a schema notification uses.'),
+			],
+			[
+				'key' => 'body',
+				'label' => $this->l10n->t('Body'),
+				'type' => 'textarea',
+				'help' => $this->l10n->t('What the email says. Placeholders read fields from the item.'),
+				'required' => true,
+			],
+		];
+	}//end configForm()
+
+	/**
+	 * Send, then pass the items through unchanged.
+	 *
+	 * Sending is a side effect, not a transformation. Failures throw and are
+	 * routed through the step's `onError` policy; every non-delivery lands in
+	 * the run log with its reason.
+	 *
+	 * @param array $items The input items.
+	 * @param array $config The step configuration.
+	 * @param array $context Run-level metadata.
+	 *
+	 * @return array The items, unchanged.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
+	 */
+	public function execute(array $items, array $config, array $context): array {
+		$this->messaging->sendEmail(
+			config: $config,
+			items: $items,
+			context: $context,
+			stepName: self::TYPE
+		);
+
+		return $items;
+	}//end execute()
+}//end class

--- a/lib/Service/Flow/Nodes/SendEmailNode.php
+++ b/lib/Service/Flow/Nodes/SendEmailNode.php
@@ -159,7 +159,7 @@ class SendEmailNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigFo
 	 *
 	 * @return array<int, array<string, mixed>> The field descriptions.
 	 *
-	 * @spec openspec/changes/flow-node-config-forms/specs/flow-node-config-forms/spec.md
+	 * @spec openspec/specs/flow-engine/spec.md#requirement-a-node-type-declares-its-own-form-and-its-own-run-log-actions
 	 */
 	public function configForm(): array {
 		return [

--- a/lib/Service/Flow/Nodes/SendNotificationNode.php
+++ b/lib/Service/Flow/Nodes/SendNotificationNode.php
@@ -1,0 +1,217 @@
+<?php
+
+/**
+ * Sends an in-app Nextcloud notification at this point in the process.
+ *
+ * A thin invoker of the ADR-031 notification subsystem, through
+ * FlowMessagingService: the same channel sender, recipient resolver,
+ * templating, rate limiter and kill switches a schema annotation uses. The
+ * boundary stands — notifications notify (whenever X happens), flows
+ * orchestrate (at this point in the process) — so this node accepts no
+ * schema or event subscription: a node that fires on events is a trigger,
+ * and triggering is already spec'd.
+ *
+ * Sending is a side effect, not a transformation: items pass through
+ * unchanged. Web-push rides along with the nc-notification channel under the
+ * dispatcher's existing rules, with no flow-side configuration.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow\Nodes
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow\Nodes;
+
+use OCA\OpenRegister\Service\Flow\FlowMessagingService;
+use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigForm;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\WorkflowEngine\IManager;
+use UnexpectedValueException;
+
+/**
+ * The "Send a notification" step.
+ */
+class SendNotificationNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigForm {
+
+	/**
+	 * The step type this node answers to.
+	 */
+	public const TYPE = 'openregister.send-notification';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param FlowMessagingService $messaging The bridge onto the notification subsystem.
+	 * @param IL10N $l10n Translations.
+	 * @param IURLGenerator $urls For the palette icon.
+	 */
+	public function __construct(
+		private readonly FlowMessagingService $messaging,
+		private readonly IL10N $l10n,
+		private readonly IURLGenerator $urls,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * The step type.
+	 *
+	 * @return string The id.
+	 */
+	public function getId(): string {
+		return self::TYPE;
+	}//end getId()
+
+	/**
+	 * Palette name.
+	 *
+	 * @return string The display name.
+	 */
+	public function getDisplayName(): string {
+		return $this->l10n->t('Send a notification');
+	}//end getDisplayName()
+
+	/**
+	 * Palette description.
+	 *
+	 * @return string The description.
+	 */
+	public function getDescription(): string {
+		return $this->l10n->t('Send an in-app notification to people, at this point in the flow.');
+	}//end getDescription()
+
+	/**
+	 * Palette icon.
+	 *
+	 * @return string The icon URL.
+	 */
+	public function getIcon(): string {
+		return $this->urls->imagePath('core', 'actions/sound.svg');
+	}//end getIcon()
+
+	/**
+	 * Messaging people is not privileged beyond the run's own identity, so
+	 * both scopes get it; every guardrail applies either way.
+	 *
+	 * @param int $scope The scope constant.
+	 *
+	 * @return boolean Whether it is available.
+	 */
+	public function isAvailableForScope(int $scope): bool {
+		return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
+	}//end isAvailableForScope()
+
+	/**
+	 * The config vocabulary of a send-notification step.
+	 *
+	 * @return array<int, string> The accepted config keys.
+	 *
+	 * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+	 */
+	public function configKeys(): array {
+		return ['recipients', 'title', 'message'];
+	}//end configKeys()
+
+	/**
+	 * Reject a send with nothing to say or nobody to say it to.
+	 *
+	 * @param array $config The step configuration.
+	 *
+	 * @return void
+	 *
+	 * @throws UnexpectedValueException When the message or the recipients are empty.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
+	 */
+	public function validateConfig(array $config): void {
+		if (trim((string)($config['message'] ?? '')) === '') {
+			throw new UnexpectedValueException($this->l10n->t('A notification needs a message.'));
+		}
+
+		$recipients = ($config['recipients'] ?? []);
+		if (is_string($recipients) === true) {
+			$recipients = [$recipients];
+		}
+
+		$recipients = array_filter(
+			(array)$recipients,
+			static fn (mixed $entry): bool => is_string($entry) === true && trim($entry) !== ''
+		);
+		if ($recipients === []) {
+			throw new UnexpectedValueException($this->l10n->t('A notification needs at least one recipient.'));
+		}
+	}//end validateConfig()
+
+	/**
+	 * The fields this node's configuration is edited through.
+	 *
+	 * @return array<int, array<string, mixed>> The field descriptions.
+	 *
+	 * @spec openspec/changes/flow-node-config-forms/specs/flow-node-config-forms/spec.md
+	 */
+	public function configForm(): array {
+		return [
+			[
+				'key' => 'recipients',
+				'label' => $this->l10n->t('Who to tell'),
+				'type' => 'text',
+				'help' => $this->l10n->t('User or group ids, or a field on the item such as {{ assignee }}. Groups are expanded.'),
+				'required' => true,
+			],
+			[
+				'key' => 'title',
+				'label' => $this->l10n->t('Title'),
+				'type' => 'text',
+				'help' => $this->l10n->t('Placeholders such as {{ name }} read fields from the item, the same syntax a schema notification uses.'),
+			],
+			[
+				'key' => 'message',
+				'label' => $this->l10n->t('Message'),
+				'type' => 'textarea',
+				'help' => $this->l10n->t('What the notification says. Placeholders read fields from the item.'),
+				'required' => true,
+			],
+		];
+	}//end configForm()
+
+	/**
+	 * Send, then pass the items through unchanged.
+	 *
+	 * Sending is a side effect, not a transformation. Failures throw and are
+	 * routed through the step's `onError` policy; every non-delivery lands in
+	 * the run log with its reason.
+	 *
+	 * @param array $items The input items.
+	 * @param array $config The step configuration.
+	 * @param array $context Run-level metadata.
+	 *
+	 * @return array The items, unchanged.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
+	 */
+	public function execute(array $items, array $config, array $context): array {
+		$this->messaging->sendNotification(
+			config: $config,
+			items: $items,
+			context: $context,
+			stepName: self::TYPE
+		);
+
+		return $items;
+	}//end execute()
+}//end class

--- a/lib/Service/Flow/Nodes/SendNotificationNode.php
+++ b/lib/Service/Flow/Nodes/SendNotificationNode.php
@@ -162,7 +162,7 @@ class SendNotificationNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeC
 	 *
 	 * @return array<int, array<string, mixed>> The field descriptions.
 	 *
-	 * @spec openspec/changes/flow-node-config-forms/specs/flow-node-config-forms/spec.md
+	 * @spec openspec/specs/flow-engine/spec.md#requirement-a-node-type-declares-its-own-form-and-its-own-run-log-actions
 	 */
 	public function configForm(): array {
 		return [

--- a/lib/Service/Flow/Nodes/SendTalkMessageNode.php
+++ b/lib/Service/Flow/Nodes/SendTalkMessageNode.php
@@ -1,0 +1,201 @@
+<?php
+
+/**
+ * Posts a Talk chat message at this point in the process.
+ *
+ * A thin invoker of the ADR-031 notification subsystem's Talk send unit,
+ * through FlowMessagingService. The message is attributed to the flow run's
+ * ACTING user — replies have an addressee, audits have an actor — which
+ * requires that user to be a participant of the target conversation. "Not a
+ * participant" is a step failure with that reason; the node NEVER auto-joins
+ * a user into a conversation, which would be a privacy-relevant side effect
+ * performed by a messaging convenience.
+ *
+ * Sending is a side effect, not a transformation: items pass through
+ * unchanged.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow\Nodes
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flow-sends-are-attributed-logged-and-bounded
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow\Nodes;
+
+use OCA\OpenRegister\Service\Flow\FlowMessagingService;
+use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigForm;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\WorkflowEngine\IManager;
+use UnexpectedValueException;
+
+/**
+ * The "Send a Talk message" step.
+ */
+class SendTalkMessageNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigForm {
+
+	/**
+	 * The step type this node answers to.
+	 */
+	public const TYPE = 'openregister.send-talk-message';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param FlowMessagingService $messaging The bridge onto the notification subsystem.
+	 * @param IL10N $l10n Translations.
+	 * @param IURLGenerator $urls For the palette icon.
+	 */
+	public function __construct(
+		private readonly FlowMessagingService $messaging,
+		private readonly IL10N $l10n,
+		private readonly IURLGenerator $urls,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * The step type.
+	 *
+	 * @return string The id.
+	 */
+	public function getId(): string {
+		return self::TYPE;
+	}//end getId()
+
+	/**
+	 * Palette name.
+	 *
+	 * @return string The display name.
+	 */
+	public function getDisplayName(): string {
+		return $this->l10n->t('Send a Talk message');
+	}//end getDisplayName()
+
+	/**
+	 * Palette description.
+	 *
+	 * @return string The description.
+	 */
+	public function getDescription(): string {
+		return $this->l10n->t('Post a chat message to a Talk conversation, as the user this flow runs as.');
+	}//end getDescription()
+
+	/**
+	 * Palette icon.
+	 *
+	 * @return string The icon URL.
+	 */
+	public function getIcon(): string {
+		return $this->urls->imagePath('core', 'actions/comment.svg');
+	}//end getIcon()
+
+	/**
+	 * Posting requires the acting user to be a participant either way, so
+	 * both scopes get it; every guardrail applies regardless.
+	 *
+	 * @param int $scope The scope constant.
+	 *
+	 * @return boolean Whether it is available.
+	 */
+	public function isAvailableForScope(int $scope): bool {
+		return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
+	}//end isAvailableForScope()
+
+	/**
+	 * The config vocabulary of a send-talk-message step.
+	 *
+	 * @return array<int, string> The accepted config keys.
+	 *
+	 * @spec openspec/changes/or-flow-preflight/specs/flow-preflight/spec.md
+	 */
+	public function configKeys(): array {
+		return ['conversation', 'message'];
+	}//end configKeys()
+
+	/**
+	 * Reject a post with nothing to say or no conversation to say it in.
+	 *
+	 * @param array $config The step configuration.
+	 *
+	 * @return void
+	 *
+	 * @throws UnexpectedValueException When the message or the conversation is empty.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
+	 */
+	public function validateConfig(array $config): void {
+		if (trim((string)($config['message'] ?? '')) === '') {
+			throw new UnexpectedValueException($this->l10n->t('A Talk message needs a message.'));
+		}
+
+		if (trim((string)($config['conversation'] ?? '')) === '') {
+			throw new UnexpectedValueException($this->l10n->t('A Talk message needs a conversation token, or a field on the item that holds one.'));
+		}
+	}//end validateConfig()
+
+	/**
+	 * The fields this node's configuration is edited through.
+	 *
+	 * @return array<int, array<string, mixed>> The field descriptions.
+	 *
+	 * @spec openspec/changes/flow-node-config-forms/specs/flow-node-config-forms/spec.md
+	 */
+	public function configForm(): array {
+		return [
+			[
+				'key' => 'conversation',
+				'label' => $this->l10n->t('Conversation'),
+				'type' => 'text',
+				'help' => $this->l10n->t('A conversation token, or a field on the item such as {{ conversationToken }}. The acting user must be a participant.'),
+				'required' => true,
+			],
+			[
+				'key' => 'message',
+				'label' => $this->l10n->t('Message'),
+				'type' => 'textarea',
+				'help' => $this->l10n->t('What the message says. Placeholders such as {{ name }} read fields from the item.'),
+				'required' => true,
+			],
+		];
+	}//end configForm()
+
+	/**
+	 * Post, then pass the items through unchanged.
+	 *
+	 * Sending is a side effect, not a transformation. Failures — Talk absent,
+	 * an unknown conversation, the acting user not a participant, a refused
+	 * post — throw and are routed through the step's `onError` policy.
+	 *
+	 * @param array $items The input items.
+	 * @param array $config The step configuration.
+	 * @param array $context Run-level metadata.
+	 *
+	 * @return array The items, unchanged.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flow-sends-are-attributed-logged-and-bounded
+	 */
+	public function execute(array $items, array $config, array $context): array {
+		$this->messaging->sendTalkMessage(
+			config: $config,
+			items: $items,
+			context: $context,
+			stepName: self::TYPE
+		);
+
+		return $items;
+	}//end execute()
+}//end class

--- a/lib/Service/Flow/Nodes/SendTalkMessageNode.php
+++ b/lib/Service/Flow/Nodes/SendTalkMessageNode.php
@@ -152,7 +152,7 @@ class SendTalkMessageNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeCo
 	 *
 	 * @return array<int, array<string, mixed>> The field descriptions.
 	 *
-	 * @spec openspec/changes/flow-node-config-forms/specs/flow-node-config-forms/spec.md
+	 * @spec openspec/specs/flow-engine/spec.md#requirement-a-node-type-declares-its-own-form-and-its-own-run-log-actions
 	 */
 	public function configForm(): array {
 		return [

--- a/lib/Service/Notification/AnnotationNotificationDispatcher.php
+++ b/lib/Service/Notification/AnnotationNotificationDispatcher.php
@@ -30,7 +30,6 @@ namespace OCA\OpenRegister\Service\Notification;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
-use OCA\OpenRegister\BackgroundJob\WebPushDispatchJob;
 use OCA\OpenRegister\Db\DuplicateDispatchException;
 use OCA\OpenRegister\Db\NotificationDispatchLogMapper;
 use OCA\OpenRegister\Db\NotificationHistoryMapper;
@@ -78,13 +77,43 @@ use Psr\Log\LoggerInterface;
 class AnnotationNotificationDispatcher {
 
 	/**
-	 * Per-instance cache of resolved relation display names, keyed by UUID.
-	 * Avoids repeat ObjectService lookups when the same relation is
-	 * interpolated across a recipient fan-out.
+	 * The nc-notification channel unit — injected, or lazily built.
+	 * Nullable-and-lazy keeps every existing constructor call site working:
+	 * the shared units are appended OPTIONAL constructor parameters, and a
+	 * dispatcher constructed without them builds each from its own
+	 * dependencies on first use — the same objects, wired the same way.
 	 *
-	 * @var array<string, string|null>
+	 * @var NcNotificationSender|null
 	 */
-	private array $relationDisplayCache = [];
+	private ?NcNotificationSender $lazyNcSender = null;
+
+	/**
+	 * The email channel unit — injected, or lazily built.
+	 *
+	 * @var EmailSender|null
+	 */
+	private ?EmailSender $lazyEmailSender = null;
+
+	/**
+	 * The Talk channel unit — injected, or lazily built.
+	 *
+	 * @var TalkSender|null
+	 */
+	private ?TalkSender $lazyTalkSender = null;
+
+	/**
+	 * The shared recipient resolver — injected, or lazily built.
+	 *
+	 * @var NotificationRecipientResolver|null
+	 */
+	private ?NotificationRecipientResolver $lazyRecipientResolver = null;
+
+	/**
+	 * The dialect's placeholder evaluator — injected, or lazily built.
+	 *
+	 * @var NotificationTemplating|null
+	 */
+	private ?NotificationTemplating $lazyTemplating = null;
 
 	/**
 	 * Constructor.
@@ -115,6 +144,11 @@ class AnnotationNotificationDispatcher {
 	 * @param QueuedNotificationMapper|null $queuedNotificationMapper Durable queue mapper (quiet-hours + digest schedule).
 	 * @param DigestScheduleEvaluator|null $digestScheduleEvaluator Live evaluator for the `digest` fixed-time schedule.
 	 * @param ITimeFactory|null $timeFactory Time source for the delivery/digest gate.
+	 * @param NcNotificationSender|null $ncSender Shared nc-notification channel unit (lazily built when absent).
+	 * @param EmailSender|null $emailSender Shared email channel unit (lazily built when absent).
+	 * @param TalkSender|null $talkSender Shared Talk channel unit (lazily built when absent).
+	 * @param NotificationRecipientResolver|null $recipientResolver Shared recipient resolver (lazily built when absent).
+	 * @param NotificationTemplating|null $templating Shared placeholder evaluator (lazily built when absent).
 	 *
 	 * @SuppressWarnings(PHPMD.ExcessiveParameterList) DI-injected dependencies.
 	 */
@@ -145,8 +179,130 @@ class AnnotationNotificationDispatcher {
 		private readonly ?QueuedNotificationMapper $queuedNotificationMapper = null,
 		private readonly ?DigestScheduleEvaluator $digestScheduleEvaluator = null,
 		private readonly ?ITimeFactory $timeFactory = null,
+		?NcNotificationSender $ncSender = null,
+		?EmailSender $emailSender = null,
+		?TalkSender $talkSender = null,
+		?NotificationRecipientResolver $recipientResolver = null,
+		?NotificationTemplating $templating = null,
 	) {
+		$this->lazyNcSender = $ncSender;
+		$this->lazyEmailSender = $emailSender;
+		$this->lazyTalkSender = $talkSender;
+		$this->lazyRecipientResolver = $recipientResolver;
+		$this->lazyTemplating = $templating;
 	}//end __construct()
+
+	/**
+	 * The nc-notification channel sender — injected, or built from this
+	 * dispatcher's own dependencies. One implementation either way; the flow
+	 * messaging service invokes the same class.
+	 *
+	 * @return NcNotificationSender The sender.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
+	 */
+	private function ncSender(): NcNotificationSender {
+		$this->lazyNcSender ??= new NcNotificationSender(
+			notificationManager: $this->notificationManager,
+			logger: $this->logger,
+			userManager: $this->userManager,
+			jobList: $this->jobList
+		);
+
+		return $this->lazyNcSender;
+	}//end ncSender()
+
+	/**
+	 * The email channel sender — injected, or built from this dispatcher's
+	 * own dependencies.
+	 *
+	 * @return EmailSender The sender.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
+	 */
+	private function emailSender(): EmailSender {
+		$this->lazyEmailSender ??= new EmailSender(
+			userManager: $this->userManager,
+			mailer: $this->mailer,
+			logger: $this->logger
+		);
+
+		return $this->lazyEmailSender;
+	}//end emailSender()
+
+	/**
+	 * The Talk channel sender — injected, or built from this dispatcher's
+	 * own dependencies.
+	 *
+	 * @return TalkSender The sender.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
+	 */
+	private function talkSender(): TalkSender {
+		$this->lazyTalkSender ??= new TalkSender(
+			httpClient: $this->httpClient,
+			logger: $this->logger,
+			config: ($this->config ?? $this->systemConfig())
+		);
+
+		return $this->lazyTalkSender;
+	}//end talkSender()
+
+	/**
+	 * The recipient resolver — injected, or built from this dispatcher's own
+	 * dependencies.
+	 *
+	 * @return NotificationRecipientResolver The resolver.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
+	 */
+	private function recipientResolver(): NotificationRecipientResolver {
+		$this->lazyRecipientResolver ??= new NotificationRecipientResolver(
+			userManager: $this->userManager,
+			groupManager: $this->groupManager,
+			logger: $this->logger,
+			serverContainer: $this->serverContainer
+		);
+
+		return $this->lazyRecipientResolver;
+	}//end recipientResolver()
+
+	/**
+	 * The dialect's placeholder evaluator — injected, or built from this
+	 * dispatcher's own dependencies.
+	 *
+	 * @return NotificationTemplating The evaluator.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
+	 */
+	private function templating(): NotificationTemplating {
+		$this->lazyTemplating ??= new NotificationTemplating(
+			logger: $this->logger,
+			objectService: $this->objectService
+		);
+
+		return $this->lazyTemplating;
+	}//end templating()
+
+	/**
+	 * The system config, resolved through the server container for callers
+	 * that constructed the dispatcher with the legacy (no-IConfig) signature.
+	 *
+	 * @return IConfig|null The config service, or null when unresolvable.
+	 */
+	private function systemConfig(): ?IConfig {
+		try {
+			$config = $this->serverContainer->get(IConfig::class);
+		} catch (\Throwable $e) {
+			return null;
+		}
+
+		if (($config instanceof IConfig) === false) {
+			return null;
+		}
+
+		return $config;
+	}//end systemConfig()
 
 	/**
 	 * Fire any notifications declared on the schema whose trigger matches.
@@ -1381,43 +1537,10 @@ class AnnotationNotificationDispatcher {
 			return;
 		}
 
-		try {
-			$client = $this->httpClient->newClient();
-			// Resolve the local OC URL — Talk's chat endpoint is internal
-			// to the NC instance, so we route via the configured overwrite
-			// host or fall back to the loopback. The injected IConfig
-			// dependency is preferred; the server container fallback
-			// exists for callers that constructed the dispatcher with
-			// the legacy (no-IConfig) signature.
-			$base = (string)$this->serverContainer->get(\OCP\IConfig::class)->getSystemValue('overwrite.cli.url', 'http://localhost');
-			if ($this->config !== null) {
-				$base = (string)$this->config->getSystemValue('overwrite.cli.url', 'http://localhost');
-			}
-
-			$base = rtrim($base, '/');
-			$url = $base . '/ocs/v2.php/apps/spreed/api/v1/chat/' . rawurlencode($token);
-
-			$client->post(
-				$url,
-				[
-					'headers' => [
-						'OCS-APIRequest' => 'true',
-						'Accept' => 'application/json',
-						'Content-Type' => 'application/x-www-form-urlencoded',
-					],
-					'body' => [
-						'message' => $message,
-						'actorType' => 'bots',
-						'actorId' => 'openregister',
-					],
-					'timeout' => 5,
-				]
-			);
-		} catch (\Throwable $e) {
-			$this->logger->warning(
-				sprintf('[AnnotationNotificationDispatcher] talk to "%s" failed: %s', $token, $e->getMessage())
-			);
-		}//end try
+		// The shared Talk send unit — the same class the flow messaging
+		// service invokes. The declarative path stays a best-effort bot
+		// broadcast, so the outcome is not escalated here.
+		$this->talkSender()->postAsBot(token: $token, message: $message);
 	}//end emitTalk()
 
 	/**
@@ -1828,322 +1951,29 @@ class AnnotationNotificationDispatcher {
 	 * recipient-resolution contract.
 	 */
 	private function resolveRecipients(array $recipientsSpec, array $data, ?ObjectEntity $object = null, array $context = []): array {
-		$uids = [];
-		foreach ($recipientsSpec as $r) {
-			if (is_array($r) === false) {
-				continue;
-			}
-
-			$kind = (string)($r['kind'] ?? '');
-			if ($kind === 'users') {
-				foreach ((array)($r['users'] ?? []) as $u) {
-					if (is_string($u) === true && $u !== '' && $this->userExists(uid: $u) === true) {
-						$uids[] = $u;
-					}
-				}
-
-				continue;
-			}
-
-			if ($kind === 'field') {
-				// The field's value comes from the object's stored data,
-				// which is writeable by anyone with `update` permission
-				// on the object. An attacker who controls the field
-				// could otherwise direct notifications at any uid string,
-				// including admins, with an attacker-shaped subject.
-				// Verify the value names a real Nextcloud user before
-				// adding it to the recipient list.
-				$field = (string)($r['field'] ?? '');
-				$value = ($data[$field] ?? null);
-				if (is_string($value) === true && $value !== '' && $this->userExists(uid: $value) === true) {
-					$uids[] = $value;
-				}
-
-				continue;
-			}
-
-			if ($kind === 'relation') {
-				// Resolve a typed relation (declared via x-openregister-relations).
-				// Reads $data[<relationFieldName>] which by convention holds
-				// either a string UID, an array of string UIDs, or an
-				// array of objects each carrying a userId field. Same
-				// attacker-controlled-input reasoning as the `field`
-				// kind above — every extracted uid is checked against
-				// IUserManager::userExists().
-				$relName = (string)($r['relation'] ?? '');
-				if ($relName === '') {
-					continue;
-				}
-
-				$value = ($data[$relName] ?? null);
-				foreach ($this->extractUidsFromRelation(value: $value) as $uid) {
-					if ($this->userExists(uid: $uid) === true) {
-						$uids[] = $uid;
-					}
-				}
-
-				continue;
-			}//end if
-
-			if ($kind === 'object-acl') {
-				if ($object !== null) {
-					$perm = (string)($r['permission'] ?? 'read');
-					foreach ($this->resolveObjectAclRecipients(object: $object, permission: $perm) as $uid) {
-						$uids[] = $uid;
-					}
-				}
-
-				continue;
-			}
-
-			if ($kind === 'expression') {
-				if ($object !== null) {
-					$resolverTag = (string)($r['resolver'] ?? '');
-					$resolved = $this->resolveExpressionRecipients(
-						resolverTag: $resolverTag,
-						object: $object,
-						context: $context
-					);
-					foreach ($resolved as $uid) {
-						$uids[] = $uid;
-					}
-				}
-
-				continue;
-			}
-
-			if ($kind === 'groups') {
-				foreach ((array)($r['groups'] ?? []) as $gid) {
-					if (is_string($gid) === false || $gid === '') {
-						continue;
-					}
-
-					try {
-						$group = $this->groupManager->get($gid);
-						if ($group === null) {
-							continue;
-						}
-
-						foreach ($group->getUsers() as $user) {
-							$uids[] = $user->getUID();
-						}
-					} catch (\Throwable $e) {
-						$this->logger->warning(
-							sprintf('[AnnotationNotificationDispatcher] group "%s" lookup failed: %s', $gid, $e->getMessage())
-						);
-					}
-				}
-			}//end if
-		}//end foreach
-
-		return array_values(array_unique($uids));
+		// The subsystem's ONE recipient resolver — the same class the flow
+		// messaging service expands its node recipients through.
+		return $this->recipientResolver()->resolve(
+			recipientsSpec: $recipientsSpec,
+			data: $data,
+			object: $object,
+			context: $context
+		);
 	}//end resolveRecipients()
-
-	/**
-	 * Resolve recipients from the object's per-object ACL.
-	 *
-	 * Reads `$object->getAuthorization()` (Schema entity carries the
-	 * permission map per object). Returns every uid (and group-member
-	 * uids) holding the requested permission level.
-	 *
-	 * v1 implementation: best-effort. Reads the object's `groups` and
-	 * `owner` fields directly. Per-object ACL granularity (read vs
-	 * manage) is treated as: `read` matches any user/group in the ACL;
-	 * `manage` matches only the object owner. A future iteration can
-	 * walk the full RBAC `OrObjectAclMapper` once that surface is
-	 * stable.
-	 *
-	 * @param ObjectEntity $object The object whose ACL should be read.
-	 * @param string $permission The required permission (`read` or `manage`).
-	 *
-	 * @return array<int, string>
-	 *
-	 * @SuppressWarnings(PHPMD.CyclomaticComplexity) resolveObjectAclRecipients() walks owner,
-	 * per-user, per-role, and per-group ACL entries; each entry type requires separate null-guards
-	 * and uid-extraction logic that cannot be merged without losing the distinction between
-	 * role-based and explicit-user grants.
-	 */
-	private function resolveObjectAclRecipients(ObjectEntity $object, string $permission): array {
-		$uids = [];
-		$owner = $object->getOwner();
-		if (is_string($owner) === true && $owner !== '') {
-			$uids[] = $owner;
-		}
-
-		if ($permission === 'manage') {
-			return $uids;
-		}
-
-		// Read permission: also include groups via getGroups(). The
-		// Entity base uses __call magic for accessors, so method_exists()
-		// is unreliable — fall through and let the magic call surface
-		// the value (or throw, which is caught below).
-		try {
-			$groupsRaw = $object->getGroups();
-			if (is_array($groupsRaw) === true) {
-				foreach ($groupsRaw as $gid) {
-					if (is_string($gid) === false || $gid === '') {
-						continue;
-					}
-
-					$group = $this->groupManager->get($gid);
-					if ($group === null) {
-						continue;
-					}
-
-					foreach ($group->getUsers() as $user) {
-						$uids[] = $user->getUID();
-					}
-				}
-			}
-		} catch (\Throwable $e) {
-			$this->logger->warning(
-				sprintf('[AnnotationNotificationDispatcher] object-acl read resolution failed: %s', $e->getMessage())
-			);
-		}//end try
-
-		return $uids;
-	}//end resolveObjectAclRecipients()
-
-	/**
-	 * Resolve recipients via a DI-tagged RecipientResolverInterface.
-	 *
-	 * Looks up the resolver via the injected IServerContainer so apps
-	 * can register their resolver class by FQCN and have NC autowire
-	 * its dependencies. Skips silently when the resolver doesn't exist
-	 * or doesn't implement the interface.
-	 *
-	 * The previous implementation reached for the `\OC::$server` static
-	 * accessor; this PR's ADR (`docs/development-notes/AUDIT_2026-05-01.md`)
-	 * bans that pattern in `lib/`. The injected container is functionally
-	 * equivalent without coupling to the static accessor.
-	 *
-	 * @param string $resolverTag DI tag (or FQCN) of the resolver service.
-	 * @param ObjectEntity $object The object whose recipients are being resolved.
-	 * @param array<string, mixed> $context Per-event context passed through to the resolver.
-	 *
-	 * @return array<int, string>
-	 */
-	private function resolveExpressionRecipients(string $resolverTag, ObjectEntity $object, array $context): array {
-		if ($resolverTag === '') {
-			return [];
-		}
-
-		try {
-			$resolver = $this->serverContainer->get($resolverTag);
-			if (($resolver instanceof RecipientResolverInterface) === false) {
-				$this->logger->warning(
-					sprintf('[AnnotationNotificationDispatcher] expression resolver "%s" does not implement RecipientResolverInterface', $resolverTag)
-				);
-				return [];
-			}
-
-			return array_values($resolver->resolve($object, $context));
-		} catch (\Throwable $e) {
-			$this->logger->warning(
-				sprintf('[AnnotationNotificationDispatcher] expression resolver "%s" failed: %s', $resolverTag, $e->getMessage())
-			);
-			return [];
-		}
-	}//end resolveExpressionRecipients()
 
 	/**
 	 * Verify that a uid corresponds to an actual Nextcloud user.
 	 *
-	 * Notification recipient lists pull strings from object data
-	 * (`field` / `relation` kinds) and from schema annotations
-	 * (`users` kind). Without this check, an attacker who can write
-	 * objects in a schema using `field` recipients could direct a
-	 * notification (with an attacker-shaped subject) at any uid string
-	 * — including admins. Backed by a per-request cache to keep the
-	 * cost flat across N recipients in a single dispatch.
+	 * Delegates to the shared recipient resolver, whose per-request cache and
+	 * only-cache-definitive-verdicts posture this method used to carry.
 	 *
 	 * @param string $uid Candidate Nextcloud user identifier.
 	 *
 	 * @return bool True when the uid corresponds to a real Nextcloud user.
 	 */
 	private function userExists(string $uid): bool {
-		if ($uid === '') {
-			return false;
-		}
-
-		if (isset($this->userExistsCache[$uid]) === true) {
-			return $this->userExistsCache[$uid];
-		}
-
-		// R06: only cache definitive verdicts. A `\Throwable` from
-		// IUserManager (transient DB/LDAP failure, momentary container
-		// hiccup) is NOT a definitive "user doesn't exist" — caching it
-		// would silently drop every notification for this uid for the
-		// rest of the request, even after the underlying problem
-		// clears. Log + return false WITHOUT writing to the cache so
-		// the next call within the same request retries the lookup.
-		try {
-			$exists = $this->userManager->userExists($uid);
-		} catch (\Throwable $e) {
-			$this->logger->warning(
-				sprintf('[AnnotationNotificationDispatcher] userExists check failed for "%s" (not cached, will retry): %s', $uid, $e->getMessage())
-			);
-			return false;
-		}
-
-		$this->userExistsCache[$uid] = (bool)$exists;
-		return $this->userExistsCache[$uid];
+		return $this->recipientResolver()->userExists(uid: $uid);
 	}//end userExists()
-
-	/**
-	 * Per-request cache for userExists() lookups.
-	 *
-	 * @var array<string, bool>
-	 */
-	private array $userExistsCache = [];
-
-	/**
-	 * Extract candidate UIDs from a relation value. The relation value
-	 * can be:
-	 *   - a string (treat as UID directly)
-	 *   - an array of strings (each treated as a UID)
-	 *   - an array of objects with a `userId` or `uid` field
-	 *   - any nested combination of the above
-	 *
-	 * @param mixed $value The raw relation value.
-	 *
-	 * @return array<int, string>
-	 *
-	 * @SuppressWarnings(PHPMD.CyclomaticComplexity) extractUidsFromRelation() handles six distinct
-	 * relation shapes (null, array-of-strings, array-of-objects with uid/id/userId, plain string);
-	 * each shape requires a separate extraction branch that cannot be unified.
-	 */
-	private function extractUidsFromRelation(mixed $value): array {
-		if ($value === null) {
-			return [];
-		}
-
-		if (is_string($value) === true && $value !== '') {
-			return [$value];
-		}
-
-		if (is_array($value) === false) {
-			return [];
-		}
-
-		$out = [];
-		foreach ($value as $entry) {
-			if (is_string($entry) === true && $entry !== '') {
-				$out[] = $entry;
-				continue;
-			}
-
-			if (is_array($entry) === true) {
-				$candidate = ($entry['userId'] ?? $entry['uid'] ?? $entry['user_id'] ?? null);
-				if (is_string($candidate) === true && $candidate !== '') {
-					$out[] = $candidate;
-				}
-			}
-		}
-
-		return $out;
-	}//end extractUidsFromRelation()
 
 	/**
 	 * Resolve a localized subject template against a recipient locale.
@@ -2395,87 +2225,10 @@ class AnnotationNotificationDispatcher {
 	 * @return string The interpolated string.
 	 */
 	private function interpolate(string $template, array $data, array $context): string {
-		return preg_replace_callback(
-			'/\{\{\s*([a-zA-Z0-9_.-]+)\s*\}\}/',
-			function (array $matches) use ($data, $context): string {
-				$key = $matches[1];
-				if (array_key_exists($key, $data) === true) {
-					if (is_scalar($data[$key]) === false) {
-						return '';
-					}
-
-					// Relation fields hold a UUID reference; show the related
-					// object's display name instead of the raw UUID so
-					// "{{client}}" reads "Acme Gemeente BV", not a UUID string.
-					$raw = (string)$data[$key];
-					$display = $this->resolveRelationDisplayName(value: $raw);
-
-					return htmlspecialchars(($display ?? $raw), ENT_QUOTES, 'UTF-8');
-				}
-
-				if (array_key_exists($key, $context) === true) {
-					if (is_scalar($context[$key]) === false) {
-						return '';
-					}
-
-					return htmlspecialchars((string)$context[$key], ENT_QUOTES, 'UTF-8');
-				}
-
-				return '';
-			},
-			$template
-		) ?? $template;
+		// The dialect's ONE placeholder evaluator — the same class the flow
+		// messaging service renders node templates through.
+		return $this->templating()->interpolate(template: $template, data: $data, context: $context);
 	}//end interpolate()
-
-	/**
-	 * Resolve a relation-reference UUID to the related object's display name.
-	 *
-	 * Notification subjects/bodies interpolate `{{prop}}` from the object's
-	 * data; a relation field holds a UUID, which reads poorly in a popup
-	 * ("Incoming call from 3b9f…"). When the value is UUID-shaped, resolve the
-	 * related object through OpenRegister (RBAC-scoped, mirroring the action
-	 * deeplink resolver) and return its name. Returns null — so the caller
-	 * keeps the raw value — for non-UUID values, an absent ObjectService, an
-	 * unresolvable id, or a nameless object. Cached per dispatcher instance to
-	 * avoid repeat lookups across a recipient fan-out.
-	 *
-	 * @param string $value The interpolated field value.
-	 *
-	 * @return string|null The related object's display name, or null to keep the raw value.
-	 *
-	 * @spec openspec/changes/openregister-notification-relation-names/specs/notificatie-engine/spec.md
-	 */
-	private function resolveRelationDisplayName(string $value): ?string {
-		if (preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i', $value) !== 1) {
-			return null;
-		}
-
-		if ($this->objectService === null) {
-			return null;
-		}
-
-		if (array_key_exists($value, $this->relationDisplayCache) === true) {
-			return $this->relationDisplayCache[$value];
-		}
-
-		$name = null;
-		try {
-			$related = $this->objectService->find(id: $value, _rbac: true);
-			if ($related !== null) {
-				$candidate = $related->getName();
-				if (is_string($candidate) === true && $candidate !== '') {
-					$name = $candidate;
-				}
-			}
-		} catch (\Throwable $e) {
-			$this->logger->debug('[AnnotationNotificationDispatcher] relation display-name resolve failed: ' . $e->getMessage());
-			$name = null;
-		}
-
-		$this->relationDisplayCache[$value] = $name;
-
-		return $name;
-	}//end resolveRelationDisplayName()
 
 	/**
 	 * Map a trigger to the canonical INotification subject the Notifier
@@ -2851,32 +2604,23 @@ class AnnotationNotificationDispatcher {
 			return;
 		}
 
-		$objectUuid = (string)($object->getUuid() ?? '');
-		$tagSuffix = $ruleId;
-		if ($objectUuid !== '') {
-			$tagSuffix = $objectUuid;
-		}
-
-		$tag = sprintf('openregister-%s-%s', $ruleId, $tagSuffix);
-
-		foreach ($recipients as $uid) {
-			if (is_string($uid) === false || $uid === '' || $this->userExists(uid: $uid) === false) {
-				continue;
-			}
-
-			$this->jobList->add(
-				WebPushDispatchJob::class,
-				[
-					'uid' => $uid,
-					'ruleId' => $ruleId,
-					'originApp' => $originApp,
-					'title' => $subject,
-					'body' => $message,
-					'tag' => $tag,
-					'actions' => $actions,
-				]
-			);
-		}//end foreach
+		// The shared ride-along unit — the same class the flow messaging
+		// service rides web-push along with. Recipients are pre-verified here
+		// so the unit's own check is a second, cheap gate.
+		$this->ncSender()->enqueueWebPush(
+			recipients: array_values(
+				array_filter(
+					$recipients,
+					fn (mixed $uid): bool => is_string($uid) === true && $uid !== '' && $this->userExists(uid: $uid) === true
+				)
+			),
+			ruleId: $ruleId,
+			originApp: $originApp,
+			subject: $subject,
+			message: $message,
+			actions: $actions,
+			object: $object
+		);
 	}//end enqueueWebPush()
 
 	/**
@@ -2920,60 +2664,21 @@ class AnnotationNotificationDispatcher {
 		array $actions = [],
 		bool $webPushActive = false,
 	): void {
-		$objectUuid = (string)($object->getUuid() ?? '');
-		$tagSuffix = $name;
-		if ($objectUuid !== '') {
-			$tagSuffix = $objectUuid;
-		}
-
-		$linkParams = [
-			'objectTitle' => (string)($object->getName() ?? $objectUuid),
-			'registerId' => $object->getRegister(),
-			'schemaId' => $object->getSchema(),
-			'objectUuid' => $objectUuid,
-			// The resolved origin app drives the notifier icon (originApp hex
-			// composite) and the deeplink base for declared actions.
-			'originApp' => $originApp,
-			// Declared, server-resolved action buttons. The notifier renders
-			// these via addAction(); an empty array keeps the implicit "View".
-			'_actions' => $actions,
-			// Pre-interpolated notification BODY (distinct from the title).
-			// The notifier sets it via setParsedMessage() when non-empty;
-			// an empty string leaves the body unset (back-compat).
-			'_message' => $message,
-			// Stable notification tag used by the Service Worker / foreground
-			// client to COLLAPSE the web-push and the stock popup so the
-			// recipient never sees a duplicate. Keyed by (rule, object).
-			'_tag' => sprintf('openregister-%s-%s', $name, $tagSuffix),
-			// Foreground-suppression flag: when web-push is active for this
-			// rule, an open tab that holds an active push subscription
-			// declines to render the plain duplicate popup for this tag
-			// (see js/openregister-push-sw.js + src/webpush/register.js).
-			'_suppressForegroundPopup' => $webPushActive,
-		];
-
-		$objectRef = $name;
-		if ($objectUuid !== '') {
-			$objectRef = $objectUuid;
-		}
-
-		try {
-			$notification = $this->notificationManager->createNotification();
-			$notification
-				->setApp('openregister')
-				->setUser($uid)
-				->setDateTime(new DateTime())
-				->setObject('object', $objectRef)
-				->setSubject(
-					$subjectKey,
-					array_merge($context, $linkParams, ['_text' => $subject, 'notificationType' => $name])
-				);
-			$this->notificationManager->notify($notification);
-		} catch (\Throwable $e) {
-			$this->logger->warning(
-				sprintf('Notification "%s" to "%s" failed: %s', $name, $uid, $e->getMessage())
-			);
-		}
+		// The shared channel send unit — the same class the flow messaging
+		// service invokes. The declarative path stays best-effort, so the
+		// outcome is not escalated here; the unit already logs failures.
+		$this->ncSender()->send(
+			uid: $uid,
+			object: $object,
+			subjectKey: $subjectKey,
+			name: $name,
+			subject: $subject,
+			message: $message,
+			context: $context,
+			originApp: $originApp,
+			actions: $actions,
+			webPushActive: $webPushActive
+		);
 	}//end emitNotification()
 
 	/**
@@ -2990,29 +2695,11 @@ class AnnotationNotificationDispatcher {
 	 * @return void
 	 */
 	private function emitEmail(string $uid, string $subject, string $body): void {
-		try {
-			$user = $this->userManager->get($uid);
-			if ($user === null) {
-				return;
-			}
-
-			$to = $user->getEMailAddress();
-			if ($to === null || $to === '') {
-				return;
-			}
-
-			$msg = $this->mailer->createMessage();
-			$msg->setTo([$to => $user->getDisplayName()]);
-			$msg->setSubject($subject);
-			$msg->setPlainBody($body);
-			$this->mailer->send($msg);
-		} catch (\Throwable $e) {
-			// Don't escalate — email is best-effort. SMTP not configured
-			// is normal in dev containers.
-			$this->logger->debug(
-				sprintf('[AnnotationNotificationDispatcher] email to "%s" failed (%s)', $uid, $e->getMessage())
-			);
-		}//end try
+		// The shared channel send unit — the same class the flow messaging
+		// service invokes. The declarative path stays best-effort (SMTP not
+		// configured is normal in dev containers), so the outcome is not
+		// escalated here; the unit already logs failures.
+		$this->emailSender()->send(uid: $uid, subject: $subject, body: $body);
 	}//end emitEmail()
 
 	/**

--- a/lib/Service/Notification/EmailSender.php
+++ b/lib/Service/Notification/EmailSender.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * The email channel's composition/handoff, as a call-shared unit.
+ *
+ * Extracted from AnnotationNotificationDispatcher so both callers — the
+ * declarative dispatcher and the flow messaging service — compose and hand a
+ * transactional mail to the ONE mailer. The unit reports its outcome instead
+ * of swallowing it, because the two callers disagree about what a failure
+ * means: the declarative path stays best-effort (SMTP not configured is
+ * normal in dev containers), while a flow send node turns a failed handoff
+ * into a step failure — a COMPLETED run must never hide an undelivered
+ * message.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Notification
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Notification;
+
+use OCP\IUserManager;
+use OCP\Mail\IMailer;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Composes and hands off a transactional email to a Nextcloud user.
+ */
+class EmailSender {
+
+	public const OUTCOME_DISPATCHED = 'dispatched';
+
+	public const OUTCOME_KILL_SWITCH = 'kill-switch';
+
+	public const OUTCOME_NO_ADDRESS = 'no-address';
+
+	public const OUTCOME_FAILED = 'failed';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IUserManager $userManager User resolver for the recipient's address.
+	 * @param IMailer $mailer The mailer.
+	 * @param LoggerInterface $logger Logger for handoff diagnostics.
+	 * @param NotificationChannelPolicy|null $channelPolicy The subsystem's per-channel kill switches; null means enabled.
+	 */
+	public function __construct(
+		private readonly IUserManager $userManager,
+		private readonly IMailer $mailer,
+		private readonly LoggerInterface $logger,
+		private readonly ?NotificationChannelPolicy $channelPolicy = null,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * Send a transactional email to a Nextcloud user.
+	 *
+	 * Resolves the user's email via IUserManager. Never throws: the outcome
+	 * says what happened, and each caller decides what a non-delivery means —
+	 * the declarative dispatcher logs and moves on, the flow messaging
+	 * service escalates a failure into a step failure.
+	 *
+	 * @param string $uid Recipient user UID.
+	 * @param string $subject Email subject line.
+	 * @param string $body Email body text.
+	 *
+	 * @return string One of the OUTCOME_* constants.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
+	 */
+	public function send(string $uid, string $subject, string $body): string {
+		if ($this->channelPolicy !== null && $this->channelPolicy->isChannelEnabled(channel: 'email') === false) {
+			return self::OUTCOME_KILL_SWITCH;
+		}
+
+		try {
+			$user = $this->userManager->get($uid);
+			if ($user === null) {
+				return self::OUTCOME_NO_ADDRESS;
+			}
+
+			$to = $user->getEMailAddress();
+			if ($to === null || $to === '') {
+				return self::OUTCOME_NO_ADDRESS;
+			}
+
+			$msg = $this->mailer->createMessage();
+			$msg->setTo([$to => $user->getDisplayName()]);
+			$msg->setSubject($subject);
+			$msg->setPlainBody($body);
+			$this->mailer->send($msg);
+		} catch (\Throwable $e) {
+			// SMTP not configured is normal in dev containers; the caller
+			// decides whether this outcome escalates.
+			$this->logger->debug(
+				sprintf('[EmailSender] email to "%s" failed (%s)', $uid, $e->getMessage())
+			);
+			return self::OUTCOME_FAILED;
+		}//end try
+
+		return self::OUTCOME_DISPATCHED;
+	}//end send()
+}//end class

--- a/lib/Service/Notification/NcNotificationSender.php
+++ b/lib/Service/Notification/NcNotificationSender.php
@@ -1,0 +1,268 @@
+<?php
+
+/**
+ * The nc-notification channel sender, as a call-shared unit.
+ *
+ * Extracted from AnnotationNotificationDispatcher so both callers — the
+ * declarative dispatcher and the flow messaging service — persist and push an
+ * in-app notification through ONE implementation, with the web-push delivery
+ * riding along under the same rules for both. The unit checks the channel's
+ * kill switch itself, which is what makes the switch reach both callers by
+ * construction rather than by each caller remembering to ask.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Notification
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Notification;
+
+use DateTime;
+use OCA\OpenRegister\BackgroundJob\WebPushDispatchJob;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCP\BackgroundJob\IJobList;
+use OCP\IUserManager;
+use OCP\Notification\IManager as INotificationManager;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Persists and pushes a single in-app Nextcloud notification.
+ */
+class NcNotificationSender {
+
+	public const OUTCOME_DISPATCHED = 'dispatched';
+
+	public const OUTCOME_KILL_SWITCH = 'kill-switch';
+
+	public const OUTCOME_FAILED = 'failed';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param INotificationManager $notificationManager Nextcloud notification API.
+	 * @param LoggerInterface $logger Logger for dispatch diagnostics.
+	 * @param IUserManager|null $userManager User resolver for the web-push ride-along.
+	 * @param IJobList|null $jobList Job list used to enqueue the web-push dispatch job.
+	 * @param NotificationChannelPolicy|null $channelPolicy The subsystem's per-channel kill switches; null means enabled.
+	 */
+	public function __construct(
+		private readonly INotificationManager $notificationManager,
+		private readonly LoggerInterface $logger,
+		private readonly ?IUserManager $userManager = null,
+		private readonly ?IJobList $jobList = null,
+		private readonly ?NotificationChannelPolicy $channelPolicy = null,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * Persist + dispatch a single in-app Nextcloud notification row.
+	 *
+	 * The INotification carries the canonical `$subjectKey` (which the
+	 * Notifier switches on to render localised text + an object-detail
+	 * action link), the routing parameters the action link needs
+	 * (`objectTitle`, `registerId`, `schemaId`, `objectUuid`), the rule's
+	 * own name under `notificationType`, and the pre-rendered subject text
+	 * under `_text` (so a schema's custom per-locale subject still wins).
+	 *
+	 * Push delivery needs no extra code: `notify_push` auto-intercepts this
+	 * same `IManager::notify()` call and relays it to connected devices.
+	 *
+	 * @param string $uid Recipient user UID.
+	 * @param ObjectEntity $object The object the event happened on.
+	 * @param string $subjectKey Canonical subject identifier (object_created/_updated/_transitioned).
+	 * @param string $name Rule name or step identity (notification type identifier).
+	 * @param string $subject Pre-interpolated subject text (notification title).
+	 * @param string $message Pre-interpolated body text (notification body); may be empty.
+	 * @param array<string, mixed> $context Trigger context (action, from, to).
+	 * @param string $originApp Resolved originApp (declared or register-owning app).
+	 * @param array<int, array<string, mixed>> $actions Resolved action buttons (label map + deeplink url + primary).
+	 * @param bool $webPushActive Whether the send also delivers over web-push (drives duplicate suppression).
+	 *
+	 * @return string One of the OUTCOME_* constants.
+	 *
+	 * @SuppressWarnings(PHPMD.ExcessiveParameterList) The dispatcher's emit signature, moved verbatim:
+	 * every argument is one field of the INotification the channel persists.
+	 * @SuppressWarnings(PHPMD.BooleanArgumentFlag) `$webPushActive` is the foreground-suppression
+	 * flag on the notification tag, a delivery detail of this channel, not a second responsibility.
+	 *
+	 * @spec openspec/changes/openregister-notification-body/specs/notificatie-engine/spec.md
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
+	 */
+	public function send(
+		string $uid,
+		ObjectEntity $object,
+		string $subjectKey,
+		string $name,
+		string $subject,
+		string $message,
+		array $context,
+		string $originApp = 'openregister',
+		array $actions = [],
+		bool $webPushActive = false,
+	): string {
+		if ($this->channelPolicy !== null && $this->channelPolicy->isChannelEnabled(channel: 'nc-notification') === false) {
+			return self::OUTCOME_KILL_SWITCH;
+		}
+
+		$objectUuid = (string)($object->getUuid() ?? '');
+		$tagSuffix = $name;
+		if ($objectUuid !== '') {
+			$tagSuffix = $objectUuid;
+		}
+
+		$linkParams = [
+			'objectTitle' => (string)($object->getName() ?? $objectUuid),
+			'registerId' => $object->getRegister(),
+			'schemaId' => $object->getSchema(),
+			'objectUuid' => $objectUuid,
+			// The resolved origin app drives the notifier icon (originApp hex
+			// composite) and the deeplink base for declared actions.
+			'originApp' => $originApp,
+			// Declared, server-resolved action buttons. The notifier renders
+			// these via addAction(); an empty array keeps the implicit "View".
+			'_actions' => $actions,
+			// Pre-interpolated notification BODY (distinct from the title).
+			// The notifier sets it via setParsedMessage() when non-empty;
+			// an empty string leaves the body unset (back-compat).
+			'_message' => $message,
+			// Stable notification tag used by the Service Worker / foreground
+			// client to COLLAPSE the web-push and the stock popup so the
+			// recipient never sees a duplicate. Keyed by (rule, object).
+			'_tag' => sprintf('openregister-%s-%s', $name, $tagSuffix),
+			// Foreground-suppression flag: when web-push is active for this
+			// rule, an open tab that holds an active push subscription
+			// declines to render the plain duplicate popup for this tag
+			// (see js/openregister-push-sw.js + src/webpush/register.js).
+			'_suppressForegroundPopup' => $webPushActive,
+		];
+
+		$objectRef = $name;
+		if ($objectUuid !== '') {
+			$objectRef = $objectUuid;
+		}
+
+		try {
+			$notification = $this->notificationManager->createNotification();
+			$notification
+				->setApp('openregister')
+				->setUser($uid)
+				->setDateTime(new DateTime())
+				->setObject('object', $objectRef)
+				->setSubject(
+					$subjectKey,
+					array_merge($context, $linkParams, ['_text' => $subject, 'notificationType' => $name])
+				);
+			$this->notificationManager->notify($notification);
+		} catch (\Throwable $e) {
+			$this->logger->warning(
+				sprintf('Notification "%s" to "%s" failed: %s', $name, $uid, $e->getMessage())
+			);
+			return self::OUTCOME_FAILED;
+		}
+
+		return self::OUTCOME_DISPATCHED;
+	}//end send()
+
+	/**
+	 * Enqueue the web-push ride-along for a set of recipients.
+	 *
+	 * Routed out of band: a background job per recipient so the originating
+	 * request is never blocked on push I/O. The job re-resolves recipients to
+	 * their stored subscriptions and sends the encrypted VAPID payload. The
+	 * ride-along follows the nc-notification channel's kill switch — web-push
+	 * is a delivery detail of that channel, not a channel of its own.
+	 *
+	 * @param array<int, string> $recipients Recipient uids.
+	 * @param string $ruleId Rule name or step identity.
+	 * @param string $originApp Resolved origin app.
+	 * @param string $subject Pre-interpolated title.
+	 * @param string $message Pre-interpolated body.
+	 * @param array<int, array<string, mixed>> $actions Resolved action buttons.
+	 * @param ObjectEntity $object The object the event happened on.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/openregister-web-push-engine/specs/notificatie-engine/spec.md
+	 */
+	public function enqueueWebPush(
+		array $recipients,
+		string $ruleId,
+		string $originApp,
+		string $subject,
+		string $message,
+		array $actions,
+		ObjectEntity $object,
+	): void {
+		if ($this->jobList === null) {
+			$this->logger->debug('[NcNotificationSender] web-push declared but IJobList unavailable.');
+			return;
+		}
+
+		if ($this->channelPolicy !== null && $this->channelPolicy->isChannelEnabled(channel: 'nc-notification') === false) {
+			return;
+		}
+
+		$objectUuid = (string)($object->getUuid() ?? '');
+		$tagSuffix = $ruleId;
+		if ($objectUuid !== '') {
+			$tagSuffix = $objectUuid;
+		}
+
+		$tag = sprintf('openregister-%s-%s', $ruleId, $tagSuffix);
+
+		foreach ($recipients as $uid) {
+			if (is_string($uid) === false || $uid === '' || $this->recipientExists(uid: $uid) === false) {
+				continue;
+			}
+
+			$this->jobList->add(
+				WebPushDispatchJob::class,
+				[
+					'uid' => $uid,
+					'ruleId' => $ruleId,
+					'originApp' => $originApp,
+					'title' => $subject,
+					'body' => $message,
+					'tag' => $tag,
+					'actions' => $actions,
+				]
+			);
+		}//end foreach
+	}//end enqueueWebPush()
+
+	/**
+	 * Whether a uid names a real user; true when no user manager was injected
+	 * (the caller has then already verified its recipients).
+	 *
+	 * @param string $uid Candidate uid.
+	 *
+	 * @return bool True when the uid may be enqueued.
+	 */
+	private function recipientExists(string $uid): bool {
+		if ($this->userManager === null) {
+			return true;
+		}
+
+		try {
+			return $this->userManager->userExists($uid);
+		} catch (\Throwable $e) {
+			$this->logger->warning(
+				sprintf('[NcNotificationSender] userExists check failed for "%s": %s', $uid, $e->getMessage())
+			);
+			return false;
+		}
+	}//end recipientExists()
+}//end class

--- a/lib/Service/Notification/NotificationChannelPolicy.php
+++ b/lib/Service/Notification/NotificationChannelPolicy.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * The notification subsystem's per-channel kill switches.
+ *
+ * One switch per channel, read at send time by the shared channel senders —
+ * which is what makes the switch reach BOTH callers by construction: the
+ * declarative dispatcher and the flow messaging service invoke the same units,
+ * so a silenced channel is silent for a schema annotation and for a flow node
+ * alike. There is deliberately NO flow-specific switch here: stopping a
+ * sending flow is the per-flow `enabled` flag or the instance flow kill
+ * switch, both of which halt the run before any sender is reached.
+ *
+ * Defaults to enabled and fails open, matching the RateLimiter's posture: a
+ * broken config read must never silently silence an instance's notifications.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Notification
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flow-sends-are-attributed-logged-and-bounded
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Notification;
+
+use OCP\IAppConfig;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Reads the per-channel notification kill switches.
+ */
+class NotificationChannelPolicy {
+
+	public const APP_ID = 'openregister';
+
+	/**
+	 * App-config key template for a channel's kill switch, e.g.
+	 * `notification_channel_email_enabled`. Dashes in the channel name are
+	 * folded to underscores (`nc-notification` -> `nc_notification`).
+	 */
+	public const CONFIG_KEY_TEMPLATE = 'notification_channel_%s_enabled';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IAppConfig $appConfig App-config reader for the switches.
+	 * @param LoggerInterface $logger Logger for silenced-send info events.
+	 */
+	public function __construct(
+		private readonly IAppConfig $appConfig,
+		private readonly LoggerInterface $logger,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * Whether the given channel may send. Defaults to ON.
+	 *
+	 * @param string $channel The channel name (`nc-notification`, `email`, `talk`).
+	 *
+	 * @return bool True when sends on this channel may proceed.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flow-sends-are-attributed-logged-and-bounded
+	 */
+	public function isChannelEnabled(string $channel): bool {
+		$key = sprintf(self::CONFIG_KEY_TEMPLATE, str_replace('-', '_', $channel));
+
+		try {
+			$value = $this->appConfig->getValueString(self::APP_ID, $key, 'true');
+		} catch (\Throwable $e) {
+			// Fail open: a broken config read must never become a silent
+			// instance-wide notification outage.
+			return true;
+		}
+
+		$enabled = ($value !== 'false' && $value !== '0');
+		if ($enabled === false) {
+			$this->logger->info(
+				sprintf('[NotificationChannelPolicy] channel "%s" silenced by kill switch (%s)', $channel, $key)
+			);
+		}
+
+		return $enabled;
+	}//end isChannelEnabled()
+}//end class

--- a/lib/Service/Notification/NotificationRecipientResolver.php
+++ b/lib/Service/Notification/NotificationRecipientResolver.php
@@ -214,6 +214,8 @@ class NotificationRecipientResolver {
 	 * @param string $uid Candidate Nextcloud user identifier.
 	 *
 	 * @return bool True when the uid corresponds to a real Nextcloud user.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
 	 */
 	public function userExists(string $uid): bool {
 		if ($uid === '') {
@@ -246,6 +248,8 @@ class NotificationRecipientResolver {
 	 * @param string $gid Candidate group id.
 	 *
 	 * @return bool True when the group exists.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
 	 */
 	public function groupExists(string $gid): bool {
 		if ($gid === '') {
@@ -277,6 +281,8 @@ class NotificationRecipientResolver {
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity) Handles six distinct relation shapes
 	 * (null, array-of-strings, array-of-objects with uid/id/userId, plain string); each
 	 * shape requires a separate extraction branch that cannot be unified.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
 	 */
 	public function extractUidsFromRelation(mixed $value): array {
 		if ($value === null) {

--- a/lib/Service/Notification/NotificationRecipientResolver.php
+++ b/lib/Service/Notification/NotificationRecipientResolver.php
@@ -1,0 +1,406 @@
+<?php
+
+/**
+ * The notification subsystem's recipient resolver, as a call-shared unit.
+ *
+ * Extracted from AnnotationNotificationDispatcher so both callers — the
+ * declarative dispatcher resolving a schema rule's recipients, and the flow
+ * messaging service resolving a send node's — expand groups, verify uids and
+ * walk relations through ONE implementation. A second resolver is exactly the
+ * place where "who gets told" would start answering differently per caller.
+ *
+ * Behaviour is the dispatcher's, verbatim: every candidate uid is verified
+ * against IUserManager before it may receive anything (recipient lists pull
+ * strings from object data, which is writeable by anyone with `update` on the
+ * object), groups are expanded to their members, and unknown ids are dropped.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Notification
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Notification;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCP\IGroupManager;
+use OCP\IServerContainer;
+use OCP\IUserManager;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Resolves a recipients spec to verified Nextcloud uids.
+ *
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) Six recipient kinds, each with its own
+ * verification posture, plus the uid/group existence checks both callers share; PHPMD sums
+ * every helper's branches into the class total.
+ */
+class NotificationRecipientResolver {
+
+	/**
+	 * Per-request cache for userExists() lookups.
+	 *
+	 * @var array<string, bool>
+	 */
+	private array $userExistsCache = [];
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IUserManager $userManager User resolver for uid verification.
+	 * @param IGroupManager $groupManager Group resolver for `groups` recipient kinds.
+	 * @param LoggerInterface $logger Logger for resolution diagnostics.
+	 * @param IServerContainer|null $serverContainer Container for `expression` resolvers; null disables that kind.
+	 */
+	public function __construct(
+		private readonly IUserManager $userManager,
+		private readonly IGroupManager $groupManager,
+		private readonly LoggerInterface $logger,
+		private readonly ?IServerContainer $serverContainer = null,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * Resolve a recipients spec to a deduplicated list of verified uids.
+	 *
+	 * Supported kinds: `users`, `field`, `relation`, `object-acl`,
+	 * `expression`, `groups` — the dispatcher's set, unchanged.
+	 *
+	 * @param array<int, mixed> $recipientsSpec The rule's `recipients` declaration.
+	 * @param array<string, mixed> $data The object's stored data (or a flow item's json).
+	 * @param ObjectEntity|null $object The object, for `object-acl` and `expression` kinds.
+	 * @param array<string, mixed> $context Trigger-specific extras handed to expression resolvers.
+	 *
+	 * @return array<int, string> Verified, deduplicated uids.
+	 *
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity) One branch per recipient kind; each is a distinct
+	 * resolution rule that cannot be merged without losing the kind's own verification posture.
+	 * @SuppressWarnings(PHPMD.NPathComplexity) Kind dispatch times per-kind guards; all required.
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength) One branch per recipient kind, moved verbatim
+	 * from the dispatcher; splitting per kind would scatter the shared verification posture.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
+	 */
+	public function resolve(array $recipientsSpec, array $data, ?ObjectEntity $object = null, array $context = []): array {
+		$uids = [];
+		foreach ($recipientsSpec as $r) {
+			if (is_array($r) === false) {
+				continue;
+			}
+
+			$kind = (string)($r['kind'] ?? '');
+			if ($kind === 'users') {
+				foreach ((array)($r['users'] ?? []) as $u) {
+					if (is_string($u) === true && $u !== '' && $this->userExists(uid: $u) === true) {
+						$uids[] = $u;
+					}
+				}
+
+				continue;
+			}
+
+			if ($kind === 'field') {
+				// The field's value comes from the object's stored data,
+				// which is writeable by anyone with `update` permission
+				// on the object. An attacker who controls the field
+				// could otherwise direct notifications at any uid string,
+				// including admins, with an attacker-shaped subject.
+				// Verify the value names a real Nextcloud user before
+				// adding it to the recipient list.
+				$field = (string)($r['field'] ?? '');
+				$value = ($data[$field] ?? null);
+				if (is_string($value) === true && $value !== '' && $this->userExists(uid: $value) === true) {
+					$uids[] = $value;
+				}
+
+				continue;
+			}
+
+			if ($kind === 'relation') {
+				// Resolve a typed relation (declared via x-openregister-relations).
+				// Same attacker-controlled-input reasoning as the `field`
+				// kind above — every extracted uid is checked against
+				// IUserManager::userExists().
+				$relName = (string)($r['relation'] ?? '');
+				if ($relName === '') {
+					continue;
+				}
+
+				$value = ($data[$relName] ?? null);
+				foreach ($this->extractUidsFromRelation(value: $value) as $uid) {
+					if ($this->userExists(uid: $uid) === true) {
+						$uids[] = $uid;
+					}
+				}
+
+				continue;
+			}//end if
+
+			if ($kind === 'object-acl') {
+				if ($object !== null) {
+					$perm = (string)($r['permission'] ?? 'read');
+					foreach ($this->resolveObjectAclRecipients(object: $object, permission: $perm) as $uid) {
+						$uids[] = $uid;
+					}
+				}
+
+				continue;
+			}
+
+			if ($kind === 'expression') {
+				if ($object !== null) {
+					$resolverTag = (string)($r['resolver'] ?? '');
+					$resolved = $this->resolveExpressionRecipients(
+						resolverTag: $resolverTag,
+						object: $object,
+						context: $context
+					);
+					foreach ($resolved as $uid) {
+						$uids[] = $uid;
+					}
+				}
+
+				continue;
+			}
+
+			if ($kind === 'groups') {
+				foreach ((array)($r['groups'] ?? []) as $gid) {
+					if (is_string($gid) === false || $gid === '') {
+						continue;
+					}
+
+					try {
+						$group = $this->groupManager->get($gid);
+						if ($group === null) {
+							continue;
+						}
+
+						foreach ($group->getUsers() as $user) {
+							$uids[] = $user->getUID();
+						}
+					} catch (\Throwable $e) {
+						$this->logger->warning(
+							sprintf('[NotificationRecipientResolver] group "%s" lookup failed: %s', $gid, $e->getMessage())
+						);
+					}
+				}
+			}//end if
+		}//end foreach
+
+		return array_values(array_unique($uids));
+	}//end resolve()
+
+	/**
+	 * Verify that a uid corresponds to an actual Nextcloud user.
+	 *
+	 * Backed by a per-request cache; only definitive verdicts are cached. A
+	 * `\Throwable` from IUserManager (transient DB/LDAP failure) is NOT a
+	 * definitive "user doesn't exist" — caching it would silently drop every
+	 * notification for this uid for the rest of the request, even after the
+	 * underlying problem clears.
+	 *
+	 * @param string $uid Candidate Nextcloud user identifier.
+	 *
+	 * @return bool True when the uid corresponds to a real Nextcloud user.
+	 */
+	public function userExists(string $uid): bool {
+		if ($uid === '') {
+			return false;
+		}
+
+		if (isset($this->userExistsCache[$uid]) === true) {
+			return $this->userExistsCache[$uid];
+		}
+
+		try {
+			$exists = $this->userManager->userExists($uid);
+		} catch (\Throwable $e) {
+			$this->logger->warning(
+				sprintf('[NotificationRecipientResolver] userExists check failed for "%s" (not cached, will retry): %s', $uid, $e->getMessage())
+			);
+			return false;
+		}
+
+		$this->userExistsCache[$uid] = (bool)$exists;
+		return $this->userExistsCache[$uid];
+	}//end userExists()
+
+	/**
+	 * Whether a group id names a real group.
+	 *
+	 * Used by the flow messaging service to classify a literal recipient
+	 * entry as a group before asking for a `groups` expansion.
+	 *
+	 * @param string $gid Candidate group id.
+	 *
+	 * @return bool True when the group exists.
+	 */
+	public function groupExists(string $gid): bool {
+		if ($gid === '') {
+			return false;
+		}
+
+		try {
+			return $this->groupManager->groupExists($gid);
+		} catch (\Throwable $e) {
+			$this->logger->warning(
+				sprintf('[NotificationRecipientResolver] groupExists check failed for "%s": %s', $gid, $e->getMessage())
+			);
+			return false;
+		}
+	}//end groupExists()
+
+	/**
+	 * Extract candidate UIDs from a relation value. The relation value
+	 * can be:
+	 *   - a string (treat as UID directly)
+	 *   - an array of strings (each treated as a UID)
+	 *   - an array of objects with a `userId` or `uid` field
+	 *   - any nested combination of the above
+	 *
+	 * @param mixed $value The raw relation value.
+	 *
+	 * @return array<int, string>
+	 *
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity) Handles six distinct relation shapes
+	 * (null, array-of-strings, array-of-objects with uid/id/userId, plain string); each
+	 * shape requires a separate extraction branch that cannot be unified.
+	 */
+	public function extractUidsFromRelation(mixed $value): array {
+		if ($value === null) {
+			return [];
+		}
+
+		if (is_string($value) === true && $value !== '') {
+			return [$value];
+		}
+
+		if (is_array($value) === false) {
+			return [];
+		}
+
+		$out = [];
+		foreach ($value as $entry) {
+			if (is_string($entry) === true && $entry !== '') {
+				$out[] = $entry;
+				continue;
+			}
+
+			if (is_array($entry) === true) {
+				$candidate = ($entry['userId'] ?? $entry['uid'] ?? $entry['user_id'] ?? null);
+				if (is_string($candidate) === true && $candidate !== '') {
+					$out[] = $candidate;
+				}
+			}
+		}
+
+		return $out;
+	}//end extractUidsFromRelation()
+
+	/**
+	 * Resolve recipients from the object's per-object ACL.
+	 *
+	 * V1 implementation: best-effort. Reads the object's `groups` and
+	 * `owner` fields directly. Per-object ACL granularity (read vs
+	 * manage) is treated as: `read` matches any user/group in the ACL;
+	 * `manage` matches only the object owner.
+	 *
+	 * @param ObjectEntity $object The object whose ACL should be read.
+	 * @param string $permission The required permission (`read` or `manage`).
+	 *
+	 * @return array<int, string>
+	 *
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity) Walks owner, per-user, per-role and per-group
+	 * ACL entries; each needs its own null-guard and uid extraction.
+	 */
+	private function resolveObjectAclRecipients(ObjectEntity $object, string $permission): array {
+		$uids = [];
+		$owner = $object->getOwner();
+		if (is_string($owner) === true && $owner !== '') {
+			$uids[] = $owner;
+		}
+
+		if ($permission === 'manage') {
+			return $uids;
+		}
+
+		// Read permission: also include groups via getGroups(). The
+		// Entity base uses __call magic for accessors, so method_exists()
+		// is unreliable — fall through and let the magic call surface
+		// the value (or throw, which is caught below).
+		try {
+			$groupsRaw = $object->getGroups();
+			if (is_array($groupsRaw) === true) {
+				foreach ($groupsRaw as $gid) {
+					if (is_string($gid) === false || $gid === '') {
+						continue;
+					}
+
+					$group = $this->groupManager->get($gid);
+					if ($group === null) {
+						continue;
+					}
+
+					foreach ($group->getUsers() as $user) {
+						$uids[] = $user->getUID();
+					}
+				}
+			}
+		} catch (\Throwable $e) {
+			$this->logger->warning(
+				sprintf('[NotificationRecipientResolver] object-acl read resolution failed: %s', $e->getMessage())
+			);
+		}//end try
+
+		return $uids;
+	}//end resolveObjectAclRecipients()
+
+	/**
+	 * Resolve recipients via a DI-tagged RecipientResolverInterface.
+	 *
+	 * Looks up the resolver via the injected IServerContainer so apps
+	 * can register their resolver class by FQCN and have NC autowire
+	 * its dependencies. Skips silently when the resolver doesn't exist
+	 * or doesn't implement the interface.
+	 *
+	 * @param string $resolverTag DI tag (or FQCN) of the resolver service.
+	 * @param ObjectEntity $object The object whose recipients are being resolved.
+	 * @param array<string, mixed> $context Per-event context passed through to the resolver.
+	 *
+	 * @return array<int, string>
+	 */
+	private function resolveExpressionRecipients(string $resolverTag, ObjectEntity $object, array $context): array {
+		if ($resolverTag === '' || $this->serverContainer === null) {
+			return [];
+		}
+
+		try {
+			$resolver = $this->serverContainer->get($resolverTag);
+			if (($resolver instanceof RecipientResolverInterface) === false) {
+				$this->logger->warning(
+					sprintf('[NotificationRecipientResolver] expression resolver "%s" does not implement RecipientResolverInterface', $resolverTag)
+				);
+				return [];
+			}
+
+			return array_values($resolver->resolve($object, $context));
+		} catch (\Throwable $e) {
+			$this->logger->warning(
+				sprintf('[NotificationRecipientResolver] expression resolver "%s" failed: %s', $resolverTag, $e->getMessage())
+			);
+			return [];
+		}
+	}//end resolveExpressionRecipients()
+}//end class

--- a/lib/Service/Notification/NotificationTemplating.php
+++ b/lib/Service/Notification/NotificationTemplating.php
@@ -1,0 +1,156 @@
+<?php
+
+/**
+ * The notification dialect's placeholder evaluator, as a call-shared unit.
+ *
+ * Extracted from AnnotationNotificationDispatcher so the SAME `{{ key }}`
+ * evaluation serves both callers: the declarative dispatcher rendering a
+ * schema-declared subject, and the flow messaging service rendering a node's
+ * template against a flow item. One placeholder syntax, one implementation —
+ * a second evaluator is precisely the place where the two would drift apart.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Notification
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Notification;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Interpolates `{{ key }}` placeholders against data and context.
+ */
+class NotificationTemplating {
+
+	/**
+	 * Per-instance cache of resolved relation display names, keyed by UUID.
+	 * Avoids repeat ObjectService lookups when the same relation is
+	 * interpolated across a recipient fan-out.
+	 *
+	 * @var array<string, string|null>
+	 */
+	private array $relationDisplayCache = [];
+
+	/**
+	 * Constructor.
+	 *
+	 * @param LoggerInterface $logger Logger for resolve diagnostics.
+	 * @param \OCA\OpenRegister\Service\ObjectService|null $objectService Object resolver for relation display names (RBAC-scoped).
+	 */
+	public function __construct(
+		private readonly LoggerInterface $logger,
+		private readonly ?\OCA\OpenRegister\Service\ObjectService $objectService = null,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * Interpolate `{{ key }}` placeholders in a template.
+	 *
+	 * Data keys win over context keys; a placeholder that resolves to a
+	 * non-scalar or to nothing renders as an empty string. A UUID-shaped data
+	 * value is resolved to the related object's display name when possible,
+	 * so `{{client}}` reads "Acme Gemeente BV" rather than a UUID.
+	 *
+	 * This is the notification dialect's ONE placeholder syntax; the flow
+	 * messaging nodes reuse it verbatim rather than introducing a second one.
+	 *
+	 * @param string $template The template carrying `{{ key }}` placeholders.
+	 * @param array<string, mixed> $data The primary data (object data, or a flow item's json).
+	 * @param array<string, mixed> $context Secondary lookup values.
+	 *
+	 * @return string The interpolated string.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
+	 */
+	public function interpolate(string $template, array $data, array $context): string {
+		return preg_replace_callback(
+			'/\{\{\s*([a-zA-Z0-9_.-]+)\s*\}\}/',
+			function (array $matches) use ($data, $context): string {
+				$key = $matches[1];
+				if (array_key_exists($key, $data) === true) {
+					if (is_scalar($data[$key]) === false) {
+						return '';
+					}
+
+					// Relation fields hold a UUID reference; show the related
+					// object's display name instead of the raw UUID so
+					// "{{client}}" reads "Acme Gemeente BV", not a UUID string.
+					$raw = (string)$data[$key];
+					$display = $this->resolveRelationDisplayName(value: $raw);
+
+					return htmlspecialchars(($display ?? $raw), ENT_QUOTES, 'UTF-8');
+				}
+
+				if (array_key_exists($key, $context) === true) {
+					if (is_scalar($context[$key]) === false) {
+						return '';
+					}
+
+					return htmlspecialchars((string)$context[$key], ENT_QUOTES, 'UTF-8');
+				}
+
+				return '';
+			},
+			$template
+		) ?? $template;
+	}//end interpolate()
+
+	/**
+	 * Resolve a relation-reference UUID to the related object's display name.
+	 *
+	 * Returns null — so the caller keeps the raw value — for non-UUID values,
+	 * an absent ObjectService, an unresolvable id, or a nameless object.
+	 * Cached per instance to avoid repeat lookups across a recipient fan-out.
+	 *
+	 * @param string $value The interpolated field value.
+	 *
+	 * @return string|null The related object's display name, or null to keep the raw value.
+	 *
+	 * @spec openspec/changes/openregister-notification-relation-names/specs/notificatie-engine/spec.md
+	 */
+	public function resolveRelationDisplayName(string $value): ?string {
+		if (preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i', $value) !== 1) {
+			return null;
+		}
+
+		if ($this->objectService === null) {
+			return null;
+		}
+
+		if (array_key_exists($value, $this->relationDisplayCache) === true) {
+			return $this->relationDisplayCache[$value];
+		}
+
+		$name = null;
+		try {
+			$related = $this->objectService->find(id: $value, _rbac: true);
+			if ($related !== null) {
+				$candidate = $related->getName();
+				if (is_string($candidate) === true && $candidate !== '') {
+					$name = $candidate;
+				}
+			}
+		} catch (\Throwable $e) {
+			$this->logger->debug('[NotificationTemplating] relation display-name resolve failed: ' . $e->getMessage());
+			$name = null;
+		}
+
+		$this->relationDisplayCache[$value] = $name;
+
+		return $name;
+	}//end resolveRelationDisplayName()
+}//end class

--- a/lib/Service/Notification/RateLimiter.php
+++ b/lib/Service/Notification/RateLimiter.php
@@ -152,10 +152,87 @@ class RateLimiter {
 		$key = $this->key(ruleId: $ruleId, recipient: $recipient);
 		$now = ($this->timeProvider)();
 
-		try {
-			$state = $this->cache->get($key);
-		} catch (\Throwable $e) {
+		$ruleTokens = $this->currentTokens(key: $key, bucketSize: $bucketSize, refillSeconds: $refillSeconds, now: $now);
+		if ($ruleTokens === null) {
 			return true;
+		}
+
+		if ($ruleTokens < 1.0) {
+			$this->logger->info(
+				sprintf(
+					'[NotificationRateLimiter] dropped rule="%s" recipient="%s" bucket=%d refillSeconds=%d',
+					$ruleId,
+					$recipient,
+					$bucketSize,
+					$refillSeconds
+				)
+			);
+			// Persist the new lastRefill so partial earnings don't
+			// get lost on the next call. The shared bucket is untouched:
+			// a refused dispatch messaged nobody.
+			$this->persist(key: $key, tokens: $ruleTokens, lastRefill: $now);
+			return false;
+		}
+
+		// The SHARED per-recipient budget. Bucket keys are caller-agnostic —
+		// the key is the recipient, nothing else — so a declarative rule and a
+		// flow send node draw from ONE budget by construction: the abuse being
+		// bounded is "how much this instance messages this person", not "per
+		// subsystem" or "per rule". Sized from the app-config defaults only;
+		// a single rule's generous per-rule override must not widen every
+		// caller's ceiling. Pseudo-recipients (broadcast channel keys such as
+		// `__webhook__`) are not people and stay outside the shared budget.
+		$sharedTokens = null;
+		$sharedKey = null;
+		[$sharedBucketSize, $sharedRefillSeconds] = $this->resolveLimits(perRuleOverride: null);
+		if (str_starts_with($recipient, '__') === false) {
+			$sharedKey = $this->sharedKey(recipient: $recipient);
+			$sharedTokens = $this->currentTokens(
+				key: $sharedKey,
+				bucketSize: $sharedBucketSize,
+				refillSeconds: $sharedRefillSeconds,
+				now: $now
+			);
+
+			if ($sharedTokens !== null && $sharedTokens < 1.0) {
+				$this->logger->info(
+					sprintf(
+						'[NotificationRateLimiter] dropped rule="%s" recipient="%s" by the shared per-recipient budget bucket=%d refillSeconds=%d',
+						$ruleId,
+						$recipient,
+						$sharedBucketSize,
+						$sharedRefillSeconds
+					)
+				);
+				$this->persist(key: $sharedKey, tokens: $sharedTokens, lastRefill: $now);
+				return false;
+			}
+		}
+
+		$this->persist(key: $key, tokens: ($ruleTokens - 1.0), lastRefill: $now);
+		if ($sharedKey !== null && $sharedTokens !== null) {
+			$this->persist(key: $sharedKey, tokens: ($sharedTokens - 1.0), lastRefill: $now);
+		}
+
+		return true;
+	}//end tryConsume()
+
+	/**
+	 * The refilled token count for a bucket, or null when the cache cannot
+	 * answer (the limiter then fails open, as everywhere else).
+	 *
+	 * @param string $key Cache key.
+	 * @param int $bucketSize Bucket capacity.
+	 * @param int $refillSeconds Seconds per earned token.
+	 * @param int $now Current unix timestamp.
+	 *
+	 * @return float|null The available tokens, or null to fail open.
+	 */
+	private function currentTokens(string $key, int $bucketSize, int $refillSeconds, int $now): ?float {
+		try {
+			$state = $this->cache?->get($key);
+		} catch (\Throwable $e) {
+			return null;
 		}//end try
 
 		$tokens = (float)$bucketSize;
@@ -175,26 +252,23 @@ class RateLimiter {
 			$tokens = min((float)$bucketSize, ($tokens + $earned));
 		}
 
-		if ($tokens < 1.0) {
-			$this->logger->info(
-				sprintf(
-					'[NotificationRateLimiter] dropped rule="%s" recipient="%s" bucket=%d refillSeconds=%d',
-					$ruleId,
-					$recipient,
-					$bucketSize,
-					$refillSeconds
-				)
-			);
-			// Persist the new lastRefill so partial earnings don't
-			// get lost on the next call.
-			$this->persist(key: $key, tokens: $tokens, lastRefill: $now);
-			return false;
-		}
+		return $tokens;
+	}//end currentTokens()
 
-		$tokens -= 1.0;
-		$this->persist(key: $key, tokens: $tokens, lastRefill: $now);
-		return true;
-	}//end tryConsume()
+	/**
+	 * The shared per-recipient budget's cache key. Deliberately blind to the
+	 * rule and to the caller: every subsystem that messages this recipient
+	 * lands on the same bucket.
+	 *
+	 * @param string $recipient Recipient identifier.
+	 *
+	 * @return string Cache key.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flow-sends-are-attributed-logged-and-bounded
+	 */
+	private function sharedKey(string $recipient): string {
+		return 'notification:rate:shared:' . sha1($recipient);
+	}//end sharedKey()
 
 	/**
 	 * Whether the limiter is enabled. Defaults to ON.

--- a/lib/Service/Notification/TalkSendException.php
+++ b/lib/Service/Notification/TalkSendException.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * A Talk post that could not be performed, with the reason a person can act on.
+ *
+ * Raised by TalkSender's attributed path: Talk not installed, an unknown
+ * conversation, an acting user who is not a participant, or a post the Talk
+ * API refused. Never raised for the kill switch — a silenced channel is a
+ * skip, not a failure.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Notification
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flow-sends-are-attributed-logged-and-bounded
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Notification;
+
+use RuntimeException;
+
+/**
+ * A failed Talk post, carrying its reason.
+ */
+class TalkSendException extends RuntimeException {
+}//end class

--- a/lib/Service/Notification/TalkSender.php
+++ b/lib/Service/Notification/TalkSender.php
@@ -1,0 +1,225 @@
+<?php
+
+/**
+ * The Talk channel's post, as a call-shared unit.
+ *
+ * Extracted from AnnotationNotificationDispatcher so both callers post a chat
+ * message through ONE implementation. Two paths, deliberately distinct:
+ *
+ * - `postAsBot()` is the declarative dispatcher's existing behaviour,
+ *   verbatim — a broadcast to a configured room from the `openregister` bot
+ *   actor, best-effort.
+ * - `postAsUser()` is the flow messaging path: the message is attributed to
+ *   the flow run's ACTING user, which requires that user to be a participant
+ *   of the target conversation. "Not a participant" is a failure with that
+ *   reason — it is NEVER an auto-join, which would be a privacy-relevant side
+ *   effect performed by a messaging convenience.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Notification
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Notification;
+
+use DateTime;
+use OCP\Http\Client\IClientService;
+use OCP\IConfig;
+use OCP\IServerContainer;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Posts a chat message to a Talk conversation.
+ */
+class TalkSender {
+
+	public const OUTCOME_DISPATCHED = 'dispatched';
+
+	public const OUTCOME_KILL_SWITCH = 'kill-switch';
+
+	public const OUTCOME_FAILED = 'failed';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IClientService $httpClient HTTP client for the bot post.
+	 * @param LoggerInterface $logger Logger for post diagnostics.
+	 * @param IConfig|null $config Config service for the local OCS base URL.
+	 * @param NotificationChannelPolicy|null $channelPolicy The subsystem's per-channel kill switches; null means enabled.
+	 * @param IServerContainer|null $serverContainer Container used to reach the Talk app for the attributed path.
+	 */
+	public function __construct(
+		private readonly IClientService $httpClient,
+		private readonly LoggerInterface $logger,
+		private readonly ?IConfig $config = null,
+		private readonly ?NotificationChannelPolicy $channelPolicy = null,
+		private readonly ?IServerContainer $serverContainer = null,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * Post a chat message to a Talk room as the `openregister` bot.
+	 *
+	 * The declarative dispatcher's behaviour, verbatim: best-effort, via the
+	 * local OCS endpoint, no attribution to a person.
+	 *
+	 * @param string $token The Talk conversation token.
+	 * @param string $message The message text.
+	 *
+	 * @return string One of the OUTCOME_* constants.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flows-send-through-the-notification-subsystem-never-beside-it
+	 */
+	public function postAsBot(string $token, string $message): string {
+		if ($token === '') {
+			return self::OUTCOME_FAILED;
+		}
+
+		if ($this->channelPolicy !== null && $this->channelPolicy->isChannelEnabled(channel: 'talk') === false) {
+			return self::OUTCOME_KILL_SWITCH;
+		}
+
+		try {
+			$client = $this->httpClient->newClient();
+			// Talk's chat endpoint is internal to the NC instance, so route
+			// via the configured overwrite host or fall back to the loopback.
+			$base = 'http://localhost';
+			if ($this->config !== null) {
+				$base = (string)$this->config->getSystemValue('overwrite.cli.url', 'http://localhost');
+			}
+
+			$base = rtrim($base, '/');
+			$url = $base . '/ocs/v2.php/apps/spreed/api/v1/chat/' . rawurlencode($token);
+
+			$client->post(
+				$url,
+				[
+					'headers' => [
+						'OCS-APIRequest' => 'true',
+						'Accept' => 'application/json',
+						'Content-Type' => 'application/x-www-form-urlencoded',
+					],
+					'body' => [
+						'message' => $message,
+						'actorType' => 'bots',
+						'actorId' => 'openregister',
+					],
+					'timeout' => 5,
+				]
+			);
+		} catch (\Throwable $e) {
+			$this->logger->warning(
+				sprintf('[TalkSender] talk to "%s" failed: %s', $token, $e->getMessage())
+			);
+			return self::OUTCOME_FAILED;
+		}//end try
+
+		return self::OUTCOME_DISPATCHED;
+	}//end postAsBot()
+
+	/**
+	 * Post a chat message to a Talk conversation AS a user.
+	 *
+	 * The flow messaging path: the message appears from the acting user, so
+	 * replies have an addressee and the audit trail an actor. The user MUST
+	 * already be a participant of the conversation; "not a participant" is a
+	 * failure with that reason, never an auto-join.
+	 *
+	 * @param string $token The Talk conversation token.
+	 * @param string $message The message text.
+	 * @param string $actorUid The acting user's uid.
+	 *
+	 * @return string OUTCOME_DISPATCHED or OUTCOME_KILL_SWITCH.
+	 *
+	 * @throws TalkSendException When Talk is unavailable, the conversation is
+	 *                           unknown, the acting user is not a participant,
+	 *                           or the post is refused.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flow-sends-are-attributed-logged-and-bounded
+	 */
+	public function postAsUser(string $token, string $message, string $actorUid): string {
+		if ($token === '') {
+			throw new TalkSendException('No Talk conversation token was given.');
+		}
+
+		if ($this->channelPolicy !== null && $this->channelPolicy->isChannelEnabled(channel: 'talk') === false) {
+			return self::OUTCOME_KILL_SWITCH;
+		}
+
+		$this->postViaTalkApp(token: $token, message: $message, actorUid: $actorUid);
+
+		return self::OUTCOME_DISPATCHED;
+	}//end postAsUser()
+
+	/**
+	 * Perform the attributed post through the Talk app's own services.
+	 *
+	 * Talk publishes no OCP surface for posting as a user, so the classes are
+	 * resolved by name through the container — a duck-typed integration that
+	 * fails LOUDLY on every miss: Talk absent, conversation unknown, actor not
+	 * a participant, API shape changed. A silent no-op here would be a
+	 * COMPLETED run hiding an undelivered message.
+	 *
+	 * Protected so unit tests can substitute the Talk side without a Talk
+	 * installation; the decision logic above it stays under test either way.
+	 *
+	 * @param string $token The conversation token.
+	 * @param string $message The message text.
+	 * @param string $actorUid The acting user's uid.
+	 *
+	 * @return void
+	 *
+	 * @throws TalkSendException On every non-delivery, naming the reason.
+	 */
+	protected function postViaTalkApp(string $token, string $message, string $actorUid): void {
+		if ($this->serverContainer === null) {
+			throw new TalkSendException('Talk posting is unavailable: no server container to reach the Talk app.');
+		}
+
+		try {
+			$manager = $this->serverContainer->get('OCA\\Talk\\Manager');
+		} catch (\Throwable $e) {
+			throw new TalkSendException('Talk (spreed) is not installed, so no Talk message can be sent.');
+		}
+
+		try {
+			// Resolving the room FOR the user is also the participant check:
+			// Talk refuses the lookup for a conversation the user is not in.
+			$room = $manager->getRoomForUserByToken($token, $actorUid);
+			$participantService = $this->serverContainer->get('OCA\\Talk\\Service\\ParticipantService');
+			$participant = $participantService->getParticipant($room, $actorUid, false);
+			$chatManager = $this->serverContainer->get('OCA\\Talk\\Chat\\ChatManager');
+			$chatManager->sendMessage($room, $participant, 'users', $actorUid, $message, new DateTime());
+		} catch (TalkSendException $e) {
+			throw $e;
+		} catch (\Throwable $e) {
+			$class = get_class($e);
+			if (str_contains($class, 'ParticipantNotFound') === true || str_contains($class, 'RoomNotFound') === true) {
+				throw new TalkSendException(
+					sprintf(
+						'User "%s" is not a participant of Talk conversation "%s"; the message was not sent and the user was not auto-joined.',
+						$actorUid,
+						$token
+					)
+				);
+			}
+
+			throw new TalkSendException(
+				sprintf('Talk post to "%s" as "%s" failed: %s', $token, $actorUid, $e->getMessage())
+			);
+		}//end try
+	}//end postViaTalkApp()
+}//end class

--- a/lib/Service/Notification/TalkSender.php
+++ b/lib/Service/Notification/TalkSender.php
@@ -183,6 +183,8 @@ class TalkSender {
 	 * @return void
 	 *
 	 * @throws TalkSendException On every non-delivery, naming the reason.
+	 *
+	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flow-sends-are-attributed-logged-and-bounded
 	 */
 	protected function postViaTalkApp(string $token, string $message, string $actorUid): void {
 		if ($this->serverContainer === null) {

--- a/openspec/changes/flow-engine-docs/tasks.md
+++ b/openspec/changes/flow-engine-docs/tasks.md
@@ -25,7 +25,16 @@ code named beside it:
       iterate, batch, flow-state, wait, sub-flow, await-signal, end), one
       paragraph each: what it does, its config keys, a worked example;
       contributed nodes (openconnector, hermiq) noted as coming from their
-      apps' palettes with their own docs.
+      apps' palettes with their own docs. Fed from `flow-messaging-nodes`
+      (shipped): `openregister.send-notification` sends an in-app
+      notification (web-push riding along) to users, groups or an item
+      field, through the ADR-031 channel machinery;
+      `openregister.send-email` sends an email with the same recipients,
+      guardrails and placeholder syntax; `openregister.send-talk-message`
+      posts a Talk chat message as the run's acting user, who must already
+      be a participant. State the boundary beside them: notifications
+      notify, flows orchestrate, and API calls go through OpenConnector
+      sources — there is deliberately no send-webhook node.
 - [ ] **Approvals** — await-signal end to end: the question, who answers,
       how the answer routes downstream, the heartbeat, what happens when
       nobody answers (reaped as failed, flow schedulable again); telling

--- a/openspec/changes/flow-messaging-nodes/tasks.md
+++ b/openspec/changes/flow-messaging-nodes/tasks.md
@@ -2,63 +2,63 @@
 
 ## Extraction (behaviour-preserving refactor first)
 
-- [ ] Extract the per-channel send units from
+- [x] Extract the per-channel send units from
       `AnnotationNotificationDispatcher` — nc-notification (+ web-push
       ride-along), email composition/handoff, Talk post — and the recipient
       resolver into injectable units under `lib/Service/Notification/`;
       dispatcher re-wired onto them with its existing tests green and
       unchanged.
-- [ ] Confirm `RateLimiter` bucket keys are caller-agnostic (recipient +
+- [x] Confirm `RateLimiter` bucket keys are caller-agnostic (recipient +
       channel + window), so both callers share one budget by construction.
 
 ## FlowMessagingService
 
-- [ ] `FlowMessagingService` invoking the extracted units; applies, in
+- [x] `FlowMessagingService` invoking the extracted units; applies, in
       order: subsystem kill switches → preference filter (per-recipient
       channels) → recipient bound (post-expansion, default from app config)
       → rate limiter → send. No flow-messaging-specific switch: stopping a
       sending flow is the per-flow `enabled` flag or the instance flow kill
       switch, both of which halt the run before this service is reached.
-- [ ] Acting-user resolution from the run; no resolvable actor = step
+- [x] Acting-user resolution from the run; no resolvable actor = step
       failure naming the missing actor (never a system-identity fallback).
-- [ ] Templating through the notification dialect's placeholder evaluation
+- [x] Templating through the notification dialect's placeholder evaluation
       against the flow item — reuse the dialect's evaluator, add none.
-- [ ] Per-recipient/channel outcome collection (delivered / skipped-by-
+- [x] Per-recipient/channel outcome collection (delivered / skipped-by-
       preference / skipped-by-kill-switch / rate-limited / failed) returned
       for the run log, bounded by the log's sampling rule.
 
 ## Nodes
 
-- [ ] `SendNotificationNode` (`openregister.send-notification`) — recipients
+- [x] `SendNotificationNode` (`openregister.send-notification`) — recipients
       (literal or item-field template), title + message templates;
       `validateConfig` refuses an empty message and an empty recipient
       config; `configForm()` per the flow-node-config-forms floor.
-- [ ] `SendEmailNode` (`openregister.send-email`) — recipients, subject +
+- [x] `SendEmailNode` (`openregister.send-email`) — recipients, subject +
       body templates; same validation and form obligations.
-- [ ] `SendTalkMessageNode` (`openregister.send-talk-message`) —
+- [x] `SendTalkMessageNode` (`openregister.send-talk-message`) —
       conversation token or item-field lookup, message template;
       "acting user not a participant" is a step failure, never an auto-join.
-- [ ] All three: items returned unchanged; failures routed through the
+- [x] All three: items returned unchanged; failures routed through the
       step's `onError` policy; registration in
       `FlowNodeRegistrationListener`.
 
 ## Tests
 
-- [ ] Equivalence test: schema annotation vs flow node, same recipients and
+- [x] Equivalence test: schema annotation vs flow node, same recipients and
       template, same object — identical deliveries through a recorded
       sender double.
-- [ ] Guardrail tests, each with a positive control (the send that DOES go
+- [x] Guardrail tests, each with a positive control (the send that DOES go
       out when the guard is off): flow kill switch (and declarative path
       unaffected by it), subsystem kill switches, shared rate-limit bucket
       (declarative fill blocks flow send), recipient bound, preference skip.
-- [ ] Attribution tests: acting user carried onto each channel; missing
+- [x] Attribution tests: acting user carried onto each channel; missing
       actor fails the step.
-- [ ] Palette test: exactly these three messaging types; no
+- [x] Palette test: exactly these three messaging types; no
       `openregister.send-webhook` (boundary with ADR-094).
 
 ## Documentation
 
-- [ ] Feed the three nodes and the boundary statement ("notifications
+- [x] Feed the three nodes and the boundary statement ("notifications
       notify; flows orchestrate; API calls via OpenConnector sources") into
       `flow-engine-docs`' steps catalogue — one sentence each here, the
       prose lives there.

--- a/tests/Unit/Service/Flow/FlowMessagingEquivalenceTest.php
+++ b/tests/Unit/Service/Flow/FlowMessagingEquivalenceTest.php
@@ -1,0 +1,328 @@
+<?php
+
+/**
+ * The equivalence and independence properties between the two callers of the
+ * notification subsystem's channel machinery.
+ *
+ * - EQUIVALENCE: a schema annotation and a send-notification node, configured
+ *   with the same recipients and template against the same object, produce
+ *   identical deliveries — recorded through ONE sender double injected into
+ *   BOTH callers, which is also the structural proof they share the channel
+ *   sender rather than each carrying their own.
+ * - INDEPENDENCE: the instance FLOW kill switch does not silence declarative
+ *   notifications — the dispatcher structurally never consults it — while the
+ *   flow side's own oversight check refuses under the same config.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Flow;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\FlowMessagingService;
+use OCA\OpenRegister\Service\Flow\Oversight\KillSwitchCheck;
+use OCA\OpenRegister\Service\Notification\AnnotationNotificationDispatcher;
+use OCA\OpenRegister\Service\Notification\EmailSender;
+use OCA\OpenRegister\Service\Notification\NcNotificationSender;
+use OCA\OpenRegister\Service\Notification\NotificationChannelPolicy;
+use OCA\OpenRegister\Service\Notification\NotificationPreferenceService;
+use OCA\OpenRegister\Service\Notification\NotificationRecipientResolver;
+use OCA\OpenRegister\Service\Notification\NotificationTemplating;
+use OCA\OpenRegister\Service\Notification\RateLimiter;
+use OCA\OpenRegister\Service\Notification\TalkSender;
+use OCP\Activity\IManager as IActivityManager;
+use OCP\Http\Client\IClientService;
+use OCP\IAppConfig;
+use OCP\ICacheFactory;
+use OCP\IConfig;
+use OCP\IGroupManager;
+use OCP\IServerContainer;
+use OCP\IUserManager;
+use OCP\Mail\IMailer;
+use OCP\Notification\IManager as INotificationManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Records every send handed to the nc-notification channel unit.
+ */
+class RecordingNcSender extends NcNotificationSender {
+	/** @var array<int, array<string, string>> */
+	public array $sends = [];
+
+	public function send(
+		string $uid,
+		ObjectEntity $object,
+		string $subjectKey,
+		string $name,
+		string $subject,
+		string $message,
+		array $context,
+		string $originApp = 'openregister',
+		array $actions = [],
+		bool $webPushActive = false,
+	): string {
+		$this->sends[] = [
+			'channel' => 'nc-notification',
+			'uid' => $uid,
+			'subject' => $subject,
+			'message' => $message,
+		];
+
+		return self::OUTCOME_DISPATCHED;
+	}
+
+	public function enqueueWebPush(
+		array $recipients,
+		string $ruleId,
+		string $originApp,
+		string $subject,
+		string $message,
+		array $actions,
+		ObjectEntity $object,
+	): void {
+		// Ride-alongs are not part of the delivery comparison.
+	}
+}//end class
+
+/**
+ * Same send from both callers; independent kill switches.
+ */
+class FlowMessagingEquivalenceTest extends TestCase {
+
+	/**
+	 * App-config values behind both subsystems' switches.
+	 *
+	 * @var array<string, string>
+	 */
+	private array $appValues = [];
+
+	/**
+	 * The one recorded sender both callers are wired onto.
+	 */
+	private RecordingNcSender $recorder;
+
+	private IUserManager $userManager;
+
+	private IGroupManager $groupManager;
+
+	private IAppConfig $appConfig;
+
+	private LoggerInterface $logger;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$userManager = $this->createMock(IUserManager::class);
+		$userManager->method('userExists')->willReturn(true);
+		$userManager->method('get')->willReturnCallback(
+			function (string $uid) {
+				$user = $this->createMock(\OCP\IUser::class);
+				$user->method('getUID')->willReturn($uid);
+				$user->method('isEnabled')->willReturn(true);
+				return $user;
+			}
+		);
+		$this->userManager = $userManager;
+		$this->groupManager = $this->createMock(IGroupManager::class);
+
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getValueString')->willReturnCallback(
+			fn (string $app, string $key, string $default = ''): string => ($this->appValues[$key] ?? $default)
+		);
+		$appConfig->method('getValueInt')->willReturnCallback(
+			fn (string $app, string $key, int $default = 0): int => (int)($this->appValues[$key] ?? $default)
+		);
+		$appConfig->method('getValueBool')->willReturnCallback(
+			fn (string $app, string $key, bool $default = false): bool => (($this->appValues[$key] ?? null) === 'true') || $default
+		);
+		$this->appConfig = $appConfig;
+
+		$this->recorder = new RecordingNcSender(
+			notificationManager: $this->createMock(INotificationManager::class),
+			logger: $this->logger
+		);
+	}//end setUp()
+
+	/**
+	 * The declarative dispatcher, wired onto the recorded sender.
+	 *
+	 * @return AnnotationNotificationDispatcher The dispatcher.
+	 */
+	private function makeDispatcher(): AnnotationNotificationDispatcher {
+		return new AnnotationNotificationDispatcher(
+			schemaMapper: $this->createMock(SchemaMapper::class),
+			notificationManager: $this->createMock(INotificationManager::class),
+			logger: $this->logger,
+			groupManager: $this->groupManager,
+			userManager: $this->userManager,
+			mailer: $this->createMock(IMailer::class),
+			activityManager: $this->createMock(IActivityManager::class),
+			httpClient: $this->createMock(IClientService::class),
+			serverContainer: $this->createMock(IServerContainer::class),
+			ncSender: $this->recorder,
+			recipientResolver: new NotificationRecipientResolver(
+				userManager: $this->userManager,
+				groupManager: $this->groupManager,
+				logger: $this->logger
+			),
+			templating: new NotificationTemplating(logger: $this->logger)
+		);
+	}//end makeDispatcher()
+
+	/**
+	 * The flow messaging service, wired onto the SAME recorded sender.
+	 *
+	 * @return FlowMessagingService The service.
+	 */
+	private function makeMessaging(): FlowMessagingService {
+		$cacheFactory = $this->createMock(ICacheFactory::class);
+		$cacheFactory->method('createDistributed')->willReturn($this->createMock(\OCP\ICache::class));
+		$config = $this->createMock(IConfig::class);
+		$config->method('getUserValue')->willReturnArgument(3);
+
+		return new FlowMessagingService(
+			channelPolicy: new NotificationChannelPolicy(appConfig: $this->appConfig, logger: $this->logger),
+			recipientResolver: new NotificationRecipientResolver(
+				userManager: $this->userManager,
+				groupManager: $this->groupManager,
+				logger: $this->logger
+			),
+			templating: new NotificationTemplating(logger: $this->logger),
+			ncSender: $this->recorder,
+			emailSender: new EmailSender(
+				userManager: $this->userManager,
+				mailer: $this->createMock(IMailer::class),
+				logger: $this->logger
+			),
+			talkSender: new TalkSender(
+				httpClient: $this->createMock(IClientService::class),
+				logger: $this->logger
+			),
+			rateLimiter: new RateLimiter(
+				cacheFactory: $cacheFactory,
+				appConfig: $this->appConfig,
+				logger: $this->logger
+			),
+			preferences: new NotificationPreferenceService(
+				config: $config,
+				schemaMapper: $this->createMock(SchemaMapper::class),
+				logger: $this->logger
+			),
+			userManager: $this->userManager,
+			appConfig: $this->appConfig,
+			logger: $this->logger
+		);
+	}//end makeMessaging()
+
+	public function testSchemaAnnotationAndFlowNodeProduceTheSameSendThroughTheSameSender(): void {
+		$data = ['title' => 'Bezwaar 12', 'status' => 'moved'];
+
+		// The DECLARATIVE path: a schema annotation firing on the object.
+		$schema = new Schema();
+		$schema->setId(1);
+		$schema->setSlug('case');
+		$schema->setConfiguration(
+			[
+				'x-openregister-notifications' => [
+					'case-moved' => [
+						'trigger' => ['type' => 'updated'],
+						'channels' => ['nc-notification'],
+						'recipients' => [
+							[
+								'kind' => 'users',
+								'users' => ['bob', 'carol'],
+							],
+						],
+						'subject' => 'Case {{ title }} moved',
+						'message' => 'Case {{ title }} is now {{ status }}.',
+					],
+				],
+			]
+		);
+
+		$object = new ObjectEntity();
+		$object->setUuid('uuid-1');
+		$object->setObject($data);
+
+		$this->makeDispatcher()->dispatchWithSchema(object: $object, trigger: 'updated', context: [], schema: $schema);
+		$declarative = $this->recorder->sends;
+		$this->recorder->sends = [];
+
+		// The FLOW path: a send-notification node's config with the same
+		// recipients and templates, against the same object as an item.
+		$this->makeMessaging()->sendNotification(
+			config: [
+				'recipients' => ['bob', 'carol'],
+				'title' => 'Case {{ title }} moved',
+				'message' => 'Case {{ title }} is now {{ status }}.',
+			],
+			items: [FlowItems::item(json: $data)],
+			context: ['runAs' => 'alice'],
+			stepName: 'openregister.send-notification'
+		);
+		$flow = $this->recorder->sends;
+
+		// Identical in channel, body and recipients — and both lists exist at
+		// all only because both callers went through the SAME sender instance.
+		$this->assertNotSame([], $declarative);
+		$this->assertSame($declarative, $flow);
+	}//end testSchemaAnnotationAndFlowNodeProduceTheSameSendThroughTheSameSender()
+
+	public function testTheFlowKillSwitchDoesNotSilenceDeclarativeNotifications(): void {
+		// The instance FLOW kill switch is set: the flow side's own oversight
+		// check refuses every hop under this config…
+		$this->appValues[KillSwitchCheck::CONFIG_KEY] = 'true';
+		$check = new KillSwitchCheck(appConfig: $this->appConfig);
+		$this->assertNotNull($check->veto(context: []), 'The flow kill switch must refuse flow hops under this config');
+
+		// …and the DECLARATIVE dispatch still delivers: killing flows never
+		// silences case-update notifications.
+		$schema = new Schema();
+		$schema->setId(1);
+		$schema->setSlug('case');
+		$schema->setConfiguration(
+			[
+				'x-openregister-notifications' => [
+					'case-moved' => [
+						'trigger' => ['type' => 'updated'],
+						'channels' => ['nc-notification'],
+						'recipients' => [
+							[
+								'kind' => 'users',
+								'users' => ['bob'],
+							],
+						],
+						'subject' => 'moved',
+					],
+				],
+			]
+		);
+		$object = new ObjectEntity();
+		$object->setUuid('uuid-1');
+		$object->setObject(['title' => 'x']);
+
+		$this->makeDispatcher()->dispatchWithSchema(object: $object, trigger: 'updated', context: [], schema: $schema);
+
+		$this->assertCount(1, $this->recorder->sends);
+		$this->assertSame('bob', $this->recorder->sends[0]['uid']);
+	}//end testTheFlowKillSwitchDoesNotSilenceDeclarativeNotifications()
+}//end class

--- a/tests/Unit/Service/Flow/FlowMessagingServiceTest.php
+++ b/tests/Unit/Service/Flow/FlowMessagingServiceTest.php
@@ -1,0 +1,614 @@
+<?php
+
+/**
+ * FlowMessagingService guardrail and attribution tests.
+ *
+ * Every guardrail is exercised WITH ITS POSITIVE CONTROL — the send that DOES
+ * go out when the guard is off — so a green test cannot be a guard that fires
+ * always (or never). The senders are the REAL shared units over mocked
+ * Nextcloud services, so the assertion "the flow send went through the same
+ * channel sender" is structural, not declared.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Flow;
+
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\FlowMessagingService;
+use OCA\OpenRegister\Service\Flow\FlowStepReport;
+use OCA\OpenRegister\Service\Notification\EmailSender;
+use OCA\OpenRegister\Service\Notification\NcNotificationSender;
+use OCA\OpenRegister\Service\Notification\NotificationChannelPolicy;
+use OCA\OpenRegister\Service\Notification\NotificationPreferenceService;
+use OCA\OpenRegister\Service\Notification\NotificationRecipientResolver;
+use OCA\OpenRegister\Service\Notification\NotificationTemplating;
+use OCA\OpenRegister\Service\Notification\RateLimiter;
+use OCA\OpenRegister\Service\Notification\TalkSender;
+use OCA\OpenRegister\Service\Notification\TalkSendException;
+use OCP\BackgroundJob\IJobList;
+use OCP\Http\Client\IClientService;
+use OCP\IAppConfig;
+use OCP\ICache;
+use OCP\ICacheFactory;
+use OCP\IConfig;
+use OCP\IGroup;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\Mail\IMailer;
+use OCP\Mail\IMessage;
+use OCP\Notification\IManager as INotificationManager;
+use OCP\Notification\INotification;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * A tiny in-memory ICache for the rate limiter, so bucket state is real
+ * between calls without a cache backend.
+ */
+class MessagingTestCache implements ICache {
+	/** @var array<string, mixed> */
+	private array $data = [];
+
+	public function get($key) {
+		return ($this->data[$key] ?? null);
+	}
+
+	public function set($key, $value, $ttl = 0) {
+		$this->data[$key] = $value;
+		return true;
+	}
+
+	public function hasKey($key) {
+		return isset($this->data[$key]);
+	}
+
+	public function remove($key) {
+		unset($this->data[$key]);
+		return true;
+	}
+
+	public function clear($prefix = '') {
+		$this->data = [];
+		return true;
+	}
+
+	public static function isAvailable(): bool {
+		return true;
+	}
+}//end class
+
+/**
+ * A TalkSender whose Talk-app boundary is replaced by a recorder, so the
+ * decision logic above it (attribution, kill switch, failure escalation)
+ * runs for real without a Talk installation.
+ */
+class RecordingTalkSender extends TalkSender {
+	/** @var array<int, array<string, string>> */
+	public array $posts = [];
+
+	public ?TalkSendException $throwOnPost = null;
+
+	protected function postViaTalkApp(string $token, string $message, string $actorUid): void {
+		if ($this->throwOnPost !== null) {
+			throw $this->throwOnPost;
+		}
+
+		$this->posts[] = [
+			'token' => $token,
+			'message' => $message,
+			'actor' => $actorUid,
+		];
+	}
+}//end class
+
+/**
+ * Guardrails, attribution and outcome reporting of the flow messaging bridge.
+ */
+class FlowMessagingServiceTest extends TestCase {
+
+	private IAppConfig&MockObject $appConfig;
+
+	private IUserManager&MockObject $userManager;
+
+	private IGroupManager&MockObject $groupManager;
+
+	private INotificationManager&MockObject $notificationManager;
+
+	private IMailer&MockObject $mailer;
+
+	private IJobList&MockObject $jobList;
+
+	private IConfig&MockObject $config;
+
+	private RecordingTalkSender $talkSender;
+
+	private MessagingTestCache $cache;
+
+	/**
+	 * Mutable app-config values read through the IAppConfig mock.
+	 *
+	 * @var array<string, string>
+	 */
+	private array $appValues = [];
+
+	/**
+	 * Mutable user-config values read through the IConfig mock (preferences).
+	 *
+	 * @var array<string, string>
+	 */
+	private array $userValues = [];
+
+	/**
+	 * Users that exist, uid => enabled.
+	 *
+	 * @var array<string, bool>
+	 */
+	private array $users = [
+		'alice' => true,
+		'bob' => true,
+		'carol' => true,
+	];
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->appConfig->method('getValueString')->willReturnCallback(
+			fn (string $app, string $key, string $default = ''): string => ($this->appValues[$key] ?? $default)
+		);
+		$this->appConfig->method('getValueInt')->willReturnCallback(
+			fn (string $app, string $key, int $default = 0): int => (int)($this->appValues[$key] ?? $default)
+		);
+
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->userManager->method('userExists')->willReturnCallback(
+			fn (string $uid): bool => isset($this->users[$uid])
+		);
+		$this->userManager->method('get')->willReturnCallback(
+			function (string $uid): ?IUser {
+				if (isset($this->users[$uid]) === false) {
+					return null;
+				}
+
+				$user = $this->createMock(IUser::class);
+				$user->method('getUID')->willReturn($uid);
+				$user->method('isEnabled')->willReturn($this->users[$uid]);
+				$user->method('getEMailAddress')->willReturn($uid . '@example.org');
+				$user->method('getDisplayName')->willReturn(ucfirst($uid));
+				return $user;
+			}
+		);
+
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->notificationManager = $this->createMock(INotificationManager::class);
+		$this->mailer = $this->createMock(IMailer::class);
+		$this->jobList = $this->createMock(IJobList::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->config->method('getUserValue')->willReturnCallback(
+			fn (string $uid, string $app, string $key, string $default = ''): string => ($this->userValues[$uid . '|' . $key] ?? $default)
+		);
+
+		$this->cache = new MessagingTestCache();
+		$this->talkSender = new RecordingTalkSender(
+			httpClient: $this->createMock(IClientService::class),
+			logger: $this->createMock(LoggerInterface::class),
+			config: null,
+			channelPolicy: $this->channelPolicy()
+		);
+	}//end setUp()
+
+	/**
+	 * A real channel policy over the mutable app-config map.
+	 *
+	 * @return NotificationChannelPolicy The policy.
+	 */
+	private function channelPolicy(): NotificationChannelPolicy {
+		return new NotificationChannelPolicy(
+			appConfig: $this->appConfig,
+			logger: $this->createMock(LoggerInterface::class)
+		);
+	}//end channelPolicy()
+
+	/**
+	 * The service under test, wired onto the REAL shared units.
+	 *
+	 * @return FlowMessagingService The service.
+	 */
+	private function makeService(): FlowMessagingService {
+		$logger = $this->createMock(LoggerInterface::class);
+
+		$cacheFactory = $this->createMock(ICacheFactory::class);
+		$cacheFactory->method('createDistributed')->willReturn($this->cache);
+
+		return new FlowMessagingService(
+			channelPolicy: $this->channelPolicy(),
+			recipientResolver: new NotificationRecipientResolver(
+				userManager: $this->userManager,
+				groupManager: $this->groupManager,
+				logger: $logger
+			),
+			templating: new NotificationTemplating(logger: $logger),
+			ncSender: new NcNotificationSender(
+				notificationManager: $this->notificationManager,
+				logger: $logger,
+				userManager: $this->userManager,
+				jobList: $this->jobList,
+				channelPolicy: $this->channelPolicy()
+			),
+			emailSender: new EmailSender(
+				userManager: $this->userManager,
+				mailer: $this->mailer,
+				logger: $logger,
+				channelPolicy: $this->channelPolicy()
+			),
+			talkSender: $this->talkSender,
+			rateLimiter: $this->rateLimiter(),
+			preferences: new NotificationPreferenceService(
+				config: $this->config,
+				schemaMapper: $this->createMock(SchemaMapper::class),
+				logger: $logger
+			),
+			userManager: $this->userManager,
+			appConfig: $this->appConfig,
+			logger: $logger
+		);
+	}//end makeService()
+
+	/**
+	 * A real rate limiter over the shared in-memory cache.
+	 *
+	 * @return RateLimiter The limiter.
+	 */
+	private function rateLimiter(): RateLimiter {
+		$cacheFactory = $this->createMock(ICacheFactory::class);
+		$cacheFactory->method('createDistributed')->willReturn($this->cache);
+
+		return new RateLimiter(
+			cacheFactory: $cacheFactory,
+			appConfig: $this->appConfig,
+			logger: $this->createMock(LoggerInterface::class)
+		);
+	}//end rateLimiter()
+
+	/**
+	 * A run context with an acting user and a step report handle.
+	 *
+	 * @param string|null $runAs The acting user, or null for none.
+	 *
+	 * @return array The context.
+	 */
+	private function contextFor(?string $runAs = 'alice'): array {
+		$context = [FlowStepReport::CONTEXT_KEY => new FlowStepReport()];
+		if ($runAs !== null) {
+			$context['runAs'] = $runAs;
+		}
+
+		return $context;
+	}//end contextFor()
+
+	/**
+	 * One item with the given json.
+	 *
+	 * @param array $json The item json.
+	 *
+	 * @return array The item list.
+	 */
+	private function itemsOf(array $json = ['name' => 'Case 7']): array {
+		return [FlowItems::item(json: $json)];
+	}//end itemsOf()
+
+	/**
+	 * A mock INotification whose fluent setters chain.
+	 *
+	 * @return INotification&MockObject The mock.
+	 */
+	private function fluentNotification(): INotification&MockObject {
+		$notification = $this->createMock(INotification::class);
+		$notification->method('setApp')->willReturnSelf();
+		$notification->method('setUser')->willReturnSelf();
+		$notification->method('setDateTime')->willReturnSelf();
+		$notification->method('setObject')->willReturnSelf();
+		$notification->method('setSubject')->willReturnSelf();
+
+		return $notification;
+	}//end fluentNotification()
+
+	// ---- Attribution -------------------------------------------------------
+
+	public function testMissingActingUserFailsTheStepAndSendsNothing(): void {
+		$this->notificationManager->expects($this->never())->method('notify');
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/runAs/');
+
+		$this->makeService()->sendNotification(
+			config: ['recipients' => ['bob'], 'message' => 'hi'],
+			items: $this->itemsOf(),
+			context: $this->contextFor(runAs: null),
+			stepName: 'openregister.send-notification'
+		);
+	}//end testMissingActingUserFailsTheStepAndSendsNothing()
+
+	public function testDisabledActingUserFailsTheStepAndSendsNothing(): void {
+		$this->users['ghosted'] = false;
+		$this->notificationManager->expects($this->never())->method('notify');
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/disabled/');
+
+		$this->makeService()->sendNotification(
+			config: ['recipients' => ['bob'], 'message' => 'hi'],
+			items: $this->itemsOf(),
+			context: $this->contextFor(runAs: 'ghosted'),
+			stepName: 'openregister.send-notification'
+		);
+	}//end testDisabledActingUserFailsTheStepAndSendsNothing()
+
+	public function testTalkPostIsAttributedToTheActingUser(): void {
+		$report = $this->makeService()->sendTalkMessage(
+			config: ['conversation' => 'room-token', 'message' => 'Case {{ name }} moved'],
+			items: $this->itemsOf(json: ['name' => 'Case 7']),
+			context: $this->contextFor(runAs: 'alice'),
+			stepName: 'openregister.send-talk-message'
+		);
+
+		$this->assertCount(1, $this->talkSender->posts);
+		$this->assertSame('alice', $this->talkSender->posts[0]['actor']);
+		$this->assertSame('room-token', $this->talkSender->posts[0]['token']);
+		$this->assertSame('Case Case 7 moved', $this->talkSender->posts[0]['message']);
+		$this->assertSame('alice', $report['actor']);
+		$this->assertSame(1, $report['delivered']['count']);
+	}//end testTalkPostIsAttributedToTheActingUser()
+
+	public function testTalkNonParticipantIsAStepFailureNotAnAutoJoin(): void {
+		$this->talkSender->throwOnPost = new TalkSendException(
+			'User "alice" is not a participant of Talk conversation "room-token"; the message was not sent and the user was not auto-joined.'
+		);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/not a participant/');
+
+		$this->makeService()->sendTalkMessage(
+			config: ['conversation' => 'room-token', 'message' => 'hello'],
+			items: $this->itemsOf(),
+			context: $this->contextFor(runAs: 'alice'),
+			stepName: 'openregister.send-talk-message'
+		);
+	}//end testTalkNonParticipantIsAStepFailureNotAnAutoJoin()
+
+	// ---- Kill switches -----------------------------------------------------
+
+	public function testChannelKillSwitchSilencesFlowSendsAndRecordsTheSkip(): void {
+		// POSITIVE CONTROL first: with the switch off, the send goes out
+		// through the real channel sender.
+		$this->notificationManager->method('createNotification')->willReturn($this->fluentNotification());
+		$this->notificationManager->expects($this->exactly(1))->method('notify');
+
+		$service = $this->makeService();
+		$context = $this->contextFor();
+		$service->sendNotification(
+			config: ['recipients' => ['bob'], 'message' => 'hi'],
+			items: $this->itemsOf(),
+			context: $context,
+			stepName: 'openregister.send-notification'
+		);
+
+		// Now the guard: switch thrown, nothing may leave, and the outcome is
+		// a SKIP in the report — not a failure, not silence.
+		$this->appValues['notification_channel_nc_notification_enabled'] = 'false';
+		$report = $service->sendNotification(
+			config: ['recipients' => ['bob'], 'message' => 'hi'],
+			items: $this->itemsOf(),
+			context: $context,
+			stepName: 'openregister.send-notification'
+		);
+
+		$this->assertSame(1, $report['skippedByKillSwitch']['count']);
+		$this->assertSame(['bob'], $report['skippedByKillSwitch']['sample']);
+		$this->assertSame(0, $report['delivered']['count']);
+	}//end testChannelKillSwitchSilencesFlowSendsAndRecordsTheSkip()
+
+	public function testEmailKillSwitchStopsTheMailer(): void {
+		$this->mailer->expects($this->never())->method('send');
+		$this->appValues['notification_channel_email_enabled'] = 'false';
+
+		$report = $this->makeService()->sendEmail(
+			config: ['recipients' => ['bob'], 'subject' => 's', 'body' => 'b'],
+			items: $this->itemsOf(),
+			context: $this->contextFor(),
+			stepName: 'openregister.send-email'
+		);
+
+		$this->assertSame(1, $report['skippedByKillSwitch']['count']);
+	}//end testEmailKillSwitchStopsTheMailer()
+
+	// ---- Preferences -------------------------------------------------------
+
+	public function testRecipientPreferenceSkipsTheChannelAndIsRecordedAsSkipNotFailure(): void {
+		// bob turned flow sends off; carol did not. One mail leaves, for
+		// carol — the positive control inside the same dispatch.
+		$this->userValues['bob|notification_pref/flow/send'] = json_encode(['enabled' => false]);
+		$message = $this->createMock(IMessage::class);
+		$message->method('setTo')->willReturnSelf();
+		$message->method('setSubject')->willReturnSelf();
+		$message->method('setPlainBody')->willReturnSelf();
+		$this->mailer->method('createMessage')->willReturn($message);
+		$this->mailer->expects($this->exactly(1))->method('send');
+
+		$report = $this->makeService()->sendEmail(
+			config: ['recipients' => ['bob', 'carol'], 'subject' => 's', 'body' => 'b'],
+			items: $this->itemsOf(),
+			context: $this->contextFor(),
+			stepName: 'openregister.send-email'
+		);
+
+		$this->assertSame(1, $report['skippedByPreference']['count']);
+		$this->assertSame(['bob'], $report['skippedByPreference']['sample']);
+		$this->assertSame(1, $report['delivered']['count']);
+		$this->assertSame(['carol'], $report['delivered']['sample']);
+		$this->assertSame(0, $report['failed']['count']);
+	}//end testRecipientPreferenceSkipsTheChannelAndIsRecordedAsSkipNotFailure()
+
+	// ---- Recipient bound ---------------------------------------------------
+
+	public function testExplodingRecipientListIsRefusedBeforeAnythingSends(): void {
+		// A group that expands to 30 members against the default bound of 25.
+		$members = [];
+		for ($i = 0; $i < 30; $i++) {
+			$uid = sprintf('user%02d', $i);
+			$this->users[$uid] = true;
+			$member = $this->createMock(IUser::class);
+			$member->method('getUID')->willReturn($uid);
+			$members[] = $member;
+		}
+
+		$group = $this->createMock(IGroup::class);
+		$group->method('getUsers')->willReturn($members);
+		$this->groupManager->method('groupExists')->willReturn(true);
+		$this->groupManager->method('get')->willReturn($group);
+
+		$this->notificationManager->expects($this->never())->method('notify');
+
+		try {
+			$this->makeService()->sendNotification(
+				config: ['recipients' => ['everyone'], 'message' => 'hi'],
+				items: $this->itemsOf(),
+				context: $this->contextFor(),
+				stepName: 'openregister.send-notification'
+			);
+			$this->fail('The exploding recipient list must be refused.');
+		} catch (RuntimeException $e) {
+			// The failure names the resolved count and the bound.
+			$this->assertStringContainsString('30', $e->getMessage());
+			$this->assertStringContainsString('25', $e->getMessage());
+		}
+	}//end testExplodingRecipientListIsRefusedBeforeAnythingSends()
+
+	public function testRecipientBoundIsAppConfigRaisable(): void {
+		$this->appValues[FlowMessagingService::CONFIG_RECIPIENT_BOUND] = '2';
+		$this->notificationManager->method('createNotification')->willReturn($this->fluentNotification());
+		$this->notificationManager->expects($this->exactly(2))->method('notify');
+
+		// Two recipients under a bound of two: sends proceed.
+		$this->makeService()->sendNotification(
+			config: ['recipients' => ['bob', 'carol'], 'message' => 'hi'],
+			items: $this->itemsOf(),
+			context: $this->contextFor(),
+			stepName: 'openregister.send-notification'
+		);
+	}//end testRecipientBoundIsAppConfigRaisable()
+
+	// ---- Rate limiting -----------------------------------------------------
+
+	public function testDeclarativeFillBlocksTheFlowSendTheBudgetIsShared(): void {
+		// The DECLARATIVE subsystem fills bob's shared per-recipient budget
+		// (default bucket 10) under its own rule ids…
+		$limiter = $this->rateLimiter();
+		for ($i = 0; $i < 10; $i++) {
+			$this->assertTrue($limiter->tryConsume('schema-rule-' . $i, 'bob'));
+		}
+
+		// …and the flow send to bob in the same window is rate-limited, while
+		// carol — whose budget is untouched — receives: the positive control.
+		$this->notificationManager->method('createNotification')->willReturn($this->fluentNotification());
+		$this->notificationManager->expects($this->exactly(1))->method('notify');
+
+		$report = $this->makeService()->sendNotification(
+			config: ['recipients' => ['bob', 'carol'], 'message' => 'hi'],
+			items: $this->itemsOf(),
+			context: $this->contextFor(),
+			stepName: 'openregister.send-notification'
+		);
+
+		$this->assertSame(1, $report['rateLimited']['count']);
+		$this->assertSame(['bob'], $report['rateLimited']['sample']);
+		$this->assertSame(['carol'], $report['delivered']['sample']);
+	}//end testDeclarativeFillBlocksTheFlowSendTheBudgetIsShared()
+
+	// ---- Failures and the run log -----------------------------------------
+
+	public function testSendFailureIsAStepFailureAndTheReportNamesIt(): void {
+		$this->mailer->method('createMessage')->willThrowException(new RuntimeException('SMTP down'));
+
+		$context = $this->contextFor();
+		try {
+			$this->makeService()->sendEmail(
+				config: ['recipients' => ['bob'], 'subject' => 's', 'body' => 'b'],
+				items: $this->itemsOf(),
+				context: $context,
+				stepName: 'openregister.send-email'
+			);
+			$this->fail('A failed handoff must fail the step.');
+		} catch (RuntimeException $e) {
+			$this->assertStringContainsString('email', $e->getMessage());
+		}
+
+		// The report reached the run-log handle BEFORE the throw, so a failed
+		// step still explains itself.
+		$handle = $context[FlowStepReport::CONTEXT_KEY];
+		$detail = $handle->take();
+		$this->assertSame(1, $detail['messaging']['failed']['count']);
+		$this->assertSame(['bob'], $detail['messaging']['failed']['sample']);
+	}//end testSendFailureIsAStepFailureAndTheReportNamesIt()
+
+	public function testUnknownRecipientsAreReportedNotSilentlyDropped(): void {
+		$this->notificationManager->method('createNotification')->willReturn($this->fluentNotification());
+
+		$context = $this->contextFor();
+		$report = $this->makeService()->sendNotification(
+			config: ['recipients' => ['bob', 'nobody-here'], 'message' => 'hi'],
+			items: $this->itemsOf(),
+			context: $context,
+			stepName: 'openregister.send-notification'
+		);
+
+		$this->assertSame(1, $report['unknownRecipients']['count']);
+		$this->assertSame(['nobody-here'], $report['unknownRecipients']['sample']);
+	}//end testUnknownRecipientsAreReportedNotSilentlyDropped()
+
+	public function testTemplateRecipientResolvesAFieldOnTheItem(): void {
+		$this->notificationManager->method('createNotification')->willReturn($this->fluentNotification());
+		$this->notificationManager->expects($this->exactly(1))->method('notify');
+
+		$report = $this->makeService()->sendNotification(
+			config: ['recipients' => ['{{ item.assignee }}'], 'message' => 'hi'],
+			items: $this->itemsOf(json: ['assignee' => 'carol']),
+			context: $this->contextFor(),
+			stepName: 'openregister.send-notification'
+		);
+
+		$this->assertSame(['carol'], $report['delivered']['sample']);
+	}//end testTemplateRecipientResolvesAFieldOnTheItem()
+
+	public function testWebPushRidesAlongWithADeliveredNotification(): void {
+		$this->notificationManager->method('createNotification')->willReturn($this->fluentNotification());
+		// One notification, one ride-along job — with no flow-side
+		// configuration asking for it.
+		$this->jobList->expects($this->exactly(1))->method('add');
+
+		$this->makeService()->sendNotification(
+			config: ['recipients' => ['bob'], 'message' => 'hi'],
+			items: $this->itemsOf(),
+			context: $this->contextFor(),
+			stepName: 'openregister.send-notification'
+		);
+	}//end testWebPushRidesAlongWithADeliveredNotification()
+}//end class

--- a/tests/Unit/Service/Flow/SendMessagingNodesTest.php
+++ b/tests/Unit/Service/Flow/SendMessagingNodesTest.php
@@ -1,0 +1,201 @@
+<?php
+
+/**
+ * The three messaging step nodes: validation, pass-through, form floor, and
+ * the palette boundary (exactly these three; no send-webhook).
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Flow;
+
+use OCA\OpenRegister\Listener\FlowNodeRegistrationListener;
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\FlowMessagingService;
+use OCA\OpenRegister\Service\Flow\Nodes\SendEmailNode;
+use OCA\OpenRegister\Service\Flow\Nodes\SendNotificationNode;
+use OCA\OpenRegister\Service\Flow\Nodes\SendTalkMessageNode;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionNamedType;
+use UnexpectedValueException;
+
+/**
+ * Node-level behaviour of the messaging palette.
+ */
+class SendMessagingNodesTest extends TestCase {
+
+	private FlowMessagingService&MockObject $messaging;
+
+	private IL10N&MockObject $l10n;
+
+	private IURLGenerator&MockObject $urls;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->messaging = $this->createMock(FlowMessagingService::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->l10n->method('t')->willReturnCallback(
+			static fn (string $text, array $params = []): string => vsprintf(str_replace(['{example}', '{given}'], '%s', $text), $params)
+		);
+		$this->urls = $this->createMock(IURLGenerator::class);
+	}//end setUp()
+
+	/**
+	 * All three nodes, keyed by their type id.
+	 *
+	 * @return array<string, object> The nodes.
+	 */
+	private function nodes(): array {
+		return [
+			SendNotificationNode::TYPE => new SendNotificationNode(messaging: $this->messaging, l10n: $this->l10n, urls: $this->urls),
+			SendEmailNode::TYPE => new SendEmailNode(messaging: $this->messaging, l10n: $this->l10n, urls: $this->urls),
+			SendTalkMessageNode::TYPE => new SendTalkMessageNode(messaging: $this->messaging, l10n: $this->l10n, urls: $this->urls),
+		];
+	}//end nodes()
+
+	public function testItemsFlowThroughUnchanged(): void {
+		$items = [
+			FlowItems::item(json: ['name' => 'a']),
+			FlowItems::item(json: ['name' => 'b']),
+			FlowItems::item(json: ['name' => 'c']),
+		];
+
+		$config = [
+			SendNotificationNode::TYPE => ['recipients' => ['bob'], 'message' => 'm'],
+			SendEmailNode::TYPE => ['recipients' => ['bob'], 'subject' => 's', 'body' => 'b'],
+			SendTalkMessageNode::TYPE => ['conversation' => 't', 'message' => 'm'],
+		];
+
+		foreach ($this->nodes() as $type => $node) {
+			$out = $node->execute(items: $items, config: $config[$type], context: ['runAs' => 'alice']);
+			// Sending is a side effect, not a transformation: the three items
+			// come back IDENTICAL for downstream steps.
+			$this->assertSame($items, $out, $type . ' must pass items through unchanged');
+		}
+	}//end testItemsFlowThroughUnchanged()
+
+	public function testValidateConfigRefusesAnEmptyMessage(): void {
+		$cases = [
+			[new SendNotificationNode(messaging: $this->messaging, l10n: $this->l10n, urls: $this->urls), ['recipients' => ['bob']]],
+			[new SendEmailNode(messaging: $this->messaging, l10n: $this->l10n, urls: $this->urls), ['recipients' => ['bob'], 'subject' => 's']],
+			[new SendTalkMessageNode(messaging: $this->messaging, l10n: $this->l10n, urls: $this->urls), ['conversation' => 'tok']],
+		];
+
+		foreach ($cases as [$node, $config]) {
+			try {
+				$node->validateConfig(config: $config);
+				$this->fail(get_class($node) . ' must refuse an empty message');
+			} catch (UnexpectedValueException $e) {
+				$this->assertNotSame('', $e->getMessage());
+			}
+		}
+	}//end testValidateConfigRefusesAnEmptyMessage()
+
+	public function testValidateConfigRefusesAnEmptyRecipientConfig(): void {
+		$notification = new SendNotificationNode(messaging: $this->messaging, l10n: $this->l10n, urls: $this->urls);
+		$email = new SendEmailNode(messaging: $this->messaging, l10n: $this->l10n, urls: $this->urls);
+		$talk = new SendTalkMessageNode(messaging: $this->messaging, l10n: $this->l10n, urls: $this->urls);
+
+		$refused = 0;
+		foreach ([
+			[$notification, ['message' => 'm', 'recipients' => []]],
+			[$notification, ['message' => 'm', 'recipients' => ['   ']]],
+			[$email, ['body' => 'b', 'recipients' => []]],
+			[$talk, ['message' => 'm', 'conversation' => '  ']],
+		] as [$node, $config]) {
+			try {
+				$node->validateConfig(config: $config);
+			} catch (UnexpectedValueException $e) {
+				$refused++;
+				continue;
+			}
+
+			$this->fail(get_class($node) . ' must refuse an empty recipient/conversation config');
+		}
+
+		$this->assertSame(4, $refused, 'Every empty-recipient shape must be refused.');
+	}//end testValidateConfigRefusesAnEmptyRecipientConfig()
+
+	public function testValidateConfigAcceptsACompleteConfig(): void {
+		foreach ([
+			[new SendNotificationNode(messaging: $this->messaging, l10n: $this->l10n, urls: $this->urls), ['recipients' => ['bob'], 'title' => 't', 'message' => 'm']],
+			[new SendEmailNode(messaging: $this->messaging, l10n: $this->l10n, urls: $this->urls), ['recipients' => '{{ assignee }}', 'subject' => 's', 'body' => 'b']],
+			[new SendTalkMessageNode(messaging: $this->messaging, l10n: $this->l10n, urls: $this->urls), ['conversation' => '{{ token }}', 'message' => 'm']],
+		] as [$node, $config]) {
+			$node->validateConfig(config: $config);
+		}
+
+		$this->addToAssertionCount(3);
+	}//end testValidateConfigAcceptsACompleteConfig()
+
+	public function testEveryFormFieldWritesADeclaredConfigKey(): void {
+		// The flow-node-config-forms floor: a form field over a key the node
+		// ignores looks like it works and changes nothing.
+		foreach ($this->nodes() as $type => $node) {
+			$keys = $node->configKeys();
+			$formKeys = array_map(static fn (array $field): string => (string)$field['key'], $node->configForm());
+			$this->assertNotSame([], $formKeys, $type . ' must declare a form');
+			foreach ($formKeys as $key) {
+				$this->assertContains($key, $keys, $type . ' form field "' . $key . '" must be a declared config key');
+			}
+		}
+	}//end testEveryFormFieldWritesADeclaredConfigKey()
+
+	public function testThePaletteHasExactlyTheseThreeMessagingTypesAndNoWebhook(): void {
+		// The three ids, from the nodes themselves.
+		$this->assertSame(
+			['openregister.send-email', 'openregister.send-notification', 'openregister.send-talk-message'],
+			array_values(array_intersect(
+				['openregister.send-email', 'openregister.send-notification', 'openregister.send-talk-message'],
+				array_keys($this->nodes())
+			))
+		);
+
+		// The registration listener constructor carries all three node types,
+		// which is the wiring `handle()` registers.
+		$ctor = (new ReflectionClass(FlowNodeRegistrationListener::class))->getConstructor();
+		$paramTypes = [];
+		foreach ($ctor->getParameters() as $param) {
+			$type = $param->getType();
+			if ($type instanceof ReflectionNamedType) {
+				$paramTypes[] = $type->getName();
+			}
+		}
+
+		$this->assertContains(SendNotificationNode::class, $paramTypes);
+		$this->assertContains(SendEmailNode::class, $paramTypes);
+		$this->assertContains(SendTalkMessageNode::class, $paramTypes);
+
+		// The boundary with ADR-094: outbound HTTP stays with OpenConnector.
+		// No send-webhook node exists — not in the built-ins directory, and no
+		// registered constructor parameter carries one.
+		$nodesDir = dirname((new ReflectionClass(SendEmailNode::class))->getFileName());
+		$this->assertSame([], glob($nodesDir . '/*Webhook*'), 'No webhook node may exist in the built-in palette');
+		foreach ($paramTypes as $paramType) {
+			$this->assertStringNotContainsString('Webhook', $paramType);
+		}
+
+		// Nor may activity or web-push be step types: activity is an audit
+		// surface, web-push rides along with send-notification.
+		$this->assertSame([], glob($nodesDir . '/*Activity*'));
+		$this->assertSame([], glob($nodesDir . '/*WebPush*'));
+	}//end testThePaletteHasExactlyTheseThreeMessagingTypesAndNoWebhook()
+}//end class

--- a/tests/Unit/Service/Notification/RateLimiterTest.php
+++ b/tests/Unit/Service/Notification/RateLimiterTest.php
@@ -159,6 +159,36 @@ class RateLimiterTest extends TestCase {
 		$limiter->tryConsume('rule', 'alice', $override); // dropped
 	}
 
+	public function testTheSharedPerRecipientBudgetIsCallerAgnostic(): void {
+		// Ten different rules — the declarative subsystem's shape — each
+		// consume once for alice. Every per-rule bucket is nearly full, but
+		// the SHARED per-recipient bucket (default size 10) is now empty…
+		$this->appConfigDefaults();
+		$limiter = $this->makeLimiter();
+		for ($i = 0; $i < 10; $i++) {
+			$this->assertTrue($limiter->tryConsume('rule-' . $i, 'alice'));
+		}
+
+		// …so an ELEVENTH caller — a flow send, under its own rule id whose
+		// per-rule bucket is untouched — is refused by the shared budget.
+		// The bucket key is the recipient, not the caller: one budget for
+		// "how much this instance messages this person".
+		$this->assertFalse($limiter->tryConsume('openregister.send-notification', 'alice'));
+
+		// A different recipient's budget is unaffected: the positive control.
+		$this->assertTrue($limiter->tryConsume('openregister.send-notification', 'bob'));
+	}
+
+	public function testBroadcastPseudoRecipientsStayOutsideTheSharedBudget(): void {
+		// `__webhook__` / `__talk__` keys are channels, not people; filling
+		// many rules' broadcast buckets must not starve one another.
+		$this->appConfigDefaults();
+		$limiter = $this->makeLimiter();
+		for ($i = 0; $i < 15; $i++) {
+			$this->assertTrue($limiter->tryConsume('rule-' . $i, '__webhook__'));
+		}
+	}
+
 	private function appConfigDefaults(): void {
 		$this->appConfig->method('getValueString')
 			->willReturnCallback(static fn (string $app, string $key, string $default): string => $default);


### PR DESCRIPTION
Implements the merged openspec change `flow-messaging-nodes` (15/15 tasks ticked in `openspec/changes/flow-messaging-nodes/tasks.md`).

## What this adds

Three step nodes, registered like every other built-in through `FlowNodeRegistrationListener`:

- `openregister.send-notification` (in-app notification, web-push riding along)
- `openregister.send-email`
- `openregister.send-talk-message` (posts as the run's acting user; "not a participant" is a step failure, never an auto-join)

Each is a thin invoker of the ADR-031 notification subsystem through a new `FlowMessagingService`. There is deliberately no `send-webhook` node: outbound HTTP stays with OpenConnector (ADR-094). `activity` and `web-push` are not step types either.

## Extraction (behaviour-preserving)

The per-channel send units, the recipient resolver and the dialect's placeholder evaluator are extracted from `AnnotationNotificationDispatcher` into call-shared units under `lib/Service/Notification/`: `NcNotificationSender`, `EmailSender`, `TalkSender`, `NotificationRecipientResolver`, `NotificationTemplating`. The dispatcher is re-wired onto them (appended optional constructor parameters, lazily built when absent) with its 282 existing tests green and unchanged.

## Guardrails, in order

1. **Subsystem kill switches**: new per-channel app-config switches (`notification_channel_<channel>_enabled`, default on) read inside the shared senders, so they silence declarative and flow sends alike. No flow-messaging switch exists: a runaway flow is stopped by its `enabled` flag or the instance flow kill switch, and the test proves the flow kill switch does not silence declarative notifications.
2. **Recipient preference**: resolved through `NotificationPreferenceService` under the `flow`/`send` scope; a skip is recorded as a skip, not a failure.
3. **Recipient bound**: post-expansion, default 25, raisable via `flow_messaging_recipient_bound`; refusal names the count and the bound and follows `onError`.
4. **Rate limiting**: `RateLimiter` gains a caller-agnostic shared per-recipient budget alongside its per-rule buckets, so a declarative fill blocks a flow send to the same person (and vice versa). Per-rule isolation is unchanged; broadcast pseudo-recipients (`__webhook__`) stay outside the shared budget.

Sends are attributed to the run's acting user (`runAs`); no resolvable actor fails the step naming the missing actor. Items pass through unchanged. A send failure is a step failure through the step's `onError` policy.

## Run log

Per-recipient/channel outcomes (delivered / skipped-by-preference / skipped-by-kill-switch / rate-limited / failed, plus unknown recipients) land on the step's log entry via a new `FlowStepReport` context handle that `FlowEngine` drains per hop (also on a failed step), bounded by `LOG_ITEM_SAMPLE`. This implements the flow-engine spec's existing "and its own log lines" requirement, which had no mechanism before.

## Engine files touched

`lib/Service/Flow/FlowEngine.php` (drains the step report onto the completed/failed log entry; ~25 additive lines), `lib/Service/Flow/FlowRunService.php` (one line: puts the report handle in the node context), `lib/Listener/FlowNodeRegistrationListener.php` (three registrations). Also `lib/Notification/AnnotationNotifier.php`: a custom subject with `_text` no longer indexes `SUBJECT_TEMPLATES` with an undefined key.

## Docs

The three nodes and the boundary statement are fed into `flow-engine-docs`' Steps catalogue task (the flows page itself is not written yet).

## Checks (run locally on this branch, rebased on development)

- `php -l` over every PHP file: clean
- phpcs (`phpcs.xml`, warnings off) on all 18 touched lib files: 0 errors
- phpmd (both rulesets, with baseline) on all touched lib files: 0 findings
- Psalm (`--no-cache`, full app): No errors found
- PHPStan (full app): No errors
- PHPUnit `Unit Tests` suite: 17884 tests, 40189 assertions, 0 failures, 0 errors (3 pre-existing risky tests in `TextExtractionServiceTest`, unrelated)
- New tests: `FlowMessagingServiceTest` (14), `FlowMessagingEquivalenceTest` (2), `SendMessagingNodesTest` (6), `RateLimiterTest` (+2)

Note: the composer `check:strict` wrapper hits composer's 300s process timeout on this machine when Psalm runs whole-app; the five checks it wraps were run individually as listed above.

@spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md