### PR TITLE
feat(flow): a case page's view of the engine, scoped to one subject

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -1338,6 +1338,11 @@ return [
 		// resolves routes in declaration order, so a later registration would be
 		// answered by `show('active')` → 404 for every request.
 		['name' => 'flowRun#active', 'url' => '/api/flow-runs/active', 'verb' => 'GET'],
+		// Finished runs on ONE subject object (flow-runs-subject-scope): the case
+		// page's run history. `subject` is REQUIRED (400 without it) and the read is
+		// organisation-scoped like `active`. Same ordering rule: it MUST stay above
+		// the `{uuid}` route or `show('completed')` answers it with a 404.
+		['name' => 'flowRun#completedForSubject', 'url' => '/api/flow-runs/completed', 'verb' => 'GET'],
 		['name' => 'flowRun#show', 'url' => '/api/flow-runs/{uuid}', 'verb' => 'GET', 'requirements' => ['uuid' => '[^/]+']],
 		['name' => 'flowRun#objects', 'url' => '/api/flow-runs/{uuid}/objects', 'verb' => 'GET', 'requirements' => ['uuid' => '[^/]+']],
 		['name' => 'flowRun#retry', 'url' => '/api/flow-runs/{uuid}/retry', 'verb' => 'POST', 'requirements' => ['uuid' => '[^/]+']],

--- a/lib/Controller/FlowRunController.php
+++ b/lib/Controller/FlowRunController.php
@@ -213,26 +213,142 @@ class FlowRunController extends Controller {
 	 * `shared-credentials-and-flows`. Until that landed `index()` was unscoped and
 	 * returned every run on the instance to any authenticated user.
 	 *
+	 * An optional `subject` (a subject object uuid) narrows the list to the
+	 * runs anchored to that one object: a case detail page's view of the
+	 * engine. It narrows INSIDE the organisation scope and can never widen it;
+	 * the mapper applies both predicates, and the total counts the filtered
+	 * set. Without `subject` the read is bit-identical to what it was.
+	 *
 	 * @return JSONResponse `{results, total, limit}` — the live runs.
 	 *
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 *
 	 * @spec openspec/changes/or-flow-active-runs/specs/flow-active-runs/spec.md
+	 * @spec openspec/changes/flow-runs-subject-scope/specs/flow-runs-subject-scope/spec.md
 	 */
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
 	public function active(): JSONResponse {
-		$limit = min(50, max(1, (int)$this->request->getParam('limit', 10)));
+		$limit = $this->pageLimit();
+		$subject = $this->subjectFilter();
 		$organisation = $this->activeOrganisation();
 
 		if ($organisation === null) {
 			return new JSONResponse(['results' => [], 'total' => 0, 'limit' => $limit]);
 		}
 
-		$runs = $this->mapper->findActive(organisation: $organisation, limit: $limit);
-		$total = $this->mapper->countActive(organisation: $organisation);
+		$runs = $this->mapper->findActive(organisation: $organisation, limit: $limit, subject: $subject);
+		$total = $this->mapper->countActive(organisation: $organisation, subject: $subject);
 
+		return $this->page(runs: $runs, total: $total, limit: $limit);
+
+	}//end active()
+
+	/**
+	 * The finished runs on ONE subject object: a case page's run history.
+	 *
+	 * The other half of the case view. A flow that completed on a case must
+	 * not look like nothing ever happened, so this returns the terminal runs
+	 * (`FlowRun::TERMINAL`: completed, stopped, dead_letter, failed) anchored
+	 * to the given subject, newest first, bounded, with an honest total.
+	 *
+	 * The subject is REQUIRED. There is no org-wide "everything that ever
+	 * finished" here: `or-flow-active-runs` requires the history surface
+	 * (`index()`, with its per-caller visibility rule) to stay unchanged, and
+	 * this read exists beside it rather than as a loosening of it. A request
+	 * without a subject is refused, not answered widely.
+	 *
+	 * Authorization is the organisation scope, exactly as on `active()`: the
+	 * mapper's organisation predicate is unconditional, a caller with no
+	 * resolvable organisation reads nothing without a query being issued, and
+	 * a subject uuid from another tenant matches zero rows. Rows are the same
+	 * summarised shape as the live read, so a widget renders one list.
+	 *
+	 * @return JSONResponse `{results, total, limit}`, or 400 when no subject was given.
+	 *
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 *
+	 * @spec openspec/changes/flow-runs-subject-scope/specs/flow-runs-subject-scope/spec.md
+	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	public function completedForSubject(): JSONResponse {
+		$subject = $this->subjectFilter();
+		if ($subject === null) {
+			return new JSONResponse(
+				['error' => 'The completed-runs read needs a subject: pass the subject object uuid as `subject`.'],
+				Http::STATUS_BAD_REQUEST
+			);
+		}
+
+		$limit = $this->pageLimit();
+		$organisation = $this->activeOrganisation();
+
+		if ($organisation === null) {
+			return new JSONResponse(['results' => [], 'total' => 0, 'limit' => $limit]);
+		}
+
+		$runs = $this->mapper->findCompletedForSubject(organisation: $organisation, subject: $subject, limit: $limit);
+		$total = $this->mapper->countCompletedForSubject(organisation: $organisation, subject: $subject);
+
+		return $this->page(runs: $runs, total: $total, limit: $limit);
+
+	}//end completedForSubject()
+
+	/**
+	 * The bounded page size for the two case-widget reads, capped at 50.
+	 *
+	 * @return integer The limit.
+	 *
+	 * @spec openspec/changes/flow-runs-subject-scope/specs/flow-runs-subject-scope/spec.md
+	 */
+	private function pageLimit(): int {
+		return min(50, max(1, (int)$this->request->getParam('limit', 10)));
+	}//end pageLimit()
+
+	/**
+	 * The `subject` request parameter as a uuid, or null when none was given.
+	 *
+	 * Blank and non-string values count as absent: a filter that is not a
+	 * uuid cannot name a subject, and treating it as one would either match
+	 * nothing (misleading) or be coerced into something the caller did not
+	 * send (worse).
+	 *
+	 * @return string|null The subject object uuid.
+	 *
+	 * @spec openspec/changes/flow-runs-subject-scope/specs/flow-runs-subject-scope/spec.md
+	 */
+	private function subjectFilter(): ?string {
+		$subject = $this->request->getParam('subject');
+		if (is_string($subject) === false) {
+			return null;
+		}
+
+		$subject = trim($subject);
+		if ($subject === '') {
+			return null;
+		}
+
+		return $subject;
+	}//end subjectFilter()
+
+	/**
+	 * A bounded list of summarised runs plus its honest total.
+	 *
+	 * Shared by the live read and the completed read so the two cannot drift
+	 * apart on shape: the spec makes one row contract a requirement.
+	 *
+	 * @param array<int, FlowRun> $runs The page of runs.
+	 * @param integer $total How many runs matched in all.
+	 * @param integer $limit The page size that was applied.
+	 *
+	 * @return JSONResponse `{results, total, limit}`.
+	 *
+	 * @spec openspec/changes/flow-runs-subject-scope/specs/flow-runs-subject-scope/spec.md
+	 */
+	private function page(array $runs, int $total, int $limit): JSONResponse {
 		return new JSONResponse(
 			[
 				'results' => array_map(fn (FlowRun $run): array => $this->summarise(run: $run), $runs),
@@ -240,8 +356,7 @@ class FlowRunController extends Controller {
 				'limit' => $limit,
 			]
 		);
-
-	}//end active()
+	}//end page()
 
 	/**
 	 * The caller's active organisation uuid, or null when none resolves.

--- a/lib/Db/FlowRunMapper.php
+++ b/lib/Db/FlowRunMapper.php
@@ -36,6 +36,16 @@ use OCP\IDBConnection;
  * ad-hoc query builders at each call site.
  *
  * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ * @SuppressWarnings(PHPMD.TooManyMethods)     Over by four since the subject-scoped
+ * reads of `flow-runs-subject-scope`, for the same reason: each public method is
+ * a distinct question with its own predicate set, and the private helpers behind
+ * the new reads exist so a row read and its count cannot drift apart on what
+ * they filter. Splitting the table across two mappers would hide the count, not
+ * the vocabulary.
+ * @SuppressWarnings(PHPMD.ExcessiveClassLength) Over the line budget by the same
+ * change. Most of the length is the docblocks that record WHY each query carries
+ * the predicates it does; those predicates are tenant boundaries, and trimming
+ * the reasoning to fit a line count is the wrong trade.
  *
  * @template-extends QBMapper<FlowRun>
  *
@@ -467,14 +477,24 @@ class FlowRunMapper extends QBMapper {
 	 * every user, and guessing a tenant for an unattributed run would leak one
 	 * tenant's activity into another's dashboard.
 	 *
+	 * The subject filter only ever NARROWS. It is a second predicate on
+	 * `subject_uuid` added NEXT TO the organisation predicate, never instead of
+	 * it: a subject uuid is guessable, so a run in another organisation that
+	 * happens to carry the asked-for subject must stay as invisible as it is
+	 * without the filter. Filtering here, in the datastore, is also what keeps
+	 * the total honest: a caller that filtered a bounded page client-side would
+	 * silently drop every matching run the page did not contain.
+	 *
 	 * @param string|null $organisation Restrict to one organisation uuid.
 	 * @param integer $limit Page size.
+	 * @param string|null $subject Restrict to runs anchored to one subject object uuid.
 	 *
 	 * @return array<int, FlowRun> The non-terminal runs.
 	 *
 	 * @spec openspec/changes/or-flow-active-runs/specs/flow-active-runs/spec.md
+	 * @spec openspec/changes/flow-runs-subject-scope/specs/flow-runs-subject-scope/spec.md
 	 */
-	public function findActive(?string $organisation = null, int $limit = 25): array {
+	public function findActive(?string $organisation = null, int $limit = 25, ?string $subject = null): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from($this->getTableName())
@@ -490,6 +510,8 @@ class FlowRunMapper extends QBMapper {
 		if ($organisation !== null && $organisation !== '') {
 			$qb->andWhere($qb->expr()->eq('organisation', $qb->createNamedParameter($organisation)));
 		}
+
+		$this->narrowToSubject(qb: $qb, subject: $subject);
 
 		return $this->findEntities(query: $qb);
 	}//end findActive()
@@ -556,13 +578,19 @@ class FlowRunMapper extends QBMapper {
 	 * an honest total — "3 of 47 running" needs the 47, and paging the whole
 	 * set to count it would be absurd.
 	 *
+	 * Takes the same subject filter as {@see findActive}, applied the same
+	 * way, so the total a widget states is the total of the rows it filtered
+	 * rather than of a set the caller never asked for.
+	 *
 	 * @param string|null $organisation Restrict to one organisation uuid.
+	 * @param string|null $subject Restrict to runs anchored to one subject object uuid.
 	 *
 	 * @return integer The number of non-terminal runs.
 	 *
 	 * @spec openspec/changes/or-flow-active-runs/specs/flow-active-runs/spec.md
+	 * @spec openspec/changes/flow-runs-subject-scope/specs/flow-runs-subject-scope/spec.md
 	 */
-	public function countActive(?string $organisation = null): int {
+	public function countActive(?string $organisation = null, ?string $subject = null): int {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select($qb->createFunction('COUNT(*) AS `total`'))
 			->from($this->getTableName())
@@ -577,12 +605,141 @@ class FlowRunMapper extends QBMapper {
 			$qb->andWhere($qb->expr()->eq('organisation', $qb->createNamedParameter($organisation)));
 		}
 
+		$this->narrowToSubject(qb: $qb, subject: $subject);
+
+		return $this->fetchTotal(qb: $qb);
+	}//end countActive()
+
+	/**
+	 * The finished runs anchored to ONE subject object, newest first.
+	 *
+	 * A case page's "what already ran here". The read is deliberately narrow
+	 * in a way the history surface (`findAllRuns`) is not: the subject is
+	 * REQUIRED and the organisation is REQUIRED, and both are equality
+	 * predicates in the datastore. There is no org-wide "all finished runs"
+	 * on this path; a caller who wants that has the history endpoint, with
+	 * its own per-caller visibility rule. Widening THIS read would widen run
+	 * visibility through the back door, which `or-flow-active-runs` forbids.
+	 *
+	 * Fails CLOSED on a missing predicate: an empty organisation or subject
+	 * returns nothing without a query rather than dropping the predicate and
+	 * answering a wider question than was asked.
+	 *
+	 * @param string $organisation The caller's organisation uuid.
+	 * @param string $subject The subject object uuid.
+	 * @param integer $limit Page size.
+	 *
+	 * @return array<int, FlowRun> The terminal runs, newest first.
+	 *
+	 * @spec openspec/changes/flow-runs-subject-scope/specs/flow-runs-subject-scope/spec.md
+	 */
+	public function findCompletedForSubject(string $organisation, string $subject, int $limit = 25): array {
+		if ($organisation === '' || $subject === '') {
+			return [];
+		}
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->orderBy('id', 'DESC')
+			->setMaxResults($limit);
+
+		$this->whereTerminalForSubject(qb: $qb, organisation: $organisation, subject: $subject);
+
+		return $this->findEntities(query: $qb);
+	}//end findCompletedForSubject()
+
+	/**
+	 * How many finished runs one subject object has, for the honest total.
+	 *
+	 * Same predicates as {@see findCompletedForSubject}, so "3 of 14 earlier
+	 * runs" counts the set the rows came from.
+	 *
+	 * @param string $organisation The caller's organisation uuid.
+	 * @param string $subject The subject object uuid.
+	 *
+	 * @return integer The number of terminal runs on the subject.
+	 *
+	 * @spec openspec/changes/flow-runs-subject-scope/specs/flow-runs-subject-scope/spec.md
+	 */
+	public function countCompletedForSubject(string $organisation, string $subject): int {
+		if ($organisation === '' || $subject === '') {
+			return 0;
+		}
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->select($qb->createFunction('COUNT(*) AS `total`'))
+			->from($this->getTableName());
+
+		$this->whereTerminalForSubject(qb: $qb, organisation: $organisation, subject: $subject);
+
+		return $this->fetchTotal(qb: $qb);
+	}//end countCompletedForSubject()
+
+	/**
+	 * Add the subject predicate when a subject was asked for.
+	 *
+	 * One place for both the row read and the count, so the two cannot drift
+	 * apart on what "this subject's runs" means. A null or empty subject adds
+	 * nothing, which is what makes the unfiltered read bit-identical to before.
+	 *
+	 * @param IQueryBuilder $qb The query being built.
+	 * @param string|null $subject The subject object uuid, or null for no filter.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-runs-subject-scope/specs/flow-runs-subject-scope/spec.md
+	 */
+	private function narrowToSubject(IQueryBuilder $qb, ?string $subject): void {
+		if ($subject === null || $subject === '') {
+			return;
+		}
+
+		$qb->andWhere($qb->expr()->eq('subject_uuid', $qb->createNamedParameter($subject)));
+	}//end narrowToSubject()
+
+	/**
+	 * The three predicates of the completed-runs read: terminal, this organisation, this subject.
+	 *
+	 * Order is a correctness statement, not an optimisation: the organisation
+	 * predicate is unconditional, so a guessed subject uuid from another
+	 * tenant matches zero rows rather than leaking one.
+	 *
+	 * @param IQueryBuilder $qb The query being built.
+	 * @param string $organisation The caller's organisation uuid.
+	 * @param string $subject The subject object uuid.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-runs-subject-scope/specs/flow-runs-subject-scope/spec.md
+	 */
+	private function whereTerminalForSubject(IQueryBuilder $qb, string $organisation, string $subject): void {
+		$qb->where(
+			$qb->expr()->in(
+				'status',
+				$qb->createNamedParameter(FlowRun::TERMINAL, IQueryBuilder::PARAM_STR_ARRAY)
+			)
+		)
+			->andWhere($qb->expr()->eq('organisation', $qb->createNamedParameter($organisation)))
+			->andWhere($qb->expr()->eq('subject_uuid', $qb->createNamedParameter($subject)));
+	}//end whereTerminalForSubject()
+
+	/**
+	 * Run a COUNT(*) query and return its one number.
+	 *
+	 * @param IQueryBuilder $qb A query selecting `COUNT(*) AS total`.
+	 *
+	 * @return integer The count.
+	 *
+	 * @spec openspec/changes/flow-runs-subject-scope/specs/flow-runs-subject-scope/spec.md
+	 */
+	private function fetchTotal(IQueryBuilder $qb): int {
 		$result = $qb->executeQuery();
 		$total = (int)$result->fetchOne();
 		$result->closeCursor();
 
 		return $total;
-	}//end countActive()
+	}//end fetchTotal()
 
 	/**
 	 * Suspended runs that are due to resume.

--- a/lib/Migration/Version1Date20260901123000.php
+++ b/lib/Migration/Version1Date20260901123000.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * Index `openregister_flow_runs` on (organisation, subject_uuid, status, id)
+ * for the two subject-scoped run reads.
+ *
+ * FLOW-RUNS-SUBJECT-SCOPE (openspec/changes/flow-runs-subject-scope). A case
+ * detail page asks two questions of the run table: "what is running on THIS
+ * object" (`organisation = ? AND subject_uuid = ? AND status IN (active set)`)
+ * and "what already ran on it" (same, over the terminal set), both newest
+ * first and bounded. The existing `or_flowrun_org_status_idx` leads with
+ * `(organisation, status, id)`, which serves the org-wide widget but makes a
+ * subject read scan every live or every finished run of the tenant and filter
+ * on `subject_uuid` afterwards. On a busy tenant the finished set is the whole
+ * history, so that is a walk, not a lookup.
+ *
+ * `organisation` leads because it is the equality that eliminates the most
+ * rows and is the predicate that is never optional, `subject_uuid` follows as
+ * the second equality (one case out of thousands), `status` third for the IN
+ * over the status set, and `id` last so the newest-first ordering and the
+ * LIMIT come off the index rather than a sort.
+ *
+ * Strictly additive: an index add cannot fail on existing data and changes no
+ * rows. Idempotent: added only when absent.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-runs-subject-scope/specs/flow-runs-subject-scope/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Adds `or_flowrun_org_subject_idx` on `openregister_flow_runs`.
+ *
+ * @spec openspec/changes/flow-runs-subject-scope/specs/flow-runs-subject-scope/spec.md
+ */
+class Version1Date20260901123000 extends SimpleMigrationStep {
+	/**
+	 * The index that serves the subject-scoped live and completed reads.
+	 *
+	 * @var string
+	 */
+	private const SUBJECT_RUNS_INDEX = 'or_flowrun_org_subject_idx';
+
+	/**
+	 * Change the database schema.
+	 *
+	 * @param IOutput $output Output for the migration process.
+	 * @param Closure $schemaClosure The schema closure.
+	 * @param array<array-key, mixed> $options Migration options.
+	 *
+	 * @return ISchemaWrapper|null
+	 *
+	 * @spec openspec/changes/flow-runs-subject-scope/specs/flow-runs-subject-scope/spec.md
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/*
+		 * @var ISchemaWrapper $schema
+		 */
+
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('openregister_flow_runs') === false) {
+			return $schema;
+		}
+
+		$table = $schema->getTable('openregister_flow_runs');
+
+		if ($table->hasIndex(self::SUBJECT_RUNS_INDEX) === true) {
+			$output->info(self::SUBJECT_RUNS_INDEX . ' already present on openregister_flow_runs; nothing to do.');
+			return $schema;
+		}
+
+		$table->addIndex(['organisation', 'subject_uuid', 'status', 'id'], self::SUBJECT_RUNS_INDEX);
+		$output->info(
+			'Added ' . self::SUBJECT_RUNS_INDEX . ' on openregister_flow_runs(organisation, subject_uuid, status, id): '
+			. 'the subject-scoped live and completed reads are a range scan on one case '
+			. 'rather than a walk over every run of the tenant.'
+		);
+
+		return $schema;
+	}//end changeSchema()
+}//end class

--- a/openspec/changes/flow-runs-subject-scope/tasks.md
+++ b/openspec/changes/flow-runs-subject-scope/tasks.md
@@ -2,12 +2,12 @@
 
 ## 1. The subject filter on the live read
 
-- [ ] 1.1 `FlowRunMapper::findActive()` and `countActive()` gain an
+- [x] 1.1 `FlowRunMapper::findActive()` and `countActive()` gain an
       optional `subject` argument, added as an `AND` predicate on
       `subject_uuid` next to the unconditional organisation predicate
       (`lib/Db/FlowRunMapper.php:477`, `:565`). Rows and total share the
       predicates.
-- [ ] 1.2 `FlowRunController::active()` reads the `subject` request
+- [x] 1.2 `FlowRunController::active()` reads the `subject` request
       parameter and passes it through
       (`lib/Controller/FlowRunController.php:225`). Absent parameter is
       bit-identical to today; the no-organisation early return stays
@@ -15,18 +15,18 @@
 
 ## 2. The completed-runs read
 
-- [ ] 2.1 `FlowRunMapper::findCompletedForSubject()` +
+- [x] 2.1 `FlowRunMapper::findCompletedForSubject()` +
       `countCompletedForSubject()`: `FlowRun::TERMINAL` statuses
       (`lib/Db/FlowRun.php:142`), required subject uuid, organisation
       predicate, newest first, capped limit.
-- [ ] 2.2 `FlowRunController::completedForSubject()` + route
+- [x] 2.2 `FlowRunController::completedForSubject()` + route
       `GET /api/flow-runs/completed` in `appinfo/routes.php`, refusing a
       request without `subject` and reusing `summarise()` unchanged. The
       existing `flowRun#index` history endpoint is not touched.
 
 ## 3. The index
 
-- [ ] 3.1 Migration adding a composite index over
+- [x] 3.1 Migration adding a composite index over
       `(organisation, subject_uuid, status)` on the runs table.
 
 ## 4. Follow-up (not in this change)
@@ -38,11 +38,11 @@
 
 ## 5. Tests
 
-- [ ] 5.1 Mapper unit tests: subject narrowing with honest totals; a
+- [x] 5.1 Mapper unit tests: subject narrowing with honest totals; a
       matching subject uuid in another organisation returns and counts
       nothing; the terminal set drives the completed read (including
       `failed`); newest-first ordering.
-- [ ] 5.2 Controller unit tests: absent `subject` equals today's read;
+- [x] 5.2 Controller unit tests: absent `subject` equals today's read;
       missing subject on the completed read is refused naming the
       parameter; both reads return the summarised row (uuid, flow name,
       step, status, started at, subject block) and never marking, items

--- a/tests/Unit/Controller/FlowRunControllerTest.php
+++ b/tests/Unit/Controller/FlowRunControllerTest.php
@@ -170,15 +170,184 @@ class FlowRunControllerTest extends TestCase {
 		$this->params([]);
 		$this->activeOrganisation('org-a');
 
+		// No `subject` on the request means NO subject predicate reaches the
+		// mapper: the org-wide widget's read is bit-identical to before.
 		$this->mapper->expects($this->once())->method('findActive')
-			->with('org-a', 10)
+			->with('org-a', 10, null)
 			->willReturn([]);
 		$this->mapper->expects($this->once())->method('countActive')
-			->with('org-a')
+			->with('org-a', null)
 			->willReturn(0);
 
 		$this->controller->active();
 	}//end testActiveScopesToTheCallersOrganisation()
+
+	public function testActivePassesTheSubjectToBothTheRowsAndTheTotal(): void {
+		$this->params(['subject' => 'case-x']);
+		$this->activeOrganisation('org-a');
+
+		// The organisation predicate stays: the subject NARROWS inside it. And
+		// the total is counted with the same filter, so a case widget can say
+		// "2 running" rather than the tenant-wide number.
+		$this->mapper->expects($this->once())->method('findActive')
+			->with('org-a', 10, 'case-x')
+			->willReturn([]);
+		$this->mapper->expects($this->once())->method('countActive')
+			->with('org-a', 'case-x')
+			->willReturn(2);
+
+		$this->assertSame(2, $this->controller->active()->getData()['total']);
+	}//end testActivePassesTheSubjectToBothTheRowsAndTheTotal()
+
+	public function testActiveWithASubjectStillReadsNothingWithoutAnOrganisation(): void {
+		$this->params(['subject' => 'case-x']);
+		$this->activeOrganisation(null);
+
+		// A subject uuid is guessable. It must not become a way to read runs
+		// when the tenant scope cannot be established: no query at all.
+		$this->mapper->expects($this->never())->method('findActive');
+		$this->mapper->expects($this->never())->method('countActive');
+
+		$body = $this->controller->active()->getData();
+
+		$this->assertSame([], $body['results']);
+		$this->assertSame(0, $body['total']);
+	}//end testActiveWithASubjectStillReadsNothingWithoutAnOrganisation()
+
+	public function testABlankSubjectOnTheLiveReadIsNoFilter(): void {
+		$this->params(['subject' => '   ']);
+		$this->activeOrganisation('org-a');
+
+		$this->mapper->expects($this->once())->method('findActive')
+			->with('org-a', 10, null)
+			->willReturn([]);
+		$this->mapper->method('countActive')->willReturn(0);
+
+		$this->controller->active();
+	}//end testABlankSubjectOnTheLiveReadIsNoFilter()
+
+	public function testCompletedForSubjectWithoutASubjectIsRefusedNamingTheParameter(): void {
+		$this->params([]);
+		$this->activeOrganisation('org-a');
+
+		// Refused, not answered widely: there is no org-wide "everything that
+		// ever finished" on this path. The history endpoint is that surface,
+		// with its own per-caller visibility rule.
+		$this->mapper->expects($this->never())->method('findCompletedForSubject');
+		$this->mapper->expects($this->never())->method('countCompletedForSubject');
+
+		$response = $this->controller->completedForSubject();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertStringContainsString('subject', $response->getData()['error']);
+	}//end testCompletedForSubjectWithoutASubjectIsRefusedNamingTheParameter()
+
+	public function testCompletedForSubjectWithABlankSubjectIsRefused(): void {
+		$this->params(['subject' => '  ']);
+		$this->activeOrganisation('org-a');
+
+		$this->mapper->expects($this->never())->method('findCompletedForSubject');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $this->controller->completedForSubject()->getStatus());
+	}//end testCompletedForSubjectWithABlankSubjectIsRefused()
+
+	public function testCompletedForSubjectWithNoResolvableOrganisationReturnsNothing(): void {
+		$this->params(['subject' => 'case-x']);
+		$this->activeOrganisation(null);
+
+		$this->mapper->expects($this->never())->method('findCompletedForSubject');
+		$this->mapper->expects($this->never())->method('countCompletedForSubject');
+
+		$response = $this->controller->completedForSubject();
+		$body = $response->getData();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame([], $body['results']);
+		$this->assertSame(0, $body['total']);
+	}//end testCompletedForSubjectWithNoResolvableOrganisationReturnsNothing()
+
+	public function testCompletedForSubjectScopesToTheOrganisationAndTheSubjectWithACappedLimit(): void {
+		$this->params(['subject' => 'case-x', 'limit' => 5000]);
+		$this->activeOrganisation('org-a');
+
+		$this->mapper->expects($this->once())->method('findCompletedForSubject')
+			->with('org-a', 'case-x', 50)
+			->willReturn([]);
+		$this->mapper->expects($this->once())->method('countCompletedForSubject')
+			->with('org-a', 'case-x')
+			->willReturn(14);
+
+		$body = $this->controller->completedForSubject()->getData();
+
+		$this->assertSame(50, $body['limit']);
+		// The honest total, not the length of the bounded page.
+		$this->assertSame(14, $body['total']);
+	}//end testCompletedForSubjectScopesToTheOrganisationAndTheSubjectWithACappedLimit()
+
+	public function testBothReadsShareOneRowShapeAndNeverCarryTheMarkingItemsOrLog(): void {
+		$this->params(['subject' => 'case-x']);
+		$this->activeOrganisation('org-a');
+
+		$live = new FlowRun();
+		$live->setUuid('run-live');
+		$live->setFlowId('f1');
+		$live->setStatus(FlowRun::STATUS_SUSPENDED);
+		$live->setMarking(['await-reply' => 1]);
+		$live->setItems([['record' => 'the subject\'s own data']]);
+		$live->setLog([['step' => 1, 'node' => 'start']]);
+		$live->setContext(['secret' => 'x']);
+		$live->setCreated(new \DateTime('2026-09-01T10:00:00+00:00'));
+		$live->setSubjectUuid('case-x');
+		$live->setSubjectRegister('cases');
+		$live->setSubjectSchema('case');
+
+		$done = new FlowRun();
+		$done->setUuid('run-done');
+		$done->setFlowId('f1');
+		$done->setStatus(FlowRun::STATUS_FAILED);
+		// A finished run has no token anywhere: step must read null, not ''.
+		$done->setMarking([]);
+		$done->setItems([['record' => 'more subject data']]);
+		$done->setLog([['step' => 1], ['step' => 2]]);
+		$done->setCreated(new \DateTime('2026-08-30T09:00:00+00:00'));
+		$done->setSubjectUuid('case-x');
+		$done->setSubjectRegister('cases');
+		$done->setSubjectSchema('case');
+
+		$this->mapper->method('findActive')->willReturn([$live]);
+		$this->mapper->method('countActive')->willReturn(1);
+		$this->mapper->method('findCompletedForSubject')->willReturn([$done]);
+		$this->mapper->method('countCompletedForSubject')->willReturn(1);
+		$this->resolvers->method('resolveFlow')->with('f1')->willReturn(['id' => 'f1', 'name' => 'Hersteltermijn']);
+
+		$liveRow = $this->controller->active()->getData()['results'][0];
+		$doneRow = $this->controller->completedForSubject()->getData()['results'][0];
+
+		// The five widget fields plus the subject block, on both.
+		$this->assertSame('run-live', $liveRow['uuid']);
+		$this->assertSame('Hersteltermijn', $liveRow['flowName']);
+		$this->assertSame('await-reply', $liveRow['step']);
+		$this->assertSame(FlowRun::STATUS_SUSPENDED, $liveRow['status']);
+		$this->assertSame('2026-09-01T10:00:00+00:00', $liveRow['created']);
+		$this->assertSame(['uuid' => 'case-x', 'register' => 'cases', 'schema' => 'case'], $liveRow['subject']);
+
+		$this->assertSame('run-done', $doneRow['uuid']);
+		$this->assertSame('Hersteltermijn', $doneRow['flowName']);
+		$this->assertNull($doneRow['step']);
+		$this->assertSame(FlowRun::STATUS_FAILED, $doneRow['status']);
+		$this->assertSame('2026-08-30T09:00:00+00:00', $doneRow['created']);
+		$this->assertSame(['uuid' => 'case-x', 'register' => 'cases', 'schema' => 'case'], $doneRow['subject']);
+
+		// One shape: a widget renders live and finished runs as one list.
+		$this->assertSame(array_keys($liveRow), array_keys($doneRow));
+
+		// And never the heavy fields: kilobytes per row a list never renders,
+		// and items can hold the subject's own record data.
+		foreach (['marking', 'items', 'log', 'context', 'error', 'steps'] as $heavy) {
+			$this->assertArrayNotHasKey($heavy, $liveRow, "live row leaks '$heavy'");
+			$this->assertArrayNotHasKey($heavy, $doneRow, "completed row leaks '$heavy'");
+		}
+	}//end testBothReadsShareOneRowShapeAndNeverCarryTheMarkingItemsOrLog()
 
 	public function testActiveSummarisesEachRunWithItsFlowNameAndStep(): void {
 		$this->params(['limit' => 5]);

--- a/tests/Unit/Db/FlowRunMapperSubjectScopeTest.php
+++ b/tests/Unit/Db/FlowRunMapperSubjectScopeTest.php
@@ -1,0 +1,258 @@
+<?php
+
+/**
+ * The subject-scoped run reads: what predicates reach the datastore.
+ *
+ * A case detail page asks "what is running on THIS object, and what already
+ * ran". Both answers must be narrowed INSIDE the caller's organisation, in the
+ * database, and never widened by the subject: a subject uuid is guessable, so
+ * a filter that replaced the organisation predicate would turn the case anchor
+ * into a cross-tenant read primitive.
+ *
+ * These tests record the predicates, ordering and bounds each read builds and
+ * assert on them directly, because that is where the property lives. The
+ * two-organisation scenario in the spec ("a matching subject in organisation B
+ * stays invisible to a caller in organisation A") is, at this layer, exactly
+ * the assertion that the `organisation = ?` predicate is present next to the
+ * `subject_uuid = ?` predicate on every one of the four reads.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Db
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-runs-subject-scope/specs/flow-runs-subject-scope/spec.md
+ */
+
+declare(strict_types=1);
+
+// phpcs:disable PEAR.Commenting.FunctionComment.Missing -- arrange/act/assert PHPUnit conventions; the test name is the statement.
+// phpcs:disable CustomSniffs.Functions.NamedParameters.RequireNamedParameters -- PHPUnit assertion helpers use positional args.
+
+namespace OCA\OpenRegister\Tests\Unit\Db;
+
+use OCA\OpenRegister\Db\FlowRun;
+use OCA\OpenRegister\Db\FlowRunMapper;
+use OCP\DB\IResult;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use PHPUnit\Framework\TestCase;
+
+class FlowRunMapperSubjectScopeTest extends TestCase {
+
+	/**
+	 * Every predicate the query received, in order, rendered as `column OP value`.
+	 *
+	 * @var array<int, string>
+	 */
+	private array $predicates = [];
+
+	/**
+	 * The `orderBy` calls, as `[column, direction]` pairs.
+	 *
+	 * @var array<int, array<int, string>>
+	 */
+	private array $orderBy = [];
+
+	/**
+	 * The `setMaxResults` argument, or null when never bounded.
+	 *
+	 * @var integer|null
+	 */
+	private ?int $limit = null;
+
+	/**
+	 * How many query builders the mapper asked for.
+	 *
+	 * @var integer
+	 */
+	private int $queries = 0;
+
+	/**
+	 * A mapper over a connection whose query builder records what is asked of it.
+	 *
+	 * The expression builder renders `eq()`/`in()` as readable strings and
+	 * `createNamedParameter()` returns the VALUE (json-encoded) instead of a
+	 * placeholder, so a recorded predicate reads `organisation = "org-a"` and
+	 * can be asserted on directly. The result set is empty: what is under test
+	 * is the question, not the rows.
+	 *
+	 * @param integer $total What a COUNT(*) query answers.
+	 *
+	 * @return FlowRunMapper The mapper.
+	 */
+	private function recordingMapper(int $total = 0): FlowRunMapper {
+		$expr = $this->createMock(IExpressionBuilder::class);
+		$expr->method('eq')->willReturnCallback(
+			static fn (string $column, string $value): string => $column . ' = ' . $value
+		);
+		$expr->method('in')->willReturnCallback(
+			static fn (string $column, string $value): string => $column . ' IN ' . $value
+		);
+
+		$result = $this->createMock(IResult::class);
+		$result->method('fetch')->willReturn(false);
+		$result->method('fetchOne')->willReturn($total);
+
+		$qb = $this->createMock(IQueryBuilder::class);
+		$qb->method('expr')->willReturn($expr);
+		$qb->method('createNamedParameter')->willReturnCallback(
+			static fn ($value): string => (string)json_encode($value)
+		);
+		$qb->method('createFunction')->willReturnArgument(0);
+		$qb->method('select')->willReturnSelf();
+		$qb->method('from')->willReturnSelf();
+		$qb->method('where')->willReturnCallback(
+			function (string $predicate) use ($qb): IQueryBuilder {
+				$this->predicates[] = $predicate;
+				return $qb;
+			}
+		);
+		$qb->method('andWhere')->willReturnCallback(
+			function (string $predicate) use ($qb): IQueryBuilder {
+				$this->predicates[] = $predicate;
+				return $qb;
+			}
+		);
+		$qb->method('orderBy')->willReturnCallback(
+			function (string $column, ?string $direction = null) use ($qb): IQueryBuilder {
+				$this->orderBy[] = [$column, (string)$direction];
+				return $qb;
+			}
+		);
+		$qb->method('setMaxResults')->willReturnCallback(
+			function (?int $limit) use ($qb): IQueryBuilder {
+				$this->limit = $limit;
+				return $qb;
+			}
+		);
+		$qb->method('executeQuery')->willReturn($result);
+
+		$db = $this->createMock(IDBConnection::class);
+		$db->method('getQueryBuilder')->willReturnCallback(
+			function () use ($qb): IQueryBuilder {
+				$this->queries++;
+				return $qb;
+			}
+		);
+
+		return new FlowRunMapper($db);
+	}//end recordingMapper()
+
+	/**
+	 * The status set as the recording builder renders it.
+	 *
+	 * @param array<int, string> $statuses The status set.
+	 *
+	 * @return string The rendered IN predicate.
+	 */
+	private static function statusIn(array $statuses): string {
+		return 'status IN ' . json_encode($statuses);
+	}//end statusIn()
+
+	public function testFindActiveWithASubjectKeepsTheOrganisationPredicateAndAddsTheSubject(): void {
+		$mapper = $this->recordingMapper();
+
+		$mapper->findActive(organisation: 'org-a', limit: 25, subject: 'case-x');
+
+		// The organisation predicate is unconditional and comes FIRST; the
+		// subject narrows after it. This is the two-organisation scenario: a
+		// caller in org A asking for a subject that lives in org B hits
+		// `organisation = "org-a"` before `subject_uuid` is ever consulted.
+		$this->assertSame(
+			[self::statusIn(FlowRun::ACTIVE), 'organisation = "org-a"', 'subject_uuid = "case-x"'],
+			$this->predicates
+		);
+	}//end testFindActiveWithASubjectKeepsTheOrganisationPredicateAndAddsTheSubject()
+
+	public function testFindActiveWithoutASubjectIsTodaysRead(): void {
+		$mapper = $this->recordingMapper();
+
+		$mapper->findActive(organisation: 'org-a', limit: 25);
+
+		$this->assertSame([self::statusIn(FlowRun::ACTIVE), 'organisation = "org-a"'], $this->predicates);
+		$this->assertSame([['id', 'DESC']], $this->orderBy);
+		$this->assertSame(25, $this->limit);
+	}//end testFindActiveWithoutASubjectIsTodaysRead()
+
+	public function testABlankSubjectAddsNoPredicate(): void {
+		$mapper = $this->recordingMapper();
+
+		$mapper->findActive(organisation: 'org-a', limit: 25, subject: '');
+
+		$this->assertNotContains('subject_uuid = ""', $this->predicates);
+		$this->assertCount(2, $this->predicates);
+	}//end testABlankSubjectAddsNoPredicate()
+
+	public function testCountActiveSharesTheRowPredicatesSoTheTotalIsHonest(): void {
+		$mapper = $this->recordingMapper(total: 2);
+
+		$total = $mapper->countActive(organisation: 'org-a', subject: 'case-x');
+
+		$this->assertSame(2, $total);
+		$this->assertSame(
+			[self::statusIn(FlowRun::ACTIVE), 'organisation = "org-a"', 'subject_uuid = "case-x"'],
+			$this->predicates
+		);
+	}//end testCountActiveSharesTheRowPredicatesSoTheTotalIsHonest()
+
+	public function testTheCompletedReadAsksForTheTerminalSetOnThisOrganisationAndSubjectNewestFirst(): void {
+		$mapper = $this->recordingMapper();
+
+		$mapper->findCompletedForSubject(organisation: 'org-a', subject: 'case-x', limit: 7);
+
+		$this->assertSame(
+			[self::statusIn(FlowRun::TERMINAL), 'organisation = "org-a"', 'subject_uuid = "case-x"'],
+			$this->predicates
+		);
+		$this->assertSame([['id', 'DESC']], $this->orderBy);
+		$this->assertSame(7, $this->limit);
+	}//end testTheCompletedReadAsksForTheTerminalSetOnThisOrganisationAndSubjectNewestFirst()
+
+	public function testTheTerminalSetTheCompletedReadUsesIncludesFailed(): void {
+		// "A failed run is history too": the read is driven by the entity's
+		// terminal set, and that set carries `failed`. If someone ever trims it
+		// to `completed` alone, a failed hersteltermijn vanishes from its case.
+		$this->assertContains(FlowRun::STATUS_FAILED, FlowRun::TERMINAL);
+		$this->assertContains(FlowRun::STATUS_COMPLETED, FlowRun::TERMINAL);
+		$this->assertContains(FlowRun::STATUS_STOPPED, FlowRun::TERMINAL);
+		$this->assertContains(FlowRun::STATUS_DEAD_LETTER, FlowRun::TERMINAL);
+
+		$mapper = $this->recordingMapper();
+		$mapper->findCompletedForSubject(organisation: 'org-a', subject: 'case-x');
+
+		$this->assertStringContainsString('"failed"', $this->predicates[0]);
+	}//end testTheTerminalSetTheCompletedReadUsesIncludesFailed()
+
+	public function testTheCompletedCountSharesThePredicates(): void {
+		$mapper = $this->recordingMapper(total: 14);
+
+		$total = $mapper->countCompletedForSubject(organisation: 'org-a', subject: 'case-x');
+
+		$this->assertSame(14, $total);
+		$this->assertSame(
+			[self::statusIn(FlowRun::TERMINAL), 'organisation = "org-a"', 'subject_uuid = "case-x"'],
+			$this->predicates
+		);
+	}//end testTheCompletedCountSharesThePredicates()
+
+	public function testTheCompletedReadFailsClosedWithoutASubjectOrOrganisation(): void {
+		$mapper = $this->recordingMapper(total: 99);
+
+		// Dropping a required predicate would answer a WIDER question than was
+		// asked. Nothing is queried; the answer is empty and zero.
+		$this->assertSame([], $mapper->findCompletedForSubject(organisation: 'org-a', subject: ''));
+		$this->assertSame([], $mapper->findCompletedForSubject(organisation: '', subject: 'case-x'));
+		$this->assertSame(0, $mapper->countCompletedForSubject(organisation: 'org-a', subject: ''));
+		$this->assertSame(0, $mapper->countCompletedForSubject(organisation: '', subject: 'case-x'));
+		$this->assertSame(0, $this->queries);
+	}//end testTheCompletedReadFailsClosedWithoutASubjectOrOrganisation()
+}//end class


### PR DESCRIPTION
Implements the openspec change `flow-runs-subject-scope` (spec merged in #3250). A case detail page gets one honest read of the runs about one object.

## What changes

**`GET /api/flow-runs/active?subject=<uuid>`** narrows the live-runs read to the runs anchored to that subject object. The filter is a second `AND` predicate on `subject_uuid`, applied in the datastore next to the organisation predicate. The organisation predicate stays unconditional, so a guessed uuid from another tenant matches nothing. `total` counts the filtered set. Without `subject` the response is bit-identical to today.

**`GET /api/flow-runs/completed?subject=<uuid>&limit=<n>`** is new. It returns the terminal runs (`completed`, `stopped`, `dead_letter`, `failed`) on one subject, newest first, capped at 50, with an honest total. `subject` is required: a request without one gets a 400 naming the parameter, not an org-wide history dump. `flowRun#index` is untouched, as `or-flow-active-runs` requires.

Both reads return the same row through the existing `summarise()`: `uuid`, `flowId`, `flowName` (id fallback), `status`, `trigger`, `startedBy`, `subject {uuid, register, schema}`, `step` (null without a marking), `resumeAt`, `created`, `updated`. Never `marking`, `items`, `log` or `context`.

One migration adds `or_flowrun_org_subject_idx` on `(organisation, subject_uuid, status, id)`. The design named the first three columns. `id` is added so the newest-first `LIMIT` comes off the index, for the reason `or_flowrun_org_status_idx` already records.

## Authorization

Tenancy is the authorization on both reads, as it is on `active()` today. The mapper's organisation predicate is unconditional. A caller with no resolvable organisation reads nothing, and no query is issued. The subject can only narrow. Gate-7 (no-admin-idor) recognises the `activeOrganisation()` scoping and passes.

## Consumer contract

nextcloud-vue#898 (`CnFlowRunsWidget` `content.subject`) is written against these two URLs. It parses `results`, `total`, and per row `uuid`, `flowName`, `status`, `step`, `created` and `subject`. Its history-error test mocks a 400. No mismatch was found, and nothing was changed on either side to make them agree.

## Verification

- PHPUnit: `FlowRunControllerTest` 24 to 32 tests, `FlowRunMapperSubjectScopeTest` 8 new, `FlowRunMapperFairnessTest` 11 unchanged. 51 tests, 176 assertions, green.
- Each stage of `check:strict` run individually in the foreground, exit code read per stage (the composite script hits composer's 300s process timeout, so its single verdict is not evidence):
  - `phpcs --standard=phpcs.xml --warning-severity=0`: exit 0, 74 files.
  - `phpmd` per `lib/` subdirectory (37 directories, both rulesets, with the baseline): exit 0 on every one.
  - `psalm --threads=4 --no-cache`: exit 0, no errors found.
  - `phpstan analyse --memory-limit=2G`: exit 0, no errors.
  - `phpunit` on `FlowRunControllerTest`, `FlowRunMapperFairnessTest`, `FlowRunMapperSubjectScopeTest`: exit 0.
- hydra-gates, diff-scoped against `origin/development`: 35 applicable gates, 35 passed. Gates 5, 6, 7, 16, 17, 47 and 48 all PASS.
- PHPMD: `FlowRunMapper` crossed `TooManyMethods` (25) and `ExcessiveClassLength` (1000) with the two public reads the design mandates. Suppressed on the class docblock with the reason, next to the existing `TooManyPublicMethods` suppression.

## Not in this PR

- Tasks 4.1 (the nc-vue widget, which is nextcloud-vue#898) and 5.3 (Playwright for the two `@e2e` scenarios). Both need a case detail page with the widget placed on it, and that page lives in a leaf app.
- `appinfo/routes.php` carries 199 pre-existing PHPCS line-length findings outside `check:strict`'s `lib` scope. Left alone on purpose: the sibling flow PRs edit the same block, and a reformat would conflict with every one of them.

## Where to start reviewing

Read `FlowRunMapper::whereTerminalForSubject()` and the predicate-order test in `FlowRunMapperSubjectScopeTest` first. That is where the tenant boundary lives. Then `FlowRunController::completedForSubject()` for the 400 path.