### PR TITLE
fix(controllers): name the register before the schema

### DIFF
--- a/lib/Controller/ActivityLinksController.php
+++ b/lib/Controller/ActivityLinksController.php
@@ -248,8 +248,8 @@ class ActivityLinksController extends Controller {
 	 *                               returns for other reasons, which the caller could no longer tell apart.
 	 */
 	private function validateObject(string $register, string $schema, string $id): ?ObjectEntity {
-		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
+		$this->objectService->setSchema($schema);
 		$this->objectService->setObject($id);
 
 		return $this->objectService->getObject();

--- a/lib/Controller/AnalyticsLinksController.php
+++ b/lib/Controller/AnalyticsLinksController.php
@@ -305,8 +305,8 @@ class AnalyticsLinksController extends Controller {
 	 *                               returns for other reasons, which the caller could no longer tell apart.
 	 */
 	private function validateObject(string $register, string $schema, string $id): ?ObjectEntity {
-		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
+		$this->objectService->setSchema($schema);
 		$this->objectService->setObject($id);
 
 		return $this->objectService->getObject();

--- a/lib/Controller/BookmarkLinksController.php
+++ b/lib/Controller/BookmarkLinksController.php
@@ -320,8 +320,8 @@ class BookmarkLinksController extends Controller {
 	 *                               returns for other reasons, which the caller could no longer tell apart.
 	 */
 	private function validateObject(string $register, string $schema, string $id): ?ObjectEntity {
-		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
+		$this->objectService->setSchema($schema);
 		$this->objectService->setObject($id);
 
 		return $this->objectService->getObject();

--- a/lib/Controller/CalendarEventsController.php
+++ b/lib/Controller/CalendarEventsController.php
@@ -411,8 +411,8 @@ class CalendarEventsController extends Controller {
 		string $schema,
 		string $id,
 	): ?\OCA\OpenRegister\Db\ObjectEntity {
-		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
+		$this->objectService->setSchema($schema);
 		$this->objectService->setObject($id);
 
 		return $this->objectService->getObject();

--- a/lib/Controller/CollectiveLinksController.php
+++ b/lib/Controller/CollectiveLinksController.php
@@ -327,8 +327,8 @@ class CollectiveLinksController extends Controller {
 	 *                               returns for other reasons, which the caller could no longer tell apart.
 	 */
 	private function validateObject(string $register, string $schema, string $id): ?ObjectEntity {
-		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
+		$this->objectService->setSchema($schema);
 		$this->objectService->setObject($id);
 
 		return $this->objectService->getObject();

--- a/lib/Controller/ContactsController.php
+++ b/lib/Controller/ContactsController.php
@@ -462,8 +462,8 @@ class ContactsController extends Controller {
 		string $schema,
 		string $id,
 	): ?\OCA\OpenRegister\Db\ObjectEntity {
-		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
+		$this->objectService->setSchema($schema);
 		$this->objectService->setObject($id);
 
 		return $this->objectService->getObject();

--- a/lib/Controller/CospendLinksController.php
+++ b/lib/Controller/CospendLinksController.php
@@ -329,8 +329,8 @@ class CospendLinksController extends Controller {
 	 *                               returns for other reasons, which the caller could no longer tell apart.
 	 */
 	private function validateObject(string $register, string $schema, string $id): ?ObjectEntity {
-		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
+		$this->objectService->setSchema($schema);
 		$this->objectService->setObject($id);
 
 		return $this->objectService->getObject();

--- a/lib/Controller/DeckController.php
+++ b/lib/Controller/DeckController.php
@@ -219,8 +219,8 @@ class DeckController extends Controller {
 		string $schema,
 		string $id,
 	): ?\OCA\OpenRegister\Db\ObjectEntity {
-		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
+		$this->objectService->setSchema($schema);
 		$this->objectService->setObject($id);
 
 		return $this->objectService->getObject();

--- a/lib/Controller/DeckLinksController.php
+++ b/lib/Controller/DeckLinksController.php
@@ -407,8 +407,8 @@ class DeckLinksController extends Controller {
 	 *                               returns for other reasons, which the caller could no longer tell apart.
 	 */
 	private function validateObject(string $register, string $schema, string $id): ?ObjectEntity {
-		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
+		$this->objectService->setSchema($schema);
 		$this->objectService->setObject($id);
 
 		return $this->objectService->getObject();

--- a/lib/Controller/EmailLinksController.php
+++ b/lib/Controller/EmailLinksController.php
@@ -322,8 +322,8 @@ class EmailLinksController extends Controller {
 	 *                               returns for other reasons, which the caller could no longer tell apart.
 	 */
 	private function validateObject(string $register, string $schema, string $id): ?ObjectEntity {
-		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
+		$this->objectService->setSchema($schema);
 		$this->objectService->setObject($id);
 
 		return $this->objectService->getObject();

--- a/lib/Controller/EmailsController.php
+++ b/lib/Controller/EmailsController.php
@@ -321,8 +321,8 @@ class EmailsController extends Controller {
 		string $schema,
 		string $id,
 	): ?\OCA\OpenRegister\Db\ObjectEntity {
-		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
+		$this->objectService->setSchema($schema);
 		$this->objectService->setObject($id);
 
 		return $this->objectService->getObject();

--- a/lib/Controller/FlowLinksController.php
+++ b/lib/Controller/FlowLinksController.php
@@ -261,8 +261,8 @@ class FlowLinksController extends Controller {
 	 *                               returns for other reasons, which the caller could no longer tell apart.
 	 */
 	private function validateObject(string $register, string $schema, string $id): ?ObjectEntity {
-		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
+		$this->objectService->setSchema($schema);
 		$this->objectService->setObject($id);
 
 		return $this->objectService->getObject();

--- a/lib/Controller/FormLinksController.php
+++ b/lib/Controller/FormLinksController.php
@@ -424,8 +424,8 @@ class FormLinksController extends Controller {
 		string $schema,
 		string $id,
 	): ?\OCA\OpenRegister\Db\ObjectEntity {
-		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
+		$this->objectService->setSchema($schema);
 		$this->objectService->setObject($id);
 
 		return $this->objectService->getObject();

--- a/lib/Controller/MapLinksController.php
+++ b/lib/Controller/MapLinksController.php
@@ -336,8 +336,8 @@ class MapLinksController extends Controller {
 	 *                               returns for other reasons, which the caller could no longer tell apart.
 	 */
 	private function validateObject(string $register, string $schema, string $id): ?ObjectEntity {
-		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
+		$this->objectService->setSchema($schema);
 		$this->objectService->setObject($id);
 
 		return $this->objectService->getObject();

--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -279,8 +279,15 @@ class NotesController extends Controller {
 		string $schema,
 		string $id,
 	): ?\OCA\OpenRegister\Db\ObjectEntity {
-		$this->objectService->setSchema($schema);
+		// REGISTER FIRST. `setSchema()` scopes its slug lookup to whatever
+		// register is currently set, and ObjectService is reused across many
+		// operations in one process — so setting the schema first resolves it
+		// against a register LEFT BEHIND by an unrelated call. Measured here:
+		// `/objects/dossiq/case/{id}/notes` threw `Schema slug "case" is not
+		// carried by register "buildiq"`, an app this request never mentioned.
+		// Naming the register first makes the boundary the caller's own.
 		$this->objectService->setRegister($register);
+		$this->objectService->setSchema($schema);
 		$this->objectService->setObject($id);
 
 		return $this->objectService->getObject();

--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -3911,8 +3911,8 @@ class ObjectsController extends Controller {
 	public function lock(string $register, string $schema, string $id): JSONResponse {
 		try {
 			// Set the schema and register to the object service.
-			$this->objectService->setSchema(schema: $schema);
 			$this->objectService->setRegister(register: $register);
+			$this->objectService->setSchema(schema: $schema);
 
 			$data = $this->request->getParams();
 			$process = ($data['process'] ?? null);

--- a/lib/Controller/OpenProjectLinksController.php
+++ b/lib/Controller/OpenProjectLinksController.php
@@ -312,8 +312,8 @@ class OpenProjectLinksController extends Controller {
 	 *                               returns for other reasons, which the caller could no longer tell apart.
 	 */
 	private function validateObject(string $register, string $schema, string $id): ?ObjectEntity {
-		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
+		$this->objectService->setSchema($schema);
 		$this->objectService->setObject($id);
 
 		return $this->objectService->getObject();

--- a/lib/Controller/PhotoLinksController.php
+++ b/lib/Controller/PhotoLinksController.php
@@ -293,8 +293,8 @@ class PhotoLinksController extends Controller {
 	 *                               returns for other reasons, which the caller could no longer tell apart.
 	 */
 	private function validateObject(string $register, string $schema, string $id): ?ObjectEntity {
-		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
+		$this->objectService->setSchema($schema);
 		$this->objectService->setObject($id);
 
 		return $this->objectService->getObject();

--- a/lib/Controller/PollLinksController.php
+++ b/lib/Controller/PollLinksController.php
@@ -319,8 +319,8 @@ class PollLinksController extends Controller {
 	 *                               returns for other reasons, which the caller could no longer tell apart.
 	 */
 	private function validateObject(string $register, string $schema, string $id): ?ObjectEntity {
-		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
+		$this->objectService->setSchema($schema);
 		$this->objectService->setObject($id);
 
 		return $this->objectService->getObject();

--- a/lib/Controller/RelationsController.php
+++ b/lib/Controller/RelationsController.php
@@ -531,8 +531,8 @@ class RelationsController extends Controller {
 		string $schema,
 		string $id,
 	): ?\OCA\OpenRegister\Db\ObjectEntity {
-		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
+		$this->objectService->setSchema($schema);
 		$this->objectService->setObject($id);
 
 		return $this->objectService->getObject();

--- a/lib/Controller/ShareLinksController.php
+++ b/lib/Controller/ShareLinksController.php
@@ -254,8 +254,8 @@ class ShareLinksController extends Controller {
 	 *                               returns for other reasons, which the caller could no longer tell apart.
 	 */
 	private function validateObject(string $register, string $schema, string $id): ?ObjectEntity {
-		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
+		$this->objectService->setSchema($schema);
 		$this->objectService->setObject($id);
 
 		return $this->objectService->getObject();

--- a/lib/Controller/TagsController.php
+++ b/lib/Controller/TagsController.php
@@ -155,8 +155,8 @@ class TagsController extends Controller {
 		string $id,
 	): JSONResponse {
 		try {
-			$this->objectService->setSchema($schema);
 			$this->objectService->setRegister($register);
+			$this->objectService->setSchema($schema);
 			$this->objectService->setObject($id);
 			$object = $this->objectService->getObject();
 
@@ -194,8 +194,8 @@ class TagsController extends Controller {
 		string $id,
 	): JSONResponse {
 		try {
-			$this->objectService->setSchema($schema);
 			$this->objectService->setRegister($register);
+			$this->objectService->setSchema($schema);
 			$this->objectService->setObject($id);
 			$object = $this->objectService->getObject();
 
@@ -245,8 +245,8 @@ class TagsController extends Controller {
 		string $tag,
 	): JSONResponse {
 		try {
-			$this->objectService->setSchema($schema);
 			$this->objectService->setRegister($register);
+			$this->objectService->setSchema($schema);
 			$this->objectService->setObject($id);
 			$object = $this->objectService->getObject();
 

--- a/lib/Controller/TalkLinksController.php
+++ b/lib/Controller/TalkLinksController.php
@@ -298,8 +298,8 @@ class TalkLinksController extends Controller {
 	 *                               returns for other reasons, which the caller could no longer tell apart.
 	 */
 	private function validateObject(string $register, string $schema, string $id): ?ObjectEntity {
-		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
+		$this->objectService->setSchema($schema);
 		$this->objectService->setObject($id);
 
 		return $this->objectService->getObject();

--- a/lib/Controller/TasksController.php
+++ b/lib/Controller/TasksController.php
@@ -363,8 +363,8 @@ class TasksController extends Controller {
 		string $schema,
 		string $id,
 	): ?\OCA\OpenRegister\Db\ObjectEntity {
-		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
+		$this->objectService->setSchema($schema);
 		$this->objectService->setObject($id);
 
 		return $this->objectService->getObject();

--- a/lib/Controller/TimeTrackerLinksController.php
+++ b/lib/Controller/TimeTrackerLinksController.php
@@ -314,8 +314,8 @@ class TimeTrackerLinksController extends Controller {
 	 *                               returns for other reasons, which the caller could no longer tell apart.
 	 */
 	private function validateObject(string $register, string $schema, string $id): ?ObjectEntity {
-		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
+		$this->objectService->setSchema($schema);
 		$this->objectService->setObject($id);
 
 		return $this->objectService->getObject();

--- a/lib/Controller/XwikiLinksController.php
+++ b/lib/Controller/XwikiLinksController.php
@@ -355,8 +355,8 @@ class XwikiLinksController extends Controller {
 	 *                               returns for other reasons, which the caller could no longer tell apart.
 	 */
 	private function validateObject(string $register, string $schema, string $id): ?ObjectEntity {
-		$this->objectService->setSchema($schema);
 		$this->objectService->setRegister($register);
+		$this->objectService->setSchema($schema);
 		$this->objectService->setObject($id);
 
 		return $this->objectService->getObject();

--- a/tests/Unit/Controller/RegisterBeforeSchemaOrderTest.php
+++ b/tests/Unit/Controller/RegisterBeforeSchemaOrderTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * A controller must name the register BEFORE the schema.
+ *
+ * `ObjectService::setSchema()` resolves a slug scoped to whatever register is
+ * currently set, and the service is reused across many operations in one
+ * process. So `setSchema($s)` followed by `setRegister($r)` resolves the slug
+ * against a register LEFT BEHIND by an unrelated call, while reading exactly
+ * like the correct order.
+ *
+ * Measured on the development instance 2026-09-01:
+ * `GET /objects/dossiq/case/{id}/notes` answered 404 "Object not found". The
+ * object resolved fine at `/objects/dossiq/case/{id}`, and the identical
+ * resolution chain succeeded from `occ`. Under HTTP it threw
+ * `Schema slug "case" is not carried by register "buildiq"` — an app the
+ * request never mentioned, whose own `case` schema the global slug lookup had
+ * reached first.
+ *
+ * Every object sub-resource was affected, in every app on the instance: notes,
+ * tags, relations, emails, polls, talk, bookmarks, deck, calendar, tasks,
+ * time-tracker and the rest. All of them rendered their EMPTY state, so a case
+ * with notes said "No notes yet" rather than that it could not ask. 25
+ * controllers carried the inverted order; `FilesController` did not, and its
+ * docblock already described this bug.
+ *
+ * `ObjectService::setRegister()` re-resolves a pending schema ref for exactly
+ * this reason, and its own comment names this helper as the shape that inverted
+ * the two. That repair cannot help here: the throw happens inside `setSchema()`
+ * itself, before `setRegister()` is ever reached.
+ *
+ * This test is static on purpose. The runtime symptom needs a second register
+ * that happens to share a slug AND a prior operation that left its register
+ * set, which is a state no unit test would naturally reproduce and exactly the
+ * state a live instance reaches constantly.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Controller
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Controller;
+
+use PHPUnit\Framework\TestCase;
+
+class RegisterBeforeSchemaOrderTest extends TestCase {
+
+	/**
+	 * Every controller source file.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public static function controllerFiles(): array {
+		$dir   = __DIR__ . '/../../../lib/Controller';
+		$cases = [];
+		foreach (glob($dir . '/*.php') as $file) {
+			$cases[basename($file)] = [$file];
+		}
+
+		return $cases;
+	}//end controllerFiles()
+
+	/**
+	 * `setSchema()` must never immediately precede `setRegister()`.
+	 *
+	 * @param string $file The controller file to scan.
+	 *
+	 * @return void
+	 *
+	 * @dataProvider controllerFiles
+	 */
+	public function testRegisterIsNamedBeforeSchema(string $file): void {
+		$source = file_get_contents($file);
+		$this->assertIsString($source, 'controller source is readable');
+
+		$inverted = preg_match_all(
+			'/setSchema\(\s*[^)]*\s*\)\s*;\s*\n\s*\$this->objectService->setRegister\(/',
+			$source
+		);
+
+		$this->assertSame(
+			0,
+			$inverted,
+			basename($file) . ' calls setSchema() before setRegister(). '
+			. 'setSchema() scopes its slug lookup to the register currently set on the '
+			. 'shared ObjectService, so this resolves the slug against whatever register '
+			. 'an unrelated earlier operation left behind. Name the register first.'
+		);
+	}//end testRegisterIsNamedBeforeSchema()
+}//end class


### PR DESCRIPTION
Every object sub-resource endpoint answers **404 "Object not found"**, in every app on the instance: notes, tags, relations, emails, polls, talk, bookmarks, deck, calendar, tasks, time-tracker and the rest.

```
GET /objects/dossiq/case/{id}           200 ✓
GET /objects/dossiq/case/{id}/notes     404 ✗
GET /objects/dossiq/case/{id}/tags      404 ✗
GET /objects/pipelinq/client/{id}/notes 404 ✗
```

The same resolution chain succeeds from `occ`, which is what made this hard to see. Under HTTP it throws:

> `Schema slug "case" is not carried by register "buildiq" (id 33)`

on a request that named **dossiq**.

## Why

`ObjectService::setSchema()` scopes its slug lookup to whatever register is **currently set**, and the service is reused across many operations in one process. So `setSchema()` before `setRegister()` resolves the slug against a register **left behind by an unrelated earlier call**. Buildiq owns a `case` schema too, and the global lookup reached it first.

`setRegister()` already re-resolves a pending schema ref for exactly this reason, and its own comment names this helper as the shape that inverted the two:

> That inversion is not rare: it is the shape of the copy-pasted `validateObject()` helper in ~24 link controllers […]

That repair cannot help here. The throw happens **inside `setSchema()`**, before `setRegister()` is ever reached.

## What this cost

Every one of those surfaces renders an **empty state, not an error**. A case with notes said "No notes yet". The page never reported that it could not ask, so the failure was indistinguishable from the data genuinely being absent — which is why it survived.

## The change

25 controllers carried the inverted order; 27 call sites swapped. `FilesController` did **not**, and its docblock already described this bug, so the rule was known and simply never applied to the others.

## The regression guard

A static scan over all 131 controllers rather than a behavioural test. Reproducing the runtime symptom needs a second register that happens to share a slug **and** a prior operation that left its register set — a state no unit test reaches naturally and one a live instance reaches constantly.

I verified the test fails when the order is put back, rather than trusting a green run.

## Verification

- `notes`, `tags`, `relations`, `emails`, `files`, `audit-trails` all return **200** where they returned 404.
- Confirmed on **pipelinq**, an app untouched by this change.
- **3227** controller tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)