### PR TITLE
feat(router): move openregister off hash routing, and stop the catch-all eating the API

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -1371,5 +1371,24 @@ return [
 		['name' => 'federatedConfig#publicKey', 'url' => '/api/federated-config/public-key', 'verb' => 'GET'],
 		['name' => 'federatedConfig#trust', 'url' => '/api/federated-config/trust', 'verb' => 'GET'],
 		['name' => 'federatedConfig#setTrust', 'url' => '/api/federated-config/trust', 'verb' => 'PUT'],
+
+		// SPA catch-all — MUST stay last so every explicit route above keeps
+		// priority over the /{path} fallback. Without it only `/` served the
+		// shell, so any deep link (/registers, /schemas, a detail route) never
+		// reached the SPA at all — the #133 regression that forced this app back
+		// onto hash routing. Spelled inline rather than via
+		// \OCA\OpenRegister\AppHost\Routes::standard() because this file also
+		// declares a `resources` block the builder does not carry, and because
+		// this IS openregister — guarding a call to its own class would be odd.
+		// ⚠️ `(?!api/)` is load-bearing. Nextcloud's RouteParser processes the
+		// `routes` array BEFORE the `resources` array
+		// (RouteParser::parseDefaultRoutes), and Symfony matches in insertion
+		// order — so even as the LAST entry here this route still registers
+		// ahead of all nine `api/...` resource routes below. Without the
+		// lookahead `.+` (which matches slashes) would swallow
+		// GET /api/registers, /api/schemas and the rest, answering the SPA
+		// shell instead of JSON. The SPA never needs an `api/` path.
+		['name' => 'dashboard#catchAll', 'url' => '/{path}', 'verb' => 'GET',
+			'requirements' => ['path' => '(?!api/).+'], 'defaults' => ['path' => '']],
     ],
 ];

--- a/lib/AppHost/Routes.php
+++ b/lib/AppHost/Routes.php
@@ -165,7 +165,18 @@ class Routes {
 			'name' => 'dashboard#catchAll',
 			'url' => '/{path}',
 			'verb' => 'GET',
-			'requirements' => ['path' => '.+'],
+			// ⚠️ `(?!api/)` is load-bearing for any adopter whose routes.php
+			// also declares a `resources` block. Nextcloud's RouteParser
+			// processes the `routes` array BEFORE the `resources` array
+			// (RouteParser::parseDefaultRoutes) and Symfony matches in
+			// insertion order, so this route registers ahead of every
+			// resource-generated route no matter that it is appended LAST
+			// here. `.+` matches slashes, so without the lookahead it
+			// swallows GET api/<resource> and answers the SPA shell with
+			// HTTP 200 — a JSON caller receives HTML and nothing errors
+			// loudly. zaakafhandelapp lost all seventeen of its ZGW resource
+			// routes that way. The SPA never needs an `api/` path.
+			'requirements' => ['path' => '(?!api/).+'],
 			'defaults' => ['path' => ''],
 		];
 	}//end catchAllRoute()

--- a/lib/Calendar/CalendarEventTransformer.php
+++ b/lib/Calendar/CalendarEventTransformer.php
@@ -139,7 +139,7 @@ class CalendarEventTransformer {
 
 		// URL to OpenRegister object.
 		$register = $object->getRegister();
-		$url = '/apps/openregister/#/objects/' . $register . '/' . $schemaId . '/' . $objectUuid;
+		$url = '/apps/openregister/objects/' . $register . '/' . $schemaId . '/' . $objectUuid;
 		$veventProperties['URL'] = [$url, []];
 
 		return [

--- a/lib/Controller/DashboardController.php
+++ b/lib/Controller/DashboardController.php
@@ -174,6 +174,32 @@ class DashboardController extends Controller {
 	}//end page()
 
 	/**
+	 * Serve the SPA for deep links (Vue history mode). Delegates to {@see page()}.
+	 *
+	 * THIS IS THE FIX FOR #133. This app registered exactly one frontend route —
+	 * `dashboard#page` at `/` — and nothing that served the SPA shell for a deep
+	 * sub-path like /registers or /schemas. A bookmark or full-page load to one
+	 * of those therefore never reached the SPA, the router resolved the base
+	 * path instead, and the grouped index pages rendered empty (no Add button,
+	 * no list). The app was moved back to hash routing to work around it; with
+	 * this route the workaround is no longer needed.
+	 *
+	 * ⚠️ Probing an enumerated path does NOT prove a catch-all exists — probe a
+	 * nonsense one. /apps/openregister/zzz-nonsense returned 404 before this and
+	 * 401 after.
+	 *
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 *
+	 * @return TemplateResponse
+	 *
+	 * @spec exclude Vue history-mode fallback — delegates to page(); pure framework plumbing, no domain logic.
+	 */
+	public function catchAll(): TemplateResponse {
+		return $this->page();
+	}//end catchAll()
+
+	/**
 	 * Retrieves dashboard data including registers with their schemas
 	 *
 	 * Returns JSON response containing dashboard data with registers and schemas.

--- a/src/main.js
+++ b/src/main.js
@@ -6,9 +6,10 @@ import {
 	registerIcons,
 } from '@conduction/nextcloud-vue'
 import { translatePlural as n, translate as t } from '@nextcloud/l10n'
+import { generateUrl } from '@nextcloud/router'
 import { createApp, h } from 'vue'
 // eslint-disable-next-line n/no-unpublished-import
-import { createRouter, createWebHashHistory } from 'vue-router'
+import { createRouter, createWebHistory } from 'vue-router'
 import App from './App.vue'
 import appIcons from './icons.js'
 import { ensureIntegrationRegistry } from './integrations/bootstrap.js'
@@ -173,18 +174,38 @@ function routesFromManifest(manifest) {
 	return routes
 }
 
-// Hash mode (not history): the PHP backend registers exactly one frontend
-// route — `dashboard#page` at `/` (appinfo/routes.php) — and no catch-all that
-// serves the SPA shell for deep sub-paths like `/registers` or `/schemas`. In
-// history mode a full-page load or bookmark to `#/registers` drops the fragment
-// and resolves the base path `/` → the Dashboard surface, so the relocated /
-// grouped index pages render empty (no Add button, no list) on deep-link — the
-// #133 regression. Hash mode keeps every route under the single `/` server
-// route, so `#/registers` etc. resolve client-side to their correct index
-// surface. This also matches the e2e harness contract (tests deep-link via
-// `/index.php/apps/openregister/#/<route>`).
+/**
+ * The router base for THIS page load.
+ *
+ * ⚠️ `generateUrl('/apps/openregister')` alone is not enough. Nextcloud serves
+ * the app under BOTH `/apps/openregister/...` and
+ * `/index.php/apps/openregister/...`, but `generateUrl()` returns only the form
+ * the instance is configured for. A visitor arriving on the other form falls
+ * outside the router base, vue-router cannot resolve the path, and the
+ * catch-all above redirects to `/`: they land on the Dashboard with no error
+ * and the deep link is silently swallowed. This app's e2e harness deep-links
+ * via the `/index.php` form, so pinning the other one would break every one of
+ * those.
+ *
+ * @return {string} The base path vue-router should strip from the URL.
+ */
+function routerBase() {
+	const match = window.location.pathname.match(/^(.*\/apps\/openregister)(?:\/|$)/)
+	return match ? match[1] : generateUrl('/apps/openregister')
+}
+
+// History mode. This app ran on HASH mode as a workaround for #133: the PHP
+// backend registered exactly one frontend route — `dashboard#page` at `/` — and
+// no catch-all serving the SPA shell for deep sub-paths like `/registers` or
+// `/schemas`, so a bookmark or full-page load never reached the SPA and the
+// grouped index pages rendered empty (no Add button, no list).
+//
+// `dashboard#catchAll` in appinfo/routes.php now serves the shell on any
+// sub-path, which removes the cause rather than working around it. Verified by
+// requesting a NONSENSE path: /apps/openregister/zzz-nonsense answered 404
+// before and 401 after — an enumerated path would have proved nothing.
 const router = createRouter({
-	history: createWebHashHistory(),
+	history: createWebHistory(routerBase()),
 	routes: routesFromManifest(mergedManifest),
 })
 

--- a/src/views/quality/RegisterSchemaSelector.vue
+++ b/src/views/quality/RegisterSchemaSelector.vue
@@ -34,9 +34,9 @@ import { qualityStore } from '../../store/store.js'
  * committed to the `quality` Pinia store so switching between MDM views
  * preserves the selection (design.md D3).
  *
- * The selection is also mirrored into the hash-mode route query
+ * The selection is also mirrored into the route query
  * (`?register=&schema=`): a deep-link such as
- * `#/quality?register=16&schema=1207` pre-selects and loads with no clicks,
+ * `/quality?register=16&schema=1207` pre-selects and loads with no clicks,
  * and every in-UI selection change reflects back into the URL so the view is
  * bookmarkable and shareable (mdm-views-route-scoping). The store remains the
  * source of truth; the route is a mirror + entry point.

--- a/tests/Unit/AppHost/RoutesTest.php
+++ b/tests/Unit/AppHost/RoutesTest.php
@@ -72,8 +72,34 @@ class RoutesTest extends TestCase {
 
 		$this->assertSame('dashboard#catchAll', $last['name']);
 		$this->assertSame('/{path}', $last['url']);
-		$this->assertSame('.+', $last['requirements']['path']);
+		$this->assertSame('(?!api/).+', $last['requirements']['path']);
 	}//end testCatchAllIsLastAndHasPathRequirement()
+
+	/**
+	 * Being LAST in the `routes` array is not enough to keep the catch-all off
+	 * the API, which is the trap this guards. Nextcloud's RouteParser processes
+	 * `routes` BEFORE `resources` (RouteParser::parseDefaultRoutes) and Symfony
+	 * matches in insertion order, so the catch-all still registers ahead of
+	 * every route generated from a `resources` block. `.+` matches slashes, so
+	 * without the lookahead it answers the SPA shell for GET api/<resource> —
+	 * with HTTP 200, so a JSON caller silently receives HTML.
+	 *
+	 * Asserts the requirement as a REGEX against real paths rather than as a
+	 * string, so it keeps holding if the spelling is ever rewritten.
+	 */
+	public function testCatchAllRequirementExcludesApiPaths(): void {
+		$routes = Routes::standard()['routes'];
+		$last = end($routes);
+		$pattern = '#^' . $last['requirements']['path'] . '$#';
+
+		foreach (['api/taken', 'api/klanten', 'api/zrc/zaken', 'api/registers/1'] as $apiPath) {
+			$this->assertSame(0, preg_match($pattern, $apiPath), "catch-all must NOT match $apiPath");
+		}
+
+		foreach (['registers', 'schemas/12', 'features-roadmap', 'zaken/abc-123'] as $spaPath) {
+			$this->assertSame(1, preg_match($pattern, $spaPath), "catch-all MUST match $spaPath");
+		}
+	}//end testCatchAllRequirementExcludesApiPaths()
 
 	public function testIndexRouteIsGetSlash(): void {
 		$routes = Routes::standard()['routes'];

--- a/tests/Unit/Calendar/CalendarEventTransformerTest.php
+++ b/tests/Unit/Calendar/CalendarEventTransformerTest.php
@@ -228,7 +228,7 @@ class CalendarEventTransformerTest extends TestCase {
 
 		$result = $this->transformer->transform($object, $this->schema, $config);
 
-		$this->assertSame('/apps/openregister/#/objects/5/12/abc-123', $result['objects'][0]['URL'][0]);
+		$this->assertSame('/apps/openregister/objects/5/12/abc-123', $result['objects'][0]['URL'][0]);
 	}
 
 	public function testCategoriesIncludeOpenRegisterAndSchemaName(): void {

--- a/tests/Unit/Controller/DashboardControllerTest.php
+++ b/tests/Unit/Controller/DashboardControllerTest.php
@@ -85,6 +85,23 @@ class DashboardControllerTest extends TestCase {
 		$this->assertInstanceOf(TemplateResponse::class, $result);
 	}
 
+	/**
+	 * The SPA catch-all serves the same shell as page().
+	 *
+	 * `dashboard#catchAll` at GET /{path} is what lets a deep link such as
+	 * /registers reach the SPA at all; before it, only `/` was routed and every
+	 * sub-path 404'd at the server, which is why this app ran on hash routing.
+	 * Asserting equality with page() rather than merely "returns a response"
+	 * pins the delegation, so a rewrite that stops delegating has to say so.
+	 */
+	public function testCatchAllServesTheSameShellAsPage(): void {
+		$result = $this->controller->catchAll();
+
+		$this->assertInstanceOf(TemplateResponse::class, $result);
+		$this->assertEquals($this->controller->page()->getTemplateName(), $result->getTemplateName());
+		$this->assertEquals($this->controller->page()->getRenderAs(), $result->getRenderAs());
+	}
+
 	public function testIndexSuccess(): void {
 		$this->request->method('getParams')->willReturn([]);
 		$this->dashboardService->method('getRegistersWithSchemas')->willReturn([]);

--- a/tests/e2e/_page-routes.ts
+++ b/tests/e2e/_page-routes.ts
@@ -39,7 +39,7 @@
  * ⚠️ THE ROUTER RUNS IN HASH MODE (`src/main.js`). These are hash routes: a
  * path-form deep link is rewritten by the hash router and renders the
  * DASHBOARD instead of the target page. Callers must compose them as
- * `…/apps/openregister/#${route}` — which every `gotoPage`/`gotoApp`/`go`
+ * `…/apps/openregister${route}` — which every `gotoPage`/`gotoApp`/`go`
  * helper in this suite already does.
  */
 

--- a/tests/e2e/ci/flow-controls.spec.ts
+++ b/tests/e2e/ci/flow-controls.spec.ts
@@ -110,7 +110,7 @@ import * as path from 'path'
 
 const STORAGE_STATE = path.resolve(__dirname, '../.auth/admin.json')
 
-const FLOWS_ROUTE = '/index.php/apps/openregister/#/flows'
+const FLOWS_ROUTE = '/index.php/apps/openregister/flows'
 
 test.use(fs.existsSync(STORAGE_STATE) ? { storageState: STORAGE_STATE } : {})
 

--- a/tests/e2e/ci/object-shares-tab.spec.ts
+++ b/tests/e2e/ci/object-shares-tab.spec.ts
@@ -115,7 +115,7 @@ async function openSharesTab(
 	uuid: string,
 ) {
 	await page.goto(
-		`/index.php/apps/openregister/#/objects/${register}/${schema}/${uuid}`,
+		`/index.php/apps/openregister/objects/${register}/${schema}/${uuid}`,
 		{ waitUntil: 'domcontentloaded' },
 	)
 

--- a/tests/e2e/ci/smoke-boot.spec.ts
+++ b/tests/e2e/ci/smoke-boot.spec.ts
@@ -44,7 +44,7 @@ const STORAGE_STATE = path.resolve(__dirname, '../.auth/admin.json')
 // shows up as a MIME refusal here and nowhere else.
 const ROUTES = [
 	{ name: 'app root', url: '/index.php/apps/openregister/' },
-	{ name: 'registers', url: '/index.php/apps/openregister/#/registers' },
+	{ name: 'registers', url: '/index.php/apps/openregister/registers' },
 ]
 
 /** Console messages that mean the bundle never booted. */

--- a/tests/e2e/core-crud.spec.ts
+++ b/tests/e2e/core-crud.spec.ts
@@ -111,7 +111,7 @@ test.describe('frontend-app-bootstrap — app mount and data load', () => {
 	test('navigating to /registers renders the register list view', async ({
 		page,
 	}) => {
-		await page.goto('/index.php/apps/openregister/#/registers', {
+		await page.goto('/index.php/apps/openregister/registers', {
 			waitUntil: 'domcontentloaded',
 		})
 		// Don't wait for networkidle — NC SPA keeps background XHR alive indefinitely.
@@ -141,7 +141,7 @@ test.describe('deep-link-registry — hash routes render correct views', () => {
 	test.use({ storageState: STORAGE_STATE })
 
 	test('#/registers route renders register list', async ({ page }) => {
-		await page.goto('/index.php/apps/openregister/#/registers', {
+		await page.goto('/index.php/apps/openregister/registers', {
 			waitUntil: 'domcontentloaded',
 		})
 		// Should NOT redirect to a different page or show a 404.
@@ -152,7 +152,7 @@ test.describe('deep-link-registry — hash routes render correct views', () => {
 	})
 
 	test('#/schemas route renders schema list', async ({ page }) => {
-		await page.goto('/index.php/apps/openregister/#/schemas', {
+		await page.goto('/index.php/apps/openregister/schemas', {
 			waitUntil: 'domcontentloaded',
 		})
 		expect(page.url()).toContain('/openregister/')
@@ -162,7 +162,7 @@ test.describe('deep-link-registry — hash routes render correct views', () => {
 	})
 
 	test('#/objects route renders object list', async ({ page }) => {
-		await page.goto('/index.php/apps/openregister/#/objects', {
+		await page.goto('/index.php/apps/openregister/objects', {
 			waitUntil: 'domcontentloaded',
 		})
 		expect(page.url()).toContain('/openregister/')
@@ -179,7 +179,7 @@ test.describe('deep-link-registry — hash routes render correct views', () => {
 		test.skip(objectId === null, 'no live object found for deep-link test')
 
 		await page.goto(
-			`/index.php/apps/openregister/#/objects/${REGISTER_ID}/${SCHEMA_ID}/${objectId}`,
+			`/index.php/apps/openregister/objects/${REGISTER_ID}/${SCHEMA_ID}/${objectId}`,
 			{ waitUntil: 'domcontentloaded' },
 		)
 		expect(page.url()).toContain('/openregister/')

--- a/tests/e2e/crud/object-crud.spec.ts
+++ b/tests/e2e/crud/object-crud.spec.ts
@@ -126,7 +126,7 @@ test.describe('object-crud — create→read→update→delete with field-value 
 		test.skip(objectId === null, 'no object created')
 
 		// Deep-link to the object detail (path routing in the manifest-v2 shell).
-		await page.goto(`${APP}/#/objects/${register.id}/${schema.id}/${objectId}`, {
+		await page.goto(`${APP}/objects/${register.id}/${schema.id}/${objectId}`, {
 			waitUntil: 'domcontentloaded',
 		})
 		await expect(
@@ -172,7 +172,7 @@ test.describe('object-crud — create→read→update→delete with field-value 
 		expect(Number(fresh.count)).toBe(COUNT_UPDATED)
 
 		// The detail surface still resolves the (now-updated) object by uuid.
-		await page.goto(`${APP}/#/objects/${register.id}/${schema.id}/${objectId}`, {
+		await page.goto(`${APP}/objects/${register.id}/${schema.id}/${objectId}`, {
 			waitUntil: 'domcontentloaded',
 		})
 		await expect(

--- a/tests/e2e/crud/register-crud.spec.ts
+++ b/tests/e2e/crud/register-crud.spec.ts
@@ -35,7 +35,7 @@ import { makeRunId } from '../_fixtures.ts'
 const STORAGE_STATE = path.resolve(__dirname, '..', '.auth', 'admin.json')
 // HASH form — the router runs in hash mode (src/main.js); the path-form URL
 // renders the dashboard instead of the registers page.
-const REGISTERS_ROUTE = '/index.php/apps/openregister/#/registers'
+const REGISTERS_ROUTE = '/index.php/apps/openregister/registers'
 const API = '/index.php/apps/openregister/api'
 
 const RUN_ID = makeRunId()

--- a/tests/e2e/crud/schema-crud.spec.ts
+++ b/tests/e2e/crud/schema-crud.spec.ts
@@ -29,7 +29,7 @@ import { makeRunId, twoPropertySchema } from '../_fixtures.ts'
 const STORAGE_STATE = path.resolve(__dirname, '..', '.auth', 'admin.json')
 // HASH form — the router runs in hash mode (src/main.js); the path-form URL
 // renders the dashboard instead of the schemas page.
-const SCHEMAS_ROUTE = '/index.php/apps/openregister/#/schemas'
+const SCHEMAS_ROUTE = '/index.php/apps/openregister/schemas'
 const API = '/index.php/apps/openregister/api'
 
 const RUN_ID = makeRunId()

--- a/tests/e2e/docs-screenshots.spec.ts
+++ b/tests/e2e/docs-screenshots.spec.ts
@@ -117,7 +117,7 @@ async function go(page: Page, route: string): Promise<void> {
 	const url =
 		route.startsWith('/apps/') || route.startsWith('/settings/')
 			? `/index.php${route}`
-			: `/index.php${APP}/#${route}`
+			: `/index.php${APP}${route}`
 	// `networkidle` NEVER settles on Nextcloud (ADR-074 rule 4): the
 	// notification long-poll keeps a request in flight for the life of the
 	// page, so this wait always ran to its timeout and the `.catch()` hid

--- a/tests/e2e/flow-engine.spec.ts
+++ b/tests/e2e/flow-engine.spec.ts
@@ -656,7 +656,7 @@ test.describe('the Flows page', () => {
 
 		// `networkidle` never settles on Nextcloud (ADR-074 rule 4) — the
 		// readiness signal is the row/name assertion that follows each goto.
-		await page.goto(`/apps/openregister/#${FlowsIndex}`, {
+		await page.goto(`/apps/openregister${FlowsIndex}`, {
 			waitUntil: 'domcontentloaded',
 		})
 
@@ -664,7 +664,7 @@ test.describe('the Flows page', () => {
 			timeout: 15000,
 		})
 
-		await page.goto(`/apps/openregister/#${FlowDetailPage(flow.id)}`, {
+		await page.goto(`/apps/openregister${FlowDetailPage(flow.id)}`, {
 			waitUntil: 'domcontentloaded',
 		})
 
@@ -692,7 +692,7 @@ test.describe('the Flows page', () => {
 			nodes: [{ id: 'end1', type: 'openregister.end', config: {} }],
 		})
 
-		await page.goto(`/apps/openregister/#${FlowDetailPage(flow.id)}`, {
+		await page.goto(`/apps/openregister${FlowDetailPage(flow.id)}`, {
 			waitUntil: 'domcontentloaded',
 		})
 
@@ -742,7 +742,7 @@ test.describe('the Flows page', () => {
 			{ publish: false },
 		)
 
-		await page.goto(`/apps/openregister/#${FlowDetailPage(flow.id)}`, {
+		await page.goto(`/apps/openregister${FlowDetailPage(flow.id)}`, {
 			waitUntil: 'domcontentloaded',
 		})
 
@@ -772,7 +772,7 @@ test.describe('the Flows page', () => {
 	test('the list is an ordinary index page with a New flow action (ADR-096)', async ({
 		page,
 	}) => {
-		await page.goto(`/apps/openregister/#${FlowsIndex}`, {
+		await page.goto(`/apps/openregister${FlowsIndex}`, {
 			waitUntil: 'domcontentloaded',
 		})
 
@@ -789,7 +789,7 @@ test.describe('the Flows page', () => {
 	test('a new flow is the SAME editor holding only a starting point', async ({
 		page,
 	}) => {
-		await page.goto(`/apps/openregister/#${FlowDetailPage('new')}`, {
+		await page.goto(`/apps/openregister${FlowDetailPage('new')}`, {
 			waitUntil: 'domcontentloaded',
 		})
 
@@ -823,7 +823,7 @@ test.describe('the Flows page', () => {
 		page,
 		request,
 	}) => {
-		await page.goto(`/apps/openregister/#${FlowDetailPage('new')}`, {
+		await page.goto(`/apps/openregister${FlowDetailPage('new')}`, {
 			waitUntil: 'domcontentloaded',
 		})
 
@@ -868,7 +868,7 @@ test.describe('the Flows page', () => {
 
 		// `networkidle` never settles on Nextcloud (ADR-074 rule 4); the row
 		// assertion below is the real wait.
-		await page.goto(`/apps/openregister/#${FlowsIndex}`, {
+		await page.goto(`/apps/openregister${FlowsIndex}`, {
 			waitUntil: 'domcontentloaded',
 		})
 

--- a/tests/e2e/integration-mount.spec.ts
+++ b/tests/e2e/integration-mount.spec.ts
@@ -162,7 +162,7 @@ async function openObjectDetail(
 	// URL dispatches `objectDetail` (route name in the manifest) to
 	// ObjectsIndex and its param-watch primes the object store.
 	await page.goto(
-		`${baseURL}/index.php/apps/openregister/#/objects/${triple.register}/${triple.schema}/${triple.objectId}`,
+		`${baseURL}/index.php/apps/openregister/objects/${triple.register}/${triple.schema}/${triple.objectId}`,
 		// `networkidle` never settles on Nextcloud (ADR-074 rule 4): the
 		// long-poll / notification channels keep a request in flight for the
 		// life of the page, so it always burns its timeout. The readiness

--- a/tests/e2e/leaf-screenshots.spec.ts
+++ b/tests/e2e/leaf-screenshots.spec.ts
@@ -49,7 +49,7 @@ test.describe('Per-leaf screenshot harness', () => {
 		await page.goto(
 			// HASH form — the router runs in hash mode (src/main.js); the
 			// path-form URL renders the dashboard instead of the integrations view.
-			`${baseURL}/index.php/apps/openregister/#${IntegrationsView(
+			`${baseURL}/index.php/apps/openregister${IntegrationsView(
 				REGISTER,
 				SCHEMA,
 				OBJECT_ID,

--- a/tests/e2e/manifest-shell.spec.ts
+++ b/tests/e2e/manifest-shell.spec.ts
@@ -34,7 +34,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 
 const STORAGE_STATE = path.resolve(__dirname, '.auth/admin.json')
-const APP_BASE = '/index.php/apps/openregister/#'
+const APP_BASE = '/index.php/apps/openregister'
 
 function requireAuth() {
 	if (!fs.existsSync(STORAGE_STATE)) {
@@ -42,8 +42,8 @@ function requireAuth() {
 	}
 }
 
-async function gotoRoute(page: Page, hash: string) {
-	await page.goto(`${APP_BASE}${hash}`, { waitUntil: 'domcontentloaded' })
+async function gotoRoute(page: Page, route: string) {
+	await page.goto(`${APP_BASE}${route}`, { waitUntil: 'domcontentloaded' })
 	// App content shell must render for every manifest-driven route.
 	await expect(page.locator('main, .app-content').first()).toBeVisible({
 		timeout: 25_000,
@@ -84,7 +84,7 @@ test.describe('openregister-app-manifest — CnAppRoot shell mounts', () => {
 		// A non-root manifest route must resolve via the manifest-built router
 		// rather than redirecting away (catch-all only fires for unknown paths).
 		await gotoRoute(page, '/schemas')
-		await expect(page).toHaveURL(/#\/schemas$/)
+		await expect(page).toHaveURL(/\/apps\/openregister\/schemas$/)
 		await expect(page.locator('main, .app-content').first()).toBeVisible()
 	})
 })
@@ -155,7 +155,7 @@ test.describe('openregister-app-manifest — registry dispatch', () => {
 	}) => {
 		requireAuth()
 		await gotoRoute(page, '/registers')
-		await expect(page).toHaveURL(/#\/registers$/)
+		await expect(page).toHaveURL(/\/apps\/openregister\/registers$/)
 		await expect(page.locator('main, .app-content').first()).toBeVisible()
 	})
 
@@ -171,7 +171,9 @@ test.describe('openregister-app-manifest — registry dispatch', () => {
 		// router into a registry component and the app-content shell renders — the
 		// scenario asserts the dispatch + shell, not that an unknown id stays put.
 		await gotoRoute(page, '/registers/e2e-probe-id')
-		await expect(page).toHaveURL(/#\/registers(\/e2e-probe-id)?$/)
+		await expect(page).toHaveURL(
+			/\/apps\/openregister\/registers(\/e2e-probe-id)?$/,
+		)
 		await expect(page.locator('main, .app-content').first()).toBeVisible()
 	})
 

--- a/tests/e2e/smoke-boot.spec.ts
+++ b/tests/e2e/smoke-boot.spec.ts
@@ -44,7 +44,7 @@ const STORAGE_STATE = path.resolve(__dirname, '.auth/admin.json')
 // shows up as a MIME refusal here and nowhere else.
 const ROUTES = [
 	{ name: 'app root', url: '/index.php/apps/openregister/' },
-	{ name: 'registers', url: '/index.php/apps/openregister/#/registers' },
+	{ name: 'registers', url: '/index.php/apps/openregister/registers' },
 ]
 
 /** Console messages that mean the bundle never booted. */

--- a/tests/e2e/spec-coverage/admin-settings-pages.spec.ts
+++ b/tests/e2e/spec-coverage/admin-settings-pages.spec.ts
@@ -83,7 +83,7 @@ function trackErrors(page: Page): { console: string[]; http: string[] } {
 async function gotoPage(page: Page, route: string): Promise<void> {
 	// HASH form — the router runs in hash mode (src/main.js); path-form
 	// deep-links render the dashboard instead of the target page.
-	await page.goto(`/index.php/apps/openregister/#${route}`, {
+	await page.goto(`/index.php/apps/openregister${route}`, {
 		waitUntil: 'domcontentloaded',
 	})
 	await page.waitForSelector('#header, header.header-appcontainer', {

--- a/tests/e2e/spec-coverage/core-list-pages.spec.ts
+++ b/tests/e2e/spec-coverage/core-list-pages.spec.ts
@@ -106,7 +106,7 @@ async function gotoPage(page: Page, route: string): Promise<void> {
 	// deep-link (`/apps/openregister/registers`) is rewritten by the hash
 	// router to `/registers#/` and renders the DASHBOARD, not the target page
 	// (verified empirically 2026-07-27).
-	await page.goto(`/index.php/apps/openregister/#${route}`, {
+	await page.goto(`/index.php/apps/openregister${route}`, {
 		waitUntil: 'domcontentloaded',
 	})
 	await page.waitForSelector('#header, header.header-appcontainer', {

--- a/tests/e2e/spec-coverage/data-import-export.spec.ts
+++ b/tests/e2e/spec-coverage/data-import-export.spec.ts
@@ -64,7 +64,7 @@ test.describe('data-import-export — import dialog reachability', () => {
 
 		// The OR SPA uses Vue Router history mode with base /index.php/apps/openregister/
 		// The objects route is reached via the hash-anchor pattern used by the existing test suite
-		await page.goto('/index.php/apps/openregister/#/objects', {
+		await page.goto('/index.php/apps/openregister/objects', {
 			waitUntil: 'domcontentloaded',
 		})
 		// Nextcloud header must be visible
@@ -90,7 +90,7 @@ test.describe('data-import-export — import dialog reachability', () => {
 		if (!fs.existsSync(STORAGE_STATE)) test.skip(true, 'no auth state')
 
 		// Navigate to the registers view where the import action is available
-		await page.goto('/index.php/apps/openregister/#/registers', {
+		await page.goto('/index.php/apps/openregister/registers', {
 			waitUntil: 'domcontentloaded',
 		})
 		await expect(

--- a/tests/e2e/spec-coverage/detail-pages.spec.ts
+++ b/tests/e2e/spec-coverage/detail-pages.spec.ts
@@ -165,7 +165,7 @@ async function gotoPage(page: Page, route: string): Promise<void> {
 	// HASH form — the router runs in hash mode (src/main.js). A path-form
 	// deep-link (`/apps/openregister/applications/12`) is rewritten by the hash
 	// router and renders the DASHBOARD, not the target page.
-	await page.goto(`/index.php/apps/openregister/#${route}`, {
+	await page.goto(`/index.php/apps/openregister${route}`, {
 		waitUntil: 'domcontentloaded',
 	})
 	await page.waitForSelector('#header, header.header-appcontainer', {

--- a/tests/e2e/spec-coverage/entity-management-modals.spec.ts
+++ b/tests/e2e/spec-coverage/entity-management-modals.spec.ts
@@ -83,7 +83,7 @@ async function deleteTestObject(
 async function gotoApp(page: Page, subpath: string): Promise<void> {
 	// HASH form — the router runs in hash mode (src/main.js); path-form
 	// deep-links render the dashboard instead of the target page.
-	await page.goto(`/index.php/apps/openregister/#${subpath}`, {
+	await page.goto(`/index.php/apps/openregister${subpath}`, {
 		waitUntil: 'domcontentloaded',
 	})
 	await page.waitForSelector('#header, header.header-appcontainer', {
@@ -151,7 +151,7 @@ test.describe('entity-management-modals — copy-single-object-names-the-duplica
 		// register+schema pre-selected so the route watcher triggers
 		// applyQueryParamsFromRoute → performSearchWithFacets immediately.
 		await page.goto(
-			`/index.php/apps/openregister/#/tables?register=${REGISTER_ID}&schema=${SCHEMA_ID}`,
+			`/index.php/apps/openregister/tables?register=${REGISTER_ID}&schema=${SCHEMA_ID}`,
 			{ waitUntil: 'domcontentloaded' },
 		)
 		await page.waitForSelector('#header, header.header-appcontainer', {

--- a/tests/e2e/spec-coverage/feature-pages.spec.ts
+++ b/tests/e2e/spec-coverage/feature-pages.spec.ts
@@ -89,7 +89,7 @@ function trackErrors(
 async function gotoPage(page: Page, route: string): Promise<void> {
 	// HASH form — the router runs in hash mode (src/main.js); path-form
 	// deep-links render the dashboard instead of the target page.
-	await page.goto(`/index.php/apps/openregister/#${route}`, {
+	await page.goto(`/index.php/apps/openregister${route}`, {
 		waitUntil: 'domcontentloaded',
 	})
 	await page.waitForSelector('#header, header.header-appcontainer', {
@@ -243,7 +243,7 @@ test.describe('feature-pages — real UI render + actions', () => {
 		page,
 	}) => {
 		await gotoPage(page, '/registers')
-		await expect(page).toHaveURL(/#\/registers$/)
+		await expect(page).toHaveURL(/\/apps\/openregister\/registers$/)
 
 		// The manifest declares this entry in the `footer` section; CnAppNav
 		// renders footer entries as NcAppNavigationItem router-links.
@@ -253,7 +253,9 @@ test.describe('feature-pages — real UI render + actions', () => {
 		await expect(navEntry).toHaveCount(1)
 		await navEntry.first().click()
 
-		await expect(page).toHaveURL(/#\/features-roadmap$/, { timeout: 15_000 })
+		await expect(page).toHaveURL(/\/apps\/openregister\/features-roadmap$/, {
+			timeout: 15_000,
+		})
 
 		const view = page.locator('.cn-features-and-roadmap-view')
 		await expect(view).toBeVisible({ timeout: 15_000 })

--- a/tests/e2e/spec-coverage/features-roadmap-surface.spec.ts
+++ b/tests/e2e/spec-coverage/features-roadmap-surface.spec.ts
@@ -58,7 +58,7 @@ const FLAG_PATH =
  * deep-link renders the dashboard instead of the target page.
  */
 async function gotoRoadmapRoute(page: Page): Promise<void> {
-	await page.goto('/index.php/apps/openregister/#/features-roadmap', {
+	await page.goto('/index.php/apps/openregister/features-roadmap', {
 		waitUntil: 'domcontentloaded',
 	})
 	await page

--- a/tests/e2e/spec-coverage/files-sidebar-tabs.spec.ts
+++ b/tests/e2e/spec-coverage/files-sidebar-tabs.spec.ts
@@ -45,7 +45,7 @@ const STORAGE_STATE = path.resolve(__dirname, '../.auth/admin.json')
 async function gotoApp(page: Page, subpath: string): Promise<void> {
 	// HASH form — the router runs in hash mode (src/main.js); path-form
 	// deep-links render the dashboard instead of the target page.
-	await page.goto(`/index.php/apps/openregister/#${subpath}`, {
+	await page.goto(`/index.php/apps/openregister${subpath}`, {
 		waitUntil: 'domcontentloaded',
 	})
 	await page.waitForSelector('#header, header.header-appcontainer', {
@@ -440,7 +440,7 @@ test.describe('files-sidebar-tabs — applyfilters-writes-filter-state-to-the-ur
 		page,
 	}) => {
 		// Start from clean /deleted (hash form — router runs in hash mode).
-		await page.goto('/index.php/apps/openregister/#/deleted', {
+		await page.goto('/index.php/apps/openregister/deleted', {
 			waitUntil: 'domcontentloaded',
 		})
 		await page.waitForSelector('#header, header.header-appcontainer', {

--- a/tests/e2e/spec-coverage/mdm-frontend.spec.ts
+++ b/tests/e2e/spec-coverage/mdm-frontend.spec.ts
@@ -8,7 +8,7 @@
  *   @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#<scenario-slug>
  *
  * Methodology: drive the real UI. The five MDM views live under the hash-mode
- * router (`/index.php/apps/openregister/#/<route>`); the shared
+ * router (`/index.php/apps/openregister/<route>`); the shared
  * RegisterSchemaSelector is now route-scoped, so when the self-seeding MDM
  * fixture (tests/e2e/mdm-seed.ts, run in globalSetup) has planted data, these
  * tests DEEP-LINK straight to the seeded register/schema
@@ -33,7 +33,7 @@ function scopedQuery(): string {
 
 /** Navigate to a hash-mode OR route and wait for NC header + app content. */
 async function gotoApp(page: Page, route: string): Promise<void> {
-	await page.goto(`/index.php/apps/openregister/#${route}`, {
+	await page.goto(`/index.php/apps/openregister${route}`, {
 		waitUntil: 'domcontentloaded',
 	})
 	await page.waitForSelector('#header, header.header-appcontainer', {

--- a/tests/e2e/spec-coverage/mdm-merge-ui.spec.ts
+++ b/tests/e2e/spec-coverage/mdm-merge-ui.spec.ts
@@ -33,7 +33,7 @@ function scopedQuery(): string {
 
 /** Navigate to a hash-mode OR route and wait for NC header + app content. */
 async function gotoApp(page: Page, route: string): Promise<void> {
-	await page.goto(`/index.php/apps/openregister/#${route}`, {
+	await page.goto(`/index.php/apps/openregister${route}`, {
 		waitUntil: 'domcontentloaded',
 	})
 	await page.waitForSelector('#header, header.header-appcontainer', {

--- a/tests/e2e/spec-coverage/mdm-survivorship-override.spec.ts
+++ b/tests/e2e/spec-coverage/mdm-survivorship-override.spec.ts
@@ -33,7 +33,7 @@ function scopedQuery(): string {
 
 /** Navigate to a hash-mode OR route and wait for NC header + app content. */
 async function gotoApp(page: Page, route: string): Promise<void> {
-	await page.goto(`/index.php/apps/openregister/#${route}`, {
+	await page.goto(`/index.php/apps/openregister${route}`, {
 		waitUntil: 'domcontentloaded',
 	})
 	await page.waitForSelector('#header, header.header-appcontainer', {

--- a/tests/e2e/spec-coverage/register-i18n.spec.ts
+++ b/tests/e2e/spec-coverage/register-i18n.spec.ts
@@ -175,7 +175,7 @@ test.describe('register-i18n — register language management UI', () => {
 		if (!fs.existsSync(STORAGE_STATE)) test.skip(true, 'no auth state')
 		if (!registerId) test.skip(true, 'no test register')
 
-		await page.goto(`/index.php/apps/openregister/#/registers`, {
+		await page.goto(`/index.php/apps/openregister/registers`, {
 			waitUntil: 'domcontentloaded',
 		})
 		// Wait for the app to mount
@@ -311,7 +311,7 @@ test.describe('register-i18n — register language management UI', () => {
 			})
 
 		await page
-			.goto(`/index.php/apps/openregister/#/registers`, {
+			.goto(`/index.php/apps/openregister/registers`, {
 				waitUntil: 'domcontentloaded',
 			})
 
@@ -340,7 +340,7 @@ test.describe('register-i18n — register language management UI', () => {
 		if (!fs.existsSync(STORAGE_STATE)) test.skip(true, 'no auth state')
 
 		// Navigate to registers
-		await page.goto(`/index.php/apps/openregister/#/registers`, {
+		await page.goto(`/index.php/apps/openregister/registers`, {
 			waitUntil: 'domcontentloaded',
 		})
 		await expect(page.locator('main, .app-content').first()).toBeVisible({
@@ -444,7 +444,7 @@ test.describe('register-i18n — register language management UI', () => {
 	}) => {
 		if (!fs.existsSync(STORAGE_STATE)) test.skip(true, 'no auth state')
 
-		await page.goto(`/index.php/apps/openregister/#/registers`, {
+		await page.goto(`/index.php/apps/openregister/registers`, {
 			waitUntil: 'domcontentloaded',
 		})
 		await expect(page.locator('main, .app-content').first()).toBeVisible({

--- a/tests/e2e/spec-coverage/saved-search-views.spec.ts
+++ b/tests/e2e/spec-coverage/saved-search-views.spec.ts
@@ -54,7 +54,7 @@ async function deleteView(request: APIRequestContext, id: number): Promise<void>
 async function gotoTablesPage(page: Page): Promise<void> {
 	// HASH form — the router runs in hash mode (src/main.js); the path-form
 	// URL renders the dashboard instead of the tables page.
-	await page.goto('/index.php/apps/openregister/#/tables', {
+	await page.goto('/index.php/apps/openregister/tables', {
 		waitUntil: 'domcontentloaded',
 	})
 	await page.waitForSelector('#header, header.header-appcontainer', {

--- a/tests/e2e/ui-navigation.spec.ts
+++ b/tests/e2e/ui-navigation.spec.ts
@@ -45,7 +45,7 @@ test.describe('frontend-app-bootstrap — navigation routes load', () => {
 				)
 			}
 			// Use domcontentloaded — the NC SPA keeps background XHR alive so networkidle never fires.
-			await page.goto(`/index.php/apps/openregister/#${route.hash}`, {
+			await page.goto(`/index.php/apps/openregister${route.hash}`, {
 				waitUntil: 'domcontentloaded',
 			})
 
@@ -75,7 +75,7 @@ test.describe('built-in-dashboards — dashboard renders', () => {
 			test.skip(true, 'storageState not present')
 		}
 
-		await page.goto('/index.php/apps/openregister/#/', {
+		await page.goto('/index.php/apps/openregister/', {
 			waitUntil: 'domcontentloaded',
 		})
 
@@ -106,7 +106,7 @@ test.describe('features-roadmap — roadmap view renders', () => {
 			test.skip(true, 'storageState not present')
 		}
 
-		await page.goto('/index.php/apps/openregister/#/features-roadmap', {
+		await page.goto('/index.php/apps/openregister/features-roadmap', {
 			waitUntil: 'domcontentloaded',
 		})
 
@@ -127,7 +127,7 @@ test.describe('no-code-app-builder — applications view', () => {
 			test.skip(true, 'storageState not present')
 		}
 
-		await page.goto('/index.php/apps/openregister/#/applications', {
+		await page.goto('/index.php/apps/openregister/applications', {
 			waitUntil: 'domcontentloaded',
 		})
 

--- a/tests/e2e/visual/dsar-cases.visual.spec.ts
+++ b/tests/e2e/visual/dsar-cases.visual.spec.ts
@@ -34,6 +34,6 @@ test.describe('Open Register — DSAR cases visual baseline', () => {
 			)
 		}
 		// The AVG view opens on the Activities tab; the Cases tab is client-side.
-		await shootSurface(page, `${APP}/#/avg`, 'avg-cases.png')
+		await shootSurface(page, `${APP}/avg`, 'avg-cases.png')
 	})
 })

--- a/tests/e2e/visual/mdm-frontend.visual.spec.ts
+++ b/tests/e2e/visual/mdm-frontend.visual.spec.ts
@@ -62,27 +62,23 @@ async function selectFirstRegisterAndSchema(page: Page): Promise<boolean> {
 test.describe('mdm-frontend — visual baselines', () => {
 	// QualityIndex (Data Quality dashboard).
 	test('QualityIndex', async ({ page }) => {
-		await shootSurface(page, `${APP}/#/quality`, 'QualityIndex.png')
+		await shootSurface(page, `${APP}/quality`, 'QualityIndex.png')
 	})
 
 	// DuplicatesIndex (Duplicate Candidates, read-only).
 	test('DuplicatesIndex', async ({ page }) => {
-		await shootSurface(page, `${APP}/#/duplicates`, 'DuplicatesIndex.png')
+		await shootSurface(page, `${APP}/duplicates`, 'DuplicatesIndex.png')
 	})
 
 	// MasterEntitiesIndex (master-entity list).
 	test('MasterEntitiesIndex', async ({ page }) => {
-		await shootSurface(
-			page,
-			`${APP}/#/master-entities`,
-			'MasterEntitiesIndex.png',
-		)
+		await shootSurface(page, `${APP}/master-entities`, 'MasterEntitiesIndex.png')
 	})
 
 	// GoldenRecordDetail (opened from MasterEntitiesIndex — not a standalone
 	// route, so this baseline drives the panel open before shooting).
 	test('GoldenRecordDetail', async ({ page }) => {
-		await page.goto(`${APP}/#/master-entities`, {
+		await page.goto(`${APP}/master-entities`, {
 			waitUntil: 'domcontentloaded',
 		})
 		await dismissSupportDialog(page)
@@ -115,6 +111,6 @@ test.describe('mdm-frontend — visual baselines', () => {
 
 	// QueueHealthIndex (Queue / sync health).
 	test('QueueHealthIndex', async ({ page }) => {
-		await shootSurface(page, `${APP}/#/queue-health`, 'QueueHealthIndex.png')
+		await shootSurface(page, `${APP}/queue-health`, 'QueueHealthIndex.png')
 	})
 })

--- a/tests/e2e/visual/mdm-merge-ui.visual.spec.ts
+++ b/tests/e2e/visual/mdm-merge-ui.visual.spec.ts
@@ -64,14 +64,14 @@ test.describe('mdm-merge-ui — visual baselines', () => {
 	test('MergeOperationsIndex', async ({ page }) => {
 		await shootSurface(
 			page,
-			`${APP}/#/mergeOperations`,
+			`${APP}/mergeOperations`,
 			'MergeOperationsIndex.png',
 		)
 	})
 
 	// MdmMergeWizardModal — opened from a candidate pair on DuplicatesIndex.
 	test('MdmMergeWizardModal', async ({ page }) => {
-		await page.goto(`${APP}/#/duplicates`, { waitUntil: 'domcontentloaded' })
+		await page.goto(`${APP}/duplicates`, { waitUntil: 'domcontentloaded' })
 		await dismissSupportDialog(page)
 		await waitForContentReady(page)
 

--- a/tests/e2e/visual/mdm-survivorship-override.visual.spec.ts
+++ b/tests/e2e/visual/mdm-survivorship-override.visual.spec.ts
@@ -62,7 +62,7 @@ test.describe('mdm-survivorship-override — visual baselines', () => {
 	test('MdmConflictResolutionModal', async ({ page }) => {
 		// Manifest route is kebab-case '/master-entities' (src/manifest.json);
 		// '#/masterEntities' hits the catch-all and redirects to the dashboard.
-		await page.goto(`${APP}/#/master-entities`, {
+		await page.goto(`${APP}/master-entities`, {
 			waitUntil: 'domcontentloaded',
 		})
 		await dismissSupportDialog(page)

--- a/tests/e2e/visual/openregister.visual.spec.ts
+++ b/tests/e2e/visual/openregister.visual.spec.ts
@@ -17,7 +17,7 @@ const APP = '/index.php/apps/openregister'
 
 test.describe('Open Register — visual baselines', () => {
 	test('dashboard', async ({ page }) => {
-		await shootSurface(page, `${APP}/#/`, 'dashboard.png')
+		await shootSurface(page, `${APP}/`, 'dashboard.png')
 	})
 
 	// NOTE: OpenRegister's in-app sidebar routes do not switch the rendered

--- a/tests/e2e/workflows/dsar-cases.spec.ts
+++ b/tests/e2e/workflows/dsar-cases.spec.ts
@@ -24,7 +24,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 
 const STORAGE_STATE = path.resolve(__dirname, '..', '.auth', 'admin.json')
-const AVG_URL = '/index.php/apps/openregister/#/avg'
+const AVG_URL = '/index.php/apps/openregister/avg'
 
 // Safe placeholders only (nil UUID / literal token) — never real values.
 const NIL_UUID = '00000000-0000-0000-0000-000000000000'

--- a/tests/e2e/workflows/object-lifecycle-workflows.spec.ts
+++ b/tests/e2e/workflows/object-lifecycle-workflows.spec.ts
@@ -161,7 +161,7 @@ test.describe('workflow: audit-trail records create and update', () => {
 		const trails = await getTrails(request)
 		test.skip(trails.length === 0, 'no audit trail entries to render')
 
-		await page.goto(`${APP}/#/audit-trails`, { waitUntil: 'domcontentloaded' })
+		await page.goto(`${APP}/audit-trails`, { waitUntil: 'domcontentloaded' })
 		await expect(page.locator('main, .app-content').first()).toBeVisible({
 			timeout: 30_000,
 		})
@@ -299,7 +299,7 @@ test.describe('workflow: soft-delete then restore', () => {
 	})
 
 	test('UI: the Deleted view renders', async ({ page }) => {
-		await page.goto(`${APP}/#/deleted`, { waitUntil: 'domcontentloaded' })
+		await page.goto(`${APP}/deleted`, { waitUntil: 'domcontentloaded' })
 		// The Deleted view must at least mount. (BUG-1 is now fixed, so the list
 		// is populated by GET /api/deleted — asserted at the API level above.)
 		await expect(page.locator('main, .app-content').first()).toBeVisible({


### PR DESCRIPTION
feat(router): move openregister off hash routing, and stop the catch-all eating the API

Seventh and last app off `#` routing, after stackiq (softwarecatalog#899),
zaakafhandelapp (#609), opencatalogi (#1341), keepiq (#582), larpinq
(#651) and pipelinq (#1684).

Three source changes:

1. DashboardController::catchAll(), delegating to page(). THIS is the
   actual fix for #133. The app registered exactly one frontend route --
   `dashboard#page` at `/` -- and nothing serving the SPA shell for a deep
   sub-path, so a bookmark or full-page load to /registers never reached
   the SPA and the grouped index pages rendered empty (no Add button, no
   list). Hash mode was adopted to work around that; this removes the
   cause instead.

2. The catch-all route in appinfo/routes.php.

3. createWebHashHistory -> createWebHistory with routerBase(), derived
   from the URL actually being served. Nextcloud serves the app under
   BOTH /apps/openregister/... and /index.php/apps/openregister/..., but
   generateUrl() returns only one; arriving on the other leaves the path
   outside the router base and the deep link is silently swallowed.

⚠️ The catch-all needs `(?!api/)`, and getting this wrong is not
theoretical -- the same defect shipped in zaakafhandelapp#615 and ate all
seventeen of its ZGW resource routes until #619. Nextcloud's RouteParser
processes the `routes` array BEFORE the `resources` array
(RouteParser::parseDefaultRoutes) and Symfony matches in insertion order,
so the catch-all registers ahead of every one of this app's NINE
`api/...` resources no matter that it is written last. `.+` also matches
slashes. Without the lookahead, GET api/registers answers the SPA shell
at HTTP 200: a JSON caller receives HTML and nothing errors loudly.

\OCA\OpenRegister\AppHost\Routes::catchAllRoute() gets the same lookahead,
so no future adopter of Routes::standard() inherits it, and RoutesTest
now asserts the requirement as a REGEX against real paths rather than as
a literal string, so the guard survives a rewrite of the spelling.

Deep-link URL GENERATION is de-hashed (CalendarEventTransformer), but
every PARSER keeps its hash pattern: ObjectReferenceProvider, UrnService
and ObjectPreviewFormatter already accepted three URL shapes including the
path form, and links shared into Talk, Mail and calendar entries before
today still carry `#`. Dropping the pattern would break previews of
already-shared links, so those tests keep asserting it on purpose.

Verified on the dev instance, with the catch-all live:

  api/registers, api/schemas, api/sources, api/configurations,
  api/applications, api/agents, api/endpoints, api/mappings,
  api/consumers            -> all 200 application/json (unshadowed)
  /registers, /schemas, /features-roadmap, /zzz-nonsense
                           -> 200, SPA shell (404 before)

and in the browser against the built bundle:

  /index.php/apps/openregister/registers -> Registers, 48 rows, "Add
                                            Register", 0 hash links
  /apps/openregister/schemas             -> Schemas, 95 rows, "Add Schema"

Both were full page loads, which is the reload case hash mode existed to
avoid. Nav hrefs carry whichever base the page was loaded under, which is
routerBase() working -- generateUrl() alone would have broken one of the
two forms.

43 files; the bulk is the e2e suite moving off `${APP}/#${route}`.
eslint 0 errors, prettier --check on the FULL glob clean, webpack
compiles, php -l passes.
