### PR TITLE
fix(controllers): two more inverted call sites, and a guard that can see them

### DIFF
--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -3538,9 +3538,12 @@ class ObjectsController extends Controller {
 	 * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md
 	 */
 	public function contracts(string $id, string $register, string $schema, ObjectService $objectService): JSONResponse {
-		// Set the schema and register to the object service.
-		$objectService->setSchema(schema: $schema);
+		// REGISTER FIRST. `setSchema()` scopes its slug lookup to whatever
+		// register is currently set, and ObjectService is reused across many
+		// operations in one process, so naming the schema first resolves it
+		// against a register an unrelated call left behind.
 		$objectService->setRegister(register: $register);
+		$objectService->setSchema(schema: $schema);
 
 		// Get request parameters for filtering.
 		$requestParams = $this->request->getParams();
@@ -3753,9 +3756,12 @@ class ObjectsController extends Controller {
 	 * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md
 	 */
 	public function used(string $id, string $register, string $schema, ObjectService $objectService): JSONResponse {
-		// Set the schema and register to the object service.
-		$objectService->setSchema(schema: $schema);
+		// REGISTER FIRST. `setSchema()` scopes its slug lookup to whatever
+		// register is currently set, and ObjectService is reused across many
+		// operations in one process, so naming the schema first resolves it
+		// against a register an unrelated call left behind.
 		$objectService->setRegister(register: $register);
+		$objectService->setSchema(schema: $schema);
 
 		// Build search query from request parameters.
 		$queryParams = $this->request->getParams();

--- a/tests/Unit/Controller/RegisterBeforeSchemaOrderTest.php
+++ b/tests/Unit/Controller/RegisterBeforeSchemaOrderTest.php
@@ -75,8 +75,19 @@ class RegisterBeforeSchemaOrderTest extends TestCase {
 		$source = file_get_contents($file);
 		$this->assertIsString($source, 'controller source is readable');
 
+		// Matches ANY receiver, not just `$this->objectService`. The first pass
+		// of this guard pinned the receiver and so missed
+		// `ObjectsController::contracts()` and `::used()`, which call the same
+		// two setters on an INJECTED `$objectService` parameter and with named
+		// arguments. A guard narrower than the defect finds only the instances
+		// you already fixed.
+		//
+		// Entity setters (`$objectEntity->setSchema()`, `$auditTrail->…`) share
+		// the method names and are NOT this defect, so the receiver must repeat
+		// between the two calls: the bug is one object being configured in the
+		// wrong order, not two unrelated writes.
 		$inverted = preg_match_all(
-			'/setSchema\(\s*[^)]*\s*\)\s*;\s*\n\s*\$this->objectService->setRegister\(/',
+			'/(\$[A-Za-z_>\-\[\]\'\"\w]*?)->setSchema\((?:schema:\s*)?[^)]*\)\s*;\s*\n\s*\1->setRegister\(/',
 			$source
 		);
 


### PR DESCRIPTION
Follow-up to #3266, which fixed 27 call sites and added a static guard. **Both were narrower than the defect.**

The guard's regex pinned the receiver to `$this->objectService`, so it could not see `ObjectsController::contracts()` and `::used()` — which call the same two setters on an **injected** `$objectService` parameter, with named arguments:

```php
$objectService->setSchema(schema: $schema);
$objectService->setRegister(register: $register);
```

A guard written from the instances you already found will only ever find the instances you already found.

## The user-visible half

Both endpoints back the related-objects surface, so this is the same failure as #3266:

```
GET /objects/dossiq/case/{id}/contracts   500  →  200
GET /objects/dossiq/case/{id}/used        500  →  200
GET /objects/dossiq/case/{id}/uses        200       (unaffected, beside them)
```

## The widened guard

It now matches **any receiver**, and requires the **same** receiver on both calls. That second part is what separates the defect from the entity setters sharing the method names — `$objectEntity->setSchema()`, `$auditTrail->setSchema()` — which a receiver-blind regex would have flagged as false positives. I checked all five candidates across `lib/` by hand: two were the defect, three were entity writes.

## Verification

Verified the widened guard **fails on the two sites before fixing them**, then passes after — the same discipline as the original, since a guard that has never failed is not evidence.

131 controller files scanned, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)