### PR TITLE
fix(db): guard PostgreSQL-only jsonb syntax in MagicSearchHandler relation filters (WOO-548)

### DIFF
--- a/lib/Db/MagicMapper/MagicSearchHandler.php
+++ b/lib/Db/MagicMapper/MagicSearchHandler.php
@@ -1821,10 +1821,15 @@ class MagicSearchHandler {
 	}//end applyIdFilters()
 
 	/**
-	 * Apply relations contains filter to find objects referencing a specific UUID
+	 * Apply relations contains filter to find objects referencing a specific UUID.
 	 *
-	 * This uses PostgreSQL's JSONB @> operator to check if the _relations array
-	 * contains the specified UUID.
+	 * Relations can be stored as either an array (`["uuid1", "uuid2", ...]`, the
+	 * legacy/common format) or an object (`{"fieldName": "uuid", ...}`, the newer
+	 * format). Both dialects are handled below via a platform-conditional branch;
+	 * PostgreSQL uses jsonb_typeof + `@>`, MariaDB/MySQL use JSON_SEARCH which
+	 * walks both structures natively.
+	 *
+	 * Consumed by OpenCatalogi's public search (WOO-536 Stap 5a) — see WOO-548.
 	 *
 	 * @param IQueryBuilder $qb Query builder to modify
 	 * @param string $uuid UUID to search for in relations
@@ -1832,20 +1837,25 @@ class MagicSearchHandler {
 	 * @return void
 	 */
 	private function applyRelationsContainsFilter(IQueryBuilder $qb, string $uuid): void {
-		// Relations can be stored as either:
-		// - An array: ["uuid1", "uuid2", ...] (legacy/common format)
-		// - An object: {"fieldName": "uuid", ...} (new format)
-		// Handle both formats using jsonb_typeof to dispatch correctly.
 		$param = $qb->createNamedParameter($uuid);
-		$qb->andWhere(
-			"(
+		if ($this->isPostgresPlatform() === true) {
+			$qb->andWhere(
+				"(
                 (jsonb_typeof(t._relations) = 'array' AND t._relations @> to_jsonb({$param}::text))
                 OR
                 (jsonb_typeof(t._relations) = 'object' AND EXISTS (
                     SELECT 1 FROM jsonb_each_text(t._relations) AS kv WHERE kv.value = {$param}
                 ))
             )"
-		);
+			);
+			return;
+		}
+
+		// MariaDB / MySQL: JSON_SEARCH walks both array and object structures and
+		// returns the path (or NULL) for the first match of the value at any
+		// depth — semantic parallel to the PostgreSQL branch above. Available on
+		// MariaDB 10.2+ / MySQL 5.7+ (both mandated by the NC platform baseline).
+		$qb->andWhere("JSON_SEARCH(t._relations, 'one', {$param}) IS NOT NULL");
 	}//end applyRelationsContainsFilter()
 
 	/**
@@ -1904,8 +1914,9 @@ class MagicSearchHandler {
 		// Array-indexed relation keys are stored as `<field>.<n>` (e.g. `keywords.1`).
 		$prefixParam = $qb->createNamedParameter($field . '.%');
 
-		$qb->andWhere(
-			"(
+		if ($this->isPostgresPlatform() === true) {
+			$qb->andWhere(
+				"(
                 (jsonb_typeof(t._relations) = 'object' AND EXISTS (
                     SELECT 1 FROM jsonb_each_text(t._relations) AS kv
                     WHERE kv.value = {$valueParam}
@@ -1913,6 +1924,21 @@ class MagicSearchHandler {
                 ))
                 OR
                 (jsonb_typeof(t._relations) = 'array' AND t._relations @> to_jsonb({$valueParam}::text))
+            )"
+			);
+			return;
+		}
+
+		// MariaDB / MySQL fallback (WOO-548).
+		//   1. Object with exact field key:  JSON_EXTRACT($.<field>) equals the value
+		//   2. Object with array-indexed key: JSON_SEARCH restricted to path $.<field>.%
+		//   3. Legacy array shape:            JSON_CONTAINS on the whole array
+		// JSON path arg composed via CONCAT so the field-name parameter binds through.
+		$qb->andWhere(
+			"(
+                JSON_UNQUOTE(JSON_EXTRACT(t._relations, CONCAT('$.', {$exactKey}))) = {$valueParam}
+                OR JSON_SEARCH(t._relations, 'one', {$valueParam}, NULL, CONCAT('$.', {$prefixParam})) IS NOT NULL
+                OR JSON_CONTAINS(t._relations, JSON_QUOTE({$valueParam}))
             )"
 		);
 	}//end applyRelationFieldFilter()
@@ -1929,13 +1955,15 @@ class MagicSearchHandler {
 	 * @return string[] Array of SQL conditions (without leading AND/WHERE).
 	 */
 	private function buildRelationFilterConditionsSql(array $query, object $connection): array {
+		$isPostgres = $this->isPostgresPlatform();
 		$conditions = [];
 		foreach ($this->extractRelationFieldFilters(query: $query) as $field => $value) {
 			$valueQuoted = $connection->quote($value);
 			$exactQuoted = $connection->quote($field);
 			$prefixQuoted = $connection->quote($field . '.%');
 
-			$conditions[] = "(
+			if ($isPostgres === true) {
+				$conditions[] = "(
                 (jsonb_typeof(_relations) = 'object' AND EXISTS (
                     SELECT 1 FROM jsonb_each_text(_relations) AS kv
                     WHERE kv.value = {$valueQuoted}
@@ -1943,6 +1971,15 @@ class MagicSearchHandler {
                 ))
                 OR
                 (jsonb_typeof(_relations) = 'array' AND _relations @> to_jsonb({$valueQuoted}::text))
+            )";
+				continue;
+			}
+
+			// MariaDB / MySQL fallback — see applyRelationFieldFilter() (WOO-548).
+			$conditions[] = "(
+                JSON_UNQUOTE(JSON_EXTRACT(_relations, CONCAT('$.', {$exactQuoted}))) = {$valueQuoted}
+                OR JSON_SEARCH(_relations, 'one', {$valueQuoted}, NULL, CONCAT('$.', {$prefixQuoted})) IS NOT NULL
+                OR JSON_CONTAINS(_relations, JSON_QUOTE({$valueQuoted}))
             )";
 		}
 

--- a/lib/Db/MagicMapper/MagicSearchHandler.php
+++ b/lib/Db/MagicMapper/MagicSearchHandler.php
@@ -1934,6 +1934,19 @@ class MagicSearchHandler {
 		//   2. Object with array-indexed key: JSON_SEARCH restricted to path $.<field>.%
 		//   3. Legacy array shape:            JSON_CONTAINS on the whole array
 		// JSON path arg composed via CONCAT so the field-name parameter binds through.
+		//
+		// Divergence with the Postgres branch: PG matches a flat top-level key
+		// literally named `<field>.<n>` via `kv.key LIKE '<field>.%'` (SQL LIKE
+		// on the flat key string). MariaDB's `$.<field>.%` here is a JSON path
+		// *navigator* — it descends into the member named `<field>` and
+		// wildcard-matches its children. No writer in this repo currently
+		// persists the flat dot-in-key shape (grep -rn '\\.[0-9]' lib/ against
+		// _relations writers — empty), so the two branches are semantically
+		// equivalent for every shape produced in practice. If a writer for the
+		// flat-dot-in-key shape is ever added, this branch has to grow a
+		// `JSON_SEARCH(JSON_KEYS(t._relations), 'one', {$prefixParam})`-based
+		// key-scan too (or, cleaner, the writer switches to the nested-object
+		// shape both branches already handle).
 		$qb->andWhere(
 			"(
                 JSON_UNQUOTE(JSON_EXTRACT(t._relations, CONCAT('$.', {$exactKey}))) = {$valueParam}

--- a/tests/Unit/Db/MagicSearchHandlerRelationsFilterMariaDbTest.php
+++ b/tests/Unit/Db/MagicSearchHandlerRelationsFilterMariaDbTest.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * WOO-548 regression: `_relations.<field>` VALUE-filtering on MariaDB/MySQL.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Db;
+
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use OCA\OpenRegister\Db\MagicMapper\MagicOrganizationHandler;
+use OCA\OpenRegister\Db\MagicMapper\MagicRbacHandler;
+use OCA\OpenRegister\Db\MagicMapper\MagicSearchHandler;
+use OCA\OpenRegister\Service\DateTimeNormalizer;
+use OCA\OpenRegister\Service\Object\SchemaTypeConverter;
+use OCP\IDBConnection;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionMethod;
+
+/**
+ * Locks the WOO-548 MariaDB/MySQL fallback for the three `_relations`-touching
+ * methods in {@see MagicSearchHandler}. Previous shape emitted unguarded
+ * PostgreSQL-only `jsonb_typeof` / `to_jsonb` / `@>`, which raised a syntax
+ * error (or silently returned empty) on MariaDB/MySQL. Consumed by
+ * OpenCatalogi's public search (WOO-536 Stap 5a).
+ *
+ * The PostgreSQL branch is covered by the sibling
+ * {@see MagicSearchHandlerRelationsFilterTest}.
+ */
+class MagicSearchHandlerRelationsFilterMariaDbTest extends TestCase {
+
+	private IDBConnection&MockObject $db;
+
+	private LoggerInterface&MockObject $logger;
+
+	private MagicRbacHandler&MockObject $rbacHandler;
+
+	private MagicOrganizationHandler&MockObject $organizationHandler;
+
+	private MagicSearchHandler $handler;
+
+	protected function setUp(): void {
+		$this->db = $this->createMock(IDBConnection::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->rbacHandler = $this->createMock(MagicRbacHandler::class);
+		$this->organizationHandler = $this->createMock(MagicOrganizationHandler::class);
+		$this->db->method('getDatabasePlatform')->willReturn(new MariaDBPlatform());
+
+		$this->handler = new MagicSearchHandler(
+			db: $this->db,
+			logger: $this->logger,
+			rbacHandler: $this->rbacHandler,
+			organizationHandler: $this->organizationHandler,
+			schemaTypeConverter: new SchemaTypeConverter(),
+			dateTimeNormalizer: new DateTimeNormalizer($this->logger)
+		);
+	}//end setUp()
+
+	/**
+	 * Build a connection mock whose quote() wraps values in single quotes.
+	 */
+	private function makeConnection(): object {
+		$conn = $this->createMock(IDBConnection::class);
+		$conn->method('quote')->willReturnCallback(fn ($v) => "'{$v}'");
+		return $conn;
+	}//end makeConnection()
+
+	/**
+	 * Invoke the private buildRelationFilterConditionsSql() via reflection.
+	 *
+	 * @param array<string,mixed> $query Search query.
+	 *
+	 * @return string[] Generated SQL conditions.
+	 */
+	private function invokeRelationFilters(array $query): array {
+		$method = new ReflectionMethod(MagicSearchHandler::class, 'buildRelationFilterConditionsSql');
+		$method->setAccessible(true);
+		return $method->invoke($this->handler, $query, $this->makeConnection());
+	}//end invokeRelationFilters()
+
+	public function testUnionBranchEmitsPortableJsonFunctionsOnMariaDb(): void {
+		$conditions = $this->invokeRelationFilters(['_relations.author' => 'person-42']);
+
+		$this->assertCount(1, $conditions);
+		$sql = $conditions[0];
+
+		// MariaDB fallback must be free of PostgreSQL-only syntax so the query
+		// stops raising SQLSTATE[42601] on non-Postgres deployments.
+		$this->assertStringNotContainsString('jsonb_typeof', $sql);
+		$this->assertStringNotContainsString('to_jsonb', $sql);
+		$this->assertStringNotContainsString('@>', $sql);
+		$this->assertStringNotContainsString('::text', $sql);
+
+		// It must still filter on the referenced id VALUE and its named field
+		// (mirroring the semantics locked by the sibling PG test).
+		$this->assertStringContainsString("JSON_EXTRACT(_relations, CONCAT('\$.', 'author'))", $sql);
+		$this->assertStringContainsString("'person-42'", $sql);
+		$this->assertStringContainsString("JSON_SEARCH(_relations, 'one', 'person-42', NULL, CONCAT('\$.', 'author.%'))", $sql);
+		// Legacy array shape still matches (JSON_CONTAINS on the whole array).
+		$this->assertStringContainsString('JSON_CONTAINS(_relations, JSON_QUOTE(\'person-42\'))', $sql);
+	}//end testUnionBranchEmitsPortableJsonFunctionsOnMariaDb()
+
+	public function testMultipleRelationFiltersEachCarryTheirOwnValueOnMariaDb(): void {
+		$conditions = $this->invokeRelationFilters(
+			[
+				'_relations.author' => 'person-1',
+				'_relations.reviewer' => 'person-2',
+			]
+		);
+
+		$this->assertCount(2, $conditions);
+		$this->assertStringContainsString("'person-1'", $conditions[0]);
+		$this->assertStringContainsString("'author'", $conditions[0]);
+		$this->assertStringContainsString("'person-2'", $conditions[1]);
+		$this->assertStringContainsString("'reviewer'", $conditions[1]);
+	}//end testMultipleRelationFiltersEachCarryTheirOwnValueOnMariaDb()
+
+	public function testMariaDbBranchDropsPostgresJsonbSyntaxAcrossAllConditions(): void {
+		// Regression against the pre-WOO-548 bug: even multiple filters must
+		// each land in the MariaDB branch, no straggler PG syntax anywhere.
+		$conditions = $this->invokeRelationFilters(
+			[
+				'_relations.author' => 'a',
+				'_relations.reviewer' => 'b',
+				'_relations.editor' => 'c',
+			]
+		);
+		foreach ($conditions as $sql) {
+			$this->assertStringNotContainsString('jsonb_typeof', $sql);
+			$this->assertStringNotContainsString('to_jsonb', $sql);
+			$this->assertStringNotContainsString('@>', $sql);
+		}
+	}//end testMariaDbBranchDropsPostgresJsonbSyntaxAcrossAllConditions()
+
+}//end class

--- a/tests/Unit/Db/MagicSearchHandlerRelationsFilterMariaDbTest.php
+++ b/tests/Unit/Db/MagicSearchHandlerRelationsFilterMariaDbTest.php
@@ -3,11 +3,14 @@
 /**
  * WOO-548 regression: `_relations.<field>` VALUE-filtering on MariaDB/MySQL.
  *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
  * @category Test
  * @package  OCA\OpenRegister\Tests\Unit\Db
  *
- * @author    Conduction Development Team <info@conduction.nl>
- * @copyright 2024 Conduction B.V.
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @version GIT: <git-id>
@@ -145,5 +148,34 @@ class MagicSearchHandlerRelationsFilterMariaDbTest extends TestCase {
 			$this->assertStringNotContainsString('@>', $sql);
 		}
 	}//end testMariaDbBranchDropsPostgresJsonbSyntaxAcrossAllConditions()
+
+	/**
+	 * `applyRelationsContainsFilter` is the direct consumer of the
+	 * `_relations_contains` public query filter (WOO-536 Stap 5a). Lock its
+	 * MariaDB shape so a future refactor can't silently regress the two-line
+	 * fallback back into PG syntax.
+	 */
+	public function testRelationsContainsFilterEmitsPortableJsonSearchOnMariaDb(): void {
+		$qb = $this->createMock(\OCP\DB\QueryBuilder\IQueryBuilder::class);
+		$captured = '';
+		$qb->method('createNamedParameter')->willReturnCallback(
+			fn ($v) => "'{$v}'"
+		);
+		$qb->method('andWhere')->willReturnCallback(
+			function (string $sql) use (&$captured) {
+				$captured = $sql;
+			}
+		);
+
+		$method = new ReflectionMethod(MagicSearchHandler::class, 'applyRelationsContainsFilter');
+		$method->setAccessible(true);
+		$method->invoke($this->handler, $qb, 'uuid-abc');
+
+		$this->assertStringNotContainsString('jsonb_typeof', $captured);
+		$this->assertStringNotContainsString('to_jsonb', $captured);
+		$this->assertStringNotContainsString('@>', $captured);
+		$this->assertStringContainsString("JSON_SEARCH(t._relations, 'one', 'uuid-abc')", $captured);
+		$this->assertStringContainsString('IS NOT NULL', $captured);
+	}//end testRelationsContainsFilterEmitsPortableJsonSearchOnMariaDb()
 
 }//end class

--- a/tests/Unit/Db/MagicSearchHandlerRelationsFilterTest.php
+++ b/tests/Unit/Db/MagicSearchHandlerRelationsFilterTest.php
@@ -19,6 +19,8 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Tests\Unit\Db;
 
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use OCA\OpenRegister\Db\MagicMapper\MagicOrganizationHandler;
 use OCA\OpenRegister\Db\MagicMapper\MagicRbacHandler;
 use OCA\OpenRegister\Db\MagicMapper\MagicSearchHandler;
@@ -59,6 +61,10 @@ class MagicSearchHandlerRelationsFilterTest extends TestCase {
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->rbacHandler = $this->createMock(MagicRbacHandler::class);
 		$this->organizationHandler = $this->createMock(MagicOrganizationHandler::class);
+		// Existing assertions here lock in the PostgreSQL SQL shape — pin the
+		// platform mock accordingly. Tests exercising the MariaDB fallback path
+		// override the platform inline (see the WOO-548 MariaDB branch below).
+		$this->db->method('getDatabasePlatform')->willReturn(new PostgreSQLPlatform());
 
 		$this->handler = new MagicSearchHandler(
 			db: $this->db,


### PR DESCRIPTION
## Samenvatting

Drie methodes in `MagicSearchHandler` emitten PostgreSQL-only `jsonb_typeof(...)`, `to_jsonb(...::text)` en JSON-containment `@>` zonder platform-check:

- `applyRelationsContainsFilter` (single-schema pad, `_relations_contains`)
- `applyRelationFieldFilter` (single-schema, dotted-field `_relations.<field>`)
- `buildRelationFilterConditionsSql` (UNION-pad, multi-schema search + facets)

Op MariaDB / MySQL raise dit `SQLSTATE[42601]` óf retourneert stil een lege set. WOO-536 Stap 5a (OpenCatalogi's public search) consumeert `_relations_contains` op elke document-refinement, dus het defect surface op elke `/api/search` request op non-Postgres deploys.

## Aanpak

Volgt het WOO-544 patroon (openregister#3197): branch op `isPostgresPlatform()`, behoud de bestaande jsonb-SQL op Postgres.

MariaDB/MySQL fallback:
- `applyRelationsContainsFilter` gebruikt `JSON_SEARCH(..., 'one', ...)` — walkt zowel array- als object-shape natively.
- `applyRelationFieldFilter` / `buildRelationFilterConditionsSql` combineren `JSON_EXTRACT` op de exacte pad, `JSON_SEARCH` scoped op de array-geïndexeerde `$.<field>.%` sub-pad, en `JSON_CONTAINS` voor de legacy top-level-array shape.

Alles beschikbaar op MariaDB 10.2+ / MySQL 5.7+, beide vereist door de Nextcloud baseline.

## Design keuze — waarom `JSON_SEARCH` als hoofdcontract

Voor `applyRelationsContainsFilter` was de PG-versie een expliciete OR tussen array- en object-shape. `JSON_SEARCH(_relations, 'one', ${uuid}) IS NOT NULL` doet beide in één functie-aanroep zonder een `JSON_TYPE`-branch — semantisch gelijk aan de PG jsonb variant, korter, en niet stiller.

Voor de field-specific varianten was `JSON_SEARCH` alléén niet voldoende (moet gescoped op field-naam), dus daar behouden we de drieledige OR (`JSON_EXTRACT` exact + `JSON_SEARCH` scoped path + `JSON_CONTAINS` legacy array).

## Tests

- 11/11 groen (`OPENREGISTER_TEST_SKIP_NC=1 ./vendor/bin/phpunit --filter MagicSearchHandlerRelationsFilter`)
- Bestaande PG-shape test pin nu de platform mock op Postgres in `setUp`, zodat de hard-coded assertions blijven werken
- Nieuwe `MagicSearchHandlerRelationsFilterMariaDbTest` fixt de platform op MariaDB en verifieert dat de SQL vrij is van PG-syntaxis + de verwachte `JSON_` builtins draagt

## Test plan

- [ ] MariaDB-instance smoke: `GET /apps/opencatalogi/api/search?_search=<term>&_content=true` — geen SQLSTATE meer in logs, resultaten conform PG
- [ ] `GET /apps/opencatalogi/api/publications/<catalog>/<pub>` met docs — document→publication resolution werkt (M2 fast-path relations lookup)
- [ ] Postgres regressie: bestaande workflow ongewijzigd

## Follow-up (niet in deze PR)

WOO-548 zelf beschrijft alleen deze 3 methodes. Andere PG-syntax hotspots in de bredere `MagicSearchHandler` (bijv. `applyFullTextSearch` fuzzy-branch) waren al platform-guarded in WOO-544 en zijn buiten scope hier.

Ref: [WOO-548](https://conduction.atlassian.net/browse/WOO-548), parent [WOO-536](https://conduction.atlassian.net/browse/WOO-536)

Related: openregister#3197 (WOO-544 base pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WOO-548]: https://conduction.atlassian.net/browse/WOO-548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ