### PR TITLE
fix(e2e): give occ a maxBuffer so the worker scenarios stop self-skipping

### DIFF
--- a/tests/e2e/api-direct/flow-user-task.spec.ts
+++ b/tests/e2e/api-direct/flow-user-task.spec.ts
@@ -63,6 +63,13 @@ function occ(args: string): string {
 	}
 	return execSync(`docker exec -u www-data ${CONTAINER} php occ ${args}`, {
 		encoding: 'utf8',
+		// `background-job:list` prints every job's serialized argument in one
+		// table; on a live instance that is well past Node's 1 MiB execSync
+		// default. The overflow throws ENOBUFS, the catch in runWorkerJobId()
+		// returns null, and the worker-driven scenarios self-skip as "occ not
+		// reachable" while occ is fine. Measured 1.8 MiB on a fresh proof
+		// instance, 2026-09-01.
+		maxBuffer: 32 * 1024 * 1024,
 	})
 }
 


### PR DESCRIPTION
On a live instance `occ background-job:list` prints 1.8 MiB (every job's serialized argument), past Node's 1 MiB `execSync` default. The overflow threw, `runWorkerJobId()` caught it into `null`, and the worker-driven scenarios of `flow-user-task.spec.ts` self-skipped as *occ not reachable* while occ was fine — a skip that reads as an environment limitation instead of a lost scenario.

One change: the `occ()` helper passes `maxBuffer: 32 MiB`.

Verified on the dossiq proof instance (8614): before the fix, scenario 3 ('completing a task from the inbox advances its flow run') skipped on every run; after it, the scenario runs and **passes**, including the worker half. Found during the 2026-09-01 dossiq case-flow acceptance run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)