### PR TITLE
fix(e2e): follow the router off hash routing in the three specs that lagged it

### DIFF
--- a/tests/e2e/ci/flow-controls.spec.ts
+++ b/tests/e2e/ci/flow-controls.spec.ts
@@ -504,7 +504,7 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 		// The route still has to catch up, or a reload lands back on `new`. With
 		// the create already asserted above this is a pure router assertion with
 		// no round-trip left in it, so it needs a fraction of the old budget.
-		await page.waitForURL(new RegExp(`#/flows/${uuid}$`), {
+		await page.waitForURL(new RegExp(`/flows/${uuid}$`), {
 			timeout: 5_000,
 		})
 

--- a/tests/e2e/docs-screenshots.spec.ts
+++ b/tests/e2e/docs-screenshots.spec.ts
@@ -112,8 +112,9 @@ async function dismissOverlays(page: Page): Promise<void> {
 
 /** Navigate to an OR (or absolute) route and settle. */
 async function go(page: Page, route: string): Promise<void> {
-	// OR routes use HASH form — the router runs in hash mode (src/main.js);
-	// path-form deep-links render the dashboard instead of the target page.
+	// OR routes use PATH form. They used to be hash routes, and a path deep-link
+	// then rendered the dashboard instead of the target page; #3270 moved the
+	// router to createWebHistory and inverted that.
 	const url =
 		route.startsWith('/apps/') || route.startsWith('/settings/')
 			? `/index.php${route}`
@@ -295,7 +296,7 @@ test.describe('docs: user track', () => {
 		}
 
 		const route =
-			reg && sch ? `/#/tables?register=${reg}&schema=${sch}` : '/#/tables'
+			reg && sch ? `/tables?register=${reg}&schema=${sch}` : '/tables'
 		await go(page, route)
 		// Wait for the deep-linked register/schema selection to actually apply
 		// (SearchSideBar.applyQueryParamsFromRoute retries while the register

--- a/tests/e2e/manifest-shell.spec.ts
+++ b/tests/e2e/manifest-shell.spec.ts
@@ -182,6 +182,13 @@ test.describe('openregister-app-manifest — registry dispatch', () => {
 		page,
 	}) => {
 		requireAuth()
+		// Eighteen routes, and since `feat(router): move openregister off hash
+		// routing` (#3270) each one is a full document load rather than a
+		// same-document hash change — the app boots eighteen times, not once.
+		// The default budget was sized for the cheap version and now runs out
+		// around the eleventh route, which surfaces as a teardown error
+		// ("session closed") against whichever route it happened to reach.
+		test.setTimeout(180_000)
 		// One representative route per top-level manifest destination. Each must
 		// resolve through CnPageRenderer → registry kind:"page" entry and render
 		// the app-content shell (lists may be empty against a fresh instance).


### PR DESCRIPTION
## What

The two E2E failures on `development` (run 33537803790: **2 failed / 65 passed**) are both fallout from `#3270`, which moved openregister to `createWebHistory`.

## The two failures

`flow-controls.spec.ts:507` waited for `#/flows/<uuid>`. The log shows the browser had already navigated to `/index.php/apps/openregister/flows/<uuid>`, the path form. The wait could never match, so it burned its 5s and failed.

`manifest-shell.spec.ts:181` walks eighteen routes in a single test. Under hash routing only the first was a document load and the rest were same-document hash changes. Now every one boots the app. The budget was sized for the cheap version and runs out around the eleventh route, `/deleted`. It reported `Protocol error … session closed` and `Received: undefined`, which reads like a browser crash. It is the context being torn down after `Test timeout of 45000ms exceeded`. Raised to 180s, matching `integration-mount.spec.ts`.

## Also fixed

`docs-screenshots.spec.ts` built one `/#/tables` route while every other `go()` call in the same file already used the path form, and its helper comment still asserted the router ran in hash mode.

## Deliberately not changed

Test titles in `core-crud` and `ui-navigation` still read `#/registers`. Those tests navigate by path already, so the names are merely stale. Renaming them moves test ids that spec-coverage keys on.

## Noted, not fixed here

`TaskController::open()` (`lib/Controller/TaskController.php:169`) still redirects to `…/#/flow-tasks/<uuid>`. That is the calendar VTODO deep link. Two things are wrong with it and neither is mine to guess at: the hash form no longer routes, and there is no `/flow-tasks` route declared in the manifest at all. `task-projections.spec.ts:164` asserts only the redirect's `Location` header, so it passes either way. Worth a separate issue.

## Verification

`eslint` and `prettier --check` clean on all three files; `playwright test --list` collects 216 tests. The suite needs an instance serving this build, so CI is the measurement.
