### PR TITLE
fix(flow): the await-signal answer lands in the item's record, not beside it

### DIFF
--- a/lib/Service/Flow/Nodes/AwaitSignalNode.php
+++ b/lib/Service/Flow/Nodes/AwaitSignalNode.php
@@ -27,9 +27,9 @@
  *
  * WHAT COUNTS AS AN ANSWER. The payload posted to the resume endpoint lands at
  * `context.signal`. This node reads `decision` from it and writes the whole
- * payload onto every item under `signalKey`, so the steps after it can branch on
- * what was decided and see who decided it. A resume with no `decision` is a
- * nudge, not an answer: the node suspends again. That is what makes an
+ * payload into every item's record under `json.<signalKey>`, so the steps after
+ * it can branch on what was decided and see who decided it. A resume with no
+ * `decision` is a nudge, not an answer: the node suspends again. That is what makes an
  * accidental or duplicate POST harmless.
  *
  * REJECTION IS NOT FAILURE. A rejected approval is the flow working correctly —
@@ -301,15 +301,19 @@ class AwaitSignalNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfig
 			$key = 'signal';
 		}
 
-		// Onto every item rather than into the token, because the steps that
-		// follow route per item; a Switch cannot branch on something only the
-		// run holds.
+		// Into every item's record (`json`), not beside it, and not into the
+		// token: the steps that follow route per item and read `json.<key>`
+		// (FlowExpression::dataFor exposes json.*, and a rebuilding node like
+		// set-fields keeps only [json, binary]). A key at the envelope level
+		// is invisible to a Switch and silently dropped by the next rebuild.
 		foreach ($items as $index => $item) {
 			if (is_array($item) === false) {
 				continue;
 			}
 
-			$item[$key] = $signal;
+			$json = (array)($item[FlowItems::JSON] ?? []);
+			$json[$key] = $signal;
+			$item[FlowItems::JSON] = $json;
 			$items[$index] = $item;
 		}
 

--- a/tests/Unit/Service/Flow/AwaitSignalNodeTest.php
+++ b/tests/Unit/Service/Flow/AwaitSignalNodeTest.php
@@ -16,6 +16,7 @@ use OCA\OpenRegister\Service\Flow\FlowRunService;
 use OCA\OpenRegister\Service\Flow\FlowStop;
 use OCA\OpenRegister\Service\Flow\FlowSuspension;
 use OCA\OpenRegister\Service\Flow\Nodes\AwaitSignalNode;
+use OCA\OpenRegister\Service\Flow\Nodes\SetFieldsNode;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -113,9 +114,28 @@ class AwaitSignalNodeTest extends TestCase {
 
 		$this->assertCount(2, $out);
 		foreach ($out as $item) {
-			$this->assertSame('approve', $item['signal']['decision']);
-			$this->assertSame('ruben', $item['signal']['by']);
+			$this->assertSame('approve', $item[FlowItems::JSON]['signal']['decision']);
+			$this->assertSame('ruben', $item[FlowItems::JSON]['signal']['by']);
 		}
+	}
+
+	/**
+	 * WHERE the answer lands is part of the contract: inside the item's record
+	 * (`json.<key>`), never beside it at the envelope level. The engine's
+	 * expression data (FlowExpression::dataFor) exposes `json.*` only, and a
+	 * rebuilding node keeps only `[json, binary]` — an envelope-level key is
+	 * invisible to a Switch and silently dropped by the next rebuild.
+	 */
+	public function testTheAnswerLandsInsideTheItemsRecordNotBesideIt(): void {
+		$out = $this->node->execute(
+			$this->items([['id' => 1]]),
+			['question' => 'Publish it?'],
+			[FlowRunService::SIGNAL_CONTEXT_KEY => ['decision' => 'approve']]
+		);
+
+		$this->assertArrayNotHasKey('signal', $out[0], 'the answer must not sit at the envelope level');
+		$this->assertSame('approve', $out[0][FlowItems::JSON]['signal']['decision']);
+		$this->assertSame(1, $out[0][FlowItems::JSON]['id'], 'the record itself is kept, not replaced');
 	}
 
 	/**
@@ -130,8 +150,8 @@ class AwaitSignalNodeTest extends TestCase {
 			[FlowRunService::SIGNAL_CONTEXT_KEY => ['decision' => 'approve']]
 		);
 
-		$this->assertSame('approve', $out[0]['legalReview']['decision']);
-		$this->assertArrayNotHasKey('signal', $out[0]);
+		$this->assertSame('approve', $out[0][FlowItems::JSON]['legalReview']['decision']);
+		$this->assertArrayNotHasKey('signal', $out[0][FlowItems::JSON]);
 	}
 
 	/**
@@ -177,7 +197,7 @@ class AwaitSignalNodeTest extends TestCase {
 			[FlowRunService::SIGNAL_CONTEXT_KEY => ['decision' => 'reject', 'reason' => 'not ready']]
 		);
 
-		$this->assertSame('reject', $out[0]['signal']['decision']);
+		$this->assertSame('reject', $out[0][FlowItems::JSON]['signal']['decision']);
 	}
 
 	/**
@@ -264,5 +284,33 @@ class AwaitSignalNodeTest extends TestCase {
 		foreach ($this->node->configForm() as $field) {
 			$this->assertContains($field['key'], $keys);
 		}
+	}
+
+	/**
+	 * The regression that motivated json-level placement: set-fields rebuilds
+	 * every item as `[json, binary]`, so an answer written at the envelope
+	 * level did not survive the very next step. The flow in
+	 * flow-user-task.spec.ts (two gates, then set-fields) read
+	 * `item.firstGate` as undefined for exactly this reason.
+	 */
+	public function testTheAnswerSurvivesASetFieldsRebuild(): void {
+		$answered = $this->node->execute(
+			$this->items([['id' => 1]]),
+			['question' => 'First gate?', 'signalKey' => 'firstGate'],
+			[FlowRunService::SIGNAL_CONTEXT_KEY => ['decision' => 'approved', 'mark' => 'first']]
+		);
+
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnArgument(0);
+		$setFields = new SetFieldsNode($l10n, $this->createMock(IURLGenerator::class));
+
+		$out = $setFields->execute($answered, ['set' => ['finished' => true]], []);
+
+		$this->assertTrue($out[0][FlowItems::JSON]['finished']);
+		$this->assertSame(
+			'first',
+			$out[0][FlowItems::JSON]['firstGate']['mark'] ?? null,
+			'the gate answer must survive the set-fields rebuild'
+		);
 	}
 }

--- a/tests/Unit/Service/Integration/Providers/LeafProvidersMetadataTest.php
+++ b/tests/Unit/Service/Integration/Providers/LeafProvidersMetadataTest.php
@@ -513,7 +513,7 @@ class LeafProvidersMetadataTest extends TestCase {
 	 *
 	 * @return array<string,array{0: string, 1: string, 2: string, 3: string, 4: ?string, 5: string}>
 	 */
-	public function greenfieldStubProvider(): array {
+	public static function greenfieldStubProvider(): array {
 		// [class, id, label, icon, group, requiredApp, storage]
 		return [
 			'activity' => [ActivityProvider::class, 'activity', 'Activity', 'Timeline', 'workflow', 'activity', 'query-time'],

--- a/tests/Unit/Service/MagicMapperTest.php
+++ b/tests/Unit/Service/MagicMapperTest.php
@@ -282,7 +282,7 @@ class MagicMapperTest extends TestCase {
 	 *
 	 * @return array<string, array<mixed>>
 	 */
-	public function registerSchemaTableNameProvider(): array {
+	public static function registerSchemaTableNameProvider(): array {
 		return [
 			'basic_combination' => [
 				'registerId' => 1,
@@ -334,7 +334,7 @@ class MagicMapperTest extends TestCase {
 	 *
 	 * @return array<string, array<mixed>>
 	 */
-	public function magicMappingConfigProvider(): array {
+	public static function magicMappingConfigProvider(): array {
 		return [
 			'enabled_in_schema' => [
 				'schemaConfig' => ['magicMapping' => true],
@@ -396,7 +396,7 @@ class MagicMapperTest extends TestCase {
 	 *
 	 * @return array<string, array<string, string>>
 	 */
-	public function columnSanitizationProvider(): array {
+	public static function columnSanitizationProvider(): array {
 		return [
 			'simple_name' => [
 				'input' => 'name',
@@ -498,7 +498,7 @@ class MagicMapperTest extends TestCase {
 	 *
 	 * @return array<string, array<mixed>>
 	 */
-	public function schemaPropertyMappingProvider(): array {
+	public static function schemaPropertyMappingProvider(): array {
 		return [
 			'string_property' => [
 				'propertyConfig' => ['type' => 'string'],
@@ -748,7 +748,7 @@ class MagicMapperTest extends TestCase {
 
 		$tableExistsCache = $reflection->getProperty('tableExistsCache');
 		$tableExistsCache->setAccessible(true);
-		$tableExistsCache->setValue(['test_table' => time()]);
+		$tableExistsCache->setValue(null, ['test_table' => time()]);
 
 		// Test full cache clear.
 		$this->magicMapper->clearCache();
@@ -757,7 +757,7 @@ class MagicMapperTest extends TestCase {
 		$this->assertEquals([], $tableExistsCache->getValue());
 
 		// Test targeted cache clear.
-		$tableExistsCache->setValue(['1_1' => time()]);
+		$tableExistsCache->setValue(null, ['1_1' => time()]);
 		$this->magicMapper->clearCache(1, 1);
 
 		// Should clear specific cache entry.


### PR DESCRIPTION
## What

AwaitSignalNode wrote its resume payload at the item envelope level (`$item[$key] = $signal`) while flow items are `{json, binary}` envelopes. Nothing downstream could see the answer: `FlowExpression::dataFor` exposes `json.*` only, so a Switch could not branch on it, and SetFieldsNode rebuilds every item as `[json, binary]`, dropping the stray key entirely. The two-gates e2e in `flow-user-task.spec.ts` read `item.firstGate` as undefined for exactly this reason, and the user-task node's own report already flagged that the 'Switch can branch on it' claim was not true.

The payload now lands at `json.<signalKey>`, matching where UserTaskNode places its outcome bag.

## Readers of the old shape

Checked every reader of the envelope-level key in `lib/` and `tests/`: the only consumers were AwaitSignalNode's own unit tests, now updated. `FlowEngineResumeScopeTest`'s scoped-ask stub already wrote into `json`, and `recordRequest` reads `$item[FlowItems::JSON] ?? $item`, so no backward tolerance for the old shape is kept: nothing in production ever consumed it.

## Tests

- `testTheAnswerLandsInsideTheItemsRecordNotBesideIt` pins json-level placement and that the record itself is preserved.
- `testTheAnswerSurvivesASetFieldsRebuild` chains the node into SetFieldsNode and proves the answer survives the rebuild.
- The red e2e `flow-user-task.spec.ts:584` (two gates, then set-fields) now passes against the live dev instance, and was re-run without the fix to confirm it goes red again. The full `flow-user-task.spec.ts` suite is green. Five `flow-engine.spec.ts` tests fail identically with and without this change (422 on `POST /api/flows` at createFlow), so they are pre-existing on development.

## Also fixed in passing

Five non-static PHPUnit data providers (MagicMapperTest, LeafProvidersMetadataTest) and two single-argument `ReflectionProperty::setValue()` calls on a static property, all flagged as deprecations by PHPUnit 10.

## Checks

- composer lint, phpcs, PHPMD (per lib/ subdirectory, both configs), Psalm, PHPStan (2G): all pass
- PHPUnit Unit Tests: 18957 tests, 46152 assertions, 0 failures
- hydra gates `--scope-to-diff --base origin/development`: exit 0, 0 FAIL, 29 of 29 applicable gates ran

🤖 Generated with [Claude Code](https://claude.com/claude-code)