### PR TITLE
feat(flow): a decision-table node puts rule evaluation into the graph

### DIFF
--- a/lib/Listener/FlowNodeRegistrationListener.php
+++ b/lib/Listener/FlowNodeRegistrationListener.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Listener;
 
 use OCA\OpenRegister\Service\Flow\Nodes\AwaitSignalNode;
+use OCA\OpenRegister\Service\Flow\Nodes\DecisionTableNode;
 use OCA\OpenRegister\Service\Flow\Nodes\EndNode;
 use OCA\OpenRegister\Service\Flow\Nodes\ExplodeNode;
 use OCA\OpenRegister\Service\Flow\Nodes\FilterNode;
@@ -89,6 +90,7 @@ class FlowNodeRegistrationListener implements IEventListener {
 	 * @param TriggerManualNode $triggerManual The "When someone runs it" entry point.
 	 * @param UserTaskNode $userTask The built-in "Ask a person" node.
 	 * @param PortalTaskNode $portalTask The built-in "Ask a party outside the organisation" node.
+	 * @param DecisionTableNode $decisionTable The built-in "Evaluate a decision table" node.
 	 */
 	public function __construct(
 		private readonly SetFieldsNode $setFields,
@@ -115,6 +117,7 @@ class FlowNodeRegistrationListener implements IEventListener {
 		private readonly TriggerManualNode $triggerManual,
 		private readonly UserTaskNode $userTask,
 		private readonly PortalTaskNode $portalTask,
+		private readonly DecisionTableNode $decisionTable,
 	) {
 
 	}//end __construct()
@@ -149,6 +152,13 @@ class FlowNodeRegistrationListener implements IEventListener {
 		$event->registerNode(node: $this->flowState);
 		$event->registerNode(node: $this->map);
 		$event->registerNode(node: $this->iterate);
+
+		// The rule step (flow-decision-tables). Registered with the data
+		// reshapers rather than the waiters, deliberately: it decides and
+		// moves on in one firing. A decision that needs a person is the
+		// user task below, and the split is the fleet's directive - rule
+		// evaluation is the engine's, human decisions are decidiq's.
+		$event->registerNode(node: $this->decisionTable);
 
 		// Messaging. Three nodes, not one "send" with a channel picker: the
 		// three differ in config shape and failure modes, so three flat forms

--- a/lib/Service/Dmn/DecisionTableEvaluator.php
+++ b/lib/Service/Dmn/DecisionTableEvaluator.php
@@ -38,11 +38,6 @@ namespace OCA\OpenRegister\Service\Dmn;
 class DecisionTableEvaluator {
 
 	/**
-	 * Hit policies fully implemented by this engine.
-	 *
-	 * @var string[]
-	 */
-	/**
 	 * The hit policies this evaluator implements.
 	 *
 	 * PRIORITY is here because openbuild's evaluator had it and dossiq's did
@@ -51,9 +46,13 @@ class DecisionTableEvaluator {
 	 * tables can already use it. This list is the union of the two, not the
 	 * intersection.
 	 *
+	 * Public so that {@see DecisionTableValidator} refuses exactly the
+	 * policies this class refuses. A second list would drift; the constant
+	 * cannot.
+	 *
 	 * @var array<int, string>
 	 */
-	private const IMPLEMENTED_HIT_POLICIES = ['UNIQUE', 'FIRST', 'COLLECT', 'PRIORITY', 'ANY'];
+	public const IMPLEMENTED_HIT_POLICIES = ['UNIQUE', 'FIRST', 'COLLECT', 'PRIORITY', 'ANY'];
 
 	/**
 	 * Common spellings of the declared column types, mapped onto this
@@ -401,6 +400,31 @@ class DecisionTableEvaluator {
 	}//end applyHitPolicy()
 
 	/**
+	 * The type a declared column type actually evaluates under.
+	 *
+	 * Applies {@see TYPE_ALIASES} and the string fallback in one place.
+	 * Public because {@see DecisionTableValidator} probes every rule cell
+	 * with a value of the column's effective type; if it normalised types
+	 * itself, the validator and the evaluator could disagree about what a
+	 * column means, which is the drift this method exists to prevent.
+	 *
+	 * @param string $type The declared column type, any spelling.
+	 *
+	 * @return string One of {@see UnaryTestEvaluator::VALID_TYPES}.
+	 *
+	 * @spec openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md#requirement-a-table-the-evaluator-cannot-execute-is-refused-at-save
+	 */
+	public static function effectiveType(string $type): string {
+		$lower = strtolower($type);
+		$lower = (self::TYPE_ALIASES[$lower] ?? $lower);
+		if (in_array($lower, UnaryTestEvaluator::VALID_TYPES, true) === false) {
+			return 'string';
+		}
+
+		return $lower;
+	}//end effectiveType()
+
+	/**
 	 * Normalise a decision table's `inputs`/`outputs` array into a clean
 	 * positional list of `{name, type}`.
 	 *
@@ -420,13 +444,7 @@ class DecisionTableEvaluator {
 				continue;
 			}
 
-			$type = strtolower((string)($field['type'] ?? 'string'));
-			$type = (self::TYPE_ALIASES[$type] ?? $type);
-			if (in_array($type, UnaryTestEvaluator::VALID_TYPES, true) === false) {
-				$type = 'string';
-			}
-
-			$result[] = ['name' => $name, 'type' => $type];
+			$result[] = ['name' => $name, 'type' => self::effectiveType(type: (string)($field['type'] ?? 'string'))];
 		}
 
 		return $result;

--- a/lib/Service/Dmn/DecisionTableValidator.php
+++ b/lib/Service/Dmn/DecisionTableValidator.php
@@ -1,0 +1,278 @@
+<?php
+
+/**
+ * OpenRegister decision-table validator.
+ *
+ * Structural and grammar validation of a decision-table definition, for the
+ * save path. The grammar half does not parse anything itself: every rule
+ * cell is EXECUTED through {@see UnaryTestEvaluator::matches()} with a probe
+ * value of the column's effective type, so the accepted grammar is the
+ * executable grammar by construction. A parallel parser here would be a
+ * second opinion that can drift, and a cell it wrongly accepted would fail
+ * at run time in a scheduled flow at 03:00 instead of in the editor.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Dmn
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md#requirement-a-table-the-evaluator-cannot-execute-is-refused-at-save
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Dmn;
+
+/**
+ * Says, at save time, whether the evaluator could execute a table.
+ *
+ * Returns problems rather than throwing, so a caller can show every defect
+ * in one refusal instead of one per save attempt.
+ *
+ * @spec openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md#requirement-a-table-the-evaluator-cannot-execute-is-refused-at-save
+ */
+class DecisionTableValidator {
+
+	/**
+	 * One already-coerced probe value per effective type, used to exercise
+	 * every rule cell through the evaluator's own grammar. The probe's VALUE
+	 * is irrelevant — a cell may match it or not — only the parse matters:
+	 * `invalid_expression` and `type_mismatch` surface authoring errors, a
+	 * boolean answer means the grammar executed.
+	 *
+	 * @var array<string, string|float|bool|int>
+	 */
+	private const PROBES = [
+		'string'  => '',
+		'number'  => 0.0,
+		'boolean' => false,
+		'date'    => 0,
+	];
+
+	/**
+	 * Constructor.
+	 *
+	 * @param UnaryTestEvaluator $evaluator The grammar being validated against, never re-implemented.
+	 */
+	public function __construct(
+		private readonly UnaryTestEvaluator $evaluator = new UnaryTestEvaluator(),
+	) {
+	}//end __construct()
+
+	/**
+	 * Validate a decision-table definition.
+	 *
+	 * @param array<string, mixed> $table The table definition (`hitPolicy`, `inputs`, `outputs`, `rules`).
+	 *
+	 * @return array<int, string> Problems, each naming the offending part. Empty means the evaluator can execute the table.
+	 *
+	 * @spec openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md#requirement-a-table-the-evaluator-cannot-execute-is-refused-at-save
+	 */
+	public function validate(array $table): array {
+		$problems = [];
+
+		$hitPolicy = strtoupper(trim((string)($table['hitPolicy'] ?? 'UNIQUE')));
+		if (in_array($hitPolicy, DecisionTableEvaluator::IMPLEMENTED_HIT_POLICIES, true) === false) {
+			$problems[] = sprintf(
+				'hit policy "%s" is not implemented; the implemented policies are %s',
+				$hitPolicy,
+				implode(', ', DecisionTableEvaluator::IMPLEMENTED_HIT_POLICIES)
+			);
+		}
+
+		$inputs = $this->validateColumns(raw: ($table['inputs'] ?? null), side: 'inputs', problems: $problems);
+		$outputs = $this->validateColumns(raw: ($table['outputs'] ?? null), side: 'outputs', problems: $problems);
+
+		$this->validateRules(
+			raw: ($table['rules'] ?? null),
+			inputs: $inputs,
+			outputCount: count($outputs),
+			problems: $problems
+		);
+
+		return $problems;
+	}//end validate()
+
+	/**
+	 * Validate one side's column declarations.
+	 *
+	 * An empty side is refused: a table with no inputs matches nothing in
+	 * particular and a table with no outputs decides nothing — both are the
+	 * silent no-op shape. A duplicate name is refused because evaluation
+	 * results are keyed by name, so two columns sharing one would silently
+	 * collapse into a single answer.
+	 *
+	 * @param mixed $raw The declared `inputs` or `outputs`.
+	 * @param string $side `inputs` or `outputs`, for the messages.
+	 * @param array<int, string> $problems Collected problems, appended to.
+	 *
+	 * @return array<int, array{name: string, type: string}> The usable columns, with effective types.
+	 *
+	 * @spec openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md#requirement-a-table-the-evaluator-cannot-execute-is-refused-at-save
+	 */
+	private function validateColumns(mixed $raw, string $side, array &$problems): array {
+		if (is_array($raw) === false || $raw === []) {
+			$problems[] = sprintf('the table declares no %s; it needs at least one', $side);
+
+			return [];
+		}
+
+		$columns = [];
+		$seen = [];
+		foreach (array_values($raw) as $position => $column) {
+			if (is_array($column) === false) {
+				$problems[] = sprintf('%s entry %d is not an object', $side, $position);
+				continue;
+			}
+
+			$name = trim((string)($column['name'] ?? ''));
+			if ($name === '') {
+				$problems[] = sprintf('%s entry %d has no name', $side, $position);
+				continue;
+			}
+
+			if (in_array($name, $seen, true) === true) {
+				$problems[] = sprintf('%s name "%s" is declared twice; results are keyed by name, so the columns would collapse', $side, $name);
+				continue;
+			}
+
+			$seen[] = $name;
+			$columns[] = [
+				'name' => $name,
+				'type' => DecisionTableEvaluator::effectiveType(type: (string)($column['type'] ?? 'string')),
+			];
+		}//end foreach
+
+		return $columns;
+	}//end validateColumns()
+
+	/**
+	 * Validate the rules: positional alignment, integer priority, and every
+	 * input cell executed through the evaluator's grammar.
+	 *
+	 * @param mixed $raw The declared `rules`.
+	 * @param array<int, array{name: string, type: string}> $inputs The declared inputs, positionally.
+	 * @param int $outputCount The declared output count.
+	 * @param array<int, string> $problems Collected problems, appended to.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md#requirement-a-table-the-evaluator-cannot-execute-is-refused-at-save
+	 */
+	private function validateRules(mixed $raw, array $inputs, int $outputCount, array &$problems): void {
+		if (is_array($raw) === false || $raw === []) {
+			$problems[] = 'the table declares no rules; a table that can never match decides nothing';
+
+			return;
+		}
+
+		foreach (array_values($raw) as $position => $rule) {
+			if (is_array($rule) === false) {
+				$problems[] = sprintf('rule %d is not an object', $position);
+				continue;
+			}
+
+			$ruleId = trim((string)($rule['id'] ?? '')) !== '' ? trim((string)$rule['id']) : ('#' . $position);
+			$this->validateRule(rule: $rule, ruleId: $ruleId, inputs: $inputs, outputCount: $outputCount, problems: $problems);
+		}
+
+	}//end validateRules()
+
+	/**
+	 * Validate one rule row.
+	 *
+	 * @param array<string, mixed> $rule The rule row.
+	 * @param string $ruleId The rule's id or position, for the messages.
+	 * @param array<int, array{name: string, type: string}> $inputs The declared inputs, positionally.
+	 * @param int $outputCount The declared output count.
+	 * @param array<int, string> $problems Collected problems, appended to.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md#requirement-a-table-the-evaluator-cannot-execute-is-refused-at-save
+	 */
+	private function validateRule(array $rule, string $ruleId, array $inputs, int $outputCount, array &$problems): void {
+		$inputEntries = is_array($rule['inputEntries'] ?? null) === true ? array_values($rule['inputEntries']) : [];
+		$outputEntries = is_array($rule['outputEntries'] ?? null) === true ? array_values($rule['outputEntries']) : [];
+
+		if (count($inputEntries) !== count($inputs)) {
+			// A short row would silently wildcard its missing tail: the
+			// evaluator reads an absent positional entry as `-`.
+			$problems[] = sprintf(
+				'rule %s has %d input entries for %d declared inputs; a short row would silently wildcard the missing columns',
+				$ruleId,
+				count($inputEntries),
+				count($inputs)
+			);
+		}
+
+		if (count($outputEntries) !== $outputCount) {
+			$problems[] = sprintf(
+				'rule %s has %d output entries for %d declared outputs',
+				$ruleId,
+				count($outputEntries),
+				$outputCount
+			);
+		}
+
+		if (array_key_exists('priority', $rule) === true && is_int($rule['priority']) === false) {
+			$problems[] = sprintf('rule %s has a non-integer priority', $ruleId);
+		}
+
+		foreach ($inputs as $columnPosition => $column) {
+			if (array_key_exists($columnPosition, $inputEntries) === false) {
+				continue;
+			}
+
+			$this->probeCell(
+				expression: (string)$inputEntries[$columnPosition],
+				column: $column,
+				ruleId: $ruleId,
+				problems: $problems
+			);
+		}
+
+	}//end validateRule()
+
+	/**
+	 * Execute one cell through the evaluator's grammar and record what it
+	 * refused. A boolean answer means the cell is executable; whether the
+	 * probe matched is deliberately ignored.
+	 *
+	 * @param string $expression The raw cell text.
+	 * @param array{name: string, type: string} $column The column it sits under.
+	 * @param string $ruleId The rule's id, for the messages.
+	 * @param array<int, string> $problems Collected problems, appended to.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md#requirement-a-table-the-evaluator-cannot-execute-is-refused-at-save
+	 */
+	private function probeCell(string $expression, array $column, string $ruleId, array &$problems): void {
+		try {
+			$this->evaluator->matches(
+				expression: $expression,
+				value: self::PROBES[$column['type']],
+				type: $column['type']
+			);
+		} catch (DecisionEvaluationException $e) {
+			$problems[] = sprintf(
+				'rule %s, column "%s": the cell "%s" cannot be executed (%s)',
+				$ruleId,
+				$column['name'],
+				$expression,
+				$e->getErrorCode()
+			);
+		}
+
+	}//end probeCell()
+}//end class

--- a/lib/Service/Dmn/DecisionTableValidator.php
+++ b/lib/Service/Dmn/DecisionTableValidator.php
@@ -118,6 +118,9 @@ class DecisionTableValidator {
 	 * @return array<int, array{name: string, type: string}> The usable columns, with effective types.
 	 *
 	 * @spec openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md#requirement-a-table-the-evaluator-cannot-execute-is-refused-at-save
+	 *
+	 * @SuppressWarnings(PHPMD.StaticAccess) `DecisionTableEvaluator::effectiveType()`
+	 * is static precisely so validator and evaluator share one normalisation.
 	 */
 	private function validateColumns(mixed $raw, string $side, array &$problems): array {
 		if (is_array($raw) === false || $raw === []) {
@@ -181,7 +184,11 @@ class DecisionTableValidator {
 				continue;
 			}
 
-			$ruleId = trim((string)($rule['id'] ?? '')) !== '' ? trim((string)$rule['id']) : ('#' . $position);
+			$ruleId = trim((string)($rule['id'] ?? ''));
+			if ($ruleId === '') {
+				$ruleId = ('#' . $position);
+			}
+
 			$this->validateRule(rule: $rule, ruleId: $ruleId, inputs: $inputs, outputCount: $outputCount, problems: $problems);
 		}
 
@@ -201,8 +208,15 @@ class DecisionTableValidator {
 	 * @spec openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md#requirement-a-table-the-evaluator-cannot-execute-is-refused-at-save
 	 */
 	private function validateRule(array $rule, string $ruleId, array $inputs, int $outputCount, array &$problems): void {
-		$inputEntries = is_array($rule['inputEntries'] ?? null) === true ? array_values($rule['inputEntries']) : [];
-		$outputEntries = is_array($rule['outputEntries'] ?? null) === true ? array_values($rule['outputEntries']) : [];
+		$inputEntries = [];
+		if (is_array($rule['inputEntries'] ?? null) === true) {
+			$inputEntries = array_values($rule['inputEntries']);
+		}
+
+		$outputEntries = [];
+		if (is_array($rule['outputEntries'] ?? null) === true) {
+			$outputEntries = array_values($rule['outputEntries']);
+		}
 
 		if (count($inputEntries) !== count($inputs)) {
 			// A short row would silently wildcard its missing tail: the

--- a/lib/Service/Flow/Nodes/DecisionTableNode.php
+++ b/lib/Service/Flow/Nodes/DecisionTableNode.php
@@ -1,0 +1,550 @@
+<?php
+
+/**
+ * Evaluate a decision table against every item.
+ *
+ * The flow engine's rule step: the table travels inline in the step's
+ * configuration, the shared {@see DecisionTableEvaluator} does the deciding,
+ * and the outputs land on the item so the next node can route on them. This
+ * node never suspends and never asks anybody anything: a decision that needs
+ * a person is `openregister.user-task`, not a rule.
+ *
+ * The configuration vocabulary (`inputMapping`/`outputMapping` with a
+ * same-name default) is dossiq's `evaluateDecision` handler's, kept verbatim
+ * so retiring the app-side copy is a mechanical rewrite rather than a
+ * translation.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow\Nodes
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow\Nodes;
+
+use OCA\OpenRegister\Service\Dmn\DecisionEvaluationException;
+use OCA\OpenRegister\Service\Dmn\DecisionTableEvaluator;
+use OCA\OpenRegister\Service\Dmn\DecisionTableValidator;
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\FlowValueTemplate;
+use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigForm;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\WorkflowEngine\IManager;
+use UnexpectedValueException;
+
+/**
+ * Decides each item by its inline decision table.
+ */
+class DecisionTableNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigForm {
+
+	/**
+	 * The step type.
+	 *
+	 * @var string
+	 */
+	public const NODE_ID = 'openregister.decision-table';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param DecisionTableEvaluator $engine The shared evaluator; all deciding is delegated to it.
+	 * @param DecisionTableValidator $validator Refuses a table the evaluator could not execute.
+	 * @param IL10N $l10n Translations.
+	 * @param IURLGenerator $urls For the palette icon.
+	 */
+	public function __construct(
+		private readonly DecisionTableEvaluator $engine,
+		private readonly DecisionTableValidator $validator,
+		private readonly IL10N $l10n,
+		private readonly IURLGenerator $urls,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * The step type.
+	 *
+	 * @return string The id.
+	 *
+	 * @spec openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md#requirement-a-decision-table-step-evaluates-its-table-against-every-item
+	 */
+	public function getId(): string {
+		return self::NODE_ID;
+	}//end getId()
+
+	/**
+	 * Palette name.
+	 *
+	 * @return string The display name.
+	 *
+	 * @spec openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md#requirement-the-node-describes-its-own-form-and-writes-an-optional-evaluation-record
+	 */
+	public function getDisplayName(): string {
+		return $this->l10n->t('Evaluate a decision table');
+	}//end getDisplayName()
+
+	/**
+	 * Palette description.
+	 *
+	 * @return string The description.
+	 *
+	 * @spec openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md#requirement-the-node-describes-its-own-form-and-writes-an-optional-evaluation-record
+	 */
+	public function getDescription(): string {
+		return $this->l10n->t('Apply a table of rules to each item and write the outcome onto it.');
+	}//end getDescription()
+
+	/**
+	 * Palette icon.
+	 *
+	 * @return string The icon URL.
+	 *
+	 * @spec openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md#requirement-the-node-describes-its-own-form-and-writes-an-optional-evaluation-record
+	 */
+	public function getIcon(): string {
+		return $this->urls->imagePath('core', 'actions/checkmark.svg');
+	}//end getIcon()
+
+	/**
+	 * Available in both scopes. Deciding over data the run already carries
+	 * grants no privilege; what may be read and written is governed where it
+	 * always is, at the object nodes.
+	 *
+	 * @param int $scope The scope constant.
+	 *
+	 * @return bool Whether it is available.
+	 *
+	 * @spec openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md#requirement-a-decision-table-step-evaluates-its-table-against-every-item
+	 */
+	public function isAvailableForScope(int $scope): bool {
+		return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
+	}//end isAvailableForScope()
+
+	/**
+	 * The config vocabulary of a decision-table step.
+	 *
+	 * @return array<int, string> The accepted config keys.
+	 *
+	 * @spec openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md#requirement-the-node-describes-its-own-form-and-writes-an-optional-evaluation-record
+	 */
+	public function configKeys(): array {
+		return ['table', 'inputMapping', 'outputMapping', 'defaultOutputs', 'resultKey'];
+	}//end configKeys()
+
+	/**
+	 * The fields this node is edited through.
+	 *
+	 * The table itself is edited as JSON for now; the raw pane is the honest
+	 * fallback until the canvas grows a table editor, and the save path
+	 * refuses anything the evaluator could not execute either way.
+	 *
+	 * @return array<int, array<string, mixed>> The field descriptions.
+	 *
+	 * @spec openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md#requirement-the-node-describes-its-own-form-and-writes-an-optional-evaluation-record
+	 */
+	public function configForm(): array {
+		return [
+			[
+				'key' => 'table',
+				'label' => $this->l10n->t('Decision table'),
+				'type' => 'textarea',
+				'help' => $this->l10n->t('The table as JSON: hit policy, inputs, outputs and rules. Saving refuses a table the engine cannot run.'),
+				'required' => true,
+			],
+			[
+				'key' => 'inputMapping',
+				'label' => $this->l10n->t('Input fields'),
+				'type' => 'textarea',
+				'help' => $this->l10n->t('Where each table input is read from, as input name to field path. An input without an entry reads the field with its own name.'),
+			],
+			[
+				'key' => 'outputMapping',
+				'label' => $this->l10n->t('Output fields'),
+				'type' => 'textarea',
+				'help' => $this->l10n->t('Where each table output is written, as output name to field path. An output without an entry writes the field with its own name.'),
+			],
+			[
+				'key' => 'defaultOutputs',
+				'label' => $this->l10n->t('When no rule matches'),
+				'type' => 'textarea',
+				'help' => $this->l10n->t('Values to write when no rule matches, one per output. Leave empty to fail the step instead.'),
+			],
+			[
+				'key' => 'resultKey',
+				'label' => $this->l10n->t('Record the evaluation under'),
+				'type' => 'text',
+				'help' => $this->l10n->t('Optional field path for the evaluation record: which rules matched and under which hit policy.'),
+			],
+		];
+	}//end configForm()
+
+	/**
+	 * Refuse a configuration the evaluator could not execute, when the flow
+	 * is saved or imported rather than when a run reaches the step.
+	 *
+	 * @param array $config The step configuration.
+	 *
+	 * @return void
+	 *
+	 * @throws UnexpectedValueException When the table or the mappings are refused.
+	 *
+	 * @spec openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md#requirement-a-table-the-evaluator-cannot-execute-is-refused-at-save
+	 */
+	public function validateConfig(array $config): void {
+		$table = ($config['table'] ?? null);
+		if (is_array($table) === false || $table === []) {
+			throw new UnexpectedValueException(
+				$this->l10n->t('A decision-table step needs a table.')
+			);
+		}
+
+		$problems = $this->validator->validate(table: $table);
+		if ($problems !== []) {
+			throw new UnexpectedValueException(
+				$this->l10n->t('The decision table cannot be run: %s.', [implode('; ', $problems)])
+			);
+		}
+
+		$inputNames = $this->columnNames(columns: (array)($table['inputs'] ?? []));
+		$outputNames = $this->columnNames(columns: (array)($table['outputs'] ?? []));
+
+		$this->assertMapping(config: $config, key: 'inputMapping', declared: $inputNames);
+		$this->assertMapping(config: $config, key: 'outputMapping', declared: $outputNames);
+		$this->assertDefaults(config: $config, table: $table, outputNames: $outputNames);
+
+		if (array_key_exists('resultKey', $config) === true) {
+			$this->assertPath(path: $config['resultKey'], where: 'resultKey');
+		}
+
+	}//end validateConfig()
+
+	/**
+	 * Decide every item: map the inputs in, evaluate, map the outputs back.
+	 *
+	 * Deterministic by construction: no I/O, no clock, no state. The same
+	 * item and the same configuration decide the same way every firing, and
+	 * the node never suspends: a rule step completes in the firing that
+	 * reached it.
+	 *
+	 * @param array $items The input items.
+	 * @param array $config The step configuration.
+	 * @param array $context Run-level metadata (unused: the decision reads only the item).
+	 *
+	 * @return array The output items, one per input item.
+	 *
+	 * @throws UnexpectedValueException When the configuration is refused.
+	 * @throws DecisionEvaluationException When an item cannot be decided and no default row is configured.
+	 *
+	 * @spec openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md#requirement-the-step-is-deterministic-and-never-suspends
+	 *
+	 * @SuppressWarnings(PHPMD.UnusedFormalParameter) `$context` is part of the
+	 * node contract; a deterministic rule step deliberately reads none of it.
+	 * @SuppressWarnings(PHPMD.StaticAccess) `FlowItems::item()` and
+	 * `FlowValueTemplate::render()` are the engine's canonical constructors.
+	 */
+	public function execute(array $items, array $config, array $context): array {
+		if ($items === []) {
+			return [];
+		}
+
+		// A flow written by hand or imported past the editor must meet the
+		// same bar as one saved through it, so the refusals run here too —
+		// the same belt-and-braces ObjectReadNode wears.
+		$this->validateConfig(config: $config);
+
+		$table = (array)$config['table'];
+		$inputMapping = (array)($config['inputMapping'] ?? []);
+		$outputMapping = (array)($config['outputMapping'] ?? []);
+		$resultKey = trim((string)($config['resultKey'] ?? ''));
+
+		$out = [];
+		foreach ($items as $index => $item) {
+			$json = (array)($item[FlowItems::JSON] ?? []);
+
+			$result = $this->decide(table: $table, config: $config, json: $json, inputMapping: $inputMapping);
+
+			foreach ($this->columnNames(columns: (array)($table['outputs'] ?? [])) as $name) {
+				self::assign(
+					json: $json,
+					path: (string)($outputMapping[$name] ?? $name),
+					value: ($result['outputs'][$name] ?? null)
+				);
+			}
+
+			if ($resultKey !== '') {
+				self::assign(
+					json: $json,
+					path: $resultKey,
+					value: [
+						'hitPolicy' => $result['hitPolicy'],
+						'matchedRuleIds' => $result['matchedRuleIds'],
+						'defaulted' => $result['defaulted'],
+						'tableName' => (string)($table['name'] ?? ''),
+						'tableKey' => (string)($table['key'] ?? ''),
+					]
+				);
+			}
+
+			$out[] = FlowItems::item(
+				json: $json,
+				binary: (array)($item[FlowItems::BINARY] ?? []),
+				fromItemIndex: $index
+			);
+		}//end foreach
+
+		return $out;
+	}//end execute()
+
+	/**
+	 * Decide one item: build the inputs, run the evaluator, apply the
+	 * author's no-match choice.
+	 *
+	 * @param array<string, mixed> $table The table definition.
+	 * @param array<string, mixed> $config The step configuration.
+	 * @param array<string, mixed> $json The item's record.
+	 * @param array<string, mixed> $inputMapping Declared input name to field path.
+	 *
+	 * @return array{outputs: array<string, mixed>, matchedRuleIds: array<int, string>, hitPolicy: string, defaulted: bool}
+	 *
+	 * @throws DecisionEvaluationException When the item cannot be decided and no default row exists.
+	 *
+	 * @spec openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md#requirement-no-match-takes-the-authors-explicit-default-or-fails-loudly
+	 */
+	private function decide(array $table, array $config, array $json, array $inputMapping): array {
+		$inputs = [];
+		foreach ($this->columnNames(columns: (array)($table['inputs'] ?? [])) as $name) {
+			$path = (string)($inputMapping[$name] ?? $name);
+			// A value that is exactly one placeholder keeps its type, so a
+			// number stays a number on its way into the coercion.
+			$inputs[$name] = FlowValueTemplate::render(value: ('{{' . $path . '}}'), json: $json);
+		}
+
+		try {
+			$result = $this->engine->evaluate(decisionTable: $table, inputs: $inputs);
+
+			return [
+				'outputs' => $result['outputs'],
+				'matchedRuleIds' => $result['matchedRuleIds'],
+				'hitPolicy' => $result['hitPolicy'],
+				'defaulted' => false,
+			];
+		} catch (DecisionEvaluationException $e) {
+			$defaults = ($config['defaultOutputs'] ?? null);
+			if ($e->getErrorCode() !== 'no_rule_matched' || is_array($defaults) === false) {
+				// Everything else — a missing input, a type mismatch, a hit
+				// policy violation — is a fault, not a no-match, and the
+				// step's onError policy is the place that decides what a
+				// fault costs. Catching it here would report a completed
+				// decision that never happened.
+				throw $e;
+			}
+
+			return [
+				'outputs' => $defaults,
+				'matchedRuleIds' => [],
+				'hitPolicy' => strtoupper((string)($table['hitPolicy'] ?? 'UNIQUE')),
+				'defaulted' => true,
+			];
+		}//end try
+	}//end decide()
+
+	/**
+	 * The declared column names, in declaration order.
+	 *
+	 * @param array<int, mixed> $columns The declared `inputs` or `outputs`.
+	 *
+	 * @return array<int, string> The names.
+	 */
+	private function columnNames(array $columns): array {
+		$names = [];
+		foreach ($columns as $column) {
+			if (is_array($column) === false) {
+				continue;
+			}
+
+			$name = trim((string)($column['name'] ?? ''));
+			if ($name !== '') {
+				$names[] = $name;
+			}
+		}
+
+		return $names;
+	}//end columnNames()
+
+	/**
+	 * Refuse a mapping the step would otherwise silently ignore.
+	 *
+	 * A mapping entry for a name the table does not declare is configuration
+	 * that looks like behaviour and is not; a templated path would let item
+	 * data choose the write position on a RULE step, which no migrating
+	 * table needs and which is refused rather than half-supported.
+	 *
+	 * @param array<string, mixed> $config The step configuration.
+	 * @param string $key `inputMapping` or `outputMapping`.
+	 * @param array<int, string> $declared The declared names for that side.
+	 *
+	 * @return void
+	 *
+	 * @throws UnexpectedValueException When the mapping is refused.
+	 *
+	 * @spec openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md#requirement-a-table-the-evaluator-cannot-execute-is-refused-at-save
+	 */
+	private function assertMapping(array $config, string $key, array $declared): void {
+		if (array_key_exists($key, $config) === false) {
+			return;
+		}
+
+		if (is_array($config[$key]) === false) {
+			throw new UnexpectedValueException(
+				$this->l10n->t('The %s must be an object of name to field path.', [$key])
+			);
+		}
+
+		foreach ($config[$key] as $name => $path) {
+			if (in_array((string)$name, $declared, true) === false) {
+				throw new UnexpectedValueException(
+					$this->l10n->t('The %1$s names "%2$s", which the table does not declare. The step would silently ignore it.', [$key, (string)$name])
+				);
+			}
+
+			$this->assertPath(path: $path, where: ($key . ' "' . (string)$name . '"'));
+		}
+
+	}//end assertMapping()
+
+	/**
+	 * Refuse the author's default row unless it is complete, and refuse it
+	 * entirely on COLLECT.
+	 *
+	 * A partial default writes half a decision and nulls for the rest, which
+	 * is the silent shape this node exists to refuse. On COLLECT the empty
+	 * list is a real answer, so a default would be unreachable configuration
+	 * that looks like behaviour.
+	 *
+	 * @param array<string, mixed> $config The step configuration.
+	 * @param array<string, mixed> $table The table definition.
+	 * @param array<int, string> $outputNames The declared output names.
+	 *
+	 * @return void
+	 *
+	 * @throws UnexpectedValueException When the defaults are refused.
+	 *
+	 * @spec openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md#requirement-no-match-takes-the-authors-explicit-default-or-fails-loudly
+	 */
+	private function assertDefaults(array $config, array $table, array $outputNames): void {
+		if (array_key_exists('defaultOutputs', $config) === false) {
+			return;
+		}
+
+		if (is_array($config['defaultOutputs']) === false) {
+			throw new UnexpectedValueException(
+				$this->l10n->t('The defaultOutputs must be an object of output name to value.')
+			);
+		}
+
+		if (strtoupper(trim((string)($table['hitPolicy'] ?? 'UNIQUE'))) === 'COLLECT') {
+			throw new UnexpectedValueException(
+				$this->l10n->t('A COLLECT table never fails to match: its empty list is the answer. Remove defaultOutputs.')
+			);
+		}
+
+		foreach ($outputNames as $name) {
+			if (array_key_exists($name, $config['defaultOutputs']) === false) {
+				throw new UnexpectedValueException(
+					$this->l10n->t('The defaultOutputs are missing a value for output "%s". A partial default writes half a decision.', [$name])
+				);
+			}
+		}
+
+		foreach (array_keys($config['defaultOutputs']) as $name) {
+			if (in_array((string)$name, $outputNames, true) === false) {
+				throw new UnexpectedValueException(
+					$this->l10n->t('The defaultOutputs name "%s", which the table does not declare. The step would silently ignore it.', [(string)$name])
+				);
+			}
+		}
+
+	}//end assertDefaults()
+
+	/**
+	 * Refuse a field path that is empty, not a string, or templated.
+	 *
+	 * @param mixed $path The configured path.
+	 * @param string $where Which configuration entry it came from, for the message.
+	 *
+	 * @return void
+	 *
+	 * @throws UnexpectedValueException When the path is refused.
+	 *
+	 * @spec openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md#requirement-a-table-the-evaluator-cannot-execute-is-refused-at-save
+	 */
+	private function assertPath(mixed $path, string $where): void {
+		if (is_string($path) === false || trim($path) === '') {
+			throw new UnexpectedValueException(
+				$this->l10n->t('The field path for %s is empty. A position is never empty.', [$where])
+			);
+		}
+
+		if (str_contains($path, '{{') === true) {
+			throw new UnexpectedValueException(
+				$this->l10n->t('The field path for %s is templated. A rule step reads and writes the positions its author named, literally.', [$where])
+			);
+		}
+
+	}//end assertPath()
+
+	/**
+	 * Write a value at a dotted path, creating the containers it needs.
+	 *
+	 * Same semantics as `openregister.set-fields` gives a literal path: the
+	 * structure is a property of the configuration. A segment whose current
+	 * value is not an array is replaced by a container, because merging into
+	 * a scalar has no meaning and skipping silently would be the invisible
+	 * no-op this node refuses everywhere else.
+	 *
+	 * @param array $json The item's record, modified in place.
+	 * @param string $path The field path, optionally dotted.
+	 * @param mixed $value The value to write.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md#requirement-a-decision-table-step-evaluates-its-table-against-every-item
+	 */
+	private static function assign(array &$json, string $path, mixed $value): void {
+		if (str_contains($path, '.') === false) {
+			$json[$path] = $value;
+
+			return;
+		}
+
+		$segments = explode('.', $path);
+		$last = array_pop($segments);
+		$cursor = &$json;
+
+		foreach ($segments as $segment) {
+			if (isset($cursor[$segment]) === false || is_array($cursor[$segment]) === false) {
+				$cursor[$segment] = [];
+			}
+
+			$cursor = &$cursor[$segment];
+		}
+
+		$cursor[$last] = $value;
+		unset($cursor);
+
+	}//end assign()
+}//end class

--- a/lib/Service/Flow/Nodes/DecisionTableNode.php
+++ b/lib/Service/Flow/Nodes/DecisionTableNode.php
@@ -169,13 +169,17 @@ class DecisionTableNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConf
 				'key' => 'inputMapping',
 				'label' => $this->l10n->t('Input fields'),
 				'type' => 'textarea',
-				'help' => $this->l10n->t('Where each table input is read from, as input name to field path. An input without an entry reads the field with its own name.'),
+				'help' => $this->l10n->t(
+					'Where each table input is read from, as input name to field path. An input without an entry reads the field with its own name.'
+				),
 			],
 			[
 				'key' => 'outputMapping',
 				'label' => $this->l10n->t('Output fields'),
 				'type' => 'textarea',
-				'help' => $this->l10n->t('Where each table output is written, as output name to field path. An output without an entry writes the field with its own name.'),
+				'help' => $this->l10n->t(
+					'Where each table output is written, as output name to field path. An output without an entry writes the field with its own name.'
+				),
 			],
 			[
 				'key' => 'defaultOutputs',
@@ -323,6 +327,9 @@ class DecisionTableNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConf
 	 * @throws DecisionEvaluationException When the item cannot be decided and no default row exists.
 	 *
 	 * @spec openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md#requirement-no-match-takes-the-authors-explicit-default-or-fails-loudly
+	 *
+	 * @SuppressWarnings(PHPMD.StaticAccess) `FlowValueTemplate::render()` is the
+	 * engine's canonical dotted-path read.
 	 */
 	private function decide(array $table, array $config, array $json, array $inputMapping): array {
 		$inputs = [];

--- a/openspec/changes/flow-decision-tables/design.md
+++ b/openspec/changes/flow-decision-tables/design.md
@@ -1,0 +1,140 @@
+# Design: flow-decision-tables
+
+## D-1: The table lives inline in the node config, not behind a reference
+
+Two storage shapes were on the table:
+
+1. **Inline**: the full table (`hitPolicy`, `inputs`, `outputs`, `rules`)
+   sits in the node's `table` config key.
+2. **Referenced**: the node holds a register/schema/key triple and fetches
+   an engine-stored table object at run time — the shape dossiq has today
+   (`DecisionTableService::findByKey()` over a `decisionTable` schema).
+
+Inline wins, and the deciding facts are dossiq's own tables:
+
+- **Size.** dossiq's real tables are small. The LHS enforcement matrix —
+  the largest real producer, projected by
+  `LhsMatrixDecisionTableMigrator` — is three string inputs, one string
+  output and one rule per matrix cell; the register schema caps the shape
+  at flat positional arrays of short strings. A node config carries that
+  comfortably. Nothing in dossiq's data needs an out-of-band store.
+- **Pinning is the point, and inline gets it for free.** A published flow
+  is pinned to its definition; a table inside that definition is pinned
+  with it. A referenced table is live data under a published flow: editing
+  a rule silently changes what every pinned run does, which is precisely
+  the mutable-rule-store hazard this migration retires. Making a reference
+  honour pinning would mean engine-side table versioning, a second
+  version graph, and a copy-on-publish story — all machinery the data does
+  not ask for.
+- **Import already works.** `x-openregister-flows` imports flow
+  definitions whole; an inline table arrives inside its step and is
+  validated on the same save path as every hand-authored one. A reference
+  would need ordered two-phase import (tables before flows) and a
+  broken-link story.
+- **Validation at save is only possible for a shape the save can see.**
+  The spec requires refusing a malformed table when the flow is saved. An
+  inline table is validated then and there. A referenced table can only be
+  validated at run time, which is the edge-condition defect's shape: an
+  accepted configuration whose executable content was never checked.
+
+What is given up, and why that is acceptable:
+
+- **Reuse across flows** becomes copy-per-node. dossiq's tables are keyed
+  per decision and invoked from specific transitions; fleet-wide, a
+  genuinely shared decision is expressed once in one flow and invoked via
+  `openregister.sub-flow`, which also gives the shared decision one
+  version history. If a real catalogue need emerges, a `tableFrom` key
+  reading a table fetched by `openregister.object-read` composes on top of
+  this node without changing its contract — recorded here so the future
+  discussion starts from the refusal, not from scratch.
+- **Editing rules without republishing** is exactly the property refused
+  on purpose. Changing a decision rule IS changing the flow; the version
+  history should say so.
+
+## D-2: Validation executes the evaluator's grammar; nothing re-implements it
+
+The lesson written into this repo more than once: an accepted grammar that
+is not the executable grammar accepts flows that fail at 03:00.
+`DecisionTableValidator` therefore does not parse rule cells itself. For
+every cell it calls `UnaryTestEvaluator::matches()` with a probe value of
+the column's effective type and treats `invalid_expression` and
+`type_mismatch` as authoring errors to report with the rule id and column
+name. A cell the evaluator cannot execute cannot be saved; a cell it can
+execute needs no second parser to agree.
+
+Two consequences worth naming:
+
+- The evaluator's type normalisation (`integer` → `number`, `bool` →
+  `boolean`, unknown → `string`) is exposed as
+  `DecisionTableEvaluator::effectiveType()` and used by the validator, so
+  the two cannot drift on what a column's type means.
+- The evaluator's implemented-hit-policy list is exposed as a constant and
+  the validator refuses anything outside it BY NAME
+  (`hit policy "X" is not implemented`), loudly, at save. dossiq's five
+  (UNIQUE, FIRST, PRIORITY, ANY, COLLECT) are all implemented, so no
+  migrating table hits this; a future sixth spelling fails the save, not
+  the run.
+
+Structural checks beyond the grammar, each refusing a silent no-op or a
+silent collapse:
+
+- at least one input, one output, one rule (a table missing any of them
+  can never decide anything);
+- unique input names and unique output names (the evaluator keys results
+  by name, so a duplicate would silently collapse two columns into one);
+- per rule, entry counts equal to the declared input/output counts
+  (positional alignment is the contract; a short row would silently
+  wildcard the missing tail);
+- `priority`, when present, an integer.
+
+## D-3: No-match is an explicit choice: a complete default row, or a loud failure
+
+The evaluator throws `no_rule_matched` for the single-winner policies and
+returns empty lists for COLLECT. The node adds exactly one thing on top:
+an optional `defaultOutputs` map. When configured, a no-match yields those
+outputs (flagged `defaulted: true` in the `resultKey` record); when not,
+the exception propagates and the step's `onError` policy decides. Two
+refusals keep this honest:
+
+- `defaultOutputs` must cover EVERY declared output — a partial default
+  would write half a decision and nulls for the rest, which is the silent
+  shape this whole node refuses.
+- `defaultOutputs` is refused on a COLLECT table: COLLECT's empty list is
+  a real answer ("nothing applied"), not a failure to answer, so a default
+  would be unreachable code that looks like behaviour.
+
+## D-4: The node is a rule step: per item, deterministic, no suspension
+
+- **Per item, independently.** Inputs are read from each item's record via
+  `inputMapping` (declared input name → dotted path, same-name default —
+  dossiq's handler vocabulary, kept verbatim so the migration is a
+  mechanical rewrite). Outputs are written back per item via
+  `outputMapping`, same default. One item's failure semantics follow the
+  engine's `onError` policy like every other node.
+- **Deterministic.** The evaluation path does no I/O, reads no clock, and
+  holds no state. Same item + same config = same outputs. This is asserted
+  by test, not just by prose.
+- **Never suspends.** Rule steps and human steps are different species:
+  the human half is `openregister.user-task` and decidiq's consumption of
+  it. This node completes in the firing that reached it.
+- **Mapping paths are literal.** A `{{templated}}` mapping path is refused
+  at save. SetFieldsNode earned its templated positions; here a
+  data-controlled write position on a RULE step would mean the table's
+  outputs land somewhere the author never named, and no dossiq table needs
+  it. Add it later if a table does; refusing now keeps the contract small.
+- **A mapping for a name the table does not declare is refused.** It would
+  be configuration the node silently ignores — the looks-like-it-works
+  shape `IFlowNodeConfigForm`'s own docblock warns about.
+
+## D-5: What lands on the item
+
+- Each declared output's value at its mapped (dotted) path, created
+  containers included — the same `assign` semantics as
+  `openregister.set-fields`, minus templated positions.
+- Optionally, under `resultKey`, the evaluation record:
+  `{hitPolicy, matchedRuleIds, defaulted, tableName, tableKey}` — enough
+  for a downstream Switch to branch on which rule fired and for a run log
+  reader to see why. Off by default: a node that stamps bookkeeping on
+  every record unasked pollutes schemas.
+- COLLECT writes lists (one entry per matched rule, in declaration order),
+  matching the shared evaluator's contract unchanged.

--- a/openspec/changes/flow-decision-tables/proposal.md
+++ b/openspec/changes/flow-decision-tables/proposal.md
@@ -1,0 +1,93 @@
+---
+kind: code
+depends_on: [shared-decision-table-evaluator]
+---
+
+# Proposal: flow-decision-tables
+
+## Summary
+
+Put rule evaluation into the graph. A new node type
+`openregister.decision-table` evaluates a DMN-style decision table against
+each item and writes the winning outputs onto configured item fields. The
+table travels inline in the node's configuration, so flow versioning and
+pinning apply to the rules the same way they apply to every other authored
+step. Evaluation is delegated in full to the shared
+`DecisionTableEvaluator`; this node maps item fields in and out, and
+refuses a table the evaluator could not execute at save time rather than at
+run time.
+
+## Why
+
+**The directive is explicit: apps get no flow engines of their own, and
+decision tables are flow-engine work.** dossiq ships its own decision-table
+storage, lookup and wiring (`EvaluateDecisionHandler`,
+`DecisionTableService`, a `decisionTable` register schema and a
+`dossiq.evaluateDecision` flow-node wrapper) and is staging their
+retirement against this change. The evaluation core already moved here —
+`shared-decision-table-evaluator` consolidated dossiq's and openbuild's
+engines into `lib/Service/Dmn/` — but nothing in the flow palette can
+invoke it. The capability exists and is unreachable from a flow, which is
+exactly the orphan shape gate-57 exists to catch.
+
+**A rule step is not a human step.** The fleet's decision split is:
+automated rule evaluation belongs to the engine (this node), human
+decisions belong to decidiq (`openregister.user-task` and its consumers).
+This node therefore never suspends, never creates a task and never waits.
+It is deterministic: the same item and the same configuration produce the
+same outputs, every time, with no I/O in the evaluation path.
+
+**The migration must not strand.** dossiq's tables and handler define the
+floor: five hit policies (UNIQUE, FIRST, PRIORITY, ANY, COLLECT — the
+shared evaluator already implements all five), positional
+`inputEntries`/`outputEntries`, typed inputs (string, number, boolean,
+date), an `inputMapping`/`outputMapping` vocabulary with a same-name
+default, and loud typed failures. Every one of those is expressible here,
+and the test suite proves it with a table translated from dossiq's real
+LHS enforcement matrix.
+
+## What Changes
+
+- **A new node, `openregister.decision-table`**, in
+  `lib/Service/Flow/Nodes/`, implementing `IFlowNode`,
+  `IFlowNodeConfigKeys` and `IFlowNodeConfigForm`, registered through
+  `lib/Listener/FlowNodeRegistrationListener.php` like every built-in. Its
+  `configForm()` is served by the existing node catalog; no editor change.
+- **The table is inline in the node config** (`table`), so it is versioned
+  and pinned with the flow and imported through `x-openregister-flows`
+  with no extra machinery. See design.md D-1 for why a live object
+  reference was considered and refused.
+- **A new engine-owned validator, `DecisionTableValidator`**, in
+  `lib/Service/Dmn/`, that validates a table by exercising the
+  evaluator's own grammar against every rule cell. The accepted grammar is
+  the executable one by construction, not by a parallel re-implementation
+  that can drift.
+- **No-match behaviour is a choice the author makes explicitly**:
+  `defaultOutputs` supplies a complete fallback row, otherwise a no-match
+  fails the step loudly and the step's `onError` policy decides. There is
+  no silent empty result.
+- **No new endpoints.** The node plus the existing flow save/import path
+  is the whole surface.
+
+## Out of Scope
+
+- **A referenced, engine-stored table catalogue.** Refused for now, with
+  the reasoning recorded in design.md D-1. If it returns it composes on
+  top of this node rather than replacing it.
+- **Retiring dossiq's copies.** The parallel dossiq change does that,
+  pointing at this node; deleting a working evaluation path from here
+  would couple two repos' release trains.
+- **DMN XML interchange and full FEEL.** Both already ruled out by
+  ADR-065 and `shared-decision-table-evaluator`; nothing here reopens
+  them.
+
+## Risks
+
+- ⚠️ **An inline table is copied per node.** Two nodes using one policy
+  table hold two copies. Deliberate: a shared mutable table under a
+  published flow is the bigger hazard (design.md D-1); a genuinely shared
+  decision lives in one flow invoked via `openregister.sub-flow`.
+- ⚠️ **Every declared input must resolve on the item.** The evaluator
+  refuses a missing input (`type_mismatch`/`missing_input`) rather than
+  wildcarding it, inherited deliberately from dossiq's handler: a decision
+  taken over absent data is not a decision.

--- a/openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md
+++ b/openspec/changes/flow-decision-tables/specs/flow-decision-tables/spec.md
@@ -1,0 +1,222 @@
+# Spec: flow decision tables
+
+## Purpose
+
+One step type that evaluates a decision table inside a flow: rules in the
+graph, evaluated by the engine's shared evaluator, with the outputs written
+onto the items so downstream nodes can route on them. Rule steps are the
+engine's; human decisions stay with the user-task machinery and its
+consumers.
+
+## ADDED Requirements
+
+### Requirement: A decision-table step evaluates its table against every item
+
+The system SHALL provide a step node type `openregister.decision-table`.
+For each item that reaches it, the node SHALL build the table's declared
+inputs from the item's record, evaluate the table through the shared
+decision-table evaluator, and write every declared output's value onto the
+item's record.
+
+The node SHALL delegate evaluation in full: hit policies, unary-test
+grammar, type coercion and typed errors are the shared evaluator's, and the
+node SHALL NOT re-implement or wrap any of them in altered form.
+
+Input values SHALL be read via `inputMapping` (declared input name to a
+dotted path in the item's record) with a same-name default, and outputs
+SHALL be written via `outputMapping` with the same default — the vocabulary
+dossiq's `evaluateDecision` handler already uses, kept so the migration is
+a mechanical rewrite.
+
+An item that lacks a declared input SHALL fail that item's evaluation with
+the evaluator's typed error rather than wildcarding the gap: a decision
+over absent data is not a decision.
+
+A firing with no items SHALL return no items and do nothing else.
+
+#### Scenario: A dossiq table decides an item
+
+- **GIVEN** a decision-table step carrying dossiq's LHS enforcement table
+  (three string inputs, one output, UNIQUE)
+- **WHEN** an item carrying `severity`, `behaviour` and `actorType` passes
+  through
+- **THEN** the item's record MUST carry the matched rule's `intervention`
+- @e2e exclude engine-internal node behaviour, proven by the
+  DecisionTableNode unit suite's dossiq fixture
+
+#### Scenario: Mapped paths read and write nested fields
+
+- **GIVEN** `inputMapping` pointing an input at `case.severity` and
+  `outputMapping` pointing an output at `advies.maatregel`
+- **WHEN** an item with a nested `case` record passes through
+- **THEN** the input MUST be read from the nested path and the output MUST
+  be written at the nested path, containers created as needed
+- @e2e exclude engine-internal mapping semantics, covered by unit tests
+
+#### Scenario: A missing input fails loudly
+
+- **GIVEN** a table declaring input `severity` and an item without it
+- **WHEN** the step fires
+- **THEN** the step MUST fail with the evaluator's typed error
+- **AND** the step MUST NOT evaluate the table as if the input were a
+  wildcard
+- @e2e exclude failure-path semantics, covered by unit tests
+
+### Requirement: The step is deterministic and never suspends
+
+The node SHALL be a pure function of (item record, step configuration): no
+I/O, no clock reads and no stored state in the evaluation path. Evaluating
+the same item against the same configuration twice SHALL produce identical
+outputs.
+
+The node SHALL NOT suspend the run, create a task, or wait for anything.
+Automated rule evaluation is a rule step; a decision needing a person is a
+user task and belongs to that node type and its consumers.
+
+#### Scenario: The same item decides the same way twice
+
+- **GIVEN** any valid decision-table step and any item its table accepts
+- **WHEN** the step fires twice over an identical item
+- **THEN** both firings MUST produce identical records
+- @e2e exclude determinism is a unit-level property, asserted by unit tests
+
+### Requirement: The table travels inline and is pinned with the flow
+
+The step SHALL carry its decision table inline in the `table` configuration
+key. The table is thereby part of the flow definition: versioning, pinning
+and `x-openregister-flows` import apply to it exactly as they apply to any
+other authored step configuration, with no additional machinery.
+
+The system SHALL NOT resolve the table from live data at run time. Changing
+a decision rule is changing the flow, and the flow's version history SHALL
+record it as such.
+
+#### Scenario: A pinned run keeps the rules it was published with
+
+- **GIVEN** a published flow whose decision-table step carries version A of
+  a table
+- **WHEN** the draft's table is edited to version B without republishing
+- **THEN** runs of the published flow MUST keep evaluating version A
+- @e2e exclude follows from definition pinning, which flow-engine already
+  specifies and tests; the table adds no new pinning surface
+
+### Requirement: A table the evaluator cannot execute is refused at save
+
+The node's configuration validation SHALL refuse, when the flow is saved or
+imported and with a message naming the offending part:
+
+- a missing or non-object `table`;
+- a hit policy the shared evaluator does not implement, by name;
+- a table without at least one input, one output and one rule;
+- a duplicate input name or duplicate output name;
+- a rule whose `inputEntries` or `outputEntries` count differs from the
+  declared inputs/outputs count;
+- a rule cell the evaluator's own grammar cannot execute.
+
+Grammar validation SHALL be performed by exercising the shared evaluator
+against every rule cell, not by a parallel parser: the accepted grammar
+MUST be the executable grammar by construction.
+
+The validation SHALL also refuse configuration the node would otherwise
+silently ignore: an `inputMapping` or `outputMapping` entry naming an
+undeclared input/output, a templated (`{{...}}`) mapping path, and a
+non-string mapping path.
+
+#### Scenario: A malformed rule cell cannot be saved
+
+- **GIVEN** a table whose rule cell reads `[5..` on a number column
+- **WHEN** the flow is saved or imported
+- **THEN** the save MUST be refused with a message naming the rule and the
+  column
+- @e2e exclude save-path refusal, covered by validator and node unit tests
+
+#### Scenario: An unimplemented hit policy is refused by name
+
+- **GIVEN** a table declaring hit policy `OUTPUT ORDER`
+- **WHEN** the flow is saved or imported
+- **THEN** the save MUST be refused with a message naming `OUTPUT ORDER`
+  as not implemented
+- @e2e exclude save-path refusal, covered by unit tests
+
+#### Scenario: A mapping over an undeclared name is refused
+
+- **GIVEN** an `outputMapping` entry for an output the table does not
+  declare
+- **WHEN** the flow is saved
+- **THEN** the save MUST be refused: configuration the step ignores looks
+  like behaviour and is not
+- @e2e exclude save-path refusal, covered by unit tests
+
+### Requirement: Hit policies are the shared evaluator's five, unchanged
+
+The step SHALL support exactly the hit policies the shared evaluator
+implements — UNIQUE, FIRST, PRIORITY, ANY and COLLECT — with the shared
+evaluator's semantics, including UNIQUE refusing multiple matches, ANY
+refusing disagreeing matches, PRIORITY taking the highest priority with
+declaration order breaking ties, and COLLECT returning one list per output.
+
+#### Scenario: COLLECT writes lists
+
+- **GIVEN** a COLLECT table where two rules match an item
+- **WHEN** the step fires
+- **THEN** each mapped output field MUST hold a two-entry list in rule
+  declaration order
+- @e2e exclude policy semantics live in the shared evaluator; the node's
+  pass-through is unit-tested per policy
+
+#### Scenario: UNIQUE with two matches fails the step
+
+- **GIVEN** a UNIQUE table where two rules match an item
+- **WHEN** the step fires
+- **THEN** the step MUST fail with the evaluator's `hit_policy_violation`
+- @e2e exclude failure-path semantics, covered by unit tests
+
+### Requirement: No-match takes the author's explicit default or fails loudly
+
+When no rule matches under a single-winner policy, the step SHALL fail with
+the evaluator's `no_rule_matched` error unless the configuration carries
+`defaultOutputs`, in which case the step SHALL write those values instead
+and mark the evaluation record as defaulted.
+
+`defaultOutputs`, when present, SHALL be refused at save unless it provides
+a value for every declared output: a partial default writes half a decision.
+It SHALL also be refused on a COLLECT table, whose empty list is an answer
+rather than a failure to answer.
+
+#### Scenario: No match without defaults fails the step
+
+- **GIVEN** a FIRST table none of whose rules match an item, and no
+  `defaultOutputs`
+- **WHEN** the step fires
+- **THEN** the step MUST fail with `no_rule_matched`
+- @e2e exclude failure-path semantics, covered by unit tests
+
+#### Scenario: No match with a complete default row decides the default
+
+- **GIVEN** the same table with `defaultOutputs` covering every output
+- **WHEN** the step fires
+- **THEN** the item MUST carry the default values
+- **AND** the evaluation record under `resultKey`, when configured, MUST
+  say `defaulted: true` with no matched rule ids
+- @e2e exclude default-path semantics, covered by unit tests
+
+### Requirement: The node describes its own form and writes an optional evaluation record
+
+The node SHALL implement the config-form contract so the canvas can edit
+it, describing at least the table, both mappings, `defaultOutputs` and
+`resultKey`. All palette and form strings SHALL be translated, in sentence
+case, without em-dashes.
+
+When `resultKey` is configured, the node SHALL write the evaluation record
+`{hitPolicy, matchedRuleIds, defaulted, tableName, tableKey}` at that
+dotted path on each item, so a downstream switch can branch on which rule
+fired. Without `resultKey` the node SHALL write only the mapped outputs.
+
+#### Scenario: The palette serves the form
+
+- **GIVEN** the node catalog endpoint
+- **WHEN** the palette is fetched
+- **THEN** `openregister.decision-table` MUST be present with a non-empty
+  `configForm`
+- @e2e exclude catalog plumbing is flow-node-config-forms' tested surface;
+  the node's form content is unit-tested

--- a/openspec/changes/flow-decision-tables/tasks.md
+++ b/openspec/changes/flow-decision-tables/tasks.md
@@ -1,0 +1,64 @@
+# Tasks: flow-decision-tables
+
+## 1. The validator
+
+- [x] 1.1 `lib/Service/Dmn/DecisionTableValidator.php`: structural checks
+      (hit policy by name against the evaluator's implemented list, at
+      least one input/output/rule, unique names, positional entry counts,
+      integer `priority`) plus grammar checks that EXECUTE
+      `UnaryTestEvaluator::matches()` over every rule cell with a probe of
+      the column's effective type. Returns a list of problems naming rule
+      and column; never a boolean.
+- [x] 1.2 Expose `DecisionTableEvaluator::effectiveType()` and make the
+      implemented-hit-policy list public, so validator and evaluator cannot
+      drift. `normaliseFields()` switches to `effectiveType()`.
+
+## 2. The node
+
+- [x] 2.1 `lib/Service/Flow/Nodes/DecisionTableNode.php` implementing
+      `IFlowNode`, `IFlowNodeConfigKeys` and `IFlowNodeConfigForm`.
+      `getId()` returns `openregister.decision-table`; scope is admin and
+      user (reshaping data grants no privilege); EUPL-1.2 header; `@spec`
+      on every method.
+- [x] 2.2 `configKeys()`: `table`, `inputMapping`, `outputMapping`,
+      `defaultOutputs`, `resultKey`. `configForm()` describes each in the
+      Conduction voice (sentence case, no em-dashes), l10n throughout.
+- [x] 2.3 `validateConfig()`: table through the validator; mappings must be
+      string maps over declared names only, with literal (untemplated)
+      paths; `defaultOutputs` complete over the declared outputs and
+      refused on COLLECT; `resultKey` a non-empty literal path when
+      present.
+- [x] 2.4 `execute()`: per item — inputs via mapping paths (same-name
+      default, type-preserving dotted reads), evaluate through
+      `DecisionTableEvaluator`, `no_rule_matched` takes `defaultOutputs`
+      when configured and rethrows otherwise, outputs written via dotted
+      assign, optional `resultKey` record, provenance via
+      `FlowItems::item(fromItemIndex:)`. No suspension anywhere.
+- [x] 2.5 Register in `lib/Listener/FlowNodeRegistrationListener.php`.
+
+## 3. Tests
+
+- [x] 3.1 `tests/Unit/Service/Dmn/DecisionTableValidatorTest.php`: every
+      structural refusal, grammar refusals through the evaluator (bad
+      range, bad operand, bad literal for the column type), type aliases
+      accepted, a clean table over each of the five policies passing.
+- [x] 3.2 `tests/Unit/Service/Flow/Nodes/DecisionTableNodeTest.php`:
+      evaluation per hit policy (UNIQUE match + violation, FIRST,
+      PRIORITY with tie, ANY agree + disagree, COLLECT lists + empty),
+      mapping in and out over nested paths, missing input loud,
+      no-match default vs loud failure, validation refusals at the node
+      boundary, determinism (two firings, identical records), empty items,
+      provenance and binary pass-through.
+- [x] 3.3 The dossiq fixture: a table translated from the LHS enforcement
+      matrix (`LhsMatrixDecisionTableMigrator::tableFor()`'s shape) with
+      the `inputMapping`/`outputMapping` vocabulary of
+      `EvaluateDecisionHandler`, proving the migration's expressiveness
+      end to end.
+- [x] 3.4 Complete `@covers`/`@uses` on both test classes.
+
+## 4. Quality
+
+- [x] 4.1 Analyzers individually and in the foreground: phpcs, phpstan,
+      psalm, phpmd (per subdirectory), full Unit slice.
+- [x] 4.2 hydra gates `--scope-to-diff`, zero FAIL.
+- [x] 4.3 One PR to `development`.

--- a/tests/Unit/Listener/FlowNodeRegistrationListenerTest.php
+++ b/tests/Unit/Listener/FlowNodeRegistrationListenerTest.php
@@ -23,6 +23,7 @@ use OCA\OpenRegister\Listener\FlowNodeRegistrationListener;
 use OCA\OpenRegister\Service\Flow\FlowNodeRegistry;
 use OCA\OpenRegister\Service\Flow\IFlowNode;
 use OCA\OpenRegister\Service\Flow\Nodes\AwaitSignalNode;
+use OCA\OpenRegister\Service\Flow\Nodes\DecisionTableNode;
 use OCA\OpenRegister\Service\Flow\Nodes\EndNode;
 use OCA\OpenRegister\Service\Flow\Nodes\ExplodeNode;
 use OCA\OpenRegister\Service\Flow\Nodes\FilterNode;
@@ -92,6 +93,7 @@ class FlowNodeRegistrationListenerTest extends TestCase {
 			triggerManual: $mock(TriggerManualNode::class),
 			userTask: $mock(UserTaskNode::class),
 			portalTask: $mock(PortalTaskNode::class),
+			decisionTable: $mock(DecisionTableNode::class),
 		);
 
 		return $listener;
@@ -116,7 +118,7 @@ class FlowNodeRegistrationListenerTest extends TestCase {
 
 		$listener->handle(new RegisterFlowNodesEvent(registry: $registry));
 
-		$this->assertCount(24, $registered, 'all twenty-four built-ins are registered');
+		$this->assertCount(25, $registered, 'all twenty-five built-ins are registered');
 		$classes = array_map(static fn (IFlowNode $node): string => get_parent_class($node) ?: get_class($node), $registered);
 		foreach ([PortalTaskNode::class, UserTaskNode::class, AwaitSignalNode::class] as $waiter) {
 			$this->assertContains($waiter, $classes, "$waiter is registered");

--- a/tests/Unit/Service/Dmn/DecisionTableValidatorTest.php
+++ b/tests/Unit/Service/Dmn/DecisionTableValidatorTest.php
@@ -1,0 +1,266 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Dmn;
+
+use OCA\OpenRegister\Service\Dmn\DecisionTableEvaluator;
+use OCA\OpenRegister\Service\Dmn\DecisionTableValidator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The save-time table validator.
+ *
+ * The property under test is single: the accepted grammar is the executable
+ * grammar. Every refusal here is a run-time failure moved to the editor, and
+ * every acceptance is backed by the evaluator executing the same cell —
+ * because the validator PROBES the evaluator rather than parsing anything
+ * itself, the two cannot disagree.
+ *
+ * @covers \OCA\OpenRegister\Service\Dmn\DecisionTableValidator
+ * @uses \OCA\OpenRegister\Service\Dmn\DecisionTableEvaluator
+ * @uses \OCA\OpenRegister\Service\Dmn\UnaryTestEvaluator
+ * @uses \OCA\OpenRegister\Service\Dmn\DecisionEvaluationException
+ */
+class DecisionTableValidatorTest extends TestCase {
+
+	/**
+	 * The validator under test.
+	 *
+	 * @return DecisionTableValidator The validator.
+	 */
+	private function validator(): DecisionTableValidator {
+		return new DecisionTableValidator();
+
+	}//end validator()
+
+	/**
+	 * A minimal well-formed table.
+	 *
+	 * @param array<string, mixed> $overrides Keys to replace.
+	 *
+	 * @return array<string, mixed> The table.
+	 */
+	private function table(array $overrides = []): array {
+		return array_merge(
+			[
+				'hitPolicy' => 'UNIQUE',
+				'inputs' => [['name' => 'severity', 'type' => 'string']],
+				'outputs' => [['name' => 'intervention', 'type' => 'string']],
+				'rules' => [
+					[
+						'id' => 'r1',
+						'inputEntries' => ['ernstig'],
+						'outputEntries' => ['boete'],
+					],
+				],
+			],
+			$overrides
+		);
+
+	}//end table()
+
+	/**
+	 * A clean table passes under every implemented hit policy.
+	 *
+	 * @return void
+	 */
+	public function testCleanTablePassesUnderEveryImplementedPolicy(): void {
+		foreach (DecisionTableEvaluator::IMPLEMENTED_HIT_POLICIES as $policy) {
+			$problems = $this->validator()->validate(table: $this->table(['hitPolicy' => $policy]));
+			$this->assertSame([], $problems, 'policy ' . $policy);
+		}
+
+	}//end testCleanTablePassesUnderEveryImplementedPolicy()
+
+	/**
+	 * An unimplemented hit policy is refused BY NAME, so the author learns
+	 * which spelling the engine rejected rather than that "something" did.
+	 *
+	 * @return void
+	 */
+	public function testUnimplementedHitPolicyIsRefusedByName(): void {
+		$problems = $this->validator()->validate(table: $this->table(['hitPolicy' => 'OUTPUT ORDER']));
+
+		$this->assertCount(1, $problems);
+		$this->assertStringContainsString('OUTPUT ORDER', $problems[0]);
+		$this->assertStringContainsString('not implemented', $problems[0]);
+
+	}//end testUnimplementedHitPolicyIsRefusedByName()
+
+	/**
+	 * A table without inputs, outputs or rules can never decide anything and
+	 * is refused rather than saved as a silent no-op.
+	 *
+	 * @return void
+	 */
+	public function testEmptySidesAndEmptyRulesAreRefused(): void {
+		$this->assertNotSame([], $this->validator()->validate(table: $this->table(['inputs' => []])));
+		$this->assertNotSame([], $this->validator()->validate(table: $this->table(['outputs' => []])));
+		$this->assertNotSame([], $this->validator()->validate(table: $this->table(['rules' => []])));
+
+	}//end testEmptySidesAndEmptyRulesAreRefused()
+
+	/**
+	 * Results are keyed by name, so a duplicate column name would silently
+	 * collapse two columns into one answer.
+	 *
+	 * @return void
+	 */
+	public function testDuplicateColumnNamesAreRefused(): void {
+		$problems = $this->validator()->validate(
+			table: $this->table(
+				[
+					'outputs' => [
+						['name' => 'intervention', 'type' => 'string'],
+						['name' => 'intervention', 'type' => 'string'],
+					],
+					'rules' => [
+						['id' => 'r1', 'inputEntries' => ['ernstig'], 'outputEntries' => ['boete', 'boete']],
+					],
+				]
+			)
+		);
+
+		$this->assertNotSame([], $problems);
+		$this->assertStringContainsString('declared twice', $problems[0]);
+
+	}//end testDuplicateColumnNamesAreRefused()
+
+	/**
+	 * A short input row would be read as wildcards for the missing tail; a
+	 * short output row as nulls. Both are refused with the counts named.
+	 *
+	 * @return void
+	 */
+	public function testEntryCountMismatchesAreRefused(): void {
+		$problems = $this->validator()->validate(
+			table: $this->table(
+				[
+					'rules' => [
+						['id' => 'kort', 'inputEntries' => [], 'outputEntries' => ['boete']],
+						['id' => 'leeg', 'inputEntries' => ['ernstig'], 'outputEntries' => []],
+					],
+				]
+			)
+		);
+
+		$this->assertCount(2, $problems);
+		$this->assertStringContainsString('kort', $problems[0]);
+		$this->assertStringContainsString('wildcard', $problems[0]);
+		$this->assertStringContainsString('leeg', $problems[1]);
+
+	}//end testEntryCountMismatchesAreRefused()
+
+	/**
+	 * PRIORITY ranks by an integer; a string that looks like one is an
+	 * authoring error, not a coercion opportunity.
+	 *
+	 * @return void
+	 */
+	public function testNonIntegerPriorityIsRefused(): void {
+		$problems = $this->validator()->validate(
+			table: $this->table(
+				[
+					'rules' => [
+						['id' => 'r1', 'inputEntries' => ['ernstig'], 'outputEntries' => ['boete'], 'priority' => 'hoog'],
+					],
+				]
+			)
+		);
+
+		$this->assertCount(1, $problems);
+		$this->assertStringContainsString('non-integer priority', $problems[0]);
+
+	}//end testNonIntegerPriorityIsRefused()
+
+	/**
+	 * Grammar refusals come from the evaluator executing the cell, and the
+	 * problem names the rule and the column so the author can find it.
+	 *
+	 * @return void
+	 */
+	public function testMalformedCellsAreRefusedWithRuleAndColumn(): void {
+		$problems = $this->validator()->validate(
+			table: $this->table(
+				[
+					'inputs' => [['name' => 'bedrag', 'type' => 'number']],
+					'rules' => [
+						['id' => 'r1', 'inputEntries' => ['[5..'], 'outputEntries' => ['boete']],
+						['id' => 'r2', 'inputEntries' => ['>='], 'outputEntries' => ['boete']],
+						['id' => 'r3', 'inputEntries' => ['abc'], 'outputEntries' => ['boete']],
+					],
+				]
+			)
+		);
+
+		$this->assertCount(3, $problems);
+		$this->assertStringContainsString('r1', $problems[0]);
+		$this->assertStringContainsString('bedrag', $problems[0]);
+		$this->assertStringContainsString('r2', $problems[1]);
+		// `abc` on a number column is a literal that can never be coerced, so
+		// the rule could never match anything: an authoring error, not data.
+		$this->assertStringContainsString('r3', $problems[2]);
+		$this->assertStringContainsString('type_mismatch', $problems[2]);
+
+	}//end testMalformedCellsAreRefusedWithRuleAndColumn()
+
+	/**
+	 * The fleet's tables spell types in more than one vocabulary; the
+	 * validator honours the evaluator's aliases so a table the evaluator
+	 * would run is not refused over a spelling.
+	 *
+	 * @return void
+	 */
+	public function testAliasedAndUnknownTypesFollowTheEvaluator(): void {
+		$problems = $this->validator()->validate(
+			table: $this->table(
+				[
+					'inputs' => [
+						['name' => 'leeftijd', 'type' => 'integer'],
+						['name' => 'akkoord', 'type' => 'bool'],
+						['name' => 'vrij', 'type' => 'onbekend'],
+					],
+					'rules' => [
+						['id' => 'r1', 'inputEntries' => ['>=18', 'true', 'x'], 'outputEntries' => ['boete']],
+					],
+				]
+			)
+		);
+
+		$this->assertSame([], $problems);
+
+	}//end testAliasedAndUnknownTypesFollowTheEvaluator()
+
+	/**
+	 * Wildcards, quoted literals, ranges, comparisons and sets all execute:
+	 * the grammar the editor accepts is the one dossiq's tables already use.
+	 *
+	 * @return void
+	 */
+	public function testTheFullUnaryGrammarIsAccepted(): void {
+		$problems = $this->validator()->validate(
+			table: $this->table(
+				[
+					'inputs' => [
+						['name' => 'soort', 'type' => 'string'],
+						['name' => 'bedrag', 'type' => 'number'],
+					],
+					'rules' => [
+						['id' => 'r1', 'inputEntries' => ['-', '[0..25000]'], 'outputEntries' => ['boete']],
+						['id' => 'r2', 'inputEntries' => ['"-"', '> 25000'], 'outputEntries' => ['dwangsom']],
+						['id' => 'r3', 'inputEntries' => ['in (bouw, milieu)', '!= 0'], 'outputEntries' => ['waarschuwing']],
+					],
+				]
+			)
+		);
+
+		$this->assertSame([], $problems);
+
+	}//end testTheFullUnaryGrammarIsAccepted()
+}//end class

--- a/tests/Unit/Service/Flow/Nodes/DecisionTableNodeTest.php
+++ b/tests/Unit/Service/Flow/Nodes/DecisionTableNodeTest.php
@@ -1,0 +1,623 @@
+<?php
+
+/**
+ * Tests for the decision-table node.
+ *
+ * Two things carry the weight. First, the dossiq fixture: a table translated
+ * from dossiq's real LHS enforcement matrix, driven through the
+ * `inputMapping`/`outputMapping` vocabulary of dossiq's
+ * `EvaluateDecisionHandler` — if this node cannot express that table, the
+ * migration strands. Second, the refusals: a rule step that silently ignored
+ * a mapping, wildcarded a missing input, or wrote half a default row would
+ * report a completed decision that never happened.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow\Nodes
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @covers \OCA\OpenRegister\Service\Flow\Nodes\DecisionTableNode
+ * @uses \OCA\OpenRegister\Service\Dmn\DecisionTableEvaluator
+ * @uses \OCA\OpenRegister\Service\Dmn\DecisionTableValidator
+ * @uses \OCA\OpenRegister\Service\Dmn\UnaryTestEvaluator
+ * @uses \OCA\OpenRegister\Service\Dmn\DecisionEvaluationException
+ * @uses \OCA\OpenRegister\Service\Flow\FlowItems
+ * @uses \OCA\OpenRegister\Service\Flow\FlowValueTemplate
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Flow\Nodes;
+
+use OCA\OpenRegister\Service\Dmn\DecisionEvaluationException;
+use OCA\OpenRegister\Service\Dmn\DecisionTableEvaluator;
+use OCA\OpenRegister\Service\Dmn\DecisionTableValidator;
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\Nodes\DecisionTableNode;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
+
+/**
+ * DecisionTableNode behaviour.
+ */
+class DecisionTableNodeTest extends TestCase {
+
+	/**
+	 * The node under test.
+	 *
+	 * @var DecisionTableNode
+	 */
+	private DecisionTableNode $node;
+
+	/**
+	 * Build the node. The evaluator and validator are REAL, deliberately: a
+	 * mocked evaluator here would be the fake-agrees-with-the-caller shape,
+	 * and the whole point of the fixture is that the shared engine itself
+	 * decides dossiq's table.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnCallback(
+			static fn (string $text, array $params = []): string => vsprintf($text, $params)
+		);
+
+		$urls = $this->createMock(IURLGenerator::class);
+		$urls->method('imagePath')->willReturn('/icon.svg');
+
+		$this->node = new DecisionTableNode(
+			engine: new DecisionTableEvaluator(),
+			validator: new DecisionTableValidator(),
+			l10n: $l10n,
+			urls: $urls
+		);
+
+	}//end setUp()
+
+	/**
+	 * dossiq's LHS enforcement matrix, in the shape
+	 * `LhsMatrixDecisionTableMigrator::tableFor()` produces: three string
+	 * inputs, one output, UNIQUE, one rule per matrix cell.
+	 *
+	 * @return array<string, mixed> The table.
+	 */
+	private function lhsTable(): array {
+		return [
+			'name' => 'LHS',
+			'key' => 'lhs-matrix-1',
+			'hitPolicy' => 'UNIQUE',
+			'inputs' => [
+				['name' => 'severity', 'type' => 'string'],
+				['name' => 'behaviour', 'type' => 'string'],
+				['name' => 'actorType', 'type' => 'string'],
+			],
+			'outputs' => [['name' => 'intervention', 'type' => 'string']],
+			'rules' => [
+				[
+					'id' => 'ernstig:opzettelijk:bedrijf',
+					'inputEntries' => ['ernstig', 'opzettelijk', 'bedrijf'],
+					'outputEntries' => ['bestuurlijke boete'],
+				],
+				[
+					'id' => 'ernstig:onverschillig:bedrijf',
+					'inputEntries' => ['ernstig', 'onverschillig', 'bedrijf'],
+					'outputEntries' => ['last onder dwangsom'],
+				],
+				[
+					'id' => 'licht:goedwillend:burger',
+					'inputEntries' => ['licht', 'goedwillend', 'burger'],
+					'outputEntries' => ['waarschuwing'],
+				],
+			],
+		];
+
+	}//end lhsTable()
+
+	/**
+	 * A one-input, one-output table for the policy tests.
+	 *
+	 * @param string $hitPolicy The hit policy.
+	 * @param array<int, array<string, mixed>> $rules The rules.
+	 *
+	 * @return array<string, mixed> The table.
+	 */
+	private function table(string $hitPolicy, array $rules): array {
+		return [
+			'hitPolicy' => $hitPolicy,
+			'inputs' => [['name' => 'severity', 'type' => 'string']],
+			'outputs' => [['name' => 'intervention', 'type' => 'string']],
+			'rules' => $rules,
+		];
+
+	}//end table()
+
+	/**
+	 * One flow item.
+	 *
+	 * @param array<string, mixed> $json The record.
+	 *
+	 * @return array<string, mixed> The item.
+	 */
+	private function item(array $json): array {
+		return FlowItems::item(json: $json);
+
+	}//end item()
+
+	/**
+	 * The dossiq proof: the real LHS table, driven through dossiq's own
+	 * mapping vocabulary, decided by the shared engine inside the node.
+	 *
+	 * @return void
+	 */
+	public function testDossiqLhsTableDecidesAnItem(): void {
+		$config = [
+			'table' => $this->lhsTable(),
+			'inputMapping' => [
+				'severity' => 'case.severity',
+				'behaviour' => 'case.behaviour',
+				'actorType' => 'case.actorType',
+			],
+			'outputMapping' => ['intervention' => 'advies.maatregel'],
+			'resultKey' => 'advies.evaluatie',
+		];
+
+		$out = $this->node->execute(
+			items: [$this->item(['case' => ['severity' => 'ernstig', 'behaviour' => 'opzettelijk', 'actorType' => 'bedrijf']])],
+			config: $config,
+			context: []
+		);
+
+		$this->assertCount(1, $out);
+		$json = $out[0][FlowItems::JSON];
+		$this->assertSame('bestuurlijke boete', $json['advies']['maatregel']);
+		$this->assertSame(['ernstig:opzettelijk:bedrijf'], $json['advies']['evaluatie']['matchedRuleIds']);
+		$this->assertSame('UNIQUE', $json['advies']['evaluatie']['hitPolicy']);
+		$this->assertFalse($json['advies']['evaluatie']['defaulted']);
+		$this->assertSame('lhs-matrix-1', $json['advies']['evaluatie']['tableKey']);
+
+	}//end testDossiqLhsTableDecidesAnItem()
+
+	/**
+	 * Without mappings, every input reads and every output writes the field
+	 * carrying its own name — dossiq's same-name default, kept verbatim.
+	 *
+	 * @return void
+	 */
+	public function testSameNameDefaultsMapInputsAndOutputs(): void {
+		$out = $this->node->execute(
+			items: [$this->item(['severity' => 'licht', 'behaviour' => 'goedwillend', 'actorType' => 'burger'])],
+			config: ['table' => $this->lhsTable()],
+			context: []
+		);
+
+		$this->assertSame('waarschuwing', $out[0][FlowItems::JSON]['intervention']);
+
+	}//end testSameNameDefaultsMapInputsAndOutputs()
+
+	/**
+	 * The typed unary grammar decides typed item fields: a number read from
+	 * the item stays a number on its way into a range cell.
+	 *
+	 * @return void
+	 */
+	public function testTypedExpressionsDecideTypedInputs(): void {
+		$table = [
+			'hitPolicy' => 'FIRST',
+			'inputs' => [['name' => 'leeftijd', 'type' => 'number']],
+			'outputs' => [['name' => 'categorie', 'type' => 'string']],
+			'rules' => [
+				['id' => 'jong', 'inputEntries' => ['< 18'], 'outputEntries' => ['minderjarig']],
+				['id' => 'werk', 'inputEntries' => ['[18..67)'], 'outputEntries' => ['volwassen']],
+				['id' => 'oud', 'inputEntries' => ['>= 67'], 'outputEntries' => ['gepensioneerd']],
+			],
+		];
+
+		$out = $this->node->execute(
+			items: [$this->item(['leeftijd' => 42])],
+			config: ['table' => $table],
+			context: []
+		);
+
+		$this->assertSame('volwassen', $out[0][FlowItems::JSON]['categorie']);
+
+	}//end testTypedExpressionsDecideTypedInputs()
+
+	/**
+	 * UNIQUE with two matching rules is the evaluator's refusal, passed
+	 * through untouched so the step's onError policy sees the real fault.
+	 *
+	 * @return void
+	 */
+	public function testUniqueViolationFailsTheStep(): void {
+		$table = $this->table(
+			'UNIQUE',
+			[
+				['id' => 'r1', 'inputEntries' => ['-'], 'outputEntries' => ['boete']],
+				['id' => 'r2', 'inputEntries' => ['-'], 'outputEntries' => ['dwangsom']],
+			]
+		);
+
+		$this->expectException(DecisionEvaluationException::class);
+		$this->expectExceptionMessage('hit_policy_violation');
+
+		$this->node->execute(items: [$this->item(['severity' => 'x'])], config: ['table' => $table], context: []);
+
+	}//end testUniqueViolationFailsTheStep()
+
+	/**
+	 * FIRST takes declaration order.
+	 *
+	 * @return void
+	 */
+	public function testFirstTakesDeclarationOrder(): void {
+		$table = $this->table(
+			'FIRST',
+			[
+				['id' => 'r1', 'inputEntries' => ['-'], 'outputEntries' => ['eerste']],
+				['id' => 'r2', 'inputEntries' => ['-'], 'outputEntries' => ['tweede']],
+			]
+		);
+
+		$out = $this->node->execute(items: [$this->item(['severity' => 'x'])], config: ['table' => $table], context: []);
+
+		$this->assertSame('eerste', $out[0][FlowItems::JSON]['intervention']);
+
+	}//end testFirstTakesDeclarationOrder()
+
+	/**
+	 * PRIORITY takes the highest priority; an equal priority leaves the
+	 * earlier rule in place, so the outcome is deterministic.
+	 *
+	 * @return void
+	 */
+	public function testPriorityTakesHighestAndTiesBreakByOrder(): void {
+		$table = $this->table(
+			'PRIORITY',
+			[
+				['id' => 'laag', 'inputEntries' => ['-'], 'outputEntries' => ['laag'], 'priority' => 1],
+				['id' => 'hoog', 'inputEntries' => ['-'], 'outputEntries' => ['hoog'], 'priority' => 5],
+				['id' => 'gelijk', 'inputEntries' => ['-'], 'outputEntries' => ['gelijk'], 'priority' => 5],
+			]
+		);
+
+		$out = $this->node->execute(items: [$this->item(['severity' => 'x'])], config: ['table' => $table], context: []);
+
+		$this->assertSame('hoog', $out[0][FlowItems::JSON]['intervention']);
+
+	}//end testPriorityTakesHighestAndTiesBreakByOrder()
+
+	/**
+	 * ANY passes when every matching rule agrees and fails when they differ:
+	 * a disagreement is a fault in the table, not a choice to make silently.
+	 *
+	 * @return void
+	 */
+	public function testAnyAgreesOrFails(): void {
+		$agreeing = $this->table(
+			'ANY',
+			[
+				['id' => 'r1', 'inputEntries' => ['-'], 'outputEntries' => ['boete']],
+				['id' => 'r2', 'inputEntries' => ['-'], 'outputEntries' => ['boete']],
+			]
+		);
+
+		$out = $this->node->execute(items: [$this->item(['severity' => 'x'])], config: ['table' => $agreeing], context: []);
+		$this->assertSame('boete', $out[0][FlowItems::JSON]['intervention']);
+
+		$disagreeing = $this->table(
+			'ANY',
+			[
+				['id' => 'r1', 'inputEntries' => ['-'], 'outputEntries' => ['boete']],
+				['id' => 'r2', 'inputEntries' => ['-'], 'outputEntries' => ['dwangsom']],
+			]
+		);
+
+		$this->expectException(DecisionEvaluationException::class);
+		$this->node->execute(items: [$this->item(['severity' => 'x'])], config: ['table' => $disagreeing], context: []);
+
+	}//end testAnyAgreesOrFails()
+
+	/**
+	 * COLLECT writes one list per output, in declaration order, and an empty
+	 * match writes empty lists rather than failing: "nothing applied" is an
+	 * answer.
+	 *
+	 * @return void
+	 */
+	public function testCollectWritesListsAndEmptyMatchIsAnAnswer(): void {
+		$table = $this->table(
+			'COLLECT',
+			[
+				['id' => 'r1', 'inputEntries' => ['ernstig'], 'outputEntries' => ['boete']],
+				['id' => 'r2', 'inputEntries' => ['in (ernstig, matig)'], 'outputEntries' => ['dwangsom']],
+			]
+		);
+
+		$out = $this->node->execute(items: [$this->item(['severity' => 'ernstig'])], config: ['table' => $table], context: []);
+		$this->assertSame(['boete', 'dwangsom'], $out[0][FlowItems::JSON]['intervention']);
+
+		$out = $this->node->execute(items: [$this->item(['severity' => 'anders'])], config: ['table' => $table], context: []);
+		$this->assertSame([], $out[0][FlowItems::JSON]['intervention']);
+
+	}//end testCollectWritesListsAndEmptyMatchIsAnAnswer()
+
+	/**
+	 * No match without a default row is a loud failure for the onError
+	 * policy, never a silent empty result.
+	 *
+	 * @return void
+	 */
+	public function testNoMatchWithoutDefaultsFailsLoudly(): void {
+		$table = $this->table(
+			'FIRST',
+			[['id' => 'r1', 'inputEntries' => ['ernstig'], 'outputEntries' => ['boete']]]
+		);
+
+		$this->expectException(DecisionEvaluationException::class);
+		$this->expectExceptionMessage('no_rule_matched');
+
+		$this->node->execute(items: [$this->item(['severity' => 'anders'])], config: ['table' => $table], context: []);
+
+	}//end testNoMatchWithoutDefaultsFailsLoudly()
+
+	/**
+	 * No match with a complete default row decides the default, and the
+	 * evaluation record says so: defaulted, with no matched rule ids.
+	 *
+	 * @return void
+	 */
+	public function testNoMatchWithDefaultsDecidesTheDefault(): void {
+		$table = $this->table(
+			'FIRST',
+			[['id' => 'r1', 'inputEntries' => ['ernstig'], 'outputEntries' => ['boete']]]
+		);
+
+		$out = $this->node->execute(
+			items: [$this->item(['severity' => 'anders'])],
+			config: [
+				'table' => $table,
+				'defaultOutputs' => ['intervention' => 'geen actie'],
+				'resultKey' => 'evaluatie',
+			],
+			context: []
+		);
+
+		$json = $out[0][FlowItems::JSON];
+		$this->assertSame('geen actie', $json['intervention']);
+		$this->assertTrue($json['evaluatie']['defaulted']);
+		$this->assertSame([], $json['evaluatie']['matchedRuleIds']);
+
+	}//end testNoMatchWithDefaultsDecidesTheDefault()
+
+	/**
+	 * A missing input fails with the evaluator's typed error rather than
+	 * being wildcarded: a decision over absent data is not a decision. The
+	 * default row does NOT catch this — it answers "no rule matched", not
+	 * "the question could not be asked".
+	 *
+	 * @return void
+	 */
+	public function testMissingInputFailsLoudlyEvenWithDefaults(): void {
+		$this->expectException(DecisionEvaluationException::class);
+
+		$this->node->execute(
+			items: [$this->item(['behaviour' => 'opzettelijk', 'actorType' => 'bedrijf'])],
+			config: [
+				'table' => $this->lhsTable(),
+				'defaultOutputs' => ['intervention' => 'geen actie'],
+			],
+			context: []
+		);
+
+	}//end testMissingInputFailsLoudlyEvenWithDefaults()
+
+	/**
+	 * Determinism: the same item against the same configuration decides the
+	 * same way, and the second firing's records are identical to the first's.
+	 *
+	 * @return void
+	 */
+	public function testTheSameItemDecidesTheSameWayTwice(): void {
+		$config = ['table' => $this->lhsTable(), 'resultKey' => 'evaluatie'];
+		$items = [$this->item(['severity' => 'ernstig', 'behaviour' => 'onverschillig', 'actorType' => 'bedrijf'])];
+
+		$first = $this->node->execute(items: $items, config: $config, context: []);
+		$second = $this->node->execute(items: $items, config: $config, context: []);
+
+		$this->assertSame($first, $second);
+		$this->assertSame('last onder dwangsom', $first[0][FlowItems::JSON]['intervention']);
+
+	}//end testTheSameItemDecidesTheSameWayTwice()
+
+	/**
+	 * Items are decided independently, provenance points each output item at
+	 * its input, and binaries ride along untouched.
+	 *
+	 * @return void
+	 */
+	public function testItemsAreIndependentAndProvenanceIsKept(): void {
+		$out = $this->node->execute(
+			items: [
+				FlowItems::item(json: ['severity' => 'licht', 'behaviour' => 'goedwillend', 'actorType' => 'burger'], binary: ['scan' => 'blob']),
+				FlowItems::item(json: ['severity' => 'ernstig', 'behaviour' => 'opzettelijk', 'actorType' => 'bedrijf']),
+			],
+			config: ['table' => $this->lhsTable()],
+			context: []
+		);
+
+		$this->assertCount(2, $out);
+		$this->assertSame('waarschuwing', $out[0][FlowItems::JSON]['intervention']);
+		$this->assertSame('bestuurlijke boete', $out[1][FlowItems::JSON]['intervention']);
+		$this->assertSame(['scan' => 'blob'], $out[0][FlowItems::BINARY]);
+		$this->assertSame(['item' => 0], $out[0][FlowItems::PAIRED_ITEM]);
+		$this->assertSame(['item' => 1], $out[1][FlowItems::PAIRED_ITEM]);
+
+	}//end testItemsAreIndependentAndProvenanceIsKept()
+
+	/**
+	 * An empty firing returns nothing and touches nothing.
+	 *
+	 * @return void
+	 */
+	public function testEmptyItemsReturnEmpty(): void {
+		$this->assertSame([], $this->node->execute(items: [], config: [], context: []));
+
+	}//end testEmptyItemsReturnEmpty()
+
+	/**
+	 * The save-path refusals, one per silent failure they close off.
+	 *
+	 * @return void
+	 */
+	public function testMissingTableIsRefused(): void {
+		$this->expectException(UnexpectedValueException::class);
+		$this->node->validateConfig(config: []);
+
+	}//end testMissingTableIsRefused()
+
+	/**
+	 * An unimplemented hit policy is refused at save, by name.
+	 *
+	 * @return void
+	 */
+	public function testUnimplementedHitPolicyIsRefusedAtSave(): void {
+		$table = $this->lhsTable();
+		$table['hitPolicy'] = 'RULE ORDER';
+
+		$this->expectException(UnexpectedValueException::class);
+		$this->expectExceptionMessage('RULE ORDER');
+
+		$this->node->validateConfig(config: ['table' => $table]);
+
+	}//end testUnimplementedHitPolicyIsRefusedAtSave()
+
+	/**
+	 * A malformed rule cell cannot be saved; the refusal names the rule and
+	 * the column.
+	 *
+	 * @return void
+	 */
+	public function testMalformedCellIsRefusedAtSave(): void {
+		// `>=` with no operand is malformed on any column type; the string
+		// column cases that ARE executable (a bare `[5..` is a literal on a
+		// string column) belong to the validator's own suite.
+		$table = $this->lhsTable();
+		$table['rules'][0]['inputEntries'][0] = '>=';
+
+		$this->expectException(UnexpectedValueException::class);
+		$this->expectExceptionMessage('severity');
+
+		$this->node->validateConfig(config: ['table' => $table]);
+
+	}//end testMalformedCellIsRefusedAtSave()
+
+	/**
+	 * A mapping naming something the table does not declare is refused: the
+	 * step would silently ignore it, which looks like behaviour and is not.
+	 *
+	 * @return void
+	 */
+	public function testMappingOverUndeclaredNameIsRefused(): void {
+		$this->expectException(UnexpectedValueException::class);
+		$this->expectExceptionMessage('spookveld');
+
+		$this->node->validateConfig(
+			config: [
+				'table' => $this->lhsTable(),
+				'outputMapping' => ['spookveld' => 'ergens'],
+			]
+		);
+
+	}//end testMappingOverUndeclaredNameIsRefused()
+
+	/**
+	 * A templated mapping path is refused: a rule step's positions are the
+	 * author's, literally, never the data's.
+	 *
+	 * @return void
+	 */
+	public function testTemplatedMappingPathIsRefused(): void {
+		$this->expectException(UnexpectedValueException::class);
+		$this->expectExceptionMessage('templated');
+
+		$this->node->validateConfig(
+			config: [
+				'table' => $this->lhsTable(),
+				'outputMapping' => ['intervention' => 'advies.{{veld}}'],
+			]
+		);
+
+	}//end testTemplatedMappingPathIsRefused()
+
+	/**
+	 * A default row missing a declared output is refused: a partial default
+	 * writes half a decision.
+	 *
+	 * @return void
+	 */
+	public function testPartialDefaultRowIsRefused(): void {
+		$table = $this->lhsTable();
+		$table['outputs'][] = ['name' => 'termijn', 'type' => 'string'];
+		foreach ($table['rules'] as $index => $rule) {
+			$table['rules'][$index]['outputEntries'][] = '6 weken';
+		}
+
+		$this->expectException(UnexpectedValueException::class);
+		$this->expectExceptionMessage('termijn');
+
+		$this->node->validateConfig(
+			config: [
+				'table' => $table,
+				'defaultOutputs' => ['intervention' => 'geen actie'],
+			]
+		);
+
+	}//end testPartialDefaultRowIsRefused()
+
+	/**
+	 * A default row on COLLECT is refused: the empty list is the answer.
+	 *
+	 * @return void
+	 */
+	public function testDefaultsOnCollectAreRefused(): void {
+		$table = $this->lhsTable();
+		$table['hitPolicy'] = 'COLLECT';
+
+		$this->expectException(UnexpectedValueException::class);
+		$this->expectExceptionMessage('COLLECT');
+
+		$this->node->validateConfig(
+			config: [
+				'table' => $table,
+				'defaultOutputs' => ['intervention' => 'geen actie'],
+			]
+		);
+
+	}//end testDefaultsOnCollectAreRefused()
+
+	/**
+	 * The palette contract: the id, and a form field for every configurable
+	 * key so the canvas never edits a key the node ignores.
+	 *
+	 * @return void
+	 */
+	public function testPaletteAndFormCoverTheVocabulary(): void {
+		$this->assertSame('openregister.decision-table', $this->node->getId());
+		$this->assertNotSame('', $this->node->getDisplayName());
+		$this->assertNotSame('', $this->node->getDescription());
+
+		$formKeys = array_map(static fn (array $field): string => (string)$field['key'], $this->node->configForm());
+		$this->assertSame($this->node->configKeys(), $formKeys);
+
+	}//end testPaletteAndFormCoverTheVocabulary()
+}//end class


### PR DESCRIPTION
## Summary

OpenSpec change `flow-decision-tables`: a new node type `openregister.decision-table` puts rule evaluation into the flow graph. It evaluates a DMN-style decision table against each item through the shared evaluator from `shared-decision-table-evaluator` and writes the outputs onto configured item fields. dossiq is staging the retirement of its app-side decision tables against this node, per the directive that apps get no flow engines of their own.

## What changed

- `lib/Service/Flow/Nodes/DecisionTableNode.php`: the node. Implements `IFlowNode`, `IFlowNodeConfigKeys` and `IFlowNodeConfigForm`. Config keys: `table` (inline definition), `inputMapping`, `outputMapping` (name to dotted path, same-name default, dossiq's handler vocabulary kept verbatim), `defaultOutputs` (explicit no-match row), `resultKey` (optional evaluation record). Deterministic, per item, never suspends.
- `lib/Service/Dmn/DecisionTableValidator.php`: save-time validation that probes every rule cell through `UnaryTestEvaluator::matches()`, so the accepted grammar is the executable grammar by construction. Structural refusals: unimplemented hit policy by name, empty inputs/outputs/rules, duplicate column names, positional count mismatches, non-integer priority.
- `lib/Service/Dmn/DecisionTableEvaluator.php`: exposes `effectiveType()` and makes `IMPLEMENTED_HIT_POLICIES` public so validator and evaluator cannot drift. No behaviour change; the existing evaluator suite stays green.
- `lib/Listener/FlowNodeRegistrationListener.php`: registers the node as the 25th built-in.
- `openspec/changes/flow-decision-tables/`: proposal, design, tasks and spec. Design D-1 argues the storage decision: the table travels inline in the node config, so flow versioning, pinning and `x-openregister-flows` import apply with no extra machinery; a live object reference is refused there with reasons.

## Hit policies

All five the shared evaluator implements: UNIQUE, FIRST, PRIORITY, ANY, COLLECT. That is a superset of what dossiq's tables use. Anything else is refused at save, by name.

## No-match behaviour

A complete `defaultOutputs` row decides the default and flags `defaulted: true` in the evaluation record; without one the step fails loudly with `no_rule_matched` and the step's `onError` policy decides. A partial default row and a default row on COLLECT are refused at save.

## Tests

78 decision-table assertions green, including a fixture translated from dossiq's real LHS enforcement matrix driven through dossiq's own `inputMapping`/`outputMapping` vocabulary, per-policy evaluation, no-match both ways, determinism, and every validation refusal. Full local Unit slice run; the only new failures were the listener test arity, fixed here.

## Checks

- phpcs, phpstan, psalm: clean on the changed files
- phpmd (per subdirectory, foreground): clean
- hydra gates `--scope-to-diff`: all diff-scoped gates pass. Gates 22 and 53 fail on development HEAD as well: hydra-gates v1.10.0's vendored manifest schema does not know the `flow` page type that nc-vue 2.27.0 defines and `src/manifest.json` page 18 uses. That fix belongs in ConductionNL/.github (vendored schema bump), not here.

## For the dossiq migration

Replace an `evaluateDecision` transition action with an `openregister.decision-table` step: put the table definition under `table`, carry the existing `inputMapping`/`outputMapping` over unchanged, and add `defaultOutputs` only where a no-match should not fail the step. Nothing app-side needs to be declared or registered.
