### PR TITLE
feat(flow): the engine owns the two seams every consumer was rebuilding

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -526,7 +526,11 @@ class Application extends App implements IBootstrap {
 			\OCA\OpenRegister\Service\Flow\FlowStepDispatcher::class,
 			static function ($c) {
 				return new RegistryStepDispatcher(
-					registry: $c->get(\OCA\OpenRegister\Service\Flow\FlowNodeRegistry::class)
+					registry: $c->get(\OCA\OpenRegister\Service\Flow\FlowNodeRegistry::class),
+					// The acting-identity scope IS container state, unlike the
+					// guard: a loop's body steps must scope a contributed node
+					// to the run's runAs exactly as top-level steps do.
+					scope: $c->get(\OCA\OpenRegister\Service\Flow\FlowRunAsScope::class)
 				);
 			}
 		);

--- a/lib/Controller/FlowRunController.php
+++ b/lib/Controller/FlowRunController.php
@@ -35,8 +35,9 @@ use OCA\OpenRegister\Service\Flow\FlowItems;
 use OCA\OpenRegister\Service\Flow\FlowDeadEnd;
 use OCA\OpenRegister\Service\Flow\FlowLifecycleRefused;
 use OCA\OpenRegister\Service\Flow\FlowLocator;
-use OCA\OpenRegister\Service\Flow\FlowRunAssignee;
+use OCA\OpenRegister\Exception\FlowSignalRefused;
 use OCA\OpenRegister\Service\Flow\FlowRunService;
+use OCA\OpenRegister\Service\Flow\FlowRunSignalService;
 use OCA\OpenRegister\Service\Flow\FlowService;
 use OCA\OpenRegister\Service\OrganisationService;
 use OCP\AppFramework\Controller;
@@ -97,6 +98,14 @@ class FlowRunController extends Controller {
 	 *                                           caller; absent, the endpoint
 	 *                                           reports the surface unavailable
 	 *                                           rather than an empty run.
+	 * @param FlowRunSignalService|null $signalService The guarded signal seam the
+	 *                                                 resume endpoints delegate to.
+	 *                                                 Nullable and appended so no
+	 *                                                 construction site shifts;
+	 *                                                 absent, one is built on
+	 *                                                 demand from this
+	 *                                                 controller's own
+	 *                                                 collaborators.
 	 */
 	public function __construct(
 		string $appName,
@@ -112,6 +121,7 @@ class FlowRunController extends Controller {
 		// inserted anywhere else shifts every positional caller, and the
 		// resulting TypeError names the argument AFTER the one that moved.
 		private readonly ?AuditFlowAttribution $auditTrails = null,
+		private readonly ?FlowRunSignalService $signalService = null,
 	) {
 		parent::__construct(appName: $appName, request: $request);
 
@@ -681,21 +691,16 @@ class FlowRunController extends Controller {
 			return $refusal;
 		}
 
-		$refusal = $this->refuseUnlessAssignee(run: $run);
-		if ($refusal !== null) {
-			return $refusal;
-		}
-
 		$payload = $this->request->getParams();
 		// Routing artefacts, not part of what the signaller is telling the run.
 		unset($payload['uuid'], $payload['_route']);
 
-		$signalled = $this->runner->signal(run: $run, payload: $payload);
-		if ($signalled === null) {
-			return new JSONResponse(
-				['error' => 'Only a suspended run can be resumed; this one is ' . $run->getStatus() . '.'],
-				Http::STATUS_CONFLICT
-			);
+		// The guard and the delivery are ONE seam — the same one a PHP consumer
+		// calls — so who may answer is decided in exactly one place.
+		try {
+			$signalled = $this->signals()->signalRunAs(run: $run, payload: $payload, actorUid: $this->callerUid());
+		} catch (FlowSignalRefused $refused) {
+			return $this->refusalResponse(refused: $refused, run: $run, verb: 'resumed');
 		}
 
 		return new JSONResponse($signalled->jsonSerialize());
@@ -762,21 +767,15 @@ class FlowRunController extends Controller {
 			return $refusal;
 		}
 
-		$refusal = $this->refuseUnlessAssignee(run: $run);
-		if ($refusal !== null) {
-			return $refusal;
-		}
-
 		$payload = $this->request->getParams();
 		// Routing artefacts, not part of what the signaller is telling the run.
 		unset($payload['key'], $payload['_route']);
 
-		$signalled = $this->runner->signal(run: $run, payload: $payload);
-		if ($signalled === null) {
-			return new JSONResponse(
-				['error' => 'Only a suspended run can be signalled; this one is ' . $run->getStatus() . '.'],
-				Http::STATUS_CONFLICT
-			);
+		// Same seam as resume() and as every PHP consumer: one guard.
+		try {
+			$signalled = $this->signals()->signalRunAs(run: $run, payload: $payload, actorUid: $this->callerUid());
+		} catch (FlowSignalRefused $refused) {
+			return $this->refusalResponse(refused: $refused, run: $run, verb: 'signalled');
 		}
 
 		return new JSONResponse($signalled->jsonSerialize());
@@ -823,70 +822,66 @@ class FlowRunController extends Controller {
 	}//end refuseUnlessRunnable()
 
 	/**
-	 * Refuse when the awaiting step names an assignee and the caller is not it.
+	 * Translate the seam's typed refusal into this endpoint's HTTP contract.
 	 *
-	 * WHY THIS EXISTS. `AwaitSignalNode` has always RECORDED an `assignee` on
-	 * the suspension, and nothing ever read it back. The run-level check above
-	 * asks "may you run this flow?", which is a different question from "is
-	 * this decision yours to make": everyone who could run the flow could
-	 * approve a step assigned to someone else, and the recorded assignee made
-	 * it look otherwise. ADR-098 names this gap — "no task authz — anyone
-	 * reaching the resume endpoint can decide".
+	 * The GUARD lives in {@see FlowRunSignalService} — the same seam a PHP
+	 * consumer calls, so who may answer is decided in one place (ADR-098 named
+	 * the gap this closes: "no task authz — anyone reaching the resume endpoint
+	 * can decide"). What stays here is only the WORDING, which differs per
+	 * endpoint and is part of the existing HTTP contract.
 	 *
-	 * Scope, stated honestly: this closes the WHO of an already-recorded
-	 * assignment. It is not the task entity, inbox or definition versioning
-	 * ADR-098 describes, and a step with no assignee is unchanged — silence
-	 * still means anyone, because tightening that would break every existing
-	 * webhook and child-run signal, which are not human decisions at all.
+	 * A step with no assignee is unchanged — silence still means anyone,
+	 * because tightening that would break every existing webhook and child-run
+	 * signal, which are not human decisions at all.
 	 *
-	 * @param FlowRun $run The suspended run.
+	 * @param FlowSignalRefused $refused The seam's refusal.
+	 * @param FlowRun $run The run the signal addressed.
+	 * @param string $verb This endpoint's verb for the 409 wording ('resumed' or 'signalled').
 	 *
-	 * @return JSONResponse|null A 403 when the caller is not the assignee.
+	 * @return JSONResponse The 403 or 409 the refusal maps to.
+	 *
+	 * @spec openspec/changes/flow-engine-consumer-seams/specs/flow-engine-consumer-seams/spec.md#requirement-a-server-side-signal-passes-the-same-guard-as-the-http-resume
 	 */
-	private function refuseUnlessAssignee(FlowRun $run): ?JSONResponse {
-		// The rule itself lives in FlowRunAssignee, because HTTP is no longer
-		// the only way to answer a step: a leaf app whose object completes a
-		// task resumes the run in-process through FlowRunService::signal(),
-		// which never passes this controller. One implementation, so the two
-		// paths cannot drift into disagreeing about who may answer.
-		$assignee = $this->assignees()->recordedFor(run: $run);
-		if ($assignee === '') {
-			return null;
-		}
+	private function refusalResponse(FlowSignalRefused $refused, FlowRun $run, string $verb): JSONResponse {
+		if ($refused->getReason() === FlowSignalRefused::NOT_ASSIGNEE) {
+			if ($refused->getActorUid() === null) {
+				return new JSONResponse(
+					['error' => 'This step is assigned; sign in as the assignee to answer it.'],
+					Http::STATUS_FORBIDDEN
+				);
+			}
 
-		$uid = $this->callerUid();
-
-		if ($this->assignees()->mayAnswer(run: $run, uid: $uid) === true) {
-			return null;
-		}
-
-		if ($uid === null) {
 			return new JSONResponse(
-				['error' => 'This step is assigned; sign in as the assignee to answer it.'],
+				['error' => 'This step is assigned to someone else.'],
 				Http::STATUS_FORBIDDEN
 			);
 		}
 
 		return new JSONResponse(
-			['error' => 'This step is assigned to someone else.'],
-			Http::STATUS_FORBIDDEN
+			['error' => 'Only a suspended run can be ' . $verb . '; this one is ' . $run->getStatus() . '.'],
+			Http::STATUS_CONFLICT
 		);
-	}//end refuseUnlessAssignee()
+	}//end refusalResponse()
 
 	/**
-	 * The assignee rule, made on demand when none was injected.
+	 * The guarded signal seam, made on demand when none was injected.
 	 *
 	 * Built locally rather than required as a constructor argument so adding it
-	 * breaks no existing construction site; it holds no state, so a locally
-	 * made one is indistinguishable from an injected one.
+	 * breaks no existing construction site. The refusal a locally-built seam
+	 * cannot log still reaches the caller as the 403 above, so nothing is
+	 * silent; the container-built instance audits too.
 	 *
-	 * @return FlowRunAssignee The rule.
+	 * @return FlowRunSignalService The seam.
 	 *
-	 * @spec openspec/specs/flow-engine/spec.md#requirement-a-run-suspended-on-an-external-signal-must-be-reachable
+	 * @spec openspec/changes/flow-engine-consumer-seams/specs/flow-engine-consumer-seams/spec.md#requirement-a-server-side-signal-passes-the-same-guard-as-the-http-resume
 	 */
-	private function assignees(): FlowRunAssignee {
-		return new FlowRunAssignee(groupManager: $this->groupManager);
-	}//end assignees()
+	private function signals(): FlowRunSignalService {
+		return ($this->signalService ?? new FlowRunSignalService(
+			mapper: $this->mapper,
+			runner: $this->runner,
+			groupManager: $this->groupManager
+		));
+	}//end signals()
 
 	/**
 	 * The current caller's uid, or null when anonymous.

--- a/lib/Exception/FlowSignalRefused.php
+++ b/lib/Exception/FlowSignalRefused.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * A server-side signal was refused before anything was delivered.
+ *
+ * The guarded signal seam ({@see \OCA\OpenRegister\Service\Flow\FlowRunSignalService})
+ * refuses with THIS exception rather than a nullable return, deliberately: the
+ * unguarded primitive already uses `null` to mean "not suspended", and a guard
+ * whose refusal can be ignored by ignoring a return value is not a guard. A
+ * caller that catches this has been told exactly why — the reason constant —
+ * without matching on message strings.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Exception
+ * @package  OCA\OpenRegister\Exception
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-engine-consumer-seams/specs/flow-engine-consumer-seams/spec.md#requirement-a-server-side-signal-passes-the-same-guard-as-the-http-resume
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Exception;
+
+use RuntimeException;
+
+/**
+ * Thrown by the guarded signal seam when a signal may not be delivered.
+ */
+class FlowSignalRefused extends RuntimeException {
+	/**
+	 * No run carries the given uuid.
+	 *
+	 * @var string
+	 */
+	public const RUN_NOT_FOUND = 'run-not-found';
+
+	/**
+	 * The awaiting step is assigned, and the actor is not its assignee.
+	 *
+	 * @var string
+	 */
+	public const NOT_ASSIGNEE = 'not-assignee';
+
+	/**
+	 * The run is not suspended, so there is nothing to answer.
+	 *
+	 * @var string
+	 */
+	public const NOT_SUSPENDED = 'not-suspended';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $reason One of the reason constants.
+	 * @param string $message What went wrong, for a human.
+	 * @param string $runUuid The run the signal addressed.
+	 * @param string|null $actorUid The refused actor, or null when anonymous.
+	 */
+	public function __construct(
+		private readonly string $reason,
+		string $message,
+		private readonly string $runUuid = '',
+		private readonly ?string $actorUid = null,
+	) {
+		parent::__construct(message: $message);
+	}//end __construct()
+
+	/**
+	 * Why the signal was refused — one of the reason constants.
+	 *
+	 * @return string The reason.
+	 */
+	public function getReason(): string {
+		return $this->reason;
+	}//end getReason()
+
+	/**
+	 * The run the refused signal addressed.
+	 *
+	 * @return string The run uuid, or '' when unknown.
+	 */
+	public function getRunUuid(): string {
+		return $this->runUuid;
+	}//end getRunUuid()
+
+	/**
+	 * The refused actor.
+	 *
+	 * @return string|null The actor uid, or null when the caller was anonymous.
+	 */
+	public function getActorUid(): ?string {
+		return $this->actorUid;
+	}//end getActorUid()
+}//end class

--- a/lib/Service/Flow/FlowMessagingService.php
+++ b/lib/Service/Flow/FlowMessagingService.php
@@ -518,7 +518,7 @@ class FlowMessagingService {
 	 * @spec openspec/changes/flow-messaging-nodes/specs/flow-messaging-nodes/spec.md#requirement-flow-sends-are-attributed-logged-and-bounded
 	 */
 	private function resolveActingUser(array $context): string {
-		$uid = ($context['runAs'] ?? null);
+		$uid = ($context[FlowRunService::RUN_AS_CONTEXT_KEY] ?? null);
 		if (is_string($uid) === false || trim($uid) === '') {
 			throw new RuntimeException(
 				'This flow run has no acting identity (runAs); a message must have a sender, so nothing was sent.'

--- a/lib/Service/Flow/FlowRunAsScope.php
+++ b/lib/Service/Flow/FlowRunAsScope.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * Runs a contributed node's work as the run's acting identity.
+ *
+ * WHY THIS EXISTS. The engine stamps the run's `runAs` into every node
+ * context, and its OWN storage-touching nodes wrap their work in
+ * `ObjectService::runAs()` — because the permission gate (MagicRbacHandler /
+ * MagicOrganizationHandler) reads the AMBIENT SESSION user, not a parameter.
+ * Under the cron worker that session carries nobody, so a bare write is
+ * refused as anonymous no matter whose rights the run declares. A CONTRIBUTED
+ * node used to get the context key and nothing else: every consuming app had
+ * to build this exact wrapper itself, and dossiq shipped three broken nodes
+ * (plus MergeTemplateHandler, a fourth) before it did. The identity is
+ * run-level state, so scoping to it belongs to the engine — this class is the
+ * engine-owned twin of dossiq's `FlowRunAsScope`, which becomes deletable.
+ *
+ * 🔴 IT NARROWS, NEVER GRANTS. `runAs()` sets the session subject to a NAMED
+ * user for the duration of the callable; a run whose identity cannot write is
+ * still refused, and now for the right reason. Deliberately not
+ * `runAsSystem()`: a flow node executes user-authored input, which is exactly
+ * the caller ADR-099 forbids from reaching the userless principal.
+ *
+ * WHEN THE CONTEXT NAMES NOBODY the operation runs bare, under whatever
+ * session is ambient — the interactive path, where the logged-in user IS the
+ * acting identity and no `runAs` key was stamped.
+ *
+ * WHEN THE CONTEXT NAMES SOMEBODY UNUSABLE it refuses loudly. An identity
+ * that resolves to no account, or to a DISABLED one, is a run that must stop,
+ * not a write that silently happens as someone else. Rights are re-resolved
+ * at the moment work runs precisely so a revocation takes effect: a run
+ * parked for weeks must not resume with the rights of somebody who has since
+ * been offboarded. The same refusal shape as `ObjectWriteNode::resolveOwner()`,
+ * because it is the same rule.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-engine-consumer-seams/specs/flow-engine-consumer-seams/spec.md#requirement-a-contributed-node-executes-under-the-runs-acting-identity
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\IUserManager;
+use RuntimeException;
+
+/**
+ * Validates the run's acting identity and scopes a callable to it.
+ *
+ * @spec openspec/changes/flow-engine-consumer-seams/specs/flow-engine-consumer-seams/spec.md#requirement-a-contributed-node-executes-under-the-runs-acting-identity
+ */
+class FlowRunAsScope {
+	/**
+	 * Constructor.
+	 *
+	 * @param IUserManager $userManager Resolves the named identity to a real account.
+	 * @param ObjectService $objectService Owns the session-scoping seam every
+	 *                                     RBAC and organisation predicate reads.
+	 */
+	public function __construct(
+		private readonly IUserManager $userManager,
+		private readonly ObjectService $objectService,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * Run the operation as the context's acting identity, when it names one.
+	 *
+	 * @param array $context The node context, possibly carrying the identity
+	 *                       under {@see FlowRunService::RUN_AS_CONTEXT_KEY}.
+	 * @param callable $operation The node's work.
+	 *
+	 * @return mixed Whatever the operation returns.
+	 *
+	 * @throws RuntimeException When the named identity cannot be acted as.
+	 *
+	 * @spec openspec/changes/flow-engine-consumer-seams/specs/flow-engine-consumer-seams/spec.md#requirement-a-contributed-node-executes-under-the-runs-acting-identity
+	 */
+	public function call(array $context, callable $operation): mixed {
+		$uid = trim((string)($context[FlowRunService::RUN_AS_CONTEXT_KEY] ?? ''));
+		if ($uid === '') {
+			// No acting identity declared: the interactive path, where the
+			// ambient session user already answers the permission checks.
+			return $operation();
+		}
+
+		$user = $this->userManager->get($uid);
+		if ($user === null) {
+			throw new RuntimeException(
+				sprintf('This flow run\'s acting identity "%s" (runAs) is not a user account; the step is refused.', $uid)
+			);
+		}
+
+		if ($user->isEnabled() === false) {
+			throw new RuntimeException(
+				sprintf('This flow run\'s acting identity "%s" (runAs) is a disabled account; the step is refused.', $uid)
+			);
+		}
+
+		return $this->objectService->runAs($user, $operation);
+	}//end call()
+}//end class

--- a/lib/Service/Flow/FlowRunAssignee.php
+++ b/lib/Service/Flow/FlowRunAssignee.php
@@ -74,17 +74,35 @@ class FlowRunAssignee {
 	 * several nodes across its life, so the one that matters is a slot that
 	 * ASKED (`askedAt`) and has not been answered.
 	 *
+	 * WITH A NODE ID, the addressed node's own slot decides. A run can await
+	 * several nodes at once, each with its own assignee, and the run-level scan
+	 * answers with the FIRST asked slot's — which refuses the second node's own
+	 * audience. A `nodeId` whose slot is NOT held falls through to the scan:
+	 * naming a node that asked nothing must not become a way around the guard
+	 * on the node that did.
+	 *
 	 * @param FlowRun $run The suspended run.
+	 * @param string|null $nodeId The node the answer addresses, when the caller knows it.
 	 *
 	 * @return string The assignee uid or group id; '' when the step is unassigned.
 	 *
-	 * @spec openspec/specs/flow-engine/spec.md#requirement-a-run-suspended-on-an-external-signal-must-be-reachable
+	 * @spec openspec/changes/flow-engine-consumer-seams/specs/flow-engine-consumer-seams/spec.md#requirement-a-server-side-signal-passes-the-same-guard-as-the-http-resume
 	 */
-	public function recordedFor(FlowRun $run): string {
+	public function recordedFor(FlowRun $run, ?string $nodeId = null): string {
 		$context = ($run->getContext() ?? []);
 		$slots = ($context[FlowResumeState::CONTEXT_KEY] ?? []);
 		if (is_array($slots) === false) {
 			return '';
+		}
+
+		$nodeId = trim((string)$nodeId);
+		if ($nodeId !== '') {
+			$slot = ($slots[$nodeId] ?? null);
+			if (is_array($slot) === true && isset($slot['askedAt']) === true) {
+				// The addressed node is asking; ITS record decides, including
+				// an empty one — an unassigned step is deliberately open.
+				return trim((string)($slot['assignee'] ?? ''));
+			}
 		}
 
 		foreach ($slots as $slot) {
@@ -110,13 +128,16 @@ class FlowRunAssignee {
 	 *
 	 * @param FlowRun     $run The suspended run.
 	 * @param string|null $uid The acting user, or null when there is no session.
+	 * @param string|null $nodeId The node the answer addresses, when the caller
+	 *                            knows it — see {@see recordedFor()} for how
+	 *                            addressing narrows and never loosens.
 	 *
 	 * @return boolean True when the answer may be accepted.
 	 *
 	 * @spec openspec/specs/flow-engine/spec.md#requirement-a-run-suspended-on-an-external-signal-must-be-reachable
 	 */
-	public function mayAnswer(FlowRun $run, ?string $uid): bool {
-		$assignee = $this->recordedFor(run: $run);
+	public function mayAnswer(FlowRun $run, ?string $uid, ?string $nodeId = null): bool {
+		$assignee = $this->recordedFor(run: $run, nodeId: $nodeId);
 
 		// Unassigned is deliberately open — see the class docblock. This is the
 		// one branch that must NOT be tightened without changing the spec.

--- a/lib/Service/Flow/FlowRunService.php
+++ b/lib/Service/Flow/FlowRunService.php
@@ -87,6 +87,39 @@ class FlowRunService {
 	public const SIGNAL_CONTEXT_KEY = 'signal';
 
 	/**
+	 * The context key the run's ACTING IDENTITY travels under.
+	 *
+	 * Stamped by {@see self::baseContextFor()} from the run — never from the
+	 * context, per ADR-099 — and read back by every node whose work needs the
+	 * run's rights. Exported so consumers reference one name instead of each
+	 * hard-coding the literal; the VALUE is frozen, because it is stored inside
+	 * every parked run's context and a rename would strand them.
+	 *
+	 * @var string
+	 */
+	public const RUN_AS_CONTEXT_KEY = 'runAs';
+
+	/**
+	 * The acting-identity scope handed to every dispatcher this service builds.
+	 *
+	 * Resolved lazily from the container and cached — see {@see identityScope()}.
+	 *
+	 * @var FlowRunAsScope|null
+	 */
+	private ?FlowRunAsScope $runAsScope = null;
+
+	/**
+	 * Whether the lazy resolution above has been attempted.
+	 *
+	 * A separate flag because null is ALSO a valid outcome: a harness container
+	 * that cannot build the scope answers null once rather than being asked on
+	 * every step.
+	 *
+	 * @var boolean
+	 */
+	private bool $runAsScopeResolved = false;
+
+	/**
 	 * Loads and writes back the state that belongs to the FLOW, not the run.
 	 *
 	 * A separate collaborator because it handles a different lifetime: the token
@@ -295,7 +328,7 @@ class FlowRunService {
 			flow: $flow,
 			store: new FlowRunMarkingStore(run: $run),
 			subject: $subject,
-			dispatcher: new RegistryStepDispatcher(registry: $this->registry, guard: $guard),
+			dispatcher: new RegistryStepDispatcher(registry: $this->registry, guard: $guard, scope: $this->identityScope()),
 			context: $context,
 			items: ($run->getItems() ?? []),
 			startAt: null,
@@ -401,7 +434,7 @@ class FlowRunService {
 		// Assignment, not coalesce: the run wins over anything the stored context
 		// carries. See the docblock — a context-supplied acting identity would be
 		// an authoring-time privilege escalation.
-		$context['runAs'] = $run->getRunAs();
+		$context[self::RUN_AS_CONTEXT_KEY] = $run->getRunAs();
 
 		return $context;
 	}//end baseContextFor()
@@ -457,6 +490,39 @@ class FlowRunService {
 
 		return $context;
 	}//end nodeContextFor()
+
+	/**
+	 * The acting-identity scope for the dispatchers this service builds.
+	 *
+	 * Resolved from the container rather than the constructor so adding it
+	 * breaks no existing construction site, and LAZILY because most of what
+	 * this service does (queueing, listing, signalling) never dispatches a
+	 * node. A container that cannot build one — the unit harness — answers
+	 * null, and the dispatcher then runs nodes bare, which is the harness's
+	 * existing contract; every production container can build it.
+	 *
+	 * @return FlowRunAsScope|null The scope, or null when the container cannot build one.
+	 *
+	 * @spec openspec/changes/flow-engine-consumer-seams/specs/flow-engine-consumer-seams/spec.md#requirement-a-contributed-node-executes-under-the-runs-acting-identity
+	 */
+	private function identityScope(): ?FlowRunAsScope {
+		if ($this->runAsScopeResolved === true) {
+			return $this->runAsScope;
+		}
+
+		$this->runAsScopeResolved = true;
+
+		try {
+			$scope = $this->container->get(FlowRunAsScope::class);
+			if ($scope instanceof FlowRunAsScope === true) {
+				$this->runAsScope = $scope;
+			}
+		} catch (Throwable $e) {
+			$this->runAsScope = null;
+		}
+
+		return $this->runAsScope;
+	}//end identityScope()
 
 
 
@@ -761,6 +827,17 @@ class FlowRunService {
 	 * walk ({@see self::persistResult()}), so a node reads the answer to ITS
 	 * question rather than one left behind by an earlier suspension.
 	 *
+	 * 🔴 THIS IS THE UNGUARDED PRIMITIVE, for trusted engine-internal delivery
+	 * only: it checks the run's STATUS and nothing about the CALLER, so calling
+	 * it directly is asserting "whoever I am acting for has already been
+	 * allowed to answer this". Everything outside the engine goes through
+	 * {@see FlowRunSignalService::signalAs()}, which applies the
+	 * recorded-assignee guard (group resolution included) and audits a refusal
+	 * — the HTTP resume endpoints use that same seam, so there is exactly one
+	 * guard. A consumer that calls this method instead has re-opened the gap
+	 * the seam exists to close, silently: the wrong person's answer arrives
+	 * correctly formatted.
+	 *
 	 * @param FlowRun $run The suspended run to wake.
 	 * @param array $payload What the signaller wants the run to know.
 	 *
@@ -858,7 +935,7 @@ class FlowRunService {
 				flow: $flow,
 				store: new FlowRunMarkingStore(run: $run),
 				subject: $subject,
-				dispatcher: new RegistryStepDispatcher(registry: $this->registry, guard: $guard),
+				dispatcher: new RegistryStepDispatcher(registry: $this->registry, guard: $guard, scope: $this->identityScope()),
 				context: $context,
 				items: $items,
 				startAt: $start,

--- a/lib/Service/Flow/FlowRunSignalService.php
+++ b/lib/Service/Flow/FlowRunSignalService.php
@@ -1,0 +1,221 @@
+<?php
+
+/**
+ * The guarded way to answer a suspended run on somebody's behalf.
+ *
+ * WHY THIS EXISTS. The assignee rule ({@see FlowRunAssignee}) has one
+ * implementation, but until now the engine left CALLING it to the consumer:
+ * the HTTP resume endpoint consulted it, while an app resuming a run from PHP
+ * called `FlowRunService::signal()` directly — which delivers unconditionally.
+ * dossiq's two resume listeners each remembered to consult the rule first, and
+ * "each caller must remember" is the failure mode: the next app forgets, and a
+ * forgotten check does not throw — it lets the wrong person answer somebody
+ * else's step, correctly formatted, HTTP 200. This service is the verb the
+ * rule was missing: resolve, guard, audit, deliver.
+ *
+ * ONE GUARD. The HTTP resume path delegates here too, so a change to who may
+ * answer is a change to exactly one place. `FlowRunService::signal()` remains
+ * the unguarded engine-internal primitive underneath.
+ *
+ * THE GUARD, STATED HONESTLY. It is the recorded-assignee rule and nothing
+ * more: an assigned step admits its assignee (group resolution included) and
+ * refuses everyone else, an unassigned step admits anyone — webhook and
+ * child-run signals are not human decisions. It does not decide whether the
+ * actor may SEE the flow; an HTTP caller gets that from the controller's
+ * flow-level check, and a PHP caller is already inside the trust boundary
+ * where the object it reacted to was resolved.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-engine-consumer-seams/specs/flow-engine-consumer-seams/spec.md#requirement-a-server-side-signal-passes-the-same-guard-as-the-http-resume
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+use OCA\OpenRegister\Db\FlowRun;
+use OCA\OpenRegister\Db\FlowRunMapper;
+use OCA\OpenRegister\Exception\FlowSignalRefused;
+use OCP\IGroupManager;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Delivers a signal to a suspended run, on behalf of a named actor, guarded.
+ *
+ * @spec openspec/changes/flow-engine-consumer-seams/specs/flow-engine-consumer-seams/spec.md#requirement-a-server-side-signal-passes-the-same-guard-as-the-http-resume
+ */
+class FlowRunSignalService {
+	/**
+	 * Constructor.
+	 *
+	 * @param FlowRunMapper $mapper Resolves a run uuid to the run.
+	 * @param FlowRunService $runner Owns the unguarded delivery primitive.
+	 * @param LoggerInterface|null $logger Audits a refusal. Nullable so the
+	 *                                     controller can build this seam on
+	 *                                     demand without one — there the
+	 *                                     refusal is surfaced to the caller as
+	 *                                     a 403, so nothing goes unrecorded;
+	 *                                     the container-built instance always
+	 *                                     has a logger.
+	 * @param IGroupManager|null $groupManager Resolves group assignment. Absent,
+	 *                                         a group-assigned step refuses
+	 *                                         rather than admits — the
+	 *                                         fail-closed direction.
+	 * @param FlowRunAssignee|null $assignees The access rule. Injectable so a
+	 *                                        consumer's test can drive the real
+	 *                                        contract; defaults to the real one.
+	 */
+	public function __construct(
+		private readonly FlowRunMapper $mapper,
+		private readonly FlowRunService $runner,
+		private readonly ?LoggerInterface $logger = null,
+		private readonly ?IGroupManager $groupManager = null,
+		private readonly ?FlowRunAssignee $assignees = null,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * Answer a suspended run by uuid, as a named actor, guarded.
+	 *
+	 * The entry point for PHP consumers — a listener whose object completes a
+	 * task holds exactly a run uuid. Resolution, the guard and delivery are
+	 * one call, so there is nothing left for the consumer to remember.
+	 *
+	 * @param string $runUuid The run to answer.
+	 * @param array $payload What the signaller wants the run to know.
+	 * @param string|null $actorUid Who is answering; null or '' means anonymous,
+	 *                              which an ASSIGNED step refuses.
+	 * @param string|null $nodeId The node the answer addresses, when known. The
+	 *                            guard then checks THAT node's recorded
+	 *                            assignee; addressing can narrow the check but
+	 *                            never loosen it — see {@see FlowRunAssignee::recordedFor()}.
+	 *
+	 * @return FlowRun The parked run, due for the worker's next pass.
+	 *
+	 * @throws FlowSignalRefused With reason RUN_NOT_FOUND, NOT_ASSIGNEE or NOT_SUSPENDED.
+	 *
+	 * @spec openspec/changes/flow-engine-consumer-seams/specs/flow-engine-consumer-seams/spec.md#requirement-a-server-side-signal-passes-the-same-guard-as-the-http-resume
+	 */
+	public function signalAs(string $runUuid, array $payload, ?string $actorUid, ?string $nodeId = null): FlowRun {
+		try {
+			$run = $this->mapper->findByUuid($runUuid);
+		} catch (Throwable $e) {
+			throw new FlowSignalRefused(
+				reason: FlowSignalRefused::RUN_NOT_FOUND,
+				message: 'No run carries uuid "' . $runUuid . '"; the signal was not delivered.',
+				runUuid: $runUuid,
+				actorUid: $this->normalize(actorUid: $actorUid)
+			);
+		}
+
+		return $this->signalRunAs(run: $run, payload: $payload, actorUid: $actorUid, nodeId: $nodeId);
+	}//end signalAs()
+
+	/**
+	 * Answer an already-resolved run, as a named actor, guarded.
+	 *
+	 * For callers that resolved the run themselves — the HTTP endpoints, whose
+	 * 404 wording is their own. The guard and the delivery are identical to
+	 * {@see signalAs()}; a refusal touches nothing.
+	 *
+	 * @param FlowRun $run The run to answer.
+	 * @param array $payload What the signaller wants the run to know.
+	 * @param string|null $actorUid Who is answering; null or '' means anonymous.
+	 * @param string|null $nodeId The node the answer addresses, when known.
+	 *
+	 * @return FlowRun The parked run, due for the worker's next pass.
+	 *
+	 * @throws FlowSignalRefused With reason NOT_ASSIGNEE or NOT_SUSPENDED.
+	 *
+	 * @spec openspec/changes/flow-engine-consumer-seams/specs/flow-engine-consumer-seams/spec.md#requirement-a-server-side-signal-passes-the-same-guard-as-the-http-resume
+	 */
+	public function signalRunAs(FlowRun $run, array $payload, ?string $actorUid, ?string $nodeId = null): FlowRun {
+		$actor = $this->normalize(actorUid: $actorUid);
+		$rule = ($this->assignees ?? new FlowRunAssignee(groupManager: $this->groupManager));
+
+		if ($rule->mayAnswer(run: $run, uid: $actor, nodeId: $nodeId) === false) {
+			$this->auditRefusal(run: $run, actor: $actor, assignee: $rule->recordedFor(run: $run, nodeId: $nodeId), nodeId: $nodeId);
+
+			throw new FlowSignalRefused(
+				reason: FlowSignalRefused::NOT_ASSIGNEE,
+				message: 'The awaiting step of run "' . (string)$run->getUuid()
+					. '" is assigned, and the acting user is not its assignee; the signal was not delivered.',
+				runUuid: (string)$run->getUuid(),
+				actorUid: $actor
+			);
+		}
+
+		$signalled = $this->runner->signal(run: $run, payload: $payload);
+		if ($signalled === null) {
+			throw new FlowSignalRefused(
+				reason: FlowSignalRefused::NOT_SUSPENDED,
+				message: 'Only a suspended run can be signalled; run "' . (string)$run->getUuid()
+					. '" is ' . (string)$run->getStatus() . '.',
+				runUuid: (string)$run->getUuid(),
+				actorUid: $actor
+			);
+		}
+
+		return $signalled;
+	}//end signalRunAs()
+
+	/**
+	 * An empty actor is an anonymous one.
+	 *
+	 * @param string|null $actorUid The claimed actor.
+	 *
+	 * @return string|null The uid, or null when there is effectively none.
+	 */
+	private function normalize(?string $actorUid): ?string {
+		if ($actorUid === null || trim($actorUid) === '') {
+			return null;
+		}
+
+		return trim($actorUid);
+	}//end normalize()
+
+	/**
+	 * Record who was refused from answering what.
+	 *
+	 * The refusal ALSO reaches the caller as an exception, but the caller may
+	 * be a listener that can only log it locally — dossiq's task listener sees
+	 * the refusal after the task is already saved, so the only trace of "the
+	 * wrong person tried to advance this decision" is this record. Written by
+	 * the engine so it exists whether or not the consumer remembers to.
+	 *
+	 * @param FlowRun $run The run the signal addressed.
+	 * @param string|null $actor Who tried, or null when anonymous.
+	 * @param string $assignee Who the step is recorded for.
+	 * @param string|null $nodeId The addressed node, when the caller named one.
+	 *
+	 * @return void
+	 */
+	private function auditRefusal(FlowRun $run, ?string $actor, string $assignee, ?string $nodeId): void {
+		$this->logger?->warning(
+			message: '[FlowRunSignalService] Refused a signal: the actor is not the awaiting step\'s assignee',
+			context: [
+				'file' => __FILE__,
+				'line' => __LINE__,
+				'run' => (string)$run->getUuid(),
+				'flow' => (string)$run->getFlowId(),
+				'actor' => ($actor ?? '(anonymous)'),
+				'assignee' => $assignee,
+				'node' => ($nodeId ?? ''),
+			]
+		);
+
+	}//end auditRefusal()
+}//end class

--- a/lib/Service/Flow/IFlowSelfScopedNode.php
+++ b/lib/Service/Flow/IFlowSelfScopedNode.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * The escape hatch from the dispatcher's acting-identity scoping.
+ *
+ * The dispatcher executes every CONTRIBUTED node inside the run's `runAs`
+ * identity ({@see FlowRunAsScope}), so an app node's reads and writes inherit
+ * the run's rights without the app building a wrapper. A node that declares
+ * THIS interface is executed bare instead — under whatever session is ambient,
+ * which under the cron worker is nobody.
+ *
+ * DECLARING IT IS TAKING ON OBLIGATIONS, and they are worth reading twice:
+ *
+ * - the node manages its own acting identity for every read and write it
+ *   performs, the way the engine's own nodes do — validating that the
+ *   identity exists and is enabled before acting as it;
+ * - a node whose work is genuinely system-level (installation plumbing,
+ *   shipped-data seeding) still may NOT reach `ObjectService::runAsSystem()`
+ *   from node code — ADR-099 forbids the userless principal to flow nodes,
+ *   and `SystemOperationContextBoundaryTest` pins the call-site set;
+ * - an unscoped write that "works" under an interactive session and is
+ *   refused under the worker is exactly the defect the default wrap removes.
+ *   Opting out re-opens it, for this node, deliberately.
+ *
+ * The honest use is a node that performs NO register work at all, or one
+ * whose scoping needs differ per call in a way the run-level identity cannot
+ * express — and such a node documents its reasoning where it declares this.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-engine-consumer-seams/specs/flow-engine-consumer-seams/spec.md#requirement-a-contributed-node-executes-under-the-runs-acting-identity
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+/**
+ * Marks a contributed node that manages its own acting identity.
+ */
+interface IFlowSelfScopedNode {
+
+}//end interface

--- a/lib/Service/Flow/Nodes/ObjectReadNode.php
+++ b/lib/Service/Flow/Nodes/ObjectReadNode.php
@@ -70,6 +70,7 @@ use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\FlowRunService;
 use OCA\OpenRegister\Service\Flow\FlowValueTemplate;
 use OCA\OpenRegister\Service\Flow\IFlowNode;
 use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
@@ -475,7 +476,7 @@ class ObjectReadNode implements IFlowNode, IFlowNodeConfigKeys {
 		// For a scheduled run they differ — the cause is a schedule, the acting
 		// identity is the user the trigger declares — and reading provenance here
 		// is what made a scheduled read execute as whoever authored the flow.
-		$uid = ($context['runAs'] ?? null);
+		$uid = ($context[FlowRunService::RUN_AS_CONTEXT_KEY] ?? null);
 		if (is_string($uid) === false || trim($uid) === '') {
 			throw new RuntimeException(
 				$this->l10n->t('This flow run has no acting identity (runAs); an object read must be attributable.')

--- a/lib/Service/Flow/Nodes/ObjectWriteNode.php
+++ b/lib/Service/Flow/Nodes/ObjectWriteNode.php
@@ -96,6 +96,7 @@ use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\FlowRunService;
 use OCA\OpenRegister\Service\Flow\IFlowNode;
 use OCA\OpenRegister\Service\Flow\IFlowNodeConfigForm;
 use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
@@ -1528,7 +1529,7 @@ class ObjectWriteNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfig
 		// For a scheduled run they differ — the cause is a schedule, the acting
 		// identity is the user the trigger declares — and reading provenance here
 		// is what made a scheduled write execute as whoever authored the flow.
-		$uid = ($context['runAs'] ?? null);
+		$uid = ($context[FlowRunService::RUN_AS_CONTEXT_KEY] ?? null);
 		if (is_string($uid) === false || trim($uid) === '') {
 			throw new RuntimeException(
 				$this->l10n->t('This flow run has no acting identity (runAs); an object write must be attributable.')

--- a/lib/Service/Flow/RegistryStepDispatcher.php
+++ b/lib/Service/Flow/RegistryStepDispatcher.php
@@ -48,10 +48,19 @@ class RegistryStepDispatcher implements FlowStepDispatcher {
 	 *                                 callers with no run to guard — the flow
 	 *                                 tester and the node unit tests dispatch
 	 *                                 without one.
+	 * @param FlowRunAsScope|null $scope Executes a CONTRIBUTED node as the
+	 *                                   run's acting identity. Null only for a
+	 *                                   dispatcher built by hand with no
+	 *                                   container behind it — the flow tester
+	 *                                   and the node unit tests — which then
+	 *                                   runs every node bare, exactly like the
+	 *                                   nullable guard; all three production
+	 *                                   construction sites supply one.
 	 */
 	public function __construct(
 		private readonly FlowNodeRegistry $registry,
 		private readonly ?FlowRunGuard $guard = null,
+		private readonly ?FlowRunAsScope $scope = null,
 	) {
 
 	}//end __construct()
@@ -117,7 +126,7 @@ class RegistryStepDispatcher implements FlowStepDispatcher {
 		$this->scopeSignal(context: $context, scoped: $scoped);
 
 		$startedAt = microtime(true);
-		$out = $node->execute(items: $items, config: $config, context: $context);
+		$out = $this->executeScoped(node: $node, items: $items, config: $config, context: $context);
 		$tookMs = (int)round((microtime(true) - $startedAt) * 1000);
 
 		// Reached only when the node RETURNED. A node that suspends throws, so
@@ -132,6 +141,56 @@ class RegistryStepDispatcher implements FlowStepDispatcher {
 
 		return $out;
 	}//end dispatch()
+
+	/**
+	 * Execute the node — a CONTRIBUTED one inside the run's acting identity.
+	 *
+	 * The engine's `runAs` used to reach a contributed node as a context key
+	 * and nothing more: unless the app built its own wrapper, every write the
+	 * node performed ran under the ambient session — which under the cron
+	 * worker is nobody, so it was refused as anonymous no matter whose rights
+	 * the run declared. dossiq shipped three broken nodes (and a fourth
+	 * handler) before building that wrapper. The identity is run-level state,
+	 * so the dispatcher applies it: every consumer inherits the scoping
+	 * instead of re-implementing it.
+	 *
+	 * WHO IS WRAPPED. A node whose class lives under `OCA\OpenRegister\` is
+	 * the engine's own and already scopes itself — `ObjectWriteNode` and
+	 * friends validate and wrap internally, with node-specific wording and
+	 * skip-when semantics — so wrapping it again would change the ambient
+	 * identity of nodes that deliberately run bare. Everything else is
+	 * contributed and runs inside {@see FlowRunAsScope}, which validates the
+	 * identity (exists, enabled — refused loudly otherwise) and NARROWS to it;
+	 * a contributed node that must manage its own identity declares
+	 * {@see IFlowSelfScopedNode}, the documented escape hatch.
+	 *
+	 * A context that names NO identity runs the node bare either way — the
+	 * interactive path — so a dispatcher walking a tester context changes
+	 * nothing.
+	 *
+	 * @param IFlowNode $node The resolved node.
+	 * @param array $items The input items.
+	 * @param array $config The step configuration.
+	 * @param array $context The node context.
+	 *
+	 * @return array The output items.
+	 *
+	 * @spec openspec/changes/flow-engine-consumer-seams/specs/flow-engine-consumer-seams/spec.md#requirement-a-contributed-node-executes-under-the-runs-acting-identity
+	 */
+	private function executeScoped(IFlowNode $node, array $items, array $config, array $context): array {
+		$engineOwned = str_starts_with(get_class($node), 'OCA\\OpenRegister\\');
+
+		if ($this->scope === null || $engineOwned === true || $node instanceof IFlowSelfScopedNode === true) {
+			return $node->execute(items: $items, config: $config, context: $context);
+		}
+
+		return (array)$this->scope->call(
+			context: $context,
+			operation: static function () use ($node, $items, $config, $context): array {
+				return $node->execute(items: $items, config: $config, context: $context);
+			}
+		);
+	}//end executeScoped()
 
 	/**
 	 * Put this node's resume slot into the context it is about to be called with.

--- a/openspec/changes/flow-engine-consumer-seams/.openspec.yaml
+++ b/openspec/changes/flow-engine-consumer-seams/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-02

--- a/openspec/changes/flow-engine-consumer-seams/design.md
+++ b/openspec/changes/flow-engine-consumer-seams/design.md
@@ -1,0 +1,134 @@
+# Design: flow-engine-consumer-seams
+
+## Context
+
+The state of the code today:
+
+- `FlowRunAssignee` (`lib/Service/Flow/FlowRunAssignee.php`) already holds the
+  ONE copy of the "who may answer" rule — uid match, group resolution,
+  unassigned-is-open, anonymous-fails-closed. What the engine does not hold is
+  a guarded VERB: `FlowRunController::refuseUnlessAssignee()` consults the
+  rule for HTTP, and every PHP caller of `FlowRunService::signal()` must
+  remember to consult it themselves. dossiq's two listeners do; the seam
+  exists so the third consumer does not have to.
+- `FlowRunService::baseContextFor()` stamps `$context['runAs'] =
+  $run->getRunAs()` on every walk — assignment, not coalesce, per ADR-099
+  (identity narrows, never widens; a context-supplied identity would be a
+  queue-time privilege escalation). The literal `'runAs'` is read back in
+  `ObjectWriteNode`, `ObjectReadNode` and `FlowMessagingService`, and by
+  dossiq's `FlowRunAsScope` — with no exported constant to reference.
+- `RegistryStepDispatcher::dispatch()` checkpoints the guard, scopes the
+  resume slot, scopes the signal (#3325), executes the node, clears the slot.
+  It is constructed at three sites: twice inside `FlowRunService` (execute and
+  the #3310 stream walk — both with a per-run guard) and once as a container
+  factory in `Application.php` (guardless; the loop node's dispatcher).
+- OpenRegister's own storage-touching nodes each wrap their work in
+  `ObjectService::runAs()` after validating the identity exists and is
+  enabled (`ObjectWriteNode::resolveOwner()`). A contributed node starts with
+  none of that.
+
+## Decisions
+
+### D-1: The signal seam wraps the existing rule; it does not replace it
+
+`FlowRunSignalService` composes `FlowRunAssignee` + `FlowRunMapper` +
+`FlowRunService::signal()`. The rule object stays exactly where it is and
+keeps its contract (unassigned means anyone; anonymous fails closed; group
+membership admits). What the seam adds is the VERB: resolve the run, apply
+the rule for a NAMED actor, audit a refusal, deliver. Two methods:
+
+- `signalAs(runUuid, payload, actorUid, nodeId?)` — for callers holding a
+  uuid (dossiq's listeners hold exactly that).
+- `signalRunAs(run, payload, actorUid, nodeId?)` — for callers that already
+  resolved the run (the controller, which must 404 before it 403s).
+
+Refusals are one typed exception, `FlowSignalRefused`, carrying a reason
+constant. An exception rather than a nullable return because the unguarded
+primitive already uses `null` to mean "not suspended", and a seam whose
+refusal can be ignored by ignoring a return value is not a guard.
+
+### D-2: The HTTP path migrates onto the seam, byte-identical
+
+`resume()` and `signalByKey()` keep their own run resolution (their 404/409
+wording differs per endpoint and is asserted by existing tests) and delegate
+the guard + delivery to `signalRunAs()`. `refuseUnlessAssignee()` and the
+controller's private rule factory are deleted — the controller no longer
+touches `FlowRunAssignee` at all. Status codes, bodies and the
+routing-artefact stripping are unchanged, so no contract test moves.
+
+### D-3: `nodeId` narrows the guard to the addressed slot, and can only narrow
+
+A run can await several nodes at once, each with its own recorded assignee.
+The run-level rule answers with the FIRST asked slot's assignee, which
+refuses the second node's own audience. When the caller names the node its
+answer addresses, the guard checks THAT node's recorded assignee. A `nodeId`
+whose slot is not held (the node is not asking) falls back to the run-level
+rule — naming a node that asked nothing must not become a way around the
+guard on the node that did.
+
+### D-4: The dispatcher scopes contributed nodes; engine nodes are untouched
+
+The identity wrap happens in `RegistryStepDispatcher::dispatch()`, around
+`$node->execute()` only — after the checkpoint, the resume-slot scoping and
+the signal scoping (#3325), and before the per-node budget check, so neither
+#3325's addressing nor #3310's stream walk changes shape.
+
+Which nodes: a node whose class lives under `OCA\OpenRegister\` manages its
+own scoping today (`ObjectWriteNode` et al. validate and wrap internally,
+with node-specific error wording and skip-when semantics) and is left alone —
+wrapping it again would be harmless for writes but would change the ambient
+identity of nodes that deliberately run bare. Everything else is contributed
+and gets the wrap, unless it implements `IFlowSelfScopedNode` — the
+documented escape hatch for a node that must manage its own identity (for
+example one whose work is legitimately system-level installation plumbing;
+such a node takes on the obligations the interface docblock names).
+
+Semantics match dossiq's `FlowRunAsScope`, which mirrored
+`ObjectWriteNode::resolveOwner()`:
+
+- context names NO identity → the node runs bare (the interactive path, and
+  every existing test fixture);
+- identity resolves to no account → refuse loudly;
+- identity resolves to a DISABLED account → refuse loudly, so a run parked
+  for weeks cannot resume with an offboarded user's rights;
+- identity valid → `ObjectService::runAs($user, execute)`. Narrowing only:
+  a run whose owner cannot write is still refused, now for the right reason.
+
+### D-5: The scope collaborator is nullable, and null means the harness
+
+The dispatcher's scope is resolved from the container (`FlowRunService`
+resolves it lazily; the `Application.php` factory injects it). A dispatcher
+built by hand with none — the flow tester, node unit tests — runs nodes bare,
+exactly as the nullable `FlowRunGuard` already works. This is not fail-open
+in production: all three production construction sites supply the scope, and
+the refusal tests pin the behaviour when it is present.
+
+### D-6: The context key becomes a constant, and the value is frozen
+
+`FlowRunService::RUN_AS_CONTEXT_KEY = 'runAs'`. The literal is stored inside
+every parked run's context, so the VALUE can never change; the constant
+exists so readers (engine nodes, the messaging service, consuming apps)
+reference one name. All in-tree literal reads migrate to it.
+
+## Follow-ups (audit gaps NOT built here)
+
+The fleet audit named four engine gaps; this change closes two. The other two
+are recorded so the change record is honest about scope:
+
+- **Request-scoped trigger**: apps that trigger flows from a live request
+  still queue through the worker; a request-scoped fire-and-return seam is a
+  separate change.
+- **Shared retry-policy vocabulary**: each app still declares its own retry
+  semantics for failed runs; a shared vocabulary (and its config schema) is a
+  separate change.
+
+## Risks / Trade-offs
+
+- **A contributed node that relied on running bare while its run named a
+  `runAs` changes behaviour** — it now executes under the run's identity, or
+  is refused if that identity is stale. That is the point; the escape hatch
+  is the opt-out and its docblock names the cost.
+- **Class-namespace as the engine/contributed test** is a heuristic, but a
+  stable one: the namespace is claimed by this app's autoloader, and a
+  contributed node cannot live under it. The marker interface exists for the
+  cases the heuristic cannot express.

--- a/openspec/changes/flow-engine-consumer-seams/proposal.md
+++ b/openspec/changes/flow-engine-consumer-seams/proposal.md
@@ -1,0 +1,92 @@
+---
+kind: code
+depends_on: [flow-approval-consolidation]
+---
+
+# Proposal: flow-engine-consumer-seams
+
+## Summary
+
+Close the two engine gaps the fleet audit handed back, both of the shape
+"every consuming app re-implements a rule the engine should own":
+
+1. **A guarded server-side signal API.** `FlowRunSignalService::signalAs()`
+   resumes a suspended run on behalf of a named actor and applies the
+   recorded-assignee guard (group resolution included) before anything is
+   delivered, auditing a refusal. The HTTP resume path migrates onto the same
+   seam, so there is ONE guard. `FlowRunService::signal()` stays as the
+   unguarded engine-internal primitive and is documented as such.
+
+2. **Native `runAs` scoping for contributed nodes.** `RegistryStepDispatcher`
+   resolves the run's acting identity (validated: the account exists and is
+   enabled, refused loudly otherwise) and executes every CONTRIBUTED node
+   inside `ObjectService::runAs()`, so an app node's writes inherit the run's
+   identity without the app building a wrapper. The context key is exported as
+   a constant, and a documented escape hatch exists for nodes that manage
+   their own scoping. OpenRegister's own nodes are unaffected — they already
+   scope themselves.
+
+## Why
+
+**Gap 1 — the guard only lives on the HTTP path.** The assignee rule was
+extracted into `FlowRunAssignee` precisely because in-process resumes exist,
+but the engine still leaves CALLING it to the consumer:
+`FlowRunController::refuseUnlessAssignee()` applies it for HTTP, while an app
+that resumes from PHP calls `FlowRunService::signal()` directly — which
+delivers unconditionally. dossiq's `TaskCompletionResumeListener` and
+`ParaafResumeListener` each remembered to consult the rule (and
+mutation-tested it), but "each caller must remember" is the defect class: the
+next app forgets, and a forgotten check does not throw — it lets the wrong
+person answer somebody else's step, HTTP 200. The engine must offer the
+guarded verb so the unguarded primitive stops being the obvious API.
+
+**Gap 2 — app nodes execute as nobody.** The engine stamps the run's `runAs`
+into the node context, and its OWN write-capable nodes (`ObjectWriteNode`,
+`ObjectReadNode`) wrap their storage calls in `ObjectService::runAs()` —
+because the RBAC handlers read the ambient session, which under a cron worker
+carries no one. A contributed node gets the context key and nothing else:
+unless the app builds its own wrapper, every write it performs is refused as
+anonymous (or worse, silently executed under whatever ambient identity a
+request happens to carry). dossiq shipped THREE broken nodes before building
+`FlowRunAsScope`, and `MergeTemplateHandler` was a fourth. The identity is
+run-level state; scoping to it belongs in the dispatcher that hands the node
+its context, not in every app.
+
+**Measured this week:** two shipped dossiq defects trace to these gaps; the
+audit found the same re-implementation pressure in every consuming app.
+
+## What Changes
+
+- New `lib/Service/Flow/FlowRunSignalService.php` — `signalAs(runUuid,
+  payload, actorUid, nodeId?)` and `signalRunAs(run, …)`: resolve, guard
+  (via the existing `FlowRunAssignee` rule), audit a refusal, deliver via
+  `FlowRunService::signal()`.
+- New `lib/Exception/FlowSignalRefused.php` — one typed refusal with a reason
+  (`run-not-found`, `not-assignee`, `not-suspended`) so PHP callers and the
+  controller map it without string-matching.
+- `FlowRunAssignee` learns an optional `nodeId`: a caller that knows WHICH
+  node its answer addresses is checked against that node's recorded assignee;
+  naming a node that is not asking falls back to the run-level rule, so
+  addressing can never loosen the guard.
+- `FlowRunController::resume()` and `signalByKey()` migrate onto the seam;
+  their routes, status codes and response bodies are byte-identical.
+- `FlowRunService::signal()` is documented as the trusted engine-internal
+  primitive; `FlowRunService` exports `RUN_AS_CONTEXT_KEY`.
+- New `lib/Service/Flow/FlowRunAsScope.php` — validates and applies the acting
+  identity (mirrors dossiq's service of the same name, which becomes
+  deletable).
+- New `lib/Service/Flow/IFlowSelfScopedNode.php` — the escape hatch marker for
+  contributed nodes that manage their own identity.
+- `RegistryStepDispatcher` executes contributed nodes inside the scope.
+
+## Impact
+
+- Affected specs: `flow-engine-consumer-seams` (new capability, delta spec in
+  this change).
+- Affected code: `lib/Service/Flow/` (dispatcher, run service, assignee rule,
+  two new services, one marker interface), `lib/Controller/FlowRunController.php`,
+  `lib/Exception/`, `lib/AppInfo/Application.php`.
+- No route, migration or frontend changes. The HTTP contract is unchanged.
+- Consuming apps: dossiq's `FlowRunAsScope` and the guard block in its two
+  resume listeners become deletable once they adopt the seam; the next app
+  never builds either.

--- a/openspec/changes/flow-engine-consumer-seams/specs/flow-engine-consumer-seams/spec.md
+++ b/openspec/changes/flow-engine-consumer-seams/specs/flow-engine-consumer-seams/spec.md
@@ -1,0 +1,120 @@
+## Purpose
+
+The two seams every consuming app was re-implementing: a guarded server-side
+signal verb, and native acting-identity scoping for contributed nodes.
+
+## ADDED Requirements
+
+### Requirement: A server-side signal passes the same guard as the HTTP resume
+
+The engine SHALL provide a guarded server-side signal verb —
+`FlowRunSignalService::signalAs()` — that resumes a suspended run on behalf
+of a NAMED actor. It SHALL apply the same recorded-assignee rule as the HTTP
+resume endpoint, group resolution included, through the same implementation
+(`FlowRunAssignee`), so the two paths cannot drift.
+
+A refusal SHALL be a typed exception naming its reason (run not found, actor
+not the assignee, run not suspended) and SHALL be audited with the run, the
+actor and the recorded assignee. A refused signal SHALL NOT touch the run.
+
+The unguarded primitive `FlowRunService::signal()` SHALL remain for
+engine-internal delivery and SHALL be documented as such; consumers outside
+the engine use the guarded verb.
+
+A caller MAY name the node its answer addresses. The guard then SHALL check
+that node's recorded assignee; naming a node that is not awaiting an answer
+SHALL fall back to the run-level rule, so addressing can never loosen the
+guard. A step that records no assignee remains answerable by anyone, per the
+existing contract.
+
+The HTTP resume endpoints SHALL delegate to this seam, so exactly one guard
+exists.
+
+#### Scenario: The recorded assignee may answer
+- **GIVEN** a run suspended on a step assigned to alice
+- **WHEN** `signalAs` is called with actor alice
+- **THEN** the run MUST become due and carry the payload
+- @e2e exclude server-side PHP seam — covered by FlowRunSignalServiceTest
+
+#### Scenario: A member of the assigned group may answer
+- **GIVEN** a run suspended on a step assigned to group reviewers
+- **WHEN** `signalAs` is called with an actor who is in reviewers
+- **THEN** the run MUST become due and carry the payload
+- @e2e exclude server-side PHP seam — covered by FlowRunSignalServiceTest
+
+#### Scenario: A stranger is refused and the run is untouched
+- **GIVEN** a run suspended on a step assigned to alice
+- **WHEN** `signalAs` is called with actor mallory
+- **THEN** the call MUST be refused with reason not-assignee
+- **AND** the run MUST remain suspended with no payload delivered
+- **AND** the refusal MUST be audited
+- @e2e exclude server-side PHP seam — covered by FlowRunSignalServiceTest
+
+#### Scenario: An unassigned step is answerable by anyone
+- **GIVEN** a run suspended on a step that records no assignee
+- **WHEN** `signalAs` is called with any actor
+- **THEN** the run MUST become due
+- @e2e exclude server-side PHP seam — covered by FlowRunSignalServiceTest
+
+#### Scenario: Addressing a node checks that node's assignee
+- **GIVEN** a run awaiting node A (assigned to alice) and node B (assigned to bob)
+- **WHEN** `signalAs` is called with actor bob naming node B
+- **THEN** the run MUST become due
+- @e2e exclude server-side PHP seam — covered by FlowRunSignalServiceTest
+
+#### Scenario: Addressing a silent node cannot loosen the guard
+- **GIVEN** a run awaiting node A, assigned to alice
+- **WHEN** `signalAs` is called with actor mallory naming a node that is not asking
+- **THEN** the call MUST be refused with reason not-assignee
+- @e2e exclude server-side PHP seam — covered by FlowRunSignalServiceTest
+
+### Requirement: A contributed node executes under the run's acting identity
+
+The step dispatcher SHALL execute every CONTRIBUTED node (one whose class is
+not the engine's own) inside `ObjectService::runAs()` scoped to the run's
+`runAs` identity, so every read and write the node performs inherits the
+run's rights without the contributing app building a wrapper.
+
+The identity SHALL be validated at execution time: an identity that resolves
+to no account, or to a disabled account, SHALL refuse the step loudly rather
+than execute it as anyone else. A run whose context names NO identity SHALL
+run the node bare, under the ambient session — the interactive path.
+
+The scoping SHALL narrow, never grant: a run whose identity lacks a right is
+still refused it. The engine's own nodes, which already scope themselves,
+SHALL be unaffected. A contributed node that must manage its own identity
+MAY declare so via `IFlowSelfScopedNode`, the documented escape hatch.
+
+The engine SHALL export the context key under which the acting identity
+travels (`FlowRunService::RUN_AS_CONTEXT_KEY`), and its value SHALL remain
+`runAs` — it is stored inside parked runs' contexts and cannot move.
+
+#### Scenario: A contributed node's write executes as the run owner
+- **GIVEN** a run whose runAs is alice, an enabled account
+- **WHEN** the dispatcher executes a contributed node
+- **THEN** the node MUST execute inside `ObjectService::runAs(alice)`
+- @e2e exclude dispatcher-internal — covered by RegistryStepDispatcherRunAsTest
+
+#### Scenario: An unresolvable identity refuses loudly
+- **GIVEN** a run whose runAs names no existing account
+- **WHEN** the dispatcher executes a contributed node
+- **THEN** the step MUST be refused with a message naming the identity
+- @e2e exclude dispatcher-internal — covered by RegistryStepDispatcherRunAsTest
+
+#### Scenario: A disabled identity refuses loudly
+- **GIVEN** a run whose runAs names a disabled account
+- **WHEN** the dispatcher executes a contributed node
+- **THEN** the step MUST be refused with a message naming the identity
+- @e2e exclude dispatcher-internal — covered by RegistryStepDispatcherRunAsTest
+
+#### Scenario: The engine's own nodes are unaffected
+- **GIVEN** a run whose runAs is set
+- **WHEN** the dispatcher executes one of the engine's own nodes
+- **THEN** the dispatcher MUST NOT wrap it — the node scopes itself
+- @e2e exclude dispatcher-internal — covered by RegistryStepDispatcherRunAsTest
+
+#### Scenario: A self-scoped contributed node runs bare
+- **GIVEN** a contributed node declaring `IFlowSelfScopedNode`
+- **WHEN** the dispatcher executes it on a run whose runAs is set
+- **THEN** the dispatcher MUST NOT wrap it
+- @e2e exclude dispatcher-internal — covered by RegistryStepDispatcherRunAsTest

--- a/openspec/changes/flow-engine-consumer-seams/tasks.md
+++ b/openspec/changes/flow-engine-consumer-seams/tasks.md
@@ -1,0 +1,57 @@
+# Tasks: flow-engine-consumer-seams
+
+## 1. The guarded signal seam
+
+- [x] 1.1 `lib/Exception/FlowSignalRefused.php`: one typed refusal with reason
+      constants (`run-not-found`, `not-assignee`, `not-suspended`), the
+      refused actor and the run uuid readable by the caller.
+- [x] 1.2 `lib/Service/Flow/FlowRunSignalService.php`: `signalAs(runUuid,
+      payload, actorUid, nodeId?)` and `signalRunAs(run, …)` — resolve, apply
+      `FlowRunAssignee` (group resolution included), audit a refusal with
+      run/actor/assignee, deliver via `FlowRunService::signal()`. A refused
+      signal touches nothing.
+- [x] 1.3 `FlowRunAssignee`: optional `nodeId` on `recordedFor()` /
+      `mayAnswer()` — an addressed held slot's assignee decides; a `nodeId`
+      whose slot is not held falls back to the run-level rule.
+- [x] 1.4 Migrate `FlowRunController::resume()` and `signalByKey()` onto
+      `signalRunAs()`; delete `refuseUnlessAssignee()` and the local rule
+      factory. Responses stay byte-identical.
+- [x] 1.5 Document `FlowRunService::signal()` as the unguarded
+      engine-internal primitive, pointing consumers at the seam.
+
+## 2. Native runAs scoping
+
+- [x] 2.1 `FlowRunService::RUN_AS_CONTEXT_KEY = 'runAs'`; migrate the
+      in-tree literal reads (`baseContextFor`, `ObjectWriteNode`,
+      `ObjectReadNode`, `FlowMessagingService`) onto it.
+- [x] 2.2 `lib/Service/Flow/FlowRunAsScope.php`: validate (exists, enabled —
+      refuse loudly otherwise) and apply `ObjectService::runAs()`; bare when
+      the context names nobody.
+- [x] 2.3 `lib/Service/Flow/IFlowSelfScopedNode.php`: the escape-hatch marker,
+      with the obligations documented.
+- [x] 2.4 `RegistryStepDispatcher`: execute contributed nodes inside the
+      scope; engine-owned nodes and marker-declaring nodes untouched; wrap
+      sits inside the #3325 signal scoping and the per-node budget check so
+      neither moves.
+- [x] 2.5 Wire the scope into all three dispatcher construction sites
+      (`FlowRunService::execute()`, the #3310 stream walk, the
+      `Application.php` factory).
+
+## 3. Tests
+
+- [x] 3.1 `FlowRunSignalServiceTest`: assignee passes, group member passes,
+      stranger refused with nothing touched (the mutation check: skipping the
+      guard reds it), anonymous refused, unassigned open, not-suspended and
+      not-found reasons, nodeId addressing and its no-loosening fallback,
+      refusal audited.
+- [x] 3.2 `FlowRunAssigneeTest`: the nodeId addressing branches.
+- [x] 3.3 `FlowRunAsScopeTest`: valid identity narrows via
+      `ObjectService::runAs`, unknown refused, disabled refused, empty runs
+      bare.
+- [x] 3.4 `RegistryStepDispatcherRunAsTest`: contributed node wrapped as the
+      run owner, unresolvable/disabled identity refused loudly, engine-owned
+      node untouched, marker node untouched, scope-less dispatcher (the
+      harness) runs bare, no-runAs context runs bare.
+- [x] 3.5 Existing suites stay green: #3325 signal scoping
+      (`RegistryStepDispatcherResumeTest`), #3310 stream walk
+      (`FlowRunServiceAdvanceStreamTest`), the controller's resume tests.

--- a/tests/Unit/Service/Flow/FlowRunAsScopeTest.php
+++ b/tests/Unit/Service/Flow/FlowRunAsScopeTest.php
@@ -1,0 +1,159 @@
+<?php
+
+/**
+ * Unit tests for FlowRunAsScope — the run's acting identity, validated and applied.
+ *
+ * The refusals are the tests that matter: an identity that resolves to no
+ * account or to a disabled one must stop the step loudly, because the silent
+ * alternative is a write performed as whoever the ambient session happens to
+ * carry — under a worker, nobody, and on an interactive request somebody
+ * else entirely.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @spec openspec/changes/flow-engine-consumer-seams/specs/flow-engine-consumer-seams/spec.md#requirement-a-contributed-node-executes-under-the-runs-acting-identity
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Service\Flow\FlowRunAsScope;
+use OCA\OpenRegister\Service\Flow\FlowRunService;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\IUser;
+use OCP\IUserManager;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class FlowRunAsScopeTest extends TestCase {
+
+	/**
+	 * A user manager resolving exactly one uid.
+	 *
+	 * @param string $uid The uid that resolves.
+	 * @param boolean $enabled Whether the account is enabled.
+	 *
+	 * @return IUserManager The manager.
+	 */
+	private function userManagerWith(string $uid, bool $enabled): IUserManager {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$user->method('isEnabled')->willReturn($enabled);
+
+		$manager = $this->createMock(IUserManager::class);
+		$manager->method('get')->willReturnCallback(
+			static function (string $asked) use ($uid, $user): ?IUser {
+				if ($asked === $uid) {
+					return $user;
+				}
+
+				return null;
+			}
+		);
+
+		return $manager;
+	}//end userManagerWith()
+
+	public function testAValidIdentityRunsTheOperationInsideRunAs(): void {
+		$scopedAs = null;
+		$objects = $this->createMock(ObjectService::class);
+		$objects->method('runAs')->willReturnCallback(
+			static function (IUser $user, callable $operation) use (&$scopedAs): mixed {
+				$scopedAs = $user->getUID();
+
+				return $operation();
+			}
+		);
+
+		$scope = new FlowRunAsScope(
+			userManager: $this->userManagerWith(uid: 'alice', enabled: true),
+			objectService: $objects
+		);
+
+		$out = $scope->call(
+			context: [FlowRunService::RUN_AS_CONTEXT_KEY => 'alice'],
+			operation: static fn (): string => 'wrote'
+		);
+
+		$this->assertSame('wrote', $out);
+		$this->assertSame('alice', $scopedAs, 'the work must run inside runAs(alice)');
+	}//end testAValidIdentityRunsTheOperationInsideRunAs()
+
+	/**
+	 * No identity declared is the interactive path: the operation runs bare,
+	 * under the ambient session, and runAs is never involved.
+	 */
+	public function testNoIdentityRunsBare(): void {
+		$objects = $this->createMock(ObjectService::class);
+		$objects->expects($this->never())->method('runAs');
+
+		$scope = new FlowRunAsScope(
+			userManager: $this->createMock(IUserManager::class),
+			objectService: $objects
+		);
+
+		$this->assertSame('bare', $scope->call(context: [], operation: static fn (): string => 'bare'));
+		$this->assertSame(
+			'bare',
+			$scope->call(
+				context: [FlowRunService::RUN_AS_CONTEXT_KEY => '  '],
+				operation: static fn (): string => 'bare'
+			)
+		);
+	}//end testNoIdentityRunsBare()
+
+	/**
+	 * 🔴 An identity that resolves to NO account refuses loudly, and the
+	 * operation never runs.
+	 */
+	public function testAnUnknownIdentityRefusesLoudly(): void {
+		$objects = $this->createMock(ObjectService::class);
+		$objects->expects($this->never())->method('runAs');
+
+		$scope = new FlowRunAsScope(
+			userManager: $this->userManagerWith(uid: 'alice', enabled: true),
+			objectService: $objects
+		);
+
+		$ran = false;
+
+		try {
+			$scope->call(
+				context: [FlowRunService::RUN_AS_CONTEXT_KEY => 'ghost'],
+				operation: static function () use (&$ran): void {
+					$ran = true;
+				}
+			);
+			$this->fail('Expected the step to be refused.');
+		} catch (RuntimeException $refused) {
+			$this->assertStringContainsString('ghost', $refused->getMessage());
+		}
+
+		$this->assertFalse($ran, 'a refused step must not have run its work');
+	}//end testAnUnknownIdentityRefusesLoudly()
+
+	/**
+	 * 🔴 A DISABLED account still resolves, and must refuse anyway: rights are
+	 * re-checked at the moment work runs so that offboarding takes effect on a
+	 * run parked for weeks.
+	 */
+	public function testADisabledIdentityRefusesLoudly(): void {
+		$objects = $this->createMock(ObjectService::class);
+		$objects->expects($this->never())->method('runAs');
+
+		$scope = new FlowRunAsScope(
+			userManager: $this->userManagerWith(uid: 'former', enabled: false),
+			objectService: $objects
+		);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/disabled/');
+
+		$scope->call(
+			context: [FlowRunService::RUN_AS_CONTEXT_KEY => 'former'],
+			operation: static fn (): string => 'never'
+		);
+	}//end testADisabledIdentityRefusesLoudly()
+}//end class

--- a/tests/Unit/Service/Flow/FlowRunAssigneeTest.php
+++ b/tests/Unit/Service/Flow/FlowRunAssigneeTest.php
@@ -151,4 +151,69 @@ class FlowRunAssigneeTest extends TestCase {
 		$this->assertSame('', $assignee->recordedFor(run: $run));
 		$this->assertTrue($assignee->mayAnswer(run: $run, uid: 'anyone'));
 	}//end testARunWithNoSlotsNamesNobodyAndIsOpen()
+
+	/**
+	 * ADDRESSING. A run can await several nodes at once, each with its own
+	 * assignee. The run-level scan answers with the FIRST asked slot's, which
+	 * refuses the second node's own audience — so a caller that knows which
+	 * node its answer addresses is checked against THAT node's record.
+	 */
+	public function testAddressingANodeChecksThatNodesAssignee(): void {
+		$run = $this->runWithSlots([
+			'ask-a' => ['askedAt' => 'now', 'assignee' => 'alice'],
+			'ask-b' => ['askedAt' => 'now', 'assignee' => 'bob'],
+		]);
+
+		$assignee = new FlowRunAssignee();
+
+		$this->assertSame('bob', $assignee->recordedFor(run: $run, nodeId: 'ask-b'));
+		$this->assertTrue($assignee->mayAnswer(run: $run, uid: 'bob', nodeId: 'ask-b'));
+		// Without addressing, the run-level scan would have refused bob.
+		$this->assertFalse($assignee->mayAnswer(run: $run, uid: 'bob'));
+	}//end testAddressingANodeChecksThatNodesAssignee()
+
+	/**
+	 * 🔴 Addressing can NARROW the check but never loosen it: a nodeId whose
+	 * slot is not held (the node is not asking) falls back to the run-level
+	 * rule, so naming a silent node is not a way around the guard on the node
+	 * that IS asking.
+	 */
+	public function testAddressingASilentNodeFallsBackToTheRunLevelRule(): void {
+		$run = $this->runWithSlots(['ask-a' => ['askedAt' => 'now', 'assignee' => 'alice']]);
+
+		$assignee = new FlowRunAssignee();
+
+		$this->assertSame('alice', $assignee->recordedFor(run: $run, nodeId: 'never-asked'));
+		$this->assertFalse($assignee->mayAnswer(run: $run, uid: 'mallory', nodeId: 'never-asked'));
+	}//end testAddressingASilentNodeFallsBackToTheRunLevelRule()
+
+	/**
+	 * ...and a slot that exists but never ASKED is equally silent: recording
+	 * an assignee is not asking a question.
+	 */
+	public function testAddressingAnUnaskedSlotFallsBackToo(): void {
+		$run = $this->runWithSlots([
+			'ask-a' => ['askedAt' => 'now', 'assignee' => 'alice'],
+			'idle' => ['assignee' => 'mallory'],
+		]);
+
+		$this->assertFalse(
+			(new FlowRunAssignee())->mayAnswer(run: $run, uid: 'mallory', nodeId: 'idle')
+		);
+	}//end testAddressingAnUnaskedSlotFallsBackToo()
+
+	/**
+	 * An addressed node whose held slot records NO assignee is open — the
+	 * unassigned contract holds per node, exactly as it does run-level.
+	 */
+	public function testAnAddressedUnassignedNodeIsOpen(): void {
+		$run = $this->runWithSlots([
+			'ask-a' => ['askedAt' => 'now', 'assignee' => 'alice'],
+			'hook' => ['askedAt' => 'now'],
+		]);
+
+		$this->assertTrue(
+			(new FlowRunAssignee())->mayAnswer(run: $run, uid: 'anyone', nodeId: 'hook')
+		);
+	}//end testAnAddressedUnassignedNodeIsOpen()
 }//end class

--- a/tests/Unit/Service/Flow/FlowRunSignalServiceTest.php
+++ b/tests/Unit/Service/Flow/FlowRunSignalServiceTest.php
@@ -1,0 +1,260 @@
+<?php
+
+/**
+ * Unit tests for FlowRunSignalService — the guarded server-side signal seam.
+ *
+ * The seam exists so a PHP consumer cannot forget the assignee guard the HTTP
+ * endpoint applies: resolve, guard, audit, deliver is ONE call. The tests that
+ * matter most are the refusals, because each has a way of passing while
+ * broken:
+ *
+ *   - the STRANGER case is the mutation check: were the guard skipped, the
+ *     signal would be delivered and the expectException here reds the suite —
+ *     "disabling the guard" cannot go green;
+ *   - a refusal must touch NOTHING: a 403 that still woke the run would be
+ *     the vulnerability with extra steps;
+ *   - the GROUP branch admits the step's intended audience, and a broken
+ *     group lookup reads as "the guard works" because refusing is what a
+ *     guard does.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @spec openspec/changes/flow-engine-consumer-seams/specs/flow-engine-consumer-seams/spec.md#requirement-a-server-side-signal-passes-the-same-guard-as-the-http-resume
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Db\FlowRun;
+use OCA\OpenRegister\Db\FlowRunMapper;
+use OCA\OpenRegister\Exception\FlowSignalRefused;
+use OCA\OpenRegister\Service\Flow\FlowResumeState;
+use OCA\OpenRegister\Service\Flow\FlowRunService;
+use OCA\OpenRegister\Service\Flow\FlowRunSignalService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IGroupManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class FlowRunSignalServiceTest extends TestCase {
+
+	/**
+	 * The delivery primitive underneath the seam.
+	 *
+	 * @var FlowRunService&MockObject
+	 */
+	private FlowRunService $runner;
+
+	/**
+	 * Resolves uuids to runs.
+	 *
+	 * @var FlowRunMapper&MockObject
+	 */
+	private FlowRunMapper $mapper;
+
+	/**
+	 * Receives the refusal audit.
+	 *
+	 * @var LoggerInterface&MockObject
+	 */
+	private LoggerInterface $logger;
+
+	protected function setUp(): void {
+		$this->runner = $this->createMock(FlowRunService::class);
+		$this->mapper = $this->createMock(FlowRunMapper::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+	}//end setUp()
+
+	/**
+	 * A suspended run whose resume slots are exactly as given.
+	 *
+	 * @param array $slots The per-node resume slots.
+	 *
+	 * @return FlowRun The run.
+	 */
+	private function suspendedRun(array $slots): FlowRun {
+		$run = new FlowRun();
+		$run->setUuid('run-1');
+		$run->setStatus(FlowRun::STATUS_SUSPENDED);
+		$run->setContext([FlowResumeState::CONTEXT_KEY => $slots]);
+
+		return $run;
+	}//end suspendedRun()
+
+	/**
+	 * The seam under test.
+	 *
+	 * @param IGroupManager|null $groups The group resolver, when the test needs one.
+	 *
+	 * @return FlowRunSignalService The seam.
+	 */
+	private function seam(?IGroupManager $groups = null): FlowRunSignalService {
+		return new FlowRunSignalService(
+			mapper: $this->mapper,
+			runner: $this->runner,
+			logger: $this->logger,
+			groupManager: $groups
+		);
+	}//end seam()
+
+	public function testTheRecordedAssigneeMayAnswer(): void {
+		$run = $this->suspendedRun(['ask' => ['askedAt' => 'now', 'assignee' => 'alice']]);
+
+		$this->runner->expects($this->once())
+			->method('signal')
+			->with($run, ['decision' => 'approved'])
+			->willReturn($run);
+
+		$signalled = $this->seam()->signalRunAs(run: $run, payload: ['decision' => 'approved'], actorUid: 'alice');
+
+		$this->assertSame($run, $signalled);
+	}//end testTheRecordedAssigneeMayAnswer()
+
+	/**
+	 * 🔴 THE GROUP BRANCH — the half a hand-written copy of the guard tends to
+	 * forget, refusing the step's own intended audience while reading as "the
+	 * guard works".
+	 */
+	public function testAGroupMemberMayAnswerAGroupAssignedStep(): void {
+		$run = $this->suspendedRun(['ask' => ['askedAt' => 'now', 'assignee' => 'behandelaars']]);
+
+		$groups = $this->createMock(IGroupManager::class);
+		$groups->method('isInGroup')->with('carol', 'behandelaars')->willReturn(true);
+
+		$this->runner->expects($this->once())->method('signal')->willReturn($run);
+
+		$this->seam(groups: $groups)->signalRunAs(run: $run, payload: [], actorUid: 'carol');
+	}//end testAGroupMemberMayAnswerAGroupAssignedStep()
+
+	/**
+	 * 🔴 THE MUTATION CHECK. Skip the guard and this test reds: the signal
+	 * would be delivered instead of the refusal being thrown, and the
+	 * never-called delivery assertion fails with it.
+	 */
+	public function testAStrangerIsRefusedAndTheRunIsUntouched(): void {
+		$run = $this->suspendedRun(['ask' => ['askedAt' => 'now', 'assignee' => 'alice']]);
+
+		$this->runner->expects($this->never())->method('signal');
+
+		try {
+			$this->seam()->signalRunAs(run: $run, payload: ['decision' => 'approved'], actorUid: 'mallory');
+			$this->fail('Expected the signal to be refused.');
+		} catch (FlowSignalRefused $refused) {
+			$this->assertSame(FlowSignalRefused::NOT_ASSIGNEE, $refused->getReason());
+			$this->assertSame('mallory', $refused->getActorUid());
+			$this->assertSame('run-1', $refused->getRunUuid());
+		}
+	}//end testAStrangerIsRefusedAndTheRunIsUntouched()
+
+	/**
+	 * The refusal is AUDITED by the engine, so the trace exists whether or not
+	 * the consumer remembers to log it — a listener sees the refusal after its
+	 * own object is already saved, and this record is what is left.
+	 */
+	public function testARefusalIsAudited(): void {
+		$run = $this->suspendedRun(['ask' => ['askedAt' => 'now', 'assignee' => 'alice']]);
+
+		$this->logger->expects($this->once())->method('warning');
+
+		$this->expectException(FlowSignalRefused::class);
+		$this->seam()->signalRunAs(run: $run, payload: [], actorUid: 'mallory');
+	}//end testARefusalIsAudited()
+
+	public function testAnAnonymousActorIsRefusedOnAnAssignedStep(): void {
+		$run = $this->suspendedRun(['ask' => ['askedAt' => 'now', 'assignee' => 'alice']]);
+
+		$this->runner->expects($this->never())->method('signal');
+
+		try {
+			$this->seam()->signalRunAs(run: $run, payload: [], actorUid: null);
+			$this->fail('Expected the signal to be refused.');
+		} catch (FlowSignalRefused $refused) {
+			$this->assertSame(FlowSignalRefused::NOT_ASSIGNEE, $refused->getReason());
+			// A blank actor is anonymous, and the refusal says so.
+			$this->assertNull($refused->getActorUid());
+		}
+	}//end testAnAnonymousActorIsRefusedOnAnAssignedStep()
+
+	/**
+	 * The unassigned contract is UNCHANGED by the seam: webhook and child-run
+	 * signals are not human decisions, and silence still means anyone.
+	 */
+	public function testAnUnassignedStepIsAnswerableByAnyone(): void {
+		$run = $this->suspendedRun(['hook' => ['askedAt' => 'now']]);
+
+		$this->runner->expects($this->once())->method('signal')->willReturn($run);
+
+		$this->seam()->signalRunAs(run: $run, payload: [], actorUid: 'anyone');
+	}//end testAnUnassignedStepIsAnswerableByAnyone()
+
+	/**
+	 * ADDRESSING. A caller that knows which node its answer addresses is
+	 * checked against that node's own assignee — the run-level scan would have
+	 * refused the second node's audience.
+	 */
+	public function testAddressingANodeChecksThatNodesAssignee(): void {
+		$run = $this->suspendedRun([
+			'ask-a' => ['askedAt' => 'now', 'assignee' => 'alice'],
+			'ask-b' => ['askedAt' => 'now', 'assignee' => 'bob'],
+		]);
+
+		$this->runner->expects($this->once())->method('signal')->willReturn($run);
+
+		$this->seam()->signalRunAs(run: $run, payload: [], actorUid: 'bob', nodeId: 'ask-b');
+	}//end testAddressingANodeChecksThatNodesAssignee()
+
+	/**
+	 * 🔴 ...and addressing can never LOOSEN the guard: a node that is not
+	 * asking has no slot, so the run-level rule still refuses the stranger.
+	 */
+	public function testAddressingASilentNodeCannotLoosenTheGuard(): void {
+		$run = $this->suspendedRun(['ask-a' => ['askedAt' => 'now', 'assignee' => 'alice']]);
+
+		$this->runner->expects($this->never())->method('signal');
+
+		$this->expectException(FlowSignalRefused::class);
+		$this->seam()->signalRunAs(run: $run, payload: [], actorUid: 'mallory', nodeId: 'never-asked');
+	}//end testAddressingASilentNodeCannotLoosenTheGuard()
+
+	public function testANonSuspendedRunRefusesWithItsOwnReason(): void {
+		$run = $this->suspendedRun([]);
+		$run->setStatus(FlowRun::STATUS_RUNNING);
+
+		// The primitive's contract: null means "not suspended".
+		$this->runner->method('signal')->willReturn(null);
+
+		try {
+			$this->seam()->signalRunAs(run: $run, payload: [], actorUid: 'alice');
+			$this->fail('Expected the signal to be refused.');
+		} catch (FlowSignalRefused $refused) {
+			$this->assertSame(FlowSignalRefused::NOT_SUSPENDED, $refused->getReason());
+		}
+	}//end testANonSuspendedRunRefusesWithItsOwnReason()
+
+	public function testSignalAsResolvesTheRunByUuid(): void {
+		$run = $this->suspendedRun(['ask' => ['askedAt' => 'now', 'assignee' => 'alice']]);
+
+		$this->mapper->method('findByUuid')->with('run-1')->willReturn($run);
+		$this->runner->expects($this->once())->method('signal')->willReturn($run);
+
+		$signalled = $this->seam()->signalAs(runUuid: 'run-1', payload: ['ok' => true], actorUid: 'alice');
+
+		$this->assertSame($run, $signalled);
+	}//end testSignalAsResolvesTheRunByUuid()
+
+	public function testSignalAsRefusesAnUnknownUuid(): void {
+		$this->mapper->method('findByUuid')->willThrowException(new DoesNotExistException('nope'));
+		$this->runner->expects($this->never())->method('signal');
+
+		try {
+			$this->seam()->signalAs(runUuid: 'ghost', payload: [], actorUid: 'alice');
+			$this->fail('Expected the signal to be refused.');
+		} catch (FlowSignalRefused $refused) {
+			$this->assertSame(FlowSignalRefused::RUN_NOT_FOUND, $refused->getReason());
+			$this->assertSame('ghost', $refused->getRunUuid());
+		}
+	}//end testSignalAsRefusesAnUnknownUuid()
+}//end class

--- a/tests/Unit/Service/Flow/RegistryStepDispatcherRunAsTest.php
+++ b/tests/Unit/Service/Flow/RegistryStepDispatcherRunAsTest.php
@@ -1,0 +1,307 @@
+<?php
+
+/**
+ * Unit tests for the dispatcher's acting-identity scoping.
+ *
+ * The claim under test: a CONTRIBUTED node executes inside the run's `runAs`
+ * identity without the contributing app writing a wrapper — and the refusals
+ * hold. dossiq shipped three broken nodes (plus a handler) before it built
+ * that wrapper itself; these tests are what make the fourth consumer's
+ * version unnecessary.
+ *
+ * The boundary tests matter as much as the wrap: the engine's own nodes
+ * already scope themselves (with node-specific wording and skip-when
+ * semantics), so wrapping them again would change the ambient identity of
+ * nodes that deliberately run bare — and a dispatcher built by hand with no
+ * scope (the flow tester, the node unit tests) must keep dispatching.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @spec openspec/changes/flow-engine-consumer-seams/specs/flow-engine-consumer-seams/spec.md#requirement-a-contributed-node-executes-under-the-runs-acting-identity
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow {
+
+	use OCA\OpenRegister\Service\Flow\FlowNodeRegistry;
+	use OCA\OpenRegister\Service\Flow\FlowRunAsScope;
+	use OCA\OpenRegister\Service\Flow\FlowRunService;
+	use OCA\OpenRegister\Service\Flow\IFlowNode;
+	use OCA\OpenRegister\Service\Flow\RegistryStepDispatcher;
+	use OCA\OpenRegister\Service\ObjectService;
+	use OCP\IUser;
+	use OCP\IUserManager;
+	use PHPUnit\Framework\TestCase;
+	use RuntimeException;
+
+	class RegistryStepDispatcherRunAsTest extends TestCase {
+
+		/**
+		 * A dispatcher resolving every type to the given node.
+		 *
+		 * @param IFlowNode $node The node the registry answers with.
+		 * @param FlowRunAsScope|null $scope The identity scope, when the test has one.
+		 *
+		 * @return RegistryStepDispatcher The dispatcher under test.
+		 */
+		private function dispatcher(IFlowNode $node, ?FlowRunAsScope $scope): RegistryStepDispatcher {
+			$registry = $this->createMock(FlowNodeRegistry::class);
+			$registry->method('get')->willReturn($node);
+
+			return new RegistryStepDispatcher(registry: $registry, scope: $scope);
+		}//end dispatcher()
+
+		/**
+		 * A REAL scope over a stub object service that records who it acted as.
+		 *
+		 * @param string $uid The uid that resolves.
+		 * @param boolean $enabled Whether that account is enabled.
+		 * @param string|null $scopedAs Receives the uid runAs() was entered with.
+		 *
+		 * @return FlowRunAsScope The scope.
+		 */
+		private function scope(string $uid, bool $enabled, ?string &$scopedAs): FlowRunAsScope {
+			$user = $this->createMock(IUser::class);
+			$user->method('getUID')->willReturn($uid);
+			$user->method('isEnabled')->willReturn($enabled);
+
+			$manager = $this->createMock(IUserManager::class);
+			$manager->method('get')->willReturnCallback(
+				static function (string $asked) use ($uid, $user): ?IUser {
+					if ($asked === $uid) {
+						return $user;
+					}
+
+					return null;
+				}
+			);
+
+			$objects = $this->createMock(ObjectService::class);
+			$objects->method('runAs')->willReturnCallback(
+				static function (IUser $user, callable $operation) use (&$scopedAs): mixed {
+					$scopedAs = $user->getUID();
+
+					return $operation();
+				}
+			);
+
+			return new FlowRunAsScope(userManager: $manager, objectService: $objects);
+		}//end scope()
+
+		/**
+		 * THE SEAM ITSELF: a contributed node's work runs inside
+		 * `ObjectService::runAs()` scoped to the run's identity — the node wrote
+		 * no wrapper and does not know one exists.
+		 */
+		public function testAContributedNodesWorkExecutesAsTheRunOwner(): void {
+			$node = new ContributedRecordingNode();
+			$scopedAs = null;
+
+			$dispatcher = $this->dispatcher(node: $node, scope: $this->scope(uid: 'alice', enabled: true, scopedAs: $scopedAs));
+
+			$out = $dispatcher->dispatch(
+				['id' => 'n1', 'type' => 'dossiq.write'],
+				[['case' => 1]],
+				[FlowRunService::RUN_AS_CONTEXT_KEY => 'alice']
+			);
+
+			$this->assertSame('alice', $scopedAs, 'the node must have run inside runAs(alice)');
+			$this->assertTrue($node->executedInsideScope, 'the WORK, not just the dispatch, must sit inside the scope');
+			$this->assertSame([['case' => 1, 'wrote' => true]], $out);
+		}//end testAContributedNodesWorkExecutesAsTheRunOwner()
+
+		/**
+		 * 🔴 An identity that resolves to nobody refuses the step LOUDLY — the
+		 * silent alternative is the node writing as whoever the ambient session
+		 * carries, which under the worker is nobody and on a request is somebody
+		 * else.
+		 */
+		public function testAnUnresolvableIdentityRefusesLoudly(): void {
+			$node = new ContributedRecordingNode();
+			$scopedAs = null;
+
+			$dispatcher = $this->dispatcher(node: $node, scope: $this->scope(uid: 'alice', enabled: true, scopedAs: $scopedAs));
+
+			try {
+				$dispatcher->dispatch(
+					['id' => 'n1', 'type' => 'dossiq.write'],
+					[],
+					[FlowRunService::RUN_AS_CONTEXT_KEY => 'ghost']
+				);
+				$this->fail('Expected the step to be refused.');
+			} catch (RuntimeException $refused) {
+				$this->assertStringContainsString('ghost', $refused->getMessage());
+			}
+
+			$this->assertFalse($node->executedInsideScope, 'a refused step must not have executed');
+		}//end testAnUnresolvableIdentityRefusesLoudly()
+
+		/**
+		 * 🔴 A DISABLED account refuses too: a run parked for weeks must not
+		 * resume with the rights of somebody who has since been offboarded.
+		 */
+		public function testADisabledIdentityRefusesLoudly(): void {
+			$node = new ContributedRecordingNode();
+			$scopedAs = null;
+
+			$dispatcher = $this->dispatcher(node: $node, scope: $this->scope(uid: 'former', enabled: false, scopedAs: $scopedAs));
+
+			$this->expectException(RuntimeException::class);
+			$this->expectExceptionMessageMatches('/disabled/');
+
+			$dispatcher->dispatch(
+				['id' => 'n1', 'type' => 'dossiq.write'],
+				[],
+				[FlowRunService::RUN_AS_CONTEXT_KEY => 'former']
+			);
+		}//end testADisabledIdentityRefusesLoudly()
+
+		/**
+		 * A run that names NO identity runs the node bare — the interactive
+		 * path, where the ambient session already answers the permission checks.
+		 */
+		public function testNoIdentityRunsTheNodeBare(): void {
+			$node = new ContributedRecordingNode();
+			$scopedAs = null;
+
+			$dispatcher = $this->dispatcher(node: $node, scope: $this->scope(uid: 'alice', enabled: true, scopedAs: $scopedAs));
+
+			$dispatcher->dispatch(['id' => 'n1', 'type' => 'dossiq.write'], [], []);
+
+			$this->assertNull($scopedAs, 'with no runAs there is nothing to scope to');
+			$this->assertTrue($node->executedInsideScope);
+		}//end testNoIdentityRunsTheNodeBare()
+
+		/**
+		 * THE BOUNDARY: the engine's own nodes scope themselves — with their own
+		 * validation wording and skip-when semantics — and are NOT wrapped, even
+		 * when the run names an identity the scope would refuse. Were the
+		 * dispatcher wrapping them, this dispatch would throw on the
+		 * unresolvable uid; instead the node runs and handles its own identity.
+		 */
+		public function testAnEngineOwnedNodeIsNotWrapped(): void {
+			$node = new \OCA\OpenRegister\Tests\Unit\Service\Flow\EngineNamespacedRecordingNode();
+			$scopedAs = null;
+
+			$dispatcher = $this->dispatcher(node: $node, scope: $this->scope(uid: 'alice', enabled: true, scopedAs: $scopedAs));
+
+			$dispatcher->dispatch(
+				['id' => 'n1', 'type' => 'openregister.write'],
+				[],
+				[FlowRunService::RUN_AS_CONTEXT_KEY => 'ghost']
+			);
+
+			$this->assertNull($scopedAs, 'an engine-owned node manages its own identity');
+			$this->assertTrue($node->executedInsideScope);
+		}//end testAnEngineOwnedNodeIsNotWrapped()
+
+		/**
+		 * The ESCAPE HATCH: a contributed node declaring IFlowSelfScopedNode
+		 * runs bare and takes on the obligations the interface documents.
+		 */
+		public function testASelfScopedContributedNodeIsNotWrapped(): void {
+			$node = new SelfScopedContributedNode();
+			$scopedAs = null;
+
+			$dispatcher = $this->dispatcher(node: $node, scope: $this->scope(uid: 'alice', enabled: true, scopedAs: $scopedAs));
+
+			$dispatcher->dispatch(
+				['id' => 'n1', 'type' => 'dossiq.system'],
+				[],
+				[FlowRunService::RUN_AS_CONTEXT_KEY => 'ghost']
+			);
+
+			$this->assertNull($scopedAs);
+			$this->assertTrue($node->executedInsideScope);
+		}//end testASelfScopedContributedNodeIsNotWrapped()
+
+		/**
+		 * A dispatcher built by hand with NO scope — the flow tester, the node
+		 * unit tests — keeps dispatching bare. The harness's existing contract,
+		 * unchanged; every production construction site supplies a scope.
+		 */
+		public function testAScopelessDispatcherRunsBare(): void {
+			$node = new ContributedRecordingNode();
+
+			$dispatcher = $this->dispatcher(node: $node, scope: null);
+
+			$dispatcher->dispatch(
+				['id' => 'n1', 'type' => 'dossiq.write'],
+				[],
+				[FlowRunService::RUN_AS_CONTEXT_KEY => 'alice']
+			);
+
+			$this->assertTrue($node->executedInsideScope);
+		}//end testAScopelessDispatcherRunsBare()
+	}//end class
+
+	/**
+	 * A contributed node: any class OUTSIDE `OCA\OpenRegister\`. Records that
+	 * (and with what) it executed, standing in for a leaf app's write node.
+	 */
+	class ContributedRecordingNode implements IFlowNode {
+
+		/**
+		 * Whether execute() ran.
+		 *
+		 * @var boolean
+		 */
+		public bool $executedInsideScope = false;
+
+		public function getId(): string {
+			return 'dossiq.write';
+		}//end getId()
+
+		public function getDisplayName(): string {
+			return 'Contributed write';
+		}//end getDisplayName()
+
+		public function getDescription(): string {
+			return 'A leaf app node that writes.';
+		}//end getDescription()
+
+		public function getIcon(): string {
+			return 'icon-edit';
+		}//end getIcon()
+
+		public function isAvailableForScope(int $scope): bool {
+			return true;
+		}//end isAvailableForScope()
+
+		public function validateConfig(array $config): void {
+		}//end validateConfig()
+
+		public function execute(array $items, array $config, array $context): array {
+			$this->executedInsideScope = true;
+
+			return array_map(
+				static function (array $item): array {
+					$item['wrote'] = true;
+
+					return $item;
+				},
+				$items
+			);
+		}//end execute()
+	}//end class
+
+	/**
+	 * The escape hatch declared: still contributed, but self-scoped.
+	 */
+	class SelfScopedContributedNode extends ContributedRecordingNode implements \OCA\OpenRegister\Service\Flow\IFlowSelfScopedNode {
+
+	}//end class
+}//end namespace
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Flow {
+
+	/**
+	 * A node under `OCA\OpenRegister\` — the dispatcher must treat it as
+	 * engine-owned and leave its identity handling to the node itself.
+	 */
+	class EngineNamespacedRecordingNode extends \Unit\Service\Flow\ContributedRecordingNode {
+
+	}//end class
+}//end namespace


### PR DESCRIPTION
## What this does

Closes the two engine gaps the fleet audit handed back — both of the shape "every consuming app re-implements a rule the engine should own", and both behind a shipped dossiq defect this week. OpenSpec change: `flow-engine-consumer-seams` (proposal, design, delta spec, tasks in this PR).

### 1. A guarded server-side signal API

Apps that resume runs from PHP called `FlowRunService::signal()` directly, which bypasses the assignee guard that only lived on the HTTP path — so each app had to remember to consult `FlowRunAssignee` itself (dossiq did; the next app forgets, and a forgotten check does not throw).

- **`FlowRunSignalService::signalAs(runUuid, payload, actorUid, nodeId?)`** and `signalRunAs(run, …)`: resolve, apply the recorded-assignee rule (group resolution included, via the existing `FlowRunAssignee` — one implementation), audit a refusal, deliver.
- Refusals are one typed `FlowSignalRefused` with reason constants (`run-not-found`, `not-assignee`, `not-suspended`) — no string matching, and a guard whose refusal cannot be ignored by ignoring a return value.
- **The HTTP path migrates onto the same seam**: `resume()` and `signalByKey()` delegate to `signalRunAs()`; `refuseUnlessAssignee()` is deleted. Routes, status codes and response bodies are byte-identical, so no contract moves.
- `signal()` stays as the unguarded engine-internal primitive and its docblock now says exactly that.
- Optional `nodeId` addressing: the guard checks the addressed node's own recorded assignee (a run awaiting two nodes no longer refuses the second node's audience); a nodeId whose slot is not held falls back to the run-level rule, so addressing can never loosen the guard.

### 2. Native runAs scoping for contributed nodes

The engine's own nodes wrap writes in `ObjectService::runAs()`; contributed nodes got the context key and nothing else — dossiq shipped three broken nodes (plus `MergeTemplateHandler`) before building its own wrapper.

- **`RegistryStepDispatcher` executes every CONTRIBUTED node inside `FlowRunAsScope`**: the run's `runAs` is validated (exists AND enabled — refused loudly otherwise, matching `ObjectWriteNode::resolveOwner()` and dossiq's semantics) and the node runs inside `ObjectService::runAs()`. Narrowing only.
- Engine-owned nodes (`OCA\OpenRegister\`) are untouched — they already scope themselves. `IFlowSelfScopedNode` is the documented escape hatch, with its obligations in the docblock.
- The context key ships as `FlowRunService::RUN_AS_CONTEXT_KEY` (value frozen at `runAs`); the in-tree literal reads (ObjectWriteNode, ObjectReadNode, FlowMessagingService) move onto it.
- The wrap sits inside #3325's signal scoping and outside nothing #3310 relies on: `RegistryStepDispatcherResumeTest` and `FlowRunServiceAdvanceStreamTest` pass unchanged.

### Follow-ups named, not built

The design records the other two audit gaps as one-line follow-ups: the request-scoped trigger, and the shared retry-policy vocabulary.

### Consumer effect (dossiq)

Once dossiq adopts `signalAs()`, its `FlowRunAsScope`, and the guard blocks in `TaskCompletionResumeListener` / `ParaafResumeListener`, become deletable.

## Checks

- `lint`, `phpcs` (full lib), `phpmd` (per subdir, both rulesets, baseline), `psalm` (no errors), `phpstan` (no errors) — all exit 0
- PHPUnit: full Unit suite 18 985 tests — the only 6 errors are the pre-existing local DBAL-stub gap in Sources/Dbal tests (untouched; green in the container)
- New: `FlowRunSignalServiceTest` (incl. the mutation check: skipping the guard reds the suite), `FlowRunAsScopeTest`, `RegistryStepDispatcherRunAsTest`, nodeId cases in `FlowRunAssigneeTest`
- hydra gates `--scope-to-diff --base origin/development`: ALL 36 applicable gates green, 0 FAIL
- `npm run check:specs`: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)