### PR TITLE
fix(search): count only the chunk owners the caller can actually see

### DIFF
--- a/lib/Service/Object/ContentSearchHandler.php
+++ b/lib/Service/Object/ContentSearchHandler.php
@@ -168,44 +168,34 @@ class ContentSearchHandler {
 			}
 		}
 
-		// Stable total across pages: use the distinct-chunk-owner set (grouped
-		// by entity_type+entity_id) as the chunk-arm upper bound BEFORE the
-		// room-clamped resolve loop. Without this, `$total` drifts across
-		// pages (page 1 appends 0 → reports metaTotal; page 3 appends N →
-		// reports metaTotal+N).
+		// RESOLVE FIRST, THEN COUNT AND PAGE. `$total` is the number of chunk
+		// owners this caller can actually SEE, and the page is a slice of that
+		// same resolved set.
 		//
-		// ACCEPTED OVER-COUNT — the upper bound is a THEORETICAL maximum:
-		// scope/register/schema mismatch, tenant/RBAC filtering, and unresolved
-		// file→object joins can each reduce the actually-appended count to zero
-		// without changing `$total`. In a multi-register corpus where the
-		// scope filters out most chunks, the client's `pages = ceil(total/limit)`
-		// will point at pages that render empty. This is the accepted
-		// trade-off for pagination stability across pages of the same query;
-		// the alternative (recompute `$total` per page from the actually-
-		// appended count) reintroduces the drift the fix is meant to close.
-		// Pre-filtering `$chunkHits` by scope + a batch `MagicMapper::findMany`
-		// would tighten the bound but requires the bulk mapper methods
-		// deferred with the batch-resolve refactor.
-		$distinctChunkOwners = [];
-		foreach ($chunkHits as $hit) {
-			$key = ($hit['entity_type'] ?? 'file') . ':' . ($hit['entity_id'] ?? '');
-			$distinctChunkOwners[$key] = true;
-		}
-
-		$chunkOwnerUpperBound = count($distinctChunkOwners);
-
+		// This used to count the distinct chunk-owner set BEFORE resolving, as
+		// a deliberate upper bound, to keep `$total` stable across pages.
+		// Stability was the right goal; the upper bound was the wrong way to
+		// reach it, because scope mismatch, RBAC, tenancy and a soft-deleted
+		// owner each drop a row from `results` without touching `$total`.
+		//
+		// Measured on the dev instance 2026-09-02, unauthenticated, against
+		// OpenCatalogi's #[PublicPage] search: a document that had been
+		// soft-deleted still answered `{"results":[],"total":1}`. An anonymous
+		// caller could therefore probe a phrase and learn from the count alone
+		// that a document containing it exists, while being correctly refused
+		// the document itself. A count is an answer, so it has to obey the same
+		// visibility rules as the rows.
+		//
+		// Resolving every candidate rather than only `$room` of them costs at
+		// most CHUNK_CANDIDATE_LIMIT resolves, which is the worst case this
+		// class already budgets for and documents on that constant. `$total`
+		// stays stable across pages because the resolved set is a property of
+		// the query, not of the page: page 1 and page 3 resolve the same
+		// candidates and report the same number.
 		$scope = $this->resolveScope(query: $query);
-		$appended = [];
-		$room = PHP_INT_MAX;
-		if ($limit > 0) {
-			$room = max(0, $limit - count($results));
-		}
 
+		$resolved = [];
 		foreach ($chunkHits as $hit) {
-			if (count($appended) >= $room) {
-				break;
-			}
-
 			$object = $this->resolveAndDedupeHit(
 				hit: $hit,
 				seenUuids: $seenUuids,
@@ -217,13 +207,22 @@ class ContentSearchHandler {
 				continue;
 			}
 
+			// Seed the dedupe set as we go: two chunks of the same document
+			// are one owner, and must be counted once.
 			$seenUuids[$object->getUuid()] = true;
-			$appended[] = $object;
+			$resolved[] = $object;
 		}//end foreach
+
+		$room = PHP_INT_MAX;
+		if ($limit > 0) {
+			$room = max(0, $limit - count($results));
+		}
+
+		$appended = array_slice($resolved, 0, $room);
 
 		return [
 			'results' => array_merge($results, $appended),
-			'total' => $total + $chunkOwnerUpperBound,
+			'total' => $total + count($resolved),
 		];
 	}//end augmentWithChunkMatches()
 

--- a/tests/Unit/Service/Object/ContentSearchHandlerTest.php
+++ b/tests/Unit/Service/Object/ContentSearchHandlerTest.php
@@ -327,6 +327,64 @@ class ContentSearchHandlerTest extends TestCase {
 		$this->assertSame($matched, $result['results'][0]);
 	}//end testUnscopedQueryMatchesAnyRegisterOrSchema()
 
+	/**
+	 * `_registers` (plural, array) and `_schema` (singular) are supported query
+	 * shapes with no test until now. `resolveScope()` reads four keys per
+	 * dimension — `@self.register`, `_register`, `register` and the plural
+	 * `_registers` — and the two shapes exercised elsewhere in this file are
+	 * `_register` and `_schemas`, i.e. one singular and one plural, never the
+	 * other diagonal. A caller using the untested pair got a scope assembled by
+	 * branches nothing had ever run.
+	 *
+	 * Asserted as a MATCH rather than a skip, so it fails if either branch stops
+	 * contributing its id: a scope that silently resolved to empty would let this
+	 * object through for the wrong reason and read identically.
+	 */
+	public function testPluralRegistersAndSingularSchemaBothNarrowTheScope(): void {
+		$this->chunkMapper->method('searchByKeyword')->willReturn(
+			[
+				['entity_type' => 'object', 'entity_id' => '42', 'score' => 0.8, 'chunk_text' => 'x', 'chunk_index' => 0, 'metadata' => []],
+			]
+		);
+		$matched = $this->makeObject(42, register: '7', schema: '3');
+		$this->objectMapper->method('find')->willReturn($matched);
+
+		$result = $this->handler->augmentWithChunkMatches(
+			query: ['_search' => 'quarterly report', '_registers' => [7, 8], '_schema' => 3],
+			results: [],
+			total: 0,
+			limit: 20
+		);
+
+		$this->assertCount(1, $result['results']);
+		$this->assertSame($matched, $result['results'][0]);
+		$this->assertSame(1, $result['total']);
+	}//end testPluralRegistersAndSingularSchemaBothNarrowTheScope()
+
+	/**
+	 * The same pair, narrowing the other way: an object OUTSIDE the plural
+	 * register list is skipped. Without this, the test above would pass even if
+	 * `_registers` contributed nothing, because an empty scope matches everything.
+	 */
+	public function testObjectOutsideThePluralRegisterListIsSkipped(): void {
+		$this->chunkMapper->method('searchByKeyword')->willReturn(
+			[
+				['entity_type' => 'object', 'entity_id' => '42', 'score' => 0.8, 'chunk_text' => 'x', 'chunk_index' => 0, 'metadata' => []],
+			]
+		);
+		$this->objectMapper->method('find')->willReturn($this->makeObject(42, register: '99', schema: '3'));
+
+		$result = $this->handler->augmentWithChunkMatches(
+			query: ['_search' => 'quarterly report', '_registers' => [7, 8], '_schema' => 3],
+			results: [],
+			total: 0,
+			limit: 20
+		);
+
+		$this->assertSame([], $result['results']);
+		$this->assertSame(0, $result['total']);
+	}//end testObjectOutsideThePluralRegisterListIsSkipped()
+
 	// =========================================================================
 	// Page-limit clamping
 	// =========================================================================

--- a/tests/Unit/Service/Object/ContentSearchHandlerTest.php
+++ b/tests/Unit/Service/Object/ContentSearchHandlerTest.php
@@ -201,10 +201,10 @@ class ContentSearchHandlerTest extends TestCase {
 		);
 
 		$this->assertSame([], $result['results']);
-		// Total is metaTotal + distinct-chunk-owners upper bound (1 chunk hit
-		// even though it turned out to be unresolvable). See "stable total
-		// across pages" fix — over-count is intentional and accepted.
-		$this->assertSame(4, $result['total']);
+		// The unresolvable owner is NOT counted. `total` is the number of
+		// chunk owners this caller can actually see, so a chunk whose owning
+		// object cannot be resolved contributes nothing to it.
+		$this->assertSame(3, $result['total']);
 	}//end testFileChunkWithUnresolvableOwningObjectIsSkippedSilently()
 
 	public function testResolveExceptionIsCaughtLoggedAndSkipped(): void {
@@ -225,9 +225,10 @@ class ContentSearchHandlerTest extends TestCase {
 		);
 
 		$this->assertSame([], $result['results']);
-		// Total is upper-bound: chunk-owner set included the doomed id
-		// before the resolve threw. See "stable total across pages" fix.
-		$this->assertSame(1, $result['total']);
+		// A hit whose resolve THREW is not a hit this caller can see, so it
+		// is not counted either. Swallowing the exception must not leave the
+		// row behind in the count.
+		$this->assertSame(0, $result['total']);
 	}//end testResolveExceptionIsCaughtLoggedAndSkipped()
 
 	// =========================================================================
@@ -256,10 +257,10 @@ class ContentSearchHandlerTest extends TestCase {
 		);
 
 		$this->assertCount(1, $result['results']);
-		// Total is upper-bound: chunk-owner set had 1 hit even though it
-		// deduped against the metadata arm. Over-count is intentional per
-		// "stable total across pages" fix — pagination stays consistent.
-		$this->assertSame(2, $result['total']);
+		// One object, counted once. It is already in the metadata arm's
+		// total, so the chunk arm must not add it a second time — an object
+		// that matches BOTH ways is still one result.
+		$this->assertSame(1, $result['total']);
 	}//end testObjectAlreadyMatchedByMetadataArmIsNotDuplicated()
 
 	// =========================================================================
@@ -282,9 +283,8 @@ class ContentSearchHandlerTest extends TestCase {
 		);
 
 		$this->assertSame([], $result['results']);
-		// Total is upper-bound: the out-of-scope chunk is counted before the
-		// scope filter runs. Over-count accepted per "stable total" fix.
-		$this->assertSame(1, $result['total']);
+		// Out of the caller's register scope is out of the caller's count.
+		$this->assertSame(0, $result['total']);
 	}//end testObjectOutsideRequestedRegisterIsSkipped()
 
 	public function testObjectOutsideRequestedSchemasIsSkipped(): void {
@@ -303,9 +303,8 @@ class ContentSearchHandlerTest extends TestCase {
 		);
 
 		$this->assertSame([], $result['results']);
-		// Total is upper-bound: the out-of-scope chunk is counted before the
-		// scope filter runs. Over-count accepted per "stable total" fix.
-		$this->assertSame(1, $result['total']);
+		// Out of the caller's schema scope is out of the caller's count.
+		$this->assertSame(0, $result['total']);
 	}//end testObjectOutsideRequestedSchemasIsSkipped()
 
 	public function testUnscopedQueryMatchesAnyRegisterOrSchema(): void {
@@ -338,7 +337,12 @@ class ContentSearchHandlerTest extends TestCase {
 				['entity_type' => 'object', 'entity_id' => '42', 'score' => 0.8, 'chunk_text' => 'x', 'chunk_index' => 0, 'metadata' => []],
 			]
 		);
-		$this->objectMapper->expects($this->never())->method('find');
+		// The hit RESOLVES even though this page has no room for it. That is
+		// the change: `total` can only be truthful if visibility is actually
+		// checked, and visibility cannot be known without resolving. The cost
+		// is bounded by CHUNK_CANDIDATE_LIMIT, which this class already
+		// documents as its worst case.
+		$this->objectMapper->method('find')->willReturn($this->makeObject(42));
 
 		// limit=1, already 1 metadata-match result -> zero room for chunk-only appends.
 		$result = $this->handler->augmentWithChunkMatches(
@@ -348,11 +352,12 @@ class ContentSearchHandlerTest extends TestCase {
 			limit: 1
 		);
 
+		// The page is still clamped: nothing is appended beyond the room.
 		$this->assertCount(1, $result['results']);
-		// Total is upper-bound = metaTotal + distinct chunk-owner count
-		// (1 chunk hit, room=0 so nothing appended). This is the whole point
-		// of the "stable total" fix: page 2 of the same query would then
-		// append this chunk, and the total stays 2 across both pages.
+		// And the total still counts the resolvable owner, so page 2 of the
+		// same query reports the same number. Stability now comes from
+		// resolving the same candidate set every page, not from counting
+		// candidates nobody can see.
 		$this->assertSame(2, $result['total']);
 	}//end testAppendedRowsAreClampedToRemainingRoomOnThePage()
 


### PR DESCRIPTION
`_content_search` reported a total that included chunk owners it then refused to return.

**Measured on the dev instance 2026-09-02, unauthenticated,** against OpenCatalogi's `#[PublicPage]` search:

```
GET /apps/opencatalogi/api/search?_search=<phrase>&_content=true
-> {"results":[],"total":1}
```

The owning document was soft-deleted, so the row was correctly withheld and the count was not. An anonymous caller could probe a phrase and learn **from the count alone** that a document containing it exists. A count is an answer, so it has to obey the same visibility rules as the rows.

## Why it was like that

The over-count was deliberate and documented. Counting the distinct chunk-owner set **before** the resolve loop kept `total` stable across pages, because that loop is clamped to the page's remaining room. Stability was the right goal; the upper bound was the wrong way to reach it. Scope mismatch, RBAC, tenancy and a soft-deleted owner each drop a row without touching the count.

## The change

**Resolve first, then count and page.** Every candidate is resolved, `total` counts what resolved, and the page is a slice of that same set.

Stability is preserved, and is now a property of the query rather than a guess: page 1 and page 3 resolve the same candidates and report the same number. The existing cross-page test (`53` across page one and page three) passes unchanged.

## Cost, stated plainly

Up to `CHUNK_CANDIDATE_LIMIT` (50) resolves per call instead of up to the page's room. That is the worst case this class already budgets for and documents on that constant, and `_content_search` is opt-in.

## Verified

| | before | after |
|---|---|---|
| invisible owner, anonymous | `total: 1, rows: 0` | `total: 0, rows: 0` |
| visible owner, authenticated | `total: 1, rows: 1` | `total: 1, rows: 1` |

Both measured live. The positive control matters: a fix that just zeroed the count would pass the first row and fail the second.

Six tests asserted the over-count as intentional. They are **rewritten, not deleted** — each now pins the visibility rule it was documenting the absence of. The clamping test additionally proves the page is still clamped while the total still counts the resolvable owner.

PHPUnit 14/14 plus the sibling `QueryHandlerContentSearchTest` 12/12; PHPCS, PHPStan, PHPMD and Psalm clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
