### PR TITLE
fix(tenant): follow the merge before the UUID becomes a scope

### DIFF
--- a/lib/Service/OrganisationService.php
+++ b/lib/Service/OrganisationService.php
@@ -1167,6 +1167,92 @@ class OrganisationService {
 	}//end hasAdminGroupInAuthorization()
 
 	/**
+	 * Resolve an organisation through its merge chain
+	 *
+	 * A merge is recorded on the row that was merged AWAY, so a UUID held
+	 * anywhere outside the mapper — a user's stored active organisation, a
+	 * membership list, a federation peer's reference — can name an organisation
+	 * that no longer owns anything. The resolver is bounded and cycle-guarded
+	 * and never fails open; if the survivor cannot be loaded this returns the
+	 * organisation it was handed, which is a real row.
+	 *
+	 * @param Organisation $organisation The (possibly merged-away) organisation.
+	 *
+	 * @return Organisation The surviving organisation, or the input if unresolvable.
+	 *
+	 * @spec openspec/changes/consolidate-organisation-on-or/tasks.md#3-merge-resolution
+	 */
+	private function followMerge(Organisation $organisation): Organisation {
+		// The overwhelming majority of rows were never merged, and those need no
+		// walk at all: the flag lives on the row that was merged AWAY.
+		if ($organisation->isMerged() === false) {
+			return $organisation;
+		}
+
+		$uuid = (string) $organisation->getUuid();
+		if ($uuid === '') {
+			return $organisation;
+		}
+
+		try {
+			return $this->organisationMapper->findByUuidFollowingMerge(uuid: $uuid);
+		} catch (Exception $e) {
+			// An unresolvable survivor is a data defect, not a reason to hand
+			// the caller nothing: the row we already have is real.
+			$this->logger->warning(
+				message: '[OrganisationService] Could not resolve merge target; keeping the organisation as stored',
+				context: [
+					'file' => __FILE__,
+					'line' => __LINE__,
+					'organisationUuid' => $uuid,
+					'error' => $e->getMessage(),
+				]
+			);
+			return $organisation;
+		}
+	}//end followMerge()
+
+	/**
+	 * Write a followed merge back into the user's stored active organisation
+	 *
+	 * Following the merge on every read is correct but leaves the dead UUID in
+	 * config forever, so every later read pays the walk. Persisting the survivor
+	 * once makes the walk a one-off per user per merge.
+	 *
+	 * @param string       $userId       The user whose setting is being corrected.
+	 * @param string       $storedUuid   The UUID currently in user config.
+	 * @param Organisation $organisation The organisation the merge resolved to.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/consolidate-organisation-on-or/tasks.md#3-merge-resolution
+	 */
+	private function persistFollowedMerge(string $userId, string $storedUuid, Organisation $organisation): void {
+		$survivorUuid = (string) $organisation->getUuid();
+		if ($survivorUuid === '' || $survivorUuid === $storedUuid) {
+			return;
+		}
+
+		$this->config->setUserValue(
+			$userId,
+			self::APP_NAME,
+			self::CONFIG_ACTIVE_ORGANISATION,
+			$survivorUuid
+		);
+
+		$this->logger->info(
+			message: '[OrganisationService] Active organisation followed a merge',
+			context: [
+				'file' => __FILE__,
+				'line' => __LINE__,
+				'userId' => $userId,
+				'from' => $storedUuid,
+				'to' => $survivorUuid,
+			]
+		);
+	}//end persistFollowedMerge()
+
+	/**
 	 * Fetch active organisation from database (cache miss fallback)
 	 *
 	 * @param string $userId The user ID to fetch active organisation for.
@@ -1190,8 +1276,21 @@ class OrganisationService {
 			try {
 				$organisation = $this->organisationMapper->findByUuid($activeUuid);
 
-				// Verify user still has access to this organisation.
+				// Follow the merge chain BEFORE the UUID is used as a scope. A
+				// merged-away organisation no longer owns its data, so using the
+				// stored UUID literally would run every scoped query for this
+				// user under a tenant boundary that no longer applies.
+				$organisation = $this->followMerge(organisation: $organisation);
+
+				// Verify user still has access to this organisation. Note this is
+				// membership of the SURVIVOR: a user the merge did not carry over
+				// falls through to their own organisation list, which fails closed.
 				if ($organisation->hasUser($userId) === true) {
+					$this->persistFollowedMerge(
+						userId: $userId,
+						storedUuid: $activeUuid,
+						organisation: $organisation
+					);
 					return $organisation;
 				}
 
@@ -1234,7 +1333,10 @@ class OrganisationService {
 				}
 			);
 
-			$oldestOrg = $organisations[0];
+			// The user's membership list can still name a merged-away
+			// organisation, so the auto-pick resolves too — otherwise the very
+			// first login after a merge writes the dead UUID back into config.
+			$oldestOrg = $this->followMerge(organisation: $organisations[0]);
 
 			// Set in user configuration.
 			$this->config->setUserValue(

--- a/openspec/changes/consolidate-organisation-on-or/tasks.md
+++ b/openspec/changes/consolidate-organisation-on-or/tasks.md
@@ -22,9 +22,13 @@
 - [x] 3.1 Implement `OrganisationMapper::resolveMergeTarget()` — bounded,
       cycle-guarded, never failing open.
 - [x] 3.2 Implement `findByUuidFollowingMerge()` as the read counterpart.
-- [ ] 3.3 Call the resolver from the live tenant-resolution path. HELD: this
-      changes which rows every scoped query returns for a merged organisation,
-      so it needs its own change and its own regression suite.
+- [x] 3.3 Call the resolver from the live tenant-resolution path. Both entries
+      into `fetchActiveOrganisationFromDatabase()` now walk it: the stored
+      active UUID, and the oldest-membership auto-pick that runs when nothing
+      is stored. The walk is guarded on `isMerged()`, so an unmerged row costs
+      no query, and the survivor is written back to user config so the walk is
+      a one-off per user per merge. Six regression tests in
+      `tests/Unit/Service/ActiveOrganisationFollowsMergeTest.php`.
 
 ## 4. Tests
 

--- a/tests/Unit/Service/ActiveOrganisationFollowsMergeTest.php
+++ b/tests/Unit/Service/ActiveOrganisationFollowsMergeTest.php
@@ -1,0 +1,267 @@
+<?php
+
+/**
+ * Tenant resolution follows the merge chain.
+ *
+ * Task 3.1 built `resolveMergeTarget()` and 3.2 built its read counterpart, but
+ * nothing on the live path called either, so a merge was recorded and never
+ * followed: every scoped query for a user whose active organisation had been
+ * merged away still ran under the merged-away UUID. That is the silent kind of
+ * defect, because the row still loads and the query still returns rows.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service;
+
+use OCA\OpenRegister\Db\Organisation;
+use OCA\OpenRegister\Db\OrganisationMapper;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IAppConfig;
+use OCP\IConfig;
+use OCP\IGroupManager;
+use OCP\ISession;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Locks the merge walk onto the live tenant-resolution path.
+ */
+class ActiveOrganisationFollowsMergeTest extends TestCase {
+	/**
+	 * @var OrganisationMapper|MockObject
+	 */
+	private $organisationMapper;
+
+	/**
+	 * @var IConfig|MockObject
+	 */
+	private $config;
+
+	/**
+	 * @var ISession|MockObject
+	 */
+	private $session;
+
+	/**
+	 * @var IUserSession|MockObject
+	 */
+	private $userSession;
+
+	/**
+	 * @var LoggerInterface|MockObject
+	 */
+	private $logger;
+
+	/**
+	 * @var OrganisationService
+	 */
+	private OrganisationService $service;
+
+	/**
+	 * Build the service over mocked collaborators and clear the static caches.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$reflection = new \ReflectionClass(OrganisationService::class);
+		foreach (['defaultOrgCache' => null, 'defaultOrgCacheTs' => null, 'userOrgsCache' => []] as $name => $value) {
+			$property = $reflection->getProperty($name);
+			$property->setAccessible(true);
+			$property->setValue(null, $value);
+		}
+
+		$this->organisationMapper = $this->createMock(OrganisationMapper::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->session = $this->createMock(ISession::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$this->userSession->method('getUser')->willReturn($user);
+
+		// No session cache, so every call reaches the database path.
+		$this->session->method('get')->willReturn(null);
+
+		$this->service = new OrganisationService(
+			organisationMapper: $this->organisationMapper,
+			userSession: $this->userSession,
+			session: $this->session,
+			config: $this->config,
+			appConfig: $this->createMock(IAppConfig::class),
+			groupManager: $this->createMock(IGroupManager::class),
+			userManager: $this->createMock(IUserManager::class),
+			logger: $this->logger
+		);
+
+	}//end setUp()
+
+	/**
+	 * Build an organisation row.
+	 *
+	 * @param string      $uuid       The organisation uuid.
+	 * @param string|null $mergedInto The uuid it was merged into, if any.
+	 * @param array       $users      The member user ids.
+	 *
+	 * @return Organisation The organisation.
+	 */
+	private function organisation(string $uuid, ?string $mergedInto = null, array $users = ['alice']): Organisation {
+		$organisation = new Organisation();
+		$organisation->setUuid($uuid);
+		$organisation->setName('Org ' . $uuid);
+		$organisation->setUsers($users);
+		$organisation->setCreated(new \DateTime('2024-01-01'));
+		$organisation->setMergedInto($mergedInto);
+
+		return $organisation;
+
+	}//end organisation()
+
+	/**
+	 * The stored active organisation was merged away, so the survivor is
+	 * returned instead of the row the UUID names.
+	 *
+	 * @return void
+	 */
+	public function testAMergedAwayActiveOrganisationResolvesToTheSurvivor(): void {
+		$merged = $this->organisation(uuid: 'dead-uuid', mergedInto: 'survivor-uuid');
+		$survivor = $this->organisation(uuid: 'survivor-uuid');
+
+		$this->config->method('getUserValue')->willReturn('dead-uuid');
+		$this->organisationMapper->method('findByUuid')->willReturn($merged);
+		$this->organisationMapper->method('findByUuidFollowingMerge')
+			->with(uuid: 'dead-uuid')
+			->willReturn($survivor);
+
+		$this->assertSame('survivor-uuid', $this->service->getActiveOrganisation()?->getUuid());
+
+	}//end testAMergedAwayActiveOrganisationResolvesToTheSurvivor()
+
+	/**
+	 * The followed merge is written back, so the walk is a one-off per user
+	 * rather than a cost every read pays forever.
+	 *
+	 * @return void
+	 */
+	public function testTheFollowedMergeIsWrittenBackToUserConfig(): void {
+		$merged = $this->organisation(uuid: 'dead-uuid', mergedInto: 'survivor-uuid');
+		$survivor = $this->organisation(uuid: 'survivor-uuid');
+
+		$this->config->method('getUserValue')->willReturn('dead-uuid');
+		$this->organisationMapper->method('findByUuid')->willReturn($merged);
+		$this->organisationMapper->method('findByUuidFollowingMerge')->willReturn($survivor);
+
+		$this->config->expects($this->once())
+			->method('setUserValue')
+			->with('alice', 'openregister', $this->anything(), 'survivor-uuid');
+
+		$this->service->getActiveOrganisation();
+
+	}//end testTheFollowedMergeIsWrittenBackToUserConfig()
+
+	/**
+	 * An organisation that was never merged is not walked at all: the flag
+	 * lives on the row that was merged away, so a lookup here would be a query
+	 * per request for the case that is almost always true.
+	 *
+	 * @return void
+	 */
+	public function testAnUnmergedOrganisationIsNeverWalked(): void {
+		$this->config->method('getUserValue')->willReturn('live-uuid');
+		$this->organisationMapper->method('findByUuid')->willReturn($this->organisation(uuid: 'live-uuid'));
+
+		$this->organisationMapper->expects($this->never())->method('findByUuidFollowingMerge');
+		$this->config->expects($this->never())->method('setUserValue');
+
+		$this->assertSame('live-uuid', $this->service->getActiveOrganisation()?->getUuid());
+
+	}//end testAnUnmergedOrganisationIsNeverWalked()
+
+	/**
+	 * A user the merge did not carry over is not a member of the survivor, so
+	 * the stale setting is cleared and resolution falls through to the user's
+	 * own organisations. It fails closed: no tenant is handed out on the
+	 * strength of a membership that ended.
+	 *
+	 * @return void
+	 */
+	public function testAUserTheMergeDidNotCarryOverFallsThrough(): void {
+		$merged = $this->organisation(uuid: 'dead-uuid', mergedInto: 'survivor-uuid');
+		$survivor = $this->organisation(uuid: 'survivor-uuid', mergedInto: null, users: ['bob']);
+		$own = $this->organisation(uuid: 'own-uuid');
+
+		$this->config->method('getUserValue')->willReturn('dead-uuid');
+		$this->organisationMapper->method('findByUuid')->willReturn($merged);
+		$this->organisationMapper->method('findByUuidFollowingMerge')->willReturn($survivor);
+		$this->organisationMapper->method('findByUserId')->willReturn([$own]);
+
+		$this->config->expects($this->once())->method('deleteUserValue');
+
+		$this->assertSame('own-uuid', $this->service->getActiveOrganisation()?->getUuid());
+
+	}//end testAUserTheMergeDidNotCarryOverFallsThrough()
+
+	/**
+	 * With no stored setting the oldest membership is auto-picked, and that
+	 * list can name a merged-away organisation too. Without the walk here the
+	 * very first login after a merge writes the dead UUID straight back into
+	 * config, which is the defect re-creating itself.
+	 *
+	 * @return void
+	 */
+	public function testTheAutoPickedOldestOrganisationFollowsTheMergeToo(): void {
+		$merged = $this->organisation(uuid: 'dead-uuid', mergedInto: 'survivor-uuid');
+		$survivor = $this->organisation(uuid: 'survivor-uuid');
+
+		$this->config->method('getUserValue')->willReturn('');
+		$this->organisationMapper->method('findByUserId')->willReturn([$merged]);
+		$this->organisationMapper->method('findByUuidFollowingMerge')->willReturn($survivor);
+
+		$this->config->expects($this->once())
+			->method('setUserValue')
+			->with('alice', 'openregister', $this->anything(), 'survivor-uuid');
+
+		$this->assertSame('survivor-uuid', $this->service->getActiveOrganisation()?->getUuid());
+
+	}//end testTheAutoPickedOldestOrganisationFollowsTheMergeToo()
+
+	/**
+	 * A merge pointing at a row that cannot be loaded is a data defect, not a
+	 * reason to hand the caller nothing. The organisation already in hand is
+	 * real, so resolution keeps it rather than throwing out of a read path.
+	 *
+	 * @return void
+	 */
+	public function testAnUnresolvableSurvivorKeepsTheOrganisationAsStored(): void {
+		$merged = $this->organisation(uuid: 'dead-uuid', mergedInto: 'ghost-uuid');
+
+		$this->config->method('getUserValue')->willReturn('dead-uuid');
+		$this->organisationMapper->method('findByUuid')->willReturn($merged);
+		$this->organisationMapper->method('findByUuidFollowingMerge')
+			->willThrowException(new DoesNotExistException('gone'));
+
+		$this->logger->expects($this->once())->method('warning');
+
+		$this->assertSame('dead-uuid', $this->service->getActiveOrganisation()?->getUuid());
+
+	}//end testAnUnresolvableSurvivorKeepsTheOrganisationAsStored()
+}//end class


### PR DESCRIPTION
## Why

`resolveMergeTarget()` and `findByUuidFollowingMerge()` landed in tasks 3.1 and 3.2 of `consolidate-organisation-on-or`, and then nothing called either of them. A merge was recorded and never followed.

That is the quiet kind of defect. A merged-away organisation still loads, its scoped queries still return rows, and nothing anywhere reports an error. The rows just come back under a tenant boundary that no longer applies.

## What changed

Both entries into `fetchActiveOrganisationFromDatabase()` now walk the chain.

The stored active UUID is the obvious one. The auto-pick is the one that matters more: a user's membership list can still name a merged-away organisation, so without a walk there, the first login after a merge writes the dead UUID straight back into config and re-creates the defect it just fixed.

Three properties worth calling out:

- **The walk is guarded on `isMerged()`.** The flag lives on the row that was merged away, and almost no row carries it, so the common case costs no extra query.
- **Membership is checked against the survivor.** A user the merge did not carry over falls through to their own organisation list, rather than being handed a tenant on the strength of a membership that ended. It fails closed.
- **The survivor is written back to user config.** Following on every read is correct but leaves the dead UUID in place forever; persisting it once makes the walk a one-off per user per merge.

An unresolvable survivor keeps the row already in hand and logs a warning. A read path is the wrong place to throw over a data defect, and the row it already holds is real.

## Verification

- 6 new tests in `tests/Unit/Service/ActiveOrganisationFollowsMergeTest.php`, including the negative case (an unmerged row is never walked) and the fail-closed case.
- The full organisation suite: 634 tests, 1496 assertions, green.
- phpcs, psalm and phpstan clean on the changed file.

Closes task 3.3 of `consolidate-organisation-on-or`.
