### PR TITLE
test(e2e): the VTODO deep link serves the shell, it no longer redirects

### DIFF
--- a/tests/e2e/task-projections.spec.ts
+++ b/tests/e2e/task-projections.spec.ts
@@ -157,12 +157,26 @@ test.describe('flow-task-projections: the calendar projection', () => {
 			expect(url).toContain(`${OPEN}/${task.uuid}`)
 			expect(url).not.toContain('/api/')
 
-			// Following it lands in the app (a redirect into the task route), not a 404.
+			// Following it lands in the app, not a 404 and not the API.
+			//
+			// THIS ASSERTED A REDIRECT AND A HASH URL, AND BOTH ARE GONE.
+			// `TaskController::open()` used to answer 302 with
+			// `Location: …/#/flow-tasks/<uuid>`; #3315 rewrote it to serve the SPA
+			// shell directly, and #3270 had already moved the router off hash
+			// routing so that fragment addressed nothing. The old assertion
+			// survived both changes because this block SKIPS on any instance whose
+			// assignee has no VTODO-capable calendar, which CI's `admin` does not
+			// have — so it has been asserting a contract that no longer exists,
+			// without ever running to say so.
 			const followed = await request.get(url!, { maxRedirects: 0 })
-			expect([302, 303]).toContain(followed.status())
-			expect(followed.headers().location).toContain(
-				`#/flow-tasks/${task.uuid}`,
-			)
+			expect(
+				followed.status(),
+				'the deep link serves the app shell directly, no redirect hop',
+			).toBe(200)
+			expect(
+				await followed.text(),
+				'the shell, not an API payload or an error page',
+			).toContain('<html')
 		} finally {
 			await cancelQuietly(request, task.uuid)
 		}


### PR DESCRIPTION
Closes #3313, which is stale in the good direction: both halves of what I filed have been fixed by other work, and what is left is a test asserting the old contract.

## What changed under the issue

- **`#3315`** ("wire the fleet task inbox into the UI") rewrote `TaskController::open()` to return a `TemplateResponse` serving the SPA shell directly. There is no redirect any more.
- **`/flow-tasks/:uuid` exists**, as `flow-task-detail` in `src/main.js`, described there as *"the one stable address every VTODO URL and notification button carries"*.

So the product question the issue was holding open — where a task should open — is answered in code.

## The leftover

`task-projections.spec.ts` still asserted the contract that went away:

```js
expect([302, 303]).toContain(followed.status())
expect(followed.headers().location).toContain(`#/flow-tasks/${task.uuid}`)
```

A redirect that no longer happens, to a hash fragment that `#3270` stopped resolving when the router moved off hash routing.

**It survived both changes because it never runs.** The block skips whenever the assignee has no VTODO-capable calendar, and CI's `admin` has none — `No VTODO-supporting calendar found for user admin` appears in the server logs. So it has been asserting a contract that stopped existing, without ever executing to say so.

That is the same shape as a skip that cannot tell "not applicable on this instance" from "this is now wrong". The skip itself is right and stays; only the assertion behind it was stale.

## Now

Asserts what `open()` actually does: **200**, and the shell rather than an API payload or an error page. Still meaningful on an instance that does have a calendar, and no longer describes a redirect that cannot occur.

## Verification

`eslint` clean; `playwright test --list` collects the five tests in this file unchanged.
