### PR TITLE
feat(tasks): task expiry enforcement and configurable timeout/reject outcomes

### DIFF
--- a/lib/BackgroundJob/FlowTimerWorker.php
+++ b/lib/BackgroundJob/FlowTimerWorker.php
@@ -100,12 +100,14 @@ class FlowTimerWorker extends TimedJob {
 			$now = DateTimeImmutable::createFromInterface($this->time->getDateTime());
 			$result = $this->sweep->run(now: $now, batch: $this->batchLimit());
 
-			if ($result['expiriesFired'] > 0 || $result['rungsFired'] > 0 || $result['truncated'] === true || $result['errors'] > 0) {
+			$quiet = ($result['expiriesFired'] === 0 && $result['rungsFired'] === 0 && $result['taskTimeouts'] === 0);
+			if ($quiet === false || $result['truncated'] === true || $result['errors'] > 0) {
 				$this->logger->info(
 					message: sprintf(
-						'[FlowTimerWorker] Fired %d expiry timer(s) and %d escalation rung(s); truncated: %s; errors: %d',
+						'[FlowTimerWorker] Fired %d expiry timer(s), %d escalation rung(s) and %d task timeout(s); truncated: %s; errors: %d',
 						$result['expiriesFired'],
 						$result['rungsFired'],
+						$result['taskTimeouts'],
 						var_export($result['truncated'], true),
 						$result['errors']
 					),

--- a/lib/Db/Task.php
+++ b/lib/Db/Task.php
@@ -99,6 +99,10 @@ use OCP\AppFramework\Db\Entity;
  * @method void setDueAt(?DateTime $dueAt)
  * @method DateTime|null getExpiresAt()
  * @method void setExpiresAt(?DateTime $expiresAt)
+ * @method string|null getOnTimeout()
+ * @method void setOnTimeout(?string $onTimeout)
+ * @method string|null getOnReject()
+ * @method void setOnReject(?string $onReject)
  * @method integer|null getSlaValue()
  * @method void setSlaValue(?int $slaValue)
  * @method string|null getSlaUnit()
@@ -213,6 +217,15 @@ class Task extends Entity implements JsonSerializable {
 		self::STATE_TERMINATED,
 		self::STATE_DISABLED,
 	];
+
+	/**
+	 * The reserved behaviour vocabulary `on_timeout` and `on_reject` accept —
+	 * the same words `TaskService::applyTimerOutcome()` resolves, so one
+	 * mapping serves the timer path, the sweep and the reject routing.
+	 *
+	 * @var array<int, string>
+	 */
+	public const OUTCOME_BEHAVIOURS = ['skip', 'error', 'dead_letter'];
 
 	/**
 	 * Performer types (ADR-098 D3).
@@ -509,6 +522,24 @@ class Task extends Entity implements JsonSerializable {
 	protected ?DateTime $expiresAt = null;
 
 	/**
+	 * Declared behaviour when the enforcing deadline passes: one value of
+	 * the reserved timer-outcome vocabulary (skip|error|dead_letter). Null
+	 * means no declared behaviour — the bare deadline enforces nothing.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $onTimeout = null;
+
+	/**
+	 * Declared behaviour on a rejecting completion: one value of the
+	 * reserved timer-outcome vocabulary. Only `dead_letter` reroutes the
+	 * record; `skip` and `error` are the resuming consumer's contract.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $onReject = null;
+
+	/**
 	 * SLA magnitude. Stored, not interpreted here.
 	 *
 	 * @var integer|null
@@ -752,6 +783,8 @@ class Task extends Entity implements JsonSerializable {
 		$this->addType(fieldName: 'startAt', type: 'datetime');
 		$this->addType(fieldName: 'dueAt', type: 'datetime');
 		$this->addType(fieldName: 'expiresAt', type: 'datetime');
+		$this->addType(fieldName: 'onTimeout', type: 'string');
+		$this->addType(fieldName: 'onReject', type: 'string');
 		$this->addType(fieldName: 'slaValue', type: 'integer');
 		$this->addType(fieldName: 'slaUnit', type: 'string');
 		$this->addType(fieldName: 'compliancePeriodDays', type: 'integer');
@@ -867,6 +900,8 @@ class Task extends Entity implements JsonSerializable {
 			'startAt' => $this->startAt?->format('c'),
 			'dueAt' => $this->dueAt?->format('c'),
 			'expiresAt' => $this->expiresAt?->format('c'),
+			'onTimeout' => $this->onTimeout,
+			'onReject' => $this->onReject,
 			'slaValue' => $this->slaValue,
 			'slaUnit' => $this->slaUnit,
 			'compliancePeriodDays' => $this->compliancePeriodDays,

--- a/lib/Db/TaskMapper.php
+++ b/lib/Db/TaskMapper.php
@@ -156,6 +156,35 @@ class TaskMapper extends QBMapper {
 	}//end announceTerminality()
 
 	/**
+	 * The due timeouts: non-terminal tasks past their enforcing deadline
+	 * that DECLARE a timeout behaviour, earliest deadline first.
+	 *
+	 * A bounded, index-backed range scan (`or_tasks_open_expiry`), the same
+	 * discipline as the timer scans (flow-business-timers design D-8): never
+	 * a page of open rows filtered in PHP. A processed row leaves the scan
+	 * because applying its behaviour makes it terminal.
+	 *
+	 * @param \DateTimeInterface $now The sweep instant.
+	 * @param int $limit The batch limit.
+	 *
+	 * @return array<int, Task> The due tasks, earliest expiry first.
+	 *
+	 * @spec openspec/changes/task-expiry-and-outcomes/specs/task-expiry-and-outcomes/spec.md#requirement-the-timer-sweep-enforces-a-declared-task-expiry
+	 */
+	public function findDueTimeouts(\DateTimeInterface $now, int $limit): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('is_terminal', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL)))
+			->andWhere($qb->expr()->isNotNull('on_timeout'))
+			->andWhere($qb->expr()->lte('expires_at', $qb->createNamedParameter($now, IQueryBuilder::PARAM_DATETIME_MUTABLE)))
+			->orderBy('expires_at', 'ASC')
+			->setMaxResults(max(1, $limit));
+
+		return $this->findEntities(query: $qb);
+	}//end findDueTimeouts()
+
+	/**
 	 * A sequence's positions, in ordinal order.
 	 *
 	 * Ordinal order is the ONLY order that means anything to a sequence:

--- a/lib/Migration/Version1Date20260902090000.php
+++ b/lib/Migration/Version1Date20260902090000.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Storage for task expiry enforcement and configurable outcomes
+ * (task-expiry-and-outcomes, harvested from integriq's HITL semantics):
+ *
+ * - `openregister_tasks` gains `on_timeout` and `on_reject`: each holds one
+ *   value of the reserved timer-outcome vocabulary (skip|error|dead_letter),
+ *   null meaning "no declared behaviour" — which is exactly the pre-change
+ *   behaviour, so existing rows change nothing.
+ * - `or_tasks_open_expiry (is_terminal, expires_at)` backs the sweep's third
+ *   range scan (`is_terminal = false AND on_timeout IS NOT NULL AND
+ *   expires_at <= now ORDER BY expires_at LIMIT batch`), keeping the
+ *   bounded-scan discipline flow-business-timers design D-8 requires.
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/task-expiry-and-outcomes/specs/task-expiry-and-outcomes/spec.md#requirement-a-task-declares-its-timeout-and-reject-behaviour-in-one-vocabulary
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use Doctrine\DBAL\Types\Types;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Adds the declared-behaviour columns and the expiry-scan index.
+ *
+ * @spec openspec/changes/task-expiry-and-outcomes/specs/task-expiry-and-outcomes/spec.md#requirement-the-timer-sweep-enforces-a-declared-task-expiry
+ */
+class Version1Date20260902090000 extends SimpleMigrationStep {
+
+	/**
+	 * The task table.
+	 */
+	private const TABLE_TASKS = 'openregister_tasks';
+
+	/**
+	 * Add the columns and the index, idempotently.
+	 *
+	 * @param IOutput $output Migration output.
+	 * @param Closure(): ISchemaWrapper $schemaClosure The schema closure.
+	 * @param array<string, mixed> $options Migration options.
+	 *
+	 * @return ISchemaWrapper|null The changed schema, or null when nothing changed.
+	 *
+	 * @SuppressWarnings(PHPMD.UnusedFormalParameter) The interface fixes the signature.
+	 *
+	 * @spec openspec/changes/task-expiry-and-outcomes/specs/task-expiry-and-outcomes/spec.md#requirement-a-task-declares-its-timeout-and-reject-behaviour-in-one-vocabulary
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+		if ($schema->hasTable(self::TABLE_TASKS) === false) {
+			return null;
+		}
+
+		$table = $schema->getTable(self::TABLE_TASKS);
+		$changed = false;
+
+		if ($table->hasColumn('on_timeout') === false) {
+			$table->addColumn('on_timeout', Types::STRING, ['notnull' => false, 'length' => 32]);
+			$changed = true;
+		}
+
+		if ($table->hasColumn('on_reject') === false) {
+			$table->addColumn('on_reject', Types::STRING, ['notnull' => false, 'length' => 32]);
+			$changed = true;
+		}
+
+		if ($table->hasIndex('or_tasks_open_expiry') === false) {
+			$table->addIndex(['is_terminal', 'expires_at'], 'or_tasks_open_expiry');
+			$changed = true;
+		}
+
+		if ($changed === false) {
+			return null;
+		}
+
+		return $schema;
+	}//end changeSchema()
+}//end class

--- a/lib/Service/Flow/Nodes/PortalTaskConfig.php
+++ b/lib/Service/Flow/Nodes/PortalTaskConfig.php
@@ -269,6 +269,8 @@ final class PortalTaskConfig {
 			'assignee' => $partyReference,
 			'dueAt' => $this->renderedOrNull(value: ($config['dueAt'] ?? null), json: $json),
 			'expiresAt' => $this->renderedOrNull(value: ($config['expiresAt'] ?? null), json: $json),
+			'onTimeout' => $this->behaviourOrNull(value: ($config['onTimeout'] ?? '')),
+			'onReject' => $this->behaviourOrNull(value: ($config['onReject'] ?? '')),
 			'metadata' => [
 				'flowNodeType' => $nodeType,
 				'flowNode' => $nodeId,
@@ -511,6 +513,23 @@ final class PortalTaskConfig {
 
 		return [];
 	}//end representativeJson()
+
+	/**
+	 * A declared behaviour value, trimmed, or null for absent. Vocabulary
+	 * validation is TaskBuilder's boundary, not this node's.
+	 *
+	 * @param mixed $value The configured value.
+	 *
+	 * @return string|null The behaviour, or null.
+	 */
+	private function behaviourOrNull(mixed $value): ?string {
+		$behaviour = trim((string)$value);
+		if ($behaviour === '') {
+			return null;
+		}
+
+		return $behaviour;
+	}//end behaviourOrNull()
 
 	/**
 	 * A templated string, or null when it renders to nothing.

--- a/lib/Service/Flow/Nodes/PortalTaskNode.php
+++ b/lib/Service/Flow/Nodes/PortalTaskNode.php
@@ -211,6 +211,8 @@ class PortalTaskNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigF
 			'reasonField',
 			'dueAt',
 			'expiresAt',
+			'onTimeout',
+			'onReject',
 			'heartbeatMinutes',
 			'advance',
 		];
@@ -599,6 +601,18 @@ class PortalTaskNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigF
 				'help' => $this->l10n->t(
 					'When the ask stops being answerable. Same shapes as "Due". Expiry is enforced by the business timers, not by this step.'
 				),
+			],
+			[
+				'key' => 'onTimeout',
+				'label' => $this->l10n->t('On timeout'),
+				'type' => 'text',
+				'help' => $this->l10n->t('What happens when the ask expires: skip, error or dead_letter. Empty means the deadline enforces nothing.'),
+			],
+			[
+				'key' => 'onReject',
+				'label' => $this->l10n->t('On rejection'),
+				'type' => 'text',
+				'help' => $this->l10n->t('Only dead_letter changes the record; skip and error are read by whatever resumes the flow.'),
 			],
 			[
 				'key' => 'heartbeatMinutes',

--- a/lib/Service/Flow/Nodes/UserTaskConfig.php
+++ b/lib/Service/Flow/Nodes/UserTaskConfig.php
@@ -195,6 +195,8 @@ final class UserTaskConfig {
 			'routingFallback' => $this->nullIfEmpty(value: trim((string)($config['routingFallback'] ?? ''))),
 			'dueAt' => $this->renderedOrNull(value: ($config['dueAt'] ?? null), json: $json),
 			'expiresAt' => $this->renderedOrNull(value: ($config['expiresAt'] ?? null), json: $json),
+			'onTimeout' => $this->nullIfEmpty(value: trim((string)($config['onTimeout'] ?? ''))),
+			'onReject' => $this->nullIfEmpty(value: trim((string)($config['onReject'] ?? ''))),
 			'metadata' => [
 				'flowNodeType' => $nodeType,
 				'flowNode' => $nodeId,

--- a/lib/Service/Flow/Nodes/UserTaskNode.php
+++ b/lib/Service/Flow/Nodes/UserTaskNode.php
@@ -197,6 +197,8 @@ class UserTaskNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigFor
 			'priority',
 			'dueAt',
 			'expiresAt',
+			'onTimeout',
+			'onReject',
 			'outcomes',
 			'outcomeKey',
 			'failOnReject',
@@ -535,6 +537,18 @@ class UserTaskNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigFor
 				'label' => $this->l10n->t('Expires'),
 				'type' => 'text',
 				'help' => $this->l10n->t('When the task stops being doable. Same shapes as "Due". Must not lie before it.'),
+			],
+			[
+				'key' => 'onTimeout',
+				'label' => $this->l10n->t('On timeout'),
+				'type' => 'text',
+				'help' => $this->l10n->t('What happens when the task expires: skip, error or dead_letter. Empty means the deadline enforces nothing.'),
+			],
+			[
+				'key' => 'onReject',
+				'label' => $this->l10n->t('On rejection'),
+				'type' => 'text',
+				'help' => $this->l10n->t('Only dead_letter changes the record; skip and error are read by whatever resumes the flow.'),
 			],
 			[
 				'key' => 'heartbeatMinutes',

--- a/lib/Service/Flow/Timer/FlowTimerService.php
+++ b/lib/Service/Flow/Timer/FlowTimerService.php
@@ -1196,23 +1196,42 @@ class FlowTimerService {
 	}//end cancelAll()
 
 	/**
-	 * Apply an expiry timer's enforcing outcome to a task subject.
+	 * Apply a fired expiry timer's outcome to a task subject.
+	 *
+	 * An enforcing timer applies its own validated `onExpiry`. A
+	 * non-enforcing expiry timer falls back to the SUBJECT TASK's declared
+	 * `onTimeout` (task-expiry-and-outcomes D-4): {@see project()} nulls the
+	 * task's `expires_at` once the last expiry timer fires, so without this
+	 * fallback the sweep's task scan would never reach a timer-managed task.
 	 *
 	 * @param FlowTimer $timer The fired timer.
 	 *
 	 * @return void
+	 *
+	 * @spec openspec/changes/task-expiry-and-outcomes/specs/task-expiry-and-outcomes/spec.md#requirement-a-non-enforcing-expiry-timer-falls-back-to-the-tasks-declared-behaviour
 	 */
 	private function applyOutcome(FlowTimer $timer): void {
-		if ($timer->isEnforcing() === false || $timer->getSubjectType() !== 'task') {
+		if ($timer->getSubjectType() !== 'task') {
+			return;
+		}
+
+		$outcome = $this->subjectTask(timer: $timer)?->getOnTimeout();
+		$basis = 'task-declared onTimeout';
+		if ($timer->isEnforcing() === true) {
+			$outcome = (string)$timer->getOnExpiry();
+			$basis = (string)$timer->getLegalEffect();
+		}
+
+		if ($outcome === null || $outcome === '') {
 			return;
 		}
 
 		try {
 			$this->taskService->applyTimerOutcome(
 				uuid: (string)$timer->getSubjectUuid(),
-				outcome: (string)$timer->getOnExpiry(),
+				outcome: $outcome,
 				source: 'flow-timer:' . (string)$timer->getUuid(),
-				reason: sprintf("Expiry timer '%s' (%s) reached its deadline.", (string)$timer->getUuid(), (string)$timer->getLegalEffect())
+				reason: sprintf("Expiry timer '%s' (%s) reached its deadline.", (string)$timer->getUuid(), $basis)
 			);
 		} catch (TaskConflictException $race) {
 			// The task closed concurrently: nothing to do, the timer is cancelled by that close.

--- a/lib/Service/Flow/Timer/FlowTimerSweep.php
+++ b/lib/Service/Flow/Timer/FlowTimerSweep.php
@@ -1,12 +1,14 @@
 <?php
 
 /**
- * One sweep pass: two bounded range scans, each row acted on.
+ * One sweep pass: three bounded range scans, each row acted on.
  *
  * `findDueExpiries(now, batch)` is `state = armed AND purpose = expiry AND
  * fire_at <= now ORDER BY fire_at LIMIT batch`; `findDueRungs(now, batch)`
  * is `state = armed AND next_rung_at <= now ORDER BY next_rung_at LIMIT
- * batch`. Neither reads a page of open rows and filters it in PHP: past the
+ * batch`; `findDueTimeouts(now, batch)` is `is_terminal = false AND
+ * on_timeout IS NOT NULL AND expires_at <= now ORDER BY expires_at LIMIT
+ * batch` (task-expiry-and-outcomes D-3). None reads a page of open rows and filters it in PHP: past the
  * page size that shape never reaches a due row while reporting a clean pass
  * (design D-8). Each timer is processed on its own; a failure on one is
  * logged and counted and does not stop the pass. The counts returned are
@@ -33,6 +35,8 @@ namespace OCA\OpenRegister\Service\Flow\Timer;
 
 use DateTimeInterface;
 use OCA\OpenRegister\Db\FlowTimerMapper;
+use OCA\OpenRegister\Db\TaskMapper;
+use OCA\OpenRegister\Service\Task\TaskService;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
@@ -42,18 +46,32 @@ use Throwable;
 class FlowTimerSweep {
 
 	/**
+	 * The actor a swept task timeout records itself as.
+	 *
+	 * @var string
+	 */
+	public const TIMEOUT_SOURCE = 'task-expiry-sweep';
+
+	/**
 	 * Constructor.
 	 *
-	 * @param FlowTimerMapper $timers The two range scans.
+	 * @param FlowTimerMapper $timers The two timer range scans.
 	 * @param FlowTimerService $service Fires expiries and rungs.
 	 * @param WorkingCalendarService $calendars Reset once per pass so memoisation is per pass.
 	 * @param LoggerInterface $logger Per-timer failure reporting.
+	 * @param TaskMapper|null $tasks The task-timeout range scan
+	 *                               (task-expiry-and-outcomes D-3). Nullable so
+	 *                               pre-existing positional instantiations keep
+	 *                               working; the container wires both.
+	 * @param TaskService|null $taskService Applies a due task's declared behaviour.
 	 */
 	public function __construct(
 		private readonly FlowTimerMapper $timers,
 		private readonly FlowTimerService $service,
 		private readonly WorkingCalendarService $calendars,
 		private readonly LoggerInterface $logger,
+		private readonly ?TaskMapper $tasks = null,
+		private readonly ?TaskService $taskService = null,
 	) {
 
 	}//end __construct()
@@ -64,14 +82,14 @@ class FlowTimerSweep {
 	 * @param DateTimeInterface $now The sweep instant.
 	 * @param int $batch The per-scan batch limit.
 	 *
-	 * @return array{expiriesFired: int, rungsFired: int, truncated: bool, errors: int} Work performed.
+	 * @return array{expiriesFired: int, rungsFired: int, taskTimeouts: int, truncated: bool, errors: int} Work performed.
 	 *
 	 * @spec openspec/changes/flow-business-timers/specs/flow-business-timers/spec.md#requirement-the-sweep-is-bounded-to-due-work-by-index-not-by-a-page-of-candidates
 	 */
 	public function run(DateTimeInterface $now, int $batch): array {
 		$batch = max(1, $batch);
 		$this->calendars->reset();
-		$result = ['expiriesFired' => 0, 'rungsFired' => 0, 'truncated' => false, 'errors' => 0];
+		$result = ['expiriesFired' => 0, 'rungsFired' => 0, 'taskTimeouts' => 0, 'truncated' => false, 'errors' => 0];
 
 		$expiries = $this->timers->findDueExpiries(now: $now, limit: $batch);
 		$result['truncated'] = (count($expiries) >= $batch);
@@ -103,6 +121,53 @@ class FlowTimerSweep {
 			}
 		}
 
+		$this->sweepTaskTimeouts(now: $now, batch: $batch, result: $result);
+
 		return $result;
 	}//end run()
+
+	/**
+	 * The third scan (task-expiry-and-outcomes D-3): non-terminal tasks past
+	 * their enforcing deadline that DECLARE a timeout behaviour, each closed
+	 * through the existing timer-outcome path. A failure on one task is
+	 * logged and counted and does not stop the pass; the row is retried next
+	 * pass because only a successful apply makes it terminal.
+	 *
+	 * @param DateTimeInterface $now The sweep instant.
+	 * @param int $batch The per-scan batch limit.
+	 * @param array{expiriesFired: int, rungsFired: int, taskTimeouts: int, truncated: bool, errors: int} $result Mutated in place.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/task-expiry-and-outcomes/specs/task-expiry-and-outcomes/spec.md#requirement-the-timer-sweep-enforces-a-declared-task-expiry
+	 */
+	private function sweepTaskTimeouts(DateTimeInterface $now, int $batch, array &$result): void {
+		if ($this->tasks === null || $this->taskService === null) {
+			return;
+		}
+
+		$due = $this->tasks->findDueTimeouts(now: $now, limit: $batch);
+		$result['truncated'] = ($result['truncated'] === true || count($due) >= $batch);
+		foreach ($due as $task) {
+			try {
+				$this->taskService->applyTimerOutcome(
+					uuid: (string)$task->getUuid(),
+					outcome: (string)$task->getOnTimeout(),
+					source: self::TIMEOUT_SOURCE,
+					reason: sprintf(
+						"Task expired at %s; declared onTimeout '%s' applied.",
+						(string)$task->getExpiresAt()?->format('c'),
+						(string)$task->getOnTimeout()
+					)
+				);
+				$result['taskTimeouts']++;
+			} catch (Throwable $failure) {
+				$result['errors']++;
+				$this->logger->error(
+					'[FlowTimerSweep] Task timeout failed: ' . $failure->getMessage(),
+					['task' => $task->getUuid(), 'exception' => $failure]
+				);
+			}
+		}
+	}//end sweepTaskTimeouts()
 }//end class

--- a/lib/Service/Task/TaskBuilder.php
+++ b/lib/Service/Task/TaskBuilder.php
@@ -114,6 +114,19 @@ class TaskBuilder {
 
 		$task->setDueAt($dueAt);
 		$task->setExpiresAt($expiresAt);
+
+		// Declared behaviours: one reserved vocabulary, refused by name
+		// outside it, and a timeout behaviour with no deadline is a
+		// configuration error, not a schedule (task-expiry-and-outcomes D-6).
+		$onTimeout = $this->validBehaviour(value: ($data['onTimeout'] ?? null), field: 'onTimeout');
+		if ($onTimeout !== null && $expiresAt === null) {
+			throw new TaskValidationException(
+				message: sprintf("onTimeout '%s' without an expiresAt is a configuration error: there is no deadline to time out on.", $onTimeout)
+			);
+		}
+
+		$task->setOnTimeout($onTimeout);
+		$task->setOnReject($this->validBehaviour(value: ($data['onReject'] ?? null), field: 'onReject'));
 		$task->setStartAt($this->parseDate(value: ($data['startAt'] ?? null), field: 'startAt'));
 		$task->setSuspendedUntil($this->parseDate(value: ($data['suspendedUntil'] ?? null), field: 'suspendedUntil'));
 
@@ -212,6 +225,38 @@ class TaskBuilder {
 
 		return $rows;
 	}//end relationsFor()
+
+	/**
+	 * A declared behaviour: one value of the reserved outcome vocabulary.
+	 *
+	 * @param mixed $value The incoming value.
+	 * @param string $field The field name, for the refusal message.
+	 *
+	 * @return string|null The validated behaviour, or null for absent.
+	 *
+	 * @throws TaskValidationException When present but outside the vocabulary.
+	 *
+	 * @spec openspec/changes/task-expiry-and-outcomes/specs/task-expiry-and-outcomes/spec.md#requirement-a-task-declares-its-timeout-and-reject-behaviour-in-one-vocabulary
+	 */
+	private function validBehaviour(mixed $value, string $field): ?string {
+		$behaviour = $this->stringOrNull(value: $value);
+		if ($behaviour === null) {
+			return null;
+		}
+
+		if (in_array($behaviour, Task::OUTCOME_BEHAVIOURS, true) === false) {
+			throw new TaskValidationException(
+				message: sprintf(
+					"Field '%s' value '%s' is not in the behaviour vocabulary (%s).",
+					$field,
+					$behaviour,
+					implode('|', Task::OUTCOME_BEHAVIOURS)
+				)
+			);
+		}
+
+		return $behaviour;
+	}//end validBehaviour()
 
 	/**
 	 * Parse a date field: DateTime passes, ISO strings parse, junk refuses.

--- a/lib/Service/Task/TaskFormResolver.php
+++ b/lib/Service/Task/TaskFormResolver.php
@@ -130,21 +130,43 @@ class TaskFormResolver {
 					'error' => $unresolvable->getMessage(),
 				],
 				'requireChecklist' => false,
+				'behaviours' => $this->behavioursOf(task: $task),
 			];
 		}
 
 		$form = null;
 		if ($declaration->isNative() === true) {
 			$form = $this->describeNative(declaration: $declaration);
-		} else if ($declaration->isExternal() === true) {
+		} elseif ($declaration->isExternal() === true) {
 			$form = $this->describeExternal(declaration: $declaration, task: $task);
 		}
 
 		return [
 			'form' => $form,
 			'requireChecklist' => $declaration->requireChecklist,
+			'behaviours' => $this->behavioursOf(task: $task),
 		];
 	}//end describe()
+
+	/**
+	 * The task's declared deadline behaviours, so a surface rendering the
+	 * form can say what happens on timeout or rejection
+	 * (task-expiry-and-outcomes: the behaviours are the task's contract,
+	 * not the form's).
+	 *
+	 * @param Task $task The task.
+	 *
+	 * @return array<string, string|null> expiresAt, onTimeout and onReject.
+	 *
+	 * @spec openspec/changes/task-expiry-and-outcomes/specs/task-expiry-and-outcomes/spec.md#requirement-a-task-declares-its-timeout-and-reject-behaviour-in-one-vocabulary
+	 */
+	private function behavioursOf(Task $task): array {
+		return [
+			'expiresAt' => $task->getExpiresAt()?->format('c'),
+			'onTimeout' => $task->getOnTimeout(),
+			'onReject' => $task->getOnReject(),
+		];
+	}//end behavioursOf()
 
 	/**
 	 * The declaration a task resolves to: pinned version, or its own record.

--- a/lib/Service/Task/TaskService.php
+++ b/lib/Service/Task/TaskService.php
@@ -49,10 +49,10 @@ use OCA\OpenRegister\Db\TaskCandidateMapper;
 use OCA\OpenRegister\Db\TaskMapper;
 use OCA\OpenRegister\Db\TaskRelationMapper;
 use OCA\OpenRegister\Event\TaskTerminalEvent;
+use OCA\OpenRegister\Event\TaskTransitionedEvent;
 use OCA\OpenRegister\Exception\TaskAccessDeniedException;
 use OCA\OpenRegister\Exception\TaskConflictException;
 use OCA\OpenRegister\Exception\TaskValidationException;
-use OCA\OpenRegister\Event\TaskTransitionedEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IDBConnection;
 use Psr\Log\LoggerInterface;
@@ -504,9 +504,9 @@ class TaskService {
 	 *                                             when the completion carries
 	 *                                             any (a portal task's form).
 	 * @param array<int, array<string, mixed>>|null $evidence References to the
-	 *                                                       files ALREADY stored
-	 *                                                       for this completion;
-	 *                                                       never bytes.
+	 *                                                        files ALREADY stored
+	 *                                                        for this completion;
+	 *                                                        never bytes.
 	 *
 	 * @return Task The completed task.
 	 *
@@ -1056,6 +1056,7 @@ class TaskService {
 	 * @throws TaskValidationException When a rejecting outcome has no comment.
 	 *
 	 * @spec openspec/changes/flow-task-entity/specs/flow-tasks/spec.md#requirement-every-lifecycle-verb-is-authorized-fail-closed
+	 * @spec openspec/changes/task-expiry-and-outcomes/specs/task-expiry-and-outcomes/spec.md#requirement-a-rejecting-completion-honours-the-tasks-declared-reject-behaviour
 	 */
 	private function completeInternal(
 		string $verb,
@@ -1084,9 +1085,36 @@ class TaskService {
 			);
 		}
 
+		// Declared reject behaviour (task-expiry-and-outcomes D-5): only
+		// `dead_letter` reroutes the record, through the SAME mapping the
+		// timer path resolves; `skip` and `error` are the resuming
+		// consumer's contract and change nothing about the completion.
+		$recordedOutcome = $outcome;
+		$targetState = Task::STATE_COMPLETED;
+		$auditReason = $comment;
+		if (TaskState::isRejectingOutcome(outcome: $outcome) === true && $task->getOnReject() === 'dead_letter') {
+			[$targetState, $recordedOutcome] = $this->timerOutcomeTarget(outcome: 'dead_letter');
+			$auditReason = sprintf(
+				"Rejected as '%s'; declared onReject 'dead_letter' routed it to the dead letter state. %s",
+				$outcome,
+				(string)$comment
+			);
+		}
+
 		return $this->transactional(
-			mutation: function () use ($task, $outcome, $resultText, $comment, $actor, $verb, $responses, $evidence): Task {
-				$task->setOutcome($outcome);
+			mutation: function () use (
+				$task,
+				$recordedOutcome,
+				$targetState,
+				$auditReason,
+				$resultText,
+				$comment,
+				$actor,
+				$verb,
+				$responses,
+				$evidence,
+			): Task {
+				$task->setOutcome($recordedOutcome);
 				$task->setResultText($resultText);
 				$task->setComment($comment);
 				if ($responses !== null) {
@@ -1099,9 +1127,9 @@ class TaskService {
 
 				$task->setCompletedAt(new DateTime());
 				$task->setCompletedBy($actor);
-				$this->applyState(task: $task, state: Task::STATE_COMPLETED, action: $verb);
+				$this->applyState(task: $task, state: $targetState, action: $verb);
 				$persisted = $this->persistOpen(task: $task);
-				$this->appendAudit(task: $persisted, action: $verb, actor: $actor, reason: $comment);
+				$this->appendAudit(task: $persisted, action: $verb, actor: $actor, reason: $auditReason);
 
 				return $persisted;
 			}
@@ -1214,7 +1242,7 @@ class TaskService {
 	 * @return Task The open, authorized task.
 	 *
 	 * @throws TaskConflictException When the task is already terminal — with
-	 *         the current state in the message.
+	 *                               the current state in the message.
 	 * @throws TaskAccessDeniedException When authorization denies (audited).
 	 *
 	 * @spec openspec/changes/flow-task-entity/specs/flow-tasks/spec.md#requirement-every-lifecycle-verb-is-authorized-fail-closed

--- a/openspec/changes/task-expiry-and-outcomes/design.md
+++ b/openspec/changes/task-expiry-and-outcomes/design.md
@@ -1,0 +1,66 @@
+# Design: task expiry and configurable outcomes
+
+## D-1: the behaviours live on the task row, not in metadata
+
+`on_timeout` and `on_reject` are two nullable string columns. The sweep
+selects on `on_timeout`, so it must be a column, not a JSON key; `on_reject`
+matches for symmetry and because consumers (a resuming bridge, a portal
+form) read it as a first-class contract of the task. Null means "no declared
+behaviour", which is exactly today's behaviour.
+
+## D-2: one vocabulary, one mapping
+
+Both columns use the reserved timer-outcome vocabulary already published by
+`TaskService::timerOutcomeTarget()`: `skip` → completed/skipped, `error` →
+terminated/failed, `dead_letter` → disabled/dead_letter. integriq's values
+map onto it directly (`error` default, `dead_letter` opt-in; its `skip`
+means "continue without the gate", which the flow reads from the recorded
+outcome). A second mapping for the same words would drift; a rejecting
+completion routed by `on_reject` therefore resolves through the SAME method
+as a fired timer.
+
+## D-3: the sweep rides FlowTimerSweep — a third scan, not a second scheduler
+
+integriq enforced expiry with its own 300s `ApprovalTimeoutSweepJob`. The
+shared service already has a 300s sweep worker (`FlowTimerWorker` →
+`FlowTimerSweep`) with the bounded-range-scan discipline (design D-8 of
+flow-business-timers: never read a page of open rows and filter in PHP).
+Task expiry becomes the pass's third scan:
+
+    is_terminal = false AND on_timeout IS NOT NULL AND expires_at <= now
+    ORDER BY expires_at LIMIT batch
+
+backed by a new `or_tasks_open_expiry (is_terminal, expires_at)` index. A
+processed row leaves the scan because `applyTimerOutcome()` makes it
+terminal; a row that fails to process is counted, logged, and retried next
+pass — the same contract the timer scans keep.
+
+## D-4: a timer-managed task is enforced at the timer, not by the scan
+
+`FlowTimerService::project()` rewrites a task's `expires_at` from its OPEN
+timers, and nulls it once the last expiry timer fires. A non-enforcing
+expiry timer (legal effect below `wettelijk`, so `onExpiry` is refused)
+would therefore fire, null the projection, and starve the scan — the task's
+declared `on_timeout` would never apply. So `applyOutcome()` gains a
+fallback: when the fired expiry timer is NOT enforcing and the subject task
+declares `on_timeout`, the task's own behaviour is applied. An enforcing
+timer still wins: `wettelijk` is the stronger claim and its `onExpiry` was
+validated at arm time.
+
+## D-5: `on_reject` only reroutes `dead_letter`
+
+integriq's `onReject` values `error` and `skip` are instructions to the
+RESUMING orchestration (fail the pipeline vs continue past the gate); the
+record itself stays `rejected`. Only `dead_letter` changes the terminal
+record. The shared service mirrors that: a rejecting completion (per
+`TaskState::isRejectingOutcome()`, comment still mandatory) of a task with
+`on_reject: dead_letter` records outcome `dead_letter` in state `disabled`,
+with the original rejecting outcome preserved in the audit reason. `error`
+and `skip` are stored and serialized for the consumer to read, and change
+nothing about the completion itself.
+
+## D-6: intake refuses a timeout with no deadline
+
+`onTimeout` without `expiresAt` is a configuration error, refused at
+`TaskBuilder` intake naming both fields — the same posture as the existing
+"expiry before due" refusal. `onReject` needs no deadline.

--- a/openspec/changes/task-expiry-and-outcomes/proposal.md
+++ b/openspec/changes/task-expiry-and-outcomes/proposal.md
@@ -1,0 +1,56 @@
+# Task expiry and configurable outcomes
+
+## Why
+
+The shared task entity stores `expires_at` and calls it the ENFORCING
+deadline, but nothing enforces it unless a `wettelijk` expiry timer happens
+to exist for the task. A task created with a bare `expiresAt` — over HTTP,
+through `import()`, or by a consuming app — keeps a decorative deadline
+forever.
+
+integriq's app-local HITL implementation (harvested by the fleet audit) has
+the semantics the shared service lacks: every `approval_request` carries an
+`expiresAt`, an `onTimeout` behaviour and an `onReject` behaviour. Its sweep
+turns a pending request past its `expiresAt` into `expired` (or
+`dead_letter` when `onTimeout` says so), and a rejection lands in
+`dead_letter` when `onReject` says so. Those behaviours are what this change
+moves into the shared service, so integriq (wave 2) and later adopters can
+delegate instead of duplicating.
+
+## What changes
+
+- `openregister_tasks` gains two nullable columns, `on_timeout` and
+  `on_reject`, each holding one value of the existing reserved timer-outcome
+  vocabulary (`skip` | `error` | `dead_letter`).
+- `TaskBuilder` accepts `onTimeout` and `onReject` at intake, refuses values
+  outside the vocabulary by name, and refuses `onTimeout` on a task without
+  an `expiresAt`.
+- `FlowTimerSweep` gains a third bounded range scan: non-terminal tasks whose
+  `expires_at` has passed and whose `on_timeout` is declared. Each hit goes
+  through the existing `TaskService::applyTimerOutcome()`. Same worker
+  (`FlowTimerWorker`), same pass, same bounded-scan discipline — no second
+  scheduler.
+- `FlowTimerService` applies a task's own declared `on_timeout` when a
+  non-enforcing expiry timer of that task fires, so a timer-managed task is
+  enforced deterministically even though `project()` rewrites `expires_at`.
+- A rejecting completion of a task that declares `on_reject: dead_letter`
+  records the dead-letter outcome instead of a plain rejection, through the
+  same outcome mapping the timer path uses.
+- The task JSON (entity serialization and the task-form description) carries
+  `onTimeout` and `onReject`, and the user-task and portal-task nodes accept
+  both keys next to `expiresAt`.
+
+## Impact
+
+- Affected specs: task-expiry-and-outcomes (new delta).
+- Affected code: `lib/Db/Task.php`, `lib/Db/TaskMapper.php`, a new
+  migration, `lib/Service/Task/TaskBuilder.php`,
+  `lib/Service/Task/TaskService.php`,
+  `lib/Service/Task/TaskFormResolver.php`,
+  `lib/Service/Flow/Timer/FlowTimerSweep.php`,
+  `lib/Service/Flow/Timer/FlowTimerService.php`,
+  `lib/Service/Flow/Nodes/UserTaskNode.php` (+ config),
+  `lib/Service/Flow/Nodes/PortalTaskNode.php` (+ config).
+- Backwards compatible: a task without a declared `on_timeout` keeps today's
+  behaviour (nothing enforces the bare deadline); a task without `on_reject`
+  keeps the plain rejecting completion.

--- a/openspec/changes/task-expiry-and-outcomes/specs/task-expiry-and-outcomes/spec.md
+++ b/openspec/changes/task-expiry-and-outcomes/specs/task-expiry-and-outcomes/spec.md
@@ -1,0 +1,85 @@
+# task-expiry-and-outcomes
+
+## ADDED Requirements
+
+### Requirement: A task declares its timeout and reject behaviour in one vocabulary
+
+A task SHALL carry two optional behaviours, `onTimeout` and `onReject`, each
+one value of the reserved outcome vocabulary (`skip`, `error`,
+`dead_letter`). Intake SHALL refuse a value outside the vocabulary by name,
+and SHALL refuse `onTimeout` on a task without an `expiresAt`. Both
+behaviours SHALL appear in the task's JSON serialization and in the
+task-form description.
+
+#### Scenario: an outcome outside the vocabulary is refused
+
+- **GIVEN** a task creation payload with `onTimeout: 'explode'`
+- **WHEN** the task is built
+- **THEN** the build is refused with a message naming the value and the vocabulary
+- @e2e exclude {intake validation is a service boundary; covered by unit tests}
+
+#### Scenario: a timeout behaviour with no deadline is refused
+
+- **GIVEN** a task creation payload with `onTimeout: 'error'` and no `expiresAt`
+- **WHEN** the task is built
+- **THEN** the build is refused naming both fields
+- @e2e exclude {intake validation is a service boundary; covered by unit tests}
+
+### Requirement: The timer sweep enforces a declared task expiry
+
+The existing sweep pass SHALL include a bounded, index-backed range scan of
+non-terminal tasks whose `expires_at` has passed and whose `on_timeout` is
+declared, and SHALL apply each hit's declared behaviour through the existing
+timer-outcome path. The scan SHALL be bounded by the pass's batch limit,
+SHALL report work performed and truncation, and a failure on one task SHALL
+NOT stop the pass. No second scheduler SHALL be introduced.
+
+#### Scenario: a task past its expiry is closed with its declared behaviour
+
+- **GIVEN** a non-terminal task with `expiresAt` in the past and `onTimeout: 'dead_letter'`
+- **WHEN** the sweep pass runs
+- **THEN** the task ends in state `disabled` with outcome `dead_letter`, audited with the sweep as actor
+- @e2e exclude {background sweep with a past deadline is not driveable from the UI; covered by unit tests}
+
+#### Scenario: a task without a declared behaviour is left alone
+
+- **GIVEN** a non-terminal task with `expiresAt` in the past and no `onTimeout`
+- **WHEN** the sweep pass runs
+- **THEN** the task is not selected and keeps its state
+- @e2e exclude {absence of background mutation is only observable in a unit test}
+
+### Requirement: A non-enforcing expiry timer falls back to the task's declared behaviour
+
+When an expiry timer fires for a task subject and the timer itself carries
+no enforcing outcome, the task's own declared `onTimeout` SHALL be applied.
+An enforcing timer's own `onExpiry` SHALL take precedence over the task's
+declared behaviour.
+
+#### Scenario: the task's behaviour applies when the timer cannot enforce
+
+- **GIVEN** a task declaring `onTimeout: 'error'` with a fired, non-enforcing expiry timer
+- **WHEN** the timer's outcome is applied
+- **THEN** the task ends in state `terminated` with outcome `failed`
+- @e2e exclude {timer firing is a background path; covered by unit tests}
+
+### Requirement: A rejecting completion honours the task's declared reject behaviour
+
+A rejecting completion of a task declaring `onReject: 'dead_letter'` SHALL
+record the dead-letter outcome through the same outcome mapping the timer
+path uses, preserving the mandatory comment and auditing the original
+rejecting outcome. Declared `onReject` values `error` and `skip` SHALL be
+stored and serialized without changing the completion itself.
+
+#### Scenario: a rejection routes to the dead letter state
+
+- **GIVEN** a task declaring `onReject: 'dead_letter'`
+- **WHEN** its assignee completes it with outcome `rejected` and a comment
+- **THEN** the task ends in state `disabled` with outcome `dead_letter`, and the audit names the original rejection
+- @e2e exclude {reject routing is a service-boundary rule; covered by unit tests}
+
+#### Scenario: a rejection without a declared behaviour stays a rejection
+
+- **GIVEN** a task with no declared `onReject`
+- **WHEN** its assignee completes it with outcome `rejected` and a comment
+- **THEN** the task ends in state `completed` with outcome `rejected`
+- @e2e exclude {existing behaviour retained; covered by unit tests}

--- a/openspec/changes/task-expiry-and-outcomes/tasks.md
+++ b/openspec/changes/task-expiry-and-outcomes/tasks.md
@@ -1,0 +1,39 @@
+# Tasks: task-expiry-and-outcomes
+
+## 1. Storage
+
+- [x] 1.1 Add `on_timeout` and `on_reject` columns plus the
+      `or_tasks_open_expiry (is_terminal, expires_at)` index to
+      `openregister_tasks` (new migration).
+- [x] 1.2 Add the fields to the `Task` entity (types, serialization).
+
+## 2. Intake
+
+- [x] 2.1 `TaskBuilder` accepts and validates `onTimeout`/`onReject`
+      against the reserved vocabulary; `onTimeout` without `expiresAt`
+      refused.
+
+## 3. Enforcement
+
+- [x] 3.1 `TaskMapper::findDueTimeouts()` — bounded, index-backed scan.
+- [x] 3.2 `FlowTimerSweep` third scan calling
+      `TaskService::applyTimerOutcome()` per hit, counted and truncation
+      reported.
+- [x] 3.3 `FlowTimerService::applyOutcome()` fallback to the task's
+      declared `onTimeout` for a non-enforcing expiry timer.
+
+## 4. Reject routing
+
+- [x] 4.1 `completeInternal()` routes a rejecting completion through the
+      timer-outcome mapping when the task declares `onReject:
+      dead_letter`.
+
+## 5. Surfaces
+
+- [x] 5.1 Task JSON and task-form description carry both behaviours.
+- [x] 5.2 User-task and portal-task nodes accept both config keys.
+
+## 6. Tests
+
+- [x] 6.1 TaskBuilder validation, sweep scan, timer fallback, reject
+      routing.

--- a/tests/Unit/BackgroundJob/FlowTimerWorkerTest.php
+++ b/tests/Unit/BackgroundJob/FlowTimerWorkerTest.php
@@ -70,16 +70,16 @@ class FlowTimerWorkerTest extends TestCase {
 		$this->appConfig->method('getValueString')->with('openregister', FlowTimerWorker::CONFIG_BATCH, '200')->willReturn('50');
 		$this->sweep->expects(self::once())->method('run')
 			->with(self::callback(static fn (DateTimeImmutable $now): bool => $now->format('Y-m-d H:i') === '2026-09-01 10:00'), 50)
-			->willReturn(['expiriesFired' => 3, 'rungsFired' => 2, 'truncated' => true, 'errors' => 0]);
+			->willReturn(['expiriesFired' => 3, 'rungsFired' => 2, 'taskTimeouts' => 1, 'truncated' => true, 'errors' => 0]);
 		$this->logger->expects(self::once())->method('info')
-			->with(self::stringContains('Fired 3 expiry timer(s) and 2 escalation rung(s); truncated: true'), self::anything());
+			->with(self::stringContains('Fired 3 expiry timer(s), 2 escalation rung(s) and 1 task timeout(s); truncated: true'), self::anything());
 		$this->tick();
 	}//end testRunsOnePassWithTheConfiguredBatchAndLogsWorkPerformed()
 
 	public function testAQuietPassLogsNothingAndABadBatchIsFlooredAtOne(): void {
 		$this->appConfig->method('getValueString')->willReturn('-5');
 		$this->sweep->expects(self::once())->method('run')->with(self::anything(), 1)
-			->willReturn(['expiriesFired' => 0, 'rungsFired' => 0, 'truncated' => false, 'errors' => 0]);
+			->willReturn(['expiriesFired' => 0, 'rungsFired' => 0, 'taskTimeouts' => 0, 'truncated' => false, 'errors' => 0]);
 		$this->logger->expects(self::never())->method('info');
 		$this->tick();
 	}//end testAQuietPassLogsNothingAndABadBatchIsFlooredAtOne()

--- a/tests/Unit/Db/TaskMapperQueriesTest.php
+++ b/tests/Unit/Db/TaskMapperQueriesTest.php
@@ -166,6 +166,28 @@ class TaskMapperQueriesTest extends TestCase {
 	}//end testInsertAndUpdateStampAndGuardTheEntityType()
 
 	/**
+	 * The sweep's task scan (task-expiry-and-outcomes D-3) selects only open
+	 * rows that DECLARE a timeout behaviour, orders by the deadline, and is
+	 * bounded by a floored batch limit.
+	 *
+	 * @return void
+	 */
+	public function testFindDueTimeoutsScansOpenDeclaredRowsBoundedAndOrdered(): void {
+		$mapper = new TaskMapper(db: $this->connectionWith(rows: [$this->row()]));
+		$due = $mapper->findDueTimeouts(now: new \DateTime('2026-09-02 10:00:00'), limit: 200);
+		$this->assertCount(1, $due);
+		$this->assertSame('t-7', $due[0]->getUuid());
+		$this->assertTrue($this->saw('expr.eq', 'is_terminal'));
+		$this->assertTrue($this->saw('expr.isNotNull', 'on_timeout'));
+		$this->assertTrue($this->saw('orderBy', 'expires_at'));
+		$this->assertTrue($this->saw('setMaxResults', 200));
+
+		// The batch limit is floored at one, never zero or negative.
+		(new TaskMapper(db: $this->connectionWith(rows: [])))->findDueTimeouts(now: new \DateTime('2026-09-02 10:00:00'), limit: -5);
+		$this->assertTrue($this->saw('setMaxResults', 1));
+	}//end testFindDueTimeoutsScansOpenDeclaredRowsBoundedAndOrdered()
+
+	/**
 	 * The propagation read selects by run uuid AND openness — the structural
 	 * half of "a standalone task survives everything".
 	 *

--- a/tests/Unit/Migration/Version1Date20260902090000Test.php
+++ b/tests/Unit/Migration/Version1Date20260902090000Test.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * The declared-behaviour migration: additive, guarded on existence, and a
+ * no-op re-run returns null instead of a schema.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Migration
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/task-expiry-and-outcomes/specs/task-expiry-and-outcomes/spec.md#requirement-a-task-declares-its-timeout-and-reject-behaviour-in-one-vocabulary
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Migration;
+
+use Doctrine\DBAL\Schema\Table;
+use OCA\OpenRegister\Migration\Version1Date20260902090000;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The migration.
+ *
+ * @covers \OCA\OpenRegister\Migration\Version1Date20260902090000
+ */
+class Version1Date20260902090000Test extends TestCase {
+
+	/**
+	 * A schema wrapper answering for the tasks table.
+	 *
+	 * @param Table&MockObject $table The table the wrapper serves.
+	 *
+	 * @return ISchemaWrapper&MockObject The wrapper.
+	 */
+	private function schemaWith(Table&MockObject $table): ISchemaWrapper&MockObject {
+		$schema = $this->createMock(ISchemaWrapper::class);
+		$schema->method('hasTable')->willReturnCallback(
+			static fn (string $name): bool => $name === 'openregister_tasks'
+		);
+		$schema->method('getTable')->willReturn($table);
+
+		return $schema;
+	}//end schemaWith()
+
+	/**
+	 * Run the step against a schema.
+	 *
+	 * @param ISchemaWrapper $schema The schema the closure yields.
+	 *
+	 * @return ISchemaWrapper|null What changeSchema() returned.
+	 */
+	private function apply(ISchemaWrapper $schema): ?ISchemaWrapper {
+		$step = new Version1Date20260902090000();
+
+		return $step->changeSchema(
+			output: $this->createMock(IOutput::class),
+			schemaClosure: static fn (): ISchemaWrapper => $schema,
+			options: []
+		);
+	}//end apply()
+
+	public function testAddsBothColumnsAndTheExpiryIndexWhenMissing(): void {
+		$table = $this->createMock(Table::class);
+		$table->method('hasColumn')->willReturn(false);
+		$table->method('hasIndex')->willReturn(false);
+
+		$added = [];
+		$table->expects($this->exactly(2))->method('addColumn')->willReturnCallback(
+			function (string $name, string $type, array $options) use (&$added): Table {
+				$added[] = [$name, $type, $options['notnull']];
+
+				return $this->createMock(Table::class);
+			}
+		);
+		$table->expects($this->once())->method('addIndex')->with(['is_terminal', 'expires_at'], 'or_tasks_open_expiry');
+
+		$schema = $this->schemaWith(table: $table);
+		self::assertSame($schema, $this->apply(schema: $schema));
+		self::assertSame([['on_timeout', 'string', false], ['on_reject', 'string', false]], $added);
+	}//end testAddsBothColumnsAndTheExpiryIndexWhenMissing()
+
+	public function testARerunAgainstAMigratedTableChangesNothingAndReturnsNull(): void {
+		$table = $this->createMock(Table::class);
+		$table->method('hasColumn')->willReturn(true);
+		$table->method('hasIndex')->willReturn(true);
+		$table->expects($this->never())->method('addColumn');
+		$table->expects($this->never())->method('addIndex');
+
+		self::assertNull($this->apply(schema: $this->schemaWith(table: $table)));
+	}//end testARerunAgainstAMigratedTableChangesNothingAndReturnsNull()
+
+	public function testAnAbsentTasksTableIsLeftAlone(): void {
+		$schema = $this->createMock(ISchemaWrapper::class);
+		$schema->method('hasTable')->willReturn(false);
+		$schema->expects($this->never())->method('getTable');
+
+		self::assertNull($this->apply(schema: $schema));
+	}//end testAnAbsentTasksTableIsLeftAlone()
+}//end class

--- a/tests/Unit/Service/Flow/Timer/FlowTimerServiceTest.php
+++ b/tests/Unit/Service/Flow/Timer/FlowTimerServiceTest.php
@@ -825,6 +825,47 @@ class FlowTimerServiceTest extends TestCase {
 		self::assertSame('2026-09-01 09:00', $timer->getAnchorAt()->format('Y-m-d H:i'));
 	}//end testAnAnchorlessTimerRunsFromNow()
 
+	public function testANonEnforcingExpiryFallsBackToTheTasksDeclaredTimeout(): void {
+		// A servicenorm expiry timer may not carry onExpiry (only wettelijk
+		// enforces), but the SUBJECT TASK declares its own onTimeout — the
+		// task's contract applies when the timer fires
+		// (task-expiry-and-outcomes D-4).
+		$task = $this->task();
+		$task->setOnTimeout('error');
+		$start = $this->at('2026-09-01 09:00');
+		$timer = $this->service->arm(
+			config: $this->config(['purpose' => 'expiry', 'legalEffect' => 'servicenorm', 'ladder' => null]),
+			actor: null,
+			now: $start
+		);
+
+		$applied = [];
+		$this->taskService->method('applyTimerOutcome')->willReturnCallback(
+			function (string $uuid, string $outcome, string $source, string $reason) use (&$applied): Task {
+				$applied[] = [$uuid, $outcome, $reason];
+
+				return $this->store->tasks[$uuid];
+			}
+		);
+
+		self::assertTrue($this->service->fireExpiry(timer: $timer, now: $start->modify('+57 days')));
+		self::assertSame([['task-1', 'error']], array_map(static fn (array $row): array => [$row[0], $row[1]], $applied));
+		self::assertStringContainsString('task-declared onTimeout', $applied[0][2]);
+	}//end testANonEnforcingExpiryFallsBackToTheTasksDeclaredTimeout()
+
+	public function testANonEnforcingExpiryWithNoDeclaredTimeoutAppliesNothing(): void {
+		$this->task();
+		$start = $this->at('2026-09-01 09:00');
+		$timer = $this->service->arm(
+			config: $this->config(['purpose' => 'expiry', 'legalEffect' => 'servicenorm', 'ladder' => null]),
+			actor: null,
+			now: $start
+		);
+
+		$this->taskService->expects(self::never())->method('applyTimerOutcome');
+		self::assertTrue($this->service->fireExpiry(timer: $timer, now: $start->modify('+57 days')));
+	}//end testANonEnforcingExpiryWithNoDeclaredTimeoutAppliesNothing()
+
 	public function testANonTaskSubjectEnforcesNothingAndEscalatesToRoles(): void {
 		// An enforcing timer on an OBJECT subject fires and records, but no
 		// task action is applied and the rung recipients stay role descriptors.

--- a/tests/Unit/Service/Flow/Timer/FlowTimerSweepTest.php
+++ b/tests/Unit/Service/Flow/Timer/FlowTimerSweepTest.php
@@ -26,9 +26,12 @@ use DateTime;
 use DateTimeImmutable;
 use OCA\OpenRegister\Db\FlowTimer;
 use OCA\OpenRegister\Db\FlowTimerMapper;
+use OCA\OpenRegister\Db\Task;
+use OCA\OpenRegister\Db\TaskMapper;
 use OCA\OpenRegister\Service\Flow\Timer\FlowTimerService;
 use OCA\OpenRegister\Service\Flow\Timer\FlowTimerSweep;
 use OCA\OpenRegister\Service\Flow\Timer\WorkingCalendarService;
+use OCA\OpenRegister\Service\Task\TaskService;
 use OCP\IDBConnection;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -39,6 +42,8 @@ use RuntimeException;
  * @covers \OCA\OpenRegister\Service\Flow\Timer\FlowTimerSweep
  * @covers \OCA\OpenRegister\Db\FlowTimer
  * @covers \OCA\OpenRegister\Db\FlowTimerMapper
+ *
+ * @uses \OCA\OpenRegister\Db\Task
  */
 class FlowTimerSweepTest extends TestCase {
 
@@ -88,7 +93,7 @@ class FlowTimerSweepTest extends TestCase {
 		$this->calendars->expects(self::once())->method('reset');
 
 		$result = $this->sweep->run(now: new DateTimeImmutable('2026-09-01 10:00:00'), batch: 200);
-		self::assertSame(['expiriesFired' => 1, 'rungsFired' => 0, 'truncated' => false, 'errors' => 0], $result);
+		self::assertSame(['expiriesFired' => 1, 'rungsFired' => 0, 'taskTimeouts' => 0, 'truncated' => false, 'errors' => 0], $result);
 	}//end testADueTimerBeyondTheBatchSizeIsStillReached()
 
 	public function testCountsReportWorkNotReadsAndTruncationIsVisible(): void {
@@ -114,7 +119,7 @@ class FlowTimerSweepTest extends TestCase {
 		$this->seed('s-1', 'expiry', '2026-08-30 00:00:00', '2026-08-30 00:00:00', FlowTimer::STATE_SUSPENDED);
 		$this->service->expects(self::never())->method('fireExpiry');
 		$this->service->expects(self::never())->method('fireRungs');
-		self::assertSame(['expiriesFired' => 0, 'rungsFired' => 0, 'truncated' => false, 'errors' => 0], $this->sweep->run(now: new DateTimeImmutable('2026-09-01'), batch: 10));
+		self::assertSame(['expiriesFired' => 0, 'rungsFired' => 0, 'taskTimeouts' => 0, 'truncated' => false, 'errors' => 0], $this->sweep->run(now: new DateTimeImmutable('2026-09-01'), batch: 10));
 	}//end testASuspendedTimerIsNeverSelected()
 
 	public function testOneFailureIsCountedAndDoesNotStopThePass(): void {
@@ -132,6 +137,69 @@ class FlowTimerSweepTest extends TestCase {
 		$this->logger->expects(self::exactly(2))->method('error');
 
 		$result = $this->sweep->run(now: new DateTimeImmutable('2026-09-01'), batch: 10);
-		self::assertSame(['expiriesFired' => 1, 'rungsFired' => 0, 'truncated' => false, 'errors' => 2], $result);
+		self::assertSame(['expiriesFired' => 1, 'rungsFired' => 0, 'taskTimeouts' => 0, 'truncated' => false, 'errors' => 2], $result);
 	}//end testOneFailureIsCountedAndDoesNotStopThePass()
+
+	/**
+	 * A sweep wired with the task scan closes each due task through the
+	 * timer-outcome path with the TASK's declared behaviour, counts the work,
+	 * reports truncation when the scan hits the batch limit, and one failure
+	 * does not stop the pass (task-expiry-and-outcomes D-3).
+	 */
+	public function testDueTaskTimeoutsAreAppliedCountedAndErrorTolerant(): void {
+		$due = [];
+		foreach ([['t-1', 'error'], ['t-2', 'dead_letter'], ['t-3', 'skip']] as [$uuid, $behaviour]) {
+			$task = new Task();
+			$task->setUuid($uuid);
+			$task->setOnTimeout($behaviour);
+			$task->setExpiresAt(new DateTime('2026-08-30 00:00:00'));
+			$due[] = $task;
+		}
+
+		$tasks = $this->createMock(TaskMapper::class);
+		$tasks->expects(self::once())->method('findDueTimeouts')->willReturn($due);
+		$taskService = $this->createMock(TaskService::class);
+		$applied = [];
+		$taskService->method('applyTimerOutcome')->willReturnCallback(
+			static function (string $uuid, string $outcome, string $source, string $reason) use (&$applied): Task {
+				if ($uuid === 't-2') {
+					throw new RuntimeException('row is poisoned');
+				}
+
+				$applied[$uuid] = [$outcome, $source, $reason];
+
+				return new Task();
+			}
+		);
+		$this->logger->expects(self::once())->method('error');
+
+		$sweep = new FlowTimerSweep(
+			timers: $this->mapper,
+			service: $this->service,
+			calendars: $this->calendars,
+			logger: $this->logger,
+			tasks: $tasks,
+			taskService: $taskService
+		);
+		$result = $sweep->run(now: new DateTimeImmutable('2026-09-01 10:00:00'), batch: 3);
+
+		self::assertSame(2, $result['taskTimeouts']);
+		self::assertSame(1, $result['errors']);
+		self::assertTrue($result['truncated'], 'the task scan hit the batch limit');
+		self::assertSame(['error', FlowTimerSweep::TIMEOUT_SOURCE], [$applied['t-1'][0], $applied['t-1'][1]]);
+		self::assertSame('skip', $applied['t-3'][0]);
+		self::assertStringContainsString('2026-08-30', $applied['t-1'][2], 'the reason names the deadline that passed');
+	}//end testDueTaskTimeoutsAreAppliedCountedAndErrorTolerant()
+
+	/**
+	 * A sweep constructed WITHOUT the task scan (the pre-change positional
+	 * shape) keeps running the two timer scans and reports zero task work.
+	 */
+	public function testASweepWithoutTheTaskScanStillSweepsTimers(): void {
+		$this->seed('exp-1', 'expiry', '2026-08-30 00:00:00');
+		$this->service->method('fireExpiry')->willReturn(true);
+
+		$result = $this->sweep->run(now: new DateTimeImmutable('2026-09-01'), batch: 10);
+		self::assertSame(['expiriesFired' => 1, 'rungsFired' => 0, 'taskTimeouts' => 0, 'truncated' => false, 'errors' => 0], $result);
+	}//end testASweepWithoutTheTaskScanStillSweepsTimers()
 }//end class

--- a/tests/Unit/Service/Task/TaskServiceTest.php
+++ b/tests/Unit/Service/Task/TaskServiceTest.php
@@ -1126,4 +1126,121 @@ class TaskServiceTest extends TestCase {
 		$this->assertSame(3, $created->getTemplateVersion());
 		$this->assertSame(['checklist' => [['id' => 'c1', 'label' => 'Vast']]], $created->getTemplateSnapshot());
 	}//end testTheTemplateIsFrozenAtCreation()
+
+	/**
+	 * A REJECTION OF A TASK DECLARING onReject dead_letter LANDS IN THE
+	 * DEAD LETTER STATE, through the same mapping the timer path resolves,
+	 * with the comment kept and the audit naming the original rejection
+	 * (task-expiry-and-outcomes D-5).
+	 *
+	 * @return void
+	 */
+	public function testARejectionRoutesToTheDeadLetterStateWhenDeclared(): void {
+		$task = $this->openTask();
+		$task->setOnReject('dead_letter');
+		$this->tasks->method('findByUuid')->willReturn($task);
+		$audited = [];
+		$this->setUpAuditRecorder(audited: $audited);
+
+		$completed = $this->service()->complete(uuid: 't-7', outcome: 'rejected', resultText: null, comment: 'niet akkoord', actor: 'alice');
+
+		$this->assertSame(Task::STATE_DISABLED, $completed->getState());
+		$this->assertSame('dead_letter', $completed->getOutcome());
+		$this->assertTrue($completed->getIsTerminal());
+		$this->assertSame('niet akkoord', $completed->getComment());
+		$this->assertStringContainsString("'rejected'", (string)$audited[0]->getReason());
+	}//end testARejectionRoutesToTheDeadLetterStateWhenDeclared()
+
+	/**
+	 * WITHOUT A DECLARED BEHAVIOUR a rejection stays a plain rejection, and
+	 * a declared `error`/`skip` changes nothing about the completion either:
+	 * those two are the resuming consumer's contract, not the record's.
+	 *
+	 * @return void
+	 */
+	public function testARejectionWithoutDeadLetterStaysARejection(): void {
+		foreach ([null, 'error', 'skip'] as $declared) {
+			$this->setUp();
+			$task = $this->openTask();
+			$task->setOnReject($declared);
+			$this->tasks->method('findByUuid')->willReturn($task);
+
+			$completed = $this->service()->complete(uuid: 't-7', outcome: 'rejected', resultText: null, comment: 'nee', actor: 'alice');
+
+			$this->assertSame(Task::STATE_COMPLETED, $completed->getState(), var_export($declared, true));
+			$this->assertSame('rejected', $completed->getOutcome(), var_export($declared, true));
+		}
+	}//end testARejectionWithoutDeadLetterStaysARejection()
+
+	/**
+	 * AN APPROVING COMPLETION IGNORES onReject ENTIRELY: the behaviour is a
+	 * reject behaviour, not a completion behaviour.
+	 *
+	 * @return void
+	 */
+	public function testAnApprovalIgnoresTheDeclaredRejectBehaviour(): void {
+		$task = $this->openTask();
+		$task->setOnReject('dead_letter');
+		$this->tasks->method('findByUuid')->willReturn($task);
+
+		$completed = $this->service()->complete(uuid: 't-7', outcome: 'approved', resultText: null, comment: null, actor: 'alice');
+
+		$this->assertSame(Task::STATE_COMPLETED, $completed->getState());
+		$this->assertSame('approved', $completed->getOutcome());
+	}//end testAnApprovalIgnoresTheDeclaredRejectBehaviour()
+
+	/**
+	 * INTAKE REFUSES a behaviour outside the vocabulary by name, and a
+	 * timeout behaviour with no deadline (task-expiry-and-outcomes D-6);
+	 * valid declarations are carried onto the row.
+	 *
+	 * @return void
+	 */
+	public function testDeclaredBehavioursAreValidatedAtIntake(): void {
+		$builder = new TaskBuilder();
+
+		try {
+			$builder->fromData(data: ['onTimeout' => 'explode', 'expiresAt' => '2027-01-01T00:00:00+00:00'], actor: 'rita');
+			$this->fail('An unknown behaviour must be refused.');
+		} catch (TaskValidationException $refusal) {
+			$this->assertStringContainsString("'explode'", $refusal->getMessage());
+			$this->assertStringContainsString('dead_letter', $refusal->getMessage());
+		}
+
+		try {
+			$builder->fromData(data: ['onTimeout' => 'error'], actor: 'rita');
+			$this->fail('A timeout behaviour without a deadline must be refused.');
+		} catch (TaskValidationException $refusal) {
+			$this->assertStringContainsString('expiresAt', $refusal->getMessage());
+		}
+
+		$task = $builder->fromData(
+			data: ['expiresAt' => '2027-01-01T00:00:00+00:00', 'onTimeout' => 'dead_letter', 'onReject' => 'error'],
+			actor: 'rita'
+		);
+		$this->assertSame('dead_letter', $task->getOnTimeout());
+		$this->assertSame('error', $task->getOnReject());
+
+		$rejectOnly = $builder->fromData(data: ['onReject' => 'dead_letter'], actor: 'rita');
+		$this->assertSame('dead_letter', $rejectOnly->getOnReject());
+		$this->assertNull($rejectOnly->getOnTimeout());
+	}//end testDeclaredBehavioursAreValidatedAtIntake()
+
+	/**
+	 * Re-route audit inserts into a local recorder for one test.
+	 *
+	 * @param array<int, TaskAudit> $audited Filled with the audit rows, by reference.
+	 *
+	 * @return void
+	 */
+	private function setUpAuditRecorder(array &$audited): void {
+		$this->audits = $this->createMock(TaskAuditMapper::class);
+		$this->audits->method('insert')->willReturnCallback(
+			static function (TaskAudit $entry) use (&$audited): TaskAudit {
+				$audited[] = $entry;
+
+				return $entry;
+			}
+		);
+	}//end setUpAuditRecorder()
 }//end class


### PR DESCRIPTION
## What

Wave 2 of the fleet task consolidation: the expiry and outcome semantics integriq's app-local HITL implementation had, moved into the shared task service (openspec change `task-expiry-and-outcomes`).

- `openregister_tasks` gains `on_timeout` and `on_reject` (nullable, reserved vocabulary `skip|error|dead_letter`) plus the `or_tasks_open_expiry (is_terminal, expires_at)` index (migration `Version1Date20260902090000`).
- `TaskBuilder` validates both at intake; `onTimeout` without `expiresAt` is refused by name.
- `FlowTimerSweep` gains a third bounded range scan: non-terminal tasks past `expires_at` that declare `on_timeout` are closed through the existing `TaskService::applyTimerOutcome()`. Same `FlowTimerWorker`, same pass, no second scheduler.
- A fired non-enforcing expiry timer falls back to the subject task's declared `onTimeout` (an enforcing `wettelijk` timer's own `onExpiry` still wins), because `project()` nulls `expires_at` after the last expiry timer fires and would starve the scan.
- A rejecting completion of a task declaring `onReject: dead_letter` records the dead-letter outcome through the same mapping the timer path uses; `error`/`skip` are stored for the resuming consumer and change nothing.
- Both behaviours are serialized on the task, in the task-form description, and accepted by the user-task and portal-task nodes next to `expiresAt`.

## Why

A task's `expires_at` claims to be the ENFORCING deadline but nothing enforced it without a wettelijk timer. integriq (and the next adopters) need timeout/reject behaviour to delegate onto; without it every app keeps its own sweep.

## Verification

- Full local unit suite: 0 failures (the 6 pre-existing DBAL-stub errors in Sources/Dbal tests are environment-only).
- phpcs, phpmd (per subdir), phpstan, psalm: clean.
- hydra gates `--scope-to-diff`: all applicable gates green.

Companion PR follows in ConductionNL/integriq (adoption seam).