### PR TITLE
A federated create may not address an existing object, and the organisation pin did not hold

### DIFF
--- a/lib/Controller/DsarCaseController.php
+++ b/lib/Controller/DsarCaseController.php
@@ -117,8 +117,19 @@ class DsarCaseController extends Controller {
 		}
 
 		$body = (array)$this->request->getParams();
-		// Strip framework-injected keys so only the case payload is saved.
-		unset($body['_route']);
+		// Strip framework-injected keys so only the case payload is saved, and
+		// the caller's IDENTITY with them. `saveObject()` resolves its target
+		// from the payload (`@self.id` first, then `id`) and the write is
+		// PUT-semantic, so a create carrying either would overwrite an existing
+		// case and null every field it omitted. This endpoint creates.
+		unset($body['_route'], $body['id'], $body['uuid']);
+		$self = (array)($body['@self'] ?? []);
+		unset($self['id'], $self['uuid']);
+		if ($self !== []) {
+			$body['@self'] = $self;
+		} else {
+			unset($body['@self']);
+		}
 
 		try {
 			$saved = $this->objectService->saveObject(

--- a/lib/Controller/DsarCaseController.php
+++ b/lib/Controller/DsarCaseController.php
@@ -122,13 +122,11 @@ class DsarCaseController extends Controller {
 		// from the payload (`@self.id` first, then `id`) and the write is
 		// PUT-semantic, so a create carrying either would overwrite an existing
 		// case and null every field it omitted. This endpoint creates.
-		unset($body['_route'], $body['id'], $body['uuid']);
 		$self = (array)($body['@self'] ?? []);
 		unset($self['id'], $self['uuid']);
+		unset($body['_route'], $body['id'], $body['uuid'], $body['@self']);
 		if ($self !== []) {
 			$body['@self'] = $self;
-		} else {
-			unset($body['@self']);
 		}
 
 		try {

--- a/lib/Controller/FederationController.php
+++ b/lib/Controller/FederationController.php
@@ -332,9 +332,37 @@ class FederationController extends Controller {
 
 		$data = (array)$this->request->getParams();
 		unset($data['shareToken'], $data['_route']);
+
+		// 🔴 STRIP THE CALLER'S IDENTITY. This endpoint CREATES.
+		//
+		// `saveObject()` resolves its target from the payload:
+		// `extractUuidAndNormalizeObject()` reads `@self.id` first, then `id`,
+		// and treats a match as the uuid to UPDATE — PUT-semantically, so every
+		// field the payload omits is NULLED.
+		//
+		// This path is `#[PublicPage]` and runs `_rbac: false`, so nothing
+		// downstream would have refused it. A share grants the holder the right
+		// to ADD objects; without this it also granted the right to overwrite
+		// every existing object in the shared register/schema.
+		//
+		// The organisation pin below was already guarding the sibling half of
+		// this — "a federated writer can never plant an object into another
+		// organisation" — but `+` preserves the LEFT operand's keys, so a
+		// caller-supplied `@self: {id: …}` survived the merge untouched.
+		unset($data['id'], $data['uuid']);
+		$self = (array)($data['@self'] ?? []);
+		unset($self['id'], $self['uuid']);
+
 		// Pin the object to the sharing organisation — a federated writer can
 		// never plant an object into another organisation.
-		$data['@self'] = (($data['@self'] ?? []) + ['organisation' => $share->getOrganisation()]);
+		//
+		// ASSIGNED, not merged. This was `$self + ['organisation' => …]`, and
+		// `+` keeps the LEFT operand's keys: a caller who supplied
+		// `@self: {organisation: 'somebody-else'}` kept it, so the pin this
+		// comment describes did not hold. The same `+` is what let a supplied
+		// `@self.id` through. A pin has to overwrite, or it is a default.
+		$self['organisation'] = $share->getOrganisation();
+		$data['@self'] = $self;
 
 		try {
 			$saved = $this->objectService->saveObject(

--- a/lib/Controller/FederationController.php
+++ b/lib/Controller/FederationController.php
@@ -319,6 +319,8 @@ class FederationController extends Controller {
 	 * @param string $shareToken The scoped bearer share token.
 	 *
 	 * @return JSONResponse The created object, or an error.
+	 *
+	 * @spec openspec/changes/federation-scope-enforcement/specs/federation-scope-enforcement/spec.md
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]

--- a/tests/Unit/Controller/FederationControllerCreateIdentityTest.php
+++ b/tests/Unit/Controller/FederationControllerCreateIdentityTest.php
@@ -1,0 +1,191 @@
+<?php
+
+/**
+ * FederationController::createObject() identity tests.
+ *
+ * A federated share grants its holder the right to ADD objects to the shared
+ * register/schema. This pins that it grants nothing more.
+ *
+ * The path is `#[PublicPage]`, `#[NoCSRFRequired]` and calls `saveObject()`
+ * with `_rbac: false` and `_multitenancy: false`, so nothing downstream will
+ * refuse a write it lets through. `saveObject()` resolves its target FROM the
+ * payload — `extractUuidAndNormalizeObject()` reads `@self.id` first, then
+ * `id` — and the write is PUT-semantic, so every field the payload omits is
+ * NULLED rather than left alone.
+ *
+ * The organisation pin already guarded the sibling half of this ("a federated
+ * writer can never plant an object into another organisation"), but it merged
+ * with `+`, which preserves the LEFT operand's keys, so a caller-supplied
+ * `@self: {id: …}` survived it untouched.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Controller;
+
+use OCA\OpenRegister\Controller\FederationController;
+use OCA\OpenRegister\Db\FederatedShare;
+use OCA\OpenRegister\Db\FederatedShareMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\FederationShareService;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\Security\Bruteforce\IThrottler;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * A federated create may not address an existing object.
+ */
+class FederationControllerCreateIdentityTest extends TestCase {
+	/**
+	 * The share mapper.
+	 *
+	 * @var FederatedShareMapper&MockObject
+	 */
+	private $shareMapper;
+
+	/**
+	 * The object service.
+	 *
+	 * @var ObjectService&MockObject
+	 */
+	private $objectService;
+
+	/**
+	 * The payload the controller handed to saveObject.
+	 *
+	 * @var array<string, mixed>|null
+	 */
+	private ?array $written = null;
+
+	/**
+	 * Build the controller over a request carrying the given body.
+	 *
+	 * @param array<string, mixed> $params The request parameters.
+	 *
+	 * @return FederationController The controller.
+	 */
+	private function controller(array $params): FederationController {
+		$share = new FederatedShare();
+		$share->setDirection('outgoing');
+		$share->setStatus('accepted');
+		$share->setScope('collection');
+		$share->setRegister('zaken');
+		$share->setSchema('zaak');
+		$share->setOrganisation('org-a');
+		$share->setPermissions('read-write');
+
+		$this->shareMapper = $this->createMock(FederatedShareMapper::class);
+		$this->shareMapper->method('findByToken')->willReturn($share);
+
+		$request = $this->createMock(IRequest::class);
+		$request->method('getParams')->willReturn($params);
+
+		$this->objectService = $this->createMock(ObjectService::class);
+		$this->objectService->method('saveObject')->willReturnCallback(
+			function (...$args) {
+				// saveObject is called with named arguments; the object is the
+				// first, however PHPUnit hands it back.
+				$this->written = (array)($args[0] ?? []);
+				return $this->createMock(ObjectEntity::class);
+			}
+		);
+
+		return new FederationController(
+			'openregister',
+			$request,
+			$this->shareMapper,
+			$this->objectService,
+			$this->createMock(FederationShareService::class),
+			$this->createMock(IThrottler::class),
+			$this->createMock(LoggerInterface::class)
+		);
+	}//end controller()
+
+	/**
+	 * 🔴 A caller-supplied `@self.id` must not reach the write.
+	 *
+	 * It is the key `saveObject()` reads FIRST, and this path disables RBAC, so
+	 * nothing downstream would have refused the resulting update.
+	 *
+	 * @return void
+	 */
+	public function testASuppliedSelfIdDoesNotReachTheWrite(): void {
+		$controller = $this->controller(
+			[
+				'title' => 'Federated addition',
+				'@self' => ['id' => 'someone-elses-object'],
+			]
+		);
+
+		$response = $controller->createObject(shareToken: 'tok');
+
+		$this->assertInstanceOf(JSONResponse::class, $response);
+		$this->assertIsArray($this->written, 'the write must have happened');
+		$this->assertArrayNotHasKey('id', $this->written['@self'] ?? []);
+		$this->assertArrayNotHasKey('uuid', $this->written['@self'] ?? []);
+	}//end testASuppliedSelfIdDoesNotReachTheWrite()
+
+	/**
+	 * A top-level `id` or `uuid` must not reach the write either.
+	 *
+	 * `@self.id` is read first, but `id` is the fallback, so stripping only the
+	 * nested one would leave the same hole one key over.
+	 *
+	 * @return void
+	 */
+	public function testASuppliedTopLevelIdDoesNotReachTheWrite(): void {
+		$controller = $this->controller(
+			[
+				'title' => 'Federated addition',
+				'id' => 'someone-elses-object',
+				'uuid' => 'someone-elses-object',
+			]
+		);
+
+		$controller->createObject(shareToken: 'tok');
+
+		$this->assertIsArray($this->written);
+		$this->assertArrayNotHasKey('id', $this->written);
+		$this->assertArrayNotHasKey('uuid', $this->written);
+	}//end testASuppliedTopLevelIdDoesNotReachTheWrite()
+
+	/**
+	 * The organisation pin still holds, and the payload still arrives.
+	 *
+	 * The guard must not have traded one defect for another: stripping too much
+	 * would break federated writes outright, and dropping the pin would let a
+	 * writer plant an object into another organisation.
+	 *
+	 * @return void
+	 */
+	public function testTheOrganisationPinAndThePayloadSurvive(): void {
+		$controller = $this->controller(
+			[
+				'title' => 'Federated addition',
+				'@self' => ['id' => 'someone-elses-object', 'organisation' => 'org-attacker'],
+			]
+		);
+
+		$controller->createObject(shareToken: 'tok');
+
+		$this->assertIsArray($this->written);
+		$this->assertSame('org-a', $this->written['@self']['organisation'] ?? null);
+		$this->assertSame('Federated addition', $this->written['title'] ?? null);
+	}//end testTheOrganisationPinAndThePayloadSurvive()
+}//end class


### PR DESCRIPTION
Found sweeping a defect class out of dossiq (ConductionNL/dossiq#1687, #1690). **Two holes in one line, and the second is the one that line was written to prevent.**

## The line

`FederationController::createObject()` is `#[PublicPage]`, `#[NoCSRFRequired]`, and calls `saveObject()` with `_rbac: false` and `_multitenancy: false` — so nothing downstream refuses what it lets through.

```php
$data['@self'] = (($data['@self'] ?? []) + ['organisation' => $share->getOrganisation()]);
```

PHP's `+` keeps the **left** operand's keys. For a caller holding a writable share token:

**1. `@self.id` survived.** `saveObject()` resolves its target from the payload — `extractUuidAndNormalizeObject()` reads `@self.id` first, then `id` — and the write is PUT-semantic, so omitted fields are **nulled**. A share granting the right to *add* objects also granted the right to overwrite every existing object in the shared register/schema.

**2. `@self.organisation` survived too**, which defeats the pin. The comment on that very line reads:

> Pin the object to the sharing organisation — a federated writer can never plant an object into another organisation.

It could.

The second was found *by the first test written for the first*. A pin has to overwrite, or it is only a default.

## Also fixed

`DsarCaseController::create()` — guarded by `requireAuthenticated()` rather than an admin setting, and stripped only `_route`, so a create could address an existing DSAR case.

## Evidence

Three new tests, each failing against the original code and passing against the fix. The third asserts the pin **and** that the payload still arrives, so the guard cannot have traded one defect for another by over-stripping.

Full suite: **19037 tests**, phpcs clean.

## Not claimed

End-to-end exploitability. Both paths need a valid `read-write` share token, and I did not drive this against a live federated pair. The code path and the `+` semantics are demonstrated; the operational reachability is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)