### PR TITLE
feat(files): a publication window on the file, so an attachment needs no object

### DIFF
--- a/lib/Db/File.php
+++ b/lib/Db/File.php
@@ -23,6 +23,24 @@
  * @link https://OpenRegister.app
  *
  * @spec openspec/changes/file-actions/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use DateTime;
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * File entity for the `openregister_files` table.
+ *
+ * The `@method` tags below belong on the CLASS, not on the file docblock they
+ * used to sit in. A static analyser resolves magic accessors from the class it
+ * is analysing; a docblock above `declare(strict_types=1)` documents the file
+ * and is invisible to it. That is why phpstan.neon carried counted ignore
+ * entries for `File::setUpdated()` and friends, and why adding one accessor
+ * made an unrelated ignore count wrong.
  *
  * @method int|null getFileId()
  * @method void setFileId(int $fileId)
@@ -44,16 +62,10 @@
  * @method void setCreated(\DateTime $created)
  * @method \DateTime|null getUpdated()
  * @method void setUpdated(?\DateTime $updated)
- */
-
-declare(strict_types=1);
-
-namespace OCA\OpenRegister\Db;
-
-use OCP\AppFramework\Db\Entity;
-
-/**
- * File entity for the `openregister_files` table.
+ * @method \DateTime|null getPublished()
+ * @method void setPublished(?\DateTime $published)
+ * @method \DateTime|null getDepublished()
+ * @method void setDepublished(?\DateTime $depublished)
  */
 class File extends Entity {
 
@@ -128,6 +140,29 @@ class File extends Entity {
 	protected ?\DateTime $updated = null;
 
 	/**
+	 * When this file becomes public.
+	 *
+	 * Null means it has never been published, which is why the key is nullable
+	 * rather than defaulting to the creation time. A file that exists is not a
+	 * file that was published, and reporting the creation time as a publication
+	 * date is what this column exists to stop.
+	 *
+	 * @var \DateTime|null
+	 */
+	protected ?\DateTime $published = null;
+
+	/**
+	 * When this file stops being public.
+	 *
+	 * Null means no end date, not "already ended". The distinction matters: a
+	 * published attachment with no depublication date stays public, which is the
+	 * ordinary case.
+	 *
+	 * @var \DateTime|null
+	 */
+	protected ?\DateTime $depublished = null;
+
+	/**
 	 * Configure typed columns for the file metadata row.
 	 *
 	 * @return void
@@ -143,6 +178,8 @@ class File extends Entity {
 		$this->addType(fieldName: 'downloadCount', type: 'integer');
 		$this->addType(fieldName: 'created', type: 'datetime');
 		$this->addType(fieldName: 'updated', type: 'datetime');
+		$this->addType(fieldName: 'published', type: 'datetime');
+		$this->addType(fieldName: 'depublished', type: 'datetime');
 
 	}//end __construct()
 
@@ -165,6 +202,51 @@ class File extends Entity {
 			'downloadCount' => $this->downloadCount,
 			'created' => $this->created?->format('c'),
 			'updated' => $this->updated?->format('c'),
+			'published' => $this->published?->format('c'),
+			'depublished' => $this->depublished?->format('c'),
+			'isPublished' => $this->isPublishedAt(),
 		];
 	}//end jsonSerialize()
+
+	/**
+	 * Whether this file is public at a given moment.
+	 *
+	 * The rule reads as three separate questions rather than one expression,
+	 * because each null means something different:
+	 *
+	 * - No `published` at all means never published. This is NOT the same as
+	 *   published long ago, and defaulting it to the creation time would make
+	 *   every file that has ever existed look published.
+	 * - A `published` in the future means not yet, which is the whole point of
+	 *   being able to set one.
+	 * - No `depublished` means no end date, not an end date in the past.
+	 *
+	 * The boundaries are inclusive at the start and exclusive at the end, so a
+	 * file published and depublished at the same instant is not public.
+	 *
+	 * @param DateTime|null $now The moment to evaluate, defaulting to this one.
+	 *
+	 * @return bool True when the file is public at that moment.
+	 *
+	 * @spec openspec/changes/file-publication-window/specs/file-publication-window/spec.md#requirement-a-file-carries-its-own-publication-window-req-fpw-101
+	 */
+	public function isPublishedAt(?DateTime $now = null): bool {
+		if ($this->published === null) {
+			return false;
+		}
+
+		if ($now === null) {
+			$now = new DateTime();
+		}
+
+		if ($this->published > $now) {
+			return false;
+		}
+
+		if ($this->depublished === null) {
+			return true;
+		}
+
+		return ($this->depublished > $now);
+	}//end isPublishedAt()
 }//end class

--- a/lib/Db/FileMapper.php
+++ b/lib/Db/FileMapper.php
@@ -42,7 +42,13 @@ use OCP\IURLGenerator;
  * @version   GIT: <git-id>
  * @link      https://OpenRegister.app
  *
- * @phpstan-type File array{
+ * The alias below describes a filecache ROW, not the {@see File} entity. It was
+ * named `File`, which shadowed that entity in every docblock in this file: a
+ * mapper method annotated `@return File` read as an array shape, which is why
+ * the phpstan baseline carried an entry for each one. Renamed rather than
+ * baselined.
+ *
+ * @phpstan-type FilecacheRow array{
  *   fileid: int,
  *   storage: int,
  *   path: string,
@@ -68,17 +74,7 @@ use OCP\IURLGenerator;
  *   published: string|null
  * }
  *
- * @method \OCP\AppFramework\Db\Entity insert(\OCP\AppFramework\Db\Entity $entity)
- * @method \OCP\AppFramework\Db\Entity update(\OCP\AppFramework\Db\Entity $entity)
- * @method \OCP\AppFramework\Db\Entity insertOrUpdate(\OCP\AppFramework\Db\Entity $entity)
- * @method \OCP\AppFramework\Db\Entity delete(\OCP\AppFramework\Db\Entity $entity)
- * @method \OCP\AppFramework\Db\Entity find(int|string $id)
- * @method \OCP\AppFramework\Db\Entity findEntity(IQueryBuilder $query)
- * @method File[] findAll(int|null $limit=null, int|null $offset=null)
- * @method File[] findEntities(IQueryBuilder $query)
- * @psalm-suppress LessSpecificImplementedReturnType - File[] is more specific than list<Entity>
- *
- * @template-extends QBMapper<Entity>
+ * @template-extends QBMapper<File>
  *
  * @SuppressWarnings(PHPMD.ExcessiveClassLength)
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
@@ -204,6 +200,34 @@ class FileMapper extends QBMapper {
 	}//end setLabelsForFile()
 
 	/**
+	 * Set the publication window for a Nextcloud file.
+	 *
+	 * Both bounds are set together because they are one fact. Setting them
+	 * separately invites the state where a depublication date precedes the
+	 * publication date it belongs to, which reads as "published" to a careless
+	 * comparison and as nothing at all to a careful one.
+	 *
+	 * @param int            $fileId      The Nextcloud filecache fileid.
+	 * @param \DateTime|null $published   When the file becomes public, or null for never.
+	 * @param \DateTime|null $depublished When it stops, or null for no end date.
+	 *
+	 * @return File The updated entity.
+	 *
+	 * @spec openspec/changes/file-publication-window/specs/file-publication-window/spec.md#requirement-a-file-carries-its-own-publication-window-req-fpw-101
+	 */
+	public function setPublicationWindowForFile(
+		int $fileId,
+		?\DateTime $published,
+		?\DateTime $depublished
+	): File {
+		$file = $this->findOrCreateByFileId(fileId: $fileId);
+		$file->setPublished($published);
+		$file->setDepublished($depublished);
+		$file->setUpdated(new DateTime());
+		return $this->update(entity: $file);
+	}//end setPublicationWindowForFile()
+
+	/**
 	 * Increment the cached download count for a Nextcloud file.
 	 * Idempotent: creates the row on first download.
 	 *
@@ -289,7 +313,7 @@ class FileMapper extends QBMapper {
 	 *
 	 * @phpstan-param  int|null $node
 	 * @phpstan-param  array<int>|null $ids
-	 * @phpstan-return list<File>
+	 * @phpstan-return list<FilecacheRow>
 	 */
 	public function getFiles(?int $node = null, ?array $ids = null): array {
 		// Create a new query builder instance.
@@ -392,7 +416,7 @@ class FileMapper extends QBMapper {
 	 * @return array|null The file as an associative array with share information and owner data, or null if not found
 	 *
 	 * @phpstan-param  int $fileId
-	 * @phpstan-return File|null
+	 * @phpstan-return FilecacheRow|null
 	 */
 	public function getFile(int $fileId): ?array {
 		// Create a new query builder instance.
@@ -488,7 +512,7 @@ class FileMapper extends QBMapper {
 	 *         numeric string, which PHP coerces to an int array key.
 	 *
 	 * @phpstan-param  array<int, int|string> $fileIds
-	 * @phpstan-return array<int|string, File>
+	 * @phpstan-return array<int|string, FilecacheRow>
 	 */
 	public function getFilesByIds(array $fileIds): array {
 		// Normalise to unique positive integers; ignore non-numeric entries.
@@ -526,7 +550,7 @@ class FileMapper extends QBMapper {
 	 * @throws \RuntimeException If more than one node is found for the object's uuid
 	 *
 	 * @phpstan-param  ObjectEntity $object
-	 * @phpstan-return list<File>
+	 * @phpstan-return list<FilecacheRow>
 	 */
 	public function getFilesForObject(ObjectEntity $object): array {
 		// Retrieve the folder property from the object entity.
@@ -802,8 +826,11 @@ class FileMapper extends QBMapper {
 	 * @param string $sharedBy The user who is sharing the file
 	 * @param string $shareOwner The owner of the file
 	 * @param int $permissions The permissions for the share (default: 1 = read)
+	 * @param \DateTime|null $depublished When the share stops working, or null for no end date
 	 *
 	 * @return (int|string)[]
+	 *
+	 * @spec openspec/changes/file-publication-window/specs/file-publication-window/spec.md#requirement-a-depublication-date-expires-the-public-share-req-fpw-102
 	 *
 	 * @throws \Exception If the share creation fails
 	 *
@@ -816,7 +843,13 @@ class FileMapper extends QBMapper {
 	 *
 	 * @psalm-return array{id: int, token: string, accessUrl: string, downloadUrl: string, published: string}
 	 */
-	public function publishFile(int $fileId, string $sharedBy, string $shareOwner, int $permissions = 1): array {
+	public function publishFile(
+		int $fileId,
+		string $sharedBy,
+		string $shareOwner,
+		int $permissions = 1,
+		?\DateTime $depublished = null
+	): array {
 		// Check if a public share already exists for this file.
 		$existingShare = $this->getPublicShare(fileId: $fileId);
 		if ($existingShare !== null) {
@@ -854,7 +887,14 @@ class FileMapper extends QBMapper {
 					'permissions' => $qb->createNamedParameter($permissions, IQueryBuilder::PARAM_INT),
 					'stime' => $qb->createNamedParameter($currentTime, IQueryBuilder::PARAM_INT),
 					'accepted' => $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT),
-					'expiration' => $qb->createNamedParameter(null),
+					// The share carries the end of the window, so Nextcloud stops
+					// serving the link on the date with nothing having to run.
+					// An OR-side flag alone would leave a public URL that still
+					// works, which is not a depublication.
+					'expiration' => $qb->createNamedParameter(
+						$depublished?->format('Y-m-d H:i:s'),
+						IQueryBuilder::PARAM_STR
+					),
 					'token' => $qb->createNamedParameter($token),
 					'mail_send' => $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT),
 					'hide_download' => $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT),

--- a/lib/Migration/Version1Date20260903090000.php
+++ b/lib/Migration/Version1Date20260903090000.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * A publication window on the file metadata row.
+ *
+ * Several apps grew their own `document` object purely to hold a publication
+ * window over an attached file. Everything else such an object carried is
+ * already on the file or on the object it hangs from: the filename and mime
+ * type are the file, `description` / `category` / `labels` are the OR-side
+ * metadata row, the owning publication is the folder the file lives in, and the
+ * file's text is already extracted into `openregister_chunks` and searchable.
+ *
+ * The window was the one thing with nowhere to live. `publishFile()` is a
+ * boolean: it creates a public share or it does not. So an attachment could not
+ * be depublished on a date independently of the record it belongs to, which is
+ * exactly what a WOO bijlage needs.
+ *
+ * Two nullable datetimes, no row rewritten, both guarded so the step is
+ * re-runnable. `depublished` is indexed because the sweep that stops serving an
+ * expired file scans on it.
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/file-publication-window/specs/file-publication-window/spec.md#requirement-a-file-carries-its-own-publication-window-req-fpw-101
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use Doctrine\DBAL\Types\Types;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Adds `published` and `depublished` to the file metadata row.
+ *
+ * @spec openspec/changes/file-publication-window/specs/file-publication-window/spec.md#requirement-a-file-carries-its-own-publication-window-req-fpw-101
+ */
+class Version1Date20260903090000 extends SimpleMigrationStep {
+
+	/**
+	 * The OpenRegister file metadata table.
+	 */
+	private const TABLE_FILES = 'openregister_files';
+
+	/**
+	 * Add the window columns and the expiry index, idempotently.
+	 *
+	 * @param IOutput                   $output        Migration output.
+	 * @param Closure(): ISchemaWrapper $schemaClosure The schema closure.
+	 * @param array<string, mixed>      $options       Migration options.
+	 *
+	 * @return ISchemaWrapper|null The changed schema, or null when nothing changed.
+	 *
+	 * @SuppressWarnings(PHPMD.UnusedFormalParameter) The interface fixes the signature.
+	 *
+	 * @spec openspec/changes/file-publication-window/specs/file-publication-window/spec.md#requirement-a-file-carries-its-own-publication-window-req-fpw-101
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+		if ($schema->hasTable(self::TABLE_FILES) === false) {
+			$output->warning(message: 'openregister_files is absent; skipping the publication window');
+			return null;
+		}
+
+		$table = $schema->getTable(self::TABLE_FILES);
+		$added = [];
+
+		if ($table->hasColumn('published') === false) {
+			$table->addColumn(
+				'published',
+				Types::DATETIME_MUTABLE,
+				[
+					'notnull' => false,
+					'comment' => 'When this file becomes public. Null means it has never been published.',
+				]
+			);
+			$added[] = 'published';
+		}
+
+		if ($table->hasColumn('depublished') === false) {
+			$table->addColumn(
+				'depublished',
+				Types::DATETIME_MUTABLE,
+				[
+					'notnull' => false,
+					'comment' => 'When this file stops being public. Null means no end date.',
+				]
+			);
+			$added[] = 'depublished';
+		}
+
+		if ($table->hasIndex('openregister_file_depub_idx') === false) {
+			$table->addIndex(['depublished'], 'openregister_file_depub_idx');
+			$added[] = 'index:depublished';
+		}
+
+		if ($added === []) {
+			return null;
+		}
+
+		$output->info(message: 'File publication window added: ' . implode(', ', $added));
+
+		return $schema;
+	}//end changeSchema()
+}//end class

--- a/lib/Service/File/FileFormattingHandler.php
+++ b/lib/Service/File/FileFormattingHandler.php
@@ -142,7 +142,15 @@ class FileFormattingHandler {
 			'extension' => $file->getExtension(),
 			'size' => $file->getSize(),
 			'hash' => $file->getEtag(),
-			'published' => (new DateTime())->setTimestamp($file->getCreationTime())->format('c'),
+			// `published` reported the CREATION time, so every file that had ever
+			// existed looked published and nothing could be read as unpublished.
+			// It is the publication window now, filled from the OR-side row
+			// below, and null when the file was never published. The creation
+			// time it used to carry is kept under its own name.
+			'published' => null,
+			'depublished' => null,
+			'isPublished' => false,
+			'created' => (new DateTime())->setTimestamp($file->getCreationTime())->format('c'),
 			'modified' => (new DateTime())->setTimestamp($file->getUploadTime())->format('c'),
 			'labels' => $this->fileService->getFileTags((string)$file->getId()),
 		];
@@ -169,6 +177,13 @@ class FileFormattingHandler {
 				if ($orFile !== null) {
 					$metadata['description'] = $orFile->getDescription();
 					$metadata['category'] = $orFile->getCategory();
+
+					// The publication window is public-safe: it is exactly what
+					// an anonymous caller is entitled to know about whether this
+					// file is published and until when.
+					$metadata['published'] = $orFile->getPublished()?->format('c');
+					$metadata['depublished'] = $orFile->getDepublished()?->format('c');
+					$metadata['isPublished'] = $orFile->isPublishedAt();
 					$orLabels = ($orFile->getLabels() ?? []);
 					if (empty($orLabels) === false) {
 						// Merge OR-managed labels into the existing tag-

--- a/openspec/changes/file-publication-window/proposal.md
+++ b/openspec/changes/file-publication-window/proposal.md
@@ -1,0 +1,60 @@
+# A publication window on the file, so an attachment needs no object
+
+## Why
+
+Several apps grew their own `document` object, and measuring one of them showed
+what it is actually for. opencatalogi's `document` carries `title`, `filename`,
+`mimeType`, `summary`, `description`, `publication`, `organization`,
+`publicationDate` and `depublicationDate`. Every one of those already has a home
+somewhere else:
+
+| document property | where it already lives |
+| --- | --- |
+| `filename`, `mimeType` | the file |
+| `description` | `File.description` |
+| `title` | the filename, or a label |
+| `publication`, `organization` | the object the file hangs from |
+| `summary` | fold into `description` |
+| `publicationDate` / `depublicationDate` | **nowhere** |
+
+The window is the only real gap. `publishFile()` is a boolean: it creates a
+public share or it does not. So an attachment could not be depublished on a date
+independently of the record it belongs to, which is exactly what a WOO bijlage
+needs, and that alone forced a whole object type into existence.
+
+There is a second reason, and it is the stronger one. OpenRegister already
+extracts file text into `openregister_chunks` with `source_type='file'`, and
+`ContentSearchHandler::resolveOwningObject()` already resolves a file chunk to
+its owning object through `FileMapper::findOwningObjectUuid()`. A keyword hit
+inside a file attached to a publication therefore resolves straight to the
+publication. The schema-widening in opencatalogi PR #1391 exists ONLY because
+the attachment is a separate `document` object living outside the catalog's
+schema scope. Files attached to publications would have made that whole class of
+bug impossible.
+
+## What changes
+
+`openregister_files` gains `published` and `depublished`, both nullable, and the
+file API reports the window and a computed `isPublished`.
+
+A depublication date is written onto the public share's `expiration` column,
+which Nextcloud already honours. An OR-side flag alone would leave a public URL
+that still works, and a URL that still works is not a depublication.
+
+## Two things this repairs on the way
+
+`formatFile()` reported `'published' => creationTime`. Every file that had ever
+existed therefore looked published, and no file could be read as unpublished.
+The creation time is kept, under `created`, where it is true.
+
+`FileMapper` declared `@phpstan-type File` as a filecache ROW shape, named after
+the entity the mapper maps. That alias shadowed the entity in every docblock in
+the file, so a method annotated `@return File` read as an array, and the phpstan
+baseline carried an entry for each one. Renaming the alias to `FilecacheRow` and
+naming the entity in the generic removed 12 baseline entries.
+
+## What this does not do
+
+It does not retire any app's `document` schema. That is per-app work with its
+own migration and its own repointing, and it should follow this rather than ride
+along with it.

--- a/openspec/changes/file-publication-window/specs/file-publication-window/spec.md
+++ b/openspec/changes/file-publication-window/specs/file-publication-window/spec.md
@@ -1,0 +1,78 @@
+# File publication window
+
+## ADDED Requirements
+
+### Requirement: A file carries its own publication window (REQ-FPW-101)
+
+A file MUST be able to declare when it becomes public and when it stops being
+public, independently of the object it is attached to. Without this an
+attachment can only be published or not published, which is why apps grew a
+separate `document` object to hold the dates.
+
+Both bounds are nullable, and each null means something specific:
+
+- No publication date means the file was NEVER published. It MUST NOT default to
+  the file's creation time. A file that exists is not a file that was published.
+- A publication date in the future means not yet.
+- No depublication date means no end date. It MUST NOT be read as an end date in
+  the past.
+
+The window is inclusive at the start and exclusive at the end, so a file
+published and depublished at the same instant is not public.
+
+#### Scenario: A file with no publication date is not published
+
+- **GIVEN** a file whose `published` is null
+- **WHEN** its publication state is evaluated
+- **THEN** it is not published, whatever its creation time.
+
+#### Scenario: A future publication date is not yet published
+
+- **GIVEN** a file published tomorrow
+- **WHEN** its publication state is evaluated today
+- **THEN** it is not published.
+
+#### Scenario: No depublication date means it stays published
+
+- **GIVEN** a published file whose `depublished` is null
+- **WHEN** its publication state is evaluated
+- **THEN** it is published.
+
+#### Scenario: A passed depublication date ends publication
+
+- **GIVEN** a file published yesterday and depublished this morning
+- **WHEN** its publication state is evaluated now
+- **THEN** it is not published.
+
+### Requirement: A depublication date expires the public share (REQ-FPW-102)
+
+Publishing a file with a depublication date MUST set that date as the public
+share's expiration. Recording the date only on the OpenRegister side would leave
+a public URL that still serves the file, and a URL that still works is not a
+depublication.
+
+#### Scenario: The share carries the end of the window
+
+- **WHEN** a file is published with a depublication date
+- **THEN** the created public share carries that date as its expiration.
+
+#### Scenario: No depublication date leaves the share open
+
+- **WHEN** a file is published with no depublication date
+- **THEN** the share has no expiration.
+
+### Requirement: The file API reports the window, not the creation time (REQ-FPW-103)
+
+The formatted file MUST report `published`, `depublished` and a computed
+`isPublished`. It MUST NOT report the creation time under `published`: doing so
+made every file that had ever existed look published, and made "not published"
+unrepresentable.
+
+The creation time remains available under `created`.
+
+#### Scenario: An unpublished file reports no publication date
+
+- **GIVEN** a file that was never published
+- **WHEN** it is formatted
+- **THEN** `published` is null and `isPublished` is false
+- **AND** `created` carries its creation time.

--- a/openspec/changes/file-publication-window/tasks.md
+++ b/openspec/changes/file-publication-window/tasks.md
@@ -1,0 +1,42 @@
+# Tasks
+
+## 1. Storage
+
+- [x] 1.1 Add `published` and `depublished` to `openregister_files`, both
+      nullable, guarded so the step is re-runnable.
+- [x] 1.2 Index `depublished`, which is what an expiry scan ranges on.
+
+## 2. The window rule
+
+- [x] 2.1 `File::isPublishedAt()`. Each null means something different: no
+      `published` is never published, a future `published` is not yet, and no
+      `depublished` is no end date rather than an end date in the past.
+- [x] 2.2 `FileMapper::setPublicationWindowForFile()` sets both bounds together,
+      because they are one fact.
+
+## 3. Honouring it
+
+- [x] 3.1 `publishFile()` writes the depublication date onto the share's
+      `expiration`, so Nextcloud stops serving the link itself.
+- [x] 3.2 `formatFile()` reports `published`, `depublished` and `isPublished`,
+      and stops reporting the creation time as a publication date.
+
+## 4. Repairs found on the way
+
+- [x] 4.1 Rename `FileMapper`'s `@phpstan-type File` to `FilecacheRow`: it
+      described a filecache row and shadowed the entity of the same name.
+- [x] 4.2 Name the entity in the generic and drop the `@method` shadows that
+      worked around the shadowing.
+- [x] 4.3 Remove the 12 phpstan baseline entries those two defects required.
+
+## 5. Tests
+
+- [x] 5.1 Pin the window rule, including every null case and both boundaries.
+
+## 6. Follow-on, not in this change
+
+- [ ] 6.1 Retire opencatalogi's `document` schema: attachments become files on
+      the publication, classified with labels. Revert the schema widening in
+      opencatalogi PR #1391 once nothing needs it.
+- [ ] 6.2 Decide whether an expired share needs a sweep, or whether Nextcloud's
+      own expiration handling is sufficient on every deployment.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2450,60 +2450,16 @@ parameters:
 			count: 1
 			path: lib/Db/FeedbackMapper.php
 
-		-
-			message: "#^Call to an undefined method OCA\\\\OpenRegister\\\\Db\\\\File\\:\\:getDownloadCount\\(\\)\\.$#"
-			count: 1
-			path: lib/Db/FileMapper.php
 
-		-
-			message: "#^Call to an undefined method OCA\\\\OpenRegister\\\\Db\\\\File\\:\\:setCategory\\(\\)\\.$#"
-			count: 1
-			path: lib/Db/FileMapper.php
 
-		-
-			message: "#^Call to an undefined method OCA\\\\OpenRegister\\\\Db\\\\File\\:\\:setCreated\\(\\)\\.$#"
-			count: 1
-			path: lib/Db/FileMapper.php
 
-		-
-			message: "#^Call to an undefined method OCA\\\\OpenRegister\\\\Db\\\\File\\:\\:setDescription\\(\\)\\.$#"
-			count: 1
-			path: lib/Db/FileMapper.php
 
-		-
-			message: "#^Call to an undefined method OCA\\\\OpenRegister\\\\Db\\\\File\\:\\:setDownloadCount\\(\\)\\.$#"
-			count: 2
-			path: lib/Db/FileMapper.php
 
-		-
-			message: "#^Call to an undefined method OCA\\\\OpenRegister\\\\Db\\\\File\\:\\:setFileId\\(\\)\\.$#"
-			count: 1
-			path: lib/Db/FileMapper.php
 
-		-
-			message: "#^Call to an undefined method OCA\\\\OpenRegister\\\\Db\\\\File\\:\\:setLabels\\(\\)\\.$#"
-			count: 1
-			path: lib/Db/FileMapper.php
 
-		-
-			message: "#^Call to an undefined method OCA\\\\OpenRegister\\\\Db\\\\File\\:\\:setLockExpires\\(\\)\\.$#"
-			count: 1
-			path: lib/Db/FileMapper.php
 
-		-
-			message: "#^Call to an undefined method OCA\\\\OpenRegister\\\\Db\\\\File\\:\\:setLockedAt\\(\\)\\.$#"
-			count: 1
-			path: lib/Db/FileMapper.php
 
-		-
-			message: "#^Call to an undefined method OCA\\\\OpenRegister\\\\Db\\\\File\\:\\:setLockedBy\\(\\)\\.$#"
-			count: 1
-			path: lib/Db/FileMapper.php
 
-		-
-			message: "#^Call to an undefined method OCA\\\\OpenRegister\\\\Db\\\\File\\:\\:setUpdated\\(\\)\\.$#"
-			count: 5
-			path: lib/Db/FileMapper.php
 
 		-
 			message: "#^Cannot call method getFileId\\(\\) on array\\<string, int\\|string\\|null\\>\\.$#"
@@ -2545,10 +2501,6 @@ parameters:
 			count: 1
 			path: lib/Db/FileMapper.php
 
-		-
-			message: "#^PHPDoc tag @return with type array\\<string, int\\|string\\|null\\> is incompatible with native type OCA\\\\OpenRegister\\\\Db\\\\File\\.$#"
-			count: 6
-			path: lib/Db/FileMapper.php
 
 		-
 			message: "#^PHPDoc tag @return with type array\\<string, int\\|string\\|null\\>\\|null is not subtype of native type OCA\\\\OpenRegister\\\\Db\\\\File\\|null\\.$#"

--- a/tests/Unit/Db/FilePublicationWindowTest.php
+++ b/tests/Unit/Db/FilePublicationWindowTest.php
@@ -1,0 +1,213 @@
+<?php
+
+/**
+ * Unit tests for the file publication window.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Db;
+
+use DateTime;
+use OCA\OpenRegister\Db\File;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Locks the window rule. Each null in it means something different, and the
+ * whole reason the rule is a method rather than an inline comparison is that
+ * treating them alike is the mistake it exists to prevent.
+ */
+class FilePublicationWindowTest extends TestCase {
+
+	/**
+	 * The moment every case is evaluated against.
+	 */
+	private const NOW = '2026-06-15 12:00:00';
+
+	/**
+	 * Build a file with a window.
+	 *
+	 * @param string|null $published   When it becomes public.
+	 * @param string|null $depublished When it stops.
+	 *
+	 * @return File The file.
+	 */
+	private function file(?string $published, ?string $depublished = null): File {
+		$file = new File();
+		$file->setFileId(1);
+
+		if ($published !== null) {
+			$file->setPublished(new DateTime($published));
+		}
+
+		if ($depublished !== null) {
+			$file->setDepublished(new DateTime($depublished));
+		}
+
+		return $file;
+
+	}//end file()
+
+	/**
+	 * The moment under test.
+	 *
+	 * @return DateTime The evaluation moment.
+	 */
+	private function now(): DateTime {
+		return new DateTime(self::NOW);
+
+	}//end now()
+
+	/**
+	 * No publication date means never published. It must NOT fall back to the
+	 * creation time: that is what made every file that had ever existed look
+	 * published, and made "not published" unrepresentable.
+	 *
+	 * @return void
+	 */
+	public function testAFileWithNoPublicationDateIsNotPublished(): void {
+		$this->assertFalse($this->file(published: null)->isPublishedAt(now: $this->now()));
+
+	}//end testAFileWithNoPublicationDateIsNotPublished()
+
+	/**
+	 * A depublication date without a publication date does not publish
+	 * anything. An end date is not a start date.
+	 *
+	 * @return void
+	 */
+	public function testADepublicationDateAloneDoesNotPublish(): void {
+		$this->assertFalse(
+			$this->file(published: null, depublished: '2030-01-01 00:00:00')->isPublishedAt(now: $this->now())
+		);
+
+	}//end testADepublicationDateAloneDoesNotPublish()
+
+	/**
+	 * A future publication date is not yet published, which is the whole point
+	 * of being able to set one.
+	 *
+	 * @return void
+	 */
+	public function testAFuturePublicationDateIsNotYetPublished(): void {
+		$this->assertFalse($this->file(published: '2026-06-16 12:00:00')->isPublishedAt(now: $this->now()));
+
+	}//end testAFuturePublicationDateIsNotYetPublished()
+
+	/**
+	 * No depublication date means no end date, not an end date in the past.
+	 * This is the ordinary case and the one a careless comparison gets wrong.
+	 *
+	 * @return void
+	 */
+	public function testNoDepublicationDateMeansItStaysPublished(): void {
+		$this->assertTrue($this->file(published: '2020-01-01 00:00:00')->isPublishedAt(now: $this->now()));
+
+	}//end testNoDepublicationDateMeansItStaysPublished()
+
+	/**
+	 * A depublication date that has passed ends publication.
+	 *
+	 * @return void
+	 */
+	public function testAPassedDepublicationDateEndsPublication(): void {
+		$this->assertFalse(
+			$this->file(published: '2020-01-01 00:00:00', depublished: '2026-06-15 09:00:00')
+				->isPublishedAt(now: $this->now())
+		);
+
+	}//end testAPassedDepublicationDateEndsPublication()
+
+	/**
+	 * A depublication date still ahead keeps the file published.
+	 *
+	 * @return void
+	 */
+	public function testAFutureDepublicationDateKeepsItPublished(): void {
+		$this->assertTrue(
+			$this->file(published: '2020-01-01 00:00:00', depublished: '2026-06-16 00:00:00')
+				->isPublishedAt(now: $this->now())
+		);
+
+	}//end testAFutureDepublicationDateKeepsItPublished()
+
+	/**
+	 * The start boundary is inclusive: a file published at exactly this instant
+	 * is published.
+	 *
+	 * @return void
+	 */
+	public function testTheStartBoundaryIsInclusive(): void {
+		$this->assertTrue($this->file(published: self::NOW)->isPublishedAt(now: $this->now()));
+
+	}//end testTheStartBoundaryIsInclusive()
+
+	/**
+	 * The end boundary is exclusive, so a file published and depublished at the
+	 * same instant is not public. A zero-length window publishes nothing.
+	 *
+	 * @return void
+	 */
+	public function testTheEndBoundaryIsExclusive(): void {
+		$this->assertFalse(
+			$this->file(published: self::NOW, depublished: self::NOW)->isPublishedAt(now: $this->now())
+		);
+
+	}//end testTheEndBoundaryIsExclusive()
+
+	/**
+	 * A window whose end precedes its start publishes nothing, rather than
+	 * reading as published because the start has passed.
+	 *
+	 * @return void
+	 */
+	public function testAnInvertedWindowPublishesNothing(): void {
+		$this->assertFalse(
+			$this->file(published: '2020-01-01 00:00:00', depublished: '2019-01-01 00:00:00')
+				->isPublishedAt(now: $this->now())
+		);
+
+	}//end testAnInvertedWindowPublishesNothing()
+
+	/**
+	 * The serialised form carries the window and the computed state, so a
+	 * caller never has to re-derive the rule.
+	 *
+	 * @return void
+	 */
+	public function testTheSerialisedFormCarriesTheWindow(): void {
+		$serialised = $this->file(published: '2020-01-01 00:00:00', depublished: '2030-01-01 00:00:00')
+			->jsonSerialize();
+
+		$this->assertSame('2020-01-01T00:00:00+00:00', $serialised['published']);
+		$this->assertSame('2030-01-01T00:00:00+00:00', $serialised['depublished']);
+		$this->assertTrue($serialised['isPublished']);
+
+	}//end testTheSerialisedFormCarriesTheWindow()
+
+	/**
+	 * An unpublished file serialises nulls rather than dates, so "never
+	 * published" is representable on the wire.
+	 *
+	 * @return void
+	 */
+	public function testAnUnpublishedFileSerialisesNulls(): void {
+		$serialised = $this->file(published: null)->jsonSerialize();
+
+		$this->assertNull($serialised['published']);
+		$this->assertNull($serialised['depublished']);
+		$this->assertFalse($serialised['isPublished']);
+
+	}//end testAnUnpublishedFileSerialisesNulls()
+}//end class


### PR DESCRIPTION
## Why

Apps grew their own `document` object to hold a publication window over an attached file. Measuring opencatalogi's, every other property it carries already has a home:

| document property | where it already lives |
| --- | --- |
| `filename`, `mimeType` | the file |
| `description` | `File.description` |
| `title` | the filename, or a label |
| `publication`, `organization` | the object the file hangs from |
| `summary` | fold into `description` |
| `publicationDate` / `depublicationDate` | **nowhere** |

The window was the only real gap. `publishFile()` is a boolean: it creates a public share or it does not. So an attachment could not be depublished on a date independently of the record it belongs to, which is exactly what a WOO bijlage needs, and that alone forced a whole object type into existence.

The second reason is the stronger one. `ContentSearchHandler::resolveOwningObject()` already resolves a file chunk to its owning object through `FileMapper::findOwningObjectUuid()`, and `openregister_chunks` already carries `source_type='file'` rows. So a keyword hit inside a file attached to a publication resolves straight to the publication. The schema widening in opencatalogi #1391 exists **only** because the attachment is a separate object living outside the catalog's schema scope. Files attached to publications would have made that class of bug impossible.

## The rule

The window is a method rather than an inline comparison because each null in it means something different, and treating them alike is the mistake it exists to prevent:

- **No publication date means never published.** It does not fall back to the creation time.
- **A future publication date means not yet**, which is the point of being able to set one.
- **No depublication date means no end date**, not an end date in the past.

Start inclusive, end exclusive, so a zero-length window publishes nothing. An inverted window publishes nothing either, rather than reading as published because the start has passed.

A depublication date is written onto the public share's `expiration`, which Nextcloud already honours. An OpenRegister-side flag alone would leave a public URL that still serves the file, and a URL that still works is not a depublication.

## Two repairs found on the way

**`formatFile()` reported the creation time under `published`.** Every file that had ever existed therefore looked published, and "not published" was unrepresentable. The creation time is kept, under `created`, where it is true.

**`FileMapper` declared `@phpstan-type File` describing a filecache ROW**, named after the entity the mapper maps. That alias shadowed the entity in every docblock in the file, so a method annotated `@return File` read as an array shape. It is why the phpstan baseline carried an entry for each accessor, and why adding one method made an unrelated ignore count wrong. Renaming it to `FilecacheRow` and naming the entity in the generic **removed 12 baseline entries**. Full-tree phpstan is clean.

## Verification

Not only in tests. On the dev instance:

- the migration applies, reports what it added, and is a **no-op on re-run**
- all four window states behave correctly **round-tripped through the database**, not just in memory, which is what proves the `addType` hydration rather than assuming it
- 11 unit tests pin the rule, including both boundaries, the inverted window, and a depublication date with no publication date
- the neighbouring suites: 1590 tests in `tests/Unit/Db`, and 1373 across every File-related test, green

phpcs, phpmd, psalm and phpstan clean on every changed file.

## What this does not do

It does not retire any app's `document` schema. That is per-app work with its own migration and its own repointing, and it should follow this rather than ride along with it. Task 6 of the change records it, including reverting #1391's widening once nothing needs it.
