### PR TITLE
feat(quality): the quality assessment is @self metadata, not object data

### DIFF
--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -2460,6 +2460,15 @@ class MagicMapper extends AbstractObjectMapper {
 				'type' => 'json',
 				'nullable' => true,
 			],
+			// Platform-owned quality assessment. Lives here rather than in the
+			// object body so a schema does not have to declare `qualityScore`
+			// as an ordinary property just to be scored — which put a number
+			// field the platform overwrites on every form the schema drives.
+			self::METADATA_PREFIX . 'quality' => [
+				'name' => self::METADATA_PREFIX . 'quality',
+				'type' => 'json',
+				'nullable' => true,
+			],
 			self::METADATA_PREFIX . 'deleted' => [
 				'name' => self::METADATA_PREFIX . 'deleted',
 				'type' => 'json',
@@ -3689,6 +3698,7 @@ class MagicMapper extends AbstractObjectMapper {
 			// which is what "not writable by this path" has to mean. Writes go
 			// through the dedicated authorization-management path.
 			'validation',
+			'quality',
 			'deleted',
 			'geo',
 			'retention',
@@ -3736,6 +3746,7 @@ class MagicMapper extends AbstractObjectMapper {
 				'locked',
 				'authorization',
 				'validation',
+				'quality',
 				'deleted',
 				'geo',
 				'retention',

--- a/lib/Db/ObjectEntity.php
+++ b/lib/Db/ObjectEntity.php
@@ -89,6 +89,8 @@ use OCP\IUserSession;
  * @method void setOrganisation(?string $organisation)
  * @method array|null getValidation()
  * @method void setValidation(?array $validation)
+ * @method array|null getQuality()
+ * @method void setQuality(?array $quality)
  * @method array|null getDeleted()
  * @method void setDeleted(?array $deleted)
  * @method array|null getGeo()
@@ -262,6 +264,24 @@ class ObjectEntity extends Entity implements JsonSerializable, ObjectEntityInter
 	 * @var array|null Array describing validation results
 	 */
 	protected ?array $validation = [];
+
+	/**
+	 * Platform-computed quality assessment for the object.
+	 *
+	 * Written by QualityScoreOnSaveListener when the schema carries an
+	 * `x-openregister-quality` annotation. Shape:
+	 *   `['score' => 0.0-1.0, 'status' => 'good'|..., 'scoredAt' => '...']`
+	 *
+	 * This is an assessment OF the object's data, not a fact about the thing
+	 * the object describes, which is why it lives in the `@self` envelope
+	 * rather than among the object's own properties. Storing it here means a
+	 * schema no longer has to declare `qualityScore` as an ordinary property
+	 * to be scored, and so no longer puts a number field the platform
+	 * overwrites in front of the person filling the form.
+	 *
+	 * @var array|null Array describing the quality assessment
+	 */
+	protected ?array $quality = [];
 
 	/**
 	 * Deletion details if the object is deleted.
@@ -694,6 +714,7 @@ class ObjectEntity extends Entity implements JsonSerializable, ObjectEntityInter
 		$this->addType(fieldName: 'application', type: 'string');
 		$this->addType(fieldName: 'organisation', type: 'string');
 		$this->addType(fieldName: 'validation', type: 'json');
+		$this->addType(fieldName: 'quality', type: 'json');
 		$this->addType(fieldName: 'deleted', type: 'json');
 		$this->addType(fieldName: 'geo', type: 'json');
 		$this->addType(fieldName: 'retention', type: 'json');
@@ -737,6 +758,7 @@ class ObjectEntity extends Entity implements JsonSerializable, ObjectEntityInter
 			'relations',
 			'authorization',
 			'validation',
+			'quality',
 			'deleted',
 			'groups',
 			'geo',
@@ -1004,6 +1026,7 @@ class ObjectEntity extends Entity implements JsonSerializable, ObjectEntityInter
 			'folder' => $this->folder,
 			'application' => $this->application,
 			'validation' => $this->getValidation(),
+			'quality' => $this->getQuality(),
 			'geo' => $this->getGeo(),
 			'retention' => $this->getRetention(),
 			'tmlo' => $this->getTmlo(),

--- a/lib/Listener/QualityScoreOnSaveListener.php
+++ b/lib/Listener/QualityScoreOnSaveListener.php
@@ -143,28 +143,53 @@ class QualityScoreOnSaveListener implements IEventListener {
 			return;
 		}
 
+		$thresholds = ($quality['thresholds'] ?? []);
+		if (is_array($thresholds) === false) {
+			$thresholds = [];
+		}
+
+		$status = $this->scorer->status(score: $score, thresholds: $thresholds);
+
+		// The assessment goes in the `@self` envelope, always. It describes
+		// the object's data rather than the thing the object describes, and
+		// putting it there is what lets a schema be scored WITHOUT declaring
+		// `qualityScore` as an ordinary property — which used to put a number
+		// field the platform overwrites on save in front of whoever was
+		// filling the form.
+		$object->setQuality(
+			[
+				'score' => $score,
+				'status' => $status,
+				'scoredAt' => (new DateTimeImmutable())->format(DATE_ATOM),
+			]
+		);
+
+		// The body properties are still written, but ONLY where the schema
+		// actually declares them. Dropping the write outright would freeze the
+		// stored value of every schema that has one, and a score that silently
+		// stops updating reads exactly like a score that is simply good.
+		//
+		// A schema that has migrated to `@self.quality` declares neither, so
+		// this writes nothing and the object body stays clean.
+		$properties = ($schema->getProperties() ?? []);
+
 		$field = (string)($quality['field'] ?? self::DEFAULT_FIELD);
 		if ($field === '') {
 			$field = self::DEFAULT_FIELD;
 		}
 
-		if (($data[$field] ?? null) !== $score) {
+		if (array_key_exists($field, $properties) === true && ($data[$field] ?? null) !== $score) {
 			$data[$field] = $score;
 			$changed = true;
 		}
 
 		$statusField = (string)($quality['statusField'] ?? '');
-		if ($statusField !== '') {
-			$thresholds = ($quality['thresholds'] ?? []);
-			if (is_array($thresholds) === false) {
-				$thresholds = [];
-			}
-
-			$status = $this->scorer->status(score: $score, thresholds: $thresholds);
-			if (($data[$statusField] ?? null) !== $status) {
-				$data[$statusField] = $status;
-				$changed = true;
-			}
+		if ($statusField !== ''
+			&& array_key_exists($statusField, $properties) === true
+			&& ($data[$statusField] ?? null) !== $status
+		) {
+			$data[$statusField] = $status;
+			$changed = true;
 		}
 
 		if ($changed === true) {

--- a/lib/Migration/Version1Date20260903090000.php
+++ b/lib/Migration/Version1Date20260903090000.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * Adds the `_quality` metadata column to every per-schema object table.
+ *
+ * A per-object quality score is an ASSESSMENT of the object's data, not a
+ * fact about the thing the object describes. Until now the scorer had no
+ * place to put it other than the object body, which forced every schema
+ * wanting a score to declare `qualityScore` and `qualityStatus` as ordinary
+ * properties. Three things follow from that, and all three are wrong:
+ *
+ * - The properties appear on every form the schema drives. A case handler
+ *   filing a case was shown a "Quality score" number field to fill in, for a
+ *   value the platform overwrites on save.
+ * - Removing the declaration silently DELETES the values, because the store
+ *   strips what the schema does not declare. So the mistake could not be
+ *   undone without data loss.
+ * - Two schemas scoring the same way had to agree on property names by
+ *   convention, with nothing to enforce it.
+ *
+ * `_quality` is the same kind of column as `_validation` and `_retention`:
+ * platform-owned metadata, surfaced in the `@self` envelope, never part of
+ * the object's own data.
+ *
+ * This step is additive and idempotent. It adds the column where it is
+ * missing and leaves it alone where it is present, so re-running it is a
+ * no-op. It does NOT remove any `qualityScore` property or its stored value:
+ * a schema that declares one keeps it, and keeps being written, until its
+ * owning app drops the declaration deliberately.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\IConfig;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Gives every per-schema object table a `_quality` metadata column.
+ */
+class Version1Date20260903090000 extends SimpleMigrationStep {
+
+	/**
+	 * The metadata column this step adds.
+	 *
+	 * @var string
+	 */
+	private const QUALITY_COLUMN = '_quality';
+
+	/**
+	 * A column that every per-schema object table carries.
+	 *
+	 * Used to tell a per-schema object table from any other table that
+	 * happens to share the prefix. `_uuid` is written by every object write
+	 * path, so a table without it is not one this step should touch.
+	 *
+	 * @var string
+	 */
+	private const SIGNATURE_COLUMN = '_uuid';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IConfig $config Reads the configured database table prefix.
+	 */
+	public function __construct(private readonly IConfig $config) {
+
+	}//end __construct()
+
+	/**
+	 * Add `_quality` to every per-schema object table that lacks it.
+	 *
+	 * @param IOutput  $output        Migration output.
+	 * @param Closure  $schemaClosure Returns the live ISchemaWrapper.
+	 * @param array    $options       Migration options.
+	 *
+	 * @return ISchemaWrapper|null The changed schema, or null when nothing changed.
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		// @var ISchemaWrapper $schema
+		$schema = $schemaClosure();
+		$prefix = $this->config->getSystemValueString('dbtableprefix', 'oc_');
+		$changed = 0;
+
+		foreach ($schema->getTables() as $table) {
+			if (str_starts_with($table->getName(), $prefix.'openregister_table_') === false) {
+				continue;
+			}
+
+			// A table sharing the prefix but missing the signature column is
+			// not an object table. Adding a column to it would be a guess.
+			if ($table->hasColumn(self::SIGNATURE_COLUMN) === false) {
+				continue;
+			}
+
+			if ($table->hasColumn(self::QUALITY_COLUMN) === true) {
+				continue;
+			}
+
+			$table->addColumn(self::QUALITY_COLUMN, Types::JSON, ['notnull' => false]);
+			$changed++;
+		}//end foreach
+
+		if ($changed === 0) {
+			$output->info('quality metadata: every per-schema object table already has _quality, nothing to do');
+			return null;
+		}
+
+		$output->info(sprintf('quality metadata: added _quality to %d per-schema object table(s)', $changed));
+
+		return $schema;
+
+	}//end changeSchema()
+
+}//end class

--- a/tests/Unit/Listener/QualityScoreOnSaveListenerTest.php
+++ b/tests/Unit/Listener/QualityScoreOnSaveListenerTest.php
@@ -1,0 +1,156 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Listener;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Event\ObjectCreatingEvent;
+use OCA\OpenRegister\Listener\QualityScoreOnSaveListener;
+use OCA\OpenRegister\Service\Quality\QualityScorer;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * The quality assessment belongs to `@self`, not to the object's data.
+ *
+ * It describes the object's data rather than the thing the object describes.
+ * Keeping it out of the body is what lets a schema be scored without
+ * declaring `qualityScore` as an ordinary property, which used to put a
+ * number field the platform overwrites in front of whoever filled the form.
+ */
+class QualityScoreOnSaveListenerTest extends TestCase {
+
+	private SchemaMapper $schemaMapper;
+
+	private QualityScorer $scorer;
+
+	private QualityScoreOnSaveListener $listener;
+
+	protected function setUp(): void {
+		$this->schemaMapper = $this->createMock(SchemaMapper::class);
+		$this->scorer = $this->createMock(QualityScorer::class);
+
+		$this->listener = new QualityScoreOnSaveListener(
+			$this->schemaMapper,
+			$this->scorer,
+			$this->createMock(LoggerInterface::class),
+		);
+	}
+
+	/**
+	 * A schema carrying the annotation, declaring the given properties.
+	 *
+	 * Only methods Schema really declares are stubbed. PHPUnit refuses to
+	 * configure one that does not exist, which is the property that makes this
+	 * mock able to fail when the real signature moves.
+	 *
+	 * @param array $properties The schema's declared properties.
+	 * @param array $quality    The `x-openregister-quality` annotation.
+	 */
+	private function schema(array $properties, array $quality = ['rules' => [['field' => 'title']]]): Schema {
+		$schema = $this->createMock(Schema::class);
+		$schema->method('getConfiguration')->willReturn(['x-openregister-quality' => $quality]);
+		$schema->method('getProperties')->willReturn($properties);
+
+		return $schema;
+	}
+
+	private function fire(ObjectEntity $object, Schema $schema): void {
+		$this->schemaMapper->method('find')->willReturn($schema);
+		$this->scorer->method('score')->willReturn(0.5);
+		$this->scorer->method('status')->willReturn('fair');
+
+		$this->listener->handle(new ObjectCreatingEvent($object));
+	}
+
+	public function testWritesTheAssessmentIntoSelf(): void {
+		$object = new ObjectEntity();
+		$object->setSchema(1);
+		$object->setObject(['title' => 'A case']);
+
+		$this->fire($object, $this->schema(['title' => ['type' => 'string']]));
+
+		$quality = $object->getQuality();
+		$this->assertSame(0.5, $quality['score']);
+		$this->assertSame('fair', $quality['status']);
+		$this->assertArrayHasKey('scoredAt', $quality);
+	}
+
+	public function testLeavesTheObjectBodyAloneWhenTheSchemaDeclaresNoQualityProperty(): void {
+		// The whole point of the change. A schema that has dropped its
+		// `qualityScore` declaration is still scored, and its objects stay
+		// clean.
+		$object = new ObjectEntity();
+		$object->setSchema(1);
+		$object->setObject(['title' => 'A case']);
+
+		$this->fire($object, $this->schema(['title' => ['type' => 'string']]));
+
+		$this->assertSame('A case', $object->getObject()['title']);
+		$this->assertArrayNotHasKey('qualityScore', $object->getObject());
+		$this->assertArrayNotHasKey('qualityStatus', $object->getObject());
+	}
+
+	public function testStillWritesTheBodyPropertyWhileTheSchemaDeclaresIt(): void {
+		// Dropping the body write outright would freeze the stored value of
+		// every schema that has one, and a score that silently stops updating
+		// reads exactly like a score that is simply good.
+		$object = new ObjectEntity();
+		$object->setSchema(1);
+		$object->setObject(['title' => 'A case', 'qualityScore' => 0.1]);
+
+		$this->fire($object, $this->schema(
+			[
+				'title' => ['type' => 'string'],
+				'qualityScore' => ['type' => 'number'],
+				'qualityStatus' => ['type' => 'string'],
+			],
+			['rules' => [['field' => 'title']], 'statusField' => 'qualityStatus'],
+		));
+
+		$this->assertSame(0.5, $object->getObject()['qualityScore']);
+		$this->assertSame('fair', $object->getObject()['qualityStatus']);
+		// And it is in @self as well, so a consumer can move over before the
+		// schema drops the declaration.
+		$this->assertSame(0.5, $object->getQuality()['score']);
+	}
+
+	public function testDoesNotInventAStatusPropertyTheSchemaNeverDeclared(): void {
+		$object = new ObjectEntity();
+		$object->setSchema(1);
+		$object->setObject(['title' => 'A case']);
+
+		$this->fire($object, $this->schema(
+			['title' => ['type' => 'string']],
+			['rules' => [['field' => 'title']], 'statusField' => 'qualityStatus'],
+		));
+
+		$this->assertArrayNotHasKey('qualityStatus', $object->getObject());
+		// The status is still assessed; it just lives in the envelope.
+		$this->assertSame('fair', $object->getQuality()['status']);
+	}
+
+	public function testIgnoresASchemaWithoutTheAnnotation(): void {
+		$object = new ObjectEntity();
+		$object->setSchema(1);
+		$object->setObject(['title' => 'A case']);
+
+		$schema = $this->createMock(Schema::class);
+		$schema->method('getConfiguration')->willReturn([]);
+		$schema->method('getProperties')->willReturn([]);
+		$this->schemaMapper->method('find')->willReturn($schema);
+
+		$this->listener->handle(new ObjectCreatingEvent($object));
+
+		$this->assertEmpty($object->getQuality());
+		$this->assertArrayNotHasKey('qualityScore', $object->getObject());
+	}
+}


### PR DESCRIPTION
## Why

A per-object quality score is an assessment **of** the object's data, not a fact about the thing the object describes. It had nowhere to live except the object body, which forced every schema wanting a score to declare `qualityScore` and `qualityStatus` as ordinary properties. Three things followed, and all three are wrong:

- **The properties appear on every form the schema drives.** A case handler filing a case in dossiq was shown a "Quality score" number field to fill in, for a value the platform overwrites on save. That is what surfaced this.
- **Removing the declaration silently deletes the values,** because the store strips what the schema does not declare. So the mistake could not be undone without data loss.
- **Two schemas scoring the same way had to agree on property names by convention,** with nothing to enforce it.

## What

`_quality` becomes a metadata column of the same kind as `_validation` and `_retention`, surfaced in the `@self` envelope as `quality`:

```json
"@self": { "quality": { "score": 0.5, "status": "fair", "scoredAt": "2026-09-03T…" } }
```

**The change is additive on purpose.** The listener still writes the body properties, but only where the schema actually declares them. Dropping that outright would freeze the stored value of every schema that has one, and a score that silently stops updating reads exactly like a score that is simply good. A schema that has migrated declares neither property, so nothing is written to its objects and the body stays clean.

That gives every app a migration path it can take on its own schedule: read `@self.quality`, then drop the declarations.

## The migration

It sweeps every per-schema object table, adding the column where missing and skipping it where present, so re-running is a no-op. It identifies an object table by the `_uuid` column rather than by the name prefix alone, so a table that merely shares the prefix is never altered.

I verified that signature against a live database rather than only against the source: every `oc_openregister_table_%` carries `_uuid` and `_validation`, and none yet carries `_quality`.

## Verification

- **1886 unit tests pass** across `tests/Unit/Db` and `tests/Unit/Listener`. The pristine tree runs 1881; the 5 added here are the difference, and the 3 pre-existing vendor warnings and 5 skips are unchanged
- The listener had **no test at all** before this; there are now 5, covering the `@self` write, the schema that declares nothing, the schema that still declares both, a `statusField` naming a property the schema never declared, and a schema with no annotation
- PHPCS (repo config, `lib` scope) and PHPStan clean on every changed file
- Psalm reports one `UnusedBaselineEntry` on `ObjectEntity`, which reproduces identically on the pristine tree. It is an artifact of analysing single files, not something this branch introduces

## Reviewer note

This touches the storage layer of the foundation repo, so the blast radius is every app. The two things worth your eyes are the migration's table-identification guard and the decision to keep writing declared body properties rather than cutting over hard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)