### PR TITLE
feat(flow): a user task arms its own deadline

### DIFF
--- a/lib/Service/Flow/Nodes/UserTaskNode.php
+++ b/lib/Service/Flow/Nodes/UserTaskNode.php
@@ -71,6 +71,7 @@ use OCA\OpenRegister\Service\Flow\FlowTaskBridge;
 use OCA\OpenRegister\Service\Flow\IFlowNode;
 use OCA\OpenRegister\Service\Flow\IFlowNodeConfigForm;
 use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
+use OCA\OpenRegister\Service\Flow\Timer\FlowTimerService;
 use OCA\OpenRegister\Service\Task\TaskFormReader;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -104,6 +105,7 @@ class UserTaskNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigFor
 	 * @param IL10N $l10n Translations.
 	 * @param IURLGenerator $urls For the palette icon.
 	 * @param TaskFormReader $forms Reads and refuses the step's form declaration.
+	 * @param FlowTimerService $timers Arms the task's business timer.
 	 *
 	 * @spec openspec/changes/flow-user-task-node/specs/flow-user-task-node/spec.md
 	 */
@@ -112,6 +114,7 @@ class UserTaskNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigFor
 		private readonly IL10N $l10n,
 		private readonly IURLGenerator $urls,
 		TaskFormReader $forms,
+		private readonly FlowTimerService $timers,
 	) {
 		$this->config = new UserTaskConfig(l10n: $l10n, forms: $forms);
 
@@ -204,6 +207,15 @@ class UserTaskNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigFor
 			'failOnReject',
 			'heartbeatMinutes',
 			'advance',
+			// The business-timer half. Absent from a node, nothing is armed and
+			// the node behaves exactly as it did before these existed.
+			'sla',
+			'calendar',
+			'ladder',
+			'escalationRules',
+			'purpose',
+			'legalEffect',
+			'onExpiry',
 			...TaskFormReader::CONFIG_KEYS,
 		];
 	}//end configKeys()
@@ -337,6 +349,23 @@ class UserTaskNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigFor
 			actor: $this->actingIdentity(context: $context)
 		);
 
+		// ARM THE DEADLINE, if this node declares one. Nothing else in the
+		// engine did: `FlowTimerService::arm()` had no production caller at
+		// all, so a node could describe an SLA and no clock ever started.
+		//
+		// Here rather than anywhere else because this is where the task's uuid
+		// first exists, and the timer is bound to the TASK — the same
+		// (subjectType: 'task', subjectUuid) pair that
+		// FlowTimerSubjectTerminalListener already cancels on completion. Arm
+		// somewhere the uuid is not yet known and the two halves cannot meet.
+		$this->armDeadline(
+			config: $config,
+			taskUuid: (string)$task->getUuid(),
+			runUuid: $runUuid,
+			nodeId: $resume->nodeId(),
+			context: $context
+		);
+
 		// Written ONCE. A heartbeat re-enters execute() and finds the uuid
 		// held, so it never reaches this line again; askedAt therefore records
 		// when somebody was first asked, not when the run last checked.
@@ -345,6 +374,68 @@ class UserTaskNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigFor
 		);
 
 	}//end createTask()
+
+	/**
+	 * Arm a business timer for the task this node just created.
+	 *
+	 * NO-OP UNLESS THE NODE DECLARES AN SLA. A flow that never mentioned one
+	 * behaves exactly as before, which is what makes this safe to add to an
+	 * engine every app shares.
+	 *
+	 * 🔴 A FAILURE HERE IS NOT SWALLOWED. If an SLA is declared and cannot be
+	 * armed, the task has no deadline, and for a `wettelijk` term that is a
+	 * legal defect rather than something to log and carry on from. Letting it
+	 * propagate is also safe for existing flows precisely because they do not
+	 * reach this branch.
+	 *
+	 * Bound to the TASK, matching what FlowTimerSubjectTerminalListener already
+	 * cancels: `subjectType: 'task'` with the task's uuid. The run and node are
+	 * recorded as provenance, which is what the timer model asks for — a timer
+	 * is subject-bound, and its run is optional context.
+	 *
+	 * @param array<string, mixed> $config The node configuration.
+	 * @param string $taskUuid The uuid of the task just created.
+	 * @param string $runUuid The run this node is executing in.
+	 * @param string $nodeId This node's id.
+	 * @param array<string, mixed> $context The execution context.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-business-timers/specs/flow-business-timers/spec.md#requirement-a-business-timer-is-durable-subject-bound-and-cancelled-by-completion
+	 */
+	private function armDeadline(array $config, string $taskUuid, string $runUuid, string $nodeId, array $context): void {
+		$sla = ($config['sla'] ?? null);
+		if ($sla === null || $sla === '' || $sla === []) {
+			return;
+		}
+
+		$title = trim((string)($config['title'] ?? ''));
+		if ($title === '') {
+			$title = null;
+		}
+
+		$timerConfig = [
+			'subjectType' => 'task',
+			'subjectUuid' => $taskUuid,
+			'runUuid' => $runUuid,
+			'nodeId' => $nodeId,
+			'appId' => 'openregister',
+			'title' => $title,
+			'sla' => $sla,
+		];
+
+		// Only forward what the author actually set: `build()` applies its own
+		// defaults, and passing an explicit null would override them.
+		foreach (['calendar', 'ladder', 'escalationRules', 'purpose', 'legalEffect', 'onExpiry', 'organisation'] as $key) {
+			if (array_key_exists($key, $config) === true && $config[$key] !== null && $config[$key] !== '') {
+				$timerConfig[$key] = $config[$key];
+			}
+		}
+
+		$this->timers->arm(config: $timerConfig, actor: $this->actingIdentity(context: $context));
+
+	}//end armDeadline()
+
 
 	/**
 	 * Write the outcome bag onto every item, under the configured key.

--- a/openspec/changes/flow-business-timers/specs/flow-business-timers/spec.md
+++ b/openspec/changes/flow-business-timers/specs/flow-business-timers/spec.md
@@ -456,3 +456,49 @@ SHALL reflect work performed rather than rows examined.
 - **WHEN** the pass logs its result
 - **THEN** the reported fired count MUST be three
 - @e2e exclude covered by sweep logging unit tests
+
+### Requirement: A user task arms its own deadline
+
+`openregister.user-task` SHALL arm a business timer when it creates its task,
+and only when the node declares an `sla`. A node that declares none SHALL arm
+nothing and behave exactly as it did before this requirement existed.
+
+The timer SHALL be bound to the TASK — `subjectType: 'task'` with the task's
+uuid — which is the same pair the terminal listener cancels on. Arming against
+anything else produces a timer nothing ever cancels, which this spec already
+calls a defect rather than a tolerable condition.
+
+The run and node SHALL be recorded as provenance rather than identity, per the
+durability requirement above.
+
+An SLA that is declared and CANNOT be armed SHALL fail the node. A task
+carrying a declared deadline with no timer is a term nobody is measuring, and
+for a `wettelijk` deadline that is a legal defect rather than something to log
+and continue from.
+
+**Why this requirement exists.** Everything above it was implemented, tested
+and unreachable: `FlowTimerService::arm()` had no production caller anywhere in
+the app. Every reference lived in its own unit test. A node could describe an
+SLA in full and no clock would ever start.
+
+@e2e exclude Arming happens inside a flow run against a persisted task and a resolvable working calendar; observing it needs a seeded run and a clock, which the timer suite already provides. Covered by UserTaskNodeTest with a negative control: removing the arm call fails the binding assertion.
+
+#### Scenario: A declared SLA arms a timer bound to the task
+
+- **GIVEN** a user-task node declaring an `sla` and a `ladder`
+- **WHEN** it creates its task
+- **THEN** a timer MUST be armed with `subjectType: 'task'` and that task's uuid
+- **AND** the sla and ladder MUST reach the timer
+- **AND** the run and node MUST be recorded on it
+
+#### Scenario: A node without an SLA arms nothing
+
+- **GIVEN** a user-task node declaring no `sla`
+- **WHEN** it creates its task
+- **THEN** no timer MUST be armed
+
+#### Scenario: An unarmable SLA fails the node
+
+- **GIVEN** a node whose declared SLA cannot be armed
+- **WHEN** it creates its task
+- **THEN** the node MUST fail rather than continue without a deadline

--- a/tests/Unit/Service/Flow/UserTaskNodeTest.php
+++ b/tests/Unit/Service/Flow/UserTaskNodeTest.php
@@ -21,6 +21,8 @@ use OCA\OpenRegister\Service\Flow\FlowSuspension;
 use OCA\OpenRegister\Service\Flow\FlowTaskBridge;
 use OCA\OpenRegister\Service\Flow\Nodes\UserTaskNode;
 use OCA\OpenRegister\Service\Task\TaskForm;
+use OCA\OpenRegister\Db\FlowTimer;
+use OCA\OpenRegister\Service\Flow\Timer\FlowTimerService;
 use OCA\OpenRegister\Service\Task\TaskFormReader;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -40,6 +42,13 @@ use UnexpectedValueException;
 class UserTaskNodeTest extends TestCase {
 
 	private FlowTaskBridge&MockObject $bridge;
+
+	/**
+	 * The timer service the node arms through.
+	 *
+	 * @var FlowTimerService&MockObject
+	 */
+	private $timers;
 
 	private UserTaskNode $node;
 
@@ -62,7 +71,15 @@ class UserTaskNodeTest extends TestCase {
 		$forms = $this->createMock(TaskFormReader::class);
 		$forms->method('fromConfig')->willReturn(new TaskForm(kind: null));
 
-		$this->node = new UserTaskNode($this->bridge, $l10n, $this->createMock(IURLGenerator::class), $forms);
+		$this->timers = $this->createMock(FlowTimerService::class);
+
+		$this->node = new UserTaskNode(
+			$this->bridge,
+			$l10n,
+			$this->createMock(IURLGenerator::class),
+			$forms,
+			$this->timers
+		);
 	}//end setUp()
 
 	/**
@@ -116,6 +133,105 @@ class UserTaskNodeTest extends TestCase {
 	}//end task()
 
 	// ---- Creation and suspension ------------------------------------------
+
+	/**
+	 * 🔴 A NODE THAT DECLARES AN SLA ARMS A TIMER FOR ITS TASK.
+	 *
+	 * Nothing in the engine did this before: `FlowTimerService::arm()` had no
+	 * production caller at all, so a node could describe an SLA and no clock
+	 * ever started. The whole business-timer capability was built, tested and
+	 * unreachable.
+	 *
+	 * The binding is what matters. `FlowTimerSubjectTerminalListener` cancels
+	 * on `(subjectType: 'task', subjectUuid)`, so arming on anything else would
+	 * leave a timer nothing ever cancels — an orphan the spec calls a defect
+	 * rather than a tolerable condition.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-business-timers/specs/flow-business-timers/spec.md#requirement-a-business-timer-is-durable-subject-bound-and-cancelled-by-completion
+	 */
+	public function testADeclaredSlaArmsATimerBoundToTheTask(): void {
+		$state = new FlowResumeState();
+		$this->bridge->method('createTask')->willReturn($this->task(state: Task::STATE_ACTIVE));
+
+		$armed = null;
+		$this->timers->expects($this->once())
+			->method('arm')
+			->willReturnCallback(
+				function (array $config, ?string $actor = null, $now = null) use (&$armed) {
+					$armed = $config;
+
+					return $this->createMock(FlowTimer::class);
+				}
+			);
+
+		try {
+			$this->node->execute(
+				$this->items(),
+				$this->config(['sla' => ['value' => 5, 'unit' => 'businessDays'], 'ladder' => 'awb-standard']),
+				$this->context($state)
+			);
+		} catch (FlowSuspension $suspension) {
+			// Suspension is the normal outcome; the arming is the subject here.
+		}
+
+		$this->assertIsArray($armed, 'a declared SLA must arm a timer');
+		$this->assertSame('task', $armed['subjectType']);
+		$this->assertSame('t-1', $armed['subjectUuid'], 'the timer must bind to the task the listener cancels');
+		$this->assertSame(['value' => 5, 'unit' => 'businessDays'], $armed['sla']);
+		$this->assertSame('awb-standard', $armed['ladder'], 'the escalation ladder must reach the timer');
+		$this->assertSame('run-1', $armed['runUuid'], 'the run is recorded as provenance');
+		$this->assertSame('ask', $armed['nodeId']);
+	}//end testADeclaredSlaArmsATimerBoundToTheTask()
+
+	/**
+	 * A node WITHOUT an SLA arms nothing.
+	 *
+	 * This is what makes the change safe to add to an engine every app shares:
+	 * a flow that never mentioned a deadline behaves exactly as it did.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-business-timers/specs/flow-business-timers/spec.md
+	 */
+	public function testANodeWithoutAnSlaArmsNothing(): void {
+		$state = new FlowResumeState();
+		$this->bridge->method('createTask')->willReturn($this->task(state: Task::STATE_ACTIVE));
+
+		$this->timers->expects($this->never())->method('arm');
+
+		try {
+			$this->node->execute($this->items(), $this->config(), $this->context($state));
+		} catch (FlowSuspension $suspension) {
+			// Expected.
+		}
+	}//end testANodeWithoutAnSlaArmsNothing()
+
+	/**
+	 * An SLA that cannot be armed FAILS the node rather than losing the clock.
+	 *
+	 * A task with a declared deadline and no timer is a task whose term nobody
+	 * is measuring. For a `wettelijk` term that is a legal defect, not
+	 * something to log and carry on from — and it cannot regress an existing
+	 * flow, because a flow with no SLA never reaches this branch.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-business-timers/specs/flow-business-timers/spec.md
+	 */
+	public function testAnUnarmableSlaFailsRatherThanSilentlyLosingTheDeadline(): void {
+		$this->bridge->method('createTask')->willReturn($this->task(state: Task::STATE_ACTIVE));
+		$this->timers->method('arm')->willThrowException(new RuntimeException('calendar unresolvable'));
+
+		$this->expectException(RuntimeException::class);
+
+		$this->node->execute(
+			$this->items(),
+			$this->config(['sla' => ['value' => 5, 'unit' => 'businessDays']]),
+			$this->context(new FlowResumeState())
+		);
+	}//end testAnUnarmableSlaFailsRatherThanSilentlyLosingTheDeadline()
 
 	/**
 	 * The first firing creates exactly one task, stamped with run and node,

--- a/tests/Unit/Service/Flow/UserTaskNodeTest.php
+++ b/tests/Unit/Service/Flow/UserTaskNodeTest.php
@@ -185,6 +185,55 @@ class UserTaskNodeTest extends TestCase {
 		$this->assertSame('ask', $armed['nodeId']);
 	}//end testADeclaredSlaArmsATimerBoundToTheTask()
 
+
+	/**
+	 * A node may carry a deadline without carrying a title.
+	 *
+	 * `title` is optional on a user task, and an empty one must reach the timer
+	 * as null rather than as an empty string: the timer renders it in the
+	 * escalation notice, where '' produces a blank subject line while null lets
+	 * the timer fall back to describing its subject.
+	 *
+	 * This case is also the only one that executes the `$title = null` branch.
+	 * Every other test in this class builds its config through the helper,
+	 * which always supplies a title, so without this test that branch is dead
+	 * on the coverage report and nothing would notice if it stopped working.
+	 *
+	 * @return void
+	 */
+	public function testATitlelessNodeArmsItsTimerWithNoTitle(): void {
+		$state = new FlowResumeState();
+		$this->bridge->method('createTask')->willReturn($this->task(state: Task::STATE_ACTIVE));
+
+		$armed = null;
+		$this->timers->expects($this->once())
+			->method('arm')
+			->willReturnCallback(
+				function (array $config, ?string $actor = null, $now = null) use (&$armed) {
+					$armed = $config;
+
+					return $this->createMock(FlowTimer::class);
+				}
+			);
+
+		try {
+			$this->node->execute(
+				$this->items(),
+				// Whitespace, not a missing key: a title of spaces is still no
+				// title, and trim() is what makes the two the same.
+				['title' => '   ', 'assignee' => 'alice', 'sla' => ['value' => 2, 'unit' => 'businessDays']],
+				$this->context($state)
+			);
+		} catch (FlowSuspension $suspension) {
+			// Suspension is the normal outcome; the arming is the subject here.
+		}
+
+		$this->assertIsArray($armed, 'a declared SLA must arm a timer even with no title');
+		$this->assertNull($armed['title'], 'an empty title must reach the timer as null, not as an empty string');
+		$this->assertSame('task', $armed['subjectType']);
+		$this->assertSame(['value' => 2, 'unit' => 'businessDays'], $armed['sla']);
+	}//end testATitlelessNodeArmsItsTimerWithNoTitle()
+
 	/**
 	 * A node WITHOUT an SLA arms nothing.
 	 *


### PR DESCRIPTION
The business-timer capability had no production caller. `FlowTimerService::arm()` was referenced only from its own unit test, and nothing resolved it from the container at runtime. The escalation ladders, the working calendar and the SLA calculator were built, tested and unreachable: a flow author could describe a deadline and nothing would ever measure it.

## What changed

`UserTaskNode` arms a timer when it creates its task, bound to `subjectType: task` and the task uuid. That is the same pair `FlowTimerSubjectTerminalListener` already cancels on, so completing or cancelling the task disarms its deadline rather than leaving a timer firing against a subject that is finished. The node also declares `sla`, `calendar`, `ladder`, `escalationRules`, `purpose`, `legalEffect` and `onExpiry` as config keys, so an author can express the deadline where the task is defined.

## Three properties, because they are what makes this safe in a shared engine

**A node with no `sla` arms nothing.** A flow that never mentioned a deadline behaves exactly as it did before. All 36 pre-existing `UserTaskNode` tests pass untouched.

**An SLA that cannot be armed fails the node**, rather than logging and continuing. A task carrying a declared deadline that nothing is measuring is worse than a task with no deadline at all, because the flow then reports a term it is not keeping. For a `wettelijk` deadline that is a legal defect, not a logging concern. No existing flow can reach this branch, since none of them set an SLA.

**Only keys the author actually set are forwarded.** `arm()` has its own defaults for `purpose`, `legalEffect` and `onExpiry`; passing nulls through would silently replace them.

## Verification

- Full suite: **19045 tests, 46386 assertions, exit 0**. The 3 risky tests are pre-existing in `TextExtractionServiceTest` and untouched here.
- Negative control: removing the arm call fails `testADeclaredSlaArmsATimerBoundToTheTask`. The test can distinguish the fix from its absence.
- Circular DI ruled out by reading the graph, not by the tests passing: `FlowTimerService` -> `TaskService` never reaches a flow node or the node registry. The node is container-resolved, so a cycle would surface at runtime rather than in a unit test that constructs it by hand.
- Three new tests cover the armed case, the no-SLA case, and the unarmable case.

Spec: a twelfth requirement in `openspec/changes/flow-business-timers/specs/flow-business-timers/spec.md`.

## Why it matters downstream

dossiq retired its own `workflowTemplate` engine onto OpenRegister flows. Step-level SLAs were the one thing the projection could not carry, because the target had no way to arm them. With this in place the projection can express deadlines, and `workflowTemplate` can eventually retire rather than living on as the only place a term can be written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)