### PR TITLE
feat(tasks): find the newest sequence for a template, across every anchor

### DIFF
--- a/lib/Db/TaskSequenceMapper.php
+++ b/lib/Db/TaskSequenceMapper.php
@@ -99,6 +99,43 @@ class TaskSequenceMapper extends QBMapper {
 	}//end findRunning()
 
 	/**
+	 * The newest sequence opened from a template, across EVERY anchor.
+	 *
+	 * The other finders here answer "what happened to THIS object". This one
+	 * answers "has this approval ever run", which is what a designer surface
+	 * needs to report a template's last outcome without knowing an object to
+	 * ask about.
+	 *
+	 * buildiq's automation dry-run panel is the caller: it used to read the
+	 * newest ApprovalStep on the chain, and when #3302 retired that surface the
+	 * per-anchor finders could not replace it — an aggregate over the template
+	 * has no anchor to pass. Without this the panel degraded to reporting
+	 * nothing at all (buildiq#651).
+	 *
+	 * Indexed by `template_id` and ordered like its siblings, so it is one row
+	 * off the same index rather than a scan.
+	 *
+	 * @param string $templateId The compiled template id.
+	 *
+	 * @return TaskSequence|null The newest sequence for the template, or null when none has run.
+	 *
+	 * @spec openspec/changes/flow-approval-consolidation/specs/flow-approval-consolidation/spec.md#requirement-an-approval-is-an-ordered-task-sequence-with-o
+	 */
+	public function findNewestForTemplate(string $templateId): ?TaskSequence {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('template_id', $qb->createNamedParameter($templateId)))
+			->orderBy('opened_at', 'DESC')
+			->addOrderBy('id', 'DESC')
+			->setMaxResults(1);
+
+		$rows = $this->findEntities(query: $qb);
+
+		return ($rows[0] ?? null);
+	}//end findNewestForTemplate()
+
+	/**
 	 * Every sequence for an anchor and template, newest first.
 	 *
 	 * A rejected cycle stays readable here after a resubmission opened a new

--- a/tests/Unit/Db/TaskSequenceMapperQueriesTest.php
+++ b/tests/Unit/Db/TaskSequenceMapperQueriesTest.php
@@ -76,6 +76,32 @@ class TaskSequenceMapperQueriesTest extends TestCase {
 		self::assertNotSame([], $orderings, 'history must be explicitly ordered, never id-lucky');
 	}//end testFindNewestForAnchorOrdersByOpenTimeDescending()
 
+	public function testFindNewestForTemplateDoesNotFilterOnAnAnchor(): void {
+		$mapper = new TaskSequenceMapper(db: $this->connectionWith(rows: [$this->row('seq-9', 'rejected')]));
+
+		$newest = $mapper->findNewestForTemplate(templateId: 'tpl-1');
+
+		self::assertSame('seq-9', $newest->getUuid());
+
+		// The whole point of this finder: it aggregates ACROSS anchors, so an
+		// anchor predicate would silently answer a different question than the
+		// caller asked. Its siblings all constrain the anchor; this one must not.
+		$predicates = array_filter($this->calls, static fn (array $call): bool => $call[0] === 'expr.eq');
+		$columns = array_map(static fn (array $call): mixed => $call[1], $predicates);
+		self::assertContains('template_id', $columns);
+		self::assertNotContains('anchor_object_uuid', $columns, 'a template-wide finder must not constrain the anchor');
+
+		// One row off the index, not a scan the caller trims.
+		$limits = array_filter($this->calls, static fn (array $call): bool => $call[0] === 'setMaxResults');
+		self::assertNotSame([], $limits, 'the newest row must be taken by the query, not in PHP');
+	}//end testFindNewestForTemplateDoesNotFilterOnAnAnchor()
+
+	public function testFindNewestForTemplateWithNoRunIsNull(): void {
+		$mapper = new TaskSequenceMapper(db: $this->connectionWith(rows: []));
+
+		self::assertNull($mapper->findNewestForTemplate(templateId: 'tpl-1'));
+	}//end testFindNewestForTemplateWithNoRunIsNull()
+
 	public function testATerminalStatusReadsAsTerminal(): void {
 		$sequence = new TaskSequence();
 		$sequence->setStatus(TaskSequence::STATUS_REJECTED);


### PR DESCRIPTION
The mapper could answer *"what happened to THIS object"* three ways and *"has this approval ever run"* not at all. `findRunning`, `findForAnchor` and `findNewestForAnchor` all constrain `anchor_object_uuid`, so an aggregate over a template had no anchor to pass.

`findNewestForTemplate($templateId)` fills that gap: one row off the existing `template_id` index, ordered like its siblings, limited in the query rather than trimmed in PHP.

## Who needs it

buildiq's automation dry-run panel. It used to report the newest `ApprovalStep` status on a chain; when #3302 retired that surface there was no replacement for the aggregate, and the panel degraded to reporting nothing at all — tracked as the last open item on ConductionNL/buildiq#651. This is the query that lets it come back.

## Verified with a negative control

Not just a green run. Adding an anchor predicate and dropping the limit makes the new test fail:

```
Failed asserting that an array does not contain 'anchor_object_uuid'.
Tests: 7, Assertions: 15, Failures: 1
```

That is the assertion that matters here — a template-wide finder which quietly constrained the anchor would answer a different question than the caller asked, and would do it silently. The second test covers the no-run case returning null.

phpcs clean (1 pre-existing warning, unchanged), phpstan `[OK] No errors`, and the suite passes: `Tests: 7, Assertions: 16`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
