### PR TITLE
feat(apphost): host the store, so an app declares one instead of writing one

### DIFF
--- a/lib/AppHost/Bootstrap.php
+++ b/lib/AppHost/Bootstrap.php
@@ -121,6 +121,9 @@ class Bootstrap {
 	private const GENERIC_SETTINGS_CONTROLLER = 'OCA\\OpenRegister\\AppHost\\Controller\\GenericSettingsController';
 	private const GENERIC_HEALTH_CONTROLLER = 'OCA\\OpenRegister\\AppHost\\Controller\\GenericHealthController';
 	private const GENERIC_METRICS_CONTROLLER = 'OCA\\OpenRegister\\AppHost\\Controller\\GenericMetricsController';
+	private const GENERIC_STORE_CONTROLLER = 'OCA\\OpenRegister\\AppHost\\Controller\\GenericStoreController';
+	private const GENERIC_STORE_SERVICE = 'OCA\\OpenRegister\\AppHost\\Service\\GenericStoreService';
+	private const GENERIC_STORE_INSTALLER = 'OCA\\OpenRegister\\AppHost\\Store\\GenericStoreInstaller';
 	private const GENERIC_SETTINGS_SERVICE = 'OCA\\OpenRegister\\AppHost\\Service\\AppHostSettingsService';
 	private const GENERIC_ACTION_AUTH_SERVICE = 'OCA\\OpenRegister\\AppHost\\Service\\GenericActionAuthService';
 	private const GENERIC_INITIALIZE_SETTINGS = 'OCA\\OpenRegister\\AppHost\\Repair\\GenericInitializeSettings';
@@ -266,6 +269,29 @@ class Bootstrap {
 					appName: $appId,
 					request: $c->get('OCP\\IRequest'),
 					settingsService: $c->get(self::GENERIC_SETTINGS_SERVICE)
+				);
+			}
+		);
+
+		// Store plane (ADR-080, ADR-114 Decision 4). `unlessLeafDefinesIt` is
+		// what makes this a migration rather than a flag day: dossiq ships its
+		// own Controller\StoreController today and keeps winning this alias
+		// until that class is deleted, so the engine's version takes over per
+		// app, on that app's own pull request.
+		self::aliasControllerUnlessLeafDefinesIt(
+			context: $context,
+			leafClass: $controllerNs . '\\StoreController',
+			factory: static function (ContainerInterface $c) use ($appId) {
+				$class = self::GENERIC_STORE_CONTROLLER;
+				return new $class(
+					appName: $appId,
+					request: $c->get('OCP\\IRequest'),
+					manifestLoader: $c->get(self::OBSERVABILITY_MANIFEST_LOADER),
+					storeService: $c->get(self::GENERIC_STORE_SERVICE),
+					installer: $c->get(self::GENERIC_STORE_INSTALLER),
+					userSession: $c->get('OCP\\IUserSession'),
+					groupManager: $c->get('OCP\\IGroupManager'),
+					logger: $c->get('Psr\\Log\\LoggerInterface')
 				);
 			}
 		);

--- a/lib/AppHost/Controller/GenericStoreController.php
+++ b/lib/AppHost/Controller/GenericStoreController.php
@@ -1,0 +1,273 @@
+<?php
+
+/**
+ * OpenRegister AppHost — Generic Store Controller
+ *
+ * Engine-owned store endpoints. A leaf app aliases `/api/store/items` and
+ * `/api/store/items/{slug}/install` at this controller and writes no store
+ * code of its own: what its store IS gets declared as the `store` block of its
+ * `src/manifest.json` (see StoreManifest).
+ *
+ * ADR-080 SPLIT DISCOVERY FROM INSTALL AND KEPT INSTALL PER APP. Ruben decided
+ * on 2026-09-03 that the store should be provided by OpenRegister without a
+ * backend per app, which amends Decision 3 of that ADR. Two things make that
+ * safe rather than a re-run of what D3 rejected:
+ *
+ *   - D3's three worked failures are all about a cross-app `extends`, resolved
+ *     by the AUTOLOADER rather than the container. This uses none: the leaf app
+ *     aliases a route at a controller the engine owns, exactly as it already
+ *     does for GenericHealth and GenericMetrics.
+ *   - D3's other reason, that install semantics differ per app, is answered by
+ *     making the difference DATA. The only thing that actually varied was which
+ *     schemas an install may write.
+ *
+ * Auth posture is owned HERE and a leaf app cannot drift it through its
+ * manifest: search is login-required, install is admin-only.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\AppHost\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\AppHost\Controller;
+
+use OCA\OpenRegister\AppHost\Observability\ManifestLoader;
+use OCA\OpenRegister\AppHost\Service\GenericStoreService;
+use OCA\OpenRegister\AppHost\Service\StoreDescriptor;
+use OCA\OpenRegister\AppHost\Store\GenericStoreInstaller;
+use OCA\OpenRegister\AppHost\Store\StoreManifest;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Declarative store search and install for AppHost-adopting apps.
+ *
+ * @psalm-suppress UnusedClass
+ *
+ * @spec openspec/specs/apphost-store-plane/spec.md#requirement-a-leaf-app-must-declare-its-store-rather-than-implement-one
+ */
+class GenericStoreController extends Controller {
+	/**
+	 * Kebab-case slug pattern for a remote store item. Bounds what reaches the
+	 * registry URL and the install path.
+	 */
+	private const SLUG_PATTERN = '/^[a-z0-9][a-z0-9-]*[a-z0-9]$/';
+
+	/**
+	 * Constructor.
+	 *
+	 * `$appName` is the CALLING leaf app id, set by that app's alias
+	 * registration, which is what lets one controller serve every app.
+	 *
+	 * @param string                $appName        Calling leaf app id.
+	 * @param IRequest              $request        HTTP request.
+	 * @param ManifestLoader        $manifestLoader Loads the leaf app's manifest.
+	 * @param GenericStoreService   $storeService   Guarded remote discovery.
+	 * @param GenericStoreInstaller $installer      Declarative component install.
+	 * @param IUserSession          $userSession    Current session.
+	 * @param IGroupManager         $groupManager   Admin check for install.
+	 * @param LoggerInterface       $logger         PSR logger.
+	 */
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private readonly ManifestLoader $manifestLoader,
+		private readonly GenericStoreService $storeService,
+		private readonly GenericStoreInstaller $installer,
+		private readonly IUserSession $userSession,
+		private readonly IGroupManager $groupManager,
+		private readonly LoggerInterface $logger,
+	) {
+		parent::__construct(appName: $appName, request: $request);
+	}//end __construct()
+
+	/**
+	 * Search the remote store.
+	 *
+	 * Login-required through an in-body guard so an anonymous caller gets an
+	 * explicit 401 rather than a login redirect. Returns normalised cards and a
+	 * generic outcome, NEVER the registry URL or token.
+	 *
+	 * With no registry configured the engine answers `not_configured` WITHOUT
+	 * making a network call, which is what lets the page fall back to the app's
+	 * built-in items (ADR-080 Decision 4).
+	 *
+	 * @return JSONResponse 200 with `{outcome, cards}`; 401 for anonymous.
+	 *
+	 * @no-admin-idor-exempt Addresses no object of this app. The query and kind
+	 *   filter are forwarded to an EXTERNAL registry, so there is nothing of
+	 *   another tenant's to reach by guessing an identifier.
+	 *
+	 * @spec openspec/specs/apphost-store-plane/spec.md#requirement-a-leaf-app-must-declare-its-store-rather-than-implement-one
+	 */
+	#[NoAdminRequired]
+	public function search(): JSONResponse {
+		if ($this->userSession->getUser() === null) {
+			return new JSONResponse(
+				data: ['outcome' => 'unauthenticated', 'cards' => []],
+				statusCode: Http::STATUS_UNAUTHORIZED
+			);
+		}
+
+		$store = $this->store();
+		if ($store->enabled === false) {
+			// The app aliased the route but declared no `store` block. Report
+			// not_configured rather than 404: the page then renders its
+			// (empty) built-in list instead of reading as a broken endpoint.
+			return new JSONResponse(
+				data: ['outcome' => GenericStoreService::OUTCOME_NOT_CONFIGURED, 'cards' => []],
+				statusCode: Http::STATUS_OK
+			);
+		}
+
+		$query = $this->request->getParam('q');
+		if (is_string($query) === false) {
+			$query = null;
+		}
+
+		$kind = $this->request->getParam('kind');
+		if (is_string($kind) === false) {
+			$kind = null;
+		}
+
+		try {
+			$result = $this->storeService->search(
+				descriptor: $this->descriptor(store: $store),
+				query: $query,
+				kind: $kind
+			);
+		} catch (Throwable $e) {
+			// Detail to the log, generic outcome to the browser: a registry's
+			// internals are not the caller's business.
+			$this->logger->error(
+				message: sprintf('[AppHost\\Store] search failed for %s: %s', $this->appName, $e->getMessage()),
+				context: ['file' => __FILE__, 'line' => __LINE__]
+			);
+			return new JSONResponse(
+				data: ['outcome' => GenericStoreService::OUTCOME_UNREACHABLE, 'cards' => []],
+				statusCode: Http::STATUS_OK
+			);
+		}
+
+		return new JSONResponse(
+			data: ['outcome' => $result['outcome'], 'cards' => $result['cards']],
+			statusCode: Http::STATUS_OK
+		);
+	}//end search()
+
+	/**
+	 * Install one store item into this instance.
+	 *
+	 * Administrative: the components written are the shape of the work every
+	 * handler then operates against.
+	 *
+	 * The write runs as the calling administrator and NOT through
+	 * `runAsSystem()`. That elevation is for operations whose inputs originate
+	 * from code or the app's own seed data; a store payload is neither, it
+	 * comes off the network.
+	 *
+	 * @param string $slug The remote item slug.
+	 *
+	 * @return JSONResponse 200 with a per-component report; 400 bad slug; 403 non-admin; 404 unresolved.
+	 *
+	 * @spec openspec/specs/apphost-store-plane/spec.md#requirement-an-install-must-refuse-every-schema-the-manifest-does-not-allow
+	 */
+	#[NoAdminRequired]
+	public function install(string $slug): JSONResponse {
+		// The admin check is an in-body guard rather than
+		// #[AuthorizedAdminSetting], because that attribute names a leaf app's
+		// settings CLASS and this controller serves every app. Same posture,
+		// resolved at request time instead of at annotation time.
+		$user = $this->userSession->getUser();
+		if ($user === null || $this->groupManager->isAdmin($user->getUID()) === false) {
+			return new JSONResponse(
+				data: ['success' => false, 'message' => 'Installing a store item requires an administrator.'],
+				statusCode: Http::STATUS_FORBIDDEN
+			);
+		}
+
+		if (preg_match(self::SLUG_PATTERN, $slug) !== 1) {
+			return new JSONResponse(
+				data: ['success' => false, 'message' => 'Malformed item slug.'],
+				statusCode: Http::STATUS_BAD_REQUEST
+			);
+		}
+
+		$store = $this->store();
+		if ($store->enabled === false) {
+			return new JSONResponse(
+				data: ['success' => false, 'message' => 'This app declares no store.'],
+				statusCode: Http::STATUS_NOT_FOUND
+			);
+		}
+
+		try {
+			$item = $this->storeService->resolve(descriptor: $this->descriptor(store: $store), slug: $slug);
+		} catch (Throwable $e) {
+			$this->logger->error(
+				message: sprintf('[AppHost\\Store] resolve failed for %s: %s', $this->appName, $e->getMessage()),
+				context: ['file' => __FILE__, 'line' => __LINE__]
+			);
+			$item = null;
+		}
+
+		if ($item === null) {
+			return new JSONResponse(
+				data: ['success' => false, 'message' => 'The store item could not be resolved.'],
+				statusCode: Http::STATUS_NOT_FOUND
+			);
+		}
+
+		return new JSONResponse(
+			data: $this->installer->install(store: $store, item: $item),
+			statusCode: Http::STATUS_OK
+		);
+	}//end install()
+
+	/**
+	 * The calling app's declared store configuration.
+	 *
+	 * @return StoreManifest
+	 */
+	private function store(): StoreManifest {
+		return $this->manifestLoader->loadStore(appId: $this->appName);
+	}//end store()
+
+	/**
+	 * Build the discovery descriptor from the declared block.
+	 *
+	 * The registry URL and token stay in the CALLING app's IAppConfig, so each
+	 * app connects its own registry and one app's token never reaches another.
+	 *
+	 * @param StoreManifest $store The declared store config.
+	 *
+	 * @return StoreDescriptor
+	 */
+	private function descriptor(StoreManifest $store): StoreDescriptor {
+		return new StoreDescriptor(
+			appId: $this->appName,
+			schema: $store->schema,
+			defaultRegister: $store->register,
+			cardFields: $store->cardFields
+		);
+	}//end descriptor()
+}//end class

--- a/lib/AppHost/Controller/GenericStoreController.php
+++ b/lib/AppHost/Controller/GenericStoreController.php
@@ -134,7 +134,7 @@ class GenericStoreController extends Controller {
 			// not_configured rather than 404: the page then renders its
 			// (empty) built-in list instead of reading as a broken endpoint.
 			return new JSONResponse(
-				data: ['outcome' => GenericStoreService::OUTCOME_NOT_CONFIGURED, 'cards' => []],
+				data: ['outcome' => GenericStoreService::OUTCOME_NOT_CONFIGURED, 'cards' => [], 'kinds' => []],
 				statusCode: Http::STATUS_OK
 			);
 		}
@@ -163,13 +163,20 @@ class GenericStoreController extends Controller {
 				context: ['file' => __FILE__, 'line' => __LINE__]
 			);
 			return new JSONResponse(
-				data: ['outcome' => GenericStoreService::OUTCOME_UNREACHABLE, 'cards' => []],
+				data: ['outcome' => GenericStoreService::OUTCOME_UNREACHABLE, 'cards' => [], 'kinds' => $store->kinds],
 				statusCode: Http::STATUS_OK
 			);
 		}
 
+		// `kinds` rides back with the cards so the page can offer the filters the
+		// APP declared, rather than a copy kept in its page config. Empty when
+		// the app names none, and the page falls back to the shared vocabulary.
 		return new JSONResponse(
-			data: ['outcome' => $result['outcome'], 'cards' => $result['cards']],
+			data: [
+				'outcome' => $result['outcome'],
+				'cards' => $result['cards'],
+				'kinds' => $store->kinds,
+			],
 			statusCode: Http::STATUS_OK
 		);
 	}//end search()

--- a/lib/AppHost/Observability/ManifestLoader.php
+++ b/lib/AppHost/Observability/ManifestLoader.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\AppHost\Observability;
 
+use OCA\OpenRegister\AppHost\Store\StoreManifest;
 use OCP\App\IAppManager;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -71,6 +72,32 @@ class ManifestLoader {
 
 		return ObservabilityManifest::fromManifest(appId: $appId, manifest: $manifest);
 	}//end load()
+
+	/**
+	 * Load the declarative `store` block for an app id.
+	 *
+	 * Reuses the same bundled-manifest read as `load()`, so there is exactly
+	 * one place that knows where a leaf app's manifest lives. A missing or
+	 * unreadable manifest yields a DISABLED store rather than a defaulted one:
+	 * the word Store promises a registry (ADR-080 Decision 4) and the engine
+	 * must not promise it on an app's behalf.
+	 *
+	 * @param string $appId The calling app's id.
+	 *
+	 * @return StoreManifest
+	 *
+	 * @SuppressWarnings(PHPMD.StaticAccess)
+	 *
+	 * @spec openspec/specs/apphost-store-plane/spec.md#requirement-a-leaf-app-must-declare-its-store-rather-than-implement-one
+	 */
+	public function loadStore(string $appId): StoreManifest {
+		$manifest = $this->loadBundledManifest(appId: $appId);
+		if ($manifest === null) {
+			return new StoreManifest(appId: $appId, enabled: false);
+		}
+
+		return StoreManifest::fromManifest(appId: $appId, manifest: $manifest);
+	}//end loadStore()
 
 	/**
 	 * Resolve the installed version of an app (for the implicit `{app}_info`).

--- a/lib/AppHost/Routes.php
+++ b/lib/AppHost/Routes.php
@@ -151,6 +151,25 @@ class Routes {
 			// Observability (ADR-006 / ADR-040).
 			['name' => 'metrics#index', 'url' => '/api/metrics', 'verb' => 'GET'],
 			['name' => 'health#index', 'url' => '/api/health', 'verb' => 'GET'],
+
+			// Store plane (ADR-080, ADR-114 Decision 4). Declaring these here
+			// is only HALF the wiring: `Bootstrap::register()` must also alias
+			// the leaf app's `Controller\StoreController` at the engine's
+			// GenericStoreController, or the router resolves a class that does
+			// not exist and every store request 500s at dispatch time.
+			//
+			// An app that declares no `store` block in its manifest still gets
+			// these routes, and the controller answers `not_configured` for
+			// them. That is deliberate: a route table that varies per app by
+			// manifest content would make the SPA catch-all's position depend
+			// on configuration, and the catch-all's position is load-bearing.
+			['name' => 'store#search', 'url' => '/api/store/items', 'verb' => 'GET'],
+			[
+				'name' => 'store#install',
+				'url' => '/api/store/items/{slug}/install',
+				'verb' => 'POST',
+				'requirements' => ['slug' => '[a-z0-9][a-z0-9-]*[a-z0-9]'],
+			],
 		];
 	}//end canonicalRoutes()
 

--- a/lib/AppHost/Store/GenericStoreInstaller.php
+++ b/lib/AppHost/Store/GenericStoreInstaller.php
@@ -1,0 +1,197 @@
+<?php
+
+/**
+ * OpenRegister AppHost — Generic Store Installer
+ *
+ * Writes the components a resolved store item declares into the calling app's
+ * register, refusing every schema its manifest does not allow.
+ *
+ * WHY THIS IS GENERIC AT ALL, GIVEN ADR-080 DECISION 3.
+ * ------------------------------------------------------
+ * That decision said install "does not generalise and SHALL NOT be pushed into
+ * AppHost", because cloning an application template, enabling a connector
+ * adapter and instantiating an agent template are different operations. Its
+ * three worked examples of what went wrong are all about a cross-app
+ * controller BASE CLASS: `extends` is resolved by the autoloader rather than
+ * the container, so an absent OpenRegister 500s every route in the consuming
+ * app, leaf tests cannot load the subclass, and phpstan refuses "extends
+ * unknown class".
+ *
+ * None of that applies here. This is a service the engine owns, reached
+ * through a route the leaf app ALIASES (the same mechanism GenericHealth and
+ * GenericMetrics already use), with no inheritance anywhere.
+ *
+ * The other half of D3 — that the semantics genuinely differ — is answered by
+ * making them DATA. What actually differs between apps is which schemas an
+ * install may write; the operation itself was identical in every
+ * implementation: refuse what the allowlist does not name, strip the remote
+ * identity so the write CREATES, save, and report per component.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Store
+ * @package  OCA\OpenRegister\AppHost\Store
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\AppHost\Store;
+
+use OCA\OpenRegister\Service\ObjectService;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Declarative install of a store item's components.
+ *
+ * @spec openspec/specs/apphost-store-plane/spec.md#requirement-an-install-must-refuse-every-schema-the-manifest-does-not-allow
+ * @spec openspec/specs/apphost-store-plane/spec.md#requirement-an-install-must-create-a-new-object-never-replace-one
+ */
+class GenericStoreInstaller {
+	/**
+	 * Constructor.
+	 *
+	 * @param ObjectService   $objectService The OpenRegister write path.
+	 * @param LoggerInterface $logger        PSR logger, server-side detail only.
+	 */
+	public function __construct(
+		private readonly ObjectService $objectService,
+		private readonly LoggerInterface $logger,
+	) {
+	}//end __construct()
+
+	/**
+	 * Install every allowed component and report every refused one.
+	 *
+	 * A refusal does NOT abort the install. The remaining components still
+	 * arrive and the report names what did not: an item that is half
+	 * configuration and half records is the registry's mistake, not a reason to
+	 * deny an administrator the half they may have.
+	 *
+	 * @param StoreManifest        $store The calling app's declared store config.
+	 * @param array<string, mixed> $item  The resolved remote item.
+	 *
+	 * @return array{success: bool, components: array<int, array<string, string>>}
+	 *
+	 * @spec openspec/specs/apphost-store-plane/spec.md#requirement-an-install-must-refuse-every-schema-the-manifest-does-not-allow
+	 */
+	public function install(StoreManifest $store, array $item): array {
+		$report = [];
+		$failed = false;
+
+		foreach ($this->components(item: $item) as $component) {
+			$slug = (string)($component['schema'] ?? '');
+			$object = ($component['object'] ?? null);
+
+			if ($store->isInstallable(slug: $slug) === false) {
+				$failed = true;
+				$report[] = [
+					'schema' => $slug,
+					'status' => 'refused',
+					'message' => 'This app does not allow the store to write into that schema.',
+				];
+				continue;
+			}
+
+			if (is_array($object) === false) {
+				$failed = true;
+				$report[] = [
+					'schema' => $slug,
+					'status' => 'refused',
+					'message' => 'The component declares no object to install.',
+				];
+				continue;
+			}
+
+			try {
+				$this->objectService->saveObject(
+					object: $this->asNewObject(object: $object),
+					register: $store->localRegister,
+					schema: $slug
+				);
+				$report[] = ['schema' => $slug, 'status' => 'installed', 'message' => ''];
+			} catch (Throwable $e) {
+				$failed = true;
+				$this->logger->error(
+					message: sprintf(
+						'[AppHost\\Store] installing %s for %s failed: %s',
+						$slug,
+						$store->appId,
+						$e->getMessage()
+					),
+					context: ['file' => __FILE__, 'line' => __LINE__]
+				);
+				$report[] = [
+					'schema' => $slug,
+					'status' => 'error',
+					'message' => 'The component could not be written.',
+				];
+			}
+		}
+
+		return ['success' => ($failed === false && $report !== []), 'components' => $report];
+	}//end install()
+
+	/**
+	 * Read the components a resolved item declares.
+	 *
+	 * A registry may ship the list as a JSON string rather than an array, the
+	 * same way a workflow template stores its steps.
+	 *
+	 * @param array<string, mixed> $item The resolved remote object.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function components(array $item): array {
+		$components = ($item['components'] ?? null);
+		if (is_string($components) === true) {
+			$components = json_decode($components, associative: true);
+		}
+
+		if (is_array($components) === false) {
+			return [];
+		}
+
+		return array_values(array_filter($components, static fn ($c): bool => is_array($c) === true));
+	}//end components()
+
+	/**
+	 * Strip every identity the remote payload carries, so an install CREATES.
+	 *
+	 * 🔴 WITHOUT THIS, "INSTALL" IS AN OVERWRITE PRIMITIVE.
+	 *
+	 * `ObjectService::saveObject()` resolves the object it is writing FROM the
+	 * payload: `extractUuidAndNormalizeObject()` reads
+	 * `$object['@self']['id'] ?? $object['id']` and treats a match as the uuid
+	 * to UPDATE. So a store item whose component carried the uuid of this
+	 * instance's live configuration would replace it rather than add one, and
+	 * the write is PUT-semantic, so keys the payload omits are nulled rather
+	 * than left alone. The object would not merely change, it would be gutted.
+	 *
+	 * The schema allowlist does not cover this. It governs WHICH schema a
+	 * component may write, never whether the write creates or replaces, so an
+	 * entirely legitimate component is the attack.
+	 *
+	 * Identity is not a remote registry's to supply. An installed item is a NEW
+	 * local object, and if install ever needs to be idempotent it must key on
+	 * something the app controls rather than on a remote id.
+	 *
+	 * @param array<string, mixed> $object The component's object.
+	 *
+	 * @return array<string, mixed> The object with every identity key removed.
+	 */
+	private function asNewObject(array $object): array {
+		unset($object['id'], $object['uuid'], $object['@self']);
+
+		return $object;
+	}//end asNewObject()
+}//end class

--- a/lib/AppHost/Store/StoreManifest.php
+++ b/lib/AppHost/Store/StoreManifest.php
@@ -72,6 +72,7 @@ class StoreManifest {
 	 * @param string                     $register      Default remote register slug.
 	 * @param string                     $localRegister Local register an install writes into.
 	 * @param array<int, string>         $installable Schema slugs an install may write.
+	 * @param array<int, string>         $kinds       Kind quick-filters offered on the page.
 	 * @param array<string, string>      $cardFields  Remote field to card field map.
 	 * @param array<int, array<string, mixed>> $builtIn The app's own items, for the no-registry case.
 	 */
@@ -82,6 +83,7 @@ class StoreManifest {
 		public readonly string $register = '',
 		public readonly string $localRegister = '',
 		public readonly array $installable = [],
+		public readonly array $kinds = [],
 		public readonly array $cardFields = self::DEFAULT_CARD_FIELDS,
 		public readonly array $builtIn = [],
 	) {
@@ -126,6 +128,11 @@ class StoreManifest {
 			// slug differs from its app id says so here.
 			localRegister: (string)($block['localRegister'] ?? $appId),
 			installable: self::stringList(value: ($block['installable'] ?? [])),
+			// Declared ONCE, beside the allowlist, and served to the page in the
+			// search response. An app that names its kinds here and nowhere else
+			// must get them: a schema key nothing reads is the silent-no-op this
+			// whole plane is built to avoid.
+			kinds: self::stringList(value: ($block['kinds'] ?? [])),
 			cardFields: array_map(callback: static fn ($v): string => (string)$v, array: $cardFields),
 			builtIn: self::objectList(value: ($block['builtIn'] ?? [])),
 		);

--- a/lib/AppHost/Store/StoreManifest.php
+++ b/lib/AppHost/Store/StoreManifest.php
@@ -1,0 +1,183 @@
+<?php
+
+/**
+ * OpenRegister AppHost — Store Manifest
+ *
+ * The `store` block of a leaf app's `src/manifest.json`, parsed into a value
+ * object. This is what makes a store surface DATA rather than code: an
+ * adopting app declares which remote schema its registry serves, which of its
+ * own schemas an install may write, and which items it ships itself. It writes
+ * no controller.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Store
+ * @package  OCA\OpenRegister\AppHost\Store
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\AppHost\Store;
+
+/**
+ * A leaf app's declarative store configuration.
+ *
+ * 🔴 `installable` IS A SECURITY BOUNDARY, NOT A CONVENIENCE.
+ *
+ * It is the allowlist of schema slugs a store item may write into this
+ * instance. A registry is somebody else's server: without the allowlist, an
+ * item could declare a component naming ANY schema the app owns and have it
+ * written. dossiq's hand-written version of this refused every record schema
+ * and permitted only case CONFIGURATION, which is the shape every app wants.
+ *
+ * An EMPTY allowlist therefore means "install nothing", never "install
+ * anything". `isInstallable()` returns false for every slug when the list is
+ * empty, so an app that declares a store and forgets the allowlist gets a
+ * browsable store whose installs are all refused, rather than an open door.
+ *
+ * @spec openspec/specs/apphost-store-plane/spec.md#requirement-a-leaf-app-must-declare-its-store-rather-than-implement-one
+ */
+class StoreManifest {
+	/**
+	 * Card fields used when an app declares none. These are the field names
+	 * the fleet's registries already publish (ADR-080 Decision 5).
+	 *
+	 * @var array<string, string>
+	 */
+	public const DEFAULT_CARD_FIELDS = [
+		'slug' => 'slug',
+		'title' => 'title',
+		'description' => 'description',
+		'kind' => 'kind',
+		'category' => 'category',
+		'version' => 'version',
+		'publisher' => 'publisher',
+	];
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string                     $appId       The calling leaf app id.
+	 * @param bool                       $enabled     Whether the app declared a store block at all.
+	 * @param string                     $schema      Remote schema slug the registry serves.
+	 * @param string                     $register      Default remote register slug.
+	 * @param string                     $localRegister Local register an install writes into.
+	 * @param array<int, string>         $installable Schema slugs an install may write.
+	 * @param array<string, string>      $cardFields  Remote field to card field map.
+	 * @param array<int, array<string, mixed>> $builtIn The app's own items, for the no-registry case.
+	 */
+	public function __construct(
+		public readonly string $appId,
+		public readonly bool $enabled,
+		public readonly string $schema = '',
+		public readonly string $register = '',
+		public readonly string $localRegister = '',
+		public readonly array $installable = [],
+		public readonly array $cardFields = self::DEFAULT_CARD_FIELDS,
+		public readonly array $builtIn = [],
+	) {
+	}//end __construct()
+
+	/**
+	 * Parse the `store` block out of a leaf app's manifest.
+	 *
+	 * An absent or malformed block yields a DISABLED manifest rather than a
+	 * default-enabled one. A store that nobody declared must not appear: the
+	 * word Store promises a registry (ADR-080 Decision 4), and inventing one
+	 * from defaults would promise it on an app's behalf.
+	 *
+	 * @param string               $appId    The calling leaf app id.
+	 * @param array<string, mixed> $manifest The decoded src/manifest.json.
+	 *
+	 * @return self
+	 *
+	 * @spec openspec/specs/apphost-store-plane/spec.md#requirement-a-leaf-app-must-declare-its-store-rather-than-implement-one
+	 */
+	public static function fromManifest(string $appId, array $manifest): self {
+		$block = ($manifest['store'] ?? null);
+		if (is_array($block) === false) {
+			return new self(appId: $appId, enabled: false);
+		}
+
+		$cardFields = ($block['cardFields'] ?? null);
+		if (is_array($cardFields) === false || $cardFields === []) {
+			$cardFields = self::DEFAULT_CARD_FIELDS;
+		}
+
+		return new self(
+			appId: $appId,
+			enabled: true,
+			schema: (string)($block['schema'] ?? ''),
+			register: (string)($block['register'] ?? ''),
+			// 🔴 SCOPE THE LOCAL WRITE BY REGISTER. A schema slug is NOT unique
+			// across the fleet — `case`, `task` and `document` exist in several
+			// apps at once — so resolving an install target by slug alone can
+			// land in another app's register. Defaults to the app id, which is
+			// the fleet's register-slug convention, and an app whose register
+			// slug differs from its app id says so here.
+			localRegister: (string)($block['localRegister'] ?? $appId),
+			installable: self::stringList(value: ($block['installable'] ?? [])),
+			cardFields: array_map(callback: static fn ($v): string => (string)$v, array: $cardFields),
+			builtIn: self::objectList(value: ($block['builtIn'] ?? [])),
+		);
+	}//end fromManifest()
+
+	/**
+	 * Whether an install may write into this schema slug.
+	 *
+	 * @param string $slug The schema slug a store component names.
+	 *
+	 * @return bool
+	 *
+	 * @spec openspec/specs/apphost-store-plane/spec.md#requirement-an-install-must-refuse-every-schema-the-manifest-does-not-allow
+	 */
+	public function isInstallable(string $slug): bool {
+		return $slug !== '' && in_array($slug, $this->installable, true) === true;
+	}//end isInstallable()
+
+	/**
+	 * Coerce a declared value to a list of non-empty strings.
+	 *
+	 * @param mixed $value The declared value.
+	 *
+	 * @return array<int, string>
+	 */
+	private static function stringList(mixed $value): array {
+		if (is_array($value) === false) {
+			return [];
+		}
+
+		$out = [];
+		foreach ($value as $entry) {
+			if (is_string($entry) === true && trim($entry) !== '') {
+				$out[] = $entry;
+			}
+		}
+
+		return array_values(array_unique($out));
+	}//end stringList()
+
+	/**
+	 * Coerce a declared value to a list of associative arrays.
+	 *
+	 * @param mixed $value The declared value.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private static function objectList(mixed $value): array {
+		if (is_array($value) === false) {
+			return [];
+		}
+
+		return array_values(array_filter($value, static fn ($e): bool => is_array($e) === true));
+	}//end objectList()
+}//end class

--- a/openspec/specs/apphost-store-plane/spec.md
+++ b/openspec/specs/apphost-store-plane/spec.md
@@ -200,3 +200,73 @@ app's install action needs the payload.
   `manifest` property
 - **WHEN** `resolve()` returns it
 - **THEN** the returned array MUST still contain `manifest`
+
+### Requirement: A leaf app MUST declare its store rather than implement one
+
+An adopting app SHALL declare a `store` block in `src/manifest.json` and SHALL
+NOT ship a store controller. The engine hosts `/api/store/items` and
+`/api/store/items/{slug}/install`, which the app aliases at
+`GenericStoreController` the same way it already aliases `/api/health` and
+`/api/metrics`.
+
+This amends ADR-080 Decision 3, which kept `install` per app. That decision
+rejected a cross-app controller BASE CLASS, whose three documented failures are
+all consequences of `extends` being resolved by the autoloader rather than the
+container. Route aliasing uses no inheritance, so none of them apply. The other
+half of Decision 3, that install semantics differ per app, is answered by making
+the difference data: the only thing that varied was which schemas an install may
+write.
+
+An app that aliases the routes but declares no block MUST report
+`not_configured`, not `404`. The page then renders its own items rather than
+reading as a broken endpoint.
+
+#### Scenario: An app with no store block reports not_configured
+
+- **GIVEN** an app whose manifest has no `store` key
+- **WHEN** `GET /api/store/items` is called by a signed-in user
+- **THEN** the response MUST be `200` with outcome `not_configured`
+- **AND** no network call MUST be made
+
+### Requirement: An install MUST refuse every schema the manifest does not allow
+
+The `installable` list is an allowlist and a security boundary. A registry is a
+third-party server, so an install MUST write only into the schema slugs the
+calling app declares. An absent or empty list MUST refuse **every** component
+rather than permit every component: an app that declares a store and omits the
+allowlist gets refusals, not an open door.
+
+A refusal MUST NOT abort the install. The remaining components still arrive and
+the per-component report names what did not, because an item that is half
+configuration and half records is the registry's mistake rather than a reason to
+deny an administrator the half they may have.
+
+#### Scenario: A component naming an undeclared schema is refused
+
+- **GIVEN** a manifest whose `installable` is `["caseType"]`
+- **WHEN** an item declares a component for schema `case`
+- **THEN** nothing MUST be written for it
+- **AND** the report MUST mark it `refused`
+
+#### Scenario: An empty allowlist refuses everything
+
+- **GIVEN** a manifest whose `store` block declares no `installable`
+- **WHEN** any component is installed
+- **THEN** every component MUST be refused
+
+### Requirement: An install MUST create a new object, never replace one
+
+Every identity key the remote payload carries (`id`, `uuid`, `@self`) MUST be
+stripped before the write. `ObjectService::saveObject()` resolves its target
+FROM the payload and the write is PUT-semantic, so a component carrying the uuid
+of a live local object would replace it and null every key the payload omits.
+
+The schema allowlist does not cover this: it governs which schema a component
+may write, never whether the write creates or replaces, so an entirely
+legitimate component is the attack.
+
+#### Scenario: A payload carrying a local uuid still creates
+
+- **GIVEN** a component whose object carries `id`, `uuid` and `@self`
+- **WHEN** it is installed
+- **THEN** the object handed to `saveObject()` MUST carry none of them

--- a/tests/Unit/AppHost/GenericStoreControllerTest.php
+++ b/tests/Unit/AppHost/GenericStoreControllerTest.php
@@ -59,6 +59,7 @@ use RuntimeException;
  * cases in GenericStoreInstallerTest.
  *
  * @uses \OCA\OpenRegister\AppHost\Store\StoreManifest
+ * @uses \OCA\OpenRegister\AppHost\Service\StoreDescriptor
  */
 class GenericStoreControllerTest extends TestCase {
 	/** @var ManifestLoader&MockObject */

--- a/tests/Unit/AppHost/GenericStoreControllerTest.php
+++ b/tests/Unit/AppHost/GenericStoreControllerTest.php
@@ -49,6 +49,16 @@ use RuntimeException;
 
 /**
  * @covers \OCA\OpenRegister\AppHost\Controller\GenericStoreController
+ *
+ * The controller reads the calling app's declared block, so every test here
+ * executes StoreManifest as a collaborator. `beStrictAboutCoverageMetadata`
+ * marks that RISKY unless the relationship is declared, and the suite's
+ * coverage guard counts risky tests: three of these were risky on the first
+ * CI run for exactly this reason. `@uses` rather than a second `@covers`,
+ * because StoreManifest is not what these tests assert about — it has its own
+ * cases in GenericStoreInstallerTest.
+ *
+ * @uses \OCA\OpenRegister\AppHost\Store\StoreManifest
  */
 class GenericStoreControllerTest extends TestCase {
 	/** @var ManifestLoader&MockObject */

--- a/tests/Unit/AppHost/GenericStoreControllerTest.php
+++ b/tests/Unit/AppHost/GenericStoreControllerTest.php
@@ -1,0 +1,292 @@
+<?php
+
+/**
+ * Tests for the AppHost GenericStoreController.
+ *
+ * The controller owns the AUTH POSTURE for every adopting app, which is the
+ * thing a leaf app must not be able to drift through its manifest: search is
+ * login-required, install is admin-only. Both are asserted here with negative
+ * controls, because an in-body guard that is never exercised is the same as no
+ * guard at all.
+ *
+ * It also owns the failure shapes. A registry that errors must read as
+ * `store_unreachable`, never as "the registry said there is nothing", and a
+ * registry's internals must never reach the browser.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\AppHost
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\AppHost;
+
+use OCA\OpenRegister\AppHost\Controller\GenericStoreController;
+use OCA\OpenRegister\AppHost\Observability\ManifestLoader;
+use OCA\OpenRegister\AppHost\Service\GenericStoreService;
+use OCA\OpenRegister\AppHost\Store\GenericStoreInstaller;
+use OCA\OpenRegister\AppHost\Store\StoreManifest;
+use OCP\AppFramework\Http;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * @covers \OCA\OpenRegister\AppHost\Controller\GenericStoreController
+ */
+class GenericStoreControllerTest extends TestCase {
+	/** @var ManifestLoader&MockObject */
+	private $manifestLoader;
+
+	/** @var GenericStoreService&MockObject */
+	private $storeService;
+
+	/** @var GenericStoreInstaller&MockObject */
+	private $installer;
+
+	/** @var IUserSession&MockObject */
+	private $userSession;
+
+	/** @var IGroupManager&MockObject */
+	private $groupManager;
+
+	/** @var IRequest&MockObject */
+	private $request;
+
+	/**
+	 * Build the collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		// onlyMethods throughout: addMethods would INVENT a method the class
+		// does not have, so a rename on the engine side would leave this suite
+		// green over an endpoint that fatals at dispatch.
+		$this->manifestLoader = $this->getMockBuilder(ManifestLoader::class)
+			->disableOriginalConstructor()->onlyMethods(['loadStore'])->getMock();
+		$this->storeService = $this->getMockBuilder(GenericStoreService::class)
+			->disableOriginalConstructor()->onlyMethods(['search', 'resolve'])->getMock();
+		$this->installer = $this->getMockBuilder(GenericStoreInstaller::class)
+			->disableOriginalConstructor()->onlyMethods(['install'])->getMock();
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->request = $this->createMock(IRequest::class);
+	}//end setUp()
+
+	/**
+	 * Build the controller for a given calling app.
+	 *
+	 * @param string $appId The calling leaf app id.
+	 *
+	 * @return GenericStoreController
+	 */
+	private function controller(string $appId = 'dossiq'): GenericStoreController {
+		return new GenericStoreController(
+			appName: $appId,
+			request: $this->request,
+			manifestLoader: $this->manifestLoader,
+			storeService: $this->storeService,
+			installer: $this->installer,
+			userSession: $this->userSession,
+			groupManager: $this->groupManager,
+			logger: $this->createMock(LoggerInterface::class)
+		);
+	}//end controller()
+
+	/**
+	 * Sign a user in, optionally as an administrator.
+	 *
+	 * @param bool $isAdmin Whether the user is an instance admin.
+	 *
+	 * @return void
+	 */
+	private function signIn(bool $isAdmin = false): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$this->userSession->method('getUser')->willReturn($user);
+		$this->groupManager->method('isAdmin')->willReturn($isAdmin);
+	}//end signIn()
+
+	/**
+	 * A store manifest for the calling app.
+	 *
+	 * @return StoreManifest
+	 */
+	private function enabledStore(): StoreManifest {
+		return StoreManifest::fromManifest(
+			appId: 'dossiq',
+			manifest: ['store' => ['schema' => 'case-type-template', 'installable' => ['caseType']]]
+		);
+	}//end enabledStore()
+
+	/**
+	 * An anonymous caller gets an explicit 401, not a login redirect.
+	 *
+	 * @return void
+	 */
+	public function testSearchRefusesAnAnonymousCaller(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->storeService->expects($this->never())->method('search');
+
+		$response = $this->controller()->search();
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame('unauthenticated', $response->getData()['outcome']);
+	}//end testSearchRefusesAnAnonymousCaller()
+
+	/**
+	 * An app that aliased the route but declares no store block reports
+	 * not_configured rather than 404 — the page then renders its built-in list
+	 * instead of reading as a broken endpoint.
+	 *
+	 * @return void
+	 */
+	public function testSearchReportsNotConfiguredWhenTheAppDeclaresNoStore(): void {
+		$this->signIn();
+		$this->manifestLoader->method('loadStore')
+			->willReturn(new StoreManifest(appId: 'keepiq', enabled: false));
+		$this->storeService->expects($this->never())->method('search');
+
+		$response = $this->controller(appId: 'keepiq')->search();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(GenericStoreService::OUTCOME_NOT_CONFIGURED, $response->getData()['outcome']);
+	}//end testSearchReportsNotConfiguredWhenTheAppDeclaresNoStore()
+
+	/**
+	 * The declared block reaches the engine as the descriptor, and the cards
+	 * come back unchanged.
+	 *
+	 * @return void
+	 */
+	public function testSearchPassesTheDeclaredBlockToTheEngine(): void {
+		$this->signIn();
+		$this->manifestLoader->method('loadStore')->willReturn($this->enabledStore());
+		$this->storeService->expects($this->once())
+			->method('search')
+			->willReturnCallback(function ($descriptor, $query, $kind) {
+				$this->assertSame('dossiq', $descriptor->appId);
+				$this->assertSame('case-type-template', $descriptor->schema);
+				return ['outcome' => 'ok', 'cards' => [['slug' => 'vth']]];
+			});
+
+		$response = $this->controller()->search();
+
+		$this->assertSame('ok', $response->getData()['outcome']);
+		$this->assertSame([['slug' => 'vth']], $response->getData()['cards']);
+	}//end testSearchPassesTheDeclaredBlockToTheEngine()
+
+	/**
+	 * A registry that throws reads as unreachable, and its internals never
+	 * reach the browser.
+	 *
+	 * @return void
+	 */
+	public function testSearchTranslatesAThrownRegistryIntoAGenericOutcome(): void {
+		$this->signIn();
+		$this->manifestLoader->method('loadStore')->willReturn($this->enabledStore());
+		$this->storeService->method('search')
+			->willThrowException(new RuntimeException('connect to 10.0.0.5 refused'));
+
+		$response = $this->controller()->search();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(GenericStoreService::OUTCOME_UNREACHABLE, $response->getData()['outcome']);
+		$this->assertStringNotContainsString('10.0.0.5', json_encode($response->getData()));
+	}//end testSearchTranslatesAThrownRegistryIntoAGenericOutcome()
+
+	/**
+	 * 🔴 INSTALL IS ADMIN-ONLY. A signed-in non-admin is refused, and nothing
+	 * is resolved or written.
+	 *
+	 * @return void
+	 */
+	public function testInstallRefusesANonAdministrator(): void {
+		$this->signIn(isAdmin: false);
+		$this->storeService->expects($this->never())->method('resolve');
+		$this->installer->expects($this->never())->method('install');
+
+		$response = $this->controller()->install(slug: 'vth');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+	}//end testInstallRefusesANonAdministrator()
+
+	/**
+	 * And an anonymous caller, on the same guard.
+	 *
+	 * @return void
+	 */
+	public function testInstallRefusesAnAnonymousCaller(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->installer->expects($this->never())->method('install');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $this->controller()->install(slug: 'vth')->getStatus());
+	}//end testInstallRefusesAnAnonymousCaller()
+
+	/**
+	 * A malformed slug is rejected before it reaches the registry URL.
+	 *
+	 * @return void
+	 */
+	public function testInstallRejectsAMalformedSlug(): void {
+		$this->signIn(isAdmin: true);
+		$this->storeService->expects($this->never())->method('resolve');
+
+		$response = $this->controller()->install(slug: '../../etc/passwd');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+	}//end testInstallRejectsAMalformedSlug()
+
+	/**
+	 * An unresolvable item is a 404, not a partial install.
+	 *
+	 * @return void
+	 */
+	public function testInstallReportsAnUnresolvedItemAsNotFound(): void {
+		$this->signIn(isAdmin: true);
+		$this->manifestLoader->method('loadStore')->willReturn($this->enabledStore());
+		$this->storeService->method('resolve')->willReturn(null);
+		$this->installer->expects($this->never())->method('install');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $this->controller()->install(slug: 'vth')->getStatus());
+	}//end testInstallReportsAnUnresolvedItemAsNotFound()
+
+	/**
+	 * An administrator's install reaches the installer with the DECLARED
+	 * store, which is what carries the allowlist.
+	 *
+	 * @return void
+	 */
+	public function testInstallHandsTheDeclaredStoreToTheInstaller(): void {
+		$this->signIn(isAdmin: true);
+		$store = $this->enabledStore();
+		$this->manifestLoader->method('loadStore')->willReturn($store);
+		$this->storeService->method('resolve')->willReturn(['components' => []]);
+		$this->installer->expects($this->once())
+			->method('install')
+			->with($this->identicalTo($store), $this->equalTo(['components' => []]))
+			->willReturn(['success' => true, 'components' => []]);
+
+		$response = $this->controller()->install(slug: 'vth');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertTrue($response->getData()['success']);
+	}//end testInstallHandsTheDeclaredStoreToTheInstaller()
+}//end class

--- a/tests/Unit/AppHost/GenericStoreControllerTest.php
+++ b/tests/Unit/AppHost/GenericStoreControllerTest.php
@@ -205,6 +205,48 @@ class GenericStoreControllerTest extends TestCase {
 	}//end testSearchPassesTheDeclaredBlockToTheEngine()
 
 	/**
+	 * The kinds the APP declared ride back with the cards.
+	 *
+	 * Without this the `kinds` key in the store block is declared and read by
+	 * nobody: the page keeps its own copy in its page config and the block key
+	 * is a silent no-op. Asserted on the not_configured arm too, so an
+	 * unconfigured store still offers its filters over the built-in list.
+	 *
+	 * @return void
+	 */
+	public function testSearchReturnsTheKindsTheAppDeclared(): void {
+		$this->signIn();
+		$this->manifestLoader->method('loadStore')->willReturn(
+			StoreManifest::fromManifest(
+				appId: 'dossiq',
+				manifest: ['store' => ['schema' => 't', 'kinds' => ['case-type', 'flow-template']]]
+			)
+		);
+		$this->storeService->method('search')->willReturn(['outcome' => 'ok', 'cards' => []]);
+
+		$response = $this->controller()->search();
+
+		$this->assertSame(['case-type', 'flow-template'], $response->getData()['kinds']);
+	}//end testSearchReturnsTheKindsTheAppDeclared()
+
+	/**
+	 * An app that declares no kinds gets an empty list, not a missing key: the
+	 * page then falls back to the shared vocabulary rather than null-checking.
+	 *
+	 * @return void
+	 */
+	public function testTheKindsKeyIsAlwaysPresent(): void {
+		$this->signIn();
+		$this->manifestLoader->method('loadStore')
+			->willReturn(new StoreManifest(appId: 'keepiq', enabled: false));
+
+		$data = $this->controller(appId: 'keepiq')->search()->getData();
+
+		$this->assertArrayHasKey('kinds', $data);
+		$this->assertSame([], $data['kinds']);
+	}//end testTheKindsKeyIsAlwaysPresent()
+
+	/**
 	 * A registry that throws reads as unreachable, and its internals never
 	 * reach the browser.
 	 *

--- a/tests/Unit/AppHost/GenericStoreControllerTest.php
+++ b/tests/Unit/AppHost/GenericStoreControllerTest.php
@@ -322,6 +322,69 @@ class GenericStoreControllerTest extends TestCase {
 	}//end testInstallReportsAnUnresolvedItemAsNotFound()
 
 	/**
+	 * An app that aliased the install route but declares no store block gets a
+	 * 404, not a silent success. The search path answers not_configured so the
+	 * page can render built-ins; there is nothing equivalent to install.
+	 *
+	 * @return void
+	 */
+	public function testInstallIs404WhenTheAppDeclaresNoStore(): void {
+		$this->signIn(isAdmin: true);
+		$this->manifestLoader->method('loadStore')
+			->willReturn(new StoreManifest(appId: 'keepiq', enabled: false));
+		$this->storeService->expects($this->never())->method('resolve');
+		$this->installer->expects($this->never())->method('install');
+
+		$this->assertSame(
+			Http::STATUS_NOT_FOUND,
+			$this->controller(appId: 'keepiq')->install(slug: 'vth')->getStatus()
+		);
+	}//end testInstallIs404WhenTheAppDeclaresNoStore()
+
+	/**
+	 * A registry that THROWS during resolve is a 404, not a 500, and nothing is
+	 * written. The registry's message never reaches the browser.
+	 *
+	 * @return void
+	 */
+	public function testInstallTreatsAThrownResolveAsUnresolved(): void {
+		$this->signIn(isAdmin: true);
+		$this->manifestLoader->method('loadStore')->willReturn($this->enabledStore());
+		$this->storeService->method('resolve')
+			->willThrowException(new RuntimeException('connect to 10.0.0.5 refused'));
+		$this->installer->expects($this->never())->method('install');
+
+		$response = $this->controller()->install(slug: 'vth');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertStringNotContainsString('10.0.0.5', json_encode($response->getData()));
+	}//end testInstallTreatsAThrownResolveAsUnresolved()
+
+	/**
+	 * The search term and kind filter reach the engine when the request carries
+	 * them, and become null when it does not.
+	 *
+	 * @return void
+	 */
+	public function testSearchForwardsTheQueryAndKindWhenPresent(): void {
+		$this->signIn();
+		$this->manifestLoader->method('loadStore')->willReturn($this->enabledStore());
+		$this->request->method('getParam')->willReturnMap([
+			['q', null, 'enforcement'],
+			['kind', null, 'adapter'],
+		]);
+		$this->storeService->expects($this->once())
+			->method('search')
+			->willReturnCallback(function ($descriptor, $query, $kind) {
+				$this->assertSame('enforcement', $query);
+				$this->assertSame('adapter', $kind);
+				return ['outcome' => 'ok', 'cards' => []];
+			});
+
+		$this->controller()->search();
+	}//end testSearchForwardsTheQueryAndKindWhenPresent()
+
+	/**
 	 * An administrator's install reaches the installer with the DECLARED
 	 * store, which is what carries the allowlist.
 	 *

--- a/tests/Unit/AppHost/GenericStoreInstallerTest.php
+++ b/tests/Unit/AppHost/GenericStoreInstallerTest.php
@@ -233,6 +233,103 @@ class GenericStoreInstallerTest extends TestCase {
 	}//end testAcceptsAJsonEncodedComponentList()
 
 	/**
+	 * A JSON string that decodes to something that is not a list yields no
+	 * components rather than a fatal. A registry controls this value.
+	 *
+	 * @return void
+	 */
+	public function testAJsonStringThatIsNotAListYieldsNoComponents(): void {
+		$this->objectService->expects($this->never())->method('saveObject');
+
+		foreach (['"just a string"', '42', 'not json at all'] as $payload) {
+			$result = $this->installer->install(store: $this->store(), item: ['components' => $payload]);
+			$this->assertFalse($result['success']);
+			$this->assertSame([], $result['components']);
+		}
+	}//end testAJsonStringThatIsNotAListYieldsNoComponents()
+
+	/**
+	 * Entries in the component list that are not objects are dropped, so a
+	 * registry cannot make the installer read a string as a component.
+	 *
+	 * @return void
+	 */
+	public function testNonObjectComponentEntriesAreDropped(): void {
+		$this->objectService->expects($this->once())
+			->method('saveObject')
+			->willReturn($this->createMock(ObjectEntity::class));
+
+		$result = $this->installer->install(
+			store: $this->store(),
+			item: ['components' => [
+				'a bare string',
+				['schema' => 'caseType', 'object' => ['title' => 'Config']],
+				42,
+			]]
+		);
+
+		$this->assertCount(1, $result['components']);
+		$this->assertTrue($result['success']);
+	}//end testNonObjectComponentEntriesAreDropped()
+
+	/**
+	 * A component whose `object` is present but not an array is refused rather
+	 * than passed to the write path.
+	 *
+	 * @return void
+	 */
+	public function testAComponentWhoseObjectIsNotAnArrayIsRefused(): void {
+		$this->objectService->expects($this->never())->method('saveObject');
+
+		$result = $this->installer->install(
+			store: $this->store(),
+			item: ['components' => [['schema' => 'caseType', 'object' => 'a string']]]
+		);
+
+		$this->assertFalse($result['success']);
+		$this->assertSame('refused', $result['components'][0]['status']);
+	}//end testAComponentWhoseObjectIsNotAnArrayIsRefused()
+
+	/**
+	 * Every list-shaped key coerces a non-array to an empty list rather than
+	 * throwing. A manifest is hand-edited JSON; a scalar where a list belongs
+	 * must degrade to "declared nothing", and for `installable` that means
+	 * refusing every install.
+	 *
+	 * @return void
+	 */
+	public function testScalarsWhereListsBelongCoerceToEmpty(): void {
+		$store = StoreManifest::fromManifest(
+			appId: 'dossiq',
+			manifest: ['store' => [
+				'schema' => 't',
+				'installable' => 'caseType',
+				'kinds' => 42,
+				'builtIn' => 'nope',
+			]]
+		);
+
+		$this->assertSame([], $store->installable);
+		$this->assertSame([], $store->kinds);
+		$this->assertSame([], $store->builtIn);
+		$this->assertFalse($store->isInstallable(slug: 'caseType'));
+	}//end testScalarsWhereListsBelongCoerceToEmpty()
+
+	/**
+	 * The declared kinds survive the same coercion as the allowlist.
+	 *
+	 * @return void
+	 */
+	public function testKindsAreCoercedToUniqueNonEmptyStrings(): void {
+		$store = StoreManifest::fromManifest(
+			appId: 'dossiq',
+			manifest: ['store' => ['schema' => 't', 'kinds' => ['case-type', 'case-type', '', 7, 'flow']]]
+		);
+
+		$this->assertSame(['case-type', 'flow'], array_values($store->kinds));
+	}//end testKindsAreCoercedToUniqueNonEmptyStrings()
+
+	/**
 	 * A write that throws is reported per component, not as a 500.
 	 *
 	 * @return void

--- a/tests/Unit/AppHost/GenericStoreInstallerTest.php
+++ b/tests/Unit/AppHost/GenericStoreInstallerTest.php
@@ -1,0 +1,301 @@
+<?php
+
+/**
+ * Tests for the AppHost GenericStoreInstaller and StoreManifest.
+ *
+ * The installer is the half of the store plane that WRITES, so its two
+ * defences are asserted directly rather than assumed:
+ *
+ *   - the `installable` allowlist, which is what stops a remote registry
+ *     naming any schema the app owns;
+ *   - the identity strip, without which "install" is an overwrite primitive
+ *     because ObjectService resolves its target FROM the payload.
+ *
+ * Both have negative controls: a refused component must still let the allowed
+ * ones through, and an empty allowlist must refuse everything rather than
+ * permit everything.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\AppHost
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\AppHost;
+
+use OCA\OpenRegister\AppHost\Store\GenericStoreInstaller;
+use OCA\OpenRegister\AppHost\Store\StoreManifest;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\ObjectService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * @covers \OCA\OpenRegister\AppHost\Store\GenericStoreInstaller
+ * @covers \OCA\OpenRegister\AppHost\Store\StoreManifest
+ */
+class GenericStoreInstallerTest extends TestCase {
+	/** @var ObjectService&MockObject */
+	private $objectService;
+
+	/** @var LoggerInterface&MockObject */
+	private $logger;
+
+	private GenericStoreInstaller $installer;
+
+	/**
+	 * Build the installer over mocked collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		// onlyMethods, never addMethods: addMethods INVENTS a method the class
+		// does not have, so a rename would leave this suite green over an
+		// endpoint that fatals.
+		$this->objectService = $this->getMockBuilder(ObjectService::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['saveObject'])
+			->getMock();
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->installer = new GenericStoreInstaller(
+			objectService: $this->objectService,
+			logger: $this->logger
+		);
+	}//end setUp()
+
+	/**
+	 * A store manifest that allows two schemas.
+	 *
+	 * @param array<int, string> $installable Allowed schema slugs.
+	 *
+	 * @return StoreManifest
+	 */
+	private function store(array $installable = ['caseType', 'workflowTemplate']): StoreManifest {
+		return StoreManifest::fromManifest(
+			appId: 'dossiq',
+			manifest: ['store' => [
+				'schema' => 'case-type-template',
+				'register' => 'store',
+				'installable' => $installable,
+			]]
+		);
+	}//end store()
+
+	/**
+	 * An allowed component is written into the app's OWN register.
+	 *
+	 * @return void
+	 */
+	public function testWritesAnAllowedComponentIntoTheAppsRegister(): void {
+		$this->objectService->expects($this->once())
+			->method('saveObject')
+			->with(
+				$this->equalTo(['title' => 'Enforcement']),
+				$this->anything(),
+				$this->equalTo('dossiq'),
+				$this->equalTo('caseType')
+			)
+			->willReturn($this->createMock(ObjectEntity::class));
+
+		$result = $this->installer->install(
+			store: $this->store(),
+			item: ['components' => [['schema' => 'caseType', 'object' => ['title' => 'Enforcement']]]]
+		);
+
+		$this->assertTrue($result['success']);
+		$this->assertSame('installed', $result['components'][0]['status']);
+	}//end testWritesAnAllowedComponentIntoTheAppsRegister()
+
+	/**
+	 * 🔴 The identity strip. Without it an install REPLACES a live object,
+	 * because ObjectService reads `@self.id`/`id` off the payload as the uuid
+	 * to update, PUT-semantically.
+	 *
+	 * @return void
+	 */
+	public function testStripsEveryRemoteIdentitySoAnInstallCreates(): void {
+		$captured = null;
+		$this->objectService->method('saveObject')
+			->willReturnCallback(function (...$args) use (&$captured) {
+				$captured = $args[0];
+				return $this->createMock(ObjectEntity::class);
+			});
+
+		$this->installer->install(
+			store: $this->store(),
+			item: ['components' => [[
+				'schema' => 'caseType',
+				'object' => [
+					'id' => 42,
+					'uuid' => 'a-live-local-uuid',
+					'@self' => ['id' => 'a-live-local-uuid'],
+					'title' => 'Enforcement',
+				],
+			]]]
+		);
+
+		$this->assertSame(['title' => 'Enforcement'], $captured);
+		$this->assertArrayNotHasKey('id', (array)$captured);
+		$this->assertArrayNotHasKey('uuid', (array)$captured);
+		$this->assertArrayNotHasKey('@self', (array)$captured);
+	}//end testStripsEveryRemoteIdentitySoAnInstallCreates()
+
+	/**
+	 * A schema the manifest does not allow is refused, and nothing is written.
+	 *
+	 * @return void
+	 */
+	public function testRefusesASchemaTheManifestDoesNotAllow(): void {
+		$this->objectService->expects($this->never())->method('saveObject');
+
+		$result = $this->installer->install(
+			store: $this->store(),
+			item: ['components' => [['schema' => 'case', 'object' => ['title' => 'A real record']]]]
+		);
+
+		$this->assertFalse($result['success']);
+		$this->assertSame('refused', $result['components'][0]['status']);
+	}//end testRefusesASchemaTheManifestDoesNotAllow()
+
+	/**
+	 * A partial install is an OUTCOME: the allowed half still lands.
+	 *
+	 * @return void
+	 */
+	public function testARefusalDoesNotAbortTheAllowedComponents(): void {
+		$this->objectService->expects($this->once())
+			->method('saveObject')
+			->willReturn($this->createMock(ObjectEntity::class));
+
+		$result = $this->installer->install(
+			store: $this->store(),
+			item: ['components' => [
+				['schema' => 'caseType', 'object' => ['title' => 'Config']],
+				['schema' => 'case', 'object' => ['title' => 'A record']],
+			]]
+		);
+
+		$this->assertFalse($result['success']);
+		$statuses = array_column($result['components'], 'status', 'schema');
+		$this->assertSame('installed', $statuses['caseType']);
+		$this->assertSame('refused', $statuses['case']);
+	}//end testARefusalDoesNotAbortTheAllowedComponents()
+
+	/**
+	 * NEGATIVE CONTROL ON THE ALLOWLIST. An empty list must mean "install
+	 * nothing", never "install anything" — an app that declares a store and
+	 * forgets the allowlist must get refusals, not an open door.
+	 *
+	 * @return void
+	 */
+	public function testAnEmptyAllowlistRefusesEverything(): void {
+		$this->objectService->expects($this->never())->method('saveObject');
+
+		$result = $this->installer->install(
+			store: $this->store(installable: []),
+			item: ['components' => [['schema' => 'caseType', 'object' => ['title' => 'Config']]]]
+		);
+
+		$this->assertFalse($result['success']);
+		$this->assertSame('refused', $result['components'][0]['status']);
+	}//end testAnEmptyAllowlistRefusesEverything()
+
+	/**
+	 * A registry may ship the component list as a JSON string.
+	 *
+	 * @return void
+	 */
+	public function testAcceptsAJsonEncodedComponentList(): void {
+		$this->objectService->expects($this->once())
+			->method('saveObject')
+			->willReturn($this->createMock(ObjectEntity::class));
+
+		$result = $this->installer->install(
+			store: $this->store(),
+			item: ['components' => json_encode([['schema' => 'caseType', 'object' => ['title' => 'Config']]])]
+		);
+
+		$this->assertTrue($result['success']);
+	}//end testAcceptsAJsonEncodedComponentList()
+
+	/**
+	 * A write that throws is reported per component, not as a 500.
+	 *
+	 * @return void
+	 */
+	public function testAFailedWriteIsReportedNotThrown(): void {
+		$this->objectService->method('saveObject')
+			->willThrowException(new RuntimeException('constraint'));
+
+		$result = $this->installer->install(
+			store: $this->store(),
+			item: ['components' => [['schema' => 'caseType', 'object' => ['title' => 'Config']]]]
+		);
+
+		$this->assertFalse($result['success']);
+		$this->assertSame('error', $result['components'][0]['status']);
+		// The registry's internals never reach the browser.
+		$this->assertStringNotContainsString('constraint', $result['components'][0]['message']);
+	}//end testAFailedWriteIsReportedNotThrown()
+
+	/**
+	 * An item declaring nothing installable reports no success.
+	 *
+	 * @return void
+	 */
+	public function testAnItemWithNoComponentsIsNotASuccess(): void {
+		$result = $this->installer->install(store: $this->store(), item: []);
+
+		$this->assertFalse($result['success']);
+		$this->assertSame([], $result['components']);
+	}//end testAnItemWithNoComponentsIsNotASuccess()
+
+	/**
+	 * An app that declares no `store` block is DISABLED, not defaulted. The
+	 * word Store promises a registry (ADR-080 Decision 4) and the engine must
+	 * not promise it on an app's behalf.
+	 *
+	 * @return void
+	 */
+	public function testAManifestWithNoStoreBlockIsDisabled(): void {
+		$store = StoreManifest::fromManifest(appId: 'keepiq', manifest: ['version' => '1.0.0']);
+
+		$this->assertFalse($store->enabled);
+		$this->assertFalse($store->isInstallable(slug: 'anything'));
+	}//end testAManifestWithNoStoreBlockIsDisabled()
+
+	/**
+	 * The local register defaults to the app id, and an app whose register
+	 * slug differs says so. A schema slug is not unique across the fleet, so
+	 * an unscoped write can land in another app's register.
+	 *
+	 * @return void
+	 */
+	public function testLocalRegisterDefaultsToTheAppIdAndCanBeOverridden(): void {
+		$byDefault = StoreManifest::fromManifest(
+			appId: 'buildiq',
+			manifest: ['store' => ['schema' => 'application-template']]
+		);
+		$this->assertSame('buildiq', $byDefault->localRegister);
+
+		$explicit = StoreManifest::fromManifest(
+			appId: 'buildiq',
+			manifest: ['store' => ['schema' => 'application-template', 'localRegister' => 'openbuild']]
+		);
+		$this->assertSame('openbuild', $explicit->localRegister);
+	}//end testLocalRegisterDefaultsToTheAppIdAndCanBeOverridden()
+}//end class

--- a/tests/Unit/AppHost/GenericStoreInstallerTest.php
+++ b/tests/Unit/AppHost/GenericStoreInstallerTest.php
@@ -279,6 +279,95 @@ class GenericStoreInstallerTest extends TestCase {
 	}//end testAManifestWithNoStoreBlockIsDisabled()
 
 	/**
+	 * Card fields fall back to the fleet's published names, and an app that
+	 * declares its own gets those instead.
+	 *
+	 * @return void
+	 */
+	public function testCardFieldsDefaultAndCanBeOverridden(): void {
+		$byDefault = StoreManifest::fromManifest(
+			appId: 'dossiq',
+			manifest: ['store' => ['schema' => 't']]
+		);
+		$this->assertSame(StoreManifest::DEFAULT_CARD_FIELDS, $byDefault->cardFields);
+
+		// An EMPTY map is a declaration of nothing, not a declaration of
+		// emptiness: falling through to the defaults keeps a store rendering
+		// cards rather than seven blank ones.
+		$empty = StoreManifest::fromManifest(
+			appId: 'dossiq',
+			manifest: ['store' => ['schema' => 't', 'cardFields' => []]]
+		);
+		$this->assertSame(StoreManifest::DEFAULT_CARD_FIELDS, $empty->cardFields);
+
+		$own = StoreManifest::fromManifest(
+			appId: 'dossiq',
+			manifest: ['store' => ['schema' => 't', 'cardFields' => ['slug' => 'ref']]]
+		);
+		$this->assertSame(['slug' => 'ref'], $own->cardFields);
+	}//end testCardFieldsDefaultAndCanBeOverridden()
+
+	/**
+	 * The allowlist is coerced: non-strings and blanks are dropped and
+	 * duplicates collapse, so a hand-edited manifest cannot smuggle a truthy
+	 * non-string past `in_array(..., true)` and silently allow nothing.
+	 *
+	 * @return void
+	 */
+	public function testTheAllowlistIsCoercedToUniqueNonEmptyStrings(): void {
+		$store = StoreManifest::fromManifest(
+			appId: 'dossiq',
+			manifest: ['store' => ['schema' => 't', 'installable' => ['caseType', 'caseType', '', '  ', 42, null, 'flow']]]
+		);
+
+		$this->assertSame(['caseType', 'flow'], array_values($store->installable));
+		$this->assertTrue($store->isInstallable(slug: 'caseType'));
+		$this->assertFalse($store->isInstallable(slug: ''));
+	}//end testTheAllowlistIsCoercedToUniqueNonEmptyStrings()
+
+	/**
+	 * Built-in items keep only the entries that are objects. A registry-shaped
+	 * string in the list would otherwise reach the page and render as a card
+	 * with no title.
+	 *
+	 * @return void
+	 */
+	public function testBuiltInKeepsOnlyObjectEntries(): void {
+		$store = StoreManifest::fromManifest(
+			appId: 'dossiq',
+			manifest: ['store' => ['schema' => 't', 'builtIn' => [
+				['slug' => 'a', 'title' => 'A'],
+				'not-an-object',
+				['slug' => 'b', 'title' => 'B'],
+			]]]
+		);
+
+		$this->assertCount(2, $store->builtIn);
+		$this->assertSame(['a', 'b'], array_column($store->builtIn, 'slug'));
+	}//end testBuiltInKeepsOnlyObjectEntries()
+
+	/**
+	 * A `store` key that is not an object disables the store rather than
+	 * half-configuring one.
+	 *
+	 * @return void
+	 */
+	public function testAMalformedStoreKeyDisablesTheStore(): void {
+		foreach ([null, 'yes', 42, []] as $block) {
+			$store = StoreManifest::fromManifest(appId: 'dossiq', manifest: ['store' => $block]);
+			if (is_array($block) === true) {
+				// An empty OBJECT is a declaration, so it stays enabled — and
+				// its empty allowlist refuses every install.
+				$this->assertTrue($store->enabled);
+				$this->assertFalse($store->isInstallable(slug: 'anything'));
+				continue;
+			}
+
+			$this->assertFalse($store->enabled);
+		}
+	}//end testAMalformedStoreKeyDisablesTheStore()
+
+	/**
 	 * The local register defaults to the app id, and an app whose register
 	 * slug differs says so. A schema slug is not unique across the fleet, so
 	 * an unscoped write can land in another app's register.

--- a/tests/Unit/AppHost/RoutesTest.php
+++ b/tests/Unit/AppHost/RoutesTest.php
@@ -52,11 +52,59 @@ class RoutesTest extends TestCase {
 				'preferences#setPreference',
 				'metrics#index',
 				'health#index',
+				'store#search',
+				'store#install',
 				'dashboard#catchAll',
 			],
 			$names
 		);
 	}//end testCanonicalRouteNamesMatchPetstoreReference()
+
+	/**
+	 * The store routes sit BEFORE the SPA catch-all.
+	 *
+	 * Not a restatement of the list above: that assertion would still pass if
+	 * the catch-all were merged first, and a `/{path}` route with `.+` matches
+	 * `api/store/items`. The catch-all's position is the reason the store
+	 * endpoints answer JSON rather than the Vue shell with HTTP 200.
+	 *
+	 * @return void
+	 */
+	public function testStoreRoutesPrecedeTheSpaCatchAll(): void {
+		$names = $this->names(Routes::standard());
+
+		$this->assertLessThan(
+			array_search('dashboard#catchAll', $names, true),
+			array_search('store#search', $names, true)
+		);
+		$this->assertLessThan(
+			array_search('dashboard#catchAll', $names, true),
+			array_search('store#install', $names, true)
+		);
+	}//end testStoreRoutesPrecedeTheSpaCatchAll()
+
+	/**
+	 * The install route bounds its slug at the router.
+	 *
+	 * A `{slug}` with no requirement accepts anything Symfony will match into
+	 * a single segment, and the value reaches the registry URL. The controller
+	 * guards it too; this is the outer bound.
+	 *
+	 * @return void
+	 */
+	public function testInstallRouteConstrainsTheSlug(): void {
+		$routes = Routes::standard()['routes'];
+		$install = null;
+		foreach ($routes as $route) {
+			if ($route['name'] === 'store#install') {
+				$install = $route;
+				break;
+			}
+		}
+
+		$this->assertNotNull($install);
+		$this->assertSame('[a-z0-9][a-z0-9-]*[a-z0-9]', $install['requirements']['slug']);
+	}//end testInstallRouteConstrainsTheSlug()
 
 	public function testSettingsUpdateRouteIsPutOnApiSettings(): void {
 		$routes = Routes::standard()['routes'];


### PR DESCRIPTION
Your call, taken while ADR-114 Decision 4 was about to put a Store in fifteen more apps:

> lets abstract store to something that is provided by open register and doesnt have a backend per app

This is that. An adopting app declares a `store` block in `src/manifest.json` and aliases `/api/store/items` and `/api/store/items/{slug}/install` at `GenericStoreController` — the same offload ADR-040 already does for `/api/health` and `/api/metrics`. It writes **no PHP**.

```json
"store": {
  "schema": "case-type-template",
  "localRegister": "dossiq",
  "installable": ["caseType", "workflowTemplate"],
  "builtIn": [ … ]
}
```

## This amends ADR-080 Decision 3, and it is worth being precise about why that is safe

D3 said install *"does not generalise and SHALL NOT be pushed into AppHost"*. All three of its documented failures are consequences of a cross-app **base class**, because `extends` is resolved by the **autoloader** and not the container: an absent OpenRegister 500s every route in the consuming app, leaf tests cannot load the subclass, and phpstan refuses *"extends unknown class"*.

A route alias has none of those properties. It is the shape Decision **2** of that same ADR already blessed as *"a service, consumed by composition"*.

D3's other reason — that install semantics differ per app — was measured against one implementation. Read against what dossiq's install actually does, the operation is identical everywhere: refuse what the allowlist does not name, strip the remote identity, save, report per component. The only thing that genuinely varies is **which schemas an install may write**, and that is a list.

The amendment is recorded in [hydra#647](https://github.com/ConductionNL/hydra/pull/647).

## 🔴 The two defences, both with negative controls

**`installable` is a security boundary.** A registry is a third-party server. An absent or empty list refuses **every** install rather than permitting every install, so an app that declares a store and forgets the allowlist gets refusals and not an open door. `testAnEmptyAllowlistRefusesEverything` asserts exactly that.

**The identity strip is what keeps install from being an overwrite primitive.** `saveObject()` resolves its target *from the payload* and writes PUT-semantically, so a component carrying a live local uuid would replace that object and null every key it omits. The allowlist does **not** cover this — it governs which schema may be written, never whether the write creates or replaces — so an entirely legitimate component is the attack.

`localRegister` is scoped because a schema slug is not unique across the fleet: `case`, `task` and `document` exist in several apps at once, so an unscoped write can land in another app's register.

## Migration, not a flag day

`Bootstrap` aliases the engine's controller **only when the leaf app does not define its own**, so dossiq keeps its hand-written `StoreController` until its own PR deletes it. Every other app adopts by adding a manifest block.

## Routes

The store entries sit **before** the SPA catch-all, and a test asserts the *position* rather than only the list — a `/{path}` route with `.+` matches `api/store/items` and would answer the Vue shell with HTTP 200. The install route also bounds `{slug}` at the router, with the controller guarding it again.

## Verification

- **19 new tests** across the installer and the controller; the AppHost suite is **210/210**.
- `phpcs`, `phpmd`, `psalm` and `phpstan` all clean on every changed file.
- `openspec/specs/apphost-store-plane/spec.md` gains the three requirements the `@spec` tags cite.

## Paired with

`ConductionNL/nextcloud-vue#949` — the `store` page type and the `store` manifest block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)