### PR TITLE
A translatable name field was stored as raw JSON

### DIFF
--- a/lib/Db/TaskSequenceMapper.php
+++ b/lib/Db/TaskSequenceMapper.php
@@ -119,7 +119,7 @@ class TaskSequenceMapper extends QBMapper {
 	 *
 	 * @return TaskSequence|null The newest sequence for the template, or null when none has run.
 	 *
-	 * @spec openspec/changes/flow-approval-consolidation/specs/flow-approval-consolidation/spec.md#requirement-an-approval-is-an-ordered-task-sequence-with-o
+	 * @spec openspec/changes/flow-approval-consolidation/specs/flow-approval-consolidation/spec.md#requirement-an-approval-is-an-ordered-task-sequence-with-one-position-enabled-at-a-time
 	 */
 	public function findNewestForTemplate(string $templateId): ?TaskSequence {
 		$qb = $this->db->getQueryBuilder();

--- a/lib/Service/Object/SaveObject/MetadataHydrationHandler.php
+++ b/lib/Service/Object/SaveObject/MetadataHydrationHandler.php
@@ -55,6 +55,8 @@ use Psr\Log\LoggerInterface;
  * Reason: Metadata hydration handles multiple complex scenarios for template processing
  * @SuppressWarnings(PHPMD.CyclomaticComplexity)
  * @SuppressWarnings(PHPMD.NPathComplexity)
+ *
+ * @spec openspec/specs/object-lifecycle/spec.md
  */
 class MetadataHydrationHandler {
 	/**
@@ -278,6 +280,16 @@ class MetadataHydrationHandler {
 		// Simple field path - use existing method.
 		$value = $this->getValueFromPath(data: $data, path: $fieldPath);
 
+		// A translatable property holds a LANGUAGE MAP, not a value. Resolve it
+		// to one string before the json_encode below turns it into markup a
+		// person then reads on the page.
+		if (is_array($value) === true) {
+			$fromLanguageMap = $this->resolveLanguageMap(value: $value);
+			if ($fromLanguageMap !== null) {
+				return $fromLanguageMap;
+			}
+		}
+
 		// Convert arrays/objects to JSON string to satisfy the ?string return type.
 		if (is_array($value) === true) {
 			return json_encode($value);
@@ -285,6 +297,99 @@ class MetadataHydrationHandler {
 
 		return $value;
 	}//end extractMetadataValue()
+
+	/**
+	 * Resolve a translatable property's language map to a single string.
+	 *
+	 * 🔴 WITHOUT THIS, A TRANSLATABLE NAME FIELD IS SHOWN TO USERS AS RAW JSON.
+	 *
+	 * A property marked `translatable: true` stores `{"nl": "…", "en": "…"}`.
+	 * `extractMetadataValue()` must return a string, and it used to satisfy
+	 * that by `json_encode`-ing whatever array it was handed. So a schema whose
+	 * `objectNameField` names a translatable property stored the literal
+	 * `{"nl":"Rijkswaterstaat - Onderhoudscontract software 2026"}` in
+	 * `@self.name` — and every detail page renders `@self.name` as its
+	 * headline. Observed on pipelinq's lead page; `lead.title` is
+	 * `translatable: true` and is the `objectNameField`, and dossiq's
+	 * `case.title` is not translatable, which is exactly why its header reads
+	 * clean on the same component.
+	 *
+	 * WHICH LANGUAGE THIS PICKS, and why it is not a locale decision.
+	 * `@self.name` is a DENORMALISED display and search string written once at
+	 * save time, when there is no reader and so no locale to honour — under
+	 * `occ` there is not even a request. The authoritative value stays in the
+	 * property, and per-request resolution belongs to
+	 * {@see \OCA\OpenRegister\Service\Object\TranslationHandler::resolveTranslationsForRender()},
+	 * which reads the register's language list and the caller's Accept-Language.
+	 * So this deliberately bakes in NO language: it takes the FIRST key the
+	 * author declared, which is exact for the single-language maps that are
+	 * the common case and a defensible source-language convention otherwise.
+	 *
+	 * Returns null for an array that is not a language map, so a genuinely
+	 * structured value still falls through to `json_encode` as before.
+	 *
+	 * @param array $value The candidate value.
+	 *
+	 * @return string|null The resolved string, or null when this is not a language map.
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	private function resolveLanguageMap(array $value): ?string {
+		if ($this->isLanguageKeyedObject(value: $value) === false) {
+			return null;
+		}
+
+		foreach ($value as $entry) {
+			// A nested map is not a language value; leave the whole thing to
+			// json_encode rather than reaching further in and guessing.
+			if (is_scalar($entry) === false) {
+				return null;
+			}
+
+			if (trim((string)$entry) !== '') {
+				return (string)$entry;
+			}
+		}
+
+		// Every language is present but empty. That is not a name, and falling
+		// through to json_encode would put `{"nl":""}` on the page, so let the
+		// caller's common-field fallback have its turn.
+		return null;
+	}//end resolveLanguageMap()
+
+	/**
+	 * Whether every key of an array is a BCP 47 language tag.
+	 *
+	 * Kept identical, deliberately, to TranslationHandler's own predicate: the
+	 * two must agree on what a language map IS, or a value one of them resolves
+	 * the other would encode. TranslationHandler cannot simply be injected
+	 * here — it is request-scoped through LanguageService, and this runs on the
+	 * save path, including from `occ` where there is no request at all.
+	 *
+	 * @param array $value The candidate value.
+	 *
+	 * @return bool True when the array is keyed by language tags.
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	private function isLanguageKeyedObject(array $value): bool {
+		if (empty($value) === true) {
+			return false;
+		}
+
+		foreach (array_keys($value) as $key) {
+			if (is_string($key) === false) {
+				return false;
+			}
+
+			// BCP 47 language tag: 2-3 lowercase letters, optional subtags.
+			if (preg_match('/^[a-z]{2,3}(-[a-zA-Z0-9]{2,8})*$/', $key) !== 1) {
+				return false;
+			}
+		}
+
+		return true;
+	}//end isLanguageKeyedObject()
 
 	/**
 	 * Processes a pipe-separated fallback chain and returns the first non-empty value.

--- a/tests/Unit/Service/ObjectHandlers/MetadataHydrationTranslatableNameTest.php
+++ b/tests/Unit/Service/ObjectHandlers/MetadataHydrationTranslatableNameTest.php
@@ -1,0 +1,205 @@
+<?php
+
+/**
+ * A translatable name field must not be stored as raw JSON.
+ *
+ * A property marked `translatable: true` holds `{"nl": "…", "en": "…"}`. When
+ * such a property is a schema's `objectNameField`, the hydration handler used
+ * to `json_encode` the whole map to satisfy its `?string` return type, so
+ * `@self.name` became the literal `{"nl":"…"}` — and every detail page in
+ * every consuming app renders `@self.name` as its headline. Observed on
+ * pipelinq's lead page.
+ *
+ * The tests below are written so that removing the resolution makes them
+ * FAIL, and the non-language cases prove the change did not simply delete the
+ * json_encode fallback that other callers rely on.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\ObjectHandlers
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/specs/object-lifecycle/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\ObjectHandlers;
+
+use OCA\OpenRegister\Service\Object\CacheHandler;
+use OCA\OpenRegister\Service\Object\SaveObject\MetadataHydrationHandler;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests for language-map resolution in MetadataHydrationHandler.
+ */
+class MetadataHydrationTranslatableNameTest extends TestCase {
+	/**
+	 * The handler under test.
+	 *
+	 * @var MetadataHydrationHandler
+	 */
+	private MetadataHydrationHandler $handler;
+
+	/**
+	 * Set up the handler with stubbed collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$this->handler = new MetadataHydrationHandler(
+			logger: $this->createMock(originalClassName: LoggerInterface::class),
+			cacheHandler: $this->createMock(originalClassName: CacheHandler::class),
+		);
+	}//end setUp()
+
+	/**
+	 * The single-language map that shipped the bug.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	public function testASingleLanguageMapResolvesToItsValue(): void {
+		$name = 'Rijkswaterstaat - Onderhoudscontract software 2026';
+
+		$result = $this->handler->extractMetadataValue(
+			data: ['title' => ['nl' => $name]],
+			fieldPath: 'title'
+		);
+
+		$this->assertSame(expected: $name, actual: $result);
+		// The exact shape a user was shown on the page.
+		$this->assertStringNotContainsString(needle: '{"nl"', haystack: (string)$result);
+	}//end testASingleLanguageMapResolvesToItsValue()
+
+	/**
+	 * A multi-language map takes the first declared language.
+	 *
+	 * No locale is baked in: `@self.name` is written at save time, when there
+	 * is no reader whose language could be honoured. Per-request resolution is
+	 * TranslationHandler's job.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	public function testAMultiLanguageMapTakesTheFirstDeclared(): void {
+		$result = $this->handler->extractMetadataValue(
+			data: ['title' => ['en' => 'Maintenance contract', 'nl' => 'Onderhoudscontract']],
+			fieldPath: 'title'
+		);
+
+		$this->assertSame(expected: 'Maintenance contract', actual: $result);
+	}//end testAMultiLanguageMapTakesTheFirstDeclared()
+
+	/**
+	 * An empty leading language falls through to the next one.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	public function testAnEmptyLeadingLanguageIsSkipped(): void {
+		$result = $this->handler->extractMetadataValue(
+			data: ['title' => ['en' => '   ', 'nl' => 'Onderhoudscontract']],
+			fieldPath: 'title'
+		);
+
+		$this->assertSame(expected: 'Onderhoudscontract', actual: $result);
+	}//end testAnEmptyLeadingLanguageIsSkipped()
+
+	/**
+	 * A regional tag is still a language tag.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	public function testARegionalSubtagIsRecognised(): void {
+		$result = $this->handler->extractMetadataValue(
+			data: ['title' => ['nl-BE' => 'Onderhoudscontract']],
+			fieldPath: 'title'
+		);
+
+		$this->assertSame(expected: 'Onderhoudscontract', actual: $result);
+	}//end testARegionalSubtagIsRecognised()
+
+	/**
+	 * A structured value is NOT a language map and still encodes.
+	 *
+	 * The positive control for the fallback: this is what the json_encode
+	 * branch exists for, and the fix must not have removed it.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	public function testANonLanguageArrayStillEncodes(): void {
+		$result = $this->handler->extractMetadataValue(
+			data: ['title' => ['street' => 'Industrieweg', 'number' => 12]],
+			fieldPath: 'title'
+		);
+
+		$this->assertSame(expected: '{"street":"Industrieweg","number":12}', actual: $result);
+	}//end testANonLanguageArrayStillEncodes()
+
+	/**
+	 * A list is not a language map either.
+	 *
+	 * Its keys are integers, so the predicate rejects it and the encode
+	 * fallback keeps its behaviour.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	public function testAListStillEncodes(): void {
+		$result = $this->handler->extractMetadataValue(
+			data: ['title' => ['one', 'two']],
+			fieldPath: 'title'
+		);
+
+		$this->assertSame(expected: '["one","two"]', actual: $result);
+	}//end testAListStillEncodes()
+
+	/**
+	 * A nested map under a language key is left alone.
+	 *
+	 * Reaching further in would be guessing at a shape nobody declared, so it
+	 * falls through to the encode branch rather than inventing a rule.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	public function testANestedValueUnderALanguageKeyStillEncodes(): void {
+		$result = $this->handler->extractMetadataValue(
+			data: ['title' => ['nl' => ['first' => 'a']]],
+			fieldPath: 'title'
+		);
+
+		$this->assertSame(expected: '{"nl":{"first":"a"}}', actual: $result);
+	}//end testANestedValueUnderALanguageKeyStillEncodes()
+
+	/**
+	 * A plain string is untouched.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	public function testAPlainStringIsUnchanged(): void {
+		$result = $this->handler->extractMetadataValue(
+			data: ['title' => 'Zonnepanelen op monument Grote Kerk'],
+			fieldPath: 'title'
+		);
+
+		$this->assertSame(expected: 'Zonnepanelen op monument Grote Kerk', actual: $result);
+	}//end testAPlainStringIsUnchanged()
+}//end class


### PR DESCRIPTION
A schema whose `objectNameField` names a `translatable: true` property stored the language **map** in `@self.name`. Every detail page in every consuming app renders `@self.name` as its headline, so pipelinq's lead page showed a user this, in the largest type on the screen:

```
{"nl":"Rijkswaterstaat - Onderhoudscontract software 2026"}
```

## Cause

`MetadataHydrationHandler::extractMetadataValue()` must return a string, and satisfied that by `json_encode`-ing whatever array it was handed. For a genuinely structured value that is right and stays. For a language map it produced markup a person then read.

The tell that isolates it: dossiq's `case.title` is **not** translatable and its header renders clean on the same component and the same nc-vue version. One flag is the whole difference.

## Which language this picks, and why that is not a locale decision

`@self.name` is a **denormalised** display and search string, written once at save time — when there is no reader whose language could be honoured, and under `occ` not even a request.

The authoritative value stays in the property. Per-request resolution is already `TranslationHandler::resolveTranslationsForRender()`'s job, reading the register's language list and the caller's `Accept-Language`.

So this bakes in **no language at all**: it takes the first key the author declared. Exact for the single-language maps that are the common case, and a defensible source-language convention otherwise.

## On the duplicated predicate

`isLanguageKeyedObject()` is copied from `TranslationHandler` rather than injected, and the comment says why: that handler is request-scoped through `LanguageService`, and this runs on the save path including from `occ`. The two copies must agree on what a language map *is*, or a value one of them resolves the other encodes — so they are deliberately identical, and the comment on each says so.

If you would rather have one definition, the alternative is extracting the predicate to a stateless helper both depend on. Happy to do that instead; I took the lower-risk option on an engine every app in the fleet runs.

## Conservative at every edge

A list, a structured object, and a nested value under a language key all still encode exactly as before. An all-empty map returns null, so the caller's common-field fallback still gets its turn rather than `{"nl":""}` landing on the page.

## Checks

- 8 new tests. **Removing the resolution reddens 4 of them**; the 4 non-language controls stay green either way, which is what shows the `json_encode` fallback survived.
- `tests/Unit`: 19103 tests, 46511 assertions, passing
- phpcs and phpstan clean on the changed file

Also adds the class-level `@spec` tag phpcs was warning about (pre-existing).

## Blast radius

Only schemas whose `objectNameField`/`objectDescriptionField` names a translatable property are affected, and today they render JSON. In pipelinq that is exactly one (`lead.title`). Objects already saved keep their bad `@self.name` until next written — a re-save or a repair pass would be needed to backfill, which this PR does not attempt.

## Note on an earlier commit in this branch

This branch briefly carried a fix for a truncated `@spec` anchor in `lib/Db/TaskSequenceMapper.php`, which was failing gate-46 on `development` itself. **That landed upstream independently as `c130aa2` while this PR was open**, so `development` has been merged in and the commit is now a no-op. The diff is only the two files above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)