### PR TITLE
fix(nav): let users reach Personal settings again

### DIFF
--- a/lib/Db/TaskSequenceMapper.php
+++ b/lib/Db/TaskSequenceMapper.php
@@ -119,7 +119,7 @@ class TaskSequenceMapper extends QBMapper {
 	 *
 	 * @return TaskSequence|null The newest sequence for the template, or null when none has run.
 	 *
-	 * @spec openspec/changes/flow-approval-consolidation/specs/flow-approval-consolidation/spec.md#requirement-an-approval-is-an-ordered-task-sequence-with-o
+	 * @spec openspec/changes/flow-approval-consolidation/specs/flow-approval-consolidation/spec.md#requirement-an-approval-is-an-ordered-task-sequence-with-one-position-enabled-at-a-time
 	 */
 	public function findNewestForTemplate(string $templateId): ?TaskSequence {
 		$qb = $this->db->getQueryBuilder();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -26,9 +26,6 @@
       ]
     },
   "version": "1.1.0",
-  "nav": {
-    "includePersonalSettings": false
-  },
   "pages": [
     {
       "id": "dashboard",


### PR DESCRIPTION
## What this fixes

Both apps carried `nav.includePersonalSettings: false` with no note and nothing in its place. That flag turns off the entry `CnAppNav` auto-prepends at the top of the settings foldout.

**That entry is not decoration.** It opens `CnAppRoot`'s `NcAppSettingsDialog`, whose `#user-settings` slot falls back to the user's **notification preferences** and renders the **ADR-110 Integrations section** below them. Suppressing it put both out of reach from inside the app entirely.

## When the flag *is* correct

For an app that declares its own entry with `action: "user-settings"`, which opens the same dialog. **keepiq does exactly that** and injects its own Session / Security / Encryption sections into the slot, so re-enabling the shell copy there would give it two entries onto one dialog. keepiq is right and is untouched.

Neither of these two declares such an entry, so the flag was only hiding a surface.

## How it was found

Pointing gate-107 (ADR-114, the seven-item app chrome) at the fleet. Three apps set the flag; only keepiq had a replacement. The rule is added to the gate in `ConductionNL/.github` so this cannot recur, with keepiq's shape as the fixture's anti-widening control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)