### PR TITLE
fix(deferral): register the shutdown flush through a closure, and test that it registers

### DIFF
--- a/lib/Service/Deferral/ListenerDeferralService.php
+++ b/lib/Service/Deferral/ListenerDeferralService.php
@@ -311,6 +311,14 @@ class ListenerDeferralService {
 	/**
 	 * Register the shutdown flush exactly once per request.
 	 *
+	 * The callback is a closure calling `flushAll()` rather than the
+	 * `[$this, 'flushAll']` array form it replaced. A string method name is
+	 * invisible to every static tool: a rename of `flushAll()` leaves the
+	 * array callable pointing at nothing and fails only at shutdown, where
+	 * nothing observes it — the deferred jobs would simply stop being
+	 * enqueued, silently. The closure makes the call site greppable and
+	 * rename-safe, and matches ObjectEventProxyListener::traceEnabled().
+	 *
 	 * @return void
 	 */
 	private function hookShutdown(): void {
@@ -319,6 +327,10 @@ class ListenerDeferralService {
 		}
 
 		$this->shutdownHooked = true;
-		register_shutdown_function([$this, 'flushAll']);
+		register_shutdown_function(
+			function (): void {
+				$this->flushAll();
+			}
+		);
 	}//end hookShutdown()
 }//end class

--- a/lib/Service/Object/SearchQueryHandler.php
+++ b/lib/Service/Object/SearchQueryHandler.php
@@ -664,9 +664,17 @@ class SearchQueryHandler {
 
 		// Register the deferred flush once per request; it runs after the
 		// response has been generated so the write cost is off the hot path.
+		// The callback is a closure rather than the `[$this, 'flushSearchTrails']`
+		// array form it replaced: a string method name is invisible to every
+		// static tool, so renaming the flush would break the registration with
+		// no error anywhere — trails would just stop being written.
 		if ($this->trailFlushRegistered === false) {
 			$this->trailFlushRegistered = true;
-			register_shutdown_function([$this, 'flushSearchTrails']);
+			register_shutdown_function(
+				function (): void {
+					$this->flushSearchTrails();
+				}
+			);
 		}
 	}//end logSearchTrail()
 

--- a/tests/Support/ShutdownFunctionSpy.php
+++ b/tests/Support/ShutdownFunctionSpy.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * Intercepts register_shutdown_function() for the two services that defer
+ * work to request shutdown.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `ListenerDeferralService::flushAll()` and
+ * `SearchQueryHandler::flushSearchTrails()` are only ever reached from a
+ * shutdown callback. PHP offers no way to inspect the registered shutdown
+ * functions, so the single line that makes deferred work actually run had no
+ * test at all: delete it and every existing test still passes while, in
+ * production, nothing is ever enqueued or persisted.
+ *
+ * An unqualified call to a global function resolves to the CURRENT namespace
+ * first and only then falls back to the global one. Declaring
+ * `register_shutdown_function()` inside the services' own namespaces
+ * therefore intercepts the real call in the real production line — no seam
+ * in the production class, no subclass that could stub out the very
+ * statement under test.
+ *
+ * Loading this file makes shutdown registration a no-op for the whole test
+ * process, which is also what the suites want: no test should leave a live
+ * shutdown callback behind for PHPUnit to run after the assertions are over.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Support
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Support {
+
+	/**
+	 * Records the callbacks the namespaced stubs below intercept.
+	 */
+	final class ShutdownFunctionSpy {
+
+		/**
+		 * Callbacks handed to register_shutdown_function(), in order.
+		 *
+		 * @var array<int, callable>
+		 */
+		private static array $callbacks = [];
+
+		/**
+		 * Forget every recorded callback. Call from setUp().
+		 *
+		 * @return void
+		 */
+		public static function reset(): void {
+			self::$callbacks = [];
+		}//end reset()
+
+		/**
+		 * Record one intercepted callback.
+		 *
+		 * @param callable $callback The callback that was registered.
+		 *
+		 * @return void
+		 */
+		public static function record(callable $callback): void {
+			self::$callbacks[] = $callback;
+		}//end record()
+
+		/**
+		 * Every callback recorded since the last reset().
+		 *
+		 * @return array<int, callable>
+		 */
+		public static function callbacks(): array {
+			return self::$callbacks;
+		}//end callbacks()
+
+		/**
+		 * Run every recorded callback, as PHP would at request shutdown.
+		 *
+		 * @return void
+		 */
+		public static function runAll(): void {
+			foreach (self::$callbacks as $callback) {
+				$callback();
+			}
+		}//end runAll()
+	}//end class
+}
+
+namespace OCA\OpenRegister\Service\Deferral {
+
+	use OCA\OpenRegister\Tests\Support\ShutdownFunctionSpy;
+
+	/**
+	 * Namespaced override of the global register_shutdown_function().
+	 *
+	 * @param callable $callback Callback the service registers.
+	 * @param mixed    ...$args  Ignored; the services pass no extra args.
+	 *
+	 * @return void
+	 */
+	function register_shutdown_function(callable $callback, mixed ...$args): void {
+		ShutdownFunctionSpy::record($callback);
+	}//end register_shutdown_function()
+}
+
+namespace OCA\OpenRegister\Service\Object {
+
+	use OCA\OpenRegister\Tests\Support\ShutdownFunctionSpy;
+
+	/**
+	 * Namespaced override of the global register_shutdown_function().
+	 *
+	 * @param callable $callback Callback the handler registers.
+	 * @param mixed    ...$args  Ignored; the handler passes no extra args.
+	 *
+	 * @return void
+	 */
+	function register_shutdown_function(callable $callback, mixed ...$args): void {
+		ShutdownFunctionSpy::record($callback);
+	}//end register_shutdown_function()
+}

--- a/tests/Unit/Service/Deferral/ListenerDeferralServiceTest.php
+++ b/tests/Unit/Service/Deferral/ListenerDeferralServiceTest.php
@@ -7,6 +7,7 @@ namespace Unit\Service\Deferral;
 use OCA\OpenRegister\Db\Organisation;
 use OCA\OpenRegister\Service\Deferral\ListenerDeferralService;
 use OCA\OpenRegister\Service\OrganisationService;
+use OCA\OpenRegister\Tests\Support\ShutdownFunctionSpy;
 use OCP\BackgroundJob\IJobList;
 use OCP\IAppConfig;
 use OCP\IUser;
@@ -15,12 +16,14 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
+require_once __DIR__ . '/../../../Support/ShutdownFunctionSpy.php';
+
 /**
  * Chunked buffering, dedupe coalescing, kill switch and fail-soft capture.
  *
- * Every test drains its buffers (chunk flush or explicit flushAll) so the
- * service's register_shutdown_function flush is a guaranteed no-op after the
- * test process ends.
+ * The service's shutdown registration is intercepted by ShutdownFunctionSpy,
+ * so no test leaves a live shutdown callback behind and the registration
+ * itself is asserted on rather than assumed.
  */
 class ListenerDeferralServiceTest extends TestCase {
 	private IUserSession&MockObject $userSession;
@@ -31,6 +34,7 @@ class ListenerDeferralServiceTest extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
+		ShutdownFunctionSpy::reset();
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->organisation = $this->createMock(OrganisationService::class);
 		$this->jobList = $this->createMock(IJobList::class);
@@ -183,6 +187,70 @@ class ListenerDeferralServiceTest extends TestCase {
 
 		$this->assertSame('alice', $argument['userId']);
 		$this->assertNull($argument['organisationUuid']);
+	}
+
+	// ─── Shutdown registration ───────────────────────────────────────
+
+	/**
+	 * Buffering an entry registers the shutdown flush, exactly once per
+	 * request no matter how many entries or job classes follow.
+	 *
+	 * Without this the deferral is a black hole: `defer()` buffers, nothing
+	 * ever flushes, and every other test in this file still passes because
+	 * they all call `flushAll()` by hand.
+	 */
+	public function testDeferRegistersTheShutdownFlushExactlyOnce(): void {
+		$this->actAs('alice', 'org-1');
+		$service = $this->makeService();
+
+		// Well under the default chunk size, so only the shutdown flush can
+		// ever enqueue these.
+		$this->jobList->expects($this->never())->method('add');
+
+		$service->defer(jobClass: 'Some\\Job', entry: ['uuid' => 'a']);
+		$service->defer(jobClass: 'Some\\Job', entry: ['uuid' => 'b']);
+		$service->defer(jobClass: 'Other\\Job', entry: ['uuid' => 'c']);
+
+		$this->assertCount(1, ShutdownFunctionSpy::callbacks());
+	}
+
+	/**
+	 * The callback handed to the shutdown queue really is the flush: running
+	 * it enqueues the buffered work. Proves the registration points at
+	 * flushAll() and not at some other or stale callable.
+	 */
+	public function testRegisteredShutdownCallbackEnqueuesTheBufferedWork(): void {
+		$this->actAs('alice', 'org-1');
+		$service = $this->makeService();
+
+		$enqueued = [];
+		$this->jobList->method('add')
+			->willReturnCallback(function (string $jobClass, $argument) use (&$enqueued): void {
+				$enqueued[] = ['jobClass' => $jobClass, 'argument' => $argument];
+			});
+
+		$service->defer(jobClass: 'Some\\Job', entry: ['uuid' => 'a']);
+
+		// Still only buffered: nothing reached the job list yet.
+		$this->assertSame([], $enqueued);
+		$this->assertCount(1, ShutdownFunctionSpy::callbacks());
+
+		ShutdownFunctionSpy::runAll();
+
+		$this->assertCount(1, $enqueued);
+		$this->assertSame('Some\\Job', $enqueued[0]['jobClass']);
+		$this->assertSame('alice', $enqueued[0]['argument']['userId']);
+		$this->assertSame([['uuid' => 'a']], $enqueued[0]['argument']['entries']);
+	}
+
+	/**
+	 * No entry, no registration: an idle request must not pay for a shutdown
+	 * callback it has nothing to flush.
+	 */
+	public function testNoShutdownCallbackIsRegisteredWithoutADeferredEntry(): void {
+		$this->makeService();
+
+		$this->assertSame([], ShutdownFunctionSpy::callbacks());
 	}
 
 	public function testEnqueueFailureIsLoggedNotThrown(): void {

--- a/tests/Unit/Service/Object/SearchTrailDeferralTest.php
+++ b/tests/Unit/Service/Object/SearchTrailDeferralTest.php
@@ -32,10 +32,13 @@ use OCA\OpenRegister\Db\ViewMapper;
 use OCA\OpenRegister\Service\Object\SearchQueryHandler;
 use OCA\OpenRegister\Service\SearchTrailService;
 use OCA\OpenRegister\Service\SettingsService;
+use OCA\OpenRegister\Tests\Support\ShutdownFunctionSpy;
 use OCP\IRequest;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+
+require_once __DIR__ . '/../../../Support/ShutdownFunctionSpy.php';
 
 /**
  * Unit tests for deferred search-trail recording in SearchQueryHandler.
@@ -56,6 +59,7 @@ class SearchTrailDeferralTest extends TestCase {
 	 */
 	protected function setUp(): void {
 		parent::setUp();
+		ShutdownFunctionSpy::reset();
 
 		$this->viewMapper = $this->createMock(ViewMapper::class);
 		$this->schemaMapper = $this->createMock(SchemaMapper::class);
@@ -188,6 +192,62 @@ class SearchTrailDeferralTest extends TestCase {
 
 		$this->assertSame(3, $this->handler->flushSearchTrails());
 	}//end testFlushPersistsAllBufferedEntries()
+
+	// ─── Shutdown registration ───────────────────────────────────────
+
+	/**
+	 * Buffering a trail entry registers the post-response flush, exactly once
+	 * per request however many searches it serves.
+	 *
+	 * Without this the deferral is a black hole: entries buffer and nothing
+	 * ever persists them, while every other test in this file still passes
+	 * because they all call flushSearchTrails() by hand.
+	 *
+	 * @return void
+	 */
+	public function testLogSearchTrailRegistersTheShutdownFlushExactlyOnce(): void {
+		$this->configureSettings();
+
+		$this->handler->logSearchTrail(['_search' => 'one'], 1, 1, 1.0);
+		$this->handler->logSearchTrail(['_search' => 'two'], 2, 2, 2.0);
+
+		$this->assertCount(1, ShutdownFunctionSpy::callbacks());
+	}//end testLogSearchTrailRegistersTheShutdownFlushExactlyOnce()
+
+	/**
+	 * The callback handed to the shutdown queue really is the flush: running
+	 * it persists the buffered entry. Proves the registration points at
+	 * flushSearchTrails() and not at some other or stale callable.
+	 *
+	 * @return void
+	 */
+	public function testRegisteredShutdownCallbackPersistsTheBufferedTrail(): void {
+		$this->configureSettings();
+
+		$this->searchTrailService->expects($this->once())
+			->method('createSearchTrail')
+			->with(['_search' => 'deferred'], 5, 42, 12.5, 'database')
+			->willReturn(new SearchTrail());
+
+		$this->handler->logSearchTrail(['_search' => 'deferred'], 5, 42, 12.5, 'database');
+		$this->assertCount(1, ShutdownFunctionSpy::callbacks());
+
+		ShutdownFunctionSpy::runAll();
+	}//end testRegisteredShutdownCallbackPersistsTheBufferedTrail()
+
+	/**
+	 * Trails disabled: nothing is buffered, so no shutdown callback is
+	 * registered either.
+	 *
+	 * @return void
+	 */
+	public function testNoShutdownCallbackIsRegisteredWhenTrailsAreDisabled(): void {
+		$this->configureSettings(enabled: false);
+
+		$this->handler->logSearchTrail(['_search' => 'ignored'], 1, 1, 1.0);
+
+		$this->assertSame([], ShutdownFunctionSpy::callbacks());
+	}//end testNoShutdownCallbackIsRegisteredWhenTrailsAreDisabled()
 
 	// ─── Recording disabled ──────────────────────────────────────────
 


### PR DESCRIPTION
## What gate-57 found, and what it turned out to be

Gate-57 (orphaned-write-capability) named two write-capable methods with no production caller:

- `ListenerDeferralService::flushAll()`
- `SearchQueryHandler::flushSearchTrails()`

Neither is dead. Both run from a shutdown function, and both chains are live:

- `flushAll` — five listeners registered in `Application.php` (`SourceRecordChange`, `AnnotationNotification`, `TranslationProjection`, `AggregationThreshold`, `ObjectCleanup`) call `defer()`, which calls `hookShutdown()`.
- `flushSearchTrails` — `ObjectService::recordSearchTrail()` calls `logSearchTrail()`, which arms the flush.

The gate could not see either, because both were registered as `[$this, 'method']`. Its caller index counts `->methodName(` occurrences, and a string method name inside an array callable is not one.

## Why the finding was still worth acting on

The array-callable form is genuinely worse than the closure it replaces, and not only for the gate. Rename either flush and the callable silently points at nothing. The failure surfaces at request shutdown, after the response has been sent, where nothing observes it: deferred listener jobs would stop being enqueued and search trails would stop being written, with no error anywhere. Psalm and PHPStan cannot follow the string either, so no static tool would have caught the rename.

The other three shutdown registrations in this repo (`WritePhaseProbe`, `SchemaMapper`, `ObjectEventProxyListener`) already use closures. These two were the outliers, so this brings them into line rather than inventing a convention.

## The registration had no test

Every existing test called the flush by hand, so deleting the one line that arms it left both suites green. That is the actual latent risk here, and it is now closed.

PHP cannot introspect its shutdown queue. Rather than add a seam to the production class or a subclass (either of which would stub out the very statement under test), the tests declare `register_shutdown_function()` inside the services' own namespaces. An unqualified call resolves to the current namespace before the global one, so the interception happens on the real production line.

Verified by deleting each registration and confirming four tests go red, then restoring.

## Verdicts

| Method | Verdict | Evidence |
| --- | --- | --- |
| `ListenerDeferralService::flushAll` | Live, made visible. No exclusion needed. | ADR-078 requires post-`*ed` listener work to be deferred; five registered listeners reach it. |
| `SearchQueryHandler::flushSearchTrails` | Live, made visible. No exclusion needed. | `openspec/specs/search-trail-recording/spec.md` states recording is best-effort, so the fail-soft flush is correct and discards nothing the spec retains. |

Neither needed a gate exclusion, and neither was deleted.

## Checks (local)

- gate-57 reproduced on the pre-fix files (both named), and silent after
- hydra gates v1.11.0 diff-scoped: all 29 applicable gates green
- 19105 unit tests green, 0 failures
- phpcs, phpmd, psalm, phpstan clean on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)