### PR TITLE
fix(ci): a standing release PR ran every development push twice

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -172,7 +172,31 @@ permissions:
 
 jobs:
   quality:
-    if: github.event_name != 'push' || github.event.created != true
+    # SECOND CLAUSE: skip the run a STANDING release PR triggers.
+    #
+    # `Release: merge development into beta` is permanently open with
+    # `head_ref: development`, so every push to development fires this
+    # workflow TWICE on the SAME sha — once for `push`, once for that PR's
+    # `pull_request` event. The concurrency block above deliberately gives
+    # them separate lanes so the push run is not cancelled, which is right,
+    # and the consequence is that both run to completion.
+    #
+    # The PR run is the redundant one, not the push run: its head sha IS
+    # development's, which the push run already decided, and the push run
+    # carries jobs the PR run does not (Coverage Baseline Check, SBOM,
+    # Features Extract). Measured 2026-09-03: runs 33747123932 (push) and
+    # 33747129312 (pull_request), same sha b8eb72e2, four seconds apart.
+    #
+    # 20 of the fleet's 21 apps carry `beta` in `pull_request.branches` and
+    # so pay this on every development push. Removing `beta` from that list
+    # would also work and is worse: the `release/v*` and `sync/main-to-beta`
+    # PRs genuinely need their run, and they target `beta` too.
+    #
+    # A `development -> main` promotion PR is skipped by the same clause, for
+    # the same reason and just as correctly.
+    if: >-
+      (github.event_name != 'push' || github.event.created != true)
+      && (github.event_name != 'pull_request' || github.head_ref != 'development')
     uses: ConductionNL/.github/.github/workflows/quality.yml@main
     with:
       app-name: openregister


### PR DESCRIPTION
Every push to `development` fires Code Quality **twice on the same commit** — once for the `push` event, once for the `pull_request` event of the permanently-open "Release: merge development into beta", whose `head_ref` **is** `development`.

Measured here on 2026-09-03:

| run | event | sha | created |
|---|---|---|---|
| 33747123932 | `push` | `b8eb72e2` | 10:58:04Z |
| 33747129312 | `pull_request` | `b8eb72e2` | 10:58:08Z |

Four seconds apart, same commit, both running the full suite to completion.

## Why not fix the concurrency block

Because it is not the bug. It suffixes the group by event name **deliberately**, so the push run is not cancelled by the PR run — the push run is the only carrier of Coverage Baseline Check, SBOM and Features Extract, and the PR run would always win the race by a few seconds. That reasoning is right and the comment above it explains it at length. The consequence is simply that both lanes run to completion, so the duplicate has to be dropped at the job.

## Why the PR run is the one to drop

Its head sha **is** development's — the commit the push run already decided — and it runs strictly fewer jobs. Dropping the push run instead would lose the three push-only gates.

## Why not just remove `beta` from `pull_request.branches`

That would also stop it, and it is worse. Every PR targeting `beta` is a bot PR of one of three shapes:

- `development -> beta` — the standing one, redundant
- `release/v* -> beta` — a release candidate, **needs its run**
- `sync/main-to-beta-* -> beta` — **needs its run**

Only the `head_ref: development` one is redundant, so only that one is skipped. A `development -> main` promotion PR is skipped by the same clause, for the same reason and just as correctly.

## Scope

**20 of the fleet's 21 apps** carry `beta` in `pull_request.branches` and pay this on every development push; dossiq is the only exception. This lands the fix here first — openregister had 7 queued and 3 in-progress runs when this was measured. The rest follow once a development push here shows one Code Quality run instead of two.

For context on the scale this sits in: the comment already in this file records that a previous sweep found **659 of 2,106** Code Quality runs were duplicates of a different shape (31% of the fleet's most expensive workflow), against an account ceiling of 60 concurrent jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)