### PR TITLE
fix(spec): complete the @spec anchor truncated mid-slug

### DIFF
--- a/lib/Db/TaskSequenceMapper.php
+++ b/lib/Db/TaskSequenceMapper.php
@@ -119,7 +119,7 @@ class TaskSequenceMapper extends QBMapper {
 	 *
 	 * @return TaskSequence|null The newest sequence for the template, or null when none has run.
 	 *
-	 * @spec openspec/changes/flow-approval-consolidation/specs/flow-approval-consolidation/spec.md#requirement-an-approval-is-an-ordered-task-sequence-with-o
+	 * @spec openspec/changes/flow-approval-consolidation/specs/flow-approval-consolidation/spec.md#requirement-an-approval-is-an-ordered-task-sequence-with-one-position-enabled-at-a-time
 	 */
 	public function findNewestForTemplate(string $templateId): ?TaskSequence {
 		$qb = $this->db->getQueryBuilder();


### PR DESCRIPTION
`gate-46` (spec-anchor-existence) is red on `development`, and this is the single finding.

The anchor in `TaskSequenceMapper::findNewestForTemplate()` stops at `...-sequence-with-o`, halfway through `one-position-enabled-at-a-time`, so it resolves to nothing. It arrived with #3360 earlier today.

Worth calling out because the gate's own message truncates the anchor it reports:

```
[gate-46] spec-anchor-existence: FAIL — 1 unresolved @spec finding(s) ...
  → #requirement-an-approval-is-an-ordered-task-sequence-with-o
```

That reads as though the gate did the truncating. It did not — the anchor really is cut short in the source, and the heading it should point at is in the same spec file.

## Verification

Run with the gate's own checker (`vendor/conduction/hydra-gates/.../check_spec_anchors.py`):

- `lib/Db/TaskSequenceMapper.php`: 1 finding → **0**
- full-tree over every `lib/**/*.php`: **0 findings**

Checked first whether the three in-flight spec-anchor branches (`fix/license-triangle-and-spec-anchors`, `wip/spec-anchor-repair`, `wip/spec-anchor-repair-round2`) already covered this file. None of them touch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)