### PR TITLE
chore(deps): nextcloud-vue 2.35.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
-        "@conduction/nextcloud-vue": "^2.31.1",
+        "@conduction/nextcloud-vue": "^2.35.1",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "^2.6.0",
         "@nextcloud/capabilities": "^1.2.1",
@@ -2289,9 +2289,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.31.1",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.31.1.tgz",
-      "integrity": "sha512-tF1/7yNaBgxj5iHhpNuxVdUrPugfy2ePQZILl7y+fFJTq68tR7WPs8EqPin8aaCBc6ZxgWp1ciyY+NW9rXBMYA==",
+      "version": "2.35.1",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.35.1.tgz",
+      "integrity": "sha512-PgcUCtBaqPVT/ZQNUs8Hnrk8n9r4qQQiaGDzPWeY7P6aqgPO+kEhpJEssmfV5Q8CwB5Cw5AgJHGI7aOIGVAlsw==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
-    "@conduction/nextcloud-vue": "^2.31.1",
+    "@conduction/nextcloud-vue": "^2.35.1",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "^2.6.0",
     "@nextcloud/capabilities": "^1.2.1",


### PR DESCRIPTION
openregister's bootstrap is what populates the integration registry, so a leaf fix only reaches the fleet when **this** app is rebuilt.

That is worth stating plainly because it cost me two wrong conclusions. dossiq bumping its own copy of the library changed nothing about the registered descriptors, so a fix that was correct in the library still showed the old behaviour on a case, and every static check agreed with me.

## What 2.35.1 brings

- The **notes** leaf renders its widget surface in a tab panel, so the panel gets the inline compose textarea and the widget's own styling instead of the sidebar component's.
- The **registry carries `bareWidget`** through registration. Without this the flag above is dropped by the normaliser and the opt-in silently does nothing.
- A **contact moment** leaf sourced from pipelinq's per-entity activity endpoint.
- **Array-mode dynamic properties**, so a schema can store form answers on the parent object instead of one child record each.

## Verified on the running instance, not from the version number

After this bump and rebuild, on a live dossiq case:

- `window.OCA.OpenRegister.integrations.get('notes').bareWidget` is `true`
- the tabbed Notes panel renders `CnNotesCard` **with** a `textarea`
- it carries no `cn-sidebar-tab` markup
- and it draws **no** `CnDetailCard` of its own, so there is no card nested inside the tabs card

The registry also now lists `contactmoment` among its 30 integrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
