### PR TITLE
fix(e2e): make the chrome specs pass in a real browser

### DIFF
--- a/tests/e2e/ci/app-chrome.spec.ts
+++ b/tests/e2e/ci/app-chrome.spec.ts
@@ -20,6 +20,8 @@
  *
  * ⚠️ SETTINGS ENTRIES ARE ATTACHED, NOT VISIBLE, inside a collapsed foldout.
  */
+import type { Page } from '@playwright/test'
+
 import { expect, test } from '@playwright/test'
 import * as fs from 'fs'
 import * as path from 'path'
@@ -27,6 +29,26 @@ import * as path from 'path'
 const STORAGE_STATE = path.resolve(__dirname, '../.auth/admin.json')
 
 test.use(fs.existsSync(STORAGE_STATE) ? { storageState: STORAGE_STATE } : {})
+
+/**
+ * Dismiss the first-run setup wizard if it is open.
+ *
+ * ⚠️ On a FRESH instance CnSetupWizard opens over the app and its modal
+ * intercepts pointer events, so every nav click resolves its locator and then
+ * times out after 30s — a failure that reads like the navigation is broken.
+ * Tests that navigate by URL pass, which is what makes this so easy to miss:
+ * only the click-through tests fail, and only on a clean install.
+ *
+ * @param page The page.
+ */
+async function dismissSetupWizard(page: Page): Promise<void> {
+	const modal = page.locator('[data-testid="cn-modal"]')
+	if ((await modal.count()) === 0) {
+		return
+	}
+	await modal.first().getByRole('button', { name: 'Close' }).click()
+	await expect(modal).toHaveCount(0, { timeout: 15_000 })
+}
 
 test.describe('app chrome (ADR-114)', () => {
 	test.beforeEach(async ({ page }) => {
@@ -36,6 +58,7 @@ test.describe('app chrome (ADR-114)', () => {
 		await expect(page.locator('[data-testid="cn-nav"]')).toBeVisible({
 			timeout: 30_000,
 		})
+		await dismissSetupWizard(page)
 	})
 
 	test('the footer reads Documentation, Reports, Features & roadmap, each with a glyph', async ({
@@ -115,7 +138,7 @@ test.describe('app chrome (ADR-114)', () => {
 
 		const admin = nav.locator('[data-testid="cn-nav-admin-settings"]')
 		await expect(admin).toBeAttached()
-		await expect(admin).toHaveAttribute(
+		await expect(admin.locator('a').first()).toHaveAttribute(
 			'href',
 			/\/settings\/admin\/openregister$/,
 		)


### PR DESCRIPTION
The ADR-114 chrome specs had only ever been **collected**, never run. Collecting proves a spec parses; it proves nothing about whether it passes. Running them against a real Nextcloud found three defects, all of which shipped in every app's spec.

## 1. The testid is on the wrapper, not the link

`cn-nav-entry-*` and `cn-nav-admin-settings` sit on the `<li class="app-navigation-entry-wrapper">`. The clickable element and the `href` both live on the `<a class="app-navigation-entry-link">` inside it.

So `.click()` on the testid **resolved the locator and then never became actionable** — a 30-second timeout that reads like the navigation is broken — and `toHaveAttribute('href', …)` on it returned `null`, which the report renders as the string `"null"`.

## 2. The setup wizard modal eats the clicks

On a **fresh** instance `CnSetupWizard` opens over the app, and its modal subtree intercepts pointer events:

```
<div class="modal-wrapper modal-wrapper--large"> … subtree intercepts pointer events
```

Every click-through test failed; every URL-navigation test passed. That asymmetry is exactly what makes this easy to miss — the suite looks two-thirds healthy. The specs now dismiss the wizard in `beforeEach`.

## 3. A single-word text probe matched an SVG title

`getByText('Open', { exact: false })` matched `<title>Opens in a new tab</title>` on an external-link icon: attached, hidden, and nothing to do with the report under test. Single-word probes are now scoped to `main, .app-content` and use a string only the report can supply.

## How this was verified

A throwaway Nextcloud on its own compose project and port — deliberately **not** the shared `:8080`, and not the other sessions' containers, both of which this fleet has been bitten by before.

- **planninq: 6/6 green** (was 3 failed / 3 passed)
- **keepiq: 5/5 green** (was 5 failed)

Every other app receives the same mechanical fix, linted and formatted in its own app's style. Their suites are not individually executed here — each needs its own `npm ci` plus a webpack build to test the icon assertions honestly — so this PR claims the fix, not a per-app green run.

One thing worth recording: an earlier attempt reported keepiq's Reports page rendering "This page is empty". That was **not** a product defect — it was a borrowed `node_modules` from a sibling checkout pinning nc-vue 2.27.2 where keepiq declares `^2.32.0`, too old to know the `reports` page type. With the declared version installed, the page renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
