### PR TITLE
fix(nav): let an admin reach the admin settings again

### DIFF
--- a/src/navigation/MainMenu.vue
+++ b/src/navigation/MainMenu.vue
@@ -1,5 +1,5 @@
 <template>
-	<CnAppNav :manifest="manifest" :translate="translate">
+	<CnAppNav :manifest="manifest" :translate="translate" :isAdmin="isAdmin">
 		<!-- Primary action: the active-organisation switcher button. Rendered
 		     in CnAppNav's #primary-action slot because its label is live store
 		     state (organisationStore.activeOrganisation) — the manifest's
@@ -19,6 +19,7 @@
 
 <script>
 import { CnAppNav } from '@conduction/nextcloud-vue'
+import { getCurrentUser } from '@nextcloud/auth'
 import { translate as t } from '@nextcloud/l10n'
 import { NcAppNavigationNew } from '@nextcloud/vue'
 // Icons
@@ -43,6 +44,31 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * Whether the current user administers this instance.
+		 *
+		 * CnAppRoot computes this and passes it to the CnAppNav it renders
+		 * itself. This app fills the #menu slot, and that slot carries no
+		 * scope, so the prop never arrived and CnAppNav defaulted it to
+		 * false. The Admin settings entry is gated on it, so it silently did
+		 * not render for anybody, on an app whose whole admin surface lives
+		 * there.
+		 *
+		 * Visibility only. Nextcloud's settings framework refuses
+		 * /settings/admin/openregister server-side for a non-admin.
+		 *
+		 * @return {boolean} True when the user administers the instance.
+		 *
+		 * @spec exclude App-navigation plumbing: forwards a visibility flag CnAppRoot already computes; the access decision is Nextcloud's.
+		 */
+		isAdmin() {
+			try {
+				return getCurrentUser()?.isAdmin === true
+			} catch {
+				return false
+			}
+		},
+
 		/**
 		 * Get the active organisation name to display in navigation.
 		 * Shows the current organisational context for the user.

--- a/tests/e2e/ci/app-chrome.spec.ts
+++ b/tests/e2e/ci/app-chrome.spec.ts
@@ -115,7 +115,11 @@ test.describe('app chrome (ADR-114)', () => {
 
 		const admin = nav.locator('[data-testid="cn-nav-admin-settings"]')
 		await expect(admin).toBeAttached()
-		await expect(admin).toHaveAttribute(
+		// The testid rides the NcAppNavigationItem wrapper, which is an <li>.
+		// The href is on the anchor inside it, so assert it there: on the
+		// wrapper the attribute is simply absent and the failure reads as a
+		// wrong destination rather than a wrong locator.
+		await expect(admin.locator('a').first()).toHaveAttribute(
 			'href',
 			/\/settings\/admin\/openregister$/,
 		)


### PR DESCRIPTION
## What was broken

The Admin settings entry rendered for nobody, on the app whose whole admin surface lives behind it. `tests/e2e/ci/app-chrome.spec.ts` has been red on `development` since the chrome change landed in #3379.

## Why

`CnAppRoot` computes `isAdmin` from `getCurrentUser()?.isAdmin` and passes it to the `CnAppNav` it renders itself. This app fills the `#menu` slot with its own `MainMenu`, and that slot carries no scope, so the prop never arrived. `CnAppNav` defaults `isAdmin` to `false`, and `showAdminSettingsLink` is gated on it.

Nothing failed loudly. The entry simply was not there.

`MainMenu` now computes it the same way `CnAppRoot` does. Visibility only: Nextcloud's settings framework refuses `/settings/admin/openregister` server-side for a non-admin, and that is unchanged.

## A second defect behind the first

The spec asserted the href on the element carrying the testid:

```js
const admin = nav.locator('[data-testid="cn-nav-admin-settings"]')
await expect(admin).toHaveAttribute('href', /\/settings\/admin\/openregister$/)
```

That testid rides the `NcAppNavigationItem` wrapper, which is an `<li>`. The href is on the anchor inside it. So with the entry restored the assertion would still have failed, and it would have read as a wrong destination rather than a wrong locator. It now asserts on the anchor.

## Verification

Rebuilt a local instance and ran the spec against it. 4 of 5 chrome tests pass, this one included. The fifth, "Reports opens the reports surface", times out clicking a link the call log shows as visible, enabled and stable; it passes in CI and is unrelated to this change.

## Root cause, fixed separately

ConductionNL/nextcloud-vue `fix/menu-slot-carries-its-props` gives the `#menu` slot its bindings, so the next app to wrap `CnAppNav` cannot lose them silently. This PR does not depend on it.
