### PR TITLE
chore(deps): nextcloud-vue 2.36.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
-        "@conduction/nextcloud-vue": "^2.35.1",
+        "@conduction/nextcloud-vue": "^2.36.0",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "^2.6.0",
         "@nextcloud/capabilities": "^1.2.1",
@@ -2289,9 +2289,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.35.1",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.35.1.tgz",
-      "integrity": "sha512-PgcUCtBaqPVT/ZQNUs8Hnrk8n9r4qQQiaGDzPWeY7P6aqgPO+kEhpJEssmfV5Q8CwB5Cw5AgJHGI7aOIGVAlsw==",
+      "version": "2.36.0",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.36.0.tgz",
+      "integrity": "sha512-CG1jeuFLfR0E47vojUq5lvzWPWXQeffR/Nl9+kuiakqT9QggeT1mndH0zCcoCpK70pcyJeI02LUhqjOvAuvThw==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
-    "@conduction/nextcloud-vue": "^2.35.1",
+    "@conduction/nextcloud-vue": "^2.36.0",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "^2.6.0",
     "@nextcloud/capabilities": "^1.2.1",


### PR DESCRIPTION
Picks up two cascade fixes that only a real Nextcloud page could show, and that reach users specifically through **this** app's bundle: integration leaves render from openregister's `integration-global` entry, so a consuming app bumping the library does not move them.

- **Nextcloud sets `margin-bottom: 3px` on every plain button**, with a selector scoring (0,2,1) against the library's scoped (0,2,0). Tab strips sat 4px above their bar's rule and the open tab never met its panel.
- **A dynamic component root stopped Vue applying scope ids inside `CnNotesCard`**, so Nextcloud's own `textarea { width: 130px }` won.

## Verified after rebuilding

The tab join measures **1px** on a case detail page, against 5px before. Full width and the KPI tiles are unaffected.

## One known gap this does NOT fix

The `integrationGlobal` entry resolves `CnDetailCard`'s **CSS** but not the **component**: a tabbed notes leaf renders `<cndetailcard>` as an unresolved custom element and loses its scoped styling. The same page has a correctly resolved `.cn-detail-card` elsewhere, so it is specific to that self-contained bundle, which is deliberately excluded from chunk splitting.

Tracked in #3387. A global width floor landed in the library (ConductionNL/nextcloud-vue#984) so the composer is at least usable meanwhile, but the resolution gap itself belongs here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
