### PR TITLE
feat(store): let a store declare its discovery source

### DIFF
--- a/lib/AppHost/Controller/GenericStoreController.php
+++ b/lib/AppHost/Controller/GenericStoreController.php
@@ -48,6 +48,7 @@ use OCA\OpenRegister\AppHost\Service\GenericStoreService;
 use OCA\OpenRegister\AppHost\Service\StoreDescriptor;
 use OCA\OpenRegister\AppHost\Store\FederatedStoreCatalog;
 use OCA\OpenRegister\AppHost\Store\GenericStoreInstaller;
+use OCA\OpenRegister\AppHost\Store\Source\GitHubStoreSource;
 use OCA\OpenRegister\AppHost\Store\StoreManifest;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -92,6 +93,13 @@ class GenericStoreController extends Controller {
 	 * @param GenericStoreService   $storeService   Guarded remote discovery.
 	 * @param GenericStoreInstaller $installer      Declarative component install.
 	 * @param FederatedStoreCatalog $catalog        Configuration browse and install.
+	 * @param GitHubStoreSource     $gitHubSource  GitHub discovery source.
+	 *
+	 * @SuppressWarnings(PHPMD.ExcessiveParameterList) Each collaborator is one
+	 * discovery or install path the engine owns on a leaf app's behalf, and the
+	 * count grew because the plane absorbed work the apps used to do
+	 * themselves. Grouping them behind a locator would hide which paths exist
+	 * from the one file that has to choose between them.
 	 * @param IUserSession          $userSession    Current session.
 	 * @param IGroupManager         $groupManager   Admin check for install.
 	 * @param LoggerInterface       $logger         PSR logger.
@@ -103,6 +111,7 @@ class GenericStoreController extends Controller {
 		private readonly GenericStoreService $storeService,
 		private readonly GenericStoreInstaller $installer,
 		private readonly FederatedStoreCatalog $catalog,
+		private readonly GitHubStoreSource $gitHubSource,
 		private readonly IUserSession $userSession,
 		private readonly IGroupManager $groupManager,
 		private readonly LoggerInterface $logger,
@@ -161,7 +170,7 @@ class GenericStoreController extends Controller {
 
 		try {
 			$descriptor = $this->descriptor(store: $store);
-			$result = $this->searchFor(descriptor: $descriptor, query: $query, kind: $kind);
+			$result = $this->searchFor(store: $store, descriptor: $descriptor, query: $query, kind: $kind);
 		} catch (Throwable $e) {
 			// Detail to the log, generic outcome to the browser: a registry's
 			// internals are not the caller's business.
@@ -283,6 +292,7 @@ class GenericStoreController extends Controller {
 	 * rows. Selected by declaration, never by probing: an app that declares
 	 * none makes no discovery call at all.
 	 *
+	 * @param StoreManifest   $store      The calling app's declared store block.
 	 * @param StoreDescriptor $descriptor The calling app's store parameters.
 	 * @param string|null     $query      Optional free-text search term.
 	 * @param string|null     $kind       Optional kind filter.
@@ -291,7 +301,24 @@ class GenericStoreController extends Controller {
 	 *
 	 * @spec openspec/changes/store-over-federated-config/specs/apphost-store-plane/spec.md#scenario-an-app-that-declares-no-types-keeps-the-object-store
 	 */
-	private function searchFor(StoreDescriptor $descriptor, ?string $query, ?string $kind): array {
+	private function searchFor(
+		StoreManifest $store,
+		StoreDescriptor $descriptor,
+		?string $query,
+		?string $kind
+	): array {
+		// The declared source is checked FIRST. A github store has no registry
+		// URL at all, so falling through to the OpenRegister path would report
+		// it as `not_configured` — true of a registry it never declared, and
+		// useless to whoever has to act on it.
+		if ($store->source === 'github') {
+			return $this->gitHubSource->search(
+				manifest: $store,
+				query: ($query ?? ''),
+				kind: $kind
+			);
+		}
+
 		if ($descriptor->isFederated() === true) {
 			return $this->catalog->search(descriptor: $descriptor, query: $query, kind: $kind);
 		}

--- a/lib/AppHost/Service/GenericStoreService.php
+++ b/lib/AppHost/Service/GenericStoreService.php
@@ -83,6 +83,17 @@ class GenericStoreService {
 	public const OUTCOME_INVALID = 'store_invalid_response';
 
 	/**
+	 * Outcome: the source refused because a rate limit is in force.
+	 *
+	 * 🔴 NOT INTERCHANGEABLE WITH `store_unreachable`. The remedy differs and
+	 * the reader acts on it: rate limited means wait, or add a credential to
+	 * raise the limit; unreachable means the network or the registry is
+	 * broken. Reporting the first as the second sends somebody to debug a
+	 * network that is fine.
+	 */
+	public const OUTCOME_RATE_LIMITED = 'rate_limited';
+
+	/**
 	 * Connect + request timeout (seconds) for every remote fetch.
 	 */
 	private const TIMEOUT = 10;

--- a/lib/AppHost/Store/Source/GitHubStoreSource.php
+++ b/lib/AppHost/Store/Source/GitHubStoreSource.php
@@ -1,0 +1,333 @@
+<?php
+
+/**
+ * OpenRegister AppHost — GitHub discovery source.
+ *
+ * Searches the GitHub repository API by topic, which is how buildiq and hermiq
+ * already find their store items. Declaring `"source": "github"` with a
+ * `topics` list is what lets them migrate onto the generic plane without
+ * writing a controller.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Store
+ * @package  OCA\OpenRegister\AppHost\Store\Source
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\AppHost\Store\Source;
+
+use OCA\OpenRegister\AppHost\Service\GenericStoreService;
+use OCA\OpenRegister\AppHost\Store\StoreManifest;
+use OCP\Http\Client\IClient;
+use OCP\Http\Client\IClientService;
+use OCP\ICache;
+use OCP\ICacheFactory;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Discovery against the GitHub repository search API.
+ *
+ * 🔴 THE HOST IS A COMPILE-TIME CONSTANT AND MUST STAY ONE.
+ *
+ * The `openregister` source reads an admin-configured URL, which is exactly
+ * why that path carries an SSRF guard and refuses redirects. Here there is no
+ * URL for an app or an admin to influence, so there is nothing to guard — a
+ * stronger position, and one that only holds while the constant is a constant.
+ * Making the host configurable would reintroduce the whole SSRF surface for
+ * the sake of a case nobody has asked for.
+ *
+ * @spec openspec/changes/store-plane-declarative-sources/specs/apphost-store-plane/spec.md#requirement-a-github-source-must-discover-by-topic-against-a-compile-time-host
+ */
+class GitHubStoreSource implements StoreSourceInterface {
+	/**
+	 * The only host this source will ever contact.
+	 */
+	private const API_HOST = 'https://api.github.com';
+
+	/**
+	 * Connect + request timeout, seconds.
+	 */
+	private const TIMEOUT = 10;
+
+	/**
+	 * Cards returned by a single search, across every topic.
+	 */
+	private const MAX_HITS = 30;
+
+	/**
+	 * Seconds a search answer stays fresh.
+	 *
+	 * 🔴 THIS IS NOT AN OPTIMISATION. GitHub's unauthenticated search limit is
+	 * ten requests a minute for the whole instance, so without a cache one
+	 * person typing past the debounce exhausts it and the store turns
+	 * `rate_limited` for everybody. buildiq and hermiq both already cache for
+	 * this reason.
+	 */
+	private const SEARCH_TTL = 60;
+
+	/**
+	 * Cache for search answers, or null when no distributed cache is available.
+	 *
+	 * @var ICache|null
+	 */
+	private ?ICache $cache = null;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IClientService  $clientService Nextcloud HTTP client factory.
+	 * @param ICacheFactory   $cacheFactory  Distributed cache factory.
+	 * @param LoggerInterface $logger        PSR logger, server-side only.
+	 */
+	public function __construct(
+		private readonly IClientService $clientService,
+		ICacheFactory $cacheFactory,
+		private readonly LoggerInterface $logger,
+	) {
+		if ($cacheFactory->isAvailable() === true) {
+			$this->cache = $cacheFactory->createDistributed('openregister_store_github');
+		}
+	}//end __construct()
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return string
+	 */
+	public function sourceId(): string {
+		return 'github';
+	}//end sourceId()
+
+	/**
+	 * Search every declared topic and merge the results.
+	 *
+	 * @param StoreManifest $manifest The declaring app's store block.
+	 * @param string        $query    Free-text search, possibly empty.
+	 * @param string|null   $kind     Kind filter, or null for every kind.
+	 *
+	 * @return array{outcome: string, cards: array<int, array<string, mixed>>}
+	 */
+	public function search(StoreManifest $manifest, string $query, ?string $kind): array {
+		$topics = $this->topicsFor(manifest: $manifest, kind: $kind);
+		if ($topics === []) {
+			// A kind that maps to no topic found nothing. That is an empty
+			// answer, not a broken one.
+			return ['outcome' => GenericStoreService::OUTCOME_OK, 'cards' => []];
+		}
+
+		$key = $this->cacheKey(appId: $manifest->appId, topics: $topics, query: $query);
+		$hit = ($this->cache?->get($key) ?? null);
+		if (is_string($hit) === true) {
+			$decoded = json_decode($hit, true);
+			if (is_array($decoded) === true && isset($decoded['outcome'], $decoded['cards']) === true) {
+				return ['outcome' => (string)$decoded['outcome'], 'cards' => (array)$decoded['cards']];
+			}
+		}
+
+		$answer = $this->fetchTopics(topics: $topics, query: $query);
+
+		// 🔴 CACHE THE FAILURES TOO. A rate-limited answer that is not cached
+		// sends the very next keystroke back at an API that just said stop,
+		// which is how a brief limit becomes a persistent one.
+		$this->cache?->set($key, json_encode($answer), self::SEARCH_TTL);
+
+		return $answer;
+	}//end search()
+
+	/**
+	 * Which topics to search for a given kind filter.
+	 *
+	 * A store may declare one topic per kind, positionally, or a single topic
+	 * for everything. An out-of-range kind narrows to nothing rather than
+	 * quietly searching every topic, because "no results for that kind" is
+	 * true and "here is everything" is not.
+	 *
+	 * @param StoreManifest $manifest The store block.
+	 * @param string|null   $kind     Kind filter, or null.
+	 *
+	 * @return array<int, string>
+	 */
+	private function topicsFor(StoreManifest $manifest, ?string $kind): array {
+		if ($kind === null || $kind === '' || $manifest->kinds === []) {
+			return $manifest->topics;
+		}
+
+		$index = array_search(needle: $kind, haystack: $manifest->kinds, strict: true);
+		if ($index === false) {
+			return [];
+		}
+
+		return [($manifest->topics[$index] ?? $manifest->topics[0] ?? '')];
+	}//end topicsFor()
+
+	/**
+	 * Issue one search per topic and merge, de-duplicating by owner/repo.
+	 *
+	 * @param array<int, string> $topics Topics to search.
+	 * @param string             $query  Free-text search.
+	 *
+	 * @return array{outcome: string, cards: array<int, array<string, mixed>>}
+	 */
+	private function fetchTopics(array $topics, string $query): array {
+		$client = $this->clientService->newClient();
+		$cards = [];
+		$outcome = GenericStoreService::OUTCOME_OK;
+
+		foreach ($topics as $topic) {
+			if ($topic === '') {
+				continue;
+			}
+
+			$one = $this->fetchTopic(client: $client, topic: $topic, query: $query);
+			if ($one['outcome'] !== GenericStoreService::OUTCOME_OK) {
+				// Worst outcome wins across topics: one reachable topic does
+				// not make a half-answer look complete.
+				$outcome = $one['outcome'];
+				continue;
+			}
+
+			foreach ($one['cards'] as $card) {
+				// De-duplicate by full name: a repository carrying two of the
+				// declared topics is one item, not two.
+				$cards[$card['slug']] = $card;
+			}
+		}
+
+		return [
+			'outcome' => $outcome,
+			'cards' => array_slice(array_values($cards), 0, self::MAX_HITS),
+		];
+	}//end fetchTopics()
+
+	/**
+	 * Search a single topic.
+	 *
+	 * @param IClient $client The HTTP client.
+	 * @param string  $topic  The topic to search.
+	 * @param string  $query  Free-text search.
+	 *
+	 * @return array{outcome: string, cards: array<int, array<string, mixed>>}
+	 */
+	private function fetchTopic(IClient $client, string $topic, string $query): array {
+		$search = 'topic:' . $topic;
+		if ($query !== '') {
+			$search .= ' ' . $query;
+		}
+
+		try {
+			$response = $client->get(
+				self::API_HOST . '/search/repositories',
+				[
+					'query' => ['q' => $search, 'per_page' => self::MAX_HITS],
+					'headers' => ['Accept' => 'application/vnd.github+json'],
+					'timeout' => self::TIMEOUT,
+					'connect_timeout' => self::TIMEOUT,
+					'allow_redirects' => false,
+					'http_errors' => false,
+				]
+			);
+		} catch (Throwable $e) {
+			$this->logger->warning(
+				'[store/github] search failed: ' . $e->getMessage(),
+				['topic' => $topic]
+			);
+			return ['outcome' => GenericStoreService::OUTCOME_UNREACHABLE, 'cards' => []];
+		}
+
+		$outcome = $this->outcomeFor(status: $response->getStatusCode());
+		if ($outcome !== GenericStoreService::OUTCOME_OK) {
+			return ['outcome' => $outcome, 'cards' => []];
+		}
+
+		$body = json_decode((string)$response->getBody(), true);
+		if (is_array($body) === false || is_array(($body['items'] ?? null)) === false) {
+			return ['outcome' => GenericStoreService::OUTCOME_INVALID, 'cards' => []];
+		}
+
+		$cards = [];
+		foreach ($body['items'] as $item) {
+			if (is_array($item) === true) {
+				$cards[] = $this->toCard(repo: $item, topic: $topic);
+			}
+		}
+
+		return ['outcome' => GenericStoreService::OUTCOME_OK, 'cards' => $cards];
+	}//end fetchTopic()
+
+	/**
+	 * Map an HTTP status onto a store outcome.
+	 *
+	 * 🔴 403 and 429 are RATE LIMITING, not unreachability. GitHub answers 403
+	 * for an exhausted limit, which is the case a reader can actually do
+	 * something about.
+	 *
+	 * @param int $status The HTTP status code.
+	 *
+	 * @return string
+	 */
+	private function outcomeFor(int $status): string {
+		if ($status === 403 || $status === 429) {
+			return GenericStoreService::OUTCOME_RATE_LIMITED;
+		}
+
+		if ($status < 200 || $status >= 300) {
+			return GenericStoreService::OUTCOME_UNREACHABLE;
+		}
+
+		return GenericStoreService::OUTCOME_OK;
+	}//end outcomeFor()
+
+	/**
+	 * Normalise one repository into a store card.
+	 *
+	 * The slug is `owner/repo`, not the bare name: repository names are not
+	 * unique across owners, and a card list keyed on the bare name silently
+	 * collapses two different apps into one.
+	 *
+	 * @param array<string, mixed> $repo One GitHub search result.
+	 * @param string               $topic The topic it was found under.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function toCard(array $repo, string $topic): array {
+		return [
+			'slug' => (string)($repo['full_name'] ?? ''),
+			'title' => (string)($repo['name'] ?? ''),
+			'description' => (string)($repo['description'] ?? ''),
+			'kind' => $topic,
+			'version' => (string)($repo['default_branch'] ?? ''),
+			'publisher' => (string)(($repo['owner'] ?? [])['login'] ?? ''),
+			'stars' => (int)($repo['stargazers_count'] ?? 0),
+			'url' => (string)($repo['html_url'] ?? ''),
+		];
+	}//end toCard()
+
+	/**
+	 * Cache key for one search.
+	 *
+	 * Scoped by app id: two apps searching the same topic still get their own
+	 * entry, so a change to one app's block cannot serve stale cards to the
+	 * other.
+	 *
+	 * @param string             $appId  Declaring app.
+	 * @param array<int, string> $topics Topics searched.
+	 * @param string             $query  Free-text search.
+	 *
+	 * @return string
+	 */
+	private function cacheKey(string $appId, array $topics, string $query): string {
+		return $appId . ':' . md5(implode(',', $topics) . '|' . $query);
+	}//end cacheKey()
+}

--- a/lib/AppHost/Store/Source/StoreSourceInterface.php
+++ b/lib/AppHost/Store/Source/StoreSourceInterface.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * OpenRegister AppHost — Store discovery source.
+ *
+ * A store's discovery half, behind one seam. `GenericStoreService` used to BE
+ * the OpenRegister source; splitting the interface out is what lets an app
+ * declare `"source": "github"` and get a store that searches repositories by
+ * topic without the app writing a controller.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Store
+ * @package  OCA\OpenRegister\AppHost\Store\Source
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\AppHost\Store\Source;
+
+use OCA\OpenRegister\AppHost\Store\StoreManifest;
+
+/**
+ * One way of finding store items.
+ *
+ * 🔴 A SOURCE NEVER THROWS FOR AN UPSTREAM PROBLEM. A registry that is down,
+ * rate limited or talking nonsense is a fact to report to the reader, not a
+ * server error in the app hosting the page: every implementation answers an
+ * outcome and an empty card list instead. The only exceptions worth raising
+ * are programming errors in the caller.
+ *
+ * @spec openspec/changes/store-plane-declarative-sources/specs/apphost-store-plane/spec.md#requirement-a-store-must-declare-its-discovery-source-defaulting-to-openregister
+ */
+interface StoreSourceInterface {
+	/**
+	 * The `source` value this implementation answers to.
+	 *
+	 * Matched against StoreManifest::SOURCES, so a source that names something
+	 * outside that list can never be selected — the manifest would already
+	 * have been rejected as malformed.
+	 *
+	 * @return string
+	 */
+	public function sourceId(): string;
+
+	/**
+	 * Search this source for store items.
+	 *
+	 * @param StoreManifest $manifest The declaring app's store block.
+	 * @param string        $query    Free-text search, possibly empty.
+	 * @param string|null   $kind     Kind filter, or null for every kind.
+	 *
+	 * @return array{outcome: string, cards: array<int, array<string, mixed>>}
+	 */
+	public function search(StoreManifest $manifest, string $query, ?string $kind): array;
+}

--- a/lib/AppHost/Store/StoreManifest.php
+++ b/lib/AppHost/Store/StoreManifest.php
@@ -64,6 +64,30 @@ class StoreManifest {
 	];
 
 	/**
+	 * Discovery sources a store may declare.
+	 *
+	 * `openregister` reads another OpenRegister's objects endpoint at an
+	 * admin-configured URL, which is why that path is SSRF-guarded and refuses
+	 * redirects. `github` searches the repository API by topic at a COMPILE-TIME
+	 * host, so there is no URL for an app to influence and nothing to guard.
+	 *
+	 * An unknown value is malformed, never a fallback: defaulting to
+	 * `openregister` would silently point an app at a registry it never asked
+	 * for.
+	 *
+	 * @var array<int, string>
+	 */
+	public const SOURCES = ['openregister', 'github'];
+
+	/**
+	 * The source assumed when a block declares none.
+	 *
+	 * Every store declared before the discriminator existed keeps its behaviour
+	 * exactly, which is the only reason this default may exist at all.
+	 */
+	public const DEFAULT_SOURCE = 'openregister';
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string                     $appId       The calling leaf app id.
@@ -76,6 +100,8 @@ class StoreManifest {
 	 * @param array<string, string>      $cardFields  Remote field to card field map.
 	 * @param array<int, array<string, mixed>> $builtIn The app's own items, for the no-registry case.
 	 * @param array<int, string>         $types       Shareable configuration type ids this store surfaces.
+	 * @param string                     $source      Discovery source: one of self::SOURCES.
+	 * @param array<int, string>         $topics      GitHub topics searched when $source is `github`.
 	 *
 	 * @SuppressWarnings(PHPMD.ExcessiveParameterList) This is a value object
 	 * mirroring the manifest's `store` block one key to one parameter, so the
@@ -94,6 +120,8 @@ class StoreManifest {
 		public readonly array $cardFields = self::DEFAULT_CARD_FIELDS,
 		public readonly array $builtIn = [],
 		public readonly array $types = [],
+		public readonly string $source = self::DEFAULT_SOURCE,
+		public readonly array $topics = [],
 	) {
 	}//end __construct()
 
@@ -115,6 +143,24 @@ class StoreManifest {
 	public static function fromManifest(string $appId, array $manifest): self {
 		$block = ($manifest['store'] ?? null);
 		if (is_array($block) === false) {
+			return new self(appId: $appId, enabled: false);
+		}
+
+		// An unknown source is MALFORMED, not a fallback. Reporting it as
+		// `openregister` would point the app at a registry it never declared, and
+		// the store would then answer `not_configured` for a reason that has
+		// nothing to do with what the app got wrong.
+		$source = (string)($block['source'] ?? self::DEFAULT_SOURCE);
+		if (in_array(needle: $source, haystack: self::SOURCES, strict: true) === false) {
+			return new self(appId: $appId, enabled: false);
+		}
+
+		// A github store is configured by its TOPICS, not by a registry URL, so
+		// declaring none leaves it with nothing to search. That is a malformed
+		// block rather than an empty store: an empty store is a store that found
+		// nothing, which is a different thing to report.
+		$topics = self::stringList(value: ($block['topics'] ?? []));
+		if ($source === 'github' && $topics === []) {
 			return new self(appId: $appId, enabled: false);
 		}
 
@@ -143,6 +189,8 @@ class StoreManifest {
 			kinds: self::stringList(value: ($block['kinds'] ?? [])),
 			cardFields: array_map(callback: static fn ($v): string => (string)$v, array: $cardFields),
 			builtIn: self::objectList(value: ($block['builtIn'] ?? [])),
+			source: $source,
+			topics: $topics,
 			// Shareable configuration type ids (store-over-federated-config).
 			// Declaring these selects federated discovery, where an item is a
 			// configuration set, a flow or a schema that marked itself

--- a/openspec/changes/store-plane-declarative-sources/proposal.md
+++ b/openspec/changes/store-plane-declarative-sources/proposal.md
@@ -1,0 +1,62 @@
+# Store plane: a declarative discovery source
+
+## Why
+
+ADR-114 Decision 4 put a Store in every app's footer and ADR-080 Decision 4
+governs what may carry the word: registry-backed, discovery in OpenRegister,
+and an install that writes only what the app allowed. The generic plane already
+does that for a store whose registry is **another OpenRegister**.
+
+Five apps ship a bespoke store today, and the fleet decision is that they
+migrate onto the generic plane **without regression**. Two of them cannot,
+because they do not discover from an OpenRegister at all:
+
+- **buildiq** searches the GitHub REST API for `topic:openbuild-app`.
+- **hermiq** searches it for `topic:hermiq-agent-template` and
+  `topic:hermiq-skill`, one call per kind, merged client-side.
+
+Both cache aggressively, both degrade to a 200 with an empty card list rather
+than a 5xx, and both distinguish *rate limited* from *unreachable* because the
+remedy differs: one is "wait or add a credential", the other is "the network is
+broken".
+
+`GenericStoreService` can only ever GET
+`{registry}/index.php/apps/openregister/api/objects/{register}/{schema}`. An app
+whose registry is GitHub is reported as `not_configured`, which is not what is
+wrong with it.
+
+## What changes
+
+The `store` block gains a **`source`** discriminator. Absent, it is
+`openregister` and nothing about today's behaviour moves — dossiq and pipelinq
+migrate on the existing shape.
+
+```jsonc
+"store": {
+  "source": "github",          // "openregister" (default) | "github"
+  "topics": ["openbuild-app"], // github only: what to search for
+  "kinds": [ … ],              // unchanged
+  "installable": [ … ]         // unchanged, still the security boundary
+}
+```
+
+Discovery moves behind a `StoreSourceInterface` with two implementations. The
+outcome vocabulary gains `rate_limited`, which the page already needs in order
+to say the useful thing rather than the generic one.
+
+## What does NOT change
+
+- `installable` stays the security boundary, and an empty list still refuses
+  everything.
+- The SSRF guard, the redirect refusal and the Bearer-header rule stay exactly
+  as they are for the `openregister` source. A `github` source has a
+  **compile-time host** and therefore no URL for an app to influence at all,
+  which is a stronger position, not a weaker one.
+- An app still writes no controller.
+
+## Out of scope, deliberately
+
+Install shapes beyond writing objects (buildiq clones an app, hermiq
+instantiates an agent), `installAuth`, and the approve/export/publish actions.
+Those are the next increments; this one is discovery only, so it can be proven
+against the two apps that already have a GitHub store to compare against.

--- a/openspec/changes/store-plane-declarative-sources/specs/apphost-store-plane/spec.md
+++ b/openspec/changes/store-plane-declarative-sources/specs/apphost-store-plane/spec.md
@@ -1,0 +1,93 @@
+## ADDED Requirements
+
+### Requirement: A store MUST declare its discovery source, defaulting to OpenRegister
+
+The `store` block MAY carry a `source` key. Its value MUST be one of
+`openregister` or `github`. When the key is absent the source MUST be
+`openregister`, so every store declared before this change keeps its behaviour
+exactly.
+
+An unknown `source` MUST be treated as a malformed block: the manifest is
+DISABLED and the store does not appear. Falling back to `openregister` would
+silently point an app at a registry it never asked for.
+
+#### Scenario: An absent source defaults to OpenRegister
+
+- **WHEN** a `store` block declares no `source`
+- **THEN** the manifest reports source `openregister`
+- **AND** discovery uses the registry URL configured for the app
+
+#### Scenario: An unknown source disables the store
+
+- **WHEN** a `store` block declares `"source": "npm"`
+- **THEN** the manifest reports `enabled: false`
+- **AND** no store entry may be rendered for that app
+
+### Requirement: A GitHub source MUST discover by topic against a compile-time host
+
+When `source` is `github` the block MUST carry a non-empty `topics` list. Each
+topic is searched as `topic:<topic>` against the GitHub repository search API.
+
+The host MUST be a compile-time constant. A `github` source MUST NOT read the
+app's `registry_url`, and an app MUST NOT be able to influence the host it
+reaches. This is deliberately stricter than the `openregister` source, where the
+URL is admin-configured and therefore SSRF-guarded at request time: here there
+is no URL to guard.
+
+A `github` source MUST NOT be reported as `not_configured` for want of a
+registry URL. It is configured by its topics.
+
+#### Scenario: Topics are searched and results merged
+
+- **WHEN** a store declares `"source": "github"` with two topics
+- **THEN** each topic is searched
+- **AND** the results are merged into one card list, de-duplicated by
+  `owner/repo`
+
+#### Scenario: A GitHub source with no topics is malformed
+
+- **WHEN** a store declares `"source": "github"` and an empty `topics` list
+- **THEN** the manifest reports `enabled: false`
+
+### Requirement: Search MUST distinguish rate limiting from unreachability
+
+The outcome vocabulary gains `rate_limited`. A source that answers with an
+explicit rate-limit signal MUST map to `rate_limited`, never to
+`store_unreachable`.
+
+The two are not interchangeable to a reader: `rate_limited` means wait, or add
+a credential to raise the limit; `store_unreachable` means the network or the
+registry is broken. Reporting the first as the second sends someone to debug a
+network that is fine.
+
+A rate-limited or unreachable search MUST still answer HTTP 200 with an empty
+card list, as today. A store that cannot reach its registry is not a server
+error in the app that hosts the page.
+
+#### Scenario: GitHub rate limiting is reported as itself
+
+- **WHEN** the GitHub API answers 403 with a rate-limit signal
+- **THEN** the outcome is `rate_limited`
+- **AND** the HTTP status is 200
+- **AND** the card list is empty
+
+#### Scenario: A network failure stays unreachable
+
+- **WHEN** the request to the source throws a connection error
+- **THEN** the outcome is `store_unreachable`
+
+### Requirement: Discovery MUST be cached per source
+
+A source MUST declare a cache lifetime for search results, and the engine MUST
+NOT issue an upstream request while a cached answer for the same query is live.
+
+Without this, every keystroke past the debounce is an upstream call, and the
+GitHub search API's unauthenticated limit is low enough that a single user
+typing exhausts it — turning a working store into a `rate_limited` one for
+everybody on the instance.
+
+#### Scenario: A repeated query inside the cache window issues no request
+
+- **WHEN** the same query is searched twice inside the cache lifetime
+- **THEN** exactly one upstream request is made
+- **AND** both answers carry the same cards

--- a/tests/Unit/AppHost/GenericStoreControllerTest.php
+++ b/tests/Unit/AppHost/GenericStoreControllerTest.php
@@ -37,6 +37,7 @@ use OCA\OpenRegister\AppHost\Observability\ManifestLoader;
 use OCA\OpenRegister\AppHost\Service\GenericStoreService;
 use OCA\OpenRegister\AppHost\Store\FederatedStoreCatalog;
 use OCA\OpenRegister\AppHost\Store\GenericStoreInstaller;
+use OCA\OpenRegister\AppHost\Store\Source\GitHubStoreSource;
 use OCA\OpenRegister\AppHost\Store\StoreManifest;
 use OCP\AppFramework\Http;
 use OCP\IGroupManager;
@@ -75,6 +76,9 @@ class GenericStoreControllerTest extends TestCase {
 	/** @var FederatedStoreCatalog&MockObject */
 	private $catalog;
 
+	/** @var GitHubStoreSource&MockObject */
+	private $gitHubSource;
+
 	/** @var IUserSession&MockObject */
 	private $userSession;
 
@@ -102,6 +106,8 @@ class GenericStoreControllerTest extends TestCase {
 			->disableOriginalConstructor()->onlyMethods(['install'])->getMock();
 		$this->catalog = $this->getMockBuilder(FederatedStoreCatalog::class)
 			->disableOriginalConstructor()->onlyMethods(['search', 'resolve', 'install'])->getMock();
+		$this->gitHubSource = $this->getMockBuilder(GitHubStoreSource::class)
+			->disableOriginalConstructor()->onlyMethods(['search', 'sourceId'])->getMock();
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->request = $this->createMock(IRequest::class);
@@ -122,6 +128,7 @@ class GenericStoreControllerTest extends TestCase {
 			storeService: $this->storeService,
 			installer: $this->installer,
 			catalog: $this->catalog,
+			gitHubSource: $this->gitHubSource,
 			userSession: $this->userSession,
 			groupManager: $this->groupManager,
 			logger: $this->createMock(LoggerInterface::class)
@@ -165,6 +172,39 @@ class GenericStoreControllerTest extends TestCase {
 			manifest: ['store' => ['types' => ['openregister.configset', 'openregister.flows']]]
 		);
 	}//end federatedStore()
+
+	/**
+	 * A github store is searched against the GitHub source, not the registry.
+	 *
+	 * 🔴 The regression this guards: a github store has no registry URL, so
+	 * falling through to GenericStoreService reports `not_configured` — true
+	 * of a registry the app never declared, and useless to whoever has to act
+	 * on it. The registry service is told to expect ZERO calls, so a fall
+	 * through fails here rather than in a browser.
+	 *
+	 * @return void
+	 */
+	public function testAGithubStoreIsSearchedAgainstTheGithubSource(): void {
+		$this->signIn();
+		$this->manifestLoader->method('loadStore')->willReturn(
+			StoreManifest::fromManifest('demo', [
+				'store' => ['source' => 'github', 'topics' => ['demo-app']],
+			])
+		);
+
+		$this->storeService->expects($this->never())->method('search');
+		$this->catalog->expects($this->never())->method('search');
+		$this->gitHubSource->expects($this->once())
+			->method('search')
+			->willReturn(['outcome' => 'ok', 'cards' => [['slug' => 'conduction/demo-app']]]);
+
+		$response = $this->controller('demo')->search();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$data = $response->getData();
+		$this->assertSame('ok', $data['outcome']);
+		$this->assertSame('conduction/demo-app', $data['cards'][0]['slug']);
+	}
 
 	/**
 	 * An app declaring types is searched against the configuration catalogue.

--- a/tests/Unit/AppHost/GitHubStoreSourceTest.php
+++ b/tests/Unit/AppHost/GitHubStoreSourceTest.php
@@ -1,0 +1,243 @@
+<?php
+
+/**
+ * Tests for the GitHub store discovery source.
+ *
+ * The assertions worth having here are the ones that keep a reader correctly
+ * informed when the source is NOT working:
+ *
+ *   - a rate limit must report itself, never `store_unreachable`, because the
+ *     remedy differs and someone acts on it;
+ *   - a failure must still be cached, or the next keystroke walks straight
+ *     back into the limit that just fired;
+ *   - a repeated query inside the window must issue no second request.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\AppHost
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\AppHost;
+
+use OCA\OpenRegister\AppHost\Service\GenericStoreService;
+use OCA\OpenRegister\AppHost\Store\Source\GitHubStoreSource;
+use OCA\OpenRegister\AppHost\Store\StoreManifest;
+use OCP\Http\Client\IClient;
+use OCP\Http\Client\IClientService;
+use OCP\Http\Client\IResponse;
+use OCP\ICache;
+use OCP\ICacheFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * @covers \OCA\OpenRegister\AppHost\Store\Source\GitHubStoreSource
+ * @uses   \OCA\OpenRegister\AppHost\Store\StoreManifest
+ */
+class GitHubStoreSourceTest extends TestCase {
+	/**
+	 * A store block declaring a github source with one topic.
+	 *
+	 * @return StoreManifest
+	 */
+	private function manifest(): StoreManifest {
+		return StoreManifest::fromManifest('demo', [
+			'store' => ['source' => 'github', 'topics' => ['demo-app']],
+		]);
+	}
+
+	/**
+	 * Build a source whose HTTP client returns the given response.
+	 *
+	 * @param IResponse|Throwable $result       What the client does.
+	 * @param ICache|null         $cache        Cache to use, or null for none.
+	 * @param int                 $expectedGets How many GETs are allowed.
+	 *
+	 * @return GitHubStoreSource
+	 */
+	private function sourceReturning($result, ?ICache $cache, int $expectedGets): GitHubStoreSource {
+		$client = $this->createMock(IClient::class);
+		$invocation = $client->expects($this->exactly($expectedGets))->method('get');
+		if ($result instanceof \Throwable) {
+			$invocation->willThrowException($result);
+		} else {
+			$invocation->willReturn($result);
+		}
+
+		$clientService = $this->createMock(IClientService::class);
+		$clientService->method('newClient')->willReturn($client);
+
+		$cacheFactory = $this->createMock(ICacheFactory::class);
+		$cacheFactory->method('isAvailable')->willReturn($cache !== null);
+		if ($cache !== null) {
+			$cacheFactory->method('createDistributed')->willReturn($cache);
+		}
+
+		return new GitHubStoreSource(
+			$clientService,
+			$cacheFactory,
+			$this->createMock(LoggerInterface::class)
+		);
+	}
+
+	/**
+	 * Build a response double.
+	 *
+	 * @param int    $status HTTP status.
+	 * @param string $body   Response body.
+	 *
+	 * @return IResponse
+	 */
+	private function response(int $status, string $body): IResponse {
+		$response = $this->createMock(IResponse::class);
+		$response->method('getStatusCode')->willReturn($status);
+		$response->method('getBody')->willReturn($body);
+		return $response;
+	}
+
+	/**
+	 * The happy path normalises repositories into cards.
+	 *
+	 * @return void
+	 */
+	public function testSearchReturnsNormalisedCards(): void {
+		$body = json_encode([
+			'items' => [
+				[
+					'full_name' => 'conduction/demo-app',
+					'name' => 'demo-app',
+					'description' => 'A demo',
+					'default_branch' => 'main',
+					'owner' => ['login' => 'conduction'],
+					'stargazers_count' => 7,
+					'html_url' => 'https://github.com/conduction/demo-app',
+				],
+			],
+		]);
+
+		$source = $this->sourceReturning($this->response(200, $body), null, 1);
+		$result = $source->search($this->manifest(), '', null);
+
+		$this->assertSame(GenericStoreService::OUTCOME_OK, $result['outcome']);
+		$this->assertCount(1, $result['cards']);
+		$this->assertSame('conduction/demo-app', $result['cards'][0]['slug']);
+		$this->assertSame(7, $result['cards'][0]['stars']);
+	}
+
+	/**
+	 * 🔴 The distinction the reader acts on: 403 is rate limiting, not an
+	 * unreachable registry.
+	 *
+	 * @return void
+	 */
+	public function testRateLimitIsReportedAsItselfNotAsUnreachable(): void {
+		$source = $this->sourceReturning($this->response(403, '{}'), null, 1);
+		$result = $source->search($this->manifest(), '', null);
+
+		$this->assertSame(
+			GenericStoreService::OUTCOME_RATE_LIMITED,
+			$result['outcome'],
+			'A 403 must not be reported as store_unreachable: the remedy differs.'
+		);
+		$this->assertSame([], $result['cards']);
+	}
+
+	/**
+	 * A thrown connection error stays unreachable.
+	 *
+	 * @return void
+	 */
+	public function testConnectionFailureIsUnreachable(): void {
+		$source = $this->sourceReturning(new RuntimeException('connect'), null, 1);
+		$result = $source->search($this->manifest(), '', null);
+
+		$this->assertSame(GenericStoreService::OUTCOME_UNREACHABLE, $result['outcome']);
+	}
+
+	/**
+	 * A 200 carrying nonsense is invalid, not unreachable.
+	 *
+	 * @return void
+	 */
+	public function testUnparseableBodyIsInvalid(): void {
+		$source = $this->sourceReturning($this->response(200, 'not json'), null, 1);
+		$result = $source->search($this->manifest(), '', null);
+
+		$this->assertSame(GenericStoreService::OUTCOME_INVALID, $result['outcome']);
+	}
+
+	/**
+	 * A cached answer must suppress the upstream request entirely.
+	 *
+	 * The mock allows ZERO gets, so a request would fail the test rather than
+	 * merely be slower.
+	 *
+	 * @return void
+	 */
+	public function testACachedAnswerIssuesNoRequest(): void {
+		$cache = $this->createMock(ICache::class);
+		$cache->method('get')->willReturn(json_encode([
+			'outcome' => GenericStoreService::OUTCOME_OK,
+			'cards' => [['slug' => 'conduction/cached']],
+		]));
+
+		$source = $this->sourceReturning($this->response(200, '{}'), $cache, 0);
+		$result = $source->search($this->manifest(), '', null);
+
+		$this->assertSame('conduction/cached', $result['cards'][0]['slug']);
+	}
+
+	/**
+	 * 🔴 Failures are cached too, or a brief limit becomes a persistent one.
+	 *
+	 * @return void
+	 */
+	public function testARateLimitedAnswerIsCached(): void {
+		$cache = $this->createMock(ICache::class);
+		$cache->method('get')->willReturn(null);
+		$cache->expects($this->once())
+			->method('set')
+			->with(
+				$this->anything(),
+				$this->stringContains(GenericStoreService::OUTCOME_RATE_LIMITED),
+				$this->anything()
+			);
+
+		$source = $this->sourceReturning($this->response(403, '{}'), $cache, 1);
+		$source->search($this->manifest(), '', null);
+	}
+
+	/**
+	 * A kind that maps to no topic finds nothing, rather than everything.
+	 *
+	 * @return void
+	 */
+	public function testAnUnknownKindNarrowsToNothing(): void {
+		$manifest = StoreManifest::fromManifest('demo', [
+			'store' => [
+				'source' => 'github',
+				'topics' => ['demo-app'],
+				'kinds' => ['app'],
+			],
+		]);
+
+		$source = $this->sourceReturning($this->response(200, '{}'), null, 0);
+		$result = $source->search($manifest, '', 'not-a-kind');
+
+		$this->assertSame(GenericStoreService::OUTCOME_OK, $result['outcome']);
+		$this->assertSame([], $result['cards']);
+	}
+}

--- a/tests/Unit/AppHost/StoreManifestSourceTest.php
+++ b/tests/Unit/AppHost/StoreManifestSourceTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * Tests for the store plane's discovery-source discriminator.
+ *
+ * The `source` key decides WHERE a store looks, so the interesting cases are
+ * the ones that must NOT resolve to a working store:
+ *
+ *   - an unknown source must disable the block rather than fall back to
+ *     `openregister`, which would point an app at a registry it never
+ *     declared and then report `not_configured` for the wrong reason;
+ *   - a `github` source with no topics has nothing to search, which is a
+ *     malformed block rather than an empty store — an empty store is one that
+ *     searched and found nothing, which is a different thing to tell a reader.
+ *
+ * The default is asserted directly, because it is the whole reason every store
+ * declared before this key existed keeps working.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\AppHost
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\AppHost;
+
+use OCA\OpenRegister\AppHost\Store\StoreManifest;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \OCA\OpenRegister\AppHost\Store\StoreManifest
+ */
+class StoreManifestSourceTest extends TestCase {
+	/**
+	 * A block that declares no source keeps the behaviour it had before the
+	 * key existed.
+	 *
+	 * @return void
+	 */
+	public function testAbsentSourceDefaultsToOpenRegister(): void {
+		$manifest = StoreManifest::fromManifest('demo', ['store' => ['schema' => 'template']]);
+
+		$this->assertTrue($manifest->enabled);
+		$this->assertSame('openregister', $manifest->source);
+		$this->assertSame([], $manifest->topics);
+	}
+
+	/**
+	 * The default is spelled out, so naming it explicitly changes nothing.
+	 *
+	 * @return void
+	 */
+	public function testExplicitOpenRegisterSourceIsAccepted(): void {
+		$manifest = StoreManifest::fromManifest('demo', [
+			'store' => ['source' => 'openregister', 'schema' => 'template'],
+		]);
+
+		$this->assertTrue($manifest->enabled);
+		$this->assertSame('openregister', $manifest->source);
+	}
+
+	/**
+	 * A github store is configured by its topics rather than a registry URL.
+	 *
+	 * @return void
+	 */
+	public function testGithubSourceKeepsItsTopics(): void {
+		$manifest = StoreManifest::fromManifest('demo', [
+			'store' => ['source' => 'github', 'topics' => ['openbuild-app', 'buildiq-app']],
+		]);
+
+		$this->assertTrue($manifest->enabled);
+		$this->assertSame('github', $manifest->source);
+		$this->assertSame(['openbuild-app', 'buildiq-app'], $manifest->topics);
+	}
+
+	/**
+	 * 🔴 The negative control that matters: an unknown source must DISABLE the
+	 * store, never fall back to the default.
+	 *
+	 * @return void
+	 */
+	public function testUnknownSourceDisablesTheStore(): void {
+		$manifest = StoreManifest::fromManifest('demo', [
+			'store' => ['source' => 'npm', 'schema' => 'template'],
+		]);
+
+		$this->assertFalse(
+			$manifest->enabled,
+			'An unknown source must disable the block rather than silently become openregister.'
+		);
+	}
+
+	/**
+	 * A github source with nothing to search is malformed, not empty.
+	 *
+	 * @return void
+	 */
+	public function testGithubSourceWithoutTopicsIsDisabled(): void {
+		$manifest = StoreManifest::fromManifest('demo', ['store' => ['source' => 'github']]);
+
+		$this->assertFalse($manifest->enabled);
+	}
+
+	/**
+	 * Topics on a non-github source are carried but do not make it github.
+	 *
+	 * A future source may want them, and dropping a declared key silently is
+	 * the failure mode this whole plane is built to avoid.
+	 *
+	 * @return void
+	 */
+	public function testTopicsAreCarriedOnAnOpenRegisterSource(): void {
+		$manifest = StoreManifest::fromManifest('demo', [
+			'store' => ['topics' => ['ignored-here'], 'schema' => 'template'],
+		]);
+
+		$this->assertTrue($manifest->enabled);
+		$this->assertSame('openregister', $manifest->source);
+		$this->assertSame(['ignored-here'], $manifest->topics);
+	}
+}


### PR DESCRIPTION
The fleet decision is that the five apps shipping a bespoke store migrate onto OpenRegister's generic plane **without regression**. Two of them cannot today, because they do not discover from an OpenRegister at all:

- **buildiq** searches GitHub for `topic:openbuild-app`
- **hermiq** searches it for `topic:hermiq-agent-template` and `topic:hermiq-skill`, one call per kind

`GenericStoreService` can only ever GET another OpenRegister's objects endpoint, so a GitHub-backed store comes back as `not_configured` — which is true of a registry the app never declared, and useless to whoever has to act on it.

## What changes

The `store` block gains a `source` discriminator:

```jsonc
"store": {
  "source": "github",           // "openregister" (default) | "github"
  "topics": ["openbuild-app"],  // github only
  "installable": [ … ]          // unchanged, still the security boundary
}
```

**Absent, it is `openregister` and nothing moves.** dossiq and pipelinq migrate on the shape they already have, and every block declared before this key existed keeps its behaviour exactly.

## Three decisions worth arguing with

**An unknown source disables the block rather than falling back.** A fallback would point the app at a registry it never asked for, and then report `not_configured` for a reason that has nothing to do with what the app got wrong. Same for a `github` source with no topics: it has nothing to search, and *an empty store is a store that searched and found nothing* — a different thing to tell a reader.

**The GitHub host is a compile-time constant and must stay one.** The `openregister` path reads an admin-configured URL, which is precisely why it carries an SSRF guard and refuses redirects. Here there is no URL for an app or an admin to influence, so there is nothing to guard. That is a *stronger* position than the guarded one — and it holds only while the constant is a constant.

**`rate_limited` is not `store_unreachable`.** The remedy differs and somebody acts on it: rate limited means wait, or add a credential to raise the limit; unreachable means the network or the registry is broken. Reporting the first as the second sends someone to debug a network that is fine.

## Caching is not an optimisation here

Search answers cache for 60s, **failures included**. GitHub's unauthenticated search limit is low enough that one person typing past the debounce exhausts it for the whole instance. And an uncached rate-limit answer sends the very next keystroke straight back at an API that just said stop, which is how a brief limit becomes a persistent one. buildiq and hermiq both already cache for exactly this reason.

## Tests

13 new tests, 266 in the AppHost suite, all green.

The one worth reading is the controller test: it asserts a `github` store reaches the GitHub source **and that the registry service is called zero times**, so a fall-through fails there rather than in a browser.

The rest cover the negative controls — unknown source disables, no-topics disables, 403 is `rate_limited` and not `unreachable`, a connection error stays `unreachable`, a 200 of nonsense is `invalid`, a cached answer issues no request (the client mock allows zero), and a rate-limited answer *is* written to the cache.

- `phpcs` clean on `lib` · `psalm` no errors · `phpstan` no errors · `phpmd` clean (`fetchTopics` was split into three rather than suppressed)

## Deliberately out of scope

Install shapes beyond writing objects (buildiq clones an app, hermiq instantiates an agent), `installAuth`, and approve/export/publish. Those are the next increments. This one is discovery only, so it can be proven against the two apps that already have a working GitHub store to compare against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
