### PR TITLE
feat(store): let a store declare who may install

### DIFF
--- a/lib/AppHost/Bootstrap.php
+++ b/lib/AppHost/Bootstrap.php
@@ -129,6 +129,11 @@ class Bootstrap {
 	 * The catalogue serving a store that exchanges configuration.
 	 */
 	private const FEDERATED_STORE_CATALOG = 'OCA\\OpenRegister\\AppHost\\Store\\FederatedStoreCatalog';
+
+	/**
+	 * The GitHub discovery source, for stores declaring `source: github`.
+	 */
+	private const GITHUB_STORE_SOURCE = 'OCA\\OpenRegister\\AppHost\\Store\\Source\\GitHubStoreSource';
 	private const GENERIC_SETTINGS_SERVICE = 'OCA\\OpenRegister\\AppHost\\Service\\AppHostSettingsService';
 	private const GENERIC_ACTION_AUTH_SERVICE = 'OCA\\OpenRegister\\AppHost\\Service\\GenericActionAuthService';
 	private const GENERIC_INITIALIZE_SETTINGS = 'OCA\\OpenRegister\\AppHost\\Repair\\GenericInitializeSettings';
@@ -295,6 +300,7 @@ class Bootstrap {
 					storeService: $c->get(self::GENERIC_STORE_SERVICE),
 					installer: $c->get(self::GENERIC_STORE_INSTALLER),
 					catalog: $c->get(self::FEDERATED_STORE_CATALOG),
+					gitHubSource: $c->get(self::GITHUB_STORE_SOURCE),
 					userSession: $c->get('OCP\\IUserSession'),
 					groupManager: $c->get('OCP\\IGroupManager'),
 					logger: $c->get('Psr\\Log\\LoggerInterface')

--- a/lib/AppHost/Controller/GenericStoreController.php
+++ b/lib/AppHost/Controller/GenericStoreController.php
@@ -93,16 +93,16 @@ class GenericStoreController extends Controller {
 	 * @param GenericStoreService   $storeService   Guarded remote discovery.
 	 * @param GenericStoreInstaller $installer      Declarative component install.
 	 * @param FederatedStoreCatalog $catalog        Configuration browse and install.
-	 * @param GitHubStoreSource     $gitHubSource  GitHub discovery source.
+	 * @param GitHubStoreSource     $gitHubSource   GitHub discovery source.
+	 * @param IUserSession          $userSession    Current session.
+	 * @param IGroupManager         $groupManager   Admin check for install.
+	 * @param LoggerInterface       $logger         PSR logger.
 	 *
 	 * @SuppressWarnings(PHPMD.ExcessiveParameterList) Each collaborator is one
 	 * discovery or install path the engine owns on a leaf app's behalf, and the
 	 * count grew because the plane absorbed work the apps used to do
 	 * themselves. Grouping them behind a locator would hide which paths exist
 	 * from the one file that has to choose between them.
-	 * @param IUserSession          $userSession    Current session.
-	 * @param IGroupManager         $groupManager   Admin check for install.
-	 * @param LoggerInterface       $logger         PSR logger.
 	 */
 	public function __construct(
 		string $appName,
@@ -225,17 +225,12 @@ class GenericStoreController extends Controller {
 	 */
 	#[NoAdminRequired]
 	public function install(string $slug): JSONResponse {
-		// The admin check is an in-body guard rather than
-		// #[AuthorizedAdminSetting], because that attribute names a leaf app's
-		// settings CLASS and this controller serves every app. Same posture,
-		// resolved at request time instead of at annotation time.
+		// The gate is an in-body guard rather than #[AuthorizedAdminSetting],
+		// because that attribute names a leaf app's settings CLASS and this
+		// controller serves every app. Resolved at request time instead of at
+		// annotation time — which is also what lets the APP declare the
+		// posture rather than the engine assuming one.
 		$user = $this->userSession->getUser();
-		if ($user === null || $this->groupManager->isAdmin($user->getUID()) === false) {
-			return new JSONResponse(
-				data: ['success' => false, 'message' => 'Installing a store item requires an administrator.'],
-				statusCode: Http::STATUS_FORBIDDEN
-			);
-		}
 
 		if (preg_match(self::SLUG_PATTERN, $slug) !== 1) {
 			return new JSONResponse(
@@ -249,6 +244,39 @@ class GenericStoreController extends Controller {
 			return new JSONResponse(
 				data: ['success' => false, 'message' => 'This app declares no store.'],
 				statusCode: Http::STATUS_NOT_FOUND
+			);
+		}
+
+		// A posture this engine cannot yet enforce is REFUSED, never
+		// downgraded. `action:<name>` needs an ADR-023 resolver that lives in
+		// the leaf apps; until that lands, treating it as `authenticated`
+		// would quietly install on a weaker gate than the app asked for.
+		if ($store->isInstallAuthEnforceable() === false) {
+			$this->logger->error(
+				message: sprintf(
+					'[AppHost\\Store] %s declares an installAuth this engine cannot enforce: %s',
+					$this->appName,
+					$store->installAuth
+				),
+				context: ['file' => __FILE__, 'line' => __LINE__]
+			);
+			return new JSONResponse(
+				data: ['success' => false, 'message' => 'This store declares an install posture this server cannot enforce.'],
+				statusCode: Http::STATUS_FORBIDDEN
+			);
+		}
+
+		// WHO may install is the app's declaration; WHAT may be written stays
+		// the `installable` allowlist, which the installer enforces regardless.
+		// Anonymous is refused on this same guard: `authenticated` is the
+		// weakest posture the vocabulary offers and it still means signed in.
+		if ($store->permitsInstall(
+			isSignedIn: ($user !== null),
+			isAdmin: ($user !== null && $this->groupManager->isAdmin($user->getUID()))
+		) === false) {
+			return new JSONResponse(
+				data: ['success' => false, 'message' => 'Installing a store item requires an administrator.'],
+				statusCode: Http::STATUS_FORBIDDEN
 			);
 		}
 

--- a/lib/AppHost/Store/StoreManifest.php
+++ b/lib/AppHost/Store/StoreManifest.php
@@ -80,6 +80,36 @@ class StoreManifest {
 	public const SOURCES = ['openregister', 'github'];
 
 	/**
+	 * Install postures a store may declare.
+	 *
+	 * `admin` is an instance administrator. `authenticated` is any signed-in
+	 * user — hermiq and buildiq both rely on it, hermiq because the install
+	 * lands quarantined and the gate that matters is approval. `action:<name>`
+	 * defers to ADR-023, which is integriq's posture.
+	 *
+	 * 🔴 THIS DECIDES WHO, NEVER WHAT. `installable` remains the security
+	 * boundary: an `authenticated` install refuses every schema the allowlist
+	 * omits, exactly as an admin install does. The two keys sit side by side and
+	 * read like a pair; they are not one.
+	 *
+	 * @var array<int, string>
+	 */
+	public const INSTALL_AUTH = ['admin', 'authenticated'];
+
+	/**
+	 * Prefix of the ADR-023 action posture.
+	 */
+	public const INSTALL_AUTH_ACTION_PREFIX = 'action:';
+
+	/**
+	 * The posture assumed when a block declares none.
+	 *
+	 * Deliberately the STRICTEST of them. A block that says nothing gets the
+	 * gate it had before the key existed.
+	 */
+	public const DEFAULT_INSTALL_AUTH = 'admin';
+
+	/**
 	 * The source assumed when a block declares none.
 	 *
 	 * Every store declared before the discriminator existed keeps its behaviour
@@ -102,6 +132,7 @@ class StoreManifest {
 	 * @param array<int, string>         $types       Shareable configuration type ids this store surfaces.
 	 * @param string                     $source      Discovery source: one of self::SOURCES.
 	 * @param array<int, string>         $topics      GitHub topics searched when $source is `github`.
+	 * @param string                     $installAuth Who may install: see self::INSTALL_AUTH.
 	 *
 	 * @SuppressWarnings(PHPMD.ExcessiveParameterList) This is a value object
 	 * mirroring the manifest's `store` block one key to one parameter, so the
@@ -122,6 +153,7 @@ class StoreManifest {
 		public readonly array $types = [],
 		public readonly string $source = self::DEFAULT_SOURCE,
 		public readonly array $topics = [],
+		public readonly string $installAuth = self::DEFAULT_INSTALL_AUTH,
 	) {
 	}//end __construct()
 
@@ -159,6 +191,15 @@ class StoreManifest {
 		// declaring none leaves it with nothing to search. That is a malformed
 		// block rather than an empty store: an empty store is a store that found
 		// nothing, which is a different thing to report.
+		// An unrecognised posture DISABLES the block. Falling back to `admin`
+		// would silently remove a capability from an app that asked for a weaker
+		// gate: the store still works, for fewer people, for no stated reason,
+		// which is harder to notice than an outright refusal.
+		$installAuth = (string)($block['installAuth'] ?? self::DEFAULT_INSTALL_AUTH);
+		if (self::isKnownInstallAuth(value: $installAuth) === false) {
+			return new self(appId: $appId, enabled: false);
+		}
+
 		$topics = self::stringList(value: ($block['topics'] ?? []));
 		if ($source === 'github' && $topics === []) {
 			return new self(appId: $appId, enabled: false);
@@ -191,6 +232,7 @@ class StoreManifest {
 			builtIn: self::objectList(value: ($block['builtIn'] ?? [])),
 			source: $source,
 			topics: $topics,
+			installAuth: $installAuth,
 			// Shareable configuration type ids (store-over-federated-config).
 			// Declaring these selects federated discovery, where an item is a
 			// configuration set, a flow or a schema that marked itself
@@ -275,4 +317,58 @@ class StoreManifest {
 
 		return array_values(array_filter($value, static fn ($e): bool => is_array($e) === true));
 	}//end objectList()
+	/**
+	 * Whether a declared install posture is one this engine understands.
+	 *
+	 * The `action:` arm is recognised here but NOT yet enforceable: resolving
+	 * an ADR-023 action needs a resolver that lives in the leaf apps. Until
+	 * that lands, isInstallAuthEnforceable() reports it as unenforceable and
+	 * the controller refuses the install rather than quietly downgrading it to
+	 * `authenticated`.
+	 *
+	 * @param string $value The declared posture.
+	 *
+	 * @return bool
+	 */
+	private static function isKnownInstallAuth(string $value): bool {
+		if (in_array(needle: $value, haystack: self::INSTALL_AUTH, strict: true) === true) {
+			return true;
+		}
+
+		return str_starts_with($value, self::INSTALL_AUTH_ACTION_PREFIX) === true
+			&& strlen($value) > strlen(self::INSTALL_AUTH_ACTION_PREFIX);
+	}//end isKnownInstallAuth()
+
+	/**
+	 * Whether this engine can enforce the declared posture today.
+	 *
+	 * @return bool
+	 */
+	public function isInstallAuthEnforceable(): bool {
+		return in_array(needle: $this->installAuth, haystack: self::INSTALL_AUTH, strict: true);
+	}//end isInstallAuthEnforceable()
+
+	/**
+	 * Whether an install by this user is permitted by the declared posture.
+	 *
+	 * 🔴 ANONYMOUS IS REFUSED WHATEVER THE POSTURE. `authenticated` is the
+	 * weakest gate the vocabulary offers, and it still means signed in.
+	 *
+	 * @param bool $isSignedIn Whether a user is signed in.
+	 * @param bool $isAdmin    Whether that user is an instance administrator.
+	 *
+	 * @return bool
+	 */
+	public function permitsInstall(bool $isSignedIn, bool $isAdmin): bool {
+		if ($isSignedIn === false) {
+			return false;
+		}
+
+		if ($this->installAuth === 'authenticated') {
+			return true;
+		}
+
+		return $isAdmin;
+	}//end permitsInstall()
+
 }//end class

--- a/openspec/changes/store-plane-install-auth/proposal.md
+++ b/openspec/changes/store-plane-install-auth/proposal.md
@@ -1,0 +1,59 @@
+# Store plane: a declared install authorization
+
+## Why
+
+The engine hardcodes `IGroupManager::isAdmin` on install. That is the right
+posture for dossiq and pipelinq, whose installs write case and commercial
+CONFIGURATION — the shape every later handler operates against.
+
+It is the wrong posture for the other three, and each is wrong differently:
+
+- **integriq** gates instantiate on ADR-023 `catalog.instantiate`, and the
+  `source` schema carries its own data-layer admin lock. An admin-only route
+  would take a capability away from every operator who has the action and is
+  not an instance administrator.
+- **hermiq** lets any authenticated user install, because the install lands
+  `state: quarantined` and an ADR-023 action (`agenttemplate.approve-quarantined`)
+  gates the thing that actually matters — approval.
+- **buildiq** lets any authenticated user install, and the installer becomes
+  the owner of the app they cloned.
+
+Migrating those three onto an admin-only install is a regression, and the fleet
+decision is explicitly that they migrate without one.
+
+## What changes
+
+The `store` block gains `installAuth`. Absent, it is `admin`, so dossiq,
+pipelinq and every block written before this key keep exactly the posture they
+have.
+
+```jsonc
+"store": {
+  "installAuth": "admin"                      // default
+  // "installAuth": "authenticated"
+  // "installAuth": "action:catalog.instantiate"
+}
+```
+
+An unknown value is malformed and DISABLES the store, for the same reason an
+unknown `source` does: the alternative is guessing at an authorization posture
+on an app's behalf, and the safe-looking guess (fall back to `admin`) silently
+removes a capability rather than granting one, which is just as wrong and
+harder to notice.
+
+## What does NOT change
+
+- `installable` remains the security boundary and is unaffected by this key.
+  Loosening WHO may install does not widen WHAT may be written; an
+  `authenticated` install still refuses every schema the allowlist omits.
+- The write still runs as the calling user and never through `runAsSystem()`.
+  A store payload comes off the network.
+- Discovery is untouched.
+
+## Out of scope
+
+The `action:` arm resolves through ADR-023's `ActionAuthService`, which lives
+in the leaf apps rather than in OpenRegister. This change defines the
+vocabulary and enforces `admin` and `authenticated`; wiring `action:` to a
+resolver is the increment that follows, and until then a store declaring it is
+rejected as malformed rather than silently treated as `authenticated`.

--- a/openspec/changes/store-plane-install-auth/specs/apphost-store-plane/spec.md
+++ b/openspec/changes/store-plane-install-auth/specs/apphost-store-plane/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: A store MUST declare who may install, defaulting to admin
+
+The `store` block MAY carry an `installAuth` key. Its value MUST be one of
+`admin`, `authenticated`, or `action:<name>`. When the key is absent the
+posture MUST be `admin`, so every store declared before this key existed keeps
+the posture it has.
+
+An unrecognised value MUST disable the block. Falling back to `admin` would
+silently REMOVE a capability from an app that asked for a weaker gate, which is
+as wrong as granting one it did not ask for and considerably harder to notice:
+the store still works, for fewer people, for no stated reason.
+
+#### Scenario: An absent installAuth stays admin-only
+
+- **WHEN** a `store` block declares no `installAuth`
+- **AND** a signed-in non-administrator posts an install
+- **THEN** the response is 403
+
+#### Scenario: An authenticated store admits a non-administrator
+
+- **WHEN** a `store` block declares `"installAuth": "authenticated"`
+- **AND** a signed-in non-administrator posts an install
+- **THEN** the install proceeds
+
+#### Scenario: Anonymous is refused whatever the posture
+
+- **WHEN** a `store` block declares `"installAuth": "authenticated"`
+- **AND** an anonymous caller posts an install
+- **THEN** the response is 403, on the same guard as a permitted-but-unauthorised
+  user
+
+`authenticated` is the weakest posture the vocabulary offers and it still means
+signed in. Anonymous and not-permitted share one guard deliberately, which is
+the contract the endpoint already had.
+
+#### Scenario: An unknown posture disables the store
+
+- **WHEN** a `store` block declares `"installAuth": "everyone"`
+- **THEN** the manifest reports `enabled: false`
+
+### Requirement: A loosened install posture MUST NOT widen the allowlist
+
+`installAuth` decides WHO may install. `installable` decides WHAT an install
+may write. The two MUST remain independent: an `authenticated` install MUST
+refuse every schema the allowlist omits, exactly as an `admin` install does,
+and an empty allowlist MUST still refuse everything.
+
+This is stated as its own requirement because the two keys sit side by side in
+the same block and read like a pair. They are not one: relaxing the gate on the
+door does not enlarge the room.
+
+#### Scenario: A non-administrator cannot write a schema the allowlist omits
+
+- **WHEN** a store declares `"installAuth": "authenticated"` and an
+  `installable` list that omits `case`
+- **AND** a signed-in non-administrator installs an item whose component names
+  `case`
+- **THEN** that component is refused
+- **AND** the refusal is reported per component, as for an administrator

--- a/tests/Unit/AppHost/GenericStoreControllerTest.php
+++ b/tests/Unit/AppHost/GenericStoreControllerTest.php
@@ -426,6 +426,10 @@ class GenericStoreControllerTest extends TestCase {
 	 */
 	public function testInstallRefusesANonAdministrator(): void {
 		$this->signIn(isAdmin: false);
+		// The store is loaded BEFORE the gate now, because the gate is the
+		// app's declaration rather than the engine's assumption. A default
+		// block declares no installAuth, so the posture is `admin`.
+		$this->manifestLoader->method('loadStore')->willReturn($this->enabledStore());
 		$this->storeService->expects($this->never())->method('resolve');
 		$this->installer->expects($this->never())->method('install');
 
@@ -435,12 +439,94 @@ class GenericStoreControllerTest extends TestCase {
 	}//end testInstallRefusesANonAdministrator()
 
 	/**
+	 * An `authenticated` store admits a signed-in non-administrator.
+	 *
+	 * This is the capability hermiq and buildiq would LOSE by migrating onto
+	 * an admin-only install, so it is asserted rather than assumed.
+	 *
+	 * @return void
+	 */
+	public function testAnAuthenticatedStoreAdmitsANonAdministrator(): void {
+		$this->signIn(isAdmin: false);
+		$this->manifestLoader->method('loadStore')->willReturn(
+			StoreManifest::fromManifest('demo', [
+				'store' => [
+					'schema' => 'template',
+					'installAuth' => 'authenticated',
+					'installable' => ['caseType'],
+				],
+			])
+		);
+		$this->storeService->method('resolve')->willReturn(['slug' => 'vth', 'components' => []]);
+		$this->installer->expects($this->once())
+			->method('install')
+			->willReturn(['success' => true, 'components' => []]);
+
+		$response = $this->controller('demo')->install(slug: 'vth');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}
+
+	/**
+	 * An anonymous caller is refused even by an `authenticated` store.
+	 *
+	 * 🔴 `authenticated` is the weakest posture the vocabulary offers, and it
+	 * still means signed in. If this ever passes, the weakest gate has become
+	 * no gate.
+	 *
+	 * @return void
+	 */
+	public function testAnAuthenticatedStoreStillRefusesAnonymous(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->manifestLoader->method('loadStore')->willReturn(
+			StoreManifest::fromManifest('demo', [
+				'store' => ['schema' => 'template', 'installAuth' => 'authenticated'],
+			])
+		);
+		$this->installer->expects($this->never())->method('install');
+
+		$this->assertSame(
+			Http::STATUS_FORBIDDEN,
+			$this->controller('demo')->install(slug: 'vth')->getStatus()
+		);
+	}
+
+	/**
+	 * A posture the engine cannot enforce is refused, never downgraded.
+	 *
+	 * 🔴 The regression this guards: silently treating `action:<name>` as
+	 * `authenticated` would install on a WEAKER gate than the app asked for,
+	 * and the store would look like it was working.
+	 *
+	 * @return void
+	 */
+	public function testAnUnenforceablePostureRefusesTheInstall(): void {
+		$this->signIn(isAdmin: true);
+		$this->manifestLoader->method('loadStore')->willReturn(
+			StoreManifest::fromManifest('demo', [
+				'store' => [
+					'schema' => 'template',
+					'installAuth' => 'action:catalog.instantiate',
+				],
+			])
+		);
+		$this->installer->expects($this->never())->method('install');
+
+		$this->assertSame(
+			Http::STATUS_FORBIDDEN,
+			$this->controller('demo')->install(slug: 'vth')->getStatus(),
+			'An action: posture must be refused until a resolver exists, not downgraded.'
+		);
+	}
+
+	/**
 	 * And an anonymous caller, on the same guard.
 	 *
 	 * @return void
 	 */
 	public function testInstallRefusesAnAnonymousCaller(): void {
 		$this->userSession->method('getUser')->willReturn(null);
+		$this->manifestLoader->method('loadStore')->willReturn($this->enabledStore());
 		$this->installer->expects($this->never())->method('install');
 
 		$this->assertSame(Http::STATUS_FORBIDDEN, $this->controller()->install(slug: 'vth')->getStatus());

--- a/tests/Unit/AppHost/GenericStoreInstallerTest.php
+++ b/tests/Unit/AppHost/GenericStoreInstallerTest.php
@@ -484,4 +484,44 @@ class GenericStoreInstallerTest extends TestCase {
 		);
 		$this->assertSame('openbuild', $explicit->localRegister);
 	}//end testLocalRegisterDefaultsToTheAppIdAndCanBeOverridden()
-}//end class
+
+	/**
+	 * 🔴 A loosened install posture does NOT widen the allowlist.
+	 *
+	 * `installAuth` decides WHO may install; `installable` decides WHAT an
+	 * install may write. The two keys sit side by side in the same block and
+	 * read like a pair. They are not one: relaxing the gate on the door does
+	 * not enlarge the room.
+	 *
+	 * @return void
+	 */
+	public function testAnAuthenticatedStoreStillRefusesADisallowedSchema(): void {
+		$manifest = StoreManifest::fromManifest('demo', [
+			'store' => [
+				'schema' => 'template',
+				'installAuth' => 'authenticated',
+				'installable' => ['caseType'],
+			],
+		]);
+
+		$this->assertTrue($manifest->isInstallable('caseType'));
+		$this->assertFalse(
+			$manifest->isInstallable('case'),
+			'A weaker install posture must not widen what may be written.'
+		);
+	}
+
+	/**
+	 * An empty allowlist still refuses everything, whatever the posture.
+	 *
+	 * @return void
+	 */
+	public function testAnAuthenticatedStoreWithAnEmptyAllowlistRefusesEverything(): void {
+		$manifest = StoreManifest::fromManifest('demo', [
+			'store' => ['schema' => 'template', 'installAuth' => 'authenticated'],
+		]);
+
+		$this->assertFalse($manifest->isInstallable('caseType'));
+		$this->assertFalse($manifest->isInstallable('anything'));
+	}
+}

--- a/tests/Unit/AppHost/StoreManifestSourceTest.php
+++ b/tests/Unit/AppHost/StoreManifestSourceTest.php
@@ -130,4 +130,83 @@ class StoreManifestSourceTest extends TestCase {
 		$this->assertSame('openregister', $manifest->source);
 		$this->assertSame(['ignored-here'], $manifest->topics);
 	}
+
+	/**
+	 * A block that declares no posture keeps the strictest one.
+	 *
+	 * @return void
+	 */
+	public function testAbsentInstallAuthDefaultsToAdmin(): void {
+		$manifest = StoreManifest::fromManifest('demo', ['store' => ['schema' => 'template']]);
+
+		$this->assertSame('admin', $manifest->installAuth);
+		$this->assertTrue($manifest->isInstallAuthEnforceable());
+		$this->assertFalse($manifest->permitsInstall(isSignedIn: true, isAdmin: false));
+		$this->assertTrue($manifest->permitsInstall(isSignedIn: true, isAdmin: true));
+	}
+
+	/**
+	 * `authenticated` admits any signed-in user and no anonymous one.
+	 *
+	 * @return void
+	 */
+	public function testAuthenticatedPostureAdmitsSignedInUsersOnly(): void {
+		$manifest = StoreManifest::fromManifest('demo', [
+			'store' => ['schema' => 'template', 'installAuth' => 'authenticated'],
+		]);
+
+		$this->assertTrue($manifest->permitsInstall(isSignedIn: true, isAdmin: false));
+		$this->assertFalse(
+			$manifest->permitsInstall(isSignedIn: false, isAdmin: false),
+			'The weakest posture must still mean signed in.'
+		);
+	}
+
+	/**
+	 * 🔴 An unknown posture disables the store rather than falling back.
+	 *
+	 * Falling back to `admin` would silently REMOVE a capability from an app
+	 * that asked for a weaker gate: the store still works, for fewer people,
+	 * for no stated reason.
+	 *
+	 * @return void
+	 */
+	public function testUnknownInstallAuthDisablesTheStore(): void {
+		$manifest = StoreManifest::fromManifest('demo', [
+			'store' => ['schema' => 'template', 'installAuth' => 'everyone'],
+		]);
+
+		$this->assertFalse($manifest->enabled);
+	}
+
+	/**
+	 * An `action:` posture parses but is not yet enforceable.
+	 *
+	 * @return void
+	 */
+	public function testActionPostureParsesButIsNotEnforceable(): void {
+		$manifest = StoreManifest::fromManifest('demo', [
+			'store' => ['schema' => 'template', 'installAuth' => 'action:catalog.instantiate'],
+		]);
+
+		$this->assertTrue($manifest->enabled);
+		$this->assertSame('action:catalog.instantiate', $manifest->installAuth);
+		$this->assertFalse(
+			$manifest->isInstallAuthEnforceable(),
+			'Recognised is not the same as enforceable; the controller must refuse it.'
+		);
+	}
+
+	/**
+	 * A bare `action:` with no name is malformed.
+	 *
+	 * @return void
+	 */
+	public function testABareActionPrefixIsMalformed(): void {
+		$manifest = StoreManifest::fromManifest('demo', [
+			'store' => ['schema' => 'template', 'installAuth' => 'action:'],
+		]);
+
+		$this->assertFalse($manifest->enabled);
+	}
 }


### PR DESCRIPTION
Stacked on #3395 (`feat/store-plane-declarative-sources`), which it branches from. Review that one first.

## Why

The engine hardcodes `IGroupManager::isAdmin` on install. That is the right posture for dossiq and pipelinq, whose installs write case and commercial **configuration** — the shape every later handler operates against.

It is the wrong posture for the other three apps migrating onto this plane, and each is wrong differently:

| app | posture today | what admin-only would cost |
|---|---|---|
| **integriq** | ADR-023 `catalog.instantiate` | every operator who holds the action but is not an instance admin loses the capability |
| **hermiq** | any authenticated user | install lands `quarantined`; the gate that matters is *approval*, which is separately action-gated |
| **buildiq** | any authenticated user | the installer becomes the owner of the app they cloned |

Migrating those three onto an admin-only install is a regression, and the fleet decision is explicitly that they migrate without one.

## What changes

```jsonc
"store": {
  "installAuth": "admin"            // default — unchanged for every existing block
  // "authenticated"
  // "action:catalog.instantiate"
}
```

**An unrecognised value disables the block.** Falling back to `admin` would silently *remove* a capability from an app that asked for a weaker gate — the store still works, for fewer people, for no stated reason. That is harder to notice than an outright refusal, which is why it is not the behaviour.

**`action:<name>` parses but is not yet enforceable, and the controller refuses it rather than downgrading it.** Silently treating it as `authenticated` would install on a *weaker* gate than the app asked for, while looking like it worked. The ADR-023 resolver lives in the leaf apps; wiring it is the next increment.

## 🔴 installAuth decides WHO, never WHAT

`installable` remains the security boundary. An `authenticated` install refuses every schema the allowlist omits, and an empty allowlist still refuses everything.

The two keys sit side by side in the same block and read like a pair. They are not one — relaxing the gate on the door does not enlarge the room — so that independence is asserted directly rather than left to be inferred.

## What phpstan caught

`Bootstrap::register()` constructs this controller and did not pass the new discovery source. That is a **dispatch-time fatal on every store request**, not a type error anywhere useful — precisely the failure mode `Routes.php` already warns about for this controller. Worth noting that no test caught it: the suite builds the controller itself.

## Tests

276 green in the AppHost suite. The ones worth reading:

- an `authenticated` store admits a signed-in non-administrator — the capability hermiq and buildiq would otherwise lose
- an `authenticated` store **still refuses anonymous** — the weakest posture must not become no posture
- an unenforceable `action:` posture refuses the install rather than downgrading it
- a weaker posture does **not** widen the allowlist, and an empty allowlist still refuses everything

`phpcs`, `phpmd`, `psalm` and `phpstan` all clean on `lib/AppHost`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
