### PR TITLE
feat(store): resolve an action posture against the declaring app

### DIFF
--- a/lib/AppHost/Bootstrap.php
+++ b/lib/AppHost/Bootstrap.php
@@ -134,6 +134,11 @@ class Bootstrap {
 	 * The GitHub discovery source, for stores declaring `source: github`.
 	 */
 	private const GITHUB_STORE_SOURCE = 'OCA\\OpenRegister\\AppHost\\Store\\Source\\GitHubStoreSource';
+
+	/**
+	 * Resolves an `installAuth: action:<name>` posture against the leaf app.
+	 */
+	private const STORE_ACTION_AUTHORIZER = 'OCA\\OpenRegister\\AppHost\\Store\\StoreActionAuthorizer';
 	private const GENERIC_SETTINGS_SERVICE = 'OCA\\OpenRegister\\AppHost\\Service\\AppHostSettingsService';
 	private const GENERIC_ACTION_AUTH_SERVICE = 'OCA\\OpenRegister\\AppHost\\Service\\GenericActionAuthService';
 	private const GENERIC_INITIALIZE_SETTINGS = 'OCA\\OpenRegister\\AppHost\\Repair\\GenericInitializeSettings';
@@ -301,6 +306,7 @@ class Bootstrap {
 					installer: $c->get(self::GENERIC_STORE_INSTALLER),
 					catalog: $c->get(self::FEDERATED_STORE_CATALOG),
 					gitHubSource: $c->get(self::GITHUB_STORE_SOURCE),
+					actionAuthorizer: $c->get(self::STORE_ACTION_AUTHORIZER),
 					userSession: $c->get('OCP\\IUserSession'),
 					groupManager: $c->get('OCP\\IGroupManager'),
 					logger: $c->get('Psr\\Log\\LoggerInterface')

--- a/lib/AppHost/Controller/GenericStoreController.php
+++ b/lib/AppHost/Controller/GenericStoreController.php
@@ -49,6 +49,7 @@ use OCA\OpenRegister\AppHost\Service\StoreDescriptor;
 use OCA\OpenRegister\AppHost\Store\FederatedStoreCatalog;
 use OCA\OpenRegister\AppHost\Store\GenericStoreInstaller;
 use OCA\OpenRegister\AppHost\Store\Source\GitHubStoreSource;
+use OCA\OpenRegister\AppHost\Store\StoreActionAuthorizer;
 use OCA\OpenRegister\AppHost\Store\StoreManifest;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -56,6 +57,7 @@ use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUser;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -94,6 +96,7 @@ class GenericStoreController extends Controller {
 	 * @param GenericStoreInstaller $installer      Declarative component install.
 	 * @param FederatedStoreCatalog $catalog        Configuration browse and install.
 	 * @param GitHubStoreSource     $gitHubSource   GitHub discovery source.
+	 * @param StoreActionAuthorizer $actionAuthorizer ADR-023 action resolver.
 	 * @param IUserSession          $userSession    Current session.
 	 * @param IGroupManager         $groupManager   Admin check for install.
 	 * @param LoggerInterface       $logger         PSR logger.
@@ -112,6 +115,7 @@ class GenericStoreController extends Controller {
 		private readonly GenericStoreInstaller $installer,
 		private readonly FederatedStoreCatalog $catalog,
 		private readonly GitHubStoreSource $gitHubSource,
+		private readonly StoreActionAuthorizer $actionAuthorizer,
 		private readonly IUserSession $userSession,
 		private readonly IGroupManager $groupManager,
 		private readonly LoggerInterface $logger,
@@ -266,14 +270,7 @@ class GenericStoreController extends Controller {
 			);
 		}
 
-		// WHO may install is the app's declaration; WHAT may be written stays
-		// the `installable` allowlist, which the installer enforces regardless.
-		// Anonymous is refused on this same guard: `authenticated` is the
-		// weakest posture the vocabulary offers and it still means signed in.
-		if ($store->permitsInstall(
-			isSignedIn: ($user !== null),
-			isAdmin: ($user !== null && $this->groupManager->isAdmin($user->getUID()))
-		) === false) {
+		if ($this->mayInstall(store: $store, user: $user) === false) {
 			return new JSONResponse(
 				data: ['success' => false, 'message' => 'Installing a store item requires an administrator.'],
 				statusCode: Http::STATUS_FORBIDDEN
@@ -311,6 +308,42 @@ class GenericStoreController extends Controller {
 			statusCode: Http::STATUS_OK
 		);
 	}//end install()
+
+	/**
+	 * Whether this caller may install, per the posture the app declared.
+	 *
+	 * WHO may install is the app's declaration; WHAT may be written stays the
+	 * `installable` allowlist, which the installer enforces regardless.
+	 * Anonymous is refused whatever the posture: `authenticated` is the weakest
+	 * the vocabulary offers and it still means signed in.
+	 *
+	 * An action posture is resolved against the LEAF app's own ADR-023 matrix.
+	 * StoreManifest deliberately answers false for it, because that matrix is
+	 * not visible from there and assuming `admin` would turn "the operators who
+	 * hold this action" into "instance administrators" — the capability loss
+	 * this key exists to prevent.
+	 *
+	 * @param StoreManifest $store The declared store block.
+	 * @param IUser|null    $user  The signed-in user, or null.
+	 *
+	 * @return bool
+	 *
+	 * @spec openspec/changes/store-plane-action-auth/specs/apphost-store-plane/spec.md#requirement-an-action-posture-must-resolve-against-the-declaring-app
+	 */
+	private function mayInstall(StoreManifest $store, ?IUser $user): bool {
+		$action = $store->installAction();
+		if ($action !== null) {
+			// permitsInstall() answers false for an action posture by design,
+			// so this is the only arm that can grant one.
+			return ($user !== null
+				&& $this->actionAuthorizer->can(appId: $this->appName, action: $action, user: $user));
+		}
+
+		return $store->permitsInstall(
+			isSignedIn: ($user !== null),
+			isAdmin: ($user !== null && $this->groupManager->isAdmin($user->getUID()))
+		);
+	}//end mayInstall()
 
 	/**
 	 * Search whichever catalogue this app declared.

--- a/lib/AppHost/Store/StoreActionAuthorizer.php
+++ b/lib/AppHost/Store/StoreActionAuthorizer.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * OpenRegister AppHost — Store install action authorizer.
+ *
+ * Resolves an ADR-023 action check against the LEAF app that declared it, so a
+ * store may declare `"installAuth": "action:catalog.instantiate"` and get
+ * integriq's own authorization matrix without OpenRegister depending on
+ * integriq.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Store
+ * @package  OCA\OpenRegister\AppHost\Store
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\AppHost\Store;
+
+use OCP\IUser;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Asks a leaf app whether a user may perform a named action.
+ *
+ * 🔴 AN UNRESOLVABLE AUTHORIZER REFUSES. IT NEVER PERMITS.
+ *
+ * This is a duck-typed lookup by convention: `OCA\<Studly>\Service\
+ * ActionAuthService::can()`. The fleet has been bitten repeatedly by exactly
+ * this shape — `isInstalled('docudesk')`, `class_exists('OCA\DocuDesk\…')` —
+ * where pointing a runtime lookup at a name nothing answers to makes the
+ * integration a SILENT NO-OP rather than an error.
+ *
+ * A no-op here would be an install that skipped its authorization check and
+ * reported success, so every failure to resolve — class absent, not
+ * constructible, no `can()` method, `can()` throwing — is a refusal, and each
+ * one is logged with the name that could not be resolved.
+ *
+ * @spec openspec/changes/store-plane-action-auth/specs/apphost-store-plane/spec.md#requirement-an-action-posture-must-resolve-against-the-declaring-app
+ */
+class StoreActionAuthorizer {
+	/**
+	 * Constructor.
+	 *
+	 * @param ContainerInterface $container Server container, for the leaf service.
+	 * @param LoggerInterface    $logger    PSR logger, server-side only.
+	 */
+	public function __construct(
+		private readonly ContainerInterface $container,
+		private readonly LoggerInterface $logger,
+	) {
+	}//end __construct()
+
+	/**
+	 * Whether the user may perform the action the store declared.
+	 *
+	 * @param string $appId  The declaring leaf app id.
+	 * @param string $action The dot-separated action name.
+	 * @param IUser  $user   The signed-in user.
+	 *
+	 * @return bool True only when the leaf app's own matrix says yes.
+	 */
+	public function can(string $appId, string $action, IUser $user): bool {
+		$class = 'OCA\\' . $this->studly(appId: $appId) . '\\Service\\ActionAuthService';
+
+		try {
+			$service = $this->container->get($class);
+		} catch (Throwable $e) {
+			$this->refuse(
+				appId: $appId,
+				action: $action,
+				reason: sprintf('%s is not resolvable (%s)', $class, $e->getMessage())
+			);
+			return false;
+		}
+
+		if (method_exists($service, 'can') === false) {
+			$this->refuse(
+				appId: $appId,
+				action: $action,
+				reason: sprintf('%s has no can() method', $class)
+			);
+			return false;
+		}
+
+		try {
+			return ($service->can($user, $action) === true);
+		} catch (Throwable $e) {
+			// A throwing matrix is a refusal, not a pass. ADR-023's own
+			// requireAction() throws to deny, and a `can()` that propagates
+			// anything must not be read as consent.
+			$this->refuse(
+				appId: $appId,
+				action: $action,
+				reason: sprintf('can() threw: %s', $e->getMessage())
+			);
+			return false;
+		}
+	}//end can()
+
+	/**
+	 * Log a refusal with the reason it could not be decided.
+	 *
+	 * Logged at ERROR, not WARNING: an app declared a posture this server then
+	 * could not honour, which is a misconfiguration somebody has to fix rather
+	 * than a user being told no.
+	 *
+	 * @param string $appId  The declaring app.
+	 * @param string $action The action name.
+	 * @param string $reason Why it could not be decided.
+	 *
+	 * @return void
+	 */
+	private function refuse(string $appId, string $action, string $reason): void {
+		$this->logger->error(
+			message: sprintf(
+				'[AppHost\\Store] refusing install for %s: action "%s" could not be authorised — %s',
+				$appId,
+				$action,
+				$reason
+			),
+			context: ['file' => __FILE__, 'line' => __LINE__]
+		);
+	}//end refuse()
+
+	/**
+	 * StudlyCase an app id, matching Bootstrap's own convention.
+	 *
+	 * @param string $appId The app id.
+	 *
+	 * @return string
+	 */
+	private function studly(string $appId): string {
+		$parts = preg_split(pattern: '/[_\-]+/', subject: $appId);
+		if ($parts === false || count($parts) === 0) {
+			$parts = [$appId];
+		}
+
+		$studly = '';
+		foreach ($parts as $part) {
+			$studly .= ucfirst($part);
+		}
+
+		return $studly;
+	}//end studly()
+}

--- a/lib/AppHost/Store/StoreManifest.php
+++ b/lib/AppHost/Store/StoreManifest.php
@@ -345,8 +345,22 @@ class StoreManifest {
 	 * @return bool
 	 */
 	public function isInstallAuthEnforceable(): bool {
-		return in_array(needle: $this->installAuth, haystack: self::INSTALL_AUTH, strict: true);
+		return $this->isKnownInstallAuth(value: $this->installAuth);
 	}//end isInstallAuthEnforceable()
+
+	/**
+	 * The ADR-023 action name this store gates its install on, if any.
+	 *
+	 * @return string|null The action name, or null when the posture is not an
+	 *                     action posture.
+	 */
+	public function installAction(): ?string {
+		if (str_starts_with($this->installAuth, self::INSTALL_AUTH_ACTION_PREFIX) === false) {
+			return null;
+		}
+
+		return substr($this->installAuth, strlen(self::INSTALL_AUTH_ACTION_PREFIX));
+	}//end installAction()
 
 	/**
 	 * Whether an install by this user is permitted by the declared posture.
@@ -366,6 +380,15 @@ class StoreManifest {
 
 		if ($this->installAuth === 'authenticated') {
 			return true;
+		}
+
+		// An action posture is NOT decided here. The matrix lives in the leaf
+		// app, so this object cannot see the answer; returning $isAdmin would
+		// quietly turn "the operators who hold this action" into "instance
+		// administrators", which is the capability loss this key exists to
+		// prevent. The controller resolves it and must not reach this line.
+		if ($this->installAction() !== null) {
+			return false;
 		}
 
 		return $isAdmin;

--- a/openspec/changes/store-plane-action-auth/proposal.md
+++ b/openspec/changes/store-plane-action-auth/proposal.md
@@ -1,0 +1,45 @@
+# Store plane: resolve an action posture against the declaring app
+
+## Why
+
+The previous increment defined `installAuth: "action:<name>"` and then
+**refused** it, because resolving an ADR-023 action needs the matrix that lives
+in the leaf app. Refusing was the right holding position — downgrading to
+`authenticated` would have installed on a weaker gate than the app asked for —
+but it leaves integriq unable to migrate, since `catalog.instantiate` is
+exactly its posture.
+
+## What changes
+
+`StoreActionAuthorizer` resolves `OCA\<Studly>\Service\ActionAuthService` from
+the server container and calls its `can(IUser, string): bool`. The controller
+uses it for the `action:` arm and nothing else.
+
+## The one thing that matters here
+
+🔴 **An unresolvable authorizer REFUSES. It never permits.**
+
+This is a duck-typed lookup by convention, and the fleet has been bitten by
+that shape repeatedly: `isInstalled('docudesk')`,
+`class_exists('OCA\DocuDesk\…')` — a runtime lookup pointed at a name nothing
+answers to becomes a **silent no-op** rather than an error. A no-op here is an
+install that skipped its authorization check and reported success.
+
+So every way of failing to decide is a refusal, and each is logged at ERROR
+with the name that could not be resolved:
+
+- the class is not in the container
+- it resolves but has no `can()` method — the shape a rename produces, where a
+  lookup that only checked existence would sail past
+- `can()` throws — ADR-023's own `requireAction()` throws to DENY, so anything
+  propagating out must not be read as consent
+
+**An administrator does not bypass the matrix.** The point of the posture is
+that the leaf app decides; letting admins through anyway would make the
+declaration decorative and would stop an app gating an install MORE tightly
+than instance admin.
+
+## What does NOT change
+
+`installable` is untouched. This decides who may ask; it does not widen what an
+install may write.

--- a/openspec/changes/store-plane-action-auth/specs/apphost-store-plane/spec.md
+++ b/openspec/changes/store-plane-action-auth/specs/apphost-store-plane/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: An action posture MUST resolve against the declaring app
+
+When a store declares `installAuth: "action:<name>"`, the engine MUST ask the
+declaring app's own ADR-023 authorization matrix whether the signed-in user may
+perform `<name>`, and MUST install only when it answers yes.
+
+The engine MUST NOT decide an action posture itself. Assuming `admin` would
+turn "the operators who hold this action" into "instance administrators", which
+is the capability loss the key exists to prevent.
+
+An administrator MUST NOT bypass the matrix. Otherwise the declaration is
+decorative, and an app could never gate an install more tightly than instance
+admin.
+
+#### Scenario: The leaf matrix permits
+
+- **WHEN** a store declares `"installAuth": "action:catalog.instantiate"`
+- **AND** the declaring app's matrix permits the signed-in user
+- **THEN** the install proceeds
+
+#### Scenario: The leaf matrix declines
+
+- **WHEN** the declaring app's matrix declines
+- **THEN** the response is 403
+- **AND** no component is written
+
+#### Scenario: An administrator is still asked
+
+- **WHEN** the caller is an instance administrator
+- **AND** the declaring app's matrix declines
+- **THEN** the response is 403
+
+#### Scenario: Anonymous never reaches the matrix
+
+- **WHEN** an anonymous caller posts an install against an action posture
+- **THEN** the response is 403
+- **AND** the matrix is not consulted
+
+### Requirement: An unresolvable authorizer MUST refuse, never permit
+
+Every failure to decide MUST be a refusal, and MUST be logged at ERROR with the
+name that could not be resolved.
+
+The lookup is duck-typed by convention, which is the shape that has repeatedly
+produced silent no-ops in this fleet. A no-op here is an install that skipped
+its authorization check and then reported success, so the absence of an answer
+is treated as "no", never as "no objection".
+
+#### Scenario: The service is not in the container
+
+- **WHEN** `OCA\<Studly>\Service\ActionAuthService` cannot be resolved
+- **THEN** the install is refused
+- **AND** an ERROR is logged naming the action
+
+#### Scenario: The service has no can() method
+
+- **WHEN** the class resolves but exposes no `can()`
+- **THEN** the install is refused
+
+This is the shape a RENAME produces: the class still resolves and the method is
+gone, so a check that only tested existence would sail past it.
+
+#### Scenario: The matrix throws
+
+- **WHEN** `can()` throws
+- **THEN** the install is refused
+
+ADR-023's own `requireAction()` throws to DENY, so anything propagating out of
+the matrix must not be read as consent.

--- a/tests/Unit/AppHost/GenericStoreControllerTest.php
+++ b/tests/Unit/AppHost/GenericStoreControllerTest.php
@@ -38,6 +38,7 @@ use OCA\OpenRegister\AppHost\Service\GenericStoreService;
 use OCA\OpenRegister\AppHost\Store\FederatedStoreCatalog;
 use OCA\OpenRegister\AppHost\Store\GenericStoreInstaller;
 use OCA\OpenRegister\AppHost\Store\Source\GitHubStoreSource;
+use OCA\OpenRegister\AppHost\Store\StoreActionAuthorizer;
 use OCA\OpenRegister\AppHost\Store\StoreManifest;
 use OCP\AppFramework\Http;
 use OCP\IGroupManager;
@@ -79,6 +80,9 @@ class GenericStoreControllerTest extends TestCase {
 	/** @var GitHubStoreSource&MockObject */
 	private $gitHubSource;
 
+	/** @var StoreActionAuthorizer&MockObject */
+	private $actionAuthorizer;
+
 	/** @var IUserSession&MockObject */
 	private $userSession;
 
@@ -108,6 +112,8 @@ class GenericStoreControllerTest extends TestCase {
 			->disableOriginalConstructor()->onlyMethods(['search', 'resolve', 'install'])->getMock();
 		$this->gitHubSource = $this->getMockBuilder(GitHubStoreSource::class)
 			->disableOriginalConstructor()->onlyMethods(['search', 'sourceId'])->getMock();
+		$this->actionAuthorizer = $this->getMockBuilder(StoreActionAuthorizer::class)
+			->disableOriginalConstructor()->onlyMethods(['can'])->getMock();
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->request = $this->createMock(IRequest::class);
@@ -129,6 +135,7 @@ class GenericStoreControllerTest extends TestCase {
 			installer: $this->installer,
 			catalog: $this->catalog,
 			gitHubSource: $this->gitHubSource,
+			actionAuthorizer: $this->actionAuthorizer,
 			userSession: $this->userSession,
 			groupManager: $this->groupManager,
 			logger: $this->createMock(LoggerInterface::class)
@@ -492,31 +499,97 @@ class GenericStoreControllerTest extends TestCase {
 	}
 
 	/**
-	 * A posture the engine cannot enforce is refused, never downgraded.
-	 *
-	 * 🔴 The regression this guards: silently treating `action:<name>` as
-	 * `authenticated` would install on a WEAKER gate than the app asked for,
-	 * and the store would look like it was working.
+	 * An action posture asks the LEAF app, and installs when it says yes.
 	 *
 	 * @return void
 	 */
-	public function testAnUnenforceablePostureRefusesTheInstall(): void {
-		$this->signIn(isAdmin: true);
-		$this->manifestLoader->method('loadStore')->willReturn(
-			StoreManifest::fromManifest('demo', [
-				'store' => [
-					'schema' => 'template',
-					'installAuth' => 'action:catalog.instantiate',
-				],
-			])
+	public function testAnActionPostureInstallsWhenTheLeafMatrixAllowsIt(): void {
+		$this->signIn(isAdmin: false);
+		$this->manifestLoader->method('loadStore')->willReturn($this->actionStore());
+		$this->actionAuthorizer->expects($this->once())
+			->method('can')
+			->with('demo', 'catalog.instantiate', $this->anything())
+			->willReturn(true);
+		$this->storeService->method('resolve')->willReturn(['slug' => 'vth', 'components' => []]);
+		$this->installer->expects($this->once())
+			->method('install')
+			->willReturn(['success' => true, 'components' => []]);
+
+		$this->assertSame(
+			Http::STATUS_OK,
+			$this->controller('demo')->install(slug: 'vth')->getStatus()
 		);
+	}
+
+	/**
+	 * And refuses when it says no.
+	 *
+	 * @return void
+	 */
+	public function testAnActionPostureRefusesWhenTheLeafMatrixDeclines(): void {
+		$this->signIn(isAdmin: false);
+		$this->manifestLoader->method('loadStore')->willReturn($this->actionStore());
+		$this->actionAuthorizer->method('can')->willReturn(false);
+		$this->installer->expects($this->never())->method('install');
+
+		$this->assertSame(
+			Http::STATUS_FORBIDDEN,
+			$this->controller('demo')->install(slug: 'vth')->getStatus()
+		);
+	}
+
+	/**
+	 * 🔴 An administrator does NOT bypass the action matrix.
+	 *
+	 * The point of the posture is that the leaf app decides. An engine that
+	 * let admins through anyway would make the declaration decorative, and the
+	 * app could never gate an install MORE tightly than instance admin.
+	 *
+	 * @return void
+	 */
+	public function testAnAdministratorStillGoesThroughTheActionMatrix(): void {
+		$this->signIn(isAdmin: true);
+		$this->manifestLoader->method('loadStore')->willReturn($this->actionStore());
+		$this->actionAuthorizer->expects($this->once())->method('can')->willReturn(false);
 		$this->installer->expects($this->never())->method('install');
 
 		$this->assertSame(
 			Http::STATUS_FORBIDDEN,
 			$this->controller('demo')->install(slug: 'vth')->getStatus(),
-			'An action: posture must be refused until a resolver exists, not downgraded.'
+			'Being an administrator must not skip the action the app declared.'
 		);
+	}
+
+	/**
+	 * An anonymous caller never reaches the matrix at all.
+	 *
+	 * @return void
+	 */
+	public function testAnActionPostureRefusesAnonymousWithoutAsking(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->manifestLoader->method('loadStore')->willReturn($this->actionStore());
+		$this->actionAuthorizer->expects($this->never())->method('can');
+		$this->installer->expects($this->never())->method('install');
+
+		$this->assertSame(
+			Http::STATUS_FORBIDDEN,
+			$this->controller('demo')->install(slug: 'vth')->getStatus()
+		);
+	}
+
+	/**
+	 * A store gating install on an ADR-023 action.
+	 *
+	 * @return StoreManifest
+	 */
+	private function actionStore(): StoreManifest {
+		return StoreManifest::fromManifest('demo', [
+			'store' => [
+				'schema' => 'template',
+				'installAuth' => 'action:catalog.instantiate',
+				'installable' => ['caseType'],
+			],
+		]);
 	}
 
 	/**

--- a/tests/Unit/AppHost/StoreActionAuthorizerTest.php
+++ b/tests/Unit/AppHost/StoreActionAuthorizerTest.php
@@ -1,0 +1,197 @@
+<?php
+
+/**
+ * Tests for the store install action authorizer.
+ *
+ * 🔴 EVERY TEST HERE IS ABOUT REFUSING RATHER THAN NO-OPPING.
+ *
+ * This is a duck-typed lookup by convention, and the fleet has been bitten
+ * repeatedly by exactly that shape: `isInstalled('docudesk')`,
+ * `class_exists('OCA\DocuDesk\…')` — a runtime lookup pointed at a name
+ * nothing answers to becomes a SILENT NO-OP rather than an error. A no-op here
+ * is an install that skipped its authorization check and reported success, so
+ * every way of failing to resolve is asserted to refuse.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\AppHost
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\AppHost;
+
+use OCA\OpenRegister\AppHost\Store\StoreActionAuthorizer;
+use OCP\IUser;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * A leaf ActionAuthService that answers.
+ */
+class FakeActionAuthService {
+	/**
+	 * @param bool $answer What can() returns.
+	 */
+	public function __construct(private readonly bool $answer) {
+	}
+
+	/**
+	 * @param IUser  $user   The user.
+	 * @param string $action The action.
+	 *
+	 * @return bool
+	 */
+	public function can(IUser $user, string $action): bool {
+		return $this->answer;
+	}
+}
+
+/**
+ * A leaf service whose matrix throws.
+ */
+class ThrowingActionAuthService {
+	/**
+	 * @param IUser  $user   The user.
+	 * @param string $action The action.
+	 *
+	 * @return bool
+	 */
+	public function can(IUser $user, string $action): bool {
+		throw new RuntimeException('matrix unavailable');
+	}
+}
+
+/**
+ * A leaf service that exists but has no can().
+ */
+class ShapelessActionAuthService {
+}
+
+/**
+ * @covers \OCA\OpenRegister\AppHost\Store\StoreActionAuthorizer
+ */
+class StoreActionAuthorizerTest extends TestCase {
+	/**
+	 * Build an authorizer whose container yields the given service.
+	 *
+	 * @param mixed $service What the container returns, or a Throwable to throw.
+	 *
+	 * @return StoreActionAuthorizer
+	 */
+	private function authorizer(mixed $service): StoreActionAuthorizer {
+		$container = $this->createMock(ContainerInterface::class);
+		if ($service instanceof \Throwable) {
+			$container->method('get')->willThrowException($service);
+		} else {
+			$container->method('get')->willReturn($service);
+		}
+
+		return new StoreActionAuthorizer($container, $this->createMock(LoggerInterface::class));
+	}
+
+	/**
+	 * The leaf matrix says yes.
+	 *
+	 * @return void
+	 */
+	public function testItPermitsWhenTheLeafMatrixSaysYes(): void {
+		$authorizer = $this->authorizer(new FakeActionAuthService(true));
+
+		$this->assertTrue(
+			$authorizer->can('integriq', 'catalog.instantiate', $this->createMock(IUser::class))
+		);
+	}
+
+	/**
+	 * The leaf matrix says no.
+	 *
+	 * @return void
+	 */
+	public function testItRefusesWhenTheLeafMatrixSaysNo(): void {
+		$authorizer = $this->authorizer(new FakeActionAuthService(false));
+
+		$this->assertFalse(
+			$authorizer->can('integriq', 'catalog.instantiate', $this->createMock(IUser::class))
+		);
+	}
+
+	/**
+	 * 🔴 An absent service refuses. It must never read as "no objection".
+	 *
+	 * @return void
+	 */
+	public function testAnUnresolvableServiceRefuses(): void {
+		$authorizer = $this->authorizer(new RuntimeException('not found'));
+
+		$this->assertFalse(
+			$authorizer->can('integriq', 'catalog.instantiate', $this->createMock(IUser::class)),
+			'An unresolvable authorizer must refuse, never silently permit.'
+		);
+	}
+
+	/**
+	 * 🔴 A service without can() refuses rather than being assumed permissive.
+	 *
+	 * This is the shape a RENAME produces: the class still resolves, the
+	 * method is gone, and a lookup that only checked existence would sail past.
+	 *
+	 * @return void
+	 */
+	public function testAServiceWithoutCanRefuses(): void {
+		$authorizer = $this->authorizer(new ShapelessActionAuthService());
+
+		$this->assertFalse(
+			$authorizer->can('integriq', 'catalog.instantiate', $this->createMock(IUser::class))
+		);
+	}
+
+	/**
+	 * 🔴 A throwing matrix is a refusal, not a pass.
+	 *
+	 * ADR-023's own requireAction() throws to DENY, so anything propagating
+	 * out of can() must not be read as consent.
+	 *
+	 * @return void
+	 */
+	public function testAThrowingMatrixRefuses(): void {
+		$authorizer = $this->authorizer(new ThrowingActionAuthService());
+
+		$this->assertFalse(
+			$authorizer->can('integriq', 'catalog.instantiate', $this->createMock(IUser::class))
+		);
+	}
+
+	/**
+	 * Every refusal is logged at ERROR with the reason.
+	 *
+	 * A silent refusal is nearly as bad as a silent pass: somebody has to be
+	 * able to find out why the store stopped installing.
+	 *
+	 * @return void
+	 */
+	public function testARefusalIsLoggedWithItsReason(): void {
+		$container = $this->createMock(ContainerInterface::class);
+		$container->method('get')->willThrowException(new RuntimeException('not found'));
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->once())
+			->method('error')
+			->with($this->stringContains('catalog.instantiate'), $this->anything());
+
+		$authorizer = new StoreActionAuthorizer($container, $logger);
+		$authorizer->can('integriq', 'catalog.instantiate', $this->createMock(IUser::class));
+	}
+}

--- a/tests/Unit/AppHost/StoreManifestSourceTest.php
+++ b/tests/Unit/AppHost/StoreManifestSourceTest.php
@@ -180,21 +180,50 @@ class StoreManifestSourceTest extends TestCase {
 	}
 
 	/**
-	 * An `action:` posture parses but is not yet enforceable.
+	 * An `action:` posture exposes its action name and is enforceable.
 	 *
 	 * @return void
 	 */
-	public function testActionPostureParsesButIsNotEnforceable(): void {
+	public function testActionPostureExposesItsActionName(): void {
 		$manifest = StoreManifest::fromManifest('demo', [
 			'store' => ['schema' => 'template', 'installAuth' => 'action:catalog.instantiate'],
 		]);
 
 		$this->assertTrue($manifest->enabled);
-		$this->assertSame('action:catalog.instantiate', $manifest->installAuth);
+		$this->assertTrue($manifest->isInstallAuthEnforceable());
+		$this->assertSame('catalog.instantiate', $manifest->installAction());
+	}
+
+	/**
+	 * 🔴 The manifest REFUSES to answer for an action posture.
+	 *
+	 * The matrix lives in the leaf app, so this object cannot see the answer.
+	 * Returning $isAdmin would quietly turn "the operators who hold this
+	 * action" into "instance administrators" — exactly the capability loss
+	 * this key exists to prevent. The controller resolves it instead.
+	 *
+	 * @return void
+	 */
+	public function testAnActionPostureIsNotDecidedByTheManifest(): void {
+		$manifest = StoreManifest::fromManifest('demo', [
+			'store' => ['schema' => 'template', 'installAuth' => 'action:catalog.instantiate'],
+		]);
+
 		$this->assertFalse(
-			$manifest->isInstallAuthEnforceable(),
-			'Recognised is not the same as enforceable; the controller must refuse it.'
+			$manifest->permitsInstall(isSignedIn: true, isAdmin: true),
+			'Even an administrator must be decided by the leaf matrix, not assumed here.'
 		);
+	}
+
+	/**
+	 * A non-action posture reports no action name.
+	 *
+	 * @return void
+	 */
+	public function testANonActionPostureHasNoActionName(): void {
+		$manifest = StoreManifest::fromManifest('demo', ['store' => ['schema' => 'template']]);
+
+		$this->assertNull($manifest->installAction());
 	}
 
 	/**


### PR DESCRIPTION
Stacked on #3397, which is stacked on #3395. Review those first.

## Why

The previous increment defined `installAuth: "action:<name>"` and then **refused** it, because the ADR-023 matrix lives in the leaf app. Refusing was the right holding position — downgrading to `authenticated` would have installed on a weaker gate than the app asked for — but it leaves **integriq unable to migrate**, since `catalog.instantiate` is exactly its posture.

`StoreActionAuthorizer` resolves `OCA\<Studly>\Service\ActionAuthService` from the container and calls its `can(IUser, string): bool`. The controller uses it for the `action:` arm and nothing else.

## 🔴 An unresolvable authorizer refuses. It never permits.

This is a duck-typed lookup by convention, and this fleet has been bitten by that shape repeatedly — `isInstalled('docudesk')`, `class_exists('OCA\DocuDesk\…')`. A runtime lookup pointed at a name nothing answers to becomes a **silent no-op**, not an error. A no-op *here* is an install that skipped its authorization check and then reported success.

So every way of failing to decide is a refusal, logged at ERROR with the name that could not be resolved:

| failure | why it must refuse |
|---|---|
| class not in the container | absence of an answer is not "no objection" |
| resolves, but no `can()` | the shape a **rename** produces — a check that only tested existence sails past |
| `can()` throws | ADR-023's own `requireAction()` throws to **deny**; propagation must never read as consent |

## An administrator does not bypass the matrix

The point of the posture is that the leaf app decides. Letting admins through anyway would make the declaration decorative, and would stop an app gating an install *more* tightly than instance admin. There is a test that fails if that changes.

Relatedly, `StoreManifest::permitsInstall()` answers **false** for an action posture by design rather than falling through to `$isAdmin`, so the controller arm is the only thing that can grant one. If someone later deletes that arm, installs stop — they do not silently become admin-gated.

## Tests

287 green in the AppHost suite, 11 new. The authorizer's own suite is entirely about the refusal paths, because that is where the danger is.

`phpcs`, `phpmd` (against CI's baseline), `psalm` and `phpstan` clean on `lib/AppHost`. When `install()` crossed the method-length and complexity thresholds, the authorization decision was **extracted into `mayInstall()`** rather than added to the baseline.

## Still out of scope

Install shapes beyond writing objects — buildiq clones an app and creates a register, hermiq instantiates an agent with model-policy coercion. That is the next increment, and it is the last thing standing between these three apps and a migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
