### PR TITLE
feat(store): install operations other than writing an object

### DIFF
--- a/lib/AppHost/Controller/GenericStoreController.php
+++ b/lib/AppHost/Controller/GenericStoreController.php
@@ -333,8 +333,8 @@ class GenericStoreController extends Controller {
 	private function mayInstall(StoreManifest $store, ?IUser $user): bool {
 		$action = $store->installAction();
 		if ($action !== null) {
-			// permitsInstall() answers false for an action posture by design,
-			// so this is the only arm that can grant one.
+			// StoreManifest answers false for an action posture by design, so
+			// this is the only arm that can grant one.
 			return ($user !== null
 				&& $this->actionAuthorizer->can(appId: $this->appName, action: $action, user: $user));
 		}

--- a/lib/AppHost/Store/GenericStoreInstaller.php
+++ b/lib/AppHost/Store/GenericStoreInstaller.php
@@ -47,6 +47,7 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\AppHost\Store;
 
 use OCA\OpenRegister\Service\ObjectService;
+use OCP\IAppConfig;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
@@ -61,10 +62,12 @@ class GenericStoreInstaller {
 	 * Constructor.
 	 *
 	 * @param ObjectService   $objectService The OpenRegister write path.
+	 * @param IAppConfig      $appConfig     The declaring app's config store.
 	 * @param LoggerInterface $logger        PSR logger, server-side detail only.
 	 */
 	public function __construct(
 		private readonly ObjectService $objectService,
+		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
 	) {
 	}//end __construct()
@@ -89,57 +92,160 @@ class GenericStoreInstaller {
 		$failed = false;
 
 		foreach ($this->components(item: $item) as $component) {
-			$slug = (string)($component['schema'] ?? '');
-			$object = ($component['object'] ?? null);
-
-			if ($store->isInstallable(slug: $slug) === false) {
+			$result = $this->installComponent(store: $store, component: $component);
+			if ($result['status'] !== 'installed') {
 				$failed = true;
-				$report[] = [
-					'schema' => $slug,
-					'status' => 'refused',
-					'message' => 'This app does not allow the store to write into that schema.',
-				];
-				continue;
 			}
 
-			if (is_array($object) === false) {
-				$failed = true;
-				$report[] = [
-					'schema' => $slug,
-					'status' => 'refused',
-					'message' => 'The component declares no object to install.',
-				];
-				continue;
-			}
-
-			try {
-				$this->objectService->saveObject(
-					object: $this->asNewObject(object: $object),
-					register: $store->localRegister,
-					schema: $slug
-				);
-				$report[] = ['schema' => $slug, 'status' => 'installed', 'message' => ''];
-			} catch (Throwable $e) {
-				$failed = true;
-				$this->logger->error(
-					message: sprintf(
-						'[AppHost\\Store] installing %s for %s failed: %s',
-						$slug,
-						$store->appId,
-						$e->getMessage()
-					),
-					context: ['file' => __FILE__, 'line' => __LINE__]
-				);
-				$report[] = [
-					'schema' => $slug,
-					'status' => 'error',
-					'message' => 'The component could not be written.',
-				];
-			}
+			$report[] = $result;
 		}
 
 		return ['success' => ($failed === false && $report !== []), 'components' => $report];
 	}//end install()
+
+	/**
+	 * Install one component, whatever operation it declares.
+	 *
+	 * An unrecognised `op` is refused for THAT component only. A component
+	 * whose operation this server does not understand is the registry's
+	 * mistake, not a reason to deny an administrator the components it does
+	 * understand.
+	 *
+	 * @param StoreManifest        $store     The declared store block.
+	 * @param array<string, mixed> $component One component of the item.
+	 *
+	 * @return array<string, string> The per-component report row.
+	 *
+	 * @spec openspec/changes/store-plane-install-ops/specs/apphost-store-plane/spec.md#requirement-a-component-must-declare-its-install-operation-defaulting-to-writing-an-object
+	 */
+	private function installComponent(StoreManifest $store, array $component): array {
+		$op = (string)($component['op'] ?? StoreManifest::DEFAULT_INSTALL_OP);
+
+		if ($op === 'setAppConfig') {
+			return $this->setAppConfig(store: $store, component: $component);
+		}
+
+		if ($op !== StoreManifest::DEFAULT_INSTALL_OP) {
+			return [
+				'schema' => (string)($component['schema'] ?? ''),
+				'status' => 'refused',
+				'message' => 'This server does not understand that install operation.',
+			];
+		}
+
+		return $this->writeObject(store: $store, component: $component);
+	}//end installComponent()
+
+	/**
+	 * Write a component's object into an allowed schema.
+	 *
+	 * @param StoreManifest        $store     The declared store block.
+	 * @param array<string, mixed> $component One component of the item.
+	 *
+	 * @return array<string, string>
+	 */
+	private function writeObject(StoreManifest $store, array $component): array {
+		$slug = (string)($component['schema'] ?? '');
+		$object = ($component['object'] ?? null);
+
+		if ($store->isInstallable(slug: $slug) === false) {
+			return [
+				'schema' => $slug,
+				'status' => 'refused',
+				'message' => 'This app does not allow the store to write into that schema.',
+			];
+		}
+
+		if (is_array($object) === false) {
+			return [
+				'schema' => $slug,
+				'status' => 'refused',
+				'message' => 'The component declares no object to install.',
+			];
+		}
+
+		try {
+			$this->objectService->saveObject(
+				object: $this->asNewObject(object: $object),
+				register: $store->localRegister,
+				schema: $slug
+			);
+			return ['schema' => $slug, 'status' => 'installed', 'message' => ''];
+		} catch (Throwable $e) {
+			$this->logger->error(
+				message: sprintf(
+					'[AppHost\\Store] installing %s for %s failed: %s',
+					$slug,
+					$store->appId,
+					$e->getMessage()
+				),
+				context: ['file' => __FILE__, 'line' => __LINE__]
+			);
+			return [
+				'schema' => $slug,
+				'status' => 'error',
+				'message' => 'The component could not be written.',
+			];
+		}
+	}//end writeObject()
+
+	/**
+	 * Write an allowlisted config key into the DECLARING app's namespace.
+	 *
+	 * 🔴 The app id comes from the manifest, never from the component. A
+	 * registry naming another app's namespace would otherwise be writing into
+	 * an app that never opted into a store at all.
+	 *
+	 * @param StoreManifest        $store     The declared store block.
+	 * @param array<string, mixed> $component One component of the item.
+	 *
+	 * @return array<string, string>
+	 *
+	 * @spec openspec/changes/store-plane-install-ops/specs/apphost-store-plane/spec.md#requirement-a-config-write-must-be-allowlisted-by-key-and-scoped-to-the-declaring-app
+	 */
+	private function setAppConfig(StoreManifest $store, array $component): array {
+		$key = (string)($component['key'] ?? '');
+
+		if ($store->isConfigurable(key: $key) === false) {
+			return [
+				'schema' => $key,
+				'status' => 'refused',
+				'message' => 'This app does not allow the store to write that setting.',
+			];
+		}
+
+		$value = ($component['value'] ?? null);
+		if (is_scalar($value) === false) {
+			// Config is a flat key-value store. Serialising a structure into it
+			// produces a value the app later reads back as a string it never
+			// wrote.
+			return [
+				'schema' => $key,
+				'status' => 'refused',
+				'message' => 'A setting must be a boolean, string or number.',
+			];
+		}
+
+		try {
+			$this->appConfig->setValueString($store->appId, $key, (string)$value);
+			return ['schema' => $key, 'status' => 'installed', 'message' => ''];
+		} catch (Throwable $e) {
+			$this->logger->error(
+				message: sprintf(
+					'[AppHost\\Store] setting %s for %s failed: %s',
+					$key,
+					$store->appId,
+					$e->getMessage()
+				),
+				context: ['file' => __FILE__, 'line' => __LINE__]
+			);
+			return [
+				'schema' => $key,
+				'status' => 'error',
+				'message' => 'The setting could not be written.',
+			];
+		}
+	}//end setAppConfig()
 
 	/**
 	 * Read the components a resolved item declares.

--- a/lib/AppHost/Store/StoreManifest.php
+++ b/lib/AppHost/Store/StoreManifest.php
@@ -80,6 +80,26 @@ class StoreManifest {
 	public const SOURCES = ['openregister', 'github'];
 
 	/**
+	 * Config keys an install may write, when a component declares
+	 * `op: setAppConfig`.
+	 *
+	 * 🔴 A SECOND SECURITY BOUNDARY, NOT A CONVENIENCE. `installable` stops a
+	 * remote registry naming any schema the app owns; this stops it naming any
+	 * config key. An app's config namespace holds registry URLs, tokens and
+	 * feature flags, so an unallowlisted write is a remote actor toggling
+	 * whatever it names. An empty list refuses every key, exactly as an empty
+	 * `installable` refuses every schema.
+	 *
+	 * @var array<int, string>
+	 */
+	public const INSTALL_OPS = ['writeObject', 'setAppConfig'];
+
+	/**
+	 * The operation assumed when a component declares none.
+	 */
+	public const DEFAULT_INSTALL_OP = 'writeObject';
+
+	/**
 	 * Install postures a store may declare.
 	 *
 	 * `admin` is an instance administrator. `authenticated` is any signed-in
@@ -133,6 +153,7 @@ class StoreManifest {
 	 * @param string                     $source      Discovery source: one of self::SOURCES.
 	 * @param array<int, string>         $topics      GitHub topics searched when $source is `github`.
 	 * @param string                     $installAuth Who may install: see self::INSTALL_AUTH.
+	 * @param array<int, string>         $configurable Config keys an install may write.
 	 *
 	 * @SuppressWarnings(PHPMD.ExcessiveParameterList) This is a value object
 	 * mirroring the manifest's `store` block one key to one parameter, so the
@@ -154,6 +175,7 @@ class StoreManifest {
 		public readonly string $source = self::DEFAULT_SOURCE,
 		public readonly array $topics = [],
 		public readonly string $installAuth = self::DEFAULT_INSTALL_AUTH,
+		public readonly array $configurable = [],
 	) {
 	}//end __construct()
 
@@ -233,6 +255,7 @@ class StoreManifest {
 			source: $source,
 			topics: $topics,
 			installAuth: $installAuth,
+			configurable: self::stringList(value: ($block['configurable'] ?? [])),
 			// Shareable configuration type ids (store-over-federated-config).
 			// Declaring these selects federated discovery, where an item is a
 			// configuration set, a flow or a schema that marked itself
@@ -393,5 +416,26 @@ class StoreManifest {
 
 		return $isAdmin;
 	}//end permitsInstall()
+
+	/**
+	 * Whether an install may write this config key.
+	 *
+	 * 🔴 An EMPTY allowlist refuses everything, never permits everything. An
+	 * app that declares a store and forgets `configurable` gets config writes
+	 * that are all refused, rather than an open door onto its own settings.
+	 *
+	 * @param string $key The config key a component names.
+	 *
+	 * @return bool
+	 *
+	 * @spec openspec/changes/store-plane-install-ops/specs/apphost-store-plane/spec.md#requirement-a-config-write-must-be-allowlisted-by-key-and-scoped-to-the-declaring-app
+	 */
+	public function isConfigurable(string $key): bool {
+		if ($key === '' || $this->configurable === []) {
+			return false;
+		}
+
+		return in_array(needle: $key, haystack: $this->configurable, strict: true);
+	}//end isConfigurable()
 
 }//end class

--- a/openspec/changes/store-plane-install-ops/proposal.md
+++ b/openspec/changes/store-plane-install-ops/proposal.md
@@ -1,0 +1,59 @@
+# Store plane: install operations other than writing an object
+
+## Why
+
+`GenericStoreInstaller` can do exactly one thing: write a component's object
+into an allowed schema. That is the whole of what dossiq and pipelinq install,
+and it is why they migrate cleanly.
+
+It is not the whole of what the other three do. integriq's catalogue has two
+kinds of item and only one of them is an object: a **flag-gated** item installs
+by flipping an `IAppConfig` boolean, and a **source-backed** one writes a
+`source` object. An engine that can only write objects can express half of
+integriq's store.
+
+## What changes
+
+A component MAY declare an `op`. Absent, it is `writeObject`, which is exactly
+today's behaviour, so every existing item installs unchanged.
+
+```jsonc
+{
+  "op": "setAppConfig",          // "writeObject" (default) | "setAppConfig"
+  "key": "enableSoapAdapter",
+  "value": true
+}
+```
+
+`setAppConfig` writes a boolean into the **declaring app's own** config
+namespace. It cannot address another app's config, and the key must be
+allowlisted by the store block's new `configurable` list — the same shape, and
+the same reasoning, as `installable` for schemas.
+
+## 🔴 `configurable` is a second security boundary, not a convenience
+
+`installable` stops a remote registry naming any schema the app owns.
+`setAppConfig` needs the identical defence for config keys, and it needs it
+more: an app's config namespace holds registry URLs, tokens and feature flags,
+so an unallowlisted write is a remote actor toggling whatever it names.
+
+An empty `configurable` list therefore refuses every key, exactly as an empty
+`installable` refuses every schema.
+
+## What does NOT change
+
+- Objects still install through the existing path, still identity-stripped,
+  still allowlisted.
+- A refusal still does not abort the install, and is still reported per
+  component.
+- Nothing here touches WHO may install.
+
+## Out of scope, and honestly so
+
+buildiq's install clones an Application, creates a per-app register, namespaces
+companion schemas and rewrites a manifest. hermiq's imports a package through a
+content scanner and lands it quarantined, then instantiates an Agent with
+model-policy coercion. Neither is expressible as a declarative op without
+inventing a language to describe them, and a vocabulary that covers them badly
+would be worse than one that admits it does not. They are named here so the gap
+is visible rather than discovered later.

--- a/openspec/changes/store-plane-install-ops/specs/apphost-store-plane/spec.md
+++ b/openspec/changes/store-plane-install-ops/specs/apphost-store-plane/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: A component MUST declare its install operation, defaulting to writing an object
+
+A component MAY carry an `op` key. Its value MUST be one of `writeObject` or
+`setAppConfig`. Absent, it MUST be `writeObject`, so every item that installs
+today installs unchanged.
+
+An unrecognised `op` MUST be refused for that component and reported, and MUST
+NOT abort the remaining components. A component whose operation this server
+does not understand is the registry's mistake, not a reason to deny an
+administrator the components it does understand.
+
+#### Scenario: A component with no op writes an object
+
+- **WHEN** a component declares no `op`
+- **THEN** it is installed through the object write path
+- **AND** the `installable` allowlist applies to it
+
+#### Scenario: An unknown op is refused, and the rest still install
+
+- **WHEN** an item carries one component with `"op": "summonDaemon"` and one
+  ordinary object component
+- **THEN** the unknown component is reported as refused
+- **AND** the object component is still installed
+
+### Requirement: A config write MUST be allowlisted by key and scoped to the declaring app
+
+`setAppConfig` MUST write only into the declaring app's own config namespace,
+and only for a key named in the store block's `configurable` list.
+
+An empty or absent `configurable` list MUST refuse every key.
+
+🔴 This is a second security boundary, not a convenience. `installable` stops a
+remote registry naming any schema the app owns; an app's config namespace holds
+registry URLs, tokens and feature flags, so an unallowlisted config write is a
+remote actor toggling whatever it names. The default must therefore be "refuse
+everything", exactly as it is for schemas.
+
+#### Scenario: An allowlisted key is written
+
+- **WHEN** a store declares `"configurable": ["enableSoapAdapter"]`
+- **AND** a component sets that key
+- **THEN** the value is written to the declaring app's config
+
+#### Scenario: A key outside the allowlist is refused
+
+- **WHEN** a component sets a key the `configurable` list omits
+- **THEN** the component is refused and reported
+
+#### Scenario: An absent configurable list refuses everything
+
+- **WHEN** a store declares no `configurable` list
+- **AND** a component declares `setAppConfig`
+- **THEN** the component is refused
+
+#### Scenario: A config write cannot address another app
+
+- **WHEN** a component's key names another app's namespace
+- **THEN** the key is treated as a plain key of the declaring app, never as a
+  cross-app write
+
+### Requirement: A config value MUST be a scalar
+
+`setAppConfig` MUST accept only a boolean, string or number. An array or object
+MUST be refused.
+
+Config is a flat key-value store, and silently serialising a structure into it
+produces a value the app will later read back as a string it never wrote.
+
+#### Scenario: A structured value is refused
+
+- **WHEN** a component sets a key to an object
+- **THEN** the component is refused and reported

--- a/tests/Unit/AppHost/GenericStoreInstallerTest.php
+++ b/tests/Unit/AppHost/GenericStoreInstallerTest.php
@@ -38,6 +38,7 @@ use OCA\OpenRegister\AppHost\Store\GenericStoreInstaller;
 use OCA\OpenRegister\AppHost\Store\StoreManifest;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Service\ObjectService;
+use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -50,6 +51,9 @@ use RuntimeException;
 class GenericStoreInstallerTest extends TestCase {
 	/** @var ObjectService&MockObject */
 	private $objectService;
+
+	/** @var IAppConfig&MockObject */
+	private $appConfig;
 
 	/** @var LoggerInterface&MockObject */
 	private $logger;
@@ -71,8 +75,10 @@ class GenericStoreInstallerTest extends TestCase {
 			->onlyMethods(['saveObject'])
 			->getMock();
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->installer = new GenericStoreInstaller(
 			objectService: $this->objectService,
+			appConfig: $this->appConfig,
 			logger: $this->logger
 		);
 	}//end setUp()
@@ -523,5 +529,131 @@ class GenericStoreInstallerTest extends TestCase {
 
 		$this->assertFalse($manifest->isInstallable('caseType'));
 		$this->assertFalse($manifest->isInstallable('anything'));
+	}
+
+	/**
+	 * An allowlisted config key is written into the DECLARING app's namespace.
+	 *
+	 * @return void
+	 */
+	public function testAnAllowlistedConfigKeyIsWritten(): void {
+		$store = StoreManifest::fromManifest('integriq', [
+			'store' => ['schema' => 'catalog_item', 'configurable' => ['enableSoapAdapter']],
+		]);
+		$this->appConfig->expects($this->once())
+			->method('setValueString')
+			->with('integriq', 'enableSoapAdapter', '1');
+
+		$report = $this->installer->install($store, [
+			'components' => [
+				['op' => 'setAppConfig', 'key' => 'enableSoapAdapter', 'value' => true],
+			],
+		]);
+
+		$this->assertTrue($report['success']);
+		$this->assertSame('installed', $report['components'][0]['status']);
+	}
+
+	/**
+	 * 🔴 A key outside the allowlist is refused.
+	 *
+	 * An app's config namespace holds registry URLs, tokens and feature flags,
+	 * so an unallowlisted write is a remote actor toggling whatever it names.
+	 *
+	 * @return void
+	 */
+	public function testAConfigKeyOutsideTheAllowlistIsRefused(): void {
+		$store = StoreManifest::fromManifest('integriq', [
+			'store' => ['schema' => 'catalog_item', 'configurable' => ['enableSoapAdapter']],
+		]);
+		$this->appConfig->expects($this->never())->method('setValueString');
+
+		$report = $this->installer->install($store, [
+			'components' => [
+				['op' => 'setAppConfig', 'key' => 'store_registry_token', 'value' => 'stolen'],
+			],
+		]);
+
+		$this->assertFalse($report['success']);
+		$this->assertSame('refused', $report['components'][0]['status']);
+	}
+
+	/**
+	 * 🔴 An absent `configurable` list refuses every key.
+	 *
+	 * The empty-means-refuse default, matching `installable`. An app that
+	 * declares a store and forgets the list gets refused config writes rather
+	 * than an open door onto its own settings.
+	 *
+	 * @return void
+	 */
+	public function testAnAbsentConfigurableListRefusesEveryKey(): void {
+		$store = StoreManifest::fromManifest('integriq', ['store' => ['schema' => 'catalog_item']]);
+		$this->appConfig->expects($this->never())->method('setValueString');
+
+		$report = $this->installer->install($store, [
+			'components' => [['op' => 'setAppConfig', 'key' => 'anything', 'value' => true]],
+		]);
+
+		$this->assertSame('refused', $report['components'][0]['status']);
+	}
+
+	/**
+	 * A structured value is refused rather than silently serialised.
+	 *
+	 * @return void
+	 */
+	public function testAStructuredConfigValueIsRefused(): void {
+		$store = StoreManifest::fromManifest('integriq', [
+			'store' => ['schema' => 'catalog_item', 'configurable' => ['someKey']],
+		]);
+		$this->appConfig->expects($this->never())->method('setValueString');
+
+		$report = $this->installer->install($store, [
+			'components' => [['op' => 'setAppConfig', 'key' => 'someKey', 'value' => ['a' => 1]]],
+		]);
+
+		$this->assertSame('refused', $report['components'][0]['status']);
+	}
+
+	/**
+	 * An unknown op is refused for that component, and the rest still install.
+	 *
+	 * @return void
+	 */
+	public function testAnUnknownOpDoesNotAbortTheOtherComponents(): void {
+		$store = StoreManifest::fromManifest('demo', [
+			'store' => ['schema' => 'template', 'installable' => ['caseType']],
+		]);
+		$this->objectService->expects($this->once())->method('saveObject');
+
+		$report = $this->installer->install($store, [
+			'components' => [
+				['op' => 'summonDaemon', 'schema' => 'caseType'],
+				['schema' => 'caseType', 'object' => ['title' => 'A case type']],
+			],
+		]);
+
+		$this->assertFalse($report['success']);
+		$this->assertSame('refused', $report['components'][0]['status']);
+		$this->assertSame('installed', $report['components'][1]['status']);
+	}
+
+	/**
+	 * A component with no op still writes an object, exactly as before.
+	 *
+	 * @return void
+	 */
+	public function testAComponentWithNoOpStillWritesAnObject(): void {
+		$store = StoreManifest::fromManifest('demo', [
+			'store' => ['schema' => 'template', 'installable' => ['caseType']],
+		]);
+		$this->objectService->expects($this->once())->method('saveObject');
+
+		$report = $this->installer->install($store, [
+			'components' => [['schema' => 'caseType', 'object' => ['title' => 'A case type']]],
+		]);
+
+		$this->assertTrue($report['success']);
 	}
 }


### PR DESCRIPTION
Stacked on #3398 → #3397 → #3395. Review those first.

## Why

`GenericStoreInstaller` could do exactly one thing: write a component's object into an allowed schema. That is the whole of what dossiq and pipelinq install, which is why those two migrate cleanly.

It is **not** the whole of what integriq installs. Its catalogue has two kinds of item and only one is an object: a **flag-gated** item installs by flipping an `IAppConfig` boolean, a **source-backed** one writes a `source` object. An engine that can only write objects expresses half of that store.

## What changes

```jsonc
{ "op": "setAppConfig", "key": "enableSoapAdapter", "value": true }
```

Absent, `op` is `writeObject` — exactly today's behaviour, so every existing item installs unchanged.

An unrecognised `op` is refused for **that component only** and does not abort the others. An operation this server does not understand is the registry's mistake, not a reason to deny an administrator the components it *does* understand. There is a test with one bogus component and one good one that asserts the good one still installs.

## 🔴 `configurable` is a second security boundary

`installable` stops a remote registry naming any schema the app owns. `configurable` stops it naming any config key — and it matters *more*, because an app's config namespace holds registry URLs, tokens and feature flags. An unallowlisted config write is a remote actor toggling whatever it names.

So it inherits the same default: **an empty or absent list refuses every key**, including the case where an app declares a store and forgets the list entirely. Asserted directly, alongside a test that a component naming `store_registry_token` is refused.

Two further constraints:

- **The app id comes from the manifest, never from the component.** A registry naming another app's namespace cannot write into an app that never opted into a store.
- **A value must be scalar.** Config is a flat key-value store; silently serialising a structure into it produces a value the app later reads back as a string it never wrote.

## What is deliberately not here

buildiq's install clones an Application, creates a per-app register, namespaces companion schemas and rewrites a manifest. hermiq's imports a package through a content scanner, lands it `quarantined`, and instantiates an Agent with model-policy coercion.

Neither is expressible as a declarative op without inventing a language to describe them, and **a vocabulary that covered them badly would be worse than one that admits it does not**. They are named in the proposal so the gap is visible now rather than discovered during their migration.

After this increment: dossiq, pipelinq and integriq can migrate. buildiq and hermiq cannot, and that is a decision to take deliberately rather than by omission.

## Checks

293 tests green. `phpcs`, `phpmd` (against CI's baseline), `psalm` and `phpstan` clean on `lib/AppHost`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
