### PR TITLE
feat(chrome): give openregister the Store surface it hosts for everyone else

### DIFF
--- a/l10n/be.js
+++ b/l10n/be.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Завяршыць",
         "Complete: {outcome}": "Завяршыць: {outcome}",
         "Could not load the task": "Не ўдалося загрузіць задачу",
-        "The task refused that action": "Задача адхіліла гэта дзеянне"
+        "The task refused that action": "Задача адхіліла гэта дзеянне",
+        "Store": "Крама",
+        "Install registers, schemas and flows that other organisations have published.": "Усталюйце рэестры, схемы і патокі, апублікаваныя іншымі арганізацыямі."
     },
     "nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);"
 )

--- a/l10n/be.json
+++ b/l10n/be.json
@@ -2904,7 +2904,9 @@
         "Complete": "Завяршыць",
         "Complete: {outcome}": "Завяршыць: {outcome}",
         "Could not load the task": "Не ўдалося загрузіць задачу",
-        "The task refused that action": "Задача адхіліла гэта дзеянне"
+        "The task refused that action": "Задача адхіліла гэта дзеянне",
+        "Store": "Крама",
+        "Install registers, schemas and flows that other organisations have published.": "Усталюйце рэестры, схемы і патокі, апублікаваныя іншымі арганізацыямі."
     },
     "pluralForm": "nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);",
     "plurals": {

--- a/l10n/bg.js
+++ b/l10n/bg.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Завършване",
         "Complete: {outcome}": "Завършване: {outcome}",
         "Could not load the task": "Задачата не можа да се зареди",
-        "The task refused that action": "Задачата отказа това действие"
+        "The task refused that action": "Задачата отказа това действие",
+        "Store": "Магазин",
+        "Install registers, schemas and flows that other organisations have published.": "Инсталирайте регистри, схеми и потоци, публикувани от други организации."
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/bg.json
+++ b/l10n/bg.json
@@ -2872,7 +2872,9 @@
         "Complete": "Завършване",
         "Complete: {outcome}": "Завършване: {outcome}",
         "Could not load the task": "Задачата не можа да се зареди",
-        "The task refused that action": "Задачата отказа това действие"
+        "The task refused that action": "Задачата отказа това действие",
+        "Store": "Магазин",
+        "Install registers, schemas and flows that other organisations have published.": "Инсталирайте регистри, схеми и потоци, публикувани от други организации."
     },
     "pluralForm": "nplurals=2; plural=(n != 1);",
     "plurals": {

--- a/l10n/bs.js
+++ b/l10n/bs.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Završi",
         "Complete: {outcome}": "Završi: {outcome}",
         "Could not load the task": "Zadatak se ne može učitati",
-        "The task refused that action": "Zadatak je odbio tu radnju"
+        "The task refused that action": "Zadatak je odbio tu radnju",
+        "Store": "Trgovina",
+        "Install registers, schemas and flows that other organisations have published.": "Instalirajte registre, šeme i tokove koje su objavile druge organizacije."
     },
     "nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;"
 )

--- a/l10n/bs.json
+++ b/l10n/bs.json
@@ -2888,7 +2888,9 @@
         "Complete": "Završi",
         "Complete: {outcome}": "Završi: {outcome}",
         "Could not load the task": "Zadatak se ne može učitati",
-        "The task refused that action": "Zadatak je odbio tu radnju"
+        "The task refused that action": "Zadatak je odbio tu radnju",
+        "Store": "Trgovina",
+        "Install registers, schemas and flows that other organisations have published.": "Instalirajte registre, šeme i tokove koje su objavile druge organizacije."
     },
     "pluralForm": "nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;",
     "plurals": {

--- a/l10n/ca.js
+++ b/l10n/ca.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Completa",
         "Complete: {outcome}": "Completa: {outcome}",
         "Could not load the task": "No s'ha pogut carregar la tasca",
-        "The task refused that action": "La tasca ha rebutjat aquesta acció"
+        "The task refused that action": "La tasca ha rebutjat aquesta acció",
+        "Store": "Botiga",
+        "Install registers, schemas and flows that other organisations have published.": "Instal·leu registres, esquemes i fluxos publicats per altres organitzacions."
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/ca.json
+++ b/l10n/ca.json
@@ -2872,7 +2872,9 @@
         "Complete": "Completa",
         "Complete: {outcome}": "Completa: {outcome}",
         "Could not load the task": "No s'ha pogut carregar la tasca",
-        "The task refused that action": "La tasca ha rebutjat aquesta acció"
+        "The task refused that action": "La tasca ha rebutjat aquesta acció",
+        "Store": "Botiga",
+        "Install registers, schemas and flows that other organisations have published.": "Instal·leu registres, esquemes i fluxos publicats per altres organitzacions."
     },
     "pluralForm": "nplurals=2; plural=(n != 1);",
     "plurals": {

--- a/l10n/cs.js
+++ b/l10n/cs.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Dokončit",
         "Complete: {outcome}": "Dokončit: {outcome}",
         "Could not load the task": "Úkol se nepodařilo načíst",
-        "The task refused that action": "Úkol tuto akci odmítl"
+        "The task refused that action": "Úkol tuto akci odmítl",
+        "Store": "Obchod",
+        "Install registers, schemas and flows that other organisations have published.": "Nainstalujte registry, schémata a toky zveřejněné jinými organizacemi."
     },
     "nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && n <= 4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;"
 )

--- a/l10n/cs.json
+++ b/l10n/cs.json
@@ -2904,7 +2904,9 @@
         "Complete": "Dokončit",
         "Complete: {outcome}": "Dokončit: {outcome}",
         "Could not load the task": "Úkol se nepodařilo načíst",
-        "The task refused that action": "Úkol tuto akci odmítl"
+        "The task refused that action": "Úkol tuto akci odmítl",
+        "Store": "Obchod",
+        "Install registers, schemas and flows that other organisations have published.": "Nainstalujte registry, schémata a toky zveřejněné jinými organizacemi."
     },
     "pluralForm": "nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && n <= 4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;",
     "plurals": {

--- a/l10n/da.js
+++ b/l10n/da.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Fuldfør",
         "Complete: {outcome}": "Fuldfør: {outcome}",
         "Could not load the task": "Kunne ikke indlæse opgaven",
-        "The task refused that action": "Opgaven afviste den handling"
+        "The task refused that action": "Opgaven afviste den handling",
+        "Store": "Butik",
+        "Install registers, schemas and flows that other organisations have published.": "Installer registre, skemaer og flows, som andre organisationer har udgivet."
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/da.json
+++ b/l10n/da.json
@@ -2872,7 +2872,9 @@
         "Complete": "Fuldfør",
         "Complete: {outcome}": "Fuldfør: {outcome}",
         "Could not load the task": "Kunne ikke indlæse opgaven",
-        "The task refused that action": "Opgaven afviste den handling"
+        "The task refused that action": "Opgaven afviste den handling",
+        "Store": "Butik",
+        "Install registers, schemas and flows that other organisations have published.": "Installer registre, skemaer og flows, som andre organisationer har udgivet."
     },
     "pluralForm": "nplurals=2; plural=(n != 1);",
     "plurals": {

--- a/l10n/de.js
+++ b/l10n/de.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Abschließen",
         "Complete: {outcome}": "Abschließen: {outcome}",
         "Could not load the task": "Aufgabe konnte nicht geladen werden",
-        "The task refused that action": "Die Aufgabe hat diese Aktion abgelehnt"
+        "The task refused that action": "Die Aufgabe hat diese Aktion abgelehnt",
+        "Store": "Store",
+        "Install registers, schemas and flows that other organisations have published.": "Installieren Sie Register, Schemata und Flows, die andere Organisationen veröffentlicht haben."
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -2872,7 +2872,9 @@
         "Complete": "Abschließen",
         "Complete: {outcome}": "Abschließen: {outcome}",
         "Could not load the task": "Aufgabe konnte nicht geladen werden",
-        "The task refused that action": "Die Aufgabe hat diese Aktion abgelehnt"
+        "The task refused that action": "Die Aufgabe hat diese Aktion abgelehnt",
+        "Store": "Store",
+        "Install registers, schemas and flows that other organisations have published.": "Installieren Sie Register, Schemata und Flows, die andere Organisationen veröffentlicht haben."
     },
     "pluralForm": "nplurals=2; plural=(n != 1);",
     "plurals": {

--- a/l10n/el.js
+++ b/l10n/el.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Ολοκλήρωση",
         "Complete: {outcome}": "Ολοκλήρωση: {outcome}",
         "Could not load the task": "Δεν ήταν δυνατή η φόρτωση της εργασίας",
-        "The task refused that action": "Η εργασία απέρριψε αυτήν την ενέργεια"
+        "The task refused that action": "Η εργασία απέρριψε αυτήν την ενέργεια",
+        "Store": "Κατάστημα",
+        "Install registers, schemas and flows that other organisations have published.": "Εγκαταστήστε μητρώα, σχήματα και ροές που έχουν δημοσιεύσει άλλοι οργανισμοί."
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/el.json
+++ b/l10n/el.json
@@ -2872,7 +2872,9 @@
         "Complete": "Ολοκλήρωση",
         "Complete: {outcome}": "Ολοκλήρωση: {outcome}",
         "Could not load the task": "Δεν ήταν δυνατή η φόρτωση της εργασίας",
-        "The task refused that action": "Η εργασία απέρριψε αυτήν την ενέργεια"
+        "The task refused that action": "Η εργασία απέρριψε αυτήν την ενέργεια",
+        "Store": "Κατάστημα",
+        "Install registers, schemas and flows that other organisations have published.": "Εγκαταστήστε μητρώα, σχήματα και ροές που έχουν δημοσιεύσει άλλοι οργανισμοί."
     },
     "pluralForm": "nplurals=2; plural=(n != 1);",
     "plurals": {

--- a/l10n/es.js
+++ b/l10n/es.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Completar",
         "Complete: {outcome}": "Completar: {outcome}",
         "Could not load the task": "No se pudo cargar la tarea",
-        "The task refused that action": "La tarea rechazó esa acción"
+        "The task refused that action": "La tarea rechazó esa acción",
+        "Store": "Tienda",
+        "Install registers, schemas and flows that other organisations have published.": "Instale registros, esquemas y flujos publicados por otras organizaciones."
     },
     "nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 )

--- a/l10n/es.json
+++ b/l10n/es.json
@@ -2888,7 +2888,9 @@
         "Complete": "Completar",
         "Complete: {outcome}": "Completar: {outcome}",
         "Could not load the task": "No se pudo cargar la tarea",
-        "The task refused that action": "La tarea rechazó esa acción"
+        "The task refused that action": "La tarea rechazó esa acción",
+        "Store": "Tienda",
+        "Install registers, schemas and flows that other organisations have published.": "Instale registros, esquemas y flujos publicados por otras organizaciones."
     },
     "pluralForm": "nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;",
     "plurals": {

--- a/l10n/et.js
+++ b/l10n/et.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Lõpeta",
         "Complete: {outcome}": "Lõpeta: {outcome}",
         "Could not load the task": "Ülesannet ei õnnestunud laadida",
-        "The task refused that action": "Ülesanne keeldus sellest toimingust"
+        "The task refused that action": "Ülesanne keeldus sellest toimingust",
+        "Store": "Pood",
+        "Install registers, schemas and flows that other organisations have published.": "Paigalda registrid, skeemid ja voog, mille teised organisatsioonid on avaldanud."
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/et.json
+++ b/l10n/et.json
@@ -2872,7 +2872,9 @@
         "Complete": "Lõpeta",
         "Complete: {outcome}": "Lõpeta: {outcome}",
         "Could not load the task": "Ülesannet ei õnnestunud laadida",
-        "The task refused that action": "Ülesanne keeldus sellest toimingust"
+        "The task refused that action": "Ülesanne keeldus sellest toimingust",
+        "Store": "Pood",
+        "Install registers, schemas and flows that other organisations have published.": "Paigalda registrid, skeemid ja voog, mille teised organisatsioonid on avaldanud."
     },
     "pluralForm": "nplurals=2; plural=(n != 1);",
     "plurals": {

--- a/l10n/fi.js
+++ b/l10n/fi.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Valmis",
         "Complete: {outcome}": "Valmis: {outcome}",
         "Could not load the task": "Tehtävän lataus epäonnistui",
-        "The task refused that action": "Tehtävä hylkäsi toiminnon"
+        "The task refused that action": "Tehtävä hylkäsi toiminnon",
+        "Store": "Kauppa",
+        "Install registers, schemas and flows that other organisations have published.": "Asenna muiden organisaatioiden julkaisemia rekistereitä, skeemoja ja vuokaavioita."
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/fi.json
+++ b/l10n/fi.json
@@ -2872,7 +2872,9 @@
         "Complete": "Valmis",
         "Complete: {outcome}": "Valmis: {outcome}",
         "Could not load the task": "Tehtävän lataus epäonnistui",
-        "The task refused that action": "Tehtävä hylkäsi toiminnon"
+        "The task refused that action": "Tehtävä hylkäsi toiminnon",
+        "Store": "Kauppa",
+        "Install registers, schemas and flows that other organisations have published.": "Asenna muiden organisaatioiden julkaisemia rekistereitä, skeemoja ja vuokaavioita."
     },
     "pluralForm": "nplurals=2; plural=(n != 1);",
     "plurals": {

--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Terminer",
         "Complete: {outcome}": "Terminer : {outcome}",
         "Could not load the task": "Impossible de charger la tâche",
-        "The task refused that action": "La tâche a refusé cette action"
+        "The task refused that action": "La tâche a refusé cette action",
+        "Store": "Boutique",
+        "Install registers, schemas and flows that other organisations have published.": "Installez des registres, schémas et flux publiés par d'autres organisations."
     },
     "nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 )

--- a/l10n/fr.json
+++ b/l10n/fr.json
@@ -2888,7 +2888,9 @@
         "Complete": "Terminer",
         "Complete: {outcome}": "Terminer : {outcome}",
         "Could not load the task": "Impossible de charger la tâche",
-        "The task refused that action": "La tâche a refusé cette action"
+        "The task refused that action": "La tâche a refusé cette action",
+        "Store": "Boutique",
+        "Install registers, schemas and flows that other organisations have published.": "Installez des registres, schémas et flux publiés par d'autres organisations."
     },
     "pluralForm": "nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;",
     "plurals": {

--- a/l10n/ga.js
+++ b/l10n/ga.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Críochnaigh",
         "Complete: {outcome}": "Críochnaigh: {outcome}",
         "Could not load the task": "Níorbh fhéidir an tasc a lódáil",
-        "The task refused that action": "Dhiúltaigh an tasc don ghníomh sin"
+        "The task refused that action": "Dhiúltaigh an tasc don ghníomh sin",
+        "Store": "Siopa",
+        "Install registers, schemas and flows that other organisations have published.": "Suiteáil cláir, scéimeanna agus sruthanna a d'fhoilsigh eagraíochtaí eile."
     },
     "nplurals=5; plural=(n==1 ? 0 : n==2 ? 1 : n<7 ? 2 : n<11 ? 3 : 4);"
 )

--- a/l10n/ga.json
+++ b/l10n/ga.json
@@ -2920,7 +2920,9 @@
         "Complete": "Críochnaigh",
         "Complete: {outcome}": "Críochnaigh: {outcome}",
         "Could not load the task": "Níorbh fhéidir an tasc a lódáil",
-        "The task refused that action": "Dhiúltaigh an tasc don ghníomh sin"
+        "The task refused that action": "Dhiúltaigh an tasc don ghníomh sin",
+        "Store": "Siopa",
+        "Install registers, schemas and flows that other organisations have published.": "Suiteáil cláir, scéimeanna agus sruthanna a d'fhoilsigh eagraíochtaí eile."
     },
     "pluralForm": "nplurals=5; plural=(n==1 ? 0 : n==2 ? 1 : n<7 ? 2 : n<11 ? 3 : 4);",
     "plurals": {

--- a/l10n/hr.js
+++ b/l10n/hr.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Dovrši",
         "Complete: {outcome}": "Dovrši: {outcome}",
         "Could not load the task": "Zadatak se ne može učitati",
-        "The task refused that action": "Zadatak je odbio tu radnju"
+        "The task refused that action": "Zadatak je odbio tu radnju",
+        "Store": "Trgovina",
+        "Install registers, schemas and flows that other organisations have published.": "Instalirajte registre, sheme i tokove koje su objavile druge organizacije."
     },
     "nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;"
 )

--- a/l10n/hr.json
+++ b/l10n/hr.json
@@ -2888,7 +2888,9 @@
         "Complete": "Dovrši",
         "Complete: {outcome}": "Dovrši: {outcome}",
         "Could not load the task": "Zadatak se ne može učitati",
-        "The task refused that action": "Zadatak je odbio tu radnju"
+        "The task refused that action": "Zadatak je odbio tu radnju",
+        "Store": "Trgovina",
+        "Install registers, schemas and flows that other organisations have published.": "Instalirajte registre, sheme i tokove koje su objavile druge organizacije."
     },
     "pluralForm": "nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;",
     "plurals": {

--- a/l10n/hu.js
+++ b/l10n/hu.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Befejezés",
         "Complete: {outcome}": "Befejezés: {outcome}",
         "Could not load the task": "A feladat nem tölthető be",
-        "The task refused that action": "A feladat elutasította a műveletet"
+        "The task refused that action": "A feladat elutasította a műveletet",
+        "Store": "Áruház",
+        "Install registers, schemas and flows that other organisations have published.": "Telepítsen más szervezetek által közzétett nyilvántartásokat, sémákat és folyamatokat."
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/hu.json
+++ b/l10n/hu.json
@@ -2872,7 +2872,9 @@
         "Complete": "Befejezés",
         "Complete: {outcome}": "Befejezés: {outcome}",
         "Could not load the task": "A feladat nem tölthető be",
-        "The task refused that action": "A feladat elutasította a műveletet"
+        "The task refused that action": "A feladat elutasította a műveletet",
+        "Store": "Áruház",
+        "Install registers, schemas and flows that other organisations have published.": "Telepítsen más szervezetek által közzétett nyilvántartásokat, sémákat és folyamatokat."
     },
     "pluralForm": "nplurals=2; plural=(n != 1);",
     "plurals": {

--- a/l10n/is.js
+++ b/l10n/is.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Ljúka",
         "Complete: {outcome}": "Ljúka: {outcome}",
         "Could not load the task": "Gat ekki hlaðið verkefninu",
-        "The task refused that action": "Verkefnið hafnaði þeirri aðgerð"
+        "The task refused that action": "Verkefnið hafnaði þeirri aðgerð",
+        "Store": "Verslun",
+        "Install registers, schemas and flows that other organisations have published.": "Settu upp skrár, skemu og flæði sem aðrar stofnanir hafa birt."
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/is.json
+++ b/l10n/is.json
@@ -2872,7 +2872,9 @@
         "Complete": "Ljúka",
         "Complete: {outcome}": "Ljúka: {outcome}",
         "Could not load the task": "Gat ekki hlaðið verkefninu",
-        "The task refused that action": "Verkefnið hafnaði þeirri aðgerð"
+        "The task refused that action": "Verkefnið hafnaði þeirri aðgerð",
+        "Store": "Verslun",
+        "Install registers, schemas and flows that other organisations have published.": "Settu upp skrár, skemu og flæði sem aðrar stofnanir hafa birt."
     },
     "pluralForm": "nplurals=2; plural=(n != 1);",
     "plurals": {

--- a/l10n/it.js
+++ b/l10n/it.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Completa",
         "Complete: {outcome}": "Completa: {outcome}",
         "Could not load the task": "Impossibile caricare l'attività",
-        "The task refused that action": "L'attività ha rifiutato l'azione"
+        "The task refused that action": "L'attività ha rifiutato l'azione",
+        "Store": "Store",
+        "Install registers, schemas and flows that other organisations have published.": "Installa registri, schemi e flussi pubblicati da altre organizzazioni."
     },
     "nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 )

--- a/l10n/it.json
+++ b/l10n/it.json
@@ -2888,7 +2888,9 @@
         "Complete": "Completa",
         "Complete: {outcome}": "Completa: {outcome}",
         "Could not load the task": "Impossibile caricare l'attività",
-        "The task refused that action": "L'attività ha rifiutato l'azione"
+        "The task refused that action": "L'attività ha rifiutato l'azione",
+        "Store": "Store",
+        "Install registers, schemas and flows that other organisations have published.": "Installa registri, schemi e flussi pubblicati da altre organizzazioni."
     },
     "pluralForm": "nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;",
     "plurals": {

--- a/l10n/lb.js
+++ b/l10n/lb.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Ofschléissen",
         "Complete: {outcome}": "Ofschléissen: {outcome}",
         "Could not load the task": "D'Aufgab konnt net geluede ginn",
-        "The task refused that action": "D'Aufgab huet dës Aktioun refuséiert"
+        "The task refused that action": "D'Aufgab huet dës Aktioun refuséiert",
+        "Store": "Buttek",
+        "Install registers, schemas and flows that other organisations have published.": "Installéiert Registeren, Schemaen a Flows déi aner Organisatiounen publizéiert hunn."
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/lb.json
+++ b/l10n/lb.json
@@ -2872,7 +2872,9 @@
         "Complete": "Ofschléissen",
         "Complete: {outcome}": "Ofschléissen: {outcome}",
         "Could not load the task": "D'Aufgab konnt net geluede ginn",
-        "The task refused that action": "D'Aufgab huet dës Aktioun refuséiert"
+        "The task refused that action": "D'Aufgab huet dës Aktioun refuséiert",
+        "Store": "Buttek",
+        "Install registers, schemas and flows that other organisations have published.": "Installéiert Registeren, Schemaen a Flows déi aner Organisatiounen publizéiert hunn."
     },
     "pluralForm": "nplurals=2; plural=(n != 1);",
     "plurals": {

--- a/l10n/lt.js
+++ b/l10n/lt.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Užbaigti",
         "Complete: {outcome}": "Užbaigti: {outcome}",
         "Could not load the task": "Nepavyko įkelti užduoties",
-        "The task refused that action": "Užduotis atmetė šį veiksmą"
+        "The task refused that action": "Užduotis atmetė šį veiksmą",
+        "Store": "Parduotuvė",
+        "Install registers, schemas and flows that other organisations have published.": "Įdiekite registrus, schemas ir srautus, kuriuos paskelbė kitos organizacijos."
     },
     "nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);"
 )

--- a/l10n/lt.json
+++ b/l10n/lt.json
@@ -2888,7 +2888,9 @@
         "Complete": "Užbaigti",
         "Complete: {outcome}": "Užbaigti: {outcome}",
         "Could not load the task": "Nepavyko įkelti užduoties",
-        "The task refused that action": "Užduotis atmetė šį veiksmą"
+        "The task refused that action": "Užduotis atmetė šį veiksmą",
+        "Store": "Parduotuvė",
+        "Install registers, schemas and flows that other organisations have published.": "Įdiekite registrus, schemas ir srautus, kuriuos paskelbė kitos organizacijos."
     },
     "pluralForm": "nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);",
     "plurals": {

--- a/l10n/lv.js
+++ b/l10n/lv.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Pabeigt",
         "Complete: {outcome}": "Pabeigt: {outcome}",
         "Could not load the task": "Neizdevās ielādēt uzdevumu",
-        "The task refused that action": "Uzdevums noraidīja šo darbību"
+        "The task refused that action": "Uzdevums noraidīja šo darbību",
+        "Store": "Veikals",
+        "Install registers, schemas and flows that other organisations have published.": "Instalējiet reģistrus, shēmas un plūsmas, ko publicējušas citas organizācijas."
     },
     "nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2);"
 )

--- a/l10n/lv.json
+++ b/l10n/lv.json
@@ -2888,7 +2888,9 @@
         "Complete": "Pabeigt",
         "Complete: {outcome}": "Pabeigt: {outcome}",
         "Could not load the task": "Neizdevās ielādēt uzdevumu",
-        "The task refused that action": "Uzdevums noraidīja šo darbību"
+        "The task refused that action": "Uzdevums noraidīja šo darbību",
+        "Store": "Veikals",
+        "Install registers, schemas and flows that other organisations have published.": "Instalējiet reģistrus, shēmas un plūsmas, ko publicējušas citas organizācijas."
     },
     "pluralForm": "nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2);",
     "plurals": {

--- a/l10n/mk.js
+++ b/l10n/mk.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Заврши",
         "Complete: {outcome}": "Заврши: {outcome}",
         "Could not load the task": "Задачата не може да се вчита",
-        "The task refused that action": "Задачата го одби тоа дејство"
+        "The task refused that action": "Задачата го одби тоа дејство",
+        "Store": "Продавница",
+        "Install registers, schemas and flows that other organisations have published.": "Инсталирајте регистри, шеми и текови објавени од други организации."
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/mk.json
+++ b/l10n/mk.json
@@ -2872,7 +2872,9 @@
         "Complete": "Заврши",
         "Complete: {outcome}": "Заврши: {outcome}",
         "Could not load the task": "Задачата не може да се вчита",
-        "The task refused that action": "Задачата го одби тоа дејство"
+        "The task refused that action": "Задачата го одби тоа дејство",
+        "Store": "Продавница",
+        "Install registers, schemas and flows that other organisations have published.": "Инсталирајте регистри, шеми и текови објавени од други организации."
     },
     "pluralForm": "nplurals=2; plural=(n != 1);",
     "plurals": {

--- a/l10n/mt.js
+++ b/l10n/mt.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Lesti",
         "Complete: {outcome}": "Lesti: {outcome}",
         "Could not load the task": "Ma setax jitgħabba l-kompitu",
-        "The task refused that action": "Il-kompitu rrifjuta dik l-azzjoni"
+        "The task refused that action": "Il-kompitu rrifjuta dik l-azzjoni",
+        "Store": "Ħanut",
+        "Install registers, schemas and flows that other organisations have published.": "Installa reġistri, skemi u flussi ppubblikati minn organizzazzjonijiet oħra."
     },
     "nplurals=4; plural=(n==1 ? 0 : n==0 || ( n%100>1 && n%100<11) ? 1 : (n%100>10 && n%100<20 ) ? 2 : 3);"
 )

--- a/l10n/mt.json
+++ b/l10n/mt.json
@@ -2904,7 +2904,9 @@
         "Complete": "Lesti",
         "Complete: {outcome}": "Lesti: {outcome}",
         "Could not load the task": "Ma setax jitgħabba l-kompitu",
-        "The task refused that action": "Il-kompitu rrifjuta dik l-azzjoni"
+        "The task refused that action": "Il-kompitu rrifjuta dik l-azzjoni",
+        "Store": "Ħanut",
+        "Install registers, schemas and flows that other organisations have published.": "Installa reġistri, skemi u flussi ppubblikati minn organizzazzjonijiet oħra."
     },
     "pluralForm": "nplurals=4; plural=(n==1 ? 0 : n==0 || ( n%100>1 && n%100<11) ? 1 : (n%100>10 && n%100<20 ) ? 2 : 3);",
     "plurals": {

--- a/l10n/nb.js
+++ b/l10n/nb.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Fullfør",
         "Complete: {outcome}": "Fullfør: {outcome}",
         "Could not load the task": "Kunne ikke laste oppgaven",
-        "The task refused that action": "Oppgaven avviste den handlingen"
+        "The task refused that action": "Oppgaven avviste den handlingen",
+        "Store": "Butikk",
+        "Install registers, schemas and flows that other organisations have published.": "Installer registre, skjemaer og flyter som andre organisasjoner har publisert."
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/nb.json
+++ b/l10n/nb.json
@@ -2872,7 +2872,9 @@
         "Complete": "Fullfør",
         "Complete: {outcome}": "Fullfør: {outcome}",
         "Could not load the task": "Kunne ikke laste oppgaven",
-        "The task refused that action": "Oppgaven avviste den handlingen"
+        "The task refused that action": "Oppgaven avviste den handlingen",
+        "Store": "Butikk",
+        "Install registers, schemas and flows that other organisations have published.": "Installer registre, skjemaer og flyter som andre organisasjoner har publisert."
     },
     "pluralForm": "nplurals=2; plural=(n != 1);",
     "plurals": {

--- a/l10n/nl.js
+++ b/l10n/nl.js
@@ -2882,7 +2882,9 @@ OC.L10N.register(
         "Complete": "Afronden",
         "Complete: {outcome}": "Afronden: {outcome}",
         "Could not load the task": "Kon de taak niet laden",
-        "The task refused that action": "De taak weigerde die actie"
+        "The task refused that action": "De taak weigerde die actie",
+        "Store": "Store",
+        "Install registers, schemas and flows that other organisations have published.": "Installeer registers, schema's en flows die andere organisaties hebben gepubliceerd."
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -2929,7 +2929,9 @@
         "Complete": "Afronden",
         "Complete: {outcome}": "Afronden: {outcome}",
         "Could not load the task": "Kon de taak niet laden",
-        "The task refused that action": "De taak weigerde die actie"
+        "The task refused that action": "De taak weigerde die actie",
+        "Store": "Store",
+        "Install registers, schemas and flows that other organisations have published.": "Installeer registers, schema's en flows die andere organisaties hebben gepubliceerd."
     },
     "pluralForm": "nplurals=2; plural=(n != 1);",
     "plurals": {

--- a/l10n/pl.js
+++ b/l10n/pl.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Zakończ",
         "Complete: {outcome}": "Zakończ: {outcome}",
         "Could not load the task": "Nie można wczytać zadania",
-        "The task refused that action": "Zadanie odrzuciło tę akcję"
+        "The task refused that action": "Zadanie odrzuciło tę akcję",
+        "Store": "Sklep",
+        "Install registers, schemas and flows that other organisations have published.": "Zainstaluj rejestry, schematy i przepływy opublikowane przez inne organizacje."
     },
     "nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);"
 )

--- a/l10n/pl.json
+++ b/l10n/pl.json
@@ -2904,7 +2904,9 @@
         "Complete": "Zakończ",
         "Complete: {outcome}": "Zakończ: {outcome}",
         "Could not load the task": "Nie można wczytać zadania",
-        "The task refused that action": "Zadanie odrzuciło tę akcję"
+        "The task refused that action": "Zadanie odrzuciło tę akcję",
+        "Store": "Sklep",
+        "Install registers, schemas and flows that other organisations have published.": "Zainstaluj rejestry, schematy i przepływy opublikowane przez inne organizacje."
     },
     "pluralForm": "nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);",
     "plurals": {

--- a/l10n/pt.js
+++ b/l10n/pt.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Concluir",
         "Complete: {outcome}": "Concluir: {outcome}",
         "Could not load the task": "Não foi possível carregar a tarefa",
-        "The task refused that action": "A tarefa recusou essa ação"
+        "The task refused that action": "A tarefa recusou essa ação",
+        "Store": "Loja",
+        "Install registers, schemas and flows that other organisations have published.": "Instale registos, esquemas e fluxos publicados por outras organizações."
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/pt.json
+++ b/l10n/pt.json
@@ -2872,7 +2872,9 @@
         "Complete": "Concluir",
         "Complete: {outcome}": "Concluir: {outcome}",
         "Could not load the task": "Não foi possível carregar a tarefa",
-        "The task refused that action": "A tarefa recusou essa ação"
+        "The task refused that action": "A tarefa recusou essa ação",
+        "Store": "Loja",
+        "Install registers, schemas and flows that other organisations have published.": "Instale registos, esquemas e fluxos publicados por outras organizações."
     },
     "pluralForm": "nplurals=2; plural=(n != 1);",
     "plurals": {

--- a/l10n/rm.js
+++ b/l10n/rm.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Terminar",
         "Complete: {outcome}": "Terminar: {outcome}",
         "Could not load the task": "L'incumbensa n'ha betg pudì vegnir chargiada",
-        "The task refused that action": "L'incumbensa ha refusà questa acziun"
+        "The task refused that action": "L'incumbensa ha refusà questa acziun",
+        "Store": "Butia",
+        "Install registers, schemas and flows that other organisations have published.": "Installescha registers, schemas e process ch'autras organisaziuns han publitgà."
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/rm.json
+++ b/l10n/rm.json
@@ -2872,7 +2872,9 @@
         "Complete": "Terminar",
         "Complete: {outcome}": "Terminar: {outcome}",
         "Could not load the task": "L'incumbensa n'ha betg pudì vegnir chargiada",
-        "The task refused that action": "L'incumbensa ha refusà questa acziun"
+        "The task refused that action": "L'incumbensa ha refusà questa acziun",
+        "Store": "Butia",
+        "Install registers, schemas and flows that other organisations have published.": "Installescha registers, schemas e process ch'autras organisaziuns han publitgà."
     },
     "pluralForm": "nplurals=2; plural=(n != 1);",
     "plurals": {

--- a/l10n/ro.js
+++ b/l10n/ro.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Finalizează",
         "Complete: {outcome}": "Finalizează: {outcome}",
         "Could not load the task": "Sarcina nu a putut fi încărcată",
-        "The task refused that action": "Sarcina a refuzat această acțiune"
+        "The task refused that action": "Sarcina a refuzat această acțiune",
+        "Store": "Magazin",
+        "Install registers, schemas and flows that other organisations have published.": "Instalați registre, scheme și fluxuri publicate de alte organizații."
     },
     "nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?2:1));"
 )

--- a/l10n/ro.json
+++ b/l10n/ro.json
@@ -2888,7 +2888,9 @@
         "Complete": "Finalizează",
         "Complete: {outcome}": "Finalizează: {outcome}",
         "Could not load the task": "Sarcina nu a putut fi încărcată",
-        "The task refused that action": "Sarcina a refuzat această acțiune"
+        "The task refused that action": "Sarcina a refuzat această acțiune",
+        "Store": "Magazin",
+        "Install registers, schemas and flows that other organisations have published.": "Instalați registre, scheme și fluxuri publicate de alte organizații."
     },
     "pluralForm": "nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?2:1));",
     "plurals": {

--- a/l10n/ru.js
+++ b/l10n/ru.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Завершить",
         "Complete: {outcome}": "Завершить: {outcome}",
         "Could not load the task": "Не удалось загрузить задачу",
-        "The task refused that action": "Задача отклонила это действие"
+        "The task refused that action": "Задача отклонила это действие",
+        "Store": "Магазин",
+        "Install registers, schemas and flows that other organisations have published.": "Установите реестры, схемы и потоки, опубликованные другими организациями."
     },
     "nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);"
 )

--- a/l10n/ru.json
+++ b/l10n/ru.json
@@ -2904,7 +2904,9 @@
         "Complete": "Завершить",
         "Complete: {outcome}": "Завершить: {outcome}",
         "Could not load the task": "Не удалось загрузить задачу",
-        "The task refused that action": "Задача отклонила это действие"
+        "The task refused that action": "Задача отклонила это действие",
+        "Store": "Магазин",
+        "Install registers, schemas and flows that other organisations have published.": "Установите реестры, схемы и потоки, опубликованные другими организациями."
     },
     "pluralForm": "nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);",
     "plurals": {

--- a/l10n/sk.js
+++ b/l10n/sk.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Dokončiť",
         "Complete: {outcome}": "Dokončiť: {outcome}",
         "Could not load the task": "Úlohu sa nepodarilo načítať",
-        "The task refused that action": "Úloha túto akciu odmietla"
+        "The task refused that action": "Úloha túto akciu odmietla",
+        "Store": "Obchod",
+        "Install registers, schemas and flows that other organisations have published.": "Nainštalujte registre, schémy a toky zverejnené inými organizáciami."
     },
     "nplurals=4; plural=(n % 1 == 0 && n == 1 ? 0 : n % 1 == 0 && n >= 2 && n <= 4 ? 1 : n % 1 != 0 ? 2: 3);"
 )

--- a/l10n/sk.json
+++ b/l10n/sk.json
@@ -2904,7 +2904,9 @@
         "Complete": "Dokončiť",
         "Complete: {outcome}": "Dokončiť: {outcome}",
         "Could not load the task": "Úlohu sa nepodarilo načítať",
-        "The task refused that action": "Úloha túto akciu odmietla"
+        "The task refused that action": "Úloha túto akciu odmietla",
+        "Store": "Obchod",
+        "Install registers, schemas and flows that other organisations have published.": "Nainštalujte registre, schémy a toky zverejnené inými organizáciami."
     },
     "pluralForm": "nplurals=4; plural=(n % 1 == 0 && n == 1 ? 0 : n % 1 == 0 && n >= 2 && n <= 4 ? 1 : n % 1 != 0 ? 2: 3);",
     "plurals": {

--- a/l10n/sl.js
+++ b/l10n/sl.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Dokončaj",
         "Complete: {outcome}": "Dokončaj: {outcome}",
         "Could not load the task": "Naloge ni bilo mogoče naložiti",
-        "The task refused that action": "Naloga je zavrnila to dejanje"
+        "The task refused that action": "Naloga je zavrnila to dejanje",
+        "Store": "Trgovina",
+        "Install registers, schemas and flows that other organisations have published.": "Namestite registre, sheme in tokove, ki so jih objavile druge organizacije."
     },
     "nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);"
 )

--- a/l10n/sl.json
+++ b/l10n/sl.json
@@ -2904,7 +2904,9 @@
         "Complete": "Dokončaj",
         "Complete: {outcome}": "Dokončaj: {outcome}",
         "Could not load the task": "Naloge ni bilo mogoče naložiti",
-        "The task refused that action": "Naloga je zavrnila to dejanje"
+        "The task refused that action": "Naloga je zavrnila to dejanje",
+        "Store": "Trgovina",
+        "Install registers, schemas and flows that other organisations have published.": "Namestite registre, sheme in tokove, ki so jih objavile druge organizacije."
     },
     "pluralForm": "nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);",
     "plurals": {

--- a/l10n/sq.js
+++ b/l10n/sq.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Përfundo",
         "Complete: {outcome}": "Përfundo: {outcome}",
         "Could not load the task": "Detyra nuk u ngarkua dot",
-        "The task refused that action": "Detyra e refuzoi atë veprim"
+        "The task refused that action": "Detyra e refuzoi atë veprim",
+        "Store": "Dyqani",
+        "Install registers, schemas and flows that other organisations have published.": "Instaloni regjistra, skema dhe rrjedha të publikuara nga organizata të tjera."
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/sq.json
+++ b/l10n/sq.json
@@ -2872,7 +2872,9 @@
         "Complete": "Përfundo",
         "Complete: {outcome}": "Përfundo: {outcome}",
         "Could not load the task": "Detyra nuk u ngarkua dot",
-        "The task refused that action": "Detyra e refuzoi atë veprim"
+        "The task refused that action": "Detyra e refuzoi atë veprim",
+        "Store": "Dyqani",
+        "Install registers, schemas and flows that other organisations have published.": "Instaloni regjistra, skema dhe rrjedha të publikuara nga organizata të tjera."
     },
     "pluralForm": "nplurals=2; plural=(n != 1);",
     "plurals": {

--- a/l10n/sr.js
+++ b/l10n/sr.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Заврши",
         "Complete: {outcome}": "Заврши: {outcome}",
         "Could not load the task": "Задатак није могао да се учита",
-        "The task refused that action": "Задатак је одбио ту радњу"
+        "The task refused that action": "Задатак је одбио ту радњу",
+        "Store": "Продавница",
+        "Install registers, schemas and flows that other organisations have published.": "Инсталирајте регистре, шеме и токове које су објавиле друге организације."
     },
     "nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);"
 )

--- a/l10n/sr.json
+++ b/l10n/sr.json
@@ -2888,7 +2888,9 @@
         "Complete": "Заврши",
         "Complete: {outcome}": "Заврши: {outcome}",
         "Could not load the task": "Задатак није могао да се учита",
-        "The task refused that action": "Задатак је одбио ту радњу"
+        "The task refused that action": "Задатак је одбио ту радњу",
+        "Store": "Продавница",
+        "Install registers, schemas and flows that other organisations have published.": "Инсталирајте регистре, шеме и токове које су објавиле друге организације."
     },
     "pluralForm": "nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);",
     "plurals": {

--- a/l10n/sv.js
+++ b/l10n/sv.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Slutför",
         "Complete: {outcome}": "Slutför: {outcome}",
         "Could not load the task": "Kunde inte läsa in uppgiften",
-        "The task refused that action": "Uppgiften nekade den åtgärden"
+        "The task refused that action": "Uppgiften nekade den åtgärden",
+        "Store": "Butik",
+        "Install registers, schemas and flows that other organisations have published.": "Installera register, scheman och flöden som andra organisationer har publicerat."
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/sv.json
+++ b/l10n/sv.json
@@ -2872,7 +2872,9 @@
         "Complete": "Slutför",
         "Complete: {outcome}": "Slutför: {outcome}",
         "Could not load the task": "Kunde inte läsa in uppgiften",
-        "The task refused that action": "Uppgiften nekade den åtgärden"
+        "The task refused that action": "Uppgiften nekade den åtgärden",
+        "Store": "Butik",
+        "Install registers, schemas and flows that other organisations have published.": "Installera register, scheman och flöden som andra organisationer har publicerat."
     },
     "pluralForm": "nplurals=2; plural=(n != 1);",
     "plurals": {

--- a/l10n/tr.js
+++ b/l10n/tr.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Tamamla",
         "Complete: {outcome}": "Tamamla: {outcome}",
         "Could not load the task": "Görev yüklenemedi",
-        "The task refused that action": "Görev bu eylemi reddetti"
+        "The task refused that action": "Görev bu eylemi reddetti",
+        "Store": "Mağaza",
+        "Install registers, schemas and flows that other organisations have published.": "Diğer kuruluşların yayımladığı kayıtları, şemaları ve akışları yükleyin."
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/tr.json
+++ b/l10n/tr.json
@@ -2872,7 +2872,9 @@
         "Complete": "Tamamla",
         "Complete: {outcome}": "Tamamla: {outcome}",
         "Could not load the task": "Görev yüklenemedi",
-        "The task refused that action": "Görev bu eylemi reddetti"
+        "The task refused that action": "Görev bu eylemi reddetti",
+        "Store": "Mağaza",
+        "Install registers, schemas and flows that other organisations have published.": "Diğer kuruluşların yayımladığı kayıtları, şemaları ve akışları yükleyin."
     },
     "pluralForm": "nplurals=2; plural=(n != 1);",
     "plurals": {

--- a/l10n/uk.js
+++ b/l10n/uk.js
@@ -2825,7 +2825,9 @@ OC.L10N.register(
         "Complete": "Завершити",
         "Complete: {outcome}": "Завершити: {outcome}",
         "Could not load the task": "Не вдалося завантажити завдання",
-        "The task refused that action": "Завдання відхилило цю дію"
+        "The task refused that action": "Завдання відхилило цю дію",
+        "Store": "Магазин",
+        "Install registers, schemas and flows that other organisations have published.": "Встановлюйте реєстри, схеми та потоки, опубліковані іншими організаціями."
     },
     "nplurals=4; plural=(n % 1 == 0 && n % 10 == 1 && n % 100 != 11 ? 0 : n % 1 == 0 && n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14) ? 1 : n % 1 == 0 && (n % 10 ==0 || (n % 10 >=5 && n % 10 <=9) || (n % 100 >=11 && n % 100 <=14 )) ? 2: 3);"
 )

--- a/l10n/uk.json
+++ b/l10n/uk.json
@@ -2904,7 +2904,9 @@
         "Complete": "Завершити",
         "Complete: {outcome}": "Завершити: {outcome}",
         "Could not load the task": "Не вдалося завантажити завдання",
-        "The task refused that action": "Завдання відхилило цю дію"
+        "The task refused that action": "Завдання відхилило цю дію",
+        "Store": "Магазин",
+        "Install registers, schemas and flows that other organisations have published.": "Встановлюйте реєстри, схеми та потоки, опубліковані іншими організаціями."
     },
     "pluralForm": "nplurals=4; plural=(n % 1 == 0 && n % 10 == 1 && n % 100 != 11 ? 0 : n % 1 == 0 && n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14) ? 1 : n % 1 == 0 && (n % 10 ==0 || (n % 10 >=5 && n % 10 <=9) || (n % 100 >=11 && n % 100 <=14 )) ? 2: 3);",
     "plurals": {

--- a/src/icons.js
+++ b/src/icons.js
@@ -44,6 +44,7 @@ import RobotOutline from 'vue-material-design-icons/RobotOutline.vue'
 import ShieldAccountOutline from 'vue-material-design-icons/ShieldAccountOutline.vue'
 import ShieldLockOutline from 'vue-material-design-icons/ShieldLockOutline.vue'
 import SitemapOutline from 'vue-material-design-icons/SitemapOutline.vue'
+import StoreOutline from 'vue-material-design-icons/StoreOutline.vue'
 import TextBoxOutline from 'vue-material-design-icons/TextBoxOutline.vue'
 import TrayFull from 'vue-material-design-icons/TrayFull.vue'
 import ViewDashboardOutline from 'vue-material-design-icons/ViewDashboardOutline.vue'
@@ -82,6 +83,7 @@ export default {
 	ShieldAccountOutline,
 	ShieldLockOutline,
 	SitemapOutline,
+	StoreOutline,
 	TextBoxOutline,
 	TrayFull,
 	ViewDashboardOutline,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -28,6 +28,18 @@
   "version": "1.1.0",
   "pages": [
     {
+      "id": "Store",
+      "route": "/store",
+      "type": "store",
+      "title": "Store",
+      "config": {
+        "app": "openregister",
+        "title": "Store",
+        "description": "Install registers, schemas and flows that other organisations have published."
+      },
+      "_note": "ADR-114 Decision 4 / ADR-080. Declarative: openregister hosts the store plane itself, so this page writes no controller and the app ships no store backend of its own. With no registry configured it renders openregister's own items and makes NO network call."
+    },
+    {
       "id": "dashboard",
       "route": "/",
       "type": "custom",
@@ -356,6 +368,14 @@
       "_note": "MDM steward surface (ADR-045 follow-on #C): audit list of recent mergeOperation rows with an in-window reverse action, read through the generic object-read surface (design.md D2)."
     }
   ],
+  "store": {
+    "_note": "Configuration exchange, not rows. A configuration set carries the registers, schemas, objects, views, flows, sources and mappings that make one way of working hold together. `types` selects that path; an app declaring none keeps the remote objects API. There is deliberately NO `installable` allowlist: a set exists to introduce schemas the instance does not have YET, so listing schemas openregister already owns would refuse exactly the sets worth installing. The trust boundary for a bundle is its publisher, enforced by the engine's source allowlist and trusted-key check. ⚠️ An EMPTY `installable` would mean install NOTHING, not install anything — omitting the key and declaring an empty list are different things.",
+    "types": [
+      "openregister.configset",
+      "openregister.flows"
+    ],
+    "localRegister": "openregister"
+  },
   "menu": [
     {
       "id": "Dashboard",
@@ -564,6 +584,14 @@
       "href": "https://openregister.conduction.nl",
       "section": "footer",
       "order": 90
+    },
+    {
+      "id": "StoreMenu",
+      "label": "Store",
+      "icon": "StoreOutline",
+      "route": "Store",
+      "section": "footer",
+      "order": 92
     },
     {
       "id": "Reports",

--- a/tests/e2e/ci/app-chrome.spec.ts
+++ b/tests/e2e/ci/app-chrome.spec.ts
@@ -67,7 +67,7 @@ test.describe('app chrome (ADR-114)', () => {
 		await dismissSetupWizard(page)
 	})
 
-	test('the footer reads Documentation, Reports, Features & roadmap, each with a glyph', async ({
+	test('the footer reads Documentation, Store, Reports, Features & roadmap, each with a glyph', async ({
 		page,
 	}) => {
 		const footer = page.locator(
@@ -83,11 +83,14 @@ test.describe('app chrome (ADR-114)', () => {
 		// ORDER is the rule, not the numbers. This app ran its footer at 1 and 2
 		// while pipelinq runs 160/200/230, and both read correctly; ADR-114
 		// fixes the sequence and leaves the numbers to the app.
-		const seen = texts.filter((t) => /Documentation|Reports|roadmap/i.test(t))
-		expect(seen.length).toBe(3)
+		const seen = texts.filter((t) =>
+			/Documentation|Store|Reports|roadmap/i.test(t),
+		)
+		expect(seen.length).toBe(4)
 		expect(seen[0]).toMatch(/Documentation/i)
-		expect(seen[1]).toMatch(/Reports/i)
-		expect(seen[2]).toMatch(/roadmap/i)
+		expect(seen[1]).toMatch(/Store/i)
+		expect(seen[2]).toMatch(/Reports/i)
+		expect(seen[3]).toMatch(/roadmap/i)
 
 		for (const row of await rows.all()) {
 			await expect(
@@ -123,6 +126,28 @@ test.describe('app chrome (ADR-114)', () => {
 		// footer; this asserts the move rather than only the arrival.
 		const main = page.locator('[data-testid="cn-nav"] .cn-app-nav__footer-list')
 		await expect(main.getByRole('link', { name: /^Reports$/ })).toHaveCount(1)
+	})
+
+	test('Store opens the hosted store surface, which this app writes no backend for', async ({
+		page,
+	}) => {
+		const footer = page.locator(
+			'[data-testid="cn-nav"] .cn-app-nav__footer-list',
+		)
+		await footer
+			.getByRole('link', { name: /^Store$/ })
+			.first()
+			.click()
+
+		await expect(page).toHaveURL(/\/apps\/openregister\/store(\?|$)/, {
+			timeout: 15_000,
+		})
+
+		// openregister HOSTS the store plane, so this page is declarative: the
+		// app ships no store controller of its own (ADR-080, ADR-114 Decision
+		// 4). With no registry configured it renders its own items and makes NO
+		// network call, so this must pass on a plain instance.
+		await expect(page.locator('[data-testid="cn-nav"]')).toBeVisible()
 	})
 
 	test('the settings foldout carries Personal settings, Admin settings and Flows', async ({


### PR DESCRIPTION
ADR-114 puts Documentation, Store, Reports and Features & roadmap in the footer, in that order. Openregister hosts the store plane for the whole fleet and had no Store of its own. gate-107 goes from **4 of 5 to 5 of 5**.

## The page writes no backend

Openregister already owns `GenericStoreService`, `GenericStoreInstaller` and `GenericStoreController`, so it adopts its own plane the same way every leaf app does: a `type:"store"` page plus a top-level `store` block, and nothing else. With no registry configured the page renders openregister's own items and makes **no network call**.

## No `installable` allowlist, deliberately

Following decidiq's precedent. A configuration set exists to introduce schemas the instance *does not have yet*, so listing schemas openregister already owns would refuse exactly the sets worth installing. The trust boundary for a bundle is its publisher, enforced by the engine's source allowlist and trusted-key check.

Worth stating in the manifest because the two are not interchangeable: an **empty** `installable` means install *nothing*, not install anything. `StoreManifest::isInstallable()` returns false for every slug when the list is empty, so omitting the key and declaring an empty list are different things on purpose.

## Icons and locales

`StoreOutline` had to be registered in `src/icons.js` — an unregistered name renders **no glyph at all**, no fallback and no console error, and gate-60 is the only thing that catches it.

Two strings across all 36 locales. Openregister was at **full parity** and still is; adding English-only keys would have broken a currently green check.

**No dependency bump needed:** `^2.36.0` already resolves to a nextcloud-vue that ships `CnStorePage`. Verified by unpacking the published tarball rather than trusting the version number — the locally installed copy is stale and does *not* contain it, which is exactly the sort of thing that reads as a missing feature.

## Checks

- gate-107 `app-chrome`: `{"status":"passed","checked":5,"failed":0,"warned":0}`
- gate-60 icon vocabulary: 17 manifests, 0 failures
- manifest l10n coverage: 0 failures
- l10n parity: OK, every locale at full parity
- eslint and prettier clean on the changed files

`src/manifest.json` already fails `prettier --check` on `development`; reformatting it would churn thousands of unrelated lines, so it is left alone.

CI is queue-bottlenecked, so this was verified locally rather than waiting on Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
