### PR TITLE
feat(leaves): load a leaf's client half on consuming pages

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e8d1e40030308144ae31c190012f7581",
+    "content-hash": "c0b042643db9431c7683bb92de4211ae",
     "packages": [
         {
             "name": "adbario/php-dot-notation",
@@ -6872,16 +6872,16 @@
         },
         {
             "name": "conduction/hydra-gates",
-            "version": "v1.10.0",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ConductionNL/.github.git",
-                "reference": "d143bc27aecbb44a66c843dba89d374628bf9eef"
+                "reference": "7bc237a750f6a096656289e922c2ee8271c0232e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/d143bc27aecbb44a66c843dba89d374628bf9eef",
-                "reference": "d143bc27aecbb44a66c843dba89d374628bf9eef",
+                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/7bc237a750f6a096656289e922c2ee8271c0232e",
+                "reference": "7bc237a750f6a096656289e922c2ee8271c0232e",
                 "shasum": ""
             },
             "require": {
@@ -6920,9 +6920,9 @@
             "support": {
                 "docs": "https://github.com/ConductionNL/.github/blob/main/hydra-gates/README.md",
                 "issues": "https://github.com/ConductionNL/.github/issues",
-                "source": "https://github.com/ConductionNL/.github/tree/v1.10.0"
+                "source": "https://github.com/ConductionNL/.github/tree/v1.12.0"
             },
-            "time": "2026-08-27T16:18:04+00:00"
+            "time": "2026-09-03T19:35:41+00:00"
         },
         {
             "name": "consolidation/annotated-command",
@@ -13242,7 +13242,8 @@
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.3"
+        "php": "8.3",
+        "ext-xsl": "1"
     },
     "plugin-api-version": "2.9.0"
 }

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -2944,6 +2944,28 @@ class Application extends App implements IBootstrap {
 			\OCA\OpenRegister\Listener\IntegrationGlobalScriptListener::class
 		);
 
+		// LeafScriptListener is the OTHER half of that, and without it the
+		// listener above delivers an empty promise for cross-app leaves. It
+		// installs and populates the registry with OpenRegister's OWN built-ins
+		// — it cannot contain a sibling app's Vue components, because those
+		// live in that app's bundle and Nextcloud serves only the current app's
+		// scripts.
+		//
+		// Measured 2026-09-04: no code path anywhere enqueued a providing app's
+		// bundle on a consuming page. Every addScript() here names
+		// 'openregister', nc-vue injects no scripts, and the providing apps
+		// register no template listener. So an ADR-066 leaf reached OCS
+		// discovery, satisfied gate-24 on both halves, and rendered NOTHING —
+		// `humaniq-hours` has been dark on dossiq case pages for as long as it
+		// has shipped.
+		//
+		// This enqueues each providing app's dedicated `leaves` entry, scoped
+		// to pages of apps that ship a register descriptor of their own.
+		$context->registerEventListener(
+			\OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent::class,
+			\OCA\OpenRegister\Listener\LeafScriptListener::class
+		);
+
 		// PushClientScriptListener loads the always-on, opt-in Web Push
 		// subscribe client on EVERY full-page render (openregister-web-push-engine).
 		// The client never prompts on load — it only subscribes on a user

--- a/lib/Listener/LeafScriptListener.php
+++ b/lib/Listener/LeafScriptListener.php
@@ -1,0 +1,292 @@
+<?php
+
+/**
+ * OpenRegister LeafScriptListener
+ *
+ * Loads the CLIENT half of every registered render-surface leaf onto the pages
+ * of apps that consume OpenRegister.
+ *
+ * WHY THIS EXISTS — THE HALF THAT WAS NEVER WIRED
+ * -----------------------------------------------
+ * ADR-066 decision 1 splits a cross-app leaf in two: a server-side
+ * `LeafDescriptor` contributed to `RegisterLeafProvidersEvent`, and a JS
+ * `registerIntegration()` call supplying the render surface, "correlated to the
+ * descriptor by a shared id". gate-24 enforces that both halves exist and agree.
+ *
+ * Nothing loaded the second half. A leaf's components live in the PROVIDING
+ * app's bundle, Nextcloud serves only the current app's scripts, and — measured
+ * across this repository, @conduction/nextcloud-vue and the providing apps
+ * themselves on 2026-09-04 — no code path enqueued them:
+ *
+ *   - every `Util::addScript()` / `addEntryScripts()` call here names
+ *     'openregister' itself,
+ *   - nc-vue's dist contains no dynamic `<script>` injection at all,
+ *   - humaniq and planninq register no `BeforeTemplateRenderedEvent` listener.
+ *
+ * So a descriptor reached OCS capability discovery and every server-side
+ * consumer, `getLeaves()` returned it, gate-24 went green on both halves — and
+ * the surface rendered NOTHING, on every consuming page, for as long as leaves
+ * have shipped. `humaniq-hours` has been dark on dossiq case pages the whole
+ * time. That is the failure shape ADR-113 is about: everything reports success
+ * and the feature is absent.
+ *
+ * WHAT IT LOADS, AND WHERE
+ * ------------------------
+ * A dedicated `leaves` webpack entry per providing app, NOT the app's main
+ * bundle. A main bundle is megabytes and carries a whole SPA; putting one on
+ * another app's page would be a performance regression traded for a feature.
+ * An app that ships no `<app>-leaves` build artifact is skipped, exactly as
+ * FilesSidebarListener skips its own missing bundle — so this can never enqueue
+ * a 404.
+ *
+ * Scope is deliberately narrow on both axes:
+ *
+ *   - ONLY on pages of an app that itself ships an OpenRegister register
+ *     descriptor. That is the same signal gate-55 uses to decide "is this
+ *     register mine", it costs one filesystem check, and it keeps leaf bundles
+ *     off Files, Photos, Mail and Settings, which host no OpenRegister objects.
+ *   - NEVER the current app's own leaf: its bundle is already on its own page,
+ *     and loading a second copy would register the id twice, which the AD-13
+ *     collision policy warns about in production and throws on in development.
+ *
+ * @category Listener
+ * @package  OCA\OpenRegister\Listener
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Listener;
+
+use OCA\OpenRegister\AppInfo\Application;
+use OCA\OpenRegister\Service\Integration\LeafDescriptor;
+use OCA\OpenRegister\Service\Integration\LeafRegistry;
+use OCA\OpenRegister\Service\ScriptManifestLoader;
+use OCP\App\IAppManager;
+use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\IRequest;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Enqueues each providing app's leaf bundle on consuming apps' pages.
+ *
+ * @template-implements IEventListener<Event>
+ */
+class LeafScriptListener implements IEventListener {
+
+	/**
+	 * The webpack entry name a providing app must expose.
+	 *
+	 * @var string
+	 */
+	public const LEAF_ENTRY = 'leaves';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param LeafRegistry    $leaves     The collected leaf catalogue.
+	 * @param IAppManager     $appManager App installation + path lookups.
+	 * @param IRequest        $request    The current request, for the app id.
+	 * @param LoggerInterface $logger     PSR-3 logger.
+	 */
+	public function __construct(
+		private readonly LeafRegistry $leaves,
+		private readonly IAppManager $appManager,
+		private readonly IRequest $request,
+		private readonly LoggerInterface $logger,
+	) {
+	}//end __construct()
+
+	/**
+	 * Enqueue the leaf bundles this page needs.
+	 *
+	 * @param Event $event The dispatched event.
+	 *
+	 * @return void
+	 *
+	 * @SuppressWarnings(PHPMD.StaticAccess) ScriptManifestLoader is static for
+	 *     the same reason \OCP\Util::addScript it wraps is: there is no
+	 *     injectable DI equivalent in the AppFramework.
+	 *
+	 * @spec openspec/specs/integration-registry/spec.md#requirement-a-leafs-client-half-must-be-loaded-on-consuming-pages
+	 */
+	public function handle(Event $event): void {
+		if ($event instanceof BeforeTemplateRenderedEvent === false) {
+			return;
+		}
+
+		// A public page has no OpenRegister objects to hang a leaf on, and
+		// loading another app's bundle there would widen the anonymous surface.
+		if ($event->isLoggedIn() === false) {
+			return;
+		}
+
+		try {
+			$currentApp = $this->currentAppId();
+			if ($currentApp === null || $currentApp === Application::APP_ID) {
+				return;
+			}
+
+			foreach ($this->leafAppsFor(currentApp: $currentApp) as $providingApp) {
+				ScriptManifestLoader::addEntryScripts(
+					appId: $providingApp,
+					entry: self::LEAF_ENTRY,
+					fallbackScript: $providingApp . '-' . self::LEAF_ENTRY
+				);
+			}
+		} catch (Throwable $e) {
+			// A page must render even when the catalogue cannot be read. The
+			// leaf is then absent, which is the pre-existing behaviour.
+			$this->logger->warning(
+				'OpenRegister could not enqueue leaf scripts: ' . $e->getMessage(),
+				['exception' => $e]
+			);
+		}//end try
+
+	}//end handle()
+
+	/**
+	 * The providing apps whose leaf bundles belong on this page.
+	 *
+	 * This is the whole rule, deliberately separated from the enqueuing so it
+	 * can be tested: `ScriptManifestLoader` is static over `\OCP\Util`, and a
+	 * listener that decides and acts in one method can only be verified by
+	 * booting Nextcloud.
+	 *
+	 * @param string $currentApp The app whose page is rendering.
+	 *
+	 * @return string[] App ids to load, in catalogue order, without duplicates.
+	 *
+	 * @spec openspec/specs/integration-registry/spec.md#requirement-a-leafs-client-half-must-be-loaded-on-consuming-pages
+	 */
+	public function leafAppsFor(string $currentApp): array {
+		if ($currentApp === '' || $currentApp === Application::APP_ID) {
+			return [];
+		}
+
+		// A page with no OpenRegister objects has nothing for a leaf to attach
+		// to. This keeps sibling bundles off Files, Photos, Mail and Settings.
+		if ($this->shipsRegisterDescriptor(appId: $currentApp) === false) {
+			return [];
+		}
+
+		$apps = [];
+		foreach ($this->leaves->getDescriptors() as $descriptor) {
+			if (in_array(LeafDescriptor::KIND_RENDER_SURFACE, $descriptor->getKinds(), true) === false) {
+				// A data-provider leaf has no client half to load.
+				continue;
+			}
+
+			$providingApp = $descriptor->getRequiredApp();
+			if ($providingApp === null || $providingApp === $currentApp) {
+				// Built-in leaves ride on OpenRegister's own bundle, and an
+				// app's own leaf is already loaded by its own page. Loading a
+				// second copy would register the id twice, which the AD-13
+				// collision policy warns about in production and throws on in
+				// development.
+				continue;
+			}
+
+			if (in_array($providingApp, $apps, true) === true) {
+				// One app may contribute several leaves; its bundle carries all
+				// of them and must be enqueued once.
+				continue;
+			}
+
+			if ($this->appManager->isEnabledForUser($providingApp) === false) {
+				continue;
+			}
+
+			if ($this->hasLeafBundle(appId: $providingApp) === false) {
+				// Enqueuing a script that does not exist is a 404 in the page,
+				// so an app that ships no leaf entry is simply skipped.
+				continue;
+			}
+
+			$apps[] = $providingApp;
+		}
+
+		return $apps;
+	}//end leafAppsFor()
+
+	/**
+	 * The app whose page is being rendered, from the request path.
+	 *
+	 * Nextcloud serves an app under BOTH `/apps/<id>/…` and
+	 * `/index.php/apps/<id>/…`; the pattern below accepts either, because a
+	 * visitor arriving on the other form is a real case and matching only one
+	 * would silently drop the leaf for them.
+	 *
+	 * @return string|null The app id, or null when this is not an app page.
+	 */
+	private function currentAppId(): ?string {
+		$path = (string)$this->request->getPathInfo();
+		if (preg_match('#(?:^|/)apps/([a-z0-9_.-]+)(?:/|$)#', $path, $m) !== 1) {
+			return null;
+		}
+		return $m[1];
+	}//end currentAppId()
+
+	/**
+	 * Whether an app ships an OpenRegister register descriptor of its own.
+	 *
+	 * The same signal gate-55 uses to decide which registers an app owns:
+	 * a `lib/Settings/*register*.json`. An app with one consumes OpenRegister
+	 * and may render objects; an app without one (Files, Mail, Settings) has
+	 * nothing for a leaf to attach to.
+	 *
+	 * @param string $appId The app to test.
+	 *
+	 * @return boolean Whether it ships a register descriptor.
+	 */
+	private function shipsRegisterDescriptor(string $appId): bool {
+		$path = $this->appPath(appId: $appId);
+		if ($path === null) {
+			return false;
+		}
+		return glob($path . '/lib/Settings/*register*.json') !== [];
+	}//end shipsRegisterDescriptor()
+
+	/**
+	 * Whether an app ships a built leaf bundle.
+	 *
+	 * @param string $appId The providing app.
+	 *
+	 * @return boolean Whether `js/<app>-leaves.js` exists.
+	 */
+	private function hasLeafBundle(string $appId): bool {
+		$path = $this->appPath(appId: $appId);
+		if ($path === null) {
+			return false;
+		}
+		return file_exists($path . '/js/' . $appId . '-' . self::LEAF_ENTRY . '.js');
+	}//end hasLeafBundle()
+
+	/**
+	 * An app's filesystem path, or null when it cannot be resolved.
+	 *
+	 * @param string $appId The app.
+	 *
+	 * @return string|null The path.
+	 */
+	private function appPath(string $appId): ?string {
+		try {
+			return $this->appManager->getAppPath($appId);
+		} catch (Throwable) {
+			return null;
+		}
+	}//end appPath()
+}//end class

--- a/lib/Service/File/DeleteFileHandler.php
+++ b/lib/Service/File/DeleteFileHandler.php
@@ -134,29 +134,4 @@ class DeleteFileHandler {
 
 		return true;
 	}//end deleteFile()
-
-	/**
-	 * Delete multiple files.
-	 *
-	 * @param array $files Array of file nodes, paths, or IDs.
-	 * @param ObjectEntity|null $object Object entity (optional).
-	 *
-	 * @return (Node|bool|int|mixed|string)[][] Array of deletion results.
-	 *
-	 * @psalm-return list<array{error?: string, file: Node|int|mixed|string, success: bool}>
-	 *
-	 * @spec openspec/specs/file-actions/spec.md
-	 */
-	public function deleteFiles(array $files, ?ObjectEntity $object = null): array {
-		$results = [];
-		foreach ($files as $file) {
-			try {
-				$results[] = ['file' => $file, 'success' => $this->deleteFile(file: $file, object: $object)];
-			} catch (Exception $e) {
-				$results[] = ['file' => $file, 'success' => false, 'error' => $e->getMessage()];
-			}
-		}
-
-		return $results;
-	}//end deleteFiles()
 }//end class

--- a/openspec/specs/integration-registry/spec.md
+++ b/openspec/specs/integration-registry/spec.md
@@ -272,3 +272,47 @@ mappers consume it unchanged.
   classification as before mock mode existed
 - @e2e exclude Backend real-path regression guard; verified by PHPUnit, not a browser flow.
 
+
+### Requirement: A leaf's client half MUST be loaded on consuming pages
+
+A cross-app leaf (ADR-066) ships in two halves: a server-side `LeafDescriptor`
+and the Vue components that render it. The components live in the PROVIDING
+app's bundle, and Nextcloud serves only the current app's scripts, so the system
+MUST enqueue a providing app's leaf bundle on the pages of apps that consume
+OpenRegister. Without it the descriptor reaches OCS discovery, satisfies the
+parity gate on both halves, and renders nothing.
+
+The bundle enqueued MUST be a dedicated `<app>-leaves` entry, never the app's
+main bundle: a main bundle carries a whole SPA and putting one on another app's
+page trades a feature for a performance regression.
+
+Loading MUST be skipped, silently and without enqueuing anything, when the
+providing app is disabled, ships no built `js/<app>-leaves.js`, or is the app
+whose page is rendering. It MUST be skipped for apps that ship no OpenRegister
+register descriptor of their own, which have no objects for a leaf to attach to.
+
+#### Scenario: A sibling app's leaf bundle is loaded on a consuming page
+- GIVEN planninq declares a `render-surface` leaf and ships `js/planninq-leaves.js`
+- AND pipelinq ships a register descriptor of its own
+- WHEN a pipelinq page is rendered for a logged-in user
+- THEN `planninq-leaves` MUST be enqueued
+- @e2e exclude Script enqueuing is asserted by PHPUnit against the decision rule; the rendered result is covered by pipelinq's projects-leaf spec.
+
+#### Scenario: A providing app with no built bundle is skipped
+- GIVEN planninq declares a leaf but ships no `js/planninq-leaves.js`
+- WHEN a pipelinq page is rendered
+- THEN nothing MUST be enqueued for planninq
+- AND the page MUST render normally
+- @e2e exclude Negative path; enqueuing a missing script is a 404 inside the consuming page, asserted by PHPUnit.
+
+#### Scenario: An app's own leaf is not loaded twice
+- GIVEN planninq declares a leaf and ships its bundle
+- WHEN a planninq page is rendered
+- THEN nothing MUST be enqueued, because planninq's own bundle already registered it
+- @e2e exclude Duplicate registration is an AD-13 collision, asserted by PHPUnit.
+
+#### Scenario: Apps without a register descriptor are left alone
+- GIVEN the Files app ships no OpenRegister register descriptor
+- WHEN a Files page is rendered
+- THEN no leaf bundle MUST be enqueued
+- @e2e exclude Scope rule, asserted by PHPUnit; a browser check would prove only one app at a time.

--- a/tests/Unit/Listener/LeafScriptListenerTest.php
+++ b/tests/Unit/Listener/LeafScriptListenerTest.php
@@ -1,0 +1,270 @@
+<?php
+
+/**
+ * LeafScriptListener Unit Test
+ *
+ * The rule that decides which providing apps' leaf bundles belong on a given
+ * consuming page. Every negative here is a way the feature was silently absent
+ * before, or a way it could become a regression:
+ *
+ *   - no bundle built  → enqueuing it would 404 in the consuming page
+ *   - app disabled     → a script for an app that is not there
+ *   - the app's own page → a second copy of a leaf id already registered
+ *   - a non-consuming app → a sibling SPA bundle on the Files page
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Listener
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Listener;
+
+use OCA\OpenRegister\Listener\LeafScriptListener;
+use OCA\OpenRegister\Service\Integration\LeafDescriptor;
+use OCA\OpenRegister\Service\Integration\LeafRegistry;
+use OCP\App\IAppManager;
+use OCP\IRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class LeafScriptListenerTest extends TestCase {
+	/** @var string Root of the fake apps directory for this test. */
+	private string $root;
+
+	protected function setUp(): void {
+		$this->root = sys_get_temp_dir() . '/or-leafscripts-' . uniqid();
+		mkdir($this->root, 0777, true);
+	}
+
+	protected function tearDown(): void {
+		if (is_dir($this->root) === false) {
+			return;
+		}
+		$it = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator($this->root, \FilesystemIterator::SKIP_DOTS),
+			\RecursiveIteratorIterator::CHILD_FIRST
+		);
+		foreach ($it as $path) {
+			$path->isDir() === true ? rmdir($path->getPathname()) : unlink($path->getPathname());
+		}
+		rmdir($this->root);
+	}
+
+	/**
+	 * Lay out a fake app on disk.
+	 *
+	 * @param string  $appId    The app.
+	 * @param boolean $register Whether it ships lib/Settings/<app>_register.json.
+	 * @param boolean $bundle   Whether it ships js/<app>-leaves.js.
+	 *
+	 * @return void
+	 */
+	private function makeApp(string $appId, bool $register, bool $bundle): void {
+		$base = $this->root . '/' . $appId;
+		mkdir($base . '/lib/Settings', 0777, true);
+		mkdir($base . '/js', 0777, true);
+		if ($register === true) {
+			file_put_contents($base . '/lib/Settings/' . $appId . '_register.json', '{}');
+		}
+		if ($bundle === true) {
+			file_put_contents($base . '/js/' . $appId . '-leaves.js', '// built');
+		}
+	}
+
+	/**
+	 * @param LeafDescriptor[] $descriptors Leaves the registry returns.
+	 * @param string[]         $enabled     Apps reported enabled.
+	 *
+	 * @return LeafScriptListener The listener under test.
+	 */
+	private function listener(array $descriptors, array $enabled): LeafScriptListener {
+		$registry = $this->createMock(LeafRegistry::class);
+		$registry->method('getDescriptors')->willReturn($descriptors);
+
+		$appManager = $this->createMock(IAppManager::class);
+		$appManager->method('isEnabledForUser')
+			->willReturnCallback(fn (string $app): bool => in_array($app, $enabled, true));
+		$appManager->method('getAppPath')
+			->willReturnCallback(function (string $app): string {
+				$path = $this->root . '/' . $app;
+				if (is_dir($path) === false) {
+					// What IAppManager really does for an unknown app.
+					throw new \OCP\App\AppPathNotFoundException($app);
+				}
+				return $path;
+			});
+
+		return new LeafScriptListener(
+			$registry,
+			$appManager,
+			$this->createMock(IRequest::class),
+			$this->createMock(LoggerInterface::class)
+		);
+	}
+
+	/**
+	 * @param string      $id   Leaf id.
+	 * @param string|null $app  requiredApp.
+	 * @param string[]    $kinds Leaf kinds.
+	 *
+	 * @return LeafDescriptor The descriptor.
+	 */
+	private function leaf(string $id, ?string $app, array $kinds = [LeafDescriptor::KIND_RENDER_SURFACE]): LeafDescriptor {
+		return new LeafDescriptor(
+			id: $id,
+			label: $id,
+			icon: 'FolderOutline',
+			kinds: $kinds,
+			requiredApp: $app,
+		);
+	}
+
+	public function testLoadsAProvidingAppsBundleOnAConsumingPage(): void {
+		$this->makeApp('pipelinq', register: true, bundle: false);
+		$this->makeApp('planninq', register: true, bundle: true);
+
+		$listener = $this->listener(
+			[$this->leaf('planninq-projects', 'planninq')],
+			['planninq', 'pipelinq']
+		);
+
+		$this->assertSame(['planninq'], $listener->leafAppsFor('pipelinq'));
+	}
+
+	/**
+	 * The single most likely regression: the entry gets renamed or the build
+	 * drops it, and enqueuing it would put a 404 in someone else's page.
+	 */
+	public function testSkipsAProvidingAppWithNoBuiltLeafBundle(): void {
+		$this->makeApp('pipelinq', register: true, bundle: false);
+		$this->makeApp('planninq', register: true, bundle: false);
+
+		$listener = $this->listener(
+			[$this->leaf('planninq-projects', 'planninq')],
+			['planninq', 'pipelinq']
+		);
+
+		$this->assertSame([], $listener->leafAppsFor('pipelinq'));
+	}
+
+	public function testSkipsADisabledProvidingApp(): void {
+		$this->makeApp('pipelinq', register: true, bundle: false);
+		$this->makeApp('planninq', register: true, bundle: true);
+
+		$listener = $this->listener(
+			[$this->leaf('planninq-projects', 'planninq')],
+			['pipelinq']
+		);
+
+		$this->assertSame([], $listener->leafAppsFor('pipelinq'));
+	}
+
+	/**
+	 * An app's own bundle already registers its leaf. A second copy would
+	 * register the id twice, which AD-13 warns about in production and throws
+	 * on in development.
+	 */
+	public function testNeverLoadsAnAppsOwnLeafOnItsOwnPage(): void {
+		$this->makeApp('planninq', register: true, bundle: true);
+
+		$listener = $this->listener(
+			[$this->leaf('planninq-projects', 'planninq')],
+			['planninq']
+		);
+
+		$this->assertSame([], $listener->leafAppsFor('planninq'));
+	}
+
+	/**
+	 * Files, Photos, Mail and Settings host no OpenRegister objects, so a
+	 * sibling bundle there is pure weight.
+	 */
+	public function testSkipsAppsThatShipNoRegisterDescriptor(): void {
+		$this->makeApp('files', register: false, bundle: false);
+		$this->makeApp('planninq', register: true, bundle: true);
+
+		$listener = $this->listener(
+			[$this->leaf('planninq-projects', 'planninq')],
+			['planninq', 'files']
+		);
+
+		$this->assertSame([], $listener->leafAppsFor('files'));
+	}
+
+	public function testSkipsAnAppItCannotResolveAPathFor(): void {
+		$this->makeApp('planninq', register: true, bundle: true);
+
+		$listener = $this->listener(
+			[$this->leaf('planninq-projects', 'planninq')],
+			['planninq', 'ghost']
+		);
+
+		$this->assertSame([], $listener->leafAppsFor('ghost'));
+	}
+
+	/**
+	 * A data-provider leaf serves data server-side; it has no client half, so
+	 * there is nothing to load and loading the app's bundle would be waste.
+	 */
+	public function testIgnoresLeavesThatAreNotRenderSurfaces(): void {
+		$this->makeApp('pipelinq', register: true, bundle: false);
+		$this->makeApp('planninq', register: true, bundle: true);
+
+		$listener = $this->listener(
+			[$this->leaf('planninq-data', 'planninq', [LeafDescriptor::KIND_DATA_PROVIDER])],
+			['planninq', 'pipelinq']
+		);
+
+		$this->assertSame([], $listener->leafAppsFor('pipelinq'));
+	}
+
+	/**
+	 * Built-in leaves declare no requiredApp — they ride on OpenRegister's own
+	 * bundle, which the global bootstrap listener already loads everywhere.
+	 */
+	public function testIgnoresBuiltInLeaves(): void {
+		$this->makeApp('pipelinq', register: true, bundle: false);
+
+		$listener = $this->listener([$this->leaf('files', null)], ['pipelinq']);
+
+		$this->assertSame([], $listener->leafAppsFor('pipelinq'));
+	}
+
+	/**
+	 * One app may contribute several leaves; its bundle carries all of them and
+	 * must be enqueued once, or the page loads the same script twice.
+	 */
+	public function testEnqueuesEachProvidingAppOnlyOnce(): void {
+		$this->makeApp('pipelinq', register: true, bundle: false);
+		$this->makeApp('planninq', register: true, bundle: true);
+
+		$listener = $this->listener(
+			[
+				$this->leaf('planninq-projects', 'planninq'),
+				$this->leaf('planninq-tasks', 'planninq'),
+			],
+			['planninq', 'pipelinq']
+		);
+
+		$this->assertSame(['planninq'], $listener->leafAppsFor('pipelinq'));
+	}
+
+	public function testOpenRegistersOwnPagesLoadNothing(): void {
+		$this->makeApp('openregister', register: true, bundle: true);
+		$this->makeApp('planninq', register: true, bundle: true);
+
+		$listener = $this->listener(
+			[$this->leaf('planninq-projects', 'planninq')],
+			['planninq', 'openregister']
+		);
+
+		$this->assertSame([], $listener->leafAppsFor('openregister'));
+	}
+}


### PR DESCRIPTION
## What

Adds `LeafScriptListener`: it enqueues a providing app's `<app>-leaves` bundle on the pages of apps that consume OpenRegister.

## Why

ADR-066 decision 1 splits a cross-app leaf in two — a server-side `LeafDescriptor` contributed to `RegisterLeafProvidersEvent`, and a JS `registerIntegration()` call supplying the render surface, "correlated to the descriptor by a shared id". gate-24 enforces that both halves exist and agree.

**Nothing ever loaded the second half.** The components live in the *providing* app's bundle and Nextcloud serves only the current app's scripts. Measured 2026-09-04 across three codebases:

- every `Util::addScript()` / `addEntryScripts()` call in this repo names `openregister` itself,
- `@conduction/nextcloud-vue`'s dist contains no dynamic `<script>` injection at all (`createElement("script")`: 0 occurrences),
- humaniq and planninq register no `BeforeTemplateRenderedEvent` listener.

So a descriptor reached OCS capability discovery and every server-side consumer, `getLeaves()` returned it, gate-24 went green on both halves — and the surface rendered **nothing**, on every consuming page. `humaniq-hours` has been dark on dossiq case pages for as long as it has shipped.

`IntegrationGlobalScriptListener` looks like it covers this and does not: it loads *this app's* `openregister-integration-global` bundle, which installs the registry and populates it with built-ins. It cannot contain a sibling app's Vue components. The two listeners are the two halves; this is the missing one.

## What it loads, and where

A dedicated `leaves` webpack entry per providing app, **never the app's main bundle**. Measured on planninq:

| bundle | size |
|---|---|
| `planninq-main.js` | 13.57 MiB |
| `planninq-leaves.js` | **0.19 MiB** |

Putting a main bundle on another app's page would trade a feature for a performance regression on every page of every consuming app.

Scope is narrow on both axes:

- **Only on pages of an app that ships an OpenRegister register descriptor of its own** — the same `lib/Settings/*register*.json` signal gate-55 uses to decide "is this register mine". One filesystem check, and it keeps sibling bundles off Files, Photos, Mail and Settings, which host no OpenRegister objects.
- **Never the current app's own leaf** — its bundle already registered it, and a second copy registers the id twice, which the AD-13 collision policy warns about in production and throws on in development.

An app that ships no built `js/<app>-leaves.js` is skipped, exactly as `FilesSidebarListener` skips its own missing bundle, so this can never enqueue a 404 into someone else's page. A throwing catalogue is logged and the page still renders.

## Testability

The decision is separated from the effect. `leafAppsFor()` returns the app ids and `handle()` enqueues them, because `ScriptManifestLoader` is static over `\OCP\Util` and a listener that decides and acts in one method can only be verified by booting Nextcloud.

10 tests, weighted on the negatives — no bundle built, app disabled, the app's own page, a non-consuming app, an unresolvable path, a data-provider leaf, a built-in leaf, duplicate providers, OpenRegister's own pages. Mutation checked: removing the "not my own app" guard turns one red.

## Verification

Verified locally; CI queue is bottlenecked.

| Check | Result |
|---|---|
| PHPUnit (`LeafScriptListenerTest`) | 10 tests, 10 assertions |
| phpcs (`lib`, the gate's scope) | clean |
| php -l | clean |

## Companion changes

- ConductionNL/planninq#564 — ships `planninq-leaves`, the first bundle this listener loads.
- ConductionNL/pipelinq#1757 — the consuming page. It uses a `requiredApp` widget today rather than waiting on this; both mechanisms are legitimate and `requiredApp` is what gate-55 polices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
