### PR TITLE
feat(objects): raw append and expiry purge for high-volume writers; enforce search trail retention

### DIFF
--- a/docs/Features/search.md
+++ b/docs/Features/search.md
@@ -1132,14 +1132,12 @@ Clean up old search trail entries.
 
 #### Retention Policy
 
-Configure search trail retention:
-
-```php
-// In app configuration
-'search_trail_retention_days' => 90,
-'search_trail_cleanup_enabled' => true,
-'search_trail_cleanup_schedule' => 'daily',
-```
+Search trail retention is the `searchTrailRetention` value on the Retention
+admin page (milliseconds, default `2592000000`, 30 days), read and written
+through `GET`/`PATCH /api/settings/retention`. The hourly `LogCleanUpTask`
+background job enforces it: rows without an expiry are stamped `created` plus
+the retention, and rows whose expiry has passed are deleted. There is no
+separate enable switch or schedule for the cleanup.
 
 #### Privacy Settings
 

--- a/docs/features/search-and-faceting.md
+++ b/docs/features/search-and-faceting.md
@@ -238,6 +238,16 @@ Recording is best-effort: a write failure logs a warning and the search returns
 normally, so analytics recording never degrades search availability. The settings
 round-trip through `GET`/`PATCH /api/settings/retention`.
 
+**Retention.** A third setting on the same page, `searchTrailRetention`
+(milliseconds, default `2592000000`, 30 days), says how long a trail entry is
+kept. The hourly `LogCleanUpTask` background job enforces it: entries are
+recorded without an expiry, so the job first stamps `expires` = `created` plus
+the retention on entries that have none, then deletes every entry whose expiry
+has passed. The same job tombstones expired audit trail rows; the two sweeps are
+independent, so a failure in one never skips the other. A value of `0` or lower
+keeps entries indefinitely. `POST /api/search-trails/cleanup` runs the same
+deletion on demand.
+
 **Standards**: BIO (audit logging), AVG/GDPR Article 30 (processing register context).
 
 ## Related Features

--- a/lib/BackgroundJob/LogCleanUpTask.php
+++ b/lib/BackgroundJob/LogCleanUpTask.php
@@ -3,8 +3,8 @@
 /**
  * OpenRegister Log Cleanup Task
  *
- * This file contains the background job for cleaning up expired audit trail logs
- * in the OpenRegister application.
+ * This file contains the background job that enforces the configured retention
+ * on the audit trail and the search trail in the OpenRegister application.
  *
  * SPDX-License-Identifier: EUPL-1.2
  * SPDX-FileCopyrightText: 2026 Conduction B.V.
@@ -21,16 +21,27 @@
 namespace OCA\OpenRegister\BackgroundJob;
 
 use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\SearchTrailMapper;
+use OCA\OpenRegister\Service\Settings\ObjectRetentionHandler;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJob;
 use OCP\BackgroundJob\TimedJob;
 use Psr\Log\LoggerInterface;
 
 /**
- * Background job for cleaning up expired audit trail logs
+ * Background job that enforces log retention
  *
- * This job runs periodically to remove expired audit trail entries from the database
- * to prevent the database from growing indefinitely and maintain performance.
+ * Runs hourly and performs two INDEPENDENT sweeps:
+ *
+ *   1. Audit trail: expired rows are tombstoned (payload destroyed, row and
+ *      hash-chain links kept) through AuditTrailMapper::clearLogs().
+ *   2. Search trail: rows past the configured `searchTrailRetention` are
+ *      deleted. Search trail rows are inserted WITHOUT an expiry, so the job
+ *      stamps `expires` first and sweeps second; before this job did that, the
+ *      retention setting was echoed to the admin UI and enforced by nothing,
+ *      the only caller of the sweep being a manual admin endpoint.
+ *
+ * A failure in one sweep is logged and never skips the other.
  *
  * @package OCA\OpenRegister\BackgroundJob
  *
@@ -39,11 +50,34 @@ use Psr\Log\LoggerInterface;
 class LogCleanUpTask extends TimedJob {
 
 	/**
+	 * Fallback search trail retention when the setting is absent: 30 days in milliseconds.
+	 *
+	 * Mirrors the default ObjectRetentionHandler::getRetentionSettingsOnly() serves.
+	 *
+	 * @var int
+	 */
+	private const DEFAULT_SEARCH_TRAIL_RETENTION_MS = 2592000000;
+
+	/**
 	 * The audit trail mapper for database operations
 	 *
 	 * @var AuditTrailMapper
 	 */
 	private readonly AuditTrailMapper $auditTrailMapper;
+
+	/**
+	 * The search trail mapper for database operations
+	 *
+	 * @var SearchTrailMapper
+	 */
+	private readonly SearchTrailMapper $searchTrailMapper;
+
+	/**
+	 * The retention settings handler that carries `searchTrailRetention`
+	 *
+	 * @var ObjectRetentionHandler
+	 */
+	private readonly ObjectRetentionHandler $retentionHandler;
 
 	/**
 	 * The logger for logging operations
@@ -55,21 +89,27 @@ class LogCleanUpTask extends TimedJob {
 	/**
 	 * Constructor for the LogCleanUpTask
 	 *
-	 * @param ITimeFactory $time The time factory for time operations
-	 * @param AuditTrailMapper $auditTrailMapper The audit trail mapper for database operations
-	 * @param LoggerInterface $logger The logger for logging operations
+	 * @param ITimeFactory           $time              The time factory for time operations
+	 * @param AuditTrailMapper       $auditTrailMapper  The audit trail mapper for database operations
+	 * @param SearchTrailMapper      $searchTrailMapper The search trail mapper for database operations
+	 * @param ObjectRetentionHandler $retentionHandler  The retention settings handler
+	 * @param LoggerInterface        $logger            The logger for logging operations
 	 *
 	 * @return void
 	 *
-	 * @spec openspec/specs/retention-management/spec.md
+	 * @spec openspec/specs/retention-management/spec.md#requirement-the-hourly-log-cleanup-job-must-enforce-the-configured-search-trail-retention
 	 */
 	public function __construct(
 		ITimeFactory $time,
 		AuditTrailMapper $auditTrailMapper,
+		SearchTrailMapper $searchTrailMapper,
+		ObjectRetentionHandler $retentionHandler,
 		LoggerInterface $logger,
 	) {
 		parent::__construct(time: $time);
 		$this->auditTrailMapper = $auditTrailMapper;
+		$this->searchTrailMapper = $searchTrailMapper;
+		$this->retentionHandler = $retentionHandler;
 		$this->logger = $logger;
 
 		// Run every hour (3600 seconds).
@@ -85,8 +125,9 @@ class LogCleanUpTask extends TimedJob {
 	/**
 	 * Execute the log cleanup task
 	 *
-	 * This method is called by the Nextcloud background job system to clean up
-	 * expired audit trail logs from the database.
+	 * Each sweep contains its own failures, so the order below is not a
+	 * dependency: the search trail sweep runs whether or not the audit sweep
+	 * succeeded, and vice versa.
 	 *
 	 * @param mixed $argument The job argument (not used in this implementation).
 	 *
@@ -94,9 +135,21 @@ class LogCleanUpTask extends TimedJob {
 	 *
 	 * @SuppressWarnings(PHPMD.UnusedFormalParameter)
 	 *
-	 * @spec openspec/specs/retention-management/spec.md
+	 * @spec openspec/specs/retention-management/spec.md#requirement-the-hourly-log-cleanup-job-must-enforce-the-configured-search-trail-retention
 	 */
 	protected function run($argument): void {
+		$this->clearAuditTrails();
+		$this->clearSearchTrails();
+	}//end run()
+
+	/**
+	 * Tombstone expired audit trail rows
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/retention-management/spec.md#requirement-the-hourly-log-cleanup-job-must-enforce-the-configured-search-trail-retention
+	 */
+	private function clearAuditTrails(): void {
 		try {
 			// Tombstone expired audit rows. Since or#2265 this destroys the
 			// payload and stamps `purged_at` rather than deleting the row, so
@@ -126,7 +179,7 @@ class LogCleanUpTask extends TimedJob {
 					'app' => 'openregister',
 				]
 			);
-		} catch (\Exception $e) {
+		} catch (\Throwable $e) {
 			// Log any errors that occur during cleanup.
 			$this->logger->error(
 				message: '[LogCleanUpTask] Failed to clear expired audit trail logs: ' . $e->getMessage(),
@@ -138,5 +191,76 @@ class LogCleanUpTask extends TimedJob {
 				]
 			);
 		}//end try
-	}//end run()
+	}//end clearAuditTrails()
+
+	/**
+	 * Delete search trail rows past the configured retention
+	 *
+	 * Two statements, in this order: stamp `expires` on rows that have none
+	 * (SearchTrailMapper::createSearchTrail() never sets it), then delete rows
+	 * whose `expires` has passed. A row stamped under an earlier retention
+	 * keeps that expiry, the same rule the audit trail follows. A non-positive
+	 * retention means "keep": nothing is stamped and nothing is deleted.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/retention-management/spec.md#requirement-the-hourly-log-cleanup-job-must-enforce-the-configured-search-trail-retention
+	 */
+	private function clearSearchTrails(): void {
+		try {
+			$settings = $this->retentionHandler->getRetentionSettingsOnly();
+			$retentionMs = (int) ($settings['searchTrailRetention'] ?? self::DEFAULT_SEARCH_TRAIL_RETENTION_MS);
+
+			if ($retentionMs <= 0) {
+				$this->logger->debug(
+					message: '[LogCleanUpTask] Search trail retention is not positive, search trails are kept',
+					context: [
+						'file' => __FILE__,
+						'line' => __LINE__,
+						'app' => 'openregister',
+						'searchTrailRetention' => $retentionMs,
+					]
+				);
+				return;
+			}
+
+			$stamped = $this->searchTrailMapper->setExpiryDate(retentionMs: $retentionMs);
+			$logsCleared = $this->searchTrailMapper->clearLogs();
+
+			if ($logsCleared === true) {
+				$this->logger->info(
+					message: '[LogCleanUpTask] Deleted search trail rows past the configured retention',
+					context: [
+						'file' => __FILE__,
+						'line' => __LINE__,
+						'app' => 'openregister',
+						'searchTrailRetention' => $retentionMs,
+						'newlyStamped' => $stamped,
+					]
+				);
+				return;
+			}
+
+			$this->logger->debug(
+				message: '[LogCleanUpTask] No expired search trail logs found to clear',
+				context: [
+					'file' => __FILE__,
+					'line' => __LINE__,
+					'app' => 'openregister',
+					'searchTrailRetention' => $retentionMs,
+					'newlyStamped' => $stamped,
+				]
+			);
+		} catch (\Throwable $e) {
+			$this->logger->error(
+				message: '[LogCleanUpTask] Failed to clear expired search trail logs: ' . $e->getMessage(),
+				context: [
+					'file' => __FILE__,
+					'line' => __LINE__,
+					'app' => 'openregister',
+					'exception' => $e,
+				]
+			);
+		}//end try
+	}//end clearSearchTrails()
 }//end class

--- a/lib/Contract/ObjectServiceInterface.php
+++ b/lib/Contract/ObjectServiceInterface.php
@@ -61,6 +61,12 @@ use OCP\IUser;
  * this contract. It is published because `updateObject()` REPLACES, so a
  * consumer holding a partial payload had no correct method to call and either
  * hand-rolled read-merge-write or silently erased the fields it omitted.
+ * `appendObjectsRaw()` and `purgeExpiredObjectsRaw()` were added 2026-09-04
+ * for the traffic-analytics collector, which writes thousands of rows a
+ * minute that no person edits: the normal save path's per-row RBAC, audit,
+ * validation and events are exactly the cost it cannot pay. They are the raw
+ * bulk path made reachable through the contract, and they carry the same
+ * responsibility model as `_rbac: false`.
  * The four it omits are omitted for a reason, and the ten classes they hold
  * back are listed rather than left to be discovered:
  *
@@ -132,7 +138,7 @@ use OCP\IUser;
  *
  * @SuppressWarnings(PHPMD.BooleanArgumentFlag)   RBAC and multitenancy flags — see above.
  * @SuppressWarnings(PHPMD.ExcessiveParameterList) Mirrors ObjectService::saveObject().
- * @SuppressWarnings(PHPMD.ExcessivePublicCount)  26 methods, measured — see Scope above.
+ * @SuppressWarnings(PHPMD.ExcessivePublicCount)  28 methods: 26 measured (see Scope above) plus the two raw entry points.
  */
 interface ObjectServiceInterface {
 
@@ -373,6 +379,41 @@ interface ObjectServiceInterface {
 		bool $enrich=true,
 		bool $_audit=true
 	): array;
+
+	/**
+	 * Append rows with every safeguard switched OFF.
+	 *
+	 * No RBAC, no multitenancy, no validation, no audit trail, no lifecycle
+	 * events, no search index, no relations, no files. Calling it is the same
+	 * declaration as `_rbac: false`: the caller has taken the authorisation
+	 * responsibility. It exists for high-volume, low-value rows such as traffic
+	 * events and telemetry; use saveObjects() for anything a person will edit,
+	 * audit or revert.
+	 *
+	 * Each row is a plain property map plus the optional metadata keys `uuid`
+	 * (generated when absent), `expires` (ISO 8601 or DateTimeInterface, swept
+	 * by purgeExpiredObjectsRaw()), `owner` and `organisation`.
+	 *
+	 * @param array      $objects  Rows to append, as plain arrays.
+	 * @param string|int $register Register id, uuid or slug.
+	 * @param string|int $schema   Schema id, uuid or slug, resolved within the register.
+	 *
+	 * @return int The number of rows written.
+	 */
+	public function appendObjectsRaw(array $objects, string|int $register, string|int $schema): int;
+
+	/**
+	 * Hard-delete the rows of a register+schema whose `expires` has passed.
+	 *
+	 * The sweep for appendObjectsRaw(). Bypasses soft-delete and the audit
+	 * trail on purpose: raw rows never had either.
+	 *
+	 * @param string|int $register Register id, uuid or slug.
+	 * @param string|int $schema   Schema id, uuid or slug, resolved within the register.
+	 *
+	 * @return int The number of rows removed.
+	 */
+	public function purgeExpiredObjectsRaw(string|int $register, string|int $schema): int;
 
 	/**
 	 * Run an operation with system privileges, bypassing user scoping.

--- a/lib/Contract/ObjectServiceInterface.php
+++ b/lib/Contract/ObjectServiceInterface.php
@@ -399,6 +399,16 @@ interface ObjectServiceInterface {
 	 * @param string|int $schema   Schema id, uuid or slug, resolved within the register.
 	 *
 	 * @return int The number of rows written.
+	 *
+	 * @contract-shift announced — openregister#3406 names the fleet test doubles that
+	 * must declare this method or fatal at class load: pipelinq
+	 * tests/Stubs/Service/ObjectService.php (with its paired
+	 * tests/Stubs/Contract/ObjectServiceInterface.php) and shillinq
+	 * tests/Unit/Service/Support/{InMemoryObjectServiceStub,DuckObjectServiceAdapter}.php.
+	 * createMock() sites are unaffected. The break lands on the
+	 * `conduction/hydra-gates` RELEASE carrying this contract, not on this
+	 * merge, because leaf apps read it from vendor/: land the doubles before
+	 * the release, or pin.
 	 */
 	public function appendObjectsRaw(array $objects, string|int $register, string|int $schema): int;
 
@@ -412,6 +422,16 @@ interface ObjectServiceInterface {
 	 * @param string|int $schema   Schema id, uuid or slug, resolved within the register.
 	 *
 	 * @return int The number of rows removed.
+	 *
+	 * @contract-shift announced — openregister#3406 names the fleet test doubles that
+	 * must declare this method or fatal at class load: pipelinq
+	 * tests/Stubs/Service/ObjectService.php (with its paired
+	 * tests/Stubs/Contract/ObjectServiceInterface.php) and shillinq
+	 * tests/Unit/Service/Support/{InMemoryObjectServiceStub,DuckObjectServiceAdapter}.php.
+	 * createMock() sites are unaffected. The break lands on the
+	 * `conduction/hydra-gates` RELEASE carrying this contract, not on this
+	 * merge, because leaf apps read it from vendor/: land the doubles before
+	 * the release, or pin.
 	 */
 	public function purgeExpiredObjectsRaw(string|int $register, string|int $schema): int;
 

--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -7529,6 +7529,36 @@ class MagicMapper extends AbstractObjectMapper {
 	}//end deleteObjectsBySchema()
 
 	/**
+	 * Hard-delete the rows of a register+schema table whose `_expires` has passed.
+	 *
+	 * The sweep for rows written through bulkUpsert() with an expiry, i.e. raw
+	 * appends. There is no soft-delete and no audit entry: those rows never had
+	 * either, and keeping expired telemetry as tombstones would defeat the
+	 * retention the expiry expresses. Rows with a NULL `_expires` are never
+	 * touched. A table that does not exist yet has nothing to purge and answers 0.
+	 *
+	 * @param Register $register The register context.
+	 * @param Schema   $schema   The schema context.
+	 *
+	 * @return int The number of rows removed.
+	 *
+	 * @throws Exception If the delete fails.
+	 *
+	 * @spec openspec/specs/data-import-export/spec.md#requirement-raw-append-for-high-volume-writers
+	 */
+	public function purgeExpired(Register $register, Schema $schema): int {
+		if ($this->tableExistsForRegisterSchema(register: $register, schema: $schema) === false) {
+			return 0;
+		}
+
+		return $this->bulkHandler->purgeExpired(
+			register: $register,
+			schema: $schema,
+			tableName: $this->getTableNameForRegisterSchema(register: $register, schema: $schema)
+		);
+	}//end purgeExpired()
+
+	/**
 	 * Batch delete objects by UUID list from a register+schema magic table.
 	 *
 	 * Performs a single SQL statement for all UUIDs instead of one-by-one.

--- a/lib/Db/MagicMapper/MagicBulkHandler.php
+++ b/lib/Db/MagicMapper/MagicBulkHandler.php
@@ -45,6 +45,7 @@ use Exception;
 use OCA\OpenRegister\Db\Register;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Service\DateTimeNormalizer;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -169,6 +170,7 @@ class MagicBulkHandler {
 			);
 
 			$preparedObject['_updated'] = $now->format('Y-m-d H:i:s');
+			$preparedObject = $this->withExpiry(prepared: $preparedObject, object: $object, selfData: $selfData);
 
 			$preparedObject['_name'] = $selfData['name'] ?? $object['name'] ?? null;
 			$preparedObject['_description'] = $selfData['description'] ?? $object['description'] ?? null;
@@ -223,6 +225,39 @@ class MagicBulkHandler {
 
 		return $prepared;
 	}//end prepareObjectsForDynamicTable()
+
+	/**
+	 * Copy an object's expiry into the prepared row's `_expires` column, when it has one.
+	 *
+	 * An expiry is METADATA, not a property: it lives in the metadata block
+	 * (`@self`, or the flat selfData shape whose properties sit under `object`)
+	 * and lands in the indexed `_expires` column that purgeExpired() sweeps. It
+	 * is deliberately NOT read from a bare property map: a schema is free to
+	 * declare its own `expires` property, and that must stay a plain data
+	 * column rather than silently scheduling the row for deletion. A row that
+	 * carries no expiry gets NO `_expires` key, so an upsert of an existing row
+	 * leaves its expiry alone; a row inserted without one keeps NULL and is
+	 * never purged.
+	 *
+	 * @param array $prepared The prepared row so far.
+	 * @param array $object   The object as passed to bulkUpsert().
+	 * @param array $selfData The object's metadata block.
+	 *
+	 * @return array The prepared row, with `_expires` set when the object carries an expiry.
+	 *
+	 * @spec openspec/specs/data-import-export/spec.md#requirement-raw-append-for-high-volume-writers
+	 */
+	private function withExpiry(array $prepared, array $object, array $selfData): array {
+		$hasMetadataBlock = (($object['@self'] ?? null) !== null || isset($object['object']) === true);
+		$expiresValue = $selfData['expires'] ?? null;
+		if ($expiresValue === null || $hasMetadataBlock === false) {
+			return $prepared;
+		}
+
+		$prepared['_expires'] = $this->formatDateTimeForDatabase(value: $expiresValue, default: null);
+
+		return $prepared;
+	}//end withExpiry()
 
 	/**
 	 * Calculate optimal chunk size for bulk operations
@@ -919,4 +954,50 @@ class MagicBulkHandler {
 		$formatted = $this->dateTimeNormalizer->formatForDatabase($value);
 		return $formatted ?? $default;
 	}//end formatDateTimeForDatabase()
+
+	/**
+	 * Hard-delete every row of a register+schema table whose `_expires` has passed.
+	 *
+	 * The counterpart of a raw append: rows written through `bulkUpsert()` with an
+	 * expiry carry no audit trail, so there is nothing to tombstone and nothing to
+	 * soft-delete. They are simply removed. Rows with a NULL `_expires` are never
+	 * touched, and the comparison is done by the database clock (`NOW()`), the
+	 * same clock that `SearchTrailMapper::clearLogs()` sweeps by, so a PHP/DB
+	 * timezone mismatch cannot widen the window.
+	 *
+	 * @param Register $register  The register context.
+	 * @param Schema   $schema    The schema context.
+	 * @param string   $tableName The bare (unprefixed) table name to sweep.
+	 *
+	 * @return int The number of rows removed.
+	 *
+	 * @throws \OCP\DB\Exception If the delete fails.
+	 *
+	 * @spec openspec/specs/data-import-export/spec.md#requirement-raw-append-for-high-volume-writers
+	 */
+	public function purgeExpired(Register $register, Schema $schema, string $tableName): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($tableName)
+			->where($qb->expr()->eq('_register', $qb->createNamedParameter($register->getId(), IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('_schema', $qb->createNamedParameter($schema->getId(), IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->isNotNull('_expires'))
+			->andWhere($qb->expr()->lt('_expires', $qb->createFunction('NOW()')));
+
+		$purged = $qb->executeStatement();
+
+		// Info, not debug: this is destruction, and the count is the only record of it.
+		$this->logger->info(
+			message: '[MagicBulkHandler] Purged expired raw rows',
+			context: [
+				'file' => __FILE__,
+				'line' => __LINE__,
+				'register' => $register->getId(),
+				'schema' => $schema->getId(),
+				'table' => $tableName,
+				'purged' => $purged,
+			]
+		);
+
+		return $purged;
+	}//end purgeExpired()
 }//end class

--- a/lib/Db/SearchTrailMapper.php
+++ b/lib/Db/SearchTrailMapper.php
@@ -1005,14 +1005,17 @@ class SearchTrailMapper extends QBMapper {
 			// Get the query builder.
 			$qb = $this->db->getQueryBuilder();
 
+			// DATE_ADD is MySQL/MariaDB only. Now that the hourly LogCleanUpTask
+			// calls this, a MySQL-only expression would fail every hour on a
+			// PostgreSQL install, so the interval is spelled per platform.
+			$expiresExpression = sprintf('DATE_ADD(created, INTERVAL %d SECOND)', $retentionSeconds);
+			if ($this->db->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\PostgreSQLPlatform) {
+				$expiresExpression = sprintf("created + INTERVAL '%d seconds'", $retentionSeconds);
+			}
+
 			// Update search trails that don't have an expiry date set.
 			$qb->update($this->getTableName())
-				->set(
-					'expires',
-					$qb->createFunction(
-						sprintf('DATE_ADD(created, INTERVAL %d SECOND)', $retentionSeconds)
-					)
-				)
+				->set('expires', $qb->createFunction($expiresExpression))
 				->where($qb->expr()->isNull('expires'));
 
 			// Execute the update and return number of affected rows.

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -4158,6 +4158,184 @@ class ObjectService implements ObjectServiceInterface
 
     }//end saveObjectsStreaming()
 
+
+    /**
+     * Append rows to a register+schema table with every safeguard switched OFF.
+     *
+     * THIS IS THE FAST PATH FOR HIGH-VOLUME, LOW-VALUE WRITERS such as traffic
+     * events and telemetry: chunked multi-row INSERT ... ON DUPLICATE KEY UPDATE
+     * statements straight into the magic table. It exists because the normal
+     * save path costs several queries and side effects PER ROW, and a collector
+     * receiving thousands of events a minute can afford neither.
+     *
+     * WHAT IS SKIPPED, on purpose and without exception:
+     *   - RBAC and multitenancy: nobody's permissions are checked. Rows carry
+     *     whatever `owner` / `organisation` the caller passes, or NULL, so they
+     *     may be invisible to tenant-scoped reads.
+     *   - Schema validation: property values are written as given. A value that
+     *     does not fit its column fails at the database; a property the table
+     *     has no column for is dropped.
+     *   - Audit trail: no create/update entry is written, so these rows have no
+     *     history, no revert and no hash chain.
+     *   - Lifecycle events: no ObjectCreated/ObjectUpdated events, so webhooks,
+     *     flows and the search index are not notified.
+     *   - Relations, files, computed fields, slugs, cascading and enrichment.
+     *
+     * THE CALLER TAKES THE AUTHORISATION RESPONSIBILITY. Calling this method is
+     * the same declaration as `_rbac: false` on the normal path (ADR-022): the
+     * caller has decided who may write here. Use saveObjects() for anything a
+     * person will edit, audit or revert.
+     *
+     * Each `$objects` entry is a plain associative array of property values,
+     * plus the optional metadata keys `uuid` (a v4 is generated when absent),
+     * `expires` (ISO 8601 string or DateTimeInterface; lands in the indexed
+     * `_expires` column that purgeExpiredObjectsRaw() sweeps), `owner` and
+     * `organisation`. `_created` and `_updated` are set to now. The service's
+     * current register/schema context is left untouched.
+     *
+     * @param array               $objects  Rows to append, as plain arrays.
+     * @param Register|string|int $register The register entity, id, uuid or slug.
+     * @param Schema|string|int   $schema   The schema entity, id, uuid or slug, resolved WITHIN the register.
+     *
+     * @return int The number of rows written.
+     *
+     * @throws OcpDoesNotExistException     When the register does not exist.
+     * @throws SchemaNotInRegisterException When the register does not carry the schema.
+     * @throws \OCP\DB\Exception            When the insert fails.
+     *
+     * @psalm-param   array<int, array<string, mixed>> $objects
+     * @phpstan-param array<int, array<string, mixed>> $objects
+     *
+     * @spec openspec/specs/data-import-export/spec.md#requirement-raw-append-for-high-volume-writers
+     */
+    public function appendObjectsRaw(array $objects, Register|string|int $register, Schema|string|int $schema): int
+    {
+        if ($objects === []) {
+            return 0;
+        }
+
+        [$registerEntity, $schemaEntity] = $this->resolveRawTarget(register: $register, schema: $schema);
+
+        $rows = array_map(
+            fn (array $object): array => $this->prepareRawRow(object: $object),
+            array_values($objects)
+        );
+
+        // The bulk upsert creates a missing table only after a failed statement;
+        // creating it up front keeps the first append on the same path as
+        // every later one.
+        $this->objectMapper->ensureTableForRegisterSchema(register: $registerEntity, schema: $schemaEntity);
+        $tableName = $this->objectMapper->getTableNameForRegisterSchema(register: $registerEntity, schema: $schemaEntity);
+
+        $written = $this->objectMapper->bulkUpsert(
+            objects: $rows,
+            register: $registerEntity,
+            schema: $schemaEntity,
+            tableName: $tableName,
+            needsPreUpdateState: false
+        );
+
+        return count($written);
+    }//end appendObjectsRaw()
+
+
+    /**
+     * Hard-delete the rows of a register+schema table whose expiry has passed.
+     *
+     * The sweep for appendObjectsRaw(). Rows with a NULL `_expires` are never
+     * touched. This BYPASSES soft-delete and the audit trail on purpose: raw
+     * rows never had an audit trail, so there is nothing to tombstone, and
+     * keeping expired telemetry as soft-deleted rows would defeat the
+     * retention the expiry expresses. Same responsibility model as the append:
+     * the caller has decided that this register+schema holds expiring raw rows.
+     *
+     * @param Register|string|int $register The register entity, id, uuid or slug.
+     * @param Schema|string|int   $schema   The schema entity, id, uuid or slug, resolved WITHIN the register.
+     *
+     * @return int The number of rows removed; 0 when the table does not exist yet.
+     *
+     * @throws OcpDoesNotExistException     When the register does not exist.
+     * @throws SchemaNotInRegisterException When the register does not carry the schema.
+     * @throws \OCP\DB\Exception            When the delete fails.
+     *
+     * @spec openspec/specs/data-import-export/spec.md#requirement-raw-append-for-high-volume-writers
+     */
+    public function purgeExpiredObjectsRaw(Register|string|int $register, Schema|string|int $schema): int
+    {
+        [$registerEntity, $schemaEntity] = $this->resolveRawTarget(register: $register, schema: $schema);
+
+        return $this->objectMapper->purgeExpired(register: $registerEntity, schema: $schemaEntity);
+    }//end purgeExpiredObjectsRaw()
+
+
+    /**
+     * Resolve a register and a schema for a raw operation without touching the service context.
+     *
+     * The register is the boundary: the schema is resolved among the schemas the
+     * register carries, never instance-wide, exactly as setRegister()/setSchema()
+     * do. Unlike those setters nothing is stored on `$this`, so a raw write from
+     * a background job cannot leak a register or a pending schema ref into the
+     * next caller's chain.
+     *
+     * @param Register|string|int $register The register entity, id, uuid or slug.
+     * @param Schema|string|int   $schema   The schema entity, id, uuid or slug.
+     *
+     * @return array{0: Register, 1: Schema} The resolved pair.
+     *
+     * @throws OcpDoesNotExistException     When the register does not exist.
+     * @throws SchemaNotInRegisterException When the register does not carry the schema.
+     *
+     * @spec openspec/specs/data-import-export/spec.md#requirement-raw-append-for-high-volume-writers
+     */
+    private function resolveRawTarget(Register|string|int $register, Schema|string|int $schema): array
+    {
+        if (($register instanceof Register) === false) {
+            $register = $this->registerMapper->find(id: $register, _rbac: false, _multitenancy: false);
+        }
+
+        if (($schema instanceof Schema) === false) {
+            $schema = $this->scopedSchemaResolver->resolveSchemaWithin(register: $register, schemaRef: $schema);
+        }
+
+        return [$register, $schema];
+    }//end resolveRawTarget()
+
+
+    /**
+     * Shape one caller-supplied row for the bulk handler.
+     *
+     * Metadata moves into `@self`, which is where the handler reads it from;
+     * everything else stays a property. Keys the caller did not pass are left
+     * to the handler's defaults: NULL owner and organisation, no expiry.
+     *
+     * @param array<string, mixed> $object A plain row as passed to appendObjectsRaw().
+     *
+     * @return array<string, mixed> The row in the handler's `@self` + properties shape.
+     *
+     * @spec openspec/specs/data-import-export/spec.md#requirement-raw-append-for-high-volume-writers
+     */
+    private function prepareRawRow(array $object): array
+    {
+        $self = ['uuid' => (string) ($object['uuid'] ?? Uuid::v4()->toRfc4122())];
+
+        foreach (['expires', 'owner', 'organisation'] as $metadataKey) {
+            if (array_key_exists($metadataKey, $object) === true) {
+                $self[$metadataKey] = $object[$metadataKey];
+            }
+        }
+
+        unset(
+            $object['uuid'],
+            $object['expires'],
+            $object['owner'],
+            $object['organisation'],
+            $object['@self'],
+            $object['object']
+        );
+
+        return ['@self' => $self] + $object;
+    }//end prepareRawRow()
+
     /**
      * Transform objects from serialized format to database format
      *

--- a/openspec/specs/data-import-export/spec.md
+++ b/openspec/specs/data-import-export/spec.md
@@ -796,6 +796,45 @@ size-guard its input, and any cap applied SHALL be logged, never silent.
 - **THEN** its content is not loaded into memory
 - **AND** it is skipped with a logged, non-fatal outcome
 
+### Requirement: Raw append for high-volume writers
+
+The object service SHALL offer a raw append entry point, `appendObjectsRaw()`,
+for high-volume, low-value rows such as traffic events and telemetry, and a
+matching sweep, `purgeExpiredObjectsRaw()`. The raw append SHALL write straight
+into the register+schema table in chunked multi-row statements and SHALL skip
+RBAC, multitenancy, schema validation, the audit trail, lifecycle events, the
+search index, relations and files. The caller takes the authorisation
+responsibility, as with `_rbac: false` (ADR-022). Both entry points SHALL be
+part of `ObjectServiceInterface` so a leaf app can reach them without
+OpenRegister internals, and neither SHALL alter the service's current
+register/schema context.
+
+#### Scenario: Rows are appended without side effects @e2e exclude server-side PHP API with no UI, covered by the PHPUnit DB test tests/Db/RawAppendIntegrationTest.php
+- **GIVEN** a register and a schema the register carries
+- **WHEN** a caller passes three plain property maps to `appendObjectsRaw()`
+- **THEN** the register+schema table holds three rows, each with a uuid (generated when the caller passed none)
+- **AND** no audit trail entry, lifecycle event or search-index update is produced for them
+- **AND** the return value is the number of rows written
+
+#### Scenario: An expiry lands in the indexed expires column @e2e exclude server-side PHP API with no UI, covered by the PHPUnit DB test tests/Db/RawAppendIntegrationTest.php
+- **GIVEN** a row passed with an `expires` value
+- **WHEN** it is appended
+- **THEN** the row's `_expires` column holds that instant
+- **AND** a row passed without `expires` keeps `_expires` NULL
+
+#### Scenario: Expired rows are hard-deleted by the purge @e2e exclude server-side PHP API with no UI, covered by the PHPUnit DB test tests/Db/RawAppendIntegrationTest.php
+- **GIVEN** three appended rows of which one has an `expires` in the past
+- **WHEN** `purgeExpiredObjectsRaw()` runs for that register and schema
+- **THEN** exactly that row is removed, with no soft-delete marker and no audit entry
+- **AND** the return value is 1
+- **AND** a register+schema whose table does not exist yet answers 0
+
+#### Scenario: Identifiers resolve within the register @e2e exclude server-side PHP API with no UI, covered by the PHPUnit unit test tests/Unit/Service/ObjectServiceRawAppendTest.php
+- **GIVEN** a register slug and a schema slug
+- **WHEN** either raw entry point is called with them
+- **THEN** the schema is resolved among the schemas that register carries, never instance-wide
+- **AND** the service's current register and schema context is unchanged afterwards
+
 ### Requirement: Auto-create a missing register from a bundle (REQ-IMP-AC-01)
 
 The register-bundle import MUST create a missing register and its referenced

--- a/openspec/specs/retention-management/spec.md
+++ b/openspec/specs/retention-management/spec.md
@@ -256,6 +256,29 @@ Administrators MUST be able to configure retention-related settings through the 
 - **THEN** the settings MUST be persisted in app configuration
 - **AND** the DestructionCheckJob interval MUST be updated if `destructionCheckInterval` changed
 
+### Requirement: The hourly log cleanup job MUST enforce the configured search trail retention
+
+`LogCleanUpTask` runs hourly and MUST enforce `searchTrailRetention` (milliseconds, default `2592000000`, 30 days) on the search trail table, alongside the audit trail sweep it already performs. Search trail rows are inserted without an expiry, so the job MUST first stamp `expires` = `created` + retention on rows that have none, and then delete the rows whose `expires` has passed. The two sweeps MUST be independent: a failure in one MUST be logged and MUST NOT prevent the other from running, and each MUST log its own outcome. Before this requirement the setting was echoed to the admin UI and enforced by nothing; the only caller of the sweep was a manual admin endpoint.
+
+#### Scenario: Search trails past retention are deleted by the hourly job @e2e exclude hourly background job with no UI, covered by tests/Unit/BackgroundJob/LogCleanUpTaskTest.php
+- **GIVEN** `searchTrailRetention` is configured, or left at its default
+- **AND** search trail rows exist whose `created` plus the retention lies in the past
+- **WHEN** `LogCleanUpTask` runs
+- **THEN** rows without an `expires` are stamped `created` + retention
+- **AND** rows whose `expires` has passed are deleted
+- **AND** the job logs the outcome of the search trail sweep separately from the audit trail sweep
+
+#### Scenario: A failing audit sweep does not skip the search trail sweep @e2e exclude hourly background job with no UI, covered by tests/Unit/BackgroundJob/LogCleanUpTaskTest.php
+- **GIVEN** the audit trail sweep throws
+- **WHEN** `LogCleanUpTask` runs
+- **THEN** the error is logged
+- **AND** the search trail sweep still runs, and a throwing search trail sweep likewise leaves the audit sweep's outcome intact
+
+#### Scenario: A non-positive retention keeps search trails @e2e exclude hourly background job with no UI, covered by tests/Unit/BackgroundJob/LogCleanUpTaskTest.php
+- **GIVEN** `searchTrailRetention` is `0` or negative
+- **WHEN** `LogCleanUpTask` runs
+- **THEN** no expiry is stamped and nothing is deleted from the search trail table
+
 ### Requirement: Cascading destruction MUST respect referential integrity
 When an object is destroyed via an approved destruction list, the system MUST evaluate related objects according to the existing referential integrity cascade rules.
 

--- a/tests/Db/RawAppendIntegrationTest.php
+++ b/tests/Db/RawAppendIntegrationTest.php
@@ -7,8 +7,19 @@
  * table, `_expires` really holds the expiry, and the purge really removes
  * only what has expired, with no audit trail written for any of it.
  *
- * @category Test
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Tests
  * @package  OCA\OpenRegister\Tests\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenRegister.app
  */
 
 namespace OCA\OpenRegister\Tests\Db;

--- a/tests/Db/RawAppendIntegrationTest.php
+++ b/tests/Db/RawAppendIntegrationTest.php
@@ -1,0 +1,218 @@
+<?php
+
+/**
+ * Integration tests for the raw append and expiry purge on ObjectService.
+ *
+ * Runs against a live database: rows really land in the register+schema
+ * table, `_expires` really holds the expiry, and the purge really removes
+ * only what has expired, with no audit trail written for any of it.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Db
+ */
+
+namespace OCA\OpenRegister\Tests\Db;
+
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group DB
+ */
+class RawAppendIntegrationTest extends TestCase {
+	private ObjectService $objectService;
+	private MagicMapper $mapper;
+	private RegisterMapper $registerMapper;
+	private SchemaMapper $schemaMapper;
+	private IDBConnection $db;
+
+	/** @var int[] IDs of schemas created during tests */
+	private array $createdSchemaIds = [];
+	/** @var int[] IDs of registers created during tests */
+	private array $createdRegisterIds = [];
+	/** @var string[] Prefixed names of magic tables created during tests */
+	private array $createdTables = [];
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->objectService = \OC::$server->get(ObjectService::class);
+		$this->mapper = \OC::$server->get(MagicMapper::class);
+		$this->registerMapper = \OC::$server->get(RegisterMapper::class);
+		$this->schemaMapper = \OC::$server->get(SchemaMapper::class);
+		$this->db = \OC::$server->get(IDBConnection::class);
+	}
+
+	protected function tearDown(): void {
+		foreach ($this->createdTables as $tableName) {
+			try {
+				$this->db->prepare("DROP TABLE IF EXISTS $tableName")->execute();
+			} catch (\Exception $e) {
+				// Table may not exist
+			}
+		}
+
+		foreach ($this->createdSchemaIds as $id) {
+			try {
+				$qb = $this->db->getQueryBuilder();
+				$qb->delete('openregister_schemas')
+					->where($qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
+				$qb->executeStatement();
+			} catch (\Exception $e) {
+				// Already cleaned up
+			}
+		}
+
+		foreach ($this->createdRegisterIds as $id) {
+			try {
+				$qb = $this->db->getQueryBuilder();
+				$qb->delete('openregister_registers')
+					->where($qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
+				$qb->executeStatement();
+			} catch (\Exception $e) {
+				// Already cleaned up
+			}
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Create a schema with a couple of plain properties.
+	 */
+	private function createTestSchema(): Schema {
+		$schema = $this->schemaMapper->createFromArray([
+			'title' => 'PHPUnit Raw Append Schema ' . uniqid(),
+			'description' => 'Schema for raw append integration tests',
+			'properties' => [
+				'name' => ['type' => 'string', 'title' => 'Name', 'maxLength' => 255],
+				'pagePath' => ['type' => 'string', 'title' => 'Page path', 'maxLength' => 512],
+				'hits' => ['type' => 'integer', 'title' => 'Hits'],
+			],
+		]);
+		$this->createdSchemaIds[] = $schema->getId();
+
+		return $schema;
+	}
+
+	/**
+	 * Create a register that carries the given schema, so slugs resolve within it.
+	 */
+	private function createTestRegister(Schema $schema): Register {
+		$register = $this->registerMapper->createFromArray([
+			'title' => 'PHPUnit Raw Append Register ' . uniqid(),
+			'description' => 'Register for raw append integration tests',
+			'schemas' => [$schema->getId()],
+		]);
+		$this->createdRegisterIds[] = $register->getId();
+
+		return $register;
+	}
+
+	private function trackTable(Register $register, Schema $schema): string {
+		$tableName = $this->mapper->getTableNameForRegisterSchema($register, $schema);
+		$this->createdTables[] = 'oc_' . $tableName;
+
+		return $tableName;
+	}
+
+	/**
+	 * Read `_uuid` => `_expires` for every row in the table.
+	 *
+	 * @return array<string, string|null>
+	 */
+	private function rowsByUuid(string $tableName): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('_uuid', '_expires')->from($tableName);
+		$result = $qb->executeQuery();
+		$rows = [];
+		while (($row = $result->fetch()) !== false) {
+			$rows[$row['_uuid']] = $row['_expires'];
+		}
+
+		$result->closeCursor();
+
+		return $rows;
+	}
+
+	private function countAuditRowsFor(array $uuids): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select($qb->func()->count('id', 'cnt'))
+			->from('openregister_audit_trails')
+			->where($qb->expr()->in('object', $qb->createNamedParameter($uuids, IQueryBuilder::PARAM_STR_ARRAY)));
+		$result = $qb->executeQuery();
+		$count = (int) $result->fetchOne();
+		$result->closeCursor();
+
+		return $count;
+	}
+
+	public function testAppendThenPurgeRemovesOnlyTheExpiredRow(): void {
+		$schema = $this->createTestSchema();
+		$register = $this->createTestRegister($schema);
+		$tableName = $this->trackTable($register, $schema);
+
+		$written = $this->objectService->appendObjectsRaw(
+			objects: [
+				['uuid' => 'raw-expired', 'expires' => (new \DateTimeImmutable('-1 day'))->format(DATE_ATOM), 'name' => 'page_view', 'pagePath' => '/old', 'hits' => 1],
+				['uuid' => 'raw-future', 'expires' => (new \DateTimeImmutable('+1 day'))->format(DATE_ATOM), 'name' => 'page_view', 'pagePath' => '/new', 'hits' => 2],
+				['uuid' => 'raw-forever', 'name' => 'scroll', 'pagePath' => '/keep', 'hits' => 3],
+			],
+			register: $register,
+			schema: $schema
+		);
+
+		$this->assertSame(3, $written);
+
+		$rows = $this->rowsByUuid($tableName);
+		$uuids = array_keys($rows);
+		sort($uuids);
+		$this->assertSame(['raw-expired', 'raw-forever', 'raw-future'], $uuids);
+		$this->assertNotNull($rows['raw-expired'], 'An expiry passed by the caller lands in _expires.');
+		$this->assertNotNull($rows['raw-future']);
+		$this->assertNull($rows['raw-forever'], 'A row without an expiry keeps _expires NULL.');
+
+		// No audit trail for raw rows: that is the contract.
+		$this->assertSame(0, $this->countAuditRowsFor(['raw-expired', 'raw-future', 'raw-forever']));
+
+		$purged = $this->objectService->purgeExpiredObjectsRaw(register: $register, schema: $schema);
+		$this->assertSame(1, $purged);
+
+		$remaining = $this->rowsByUuid($tableName);
+		$this->assertArrayNotHasKey('raw-expired', $remaining);
+		$this->assertArrayHasKey('raw-future', $remaining);
+		$this->assertArrayHasKey('raw-forever', $remaining);
+
+		// Idempotent: a second sweep finds nothing.
+		$this->assertSame(0, $this->objectService->purgeExpiredObjectsRaw(register: $register, schema: $schema));
+	}
+
+	public function testSlugsResolveWithinTheRegister(): void {
+		$schema = $this->createTestSchema();
+		$register = $this->createTestRegister($schema);
+		$tableName = $this->trackTable($register, $schema);
+
+		$written = $this->objectService->appendObjectsRaw(
+			objects: [['name' => 'page_view', 'pagePath' => '/slug', 'hits' => 1]],
+			register: $register->getSlug(),
+			schema: $schema->getSlug()
+		);
+
+		$this->assertSame(1, $written);
+		$this->assertCount(1, $this->rowsByUuid($tableName));
+	}
+
+	public function testPurgeOnASchemaNothingWasAppendedToAnswersZero(): void {
+		$schema = $this->createTestSchema();
+		$register = $this->createTestRegister($schema);
+		$this->trackTable($register, $schema);
+
+		$this->assertSame(0, $this->objectService->purgeExpiredObjectsRaw(register: $register, schema: $schema));
+	}
+}

--- a/tests/Unit/BackgroundJob/LogCleanUpTaskTest.php
+++ b/tests/Unit/BackgroundJob/LogCleanUpTaskTest.php
@@ -1,5 +1,23 @@
 <?php
 
+/**
+ * LogCleanUpTask tests: the hourly audit trail and search trail retention sweeps.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Tests
+ * @package  Unit\BackgroundJob
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenRegister.app
+ */
+
 declare(strict_types=1);
 
 namespace Unit\BackgroundJob;

--- a/tests/Unit/BackgroundJob/LogCleanUpTaskTest.php
+++ b/tests/Unit/BackgroundJob/LogCleanUpTaskTest.php
@@ -6,6 +6,8 @@ namespace Unit\BackgroundJob;
 
 use OCA\OpenRegister\BackgroundJob\LogCleanUpTask;
 use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\SearchTrailMapper;
+use OCA\OpenRegister\Service\Settings\ObjectRetentionHandler;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJob;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -13,20 +15,45 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 class LogCleanUpTaskTest extends TestCase {
+	private const THIRTY_DAYS_MS = 2592000000;
+
 	private LogCleanUpTask $task;
 	private AuditTrailMapper&MockObject $auditTrailMapper;
+	private SearchTrailMapper&MockObject $searchTrailMapper;
+	private ObjectRetentionHandler&MockObject $retentionHandler;
 	private LoggerInterface&MockObject $logger;
+
+	/** @var array<int, array{level: string, message: string, context: array}> */
+	private array $logged = [];
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$timeFactory = $this->createMock(ITimeFactory::class);
 		$this->auditTrailMapper = $this->createMock(AuditTrailMapper::class);
+		$this->searchTrailMapper = $this->createMock(SearchTrailMapper::class);
+		$this->retentionHandler = $this->createMock(ObjectRetentionHandler::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+
+		// Default: the shipped retention, read the way the settings page reads it.
+		$this->retentionHandler->method('getRetentionSettingsOnly')
+			->willReturn(['searchTrailRetention' => self::THIRTY_DAYS_MS]);
+
+		// Record every log line so a test can assert on the SET of outcomes.
+		$this->logged = [];
+		foreach (['info', 'debug', 'error', 'warning'] as $level) {
+			$this->logger->method($level)->willReturnCallback(
+				function (string $message, array $context = []) use ($level): void {
+					$this->logged[] = ['level' => $level, 'message' => $message, 'context' => $context];
+				}
+			);
+		}
 
 		$this->task = new LogCleanUpTask(
 			$timeFactory,
 			$this->auditTrailMapper,
+			$this->searchTrailMapper,
+			$this->retentionHandler,
 			$this->logger,
 		);
 	}
@@ -36,6 +63,18 @@ class LogCleanUpTaskTest extends TestCase {
 		$method = $reflection->getMethod('run');
 		$method->setAccessible(true);
 		$method->invoke($this->task, $argument);
+	}
+
+	/**
+	 * Messages logged at a level, in order.
+	 *
+	 * @return string[]
+	 */
+	private function messagesAt(string $level): array {
+		return array_values(array_map(
+			fn (array $entry): string => $entry['message'],
+			array_filter($this->logged, fn (array $entry): bool => $entry['level'] === $level)
+		));
 	}
 
 	public function testConstructorSetsInterval(): void {
@@ -62,92 +101,150 @@ class LogCleanUpTaskTest extends TestCase {
 		$this->assertFalse($property->getValue($this->task));
 	}
 
-	public function testRunClearsLogsSuccessfully(): void {
-		$this->auditTrailMapper->expects($this->once())
-			->method('clearLogs')
-			->willReturn(true);
+	public function testRunSweepsBothTrailsAndLogsEachOutcome(): void {
+		$this->auditTrailMapper->expects($this->once())->method('clearLogs')->willReturn(true);
 
-		// Since or#2265 the sweep TOMBSTONES rather than deletes: the payload
-		// is destroyed but the row and its hash links survive, so the chain
-		// stays verifiable across a lawful purge. The log line says so.
-		$this->logger->expects($this->once())
-			->method('info')
-			->with(
-				$this->stringContains('Tombstoned expired audit trail rows'),
-				$this->anything()
-			);
-
-		$this->logger->expects($this->never())->method('debug');
-		$this->logger->expects($this->never())->method('error');
+		// Search trail rows are inserted without an expiry: stamp first, sweep second.
+		$this->searchTrailMapper->expects($this->once())
+			->method('setExpiryDate')
+			->with(self::THIRTY_DAYS_MS)
+			->willReturn(5);
+		$this->searchTrailMapper->expects($this->once())->method('clearLogs')->willReturn(true);
 
 		$this->runTask(null);
+
+		$info = $this->messagesAt('info');
+		$this->assertCount(2, $info, 'Each sweep logs its own outcome.');
+		// Since or#2265 the audit sweep TOMBSTONES rather than deletes: the
+		// payload is destroyed but the row and its hash links survive.
+		$this->assertStringContainsString('Tombstoned expired audit trail rows', $info[0]);
+		$this->assertStringContainsString('Deleted search trail rows past the configured retention', $info[1]);
+		$this->assertSame([], $this->messagesAt('error'));
+		$this->assertSame([], $this->messagesAt('debug'));
+
+		$searchContext = $this->logged[1]['context'];
+		$this->assertSame(self::THIRTY_DAYS_MS, $searchContext['searchTrailRetention']);
+		$this->assertSame(5, $searchContext['newlyStamped']);
 	}
 
 	public function testRunNoExpiredLogs(): void {
-		$this->auditTrailMapper->expects($this->once())
-			->method('clearLogs')
-			->willReturn(false);
-
-		$this->logger->expects($this->never())->method('info');
-
-		$this->logger->expects($this->once())
-			->method('debug')
-			->with(
-				$this->stringContains('No expired audit trail logs found'),
-				$this->anything()
-			);
+		$this->auditTrailMapper->expects($this->once())->method('clearLogs')->willReturn(false);
+		$this->searchTrailMapper->method('setExpiryDate')->willReturn(0);
+		$this->searchTrailMapper->expects($this->once())->method('clearLogs')->willReturn(false);
 
 		$this->runTask(null);
+
+		$this->assertSame([], $this->messagesAt('info'));
+		$debug = $this->messagesAt('debug');
+		$this->assertCount(2, $debug);
+		$this->assertStringContainsString('No expired audit trail logs found', $debug[0]);
+		$this->assertStringContainsString('No expired search trail logs found', $debug[1]);
 	}
 
-	public function testRunHandlesException(): void {
+	public function testAFailingAuditSweepDoesNotSkipTheSearchTrailSweep(): void {
 		$exception = new \Exception('Database connection failed');
-
 		$this->auditTrailMapper->expects($this->once())
 			->method('clearLogs')
 			->willThrowException($exception);
 
-		$this->logger->expects($this->once())
-			->method('error')
-			->with(
-				$this->stringContains('Failed to clear expired audit trail logs: Database connection failed'),
-				$this->callback(function (array $context) use ($exception) {
-					return $context['exception'] === $exception
-						&& $context['app'] === 'openregister';
-				})
-			);
+		$this->searchTrailMapper->expects($this->once())->method('setExpiryDate')->willReturn(0);
+		$this->searchTrailMapper->expects($this->once())->method('clearLogs')->willReturn(true);
 
 		$this->runTask(null);
+
+		$errors = $this->messagesAt('error');
+		$this->assertCount(1, $errors);
+		$this->assertStringContainsString('Failed to clear expired audit trail logs: Database connection failed', $errors[0]);
+
+		$errorContext = array_values(array_filter($this->logged, fn (array $e): bool => $e['level'] === 'error'))[0]['context'];
+		$this->assertSame($exception, $errorContext['exception']);
+		$this->assertSame('openregister', $errorContext['app']);
+
+		$this->assertStringContainsString('Deleted search trail rows', $this->messagesAt('info')[0]);
 	}
 
-	public function testRunHandlesRuntimeException(): void {
-		$this->auditTrailMapper->expects($this->once())
-			->method('clearLogs')
+	public function testAFailingSearchTrailSweepLeavesTheAuditOutcomeIntact(): void {
+		$this->auditTrailMapper->expects($this->once())->method('clearLogs')->willReturn(true);
+		$this->searchTrailMapper->expects($this->once())
+			->method('setExpiryDate')
 			->willThrowException(new \RuntimeException('Timeout'));
-
-		$this->logger->expects($this->once())
-			->method('error')
-			->with(
-				$this->stringContains('Timeout'),
-				$this->anything()
-			);
+		$this->searchTrailMapper->expects($this->never())->method('clearLogs');
 
 		$this->runTask(null);
+
+		$this->assertStringContainsString('Tombstoned expired audit trail rows', $this->messagesAt('info')[0]);
+		$errors = $this->messagesAt('error');
+		$this->assertCount(1, $errors);
+		$this->assertStringContainsString('Failed to clear expired search trail logs: Timeout', $errors[0]);
 	}
 
-	public function testRunWithNullArgument(): void {
-		$this->auditTrailMapper->expects($this->once())
-			->method('clearLogs')
-			->willReturn(true);
+	public function testTheConfiguredRetentionIsWhatTheMapperIsToldToStamp(): void {
+		// Stored JSON may hand the value back as a string; the job normalises it.
+		$handler = $this->createMock(ObjectRetentionHandler::class);
+		$handler->method('getRetentionSettingsOnly')->willReturn(['searchTrailRetention' => '86400000']);
+		$task = new LogCleanUpTask(
+			$this->createMock(ITimeFactory::class),
+			$this->auditTrailMapper,
+			$this->searchTrailMapper,
+			$handler,
+			$this->logger,
+		);
 
-		// Should not throw regardless of argument value
-		$this->runTask(null);
+		$this->searchTrailMapper->expects($this->once())->method('setExpiryDate')->with(86400000)->willReturn(1);
+		$this->searchTrailMapper->method('clearLogs')->willReturn(false);
+
+		$method = (new \ReflectionClass($task))->getMethod('run');
+		$method->setAccessible(true);
+		$method->invoke($task, null);
+	}
+
+	public function testANonPositiveRetentionKeepsSearchTrails(): void {
+		$handler = $this->createMock(ObjectRetentionHandler::class);
+		$handler->method('getRetentionSettingsOnly')->willReturn(['searchTrailRetention' => 0]);
+		$task = new LogCleanUpTask(
+			$this->createMock(ITimeFactory::class),
+			$this->auditTrailMapper,
+			$this->searchTrailMapper,
+			$handler,
+			$this->logger,
+		);
+
+		$this->searchTrailMapper->expects($this->never())->method('setExpiryDate');
+		$this->searchTrailMapper->expects($this->never())->method('clearLogs');
+		$this->auditTrailMapper->expects($this->once())->method('clearLogs')->willReturn(false);
+
+		$method = (new \ReflectionClass($task))->getMethod('run');
+		$method->setAccessible(true);
+		$method->invoke($task, null);
+
+		$this->assertStringContainsString('search trails are kept', $this->messagesAt('debug')[1]);
+	}
+
+	public function testAnUnreadableSettingIsLoggedAndTheAuditSweepStillRuns(): void {
+		$handler = $this->createMock(ObjectRetentionHandler::class);
+		$handler->method('getRetentionSettingsOnly')->willThrowException(new \RuntimeException('Failed to retrieve Retention settings'));
+		$task = new LogCleanUpTask(
+			$this->createMock(ITimeFactory::class),
+			$this->auditTrailMapper,
+			$this->searchTrailMapper,
+			$handler,
+			$this->logger,
+		);
+
+		$this->auditTrailMapper->expects($this->once())->method('clearLogs')->willReturn(true);
+		$this->searchTrailMapper->expects($this->never())->method('setExpiryDate');
+
+		$method = (new \ReflectionClass($task))->getMethod('run');
+		$method->setAccessible(true);
+		$method->invoke($task, null);
+
+		$this->assertCount(1, $this->messagesAt('error'));
+		$this->assertStringContainsString('Failed to retrieve Retention settings', $this->messagesAt('error')[0]);
 	}
 
 	public function testRunWithArrayArgument(): void {
-		$this->auditTrailMapper->expects($this->once())
-			->method('clearLogs')
-			->willReturn(false);
+		$this->auditTrailMapper->expects($this->once())->method('clearLogs')->willReturn(false);
+		$this->searchTrailMapper->method('clearLogs')->willReturn(false);
 
 		// Should not throw regardless of argument value
 		$this->runTask(['some' => 'data']);

--- a/tests/Unit/Db/MagicBulkHandlerRawAppendTest.php
+++ b/tests/Unit/Db/MagicBulkHandlerRawAppendTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Unit tests for the raw-append side of MagicBulkHandler.
+ *
+ * Two things are pinned here. First, that an expiry in the metadata block
+ * lands in `_expires`, and that a bare property called `expires` does NOT:
+ * a schema may declare that property, and mapping it would silently
+ * schedule the row for deletion. Second, that purgeExpired() deletes by
+ * register, schema and a passed `_expires`, and reports the count.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Db
+ */
+
+namespace Unit\Db;
+
+use OCA\OpenRegister\Db\MagicMapper\MagicBulkHandler;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Service\DateTimeNormalizer;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionMethod;
+
+class MagicBulkHandlerRawAppendTest extends TestCase {
+
+	private IDBConnection&MockObject $db;
+
+	private MagicBulkHandler $handler;
+
+	private Register $register;
+
+	private Schema $schema;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->db = $this->createMock(IDBConnection::class);
+		$logger = $this->createMock(LoggerInterface::class);
+
+		// A REAL normaliser: the point of the expiry test is the stored format.
+		$this->handler = new MagicBulkHandler(
+			$this->db,
+			$logger,
+			$this->createMock(IEventDispatcher::class),
+			new DateTimeNormalizer($logger),
+			$this->createMock(IConfig::class)
+		);
+
+		$this->register = new Register();
+		$this->register->setId(11);
+
+		$this->schema = new Schema();
+		$this->schema->setId(22);
+	}
+
+	/**
+	 * Run the private row preparation on one object.
+	 */
+	private function prepare(array $object): array {
+		$method = new ReflectionMethod(MagicBulkHandler::class, 'prepareObjectsForDynamicTable');
+		$method->setAccessible(true);
+
+		$prepared = $method->invoke($this->handler, [$object], $this->register, $this->schema);
+
+		return $prepared[0];
+	}
+
+	public function testAnExpiryInTheMetadataBlockLandsInTheExpiresColumn(): void {
+		// Midday, so the calendar date survives any server timezone.
+		$row = $this->prepare([
+			'@self' => ['uuid' => 'u-1', 'expires' => '2026-01-01T12:00:00+00:00'],
+			'name' => 'page_view',
+		]);
+
+		$this->assertSame('u-1', $row['_uuid']);
+		$this->assertArrayHasKey('_expires', $row);
+		$this->assertMatchesRegularExpression('/^2026-01-01 \d{2}:\d{2}:\d{2}$/', $row['_expires']);
+		$this->assertSame('page_view', $row['name']);
+	}
+
+	public function testAFlatMetadataRowAlsoCarriesItsExpiry(): void {
+		$row = $this->prepare([
+			'uuid' => 'u-2',
+			'expires' => new \DateTimeImmutable('2027-06-15 12:00:00', new \DateTimeZone('UTC')),
+			'object' => ['name' => 'scroll'],
+		]);
+
+		$this->assertSame('u-2', $row['_uuid']);
+		$this->assertMatchesRegularExpression('/^2027-06-15 \d{2}:\d{2}:\d{2}$/', $row['_expires']);
+		$this->assertSame('scroll', $row['name']);
+	}
+
+	public function testABarePropertyCalledExpiresStaysAProperty(): void {
+		$row = $this->prepare(['uuid' => 'u-3', 'expires' => '2026-01-01T12:00:00+00:00', 'name' => 'licence']);
+
+		$this->assertArrayNotHasKey('_expires', $row, 'A schema property named expires must not schedule the row for purge.');
+		$this->assertSame('2026-01-01T12:00:00+00:00', $row['expires']);
+	}
+
+	public function testNoExpiryMeansNoExpiresKeyAtAll(): void {
+		// Absent, not null: an upsert of an existing row must not null out its expiry.
+		$row = $this->prepare(['@self' => ['uuid' => 'u-4'], 'name' => 'page_view']);
+
+		$this->assertArrayNotHasKey('_expires', $row);
+	}
+
+	public function testPurgeExpiredDeletesByRegisterSchemaAndPassedExpiry(): void {
+		$expr = $this->createMock(IExpressionBuilder::class);
+		$expr->method('eq')->willReturnCallback(fn (string $col, string $param): string => "$col = $param");
+		$expr->expects($this->once())->method('isNotNull')->with('_expires')->willReturn('_expires IS NOT NULL');
+		$expr->expects($this->once())->method('lt')->with('_expires', 'NOW()')->willReturn('_expires < NOW()');
+
+		$qb = $this->createMock(IQueryBuilder::class);
+		$qb->method('expr')->willReturn($expr);
+		$qb->method('createNamedParameter')->willReturnCallback(fn (mixed $value): string => ':p' . $value);
+		$qb->method('createFunction')->willReturnCallback(fn (string $fn): string => $fn);
+		$qb->expects($this->once())->method('delete')->with('openregister_table_11_22')->willReturnSelf();
+		$qb->expects($this->once())->method('where')->with('_register = :p11')->willReturnSelf();
+
+		$andWheres = [];
+		$qb->expects($this->exactly(3))
+			->method('andWhere')
+			->willReturnCallback(function (string $clause) use (&$andWheres, $qb): IQueryBuilder {
+				$andWheres[] = $clause;
+				return $qb;
+			});
+		$qb->expects($this->once())->method('executeStatement')->willReturn(4);
+
+		$this->db->method('getQueryBuilder')->willReturn($qb);
+
+		$purged = $this->handler->purgeExpired($this->register, $this->schema, 'openregister_table_11_22');
+
+		$this->assertSame(4, $purged);
+		$this->assertSame(['_schema = :p22', '_expires IS NOT NULL', '_expires < NOW()'], $andWheres);
+	}
+}

--- a/tests/Unit/Db/MagicBulkHandlerRawAppendTest.php
+++ b/tests/Unit/Db/MagicBulkHandlerRawAppendTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Unit tests for the raw-append side of MagicBulkHandler.
  *
@@ -11,9 +9,22 @@ declare(strict_types=1);
  * schedule the row for deletion. Second, that purgeExpired() deletes by
  * register, schema and a passed `_expires`, and reports the count.
  *
- * @category Test
- * @package  OCA\OpenRegister\Tests\Unit\Db
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Tests
+ * @package  Unit\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenRegister.app
  */
+
+declare(strict_types=1);
 
 namespace Unit\Db;
 

--- a/tests/Unit/Db/MagicMapper/MagicMapperPurgeExpiredTest.php
+++ b/tests/Unit/Db/MagicMapper/MagicMapperPurgeExpiredTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Unit tests for MagicMapper::purgeExpired().
+ *
+ * The mapper does two things around the handler: it answers 0 for a table
+ * that does not exist yet (a schema nothing has been appended to), and it
+ * hands the handler the register+schema table name it resolves itself.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Db\MagicMapper
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Db\MagicMapper;
+
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\MagicMapper\MagicBulkHandler;
+use OCA\OpenRegister\Db\MagicMapper\MagicTableHandler;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\DateTimeNormalizer;
+use OCA\OpenRegister\Service\SettingsService;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IAppConfig;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use ReflectionProperty;
+
+class MagicMapperPurgeExpiredTest extends TestCase {
+
+	private MagicMapper $mapper;
+
+	private MagicTableHandler&MockObject $tableHandler;
+
+	private MagicBulkHandler&MockObject $bulkHandler;
+
+	private Register $register;
+
+	private Schema $schema;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$db = $this->createMock(IDBConnection::class);
+		$db->method('getDatabasePlatform')->willReturn(
+			$this->createMock(\Doctrine\DBAL\Platforms\AbstractPlatform::class)
+		);
+
+		$dateTimeNormalizer = $this->createMock(DateTimeNormalizer::class);
+		$conditionMatcher = $this->createMock(\OCA\OpenRegister\Service\ConditionMatcher::class);
+		$schemaTypeConverter = $this->createMock(\OCA\OpenRegister\Service\Object\SchemaTypeConverter::class);
+		$container = $this->createMock(ContainerInterface::class);
+		$container->method('get')->willReturnCallback(
+			function (string $id) use ($dateTimeNormalizer, $conditionMatcher, $schemaTypeConverter) {
+				if ($id === DateTimeNormalizer::class) {
+					return $dateTimeNormalizer;
+				}
+
+				if ($id === \OCA\OpenRegister\Service\ConditionMatcher::class) {
+					return $conditionMatcher;
+				}
+
+				if ($id === \OCA\OpenRegister\Service\Object\SchemaTypeConverter::class) {
+					return $schemaTypeConverter;
+				}
+
+				return null;
+			}
+		);
+
+		$this->mapper = new MagicMapper(
+			$db,
+			$this->createMock(SchemaMapper::class),
+			$this->createMock(RegisterMapper::class),
+			$this->createMock(IConfig::class),
+			$this->createMock(IEventDispatcher::class),
+			$this->createMock(IUserSession::class),
+			$this->createMock(IGroupManager::class),
+			$this->createMock(IUserManager::class),
+			$this->createMock(IAppConfig::class),
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(SettingsService::class),
+			$container
+		);
+
+		// Swap the two handlers the method touches for mocks; the rest stay real.
+		$this->tableHandler = $this->createMock(MagicTableHandler::class);
+		$this->bulkHandler = $this->createMock(MagicBulkHandler::class);
+		$this->inject('tableHandler', $this->tableHandler);
+		$this->inject('bulkHandler', $this->bulkHandler);
+
+		$this->register = new Register();
+		$this->register->setId(5);
+
+		$this->schema = new Schema();
+		$this->schema->setId(9);
+	}
+
+	private function inject(string $property, object $value): void {
+		$reflection = new ReflectionProperty(MagicMapper::class, $property);
+		$reflection->setAccessible(true);
+		$reflection->setValue($this->mapper, $value);
+	}
+
+	public function testAMissingTableHasNothingToPurge(): void {
+		$this->tableHandler->method('tableExistsForRegisterSchema')
+			->with($this->register, $this->schema)
+			->willReturn(false);
+		$this->bulkHandler->expects($this->never())->method('purgeExpired');
+
+		$this->assertSame(0, $this->mapper->purgeExpired($this->register, $this->schema));
+	}
+
+	public function testAnExistingTableIsSweptByTheHandlerUnderItsResolvedName(): void {
+		$this->tableHandler->method('tableExistsForRegisterSchema')->willReturn(true);
+		$this->tableHandler->method('getTableNameForRegisterSchema')
+			->with($this->register, $this->schema)
+			->willReturn('openregister_table_5_9');
+
+		$this->bulkHandler->expects($this->once())
+			->method('purgeExpired')
+			->with($this->register, $this->schema, 'openregister_table_5_9')
+			->willReturn(7);
+
+		$this->assertSame(7, $this->mapper->purgeExpired($this->register, $this->schema));
+	}
+}

--- a/tests/Unit/Db/MagicMapper/MagicMapperPurgeExpiredTest.php
+++ b/tests/Unit/Db/MagicMapper/MagicMapperPurgeExpiredTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Unit tests for MagicMapper::purgeExpired().
  *
@@ -9,9 +7,22 @@ declare(strict_types=1);
  * that does not exist yet (a schema nothing has been appended to), and it
  * hands the handler the register+schema table name it resolves itself.
  *
- * @category Test
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Db\MagicMapper
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenRegister.app
  */
+
+declare(strict_types=1);
 
 namespace OCA\OpenRegister\Tests\Unit\Db\MagicMapper;
 

--- a/tests/Unit/Service/ObjectServiceRawAppendTest.php
+++ b/tests/Unit/Service/ObjectServiceRawAppendTest.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Unit tests for the raw append entry points on ObjectService.
+ *
+ * appendObjectsRaw() and purgeExpiredObjectsRaw() are the fast path for
+ * high-volume writers. These tests pin what the service does AROUND the
+ * mapper: how a plain row is shaped for the bulk handler, that the bulk
+ * upsert runs with the pre-update fetch switched off, how identifiers are
+ * resolved within the register, and that the service's own register/schema
+ * context is never touched.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Service;
+
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Db\ViewMapper;
+use OCA\OpenRegister\Service\DateTimeNormalizer;
+use OCA\OpenRegister\Service\FileService;
+use OCA\OpenRegister\Service\Object\AuditHandler;
+use OCA\OpenRegister\Service\Object\CacheHandler;
+use OCA\OpenRegister\Service\Object\CascadingHandler;
+use OCA\OpenRegister\Service\Object\DataManipulationHandler;
+use OCA\OpenRegister\Service\Object\DeleteObject;
+use OCA\OpenRegister\Service\Object\FacetHandler;
+use OCA\OpenRegister\Service\Object\GetObject;
+use OCA\OpenRegister\Service\Object\LockHandler;
+use OCA\OpenRegister\Service\Object\MergeHandler;
+use OCA\OpenRegister\Service\Object\MetadataHandler;
+use OCA\OpenRegister\Service\Object\MigrationHandler;
+use OCA\OpenRegister\Service\Object\PerformanceOptimizationHandler;
+use OCA\OpenRegister\Service\Object\PermissionHandler;
+use OCA\OpenRegister\Service\Object\QueryHandler;
+use OCA\OpenRegister\Service\Object\RelationHandler;
+use OCA\OpenRegister\Service\Object\RenderObject;
+use OCA\OpenRegister\Service\Object\RevertHandler;
+use OCA\OpenRegister\Service\Object\SaveObject;
+use OCA\OpenRegister\Service\Object\SaveObjects;
+use OCA\OpenRegister\Service\Object\SearchQueryHandler;
+use OCA\OpenRegister\Service\Object\UtilityHandler;
+use OCA\OpenRegister\Service\Object\ValidateObject;
+use OCA\OpenRegister\Service\Object\ValidationHandler;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\ObjectSource\ObjectSourceRegistry;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCA\OpenRegister\Service\SearchTrailService;
+use OCA\OpenRegister\Service\SettingsService;
+use OCP\AppFramework\IAppContainer;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionClass;
+
+class ObjectServiceRawAppendTest extends TestCase {
+
+	private ObjectService $service;
+
+	private MagicMapper&MockObject $magicMapper;
+
+	private RegisterMapper&MockObject $registerMapper;
+
+	private SchemaMapper&MockObject $schemaMapper;
+
+	private Register $register;
+
+	private Schema $schema;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->magicMapper = $this->createMock(MagicMapper::class);
+		$this->registerMapper = $this->createMock(RegisterMapper::class);
+		$this->schemaMapper = $this->createMock(SchemaMapper::class);
+
+		$this->register = new Register();
+		$this->register->setId(1);
+		$this->register->setSlug('portaliq');
+		$this->register->setSchemas([2]);
+
+		$this->schema = new Schema();
+		$this->schema->setId(2);
+		$this->schema->setSlug('portalTrafficEvent');
+
+		$this->service = new ObjectService(
+			$this->createMock(DataManipulationHandler::class),
+			$this->createMock(DeleteObject::class),
+			$this->createMock(GetObject::class),
+			$this->createMock(PermissionHandler::class),
+			$this->createMock(RenderObject::class),
+			$this->createMock(SaveObject::class),
+			$this->createMock(SaveObjects::class),
+			$this->createMock(SearchQueryHandler::class),
+			$this->createMock(ValidateObject::class),
+			$this->createMock(LockHandler::class),
+			$this->createMock(AuditHandler::class),
+			$this->createMock(RelationHandler::class),
+			$this->createMock(MergeHandler::class),
+			$this->createMock(FacetHandler::class),
+			$this->createMock(MetadataHandler::class),
+			$this->createMock(PerformanceOptimizationHandler::class),
+			$this->createMock(QueryHandler::class),
+			$this->createMock(RevertHandler::class),
+			$this->createMock(UtilityHandler::class),
+			$this->createMock(ValidationHandler::class),
+			$this->createMock(CascadingHandler::class),
+			$this->createMock(MigrationHandler::class),
+			$this->registerMapper,
+			$this->schemaMapper,
+			$this->createMock(ViewMapper::class),
+			$this->magicMapper,
+			$this->createMock(FileService::class),
+			$this->createMock(IUserSession::class),
+			$this->createMock(SearchTrailService::class),
+			$this->createMock(IGroupManager::class),
+			$this->createMock(IUserManager::class),
+			$this->createMock(OrganisationService::class),
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(CacheHandler::class),
+			$this->createMock(SettingsService::class),
+			$this->createMock(DateTimeNormalizer::class),
+			$this->createMock(IAppContainer::class),
+			$this->createMock(ObjectSourceRegistry::class)
+		);
+	}
+
+	/**
+	 * Read a private property off the service.
+	 */
+	private function contextProperty(string $name): mixed {
+		$property = (new ReflectionClass(ObjectService::class))->getProperty($name);
+		$property->setAccessible(true);
+
+		return $property->getValue($this->service);
+	}
+
+	public function testAppendShapesRowsAndRunsTheBulkPathWithSafeguardsOff(): void {
+		$this->magicMapper->expects($this->once())
+			->method('ensureTableForRegisterSchema')
+			->with($this->register, $this->schema);
+		$this->magicMapper->method('getTableNameForRegisterSchema')
+			->with($this->register, $this->schema)
+			->willReturn('openregister_table_1_2');
+
+		$captured = [];
+		$this->magicMapper->expects($this->once())
+			->method('bulkUpsert')
+			->with(
+				$this->callback(function (array $rows) use (&$captured): bool {
+					$captured = $rows;
+					return true;
+				}),
+				$this->register,
+				$this->schema,
+				'openregister_table_1_2',
+				false
+			)
+			->willReturn([['_uuid' => 'a'], ['_uuid' => 'b']]);
+
+		$written = $this->service->appendObjectsRaw(
+			objects: [
+				[
+					'uuid' => 'fixed-uuid',
+					'expires' => '2026-12-31T00:00:00+00:00',
+					'owner' => 'collector',
+					'name' => 'page_view',
+					'pagePath' => '/home',
+				],
+				['name' => 'scroll', 'params' => ['depth' => 90]],
+			],
+			register: $this->register,
+			schema: $this->schema
+		);
+
+		$this->assertSame(2, $written, 'The return value is the number of rows the mapper reports written.');
+		$this->assertCount(2, $captured);
+
+		// Metadata moved into @self; properties stayed at the top level.
+		$this->assertSame('fixed-uuid', $captured[0]['@self']['uuid']);
+		$this->assertSame('2026-12-31T00:00:00+00:00', $captured[0]['@self']['expires']);
+		$this->assertSame('collector', $captured[0]['@self']['owner']);
+		$this->assertArrayNotHasKey('uuid', $captured[0]);
+		$this->assertArrayNotHasKey('expires', $captured[0]);
+		$this->assertArrayNotHasKey('owner', $captured[0]);
+		$this->assertSame('page_view', $captured[0]['name']);
+		$this->assertSame('/home', $captured[0]['pagePath']);
+
+		// A row without a uuid gets a generated v4; no expiry key is invented.
+		$this->assertMatchesRegularExpression(
+			'/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
+			$captured[1]['@self']['uuid']
+		);
+		$this->assertArrayNotHasKey('expires', $captured[1]['@self']);
+		$this->assertSame(['depth' => 90], $captured[1]['params']);
+	}
+
+	public function testAppendOfNothingTouchesNothing(): void {
+		$this->magicMapper->expects($this->never())->method('ensureTableForRegisterSchema');
+		$this->magicMapper->expects($this->never())->method('bulkUpsert');
+		$this->registerMapper->expects($this->never())->method('find');
+
+		$this->assertSame(0, $this->service->appendObjectsRaw(objects: [], register: 'portaliq', schema: 'portalTrafficEvent'));
+	}
+
+	public function testSlugsResolveWithinTheRegisterAndLeaveTheContextAlone(): void {
+		// The register resolves without RBAC or tenancy, like setRegister() does.
+		$this->registerMapper->expects($this->once())
+			->method('find')
+			->with('portaliq', false, false)
+			->willReturn($this->register);
+
+		// The schema resolves among the register's carried ids, never globally.
+		$this->schemaMapper->expects($this->once())
+			->method('findInIds')
+			->with('portalTrafficEvent', [2])
+			->willReturn($this->schema);
+		$this->schemaMapper->expects($this->never())->method('find');
+
+		$this->magicMapper->method('getTableNameForRegisterSchema')->willReturn('openregister_table_1_2');
+		$this->magicMapper->expects($this->once())
+			->method('bulkUpsert')
+			->with($this->anything(), $this->register, $this->schema, 'openregister_table_1_2', false)
+			->willReturn([['_uuid' => 'a']]);
+
+		$written = $this->service->appendObjectsRaw(
+			objects: [['name' => 'page_view']],
+			register: 'portaliq',
+			schema: 'portalTrafficEvent'
+		);
+
+		$this->assertSame(1, $written);
+		$this->assertNull($this->contextProperty('currentRegister'), 'A raw append must not set the service register context.');
+		$this->assertNull($this->contextProperty('currentSchema'), 'A raw append must not set the service schema context.');
+		$this->assertNull($this->contextProperty('currentSchemaRef'), 'A raw append must not leave a pending schema ref behind.');
+	}
+
+	public function testPurgeDelegatesToTheMapperAndReportsTheCount(): void {
+		$this->magicMapper->expects($this->once())
+			->method('purgeExpired')
+			->with($this->register, $this->schema)
+			->willReturn(3);
+
+		$this->assertSame(3, $this->service->purgeExpiredObjectsRaw(register: $this->register, schema: $this->schema));
+	}
+
+	public function testPurgeResolvesIdentifiersWithinTheRegister(): void {
+		$this->registerMapper->expects($this->once())
+			->method('find')
+			->with(1, false, false)
+			->willReturn($this->register);
+		$this->schemaMapper->expects($this->once())
+			->method('findInIds')
+			->with(2, [2])
+			->willReturn($this->schema);
+
+		$this->magicMapper->expects($this->once())
+			->method('purgeExpired')
+			->with($this->register, $this->schema)
+			->willReturn(0);
+
+		$this->assertSame(0, $this->service->purgeExpiredObjectsRaw(register: 1, schema: 2));
+		$this->assertNull($this->contextProperty('currentRegister'));
+		$this->assertNull($this->contextProperty('currentSchema'));
+	}
+}

--- a/tests/Unit/Service/ObjectServiceRawAppendTest.php
+++ b/tests/Unit/Service/ObjectServiceRawAppendTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Unit tests for the raw append entry points on ObjectService.
  *
@@ -12,9 +10,22 @@ declare(strict_types=1);
  * resolved within the register, and that the service's own register/schema
  * context is never touched.
  *
- * @category Test
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Tests
  * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenRegister.app
  */
+
+declare(strict_types=1);
 
 namespace OCA\OpenRegister\Tests\Unit\Service;
 


### PR DESCRIPTION
## Why

The traffic-analytics collector (pipelinq marketing programme, CONTRACT.md section 2) writes thousands of rows a minute that no person ever edits. The normal save path costs several queries and side effects per row (RBAC, multitenancy, validation, audit trail, lifecycle events, search index, relations, files), which a collector at that rate cannot pay. While wiring its retention, the search trail turned out to have no retention at all.

## Change 1: raw append and expiry purge (`feat(objects)`)

Two entry points on `ObjectService`, both on `ObjectServiceInterface` so a leaf app reaches them without OpenRegister internals:

```php
public function appendObjectsRaw(array $objects, Register|string|int $register, Schema|string|int $schema): int;
public function purgeExpiredObjectsRaw(Register|string|int $register, Schema|string|int $schema): int;
```

- `appendObjectsRaw()` resolves the register, resolves the schema within that register, calls `ensureTableForRegisterSchema()` and hands the rows to the existing chunked `MagicMapper::bulkUpsert()` with the pre-update fetch off. The docblock lists what is skipped, on purpose: RBAC, multitenancy, validation, audit trail, events, search index, relations, files. Calling it is the same declaration as `_rbac: false`: the caller has taken the authorisation responsibility.
- Each row is a plain property map plus optional `uuid`, `expires`, `owner`, `organisation`. The bulk handler maps an expiry from the metadata block into the indexed `_expires` column; a bare schema property called `expires` stays a property.
- `purgeExpiredObjectsRaw()` hard-deletes rows whose `_expires` has passed, by the database clock. No soft delete, no audit entry: raw rows never had either. A table that does not exist yet answers 0.
- Neither touches the service's register/schema context.
- Both interface methods carry `@contract-shift announced`, pointing at #3406, which names the fleet test doubles that must declare them before the hydra-gates release that ships this contract.

Spec: `openspec/specs/data-import-export/spec.md`, requirement "Raw append for high-volume writers" (4 scenarios, `@e2e exclude`, covered by PHPUnit).

## Change 2: search trail retention was enforced by nothing (`fix(retention)`)

`searchTrailRetention` was read only to echo it to the settings page. Search trail rows are inserted without an expiry, `SearchTrailMapper::setExpiryDate()` had no caller, and `clearLogs()` was reachable only from the manual admin endpoint. `LogCleanUpTask` (hourly) now stamps `expires` on rows that have none and deletes the rows past it, next to the audit sweep it already ran. The two sweeps are independent: a failure in one is logged and never skips the other. `setExpiryDate()` spells the interval per platform so the hourly job does not fail on PostgreSQL.

Spec: `openspec/specs/retention-management/spec.md`, requirement "The hourly log cleanup job MUST enforce the configured search trail retention" (3 scenarios, `@e2e exclude`). Docs updated on both search pages.

## Follow-up commits in this PR

- `chore(tests)`: licence headers on the five test files, in the repository's position (docblock before `declare`).
- `docs(contract)`: the `@contract-shift` annotation gate-83 requires.

## Local verification (exit codes)

CI is bottlenecked; everything below ran locally in a clean clone, verified by exit code.

| Check | Exit |
|---|---|
| `phpunit --no-coverage tests/Unit/Service/ObjectServiceRawAppendTest.php` (5 tests, 32 assertions) | 0 |
| `phpunit --no-coverage tests/Unit/Db/MagicBulkHandlerRawAppendTest.php` (5 tests, 14 assertions) | 0 |
| `phpunit --no-coverage tests/Unit/Db/MagicMapper/MagicMapperPurgeExpiredTest.php` (2 tests, 4 assertions) | 0 |
| `phpunit --no-coverage tests/Unit/BackgroundJob/LogCleanUpTaskTest.php` (11 tests, 39 assertions) | 0 |
| `phpcs --standard=phpcs.xml --warning-severity=0` on the six changed `lib/` files | 0 |
| `phpmd <file> text phpmd.xml` and `phpmd-unusedparams.xml`, per changed `lib/` file (12 runs) | 0 |
| `psalm --threads=4 --no-cache` ("No errors found!") | 0 |
| `phpstan analyse --memory-limit=1G` ("[OK] No errors") | 0 |
| `check_contract_surface_shift.py . --base origin/development` (gate-83 standalone, after the annotation) | 0 |
| hydra-gates v1.12.0, full scope, `--base origin/development`, final tree with `npm ci` done | 4 (73 pass, 4 fail: 22, 53, 57, 67, explained below; 78 of 78 applicable gates ran; gate-83 passes) |
| `node scripts/lib/check_manifest.js src/manifest.json` (gate-22 validator, with `ajv` installed) | 1, inherited: see below |

## Not verified here

- `composer test:db` **skipped** (exit 0, but skipped): the `@group DB` integration test `tests/Db/RawAppendIntegrationTest.php` needs a booted Nextcloud with a live database (`../../lib/base.php`), which this clone does not have. It has not been run.
- `composer psalm` via the composer script hit composer's 300 s process timeout on this loaded box; psalm was run directly with the same flags apart from `--threads=4`.
- phpcs is configured for `lib/` only; the five test files, run against the same standard out of curiosity, carry the usual test-file findings (named arguments, member docblocks) that every test in this repository carries.

## Gate findings that remain, and why

- **gate-22 manifest-validation**: in the full run `ajv` was not resolvable (no `node_modules`). With `npm ci` done, the validator judges `src/manifest.json` and fails it on two points that are not this PR's: the top-level `store` key and `pages[0].type = "store"`, both added to `development` today in `0b4a3f0` (feat(chrome): the Store surface) and unknown to the manifest schema vendored in hydra-gates v1.12.0. `src/manifest.json` is byte-identical to `origin/development` here (0 diff lines).
- **gate-53 effective-manifest-crossref**: 2 structural violations in the assembled manifest, the same inherited `store` page type and key.
- **gate-83 contract-surface-shift**: the two new interface methods lacked `@contract-shift`. Fixed by the `docs(contract)` commit; passes in the final run.
- **gate-67 openregister-contract-parity**: `lib/Contract/ObjectServiceInterface.php` no longer matches the copy shipped in `hydra-gates/contracts/` (it matched byte for byte before this change). By ADR-084 the canonical file must be copied over the shipped one in **ConductionNL/.github** (`hydra-gates/contracts/ObjectServiceInterface.php`, base `main`), as #2543 did for `patchObject()`. That companion PR is not opened from here: the sandbox refused to act in the `.github` clone. Until a hydra-gates release carries the new copy and the app's lock is bumped, gate-67 stays red on `development` for this file.
- **gate-57 orphaned-write-capability**: `lib/Service/File/DeleteFileHandler.php:150 deleteFiles()`, untouched by this PR and present on `origin/development`. Left alone: a gate finding is a question, and this PR is not the place to answer it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
