### PR TITLE
fix(flows): stop the flow migration copying non-flow objects, and remove the rows it already wrote

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -217,6 +217,27 @@ Vrij en open source onder de EUPL-licentie.
 			     Copies the register-authored ones across, disabled, leaving the
 			     register rows in place so the step stays reversible. -->
 			<step>OCA\OpenRegister\Repair\MigrateRegisterFlowsToTable</step>
+			<!-- CLEANS UP AFTER THE VERSION OF THE STEP ABOVE THAT DID NOT SCOPE
+			     ITS READ. It asked findAll() for register `flows` / schema `flow`
+			     at the TOP LEVEL of the config; ObjectService reads that pair
+			     from `filters` and nowhere else, so both keys were inert and the
+			     read ran against whatever register/schema the SHARED service was
+			     still carrying. saveObject() sets that context and never restores
+			     it, and ImportCredentialBrokerRegister saves two example objects
+			     through it four steps earlier — so the migration copied both
+			     `brokeredcredential` examples into openregister_flows: no nodes,
+			     no edges, no trigger, owner `__system__`.
+
+			     Post-migration ONLY. A fresh install runs the fixed migration,
+			     which cannot produce these rows, so listing this under <install>
+			     would be a guaranteed no-op.
+
+			     Removes a row ONLY on the full conjunction: openregister-owned,
+			     disabled, no nodes, no edges, no trigger/cron, never dispatched
+			     (lastRun* null AND zero run rows), AND its uuid still resolves to
+			     a register object whose schema is not `flow`. Anything ambiguous
+			     is REPORTED by uuid, not deleted. Idempotent. -->
+			<step>OCA\OpenRegister\Repair\PurgePhantomMigratedFlows</step>
 			<step>OCA\OpenRegister\Repair\ImportTrustConfigurationRegister</step>
 			<step>OCA\OpenRegister\Repair\SeedVocabularyRegister</step>
 			<step>OCA\OpenRegister\Repair\RegisterOpenRegisterWithDoriath</step>

--- a/lib/Db/Flow.php
+++ b/lib/Db/Flow.php
@@ -96,6 +96,18 @@ use OCP\AppFramework\Db\Entity;
  * @method void setCreated(?DateTime $created)
  * @method DateTime|null getUpdated()
  * @method void setUpdated(?DateTime $updated)
+ * @method string|null getStatus()
+ * @method void setStatus(?string $status)
+ * @method string|null getStatusMessage()
+ * @method void setStatusMessage(?string $statusMessage)
+ * @method string|null getLastRunUuid()
+ * @method void setLastRunUuid(?string $lastRunUuid)
+ * @method string|null getLastRunStatus()
+ * @method void setLastRunStatus(?string $lastRunStatus)
+ * @method string|null getLastRunMessage()
+ * @method void setLastRunMessage(?string $lastRunMessage)
+ * @method DateTime|null getLastRunAt()
+ * @method void setLastRunAt(?DateTime $lastRunAt)
  *
  * An Entity mirrors its table one field per column, so the field count below is
  * the schema's rather than a design choice. Splitting it would need a second

--- a/lib/Db/FlowRunMapper.php
+++ b/lib/Db/FlowRunMapper.php
@@ -675,6 +675,41 @@ class FlowRunMapper extends QBMapper {
 	}//end hasActiveRun()
 
 	/**
+	 * How many runs this flow has EVER had, terminal ones included.
+	 *
+	 * {@see hasActiveRun} answers a different question — whether a run is going
+	 * right now — and a flow that ran to completion last year has none. Deleting
+	 * a flow is irreversible, so the guard that authorises it has to ask about
+	 * the flow's whole history, not its current activity.
+	 *
+	 * Used by {@see \OCA\OpenRegister\Repair\PurgePhantomMigratedFlows} as one
+	 * conjunct of the never-dispatched proof: a row with even one run row has
+	 * been part of something that happened and is never removed.
+	 *
+	 * @param string $flowId The flow's uuid.
+	 *
+	 * @return integer The number of run rows recorded against this flow.
+	 *
+	 * @spec openspec/changes/flow-engine-unification/specs/flow-storage/spec.md
+	 */
+	public function countRunsForFlow(string $flowId): int {
+		if (trim($flowId) === '') {
+			return 0;
+		}
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->select($qb->createFunction('COUNT(*) AS `total`'))
+			->from($this->getTableName())
+			->where($qb->expr()->eq('flow_id', $qb->createNamedParameter($flowId)));
+
+		$result = $qb->executeQuery();
+		$row = $result->fetch();
+		$result->closeCursor();
+
+		return (int)($row['total'] ?? 0);
+	}//end countRunsForFlow()
+
+	/**
 	 * How many runs are still going, for one organisation.
 	 *
 	 * Separate from {@see findActive} because a widget shows a bounded list but

--- a/lib/Repair/MigrateRegisterFlowsToTable.php
+++ b/lib/Repair/MigrateRegisterFlowsToTable.php
@@ -175,12 +175,23 @@ class MigrateRegisterFlowsToTable implements IRepairStep {
 		$moved = 0;
 		$already = 0;
 		$failed = 0;
+		$notFlows = 0;
 
 		foreach ($objects as $object) {
 			$row  = $this->normalise(row: $object);
 			$uuid = $row['uuid'];
 			if ($uuid === '') {
 				$failed++;
+				continue;
+			}
+
+			// The second, independent guard — see isFlowDefinition().
+			if ($this->isFlowDefinition(object: $row['data']) === false) {
+				$notFlows++;
+				$this->logger->warning(
+					'[MigrateRegisterFlowsToTable] refused ' . $uuid
+					. ': no nodes, no edges and no trigger, so it is not a flow definition'
+				);
 				continue;
 			}
 
@@ -211,13 +222,48 @@ class MigrateRegisterFlowsToTable implements IRepairStep {
 		// the defect this repairs stayed invisible.
 		$output->info(
 			sprintf(
-				'Register-authored flows: %d migrated, %d already in the table, %d failed (register rows left in place).',
+				'Register-authored flows: %d migrated, %d already in the table, %d not a flow definition, %d failed (register rows left in place).',
 				$moved,
 				$already,
+				$notFlows,
 				$failed
 			)
 		);
 	}//end run()
+
+	/**
+	 * Whether this object is a flow definition at all.
+	 *
+	 * 🔴 BOTH GUARDS, DELIBERATELY. Scoping the read (see registerFlows()) fixes
+	 * the wrong POPULATION being selected; this fixes a wrong ROW inside the
+	 * selected one being written. They fail independently, which is the point:
+	 * the scoping guard depends on shared, mutable service state staying correct
+	 * for the whole of an `occ upgrade`, and that state is exactly what broke.
+	 * This one depends on nothing but the row in front of it.
+	 *
+	 * The test is what the flow engine needs to do anything: a graph to walk
+	 * (`nodes` or `edges`) or something to start it (`trigger`). A row with none
+	 * of the three cannot run, cannot be made to run, and is not a flow — it is
+	 * whatever else the read handed us. It is not a completeness check: an empty
+	 * graph that already names a trigger is a half-authored flow and crosses.
+	 *
+	 * @param array<string, mixed> $object The register object's payload.
+	 *
+	 * @return boolean True when the payload is a flow definition.
+	 */
+	private function isFlowDefinition(array $object): bool {
+		if (empty($object['nodes']) === false) {
+			return true;
+		}
+
+		if (empty($object['edges']) === false) {
+			return true;
+		}
+
+		$trigger = ($object['trigger'] ?? null);
+
+		return is_string($trigger) === true && trim($trigger) !== '';
+	}//end isFlowDefinition()
 
 	/**
 	 * Every object in the flows register.
@@ -225,12 +271,38 @@ class MigrateRegisterFlowsToTable implements IRepairStep {
 	 * @return array<int, mixed> The rows, each an ObjectEntity (see normalise()).
 	 */
 	private function registerFlows(): array {
+		// 🔴 `register` / `schema` GO UNDER `filters`, AND NOWHERE ELSE.
+		//
+		// This step used to pass them at the top level of the config, which
+		// reads correctly and does nothing: `ObjectService::prepareFindAllConfig()`
+		// inspects `$config['filters']['register']` and `$config['filters']['schema']`
+		// and no other key, so `setRegister()` / `setSchema()` were never called
+		// and the read ran against whatever `$currentRegister` / `$currentSchema`
+		// the SHARED ObjectService instance was still carrying.
+		//
+		// MEASURED, not inferred. `saveObject()` sets that context and never
+		// restores it — `find()` does, in a `finally`; `saveObject()` has no such
+		// block. `ImportCredentialBrokerRegister` runs four repair steps ahead of
+		// this one and saves `credential_broker_register.json`'s two example
+		// objects through it. So this step inherited `credential-broker` /
+		// `brokeredcredential` and copied both examples into `openregister_flows`:
+		// empty nodes, empty edges, no trigger, `_owner` = `__system__` (which is
+		// only what OpenRegister stamps on a sessionless write, not a convention).
+		//
+		// Every other `findAll()` caller under `lib/` nests the pair. This step
+		// was the outlier, and `_rbac` / `_multitenancy` are off because a repair
+		// step has no session — `occ` runs as Anonymous, so a scoped read would
+		// return nothing at all.
 		$result = $this->objectService->findAll(
-			[
-				'register' => self::FLOW_REGISTER,
-				'schema'   => self::FLOW_SCHEMA,
-				'limit'    => 1000,
-			]
+			config: [
+				'filters' => [
+					'register' => self::FLOW_REGISTER,
+					'schema'   => self::FLOW_SCHEMA,
+				],
+				'limit'   => 1000,
+			],
+			_rbac: false,
+			_multitenancy: false
 		);
 
 		// No `is_array($result)` guard: `findAll()` is typed to return an array,

--- a/lib/Repair/PurgePhantomMigratedFlows.php
+++ b/lib/Repair/PurgePhantomMigratedFlows.php
@@ -1,0 +1,357 @@
+<?php
+
+/**
+ * PurgePhantomMigratedFlows — removes rows the flow migration should never have written.
+ *
+ * 🔴 WHAT WENT WRONG, MEASURED.
+ *
+ * {@see MigrateRegisterFlowsToTable} asked `ObjectService::findAll()` for
+ * `['register' => 'flows', 'schema' => 'flow']` at the TOP LEVEL of the config.
+ * `prepareFindAllConfig()` reads `$config['filters']['register']` and
+ * `$config['filters']['schema']` and no other key, so both were inert: the read
+ * was never scoped and ran against whatever `$currentRegister` / `$currentSchema`
+ * the SHARED ObjectService instance was still carrying.
+ *
+ * `saveObject()` sets that context and never restores it — `find()` puts it back
+ * in a `finally`, `saveObject()` has no such block — and
+ * `ImportCredentialBrokerRegister` runs four repair steps ahead of the migration,
+ * saving `credential_broker_register.json`'s two example objects through it. So
+ * the migration inherited `credential-broker` / `brokeredcredential` and copied
+ * both examples into `openregister_flows`.
+ *
+ * The rows it left behind have empty nodes, empty edges, no trigger, no trigger
+ * schema and `_owner` = `__system__` — which is only what OpenRegister stamps on
+ * a sessionless write, not a convention for a shipped flow. They cost twice:
+ * they are listed forever as flows that can never run, and they were read as
+ * precedent by a later diagnosis that nearly copied `owner=__system__` into
+ * another app's shipped flow declarations.
+ *
+ * 🔴 DELETING ROWS IS IRREVERSIBLE, SO THE PREDICATE IS PROOF, NOT A HEURISTIC.
+ *
+ * A row is removed only when ALL of the following hold:
+ *
+ *   1. it is owned by `openregister` — the only `app` value the migration writes;
+ *   2. it is disabled;
+ *   3. `nodes` is empty AND `edges` is empty — nothing to walk;
+ *   4. `trigger`, `triggerRegister`, `triggerSchema` and `cron` are all empty —
+ *      nothing that could ever start it;
+ *   5. it has never been dispatched: no `lastRunUuid`, no `lastRunAt`, no
+ *      `lastRunStatus`, and zero rows in `openregister_flow_runs`;
+ *   6. and — the provenance proof — its uuid still resolves to a register object
+ *      whose schema is NOT `flow`. That is the defect's signature: the row is a
+ *      copy of something that was never a flow.
+ *
+ * (1)–(5) establish that the row cannot run and never has. (6) establishes that
+ * it is this defect's artefact rather than somebody's empty draft. Only the
+ * conjunction deletes.
+ *
+ * 🔴 WHAT IT DELIBERATELY SPARES, and reports instead:
+ *
+ *   - any flow with one node or one edge, whatever else is missing;
+ *   - any flow naming a trigger, trigger register/schema or cron — including a
+ *     graph-less draft someone is part-way through authoring;
+ *   - any enabled flow, whatever its shape;
+ *   - any flow with run history, even a single terminal run;
+ *   - any flow owned by another app;
+ *   - AND the ambiguous case: an unrunnable shell whose uuid resolves to nothing,
+ *     or to a real `flow` object. Its source may have been deleted since, or it
+ *     may be a genuine empty draft, and the two are indistinguishable from here.
+ *     Reported by uuid, never removed. Erring toward keeping an unrunnable row is
+ *     recoverable; erring the other way is not.
+ *
+ * Idempotent: a second run finds nothing left to match and reports zero.
+ *
+ * @category Repair
+ * @package  OCA\OpenRegister\Repair
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/register-descriptor-admin/specs/register-descriptor-admin/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Repair;
+
+use OCA\OpenRegister\Db\Flow;
+use OCA\OpenRegister\Db\FlowMapper;
+use OCA\OpenRegister\Db\FlowRunMapper;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Removes non-flow rows the mis-scoped flow migration copied into the flow table.
+ *
+ * @spec openspec/changes/register-descriptor-admin/specs/register-descriptor-admin/spec.md
+ *
+ * @psalm-suppress UnusedClass Instantiated by the NC repair framework (appinfo/info.xml).
+ */
+class PurgePhantomMigratedFlows implements IRepairStep {
+	/**
+	 * The only `app` value MigrateRegisterFlowsToTable writes.
+	 *
+	 * Scoping to it spares every flow another app owns without having to reason
+	 * about that app's conventions at all.
+	 *
+	 * @var string
+	 */
+	private const MIGRATED_APP = 'openregister';
+
+	/**
+	 * The schema slug a real flow definition lives under.
+	 *
+	 * @var string
+	 */
+	private const FLOW_SCHEMA = 'flow';
+
+	/**
+	 * Page size for the table walk.
+	 *
+	 * @var int
+	 */
+	private const PAGE = 200;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param FlowMapper      $flowMapper    Reads and removes rows in the flow table.
+	 * @param FlowRunMapper   $flowRunMapper Proves a row has never been dispatched.
+	 * @param MagicMapper     $objectMapper  Resolves a uuid back to the object it was copied from.
+	 * @param SchemaMapper    $schemaMapper  Turns that object's schema reference into a slug.
+	 * @param LoggerInterface $logger        Records every removal and every spared ambiguity.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly FlowMapper $flowMapper,
+		private readonly FlowRunMapper $flowRunMapper,
+		private readonly MagicMapper $objectMapper,
+		private readonly SchemaMapper $schemaMapper,
+		private readonly LoggerInterface $logger,
+	) {
+	}//end __construct()
+
+	/**
+	 * Get the name of this repair step.
+	 *
+	 * @return string The step name.
+	 *
+	 * @spec openspec/changes/register-descriptor-admin/specs/register-descriptor-admin/spec.md
+	 */
+	public function getName(): string {
+		return 'Remove non-flow rows copied into the flow table by the mis-scoped flow migration';
+	}//end getName()
+
+	/**
+	 * Walk the flow table and remove only what is provably this defect's artefact.
+	 *
+	 * Never throws: a failure here must not take an upgrade down, and a row left
+	 * in place is the safe direction anyway.
+	 *
+	 * @param IOutput $output Output interface for status messages.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/register-descriptor-admin/specs/register-descriptor-admin/spec.md
+	 */
+	public function run(IOutput $output): void {
+		$removed = 0;
+		$reported = [];
+
+		try {
+			foreach ($this->migratedFlows() as $flow) {
+				if ($this->isUnrunnableShell(flow: $flow) === false) {
+					continue;
+				}
+
+				$uuid = (string)$flow->getUuid();
+
+				if ($this->hasEverRun(flow: $flow) === true) {
+					$reported[] = $uuid . ' (unrunnable, but it has run history)';
+					continue;
+				}
+
+				$sourceSchema = $this->sourceSchemaSlug(uuid: $uuid);
+				if ($sourceSchema === null) {
+					$reported[] = $uuid . ' (unrunnable, but no source object to identify it by)';
+					continue;
+				}
+
+				if ($sourceSchema === self::FLOW_SCHEMA) {
+					$reported[] = $uuid . ' (unrunnable, but it really is a flow object — an empty draft)';
+					continue;
+				}
+
+				$this->flowMapper->delete($flow);
+				$removed++;
+				$this->logger->warning(
+					'[PurgePhantomMigratedFlows] removed ' . $uuid
+					. ': an unrunnable, never-dispatched copy of a `' . $sourceSchema . '` object'
+				);
+			}//end foreach
+		} catch (Throwable $e) {
+			$this->logger->warning('[PurgePhantomMigratedFlows] aborted: ' . $e->getMessage());
+			$output->warning('Phantom-flow purge stopped early: ' . $e->getMessage());
+		}//end try
+
+		// 🔴 THE COUNTS AND THE SPARED UUIDS, ALWAYS. A destructive step that
+		// says only "done" cannot be told from one that matched nothing, and the
+		// reported rows are the ones a human has to look at — naming them here is
+		// the whole point of not deleting them.
+		$output->info(
+			sprintf('Phantom flow rows: %d removed, %d reported for review.', $removed, count($reported))
+		);
+
+		foreach ($reported as $line) {
+			$output->info('  needs review: ' . $line);
+		}
+	}//end run()
+
+	/**
+	 * Every flow this migration could have written, page by page.
+	 *
+	 * @return iterable<int, Flow> The candidate rows.
+	 */
+	private function migratedFlows(): iterable {
+		$offset = 0;
+
+		while (true) {
+			$page = $this->flowMapper->findAllFlows(
+				app: self::MIGRATED_APP,
+				limit: self::PAGE,
+				offset: $offset
+			);
+
+			if (empty($page) === true) {
+				return;
+			}
+
+			yield from $page;
+
+			if (count($page) < self::PAGE) {
+				return;
+			}
+
+			$offset += self::PAGE;
+		}
+	}//end migratedFlows()
+
+	/**
+	 * Whether this row has nothing to walk and nothing that could start it.
+	 *
+	 * Conjuncts (2)–(4) of the predicate in the class docblock. Every one of them
+	 * spares something: `enabled` spares a switched-on flow whatever its shape,
+	 * the graph pair spares anything with a single node or edge, and the trigger
+	 * group spares a graph-less draft that already names how it should start.
+	 *
+	 * @param Flow $flow The row under test.
+	 *
+	 * @return boolean True when the row cannot run and cannot be started.
+	 */
+	private function isUnrunnableShell(Flow $flow): bool {
+		if ($flow->getEnabled() === true) {
+			return false;
+		}
+
+		if (empty($flow->getNodes()) === false || empty($flow->getEdges()) === false) {
+			return false;
+		}
+
+		$starters = [
+			$flow->getTrigger(),
+			$flow->getTriggerRegister(),
+			$flow->getTriggerSchema(),
+			$flow->getCron(),
+		];
+
+		foreach ($starters as $starter) {
+			if ($starter !== null && trim($starter) !== '') {
+				return false;
+			}
+		}
+
+		return true;
+	}//end isUnrunnableShell()
+
+	/**
+	 * Whether this flow has ever been dispatched.
+	 *
+	 * Conjunct (5). Both halves are load-bearing: the `lastRun*` columns are the
+	 * flow's own memory of a dispatch, and the run table is the record of one.
+	 * A run row can be pruned by retention while the columns survive, and the
+	 * columns were only added in a later migration while older run rows remain —
+	 * so either alone would miss a flow that has demonstrably run.
+	 *
+	 * @param Flow $flow The row under test.
+	 *
+	 * @return boolean True when anything at all says this flow has run.
+	 */
+	private function hasEverRun(Flow $flow): bool {
+		if ($flow->getLastRunUuid() !== null || $flow->getLastRunAt() !== null || $flow->getLastRunStatus() !== null) {
+			return true;
+		}
+
+		return $this->flowRunMapper->countRunsForFlow((string)$flow->getUuid()) > 0;
+	}//end hasEverRun()
+
+	/**
+	 * The schema slug of the register object this uuid came from, if any.
+	 *
+	 * Conjunct (6), the provenance proof. The migration preserves the source
+	 * object's uuid and leaves the register rows in place, so the object it was
+	 * copied from is still there to be asked. `findMultipleAcrossAllMagicTables()`
+	 * is used rather than `ObjectService` on purpose: it takes no register/schema
+	 * context, and inheriting a stale one is the bug being repaired.
+	 *
+	 * @param string $uuid The flow row's uuid.
+	 *
+	 * @return string|null The source object's schema slug, or null when nothing resolves.
+	 */
+	private function sourceSchemaSlug(string $uuid): ?string {
+		if (trim($uuid) === '') {
+			return null;
+		}
+
+		try {
+			$objects = $this->objectMapper->findMultipleAcrossAllMagicTables(uuids: [$uuid]);
+		} catch (Throwable $e) {
+			$this->logger->warning('[PurgePhantomMigratedFlows] could not resolve ' . $uuid . ': ' . $e->getMessage());
+			return null;
+		}
+
+		$object = ($objects[0] ?? null);
+		if ($object === null) {
+			return null;
+		}
+
+		$schemaRef = $object->getSchema();
+		if ($schemaRef === null || trim((string)$schemaRef) === '') {
+			return null;
+		}
+
+		try {
+			$schema = $this->schemaMapper->find(id: $schemaRef, _rbac: false, _multitenancy: false);
+		} catch (Throwable $e) {
+			$this->logger->warning('[PurgePhantomMigratedFlows] could not resolve schema for ' . $uuid . ': ' . $e->getMessage());
+			return null;
+		}
+
+		$slug = $schema->getSlug();
+		if ($slug === null || trim($slug) === '') {
+			return null;
+		}
+
+		return $slug;
+	}//end sourceSchemaSlug()
+}//end class

--- a/tests/Unit/Repair/MigrateRegisterFlowsToTableTest.php
+++ b/tests/Unit/Repair/MigrateRegisterFlowsToTableTest.php
@@ -47,12 +47,20 @@ class MigrateRegisterFlowsToTableTest extends TestCase {
 	/** @var array<int, string> */
 	private array $said = [];
 
+	/**
+	 * The config the step actually handed to `ObjectService::findAll()`.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private array $askedFor = [];
+
 	protected function setUp(): void {
 		$this->flowMapper    = $this->createMock(FlowMapper::class);
 		$this->objectService = $this->createMock(ObjectService::class);
 		$this->output        = $this->createMock(IOutput::class);
 
 		$this->said = [];
+		$this->askedFor = [];
 		$this->output->method('info')->willReturnCallback(function (string $m): void {
 			$this->said[] = $m;
 		});
@@ -79,7 +87,12 @@ class MigrateRegisterFlowsToTableTest extends TestCase {
 	}
 
 	private function serve(array $objects): void {
-		$this->objectService->method('findAll')->willReturn(['results' => $objects]);
+		$this->objectService->method('findAll')->willReturnCallback(
+			function (array $config = []) use ($objects): array {
+				$this->askedFor = $config;
+				return ['results' => $objects];
+			}
+		);
 	}
 
 	private function summary(): string {
@@ -261,6 +274,148 @@ class MigrateRegisterFlowsToTableTest extends TestCase {
 		// that an ObjectEntity does not have.
 		$this->assertSame('admin', $captured->getOwner());
 		$this->assertSame('org-1', $captured->getOrganisation());
+		$this->assertStringContainsString('1 migrated', $this->summary());
+	}
+
+	/**
+	 * 🔴 THE READ MUST BE SCOPED, AND THE SCOPE MUST BE WHERE THE SERVICE LOOKS.
+	 *
+	 * The step asked for `['register' => 'flows', 'schema' => 'flow']` at the TOP
+	 * LEVEL of the config. `ObjectService::prepareFindAllConfig()` only reads
+	 * `$config['filters']['register']` and `$config['filters']['schema']`, so
+	 * those two keys were inert: `setRegister()` / `setSchema()` were never
+	 * called and `findAll()` ran against whatever `$currentRegister` /
+	 * `$currentSchema` the SHARED service instance happened to be carrying.
+	 *
+	 * That is not hypothetical. `saveObject()` sets the context and — unlike
+	 * `find()`, which restores it in a `finally` — never puts it back, and
+	 * `ImportCredentialBrokerRegister` runs four repair steps before this one and
+	 * saves two example objects through it. The context this step inherited was
+	 * therefore `credential-broker` / `brokeredcredential`, and it read those two
+	 * examples as if they were flows.
+	 *
+	 * Every other `findAll()` caller in `lib/` nests the pair under `filters`.
+	 * This step was the outlier, and no test looked at the argument, because
+	 * every fixture mocked `findAll()` to return rows regardless of what was
+	 * asked for. A mock that answers any question cannot report a wrong one.
+	 */
+	public function testTheReadIsScopedWhereTheServiceActuallyLooks(): void {
+		$this->serve([]);
+
+		$this->step->run($this->output);
+
+		$this->assertSame(
+			'flows',
+			($this->askedFor['filters']['register'] ?? null),
+			'the register must be requested under `filters`, which is the only place ObjectService reads it'
+		);
+		$this->assertSame(
+			'flow',
+			($this->askedFor['filters']['schema'] ?? null),
+			'and so must the schema — a top-level key here is silently ignored'
+		);
+	}
+
+	/**
+	 * 🔴 THE ROW THAT SHIPPED. Both of `credential_broker_register.json`'s
+	 * example objects landed in `openregister_flows` on a real instance: empty
+	 * nodes, empty edges, no trigger, no trigger schema, `_owner` = `__system__`
+	 * because the import that wrote them ran sessionless.
+	 *
+	 * They are not flows and can never become flows. They sit in the table
+	 * forever, appear wherever flows are listed, and — measured — misled a
+	 * diagnosis into reading `owner=__system__` as OpenRegister's own convention
+	 * for a shipped flow, which is an artefact, not a precedent.
+	 *
+	 * The scoping fix above stops the wrong POPULATION being read. This asserts
+	 * the second, independent guard: even handed such a row, the step must
+	 * refuse to write it. A row with no nodes, no edges and no trigger has
+	 * nothing to walk and nothing to start it.
+	 */
+	public function testACredentialBrokerExampleIsNeverWrittenAsAFlow(): void {
+		$example = new ObjectEntity();
+		$example->setUuid('brokered-1');
+		$example->setOwner('__system__');
+		$example->setObject(
+			[
+				'name' => 'Gemeente Example — GitHub publisher',
+				'provider' => 'github',
+				'owner' => '00000000-0000-0000-0000-000000000000',
+				'allowedApps' => ['hermiq'],
+				'createdAt' => '2026-01-01T00:00:00+00:00',
+			]
+		);
+
+		$this->objectService->method('findAll')->willReturn([$example]);
+		$this->flowMapper->method('findByUuid')->willThrowException(new DoesNotExistException('nope'));
+		$this->flowMapper->expects($this->never())->method('insert');
+
+		$this->step->run($this->output);
+
+		$this->assertStringContainsString('0 migrated', $this->summary());
+		$this->assertStringContainsString('1 not a flow', $this->summary());
+	}
+
+	/**
+	 * The negative control for the guard above: a genuine flow shares the
+	 * credential-broker row's whole silhouette apart from having a graph, and it
+	 * must still cross. A guard that also stopped this one would be trading one
+	 * silent defect for another.
+	 */
+	public function testAGenuineFlowStillCrossesAlongsideTheArtefact(): void {
+		$real = new ObjectEntity();
+		$real->setUuid('flow-1');
+		$real->setOwner('admin');
+		$real->setOrganisation('org-1');
+		$real->setObject(
+			[
+				'name' => 'Nightly sweep',
+				'trigger' => 'schedule',
+				'cron' => '* * * * *',
+				'nodes' => [['id' => 'a']],
+				'edges' => [['from' => 'a', 'to' => 'b']],
+			]
+		);
+
+		$artefact = new ObjectEntity();
+		$artefact->setUuid('brokered-1');
+		$artefact->setOwner('__system__');
+		$artefact->setObject(['name' => 'Reisbureau Example — GitLab discovery', 'provider' => 'gitlab']);
+
+		$this->objectService->method('findAll')->willReturn([$real, $artefact]);
+		$this->flowMapper->method('findByUuid')->willThrowException(new DoesNotExistException('nope'));
+
+		$written = [];
+		$this->flowMapper->expects($this->once())->method('insert')
+			->willReturnCallback(function (Flow $f) use (&$written): Flow {
+				$written[] = $f->getUuid();
+				return $f;
+			});
+
+		$this->step->run($this->output);
+
+		$this->assertSame(['flow-1'], $written);
+		$this->assertStringContainsString('1 migrated', $this->summary());
+		$this->assertStringContainsString('1 not a flow', $this->summary());
+	}
+
+	/**
+	 * A flow whose graph is still empty but which already names a trigger IS a
+	 * flow definition — a draft someone is part-way through authoring. The guard
+	 * is "nothing to walk AND nothing to start it", not "no nodes".
+	 */
+	public function testAnEmptyGraphWithATriggerIsStillAFlow(): void {
+		$draft = new ObjectEntity();
+		$draft->setUuid('draft-1');
+		$draft->setOwner('admin');
+		$draft->setObject(['name' => 'Half-written', 'trigger' => 'object.created', 'nodes' => [], 'edges' => []]);
+
+		$this->objectService->method('findAll')->willReturn([$draft]);
+		$this->flowMapper->method('findByUuid')->willThrowException(new DoesNotExistException('nope'));
+		$this->flowMapper->expects($this->once())->method('insert')->willReturnArgument(0);
+
+		$this->step->run($this->output);
+
 		$this->assertStringContainsString('1 migrated', $this->summary());
 	}
 

--- a/tests/Unit/Repair/PurgePhantomMigratedFlowsTest.php
+++ b/tests/Unit/Repair/PurgePhantomMigratedFlowsTest.php
@@ -1,0 +1,365 @@
+<?php
+
+/**
+ * PurgePhantomMigratedFlowsTest.
+ *
+ * This step DELETES rows, and a delete is not undone by a fix in the next
+ * release. So the assertions here are symmetrical on purpose: one that the
+ * artefact is removed, and one for every conjunct of the predicate showing that
+ * dropping that conjunct alone is enough to keep a row. A test suite that only
+ * proves the deletion happens cannot tell a correct predicate from an eager one.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Repair
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @spec openspec/changes/register-descriptor-admin/specs/register-descriptor-admin/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Repair;
+
+use DateTime;
+use OCA\OpenRegister\Db\Flow;
+use OCA\OpenRegister\Db\FlowMapper;
+use OCA\OpenRegister\Db\FlowRunMapper;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Repair\PurgePhantomMigratedFlows;
+use OCP\Migration\IOutput;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Covers the purge predicate in both directions.
+ */
+class PurgePhantomMigratedFlowsTest extends TestCase {
+	private FlowMapper&MockObject $flowMapper;
+
+	private FlowRunMapper&MockObject $flowRunMapper;
+
+	private MagicMapper&MockObject $objectMapper;
+
+	private SchemaMapper&MockObject $schemaMapper;
+
+	private IOutput&MockObject $output;
+
+	private PurgePhantomMigratedFlows $step;
+
+	/** @var array<int, string> */
+	private array $said = [];
+
+	/** @var array<int, string> */
+	private array $deleted = [];
+
+	protected function setUp(): void {
+		$this->flowMapper    = $this->createMock(FlowMapper::class);
+		$this->flowRunMapper = $this->createMock(FlowRunMapper::class);
+		$this->objectMapper  = $this->createMock(MagicMapper::class);
+		$this->schemaMapper  = $this->createMock(SchemaMapper::class);
+		$this->output        = $this->createMock(IOutput::class);
+
+		$this->said    = [];
+		$this->deleted = [];
+
+		$this->output->method('info')->willReturnCallback(function (string $m): void {
+			$this->said[] = $m;
+		});
+		$this->flowMapper->method('delete')->willReturnCallback(
+			function (Flow $f): Flow {
+				$this->deleted[] = (string)$f->getUuid();
+				return $f;
+			}
+		);
+
+		// Default posture: nothing has ever run.
+		$this->flowRunMapper->method('countRunsForFlow')->willReturn(0);
+
+		$this->step = new PurgePhantomMigratedFlows(
+			$this->flowMapper,
+			$this->flowRunMapper,
+			$this->objectMapper,
+			$this->schemaMapper,
+			$this->createMock(LoggerInterface::class)
+		);
+	}
+
+	/**
+	 * The row the defect actually wrote: a copy of a `brokeredcredential`
+	 * example object, with the whole payload the migration could find.
+	 *
+	 * @param array<string, mixed> $overrides Fields to change for one case.
+	 *
+	 * @return Flow The candidate row.
+	 */
+	private function phantom(string $uuid = 'brokered-1', array $overrides = []): Flow {
+		$flow = new Flow();
+		$flow->setUuid($uuid);
+		$flow->setApp('openregister');
+		$flow->setName('Gemeente Example — GitHub publisher');
+		$flow->setEnabled(false);
+		$flow->setOwner('__system__');
+		$flow->setNodes([]);
+		$flow->setEdges([]);
+
+		foreach ($overrides as $field => $value) {
+			$flow->{'set' . ucfirst($field)}($value);
+		}
+
+		return $flow;
+	}
+
+	/**
+	 * A flow anyone would recognise as one.
+	 *
+	 * @param array<string, mixed> $overrides Fields to change for one case.
+	 *
+	 * @return Flow The row that must survive.
+	 */
+	private function realFlow(string $uuid = 'flow-1', array $overrides = []): Flow {
+		$flow = new Flow();
+		$flow->setUuid($uuid);
+		$flow->setApp('openregister');
+		$flow->setName('Nightly sweep');
+		$flow->setEnabled(false);
+		$flow->setOwner('admin');
+		$flow->setTrigger('schedule');
+		$flow->setCron('0 3 * * *');
+		$flow->setNodes([['id' => 'a']]);
+		$flow->setEdges([['from' => 'a', 'to' => 'b']]);
+
+		foreach ($overrides as $field => $value) {
+			$flow->{'set' . ucfirst($field)}($value);
+		}
+
+		return $flow;
+	}
+
+	/**
+	 * @param array<int, Flow> $flows The table contents this run sees.
+	 */
+	private function tableHolds(array $flows): void {
+		$served = false;
+		$this->flowMapper->method('findAllFlows')->willReturnCallback(
+			function () use ($flows, &$served): array {
+				if ($served === true) {
+					return [];
+				}
+
+				$served = true;
+				return $flows;
+			}
+		);
+	}
+
+	/**
+	 * Say what register object a uuid resolves back to, and under which schema.
+	 *
+	 * @param array<string, string|null> $map uuid => schema slug, or null for "nothing resolves".
+	 */
+	private function sourcesAre(array $map): void {
+		$this->objectMapper->method('findMultipleAcrossAllMagicTables')->willReturnCallback(
+			function (array $uuids) use ($map): array {
+				$uuid = (string)($uuids[0] ?? '');
+				if (array_key_exists($uuid, $map) === false || $map[$uuid] === null) {
+					return [];
+				}
+
+				$object = new ObjectEntity();
+				$object->setUuid($uuid);
+				$object->setSchema('schema-of-' . $uuid);
+				return [$object];
+			}
+		);
+
+		$this->schemaMapper->method('find')->willReturnCallback(
+			function (string|int $id) use ($map): Schema {
+				$uuid = str_replace('schema-of-', '', (string)$id);
+				$schema = new Schema();
+				$schema->setSlug($map[$uuid] ?? null);
+				return $schema;
+			}
+		);
+	}
+
+	private function summary(): string {
+		return implode(' ', $this->said);
+	}
+
+	/**
+	 * 🔴 THE ARTEFACT GOES. Both `credential_broker_register.json` examples were
+	 * copied into the flow table; each is a disabled, graph-less, triggerless,
+	 * never-dispatched copy of a `brokeredcredential` object.
+	 */
+	public function testTheCredentialBrokerArtefactIsRemoved(): void {
+		$this->tableHolds([$this->phantom('brokered-1'), $this->phantom('brokered-2')]);
+		$this->sourcesAre(['brokered-1' => 'brokeredcredential', 'brokered-2' => 'brokeredcredential']);
+
+		$this->step->run($this->output);
+
+		$this->assertSame(['brokered-1', 'brokered-2'], $this->deleted);
+		$this->assertStringContainsString('2 removed', $this->summary());
+		$this->assertStringContainsString('0 reported', $this->summary());
+	}
+
+	/**
+	 * 🔴 THE NEGATIVE CONTROL THE DELETION TEST CANNOT PROVIDE. A real flow sits
+	 * in the same table, is owned by the same app and is equally disabled.
+	 */
+	public function testARealFlowIsSparedInTheSameRun(): void {
+		$this->tableHolds([$this->phantom('brokered-1'), $this->realFlow('flow-1')]);
+		$this->sourcesAre(['brokered-1' => 'brokeredcredential', 'flow-1' => 'flow']);
+
+		$this->step->run($this->output);
+
+		$this->assertSame(['brokered-1'], $this->deleted);
+		$this->assertNotContains('flow-1', $this->deleted);
+		$this->assertStringContainsString('1 removed', $this->summary());
+	}
+
+	/**
+	 * One conjunct at a time. Each case is the artefact with exactly ONE field
+	 * changed, and each must survive — that is what makes the predicate a
+	 * conjunction rather than a hopeful list.
+	 *
+	 * @return array<string, array{0: array<string, mixed>}>
+	 */
+	public static function sparingFieldProvider(): array {
+		return [
+			'a single node' => [['nodes' => [['id' => 'a']]]],
+			'a single edge' => [['edges' => [['from' => 'a', 'to' => 'b']]]],
+			'a trigger' => [['trigger' => 'object.created']],
+			'a trigger register' => [['triggerRegister' => 'publicaties']],
+			'a trigger schema' => [['triggerSchema' => 'publicatie']],
+			'a cron expression' => [['cron' => '0 3 * * *']],
+			'being enabled' => [['enabled' => true]],
+			'a last-run uuid' => [['lastRunUuid' => 'run-9']],
+			'a last-run status' => [['lastRunStatus' => 'completed']],
+		];
+	}
+
+	/**
+	 * @dataProvider sparingFieldProvider
+	 *
+	 * @param array<string, mixed> $overrides The one field that saves the row.
+	 */
+	public function testAnyOneOfTheseFieldsSparesTheRow(array $overrides): void {
+		$this->tableHolds([$this->phantom('brokered-1', $overrides)]);
+		$this->sourcesAre(['brokered-1' => 'brokeredcredential']);
+
+		$this->step->run($this->output);
+
+		$this->assertSame([], $this->deleted, 'this field alone must be enough to keep the row');
+	}
+
+	/**
+	 * A last-run timestamp spares the row too. Kept out of the provider because
+	 * the value is an object rather than a scalar.
+	 */
+	public function testALastRunTimestampSparesTheRow(): void {
+		$this->tableHolds([$this->phantom('brokered-1', ['lastRunAt' => new DateTime()])]);
+		$this->sourcesAre(['brokered-1' => 'brokeredcredential']);
+
+		$this->step->run($this->output);
+
+		$this->assertSame([], $this->deleted);
+	}
+
+	/**
+	 * 🔴 RUN HISTORY OUTRANKS SHAPE. A row can look exactly like the artefact and
+	 * still have been part of something that happened. The `lastRun*` columns
+	 * were added by a later migration, so an older run row is the only trace —
+	 * which is why the run table is asked as well as the columns.
+	 */
+	public function testARowWithRunHistoryIsReportedNotRemoved(): void {
+		$run = $this->createMock(FlowRunMapper::class);
+		$run->method('countRunsForFlow')->willReturn(3);
+		$step = new PurgePhantomMigratedFlows(
+			$this->flowMapper,
+			$run,
+			$this->objectMapper,
+			$this->schemaMapper,
+			$this->createMock(LoggerInterface::class)
+		);
+
+		$this->tableHolds([$this->phantom('brokered-1')]);
+		$this->sourcesAre(['brokered-1' => 'brokeredcredential']);
+
+		$step->run($this->output);
+
+		$this->assertSame([], $this->deleted);
+		$this->assertStringContainsString('0 removed', $this->summary());
+		$this->assertStringContainsString('1 reported', $this->summary());
+		$this->assertStringContainsString('run history', $this->summary());
+	}
+
+	/**
+	 * 🔴 THE AMBIGUOUS CASE. An unrunnable shell whose uuid resolves to nothing
+	 * might be this defect's artefact whose source object was deleted since — or
+	 * an empty draft authored straight into the table. Nothing here can tell
+	 * those apart, so it is named in the output and left alone.
+	 */
+	public function testAnUnidentifiableShellIsReportedNotRemoved(): void {
+		$this->tableHolds([$this->phantom('orphan-1')]);
+		$this->sourcesAre(['orphan-1' => null]);
+
+		$this->step->run($this->output);
+
+		$this->assertSame([], $this->deleted);
+		$this->assertStringContainsString('1 reported', $this->summary());
+		$this->assertStringContainsString('orphan-1', $this->summary());
+	}
+
+	/**
+	 * An empty draft that IS a flow object stays. It is the shape a user gets by
+	 * creating a flow and not filling it in yet, and it is theirs.
+	 */
+	public function testAnEmptyDraftBackedByARealFlowObjectIsSpared(): void {
+		$this->tableHolds([$this->phantom('draft-1')]);
+		$this->sourcesAre(['draft-1' => 'flow']);
+
+		$this->step->run($this->output);
+
+		$this->assertSame([], $this->deleted);
+		$this->assertStringContainsString('an empty draft', $this->summary());
+	}
+
+	/**
+	 * 🔴 IDEMPOTENT. This runs on every upgrade. Once the rows are gone the step
+	 * must find nothing and say so, rather than reaching for the next-closest
+	 * thing in the table.
+	 */
+	public function testASecondRunOverACleanTableRemovesNothing(): void {
+		$this->tableHolds([$this->realFlow('flow-1')]);
+		$this->sourcesAre(['flow-1' => 'flow']);
+
+		$this->step->run($this->output);
+
+		$this->assertSame([], $this->deleted);
+		$this->assertStringContainsString('0 removed, 0 reported', $this->summary());
+	}
+
+	/**
+	 * A read that blows up must not take the upgrade with it, and must not be
+	 * reported as a clean sweep either.
+	 */
+	public function testAFailedReadIsSurvivedAndAnnounced(): void {
+		$this->flowMapper->method('findAllFlows')->willThrowException(new RuntimeException('table gone'));
+		$warned = [];
+		$this->output->method('warning')->willReturnCallback(function (string $m) use (&$warned): void {
+			$warned[] = $m;
+		});
+
+		$this->step->run($this->output);
+
+		$this->assertSame([], $this->deleted);
+		$this->assertNotEmpty($warned);
+	}
+}


### PR DESCRIPTION
## What went wrong, measured

`MigrateRegisterFlowsToTable` copies register-authored flows into `openregister_flows`. On a real instance it landed **both** of `credential_broker_register.json`'s example objects there instead: empty nodes, empty edges, no trigger, no trigger schema, `_owner` = `__system__`.

The match was not "too loose". **There was no scoping at all.**

The step asked `ObjectService::findAll()` for `['register' => 'flows', 'schema' => 'flow']` at the **top level** of the config. `prepareFindAllConfig()` reads `$config['filters']['register']` and `$config['filters']['schema']` and no other key, so both were inert: `setRegister()` / `setSchema()` were never called, and `findAll()` passed `$this->currentRegister` / `$this->currentSchema` — leftover shared instance state — down to the handler.

That state was not empty, and not random:

- `saveObject()` sets the register/schema context and **never restores it**. `find()` puts it back in a `finally`; `saveObject()` has no such block.
- `ImportCredentialBrokerRegister` runs four repair steps ahead of the migration (in `<install>` and `<post-migration>` alike) and saves its two example objects through `saveObject(register: credential-broker, schema: brokeredcredential)`.
- So the migration inherited `credential-broker` / `brokeredcredential` and read those two examples as flows.

`__system__` is just what OpenRegister stamps on a sessionless write — the import runs inside `SystemOperationContext::run()`. It is an artefact, not a convention, and it was read as precedent by a later diagnosis that nearly copied it into another app's shipped flow declarations.

Scanned every `findAll()` / `count()` caller under `lib/`: **17 of 20 nest the pair under `filters`**. This step was one of three outliers. (The other two, `VocabularyController` and `VocabularyImportService`, pass them top-level as well and set no context of their own — reported here, not changed, since neither is in this defect's path and both need their own tests.)

## The fix: two guards, because they fail independently

**Selection.** The pair moves under `filters`, with `_rbac` / `_multitenancy` off — a repair step has no session (`occ` runs as Anonymous), so a scoped read would return nothing.

**Validity.** `isFlowDefinition()` refuses any row with no nodes, no edges *and* no trigger. Not a completeness check: an empty graph that already names a trigger is a half-authored flow and still crosses.

Both, not either. The scoping guard depends on shared mutable service state staying correct for a whole `occ upgrade` — and that state is exactly what broke. The validity guard depends on nothing but the row in front of it. The summary line gained a `not a flow definition` count so a refusal is visible rather than silent.

## The repair: `PurgePhantomMigratedFlows`

Deleting rows is irreversible, so the predicate is a conjunction of proofs, not a heuristic. A row is removed **only** when all of:

1. `app` = `openregister` — the only value the migration writes;
2. disabled;
3. `nodes` empty **and** `edges` empty — nothing to walk;
4. `trigger`, `triggerRegister`, `triggerSchema`, `cron` all empty — nothing that could start it;
5. never dispatched: `lastRunUuid`, `lastRunAt`, `lastRunStatus` all null **and** zero rows in `openregister_flow_runs`;
6. its uuid still resolves to a register object whose schema is **not** `flow`.

(1)–(5) prove the row cannot run and never has. (6) proves it is *this defect's artefact* rather than somebody's empty draft — the migration preserves the source uuid and leaves register rows in place, so the object it was copied from is still there to be asked. Resolved via `MagicMapper::findMultipleAcrossAllMagicTables()`, which takes no register/schema context — inheriting a stale one is the bug being repaired.

**What it deliberately spares:** any flow with one node or one edge; any flow naming a trigger, trigger register/schema or cron, including a graph-less draft; any enabled flow; anything with run history, even one terminal run; any other app's flow. And the ambiguous case — an unrunnable shell that resolves to nothing, or to a real `flow` object — is **named in the output by uuid and left alone**. Its source may have been deleted since, or it may be a genuine empty draft, and nothing here can tell those apart. Erring toward keeping an unrunnable row is recoverable; erring the other way is not.

Idempotent. Post-migration only: a fresh install runs the fixed migration, which cannot produce these rows.

## Tests

**Migration** (proved red first — 3 failures on the unfixed code):
- the read is scoped where `ObjectService` actually looks (`filters.register` / `filters.schema`) — this is the assertion that was missing, because every fixture mocked `findAll()` to answer regardless of what was asked, and a mock that answers any question cannot report a wrong one;
- a `brokeredcredential` example — the real payload, verbatim from the descriptor — is never written as a flow;
- **negative control:** a genuine flow in the same batch still crosses;
- **negative control:** an empty graph that names a trigger is still a flow.

**Repair** (17 tests, then mutation-proved in six directions — each mutation reddens only the tests that conjunct is responsible for):

| conjunct removed | tests that go red |
|---|---|
| provenance (source schema ignored) | empty-draft-backed-by-a-flow-object |
| shell shape never matches | 5, including both removal tests |
| trigger / triggerRegister / triggerSchema / cron | 4 provider cases |
| never-dispatched (`lastRun*` + run rows) | 4 |
| disabled | being-enabled |
| empty graph | single-node, single-edge |

Every conjunct is load-bearing and independently proven. Negative controls throughout: a real flow spared in the same run as the artefact is deleted; a shell with run history reported, not removed; an unidentifiable shell reported, not removed; a clean table yields `0 removed, 0 reported`.

## Also

Completed `Flow`'s `@method` roster. `status`, `statusMessage` and the four `lastRun*` accessors were added as columns by `Version1Date20260805100000` and never declared, so phpstan could not see them — it flagged all three `lastRun*` getters as undefined the first time anything called them.

## Verified locally

CI is bottlenecked, so this was verified on this host and merged on local green. Each run's **exit code**, not its summary line:

- `composer phpcs` — **0**
- `phpstan analyse` — **0** (`No errors`)
- `psalm --threads=4 --no-cache` — **0** (`No errors found!`), re-run after the rebase
- `phpmd` **per subdirectory** (never full-tree — it OOM-kills this host): `lib/Repair`, `lib/Controller`, `lib/AppHost`, `lib/BackgroundJob`, `lib/Migration`, `lib/Settings`, `lib/Service/{Object,Configuration,Flow,Schema}` and the four changed files individually — all **0**. `lib/Db` reports one NPath-486 finding in `MagicMapper/MagicSearchHandler.php`, which is **pre-existing on `origin/development`** (arrived with #3405), is not in this diff, and reproduces identically on a pristine `origin/development` copy of that file.
- `phpunit --testsuite "Unit Tests"` — **18,880 tests, 45,856 assertions, zero failures**. Exit 1 is the host's `No code coverage driver available` warning, confirmed identical on the untouched baseline before any change.
- hydra gates **v1.12.0** `--scope-to-diff` with `HYDRA_GATE_BASE_REF=origin/development` — **0**. COVERAGE: 29 of 29 applicable gates ran and passed, including gate-98 `repair-step-registration` (the new step's `info.xml` wiring) and gate-97 `system-elevation-reachability`.

No coverage driver on this box, so strict-coverage RISKY cannot be observed locally. `phpunit.xml` sets `requireCoverageMetadata="false"`, and the new test carries no `@covers` roster — matching its sibling `MigrateRegisterFlowsToTableTest` and 9 of 17 tests under `tests/Unit/Repair/` — rather than declaring a roster nothing here can check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
