### PR TITLE
fix(tests): filter the audit-trail check on object_uuid, not the integer object column

### DIFF
--- a/tests/Db/RawAppendIntegrationTest.php
+++ b/tests/Db/RawAppendIntegrationTest.php
@@ -156,7 +156,7 @@ class RawAppendIntegrationTest extends TestCase {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select($qb->func()->count('id', 'cnt'))
 			->from('openregister_audit_trails')
-			->where($qb->expr()->in('object', $qb->createNamedParameter($uuids, IQueryBuilder::PARAM_STR_ARRAY)));
+			->where($qb->expr()->in('object_uuid', $qb->createNamedParameter($uuids, IQueryBuilder::PARAM_STR_ARRAY)));
 		$result = $qb->executeQuery();
 		$count = (int) $result->fetchOne();
 		$result->closeCursor();


### PR DESCRIPTION
## What

`tests/Db/RawAppendIntegrationTest.php` (merged in #3407, `@group DB`) had never run: it needs a booted Nextcloud. Run for real inside a Nextcloud 34 container with openregister at `development`, on Postgres, it errors before its first raw-append assertion:

```
SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input syntax for type integer: "raw-expired"
```

`countAuditRowsFor()` filtered `openregister_audit_trails.object` by UUID, but that column is the integer object id (`Version1Date20241020231700`). The UUID lives in `object_uuid`, which is the column `AuditTrailMapper` itself filters on. MySQL would have coerced the comparison silently, so only a Postgres run could show it.

Two commits:

1. The behavioural fix: filter on `object_uuid`.
2. Style: the file was written this morning and never met the phpcs standard (`phpcs.xml` scopes `lib/`, so CI never saw it). 42 errors and 3 warnings hand-fixed, `phpcbf` had nothing mechanical to offer: member, `setUp`/`tearDown` and helper docblocks, `@param`/`@return` tags, named arguments on assertions and helper calls, two fixture lines over 150 characters hoisted into variables, inline comments ending in a full stop. No behaviour change.

## Verification (local only, CI queue is bottlenecked)

Inside the container, as www-data, from `/var/www/html/custom_apps/openregister`, with a dev `vendor/` staged in `/tmp`:

```
php /tmp/or-devvendor/vendor/bin/phpunit -c phpunit.xml --no-coverage --group DB tests/Db/RawAppendIntegrationTest.php
```

Before: `Tests: 3, Assertions: 8, Errors: 1`, exit 2.
After commit 1: `OK (3 tests, 14 assertions)`, exit 0.
After commit 2: `OK (3 tests, 14 assertions)`, exit 0.

`./vendor/bin/phpcs --standard=phpcs.xml tests/Db/RawAppendIntegrationTest.php`: exit 0 (was exit 1 with 42 errors, 3 warnings).
`php -l`: exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
