### PR TITLE
fix(store): serve the built-in items the manifest declares

### DIFF
--- a/lib/AppHost/Controller/GenericStoreController.php
+++ b/lib/AppHost/Controller/GenericStoreController.php
@@ -157,7 +157,12 @@ class GenericStoreController extends Controller {
 			// not_configured rather than 404: the page then renders its
 			// (empty) built-in list instead of reading as a broken endpoint.
 			return new JSONResponse(
-				data: ['outcome' => GenericStoreService::OUTCOME_NOT_CONFIGURED, 'cards' => [], 'kinds' => []],
+				data: [
+					'outcome' => GenericStoreService::OUTCOME_NOT_CONFIGURED,
+					'cards' => [],
+					'kinds' => [],
+					'builtIn' => [],
+				],
 				statusCode: Http::STATUS_OK
 			);
 		}
@@ -183,7 +188,12 @@ class GenericStoreController extends Controller {
 				context: ['file' => __FILE__, 'line' => __LINE__]
 			);
 			return new JSONResponse(
-				data: ['outcome' => GenericStoreService::OUTCOME_UNREACHABLE, 'cards' => [], 'kinds' => $store->kinds],
+				data: [
+					'outcome' => GenericStoreService::OUTCOME_UNREACHABLE,
+					'cards' => [],
+					'kinds' => $store->kinds,
+					'builtIn' => $store->builtIn,
+				],
 				statusCode: Http::STATUS_OK
 			);
 		}
@@ -200,11 +210,25 @@ class GenericStoreController extends Controller {
 			$kinds = $store->declaredTypes();
 		}
 
+		// 🔴 `builtIn` RIDES BACK FOR THE SAME REASON `kinds` DOES.
+		//
+		// An app declares its own items ONCE, in the `store` block beside the
+		// allowlist. StoreManifest parses them and, until now, nothing ever
+		// sent them anywhere: `CnStorePage`'s `builtIn` prop is fed from the
+		// PAGE CONFIG, which is a second place to write the same list. An app
+		// that declared them only in the `store` block therefore rendered an
+		// empty store while its manifest said otherwise.
+		//
+		// Measured on decidiq, which declares four example sets and showed
+		// none of them: the search response carried `outcome`, `cards` and
+		// `kinds`, and no `builtIn` key at all. ADR-080 Decision 4 exists to
+		// stop precisely that blank surface.
 		return new JSONResponse(
 			data: [
 				'outcome' => $result['outcome'],
 				'cards' => $result['cards'],
 				'kinds' => $kinds,
+				'builtIn' => $store->builtIn,
 			],
 			statusCode: Http::STATUS_OK
 		);

--- a/tests/Unit/AppHost/GenericStoreControllerTest.php
+++ b/tests/Unit/AppHost/GenericStoreControllerTest.php
@@ -308,6 +308,60 @@ class GenericStoreControllerTest extends TestCase {
 	}//end testFederatedSearchFailureIsContained()
 
 	/**
+	 * The app's own items ride back with the cards.
+	 *
+	 * They are declared ONCE, in the `store` block. StoreManifest parsed them
+	 * and nothing ever sent them anywhere, because CnStorePage's `builtIn`
+	 * prop is fed from the PAGE CONFIG — a second place to write the same
+	 * list. An app that declared them only in the `store` block rendered an
+	 * empty store while its manifest said otherwise. Measured on decidiq,
+	 * which declares four example sets and showed none.
+	 *
+	 * @return void
+	 */
+	public function testSearchServesTheBuiltInItemsTheManifestDeclares(): void {
+		$this->signIn();
+		$this->manifestLoader->method('loadStore')->willReturn(
+			StoreManifest::fromManifest(
+				appId: 'decidiq',
+				manifest: [
+					'store' => [
+						'types' => ['openregister.configset'],
+						'builtIn' => [
+							['slug' => 'municipality', 'title' => 'Municipality'],
+							['slug' => 'association', 'title' => 'Association or VvE'],
+						],
+					],
+				]
+			)
+		);
+		$this->catalog->method('search')->willReturn(['outcome' => 'ok', 'cards' => []]);
+
+		$data = $this->controller(appId: 'decidiq')->search()->getData();
+
+		$this->assertArrayHasKey('builtIn', $data);
+		$this->assertCount(2, $data['builtIn']);
+		$this->assertSame('municipality', $data['builtIn'][0]['slug']);
+	}//end testSearchServesTheBuiltInItemsTheManifestDeclares()
+
+	/**
+	 * With no store block at all there is nothing to ship, and the key is
+	 * still present so the page never has to null-check it.
+	 *
+	 * @return void
+	 */
+	public function testBuiltInIsAnEmptyListWhenNoStoreIsDeclared(): void {
+		$this->signIn();
+		$this->manifestLoader->method('loadStore')
+			->willReturn(new StoreManifest(appId: 'keepiq', enabled: false));
+
+		$data = $this->controller(appId: 'keepiq')->search()->getData();
+
+		$this->assertArrayHasKey('builtIn', $data);
+		$this->assertSame([], $data['builtIn']);
+	}//end testBuiltInIsAnEmptyListWhenNoStoreIsDeclared()
+
+	/**
 	 * An anonymous caller gets an explicit 401, not a login redirect.
 	 *
 	 * @return void


### PR DESCRIPTION
## The defect

An app declares its own store items **once**, in the `store` block beside the allowlist, where the manifest schema documents them. `StoreManifest` parses them into `$store->builtIn`.

Nothing ever sent them anywhere.

`CnStorePage`'s `builtIn` prop is fed from the **page config** — a second place to write the same list. An app that declared them only in the `store` block rendered an empty store while its manifest said otherwise.

Measured on decidiq, which declares four example sets (municipality, association, company board, works council) and showed none:

```json
{"outcome":"ok","cards":[],"kinds":["openregister.configset","openregister.flows"]}
```

No `builtIn` key at all.

## Why this shape is already the house style

`kinds` sits right beside it and rides back for exactly this reason. Its own comment in this file says so:

> Declared ONCE here, beside the allowlist: the engine returns them in the search response and CnStorePage prefers them over its page config.

`builtIn` now does the same.

## The early returns matter most

`not_configured` and `store_unreachable` are precisely when the app's own items are **all there is to show**, so both carry the list too. ADR-080 Decision 4 exists to stop that surface going blank, and those are the two paths where it would.

The `not_configured` branch returns an empty list rather than omitting the key, so the page never has to null-check it.

## Checks

| check | result |
| --- | --- |
| phpunit (AppHost) | 297 passed, 712 assertions (2 new) |
| phpcs | clean |
| phpmd | clean |

The companion change in `nextcloud-vue` makes `CnStorePage` prefer the served list, mirroring how it already prefers served `kinds`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
