### PR TITLE
chore(deps): bump conduction/hydra-gates to v1.13.0 (gate-57 DeleteFileHandler follow-up)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6872,16 +6872,16 @@
         },
         {
             "name": "conduction/hydra-gates",
-            "version": "v1.12.0",
+            "version": "v1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ConductionNL/.github.git",
-                "reference": "7bc237a750f6a096656289e922c2ee8271c0232e"
+                "reference": "a4f5c471451220ea4dc48492cb8ffdce5aa22449"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/7bc237a750f6a096656289e922c2ee8271c0232e",
-                "reference": "7bc237a750f6a096656289e922c2ee8271c0232e",
+                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/a4f5c471451220ea4dc48492cb8ffdce5aa22449",
+                "reference": "a4f5c471451220ea4dc48492cb8ffdce5aa22449",
                 "shasum": ""
             },
             "require": {
@@ -6920,9 +6920,9 @@
             "support": {
                 "docs": "https://github.com/ConductionNL/.github/blob/main/hydra-gates/README.md",
                 "issues": "https://github.com/ConductionNL/.github/issues",
-                "source": "https://github.com/ConductionNL/.github/tree/v1.12.0"
+                "source": "https://github.com/ConductionNL/.github/tree/v1.13.0"
             },
-            "time": "2026-09-03T19:35:41+00:00"
+            "time": "2026-09-04T14:12:31+00:00"
         },
         {
             "name": "consolidation/annotated-command",


### PR DESCRIPTION
## What

Bumps `conduction/hydra-gates` v1.12.0 → v1.13.0 in `composer.lock` (fixes gate-22/53's refusal of the `store` page type). `vendor-bin/phpunit/composer.lock` picked up an unrelated `platform-overrides` block from the same update and was reverted to keep this to the one dependency.

## The gate-57 finding: already resolved, nothing to wire or delete

Gate-57 (orphaned-write-capability) reported `DeleteFileHandler::deleteFiles()`. Investigated as a question, not an instruction:

- `grep -rn deleteFiles lib/ tests/ openspec/` on `development` finds no code at all: only the archived retrofit change (`openspec/changes/archive/2026-05-31-retrofit-2026-05-24-file-actions/`) and a stale entry in the generated `openspec/coverage-report.json`. The live `openspec/specs/file-actions/spec.md` never names `deleteFiles`; its batch-delete scenario (line 510) is the routed `FilesController::batch()` path.
- `git log -S"function deleteFiles"` shows it was removed by fa805d7 (#3404, on `development`) with the option-(1) evidence: it was a second, unreferenced implementation of the loop `FileBatchHandler::executeBatch()` already runs through `FileService::deleteFile()` on `appinfo/routes.php:904`, and that path is what produces the per-file results the spec asks for.

So the finding was pre-existing relative to the gate report but not relative to `development`. This PR carries only the lock bump the follow-up asked for. Not touched: the stale `deleteFiles` row in `openspec/coverage-report.json` (a generated scan artefact no gate reads).

## Verification (local only, CI queue is bottlenecked)

All on this branch, clone at `origin/development` + this commit:

- `composer update conduction/hydra-gates`: exit 0, lock at v1.13.0, `vendor/composer/installed.json` confirms v1.13.0.
- `HYDRA_GATE_BASE_REF=origin/development bash vendor/conduction/hydra-gates/hydra-gates/scripts/run-hydra-gates.sh`: exit 0. COVERAGE: 76 of 88 declared gates reported a result, 76 of 76 applicable ran. gate-57 PASS, gate-6 PASS, gate-22 PASS, gate-53 PASS. gate-19 warns (902 scenarios without `@e2e`, advisory, pre-existing). gate-16 and gate-101 reported NOT APPLICABLE ("no delta base resolved") even with `HYDRA_GATE_BASE_REF` set; this diff has no PHP, so there is nothing for them to judge here, but that message is worth a look in the runner.
- `composer phpcs`: exit 0.
- `./vendor/bin/psalm --threads=1 --no-cache`: exit 0, "No errors". `./vendor/bin/phpstan analyse --memory-limit=1G`: exit 0. Both run directly because `composer psalm`/`composer phpstan` hit composer's 300 s process timeout on a loaded box, not a finding.
- phpunit and phpmd: not run, no PHP file changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
