### PR TITLE
fix(objects): a write no longer leaves its scope behind for the next reader

### DIFF
--- a/lib/Controller/VocabularyController.php
+++ b/lib/Controller/VocabularyController.php
@@ -216,11 +216,20 @@ class VocabularyController extends Controller {
 		$offset = max(0, (int)$this->request->getParam('_offset', 0));
 
 		try {
+			// The pair goes UNDER `filters`. `ObjectService::prepareFindAllConfig()`
+			// reads `$config['filters']['register']` and
+			// `$config['filters']['schema']` and no other key, so a top-level pair
+			// is read by nothing: the read then ran on whatever register/schema
+			// the last write left on the shared service. See openregister#3408,
+			// where exactly this shape made a repair step copy two
+			// `brokeredcredential` examples into the flow table.
 			$all = $this->objectService->findAll(
 				config: [
-					'register' => self::REGISTER,
-					'schema' => self::SCHEMA_CONCEPT,
-					'filters' => ['inScheme' => $schemeUuid],
+					'filters' => [
+						'register' => self::REGISTER,
+						'schema' => self::SCHEMA_CONCEPT,
+						'inScheme' => $schemeUuid,
+					],
 					'limit' => self::MAX_SCHEME_CONCEPTS,
 				]
 			);
@@ -296,11 +305,18 @@ class VocabularyController extends Controller {
 	 */
 	private function findOneBy(string $schema, array $filters): ?ObjectEntity {
 		try {
+			// The pair goes UNDER `filters` — see listConcepts() for why a
+			// top-level pair is inert. `$filters` is spread after the pair so a
+			// caller can never shadow the scope with a field of the same name.
 			$results = $this->objectService->findAll(
 				config: [
-					'register' => self::REGISTER,
-					'schema' => $schema,
-					'filters' => $filters,
+					'filters' => array_merge(
+						$filters,
+						[
+							'register' => self::REGISTER,
+							'schema' => $schema,
+						]
+					),
 					'limit' => 1,
 				]
 			);

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -766,6 +766,61 @@ class ObjectService implements ObjectServiceInterface
     }//end discardPendingSchemaRef()
 
     /**
+     * Put back the scope an entry point found, after it resolved its own.
+     *
+     * THE CONTRACT THIS ESTABLISHES.
+     *
+     * `setRegister()` / `setSchema()` are the CALLER'S way of anchoring this
+     * shared service, and they are meant to persist: the fluent pattern
+     * `setRegister($r)->setSchema($s)` followed by `findAll()` is how a dozen
+     * controllers scope a read, and nothing here changes that.
+     *
+     * An entry point that takes `register:` / `schema:` ARGUMENTS is a different
+     * thing. It is scoping ITSELF, for the duration of one operation, and the
+     * scope belongs to that operation — not to whoever calls next. Leaving it
+     * behind turns a write into an invisible `setRegister()`/`setSchema()` on a
+     * service instance that is reused for the whole request (and, under `occ`,
+     * for a whole `upgrade` run).
+     *
+     * WHY THIS IS NOT HYPOTHETICAL. `find()` has restored its context in a
+     * `finally` since BUG-OBJ-13 (openregister#1520). `saveObject()` never did,
+     * and openregister#3408 is what that costs: `ImportCredentialBrokerRegister`
+     * saved two example objects through
+     * `saveObject(register: credential-broker, schema: brokeredcredential)`, and
+     * four repair steps later `MigrateRegisterFlowsToTable` — whose own read was
+     * unscoped — inherited that pair and copied two `brokeredcredential`
+     * examples into `openregister_flows` as flows. Deterministically, on every
+     * install and every `occ upgrade`, with no error anywhere.
+     *
+     * That defect was fixed at its call site. This is the same fix at the source,
+     * so the next unscoped reader after a write inherits NOTHING rather than
+     * inheriting the write's scope.
+     *
+     * WHERE THIS IS CALLED FROM. Every entry point that resolves a scope from
+     * its own arguments, in a `finally` so a throw restores too: `saveObject()`,
+     * `saveObjects()`, `saveObjectsStreaming()`, `patchObject()`,
+     * `deleteObject()` and `findSilent()`. `find()` predates this helper and
+     * keeps its own inline restore, documented at BUG-OBJ-13.
+     *
+     * @param Register|null $register The register context to put back.
+     * @param Schema|null   $schema   The schema context to put back.
+     *
+     * @return void
+     *
+     * @spec exclude Context hygiene shared by every scoping entry point; no business rule of its own.
+     */
+    private function restoreScopeContext(?Register $register, ?Schema $schema): void
+    {
+        $this->currentRegister = $register;
+        $this->currentSchema   = $schema;
+        // The pending ref is CLEARED rather than restored, exactly as find()
+        // does: the restored schema is an already-resolved ENTITY, so a
+        // surviving raw ref would only give the next setRegister() something
+        // unrelated to re-resolve.
+        $this->currentSchemaRef = null;
+    }//end restoreScopeContext()
+
+    /**
      * Get the register entity resolved by the last setRegister() call.
      *
      * Exposes the already-resolved entity so callers (e.g. controllers that
@@ -1193,27 +1248,38 @@ class ObjectService implements ObjectServiceInterface
         bool $_rbac=true,
         bool $_multitenancy=true
     ): ObjectEntity {
-        $this->discardPendingSchemaRef();
-        // Check if a register is provided and set the current register context.
-        if ($register !== null) {
-            $this->setRegister(register: $register);
-        }
+        // Same contract as find(), which has restored its context since
+        // BUG-OBJ-13. findSilent() differs from find() only in skipping the
+        // audit row; there is no reason for it to differ in what it leaves
+        // behind. See restoreScopeContext().
+        $previousRegister = $this->currentRegister;
+        $previousSchema   = $this->currentSchema;
 
-        // Check if a schema is provided and set the current schema context.
-        if ($schema !== null) {
-            $this->setSchema(schema: $schema);
-        }
+        try {
+            $this->discardPendingSchemaRef();
+            // Check if a register is provided and set the current register context.
+            if ($register !== null) {
+                $this->setRegister(register: $register);
+            }
 
-        // Use the silent find method from the GetObject handler.
-        return $this->getHandler->findSilent(
-            id: $id,
-            register: $this->currentRegister,
-            schema: $this->currentSchema,
-            _extend: $_extend,
-            files: $files,
-            _rbac: $_rbac,
-            _multitenancy: $_multitenancy
-        );
+            // Check if a schema is provided and set the current schema context.
+            if ($schema !== null) {
+                $this->setSchema(schema: $schema);
+            }
+
+            // Use the silent find method from the GetObject handler.
+            return $this->getHandler->findSilent(
+                id: $id,
+                register: $this->currentRegister,
+                schema: $this->currentSchema,
+                _extend: $_extend,
+                files: $files,
+                _rbac: $_rbac,
+                _multitenancy: $_multitenancy
+            );
+        } finally {
+            $this->restoreScopeContext(register: $previousRegister, schema: $previousSchema);
+        }
     }//end findSilent()
 
     /**
@@ -1501,295 +1567,308 @@ class ObjectService implements ObjectServiceInterface
         bool $failIfExists=false,
         bool $_unowned=false
     ): ObjectEntity {
-        $this->discardPendingSchemaRef();
-        // Bound the folder-access revalidation cache to this single save call
-        // (not the whole FileService/request lifetime), so a cascade save that
-        // moves or trashes a folder mid-request can't be waved through on a
-        // stale "accessible" verdict from an earlier write.
-        $this->fileService->resetFolderAccessRevalidationCache();
+        // A SAVE SCOPES ITSELF; IT DOES NOT SCOPE THE NEXT CALLER.
+        //
+        // See restoreScopeContext() for the contract and for openregister#3408,
+        // the defect this leak produced. A caller that anchored the service with
+        // setRegister()/setSchema() and then saves WITHOUT naming a scope is
+        // unaffected: the snapshot and the restore are the same context.
+        $previousRegister = $this->currentRegister;
+        $previousSchema   = $this->currentSchema;
 
-        \OCA\OpenRegister\Service\WritePhaseProbe::mark('start');
+        try {
+            $this->discardPendingSchemaRef();
+            // Bound the folder-access revalidation cache to this single save call
+            // (not the whole FileService/request lifetime), so a cascade save that
+            // moves or trashes a folder mid-request can't be waved through on a
+            // stale "accessible" verdict from an earlier write.
+            $this->fileService->resetFolderAccessRevalidationCache();
 
-        // Set register/schema context.
-        $this->setContextFromParameters(
-            register: $register,
-            schema: $schema
-        );
+            \OCA\OpenRegister\Service\WritePhaseProbe::mark('start');
 
-        // Extract UUID and convert ObjectEntity to array if needed.
-        [$object, $uuid] = $this->extractUuidAndNormalizeObject(
-            object: $object,
-            uuid: $uuid
-        );
-
-        // Check permissions for CREATE or UPDATE operation.
-        \OCA\OpenRegister\Service\WritePhaseProbe::mark('pc:context+uuid');
-
-        $this->checkSavePermissions(
-            uuid: $uuid,
-            _rbac: $_rbac
-        );
-
-        \OCA\OpenRegister\Service\WritePhaseProbe::mark('pc:permissions.check');
-
-        // Reject updates to transferred objects (archiefstatus = overgebracht).
-        if ($uuid !== null) {
-            $this->rejectIfTransferred(uuid: $uuid);
-        }
-
-        // Reject UPDATE operations on append-only schemas (INSERT is still allowed).
-        if ($uuid !== null && $this->currentSchema !== null && $this->currentSchema->isAppendOnly() === true) {
-            $schemaSlug = $this->currentSchema->getSlug() ?? (string) $this->currentSchema->getId();
-            throw new AppendOnlyException(
-                schemaIdentifier: $schemaSlug,
-                operation: 'update'
+            // Set register/schema context.
+            $this->setContextFromParameters(
+                register: $register,
+                schema: $schema
             );
-        }
 
-        // Track if UUID was originally null (to distinguish user-provided vs auto-generated UUIDs).
-        $uuidWasNull = ($uuid === null);
+            // Extract UUID and convert ObjectEntity to array if needed.
+            [$object, $uuid] = $this->extractUuidAndNormalizeObject(
+                object: $object,
+                uuid: $uuid
+            );
 
-        // Handle cascading relations while preserving context.
-        \OCA\OpenRegister\Service\WritePhaseProbe::mark('pc:permissions');
+            // Check permissions for CREATE or UPDATE operation.
+            \OCA\OpenRegister\Service\WritePhaseProbe::mark('pc:context+uuid');
 
-        [$object, $uuid] = $this->handleCascadingWithContextPreservation(
-            object: $object,
-            uuid: $uuid
-        );
+            $this->checkSavePermissions(
+                uuid: $uuid,
+                _rbac: $_rbac
+            );
 
-        // If UUID was null and is now set, mark it as auto-generated in object data.
-        // This allows SaveObject to distinguish between user-provided UUIDs (UPDATE)
-        // and auto-generated UUIDs (CREATE).
-        if ($uuidWasNull === true && $uuid !== null) {
-            // Store flag in @self to indicate this is a CREATE operation.
-            if (isset($object['@self']) === false || is_array($object['@self']) === false) {
-                $object['@self'] = [];
+            \OCA\OpenRegister\Service\WritePhaseProbe::mark('pc:permissions.check');
+
+            // Reject updates to transferred objects (archiefstatus = overgebracht).
+            if ($uuid !== null) {
+                $this->rejectIfTransferred(uuid: $uuid);
             }
 
-            $object['@self']['_autoGeneratedUuid'] = true;
-            $this->logger->debug(
-                message: '[ObjectService] UUID auto-generated by CascadingHandler, marking as CREATE operation',
-                context: [
-                    'file'     => __FILE__,
-                    'line'     => __LINE__,
-                    'uuid'     => $uuid,
-                    'register' => $this->currentRegister?->getId(),
-                    'schema'   => $this->currentSchema?->getId(),
-                ]
+            // Reject UPDATE operations on append-only schemas (INSERT is still allowed).
+            if ($uuid !== null && $this->currentSchema !== null && $this->currentSchema->isAppendOnly() === true) {
+                $schemaSlug = $this->currentSchema->getSlug() ?? (string) $this->currentSchema->getId();
+                throw new AppendOnlyException(
+                    schemaIdentifier: $schemaSlug,
+                    operation: 'update'
+                );
+            }
+
+            // Track if UUID was originally null (to distinguish user-provided vs auto-generated UUIDs).
+            $uuidWasNull = ($uuid === null);
+
+            // Handle cascading relations while preserving context.
+            \OCA\OpenRegister\Service\WritePhaseProbe::mark('pc:permissions');
+
+            [$object, $uuid] = $this->handleCascadingWithContextPreservation(
+                object: $object,
+                uuid: $uuid
             );
-        }
 
-        // BUG-OBJ-4: applyAlwaysDefaults() and validateObjectIfRequired()
-        // both dereference $this->currentSchema (non-nullable param /
-        // ->getHardValidation()). If the schema could not be resolved from
-        // the request we would otherwise emit a raw TypeError 500 here.
-        // Throw a structured ValidationException instead, which the
-        // controllers translate into a clean 400 via handleValidationException().
-        if ($this->currentSchema === null) {
-            throw new ValidationException(
-                message: 'Schema could not be resolved for this object; provide a valid register/schema.'
-            );
-        }
+            // If UUID was null and is now set, mark it as auto-generated in object data.
+            // This allows SaveObject to distinguish between user-provided UUIDs (UPDATE)
+            // and auto-generated UUIDs (CREATE).
+            if ($uuidWasNull === true && $uuid !== null) {
+                // Store flag in @self to indicate this is a CREATE operation.
+                if (isset($object['@self']) === false || is_array($object['@self']) === false) {
+                    $object['@self'] = [];
+                }
 
-        // Apply "always" defaults BEFORE validation.
-        // This ensures computed/derived properties (e.g., dienstType from type) are set
-        // before validation runs, allowing them to override invalid incoming values.
-        $object = $this->saveHandler->applyAlwaysDefaults(
-            schema: $this->currentSchema,
-            data: $object
-        );
+                $object['@self']['_autoGeneratedUuid'] = true;
+                $this->logger->debug(
+                    message: '[ObjectService] UUID auto-generated by CascadingHandler, marking as CREATE operation',
+                    context: [
+                        'file'     => __FILE__,
+                        'line'     => __LINE__,
+                        'uuid'     => $uuid,
+                        'register' => $this->currentRegister?->getId(),
+                        'schema'   => $this->currentSchema?->getId(),
+                    ]
+                );
+            }
 
-        // Normalize date values BEFORE validation.
-        // Accepts datetime input (e.g. "2024-01-15T10:30:00+02:00") for date fields
-        // and casts it to date-only (e.g. "2024-01-15") so Opis validation passes.
-        $object = $this->normalizeDateValues(object: $object);
+            // BUG-OBJ-4: applyAlwaysDefaults() and validateObjectIfRequired()
+            // both dereference $this->currentSchema (non-nullable param /
+            // ->getHardValidation()). If the schema could not be resolved from
+            // the request we would otherwise emit a raw TypeError 500 here.
+            // Throw a structured ValidationException instead, which the
+            // controllers translate into a clean 400 via handleValidationException().
+            if ($this->currentSchema === null) {
+                throw new ValidationException(
+                    message: 'Schema could not be resolved for this object; provide a valid register/schema.'
+                );
+            }
 
-        // Auto-seed a graph-lifecycle field from the parent on CREATE only,
-        // BEFORE validation, so a required `$ref` lifecycle field passes on a
-        // seeded create. $uuidWasNull is the create signal (updates always
-        // carry a UUID); the seed itself is empty-field-only and fail-soft, so
-        // it never overwrites a client-supplied value. See the object-lifecycle
-        // spec: fk-graph-lifecycle-transitions.
-        if ($uuidWasNull === true) {
-            $object = $this->saveHandler->seedLifecycleFieldOnCreate(
+            // Apply "always" defaults BEFORE validation.
+            // This ensures computed/derived properties (e.g., dienstType from type) are set
+            // before validation runs, allowing them to override invalid incoming values.
+            $object = $this->saveHandler->applyAlwaysDefaults(
                 schema: $this->currentSchema,
                 data: $object
             );
-        }
 
-        \OCA\OpenRegister\Service\WritePhaseProbe::mark('prepare+cascade');
+            // Normalize date values BEFORE validation.
+            // Accepts datetime input (e.g. "2024-01-15T10:30:00+02:00") for date fields
+            // and casts it to date-only (e.g. "2024-01-15") so Opis validation passes.
+            $object = $this->normalizeDateValues(object: $object);
 
-        // Validate if hard validation is enabled.
-        $this->validateObjectIfRequired(object: $object);
-        \OCA\OpenRegister\Service\WritePhaseProbe::mark('validate');
-
-        // Wave-12 Fix 1: enforce JSON-Schema `readOnly: true` on UPDATE.
-        // Skipped on CREATE (no prior value to violate). Loads the existing
-        // object exactly once so the check is data-driven, not metadata-only.
-        $this->enforceReadOnlyOnUpdate(object: $object, uuid: $uuid);
-
-        \OCA\OpenRegister\Service\WritePhaseProbe::mark('folder.readonly');
-
-        // Ensure folder exists for the object.
-        $folderId = $this->ensureObjectFolder(uuid: $uuid, currentUser: $currentUser);
-
-        \OCA\OpenRegister\Service\WritePhaseProbe::mark('folder.ensure');
-
-        // Clear request-scoped caches before starting a new top-level save operation.
-        // This ensures cascade operations benefit from caching while avoiding stale data.
-        $this->saveHandler->clearAllCaches();
-
-        \OCA\OpenRegister\Service\WritePhaseProbe::mark('folder');
-
-        // Delegate to SaveObject handler for actual save operation.
-        $savedObject = $this->saveHandler->saveObject(
-            register: $this->currentRegister,
-            schema: $this->currentSchema,
-            data: $object,
-            uuid: $uuid,
-            folderId: $folderId,
-            _rbac: $_rbac,
-            _multitenancy: $_multitenancy,
-            persist: true,
-            silent: $silent,
-            _validation: $_validation,
-            uploadedFiles: $uploadedFiles,
-            currentUser: $currentUser,
-            failIfExists: $failIfExists,
-            _unowned: $_unowned
-        );
-
-        // Invalidate contact matching cache for objects with email properties.
-        // BUG-OBJ-9: invalidate against the SAVED object's data (final UUID +
-        // applied defaults), not the pre-save input array, so an email value
-        // injected by a default/computed property is also invalidated.
-        try {
-            $container = \OC::$server;
-            if ($container !== null) {
-                $contactMatchingService = $container->get(
-                    \OCA\OpenRegister\Service\ContactMatchingService::class
+            // Auto-seed a graph-lifecycle field from the parent on CREATE only,
+            // BEFORE validation, so a required `$ref` lifecycle field passes on a
+            // seeded create. $uuidWasNull is the create signal (updates always
+            // carry a UUID); the seed itself is empty-field-only and fail-soft, so
+            // it never overwrites a client-supplied value. See the object-lifecycle
+            // spec: fk-graph-lifecycle-transitions.
+            if ($uuidWasNull === true) {
+                $object = $this->saveHandler->seedLifecycleFieldOnCreate(
+                    schema: $this->currentSchema,
+                    data: $object
                 );
-                $contactMatchingService->invalidateCacheForObject($savedObject->getObject());
             }
-        } catch (\Throwable $e) {
-            // BUG-OBJ-9 / BUG-OBJ-14: contact-match cache invalidation is a
-            // non-essential post-save side-effect and must NEVER fail the save.
-            // Catch \Throwable (the invalidation path can raise a runtime Error,
-            // e.g. an unavailable SystemTag subsystem, not just a container
-            // exception) but log it with object context so the miss stays
-            // visible instead of being silently swallowed.
-            $this->logger->warning(
-                message: '[ObjectService] Skipped contact-match cache invalidation: invalidation failed',
-                context: [
-                    'file'      => __FILE__,
-                    'line'      => __LINE__,
-                    'exception' => $e->getMessage(),
-                    'uuid'      => $savedObject->getUuid(),
-                    'register'  => $this->currentRegister?->getId(),
-                    'schema'    => $this->currentSchema?->getId(),
-                ]
+
+            \OCA\OpenRegister\Service\WritePhaseProbe::mark('prepare+cascade');
+
+            // Validate if hard validation is enabled.
+            $this->validateObjectIfRequired(object: $object);
+            \OCA\OpenRegister\Service\WritePhaseProbe::mark('validate');
+
+            // Wave-12 Fix 1: enforce JSON-Schema `readOnly: true` on UPDATE.
+            // Skipped on CREATE (no prior value to violate). Loads the existing
+            // object exactly once so the check is data-driven, not metadata-only.
+            $this->enforceReadOnlyOnUpdate(object: $object, uuid: $uuid);
+
+            \OCA\OpenRegister\Service\WritePhaseProbe::mark('folder.readonly');
+
+            // Ensure folder exists for the object.
+            $folderId = $this->ensureObjectFolder(uuid: $uuid, currentUser: $currentUser);
+
+            \OCA\OpenRegister\Service\WritePhaseProbe::mark('folder.ensure');
+
+            // Clear request-scoped caches before starting a new top-level save operation.
+            // This ensures cascade operations benefit from caching while avoiding stale data.
+            $this->saveHandler->clearAllCaches();
+
+            \OCA\OpenRegister\Service\WritePhaseProbe::mark('folder');
+
+            // Delegate to SaveObject handler for actual save operation.
+            $savedObject = $this->saveHandler->saveObject(
+                register: $this->currentRegister,
+                schema: $this->currentSchema,
+                data: $object,
+                uuid: $uuid,
+                folderId: $folderId,
+                _rbac: $_rbac,
+                _multitenancy: $_multitenancy,
+                persist: true,
+                silent: $silent,
+                _validation: $_validation,
+                uploadedFiles: $uploadedFiles,
+                currentUser: $currentUser,
+                failIfExists: $failIfExists,
+                _unowned: $_unowned
             );
-        }//end try
 
-        // Invalidate Smart Picker / reference-provider preview caches for the
-        // saved object, so an edit is reflected the next time the object is
-        // resolved as a reference (mail-smart-picker spec: "Cache invalidation
-        // on object update"). Every canonical URL shape OpenRegister itself
-        // recognises comes from ObjectPreviewFormatter::buildCanonicalUrls() —
-        // the SAME pattern list matchReference()/getCachePrefix() use — so
-        // this can never invalidate a different set of shapes than the ones
-        // the providers actually match against (design.md D4). Best-effort:
-        // never fails the save.
-        try {
-            $container = \OC::$server;
-            if ($container !== null) {
-                $referenceManager = $container->get(\OCP\Collaboration\Reference\IReferenceManager::class);
-                $formatter = $container->get(\OCA\OpenRegister\Service\Reference\ObjectPreviewFormatter::class);
-                $deepLinkRegistry = $container->get(\OCA\OpenRegister\Service\DeepLinkRegistryService::class);
-
-                $invalidationRegisterId = (int)$this->currentRegister?->getId();
-                $invalidationSchemaId = (int)$this->currentSchema?->getId();
-                $invalidationUuid = (string)$savedObject->getUuid();
-
-                $invalidatedPrefixes = [];
-                foreach (
-                    $formatter->buildCanonicalUrls(
-                        registerId: $invalidationRegisterId,
-                        schemaId: $invalidationSchemaId,
-                        uuid: $invalidationUuid
-                    ) as $canonicalUrl
-                ) {
-                    $prefix = $formatter->resolveCachePrefix(referenceText: $canonicalUrl);
-                    if (isset($invalidatedPrefixes[$prefix]) === false) {
-                        $referenceManager->invalidateCache(cachePrefix: $prefix);
-                        $invalidatedPrefixes[$prefix] = true;
-                    }
+            // Invalidate contact matching cache for objects with email properties.
+            // BUG-OBJ-9: invalidate against the SAVED object's data (final UUID +
+            // applied defaults), not the pre-save input array, so an email value
+            // injected by a default/computed property is also invalidated.
+            try {
+                $container = \OC::$server;
+                if ($container !== null) {
+                    $contactMatchingService = $container->get(
+                        \OCA\OpenRegister\Service\ContactMatchingService::class
+                    );
+                    $contactMatchingService->invalidateCacheForObject($savedObject->getObject());
                 }
-
-                // Flat data shape deep link URL templates resolve placeholders
-                // against — same shape ObjectPreviewFormatter::buildReference()
-                // and ObjectSearchResultFormatter::format() build for the same
-                // purpose: the object's own fields plus the identity triple.
-                $deepLinkObjectData = array_merge(
-                    $savedObject->getObject(),
-                    [
-                        'uuid' => $invalidationUuid,
-                        'register' => $invalidationRegisterId,
-                        'schema' => $invalidationSchemaId,
+            } catch (\Throwable $e) {
+                // BUG-OBJ-9 / BUG-OBJ-14: contact-match cache invalidation is a
+                // non-essential post-save side-effect and must NEVER fail the save.
+                // Catch \Throwable (the invalidation path can raise a runtime Error,
+                // e.g. an unavailable SystemTag subsystem, not just a container
+                // exception) but log it with object context so the miss stays
+                // visible instead of being silently swallowed.
+                $this->logger->warning(
+                    message: '[ObjectService] Skipped contact-match cache invalidation: invalidation failed',
+                    context: [
+                        'file'      => __FILE__,
+                        'line'      => __LINE__,
+                        'exception' => $e->getMessage(),
+                        'uuid'      => $savedObject->getUuid(),
+                        'register'  => $this->currentRegister?->getId(),
+                        'schema'    => $this->currentSchema?->getId(),
                     ]
                 );
+            }//end try
 
-                $deepLinkUrl = $deepLinkRegistry->resolveUrl(
-                    registerId: $invalidationRegisterId,
-                    schemaId: $invalidationSchemaId,
-                    objectData: $deepLinkObjectData
+            // Invalidate Smart Picker / reference-provider preview caches for the
+            // saved object, so an edit is reflected the next time the object is
+            // resolved as a reference (mail-smart-picker spec: "Cache invalidation
+            // on object update"). Every canonical URL shape OpenRegister itself
+            // recognises comes from ObjectPreviewFormatter::buildCanonicalUrls() —
+            // the SAME pattern list matchReference()/getCachePrefix() use — so
+            // this can never invalidate a different set of shapes than the ones
+            // the providers actually match against (design.md D4). Best-effort:
+            // never fails the save.
+            try {
+                $container = \OC::$server;
+                if ($container !== null) {
+                    $referenceManager = $container->get(\OCP\Collaboration\Reference\IReferenceManager::class);
+                    $formatter = $container->get(\OCA\OpenRegister\Service\Reference\ObjectPreviewFormatter::class);
+                    $deepLinkRegistry = $container->get(\OCA\OpenRegister\Service\DeepLinkRegistryService::class);
+
+                    $invalidationRegisterId = (int)$this->currentRegister?->getId();
+                    $invalidationSchemaId = (int)$this->currentSchema?->getId();
+                    $invalidationUuid = (string)$savedObject->getUuid();
+
+                    $invalidatedPrefixes = [];
+                    foreach (
+                        $formatter->buildCanonicalUrls(
+                            registerId: $invalidationRegisterId,
+                            schemaId: $invalidationSchemaId,
+                            uuid: $invalidationUuid
+                        ) as $canonicalUrl
+                    ) {
+                        $prefix = $formatter->resolveCachePrefix(referenceText: $canonicalUrl);
+                        if (isset($invalidatedPrefixes[$prefix]) === false) {
+                            $referenceManager->invalidateCache(cachePrefix: $prefix);
+                            $invalidatedPrefixes[$prefix] = true;
+                        }
+                    }
+
+                    // Flat data shape deep link URL templates resolve placeholders
+                    // against — same shape ObjectPreviewFormatter::buildReference()
+                    // and ObjectSearchResultFormatter::format() build for the same
+                    // purpose: the object's own fields plus the identity triple.
+                    $deepLinkObjectData = array_merge(
+                        $savedObject->getObject(),
+                        [
+                            'uuid' => $invalidationUuid,
+                            'register' => $invalidationRegisterId,
+                            'schema' => $invalidationSchemaId,
+                        ]
+                    );
+
+                    $deepLinkUrl = $deepLinkRegistry->resolveUrl(
+                        registerId: $invalidationRegisterId,
+                        schemaId: $invalidationSchemaId,
+                        objectData: $deepLinkObjectData
+                    );
+                    if ($deepLinkUrl !== null) {
+                        $referenceManager->invalidateCache(cachePrefix: $deepLinkUrl);
+                    }
+                }//end if
+            } catch (\Throwable $e) {
+                // Smart Picker cache invalidation is a non-essential post-save
+                // side-effect and must NEVER fail the save. Catch \Throwable (the
+                // reference manager or an unavailable formatter service can raise
+                // a runtime Error, not just a container exception) but log it with
+                // object context so the miss stays visible instead of being
+                // silently swallowed.
+                $this->logger->warning(
+                    message: '[ObjectService] Skipped Smart Picker cache invalidation: invalidation failed',
+                    context: [
+                        'file'      => __FILE__,
+                        'line'      => __LINE__,
+                        'exception' => $e->getMessage(),
+                        'uuid'      => $savedObject->getUuid(),
+                        'register'  => $this->currentRegister?->getId(),
+                        'schema'    => $this->currentSchema?->getId(),
+                    ]
                 );
-                if ($deepLinkUrl !== null) {
-                    $referenceManager->invalidateCache(cachePrefix: $deepLinkUrl);
-                }
-            }//end if
-        } catch (\Throwable $e) {
-            // Smart Picker cache invalidation is a non-essential post-save
-            // side-effect and must NEVER fail the save. Catch \Throwable (the
-            // reference manager or an unavailable formatter service can raise
-            // a runtime Error, not just a container exception) but log it with
-            // object context so the miss stays visible instead of being
-            // silently swallowed.
-            $this->logger->warning(
-                message: '[ObjectService] Skipped Smart Picker cache invalidation: invalidation failed',
-                context: [
-                    'file'      => __FILE__,
-                    'line'      => __LINE__,
-                    'exception' => $e->getMessage(),
-                    'uuid'      => $savedObject->getUuid(),
-                    'register'  => $this->currentRegister?->getId(),
-                    'schema'    => $this->currentSchema?->getId(),
-                ]
+            }//end try
+
+            // Lazy folder creation: intentionally do NOT create a file-storage
+            // folder here. An object only needs a folder once a file is attached;
+            // the folder is created on demand on the first upload
+            // (CreateFileHandler → getObjectFolder, which creates-if-missing). This
+            // avoids cluttering the Files tree with an empty folder per object and
+            // avoids binding system/seed-created objects to a folder a later editor
+            // can't access (the folder_access_denied case).
+            \OCA\OpenRegister\Service\WritePhaseProbe::mark('persist+events');
+
+            // Render and return the saved object.
+            $renderedObject = $this->renderHandler->renderEntity(
+                entity: $savedObject,
+                _extend: $extend ?? [],
+                registers: null,
+                schemas: null,
+                _rbac: $_rbac,
+                _multitenancy: $_multitenancy
             );
-        }//end try
+            \OCA\OpenRegister\Service\WritePhaseProbe::mark('render');
+            \OCA\OpenRegister\Service\WritePhaseProbe::flush();
 
-        // Lazy folder creation: intentionally do NOT create a file-storage
-        // folder here. An object only needs a folder once a file is attached;
-        // the folder is created on demand on the first upload
-        // (CreateFileHandler → getObjectFolder, which creates-if-missing). This
-        // avoids cluttering the Files tree with an empty folder per object and
-        // avoids binding system/seed-created objects to a folder a later editor
-        // can't access (the folder_access_denied case).
-        \OCA\OpenRegister\Service\WritePhaseProbe::mark('persist+events');
-
-        // Render and return the saved object.
-        $renderedObject = $this->renderHandler->renderEntity(
-            entity: $savedObject,
-            _extend: $extend ?? [],
-            registers: null,
-            schemas: null,
-            _rbac: $_rbac,
-            _multitenancy: $_multitenancy
-        );
-        \OCA\OpenRegister\Service\WritePhaseProbe::mark('render');
-        \OCA\OpenRegister\Service\WritePhaseProbe::flush();
-
-        return $renderedObject;
+            return $renderedObject;
+        } finally {
+            $this->restoreScopeContext(register: $previousRegister, schema: $previousSchema);
+        }
     }//end saveObject()
 
     /**
@@ -2370,123 +2449,132 @@ class ObjectService implements ObjectServiceInterface
         ?IUser $currentUser=null,
         bool $permanent=false
     ): bool {
-        $this->discardPendingSchemaRef();
-        // Explicit acting user for the permission check; null keeps today's
-        // session-resolved behaviour for every existing caller.
-        $actingUserId = $currentUser?->getUID();
-
-        // Resolve the explicit scope (if any) onto the service's currentRegister
-        // / currentSchema so downstream context (permission checks, audit-trail
-        // recording) sees the API-supplied scope, not a stale leftover from a
-        // previous call on this service instance.
-        $hasScope = ($register !== null && $schema !== null);
-        if ($register !== null) {
-            $this->setRegister(register: $register);
-        }
-
-        if ($schema !== null) {
-            $this->setSchema(schema: $schema);
-        }
-
-        \OCA\OpenRegister\Service\WritePhaseProbe::stamp('del.scope');
-
-        // Reject deletion of transferred objects (archiefstatus = overgebracht).
-        $this->rejectIfTransferred(uuid: $uuid);
-
-        \OCA\OpenRegister\Service\WritePhaseProbe::stamp('del.transferred');
-
-        // Reject DELETE operations on append-only schemas.
-        if ($this->currentSchema !== null && $this->currentSchema->isAppendOnly() === true) {
-            $schemaSlug = $this->currentSchema->getSlug() ?? (string) $this->currentSchema->getId();
-            throw new AppendOnlyException(
-                schemaIdentifier: $schemaSlug,
-                operation: 'delete'
-            );
-        }
-
-        // Reject DELETE operations on archival-annotated schemas unless this
-        // call originates from the retention sweep cron (which alone sets
-        // $_retentionSweep true). User-driven deletes get a structured 403.
-        if ($_retentionSweep === false
-            && $this->currentSchema !== null
-            && $this->schemaHasArchivalAnnotation(schema: $this->currentSchema) === true
-        ) {
-            $schemaSlug = $this->currentSchema->getSlug() ?? (string) $this->currentSchema->getId();
-            throw new ArchivalImmutableException(
-                schemaIdentifier: $schemaSlug,
-                operation: 'delete'
-            );
-        }
-
-        // Find the object to get its owner for permission check (include soft-deleted objects).
-        // When the caller supplied both register + schema, the lookup is scoped
-        // to a single magic table — a UUID in a different scope raises
-        // DoesNotExistException and never reaches the delete handler.
-        $scopedRegister = null;
-        $scopedSchema   = null;
-        if ($hasScope === true) {
-            $scopedRegister = $this->currentRegister;
-            $scopedSchema   = $this->currentSchema;
-        }
+        // A DELETE SCOPES ITSELF; IT DOES NOT SCOPE THE NEXT CALLER.
+        // Same contract as find() and saveObject(); see restoreScopeContext().
+        $previousRegister = $this->currentRegister;
+        $previousSchema   = $this->currentSchema;
 
         try {
-            $objectToDelete = $this->objectMapper->find(
-                identifier: $uuid,
-                register: $scopedRegister,
-                schema: $scopedSchema,
-                includeDeleted: true
-            );
+            $this->discardPendingSchemaRef();
+            // Explicit acting user for the permission check; null keeps today's
+            // session-resolved behaviour for every existing caller.
+            $actingUserId = $currentUser?->getUID();
 
-            // If no schema was provided but we have an object, derive the schema from the object.
-            if ($this->currentSchema === null) {
-                $this->setSchema(schema: $objectToDelete->getSchema());
+            // Resolve the explicit scope (if any) onto the service's currentRegister
+            // / currentSchema so downstream context (permission checks, audit-trail
+            // recording) sees the API-supplied scope, not a stale leftover from a
+            // previous call on this service instance.
+            $hasScope = ($register !== null && $schema !== null);
+            if ($register !== null) {
+                $this->setRegister(register: $register);
             }
 
-            \OCA\OpenRegister\Service\WritePhaseProbe::stamp('del.found');
+            if ($schema !== null) {
+                $this->setSchema(schema: $schema);
+            }
 
-            // Check user has permission to delete this specific object.
-            $this->checkPermission(
-                schema: $this->currentSchema,
-                action: 'delete',
-                userId: $actingUserId,
-                objectOwner: $objectToDelete->getOwner(),
-                _rbac: $_rbac,
-                object: $objectToDelete
-            );
+            \OCA\OpenRegister\Service\WritePhaseProbe::stamp('del.scope');
 
-            \OCA\OpenRegister\Service\WritePhaseProbe::stamp('del.permitted');
-        } catch (\OCP\AppFramework\Db\DoesNotExistException $e) {
-            // Scoped lookup is authoritative: if the caller asked for a
-            // specific (register, schema) and the UUID is not in that scope,
-            // re-throw so the failure mode is "404 not in scope" instead of
-            // "silently look at another magic table" (the #1638 bug).
+            // Reject deletion of transferred objects (archiefstatus = overgebracht).
+            $this->rejectIfTransferred(uuid: $uuid);
+
+            \OCA\OpenRegister\Service\WritePhaseProbe::stamp('del.transferred');
+
+            // Reject DELETE operations on append-only schemas.
+            if ($this->currentSchema !== null && $this->currentSchema->isAppendOnly() === true) {
+                $schemaSlug = $this->currentSchema->getSlug() ?? (string) $this->currentSchema->getId();
+                throw new AppendOnlyException(
+                    schemaIdentifier: $schemaSlug,
+                    operation: 'delete'
+                );
+            }
+
+            // Reject DELETE operations on archival-annotated schemas unless this
+            // call originates from the retention sweep cron (which alone sets
+            // $_retentionSweep true). User-driven deletes get a structured 403.
+            if ($_retentionSweep === false
+                && $this->currentSchema !== null
+                && $this->schemaHasArchivalAnnotation(schema: $this->currentSchema) === true
+            ) {
+                $schemaSlug = $this->currentSchema->getSlug() ?? (string) $this->currentSchema->getId();
+                throw new ArchivalImmutableException(
+                    schemaIdentifier: $schemaSlug,
+                    operation: 'delete'
+                );
+            }
+
+            // Find the object to get its owner for permission check (include soft-deleted objects).
+            // When the caller supplied both register + schema, the lookup is scoped
+            // to a single magic table — a UUID in a different scope raises
+            // DoesNotExistException and never reaches the delete handler.
+            $scopedRegister = null;
+            $scopedSchema   = null;
             if ($hasScope === true) {
-                throw $e;
+                $scopedRegister = $this->currentRegister;
+                $scopedSchema   = $this->currentSchema;
             }
 
-            // Unscoped path: object doesn't exist anywhere, no permission check
-            // needed but let deleteHandler raise its own consistent error path.
-            if ($this->currentSchema !== null) {
+            try {
+                $objectToDelete = $this->objectMapper->find(
+                    identifier: $uuid,
+                    register: $scopedRegister,
+                    schema: $scopedSchema,
+                    includeDeleted: true
+                );
+
+                // If no schema was provided but we have an object, derive the schema from the object.
+                if ($this->currentSchema === null) {
+                    $this->setSchema(schema: $objectToDelete->getSchema());
+                }
+
+                \OCA\OpenRegister\Service\WritePhaseProbe::stamp('del.found');
+
+                // Check user has permission to delete this specific object.
                 $this->checkPermission(
                     schema: $this->currentSchema,
                     action: 'delete',
                     userId: $actingUserId,
-                    objectOwner: null,
-                    _rbac: $_rbac
+                    objectOwner: $objectToDelete->getOwner(),
+                    _rbac: $_rbac,
+                    object: $objectToDelete
                 );
-            }
-        }//end try
 
-        return $this->deleteHandler->deleteObject(
-            register: $this->currentRegister,
-            schema: $this->currentSchema,
-            uuid: $uuid,
-            originalObjectId: null,
-            _rbac: $_rbac,
-            _multitenancy: $_multitenancy,
-            scoped: $hasScope,
-            permanent: $permanent
-        );
+                \OCA\OpenRegister\Service\WritePhaseProbe::stamp('del.permitted');
+            } catch (\OCP\AppFramework\Db\DoesNotExistException $e) {
+                // Scoped lookup is authoritative: if the caller asked for a
+                // specific (register, schema) and the UUID is not in that scope,
+                // re-throw so the failure mode is "404 not in scope" instead of
+                // "silently look at another magic table" (the #1638 bug).
+                if ($hasScope === true) {
+                    throw $e;
+                }
+
+                // Unscoped path: object doesn't exist anywhere, no permission check
+                // needed but let deleteHandler raise its own consistent error path.
+                if ($this->currentSchema !== null) {
+                    $this->checkPermission(
+                        schema: $this->currentSchema,
+                        action: 'delete',
+                        userId: $actingUserId,
+                        objectOwner: null,
+                        _rbac: $_rbac
+                    );
+                }
+            }//end try
+
+            return $this->deleteHandler->deleteObject(
+                register: $this->currentRegister,
+                schema: $this->currentSchema,
+                uuid: $uuid,
+                originalObjectId: null,
+                _rbac: $_rbac,
+                _multitenancy: $_multitenancy,
+                scoped: $hasScope,
+                permanent: $permanent
+            );
+        } finally {
+            $this->restoreScopeContext(register: $previousRegister, schema: $previousSchema);
+        }
     }//end deleteObject()
 
     /**
@@ -4041,63 +4129,72 @@ class ObjectService implements ObjectServiceInterface
         bool $enrich=true,
         bool $_audit=true
     ): array {
-        $this->discardPendingSchemaRef();
+        // A BULK SAVE SCOPES ITSELF; IT DOES NOT SCOPE THE NEXT CALLER.
+        // Same contract as saveObject(); see restoreScopeContext().
+        $previousRegister = $this->currentRegister;
+        $previousSchema   = $this->currentSchema;
 
-        // Bound the folder-access revalidation cache to this bulk-save call
-        // (see saveObject) so mid-request folder mutations are re-validated.
-        $this->fileService->resetFolderAccessRevalidationCache();
+        try {
+            $this->discardPendingSchemaRef();
 
-        // Set register and schema context if provided.
-        if ($register !== null) {
-            $this->setRegister(register: $register);
-        }
+            // Bound the folder-access revalidation cache to this bulk-save call
+            // (see saveObject) so mid-request folder mutations are re-validated.
+            $this->fileService->resetFolderAccessRevalidationCache();
 
-        if ($schema !== null) {
-            $this->setSchema(schema: $schema);
-        }
-
-        // Delegate to SaveObjects handler for bulk save operations.
-        $bulkResult = $this->saveObjectsHandler->saveObjects(
-            objects: $objects,
-            register: $this->currentRegister,
-            schema: $this->currentSchema,
-            _rbac: $_rbac,
-            _multitenancy: $_multitenancy,
-            _validation: $validation,
-            _events: $events,
-            deduplicateIds: $deduplicateIds,
-            enrich: $enrich,
-            _audit: $_audit
-        );
-
-        // Invalidate collection caches after successful bulk operations.
-        $createdCount  = (int) ($bulkResult['statistics']['objectsCreated'] ?? 0);
-        $updatedCount  = (int) ($bulkResult['statistics']['objectsUpdated'] ?? 0);
-        $totalAffected = $createdCount + $updatedCount;
-
-        if ($totalAffected > 0) {
-            try {
-                $this->cacheHandler->invalidateForObjectChange(
-                    object: null,
-                    operation: 'bulk_save',
-                    registerId: $this->currentRegister?->getId(),
-                    schemaId: $this->currentSchema?->getId()
-                );
-            } catch (\Exception $e) {
-                // BUG-OBJ-14: include register/schema context in the warning.
-                $this->logger->warning(
-                    message: '[ObjectService] Bulk save cache invalidation failed',
-                    context: [
-                        'error'         => $e->getMessage(),
-                        'totalAffected' => $totalAffected,
-                        'registerId'    => $this->currentRegister?->getId(),
-                        'schemaId'      => $this->currentSchema?->getId(),
-                    ]
-                );
+            // Set register and schema context if provided.
+            if ($register !== null) {
+                $this->setRegister(register: $register);
             }
-        }//end if
 
-        return $bulkResult;
+            if ($schema !== null) {
+                $this->setSchema(schema: $schema);
+            }
+
+            // Delegate to SaveObjects handler for bulk save operations.
+            $bulkResult = $this->saveObjectsHandler->saveObjects(
+                objects: $objects,
+                register: $this->currentRegister,
+                schema: $this->currentSchema,
+                _rbac: $_rbac,
+                _multitenancy: $_multitenancy,
+                _validation: $validation,
+                _events: $events,
+                deduplicateIds: $deduplicateIds,
+                enrich: $enrich,
+                _audit: $_audit
+            );
+
+            // Invalidate collection caches after successful bulk operations.
+            $createdCount  = (int) ($bulkResult['statistics']['objectsCreated'] ?? 0);
+            $updatedCount  = (int) ($bulkResult['statistics']['objectsUpdated'] ?? 0);
+            $totalAffected = $createdCount + $updatedCount;
+
+            if ($totalAffected > 0) {
+                try {
+                    $this->cacheHandler->invalidateForObjectChange(
+                        object: null,
+                        operation: 'bulk_save',
+                        registerId: $this->currentRegister?->getId(),
+                        schemaId: $this->currentSchema?->getId()
+                    );
+                } catch (\Exception $e) {
+                    // BUG-OBJ-14: include register/schema context in the warning.
+                    $this->logger->warning(
+                        message: '[ObjectService] Bulk save cache invalidation failed',
+                        context: [
+                            'error'         => $e->getMessage(),
+                            'totalAffected' => $totalAffected,
+                            'registerId'    => $this->currentRegister?->getId(),
+                            'schemaId'      => $this->currentSchema?->getId(),
+                        ]
+                    );
+                }
+            }//end if
+
+            return $bulkResult;
+        } finally {
+            $this->restoreScopeContext(register: $previousRegister, schema: $previousSchema);
+        }
     }//end saveObjects()
 
     /**
@@ -4138,24 +4235,33 @@ class ObjectService implements ObjectServiceInterface
         Register | string | int | null $register=null,
         Schema | string | int | null $schema=null
     ): BatchOperationStatus {
-        if ($register !== null) {
-            $this->setRegister(register: $register);
+        // A STREAMING SAVE SCOPES ITSELF; IT DOES NOT SCOPE THE NEXT CALLER.
+        // Same contract as saveObject(); see restoreScopeContext().
+        $previousRegister = $this->currentRegister;
+        $previousSchema   = $this->currentSchema;
+
+        try {
+            if ($register !== null) {
+                $this->setRegister(register: $register);
+            }
+
+            if ($schema !== null) {
+                $this->setSchema(schema: $schema);
+            }
+
+            // The reference cache is request-scoped and this call is a logical
+            // boundary: verdicts from an earlier batch must not decide this one.
+            $this->saveHandler->clearReferenceValidationCache();
+
+            return $this->saveHandler->saveObjectsStreaming(
+                register: $this->currentRegister,
+                schema: $this->currentSchema,
+                rows: $objects
+            );
+
+        } finally {
+            $this->restoreScopeContext(register: $previousRegister, schema: $previousSchema);
         }
-
-        if ($schema !== null) {
-            $this->setSchema(schema: $schema);
-        }
-
-        // The reference cache is request-scoped and this call is a logical
-        // boundary: verdicts from an earlier batch must not decide this one.
-        $this->saveHandler->clearReferenceValidationCache();
-
-        return $this->saveHandler->saveObjectsStreaming(
-            register: $this->currentRegister,
-            schema: $this->currentSchema,
-            rows: $objects
-        );
-
     }//end saveObjectsStreaming()
 
 
@@ -5074,47 +5180,58 @@ class ObjectService implements ObjectServiceInterface
         bool $_multitenancy=true,
         ?IUser $currentUser=null
     ): ObjectEntity {
-        // Resolve the caller's scope onto the service context first, so the
-        // lookup below and the save that follows both see the same one.
-        $this->setContextFromParameters(
-            register: $register,
-            schema: $schema
-        );
+        // A PATCH SCOPES ITSELF; IT DOES NOT SCOPE THE NEXT CALLER.
+        // The saveObject() it delegates to now restores too, so without this the
+        // only context left behind would be the one patchObject() set itself.
+        // See restoreScopeContext().
+        $previousRegister = $this->currentRegister;
+        $previousSchema   = $this->currentSchema;
 
-        // Scoped lookup when both halves of the scope are known — that targets
-        // exactly one magic table. Otherwise the legacy cross-table resolve,
-        // which every existing caller relies on. Note the identifier is passed
-        // through unchanged: casting a uuid to int resolves to an unrelated row.
-        $scopedRegister = null;
-        $scopedSchema   = null;
-        if ($register !== null && $schema !== null) {
-            $scopedRegister = $this->currentRegister;
-            $scopedSchema   = $this->currentSchema;
+        try {
+            // Resolve the caller's scope onto the service context first, so the
+            // lookup below and the save that follows both see the same one.
+            $this->setContextFromParameters(
+                register: $register,
+                schema: $schema
+            );
+
+            // Scoped lookup when both halves of the scope are known — that targets
+            // exactly one magic table. Otherwise the legacy cross-table resolve,
+            // which every existing caller relies on. Note the identifier is passed
+            // through unchanged: casting a uuid to int resolves to an unrelated row.
+            $scopedRegister = null;
+            $scopedSchema   = null;
+            if ($register !== null && $schema !== null) {
+                $scopedRegister = $this->currentRegister;
+                $scopedSchema   = $this->currentSchema;
+            }
+
+            $existing = $this->objectMapper->find(
+                identifier: $objectId,
+                register: $scopedRegister,
+                schema: $scopedSchema
+            );
+
+            $merged = $this->mergePatchData(
+                stored: (array) $existing->getObject(),
+                patch: $data
+            );
+
+            // Address the save at the object we actually resolved, not at whatever
+            // form of the identifier the caller happened to hold.
+            $merged['id'] = ($existing->getUuid() ?? $objectId);
+
+            return $this->saveObject(
+                object: $merged,
+                register: $register,
+                schema: $schema,
+                _rbac: $_rbac,
+                _multitenancy: $_multitenancy,
+                currentUser: $currentUser
+            );
+        } finally {
+            $this->restoreScopeContext(register: $previousRegister, schema: $previousSchema);
         }
-
-        $existing = $this->objectMapper->find(
-            identifier: $objectId,
-            register: $scopedRegister,
-            schema: $scopedSchema
-        );
-
-        $merged = $this->mergePatchData(
-            stored: (array) $existing->getObject(),
-            patch: $data
-        );
-
-        // Address the save at the object we actually resolved, not at whatever
-        // form of the identifier the caller happened to hold.
-        $merged['id'] = ($existing->getUuid() ?? $objectId);
-
-        return $this->saveObject(
-            object: $merged,
-            register: $register,
-            schema: $schema,
-            _rbac: $_rbac,
-            _multitenancy: $_multitenancy,
-            currentUser: $currentUser
-        );
     }//end patchObject()
 
     /**

--- a/lib/Service/VocabularyImportService.php
+++ b/lib/Service/VocabularyImportService.php
@@ -546,11 +546,21 @@ class VocabularyImportService {
 		$offset = 0;
 
 		do {
+			// The pair goes UNDER `filters`. `prepareFindAllConfig()` reads
+			// `$config['filters']['register']` / `['schema']` and no other key, so
+			// a top-level pair scopes NOTHING — the read ran on whatever the last
+			// write left on the shared ObjectService. In this loop that was
+			// self-concealing: the `saveObject()` below anchors the service on
+			// exactly this pair, so page 1 read an arbitrary scope and every later
+			// page read the right one, by accident. openregister#3408 is what the
+			// same shape costs when no write happens to precede the read.
 			$results = $this->objectService->findAll(
 				config: [
-					'register' => self::REGISTER,
-					'schema' => self::SCHEMA_CONCEPT,
-					'filters' => ['inScheme' => $schemeUuid],
+					'filters' => [
+						'register' => self::REGISTER,
+						'schema' => self::SCHEMA_CONCEPT,
+						'inScheme' => $schemeUuid,
+					],
 					'limit' => $limit,
 					'offset' => $offset,
 				]
@@ -596,11 +606,17 @@ class VocabularyImportService {
 	 * @return ObjectEntity|null The matching object, or null when absent.
 	 */
 	private function findByUri(string $schema, string $uri): ?ObjectEntity {
+		// The pair goes UNDER `filters` — see deprecateMissing() for why a
+		// top-level pair is inert. This one is the import's identity lookup: an
+		// unscoped read here answers "does this uri already exist?" from the
+		// wrong table, and the import creates a duplicate rather than updating.
 		$results = $this->objectService->findAll(
 			config: [
-				'register' => self::REGISTER,
-				'schema' => $schema,
-				'filters' => ['uri' => $uri],
+				'filters' => [
+					'register' => self::REGISTER,
+					'schema' => $schema,
+					'uri' => $uri,
+				],
 				'limit' => 1,
 			]
 		);

--- a/tests/Unit/Controller/VocabularyControllerTest.php
+++ b/tests/Unit/Controller/VocabularyControllerTest.php
@@ -46,9 +46,19 @@ class VocabularyControllerTest extends TestCase {
 	private array $params = [];
 
 	/**
+	 * Every config array handed to ObjectService::findAll(), in call order.
+	 *
+	 * Recorded so the tests can assert what was ASKED, not only what came back.
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	private array $findAllCalls = [];
+
+	/**
 	 * @return void
 	 */
 	protected function setUp(): void {
+		$this->findAllCalls = [];
 		$this->objectService = $this->createMock(ObjectService::class);
 
 		$request = $this->createMock(IRequest::class);
@@ -62,6 +72,40 @@ class VocabularyControllerTest extends TestCase {
 			objectService: $this->objectService
 		);
 	}//end setUp()
+
+	/**
+	 * Record a findAll() config and answer it from where the scope really lives.
+	 *
+	 * A FAKE THAT ANSWERS ANY QUESTION CANNOT REPORT A WRONG ONE. This refuses a
+	 * read whose scope is not under `filters`, because that is the only place
+	 * `ObjectService::prepareFindAllConfig()` looks — a pair anywhere else scopes
+	 * nothing and the read runs on leftover shared state (openregister#3408).
+	 *
+	 * @param array<string, mixed> $config The findAll() config under test.
+	 * @param ObjectEntity $scheme The conceptScheme row to answer scheme reads with.
+	 * @param array<int, ObjectEntity> $concepts The concept rows to answer concept reads with.
+	 *
+	 * @return array<int, ObjectEntity>
+	 */
+	private function recordAndRoute(array $config, ObjectEntity $scheme, array $concepts): array {
+		$this->findAllCalls[] = $config;
+
+		$register = ($config['filters']['register'] ?? null);
+		$schema = ($config['filters']['schema'] ?? null);
+		if ($register === null || $schema === null) {
+			throw new \RuntimeException(
+				'findAll() was called without filters.register / filters.schema; ObjectService reads the '
+				.'scope from nowhere else, so this read would have run on whatever context the last write '
+				.'left behind.'
+			);
+		}
+
+		if ($schema === VocabularyImportService::SCHEMA_SCHEME) {
+			return [$scheme];
+		}
+
+		return $concepts;
+	}//end recordAndRoute()
 
 	/**
 	 * @param string $uuid The object uuid.
@@ -138,13 +182,7 @@ class VocabularyControllerTest extends TestCase {
 		$draft = $this->entity('uuid-1', ['uri' => 'https://example.org/vocab/c1', 'notation' => 'c_1']);
 
 		$this->objectService->method('findAll')->willReturnCallback(
-			function (array $config) use ($scheme, $draft) {
-				if ($config['schema'] === VocabularyImportService::SCHEMA_SCHEME) {
-					return [$scheme];
-				}
-
-				return [$draft];
-			}
+			fn (array $config): array => $this->recordAndRoute(config: $config, scheme: $scheme, concepts: [$draft])
 		);
 
 		$response = $this->controller->resolveByNotation();
@@ -225,11 +263,11 @@ class VocabularyControllerTest extends TestCase {
 
 		$this->objectService->method('findAll')->willReturnCallback(
 			function (array $config) use ($scheme, $a, $b) {
-				if ($config['schema'] === VocabularyImportService::SCHEMA_SCHEME) {
-					return [$scheme];
-				}
-
-				return [$a, $b];
+				// Answer from where ObjectService actually reads the scope. This
+				// used to read `$config['schema']`, a key `prepareFindAllConfig()`
+				// never looks at, so the fake replied correctly to a question the
+				// real service is never asked — see openregister#3408.
+				return ($this->recordAndRoute(config: $config, scheme: $scheme, concepts: [$a, $b]));
 			}
 		);
 
@@ -256,11 +294,11 @@ class VocabularyControllerTest extends TestCase {
 
 		$this->objectService->method('findAll')->willReturnCallback(
 			function (array $config) use ($scheme, $a, $b) {
-				if ($config['schema'] === VocabularyImportService::SCHEMA_SCHEME) {
-					return [$scheme];
-				}
-
-				return [$a, $b];
+				// Answer from where ObjectService actually reads the scope. This
+				// used to read `$config['schema']`, a key `prepareFindAllConfig()`
+				// never looks at, so the fake replied correctly to a question the
+				// real service is never asked — see openregister#3408.
+				return ($this->recordAndRoute(config: $config, scheme: $scheme, concepts: [$a, $b]));
 			}
 		);
 
@@ -270,4 +308,117 @@ class VocabularyControllerTest extends TestCase {
 		$this->assertSame(2, $data['total']);
 		$this->assertCount(2, $data['results']);
 	}//end testListConceptsWithoutQueryReturnsAllConceptsOfScheme()
+
+	/**
+	 * EVERY read must name its scope where ObjectService actually looks.
+	 *
+	 * `ObjectService::prepareFindAllConfig()` reads
+	 * `$config['filters']['register']` and `$config['filters']['schema']`, and no
+	 * other key. A pair at the TOP level of the config is read by nothing:
+	 * `setRegister()` / `setSchema()` are never called, and `findAll()` passes
+	 * the handler `$this->currentRegister` / `$this->currentSchema` — leftover
+	 * state from whatever ran last on the same shared service instance.
+	 *
+	 * This controller used the top-level shape at both of its read sites. It was
+	 * the third of the outliers openregister#3408 found and reported rather than
+	 * changed, because it was not in that defect's path and needed its own test.
+	 * This is that test.
+	 *
+	 * It asserts the ARGUMENTS, not the response: the fake used to answer from
+	 * `$config['schema']`, so it replied correctly to a question the real service
+	 * is never asked, and every assertion about the returned concepts passed with
+	 * the scope wired to nothing.
+	 *
+	 * `listConcepts()` is a `#[PublicPage]`, so the unscoped read was reachable
+	 * without a session — the widest possible audience for a wrong answer.
+	 *
+	 * @return void
+	 */
+	public function testEveryReadNamesItsScopeWhereObjectServiceReadsIt(): void {
+		$this->params = ['scheme' => 'https://example.org/vocab/scheme'];
+
+		$scheme = $this->entity('scheme-uuid', ['uri' => 'https://example.org/vocab/scheme']);
+		$a = $this->entity('a', ['uri' => 'https://example.org/vocab/a', 'inScheme' => 'scheme-uuid', 'prefLabel' => ['nl' => 'A']]);
+
+		$this->objectService->method('findAll')->willReturnCallback(
+			fn (array $config): array => $this->recordAndRoute(config: $config, scheme: $scheme, concepts: [$a])
+		);
+
+		$response = $this->controller->listConcepts();
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+
+		// listConcepts() resolves the scheme and then lists its concepts, so a
+		// recording of fewer than two calls means the endpoint did not run and
+		// the loop below would prove nothing.
+		$this->assertCount(
+			2,
+			$this->findAllCalls,
+			'Expected a scheme lookup followed by a concept list.'
+		);
+
+		foreach ($this->findAllCalls as $index => $config) {
+			$this->assertArrayNotHasKey(
+				'register',
+				$config,
+				"findAll() call #$index puts `register` at the top level, where nothing reads it."
+			);
+			$this->assertArrayNotHasKey(
+				'schema',
+				$config,
+				"findAll() call #$index puts `schema` at the top level, where nothing reads it."
+			);
+			$this->assertSame(
+				VocabularyImportService::REGISTER,
+				($config['filters']['register'] ?? null),
+				"findAll() call #$index does not scope its register under `filters`."
+			);
+		}
+
+		$this->assertSame(
+			VocabularyImportService::SCHEMA_SCHEME,
+			($this->findAllCalls[0]['filters']['schema'] ?? null),
+			'The scheme lookup must be scoped to the conceptScheme schema.'
+		);
+		$this->assertSame(
+			VocabularyImportService::SCHEMA_CONCEPT,
+			($this->findAllCalls[1]['filters']['schema'] ?? null),
+			'The concept list must be scoped to the concept schema.'
+		);
+	}//end testEveryReadNamesItsScopeWhereObjectServiceReadsIt()
+
+	/**
+	 * The uri lookup is scoped too, and still carries its field filter.
+	 *
+	 * `findOneBy()` is the second read site and merges the caller's exact-match
+	 * filters into the same array the scope now lives in. Both have to survive
+	 * that merge: dropping the scope reinstates the defect, and dropping the
+	 * field filter turns "find the concept with this uri" into "find any
+	 * concept", which would answer 200 with the wrong row.
+	 *
+	 * @return void
+	 */
+	public function testTheUriLookupIsScopedAndKeepsItsFieldFilter(): void {
+		$this->params = ['uri' => 'https://example.org/vocab/a'];
+
+		$scheme = $this->entity('scheme-uuid', ['uri' => 'https://example.org/vocab/scheme']);
+		$a = $this->entity('a', ['uri' => 'https://example.org/vocab/a']);
+
+		$this->objectService->method('findAll')->willReturnCallback(
+			fn (array $config): array => $this->recordAndRoute(config: $config, scheme: $scheme, concepts: [$a])
+		);
+
+		$response = $this->controller->resolveByUri();
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+
+		$this->assertCount(1, $this->findAllCalls, 'The uri lookup is a single scoped read.');
+		$filters = ($this->findAllCalls[0]['filters'] ?? []);
+
+		$this->assertSame(VocabularyImportService::REGISTER, ($filters['register'] ?? null));
+		$this->assertSame(VocabularyImportService::SCHEMA_CONCEPT, ($filters['schema'] ?? null));
+		$this->assertSame(
+			'https://example.org/vocab/a',
+			($filters['uri'] ?? null),
+			'Nesting the scope must not displace the field filter the lookup exists for.'
+		);
+	}//end testTheUriLookupIsScopedAndKeepsItsFieldFilter()
 }//end class

--- a/tests/Unit/Service/ObjectServiceContextRestorationTest.php
+++ b/tests/Unit/Service/ObjectServiceContextRestorationTest.php
@@ -1,0 +1,648 @@
+<?php
+
+/**
+ * ObjectService register/schema context restoration.
+ *
+ * Pins the contract that an entry point which resolves its OWN scope from its
+ * arguments must not leave that scope on the shared service for the next
+ * caller. See openregister#3408 for the defect the missing contract produced.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service;
+
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Db\ViewMapper;
+use OCA\OpenRegister\Service\DateTimeNormalizer;
+use OCA\OpenRegister\Service\FileService;
+use OCA\OpenRegister\Service\Object\AuditHandler;
+use OCA\OpenRegister\Service\Object\CacheHandler;
+use OCA\OpenRegister\Service\Object\CascadingHandler;
+use OCA\OpenRegister\Service\Object\DataManipulationHandler;
+use OCA\OpenRegister\Service\Object\DeleteObject;
+use OCA\OpenRegister\Service\Object\FacetHandler;
+use OCA\OpenRegister\Service\Object\GetObject;
+use OCA\OpenRegister\Service\Object\LockHandler;
+use OCA\OpenRegister\Service\Object\MergeHandler;
+use OCA\OpenRegister\Service\Object\MetadataHandler;
+use OCA\OpenRegister\Service\Object\MigrationHandler;
+use OCA\OpenRegister\Service\Object\PerformanceOptimizationHandler;
+use OCA\OpenRegister\Service\Object\PermissionHandler;
+use OCA\OpenRegister\Service\Object\QueryHandler;
+use OCA\OpenRegister\Service\Object\RelationHandler;
+use OCA\OpenRegister\Service\Object\RenderObject;
+use OCA\OpenRegister\Service\Object\RevertHandler;
+use OCA\OpenRegister\Service\Object\SaveObject;
+use OCA\OpenRegister\Service\Object\SaveObjects;
+use OCA\OpenRegister\Service\Object\SearchQueryHandler;
+use OCA\OpenRegister\Service\Object\UtilityHandler;
+use OCA\OpenRegister\Service\Object\ValidateObject;
+use OCA\OpenRegister\Service\Object\ValidationHandler;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\ObjectSource\ObjectSourceRegistry;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCA\OpenRegister\Service\SearchTrailService;
+use OCA\OpenRegister\Service\SettingsService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\IAppContainer;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * A WRITE MUST NOT SCOPE THE NEXT READ.
+ *
+ * `ObjectService` is one shared instance for a whole request — and, under
+ * `occ`, for a whole `upgrade` run. `setRegister()` / `setSchema()` are the
+ * CALLER's way of anchoring it and are meant to persist. An entry point that
+ * takes `register:` / `schema:` ARGUMENTS is scoping itself for one operation,
+ * and that scope belongs to the operation, not to whoever calls next.
+ *
+ * `find()` has restored its context in a `finally` since BUG-OBJ-13
+ * (openregister#1520). `saveObject()` did not, and openregister#3408 is what
+ * that cost: `ImportCredentialBrokerRegister` wrote its two example objects
+ * with `saveObject(register: credential-broker, schema: brokeredcredential)`,
+ * and four repair steps later `MigrateRegisterFlowsToTable` — whose own read
+ * named its scope in a key nothing reads — inherited that pair and copied two
+ * `brokeredcredential` examples into `openregister_flows` as flows.
+ * Deterministically, on every install, with no error anywhere.
+ *
+ * These tests assert what the SERVICE HANDS ITS HANDLER, not what the caller
+ * gets back. #3408's finding was that every fixture mocked `findAll()` to
+ * answer regardless of what it was asked, and a mock that answers any question
+ * cannot report a wrong one.
+ */
+class ObjectServiceContextRestorationTest extends TestCase {
+
+	private const BROKER_REGISTER = 'credential-broker';
+
+	private const BROKER_SCHEMA = 'brokeredcredential';
+
+	private const FLOW_REGISTER = 'flows';
+
+	private const FLOW_SCHEMA = 'flow';
+
+	/** @var GetObject&MockObject */
+	private GetObject $getHandler;
+
+	/** @var SaveObject&MockObject */
+	private SaveObject $saveHandler;
+
+	/** @var DeleteObject&MockObject */
+	private DeleteObject $deleteHandler;
+
+	/** @var SaveObjects&MockObject */
+	private SaveObjects $saveObjectsHandler;
+
+	/** @var MagicMapper&MockObject */
+	private MagicMapper $objectMapper;
+
+	private ObjectService $service;
+
+	/**
+	 * The register/schema pair handed to the last `getHandler->findAll()` call.
+	 *
+	 * @var array{register: ?Register, schema: ?Schema}|null
+	 */
+	private ?array $findAllScope = null;
+
+	/**
+	 * The register/schema pair handed to the last `saveHandler->saveObject()`.
+	 *
+	 * @var array{register: mixed, schema: mixed}|null
+	 */
+	private ?array $saveScope = null;
+
+	/**
+	 * The row `objectMapper->find()` answers with, or null to answer "absent".
+	 *
+	 * Absent is the default because the save tests are CREATEs. The delete test
+	 * sets one, because a delete of nothing never reaches the scope handling
+	 * this file is about.
+	 *
+	 * @var ObjectEntity|null
+	 */
+	private ?ObjectEntity $existingObject = null;
+
+	/**
+	 * Registers this instance can resolve, by slug.
+	 *
+	 * @var array<string, Register>
+	 */
+	private array $registers = [];
+
+	/**
+	 * Schemas this instance can resolve, by slug.
+	 *
+	 * @var array<string, Schema>
+	 */
+	private array $schemas = [];
+
+	/**
+	 * Build an ObjectService whose save path completes on mocks alone.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->buildFixtureRegisters();
+
+		$this->getHandler = $this->createMock(GetObject::class);
+		$this->saveHandler = $this->createMock(SaveObject::class);
+		$this->deleteHandler = $this->createMock(DeleteObject::class);
+		$this->saveObjectsHandler = $this->createMock(SaveObjects::class);
+		$this->objectMapper = $this->createMock(MagicMapper::class);
+
+		$registerMapper = $this->createMock(RegisterMapper::class);
+		$registerMapper->method('find')->willReturnCallback(
+			function ($id, ...$rest): Register {
+				$register = ($this->registers[(string)$id] ?? null);
+				if ($register === null) {
+					throw new DoesNotExistException('no such register: ' . (string)$id);
+				}
+
+				return $register;
+			}
+		);
+
+		$schemaMapper = $this->createMock(SchemaMapper::class);
+		$schemaMapper->method('find')->willReturnCallback(
+			function ($id, ...$rest): Schema {
+				$schema = ($this->schemas[(string)$id] ?? null);
+				if ($schema === null) {
+					throw new DoesNotExistException('no such schema: ' . (string)$id);
+				}
+
+				return $schema;
+			}
+		);
+		// Register-scoped resolution: only schemas whose id is listed on the
+		// register resolve inside it, which is what makes the register a
+		// boundary and what these fixtures need to model.
+		$schemaMapper->method('findInIds')->willReturnCallback(
+			function ($id, array $schemaIds): ?Schema {
+				$schema = ($this->schemas[(string)$id] ?? null);
+				if ($schema === null || in_array($schema->getId(), $schemaIds, true) === false) {
+					return null;
+				}
+
+				return $schema;
+			}
+		);
+
+		$renderHandler = $this->createMock(RenderObject::class);
+		$renderHandler->method('renderEntity')->willReturnArgument(0);
+		$renderHandler->method('renderEntities')->willReturnArgument(0);
+
+		// Record the scope the service resolves for a LIST read. This is the
+		// assertion #3408 found missing everywhere.
+		$this->getHandler->method('findAll')->willReturnCallback(
+			function (
+				?int $limit = null,
+				?int $offset = null,
+				array $filters = [],
+				array $sort = [],
+				?string $search = null,
+				?array $_extend = [],
+				bool $files = false,
+				?string $uses = null,
+				?Register $register = null,
+				?Schema $schema = null,
+				?array $ids = null,
+				bool $_rbac = true,
+				bool $_multitenancy = true,
+			): array {
+				$this->findAllScope = ['register' => $register, 'schema' => $schema];
+				return [];
+			}
+		);
+
+		$this->saveHandler->method('applyAlwaysDefaults')->willReturnArgument(1);
+		$this->saveHandler->method('seedLifecycleFieldOnCreate')->willReturnArgument(1);
+		$this->saveHandler->method('saveObject')->willReturnCallback(
+			function ($register, $schema, array $data, ...$rest): ObjectEntity {
+				$this->saveScope = ['register' => $register, 'schema' => $schema];
+
+				$entity = new ObjectEntity();
+				$entity->setUuid('saved-uuid');
+				$entity->setObject($data);
+				return $entity;
+			}
+		);
+
+		// New object: no row exists yet, so the save is a CREATE. A test that
+		// needs an existing row sets $this->existingObject.
+		$this->objectMapper->method('find')->willReturnCallback(
+			function (...$args): ObjectEntity {
+				if ($this->existingObject === null) {
+					throw new DoesNotExistException('not found');
+				}
+
+				return $this->existingObject;
+			}
+		);
+
+		$dateTimeNormalizer = $this->createMock(DateTimeNormalizer::class);
+		$dateTimeNormalizer->method('normalize')->willReturn(null);
+
+		$cascadingHandler = $this->createMock(CascadingHandler::class);
+		$cascadingHandler->method('handlePreValidationCascading')->willReturnCallback(
+			static fn (array $object, mixed $schema, ?string $uuid, ?int $register): array => [$object, $uuid]
+		);
+
+		$this->service = new ObjectService(
+			dataManipHandler: $this->createMock(DataManipulationHandler::class),
+			deleteHandler: $this->deleteHandler,
+			getHandler: $this->getHandler,
+			permissionHandler: $this->createMock(PermissionHandler::class),
+			renderHandler: $renderHandler,
+			saveHandler: $this->saveHandler,
+			saveObjectsHandler: $this->saveObjectsHandler,
+			searchQueryHandler: $this->createMock(SearchQueryHandler::class),
+			validateHandler: $this->createMock(ValidateObject::class),
+			lockHandler: $this->createMock(LockHandler::class),
+			auditHandler: $this->createMock(AuditHandler::class),
+			relationHandler: $this->createMock(RelationHandler::class),
+			mergeHandler: $this->createMock(MergeHandler::class),
+			facetHandler: $this->createMock(FacetHandler::class),
+			metadataHandler: $this->createMock(MetadataHandler::class),
+			perfOptHandler: $this->createMock(PerformanceOptimizationHandler::class),
+			queryHandler: $this->createMock(QueryHandler::class),
+			revertHandler: $this->createMock(RevertHandler::class),
+			utilityHandler: $this->createMock(UtilityHandler::class),
+			validationHandler: $this->createMock(ValidationHandler::class),
+			cascadingHandler: $cascadingHandler,
+			migrationHandler: $this->createMock(MigrationHandler::class),
+			registerMapper: $registerMapper,
+			schemaMapper: $schemaMapper,
+			viewMapper: $this->createMock(ViewMapper::class),
+			objectMapper: $this->objectMapper,
+			fileService: $this->createMock(FileService::class),
+			userSession: $this->createMock(IUserSession::class),
+			searchTrailService: $this->createMock(SearchTrailService::class),
+			groupManager: $this->createMock(IGroupManager::class),
+			userManager: $this->createMock(IUserManager::class),
+			organisationService: $this->createMock(OrganisationService::class),
+			logger: $this->createMock(LoggerInterface::class),
+			cacheHandler: $this->createMock(CacheHandler::class),
+			settingsService: $this->createMock(SettingsService::class),
+			dateTimeNormalizer: $dateTimeNormalizer,
+			container: $this->createMock(IAppContainer::class),
+			objectSourceRegistry: $this->createMock(ObjectSourceRegistry::class)
+		);
+	}//end setUp()
+
+	/**
+	 * Two register/schema pairs, each carrying only its own schema.
+	 *
+	 * The pairs are the real ones from openregister#3408 so the test names the
+	 * defect it pins rather than an abstraction of it.
+	 *
+	 * @return void
+	 */
+	private function buildFixtureRegisters(): void {
+		$brokerSchema = new Schema();
+		$brokerSchema->setId(9101);
+		$brokerSchema->setSlug(self::BROKER_SCHEMA);
+		$brokerSchema->setHardValidation(false);
+
+		$flowSchema = new Schema();
+		$flowSchema->setId(9102);
+		$flowSchema->setSlug(self::FLOW_SCHEMA);
+		$flowSchema->setHardValidation(false);
+
+		$brokerRegister = new Register();
+		$brokerRegister->setId(701);
+		$brokerRegister->setSlug(self::BROKER_REGISTER);
+		$brokerRegister->setSchemas([$brokerSchema->getId()]);
+
+		$flowRegister = new Register();
+		$flowRegister->setId(702);
+		$flowRegister->setSlug(self::FLOW_REGISTER);
+		$flowRegister->setSchemas([$flowSchema->getId()]);
+
+		$this->registers = [
+			self::BROKER_REGISTER => $brokerRegister,
+			self::FLOW_REGISTER => $flowRegister,
+		];
+		$this->schemas = [
+			self::BROKER_SCHEMA => $brokerSchema,
+			self::FLOW_SCHEMA => $flowSchema,
+		];
+	}//end buildFixtureRegisters()
+
+	/**
+	 * Write one object into the credential-broker register/schema.
+	 *
+	 * @return void
+	 */
+	private function saveIntoBrokerScope(): void {
+		$this->service->saveObject(
+			object: ['name' => 'example credential'],
+			register: self::BROKER_REGISTER,
+			schema: self::BROKER_SCHEMA,
+			_rbac: false,
+			_multitenancy: false
+		);
+	}//end saveIntoBrokerScope()
+
+	// =====================================================================
+	// THE CONTRACT
+	// =====================================================================
+
+	/**
+	 * THE DEFECT, REPRODUCED: a save must not scope the next unscoped read.
+	 *
+	 * This is openregister#3408 in miniature. A repair step writes with an
+	 * explicit register/schema; a later, unrelated step reads without naming
+	 * one. Before the fix the reader was handed the WRITER's pair and read the
+	 * writer's table — which is how two `brokeredcredential` example objects
+	 * became two rows in `openregister_flows`.
+	 *
+	 * The assertion is on the arguments handed to the GetObject handler, which
+	 * is the only place the resolved scope is observable.
+	 *
+	 * @return void
+	 */
+	public function testASaveDoesNotScopeATheNextUnscopedRead(): void {
+		$this->saveIntoBrokerScope();
+
+		// A later caller reads without naming a scope. Nothing anchored this
+		// service before the save, so there is nothing for it to inherit.
+		$this->service->findAll(config: [], _rbac: false, _multitenancy: false);
+
+		$this->assertNotNull($this->findAllScope, 'The read never reached the handler.');
+		$this->assertNull(
+			$this->findAllScope['register'],
+			'The unscoped read inherited the save\'s REGISTER. This is openregister#3408.'
+		);
+		$this->assertNull(
+			$this->findAllScope['schema'],
+			'The unscoped read inherited the save\'s SCHEMA. This is openregister#3408.'
+		);
+	}//end testASaveDoesNotScopeATheNextUnscopedRead()
+
+	/**
+	 * A save restores the CALLER's context rather than clearing it.
+	 *
+	 * The fluent pattern — `setRegister($r)->setSchema($s)` and then a read —
+	 * is how a dozen controllers scope their work, and it must survive a write
+	 * that names a different scope in between. Restoring, not clearing, is what
+	 * makes that true; a `clearCurrents()` at the end of a save would fix the
+	 * leak and break this.
+	 *
+	 * @return void
+	 */
+	public function testASaveRestoresTheCallersOwnContextRatherThanClearingIt(): void {
+		$this->service->setRegister(self::FLOW_REGISTER);
+		$this->service->setSchema(self::FLOW_SCHEMA);
+
+		$this->saveIntoBrokerScope();
+
+		$this->service->findAll(config: [], _rbac: false, _multitenancy: false);
+
+		$this->assertNotNull($this->findAllScope, 'The read never reached the handler.');
+		$this->assertSame(
+			self::FLOW_REGISTER,
+			$this->findAllScope['register']?->getSlug(),
+			'The caller anchored this service on `flows` and must still be on it after an unrelated save.'
+		);
+		$this->assertSame(
+			self::FLOW_SCHEMA,
+			$this->findAllScope['schema']?->getSlug(),
+			'The caller anchored this service on `flow` and must still be on it after an unrelated save.'
+		);
+	}//end testASaveRestoresTheCallersOwnContextRatherThanClearingIt()
+
+	/**
+	 * NEGATIVE CONTROL: the save itself is still scoped by its own arguments.
+	 *
+	 * Restoring afterwards must not mean the write ran unscoped. Without this
+	 * the leak could be "fixed" by never resolving the scope at all, and the
+	 * two tests above would still pass while every write went to the wrong
+	 * table.
+	 *
+	 * @return void
+	 */
+	public function testTheSaveItselfStillRunsInTheScopeItsArgumentsName(): void {
+		$this->service->setRegister(self::FLOW_REGISTER);
+		$this->service->setSchema(self::FLOW_SCHEMA);
+
+		$this->saveIntoBrokerScope();
+
+		$this->assertNotNull($this->saveScope, 'The save never reached the handler.');
+		$this->assertInstanceOf(Register::class, $this->saveScope['register']);
+		$this->assertInstanceOf(Schema::class, $this->saveScope['schema']);
+		$this->assertSame(self::BROKER_REGISTER, $this->saveScope['register']->getSlug());
+		$this->assertSame(self::BROKER_SCHEMA, $this->saveScope['schema']->getSlug());
+	}//end testTheSaveItselfStillRunsInTheScopeItsArgumentsName()
+
+	/**
+	 * NEGATIVE CONTROL: a save that names NO scope changes nothing.
+	 *
+	 * `createObject()` and `updateObject()` both delegate to
+	 * `saveObject(object: $data)` with no register or schema, relying on the
+	 * caller having anchored the service first. For them the snapshot and the
+	 * restore are the same context, so the fix is a no-op — and that has to
+	 * stay true or every one of those callers writes into nothing.
+	 *
+	 * @return void
+	 */
+	public function testASaveThatNamesNoScopeLeavesTheCallersContextUntouched(): void {
+		$this->service->setRegister(self::FLOW_REGISTER);
+		$this->service->setSchema(self::FLOW_SCHEMA);
+
+		$this->service->saveObject(
+			object: ['name' => 'anchored by the caller'],
+			_rbac: false,
+			_multitenancy: false
+		);
+
+		$this->assertNotNull($this->saveScope, 'The save never reached the handler.');
+		$this->assertSame(
+			self::FLOW_REGISTER,
+			$this->saveScope['register']?->getSlug(),
+			'A save with no scope arguments must still write into the caller\'s anchored register.'
+		);
+
+		$this->service->findAll(config: [], _rbac: false, _multitenancy: false);
+		$this->assertSame(self::FLOW_REGISTER, $this->findAllScope['register']?->getSlug());
+		$this->assertSame(self::FLOW_SCHEMA, $this->findAllScope['schema']?->getSlug());
+	}//end testASaveThatNamesNoScopeLeavesTheCallersContextUntouched()
+
+	/**
+	 * A save that THROWS must not leave its half-resolved scope behind either.
+	 *
+	 * A failed operation's leftovers are the least meaningful of all — nothing
+	 * downstream asked for that scope and nothing succeeded in it. `find()`
+	 * restores in a `finally` for this reason; so does the write path now.
+	 *
+	 * @return void
+	 */
+	public function testAFailedSaveDoesNotLeaveItsScopeBehind(): void {
+		$this->service->setRegister(self::FLOW_REGISTER);
+		$this->service->setSchema(self::FLOW_SCHEMA);
+
+		$this->saveHandler->method('saveObject')->willThrowException(new \RuntimeException('write failed'));
+
+		try {
+			$this->service->saveObject(
+				object: ['name' => 'doomed'],
+				register: self::BROKER_REGISTER,
+				schema: self::BROKER_SCHEMA,
+				_rbac: false,
+				_multitenancy: false
+			);
+			$this->fail('The save was expected to throw.');
+		} catch (\RuntimeException $e) {
+			$this->assertSame('write failed', $e->getMessage());
+		}
+
+		$this->service->findAll(config: [], _rbac: false, _multitenancy: false);
+		$this->assertSame(
+			self::FLOW_REGISTER,
+			$this->findAllScope['register']?->getSlug(),
+			'A throw mid-save left the failed operation\'s register on the shared service.'
+		);
+		$this->assertSame(self::FLOW_SCHEMA, $this->findAllScope['schema']?->getSlug());
+	}//end testAFailedSaveDoesNotLeaveItsScopeBehind()
+
+	/**
+	 * The same contract on the delete path.
+	 *
+	 * `deleteObject()` resolves its scope from its own arguments exactly as
+	 * `saveObject()` does, and left it behind exactly as `saveObject()` did.
+	 *
+	 * @return void
+	 */
+	public function testADeleteDoesNotScopeTheNextUnscopedRead(): void {
+		$this->service->setRegister(self::FLOW_REGISTER);
+		$this->service->setSchema(self::FLOW_SCHEMA);
+
+		$existing = new ObjectEntity();
+		$existing->setUuid('a2e21c1c-4b71-4a5a-9f0e-2f7b4a1c1f11');
+		$existing->setObject([]);
+		$this->existingObject = $existing;
+
+		$this->deleteHandler->method('deleteObject')->willReturn(true);
+
+		$this->service->deleteObject(
+			uuid: 'a2e21c1c-4b71-4a5a-9f0e-2f7b4a1c1f11',
+			register: self::BROKER_REGISTER,
+			schema: self::BROKER_SCHEMA,
+			_rbac: false,
+			_multitenancy: false
+		);
+
+		$this->service->findAll(config: [], _rbac: false, _multitenancy: false);
+		$this->assertSame(self::FLOW_REGISTER, $this->findAllScope['register']?->getSlug());
+		$this->assertSame(self::FLOW_SCHEMA, $this->findAllScope['schema']?->getSlug());
+	}//end testADeleteDoesNotScopeTheNextUnscopedRead()
+
+	/**
+	 * The same contract on the bulk-save path.
+	 *
+	 * `saveObjects()` is the import path — the one most likely to be followed
+	 * by an unscoped read in the same repair or migration run.
+	 *
+	 * @return void
+	 */
+	public function testABulkSaveDoesNotScopeTheNextUnscopedRead(): void {
+		$this->service->setRegister(self::FLOW_REGISTER);
+		$this->service->setSchema(self::FLOW_SCHEMA);
+
+		$this->saveObjectsHandler->method('saveObjects')->willReturn(['statistics' => []]);
+
+		$this->service->saveObjects(
+			objects: [['name' => 'bulk row']],
+			register: self::BROKER_REGISTER,
+			schema: self::BROKER_SCHEMA,
+			_rbac: false,
+			_multitenancy: false
+		);
+
+		$this->service->findAll(config: [], _rbac: false, _multitenancy: false);
+		$this->assertSame(self::FLOW_REGISTER, $this->findAllScope['register']?->getSlug());
+		$this->assertSame(self::FLOW_SCHEMA, $this->findAllScope['schema']?->getSlug());
+	}//end testABulkSaveDoesNotScopeTheNextUnscopedRead()
+
+	/**
+	 * The same contract on `findSilent()`.
+	 *
+	 * `find()` has restored since BUG-OBJ-13. `findSilent()` differs from it
+	 * only in skipping the audit row, so it had no business differing in what
+	 * it leaves behind — and it did.
+	 *
+	 * @return void
+	 */
+	public function testFindSilentDoesNotScopeTheNextUnscopedRead(): void {
+		$this->service->setRegister(self::FLOW_REGISTER);
+		$this->service->setSchema(self::FLOW_SCHEMA);
+
+		$this->getHandler->method('findSilent')->willReturn(new ObjectEntity());
+
+		$this->service->findSilent(
+			id: 'a2e21c1c-4b71-4a5a-9f0e-2f7b4a1c1f11',
+			register: self::BROKER_REGISTER,
+			schema: self::BROKER_SCHEMA,
+			_rbac: false,
+			_multitenancy: false
+		);
+
+		$this->service->findAll(config: [], _rbac: false, _multitenancy: false);
+		$this->assertSame(self::FLOW_REGISTER, $this->findAllScope['register']?->getSlug());
+		$this->assertSame(self::FLOW_SCHEMA, $this->findAllScope['schema']?->getSlug());
+	}//end testFindSilentDoesNotScopeTheNextUnscopedRead()
+
+	/**
+	 * NEGATIVE CONTROL: a read that DOES name its scope still gets it.
+	 *
+	 * `prepareFindAllConfig()` reads `filters.register` / `filters.schema`, and
+	 * that path is what every correct caller uses. Restoring the context after
+	 * a write must not disturb it — otherwise the fix would trade a silent
+	 * wrong answer for a silent empty one.
+	 *
+	 * @return void
+	 */
+	public function testAReadThatNamesItsScopeUnderFiltersStillGetsIt(): void {
+		$this->saveIntoBrokerScope();
+
+		$this->service->findAll(
+			config: [
+				'filters' => [
+					'register' => self::FLOW_REGISTER,
+					'schema' => self::FLOW_SCHEMA,
+				],
+			],
+			_rbac: false,
+			_multitenancy: false
+		);
+
+		$this->assertSame(self::FLOW_REGISTER, $this->findAllScope['register']?->getSlug());
+		$this->assertSame(self::FLOW_SCHEMA, $this->findAllScope['schema']?->getSlug());
+	}//end testAReadThatNamesItsScopeUnderFiltersStillGetsIt()
+}//end class

--- a/tests/Unit/Service/ObjectServiceTest.php
+++ b/tests/Unit/Service/ObjectServiceTest.php
@@ -715,6 +715,16 @@ class ObjectServiceTest extends TestCase {
 
 	/**
 	 * Test saveObject sets context from register and schema parameters.
+	 *
+	 * OBSERVED AT THE HANDLER, NOT ON THE INSTANCE AFTERWARDS.
+	 *
+	 * This used to read `currentRegister` / `currentSchema` off the service once
+	 * the save had returned, which asserted a LEAK rather than the intent: a
+	 * save's scope belongs to the save, and leaving it on a service shared for
+	 * the whole request is what let openregister#3408 copy two
+	 * `brokeredcredential` examples into the flow table. The intent — the write
+	 * runs in the scope its arguments name — is unchanged and is now checked
+	 * where it is actually observable.
 	 */
 	public function testSaveObjectSetsContextFromParameters(): void {
 		$schemaNoVal = new Schema();
@@ -727,7 +737,14 @@ class ObjectServiceTest extends TestCase {
 
 		$savedEntity = new ObjectEntity();
 		$savedEntity->setId(1);
-		$this->saveHandler->method('saveObject')->willReturn($savedEntity);
+
+		$handlerScope = null;
+		$this->saveHandler->method('saveObject')->willReturnCallback(
+			function ($register, $schema, ...$rest) use ($savedEntity, &$handlerScope): ObjectEntity {
+				$handlerScope = ['register' => $register, 'schema' => $schema];
+				return $savedEntity;
+			}
+		);
 		$this->renderHandler->method('renderEntity')->willReturn($savedEntity);
 
 		$this->service->saveObject(
@@ -736,8 +753,13 @@ class ObjectServiceTest extends TestCase {
 			schema: $schemaNoVal
 		);
 
-		$this->assertSame($this->register, $this->getProperty('currentRegister'));
-		$this->assertSame($schemaNoVal, $this->getProperty('currentSchema'));
+		$this->assertNotNull($handlerScope, 'The save never reached the handler.');
+		$this->assertSame($this->register, $handlerScope['register']);
+		$this->assertSame($schemaNoVal, $handlerScope['schema']);
+
+		// ...and it is not left behind for the next caller.
+		$this->assertNull($this->getProperty('currentRegister'));
+		$this->assertNull($this->getProperty('currentSchema'));
 	}
 
 	// ── 8. deleteObject() tests ─────────────────────────────────────────
@@ -1644,12 +1666,23 @@ class ObjectServiceTest extends TestCase {
 
 	/**
 	 * Test findSilent sets register and schema context when provided.
+	 *
+	 * Observed at the handler, for the same reason as
+	 * {@see testSaveObjectSetsContextFromParameters()}. `find()` has restored
+	 * its context since BUG-OBJ-13; `findSilent()` differs from it only in
+	 * skipping the audit row, so it now restores too.
 	 */
 	public function testFindSilentSetsContextWhenProvided(): void {
 		$entity = new ObjectEntity();
 		$entity->setId(1);
 
-		$this->getHandler->method('findSilent')->willReturn($entity);
+		$handlerScope = null;
+		$this->getHandler->method('findSilent')->willReturnCallback(
+			function ($id, $register = null, $schema = null, ...$rest) use ($entity, &$handlerScope): ObjectEntity {
+				$handlerScope = ['register' => $register, 'schema' => $schema];
+				return $entity;
+			}
+		);
 
 		$this->service->findSilent(
 			id: 'test-uuid',
@@ -1657,8 +1690,13 @@ class ObjectServiceTest extends TestCase {
 			schema: $this->schema
 		);
 
-		$this->assertSame($this->register, $this->getProperty('currentRegister'));
-		$this->assertSame($this->schema, $this->getProperty('currentSchema'));
+		$this->assertNotNull($handlerScope, 'The read never reached the handler.');
+		$this->assertSame($this->register, $handlerScope['register']);
+		$this->assertSame($this->schema, $handlerScope['schema']);
+
+		// ...and it is not left behind for the next caller.
+		$this->assertNull($this->getProperty('currentRegister'));
+		$this->assertNull($this->getProperty('currentSchema'));
 	}
 
 	// ── 31. Private: handleCascadingWithContextPreservation() tests ─────

--- a/tests/Unit/Service/VocabularyImportServiceTest.php
+++ b/tests/Unit/Service/VocabularyImportServiceTest.php
@@ -55,6 +55,15 @@ class VocabularyImportServiceTest extends TestCase {
 	private int $sequence = 0;
 
 	/**
+	 * Every config array handed to ObjectService::findAll(), in call order.
+	 *
+	 * Recorded so the tests can assert what was ASKED, not only what came back.
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	private array $findAllCalls = [];
+
+	/**
 	 * @var ObjectService&MockObject
 	 */
 	private ObjectService $objectService;
@@ -69,6 +78,7 @@ class VocabularyImportServiceTest extends TestCase {
 	protected function setUp(): void {
 		$this->store = [];
 		$this->sequence = 0;
+		$this->findAllCalls = [];
 		$this->fixturesDir = __DIR__ . '/../../Fixtures/vocabulary';
 
 		$this->objectService = $this->createMock(ObjectService::class);
@@ -203,6 +213,107 @@ class VocabularyImportServiceTest extends TestCase {
 		$this->assertSame([$x->getUuid()], $y->getObject()['broader']);
 	}//end testImportCsvValueListCreatesSchemeAndConceptsWithBroaderRelation()
 
+	/**
+	 * EVERY read must name its scope where ObjectService actually looks.
+	 *
+	 * `prepareFindAllConfig()` reads `$config['filters']['register']` and
+	 * `$config['filters']['schema']`, and no other key. A pair at the TOP level
+	 * of the config is therefore read by nothing: `setRegister()`/`setSchema()`
+	 * are never called and `findAll()` hands the handler
+	 * `$this->currentRegister` / `$this->currentSchema` — leftover shared state
+	 * from whatever ran last on the same service instance.
+	 *
+	 * This importer used the top-level shape at both of its read sites. It was
+	 * the second of the three outliers openregister#3408 found while diagnosing
+	 * the flow migration, and was reported there rather than changed because it
+	 * was not in that defect's path and needed its own test. This is that test.
+	 *
+	 * It asserts the ARGUMENTS, not the result: the fake used to answer from
+	 * `$config['schema']`, so it replied correctly to a question the real
+	 * service is never asked, and every assertion about the returned objects
+	 * passed with the scope wired to nothing.
+	 *
+	 * @return void
+	 */
+	public function testEveryReadNamesItsScopeWhereObjectServiceReadsIt(): void {
+		$this->importFixture('sample-scheme.jsonld');
+		$this->importFixture('sample-scheme-updated.jsonld');
+
+		// A recording that stayed empty would satisfy every loop below, so the
+		// count is asserted first: this import performs identity lookups and a
+		// deprecation sweep, so there is no version of it that reads nothing.
+		$this->assertGreaterThan(
+			0,
+			count($this->findAllCalls),
+			'No findAll() call was recorded, so the assertions below prove nothing.'
+		);
+
+		foreach ($this->findAllCalls as $index => $config) {
+			$this->assertArrayNotHasKey(
+				'register',
+				$config,
+				"findAll() call #$index puts `register` at the top level, where nothing reads it."
+			);
+			$this->assertArrayNotHasKey(
+				'schema',
+				$config,
+				"findAll() call #$index puts `schema` at the top level, where nothing reads it."
+			);
+			$this->assertSame(
+				VocabularyImportService::REGISTER,
+				($config['filters']['register'] ?? null),
+				"findAll() call #$index does not scope its register under `filters`."
+			);
+			$this->assertContains(
+				($config['filters']['schema'] ?? null),
+				[VocabularyImportService::SCHEMA_SCHEME, VocabularyImportService::SCHEMA_CONCEPT],
+				"findAll() call #$index does not scope its schema under `filters`."
+			);
+		}
+	}//end testEveryReadNamesItsScopeWhereObjectServiceReadsIt()
+
+	/**
+	 * The deprecation sweep's FIRST page must be scoped, not just the later ones.
+	 *
+	 * `deprecateMissing()` pages through a scheme's concepts and writes a
+	 * `deprecated` flag as it goes. Its `saveObject()` names register and schema,
+	 * so under the old shape the write anchored the shared service on exactly the
+	 * pair the read wanted — and every page AFTER the first inherited a correct
+	 * context by accident. Only page one read whatever an unrelated caller had
+	 * left behind.
+	 *
+	 * That is what made the defect invisible: the loop appeared to work. This
+	 * pins the first read of the sweep specifically.
+	 *
+	 * @return void
+	 */
+	public function testTheDeprecationSweepScopesItsFirstPageAndNotOnlyThePagesAfterAWrite(): void {
+		$this->importFixture('sample-scheme.jsonld');
+
+		// The re-import is the run that deprecates the concept absent from the
+		// updated source, so its sweep is the one to inspect.
+		$this->findAllCalls = [];
+		$report = $this->importFixture('sample-scheme-updated.jsonld');
+		$this->assertSame(1, $report['deprecated'], 'Fixture must still exercise the deprecation sweep.');
+
+		$conceptReads = array_values(
+			array_filter(
+				$this->findAllCalls,
+				static fn (array $config): bool => (($config['filters']['schema'] ?? null)
+					=== VocabularyImportService::SCHEMA_CONCEPT)
+					&& isset($config['filters']['inScheme']) === true
+			)
+		);
+
+		$this->assertNotEmpty($conceptReads, 'The deprecation sweep performed no scoped concept read.');
+		$this->assertSame(
+			VocabularyImportService::REGISTER,
+			($conceptReads[0]['filters']['register'] ?? null),
+			'The sweep\'s FIRST page must carry its own scope; it cannot borrow one from a later write.'
+		);
+		$this->assertSame(0, ($conceptReads[0]['offset'] ?? 0), 'The first recorded sweep read must be page one.');
+	}//end testTheDeprecationSweepScopesItsFirstPageAndNotOnlyThePagesAfterAWrite()
+
 	// -------------------------------------------------------------------
 	// Fixture + fake-store helpers.
 	// -------------------------------------------------------------------
@@ -240,8 +351,39 @@ class VocabularyImportServiceTest extends TestCase {
 	 * @return array<int, ObjectEntity>
 	 */
 	private function fakeFindAll(array $config): array {
-		$schema = (string)($config['schema'] ?? '');
+		// A FAKE THAT ANSWERS ANY QUESTION CANNOT REPORT A WRONG ONE.
+		//
+		// This used to read `$config['schema']` — a key `ObjectService` never
+		// looks at. `prepareFindAllConfig()` reads `$config['filters']['register']`
+		// and `$config['filters']['schema']` and nothing else, so the fake was
+		// answering a question the real service is not asked, and the service's
+		// answer came from whatever register/schema the previous CALLER had left
+		// on it. Every test here passed either way, which is why the defect
+		// survived (openregister#3408).
+		//
+		// The fake now reads the scope from exactly where the service reads it,
+		// and refuses the read outright when the scope is absent — so a caller
+		// that goes back to the top-level shape fails here rather than being
+		// quietly served.
+		$this->findAllCalls[] = $config;
+
+		$register = ($config['filters']['register'] ?? null);
+		$schema = ($config['filters']['schema'] ?? null);
+		if ($register === null || $schema === null) {
+			throw new \RuntimeException(
+				'findAll() was called without filters.register / filters.schema; '
+				.'ObjectService reads the scope from nowhere else, so this read '
+				.'would have run on whatever context the last write left behind.'
+			);
+		}
+
+		$schema = (string)$schema;
+		// `register` and `schema` are reserved query context, not object fields.
+		// MagicSearchHandler::getReservedParams() strips them before filtering;
+		// leaving them in here would match every stored row against a field that
+		// does not exist and return nothing.
 		$filters = ($config['filters'] ?? []);
+		unset($filters['register'], $filters['schema']);
 		$limit = ($config['limit'] ?? null);
 		$offset = ($config['offset'] ?? 0);
 


### PR DESCRIPTION
`saveObject()` resolved a register/schema from its arguments, set them as the service's current context, and **never put back what it found**. `find()` has restored its context in a `finally` since BUG-OBJ-13. Everything else did not.

## What that cost

openregister#3408: `ImportCredentialBrokerRegister` saved two example objects through `saveObject(register: credential-broker, schema: brokeredcredential)`, and four repair steps later a migration whose own read was unscoped inherited that pair and copied two `brokeredcredential` examples into the flow table **as flows** — deterministically, on every install and every `occ upgrade`, with no error anywhere. Those artefacts then nearly propagated a wrong precedent into another app, because `__system__` (merely what OpenRegister stamps on a sessionless write) looked like a convention.

That defect was fixed at its call site. This is the same fix at the source, so the next unscoped reader after a write inherits **nothing** rather than inheriting the write's scope.

## The contract, deliberately narrow

`setRegister()` / `setSchema()` **still persist** — that fluent pattern is how a dozen controllers scope a read, and nothing here changes it. An entry point that takes `register:` / `schema:` **arguments** is a different thing: it is scoping itself for the duration of one operation, so it now restores in a `finally` (a throw restores too). Applied to `saveObject`, `saveObjects`, `saveObjectsStreaming`, `patchObject`, `deleteObject` and `findSilent`; `find()` keeps its existing inline restore.

Most of the diff is method bodies reindenting into `try { … } finally { … }` — `git diff -w` is **+117 / −0**.

## The last two inert-filter callers

`VocabularyController` and `VocabularyImportService` passed `register`/`schema` at the **top level** of a `findAll` config, where `prepareFindAllConfig()` reads nothing — so the filters were silently ignored and both read against leftover context, exactly as the migration did. #3408 found and reported them; they are fixed here. Their tests now assert the **arguments** handed to `findAll()`, because a mock that answers any question cannot report a wrong one.

## Verified locally (CI bottlenecked, per the current merge-on-local-verification policy)

phpcs **0** · psalm **0** · phpstan **0** · phpmd on the changed files **0** · phpunit `Unit Tests` **18,907 tests, 46,020 assertions, 0 failures**. Judged by exit code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)