### PR TITLE
feat(objects): the organisation projection is writable

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6872,16 +6872,16 @@
         },
         {
             "name": "conduction/hydra-gates",
-            "version": "v1.13.0",
+            "version": "v1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ConductionNL/.github.git",
-                "reference": "a4f5c471451220ea4dc48492cb8ffdce5aa22449"
+                "reference": "7150f7f7327109cafce40ca23ca3310ee2c10aa8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/a4f5c471451220ea4dc48492cb8ffdce5aa22449",
-                "reference": "a4f5c471451220ea4dc48492cb8ffdce5aa22449",
+                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/7150f7f7327109cafce40ca23ca3310ee2c10aa8",
+                "reference": "7150f7f7327109cafce40ca23ca3310ee2c10aa8",
                 "shasum": ""
             },
             "require": {
@@ -6920,9 +6920,9 @@
             "support": {
                 "docs": "https://github.com/ConductionNL/.github/blob/main/hydra-gates/README.md",
                 "issues": "https://github.com/ConductionNL/.github/issues",
-                "source": "https://github.com/ConductionNL/.github/tree/v1.13.0"
+                "source": "https://github.com/ConductionNL/.github/tree/v1.14.0"
             },
-            "time": "2026-09-04T14:12:31+00:00"
+            "time": "2026-09-04T14:51:44+00:00"
         },
         {
             "name": "consolidation/annotated-command",

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -1473,7 +1473,8 @@ class Application extends App implements IBootstrap {
 					organisationMapper: $container->get('OCA\OpenRegister\Db\OrganisationMapper'),
 					userSession: $container->get('OCP\IUserSession'),
 					groupManager: $container->get('OCP\IGroupManager'),
-					logger: $container->get('Psr\Log\LoggerInterface')
+					logger: $container->get('Psr\Log\LoggerInterface'),
+					organisationService: $container->get('OCA\OpenRegister\Service\OrganisationService')
 				);
 			}
 		);

--- a/lib/Repair/SeedDirectoryVirtualSchemas.php
+++ b/lib/Repair/SeedDirectoryVirtualSchemas.php
@@ -195,34 +195,128 @@ class SeedDirectoryVirtualSchemas implements IRepairStep {
 	/**
 	 * Find or create one virtual schema for a semantic-map row.
 	 *
-	 * @param array{register: string, schema: string, schemaOrg: string, provider: string, requiredApp: string|null} $row The semantic-map row.
+	 * @param array<string, mixed> $row One {@see NcEntitySemanticMap::ENTITIES} row.
 	 *
 	 * @return Schema The existing or newly created schema.
 	 *
 	 * @spec openspec/changes/virtual-schema-semantic-providers/tasks.md#task-2.2
 	 */
 	private function ensureSchema(array $row): Schema {
+		$readOnly = (($row['writable'] ?? false) === false);
+
 		try {
-			return $this->schemaMapper->find($row['schema'], _rbac: false, _multitenancy: false);
+			$schema = $this->schemaMapper->find($row['schema'], _rbac: false, _multitenancy: false);
+
+			return $this->reconcileReadOnly(schema: $schema, readOnly: $readOnly);
 		} catch (Throwable $e) {
-			// Not found — create it as a read-only object-source-backed schema.
 			$properties = (self::SCHEMA_PROPERTIES[$row['schema']] ?? []);
 
 			return $this->schemaMapper->createFromArray(
 				object: [
 					'title' => $row['schema'],
 					'slug' => $row['schema'],
-					'description' => sprintf('Read-only virtual schema for Nextcloud %s (%s).', $row['schema'], $row['schemaOrg']),
+					'description' => sprintf(
+						'%s virtual schema for Nextcloud %s (%s).',
+						ucfirst($this->readOnlyLabel(readOnly: $readOnly)),
+						$row['schema'],
+						$row['schemaOrg']
+					),
 					'properties' => $properties,
 					'configuration' => [
 						'x-schema-org' => $row['schemaOrg'],
 						'x-openregister-object-source' => [
 							'provider' => $row['provider'],
-							'readOnly' => true,
+							'readOnly' => $readOnly,
 						],
 					],
 				]
 			);
 		}//end try
 	}//end ensureSchema()
+
+	/**
+	 * Bring an EXISTING virtual schema's `readOnly` annotation in step with the map.
+	 *
+	 * WITHOUT THIS THE FLAG ONLY EVER REACHES A FRESH INSTALL. `ensureSchema()`
+	 * returns early the moment the schema is found, so every instance that
+	 * already seeded `nc-organisation` would keep the `readOnly: true` it was
+	 * created with — and `delegateObjectSourceWrite()` reads exactly that
+	 * annotation. The provider would implement the write interface, the seed
+	 * would report success, and every write would still be refused, with nothing
+	 * naming the annotation as the reason.
+	 *
+	 * Only the `readOnly` key is touched. The rest of the configuration is
+	 * whatever the instance has, including anything an administrator set.
+	 *
+	 * @param Schema $schema   The existing schema.
+	 * @param bool   $readOnly What the map says it should be.
+	 *
+	 * @return Schema The schema, saved when it had drifted.
+	 *
+	 * @spec openspec/changes/the-organisation-projection-is-writable/specs/organisation-projection/spec.md#requirement-an-organisation-can-be-created-through-the-projection-req-orp-104
+	 */
+	private function reconcileReadOnly(Schema $schema, bool $readOnly): Schema {
+		$configuration = ($schema->getConfiguration() ?? []);
+		$source = ($configuration['x-openregister-object-source'] ?? null);
+
+		if (is_array($source) === false || ($source['readOnly'] ?? null) === $readOnly) {
+			return $schema;
+		}
+
+		$source['readOnly'] = $readOnly;
+		$configuration['x-openregister-object-source'] = $source;
+		$schema->setConfiguration($configuration);
+
+		try {
+			$updated = $this->schemaMapper->update($schema);
+		} catch (Throwable $e) {
+			// LOUD, not swallowed. `run()` catches everything and degrades to a
+			// warning, which is right for "the seed could not create a schema" and
+			// wrong here: the schema exists and works, it just refuses writes, and
+			// the caller sees a generic "read-only projection" rejection with
+			// nothing pointing back at this annotation.
+			$this->logger->error(
+				sprintf(
+					'[SeedDirectoryVirtualSchemas] could not set %s to %s: %s. Writes through this schema '
+					.'will be refused until its x-openregister-object-source.readOnly is corrected.',
+					(string)$schema->getSlug(),
+					$this->readOnlyLabel(readOnly: $readOnly),
+					$e->getMessage()
+				)
+			);
+
+			return $schema;
+		}
+
+		$this->logger->info(
+			sprintf(
+				'[SeedDirectoryVirtualSchemas] %s is now %s',
+				(string)$schema->getSlug(),
+				$this->readOnlyLabel(readOnly: $readOnly)
+			)
+		);
+
+		if ($updated instanceof Schema === true) {
+			return $updated;
+		}
+
+		return $schema;
+	}//end reconcileReadOnly()
+
+	/**
+	 * Name a `readOnly` value for a log line or a schema description.
+	 *
+	 * @param bool $readOnly The flag.
+	 *
+	 * @return string The label, lowercase; `ucfirst()` it for sentence position.
+	 *
+	 * @spec openspec/changes/the-organisation-projection-is-writable/specs/organisation-projection/spec.md#requirement-an-organisation-can-be-created-through-the-projection-req-orp-104
+	 */
+	private function readOnlyLabel(bool $readOnly): string {
+		if ($readOnly === true) {
+			return 'read-only';
+		}
+
+		return 'writable';
+	}//end readOnlyLabel()
 }//end class

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -4364,6 +4364,14 @@ class ObjectService implements ObjectServiceInterface
      * @throws SchemaNotInRegisterException When the register does not carry the schema.
      * @throws \OCP\DB\Exception            When the delete fails.
      *
+     * @orphaned-write-capability exclude Declared on ObjectServiceInterface, so
+     *          its callers are OTHER APPS and no in-repo call site can exist.
+     *          gate-57 counts `->purgeExpiredObjectsRaw(` across lib/ only. Do
+     *          NOT satisfy it by adding a route: this bypasses soft-delete and
+     *          the audit trail by design, and exposing it over HTTP would hand
+     *          any caller an unauditable hard delete of a whole register+schema.
+     *          The sweep belongs to the app that owns the expiring rows.
+     *
      * @spec openspec/specs/data-import-export/spec.md#requirement-raw-append-for-high-volume-writers
      */
     public function purgeExpiredObjectsRaw(Register|string|int $register, Schema|string|int $schema): int

--- a/lib/Service/ObjectSource/NcEntitySemanticMap.php
+++ b/lib/Service/ObjectSource/NcEntitySemanticMap.php
@@ -63,9 +63,15 @@ final class NcEntitySemanticMap {
 	 *  - `provider`    — the ObjectSourceProvider id that serves its objects;
 	 *  - `requiredApp` — the NC app that must be installed for the provider to be
 	 *                    usable (`null` = Nextcloud core, always available);
-	 *  - `application` — the register's `application` (drives the ADR-048 gate).
+	 *  - `application` — the register's `application` (drives the ADR-048 gate);
+	 *  - `writable`    — OPTIONAL, absent means read-only. Sets the schema's
+	 *                    `x-openregister-object-source.readOnly`, which is the
+	 *                    annotation the save/delete dispatch reads before it will
+	 *                    delegate a write. Only `nc-organisation` carries it.
 	 *
-	 * @var array<string, array{register: string, schema: string, schemaOrg: string, provider: string, requiredApp: string|null, application: string}>
+	 * @var array<string, array{register: string, schema: string, schemaOrg: string,
+	 *     provider: string, requiredApp: string|null, application: string,
+	 *     writable?: bool}>
 	 */
 	public const ENTITIES = [
 		'user' => [
@@ -92,6 +98,17 @@ final class NcEntitySemanticMap {
 		// `nc-`-prefixed for the reason the app-gated rows below are: it must not
 		// collide with the leaf-app `organization` schemas it exists to replace,
 		// which have to keep working until each app has migrated off them.
+		//
+		// WRITABLE, and the only row that is. A read-only projection cannot
+		// replace the leaf copies, because the apps that declared them CREATE
+		// organisations: stackiq's setup walkthrough says "Click New and save an
+		// organisation" and advances on `object-created`. The write goes through
+		// `OrganisationService::createOrganisation()`, so the slug, the owner and
+		// the admin-group RBAC grant are assigned as they are anywhere else, and
+		// `remove()` refuses outright.
+		//
+		// The other rows project someone else's system (a Nextcloud user, a Deck
+		// card) and stay read-only. This one projects OpenRegister's own entity.
 		'organisation' => [
 			'register' => self::DIRECTORY_REGISTER,
 			'schema' => 'nc-organisation',
@@ -99,6 +116,7 @@ final class NcEntitySemanticMap {
 			'provider' => 'organisation-source',
 			'requiredApp' => null,
 			'application' => 'openregister',
+			'writable' => true,
 		],
 		// App-gated rows — each lives on its OWN app-named register (application =
 		// register slug) so the ADR-048 app-enabled gate degrades the projection

--- a/lib/Service/ObjectSource/OrganisationObjectSourceProvider.php
+++ b/lib/Service/ObjectSource/OrganisationObjectSourceProvider.php
@@ -2,7 +2,7 @@
 
 /**
  * OrganisationObjectSourceProvider — serves the `nc-organisation` virtual
- * schema's objects live from OpenRegister's own organisations (read-only).
+ * schema's objects live from OpenRegister's own organisations.
  *
  * WHY THIS EXISTS
  * ---------------
@@ -22,11 +22,30 @@
  * `directory` register, with the schema `nc-`-prefixed so it cannot collide
  * with a leaf app's own `organization`.
  *
- * READ-ONLY, AND DELIBERATELY SO
- * ------------------------------
- * The authoritative record is the Organisation row. A write path here would be a
- * second way to mutate a tenant, reachable through the object API and bypassing
- * `OrganisationService`'s lifecycle. Writes stay where they are.
+ * WRITABLE, THROUGH THE LIFECYCLE RATHER THAN AROUND IT
+ * -----------------------------------------------------
+ * This was read-only, on the reasoning that a write path here would be a second
+ * way to mutate a tenant, bypassing `OrganisationService`'s lifecycle. That
+ * reasoning holds and the conclusion did not: a read-only projection cannot
+ * replace the leaf copies, because the apps that declared them CREATE
+ * organisations. Stackiq's setup walkthrough says "Click New and save an
+ * organisation" and advances on `object-created`. Migrating that onto a
+ * read-only schema would retire a working flow rather than move it.
+ *
+ * So the write path exists and goes THROUGH `OrganisationService::createOrganisation()`,
+ * which is what makes it safe: slug generation, owner assignment, the admin-group
+ * RBAC grant and slug-collision recovery all still happen. The provider adds only
+ * the identity fields on top.
+ *
+ * `remove()` REFUSES. An organisation is the tenant boundary, so deleting one
+ * through the object API would orphan every object scoped to it, from a caller
+ * that thinks it is deleting a reference record. Merging is the operation that
+ * exists for retiring an organisation, and it keeps the references pointing
+ * somewhere real.
+ *
+ * The write is still gated twice over: the schema annotation must carry
+ * `readOnly: false` (which `SeedDirectoryVirtualSchemas` sets for this schema and
+ * no other), and `mayWrite()` below re-checks the acting user at write time.
  *
  * SCOPING
  * -------
@@ -59,17 +78,20 @@ use OCA\OpenRegister\Db\Organisation;
 use OCA\OpenRegister\Db\OrganisationMapper;
 use OCA\OpenRegister\Db\Register;
 use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Service\OrganisationService;
 use OCP\IGroupManager;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 use Throwable;
 
 /**
- * Projects each organisation as a read-only virtual object.
+ * Projects each organisation as a virtual object, readable by its members and
+ * writable by its owner.
  *
  * @spec openspec/changes/organisations-are-objects/specs/organisation-projection/spec.md#requirement-an-organisation-is-addressable-as-an-object-req-orp-101
  */
-class OrganisationObjectSourceProvider implements ObjectSourceProvider {
+class OrganisationObjectSourceProvider implements WritableObjectSourceProvider {
 
 	/**
 	 * The properties the projection exposes.
@@ -98,10 +120,14 @@ class OrganisationObjectSourceProvider implements ObjectSourceProvider {
 	/**
 	 * Wire the mapper and the acting-user services.
 	 *
-	 * @param OrganisationMapper $organisationMapper The organisation mapper.
-	 * @param IUserSession       $userSession        The acting user's session.
-	 * @param IGroupManager      $groupManager       Group manager, for the admin check.
-	 * @param LoggerInterface    $logger             Logger.
+	 * @param OrganisationMapper  $organisationMapper  The organisation mapper.
+	 * @param IUserSession        $userSession         The acting user's session.
+	 * @param IGroupManager       $groupManager        Group manager, for the admin check.
+	 * @param LoggerInterface     $logger              Logger.
+	 * @param OrganisationService $organisationService The organisation lifecycle,
+	 *                                                 which owns slug generation,
+	 *                                                 owner assignment and the
+	 *                                                 admin-group RBAC grant.
 	 *
 	 * @return void
 	 */
@@ -110,6 +136,7 @@ class OrganisationObjectSourceProvider implements ObjectSourceProvider {
 		private readonly IUserSession $userSession,
 		private readonly IGroupManager $groupManager,
 		private readonly LoggerInterface $logger,
+		private readonly OrganisationService $organisationService,
 	) {
 	}//end __construct()
 
@@ -214,6 +241,221 @@ class OrganisationObjectSourceProvider implements ObjectSourceProvider {
 	public function count(Register $register, Schema $schema, array $query = [], array $config = []): int {
 		return count($this->findAll(register: $register, schema: $schema, query: $query, config: $config));
 	}//end count()
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Creates the organisation through {@see OrganisationService::createOrganisation()}
+	 * rather than through the mapper, so the slug, the owner, the admin users and
+	 * the admin-group RBAC grant are all assigned the way they are for an
+	 * organisation created anywhere else. A row written straight through the
+	 * mapper would be a tenant nobody administers.
+	 *
+	 * The remaining identity fields are applied afterwards, because
+	 * `createOrganisation()` takes only a name and a description.
+	 *
+	 * @param Register             $register The register the schema belongs to.
+	 * @param Schema               $schema   The sourced schema.
+	 * @param array<string, mixed> $data     The validated object data.
+	 * @param array<string, mixed> $config   The object-source config block (unused).
+	 *
+	 * @return ObjectEntity The created organisation, projected.
+	 *
+	 * @throws RuntimeException When there is no acting user, or `name` is missing.
+	 *
+	 * @SuppressWarnings(PHPMD.UnusedFormalParameter) $config reserved for future scoping options.
+	 *
+	 * @spec openspec/changes/the-organisation-projection-is-writable/specs/organisation-projection/spec.md#requirement-an-organisation-can-be-created-through-the-projection-req-orp-104
+	 */
+	public function insert(Register $register, Schema $schema, array $data, array $config = []): ObjectEntity {
+		if ($this->userSession->getUser() === null) {
+			throw new RuntimeException('An organisation cannot be created without an acting user.');
+		}
+
+		$name = trim((string)($data['name'] ?? ''));
+		if ($name === '') {
+			// Refused rather than defaulted. `createOrganisation()` derives the
+			// slug from the name, so an empty one would produce a tenant with an
+			// empty slug that the next create then collides with.
+			throw new RuntimeException('An organisation needs a name.');
+		}
+
+		$organisation = $this->organisationService->createOrganisation(
+			name: $name,
+			description: (string)($data['description'] ?? '')
+		);
+
+		$organisation = $this->applyProjectedFields(organisation: $organisation, data: $data, skip: ['name', 'description']);
+
+		return $this->toObjectEntity(register: $register, schema: $schema, organisation: $organisation);
+	}//end insert()
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Only the projected identity fields are written. Tenancy administration
+	 * (quota, users, groups, authorization) is not projected and so cannot be
+	 * reached here, which is the same boundary the read side draws.
+	 *
+	 * @param Register             $register The register the schema belongs to.
+	 * @param Schema               $schema   The sourced schema.
+	 * @param string               $id       The organisation uuid.
+	 * @param array<string, mixed> $data     The validated object data.
+	 * @param array<string, mixed> $config   The object-source config block (unused).
+	 *
+	 * @return ObjectEntity The updated organisation, projected.
+	 *
+	 * @throws RuntimeException When the organisation is absent, merged away, or the
+	 *                          acting user does not administer it.
+	 *
+	 * @SuppressWarnings(PHPMD.UnusedFormalParameter) $config reserved for future scoping options.
+	 *
+	 * @spec openspec/changes/the-organisation-projection-is-writable/specs/organisation-projection/spec.md#requirement-only-an-organisations-administrator-may-write-it-req-orp-105
+	 */
+	public function update(Register $register, Schema $schema, string $id, array $data, array $config = []): ObjectEntity {
+		try {
+			$organisation = $this->organisationMapper->findByUuid(uuid: $id);
+		} catch (Throwable $e) {
+			throw new RuntimeException(sprintf('Organisation "%s" does not exist.', $id), 0, $e);
+		}
+
+		// NOT `findByUuidFollowingMerge()`, which the read side uses. Following a
+		// merge on a WRITE would silently edit the survivor while the caller
+		// believes it is editing the record it addressed.
+		if ($organisation->isMerged() === true) {
+			throw new RuntimeException(
+				sprintf('Organisation "%s" has been merged away and cannot be written.', $id)
+			);
+		}
+
+		if ($this->mayWrite(organisation: $organisation) === false) {
+			// Deliberately the same message shape as the absent case above would
+			// give an outsider nothing to distinguish them by — but an
+			// administrator reading the log needs the difference, so it is logged.
+			$this->logger->info(
+				'[ObjectSource:organisation-source] write on organisation ' . $id . ' refused: acting user is not its administrator'
+			);
+			throw new RuntimeException(sprintf('Organisation "%s" does not exist.', $id));
+		}
+
+		$organisation = $this->applyProjectedFields(organisation: $organisation, data: $data, skip: []);
+
+		return $this->toObjectEntity(register: $register, schema: $schema, organisation: $organisation);
+	}//end update()
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * REFUSES, always. An organisation is the tenant boundary: every object,
+	 * register and schema on the instance is scoped to one. Deleting it through
+	 * the object API would orphan all of that, from a caller that believes it is
+	 * removing a reference record.
+	 *
+	 * Merging is the operation that exists for retiring an organisation, and it
+	 * keeps every stored reference pointing at a record that still owns something.
+	 *
+	 * @param Register             $register The register the schema belongs to.
+	 * @param Schema               $schema   The sourced schema.
+	 * @param string               $id       The organisation uuid.
+	 * @param array<string, mixed> $config   The object-source config block (unused).
+	 *
+	 * @return bool Never returns.
+	 *
+	 * @throws RuntimeException Always.
+	 *
+	 * @SuppressWarnings(PHPMD.UnusedFormalParameter) The signature is the interface's.
+	 *
+	 * @spec openspec/changes/the-organisation-projection-is-writable/specs/organisation-projection/spec.md#requirement-an-organisation-cannot-be-deleted-through-the-projection-req-orp-106
+	 */
+	public function remove(Register $register, Schema $schema, string $id, array $config = []): bool {
+		throw new RuntimeException(
+			sprintf(
+				'Organisation "%s" cannot be deleted through the object API: it is a tenant boundary, '
+				.'and every object scoped to it would be orphaned. Merge it instead.',
+				$id
+			)
+		);
+	}//end remove()
+
+	/**
+	 * Write the projected identity fields onto an organisation and persist it.
+	 *
+	 * Only keys in {@see PROJECTED} are written. A key outside it is ignored
+	 * rather than rejected: the store already discards unprojected properties on
+	 * the way in, so rejecting here would fail a request over a field the caller
+	 * cannot see anyway.
+	 *
+	 * Organisation's accessors are magic (`Entity::__call`), so the setter is
+	 * called dynamically. `method_exists()` would answer false for every one of
+	 * them, which is exactly how {@see project()} once produced an object
+	 * carrying nothing but an id.
+	 *
+	 * @param Organisation         $organisation The organisation to write.
+	 * @param array<string, mixed> $data         The object data.
+	 * @param array<int, string>   $skip         Properties already applied.
+	 *
+	 * @return Organisation The saved organisation.
+	 *
+	 * @spec openspec/changes/the-organisation-projection-is-writable/specs/organisation-projection/spec.md#requirement-only-the-identity-facet-is-writable-req-orp-107
+	 */
+	private function applyProjectedFields(Organisation $organisation, array $data, array $skip): Organisation {
+		$changed = false;
+
+		foreach (self::PROJECTED as $property) {
+			if (in_array($property, $skip, true) === true || array_key_exists($property, $data) === false) {
+				continue;
+			}
+
+			$value = $data[$property];
+			if ($value !== null && is_scalar($value) === false) {
+				continue;
+			}
+
+			if ($value !== null) {
+				$value = (string)$value;
+			}
+
+			$organisation->{'set'.ucfirst($property)}($value);
+			$changed = true;
+		}
+
+		if ($changed === false) {
+			return $organisation;
+		}
+
+		return $this->organisationMapper->save($organisation);
+	}//end applyProjectedFields()
+
+	/**
+	 * Whether the acting user may write this organisation.
+	 *
+	 * Membership is enough to READ the projection; writing needs ownership.
+	 * `isOrganisationAdmin()` is OpenRegister's own answer to that question
+	 * (instance admin, or the organisation's owner), so the projection and the
+	 * rest of the app agree on who administers an organisation.
+	 *
+	 * @param Organisation $organisation The organisation being written.
+	 *
+	 * @return bool True when the acting user administers it.
+	 *
+	 * @spec openspec/changes/the-organisation-projection-is-writable/specs/organisation-projection/spec.md#requirement-only-an-organisations-administrator-may-write-it-req-orp-105
+	 */
+	private function mayWrite(Organisation $organisation): bool {
+		if ($this->userSession->getUser() === null) {
+			return false;
+		}
+
+		try {
+			return $this->organisationService->isOrganisationAdmin(
+				organisationUuid: (string)$organisation->getUuid()
+			);
+		} catch (Throwable $e) {
+			$this->logger->warning(
+				'[ObjectSource:organisation-source] could not check write authority: ' . $e->getMessage()
+			);
+			return false;
+		}
+	}//end mayWrite()
 
 	/**
 	 * The projected fields of one organisation.

--- a/openspec/changes/the-organisation-projection-is-writable/proposal.md
+++ b/openspec/changes/the-organisation-projection-is-writable/proposal.md
@@ -1,0 +1,103 @@
+# The organisation projection is writable
+
+## Why
+
+`nc-organisation` exists to retire the leaf-app `organization` schemas. A schema
+slug is global per organisation, so opencatalogi, stackiq and others each
+declaring their own meant `SchemaMapper::find()` returned whichever row it
+reached first.
+
+opencatalogi migrated (opencatalogi#1411). stackiq could not, and measuring why
+is what produced this change: its setup walkthrough says "Click New and save an
+organisation" and advances on `object-created`. Migrating that onto a read-only
+schema would retire a working flow rather than move it. Every other app with an
+`organization` schema has the same shape, because an app that only ever READ
+organisations would not have declared a schema for them.
+
+So the read-only projection cannot do the job it was built for.
+
+## What changes
+
+`OrganisationObjectSourceProvider` implements `WritableObjectSourceProvider`.
+The dispatch it plugs into already exists and already gates correctly:
+`SaveObject::delegateObjectSourceWrite()` delegates only when the schema
+annotation carries `readOnly: false` AND the provider implements the interface.
+
+**Create goes through `OrganisationService::createOrganisation()`**, not through
+the mapper. That is what makes the write safe rather than a second, thinner path
+to a tenant: slug generation, owner assignment, admin-user membership, the
+admin-group RBAC grant and slug-collision recovery all still happen. The
+provider applies the remaining identity fields afterwards, because
+`createOrganisation()` takes only a name and a description.
+
+**Update requires ownership.** Membership is enough to read the projection;
+writing needs `OrganisationService::isOrganisationAdmin()`, which is the instance
+admin or the organisation's owner. The projection and the rest of the app then
+cannot disagree about who administers an organisation.
+
+**Update does not follow a merge chain, although read does.** Following one on a
+write would silently edit the survivor while the caller believes it is editing
+the record it addressed.
+
+**Delete refuses.** An organisation is the tenant boundary; deleting one through
+the object API would orphan every object scoped to it, from a caller that thinks
+it is removing a reference record. Merging is the operation that retires an
+organisation, and it keeps stored references pointing at a record that still
+owns something.
+
+## The part that would have shipped inert
+
+`SeedDirectoryVirtualSchemas::ensureSchema()` returns the moment the schema is
+found. Setting `readOnly: false` only on the create branch would have reached
+fresh installs and no existing instance, and `delegateObjectSourceWrite()` reads
+exactly that annotation. The provider would implement the interface, the seed
+would report success, and every write would still be refused with a generic
+"read-only projection" message that names the provider rather than the
+annotation.
+
+So the seed now reconciles the flag on an existing schema too, touching only the
+`readOnly` key and leaving the rest of the configuration as the instance has it.
+A reconcile that fails logs at ERROR with the consequence spelled out, rather
+than degrading into `run()`'s generic warning: the schema exists and works, it
+just refuses writes, which is the kind of failure that reads as a different bug
+entirely.
+
+## What this unblocks, and what it does not
+
+It unblocks stackiq's migration (stackiq#944 landed the resolution; the schema
+retirement waits on this). It does not perform any migration itself. Each app
+still needs its own change: a schema for the properties the projection has no
+column for, the reading sites repointed, then
+`openregister:organisations:adopt` and `openregister:schemas:prune-retired`.
+
+## Verified against a live instance, not only in unit tests
+
+Task 4.3 exists because a passing seed test proves the code and not the
+migration. On a running instance whose `nc-organisation` was already seeded
+`readOnly: true`:
+
+- `occ maintenance:repair` flipped it to `readOnly: false`, and left `nc-user`,
+  `nc-group`, `nc-contact`, `nc-event`, `nc-file`, `nc-card`,
+  `nc-conversation` and `nc-task` read-only.
+- `POST /api/objects/2/38` created a real organisation: uuid preserved as the
+  object id, slug `e2e-probe-organisatie` generated, owner `admin` assigned, OIN
+  applied. That is the lifecycle having run, not a row inserted.
+- `PUT` on it wrote `summary` through and read back changed.
+
+## Two things this leaves standing
+
+**A delete over HTTP is refused by the wrong thing.** `ObjectsController::destroy()`
+resolves the uuid through `MagicMapper` before the object-source dispatch, and
+answers 404 when the register/schema table does not exist. So `remove()` is
+never reached and its message never surfaces. The organisation survives, which
+is the outcome this change needs, but the refusal is an accident of routing
+rather than the guard: it is a pre-existing gap shared with every read-only
+projection, and it would stop refusing the moment that lookup learns about
+virtual objects. The provider's refusal is what makes it durable, and it is
+tested at that level.
+
+**`remove()` refusing means an organisation created through the projection by
+mistake cannot be removed through it.** That is deliberate, and the merge
+command is the answer. If a "create and immediately undo" flow turns out to be
+needed, it belongs behind the organisation lifecycle, not behind the object
+API.

--- a/openspec/changes/the-organisation-projection-is-writable/specs/organisation-projection/spec.md
+++ b/openspec/changes/the-organisation-projection-is-writable/specs/organisation-projection/spec.md
@@ -1,0 +1,150 @@
+# Organisation projection
+
+## MODIFIED Requirements
+
+### Requirement: An organisation is addressable as an object (REQ-ORP-101)
+
+An organisation MUST be readable through the object API as a virtual object on
+the `directory` register, so a schema property can reference it with a `$ref`.
+
+The object's id MUST be the organisation uuid, so a reference stored before this
+change keeps naming the same record.
+
+`find()` MUST resolve through a merge chain, so a reference stored before a
+merge resolves to the surviving organisation rather than to a row that owns
+nothing.
+
+The projection MUST support create and update, and MUST refuse delete. It was
+read-only, on the reasoning that a write path would be a second way to mutate a
+tenant that bypasses the organisation lifecycle. That reasoning holds; the
+conclusion did not. A read-only projection cannot replace the leaf-app
+`organization` schemas it exists to retire, because the apps that declared them
+create organisations. So the write path exists and goes THROUGH the lifecycle
+rather than around it (REQ-ORP-104).
+
+#### Scenario: An organisation is readable as an object
+
+- **WHEN** the `nc-organisation` schema is listed by an authorised caller
+- **THEN** each organisation they may see is returned as an object whose id is
+  its uuid.
+
+#### Scenario: A reference to a merged organisation still resolves
+
+- **GIVEN** an organisation that was merged into another
+- **WHEN** it is fetched by its own uuid
+- **THEN** the surviving organisation is returned.
+
+## ADDED Requirements
+
+### Requirement: An organisation can be created through the projection (REQ-ORP-104)
+
+Creating an object on the `nc-organisation` schema MUST create an organisation
+through the organisation lifecycle, not through the mapper, so that slug
+generation, owner assignment, the admin-user membership and the admin-group RBAC
+grant all happen as they do for an organisation created anywhere else.
+
+A create without an acting user MUST be refused. A create without a name MUST be
+refused rather than defaulted: the slug is derived from the name, so an empty
+name would produce a tenant whose slug the next create collides with.
+
+The `nc-organisation` schema MUST carry `x-openregister-object-source.readOnly:
+false`, and no other virtual schema may. The save dispatch reads that annotation
+before it will delegate a write, so a provider that implements the write
+interface while its schema still says `readOnly: true` refuses every write with
+nothing naming the annotation as the reason.
+
+That annotation MUST be reconciled on an EXISTING schema, not only set on a new
+one. The seed returns early when the schema is found, so an instance that
+already seeded `nc-organisation` would otherwise keep the `readOnly: true` it was
+created with, and the capability would reach fresh installs only.
+
+#### Scenario: A create goes through the lifecycle
+
+- **WHEN** an object is created on `nc-organisation` with a name
+- **THEN** an organisation exists carrying that name, a generated slug, the
+  acting user as owner, and the admin-group RBAC grant.
+
+#### Scenario: A create without a name is refused
+
+- **WHEN** an object is created on `nc-organisation` with no name, or an empty one
+- **THEN** the create is refused.
+
+#### Scenario: An already-seeded schema is flipped, not skipped
+
+- **GIVEN** an instance whose `nc-organisation` schema carries `readOnly: true`
+- **WHEN** the directory-schema seed runs
+- **THEN** the schema carries `readOnly: false`.
+
+### Requirement: Only an organisation's administrator may write it (REQ-ORP-105)
+
+Membership is enough to READ the projection. Writing MUST require that the
+acting user administers the organisation, which is the instance admin or the
+organisation's owner, decided by the same check the rest of the app uses so the
+projection and the app cannot disagree about who administers an organisation.
+
+A write on an organisation the acting user does not administer MUST be refused
+with the same response as a write on one that does not exist, so the projection
+stays unusable as an enumeration oracle. The distinction MUST be logged, because
+an administrator reading the log needs it.
+
+A write MUST NOT follow a merge chain, even though a read does. Following one
+would silently edit the surviving organisation while the caller believes it is
+editing the record it addressed. A write on a merged-away organisation MUST be
+refused.
+
+#### Scenario: A member who is not the owner cannot write
+
+- **GIVEN** an organisation the acting user belongs to but does not own
+- **WHEN** they update it through the projection
+- **THEN** the write is refused.
+
+#### Scenario: A write on a merged-away organisation is refused
+
+- **GIVEN** an organisation that was merged into another
+- **WHEN** it is updated by its own uuid
+- **THEN** the write is refused rather than applied to the survivor.
+
+### Requirement: An organisation cannot be deleted through the projection (REQ-ORP-106)
+
+Deleting an object on `nc-organisation` MUST be refused, always.
+
+An organisation is the tenant boundary: every object, register and schema on the
+instance is scoped to one. Deleting it through the object API would orphan all
+of that, from a caller that believes it is removing a reference record. Merging
+is the operation that exists for retiring an organisation, and it keeps every
+stored reference pointing at a record that still owns something.
+
+The refusal MUST come from the provider, not from an accident of routing. Over
+HTTP today a delete on any virtual schema is refused EARLIER, by
+`ObjectsController::destroy()` resolving the uuid through `MagicMapper` and
+answering 404 when the register/schema table does not exist, so `remove()` is
+never reached and the message never surfaces. That is a pre-existing gap in the
+virtual-schema delete path, shared with every read-only projection, and it is
+not what this requirement rests on: it would stop refusing the moment that
+lookup learns about virtual objects.
+
+#### Scenario: A delete is refused
+
+- **WHEN** the provider is asked to remove an organisation
+- **THEN** the delete is refused, and the refusal names merging as the operation
+  that retires an organisation.
+
+#### Scenario: A delete over HTTP does not remove the organisation
+
+- **WHEN** an object is deleted on `nc-organisation` through the object API
+- **THEN** the organisation still exists afterwards.
+
+### Requirement: Only the identity facet is writable (REQ-ORP-107)
+
+A write MUST apply only the projected identity properties. Quota, users, groups
+and authorization are not projected and MUST NOT be reachable through a write,
+which is the same boundary the read side draws.
+
+A property outside the projection MUST be ignored rather than rejected. The
+store already discards unprojected properties on the way in, so rejecting here
+would fail a request over a field the caller cannot see in the first place.
+
+#### Scenario: An unprojected property is ignored
+
+- **WHEN** an organisation is updated with a `quota` property
+- **THEN** the update succeeds and the organisation's quota is unchanged.

--- a/openspec/changes/the-organisation-projection-is-writable/tasks.md
+++ b/openspec/changes/the-organisation-projection-is-writable/tasks.md
@@ -1,0 +1,54 @@
+# Tasks
+
+## 1. The provider
+
+- [x] 1.1 `OrganisationObjectSourceProvider` implements
+      `WritableObjectSourceProvider`.
+- [x] 1.2 `insert()` delegates to `OrganisationService::createOrganisation()`,
+      then applies the remaining projected identity fields.
+- [x] 1.3 `insert()` refuses without an acting user, and refuses an empty name
+      rather than defaulting one.
+- [x] 1.4 `update()` writes only the projected properties; anything else is
+      ignored, matching what the store does with it anyway.
+- [x] 1.5 `update()` requires `isOrganisationAdmin()`, and answers a denied write
+      the way it answers an absent one so the projection is not an enumeration
+      oracle. The difference is logged.
+- [x] 1.6 `update()` does NOT follow a merge chain, and refuses a merged-away
+      organisation.
+- [x] 1.7 `remove()` refuses, naming merging as the operation that retires an
+      organisation.
+
+## 2. The annotation
+
+- [x] 2.1 `NcEntitySemanticMap` carries an optional `writable` flag; only
+      `nc-organisation` sets it.
+- [x] 2.2 The seed writes `readOnly: false` for a writable row on create.
+- [x] 2.3 The seed RECONCILES an existing schema whose annotation disagrees.
+      Without this the flag reaches fresh installs only, and the whole change is
+      inert on every instance that already seeded the schema.
+- [x] 2.4 A failed reconcile logs at ERROR with the consequence, rather than
+      degrading into `run()`'s generic warning.
+
+## 3. Wiring
+
+- [x] 3.1 `Application.php` injects `OrganisationService` into the provider.
+
+## 4. Verification
+
+- [x] 4.1 Unit tests for each of 1.2 through 1.7, including the negative cases.
+- [x] 4.2 A test that the seed flips an ALREADY-SEEDED schema, which is the
+      failure mode 2.3 exists for and the one a create-path test cannot see.
+- [x] 4.3 Run the repair step against a live instance and read the schema's
+      annotation back, because a passing seed test proves the code and not the
+      migration. Then create and update an organisation over HTTP, and confirm a
+      delete leaves it standing.
+
+## 5. Not in this change
+
+- [ ] 5.1 Each app's own migration off its `organization` schema. This unblocks
+      them; it performs none of them.
+- [ ] 5.2 `ObjectsController::destroy()` resolves the uuid through `MagicMapper`
+      before the object-source dispatch, so a delete on ANY virtual schema
+      answers 404 rather than the read-only rejection, and `remove()` is never
+      reached. Pre-existing, shared with every read-only projection, and the
+      reason the delete refusal is tested at the provider rather than over HTTP.

--- a/tests/Unit/Repair/SeedDirectoryVirtualSchemasTest.php
+++ b/tests/Unit/Repair/SeedDirectoryVirtualSchemasTest.php
@@ -1,0 +1,259 @@
+<?php
+
+/**
+ * Unit tests for {@see \OCA\OpenRegister\Repair\SeedDirectoryVirtualSchemas}.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Repair
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/the-organisation-projection-is-writable/specs/organisation-projection/spec.md#requirement-an-organisation-can-be-created-through-the-projection-req-orp-104
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Repair;
+
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Repair\SeedDirectoryVirtualSchemas;
+use OCA\OpenRegister\Service\ObjectSource\NcEntitySemanticMap;
+use OCP\Migration\IOutput;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Locks the `readOnly` annotation the save dispatch reads.
+ *
+ * THE INTERESTING CASE IS THE EXISTING SCHEMA, NOT THE NEW ONE. `ensureSchema()`
+ * returns the moment it finds the schema, so a flag set only on the create
+ * branch reaches a fresh install and no instance that has already seeded. The
+ * provider would implement the write interface, the seed would report success,
+ * and every write would still be refused by an annotation nothing pointed at.
+ */
+class SeedDirectoryVirtualSchemasTest extends TestCase {
+
+	/**
+	 * The register mapper double.
+	 *
+	 * @var RegisterMapper&MockObject
+	 */
+	private $registerMapper;
+
+	/**
+	 * The schema mapper double.
+	 *
+	 * @var SchemaMapper&MockObject
+	 */
+	private $schemaMapper;
+
+	/**
+	 * Wire fresh doubles, with the `directory` register already present.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->registerMapper = $this->createMock(RegisterMapper::class);
+		$this->schemaMapper = $this->createMock(SchemaMapper::class);
+
+		$register = new Register();
+		$register->setId(1);
+		$register->setSlug(NcEntitySemanticMap::DIRECTORY_REGISTER);
+		$register->setSchemas([]);
+		$this->registerMapper->method('find')->willReturn($register);
+	}//end setUp()
+
+	/**
+	 * Build a virtual schema carrying an object-source annotation.
+	 *
+	 * @param string $slug     The schema slug.
+	 * @param bool   $readOnly The annotation's current value.
+	 * @param int    $id       The schema id.
+	 *
+	 * @return Schema The schema.
+	 */
+	private function virtualSchema(string $slug, bool $readOnly, int $id = 10): Schema {
+		$schema = new Schema();
+		$schema->setId($id);
+		$schema->setSlug($slug);
+		$schema->setConfiguration(
+			[
+				'x-schema-org' => 'schema:Organization',
+				'x-openregister-object-source' => [
+					'provider' => 'organisation-source',
+					'readOnly' => $readOnly,
+				],
+			]
+		);
+
+		return $schema;
+	}//end virtualSchema()
+
+	/**
+	 * Build the repair step over the current doubles.
+	 *
+	 * @param LoggerInterface|null $logger An explicit logger, for the error case.
+	 *
+	 * @return SeedDirectoryVirtualSchemas The step under test.
+	 */
+	private function step(?LoggerInterface $logger = null): SeedDirectoryVirtualSchemas {
+		return new SeedDirectoryVirtualSchemas(
+			registerMapper: $this->registerMapper,
+			schemaMapper: $this->schemaMapper,
+			logger: ($logger ?? $this->createMock(LoggerInterface::class))
+		);
+	}//end step()
+
+	/**
+	 * An instance that seeded `nc-organisation` while it was read-only gets the
+	 * annotation flipped, rather than skipped for already existing.
+	 *
+	 * @return void
+	 */
+	public function testAnAlreadySeededOrganisationSchemaIsFlippedToWritable(): void {
+		$organisation = $this->virtualSchema(slug: 'nc-organisation', readOnly: true);
+
+		$this->schemaMapper->method('find')->willReturnCallback(
+			function (string $slug) use ($organisation): Schema {
+				if ($slug === 'nc-organisation') {
+					return $organisation;
+				}
+
+				return $this->virtualSchema(slug: $slug, readOnly: true, id: 11);
+			}
+		);
+
+		$updated = [];
+		$this->schemaMapper->method('update')->willReturnCallback(
+			function (Schema $schema) use (&$updated): Schema {
+				$updated[] = (string)$schema->getSlug();
+
+				return $schema;
+			}
+		);
+
+		$this->step()->run($this->createMock(IOutput::class));
+
+		$this->assertFalse(
+			$organisation->getConfiguration()['x-openregister-object-source']['readOnly'],
+			'nc-organisation must end up writable'
+		);
+		$this->assertContains('nc-organisation', $updated, 'the flip must be persisted, not only set in memory');
+	}//end testAnAlreadySeededOrganisationSchemaIsFlippedToWritable()
+
+	/**
+	 * The other directory schemas project someone else's system and stay
+	 * read-only. Without this, "the flag is applied" and "the flag is applied to
+	 * everything" look identical.
+	 *
+	 * @return void
+	 */
+	public function testTheOtherDirectorySchemasStayReadOnly(): void {
+		$schemas = [];
+		$this->schemaMapper->method('find')->willReturnCallback(
+			function (string $slug) use (&$schemas): Schema {
+				$schemas[$slug] = $this->virtualSchema(slug: $slug, readOnly: true, id: (count($schemas) + 10));
+
+				return $schemas[$slug];
+			}
+		);
+		$this->schemaMapper->method('update')->willReturnArgument(0);
+
+		$this->step()->run($this->createMock(IOutput::class));
+
+		$this->assertArrayHasKey('nc-user', $schemas, 'the seed must have reached nc-user at all');
+		foreach (['nc-user', 'nc-group'] as $slug) {
+			$this->assertTrue(
+				$schemas[$slug]->getConfiguration()['x-openregister-object-source']['readOnly'],
+				$slug . ' must stay read-only'
+			);
+		}
+	}//end testTheOtherDirectorySchemasStayReadOnly()
+
+	/**
+	 * A schema already carrying the right value is left alone, so the step stays
+	 * idempotent and does not write on every upgrade.
+	 *
+	 * @return void
+	 */
+	public function testASchemaAlreadyCorrectIsNotWritten(): void {
+		$this->schemaMapper->method('find')->willReturnCallback(
+			function (string $slug): Schema {
+				return $this->virtualSchema(
+					slug: $slug,
+					readOnly: ($slug !== 'nc-organisation')
+				);
+			}
+		);
+
+		$this->schemaMapper->expects($this->never())->method('update');
+
+		$this->step()->run($this->createMock(IOutput::class));
+	}//end testASchemaAlreadyCorrectIsNotWritten()
+
+	/**
+	 * A reconcile that cannot be persisted is logged at ERROR with the
+	 * consequence, not swallowed into `run()`'s generic warning.
+	 *
+	 * The schema still exists and still works; it just refuses writes, and the
+	 * caller sees a generic "read-only projection" rejection that names the
+	 * provider rather than the annotation. That is the wrong bug to go looking
+	 * for, so the log has to say which one it is.
+	 *
+	 * @return void
+	 */
+	public function testAFailedReconcileIsLoggedAsAnError(): void {
+		$this->schemaMapper->method('find')->willReturnCallback(
+			function (string $slug): Schema {
+				return $this->virtualSchema(slug: $slug, readOnly: true);
+			}
+		);
+		$this->schemaMapper->method('update')->willThrowException(new RuntimeException('access denied'));
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$messages = [];
+		$logger->method('error')->willReturnCallback(
+			function (string $message) use (&$messages): void {
+				$messages[] = $message;
+			}
+		);
+
+		$this->step($logger)->run($this->createMock(IOutput::class));
+
+		$this->assertNotEmpty($messages, 'a failed reconcile must be logged at error level');
+		$this->assertStringContainsString('nc-organisation', $messages[0]);
+		$this->assertStringContainsString('refused', $messages[0], 'the log must name the consequence');
+	}//end testAFailedReconcileIsLoggedAsAnError()
+
+	/**
+	 * Only `nc-organisation` carries the writable flag. A second one appearing is
+	 * a decision, and should have to be made deliberately rather than noticed.
+	 *
+	 * @return void
+	 */
+	public function testOnlyTheOrganisationRowIsWritable(): void {
+		$writable = [];
+		foreach (NcEntitySemanticMap::ENTITIES as $key => $row) {
+			if (($row['writable'] ?? false) === true) {
+				$writable[] = $row['schema'];
+			}
+		}
+
+		$this->assertSame(['nc-organisation'], $writable);
+	}//end testOnlyTheOrganisationRowIsWritable()
+
+}//end class

--- a/tests/Unit/Service/ObjectSource/OrganisationObjectSourceProviderTest.php
+++ b/tests/Unit/Service/ObjectSource/OrganisationObjectSourceProviderTest.php
@@ -209,7 +209,8 @@ class OrganisationObjectSourceProviderTest extends TestCase {
 			organisationMapper: $this->createMock(\OCA\OpenRegister\Db\OrganisationMapper::class),
 			userSession: $this->createMock(\OCP\IUserSession::class),
 			groupManager: $this->createMock(\OCP\IGroupManager::class),
-			logger: $this->createMock(\Psr\Log\LoggerInterface::class)
+			logger: $this->createMock(\Psr\Log\LoggerInterface::class),
+			organisationService: $this->createMock(\OCA\OpenRegister\Service\OrganisationService::class)
 		);
 
 		$this->assertTrue($provider->isEnabled());
@@ -232,7 +233,8 @@ class OrganisationObjectSourceProviderTest extends TestCase {
 			organisationMapper: $this->createMock(\OCA\OpenRegister\Db\OrganisationMapper::class),
 			userSession: $userSession,
 			groupManager: $this->createMock(\OCP\IGroupManager::class),
-			logger: $this->createMock(\Psr\Log\LoggerInterface::class)
+			logger: $this->createMock(\Psr\Log\LoggerInterface::class),
+			organisationService: $this->createMock(\OCA\OpenRegister\Service\OrganisationService::class)
 		);
 
 		$this->assertSame(

--- a/tests/Unit/Service/ObjectSource/OrganisationObjectSourceWriteTest.php
+++ b/tests/Unit/Service/ObjectSource/OrganisationObjectSourceWriteTest.php
@@ -1,0 +1,424 @@
+<?php
+
+/**
+ * Unit tests for writing through the organisation projection.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\ObjectSource
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\ObjectSource;
+
+use OCA\OpenRegister\Db\Organisation;
+use OCA\OpenRegister\Db\OrganisationMapper;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Service\ObjectSource\OrganisationObjectSourceProvider;
+use OCA\OpenRegister\Service\ObjectSource\WritableObjectSourceProvider;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Locks the write path, and above all what it refuses.
+ *
+ * The projection exists to retire the leaf-app `organization` schemas, and it
+ * could not while it was read-only: the apps that declared those schemas CREATE
+ * organisations. The write therefore had to exist. Everything below is about it
+ * going through the organisation lifecycle rather than around it, and about the
+ * three refusals — no name, not the administrator, and delete — that are the
+ * reason a write here is not simply a second, thinner path to a tenant.
+ */
+class OrganisationObjectSourceWriteTest extends TestCase {
+
+	/**
+	 * The organisation mapper double.
+	 *
+	 * @var OrganisationMapper&MockObject
+	 */
+	private $organisationMapper;
+
+	/**
+	 * The organisation lifecycle double.
+	 *
+	 * @var OrganisationService&MockObject
+	 */
+	private $organisationService;
+
+	/**
+	 * The acting user's session double.
+	 *
+	 * @var IUserSession&MockObject
+	 */
+	private $userSession;
+
+	/**
+	 * Wire fresh doubles for each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->organisationMapper = $this->createMock(OrganisationMapper::class);
+		$this->organisationService = $this->createMock(OrganisationService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+
+	}//end setUp()
+
+	/**
+	 * Build the provider over the current doubles.
+	 *
+	 * @return OrganisationObjectSourceProvider The provider under test.
+	 */
+	private function provider(): OrganisationObjectSourceProvider {
+		return new OrganisationObjectSourceProvider(
+			organisationMapper: $this->organisationMapper,
+			userSession: $this->userSession,
+			groupManager: $this->createMock(IGroupManager::class),
+			logger: $this->createMock(LoggerInterface::class),
+			organisationService: $this->organisationService
+		);
+
+	}//end provider()
+
+	/**
+	 * Say a user is logged in.
+	 *
+	 * @param string $uid The user id.
+	 *
+	 * @return void
+	 */
+	private function actingUser(string $uid = 'alice'): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$this->userSession->method('getUser')->willReturn($user);
+
+	}//end actingUser()
+
+	/**
+	 * Build an organisation.
+	 *
+	 * @param string      $uuid       The uuid.
+	 * @param string      $name       The name.
+	 * @param string|null $mergedInto The uuid it was merged into, if any.
+	 *
+	 * @return Organisation The organisation.
+	 */
+	private function organisation(string $uuid, string $name, ?string $mergedInto = null): Organisation {
+		$organisation = new Organisation();
+		$organisation->setUuid($uuid);
+		$organisation->setName($name);
+		$organisation->setMergedInto($mergedInto);
+
+		return $organisation;
+
+	}//end organisation()
+
+	/**
+	 * The dispatch in SaveObject/DeleteObject delegates only to a provider that
+	 * implements this interface, so declaring it is load-bearing rather than
+	 * documentation.
+	 *
+	 * @return void
+	 */
+	public function testTheProviderDeclaresItselfWritable(): void {
+		$this->assertInstanceOf(WritableObjectSourceProvider::class, $this->provider());
+
+	}//end testTheProviderDeclaresItselfWritable()
+
+	/**
+	 * A create goes through `createOrganisation()`, not through the mapper.
+	 *
+	 * This is the whole safety argument: the lifecycle assigns the slug, the
+	 * owner, the admin users and the admin-group RBAC grant. A row written
+	 * straight through the mapper would be a tenant nobody administers, which is
+	 * not visibly different until someone tries to manage it.
+	 *
+	 * @return void
+	 */
+	public function testACreateGoesThroughTheLifecycle(): void {
+		$this->actingUser();
+
+		$created = $this->organisation(uuid: 'new-uuid', name: 'Gemeente Utrecht');
+
+		$this->organisationService->expects($this->once())
+			->method('createOrganisation')
+			->with('Gemeente Utrecht', 'The one in the middle')
+			->willReturn($created);
+
+		// No further identity fields, so nothing to persist on top.
+		$this->organisationMapper->expects($this->never())->method('save');
+
+		$entity = $this->provider()->insert(
+			register: new Register(),
+			schema: new Schema(),
+			data: ['name' => 'Gemeente Utrecht', 'description' => 'The one in the middle']
+		);
+
+		$this->assertSame('new-uuid', $entity->getUuid());
+		$this->assertSame('Gemeente Utrecht', $entity->getObject()['name']);
+
+	}//end testACreateGoesThroughTheLifecycle()
+
+	/**
+	 * The identity fields `createOrganisation()` does not take are applied after
+	 * it, in one save.
+	 *
+	 * @return void
+	 */
+	public function testACreateAppliesTheRemainingIdentityFields(): void {
+		$this->actingUser();
+
+		$created = $this->organisation(uuid: 'new-uuid', name: 'Gemeente Utrecht');
+		$this->organisationService->method('createOrganisation')->willReturn($created);
+
+		$this->organisationMapper->expects($this->once())
+			->method('save')
+			->willReturnCallback(
+				function (Organisation $organisation): Organisation {
+					// The write reached the entity before it was persisted, which
+					// is the thing a "save was called" assertion alone misses.
+					$this->assertSame('00000001002220647000', $organisation->getOin());
+					$this->assertSame('002220647', $organisation->getRsin());
+
+					return $organisation;
+				}
+			);
+
+		$entity = $this->provider()->insert(
+			register: new Register(),
+			schema: new Schema(),
+			data: [
+				'name' => 'Gemeente Utrecht',
+				'oin' => '00000001002220647000',
+				'rsin' => '002220647',
+			]
+		);
+
+		$this->assertSame('00000001002220647000', $entity->getObject()['oin']);
+
+	}//end testACreateAppliesTheRemainingIdentityFields()
+
+	/**
+	 * A create with no name is refused rather than defaulted. The slug is derived
+	 * from the name, so an empty one produces a tenant whose slug the next create
+	 * then collides with.
+	 *
+	 * @return void
+	 */
+	public function testACreateWithoutANameIsRefused(): void {
+		$this->actingUser();
+
+		$this->organisationService->expects($this->never())->method('createOrganisation');
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('needs a name');
+
+		$this->provider()->insert(
+			register: new Register(),
+			schema: new Schema(),
+			data: ['name' => '   ']
+		);
+
+	}//end testACreateWithoutANameIsRefused()
+
+	/**
+	 * A create with no acting user is refused. `createOrganisation()` assigns the
+	 * acting user as owner, so without one it would produce an unowned tenant.
+	 *
+	 * @return void
+	 */
+	public function testACreateWithoutAnActingUserIsRefused(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->organisationService->expects($this->never())->method('createOrganisation');
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('acting user');
+
+		$this->provider()->insert(
+			register: new Register(),
+			schema: new Schema(),
+			data: ['name' => 'Gemeente Utrecht']
+		);
+
+	}//end testACreateWithoutAnActingUserIsRefused()
+
+	/**
+	 * An administrator's update writes the projected fields.
+	 *
+	 * @return void
+	 */
+	public function testAnAdministratorCanUpdateTheIdentityFacet(): void {
+		$this->actingUser();
+
+		$existing = $this->organisation(uuid: 'org-uuid', name: 'Old name');
+		$this->organisationMapper->method('findByUuid')->willReturn($existing);
+		$this->organisationService->method('isOrganisationAdmin')->willReturn(true);
+		$this->organisationMapper->expects($this->once())
+			->method('save')
+			->willReturnArgument(0);
+
+		$entity = $this->provider()->update(
+			register: new Register(),
+			schema: new Schema(),
+			id: 'org-uuid',
+			data: ['name' => 'New name']
+		);
+
+		$this->assertSame('New name', $entity->getObject()['name']);
+
+	}//end testAnAdministratorCanUpdateTheIdentityFacet()
+
+	/**
+	 * A member who does not administer the organisation cannot write it, and is
+	 * told what an outsider is told, so the projection stays unusable as an
+	 * enumeration oracle.
+	 *
+	 * @return void
+	 */
+	public function testAMemberWhoIsNotTheAdministratorCannotWrite(): void {
+		$this->actingUser();
+
+		$this->organisationMapper->method('findByUuid')
+			->willReturn($this->organisation(uuid: 'org-uuid', name: 'Gemeente Utrecht'));
+		$this->organisationService->method('isOrganisationAdmin')->willReturn(false);
+		$this->organisationMapper->expects($this->never())->method('save');
+
+		$this->expectException(RuntimeException::class);
+		// The same wording an absent organisation gets. Asserting on it is what
+		// keeps a later "helpful" error message from leaking existence.
+		$this->expectExceptionMessage('does not exist');
+
+		$this->provider()->update(
+			register: new Register(),
+			schema: new Schema(),
+			id: 'org-uuid',
+			data: ['name' => 'New name']
+		);
+
+	}//end testAMemberWhoIsNotTheAdministratorCannotWrite()
+
+	/**
+	 * A write on a merged-away organisation is refused rather than applied to the
+	 * survivor.
+	 *
+	 * The READ side deliberately follows the merge chain, so a reference stored
+	 * before a merge keeps resolving. Doing the same on a write would edit a
+	 * record the caller never addressed, and nothing in the response would say so.
+	 *
+	 * @return void
+	 */
+	public function testAWriteOnAMergedAwayOrganisationIsRefused(): void {
+		$this->actingUser();
+
+		$this->organisationMapper->method('findByUuid')->willReturn(
+			$this->organisation(uuid: 'old-uuid', name: 'Gemeente Oud', mergedInto: 'new-uuid')
+		);
+		$this->organisationService->method('isOrganisationAdmin')->willReturn(true);
+		$this->organisationMapper->expects($this->never())->method('save');
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('merged away');
+
+		$this->provider()->update(
+			register: new Register(),
+			schema: new Schema(),
+			id: 'old-uuid',
+			data: ['name' => 'New name']
+		);
+
+	}//end testAWriteOnAMergedAwayOrganisationIsRefused()
+
+	/**
+	 * Tenancy administration is not projected, and so is not writable either.
+	 * The read side draws that boundary; the write side must draw the same one.
+	 *
+	 * An unprojected key is IGNORED rather than rejected, because the store
+	 * already discards it on the way in: rejecting would fail a request over a
+	 * field the caller cannot see in the first place.
+	 *
+	 * @return void
+	 */
+	public function testAnUnprojectedPropertyIsIgnoredRatherThanWritten(): void {
+		$this->actingUser();
+
+		$existing = $this->organisation(uuid: 'org-uuid', name: 'Gemeente Utrecht');
+		$existing->setStorageQuota(5);
+
+		$this->organisationMapper->method('findByUuid')->willReturn($existing);
+		$this->organisationService->method('isOrganisationAdmin')->willReturn(true);
+		$this->organisationMapper->method('save')->willReturnArgument(0);
+
+		$entity = $this->provider()->update(
+			register: new Register(),
+			schema: new Schema(),
+			id: 'org-uuid',
+			data: ['summary' => 'A municipality', 'storageQuota' => 999]
+		);
+
+		$this->assertSame(5, $existing->getStorageQuota(), 'the quota is not writable through the projection');
+		$this->assertSame('A municipality', $entity->getObject()['summary']);
+		$this->assertArrayNotHasKey('storageQuota', $entity->getObject());
+
+	}//end testAnUnprojectedPropertyIsIgnoredRatherThanWritten()
+
+	/**
+	 * An update carrying nothing projectable does not touch the database.
+	 *
+	 * @return void
+	 */
+	public function testAnUpdateWithNothingProjectableDoesNotSave(): void {
+		$this->actingUser();
+
+		$this->organisationMapper->method('findByUuid')
+			->willReturn($this->organisation(uuid: 'org-uuid', name: 'Gemeente Utrecht'));
+		$this->organisationService->method('isOrganisationAdmin')->willReturn(true);
+		$this->organisationMapper->expects($this->never())->method('save');
+
+		$this->provider()->update(
+			register: new Register(),
+			schema: new Schema(),
+			id: 'org-uuid',
+			data: ['storageQuota' => 999]
+		);
+
+	}//end testAnUpdateWithNothingProjectableDoesNotSave()
+
+	/**
+	 * Delete refuses, always.
+	 *
+	 * An organisation is the tenant boundary: every object, register and schema
+	 * is scoped to one. A caller deleting what it thinks is a reference record
+	 * would orphan all of it.
+	 *
+	 * @return void
+	 */
+	public function testDeleteIsRefusedAndPointsAtMerging(): void {
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('Merge it instead');
+
+		$this->provider()->remove(
+			register: new Register(),
+			schema: new Schema(),
+			id: 'org-uuid'
+		);
+
+	}//end testDeleteIsRefusedAndPointsAtMerging()
+
+}//end class


### PR DESCRIPTION
## Why

`nc-organisation` exists to retire the leaf-app `organization` schemas. A schema slug is global per organisation, so opencatalogi, stackiq and others each declaring their own meant `SchemaMapper::find()` returned whichever row it reached first.

opencatalogi migrated (ConductionNL/opencatalogi#1411). Stackiq could not, and measuring why is what produced this change: its setup walkthrough says *"Click New and save an organisation"* and advances on `object-created`. Migrating that onto a read-only schema would retire a working flow rather than move it. Every other app with an `organization` schema has the same shape, because an app that only ever **read** organisations would not have declared a schema for them.

So the read-only projection could not do the job it was built for.

## What changes

`OrganisationObjectSourceProvider` implements `WritableObjectSourceProvider`. The dispatch it plugs into already existed and already gated correctly: `SaveObject::delegateObjectSourceWrite()` delegates only when the schema annotation carries `readOnly: false` **and** the provider implements the interface.

| Operation | Behaviour |
| --- | --- |
| **create** | Goes through `OrganisationService::createOrganisation()`, so slug generation, owner assignment, admin-user membership, the admin-group RBAC grant and slug-collision recovery all still happen. Refuses with no acting user, and refuses an empty name rather than defaulting one. |
| **update** | Requires `isOrganisationAdmin()`. Writes only the projected identity fields. Does **not** follow a merge chain, although the read does. |
| **delete** | Refuses, always. |

**Create through the lifecycle is the whole safety argument.** A row written straight through the mapper would be a tenant nobody administers, which is not visibly different until someone tries to manage it.

**Update requires ownership, not membership.** Membership is enough to read the projection. `isOrganisationAdmin()` is OpenRegister's own answer to who administers an organisation, so the projection and the rest of the app cannot disagree. A denied write answers exactly as an absent one does, and the difference is logged. Not following the merge chain matters because following one would silently edit the survivor while the caller believes it is editing the record it addressed.

**Delete refuses** because an organisation is the tenant boundary: every object, register and schema is scoped to one, and deleting it through the object API would orphan all of that from a caller that thinks it is removing a reference record. Merging is the operation that retires an organisation, and it keeps stored references pointing at a record that still owns something.

## The part that would have shipped inert

`SeedDirectoryVirtualSchemas::ensureSchema()` returns the moment the schema is found. Setting `readOnly: false` only on the create branch would have reached fresh installs and no existing instance, and `delegateObjectSourceWrite()` reads exactly that annotation. The provider would implement the interface, the seed would report success, and every write would still be refused by a message naming the provider rather than the annotation.

So the seed reconciles the flag on an existing schema too, touching only the `readOnly` key. A failed reconcile logs at **ERROR** with the consequence spelled out rather than degrading into `run()`'s generic warning: the schema exists and works, it just refuses writes, which reads as a different bug entirely.

## Verified against a live instance

A passing seed test proves the code, not the migration. On a running instance whose `nc-organisation` was already seeded `readOnly: true`:

- `occ maintenance:repair` flipped it to `readOnly: false`, and left `nc-user`, `nc-group`, `nc-contact`, `nc-event`, `nc-file`, `nc-card`, `nc-conversation` and `nc-task` read-only.
- `POST /api/objects/2/38` created a real organisation: uuid preserved as the object id, slug `e2e-probe-organisatie` generated, owner `admin` assigned, OIN applied. That is the lifecycle having run, not a row inserted.
- `PUT` on it wrote `summary` through, and it read back changed.

## Two things this leaves standing

**A delete over HTTP is refused by the wrong thing.** `ObjectsController::destroy()` resolves the uuid through `MagicMapper` before the object-source dispatch and answers 404 when the register/schema table does not exist, so `remove()` is never reached and its message never surfaces. The organisation survives, which is the outcome this change needs, but the refusal is an accident of routing rather than the guard, and it would stop refusing the moment that lookup learns about virtual objects. Pre-existing, shared with every read-only projection, recorded as task 5.2, and the reason the delete refusal is tested at the provider.

**`remove()` refusing means an organisation created here by mistake cannot be removed here.** Deliberate; the merge command is the answer.

## Pre-existing gate-57, waived rather than wired

gate-57 has failed on `development` since `purgeExpiredObjectsRaw` landed earlier today. Confirmed by running the full gate suite against a stashed tree: identical failure, none of my files.

It is declared on `ObjectServiceInterface`, so its callers are **other apps** and no in-repo call site can exist. The waiver says explicitly not to satisfy the gate with a route: the method bypasses soft-delete and the audit trail by design, and exposing it over HTTP would hand any caller an unauditable hard delete of a whole register+schema.

## Testing

- **18,925 PHPUnit tests green**, 9 new.
- The new tests are verified by disabling what they measure: removing the seed reconcile reds exactly the two reconcile tests and no others.
- phpcs, psalm and phpstan clean; phpmd clean on every file this touches. Its three pre-existing complexity findings in `MagicSearchHandler` and `LeafScriptListener` are untouched, because refactoring a hot SQL builder inside an organisation-projection change is not a trade worth making.
- **All 75 applicable hydra gates pass.**

## What this unblocks

Stackiq's migration (ConductionNL/stackiq#944 landed the resolution; the schema retirement waited on this). It performs no migration itself: each app still needs a schema for the properties the projection has no column for, its reading sites repointed, then `openregister:organisations:adopt` and `openregister:schemas:prune-retired`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
