### PR TITLE
fix(flow): a run killed by a failing step is failed, not stopped

### DIFF
--- a/lib/Service/Flow/FlowEngine.php
+++ b/lib/Service/Flow/FlowEngine.php
@@ -970,7 +970,15 @@ class FlowEngine {
 				if ($policy !== self::ON_ERROR_CONTINUE) {
 					// Terminal for the run: the failed stream ends with the
 					// reason, every other stream ends with the run.
-					$terminal = self::STATUS_STOPPED;
+					//
+					// `failed`, not `stopped` — the same distinction
+					// {@see self::outcomeForFailedStep()} explains for the
+					// single-stream walk, and it has to be made in BOTH places
+					// or which walk happened to run decides whether a wreck is
+					// queryable. The stream row already carried the message;
+					// the RUN row is what a query reads, so the envelope
+					// carries it too and `persistResult()` puts it on `error`.
+					$terminal = self::STATUS_FAILED;
 					if ($policy === self::ON_ERROR_DEAD_LETTER) {
 						$terminal = self::STATUS_DEAD_LETTER;
 					}
@@ -981,7 +989,13 @@ class FlowEngine {
 					$streams->endStream(id: $streamId, status: $terminal, error: $e->getMessage(), claimed: $claimed, enabled: false);
 					$streams->finalize(enabled: false, forcedTerminal: $terminal);
 
-					return ['status' => $terminal, 'log' => $log, 'context' => $context, 'items' => $items];
+					return [
+						'status' => $terminal,
+						'log' => $log,
+						'context' => $context,
+						'items' => $items,
+						'error' => $e->getMessage(),
+					];
 				}
 
 				// `continue`: the marking advances (leaving the token would spin
@@ -1162,6 +1176,25 @@ class FlowEngine {
 	 * policy so a typo fails safe), or null when the policy is `continue` and
 	 * the walk should go on. The failure is logged either way.
 	 *
+	 * 🔴 THE POLICY SAYS WHETHER TO END THE RUN; IT DOES NOT SAY THE RUN ENDED
+	 * WELL. `onError: stop` used to return `stopped` with no `error`, which is
+	 * byte-for-byte what a deliberate Stop node returns — so a run killed by a
+	 * broken step and a run an author ended on purpose were the same row. The
+	 * only trace of the difference was the last entry of the JSON `log`, which
+	 * no query reaches: `SELECT ... WHERE status = 'stopped'` cannot tell a
+	 * healthy guard branch from a wreck. Measured on dossiq's shipped `Case
+	 * behandeling` flow, where nine runs died on `status_not_found_on_case_type`
+	 * and every one of them read as a clean end.
+	 *
+	 * So a step failure ends the run as `failed`, with the step's message on the
+	 * `error` column. Both were already in the vocabulary and used elsewhere
+	 * ({@see FlowRun::STATUS_FAILED}, ranked most-severe in
+	 * {@see FlowRunCommit::SEVERITY}); this path simply was not reaching for
+	 * them. `stopped` goes back to meaning what {@see SubFlowNode::itemsFrom()}
+	 * already documents it to mean — a deliberate, successful end — which also
+	 * stops a sub-flow whose step failed from handing its stale items to its
+	 * parent as though it had finished.
+	 *
 	 * @param array $step The step configuration.
 	 * @param Throwable $error The failure.
 	 * @param string $name The transition name.
@@ -1198,11 +1231,23 @@ class FlowEngine {
 		);
 
 		if ($policy === self::ON_ERROR_DEAD_LETTER) {
-			return ['status' => self::STATUS_DEAD_LETTER, 'log' => $log, 'context' => $context, 'items' => $items];
+			return [
+				'status' => self::STATUS_DEAD_LETTER,
+				'log' => $log,
+				'context' => $context,
+				'items' => $items,
+				'error' => $error->getMessage(),
+			];
 		}
 
 		if ($policy !== self::ON_ERROR_CONTINUE) {
-			return ['status' => self::STATUS_STOPPED, 'log' => $log, 'context' => $context, 'items' => $items];
+			return [
+				'status' => self::STATUS_FAILED,
+				'log' => $log,
+				'context' => $context,
+				'items' => $items,
+				'error' => $error->getMessage(),
+			];
 		}
 
 		return null;

--- a/tests/Unit/Service/Flow/FlowEngineStreamWalkTest.php
+++ b/tests/Unit/Service/Flow/FlowEngineStreamWalkTest.php
@@ -390,9 +390,13 @@ class FlowEngineStreamWalkTest extends TestCase {
 		$dispatcher = new StreamWalkDispatcher(failOn: 'hearing');
 		$result = $this->walk($this->splitFlow(), $dispatcher, $this->fakeWalk());
 
-		$this->assertSame(FlowEngine::STATUS_STOPPED, $result['status']);
+		// `failed`, not `stopped`: a broken step is not a deliberate end, and
+		// this walk must agree with the single-stream one about that or which
+		// walk ran would decide whether the wreck is queryable.
+		$this->assertSame(FlowEngine::STATUS_FAILED, $result['status']);
+		$this->assertSame('boom', $result['error']);
 		$this->assertCount(1, $this->seen['ended']);
-		$this->assertSame(FlowRun::STATUS_STOPPED, $this->seen['ended'][0][1]);
+		$this->assertSame(FlowRun::STATUS_FAILED, $this->seen['ended'][0][1]);
 	}//end testATerminalStepFailureEndsTheStreamAndTheRun()
 
 	public function testASingleStreamFlowWalksExactlyAsTheLegacyWalk(): void {

--- a/tests/Unit/Service/Flow/FlowEngineTest.php
+++ b/tests/Unit/Service/Flow/FlowEngineTest.php
@@ -299,10 +299,16 @@ class FlowEngineTest extends TestCase {
 
 		$result = $this->runFlow($flow, $dispatcher);
 
-		$this->assertSame(FlowEngine::STATUS_STOPPED, $result['status']);
+		// The POLICY is `stop` — end the run rather than carry on. The run's
+		// terminal STATUS is `failed`, because a step broke; `stopped` is
+		// reserved for an end an author asked for. Both used to be `stopped`,
+		// which made a wreck and a guard branch the same row.
+		$this->assertSame(FlowEngine::STATUS_FAILED, $result['status']);
 		$this->assertSame(['first'], $dispatcher->dispatched);
 		$this->assertSame('failed', $result['log'][0]['status']);
 		$this->assertSame('step blew up', $result['log'][0]['error']);
+		// And on the envelope key `persistResult()` writes to the column.
+		$this->assertSame('step blew up', $result['error']);
 	}//end testOnErrorStopHaltsTheRunAndRecordsTheFailure()
 
 	public function testOnErrorContinueCarriesOnPastAFailedStep(): void {
@@ -325,9 +331,11 @@ class FlowEngineTest extends TestCase {
 		$result = $this->runFlow($flow, $dispatcher);
 
 		$this->assertSame(FlowEngine::STATUS_DEAD_LETTER, $result['status']);
+		// Its own state, but still a failure, so it still says what broke.
+		$this->assertSame('step blew up', $result['error']);
 	}//end testOnErrorDeadLetterEndsTheRunInItsOwnState()
 
-	public function testAnUnknownErrorPolicyFailsSafeByStopping(): void {
+	public function testAnUnknownErrorPolicyFailsSafeByEndingTheRun(): void {
 		// A typo in `onError` must not silently mean "continue".
 		$dispatcher = new RecordingDispatcher(failOn: 'first');
 		$flow = $this->linearFlow();
@@ -335,15 +343,16 @@ class FlowEngineTest extends TestCase {
 
 		$result = $this->runFlow($flow, $dispatcher);
 
-		$this->assertSame(FlowEngine::STATUS_STOPPED, $result['status']);
-	}//end testAnUnknownErrorPolicyFailsSafeByStopping()
+		$this->assertSame(FlowEngine::STATUS_FAILED, $result['status']);
+	}//end testAnUnknownErrorPolicyFailsSafeByEndingTheRun()
 
-	public function testTheDefaultErrorPolicyIsStop(): void {
+	public function testTheDefaultErrorPolicyEndsTheRunAsFailed(): void {
 		$dispatcher = new RecordingDispatcher(failOn: 'first');
 		$result = $this->runFlow($this->linearFlow(), $dispatcher);
 
-		$this->assertSame(FlowEngine::STATUS_STOPPED, $result['status']);
-	}//end testTheDefaultErrorPolicyIsStop()
+		$this->assertSame(FlowEngine::STATUS_FAILED, $result['status']);
+		$this->assertSame('step blew up', $result['error']);
+	}//end testTheDefaultErrorPolicyEndsTheRunAsFailed()
 
 	public function testAMalformedFlowFailsLoudlyRatherThanSilently(): void {
 		// x-openregister-flows swallows by design; this engine must not.

--- a/tests/Unit/Service/Flow/FlowLogicTest.php
+++ b/tests/Unit/Service/Flow/FlowLogicTest.php
@@ -43,6 +43,13 @@ class TrackingDispatcher implements FlowStepDispatcher {
 			throw new FlowStop(reason: (string)($step['config']['message'] ?? 'stopped'), isError: (($step['config']['error'] ?? false) === true));
 		}
 
+		// A step that BREAKS, as any node does when its work cannot be done —
+		// dossiq's setStatus refusing a status its case type does not carry,
+		// say. Distinct from the stop above: nobody asked for this end.
+		if ($type === 'boom') {
+			throw new \RuntimeException((string)($step['config']['message'] ?? 'step blew up'));
+		}
+
 		return $items;
 	}
 }
@@ -379,6 +386,59 @@ class FlowLogicTest extends TestCase {
 
 		$this->assertSame(FlowEngine::STATUS_FAILED, $result['status']);
 		$this->assertSame('invariant broken', $result['error']);
+	}
+
+	/**
+	 * A run wrecked by a broken step is not the same row as one an author ended.
+	 *
+	 * THE REGRESSION THIS EXISTS FOR. Both runs used to persist as
+	 * `status = 'stopped'`, `error = null` — identical in every column a query
+	 * can reach. The difference survived only in the last entry of the JSON
+	 * `log`, so `WHERE status = 'stopped'` returned a healthy guard branch and a
+	 * wreck side by side and nothing said which was which. Nine dossiq demo runs
+	 * died that way and read as clean ends.
+	 *
+	 * Asserted as ONE test over BOTH walks, deliberately: the property is a
+	 * DIFFERENCE, and two separate tests each asserting its own status would
+	 * both have passed on the broken code, which is how this shipped.
+	 */
+	public function testAFailedStepIsDistinguishableFromACleanStop(): void {
+		$clean = $this->walk(
+			[
+				'id' => 'clean',
+				'nodes' => [['id' => 'stop', 'type' => 'stop', 'config' => ['message' => 'nothing to do']]],
+				'edges' => [],
+			],
+			[FlowItems::item(json: ['a' => 1])],
+			new TrackingDispatcher()
+		);
+
+		$wrecked = $this->walk(
+			[
+				'id' => 'wrecked',
+				'nodes' => [['id' => 'move', 'type' => 'boom', 'config' => ['message' => 'status_not_found_on_case_type']]],
+				'edges' => [],
+			],
+			[FlowItems::item(json: ['a' => 1])],
+			new TrackingDispatcher()
+		);
+
+		// The two runs must not be the same row.
+		$this->assertNotSame(
+			$wrecked['status'],
+			$clean['status'],
+			'A run wrecked by a failing step must not carry the same status as one an author ended on purpose.'
+		);
+
+		// A deliberate end stays a deliberate end, with nothing on `error`.
+		$this->assertSame(FlowEngine::STATUS_STOPPED, $clean['status']);
+		$this->assertNull(($clean['error'] ?? null));
+
+		// The wreck is queryable AS a wreck, and says what broke — `error` is
+		// the column `persistResult()` writes, so this is what an operator
+		// filtering the runs table actually sees.
+		$this->assertSame(FlowEngine::STATUS_FAILED, $wrecked['status']);
+		$this->assertSame('status_not_found_on_case_type', $wrecked['error']);
 	}
 }
 


### PR DESCRIPTION
## The defect

`onError: stop` — the default — ended a run as `stopped` with **no `error`**, which is byte-for-byte what a deliberate Stop node returns. A run wrecked by a broken step and a run an author ended on purpose were therefore **the same row**. The only trace of the difference lived in the last entry of the JSON `log`, which no query reaches: `WHERE status = 'stopped'` returns a healthy guard branch and a wreck side by side and nothing says which is which.

Measured on dossiq's shipped `Case behandeling` flow against the demo caseload: nine runs died on `status_not_found_on_case_type` and every one of them read as a clean end.

## The fix

A step failure ends the run as `failed`, carrying the step's message on the `error` column.

Both were already in the vocabulary and used elsewhere — `FlowRun::STATUS_FAILED` is set by the worker, the advancer and consent parking, and is ranked most-severe in `FlowRunCommit::SEVERITY`. This path simply was not reaching for them, so there is **no migration and no new state for the UI to learn**. `dead_letter` keeps its own status and gains the message.

Fixed in **both walks** — the single-stream in-memory walk and the persisted stream walk each decide this for themselves, and leaving one behind would make *which walk happened to run* decide whether a wreck is queryable.

### A second consequence falls out

`SubFlowNode::itemsFrom()` documents `stopped` as a SUCCESS terminal state — it is what an End node does — and accepted it. A sub-flow whose step *failed* was therefore handing its stale items back to its parent as though it had finished. It now raises, and reaches the parent as the step failure it is.

## Proven red first

`testAFailedStepIsDistinguishableFromACleanStop` runs **both** a clean stop and a step failure in one test and asserts they differ. Deliberately one test over two walks: two separate tests each asserting their own status both pass on the broken code, which is how this shipped.

On unmodified `development` it fails with `A run wrecked by a failing step must not carry the same status as one an author ended on purpose. Failed asserting that two strings are not identical.` Three existing tests encoded the defect and are updated.

## Verified locally

CI is bottlenecked, so this was verified locally and judged by exit code:

| check | result |
|---|---|
| `phpunit` Unit Tests | **18926 tests, 0 failures, 0 errors** |
| `phpcs` (changed file) | exit 0 |
| `phpstan` (changed file) | exit 0 |
| `psalm` (changed file) | exit 0 |
| `phpmd` (changed file) | exit 0 |
| `hydra-gates --scope-to-diff` (v1.14.0) | exit 0 — ALL 32 APPLICABLE GATES PASSED, 32 of 32 ran |

The suite's exit 1 is the environmental `No code coverage driver available` warning; an untouched test file exits 1 identically.

## Rig evidence

Two throwaway Nextcloud 32 + Postgres 16 rigs on free ports (8641 / 8642), one running this branch and one running plain `development`, seeded identically with dossiq's 18-case demo caseload and drained with `occ background-job:execute <id> --force-execute` (not `cron.php`, which is interval-gated).

```
BEFORE (development)   18 runs   status=stopped   error=NULL
AFTER  (this branch)   18 runs   status=failed    error='decision_could_not_be_raised: ...'
```

On the before rig, a run killed by a broken status step and a run that merely hit a missing optional app were **identical in every queryable column**:

```
broken-flow run  : status=stopped  error=NULL
decision-gap run : status=stopped  error=NULL
```

Both rigs torn down with `docker compose down -v`.

Pairs with ConductionNL/dossiq#1818, which is the half this one was hiding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
