### PR TITLE
fix(deleted): refuse to purge a live object, and an archival record at all

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -373,6 +373,10 @@ Vrij en open source onder de EUPL-licentie.
 		<command>OCA\OpenRegister\Command\PruneRetiredSchemasCommand</command>
 		<command>OCA\OpenRegister\Command\RelinkRegisterSchemasCommand</command>
 		<command>OCA\OpenRegister\Command\ReconcileMagicTablesCommand</command>
+		<!-- The sanctioned administrative purge. Every HTTP delete route refuses an
+		     archival record; this is the one path that can still destroy one, and it
+		     needs shell access plus an explicit force flag. -->
+		<command>OCA\OpenRegister\Command\PurgeObjectCommand</command>
 		<command>OCA\OpenRegister\Command\DedupeConfigurationsCommand</command>
 		<command>OCA\OpenRegister\Command\ResolverListCommand</command>
 		<command>OCA\OpenRegister\Command\TimeReconcileCommand</command>

--- a/lib/Command/PurgeObjectCommand.php
+++ b/lib/Command/PurgeObjectCommand.php
@@ -75,6 +75,8 @@ class PurgeObjectCommand extends Command {
 	 * Configure the command.
 	 *
 	 * @return void
+	 *
+	 * @spec openspec/specs/archival-annotation-vocabulary/spec.md
 	 */
 	protected function configure(): void {
 		$this->setName(name: 'openregister:objects:purge')
@@ -110,6 +112,8 @@ class PurgeObjectCommand extends Command {
 	 * @param OutputInterface $output Console output.
 	 *
 	 * @return int 0 when every named object was handled, 1 when any was refused or failed.
+	 *
+	 * @spec openspec/specs/archival-annotation-vocabulary/spec.md
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$uuids = $input->getArgument('uuid');

--- a/lib/Command/PurgeObjectCommand.php
+++ b/lib/Command/PurgeObjectCommand.php
@@ -1,0 +1,250 @@
+<?php
+
+/**
+ * OpenRegister purge-object command
+ *
+ * The administrative escape hatch for permanently destroying an object row,
+ * including one on an archival schema.
+ *
+ * Every HTTP delete route refuses an archival record. That refusal is the point
+ * — an archival schema holds legally retained records, and the retention cron
+ * is the only routine way a row leaves. But "no route at all" is not the same
+ * as "no route": an instance still needs a way to remove a row created in
+ * error, a test fixture, or a record whose retention obligation has ended by a
+ * decision the platform cannot see.
+ *
+ * That way is this command, and it is a CLI command deliberately. `occ` requires
+ * shell access to the server, which is a real authorization boundary rather than
+ * a header an authenticated user can send, and it leaves the operator's own
+ * shell history as the record of who did it. Purging an archival record
+ * additionally requires --force, so it is never something an operator does by
+ * reaching for the same flag they use for ordinary cleanup.
+ *
+ * @category Command
+ * @package  OCA\OpenRegister\Command
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Command;
+
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Permanently destroy object rows by UUID.
+ *
+ * @spec openspec/specs/archival-annotation-vocabulary/spec.md
+ */
+class PurgeObjectCommand extends Command {
+
+	/**
+	 * Wire the mappers.
+	 *
+	 * @param MagicMapper  $objectMapper Magic-table object lookup and delete.
+	 * @param SchemaMapper $schemaMapper Schema lookup, to read the archival annotation.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly MagicMapper $objectMapper,
+		private readonly SchemaMapper $schemaMapper,
+	) {
+		parent::__construct();
+	}//end __construct()
+
+	/**
+	 * Configure the command.
+	 *
+	 * @return void
+	 */
+	protected function configure(): void {
+		$this->setName(name: 'openregister:objects:purge')
+			->setDescription(
+				description: 'Permanently destroy object rows by UUID, including archival records with --force'
+			)
+			->addArgument(
+				name: 'uuid',
+				mode: (InputArgument::REQUIRED | InputArgument::IS_ARRAY),
+				description: 'One or more object UUIDs to purge'
+			)
+			->addOption(
+				name: 'force',
+				shortcut: null,
+				mode: InputOption::VALUE_NONE,
+				description: 'Also purge records on archival schemas, and records that are still live'
+			)
+			->addOption(
+				name: 'apply',
+				shortcut: null,
+				mode: InputOption::VALUE_NONE,
+				description: 'Actually destroy the rows. Without it the command reports what it would do'
+			);
+	}//end configure()
+
+	/**
+	 * Purge each named object.
+	 *
+	 * Dry-run by default: an operator sees exactly which rows would be
+	 * destroyed, and which are archival, before anything is written.
+	 *
+	 * @param InputInterface  $input  Console input.
+	 * @param OutputInterface $output Console output.
+	 *
+	 * @return int 0 when every named object was handled, 1 when any was refused or failed.
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$uuids = $input->getArgument('uuid');
+		$force = (bool)$input->getOption('force');
+		$apply = (bool)$input->getOption('apply');
+
+		$failures = 0;
+		foreach ($uuids as $uuid) {
+			$failures += $this->purgeOne(
+				uuid: (string)$uuid,
+				force: $force,
+				apply: $apply,
+				output: $output
+			);
+		}
+
+		if ($apply === false) {
+			$output->writeln('');
+			$output->writeln('<comment>Dry run. Re-run with --apply to destroy these rows.</comment>');
+		}
+
+		if ($failures > 0) {
+			return 1;
+		}
+
+		return 0;
+	}//end execute()
+
+	/**
+	 * Handle a single UUID.
+	 *
+	 * @param string          $uuid   The object UUID.
+	 * @param bool            $force  Whether archival and live rows may be purged.
+	 * @param bool            $apply  Whether to actually write.
+	 * @param OutputInterface $output Console output.
+	 *
+	 * @return int 1 when the object was refused or could not be handled, 0 otherwise.
+	 */
+	private function purgeOne(string $uuid, bool $force, bool $apply, OutputInterface $output): int {
+		try {
+			$object = $this->objectMapper->find(
+				identifier: $uuid,
+				register: null,
+				schema: null,
+				includeDeleted: true,
+				_rbac: false,
+				_multitenancy: false
+			);
+		} catch (\Throwable $e) {
+			$output->writeln(sprintf('<error>%s: not found (%s)</error>', $uuid, $e->getMessage()));
+			return 1;
+		}
+
+		$schema = $this->resolveSchema(object: $object);
+		$isArchival = ($schema !== null && $schema->hasArchivalAnnotation() === true);
+		$label = ($schema?->getSlug() ?? (string)$object->getSchema());
+
+		$refusal = $this->refusalReason(object: $object, isArchival: $isArchival, force: $force, label: $label);
+		if ($refusal !== null) {
+			$output->writeln(sprintf('<error>%s: refused — %s</error>', $uuid, $refusal));
+			return 1;
+		}
+
+		$note = '';
+		if ($isArchival === true) {
+			$note = ' <comment>(ARCHIVAL RECORD)</comment>';
+		}
+
+		if ($apply === false) {
+			$output->writeln(sprintf('would purge %s from "%s"%s', $uuid, $label, $note));
+			return 0;
+		}
+
+		try {
+			$this->objectMapper->delete($object);
+		} catch (\Throwable $e) {
+			$output->writeln(sprintf('<error>%s: purge failed (%s)</error>', $uuid, $e->getMessage()));
+			return 1;
+		}
+
+		$output->writeln(sprintf('<info>purged</info> %s from "%s"%s', $uuid, $label, $note));
+		return 0;
+	}//end purgeOne()
+
+	/**
+	 * Why this object may not be purged, or null when it may.
+	 *
+	 * Both refusals are lifted by --force, and both exist for the same reason:
+	 * the routine paths that create and remove rows have already declined, so
+	 * the operator has to say out loud that they are overriding them.
+	 *
+	 * @param ObjectEntity $object     The object being purged.
+	 * @param bool         $isArchival Whether its schema declares the archival annotation.
+	 * @param bool         $force      Whether the operator passed --force.
+	 * @param string       $label      The schema slug or id, for the message.
+	 *
+	 * @return string|null The refusal reason, or null when the purge may proceed.
+	 */
+	private function refusalReason(ObjectEntity $object, bool $isArchival, bool $force, string $label): ?string {
+		if ($force === true) {
+			return null;
+		}
+
+		if ($isArchival === true) {
+			return sprintf(
+				'schema "%s" declares x-openregister-archival. '
+				. 'Pass --force to purge a legally retained record.',
+				$label
+			);
+		}
+
+		if ($object->isSoftDeleted() === false) {
+			return 'the object is live, not in the trash. Delete it first, or pass --force.';
+		}
+
+		return null;
+	}//end refusalReason()
+
+	/**
+	 * Resolve an object's schema, or null when it cannot be found.
+	 *
+	 * @param ObjectEntity $object The object whose schema to resolve.
+	 *
+	 * @return Schema|null The schema, or null.
+	 */
+	private function resolveSchema(ObjectEntity $object): ?Schema {
+		$schemaId = $object->getSchema();
+		if ($schemaId === null || $schemaId === '') {
+			return null;
+		}
+
+		try {
+			return $this->schemaMapper->find((int)$schemaId);
+		} catch (\Throwable $e) {
+			return null;
+		}
+	}//end resolveSchema()
+}//end class

--- a/lib/Controller/DeletedController.php
+++ b/lib/Controller/DeletedController.php
@@ -31,7 +31,9 @@ use DateTime;
 use OCA\OpenRegister\Db\MagicMapper;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Exception\ArchivalImmutableException;
 use OCA\OpenRegister\Service\Object\PermissionHandler;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
@@ -45,6 +47,12 @@ use OCP\IUserSession;
  * Controller for managing soft deleted objects
  *
  * @psalm-suppress UnusedClass
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) One over, from the archival
+ * gate: refusing a retained record needs the Schema it is declared on and the
+ * ArchivalImmutableException that carries the wire contract. Both come from the
+ * sanctioned delete path, which is the point — the alternative to that coupling
+ * is a second, quietly different rule.
  */
 
 class DeletedController extends Controller {
@@ -143,6 +151,66 @@ class DeletedController extends Controller {
 			return false;
 		}
 	}//end userMayActOnDeletedObject()
+
+	/**
+	 * Resolve a soft-deleted object's schema, or null when it cannot be found.
+	 *
+	 * @param ObjectEntity $object The object whose schema to resolve.
+	 *
+	 * @return Schema|null The schema, or null when it cannot be resolved.
+	 */
+	private function resolveSchema(ObjectEntity $object): ?Schema {
+		$schemaId = $object->getSchema();
+		if ($schemaId === null || $schemaId === '') {
+			return null;
+		}
+
+		try {
+			return $this->schemaMapper->find((int)$schemaId);
+		} catch (\Throwable $e) {
+			return null;
+		}
+	}//end resolveSchema()
+
+	/**
+	 * Refuse a purge when the object is a legally retained archival record.
+	 *
+	 * `DELETE /api/objects/{register}/{schema}/{id}` rejects a delete on an
+	 * archival schema with 403 SCHEMA_ARCHIVAL_IMMUTABLE
+	 * ({@see \OCA\OpenRegister\Service\ObjectService::deleteObject()}). Purging
+	 * is strictly more destructive than deleting, so it answers on the same
+	 * terms, from the same definition ({@see Schema::hasArchivalAnnotation()}) —
+	 * otherwise the trash is a second door onto the records the first door
+	 * exists to protect.
+	 *
+	 * Fails CLOSED: an object whose schema cannot be resolved is refused, since
+	 * an unresolvable schema is exactly the case where the annotation cannot be
+	 * read and the row might be retained.
+	 *
+	 * @param ObjectEntity $object The object being purged.
+	 *
+	 * @return ArchivalImmutableException|null The refusal, or null when the purge may proceed.
+	 *
+	 * @spec openspec/specs/archival-annotation-vocabulary/spec.md
+	 */
+	private function archivalRefusal(ObjectEntity $object): ?ArchivalImmutableException {
+		$schema = $this->resolveSchema(object: $object);
+		if ($schema === null) {
+			return new ArchivalImmutableException(
+				schemaIdentifier: (string)($object->getSchema() ?? 'unknown'),
+				operation: 'purge'
+			);
+		}
+
+		if ($schema->hasArchivalAnnotation() === false) {
+			return null;
+		}
+
+		return new ArchivalImmutableException(
+			schemaIdentifier: ($schema->getSlug() ?? (string)$schema->getId()),
+			operation: 'purge'
+		);
+	}//end archivalRefusal()
 
 	/**
 	 * Helper method to extract request parameters for deleted objects
@@ -399,7 +467,7 @@ class DeletedController extends Controller {
 		try {
 			$object = $this->objectEntityMapper->find($id, null, null, true);
 
-			if ($object->getDeleted() === null || $object->getDeleted() === []) {
+			if ($object->isSoftDeleted() === false) {
 				return new JSONResponse(
 					data: [
 						'error' => 'Object is not deleted',
@@ -487,7 +555,7 @@ class DeletedController extends Controller {
 				$foundIds[] = $object->getUuid();
 
 				try {
-					if ($object->getDeleted() === null) {
+					if ($object->isSoftDeleted() === false) {
 						// Object exists but is not deleted.
 						$failed++;
 						continue;
@@ -563,7 +631,24 @@ class DeletedController extends Controller {
 		try {
 			$object = $this->objectEntityMapper->find(identifier: $id, register: null, schema: null, includeDeleted: true);
 
-			if ($object->getDeleted() === null) {
+			// An archival record is refused here on the same terms the normal
+			// delete path refuses it. Answered BEFORE the trash check, so a
+			// caller holding a live archival record is told the record is
+			// immutable rather than "not deleted yet" — which would read as an
+			// invitation to soft-delete it first and come back.
+			$refusal = $this->archivalRefusal(object: $object);
+			if ($refusal !== null) {
+				return new JSONResponse(
+					data: $refusal->toResponseBody(),
+					statusCode: 403
+				);
+			}
+
+			// A purge empties the TRASH. `getDeleted() === null` never answered
+			// that question — the property defaults to `[]` and a live row keeps
+			// that default — so this guard let every live object through and
+			// destroyed it. See ObjectEntity::isSoftDeleted().
+			if ($object->isSoftDeleted() === false) {
 				return new JSONResponse(
 					data: [
 						'error' => 'Object is not deleted',
@@ -658,7 +743,15 @@ class DeletedController extends Controller {
 				$foundIds[] = $object->getUuid();
 
 				try {
-					if ($object->getDeleted() === null) {
+					// An archival record is never purged, in bulk or singly.
+					// Counted as failed rather than aborting the batch, so one
+					// retained row does not strand the rest of the cleanup.
+					if ($this->archivalRefusal(object: $object) !== null) {
+						$failed++;
+						continue;
+					}
+
+					if ($object->isSoftDeleted() === false) {
 						// Object exists but is not deleted.
 						$failed++;
 						continue;

--- a/lib/Db/ObjectEntity.php
+++ b/lib/Db/ObjectEntity.php
@@ -286,6 +286,13 @@ class ObjectEntity extends Entity implements JsonSerializable, ObjectEntityInter
 	/**
 	 * Deletion details if the object is deleted.
 	 *
+	 * ⚠️ This property defaults to `[]`, NOT `null`, and the row hydrator
+	 * (`MagicStatisticsHandler::convertRowToObjectEntity()`) skips every NULL
+	 * column rather than calling its setter — so a LIVE object never has
+	 * `setDeleted()` called on it and keeps this default. `getDeleted() === null`
+	 * is therefore false for every object that has ever existed, and a guard
+	 * written that way does not guard. Ask {@see self::isSoftDeleted()} instead.
+	 *
 	 * @var array|null Array describing deletion details
 	 */
 	protected ?array $deleted = [];
@@ -1317,6 +1324,23 @@ class ObjectEntity extends Entity implements JsonSerializable, ObjectEntityInter
 
 		return $this;
 	}//end delete()
+
+	/**
+	 * Whether this object is in the trash.
+	 *
+	 * The one honest answer to "has this been soft-deleted?". The raw
+	 * `getDeleted()` accessor cannot be compared with `null`: the property
+	 * defaults to `[]` and the hydrator never overwrites that default for a
+	 * live row, so `getDeleted() === null` is false for every object, deleted
+	 * or not. Every guard that means "already in the trash" MUST call this.
+	 *
+	 * @return bool True when the object carries deletion metadata.
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	public function isSoftDeleted(): bool {
+		return $this->deleted !== null && $this->deleted !== [];
+	}//end isSoftDeleted()
 
 	/**
 	 * Get the last log entry for this object (runtime only)

--- a/lib/Db/Schema.php
+++ b/lib/Db/Schema.php
@@ -2718,6 +2718,29 @@ class Schema extends Entity implements JsonSerializable {
 	}//end isAppendOnly()
 
 	/**
+	 * Check whether this schema declares `x-openregister-archival`.
+	 *
+	 * An archival schema holds legally retained records: user-driven deletes are
+	 * rejected with HTTP 403 and error code SCHEMA_ARCHIVAL_IMMUTABLE, and rows
+	 * leave only through {@see \OCA\OpenRegister\BackgroundJob\ArchivalRetentionTask}
+	 * when they pass their retention, or through the administrative
+	 * `openregister:objects:purge --force` CLI path.
+	 *
+	 * This is the single definition of "is archival". Every gate MUST ask here
+	 * rather than re-reading the annotation, so a second delete route cannot
+	 * quietly disagree with the first.
+	 *
+	 * @return bool True if the schema declares the archival annotation.
+	 *
+	 * @spec openspec/specs/archival-annotation-vocabulary/spec.md
+	 */
+	public function hasArchivalAnnotation(): bool {
+		$configuration = ($this->getConfiguration() ?? []);
+
+		return is_array($configuration['x-openregister-archival'] ?? null);
+	}//end hasArchivalAnnotation()
+
+	/**
 	 * String representation of the schema
 	 *
 	 * This magic method is required for proper entity handling in Nextcloud

--- a/lib/Service/Archival/DestructionService.php
+++ b/lib/Service/Archival/DestructionService.php
@@ -212,7 +212,7 @@ class DestructionService {
 				'register' => $object->getRegister(),
 				'archiefactiedatum' => $actiedatum,
 				'classification' => $retention['classification'] ?? null,
-				'alreadySoftDeleted' => ($object->getDeleted() !== null),
+				'alreadySoftDeleted' => $object->isSoftDeleted(),
 			];
 		}//end foreach
 

--- a/lib/Service/Authorization/RbacGroupCollector.php
+++ b/lib/Service/Authorization/RbacGroupCollector.php
@@ -48,10 +48,24 @@ class RbacGroupCollector {
 	 * `public` is a PSEUDO-principal denoting anonymous access; creating a real
 	 * Nextcloud group named `public` would be meaningless at best and would
 	 * suggest a membership-based grant that RBAC never consults.
+	 * `authenticated` is the same shape of pseudo-principal for "any logged-in
+	 * user". Three independent resolvers short-circuit it before any group test
+	 * — {@see \OCA\OpenRegister\Db\MagicMapper\MagicRbacHandler},
+	 * {@see \OCA\OpenRegister\Service\Object\PermissionHandler} and
+	 * {@see \OCA\OpenRegister\Service\PropertyRbacHandler} — so it is never
+	 * resolved through IGroupManager and a real group of that name grants
+	 * nothing extra. Leaving it out cost twice: provisioning created an empty
+	 * Nextcloud group called `authenticated`, and `occ openregister:declared-groups`
+	 * then reported the fleet's broadest working grant as "grants nobody
+	 * anything" — a false alarm that sends an operator hunting a bug that is not
+	 * there. Verified 2026-09-05 on a dev instance carrying both symptoms.
+	 *
+	 * The full set of virtual principals is exactly these three; a grep of the
+	 * three resolvers for special-cased principal strings finds no fourth.
 	 *
 	 * @var string[]
 	 */
-	public const RESERVED_PRINCIPALS = ['admin', 'public'];
+	public const RESERVED_PRINCIPALS = ['admin', 'public', 'authenticated'];
 
 	/**
 	 * Authorization keys that hold a role-name => group(s) map rather than an

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -2581,9 +2581,10 @@ class ObjectService implements ObjectServiceInterface
      * Check whether a schema declares an `x-openregister-archival` annotation.
      *
      * Used by the deleteObject() immutability gate to short-circuit
-     * user-driven deletes before any DB work. Reads from the schema's
-     * `configuration` array; absence of the key (or a non-array value)
-     * means archival enforcement does NOT apply.
+     * user-driven deletes before any DB work. Delegates to
+     * {@see Schema::hasArchivalAnnotation()}, which is the single definition of
+     * the rule: DeletedController's purge gate asks the same question of the
+     * same method, so the two delete routes cannot drift apart.
      *
      * @param Schema $schema Schema to inspect.
      *
@@ -2593,8 +2594,7 @@ class ObjectService implements ObjectServiceInterface
      */
     private function schemaHasArchivalAnnotation(Schema $schema): bool
     {
-        $configuration = ($schema->getConfiguration() ?? []);
-        return is_array($configuration['x-openregister-archival'] ?? null);
+        return $schema->hasArchivalAnnotation();
     }//end schemaHasArchivalAnnotation()
 
     /**

--- a/lib/Service/RetentionService.php
+++ b/lib/Service/RetentionService.php
@@ -771,7 +771,7 @@ class RetentionService {
 				'register' => $object->getRegister(),
 				'archiefactiedatum' => $retention['archiefactiedatum'] ?? null,
 				'classification' => $retention['classification'] ?? null,
-				'softDeleted' => $object->getDeleted() !== null,
+				'softDeleted' => $object->isSoftDeleted(),
 				'wooGepubliceerd' => $isWooPublished,
 			];
 		}

--- a/openspec/specs/archival-annotation-vocabulary/spec.md
+++ b/openspec/specs/archival-annotation-vocabulary/spec.md
@@ -76,6 +76,59 @@ When a schema declares `x-openregister-archival`, `ObjectService::deleteObject()
 - **THEN** the immutability gate SHALL be bypassed
 - **AND** the row SHALL be deleted via the standard `DeleteObject` handler with an audit-trail entry
 
+### Requirement: Purging an archival record is refused on the same terms as deleting one
+
+`DELETE /api/deleted/{uuid}` and `DELETE /api/deleted` permanently destroy rows rather than tombstoning them, so they SHALL apply the archival gate that `ObjectService::deleteObject()` applies. When the object's schema declares `x-openregister-archival`, the single-object route SHALL respond `403` with body `{ error: "SCHEMA_ARCHIVAL_IMMUTABLE", message, schema, operation: "purge", hint }`, and the bulk route SHALL count the object as `failed` rather than destroying it. Both routes SHALL fail closed: an object whose schema cannot be resolved SHALL be refused, because an unreadable annotation is indistinguishable from a retained record.
+
+The gate SHALL read `Schema::hasArchivalAnnotation()`, which is the single definition of the rule for both delete routes.
+
+#### Scenario: Purging a live archival record is refused
+- **GIVEN** the `dossiq/case` schema declares `x-openregister-archival`
+- **AND** an admin authenticates and a live `case` row exists with UUID `<uuid>`
+- **WHEN** `DELETE /api/deleted/<uuid>` is called
+- **THEN** the response SHALL be HTTP 403 with `error: "SCHEMA_ARCHIVAL_IMMUTABLE"`
+- **AND** the underlying row SHALL still exist in the magic table
+
+#### Scenario: Purging a soft-deleted archival record is refused
+- **GIVEN** a soft-deleted `case` row on the same archival schema
+- **WHEN** `DELETE /api/deleted/<uuid>` is called
+- **THEN** the response SHALL be HTTP 403 with `operation: "purge"`
+- **AND** the row SHALL still exist
+
+#### Scenario: Emptying the trash still works for an ordinary record
+- **GIVEN** a soft-deleted row on a schema that does NOT declare `x-openregister-archival`
+- **WHEN** `DELETE /api/deleted/<uuid>` is called
+- **THEN** the response SHALL be HTTP 200 and the row SHALL be destroyed
+
+### Requirement: A live object cannot be purged through the trash endpoints
+
+`DELETE /api/deleted/{uuid}` empties the TRASH. It SHALL refuse any object that is not soft-deleted, with HTTP 400 and `{ error: "Object is not deleted" }`. The soft-delete test SHALL be `ObjectEntity::isSoftDeleted()`; comparing `getDeleted()` with `null` SHALL NOT be used, because `ObjectEntity::$deleted` defaults to `[]` and the row hydrator skips NULL columns, so a live object answers `[]` and such a comparison never refuses anything.
+
+#### Scenario: Purging a live object is refused
+- **GIVEN** a live row on any schema
+- **WHEN** `DELETE /api/deleted/<uuid>` is called
+- **THEN** the response SHALL be HTTP 400 with `error: "Object is not deleted"`
+- **AND** the row SHALL still exist
+
+#### Scenario: Bulk purge skips live rows
+- **GIVEN** a request naming one live row and one soft-deleted non-archival row
+- **WHEN** `DELETE /api/deleted` is called
+- **THEN** exactly one row SHALL be destroyed and the live row SHALL be counted as `failed`
+
+### Requirement: An administrative CLI purge is the only path that can destroy an archival record
+
+The platform SHALL ship `occ openregister:objects:purge <uuid>...`. It SHALL be dry-run by default and write only with `--apply`. Without `--force` it SHALL refuse an archival record and SHALL refuse a live (not soft-deleted) object. With `--force` it SHALL destroy either, and SHALL name the record as archival in its output.
+
+This is deliberately a CLI surface: `occ` requires shell access to the server, which is an authorization boundary an HTTP caller cannot cross, and it is the sanctioned path for removing a record created in error or a test fixture on an archival schema.
+
+#### Scenario: Archival record refused without force
+- **WHEN** `occ openregister:objects:purge <uuid> --apply` names a row on an archival schema
+- **THEN** the command SHALL exit non-zero, SHALL name `x-openregister-archival`, and SHALL destroy nothing
+
+#### Scenario: Force purges an archival record
+- **WHEN** `occ openregister:objects:purge <uuid> --apply --force` names the same row
+- **THEN** the command SHALL exit zero, SHALL report the row as an ARCHIVAL RECORD, and the row SHALL be destroyed
+
 ### Requirement: RetentionConditionEvaluator parses the minimal condition DSL
 
 The platform SHALL ship `OCA\OpenRegister\Service\Archival\RetentionConditionEvaluator` exposing `evaluate(string $condition, array $row): bool`. The grammar SHALL be exactly `<field> <op> <literal>` with operators `<`, `<=`, `==`, `!=`, `>=`, `>` and literals: integer, float, single- or double-quoted string, `true`, `false`, `null`. A field absent from `$row` SHALL evaluate to `false` (no rule match). A malformed condition SHALL throw `\InvalidArgumentException` and SHALL NOT crash the cron — callers are responsible for catching and logging.

--- a/tests/Unit/Command/PurgeObjectCommandTest.php
+++ b/tests/Unit/Command/PurgeObjectCommandTest.php
@@ -1,0 +1,200 @@
+<?php
+
+/**
+ * Unit tests for the sanctioned administrative purge.
+ *
+ * The HTTP trash endpoint refuses an archival record outright. This command is
+ * the one path that can still destroy one, so what it refuses without --force
+ * is as much a part of the contract as what it destroys with it.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Command
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/archival-annotation-vocabulary/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Command;
+
+use OCA\OpenRegister\Command\PurgeObjectCommand;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Contract tests for `occ openregister:objects:purge`.
+ */
+class PurgeObjectCommandTest extends TestCase {
+
+	/**
+	 * Object mapper double.
+	 *
+	 * @var MagicMapper&MockObject
+	 */
+	private MagicMapper&MockObject $objectMapper;
+
+	/**
+	 * Schema mapper double.
+	 *
+	 * @var SchemaMapper&MockObject
+	 */
+	private SchemaMapper&MockObject $schemaMapper;
+
+	/**
+	 * UUIDs actually destroyed.
+	 *
+	 * @var string[]
+	 */
+	private array $purged = [];
+
+	/**
+	 * Build the command under test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->objectMapper = $this->createMock(MagicMapper::class);
+		$this->schemaMapper = $this->createMock(SchemaMapper::class);
+		$this->purged = [];
+
+		$this->objectMapper->method('delete')->willReturnCallback(
+			function (ObjectEntity $entity): ObjectEntity {
+				$this->purged[] = (string)$entity->getUuid();
+
+				return $entity;
+			}
+		);
+	}//end setUp()
+
+	/**
+	 * Run the command against one prepared object.
+	 *
+	 * @param bool     $trashed  Whether the object carries deletion metadata.
+	 * @param bool     $archival Whether its schema declares x-openregister-archival.
+	 * @param string[] $options  Extra console options, e.g. ['--force' => true].
+	 *
+	 * @return CommandTester The finished tester.
+	 */
+	private function runPurge(bool $trashed, bool $archival, array $options = []): CommandTester {
+		$object = new ObjectEntity();
+		$object->setUuid('obj-1');
+		$object->setSchema('172');
+		if ($trashed === true) {
+			$object->setDeleted(['deleted' => '2026-01-01T00:00:00+00:00']);
+		}
+
+		$schema = new Schema();
+		$schema->setSlug('case');
+		$configuration = [];
+		if ($archival === true) {
+			$configuration = ['x-openregister-archival' => ['retention' => ['default' => 'P30D']]];
+		}
+
+		$schema->setConfiguration($configuration);
+
+		$this->objectMapper->method('find')->willReturn($object);
+		$this->schemaMapper->method('find')->willReturn($schema);
+
+		$tester = new CommandTester(
+			new PurgeObjectCommand(objectMapper: $this->objectMapper, schemaMapper: $this->schemaMapper)
+		);
+		$tester->execute(array_merge(['uuid' => ['obj-1'], '--apply' => true], $options));
+
+		return $tester;
+	}//end runPurge()
+
+	/**
+	 * Without --force an archival record is refused, exactly as over HTTP.
+	 *
+	 * @return void
+	 */
+	public function testRefusesAnArchivalRecordWithoutForce(): void {
+		$tester = $this->runPurge(trashed: true, archival: true);
+
+		$this->assertSame(1, $tester->getStatusCode());
+		$this->assertStringContainsString('x-openregister-archival', $tester->getDisplay());
+		$this->assertSame([], $this->purged);
+	}//end testRefusesAnArchivalRecordWithoutForce()
+
+	/**
+	 * With --force it is destroyed, and the output says what it was.
+	 *
+	 * @return void
+	 */
+	public function testForcePurgesAnArchivalRecord(): void {
+		$tester = $this->runPurge(trashed: true, archival: true, options: ['--force' => true]);
+
+		$this->assertSame(0, $tester->getStatusCode());
+		$this->assertStringContainsString('ARCHIVAL RECORD', $tester->getDisplay());
+		$this->assertSame(['obj-1'], $this->purged);
+	}//end testForcePurgesAnArchivalRecord()
+
+	/**
+	 * A live object is refused without --force here too: the command is an
+	 * administrative escape hatch, not a shortcut around the lifecycle.
+	 *
+	 * @return void
+	 */
+	public function testRefusesALiveObjectWithoutForce(): void {
+		$tester = $this->runPurge(trashed: false, archival: false);
+
+		$this->assertSame(1, $tester->getStatusCode());
+		$this->assertStringContainsString('live', $tester->getDisplay());
+		$this->assertSame([], $this->purged);
+	}//end testRefusesALiveObjectWithoutForce()
+
+	/**
+	 * An ordinary trashed object needs no flag.
+	 *
+	 * @return void
+	 */
+	public function testPurgesAnOrdinaryTrashedObject(): void {
+		$tester = $this->runPurge(trashed: true, archival: false);
+
+		$this->assertSame(0, $tester->getStatusCode());
+		$this->assertSame(['obj-1'], $this->purged);
+	}//end testPurgesAnOrdinaryTrashedObject()
+
+	/**
+	 * Dry run is the default: without --apply nothing is written.
+	 *
+	 * @return void
+	 */
+	public function testDryRunDestroysNothing(): void {
+		$object = new ObjectEntity();
+		$object->setUuid('obj-1');
+		$object->setSchema('172');
+		$object->setDeleted(['deleted' => '2026-01-01T00:00:00+00:00']);
+
+		$schema = new Schema();
+		$schema->setSlug('case');
+		$schema->setConfiguration([]);
+
+		$this->objectMapper->method('find')->willReturn($object);
+		$this->schemaMapper->method('find')->willReturn($schema);
+
+		$tester = new CommandTester(
+			new PurgeObjectCommand(objectMapper: $this->objectMapper, schemaMapper: $this->schemaMapper)
+		);
+		$tester->execute(['uuid' => ['obj-1']]);
+
+		$this->assertSame(0, $tester->getStatusCode());
+		$this->assertStringContainsString('would purge', $tester->getDisplay());
+		$this->assertSame([], $this->purged);
+	}//end testDryRunDestroysNothing()
+}//end class

--- a/tests/Unit/Controller/DeletedControllerGapTest.php
+++ b/tests/Unit/Controller/DeletedControllerGapTest.php
@@ -246,10 +246,14 @@ class DeletedControllerGapTest extends TestCase {
 		$deletedObject = new ObjectEntity();
 		$deletedObject->setDeleted(['deleted' => '2024-01-01']);
 		$deletedObject->setUuid('uuid-1');
+		$deletedObject->setSchema('10');
 
 		$notDeletedObject = new ObjectEntity();
-		// deleted is null by default
+		// Never deleted. NOTE: `getDeleted()` answers `[]` here, not null — the
+		// property's declared default, which the row hydrator never overwrites
+		// for a live row. The controller therefore asks isSoftDeleted().
 		$notDeletedObject->setUuid('uuid-2');
+		$notDeletedObject->setSchema('10');
 
 		$this->request->method('getParam')
 			->willReturnMap([
@@ -266,11 +270,10 @@ class DeletedControllerGapTest extends TestCase {
 		$this->assertEquals(200, $result->getStatus());
 		$data = $result->getData();
 		$this->assertTrue($data['success']);
-		// Entity.getDeleted() returns [] for null (not null), so === null check
-		// is false for non-deleted objects too, meaning they get "restored".
-		// Both objects are restored, only uuid-missing counts as notFound.
-		$this->assertEquals(2, $data['restored']);
-		$this->assertEquals(1, $data['failed']); // 1 not found
+		// Only the genuinely soft-deleted object is restored. uuid-2 is live and
+		// uuid-missing was never found, so both count as failed.
+		$this->assertEquals(1, $data['restored']);
+		$this->assertEquals(2, $data['failed']);
 		$this->assertEquals(1, $data['notFound']);
 		$this->assertStringContainsString('not found', $data['message']);
 	}
@@ -283,9 +286,11 @@ class DeletedControllerGapTest extends TestCase {
 		$deletedObject = new ObjectEntity();
 		$deletedObject->setDeleted(['deleted' => '2024-01-01']);
 		$deletedObject->setUuid('uuid-1');
+		$deletedObject->setSchema('10');
 
 		$notDeletedObject = new ObjectEntity();
 		$notDeletedObject->setUuid('uuid-2');
+		$notDeletedObject->setSchema('10');
 
 		$this->request->method('getParam')
 			->willReturnMap([
@@ -300,10 +305,10 @@ class DeletedControllerGapTest extends TestCase {
 		$this->assertEquals(200, $result->getStatus());
 		$data = $result->getData();
 		$this->assertTrue($data['success']);
-		// Same Entity behavior: getDeleted() returns [] not null,
-		// so === null check is false for both, both get deleted.
-		$this->assertEquals(2, $data['deleted']);
-		$this->assertEquals(1, $data['failed']); // 1 not found
+		// Only the genuinely soft-deleted object is purged. Purging uuid-2 would
+		// have destroyed a LIVE record — the defect this endpoint shipped with.
+		$this->assertEquals(1, $data['deleted']);
+		$this->assertEquals(2, $data['failed']);
 		$this->assertEquals(1, $data['notFound']);
 		$this->assertStringContainsString('not found', $data['message']);
 	}

--- a/tests/Unit/Controller/DeletedControllerPurgeGuardTest.php
+++ b/tests/Unit/Controller/DeletedControllerPurgeGuardTest.php
@@ -1,0 +1,316 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Purge-guard contract tests for DeletedController.
+ *
+ * `DELETE /api/deleted/{uuid}` permanently destroys a row. It is meant to
+ * empty the trash, so it must be reachable for exactly one kind of object:
+ * a soft-deleted row on a schema that does not declare
+ * `x-openregister-archival`. These tests pin all three answers.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Controller
+ *
+ * @author   Conduction Development Team <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/archival-annotation-vocabulary/spec.md
+ * @spec openspec/specs/deletion-audit-trail/spec.md
+ */
+
+namespace Unit\Controller;
+
+use OCA\OpenRegister\Controller\DeletedController;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Object\PermissionHandler;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Contract tests for the trash-purge endpoints.
+ */
+class DeletedControllerPurgeGuardTest extends TestCase {
+
+	/**
+	 * Controller under test.
+	 *
+	 * @var DeletedController
+	 */
+	private DeletedController $controller;
+
+	/**
+	 * Request double.
+	 *
+	 * @var IRequest&MockObject
+	 */
+	private IRequest&MockObject $request;
+
+	/**
+	 * Object mapper double.
+	 *
+	 * @var MagicMapper&MockObject
+	 */
+	private MagicMapper&MockObject $objectMapper;
+
+	/**
+	 * Schema mapper double.
+	 *
+	 * @var SchemaMapper&MockObject
+	 */
+	private SchemaMapper&MockObject $schemaMapper;
+
+	/**
+	 * User session double.
+	 *
+	 * @var IUserSession&MockObject
+	 */
+	private IUserSession&MockObject $userSession;
+
+	/**
+	 * Group manager double.
+	 *
+	 * @var IGroupManager&MockObject
+	 */
+	private IGroupManager&MockObject $groupManager;
+
+	/**
+	 * Build the controller with mocked collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->objectMapper = $this->createMock(MagicMapper::class);
+		$this->schemaMapper = $this->createMock(SchemaMapper::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+
+		$this->controller = new DeletedController(
+			'openregister',
+			$this->request,
+			$this->objectMapper,
+			$this->createMock(RegisterMapper::class),
+			$this->schemaMapper,
+			$this->userSession,
+			$this->groupManager,
+			$this->createMock(PermissionHandler::class)
+		);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('admin');
+		$this->userSession->method('getUser')->willReturn($user);
+		$this->groupManager->method('isAdmin')->willReturn(true);
+	}//end setUp()
+
+	/**
+	 * UUIDs the controller actually passed to the mapper's hard delete.
+	 *
+	 * A spy rather than a `never()` expectation: an unmet expectation raises
+	 * inside the controller's own try/catch and surfaces as a 500, which hides
+	 * the status code the test is really about.
+	 *
+	 * @var string[]
+	 */
+	private array $purged = [];
+
+	/**
+	 * Record every hard delete the controller performs.
+	 *
+	 * @return void
+	 */
+	private function spyOnPurges(): void {
+		$this->objectMapper->method('delete')->willReturnCallback(
+			function (ObjectEntity $entity): ObjectEntity {
+				$this->purged[] = (string)$entity->getUuid();
+
+				return $entity;
+			}
+		);
+	}//end spyOnPurges()
+
+	/**
+	 * Build a real Schema entity. `getSlug()` is a magic Entity accessor, so it
+	 * cannot be stubbed on a mock — the schema has to be a real one.
+	 *
+	 * @param string $slug     The schema slug.
+	 * @param bool   $archival Whether it declares x-openregister-archival.
+	 *
+	 * @return Schema The prepared schema.
+	 */
+	private function makeSchema(string $slug, bool $archival): Schema {
+		$configuration = [];
+		if ($archival === true) {
+			$configuration = ['x-openregister-archival' => ['retention' => ['default' => 'P30D']]];
+		}
+
+		$schema = new Schema();
+		$schema->setSlug($slug);
+		$schema->setConfiguration($configuration);
+
+		return $schema;
+	}//end makeSchema()
+
+	/**
+	 * Build an object entity in a given lifecycle state.
+	 *
+	 * @param string $uuid       Object UUID.
+	 * @param bool   $trashed    Whether the object carries deletion metadata.
+	 * @param bool   $archival   Whether its schema declares x-openregister-archival.
+	 *
+	 * @return ObjectEntity The prepared entity.
+	 */
+	private function makeObject(string $uuid, bool $trashed, bool $archival): ObjectEntity {
+		$object = new ObjectEntity();
+		$object->setUuid($uuid);
+		$object->setSchema('172');
+		if ($trashed === true) {
+			$object->setDeleted(['deleted' => '2026-01-01T00:00:00+00:00', 'deletedBy' => 'admin']);
+		}
+
+		$this->schemaMapper->method('find')->willReturn($this->makeSchema(slug: 'case', archival: $archival));
+
+		return $object;
+	}//end makeObject()
+
+	/**
+	 * A live object is not in the trash, so purging it must be refused.
+	 *
+	 * @return void
+	 */
+	public function testPurgeRefusesALiveObject(): void {
+		$object = $this->makeObject(uuid: 'live-1', trashed: false, archival: false);
+		$this->objectMapper->method('find')->willReturn($object);
+		$this->spyOnPurges();
+
+		$response = $this->controller->destroy('live-1');
+
+		$this->assertSame(400, $response->getStatus());
+		$this->assertSame('Object is not deleted', $response->getData()['error']);
+		$this->assertSame([], $this->purged, 'a live object must never be purged');
+	}//end testPurgeRefusesALiveObject()
+
+	/**
+	 * A live object on an archival schema is refused, and refused as archival:
+	 * the sanctioned delete path answers 403 SCHEMA_ARCHIVAL_IMMUTABLE and this
+	 * endpoint must not be a second door with a different answer.
+	 *
+	 * @return void
+	 */
+	public function testPurgeRefusesALiveArchivalObject(): void {
+		$object = $this->makeObject(uuid: 'live-arch', trashed: false, archival: true);
+		$this->objectMapper->method('find')->willReturn($object);
+		$this->spyOnPurges();
+
+		$response = $this->controller->destroy('live-arch');
+
+		$this->assertSame(403, $response->getStatus());
+		$this->assertSame('SCHEMA_ARCHIVAL_IMMUTABLE', $response->getData()['error']);
+		$this->assertSame([], $this->purged, 'an archival record must never be purged');
+	}//end testPurgeRefusesALiveArchivalObject()
+
+	/**
+	 * A soft-deleted object on an archival schema is still legally retained:
+	 * emptying the trash must not destroy it.
+	 *
+	 * @return void
+	 */
+	public function testPurgeRefusesATrashedArchivalObject(): void {
+		$object = $this->makeObject(uuid: 'trash-arch', trashed: true, archival: true);
+		$this->objectMapper->method('find')->willReturn($object);
+		$this->spyOnPurges();
+
+		$response = $this->controller->destroy('trash-arch');
+
+		$this->assertSame(403, $response->getStatus());
+		$data = $response->getData();
+		$this->assertSame('SCHEMA_ARCHIVAL_IMMUTABLE', $data['error']);
+		$this->assertSame('case', $data['schema']);
+		$this->assertSame('purge', $data['operation']);
+		$this->assertSame([], $this->purged, 'an archival record must never be purged');
+	}//end testPurgeRefusesATrashedArchivalObject()
+
+	/**
+	 * Emptying the trash still works for an ordinary soft-deleted object.
+	 *
+	 * @return void
+	 */
+	public function testPurgeAllowsATrashedNonArchivalObject(): void {
+		$object = $this->makeObject(uuid: 'trash-plain', trashed: true, archival: false);
+		$this->objectMapper->method('find')->willReturn($object);
+		$this->spyOnPurges();
+
+		$response = $this->controller->destroy('trash-plain');
+
+		$this->assertSame(200, $response->getStatus());
+		$this->assertTrue($response->getData()['success']);
+		$this->assertSame(['trash-plain'], $this->purged, 'emptying the trash must still work');
+	}//end testPurgeAllowsATrashedNonArchivalObject()
+
+	/**
+	 * The bulk endpoint carries the same destructive power, so it carries the
+	 * same three answers: a live row and an archival row are both refused, and
+	 * only the ordinary trashed row is destroyed.
+	 *
+	 * @return void
+	 */
+	public function testPurgeMultipleRefusesLiveAndArchivalRows(): void {
+		$live = new ObjectEntity();
+		$live->setUuid('live-2');
+		$live->setSchema('10');
+
+		$archival = new ObjectEntity();
+		$archival->setUuid('arch-2');
+		$archival->setSchema('172');
+		$archival->setDeleted(['deleted' => '2026-01-01T00:00:00+00:00']);
+
+		$trashed = new ObjectEntity();
+		$trashed->setUuid('trash-2');
+		$trashed->setSchema('10');
+		$trashed->setDeleted(['deleted' => '2026-01-01T00:00:00+00:00']);
+
+		$plainSchema = $this->makeSchema(slug: 'document', archival: false);
+		$archivalSchema = $this->makeSchema(slug: 'case', archival: true);
+
+		$this->schemaMapper->method('find')->willReturnCallback(
+			static function (int $id) use ($plainSchema, $archivalSchema): Schema {
+				if ($id === 172) {
+					return $archivalSchema;
+				}
+
+				return $plainSchema;
+			}
+		);
+
+		$this->request->method('getParam')->willReturnMap(
+			[['ids', [], ['live-2', 'arch-2', 'trash-2']]]
+		);
+		$this->objectMapper->method('findMultipleAcrossAllMagicTables')
+			->willReturn([$live, $archival, $trashed]);
+		$this->spyOnPurges();
+
+		$response = $this->controller->destroyMultiple();
+		$data = $response->getData();
+
+		$this->assertSame(200, $response->getStatus());
+		$this->assertSame(1, $data['deleted']);
+		$this->assertSame(2, $data['failed']);
+		$this->assertSame(['trash-2'], $this->purged, 'only the ordinary trashed row may be purged');
+	}//end testPurgeMultipleRefusesLiveAndArchivalRows()
+}//end class

--- a/tests/Unit/Controller/DeletedControllerTest.php
+++ b/tests/Unit/Controller/DeletedControllerTest.php
@@ -168,24 +168,27 @@ class DeletedControllerTest extends TestCase {
 	}
 
 	public function testDestroyObjectNotDeleted(): void {
-		// ObjectEntity::getter() converts null to [] for the 'deleted' field,
-		// but the controller's destroy() only checks === null (not === []),
-		// so a non-deleted object bypasses the guard and proceeds to delete.
-		// This matches the actual controller behavior (unlike restore() which
-		// checks both null and []).
+		// A purge empties the trash, so an object that is not IN the trash is
+		// refused. This test previously asserted 200 and explained why: the
+		// guard compared `getDeleted()` with null, and the property defaults to
+		// `[]`, so the guard never fired and destroyed live records. It now
+		// pins the intended contract instead of the defect.
 		$this->stubAdminUser();
 		$object = new ObjectEntity();
+		$object->setSchema('10');
 		$object->setDeleted(null);
 		$this->objectMapper->method('find')->willReturn($object);
 
 		$result = $this->controller->destroy('uuid-123');
 
-		$this->assertEquals(200, $result->getStatus());
+		$this->assertEquals(400, $result->getStatus());
+		$this->assertEquals('Object is not deleted', $result->getData()['error']);
 	}
 
 	public function testDestroySuccess(): void {
 		$this->stubAdminUser();
 		$object = new ObjectEntity();
+		$object->setSchema('10');
 		$object->setDeleted(['deleted' => '2024-01-01']);
 		$this->objectMapper->method('find')->willReturn($object);
 
@@ -309,6 +312,7 @@ class DeletedControllerTest extends TestCase {
 	public function testDestroyMultipleSuccess(): void {
 		$this->stubAdminUser();
 		$deletedObject = new ObjectEntity();
+		$deletedObject->setSchema('10');
 		$deletedObject->setDeleted(['deleted' => '2024-01-01']);
 		$deletedObject->setUuid('uuid-1');
 

--- a/tests/Unit/Db/ObjectEntityTest.php
+++ b/tests/Unit/Db/ObjectEntityTest.php
@@ -80,6 +80,33 @@ class ObjectEntityTest extends TestCase {
 		$this->assertSame([], $this->entity->getGroups());
 	}
 
+	// --- soft-delete predicate ---
+
+	/**
+	 * The trap this predicate exists to close: `getDeleted()` answers `[]` for a
+	 * live object, so `=== null` is false for every object that has ever
+	 * existed. A guard written that way does not guard, and on
+	 * `DELETE /api/deleted/{uuid}` it permanently destroyed live records.
+	 */
+	public function testIsSoftDeletedIsFalseForALiveObjectEvenThoughGetDeletedIsNotNull(): void {
+		$this->assertNotNull($this->entity->getDeleted());
+		$this->assertSame([], $this->entity->getDeleted());
+		$this->assertFalse($this->entity->isSoftDeleted());
+	}
+
+	public function testIsSoftDeletedIsTrueOnceDeletionMetadataIsSet(): void {
+		$this->entity->setDeleted(['deleted' => '2026-01-01T00:00:00+00:00', 'deletedBy' => 'admin']);
+
+		$this->assertTrue($this->entity->isSoftDeleted());
+	}
+
+	public function testIsSoftDeletedIsFalseWhenDeletionMetadataIsClearedToNull(): void {
+		$this->entity->setDeleted(['deleted' => '2026-01-01T00:00:00+00:00']);
+		$this->entity->setDeleted(null);
+
+		$this->assertFalse($this->entity->isSoftDeleted());
+	}
+
 	// --- getter override ---
 
 	public function testGetterReturnsEmptyArrayForNullArrayFields(): void {

--- a/tests/Unit/Db/SchemaArchivalVocabularyTest.php
+++ b/tests/Unit/Db/SchemaArchivalVocabularyTest.php
@@ -108,6 +108,47 @@ final class SchemaArchivalVocabularyTest extends TestCase {
 		self::assertContains('x-openregister-lifecycl', $schema->consumeDroppedAnnotationKeys());
 	}//end testUnknownAnnotationKeyStillDropped()
 
+	/**
+	 * `hasArchivalAnnotation()` is the single definition of the archival rule.
+	 * Both delete routes ask it, so it is pinned here rather than reimplemented
+	 * at each call site.
+	 *
+	 * @return void
+	 */
+	public function testHasArchivalAnnotationIsTrueWhenTheAnnotationIsDeclared(): void {
+		$schema = new Schema();
+		$schema->setConfiguration(['x-openregister-archival' => ['retention' => ['default' => 'P30D']]]);
+
+		self::assertTrue($schema->hasArchivalAnnotation());
+	}//end testHasArchivalAnnotationIsTrueWhenTheAnnotationIsDeclared()
+
+	/**
+	 * A schema with no configuration at all is not archival.
+	 *
+	 * @return void
+	 */
+	public function testHasArchivalAnnotationIsFalseWithoutTheAnnotation(): void {
+		$schema = new Schema();
+		$schema->setConfiguration(['x-openregister-lifecycle' => ['field' => 'status']]);
+
+		self::assertFalse($schema->hasArchivalAnnotation());
+
+		self::assertFalse((new Schema())->hasArchivalAnnotation());
+	}//end testHasArchivalAnnotationIsFalseWithoutTheAnnotation()
+
+	/**
+	 * A non-array value is not a valid annotation, so it does not make the
+	 * schema archival — the delete gates must not be armed by `"archival": true`.
+	 *
+	 * @return void
+	 */
+	public function testHasArchivalAnnotationIsFalseForANonArrayValue(): void {
+		$schema = new Schema();
+		$schema->setConfiguration(['x-openregister-archival' => true]);
+
+		self::assertFalse($schema->hasArchivalAnnotation());
+	}//end testHasArchivalAnnotationIsFalseForANonArrayValue()
+
 	public function testArchivalAndProcessingNotRecordedAsDroppedKeys(): void {
 		$schema = new Schema();
 		$this->invokeValidateConfigurationArray(

--- a/tests/Unit/Service/Archival/ArchivalDeleteGateTest.php
+++ b/tests/Unit/Service/Archival/ArchivalDeleteGateTest.php
@@ -27,10 +27,12 @@ use PHPUnit\Framework\TestCase;
 /**
  * Tests for the archival immutability gate in ObjectService.
  *
- * We test the gate logic directly (not via a full ObjectService mock stack)
- * because instantiating ObjectService requires 30+ DI arguments. Instead,
- * we use a small anonymous class that exposes the gate logic via an extracted
- * helper, verifying the exception shape and the sweep-flag bypass path.
+ * Instantiating ObjectService takes 30+ DI arguments, so the gate's CONDITION
+ * is exercised through the production predicate it actually calls,
+ * {@see Schema::hasArchivalAnnotation()}, rather than through a local copy of
+ * the `if`. An earlier version of this file reimplemented the condition in a
+ * private `runGate()` helper: it agreed with itself no matter what the shipped
+ * gate did, so it could not have failed if the gate had been deleted.
  */
 class ArchivalDeleteGateTest extends TestCase {
 
@@ -64,10 +66,8 @@ class ArchivalDeleteGateTest extends TestCase {
 	public function testGateThrowsForArchivalSchemaWithoutSweepFlag(): void {
 		$this->expectException(ArchivalImmutableException::class);
 
-		// Gate reads getConfiguration() — mock that, not the magic getSlug().
-		$schema = $this->createMock(Schema::class);
-		$schema->method('getConfiguration')
-			->willReturn(['x-openregister-archival' => ['retention' => ['default' => 'P30D']]]);
+		$schema = new Schema();
+		$schema->setConfiguration(['x-openregister-archival' => ['retention' => ['default' => 'P30D']]]);
 
 		$this->runGate(schema: $schema, retentionSweep: false);
 	}
@@ -76,9 +76,8 @@ class ArchivalDeleteGateTest extends TestCase {
 	 * Gate is bypassed when $_retentionSweep is true (cron path).
 	 */
 	public function testGatePassesWhenRetentionSweepIsTrue(): void {
-		$schema = $this->createMock(Schema::class);
-		$schema->method('getConfiguration')
-			->willReturn(['x-openregister-archival' => ['retention' => ['default' => 'P30D']]]);
+		$schema = new Schema();
+		$schema->setConfiguration(['x-openregister-archival' => ['retention' => ['default' => 'P30D']]]);
 
 		// Should not throw.
 		$this->runGate(schema: $schema, retentionSweep: true);
@@ -89,8 +88,8 @@ class ArchivalDeleteGateTest extends TestCase {
 	 * Gate is skipped for non-archival schemas regardless of sweep flag.
 	 */
 	public function testGateSkippedForNonArchivalSchema(): void {
-		$schema = $this->createMock(Schema::class);
-		$schema->method('getConfiguration')->willReturn(['x-openregister-lifecycle' => []]);
+		$schema = new Schema();
+		$schema->setConfiguration(['x-openregister-lifecycle' => []]);
 
 		$this->runGate(schema: $schema, retentionSweep: false);
 		$this->assertTrue(true);
@@ -107,14 +106,13 @@ class ArchivalDeleteGateTest extends TestCase {
 	 * @return void
 	 */
 	private function runGate(Schema $schema, bool $retentionSweep): void {
-		if ($retentionSweep === false) {
-			$config = $schema->getConfiguration() ?? [];
-			if (isset($config['x-openregister-archival']) === true) {
-				throw new ArchivalImmutableException(
-					schemaIdentifier: 'test-schema',
-					operation: 'delete'
-				);
-			}
+		// The condition comes from the production predicate, so deleting or
+		// breaking `Schema::hasArchivalAnnotation()` fails this test.
+		if ($retentionSweep === false && $schema->hasArchivalAnnotation() === true) {
+			throw new ArchivalImmutableException(
+				schemaIdentifier: 'test-schema',
+				operation: 'delete'
+			);
 		}
 	}//end runGate()
 }//end class

--- a/tests/Unit/Service/Authorization/RbacGroupCollectorTest.php
+++ b/tests/Unit/Service/Authorization/RbacGroupCollectorTest.php
@@ -178,6 +178,40 @@ class RbacGroupCollectorTest extends TestCase {
 	}//end testProvisionableDropsReservedPrincipals()
 
 	/**
+	 * `authenticated` is a virtual principal, not a group.
+	 *
+	 * MagicRbacHandler, PermissionHandler and PropertyRbacHandler all
+	 * short-circuit it before any IGroupManager lookup, so a real Nextcloud
+	 * group of that name grants nothing. Treating it as provisionable created
+	 * an empty group AND made `occ openregister:declared-groups` report the
+	 * broadest working grant on the instance as granting nobody anything.
+	 *
+	 * @return void
+	 */
+	public function testProvisionableDropsTheAuthenticatedPseudoPrincipal(): void {
+		$groups = $this->collector->provisionable(
+			groups: ['authenticated', 'behandelaars']
+		);
+
+		$this->assertSame(['behandelaars'], $groups);
+		$this->assertNotContains('authenticated', $groups);
+	}//end testProvisionableDropsTheAuthenticatedPseudoPrincipal()
+
+	/**
+	 * The reserved set is exactly the three virtual principals the RBAC
+	 * resolvers special-case. A fourth one added to a resolver without being
+	 * added here would be silently provisioned as a real group.
+	 *
+	 * @return void
+	 */
+	public function testReservedPrincipalsCoversEveryVirtualPrincipal(): void {
+		$this->assertSame(
+			['admin', 'public', 'authenticated'],
+			RbacGroupCollector::RESERVED_PRINCIPALS
+		);
+	}//end testReservedPrincipalsCoversEveryVirtualPrincipal()
+
+	/**
 	 * The authored scope map contributes group ids the derived floor cannot —
 	 * a group declared before any authorization block references it.
 	 *


### PR DESCRIPTION
## The defect

`DELETE /api/deleted/{uuid}` (`DeletedController::destroy`) guarded with `getDeleted() === null`, meaning "only purge what is already in the trash". `ObjectEntity` declares `protected ?array $deleted = [];`, and the row hydrator (`MagicStatisticsHandler::convertRowToObjectEntity()`) skips every NULL column rather than calling its setter — so a **live** object never has `setDeleted()` called on it, keeps the `[]` default, and answers `[]` rather than `null`. The guard never fired.

The endpoint therefore permanently destroyed live records, including on schemas declaring `x-openregister-archival` that the sanctioned delete path refuses with `403 SCHEMA_ARCHIVAL_IMMUTABLE`. Two doors onto the same rows, one of them with no lock.

### Reproduced on a dev instance before changing anything

On the `dossiq/case` schema (which declares `x-openregister-archival`):

1. Created a live case, UUID `b3aa6b3c-…`.
2. `DELETE /api/objects/dossiq/case/<uuid>` returned **403 SCHEMA_ARCHIVAL_IMMUTABLE**, and a follow-up GET returned **200**. The record was protected.
3. `DELETE /api/deleted/<uuid>` on that same live record returned **200 `{"success":true,"message":"Object permanently deleted"}`**.
4. GET returned **404**, the record was absent from `GET /api/deleted`, and `SELECT count(*) FROM oc_openregister_table_23_172 WHERE _uuid = '…'` returned **0**. The row was gone from the database, not tombstoned.

## The fix

**`ObjectEntity::isSoftDeleted()`** is now the one honest answer to "is this in the trash", and every guard that meant that asks it. The `$deleted` property carries a docblock explaining why comparing it with `null` does not work.

**`Schema::hasArchivalAnnotation()`** is the single definition of the archival rule. `ObjectService::deleteObject()` now delegates its gate to it and `DeletedController` reads the same method, so the two delete routes cannot drift apart — which is the failure this PR is about. The purge refusal reuses `ArchivalImmutableException` and returns the same structured body with `operation: "purge"`. It fails **closed**: an object whose schema cannot be resolved is refused, because an unreadable annotation is indistinguishable from a retained record. The archival check runs *before* the trash check, so a caller holding a live archival record is told the record is immutable rather than "not deleted yet", which would read as an invitation to soft-delete it and come back.

`destroyMultiple` gets the same two guards; a refused row is counted as `failed` rather than aborting the batch.

## The sanctioned path for destroying an archival record

`occ openregister:objects:purge <uuid>... [--force] [--apply]`.

Dry-run by default. Without `--force` it refuses an archival record and refuses a live (not soft-deleted) object, with the same reasons the HTTP routes give. With `--force` it destroys either and names the record as `ARCHIVAL RECORD` in its output.

It is a CLI surface deliberately: `occ` requires shell access to the server, which is an authorization boundary an HTTP caller cannot cross by sending a header, and the operator's own shell history is the record of who did it. This is the path for a record created in error, or for a test fixture on an archival schema.

**⚠️ Downstream:** dossiq#1824's e2e teardown relies on the hole this PR closes to purge archival fixture cases, deliberately and with a verify step that reds once OpenRegister fixes it. Companion issue **ConductionNL/dossiq#1826** points that teardown at the new command.

## The null-vs-`[]` sweep

Swept every `?array $x = []` (and `?string`/`?int`/`?bool` with a non-null default) declared under `lib/Db/`, then every `=== null` / `!== null` comparison against those getters across `lib/`, `tests/` and `appinfo/`.

- **66** properties declared nullable with a non-null default.
- **10** comparison sites against their getters.
- **1** false positive: `FilesController:2156` calls `ObjectService::getObject(): ?ObjectEntity`, a genuinely nullable return on a different class.
- **4** already compensated (`|| === []`, or `&& empty(...) === false`): `DeletedController::restore`, `ReferentialIntegrityService:820`, `ContextRetrievalHandler:141`, `MagicMapper:7139`.
- **5 real defects, all fixed here:**
  - `DeletedController::destroy` — the data-destruction bug.
  - `DeletedController::destroyMultiple` — the same destructive power in bulk.
  - `DeletedController::restoreMultiple` — "restored" live objects and reported them as restored.
  - `RetentionService:774` — `'softDeleted' => getDeleted() !== null`, unconditionally **true** for every object in a destruction list.
  - `DestructionService:215` — `'alreadySoftDeleted'`, same, on the archival destruction workflow.

**Other delete/purge routes checked for a missing archival gate.** `objects#destroy` goes through the gated `ObjectService::deleteObject()` (verified live: 403). `bulk#delete` / `deleteSchema` / `deleteSchemaObjects` reach `DeleteObject::deleteObject()` without passing the `ObjectService` gate — noted, not fixed here, because on this instance `bulk#delete` deletes nothing at all (`requested_count: 1, deleted_count: 0, skipped_count: 0` for both an archival and a non-archival control object), so any "it refused the archival row" reading of it would be a test that cannot fail. That accounting deserves its own issue rather than a speculative fix inside a data-destruction hotfix. `HandoffService:726` and `SaveObject:3614` are compensating rollbacks of a row the same request just created — not user-driven deletes of a retained record.

## Second defect: `RESERVED_PRINCIPALS` omitted `authenticated`

`MagicRbacHandler`, `PermissionHandler` and `PropertyRbacHandler` all short-circuit `authenticated` before any `IGroupManager` lookup, so it is a virtual principal like `public`, not a group. Leaving it out of `RESERVED_PRINCIPALS` cost twice, both reproduced on the dev instance:

- `occ openregister:declared-groups --problems-only` listed `authenticated` among 27 groups that "grant nobody anything" — a false alarm about the instance's *broadest working grant*, which sends an operator hunting a bug that is not there.
- `occ group:list` showed a real, empty Nextcloud group named `authenticated` had actually been provisioned, because `provisionable()` did not drop it. That is exactly the harm the docblock already warned about for `public`.

Grepping the three resolvers for special-cased principal strings finds no fourth virtual principal; the set is exactly `{admin, public, authenticated}`, and a test now pins that.

## Tests

New `DeletedControllerPurgeGuardTest` pins all three answers: a live object cannot be purged (400), an archival object cannot be purged (403 `operation: "purge"`, live or trashed), a genuinely trashed non-archival object still can (200). **Proven red first** — before the fix, 4 of 5 failed, with the live object returning 200 and the bulk route purging all three rows. The one that passed is the one that should.

New `PurgeObjectCommandTest` pins what the command refuses without `--force` as much as what it destroys with it, plus dry-run.

**Three existing tests asserted the defect as correct behaviour**, two of them with a comment explaining the `[]`-not-null mechanism (`DeletedControllerGapTest::testRestoreMultipleWithMixedObjects`, `::testDestroyMultipleWithMixedObjects`, `DeletedControllerTest::testDestroyObjectNotDeleted` — the last saying "so a non-deleted object bypasses the guard and proceeds to delete. This matches the actual controller behavior"). The bug was observed, written down, and locked in. They now pin the contract.

`ArchivalDeleteGateTest` reimplemented the gate condition in a private `runGate()` helper, so it agreed with itself no matter what the shipped gate did — it could not have failed if the gate had been deleted. It now calls `Schema::hasArchivalAnnotation()`. Verified by sabotage: stubbing that method to `return false` reds 5 tests across three files; restoring it greens all 17.

Spec requirements added to `openspec/specs/archival-annotation-vocabulary/spec.md` for the purge refusal, the live-object refusal, and the CLI escape hatch.

## Verified locally (CI is bottlenecked; judged by exit code)

- `vendor/bin/phpunit --no-coverage` — **exit 0**, 18944 tests, 46118 assertions. Confirmed the 10 new tests are actually collected by the suite via `--list-tests`.
- `vendor/bin/phpcs --standard=phpcs.xml` on all changed files — **exit 0**, 0 errors. The new command file alone: 0 warnings too.
- `vendor/bin/psalm --threads=1 --no-cache` (full tree) — **exit 0**, "No errors found!"
- `vendor/bin/phpstan analyse` (full tree) — **exit 0**, "No errors".
- `vendor/bin/phpmd` on the **changed files only** (both `phpmd.xml` and `phpmd-unusedparams.xml`) — **exit 0**. It first found two real issues in this PR's own code, both fixed: `purgeOne()` at complexity 10, split out into `refusalReason()`; and `DeletedController` coupling at 14, now carrying a reason-bearing `@SuppressWarnings`.
- `hydra-gates . --scope-to-diff` with `HYDRA_GATE_BASE_REF=origin/development`, on `conduction/hydra-gates v1.14.0` after `composer update` within the existing caret — **exit 0**, "ALL 41 APPLICABLE GATES PASSED — and all 41 of them ran". gate-16 failed on the first run for two missing `@spec` tags on the new command; fixed in the follow-up commit.

**Not verified live:** the reproduction above is of the *defect*, against the dev instance's deployed copy. The *fix* was not deployed to that instance, because openregister there is bind-mounted from the user's own working checkout and I did not write into it. The fix's evidence is the unit tests (red-then-green, with a mutation check) and the static analysis above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
