### PR TITLE
fix(bulk): make bulk delete actually delete, account for every row, and honour archival immutability

### DIFF
--- a/lib/Controller/BulkController.php
+++ b/lib/Controller/BulkController.php
@@ -277,17 +277,33 @@ class BulkController extends Controller {
 			$result = $this->objectService->deleteObjects($uuids);
 			$deletedUuids = $result['deleted_uuids'];
 			$skippedUuids = $result['skipped_uuids'];
+			$skippedReasons = ($result['skipped_reasons'] ?? []);
 			$cascadeCount = $result['cascade_count'];
+
+			// `success` REPORTS THE SHORTFALL, as the bulk save path already does
+			// (see writeBatch()). A row this endpoint refused is a row the caller
+			// still believes it deleted, and a constant `true` said exactly that:
+			// the live symptom of the filter bug was a 200 reading `success: true,
+			// requested_count: 1, deleted_count: 0` over an untouched object.
+			$message = 'Bulk delete operation completed successfully';
+			if (empty($skippedUuids) === false) {
+				$message = sprintf(
+					'Bulk delete completed with %d of %d objects refused; see skipped_reasons.',
+					count($skippedUuids),
+					count($uuids)
+				);
+			}
 
 			return new JSONResponse(
 				data: [
-					'success' => true,
-					'message' => 'Bulk delete operation completed successfully',
+					'success' => empty($skippedUuids),
+					'message' => $message,
 					'deleted_count' => count($deletedUuids),
 					'deleted_uuids' => $deletedUuids,
 					'requested_count' => count($uuids),
 					'skipped_count' => count($skippedUuids),
 					'skipped_uuids' => $skippedUuids,
+					'skipped_reasons' => $skippedReasons,
 					'cascade_count' => $cascadeCount,
 					'total_affected' => count($deletedUuids) + $cascadeCount,
 				]

--- a/lib/Controller/BulkController.php
+++ b/lib/Controller/BulkController.php
@@ -269,6 +269,13 @@ class BulkController extends Controller {
 				);
 			}
 
+			// DEDUPLICATE BEFORE COUNTING. Naming the same object twice is one
+			// deletion, and the service resolves each UUID once — so counting the
+			// raw list as `requested_count` would leave `requested = deleted +
+			// skipped` unsatisfiable for a caller that repeated an entry, which is
+			// exactly the arithmetic this endpoint is supposed to make legible.
+			$uuids = array_values(array_unique($uuids));
+
 			// Set register and schema context using resolved IDs.
 			$this->objectService->setRegister((string)$resolved['register']);
 			$this->objectService->setSchema((string)$resolved['schema']);

--- a/lib/Service/Object/PermissionHandler.php
+++ b/lib/Service/Object/PermissionHandler.php
@@ -1161,7 +1161,25 @@ class PermissionHandler {
 		$activeOrganisation = $this->getActiveOrganisationForContext();
 
 		// Get objects for permission checking.
-		$objects = $this->objectEntityMapper->findAll(ids: $uuids, includeDeleted: true);
+		//
+		// This must be the CROSS-TABLE lookup. `MagicMapper::findAll()` needs a
+		// Register AND a Schema entity to know which magic table to read, and
+		// returns `[]` — after a log warning and nothing else — when it has
+		// neither. This handler has neither, so asking it here resolved nothing
+		// for every input: the filter answered `[]` unconditionally, and its one
+		// caller, ObjectService::deleteObjects(), then ran zero loop iterations.
+		// `POST /api/bulk/{register}/{schema}/delete` accordingly deleted nothing
+		// and reported nothing, answering `requested 1, deleted 0, skipped 0`.
+		//
+		// A bulk delete is cross-table by nature — its UUIDs may sit in any magic
+		// table — which is why deleteObjects() already resolves the very same
+		// UUIDs through findMultipleAcrossAllMagicTables() a few lines later.
+		// Soft-deleted rows are included: bulk-deleting an already-trashed object
+		// is how it is destroyed for good.
+		$objects = $this->objectEntityMapper->findMultipleAcrossAllMagicTables(
+			uuids: $uuids,
+			includeDeleted: true
+		);
 
 		foreach ($objects as $object) {
 			$objectUuid = $object->getUuid();

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -4556,10 +4556,14 @@ class ObjectService implements ObjectServiceInterface
     /**
      * Perform bulk delete operations on objects by UUID
      *
-     * This method handles both soft delete and hard delete based on the current state
-     * of the objects. If an object has no deleted value set, it performs a soft delete
-     * by setting the deleted timestamp. If an object already has a deleted value set,
-     * it performs a hard delete by removing the object from the database.
+     * EVERY DELETE HERE IS A SOFT DELETE. This docblock used to claim the loop
+     * escalated to a hard delete for a row already carrying a deleted timestamp;
+     * it does not, and never did — it calls `DeleteObject::deleteObject()` without
+     * `permanent: true`, which is the only thing that destroys a row. The claim
+     * was unfalsifiable while the loop ran zero iterations. Deleting a trashed row
+     * again re-tombstones it and reports success. Destroying a row for good is
+     * `DELETE /api/deleted/{uuid}` or `occ openregister:objects:purge`, both of
+     * which refuse an archival record (openregister#3428).
      *
      * EVERY REQUESTED UUID LANDS IN EXACTLY ONE OUTCOME BUCKET: the union of
      * 'deleted_uuids' and 'skipped_uuids' is the submitted set. It used not to be

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -2492,14 +2492,10 @@ class ObjectService implements ObjectServiceInterface
             // Reject DELETE operations on archival-annotated schemas unless this
             // call originates from the retention sweep cron (which alone sets
             // $_retentionSweep true). User-driven deletes get a structured 403.
-            if ($_retentionSweep === false
-                && $this->currentSchema !== null
-                && $this->schemaHasArchivalAnnotation(schema: $this->currentSchema) === true
-            ) {
-                $schemaSlug = $this->currentSchema->getSlug() ?? (string) $this->currentSchema->getId();
-                throw new ArchivalImmutableException(
-                    schemaIdentifier: $schemaSlug,
-                    operation: 'delete'
+            if ($this->currentSchema !== null) {
+                $this->rejectIfArchivalImmutable(
+                    schema: $this->currentSchema,
+                    retentionSweep: $_retentionSweep
                 );
             }
 
@@ -2596,6 +2592,57 @@ class ObjectService implements ObjectServiceInterface
     {
         return $schema->hasArchivalAnnotation();
     }//end schemaHasArchivalAnnotation()
+
+    /**
+     * Refuse a delete on an archival-annotated schema.
+     *
+     * THE ONE PLACE THIS SERVICE DECIDES A DELETE IS NOT ALLOWED.
+     *
+     * `deleteObject()` and `deleteObjects()` destroy rows through different
+     * routes — the single-object path resolves its own scope and calls the
+     * delete handler once; the bulk loop resolves each row's scope itself and
+     * calls the handler per row. Only the first one used to ask this question,
+     * so `POST /api/bulk/{register}/{schema}/delete` was a third door onto the
+     * destruction that `DELETE /api/objects/...` answers with a 403 and
+     * `DELETE /api/deleted/{uuid}` has refused since openregister#3428. Both
+     * callers now go through here, so the rule has one definition per door and
+     * the doors read the same one.
+     *
+     * WHAT TO DO ABOUT AN UNRESOLVED SCHEMA IS THE CALLER'S DECISION, and the two
+     * callers genuinely differ, so this method takes a resolved Schema and each
+     * call site states its own policy. `deleteObject()` keeps skipping the gate
+     * when it has no schema in scope — a bare `deleteObject($uuid)` never had
+     * one and refusing those now would break every scopeless caller. The bulk
+     * loop refuses instead, because it resolves each ROW's own schema: failing
+     * to resolve one is not evidence the row is deletable, and falling back to
+     * the route's schema would gate a cross-table row on the wrong annotation.
+     *
+     * @param Schema $schema         Schema the row belongs to.
+     * @param bool   $retentionSweep True only for ArchivalRetentionTask, the sanctioned expiry path.
+     *
+     * @return void
+     *
+     * @throws ArchivalImmutableException When the delete is not permitted.
+     *
+     * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Mirrors deleteObject()'s $_retentionSweep parameter.
+     *
+     * @spec openspec/specs/archival-annotation-vocabulary/spec.md
+     */
+    private function rejectIfArchivalImmutable(Schema $schema, bool $retentionSweep): void
+    {
+        if ($retentionSweep === true) {
+            return;
+        }
+
+        if ($this->schemaHasArchivalAnnotation(schema: $schema) === false) {
+            return;
+        }
+
+        throw new ArchivalImmutableException(
+            schemaIdentifier: ($schema->getSlug() ?? (string) $schema->getId()),
+            operation: 'delete'
+        );
+    }//end rejectIfArchivalImmutable()
 
     /**
      * Reject an operation if the object has been transferred to e-Depot.
@@ -4514,19 +4561,40 @@ class ObjectService implements ObjectServiceInterface
      * by setting the deleted timestamp. If an object already has a deleted value set,
      * it performs a hard delete by removing the object from the database.
      *
+     * EVERY REQUESTED UUID LANDS IN EXACTLY ONE OUTCOME BUCKET: the union of
+     * 'deleted_uuids' and 'skipped_uuids' is the submitted set. It used not to be
+     * — a UUID the permission filter removed, and a UUID whose handler answered
+     * false rather than throwing, left the loop in neither — so a caller could be
+     * told `requested 1, deleted 0, skipped 0` about a row that is still there.
+     *
      * @param array $uuids         Array of object UUIDs to delete
      * @param bool  $_rbac         Whether to apply RBAC filtering
      * @param bool  $_multitenancy Whether to apply multi-organization filtering
      *
-     * @return array Associative array with 'deleted_uuids', 'skipped_uuids', and 'cascade_count' keys.
+     * @return array Associative array with 'deleted_uuids', 'skipped_uuids',
+     *               'skipped_reasons' and 'cascade_count' keys.
      *               'deleted_uuids' contains UUIDs of successfully deleted objects.
-     *               'skipped_uuids' contains UUIDs skipped due to RESTRICT or errors.
+     *               'skipped_uuids' contains UUIDs skipped by a gate, a RESTRICT
+     *               constraint or an error; it is the complement of 'deleted_uuids'.
+     *               'skipped_reasons' maps each skipped UUID to a structured
+     *               {error, message} pair, so an archival refusal is legible as
+     *               something other than a RESTRICT block.
      *               'cascade_count' contains total count of objects affected by cascade operations.
      *
      * @phpstan-param  array<int, string> $uuids
      * @psalm-param    array<int, string> $uuids
-     * @phpstan-return array{deleted_uuids: array<int, string>, skipped_uuids: array<int, string>, cascade_count: int}
-     * @psalm-return   array{deleted_uuids: array<int, string>, skipped_uuids: array<int, string>, cascade_count: int}
+     * @phpstan-return array{
+     *     deleted_uuids: array<int, string>,
+     *     skipped_uuids: array<int, string>,
+     *     skipped_reasons: array<string, array<string, mixed>>,
+     *     cascade_count: int
+     * }
+     * @psalm-return array{
+     *     deleted_uuids: array<int, string>,
+     *     skipped_uuids: array<int, string>,
+     *     skipped_reasons: array<string, array<string, mixed>>,
+     *     cascade_count: int
+     * }
      *
      * @spec exclude Bulk-delete loop over deleteHandler->deleteObject(); per-object RESTRICT/CASCADE behavior owned by referential-integrity.
      */
@@ -4534,7 +4602,12 @@ class ObjectService implements ObjectServiceInterface
     {
         $this->discardPendingSchemaRef();
         if (empty($uuids) === true) {
-            return ['deleted_uuids' => [], 'skipped_uuids' => [], 'cascade_count' => 0];
+            return [
+                'deleted_uuids'   => [],
+                'skipped_uuids'   => [],
+                'skipped_reasons' => [],
+                'cascade_count'   => 0,
+            ];
         }
 
         // Apply RBAC and multi-organization filtering if enabled.
@@ -4545,6 +4618,20 @@ class ObjectService implements ObjectServiceInterface
                 _rbac: $_rbac,
                 _multitenancy: $_multitenancy
             );
+        }
+
+        // EVERY REQUESTED UUID MUST LAND IN EXACTLY ONE OUTCOME BUCKET.
+        // A UUID the filter removes is a row the caller asked to delete and
+        // still believes it deleted. These used to vanish here: the endpoint
+        // reported `requested_count: 1, deleted_count: 0, skipped_count: 0`,
+        // which names no failure for a caller to act on. Report them as
+        // skipped, with the reason, so `requested = deleted + skipped` holds.
+        $skippedReasons = [];
+        foreach (array_diff($uuids, $filteredUuids) as $refusedUuid) {
+            $skippedReasons[$refusedUuid] = [
+                'error'   => 'OBJECT_NOT_PERMITTED',
+                'message' => 'Object is not visible to this user, or does not exist.',
+            ];
         }
 
         // PERF: resolve the scope AND the entity of every UUID with ONE batched
@@ -4562,7 +4649,7 @@ class ObjectService implements ObjectServiceInterface
         // referential integrity rules (CASCADE, SET_NULL, SET_DEFAULT, RESTRICT)
         // are enforced per object. Skips objects that fail (e.g., RESTRICT blocks).
         $deletedObjectIds  = [];
-        $skippedUuids      = [];
+        $skippedUuids      = array_keys($skippedReasons);
         $totalCascadeCount = 0;
         // BUG-OBJ-5: collect the distinct (registerId, schemaId) pairs of the
         // objects we actually delete so we can invalidate the per-schema query
@@ -4631,6 +4718,42 @@ class ObjectService implements ObjectServiceInterface
                     }
                 }
 
+                // ARCHIVAL IMMUTABILITY, ON THE THIRD DOOR.
+                // This loop calls the delete HANDLER directly, so it never went
+                // through deleteObject()'s gate: a schema declaring
+                // `x-openregister-archival` — refused with 403 by
+                // `DELETE /api/objects/...`, and by the purge route since
+                // openregister#3428 — was destroyed here without a word.
+                //
+                // The question is asked of the ROW's OWN schema, not of the
+                // route's. A bulk delete spans magic tables, so gating on the
+                // scope the controller happened to set would check somebody
+                // else's annotation. A row whose schema cannot be resolved is
+                // refused rather than deleted: an unresolvable schema is not
+                // evidence that a row is deletable. The refusal is per row, so
+                // the rest of the batch still runs.
+                $gateSchema = $this->loadRowSchema(
+                    schemaId: $deletedSchemaId,
+                    schemaCache: $schemaEntityCache
+                );
+                if ($gateSchema === null) {
+                    $skippedUuids[]        = $uuid;
+                    $skippedReasons[$uuid] = [
+                        'error'   => 'SCHEMA_UNRESOLVED',
+                        'message' => 'The schema of this object could not be resolved, '
+                            .'so its archival status could not be established.',
+                    ];
+                    continue;
+                }
+
+                try {
+                    $this->rejectIfArchivalImmutable(schema: $gateSchema, retentionSweep: false);
+                } catch (ArchivalImmutableException $archivalRefusal) {
+                    $skippedUuids[]        = $uuid;
+                    $skippedReasons[$uuid] = $archivalRefusal->toResponseBody();
+                    continue;
+                }
+
                 $result = $this->deleteHandler->deleteObject(
                     register: $handlerRegister,
                     schema: $handlerSchema,
@@ -4665,6 +4788,23 @@ class ObjectService implements ObjectServiceInterface
                         ];
                     }
                 }//end if
+
+                if ($result !== true) {
+                    // The handler reports some refusals by RETURN VALUE rather
+                    // than by throwing — a read-only object source declines this
+                    // way, and so does its own catch when the inner delete
+                    // fails. Without this branch the UUID left the loop in
+                    // neither bucket and the caller was told nothing at all.
+                    $this->logger->warning(
+                        message: '[ObjectService] Bulk delete handler refused object',
+                        context: ['uuid' => $uuid]
+                    );
+                    $skippedUuids[]        = $uuid;
+                    $skippedReasons[$uuid] = [
+                        'error'   => 'DELETE_REFUSED',
+                        'message' => 'The delete handler did not delete this object.',
+                    ];
+                }
             } catch (\OCA\OpenRegister\Exception\ReferentialIntegrityException $e) {
                 // RESTRICT blocks should not abort the entire bulk operation.
                 // Log and skip this object, continue with the rest.
@@ -4675,7 +4815,11 @@ class ObjectService implements ObjectServiceInterface
                         'blockers' => count($e->getAnalysis()->blockers),
                     ]
                 );
-                $skippedUuids[] = $uuid;
+                $skippedUuids[]        = $uuid;
+                $skippedReasons[$uuid] = [
+                    'error'   => 'REFERENTIAL_INTEGRITY_RESTRICT',
+                    'message' => $e->getMessage(),
+                ];
             } catch (\Exception $e) {
                 // Other failures (transaction rollback, etc.) are logged and skipped.
                 $this->logger->warning(
@@ -4685,7 +4829,11 @@ class ObjectService implements ObjectServiceInterface
                         'error' => $e->getMessage(),
                     ]
                 );
-                $skippedUuids[] = $uuid;
+                $skippedUuids[]        = $uuid;
+                $skippedReasons[$uuid] = [
+                    'error'   => 'DELETE_FAILED',
+                    'message' => $e->getMessage(),
+                ];
             }//end try
         }//end foreach
 
@@ -4726,9 +4874,10 @@ class ObjectService implements ObjectServiceInterface
         }//end if
 
         return [
-            'deleted_uuids' => $deletedObjectIds,
-            'skipped_uuids' => $skippedUuids,
-            'cascade_count' => $totalCascadeCount,
+            'deleted_uuids'   => $deletedObjectIds,
+            'skipped_uuids'   => $skippedUuids,
+            'skipped_reasons' => $skippedReasons,
+            'cascade_count'   => $totalCascadeCount,
         ];
     }//end deleteObjects()
 
@@ -4832,6 +4981,57 @@ class ObjectService implements ObjectServiceInterface
 
         return [$registerCache[$registerKey], $schemaCache[$schemaKey]];
     }//end loadDeleteScopeEntities()
+
+    /**
+     * Materialise the Schema a bulk-delete candidate actually belongs to.
+     *
+     * Separate from {@see loadDeleteScopeEntities()} because the archival gate
+     * needs the row's schema on BOTH delete paths, including the legacy one
+     * that hands the handler no pre-resolved entity — there the register may be
+     * unknown while the schema is not, and refusing the delete because the
+     * register did not materialise would be a refusal for the wrong reason.
+     *
+     * Shares the caller's per-operation schema cache, so a batch of rows on one
+     * schema costs one lookup. Returns null when the id is absent or does not
+     * resolve; the caller decides what that means.
+     *
+     * @param string|int|null $schemaId    The schema id carried by the resolved row.
+     * @param array           $schemaCache Cache of Schema entities keyed by int id.
+     *
+     * @return Schema|null The schema, or null when it cannot be established.
+     *
+     * @spec openspec/specs/archival-annotation-vocabulary/spec.md
+     */
+    private function loadRowSchema(string | int | null $schemaId, array &$schemaCache): ?Schema
+    {
+        if (is_numeric($schemaId) === false) {
+            return null;
+        }
+
+        $schemaKey = (int) $schemaId;
+        if (isset($schemaCache[$schemaKey]) === true) {
+            return $schemaCache[$schemaKey];
+        }
+
+        try {
+            $schemaCache[$schemaKey] = $this->schemaMapper->find(
+                $schemaKey,
+                _rbac: false,
+                _multitenancy: false
+            );
+        } catch (\Throwable $schemaError) {
+            $this->logger->warning(
+                message: '[ObjectService] Bulk delete could not resolve the schema of a candidate row',
+                context: [
+                    'schemaId' => $schemaKey,
+                    'error'    => $schemaError->getMessage(),
+                ]
+            );
+            return null;
+        }
+
+        return $schemaCache[$schemaKey];
+    }//end loadRowSchema()
 
     /**
      * Delete all objects belonging to a specific schema

--- a/tests/Unit/Controller/BulkControllerTest.php
+++ b/tests/Unit/Controller/BulkControllerTest.php
@@ -135,11 +135,23 @@ class BulkControllerTest extends TestCase {
 		$this->assertEquals(Http::STATUS_BAD_REQUEST, $result->getStatus());
 	}
 
-	public function testDeleteSuccess(): void {
+	/**
+	 * A batch that refused a row does not answer `success: true`.
+	 *
+	 * This assertion used to read the other way round, and that is the shape the
+	 * live defect wore: a 200 saying `success: true, requested_count: 1,
+	 * deleted_count: 0` over an object still sitting in its table. A row this
+	 * endpoint refused is a row the caller otherwise believes it deleted, so
+	 * `success` reports the shortfall — the same rule the bulk save path states
+	 * in writeBatch(). `testDeleteAllSuccessful()` below is the control: nothing
+	 * skipped still answers true.
+	 */
+	public function testDeleteReportsTheShortfallWhenARowIsRefused(): void {
 		$this->setupResolveSuccess();
 		$this->objectService->method('deleteObjects')->willReturn([
 			'deleted_uuids' => ['uuid1', 'uuid2'],
 			'skipped_uuids' => ['uuid3'],
+			'skipped_reasons' => ['uuid3' => ['error' => 'SCHEMA_ARCHIVAL_IMMUTABLE']],
 			'cascade_count' => 0,
 		]);
 
@@ -151,7 +163,7 @@ class BulkControllerTest extends TestCase {
 
 		$this->assertEquals(Http::STATUS_OK, $result->getStatus());
 		$data = $result->getData();
-		$this->assertTrue($data['success']);
+		$this->assertFalse($data['success']);
 		$this->assertEquals(2, $data['deleted_count']);
 		$this->assertEquals(['uuid1', 'uuid2'], $data['deleted_uuids']);
 		$this->assertEquals(3, $data['requested_count']);
@@ -159,7 +171,12 @@ class BulkControllerTest extends TestCase {
 		$this->assertEquals(['uuid3'], $data['skipped_uuids']);
 		$this->assertEquals(0, $data['cascade_count']);
 		$this->assertEquals(2, $data['total_affected']);
-		$this->assertEquals('Bulk delete operation completed successfully', $data['message']);
+		$this->assertStringContainsString('1 of 3 objects refused', $data['message']);
+		$this->assertSame(
+			'SCHEMA_ARCHIVAL_IMMUTABLE',
+			$data['skipped_reasons']['uuid3']['error'],
+			'the caller is told WHY the row survived, not just that it did'
+		);
 	}
 
 	public function testDeleteAllSuccessful(): void {

--- a/tests/Unit/Controller/BulkControllerTest.php
+++ b/tests/Unit/Controller/BulkControllerTest.php
@@ -136,6 +136,48 @@ class BulkControllerTest extends TestCase {
 	}
 
 	/**
+	 * A UUID named twice is one deletion, and the counts still add up.
+	 *
+	 * `requested = deleted + skipped` is the whole point of this response, and a
+	 * repeated entry used to make it unsatisfiable: the service resolves each
+	 * UUID once, so a raw `count($uuids)` counted a row the loop only ever saw
+	 * once.
+	 *
+	 * @return void
+	 */
+	public function testDuplicateUuidIsRequestedOnce(): void {
+		$this->setupResolveSuccess();
+		$captured = [];
+		$this->objectService->method('deleteObjects')->willReturnCallback(
+			function (array $uuids) use (&$captured): array {
+				$captured = $uuids;
+
+				return [
+					'deleted_uuids' => $uuids,
+					'skipped_uuids' => [],
+					'skipped_reasons' => [],
+					'cascade_count' => 0,
+				];
+			}
+		);
+
+		$this->request->method('getParams')->willReturn([
+			'uuids' => ['uuid1', 'uuid1', 'uuid2'],
+		]);
+
+		$result = $this->controller->delete('1', '2');
+		$data = $result->getData();
+
+		$this->assertSame(['uuid1', 'uuid2'], $captured, 'the service is asked once per object');
+		$this->assertEquals(2, $data['requested_count']);
+		$this->assertEquals(
+			$data['requested_count'],
+			$data['deleted_count'] + $data['skipped_count'],
+			'requested must equal deleted + skipped'
+		);
+	}
+
+	/**
 	 * A batch that refused a row does not answer `success: true`.
 	 *
 	 * This assertion used to read the other way round, and that is the shape the

--- a/tests/Unit/Service/Object/PermissionHandlerBulkDeleteLookupTest.php
+++ b/tests/Unit/Service/Object/PermissionHandlerBulkDeleteLookupTest.php
@@ -1,0 +1,170 @@
+<?php
+
+/**
+ * Unit coverage for the object lookup behind PermissionHandler::filterUuidsForPermissions().
+ *
+ * The filter is the only permission gate on `POST /api/bulk/{register}/{schema}/delete`:
+ * ObjectService::deleteObjects() deletes exactly what this method hands back. It used to
+ * resolve its candidates with `MagicMapper::findAll(ids: $uuids, includeDeleted: true)`,
+ * which returns `[]` — after a warning and nothing else — whenever it is called without a
+ * Register and a Schema entity, and this handler has neither. So the filter returned an
+ * empty list for every input, the bulk delete loop never ran a single iteration, and the
+ * endpoint answered `requested_count: 1, deleted_count: 0, skipped_count: 0` while leaving
+ * the row in place.
+ *
+ * A bulk delete is cross-table by nature — its UUIDs may live in any magic table — so the
+ * lookup that belongs here is the cross-table one, which is also what
+ * ObjectService::batchResolveDeleteScopes() already uses on the very same UUIDs.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Object
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Object;
+
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\ConditionMatcher;
+use OCA\OpenRegister\Service\Object\PermissionHandler;
+use OCP\IAppConfig;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Locks the lookup the bulk-delete permission filter uses to resolve its candidates.
+ */
+class PermissionHandlerBulkDeleteLookupTest extends TestCase {
+
+	/**
+	 * Build a PermissionHandler over a supplied object mapper.
+	 *
+	 * Every other collaborator is a bare double: with RBAC and multitenancy off,
+	 * `filterUuidsForPermissions()` touches none of them.
+	 *
+	 * @param MagicMapper $objectMapper The mapper the handler should resolve through.
+	 *
+	 * @return PermissionHandler The handler under test.
+	 */
+	private function handlerOver(MagicMapper $objectMapper): PermissionHandler {
+		// No OrganisationService on this container: the handler's own catch then
+		// resolves "no active organisation", which is the shape a bulk delete on
+		// a single-tenant instance already has.
+		$container = $this->createMock(ContainerInterface::class);
+		$container->method('get')->willThrowException(new \RuntimeException('no organisation service'));
+
+		return new PermissionHandler(
+			userSession: $this->createMock(IUserSession::class),
+			userManager: $this->createMock(IUserManager::class),
+			groupManager: $this->createMock(IGroupManager::class),
+			schemaMapper: $this->createMock(SchemaMapper::class),
+			objectEntityMapper: $objectMapper,
+			conditionMatcher: $this->createMock(ConditionMatcher::class),
+			appConfig: $this->createMock(IAppConfig::class),
+			logger: $this->createMock(LoggerInterface::class),
+			container: $container,
+		);
+	}//end handlerOver()
+
+	/**
+	 * Build an ObjectEntity carrying just a UUID.
+	 *
+	 * @param string $uuid The UUID to carry.
+	 *
+	 * @return ObjectEntity The entity.
+	 */
+	private function entity(string $uuid): ObjectEntity {
+		$object = new ObjectEntity();
+		$object->setUuid($uuid);
+
+		return $object;
+	}//end entity()
+
+	/**
+	 * A UUID the cross-table lookup resolves survives the filter.
+	 *
+	 * This is the property the endpoint depends on. The double answers the
+	 * register/schema-scoped `findAll()` with `[]` exactly as the real
+	 * MagicMapper does when called without that scope, so a handler that still
+	 * asks the scoped lookup resolves nothing and fails here.
+	 *
+	 * @return void
+	 */
+	public function testResolvedUuidSurvivesTheFilter(): void {
+		$mapper = $this->createMock(MagicMapper::class);
+		$mapper->method('findAll')->willReturn([]);
+		$mapper->method('findMultipleAcrossAllMagicTables')
+			->willReturn([$this->entity('uuid-alpha')]);
+
+		$filtered = $this->handlerOver($mapper)->filterUuidsForPermissions(
+			uuids: ['uuid-alpha'],
+			_rbac: false,
+			_multitenancy: false
+		);
+
+		$this->assertSame(['uuid-alpha'], $filtered);
+	}//end testResolvedUuidSurvivesTheFilter()
+
+	/**
+	 * The lookup must include soft-deleted rows.
+	 *
+	 * A bulk delete of an already-trashed object is a hard delete, so a filter
+	 * that only sees live rows would silently refuse every second delete.
+	 *
+	 * @return void
+	 */
+	public function testLookupIncludesSoftDeletedRows(): void {
+		$mapper = $this->createMock(MagicMapper::class);
+		$mapper->method('findAll')->willReturn([]);
+		$mapper->expects($this->once())
+			->method('findMultipleAcrossAllMagicTables')
+			->with(['uuid-alpha'], true)
+			->willReturn([$this->entity('uuid-alpha')]);
+
+		$this->handlerOver($mapper)->filterUuidsForPermissions(
+			uuids: ['uuid-alpha'],
+			_rbac: false,
+			_multitenancy: false
+		);
+	}//end testLookupIncludesSoftDeletedRows()
+
+	/**
+	 * NEGATIVE CONTROL: an unresolvable UUID does not survive the filter.
+	 *
+	 * Without this, `return $uuids;` would satisfy the two tests above — the
+	 * filter would stop being a filter and every caller's RBAC gate with it.
+	 *
+	 * @return void
+	 */
+	public function testUnresolvableUuidIsDropped(): void {
+		$mapper = $this->createMock(MagicMapper::class);
+		$mapper->method('findAll')->willReturn([]);
+		$mapper->method('findMultipleAcrossAllMagicTables')
+			->willReturn([$this->entity('uuid-alpha')]);
+
+		$filtered = $this->handlerOver($mapper)->filterUuidsForPermissions(
+			uuids: ['uuid-alpha', 'uuid-ghost'],
+			_rbac: false,
+			_multitenancy: false
+		);
+
+		$this->assertSame(['uuid-alpha'], $filtered);
+	}//end testUnresolvableUuidIsDropped()
+}//end class

--- a/tests/Unit/Service/ObjectServiceBulkDeleteTest.php
+++ b/tests/Unit/Service/ObjectServiceBulkDeleteTest.php
@@ -1,0 +1,303 @@
+<?php
+
+/**
+ * Unit coverage for ObjectService::deleteObjects(), the engine behind
+ * `POST /api/bulk/{register}/{schema}/delete`.
+ *
+ * Two properties are pinned here, and both were broken.
+ *
+ * ACCOUNTING. The endpoint reports `requested_count`, `deleted_count` and
+ * `skipped_count`, and a caller reads them to learn what happened to each row it
+ * submitted. Those three only mean anything if every requested row lands in exactly
+ * one of the two outcome buckets. It did not: UUIDs the permission filter removed
+ * were dropped without a trace, and so was any UUID whose delete handler answered
+ * `false` rather than throwing — the loop's `if ($result === true)` had no else. A
+ * live rig answered `requested 1, deleted 0, skipped 0, success: true` with the row
+ * still in place, which is the worst possible answer: it names no failure to act on.
+ *
+ * ARCHIVAL IMMUTABILITY. openregister#3428 made `Schema::hasArchivalAnnotation()`
+ * the single definition of the rule and routed `ObjectService::deleteObject()` and
+ * the purge routes through it. The bulk loop calls `DeleteObject::deleteObject()`
+ * directly, so it never passed that gate — a third door onto the same destruction.
+ *
+ * These tests run the real `deleteObjects()` over doubled collaborators rather than
+ * reimplementing its conditions: the archival decision is taken by the shipped
+ * predicate reading a real Schema entity, so removing or weakening the gate fails
+ * the test instead of agreeing with it.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service;
+
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Object\CacheHandler;
+use OCA\OpenRegister\Service\Object\DeleteObject;
+use OCA\OpenRegister\Service\Object\PermissionHandler;
+use OCA\OpenRegister\Service\ObjectService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionClass;
+
+/**
+ * Locks the accounting and the archival refusal of the bulk delete loop.
+ */
+class ObjectServiceBulkDeleteTest extends TestCase {
+
+	/**
+	 * The archival retention annotation a schema carries to become immutable.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private const ARCHIVAL_CONFIGURATION = [
+		'x-openregister-archival' => ['retention' => ['default' => 'P10Y']],
+	];
+
+	private ObjectService $service;
+
+	private DeleteObject&MockObject $deleteHandler;
+
+	/**
+	 * Schema entities this test's SchemaMapper double resolves, keyed by id.
+	 *
+	 * @var array<int, Schema>
+	 */
+	private array $schemas = [];
+
+	/**
+	 * Register/schema ids of the objects the mappers resolve, keyed by uuid.
+	 *
+	 * @var array<string, array{register: int, schema: int}>
+	 */
+	private array $scopes = [];
+
+	/**
+	 * Build a Schema entity with a given id and configuration.
+	 *
+	 * @param int   $id            The schema id.
+	 * @param array $configuration The schema configuration.
+	 *
+	 * @return Schema The entity.
+	 */
+	private function schema(int $id, array $configuration): Schema {
+		$schema = new Schema();
+		$schema->setId($id);
+		$schema->setSlug('schema-'.$id);
+		$schema->setConfiguration($configuration);
+
+		return $schema;
+	}//end schema()
+
+	/**
+	 * Register the scope and schema of one object this test operates on.
+	 *
+	 * @param string $uuid          The object's uuid.
+	 * @param int    $schemaId      The schema the object belongs to.
+	 * @param array  $configuration The schema's configuration.
+	 *
+	 * @return ObjectEntity The entity the mappers will resolve for this uuid.
+	 */
+	private function givenObject(string $uuid, int $schemaId, array $configuration = []): ObjectEntity {
+		$this->schemas[$schemaId] = $this->schema(id: $schemaId, configuration: $configuration);
+		$this->scopes[$uuid]      = ['register' => 7, 'schema' => $schemaId];
+
+		$object = new ObjectEntity();
+		$object->setUuid($uuid);
+		$object->setRegister('7');
+		$object->setSchema((string) $schemaId);
+
+		return $object;
+	}//end givenObject()
+
+	/**
+	 * Assemble an ObjectService carrying only the collaborators deleteObjects() uses.
+	 *
+	 * ObjectService takes ~40 constructor arguments; the bulk delete loop touches
+	 * seven of them, so the rest are left uninitialised rather than doubled.
+	 *
+	 * @param array<int, ObjectEntity> $resolvable Objects the mappers can resolve.
+	 *
+	 * @return void
+	 */
+	private function buildService(array $resolvable): void {
+		$permissionHandler = $this->createMock(PermissionHandler::class);
+		$permissionHandler->method('filterUuidsForPermissions')
+			->willReturnCallback(
+				static function (array $uuids) use ($resolvable): array {
+					$known = array_map(static fn (ObjectEntity $o): string => (string) $o->getUuid(), $resolvable);
+
+					return array_values(array_intersect($uuids, $known));
+				}
+			);
+
+		$objectMapper = $this->createMock(MagicMapper::class);
+		$objectMapper->method('findMultipleAcrossAllMagicTables')->willReturn($resolvable);
+
+		$schemaMapper = $this->createMock(SchemaMapper::class);
+		$schemaMapper->method('find')->willReturnCallback(
+			function (int|string $id): Schema {
+				return $this->schemas[(int) $id];
+			}
+		);
+
+		$register = new Register();
+		$register->setId(7);
+		$registerMapper = $this->createMock(RegisterMapper::class);
+		$registerMapper->method('find')->willReturn($register);
+
+		$this->deleteHandler = $this->createMock(DeleteObject::class);
+		$this->deleteHandler->method('getLastCascadeCount')->willReturn(0);
+
+		$this->service = (new ReflectionClass(ObjectService::class))->newInstanceWithoutConstructor();
+		$this->inject('permissionHandler', $permissionHandler);
+		$this->inject('objectMapper', $objectMapper);
+		$this->inject('schemaMapper', $schemaMapper);
+		$this->inject('registerMapper', $registerMapper);
+		$this->inject('deleteHandler', $this->deleteHandler);
+		$this->inject('cacheHandler', $this->createMock(CacheHandler::class));
+		$this->inject('logger', $this->createMock(LoggerInterface::class));
+	}//end buildService()
+
+	/**
+	 * Set one private property on the service under test.
+	 *
+	 * @param string $name  Property name.
+	 * @param mixed  $value Value to set.
+	 *
+	 * @return void
+	 */
+	private function inject(string $name, mixed $value): void {
+		$property = (new ReflectionClass(ObjectService::class))->getProperty($name);
+		$property->setValue($this->service, $value);
+	}//end inject()
+
+	/**
+	 * Every requested UUID is accounted for, and a permitted row is really deleted.
+	 *
+	 * `stays` is a row whose delete handler answers false without throwing — a
+	 * RESTRICT-adjacent refusal the handler reports by return value. It used to
+	 * fall out of both buckets, so `requested_count` exceeded
+	 * `deleted_count + skipped_count` and the caller could not tell which row
+	 * survived.
+	 *
+	 * @return void
+	 */
+	public function testEveryRequestedUuidLandsInExactlyOneBucket(): void {
+		$goes  = $this->givenObject(uuid: 'uuid-goes', schemaId: 11);
+		$stays = $this->givenObject(uuid: 'uuid-stays', schemaId: 11);
+		$this->buildService([$goes, $stays]);
+
+		$this->deleteHandler->method('deleteObject')->willReturnCallback(
+			static fn (mixed ...$args): bool => ($args[2] ?? null) === 'uuid-goes'
+		);
+
+		$result = $this->service->deleteObjects(['uuid-goes', 'uuid-stays']);
+
+		$this->assertSame(['uuid-goes'], $result['deleted_uuids'], 'the permitted row is deleted');
+		$this->assertSame(['uuid-stays'], $result['skipped_uuids'], 'the refused row is named as skipped');
+		$this->assertCount(
+			2,
+			array_merge($result['deleted_uuids'], $result['skipped_uuids']),
+			'requested must equal deleted + skipped'
+		);
+	}//end testEveryRequestedUuidLandsInExactlyOneBucket()
+
+	/**
+	 * A UUID the permission filter removes is reported, not dropped.
+	 *
+	 * @return void
+	 */
+	public function testUuidRefusedByThePermissionFilterIsReportedAsSkipped(): void {
+		$permitted = $this->givenObject(uuid: 'uuid-permitted', schemaId: 11);
+		$this->buildService([$permitted]);
+
+		$this->deleteHandler->method('deleteObject')->willReturn(true);
+
+		$result = $this->service->deleteObjects(['uuid-permitted', 'uuid-forbidden']);
+
+		$this->assertSame(['uuid-permitted'], $result['deleted_uuids']);
+		$this->assertSame(['uuid-forbidden'], $result['skipped_uuids']);
+	}//end testUuidRefusedByThePermissionFilterIsReportedAsSkipped()
+
+	/**
+	 * A row on an archival schema is refused, named, and left intact —
+	 * while the rest of the batch is still processed.
+	 *
+	 * The refusal is decided by `Schema::hasArchivalAnnotation()` reading the real
+	 * configuration below, so this fails if the gate is removed rather than
+	 * agreeing with a copy of its condition.
+	 *
+	 * @return void
+	 */
+	public function testArchivalRowIsRefusedWhileTheRestOfTheBatchProceeds(): void {
+		$archival = $this->givenObject(
+			uuid: 'uuid-archival',
+			schemaId: 12,
+			configuration: self::ARCHIVAL_CONFIGURATION
+		);
+		$plain = $this->givenObject(uuid: 'uuid-plain', schemaId: 11);
+		$this->buildService([$archival, $plain]);
+
+		// The archival row must never reach the destructive call at all.
+		$this->deleteHandler->expects($this->once())
+			->method('deleteObject')
+			->with($this->anything(), $this->anything(), 'uuid-plain')
+			->willReturn(true);
+
+		$result = $this->service->deleteObjects(['uuid-archival', 'uuid-plain']);
+
+		$this->assertSame(['uuid-plain'], $result['deleted_uuids'], 'the rest of the batch still runs');
+		$this->assertSame(['uuid-archival'], $result['skipped_uuids'], 'the refused row is named');
+		$this->assertSame(
+			'SCHEMA_ARCHIVAL_IMMUTABLE',
+			$result['skipped_reasons']['uuid-archival']['error'] ?? null,
+			'the refusal says why'
+		);
+	}//end testArchivalRowIsRefusedWhileTheRestOfTheBatchProceeds()
+
+	/**
+	 * NEGATIVE CONTROL: the same row on a schema WITHOUT the annotation is deleted.
+	 *
+	 * The only difference from the test above is the schema configuration. Without
+	 * this, a gate that refused every bulk delete outright would look correct.
+	 *
+	 * @return void
+	 */
+	public function testRowOnANonArchivalSchemaIsNotRefused(): void {
+		$object = $this->givenObject(
+			uuid: 'uuid-archival',
+			schemaId: 12,
+			configuration: ['x-openregister-lifecycle' => ['default' => 'P10Y']]
+		);
+		$this->buildService([$object]);
+
+		$this->deleteHandler->expects($this->once())
+			->method('deleteObject')
+			->willReturn(true);
+
+		$result = $this->service->deleteObjects(['uuid-archival']);
+
+		$this->assertSame(['uuid-archival'], $result['deleted_uuids']);
+		$this->assertSame([], $result['skipped_uuids']);
+	}//end testRowOnANonArchivalSchemaIsNotRefused()
+}//end class


### PR DESCRIPTION
## The endpoint deleted nothing and said nothing

openregister#3428 noticed that `bulk#delete` reaches `DeleteObject::deleteObject()` without the archival gate, and deliberately left it: reporting the endpoint as "refuses" would have been a test that cannot fail, because on a live rig the endpoint deletes nothing at all.

Reproduced first, before touching the gate. Throwaway Nextcloud 32 rig, own compose project on a free port, register `bulkrig` with a plain schema and one declaring `x-openregister-archival`:

```
POST /api/bulk/bulkrig/plain/delete   {"uuids":["9868aff0-…"]}
{"success":true,"deleted_count":0,"requested_count":1,"skipped_count":0,…}
GET  /api/objects/bulkrig/plain/9868aff0-…   → 200   (still there)
```

Identical for the archival row and for the non-archival control. Three numbers that do not add up, over an object nothing happened to, under `success: true`.

## Where the row went

`ObjectService::deleteObjects()` deletes exactly what `PermissionHandler::filterUuidsForPermissions()` hands back, and that method resolved its candidates with:

```php
$objects = $this->objectEntityMapper->findAll(ids: $uuids, includeDeleted: true);
```

`MagicMapper::findAll()` needs a `Register` **and** a `Schema` entity to know which magic table to read, and returns `[]` — after one log warning and nothing else — when it has neither. This handler has neither. So the filter answered `[]` for every input, the delete loop ran zero iterations, and the counts collapsed. The rig's log confirms it, one line per call:

```
[MagicMapper] findAll() called without register/schema context
```

The lookup that belongs here is the cross-table one — a bulk delete's UUIDs may sit in any magic table, which is why `batchResolveDeleteScopes()` already runs `findMultipleAcrossAllMagicTables()` over the very same UUIDs a few lines later.

## Two more things, once the loop executes

**Every requested UUID now lands in exactly one outcome bucket.** UUIDs the filter removed vanished, and so did any UUID whose handler answered `false` rather than throwing — `if ($result === true)` had no else. `requested = deleted + skipped` now holds; `skipped_reasons` maps each survivor to a structured `{error, message}` so an archival refusal is legible as something other than a RESTRICT block; and `success` reports the shortfall the way the bulk save path already documents in `writeBatch()`. A row this endpoint refused is a row the caller otherwise believes it deleted.

A repeated UUID is deduplicated before it is counted. Naming the same object twice is one deletion and the service resolves each UUID once, so a raw `count($uuids)` counted a row the loop only ever saw one of — which left the invariant unsatisfiable for exactly the caller most likely to be reading it.

**Archival immutability reaches the third door.** The loop calls the delete handler directly, so it never passed `ObjectService::deleteObject()`'s gate. Both paths now go through one `rejectIfArchivalImmutable()`, asking the `Schema::hasArchivalAnnotation()` that #3428 made the single definition. The bulk gate reads the **row's own** schema, not the route's: a bulk delete spans magic tables, so gating on the controller's scope would check somebody else's annotation. A row whose schema cannot be resolved is refused rather than deleted.

`deleteObject()` keeps skipping the gate when it has no schema in scope — a bare `deleteObject($uuid)` never had one, and refusing those would break every scopeless caller. That difference is stated at each call site rather than hidden inside the gate.

## Verified on the rig, after the fix

```
POST /api/bulk/bulkrig/plain/delete  {"uuids":[<plain>, <archival>]}
success false | requested 2 | deleted 1 | skipped 1 | requested == deleted + skipped
deleted:  [<plain>]
skipped:  <archival> → SCHEMA_ARCHIVAL_IMMUTABLE
GET plain     → 404   (gone from the list, present in the trash)
GET archival  → 200   (intact)
```

The archival row was submitted through the **plain** route on purpose: with a route-schema fallback it would have been deleted. A nonexistent UUID in the batch comes back as `OBJECT_NOT_PERMITTED` rather than disappearing.

## Tests

Both were proven red first, and both call production code rather than a copy of its condition — #3428's lesson applies directly here.

- `PermissionHandlerBulkDeleteLookupTest` — a resolved UUID survives the filter; the lookup includes soft-deleted rows. **Negative control:** an unresolvable UUID is dropped, so `return $uuids;` cannot satisfy the file.
- `ObjectServiceBulkDeleteTest` — runs the real `deleteObjects()` over doubled collaborators. Every requested UUID lands in one bucket; a filter refusal is reported; an archival row is refused, named, never reaches the destructive call, and the rest of the batch still runs. The refusal is decided by the shipped predicate reading a real `Schema` entity, so deleting the gate fails the test. **Negative control:** the same row on a schema without the annotation is deleted.
- `BulkControllerTest::testDuplicateUuidIsRequestedOnce` — a UUID named twice is asked of the service once and counted once. Red without the dedupe.
- `BulkControllerTest::testDeleteSuccess` asserted `success === true` for a batch that refused a row — the exact shape of the live defect. Replaced by `testDeleteReportsTheShortfallWhenARowIsRefused`; the neighbouring `testDeleteAllSuccessful` is its control.

## Two things a working endpoint made visible

Neither is introduced here; both were unobservable while the loop ran zero iterations.

- **The loop never hard-deletes.** The docblock claimed a second delete of an already-trashed row escalates to a hard delete. It calls `DeleteObject::deleteObject()` without `permanent: true`, and that flag is the only thing that destroys a row — on the rig the second delete answers `deleted_count: 1` and the row is still in `oc_openregister_table_17_22` with its tombstone. The false claim is corrected rather than left standing; destroying a row for good remains the purge route or `occ openregister:objects:purge`, both of which refuse an archival record.
- **`bulk#deleteSchema` and `bulk#deleteSchemaObjects` are a fourth door.** They go through `SchemaDeletionService`, which never mentions `x-openregister-archival`. Out of scope here — wholesale schema deletion may well want a different rule — but it is the next place this question needs asking.

## Verified locally

CI is bottlenecked, so this was judged by exit code on this host, not by a CI run:

- `phpunit --testsuite "Unit Tests"` — 19074 tests, **0 failures**. Exits 1 on `No code coverage driver available`; an untouched pre-existing class (`ArchivalDeleteGateTest`) exits 1 the same way on this host, so the code is not inheriting that claim.
- `phpcs`, `psalm`, `phpstan`, `phpmd` (both rulesets) on the changed files — **exit 0** each. `phpmd` was scoped to changed files: `phpmd lib/Service` is OOM-killed on this host.
- `hydra-gates` v1.14.0 against `origin/development`.
- Rig torn down with `docker compose -p orbulkdel -f bulkdel-rig-compose.yaml down -v`.

Not run locally: E2E (no e2e touches this endpoint) and the coverage-driver-dependent strict-coverage checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
