### PR TITLE
fix(schemas): close the fourth delete door on archival schemas

### DIFF
--- a/lib/Command/PruneRetiredSchemasCommand.php
+++ b/lib/Command/PruneRetiredSchemasCommand.php
@@ -119,6 +119,16 @@ class PruneRetiredSchemasCommand extends Command {
 				InputOption::VALUE_NONE,
 				'Also delete a schema that still owns objects (DANGEROUS — drops those objects). '
 				. 'Has no effect without --apply.'
+			)
+			->addOption(
+				'force-archival',
+				null,
+				InputOption::VALUE_NONE,
+				'Also delete a schema declaring x-openregister-archival, destroying records the '
+				. 'operator may be legally required to retain. Deliberately separate from --force: '
+				. 'an operator pruning a retired schema that happens to hold a few leftover rows has '
+				. 'said nothing about retained records, and this flag is where they say it. Requires '
+				. '--force and --apply.'
 			);
 	}//end configure()
 
@@ -141,6 +151,7 @@ class PruneRetiredSchemasCommand extends Command {
 		$slugs = (array)$input->getOption('slug');
 		$apply = (bool)$input->getOption('apply');
 		$force = (bool)$input->getOption('force');
+		$forceArchival = (bool)$input->getOption('force-archival');
 		$dryRun = ($apply === false);
 
 		if ($appId === '') {
@@ -204,8 +215,30 @@ class PruneRetiredSchemasCommand extends Command {
 				continue;
 			}
 
+			// The archival refusal is answered here as well as in the service, so the
+			// operator is told which flag lifts it instead of reading a raw exception
+			// out of the FAILED branch below. The condition comes from the production
+			// predicate the other four delete doors read, not from a second reading of
+			// the annotation.
+			$isArchival = $schema->hasArchivalAnnotation();
+			if ($isArchival === true && $forceArchival === false) {
+				$skipped++;
+				$output->writeln(
+					'  <comment>SKIP — declares x-openregister-archival, so its objects are '
+					. 'legally retained records. Re-run with --force-archival to destroy them.</comment>'
+				);
+				continue;
+			}
+
+			$archivalNote = '';
+			if ($isArchival === true) {
+				$archivalNote = ' <comment>(ARCHIVAL RECORDS)</comment>';
+			}
+
 			if ($dryRun === true) {
-				$output->writeln(sprintf('  <comment>WOULD DELETE (objects=%d)</comment>', $objectCount));
+				$output->writeln(
+					sprintf('  <comment>WOULD DELETE (objects=%d)</comment>%s', $objectCount, $archivalNote)
+				);
 				continue;
 			}
 
@@ -222,7 +255,10 @@ class PruneRetiredSchemasCommand extends Command {
 			}
 
 			try {
-				$result = $this->deletionService->cascadeDeleteSchema(schema: $schema);
+				$result = $this->deletionService->cascadeDeleteSchema(
+					schema: $schema,
+					archivalOverride: $forceArchival
+				);
 			} catch (\Throwable $e) {
 				$skipped++;
 				$output->writeln(sprintf('  <error>FAILED: %s</error>', $e->getMessage()));
@@ -237,9 +273,10 @@ class PruneRetiredSchemasCommand extends Command {
 
 			$output->writeln(
 				sprintf(
-					'  <info>DELETED (objects removed=%d, table dropped=%s)</info>',
+					'  <info>DELETED (objects removed=%d, table dropped=%s)</info>%s',
 					(int)$result['deletedCount'],
-					$tableDropped
+					$tableDropped,
+					$archivalNote
 				)
 			);
 		}//end foreach

--- a/lib/Command/PruneRetiredSchemasCommand.php
+++ b/lib/Command/PruneRetiredSchemasCommand.php
@@ -117,7 +117,7 @@ class PruneRetiredSchemasCommand extends Command {
 				'force',
 				null,
 				InputOption::VALUE_NONE,
-				'Also delete a schema that still owns objects (DANGEROUS — drops those objects). '
+				'Also delete a schema that still owns objects. DANGEROUS: it drops those objects. '
 				. 'Has no effect without --apply.'
 			)
 			->addOption(
@@ -166,7 +166,7 @@ class PruneRetiredSchemasCommand extends Command {
 
 		if ($dryRun === true) {
 			$output->writeln(
-				'<comment>Running in DRY-RUN mode — nothing will be deleted. '
+				'<comment>Running in DRY-RUN mode. Nothing will be deleted. '
 				. 'Re-run with --apply to perform deletions.</comment>'
 			);
 		}
@@ -209,7 +209,7 @@ class PruneRetiredSchemasCommand extends Command {
 			if ($objectCount > 0 && $force === false) {
 				$skipped++;
 				$output->writeln(
-					'  <comment>SKIP — still owns objects. Re-run with --force to drop them, '
+					'  <comment>SKIP: still owns objects. Re-run with --force to drop them, '
 					. 'or migrate them first.</comment>'
 				);
 				continue;
@@ -224,7 +224,7 @@ class PruneRetiredSchemasCommand extends Command {
 			if ($isArchival === true && $forceArchival === false) {
 				$skipped++;
 				$output->writeln(
-					'  <comment>SKIP — declares x-openregister-archival, so its objects are '
+					'  <comment>SKIP: declares x-openregister-archival, so its objects are '
 					. 'legally retained records. Re-run with --force-archival to destroy them.</comment>'
 				);
 				continue;
@@ -283,7 +283,7 @@ class PruneRetiredSchemasCommand extends Command {
 
 		$suffix = '';
 		if ($dryRun === true) {
-			$suffix = ' (dry run — no writes performed)';
+			$suffix = ' (dry run, no writes performed)';
 		}
 
 		$output->writeln(

--- a/lib/Controller/BulkController.php
+++ b/lib/Controller/BulkController.php
@@ -34,6 +34,7 @@ use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Dto\BulkSaveOutcome;
 use OCA\OpenRegister\Controller\Trait\ResolvesRegisterAndSchemaTrait;
+use OCA\OpenRegister\Exception\ArchivalImmutableException;
 use OCA\OpenRegister\Exception\RegisterNotFoundException;
 use OCA\OpenRegister\Exception\SchemaNotFoundException;
 use OCA\OpenRegister\Service\ObjectService;
@@ -695,6 +696,10 @@ class BulkController extends Controller {
 					'hard_delete' => $hardDelete,
 				]
 			);
+		} catch (ArchivalImmutableException $e) {
+			// The schema holds legally retained records. Caught ahead of the generic
+			// handler below, which would have reported a deliberate refusal as a 500.
+			return new JSONResponse(data: $e->toResponseBody(), statusCode: Http::STATUS_FORBIDDEN);
 		} catch (Exception $e) {
 			return new JSONResponse(
 				data: ['error' => 'Schema objects deletion failed: ' . $e->getMessage()],
@@ -782,6 +787,10 @@ class BulkController extends Controller {
 					'hard_delete' => $hardDelete,
 				]
 			);
+		} catch (ArchivalImmutableException $e) {
+			// The schema holds legally retained records. Caught ahead of the generic
+			// handler below, which would have reported a deliberate refusal as a 500.
+			return new JSONResponse(data: $e->toResponseBody(), statusCode: Http::STATUS_FORBIDDEN);
 		} catch (Exception $e) {
 			return new JSONResponse(
 				data: ['error' => 'Objects deletion failed: ' . $e->getMessage()],

--- a/lib/Controller/SchemasController.php
+++ b/lib/Controller/SchemasController.php
@@ -32,6 +32,7 @@ use OCA\OpenRegister\Db\Register;
 use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Exception\ArchivalImmutableException;
 use OCA\OpenRegister\Exception\BreakingSchemaChangeException;
 use OCA\OpenRegister\Exception\DatabaseConstraintException;
 use OCA\OpenRegister\Exception\RegisterNotFoundException;
@@ -1110,6 +1111,13 @@ class SchemasController extends Controller {
 				objectCount: $objectCount,
 				force: $force
 			);
+		} catch (ArchivalImmutableException $e) {
+			// The cascade refused: this schema holds legally retained records. An HTTP
+			// caller has no way to override that — `occ openregister:schemas:prune-retired
+			// --force-archival` is the sanctioned path, because shell access is an
+			// authorization boundary a request cannot cross. Caught ahead of the generic
+			// handler, which would have reported a deliberate refusal as a 500.
+			return new JSONResponse(data: $e->toResponseBody(), statusCode: Http::STATUS_FORBIDDEN);
 		} catch (\OCA\OpenRegister\Exception\ValidationException $e) {
 			// Return 409 Conflict for cascade protection (objects still attached).
 			return new JSONResponse(data: ['error' => $e->getMessage()], statusCode: 409);

--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -7757,6 +7757,23 @@ class MagicMapper extends AbstractObjectMapper {
 					]
 				);
 
+				// ONLY CREATE A TABLE THAT IS ACTUALLY MISSING. `force: true` makes
+				// ensureTableForRegisterSchema() DROP an existing table before
+				// recreating it, which destroys every row with no audit entry — and
+				// the message test above is wider than its name: PostgreSQL says
+				// `column "x" of relation "y" does not exist` for a missing COLUMN
+				// (42703) as well as for a missing table (42P01), so a schema whose
+				// magic table was merely out of sync could reach this recovery and
+				// come back empty. If the table is there, the failure was something
+				// else, so surface it instead of resolving it destructively.
+				//
+				// Asked of the connection rather than of tableExistsForRegisterSchema(),
+				// whose positive answers are cached for TABLE_CACHE_TIMEOUT: a stale
+				// "yes" here would turn a genuine missing-table recovery into an error.
+				if ($this->db->tableExists($tableName) === true) {
+					throw $e;
+				}
+
 				// Create the table.
 				$this->ensureTableForRegisterSchema(register: $register, schema: $schema, force: true);
 

--- a/lib/Service/SchemaDeletionService.php
+++ b/lib/Service/SchemaDeletionService.php
@@ -34,6 +34,7 @@ use OCA\OpenRegister\Db\Register;
 use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Exception\ArchivalImmutableException;
 use OCP\IDBConnection;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -56,6 +57,13 @@ use Throwable;
  *   participate in phase 1's transaction nor be rolled back. A drop failure
  *   therefore leaves an EMPTY orphan table, which is reported honestly as
  *   `tableDropped: false` — it never fails a request whose data work succeeded.
+ *
+ * ARCHIVAL IMMUTABILITY: a schema declaring `x-openregister-archival` holds records
+ * its operator is legally required to retain, so neither entry point will destroy its
+ * objects. `deleteObjectsBySchema()` refuses outright; `cascadeDeleteSchema()` refuses
+ * unless an operator authorises the destruction explicitly from the CLI. See
+ * {@see self::rejectIfArchivalImmutable()} for why the audit trail is not a substitute
+ * for the record.
  *
  * KNOWN LIMIT: the cascade is synchronous, and its audit writes are inherently
  * sequential (hash-chained, ADR-003). A schema with far more than ~10k objects will
@@ -128,17 +136,25 @@ class SchemaDeletionService {
 	 * its row is touched, because `MagicMapper::deleteObjectsBySchema()` returns
 	 * only a count and cannot tell us afterwards what it removed.
 	 *
+	 * ARCHIVAL SCHEMAS ARE REFUSED OUTRIGHT. Both callers are HTTP routes, and the
+	 * spec's answer for an HTTP caller is the same at every door: an archival record
+	 * leaves only through the retention cron or the `occ` purge. There is no override
+	 * parameter here on purpose — an override this method accepted would be reachable
+	 * over HTTP the moment a controller passed it through.
+	 *
 	 * @param int $registerId The register id.
 	 * @param int $schemaId The schema id.
 	 * @param bool $hardDelete True to remove the rows, false to soft-delete them.
 	 * @param string $triggeredBy Audit trigger context.
 	 *
+	 * @throws ArchivalImmutableException If the schema declares `x-openregister-archival`.
 	 * @throws \Exception If the register or schema cannot be resolved, or deletion fails.
 	 *
 	 * @return array{deleted_count: int, deleted_uuids: array<int, string>, schema_id: int} The deletion result.
 	 *
 	 * @SuppressWarnings(PHPMD.BooleanArgumentFlag) The hard/soft toggle mirrors the mapper primitive it wraps.
 	 *
+	 * @spec openspec/specs/archival-annotation-vocabulary/spec.md
 	 * @spec openspec/changes/schema-delete-cascade/specs/runtime-schema-api/spec.md
 	 */
 	public function deleteObjectsBySchema(
@@ -149,6 +165,8 @@ class SchemaDeletionService {
 	): array {
 		$register = $this->registerMapper->find(id: $registerId);
 		$schema = $this->schemaMapper->find(id: $schemaId);
+
+		$this->rejectIfArchivalImmutable(schema: $schema, operation: 'delete');
 
 		$result = $this->deleteObjectsOfPair(
 			register: $register,
@@ -177,15 +195,36 @@ class SchemaDeletionService {
 	 * still succeeds, because the caller's intent is already satisfied and DDL is not
 	 * rollbackable on MySQL/MariaDB.
 	 *
-	 * @param Schema $schema The schema to tear down.
+	 * ARCHIVAL SCHEMAS ARE REFUSED UNLESS THE CALLER OVERRIDES EXPLICITLY, and the
+	 * override is an argument rather than a default because the two callers do not
+	 * carry the same authority. `DELETE /api/schemas/{id}?deleteObjects=true` never
+	 * passes it: an HTTP caller cannot destroy a legally retained record, exactly as
+	 * at the other three doors. `occ openregister:schemas:prune-retired` passes it
+	 * only when the operator typed `--force-archival`, which is the same bargain
+	 * `occ openregister:objects:purge --force` already strikes — shell access is an
+	 * authorization boundary an HTTP request cannot cross, and the operator has to
+	 * name the archival records out loud rather than sweep them up inside a flag
+	 * they passed for another reason.
 	 *
+	 * @param Schema $schema The schema to tear down.
+	 * @param bool $archivalOverride True only when an operator has explicitly authorised
+	 *                               destroying a legally retained record from the CLI.
+	 *
+	 * @throws ArchivalImmutableException If the schema is archival and no override was given.
 	 * @throws \Exception If phase 1 fails (nothing is deleted).
 	 *
 	 * @return array{deletedCount: int, deletedUuids: array<int, string>, tableDropped: bool} The cascade result.
 	 *
+	 * @SuppressWarnings(PHPMD.BooleanArgumentFlag) The override is the caller's authority, and it has to be stated per call site.
+	 *
+	 * @spec openspec/specs/archival-annotation-vocabulary/spec.md
 	 * @spec openspec/changes/schema-delete-cascade/specs/runtime-schema-api/spec.md
 	 */
-	public function cascadeDeleteSchema(Schema $schema): array {
+	public function cascadeDeleteSchema(Schema $schema, bool $archivalOverride = false): array {
+		if ($archivalOverride === false) {
+			$this->rejectIfArchivalImmutable(schema: $schema, operation: 'delete');
+		}
+
 		$schemaId = (int)$schema->getId();
 		$tables = $this->resolveMagicTablesForSchema(schema: $schema);
 
@@ -323,6 +362,60 @@ class SchemaDeletionService {
 		}//end try
 
 	}//end dropEmptyTablesForSchema()
+
+	/**
+	 * Refuse to destroy the objects of a schema that holds legally retained records.
+	 *
+	 * THE ONE PLACE THIS SERVICE DECIDES A SCHEMA-WIDE DELETE IS NOT ALLOWED.
+	 *
+	 * The condition is not restated here: it is read from
+	 * {@see Schema::hasArchivalAnnotation()}, the single definition of "is archival"
+	 * that `ObjectService::deleteObject()`, `ObjectService::rejectIfArchivalImmutable()`,
+	 * `DeletedController::destroy()` and `occ openregister:objects:purge` all ask. A
+	 * fifth reading of the annotation is a fifth chance to disagree with the other four.
+	 *
+	 * The gate sits in this service rather than in its callers because this service is
+	 * the single implementation of "delete every object of a schema": both bulk routes,
+	 * the HTTP cascade and the prune CLI reach the destruction through here, so a future
+	 * caller inherits the refusal instead of having to remember it.
+	 *
+	 * WHY REFUSE RATHER THAN PERMIT-WITH-AUDIT. This service audits every object into the
+	 * hash-chained trail before dropping it, which is genuinely a design for deliberate
+	 * destruction — but an audit entry records that a record was destroyed, it is not the
+	 * record. A retention obligation is discharged by still holding the row, so the audit
+	 * trail cannot stand in for it, and the fact that this path destroys carefully is not
+	 * a reason to let it destroy here.
+	 *
+	 * @param Schema $schema The schema whose objects are about to be destroyed.
+	 * @param string $operation The operation name reported in the structured error body.
+	 *
+	 * @throws ArchivalImmutableException When the schema declares `x-openregister-archival`.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/archival-annotation-vocabulary/spec.md
+	 */
+	private function rejectIfArchivalImmutable(Schema $schema, string $operation): void {
+		if ($schema->hasArchivalAnnotation() === false) {
+			return;
+		}
+
+		$this->logger->warning(
+			message: '[SchemaDeletionService] Refused a schema-wide delete on an archival schema',
+			context: [
+				'file' => __FILE__,
+				'line' => __LINE__,
+				'schemaId' => (int)$schema->getId(),
+				'schemaSlug' => $schema->getSlug(),
+				'operation' => $operation,
+			]
+		);
+
+		throw new ArchivalImmutableException(
+			schemaIdentifier: ($schema->getSlug() ?? (string)$schema->getId()),
+			operation: $operation
+		);
+	}//end rejectIfArchivalImmutable()
 
 	/**
 	 * Audit and delete every object of one register/schema magic table.

--- a/openspec/specs/archival-annotation-vocabulary/spec.md
+++ b/openspec/specs/archival-annotation-vocabulary/spec.md
@@ -115,6 +115,59 @@ The gate SHALL read `Schema::hasArchivalAnnotation()`, which is the single defin
 - **WHEN** `DELETE /api/deleted` is called
 - **THEN** exactly one row SHALL be destroyed and the live row SHALL be counted as `failed`
 
+### Requirement: Schema-wide object deletion is refused on an archival schema
+
+`SchemaDeletionService` is the single implementation of "delete every object of a schema", reached by `POST /api/bulk/{register}/{schema}/delete-objects`, its legacy twin `/delete-schema`, `DELETE /api/schemas/{id}?deleteObjects=true` and `occ openregister:schemas:prune-retired`. It SHALL apply the archival gate that `ObjectService::deleteObject()` applies, reading `Schema::hasArchivalAnnotation()` rather than the annotation itself.
+
+`deleteObjectsBySchema()` SHALL refuse an archival schema unconditionally and SHALL expose no override parameter: both of its callers are HTTP routes, and an override they could pass through would put archival destruction back on the network. `cascadeDeleteSchema()` SHALL refuse unless the caller passes an explicit `archivalOverride`, which only `occ openregister:schemas:prune-retired --force-archival` passes — the same bargain `occ openregister:objects:purge --force` strikes, on the same reasoning that shell access is an authorization boundary an HTTP caller cannot cross.
+
+`--force-archival` SHALL be a distinct flag from `--force`. `--force` means "this schema still owns objects"; an operator pruning a retired test schema passes it without having said anything about retained records, so it MUST NOT authorise their destruction.
+
+The refusal SHALL surface as HTTP 403 with the `{ error: "SCHEMA_ARCHIVAL_IMMUTABLE", message, schema, operation, hint }` body, on both the bulk routes and the schema cascade — not as a 500, which would read as an endpoint bug rather than as the platform protecting a retained record.
+
+The audit trail SHALL NOT be treated as a substitute for the record. `SchemaDeletionService` writes a hash-chained audit entry per object before removing it, but an entry recording that a record was destroyed does not discharge an obligation to retain it.
+
+#### Scenario: Bulk delete-objects on an archival schema destroys nothing
+- **GIVEN** the `dossiq/retained-case` schema declares `x-openregister-archival` and its magic table holds 3 rows
+- **WHEN** `POST /api/bulk/{register}/retained-case/delete-objects` is called with `{"hardDelete": true}`
+- **THEN** the response SHALL be HTTP 403 with `error: "SCHEMA_ARCHIVAL_IMMUTABLE"` and `operation: "delete"`
+- **AND** all 3 rows SHALL still exist in the magic table
+- **AND** no `schema.cascade_delete` audit entry SHALL be written
+
+#### Scenario: A soft schema-wide delete is refused too
+- **WHEN** the same call is made with `{"hardDelete": false}`
+- **THEN** the response SHALL be HTTP 403 and no row SHALL be tombstoned
+
+#### Scenario: The HTTP schema cascade on an archival schema is refused
+- **WHEN** `DELETE /api/schemas/{id}?deleteObjects=true` names the archival schema
+- **THEN** the response SHALL be HTTP 403 with `error: "SCHEMA_ARCHIVAL_IMMUTABLE"`
+- **AND** no transaction SHALL be opened, no row removed, no magic table dropped, and the schema entity SHALL still exist
+
+#### Scenario: The prune CLI refuses without the archival flag
+- **WHEN** `occ openregister:schemas:prune-retired --app dossiq --slug retained-case --apply --force` names the archival schema
+- **THEN** the command SHALL skip it, SHALL name `x-openregister-archival` and `--force-archival`, and SHALL destroy nothing
+
+#### Scenario: The prune CLI proceeds with the archival flag and says so
+- **WHEN** the same command is re-run with `--force-archival`
+- **THEN** the cascade SHALL run and the output SHALL mark the schema as holding ARCHIVAL RECORDS
+
+#### Scenario: An ordinary schema is unaffected
+- **GIVEN** a schema that does NOT declare `x-openregister-archival`
+- **WHEN** any of these paths deletes its objects
+- **THEN** the deletion SHALL succeed exactly as before, reporting the count and the UUIDs
+
+### Requirement: A failed bulk upsert never resolves itself by dropping the table
+
+`MagicMapper::bulkUpsert()` recovers from a missing magic table by creating it and retrying. The recovery SHALL create only a table that is actually absent, verified against the live connection. It MUST NOT reach `ensureTableForRegisterSchema(force: true)` while the table exists, because that drops the table before recreating it and destroys every row with no audit entry.
+
+The message test that selects this recovery is wider than a missing table: PostgreSQL phrases a missing COLUMN (42703) as `column "x" of relation "y" does not exist`, which matches the same substring as a missing relation (42P01). A failure that is not a missing table SHALL be re-thrown.
+
+#### Scenario: An error naming an existing table is surfaced, not resolved destructively
+- **GIVEN** a populated magic table for a register/schema pair
+- **WHEN** `bulkUpsert()` fails with an error whose message contains `does not exist` while that table exists
+- **THEN** the original exception SHALL propagate
+- **AND** the table SHALL NOT be dropped and its rows SHALL remain
+
 ### Requirement: An administrative CLI purge is the only path that can destroy an archival record
 
 The platform SHALL ship `occ openregister:objects:purge <uuid>...`. It SHALL be dry-run by default and write only with `--apply`. Without `--force` it SHALL refuse an archival record and SHALL refuse a live (not soft-deleted) object. With `--force` it SHALL destroy either, and SHALL name the record as archival in its output.

--- a/tests/Unit/Command/PruneRetiredSchemasArchivalTest.php
+++ b/tests/Unit/Command/PruneRetiredSchemasArchivalTest.php
@@ -1,0 +1,267 @@
+<?php
+
+/**
+ * `occ openregister:schemas:prune-retired` and legally retained records.
+ *
+ * The prune CLI is the ONE caller allowed to cascade-delete an archival schema,
+ * on the same terms `occ openregister:objects:purge --force` already sets: shell
+ * access is an authorization boundary an HTTP request cannot cross, so the
+ * operator may override — but only by naming the archival records out loud.
+ * `--force` means "this schema still owns objects", which an operator pruning a
+ * retired test schema passes without having said anything about retention; that
+ * is why the archival override is its own flag.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Command
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Command;
+
+use OCA\OpenRegister\Command\PruneRetiredSchemasCommand;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\SchemaDeletionService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * The archival override on the prune command.
+ */
+class PruneRetiredSchemasArchivalTest extends TestCase {
+
+	private const SCHEMA_ID = 42;
+
+	private const REGISTER_ID = 7;
+
+	/**
+	 * @var SchemaMapper&MockObject
+	 */
+	private SchemaMapper $schemaMapper;
+
+	/**
+	 * @var RegisterMapper&MockObject
+	 */
+	private RegisterMapper $registerMapper;
+
+	/**
+	 * @var MagicMapper&MockObject
+	 */
+	private MagicMapper $magicMapper;
+
+	/**
+	 * @var SchemaDeletionService&MockObject
+	 */
+	private SchemaDeletionService $deletionService;
+
+	private PruneRetiredSchemasCommand $command;
+
+	/**
+	 * Wire the command up with mocked collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->schemaMapper = $this->createMock(SchemaMapper::class);
+		$this->registerMapper = $this->createMock(RegisterMapper::class);
+		$this->magicMapper = $this->createMock(MagicMapper::class);
+		$this->deletionService = $this->createMock(SchemaDeletionService::class);
+
+		$this->command = new PruneRetiredSchemasCommand(
+			$this->schemaMapper,
+			$this->registerMapper,
+			$this->magicMapper,
+			$this->deletionService
+		);
+
+	}//end setUp()
+
+	/**
+	 * Inject an id into an entity (Entity::$id is protected).
+	 *
+	 * @param object $entity The entity.
+	 * @param int    $id     The id to inject.
+	 *
+	 * @return mixed The same entity.
+	 */
+	private function makeEntity(object $entity, int $id): mixed {
+		$property = (new ReflectionClass($entity))->getProperty('id');
+		$property->setAccessible(true);
+		$property->setValue($entity, $id);
+
+		return $entity;
+	}//end makeEntity()
+
+	/**
+	 * One register holding one archival schema with two objects.
+	 *
+	 * The configuration is the real annotation, so the command's decision comes from
+	 * `Schema::hasArchivalAnnotation()` reading real data rather than from a test copy
+	 * of the condition.
+	 *
+	 * @param bool $archival Whether the schema declares `x-openregister-archival`.
+	 *
+	 * @return Schema The schema the command will resolve.
+	 */
+	private function stubOneRetiredSchema(bool $archival): Schema {
+		$schema = $this->makeEntity(new Schema(), self::SCHEMA_ID);
+		$schema->setSlug('retained-case');
+
+		if ($archival === true) {
+			$schema->setConfiguration(
+				['x-openregister-archival' => ['retention' => ['default' => 'P10Y']]]
+			);
+		}
+
+		$register = $this->makeEntity(new Register(), self::REGISTER_ID);
+		$register->setSlug('archival-rig');
+		$register->setSchemas([self::SCHEMA_ID]);
+
+		$this->schemaMapper->method('findByApplicationAndSlug')->willReturn($schema);
+		$this->registerMapper->method('findAll')->willReturn([$register]);
+		$this->magicMapper->method('tableExistsForRegisterSchema')->willReturn(true);
+		$this->magicMapper->method('countObjectsInRegisterSchemaTable')->willReturn(2);
+
+		return $schema;
+	}//end stubOneRetiredSchema()
+
+	/**
+	 * Run the command with the given options.
+	 *
+	 * @param array<string, bool> $options Extra options beyond --app/--slug/--apply.
+	 *
+	 * @return CommandTester The finished tester.
+	 */
+	private function runPrune(array $options): CommandTester {
+		$tester = new CommandTester($this->command);
+		$tester->execute(
+			array_merge(
+				[
+					'--app' => 'dossiq',
+					'--slug' => ['retained-case'],
+					'--apply' => true,
+				],
+				$options
+			)
+		);
+
+		return $tester;
+	}//end runPrune()
+
+	/**
+	 * `--force` alone does NOT destroy archival records.
+	 *
+	 * The operator asked to drop a retired schema that still owns objects. They did
+	 * not ask to destroy legally retained ones, and this is the difference the
+	 * separate flag exists to preserve.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/archival-annotation-vocabulary/spec.md
+	 */
+	public function testForceAloneDoesNotPruneAnArchivalSchema(): void {
+		$this->stubOneRetiredSchema(archival: true);
+
+		$this->deletionService->expects($this->never())->method('cascadeDeleteSchema');
+
+		$tester = $this->runPrune(['--force' => true]);
+		$display = $tester->getDisplay();
+
+		$this->assertStringContainsString('x-openregister-archival', $display);
+		$this->assertStringContainsString('--force-archival', $display);
+		$this->assertStringContainsString('skipped=1', $display);
+
+	}//end testForceAloneDoesNotPruneAnArchivalSchema()
+
+	/**
+	 * `--force-archival` authorises the destruction, and the service is told so.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/archival-annotation-vocabulary/spec.md
+	 */
+	public function testForceArchivalPrunesAndNamesTheRecords(): void {
+		$schema = $this->stubOneRetiredSchema(archival: true);
+
+		$this->deletionService
+			->expects($this->once())
+			->method('cascadeDeleteSchema')
+			->with($this->equalTo($schema), $this->isTrue())
+			->willReturn(['deletedCount' => 2, 'deletedUuids' => ['a', 'b'], 'tableDropped' => true]);
+
+		$tester = $this->runPrune(['--force' => true, '--force-archival' => true]);
+		$display = $tester->getDisplay();
+
+		$this->assertStringContainsString('ARCHIVAL RECORDS', $display);
+		$this->assertStringContainsString('Pruned=1', $display);
+
+	}//end testForceArchivalPrunesAndNamesTheRecords()
+
+	/**
+	 * An ordinary retired schema is unaffected: the override is never passed.
+	 *
+	 * @return void
+	 */
+	public function testAnOrdinarySchemaIsPrunedWithoutTheOverride(): void {
+		$schema = $this->stubOneRetiredSchema(archival: false);
+
+		$this->deletionService
+			->expects($this->once())
+			->method('cascadeDeleteSchema')
+			->with($this->equalTo($schema), $this->isFalse())
+			->willReturn(['deletedCount' => 2, 'deletedUuids' => ['a', 'b'], 'tableDropped' => true]);
+
+		$tester = $this->runPrune(['--force' => true]);
+		$display = $tester->getDisplay();
+
+		$this->assertStringNotContainsString('ARCHIVAL RECORDS', $display);
+		$this->assertStringContainsString('Pruned=1', $display);
+
+	}//end testAnOrdinarySchemaIsPrunedWithoutTheOverride()
+
+	/**
+	 * A dry run says what it WOULD destroy, and destroys nothing.
+	 *
+	 * @return void
+	 */
+	public function testDryRunNamesTheArchivalRecordsWithoutDeleting(): void {
+		$this->stubOneRetiredSchema(archival: true);
+
+		$this->deletionService->expects($this->never())->method('cascadeDeleteSchema');
+
+		$tester = new CommandTester($this->command);
+		$tester->execute(
+			[
+				'--app' => 'dossiq',
+				'--slug' => ['retained-case'],
+				'--force' => true,
+				'--force-archival' => true,
+			]
+		);
+
+		$display = $tester->getDisplay();
+
+		$this->assertStringContainsString('WOULD DELETE', $display);
+		$this->assertStringContainsString('ARCHIVAL RECORDS', $display);
+
+	}//end testDryRunNamesTheArchivalRecordsWithoutDeleting()
+}//end class

--- a/tests/Unit/Controller/BulkControllerTest.php
+++ b/tests/Unit/Controller/BulkControllerTest.php
@@ -9,6 +9,7 @@ use OCA\OpenRegister\Db\Register;
 use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Exception\ArchivalImmutableException;
 use OCA\OpenRegister\Service\Object\BatchOperationStatus;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -1079,6 +1080,64 @@ class BulkControllerTest extends TestCase {
 		$this->assertEquals(Http::STATUS_OK, $result->getStatus());
 		$data = $result->getData();
 		$this->assertTrue($data['hard_delete']);
+	}
+
+	/**
+	 * An archival schema is refused with the 403 contract body, not a 500.
+	 *
+	 * ARCHIVAL IMMUTABILITY (openregister#3428). The service refuses the delete by
+	 * throwing ArchivalImmutableException; without a dedicated catch the generic
+	 * handler below reported that deliberate refusal as
+	 * `500 Schema objects deletion failed`, which reads as a bug in the endpoint
+	 * rather than as the platform protecting a legally retained record.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/archival-annotation-vocabulary/spec.md
+	 */
+	public function testDeleteSchemaOnAnArchivalSchemaIsRefusedWith403(): void {
+		$this->stubAdminUser();
+		$this->stubSchemaLookup(2);
+		$this->objectService->method('setRegister')->willReturnSelf();
+		$this->objectService->method('setSchema')->willReturnSelf();
+		$this->objectService->method('deleteObjectsBySchema')->willThrowException(
+			new ArchivalImmutableException(schemaIdentifier: 'retained-case', operation: 'delete')
+		);
+
+		$this->request->method('getParams')->willReturn(['hardDelete' => true]);
+
+		$result = $this->controller->deleteSchema('1', '2');
+
+		$this->assertEquals(Http::STATUS_FORBIDDEN, $result->getStatus());
+		$data = $result->getData();
+		$this->assertSame('SCHEMA_ARCHIVAL_IMMUTABLE', $data['error']);
+		$this->assertSame('retained-case', $data['schema']);
+		$this->assertSame('delete', $data['operation']);
+	}
+
+	/**
+	 * The same refusal on the current (slug-resolving) delete-objects route.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/archival-annotation-vocabulary/spec.md
+	 */
+	public function testDeleteSchemaObjectsOnAnArchivalSchemaIsRefusedWith403(): void {
+		$this->stubAdminUser();
+		$this->setupResolveSuccess();
+		$this->stubSchemaLookup(2);
+		$this->objectService->method('deleteObjectsBySchema')->willThrowException(
+			new ArchivalImmutableException(schemaIdentifier: 'retained-case', operation: 'delete')
+		);
+
+		$this->request->method('getParams')->willReturn(['hardDelete' => true]);
+
+		$result = $this->controller->deleteSchemaObjects('1', '2');
+
+		$this->assertEquals(Http::STATUS_FORBIDDEN, $result->getStatus());
+		$data = $result->getData();
+		$this->assertSame('SCHEMA_ARCHIVAL_IMMUTABLE', $data['error']);
+		$this->assertSame('delete', $data['operation']);
 	}
 
 	public function testDeleteSchemaException(): void {

--- a/tests/Unit/Controller/SchemasDestroySafetyTest.php
+++ b/tests/Unit/Controller/SchemasDestroySafetyTest.php
@@ -38,6 +38,7 @@ use OCA\OpenRegister\Db\AuditTrailMapper;
 use OCA\OpenRegister\Db\MagicMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Exception\ArchivalImmutableException;
 use OCA\OpenRegister\Service\OrganisationService;
 use OCA\OpenRegister\Service\Schema\SchemaVersioningService;
 use OCA\OpenRegister\Service\SchemaDeletionService;
@@ -414,6 +415,48 @@ class SchemasDestroySafetyTest extends TestCase {
 		$this->assertTrue($data['tableDropped']);
 
 	}//end testCascadeDeletesObjectsAndReportsWhatItRemoved()
+
+	/**
+	 * REQ (archival-annotation-vocabulary): the HTTP cascade cannot destroy a
+	 * legally retained record, and says so with the same 403 body as the other doors.
+	 *
+	 * ARCHIVAL IMMUTABILITY (openregister#3428). `?deleteObjects=true` was the
+	 * fourth delete door and the only one that never asked
+	 * `Schema::hasArchivalAnnotation()`: on an archival schema it answered 200,
+	 * destroyed every row AND dropped the magic table. There is no HTTP override —
+	 * `occ openregister:schemas:prune-retired --force-archival` is the sanctioned
+	 * path, because shell access is an authorization boundary a request cannot cross.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/archival-annotation-vocabulary/spec.md
+	 */
+	public function testCascadeOnAnArchivalSchemaIsRefusedWith403(): void {
+		$schema = $this->makeSchema(42, 'retained-case');
+
+		$this->schemaMapper->method('find')->willReturn($schema);
+		$this->objectMapper->method('getStatistics')->willReturn(['total' => 2]);
+
+		$this->stubFlags(deleteObjects: 'true');
+
+		$this->schemaDeletionService
+			->method('cascadeDeleteSchema')
+			->willThrowException(
+				new ArchivalImmutableException(schemaIdentifier: 'retained-case', operation: 'delete')
+			);
+
+		$this->schemaMapper->expects($this->never())->method('delete');
+
+		$response = $this->controller->destroy(42);
+
+		$this->assertSame(403, $response->getStatus());
+
+		$data = $response->getData();
+		$this->assertSame('SCHEMA_ARCHIVAL_IMMUTABLE', $data['error']);
+		$this->assertSame('retained-case', $data['schema']);
+		$this->assertSame('delete', $data['operation']);
+
+	}//end testCascadeOnAnArchivalSchemaIsRefusedWith403()
 
 	/**
 	 * REQ + SCENARIO: "Cascade succeeds but the table drop fails".

--- a/tests/Unit/Service/SchemaDeletionArchivalGateTest.php
+++ b/tests/Unit/Service/SchemaDeletionArchivalGateTest.php
@@ -1,0 +1,413 @@
+<?php
+
+/**
+ * SchemaDeletionService archival immutability tests — the fourth delete door.
+ *
+ * ARCHIVAL IMMUTABILITY. openregister#3428 made `Schema::hasArchivalAnnotation()`
+ * the single definition of "this schema holds legally retained records", and three
+ * delete doors were made to read it: `DELETE /api/objects/.../{id}`,
+ * `DELETE /api/deleted/{uuid}`, and `POST /api/bulk/.../delete`. `SchemaDeletionService`
+ * was the fourth and it read nothing — `POST /api/bulk/{r}/{s}/delete-objects` with
+ * `hardDelete: true` answered 200 `success: true` and destroyed every row of an
+ * archival schema, and `DELETE /api/schemas/{id}?deleteObjects=true` destroyed the
+ * rows AND dropped the magic table.
+ *
+ * These tests drive the REAL service and assert on the REAL predicate: the schema
+ * double carries an actual `x-openregister-archival` configuration and the refusal
+ * is the shipped gate's, not a copy of its condition. Breaking or deleting
+ * `Schema::hasArchivalAnnotation()` fails them.
+ *
+ * Spec REQ (archival-annotation-vocabulary):
+ *   "DELETE on an archival schema returns 403 SCHEMA_ARCHIVAL_IMMUTABLE"
+ *   "An administrative CLI purge is the only path that can destroy an archival record"
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service;
+
+use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Exception\ArchivalImmutableException;
+use OCA\OpenRegister\Service\SchemaDeletionService;
+use OCP\IDBConnection;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionClass;
+
+/**
+ * The archival gate on schema-wide object deletion.
+ */
+class SchemaDeletionArchivalGateTest extends TestCase {
+
+	private const REGISTER_ID = 7;
+
+	private const SCHEMA_ID = 42;
+
+	/**
+	 * The real archival annotation, exactly as a schema descriptor declares it.
+	 *
+	 * @var array<string, array<string, array<string, string>>>
+	 */
+	private const ARCHIVAL_CONFIGURATION = [
+		'x-openregister-archival' => ['retention' => ['default' => 'P10Y']],
+	];
+
+	/**
+	 * @var IDBConnection&MockObject
+	 */
+	private IDBConnection $db;
+
+	/**
+	 * @var MagicMapper&MockObject
+	 */
+	private MagicMapper $magicMapper;
+
+	/**
+	 * @var RegisterMapper&MockObject
+	 */
+	private RegisterMapper $registerMapper;
+
+	/**
+	 * @var SchemaMapper&MockObject
+	 */
+	private SchemaMapper $schemaMapper;
+
+	/**
+	 * @var AuditTrailMapper&MockObject
+	 */
+	private AuditTrailMapper $auditTrailMapper;
+
+	/**
+	 * @var LoggerInterface&MockObject
+	 */
+	private LoggerInterface $logger;
+
+	private SchemaDeletionService $service;
+
+	private Register $register;
+
+	/**
+	 * Wire the real service up with mocked collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->db = $this->createMock(IDBConnection::class);
+		$this->magicMapper = $this->createMock(MagicMapper::class);
+		$this->registerMapper = $this->createMock(RegisterMapper::class);
+		$this->schemaMapper = $this->createMock(SchemaMapper::class);
+		$this->auditTrailMapper = $this->createMock(AuditTrailMapper::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->service = new SchemaDeletionService(
+			$this->db,
+			$this->magicMapper,
+			$this->registerMapper,
+			$this->schemaMapper,
+			$this->auditTrailMapper,
+			$this->logger
+		);
+
+		$this->register = $this->makeEntity(new Register(), self::REGISTER_ID);
+		$this->registerMapper->method('find')->willReturn($this->register);
+
+	}//end setUp()
+
+	/**
+	 * Inject an id into an entity (Entity::$id is protected).
+	 *
+	 * @param object $entity The entity.
+	 * @param int    $id     The id to inject.
+	 *
+	 * @return mixed The same entity.
+	 */
+	private function makeEntity(object $entity, int $id): mixed {
+		$property = (new ReflectionClass($entity))->getProperty('id');
+		$property->setAccessible(true);
+		$property->setValue($entity, $id);
+
+		return $entity;
+	}//end makeEntity()
+
+	/**
+	 * Build a schema, optionally declaring the archival annotation.
+	 *
+	 * The configuration is the real annotation shape, so the gate's answer comes
+	 * from `Schema::hasArchivalAnnotation()` reading real data.
+	 *
+	 * @param bool $archival Whether the schema declares `x-openregister-archival`.
+	 *
+	 * @return Schema The schema.
+	 */
+	private function makeSchema(bool $archival): Schema {
+		$schema = $this->makeEntity(new Schema(), self::SCHEMA_ID);
+		$schema->setSlug('retained-case');
+		$schema->setTitle('Retained Case');
+
+		if ($archival === true) {
+			$schema->setConfiguration(self::ARCHIVAL_CONFIGURATION);
+		}
+
+		return $schema;
+	}//end makeSchema()
+
+	/**
+	 * Make the schema resolvable and give it one populated magic table.
+	 *
+	 * @param Schema $schema The schema the service will resolve.
+	 *
+	 * @return void
+	 */
+	private function stubOnePopulatedTable(Schema $schema): void {
+		$this->schemaMapper->method('find')->willReturn($schema);
+		$this->magicMapper->method('getAllRegisterSchemaPairs')->willReturn(
+			[['registerId' => self::REGISTER_ID, 'schemaId' => self::SCHEMA_ID]]
+		);
+		$this->magicMapper->method('tableExistsForRegisterSchema')->willReturn(true);
+
+		$object = new ObjectEntity();
+		$object->setUuid('90f1e160-c2fc-4829-9833-13c07769734b');
+		$object->setRegister((string)self::REGISTER_ID);
+		$object->setSchema((string)self::SCHEMA_ID);
+		$object->setObject(['reference' => 'CASE-001']);
+
+		$this->magicMapper->method('findAllInRegisterSchemaTable')->willReturn([$object]);
+		$this->magicMapper->method('deleteObjectsBySchema')->willReturn(1);
+
+	}//end stubOnePopulatedTable()
+
+	/**
+	 * The bulk delete-objects endpoints refuse an archival schema and touch nothing.
+	 *
+	 * This is the reproduction: on `development` this call returned
+	 * `deleted_count: 1` and the magic table came back empty.
+	 *
+	 * @return void
+	 */
+	public function testBulkSchemaDeleteRefusesAnArchivalSchema(): void {
+		$this->stubOnePopulatedTable($this->makeSchema(archival: true));
+
+		$this->magicMapper->expects($this->never())->method('deleteObjectsBySchema');
+		$this->auditTrailMapper->expects($this->never())->method('createAuditTrailEntry');
+
+		$this->expectException(ArchivalImmutableException::class);
+
+		$this->service->deleteObjectsBySchema(
+			registerId: self::REGISTER_ID,
+			schemaId: self::SCHEMA_ID,
+			hardDelete: true
+		);
+
+	}//end testBulkSchemaDeleteRefusesAnArchivalSchema()
+
+	/**
+	 * The refusal is a 403 naming the schema, so a controller can return it verbatim.
+	 *
+	 * @return void
+	 */
+	public function testBulkRefusalCarriesThe403ContractBody(): void {
+		$this->stubOnePopulatedTable($this->makeSchema(archival: true));
+
+		try {
+			$this->service->deleteObjectsBySchema(
+				registerId: self::REGISTER_ID,
+				schemaId: self::SCHEMA_ID,
+				hardDelete: true
+			);
+			$this->fail('Expected ArchivalImmutableException');
+		} catch (ArchivalImmutableException $e) {
+			$body = $e->toResponseBody();
+
+			$this->assertSame(403, $e->getCode());
+			$this->assertSame('SCHEMA_ARCHIVAL_IMMUTABLE', $body['error']);
+			$this->assertSame('retained-case', $body['schema']);
+			$this->assertSame('delete', $body['operation']);
+		}//end try
+
+	}//end testBulkRefusalCarriesThe403ContractBody()
+
+	/**
+	 * A soft bulk delete is refused too — a tombstone is still a delete.
+	 *
+	 * @return void
+	 */
+	public function testBulkSoftDeleteIsRefusedAsWell(): void {
+		$this->stubOnePopulatedTable($this->makeSchema(archival: true));
+
+		$this->magicMapper->expects($this->never())->method('deleteObjectsBySchema');
+
+		$this->expectException(ArchivalImmutableException::class);
+
+		$this->service->deleteObjectsBySchema(
+			registerId: self::REGISTER_ID,
+			schemaId: self::SCHEMA_ID,
+			hardDelete: false
+		);
+
+	}//end testBulkSoftDeleteIsRefusedAsWell()
+
+	/**
+	 * An ordinary schema is untouched by the gate.
+	 *
+	 * @return void
+	 */
+	public function testBulkDeleteStillWorksForANonArchivalSchema(): void {
+		$this->stubOnePopulatedTable($this->makeSchema(archival: false));
+
+		$result = $this->service->deleteObjectsBySchema(
+			registerId: self::REGISTER_ID,
+			schemaId: self::SCHEMA_ID,
+			hardDelete: true
+		);
+
+		$this->assertSame(1, $result['deleted_count']);
+		$this->assertSame(['90f1e160-c2fc-4829-9833-13c07769734b'], $result['deleted_uuids']);
+
+	}//end testBulkDeleteStillWorksForANonArchivalSchema()
+
+	/**
+	 * The cascade refuses an archival schema, and refuses BEFORE opening a transaction.
+	 *
+	 * Nothing is audited, no row is removed, no table is dropped and the schema
+	 * entity survives — the reproduction on `development` did all four.
+	 *
+	 * @return void
+	 */
+	public function testCascadeRefusesAnArchivalSchema(): void {
+		$schema = $this->makeSchema(archival: true);
+		$this->stubOnePopulatedTable($schema);
+
+		$this->db->expects($this->never())->method('beginTransaction');
+		$this->magicMapper->expects($this->never())->method('deleteObjectsBySchema');
+		$this->magicMapper->expects($this->never())->method('dropTable');
+		$this->schemaMapper->expects($this->never())->method('delete');
+
+		$this->expectException(ArchivalImmutableException::class);
+
+		$this->service->cascadeDeleteSchema(schema: $schema);
+
+	}//end testCascadeRefusesAnArchivalSchema()
+
+	/**
+	 * The cascade proceeds when an operator authorises it explicitly.
+	 *
+	 * `occ openregister:schemas:prune-retired --force-archival` is the only caller
+	 * that passes this; the HTTP cascade never does.
+	 *
+	 * @return void
+	 */
+	public function testCascadeProceedsWithAnExplicitArchivalOverride(): void {
+		$schema = $this->makeSchema(archival: true);
+		$this->stubOnePopulatedTable($schema);
+
+		$this->magicMapper->expects($this->once())->method('dropTable');
+		$this->schemaMapper->expects($this->once())->method('delete');
+
+		$result = $this->service->cascadeDeleteSchema(schema: $schema, archivalOverride: true);
+
+		$this->assertSame(1, $result['deletedCount']);
+		$this->assertTrue($result['tableDropped']);
+
+	}//end testCascadeProceedsWithAnExplicitArchivalOverride()
+
+	/**
+	 * The override defaults to off, so a caller that says nothing gets the refusal.
+	 *
+	 * A default-on override would make every future call site permissive by silence,
+	 * which is exactly how this door came to be open.
+	 *
+	 * @return void
+	 */
+	public function testTheArchivalOverrideIsOffByDefault(): void {
+		$reflection = new ReflectionClass(SchemaDeletionService::class);
+		$parameters = $reflection->getMethod('cascadeDeleteSchema')->getParameters();
+
+		$this->assertSame('archivalOverride', $parameters[1]->getName());
+		$this->assertTrue($parameters[1]->isDefaultValueAvailable());
+		$this->assertFalse($parameters[1]->getDefaultValue());
+
+	}//end testTheArchivalOverrideIsOffByDefault()
+
+	/**
+	 * The bulk path has NO override parameter at all.
+	 *
+	 * Its only two callers are HTTP routes, and an override they could pass through
+	 * would put archival destruction back on the network.
+	 *
+	 * @return void
+	 */
+	public function testTheBulkPathExposesNoArchivalOverride(): void {
+		$reflection = new ReflectionClass(SchemaDeletionService::class);
+		$names = array_map(
+			static fn ($parameter) => $parameter->getName(),
+			$reflection->getMethod('deleteObjectsBySchema')->getParameters()
+		);
+
+		$this->assertNotContains('archivalOverride', $names);
+
+	}//end testTheBulkPathExposesNoArchivalOverride()
+
+	/**
+	 * The cascade still runs for an ordinary schema.
+	 *
+	 * @return void
+	 */
+	public function testCascadeStillWorksForANonArchivalSchema(): void {
+		$schema = $this->makeSchema(archival: false);
+		$this->stubOnePopulatedTable($schema);
+
+		$result = $this->service->cascadeDeleteSchema(schema: $schema);
+
+		$this->assertSame(1, $result['deletedCount']);
+		$this->assertSame(['90f1e160-c2fc-4829-9833-13c07769734b'], $result['deletedUuids']);
+
+	}//end testCascadeStillWorksForANonArchivalSchema()
+
+	/**
+	 * A malformed annotation is not an archival declaration, and must not become one.
+	 *
+	 * `Schema::hasArchivalAnnotation()` requires an ARRAY value; `true` is a typo, not
+	 * a retention policy. Pinning it here keeps this gate from drifting into a looser
+	 * reading than the other three doors use.
+	 *
+	 * @return void
+	 */
+	public function testAMalformedAnnotationDoesNotGateTheDelete(): void {
+		$schema = $this->makeEntity(new Schema(), self::SCHEMA_ID);
+		$schema->setSlug('retained-case');
+		$schema->setConfiguration(['x-openregister-archival' => true]);
+		$this->stubOnePopulatedTable($schema);
+
+		$result = $this->service->deleteObjectsBySchema(
+			registerId: self::REGISTER_ID,
+			schemaId: self::SCHEMA_ID,
+			hardDelete: true
+		);
+
+		$this->assertSame(1, $result['deleted_count']);
+
+	}//end testAMalformedAnnotationDoesNotGateTheDelete()
+}//end class


### PR DESCRIPTION
## What changed

openregister#3428 closed the data-destruction bug this suite's teardown was standing on, so the teardown moves to the path that PR shipped alongside the fix.

dossiq#1824 removed archival fixture cases by calling `DELETE /api/deleted/{uuid}` on a **live** row, and said so in `purgeObject`'s docblock rather than pretending it was a contract: `DeletedController::destroy` guarded with `getDeleted() === null` while `ObjectEntity::$deleted` defaults to `[]`, so the guard never fired and the trash endpoint destroyed archival records the object API refuses. The note ended by pointing at the verification that would make the transition loud: `cleanupRunObjects` throws naming every survivor, so a sweep that removes nothing can never report a clean sweep.

Measured on the rig before changing anything, on a `dossiq/case`:

| call | status |
|---|---|
| `DELETE /api/objects/dossiq/case/{uuid}` | 403 |
| `DELETE /api/deleted/{uuid}` | 403 |
| `GET /api/objects/dossiq/case/{uuid}` after both | **200 — the case is still there** |
| `occ openregister:objects:purge {uuid} --force --apply` then GET | **404 — gone** |

That is the transition #1826 predicted, reproduced. Both doors are shut and the sanctioned one opens.

## How the suite reaches occ

`tests/e2e/helpers/occ.ts` is the one place that knows. Resolution order:

1. **`DOSSIQ_E2E_OCC`** — a complete command prefix, e.g. `docker compose -p dq-e2e exec -T -u www-data nextcloud php occ`. The escape hatch for any rig shape, and it always wins.
2. **`NEXTCLOUD_CONTAINER`** — a container name, becoming `docker exec -u www-data <name> php occ`. The common developer-rig case, and what these runs used.
3. **`php occ` from the Nextcloud server root** — `NEXTCLOUD_ROOT` when set, otherwise two directories above the app, which is the server root both on CI (`server/apps/dossiq`) and in the docker dev images (`server/apps-extra/dossiq`). This is the CI case: the shared workflow serves Nextcloud with `php -S` on the runner itself and `ci-seed.sh` already runs `php occ` exactly that way.

The reachability probe is `openregister:objects:purge --help`, not `status`, so "occ works" and "this OpenRegister has the purge command" are one answer rather than two. An instance older than #3428 fails it with Symfony's own "command is not defined", which names the real problem instead of a missing fixture.

**Where it cannot reach occ, the run fails before it has seeded anything.** `global-setup.ts` calls the probe ahead of the browser launch and throws with what it tried and what to set. Proven by running the suite with no occ variables set:

```
OccUnavailableError: The e2e suite cannot run `occ` against the instance under test, so it
cannot remove the cases it creates.
Tried:
  - no candidate invocation was even configured
Set one of:
  DOSSIQ_E2E_OCC="docker compose -p <project> exec -T -u www-data nextcloud php occ"
  NEXTCLOUD_CONTAINER=<container name>
  NEXTCLOUD_ROOT=/path/to/nextcloud
```

Exit 1, zero specs collected. It does not quietly leave fixtures behind: a teardown that cannot remove a case poisons every later run on the instance, which is the failure #1824 existed to end. An `OccUnavailableError` raised mid-sweep is rethrown rather than counted as a survivor, so it aborts once instead of being reported per fixture as though each row had individually resisted.

## What #1824 established, unchanged

- **`purgeObject` verifies and returns what it verified.** No status is trusted — not the two HTTP codes, and not the command's exit code, which is 1 for a uuid that is merely already gone. The answer comes from re-reading the object, and an unreadable answer counts as "still there".
- **`cleanupRunObjects` still throws naming every survivor.**
- **`global-setup.ts` still clears earlier runs' residue by the `E2EZAAK-` prefix.**

The CLI is reached ONLY when the HTTP pair did not manage it, so an ordinary non-archival fixture row still costs no process spawn. `sweepTrash` gets the same fallback in one batched invocation: a row an older rig soft-deleted before #3428 landed can no longer leave through HTTP either.

The docblock note describing the defect is gone, replaced by the contract that replaced it, and the two spec comments that repeated it are corrected — leaving them would read as licence to reach for the HTTP endpoint again.

## Verified locally (CI is bottlenecked; judged by exit code)

Own throwaway rig: `docker compose -p dq-purge` on :8677, `nextcloud:34-apache` + postgres, `firstrunwizard` disabled, OpenRegister built from `development` at `c715bb4` (the #3428 merge). The purge command was confirmed present in the **installed** tree, not inferred from a release title: `php occ openregister:objects:purge --help` exits 0 and prints `--force` and `--apply`.

**The suite twice on one rig, no reset between:**

| | run 1 | run 2 |
|---|---|---|
| result | **171 passed, 43 skipped, 0 failed** | **171 passed, 43 skipped, 0 failed** |
| exit code | 0 | 0 |
| wall clock | 27.4m | 26.0m |
| `E2EZAAK-` residue after, live + trash | **0 + 0** | **0 + 0** |

Not just the tallies: the per-test outcome list, all 214 entries, is byte-identical between the two runs. Both matched dossiq#1824's numbers exactly.

**A third run on the same rig after rebasing onto `development`** (so the tree carries dossiq#1827's workflow variants), redeployed and re-seeded: RUN3_RESULT

- `npm run lint` (`eslint src tests scripts`) — exit 0.
- `npx prettier --check` on every changed file — exit 0.

Fixes #1826

🤖 Generated with [Claude Code](https://claude.com/claude-code)
