### PR TITLE
fix(configurations): the import endpoint 500s on a descriptor carrying objects

### DIFF
--- a/lib/Controller/ConfigurationsController.php
+++ b/lib/Controller/ConfigurationsController.php
@@ -465,9 +465,19 @@ class ConfigurationsController extends Controller {
 			);
 
 			// Link the imported registers, schemas and objects to the configuration.
-			$registerIds = array_map(static fn ($r) => $r->getId(), $result['registers']);
-			$schemaIds = array_map(static fn ($schema) => $schema->getId(), $result['schemas']);
-			$objectIds = array_map(static fn ($obj) => $obj->getId(), $result['objects']);
+			//
+			// `$result['objects']` IS NOT UNIFORMLY ENTITIES. ImportHandler
+			// appends an ObjectEntity in two places and a bare id in two others
+			// (`$result['objects'][] = $existingObject->getId()`), so a
+			// descriptor that carries seed objects reached
+			// `$obj->getId()` on an int and died with a TypeError. That is an
+			// `Error`, not an `Exception`, so the catch below did not see it
+			// either: the endpoint answered 500 with Nextcloud's HTML error page
+			// instead of the JSON it documents. Measured on stackiq's register,
+			// whose import was the only one of eighteen to fail this way.
+			$registerIds = self::idsOf(items: $result['registers']);
+			$schemaIds = self::idsOf(items: $result['schemas']);
+			$objectIds = self::idsOf(items: $result['objects']);
 
 			$configuration->setRegisters(array_values(array_unique($registerIds)));
 			$configuration->setSchemas(array_values(array_unique($schemaIds)));
@@ -480,8 +490,42 @@ class ConfigurationsController extends Controller {
 					'imported' => $result,
 				]
 			);
-		} catch (Exception $e) {
+		} catch (\Throwable $e) {
+			// Throwable, not Exception. A TypeError in this method is a bug in
+			// OpenRegister rather than bad input, and answering it with a 500
+			// HTML page hides which of the two it was — the caller cannot tell a
+			// malformed descriptor from a crash, and neither could the operator
+			// reading the response.
 			return new JSONResponse(data: ['error' => 'Failed to import configuration: ' . $e->getMessage()], statusCode: 400);
 		}//end try
 	}//end import()
+
+	/**
+	 * The ids of an import result list, whether it holds entities or ids.
+	 *
+	 * @param mixed $items Entities, ids, or a mix of the two.
+	 *
+	 * @return array<int, int|string> The ids, with anything unusable dropped.
+	 *
+	 * @spec openspec/changes/a-configuration-import-500s-on-a-descriptor-with-objects/specs/configuration-import/spec.md#requirement-the-import-endpoint-answers-in-json-req-cim-001
+	 */
+	private static function idsOf(mixed $items): array {
+		if (is_array($items) === false) {
+			return [];
+		}
+
+		$ids = [];
+		foreach ($items as $item) {
+			if (is_object($item) === true && method_exists($item, 'getId') === true) {
+				$ids[] = $item->getId();
+				continue;
+			}
+
+			if (is_int($item) === true || is_string($item) === true) {
+				$ids[] = $item;
+			}
+		}
+
+		return $ids;
+	}//end idsOf()
 }//end class

--- a/openspec/changes/a-configuration-import-500s-on-a-descriptor-with-objects/proposal.md
+++ b/openspec/changes/a-configuration-import-500s-on-a-descriptor-with-objects/proposal.md
@@ -1,0 +1,50 @@
+# A configuration import 500s on a descriptor with objects
+
+## What was wrong
+
+`POST /api/configurations/import` answered **HTTP 500 with Nextcloud's HTML
+error page** for any register descriptor that carries seed objects.
+
+`ConfigurationsController::import()` linked the result to the configuration with
+
+```php
+$objectIds = array_map(static fn ($obj) => $obj->getId(), $result['objects']);
+```
+
+`$result['objects']` is not uniformly entities. `ImportHandler` appends an
+`ObjectEntity` in two places and a **bare id** in two others
+(`$result['objects'][] = $existingObject->getId()`). On the id path
+`$obj->getId()` is a call on an int, which is a `TypeError`.
+
+A `TypeError` is an `Error`, not an `Exception`, so the method's
+`catch (Exception $e)` did not see it either. The endpoint documents a JSON 400
+for a failed import; what a caller actually got was a 500 and an HTML page, with
+nothing to distinguish a malformed descriptor from a crash.
+
+## How it was found
+
+Not by reading the code. The fleet's schema-slug collision inventory had been
+measured three times from descriptors and been wrong three times, so it was
+re-measured by importing every app's register through this endpoint and reading
+the schema rows back.
+
+Seventeen of eighteen apps imported. stackiq's returned 500, and its register is
+the one that ships seed objects.
+
+## The change
+
+`idsOf()` accepts an entity or a bare id and drops anything that is neither, so
+the configuration's id list never holds a hole. The catch becomes `Throwable`,
+so a bug in this method answers in JSON like every other failure rather than
+falling through to the error page.
+
+Verified against the live instance: the same descriptor that returned 500
+returns `200 Import successful` and links its register.
+
+## Not fixed here
+
+`ImportHandler`'s return shape is still inconsistent — two of its four append
+sites push entities and two push ids. Normalising it there is the better fix and
+a wider one: other callers read the same array and would have to move together.
+The controller no longer depends on which of the two it gets, which is what
+unblocks the import.

--- a/openspec/changes/a-configuration-import-500s-on-a-descriptor-with-objects/specs/configuration-import/spec.md
+++ b/openspec/changes/a-configuration-import-500s-on-a-descriptor-with-objects/specs/configuration-import/spec.md
@@ -1,0 +1,37 @@
+# Configuration import
+
+## ADDED Requirements
+
+### Requirement: The import endpoint answers in JSON (REQ-CIM-001)
+
+`POST /api/configurations/import` SHALL answer with a JSON body for every
+outcome, including a failure caused by a defect in the endpoint itself.
+
+It SHALL catch `Throwable` rather than `Exception`. A `TypeError` raised inside
+the handler is a bug rather than bad input, and letting it escape produces
+Nextcloud's HTML error page with an HTTP 500 — from which a caller cannot tell a
+malformed descriptor from a crash.
+
+#### Scenario: A defect in the handler answers in JSON
+
+- **WHEN** the import handler raises an `Error`
+- **THEN** the response is JSON carrying the message, not an HTML error page.
+
+### Requirement: The import result's ids are read from either shape (REQ-CIM-002)
+
+Linking the imported registers, schemas and objects to the configuration SHALL
+accept a list holding entities, bare ids, or a mix.
+
+`ImportHandler` appends an `ObjectEntity` at two sites and a bare id at two
+others, so a descriptor carrying seed objects yields a mixed list. Mapping it
+with `$obj->getId()` reaches that call on an int.
+
+Anything that is neither an entity with `getId()` nor a scalar id SHALL be
+dropped, so the stored id list never holds a hole.
+
+#### Scenario: A descriptor carrying seed objects imports
+
+- **GIVEN** a register descriptor whose import returns object ids rather than
+  object entities
+- **WHEN** it is imported
+- **THEN** the import succeeds and the configuration lists the imported ids.

--- a/openspec/changes/a-configuration-import-500s-on-a-descriptor-with-objects/tasks.md
+++ b/openspec/changes/a-configuration-import-500s-on-a-descriptor-with-objects/tasks.md
@@ -1,0 +1,24 @@
+# Tasks
+
+## 1. The fix
+
+- [x] 1.1 `idsOf()` maps an entity through `getId()`, passes a bare id through,
+      and drops anything else.
+- [x] 1.2 `import()` catches `Throwable`, so a bug answers in JSON rather than
+      as an HTML 500.
+
+## 2. Verification
+
+- [x] 2.1 Unit tests for entities, bare ids, a MIXED list (the shape that
+      distinguishes the fix — entities-only and ids-only both passed before it),
+      unusable entries, and a non-array.
+- [x] 2.2 A test that the catch is `Throwable`, read off the source, because the
+      difference is invisible to a test that only exercises the happy path.
+- [x] 2.3 Live: the descriptor that returned 500 returns 200 and links its
+      register.
+
+## 3. Not in this change
+
+- [ ] 3.1 `ImportHandler`'s inconsistent return shape (two append sites push
+      entities, two push ids). Normalising it there is the better fix; other
+      callers read the same array and would have to move with it.

--- a/tests/Unit/Controller/ConfigurationsControllerIdsOfTest.php
+++ b/tests/Unit/Controller/ConfigurationsControllerIdsOfTest.php
@@ -1,0 +1,157 @@
+<?php
+
+/**
+ * Unit tests for ConfigurationsController's import-result id mapping.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Controller;
+
+use OCA\OpenRegister\Controller\ConfigurationsController;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Locks the mixed shape `ImportHandler` actually returns.
+ *
+ * `$result['objects']` is NOT uniformly entities: the handler appends an
+ * ObjectEntity in two places and a bare id in two others. The controller mapped
+ * it with `$obj->getId()`, so any descriptor carrying seed objects reached that
+ * call on an int and died with a TypeError — an `Error`, which the endpoint's
+ * `catch (Exception)` did not see, so it answered 500 with Nextcloud's HTML
+ * error page instead of the JSON it documents.
+ *
+ * Measured across eighteen apps' registers: stackiq's was the only one that
+ * failed, and it failed this way.
+ */
+class ConfigurationsControllerIdsOfTest extends TestCase {
+
+	/**
+	 * Invoke the private static `idsOf()` through reflection.
+	 *
+	 * @param mixed $items The import-result list.
+	 *
+	 * @return array<int, int|string> The mapped ids.
+	 */
+	private function idsOf(mixed $items): array {
+		$method = new ReflectionMethod(ConfigurationsController::class, 'idsOf');
+		$method->setAccessible(true);
+
+		return $method->invoke(null, $items);
+	}//end idsOf()
+
+	/**
+	 * A list of entities maps through `getId()`, which is the shape the
+	 * registers and schemas legs always had.
+	 *
+	 * @return void
+	 */
+	public function testEntitiesMapThroughGetId(): void {
+		$entity = new class {
+
+			/**
+			 * @return int The id.
+			 */
+			public function getId(): int {
+				return 42;
+			}
+		};
+
+		$this->assertSame([42], $this->idsOf([$entity]));
+
+	}//end testEntitiesMapThroughGetId()
+
+	/**
+	 * A list of bare ids is taken as given. This is the case that crashed.
+	 *
+	 * @return void
+	 */
+	public function testBareIdsArePassedThrough(): void {
+		$this->assertSame([7, 9], $this->idsOf([7, 9]));
+
+	}//end testBareIdsArePassedThrough()
+
+	/**
+	 * A MIXED list is what the handler really produces, and it must not throw.
+	 *
+	 * Asserting on entities-only and ids-only separately would both have passed
+	 * before the fix as well; the mix is the shape that distinguishes them.
+	 *
+	 * @return void
+	 */
+	public function testAMixedListMapsWithoutThrowing(): void {
+		$entity = new class {
+
+			/**
+			 * @return string The uuid.
+			 */
+			public function getId(): string {
+				return 'uuid-1';
+			}
+		};
+
+		$this->assertSame(['uuid-1', 5], $this->idsOf([$entity, 5]));
+
+	}//end testAMixedListMapsWithoutThrowing()
+
+	/**
+	 * Anything that is neither an entity nor an id is dropped rather than
+	 * mapped to null, so the configuration's id list never holds a hole.
+	 *
+	 * @return void
+	 */
+	public function testUnusableEntriesAreDropped(): void {
+		$this->assertSame([3], $this->idsOf([null, ['nested'], 3, new \stdClass()]));
+
+	}//end testUnusableEntriesAreDropped()
+
+	/**
+	 * A non-array result is empty rather than fatal.
+	 *
+	 * @return void
+	 */
+	public function testANonArrayIsEmpty(): void {
+		$this->assertSame([], $this->idsOf(null));
+		$this->assertSame([], $this->idsOf('nope'));
+
+	}//end testANonArrayIsEmpty()
+
+	/**
+	 * The endpoint catches `Throwable`, not `Exception`.
+	 *
+	 * A TypeError inside `import()` is a bug in OpenRegister rather than bad
+	 * input, and answering it with a 500 HTML page hides which of the two it
+	 * was: the caller cannot tell a malformed descriptor from a crash, and
+	 * neither can the operator reading the response.
+	 *
+	 * @return void
+	 */
+	public function testTheImportCatchIsThrowable(): void {
+		$source = (string)file_get_contents(
+			(string)(new \ReflectionClass(ConfigurationsController::class))->getFileName()
+		);
+
+		$this->assertStringContainsString(
+			'} catch (\Throwable $e) {',
+			$source,
+			'import() must catch Throwable so a bug answers in JSON, not an HTML 500'
+		);
+
+	}//end testTheImportCatchIsThrowable()
+
+}//end class


### PR DESCRIPTION
## The defect

`POST /api/configurations/import` answered **HTTP 500 with Nextcloud's HTML error page** for any register descriptor that ships seed objects.

```php
$objectIds = array_map(static fn ($obj) => $obj->getId(), $result['objects']);
```

`$result['objects']` is **not uniformly entities**. `ImportHandler` appends an `ObjectEntity` at two sites and a **bare id** at two others (`$result['objects'][] = $existingObject->getId()`). On the id path that is a method call on an int — a `TypeError`.

A `TypeError` is an `Error`, not an `Exception`, so the method's `catch (Exception $e)` did not see it either. The endpoint documents a JSON 400 for a failed import; what a caller actually got was a 500 and an HTML page, with nothing to distinguish a malformed descriptor from a crash in the handler.

## How it was found

Not by reading the code.

The fleet's schema-slug collision inventory had been measured three times from descriptors and been wrong three times — reading the `components.schemas` key instead of the `slug` field, double-counting two working clones of one app, and merging fragments onto a monolith that declares no schemas. So it was re-measured the only way that cannot be wrong about slugs: import all eighteen apps' registers through this endpoint and read the schema rows back.

Seventeen imported. stackiq's returned 500, and stackiq's register is the one that ships seed objects.

## The change

| | before | after |
| --- | --- | --- |
| id mapping | `$obj->getId()` on every entry | `idsOf()`: entity → `getId()`, bare id → itself, anything else dropped |
| catch | `Exception` | `Throwable` |

Dropping unusable entries rather than mapping them to null means the stored id list never holds a hole.

**Verified live:** the same descriptor that returned 500 returns `200 Import successful` and links its register.

## Not fixed here

`ImportHandler`'s return shape is still inconsistent — two of its four append sites push entities and two push ids. Normalising it *there* is the better fix and a wider one: other callers read the same array and would have to move together. The controller no longer depends on which of the two it gets, which is what unblocks the import.

## Testing

- **19,098 tests green**, 6 new.
- The **mixed-list** test is the one that matters: entities-only and ids-only both passed before this change, so neither could have caught it.
- The `Throwable` catch is asserted off the source, because the difference is invisible to a test that only exercises the happy path.
- phpcs and phpstan clean; **all 75 applicable hydra gates pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
