### PR TITLE
fix(gdpr): retention wins over erasure, and over the cascade

### DIFF
--- a/lib/BackgroundJob/AvgRetentionJob.php
+++ b/lib/BackgroundJob/AvgRetentionJob.php
@@ -142,6 +142,10 @@ class AvgRetentionJob extends TimedJob {
 					'evaluatedActivities' => $summary['evaluatedActivities'],
 					'skippedActivities' => $summary['skippedActivities'],
 					'objectsErased' => $summary['objectsErased'],
+					// A record the archival obligation kept must be visible from
+					// the cron log. Counting it as erased, or not counting it at
+					// all, is how a refusal turns back into a silent skip.
+					'objectsWithheld' => $summary['objectsWithheld'],
 				]
 			);
 		} catch (\Throwable $e) {

--- a/lib/BackgroundJob/DsarRetentionSweepJob.php
+++ b/lib/BackgroundJob/DsarRetentionSweepJob.php
@@ -141,6 +141,9 @@ class DsarRetentionSweepJob extends TimedJob {
 					'purgedCount' => count($summary['purged']),
 					'skippedHeld' => count($summary['skippedHeld']),
 					'withinWindow' => $summary['withinWindow'],
+					// Cases the archival obligation kept. Without this the sweep
+					// log reads as if they simply were not due.
+					'withheldCount' => $summary['withheldCount'],
 				]
 			);
 		} catch (\Throwable $e) {

--- a/lib/Service/Archival/ArchivalRetentionGuard.php
+++ b/lib/Service/Archival/ArchivalRetentionGuard.php
@@ -1,0 +1,332 @@
+<?php
+
+/**
+ * OpenRegister ArchivalRetentionGuard
+ *
+ * The consumer side of the archival-immutability rule for the paths that do
+ * NOT delete through a controller: the GDPR/AVG erasure services and the
+ * referential-integrity cascade.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Archival
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Archival;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Decide whether a record is retained, and say so in words a handler can use.
+ *
+ * RETENTION WINS OVER ERASURE. A record on a schema declaring
+ * `x-openregister-archival` is held under a legal obligation, and an erasure
+ * request does not lift that obligation: GDPR art. 17(3)(b) exempts processing
+ * required by law, and for a Dutch government record the Archiefwet is that law.
+ * So the erasure paths REFUSE the row, RECORD the refusal, and REPORT it back
+ * with the rest of the request's answer.
+ *
+ * The refusal is per row. A request over a mixed set still erases everything
+ * that is not retained: one held record must never block a lawful erasure of
+ * the others.
+ *
+ * FOUR DELETE DOORS ALREADY ASK THIS QUESTION — `objects#destroy`,
+ * `deleted#destroy`, `bulk#delete` and `bulk#deleteSchema` via
+ * {@see \OCA\OpenRegister\Service\SchemaDeletionService}. They ask it of
+ * {@see Schema::hasArchivalAnnotation()}, the single definition of "is
+ * archival". This guard is the fifth consumer of that same method, not a fifth
+ * definition of the rule: it does not re-read the annotation, and it does not
+ * restate the condition. Change the rule in one place and every door moves.
+ *
+ * FAILS CLOSED. A record whose schema cannot be resolved is refused, because an
+ * unresolvable schema is precisely the case where the annotation cannot be read
+ * and the record might be retained. That refusal is reported under its own
+ * ground so a handler can tell "the law holds this" from "we could not tell".
+ *
+ * @spec openspec/specs/archival-annotation-vocabulary/spec.md
+ */
+class ArchivalRetentionGuard {
+
+	/**
+	 * Ground: the record is retained under a legal archival obligation.
+	 *
+	 * @var string
+	 */
+	public const GROUND_ARCHIVAL = 'ARCHIVAL_RETENTION_OBLIGATION';
+
+	/**
+	 * Ground: the record's schema could not be resolved, so it was left alone.
+	 *
+	 * @var string
+	 */
+	public const GROUND_UNRESOLVED = 'SCHEMA_UNRESOLVED';
+
+	/**
+	 * Context: an erasure request reached this record.
+	 *
+	 * @var string
+	 */
+	public const CONTEXT_ERASURE = 'erasure';
+
+	/**
+	 * Context: a parent's delete cascaded onto this record.
+	 *
+	 * @var string
+	 */
+	public const CONTEXT_CASCADE = 'cascade';
+
+	/**
+	 * What each refusal says, per context and ground.
+	 *
+	 * This text reaches a citizen exercising a legal right, so it names the
+	 * obligation rather than the mechanism, and it ends on what happens next.
+	 *
+	 * @var array<string, array<string, array<string, string>>>
+	 */
+	private const WORDING = [
+		self::CONTEXT_ERASURE => [
+			self::GROUND_ARCHIVAL => [
+				'message' => 'The law requires us to keep this record, so we did not erase it.',
+				'basis' => 'GDPR art. 17(3)(b) and the Archiefwet.',
+				'action' => 'Name this record in your answer to the requester. '
+					. 'A records officer decides when it may be destroyed.',
+			],
+			self::GROUND_UNRESOLVED => [
+				'message' => 'We could not read the retention rules for this record, so we left it alone.',
+				'basis' => 'Precaution, because a retention rule we cannot read may be a legal one.',
+				'action' => 'Ask an administrator to repair the schema, then run the request again.',
+			],
+		],
+		self::CONTEXT_CASCADE => [
+			self::GROUND_ARCHIVAL => [
+				'message' => 'The law requires us to keep this record. Its parent is gone, this record stays.',
+				'basis' => 'GDPR art. 17(3)(b) and the Archiefwet.',
+				'action' => 'Point this record at a live parent, or record why the reference may dangle.',
+			],
+			self::GROUND_UNRESOLVED => [
+				'message' => 'We could not read the retention rules for this record, so we left it alone.',
+				'basis' => 'Precaution, because a retention rule we cannot read may be a legal one.',
+				'action' => 'Ask an administrator to repair the schema, then clean up this record by hand.',
+			],
+		],
+	];
+
+	/**
+	 * Memoised schema lookups, keyed by the raw schema identifier.
+	 *
+	 * Holds `false` for an identifier that could not be resolved, so a repeated
+	 * miss inside one request does not re-hit the mapper.
+	 *
+	 * @var array<string, Schema|false>
+	 */
+	private array $schemaMemo = [];
+
+	/**
+	 * Constructor.
+	 *
+	 * @param SchemaMapper $schemaMapper Schema reader, used unscoped (see resolveSchema()).
+	 * @param LoggerInterface $logger Logger.
+	 */
+	public function __construct(
+		private readonly SchemaMapper $schemaMapper,
+		private readonly LoggerInterface $logger,
+	) {
+	}//end __construct()
+
+	/**
+	 * Decide whether an erasure request may destroy this record.
+	 *
+	 * @param ObjectEntity $object The record an erasure request has reached.
+	 *
+	 * @return array<string, mixed>|null The withheld report, or null when the erasure may proceed.
+	 *
+	 * @spec openspec/specs/archival-annotation-vocabulary/spec.md
+	 */
+	public function erasureRefusal(ObjectEntity $object): ?array {
+		return $this->refusalFor(
+			uuid: (string)($object->getUuid() ?? ''),
+			schemaIdentifier: $object->getSchema(),
+			registerIdentifier: $object->getRegister(),
+			context: self::CONTEXT_ERASURE
+		);
+	}//end erasureRefusal()
+
+	/**
+	 * Decide whether a parent's delete may cascade onto this record.
+	 *
+	 * A RETAINED RECORD STAYS LIVE EVEN WHEN ITS PARENT GOES. The cascade skips
+	 * it and the parent delete still proceeds, so a retained child never blocks
+	 * the delete that reached it.
+	 *
+	 * @param string $uuid UUID of the cascade target.
+	 * @param string|int|null $schemaIdentifier Schema identifier carried on the cascade target.
+	 *
+	 * @return array<string, mixed>|null The retained report, or null when the cascade may proceed.
+	 *
+	 * @spec openspec/specs/archival-annotation-vocabulary/spec.md
+	 */
+	public function cascadeRefusal(string $uuid, string|int|null $schemaIdentifier): ?array {
+		return $this->refusalFor(
+			uuid: $uuid,
+			schemaIdentifier: $schemaIdentifier,
+			registerIdentifier: null,
+			context: self::CONTEXT_CASCADE
+		);
+	}//end cascadeRefusal()
+
+	/**
+	 * Build the refusal for one record, or null when it may be deleted.
+	 *
+	 * @param string $uuid Record UUID.
+	 * @param string|int|null $schemaIdentifier Schema identifier of the record.
+	 * @param string|int|null $registerIdentifier Register identifier of the record, when known.
+	 * @param string $context One of the CONTEXT_* constants.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	private function refusalFor(
+		string $uuid,
+		string|int|null $schemaIdentifier,
+		string|int|null $registerIdentifier,
+		string $context,
+	): ?array {
+		$schema = $this->resolveSchema(schemaIdentifier: $schemaIdentifier);
+
+		if ($schema === null) {
+			$this->logger->warning(
+				message: '[ArchivalRetentionGuard] Left a record alone because its schema could not be resolved',
+				context: [
+					'file' => __FILE__,
+					'line' => __LINE__,
+					'uuid' => $uuid,
+					'schema' => $schemaIdentifier,
+					'operation' => $context,
+				]
+			);
+
+			return $this->report(
+				uuid: $uuid,
+				schemaLabel: (string)($schemaIdentifier ?? 'unknown'),
+				registerIdentifier: $registerIdentifier,
+				ground: self::GROUND_UNRESOLVED,
+				context: $context
+			);
+		}
+
+		// THE SINGLE DEFINITION OF "IS ARCHIVAL", asked here and nowhere else in
+		// this class. Restating the condition is what let a test agree with
+		// itself in openregister#3428; this guard has no opinion of its own.
+		if ($schema->hasArchivalAnnotation() === false) {
+			return null;
+		}
+
+		return $this->report(
+			uuid: $uuid,
+			schemaLabel: ($schema->getSlug() ?? (string)$schema->getId()),
+			registerIdentifier: $registerIdentifier,
+			ground: self::GROUND_ARCHIVAL,
+			context: $context
+		);
+	}//end refusalFor()
+
+	/**
+	 * Resolve a schema identifier to its entity, unscoped and memoised.
+	 *
+	 * READ UNSCOPED, DELIBERATELY. Every caller here runs either as a cron with
+	 * no session or as a privacy officer sweeping across tenants, so an RBAC- or
+	 * tenant-scoped read would answer "not found" for a schema that plainly
+	 * exists. Since the guard fails closed, that miss would refuse every row in
+	 * the run and quietly stop the sweep.
+	 *
+	 * @param string|int|null $schemaIdentifier The raw identifier from the record.
+	 *
+	 * @return Schema|null The schema, or null when it cannot be resolved.
+	 */
+	private function resolveSchema(string|int|null $schemaIdentifier): ?Schema {
+		if ($schemaIdentifier === null || $schemaIdentifier === '' || $schemaIdentifier === 0) {
+			return null;
+		}
+
+		$key = (string)$schemaIdentifier;
+		if (array_key_exists($key, $this->schemaMemo) === true) {
+			$memo = $this->schemaMemo[$key];
+			if ($memo === false) {
+				return null;
+			}
+
+			return $memo;
+		}
+
+		try {
+			$schema = $this->schemaMapper->find(
+				$schemaIdentifier,
+				_rbac: false,
+				_multitenancy: false
+			);
+		} catch (\Throwable $e) {
+			$this->schemaMemo[$key] = false;
+			return null;
+		}
+
+		$this->schemaMemo[$key] = $schema;
+
+		return $schema;
+	}//end resolveSchema()
+
+	/**
+	 * Put the refusal into words a handler can pass on to the requester.
+	 *
+	 * The `message` answers the data subject: why the record is still there. The
+	 * `action` tells the handler what to do about it, because a refusal nobody
+	 * acts on is the same as a silent skip.
+	 *
+	 * @param string $uuid Record UUID.
+	 * @param string $schemaLabel Schema slug or identifier to name in the report.
+	 * @param string|int|null $registerIdentifier Register identifier, when known.
+	 * @param string $ground One of the GROUND_* constants.
+	 * @param string $context One of the CONTEXT_* constants.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function report(
+		string $uuid,
+		string $schemaLabel,
+		string|int|null $registerIdentifier,
+		string $ground,
+		string $context,
+	): array {
+		$wording = self::WORDING[$context][$ground];
+
+		$report = [
+			'uuid' => $uuid,
+			'schema' => $schemaLabel,
+			'ground' => $ground,
+			'operation' => $context,
+			'message' => $wording['message'],
+			'basis' => $wording['basis'],
+			'action' => $wording['action'],
+		];
+
+		if ($registerIdentifier !== null && $registerIdentifier !== '') {
+			$report['register'] = (string)$registerIdentifier;
+		}
+
+		return $report;
+	}//end report()
+
+}//end class

--- a/lib/Service/AvgRetentionService.php
+++ b/lib/Service/AvgRetentionService.php
@@ -44,6 +44,7 @@ use OCA\OpenRegister\Db\MagicMapper;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\Verwerkingsactiviteit;
 use OCA\OpenRegister\Db\VerwerkingsactiviteitMapper;
+use OCA\OpenRegister\Service\Archival\ArchivalRetentionGuard;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
@@ -51,6 +52,10 @@ use Psr\Log\LoggerInterface;
 
 /**
  * Retention-period-driven object retention enforcement.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) One over, from the archival
+ * retention guard: the pass must ask whether a record is legally retained
+ * before it erases it, and that question has one owner.
  */
 class AvgRetentionService {
 	/**
@@ -60,6 +65,7 @@ class AvgRetentionService {
 	 * @param VerwerkingsactiviteitMapper $vrwMapper Catalog reader.
 	 * @param MagicMapper $objectMapper Object loader.
 	 * @param LoggerInterface $logger Logger.
+	 * @param ArchivalRetentionGuard $archivalGuard Refuses erasure of a legally retained record.
 	 *
 	 * @spec openspec/specs/retention-management/spec.md
 	 */
@@ -68,6 +74,7 @@ class AvgRetentionService {
 		private readonly VerwerkingsactiviteitMapper $vrwMapper,
 		private readonly MagicMapper $objectMapper,
 		private readonly LoggerInterface $logger,
+		private readonly ArchivalRetentionGuard $archivalGuard,
 	) {
 
 	}//end __construct()
@@ -81,10 +88,17 @@ class AvgRetentionService {
 	 *     "evaluatedActivities": <int>,
 	 *     "skippedActivities":   <int>,
 	 *     "objectsErased":       <int>,
+	 *     "objectsWithheld":     <int>,
+	 *     "withheld": [
+	 *       {"uuid": "...", "schema": "...", "ground": "ARCHIVAL_RETENTION_OBLIGATION",
+	 *        "message": "...", "basis": "...", "action": "..."},
+	 *       ...
+	 *     ],
 	 *     "dryRun":              bool,
 	 *     "perActivity": [
 	 *       {"uuid": "...", "naam": "...", "bewaartermijn": "P10Y",
-	 *        "cutoff": "<iso>", "matchedObjects": <int>, "erased": <int>},
+	 *        "cutoff": "<iso>", "matchedObjects": <int>, "erased": <int>,
+	 *        "withheld": [...]},
 	 *       ...
 	 *     ]
 	 *   }
@@ -109,6 +123,11 @@ class AvgRetentionService {
 			'evaluatedActivities' => 0,
 			'skippedActivities' => 0,
 			'objectsErased' => 0,
+			// RETENTION WINS OVER ERASURE. The archival obligation on a schema
+			// outlives this activity's bewaartermijn, so those records are left
+			// live and named here rather than counted as erased.
+			'objectsWithheld' => 0,
+			'withheld' => [],
 			'dryRun' => $dryRun,
 			'perActivity' => [],
 		];
@@ -127,6 +146,8 @@ class AvgRetentionService {
 
 			$summary['evaluatedActivities']++;
 			$summary['objectsErased'] += $perActivity['erased'];
+			$summary['objectsWithheld'] += count($perActivity['withheld']);
+			$summary['withheld'] = array_merge($summary['withheld'], $perActivity['withheld']);
 			$summary['perActivity'][] = $perActivity;
 		}
 
@@ -169,11 +190,14 @@ class AvgRetentionService {
 		);
 
 		$erased = 0;
+		$withheld = [];
 		if ($dryRun === false && $candidates !== []) {
-			$erased = $this->erasePastRetention(
+			$outcome = $this->erasePastRetention(
 				candidates: $candidates,
 				activity: $activity
 			);
+			$erased = $outcome['erased'];
+			$withheld = $outcome['withheld'];
 		}
 
 		return [
@@ -183,6 +207,7 @@ class AvgRetentionService {
 			'cutoff' => $cutoff->format('c'),
 			'matchedObjects' => count($candidates),
 			'erased' => $erased,
+			'withheld' => $withheld,
 		];
 
 	}//end processActivity()
@@ -294,14 +319,24 @@ class AvgRetentionService {
 	 * erasures; failures are logged and skipped so a single bad
 	 * object doesn't abort the whole pass.
 	 *
+	 * RETENTION WINS OVER ERASURE. This pass enforces the verwerkingsregister's
+	 * bewaartermijn, which is shorter than the archival obligation a schema
+	 * declares with `x-openregister-archival`. When the two disagree the
+	 * archival obligation wins: the record is left live and named in `withheld`,
+	 * so an operator reading the run sees a record kept rather than one erased.
+	 * Withholding one record does not stop the pass.
+	 *
+	 * USED TO RETURN A BARE INT, which is why a withheld record could not be told
+	 * apart from an erased one: there was no per-object channel at all.
+	 *
 	 * @param array<int, array<string, mixed>> $candidates Overdue objects.
 	 * @param Verwerkingsactiviteit $activity Owning activity.
 	 *
-	 * @return int
+	 * @return array{erased: int, withheld: array<int, array<string, mixed>>}
 	 *
 	 * @spec openspec/specs/retention-management/spec.md
 	 */
-	private function erasePastRetention(array $candidates, Verwerkingsactiviteit $activity): int {
+	private function erasePastRetention(array $candidates, Verwerkingsactiviteit $activity): array {
 		// New writes use the renamed `retentionPeriod` key (verwerkingsregister-i18n); already
 		// -persisted historical `deleted` blobs keep their old `bewaartermijn` key unrewritten —
 		// they are point-in-time compliance-evidence snapshots (see design.md). The `reason` tag
@@ -316,9 +351,16 @@ class AvgRetentionService {
 		];
 
 		$erased = 0;
+		$withheld = [];
 		foreach ($candidates as $candidate) {
 			$object = $this->loadCandidate(candidate: $candidate);
 			if ($object === null) {
+				continue;
+			}
+
+			$refusal = $this->archivalGuard->erasureRefusal(object: $object);
+			if ($refusal !== null) {
+				$withheld[] = $refusal;
 				continue;
 			}
 
@@ -336,7 +378,10 @@ class AvgRetentionService {
 			}
 		}
 
-		return $erased;
+		return [
+			'erased' => $erased,
+			'withheld' => $withheld,
+		];
 	}//end erasePastRetention()
 
 	/**

--- a/lib/Service/DsarService.php
+++ b/lib/Service/DsarService.php
@@ -42,6 +42,7 @@ use DateTime;
 use OCA\OpenRegister\Db\MagicMapper;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\VerwerkingsactiviteitMapper;
+use OCA\OpenRegister\Service\Archival\ArchivalRetentionGuard;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IAppConfig;
 use OCP\IDBConnection;
@@ -103,6 +104,9 @@ class DsarService {
 	 * @param IGroupManager $groupManager Group manager used
 	 *                                    by the in-service
 	 *                                    admin guard.
+	 * @param ArchivalRetentionGuard $archivalGuard Refuses erasure of a legally
+	 *                                              retained record and puts the
+	 *                                              refusal into words.
 	 */
 	public function __construct(
 		private readonly IDBConnection $db,
@@ -112,6 +116,7 @@ class DsarService {
 		private readonly IUserSession $userSession,
 		private readonly LoggerInterface $logger,
 		private readonly IGroupManager $groupManager,
+		private readonly ArchivalRetentionGuard $archivalGuard,
 	) {
 
 	}//end __construct()
@@ -253,7 +258,26 @@ class DsarService {
 	 *       ['uuid' => '<object-uuid>', 'register' => '<...>', 'schema' => '<...>'],
 	 *       ...
 	 *     ],
+	 *     'withheld'     => [
+	 *       ['uuid' => '...', 'schema' => '...', 'ground' => 'ARCHIVAL_RETENTION_OBLIGATION',
+	 *        'message' => '...', 'basis' => '...', 'action' => '...'],
+	 *       ...
+	 *     ],
+	 *     'withheldCount' => <int>,
 	 *   ]
+	 *
+	 * RETENTION WINS OVER ERASURE. A record on a schema declaring
+	 * `x-openregister-archival` is kept under a legal obligation, and art-17(3)(b)
+	 * stands down for it. Those rows are refused, recorded and reported in
+	 * `withheld` with the ground and the wording to pass back to the data subject.
+	 * The refusal is decided by
+	 * {@see \OCA\OpenRegister\Service\Archival\ArchivalRetentionGuard}, which asks
+	 * {@see \OCA\OpenRegister\Db\Schema::hasArchivalAnnotation()}, the same single
+	 * definition the four HTTP delete doors already use.
+	 *
+	 * Withholding one record never blocks the rest: every non-archival match in
+	 * the same request is still erased. A run that withheld anything reports
+	 * `complete: false`, because the data is still there.
 	 *
 	 * @param string $subject Subject identifier.
 	 * @param string|null $type Optional GdprEntity type filter.
@@ -293,11 +317,17 @@ class DsarService {
 			// BUG-SVC-2: objects whose erasure failed are collected here so the
 			// caller can report a partial failure instead of a false "complete".
 			'failed' => [],
+			// RETENTION WINS OVER ERASURE: records held under an archival
+			// obligation are refused, named here, and reported back with the
+			// rest of the answer. A refusal the requester never sees is a
+			// silent skip, which is what this bucket exists to prevent.
+			'withheld' => [],
 		];
 
 		if ($dryRun === true || $entries === []) {
 			$summary['complete'] = true;
 			$summary['failedCount'] = 0;
+			$summary['withheldCount'] = 0;
 			return $summary;
 		}
 
@@ -311,52 +341,99 @@ class DsarService {
 		];
 
 		foreach ($entries as $entry) {
-			$object = $this->loadObjectByEntry(entry: $entry);
-			if ($object === null) {
-				// BUG-SVC-2: a matched object we cannot load was NOT erased —
-				// record it as a failure rather than silently skipping it.
-				$summary['failed'][] = [
-					'object' => $entry,
-					'error' => 'Object could not be loaded for erasure',
-				];
-				$this->logger->warning(
-					message: '[DSAR] Matched object could not be loaded during vergetelheid',
-					context: ['object' => $entry]
-				);
-				continue;
-			}
-
-			$object->setDeleted($deletionData);
-			if ($dsarActivityUuid !== null) {
-				$object->setProcessingActivityId($dsarActivityUuid);
-			}
-
-			try {
-				$this->objectMapper->update(entity: $object);
-				$summary['erased'][] = [
-					'uuid' => $object->getUuid(),
-					'register' => $object->getRegister(),
-					'schema' => $object->getSchema(),
-				];
-			} catch (\Throwable $e) {
-				$summary['failed'][] = [
-					'object' => $entry,
-					'error' => $e->getMessage(),
-				];
-				$this->logger->warning(
-					message: '[DSAR] Soft-delete failed during vergetelheid',
-					context: ['object' => $entry, 'error' => $e->getMessage()]
-				);
-			}
+			$this->eraseOneEntry(
+				entry: $entry,
+				deletionData: $deletionData,
+				dsarActivityUuid: $dsarActivityUuid,
+				summary: $summary
+			);
 		}//end foreach
 
 		// BUG-SVC-2: surface partial completion so callers don't treat a run
 		// with failures as a fully-successful erasure.
-		$summary['complete'] = ($summary['failed'] === []);
+		//
+		// A WITHHELD RECORD MAKES THE ERASURE INCOMPLETE, exactly as a failure
+		// does. The row is still there, so reporting `complete: true` would tell
+		// the data subject their data is gone while the law keeps it. The two
+		// counts stay separate because the answers differ: a failure is retried,
+		// a withheld record is explained.
+		$summary['complete'] = ($summary['failed'] === [] && $summary['withheld'] === []);
 		$summary['failedCount'] = count($summary['failed']);
+		$summary['withheldCount'] = count($summary['withheld']);
 
 		return $summary;
 	}//end eraseObjectsForSubject()
+
+	/**
+	 * Erase one matched object, or record why it was not erased.
+	 *
+	 * EVERY ENTRY LANDS IN EXACTLY ONE BUCKET of `$summary`: `erased`, `failed`
+	 * or `withheld`. An entry that reached none of them would be a match the
+	 * caller is never told about.
+	 *
+	 * @param array<string, mixed> $entry The deduped match (object_id / object_uuid).
+	 * @param array<string, mixed> $deletionData Soft-delete metadata to stamp.
+	 * @param string|null $dsarActivityUuid Configured DSAR activity, when set.
+	 * @param array<string, mixed> $summary Run summary, mutated in place.
+	 *
+	 * @return void
+	 */
+	private function eraseOneEntry(
+		array $entry,
+		array $deletionData,
+		?string $dsarActivityUuid,
+		array &$summary,
+	): void {
+		$object = $this->loadObjectByEntry(entry: $entry);
+		if ($object === null) {
+			// BUG-SVC-2: a matched object we cannot load was NOT erased —
+			// record it as a failure rather than silently skipping it.
+			$summary['failed'][] = [
+				'object' => $entry,
+				'error' => 'Object could not be loaded for erasure',
+			];
+			$this->logger->warning(
+				message: '[DSAR] Matched object could not be loaded during vergetelheid',
+				context: ['object' => $entry]
+			);
+			return;
+		}
+
+		// RETENTION WINS OVER ERASURE. Vergetelheid is art-17, and art-17(3)(b)
+		// stands down for processing the law requires: an archival record is
+		// kept, the refusal is recorded, and it travels back in `withheld` so
+		// the officer answering the data subject can name it. The refusal is
+		// per row, so every non-archival match in the same request is still
+		// erased.
+		$refusal = $this->archivalGuard->erasureRefusal(object: $object);
+		if ($refusal !== null) {
+			$summary['withheld'][] = $refusal;
+			return;
+		}
+
+		$object->setDeleted($deletionData);
+		if ($dsarActivityUuid !== null) {
+			$object->setProcessingActivityId($dsarActivityUuid);
+		}
+
+		try {
+			$this->objectMapper->update(entity: $object);
+			$summary['erased'][] = [
+				'uuid' => $object->getUuid(),
+				'register' => $object->getRegister(),
+				'schema' => $object->getSchema(),
+			];
+		} catch (\Throwable $e) {
+			$summary['failed'][] = [
+				'object' => $entry,
+				'error' => $e->getMessage(),
+			];
+			$this->logger->warning(
+				message: '[DSAR] Soft-delete failed during vergetelheid',
+				context: ['object' => $entry, 'error' => $e->getMessage()]
+			);
+		}
+	}//end eraseOneEntry()
 
 	/**
 	 * Build a dedup key for a relation hit row.

--- a/lib/Service/Gdpr/DataSubjectRequestService.php
+++ b/lib/Service/Gdpr/DataSubjectRequestService.php
@@ -55,6 +55,7 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use OCA\OpenRegister\Db\MagicMapper;
 use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\Archival\ArchivalRetentionGuard;
 use OCA\OpenRegister\Service\DsarService;
 use OCA\OpenRegister\Service\ObjectService;
 use OCA\OpenRegister\Service\RetentionService;
@@ -103,6 +104,7 @@ class DataSubjectRequestService {
 	 * @param DataSubjectDeadline $deadline EU art-12 deadline maths.
 	 * @param IUserSession $userSession Current user (erasure metadata).
 	 * @param LoggerInterface $logger Logger.
+	 * @param ArchivalRetentionGuard $archivalGuard Refuses erasure of a legally retained record.
 	 */
 	public function __construct(
 		private readonly IDBConnection $db,
@@ -113,6 +115,7 @@ class DataSubjectRequestService {
 		private readonly DataSubjectDeadline $deadline,
 		private readonly IUserSession $userSession,
 		private readonly LoggerInterface $logger,
+		private readonly ArchivalRetentionGuard $archivalGuard,
 	) {
 
 	}//end __construct()
@@ -238,6 +241,13 @@ class DataSubjectRequestService {
 	 * are NEVER erased; they are reported in the `held` bucket so the caller
 	 * can surface a partial result rather than a false "complete".
 	 *
+	 * RETENTION WINS OVER ERASURE. A record on a schema declaring
+	 * `x-openregister-archival` is held by the Archiefwet, and art-17(3)(b)
+	 * stands down for it. Those rows are refused and reported in `withheld`,
+	 * each carrying its ground, the sentence to pass back to the requester, and
+	 * what the handler does next. Withholding one record never blocks the rest
+	 * of the request.
+	 *
 	 * @param string $subjectId Subject identifier value.
 	 * @param string|null $type Optional GdprEntity type filter.
 	 * @param string $eraseMode One of the ERASE_MODE_* constants.
@@ -269,6 +279,10 @@ class DataSubjectRequestService {
 			'erased' => [],
 			'held' => [],
 			'failed' => [],
+			// RETENTION WINS OVER ERASURE: records the Archiefwet keeps are
+			// refused, named here with their ground, and reported back with the
+			// rest of the answer to the data subject.
+			'withheld' => [],
 		];
 
 		foreach ($grouped as $entry) {
@@ -278,6 +292,21 @@ class DataSubjectRequestService {
 					'object' => $this->refOf(entry: $entry),
 					'error' => 'Object could not be loaded (not found or not authorised)',
 				];
+				continue;
+			}
+
+			// RETENTION WINS OVER ERASURE, AND THE SCHEMA IS WHERE THE OBLIGATION
+			// LIVES. `retentionGuard()` below reads the OBJECT's own
+			// `retention.archiefstatus` and the legal hold on it; neither says
+			// anything about `x-openregister-archival`, which is declared on the
+			// SCHEMA. So a record on an archival schema that had not yet been
+			// stamped `vernietigd` or `overgebracht` was erased here, past the
+			// guard whose docblock claims to cover "immutable archival status".
+			// It is asked of Schema::hasArchivalAnnotation() now, through the same
+			// definition the four HTTP delete doors use.
+			$refusal = $this->archivalGuard->erasureRefusal(object: $object);
+			if ($refusal !== null) {
+				$summary['withheld'][] = $refusal;
 				continue;
 			}
 
@@ -305,9 +334,18 @@ class DataSubjectRequestService {
 			);
 		}//end foreach
 
-		$summary['complete'] = ($summary['failed'] === []);
+		// A RUN THAT KEPT DATA BACK IS NOT A COMPLETE ERASURE. `complete` used to
+		// mean "nothing errored", so a request that lawfully held every single
+		// record still answered `complete: true` and the data subject was told
+		// their data was gone. Held and withheld rows now count against it too.
+		// The buckets stay separate because the answers differ: `failed` is
+		// retried, `held` waits for the hold to lift, `withheld` is explained.
+		$summary['complete'] = ($summary['failed'] === []
+			&& $summary['held'] === []
+			&& $summary['withheld'] === []);
 		$summary['failedCount'] = count($summary['failed']);
 		$summary['heldCount'] = count($summary['held']);
+		$summary['withheldCount'] = count($summary['withheld']);
 
 		return $summary;
 	}//end erase()

--- a/lib/Service/Gdpr/DataSubjectRequestService.php
+++ b/lib/Service/Gdpr/DataSubjectRequestService.php
@@ -256,6 +256,8 @@ class DataSubjectRequestService {
 	 * @return array<string, mixed>
 	 *
 	 * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+	 *
+	 * @spec openspec/specs/gdpr-data-subject-rights/spec.md#requirement-erasure-honours-legal-hold-and-is-mode-parameterised
 	 */
 	public function erase(
 		string $subjectId,

--- a/lib/Service/Gdpr/Retention/RetentionSweepService.php
+++ b/lib/Service/Gdpr/Retention/RetentionSweepService.php
@@ -41,6 +41,7 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Service\Gdpr\Retention;
 
 use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\Archival\ArchivalRetentionGuard;
 use OCA\OpenRegister\Service\Gdpr\Case\CaseObjectAccessor;
 use OCA\OpenRegister\Service\Gdpr\DataSubjectRequestService;
 use OCA\OpenRegister\Service\RetentionService;
@@ -60,6 +61,7 @@ class RetentionSweepService {
 	 * @param DataSubjectRequestService $dsrService Reused evidence-PII scrub (erase pseudonymise).
 	 * @param ITimeFactory $time Time source for the `retainUntil` cut-off.
 	 * @param LoggerInterface $logger Logger.
+	 * @param ArchivalRetentionGuard $archivalGuard Refuses destruction of a legally retained case.
 	 */
 	public function __construct(
 		private readonly CaseObjectAccessor $accessor,
@@ -67,6 +69,7 @@ class RetentionSweepService {
 		private readonly DataSubjectRequestService $dsrService,
 		private readonly ITimeFactory $time,
 		private readonly LoggerInterface $logger,
+		private readonly ArchivalRetentionGuard $archivalGuard,
 	) {
 	}//end __construct()
 
@@ -78,9 +81,18 @@ class RetentionSweepService {
 	 * evidence PII via erase pseudonymise and hard-delete the dossier. Held or
 	 * immutable expired cases are reported as skipped and left intact.
 	 *
+	 * RETENTION WINS OVER ERASURE. A case on a schema declaring
+	 * `x-openregister-archival` is kept whatever its `retainUntil` says, and is
+	 * reported in `withheld` with the ground and the wording to pass on. The
+	 * refusal comes from
+	 * {@see \OCA\OpenRegister\Service\Archival\ArchivalRetentionGuard}, so it
+	 * reads the same definition as every other delete door.
+	 *
 	 * @param bool $dryRun When true, report candidates without deleting/scrubbing.
 	 *
-	 * @return array{dryRun: bool, evaluated: int, purged: array<int, string>, skippedHeld: array<int, string>, withinWindow: int}
+	 * @return array{dryRun: bool, evaluated: int, purged: array<int, string>,
+	 *               skippedHeld: array<int, string>, withinWindow: int,
+	 *               withheld: array<int, array<string, mixed>>, withheldCount: int}
 	 *
 	 * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Dry-run toggle mirrors AvgRetentionJob's contract.
 	 *
@@ -94,6 +106,9 @@ class RetentionSweepService {
 			'evaluated' => 0,
 			'purged' => [],
 			'skippedHeld' => [],
+			// RETENTION WINS OVER ERASURE: cases the Archiefwet keeps are named
+			// here with their ground, not silently swept.
+			'withheld' => [],
 			'withinWindow' => 0,
 		];
 
@@ -119,6 +134,22 @@ class RetentionSweepService {
 				continue;
 			}
 
+			// RETENTION WINS OVER ERASURE, AND THIS SWEEP HAD AN EXPLICIT BYPASS.
+			// `isProtected()` above reads the case's own legal hold and
+			// archiefstatus; it says nothing about `x-openregister-archival` on
+			// the case schema. Worse, the delete below hands
+			// `_retentionSweep: true` to ObjectService, which is exactly the flag
+			// that waves a row past the archival gate. So an archival case was
+			// hard-deleted here with no refusal anywhere in the chain. The gate is
+			// asked BEFORE the bypass is used, of the same
+			// Schema::hasArchivalAnnotation() the four HTTP doors ask. Refused
+			// cases are named in `withheld`; the rest of the sweep runs on.
+			$refusal = $this->archivalGuard->erasureRefusal(object: $case);
+			if ($refusal !== null) {
+				$summary['withheld'][] = $refusal;
+				continue;
+			}
+
 			if ($dryRun === true) {
 				$summary['purged'][] = $uuid;
 				continue;
@@ -127,6 +158,8 @@ class RetentionSweepService {
 			$this->purge(case: $case, data: $data);
 			$summary['purged'][] = $uuid;
 		}//end foreach
+
+		$summary['withheldCount'] = count($summary['withheld']);
 
 		return $summary;
 	}//end runSweep()

--- a/lib/Service/Object/DeleteObject.php
+++ b/lib/Service/Object/DeleteObject.php
@@ -81,6 +81,16 @@ class DeleteObject {
 	private int $lastCascadeCount = 0;
 
 	/**
+	 * Cascade targets the archival obligation kept live during the last root delete.
+	 *
+	 * Reset at the start of each root deleteObject() invocation, exactly like
+	 * $lastCascadeCount, so a reader never picks up a previous delete's answer.
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	private array $lastRetainedTargets = [];
+
+	/**
 	 * Audit trail mapper
 	 *
 	 * @var AuditTrailMapper
@@ -591,6 +601,7 @@ class DeleteObject {
 		// Reset cascade count for root deletions.
 		if ($originalObjectId === null) {
 			$this->lastCascadeCount = 0;
+			$this->lastRetainedTargets = [];
 		}
 
 		// Resolve the lookup: when the caller has guaranteed a (register, schema)
@@ -880,7 +891,7 @@ class DeleteObject {
 				$triggerSlug = $contextSchema->getSlug();
 			}
 
-			$this->integrityService->applyDeletionActions(
+			$integrityResult = $this->integrityService->applyDeletionActions(
 				$analysis,
 				$userId,
 				$uuid,
@@ -888,10 +899,18 @@ class DeleteObject {
 				$triggerSlug
 			);
 
-			$cCount = count($analysis->cascadeTargets);
+			// A RETAINED RECORD STAYS LIVE EVEN WHEN ITS PARENT GOES, so it is not
+			// a cascade casualty and must not be counted as one. The count used to
+			// be `count($analysis->cascadeTargets)`, the number of rows the
+			// analysis WANTED to delete, which is now a different number from the
+			// rows the cascade actually took. Reporting the analysis figure would
+			// tell a bulk caller that a record it can still see was deleted.
+			$this->lastRetainedTargets = $integrityResult['retained'];
+
+			$cCount = (count($analysis->cascadeTargets) - count($this->lastRetainedTargets));
 			$nCount = count($analysis->nullifyTargets);
 			$dCount = count($analysis->defaultTargets);
-			$this->lastCascadeCount = ($cCount + $nCount + $dCount);
+			$this->lastCascadeCount = (max(0, $cCount) + $nCount + $dCount);
 
 			$this->runLegacyCascade(context: $context, object: $object, uuid: $uuid);
 
@@ -1314,6 +1333,21 @@ class DeleteObject {
 	public function getLastCascadeCount(): int {
 		return $this->lastCascadeCount;
 	}//end getLastCascadeCount()
+
+	/**
+	 * Get the cascade targets the archival obligation kept live in the last root delete.
+	 *
+	 * The parent delete proceeded; these records did not go with it. Each entry
+	 * names the record, the ground it was kept on and what the reader does next,
+	 * so a caller can report the retention rather than leave it to a log line.
+	 *
+	 * @return array<int, array<string, mixed>> One report per retained record, empty when none.
+	 *
+	 * @spec openspec/specs/archival-annotation-vocabulary/spec.md
+	 */
+	public function getLastRetainedCascadeTargets(): array {
+		return $this->lastRetainedTargets;
+	}//end getLastRetainedCascadeTargets()
 
 	/**
 	 * Delegate a delete on an object-source schema to its writable provider.

--- a/lib/Service/Object/ReferentialIntegrityService.php
+++ b/lib/Service/Object/ReferentialIntegrityService.php
@@ -40,6 +40,7 @@ use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Dto\DeletionAnalysis;
+use OCA\OpenRegister\Service\Archival\ArchivalRetentionGuard;
 use OCP\ICacheFactory;
 use OCP\IDBConnection;
 use Psr\Log\LoggerInterface;
@@ -148,6 +149,7 @@ class ReferentialIntegrityService {
 	 * @param LoggerInterface $logger Logger for debugging.
 	 * @param IDBConnection $db Database connection for raw SQL queries.
 	 * @param ICacheFactory $cacheFactory Distributed cache for the relation index.
+	 * @param ArchivalRetentionGuard $archivalGuard Decides whether a cascade target is legally retained.
 	 *
 	 * @spec openspec/specs/object-lifecycle/spec.md
 	 */
@@ -159,6 +161,7 @@ class ReferentialIntegrityService {
 		private readonly LoggerInterface $logger,
 		private readonly IDBConnection $db,
 		private readonly ICacheFactory $cacheFactory,
+		private readonly ArchivalRetentionGuard $archivalGuard,
 	) {
 	}//end __construct()
 
@@ -201,7 +204,9 @@ class ReferentialIntegrityService {
 	 * @param string|null $organisationId The active organisation ID.
 	 * @param string|null $triggerSchemaSlug Slug of the schema of the deleted object (for audit trail).
 	 *
-	 * @return void
+	 * @return array{retained: array<int, array<string, mixed>>} The cascade targets the
+	 *               archival obligation kept live, each naming the record and the ground.
+	 *               Empty when nothing was retained.
 	 *
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity) Multiple action types require distinct handling paths
 	 *
@@ -213,7 +218,7 @@ class ReferentialIntegrityService {
 		string $cascadeSource,
 		?string $organisationId = null,
 		?string $triggerSchemaSlug = null,
-	): void {
+	): array {
 		// 1. Apply SET_NULL targets first (objects survive with cleared reference).
 		foreach ($analysis->nullifyTargets as $target) {
 			$this->applySetNull(target: $target);
@@ -255,6 +260,14 @@ class ReferentialIntegrityService {
 		// 3. Apply CASCADE targets in batch (deepest first = reverse order).
 		$cascadeTargets = array_reverse($analysis->cascadeTargets);
 
+		// A RETAINED RECORD STAYS LIVE EVEN WHEN ITS PARENT GOES. The batch below
+		// soft-deletes with `hardDelete: false`, so an archival child of a
+		// non-archival parent used to be tombstoned by a delete aimed at somebody
+		// else. It is kept out of the batch now and named in the return value,
+		// and the parent delete still proceeds: a retained child refuses the
+		// cascade, it does not block the delete that reached it.
+		[$cascadeTargets, $retained] = $this->partitionRetainedTargets(cascadeTargets: $cascadeTargets);
+
 		if (empty($cascadeTargets) === false) {
 			$this->applyBatchCascadeDelete(
 				cascadeTargets: $cascadeTargets,
@@ -264,7 +277,68 @@ class ReferentialIntegrityService {
 				organisationId: $organisationId
 			);
 		}
+
+		return ['retained' => $retained];
 	}//end applyDeletionActions()
+
+	/**
+	 * Split cascade targets into the ones that may be deleted and the ones the law keeps.
+	 *
+	 * Asks {@see ArchivalRetentionGuard}, which asks
+	 * {@see \OCA\OpenRegister\Db\Schema::hasArchivalAnnotation()}. That is the
+	 * single definition of "is archival" and the four HTTP delete doors read the
+	 * same one, so the cascade cannot quietly disagree with them.
+	 *
+	 * A target referenced through two properties appears twice in the analysis
+	 * and is reported once, keyed by uuid, so the caller's count matches the
+	 * number of records it can go and look at.
+	 *
+	 * @param array<int, array<string, mixed>> $cascadeTargets Targets, already reversed.
+	 *
+	 * @return array{0: array<int, array<string, mixed>>, 1: array<int, array<string, mixed>>}
+	 *               [0] targets the cascade may delete, [1] one report per retained record.
+	 *
+	 * @spec openspec/specs/archival-annotation-vocabulary/spec.md
+	 */
+	private function partitionRetainedTargets(array $cascadeTargets): array {
+		$proceed = [];
+		$reported = [];
+
+		foreach ($cascadeTargets as $target) {
+			$uuid = (string)($target['objectUuid'] ?? '');
+			if ($uuid === '') {
+				$proceed[] = $target;
+				continue;
+			}
+
+			if (isset($reported[$uuid]) === true) {
+				continue;
+			}
+
+			$refusal = $this->archivalGuard->cascadeRefusal(
+				uuid: $uuid,
+				schemaIdentifier: ($target['schema'] ?? null)
+			);
+			if ($refusal === null) {
+				$proceed[] = $target;
+				continue;
+			}
+
+			$reported[$uuid] = $refusal;
+			$this->logger->info(
+				message: '[ReferentialIntegrity] Kept a retained record out of a cascade',
+				context: [
+					'file' => __FILE__,
+					'line' => __LINE__,
+					'uuid' => $uuid,
+					'schema' => ($target['schema'] ?? null),
+					'ground' => $refusal['ground'],
+				]
+			);
+		}
+
+		return [$proceed, array_values($reported)];
+	}//end partitionRetainedTargets()
 
 	/**
 	 * Log a RESTRICT block event to the audit trail.

--- a/tests/Unit/Service/Archival/ArchivalRetentionGuardTest.php
+++ b/tests/Unit/Service/Archival/ArchivalRetentionGuardTest.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * ArchivalRetentionGuard unit tests.
+ *
+ * The guard is the fifth consumer of Schema::hasArchivalAnnotation(), not a
+ * fifth definition of the rule. These tests build REAL Schema entities and let
+ * the production predicate decide, so a guard that grew its own opinion of what
+ * "archival" means would fail here rather than agree with itself.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Archival
+ * @author   Conduction Development Team <dev@conduction.nl>
+ * @license  EUPL-1.2
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Archival;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Archival\ArchivalRetentionGuard;
+use OCP\AppFramework\Db\DoesNotExistException;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Test class for ArchivalRetentionGuard.
+ */
+class ArchivalRetentionGuardTest extends TestCase {
+
+	/**
+	 * Build a guard whose mapper answers with real Schema entities.
+	 *
+	 * @param array<string, bool> $schemas Map of schema identifier to "is archival".
+	 *
+	 * @return ArchivalRetentionGuard
+	 */
+	private function guard(array $schemas): ArchivalRetentionGuard {
+		$mapper = $this->createMock(SchemaMapper::class);
+		$mapper->method('find')->willReturnCallback(
+			static function ($id) use ($schemas): Schema {
+				$key = (string)$id;
+				if (array_key_exists($key, $schemas) === false) {
+					throw new DoesNotExistException('no such schema');
+				}
+
+				$schema = new Schema();
+				$schema->setSlug($key);
+				$configuration = [];
+				if ($schemas[$key] === true) {
+					$configuration['x-openregister-archival'] = ['retention' => ['default' => 'P10Y']];
+				}
+
+				$schema->setConfiguration($configuration);
+
+				return $schema;
+			}
+		);
+
+		return new ArchivalRetentionGuard($mapper, $this->createMock(LoggerInterface::class));
+	}//end guard()
+
+	/**
+	 * Build a record on a given schema.
+	 *
+	 * @param string $uuid Record uuid.
+	 * @param string $schema Schema identifier.
+	 *
+	 * @return ObjectEntity
+	 */
+	private function record(string $uuid, string $schema): ObjectEntity {
+		$object = new ObjectEntity();
+		$object->setUuid($uuid);
+		$object->setRegister('reg-1');
+		$object->setSchema($schema);
+
+		return $object;
+	}//end record()
+
+	/**
+	 * A record on an ordinary schema may be erased: no refusal.
+	 *
+	 * @return void
+	 */
+	public function testAnOrdinaryRecordIsNotRefused(): void {
+		$guard = $this->guard(['contact' => false]);
+
+		$this->assertNull($guard->erasureRefusal($this->record('u1', 'contact')));
+	}//end testAnOrdinaryRecordIsNotRefused()
+
+	/**
+	 * An archival record is refused, and the refusal says why and what to do.
+	 *
+	 * @return void
+	 */
+	public function testAnArchivalRecordIsRefusedWithAGroundAndAnAction(): void {
+		$guard = $this->guard(['besluit' => true]);
+
+		$refusal = $guard->erasureRefusal($this->record('u2', 'besluit'));
+
+		$this->assertNotNull($refusal);
+		$this->assertSame('u2', $refusal['uuid']);
+		$this->assertSame('besluit', $refusal['schema']);
+		$this->assertSame('reg-1', $refusal['register']);
+		$this->assertSame(ArchivalRetentionGuard::GROUND_ARCHIVAL, $refusal['ground']);
+		$this->assertSame(ArchivalRetentionGuard::CONTEXT_ERASURE, $refusal['operation']);
+		$this->assertSame(
+			'The law requires us to keep this record, so we did not erase it.',
+			$refusal['message']
+		);
+		$this->assertSame('GDPR art. 17(3)(b) and the Archiefwet.', $refusal['basis']);
+		$this->assertSame(
+			'Name this record in your answer to the requester. '
+			. 'A records officer decides when it may be destroyed.',
+			$refusal['action']
+		);
+	}//end testAnArchivalRecordIsRefusedWithAGroundAndAnAction()
+
+	/**
+	 * `"archival": true` is a typo, not an annotation, so it arms nothing.
+	 *
+	 * Pinned here because the guard must inherit that judgement from the
+	 * predicate rather than making its own. A guard that treated any truthy
+	 * value as archival would refuse erasures the four HTTP doors allow.
+	 *
+	 * @return void
+	 */
+	public function testANonArrayAnnotationDoesNotRefuse(): void {
+		$mapper = $this->createMock(SchemaMapper::class);
+		$mapper->method('find')->willReturnCallback(
+			static function (): Schema {
+				$schema = new Schema();
+				$schema->setSlug('typo');
+				$schema->setConfiguration(['x-openregister-archival' => true]);
+
+				return $schema;
+			}
+		);
+		$guard = new ArchivalRetentionGuard($mapper, $this->createMock(LoggerInterface::class));
+
+		$this->assertNull($guard->erasureRefusal($this->record('u3', 'typo')));
+	}//end testANonArrayAnnotationDoesNotRefuse()
+
+	/**
+	 * FAILS CLOSED: an unresolvable schema is refused, under its own ground.
+	 *
+	 * @return void
+	 */
+	public function testAnUnresolvableSchemaIsRefusedUnderItsOwnGround(): void {
+		$guard = $this->guard([]);
+
+		$refusal = $guard->erasureRefusal($this->record('u4', 'gone'));
+
+		$this->assertNotNull($refusal);
+		$this->assertSame(ArchivalRetentionGuard::GROUND_UNRESOLVED, $refusal['ground']);
+		$this->assertNotSame(
+			ArchivalRetentionGuard::GROUND_ARCHIVAL,
+			$refusal['ground'],
+			'"We could not tell" must not be reported as a legal obligation.'
+		);
+		$this->assertStringContainsString('repair the schema', $refusal['action']);
+	}//end testAnUnresolvableSchemaIsRefusedUnderItsOwnGround()
+
+	/**
+	 * A record with no schema at all is refused rather than erased.
+	 *
+	 * @return void
+	 */
+	public function testARecordWithNoSchemaIsRefused(): void {
+		$guard = $this->guard(['contact' => false]);
+		$object = new ObjectEntity();
+		$object->setUuid('u5');
+
+		$refusal = $guard->erasureRefusal($object);
+
+		$this->assertNotNull($refusal);
+		$this->assertSame(ArchivalRetentionGuard::GROUND_UNRESOLVED, $refusal['ground']);
+	}//end testARecordWithNoSchemaIsRefused()
+
+	/**
+	 * The cascade wording differs from the erasure wording, because the reader
+	 * is answering a different question: the parent is gone and this record is not.
+	 *
+	 * @return void
+	 */
+	public function testTheCascadeRefusalSpeaksAboutTheParent(): void {
+		$guard = $this->guard(['besluit' => true]);
+
+		$refusal = $guard->cascadeRefusal('child-1', 'besluit');
+
+		$this->assertNotNull($refusal);
+		$this->assertSame(ArchivalRetentionGuard::CONTEXT_CASCADE, $refusal['operation']);
+		$this->assertSame(
+			'The law requires us to keep this record. Its parent is gone, this record stays.',
+			$refusal['message']
+		);
+		$this->assertArrayNotHasKey('register', $refusal);
+	}//end testTheCascadeRefusalSpeaksAboutTheParent()
+
+	/**
+	 * Repeated questions about one schema hit the mapper once.
+	 *
+	 * A sweep asks per record, so an unmemoised guard would turn one retention
+	 * pass into one schema query per row.
+	 *
+	 * @return void
+	 */
+	public function testTheSchemaLookupIsMemoisedPerIdentifier(): void {
+		$mapper = $this->createMock(SchemaMapper::class);
+		$mapper->expects($this->once())
+			->method('find')
+			->willReturnCallback(
+				static function (): Schema {
+					$schema = new Schema();
+					$schema->setSlug('besluit');
+					$schema->setConfiguration(['x-openregister-archival' => ['retention' => []]]);
+
+					return $schema;
+				}
+			);
+		$guard = new ArchivalRetentionGuard($mapper, $this->createMock(LoggerInterface::class));
+
+		$this->assertNotNull($guard->erasureRefusal($this->record('a', 'besluit')));
+		$this->assertNotNull($guard->erasureRefusal($this->record('b', 'besluit')));
+		$this->assertNotNull($guard->cascadeRefusal('c', 'besluit'));
+	}//end testTheSchemaLookupIsMemoisedPerIdentifier()
+
+	/**
+	 * A schema that could not be resolved is not re-queried either.
+	 *
+	 * @return void
+	 */
+	public function testAnUnresolvableSchemaIsAlsoMemoised(): void {
+		$mapper = $this->createMock(SchemaMapper::class);
+		$mapper->expects($this->once())
+			->method('find')
+			->willThrowException(new DoesNotExistException('gone'));
+		$guard = new ArchivalRetentionGuard($mapper, $this->createMock(LoggerInterface::class));
+
+		$this->assertNotNull($guard->erasureRefusal($this->record('a', 'gone')));
+		$this->assertNotNull($guard->erasureRefusal($this->record('b', 'gone')));
+	}//end testAnUnresolvableSchemaIsAlsoMemoised()
+
+	/**
+	 * THE SCHEMA READ IS UNSCOPED, and it has to be.
+	 *
+	 * Every caller runs either as a cron with no session or as a privacy officer
+	 * sweeping across tenants. An RBAC- or tenant-scoped read would answer "not
+	 * found" for a schema that plainly exists, and because the guard fails
+	 * closed, that miss would refuse every row in the run and stop the sweep
+	 * without a single error.
+	 *
+	 * @return void
+	 */
+	public function testTheSchemaIsReadWithoutRbacOrTenantScoping(): void {
+		$mapper = $this->createMock(SchemaMapper::class);
+		$mapper->expects($this->once())
+			->method('find')
+			->with(
+				$this->equalTo('besluit'),
+				$this->anything(),
+				$this->isFalse(),
+				$this->isFalse()
+			)
+			->willReturn(new Schema());
+		$guard = new ArchivalRetentionGuard($mapper, $this->createMock(LoggerInterface::class));
+
+		$guard->erasureRefusal($this->record('a', 'besluit'));
+	}//end testTheSchemaIsReadWithoutRbacOrTenantScoping()
+}//end class

--- a/tests/Unit/Service/Gdpr/DataSubjectRequestServiceTest.php
+++ b/tests/Unit/Service/Gdpr/DataSubjectRequestServiceTest.php
@@ -23,6 +23,9 @@ namespace OCA\OpenRegister\Tests\Unit\Service\Gdpr;
 
 use OCA\OpenRegister\Db\MagicMapper;
 use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Archival\ArchivalRetentionGuard;
 use OCA\OpenRegister\Service\DsarService;
 use OCA\OpenRegister\Service\Gdpr\DataSubjectDeadline;
 use OCA\OpenRegister\Service\Gdpr\DataSubjectRequestService;
@@ -87,6 +90,17 @@ class DataSubjectRequestServiceTest extends TestCase {
 	private $userSession;
 
 	/**
+	 * Schema mapper mock backing the real archival guard.
+	 *
+	 * Schemas are REAL entities, so the archival decision comes from the
+	 * production predicate Schema::hasArchivalAnnotation() and a test cannot
+	 * agree with itself about what "archival" means.
+	 *
+	 * @var SchemaMapper&MockObject
+	 */
+	private $schemaMapper;
+
+	/**
 	 * Subject under test.
 	 *
 	 * @var DataSubjectRequestService
@@ -110,6 +124,13 @@ class DataSubjectRequestServiceTest extends TestCase {
 		$user->method('getUID')->willReturn('handler1');
 		$this->userSession->method('getUser')->willReturn($user);
 
+		$this->schemaMapper = $this->createMock(SchemaMapper::class);
+		// Default: every schema resolves and is NOT archival, so the existing
+		// tests keep exercising the erasure path they were written for.
+		$this->schemaMapper->method('find')->willReturnCallback(
+			fn ($id) => $this->makeSchema(identifier: (string)$id, archival: false)
+		);
+
 		$this->service = new DataSubjectRequestService(
 			$this->db,
 			$this->objectMapper,
@@ -118,10 +139,38 @@ class DataSubjectRequestServiceTest extends TestCase {
 			$this->dsarService,
 			new DataSubjectDeadline(),
 			$this->userSession,
-			$this->createMock(LoggerInterface::class)
+			$this->createMock(LoggerInterface::class),
+			new ArchivalRetentionGuard(
+				$this->schemaMapper,
+				$this->createMock(LoggerInterface::class)
+			)
 		);
 
 	}//end setUp()
+
+	/**
+	 * Build a REAL Schema, archival or not.
+	 *
+	 * The annotation is written as data and read back by the production
+	 * predicate. Nothing here restates what "archival" means.
+	 *
+	 * @param string $identifier Schema slug.
+	 * @param bool $archival Whether to declare `x-openregister-archival`.
+	 *
+	 * @return Schema
+	 */
+	private function makeSchema(string $identifier, bool $archival): Schema {
+		$schema = new Schema();
+		$schema->setSlug($identifier);
+		$configuration = [];
+		if ($archival === true) {
+			$configuration['x-openregister-archival'] = ['retention' => ['default' => 'P10Y']];
+		}
+
+		$schema->setConfiguration($configuration);
+
+		return $schema;
+	}//end makeSchema()
 
 	/**
 	 * Wire the GdprEntity ⋈ entity_relations join to return $rows.
@@ -160,14 +209,15 @@ class DataSubjectRequestServiceTest extends TestCase {
 	 *
 	 * @param string $uuid Object uuid.
 	 * @param array<string, mixed> $payload Object payload.
+	 * @param string $schema Schema identifier the object belongs to.
 	 *
 	 * @return ObjectEntity
 	 */
-	private function buildObject(string $uuid, array $payload): ObjectEntity {
+	private function buildObject(string $uuid, array $payload, string $schema = 'schema'): ObjectEntity {
 		$object = new ObjectEntity();
 		$object->setUuid($uuid);
 		$object->setRegister('reg');
-		$object->setSchema('schema');
+		$object->setSchema($schema);
 		$object->setObject($payload);
 		return $object;
 	}//end buildObject()
@@ -231,8 +281,169 @@ class DataSubjectRequestServiceTest extends TestCase {
 	}//end testAssembleAccessExportBuildsBundle()
 
 	/**
+	 * RETENTION WINS OVER ERASURE, PER RECORD.
+	 *
+	 * An erasure request reaching a mixed set withholds ONLY the records held
+	 * under an archival obligation, and reports each one back with the ground
+	 * and the wording the handler passes to the data subject. The non-archival
+	 * record in the same request is still erased: one retained row must never
+	 * block a lawful erasure of the rest.
+	 *
+	 * The archival decision is made by the production predicate
+	 * Schema::hasArchivalAnnotation(), reading a real Schema built here. Break
+	 * that method and this test fails; it has no copy of the rule to fall back on.
+	 *
+	 * @return void
+	 */
+	public function testEraseWithholdsOnlyTheArchivalRecordsAndReportsThem(): void {
+		$this->wireIndexJoin(
+			[
+				['id' => 1, 'type' => 'email', 'value' => 'jane@example.org', 'category' => 'pii', 'detected_at' => '', 'object_id' => 10, 'object_uuid' => 'ordinary'],
+				['id' => 2, 'type' => 'email', 'value' => 'jane@example.org', 'category' => 'pii', 'detected_at' => '', 'object_id' => 20, 'object_uuid' => 'retained'],
+			]
+		);
+
+		$ordinary = $this->buildObject('ordinary', ['email' => 'jane@example.org'], 'contact');
+		$retained = $this->buildObject('retained', ['email' => 'jane@example.org'], 'besluit');
+		$this->objectMapper->method('find')->willReturnCallback(
+			static fn ($id) => ($id === 'ordinary') ? $ordinary : $retained
+		);
+
+		// `besluit` carries the archival annotation; `contact` does not.
+		$this->schemaMapper = $this->createMock(SchemaMapper::class);
+		$this->schemaMapper->method('find')->willReturnCallback(
+			fn ($id) => $this->makeSchema(identifier: (string)$id, archival: ((string)$id === 'besluit'))
+		);
+		$this->rebuildServiceWithSchemaMapper();
+
+		// Nothing stands in the way except the archival obligation.
+		$this->retentionService->method('hasActiveLegalHold')->willReturn(false);
+		$this->retentionService->method('validateNotImmutable')->willReturn(null);
+
+		// EXACTLY ONE WRITE. The retained record is never handed to the audited
+		// save path at all, so it cannot be tombstoned on the way past.
+		$this->objectService->expects($this->once())->method('saveObject')->willReturnCallback(
+			function ($object) use ($ordinary) {
+				$this->assertSame($ordinary, $object);
+				return $ordinary;
+			}
+		);
+
+		$summary = $this->service->erase(
+			subjectId: 'jane@example.org',
+			eraseMode: DataSubjectRequestService::ERASE_MODE_WHOLE_OBJECT
+		);
+
+		$this->assertSame(2, $summary['matchedCount']);
+
+		// The lawful half of the request still ran.
+		$this->assertCount(1, $summary['erased']);
+
+		// The retained half is REFUSED, RECORDED and REPORTED.
+		$this->assertCount(1, $summary['withheld']);
+		$this->assertSame(1, $summary['withheldCount']);
+		$withheld = $summary['withheld'][0];
+		$this->assertSame('retained', $withheld['uuid']);
+		$this->assertSame('besluit', $withheld['schema']);
+		$this->assertSame(
+			ArchivalRetentionGuard::GROUND_ARCHIVAL,
+			$withheld['ground']
+		);
+
+		// The report carries words a handler can pass on, and a next step.
+		$this->assertSame(
+			'The law requires us to keep this record, so we did not erase it.',
+			$withheld['message']
+		);
+		$this->assertStringContainsString('art. 17(3)(b)', $withheld['basis']);
+		$this->assertStringContainsString('Archiefwet', $withheld['basis']);
+		$this->assertNotSame('', trim($withheld['action']));
+
+		// AND THE ANSWER IS NOT "DONE". Telling the data subject the erasure is
+		// complete while a record is still there is the failure this bucket exists
+		// to prevent.
+		$this->assertFalse($summary['complete']);
+
+		// The retained record was left exactly as it was: no erasure stamp on it.
+		$this->assertEmpty($retained->getDeleted());
+
+	}//end testEraseWithholdsOnlyTheArchivalRecordsAndReportsThem()
+
+	/**
+	 * A record whose schema cannot be resolved is left alone, under its own ground.
+	 *
+	 * FAILS CLOSED. An unresolvable schema is exactly the case where the
+	 * annotation cannot be read, so the record might be retained. It is reported
+	 * separately from a real archival hold, because the handler's next step
+	 * differs: repair the schema, then run the request again.
+	 *
+	 * @return void
+	 */
+	public function testEraseLeavesARecordAloneWhenItsSchemaCannotBeResolved(): void {
+		$this->wireIndexJoin(
+			[
+				['id' => 1, 'type' => 'email', 'value' => 'jane@example.org', 'category' => 'pii', 'detected_at' => '', 'object_id' => 10, 'object_uuid' => 'orphan'],
+			]
+		);
+
+		$orphan = $this->buildObject('orphan', ['email' => 'jane@example.org'], 'gone');
+		$this->objectMapper->method('find')->willReturn($orphan);
+
+		$this->schemaMapper = $this->createMock(SchemaMapper::class);
+		$this->schemaMapper->method('find')->willThrowException(
+			new DoesNotExistException('schema gone')
+		);
+		$this->rebuildServiceWithSchemaMapper();
+
+		$this->retentionService->method('hasActiveLegalHold')->willReturn(false);
+		$this->retentionService->method('validateNotImmutable')->willReturn(null);
+
+		$this->objectService->expects($this->never())->method('saveObject');
+
+		$summary = $this->service->erase(
+			subjectId: 'jane@example.org',
+			eraseMode: DataSubjectRequestService::ERASE_MODE_WHOLE_OBJECT
+		);
+
+		$this->assertCount(0, $summary['erased']);
+		$this->assertCount(1, $summary['withheld']);
+		$this->assertSame(
+			ArchivalRetentionGuard::GROUND_UNRESOLVED,
+			$summary['withheld'][0]['ground']
+		);
+		$this->assertFalse($summary['complete']);
+		$this->assertEmpty($orphan->getDeleted());
+
+	}//end testEraseLeavesARecordAloneWhenItsSchemaCannotBeResolved()
+
+	/**
+	 * Rebuild the SUT after swapping in a differently-wired schema mapper.
+	 *
+	 * @return void
+	 */
+	private function rebuildServiceWithSchemaMapper(): void {
+		$this->service = new DataSubjectRequestService(
+			$this->db,
+			$this->objectMapper,
+			$this->objectService,
+			$this->retentionService,
+			$this->dsarService,
+			new DataSubjectDeadline(),
+			$this->userSession,
+			$this->createMock(LoggerInterface::class),
+			new ArchivalRetentionGuard(
+				$this->schemaMapper,
+				$this->createMock(LoggerInterface::class)
+			)
+		);
+	}//end rebuildServiceWithSchemaMapper()
+
+	/**
 	 * erase skips an object under legal hold (reported `held`, not erased)
 	 * and erases the unheld one.
+	 *
+	 * A run that held a record back is NOT complete. See the comment on the
+	 * `complete` assertion below for why that expectation was inverted.
 	 *
 	 * @return void
 	 */
@@ -271,7 +482,18 @@ class DataSubjectRequestServiceTest extends TestCase {
 		$this->assertCount(1, $summary['held']);
 		$this->assertSame('held', $summary['held'][0]['uuid']);
 		$this->assertSame('legal-hold', $summary['held'][0]['reason']);
-		$this->assertTrue($summary['complete']);
+
+		// CHANGED DELIBERATELY. This line used to read
+		// `assertTrue($summary['complete'])`, pinning as CORRECT a run that
+		// answered "complete" while a record it had refused was still sitting
+		// there. That is the same shape 4be2adc found in a controller test
+		// asserting `success === true` for a batch that had refused a row: the
+		// green came from the summary line, not from the data.
+		//
+		// An erasure is complete when the data is gone. A held record means it is
+		// not, so the request is partial and the handler has something to explain.
+		$this->assertFalse($summary['complete']);
+		$this->assertSame(1, $summary['heldCount']);
 
 	}//end testEraseRespectsLegalHold()
 

--- a/tests/Unit/Service/Gdpr/Retention/RetentionSweepServiceTest.php
+++ b/tests/Unit/Service/Gdpr/Retention/RetentionSweepServiceTest.php
@@ -19,6 +19,9 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Tests\Unit\Service\Gdpr\Retention;
 
 use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Archival\ArchivalRetentionGuard;
 use OCA\OpenRegister\Service\Gdpr\Case\CaseObjectAccessor;
 use OCA\OpenRegister\Service\Gdpr\DataSubjectRequestService;
 use OCA\OpenRegister\Service\Gdpr\Retention\RetentionSweepService;
@@ -48,23 +51,53 @@ class RetentionSweepServiceTest extends TestCase {
 	 *
 	 * @return ObjectEntity
 	 */
-	private function caseEntity(string $uuid, string $retainUntil, string $subjectId = 's@example.org'): ObjectEntity {
+	private function caseEntity(
+		string $uuid,
+		string $retainUntil,
+		string $subjectId = 's@example.org',
+		string $schema = 'dsar-case',
+	): ObjectEntity {
 		$object = new ObjectEntity();
 		$object->setUuid($uuid);
+		$object->setSchema($schema);
 		$object->setObject(['subjectId' => $subjectId, 'retainUntil' => $retainUntil]);
 		return $object;
 	}//end caseEntity()
+
+	/**
+	 * Build a REAL Schema, archival or not.
+	 *
+	 * The annotation is written as data and read back by
+	 * Schema::hasArchivalAnnotation(). Nothing here restates the rule.
+	 *
+	 * @param string $identifier Schema slug.
+	 * @param bool $archival Whether to declare `x-openregister-archival`.
+	 *
+	 * @return Schema
+	 */
+	private function makeSchema(string $identifier, bool $archival): Schema {
+		$schema = new Schema();
+		$schema->setSlug($identifier);
+		$configuration = [];
+		if ($archival === true) {
+			$configuration['x-openregister-archival'] = ['retention' => ['default' => 'P10Y']];
+		}
+
+		$schema->setConfiguration($configuration);
+
+		return $schema;
+	}//end makeSchema()
 
 	/**
 	 * Build the SUT with a fixed clock and the supplied cases + hold verdicts.
 	 *
 	 * @param ObjectEntity[] $cases Case entities to sweep.
 	 * @param callable $holdResolver fn(ObjectEntity):bool legal-hold verdict.
-	 * @param RetentionService|null $retentionMock Optional pre-built retention mock.
+	 * @param array<int, string> $archivalSchemas Schema slugs that declare `x-openregister-archival`.
 	 *
 	 * @return array{0: RetentionSweepService, 1: \PHPUnit\Framework\MockObject\MockObject}
 	 */
-	private function build(array $cases, callable $holdResolver): array {
+	private function build(array $cases, callable $holdResolver, array $archivalSchemas = []): array {
 		$accessor = $this->createMock(CaseObjectAccessor::class);
 		$accessor->method('findAllCaseEntities')->willReturn($cases);
 
@@ -77,12 +110,21 @@ class RetentionSweepServiceTest extends TestCase {
 		$time = $this->createMock(ITimeFactory::class);
 		$time->method('getTime')->willReturn($this->now);
 
+		$schemaMapper = $this->createMock(SchemaMapper::class);
+		$schemaMapper->method('find')->willReturnCallback(
+			fn ($id) => $this->makeSchema(
+				identifier: (string)$id,
+				archival: in_array((string)$id, $archivalSchemas, true)
+			)
+		);
+
 		$service = new RetentionSweepService(
 			$accessor,
 			$retention,
 			$dsr,
 			$time,
-			$this->createMock(LoggerInterface::class)
+			$this->createMock(LoggerInterface::class),
+			new ArchivalRetentionGuard($schemaMapper, $this->createMock(LoggerInterface::class))
 		);
 
 		return [$service, $accessor, $dsr];
@@ -165,4 +207,50 @@ class RetentionSweepServiceTest extends TestCase {
 		$this->assertSame([], $summary['purged']);
 
 	}//end testExpiredButHeldCaseSkipped()
+	/**
+	 * RETENTION WINS OVER ERASURE, EVEN THROUGH THIS SWEEP'S OWN BYPASS.
+	 *
+	 * The dossier delete hands `_retentionSweep: true` to ObjectService, the flag
+	 * whose whole purpose is to wave a row past the archival gate. So an expired
+	 * case on an archival schema was hard-deleted here with no refusal anywhere
+	 * in the chain. The gate is asked before the bypass is reached now.
+	 *
+	 * The refused case is named in `withheld` and the rest of the sweep runs.
+	 *
+	 * @return void
+	 */
+	public function testExpiredArchivalCaseIsWithheldWhileTheRestOfTheSweepRuns(): void {
+		$ordinary = $this->caseEntity('case-ordinary', '2020-01-01T00:00:00+00:00', 'a@example.org', 'dsar-case');
+		$retained = $this->caseEntity('case-retained', '2020-01-01T00:00:00+00:00', 'b@example.org', 'besluit');
+
+		[$service, $accessor, $dsr] = $this->build(
+			[$ordinary, $retained],
+			static fn (): bool => false,
+			['besluit']
+		);
+
+		// EXACTLY ONE DELETE, and it is the non-archival case. The retained case
+		// never reaches deleteForSweep, so the bypass flag is never used on it.
+		$accessor->expects($this->once())
+			->method('deleteForSweep')
+			->with('case-ordinary')
+			->willReturn(true);
+
+		// The retained case's evidence is not scrubbed either: withholding the
+		// record means leaving it as it stands, not quietly redacting it.
+		$dsr->expects($this->once())->method('erase')->willReturn([]);
+
+		$summary = $service->runSweep(dryRun: false);
+
+		$this->assertSame(['case-ordinary'], $summary['purged']);
+		$this->assertCount(1, $summary['withheld']);
+		$this->assertSame(1, $summary['withheldCount']);
+		$this->assertSame('case-retained', $summary['withheld'][0]['uuid']);
+		$this->assertSame(
+			ArchivalRetentionGuard::GROUND_ARCHIVAL,
+			$summary['withheld'][0]['ground']
+		);
+		$this->assertStringContainsString('Archiefwet', $summary['withheld'][0]['basis']);
+
+	}//end testExpiredArchivalCaseIsWithheldWhileTheRestOfTheSweepRuns()
 }//end class

--- a/tests/Unit/Service/Object/DeleteObjectTest.php
+++ b/tests/Unit/Service/Object/DeleteObjectTest.php
@@ -637,10 +637,14 @@ class DeleteObjectTest extends TestCase {
 		);
 		$this->integrityService->method('canDelete')->willReturn($analysis);
 
+		// applyDeletionActions reports the cascade targets the archival obligation
+		// kept live. Nothing is retained here, so the mock answers with the empty
+		// report rather than an unshaped array.
 		$this->integrityService
 			->expects($this->once())
 			->method('applyDeletionActions')
-			->with($analysis, 'system', 'uuid-do-3', null, 'my-schema');
+			->with($analysis, 'system', 'uuid-do-3', null, 'my-schema')
+			->willReturn(['retained' => []]);
 
 		$this->withNoUser();
 		$this->withAuditTrailsEnabled(false);

--- a/tests/Unit/Service/Object/ReferentialIntegrityArchivalCascadeTest.php
+++ b/tests/Unit/Service/Object/ReferentialIntegrityArchivalCascadeTest.php
@@ -1,0 +1,343 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * ReferentialIntegrityService archival-cascade refusal tests.
+ *
+ * A RETAINED RECORD STAYS LIVE EVEN WHEN ITS PARENT GOES.
+ *
+ * The batch cascade soft-deletes with `hardDelete: false`, so an archival child
+ * of a non-archival parent used to be tombstoned by a delete aimed at somebody
+ * else: nothing in the cascade asked whether the child's own schema declared
+ * `x-openregister-archival`, and the four HTTP delete doors that DO ask were
+ * never on this path. The cascade skips such a child, names it in the result,
+ * and the parent delete still proceeds.
+ *
+ * Every archival verdict here comes from the production predicate
+ * {@see \OCA\OpenRegister\Db\Schema::hasArchivalAnnotation()} reading a real
+ * Schema built with real configuration data. Nothing in this file restates what
+ * "archival" means, so breaking that method fails these tests rather than
+ * leaving them agreeing with a private copy of the rule.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Object
+ * @author   Conduction Development Team <dev@conduction.nl>
+ * @license  EUPL-1.2
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Object;
+
+use OCA\OpenRegister\Db\AuditTrail;
+use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Dto\DeletionAnalysis;
+use OCA\OpenRegister\Service\Archival\ArchivalRetentionGuard;
+use OCA\OpenRegister\Service\Object\ReferentialIntegrityService;
+use OCP\ICache;
+use OCP\ICacheFactory;
+use OCP\IDBConnection;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * The cascade refuses an archival child, names it, and still deletes the parent.
+ */
+class ReferentialIntegrityArchivalCascadeTest extends TestCase {
+
+	/**
+	 * Schema id of the ordinary, cascade-able child.
+	 *
+	 * @var string
+	 */
+	private const SCHEMA_ORDINARY = '10';
+
+	/**
+	 * Schema id of the child held under an archival obligation.
+	 *
+	 * @var string
+	 */
+	private const SCHEMA_ARCHIVAL = '77';
+
+	/**
+	 * Object entity mapper mock.
+	 *
+	 * @var MagicMapper&MockObject
+	 */
+	private $objectMapper;
+
+	/**
+	 * Audit trail mapper mock.
+	 *
+	 * @var AuditTrailMapper&MockObject
+	 */
+	private $auditTrailMapper;
+
+	/**
+	 * Subject under test.
+	 *
+	 * @var ReferentialIntegrityService
+	 */
+	private ReferentialIntegrityService $service;
+
+	/**
+	 * Set up the SUT with a REAL archival guard over real Schema entities.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->objectMapper = $this->createMock(MagicMapper::class);
+		$this->auditTrailMapper = $this->createMock(AuditTrailMapper::class);
+
+		$schemaMapper = $this->createMock(SchemaMapper::class);
+		$schemaMapper->method('find')->willReturnCallback(
+			static function ($id): Schema {
+				$schema = new Schema();
+				$schema->setSlug('schema-' . $id);
+				$configuration = [];
+				if ((string)$id === self::SCHEMA_ARCHIVAL) {
+					// Real annotation data. The predicate reads this, not a flag
+					// the test set on a mock.
+					$configuration['x-openregister-archival'] = [
+						'retention' => ['default' => 'P10Y'],
+					];
+				}
+
+				$schema->setConfiguration($configuration);
+
+				return $schema;
+			}
+		);
+
+		$this->service = new ReferentialIntegrityService(
+			$schemaMapper,
+			$this->createMock(RegisterMapper::class),
+			$this->objectMapper,
+			$this->auditTrailMapper,
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(IDBConnection::class),
+			$this->nullCacheFactory(),
+			new ArchivalRetentionGuard($schemaMapper, $this->createMock(LoggerInterface::class))
+		);
+
+		$this->auditTrailMapper->method('buildAuditTrail')->willReturnCallback(
+			static function (): AuditTrail {
+				return new AuditTrail();
+			}
+		);
+
+	}//end setUp()
+
+	/**
+	 * A cache factory whose caches are unavailable, so nothing is memoised.
+	 *
+	 * @return ICacheFactory&MockObject
+	 */
+	private function nullCacheFactory() {
+		$cache = $this->createMock(ICache::class);
+		$factory = $this->createMock(ICacheFactory::class);
+		$factory->method('isAvailable')->willReturn(false);
+		$factory->method('createDistributed')->willReturn($cache);
+
+		return $factory;
+	}//end nullCacheFactory()
+
+	/**
+	 * Build a live ObjectEntity for a cascade target.
+	 *
+	 * @param string $uuid Target uuid.
+	 * @param string $schema Schema identifier the target belongs to.
+	 *
+	 * @return ObjectEntity
+	 */
+	private function entity(string $uuid, string $schema): ObjectEntity {
+		$entity = new ObjectEntity();
+		$entity->setUuid($uuid);
+		$entity->setRegister('5');
+		$entity->setSchema($schema);
+		$entity->setObject(['name' => $uuid]);
+
+		return $entity;
+	}//end entity()
+
+	/**
+	 * Build a cascade-target array entry.
+	 *
+	 * @param string $uuid Target uuid.
+	 * @param string $schema Schema identifier the target belongs to.
+	 * @param string $property Referencing property.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function target(string $uuid, string $schema, string $property = 'parentRef'): array {
+		return [
+			'objectUuid' => $uuid,
+			'register' => '5',
+			'schema' => $schema,
+			'property' => $property,
+		];
+	}//end target()
+
+	/**
+	 * THE RULING: a retained child stays live, is named, and the parent still goes.
+	 *
+	 * The cascade covers one ordinary child and one child on an archival schema.
+	 * The ordinary child is soft-deleted as before. The archival child never
+	 * reaches the resolve or the soft-delete write at all, so it cannot be
+	 * tombstoned on the way past, and it is reported in the return value with
+	 * its ground and the wording a reader acts on.
+	 *
+	 * @return void
+	 */
+	public function testCascadeLeavesAnArchivalChildLiveNamesItAndStillRuns(): void {
+		$ordinary = $this->entity('child-ordinary', self::SCHEMA_ORDINARY);
+
+		// THE BATCH IS ASKED FOR THE ORDINARY CHILD ONLY. If the retained child
+		// appeared in this list, the cascade would already have reached for it.
+		$this->objectMapper->expects($this->once())
+			->method('findMultipleAcrossAllMagicTables')
+			->with(
+				$this->equalTo(['child-ordinary']),
+				$this->equalTo(false)
+			)
+			->willReturn([$ordinary]);
+
+		$softDeleted = [];
+		$this->objectMapper->expects($this->once())
+			->method('softDeleteMultipleObjectEntities')
+			->willReturnCallback(
+				static function (array $entities) use (&$softDeleted): array {
+					foreach ($entities as $entity) {
+						$softDeleted[] = $entity->getUuid();
+					}
+
+					return $entities;
+				}
+			);
+
+		// The per-object fallback must not pick the retained child up either.
+		$this->objectMapper->expects($this->never())->method('deleteObjects');
+
+		$analysis = new DeletionAnalysis(
+			deletable: true,
+			cascadeTargets: [
+				$this->target('child-ordinary', self::SCHEMA_ORDINARY),
+				$this->target('child-retained', self::SCHEMA_ARCHIVAL),
+			]
+		);
+
+		$result = $this->service->applyDeletionActions($analysis, 'admin', 'parent-uuid', 'org-1', 'parent-slug');
+
+		// The ordinary child went.
+		$this->assertSame(['child-ordinary'], $softDeleted);
+
+		// The retained child is NAMED, with the ground and the words to act on.
+		$this->assertCount(1, $result['retained']);
+		$retained = $result['retained'][0];
+		$this->assertSame('child-retained', $retained['uuid']);
+		$this->assertSame(ArchivalRetentionGuard::GROUND_ARCHIVAL, $retained['ground']);
+		$this->assertSame(ArchivalRetentionGuard::CONTEXT_CASCADE, $retained['operation']);
+		$this->assertSame(
+			'The law requires us to keep this record. Its parent is gone, this record stays.',
+			$retained['message']
+		);
+		$this->assertStringContainsString('Archiefwet', $retained['basis']);
+		$this->assertNotSame('', trim($retained['action']));
+
+	}//end testCascadeLeavesAnArchivalChildLiveNamesItAndStillRuns()
+
+	/**
+	 * A cascade made entirely of retained children does no delete work at all,
+	 * and still reports every one of them.
+	 *
+	 * The PARENT delete is not this method's business and is untouched by the
+	 * refusal: applyDeletionActions returns normally rather than throwing, which
+	 * is what lets DeleteObject carry on and remove the parent.
+	 *
+	 * @return void
+	 */
+	public function testAnAllArchivalCascadeDeletesNothingAndReportsEveryChild(): void {
+		$this->objectMapper->expects($this->never())->method('findMultipleAcrossAllMagicTables');
+		$this->objectMapper->expects($this->never())->method('softDeleteMultipleObjectEntities');
+		$this->objectMapper->expects($this->never())->method('deleteObjects');
+
+		$analysis = new DeletionAnalysis(
+			deletable: true,
+			cascadeTargets: [
+				$this->target('retained-a', self::SCHEMA_ARCHIVAL),
+				$this->target('retained-b', self::SCHEMA_ARCHIVAL),
+			]
+		);
+
+		$result = $this->service->applyDeletionActions($analysis, 'admin', 'parent-uuid');
+
+		$this->assertCount(2, $result['retained']);
+		// Deepest first: applyDeletionActions reverses the analysis order before
+		// applying, and the report follows the order the cascade would have run.
+		$this->assertSame(
+			['retained-b', 'retained-a'],
+			array_column($result['retained'], 'uuid')
+		);
+
+	}//end testAnAllArchivalCascadeDeletesNothingAndReportsEveryChild()
+
+	/**
+	 * A child referenced through two properties is reported once, not twice.
+	 *
+	 * The analysis lists such a target per referencing property, so a naive
+	 * report would tell a records officer to go and look at two records when
+	 * there is only one.
+	 *
+	 * @return void
+	 */
+	public function testARetainedChildReachedTwiceIsReportedOnce(): void {
+		$analysis = new DeletionAnalysis(
+			deletable: true,
+			cascadeTargets: [
+				$this->target('retained-a', self::SCHEMA_ARCHIVAL, 'refA'),
+				$this->target('retained-a', self::SCHEMA_ARCHIVAL, 'refB'),
+			]
+		);
+
+		$result = $this->service->applyDeletionActions($analysis, 'admin', 'parent-uuid');
+
+		$this->assertCount(1, $result['retained']);
+		$this->assertSame('retained-a', $result['retained'][0]['uuid']);
+
+	}//end testARetainedChildReachedTwiceIsReportedOnce()
+
+	/**
+	 * A cascade with no retained children reports an empty list, not a missing key.
+	 *
+	 * DeleteObject reads `$result['retained']` unconditionally to work out how
+	 * many rows the cascade actually took. A missing key there would be an
+	 * undefined-index warning on the overwhelmingly common delete.
+	 *
+	 * @return void
+	 */
+	public function testAnOrdinaryCascadeReportsAnEmptyRetainedList(): void {
+		$ordinary = $this->entity('child-ordinary', self::SCHEMA_ORDINARY);
+		$this->objectMapper->method('findMultipleAcrossAllMagicTables')->willReturn([$ordinary]);
+		$this->objectMapper->method('softDeleteMultipleObjectEntities')->willReturnArgument(0);
+
+		$analysis = new DeletionAnalysis(
+			deletable: true,
+			cascadeTargets: [$this->target('child-ordinary', self::SCHEMA_ORDINARY)]
+		);
+
+		$result = $this->service->applyDeletionActions($analysis, 'admin', 'parent-uuid');
+
+		$this->assertArrayHasKey('retained', $result);
+		$this->assertSame([], $result['retained']);
+
+	}//end testAnOrdinaryCascadeReportsAnEmptyRetainedList()
+}//end class

--- a/tests/Unit/Service/Object/ReferentialIntegrityBatchCascadeTest.php
+++ b/tests/Unit/Service/Object/ReferentialIntegrityBatchCascadeTest.php
@@ -45,6 +45,8 @@ use OCP\IDBConnection;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Service\Archival\ArchivalRetentionGuard;
 
 /**
  * Unit tests for the batched referential-integrity CASCADE delete path.
@@ -117,7 +119,8 @@ class ReferentialIntegrityBatchCascadeTest extends TestCase {
 			$this->auditTrailMapper,
 			$this->logger,
 			$this->createMock(IDBConnection::class),
-			$this->createNullCacheFactory()
+			$this->createNullCacheFactory(),
+			$this->makeArchivalGuard()
 		);
 	}//end setUp()
 
@@ -628,4 +631,35 @@ class ReferentialIntegrityBatchCascadeTest extends TestCase {
 
 		$this->service->applyDeletionActions($analysis, 'admin', 'root-uuid');
 	}//end testSetNullDoesNotUseBatchedCascadeMachinery()
+	/**
+	 * A real ArchivalRetentionGuard over schemas that declare no archival annotation.
+	 *
+	 * REAL, not a mock: the cascade's retention decision must come from the
+	 * production predicate Schema::hasArchivalAnnotation(). These fixtures are
+	 * ordinary schemas, so the guard lets every cascade through and these tests
+	 * keep asserting the behaviour they were written for.
+	 *
+	 * @param array<int, string> $archivalSchemas Schema identifiers that ARE archival.
+	 *
+	 * @return ArchivalRetentionGuard
+	 */
+	private function makeArchivalGuard(array $archivalSchemas = []): ArchivalRetentionGuard {
+		$schemaMapper = $this->createMock(SchemaMapper::class);
+		$schemaMapper->method('find')->willReturnCallback(
+			function ($id) use ($archivalSchemas): Schema {
+				$schema = new Schema();
+				$schema->setSlug((string)$id);
+				$configuration = [];
+				if (in_array((string)$id, $archivalSchemas, true) === true) {
+					$configuration['x-openregister-archival'] = ['retention' => ['default' => 'P10Y']];
+				}
+
+				$schema->setConfiguration($configuration);
+
+				return $schema;
+			}
+		);
+
+		return new ArchivalRetentionGuard($schemaMapper, $this->createMock(LoggerInterface::class));
+	}//end makeArchivalGuard()
 }//end class

--- a/tests/Unit/Service/Object/ReferentialIntegrityIndexCacheTest.php
+++ b/tests/Unit/Service/Object/ReferentialIntegrityIndexCacheTest.php
@@ -37,6 +37,7 @@ use OCP\IDBConnection;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\Archival\ArchivalRetentionGuard;
 
 /**
  * @covers \OCA\OpenRegister\Service\Object\ReferentialIntegrityService
@@ -225,7 +226,8 @@ class ReferentialIntegrityIndexCacheTest extends TestCase {
 			$this->createMock(AuditTrailMapper::class),
 			$this->createMock(LoggerInterface::class),
 			$this->dbReturning($versionRows),
-			$this->cacheFactory
+			$this->cacheFactory,
+			$this->makeArchivalGuard()
 		);
 
 	}//end service()
@@ -541,4 +543,35 @@ class ReferentialIntegrityIndexCacheTest extends TestCase {
 
 	}//end testFutureStampBypassesCache()
 
+	/**
+	 * A real ArchivalRetentionGuard over schemas that declare no archival annotation.
+	 *
+	 * REAL, not a mock: the cascade's retention decision must come from the
+	 * production predicate Schema::hasArchivalAnnotation(). These fixtures are
+	 * ordinary schemas, so the guard lets every cascade through and these tests
+	 * keep asserting the behaviour they were written for.
+	 *
+	 * @param array<int, string> $archivalSchemas Schema identifiers that ARE archival.
+	 *
+	 * @return ArchivalRetentionGuard
+	 */
+	private function makeArchivalGuard(array $archivalSchemas = []): ArchivalRetentionGuard {
+		$schemaMapper = $this->createMock(SchemaMapper::class);
+		$schemaMapper->method('find')->willReturnCallback(
+			function ($id) use ($archivalSchemas): Schema {
+				$schema = new Schema();
+				$schema->setSlug((string)$id);
+				$configuration = [];
+				if (in_array((string)$id, $archivalSchemas, true) === true) {
+					$configuration['x-openregister-archival'] = ['retention' => ['default' => 'P10Y']];
+				}
+
+				$schema->setConfiguration($configuration);
+
+				return $schema;
+			}
+		);
+
+		return new ArchivalRetentionGuard($schemaMapper, $this->createMock(LoggerInterface::class));
+	}//end makeArchivalGuard()
 }//end class

--- a/tests/Unit/Service/Object/ReferentialIntegrityServiceBranchTest.php
+++ b/tests/Unit/Service/Object/ReferentialIntegrityServiceBranchTest.php
@@ -15,6 +15,8 @@ use OCP\IDBConnection;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Service\Archival\ArchivalRetentionGuard;
 
 /**
  * Branch coverage tests for ReferentialIntegrityService — targets uncovered
@@ -45,7 +47,8 @@ class ReferentialIntegrityServiceBranchTest extends TestCase {
 			$this->auditTrailMapper,
 			$this->logger,
 			$this->createMock(IDBConnection::class),
-			$this->createNullCacheFactory()
+			$this->createNullCacheFactory(),
+			$this->makeArchivalGuard()
 		);
 	}
 
@@ -244,4 +247,35 @@ class ReferentialIntegrityServiceBranchTest extends TestCase {
 		$result = $this->service->canDelete($object);
 		$this->assertTrue($result->deletable);
 	}
+	/**
+	 * A real ArchivalRetentionGuard over schemas that declare no archival annotation.
+	 *
+	 * REAL, not a mock: the cascade's retention decision must come from the
+	 * production predicate Schema::hasArchivalAnnotation(). These fixtures are
+	 * ordinary schemas, so the guard lets every cascade through and these tests
+	 * keep asserting the behaviour they were written for.
+	 *
+	 * @param array<int, string> $archivalSchemas Schema identifiers that ARE archival.
+	 *
+	 * @return ArchivalRetentionGuard
+	 */
+	private function makeArchivalGuard(array $archivalSchemas = []): ArchivalRetentionGuard {
+		$schemaMapper = $this->createMock(SchemaMapper::class);
+		$schemaMapper->method('find')->willReturnCallback(
+			function ($id) use ($archivalSchemas): Schema {
+				$schema = new Schema();
+				$schema->setSlug((string)$id);
+				$configuration = [];
+				if (in_array((string)$id, $archivalSchemas, true) === true) {
+					$configuration['x-openregister-archival'] = ['retention' => ['default' => 'P10Y']];
+				}
+
+				$schema->setConfiguration($configuration);
+
+				return $schema;
+			}
+		);
+
+		return new ArchivalRetentionGuard($schemaMapper, $this->createMock(LoggerInterface::class));
+	}//end makeArchivalGuard()
 }

--- a/tests/Unit/Service/Object/ReferentialIntegrityServiceTest.php
+++ b/tests/Unit/Service/Object/ReferentialIntegrityServiceTest.php
@@ -33,6 +33,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use ReflectionClass;
+use OCA\OpenRegister\Service\Archival\ArchivalRetentionGuard;
 
 /**
  * Unit tests for ReferentialIntegrityService
@@ -84,7 +85,8 @@ class ReferentialIntegrityServiceTest extends TestCase {
 			$this->auditTrailMapper,
 			$this->logger,
 			$this->db,
-			$this->createNullCacheFactory()
+			$this->createNullCacheFactory(),
+			$this->makeArchivalGuard()
 		);
 	}
 
@@ -1624,12 +1626,16 @@ class ReferentialIntegrityServiceTest extends TestCase {
 				$this->equalTo(false)
 			);
 
+		// The SCHEMA is populated (it was null here before, incidentally): this
+		// test is about a missing REGISTER, and the archival gate fails closed on
+		// a target whose schema it cannot resolve. Leaving it null would make the
+		// fixture assert schema-resolution behaviour it never meant to cover.
 		$analysis = new DeletionAnalysis(
 			deletable: true,
 			cascadeTargets: [[
 				'objectUuid' => 'cascade-uuid',
 				'register' => null,
-				'schema' => null,
+				'schema' => '77',
 				'property' => 'parentRef',
 			]]
 		);
@@ -2491,4 +2497,35 @@ class ReferentialIntegrityServiceTest extends TestCase {
 
 		$this->service->applyDeletionActions($analysis, 'admin', 'source-uuid');
 	}
+	/**
+	 * A real ArchivalRetentionGuard over schemas that declare no archival annotation.
+	 *
+	 * REAL, not a mock: the cascade's retention decision must come from the
+	 * production predicate Schema::hasArchivalAnnotation(). These fixtures are
+	 * ordinary schemas, so the guard lets every cascade through and these tests
+	 * keep asserting the behaviour they were written for.
+	 *
+	 * @param array<int, string> $archivalSchemas Schema identifiers that ARE archival.
+	 *
+	 * @return ArchivalRetentionGuard
+	 */
+	private function makeArchivalGuard(array $archivalSchemas = []): ArchivalRetentionGuard {
+		$schemaMapper = $this->createMock(SchemaMapper::class);
+		$schemaMapper->method('find')->willReturnCallback(
+			function ($id) use ($archivalSchemas): Schema {
+				$schema = new Schema();
+				$schema->setSlug((string)$id);
+				$configuration = [];
+				if (in_array((string)$id, $archivalSchemas, true) === true) {
+					$configuration['x-openregister-archival'] = ['retention' => ['default' => 'P10Y']];
+				}
+
+				$schema->setConfiguration($configuration);
+
+				return $schema;
+			}
+		);
+
+		return new ArchivalRetentionGuard($schemaMapper, $this->createMock(LoggerInterface::class));
+	}//end makeArchivalGuard()
 }

--- a/tests/Unit/Service/ReferentialIntegrityServiceCoverageTest.php
+++ b/tests/Unit/Service/ReferentialIntegrityServiceCoverageTest.php
@@ -36,6 +36,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use ReflectionClass;
+use OCA\OpenRegister\Service\Archival\ArchivalRetentionGuard;
 
 class ReferentialIntegrityServiceCoverageTest extends TestCase {
 	private ReferentialIntegrityService $service;
@@ -59,7 +60,8 @@ class ReferentialIntegrityServiceCoverageTest extends TestCase {
 			$this->auditTrailMapper,
 			$this->logger,
 			$this->createMock(IDBConnection::class),
-			$this->createNullCacheFactory()
+			$this->createNullCacheFactory(),
+			$this->makeArchivalGuard()
 		);
 	}
 
@@ -448,4 +450,35 @@ class ReferentialIntegrityServiceCoverageTest extends TestCase {
 		// Should not throw
 		$this->service->logRestrictBlock('uuid', '1', $analysis, 'admin');
 	}
+	/**
+	 * A real ArchivalRetentionGuard over schemas that declare no archival annotation.
+	 *
+	 * REAL, not a mock: the cascade's retention decision must come from the
+	 * production predicate Schema::hasArchivalAnnotation(). These fixtures are
+	 * ordinary schemas, so the guard lets every cascade through and these tests
+	 * keep asserting the behaviour they were written for.
+	 *
+	 * @param array<int, string> $archivalSchemas Schema identifiers that ARE archival.
+	 *
+	 * @return ArchivalRetentionGuard
+	 */
+	private function makeArchivalGuard(array $archivalSchemas = []): ArchivalRetentionGuard {
+		$schemaMapper = $this->createMock(SchemaMapper::class);
+		$schemaMapper->method('find')->willReturnCallback(
+			function ($id) use ($archivalSchemas): Schema {
+				$schema = new Schema();
+				$schema->setSlug((string)$id);
+				$configuration = [];
+				if (in_array((string)$id, $archivalSchemas, true) === true) {
+					$configuration['x-openregister-archival'] = ['retention' => ['default' => 'P10Y']];
+				}
+
+				$schema->setConfiguration($configuration);
+
+				return $schema;
+			}
+		);
+
+		return new ArchivalRetentionGuard($schemaMapper, $this->createMock(LoggerInterface::class));
+	}//end makeArchivalGuard()
 }

--- a/tests/Unit/Service/ReferentialIntegrityServiceTest.php
+++ b/tests/Unit/Service/ReferentialIntegrityServiceTest.php
@@ -41,6 +41,7 @@ use OCP\IDBConnection;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\Archival\ArchivalRetentionGuard;
 
 /**
  * Unit tests for ReferentialIntegrityService
@@ -118,7 +119,8 @@ class ReferentialIntegrityServiceTest extends TestCase {
 			auditTrailMapper: $this->auditTrailMapper,
 			logger: $this->logger,
 			db: $this->createMock(IDBConnection::class),
-			cacheFactory: $this->createNullCacheFactory()
+			cacheFactory: $this->createNullCacheFactory(),
+			archivalGuard: $this->makeArchivalGuard()
 		);
 
 		$this->reflection = new \ReflectionClass($this->service);
@@ -1412,4 +1414,35 @@ class ReferentialIntegrityServiceTest extends TestCase {
 		$this->assertContains('NO_ACTION', ReferentialIntegrityService::VALID_ON_DELETE_ACTIONS);
 		$this->assertCount(5, ReferentialIntegrityService::VALID_ON_DELETE_ACTIONS);
 	}//end testValidOnDeleteActionsConstant()
+	/**
+	 * A real ArchivalRetentionGuard over schemas that declare no archival annotation.
+	 *
+	 * REAL, not a mock: the cascade's retention decision must come from the
+	 * production predicate Schema::hasArchivalAnnotation(). These fixtures are
+	 * ordinary schemas, so the guard lets every cascade through and these tests
+	 * keep asserting the behaviour they were written for.
+	 *
+	 * @param array<int, string> $archivalSchemas Schema identifiers that ARE archival.
+	 *
+	 * @return ArchivalRetentionGuard
+	 */
+	private function makeArchivalGuard(array $archivalSchemas = []): ArchivalRetentionGuard {
+		$schemaMapper = $this->createMock(SchemaMapper::class);
+		$schemaMapper->method('find')->willReturnCallback(
+			function ($id) use ($archivalSchemas): Schema {
+				$schema = new Schema();
+				$schema->setSlug((string)$id);
+				$configuration = [];
+				if (in_array((string)$id, $archivalSchemas, true) === true) {
+					$configuration['x-openregister-archival'] = ['retention' => ['default' => 'P10Y']];
+				}
+
+				$schema->setConfiguration($configuration);
+
+				return $schema;
+			}
+		);
+
+		return new ArchivalRetentionGuard($schemaMapper, $this->createMock(LoggerInterface::class));
+	}//end makeArchivalGuard()
 }//end class


### PR DESCRIPTION
Implements two rulings Ruben took on openregister#3432, which reported both rather than guessing.

## Decision 1 — retention wins over erasure: refuse, record, report

An erasure request that reaches a record on a schema declaring `x-openregister-archival` does not lift the obligation holding it. GDPR art. 17(3)(b) stands down for processing the law requires, and for a Dutch government record the Archiefwet is that law. Those rows are refused, the refusal is recorded, and it travels back with the rest of the answer so the officer replying to the data subject can name what stayed and why.

The refusal is per row. Every non-archival match in the same request is still erased: one retained record never blocks a lawful erasure of the others.

### The erasure paths, verified rather than assumed

The reported list named three. A sweep of `lib/` found a fourth that reaches archival records, and cleared three more that must NOT be gated.

| Path | Was it blind? | Now |
|---|---|---|
| `DsarService::eraseObjectsForSubject` (art-17 vergetelheid) | yes | `withheld[]` + `withheldCount` |
| `DataSubjectRequestService::erase` (consumable art-17) | yes, and it looked covered | `withheld[]` + `withheldCount` |
| `AvgRetentionService::erasePastRetention` (AVG bewaartermijn sweep) | yes, and it had no per-object channel at all | `withheld[]` per activity + `objectsWithheld` |
| `RetentionSweepService::runSweep` (DSAR case sweep) | **the sibling not in the reported list** | `withheld[]` + `withheldCount` |

**`DataSubjectRequestService` looked covered and was not.** Its `retentionGuard()` docblock claims to cover "immutable archival status", but `validateNotImmutable()` reads the OBJECT's `retention.archiefstatus`. `x-openregister-archival` is declared on the SCHEMA. A record on an archival schema that had not yet been stamped `vernietigd` or `overgebracht` went straight through the guard that reads as though it stops exactly that.

**`RetentionSweepService` was worse than blind.** Its dossier delete hands `_retentionSweep: true` to `ObjectService`, the flag whose whole purpose is to wave a row past the archival gate. An archival case was hard-deleted with no refusal anywhere in the chain. The gate is asked before the bypass is reached.

### Three paths deliberately NOT gated

`ArchivalRetentionTask`, `DestructionExecutionJob` and `CaseObjectAccessor::deleteForSweep` are how a retained record legitimately leaves. Gating them would make archival records immortal, which is not the ruling. `CaseObjectAccessor` is now covered upstream at the sweep instead, which is where the erasure decision is actually taken.

### What the refusal says

```json
{
  "uuid": "96035100-e57a-401b-8896-02b7f8942a9e",
  "schema": "rig-besluit",
  "ground": "ARCHIVAL_RETENTION_OBLIGATION",
  "operation": "erasure",
  "message": "The law requires us to keep this record, so we did not erase it.",
  "basis": "GDPR art. 17(3)(b) and the Archiefwet.",
  "action": "Name this record in your answer to the requester. A records officer decides when it may be destroyed.",
  "register": "23"
}
```

`message` answers the data subject. `action` tells the handler what to do, because a refusal nobody acts on is the same as a silent skip. Written against the Conduction voice: no em-dashes, no Title Case, active, one claim per sentence.

## Decision 2 — a retained record stays live even when its parent goes

`ReferentialIntegrityService` batch-cascades child deletes with `hardDelete: false`, so an archival child of a non-archival parent was tombstoned by a delete aimed at somebody else. The cascade skips it, names it, and the parent delete still proceeds: a retained child refuses the cascade, it does not block the delete that reached it.

`applyDeletionActions()` returns `{retained: [...]}` instead of `void`. A child referenced through two properties is reported once, keyed by uuid, so a records officer is not sent looking for two records when there is one.

`DeleteObject` stops counting a retained target as a cascade casualty. The old count was `count($analysis->cascadeTargets)`, the number of rows the analysis WANTED to delete, which is now a different number from the rows the cascade took; reporting it would have told a bulk caller that a record it can still see was deleted. `getLastRetainedCascadeTargets()` exposes the report alongside `getLastCascadeCount()`.

## One predicate, five consumers, no sixth rule

`Schema::hasArchivalAnnotation()` (openregister#3428) stays the single definition. The new `ArchivalRetentionGuard` is its fifth consumer beside the four HTTP delete doors. It asks the question and does not restate the condition anywhere.

Two properties worth stating out loud:

- **It fails closed**, and reports an unresolvable schema under its own ground (`SCHEMA_UNRESOLVED`) so a handler can tell "the law holds this" from "we could not tell". The next step differs: repair the schema, then run the request again.
- **It reads the schema unscoped.** Every caller is either a cron with no session or a privacy officer sweeping across tenants. A scoped read would answer "not found" for a schema that plainly exists, and combined with fail-closed that miss would refuse every row in the run and stop a whole sweep without one error.

## An existing test asserted the old behaviour as correct

`DataSubjectRequestServiceTest::testEraseRespectsLegalHold` pinned `complete === true` for a run that had refused one of its two records. That is the same shape `4be2adc` found in a controller test asserting `success === true` for a batch that had refused a row: the green came from the summary line, not from the data.

Inverted deliberately, with the reasoning in the test. An erasure is complete when the data is gone, so `held` and `withheld` now count against `complete` alongside `failed`. `heldCount` was already reported and already excluded from `complete`; that was a pre-existing hollow green and is fixed in the same place.

One fixture also changed: `testApplyDeletionActionsCascadeFallbackForNoRegister` carried `'schema' => null`. Its subject is a missing REGISTER, so it now carries a schema id; leaving it null would have made it assert schema-resolution behaviour it never meant to cover.

## Rig evidence

Own compose project `orretwins` on port **8751**, torn down with `down -v`. Same rig, base tree then fixed tree. Each run builds its own register, schemas and subject, so the two runs cannot read each other's rows.

**Before**

```
--- DECISION 1: POST /api/gdpr/erase
  ordinary record erased      : True
  ARCHIVAL record erased      : True   <-- the defect
  withheld bucket present     : False
  answer claims complete      : True   <-- told the subject their data was gone

--- DECISION 2: DELETE the parent
  parent          : TOMBSTONED
  ARCHIVAL child  : TOMBSTONED         <-- the defect
```

**After**

```
--- DECISION 1: POST /api/gdpr/erase
  ordinary record erased      : True
  ARCHIVAL record erased      : False
  withheld bucket present     : True
  archival record withheld    : True
  answer claims complete      : False

--- DECISION 2: DELETE the parent
  parent          : TOMBSTONED         (the parent delete still proceeds)
  ARCHIVAL child  : LIVE
```

One measurement note worth recording: the first `after` run, taken ~40s after the file copy, still showed the cascade tombstoning the child while Decision 1 already read as fixed. That was stale PHP opcache bytecode, not a half-working fix. A clean re-run after `apachectl -k graceful` shows both green, and the container log carries `[ReferentialIntegrity] Kept a retained record out of a cascade`. A rig measured too soon after a deploy can report a fix as half-landed.

## Verified locally (CI is bottlenecked; judged by exit code)

| Check | Exit |
|---|---|
| `vendor/bin/phpunit --no-coverage` (19,114 tests, 46,693 assertions) | **0** |
| `composer phpcs` | **0** |
| `composer psalm` | **0** |
| `composer phpstan` | **0** |
| `phpmd` on each changed `lib/` file, both configs (`phpmd.xml` + `phpmd-unusedparams.xml`) | **0** |
| `hydra-gates --scope-to-diff` (`conduction/hydra-gates` v1.14.0, after `npm ci`) | **0**, 33/33 applicable |
| `hydra-gates` full tree | **0**, 77/77 applicable |

All re-run after rebasing onto `ae5a476`.

`phpmd` is run per changed file because `phpmd lib/Service` OOM-kills this host. Three findings were introduced by this change and are fixed rather than baselined: `DsarService::eraseObjectsForSubject` complexity and length (the per-entry work is extracted to `eraseOneEntry()`), a long property name in `DeleteObject`, and one-over coupling on `AvgRetentionService` (suppressed with a stated reason, the same pattern `DeletedController` already uses for the same cause). Each was confirmed absent on the untouched base before being treated as new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
