### PR TITLE
fix(schemas): prune-retired missed a duplicate row and miscounted what it destroys

### DIFF
--- a/lib/Command/PruneRetiredSchemasCommand.php
+++ b/lib/Command/PruneRetiredSchemasCommand.php
@@ -40,7 +40,6 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Command;
 
-use OCA\OpenRegister\Db\MagicMapper;
 use OCA\OpenRegister\Db\Register;
 use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
@@ -64,7 +63,6 @@ class PruneRetiredSchemasCommand extends Command {
 	 *
 	 * @param SchemaMapper $schemaMapper Schema lookup mapper (app-scoped resolution).
 	 * @param RegisterMapper $registerMapper Register mapper, to unlink the retired id.
-	 * @param MagicMapper $magicMapper Magic table resolver, for the object-count guard.
 	 * @param SchemaDeletionService $deletionService Cascade teardown (objects, tables, row).
 	 *
 	 * @return void
@@ -74,7 +72,6 @@ class PruneRetiredSchemasCommand extends Command {
 	public function __construct(
 		private readonly SchemaMapper $schemaMapper,
 		private readonly RegisterMapper $registerMapper,
-		private readonly MagicMapper $magicMapper,
 		private readonly SchemaDeletionService $deletionService,
 	) {
 		parent::__construct();
@@ -177,9 +174,21 @@ class PruneRetiredSchemasCommand extends Command {
 
 		foreach ($slugs as $slug) {
 			$slug = (string)$slug;
-			$schema = $this->schemaMapper->findByApplicationAndSlug(slug: $slug, application: $appId);
 
-			if ($schema === null) {
+			// EVERY row under this (application, slug), not the first.
+			//
+			// `findByApplicationAndSlug()` caps at one, which is correct where
+			// the pair is unique. It is not unique in practice, and this command
+			// exists because it is not: the import unions schema ids and never
+			// removes one, so a descriptor edit leaves the old row behind and a
+			// later import can add a second under the same pair. Reading one row
+			// meant removing one of two and reporting success. Measured on a live
+			// instance: opencatalogi owned two `document` rows (39 and 40), this
+			// pruned 40, printed `Pruned=1, skipped=0`, and left 39 answering
+			// every lookup.
+			$schemas = $this->schemaMapper->findAllByApplicationAndSlug(slug: $slug, application: $appId);
+
+			if ($schemas === []) {
 				$missing++;
 				$output->writeln(
 					sprintf(
@@ -191,8 +200,23 @@ class PruneRetiredSchemasCommand extends Command {
 				continue;
 			}
 
+			if (count($schemas) > 1) {
+				$output->writeln(
+					sprintf(
+						'<comment>"%s": app "%s" owns %d rows under this slug. All of them are handled below.</comment>',
+						$slug,
+						$appId,
+						count($schemas)
+					)
+				);
+			}
+
+			foreach ($schemas as $schema) {
 			$schemaId = (int)$schema->getId();
-			$objectCount = $this->countObjectsForSchema(schema: $schema);
+			// The count the DELETE would produce, from the deletion service that
+			// enumerates the tables — not a second, narrower count of its own.
+			// The guard and the delete disagreeing is the whole defect.
+			$objectCount = $this->deletionService->countObjectsCascadeWouldDelete(schema: $schema);
 			$linkedRegisters = $this->registersReferencing(schemaId: $schemaId);
 
 			$output->writeln(
@@ -279,6 +303,22 @@ class PruneRetiredSchemasCommand extends Command {
 					$archivalNote
 				)
 			);
+
+			// The count that gated the deletion and the count the deletion
+			// reports must agree. When they do not, the guard above passed on a
+			// number that did not describe what was destroyed, and the operator
+			// who read "0 object(s)" in the dry run needs to know that.
+			if ((int)$result['deletedCount'] !== $objectCount) {
+				$output->writeln(
+					sprintf(
+						'  <error>COUNT MISMATCH: the guard saw %d object(s), the delete removed %d. '
+						. 'The guard was wrong about what it was protecting.</error>',
+						$objectCount,
+						(int)$result['deletedCount']
+					)
+				);
+			}
+			}//end foreach
 		}//end foreach
 
 		$suffix = '';
@@ -336,38 +376,6 @@ class PruneRetiredSchemasCommand extends Command {
 		);
 	}//end unlinkSchemaId()
 
-	/**
-	 * Count objects a schema owns across every register that references it.
-	 *
-	 * @param Schema $schema The schema to count objects for.
-	 *
-	 * @return int Total object count across the schema's magic tables.
-	 *
-	 * @spec openspec/specs/schema-import/spec.md#requirement-a-schema-retired-from-a-descriptor-must-be-removable-from-the-instance
-	 */
-	private function countObjectsForSchema(Schema $schema): int {
-		$total = 0;
-
-		foreach ($this->registersReferencing(schemaId: (int)$schema->getId()) as $register) {
-			if ($this->magicMapper->tableExistsForRegisterSchema(register: $register, schema: $schema) === false) {
-				continue;
-			}
-
-			try {
-				$total += $this->magicMapper->countObjectsInRegisterSchemaTable(
-					query: [],
-					register: $register,
-					schema: $schema
-				);
-			} catch (\Throwable $e) {
-				// An unreadable magic table cannot be counted. Treat it as
-				// non-empty so the guard errs towards keeping data.
-				$total++;
-			}
-		}
-
-		return $total;
-	}//end countObjectsForSchema()
 
 	/**
 	 * Every register whose schema list references this schema id.

--- a/lib/Db/SchemaMapper.php
+++ b/lib/Db/SchemaMapper.php
@@ -562,6 +562,55 @@ class SchemaMapper extends QBMapper {
 	}//end findByApplicationAndSlug()
 
 	/**
+	 * EVERY schema an application owns under a slug, not just the first.
+	 *
+	 * `findByApplicationAndSlug()` caps at one row, which is correct where the
+	 * pair is treated as unique. It is not unique in practice: the import unions
+	 * schema ids and never removes one, so a descriptor edit that renames or
+	 * retires a schema leaves the old row behind and a later import can add a
+	 * second under the same pair.
+	 *
+	 * That is exactly the situation `openregister:schemas:prune-retired` exists
+	 * to clean up, and reading one row per run meant it removed one of two and
+	 * reported success. Measured on a live instance: opencatalogi owned two
+	 * `document` rows (ids 39 and 40), the command pruned 40, said
+	 * `Pruned=1, skipped=0`, and left 39 answering every lookup.
+	 *
+	 * @param string $slug        The schema slug, matched case-insensitively.
+	 * @param string $application The owning application id.
+	 *
+	 * @return array<int, Schema> Every matching schema, oldest id first.
+	 *
+	 * @spec openspec/specs/schema-import/spec.md#requirement-a-schema-retired-from-a-descriptor-must-be-removable-from-the-instance
+	 */
+	public function findAllByApplicationAndSlug(string $slug, string $application): array {
+		$this->traceRead(method: 'findAllByApplicationAndSlug');
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from('openregister_schemas')
+			->where(
+				$qb->expr()->eq(
+					$qb->func()->lower('slug'),
+					$qb->createNamedParameter(value: strtolower($slug), type: IQueryBuilder::PARAM_STR)
+				)
+			)
+			->andWhere(
+				$qb->expr()->eq('application', $qb->createNamedParameter(value: $application, type: IQueryBuilder::PARAM_STR))
+			)
+			->orderBy('id', 'ASC');
+
+		$result = $qb->executeQuery();
+		$rows = $result->fetchAll();
+		$result->closeCursor();
+
+		return array_map(
+			fn (array $row): Schema => $this->resolveSchemaExtension(schema: Schema::fromRow($row)),
+			$rows
+		);
+	}//end findAllByApplicationAndSlug()
+
+	/**
 	 * Resolve a schema by slug, scoped to a set of schema ids.
 	 *
 	 * This is the runtime-resolution half of the cross-app slug-collision fix.

--- a/lib/Service/SchemaDeletionService.php
+++ b/lib/Service/SchemaDeletionService.php
@@ -300,6 +300,60 @@ class SchemaDeletionService {
 	}//end cascadeDeleteSchema()
 
 	/**
+	 * How many objects `cascadeDeleteSchema()` would destroy.
+	 *
+	 * THE GUARD AND THE DELETE MUST LOOK AT THE SAME ROWS. They did not: the
+	 * prune command counted through the registers that REFERENCE a schema and
+	 * through `MagicSearchHandler`, which applies RBAC. Both narrow the set.
+	 *
+	 * Under `occ` there is no session, so the RBAC filter reads as Anonymous and
+	 * rows nobody anonymous may see counted as zero. And a schema referenced by
+	 * no register counted zero by construction — which is exactly the state a
+	 * half-pruned schema is left in. Either way the operator read "0 objects,
+	 * safe to delete" and the delete dropped the table.
+	 *
+	 * This counts what the delete enumerates: every magic table resolved for the
+	 * schema, including ones whose register no longer references it.
+	 *
+	 * @param Schema $schema The schema to count for.
+	 *
+	 * @return int The number of objects a cascade delete would remove.
+	 *
+	 * @spec openspec/specs/schema-import/spec.md#requirement-a-schema-retired-from-a-descriptor-must-be-removable-from-the-instance
+	 */
+	public function countObjectsCascadeWouldDelete(Schema $schema): int {
+		$total = 0;
+
+		foreach ($this->resolveMagicTablesForSchema(schema: $schema) as $entry) {
+			if ($entry['register'] === null) {
+				// A table outliving its register: the delete drops it without
+				// reading it, so it removes an unknown number of rows. Counting
+				// it as at least one keeps the guard on the side of the data.
+				$total++;
+				continue;
+			}
+
+			try {
+				$total += $this->magicMapper->countObjectsInRegisterSchemaTable(
+					query: [
+						'_rbac' => false,
+						'_multitenancy' => false,
+						'_includeDeleted' => true,
+					],
+					register: $entry['register'],
+					schema: $schema
+				);
+			} catch (Throwable $e) {
+				// An unreadable table cannot be counted. Treat it as non-empty so
+				// the guard errs towards keeping data.
+				$total++;
+			}
+		}
+
+		return $total;
+	}//end countObjectsCascadeWouldDelete()
+
+	/**
 	 * Drop the schema's magic tables, but only when they hold no rows at all.
 	 *
 	 * Used by the plain (no-flag, zero-object) delete path so it stops leaving an

--- a/tests/Unit/Command/PruneRetiredSchemasArchivalTest.php
+++ b/tests/Unit/Command/PruneRetiredSchemasArchivalTest.php
@@ -89,7 +89,6 @@ class PruneRetiredSchemasArchivalTest extends TestCase {
 		$this->command = new PruneRetiredSchemasCommand(
 			$this->schemaMapper,
 			$this->registerMapper,
-			$this->magicMapper,
 			$this->deletionService
 		);
 
@@ -136,13 +135,87 @@ class PruneRetiredSchemasArchivalTest extends TestCase {
 		$register->setSlug('archival-rig');
 		$register->setSchemas([self::SCHEMA_ID]);
 
-		$this->schemaMapper->method('findByApplicationAndSlug')->willReturn($schema);
+		// EVERY row under the pair, not the first: the command reads them all
+		// now, because the import unions schema ids and a slug can carry two.
+		$this->schemaMapper->method('findAllByApplicationAndSlug')->willReturn([$schema]);
 		$this->registerMapper->method('findAll')->willReturn([$register]);
-		$this->magicMapper->method('tableExistsForRegisterSchema')->willReturn(true);
-		$this->magicMapper->method('countObjectsInRegisterSchemaTable')->willReturn(2);
+		// The guard asks the DELETION service what it would remove, rather than
+		// running a second, narrower count of its own.
+		$this->deletionService->method('countObjectsCascadeWouldDelete')->willReturn(2);
 
 		return $schema;
 	}//end stubOneRetiredSchema()
+
+	/**
+	 * TWO rows under one (application, slug), which is what the import leaves.
+	 *
+	 * @return array<int, Schema> Both schemas, in id order.
+	 */
+	private function stubTwoRetiredSchemas(): array {
+		$first = $this->makeEntity(new Schema(), self::SCHEMA_ID);
+		$first->setSlug('document');
+		$second = $this->makeEntity(new Schema(), (self::SCHEMA_ID + 1));
+		$second->setSlug('document');
+
+		$register = $this->makeEntity(new Register(), self::REGISTER_ID);
+		$register->setSlug('archival-rig');
+		$register->setSchemas([self::SCHEMA_ID, (self::SCHEMA_ID + 1)]);
+
+		$this->schemaMapper->method('findAllByApplicationAndSlug')->willReturn([$first, $second]);
+		$this->registerMapper->method('findAll')->willReturn([$register]);
+		$this->deletionService->method('countObjectsCascadeWouldDelete')->willReturn(0);
+
+		return [$first, $second];
+	}//end stubTwoRetiredSchemas()
+
+	/**
+	 * Both rows are pruned, not the first one only.
+	 *
+	 * The import unions schema ids and never removes one, so a descriptor edit
+	 * leaves the old row behind and a later import can add a second under the
+	 * same pair — which is the situation this command exists for. It read one
+	 * row per run, so it removed one of two and printed `Pruned=1, skipped=0`.
+	 * Measured on a live instance: opencatalogi owned `document` at ids 39 and
+	 * 40, the command took 40 and left 39 answering every lookup.
+	 *
+	 * @return void
+	 */
+	public function testBothRowsUnderOneSlugArePruned(): void {
+		$this->stubTwoRetiredSchemas();
+
+		$this->deletionService->expects(self::exactly(2))
+			->method('cascadeDeleteSchema')
+			->willReturn(['deletedCount' => 0, 'tableDropped' => true]);
+
+		$tester = $this->runPrune(['--apply' => true]);
+
+		self::assertStringContainsString('Pruned=2', $tester->getDisplay());
+		self::assertStringContainsString('owns 2 rows under this slug', $tester->getDisplay());
+
+	}//end testBothRowsUnderOneSlugArePruned()
+
+	/**
+	 * When the guard's count and the delete's count disagree, say so.
+	 *
+	 * The guard read "0 objects, safe to delete" and the delete removed 2, on a
+	 * live instance. Whatever the cause, an operator who approved a deletion on
+	 * the strength of a dry run needs to be told the number was wrong rather
+	 * than left to infer it from a log line they will not read.
+	 *
+	 * @return void
+	 */
+	public function testACountMismatchIsReported(): void {
+		$this->stubOneRetiredSchema(archival: false);
+
+		$this->deletionService->method('cascadeDeleteSchema')
+			->willReturn(['deletedCount' => 7, 'tableDropped' => true]);
+
+		$tester = $this->runPrune(['--apply' => true, '--force' => true]);
+
+		self::assertStringContainsString('COUNT MISMATCH', $tester->getDisplay());
+		self::assertStringContainsString('the guard saw 2 object(s), the delete removed 7', $tester->getDisplay());
+
+	}//end testACountMismatchIsReported()
 
 	/**
 	 * Run the command with the given options.


### PR DESCRIPTION
## Two defects in a destructive command

Both found by **running it on a live instance**, not by reading it.

### 1. It handled one row per `(application, slug)`

`findByApplicationAndSlug()` caps at one, which is correct where the pair is unique. **It is not unique in practice, and this command exists because it is not**: the import unions schema ids and never removes one, so a descriptor edit leaves the old row behind and a later import can add a second under the same pair.

Measured: opencatalogi owned `document` at ids **39 and 40**. The command took 40, printed `Pruned=1, skipped=0`, and left 39 answering every lookup. An operator would reasonably read that as done.

`SchemaMapper::findAllByApplicationAndSlug()` returns every row, oldest first, and the command loops over all of them.

### 2. Its safety guard failed open

The dry run said `0 object(s)`. The apply reported `objects removed=2`.

The guard that refuses to prune a schema still holding data was counting a different set from the one the delete destroys, in **two independent ways**:

| | why it read zero |
| --- | --- |
| RBAC | the count ran through `MagicSearchHandler`, which applies RBAC and multi-tenancy by default. `occ` has no session, so the CLI reads as **Anonymous**, and rows nobody anonymous may see counted as zero |
| linkage | it iterated only the registers that **reference** the schema. A schema referenced by none counts zero *by construction* — and that is exactly the state a half-pruned schema is left in |

Either path let an operator read *"0 objects, safe to delete"* and then destroy rows.

The guard now asks the deletion service what a cascade **would** remove, over the same table set the delete enumerates, with `_rbac` and `_multitenancy` off and `_includeDeleted` on — a soft-deleted row is still a row the table drop destroys, and counting only live rows tells the operator nothing about the recovery they are giving up. A table that outlives its register counts as at least one, because the delete drops it without reading it.

And when the two numbers still disagree, the command **says so** rather than leaving the operator to infer it. The guard was wrong about what it was protecting; that is worth a line of output.

The command's own `MagicMapper` dependency goes with its count.

## Testing

- **19,116 tests green**, 2 new — both for cases the existing suite structurally could not see: two rows under one slug, and a guard/delete count mismatch. The old stub returned a single schema and a single count, so neither could have failed.
- phpcs, psalm and phpstan clean; **all 75 applicable hydra gates pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
