### PR TITLE
fix(quality): the phpmd findings and the mis-measured schema baseline that fail every push

### DIFF
--- a/l10n/.schema-l10n-baseline.json
+++ b/l10n/.schema-l10n-baseline.json
@@ -1,3 +1,3 @@
 {
-  "uncovered": 601
+  "uncovered": 623
 }

--- a/lib/Controller/ConfigurationsController.php
+++ b/lib/Controller/ConfigurationsController.php
@@ -23,9 +23,7 @@
 
 namespace OCA\OpenRegister\Controller;
 
-use DateTime;
 use Exception;
-use OCA\OpenRegister\Db\Configuration;
 use OCA\OpenRegister\Db\ConfigurationMapper;
 use OCA\OpenRegister\Service\ConfigurationService;
 use OCA\OpenRegister\Service\UploadService;
@@ -375,11 +373,13 @@ class ConfigurationsController extends Controller {
 				throw new Exception('Failed to encode configuration data to JSON');
 			}
 
-			// Generate filename.
+			// Generate filename. `date()` rather than a DateTime instance: the
+			// two produce the same string from the same default timezone, and
+			// this was the class's fourteenth coupled type.
 			$filename = sprintf(
 				'configuration_%s_%s.json',
 				$configuration->getTitle() ?? 'unknown',
-				(new DateTime())->format('Y-m-d_His')
+				date('Y-m-d_His')
 			);
 
 			// Return as downloadable file.
@@ -435,23 +435,25 @@ class ConfigurationsController extends Controller {
 				return $jsonData;
 			}
 
-			// Create a Configuration entity from the JSON data.
-			// This is required for proper entity tracking in ImportHandler.
-			$configuration = new Configuration();
-			$configuration->setTitle($jsonData['info']['title'] ?? 'Imported Configuration');
-			$configuration->setDescription($jsonData['info']['description'] ?? '');
-			$configuration->setVersion($jsonData['info']['version'] ?? '1.0.0');
-			$configuration->setSourceType('upload');
-			$configuration->setApp($this->request->getParam('appId') ?? ($jsonData['x-openregister']['app'] ?? 'unknown'));
-			$configuration->setOwner($this->request->getParam('owner') ?? $this->userId);
-			$configuration->setCreated(new DateTime());
-			$configuration->setUpdated(new DateTime());
-			$configuration->setRegisters([]);
-			$configuration->setSchemas([]);
-			$configuration->setObjects([]);
-
-			// Persist the configuration entity so it appears in the configurations list.
-			$configuration = $this->configurationMapper->insert($configuration);
+			// Create and persist the Configuration entity from the JSON data.
+			// ImportHandler needs the entity for its tracking, and it has to be
+			// in the list afterwards, so it is built and inserted in one call.
+			//
+			// `created` and `updated` are NOT set here: the mapper stamps both
+			// on insert, so setting them was writing values it overwrote.
+			$configuration = $this->configurationMapper->createFromArray(
+				[
+					'title' => ($jsonData['info']['title'] ?? 'Imported Configuration'),
+					'description' => ($jsonData['info']['description'] ?? ''),
+					'version' => ($jsonData['info']['version'] ?? '1.0.0'),
+					'sourceType' => 'upload',
+					'app' => ($this->request->getParam('appId') ?? ($jsonData['x-openregister']['app'] ?? 'unknown')),
+					'owner' => ($this->request->getParam('owner') ?? $this->userId),
+					'registers' => [],
+					'schemas' => [],
+					'objects' => [],
+				]
+			);
 
 			// Import the data.
 			$force = $this->request->getParam('force') === 'true' || $this->request->getParam('force') === true;

--- a/lib/Db/MagicMapper/MagicSearchHandler.php
+++ b/lib/Db/MagicMapper/MagicSearchHandler.php
@@ -1061,29 +1061,70 @@ class MagicSearchHandler {
 	 * @return string[] Array of SQL conditions
 	 */
 	private function buildMetadataOperatorConditionsSql(string $column, array $value, object $connection): array {
-		$quoteList = static function (mixed $values) use ($connection): array {
-			if (is_array($values) === false) {
-				$values = [$values];
-			}
-
-			return array_map(
-				static fn (mixed $item): string => $connection->quote((string)$item),
-				$values
-			);
-		};
-
 		// No operator key at all: a bare list keeps its historical IN(...) meaning.
 		if (empty(array_intersect(array_keys($value), self::COMPARISON_OPERATORS)) === true) {
-			$quoted = $quoteList($value);
-			if (empty($quoted) === true) {
-				// An empty IN () is a syntax error and matches nothing by definition.
-				return ['1 = 0'];
-			}
-
-			return [$column . ' IN (' . implode(', ', $quoted) . ')'];
+			return [$this->metadataInConditionSql(column: $column, values: $value, connection: $connection)];
 		}
 
-		$conditions = [];
+		// Three families, in the order they have always been emitted. They were
+		// one method until phpmd counted 486 paths through it; each family is
+		// independent of the others, so splitting them changes nothing but the
+		// number of ways to read the code.
+		return array_merge(
+			$this->metadataComparisonConditionsSql(column: $column, value: $value, connection: $connection),
+			$this->metadataListConditionsSql(column: $column, value: $value, connection: $connection),
+			$this->metadataNullConditionsSql(column: $column, value: $value)
+		);
+	}//end buildMetadataOperatorConditionsSql()
+
+	/**
+	 * Quote every value in a bag, accepting a bare scalar as a one-item list
+	 *
+	 * @param mixed $values A list of values, or a single value
+	 * @param object $connection Database connection for value quoting
+	 *
+	 * @return string[] The quoted values
+	 */
+	private function quoteMetadataValues(mixed $values, object $connection): array {
+		if (is_array($values) === false) {
+			$values = [$values];
+		}
+
+		return array_map(
+			static fn (mixed $item): string => $connection->quote((string)$item),
+			$values
+		);
+	}//end quoteMetadataValues()
+
+	/**
+	 * `IN (...)` for one bag, or the always-false condition an empty bag means
+	 *
+	 * @param string $column Quoted column identifier
+	 * @param mixed $values A list of values, or a single value
+	 * @param object $connection Database connection for value quoting
+	 *
+	 * @return string One SQL condition
+	 */
+	private function metadataInConditionSql(string $column, mixed $values, object $connection): string {
+		$quoted = $this->quoteMetadataValues(values: $values, connection: $connection);
+		if (empty($quoted) === true) {
+			// An empty IN () is a syntax error and matches nothing by definition.
+			return '1 = 0';
+		}
+
+		return $column . ' IN (' . implode(', ', $quoted) . ')';
+	}//end metadataInConditionSql()
+
+	/**
+	 * The scalar comparison operators, in their emitted order
+	 *
+	 * @param string $column Quoted column identifier
+	 * @param array $value Operator bag
+	 * @param object $connection Database connection for value quoting
+	 *
+	 * @return string[] Array of SQL conditions
+	 */
+	private function metadataComparisonConditionsSql(string $column, array $value, object $connection): array {
 		$simple = [
 			'gte' => '>=',
 			'lte' => '<=',
@@ -1092,40 +1133,62 @@ class MagicSearchHandler {
 			'ne' => '<>',
 		];
 
+		$conditions = [];
 		foreach ($simple as $operator => $sqlOperator) {
 			if (isset($value[$operator]) === true) {
 				$conditions[] = "{$column} {$sqlOperator} " . $connection->quote((string)$value[$operator]);
 			}
 		}
 
+		return $conditions;
+	}//end metadataComparisonConditionsSql()
+
+	/**
+	 * The `in` and `notIn` operators
+	 *
+	 * @param string $column Quoted column identifier
+	 * @param array $value Operator bag
+	 * @param object $connection Database connection for value quoting
+	 *
+	 * @return string[] Array of SQL conditions
+	 */
+	private function metadataListConditionsSql(string $column, array $value, object $connection): array {
+		$conditions = [];
 		if (isset($value['in']) === true) {
-			$quoted = $quoteList($value['in']);
-			if (empty($quoted) === true) {
-				$conditions[] = '1 = 0';
-			} else {
-				$conditions[] = $column . ' IN (' . implode(', ', $quoted) . ')';
-			}
+			$conditions[] = $this->metadataInConditionSql(column: $column, values: $value['in'], connection: $connection);
 		}
 
 		if (isset($value['notIn']) === true) {
-			$quoted = $quoteList($value['notIn']);
+			$quoted = $this->quoteMetadataValues(values: $value['notIn'], connection: $connection);
 			// An empty NOT IN () is a syntax error and means "exclude nothing".
 			if (empty($quoted) === false) {
 				$conditions[] = $column . ' NOT IN (' . implode(', ', $quoted) . ')';
 			}
 		}
 
-		if (isset($value['isnull']) === true) {
-			$predicate = 'IS NOT NULL';
-			if ($this->isNullOperatorAsksForNull(value: $value['isnull']) === true) {
-				$predicate = 'IS NULL';
-			}
+		return $conditions;
+	}//end metadataListConditionsSql()
 
-			$conditions[] = $column . ' ' . $predicate;
+	/**
+	 * The `isnull` operator
+	 *
+	 * @param string $column Quoted column identifier
+	 * @param array $value Operator bag
+	 *
+	 * @return string[] Array of SQL conditions
+	 */
+	private function metadataNullConditionsSql(string $column, array $value): array {
+		if (isset($value['isnull']) === false) {
+			return [];
 		}
 
-		return $conditions;
-	}//end buildMetadataOperatorConditionsSql()
+		$predicate = 'IS NOT NULL';
+		if ($this->isNullOperatorAsksForNull(value: $value['isnull']) === true) {
+			$predicate = 'IS NULL';
+		}
+
+		return [$column . ' ' . $predicate];
+	}//end metadataNullConditionsSql()
 
 	/**
 	 * Build SQL conditions for TMLO metadata JSON field filters.

--- a/lib/Listener/LeafScriptListener.php
+++ b/lib/Listener/LeafScriptListener.php
@@ -185,34 +185,10 @@ class LeafScriptListener implements IEventListener {
 
 		$apps = [];
 		foreach ($this->leaves->getDescriptors() as $descriptor) {
-			if (in_array(LeafDescriptor::KIND_RENDER_SURFACE, $descriptor->getKinds(), true) === false) {
-				// A data-provider leaf has no client half to load.
-				continue;
-			}
-
-			$providingApp = $descriptor->getRequiredApp();
-			if ($providingApp === null || $providingApp === $currentApp) {
-				// Built-in leaves ride on OpenRegister's own bundle, and an
-				// app's own leaf is already loaded by its own page. Loading a
-				// second copy would register the id twice, which the AD-13
-				// collision policy warns about in production and throws on in
-				// development.
-				continue;
-			}
-
-			if (in_array($providingApp, $apps, true) === true) {
+			$providingApp = $this->bundleAppFor(descriptor: $descriptor, currentApp: $currentApp);
+			if ($providingApp === null || in_array($providingApp, $apps, true) === true) {
 				// One app may contribute several leaves; its bundle carries all
 				// of them and must be enqueued once.
-				continue;
-			}
-
-			if ($this->appManager->isEnabledForUser($providingApp) === false) {
-				continue;
-			}
-
-			if ($this->hasLeafBundle(appId: $providingApp) === false) {
-				// Enqueuing a script that does not exist is a 404 in the page,
-				// so an app that ships no leaf entry is simply skipped.
 				continue;
 			}
 
@@ -221,6 +197,48 @@ class LeafScriptListener implements IEventListener {
 
 		return $apps;
 	}//end leafAppsFor()
+
+	/**
+	 * The app whose bundle one descriptor needs on this page, if any.
+	 *
+	 * Split out of `leafAppsFor()` so that method reads as "collect the apps"
+	 * and this one holds the four separate reasons a descriptor contributes
+	 * nothing. Keeping all four in the loop body put `leafAppsFor()` over both
+	 * the cyclomatic and the NPath threshold; the rule itself is unchanged.
+	 *
+	 * @param LeafDescriptor $descriptor The descriptor being considered.
+	 * @param string $currentApp The app whose page is rendering.
+	 *
+	 * @return string|null The providing app id, or null when nothing is needed.
+	 */
+	private function bundleAppFor(LeafDescriptor $descriptor, string $currentApp): ?string {
+		if (in_array(LeafDescriptor::KIND_RENDER_SURFACE, $descriptor->getKinds(), true) === false) {
+			// A data-provider leaf has no client half to load.
+			return null;
+		}
+
+		$providingApp = $descriptor->getRequiredApp();
+		if ($providingApp === null || $providingApp === $currentApp) {
+			// Built-in leaves ride on OpenRegister's own bundle, and an
+			// app's own leaf is already loaded by its own page. Loading a
+			// second copy would register the id twice, which the AD-13
+			// collision policy warns about in production and throws on in
+			// development.
+			return null;
+		}
+
+		if ($this->appManager->isEnabledForUser($providingApp) === false) {
+			return null;
+		}
+
+		if ($this->hasLeafBundle(appId: $providingApp) === false) {
+			// Enqueuing a script that does not exist is a 404 in the page,
+			// so an app that ships no leaf entry is simply skipped.
+			return null;
+		}
+
+		return $providingApp;
+	}//end bundleAppFor()
 
 	/**
 	 * The app whose page is being rendered, from the request path.
@@ -234,10 +252,11 @@ class LeafScriptListener implements IEventListener {
 	 */
 	private function currentAppId(): ?string {
 		$path = (string)$this->request->getPathInfo();
-		if (preg_match('#(?:^|/)apps/([a-z0-9_.-]+)(?:/|$)#', $path, $m) !== 1) {
+		if (preg_match('#(?:^|/)apps/([a-z0-9_.-]+)(?:/|$)#', $path, $matches) !== 1) {
 			return null;
 		}
-		return $m[1];
+
+		return $matches[1];
 	}//end currentAppId()
 
 	/**

--- a/tests/Unit/Controller/ConfigurationsControllerTest.php
+++ b/tests/Unit/Controller/ConfigurationsControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Tests\Unit\Controller;
 
 use OCA\OpenRegister\Controller\ConfigurationsController;
+use OCA\OpenRegister\Db\Configuration;
 use OCA\OpenRegister\Db\ConfigurationMapper;
 use OCA\OpenRegister\Service\ConfigurationService;
 use OCA\OpenRegister\Service\UploadService;
@@ -360,6 +361,49 @@ class ConfigurationsControllerTest extends TestCase {
 		$data = $result->getData();
 		$this->assertEquals('Import successful', $data['message']);
 		$this->assertArrayHasKey('imported', $data);
+	}
+
+	public function testImportBuildsTheConfigurationThroughTheMapper(): void {
+		// The entity used to be assembled here with `new Configuration()` and
+		// then inserted, and two of the setters wrote `created`/`updated` that
+		// the mapper stamps again on insert. It is one call now, so this pins
+		// the fields the import actually carries across.
+		$this->request->method('getUploadedFile')->willReturn(['tmp_name' => '/tmp/test.json']);
+		$this->request->method('getParam')
+			->willReturnMap([
+				['appId', null, null],
+				['owner', null, 'admin'],
+				['version', null, '1.0.0'],
+				['force', null, false],
+			]);
+		$this->request->method('getParams')->willReturn([]);
+
+		$jsonData = [
+			'info' => ['title' => 'Vergunningen', 'description' => 'Desc', 'version' => '2.1.0'],
+			'x-openregister' => ['app' => 'buildiq'],
+		];
+		$this->configurationService->method('getUploadedJson')->willReturn($jsonData);
+		$this->configurationService->method('importFromJson')->willReturn(['schemas' => [], 'registers' => [], 'objects' => []]);
+
+		$seen = null;
+		$this->configurationMapper->expects($this->once())
+			->method('createFromArray')
+			->willReturnCallback(function (array $data) use (&$seen): Configuration {
+				$seen = $data;
+
+				return new Configuration();
+			});
+
+		$this->controller->import();
+
+		$this->assertSame('Vergunningen', $seen['title']);
+		$this->assertSame('2.1.0', $seen['version']);
+		$this->assertSame('upload', $seen['sourceType']);
+		// No appId parameter, so the descriptor's own app is the fallback.
+		$this->assertSame('buildiq', $seen['app']);
+		$this->assertSame('admin', $seen['owner']);
+		$this->assertArrayNotHasKey('created', $seen, 'the mapper stamps created on insert');
+		$this->assertArrayNotHasKey('updated', $seen, 'the mapper stamps updated on insert');
 	}
 
 	public function testImportReturnsJsonResponseFromGetUploadedJson(): void {


### PR DESCRIPTION
Two of the legs that fail every push on `development`.

## `PHP Quality (phpmd)`

Five findings, four of them complexity, all of them older than the red they cause.

`LeafScriptListener::leafAppsFor()` was over both the cyclomatic and the NPath threshold because one loop body carried four separate reasons a descriptor contributes nothing. Each reason is a `return null` in `bundleAppFor()` now. The rule is unchanged and its ten tests still pass. The `$m` in `currentAppId()` is `$matches`.

`MagicSearchHandler::buildMetadataOperatorConditionsSql()` had 486 paths through it, from three independent operator families sharing one method: the scalar comparisons, `in`/`notIn`, and `isnull`. They are three methods now, emitted in the same order, so the SQL is byte for byte what it was. Its 36 tests still pass.

`ConfigurationsController` coupled fourteen types where the threshold is thirteen. Two go, and both were redundant rather than load-bearing:

- `import()` assembled a `Configuration` by hand and then inserted it, though `ConfigurationMapper::createFromArray()` does both. Two of the setters wrote `created`/`updated` that `insert()` stamps again on the way past, so they were writing values the mapper overwrote. A new test pins which fields the import actually carries across.
- The export filename asked a `DateTime` instance for the same string `date()` returns from the same default timezone.

## `Frontend Check (check:schema-l10n)`

The leg reports "22 schema string(s) added with no catalogue key". No schema string was added.

The baseline was written as 601 in the same commit that added the register descriptors (`5c9fb7a`), and that commit's own tree already measures 623. Verified by archiving the tree at that sha and running the script against it. The recorded number never described the tree it shipped with.

Leaving it costs the ratchet entirely: at 623 against 601 the leg fails on every push, so a genuinely new uncovered string is invisible inside a red everyone has learned to skip. At 623 the next one fails the build, which is what a ratchet is for.

**This translates nothing.** 623 schema strings still render in English inside an otherwise Dutch form, and each one is 36 translations because every required locale owes a value for every English key. That debt is real, unchanged, and now stated at its actual size instead of 22 below it.

## Verified locally

| check | result |
|---|---|
| `phpmd` on each of the three changed classes | green, with the baseline file CI uses |
| `phpcs` on all three | 0 errors |
| `psalm` on all three | no errors |
| `phpunit` LeafScriptListener | 10 tests green |
| `phpunit` MagicSearchHandler (3 files) | 36 tests green |
| `phpunit` ConfigurationsController | 24 tests green, including the new one |
| `check:schema-l10n` | green at 623 = 623 |

`test:l10n`, the third leg red on `development`, is fixed in #3442 instead: it is the same fourteen missing English keys that the card step's own strings surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
