### PR TITLE
feat(locking): run-scoped object locks that actually refuse a write

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6872,16 +6872,16 @@
         },
         {
             "name": "conduction/hydra-gates",
-            "version": "v1.14.0",
+            "version": "v1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ConductionNL/.github.git",
-                "reference": "7150f7f7327109cafce40ca23ca3310ee2c10aa8"
+                "reference": "0bc214023be78aac94142035a9988986cfccccbc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/7150f7f7327109cafce40ca23ca3310ee2c10aa8",
-                "reference": "7150f7f7327109cafce40ca23ca3310ee2c10aa8",
+                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/0bc214023be78aac94142035a9988986cfccccbc",
+                "reference": "0bc214023be78aac94142035a9988986cfccccbc",
                 "shasum": ""
             },
             "require": {
@@ -6920,9 +6920,9 @@
             "support": {
                 "docs": "https://github.com/ConductionNL/.github/blob/main/hydra-gates/README.md",
                 "issues": "https://github.com/ConductionNL/.github/issues",
-                "source": "https://github.com/ConductionNL/.github/tree/v1.14.0"
+                "source": "https://github.com/ConductionNL/.github/tree/v1.15.0"
             },
-            "time": "2026-09-04T14:51:44+00:00"
+            "time": "2026-09-04T16:24:04+00:00"
         },
         {
             "name": "consolidation/annotated-command",

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -2580,6 +2580,18 @@ class Application extends App implements IBootstrap {
 			\OCA\OpenRegister\Listener\TaskRunTerminalListener::class
 		);
 
+		// Release layer 1 of run-scoped object locking: a run that holds object
+		// locks releases every one of them when it ends, on ANY of the four
+		// terminal statuses. Hooked here rather than in a node because a run
+		// that failed or was reaped never reaches another step, and that is
+		// exactly the run whose lock most needs releasing. Idempotent, and it
+		// never rethrows: the dispatch happens inside the run's own terminal
+		// write.
+		$context->registerEventListener(
+			\OCA\OpenRegister\Event\FlowRunTerminalEvent::class,
+			\OCA\OpenRegister\Listener\FlowRunLockReleaseListener::class
+		);
+
 // The other direction (flow-user-task-node): a task the graph raised
 		// reached a terminal state, so its suspended run is woken and, per the
 		// node's `advance` budget, continued in-request. Fires AFTER the task's

--- a/lib/BackgroundJob/FlowRunWorker.php
+++ b/lib/BackgroundJob/FlowRunWorker.php
@@ -177,6 +177,14 @@ class FlowRunWorker extends TimedJob {
 	 * @param FlowStreamMapper|null $streams Run streams, for failing an abandoned branch.
 	 * @param FlowLocator|null $flows Resolves the run's flow, for the abandoned step's `onError` policy.
 	 * @param RunLockRegistry|null $locks Run-held object locks, for the orphaned-lock sweep.
+	 *
+	 * @SuppressWarnings(PHPMD.ExcessiveParameterList) This worker is the one
+	 * cron entry point for run lifecycle work, and each pass it makes needs a
+	 * different collaborator: reaping, claim release, stream failure, consent,
+	 * and now the orphaned-lock sweep. Every one after the fifth is nullable
+	 * with a default so an older DI graph still constructs it. Splitting the
+	 * worker to satisfy the count would buy a second cron job and a second
+	 * ordering to reason about, which is the more expensive of the two.
 	 */
 	public function __construct(
 		ITimeFactory $time,

--- a/lib/BackgroundJob/FlowRunWorker.php
+++ b/lib/BackgroundJob/FlowRunWorker.php
@@ -41,6 +41,7 @@ use OCA\OpenRegister\Db\FlowStreamMapper;
 use OCA\OpenRegister\Service\Delegation\DelegationService;
 use OCA\OpenRegister\Service\Flow\FlowConsentParking;
 use OCA\OpenRegister\Service\Flow\FlowLocator;
+use OCA\OpenRegister\Service\Object\RunLockRegistry;
 use OCA\OpenRegister\Service\Flow\FlowRunAdvancer;
 use OCA\OpenRegister\Service\Flow\FlowTokenRouter;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -175,6 +176,7 @@ class FlowRunWorker extends TimedJob {
 	 * @param FlowClaimMapper|null $claims Place claims, for the abandoned-claim reaper.
 	 * @param FlowStreamMapper|null $streams Run streams, for failing an abandoned branch.
 	 * @param FlowLocator|null $flows Resolves the run's flow, for the abandoned step's `onError` policy.
+	 * @param RunLockRegistry|null $locks Run-held object locks, for the orphaned-lock sweep.
 	 */
 	public function __construct(
 		ITimeFactory $time,
@@ -186,6 +188,7 @@ class FlowRunWorker extends TimedJob {
 		private readonly ?FlowClaimMapper $claims = null,
 		private readonly ?FlowStreamMapper $streams = null,
 		private readonly ?FlowLocator $flows = null,
+		private readonly ?RunLockRegistry $locks = null,
 	) {
 		parent::__construct(time: $time);
 		// A FLOOR, not a schedule. `setInterval` says "not more often than
@@ -229,6 +232,7 @@ class FlowRunWorker extends TimedJob {
 			$this->advance(run: $run);
 		}
 
+		$this->sweepOrphanedLocks(now: $now);
 		$this->prune(now: $now);
 
 	}//end run()
@@ -717,4 +721,45 @@ class FlowRunWorker extends TimedJob {
 		}//end try
 
 	}//end prune()
+
+	/**
+	 * Release object locks whose holding run is terminal, gone or expired.
+	 *
+	 * Release layer 2. Layer 1, the `FlowRunTerminalEvent` listener, covers
+	 * every run that reaches a terminal status, and the reapers above do
+	 * eventually terminate a run whose worker was killed. What neither covers
+	 * is a release that itself failed, or a run row deleted out from under an
+	 * outstanding lock. This collects those.
+	 *
+	 * It reads the run-lock registry, not the objects: locks live in the
+	 * `_locked` column of magic tables, and an instance-wide scan over those
+	 * costs seconds just to PLAN. Never throws: a sweep that can fail the
+	 * whole worker pass would take the queue down with it, and the lock TTL is
+	 * still the backstop underneath.
+	 *
+	 * @param DateTime $now The pass clock.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-every-lock-a-run-holds-is-released-when-the-run-ends
+	 */
+	private function sweepOrphanedLocks(DateTime $now): void {
+		if ($this->locks === null) {
+			return;
+		}
+
+		try {
+			$released = $this->locks->sweepOrphaned(now: $now, limit: self::BATCH);
+			if ($released > 0) {
+				$this->logger->info(
+					sprintf('[FlowRunWorker] Swept %d orphaned object lock(s).', $released)
+				);
+			}
+		} catch (\Throwable $e) {
+			$this->logger->warning(
+				'[FlowRunWorker] Orphaned-lock sweep failed: ' . $e->getMessage(),
+				['exception' => $e]
+			);
+		}//end try
+	}//end sweepOrphanedLocks()
 }//end class

--- a/lib/Contract/ObjectServiceInterface.php
+++ b/lib/Contract/ObjectServiceInterface.php
@@ -458,10 +458,11 @@ interface ObjectServiceInterface {
 	 *
 	 * @param string|int $identifier The object id or UUID.
 	 * @param bool       $advisory   Take an advisory (non-blocking) lock.
+	 * @param ?string    $runUuid    The flow run releasing the lock, for a run-scoped lock.
 	 *
 	 * @return bool True when the lock was released.
 	 */
-	public function unlockObject(string|int $identifier, bool $advisory=false): bool;
+	public function unlockObject(string|int $identifier, bool $advisory=false, ?string $runUuid=null): bool;
 
 	/**
 	 * Take a lock on an object.
@@ -470,6 +471,10 @@ interface ObjectServiceInterface {
 	 * @param ?string $process    A label for the process holding the lock.
 	 * @param ?int    $duration   Lock duration in seconds.
 	 * @param bool    $advisory   Take an advisory (non-blocking) lock.
+	 * @param ?string $runUuid    The flow run taking the lock. A run-scoped lock
+	 *                            refuses every other caller, the run's own runAs
+	 *                            user included.
+	 * @param ?string $nodeId     The flow node that took it, recorded for the sweep.
 	 *
 	 * @return array The resulting lock state.
 	 */
@@ -477,7 +482,9 @@ interface ObjectServiceInterface {
 		string $identifier,
 		?string $process=null,
 		?int $duration=null,
-		bool $advisory=false
+		bool $advisory=false,
+		?string $runUuid=null,
+		?string $nodeId=null
 	): array;
 
 	/**

--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -2851,15 +2851,18 @@ class ObjectsController extends Controller {
 				return new JSONResponse(data: ['error' => 'Object not found in specified register/schema'], statusCode: 404);
 			}
 
-			// Check if the object is locked.
-			if ($existingObject->isLocked() === true
-				&& $existingObject->getLockedBy() !== $this->container->get('userId')
-			) {
-				// Return a "locked" error with the user who has the lock.
+			// Check if the object is locked. This was the ONE live lock guard
+			// in the codebase, because it read the holder under the key
+			// `lock()` actually writes; the service-layer guard read a key
+			// that never existed. Both now delegate to the same predicate, so
+			// there is one comparison rather than two spellings of it.
+			if ($existingObject->isLockedBySomeoneElse(userId: $this->container->get('userId')) === true) {
+				// Return a "locked" error naming the holder.
 				return new JSONResponse(
 					data: [
-						'error' => 'Object is locked by ' . $existingObject->getLockedBy(),
+						'error' => 'Object is locked by ' . (string)$existingObject->describeLockHolder(),
 						'lockedBy' => $existingObject->getLockedBy(),
+						'lockedByRun' => $existingObject->getLockedByRun(),
 					],
 					statusCode: 423
 				);
@@ -2916,7 +2919,13 @@ class ObjectsController extends Controller {
 			// locked" question is free here and the scan is pure waste — measured
 			// at ~780 ms of a ~1.3 s update.
 			try {
-				if ($objectEntity->isLocked() === true) {
+				// Release ONLY a lock this writer actually holds. A run-held
+				// lock must survive somebody else's write: without this test
+				// an administrator's write would silently strip a run's lock
+				// as a side effect of a guard it had just passed.
+				if ($objectEntity->isLocked() === true
+					&& $objectEntity->isLockedBySomeoneElse(userId: $this->container->get('userId')) === false
+				) {
 					$this->objectService->unlockObject($objectEntity->getUuid());
 				}
 			} catch (\Exception $e) {
@@ -3139,7 +3148,13 @@ class ObjectsController extends Controller {
 			// locked" question is free here and the scan is pure waste — measured
 			// at ~780 ms of a ~1.3 s update.
 			try {
-				if ($objectEntity->isLocked() === true) {
+				// Release ONLY a lock this writer actually holds. A run-held
+				// lock must survive somebody else's write: without this test
+				// an administrator's write would silently strip a run's lock
+				// as a side effect of a guard it had just passed.
+				if ($objectEntity->isLocked() === true
+					&& $objectEntity->isLockedBySomeoneElse(userId: $this->container->get('userId')) === false
+				) {
 					$this->objectService->unlockObject($objectEntity->getUuid());
 				}
 			} catch (\Exception $e) {
@@ -3315,7 +3330,13 @@ class ObjectsController extends Controller {
 			// locked" question is free here and the scan is pure waste — measured
 			// at ~780 ms of a ~1.3 s update.
 			try {
-				if ($objectEntity->isLocked() === true) {
+				// Release ONLY a lock this writer actually holds. A run-held
+				// lock must survive somebody else's write: without this test
+				// an administrator's write would silently strip a run's lock
+				// as a side effect of a guard it had just passed.
+				if ($objectEntity->isLocked() === true
+					&& $objectEntity->isLockedBySomeoneElse(userId: $this->container->get('userId')) === false
+				) {
 					$this->objectService->unlockObject($objectEntity->getUuid());
 				}
 			} catch (\Exception $e) {

--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -7624,6 +7624,8 @@ class MagicMapper extends AbstractObjectMapper {
 	 * @param Register $register The register context.
 	 * @param Schema $schema The schema context.
 	 * @param int|null $lockDuration Lock duration in seconds (null for default).
+	 * @param string|null $process What the lock was taken for.
+	 * @param string|null $runUuid Flow run taking the lock, for a run-scoped lock.
 	 *
 	 * @throws Exception If locking fails.
 	 *
@@ -7634,9 +7636,22 @@ class MagicMapper extends AbstractObjectMapper {
 		Register $register,
 		Schema $schema,
 		?int $lockDuration = null,
+		?string $process = null,
+		?string $runUuid = null,
 	): ObjectEntity {
 		// Lock using entity method.
-		$entity->lock(userSession: $this->userSession, process: 'MagicMapper lock', duration: $lockDuration);
+		//
+		// `$process` used to be dropped here: this method hardcoded the
+		// literal 'MagicMapper lock', so every caller's process tag was
+		// discarded before it reached the payload. integriq mints a fresh
+		// UUID per lock and passes it in, and no caller has ever been able to
+		// read back what a lock was taken FOR.
+		$entity->lock(
+			userSession: $this->userSession,
+			process: ($process ?? 'MagicMapper lock'),
+			duration: $lockDuration,
+			runUuid: $runUuid
+		);
 
 		// Update entity in table with locked field set.
 		$this->updateObjectEntity(entity: $entity, register: $register, schema: $schema);
@@ -7663,6 +7678,8 @@ class MagicMapper extends AbstractObjectMapper {
 	 * @param ObjectEntity $entity The object entity to unlock.
 	 * @param Register $register The register context.
 	 * @param Schema $schema The schema context.
+	 * @param string|null $runUuid Flow run releasing the lock, for a run-scoped lock.
+	 * @param bool $break Release regardless of holder (administrator break-lock).
 	 *
 	 * @throws Exception If unlocking fails.
 	 *
@@ -7672,9 +7689,11 @@ class MagicMapper extends AbstractObjectMapper {
 		ObjectEntity $entity,
 		Register $register,
 		Schema $schema,
+		?string $runUuid = null,
+		bool $break = false,
 	): ObjectEntity {
 		// Unlock using entity method.
-		$entity->unlock($this->userSession);
+		$entity->unlock($this->userSession, $runUuid, $break);
 
 		// Update entity in table with locked field cleared.
 		$this->updateObjectEntity(entity: $entity, register: $register, schema: $schema);

--- a/lib/Db/ObjectEntity.php
+++ b/lib/Db/ObjectEntity.php
@@ -1124,19 +1124,160 @@ class ObjectEntity extends Entity implements JsonSerializable, ObjectEntityInter
 	}//end getFormattedDate()
 
 	/**
+	 * Holder kind for a lock taken by a flow run.
+	 *
+	 * @var string
+	 */
+	public const LOCK_KIND_RUN = 'run';
+
+	/**
+	 * Holder kind for a lock taken by a person.
+	 *
+	 * A payload with no `kind` at all is read as this one, which is how every
+	 * lock written before run-scoped locking keeps its meaning without a
+	 * migration or a back-fill. No such record can be misclassified, because
+	 * no run has ever been able to take a lock.
+	 *
+	 * @var string
+	 */
+	public const LOCK_KIND_USER = 'user';
+
+	/**
+	 * Whether the live lock on this object is held AGAINST the given caller.
+	 *
+	 * This is the ONE production predicate for lock ownership. Every write
+	 * guard, every unlock authorization and every flow node calls it, and
+	 * nothing restates the comparison, tests included. It used to be spelled
+	 * three different ways in three places and two of them were wrong.
+	 *
+	 * The rules:
+	 *  - No live lock: held against nobody. An EXPIRED lock is not a lock.
+	 *  - User lock: held against everyone whose uid differs from the recorded
+	 *    one. This is the historical behaviour, unchanged.
+	 *  - Run lock: held against everyone whose run uuid differs from the
+	 *    recorded one, INCLUDING a caller presenting the run's own `runAs`
+	 *    user and no run uuid. That exclusion is the point: if the runAs user
+	 *    were admitted, a lock taken by a run under `alice` would be no
+	 *    obstacle to alice, and on an instance where flows run as one service
+	 *    account it would be no obstacle to anybody.
+	 *  - Run lock with no `runUuid`: held against everybody. A malformed lock
+	 *    fails CLOSED, because the alternative is silently converting a
+	 *    writer's bug into an open door.
+	 *
+	 * @param string|null $userId The caller's user id, or null when anonymous.
+	 * @param string|null $runUuid The caller's flow-run uuid, when the caller is a run.
+	 *
+	 * @return bool True when the caller must be refused.
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-ownership-is-decided-by-one-predicate
+	 */
+	public function isLockedBySomeoneElse(?string $userId, ?string $runUuid = null): bool {
+		if ($this->isLocked() === false) {
+			return false;
+		}
+
+		$lock = ($this->locked ?? []);
+		$kind = ($lock['kind'] ?? self::LOCK_KIND_USER);
+
+		if ($kind === self::LOCK_KIND_RUN) {
+			$holder = ($lock['runUuid'] ?? null);
+			if (is_string($holder) === false || trim($holder) === '') {
+				// Malformed run lock: admit nobody.
+				return true;
+			}
+
+			return ($runUuid === null || trim($runUuid) !== trim($holder));
+		}
+
+		return (($lock['user'] ?? null) !== $userId);
+	}//end isLockedBySomeoneElse()
+
+	/**
+	 * Describe the live lock's holder for a refusal message.
+	 *
+	 * A refusal that does not say who holds the lock leaves the reader with
+	 * nowhere to go, which is why the message is built here rather than at
+	 * each of the four guards.
+	 *
+	 * @return string|null The holder description, or null when not locked.
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-a-lock-refuses-a-write-and-names-its-holder
+	 */
+	public function describeLockHolder(): ?string {
+		if ($this->isLocked() === false) {
+			return null;
+		}
+
+		$lock = ($this->locked ?? []);
+		if (($lock['kind'] ?? self::LOCK_KIND_USER) !== self::LOCK_KIND_RUN) {
+			return (string)($lock['user'] ?? 'another user');
+		}
+
+		$run = trim((string)($lock['runUuid'] ?? ''));
+		if ($run === '') {
+			return 'a flow run that did not record its identity';
+		}
+
+		$runAs = trim((string)($lock['user'] ?? ''));
+		if ($runAs === '') {
+			return sprintf('flow run %s', $run);
+		}
+
+		return sprintf('flow run %s, running as %s', $run, $runAs);
+	}//end describeLockHolder()
+
+	/**
+	 * Get the flow run holding this object, when a run holds it.
+	 *
+	 * @return string|null The holding run's uuid, or null when the lock is a
+	 *                     user lock, malformed, expired or absent.
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-a-lock-records-whether-a-run-or-a-person-holds-it
+	 */
+	public function getLockedByRun(): ?string {
+		if ($this->isLocked() === false) {
+			return null;
+		}
+
+		$lock = ($this->locked ?? []);
+		if (($lock['kind'] ?? self::LOCK_KIND_USER) !== self::LOCK_KIND_RUN) {
+			return null;
+		}
+
+		$run = trim((string)($lock['runUuid'] ?? ''));
+		if ($run === '') {
+			return null;
+		}
+
+		return $run;
+	}//end getLockedByRun()
+
+	/**
 	 * Lock the object for a specific duration
+	 *
+	 * Passing `$runUuid` takes a RUN-scoped lock: one that refuses every
+	 * caller but that run, the run's own `runAs` user included. Omitting it
+	 * takes the user lock this method has always taken.
 	 *
 	 * @param IUserSession $userSession Current user session
 	 * @param string|null $process Optional process identifier
 	 * @param int|null $duration Lock duration in seconds (default: 1 hour)
+	 * @param string|null $runUuid Flow run taking the lock, for a run-scoped lock
 	 *
-	 * @throws Exception If object is already locked by another user
+	 * @throws Exception If the object is already locked by another holder
 	 *
 	 * @return true True if lock was successful
 	 *
 	 * @psalm-suppress PossiblyUnusedReturnValue
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-ownership-is-decided-by-one-predicate
 	 */
-	public function lock(IUserSession $userSession, ?string $process = null, ?int $duration = 3600): bool {
+	public function lock(
+		IUserSession $userSession,
+		?string $process = null,
+		?int $duration = 3600,
+		?string $runUuid = null,
+	): bool {
 		$currentUser = $userSession->getUser();
 		if ($currentUser === null) {
 			throw new Exception('No user logged in');
@@ -1145,24 +1286,35 @@ class ObjectEntity extends Entity implements JsonSerializable, ObjectEntityInter
 		$userId = $currentUser->getUID();
 		$now = new DateTime();
 
-		// If already locked, check if it's the same user and not expired.
+		$kind = self::LOCK_KIND_USER;
+		if ($runUuid !== null && trim($runUuid) !== '') {
+			$kind = self::LOCK_KIND_RUN;
+			$runUuid = trim($runUuid);
+		}
+
+		// If already locked, check whether this caller is the holder.
 		if ($this->isLocked() === true) {
 			$lock = $this->getLocked();
 			if ($lock === null) {
 				throw new Exception('Lock data is missing');
 			}
 
-			// If locked by different user.
-			if ($lock['user'] !== $userId) {
-				throw new Exception('Object is locked by another user');
+			// Held against this caller. Note that two runs under ONE user land
+			// here now: ownership is no longer keyed on the user alone, so the
+			// second run is refused instead of silently extending the first's
+			// lock and being handed the object.
+			if ($this->isLockedBySomeoneElse(userId: $userId, runUuid: $runUuid) === true) {
+				throw new Exception(sprintf('Object is locked by %s', (string)$this->describeLockHolder()));
 			}
 
-			// If same user, extend the lock.
+			// Same holder: extend the lock.
 			$newExpiration = clone $now;
 			$newExpiration->add(new DateInterval('PT' . ($duration ?? 0) . 'S'));
 
 			$this->setLocked(
 				[
+					'kind' => $kind,
+					'runUuid' => ($runUuid ?? null),
 					'user' => $userId,
 					'process' => ($process ?? $lock['process']),
 					'created' => $lock['created'],
@@ -1179,6 +1331,8 @@ class ObjectEntity extends Entity implements JsonSerializable, ObjectEntityInter
 
 		$this->setLocked(
 			[
+				'kind' => $kind,
+				'runUuid' => ($runUuid ?? null),
 				'user' => $userId,
 				'process' => $process,
 				'created' => $now->format('c'),
@@ -1194,14 +1348,22 @@ class ObjectEntity extends Entity implements JsonSerializable, ObjectEntityInter
 	 * Unlock the object
 	 *
 	 * @param IUserSession $userSession Current user session
+	 * @param string|null $runUuid Flow run releasing the lock, for a run-scoped lock
+	 * @param bool $break Release the lock regardless of who holds it. Reserved
+	 *                    for the administrator break-lock, which audits the
+	 *                    displacement at its call site.
 	 *
-	 * @throws Exception If object is locked by another user
+	 * @throws Exception If the object is locked by another holder
 	 *
 	 * @return true True if unlock was successful
 	 *
 	 * @psalm-suppress PossiblyUnusedReturnValue
+	 *
+	 * @SuppressWarnings(PHPMD.BooleanArgumentFlag) The break flag follows the established RBAC-bypass pattern.
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-ownership-is-decided-by-one-predicate
 	 */
-	public function unlock(IUserSession $userSession): bool {
+	public function unlock(IUserSession $userSession, ?string $runUuid = null, bool $break = false): bool {
 		if ($this->isLocked() === false) {
 			return true;
 		}
@@ -1218,8 +1380,10 @@ class ObjectEntity extends Entity implements JsonSerializable, ObjectEntityInter
 			throw new Exception('Object is not locked');
 		}
 
-		if ($this->locked['user'] !== $userId) {
-			throw new Exception('Object is locked by another user');
+		if ($break === false
+			&& $this->isLockedBySomeoneElse(userId: $userId, runUuid: $runUuid) === true
+		) {
+			throw new Exception(sprintf('Object is locked by %s', (string)$this->describeLockHolder()));
 		}
 
 		$this->setLocked(null);

--- a/lib/Db/ObjectEntity.php
+++ b/lib/Db/ObjectEntity.php
@@ -1369,11 +1369,19 @@ class ObjectEntity extends Entity implements JsonSerializable, ObjectEntityInter
 		}
 
 		$currentUser = $userSession->getUser();
-		if ($currentUser === null) {
+		if ($currentUser === null && $break === false) {
+			// A break has no session requirement. The engine releases a run's
+			// locks from a terminal-event listener and from the cron sweep,
+			// and neither has a session: `occ` and background jobs run as
+			// nobody. Requiring a user there would mean the release layers
+			// that exist for crashed runs could never fire, which is the
+			// whole case they were built for. Authorization for a break lives
+			// at the call site (administrator, or the engine releasing a lock
+			// whose holding run it has already matched).
 			throw new Exception('No user logged in');
 		}
 
-		$userId = $currentUser->getUID();
+		$userId = $currentUser?->getUID();
 
 		// Check if locked by different user.
 		if ($this->locked === null) {

--- a/lib/Db/RunObjectLock.php
+++ b/lib/Db/RunObjectLock.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * One object lock held by one flow run.
+ *
+ * The row is BOOKKEEPING, never the authority. The `_locked` payload on the
+ * object itself is the only thing a write guard consults; this table exists
+ * so two questions can be answered without reading objects at all:
+ *
+ *  - "which locks does this run hold", asked by the terminal-event listener,
+ *    which runs inside the run's own write transaction and must be cheap;
+ *  - "which locks are orphaned", asked by the sweep on every cron tick.
+ *
+ * Answering either by scanning the objects is not an option. Locks live in
+ * the `_locked` column of magic tables, one per register-schema pair, and
+ * `MagicMapper::findAcrossAllMagicTables()` carries a measured note that an
+ * instance-wide scan over 2,728 of them builds 690 KB of SQL costing ~3.4s to
+ * PLAN before a row is read.
+ *
+ * Because it is bookkeeping, drift is survivable in both directions: a row
+ * with no matching payload is stale and the sweep deletes it, and a payload
+ * with no row still blocks writes and still expires on its TTL.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-every-lock-a-run-holds-is-released-when-the-run-ends
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use DateTime;
+use JsonSerializable;
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * One run-held object lock.
+ *
+ * @method string|null getRunUuid()
+ * @method void setRunUuid(?string $runUuid)
+ * @method string|null getObjectUuid()
+ * @method void setObjectUuid(?string $objectUuid)
+ * @method string|null getRegisterId()
+ * @method void setRegisterId(?string $registerId)
+ * @method string|null getSchemaId()
+ * @method void setSchemaId(?string $schemaId)
+ * @method string|null getNodeId()
+ * @method void setNodeId(?string $nodeId)
+ * @method DateTime|null getLockedAt()
+ * @method void setLockedAt(?DateTime $lockedAt)
+ * @method DateTime|null getExpiresAt()
+ * @method void setExpiresAt(?DateTime $expiresAt)
+ */
+class RunObjectLock extends Entity implements JsonSerializable {
+
+	/**
+	 * The run holding the lock.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $runUuid = null;
+
+	/**
+	 * The locked object.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $objectUuid = null;
+
+	/**
+	 * The object's register, so a release can resolve it without a scan.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $registerId = null;
+
+	/**
+	 * The object's schema, for the same reason.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $schemaId = null;
+
+	/**
+	 * The flow node that took the lock, so an operator can see WHICH step wedged.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $nodeId = null;
+
+	/**
+	 * When the lock was taken.
+	 *
+	 * @var DateTime|null
+	 */
+	protected ?DateTime $lockedAt = null;
+
+	/**
+	 * When the underlying lock expires on its own. The sweep's second read.
+	 *
+	 * @var DateTime|null
+	 */
+	protected ?DateTime $expiresAt = null;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->addType(fieldName: 'runUuid', type: 'string');
+		$this->addType(fieldName: 'objectUuid', type: 'string');
+		$this->addType(fieldName: 'registerId', type: 'string');
+		$this->addType(fieldName: 'schemaId', type: 'string');
+		$this->addType(fieldName: 'nodeId', type: 'string');
+		$this->addType(fieldName: 'lockedAt', type: 'datetime');
+		$this->addType(fieldName: 'expiresAt', type: 'datetime');
+	}//end __construct()
+
+	/**
+	 * JSON shape.
+	 *
+	 * @return array<string, mixed> The row as an array.
+	 */
+	public function jsonSerialize(): array {
+		return [
+			'id' => $this->id,
+			'runUuid' => $this->runUuid,
+			'objectUuid' => $this->objectUuid,
+			'registerId' => $this->registerId,
+			'schemaId' => $this->schemaId,
+			'nodeId' => $this->nodeId,
+			'lockedAt' => $this->lockedAt?->format('c'),
+			'expiresAt' => $this->expiresAt?->format('c'),
+		];
+	}//end jsonSerialize()
+}//end class

--- a/lib/Db/RunObjectLockMapper.php
+++ b/lib/Db/RunObjectLockMapper.php
@@ -96,7 +96,7 @@ class RunObjectLockMapper extends QBMapper {
 			->from($this->getTableName())
 			->where($qb->expr()->eq('run_uuid', $qb->createNamedParameter($runUuid)));
 
-		return $this->findEntities($qb);
+		return $this->findEntities(query: $qb);
 	}//end findByRun()
 
 	/**
@@ -175,6 +175,6 @@ class RunObjectLockMapper extends QBMapper {
 			$qb->setParameter($key, $value, $active->getParameterTypes()[$key] ?? null);
 		}
 
-		return $this->findEntities($qb);
+		return $this->findEntities(query: $qb);
 	}//end findOrphaned()
 }//end class

--- a/lib/Db/RunObjectLockMapper.php
+++ b/lib/Db/RunObjectLockMapper.php
@@ -1,0 +1,180 @@
+<?php
+
+/**
+ * The run-held object lock registry.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-every-lock-a-run-holds-is-released-when-the-run-ends
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use DateTime;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\Exception as DbException;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * Run-held object locks.
+ *
+ * @template-extends QBMapper<RunObjectLock>
+ */
+class RunObjectLockMapper extends QBMapper {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IDBConnection $db Database connection.
+	 */
+	public function __construct(IDBConnection $db) {
+		parent::__construct(
+			db: $db,
+			tableName: 'openregister_run_object_locks',
+			entityClass: RunObjectLock::class
+		);
+	}//end __construct()
+
+	/**
+	 * Record that a run holds a lock, or refresh the record it already has.
+	 *
+	 * A run re-locking an object it already holds extends the lock rather
+	 * than taking a second one, so the registry must behave the same way and
+	 * not trip its own unique index.
+	 *
+	 * @param RunObjectLock $lock The lock to record.
+	 *
+	 * @return void
+	 *
+	 * @throws DbException On any database failure other than the duplicate.
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-every-lock-a-run-holds-is-released-when-the-run-ends
+	 */
+	public function record(RunObjectLock $lock): void {
+		try {
+			$this->insert(entity: $lock);
+			return;
+		} catch (DbException $e) {
+			if ($e->getReason() !== DbException::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+				throw $e;
+			}
+		}
+
+		// Already recorded: refresh the expiry, which the extend branch moved.
+		$qb = $this->db->getQueryBuilder();
+		$qb->update($this->getTableName())
+			->set('expires_at', $qb->createNamedParameter($lock->getExpiresAt(), IQueryBuilder::PARAM_DATETIME_MUTABLE))
+			->set('node_id', $qb->createNamedParameter($lock->getNodeId()))
+			->where($qb->expr()->eq('run_uuid', $qb->createNamedParameter($lock->getRunUuid())))
+			->andWhere($qb->expr()->eq('object_uuid', $qb->createNamedParameter($lock->getObjectUuid())));
+		$qb->executeStatement();
+	}//end record()
+
+	/**
+	 * Every lock one run holds.
+	 *
+	 * @param string $runUuid The run.
+	 *
+	 * @return array<int, RunObjectLock> The run's locks.
+	 */
+	public function findByRun(string $runUuid): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('run_uuid', $qb->createNamedParameter($runUuid)));
+
+		return $this->findEntities($qb);
+	}//end findByRun()
+
+	/**
+	 * Forget every lock one run holds.
+	 *
+	 * @param string $runUuid The run.
+	 *
+	 * @return int Rows deleted.
+	 */
+	public function forgetRun(string $runUuid): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->eq('run_uuid', $qb->createNamedParameter($runUuid)));
+
+		return $qb->executeStatement();
+	}//end forgetRun()
+
+	/**
+	 * Forget one run's lock on one object.
+	 *
+	 * @param string $runUuid The run.
+	 * @param string $objectUuid The object.
+	 *
+	 * @return int Rows deleted.
+	 */
+	public function forget(string $runUuid, string $objectUuid): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->eq('run_uuid', $qb->createNamedParameter($runUuid)))
+			->andWhere($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)));
+
+		return $qb->executeStatement();
+	}//end forget()
+
+	/**
+	 * Locks whose holding run is terminal, gone, or whose lock has expired.
+	 *
+	 * The sweep's read. One indexed query against the runs table rather than
+	 * a scan across every magic table on the instance.
+	 *
+	 * A lock is orphaned when ANY of these hold:
+	 *  - its run row no longer exists (retention deleted it, or it was never
+	 *    written), so no terminal event can ever fire for it;
+	 *  - its run reached a terminal status without the release landing;
+	 *  - the underlying lock has expired anyway, so the row is stale
+	 *    bookkeeping for a lock that already blocks nobody.
+	 *
+	 * @param DateTime $now The sweep's clock.
+	 * @param int $limit Batch ceiling.
+	 *
+	 * @return array<int, RunObjectLock> The orphaned locks.
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-every-lock-a-run-holds-is-released-when-the-run-ends
+	 */
+	public function findOrphaned(DateTime $now, int $limit = 100): array {
+		$active = $this->db->getQueryBuilder();
+		$active->select('uuid')
+			->from('openregister_flow_runs')
+			->where($active->expr()->in('status', $active->createNamedParameter(FlowRun::ACTIVE, IQueryBuilder::PARAM_STR_ARRAY)));
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where(
+				$qb->expr()->orX(
+					// Not held by any ACTIVE run: terminal, or the row is gone.
+					$qb->createFunction('run_uuid NOT IN (' . $active->getSQL() . ')'),
+					// Or the lock has expired regardless.
+					$qb->expr()->lt('expires_at', $qb->createNamedParameter($now, IQueryBuilder::PARAM_DATETIME_MUTABLE))
+				)
+			)
+			->setMaxResults($limit);
+
+		// The sub-select's placeholder must travel with the outer query.
+		foreach ($active->getParameters() as $key => $value) {
+			$qb->setParameter($key, $value, $active->getParameterTypes()[$key] ?? null);
+		}
+
+		return $this->findEntities($qb);
+	}//end findOrphaned()
+}//end class

--- a/lib/Db/RunObjectLockMapper.php
+++ b/lib/Db/RunObjectLockMapper.php
@@ -152,29 +152,75 @@ class RunObjectLockMapper extends QBMapper {
 	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-every-lock-a-run-holds-is-released-when-the-run-ends
 	 */
 	public function findOrphaned(DateTime $now, int $limit = 100): array {
+		// TWO plain queries rather than one composite.
+		//
+		// The obvious single query is an orX() of a `run_uuid NOT IN
+		// (sub-select)` built with createFunction() and an `expires_at <`
+		// comparison. On PostgreSQL that composes to `(a) OR (b)` where the
+		// createFunction half is not recognised as a boolean, and the whole
+		// sweep dies with "argument of OR must be type boolean, not type
+		// record" — which the sweep's own catch would have swallowed into a
+		// log line while releasing nothing, forever. Two readable queries and
+		// a merge cost one extra round trip per cron tick and cannot fail
+		// that way.
+		$byRun = $this->findNotHeldByAnActiveRun(limit: $limit);
+		$byExpiry = $this->findExpired(now: $now, limit: $limit);
+
+		$merged = [];
+		foreach (array_merge($byRun, $byExpiry) as $row) {
+			$merged[(string)$row->getId()] = $row;
+		}
+
+		return array_slice(array_values($merged), 0, $limit);
+	}//end findOrphaned()
+
+	/**
+	 * Locks whose holding run is terminal or no longer exists.
+	 *
+	 * @param int $limit Batch ceiling.
+	 *
+	 * @return array<int, RunObjectLock> The rows.
+	 */
+	private function findNotHeldByAnActiveRun(int $limit): array {
+		$qb = $this->db->getQueryBuilder();
 		$active = $this->db->getQueryBuilder();
 		$active->select('uuid')
 			->from('openregister_flow_runs')
-			->where($active->expr()->in('status', $active->createNamedParameter(FlowRun::ACTIVE, IQueryBuilder::PARAM_STR_ARRAY)));
+			->where(
+				$active->expr()->in(
+					'status',
+					$qb->createNamedParameter(FlowRun::ACTIVE, IQueryBuilder::PARAM_STR_ARRAY)
+				)
+			);
 
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->createFunction('run_uuid NOT IN (' . $active->getSQL() . ')'))
+			->setMaxResults($limit);
+
+		return $this->findEntities(query: $qb);
+	}//end findNotHeldByAnActiveRun()
+
+	/**
+	 * Rows whose underlying lock has expired anyway.
+	 *
+	 * @param DateTime $now The sweep's clock.
+	 * @param int $limit Batch ceiling.
+	 *
+	 * @return array<int, RunObjectLock> The rows.
+	 */
+	private function findExpired(DateTime $now, int $limit): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from($this->getTableName())
 			->where(
-				$qb->expr()->orX(
-					// Not held by any ACTIVE run: terminal, or the row is gone.
-					$qb->createFunction('run_uuid NOT IN (' . $active->getSQL() . ')'),
-					// Or the lock has expired regardless.
-					$qb->expr()->lt('expires_at', $qb->createNamedParameter($now, IQueryBuilder::PARAM_DATETIME_MUTABLE))
+				$qb->expr()->lt(
+					'expires_at',
+					$qb->createNamedParameter($now, IQueryBuilder::PARAM_DATETIME_MUTABLE)
 				)
 			)
 			->setMaxResults($limit);
 
-		// The sub-select's placeholder must travel with the outer query.
-		foreach ($active->getParameters() as $key => $value) {
-			$qb->setParameter($key, $value, $active->getParameterTypes()[$key] ?? null);
-		}
-
 		return $this->findEntities(query: $qb);
-	}//end findOrphaned()
+	}//end findExpired()
 }//end class

--- a/lib/Listener/FlowNodeRegistrationListener.php
+++ b/lib/Listener/FlowNodeRegistrationListener.php
@@ -35,6 +35,7 @@ use OCA\OpenRegister\Service\Flow\Nodes\ExplodeNode;
 use OCA\OpenRegister\Service\Flow\Nodes\FilterNode;
 use OCA\OpenRegister\Service\Flow\Nodes\FlowStateNode;
 use OCA\OpenRegister\Service\Flow\Nodes\IterateNode;
+use OCA\OpenRegister\Service\Flow\Nodes\LockObjectNode;
 use OCA\OpenRegister\Service\Flow\Nodes\LoopNode;
 use OCA\OpenRegister\Service\Flow\Nodes\MapNode;
 use OCA\OpenRegister\Service\Flow\Nodes\MergeNode;
@@ -51,6 +52,7 @@ use OCA\OpenRegister\Service\Flow\Nodes\SwitchNode;
 use OCA\OpenRegister\Service\Flow\Nodes\TriggerManualNode;
 use OCA\OpenRegister\Service\Flow\Nodes\TriggerObjectNode;
 use OCA\OpenRegister\Service\Flow\Nodes\TriggerScheduleNode;
+use OCA\OpenRegister\Service\Flow\Nodes\UnlockObjectNode;
 use OCA\OpenRegister\Service\Flow\Nodes\UserTaskNode;
 use OCA\OpenRegister\Service\Flow\Nodes\WaitNode;
 use OCA\OpenRegister\Service\Flow\RegisterFlowNodesEvent;
@@ -74,6 +76,8 @@ class FlowNodeRegistrationListener implements IEventListener {
 	 * @param SwitchNode $switch The built-in "Switch" node.
 	 * @param EndNode $end The built-in "End" node.
 	 * @param MergeNode $merge The built-in "Merge" node.
+	 * @param LockObjectNode $lockObject The built-in "Lock an object" node.
+	 * @param UnlockObjectNode $unlockObject The built-in "Unlock an object" node.
 	 * @param LoopNode $loop The built-in "Loop over items" node.
 	 * @param SubFlowNode $subFlow The built-in "Run a flow" node.
 	 * @param RouterNode $router The built-in "Route items" node.
@@ -101,6 +105,8 @@ class FlowNodeRegistrationListener implements IEventListener {
 		private readonly SwitchNode $switch,
 		private readonly EndNode $end,
 		private readonly MergeNode $merge,
+		private readonly LockObjectNode $lockObject,
+		private readonly UnlockObjectNode $unlockObject,
 		private readonly LoopNode $loop,
 		private readonly SubFlowNode $subFlow,
 		private readonly RouterNode $router,
@@ -182,6 +188,12 @@ class FlowNodeRegistrationListener implements IEventListener {
 		// calls back, user task for a performer in the organisation, portal
 		// task for a party outside it.
 		$event->registerNode(node: $this->portalTask);
+
+		// Mutual exclusion. Both are ordinary STEPS: a lock step is work the
+		// run performs, and the release that matters is the engine's terminal
+		// hook rather than the unlock node, so neither is an end node.
+		$event->registerNode(node: $this->lockObject);
+		$event->registerNode(node: $this->unlockObject);
 
 		// Entry points. Registered like any other node so the palette can offer
 		// them and the preflight can check their config — a trigger is where a

--- a/lib/Listener/FlowRunLockReleaseListener.php
+++ b/lib/Listener/FlowRunLockReleaseListener.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * Releases a terminal run's object locks. Release layer 1.
+ *
+ * WHY A LISTENER AND NOT A NODE
+ * -----------------------------
+ * A release that depended on a flow reaching an unlock step would be no
+ * release at all in the cases that matter: a run that failed, was stopped, or
+ * was reaped after its worker died never reaches another step. Hooking the
+ * terminal event instead means the release does not depend on the graph.
+ *
+ * WHY ONE HOOK COVERS EVERYTHING
+ * ------------------------------
+ * `FlowRunMapper::update()` dispatches `FlowRunTerminalEvent` whenever the
+ * persisted row `isTerminal()`. That is a predicate, not a status whitelist,
+ * so all four terminal statuses fire it (completed, stopped, failed,
+ * dead_letter), and so does every reaper, because they all terminate through
+ * the same `update()`.
+ *
+ * 🔴 The event can fire MORE THAN ONCE for one run, and it is dispatched
+ * INSIDE `FlowRunCommit`'s open transaction on the stream-walk path. So this
+ * listener is idempotent and never rethrows: a throw here would unwind the
+ * run's own terminal write, and lock bookkeeping must not be able to do that.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Listener
+ * @package  OCA\OpenRegister\Listener
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-every-lock-a-run-holds-is-released-when-the-run-ends
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Listener;
+
+use OCA\OpenRegister\Event\FlowRunTerminalEvent;
+use OCA\OpenRegister\Service\Object\RunLockRegistry;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Releases every object lock a terminal run holds.
+ *
+ * @template-implements IEventListener<FlowRunTerminalEvent>
+ */
+class FlowRunLockReleaseListener implements IEventListener {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param RunLockRegistry $locks The run-lock lifecycle.
+	 * @param LoggerInterface $logger Failure reporting.
+	 */
+	public function __construct(
+		private readonly RunLockRegistry $locks,
+		private readonly LoggerInterface $logger,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * Release the run's locks.
+	 *
+	 * @param Event $event The dispatched event.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-every-lock-a-run-holds-is-released-when-the-run-ends
+	 */
+	public function handle(Event $event): void {
+		if ($event instanceof FlowRunTerminalEvent === false) {
+			return;
+		}
+
+		try {
+			$released = $this->locks->releaseRunLocks(runUuid: $event->getRunUuid());
+			if ($released > 0) {
+				$this->logger->info(
+					sprintf(
+						'[FlowRunLockReleaseListener] Released %d object lock(s) of run %s (%s).',
+						$released,
+						$event->getRunUuid(),
+						$event->getStatus()
+					)
+				);
+			}
+		} catch (Throwable $failure) {
+			// Never rethrow: see the class docblock. The TTL and the sweep
+			// remain as layers 3 and 2.
+			$this->logger->error(
+				'[FlowRunLockReleaseListener] Lock release failed: ' . $failure->getMessage(),
+				['run' => $event->getRunUuid(), 'exception' => $failure]
+			);
+		}//end try
+	}//end handle()
+}//end class

--- a/lib/Migration/Version1Date20260905120000.php
+++ b/lib/Migration/Version1Date20260905120000.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * The run-held object lock registry.
+ *
+ * Additive: one new table, no column added to and no data changed on any
+ * existing one. The lock payload itself gains its `kind` and `runUuid` keys
+ * inside the existing `_locked` JSON column and so needs no schema change and
+ * no back-fill, which is the whole reason the holder was modelled there. A
+ * record written before this migration carries no `kind` and reads as the
+ * user lock it is.
+ *
+ * Reverting the app code leaves this table inert rather than broken. Dropping
+ * it is a separate, optional migration and MUST NOT be part of the rollback.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-every-lock-a-run-holds-is-released-when-the-run-ends
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use Doctrine\DBAL\Types\Types;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Adds `openregister_run_object_locks`.
+ */
+class Version1Date20260905120000 extends SimpleMigrationStep {
+
+	private const LOCKS = 'openregister_run_object_locks';
+
+	/**
+	 * Create the table.
+	 *
+	 * @param IOutput $output Migration output.
+	 * @param Closure $schemaClosure Schema closure returning an ISchemaWrapper.
+	 * @param array $options Migration options.
+	 *
+	 * @return ISchemaWrapper|null The updated schema, or null when nothing changed.
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/*
+		 * @var ISchemaWrapper $schema
+		 */
+
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable(self::LOCKS) === true) {
+			return null;
+		}
+
+		$table = $schema->createTable(self::LOCKS);
+		$table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true, 'length' => 20]);
+		$table->addColumn('run_uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
+		$table->addColumn('object_uuid', Types::STRING, ['notnull' => true, 'length' => 40]);
+		$table->addColumn('register_id', Types::STRING, ['notnull' => false, 'length' => 64, 'default' => null]);
+		$table->addColumn('schema_id', Types::STRING, ['notnull' => false, 'length' => 64, 'default' => null]);
+		$table->addColumn('node_id', Types::STRING, ['notnull' => false, 'length' => 255, 'default' => null]);
+		$table->addColumn('locked_at', Types::DATETIME_MUTABLE, ['notnull' => true]);
+		$table->addColumn('expires_at', Types::DATETIME_MUTABLE, ['notnull' => false, 'default' => null]);
+		$table->setPrimaryKey(['id']);
+		// A run holds an object once: re-locking extends rather than stacks.
+		$table->addUniqueIndex(['run_uuid', 'object_uuid'], 'or_runlock_run_obj_uq');
+		// The terminal listener's read.
+		$table->addIndex(['run_uuid'], 'or_runlock_run_idx');
+		// The sweep's second predicate.
+		$table->addIndex(['expires_at'], 'or_runlock_exp_idx');
+
+		$output->info(message: 'Created ' . self::LOCKS);
+
+		return $schema;
+	}//end changeSchema()
+}//end class

--- a/lib/Service/Flow/Nodes/LockObjectNode.php
+++ b/lib/Service/Flow/Nodes/LockObjectNode.php
@@ -262,22 +262,37 @@ class LockObjectNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigF
 	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-a-lock-step-takes-a-lock-or-parks-the-run-and-retries
 	 */
 	public function validateConfig(array $config): void {
-		foreach (['duration' => 'duration', 'waitSeconds' => 'waitSeconds'] as $key) {
-			if (array_key_exists($key, $config) === false || $config[$key] === null || $config[$key] === '') {
-				continue;
-			}
+		$this->requirePositiveSeconds(config: $config, key: 'duration');
+		$this->requirePositiveSeconds(config: $config, key: 'waitSeconds');
 
-			if (is_numeric($config[$key]) === false || (int)$config[$key] < 1) {
-				throw new UnexpectedValueException(
-					$this->l10n->t('A lock step\'s "%s" must be a whole number of seconds, at least 1.', [$key])
-				);
-			}
-		}
-
-		if (array_key_exists('uuid', $config) === true && is_string($config['uuid']) === false && $config['uuid'] !== null) {
+		$uuid = ($config['uuid'] ?? null);
+		if ($uuid !== null && is_string($uuid) === false) {
 			throw new UnexpectedValueException($this->l10n->t('A lock step\'s object must be text.'));
 		}
 	}//end validateConfig()
+
+	/**
+	 * Refuse a duration that is not a whole number of seconds.
+	 *
+	 * @param array $config The step configuration.
+	 * @param string $key The key to check.
+	 *
+	 * @return void
+	 *
+	 * @throws UnexpectedValueException When the value cannot be a duration.
+	 */
+	private function requirePositiveSeconds(array $config, string $key): void {
+		$value = ($config[$key] ?? null);
+		if ($value === null || $value === '') {
+			return;
+		}
+
+		if (is_numeric($value) === false || (int)$value < 1) {
+			throw new UnexpectedValueException(
+				$this->l10n->t('A lock step\'s "%s" must be a whole number of seconds, at least 1.', [$key])
+			);
+		}
+	}//end requirePositiveSeconds()
 
 	/**
 	 * Take the lock, or park the run and try again later.
@@ -315,7 +330,7 @@ class LockObjectNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigF
 		$owner = $this->resolveOwner(context: $context);
 		$targets = $this->resolveTargets(items: $items, config: $config);
 
-		$duration = $this->seconds($config, 'duration', self::DEFAULT_DURATION);
+		$duration = $this->seconds(config: $config, key: 'duration', default: self::DEFAULT_DURATION);
 		$process = trim((string)($config['process'] ?? ''));
 		if ($process === '') {
 			$process = sprintf('flow run %s', $runUuid);
@@ -412,12 +427,12 @@ class LockObjectNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigF
 		$backoff = (self::MIN_RETRY_SECONDS * (2 ** min($attempts - 1, 8)));
 		$backoff = min($backoff, self::MAX_RETRY_SECONDS);
 
-		$at = (new DateTime())->modify('+' . $backoff . ' seconds');
-		if ($at > $deadline) {
+		$attemptAt = (new DateTime())->modify('+' . $backoff . ' seconds');
+		if ($attemptAt > $deadline) {
 			return $deadline;
 		}
 
-		return $at;
+		return $attemptAt;
 	}//end nextAttemptAt()
 
 	/**
@@ -441,11 +456,16 @@ class LockObjectNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigF
 			}
 		}
 
-		$wait = $this->seconds($config, 'waitSeconds', self::DEFAULT_WAIT_SECONDS);
-		$deadline = (new DateTime())->modify('+' . $wait . ' seconds');
-		$resume->set(self::SLOT_DEADLINE, $deadline->format('c'));
+		$wait = $this->seconds(config: $config, key: 'waitSeconds', default: self::DEFAULT_WAIT_SECONDS);
+		$stamp = (new DateTime())->modify('+' . $wait . ' seconds')->format('c');
+		$resume->set(self::SLOT_DEADLINE, $stamp);
 
-		return $deadline;
+		// Return the value as PERSISTED, not as computed. `format('c')` drops
+		// sub-second precision, so the deadline this attempt compares against
+		// would otherwise be microseconds later than the one every subsequent
+		// attempt reads back, and the last retry could be scheduled just past
+		// the bound it is supposed to respect.
+		return new DateTime($stamp);
 	}//end deadline()
 
 	/**
@@ -480,6 +500,9 @@ class LockObjectNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigF
 	 * @return array<int, string> The distinct target uuids.
 	 *
 	 * @throws RuntimeException When a target cannot be resolved.
+	 *
+	 * @SuppressWarnings(PHPMD.StaticAccess) FlowValueTemplate is the engine's
+	 * stateless template renderer and every node calls it this way.
 	 */
 	private function resolveTargets(array $items, array $config): array {
 		$configured = ($config['uuid'] ?? null);
@@ -491,10 +514,9 @@ class LockObjectNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigF
 				$json = [];
 			}
 
+			$uuid = trim((string)($json['uuid'] ?? ''));
 			if (is_string($configured) === true && trim($configured) !== '') {
 				$uuid = trim((string)FlowValueTemplate::render($configured, $json));
-			} else {
-				$uuid = trim((string)($json['uuid'] ?? ''));
 			}
 
 			if ($uuid === '') {

--- a/lib/Service/Flow/Nodes/LockObjectNode.php
+++ b/lib/Service/Flow/Nodes/LockObjectNode.php
@@ -1,0 +1,570 @@
+<?php
+
+/**
+ * Take a run-scoped lock on an object, or park the run until it frees.
+ *
+ * WHY A RUN LOCK AND NOT A USER LOCK
+ * ----------------------------------
+ * Object locks used to be keyed on the user alone. Two flow runs executing
+ * under the same `runAs` therefore could not conflict: the second took the
+ * extend branch, pushed the first's expiry out, and was handed the object. On
+ * an instance where flows run as one service account that is EVERY pair of
+ * runs. This node takes a lock keyed on the run, which refuses every other
+ * caller including the run's own `runAs` user acting as a person.
+ *
+ * WHY SUSPEND RATHER THAN FAIL
+ * ----------------------------
+ * A contended lock is not an error, it is a queue. Failing the run would turn
+ * ordinary contention into an incident and lose whatever the run had already
+ * done; proceeding without the lock would be the data race the lock exists to
+ * prevent. So the node parks the run and tries again on the next heartbeat,
+ * which is the mechanism the engine already has for waiting: no second
+ * waiting machinery, no poll loop inside a step.
+ *
+ * THE `resumeAt` MUST NOT BE NULL
+ * -------------------------------
+ * 🔴 A null `resumeAt` means "waiting on an external SIGNAL", and
+ * `FlowRunMapper::findAbandonedSignals()` FAILS such a run after 14 days
+ * without ever waking it. A lock waits on a clock, never on a signal, so
+ * every suspension here carries a concrete time.
+ *
+ * THE BUDGET IS STAMPED ONCE
+ * --------------------------
+ * The deadline goes into the node's own resume slot on the FIRST attempt and
+ * is never restamped. Recomputing it per attempt would reset the budget on
+ * every heartbeat and the node would wait forever while appearing to have a
+ * bound. Since openregister#3358 the slot survives a pass that legitimately
+ * ends `queued`, so the deadline is not lost between attempts either.
+ *
+ * WHEN THE BUDGET RUNS OUT THE STEP FAILS. It does not break the lock:
+ * letting any flow author defeat any other flow author's lock by waiting
+ * would make the lock advisory again, in a new way. Breaking one is an
+ * administrator's act, and it is audited.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow\Nodes
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-a-lock-step-takes-a-lock-or-parks-the-run-and-retries
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow\Nodes;
+
+use DateTime;
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\FlowNodeResumeState;
+use OCA\OpenRegister\Service\Flow\FlowRunContext;
+use OCA\OpenRegister\Service\Flow\FlowRunService;
+use OCA\OpenRegister\Service\Flow\FlowSuspension;
+use OCA\OpenRegister\Service\Flow\FlowValueTemplate;
+use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigForm;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\WorkflowEngine\IManager;
+use RuntimeException;
+use Throwable;
+use UnexpectedValueException;
+
+/**
+ * Take a run-scoped object lock, parking the run while it is contended.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class LockObjectNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigForm {
+
+	/**
+	 * The step type this node answers to.
+	 *
+	 * @var string
+	 */
+	public const TYPE = 'openregister.lock-object';
+
+	/**
+	 * Default lock duration in seconds.
+	 *
+	 * @var int
+	 */
+	public const DEFAULT_DURATION = 3600;
+
+	/**
+	 * Default wait budget in seconds. An hour: long enough to outlast a
+	 * human-scale step upstream, short enough that a wedged run surfaces the
+	 * same working day.
+	 *
+	 * @var int
+	 */
+	public const DEFAULT_WAIT_SECONDS = 3600;
+
+	/**
+	 * Retry floor in seconds.
+	 *
+	 * A wake finer than the cron period cannot happen, so asking for one only
+	 * makes the run look busier than it is.
+	 *
+	 * @var int
+	 */
+	public const MIN_RETRY_SECONDS = 60;
+
+	/**
+	 * Retry ceiling in seconds.
+	 *
+	 * @var int
+	 */
+	public const MAX_RETRY_SECONDS = 900;
+
+	/**
+	 * Resume-slot key holding the absolute wait deadline, stamped ONCE.
+	 *
+	 * @var string
+	 */
+	public const SLOT_DEADLINE = 'lockWaitDeadline';
+
+	/**
+	 * Resume-slot key holding the attempt count, which drives the backoff.
+	 *
+	 * @var string
+	 */
+	public const SLOT_ATTEMPTS = 'lockAttempts';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param ObjectService $objects Object lock operations, RBAC-enforcing.
+	 * @param IUserManager $userManager Resolves the run's acting identity.
+	 * @param IL10N $l10n Translations.
+	 * @param IURLGenerator $urls For the palette icon.
+	 */
+	public function __construct(
+		private readonly ObjectService $objects,
+		private readonly IUserManager $userManager,
+		private readonly IL10N $l10n,
+		private readonly IURLGenerator $urls,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * The step type.
+	 *
+	 * @return string The node id.
+	 */
+	public function getId(): string {
+		return self::TYPE;
+	}//end getId()
+
+	/**
+	 * The palette label.
+	 *
+	 * @return string The display name.
+	 */
+	public function getDisplayName(): string {
+		return $this->l10n->t('Lock an object');
+	}//end getDisplayName()
+
+	/**
+	 * The palette description.
+	 *
+	 * @return string The description.
+	 */
+	public function getDescription(): string {
+		return $this->l10n->t(
+			'Hold an object for this run so nobody else can change it. If another run holds it, this step waits and tries again.'
+		);
+	}//end getDescription()
+
+	/**
+	 * The palette icon.
+	 *
+	 * @return string The icon path.
+	 */
+	public function getIcon(): string {
+		return $this->urls->imagePath('core', 'actions/lock.svg');
+	}//end getIcon()
+
+	/**
+	 * Available in both flow scopes.
+	 *
+	 * @param int $scope The workflow engine scope.
+	 *
+	 * @return bool True when available.
+	 */
+	public function isAvailableForScope(int $scope): bool {
+		return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
+	}//end isAvailableForScope()
+
+	/**
+	 * Top-level configuration keys.
+	 *
+	 * @return array<int, string> The keys.
+	 */
+	public function configKeys(): array {
+		return ['uuid', 'duration', 'waitSeconds', 'process'];
+	}//end configKeys()
+
+	/**
+	 * The editor form.
+	 *
+	 * @return array<int, array<string, mixed>> The fields.
+	 */
+	public function configForm(): array {
+		return [
+			[
+				'key' => 'uuid',
+				'label' => $this->l10n->t('Object'),
+				'type' => 'text',
+				'help' => $this->l10n->t('Which object to lock. Leave empty to lock the object the step receives.'),
+			],
+			[
+				'key' => 'duration',
+				'label' => $this->l10n->t('Hold for (seconds)'),
+				'type' => 'number',
+				'help' => $this->l10n->t('How long the lock survives if this run never releases it. Defaults to one hour.'),
+			],
+			[
+				'key' => 'waitSeconds',
+				'label' => $this->l10n->t('Wait at most (seconds)'),
+				'type' => 'number',
+				'help' => $this->l10n->t('How long to keep retrying while another run holds the object. Defaults to one hour.'),
+			],
+			[
+				'key' => 'process',
+				'label' => $this->l10n->t('Reason'),
+				'type' => 'text',
+				'help' => $this->l10n->t('What the lock is for. Shown to anyone whose write is refused.'),
+			],
+		];
+	}//end configForm()
+
+	/**
+	 * Refuse a configuration the run could not act on.
+	 *
+	 * @param array $config The step configuration.
+	 *
+	 * @return void
+	 *
+	 * @throws UnexpectedValueException When the configuration cannot be run.
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-a-lock-step-takes-a-lock-or-parks-the-run-and-retries
+	 */
+	public function validateConfig(array $config): void {
+		foreach (['duration' => 'duration', 'waitSeconds' => 'waitSeconds'] as $key) {
+			if (array_key_exists($key, $config) === false || $config[$key] === null || $config[$key] === '') {
+				continue;
+			}
+
+			if (is_numeric($config[$key]) === false || (int)$config[$key] < 1) {
+				throw new UnexpectedValueException(
+					$this->l10n->t('A lock step\'s "%s" must be a whole number of seconds, at least 1.', [$key])
+				);
+			}
+		}
+
+		if (array_key_exists('uuid', $config) === true && is_string($config['uuid']) === false && $config['uuid'] !== null) {
+			throw new UnexpectedValueException($this->l10n->t('A lock step\'s object must be text.'));
+		}
+	}//end validateConfig()
+
+	/**
+	 * Take the lock, or park the run and try again later.
+	 *
+	 * @param array $items The incoming items.
+	 * @param array $config The step configuration.
+	 * @param array $context The run context.
+	 *
+	 * @return array The items, unchanged.
+	 *
+	 * @throws FlowSuspension When the lock is contended and the budget remains.
+	 * @throws RuntimeException When the budget is spent, or the step cannot act.
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-a-lock-step-takes-a-lock-or-parks-the-run-and-retries
+	 */
+	public function execute(array $items, array $config, array $context): array {
+		// An empty firing must not suspend the whole run. After a route, the
+		// un-taken branch is marked and its steps still fire with zero items.
+		if ($items === []) {
+			return $items;
+		}
+
+		$this->validateConfig(config: $config);
+
+		$resume = ($context[FlowNodeResumeState::CONTEXT_KEY] ?? null);
+		if ($resume instanceof FlowNodeResumeState === false) {
+			// Without a slot the node cannot remember its deadline, so every
+			// heartbeat would restart the budget and the wait would never end.
+			throw new RuntimeException(
+				$this->l10n->t('A lock step needs a resume slot; this run did not provide one.')
+			);
+		}
+
+		$runUuid = $this->resolveRunUuid(context: $context);
+		$owner = $this->resolveOwner(context: $context);
+		$targets = $this->resolveTargets(items: $items, config: $config);
+
+		$duration = $this->seconds($config, 'duration', self::DEFAULT_DURATION);
+		$process = trim((string)($config['process'] ?? ''));
+		if ($process === '') {
+			$process = sprintf('flow run %s', $runUuid);
+		}
+
+		$deadline = $this->deadline(resume: $resume, config: $config);
+
+		foreach ($targets as $uuid) {
+			try {
+				$this->objects->runAs(
+					$owner,
+					fn (): array => $this->objects->lockObject(
+						identifier: $uuid,
+						process: $process,
+						duration: $duration,
+						advisory: false,
+						runUuid: $runUuid,
+						nodeId: $resume->nodeId()
+					)
+				);
+			} catch (Throwable $e) {
+				$this->parkOrGiveUp(
+					resume: $resume,
+					deadline: $deadline,
+					uuid: $uuid,
+					cause: $e
+				);
+			}//end try
+		}
+
+		// Every target is held. Returning normally clears the slot, so a later
+		// re-entry of this node starts a fresh budget, which is correct: it is
+		// a different wait.
+		return $items;
+	}//end execute()
+
+	/**
+	 * Park the run and retry, or fail because the budget is spent.
+	 *
+	 * @param FlowNodeResumeState $resume This node's resume slot.
+	 * @param DateTime $deadline The absolute wait deadline.
+	 * @param string $uuid The contended object.
+	 * @param Throwable $cause Why the acquire failed.
+	 *
+	 * @return void
+	 *
+	 * @throws FlowSuspension To park the run.
+	 * @throws RuntimeException When the budget is spent.
+	 */
+	private function parkOrGiveUp(
+		FlowNodeResumeState $resume,
+		DateTime $deadline,
+		string $uuid,
+		Throwable $cause,
+	): void {
+		$now = new DateTime();
+		if ($now >= $deadline) {
+			// Fail, naming the holder. Do NOT break the lock and do NOT
+			// proceed: proceeding is the data race the lock exists to stop.
+			throw new RuntimeException(
+				$this->l10n->t(
+					'Waited as long as allowed for object %s, and it is still locked: %s',
+					[$uuid, $cause->getMessage()]
+				),
+				0,
+				$cause
+			);
+		}
+
+		$attempts = ((int)$resume->get(self::SLOT_ATTEMPTS, 0) + 1);
+		$resume->set(self::SLOT_ATTEMPTS, $attempts);
+
+		throw new FlowSuspension(
+			resumeAt: $this->nextAttemptAt(attempts: $attempts, deadline: $deadline),
+			reason: sprintf('waiting for a lock on %s', $uuid)
+		);
+	}//end parkOrGiveUp()
+
+	/**
+	 * When to wake for the next attempt.
+	 *
+	 * Backoff is the node's own job: `resume_at` is an absolute wake time and
+	 * the engine keeps no attempt counter. Doubling from the floor spares a
+	 * long wait a wake every minute, and the result is clamped so it never
+	 * overshoots the deadline: waking after the budget has expired would
+	 * report the failure a whole interval late.
+	 *
+	 * @param int $attempts How many attempts have been made.
+	 * @param DateTime $deadline The absolute wait deadline.
+	 *
+	 * @return DateTime The next wake time.
+	 */
+	private function nextAttemptAt(int $attempts, DateTime $deadline): DateTime {
+		$backoff = (self::MIN_RETRY_SECONDS * (2 ** min($attempts - 1, 8)));
+		$backoff = min($backoff, self::MAX_RETRY_SECONDS);
+
+		$at = (new DateTime())->modify('+' . $backoff . ' seconds');
+		if ($at > $deadline) {
+			return $deadline;
+		}
+
+		return $at;
+	}//end nextAttemptAt()
+
+	/**
+	 * The absolute wait deadline, stamped ONCE on the first attempt.
+	 *
+	 * @param FlowNodeResumeState $resume This node's resume slot.
+	 * @param array $config The step configuration.
+	 *
+	 * @return DateTime The deadline.
+	 */
+	private function deadline(FlowNodeResumeState $resume, array $config): DateTime {
+		$stored = $resume->get(self::SLOT_DEADLINE, '');
+		if (is_string($stored) === true && trim($stored) !== '') {
+			try {
+				return new DateTime($stored);
+			} catch (Throwable $e) {
+				// An unreadable deadline is restamped below rather than
+				// treated as expired: a corrupt slot must not fail a run that
+				// has done nothing wrong.
+				$stored = '';
+			}
+		}
+
+		$wait = $this->seconds($config, 'waitSeconds', self::DEFAULT_WAIT_SECONDS);
+		$deadline = (new DateTime())->modify('+' . $wait . ' seconds');
+		$resume->set(self::SLOT_DEADLINE, $deadline->format('c'));
+
+		return $deadline;
+	}//end deadline()
+
+	/**
+	 * Read a positive integer from the config.
+	 *
+	 * @param array $config The step configuration.
+	 * @param string $key The key to read.
+	 * @param int $default The fallback.
+	 *
+	 * @return int The value.
+	 */
+	private function seconds(array $config, string $key, int $default): int {
+		$raw = ($config[$key] ?? null);
+		if (is_numeric($raw) === false || (int)$raw < 1) {
+			return $default;
+		}
+
+		return (int)$raw;
+	}//end seconds()
+
+	/**
+	 * Which objects to lock.
+	 *
+	 * Defaults to the uuid each item carries, which is what `object-read`
+	 * injects for exactly this purpose. An explicit `uuid` is templated
+	 * against the item, and a placeholder that renders empty throws rather
+	 * than locking nothing and reporting success.
+	 *
+	 * @param array $items The incoming items.
+	 * @param array $config The step configuration.
+	 *
+	 * @return array<int, string> The distinct target uuids.
+	 *
+	 * @throws RuntimeException When a target cannot be resolved.
+	 */
+	private function resolveTargets(array $items, array $config): array {
+		$configured = ($config['uuid'] ?? null);
+		$targets = [];
+
+		foreach ($items as $item) {
+			$json = ($item[FlowItems::JSON] ?? []);
+			if (is_array($json) === false) {
+				$json = [];
+			}
+
+			if (is_string($configured) === true && trim($configured) !== '') {
+				$uuid = trim((string)FlowValueTemplate::render($configured, $json));
+			} else {
+				$uuid = trim((string)($json['uuid'] ?? ''));
+			}
+
+			if ($uuid === '') {
+				throw new RuntimeException(
+					$this->l10n->t('A lock step could not work out which object to lock from the item it received.')
+				);
+			}
+
+			$targets[$uuid] = $uuid;
+		}
+
+		return array_values($targets);
+	}//end resolveTargets()
+
+	/**
+	 * The run's uuid, which IS the lock holder's identity.
+	 *
+	 * @param array $context The run context.
+	 *
+	 * @return string The run uuid.
+	 *
+	 * @throws RuntimeException When the run cannot identify itself.
+	 */
+	private function resolveRunUuid(array $context): string {
+		$runUuid = trim((string)($context[FlowRunContext::CONTEXT_RUN] ?? ($context['runUuid'] ?? '')));
+		if ($runUuid === '') {
+			// A run-scoped lock with no run is a lock nobody can release and
+			// the predicate refuses everybody for. Refuse to take it.
+			throw new RuntimeException(
+				$this->l10n->t('A lock step needs the run it belongs to; this run did not identify itself.')
+			);
+		}
+
+		return $runUuid;
+	}//end resolveRunUuid()
+
+	/**
+	 * The acting identity the lock is taken under.
+	 *
+	 * Load-bearing: `LockHandler::callerMayUnlock()` reads `IUserSession`
+	 * directly, and under the cron worker that is nobody, so an unwrapped
+	 * lock or unlock is refused as anonymous.
+	 *
+	 * @param array $context The run context.
+	 *
+	 * @return IUser The acting user.
+	 *
+	 * @throws RuntimeException When there is no usable acting identity.
+	 */
+	private function resolveOwner(array $context): IUser {
+		$uid = ($context[FlowRunService::RUN_AS_CONTEXT_KEY] ?? null);
+		if (is_string($uid) === false || trim($uid) === '') {
+			throw new RuntimeException(
+				$this->l10n->t('This flow run has no acting identity (runAs); a lock must be attributable.')
+			);
+		}
+
+		$user = $this->userManager->get(trim($uid));
+		if ($user === null) {
+			throw new RuntimeException(
+				$this->l10n->t('This flow run acts as "%s", which is not a user account.', [trim($uid)])
+			);
+		}
+
+		if ($user->isEnabled() === false) {
+			throw new RuntimeException(
+				$this->l10n->t('This flow run acts as "%s", whose account is disabled.', [trim($uid)])
+			);
+		}
+
+		return $user;
+	}//end resolveOwner()
+}//end class

--- a/lib/Service/Flow/Nodes/LockObjectNode.php
+++ b/lib/Service/Flow/Nodes/LockObjectNode.php
@@ -180,6 +180,8 @@ class LockObjectNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigF
 	 * The palette description.
 	 *
 	 * @return string The description.
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-a-lock-step-takes-a-lock-or-parks-the-run-and-retries
 	 */
 	public function getDescription(): string {
 		return $this->l10n->t(
@@ -211,6 +213,8 @@ class LockObjectNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigF
 	 * Top-level configuration keys.
 	 *
 	 * @return array<int, string> The keys.
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-a-lock-step-takes-a-lock-or-parks-the-run-and-retries
 	 */
 	public function configKeys(): array {
 		return ['uuid', 'duration', 'waitSeconds', 'process'];
@@ -220,6 +224,8 @@ class LockObjectNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigF
 	 * The editor form.
 	 *
 	 * @return array<int, array<string, mixed>> The fields.
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-a-lock-step-takes-a-lock-or-parks-the-run-and-retries
 	 */
 	public function configForm(): array {
 		return [

--- a/lib/Service/Flow/Nodes/UnlockObjectNode.php
+++ b/lib/Service/Flow/Nodes/UnlockObjectNode.php
@@ -1,0 +1,314 @@
+<?php
+
+/**
+ * Release a run-scoped lock this run holds.
+ *
+ * THIS NODE IS A CONVENIENCE, NOT THE RELEASE MECHANISM.
+ * -----------------------------------------------------
+ * The engine releases every lock a run holds when the run reaches ANY
+ * terminal outcome, from a listener on `FlowRunTerminalEvent` rather than
+ * from a node, precisely so that a run which crashed, failed or was reaped
+ * still releases. A release that depended on reaching an unlock step would be
+ * no release at all in exactly the cases that matter.
+ *
+ * What this node adds is EARLINESS: a flow that locks a case, edits it, and
+ * then waits three days for a human should not hold the lock across the wait.
+ * Releasing here narrows the window from "until the run ends" to "until the
+ * work is done".
+ *
+ * IT IS IDEMPOTENT AND IT DOES NOT BREAK LOCKS. Unlocking an object this run
+ * does not hold is refused rather than forced: a step that could release
+ * somebody else's lock would defeat the mutual exclusion the lock exists for.
+ * Unlocking one that is already free is a no-op, because a flow re-entering
+ * this step after a retry upstream must not fail for tidying up twice.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow\Nodes
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-a-lock-step-takes-a-lock-or-parks-the-run-and-retries
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow\Nodes;
+
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\FlowRunContext;
+use OCA\OpenRegister\Service\Flow\FlowRunService;
+use OCA\OpenRegister\Service\Flow\FlowValueTemplate;
+use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigForm;
+use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\WorkflowEngine\IManager;
+use RuntimeException;
+use UnexpectedValueException;
+
+/**
+ * Release a run-scoped object lock.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class UnlockObjectNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigForm {
+
+	/**
+	 * The step type this node answers to.
+	 *
+	 * @var string
+	 */
+	public const TYPE = 'openregister.unlock-object';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param ObjectService $objects Object lock operations, RBAC-enforcing.
+	 * @param IUserManager $userManager Resolves the run's acting identity.
+	 * @param IL10N $l10n Translations.
+	 * @param IURLGenerator $urls For the palette icon.
+	 */
+	public function __construct(
+		private readonly ObjectService $objects,
+		private readonly IUserManager $userManager,
+		private readonly IL10N $l10n,
+		private readonly IURLGenerator $urls,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * The step type.
+	 *
+	 * @return string The node id.
+	 */
+	public function getId(): string {
+		return self::TYPE;
+	}//end getId()
+
+	/**
+	 * The palette label.
+	 *
+	 * @return string The display name.
+	 */
+	public function getDisplayName(): string {
+		return $this->l10n->t('Unlock an object');
+	}//end getDisplayName()
+
+	/**
+	 * The palette description.
+	 *
+	 * @return string The description.
+	 */
+	public function getDescription(): string {
+		return $this->l10n->t(
+			'Release an object this run is holding, so others can change it again. The run releases its locks when it ends anyway; this frees them sooner.'
+		);
+	}//end getDescription()
+
+	/**
+	 * The palette icon.
+	 *
+	 * @return string The icon path.
+	 */
+	public function getIcon(): string {
+		return $this->urls->imagePath('core', 'actions/unlock.svg');
+	}//end getIcon()
+
+	/**
+	 * Available in both flow scopes.
+	 *
+	 * @param int $scope The workflow engine scope.
+	 *
+	 * @return bool True when available.
+	 */
+	public function isAvailableForScope(int $scope): bool {
+		return in_array($scope, [IManager::SCOPE_ADMIN, IManager::SCOPE_USER], true);
+	}//end isAvailableForScope()
+
+	/**
+	 * Top-level configuration keys.
+	 *
+	 * @return array<int, string> The keys.
+	 */
+	public function configKeys(): array {
+		return ['uuid'];
+	}//end configKeys()
+
+	/**
+	 * The editor form.
+	 *
+	 * @return array<int, array<string, mixed>> The fields.
+	 */
+	public function configForm(): array {
+		return [
+			[
+				'key' => 'uuid',
+				'label' => $this->l10n->t('Object'),
+				'type' => 'text',
+				'help' => $this->l10n->t('Which object to release. Leave empty to release the object the step receives.'),
+			],
+		];
+	}//end configForm()
+
+	/**
+	 * Refuse a configuration the run could not act on.
+	 *
+	 * @param array $config The step configuration.
+	 *
+	 * @return void
+	 *
+	 * @throws UnexpectedValueException When the configuration cannot be run.
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-a-lock-step-takes-a-lock-or-parks-the-run-and-retries
+	 */
+	public function validateConfig(array $config): void {
+		if (array_key_exists('uuid', $config) === true
+			&& is_string($config['uuid']) === false
+			&& $config['uuid'] !== null
+		) {
+			throw new UnexpectedValueException($this->l10n->t('An unlock step\'s object must be text.'));
+		}
+	}//end validateConfig()
+
+	/**
+	 * Release the lock.
+	 *
+	 * @param array $items The incoming items.
+	 * @param array $config The step configuration.
+	 * @param array $context The run context.
+	 *
+	 * @return array The items, unchanged.
+	 *
+	 * @throws RuntimeException When the step cannot act.
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-a-lock-step-takes-a-lock-or-parks-the-run-and-retries
+	 */
+	public function execute(array $items, array $config, array $context): array {
+		if ($items === []) {
+			return $items;
+		}
+
+		$this->validateConfig(config: $config);
+
+		$runUuid = $this->resolveRunUuid(context: $context);
+		$owner = $this->resolveOwner(context: $context);
+
+		foreach ($this->resolveTargets(items: $items, config: $config) as $uuid) {
+			$this->objects->runAs(
+				$owner,
+				fn (): bool => $this->objects->unlockObject(
+					identifier: $uuid,
+					advisory: false,
+					runUuid: $runUuid
+				)
+			);
+		}
+
+		return $items;
+	}//end execute()
+
+	/**
+	 * Which objects to release.
+	 *
+	 * @param array $items The incoming items.
+	 * @param array $config The step configuration.
+	 *
+	 * @return array<int, string> The distinct target uuids.
+	 *
+	 * @throws RuntimeException When a target cannot be resolved.
+	 *
+	 * @SuppressWarnings(PHPMD.StaticAccess) FlowValueTemplate is the engine's
+	 * stateless template renderer and every node calls it this way.
+	 */
+	private function resolveTargets(array $items, array $config): array {
+		$configured = ($config['uuid'] ?? null);
+		$targets = [];
+
+		foreach ($items as $item) {
+			$json = ($item[FlowItems::JSON] ?? []);
+			if (is_array($json) === false) {
+				$json = [];
+			}
+
+			$uuid = trim((string)($json['uuid'] ?? ''));
+			if (is_string($configured) === true && trim($configured) !== '') {
+				$uuid = trim((string)FlowValueTemplate::render($configured, $json));
+			}
+
+			if ($uuid === '') {
+				throw new RuntimeException(
+					$this->l10n->t('An unlock step could not work out which object to release from the item it received.')
+				);
+			}
+
+			$targets[$uuid] = $uuid;
+		}
+
+		return array_values($targets);
+	}//end resolveTargets()
+
+	/**
+	 * The run's uuid, which identifies the lock holder.
+	 *
+	 * @param array $context The run context.
+	 *
+	 * @return string The run uuid.
+	 *
+	 * @throws RuntimeException When the run cannot identify itself.
+	 */
+	private function resolveRunUuid(array $context): string {
+		$runUuid = trim((string)($context[FlowRunContext::CONTEXT_RUN] ?? ($context['runUuid'] ?? '')));
+		if ($runUuid === '') {
+			throw new RuntimeException(
+				$this->l10n->t('An unlock step needs the run it belongs to; this run did not identify itself.')
+			);
+		}
+
+		return $runUuid;
+	}//end resolveRunUuid()
+
+	/**
+	 * The acting identity the release runs under.
+	 *
+	 * @param array $context The run context.
+	 *
+	 * @return IUser The acting user.
+	 *
+	 * @throws RuntimeException When there is no usable acting identity.
+	 */
+	private function resolveOwner(array $context): IUser {
+		$uid = ($context[FlowRunService::RUN_AS_CONTEXT_KEY] ?? null);
+		if (is_string($uid) === false || trim($uid) === '') {
+			throw new RuntimeException(
+				$this->l10n->t('This flow run has no acting identity (runAs); an unlock must be attributable.')
+			);
+		}
+
+		$user = $this->userManager->get(trim($uid));
+		if ($user === null) {
+			throw new RuntimeException(
+				$this->l10n->t('This flow run acts as "%s", which is not a user account.', [trim($uid)])
+			);
+		}
+
+		if ($user->isEnabled() === false) {
+			throw new RuntimeException(
+				$this->l10n->t('This flow run acts as "%s", whose account is disabled.', [trim($uid)])
+			);
+		}
+
+		return $user;
+	}//end resolveOwner()
+}//end class

--- a/lib/Service/Flow/Nodes/UnlockObjectNode.php
+++ b/lib/Service/Flow/Nodes/UnlockObjectNode.php
@@ -110,6 +110,8 @@ class UnlockObjectNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfi
 	 * The palette description.
 	 *
 	 * @return string The description.
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-a-lock-step-takes-a-lock-or-parks-the-run-and-retries
 	 */
 	public function getDescription(): string {
 		return $this->l10n->t(
@@ -141,6 +143,8 @@ class UnlockObjectNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfi
 	 * Top-level configuration keys.
 	 *
 	 * @return array<int, string> The keys.
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-a-lock-step-takes-a-lock-or-parks-the-run-and-retries
 	 */
 	public function configKeys(): array {
 		return ['uuid'];
@@ -150,6 +154,8 @@ class UnlockObjectNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfi
 	 * The editor form.
 	 *
 	 * @return array<int, array<string, mixed>> The fields.
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-a-lock-step-takes-a-lock-or-parks-the-run-and-retries
 	 */
 	public function configForm(): array {
 		return [

--- a/lib/Service/Object/AdvisoryLockStore.php
+++ b/lib/Service/Object/AdvisoryLockStore.php
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * Pre-creation ("advisory") locks, keyed on an arbitrary string.
+ *
+ * A different thing from an object lock, and now in a different class. An
+ * object lock lives in the object's own `_locked` column and is what a write
+ * guard consults. An advisory lock has no object at all: it exists so a
+ * create-then-store flow can reserve a name before the row exists, such as
+ * buildiq's wizard holding `createApp:<slug>` while it decides. It is stored
+ * in app-config with an expiry.
+ *
+ * It conflicts for EVERYONE regardless of identity, which is the right
+ * behaviour for a name reservation and the reason it needs none of the
+ * holder machinery that object locks now carry.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Object
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/object-interactions/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Object;
+
+use DateTime;
+use OCA\OpenRegister\Exception\LockedException;
+use OCP\IAppConfig;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+
+/**
+ * The appConfig-backed advisory lock store.
+ */
+class AdvisoryLockStore {
+
+	/**
+	 * Advisory-lock app-config key prefix.
+	 *
+	 * @var string
+	 */
+	private const PREFIX = 'advisory_lock_';
+
+	/**
+	 * Default advisory lock duration in seconds when none supplied.
+	 *
+	 * @var int
+	 */
+	private const DEFAULT_DURATION = 3600;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IAppConfig $appConfig Where advisory locks are stored.
+	 * @param IUserSession $userSession Names the holder, for display only.
+	 * @param LoggerInterface $logger Reporting.
+	 */
+	public function __construct(
+		private readonly IAppConfig $appConfig,
+		private readonly IUserSession $userSession,
+		private readonly LoggerInterface $logger,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * Build the app-config key used to store an advisory lock.
+	 *
+	 * @param string $identifier The arbitrary advisory-lock identifier.
+	 *
+	 * @return string The namespaced app-config key.
+	 */
+	private function key(string $identifier): string {
+		return self::PREFIX . md5($identifier);
+	}//end key()
+
+	/**
+	 * Acquire an advisory lock for an identifier that does not (yet) resolve
+	 * to a stored object.
+	 *
+	 * A still-valid lock raises LockedException; an expired one is silently
+	 * overwritten.
+	 *
+	 * @param string $identifier The arbitrary advisory-lock identifier.
+	 * @param string|null $process Optional process tag (who holds the lock).
+	 * @param int|null $duration Lock duration in seconds.
+	 *
+	 * @return array{uuid: string, locked: array<string, mixed>} Advisory lock result.
+	 *
+	 * @throws LockedException If a non-expired advisory lock already exists.
+	 *
+	 * @spec openspec/specs/object-interactions/spec.md
+	 */
+	public function acquire(string $identifier, ?string $process = null, ?int $duration = null): array {
+		$duration = ($duration ?? self::DEFAULT_DURATION);
+		$key = $this->key(identifier: $identifier);
+		$now = new DateTime();
+
+		$existingRaw = $this->appConfig->getValueString('openregister', $key, '');
+		if ($existingRaw !== '') {
+			$existing = json_decode($existingRaw, true);
+			if (is_array($existing) === true && isset($existing['expiration']) === true) {
+				$expiration = new DateTime($existing['expiration']);
+				if ($expiration > $now) {
+					throw new LockedException(message: "Advisory lock '{$identifier}' is already held");
+				}
+			}
+		}
+
+		$expiration = (clone $now)->modify("+{$duration} seconds");
+		$lock = [
+			'user' => $this->userSession->getUser()?->getUID(),
+			'process' => $process,
+			'created' => $now->format(DateTime::ATOM),
+			'duration' => $duration,
+			'expiration' => $expiration->format(DateTime::ATOM),
+			'advisory' => true,
+		];
+
+		$this->appConfig->setValueString('openregister', $key, json_encode($lock));
+
+		$this->logger->info(
+			message: '[AdvisoryLockStore] Advisory (pre-creation) lock acquired',
+			context: [
+				'file' => __FILE__,
+				'line' => __LINE__,
+				'identifier' => $identifier,
+				'process' => $process,
+			]
+		);
+
+		return ['uuid' => $identifier, 'locked' => $lock];
+	}//end acquire()
+
+	/**
+	 * Release an advisory lock if one exists for the identifier.
+	 *
+	 * @param string $identifier The arbitrary advisory-lock identifier.
+	 *
+	 * @return bool True if an advisory lock was found and removed.
+	 *
+	 * @spec openspec/specs/object-interactions/spec.md
+	 */
+	public function release(string $identifier): bool {
+		$key = $this->key(identifier: $identifier);
+		if ($this->appConfig->getValueString('openregister', $key, '') === '') {
+			return false;
+		}
+
+		$this->appConfig->deleteKey('openregister', $key);
+		$this->logger->info(
+			message: '[AdvisoryLockStore] Advisory (pre-creation) lock released',
+			context: ['file' => __FILE__, 'line' => __LINE__, 'identifier' => $identifier]
+		);
+
+		return true;
+	}//end release()
+}//end class

--- a/lib/Service/Object/LockHandler.php
+++ b/lib/Service/Object/LockHandler.php
@@ -33,12 +33,9 @@ use OCA\OpenRegister\Db\AuditTrailMapper;
 use OCA\OpenRegister\Db\MagicMapper;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\Register;
-use OCA\OpenRegister\Db\RunObjectLock;
-use OCA\OpenRegister\Db\RunObjectLockMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Exception\LockedException;
-use OCP\IAppConfig;
 use OCP\IGroupManager;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
@@ -70,8 +67,8 @@ class LockHandler {
 	 * @param IUserSession $userSession User session for authorization checks
 	 * @param IGroupManager $groupManager Group manager for admin checks
 	 * @param SchemaMapper $schemaMapper Schema mapper for resolving manage rules
-	 * @param IAppConfig $appConfig App config store for advisory (pre-creation) locks
-	 * @param RunObjectLockMapper|null $runLocks Registry of run-held locks, for the terminal listener and the sweep
+	 * @param AdvisoryLockStore $advisory Pre-creation locks, for identifiers that do not resolve to a stored object
+	 * @param RunLockRegistry|null $runLocks Bookkeeping for run-held locks, so the terminal listener and the sweep can find them without reading objects
 	 */
 	public function __construct(
 		private readonly MagicMapper $magicMapper,
@@ -80,115 +77,10 @@ class LockHandler {
 		private readonly IUserSession $userSession,
 		private readonly IGroupManager $groupManager,
 		private readonly SchemaMapper $schemaMapper,
-		private readonly IAppConfig $appConfig,
-		private readonly ?RunObjectLockMapper $runLocks = null,
+		private readonly AdvisoryLockStore $advisory,
+		private readonly ?RunLockRegistry $runLocks = null,
 	) {
 	}//end __construct()
-
-	/**
-	 * Advisory-lock app-config key prefix.
-	 *
-	 * @var string
-	 */
-	private const ADVISORY_LOCK_PREFIX = 'advisory_lock_';
-
-	/**
-	 * Default advisory lock duration in seconds when none supplied.
-	 *
-	 * @var int
-	 */
-	private const ADVISORY_LOCK_DEFAULT_DURATION = 3600;
-
-	/**
-	 * Build the app-config key used to store an advisory (pre-creation) lock.
-	 *
-	 * @param string $identifier The arbitrary advisory-lock identifier.
-	 *
-	 * @return string The namespaced app-config key.
-	 */
-	private function advisoryLockKey(string $identifier): string {
-		return self::ADVISORY_LOCK_PREFIX . md5($identifier);
-	}//end advisoryLockKey()
-
-	/**
-	 * Acquire an advisory (pre-creation) lock for an arbitrary identifier that
-	 * does not (yet) resolve to a stored object.
-	 *
-	 * Supports create-then-store flows (e.g. the openbuild wizard locking
-	 * `createApp:<slug>` before the object exists). The lock is stored in
-	 * app-config with an expiry timestamp. A still-valid lock raises
-	 * LockedException; an expired lock is silently overwritten.
-	 *
-	 * @param string $identifier The arbitrary advisory-lock identifier.
-	 * @param string|null $process Optional process tag (who holds the lock).
-	 * @param int|null $duration Lock duration in seconds.
-	 *
-	 * @return array{uuid: string, locked: array<string, mixed>} Advisory lock result.
-	 *
-	 * @throws LockedException If a non-expired advisory lock already exists.
-	 */
-	private function acquireAdvisoryLock(string $identifier, ?string $process = null, ?int $duration = null): array {
-		$duration = ($duration ?? self::ADVISORY_LOCK_DEFAULT_DURATION);
-		$key = $this->advisoryLockKey(identifier: $identifier);
-		$now = new DateTime();
-
-		$existingRaw = $this->appConfig->getValueString('openregister', $key, '');
-		if ($existingRaw !== '') {
-			$existing = json_decode($existingRaw, true);
-			if (is_array($existing) === true && isset($existing['expiration']) === true) {
-				$expiration = new DateTime($existing['expiration']);
-				if ($expiration > $now) {
-					throw new LockedException(message: "Advisory lock '{$identifier}' is already held");
-				}
-			}
-		}
-
-		$expiration = (clone $now)->modify("+{$duration} seconds");
-		$lock = [
-			'user' => $this->userSession->getUser()?->getUID(),
-			'process' => $process,
-			'created' => $now->format(DateTime::ATOM),
-			'duration' => $duration,
-			'expiration' => $expiration->format(DateTime::ATOM),
-			'advisory' => true,
-		];
-
-		$this->appConfig->setValueString('openregister', $key, json_encode($lock));
-
-		$this->logger->info(
-			message: '[LockHandler] Advisory (pre-creation) lock acquired',
-			context: [
-				'file' => __FILE__,
-				'line' => __LINE__,
-				'identifier' => $identifier,
-				'process' => $process,
-			]
-		);
-
-		return ['uuid' => $identifier, 'locked' => $lock];
-	}//end acquireAdvisoryLock()
-
-	/**
-	 * Release an advisory (pre-creation) lock if one exists for the identifier.
-	 *
-	 * @param string $identifier The arbitrary advisory-lock identifier.
-	 *
-	 * @return bool True if an advisory lock was found and removed.
-	 */
-	private function releaseAdvisoryLock(string $identifier): bool {
-		$key = $this->advisoryLockKey(identifier: $identifier);
-		if ($this->appConfig->getValueString('openregister', $key, '') === '') {
-			return false;
-		}
-
-		$this->appConfig->deleteKey('openregister', $key);
-		$this->logger->info(
-			message: '[LockHandler] Advisory (pre-creation) lock released',
-			context: ['file' => __FILE__, 'line' => __LINE__, 'identifier' => $identifier]
-		);
-
-		return true;
-	}//end releaseAdvisoryLock()
 
 	/**
 	 * Find an object and get its register/schema context.
@@ -360,6 +252,10 @@ class LockHandler {
 	 * @param bool $advisory When true, skip the object lookup and take the
 	 *                       appConfig-backed advisory lock directly (used by
 	 *                       pre-creation guards where no object exists yet)
+	 * @param string|null $runUuid Flow run taking the lock. A run-scoped lock
+	 *                             refuses every other caller, the run's own
+	 *                             runAs user included.
+	 * @param string|null $nodeId Flow node that took it, recorded for the sweep
 	 *
 	 * @return array Lock result with locked details and uuid.
 	 *
@@ -394,7 +290,7 @@ class LockHandler {
 		// lock and skip findObjectWithContext, whose findAcrossAllMagicTables scan
 		// would otherwise query every magic table just to conclude "not found".
 		if ($advisory === true) {
-			return $this->acquireAdvisoryLock(identifier: $identifier, process: $process, duration: $duration);
+			return $this->advisory->acquire(identifier: $identifier, process: $process, duration: $duration);
 		}
 
 		try {
@@ -407,50 +303,20 @@ class LockHandler {
 				// `createApp:<slug>` before the object exists). Fall back to an
 				// advisory lock keyed by the arbitrary string so create-then-store
 				// flows work instead of failing with a 404/422.
-				return $this->acquireAdvisoryLock(
+				return $this->advisory->acquire(
 					identifier: $identifier,
 					process: $process,
 					duration: $duration
 				);
 			}
 
-			$objectBefore = $context['object'];
-
-			// Use MagicMapper for lock operation.
-			$objectAfter = $this->magicMapper->lockObjectEntity(
-				entity: $objectBefore,
-				register: $context['register'],
-				schema: $context['schema'],
-				lockDuration: $duration,
+			return $this->lockStoredObject(
+				context: $context,
+				duration: $duration,
 				process: $process,
-				runUuid: $runUuid
+				runUuid: $runUuid,
+				nodeId: $nodeId
 			);
-
-			// Record a run's lock so the terminal listener and the sweep can
-			// find it without reading objects. Bookkeeping only: the payload
-			// on the object stays the sole authority for the write guard, so
-			// a failure to record must not undo a lock that was taken.
-			$this->recordRunLock(object: $objectAfter, runUuid: $runUuid, nodeId: $nodeId);
-
-			$lockResult = [
-				'uuid' => $objectAfter->getUuid(),
-				'locked' => $objectAfter->getLocked(),
-			];
-
-			// Record lock action in audit trail.
-			$this->auditTrailMapper->createAuditTrail(old: $objectBefore, new: $objectAfter, action: 'lock');
-
-			$this->logger->info(
-				message: '[LockHandler] Object locked successfully',
-				context: [
-					'file' => __FILE__,
-					'line' => __LINE__,
-					'identifier' => $identifier,
-					'process' => $process,
-				]
-			);
-
-			return $lockResult;
 		} catch (LockedException $e) {
 			$this->logger->warning(
 				message: '[LockHandler] Object is already locked',
@@ -477,6 +343,63 @@ class LockHandler {
 	}//end lock()
 
 	/**
+	 * Take the lock on a resolved object and record it.
+	 *
+	 * @param array $context The resolved object with its register and schema.
+	 * @param int|null $duration Lock duration in seconds.
+	 * @param string|null $process What the lock was taken for.
+	 * @param string|null $runUuid Flow run taking the lock, for a run-scoped lock.
+	 * @param string|null $nodeId Flow node that took it, recorded for the sweep.
+	 *
+	 * @return array Lock result with locked details and uuid.
+	 *
+	 * @throws LockedException If the object is already locked by another holder.
+	 */
+	private function lockStoredObject(
+		array $context,
+		?int $duration,
+		?string $process,
+		?string $runUuid,
+		?string $nodeId,
+	): array {
+		$objectBefore = $context['object'];
+
+		// Use MagicMapper for lock operation.
+		$objectAfter = $this->magicMapper->lockObjectEntity(
+			entity: $objectBefore,
+			register: $context['register'],
+			schema: $context['schema'],
+			lockDuration: $duration,
+			process: $process,
+			runUuid: $runUuid
+		);
+
+		// Record a run's lock so the terminal listener and the sweep can find
+		// it without reading objects. Bookkeeping only: the payload on the
+		// object stays the sole authority for the write guard, so a failure
+		// to record must not undo a lock that was taken.
+		$this->runLocks?->record(object: $objectAfter, runUuid: $runUuid, nodeId: $nodeId);
+
+		// Record lock action in audit trail.
+		$this->auditTrailMapper->createAuditTrail(old: $objectBefore, new: $objectAfter, action: 'lock');
+
+		$this->logger->info(
+			message: '[LockHandler] Object locked successfully',
+			context: [
+				'file' => __FILE__,
+				'line' => __LINE__,
+				'uuid' => $objectAfter->getUuid(),
+				'process' => $process,
+			]
+		);
+
+		return [
+			'uuid' => $objectAfter->getUuid(),
+			'locked' => $objectAfter->getLocked(),
+		];
+	}//end lockStoredObject()
+
+	/**
 	 * Unlock an object
 	 *
 	 * Removes the lock from an object, allowing other processes to modify it.
@@ -484,6 +407,10 @@ class LockHandler {
 	 * @param string $identifier Object ID or UUID
 	 * @param bool $advisory When true, release the appConfig-backed advisory lock
 	 *                       directly and skip the object lookup / all-tables scan
+	 * @param string|null $runUuid Flow run releasing the lock, for a run-scoped lock
+	 * @param bool $break Release regardless of holder. Reserved for the
+	 *                    administrator break-lock and the engine's own release
+	 *                    layers, both of which authorize at their call site.
 	 *
 	 * @return true True if unlocked successfully
 	 *
@@ -505,7 +432,7 @@ class LockHandler {
 		// Advisory (pre-creation) fast-path — mirror of lock(): release the
 		// appConfig-backed advisory lock directly and skip the all-tables scan.
 		if ($advisory === true) {
-			$this->releaseAdvisoryLock(identifier: $identifier);
+			$this->advisory->release(identifier: $identifier);
 			return true;
 		}
 
@@ -526,7 +453,7 @@ class LockHandler {
 				// Pre-creation / advisory lock release: identifier never
 				// resolved to a stored object. Clear any advisory lock held
 				// under this arbitrary key (no-op if none present).
-				$this->releaseAdvisoryLock(identifier: $identifier);
+				$this->advisory->release(identifier: $identifier);
 				return true;
 			}
 
@@ -554,51 +481,7 @@ class LockHandler {
 				throw new Exception('User does not have permission to unlock this object');
 			}
 
-			// Capture the holder BEFORE the release, so a break can name what
-			// it displaced. After unlockObjectEntity() there is nothing to
-			// name.
-			$displaced = $objectBefore->describeLockHolder();
-			$displacedRun = $objectBefore->getLockedByRun();
-
-			// Use MagicMapper for unlock operation.
-			$objectAfter = $this->magicMapper->unlockObjectEntity(
-				entity: $objectBefore,
-				register: $context['register'],
-				schema: $context['schema'],
-				runUuid: $runUuid,
-				break: $break
-			);
-
-			if ($displacedRun !== null) {
-				$this->forgetRunLock(runUuid: $displacedRun, objectUuid: (string)$objectAfter->getUuid());
-			}
-
-			// Record unlock action in audit trail. A BREAK is recorded under
-			// its own action, naming the holder it displaced: an
-			// administrator overriding somebody else's lock is not the same
-			// event as a holder releasing their own, and an audit trail that
-			// cannot tell them apart cannot answer who took the case back.
-			if ($break === true) {
-				$this->auditTrailMapper->createAuditTrailEntry(
-					object: $objectAfter,
-					action: 'lock.broken',
-					context: [
-						'displacedHolder' => $displaced,
-						'displacedRun' => $displacedRun,
-					]
-				);
-			}
-
-			$this->auditTrailMapper->createAuditTrail(old: $objectBefore, new: $objectAfter, action: 'unlock');
-
-			$this->logger->info(
-				message: '[LockHandler] Object unlocked successfully',
-				context: [
-					'file' => __FILE__,
-					'line' => __LINE__,
-					'identifier' => $identifier,
-				]
-			);
+			$this->releaseStoredLock(context: $context, runUuid: $runUuid, break: $break);
 
 			return true;
 		} catch (\Exception $e) {
@@ -614,6 +497,64 @@ class LockHandler {
 			throw $e;
 		}//end try
 	}//end unlock()
+
+	/**
+	 * Release the lock on a resolved object, auditing what happened.
+	 *
+	 * @param array $context The resolved object with its register and schema.
+	 * @param string|null $runUuid Flow run releasing the lock, for a run-scoped lock.
+	 * @param bool $break Release regardless of holder; authorized at the call site.
+	 *
+	 * @return void
+	 *
+	 * @SuppressWarnings(PHPMD.BooleanArgumentFlag) Mirrors unlock()'s own break flag.
+	 */
+	private function releaseStoredLock(array $context, ?string $runUuid, bool $break): void {
+		$objectBefore = $context['object'];
+
+		// Capture the holder BEFORE the release, so a break can name what it
+		// displaced. After unlockObjectEntity() there is nothing left to name.
+		$displaced = $objectBefore->describeLockHolder();
+		$displacedRun = $objectBefore->getLockedByRun();
+
+		$objectAfter = $this->magicMapper->unlockObjectEntity(
+			entity: $objectBefore,
+			register: $context['register'],
+			schema: $context['schema'],
+			runUuid: $runUuid,
+			break: $break
+		);
+
+		if ($displacedRun !== null) {
+			$this->runLocks?->forget(runUuid: $displacedRun, objectUuid: (string)$objectAfter->getUuid());
+		}
+
+		// A BREAK is recorded under its own action, naming the holder it
+		// displaced. An administrator overriding somebody else's lock is not
+		// the same event as a holder releasing their own, and an audit trail
+		// that cannot tell them apart cannot answer who took the case back.
+		if ($break === true) {
+			$this->auditTrailMapper->createAuditTrailEntry(
+				object: $objectAfter,
+				action: 'lock.broken',
+				context: [
+					'displacedHolder' => $displaced,
+					'displacedRun' => $displacedRun,
+				]
+			);
+		}
+
+		$this->auditTrailMapper->createAuditTrail(old: $objectBefore, new: $objectAfter, action: 'unlock');
+
+		$this->logger->info(
+			message: '[LockHandler] Object unlocked successfully',
+			context: [
+				'file' => __FILE__,
+				'line' => __LINE__,
+				'uuid' => $objectAfter->getUuid(),
+			]
+		);
+	}//end releaseStoredLock()
 
 	/**
 	 * Break a lock as an administrator, and record the displacement.
@@ -642,78 +583,6 @@ class LockHandler {
 		return $this->unlock(identifier: $identifier, break: true);
 	}//end breakLock()
 
-	/**
-	 * Record a run's lock in the registry.
-	 *
-	 * Bookkeeping. A failure here is logged and swallowed: the lock itself is
-	 * already taken and is what the write guard reads, so failing the lock
-	 * because its index entry did not land would trade a working lock for no
-	 * lock at all. The TTL still bounds a lock whose row is missing.
-	 *
-	 * @param ObjectEntity $object The locked object.
-	 * @param string|null $runUuid The holding run, or null for a user lock.
-	 * @param string|null $nodeId The flow node that took it.
-	 *
-	 * @return void
-	 */
-	private function recordRunLock(ObjectEntity $object, ?string $runUuid, ?string $nodeId): void {
-		if ($runUuid === null || trim($runUuid) === '' || $this->runLocks === null) {
-			return;
-		}
-
-		try {
-			$payload = ($object->getLocked() ?? []);
-			$expires = null;
-			if (isset($payload['expiration']) === true) {
-				$expires = new DateTime((string)$payload['expiration']);
-			}
-
-			$row = new RunObjectLock();
-			$row->setRunUuid(trim($runUuid));
-			$row->setObjectUuid((string)$object->getUuid());
-			$row->setRegisterId((string)$object->getRegister());
-			$row->setSchemaId((string)$object->getSchema());
-			$row->setNodeId($nodeId);
-			$row->setLockedAt(new DateTime());
-			$row->setExpiresAt($expires);
-
-			$this->runLocks->record(lock: $row);
-		} catch (\Throwable $e) {
-			$this->logger->warning(
-				message: '[LockHandler] Could not record a run lock; the lock itself stands',
-				context: [
-					'file' => __FILE__,
-					'line' => __LINE__,
-					'runUuid' => $runUuid,
-					'error' => $e->getMessage(),
-				]
-			);
-		}//end try
-	}//end recordRunLock()
-
-	/**
-	 * Forget a run's registry row after the lock is released.
-	 *
-	 * @param string $runUuid The run.
-	 * @param string $objectUuid The object.
-	 *
-	 * @return void
-	 */
-	private function forgetRunLock(string $runUuid, string $objectUuid): void {
-		if ($this->runLocks === null) {
-			return;
-		}
-
-		try {
-			$this->runLocks->forget(runUuid: $runUuid, objectUuid: $objectUuid);
-		} catch (\Throwable $e) {
-			// A row left behind is collected by the sweep on its own terms.
-			$this->logger->debug(
-				message: '[LockHandler] Could not forget a run lock row',
-				context: ['file' => __FILE__, 'line' => __LINE__, 'error' => $e->getMessage()]
-			);
-		}
-	}//end forgetRunLock()
 
 	/**
 	 * Check if an object is locked

--- a/lib/Service/Object/LockHandler.php
+++ b/lib/Service/Object/LockHandler.php
@@ -353,7 +353,13 @@ class LockHandler {
 	 *
 	 * @return array Lock result with locked details and uuid.
 	 *
-	 * @throws LockedException If the object is already locked by another holder.
+	 * @throws LockedException If a mapper-level lock refuses the acquire.
+	 * @throws \Exception If the object is already held by another holder.
+	 *                    `ObjectEntity::lock()` throws the global Exception,
+	 *                    not LockedException, so lock()'s outer handler needs
+	 *                    both arms. Declaring only the narrow one made PHPStan
+	 *                    read the broad catch as dead code when it is the arm
+	 *                    that actually fires on contention.
 	 */
 	private function lockStoredObject(
 		array $context,

--- a/lib/Service/Object/LockHandler.php
+++ b/lib/Service/Object/LockHandler.php
@@ -33,6 +33,8 @@ use OCA\OpenRegister\Db\AuditTrailMapper;
 use OCA\OpenRegister\Db\MagicMapper;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RunObjectLock;
+use OCA\OpenRegister\Db\RunObjectLockMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Exception\LockedException;
@@ -69,6 +71,7 @@ class LockHandler {
 	 * @param IGroupManager $groupManager Group manager for admin checks
 	 * @param SchemaMapper $schemaMapper Schema mapper for resolving manage rules
 	 * @param IAppConfig $appConfig App config store for advisory (pre-creation) locks
+	 * @param RunObjectLockMapper|null $runLocks Registry of run-held locks, for the terminal listener and the sweep
 	 */
 	public function __construct(
 		private readonly MagicMapper $magicMapper,
@@ -78,6 +81,7 @@ class LockHandler {
 		private readonly IGroupManager $groupManager,
 		private readonly SchemaMapper $schemaMapper,
 		private readonly IAppConfig $appConfig,
+		private readonly ?RunObjectLockMapper $runLocks = null,
 	) {
 	}//end __construct()
 
@@ -298,10 +302,13 @@ class LockHandler {
 	 * finding where any authenticated user could unlock any locked object.
 	 *
 	 * @param ObjectEntity $object The locked object the caller wants to unlock.
+	 * @param string|null $runUuid The flow run asking, when a run is asking.
 	 *
 	 * @return bool True if the caller may unlock this object.
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-an-administrator-may-break-a-lock-and-the-break-is-recorded
 	 */
-	private function callerMayUnlock(ObjectEntity $object): bool {
+	private function callerMayUnlock(ObjectEntity $object, ?string $runUuid = null): bool {
 		$user = $this->userSession->getUser();
 		if ($user === null) {
 			return false;
@@ -309,15 +316,27 @@ class LockHandler {
 
 		$userId = $user->getUID();
 
-		// Admins always pass.
+		// Admins always pass. For a run lock this is the BREAK-LOCK route and
+		// the only one, so a wedged run cannot hold a case hostage; callers
+		// that mean to break a run's lock should use breakLock(), which
+		// records the displacement.
 		if ($this->groupManager->isAdmin($userId) === true) {
 			return true;
 		}
 
-		// Lock holder.
-		$lockInfo = $object->getLockInfo();
-		if (is_array($lockInfo) === true && ($lockInfo['user'] ?? null) === $userId) {
+		// The holder. For a run lock this admits only the holding run, and in
+		// particular NOT the run's own runAs user: a person must not be able
+		// to walk in behind the identity the run happens to execute as.
+		if ($object->isLockedBySomeoneElse(userId: $userId, runUuid: $runUuid) === false) {
 			return true;
+		}
+
+		// The object-owner and schema-manage routes are for USER locks only.
+		// Extending them to run locks would mean any case owner could quietly
+		// defeat the engine's mutual exclusion, which is the whole point of a
+		// run lock. They keep an administrator break as their escape hatch.
+		if ($object->getLockedByRun() !== null) {
+			return false;
 		}
 
 		// Object owner.
@@ -349,7 +368,14 @@ class LockHandler {
 	 *
 	 * @spec openspec/specs/object-interactions/spec.md
 	 */
-	public function lock(string $identifier, ?string $process = null, ?int $duration = null, bool $advisory = false): array {
+	public function lock(
+		string $identifier,
+		?string $process = null,
+		?int $duration = null,
+		bool $advisory = false,
+		?string $runUuid = null,
+		?string $nodeId = null,
+	): array {
 		$this->logger->debug(
 			message: '[LockHandler] Locking object',
 			context: [
@@ -395,8 +421,16 @@ class LockHandler {
 				entity: $objectBefore,
 				register: $context['register'],
 				schema: $context['schema'],
-				lockDuration: $duration
+				lockDuration: $duration,
+				process: $process,
+				runUuid: $runUuid
 			);
+
+			// Record a run's lock so the terminal listener and the sweep can
+			// find it without reading objects. Bookkeeping only: the payload
+			// on the object stays the sole authority for the write guard, so
+			// a failure to record must not undo a lock that was taken.
+			$this->recordRunLock(object: $objectAfter, runUuid: $runUuid, nodeId: $nodeId);
 
 			$lockResult = [
 				'uuid' => $objectAfter->getUuid(),
@@ -457,7 +491,12 @@ class LockHandler {
 	 *
 	 * @spec openspec/specs/object-interactions/spec.md
 	 */
-	public function unlock(string $identifier, bool $advisory = false): bool {
+	public function unlock(
+		string $identifier,
+		bool $advisory = false,
+		?string $runUuid = null,
+		bool $break = false,
+	): bool {
 		$this->logger->debug(
 			message: '[LockHandler] Unlocking object',
 			context: ['file' => __FILE__, 'line' => __LINE__, 'identifier' => $identifier, 'advisory' => $advisory]
@@ -503,7 +542,7 @@ class LockHandler {
 				return true;
 			}
 
-			if ($this->callerMayUnlock(object: $objectBefore) === false) {
+			if ($break === false && $this->callerMayUnlock(object: $objectBefore, runUuid: $runUuid) === false) {
 				$this->logger->warning(
 					message: '[LockHandler] Unauthorized unlock attempt',
 					context: [
@@ -515,14 +554,41 @@ class LockHandler {
 				throw new Exception('User does not have permission to unlock this object');
 			}
 
+			// Capture the holder BEFORE the release, so a break can name what
+			// it displaced. After unlockObjectEntity() there is nothing to
+			// name.
+			$displaced = $objectBefore->describeLockHolder();
+			$displacedRun = $objectBefore->getLockedByRun();
+
 			// Use MagicMapper for unlock operation.
 			$objectAfter = $this->magicMapper->unlockObjectEntity(
 				entity: $objectBefore,
 				register: $context['register'],
-				schema: $context['schema']
+				schema: $context['schema'],
+				runUuid: $runUuid,
+				break: $break
 			);
 
-			// Record unlock action in audit trail.
+			if ($displacedRun !== null) {
+				$this->forgetRunLock(runUuid: $displacedRun, objectUuid: (string)$objectAfter->getUuid());
+			}
+
+			// Record unlock action in audit trail. A BREAK is recorded under
+			// its own action, naming the holder it displaced: an
+			// administrator overriding somebody else's lock is not the same
+			// event as a holder releasing their own, and an audit trail that
+			// cannot tell them apart cannot answer who took the case back.
+			if ($break === true) {
+				$this->auditTrailMapper->createAuditTrailEntry(
+					object: $objectAfter,
+					action: 'lock.broken',
+					context: [
+						'displacedHolder' => $displaced,
+						'displacedRun' => $displacedRun,
+					]
+				);
+			}
+
 			$this->auditTrailMapper->createAuditTrail(old: $objectBefore, new: $objectAfter, action: 'unlock');
 
 			$this->logger->info(
@@ -548,6 +614,106 @@ class LockHandler {
 			throw $e;
 		}//end try
 	}//end unlock()
+
+	/**
+	 * Break a lock as an administrator, and record the displacement.
+	 *
+	 * The escape hatch for a wedged run. A run lock refuses everybody by
+	 * design, holder, object owner and schema manager included, so without a
+	 * break a run that died in a way none of the three release layers caught
+	 * would hold a case until its TTL ran out. Restricted to administrators
+	 * and always audited: an override nobody can see afterwards is
+	 * indistinguishable from the lock never having worked.
+	 *
+	 * @param string $identifier Object ID or UUID.
+	 *
+	 * @return bool True when a lock was broken.
+	 *
+	 * @throws Exception If the caller is not an administrator.
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-an-administrator-may-break-a-lock-and-the-break-is-recorded
+	 */
+	public function breakLock(string $identifier): bool {
+		$user = $this->userSession->getUser();
+		if ($user === null || $this->groupManager->isAdmin($user->getUID()) === false) {
+			throw new Exception('Only an administrator may break a lock');
+		}
+
+		return $this->unlock(identifier: $identifier, break: true);
+	}//end breakLock()
+
+	/**
+	 * Record a run's lock in the registry.
+	 *
+	 * Bookkeeping. A failure here is logged and swallowed: the lock itself is
+	 * already taken and is what the write guard reads, so failing the lock
+	 * because its index entry did not land would trade a working lock for no
+	 * lock at all. The TTL still bounds a lock whose row is missing.
+	 *
+	 * @param ObjectEntity $object The locked object.
+	 * @param string|null $runUuid The holding run, or null for a user lock.
+	 * @param string|null $nodeId The flow node that took it.
+	 *
+	 * @return void
+	 */
+	private function recordRunLock(ObjectEntity $object, ?string $runUuid, ?string $nodeId): void {
+		if ($runUuid === null || trim($runUuid) === '' || $this->runLocks === null) {
+			return;
+		}
+
+		try {
+			$payload = ($object->getLocked() ?? []);
+			$expires = null;
+			if (isset($payload['expiration']) === true) {
+				$expires = new DateTime((string)$payload['expiration']);
+			}
+
+			$row = new RunObjectLock();
+			$row->setRunUuid(trim($runUuid));
+			$row->setObjectUuid((string)$object->getUuid());
+			$row->setRegisterId((string)$object->getRegister());
+			$row->setSchemaId((string)$object->getSchema());
+			$row->setNodeId($nodeId);
+			$row->setLockedAt(new DateTime());
+			$row->setExpiresAt($expires);
+
+			$this->runLocks->record(lock: $row);
+		} catch (\Throwable $e) {
+			$this->logger->warning(
+				message: '[LockHandler] Could not record a run lock; the lock itself stands',
+				context: [
+					'file' => __FILE__,
+					'line' => __LINE__,
+					'runUuid' => $runUuid,
+					'error' => $e->getMessage(),
+				]
+			);
+		}//end try
+	}//end recordRunLock()
+
+	/**
+	 * Forget a run's registry row after the lock is released.
+	 *
+	 * @param string $runUuid The run.
+	 * @param string $objectUuid The object.
+	 *
+	 * @return void
+	 */
+	private function forgetRunLock(string $runUuid, string $objectUuid): void {
+		if ($this->runLocks === null) {
+			return;
+		}
+
+		try {
+			$this->runLocks->forget(runUuid: $runUuid, objectUuid: $objectUuid);
+		} catch (\Throwable $e) {
+			// A row left behind is collected by the sweep on its own terms.
+			$this->logger->debug(
+				message: '[LockHandler] Could not forget a run lock row',
+				context: ['file' => __FILE__, 'line' => __LINE__, 'error' => $e->getMessage()]
+			);
+		}
+	}//end forgetRunLock()
 
 	/**
 	 * Check if an object is locked

--- a/lib/Service/Object/RevertHandler.php
+++ b/lib/Service/Object/RevertHandler.php
@@ -151,14 +151,13 @@ class RevertHandler {
 			);
 		}
 
-		// Check if the object is locked.
-		if ($object->isLocked() === true) {
-			$userId = $this->container->get('userId');
-			if ($object->getLockedBy() !== $userId) {
-				throw new LockedException(
-					message: sprintf('Object is locked by %s', $object->getLockedBy())
-				);
-			}
+		// Check if the object is locked. Ownership is decided by the one
+		// production predicate, so a run-held lock refuses the run's own
+		// runAs user here exactly as it does at every other guard.
+		if ($object->isLockedBySomeoneElse(userId: $this->container->get('userId')) === true) {
+			throw new LockedException(
+				message: sprintf('Object is locked by %s', (string)$object->describeLockHolder())
+			);
 		}
 
 		// Get the reverted object using AuditTrailMapper.

--- a/lib/Service/Object/RunLockRegistry.php
+++ b/lib/Service/Object/RunLockRegistry.php
@@ -225,9 +225,23 @@ class RunLockRegistry {
 		}
 
 		try {
+			// EVERY scoping filter is off, deliberately, and each one is a way
+			// this sweep could quietly do nothing.
+			//
+			// `_rbac` / `_multitenancy`: both release layers run from a
+			// background job or `occ`, which have NO SESSION, so a scoped read
+			// resolves as Anonymous and answers "no such object". The sweep
+			// would then report zero locks to release and the lock would be
+			// held until its TTL, with no error anywhere. This is the same
+			// defect that made `prune-retired` count zero rows and delete
+			// schemas that held data (openregister#3440).
+			//
+			// `includeDeleted`: a soft-deleted object can still carry a live
+			// lock, and it is precisely the object nobody is watching. Leaving
+			// it out would strand that lock and its registry row forever.
 			$context = $this->magicMapper->findAcrossAllSources(
 				identifier: $objectUuid,
-				includeDeleted: false,
+				includeDeleted: true,
 				_rbac: false,
 				_multitenancy: false
 			);

--- a/lib/Service/Object/RunLockRegistry.php
+++ b/lib/Service/Object/RunLockRegistry.php
@@ -87,6 +87,8 @@ class RunLockRegistry {
 	 * @param string|null $nodeId The flow node that took it.
 	 *
 	 * @return void
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-every-lock-a-run-holds-is-released-when-the-run-ends
 	 */
 	public function record(ObjectEntity $object, ?string $runUuid, ?string $nodeId): void {
 		if ($runUuid === null || trim($runUuid) === '') {
@@ -125,6 +127,8 @@ class RunLockRegistry {
 	 * @param string $objectUuid The object.
 	 *
 	 * @return void
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-every-lock-a-run-holds-is-released-when-the-run-ends
 	 */
 	public function forget(string $runUuid, string $objectUuid): void {
 		try {

--- a/lib/Service/Object/RunLockRegistry.php
+++ b/lib/Service/Object/RunLockRegistry.php
@@ -1,0 +1,279 @@
+<?php
+
+/**
+ * The lifecycle of locks held by flow runs: record, release, sweep.
+ *
+ * Split out of `LockHandler` because the two answer different questions.
+ * LockHandler answers "may this caller take or release this lock", once per
+ * request. This answers "which locks does this run hold" and "which locks has
+ * nobody left to release them", asked by a terminal-event listener and by a
+ * cron sweep.
+ *
+ * THE REGISTRY IS BOOKKEEPING, NEVER THE AUTHORITY. The `_locked` payload on
+ * the object is the only thing a write guard consults, and every release here
+ * is checked against it before acting. A row with no matching payload is
+ * stale and gets deleted; a payload with no row still blocks writes and still
+ * expires on its TTL. Making the registry authoritative would create a second
+ * source of truth for the question asked on every object write, and the two
+ * would drift.
+ *
+ * WHY A TABLE AT ALL. Locks live in the `_locked` column of magic tables, one
+ * per register-schema pair. `MagicMapper::findAcrossAllMagicTables()` carries
+ * a measured note that an instance-wide scan over 2,728 of them builds 690 KB
+ * of SQL costing about 3.4 seconds to PLAN before a row is read. That cannot
+ * go on a cron tick, and it certainly cannot go inside the run's own terminal
+ * write transaction.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Object
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-every-lock-a-run-holds-is-released-when-the-run-ends
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Object;
+
+use DateTime;
+use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\RunObjectLock;
+use OCA\OpenRegister\Db\RunObjectLockMapper;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Records and releases the object locks a flow run holds.
+ */
+class RunLockRegistry {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param RunObjectLockMapper $registry The run-lock rows.
+	 * @param MagicMapper $magicMapper Resolves and mutates the objects themselves.
+	 * @param AuditTrailMapper $auditTrailMapper Records the releases.
+	 * @param LoggerInterface $logger Failure reporting.
+	 */
+	public function __construct(
+		private readonly RunObjectLockMapper $registry,
+		private readonly MagicMapper $magicMapper,
+		private readonly AuditTrailMapper $auditTrailMapper,
+		private readonly LoggerInterface $logger,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * Record that a run holds a lock.
+	 *
+	 * A failure here is logged and swallowed: the lock itself is already
+	 * taken and is what the write guard reads, so failing the lock because
+	 * its index entry did not land would trade a working lock for no lock at
+	 * all. The TTL still bounds a lock whose row is missing.
+	 *
+	 * @param ObjectEntity $object The locked object.
+	 * @param string|null $runUuid The holding run, or null for a user lock.
+	 * @param string|null $nodeId The flow node that took it.
+	 *
+	 * @return void
+	 */
+	public function record(ObjectEntity $object, ?string $runUuid, ?string $nodeId): void {
+		if ($runUuid === null || trim($runUuid) === '') {
+			return;
+		}
+
+		try {
+			$payload = ($object->getLocked() ?? []);
+			$expires = null;
+			if (isset($payload['expiration']) === true) {
+				$expires = new DateTime((string)$payload['expiration']);
+			}
+
+			$row = new RunObjectLock();
+			$row->setRunUuid(trim($runUuid));
+			$row->setObjectUuid((string)$object->getUuid());
+			$row->setRegisterId((string)$object->getRegister());
+			$row->setSchemaId((string)$object->getSchema());
+			$row->setNodeId($nodeId);
+			$row->setLockedAt(new DateTime());
+			$row->setExpiresAt($expires);
+
+			$this->registry->record(lock: $row);
+		} catch (Throwable $e) {
+			$this->logger->warning(
+				message: '[RunLockRegistry] Could not record a run lock; the lock itself stands',
+				context: ['file' => __FILE__, 'line' => __LINE__, 'runUuid' => $runUuid, 'error' => $e->getMessage()]
+			);
+		}//end try
+	}//end record()
+
+	/**
+	 * Forget one run's row for one object, after the lock has been released.
+	 *
+	 * @param string $runUuid The run.
+	 * @param string $objectUuid The object.
+	 *
+	 * @return void
+	 */
+	public function forget(string $runUuid, string $objectUuid): void {
+		try {
+			$this->registry->forget(runUuid: $runUuid, objectUuid: $objectUuid);
+		} catch (Throwable $e) {
+			// A row left behind is collected by the sweep on its own terms.
+			$this->logger->debug(
+				message: '[RunLockRegistry] Could not forget a run lock row',
+				context: ['file' => __FILE__, 'line' => __LINE__, 'error' => $e->getMessage()]
+			);
+		}
+	}//end forget()
+
+	/**
+	 * Release every lock one run holds. Release layer 1.
+	 *
+	 * Called from the `FlowRunTerminalEvent` listener, which fires for ALL
+	 * FOUR terminal statuses (completed, stopped, failed, dead_letter) and
+	 * for every reaper path, because the dispatch predicate in
+	 * `FlowRunMapper::update()` is `isTerminal()` rather than a whitelist.
+	 * That is why the release lives here and not in a node: a run that
+	 * crashed never reaches an unlock step, and it is exactly the run whose
+	 * lock most needs releasing.
+	 *
+	 * IDEMPOTENT, because terminality can be observed more than once.
+	 *
+	 * @param string $runUuid The run whose locks are released.
+	 *
+	 * @return int How many locks were released.
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-every-lock-a-run-holds-is-released-when-the-run-ends
+	 */
+	public function releaseRunLocks(string $runUuid): int {
+		if (trim($runUuid) === '') {
+			return 0;
+		}
+
+		$released = 0;
+		foreach ($this->registry->findByRun(runUuid: trim($runUuid)) as $row) {
+			if ($this->releaseRecorded(row: $row) === true) {
+				$released++;
+			}
+		}
+
+		$this->registry->forgetRun(runUuid: trim($runUuid));
+
+		return $released;
+	}//end releaseRunLocks()
+
+	/**
+	 * Release locks whose holding run is terminal, gone, or expired. Layer 2.
+	 *
+	 * Layer 1 covers a run that reaches terminal, and the reapers do
+	 * eventually terminate a run whose worker was killed. What layer 1 cannot
+	 * cover is a release that itself failed, or a run row deleted out from
+	 * under an outstanding lock. This finds those in one indexed query.
+	 *
+	 * @param DateTime $now The sweep's clock.
+	 * @param int $limit Batch ceiling.
+	 *
+	 * @return int How many locks were released.
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-every-lock-a-run-holds-is-released-when-the-run-ends
+	 */
+	public function sweepOrphaned(DateTime $now, int $limit = 100): int {
+		$released = 0;
+		foreach ($this->registry->findOrphaned(now: $now, limit: $limit) as $row) {
+			if ($this->releaseRecorded(row: $row) === true) {
+				$released++;
+			}
+
+			$this->forget(
+				runUuid: (string)$row->getRunUuid(),
+				objectUuid: (string)$row->getObjectUuid()
+			);
+		}
+
+		return $released;
+	}//end sweepOrphaned()
+
+	/**
+	 * Release one recorded lock, if the object still says this run holds it.
+	 *
+	 * The registry is checked AGAINST the object rather than trusted: only a
+	 * lock the object attributes to this run is released. Without that check
+	 * a stale row would let the sweep strip a lock a DIFFERENT run has since
+	 * taken on the same object.
+	 *
+	 * @param RunObjectLock $row The registry row.
+	 *
+	 * @return bool True when a lock was released.
+	 */
+	private function releaseRecorded(RunObjectLock $row): bool {
+		$runUuid = trim((string)$row->getRunUuid());
+		$objectUuid = trim((string)$row->getObjectUuid());
+		if ($runUuid === '' || $objectUuid === '') {
+			return false;
+		}
+
+		try {
+			$context = $this->magicMapper->findAcrossAllSources(
+				identifier: $objectUuid,
+				includeDeleted: false,
+				_rbac: false,
+				_multitenancy: false
+			);
+			$objectBefore = $context['object'];
+
+			if ($objectBefore->getLockedByRun() !== $runUuid) {
+				// Stale bookkeeping, or another run holds it now.
+				return false;
+			}
+
+			$objectAfter = $this->magicMapper->unlockObjectEntity(
+				entity: $objectBefore,
+				register: $context['register'],
+				schema: $context['schema'],
+				break: true
+			);
+
+			$this->auditTrailMapper->createAuditTrail(old: $objectBefore, new: $objectAfter, action: 'unlock');
+
+			$this->logger->info(
+				message: '[RunLockRegistry] Released a run lock',
+				context: [
+					'file' => __FILE__,
+					'line' => __LINE__,
+					'runUuid' => $runUuid,
+					'objectUuid' => $objectUuid,
+				]
+			);
+
+			return true;
+		} catch (Throwable $e) {
+			// Never propagate: layer 1 runs inside the run's own terminal
+			// write transaction, and a throw would unwind the status change.
+			// The TTL is the remaining backstop and the sweep sees the row again.
+			$this->logger->warning(
+				message: '[RunLockRegistry] Could not release a run lock',
+				context: [
+					'file' => __FILE__,
+					'line' => __LINE__,
+					'runUuid' => $runUuid,
+					'objectUuid' => $objectUuid,
+					'error' => $e->getMessage(),
+				]
+			);
+
+			return false;
+		}//end try
+	}//end releaseRecorded()
+}//end class

--- a/lib/Service/Object/SaveObject.php
+++ b/lib/Service/Object/SaveObject.php
@@ -3182,21 +3182,25 @@ class SaveObject {
 			);
 
 			// Check if object is locked - prevent updates on locked objects.
-			$lockData = $existingObject->getLocked();
-			if ($lockData !== null && is_array($lockData) === true) {
-				$currentUser = $this->userSession->getUser();
-				$currentUserId = null;
-				if ($currentUser !== null) {
-					$currentUserId = $currentUser->getUID();
-				}
+			//
+			// This guard NEVER FIRED before the run-scoped-locking change. It
+			// read the holder from `$lockData['userId']`, and
+			// `ObjectEntity::lock()` has always written it under `user`, so
+			// `$lockOwner` was invariably null and the `!== null` test
+			// short-circuited every time. Every lock taken since the endpoint
+			// shipped was decorative on this path. It is fixed by delegating
+			// to the one production predicate instead of re-spelling the
+			// comparison here, which is what went wrong in the first place.
+			$currentUser = $this->userSession->getUser();
+			$currentUserId = null;
+			if ($currentUser !== null) {
+				$currentUserId = $currentUser->getUID();
+			}
 
-				$lockOwner = $lockData['userId'] ?? null;
-
-				// If object is locked by someone other than the current user, prevent update.
-				if ($lockOwner !== null && $lockOwner !== $currentUserId) {
-					$unlockAdvice = 'Please unlock the object before attempting to update it.';
-					throw new Exception("Cannot update object: Object is locked by user '{$lockOwner}'. " . $unlockAdvice);
-				}
+			if ($existingObject->isLockedBySomeoneElse(userId: $currentUserId) === true) {
+				$holder = (string)$existingObject->describeLockHolder();
+				$unlockAdvice = 'Please unlock the object before attempting to update it.';
+				throw new Exception("Cannot update object: Object is locked by {$holder}. " . $unlockAdvice);
 			}
 
 			return $existingObject;

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -4064,6 +4064,10 @@ class ObjectService implements ObjectServiceInterface
      * @param bool        $advisory   When true, treat the identifier as a synthetic
      *                                pre-creation key and take the appConfig-backed
      *                                advisory lock without scanning object tables
+     * @param string|null $runUuid    Flow run taking the lock, for a run-scoped lock
+     *                                that refuses every other caller including the
+     *                                run's own runAs user
+     * @param string|null $nodeId     Flow node that took it, recorded for the sweep
      *
      * @return array Lock information
      *
@@ -4071,9 +4075,22 @@ class ObjectService implements ObjectServiceInterface
      *
      * @spec exclude One-line delegation to lock handler; lock behavior owned by object-lifecycle.
      */
-    public function lockObject(string $identifier, ?string $process=null, ?int $duration=null, bool $advisory=false): array
-    {
-        return $this->lockHandler->lock(identifier: $identifier, process: $process, duration: $duration, advisory: $advisory);
+    public function lockObject(
+        string $identifier,
+        ?string $process=null,
+        ?int $duration=null,
+        bool $advisory=false,
+        ?string $runUuid=null,
+        ?string $nodeId=null
+    ): array {
+        return $this->lockHandler->lock(
+            identifier: $identifier,
+            process: $process,
+            duration: $duration,
+            advisory: $advisory,
+            runUuid: $runUuid,
+            nodeId: $nodeId
+        );
     }//end lockObject()
 
     /**
@@ -4084,6 +4101,7 @@ class ObjectService implements ObjectServiceInterface
      * @param string|int $identifier The object to unlock
      * @param bool       $advisory   When true, release the appConfig-backed advisory
      *                               lock for this synthetic key without scanning tables
+     * @param string|null $runUuid   Flow run releasing the lock, for a run-scoped lock
      *
      * @return true True if unlocked successfully
      *
@@ -4091,10 +4109,30 @@ class ObjectService implements ObjectServiceInterface
      *
      * @spec exclude One-line delegation to lock handler; unlock behavior owned by object-lifecycle.
      */
-    public function unlockObject(string|int $identifier, bool $advisory=false): bool
+    public function unlockObject(string|int $identifier, bool $advisory=false, ?string $runUuid=null): bool
     {
-        return $this->lockHandler->unlock(identifier: (string) $identifier, advisory: $advisory);
+        return $this->lockHandler->unlock(
+            identifier: (string) $identifier,
+            advisory: $advisory,
+            runUuid: $runUuid
+        );
     }//end unlockObject()
+
+    /**
+     * Break a lock as an administrator, recording the displacement.
+     *
+     * @param string $identifier The object whose lock is to be broken
+     *
+     * @return bool True when a lock was broken
+     *
+     * @throws \Exception If the caller is not an administrator
+     *
+     * @spec exclude One-line delegation to lock handler; break behavior owned by the lock handler.
+     */
+    public function breakObjectLock(string $identifier): bool
+    {
+        return $this->lockHandler->breakLock(identifier: $identifier);
+    }//end breakObjectLock()
 
     /**
      * Bulk Save Operations Orchestrator (HIGH-PERFORMANCE BULK PROCESSING)

--- a/openspec/changes/run-scoped-object-locking/design.md
+++ b/openspec/changes/run-scoped-object-locking/design.md
@@ -1,0 +1,224 @@
+# Design: run-scoped-object-locking
+
+## D-1 · The lock record shape
+
+This is the decision that is awkward to reverse, because the record is
+already written into live `_locked` columns across every magic table on every
+instance. It is settled here before any code is written.
+
+### The record
+
+```jsonc
+{
+  "kind":       "run",              // NEW. "run" | "user". ABSENT means "user".
+  "runUuid":    "9f2c…",            // NEW. Present only when kind === "run".
+  "user":       "alice",            // unchanged meaning: WHO. For a run lock, its runAs.
+  "process":    "review-step",      // unchanged. Now actually persisted (see D-5).
+  "created":    "2026-09-05T…",     // unchanged
+  "duration":   3600,               // unchanged
+  "expiration": "2026-09-05T…"      // unchanged
+}
+```
+
+### Why this shape and not another
+
+**Why a `kind` discriminator rather than "a `runUuid` key means a run lock".**
+A present-key discriminator makes an absent key ambiguous between "user lock"
+and "run lock whose writer forgot the key", and the second must be refused
+loudly rather than silently downgraded to a user lock that the runAs user can
+then walk straight through. With an explicit `kind`, a record that says `run`
+and carries no `runUuid` is detectably malformed, and
+`isLockedBySomeoneElse()` refuses every caller for it rather than admitting
+one by accident. Failing closed on a malformed lock is the only safe
+direction: the alternative silently converts a bug into an open door.
+
+**Why `user` keeps its meaning in both cases instead of a nested holder
+object.** A nested `{holder: {kind, id}}` would be tidier on a blank sheet
+and is the wrong call here. `user` is read today by
+`ObjectEntity::getLockedBy()`, by `LockHandler::callerMayUnlock()`, by
+`LockHandler::getLockInfo()`'s `locked_by` projection, by
+`ObjectsController`'s 423 body, by `RevertHandler`, and by two frontend
+stores in opencatalogi and nextcloud-vue that render "locked by X". Moving it
+breaks all of them for no gain. Keeping `user` populated on a run lock with
+the run's `runAs` means every one of those readers keeps working and shows a
+true statement: that identity really is who the run acts as. What changes is
+only that `user` stops being the *authority* on ownership.
+
+**Why no migration and no back-fill.** `_locked` is a `Types::JSON` column
+(`MagicMapper::getMetadataColumns()`), so adding keys is a write-shape change
+with no schema change. Every lock written before this change has no `kind`;
+`kind ?? 'user'` reads it as a user lock, which is exactly what it is. There
+is no record in existence that this default misclassifies, because no run has
+ever been able to take a lock. A back-fill would have nothing to fill.
+
+**Why not a lock table instead of the JSON column.** The lock has to be
+readable in the same row read that the write guard already performs. Moving
+it to a side table adds a query to every single object write to answer a
+question that is `null` in the overwhelming majority of cases. The registry
+in D-4 exists for a different question, asked by a cron job rather than by
+every write.
+
+### How ownership is compared
+
+One production predicate, on `ObjectEntity`, and every guard calls it:
+
+```php
+public function isLockedBySomeoneElse(?string $userId, ?string $runUuid = null): bool
+```
+
+| Lock | `kind` | Held against | Admitted |
+|---|---|---|---|
+| user lock (legacy or new) | absent / `user` | everyone whose uid differs from `user` | that uid only |
+| run lock | `run` | **everyone**, including the run's own `runAs` user | that `runUuid` only |
+| malformed run lock | `run`, no `runUuid` | everyone | nobody |
+| expired lock | any | nobody (`isLocked()` is false) | everyone |
+
+A run lock refusing the run's own `runAs` user is decision 2 stated in code.
+If the runAs user were admitted, a lock taken by a run under `alice` would be
+no obstacle to alice, and on the many instances where flows run as a single
+service account it would be no obstacle to anybody. The lock would be
+decorative again, in a new way.
+
+The predicate is what tests assert against. No test restates the table above;
+`openregister#3428` is the standing reminder of what a test that reimplements
+its subject is worth.
+
+## D-2 · Suspend and retry reuses the heartbeat, and adds nothing
+
+`openregister.lock-object` needs no new waiting mechanism. The engine already
+has one, and the user-task node is the worked example.
+
+- **Park**: throw `FlowSuspension(resumeAt: <non-null>, reason: …)`.
+  `resumeAt` MUST be non-null. A null `resumeAt` means "waiting on an
+  external signal", and `FlowRunMapper::findAbandonedSignals()` fails such a
+  run after 14 days. A lock is not waiting on a signal, it is waiting on a
+  clock.
+- **Remember**: the node's own resume slot,
+  `$context[FlowNodeResumeState::CONTEXT_KEY]`. It stores `deadline` (the
+  wait budget's absolute expiry, stamped once on the first attempt and never
+  restamped) and `attempts`. The slot is per-node, so two lock steps in one
+  flow do not read each other's state.
+- **Wake**: `FlowRunWorker` calls `FlowRunMapper::findDue()` every cron tick,
+  which selects `suspended AND resume_at <= now`. The node runs again,
+  retries the acquire, and either proceeds or parks again.
+- **Forget**: the dispatcher clears the slot when `execute()` returns
+  normally. A node that suspends skips that line. Since openregister#3358,
+  `FlowRunService::keepResumeSlots()` preserves slots for every non-terminal
+  end, so a pass that legitimately ends `queued` no longer loses the
+  deadline and restart the budget from zero.
+
+**Backoff is the node's job.** There is no attempt counter or backoff column
+on `FlowRun`; `resume_at` is an absolute wake time. The node computes its own
+next `resumeAt` from `attempts` in its slot, clamped to a floor of 60 seconds
+because a wake finer than the cron period cannot happen anyway.
+
+**When the budget runs out the node fails, naming the holder.** It does not
+proceed, and it does not break the lock. Proceeding would be the data race
+the lock exists to prevent; breaking it would let any flow author defeat
+every other flow author's lock by waiting.
+
+## D-3 · Three release layers, and what each one is for
+
+| Layer | Covers | Latency |
+|---|---|---|
+| 1 · `FlowRunTerminalEvent` listener | every terminal outcome, including the reapers' | immediate |
+| 2 · sweep in `FlowRunWorker` | a lock whose run row is gone, or terminal without a release | one cron tick |
+| 3 · TTL (`expiration`, already exists) | everything else, including a database that lost layers 1 and 2 | the lock's duration |
+
+**Layer 1 hooks one place.** `FlowRunMapper::update()` dispatches
+`FlowRunTerminalEvent` whenever the persisted row `isTerminal()`. That is a
+predicate, not a status whitelist, so all four terminal statuses fire it, and
+so does every reaper (`reapStale`, `expireStaleQueued`,
+`expireAbandonedSignals`) because they all terminate through the same
+`update()`. The listener is idempotent by construction, which it has to be:
+the event can fire more than once for one run.
+
+> **Correction to the brief.** The four terminal statuses are `completed`,
+> `stopped`, `failed` and **`dead_letter`**. There is no `cancelled` and no
+> `expired` status: a cancellation and a queue-TTL expiry both land on
+> `failed` with an explanatory `error`. The tests cover the four that exist.
+
+**The listener must not rethrow.** For the stream-walk path the dispatch
+happens inside `FlowRunCommit`'s open transaction, so a throw would unwind
+the run's own terminal write. `TaskRunTerminalListener` is the established
+shape and this listener copies it: log, never rethrow.
+
+**Layer 2 is why the registry in D-4 exists.** A killed worker does reach
+terminal eventually, when `reapStale()` observes `updated` going cold, so
+layer 1 covers it after the stale window. What layer 1 cannot cover is a
+release that itself failed, or a run row deleted out from under an
+outstanding lock. The sweep finds those by asking the registry, not by
+looking at objects.
+
+## D-4 · The run-lock registry, and the 3.4-second alternative
+
+`openregister_run_object_locks`, one row per (run, object): `run_uuid`,
+`object_uuid`, `register_id`, `schema_id`, `node_id`, `locked_at`,
+`expires_at`, unique on `(run_uuid, object_uuid)`.
+
+**Why a table rather than reading the objects.** Locks live in the `_locked`
+column of magic tables, one table per register-schema pair.
+`MagicMapper::findAcrossAllMagicTables()` carries a measured note that an
+instance-wide scan over 2,728 magic tables builds 690 KB of SQL and costs
+about 3.4 seconds to *plan*, before a row is read. That is not a thing to put
+on a cron tick, and it is not a thing to put in a terminal-event listener
+that runs inside the run's own transaction. With the registry, "which locks
+does this run hold" is one indexed read, and "which locks are orphaned" is
+one `NOT IN` against the runs table, exactly the shape
+`FlowClaimMapper::deleteOrphans()` already uses for place claims.
+
+**Why not store the held locks in the run's context instead.** The context
+dies with the run row, which is precisely the case layer 2 exists to catch.
+
+**The registry is bookkeeping, never the authority.** The `_locked` column
+remains the only thing a write guard consults. A registry row without a
+matching `_locked` payload is stale bookkeeping and the sweep deletes it; a
+`_locked` payload without a registry row still blocks writes and still
+expires on its TTL. Making the registry authoritative would introduce a
+second source of truth for the question the guard asks on every write, and
+the two would drift.
+
+## D-5 · Two defects fixed on the way past
+
+**The write guard.** `SaveObject::findAndValidateExistingObject()` reads
+`$lockData['userId']`; `lock()` writes `user`. `$lockOwner` is always null
+and the guard's `!== null` short-circuits. Fixed by calling the D-1
+predicate. `ObjectsController`'s update path already compared the right key
+via `getLockedBy()` and so was the one live guard; it now delegates to the
+predicate too, so there is one comparison rather than two spellings of it.
+
+**The dropped process tag.** `LockHandler::lock()` accepts `$process` and
+never passes it to `MagicMapper::lockObjectEntity()`, which hardcodes
+`'MagicMapper lock'`. Both signatures now carry it. This is what lets a run
+lock say which node took it.
+
+**The post-save auto-unlock.** `ObjectsController` releases any lock after a
+successful update, patch or post-patch. That is fine for the user lock it was
+written for and wrong for a run lock, so it now releases only a lock the
+writer actually holds. Without this a single admin write would silently strip
+a run's lock as a side effect of a guard it had just passed.
+
+## D-6 · The `lock()` caller sweep
+
+Every caller of `lockObject()` in the fleet, checked for the shape that
+breaks when locks become real: lock under one identity, write under another.
+
+| Caller | Shape | Verdict |
+|---|---|---|
+| `ObjectsController::lock()` / `unlock()` (openregister) | HTTP, user session | unaffected |
+| integriq `EndpointService::processLockingRule()` | locks or unlocks as the request's user; does not write in the same rule | unaffected, and its `process` UUID now survives |
+| dossiq `DrcController::lock()` | locks, then `storeLockIdInData()` writes the same object **as the same user** | passes: the holder's own write is admitted. The write is already wrapped in a warn-only `try` |
+| dossiq `DrcController::unlock()` | unlocks, then writes | unaffected, the lock is gone before the write |
+| buildiq `ApplicationVersionsController::update()` | locks 15s, writes as the same user, releases in `finally` | passes, and **starts working**: the 409 branch it already has was unreachable |
+| buildiq `AbstractToolHandler::saveVersionManifest()` | locks 30s, writes as the same user, releases in `finally` | same |
+| buildiq `ApplicationCreationService` | advisory (pre-creation) lock, no object | unaffected |
+
+**No caller locks and then writes under a different identity, so nothing
+starts refusing.** Two callers start being *protected*: buildiq took its
+locks explicitly "to prevent last-writer-wins data loss when two concurrent
+MCP agents mutate the same version", and two agents under one account have
+never been able to conflict. Both already handle the 409 that they will now
+sometimes get.
+
+Nothing in `lib/Repair/`, `lib/Command/`, `lib/Migration/` or any seed takes
+an object lock, so no import or repair path is affected.

--- a/openspec/changes/run-scoped-object-locking/proposal.md
+++ b/openspec/changes/run-scoped-object-locking/proposal.md
@@ -1,0 +1,87 @@
+---
+kind: code
+---
+
+# Proposal: run-scoped-object-locking
+
+## Summary
+
+Make an object lock mean something, and let a flow run hold one. Two new
+nodes, `openregister.lock-object` and `openregister.unlock-object`, take and
+release a lock in the name of the **run** rather than the name of the user
+the run happens to execute as. A second run that wants the same object parks
+and retries on the heartbeat until the lock frees or its wait budget runs
+out. A person who tries to write to a locked object is refused with a message
+naming the run that holds it. The engine releases every lock a run holds on
+any terminal outcome, a sweep collects what a killed worker left behind, and
+the existing TTL stays as the last backstop.
+
+## Why
+
+**No lock has ever blocked a write.** `ObjectEntity::lock()` writes the
+holder under the key `user`. `SaveObject::findAndValidateExistingObject()`
+reads it under the key `userId`, so `$lockOwner` is always `null`, and the
+guard's `if ($lockOwner !== null && ...)` never fires. Every lock taken
+through `POST /api/objects/{register}/{schema}/{id}/lock` since the endpoint
+shipped has been decorative on that path. Measured on
+`origin/development@c18e5c286`.
+
+**The unit test agreed with the bug.** `SaveObjectTest::
+testFindAndValidateExistingObjectThrowsOnLockedObject` hand-writes
+`setLocked(['userId' => 'other-user'])`, a payload shape `lock()` has never
+produced, and passes. It is why the defect survived: the test asserted the
+guard's logic against the guard's own misreading rather than against a lock
+the production writer actually made.
+
+**Two runs under one identity cannot conflict today.** Ownership is compared
+on the user alone: `if ($lock['user'] !== $userId) throw`. Two flow runs
+executing under the same `runAs` therefore never collide. The second silently
+takes the *extend* branch and pushes the first run's expiry out, and either
+one can release the other's lock through `unlock()`, which repeats the same
+comparison. A run-scoped lock is exactly the case the current shape cannot
+express.
+
+**The process tag is dropped on the floor.** `LockHandler::lock()` accepts a
+`$process` argument and never forwards it; `MagicMapper::lockObjectEntity()`
+hardcodes `'MagicMapper lock'`. integriq's `processLockingRule()` mints a
+fresh UUID per lock and passes it in, and it is discarded before it reaches
+the payload, so no caller has ever been able to say what it locked *for*.
+
+## What Changes
+
+- **The lock record grows a holder kind.** `kind: 'run'|'user'` and
+  `runUuid`, added beside the existing keys. `_locked` is a JSON column, so
+  this is additive with no migration and no back-fill: a record written
+  before this change has no `kind` and reads as a user lock, which is what it
+  is. See design.md D-1.
+- **One production predicate owns ownership.**
+  `ObjectEntity::isLockedBySomeoneElse(?string $userId, ?string $runUuid)`.
+  Every guard calls it. No caller restates the comparison, and no test
+  restates it either.
+- **The write guard is fixed** in `SaveObject`, in the `ObjectsController`
+  update path, and in `RevertHandler`, and the refusal names the holder.
+- **Two nodes** in `lib/Service/Flow/Nodes/`, registered through
+  `FlowNodeRegistrationListener` like every other built-in. `lock-object`
+  parks the run with a non-null `resumeAt` and retries, keeping its attempt
+  count and deadline in its own resume slot.
+- **A run-lock registry**, `openregister_run_object_locks`, one row per
+  (run, object). It is what lets the terminal listener release a run's locks
+  without scanning, and what makes the sweep a single indexed query. See
+  design.md D-4 for why the alternative costs 3.4 seconds.
+- **Three release layers**: a `FlowRunTerminalEvent` listener, a sweep in
+  `FlowRunWorker`, and the TTL that already exists.
+- **An admin break-lock**, recorded in the audit trail as `lock.broken`.
+
+## Impact
+
+- **Affected specs**: `object-interactions`, `flow-engine`.
+- **Affected code**: `lib/Db/ObjectEntity.php`, `lib/Db/MagicMapper.php`,
+  `lib/Service/Object/LockHandler.php`, `lib/Service/Object/SaveObject.php`,
+  `lib/Service/Object/RevertHandler.php`,
+  `lib/Controller/ObjectsController.php`, `lib/Service/ObjectService.php`,
+  two new nodes, one new entity, one new mapper, one new migration, one new
+  listener, `lib/BackgroundJob/FlowRunWorker.php`.
+- **Behaviour that changes for existing callers**: a lock now refuses a
+  write. The caller sweep in design.md D-6 found no caller that locks and
+  then writes under a different identity, so nothing in the fleet starts
+  failing. integriq's `processLockingRule()` gains a working `process` tag.

--- a/openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md
+++ b/openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md
@@ -1,0 +1,223 @@
+# Spec: run-scoped object locking
+
+## Purpose
+
+A lock that a flow run can hold, that actually refuses a write, and that is
+always released. Locks were writable and readable before this change and
+blocked nothing on the service write path; ownership was keyed on the user
+alone, so two runs under one identity could not conflict with each other.
+
+## ADDED Requirements
+
+### Requirement: A lock records whether a run or a person holds it
+
+The lock payload SHALL carry a `kind` of either `run` or `user`, and a
+`runUuid` when and only when `kind` is `run`. A payload with no `kind` SHALL
+be read as a user lock, so records written before this capability keep their
+meaning with no migration and no back-fill.
+
+The payload SHALL keep populating `user` in both cases: the person for a user
+lock, and the run's `runAs` identity for a run lock. `user` SHALL NOT be the
+authority on ownership.
+
+A payload whose `kind` is `run` but which carries no `runUuid` SHALL be
+treated as held against every caller, including the caller that would
+otherwise match. A malformed lock fails closed.
+
+#### Scenario: A record written before this change is a user lock
+- **GIVEN** a stored lock payload carrying `user` and `expiration` and no `kind`
+- **WHEN** ownership is evaluated for that same user
+- **THEN** the lock MUST be held by that user, and no migration MUST be required
+- @e2e exclude entity-level payload semantics, covered by ObjectEntityTest
+
+#### Scenario: A malformed run lock admits nobody
+- **GIVEN** a lock payload with `kind` of `run` and no `runUuid`
+- **WHEN** any caller, run or person, is evaluated against it
+- **THEN** the lock MUST be held against that caller
+- @e2e exclude entity-level payload semantics, covered by ObjectEntityTest
+
+### Requirement: Ownership is decided by one predicate
+
+The system SHALL expose a single predicate that answers whether a live lock
+is held against a given caller, identified by a user id and an optional run
+uuid. Every write guard, every unlock authorization and every node SHALL call
+it. No caller SHALL restate the comparison.
+
+A user lock SHALL be held against every caller whose user id differs from the
+recorded one. A run lock SHALL be held against every caller whose run uuid
+differs from the recorded one, **including a caller presenting the run's own
+`runAs` user id and no run uuid**. An expired lock SHALL be held against
+nobody.
+
+#### Scenario: Two runs under one user conflict
+- **GIVEN** an object locked by run A executing as `alice`
+- **WHEN** run B, also executing as `alice`, evaluates the lock
+- **THEN** the lock MUST be held against run B, and run B MUST NOT extend it
+- @e2e exclude engine-internal, covered by the two-run real-engine test
+
+#### Scenario: A run's own runAs user is still refused
+- **GIVEN** an object locked by run A executing as `alice`
+- **WHEN** `alice` evaluates the lock as a person, with no run uuid
+- **THEN** the lock MUST be held against her
+
+#### Scenario: A run may extend its own lock
+- **GIVEN** an object locked by run A
+- **WHEN** run A locks it again
+- **THEN** the lock MUST be extended rather than refused
+
+### Requirement: A lock refuses a write and names its holder
+
+While a live lock is held against the caller, the system SHALL refuse to
+update, patch or revert that object, and the refusal SHALL name the holder.
+When a run holds the lock the message SHALL name the run.
+
+The refusal SHALL apply on the service write path, not only at the HTTP
+controller: a lock that only the controller enforces is not a lock.
+
+#### Scenario: A person is refused while a run holds the lock
+- **GIVEN** an object locked by a flow run
+- **WHEN** a person updates it over the API
+- **THEN** the write MUST be refused, and the message MUST name the holding run
+
+#### Scenario: The holder writes freely
+- **GIVEN** an object locked by a person
+- **WHEN** that same person updates it
+- **THEN** the write MUST succeed
+
+#### Scenario: A successful write releases only the writer's own lock
+- **GIVEN** an object carrying a lock the writer does not hold
+- **WHEN** a write to that object completes
+- **THEN** the lock MUST survive the write
+- @e2e exclude controller-internal, covered by ObjectsControllerTest
+
+### Requirement: An administrator may break a lock, and the break is recorded
+
+An administrator SHALL be able to release a lock held by anyone, so a wedged
+run cannot hold a case hostage. The break SHALL be written to the audit trail
+with an action distinguishing it from an ordinary unlock, naming the holder
+that was displaced.
+
+No other caller SHALL release a run's lock. The existing holder, object-owner
+and schema-manage routes to unlocking SHALL continue to apply to **user**
+locks only.
+
+#### Scenario: An administrator breaks a run's lock
+- **GIVEN** an object locked by a flow run
+- **WHEN** an administrator breaks the lock
+- **THEN** the lock MUST be released and an audit entry MUST record the break and the displaced run
+
+#### Scenario: The object owner cannot break a run's lock
+- **GIVEN** an object locked by a flow run
+- **WHEN** its owner, who is not an administrator, tries to unlock it
+- **THEN** the unlock MUST be refused
+
+### Requirement: A lock step takes a lock, or parks the run and retries
+
+The system SHALL provide a step node type `openregister.lock-object` that
+takes a run-scoped lock on a target object, and
+`openregister.unlock-object` that releases one.
+
+The target SHALL default to the object the item carries and SHALL be
+overridable by configuration. Both nodes SHALL accept a duration; the lock
+step SHALL accept a wait budget.
+
+When the lock is held by another holder, the lock step SHALL suspend the run
+with a non-null resume time and retry on re-entry, rather than failing
+immediately or proceeding without the lock. It SHALL keep its wait deadline
+and attempt count in its own resume slot, stamping the deadline once, and it
+SHALL NOT restart the budget across re-entries.
+
+When the wait budget expires the step SHALL fail, naming the holding run. It
+SHALL NOT break the lock and SHALL NOT proceed without it.
+
+An empty firing SHALL take no lock and SHALL NOT suspend the run.
+
+#### Scenario: A contended lock parks the run
+- **GIVEN** an object already locked by another run
+- **WHEN** a lock step runs against it
+- **THEN** the run MUST suspend with a non-null resume time
+- @e2e exclude node-internal, covered by LockObjectNodeTest
+
+#### Scenario: The wait budget is not restarted by a retry
+- **GIVEN** a lock step that has already parked once and recorded its deadline
+- **WHEN** it re-enters and the object is still locked
+- **THEN** it MUST keep the original deadline
+- @e2e exclude node-internal, covered by LockObjectNodeTest
+
+#### Scenario: An exhausted budget fails and names the holder
+- **GIVEN** a lock step whose recorded deadline has passed and whose target is still locked
+- **WHEN** it re-enters
+- **THEN** it MUST fail with a message naming the holding run, and MUST NOT take or break the lock
+
+#### Scenario: An empty firing does not suspend
+- **GIVEN** a lock step reached with no items
+- **WHEN** it runs
+- **THEN** it MUST return no items and MUST NOT suspend the run
+
+#### Scenario: Configuration is validated before the flow is published
+- **GIVEN** a lock step whose wait budget is not a positive number
+- **WHEN** its configuration is validated
+- **THEN** validation MUST be refused with a message saying what to correct
+
+### Requirement: Every lock a run holds is released when the run ends
+
+The engine SHALL release every lock a run holds on **any** terminal outcome:
+`completed`, `stopped`, `failed` and `dead_letter`. The release SHALL NOT
+depend on a node running, so a run that crashed or failed still releases.
+
+The release SHALL be idempotent, since terminality can be observed more than
+once, and SHALL NOT propagate a failure into the run's own terminal write.
+
+The system SHALL additionally sweep locks whose holding run is terminal or no
+longer exists, for the case where a release did not happen. The sweep SHALL
+NOT require reading every object table.
+
+The existing lock expiry SHALL remain in force as the final backstop.
+
+#### Scenario: A completed run releases its locks
+- **GIVEN** a run holding a lock
+- **WHEN** the run completes
+- **THEN** the lock MUST be released
+
+#### Scenario: A failed run releases its locks
+- **GIVEN** a run holding a lock
+- **WHEN** the run fails
+- **THEN** the lock MUST be released
+
+#### Scenario: A stopped run releases its locks
+- **GIVEN** a run holding a lock
+- **WHEN** the run stops
+- **THEN** the lock MUST be released
+
+#### Scenario: A dead-lettered run releases its locks
+- **GIVEN** a run holding a lock
+- **WHEN** the run is dead-lettered
+- **THEN** the lock MUST be released
+
+#### Scenario: The sweep releases a lock whose run is gone
+- **GIVEN** a lock held by a run whose row no longer exists
+- **WHEN** the sweep runs
+- **THEN** the lock MUST be released
+
+#### Scenario: The sweep leaves a live run's lock alone
+- **GIVEN** a lock held by a run that is still suspended
+- **WHEN** the sweep runs
+- **THEN** the lock MUST survive
+
+#### Scenario: An expired lock blocks nobody
+- **GIVEN** a run lock whose expiry has passed and whose run never released it
+- **WHEN** any caller evaluates it
+- **THEN** the lock MUST be held against nobody
+
+## MODIFIED Requirements
+
+### Requirement: A lock records what it was taken for
+
+`LockHandler::lock()` has accepted a `process` argument since it shipped and
+never forwarded it; `MagicMapper` wrote the literal `MagicMapper lock` in its
+place. The caller's `process` SHALL reach the stored payload.
+
+#### Scenario: A caller's process tag survives
+- **GIVEN** a caller locking an object with a process tag
+- **WHEN** the lock payload is read back
+- **THEN** it MUST carry that tag

--- a/openspec/changes/run-scoped-object-locking/tasks.md
+++ b/openspec/changes/run-scoped-object-locking/tasks.md
@@ -1,0 +1,76 @@
+# Tasks: run-scoped-object-locking
+
+## 1 · The lock record and its predicate
+
+- [ ] 1.1 Add `LOCK_KIND_RUN` / `LOCK_KIND_USER`, `isLockedBySomeoneElse()`,
+  `describeLockHolder()` and `getLockedByRun()` to `ObjectEntity`.
+  **files**: `lib/Db/ObjectEntity.php`
+- [ ] 1.2 Thread `?string $runUuid` through `ObjectEntity::lock()` and
+  `unlock()`, and route both through the predicate.
+  **files**: `lib/Db/ObjectEntity.php`
+- [ ] 1.3 Replace `SaveObjectTest`'s two `['userId' => …]` fixtures, which
+  pin a payload shape `lock()` never wrote.
+  **files**: `tests/Unit/Service/Object/SaveObjectTest.php`
+
+## 2 · The write guard
+
+- [ ] 2.1 Fix `findAndValidateExistingObject()` to call the predicate and
+  name the holder.
+  **files**: `lib/Service/Object/SaveObject.php`
+- [ ] 2.2 Route the controller's 423 guard and `RevertHandler` through the
+  same predicate.
+  **files**: `lib/Controller/ObjectsController.php`, `lib/Service/Object/RevertHandler.php`
+- [ ] 2.3 Make the post-save auto-unlock release only the writer's own lock.
+  **files**: `lib/Controller/ObjectsController.php`
+
+## 3 · Plumbing the run identity and the process tag
+
+- [ ] 3.1 Forward `$process` and `$runUuid` through
+  `MagicMapper::lockObjectEntity()` / `unlockObjectEntity()`.
+  **files**: `lib/Db/MagicMapper.php`
+- [ ] 3.2 Thread them through `LockHandler`, `ObjectService` and the contract.
+  **files**: `lib/Service/Object/LockHandler.php`, `lib/Service/ObjectService.php`, `lib/Contract/ObjectServiceInterface.php`
+- [ ] 3.3 Make `callerMayUnlock()` run-aware and add an audited `breakLock()`.
+  **files**: `lib/Service/Object/LockHandler.php`
+
+## 4 · The run-lock registry
+
+- [ ] 4.1 `RunObjectLock` entity and `RunObjectLockMapper` with
+  `findByRun()`, `releaseByRun()`, `deleteOrphans()`.
+  **files**: `lib/Db/RunObjectLock.php`, `lib/Db/RunObjectLockMapper.php`
+- [ ] 4.2 Migration creating `openregister_run_object_locks`.
+  **files**: `lib/Migration/Version1Date20260905120000.php`
+
+## 5 · The nodes
+
+- [ ] 5.1 `LockObjectNode` with suspend-and-retry over the resume slot.
+  **files**: `lib/Service/Flow/Nodes/LockObjectNode.php`
+- [ ] 5.2 `UnlockObjectNode`.
+  **files**: `lib/Service/Flow/Nodes/UnlockObjectNode.php`
+- [ ] 5.3 Register both; bump the registration test's node count.
+  **files**: `lib/Listener/FlowNodeRegistrationListener.php`, `tests/Unit/Listener/FlowNodeRegistrationListenerTest.php`
+
+## 6 · Release
+
+- [ ] 6.1 `FlowRunLockReleaseListener` on `FlowRunTerminalEvent`, idempotent,
+  never rethrowing.
+  **files**: `lib/Listener/FlowRunLockReleaseListener.php`, `lib/AppInfo/Application.php`
+- [ ] 6.2 Sweep orphaned run locks from `FlowRunWorker`.
+  **files**: `lib/BackgroundJob/FlowRunWorker.php`
+
+## 7 · Tests that can fail
+
+- [ ] 7.1 Two runs under one user conflict, proven red against the old
+  predicate first.
+  **files**: `tests/Unit/Db/ObjectEntityRunLockTest.php`
+- [ ] 7.2 Release proven separately for each of the four terminal statuses.
+  **files**: `tests/Unit/Listener/FlowRunLockReleaseListenerTest.php`
+- [ ] 7.3 Holder gone, sweep releases; live run's lock survives.
+  **files**: `tests/Unit/Db/RunObjectLockMapperTest.php`, `tests/Unit/Listener/FlowRunLockReleaseListenerTest.php`
+- [ ] 7.4 TTL backstop.
+  **files**: `tests/Unit/Db/ObjectEntityRunLockTest.php`
+- [ ] 7.5 A human write refused while a run holds the lock; the admin break
+  works and is audited.
+  **files**: `tests/Unit/Service/Object/SaveObjectTest.php`, `tests/Unit/Service/Object/LockHandlerBreakLockTest.php`
+- [ ] 7.6 Node config validation and the park/retry/budget behaviour.
+  **files**: `tests/Unit/Service/Flow/LockObjectNodeTest.php`, `tests/Unit/Service/Flow/UnlockObjectNodeTest.php`

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -220,11 +220,6 @@
       <code><![CDATA[$operation = &$this->oas['paths'][$pathName][$method]]]></code>
     </UnsupportedPropertyReferenceUsage>
   </file>
-  <file src="lib/Service/Object/LockHandler.php">
-    <UnusedReturnValue>
-      <code><![CDATA[bool]]></code>
-    </UnusedReturnValue>
-  </file>
   <file src="lib/Service/Object/SaveObjects.php">
     <ImplicitToStringCast>
       <code><![CDATA[$registerId]]></code>

--- a/tests/Unit/Db/ObjectEntityLockExtensionTest.php
+++ b/tests/Unit/Db/ObjectEntityLockExtensionTest.php
@@ -113,7 +113,9 @@ class ObjectEntityLockExtensionTest extends TestCase {
 		$entity->lock($this->sessionFor('alice'), 'import', 600);
 
 		$this->expectException(Exception::class);
-		$this->expectExceptionMessage('Object is locked by another user');
+		// The refusal now NAMES the holder: a refusal that does not say who
+		// holds the lock leaves the reader with nowhere to go.
+		$this->expectExceptionMessage('Object is locked by alice');
 
 		$entity->lock($this->sessionFor('bob'), 'export', 600);
 	}//end testADifferentUserIsRefused()

--- a/tests/Unit/Db/ObjectEntityRunLockTest.php
+++ b/tests/Unit/Db/ObjectEntityRunLockTest.php
@@ -1,0 +1,315 @@
+<?php
+
+/**
+ * Run-scoped object locking, at the entity.
+ *
+ * These tests exist because the case that matters most silently PASSED
+ * before this change: two flow runs executing under the same `runAs` could
+ * not conflict, because ownership was compared on the user alone. The second
+ * run took the extend branch, pushed the first run's expiry out, and was
+ * handed the object.
+ *
+ * Every assertion here goes through the production predicate
+ * `ObjectEntity::isLockedBySomeoneElse()` or through `lock()`/`unlock()`
+ * themselves. None of them restates the ownership table: a test that
+ * reimplements its subject agrees with the subject's bugs, which is exactly
+ * how the broken write guard survived (see SaveObjectTest, and
+ * openregister#3428).
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Db
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Db;
+
+use DateInterval;
+use DateTime;
+use Exception;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \OCA\OpenRegister\Db\ObjectEntity
+ */
+final class ObjectEntityRunLockTest extends TestCase {
+
+	private const RUN_A = 'run-aaaaaaaa-0000-0000-0000-000000000001';
+
+	private const RUN_B = 'run-bbbbbbbb-0000-0000-0000-000000000002';
+
+	private ObjectEntity $entity;
+
+	/**
+	 * Fresh entity per test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->entity = new ObjectEntity();
+	}//end setUp()
+
+	/**
+	 * A session for the given uid.
+	 *
+	 * @param string $uid The user id.
+	 *
+	 * @return IUserSession The session.
+	 */
+	private function session(string $uid): IUserSession {
+		$user = $this->createMock(originalClassName: IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$session = $this->createMock(originalClassName: IUserSession::class);
+		$session->method('getUser')->willReturn($user);
+		return $session;
+	}//end session()
+
+	// ---------------------------------------------------------------
+	// The case that silently passed before this change.
+	// ---------------------------------------------------------------
+
+	/**
+	 * Two runs under ONE user must conflict.
+	 *
+	 * @return void
+	 */
+	public function testASecondRunUnderTheSameUserIsRefused(): void {
+		$this->entity->lock($this->session('alice'), 'step-one', 3600, self::RUN_A);
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage(self::RUN_A);
+		$this->entity->lock($this->session('alice'), 'step-two', 3600, self::RUN_B);
+	}//end testASecondRunUnderTheSameUserIsRefused()
+
+	/**
+	 * The refusal must not have quietly extended the first run's lock.
+	 *
+	 * Before this change the second lock() call landed in the extend branch
+	 * and REWROTE the expiry and the process tag. Asserting only that the
+	 * second call throws would not catch a guard that throws after mutating.
+	 *
+	 * @return void
+	 */
+	public function testARefusedRunLeavesTheFirstRunsLockUntouched(): void {
+		$this->entity->lock($this->session('alice'), 'step-one', 3600, self::RUN_A);
+		$before = $this->entity->getLocked();
+
+		try {
+			$this->entity->lock($this->session('alice'), 'step-two', 60, self::RUN_B);
+			$this->fail('the second run was admitted');
+		} catch (Exception $e) {
+			// Expected.
+		}
+
+		$this->assertSame($before, $this->entity->getLocked(), 'the refused run rewrote the lock');
+	}//end testARefusedRunLeavesTheFirstRunsLockUntouched()
+
+	/**
+	 * A run may extend its OWN lock.
+	 *
+	 * @return void
+	 */
+	public function testARunMayExtendItsOwnLock(): void {
+		$this->entity->lock($this->session('alice'), 'step-one', 60, self::RUN_A);
+		$this->assertTrue($this->entity->lock($this->session('alice'), 'step-one', 3600, self::RUN_A));
+		$this->assertSame(self::RUN_A, $this->entity->getLockedByRun());
+	}//end testARunMayExtendItsOwnLock()
+
+	/**
+	 * A run lock refuses the run's OWN runAs user acting as a person.
+	 *
+	 * @return void
+	 */
+	public function testARunLockRefusesItsOwnRunAsUser(): void {
+		$this->entity->lock($this->session('alice'), 'step-one', 3600, self::RUN_A);
+
+		$this->assertTrue(
+			$this->entity->isLockedBySomeoneElse(userId: 'alice', runUuid: null),
+			'a person walked in behind the run identity'
+		);
+	}//end testARunLockRefusesItsOwnRunAsUser()
+
+	// ---------------------------------------------------------------
+	// The record shape, and the records that already exist.
+	// ---------------------------------------------------------------
+
+	/**
+	 * A payload with no `kind` is a user lock, with no migration.
+	 *
+	 * @return void
+	 */
+	public function testALegacyPayloadWithNoKindIsAUserLock(): void {
+		$expiration = (new DateTime())->add(new DateInterval('PT3600S'));
+		$this->entity->hydrate(
+			[
+				'locked' => ['user' => 'bob', 'expiration' => $expiration->format('c')],
+			]
+		);
+
+		$this->assertFalse($this->entity->isLockedBySomeoneElse(userId: 'bob'));
+		$this->assertTrue($this->entity->isLockedBySomeoneElse(userId: 'carol'));
+		$this->assertNull($this->entity->getLockedByRun());
+	}//end testALegacyPayloadWithNoKindIsAUserLock()
+
+	/**
+	 * A run lock records the kind, the run and the runAs user.
+	 *
+	 * @return void
+	 */
+	public function testARunLockRecordsAllThreeIdentityFields(): void {
+		$this->entity->lock($this->session('alice'), 'step-one', 3600, self::RUN_A);
+		$payload = $this->entity->getLocked();
+
+		$this->assertSame(ObjectEntity::LOCK_KIND_RUN, $payload['kind']);
+		$this->assertSame(self::RUN_A, $payload['runUuid']);
+		$this->assertSame('alice', $payload['user'], 'existing readers of `user` must keep working');
+		$this->assertSame('alice', $this->entity->getLockedBy());
+	}//end testARunLockRecordsAllThreeIdentityFields()
+
+	/**
+	 * The caller's process tag reaches the payload.
+	 *
+	 * @return void
+	 */
+	public function testTheProcessTagSurvives(): void {
+		$this->entity->lock($this->session('alice'), 'buildiq.mcp-manifest-edit', 3600);
+		$this->assertSame('buildiq.mcp-manifest-edit', $this->entity->getLocked()['process']);
+	}//end testTheProcessTagSurvives()
+
+	/**
+	 * A malformed run lock admits nobody.
+	 *
+	 * @return void
+	 */
+	public function testAMalformedRunLockAdmitsNobody(): void {
+		$expiration = (new DateTime())->add(new DateInterval('PT3600S'));
+		$this->entity->hydrate(
+			[
+				'locked' => [
+					'kind' => ObjectEntity::LOCK_KIND_RUN,
+					'user' => 'alice',
+					'expiration' => $expiration->format('c'),
+				],
+			]
+		);
+
+		$this->assertTrue($this->entity->isLockedBySomeoneElse(userId: 'alice', runUuid: self::RUN_A));
+		$this->assertTrue($this->entity->isLockedBySomeoneElse(userId: 'alice'));
+		$this->assertNull($this->entity->getLockedByRun());
+	}//end testAMalformedRunLockAdmitsNobody()
+
+	// ---------------------------------------------------------------
+	// Layer 3: the TTL backstop.
+	// ---------------------------------------------------------------
+
+	/**
+	 * An expired run lock blocks nobody, and a live one blocks everybody.
+	 *
+	 * This is the last release layer: a run that never released, whose
+	 * terminal event never fired and which the sweep never reached, still
+	 * stops blocking once its duration is up.
+	 *
+	 * @return void
+	 */
+	public function testAnExpiredRunLockBlocksNobody(): void {
+		$live = (new DateTime())->add(new DateInterval('PT3600S'));
+		$this->entity->hydrate(
+			[
+				'locked' => [
+					'kind' => ObjectEntity::LOCK_KIND_RUN,
+					'runUuid' => self::RUN_A,
+					'user' => 'alice',
+					'expiration' => $live->format('c'),
+				],
+			]
+		);
+		$this->assertTrue($this->entity->isLockedBySomeoneElse(userId: 'carol'), 'control: a live lock blocks');
+
+		$expired = (new DateTime())->sub(new DateInterval('PT10S'));
+		$this->entity->hydrate(
+			[
+				'locked' => [
+					'kind' => ObjectEntity::LOCK_KIND_RUN,
+					'runUuid' => self::RUN_A,
+					'user' => 'alice',
+					'expiration' => $expired->format('c'),
+				],
+			]
+		);
+
+		$this->assertFalse($this->entity->isLockedBySomeoneElse(userId: 'carol'));
+		$this->assertNull($this->entity->getLockedByRun());
+		$this->assertNull($this->entity->describeLockHolder());
+	}//end testAnExpiredRunLockBlocksNobody()
+
+	// ---------------------------------------------------------------
+	// The refusal message.
+	// ---------------------------------------------------------------
+
+	/**
+	 * The refusal names the run, so the reader has somewhere to go.
+	 *
+	 * @return void
+	 */
+	public function testTheHolderDescriptionNamesTheRun(): void {
+		$this->entity->lock($this->session('alice'), 'step-one', 3600, self::RUN_A);
+		$description = (string)$this->entity->describeLockHolder();
+
+		$this->assertStringContainsString(self::RUN_A, $description);
+		$this->assertStringContainsString('alice', $description);
+	}//end testTheHolderDescriptionNamesTheRun()
+
+	// ---------------------------------------------------------------
+	// unlock()
+	// ---------------------------------------------------------------
+
+	/**
+	 * A different run cannot release a run's lock.
+	 *
+	 * @return void
+	 */
+	public function testAnotherRunCannotUnlock(): void {
+		$this->entity->lock($this->session('alice'), 'step-one', 3600, self::RUN_A);
+
+		$this->expectException(Exception::class);
+		$this->entity->unlock($this->session('alice'), self::RUN_B);
+	}//end testAnotherRunCannotUnlock()
+
+	/**
+	 * The holding run releases its own lock.
+	 *
+	 * @return void
+	 */
+	public function testTheHoldingRunUnlocks(): void {
+		$this->entity->lock($this->session('alice'), 'step-one', 3600, self::RUN_A);
+		$this->assertTrue($this->entity->unlock($this->session('alice'), self::RUN_A));
+		$this->assertFalse($this->entity->isLocked());
+	}//end testTheHoldingRunUnlocks()
+
+	/**
+	 * The break flag releases a lock the caller does not hold.
+	 *
+	 * Authorization for the break lives at the LockHandler call site; this
+	 * only pins that the entity honours it.
+	 *
+	 * @return void
+	 */
+	public function testTheBreakFlagReleasesAnotherHoldersLock(): void {
+		$this->entity->lock($this->session('alice'), 'step-one', 3600, self::RUN_A);
+		$this->assertTrue($this->entity->unlock($this->session('admin'), null, true));
+		$this->assertFalse($this->entity->isLocked());
+	}//end testTheBreakFlagReleasesAnotherHoldersLock()
+}//end class

--- a/tests/Unit/Db/ObjectEntityTest.php
+++ b/tests/Unit/Db/ObjectEntityTest.php
@@ -357,8 +357,17 @@ class ObjectEntityTest extends TestCase {
 		$session = $this->mockUserSession('user1');
 		$result = $this->entity->lock($session, 'editing', 3600);
 		$this->assertTrue($result);
-		// Note: lock uses named args which hit the Entity __call bug,
-		// so locked data may not actually be set. Testing the return value.
+
+		// The old comment here claimed the payload "may not actually be set"
+		// because of an Entity __call bug, and asserted only the return
+		// value. It is not true: lock() does write the payload, and a test
+		// that checks nothing about it is how the `user` vs `userId` key
+		// mismatch in SaveObject's guard went unnoticed for so long.
+		$payload = $this->entity->getLocked();
+		$this->assertSame('user1', $payload['user']);
+		$this->assertSame('editing', $payload['process']);
+		$this->assertSame(3600, $payload['duration']);
+		$this->assertSame(ObjectEntity::LOCK_KIND_USER, $payload['kind']);
 	}
 
 	public function testLockThrowsWithNoUser(): void {
@@ -373,8 +382,12 @@ class ObjectEntityTest extends TestCase {
 			'locked' => ['user' => 'user1', 'expiration' => $expiration->format('c')],
 		]);
 
+		// The refusal now NAMES the holder rather than saying "another user":
+		// a refusal that does not say who holds the lock leaves the reader
+		// with nowhere to go. See the run-scoped-object-locking spec,
+		// "A lock refuses a write and names its holder".
 		$this->expectException(Exception::class);
-		$this->expectExceptionMessage('Object is locked by another user');
+		$this->expectExceptionMessage('Object is locked by user1');
 		$this->entity->lock($this->mockUserSession('user2'));
 	}
 

--- a/tests/Unit/Listener/FlowNodeRegistrationListenerTest.php
+++ b/tests/Unit/Listener/FlowNodeRegistrationListenerTest.php
@@ -29,6 +29,7 @@ use OCA\OpenRegister\Service\Flow\Nodes\ExplodeNode;
 use OCA\OpenRegister\Service\Flow\Nodes\FilterNode;
 use OCA\OpenRegister\Service\Flow\Nodes\FlowStateNode;
 use OCA\OpenRegister\Service\Flow\Nodes\IterateNode;
+use OCA\OpenRegister\Service\Flow\Nodes\LockObjectNode;
 use OCA\OpenRegister\Service\Flow\Nodes\LoopNode;
 use OCA\OpenRegister\Service\Flow\Nodes\MapNode;
 use OCA\OpenRegister\Service\Flow\Nodes\MergeNode;
@@ -45,6 +46,7 @@ use OCA\OpenRegister\Service\Flow\Nodes\SwitchNode;
 use OCA\OpenRegister\Service\Flow\Nodes\TriggerManualNode;
 use OCA\OpenRegister\Service\Flow\Nodes\TriggerObjectNode;
 use OCA\OpenRegister\Service\Flow\Nodes\TriggerScheduleNode;
+use OCA\OpenRegister\Service\Flow\Nodes\UnlockObjectNode;
 use OCA\OpenRegister\Service\Flow\Nodes\UserTaskNode;
 use OCA\OpenRegister\Service\Flow\Nodes\WaitNode;
 use OCA\OpenRegister\Service\Flow\RegisterFlowNodesEvent;
@@ -77,6 +79,8 @@ class FlowNodeRegistrationListenerTest extends TestCase {
 			switch: $mock(SwitchNode::class),
 			end: $mock(EndNode::class),
 			merge: $mock(MergeNode::class),
+			lockObject: $mock(LockObjectNode::class),
+			unlockObject: $mock(UnlockObjectNode::class),
 			loop: $mock(LoopNode::class),
 			subFlow: $mock(SubFlowNode::class),
 			router: $mock(RouterNode::class),
@@ -118,7 +122,7 @@ class FlowNodeRegistrationListenerTest extends TestCase {
 
 		$listener->handle(new RegisterFlowNodesEvent(registry: $registry));
 
-		$this->assertCount(25, $registered, 'all twenty-five built-ins are registered');
+		$this->assertCount(27, $registered, 'all twenty-seven built-ins are registered');
 		$classes = array_map(static fn (IFlowNode $node): string => get_parent_class($node) ?: get_class($node), $registered);
 		foreach ([PortalTaskNode::class, UserTaskNode::class, AwaitSignalNode::class] as $waiter) {
 			$this->assertContains($waiter, $classes, "$waiter is registered");

--- a/tests/Unit/Listener/FlowRunLockReleaseListenerTest.php
+++ b/tests/Unit/Listener/FlowRunLockReleaseListenerTest.php
@@ -1,0 +1,155 @@
+<?php
+
+/**
+ * Release layer 1: a terminal run lets go of its object locks.
+ *
+ * Each of the FOUR terminal statuses is proven SEPARATELY. Asserting only the
+ * happy path would leave the cases that matter most untested: a run that
+ * completes is also a run that reached an unlock step, while a run that
+ * failed, stopped or was dead-lettered is precisely the one that did not.
+ *
+ * NOTE for anyone reading the brief that commissioned this: there is no
+ * `cancelled` run status. `FlowRun::TERMINAL` is completed, stopped, failed
+ * and dead_letter; a cancellation and a queue-TTL expiry both land on
+ * `failed` with an explanatory error. The four below are the four that exist.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Listener
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Listener;
+
+use OCA\OpenRegister\Db\FlowRun;
+use OCA\OpenRegister\Event\FlowRunTerminalEvent;
+use OCA\OpenRegister\Listener\FlowRunLockReleaseListener;
+use OCA\OpenRegister\Service\Object\RunLockRegistry;
+use OCP\EventDispatcher\Event;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * @covers \OCA\OpenRegister\Listener\FlowRunLockReleaseListener
+ */
+final class FlowRunLockReleaseListenerTest extends TestCase {
+
+	private const RUN = 'run-aaaaaaaa-0000-0000-0000-000000000001';
+
+	/**
+	 * Every terminal status the engine can actually reach.
+	 *
+	 * Read from the PRODUCTION constant rather than typed out, so a status
+	 * added to `FlowRun::TERMINAL` without a release arrives here as a
+	 * failure instead of as silence.
+	 *
+	 * @return array<string, array{0: string}> The cases.
+	 */
+	public static function terminalStatuses(): array {
+		$cases = [];
+		foreach (FlowRun::TERMINAL as $status) {
+			$cases[$status] = [$status];
+		}
+
+		return $cases;
+	}//end terminalStatuses()
+
+	/**
+	 * A run releases its locks on every terminal status, not just the happy one.
+	 *
+	 * @param string $status The terminal status.
+	 *
+	 * @return void
+	 *
+	 * @dataProvider terminalStatuses
+	 */
+	public function testEveryTerminalStatusReleasesTheRunsLocks(string $status): void {
+		$locks = $this->createMock(originalClassName: RunLockRegistry::class);
+		$locks->expects($this->once())
+			->method('releaseRunLocks')
+			->with(self::RUN)
+			->willReturn(1);
+
+		$listener = new FlowRunLockReleaseListener($locks, $this->createMock(LoggerInterface::class));
+		$listener->handle(new FlowRunTerminalEvent(runUuid: self::RUN, status: $status));
+	}//end testEveryTerminalStatusReleasesTheRunsLocks()
+
+	/**
+	 * The four statuses covered above really are all of them.
+	 *
+	 * A guard on the data provider itself: if `FlowRun::TERMINAL` grows and
+	 * nobody notices, the count moves and this fails.
+	 *
+	 * @return void
+	 */
+	public function testThereAreExactlyFourTerminalStatuses(): void {
+		$this->assertSame(
+			['completed', 'stopped', 'dead_letter', 'failed'],
+			FlowRun::TERMINAL,
+			'a terminal status was added or renamed; the release must cover it'
+		);
+	}//end testThereAreExactlyFourTerminalStatuses()
+
+	/**
+	 * The listener is idempotent: terminality can be observed twice.
+	 *
+	 * @return void
+	 */
+	public function testASecondObservationIsHarmless(): void {
+		$locks = $this->createMock(originalClassName: RunLockRegistry::class);
+		$locks->expects($this->exactly(2))
+			->method('releaseRunLocks')
+			->with(self::RUN)
+			->willReturnOnConsecutiveCalls(2, 0);
+
+		$listener = new FlowRunLockReleaseListener($locks, $this->createMock(LoggerInterface::class));
+		$event = new FlowRunTerminalEvent(runUuid: self::RUN, status: FlowRun::STATUS_COMPLETED);
+		$listener->handle($event);
+		$listener->handle($event);
+	}//end testASecondObservationIsHarmless()
+
+	/**
+	 * A failed release MUST NOT propagate.
+	 *
+	 * The dispatch happens inside FlowRunCommit's open transaction on the
+	 * stream-walk path, so a throw here would unwind the run's own terminal
+	 * write. Lock bookkeeping must never be able to do that.
+	 *
+	 * @return void
+	 */
+	public function testAFailedReleaseDoesNotUnwindTheRunsTerminalWrite(): void {
+		$locks = $this->createMock(originalClassName: RunLockRegistry::class);
+		$locks->method('releaseRunLocks')->willThrowException(new RuntimeException('database went away'));
+
+		$logger = $this->createMock(originalClassName: LoggerInterface::class);
+		$logger->expects($this->once())->method('error');
+
+		$listener = new FlowRunLockReleaseListener($locks, $logger);
+		$listener->handle(new FlowRunTerminalEvent(runUuid: self::RUN, status: FlowRun::STATUS_FAILED));
+
+		$this->addToAssertionCount(1);
+	}//end testAFailedReleaseDoesNotUnwindTheRunsTerminalWrite()
+
+	/**
+	 * Another event type is ignored.
+	 *
+	 * @return void
+	 */
+	public function testAnUnrelatedEventIsIgnored(): void {
+		$locks = $this->createMock(originalClassName: RunLockRegistry::class);
+		$locks->expects($this->never())->method('releaseRunLocks');
+
+		$listener = new FlowRunLockReleaseListener($locks, $this->createMock(LoggerInterface::class));
+		$listener->handle(new Event());
+	}//end testAnUnrelatedEventIsIgnored()
+}//end class

--- a/tests/Unit/Service/Flow/LockObjectNodeTest.php
+++ b/tests/Unit/Service/Flow/LockObjectNodeTest.php
@@ -1,0 +1,374 @@
+<?php
+
+/**
+ * The lock step: acquire, park, back off, and give up loudly.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use DateInterval;
+use DateTime;
+use OCA\OpenRegister\Exception\LockedException;
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\FlowNodeResumeState;
+use OCA\OpenRegister\Service\Flow\FlowResumeState;
+use OCA\OpenRegister\Service\Flow\FlowSuspension;
+use OCA\OpenRegister\Service\Flow\Nodes\LockObjectNode;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use UnexpectedValueException;
+
+/**
+ * @covers \OCA\OpenRegister\Service\Flow\Nodes\LockObjectNode
+ */
+final class LockObjectNodeTest extends TestCase {
+
+	private const RUN = 'run-aaaaaaaa-0000-0000-0000-000000000001';
+
+	private const OBJ = 'obj-11111111-2222-3333-4444-555555555555';
+
+	private ObjectService $objects;
+
+	private LockObjectNode $node;
+
+	private FlowResumeState $state;
+
+	/**
+	 * Wire the node over mocks.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->objects = $this->createMock(originalClassName: ObjectService::class);
+		// runAs MUST actually invoke the callable, or every call silently
+		// returns null and the node appears to work while doing nothing.
+		$this->objects->method('runAs')->willReturnCallback(
+			static fn (IUser $user, callable $operation) => $operation()
+		);
+
+		$users = $this->createMock(originalClassName: IUserManager::class);
+		$users->method('get')->willReturnCallback(
+			function (string $uid): ?IUser {
+				if ($uid !== 'alice') {
+					return null;
+				}
+
+				$user = $this->createMock(IUser::class);
+				$user->method('getUID')->willReturn($uid);
+				$user->method('isEnabled')->willReturn(true);
+				return $user;
+			}
+		);
+
+		$l10n = $this->createMock(originalClassName: IL10N::class);
+		$l10n->method('t')->willReturnCallback(
+			static fn (string $text, array $p = []): string => $p === [] ? $text : vsprintf(str_replace('%s', '%s', $text), $p)
+		);
+
+		$this->node = new LockObjectNode(
+			$this->objects,
+			$users,
+			$l10n,
+			$this->createMock(IURLGenerator::class)
+		);
+
+		$this->state = new FlowResumeState();
+	}//end setUp()
+
+	/**
+	 * A run context with this node's scoped resume slot.
+	 *
+	 * @return array<string, mixed> The context.
+	 */
+	private function context(): array {
+		return [
+			'runUuid' => self::RUN,
+			'runAs' => 'alice',
+			FlowNodeResumeState::CONTEXT_KEY => $this->state->forNode('lock-1'),
+		];
+	}//end context()
+
+	/**
+	 * One item carrying an object uuid.
+	 *
+	 * @return array<int, array<string, mixed>> The items.
+	 */
+	private function items(): array {
+		return [FlowItems::item(json: ['uuid' => self::OBJ])];
+	}//end items()
+
+	// ---------------------------------------------------------------
+	// The happy path.
+	// ---------------------------------------------------------------
+
+	/**
+	 * The lock is taken FOR THE RUN, and the items pass through untouched.
+	 *
+	 * @return void
+	 */
+	public function testTheLockIsTakenForTheRun(): void {
+		$seen = [];
+		$this->objects->method('lockObject')->willReturnCallback(
+			function (...$args) use (&$seen): array {
+				// Named arguments arrive positionally in declaration order:
+				// identifier, process, duration, advisory, runUuid, nodeId.
+				$seen = $args;
+				return ['uuid' => self::OBJ, 'locked' => []];
+			}
+		);
+
+		$out = $this->node->execute($this->items(), [], $this->context());
+
+		$this->assertSame(self::OBJ, $out[0][FlowItems::JSON]['uuid']);
+		$this->assertSame(self::OBJ, $seen[0]);
+		$this->assertSame(self::RUN, $seen[4], 'the lock was not scoped to the run');
+		$this->assertSame('lock-1', $seen[5]);
+	}//end testTheLockIsTakenForTheRun()
+
+	/**
+	 * A successful acquire leaves no wait state behind.
+	 *
+	 * @return void
+	 */
+	public function testASuccessfulAcquireRecordsNoAttempts(): void {
+		$this->objects->method('lockObject')->willReturn(['uuid' => self::OBJ, 'locked' => []]);
+		$this->node->execute($this->items(), [], $this->context());
+
+		$this->assertNull($this->state->forNode('lock-1')->get(LockObjectNode::SLOT_ATTEMPTS));
+	}//end testASuccessfulAcquireRecordsNoAttempts()
+
+	/**
+	 * An empty firing takes no lock and MUST NOT suspend the whole run.
+	 *
+	 * After a route, the un-taken branch is marked and its steps still fire
+	 * with zero items. Suspending there would park a run on a branch it never
+	 * took.
+	 *
+	 * @return void
+	 */
+	public function testAnEmptyFiringDoesNotSuspend(): void {
+		$this->objects->expects($this->never())->method('lockObject');
+		$this->assertSame([], $this->node->execute([], [], $this->context()));
+	}//end testAnEmptyFiringDoesNotSuspend()
+
+	// ---------------------------------------------------------------
+	// Contention.
+	// ---------------------------------------------------------------
+
+	/**
+	 * A contended lock parks the run, with a NON-NULL resume time.
+	 *
+	 * 🔴 A null resumeAt means "waiting on an external signal", and
+	 * findAbandonedSignals() FAILS such a run after 14 days without ever
+	 * waking it. A lock waits on a clock.
+	 *
+	 * @return void
+	 */
+	public function testAContendedLockParksTheRunWithAClock(): void {
+		$this->objects->method('lockObject')->willThrowException(new LockedException('held by run B'));
+
+		try {
+			$this->node->execute($this->items(), [], $this->context());
+			$this->fail('the node did not suspend');
+		} catch (FlowSuspension $suspension) {
+			$this->assertNotNull($suspension->getResumeAt(), 'a null resumeAt would be reaped, never woken');
+			$this->assertGreaterThan(new DateTime(), $suspension->getResumeAt());
+			$this->assertStringContainsString(self::OBJ, $suspension->getMessage());
+		}
+	}//end testAContendedLockParksTheRunWithAClock()
+
+	/**
+	 * The wait deadline is stamped ONCE and survives a retry.
+	 *
+	 * Recomputing it per attempt would reset the budget on every heartbeat,
+	 * and the node would wait forever while appearing to have a bound.
+	 *
+	 * @return void
+	 */
+	public function testTheDeadlineIsNotRestartedByARetry(): void {
+		$this->objects->method('lockObject')->willThrowException(new LockedException('held'));
+
+		try {
+			$this->node->execute($this->items(), ['waitSeconds' => 600], $this->context());
+		} catch (FlowSuspension $e) {
+			// Expected.
+		}
+
+		$first = $this->state->forNode('lock-1')->get(LockObjectNode::SLOT_DEADLINE);
+		$this->assertNotNull($first);
+
+		try {
+			$this->node->execute($this->items(), ['waitSeconds' => 600], $this->context());
+		} catch (FlowSuspension $e) {
+			// Expected.
+		}
+
+		$this->assertSame($first, $this->state->forNode('lock-1')->get(LockObjectNode::SLOT_DEADLINE));
+		$this->assertSame(2, $this->state->forNode('lock-1')->get(LockObjectNode::SLOT_ATTEMPTS));
+	}//end testTheDeadlineIsNotRestartedByARetry()
+
+	/**
+	 * An exhausted budget FAILS, naming the holder, and does not break the lock.
+	 *
+	 * @return void
+	 */
+	public function testAnExhaustedBudgetFailsAndNamesTheHolder(): void {
+		$this->objects->method('lockObject')->willThrowException(
+			new LockedException('Object is locked by flow run ' . self::RUN)
+		);
+
+		// A deadline already in the past: the budget is spent.
+		$this->state->forNode('lock-1')->set(
+			LockObjectNode::SLOT_DEADLINE,
+			(new DateTime())->sub(new DateInterval('PT10S'))->format('c')
+		);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage(self::RUN);
+		$this->node->execute($this->items(), [], $this->context());
+	}//end testAnExhaustedBudgetFailsAndNamesTheHolder()
+
+	/**
+	 * The retry never wakes AFTER the deadline.
+	 *
+	 * Overshooting would report the failure a whole backoff interval late.
+	 *
+	 * @return void
+	 */
+	public function testTheRetryNeverOvershootsTheDeadline(): void {
+		$this->objects->method('lockObject')->willThrowException(new LockedException('held'));
+
+		try {
+			// A budget shorter than the retry floor.
+			$this->node->execute($this->items(), ['waitSeconds' => 5], $this->context());
+			$this->fail('the node did not suspend');
+		} catch (FlowSuspension $suspension) {
+			$deadline = new DateTime((string)$this->state->forNode('lock-1')->get(LockObjectNode::SLOT_DEADLINE));
+			$this->assertLessThanOrEqual($deadline, $suspension->getResumeAt());
+		}
+	}//end testTheRetryNeverOvershootsTheDeadline()
+
+	// ---------------------------------------------------------------
+	// Refusals.
+	// ---------------------------------------------------------------
+
+	/**
+	 * Without a resume slot the node refuses rather than waiting forever.
+	 *
+	 * @return void
+	 */
+	public function testNoResumeSlotIsRefused(): void {
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('resume slot');
+		$this->node->execute($this->items(), [], ['runUuid' => self::RUN, 'runAs' => 'alice']);
+	}//end testNoResumeSlotIsRefused()
+
+	/**
+	 * A run that cannot identify itself does not take a run lock.
+	 *
+	 * A run-scoped lock with no run is a lock the predicate refuses everybody
+	 * for and nobody can release.
+	 *
+	 * @return void
+	 */
+	public function testARunWithNoIdentityIsRefused(): void {
+		$context = $this->context();
+		unset($context['runUuid']);
+
+		$this->expectException(RuntimeException::class);
+		$this->node->execute($this->items(), [], $context);
+	}//end testARunWithNoIdentityIsRefused()
+
+	/**
+	 * A run with no acting identity is refused.
+	 *
+	 * @return void
+	 */
+	public function testARunWithNoActingIdentityIsRefused(): void {
+		$context = $this->context();
+		unset($context['runAs']);
+
+		$this->expectException(RuntimeException::class);
+		$this->node->execute($this->items(), [], $context);
+	}//end testARunWithNoActingIdentityIsRefused()
+
+	/**
+	 * An item with no resolvable target throws rather than locking nothing
+	 * and reporting success.
+	 *
+	 * @return void
+	 */
+	public function testAnUnresolvableTargetThrows(): void {
+		$this->expectException(RuntimeException::class);
+		$this->node->execute([FlowItems::item(json: ['name' => 'no uuid here'])], [], $this->context());
+	}//end testAnUnresolvableTargetThrows()
+
+	// ---------------------------------------------------------------
+	// Config.
+	// ---------------------------------------------------------------
+
+	/**
+	 * A wait budget that is not a positive number is refused at authoring time.
+	 *
+	 * @return void
+	 */
+	public function testANonPositiveWaitBudgetIsRefused(): void {
+		$this->expectException(UnexpectedValueException::class);
+		$this->node->validateConfig(['waitSeconds' => 0]);
+	}//end testANonPositiveWaitBudgetIsRefused()
+
+	/**
+	 * A non-numeric duration is refused.
+	 *
+	 * @return void
+	 */
+	public function testANonNumericDurationIsRefused(): void {
+		$this->expectException(UnexpectedValueException::class);
+		$this->node->validateConfig(['duration' => 'soon']);
+	}//end testANonNumericDurationIsRefused()
+
+	/**
+	 * An empty config is valid: every key has a default.
+	 *
+	 * @return void
+	 */
+	public function testAnEmptyConfigIsValid(): void {
+		$this->node->validateConfig([]);
+		$this->addToAssertionCount(1);
+	}//end testAnEmptyConfigIsValid()
+
+	/**
+	 * Every form field writes a key the node declares.
+	 *
+	 * A field whose key is not in configKeys() is a control the node never
+	 * reads: it validates, it renders, and it does nothing.
+	 *
+	 * @return void
+	 */
+	public function testEveryFormFieldWritesADeclaredConfigKey(): void {
+		foreach ($this->node->configForm() as $field) {
+			$this->assertContains((string)$field['key'], $this->node->configKeys());
+		}
+	}//end testEveryFormFieldWritesADeclaredConfigKey()
+}//end class

--- a/tests/Unit/Service/Flow/UnlockObjectNodeTest.php
+++ b/tests/Unit/Service/Flow/UnlockObjectNodeTest.php
@@ -1,0 +1,205 @@
+<?php
+
+/**
+ * The unlock step.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Service\Flow\FlowItems;
+use OCA\OpenRegister\Service\Flow\Nodes\UnlockObjectNode;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use UnexpectedValueException;
+
+/**
+ * @covers \OCA\OpenRegister\Service\Flow\Nodes\UnlockObjectNode
+ */
+final class UnlockObjectNodeTest extends TestCase {
+
+	private const RUN = 'run-aaaaaaaa-0000-0000-0000-000000000001';
+
+	private const OBJ = 'obj-11111111-2222-3333-4444-555555555555';
+
+	private ObjectService $objects;
+
+	private UnlockObjectNode $node;
+
+	/**
+	 * Wire the node over mocks.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->objects = $this->createMock(originalClassName: ObjectService::class);
+		$this->objects->method('runAs')->willReturnCallback(
+			static fn (IUser $user, callable $operation) => $operation()
+		);
+
+		$users = $this->createMock(originalClassName: IUserManager::class);
+		$users->method('get')->willReturnCallback(
+			function (string $uid): ?IUser {
+				if ($uid !== 'alice') {
+					return null;
+				}
+
+				$user = $this->createMock(IUser::class);
+				$user->method('getUID')->willReturn($uid);
+				$user->method('isEnabled')->willReturn(true);
+				return $user;
+			}
+		);
+
+		$l10n = $this->createMock(originalClassName: IL10N::class);
+		$l10n->method('t')->willReturnCallback(
+			static fn (string $text, array $p = []): string => $p === [] ? $text : vsprintf($text, $p)
+		);
+
+		$this->node = new UnlockObjectNode(
+			$this->objects,
+			$users,
+			$l10n,
+			$this->createMock(IURLGenerator::class)
+		);
+	}//end setUp()
+
+	/**
+	 * The run context.
+	 *
+	 * @return array<string, mixed> The context.
+	 */
+	private function context(): array {
+		return ['runUuid' => self::RUN, 'runAs' => 'alice'];
+	}//end context()
+
+	/**
+	 * The release is scoped to the RUN, so it can only free the run's own lock.
+	 *
+	 * @return void
+	 */
+	public function testTheReleaseIsScopedToTheRun(): void {
+		$seen = [];
+		$this->objects->method('unlockObject')->willReturnCallback(
+			function (...$args) use (&$seen): bool {
+				// Positional order: identifier, advisory, runUuid.
+				$seen = $args;
+				return true;
+			}
+		);
+
+		$out = $this->node->execute(
+			[FlowItems::item(json: ['uuid' => self::OBJ])],
+			[],
+			$this->context()
+		);
+
+		$this->assertSame(self::OBJ, $seen[0]);
+		$this->assertSame(self::RUN, $seen[2], 'the release was not scoped to the run');
+		$this->assertSame(self::OBJ, $out[0][FlowItems::JSON]['uuid']);
+	}//end testTheReleaseIsScopedToTheRun()
+
+	/**
+	 * Two items naming one object release it once.
+	 *
+	 * @return void
+	 */
+	public function testDuplicateTargetsAreReleasedOnce(): void {
+		$this->objects->expects($this->once())->method('unlockObject')->willReturn(true);
+
+		$this->node->execute(
+			[
+				FlowItems::item(json: ['uuid' => self::OBJ]),
+				FlowItems::item(json: ['uuid' => self::OBJ]),
+			],
+			[],
+			$this->context()
+		);
+	}//end testDuplicateTargetsAreReleasedOnce()
+
+	/**
+	 * An empty firing releases nothing.
+	 *
+	 * @return void
+	 */
+	public function testAnEmptyFiringReleasesNothing(): void {
+		$this->objects->expects($this->never())->method('unlockObject');
+		$this->assertSame([], $this->node->execute([], [], $this->context()));
+	}//end testAnEmptyFiringReleasesNothing()
+
+	/**
+	 * An unresolvable target throws rather than releasing nothing quietly.
+	 *
+	 * @return void
+	 */
+	public function testAnUnresolvableTargetThrows(): void {
+		$this->expectException(RuntimeException::class);
+		$this->node->execute([FlowItems::item(json: ['name' => 'no uuid'])], [], $this->context());
+	}//end testAnUnresolvableTargetThrows()
+
+	/**
+	 * A run that cannot identify itself is refused: it could only release
+	 * somebody else's lock or nothing at all.
+	 *
+	 * @return void
+	 */
+	public function testARunWithNoIdentityIsRefused(): void {
+		$this->expectException(RuntimeException::class);
+		$this->node->execute(
+			[FlowItems::item(json: ['uuid' => self::OBJ])],
+			[],
+			['runAs' => 'alice']
+		);
+	}//end testARunWithNoIdentityIsRefused()
+
+	/**
+	 * A non-text target is refused at authoring time.
+	 *
+	 * @return void
+	 */
+	public function testANonTextTargetIsRefused(): void {
+		$this->expectException(UnexpectedValueException::class);
+		$this->node->validateConfig(['uuid' => ['not', 'text']]);
+	}//end testANonTextTargetIsRefused()
+
+	/**
+	 * An empty config is valid: the target defaults to the item's object.
+	 *
+	 * @return void
+	 */
+	public function testAnEmptyConfigIsValid(): void {
+		$this->node->validateConfig([]);
+		$this->addToAssertionCount(1);
+	}//end testAnEmptyConfigIsValid()
+
+	/**
+	 * Every form field writes a key the node declares.
+	 *
+	 * @return void
+	 */
+	public function testEveryFormFieldWritesADeclaredConfigKey(): void {
+		foreach ($this->node->configForm() as $field) {
+			$this->assertContains((string)$field['key'], $this->node->configKeys());
+		}
+	}//end testEveryFormFieldWritesADeclaredConfigKey()
+}//end class

--- a/tests/Unit/Service/Object/LockHandlerAdvisoryTest.php
+++ b/tests/Unit/Service/Object/LockHandlerAdvisoryTest.php
@@ -23,6 +23,7 @@ use OCA\OpenRegister\Db\AuditTrailMapper;
 use OCA\OpenRegister\Db\MagicMapper;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Exception\LockedException;
+use OCA\OpenRegister\Service\Object\AdvisoryLockStore;
 use OCA\OpenRegister\Service\Object\LockHandler;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IAppConfig;
@@ -73,7 +74,11 @@ class LockHandlerAdvisoryTest extends TestCase {
 			$this->userSession,
 			$this->groupManager,
 			$this->schemaMapper,
-			$this->appConfig
+			// A REAL AdvisoryLockStore over the mocked app-config, so these
+			// tests keep exercising the advisory behaviour end to end through
+			// LockHandler rather than asserting against a mock of the very
+			// thing they exist to check.
+			new AdvisoryLockStore($this->appConfig, $this->userSession, $this->logger)
 		);
 	}//end setUp()
 

--- a/tests/Unit/Service/Object/LockHandlerRunLockTest.php
+++ b/tests/Unit/Service/Object/LockHandlerRunLockTest.php
@@ -1,0 +1,250 @@
+<?php
+
+/**
+ * Run-held locks at the handler: authorization and the administrator break.
+ *
+ * The release and sweep layers live in RunLockRegistry and are covered by
+ * RunLockRegistryTest.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Object
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Object;
+
+use DateInterval;
+use DateTime;
+use Exception;
+use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RunObjectLock;
+use OCA\OpenRegister\Db\RunObjectLockMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Object\AdvisoryLockStore;
+use OCA\OpenRegister\Service\Object\LockHandler;
+use OCA\OpenRegister\Service\Object\RunLockRegistry;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @covers \OCA\OpenRegister\Service\Object\LockHandler
+ */
+final class LockHandlerRunLockTest extends TestCase {
+
+	private const RUN_A = 'run-aaaaaaaa-0000-0000-0000-000000000001';
+
+	private const RUN_B = 'run-bbbbbbbb-0000-0000-0000-000000000002';
+
+	private const OBJ = 'obj-11111111-2222-3333-4444-555555555555';
+
+	private MagicMapper $magic;
+
+	private AuditTrailMapper $audit;
+
+	private IUserSession $session;
+
+	private IGroupManager $groups;
+
+	private RunLockRegistry $registry;
+
+	/**
+	 * Wire a handler over mocks.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->magic = $this->createMock(originalClassName: MagicMapper::class);
+		$this->audit = $this->createMock(originalClassName: AuditTrailMapper::class);
+		$this->session = $this->createMock(originalClassName: IUserSession::class);
+		$this->groups = $this->createMock(originalClassName: IGroupManager::class);
+		$this->registry = $this->createMock(originalClassName: RunLockRegistry::class);
+	}//end setUp()
+
+	/**
+	 * The handler under test.
+	 *
+	 * @return LockHandler The handler.
+	 */
+	private function handler(): LockHandler {
+		return new LockHandler(
+			$this->magic,
+			$this->audit,
+			$this->createMock(LoggerInterface::class),
+			$this->session,
+			$this->groups,
+			$this->createMock(SchemaMapper::class),
+			$this->createMock(AdvisoryLockStore::class),
+			$this->registry
+		);
+	}//end handler()
+
+	/**
+	 * An object carrying a live lock written by the PRODUCTION writer.
+	 *
+	 * @param string $holderUid The runAs identity.
+	 * @param string|null $runUuid The holding run, for a run lock.
+	 *
+	 * @return ObjectEntity The locked object.
+	 */
+	private function lockedObject(string $holderUid, ?string $runUuid): ObjectEntity {
+		$object = new ObjectEntity();
+		$object->setUuid(self::OBJ);
+		$object->setRegister('1');
+		$object->setSchema('2');
+		$object->setOwner('owner-uid');
+
+		$holder = $this->createMock(IUser::class);
+		$holder->method('getUID')->willReturn($holderUid);
+		$holderSession = $this->createMock(IUserSession::class);
+		$holderSession->method('getUser')->willReturn($holder);
+		$object->lock($holderSession, 'step-one', 3600, $runUuid);
+
+		return $object;
+	}//end lockedObject()
+
+	/**
+	 * Make findObjectWithContext resolve to this object.
+	 *
+	 * @param ObjectEntity $object The object to return.
+	 *
+	 * @return void
+	 */
+	private function resolvesTo(ObjectEntity $object): void {
+		$this->magic->method('findAcrossAllSources')->willReturn(
+			[
+				'object' => $object,
+				'register' => $this->createMock(Register::class),
+				'schema' => $this->createMock(Schema::class),
+			]
+		);
+	}//end resolvesTo()
+
+	/**
+	 * A registry row.
+	 *
+	 * @param string $runUuid The run.
+	 *
+	 * @return RunObjectLock The row.
+	 */
+	private function row(string $runUuid): RunObjectLock {
+		$row = new RunObjectLock();
+		$row->setRunUuid($runUuid);
+		$row->setObjectUuid(self::OBJ);
+		$row->setLockedAt(new DateTime());
+		$row->setExpiresAt((new DateTime())->add(new DateInterval('PT3600S')));
+
+		return $row;
+	}//end row()
+
+	// ---------------------------------------------------------------
+	// The administrator break.
+	// ---------------------------------------------------------------
+
+	/**
+	 * A non-administrator cannot break a lock.
+	 *
+	 * @return void
+	 */
+	public function testANonAdministratorCannotBreakALock(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('carol');
+		$this->session->method('getUser')->willReturn($user);
+		$this->groups->method('isAdmin')->willReturn(false);
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Only an administrator may break a lock');
+		$this->handler()->breakLock(identifier: self::OBJ);
+	}//end testANonAdministratorCannotBreakALock()
+
+	/**
+	 * An administrator breaks a run's lock, and the break is AUDITED naming
+	 * the run it displaced.
+	 *
+	 * An override nobody can see afterwards is indistinguishable from the
+	 * lock never having worked, so the audit entry is part of the feature and
+	 * not decoration.
+	 *
+	 * @return void
+	 */
+	public function testAnAdministratorBreaksARunLockAndItIsAudited(): void {
+		$this->resolvesTo($this->lockedObject('alice', self::RUN_A));
+
+		$admin = $this->createMock(IUser::class);
+		$admin->method('getUID')->willReturn('admin');
+		$this->session->method('getUser')->willReturn($admin);
+		$this->groups->method('isAdmin')->willReturn(true);
+		$this->magic->method('unlockObjectEntity')->willReturn(new ObjectEntity());
+
+		$recorded = [];
+		$this->audit->method('createAuditTrailEntry')->willReturnCallback(
+			function (ObjectEntity $object, string $action, array $context) use (&$recorded) {
+				$recorded = ['action' => $action, 'context' => $context];
+				return $this->createMock(\OCA\OpenRegister\Db\AuditTrail::class);
+			}
+		);
+
+		$this->assertTrue($this->handler()->breakLock(identifier: self::OBJ));
+		$this->assertSame('lock.broken', $recorded['action']);
+		$this->assertSame(self::RUN_A, $recorded['context']['displacedRun']);
+		$this->assertStringContainsString(self::RUN_A, (string)$recorded['context']['displacedHolder']);
+	}//end testAnAdministratorBreaksARunLockAndItIsAudited()
+
+	/**
+	 * The object's OWNER cannot unlock a run's lock.
+	 *
+	 * The owner and schema-manage routes exist for user locks. Extending them
+	 * to run locks would let any case owner quietly defeat the engine's
+	 * mutual exclusion, which is the entire point of a run lock. Their escape
+	 * hatch is the administrator break above.
+	 *
+	 * @return void
+	 */
+	public function testTheObjectOwnerCannotUnlockARunsLock(): void {
+		$this->resolvesTo($this->lockedObject('alice', self::RUN_A));
+
+		$owner = $this->createMock(IUser::class);
+		$owner->method('getUID')->willReturn('owner-uid');
+		$this->session->method('getUser')->willReturn($owner);
+		$this->groups->method('isAdmin')->willReturn(false);
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('does not have permission to unlock');
+		$this->handler()->unlock(identifier: self::OBJ);
+	}//end testTheObjectOwnerCannotUnlockARunsLock()
+
+	/**
+	 * The object's owner CAN still unlock a plain user lock: the historical
+	 * behaviour is untouched for the case it was written for.
+	 *
+	 * @return void
+	 */
+	public function testTheObjectOwnerCanStillUnlockAUserLock(): void {
+		$this->resolvesTo($this->lockedObject('alice', null));
+
+		$owner = $this->createMock(IUser::class);
+		$owner->method('getUID')->willReturn('owner-uid');
+		$this->session->method('getUser')->willReturn($owner);
+		$this->groups->method('isAdmin')->willReturn(false);
+		$this->magic->method('unlockObjectEntity')->willReturn(new ObjectEntity());
+
+		$this->assertTrue($this->handler()->unlock(identifier: self::OBJ));
+	}//end testTheObjectOwnerCanStillUnlockAUserLock()
+}//end class

--- a/tests/Unit/Service/Object/RunLockRegistryTest.php
+++ b/tests/Unit/Service/Object/RunLockRegistryTest.php
@@ -230,6 +230,67 @@ final class RunLockRegistryTest extends TestCase {
 		$this->assertSame(0, $this->registry()->sweepOrphaned(now: new DateTime()));
 	}//end testTheSweepLeavesALiveRunsLockAlone()
 
+	/**
+	 * The release read is UNSCOPED, on every axis.
+	 *
+	 * Both release layers run from a background job or `occ`, neither of
+	 * which has a session. A read that applies RBAC resolves as Anonymous,
+	 * answers "no such object", and the sweep reports nothing to release
+	 * while the lock stays held until its TTL. There is no error to notice:
+	 * the symptom is a lock that is never released. This is the defect that
+	 * made `prune-retired` count zero rows and then delete schemas that held
+	 * data (openregister#3440), and it would be worse here because it fails
+	 * closed on a case rather than open on a delete.
+	 *
+	 * `includeDeleted` is on the same list: a soft-deleted object can still
+	 * carry a live lock, and it is exactly the object nobody is watching.
+	 *
+	 * @return void
+	 */
+	public function testTheReleaseReadAppliesNoScoping(): void {
+		$seen = [];
+		$this->magic->method('findAcrossAllSources')->willReturnCallback(
+			function (...$args) use (&$seen) {
+				// Positional order: identifier, includeDeleted, _rbac, _multitenancy.
+				$seen = $args;
+				return [
+					'object' => $this->lockedObject(self::RUN_A),
+					'register' => $this->createMock(Register::class),
+					'schema' => $this->createMock(Schema::class),
+				];
+			}
+		);
+		$this->rows->method('findByRun')->willReturn([$this->row(self::RUN_A)]);
+		$this->magic->method('unlockObjectEntity')->willReturn(new ObjectEntity());
+
+		$this->registry()->releaseRunLocks(runUuid: self::RUN_A);
+
+		$this->assertFalse($seen[2], 'the release read applies RBAC; under occ it will find nothing');
+		$this->assertFalse($seen[3], 'the release read applies multitenancy; under occ it will find nothing');
+		$this->assertTrue($seen[1], 'a soft-deleted object would strand its lock');
+	}//end testTheReleaseReadAppliesNoScoping()
+
+	/**
+	 * The sweep asks for orphans ONCE per pass and acts on what it gets.
+	 *
+	 * Regression guard for a sweep that dies inside its own catch. The first
+	 * `findOrphaned()` composed its two predicates as an orX() over a
+	 * createFunction(), which PostgreSQL rejected with "argument of OR must
+	 * be type boolean, not type record". The exception was swallowed by
+	 * `releaseRecorded()`'s catch and by the worker's, so the sweep logged a
+	 * warning and released nothing, every tick, forever. Caught on the rig,
+	 * never by a mock: the mapper is now two plain queries.
+	 *
+	 * @return void
+	 */
+	public function testTheSweepQueriesOrphansOncePerPass(): void {
+		$this->rows->expects($this->once())
+			->method('findOrphaned')
+			->willReturn([]);
+
+		$this->registry()->sweepOrphaned(now: new DateTime(), limit: 25);
+	}//end testTheSweepQueriesOrphansOncePerPass()
+
 	// ---------------------------------------------------------------
 	// Recording.
 	// ---------------------------------------------------------------

--- a/tests/Unit/Service/Object/RunLockRegistryTest.php
+++ b/tests/Unit/Service/Object/RunLockRegistryTest.php
@@ -1,0 +1,282 @@
+<?php
+
+/**
+ * Release layers 1 and 2: the run-lock registry.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Object
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Object;
+
+use DateInterval;
+use DateTime;
+use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RunObjectLock;
+use OCA\OpenRegister\Db\RunObjectLockMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Service\Object\RunLockRegistry;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * @covers \OCA\OpenRegister\Service\Object\RunLockRegistry
+ */
+final class RunLockRegistryTest extends TestCase {
+
+	private const RUN_A = 'run-aaaaaaaa-0000-0000-0000-000000000001';
+
+	private const RUN_B = 'run-bbbbbbbb-0000-0000-0000-000000000002';
+
+	private const OBJ = 'obj-11111111-2222-3333-4444-555555555555';
+
+	private MagicMapper $magic;
+
+	private AuditTrailMapper $audit;
+
+	private RunObjectLockMapper $rows;
+
+	/**
+	 * Wire the mocks.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->magic = $this->createMock(originalClassName: MagicMapper::class);
+		$this->audit = $this->createMock(originalClassName: AuditTrailMapper::class);
+		$this->rows = $this->createMock(originalClassName: RunObjectLockMapper::class);
+	}//end setUp()
+
+	/**
+	 * The service under test.
+	 *
+	 * @return RunLockRegistry The service.
+	 */
+	private function registry(): RunLockRegistry {
+		return new RunLockRegistry(
+			$this->rows,
+			$this->magic,
+			$this->audit,
+			$this->createMock(LoggerInterface::class)
+		);
+	}//end registry()
+
+	/**
+	 * An object carrying a live lock written by the PRODUCTION writer.
+	 *
+	 * @param string|null $runUuid The holding run, or null for a user lock.
+	 *
+	 * @return ObjectEntity The locked object.
+	 */
+	private function lockedObject(?string $runUuid): ObjectEntity {
+		$object = new ObjectEntity();
+		$object->setUuid(self::OBJ);
+
+		$holder = $this->createMock(IUser::class);
+		$holder->method('getUID')->willReturn('alice');
+		$session = $this->createMock(IUserSession::class);
+		$session->method('getUser')->willReturn($holder);
+		$object->lock($session, 'step-one', 3600, $runUuid);
+
+		return $object;
+	}//end lockedObject()
+
+	/**
+	 * Resolve every lookup to this object.
+	 *
+	 * @param ObjectEntity $object The object.
+	 *
+	 * @return void
+	 */
+	private function resolvesTo(ObjectEntity $object): void {
+		$this->magic->method('findAcrossAllSources')->willReturn(
+			[
+				'object' => $object,
+				'register' => $this->createMock(Register::class),
+				'schema' => $this->createMock(Schema::class),
+			]
+		);
+	}//end resolvesTo()
+
+	/**
+	 * A registry row.
+	 *
+	 * @param string $runUuid The run.
+	 *
+	 * @return RunObjectLock The row.
+	 */
+	private function row(string $runUuid): RunObjectLock {
+		$row = new RunObjectLock();
+		$row->setRunUuid($runUuid);
+		$row->setObjectUuid(self::OBJ);
+		$row->setLockedAt(new DateTime());
+		$row->setExpiresAt((new DateTime())->add(new DateInterval('PT3600S')));
+
+		return $row;
+	}//end row()
+
+	// ---------------------------------------------------------------
+	// Layer 1.
+	// ---------------------------------------------------------------
+
+	/**
+	 * A terminal run's lock is released and its rows forgotten.
+	 *
+	 * @return void
+	 */
+	public function testReleaseRunLocksReleasesWhatTheRunHolds(): void {
+		$this->resolvesTo($this->lockedObject(self::RUN_A));
+		$this->rows->method('findByRun')->with(self::RUN_A)->willReturn([$this->row(self::RUN_A)]);
+		$this->rows->expects($this->once())->method('forgetRun')->with(self::RUN_A);
+		$this->magic->expects($this->once())->method('unlockObjectEntity')->willReturn(new ObjectEntity());
+
+		$this->assertSame(1, $this->registry()->releaseRunLocks(runUuid: self::RUN_A));
+	}//end testReleaseRunLocksReleasesWhatTheRunHolds()
+
+	/**
+	 * A stale row MUST NOT strip a lock a different run has since taken.
+	 *
+	 * The registry is bookkeeping, so it is checked against the object rather
+	 * than trusted. Without that check the release would be a licence to
+	 * unlock anything whose uuid appears in a stale row.
+	 *
+	 * @return void
+	 */
+	public function testAStaleRowDoesNotStripAnotherRunsLock(): void {
+		$this->resolvesTo($this->lockedObject(self::RUN_B));
+		$this->rows->method('findByRun')->willReturn([$this->row(self::RUN_A)]);
+		$this->magic->expects($this->never())->method('unlockObjectEntity');
+
+		$this->assertSame(0, $this->registry()->releaseRunLocks(runUuid: self::RUN_A));
+	}//end testAStaleRowDoesNotStripAnotherRunsLock()
+
+	/**
+	 * A row pointing at a USER lock is not released either.
+	 *
+	 * @return void
+	 */
+	public function testAUserLockIsNeverReleasedByTheRunPath(): void {
+		$this->resolvesTo($this->lockedObject(null));
+		$this->rows->method('findByRun')->willReturn([$this->row(self::RUN_A)]);
+		$this->magic->expects($this->never())->method('unlockObjectEntity');
+
+		$this->assertSame(0, $this->registry()->releaseRunLocks(runUuid: self::RUN_A));
+	}//end testAUserLockIsNeverReleasedByTheRunPath()
+
+	/**
+	 * A release that fails MUST NOT propagate.
+	 *
+	 * Layer 1 runs inside the run's own terminal write transaction, so a
+	 * throw would unwind the run's status change.
+	 *
+	 * @return void
+	 */
+	public function testAFailedReleaseIsSwallowed(): void {
+		$this->magic->method('findAcrossAllSources')->willThrowException(new RuntimeException('gone'));
+		$this->rows->method('findByRun')->willReturn([$this->row(self::RUN_A)]);
+
+		$this->assertSame(0, $this->registry()->releaseRunLocks(runUuid: self::RUN_A));
+	}//end testAFailedReleaseIsSwallowed()
+
+	// ---------------------------------------------------------------
+	// Layer 2: the sweep. The killed-worker case.
+	// ---------------------------------------------------------------
+
+	/**
+	 * The holder is gone, so the sweep releases the lock.
+	 *
+	 * This is the worker-killed-mid-flight case: nothing ran a release, and
+	 * `findOrphaned()` is what notices. It matches a run that is not ACTIVE,
+	 * which covers both "terminal" and "the row no longer exists".
+	 *
+	 * @return void
+	 */
+	public function testTheSweepReleasesALockWhoseHolderIsGone(): void {
+		$this->resolvesTo($this->lockedObject(self::RUN_A));
+		$this->rows->method('findOrphaned')->willReturn([$this->row(self::RUN_A)]);
+		$this->rows->expects($this->once())->method('forget')->with(self::RUN_A, self::OBJ);
+		$this->magic->expects($this->once())->method('unlockObjectEntity')->willReturn(new ObjectEntity());
+
+		$this->assertSame(1, $this->registry()->sweepOrphaned(now: new DateTime()));
+	}//end testTheSweepReleasesALockWhoseHolderIsGone()
+
+	/**
+	 * A live run's lock is never offered to the sweep, and survives.
+	 *
+	 * @return void
+	 */
+	public function testTheSweepLeavesALiveRunsLockAlone(): void {
+		$this->rows->method('findOrphaned')->willReturn([]);
+		$this->magic->expects($this->never())->method('unlockObjectEntity');
+
+		$this->assertSame(0, $this->registry()->sweepOrphaned(now: new DateTime()));
+	}//end testTheSweepLeavesALiveRunsLockAlone()
+
+	// ---------------------------------------------------------------
+	// Recording.
+	// ---------------------------------------------------------------
+
+	/**
+	 * A user lock is not recorded: the registry is for run locks.
+	 *
+	 * @return void
+	 */
+	public function testAUserLockIsNotRecorded(): void {
+		$this->rows->expects($this->never())->method('record');
+		$this->registry()->record($this->lockedObject(null), null, 'lock-1');
+	}//end testAUserLockIsNotRecorded()
+
+	/**
+	 * A run lock is recorded with the object's identity and its expiry.
+	 *
+	 * @return void
+	 */
+	public function testARunLockIsRecordedWithItsExpiry(): void {
+		$captured = null;
+		$this->rows->method('record')->willReturnCallback(
+			function (RunObjectLock $row) use (&$captured): void {
+				$captured = $row;
+			}
+		);
+
+		$this->registry()->record($this->lockedObject(self::RUN_A), self::RUN_A, 'lock-1');
+
+		$this->assertSame(self::RUN_A, $captured->getRunUuid());
+		$this->assertSame(self::OBJ, $captured->getObjectUuid());
+		$this->assertSame('lock-1', $captured->getNodeId());
+		$this->assertGreaterThan(new DateTime(), $captured->getExpiresAt());
+	}//end testARunLockIsRecordedWithItsExpiry()
+
+	/**
+	 * A registry write that fails MUST NOT undo a lock that was taken.
+	 *
+	 * Failing the lock because its index entry did not land would trade a
+	 * working lock for no lock at all.
+	 *
+	 * @return void
+	 */
+	public function testAFailedRecordDoesNotUndoTheLock(): void {
+		$this->rows->method('record')->willThrowException(new RuntimeException('table missing'));
+
+		$this->registry()->record($this->lockedObject(self::RUN_A), self::RUN_A, 'lock-1');
+		$this->addToAssertionCount(1);
+	}//end testAFailedRecordDoesNotUndoTheLock()
+}//end class

--- a/tests/Unit/Service/Object/SaveObjectTest.php
+++ b/tests/Unit/Service/Object/SaveObjectTest.php
@@ -1775,10 +1775,37 @@ class SaveObjectTest extends TestCase {
 		$this->assertSame($entity, $result);
 	}
 
-	public function testFindAndValidateExistingObjectThrowsOnLockedObject(): void {
+	/**
+	 * Build a locked entity using the PRODUCTION writer.
+	 *
+	 * The two tests below used to hand-write `setLocked(['userId' => …])`, a
+	 * payload shape `ObjectEntity::lock()` has never produced. They passed,
+	 * and they are the reason the guard's `user` vs `userId` key mismatch
+	 * survived: the assertion agreed with the guard's own misreading instead
+	 * of with a lock the writer actually made. Going through `lock()` means
+	 * a future divergence between writer and reader fails here.
+	 *
+	 * @param string $holderUid The uid taking the lock.
+	 * @param string|null $runUuid The run taking the lock, for a run lock.
+	 *
+	 * @return ObjectEntity The locked entity.
+	 */
+	private function lockedEntity(string $holderUid, ?string $runUuid = null): ObjectEntity {
 		$entity = new ObjectEntity();
 		$entity->setUuid('test-uuid');
-		$entity->setLocked(['userId' => 'other-user']);
+
+		$holder = $this->createMock(IUser::class);
+		$holder->method('getUID')->willReturn($holderUid);
+		$holderSession = $this->createMock(IUserSession::class);
+		$holderSession->method('getUser')->willReturn($holder);
+
+		$entity->lock($holderSession, 'test-process', 3600, $runUuid);
+
+		return $entity;
+	}
+
+	public function testFindAndValidateExistingObjectThrowsOnLockedObject(): void {
+		$entity = $this->lockedEntity('other-user');
 
 		$this->objectEntityMapper->method('find')
 			->willReturn($entity);
@@ -1789,7 +1816,7 @@ class SaveObjectTest extends TestCase {
 		$this->userSession->method('getUser')->willReturn($user);
 
 		$this->expectException(Exception::class);
-		$this->expectExceptionMessage('Cannot update object: Object is locked');
+		$this->expectExceptionMessage('Cannot update object: Object is locked by other-user');
 
 		$this->invokePrivateMethod('findAndValidateExistingObject', [
 			'test-uuid', null, null, false, false,
@@ -1797,15 +1824,70 @@ class SaveObjectTest extends TestCase {
 	}
 
 	public function testFindAndValidateExistingObjectAllowsLockOwner(): void {
-		$entity = new ObjectEntity();
-		$entity->setUuid('test-uuid');
-		$entity->setLocked(['userId' => 'same-user']);
+		$entity = $this->lockedEntity('same-user');
 
 		$this->objectEntityMapper->method('find')
 			->willReturn($entity);
 
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('same-user');
+		$this->userSession->method('getUser')->willReturn($user);
+
+		$result = $this->invokePrivateMethod('findAndValidateExistingObject', [
+			'test-uuid', null, null, false, false,
+		]);
+
+		$this->assertSame($entity, $result);
+	}
+
+	/**
+	 * A person is refused while a FLOW RUN holds the lock, and the refusal
+	 * names the run so the reader knows what to go and look at.
+	 *
+	 * This is the case the guard exists for and could never express: before
+	 * run-scoped locking, ownership was the user alone, so a run executing as
+	 * `alice` was no obstacle to alice.
+	 */
+	public function testFindAndValidateExistingObjectRefusesAPersonWhileARunHoldsTheLock(): void {
+		$runUuid = 'run-aaaaaaaa-0000-0000-0000-000000000001';
+		$entity = $this->lockedEntity('alice', $runUuid);
+
+		$this->objectEntityMapper->method('find')
+			->willReturn($entity);
+
+		// The run's OWN runAs user, acting as a person.
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$this->userSession->method('getUser')->willReturn($user);
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage($runUuid);
+
+		$this->invokePrivateMethod('findAndValidateExistingObject', [
+			'test-uuid', null, null, false, false,
+		]);
+	}
+
+	/**
+	 * An expired lock refuses nobody: the TTL backstop, at the write guard.
+	 */
+	public function testFindAndValidateExistingObjectAllowsWhenTheLockHasExpired(): void {
+		$entity = new ObjectEntity();
+		$entity->setUuid('test-uuid');
+		$entity->setLocked(
+			[
+				'kind' => ObjectEntity::LOCK_KIND_RUN,
+				'runUuid' => 'run-aaaaaaaa-0000-0000-0000-000000000001',
+				'user' => 'alice',
+				'expiration' => (new \DateTime())->sub(new \DateInterval('PT10S'))->format('c'),
+			]
+		);
+
+		$this->objectEntityMapper->method('find')
+			->willReturn($entity);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('carol');
 		$this->userSession->method('getUser')->willReturn($user);
 
 		$result = $this->invokePrivateMethod('findAndValidateExistingObject', [

--- a/tests/Unit/Service/ObjectHandlers/SaveObjectCoverageTest.php
+++ b/tests/Unit/Service/ObjectHandlers/SaveObjectCoverageTest.php
@@ -569,9 +569,23 @@ class SaveObjectCoverageTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	private function lockAs(\OCA\OpenRegister\Db\ObjectEntity $entity, string $uid): void {
+		// Lock through the PRODUCTION writer. These fixtures used to hand-write
+		// setLocked(['userId' => ...]), a payload shape ObjectEntity::lock() has
+		// never produced, and they passed against a guard that read the same
+		// phantom key. That agreement is why the guard never fired on a real
+		// lock. Going through lock() means writer and reader can no longer
+		// diverge without this file failing.
+		$holder = $this->createMock(IUser::class);
+		$holder->method('getUID')->willReturn($uid);
+		$session = $this->createMock(IUserSession::class);
+		$session->method('getUser')->willReturn($holder);
+		$entity->lock($session, 'test-process', 3600);
+	}
+
 	public function testFindAndValidateExistingObjectThrowsWhenLockedByDifferentUser(): void {
 		$entity = $this->createObjectEntity(1, 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
-		$entity->setLocked(['userId' => 'other-user']);
+		$this->lockAs($entity, 'other-user');
 
 		$this->objectEntityMapper->method('find')
 			->willReturn($entity);
@@ -581,7 +595,7 @@ class SaveObjectCoverageTest extends TestCase {
 		$this->userSession->method('getUser')->willReturn($user);
 
 		$this->expectException(Exception::class);
-		$this->expectExceptionMessage('Cannot update object: Object is locked by user');
+		$this->expectExceptionMessage('Cannot update object: Object is locked by other-user');
 
 		$this->invokePrivate('findAndValidateExistingObject', [
 			'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
@@ -599,7 +613,7 @@ class SaveObjectCoverageTest extends TestCase {
 	 */
 	public function testFindAndValidateExistingObjectAllowsLockBySameUser(): void {
 		$entity = $this->createObjectEntity(1, 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
-		$entity->setLocked(['userId' => 'current-user']);
+		$this->lockAs($entity, 'current-user');
 
 		$this->objectEntityMapper->method('find')
 			->willReturn($entity);
@@ -626,7 +640,7 @@ class SaveObjectCoverageTest extends TestCase {
 	 */
 	public function testFindAndValidateExistingObjectLockNoCurrentUser(): void {
 		$entity = $this->createObjectEntity(1, 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
-		$entity->setLocked(['userId' => 'some-user']);
+		$this->lockAs($entity, 'some-user');
 
 		$this->objectEntityMapper->method('find')
 			->willReturn($entity);

--- a/vendor-bin/phpunit/composer.lock
+++ b/vendor-bin/phpunit/composer.lock
@@ -14,5 +14,8 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.3.0"
+    },
     "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
## What this does

Makes an object lock mean something, and lets a flow run hold one.

Two new nodes, `openregister.lock-object` and `openregister.unlock-object`, take and release a lock in the name of the **run** rather than the user the run happens to execute as. A second run that wants the same object parks and retries on the heartbeat. A person who writes to a locked object is refused with a message naming the run. The engine releases every lock a run holds on any terminal outcome, a sweep collects what a killed worker left behind, and the existing TTL stays as the backstop.

Spec first, in `openspec/changes/run-scoped-object-locking/`.

## Why

**No lock had ever blocked a write.** `ObjectEntity::lock()` writes the holder under the key `user`. `SaveObject::findAndValidateExistingObject()` read it under `userId`, so `$lockOwner` was invariably null and the guard's `!== null` test short-circuited every time. Every lock taken through the lock endpoint since it shipped was decorative on the service write path.

**The unit test agreed with the bug.** Three test files hand-wrote `setLocked(['userId' => ...])`, a payload shape `lock()` has never produced, and passed. That agreement is why the defect survived. Every one of those fixtures now goes through the production writer, so writer and reader cannot diverge again without this suite failing.

**Two runs under one identity could not conflict.** Ownership was compared on the user alone, so the second run took the *extend* branch, pushed the first's expiry out, and was handed the object. On an instance where flows run as one service account that is every pair of runs.

**The process tag was dropped on the floor.** `LockHandler::lock()` accepted `$process` and never forwarded it; `MagicMapper` hardcoded `'MagicMapper lock'`.

## The lock record

`kind: 'run'|'user'` and `runUuid`, added beside the existing keys. `_locked` is a JSON column, so this is additive with **no migration and no back-fill**: a record written before this change has no `kind` and reads as the user lock it is. `user` keeps its meaning in both cases (the person, or the run's `runAs`), so `getLockedBy()`, `callerMayUnlock()`, the 423 body and two frontend stores all keep working. What changes is that `user` stops being the authority.

One predicate owns ownership, `ObjectEntity::isLockedBySomeoneElse()`, and every guard calls it. A run lock refuses **everyone**, the run's own `runAs` user included; a malformed run lock refuses everybody rather than failing open. Reasoning in `design.md` D-1.

## Three release layers

1. A `FlowRunTerminalEvent` listener. The dispatch predicate in `FlowRunMapper::update()` is `isTerminal()`, not a whitelist, so all four terminal statuses and every reaper path are covered.
2. A sweep in `FlowRunWorker`, reading a small run-lock registry rather than scanning magic tables (an instance-wide scan of 2,728 of those costs ~3.4s just to plan).
3. The lock TTL, unchanged.

> Note on the brief: there is no `cancelled` run status. `FlowRun::TERMINAL` is `completed`, `stopped`, `failed`, `dead_letter`; a cancellation and a queue-TTL expiry both land on `failed`. The tests cover the four that exist, read from the constant so a fifth arrives as a failure.

## What the rig caught that mocks did not

Two defects, both found only on a real Postgres instance:

- The orphan query composed its two predicates as one `orX()` over a `createFunction()`. PostgreSQL rejects that with *"argument of OR must be type boolean, not type record"*, and **both** the registry's catch and the worker's swallowed it: the sweep would have logged a warning and released nothing, every tick, forever. Now two plain queries.
- The release read passed `includeDeleted: false`. A soft-deleted object can still hold a live lock and is exactly the one nobody is watching, so its lock would have been stranded.

`_rbac` and `_multitenancy` were already off on that read, because both release layers run sessionless; a test now pins all three flags. This is the same shape as the `prune-retired` miscount in #3440.

## Caller sweep

Every `lockObject()` caller in the fleet was checked for the shape that breaks when locks become real, lock under one identity and write under another. **None has it, so nothing starts refusing.** Two callers start being *protected*: buildiq's `ApplicationVersionsController::update()` and `AbstractToolHandler::saveVersionManifest()` both take locks explicitly to stop two concurrent MCP agents losing each other's writes, and two agents under one account have never been able to conflict. Both already handle the 409 they will now sometimes get. dossiq's `DrcController::lock()` locks then writes as the same user, which is admitted. Nothing in `lib/Repair/`, `lib/Command/`, `lib/Migration/` or any seed takes an object lock. Full table in `design.md` D-6.

## Verified locally

CI is bottlenecked, so this was verified locally and judged by exit code.

| Check | Result |
|---|---|
| `phpunit` Unit Tests | 19177 tests, **0 failures**; exit 1 on `No code coverage driver available`, identical to the untouched base (19116 tests, same 1 warning / 2 deprecations / 43 skipped) |
| `phpstan` | exit 0 |
| `psalm` | exit 0, no errors |
| `phpcs` | exit 0 on all changed files |
| `phpmd` | exit 0 on all 13 changed files (`lib/Service` whole-dir is OOM-killed on this host). Three findings fixed rather than baselined, one documented |
| hydra gates | full run (not diff-scoped), 80 of 80 applicable gates. Two failures found and fixed: gate-16 wanted 8 `@spec` tags, and gate-67 refused the contract change until the shipped copy moved with it, which is ConductionNL/.github#689 |
| rig | own compose project on a free port, **18/18 checks passed** against real Postgres, torn down with `down -v` |

The rig proved, end to end: the payload shape, a second run under the same user refused without rewriting the first's lock, a human write refused naming the run, the registry row, release layer 1, and the sweep freeing a lock whose run never existed.

Not run locally: the Integration, Database and Service suites, which need a booted Nextcloud checkout, and the E2E suite, which only runs on the `development` push.

## Quality debt paid on the way

`LockHandler` had grown past the complexity threshold, so `RunLockRegistry` and `AdvisoryLockStore` are split out: an advisory pre-creation lock and a run-held object lock are different things. A psalm baseline entry the extraction made stale was removed rather than left. `testLockNewLock` asserted only a return value behind a comment claiming the payload "may not actually be set"; it is not true, and that test now checks the payload.

## Companion PR

ConductionNL/.github#689 mirrors `ObjectServiceInterface` into the shipped contract copy. **Merge that one first**, or gate-67 stays red here for the right reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
