### PR TITLE
fix(e2e): the demo-data test arranges the choice it asserts against

### DIFF
--- a/tests/e2e/spec-coverage/demo-data-setup-step.spec.ts
+++ b/tests/e2e/spec-coverage/demo-data-setup-step.spec.ts
@@ -62,9 +62,10 @@ async function api(
 	page: Page,
 	method: string,
 	apiPath: string,
+	body?: unknown,
 ): Promise<{ status: number; json: any }> {
 	return await page.evaluate(
-		async ({ method, apiPath }) => {
+		async ({ method, apiPath, body }) => {
 			const res = await fetch(apiPath, {
 				method,
 				headers: {
@@ -73,6 +74,7 @@ async function api(
 					requesttoken: (window as any).OC?.requestToken || '',
 					'OCS-APIREQUEST': 'true',
 				},
+				body: body === undefined ? undefined : JSON.stringify(body),
 			})
 			let json: any
 			try {
@@ -82,8 +84,39 @@ async function api(
 			}
 			return { status: res.status, json }
 		},
-		{ method, apiPath },
+		{ method, apiPath, body },
 	)
+}
+
+/**
+ * Choose the shipped dataset, and answer with the id that was chosen.
+ *
+ * 🔴 THE TEST HAS TO MAKE THE DECISION IT ASSERTS AGAINST. The demo-data step
+ * is a choice followed by a load step now, and the CI seed settles the optional
+ * steps by posting `skip-demo-data` — which records "none". A load that follows
+ * correctly imports nothing, so an install test that skips this arranges no
+ * precondition and measures the seed instead of the app.
+ *
+ * The id comes from `/api/setup/status` rather than a literal: the choice step
+ * reads its options from exactly that list, so a hardcoded id can pass while
+ * the list an operator sees is empty.
+ */
+async function pickShippedDataset(page: Page): Promise<string> {
+	const status = await api(page, 'GET', `${BASE}/api/setup/status`)
+	const shipped = (status.json?.datasets ?? []).find(
+		(d: any) => d?.id && d.id !== 'none',
+	)
+	expect(
+		shipped,
+		`setup/status offers no dataset to load: ${JSON.stringify(status.json?.datasets)}`,
+	).toBeTruthy()
+
+	const saved = await api(page, 'POST', `${BASE}/api/setup/config`, {
+		demo_dataset: shipped.id,
+	})
+	expect(saved.status, JSON.stringify(saved.json)).toBe(200)
+
+	return shipped.id
 }
 
 test.describe.configure({ mode: 'serial' })
@@ -130,6 +163,8 @@ test.describe('ADR-111 demo data', () => {
 		// WROTE something.
 		test.slow()
 
+		await pickShippedDataset(page)
+
 		const res = await api(
 			page,
 			'POST',
@@ -162,6 +197,8 @@ test.describe('ADR-111 demo data', () => {
 		// The step body tells the operator it is "safe to run more than once".
 		// That sentence is a contract; this asserts the server keeps it rather
 		// than erroring or reporting failure on a second pass.
+		await pickShippedDataset(page)
+
 		const again = await api(
 			page,
 			'POST',


### PR DESCRIPTION
`installing the demo data reports HOW MUCH landed, not just success` posts the load action and then asserts the message names a non-zero object count. It never says **which** dataset to load.

That was fine while the step was a bare run-action with one possible outcome. It is not fine now. The step is a choice followed by a load step, and the CI seed settles the optional steps by posting `skip-demo-data`, which records `demo_dataset = none`. The load that follows then does exactly the right thing and imports nothing:

```
Error: the install message must name a non-zero object count;
got: "No example data was loaded."
```

So the test asserted against a decision it never made, and measured the seed instead of the app.

## The fix

- `api()` gained a body parameter. It had none, so a test could not post a choice at all.
- Both install tests call `pickShippedDataset(page)` first.
- That helper reads the id from `GET /api/setup/status` rather than writing `'demo'` as a literal. The choice step declares `optionsSource: datasets` and carries no options of its own, so the list in that response **is** what an operator sees. A hardcoded id would let this test pass while the cards render empty.

## Verified

`prettier`, `eslint` and `playwright test --list` are green on the changed file. The E2E leg itself is `skipping` on pull requests and runs on the `development` push, so the run after this merges is where it is proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
