### PR TITLE
fix(migrations): a migration that ships without a version bump reaches nobody

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -43,4 +43,20 @@ if git diff --cached --name-only | grep -qE "^openspec/(specs/|features\.overlay
   fi
 fi
 
+# A NEW MIGRATION NEEDS A VERSION BUMP, and this is the cheapest place to be
+# told. Nextcloud reads an app's migration files only when appinfo/info.xml's
+# <version> is greater than the installed_version it recorded, so a migration
+# committed without a bump runs on no existing instance and says nothing about
+# it. CI (merge-hygiene) is the enforcement; this only tells you earlier.
+#
+# WARN ONLY, like everything else in this hook: a commit is a fine moment to
+# learn about it and a bad moment to be blocked, and the bump is often the last
+# thing you write. The gate on the PR is what actually holds the line.
+if git diff --cached --name-only --diff-filter=A | grep -q "^lib/Migration/.*\.php$"; then
+  if ! php scripts/check-migration-version-bump.php >/dev/null 2>&1; then
+    echo "pre-commit: WARNING — this change adds a migration without moving <version> in appinfo/info.xml." >&2
+    echo "            Run: php scripts/check-migration-version-bump.php" >&2
+  fi
+fi
+
 exit 0

--- a/.github/workflows/merge-hygiene.yml
+++ b/.github/workflows/merge-hygiene.yml
@@ -33,7 +33,13 @@ jobs:
     name: Conflict markers and PHP syntax
     runs-on: ubuntu-latest
     steps:
+      # FULL HISTORY, deliberately. The migration/version check below compares
+      # this branch against the merge base with `development`, and a depth-1
+      # checkout has no merge base to find — it would report "no verdict" on
+      # every run, which is the silent skip the check exists to remove.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       # Conflict markers, anywhere in the tree we author. A marker means a merge
       # was committed half-finished; every downstream signal from that commit is
@@ -68,6 +74,30 @@ jobs:
         with:
           php-version: '8.3'
           coverage: none
+
+      # A MIGRATION THAT SHIPS WITHOUT A VERSION BUMP REACHES NOBODY.
+      #
+      # Nextcloud runs an app's migrations only when appinfo/info.xml's
+      # <version> is greater than the installed_version it recorded. Equal
+      # versions mean `occ upgrade` answers "No upgrade required.", exits 0, and
+      # reads none of the migration files — no log line, no failure, and the
+      # feature that needed the table is simply absent.
+      #
+      # Measured on a throwaway NC 34 rig 2026-09-05: a migration added with the
+      # version left alone did not run, was not recorded, and
+      # `occ migrations:status openregister` reported "Pending Migrations: None"
+      # while showing 204 executed of 205 available. Bumping only <version>, with
+      # the code byte-identical, ran it. The version string is the whole gate.
+      #
+      # It lives here rather than in Code Quality because it needs the base ref
+      # and takes milliseconds — the same reason everything else in this file is
+      # here.
+      - name: A new migration moves the app version
+        run: |
+          set -euo pipefail
+          BASE="${{ github.event.pull_request.base.ref || 'development' }}"
+          git fetch --no-tags --prune origin "$BASE"
+          MIGRATION_VERSION_BASE_REF="origin/$BASE" php scripts/check-migration-version-bump.php
 
       # Every PHP file parses. A conflict marker is caught above, but so is any
       # other way a file can be committed unparseable — and this is the check

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
 		"post-update-cmd": [
 			"@composer bin all update --ansi"
 		],
+		"check:migration-version": "php scripts/check-migration-version-bump.php",
 		"lint": "find . -name \\*.php -not -path './vendor/*' -not -path './vendor-bin/*' -not -path './build/*' -print0 | xargs -0 -n1 php -l",
 		"cs:check": "php-cs-fixer fix --dry-run --diff",
 		"cs:fix": "php-cs-fixer fix",
@@ -84,7 +85,7 @@
 		"openapi": "generate-spec",
 		"check": "E=0; for CMD in lint phpcs psalm test:unit; do echo; echo \"=== $CMD ===\"; composer $CMD || E=1; done; echo; if [ $E -eq 0 ]; then echo \"ALL CHECKS PASSED\"; else echo \"SOME CHECKS FAILED (see above)\"; fi; exit $E",
 		"check:full": "E=0; for CMD in lint phpcs psalm phpstan test:all; do echo; echo \"=== $CMD ===\"; composer $CMD || E=1; done; echo; if [ $E -eq 0 ]; then echo \"ALL CHECKS PASSED\"; else echo \"SOME CHECKS FAILED (see above)\"; fi; exit $E",
-		"check:strict": "E=0; for CMD in lint phpcs phpmd psalm phpstan test:all; do echo; echo \"=== $CMD ===\"; composer $CMD || E=1; done; echo; if [ $E -eq 0 ]; then echo \"ALL CHECKS PASSED\"; else echo \"SOME CHECKS FAILED (see above)\"; fi; exit $E",
+		"check:strict": "E=0; for CMD in lint check:migration-version phpcs phpmd psalm phpstan test:all; do echo; echo \"=== $CMD ===\"; composer $CMD || E=1; done; echo; if [ $E -eq 0 ]; then echo \"ALL CHECKS PASSED\"; else echo \"SOME CHECKS FAILED (see above)\"; fi; exit $E",
 		"fix": [
 			"@cs:fix"
 		],

--- a/lib/Migration/NAMING.md
+++ b/lib/Migration/NAMING.md
@@ -30,3 +30,78 @@ hazard. **These files are therefore intentionally left as-is.** This is a
 documentation-only note (per OPS-12 in `CODE-REVIEW-IMPROVEMENT-PLAN.md`): record
 the inconsistency, standardise *going forward*, and never rename already-applied
 migrations.
+
+## A migration without a version bump reaches nobody
+
+**Every change that adds a file here MUST also move `<version>` in
+`appinfo/info.xml`, in the same change.** Not in the release bump PR that
+follows it — in the same change.
+
+Nextcloud decides whether to read an app's migration directory at all by
+comparing `<version>` against the `installed_version` it recorded for that app.
+Equal versions mean "already up to date": `occ upgrade` answers
+`No upgrade required.`, **exits 0**, and never opens a single migration file.
+Nothing is logged. Nothing fails. The table the feature needs is simply not
+there, and the feature is absent with no error anywhere.
+
+Measured 2026-09-05 on a throwaway Nextcloud 34.0.3 rig running openregister
+`2.0.15-unstable.20260905134511` from its release tarball:
+
+| step | result |
+|---|---|
+| add a migration creating a table, leave `<version>` alone, `occ upgrade` | `No upgrade required.`, exit 0 |
+| … table created? | no |
+| … row in `oc_migrations`? | no |
+| change **nothing but `<version>`**, `occ upgrade` again | `Updated <openregister> to 2.0.16` |
+| … table created, migration recorded? | yes |
+
+The code was byte-identical across those two runs. One line of XML is the
+entire gate.
+
+This is not hypothetical: on 2026-09-05 `development` carried four migrations
+added since `<version>` last moved, one of them the run-lock table
+openregister#3444 depends on, and a live instance updated to that code got none
+of them.
+
+`scripts/check-migration-version-bump.php` enforces the rule. It runs in
+`Merge Hygiene` on every push and PR, in `composer check:strict`, and as a
+warning from `.githooks/pre-commit`.
+
+## Do not trust `occ migrations:status` — it will tell you nothing is pending
+
+The command is Nextcloud's, and three of its five counting fields are wrong.
+On the rig above, with one migration genuinely unrun, it reported:
+
+```
+ >> Executed Migrations:              204
+ >> Executed Unavailable Migrations:  204
+ >> Available Migrations:             205
+ >> New Migrations:                   205
+ >> Pending Migrations:               None
+```
+
+Three separate defects, all in core:
+
+- **`Pending Migrations: None`** — `MigrationService::describeMigrationStep()`
+  builds the list as `if ($migration->name())`, and
+  `SimpleMigrationStep::name()` returns `''` unless a step overrides it. None of
+  openregister's 204 migrations override it, so this field reads `None` for this
+  app **always**, whatever the state of the database.
+- **`New Migrations` and `Executed Unavailable Migrations`** —
+  `StatusCommand::getMigrationsInfos()` calls `array_keys()` on
+  `getAvailableVersions()`, which returns a **list**, so both fields diff
+  version strings against the integers `0..n` and report the full count on every
+  run. Hence 204 and 205 on an instance where nothing is wrong with either.
+- `describeMigrationStep('lastest')` is called with the alias misspelled. Benign
+  here only by luck: `sortMigrations()` falls through to `strnatcmp`, and
+  `Version…` sorts below `lastest`, so nothing is filtered out.
+
+**The only honest pair in that output is `Executed Migrations` against
+`Available Migrations`.** 204 of 205 means one migration has not run, no matter
+what the line underneath says. Read those two numbers and ignore the rest.
+
+To recover an instance that is already in this state, either bump `<version>`
+and run `occ upgrade`, or run the migration directly with
+`occ migrations:migrate openregister` (both `migrations:*` commands need
+`debug` set to `true` in `config.php`, or they are not registered at all and
+`occ` answers `Command "migrations:status" is not defined`).

--- a/scripts/check-migration-version-bump.php
+++ b/scripts/check-migration-version-bump.php
@@ -1,0 +1,261 @@
+#!/usr/bin/env php
+<?php
+/**
+ * A migration that ships without a version bump reaches nobody.
+ *
+ * Nextcloud decides whether to run an app's migrations by comparing the
+ * `<version>` in appinfo/info.xml against the `installed_version` it recorded
+ * for that app. Equal versions mean "already up to date", and `occ upgrade`
+ * then answers "No upgrade required." and exits 0. The migration files on disk
+ * are never read. Nothing is logged, nothing fails, and the feature that needed
+ * the table is simply absent.
+ *
+ * MEASURED, 2026-09-05, on a throwaway NC 34.0.3 rig with openregister
+ * 2.0.15-unstable.20260905134511 installed from its release tarball:
+ *
+ *   added lib/Migration/Version1Date20260906090000.php (creates a table),
+ *   left <version> alone, ran `occ upgrade`
+ *     -> "No upgrade required."            exit 0
+ *     -> table not created                 (0 rows in information_schema)
+ *     -> no row in oc_migrations           (the step never ran)
+ *     -> `occ migrations:status openregister` said
+ *          Executed Migrations: 204
+ *          Available Migrations: 205
+ *          Pending Migrations: None        <- see NOTE below
+ *
+ *   then changed NOTHING but `<version>`, and re-ran `occ upgrade`
+ *     -> "Updated <openregister> to 2.0.16"
+ *     -> table created, migration recorded
+ *
+ * So the version string is the whole gate, and the same code either ships or
+ * does not depending on one line of XML.
+ *
+ * NOTE on `occ migrations:status`: it cannot be used to catch this. Its
+ * "Pending Migrations" field is built by MigrationService::describeMigrationStep(),
+ * which drops every step whose `name()` is empty — and SimpleMigrationStep::name()
+ * returns '' by default, which all 204 of ours inherit. Its "New Migrations" and
+ * "Executed Unavailable Migrations" fields are worse: core's StatusCommand calls
+ * `array_keys()` on getAvailableVersions(), which returns a LIST, so both fields
+ * compare version strings against the integers 0..n and report the full count
+ * every time. The only honest pair in that output is Executed vs Available.
+ * That is Nextcloud's code, not ours; see lib/Migration/NAMING.md.
+ *
+ * WHAT THIS SCRIPT DOES. Fails when the branch adds a file under lib/Migration/
+ * without moving `<version>` in appinfo/info.xml past the value at the merge base.
+ *
+ *   php scripts/check-migration-version-bump.php [--base=<ref>] [--repo=<path>]
+ *
+ * Base ref resolution: --base, else $MIGRATION_VERSION_BASE_REF, else
+ * $HYDRA_GATE_BASE_REF, else origin/development.
+ *
+ * Exit codes: 0 clean, 1 a migration was added without a bump, 2 the check
+ * could not be run (no repo, unresolvable base, unparseable info.xml). It exits
+ * 2 rather than 0 in that case deliberately: a check that cannot see the base
+ * has no verdict to give, and a silent pass is the failure mode this whole
+ * script exists to remove.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ */
+
+declare(strict_types=1);
+
+const EXIT_OK       = 0;
+const EXIT_VIOLATION = 1;
+const EXIT_UNKNOWN  = 2;
+
+/**
+ * Run a git command and return its trimmed stdout, or null when it fails.
+ *
+ * @param string        $repo Repository working directory.
+ * @param array<string> $args Arguments after `git`.
+ *
+ * @return string|null Trimmed stdout, or null on a non-zero exit.
+ */
+function git(string $repo, array $args): ?string
+{
+    $cmd = 'git -C ' . escapeshellarg($repo);
+    foreach ($args as $arg) {
+        $cmd .= ' ' . escapeshellarg($arg);
+    }
+
+    $out  = [];
+    $code = 0;
+    exec($cmd . ' 2>/dev/null', $out, $code);
+    if ($code !== 0) {
+        return null;
+    }
+
+    return trim(implode("\n", $out));
+}
+
+/**
+ * Read the <version> element out of an info.xml document.
+ *
+ * Deliberately a regex on the raw text rather than a DOM parse: this must read
+ * the file as it stands at an arbitrary git revision, where the surrounding
+ * document may not be well formed, and a parse failure would be reported as
+ * "no version" instead of "cannot tell".
+ *
+ * @param string|null $xml The document text, or null when it could not be read.
+ *
+ * @return string|null The version, or null when absent.
+ */
+function versionFromInfoXml(?string $xml): ?string
+{
+    if ($xml === null) {
+        return null;
+    }
+
+    if (preg_match('#<version>\s*([^<\s][^<]*?)\s*</version>#', $xml, $m) !== 1) {
+        return null;
+    }
+
+    return $m[1];
+}
+
+/**
+ * Print a message to stderr.
+ *
+ * @param string $message The message.
+ *
+ * @return void
+ */
+function err(string $message): void
+{
+    fwrite(STDERR, $message . "\n");
+}
+
+$repo = getcwd();
+$base = getenv('MIGRATION_VERSION_BASE_REF');
+if ($base === false || $base === '') {
+    $base = getenv('HYDRA_GATE_BASE_REF');
+}
+
+if ($base === false || $base === '') {
+    $base = 'origin/development';
+}
+
+foreach (array_slice($argv, 1) as $arg) {
+    if (str_starts_with($arg, '--base=') === true) {
+        $base = substr($arg, 7);
+        continue;
+    }
+
+    if (str_starts_with($arg, '--repo=') === true) {
+        $repo = substr($arg, 7);
+        continue;
+    }
+
+    if ($arg === '--help' || $arg === '-h') {
+        echo "usage: check-migration-version-bump.php [--base=<ref>] [--repo=<path>]\n";
+        exit(EXIT_OK);
+    }
+
+    err('check-migration-version-bump: unknown argument ' . $arg);
+    exit(EXIT_UNKNOWN);
+}
+
+$root = git($repo, ['rev-parse', '--show-toplevel']);
+if ($root === null || $root === '') {
+    err('check-migration-version-bump: ' . $repo . ' is not a git repository — no verdict.');
+    exit(EXIT_UNKNOWN);
+}
+
+$baseSha = git($root, ['rev-parse', '--verify', '--quiet', $base . '^{commit}']);
+if ($baseSha === null || $baseSha === '') {
+    $baseSha = git($root, ['rev-parse', '--verify', '--quiet', 'origin/' . $base . '^{commit}']);
+}
+
+if ($baseSha === null || $baseSha === '') {
+    err('check-migration-version-bump: cannot resolve base ref "' . $base . '" — no verdict.');
+    err('  Fetch it first, or pass --base=<ref>. A base this check cannot see is');
+    err('  not the same as a clean branch, so this refuses to report one.');
+    exit(EXIT_UNKNOWN);
+}
+
+$mergeBase = git($root, ['merge-base', $baseSha, 'HEAD']);
+if ($mergeBase === null || $mergeBase === '') {
+    err('check-migration-version-bump: no merge base between HEAD and ' . $base . ' — no verdict.');
+    err('  A shallow clone is the usual cause; fetch with enough depth to reach it.');
+    exit(EXIT_UNKNOWN);
+}
+
+// Three ways a migration can be present and new, and all three count. The
+// committed case is what CI sees; the other two are what a developer has in
+// front of them before they push, which is where this is cheapest to fix.
+// --no-renames is deliberate: renaming an already-applied migration makes
+// Nextcloud re-run it (see lib/Migration/NAMING.md), so a rename must be
+// treated as an addition and must move the version too.
+$added = [];
+foreach (
+    [
+        ['diff', '--diff-filter=A', '--no-renames', '--name-only', $mergeBase . '..HEAD', '--', 'lib/Migration'],
+        ['diff', '--diff-filter=A', '--no-renames', '--name-only', $mergeBase, '--', 'lib/Migration'],
+        ['ls-files', '--others', '--exclude-standard', '--', 'lib/Migration'],
+    ] as $args
+) {
+    $out = git($root, $args);
+    if ($out === null || $out === '') {
+        continue;
+    }
+
+    foreach (explode("\n", $out) as $line) {
+        $line = trim($line);
+        if ($line !== '' && str_ends_with($line, '.php') === true) {
+            $added[$line] = true;
+        }
+    }
+}
+
+$added = array_keys($added);
+sort($added);
+
+if ($added === []) {
+    echo "check-migration-version-bump: no migrations added against " . substr($mergeBase, 0, 8) . ", nothing to check.\n";
+    exit(EXIT_OK);
+}
+
+$baseVersion = versionFromInfoXml(git($root, ['show', $mergeBase . ':appinfo/info.xml']));
+$headXml     = @file_get_contents($root . '/appinfo/info.xml');
+$headVersion = versionFromInfoXml($headXml === false ? null : $headXml);
+
+if ($baseVersion === null) {
+    err('check-migration-version-bump: no <version> in appinfo/info.xml at ' . substr($mergeBase, 0, 8) . ' — no verdict.');
+    exit(EXIT_UNKNOWN);
+}
+
+if ($headVersion === null) {
+    err('check-migration-version-bump: no <version> in appinfo/info.xml on this branch — no verdict.');
+    exit(EXIT_UNKNOWN);
+}
+
+if (version_compare($headVersion, $baseVersion, '>') === true) {
+    printf(
+        "check-migration-version-bump: %d migration(s) added, <version> moved %s -> %s. OK.\n",
+        count($added),
+        $baseVersion,
+        $headVersion
+    );
+    exit(EXIT_OK);
+}
+
+err('');
+err('  This branch adds ' . count($added) . ' migration(s) but does not move the app version.');
+err('');
+foreach ($added as $file) {
+    err('    ' . $file);
+}
+
+err('');
+err('  appinfo/info.xml <version>: ' . $baseVersion . ' at the merge base, ' . $headVersion . ' here.');
+err('');
+err('  Nextcloud runs an app\'s migrations only when <version> is greater than the');
+err('  installed_version it recorded. Left as it is, `occ upgrade` will answer');
+err('  "No upgrade required.", exit 0, and run none of these on any instance that');
+err('  already has this app. Nothing will be logged and nothing will fail.');
+err('');
+err('  Bump <version> in appinfo/info.xml in this same change. Do not wait for the');
+err('  release bump PR: between releases, `development` is what people deploy.');
+err('');
+exit(EXIT_VIOLATION);

--- a/tests/Unit/Migration/MigrationVersionBumpCheckTest.php
+++ b/tests/Unit/Migration/MigrationVersionBumpCheckTest.php
@@ -1,0 +1,291 @@
+<?php
+
+/**
+ * The gate that keeps a migration and the app version together.
+ *
+ * WHY THIS TEST BUILDS ITS OWN REPOSITORIES. The thing under test is a
+ * statement about a git diff, so a test that inspects THIS repository can only
+ * report whatever today's branch happens to look like: it would pass on a
+ * branch with no migrations for a reason that has nothing to do with the check
+ * working. Each case below lays down a small repository with a known history,
+ * so the red cases are red because the check found the defect and the green
+ * cases are green because there was none.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Migration;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exercises scripts/check-migration-version-bump.php over synthetic repositories.
+ *
+ * @package OCA\OpenRegister\Tests\Unit\Migration
+ */
+class MigrationVersionBumpCheckTest extends TestCase {
+
+	/**
+	 * Absolute path of the fixture repository for the running test.
+	 *
+	 * @var string|null
+	 */
+	private ?string $repo = null;
+
+	/**
+	 * Remove the fixture repository.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		if ($this->repo !== null && is_dir($this->repo) === true) {
+			exec('rm -rf ' . escapeshellarg($this->repo));
+		}
+
+		$this->repo = null;
+		parent::tearDown();
+	}
+
+	/**
+	 * Absolute path to the script under test.
+	 *
+	 * @return string
+	 */
+	private function script(): string {
+		return dirname(__DIR__, 3) . '/scripts/check-migration-version-bump.php';
+	}
+
+	/**
+	 * Create a repository holding an info.xml at $version and one migration,
+	 * committed on a branch named `development`.
+	 *
+	 * @param string $version The starting app version.
+	 *
+	 * @return string The repository path.
+	 */
+	private function repoAtVersion(string $version): string {
+		$dir = sys_get_temp_dir() . '/or-migration-gate-' . bin2hex(random_bytes(6));
+		mkdir($dir . '/appinfo', 0777, true);
+		mkdir($dir . '/lib/Migration', 0777, true);
+
+		file_put_contents($dir . '/appinfo/info.xml', $this->infoXml($version));
+		file_put_contents($dir . '/lib/Migration/Version1Date20260101000000.php', "<?php\n// base migration\n");
+		file_put_contents($dir . '/README.md', "base\n");
+
+		$this->sh('git init -q -b development', $dir);
+		$this->sh('git config user.email t@example.org', $dir);
+		$this->sh('git config user.name Test', $dir);
+		$this->sh('git config commit.gpgsign false', $dir);
+		$this->sh('git add -A', $dir);
+		$this->sh('git commit -q -m base', $dir);
+		$this->sh('git checkout -q -b feature', $dir);
+
+		$this->repo = $dir;
+		return $dir;
+	}
+
+	/**
+	 * Minimal info.xml carrying a version.
+	 *
+	 * @param string $version The version.
+	 *
+	 * @return string
+	 */
+	private function infoXml(string $version): string {
+		return "<?xml version=\"1.0\"?>\n<info>\n    <id>openregister</id>\n    <version>" . $version . "</version>\n</info>\n";
+	}
+
+	/**
+	 * Run a shell command inside a directory, ignoring its output.
+	 *
+	 * @param string $cmd The command.
+	 * @param string $cwd The working directory.
+	 *
+	 * @return void
+	 */
+	private function sh(string $cmd, string $cwd): void {
+		exec('cd ' . escapeshellarg($cwd) . ' && ' . $cmd . ' >/dev/null 2>&1');
+	}
+
+	/**
+	 * Invoke the check against a fixture repository.
+	 *
+	 * @param string $dir  The repository.
+	 * @param string $base The base ref to compare against.
+	 *
+	 * @return array{code: int, output: string}
+	 */
+	private function check(string $dir, string $base = 'development'): array {
+		$cmd = 'php ' . escapeshellarg($this->script())
+			. ' --repo=' . escapeshellarg($dir)
+			. ' --base=' . escapeshellarg($base) . ' 2>&1';
+
+		$out  = [];
+		$code = 0;
+		exec($cmd, $out, $code);
+
+		return [
+			'code'   => $code,
+			'output' => implode("\n", $out),
+		];
+	}
+
+	/**
+	 * Add a migration file and commit it.
+	 *
+	 * @param string $dir  The repository.
+	 * @param string $name The class/file name without extension.
+	 *
+	 * @return void
+	 */
+	private function addMigration(string $dir, string $name = 'Version1Date20260906090000'): void {
+		file_put_contents($dir . '/lib/Migration/' . $name . '.php', "<?php\n// added\n");
+		$this->sh('git add -A', $dir);
+		$this->sh('git commit -q -m "add migration"', $dir);
+	}
+
+	/**
+	 * THE DEFECT. A migration is added and the version is left alone.
+	 *
+	 * @return void
+	 */
+	public function testAddingAMigrationWithoutBumpingTheVersionFails(): void {
+		$dir = $this->repoAtVersion('2.0.14');
+		$this->addMigration($dir);
+
+		$result = $this->check($dir);
+
+		$this->assertSame(1, $result['code'], "expected a violation, got:\n" . $result['output']);
+		$this->assertStringContainsString(
+			'lib/Migration/Version1Date20260906090000.php',
+			$result['output'],
+			'the failure must name the migration it found, not just fail'
+		);
+		$this->assertStringContainsString('2.0.14', $result['output']);
+	}
+
+	/**
+	 * THE FIX. The same change with the version moved passes.
+	 *
+	 * @return void
+	 */
+	public function testAddingAMigrationWithAVersionBumpPasses(): void {
+		$dir = $this->repoAtVersion('2.0.14');
+		file_put_contents($dir . '/lib/Migration/Version1Date20260906090000.php', "<?php\n// added\n");
+		file_put_contents($dir . '/appinfo/info.xml', $this->infoXml('2.0.15'));
+		$this->sh('git add -A', $dir);
+		$this->sh('git commit -q -m "add migration and bump"', $dir);
+
+		$result = $this->check($dir);
+
+		$this->assertSame(0, $result['code'], "expected a pass, got:\n" . $result['output']);
+	}
+
+	/**
+	 * A prerelease version moves the way version_compare reads it, and the
+	 * fleet's release bumps all look like this. `2.0.14-unstable.<stamp>` ->
+	 * `2.0.15-unstable.<stamp>` must count as a move.
+	 *
+	 * @return void
+	 */
+	public function testAPrereleaseBumpCounts(): void {
+		$dir = $this->repoAtVersion('2.0.14-unstable.20260901212512');
+		file_put_contents($dir . '/lib/Migration/Version1Date20260906090000.php', "<?php\n// added\n");
+		file_put_contents($dir . '/appinfo/info.xml', $this->infoXml('2.0.15-unstable.20260905134511'));
+		$this->sh('git add -A', $dir);
+		$this->sh('git commit -q -m "add migration and bump"', $dir);
+
+		$this->assertSame(0, $this->check($dir)['code']);
+	}
+
+	/**
+	 * THE CONTROL. Without a new migration the check has nothing to say, even
+	 * though the version has not moved — so a pass above means the check looked
+	 * and found nothing, not that it always passes.
+	 *
+	 * @return void
+	 */
+	public function testChangingOtherFilesWithoutAMigrationPasses(): void {
+		$dir = $this->repoAtVersion('2.0.14');
+		file_put_contents($dir . '/README.md', "edited\n");
+		file_put_contents($dir . '/lib/Migration/Version1Date20260101000000.php', "<?php\n// edited in place\n");
+		$this->sh('git add -A', $dir);
+		$this->sh('git commit -q -m "edit only"', $dir);
+
+		$result = $this->check($dir);
+
+		$this->assertSame(0, $result['code'], "expected a pass, got:\n" . $result['output']);
+		$this->assertStringContainsString('nothing to check', $result['output']);
+	}
+
+	/**
+	 * A version that moves BACKWARDS is not a bump. Nextcloud compares with
+	 * version_compare, so a lower version is as inert as an equal one.
+	 *
+	 * @return void
+	 */
+	public function testLoweringTheVersionIsNotABump(): void {
+		$dir = $this->repoAtVersion('2.0.14');
+		file_put_contents($dir . '/lib/Migration/Version1Date20260906090000.php', "<?php\n// added\n");
+		file_put_contents($dir . '/appinfo/info.xml', $this->infoXml('2.0.13'));
+		$this->sh('git add -A', $dir);
+		$this->sh('git commit -q -m "add migration, lower version"', $dir);
+
+		$this->assertSame(1, $this->check($dir)['code']);
+	}
+
+	/**
+	 * The uncommitted case, which is where a developer meets this first: an
+	 * untracked migration in the working tree counts as added.
+	 *
+	 * @return void
+	 */
+	public function testAnUntrackedMigrationInTheWorkingTreeCounts(): void {
+		$dir = $this->repoAtVersion('2.0.14');
+		file_put_contents($dir . '/lib/Migration/Version1Date20260906090000.php', "<?php\n// not committed yet\n");
+
+		$result = $this->check($dir);
+
+		$this->assertSame(1, $result['code'], "expected a violation, got:\n" . $result['output']);
+		$this->assertStringContainsString('Version1Date20260906090000.php', $result['output']);
+	}
+
+	/**
+	 * A base ref it cannot resolve gets exit 2, never exit 0. A check that
+	 * cannot see the base has no verdict, and reporting a pass there is the
+	 * silent-skip failure this whole gate exists to remove.
+	 *
+	 * @return void
+	 */
+	public function testAnUnresolvableBaseRefRefusesToGiveAVerdict(): void {
+		$dir = $this->repoAtVersion('2.0.14');
+		$this->addMigration($dir);
+
+		$result = $this->check($dir, 'no-such-branch');
+
+		$this->assertSame(2, $result['code'], "expected 'no verdict', got:\n" . $result['output']);
+		$this->assertStringContainsString('no verdict', $result['output']);
+	}
+
+	/**
+	 * A directory that is not a git repository gets exit 2 for the same reason.
+	 *
+	 * @return void
+	 */
+	public function testANonRepositoryRefusesToGiveAVerdict(): void {
+		$dir = sys_get_temp_dir() . '/or-migration-gate-notarepo-' . bin2hex(random_bytes(6));
+		mkdir($dir, 0777, true);
+		$this->repo = $dir;
+
+		$this->assertSame(2, $this->check($dir)['code']);
+	}
+}


### PR DESCRIPTION
## A migration that ships without a version bump reaches nobody

Found while updating a live instance. `development` had picked up new migrations
but the app version had not moved, so `occ upgrade` ran none of them — including
the one that creates the run-lock table #3444 depends on. The feature was simply
absent, with no error anywhere.

### Reproduced, not inherited

Throwaway NC 34.0.3 rig on a free port, openregister
`2.0.15-unstable.20260905134511` installed from its release tarball, 204
migrations, `installed_version` equal to `<version>`.

| step | result |
|---|---|
| add `Version1Date20260906090000.php` (creates a table), leave `<version>` alone, `occ upgrade` | `No upgrade required.` **exit 0** |
| table created? | **no** (0 rows in `information_schema.tables`) |
| row in `oc_migrations`? | **no** |
| `occ app:update openregister` | `up-to-date or no updates could be found`, still no table |
| change **nothing but `<version>`** (2.0.15-unstable… → 2.0.16), `occ upgrade` | `Updated <openregister> to 2.0.16` |
| table created, migration recorded? | **yes** |

The code was byte-identical across the failing and passing runs. One line of XML
is the entire gate.

And the instrument agreed with the failure:

```
 >> Executed Migrations:              204
 >> Executed Unavailable Migrations:  204
 >> Available Migrations:             205
 >> New Migrations:                   205
 >> Pending Migrations:               None
```

### Which half is the defect

**The version discipline.** A PR that adds a migration must move `<version>` in
the same change, and until now nothing said so or checked it. Measured on the
real history: `<version>` last moved on 2026-09-03 (`85e8321`), and `development`
has added **four** migrations since, none of which could reach an instance
already on that version.

Waiting for the release bump PR is not enough, because between releases
`development` is what people deploy — and those bump PRs queue up (#3450 is open
right now).

The fix fits the pattern rather than inventing a third mechanism. sc#396's answer
— derive the gate value from the content it gates — does not transfer here: this
value is a published App Store semver, not an internal signature, so it cannot be
computed. dossiq#1786's answer applies instead: a deliberate bump, in the same
change, now with something mechanical behind it.

**The reporting is Nextcloud's, so it is documented rather than worked around.**
Three of the five counting fields in `occ migrations:status` are wrong, and all
three defects are in core:

- **`Pending Migrations: None`** — `MigrationService::describeMigrationStep()`
  builds its list under `if ($migration->name())`, and
  `SimpleMigrationStep::name()` returns `''` by default. **None of our 204
  migrations override it**, so this field reads `None` for openregister *always*,
  whatever the database says. It is not a wrong answer about this branch; it is a
  field that has never once been able to answer.
- **`New Migrations` / `Executed Unavailable Migrations`** —
  `StatusCommand::getMigrationsInfos()` calls `array_keys()` on
  `getAvailableVersions()`, which returns a **list**. Both fields therefore diff
  version strings against the integers `0..n` and report the full count on every
  run. That is why the rig showed 204 and 205 with nothing wrong.
- `describeMigrationStep('lastest')` — the alias is misspelled in core. Harmless
  only by luck: `sortMigrations()` falls through to `strnatcmp`, and `Version…`
  sorts below `lastest`.

**The only honest pair in that output is `Executed` against `Available`.** 204 of
205 means one migration has not run, whatever the line below it says. That is now
written down in `lib/Migration/NAMING.md`, along with the recovery — bump and
`occ upgrade`, or `occ migrations:migrate openregister` (verified on the rig: it
ran the pending step and created the table). Both `migrations:*` commands need
`debug: true` in config.php or `occ` answers `Command "migrations:status" is not
defined`.

### The mechanical check

`scripts/check-migration-version-bump.php` fails when a branch adds a file under
`lib/Migration/` without moving `<version>` past its value at the merge base.
Committed, staged and untracked additions all count, and `--no-renames` is
deliberate: renaming an applied migration makes Nextcloud re-run it, which needs
a bump and a human.

It runs in **Merge Hygiene** (every push and PR, milliseconds), in
`composer check:strict`, and as a warning from `.githooks/pre-commit`.

It exits **2**, not 0, when it cannot resolve the base ref or parse `info.xml`.
A check that cannot see the base has no verdict to give, and a silent pass is
precisely the failure this removes.

Run against the real history that caused the incident (`--base=85e8321`) it reds
and names all four files.

### Tests, proven red

`tests/Unit/Migration/MigrationVersionBumpCheckTest.php` — 8 cases, each over a
purpose-built git repository, so a green is the check looking and finding
nothing rather than the branch happening to have no migrations: the defect, the
fix, a prerelease bump (`2.0.14-unstable.…` → `2.0.15-unstable.…`), a control
that edits other files and passes, a lowered version, an untracked migration,
an unresolvable base ref, and a non-repository.

Proven red by mutation, not by assertion:

| mutation | result |
|---|---|
| gate always passes | 3 failures |
| untracked files not collected | 1 failure |
| unresolvable base returns 0 | 1 failure |
| restored | OK (8 tests, 13 assertions) |

### The sweep

Same shape elsewhere — the fleet gating work on a version string a change can
forget to move:

- **Fixed already, at one layer.** The whole-configuration import skip is decided
  by a **content hash** now, not a version (`ImportHandler` ~L2147, #426). That is
  the sc#396 answer, already landed.
- **Still version-only.** The per-register and per-schema gates inside
  `ImportHandler` (L844, L998, L1873, L2872, L3491) compare versions with no
  content escape — the dossiq#1786 shape.
- **A hand-maintained duplicate that has already drifted.** Eight Repair steps
  pass a `REGISTER_VERSION` PHP constant to that gate. Three of the nine
  (descriptor, version) pairs disagree with the descriptor's own `info.version`:
  `ImportCredentialBrokerRegister` (const `1.0.0`, JSON `1.4.0`),
  and both `ImportDsarRegisters` entries (const `1.2.0`/`1.1.0`, JSON `1.0.0`).
  The constant is what gates; the JSON version is read by
  `RegisterDescriptorService::inventory()` for the admin panel, so the panel and
  the importer can disagree about which version an instance is on. Filed
  separately rather than folded in here — deciding which of those numbers is
  canonical is a design ruling, not a gate.

### Verified locally (CI is bottlenecked), by exit code

| check | exit |
|---|---|
| `composer lint` | 0 |
| `composer check:migration-version` | 0 |
| `composer phpcs` | 0 (74 files) |
| `composer psalm` | 0 |
| `composer phpstan` | 0 (1690 files, no errors) |
| `composer test:unit` | 19,200 tests, 46,881 assertions, **0 failures**, 43 skipped |
| new test file alone | OK (8 tests, 13 assertions) |
| `phpmd lib/Migration` | 0 |
| hydra gates `--scope-to-diff` (v1.15.1) | 0 — 21 applicable gates ran, all green |

`composer test:unit` exits 1 on this host for an environmental reason, not a
failure: PHPUnit's runner warning `No code coverage driver available` under
`failOnWarning`. Reproduced on an untouched pre-existing test file
(`tests/Unit/SearchControllerTest.php`, exit 1, same single warning, 0 failures).
CI has a coverage driver.

Not run locally: the Integration, Database and Service suites (they boot a
Nextcloud server) and Playwright.

Refs #3444

🤖 Generated with [Claude Code](https://claude.com/claude-code)
