### PR TITLE
fix(folders,locking): a system context is recognised, and PATCH answers the lock

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6872,16 +6872,16 @@
         },
         {
             "name": "conduction/hydra-gates",
-            "version": "v1.15.0",
+            "version": "v1.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ConductionNL/.github.git",
-                "reference": "0bc214023be78aac94142035a9988986cfccccbc"
+                "reference": "4db52393987b85957787e144bc82bfaf67f4860c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/0bc214023be78aac94142035a9988986cfccccbc",
-                "reference": "0bc214023be78aac94142035a9988986cfccccbc",
+                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/4db52393987b85957787e144bc82bfaf67f4860c",
+                "reference": "4db52393987b85957787e144bc82bfaf67f4860c",
                 "shasum": ""
             },
             "require": {
@@ -6920,9 +6920,9 @@
             "support": {
                 "docs": "https://github.com/ConductionNL/.github/blob/main/hydra-gates/README.md",
                 "issues": "https://github.com/ConductionNL/.github/issues",
-                "source": "https://github.com/ConductionNL/.github/tree/v1.15.0"
+                "source": "https://github.com/ConductionNL/.github/tree/v1.15.1"
             },
-            "time": "2026-09-04T16:24:04+00:00"
+            "time": "2026-09-05T12:26:12+00:00"
         },
         {
             "name": "consolidation/annotated-command",

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -909,6 +909,7 @@ class Application extends App implements IBootstrap {
 					groupManager: $container->get('OCP\IGroupManager'),
 					logger: $container->get('Psr\Log\LoggerInterface'),
 					auditTrailMapper: $container->get(\OCA\OpenRegister\Db\AuditTrailMapper::class),
+					mountCache: $container->get('OCP\Files\Config\IUserMountCache'),
 					fileService: null
 				);
 			}

--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -34,12 +34,14 @@ namespace OCA\OpenRegister\Controller;
 
 use DateTime;
 use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Exception\AppendOnlyException;
 use OCA\OpenRegister\Exception\CustomValidationException;
 use OCA\OpenRegister\Exception\ExportTooLargeException;
 use OCA\OpenRegister\Exception\FolderAccessDeniedException;
+use OCA\OpenRegister\Exception\LockedException;
 use OCA\OpenRegister\Exception\NotAuthorizedException;
 use OCA\OpenRegister\Exception\ReferentialIntegrityException;
 use OCA\OpenRegister\Controller\Trait\ResolvesRegisterAndSchemaTrait;
@@ -2709,6 +2711,13 @@ class ObjectsController extends Controller {
 				],
 				statusCode: 422
 			);
+		} catch (LockedException $exception) {
+			// A lock taken between this handler's pre-read and the save reaches
+			// here as the service-layer guard's typed refusal. Caught before
+			// generic \Exception so it answers 423 naming the holder rather
+			// than falling into the hardcoded 500 that made a locked PATCH
+			// look like a server fault.
+			return $this->lockedResponse(exception: $exception);
 		} catch (FolderAccessDeniedException $exception) {
 			// MUST be caught before generic \Exception to avoid being absorbed as a 403 with
 			// a non-structured body. See the `self-folder-access-control` capability spec.
@@ -2851,21 +2860,14 @@ class ObjectsController extends Controller {
 				return new JSONResponse(data: ['error' => 'Object not found in specified register/schema'], statusCode: 404);
 			}
 
-			// Check if the object is locked. This was the ONE live lock guard
-			// in the codebase, because it read the holder under the key
-			// `lock()` actually writes; the service-layer guard read a key
-			// that never existed. Both now delegate to the same predicate, so
-			// there is one comparison rather than two spellings of it.
-			if ($existingObject->isLockedBySomeoneElse(userId: $this->container->get('userId'), runUuid: $this->callerRunUuid()) === true) {
-				// Return a "locked" error naming the holder.
-				return new JSONResponse(
-					data: [
-						'error' => 'Object is locked by ' . (string)$existingObject->describeLockHolder(),
-						'lockedBy' => $existingObject->getLockedBy(),
-						'lockedByRun' => $existingObject->getLockedByRun(),
-					],
-					statusCode: 423
-				);
+			// Check if the object is locked. This used to be the ONE live lock
+			// guard in the codebase, written inline here; PATCH and POST-patch
+			// had none and answered 400 or 500 instead. The guard now lives in
+			// `lockRefusalResponse()` and all three doors call it, so there is
+			// one comparison and one refusal rather than three spellings.
+			$lockRefusal = $this->lockRefusalResponse(existingObject: $existingObject);
+			if ($lockRefusal !== null) {
+				return $lockRefusal;
 			}
 		} catch (DoesNotExistException $exception) {
 			return new JSONResponse(data: ['error' => 'Not Found'], statusCode: 404);
@@ -2970,6 +2972,13 @@ class ObjectsController extends Controller {
 				data: ['error' => $exception->getMessage(), 'errors' => $exception->getErrors()],
 				statusCode: 422
 			);
+		} catch (LockedException $exception) {
+			// A lock taken between this handler's pre-read and the save reaches
+			// here as the service-layer guard's typed refusal. Caught before
+			// generic \Exception so it answers 423 naming the holder rather
+			// than falling into the hardcoded 500 that made a locked PATCH
+			// look like a server fault.
+			return $this->lockedResponse(exception: $exception);
 		} catch (FolderAccessDeniedException $exception) {
 			// MUST be caught before generic \Exception. See `self-folder-access-control` spec.
 			return $this->folderAccessDeniedResponse(exception: $exception);
@@ -3099,6 +3108,16 @@ class ObjectsController extends Controller {
 				return new JSONResponse(data: ['error' => 'Object not found'], statusCode: 404);
 			}//end try
 
+			// The lock answers BEFORE the optimistic-concurrency check, before
+			// the merge and before validation, exactly as it does on PUT.
+			// Ordering is the whole point: a caller told their payload is
+			// invalid, or handed a bare 500, when the real answer is "alice
+			// holds this" has been sent to fix the wrong thing.
+			$lockRefusal = $this->lockRefusalResponse(existingObject: $existingObject);
+			if ($lockRefusal !== null) {
+				return $lockRefusal;
+			}
+
 			// Optimistic concurrency (fix-object-patch-lost-update): PATCH is a
 			// read-merge-write, so two concurrent PATCHes can silently clobber each
 			// other's untouched fields. A caller that read the object may pass the
@@ -3219,6 +3238,13 @@ class ObjectsController extends Controller {
 				data: ['error' => $exception->getMessage(), 'errors' => $exception->getErrors()],
 				statusCode: 422
 			);
+		} catch (LockedException $exception) {
+			// A lock taken between this handler's pre-read and the save reaches
+			// here as the service-layer guard's typed refusal. Caught before
+			// generic \Exception so it answers 423 naming the holder rather
+			// than falling into the hardcoded 500 that made a locked PATCH
+			// look like a server fault.
+			return $this->lockedResponse(exception: $exception);
 		} catch (FolderAccessDeniedException $exception) {
 			// MUST be caught before generic \Exception. See `self-folder-access-control` spec.
 			return $this->folderAccessDeniedResponse(exception: $exception);
@@ -3319,6 +3345,14 @@ class ObjectsController extends Controller {
 				return new JSONResponse(data: ['error' => 'Object not found'], statusCode: 404);
 			}
 
+			// The lock answers BEFORE the merge and before validation, exactly
+			// as it does on PUT. Reached through the same guard, so the two
+			// doors to one object cannot drift apart again.
+			$lockRefusal = $this->lockRefusalResponse(existingObject: $existingObject);
+			if ($lockRefusal !== null) {
+				return $lockRefusal;
+			}
+
 			// Merge existing data with patch data (patch semantics).
 			$existingData = $existingObject->getObject();
 			$mergedData = array_merge($existingData ?? [], $patchData);
@@ -3385,6 +3419,13 @@ class ObjectsController extends Controller {
 				data: ['error' => $exception->getMessage(), 'errors' => $exception->getErrors()],
 				statusCode: 422
 			);
+		} catch (LockedException $exception) {
+			// A lock taken between this handler's pre-read and the save reaches
+			// here as the service-layer guard's typed refusal. Caught before
+			// generic \Exception so it answers 423 naming the holder rather
+			// than falling into the hardcoded 500 that made a locked PATCH
+			// look like a server fault.
+			return $this->lockedResponse(exception: $exception);
 		} catch (FolderAccessDeniedException $exception) {
 			// MUST be caught before generic \Exception so a @self.folder
 			// denial on the post-patch path returns 403 with the structured
@@ -4899,4 +4940,77 @@ class ObjectsController extends Controller {
 
 		return $flowContext->currentRunUuid();
 	}//end callerRunUuid()
+
+	/**
+	 * Refuse a write to a locked object, or return null when it may proceed.
+	 *
+	 * ONE guard for all three write doors. PUT carried this inline and PATCH
+	 * and POST-patch carried nothing, so the two doors to the same object gave
+	 * two different answers: 423 naming the holder on PUT, and on PATCH
+	 * whatever the payload happened to produce first — 400 from validation, or
+	 * 500 when the payload was valid and the service-layer guard's untyped
+	 * exception fell through to the generic handler. Neither said anything
+	 * about a lock.
+	 *
+	 * The condition is not restated here: `isLockedBySomeoneElse()` is the
+	 * single predicate (openregister#3454), run identity reaches it ambiently
+	 * through `FlowRunContext::currentRunUuid()`, and the refusal itself is
+	 * built by `LockedException::forObject()` so the words and the holder
+	 * fields are the same wherever a lock refuses a write.
+	 *
+	 * Callers MUST invoke this immediately after the existence pre-read and
+	 * BEFORE merging, validating or saving. A caller who is told their payload
+	 * is malformed when the real answer is "someone else holds this" has been
+	 * sent to fix the wrong thing.
+	 *
+	 * @param ObjectEntity $existingObject The object as stored, from the pre-read.
+	 *
+	 * @return JSONResponse|null The 423 refusal, or null when the caller may write.
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-a-lock-refuses-a-write-and-names-its-holder
+	 */
+	private function lockRefusalResponse(ObjectEntity $existingObject): ?JSONResponse {
+		try {
+			$callerUserId = $this->container->get('userId');
+		} catch (NotFoundExceptionInterface|ContainerExceptionInterface $unavailable) {
+			// No resolvable caller identity. A user lock is held against
+			// "nobody" just as it is against anyone who is not the holder, so
+			// the predicate still answers correctly with a null user id.
+			$callerUserId = null;
+		}
+
+		if ($existingObject->isLockedBySomeoneElse(userId: $callerUserId, runUuid: $this->callerRunUuid()) === false) {
+			return null;
+		}
+
+		return $this->lockedResponse(exception: LockedException::forObject($existingObject));
+	}//end lockRefusalResponse()
+
+	/**
+	 * Render a lock refusal as the canonical 423 response body.
+	 *
+	 * Kept separate from `lockRefusalResponse()` so a catch site that receives
+	 * a `LockedException` thrown further down (the service-layer guard in
+	 * `SaveObject::findAndValidateExistingObject()`) answers with the SAME body
+	 * rather than a second spelling of it.
+	 *
+	 * The `error` string keeps the wording PUT has always returned, because
+	 * clients match on it.
+	 *
+	 * @param LockedException $exception The refusal carrying the holder.
+	 *
+	 * @return JSONResponse The 423 response naming the lock holder.
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-a-lock-refuses-a-write-and-names-its-holder
+	 */
+	private function lockedResponse(LockedException $exception): JSONResponse {
+		return new JSONResponse(
+			data: [
+				'error' => 'Object is locked by ' . (string)$exception->getHolder(),
+				'lockedBy' => $exception->getLockedBy(),
+				'lockedByRun' => $exception->getLockedByRun(),
+			],
+			statusCode: LockedException::HTTP_STATUS
+		);
+	}//end lockedResponse()
 }//end class

--- a/lib/Controller/Trait/HandlesExceptionsTrait.php
+++ b/lib/Controller/Trait/HandlesExceptionsTrait.php
@@ -127,6 +127,10 @@ trait HandlesExceptionsTrait {
 		// Forbidden → 403.
 		NotAuthorizedException::class => Http::STATUS_FORBIDDEN,
 		FolderAccessDeniedException::class => Http::STATUS_FORBIDDEN,
+		// Locked → 423. Untyped before this, so a lock refusal thrown from the
+		// service layer reached the generic 500 handler and told the caller
+		// nothing about the lock.
+		\OCA\OpenRegister\Exception\LockedException::class => Http::STATUS_LOCKED,
 		// Validation → 422 typed / 400 argument-shaped.
 		ValidationException::class => Http::STATUS_UNPROCESSABLE_ENTITY,
 		\OCA\OpenRegister\Exception\CustomValidationException::class => Http::STATUS_UNPROCESSABLE_ENTITY,

--- a/lib/Exception/LockedException.php
+++ b/lib/Exception/LockedException.php
@@ -23,6 +23,7 @@
 namespace OCA\OpenRegister\Exception;
 
 use Exception;
+use OCA\OpenRegister\Db\ObjectEntity;
 use Throwable;
 
 /**
@@ -44,6 +45,104 @@ use Throwable;
  * @link https://OpenRegister.app
  */
 class LockedException extends Exception {
+
+	/**
+	 * The HTTP status controllers MUST map this exception to.
+	 *
+	 * A constant rather than the exception's `code` for the same reason
+	 * `FolderAccessDeniedException::HTTP_STATUS` is one: `getCode()` is an
+	 * application error code, not an HTTP status. The constructor's legacy
+	 * `$code = 423` default is left alone so nothing reading `getCode()`
+	 * changes underneath it.
+	 *
+	 * @var integer
+	 */
+	public const HTTP_STATUS = 423;
+
+	/**
+	 * The user holding the lock, when a person holds it.
+	 *
+	 * @var string|null
+	 */
+	private ?string $lockedBy = null;
+
+	/**
+	 * The flow run holding the lock, when a run holds it.
+	 *
+	 * @var string|null
+	 */
+	private ?string $lockedByRun = null;
+
+	/**
+	 * The holder description used in the message.
+	 *
+	 * @var string|null
+	 */
+	private ?string $holder = null;
+
+	/**
+	 * Build the canonical refusal for an object a caller may not write.
+	 *
+	 * The refusal is built HERE, from `ObjectEntity`'s own accessors, so that
+	 * every guard refuses in the same words and names the same holder. Before
+	 * this, PUT built the message and the holder fields inline in the
+	 * controller while the service-layer guard built a different sentence and
+	 * carried no holder at all, so the two doors to the same object answered
+	 * differently: 423 naming the holder on one, 400 or 500 naming nothing on
+	 * the other.
+	 *
+	 * The CONDITION is not restated here — callers ask
+	 * `ObjectEntity::isLockedBySomeoneElse()` and, only once it has said yes,
+	 * ask this factory for the refusal.
+	 *
+	 * @param ObjectEntity $object The locked object, already found to be locked against the caller.
+	 *
+	 * @return self The refusal carrying the holder.
+	 *
+	 * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md#requirement-a-lock-refuses-a-write-and-names-its-holder
+	 */
+	public static function forObject(ObjectEntity $object): self {
+		$holder = (string)$object->describeLockHolder();
+
+		$exception = new self(
+			message: 'Cannot update object: Object is locked by ' . $holder
+				. '. Please unlock the object before attempting to update it.'
+		);
+
+		$exception->lockedBy = $object->getLockedBy();
+		$exception->lockedByRun = $object->getLockedByRun();
+		$exception->holder = $holder;
+
+		return $exception;
+	}//end forObject()
+
+	/**
+	 * Get the user holding the lock, when a person holds it.
+	 *
+	 * @return string|null The holding user id, or null when a run holds it.
+	 */
+	public function getLockedBy(): ?string {
+		return $this->lockedBy;
+	}//end getLockedBy()
+
+	/**
+	 * Get the flow run holding the lock, when a run holds it.
+	 *
+	 * @return string|null The holding run uuid, or null when a person holds it.
+	 */
+	public function getLockedByRun(): ?string {
+		return $this->lockedByRun;
+	}//end getLockedByRun()
+
+	/**
+	 * Get the human-readable holder description.
+	 *
+	 * @return string|null The holder description, or null when not built by `forObject()`.
+	 */
+	public function getHolder(): ?string {
+		return $this->holder;
+	}//end getHolder()
+
 	/**
 	 * Constructor for LockedException
 	 *

--- a/lib/Service/File/FolderManagementHandler.php
+++ b/lib/Service/File/FolderManagementHandler.php
@@ -30,6 +30,8 @@ use OCA\OpenRegister\Db\Register;
 use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Exception\FolderAccessDeniedException;
 use OCA\OpenRegister\Service\FileService;
+use OCA\OpenRegister\Service\SystemOperationContext;
+use OCP\Files\Config\IUserMountCache;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
@@ -92,6 +94,8 @@ class FolderManagementHandler {
 	 * @param IGroupManager $groupManager Group manager for group operations.
 	 * @param LoggerInterface $logger Logger for logging operations.
 	 * @param AuditTrailMapper $auditTrailMapper Mapper for writing forensic audit-trail entries on folder-access denials.
+	 * @param IUserMountCache $mountCache Mount cache, used to recognise a folder OpenRegister manages
+	 *                                    without setting up the owning user's mounts.
 	 * @param FileService|null $fileService File service facade for cross-handler coordination
 	 *                                      (injected lazily to avoid circular dependency).
 	 */
@@ -103,6 +107,7 @@ class FolderManagementHandler {
 		private readonly IGroupManager $groupManager,
 		private readonly LoggerInterface $logger,
 		private readonly AuditTrailMapper $auditTrailMapper,
+		private readonly IUserMountCache $mountCache,
 		private ?FileService $fileService = null,
 	) {
 	}//end __construct()
@@ -856,6 +861,14 @@ class FolderManagementHandler {
 	 * callers from the OpenRegister codebase MUST invoke this method as-is;
 	 * if a different access-check policy is needed, introduce a new method
 	 * rather than overriding this one.
+	 *
+	 * @spec openspec/specs/self-folder-access-control/spec.md
+	 *
+	 * @SuppressWarnings(PHPMD.StaticAccess) SystemOperationContext::isActive is a
+	 * process-scoped flag with no instance to inject; it is deliberately static so
+	 * the scope cannot be entered from request data. Annotated here with its reason
+	 * rather than added to phpmd.baseline.xml, where the same call in
+	 * MultiTenancyTrait and PermissionHandler is invisible.
 	 */
 	final public function assertFolderIsAccessible(
 		string $folderId,
@@ -863,6 +876,24 @@ class FolderManagementHandler {
 		ObjectEntity|string|null $objectEntity = null,
 	): Folder {
 		$actingUser = $currentUser ?? $this->getCurrentUser();
+
+		// A system operation has no user by definition, and until now that was
+		// indistinguishable here from an anonymous request. Both landed on the
+		// default-deny below, so a repair step or cron job saving an object
+		// with a bound folder could not run at all: the step caught the denial,
+		// logged "could not run", and `occ upgrade` still reported success.
+		//
+		// The scope is entered from PHP code only (never from request data) —
+		// the same signal `MultiTenancyTrait::hasRbacPermission()` and
+		// `PermissionHandler::hasPermission()` already trust for exactly this
+		// reason. Recognising it resolves the app's OWN principal and then runs
+		// the SAME four checks below against that principal's mount. The guard
+		// is not skipped and not widened: an anonymous request still has no
+		// principal to resolve and still falls through to the denial.
+		if ($actingUser === null && SystemOperationContext::isActive() === true) {
+			$actingUser = $this->resolveSystemPrincipal();
+		}
+
 		if ($actingUser === null) {
 			$this->logFolderAccessDenied(
 				folderId: $folderId,
@@ -922,6 +953,179 @@ class FolderManagementHandler {
 
 		return $node;
 	}//end assertFolderIsAccessible()
+
+	/**
+	 * Resolve the OpenRegister system principal for a sessionless system operation.
+	 *
+	 * Deliberately NOT `getUser()`: that helper prefers the session user and
+	 * only falls back to the system account, which is the right precedence for
+	 * file operations on behalf of a caller and the wrong one here. This method
+	 * is reached only when there is no session user at all, so it asks for the
+	 * app's own account directly.
+	 *
+	 * Returns null rather than throwing when the account cannot be resolved, so
+	 * the caller falls through to its own default-deny instead of replacing a
+	 * denial with a different exception.
+	 *
+	 * @return IUser|null The OpenRegister system account, or null when it cannot be resolved.
+	 *
+	 * @psalm-return   IUser|null
+	 * @phpstan-return IUser|null
+	 */
+	private function resolveSystemPrincipal(): ?IUser {
+		if ($this->fileService === null) {
+			return null;
+		}
+
+		try {
+			return $this->fileService->getUser();
+		} catch (Exception $e) {
+			$this->logger->warning(
+				message: '[FolderManagementHandler] System principal unavailable: ' . $e->getMessage(),
+				context: ['file' => __FILE__, 'line' => __LINE__]
+			);
+			return null;
+		}
+	}//end resolveSystemPrincipal()
+
+	/**
+	 * Re-validate a binding OpenRegister itself stored, rather than one a caller supplied.
+	 *
+	 * `assertFolderIsAccessible()` answers "can the acting user read this node
+	 * through their own mount?", which is the right question for a
+	 * caller-supplied `@self.folder`: the caller names an arbitrary node id and
+	 * must prove they can already reach it, or a bind becomes a cross-tenant
+	 * escape hatch.
+	 *
+	 * It is the WRONG question for a value the app wrote itself. An object
+	 * folder is created under `Open Registers/` in whichever home the creating
+	 * identity had — `getOpenRegisterUserFolder()` resolves the session user
+	 * when there is one — and the compensating share back to other readers is
+	 * still a TODO. So the stored binding lands in ONE user's mount and nobody
+	 * else's, and re-validating it on every save asks every later editor to
+	 * prove they were the creator. Measured: a second user editing a colleague's
+	 * case is refused `folder_access_denied` / 403 on both PUT and PATCH, and a
+	 * repair step is refused the same way.
+	 *
+	 * This method therefore asks the question that fits a stored binding: is
+	 * this a folder OpenRegister manages? Only when the answer is no does the
+	 * full acting-user check run, and a binding that points anywhere outside
+	 * `Open Registers/` is still refused by it — which is exactly the planted
+	 * cross-tenant binding the re-validation was added (PR #1431) to catch,
+	 * since such a binding names a node in a private home.
+	 *
+	 * Known and accepted: a user may create a folder literally named
+	 * `Open Registers` in their own home and bind their own object inside it,
+	 * and that binding then reads as managed. It grants nothing — this method
+	 * decides whether a SAVE proceeds, not whether any file becomes readable;
+	 * file listing goes through the acting user's own mount and still shows
+	 * nothing. Passing the caller-supplied gate to create such a binding
+	 * already required the caller to be able to read that folder.
+	 *
+	 * @param string $folderId The stored numeric folder ID.
+	 * @param IUser|null $currentUser Explicit acting user; falls back to session resolution.
+	 * @param ObjectEntity|string|null $objectEntity Object the binding belongs to (audit context).
+	 *
+	 * @return void Nothing: this is an assertion, not a lookup. Handing back a
+	 *              `Folder` the acting user may not read would be the escape
+	 *              hatch the guard exists to close.
+	 *
+	 * @throws FolderAccessDeniedException When the binding is neither an OpenRegister-managed
+	 *                                     folder nor readable by the acting user.
+	 *
+	 * @internal `final` for the same reason `assertFolderIsAccessible()` is: the
+	 * default-deny invariant must not be weakenable by a subclass.
+	 *
+	 * @spec openspec/specs/self-folder-access-control/spec.md
+	 */
+	final public function assertManagedFolderIsAccessible(
+		string $folderId,
+		?IUser $currentUser = null,
+		ObjectEntity|string|null $objectEntity = null,
+	): void {
+		// The managed-tree question is asked FIRST, and not only because it is
+		// the cheaper one. `assertFolderIsAccessible()` writes a
+		// `folder_access_denied` audit row before every throw, so asking it
+		// first would stamp a denial into the forensic record for each save
+		// this method then goes on to ALLOW — an audit trail that reports
+		// refusals that never happened is worse than no audit at all.
+		//
+		// Nothing is lost by the order: a managed folder is accepted either
+		// way, and anything else still falls through to the full check below,
+		// which denies and audits exactly as it always did.
+		if ($this->isManagedFolder(folderId: $folderId) === true) {
+			return;
+		}
+
+		$this->assertFolderIsAccessible(
+			folderId: $folderId,
+			currentUser: $currentUser,
+			objectEntity: $objectEntity
+		);
+	}//end assertManagedFolderIsAccessible()
+
+	/**
+	 * Whether a folder id names a folder OpenRegister manages.
+	 *
+	 * Answered from the mount cache, NOT from `IRootFolder::getById()`. The
+	 * root-folder lookup returns nothing here: it needs the owning user's
+	 * mounts to have been set up, and the whole reason this method exists is
+	 * that the owner is somebody other than the acting user. Measured on the
+	 * rig — `getById()` on a folder that demonstrably exists answered `0`.
+	 *
+	 * `IUserMountCache::getMountsForFileId()` reads the cache directly, so it
+	 * resolves the node's home and internal path without mounting anything and
+	 * without granting the acting user any view of it. Nothing is returned:
+	 * this is a predicate, not a lookup, and handing back a `Folder` the caller
+	 * has no business reading would be exactly the escape hatch the guard
+	 * exists to close.
+	 *
+	 * @param string $folderId The stored numeric folder ID.
+	 *
+	 * @return bool True when the id names a folder inside an `Open Registers` tree.
+	 */
+	private function isManagedFolder(string $folderId): bool {
+		if (ctype_digit($folderId) === false) {
+			return false;
+		}
+
+		try {
+			$mounts = $this->mountCache->getMountsForFileId((int)$folderId);
+		} catch (Exception $e) {
+			$this->logger->debug(
+				message: '[FolderManagementHandler] Managed-folder lookup failed for ' . $folderId . ': ' . $e->getMessage(),
+				context: ['file' => __FILE__, 'line' => __LINE__]
+			);
+			return false;
+		}
+
+		foreach ($mounts as $mount) {
+			if ($this->isManagedFolderPath(path: $mount->getPath()) === true) {
+				return true;
+			}
+		}
+
+		return false;
+	}//end isManagedFolder()
+
+	/**
+	 * Whether a node path lies inside an OpenRegister-managed folder tree.
+	 *
+	 * Nextcloud node paths are `/<uid>/files/<path inside the home>`, so a
+	 * managed folder is `/<uid>/files/Open Registers` or anything beneath it.
+	 * The `<uid>` is deliberately unconstrained: object folders are created in
+	 * whichever home the creating identity had, so pinning it to the system
+	 * account would reject every folder created over HTTP.
+	 *
+	 * @param string $path The node path to test.
+	 *
+	 * @return bool True when the path is inside an `Open Registers` tree.
+	 */
+	private function isManagedFolderPath(string $path): bool {
+		$pattern = '#^/[^/]+/files/' . preg_quote(self::ROOT_FOLDER, '#') . '(/|$)#';
+
+		return preg_match($pattern, $path) === 1;
+	}//end isManagedFolderPath()
 
 	/**
 	 * Write a `folder_access_denied` entry to the audit trail.

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -872,23 +872,21 @@ class FileService {
 	 * saves that don't touch `@self.folder` because `setSelfMetadata`
 	 * only fires when `@self.folder` is present in the write payload.
 	 *
-	 * Re-running `assertFolderIsAccessible` on every save through
-	 * `ensureObjectFolder` makes the check apply uniformly. A
-	 * denial throws `FolderAccessDeniedException` (HTTP 403) at the
-	 * controller layer.
+	 * Re-running the check on every save through `ensureObjectFolder`
+	 * makes it apply uniformly. A denial throws
+	 * `FolderAccessDeniedException` (HTTP 403) at the controller layer.
 	 *
 	 * No-op when the object has no folder bound or the bound value
 	 * is non-numeric (legacy path-style folder, handled by the
 	 * auto-create branch in ensureObjectFolder).
 	 *
 	 * **Acting user resolution.** `$currentUser` is forwarded verbatim
-	 * to `assertFolderIsAccessible` and follows that method's
-	 * documented precedence: when non-null it is used as-is, otherwise
-	 * `IUserSession::getUser()` is consulted, otherwise the bind is
-	 * denied. Non-HTTP callers (cron, import pipelines, event listeners)
-	 * MUST pass an explicit `$currentUser` to avoid the
-	 * session-user-is-null → default-deny path; HTTP callers can omit
-	 * the argument and rely on session resolution.
+	 * and follows the documented precedence: when non-null it is used
+	 * as-is, otherwise `IUserSession::getUser()` is consulted, otherwise
+	 * the app's own principal is resolved when a system-operation scope
+	 * is active. Non-HTTP callers SHOULD still pass an explicit
+	 * `$currentUser` where they have one, so the check runs against the
+	 * identity the work is being done for rather than the app account.
 	 *
 	 * @param ObjectEntity $object The existing object whose folder must be re-validated.
 	 * @param IUser|null $currentUser Explicit acting user; falls back to session resolution.
@@ -896,6 +894,8 @@ class FileService {
 	 * @return void
 	 *
 	 * @throws \OCA\OpenRegister\Exception\FolderAccessDeniedException When the acting user cannot access the bound folder.
+	 *
+	 * @spec openspec/specs/self-folder-access-control/spec.md
 	 */
 	public function assertObjectFolderAccessible(ObjectEntity $object, ?IUser $currentUser = null): void {
 		$folder = $object->getFolder();
@@ -913,7 +913,16 @@ class FileService {
 			return;
 		}
 
-		$this->folderManagementHandler->assertFolderIsAccessible(
+		// `assertManagedFolderIsAccessible`, NOT `assertFolderIsAccessible`. The
+		// value being re-validated was written by OpenRegister, not supplied by
+		// this caller, so the question is whether it is a folder OpenRegister
+		// manages — not whether this particular user happens to be the one who
+		// created it. Asking the caller-supplied question here refused every
+		// later editor of a colleague's object and every sessionless repair
+		// step. The acting user's own mount is still tried first, and a binding
+		// pointing outside `Open Registers/` is still refused; see that method
+		// for the full rationale and the accepted residual case.
+		$this->folderManagementHandler->assertManagedFolderIsAccessible(
 			folderId: (string)$folder,
 			currentUser: $currentUser,
 			objectEntity: $object

--- a/lib/Service/Object/SaveObject.php
+++ b/lib/Service/Object/SaveObject.php
@@ -43,6 +43,7 @@ use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Event\ReferenceValidatedEvent;
 use OCA\OpenRegister\Event\ReferenceValidationFailedEvent;
 use OCA\OpenRegister\Exception\CircularReferenceException;
+use OCA\OpenRegister\Exception\LockedException;
 use OCA\OpenRegister\Exception\ObjectExistsException;
 use OCA\OpenRegister\Exception\ReferenceValidationException;
 use OCA\OpenRegister\Exception\ValidationException;
@@ -3209,10 +3210,13 @@ class SaveObject {
 			// answer a run lock already gives.
 			$callerRun = $this->runContext?->currentRunUuid();
 
+			// A TYPED refusal, not a plain `Exception`. The message is unchanged,
+			// but the type is what lets a caller answer 423 instead of falling
+			// into a generic 500 — which is what PATCH and POST-patch did for a
+			// payload that was otherwise valid. The holder travels on the
+			// exception rather than being re-derived at each catch site.
 			if ($existingObject->isLockedBySomeoneElse(userId: $currentUserId, runUuid: $callerRun) === true) {
-				$holder = (string)$existingObject->describeLockHolder();
-				$unlockAdvice = 'Please unlock the object before attempting to update it.';
-				throw new Exception("Cannot update object: Object is locked by {$holder}. " . $unlockAdvice);
+				throw LockedException::forObject($existingObject);
 			}
 
 			return $existingObject;

--- a/tests/Unit/Controller/ObjectsControllerTest.php
+++ b/tests/Unit/Controller/ObjectsControllerTest.php
@@ -2736,6 +2736,85 @@ class ObjectsControllerTest extends TestCase {
 	}
 
 	// =========================================================================
+	// update() / patch() / postPatch() — one lock, one refusal
+	// =========================================================================
+
+	/**
+	 * Build a locked object and the mocks all three write doors need.
+	 *
+	 * @param string $holder The user holding the lock.
+	 *
+	 * @return \OCA\OpenRegister\Db\ObjectEntity The locked object the pre-read returns.
+	 */
+	private function arrangeLockedObject(string $holder): \OCA\OpenRegister\Db\ObjectEntity {
+		$this->setupAdminUser();
+
+		$existingObject = new \OCA\OpenRegister\Db\ObjectEntity();
+		$existingObject->setUuid('uuid-123');
+		$existingObject->setRegister(1);
+		$existingObject->setSchema(2);
+		$existingObject->setObject(['title' => 'Old']);
+		$existingObject->setLocked([
+			'user' => $holder,
+			'expiration' => (new \DateTime('+1 hour'))->format('c'),
+			'process' => 'editing',
+		]);
+
+		$this->request->method('getParams')->willReturn(['title' => 'Updated']);
+		$this->request->method('getHeader')->willReturn('application/json');
+		$this->objectService->method('setRegister')->willReturnSelf();
+		$this->objectService->method('setSchema')->willReturnSelf();
+		$this->objectService->method('getRegister')->willReturn(1);
+		$this->objectService->method('getSchema')->willReturn(2);
+		$this->objectService->method('findSilent')->willReturn($existingObject);
+		$this->container->method('get')->willReturn('current-user');
+
+		return $existingObject;
+	}//end arrangeLockedObject()
+
+	/**
+	 * PUT, PATCH and POST-patch refuse a locked object IDENTICALLY.
+	 *
+	 * The asymmetry this pins: PUT answered 423 naming the holder while PATCH
+	 * and POST-patch reached validation first and answered 400 for a malformed
+	 * payload, or a bare 500 for a valid one — neither mentioning the lock.
+	 * Two doors to the same object gave two different answers, and the wrong
+	 * one sent the caller off to fix their payload.
+	 *
+	 * The comparison is on the WHOLE response (status and body together), so a
+	 * future divergence in either half fails here rather than being averaged
+	 * away by three separate assertions.
+	 *
+	 * `saveObject` is deliberately left unstubbed: reaching it at all means the
+	 * lock did not answer first.
+	 */
+	public function testAllThreeWriteDoorsRefuseALockedObjectIdentically(): void {
+		$this->arrangeLockedObject(holder: 'other-user');
+
+		$put = $this->controller->update('1', '2', 'uuid-123', $this->objectService);
+		$patch = $this->controller->patch('1', '2', 'uuid-123', $this->objectService);
+		$postPatch = $this->controller->postPatch('1', '2', 'uuid-123', $this->objectService);
+
+		$this->assertSame(423, $put->getStatus(), 'PUT must refuse a locked object with 423');
+		$this->assertSame(
+			[$put->getStatus(), $put->getData()],
+			[$patch->getStatus(), $patch->getData()],
+			'PATCH must give the SAME refusal as PUT'
+		);
+		$this->assertSame(
+			[$put->getStatus(), $put->getData()],
+			[$postPatch->getStatus(), $postPatch->getData()],
+			'POST-patch must give the SAME refusal as PUT'
+		);
+
+		// And that shared refusal must NAME the holder, not merely say "locked".
+		$body = $put->getData();
+		$this->assertSame('other-user', $body['lockedBy']);
+		$this->assertStringContainsString('other-user', (string)$body['error']);
+		$this->assertNull($body['lockedByRun']);
+	}//end testAllThreeWriteDoorsRefuseALockedObjectIdentically()
+
+	// =========================================================================
 	// update() — findSilent throws generic exception returns 500
 	// =========================================================================
 

--- a/tests/Unit/Service/File/FolderManagementHandlerAccessControlTest.php
+++ b/tests/Unit/Service/File/FolderManagementHandlerAccessControlTest.php
@@ -28,6 +28,7 @@ use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Exception\FolderAccessDeniedException;
 use OCA\OpenRegister\Service\File\FolderManagementHandler;
 use OCP\Files\File;
+use OCP\Files\Config\IUserMountCache;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\IGroupManager;
@@ -77,6 +78,11 @@ class FolderManagementHandlerAccessControlTest extends TestCase {
 	 */
 	private AuditTrailMapper $auditTrailMapper;
 
+	/**
+	 * @var IUserMountCache&MockObject
+	 */
+	private IUserMountCache $mountCache;
+
 	private FolderManagementHandler $handler;
 
 	protected function setUp(): void {
@@ -89,6 +95,7 @@ class FolderManagementHandlerAccessControlTest extends TestCase {
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->auditTrailMapper = $this->createMock(AuditTrailMapper::class);
+		$this->mountCache = $this->createMock(IUserMountCache::class);
 
 		$this->handler = new FolderManagementHandler(
 			rootFolder: $this->rootFolder,
@@ -97,7 +104,8 @@ class FolderManagementHandlerAccessControlTest extends TestCase {
 			userSession: $this->userSession,
 			groupManager: $this->groupManager,
 			logger: $this->logger,
-			auditTrailMapper: $this->auditTrailMapper
+			auditTrailMapper: $this->auditTrailMapper,
+			mountCache: $this->mountCache
 		);
 
 	}//end setUp()

--- a/tests/Unit/Service/File/FolderManagementHandlerSystemContextTest.php
+++ b/tests/Unit/Service/File/FolderManagementHandlerSystemContextTest.php
@@ -1,0 +1,318 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Tests for the two questions `FolderManagementHandler` asks about a folder.
+ *
+ * `assertFolderIsAccessible()` answers "can the acting user read this?", which
+ * is right for a caller-supplied `@self.folder`. Two callers could never get a
+ * useful answer out of it:
+ *
+ *  - a repair step or cron job, which has no `IUser` at all and so hit the
+ *    default-deny, and
+ *  - any user re-saving an object whose folder somebody else created, because
+ *    the folder lives in the creator's home and nobody else's.
+ *
+ * Both failed silently: the step caught the denial and logged "could not run"
+ * while `occ upgrade` reported success, and the user got a bare 403.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service\File
+ *
+ * @spec openspec/changes/validate-self-folder-access/specs/self-folder-access-control/spec.md
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Service\File;
+
+use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Exception\FolderAccessDeniedException;
+use OCA\OpenRegister\Service\File\FolderManagementHandler;
+use OCA\OpenRegister\Service\FileService;
+use OCA\OpenRegister\Service\SystemOperationContext;
+use OCP\Files\Config\ICachedMountFileInfo;
+use OCP\Files\Config\IUserMountCache;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * System-context recognition and managed-folder re-validation.
+ */
+class FolderManagementHandlerSystemContextTest extends TestCase {
+
+	/**
+	 * @var IRootFolder&MockObject
+	 */
+	private IRootFolder $rootFolder;
+
+	/**
+	 * @var IUserSession&MockObject
+	 */
+	private IUserSession $userSession;
+
+	/**
+	 * @var IUserMountCache&MockObject
+	 */
+	private IUserMountCache $mountCache;
+
+	/**
+	 * @var AuditTrailMapper&MockObject
+	 */
+	private AuditTrailMapper $auditTrailMapper;
+
+	/**
+	 * @var FileService&MockObject
+	 */
+	private FileService $fileService;
+
+	private FolderManagementHandler $handler;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->rootFolder = $this->createMock(IRootFolder::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->mountCache = $this->createMock(IUserMountCache::class);
+		$this->auditTrailMapper = $this->createMock(AuditTrailMapper::class);
+		$this->fileService = $this->createMock(FileService::class);
+
+		$this->handler = new FolderManagementHandler(
+			rootFolder: $this->rootFolder,
+			objectEntityMapper: $this->createMock(MagicMapper::class),
+			registerMapper: $this->createMock(RegisterMapper::class),
+			userSession: $this->userSession,
+			groupManager: $this->createMock(IGroupManager::class),
+			logger: $this->createMock(LoggerInterface::class),
+			auditTrailMapper: $this->auditTrailMapper,
+			mountCache: $this->mountCache
+		);
+		$this->handler->setFileService($this->fileService);
+
+	}//end setUp()
+
+	/**
+	 * Build a user mock with the given UID.
+	 *
+	 * @param string $uid The user identifier.
+	 *
+	 * @return IUser&MockObject
+	 */
+	private function makeUser(string $uid): IUser {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+
+		return $user;
+	}//end makeUser()
+
+	/**
+	 * Wire a user-folder lookup for one UID.
+	 *
+	 * @param string $uid The UID whose home is being mocked.
+	 * @param integer $folderId The id the lookup is asked for.
+	 * @param array $nodes The nodes the lookup resolves to.
+	 *
+	 * @return void
+	 */
+	private function mockUserFolderLookup(string $uid, int $folderId, array $nodes): void {
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('getById')->with($folderId)->willReturn($nodes);
+		$this->rootFolder->method('getUserFolder')->with($uid)->willReturn($userFolder);
+
+	}//end mockUserFolderLookup()
+
+	/**
+	 * Wire the mount cache to report one mount path for a file id.
+	 *
+	 * @param integer $folderId The file id.
+	 * @param string $path The path the mount cache reports.
+	 *
+	 * @return void
+	 */
+	private function mockMountPath(int $folderId, string $path): void {
+		$mount = $this->createMock(ICachedMountFileInfo::class);
+		$mount->method('getPath')->willReturn($path);
+		$this->mountCache->method('getMountsForFileId')->with($folderId)->willReturn([$mount]);
+
+	}//end mockMountPath()
+
+	/**
+	 * Build a bare object entity carrying a folder binding.
+	 *
+	 * @param string $folder The bound folder id.
+	 *
+	 * @return ObjectEntity
+	 */
+	private function makeObjectEntity(string $folder): ObjectEntity {
+		$entity = new ObjectEntity();
+		$entity->setUuid('uuid-system-context');
+		$entity->setRegister('1');
+		$entity->setSchema('1');
+		$entity->setFolder($folder);
+
+		return $entity;
+	}//end makeObjectEntity()
+
+	/**
+	 * A sessionless system operation resolves the app's own principal.
+	 *
+	 * This is the repair step / cron case. There is no `IUser`, so before the
+	 * fix this landed on the default-deny and the step could not run at all.
+	 */
+	public function testSystemContextResolvesTheAppPrincipal(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->fileService->method('getUser')->willReturn($this->makeUser('openregister'));
+
+		$folder = $this->createMock(Folder::class);
+		$folder->method('isReadable')->willReturn(true);
+		$this->mockUserFolderLookup(uid: 'openregister', folderId: 42, nodes: [$folder]);
+
+		$this->auditTrailMapper->expects($this->never())->method('insert');
+
+		$resolved = SystemOperationContext::run(
+			fn (): Folder => $this->handler->assertFolderIsAccessible(folderId: '42')
+		);
+
+		$this->assertSame($folder, $resolved);
+
+	}//end testSystemContextResolvesTheAppPrincipal()
+
+	/**
+	 * The guard is recognised, not skipped: the app principal is still checked.
+	 *
+	 * A system context that names a folder its own principal cannot read is
+	 * refused exactly as any other caller would be — this is what separates
+	 * "recognise the context" from "stop checking".
+	 */
+	public function testSystemContextStillChecksTheFolder(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->fileService->method('getUser')->willReturn($this->makeUser('openregister'));
+
+		$this->mockUserFolderLookup(uid: 'openregister', folderId: 77, nodes: []);
+
+		$this->auditTrailMapper->expects($this->once())->method('insert');
+		$this->expectException(FolderAccessDeniedException::class);
+
+		SystemOperationContext::run(
+			fn (): Folder => $this->handler->assertFolderIsAccessible(folderId: '77')
+		);
+
+	}//end testSystemContextStillChecksTheFolder()
+
+	/**
+	 * OUTSIDE a system scope, a userless caller is still denied.
+	 *
+	 * The control for the two tests above. An anonymous request has no
+	 * principal to resolve and must keep landing on the default-deny; if this
+	 * ever goes green by accident, the recognition has become a blanket
+	 * exemption.
+	 */
+	public function testUserlessRequestOutsideASystemScopeIsStillDenied(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->fileService->expects($this->never())->method('getUser');
+
+		$this->auditTrailMapper->expects($this->once())->method('insert');
+		$this->expectException(FolderAccessDeniedException::class);
+
+		$this->handler->assertFolderIsAccessible(folderId: '42');
+
+	}//end testUserlessRequestOutsideASystemScopeIsStillDenied()
+
+	/**
+	 * A stored binding into OpenRegister's own tree admits a non-creating user.
+	 *
+	 * Bob cannot read the folder through his own home — it was created in
+	 * alice's — but it is a folder OpenRegister manages, so re-validating the
+	 * binding must not refuse his write.
+	 */
+	public function testManagedBindingAdmitsAUserWhoDidNotCreateIt(): void {
+		$this->userSession->method('getUser')->willReturn($this->makeUser('bob'));
+		$this->mockMountPath(folderId: 167, path: '/alice/files/Open Registers/Cases Register/case-1');
+
+		$this->handler->assertManagedFolderIsAccessible(
+			folderId: '167',
+			objectEntity: $this->makeObjectEntity('167')
+		);
+
+		// No exception is the assertion; make it explicit for the reader.
+		$this->addToAssertionCount(1);
+
+	}//end testManagedBindingAdmitsAUserWhoDidNotCreateIt()
+
+	/**
+	 * A stored binding OUTSIDE the managed tree is still refused.
+	 *
+	 * This is the planted cross-tenant binding the re-validation exists to
+	 * catch: it names a node in somebody's private home, which is precisely
+	 * what the managed-tree test does not match.
+	 */
+	public function testBindingOutsideTheManagedTreeIsStillRefused(): void {
+		$this->userSession->method('getUser')->willReturn($this->makeUser('bob'));
+		$this->mockUserFolderLookup(uid: 'bob', folderId: 242, nodes: []);
+		$this->mockMountPath(folderId: 242, path: '/alice/files/Secret');
+
+		$this->expectException(FolderAccessDeniedException::class);
+
+		$this->handler->assertManagedFolderIsAccessible(
+			folderId: '242',
+			objectEntity: $this->makeObjectEntity('242')
+		);
+
+	}//end testBindingOutsideTheManagedTreeIsStillRefused()
+
+	/**
+	 * An ACCEPTED save writes no `folder_access_denied` audit row.
+	 *
+	 * `assertFolderIsAccessible()` audits before every throw, so the
+	 * managed-tree question has to be asked first: asking it second would
+	 * record a denial for each save this method then goes on to allow, and an
+	 * audit trail that reports refusals which never happened is worse than
+	 * none. Bob is not the creator and cannot read the folder through his own
+	 * home, so this is exactly the case that would have left the false row.
+	 */
+	public function testAnAcceptedManagedBindingWritesNoDenialAudit(): void {
+		$this->userSession->method('getUser')->willReturn($this->makeUser('bob'));
+		$this->mockMountPath(folderId: 167, path: '/alice/files/Open Registers/Cases Register/case-1');
+
+		$this->auditTrailMapper->expects($this->never())->method('insert');
+
+		$this->handler->assertManagedFolderIsAccessible(
+			folderId: '167',
+			objectEntity: $this->makeObjectEntity('167')
+		);
+
+		$this->addToAssertionCount(1);
+
+	}//end testAnAcceptedManagedBindingWritesNoDenialAudit()
+
+	/**
+	 * A folder the acting user can read is accepted with no session lookup.
+	 *
+	 * The creator's own path still works when the mount cache says nothing —
+	 * the acting-user check remains the fallback, not a removed step.
+	 */
+	public function testCreatorStillPassesWhenTheMountCacheIsSilent(): void {
+		$this->userSession->method('getUser')->willReturn($this->makeUser('alice'));
+		$this->mountCache->method('getMountsForFileId')->willReturn([]);
+
+		$folder = $this->createMock(Folder::class);
+		$folder->method('isReadable')->willReturn(true);
+		$this->mockUserFolderLookup(uid: 'alice', folderId: 167, nodes: [$folder]);
+
+		$this->handler->assertManagedFolderIsAccessible(
+			folderId: '167',
+			objectEntity: $this->makeObjectEntity('167')
+		);
+
+		$this->addToAssertionCount(1);
+
+	}//end testCreatorStillPassesWhenTheMountCacheIsSilent()
+}//end class

--- a/tests/Unit/Service/File/FolderManagementHandlerTest.php
+++ b/tests/Unit/Service/File/FolderManagementHandlerTest.php
@@ -22,6 +22,7 @@ use OCA\OpenRegister\Db\Register;
 use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Service\File\FolderManagementHandler;
 use OCA\OpenRegister\Service\FileService;
+use OCP\Files\Config\IUserMountCache;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
@@ -43,6 +44,11 @@ use Psr\Log\LoggerInterface;
  */
 class FolderManagementHandlerTest extends TestCase {
 	/** @var FolderManagementHandler */
+	/**
+	 * @var IUserMountCache&MockObject
+	 */
+	private IUserMountCache $mountCache;
+
 	private FolderManagementHandler $handler;
 
 	/** @var IRootFolder&MockObject */
@@ -82,6 +88,7 @@ class FolderManagementHandlerTest extends TestCase {
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->auditTrailMapper = $this->createMock(AuditTrailMapper::class);
+		$this->mountCache = $this->createMock(IUserMountCache::class);
 
 		// Common mock: user session returns a user
 		$this->mockUser = $this->createMock(IUser::class);
@@ -101,7 +108,8 @@ class FolderManagementHandlerTest extends TestCase {
 			$this->userSession,
 			$this->groupManager,
 			$this->logger,
-			$this->auditTrailMapper
+			$this->auditTrailMapper,
+			$this->mountCache
 		);
 	}
 
@@ -247,7 +255,8 @@ class FolderManagementHandlerTest extends TestCase {
 			$userSession,
 			$this->groupManager,
 			$this->logger,
-			$this->auditTrailMapper
+			$this->auditTrailMapper,
+			$this->mountCache
 		);
 
 		$this->expectException(Exception::class);


### PR DESCRIPTION
## What was broken

Three defects found while validating a live demo instance. None of them was found by the suite.

### 1. A repair step or cron job could not save an object with a bound folder at all

`FolderManagementHandler::assertFolderIsAccessible()` default-denies when there is no `IUser`. A system operation has no user by definition, so a repair step and an anonymous request were indistinguishable to it. `runAsSystem()` does not help: `SystemOperationContext::run()` flips a depth counter, it never sets a session user.

Every one of these callers catches and logs, so the failure is silent: the step records "could not run" and `occ upgrade` still reports success. That is how dossiq's `RealignStatutoryVocabulary` did nothing while leaving 18 cases and 7 caseTypes holding corrupted confidentiality values.

**Scope in this repo — four write paths, all behind a catch-and-log:**

| Path | Reached from |
| --- | --- |
| `lib/Command/RematerialiseCalculationsCommand.php:253` | `occ`, prints "save failed" and still exits SUCCESS |
| `lib/BackgroundJob/DsarDpiaDetectionJob.php:263` | cron, no actor forwarding |
| `lib/Service/VocabularyImportService.php` (4 sites) | `SeedVocabularyRegister` on upgrade, and `ImportSkosCsvCommand` |
| `lib/Service/Configuration/ImportHandler.php:2887` | config import, when its fallback admin cannot read the folder |

`SystemOperationContext::isActive()` is now recognised here as it already is in `MultiTenancyTrait::hasRbacPermission()` and `PermissionHandler::hasPermission()`. It resolves the app's own principal and runs the **same** four checks against that principal's mount. The guard is not skipped and not widened: an anonymous request has no principal to resolve and still lands on the default-deny.

### 2. PATCH reached validation before the lock guard

A locked object refused PUT with 423 naming the holder, while PATCH and POST-patch went straight to the merge. On the rig they answered **500** for a valid payload (the service-layer guard threw an untyped `\Exception` into a hardcoded 500) and 400 for one that fails hard validation. Two doors to the same object, two different answers, and the wrong one sends the caller off to fix their payload.

All three doors now go through one `lockRefusalResponse()`, placed before the merge and before validation. It asks the single predicate `ObjectEntity::isLockedBySomeoneElse()` with run identity arriving ambiently through `FlowRunContext::currentRunUuid()` (#3454) — the condition is not restated. The refusal is built once by `LockedException::forObject()`, which the service-layer guard now throws too, so a lock taken between the pre-read and the save answers 423 rather than 500.

### 3. The folder-binding window is not a race, and not intended

It is an identity defect. `getOpenRegisterUserFolder()` resolves the **session** user, so an object folder is created under `Open Registers/` in whichever home the creating identity happened to have, and the compensating share back to everyone else is still a TODO that shares nothing. Measured on the rig: alice's case folder is `/alice/files/Open Registers/Rig Probe Register/<uuid>`, and one created under `occ` is `/openregister/files/...`.

So a stored binding sits in exactly one user's mount, and re-validating it on every save asked every later editor to prove they were the creator. That is the reported 403: a non-admin cannot write a case somebody else created.

Re-validation of a binding the app itself wrote now asks the question that fits it — is this a folder OpenRegister manages? — through the new `assertManagedFolderIsAccessible()`. The caller-supplied `@self.folder` gate is untouched and still default-denies. A binding pointing outside `Open Registers/` is still refused, which is exactly the planted cross-tenant binding the re-validation (#1431) was added for.

The managed test runs **first**, because `assertFolderIsAccessible()` writes a `folder_access_denied` audit row before every throw: asking it first would stamp a denial into the forensic record for every save that is then allowed. Verified on the rig — two accepted saves left the audit count unchanged at 10, two genuine refusals took it to 12.

The mount lookup uses `IUserMountCache::getMountsForFileId()`, not `IRootFolder::getById()`. The latter needs the owning user's mounts to be set up and answered `0` on the rig for a folder that demonstrably exists.

## Tests

Proven red first, by neutralising each guard in turn and confirming the failure names the right thing. Each keeps a control that stays green, so a blanket exemption cannot pass as a fix.

- `FolderManagementHandlerSystemContextTest` (new, 7 tests) — a sessionless system context resolves the app principal and saves; the same context is still refused a folder its own principal cannot read; a userless request **outside** a system scope is still denied; a managed binding admits a user who did not create it; a binding outside the managed tree is still refused; an accepted save writes no denial audit row; the creator still passes when the mount cache is silent.
- `ObjectsControllerTest::testAllThreeWriteDoorsRefuseALockedObjectIdentically` — compares the whole response (status and body together) across PUT, PATCH and POST-patch, so a divergence in either half fails rather than being averaged away, then asserts the shared refusal names the holder. Red without the fix: PATCH returned `200` with an empty body, having gone straight through to the unstubbed `saveObject`.

## Verified locally

CI is bottlenecked, so this was verified by exit code on a throwaway rig — its own compose project on port **8749**, never :8080. Torn down with `down -v`.

| Check | Exit |
| --- | --- |
| `phpunit` (19,217 tests, 46,995 assertions) | 0 |
| `composer phpcs` | 0 |
| `psalm` | 0 |
| `composer phpstan` | 0 |
| `phpmd` on each changed file, both rulesets | 0 |
| `hydra-gates` v1.15.1, full tree | 0 — all 78 applicable gates ran and passed |

phpcs was canary-tested rather than trusted: a deliberate violation planted in a changed file made it exit 1 and name that file, so the clean run is a real clean run.

**Rig evidence, before → after:**

| Case | Before | After |
| --- | --- | --- |
| `occ` save of a folder-bound object in a system context | `FolderAccessDeniedException` | SAVE OK |
| PUT on a locked object | 423 naming the holder | 423 naming the holder |
| PATCH / POST-patch on a locked object | 500, lock unmentioned | 423 naming the holder |
| The lock holder's own PATCH | 200 | 200 |
| bob writes a case alice created | 403 `folder_access_denied` | 200 |
| bob writes a binding planted outside `Open Registers/` | 403 | 403 |
| Audit rows written by an accepted save | n/a | none |

`composer.lock` carries a within-caret `conduction/hydra-gates` 1.15.0 → 1.15.1 bump, taken before running the gates so a stale vendored package could not invent failures or hide one.

## Not fixed here, and deliberately

`getOpenRegisterUserFolder()` returning the session user is the root cause of defect 3, and moving object folders into the app's own home is the real repair. It is not in this PR: it relocates files out of users' Files trees while the share-back is still a TODO stub, which is a visible change to make on its own evidence rather than alongside a lock fix. The guard change above makes the symptom correct today without moving a single file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
