### PR TITLE
test(locking): e2e coverage for run-scoped object locking, each leg proven red first

### DIFF
--- a/openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md
+++ b/openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md
@@ -67,6 +67,7 @@ and no audited displacement.
 - **GIVEN** an object locked by run A executing as `alice`
 - **WHEN** `alice` evaluates the lock as a person, with no run uuid
 - **THEN** the lock MUST be held against her
+- @e2e tests/e2e/api-direct/flow-object-locking.spec.ts — a person's write is refused with 423 while a run holds the lock, the run's own runAs user included
 
 #### Scenario: A run may extend its own lock
 - **GIVEN** an object locked by run A
@@ -78,7 +79,7 @@ and no audited displacement.
 - **WHEN** a run executing as `alice` locks the same object
 - **THEN** the run MUST be refused, the payload MUST be unchanged, and the
   lock MUST still be a user lock when the run ends
-- @e2e exclude engine-internal, covered by ObjectEntityRunLockTest and the rig walk
+- @e2e tests/e2e/api-direct/flow-object-locking.spec.ts — a person's own lock survives a run passing over the object, and the run takes it once she releases
 
 ### Requirement: A lock refuses a write and names its holder
 
@@ -101,11 +102,13 @@ lock is meant to outlive every write the run makes.
 - **GIVEN** an object locked by a flow run
 - **WHEN** a person updates it over the API
 - **THEN** the write MUST be refused, and the message MUST name the holding run
+- @e2e tests/e2e/api-direct/flow-object-locking.spec.ts — a person's write is refused with 423 while a run holds the lock, the run's own runAs user included
 
 #### Scenario: The holder writes freely
 - **GIVEN** an object locked by a person
 - **WHEN** that same person updates it
 - **THEN** the write MUST succeed
+- @e2e tests/e2e/api-direct/flow-object-locking.spec.ts — a person's own lock survives a run passing over the object, and the run takes it once she releases
 
 #### Scenario: The holding run writes to the object it locked
 - **GIVEN** an object locked by run A
@@ -178,6 +181,7 @@ An empty firing SHALL take no lock and SHALL NOT suspend the run.
 - **GIVEN** a lock step whose recorded deadline has passed and whose target is still locked
 - **WHEN** it re-enters
 - **THEN** it MUST fail with a message naming the holding run, and MUST NOT take or break the lock
+- @e2e tests/e2e/api-direct/flow-object-locking.spec.ts — a second run bounces off the lock: it parks, then fails naming the holding run
 
 #### Scenario: An empty firing does not suspend
 - **GIVEN** a lock step reached with no items
@@ -216,12 +220,13 @@ The existing lock expiry SHALL remain in force as the final backstop.
 - **WHEN** the run is stored as `suspended`
 - **THEN** no terminal event MUST have been announced for it, and the lock MUST
   still be held by that run
-- @e2e exclude engine-internal, covered by RunLockReleaseTerminalityTest and the rig walk
+- @e2e tests/e2e/api-direct/flow-object-locking.spec.ts — an object is locked by its run, stays locked while the run is PARKED, and is released when the run ends
 
 #### Scenario: A completed run releases its locks
 - **GIVEN** a run holding a lock
 - **WHEN** the run completes
 - **THEN** the lock MUST be released
+- @e2e tests/e2e/api-direct/flow-object-locking.spec.ts — an object is locked by its run, stays locked while the run is PARKED, and is released when the run ends
 
 #### Scenario: A failed run releases its locks
 - **GIVEN** a run holding a lock
@@ -269,7 +274,8 @@ error naming the node.
 - **WHEN** the editor reads the node catalogue
 - **THEN** `openregister.lock-object` and `openregister.unlock-object` MUST both
   be present, each with an icon that resolves
-- @e2e exclude covered by the palette sweep in FlowNodePaletteIconsTest and the rig walk
+- @e2e tests/e2e/ci/flow-lock-nodes.spec.ts — the node catalogue serves both lock steps, each with an icon that resolves
+- @e2e tests/e2e/ci/flow-lock-nodes.spec.ts — both lock steps are offered in the editor palette and reach the canvas
 
 #### Scenario: A node with an unresolvable icon is reported, not deleted
 - **GIVEN** a registered node whose `getIcon()` names an image the server does not ship

--- a/tests/e2e/api-direct/flow-object-locking.spec.ts
+++ b/tests/e2e/api-direct/flow-object-locking.spec.ts
@@ -1,0 +1,943 @@
+import type { APIRequestContext } from '@playwright/test'
+
+/*
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * RUN-SCOPED OBJECT LOCKING, on a live instance, against the real engine.
+ *
+ * WHY THIS FILE EXISTS
+ * --------------------
+ * The capability shipped validated by a MANUAL rig walkthrough. The
+ * walkthrough never parked a run, so nobody noticed that the first version
+ * released every lock a run held the moment the run suspended — which is the
+ * one moment a lock is for. A lock that survives only while the run is
+ * actively executing is not a lock; it is a mutex held for the duration of a
+ * function call.
+ *
+ * So the assertion this suite is built around is the PARKED one:
+ * `a run's lock survives the run being parked` reads the lock while the run's
+ * stored status is `suspended`, not merely before and after the run.
+ *
+ * WHAT IS ASSERTED, AND WHY IT CANNOT PASS AGAINST THE BUG
+ * -------------------------------------------------------
+ * Every lock assertion is made through something that can only answer one way
+ * if the lock is really held:
+ *
+ *   - `@self.locked` read back from a fresh GET carries `kind` and `runUuid`,
+ *     so "locked" and "locked BY THIS RUN" are distinguishable. An earlier
+ *     round of tests for this feature asserted `locked !== null` and passed
+ *     against a user lock the run had silently stolen;
+ *   - a refused write is asserted as 423 with `lockedByRun` equal to the run
+ *     uuid, not as "some 4xx". A 400 from validation and a 500 from an
+ *     untyped service exception are both "not 200" and neither is a lock;
+ *   - the run that is supposed to bounce is asserted to reach `failed` with
+ *     the HOLDER's uuid in its error. A run that fails for any other reason
+ *     is a different bug wearing this test's green.
+ *
+ * HOW THE ENGINE IS DRIVEN
+ * ------------------------
+ * `POST /api/flow-runs/test` walks a flow synchronously until it suspends,
+ * which is how a run is brought to the parked state deterministically, with
+ * no clock and no polling. Advancing a PARKED run needs the worker, and the
+ * worker is driven explicitly with
+ * `occ background-job:execute <id> --force-execute`.
+ *
+ * ⚠️ NOT `cron.php`. `cron.php` is interval-gated: a tight loop of it performs
+ * almost no worker passes, so a run that is perfectly healthy sits at
+ * `suspended` for as long as the loop runs and the symptom reads as "wedged
+ * forever". Every wait in this file is an explicit worker pass followed by a
+ * read, never a sleep.
+ *
+ * IDEMPOTENCE (dossiq#1824, dossiq#1829)
+ * --------------------------------------
+ * Two runs of this file on one rig must give the same result. Everything it
+ * creates is namespaced with `RUN_ID` and removed in `afterAll`:
+ *   - its register and schema are deleted through the REST API;
+ *   - its objects are destroyed with `occ openregister:objects:purge --apply
+ *     --force`, so nothing is left in the deleted list either;
+ *   - ⚠️ ITS LOCKS ARE RELEASED FIRST. A fixture that leaves a lock behind is
+ *     not merely litter: the object cannot be written, so a second run of the
+ *     same file meets a state the first run never saw. Teardown breaks every
+ *     lock as the administrator before it purges.
+ *
+ * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md
+ */
+import { request as apiRequest, expect, test } from '@playwright/test'
+import { execSync } from 'node:child_process'
+import { resolveBaseUrl, resolveContainer } from '../base-url.ts'
+
+const API = '/index.php/apps/openregister/api'
+const JSON_HEADERS = {
+	'Content-Type': 'application/json',
+	Accept: 'application/json',
+}
+
+const RUN_ID = `e2elock-${Date.now().toString(36)}`
+const ADMIN = process.env.NEXTCLOUD_ADMIN_USER || process.env.OR_USER || 'admin'
+const ADMIN_PASS =
+	process.env.NEXTCLOUD_ADMIN_PASSWORD || process.env.OR_PASS || 'admin'
+
+/** A second real person, so "refused" can be told from "refused only the run". */
+const BYSTANDER = `${RUN_ID}-bystander`
+const BYSTANDER_PASS = `Bystand3r!${Date.now().toString(36)}A`
+
+// Same reasoning as flow-user-task.spec.ts: Basic auth and NO session cookie,
+// so Nextcloud never demands a CSRF token, and `OCS-APIRequest` marks the
+// calls as API traffic. With a session cookie present every write answers 412.
+const NO_SESSION = { cookies: [], origins: [] }
+const ADMIN_HEADERS = {
+	'OCS-APIRequest': 'true',
+	Accept: 'application/json',
+	Authorization: `Basic ${Buffer.from(`${ADMIN}:${ADMIN_PASS}`).toString('base64')}`,
+}
+
+test.use({ storageState: NO_SESSION, extraHTTPHeaders: ADMIN_HEADERS })
+test.describe.configure({ mode: 'serial' })
+
+const CONTAINER = resolveContainer()
+
+/**
+ * Run one `occ` command in the instance's container.
+ *
+ * @param args The occ arguments.
+ *
+ * @return The command's stdout.
+ */
+function occ(args: string): string {
+	if (CONTAINER === null) {
+		throw new Error('NC_CONTAINER is not set; refusing to guess a container.')
+	}
+	return execSync(`docker exec -u www-data ${CONTAINER} php occ ${args}`, {
+		encoding: 'utf8',
+		// `background-job:list` prints every job's serialized argument in one
+		// table, measured at 1.8 MiB on a fresh instance — well past Node's
+		// 1 MiB execSync default, whose ENOBUFS would surface as "occ is not
+		// reachable" while occ is perfectly fine.
+		maxBuffer: 32 * 1024 * 1024,
+	})
+}
+
+/**
+ * The FlowRunWorker's background-job id, found by class BASENAME so a
+ * namespace move cannot turn this into a silent skip. Null when occ is
+ * unreachable.
+ *
+ * @return The job id, or null.
+ */
+function runWorkerJobId(): string | null {
+	try {
+		const line = occ('background-job:list')
+			.split('\n')
+			.find((l) => l.includes('FlowRunWorker'))
+		return line ? (line.match(/\|\s*(\d+)\s*\|/)?.[1] ?? null) : null
+	} catch {
+		return null
+	}
+}
+
+let workerJob: string | null = null
+
+/**
+ * Perform one worker pass.
+ *
+ * Explicit, and asserted to be possible: a "wait" that cannot actually
+ * advance anything is how a healthy run comes to look wedged.
+ *
+ * @return void
+ */
+function workerPass(): void {
+	expect(
+		workerJob,
+		'the FlowRunWorker job could not be found, so a parked run can never be advanced here',
+	).not.toBeNull()
+	occ(`background-job:execute ${workerJob} --force-execute`)
+}
+
+type Json = Record<string, any>
+
+let registerSlug = ''
+let registerId: number | null = null
+let schemaSlug = ''
+let schemaId: number | null = null
+
+/** Every object uuid this file created, for the purge in afterAll. */
+const objects: string[] = []
+/** Every flow uuid this file created. */
+const flows: string[] = []
+
+/**
+ * Create an object on the fixture schema.
+ *
+ * @param request The admin API context.
+ * @param name The object's name.
+ *
+ * @return The created object's uuid.
+ */
+async function createObject(
+	request: APIRequestContext,
+	name: string,
+): Promise<string> {
+	const resp = await request.post(`${API}/objects/${registerSlug}/${schemaSlug}`, {
+		headers: JSON_HEADERS,
+		data: { name, note: 'created by flow-object-locking.spec.ts' },
+	})
+	expect(resp.status(), await resp.text()).toBeLessThanOrEqual(201)
+	const body = (await resp.json()) as Json
+	const uuid = String(body['@self']?.id ?? body.id ?? '')
+	expect(uuid, 'the created object must have a uuid').toBeTruthy()
+	objects.push(uuid)
+	return uuid
+}
+
+/**
+ * Read an object back, fresh.
+ *
+ * @param request The API context to read as.
+ * @param uuid The object uuid.
+ *
+ * @return The object body.
+ */
+async function readObject(request: APIRequestContext, uuid: string): Promise<Json> {
+	const resp = await request.get(
+		`${API}/objects/${registerSlug}/${schemaSlug}/${uuid}`,
+		{ headers: { Accept: 'application/json' } },
+	)
+	expect(resp.status(), await resp.text()).toBe(200)
+	return (await resp.json()) as Json
+}
+
+/**
+ * The stored lock payload of an object, or null when it holds none.
+ *
+ * Read from `@self.locked`, which carries `kind`, `runUuid` and `user` — the
+ * three fields that make "locked" and "locked BY WHOM" different questions.
+ *
+ * @param request The API context to read as.
+ * @param uuid The object uuid.
+ *
+ * @return The lock payload, or null.
+ */
+async function lockOf(
+	request: APIRequestContext,
+	uuid: string,
+): Promise<Json | null> {
+	const body = await readObject(request, uuid)
+	const lock = body['@self']?.locked ?? body.locked ?? null
+	if (lock === null || lock === undefined) {
+		return null
+	}
+	if (Array.isArray(lock) === true && lock.length === 0) {
+		return null
+	}
+	return lock as Json
+}
+
+/**
+ * Write to an object, merged over its current body.
+ *
+ * OpenRegister's PUT is a full replace validated against the schema, so a
+ * partial body 400s on every required property it omits — which would look
+ * like a refusal and is not one.
+ *
+ * @param request The API context to write as.
+ * @param uuid The object uuid.
+ * @param patch The fields to change.
+ *
+ * @return The raw response.
+ */
+async function writeObject(request: APIRequestContext, uuid: string, patch: Json) {
+	const current = await readObject(request, uuid)
+	const body = { ...current }
+	delete body['@self']
+	return request.put(`${API}/objects/${registerSlug}/${schemaSlug}/${uuid}`, {
+		headers: JSON_HEADERS,
+		data: { ...body, ...patch },
+	})
+}
+
+/**
+ * Author a flow and hand back its uuid.
+ *
+ * @param request The admin API context.
+ * @param label What the flow is for.
+ * @param nodes The graph's nodes.
+ * @param edges The graph's edges.
+ *
+ * @return The flow uuid.
+ */
+async function createFlow(
+	request: APIRequestContext,
+	label: string,
+	nodes: Json[],
+	edges: Json[],
+): Promise<string> {
+	const resp = await request.post(`${API}/flows`, {
+		headers: JSON_HEADERS,
+		data: {
+			name: `${RUN_ID} ${label}`,
+			description: 'Created by the run-scoped object-locking e2e suite.',
+			trigger: 'manual',
+			enabled: true,
+			nodes,
+			edges,
+		},
+	})
+	expect(resp.status(), await resp.text()).toBe(201)
+	const body = (await resp.json()) as Json
+	const uuid = String(body.uuid ?? body.id ?? '')
+	expect(uuid, 'flow uuid').toBeTruthy()
+	flows.push(uuid)
+	return uuid
+}
+
+/** A lock step against one explicit object. */
+function lockStep(id: string, uuid: string, config: Json = {}): Json {
+	return {
+		id,
+		type: 'openregister.lock-object',
+		config: { uuid, process: `${RUN_ID} holding for a test`, ...config },
+		position: { x: 0, y: 0 },
+	}
+}
+
+/** A user task, which is this suite's deterministic way to PARK a run. */
+function userTask(id: string): Json {
+	return {
+		id,
+		type: 'openregister.user-task',
+		config: {
+			title: `${RUN_ID} ${id}`,
+			assignee: ADMIN,
+			outcomes: 'done',
+		},
+		position: { x: 0, y: 0 },
+	}
+}
+
+/**
+ * The step a flow ends ON.
+ *
+ * ⚠️ DELIBERATELY `set-fields` AND NOT `openregister.end`. A run that reaches
+ * an `end` node is committed as `stopped`, because `stopped` outranks
+ * `completed` in the commit path's severity table — so a flow terminated by
+ * `end` can never assert the spec's "a COMPLETED run releases its locks"
+ * scenario, and asserting `stopped` there would quietly test a different
+ * requirement than the one named. A run whose last step simply has no
+ * outgoing edge is committed `completed`, which is the outcome under test.
+ * Measured on the rig 2026-09-05: identical graphs ending in `end` and in
+ * `set-fields` commit as `stopped` and `completed` respectively.
+ *
+ * @param id The node id.
+ *
+ * @return The node.
+ */
+function finalStep(id: string): Json {
+	return {
+		id,
+		type: 'openregister.set-fields',
+		config: { set: { finished: true } },
+		position: { x: 0, y: 0 },
+	}
+}
+
+/**
+ * Walk a flow synchronously until it suspends or ends.
+ *
+ * @param request The admin API context.
+ * @param flowId The flow uuid.
+ *
+ * @return The run row.
+ */
+async function testRun(request: APIRequestContext, flowId: string): Promise<Json> {
+	const resp = await request.post(`${API}/flow-runs/test`, {
+		headers: JSON_HEADERS,
+		data: { flowId, seedItems: [{ json: { origin: RUN_ID } }] },
+	})
+	expect(resp.status(), await resp.text()).toBe(200)
+	return (await resp.json()) as Json
+}
+
+/**
+ * Read a run back.
+ *
+ * @param request The admin API context.
+ * @param uuid The run uuid.
+ *
+ * @return The run row.
+ */
+async function readRun(request: APIRequestContext, uuid: string): Promise<Json> {
+	const resp = await request.get(`${API}/flow-runs/${uuid}`)
+	expect(resp.status(), await resp.text()).toBe(200)
+	return (await resp.json()) as Json
+}
+
+/**
+ * The open task a run raised, through the assignee's inbox.
+ *
+ * @param request The admin API context.
+ * @param runUuid The run that raised it.
+ *
+ * @return The task row, or null.
+ */
+async function openTaskFor(
+	request: APIRequestContext,
+	runUuid: string,
+): Promise<Json | null> {
+	const resp = await request.get(
+		`${API}/flow-tasks?scope=assigned&isTerminal=false&limit=100&sort=created&direction=desc`,
+	)
+	expect(resp.status(), await resp.text()).toBe(200)
+	const rows = ((await resp.json()).results ?? []) as Json[]
+	return rows.find((row) => row.runUuid === runUuid) ?? null
+}
+
+/**
+ * Advance a parked run until it leaves `suspended`, or until the worker
+ * passes run out.
+ *
+ * ⚠️ THE WAITING IS EXPLICIT, IN BOTH HALVES, AND NEITHER HALF IS OPTIONAL.
+ *
+ * 1. A worker pass only picks up a run whose `resumeAt` is DUE. A lock step
+ *    parks on `min(now + backoff, deadline)`, so a pass fired before that
+ *    moment does nothing at all — and a loop of such passes produces a
+ *    perfectly convincing "wedged forever", which is a symptom of the test,
+ *    not of the run. So sleep to the run's own stated wake time first, and
+ *    say that that is what is being waited for.
+ * 2. Then fire a pass. NOT `cron.php`: it is interval-gated, so a tight loop
+ *    of it performs almost no worker passes and fabricates the same false
+ *    symptom from the other direction.
+ *
+ * The bound is a COUNT OF WORKER PASSES rather than a wall clock, because a
+ * pass is what a parked run is actually waiting for — so the failure message
+ * can say how many it got.
+ *
+ * @param request The admin API context.
+ * @param uuid The run uuid.
+ * @param passes How many worker passes to spend.
+ *
+ * @return The run row as last read.
+ */
+async function driveUntilTerminal(
+	request: APIRequestContext,
+	uuid: string,
+	passes = 6,
+): Promise<Json> {
+	let run = await readRun(request, uuid)
+
+	for (let i = 0; i < passes && run.status === 'suspended'; i++) {
+		const due = run.resumeAt ? new Date(String(run.resumeAt)).getTime() : 0
+		const waitFor = due - Date.now()
+		if (waitFor > 0) {
+			// A 250 ms cushion: `resumeAt` is stored to whole-second precision,
+			// so waking at exactly the stamped second can land a hair early and
+			// spend a pass on a run the worker does not yet consider due.
+			await new Promise((resolve) => setTimeout(resolve, waitFor + 250))
+		}
+		workerPass()
+		run = await readRun(request, uuid)
+	}
+
+	return run
+}
+
+test.beforeAll(async () => {
+	workerJob = runWorkerJobId()
+	test.skip(
+		workerJob === null,
+		'occ is not reachable (set NC_CONTAINER), so a parked run could never be advanced and every '
+			+ 'assertion about a run ENDING would be untestable here',
+	)
+
+	const admin = await apiRequest.newContext({
+		baseURL: resolveBaseUrl(),
+		extraHTTPHeaders: ADMIN_HEADERS,
+	})
+	try {
+		// A register and schema of this file's own, so the suite depends on no
+		// seed and two rigs behave identically.
+		registerSlug = `${RUN_ID}-register`
+		schemaSlug = `${RUN_ID}-schema`
+
+		const schema = await admin.post(`${API}/schemas`, {
+			headers: JSON_HEADERS,
+			data: {
+				slug: schemaSlug,
+				title: `${RUN_ID} lockable`,
+				description: 'Fixture schema for the object-locking e2e suite.',
+				properties: {
+					name: { type: 'string', title: 'Name' },
+					note: { type: 'string', title: 'Note' },
+				},
+			},
+		})
+		expect(schema.status(), await schema.text()).toBeLessThanOrEqual(201)
+		schemaId = (await schema.json()).id ?? null
+		expect(schemaId, 'fixture schema id').toBeTruthy()
+
+		const register = await admin.post(`${API}/registers`, {
+			headers: JSON_HEADERS,
+			data: {
+				slug: registerSlug,
+				title: `${RUN_ID} lockable register`,
+				description: 'Fixture register for the object-locking e2e suite.',
+				schemas: [schemaId],
+			},
+		})
+		expect(register.status(), await register.text()).toBeLessThanOrEqual(201)
+		registerId = (await register.json()).id ?? null
+		expect(registerId, 'fixture register id').toBeTruthy()
+	} finally {
+		await admin.dispose()
+	}
+})
+
+test.afterAll(async () => {
+	const admin = await apiRequest.newContext({
+		baseURL: resolveBaseUrl(),
+		extraHTTPHeaders: ADMIN_HEADERS,
+	})
+
+	try {
+		// 1. STOP EVERY RUN THIS FILE STARTED. A suspended run wakes on the
+		//    next worker pass — including one another spec triggers — and
+		//    re-takes a lock on an object that is about to be purged.
+		for (const flow of flows) {
+			await admin.delete(`${API}/flows/${flow}`).catch(() => {})
+		}
+
+		// 2. RELEASE EVERY LOCK, as the administrator, who is the only caller
+		//    allowed to break a run's lock. Skipping this is what makes a
+		//    suite non-rerunnable: the objects below cannot be written by the
+		//    next run, and the FAILURE surfaces in whichever test writes
+		//    first, nowhere near the fixture that caused it.
+		for (const uuid of objects) {
+			await admin
+				.post(
+					`${API}/objects/${registerSlug}/${schemaSlug}/${uuid}/unlock`,
+					{
+						headers: JSON_HEADERS,
+					},
+				)
+				.catch(() => {})
+		}
+
+		// 3. DESTROY THE ROWS. `occ openregister:objects:purge` rather than a
+		//    DELETE, because a DELETE only soft-deletes: the rows would still
+		//    be in the deleted list on the next run (dossiq#1829).
+		if (objects.length > 0 && CONTAINER !== null) {
+			try {
+				occ(
+					`openregister:objects:purge ${objects.join(' ')} --force --apply`,
+				)
+			} catch (error) {
+				console.warn('[flow-object-locking] purge failed:', error)
+			}
+		}
+
+		// 4. Then the container entities.
+		if (registerId !== null) {
+			await admin.delete(`${API}/registers/${registerId}`).catch(() => {})
+		}
+		if (schemaId !== null) {
+			await admin.delete(`${API}/schemas/${schemaId}`).catch(() => {})
+		}
+	} finally {
+		await admin.dispose()
+	}
+})
+
+test.describe('run-scoped object locking, against the live engine', () => {
+	// ── LEG 5 IS NOT HERE, DELIBERATELY ─────────────────────────────────────
+	// That both lock steps are present in the node catalogue, that each one's
+	// icon actually resolves, and that each can be dropped on the editor's
+	// canvas is `tests/e2e/ci/flow-lock-nodes.spec.ts`. It needs no worker and
+	// no occ, so it runs on the CI floor, where this file cannot. Asserting it
+	// in both places would mean two spellings of one guarantee, and the one
+	// that runs less often is the one that would rot.
+
+	// ── LEG 1 ───────────────────────────────────────────────────────────────
+	// @e2e run-scoped-object-locking::a-parked-run-keeps-its-locks
+	// @e2e run-scoped-object-locking::a-completed-run-releases-its-locks
+	test('an object is locked by its run, stays locked while the run is PARKED, and is released when the run ends', async ({
+		request,
+	}) => {
+		const subject = await createObject(request, `${RUN_ID} parked subject`)
+
+		const flow = await createFlow(
+			request,
+			'lock then park',
+			[lockStep('lock', subject), userTask('wait'), finalStep('done')],
+			[
+				{ id: 'e1', from: 'lock', to: 'wait' },
+				{ id: 'e2', from: 'wait', to: 'done' },
+			],
+		)
+
+		const run = await testRun(request, flow)
+
+		// The run is parked — on a clock, never on a null resumeAt, which is
+		// the shape `findAbandonedSignals()` fails after 14 days.
+		expect(run.status, 'the run should be parked at its user task').toBe(
+			'suspended',
+		)
+		expect(
+			run.resumeAt,
+			'a parked run waits on a time, not on nothing',
+		).toBeTruthy()
+
+		// 🔴 THE ASSERTION THIS WHOLE FILE EXISTS FOR.
+		// Read the lock WHILE the run's stored status is `suspended`. The
+		// first version of this capability announced a terminal event on the
+		// way to `suspended`, and the announcement is what releases the
+		// locks — so the object was wide open for exactly as long as the run
+		// was waiting. A test that read the lock before and after the run
+		// would have passed against that.
+		const parked = await readRun(request, run.uuid)
+		expect(parked.status, 'still parked when the lock is read').toBe('suspended')
+
+		const held = await lockOf(request, subject)
+		expect(
+			held,
+			'the parked run holds NO lock — a run that loses its lock the moment it waits has no lock at all',
+		).not.toBeNull()
+		expect(held!.kind, 'the lock must be run-scoped, not a user lock').toBe(
+			'run',
+		)
+		expect(
+			held!.runUuid,
+			'the lock must name THIS run; a lock held by something else is a different bug',
+		).toBe(run.uuid)
+		expect(held!.user, "the run's acting identity is recorded too").toBe(ADMIN)
+
+		// Answer the task and let the worker finish the run.
+		const task = await openTaskFor(request, run.uuid as string)
+		expect(task, 'the parking step raised a task').toBeTruthy()
+		const done = await request.post(`${API}/flow-tasks/${task!.uuid}/complete`, {
+			headers: JSON_HEADERS,
+			data: { outcome: 'done', comment: null },
+		})
+		expect(done.status(), await done.text()).toBe(200)
+
+		const ended = await driveUntilTerminal(request, run.uuid as string)
+		expect(
+			ended.status,
+			'the run never reached a terminal state, so "released on end" was never actually exercised',
+		).toBe('completed')
+
+		expect(
+			await lockOf(request, subject),
+			'the completed run did not release its lock',
+		).toBeNull()
+
+		// And the object is writable again — the release is real, not just a
+		// cleared field.
+		const after = await writeObject(request, subject, { note: 'released' })
+		expect(after.status(), await after.text()).toBeLessThanOrEqual(201)
+	})
+
+	// ── LEG 2 ───────────────────────────────────────────────────────────────
+	// @e2e run-scoped-object-locking::an-exhausted-budget-fails-and-names-the-holder
+	test('a second run bounces off the lock: it parks, then fails naming the holding run', async ({
+		request,
+	}) => {
+		const subject = await createObject(request, `${RUN_ID} contended subject`)
+
+		// Holder: parks at a user task with the lock held, and stays there for
+		// the whole of this test.
+		const holdingFlow = await createFlow(
+			request,
+			'holder',
+			[lockStep('lock', subject), userTask('wait'), finalStep('done')],
+			[
+				{ id: 'e1', from: 'lock', to: 'wait' },
+				{ id: 'e2', from: 'wait', to: 'done' },
+			],
+		)
+		const holder = await testRun(request, holdingFlow)
+		expect(holder.status).toBe('suspended')
+		expect((await lockOf(request, subject))!.runUuid).toBe(holder.uuid)
+
+		// Challenger: a THREE-second budget, so the first attempt parks and the
+		// second is past the deadline.
+		//
+		// ⚠️ NOT ONE SECOND, WHICH IS RACY. The deadline is persisted with
+		// `format('c')`, which truncates to whole seconds, so a one-second
+		// budget stamped at .900 is already expired 200 ms later when the
+		// first acquire returns — and the run FAILS on its first attempt
+		// instead of parking. Measured on the rig 2026-09-05: identical
+		// fixtures gave `failed` and `suspended` on consecutive runs. Three
+		// seconds leaves at least two whole seconds after truncation, which is
+		// an order of magnitude more than the ~120 ms an acquire takes.
+		//
+		// It also fixes the wake time: the backoff floor is 60 s but
+		// `nextAttemptAt()` clamps to the deadline, so the run wakes AT the
+		// deadline rather than a minute later.
+		const challengingFlow = await createFlow(
+			request,
+			'challenger',
+			[lockStep('lock', subject, { waitSeconds: 3 }), finalStep('done')],
+			[{ id: 'e1', from: 'lock', to: 'done' }],
+		)
+		const challenger = await testRun(request, challengingFlow)
+
+		expect(
+			challenger.status,
+			'the second run did not park — it either took a lock another run holds, or failed on first contact',
+		).toBe('suspended')
+		expect(
+			challenger.resumeAt,
+			'a lock wait is on a clock; a null resumeAt is the "waiting for a signal" shape the reaper kills',
+		).toBeTruthy()
+
+		// The holder still holds it. The challenger parking must not have
+		// displaced anything.
+		const stillHeld = await lockOf(request, subject)
+		expect(
+			stillHeld!.runUuid,
+			'the challenger took the lock while waiting',
+		).toBe(holder.uuid)
+
+		const bounced = await driveUntilTerminal(request, challenger.uuid as string)
+		expect(
+			bounced.status,
+			'the challenger never gave up; a wait budget that never expires is not a budget',
+		).toBe('failed')
+
+		const reason = JSON.stringify(bounced.error ?? bounced.log ?? bounced)
+		expect(
+			reason,
+			'the failure does not name the run that was holding the object, so an operator cannot act on it',
+		).toContain(holder.uuid)
+
+		// AND IT DID NOT BREAK THE LOCK ON ITS WAY OUT. Letting a waiting run
+		// take the lock by outlasting it would make the lock advisory again.
+		const afterBounce = await lockOf(request, subject)
+		expect(
+			afterBounce,
+			'the failing run broke the lock it was refused',
+		).not.toBeNull()
+		expect(afterBounce!.runUuid).toBe(holder.uuid)
+	})
+
+	// ── LEG 3 ───────────────────────────────────────────────────────────────
+	// @e2e run-scoped-object-locking::a-person-is-refused-while-a-run-holds-the-lock
+	// @e2e run-scoped-object-locking::a-runs-own-runas-user-is-still-refused
+	test("a person's write is refused with 423 while a run holds the lock, the run's own runAs user included", async ({
+		request,
+	}) => {
+		const subject = await createObject(request, `${RUN_ID} guarded subject`)
+
+		const flow = await createFlow(
+			request,
+			'guard',
+			[lockStep('lock', subject), userTask('wait'), finalStep('done')],
+			[
+				{ id: 'e1', from: 'lock', to: 'wait' },
+				{ id: 'e2', from: 'wait', to: 'done' },
+			],
+		)
+		const run = await testRun(request, flow)
+		expect(run.status).toBe('suspended')
+		expect((await lockOf(request, subject))!.runUuid).toBe(run.uuid)
+
+		// 🔴 THE ADMIN IS THE RUN'S OWN `runAs`. Run-scoped ownership means a
+		// run and the person it executes as are DIFFERENT HOLDERS, so this
+		// account is refused too. Under the old user-keyed lock this write
+		// succeeded, and on an instance where flows run as one service
+		// account that is EVERY person's write.
+		const asRunAs = await writeObject(request, subject, { note: 'by the runAs' })
+		expect(
+			asRunAs.status(),
+			`the run's own runAs user was allowed to write: ${await asRunAs.text()}`,
+		).toBe(423)
+		const refusal = (await asRunAs.json()) as Json
+		expect(
+			refusal.lockedByRun,
+			'the refusal must name the holding RUN, not just say "locked"',
+		).toBe(run.uuid)
+		expect(String(refusal.error)).toContain('flow run')
+		expect(String(refusal.error)).toContain(String(run.uuid))
+
+		// And a different person, who is not the runAs either.
+		const provisioned = await request.post('/ocs/v2.php/cloud/users', {
+			data: { userid: BYSTANDER, password: BYSTANDER_PASS },
+		})
+		expect(
+			provisioned.status(),
+			'could not provision a bystander account, so the "any person" half is untested',
+		).toBe(200)
+
+		const bystander = await apiRequest.newContext({
+			baseURL: resolveBaseUrl(),
+			extraHTTPHeaders: {
+				'OCS-APIRequest': 'true',
+				Accept: 'application/json',
+				Authorization: `Basic ${Buffer.from(
+					`${BYSTANDER}:${BYSTANDER_PASS}`,
+				).toString('base64')}`,
+			},
+		})
+		try {
+			const byOther = await bystander.put(
+				`${API}/objects/${registerSlug}/${schemaSlug}/${subject}`,
+				{
+					headers: JSON_HEADERS,
+					data: { name: 'taken over', note: 'nope' },
+				},
+			)
+			// 423 when the caller can see the object, 403/404 when RBAC hides
+			// it from them first — but never a write that lands.
+			expect(
+				[423, 403, 404],
+				`a bystander's write answered ${byOther.status()}`,
+			).toContain(byOther.status())
+			expect(
+				byOther.status(),
+				'a bystander wrote to a locked object',
+			).not.toBe(200)
+		} finally {
+			await bystander.dispose()
+			await request
+				.delete(`/ocs/v2.php/cloud/users/${BYSTANDER}`)
+				.catch(() => {})
+		}
+
+		// PATCH is the same door. It used to answer 400 or 500 here, because
+		// only PUT carried the guard.
+		const patched = await request.patch(
+			`${API}/objects/${registerSlug}/${schemaSlug}/${subject}`,
+			{ headers: JSON_HEADERS, data: { note: 'by patch' } },
+		)
+		expect(
+			patched.status(),
+			`PATCH answered ${patched.status()}: a lock only PUT enforces is not a lock`,
+		).toBe(423)
+
+		// Leave nothing parked behind: end the run, which releases the lock.
+		const task = await openTaskFor(request, run.uuid as string)
+		if (task !== null) {
+			await request.post(`${API}/flow-tasks/${task.uuid}/complete`, {
+				headers: JSON_HEADERS,
+				data: { outcome: 'done', comment: null },
+			})
+			await driveUntilTerminal(request, run.uuid as string)
+		}
+	})
+
+	// ── LEG 4 ───────────────────────────────────────────────────────────────
+	// @e2e run-scoped-object-locking::a-persons-lock-survives-a-run-passing-over-the-object
+	// @e2e run-scoped-object-locking::the-holder-writes-freely
+	test("a person's own lock survives a run passing over the object, and the run takes it once she releases", async ({
+		request,
+	}) => {
+		const subject = await createObject(request, `${RUN_ID} person-held subject`)
+
+		// A PERSON takes the lock, as a person.
+		const taken = await request.post(
+			`${API}/objects/${registerSlug}/${schemaSlug}/${subject}/lock`,
+			{
+				headers: JSON_HEADERS,
+				data: { process: `${RUN_ID} mine`, duration: 3600 },
+			},
+		)
+		expect(taken.status(), await taken.text()).toBe(200)
+
+		const mine = await lockOf(request, subject)
+		expect(mine, 'the person did not get a lock').not.toBeNull()
+		expect(mine!.user).toBe(ADMIN)
+		expect(mine!.kind ?? 'user').toBe('user')
+
+		// The holder writes freely — the guard refuses others, not the owner.
+		const ownWrite = await writeObject(request, subject, { note: 'still mine' })
+		expect(
+			ownWrite.status(),
+			`the lock holder was refused her own write: ${await ownWrite.text()}`,
+		).toBeLessThanOrEqual(201)
+
+		// ⚠️ AND THAT WRITE RELEASED HER LOCK. A completed write releases the
+		// writer's OWN lock — the object was checked out, the edit landed, the
+		// checkout is over. That is by design, but it is invisible from the
+		// call, and reading it as "the lock survives a write" is exactly how
+		// this test first went green for the wrong reason: the run below then
+		// acquired an object nobody held, and the pass said "a person's lock
+		// survived a run".
+		expect(
+			await lockOf(request, subject),
+			"a holder's own successful write is expected to release her lock; if it no longer does, "
+				+ 'the re-lock below is silently testing an extend rather than a fresh take',
+		).toBeNull()
+
+		// So take it again, and THIS time do not write, so the lock the run
+		// meets below is one a person is actually still holding.
+		const retaken = await request.post(
+			`${API}/objects/${registerSlug}/${schemaSlug}/${subject}/lock`,
+			{
+				headers: JSON_HEADERS,
+				data: { process: `${RUN_ID} mine again`, duration: 3600 },
+			},
+		)
+		expect(retaken.status(), await retaken.text()).toBe(200)
+		expect((await lockOf(request, subject))!.kind ?? 'user').toBe('user')
+
+		// 🔴 NOW A RUN WALKS OVER IT, EXECUTING AS THE SAME PERSON. Under the
+		// user-keyed lock this did not merely pass the guard: it took the
+		// EXTEND branch, rewrote the payload as its own run lock, and released
+		// it when the run ended — destroying a lock a person was relying on,
+		// with no error and no audited displacement.
+		// An eight-second budget, for the same reason the challenger above uses
+		// three: `nextAttemptAt()` clamps the 60 s backoff floor to the
+		// deadline, so a short budget makes the run's own wake time short and
+		// the wait deterministic instead of a flat minute of wall clock. The
+		// person releases the lock within a few hundred milliseconds, so the
+		// budget is never what decides this test — the retry does.
+		const flow = await createFlow(
+			request,
+			'passer-by',
+			[lockStep('lock', subject, { waitSeconds: 8 }), finalStep('done')],
+			[{ id: 'e1', from: 'lock', to: 'done' }],
+		)
+		const run = await testRun(request, flow)
+
+		expect(
+			run.status,
+			"the run was handed a person's lock instead of waiting for it",
+		).toBe('suspended')
+
+		const survived = await lockOf(request, subject)
+		expect(survived, "the run destroyed the person's lock").not.toBeNull()
+		expect(
+			survived!.kind ?? 'user',
+			"the run rewrote the person's lock as its own",
+		).toBe('user')
+		expect(survived!.user, 'the recorded holder changed').toBe(ADMIN)
+		expect(
+			survived!.runUuid ?? null,
+			'a user lock must not carry a run uuid',
+		).toBeNull()
+
+		// The person releases, and only then the run picks it up.
+		const released = await request.post(
+			`${API}/objects/${registerSlug}/${schemaSlug}/${subject}/unlock`,
+			{ headers: JSON_HEADERS },
+		)
+		expect(released.status(), await released.text()).toBe(200)
+		expect(
+			await lockOf(request, subject),
+			'the unlock did not release',
+		).toBeNull()
+
+		const finished = await driveUntilTerminal(request, run.uuid as string)
+		expect(
+			finished.status,
+			'the run never resumed after the object was freed, so the retry path is unproven',
+		).toBe('completed')
+
+		// It completed, which means the lock step succeeded on re-entry — and
+		// the completed run released again, so nothing is left holding.
+		expect(
+			await lockOf(request, subject),
+			'the run that finally took the lock did not release it',
+		).toBeNull()
+	})
+})

--- a/tests/e2e/ci/flow-lock-nodes.spec.ts
+++ b/tests/e2e/ci/flow-lock-nodes.spec.ts
@@ -1,0 +1,224 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * THE LOCK STEPS ARE IN THE PALETTE, AND CAN BE PUT ON THE CANVAS.
+ *
+ * WHY THIS IS A BROWSER TEST AND NOT A REGISTRY ASSERTION
+ * ------------------------------------------------------
+ * Both nodes were registered with the engine, executable, unit-tested and
+ * completely unusable: they named `core/img/actions/lock.svg` as their icon,
+ * an image no shipped Nextcloud carries. `IURLGenerator::imagePath()` throws
+ * for an image the server does not have, and `palette()` caught that and
+ * dropped the WHOLE ENTRY rather than the icon. So the catalogue the editor
+ * reads did not list them, and a step that is not in the palette cannot be
+ * added to a flow at all — a total failure produced by a cosmetic cause.
+ *
+ * Every test that looked at the registry passed throughout, because the
+ * registry was never wrong. The only thing that could have caught it is
+ * something that reads the CATALOGUE and then puts the step on the canvas,
+ * which is what this file does:
+ *
+ *   1. the catalogue serves both nodes, and each one's icon URL answers 200 —
+ *      the exact condition that removed them;
+ *   2. the editor's palette renders an entry for each;
+ *   3. each entry, clicked, actually reaches the canvas.
+ *
+ * Assertion 1 alone would have caught the shipped defect, but not a variant of
+ * it: a catalogue entry the palette filters out client-side is just as absent
+ * to the person authoring the flow. Assertions 2 and 3 are what make this a
+ * statement about the editor rather than about an endpoint.
+ *
+ * ADMITTED TO THE CI FLOOR (tests/e2e/ci/playwright.config.ts, `ci/*.spec.ts`)
+ * ---------------------------------------------------------------------------
+ * Against that config's four criteria:
+ *   1. HERMETIC — no occ, no docker, no seeded data. It opens the editor on a
+ *      freshly installed instance and reads the app's own catalogue.
+ *   2. NON-MUTATING — it never saves. The steps are dropped on an unsaved
+ *      canvas and the page is discarded, so no flow, run or object is created
+ *      and there is nothing to clean up.
+ *   3. NO CONDITIONAL-ASSERT DEGRADATION — every check is an unconditional
+ *      `expect`. The only `.catch()` is on the support-dialog dismissal, which
+ *      is scaffolding, not a check.
+ *   4. NO test.skip AT ALL, so nothing here can quietly not run.
+ *
+ * The engine and API behaviour these steps implement — that a lock is held
+ * while its run is parked, refuses a write with 423, and is released when the
+ * run ends — is `tests/e2e/api-direct/flow-object-locking.spec.ts`, which
+ * needs the worker and therefore cannot live on this floor.
+ *
+ * @spec openspec/changes/run-scoped-object-locking/specs/run-scoped-object-locking/spec.md
+ */
+import type { Locator } from '@playwright/test'
+
+import { expect, test } from '@playwright/test'
+import * as fs from 'fs'
+import * as path from 'path'
+
+const STORAGE_STATE = path.resolve(__dirname, '../.auth/admin.json')
+const FLOWS_ROUTE = '/index.php/apps/openregister/flows'
+const API = '/index.php/apps/openregister/api'
+
+/** The two steps under test, by catalogue id and by the label the palette shows. */
+const LOCK_NODES = [
+	{ id: 'openregister.lock-object', label: 'Lock an object' },
+	{ id: 'openregister.unlock-object', label: 'Unlock an object' },
+]
+
+test.use(fs.existsSync(STORAGE_STATE) ? { storageState: STORAGE_STATE } : {})
+
+/**
+ * Click a Nextcloud themed control.
+ *
+ * Same reasoning as flow-controls.spec.ts: `.click()` times out on these even
+ * when Playwright reports the element visible, enabled and stable, so the
+ * event is dispatched directly. The visibility and enablement assertions stay,
+ * because a dispatched event reaches a Vue handler whether or not the control
+ * is one the UI is actually offering.
+ *
+ * @param locator The themed control.
+ *
+ * @return {Promise<void>} When the event has been dispatched.
+ */
+async function clickThemed(locator: Locator): Promise<void> {
+	await expect(locator).toBeVisible()
+	await expect(locator).toBeEnabled()
+	await locator.dispatchEvent('click')
+}
+
+// ⚠️ TWO TESTS, NOT ONE, AND THAT IS THE POINT.
+//
+// They were one, with the catalogue read as a preamble to the editor
+// assertions. Proving the file could fail — by restoring the `palette()`
+// behaviour that dropped a node whose icon would not resolve — showed why that
+// is wrong: the run stopped at the catalogue assertion, and the editor half
+// was never reached. A test whose later half cannot be shown to fire has not
+// been proven at all; it has only been proven to have a first half.
+//
+// Split, the editor test carries no catalogue pre-check, so the same
+// neutralisation fails it at the palette, naming the palette.
+
+// @e2e run-scoped-object-locking::the-lock-and-unlock-nodes-can-be-added-to-a-flow
+test('the node catalogue serves both lock steps, each with an icon that resolves', async ({
+	request,
+}) => {
+	const catalogue = await request.get(`${API}/flow/node-catalog`)
+	expect(catalogue.status(), await catalogue.text()).toBe(200)
+	const entries = ((await catalogue.json()).results ?? []) as Array<
+		Record<string, any>
+	>
+
+	for (const node of LOCK_NODES) {
+		const entry = entries.find((row) => row.id === node.id)
+		expect(
+			entry,
+			`the node catalogue does not list ${node.id}, so it cannot be added to a flow at all`,
+		).toBeTruthy()
+
+		// The icon is the whole reason this test exists. Assert the URL the
+		// editor will request ANSWERS, not merely that the field is a
+		// non-empty string: the shipped defect was a syntactically perfect
+		// icon path pointing at a file no Nextcloud version ships.
+		expect(entry!.icon, `${node.id} carries no icon`).toBeTruthy()
+		const icon = await request.get(String(entry!.icon))
+		expect(
+			icon.status(),
+			`${node.id}'s icon (${entry!.icon}) does not resolve; an unresolvable icon is what `
+				+ 'removed both of these steps from the palette entirely',
+		).toBe(200)
+
+		expect(String(entry!.displayName), `${node.id} display name`).toBe(
+			node.label,
+		)
+
+		// The step is configurable, not a bare label: a palette entry with no
+		// form is one an author can place and never aim at anything.
+		expect(
+			Array.isArray(entry!.configForm) && entry!.configForm.length > 0,
+			`${node.id} offers no configuration form`,
+		).toBe(true)
+	}
+
+	const lock = entries.find((row) => row.id === 'openregister.lock-object')!
+	const keys = (lock.configForm as Array<Record<string, any>>).map(
+		(field) => field.key,
+	)
+	for (const key of ['uuid', 'duration', 'waitSeconds']) {
+		expect(keys, `the lock step's form is missing "${key}"`).toContain(key)
+	}
+})
+
+// @e2e run-scoped-object-locking::the-lock-and-unlock-nodes-can-be-added-to-a-flow
+test('both lock steps are offered in the editor palette and reach the canvas', async ({
+	page,
+}) => {
+	// The support dialog is a first-open note that records its dismissal in
+	// localStorage; a Playwright context starts empty, so CI meets it EVERY
+	// run, centred over the editor, trapping focus. Suppressed by the flag the
+	// dialog itself reads, matched on the prefix so a differing app slug does
+	// not silently reintroduce it.
+	await page.addInitScript(() => {
+		const read = Storage.prototype.getItem
+		Storage.prototype.getItem = function (key: string) {
+			if (
+				typeof key === 'string'
+				&& key.startsWith('cn-support-dialog-shown:')
+			) {
+				return '1'
+			}
+			return read.call(this, key)
+		}
+	})
+
+	await page.goto(FLOWS_ROUTE, { waitUntil: 'domcontentloaded' })
+
+	const supportDialog = page.getByRole('dialog').filter({ hasText: 'Support' })
+	if (await supportDialog.isVisible({ timeout: 2_000 }).catch(() => false)) {
+		await page.keyboard.press('Escape')
+		await expect(supportDialog).toBeHidden({ timeout: 10_000 })
+	}
+
+	// Reach the editor the way a person does. Direct navigation to
+	// `/flows/new` does not reliably hydrate the canvas.
+	await clickThemed(page.getByRole('button', { name: 'New flow' }))
+
+	const palette = page.locator('.cn-flow-sidebar__palette')
+	await expect(
+		palette,
+		'the step palette did not render, so nothing can be said about what it offers',
+	).toBeVisible()
+
+	// An empty palette renders the same container as a full one, so the
+	// per-node assertions below would each fail with "not found" and none of
+	// them would say that NOTHING loaded. Establish that first.
+	await expect
+		.poll(async () => await palette.locator('> *').count(), {
+			message:
+				'the palette rendered but is empty — the node catalogue never reached the editor, '
+				+ 'so a missing lock step below would be reported as a lock bug rather than a load failure',
+			timeout: 15_000,
+		})
+		.toBeGreaterThan(0)
+
+	// ── 3. PRESENT, AND ADDABLE ─────────────────────────────────────────────
+	for (const node of LOCK_NODES) {
+		const offered = palette.getByText(node.label, { exact: true }).first()
+		await expect(
+			offered,
+			`the palette offers no "${node.label}" step, so a flow author cannot lock anything`,
+		).toBeVisible()
+
+		// "Listed" is not "usable". The failure mode being guarded against
+		// removed the entry from the catalogue outright, but a step that
+		// renders and does nothing when picked is the same thing to the person
+		// authoring the flow.
+		await clickThemed(offered)
+		await expect(
+			page.locator('.cn-flow-detail__node', { hasText: node.label }),
+			`"${node.label}" is in the palette but never reached the canvas when it was picked`,
+		).toBeVisible()
+	}
+
+	// Nothing is saved: the canvas is discarded with the page, so this spec
+	// leaves no flow, run or object behind and is rerunnable as-is.
+})


### PR DESCRIPTION
## Why

Run-scoped object locking shipped validated only by a manual rig walkthrough. The walkthrough never parked a run, so nobody noticed that its first version released every lock a run held the moment the run suspended — the one moment a lock is for. Three earlier tests asserted that behaviour as correct, because they mocked the seam that was wrong.

This adds real Playwright coverage for the five legs, and each one was proven red against the neutralised code before being kept.

## Where each leg lands, and why it is not split across repos

**All of it is in openregister.** dossiq has the larger suite and owns the case a demo locks, but its shipped case flow uses no lock step — so a "case-flow journey" there would either restate the engine assertions this PR makes, or require adding a lock step to a shipped flow, which is a product change wearing a test's name. openregister owns the lock, the nodes, the write guard and the palette.

Within this repo the split is by what the assertion needs:

| file | legs | why here |
|---|---|---|
| `tests/e2e/api-direct/flow-object-locking.spec.ts` | 1–4 | Needs `occ` to drive the worker, so it cannot join the CI floor. Sits beside `flow-user-task` / `flow-schedule` / `delegation-parking`, which are the same shape. |
| `tests/e2e/ci/flow-lock-nodes.spec.ts` | 5 | Hermetic, non-mutating, no `occ`, no skips — so `ci/*.spec.ts` admits it and CI actually runs it. |

No behaviour is asserted in both.

## The assertions are made through things that can only answer one way

- `@self.locked` is read for `kind` and `runUuid`, not for non-null. An earlier round of tests asserted `locked !== null` and passed against a user lock a run had silently stolen.
- A refusal is asserted as **423 with `lockedByRun` equal to the run uuid**, not as "some 4xx". A 400 from validation and a 500 from an untyped service exception are both "not 200", and neither is a lock.
- A run that should bounce is asserted to reach `failed` **with the holder's uuid in its error**. A run that fails for another reason would otherwise wear this test's green.
- The palette icon is asserted by **fetching the URL the editor will request**, not by checking the field is a non-empty string. The shipped defect was a syntactically perfect path to a file no Nextcloud ships.

## Red-proof, per leg

Each was neutralised on a live rig, the spec run, and the source restored.

| leg | neutralised | the spec went red with |
|---|---|---|
| a parked run keeps its lock | dropped `produced:` from `FlowEngine`'s `enabledAfter`, restoring the false mid-pass terminal | "the parked run holds NO lock — a run that loses its lock the moment it waits has no lock at all" |
| a second run bounces | made a spent wait budget proceed without the lock instead of failing | "the challenger never gave up" — run `completed`, expected `failed` |
| a person is refused, the `runAs` included | keyed run-lock ownership on the user again (the pre-#3444 predicate) | "the run's own runAs user was allowed to write" — PUT answered **200** with the run's lock still on the object |
| a person's lock survives a run | removed the branch making a run and the person it runs as different holders | "the run was handed a person's lock instead of waiting for it" — run `completed`, lock destroyed |
| both nodes in the palette | restored `palette()` resolving the icon inline, icons back on `core/img/actions/lock.svg` | catalogue 27 → 25; both tests red, the editor one naming the palette |

That last proof is why the palette file is **two** tests rather than one. As a single test the run stopped at the catalogue assertion and the editor half never executed — a test whose second half cannot be shown to fire has not been proven, only its first half has.

## Rerunnable on one rig, which took two corrections the rig found

Teardown follows dossiq#1824/#1829: runs stopped, then every lock **broken as the administrator**, then `occ openregister:objects:purge --force --apply`, then the register and schema. Releasing the locks first is not tidiness — a left lock means the object cannot be written, so the next run meets a state the first never saw and fails far from the fixture that caused it.

Two assumptions the rig refused:

- a flow terminated by `openregister.end` commits as **`stopped`**, not `completed` (`stopped` outranks `completed` in the commit path's severity table), so the fixtures end on a step with no outgoing edge instead;
- **`waitSeconds: 1` is racy.** The deadline is persisted with `format('c')`, which truncates to whole seconds, so a budget stamped at `.900` is already spent 200 ms later and the run fails on its *first* attempt instead of parking. Identical fixtures gave `failed` and `suspended` on consecutive runs. The budgets are 3 s and 8 s, with the reason written beside them.

The worker is driven with `occ background-job:execute <id> --force-execute`, never `cron.php`, and each wait sleeps to the run's own `resumeAt` first: a pass fired before a run is due does nothing, and a loop of those fabricates a convincing "wedged forever" that belongs to the test rather than the run.

## Traceability

Nine scenarios in `openspec/changes/run-scoped-object-locking/` now carry `@e2e` references to these files, and the two whose exclusions read "engine-internal, covered by … the rig walk" no longer need one.

## Verified locally

Throwaway rig, own compose project on port 8749 (never `:8080`), NC 32 + PostgreSQL 16, torn down with `down -v`.

- **Both suites run twice on that one rig, identical results:** `4 passed / 0 failed` and `2 passed / 0 failed` each time, and all 6 per-test outcomes match line for line between the passes.
- The instance holds **no** leftover flow, register, schema, object or user from the suite afterwards, so it is rerunnable with no reset.
- Each of the five red-proofs above was executed and the source restored; the full suite is green again on the restored source.
- `prettier --check` and `eslint` both exit **0**.
- Hydra gates (`conduction/hydra-gates` v1.16.0, diff-scoped to `origin/development`) exit **0** — 77 of 77 applicable gates ran, gate-16 spec-coverage PASS, gate-19 advisory-only for the repo-wide legacy backlog.

CI was not waited on; the verification above is local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
