### PR TITLE
spec(flow): plan the ask-node programme as three changes

### DIFF
--- a/openspec/changes/flow-node-taxonomy/.openspec.yaml
+++ b/openspec/changes/flow-node-taxonomy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-06

--- a/openspec/changes/flow-node-taxonomy/design.md
+++ b/openspec/changes/flow-node-taxonomy/design.md
@@ -1,0 +1,70 @@
+# Design
+
+## D-1 · Two axes, because one cannot do both jobs
+
+A single field would have to be either semantic or navigational, and each
+choice loses the other.
+
+Semantic only: the palette groups "Ask a person" with "Approve payroll" and
+"Request a decision" — correct, they are all user tasks — and separates
+"Ask a person" from "Wait for an answer", which are the two halves of one
+authoring decision and belong side by side.
+
+Navigational only: the BPMN interchange has nothing to emit, and would end up
+inferring an element type from a category, which is the mapping this design
+exists to avoid.
+
+n8n reached the same conclusion from the other direction: an architectural
+kind that decides how a node may be wired, and a separate palette category
+that includes "Human in the loop". The categories here are ours because the
+domain is ours; the kinds are BPMN's because an interchange has to speak it.
+
+## D-2 · Why the defaults are on the interface, not enforced
+
+43 of 64 nodes live in repositories this change cannot touch, on their own
+release cycles. Three options existed:
+
+1. Require the methods. Every contributed node fatals on the next release of
+   openregister. Not viable.
+2. Guess on their behalf from the node id or class name. Cheap, and produces
+   a *wrong* BPMN element type that nobody will ever revisit, because it
+   looks answered.
+3. Default them, visibly, and let each owner declare.
+
+Option 3 is the only one where being undeclared is distinguishable from being
+declared. `other` in the palette is a prompt; a guessed `serviceTask` is a
+lie with a long half-life.
+
+The gate then keeps this repository honest without reaching into anyone
+else's.
+
+## D-3 · `receiveTask` is in the `human` category on purpose
+
+The most tempting mistake in the category axis is to derive it from the kind.
+`openregister.await-signal` is a `receiveTask` — it waits for a system to
+call back — and by kind it belongs with the integration steps.
+
+But its docblock already says what it is for: it is the machine-to-machine
+half of a pair whose other half is "Ask a person", and the node's own
+description tells authors which to pick. An author deciding between them is
+looking in one place. Splitting the pair across two palette groups would undo
+the only thing that currently helps them choose.
+
+This is the concrete case that proves the axes must be independent.
+
+## Traps
+
+**Do not let the palette order come from the registry.** Registration order
+depends on which apps are installed and in what order their listeners fire,
+so the same palette reorders itself when an unrelated app is enabled. Fixed
+order, defined once.
+
+**The gate must be scoped by path, not by interface.** A gate that flags any
+`IFlowNode` implementation missing the methods will fire on every contributed
+node in the workspace, which is exactly the behaviour the defaults exist to
+prevent. Scope it to this repository's own node directory.
+
+**`getKind()` describes the step, not its subject.** An object-write step is
+a `serviceTask` because it calls something, not a `businessRuleTask` because
+the object has rules. The first wrong classification here will be copied by
+the next twenty.

--- a/openspec/changes/flow-node-taxonomy/proposal.md
+++ b/openspec/changes/flow-node-taxonomy/proposal.md
@@ -1,0 +1,47 @@
+---
+kind: code
+depends_on: []
+---
+
+## Why
+
+The node catalog on a live instance serves **64 step types as one flat list**: 21 from openregister, 18 from dossiq, 10 from openconnector, 4 from humaniq, 3 from hermiq, 2 from pipelinq. An author opening the palette to add a step is shown all of them, in whatever order the registry happened to collect them, with no grouping and nothing to say that "Wait for an answer" and "Ask a person" are two halves of one decision while "Apply a mapping" is a different kind of thing entirely.
+
+`IFlowNode` declares `getId`, `getDisplayName`, `getDescription`, `getIcon`, `isAvailableForScope`, `validateConfig` and `execute`. There is no notion of a kind or a category anywhere, so there is nothing for a palette to group by and nothing for an exporter to read.
+
+Two established taxonomies apply, and they answer different questions:
+
+- **n8n** types every node architecturally — trigger, action, core, cluster — *and* groups the palette separately, with categories including "Human in the loop". The two axes are independent on purpose: the architecture decides how a node may be wired, the category decides where an author finds it.
+- **BPMN** already defines the semantic taxonomy this domain uses: user task, service task, script task, business rule task, send task, receive task, manual task, gateway, event. `openspec/changes/flow-bpmn-interchange` is already in this repo, and an interchange cannot emit a BPMN element type it never asked the node for.
+
+So the kind is not a new invention to maintain; it is a fact the BPMN work needs anyway, currently inferred nowhere.
+
+## What Changes
+
+- **`IFlowNode` gains `getKind()`**, returning a BPMN element kind: `userTask`, `serviceTask`, `scriptTask`, `businessRuleTask`, `sendTask`, `receiveTask`, `manualTask`, `gateway`, `event`, `subProcess`.
+- **`IFlowNode` gains `getCategory()`**, returning a palette grouping: `triggers`, `human`, `objects`, `logic`, `messaging`, `ai`, `integrations`, `other`.
+- **Both are defaulted, not required.** A node that implements neither is served as `serviceTask` / `other`, so no contributed node in any app breaks and no app is forced to release in step with this. **This is the whole reason the two are separate methods on the interface rather than a required constructor argument**: 43 of the 64 nodes are in repos this change cannot touch.
+- **The catalog serves both**, and the palette groups by category with the categories in a fixed order rather than registration order.
+- **openregister's own 21 nodes declare both.** The other apps' nodes are left to their owners, arriving as `other` until then, which is visibly worse than a wrong guess made on their behalf.
+- **A gate refuses a new openregister node that declares neither**, so the flat list cannot quietly grow back.
+
+## Capabilities
+
+### New Capabilities
+- `flow-node-taxonomy`: what a node's kind and category mean, how they default, how the catalog serves them, and which axis answers which question.
+
+## Impact
+
+| Area | Change |
+|---|---|
+| `lib/Service/Flow/IFlowNode.php` | two methods, both defaulted |
+| `lib/Service/Flow/Nodes/*.php` | 21 nodes declare kind and category |
+| `lib/Service/Flow/FlowNodeRegistry.php` | serves both, applies the defaults |
+| `lib/Controller/FlowController.php` | node catalog response |
+| nextcloud-vue palette | groups by category, fixed order |
+| `.github/hydra-gates` | a gate for an openregister node declaring neither |
+
+## Out of scope, deliberately
+
+- **Assigning kinds to the 43 nodes owned by other apps.** Each app knows whether its step is a service task or a send task; guessing on their behalf would put a wrong answer into a BPMN export, which is worse than an honest `other`.
+- **Emitting BPMN.** That is `flow-bpmn-interchange`. This change gives it the fact it needs; it does not do its job.

--- a/openspec/changes/flow-node-taxonomy/specs/flow-node-taxonomy/spec.md
+++ b/openspec/changes/flow-node-taxonomy/specs/flow-node-taxonomy/spec.md
@@ -1,0 +1,108 @@
+## Purpose
+
+Two independent facts about a step type: what kind of thing it is, and where
+an author should find it. The first is semantic and is what a BPMN export
+needs; the second is a grouping and is what a palette of 64 entries needs.
+
+## ADDED Requirements
+
+### Requirement: A node declares a semantic kind, drawn from BPMN
+
+A step type SHALL be able to declare a kind, and the kind SHALL be one of the
+BPMN element types: `userTask`, `serviceTask`, `scriptTask`,
+`businessRuleTask`, `sendTask`, `receiveTask`, `manualTask`, `gateway`,
+`event`, `subProcess`.
+
+The vocabulary SHALL NOT be extended with terms of our own. Its value is that
+it is the vocabulary an interchange already has to emit; a local synonym
+would have to be mapped back, and the mapping would be the thing that rots.
+
+The kind SHALL describe what the step IS, not what it is about. A step that
+calls an external system is a `serviceTask` whether it calls a payment
+provider or a case register.
+
+#### Scenario: The catalog reports a kind for a node that declares one
+
+- **WHEN** the node catalog is read
+- **THEN** the entry for `openregister.user-task` MUST report the kind
+  `userTask`
+- **AND** the entry for `openregister.switch` MUST report `gateway`
+
+---
+
+### Requirement: A node declares a palette category, independent of its kind
+
+A step type SHALL be able to declare a category, and the category SHALL be
+one of `triggers`, `human`, `objects`, `logic`, `messaging`, `ai`,
+`integrations`, `other`.
+
+The category SHALL be independent of the kind. The two answer different
+questions and a node may pair them freely: "Ask a person" is `userTask` and
+`human`; "Send an email" is `sendTask` and `messaging`; "Wait for an answer"
+is `receiveTask` and also `human`, because an author looking for the other
+half of an approval looks where approvals are.
+
+The palette SHALL present categories in a fixed order and SHALL NOT order
+them by registration. Registration order is an accident of which apps are
+installed, so the same instance can present the palette differently after an
+app is enabled.
+
+#### Scenario: Two nodes of one kind sit in different categories
+
+- **GIVEN** `openregister.send-email` and `openregister.send-notification`,
+  both `sendTask`
+- **WHEN** the palette is grouped
+- **THEN** both MUST appear under `messaging`
+
+#### Scenario: Two nodes of one category have different kinds
+
+- **GIVEN** `openregister.user-task` (`userTask`) and
+  `openregister.await-signal` (`receiveTask`)
+- **WHEN** the palette is grouped
+- **THEN** both MUST appear under `human`
+- **AND** each MUST keep its own kind
+
+---
+
+### Requirement: Both are optional, and a node that declares neither still works
+
+A step type that declares no kind SHALL be served as `serviceTask`. A step
+type that declares no category SHALL be served as `other`.
+
+A node SHALL NOT be refused registration, hidden from the palette, or
+excluded from the catalog for declaring neither.
+
+This is load-bearing rather than lenient. Of the 64 step types on a measured
+instance, 43 are contributed by apps in other repositories, on their own
+release cycles. A required declaration would mean either breaking those apps
+or guessing their semantics for them, and a guessed `serviceTask` written
+into a BPMN export is a wrong answer wearing the appearance of a right one.
+An honest `other` in the palette is visible and gets fixed.
+
+#### Scenario: A contributed node with no declaration is still offered
+
+- **GIVEN** an app contributing a node that implements neither method
+- **WHEN** the catalog is read
+- **THEN** the node MUST appear
+- **AND** it MUST report `serviceTask` and `other`
+
+---
+
+### Requirement: A new node in this repository must declare both
+
+A gate SHALL refuse a step type defined in this repository that declares
+neither a kind nor a category.
+
+The gate SHALL apply only to this repository's own nodes. It SHALL NOT
+inspect nodes contributed by other apps, whose defaults are deliberate.
+
+Without the gate the flat list grows back one node at a time, and each
+addition is individually too small to argue with.
+
+#### Scenario: The gate refuses an undeclared node here and ignores one elsewhere
+
+- **GIVEN** a new step type added under this repository's node directory with
+  no kind and no category
+- **WHEN** the gate runs
+- **THEN** it MUST fail, naming the node
+- **AND** a node in another app's repository MUST NOT be reported

--- a/openspec/changes/flow-node-taxonomy/tasks.md
+++ b/openspec/changes/flow-node-taxonomy/tasks.md
@@ -1,0 +1,33 @@
+# Tasks
+
+## 1. The interface
+
+- [ ] 1.1 `getKind()` and `getCategory()` on `IFlowNode`, both defaulted — `serviceTask` and `other`.
+- [ ] 1.2 Enumerate both vocabularies as constants so a typo is a fatal, not a silent `other`.
+- [ ] 1.3 A test that a node implementing neither is still registered, still in the catalog, and reports the defaults.
+
+## 2. Declare this repository's 21 nodes
+
+- [ ] 2.1 Triggers: `trigger-object`, `trigger-manual`, `trigger-schedule` → `event` / `triggers`.
+- [ ] 2.2 Human: `user-task` → `userTask` / `human`; `portal-task` → `userTask` / `human`; `await-signal` → `receiveTask` / `human` (D-3).
+- [ ] 2.3 Objects: `object-read`, `object-write`, `lock-object`, `unlock-object`, `batch` → `serviceTask` / `objects`.
+- [ ] 2.4 Logic: `switch`, `route`, `filter`, `iterate`, `explode`, `merge`, `map`, `set-fields`, `flow-state`, `wait`, `end`, `sub-flow` → `gateway` or `scriptTask` or `subProcess` as each actually is; `decision-table` → `businessRuleTask` / `logic`.
+- [ ] 2.5 Messaging: `send-email`, `send-notification`, `send-talk-message` → `sendTask` / `messaging`.
+- [ ] 2.6 Review every assignment against the trap: the kind describes the step, not its subject.
+
+## 3. Catalog and palette
+
+- [ ] 3.1 The registry applies the defaults; the catalog serves both fields.
+- [ ] 3.2 The palette groups by category in a fixed order, never registration order.
+- [ ] 3.3 nc-vue: grouped palette, jest spec seen RED first, en/nl for the category labels with the `writing` skill loaded first.
+
+## 4. The gate
+
+- [ ] 4.1 A hydra gate refusing a node in THIS repository's node directory that declares neither. Scoped by path (D-3 trap), never by interface.
+- [ ] 4.2 An acceptance fixture with a planted undeclared node, so the gate is proven to refuse rather than assumed to.
+
+## 5. Proof
+
+- [ ] 5.1 Playwright: the catalog reports a kind and a category for every openregister node, and the palette renders grouped.
+- [ ] 5.2 Assert a contributed node with no declaration still appears, under `other`.
+- [ ] 5.3 `composer check:strict`, both l10n gates, full unit suite. Exit code, not summary line.

--- a/openspec/changes/flow-run-subjects-and-answers/.openspec.yaml
+++ b/openspec/changes/flow-run-subjects-and-answers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-06

--- a/openspec/changes/flow-run-subjects-and-answers/design.md
+++ b/openspec/changes/flow-run-subjects-and-answers/design.md
@@ -1,0 +1,45 @@
+# Design
+
+## D-1 · Why a declared set rather than deriving one
+
+The audit trail already answers "what did this run write", and `flow-object-attribution` built the endpoint for it. It is tempting to reuse that as the run's object set and add nothing.
+
+It cannot serve this purpose, for a reason that only shows up in the flows that need it. A case flow reads a case it never writes; it writes a task, a document and an audit row it does not consider a subject; and it may write the same object at three steps for three different reasons. The derived list therefore contains too much and too little at once, and — decisively — it carries **no role**. `attachTo: case` needs a name, and a list of things that happened has none to give.
+
+So the two coexist. Derived answers the auditor. Declared answers the author.
+
+## D-2 · Why a role and not an index
+
+`attachTo: 2` would work and would be unreadable, and would break the moment a step is inserted. A role is the flow author's own word for what the object is *to this flow*, which is the thing later steps actually mean.
+
+Roles are per-run and unconstrained on purpose. There is no vocabulary to register and no schema to keep in step: `case`, `besluit`, `aanvraag` are all fine, and a typo is caught by the addressing rule failing loudly rather than by a registry the author has to maintain.
+
+## D-3 · Replacement is recorded, not refused
+
+Re-pointing a role is legitimate: a flow that supersedes a draft decision with a final one genuinely means `decision` to be the new object. Refusing would force authors into `decision2`.
+
+But it is also exactly how a later step silently attaches to the wrong record. So it is allowed and logged. The log entry is what makes the eventual "why is this task on the old decision" answerable in under a minute.
+
+## D-4 · Attaching through the task's existing object fields
+
+`Task` already has `objectUuid`, `registerId` and `schemaId`, and three things already read them: the subject-anchored inbox query (which also relaxes the external-performer exclusion on that anchor), the case sidebar, and the portal visibility rule.
+
+Filling those from the subject entry means the attachment works everywhere immediately. A new `attachedSubjectRole` column would have needed all three taught about it, and the two that were not taught would have been found by a user.
+
+## D-5 · The answers fix is one line, and that is the point
+
+`outcomeBagFor()` gains `answers`. `PortalTaskNode` line 450 has done exactly this since it was written.
+
+The interesting question is why nobody noticed. Because the feature reads as complete from every angle except the last: the form is declared, refused at save if it names a field the schema lacks, rendered to the performer, validated on completion, and stored. Every one of those has a test. None of them asserts that a *following step* can see the value, so the one hop that was missing was the one hop nothing looked at.
+
+The test that closes it must therefore be a downstream assertion — a Switch routing on `answers.x` — not another assertion that the responses were stored.
+
+## Traps
+
+**An absent `answers` key and an empty one are different failures.** Omitting the key when a step declares no form would make every downstream expression need two guards. Always present, sometimes empty.
+
+**The subject set must survive suspension.** It lives on the run row, not in the resume slot: slots are per node, and a run holds one per node. A three-week approval must wake up still knowing what its case is.
+
+**Idempotency is not optional here.** A user-task node is re-entered on a heartbeat, by design, with the task still open. Any node that records a subject will be re-entered too, and a set that grew on each wake would report a run as working on the same case forty times.
+
+**Do not seed declared subjects from the audit in the migration.** The repair seeds the `trigger` entry from `subjectUuid` and nothing else. Back-filling roles from what old runs wrote would invent declarations the authors never made, and those declarations would then be addressable by `attachTo`.

--- a/openspec/changes/flow-run-subjects-and-answers/proposal.md
+++ b/openspec/changes/flow-run-subjects-and-answers/proposal.md
@@ -1,0 +1,49 @@
+---
+kind: code
+depends_on: []
+---
+
+## Why
+
+Two gaps, found by asking one question of a working flow: *what did the person answer, and what is this run working on?*
+
+**A user-task form's answers never reach the run.** `PortalTaskNode` line 450 puts them there: `$bag['answers'] = $task->getResponses()`. `FlowTaskBridge::outcomeBagFor()` — the bag `UserTaskNode` uses — has no `answers` key at all. It carries the outcome, the comment, the result text and the performer fields, and nothing the performer filled in.
+
+So a step may declare a form (`formKind: fields`, `formFields`, `formAction`), the performer may fill it in, the values are validated against the subject schema and written to `task.responses`, and then they stop. No later step can route on them, read them, or write them anywhere. The feature exists end to end except for the last hop, and the portal node proves the hop is one line.
+
+**A run records one object and touches many.** `FlowRun` carries `subjectUuid`, `subjectRegister`, `subjectSchema` — the thing that triggered it. `Task` carries one `objectUuid`. `GET /api/flow-runs/{uuid}/objects` exists but is derived from the audit trail: it answers *what did this run write*, which is a different question from *what is this run working on*.
+
+The difference matters as soon as a step wants to attach something. A case flow creates a case, locks it, asks somebody for a go, and records the decision. The decision belongs to the person, to the run, **and to the case** — and there is no declared set for a node to point at. A node cannot say "attach this task to the case" because nothing names the case except the trigger, and by step nine the trigger may not be the object anyone means.
+
+## What Changes
+
+- **The outcome bag carries the answers.** `outcomeBagFor()` gains `answers` from `task.responses`, the way the portal node already does, so a Switch can route on what somebody filled in. **This is a bug fix, not a feature**: the values were being collected and discarded.
+- **A run keeps a declared set of subjects.** `FlowRun` gains `subjects`: an ordered set of `{register, schema, uuid, role}` entries, where `role` is a short author-chosen name (`case`, `decision`, `document`). The trigger's subject is the first entry, with the role `trigger`, so a run with no declared subjects behaves exactly as it does now.
+- **Nodes add to it, by declaration.** `openregister.object-write` and `openregister.lock-object` accept `subjectRole`; naming one records the object they acted on under that role. Nothing is added implicitly — an implicit set would be the audit-derived list again, and that already exists.
+- **A task can attach to a subject.** `UserTaskNode` accepts `attachTo: <role>`. The task's existing `objectUuid`/`registerId`/`schemaId` are filled from that entry, so the attachment rides fields the task row and the inbox already have. Naming a role the run has not recorded fails the step, rather than creating a task attached to nothing.
+- **`GET /api/flow-runs/{uuid}` serves the declared subjects**, distinct from `/objects`, which keeps its audit-derived meaning. Two questions, two answers, neither pretending to be the other.
+
+## Capabilities
+
+### New Capabilities
+- `flow-run-subjects`: what a run's declared subject set is, how a node adds to it, how a role is addressed, and how it differs from the audit-derived objects a run touched.
+
+### Modified Capabilities
+- `flow-user-task-node`: the outcome bag carries the performer's answers; a step may attach its task to a declared subject.
+
+## Impact
+
+| Area | Change |
+|---|---|
+| `lib/Service/Flow/FlowTaskBridge.php` | `outcomeBagFor()` gains `answers` |
+| `lib/Db/FlowRun.php` | `subjects` json column |
+| `lib/Migration/` | the column, plus a repair seeding the trigger entry on open runs |
+| `lib/Service/Flow/FlowRunSubjects.php` | new — reading, adding, addressing by role |
+| `lib/Service/Flow/Nodes/ObjectWriteNode.php`, `LockObjectNode.php` | optional `subjectRole` |
+| `lib/Service/Flow/Nodes/UserTaskNode.php` | optional `attachTo` |
+| `lib/Controller/FlowRunController.php` | subjects on the run read |
+
+## Out of scope, deliberately
+
+- **Typed performers and the assignee picker** — `flow-typed-principals`, a different surface.
+- **Changing what `/objects` means.** It is audit-derived and should stay so. A run's declared subjects and the objects it wrote are different facts, and collapsing them would lose the one an auditor needs.

--- a/openspec/changes/flow-run-subjects-and-answers/specs/flow-run-subjects/spec.md
+++ b/openspec/changes/flow-run-subjects-and-answers/specs/flow-run-subjects/spec.md
@@ -1,0 +1,108 @@
+## Purpose
+
+The objects a run is deliberately working with, named by role, so a later step
+can point at one. Distinct from the objects a run has written, which the audit
+trail already answers.
+
+## ADDED Requirements
+
+### Requirement: A run keeps an ordered set of declared subjects
+
+A flow run SHALL carry a set of subject entries. Each entry SHALL name a
+`register`, a `schema`, a `uuid`, and a `role`: a short name chosen by the
+flow's author, such as `case` or `decision`.
+
+A role SHALL be unique within a run. Recording a second object under a role
+already held SHALL replace the entry, and the replacement SHALL be recorded in
+the run's log — a flow that quietly re-points `case` halfway through is a flow
+whose later steps attach to something the author did not mean.
+
+The run's triggering object, where it has one, SHALL be the first entry, with
+the role `trigger`. A run that declares nothing else therefore holds exactly
+the fact `subjectUuid` already holds, and behaves as it does today.
+
+The set SHALL be persisted with the run and SHALL survive suspension and
+resumption. A run parked on a human task for three weeks must still know what
+it is working on.
+
+#### Scenario: A run with no declarations holds only its trigger
+
+- **GIVEN** a flow with no node declaring a subject role
+- **WHEN** it runs from an object trigger
+- **THEN** the run's subjects MUST hold exactly one entry, with role `trigger`
+- **AND** it MUST name the triggering object
+
+#### Scenario: Re-pointing a role replaces and is recorded
+
+- **GIVEN** a run that has recorded object A under the role `case`
+- **WHEN** a later step records object B under `case`
+- **THEN** the entry MUST name B
+- **AND** the run's log MUST record the replacement
+
+---
+
+### Requirement: A node adds a subject only by declaring it
+
+A node SHALL record an object into the subject set only when its
+configuration names a role for it. A node that names no role SHALL record
+nothing.
+
+The system SHALL NOT populate the set implicitly from what nodes write.
+Implicit population is the audit-derived list, which already exists and
+answers a different question; a set that filled itself would answer neither
+question well.
+
+Recording SHALL be idempotent for a node that fires more than once with the
+same object and role, so a heartbeat wake, a retry or a resumed run does not
+grow the set.
+
+#### Scenario: A write with no role changes nothing
+
+- **GIVEN** an object-write step with no `subjectRole`
+- **WHEN** it writes an object
+- **THEN** the run's subject set MUST be unchanged
+- **AND** the audit-derived objects list MUST still show the write
+
+#### Scenario: A re-fired node does not duplicate an entry
+
+- **GIVEN** a step that recorded object A under `case`
+- **WHEN** the same step fires again with the same object
+- **THEN** the set MUST still hold one entry for `case`
+
+---
+
+### Requirement: Addressing a role the run has not recorded fails the step
+
+When a node names a subject role in order to READ it, and the run holds no
+entry under that role, the node SHALL fail the step, naming the role and
+listing the roles the run does hold.
+
+The system SHALL NOT fall back to the trigger. A step that asked for `case`
+and silently got the triggering object would attach a decision to the wrong
+record, and would do so most often in exactly the flows complex enough for
+the two to differ.
+
+#### Scenario: An unknown role fails loudly and says what is available
+
+- **GIVEN** a run holding subjects under `trigger` and `case`
+- **WHEN** a step addresses the role `decision`
+- **THEN** the step MUST fail
+- **AND** the failure MUST name `decision` and list `trigger` and `case`
+
+---
+
+### Requirement: The declared subjects and the touched objects are read separately
+
+The run read SHALL serve the declared subject set. The existing objects
+endpoint SHALL keep its audit-derived meaning and SHALL NOT be changed to
+serve declarations.
+
+The two answer different questions — *what is this run working on* and *what
+has this run written* — and an object may appear in either, both, or neither.
+
+#### Scenario: An object read but never written appears only in the declarations
+
+- **GIVEN** a run that recorded a case under `case` and never wrote to it
+- **WHEN** both reads are made
+- **THEN** the declared subjects MUST include the case
+- **AND** the audit-derived objects MUST NOT

--- a/openspec/changes/flow-run-subjects-and-answers/specs/flow-user-task-node/spec.md
+++ b/openspec/changes/flow-run-subjects-and-answers/specs/flow-user-task-node/spec.md
@@ -1,0 +1,68 @@
+## MODIFIED Requirements
+
+### Requirement: The outcome is written onto every item, not only onto the run
+
+The outcome bag a user-task step places on its items SHALL include the
+performer's form answers, under the key `answers`, taken from the task's
+recorded responses.
+
+An empty or absent set of responses SHALL yield an empty `answers`, never a
+missing key. A downstream expression reading `answers.reason` must fail the
+same way whether the form was skipped or the step declared none, rather than
+failing differently and teaching authors to guard for both.
+
+This closes a gap rather than adding a feature: a step could already declare
+a form, the values were already validated against the subject schema and
+already stored on the task, and the portal-task node already places them on
+its bag. Only this node's bag omitted them, so every answer a person typed
+was collected and then discarded.
+
+#### Scenario: A form answer reaches the following step
+
+- **GIVEN** a user-task step declaring the fields `reason` and `amount`
+- **WHEN** the performer completes it, filling both
+- **THEN** the items leaving the step MUST carry `answers.reason` and
+  `answers.amount`
+- **AND** a Switch on `answers.reason` MUST be able to route on it
+
+#### Scenario: A step with no form yields an empty answers set
+
+- **GIVEN** a user-task step declaring no form
+- **WHEN** it is completed
+- **THEN** the bag MUST carry `answers` as an empty set, not omit it
+
+---
+
+### Requirement: A step may attach its task to a declared subject
+
+A user-task step SHALL accept an `attachTo` naming a subject role of its run.
+When it is given, the created task SHALL be anchored to that entry through the
+task's existing object fields.
+
+Naming a role the run does not hold SHALL fail the step, per the subject
+capability. It SHALL NOT create an unattached task: a task attached to nothing
+is exactly the task an author believed was attached to the case.
+
+A step naming no `attachTo` SHALL create the task with no object anchor, as it
+does today.
+
+The anchor SHALL use the task row's existing object fields rather than a new
+one, so the subject-anchored inbox read, the case sidebar and the portal
+visibility rule all keep working with no change.
+
+#### Scenario: A go is recorded against the case, the run and the person
+
+- **GIVEN** a run holding a case under the role `case`
+- **AND** a user-task step with `attachTo: case`
+- **WHEN** the step creates its task
+- **THEN** the task MUST carry the run uuid, the node id, and the case's
+  register, schema and uuid
+- **AND** the task MUST appear in the case's subject-anchored task list
+
+#### Scenario: Attaching to a role the run never recorded fails the step
+
+- **GIVEN** a run holding no `case` entry
+- **AND** a step with `attachTo: case`
+- **WHEN** the run reaches it
+- **THEN** the step MUST fail naming the role
+- **AND** no task MUST be created

--- a/openspec/changes/flow-run-subjects-and-answers/tasks.md
+++ b/openspec/changes/flow-run-subjects-and-answers/tasks.md
@@ -1,0 +1,38 @@
+# Tasks
+
+## 1. The answers fix, first and on its own
+
+- [ ] 1.1 A test asserting a **downstream** step can route on `answers.x`, seen RED. Not another assertion that responses were stored — D-5.
+- [ ] 1.2 `FlowTaskBridge::outcomeBagFor()` gains `answers` from `task.responses`, empty set when absent, never a missing key.
+- [ ] 1.3 A test for the empty case, so the two failure shapes stay one shape.
+- [ ] 1.4 Check the portal node still places its own `answers` and that the two paths now agree.
+
+## 2. The subject set
+
+- [ ] 2.1 `subjects` json column on `FlowRun`, plus the entity accessors.
+- [ ] 2.2 Migration for the column, and a repair seeding ONLY the `trigger` entry from `subjectUuid` on runs that have one. Nothing back-filled from the audit — see the trap.
+- [ ] 2.3 Bump `<version>` in `appinfo/info.xml` in the same commit or the repair never runs (gate-110).
+- [ ] 2.4 `FlowRunSubjects`: read, record (replace-and-log on a held role), address-by-role, idempotent re-record.
+- [ ] 2.5 Unit tests seen RED: trigger-only default; replacement logged; re-fire does not duplicate; unknown role fails naming the roles held.
+
+## 3. Nodes that record
+
+- [ ] 3.1 Optional `subjectRole` on `openregister.object-write` and `openregister.lock-object`.
+- [ ] 3.2 No role, no recording — assert the audit-derived list still shows the write.
+
+## 4. Attaching a task
+
+- [ ] 4.1 Optional `attachTo` on `openregister.user-task`, filling the task's existing `objectUuid`/`registerId`/`schemaId` — D-4, not a new column.
+- [ ] 4.2 An unheld role fails the step and creates no task.
+- [ ] 4.3 Assert the attached task appears in the subject-anchored inbox read and in the case sidebar, since those are the readers the choice of fields was made for.
+
+## 5. Reading it back
+
+- [ ] 5.1 `GET /api/flow-runs/{uuid}` serves the declared subjects.
+- [ ] 5.2 `/objects` is untouched. A test asserting an object read but never written appears in one and not the other.
+
+## 6. Proof
+
+- [ ] 6.1 Playwright, over the live API, the whole scene from the brief: a case is created and recorded as `case`, locked, a person is asked with `attachTo: case`, they answer with a form value, and the answer routes a Switch. Assert the task is on the case, the run and the person.
+- [ ] 6.2 Playwright: `attachTo` naming an unheld role fails the step and leaves no task.
+- [ ] 6.3 `composer check:strict`, both l10n gates, full unit suite. Exit code, not summary line.

--- a/openspec/changes/flow-typed-principals/.openspec.yaml
+++ b/openspec/changes/flow-typed-principals/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-06

--- a/openspec/changes/flow-typed-principals/design.md
+++ b/openspec/changes/flow-typed-principals/design.md
@@ -1,0 +1,132 @@
+# Design
+
+## The decision behind every other decision
+
+A performer reference is **resolved late and re-resolved every time**, never
+frozen at task creation.
+
+The alternative — resolve once, store the uids, authorise against those — is
+simpler, faster, and wrong for the domain. A municipal approval outlives the
+roster it was raised against. A task assigned to the bezwaarcommissie in
+March must be answerable by whoever sits on it in June, and a task assigned
+to the *afdelingshoofd* must follow the post, not the person who held it. The
+frozen design gets that backwards in the direction that hurts: it keeps
+authorising someone who has left and stops authorising the person now
+responsible.
+
+The cost is a resolver call on every answer. That is one membership lookup on
+a verb a human is performing by hand, which is not a budget worth optimising
+against correctness.
+
+The resolution IS recorded, as `flow-tasks` requires — but as evidence,
+consulted by no guard. Confusing those two is how a "who was asked" audit
+field quietly becomes an authorisation bypass.
+
+## D-1 · Why an event and not an interface the apps implement directly
+
+Flow nodes are already contributed through `RegisterFlowNodesEvent`, and
+principals take the same path for the same three reasons: OpenRegister must
+not name a consuming app (gate-27, ADR-022); a type whose app is not
+installed must simply be absent rather than fatal; and the registration point
+is already a place the fleet's developers know to look.
+
+The resolver interface lives in OpenRegister and is implemented in the app
+that owns the concept. decidiq knows what a position on a body is; hermiq
+knows what a function is; dossiq knows what a case role is. None of that
+knowledge can move into the engine without the engine growing opinions about
+municipal organisation charts.
+
+## D-2 · Why the type is refused at save and the resolution at run
+
+These are two different kinds of wrongness and they are discovered by two
+different people.
+
+An **unknown type** is a defect in the document. The author is at the
+keyboard, the field is on screen, and the fix is to pick a different type.
+Refusing at save puts the error in front of the only person who can act on
+it.
+
+An **empty resolution** is a fact about the instance, and it changes. A
+committee with no members today has members next week. Refusing to *save* a
+flow because a group is momentarily empty would make the flow unauthorable
+for a reason that has nothing to do with the flow. Refusing to *create the
+task* is the right moment: that is when somebody actually needs to be found.
+
+The failure mode this replaces is the one that was measured — a task created
+for nobody, a run suspended, a heartbeat re-reading it every few minutes, and
+no signal anywhere. Silence was the defect. A loud step failure, subject to
+the flow's own error policy, is strictly better even when the author chooses
+to continue past it.
+
+## D-3 · Collapsing three candidate fields into one
+
+`candidateUsers`, `candidateGroups` and `candidateRole` are three fields that
+differ only in the kind of thing you type into them. That is a type system
+implemented as field names, and it exists only because the field was a text
+box.
+
+With typed references, one `candidates` field expresses all three and more,
+including a mix. The three keep working as input — they are read as
+candidates of type `user`, `group` and `role` — so no stored flow changes
+meaning and no migration is required for them.
+
+The one thing lost is the ability to say "these users AND these groups" as
+separate, separately-meaningful lists. Nothing in the routing strategies
+reads them separately, so nothing loses a capability.
+
+## D-4 · What the repair may and may not guess
+
+The repair rewrites a stored string to a typed reference by resolving it
+once. Three outcomes, and only one of them may be acted on:
+
+| Resolves under | Action | Why |
+|---|---|---|
+| exactly one type | rewrite | unambiguous; the string meant that |
+| more than one type | leave, report | guessing moves who may answer, silently |
+| no type | leave, report | already broken; the repair says so, it does not become the breakage |
+
+The ambiguous case is not hypothetical. A Nextcloud instance may hold a user
+and a group of the same name, and the existing `mayAnswer` accepts BOTH — uid
+equality first, then group membership — so today's behaviour is genuinely the
+union. Any rewrite narrows it. That is a decision for a person.
+
+🔴 The repair MUST NOT fail the upgrade over unresolvable strings. On the
+measured instance that would have meant 27 failures on a routine `occ
+upgrade`, for flows that were already broken before the repair existed.
+A repair step that turns pre-existing breakage into an upgrade failure is
+worse than the breakage.
+
+## D-5 · Why `performerType` goes away
+
+`Task.performerType` accepts `user | group | agent | worker` and the node
+exposed it as a free-typed word. With every reference carrying its own type,
+the field is a second, weaker copy of the same fact, and two sources of one
+truth is how they drift.
+
+The **column** stays, because it is on the task row and other things read it.
+It becomes derived: written from the resolved reference's type, never
+authored.
+
+## Traps
+
+**A bare string must keep meaning `user`.** Reading it as "try every type"
+would be friendlier and would silently widen who may answer on every existing
+flow. The current guard tries uid first, so `user` is the reading that
+preserves behaviour.
+
+**`mayAnswer` is called on a hot path and on a cold one.** It guards the
+completion verb, and it is also consulted by inbox projections. A resolver
+that is cheap for one group is expensive for a hundred rows. Inbox scoping
+must keep predicating in the datastore rather than resolving row by row in
+PHP; the resolver decides *authorisation*, not *listing*.
+
+**An agent is a performer, and agents are not users.** The `agent` resolver
+must return something the answer guard can compare against, which means an
+agent turn completes as a real identity. Whatever that identity is, it must
+not be a member of the groups a human performer belongs to, or an agent step
+would be answerable by the humans and vice versa.
+
+**Do not let the picker become the contract.** The `principal` field type
+tells the editor how to draw a field. What is *valid* is decided by the
+resolver registry on the server. An editor that offers only what it can search
+must still accept a reference typed by an app whose search it does not know.

--- a/openspec/changes/flow-typed-principals/proposal.md
+++ b/openspec/changes/flow-typed-principals/proposal.md
@@ -1,0 +1,59 @@
+---
+kind: code
+depends_on: []
+---
+
+## Why
+
+A flow step that asks a person names that person as **a string typed into a text box**, and nothing ever checks that the string names anybody.
+
+This is not a theoretical gap. Measured on the demo instance, 2026-09-06:
+
+- 24 flows carry **30 `dossiq.askPerson` nodes**. Their assignees are role names: `Beleidsadviseur`, `juridische-dienst`, `Afdelingshoofd`, `Gemeentesecretaris`, `Griffier`, `financieel-adviseur`, `teamleider`, `burgemeester`, `bezwaarcommissie`.
+- `FlowRunAssignee::mayAnswer()` accepts an answer only when the answerer's uid **equals** the assignee string, or the answerer is in a **group named exactly** that string.
+- Of those 30 nodes, **3 resolved. 27 could be answered by nobody on the instance** — not even by an administrator. The run suspends, the heartbeat re-reads forever, and nothing anywhere says why.
+- The same role appears under two spellings in one instance (`Afdelingshoofd` / `afdelingshoofd`, `Gemeentesecretaris` / `gemeentesecretaris`). That is what a free-text box produces.
+
+`validateConfig()` already refuses an *empty* assignee, with a good comment about why an unassigned task is a task anyone may complete. It cannot refuse a *non-resolving* one, because a bare string carries no type to resolve against.
+
+The vocabulary for fixing this is half-built already and unreachable. `Task.performerType` accepts `user`, `group`, `agent` and `worker`; `UserTaskNode` exposes `assignee`, `candidateUsers`, `candidateGroups`, `candidateRole`, `routingStrategy` and `performerType`. Every one of them is declared `'type' => 'text'` in the node's config form, so the editor draws seven text boxes and the author is asked to remember uids. Meanwhile the kinds of performer a Dutch municipality actually routes to — a **position** in a body (decidiq), a **function** (hermiq) — cannot be named at all.
+
+## What Changes
+
+- **A performer is a typed reference, not a string.** `assignee` and the candidate fields accept `{type, id}` where `type` is one of `user`, `group`, `role`, `position`, `function` or `agent`. A bare string keeps working and is read as `{type: 'user', id: <string>}`, so no existing flow changes meaning.
+- **`IPrincipalResolver`, contributed the way flow nodes already are.** OpenRegister owns `user` and `group`; a consuming app registers a resolver for its own type through a `RegisterPrincipalResolversEvent`, the same recipe as `RegisterFlowNodesEvent`. decidiq contributes `position`, hermiq contributes `function`, dossiq contributes its case `role`. OpenRegister never calls those apps directly (gate-27, ADR-022).
+- **A reference that cannot resolve fails when it is authored, not when a person is needed.** `validateConfig()` refuses a reference whose *type* has no registered resolver. Task creation refuses a reference that resolves to **nobody**, loudly, instead of parking a task in the void — which is the defect above, converted from silence into a refusal the author can act on.
+- **`mayAnswer()` asks the resolver.** It stops string-matching a uid and a group id, so a position or a function authorises an answer on the same terms a group does. **BREAKING for one edge case**: a task whose assignee string happens to equal a *group* name is authorised today by accident of spelling; after this it is authorised because the reference says `group`. A repair step migrates stored assignee strings to typed references by resolving them once, and reports every one it cannot.
+- **A searchable picker replaces the seven text boxes.** A new `principal` field type in the node catalog, rendered by nc-vue as a multi-select that searches users and groups as you type (`shareTypes[]=0,1`) plus the types apps contribute. The existing `user` widget stays for `runAs`, which takes one uid and means something different.
+- **Agent becomes a performer of this node.** `performerType: agent` gains a `prompt`, dispatched through the `AgentRunRequestedEvent` already designed in `flow-agent-action`, so an agent's answer is a task row with the same audit and the same handover to a person. `hermiq.agent-step` is untouched and stays the way to run a turn that is not a question.
+- The node is renamed **"Ask a person or group"**, because it always could ask a group and never said so.
+
+## Capabilities
+
+### New Capabilities
+- `flow-typed-principals`: what a typed performer reference is, how a resolver is contributed and consulted, when an unresolvable reference is refused, and how an answer is authorised through it.
+
+### Modified Capabilities
+- `flow-user-task-node`: the assignee vocabulary becomes typed; the node declares a `principal` field type; agent gains a prompt; the display name changes.
+- `flow-node-config-forms`: the catalog gains the `principal` field type and its contributed option sources.
+- `flow-tasks`: `mayAnswer` is resolver-backed rather than string-matched; task creation refuses an empty resolution.
+
+## Impact
+
+| Area | Change |
+|---|---|
+| `lib/Service/Flow/FlowRunAssignee.php` | `mayAnswer` consults the resolver registry instead of comparing strings |
+| `lib/Service/Flow/PrincipalResolver/` | new — the registry, the `user` and `group` resolvers, the reference value object |
+| `lib/Service/Flow/RegisterPrincipalResolversEvent.php` | new — the contribution seam |
+| `lib/Service/Flow/Nodes/UserTaskConfig.php` | parses and validates typed references; refuses an unresolvable type |
+| `lib/Service/Flow/Nodes/UserTaskNode.php` | `principal` field type, agent prompt, new display name |
+| `lib/Service/Task/TaskBuilder.php` | stores the resolved performers alongside the reference |
+| `lib/Migration/` | repair step migrating stored assignee strings to typed references, reporting what it cannot resolve |
+| nextcloud-vue `CnFlowNodeEditModal.vue` | the `principal` widget |
+| decidiq / hermiq / dossiq | one resolver each, in their own repos, after this lands |
+
+## Out of scope, deliberately
+
+- **Returning a task form's answers into the run.** `FlowTaskBridge::outcomeBagFor()` has no `answers` key while `PortalTaskNode` line 450 does, so a user-task form's values die on the task row. That is a real defect and it is a different surface; it belongs with the run's declared object set in its own change.
+- **Categorising the node palette.** The catalog serves 64 node types as one flat list. Also real, also separate: it touches every node in the fleet and none of this.
+- **Retiring `dossiq.askPerson`.** It depends on this landing first, it lives in another repo, and per ADR-032 a change that mixes an engine refactor with a cross-app migration is the shape that burns a cycle without shipping.

--- a/openspec/changes/flow-typed-principals/specs/flow-tasks/spec.md
+++ b/openspec/changes/flow-typed-principals/specs/flow-tasks/spec.md
@@ -1,0 +1,59 @@
+## MODIFIED Requirements
+
+### Requirement: Who may answer a task is decided by resolving its performers
+
+The task service SHALL decide whether a caller may answer a task by resolving
+the task's performer references through the principal resolvers and asking
+whether the caller is among the resulting user ids.
+
+It SHALL NOT decide this by string comparison against the stored assignee,
+and SHALL NOT decide it by group membership inferred from the assignee's
+spelling. Those two rules are the whole of the current decision, and together
+they mean a performer is authorised only when somebody happened to name a
+group exactly right.
+
+The five sanctioned visibility relationships are unchanged. Only the
+resolution of *performer* changes: `requester`, `watcher`, administrator and
+subject-anchored visibility all keep their present meaning.
+
+A task naming no performer SHALL keep whatever behaviour it has today. This
+change narrows nothing and widens nothing about unassigned tasks.
+
+#### Scenario: A resolved performer may answer
+
+- **GIVEN** a task assigned to `{type: 'group', id: 'behandelaars'}`
+- **AND** alice is a member of that group
+- **WHEN** alice completes the task
+- **THEN** the completion MUST be accepted
+
+#### Scenario: A caller outside every resolution may not answer
+
+- **GIVEN** the same task
+- **AND** bob is in no group and is not the requester or a watcher
+- **WHEN** bob attempts to complete it
+- **THEN** the attempt MUST be refused
+
+---
+
+### Requirement: A task records both the reference and the resolution that created it
+
+A task SHALL store the performer reference as authored, and SHALL
+additionally record the user ids that reference resolved to at the moment the
+task was created.
+
+The stored reference is what authorises: it is re-resolved on every answer,
+so a task follows the role rather than the roster.
+
+The recorded resolution is evidence, not authority. It answers "who was this
+in front of when it was raised", which is the question an audit asks after a
+committee has been re-composed and the reference alone can no longer say. It
+SHALL NOT be consulted by the answer guard.
+
+#### Scenario: The recorded resolution does not authorise a former member
+
+- **GIVEN** a task created while alice was in `juristen`
+- **AND** alice has since left that group
+- **WHEN** alice attempts to answer
+- **THEN** the attempt MUST be refused
+- **AND** the recorded resolution MUST still show alice, as evidence of who
+  was asked

--- a/openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+++ b/openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
@@ -1,0 +1,216 @@
+## Purpose
+
+What it means to name a performer in a flow: a reference that carries its own
+type, a registry of resolvers that turn a type and an id into real people, a
+refusal at authoring time when the type is unknown and at creation time when
+the reference names nobody, and one predicate that decides who may answer.
+
+The property this capability exists to guarantee is narrow and was measurably
+absent: **a step that asks somebody must be answerable by somebody.**
+
+## ADDED Requirements
+
+### Requirement: A performer reference carries its own type
+
+The system SHALL represent a performer as a reference of the shape
+`{type, id}`, where `type` names a kind of principal and `id` identifies one
+within that kind.
+
+The system SHALL accept the following types in the engine itself: `user` and
+`group`. It SHALL accept any further type for which a resolver has been
+registered, and the engine SHALL NOT enumerate those types in its own code.
+
+A **bare string** SHALL be read as `{type: 'user', id: <string>}`. Every
+performer stored before this capability existed is a bare string, and reading
+it as a user reference preserves exactly the behaviour those flows have
+today: `mayAnswer` matched a uid first.
+
+A reference SHALL be accepted anywhere a performer is named: the direct
+assignee, the candidate list and the routing fallback alike. A field that
+takes several performers SHALL accept a list of references, mixing types
+freely — a step may offer a task to one named person and two groups.
+
+#### Scenario: A typed reference names a group
+
+- **GIVEN** a step whose assignee is `{type: 'group', id: 'behandelaars'}`
+- **WHEN** the step creates its task
+- **THEN** the task MUST record the reference as given
+- **AND** every member of `behandelaars` MUST be able to answer it
+
+#### Scenario: A bare string still means a user
+
+- **GIVEN** a step, authored before this capability, whose assignee is the
+  bare string `alice`
+- **WHEN** the step creates its task
+- **THEN** the reference MUST be read as `{type: 'user', id: 'alice'}`
+- **AND** the behaviour MUST be indistinguishable from before
+
+#### Scenario: One field carries several references of different types
+
+- **GIVEN** a step whose candidates are `{type: 'user', id: 'alice'}` and
+  `{type: 'group', id: 'juristen'}`
+- **WHEN** the step creates its task
+- **THEN** both MUST be recorded
+- **AND** alice MUST be able to claim it, and so MUST any member of
+  `juristen`
+
+---
+
+### Requirement: A resolver is contributed, never hard-coded
+
+The system SHALL define an `IPrincipalResolver` interface. An implementation
+SHALL declare the one type it resolves, and SHALL answer, for a given id, the
+set of user ids that are the principal for that id at the moment it is asked.
+
+The system SHALL collect resolvers through a dispatched registration event,
+the same recipe by which flow nodes are already contributed. OpenRegister
+SHALL register the `user` and `group` resolvers itself. Any other type SHALL
+come from a consuming app registering a listener.
+
+OpenRegister SHALL NOT call a consuming app directly to resolve a principal,
+and SHALL NOT name decidiq, hermiq or dossiq anywhere in this mechanism. A
+type whose owning app is absent from an instance SHALL simply have no
+resolver there, which is a refusal (see below), not an error at boot.
+
+Resolution SHALL be evaluated when it is needed and SHALL NOT be cached
+across requests. Group membership, committee composition and job function all
+change while a task is open, and a task that outlives a reorganisation must be
+answerable by whoever holds the role now, not by whoever held it when the run
+started.
+
+#### Scenario: An app contributes a type the engine has never heard of
+
+- **GIVEN** an app that registers a resolver for the type `position`
+- **WHEN** a step names `{type: 'position', id: 'voorzitter'}`
+- **THEN** the reference MUST be accepted
+- **AND** the engine MUST resolve it by calling that resolver
+
+#### Scenario: Membership is read when it is asked, not when the task was made
+
+- **GIVEN** an open task assigned to `{type: 'group', id: 'juristen'}`
+- **AND** the task was created while alice was not a member
+- **WHEN** alice is added to `juristen` and then answers
+- **THEN** the answer MUST be accepted
+
+---
+
+### Requirement: An unknown type is refused when the step is saved
+
+The system SHALL refuse to save a step configuration naming a performer whose
+type has no registered resolver, and the refusal SHALL name the type and the
+field.
+
+This is refused at SAVE and not at run time on purpose. A misconfigured
+performer discovered at run time is discovered by a suspended run that nobody
+is watching, and the author who could fix it has long since moved on.
+
+#### Scenario: A type no app provides is refused at authoring time
+
+- **GIVEN** an instance with no resolver for the type `gremium`
+- **WHEN** an author saves a step naming `{type: 'gremium', id: 'raad'}`
+- **THEN** the save MUST be refused
+- **AND** the refusal MUST name both the unknown type and the field it was in
+
+---
+
+### Requirement: A reference that resolves to nobody refuses the task
+
+When a step creates a task, the system SHALL resolve every performer
+reference on it. If the direct assignee resolves to no user, task creation
+SHALL fail, and the failure SHALL name the reference that resolved to nobody.
+
+If the step names candidates rather than a direct assignee, creation SHALL
+fail when the union of every candidate reference is empty. A task that no
+candidate can see is a task in nobody's inbox.
+
+The failure SHALL be a step failure, handled by the flow's own error policy,
+so an author may deliberately choose to continue past it. It SHALL NOT be
+swallowed, and it SHALL NOT produce a suspended run waiting on an
+unanswerable task.
+
+**This is the defect this capability exists for.** Measured on a live
+instance, 27 of 30 asking steps named a performer that resolved to nobody;
+every one of them created a task, suspended its run, and reported nothing
+wrong.
+
+#### Scenario: An empty resolution fails the step instead of parking the run
+
+- **GIVEN** a step assigned to `{type: 'group', id: 'afdelingshoofd'}`
+- **AND** no such group exists on the instance
+- **WHEN** the run reaches that step
+- **THEN** the step MUST fail, naming that reference
+- **AND** the run MUST NOT be left suspended on an unanswerable task
+
+#### Scenario: A group that exists but is empty is also nobody
+
+- **GIVEN** a step assigned to a group that exists and has no members
+- **WHEN** the run reaches that step
+- **THEN** the step MUST fail
+- **AND** the failure MUST distinguish "resolved to no users" from "no such
+  principal", because the two are fixed in different places
+
+---
+
+### Requirement: Authorisation to answer is resolver-backed
+
+The system SHALL decide whether a caller may answer a task by resolving the
+task's performer references and asking whether the caller is among the
+resulting users.
+
+The system SHALL NOT decide this by comparing the caller's uid to the stored
+assignee string, and SHALL NOT decide it by asking whether the caller belongs
+to a group whose name happens to equal that string.
+
+A task naming NO performer SHALL remain answerable by anyone the task
+service already authorises, unchanged: whether an unassigned task is open to
+all is a `flow-tasks` question and not this capability's to redefine.
+
+#### Scenario: A position authorises an answer the way a group does
+
+- **GIVEN** a task assigned to `{type: 'position', id: 'voorzitter'}`
+- **AND** a resolver that answers `[bob]` for that position
+- **WHEN** bob completes the task
+- **THEN** the completion MUST be accepted
+
+#### Scenario: A coincidental name no longer authorises
+
+- **GIVEN** a task assigned to `{type: 'user', id: 'juristen'}`
+- **AND** a group also named `juristen` containing alice
+- **WHEN** alice attempts to answer
+- **THEN** the attempt MUST be refused, because the reference names a user
+
+---
+
+### Requirement: Stored assignee strings are migrated once, and what cannot be migrated is reported
+
+The system SHALL provide a repair step that reads every stored performer
+string on a task and on a flow definition, resolves it once against the
+registered resolvers, and rewrites it as a typed reference.
+
+A string that resolves to exactly one type SHALL be rewritten to that type. A
+string that resolves under MORE than one type SHALL be left alone and
+reported, because the repair cannot know which was meant, and guessing would
+silently move who may answer.
+
+A string that resolves under no type SHALL be left alone and reported. The
+repair SHALL NOT delete it, refuse the upgrade, or fail the instance: a flow
+naming a performer nobody can be is already broken, and the repair's job is
+to say so, not to become the thing that breaks it.
+
+The report SHALL name each unmigrated string, the flow or task carrying it,
+and which of the two reasons applies.
+
+#### Scenario: An ambiguous string is reported rather than guessed
+
+- **GIVEN** a stored assignee string `support` that names both a user and a
+  group
+- **WHEN** the repair runs
+- **THEN** the string MUST be left as it is
+- **AND** the report MUST name it as ambiguous, naming both types
+
+#### Scenario: The repair does not fail an upgrade over a broken flow
+
+- **GIVEN** 27 stored assignee strings that resolve to nothing
+- **WHEN** the repair runs
+- **THEN** it MUST complete
+- **AND** it MUST report all 27, with the flow each belongs to

--- a/openspec/changes/flow-typed-principals/specs/flow-user-task-node/spec.md
+++ b/openspec/changes/flow-typed-principals/specs/flow-user-task-node/spec.md
@@ -1,0 +1,109 @@
+## MODIFIED Requirements
+
+### Requirement: The node describes its own form, served from the node catalog
+
+The step type `openregister.user-task` SHALL describe itself to the node
+catalog, and the editor SHALL draw its configuration from that description
+rather than from anything the editor knows about this node.
+
+The node's display name SHALL be **"Ask a person or group"**. The node has
+accepted group performers since it existed and its name said only "person",
+which is why authors reached for a free-text box and typed a role name into
+a field they believed took one user.
+
+Every field that names a performer — `assignee`, `candidateUsers`,
+`candidateGroups`, `candidateRole` and `routingFallback` — SHALL be declared
+with the field type `principal`, not `text`.
+
+`candidateUsers`, `candidateGroups` and `candidateRole` SHALL be superseded
+by a single `candidates` field of type `principal` accepting several
+references. The three separate fields exist only because a text box cannot
+express a type; a typed reference can, and three fields that differ only in
+the kind of thing typed into them is the API asking the author to do the
+type system's job. The three SHALL keep working as input, read as candidates
+of type `user`, `group` and `role` respectively.
+
+`performerType` SHALL be removed from the config form. It duplicated, as a
+free-typed word, the type that each reference now carries.
+
+The node SHALL continue to serve its full field list from the catalog, and
+the editor SHALL continue to need no change to draw a field the node adds.
+
+#### Scenario: The catalog serves the node with typed performer fields
+
+- **WHEN** the node catalog is read
+- **THEN** the entry for `openregister.user-task` MUST be named "Ask a person
+  or group"
+- **AND** its `assignee` and `candidates` fields MUST declare the type
+  `principal`
+- **AND** no performer field MUST declare the type `text`
+
+#### Scenario: The three old candidate fields still configure a step
+
+- **GIVEN** a step saved before this change with `candidateGroups: "juristen"`
+- **WHEN** the step is loaded
+- **THEN** its candidates MUST include `{type: 'group', id: 'juristen'}`
+
+---
+
+### Requirement: An agent is a performer of this node, asked with a prompt
+
+The node SHALL accept a performer reference of type `agent`, and a step whose
+performer is an agent SHALL declare a `prompt` instead of a form.
+
+An agent step SHALL produce a task row exactly as a human step does: the same
+provenance, the same audit, the same lifecycle verbs, the same outcome bag.
+The consequence that matters is that an agent's answer is reviewable and
+re-assignable — a task an agent has not yet answered can be handed to a
+person, and a person can see what was asked.
+
+The engine SHALL NOT invoke an agent runtime. It SHALL dispatch the request
+as an event, and a consuming app performs the turn and completes the task
+through the ordinary verbs. This is the same boundary the node already keeps
+with every other performer, and the one gate-27 and ADR-022 require.
+
+The separate step type for running an agent turn SHALL remain, unchanged. A
+turn that is not a question to be answered is not a task, and forcing it
+through an inbox would put a row in front of a person for something nobody
+was ever asked.
+
+#### Scenario: An agent answers through the same verbs a person uses
+
+- **GIVEN** a step whose performer is `{type: 'agent', id: <uuid>}` with a
+  prompt
+- **WHEN** the run reaches it
+- **THEN** a task MUST exist carrying the run and node provenance
+- **AND** the run MUST suspend until that task is terminal
+- **AND** the outcome MUST reach the following steps in the ordinary outcome
+  bag
+
+#### Scenario: An unanswered agent task can be given to a person
+
+- **GIVEN** an open task whose performer is an agent
+- **WHEN** it is reassigned to `{type: 'user', id: 'alice'}`
+- **THEN** alice MUST be able to answer it
+- **AND** the reassignment MUST be recorded on the task's audit
+
+---
+
+### Requirement: A step that names nobody is refused before it can run
+
+`validateConfig` SHALL refuse a performer reference whose type has no
+registered resolver, naming the type and the field.
+
+The node SHALL continue to refuse a step that names no performer at all. The
+existing reason is unchanged and still correct: a task nobody is assigned can
+be completed by anyone.
+
+The node SHALL NOT resolve references during validation. Whether a group has
+members is a fact about the instance at run time, not about the document
+being saved, and refusing a save because a committee is temporarily empty
+would make a flow unauthorable for a reason that has nothing to do with it.
+
+#### Scenario: Validation refuses an unknown type but not an empty group
+
+- **GIVEN** an instance with no resolver for `gremium`
+- **WHEN** a step naming `{type: 'gremium', id: 'raad'}` is saved
+- **THEN** the save MUST be refused
+- **AND** a step naming an existing but empty group MUST save without
+  complaint

--- a/openspec/changes/flow-typed-principals/tasks.md
+++ b/openspec/changes/flow-typed-principals/tasks.md
@@ -1,0 +1,61 @@
+# Tasks
+
+## 1. The reference and the registry
+
+- [ ] 1.1 `lib/Service/Flow/Principal/PrincipalReference.php` — the `{type, id}` value object, with a `from()` that reads a bare string as `{type: 'user', id: …}` and a list reader that accepts mixed types.
+- [ ] 1.2 `lib/Service/Flow/Principal/IPrincipalResolver.php` — `type(): string` and `resolve(string $id): array<string>` returning user ids.
+- [ ] 1.3 `lib/Service/Flow/Principal/RegisterPrincipalResolversEvent.php` — modelled on `RegisterFlowNodesEvent`.
+- [ ] 1.4 `lib/Service/Flow/Principal/PrincipalResolverRegistry.php` — collects resolvers on first use, answers `has(type)` and `resolve(reference)`. No cross-request cache: D-1, and the late-resolution decision above it.
+- [ ] 1.5 `UserPrincipalResolver` and `GroupPrincipalResolver`, registered by openregister itself.
+- [ ] 1.6 Unit tests, each seen RED first: a bare string reads as a user; a list mixes types; an unregistered type answers `has() === false`; a group resolves to its current members and re-resolves after a membership change.
+
+## 2. Authorisation
+
+- [ ] 2.1 `FlowRunAssignee::mayAnswer()` consults the registry instead of comparing strings. Keep the null-assignee branch exactly as it is.
+- [ ] 2.2 The task service's answer guard takes the same path, so the two cannot disagree.
+- [ ] 2.3 Record the resolution at creation as evidence only. Assert in a test that the guard does **not** read it — a former member must be refused while still appearing in the record.
+- [ ] 2.4 Check every caller of `mayAnswer` for the hot-path trap: inbox listing must still predicate in the datastore, never resolve row by row.
+- [ ] 2.5 Tests: a position authorises; a coincidental group name no longer authorises a `user` reference; an unassigned task is unchanged.
+
+## 3. The node
+
+- [ ] 3.1 `UserTaskConfig` parses typed references on `assignee`, `candidates`, `routingFallback`; reads the three legacy candidate fields as typed candidates.
+- [ ] 3.2 `validateConfig` refuses an unknown type, naming type and field. It does NOT resolve — D-2.
+- [ ] 3.3 Task creation resolves; an empty resolution fails the step, distinguishing "no such principal" from "resolved to no users".
+- [ ] 3.4 Declare `principal` as the field type on every performer field; drop `performerType` from the form and derive the column from the reference.
+- [ ] 3.5 Display name to "Ask a person or group"; description reviewed against the `writing` skill before it is written.
+- [ ] 3.6 Tests: legacy `candidateGroups` still configures a step; an unknown type is refused at save; an empty group fails at creation and not at save.
+
+## 4. Agent as a performer
+
+- [ ] 4.1 Accept `{type: 'agent', id}` with a `prompt` in place of a form.
+- [ ] 4.2 Dispatch `AgentRunRequestedEvent` rather than invoking a runtime; the completing app uses the ordinary verbs.
+- [ ] 4.3 An `agent` resolver whose identity is **not** a member of human groups — see the trap; assert it.
+- [ ] 4.4 Test: an unanswered agent task reassigned to a person is answerable by that person, and the reassignment is on the audit.
+
+## 5. The picker (nextcloud-vue)
+
+- [ ] 5.1 A `principal` widget in `CnFlowNodeEditModal.vue`: multi-select, searches as you type against `/ocs/v2.php/core/autocomplete/get` with `shareTypes[]=0,1`.
+- [ ] 5.2 A stored reference the current user cannot see must still SHOW, the way the existing `user` widget synthesises an unseen uid — otherwise a save silently clears a delegation.
+- [ ] 5.3 App-contributed types are offered from a server-declared option source, not from a list the editor hard-codes.
+- [ ] 5.4 `runAs` keeps the existing single-user widget.
+- [ ] 5.5 jest specs seen RED first; en/nl catalogues for every new string, `writing` skill loaded first.
+
+## 6. The repair
+
+- [ ] 6.1 A repair step rewriting unambiguous strings on tasks and on flow definitions.
+- [ ] 6.2 Ambiguous and unresolvable strings are left alone and reported, naming the carrier and the reason. **Must not fail the upgrade** — D-4.
+- [ ] 6.3 Bump `<version>` in `appinfo/info.xml` in the same commit, or the step never runs (gate-110).
+- [ ] 6.4 Test with a fixture holding one of each: unambiguous, ambiguous, unresolvable.
+
+## 7. Proof
+
+- [ ] 7.1 Playwright, over the live API: author a step naming a group, run it, confirm a member can answer and a non-member cannot.
+- [ ] 7.2 Playwright: a step naming a group that does not exist fails the step and leaves no suspended run — the measured defect, inverted into a test.
+- [ ] 7.3 Playwright: an unknown type is refused when the flow is saved.
+- [ ] 7.4 `composer check:strict`, both l10n gates, and the full unit suite. Read the exit code, not the summary line.
+
+## 8. Afterwards, not here
+
+- [ ] 8.1 decidiq contributes `position`; hermiq contributes `function`; dossiq contributes `role`. Separate PRs in their own repos.
+- [ ] 8.2 Retiring `dossiq.askPerson` onto this node — its own change, once the resolvers exist.


### PR DESCRIPTION
Planning only. No behaviour changes, no code.

## What was measured

I went looking for how the "ask a person" step works and found the assignee
is a string typed into a text box that nothing ever checks.

On the demo instance, 2026-09-06:

- 24 flows carry **30 `dossiq.askPerson` nodes**. Their assignees are role
  names: `Beleidsadviseur`, `juridische-dienst`, `Afdelingshoofd`,
  `Gemeentesecretaris`, `Griffier`, `financieel-adviseur`, `teamleider`,
  `burgemeester`.
- `FlowRunAssignee::mayAnswer()` accepts an answer only when the uid
  **equals** the assignee string, or the answerer is in a **group named
  exactly** that string.
- **3 of 30 resolved. 27 created a task nobody on the instance could
  answer** — not even an administrator. The run suspends, the heartbeat
  re-reads it forever, nothing reports a problem.
- `Afdelingshoofd` and `afdelingshoofd` both appear, as do both spellings of
  `Gemeentesecretaris`. That is what a free-text field produces.

`validateConfig()` already refuses an *empty* assignee, with a good comment
about why. It cannot refuse a non-resolving one, because a bare string
carries no type to resolve against.

## Why three changes and not one

ADR-032 is explicit that a spec mixing surfaces burns a cycle without
shipping. These are three surfaces.

### `flow-typed-principals`

A performer becomes `{type, id}` — user, group, role, position, function,
agent. Resolvers are contributed through an event, the way flow nodes
already are, so decidiq owns what a position is and hermiq owns what a
function is, and OpenRegister names neither (gate-27, ADR-022).

Two refusals at two moments, deliberately: an **unknown type** is refused
when the step is saved, because the author is at the keyboard and can fix
it; an **empty resolution** is refused when the task is created, because
whether a committee has members is a fact about the instance that changes.
Refusing to save a flow because a group is momentarily empty would make it
unauthorable for a reason unrelated to it.

Agent becomes a performer of the same node with a prompt, so an agent's
answer is a task row with the same audit — and an unanswered agent task can
be handed to a person.

### `flow-run-subjects-and-answers`

**A one-line bug first.** `PortalTaskNode:450` does
`$bag['answers'] = $task->getResponses()`. `FlowTaskBridge::outcomeBagFor()`,
which the user-task node uses, has no `answers` key. So a step can declare a
form, the values are validated against the subject schema, stored on the
task — and then discarded. Nothing downstream can read them.

Worth noting *why* nobody caught it: the form is declared, refused at save
if it names a missing field, rendered, validated and stored, and each of
those has a test. None asserts that a **following step** can see the value.

Then a run gains a **declared** set of subjects addressed by role, distinct
from the audit-derived `/objects`, so a step can say `attachTo: case`. The
derived list cannot serve this: it contains what a run wrote, which is both
too much and too little, and it carries no role to point at.

### `flow-node-taxonomy`

The live catalog serves **64 step types as one flat list** and `IFlowNode`
has no notion of a kind or a category.

Two axes, following n8n's split: a **BPMN element kind**, which
`flow-bpmn-interchange` needs anyway and currently asks nobody for, and a
**palette category**. Both **defaulted**, because 43 of the 64 nodes live in
repositories this change cannot touch. An honest `other` in the palette is a
prompt that gets fixed; a guessed `serviceTask` written into a BPMN export
is a wrong answer that looks like a right one.

## Notes for review

- All three validate. Two INFO notices are pre-existing: `flow-tasks` and
  `flow-user-task-node` have no canonical spec under `openspec/specs/`
  because their own changes were never archived.
- One breaking edge case is called out in `flow-typed-principals`: a task
  whose assignee string happens to equal a group name is authorised today by
  accident of spelling. The repair migrates unambiguous strings, and
  **reports rather than guesses** the ambiguous ones — a Nextcloud instance
  may hold a user and a group of the same name, and today's guard accepts
  both, so any rewrite narrows who may answer.
