### PR TITLE
fix(ci): the unit gate runs in a container that has no git

### DIFF
--- a/.github/workflows/api-test-coverage.yml
+++ b/.github/workflows/api-test-coverage.yml
@@ -131,6 +131,36 @@ jobs:
           # than 40 lines later where it reads as a dependency-install failure.
           docker exec nextcloud php /usr/local/bin/composer --version
 
+      - name: Provide git inside the container
+        # Same shape as the composer step above, and for the same reason: the
+        # unit suite runs INSIDE the nextcloud container, and that image ships
+        # no git.
+        #
+        # MigrationVersionBumpCheckTest builds a small repository per case and
+        # runs scripts/check-migration-version-bump.php over it, because a test
+        # that inspects THIS repository can only report whatever today's branch
+        # happens to look like. With no git the fixtures are never created, so
+        # all six repository cases failed with
+        #
+        #     /tmp/or-migration-gate-256a137d7fd3 is not a git repository
+        #
+        # which reads as a defect in the gate rather than an absent binary.
+        # Measured 2026-09-06: this job had failed on all eight development
+        # pushes since the gate landed in #3451, and `git --version` in the
+        # container answers `command not found`. With git present the class
+        # passes 8/8.
+        #
+        # apt rather than `docker cp` of the runner's binary: git is not a
+        # single file like the composer phar, and a copied binary would leave
+        # its shared libraries and helper programs behind.
+        run: |
+          set -e
+          docker exec -u root nextcloud bash -lc \
+            'apt-get update -qq && apt-get install -y -qq --no-install-recommends git'
+          # Prove it is usable HERE, as the user the suite runs as, rather than
+          # 40 lines later where it reads as a broken gate.
+          docker exec -u www-data nextcloud git --version
+
       - name: PHPUnit unit suite (in-container, HARD GATE)
         # The unit suite requires the full Nextcloud runtime — the OCP stubs
         # reference Doctrine\DBAL\* and OC\* internals that only resolve once

--- a/tests/Unit/Migration/MigrationVersionBumpCheckTest.php
+++ b/tests/Unit/Migration/MigrationVersionBumpCheckTest.php
@@ -105,7 +105,20 @@ class MigrationVersionBumpCheckTest extends TestCase {
 	}
 
 	/**
-	 * Run a shell command inside a directory, ignoring its output.
+	 * Run a shell command inside a directory, failing the test if it does not
+	 * succeed.
+	 *
+	 * THIS USED TO DISCARD BOTH THE OUTPUT AND THE EXIT CODE, and that is how
+	 * six tests spent a day reporting the wrong cause. The nextcloud container
+	 * the unit gate runs in ships no git, so every `git init` here failed with
+	 * "command not found", the fixture repository was never created, and the
+	 * check under test then said
+	 *
+	 *     /tmp/or-migration-gate-256a137d7fd3 is not a git repository
+	 *
+	 * which names the gate rather than the missing binary. A helper that hides
+	 * an exit code cannot tell "the tool is absent" from "the tool disagreed",
+	 * so it reports the second whatever happened.
 	 *
 	 * @param string $cmd The command.
 	 * @param string $cwd The working directory.
@@ -113,7 +126,15 @@ class MigrationVersionBumpCheckTest extends TestCase {
 	 * @return void
 	 */
 	private function sh(string $cmd, string $cwd): void {
-		exec('cd ' . escapeshellarg($cwd) . ' && ' . $cmd . ' >/dev/null 2>&1');
+		$out  = [];
+		$code = 0;
+		exec('cd ' . escapeshellarg($cwd) . ' && ' . $cmd . ' 2>&1', $out, $code);
+
+		$this->assertSame(
+			0,
+			$code,
+			'fixture setup failed: ' . $cmd . ' (exit ' . $code . ")\n" . implode("\n", $out)
+		);
 	}
 
 	/**


### PR DESCRIPTION
## What was wrong

`api-test-coverage` has failed on every development push since the migration-version-bump gate landed in #3451. Eight runs, eight failures, always the same six cases of `MigrationVersionBumpCheckTest`.

Those cases each build a small repository and run the gate over it, because a test that inspects this repository can only report whatever today's branch happens to look like. The nextcloud image the unit suite runs inside ships no git, so `git init` returned 127, no fixture was ever created, and the gate then said:

```
/tmp/or-migration-gate-256a137d7fd3 is not a git repository
```

That names the gate, not the absent binary. `git --version` in the container answers `command not found`.

## What changed

**Install git in the container.** Same shape and same place as the existing composer step, which exists for the same reason. Proven with `git --version` as the user the suite runs as, so an absent binary fails where the message names it. apt rather than copying the runner's binary, since git is not a single file like the composer phar.

**Make the fixture helper assert its exit code.** It discarded both the output and the status, so it could not tell "the tool is absent" from "the tool disagreed", and reported the second whatever happened. It now fails with the command, the code and the output.

## How it was checked

With git on PATH the class passes 8 of 8, with 74 assertions where it previously reported 13, so the added checks do run.

With git removed from PATH it fails naming the real cause:

```
fixture setup failed: git init -q -b development (exit 127)
sh: 1: git: not found
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
