### PR TITLE
fix(flow): a task form's answers reach the steps that follow

### DIFF
--- a/lib/Service/Flow/FlowTaskBridge.php
+++ b/lib/Service/Flow/FlowTaskBridge.php
@@ -268,6 +268,24 @@ class FlowTaskBridge {
 	 * both are terminal, only one is an answer, and collapsing them would let
 	 * an expired approval read as an approval (D-6).
 	 *
+	 * 🔴 `answers` IS PART OF THE BAG, and was not. A step may declare a form;
+	 * the values are validated against the subject schema and written to
+	 * `task.responses`. Every hop of that had a test — the declaration is
+	 * refused if it names a field the schema lacks, the form is rendered, the
+	 * values are validated on completion, the row is stored. None of them
+	 * asked whether a LATER STEP could read the value, and none could: this
+	 * bag omitted the key while {@see PortalTaskNode} has placed one since it
+	 * was written. So every answer a person typed into a user-task form was
+	 * collected and then discarded.
+	 *
+	 * Placed HERE rather than in each node, so the two callers cannot drift
+	 * apart again — the asymmetry was the whole defect.
+	 *
+	 * ALWAYS PRESENT, sometimes empty. A missing key would make a downstream
+	 * `answers.reason` fail one way when the performer skipped the form and
+	 * another way when the step declared none, which teaches every author to
+	 * write two guards for one question.
+	 *
 	 * @param Task $task The terminal task.
 	 *
 	 * @return array<string, mixed> The outcome bag.
@@ -290,6 +308,7 @@ class FlowTaskBridge {
 			'rejected' => ($decided === true && TaskState::isRejectingOutcome(outcome: $outcome) === true),
 			'comment' => $task->getComment(),
 			'result' => $task->getResultText(),
+			'answers' => ($task->getResponses() ?? []),
 			'completedBy' => $task->getCompletedBy(),
 			'completedAt' => $task->getCompletedAt()?->format('c'),
 			'performerType' => $task->getPerformerType(),

--- a/lib/Service/Flow/Nodes/PortalTaskNode.php
+++ b/lib/Service/Flow/Nodes/PortalTaskNode.php
@@ -447,7 +447,9 @@ class PortalTaskNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigF
 	private function placeOutcome(array $items, array $config, Task $task): array {
 		$bag = FlowTaskBridge::outcomeBagFor(task: $task);
 		$metadata = ($task->getMetadata() ?? []);
-		$bag['answers'] = ($task->getResponses() ?? []);
+		// `answers` now comes from the bridge, which is where it always
+		// belonged: this node placing it and the user-task node not placing
+		// it is exactly how a form's values could be stored and never read.
 		$bag['files'] = ($task->getEvidence() ?? []);
 		$bag['party'] = $task->getAssignee();
 		$bag['cycle'] = (int)($metadata['cycle'] ?? 1);

--- a/tests/Unit/Service/Flow/UserTaskNodeTest.php
+++ b/tests/Unit/Service/Flow/UserTaskNodeTest.php
@@ -462,6 +462,71 @@ class UserTaskNodeTest extends TestCase {
 	}//end testACompletedTaskContinuesWithTheOutcomeOnEveryItem()
 
 	/**
+	 * What the performer FILLED IN reaches the steps that follow.
+	 *
+	 * Asserted on the item leaving the node, not on the task row, and that
+	 * distinction is the whole point. A step could already declare a form,
+	 * the values were already validated against the subject schema and
+	 * already written to `task.responses`, and every one of those hops had a
+	 * test. None of them asked whether a LATER STEP could see the value, and
+	 * it could not: `FlowTaskBridge::outcomeBagFor()` had no `answers` key
+	 * while `PortalTaskNode` has placed one since it was written. So every
+	 * answer a person typed into a user-task form was collected, stored, and
+	 * then discarded.
+	 *
+	 * Storing is not reaching. This test asserts reaching.
+	 *
+	 * @spec openspec/changes/flow-run-subjects-and-answers/specs/flow-user-task-node/spec.md#requirement-the-outcome-is-written-onto-every-item-not-only-onto-the-run
+	 */
+	public function testWhatThePerformerFilledInReachesTheFollowingStep(): void {
+		$state = new FlowResumeState();
+		$state->forNode(nodeId: 'ask')->set(key: FlowTaskBridge::SLOT_TASK_UUID, value: 't-1');
+		$done = $this->task(state: Task::STATE_COMPLETED);
+		$done->setOutcome('approved');
+		$done->setResponses(['reason' => 'binnen mandaat', 'amount' => 250]);
+		$this->bridge->method('taskOrNull')->willReturn($done);
+
+		$out = $this->node->execute(
+			[FlowItems::item(json: ['id' => 1])],
+			$this->config(),
+			$this->context($state)
+		);
+
+		$bag = $out[0][FlowItems::JSON]['task'];
+		$this->assertArrayHasKey('answers', $bag, 'the form answers must leave the node');
+		$this->assertSame('binnen mandaat', $bag['answers']['reason']);
+		$this->assertSame(250, $bag['answers']['amount']);
+	}//end testWhatThePerformerFilledInReachesTheFollowingStep()
+
+	/**
+	 * A step with no form yields an EMPTY answers set, never a missing key.
+	 *
+	 * Otherwise a downstream expression reading `answers.reason` fails one
+	 * way when the form was skipped and another way when the step declared
+	 * none, and every author learns to write two guards for one question.
+	 *
+	 * @spec openspec/changes/flow-run-subjects-and-answers/specs/flow-user-task-node/spec.md#requirement-the-outcome-is-written-onto-every-item-not-only-onto-the-run
+	 */
+	public function testAStepWithNoFormStillCarriesAnEmptyAnswersSet(): void {
+		$state = new FlowResumeState();
+		$state->forNode(nodeId: 'ask')->set(key: FlowTaskBridge::SLOT_TASK_UUID, value: 't-1');
+		$done = $this->task(state: Task::STATE_COMPLETED);
+		$done->setOutcome('approved');
+		$done->setResponses(null);
+		$this->bridge->method('taskOrNull')->willReturn($done);
+
+		$out = $this->node->execute(
+			[FlowItems::item(json: ['id' => 1])],
+			$this->config(),
+			$this->context($state)
+		);
+
+		$bag = $out[0][FlowItems::JSON]['task'];
+		$this->assertArrayHasKey('answers', $bag, 'the key is always present');
+		$this->assertSame([], $bag['answers']);
+	}//end testAStepWithNoFormStillCarriesAnEmptyAnswersSet()
+
+	/**
 	 * A terminal read with no signal in hand is the heartbeat recovering a
 	 * missed wake — the completion's signal was refused or lost — and that
 	 * recovery is recorded on the task's audit, attributed to its completer.


### PR DESCRIPTION
## The bug

A user-task step can declare a form. The performer fills it in, the values are
validated against the subject schema and written to `task.responses` — and no
later step can ever read them.

`FlowTaskBridge::outcomeBagFor()` had no `answers` key.
`PortalTaskNode::placeOutcome()` has placed one since it was written:

```php
$bag['answers'] = ($task->getResponses() ?? []);
```

Two nodes doing nearly the same job, four lines apart, and only one shipped
the last hop. **That asymmetry was the bug.** `grep -rn "getResponses()" lib/`
returns two hits in the whole app.

## Why nothing caught it

The feature is tested at every step except the one that matters. The
declaration is refused if it names a field the schema lacks; the form is
rendered; the values are validated on completion; the row is stored. Each has
a test. **None asserts that a following step can see the value.**

Storing is not reaching, and only reaching was missing. So both new tests
assert on the **item leaving the node**, not on the task row — asserting the
row again would have reproduced the exact blind spot that hid this.

## The fix

The key moves to the bridge, where both callers share it and cannot drift
apart again, and the portal node's own line goes.

Always present, sometimes empty. A missing key would make a downstream
`answers.reason` fail one way when the performer skipped the form and another
way when the step declared none, which teaches every author to write two
guards for one question.

## Verification

- Both tests seen **RED first**: `Failed asserting that an array has the key
  'answers'.`
- 1135 flow unit tests green, 0 failures.
- PHPCS, PHPStan and Psalm clean on both changed files.
- The portal node's own tests still pass, confirming the bridge now supplies
  what the node used to.

## A finding, for the change that follows

Trying to prove this end to end on a live instance returned:

```
HTTP 400  {"error":"This task has no subject object, so its form values have
nowhere to be written.","kind":"no-subject"}
```

`UserTaskConfig` anchors a task only from the **item's own** `uuid`/`_self`.
A manually-triggered flow therefore cannot use a field form at all — there is
no way to tell the step which object the answers belong to.

That is precisely what `attachTo` and the declared subject set are for in
`openspec/changes/flow-run-subjects-and-answers`, and it is now evidence
rather than a hypothesis. This PR is task 1 of that change, which sequences
the answers fix first and on its own.
