### PR TITLE
fix(gates): the run address names the spec it implements, and why it has no baseline

### DIFF
--- a/src/views/flows/FlowRunDetail.vue
+++ b/src/views/flows/FlowRunDetail.vue
@@ -21,6 +21,16 @@
   run uuid that does not resolve is usually a stale link from a ticket or a
   notification, and silently landing somebody on the dashboard is the
   behaviour that makes a dead link impossible to diagnose.
+
+  @visual exclude this page has no screen to baseline. Both of its states are
+  transient by design: the spinner is replaced by the flow editor as soon as
+  the run resolves, and the failure state is one NcEmptyContent whose pixels
+  say nothing the flow editor's own baselines do not already cover. What is
+  worth testing here is behaviour, not appearance — that a cold load of
+  /flow-runs/{uuid} reaches the flow rather than the manifest's catch-all,
+  that Back does not bounce because the handover replaces rather than pushes,
+  and that an absent run says so at its own address. That belongs in a
+  behavioural spec under tests/e2e/, and it is not written yet.
 -->
 <template>
 	<NcAppContent>
@@ -91,6 +101,10 @@ export default {
 	methods: {
 		/**
 		 * Read the run, then hand over to its flow's editor.
+		 *
+		 * @spec openspec/changes/flow-runs-subject-scope/specs/flow-runs-subject-scope/spec.md
+		 *   "the run uuid in the row is the deep link to it" — this is the
+		 *   resolver that makes that uuid an address a browser can open.
 		 *
 		 * @return {Promise<void>}
 		 */


### PR DESCRIPTION
## What was wrong

Hydra Gates has been red on development since #3462, on two findings that turn out to be the same new file, `src/views/flows/FlowRunDetail.vue`:

```
[gate-16] spec-coverage:   1 changed method missing @spec
[gate-26] visual-coverage: 1 new page component missing a visual baseline
```

## What changed

**gate-16.** `resolve()` now carries `@spec` pointing at the flow-runs-subject-scope spec, which is where the deep link this page implements is written down: "the run uuid in the row is the deep link to it".

The path was opened and read rather than guessed. A tag the gate accepts but that resolves to nothing clears the finding without covering anything, and the gate cannot tell the difference, so that is worth saying out loud.

**gate-26.** An `@visual exclude` with its reason, rather than a baseline. This page has no screen. It is a resolver: the spinner is replaced by the flow editor as soon as the run resolves, and the failure state is one `NcEmptyContent` whose pixels say nothing the flow editor's own baselines do not already cover.

## What is still missing

The behaviour here is worth a test and does not have one:

- a cold load of `/flow-runs/{uuid}` reaches the flow rather than the manifest's catch-all, which is exactly what broke when this address was a hash redirect
- Back does not bounce, because the handover uses `replace` and not `push`
- an absent run says so at its own address rather than landing the visitor on the dashboard

I wrote that spec and could not run it. This workstation's instance carries thirty-odd apps and the shared global setup times out logging in at 30s, twice, before any test starts. Rather than ship a playwright spec whose only evidence is that it reads correctly, the exclude says what is not covered and the comment in the file says what to write. The gap is named, not hidden.

## How it was checked

Both gates were run locally against `067d1b9`, the commit the page was added on, because a branch cut from today's development sees an empty diff and reports no finding at all:

```
[gate-26] visual-coverage: PASS — 1 new page(s), all have a visual proof
[gate-16] spec-coverage:   # count=0
```

eslint and prettier are both clean on the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
