### PR TITLE
chore(deps): refresh the shared Conduction locks

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6872,16 +6872,16 @@
         },
         {
             "name": "conduction/hydra-gates",
-            "version": "v1.15.1",
+            "version": "v1.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ConductionNL/.github.git",
-                "reference": "4db52393987b85957787e144bc82bfaf67f4860c"
+                "reference": "90d4e4b94052b5423d62bec24a61a0af781961dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/4db52393987b85957787e144bc82bfaf67f4860c",
-                "reference": "4db52393987b85957787e144bc82bfaf67f4860c",
+                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/90d4e4b94052b5423d62bec24a61a0af781961dc",
+                "reference": "90d4e4b94052b5423d62bec24a61a0af781961dc",
                 "shasum": ""
             },
             "require": {
@@ -6920,9 +6920,9 @@
             "support": {
                 "docs": "https://github.com/ConductionNL/.github/blob/main/hydra-gates/README.md",
                 "issues": "https://github.com/ConductionNL/.github/issues",
-                "source": "https://github.com/ConductionNL/.github/tree/v1.15.1"
+                "source": "https://github.com/ConductionNL/.github/tree/v1.16.0"
             },
-            "time": "2026-09-05T12:26:12+00:00"
+            "time": "2026-09-05T17:51:59+00:00"
         },
         {
             "name": "consolidation/annotated-command",


### PR DESCRIPTION
Weekly refresh of the two shared Conduction packages. **Lock-only** - both are
already declared with caret ranges that permit these versions, so what this app
*accepts* is unchanged; only what it currently resolves to moves.

| package | was | now |
|---|---|---|
| conduction/hydra-gates | v1.15.1 | v1.16.0 |
| @conduction/nextcloud-vue | - | 2.37.0 |

**Why this is automated.** Nothing here was ever pinned on purpose. The caret
always allowed the newer release; the lockfile is what froze it, and nobody
re-resolves a lock unless they happen to be touching dependencies. Measured
across the fleet on 2026-08-20: every app sat on hydra-gates v1.8.0 while
v1.8.1 was out, and fourteen sat below nc-vue 2.7.0 - twelve of them on 2.3.0.
Neither number was a decision.

**Why it is a PR and not a push.** Because a shared bump is not always safe and
this repository's suite is what knows. Taking hydra-gates v1.8.1 added
patchObject() to a published interface, which is a load-time fatal for any
concrete test double implementing it without the method - the suite dies before
a single test runs. Two apps needed stub updates first.

**If this PR is red, fix it on this branch.** While it stays open the weekly run
skips this app entirely and will not touch your commits - it never force-pushes
and never reuses a branch.

Opened by fleet-shared-dep-bump.yml in ConductionNL/.github.
