### PR TITLE
chore(deps): bump @conduction/nextcloud-vue to 2.39.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
-        "@conduction/nextcloud-vue": "^2.37.0",
+        "@conduction/nextcloud-vue": "^2.39.0",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "^2.6.0",
         "@nextcloud/capabilities": "^1.2.1",
@@ -2289,9 +2289,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.37.0",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.37.0.tgz",
-      "integrity": "sha512-3+c+vPHlcswZS0+yEO+HjaFTkgI0ET0Lk33LEmMnZc/E7rDV6lPILq9LNlmxC04WuyQNILx4+zsckkSMYEg7hQ==",
+      "version": "2.39.0",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.39.0.tgz",
+      "integrity": "sha512-LmiQwc2VizxNfdzrVXF/A2NwItjIBg5DGi2EbvkMZwA8wXAgSaDWO2uant5TU+AHXotK5Csfqe0OXSe/b5qJqA==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
-    "@conduction/nextcloud-vue": "^2.37.0",
+    "@conduction/nextcloud-vue": "^2.39.0",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "^2.6.0",
     "@nextcloud/capabilities": "^1.2.1",


### PR DESCRIPTION
Carries the flow-editor work: the settings modal no longer offers a trigger (what starts a flow is a step on the canvas), and Run explains itself rather than letting the engine refuse several seconds later in words about nodes.

The pin was already ahead of what was installed — `package.json` said `^2.37.0` while `node_modules` held **2.36.1**, so `npm install` had not been re-run since the pin last moved. This bump and a rebuild close both gaps.

Verified by rebuilding this app's bundle against 2.39.0 and exercising the result on a live instance: the settings modal shows Name, Description and the trigger note only, and Run is disabled with its explanation on a flow that has no manual start step.