### PR TITLE
feat(flow): what a publish takes away, and therefore whether it breaks

### DIFF
--- a/lib/Service/Flow/FlowGraphDiff.php
+++ b/lib/Service/Flow/FlowGraphDiff.php
@@ -1,0 +1,254 @@
+<?php
+
+/**
+ * What changed between two flow graphs, and whether it breaks anybody.
+ *
+ * THE RULE IS ABOUT REMOVAL, and that is the whole design. A consumer of a
+ * flow can depend on three things: that a step exists, that a path connects,
+ * and that a step still reads the key it read. Every one of those is broken by
+ * taking something away, and none of them by adding.
+ *
+ * Changing a VALUE can break a consumer too — an assignee that no longer
+ * resolves, a threshold that moves — but that is not detectable as breaking
+ * from the graph alone. Guessing would produce majors nobody believes, and a
+ * version people ignore carries no information at all. That gap is what the
+ * author's explicit override exists for, and why the override only goes
+ * upward: the diff is evidence, and evidence can be added to but not argued
+ * down.
+ *
+ * 🔴 A CONFIG KEY REMOVED FROM A NODE THAT ALSO DISAPPEARED COUNTS ONCE. It is
+ * one change — the node went — and counting it twice inflates the list the
+ * author reads before publishing. That list is the part that makes the verdict
+ * credible, so padding it is not a cosmetic problem.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md#requirement-taking-something-away-is-major-everything-else-is-minor
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+/**
+ * Compares two graphs and reports what a publish would take away.
+ */
+class FlowGraphDiff {
+
+	/**
+	 * The verdict when something a consumer could depend on was removed.
+	 *
+	 * @var string
+	 */
+	public const MAJOR = 'major';
+
+	/**
+	 * The verdict for every other difference, including none at all.
+	 *
+	 * @var string
+	 */
+	public const MINOR = 'minor';
+
+	/**
+	 * What the candidate graph takes away from the published one.
+	 *
+	 * @param array<string, mixed> $published The graph currently published.
+	 * @param array<string, mixed> $candidate The graph about to be published.
+	 *
+	 * @return array{verdict: string, removedNodes: array<int, string>, removedEdges: array<int, string>, removedKeys: array<int, string>}
+	 *
+	 * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md#requirement-taking-something-away-is-major-everything-else-is-minor
+	 */
+	public function compare(array $published, array $candidate): array {
+		$before = $this->nodesById(graph: $published);
+		$after = $this->nodesById(graph: $candidate);
+
+		$removedNodes = array_values(array_diff(array_keys($before), array_keys($after)));
+		sort($removedNodes);
+
+		$removedEdges = array_values(
+			array_diff($this->edgeKeys(graph: $published), $this->edgeKeys(graph: $candidate))
+		);
+		sort($removedEdges);
+
+		$removedKeys = [];
+		foreach ($before as $id => $node) {
+			// 🔴 ONLY SURVIVING NODES. A key that went with its node is one
+			// change, already reported as the node.
+			if (array_key_exists($id, $after) === false) {
+				continue;
+			}
+
+			$gone = array_diff(
+				array_keys($this->configOf(node: $node)),
+				array_keys($this->configOf(node: $after[$id]))
+			);
+
+			foreach ($gone as $key) {
+				$removedKeys[] = $id . '.' . $key;
+			}
+		}
+
+		sort($removedKeys);
+
+		$breaks = ($removedNodes !== [] || $removedEdges !== [] || $removedKeys !== []);
+
+		$verdict = self::MINOR;
+		if ($breaks === true) {
+			$verdict = self::MAJOR;
+		}
+
+		return [
+			'verdict' => $verdict,
+			'removedNodes' => $removedNodes,
+			'removedEdges' => $removedEdges,
+			'removedKeys' => $removedKeys,
+		];
+	}//end compare()
+
+	/**
+	 * A short sentence naming what was taken away, for the author to read
+	 * before they publish.
+	 *
+	 * Empty when nothing was removed: a caller writing "this publish removes:"
+	 * in front of an empty list is the shape this avoids.
+	 *
+	 * @param array{removedNodes: array<int, string>, removedEdges: array<int, string>, removedKeys: array<int, string>} $diff The comparison.
+	 *
+	 * @return string The summary, or '' when nothing was removed.
+	 *
+	 * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md#requirement-the-author-is-told-what-it-will-be-before-publishing
+	 */
+	public function summarise(array $diff): string {
+		$parts = [];
+
+		if (($diff['removedNodes'] ?? []) !== []) {
+			$parts[] = 'steps ' . implode(', ', $diff['removedNodes']);
+		}
+
+		if (($diff['removedEdges'] ?? []) !== []) {
+			$parts[] = 'connections ' . implode(', ', $diff['removedEdges']);
+		}
+
+		if (($diff['removedKeys'] ?? []) !== []) {
+			$parts[] = 'settings ' . implode(', ', $diff['removedKeys']);
+		}
+
+		if ($parts === []) {
+			return '';
+		}
+
+		return 'This removes ' . implode('; ', $parts) . '.';
+	}//end summarise()
+
+	/**
+	 * The graph's nodes, keyed by id, skipping anything without one.
+	 *
+	 * A node with no id cannot be compared with anything, and inventing a key
+	 * for it would report it as removed on every publish.
+	 *
+	 * @param array<string, mixed> $graph The graph.
+	 *
+	 * @return array<string, array<string, mixed>> The nodes.
+	 */
+	private function nodesById(array $graph): array {
+		$byId = [];
+
+		foreach (($graph['nodes'] ?? []) as $node) {
+			if (is_array($node) === false) {
+				continue;
+			}
+
+			$id = trim((string)($node['id'] ?? ''));
+			if ($id === '') {
+				continue;
+			}
+
+			$byId[$id] = $node;
+		}
+
+		return $byId;
+	}//end nodesById()
+
+	/**
+	 * Every edge as a comparable `from->to` string.
+	 *
+	 * Endpoints are normalised the way the engine reads them: `from` and `to`
+	 * are each either a string or a list, and the same connection written both
+	 * ways must not read as a removal plus an addition.
+	 *
+	 * @param array<string, mixed> $graph The graph.
+	 *
+	 * @return array<int, string> The edge keys.
+	 */
+	private function edgeKeys(array $graph): array {
+		$keys = [];
+
+		foreach (($graph['edges'] ?? []) as $edge) {
+			if (is_array($edge) === false) {
+				continue;
+			}
+
+			foreach ($this->endpoints(value: ($edge['from'] ?? null)) as $from) {
+				foreach ($this->endpoints(value: ($edge['to'] ?? null)) as $to) {
+					$keys[] = $from . '->' . $to;
+				}
+			}
+		}
+
+		return array_values(array_unique($keys));
+	}//end edgeKeys()
+
+	/**
+	 * One endpoint value as a list of node ids.
+	 *
+	 * @param mixed $value The raw endpoint.
+	 *
+	 * @return array<int, string> The ids.
+	 */
+	private function endpoints(mixed $value): array {
+		$list = [$value];
+		if (is_array($value) === true) {
+			$list = $value;
+		}
+
+		$ids = [];
+		foreach ($list as $item) {
+			$id = trim((string)$item);
+			if ($id !== '') {
+				$ids[] = $id;
+			}
+		}
+
+		return $ids;
+	}//end endpoints()
+
+	/**
+	 * A node's configuration, as an array whatever it was stored as.
+	 *
+	 * An empty config is persisted as `[]` by some writers and omitted by
+	 * others; both mean "no keys", and neither is a removal.
+	 *
+	 * @param array<string, mixed> $node The node.
+	 *
+	 * @return array<string, mixed> The config.
+	 */
+	private function configOf(array $node): array {
+		$config = ($node['config'] ?? []);
+		if (is_array($config) === false) {
+			return [];
+		}
+
+		return $config;
+	}//end configOf()
+}//end class

--- a/openspec/changes/flow-semantic-versions/.openspec.yaml
+++ b/openspec/changes/flow-semantic-versions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-07

--- a/openspec/changes/flow-semantic-versions/design.md
+++ b/openspec/changes/flow-semantic-versions/design.md
@@ -1,0 +1,90 @@
+# Design
+
+## D-1 · Why the ordinal survives
+
+The obvious reading of "use semver for flow versions" is to replace the
+integer. It would be wrong here, and the cost is concrete:
+
+- `oc_openregister_flows.version` and `oc_openregister_flow_versions.version`
+  are both `integer NOT NULL`, and the second carries `UNIQUE (flow_uuid,
+  version)`.
+- `FlowRun.flowVersion` is an integer, and it is what a RUN PINS. A run
+  resolves its graph through that pin for its whole life, including runs
+  suspended for weeks on a human task.
+- 28 call sites read or write it across seven files.
+
+All of that would be migrated to buy a label. Worse, it would make the run
+pin — the thing that guarantees a suspended run keeps walking the graph it
+started on — depend on a derivation. A derivation with a bug would then not
+merely mislabel a version; it would repoint a run.
+
+So the ordinal stays as identity and ordering, and the semantic version is an
+additional fact about a published version. The author sees semver, the engine
+pins the ordinal, and neither has to be right for the other to work.
+
+## D-2 · Why removal is the breaking rule
+
+A consumer of a flow can depend on three things: that a step exists, that a
+path connects, and that a step still reads the key it read. Every one of those
+is broken by REMOVING something, and none by adding.
+
+Changing a VALUE can also break a consumer — an assignee that no longer
+resolves, a threshold that moves — but it is not detectable as breaking from
+the graph alone. Guessing would produce majors nobody believes, which is worse
+than a minor that was actually major, because a version people ignore carries
+no information at all.
+
+That gap is exactly what the author's override is for, and why the override
+only goes upward.
+
+## D-3 · Why the asymmetry in the override
+
+The diff is evidence: it saw a node disappear. The author's optimism does not
+change what the graph says, so a removal cannot be published as minor.
+
+The author's knowledge, on the other hand, exceeds the diff — they know which
+values consumers read. So they can add a major the diff did not find.
+
+Evidence can only be added to, never argued down. Allowing both directions
+would make the version mean "what somebody felt like", which is the state we
+are leaving.
+
+## D-4 · Why patch is always zero
+
+Nothing in a graph distinguishes a fix from a feature. A derived patch level
+would be a guess wearing three digits, and three digits look far more precise
+than two. It stays `0` until something can honestly set it — an author saying
+so, or a change class we can actually detect.
+
+## D-5 · What the back-fill may and may not claim
+
+The repair cannot know whether the third publish of a flow was breaking: the
+graphs it would compare are precisely the ones it is being run to describe,
+and older definition rows may have been pruned.
+
+So it does not pretend. It stamps a flow's published versions in ordinal order
+as `1.0.0`, `1.1.0`, … and records that they were BACK-FILLED rather than
+derived. A version that says where it came from can be distrusted correctly; a
+version that silently claims to be derived cannot.
+
+🔴 It must not fail an upgrade over a version it cannot stamp. A flow whose
+history is incomplete is already in that state; a repair that turns it into a
+failed `occ upgrade` makes a reporting problem into an outage.
+
+## Traps
+
+**Do not derive at draft creation.** The ordinal is taken there, and the
+instinct is to take the semver alongside it. There is nothing to compare yet —
+the draft is a copy of the published graph — so every flow would be minor.
+
+**Compare against the PUBLISHED graph, not the previous ordinal.** They are
+usually the same and are not always: a deprecated version, or a draft opened
+and abandoned, leaves a gap. The published graph is what a consumer is running.
+
+**A config key removed from a node that ALSO disappeared is one change, not
+two.** Counting both inflates the "what was removed" list the author reads, and
+the list is the part that makes the verdict credible.
+
+**An identical republish must not be refused.** Publishing the same graph twice
+is idempotent and legitimate; making it an error would be a new failure mode
+introduced by a labelling feature.

--- a/openspec/changes/flow-semantic-versions/proposal.md
+++ b/openspec/changes/flow-semantic-versions/proposal.md
@@ -1,0 +1,50 @@
+---
+kind: code
+depends_on: []
+---
+
+## Why
+
+A flow's version is a counter. `v1`, `v2`, `v3` — one more each time somebody opens a draft, and it says nothing about what changed. An operator looking at `v7` cannot tell whether it renamed a step's label or deleted the branch their integration depended on.
+
+Both facts a version could carry are absent:
+
+- **Nothing marks a breaking change.** Removing a step, removing an edge, or dropping a config key another step reads all produce exactly the same `+1` as adding a description. A consumer pinned to a flow has no signal to act on, so every publish is either ignored or treated as dangerous.
+- **The number bumps at the wrong moment.** `FlowVersionService::createDraft()` takes `highestVersion() + 1` when a draft is *opened*. Whether the change is breaking cannot be known then, because the change has not been made yet. It is knowable at PUBLISH, where there is a previous published graph to compare against.
+
+## What Changes
+
+- **A published version carries a semantic version**, derived at publish by comparing the graph being published with the currently published one:
+  - a **removed node**, a **removed edge**, or a **removed config key** on a surviving node is **MAJOR**
+  - anything else — added nodes, added edges, changed labels, changed config values — is **MINOR**
+  - the first publish of a flow is **1.0.0**
+- **The ordinal stays.** `version` remains an integer, remains the unique key with `flow_uuid`, and remains what `FlowRun.flowVersion` pins. Semver is an ADDITIONAL, author-facing fact. Replacing the ordinal would mean migrating two unique indexes, every run row's pin and 28 call sites to buy a label — and would put the run pin at the mercy of a derivation.
+- **The author is told before they publish.** The publish confirmation names the version it is about to create and why it is major, listing what was removed. A derivation nobody can see before it fires is one nobody trusts.
+- **An author may raise it, never lower it.** Publish accepts an explicit `major`, so an author who knows a value change breaks a consumer can say so. It refuses a request to publish a major change as minor: the diff is evidence and the author's optimism is not.
+- **Patch is not derived.** Nothing in a graph distinguishes a fix from a feature, so a derived patch would be a guess wearing three digits. The third component stays `0` until something can honestly set it.
+
+## Capabilities
+
+### New Capabilities
+- `flow-semantic-versions`: what a flow's semantic version means, when it is derived, which differences are breaking, and how an author may override it.
+
+### Modified Capabilities
+- `flow-definition-versioning`: publishing derives and stores a semantic version alongside the ordinal; the ordinal's meaning is unchanged.
+
+## Impact
+
+| Area | Change |
+|---|---|
+| `lib/Db/FlowVersion.php` | `semver` column |
+| `lib/Db/Flow.php` | `semver` column, mirroring the head's |
+| `lib/Migration/` | both columns, plus a repair stamping existing published versions |
+| `lib/Service/Flow/FlowGraphDiff.php` | new — what changed between two graphs, and whether it breaks |
+| `lib/Service/Flow/FlowVersionService.php` | derives at publish, accepts an explicit raise |
+| `lib/Controller/FlowController.php` | the diff verdict on the publish preflight |
+| nextcloud-vue | the pill shows the semantic version where one exists |
+
+## Out of scope, deliberately
+
+- **Replacing the ordinal.** See above: two unique indexes, the run pin and 28 call sites, to buy a label.
+- **Deriving a patch level.** A graph cannot distinguish a fix from a feature.
+- **Consumers acting on the version.** Nothing subscribes to a flow's version today. Emitting a signal nobody reads would be inventing a contract; this change makes the fact true first.

--- a/openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md
+++ b/openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md
@@ -1,0 +1,160 @@
+## Purpose
+
+What a flow's version says about what changed: derived from the graph at
+publish, breaking when something a consumer could depend on was taken away,
+and never silently lowered.
+
+## ADDED Requirements
+
+### Requirement: A semantic version is derived at publish, from the graph
+
+The system SHALL derive a semantic version when a flow is published, by
+comparing the graph being published with the graph of the currently published
+version.
+
+The derivation SHALL happen at PUBLISH and not when a draft is created. The
+ordinal is taken at draft creation, before any change exists to classify;
+asking then what kind of change this will be has no answer.
+
+The first publish of a flow SHALL be `1.0.0`.
+
+The system SHALL keep the integer ordinal unchanged. The ordinal remains the
+unique key with the flow uuid, remains what a run pins, and remains what
+orders versions. The semantic version is an additional fact about a published
+version, not a replacement for its identity.
+
+#### Scenario: The first publish is 1.0.0
+
+- **GIVEN** a flow that has never been published
+- **WHEN** it is published
+- **THEN** its semantic version MUST be `1.0.0`
+- **AND** its ordinal MUST be unchanged by the derivation
+
+#### Scenario: A run still pins the ordinal
+
+- **GIVEN** a run of a published flow
+- **WHEN** the flow is published again
+- **THEN** the run MUST still name the ordinal it was pinned to
+- **AND** the semantic version MUST NOT be what the run resolves its graph by
+
+---
+
+### Requirement: Taking something away is major; everything else is minor
+
+The system SHALL classify a change as MAJOR when, compared with the published
+graph, the graph being published:
+
+- no longer contains a node that was there, or
+- no longer contains an edge that was there, or
+- no longer contains a configuration key on a node that survived.
+
+Every other difference SHALL be MINOR: nodes added, edges added, labels
+changed, configuration values changed, positions moved.
+
+The rule is deliberately about REMOVAL. What a consumer of a flow can depend
+on is that a step still exists, that a path still connects, and that a step
+still reads the key it read. Adding to any of those cannot break them.
+Changing a VALUE can break them, and is not detectable as such — which is
+what the author's override below is for.
+
+A publish that changes nothing at all SHALL still produce a version, and it
+SHALL be minor. An identical republish is not a breaking change, and refusing
+it would make an idempotent operation fail.
+
+#### Scenario: A removed step is major
+
+- **GIVEN** a published flow with steps `a`, `b` and `c`
+- **WHEN** a draft removing `b` is published
+- **THEN** the new semantic version MUST bump the MAJOR component
+
+#### Scenario: A removed edge is major, even with every node intact
+
+- **GIVEN** a published flow whose graph connects `a → b`
+- **WHEN** a draft removing that edge, and no node, is published
+- **THEN** the change MUST be classified MAJOR
+
+#### Scenario: A removed config key on a surviving node is major
+
+- **GIVEN** a published step carrying `assignee` and `title`
+- **WHEN** a draft that drops `assignee` from it is published
+- **THEN** the change MUST be classified MAJOR
+
+#### Scenario: Adding is minor
+
+- **GIVEN** a published flow
+- **WHEN** a draft adding a step, an edge and a config key is published
+- **THEN** the change MUST be classified MINOR
+
+#### Scenario: An identical republish is minor, not a refusal
+
+- **GIVEN** a published flow
+- **WHEN** a draft identical to it is published
+- **THEN** the publish MUST succeed
+- **AND** the change MUST be classified MINOR
+
+---
+
+### Requirement: The author is told what it will be, before publishing
+
+The system SHALL report, before a publish is committed, which component the
+publish will bump and — when major — WHAT was removed.
+
+A derivation the author cannot see before it fires is one they cannot trust,
+and the first surprising major is the one that teaches them to ignore the
+number.
+
+#### Scenario: The preflight names what was removed
+
+- **GIVEN** a draft that removes a step and an edge
+- **WHEN** the author asks what publishing would do
+- **THEN** the answer MUST say the publish is major
+- **AND** it MUST name the removed step and the removed edge
+
+---
+
+### Requirement: An author may raise the verdict and never lower it
+
+The system SHALL accept an explicit request to publish as MAJOR, and SHALL
+honour it even when the diff found only additions. An author who knows that a
+changed value breaks a consumer is the only source of that fact.
+
+The system SHALL REFUSE a request to publish as minor when the diff found a
+removal, and the refusal SHALL name what was removed.
+
+The asymmetry is the point. The diff is evidence and cannot be argued down;
+the author's knowledge exceeds the diff and can only be added to it.
+
+#### Scenario: An author raises a minor to a major
+
+- **GIVEN** a draft whose only change is a configuration VALUE
+- **WHEN** the author publishes it as major
+- **THEN** the MAJOR component MUST bump
+
+#### Scenario: An author cannot talk a removal down
+
+- **GIVEN** a draft that removes a step
+- **WHEN** the author publishes it as minor
+- **THEN** the publish MUST be refused
+- **AND** the refusal MUST name the removed step
+
+---
+
+### Requirement: Existing published versions are stamped once, and honestly
+
+The system SHALL provide a repair that gives every already-published version a
+semantic version.
+
+The repair SHALL NOT invent history. It cannot know whether the third publish
+of a flow was breaking, because the graphs it would have to compare are the
+ones it is being run to describe. It SHALL therefore stamp the versions of one
+flow in ordinal order as `1.0.0`, `1.1.0`, `1.2.0` and so on, and SHALL record
+that these were derived by back-fill rather than from a diff.
+
+The repair SHALL NOT fail an upgrade over a version it cannot stamp.
+
+#### Scenario: A back-filled version says it was back-filled
+
+- **GIVEN** a flow with four published versions and no semantic versions
+- **WHEN** the repair runs
+- **THEN** they MUST read `1.0.0`, `1.1.0`, `1.2.0`, `1.3.0`
+- **AND** each MUST be marked as back-filled rather than derived

--- a/openspec/changes/flow-semantic-versions/tasks.md
+++ b/openspec/changes/flow-semantic-versions/tasks.md
@@ -1,0 +1,44 @@
+# Tasks
+
+## 1. The diff
+
+- [ ] 1.1 `lib/Service/Flow/FlowGraphDiff.php` — compare two graphs and answer: removed nodes, removed edges, removed config keys on surviving nodes, and a MAJOR/MINOR verdict.
+- [ ] 1.2 A config key removed from a node that also disappeared counts ONCE, under the node — see the trap.
+- [ ] 1.3 Unit tests, each seen RED: removed node, removed edge, removed key, additions only, identical graphs, and the double-count case.
+
+## 2. Storage
+
+- [ ] 2.1 `semver` on `FlowVersion` and on `Flow`, plus a `semverSource` recording `derived` or `backfill`.
+- [ ] 2.2 Migration for both columns. The ordinal and its unique index are untouched — D-1.
+- [ ] 2.3 Bump `<version>` in `appinfo/info.xml` in the same commit, or the repair never runs (gate-110).
+
+## 3. Deriving at publish
+
+- [ ] 3.1 `FlowVersionService::publish()` derives from the diff against the PUBLISHED graph, not the previous ordinal — see the trap.
+- [ ] 3.2 First publish is `1.0.0`. Patch stays `0` — D-4.
+- [ ] 3.3 An explicit `major` is honoured; an explicit `minor` over a removal is REFUSED, naming what was removed — D-3.
+- [ ] 3.4 An identical republish succeeds and is minor.
+- [ ] 3.5 Tests seen RED for each of those, including the refusal's wording.
+
+## 4. Telling the author first
+
+- [ ] 4.1 The publish preflight reports the component it will bump and, when major, what was removed.
+- [ ] 4.2 Test that a major preflight names the removed step AND the removed edge.
+
+## 5. The back-fill
+
+- [ ] 5.1 A repair stamping published versions per flow in ordinal order, marked `backfill`.
+- [ ] 5.2 It must not fail an upgrade — D-5.
+- [ ] 5.3 Test with a flow whose history has a gap.
+
+## 6. The UI (nextcloud-vue)
+
+- [ ] 6.1 The version pill shows the semantic version where one exists, and the ordinal where it does not.
+- [ ] 6.2 A back-filled version is distinguishable from a derived one, so it can be distrusted correctly.
+- [ ] 6.3 jest seen RED first; en and nl in place.
+
+## 7. Proof
+
+- [ ] 7.1 Playwright over the live API: publish a flow, remove a step, publish again, assert the major bump and the named removal.
+- [ ] 7.2 Playwright: an explicit minor over a removal is refused.
+- [ ] 7.3 `composer check:strict`, both l10n gates, full unit suite. Exit code, not summary line.

--- a/tests/Unit/Service/Flow/FlowGraphDiffTest.php
+++ b/tests/Unit/Service/Flow/FlowGraphDiffTest.php
@@ -1,0 +1,232 @@
+<?php
+
+/**
+ * What a publish takes away, and therefore whether it breaks anybody.
+ *
+ * The rule is about REMOVAL. A consumer of a flow can depend on three things:
+ * that a step exists, that a path connects, and that a step still reads the key
+ * it read. Each is broken by taking something away, and none by adding.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Flow;
+
+use OCA\OpenRegister\Service\Flow\FlowGraphDiff;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for {@see FlowGraphDiff}.
+ *
+ * @covers \OCA\OpenRegister\Service\Flow\FlowGraphDiff
+ */
+class FlowGraphDiffTest extends TestCase {
+
+	/**
+	 * The subject.
+	 *
+	 * @var FlowGraphDiff
+	 */
+	private FlowGraphDiff $diff;
+
+	/**
+	 * Set up.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$this->diff = new FlowGraphDiff();
+
+	}//end setUp()
+
+	/**
+	 * A graph of three chained steps, the shape most flows have.
+	 *
+	 * @return array<string, mixed> The graph.
+	 */
+	private function published(): array {
+		return [
+			'nodes' => [
+				['id' => 'a', 'type' => 'openregister.trigger-manual', 'config' => []],
+				['id' => 'b', 'type' => 'openregister.user-task', 'config' => ['title' => 'Ask', 'assignee' => 'admin']],
+				['id' => 'c', 'type' => 'openregister.end', 'config' => []],
+			],
+			'edges' => [
+				['id' => 'e1', 'from' => 'a', 'to' => 'b'],
+				['id' => 'e2', 'from' => 'b', 'to' => 'c'],
+			],
+		];
+	}//end published()
+
+	/**
+	 * Removing a step is major, and the step is named.
+	 *
+	 * @return void
+	 */
+	public function testARemovedStepIsMajorAndNamed(): void {
+		$after = $this->published();
+		$after['nodes'] = [$after['nodes'][0], $after['nodes'][2]];
+
+		$result = $this->diff->compare(published: $this->published(), candidate: $after);
+
+		$this->assertSame(FlowGraphDiff::MAJOR, $result['verdict']);
+		$this->assertSame(['b'], $result['removedNodes']);
+	}//end testARemovedStepIsMajorAndNamed()
+
+	/**
+	 * Removing an edge is major even when every node survives.
+	 *
+	 * @return void
+	 */
+	public function testARemovedEdgeIsMajorWithEveryNodeIntact(): void {
+		$after = $this->published();
+		$after['edges'] = [$after['edges'][0]];
+
+		$result = $this->diff->compare(published: $this->published(), candidate: $after);
+
+		$this->assertSame(FlowGraphDiff::MAJOR, $result['verdict']);
+		$this->assertSame([], $result['removedNodes'], 'no node went');
+		$this->assertSame(['b->c'], $result['removedEdges']);
+	}//end testARemovedEdgeIsMajorWithEveryNodeIntact()
+
+	/**
+	 * Removing a config key from a SURVIVING node is major.
+	 *
+	 * @return void
+	 */
+	public function testARemovedConfigKeyOnASurvivingNodeIsMajor(): void {
+		$after = $this->published();
+		$after['nodes'][1]['config'] = ['title' => 'Ask'];
+
+		$result = $this->diff->compare(published: $this->published(), candidate: $after);
+
+		$this->assertSame(FlowGraphDiff::MAJOR, $result['verdict']);
+		$this->assertSame(['b.assignee'], $result['removedKeys']);
+	}//end testARemovedConfigKeyOnASurvivingNodeIsMajor()
+
+	/**
+	 * 🔴 A key that went WITH its node is one change, not two.
+	 *
+	 * Counting both inflates the list the author reads before publishing, and
+	 * that list is the part that makes the verdict credible.
+	 *
+	 * @return void
+	 */
+	public function testAKeyThatWentWithItsNodeIsCountedOnce(): void {
+		$after = $this->published();
+		$after['nodes'] = [$after['nodes'][0], $after['nodes'][2]];
+
+		$result = $this->diff->compare(published: $this->published(), candidate: $after);
+
+		$this->assertSame(['b'], $result['removedNodes']);
+		$this->assertSame([], $result['removedKeys'], 'the node is the change; its keys are not a second one');
+	}//end testAKeyThatWentWithItsNodeIsCountedOnce()
+
+	/**
+	 * Adding anything is minor.
+	 *
+	 * @return void
+	 */
+	public function testAddingIsMinor(): void {
+		$after = $this->published();
+		$after['nodes'][] = ['id' => 'd', 'type' => 'openregister.filter', 'config' => ['when' => 'x']];
+		$after['nodes'][1]['config']['priority'] = 'high';
+		$after['edges'][] = ['id' => 'e3', 'from' => 'c', 'to' => 'd'];
+
+		$result = $this->diff->compare(published: $this->published(), candidate: $after);
+
+		$this->assertSame(FlowGraphDiff::MINOR, $result['verdict']);
+	}//end testAddingIsMinor()
+
+	/**
+	 * Changing a VALUE is minor: it is not detectable as breaking from the
+	 * graph, which is what the author's override exists for.
+	 *
+	 * @return void
+	 */
+	public function testChangingAValueIsMinor(): void {
+		$after = $this->published();
+		$after['nodes'][1]['config']['assignee'] = 'somebody-else';
+
+		$result = $this->diff->compare(published: $this->published(), candidate: $after);
+
+		$this->assertSame(FlowGraphDiff::MINOR, $result['verdict']);
+	}//end testChangingAValueIsMinor()
+
+	/**
+	 * An identical republish is minor, and never a refusal.
+	 *
+	 * @return void
+	 */
+	public function testAnIdenticalRepublishIsMinor(): void {
+		$result = $this->diff->compare(published: $this->published(), candidate: $this->published());
+
+		$this->assertSame(FlowGraphDiff::MINOR, $result['verdict']);
+		$this->assertSame([], $result['removedNodes']);
+		$this->assertSame([], $result['removedEdges']);
+		$this->assertSame([], $result['removedKeys']);
+	}//end testAnIdenticalRepublishIsMinor()
+
+	/**
+	 * The same connection written as a string and as a list is ONE edge.
+	 *
+	 * The editor writes `from: 'a'` and the dossiq projections write
+	 * `from: ['a']`. Reading those as different would report a removal and an
+	 * addition on a graph nobody touched.
+	 *
+	 * @return void
+	 */
+	public function testTheTwoEdgeDialectsAreTheSameEdge(): void {
+		$before = $this->published();
+		$after = $this->published();
+		$after['edges'] = [
+			['id' => 'e1', 'from' => ['a'], 'to' => ['b']],
+			['id' => 'e2', 'from' => ['b'], 'to' => ['c']],
+		];
+
+		$result = $this->diff->compare(published: $before, candidate: $after);
+
+		$this->assertSame(FlowGraphDiff::MINOR, $result['verdict']);
+		$this->assertSame([], $result['removedEdges']);
+	}//end testTheTwoEdgeDialectsAreTheSameEdge()
+
+	/**
+	 * An omitted config and an empty one both mean "no keys".
+	 *
+	 * @return void
+	 */
+	public function testAnOmittedConfigIsNotARemoval(): void {
+		$before = ['nodes' => [['id' => 'a', 'config' => []]], 'edges' => []];
+		$after = ['nodes' => [['id' => 'a']], 'edges' => []];
+
+		$this->assertSame(FlowGraphDiff::MINOR, $this->diff->compare(published: $before, candidate: $after)['verdict']);
+	}//end testAnOmittedConfigIsNotARemoval()
+
+	/**
+	 * The summary names what went, and says nothing when nothing did.
+	 *
+	 * @return void
+	 */
+	public function testTheSummaryNamesWhatWentAndIsEmptyOtherwise(): void {
+		$after = $this->published();
+		$after['nodes'] = [$after['nodes'][0]];
+		$after['edges'] = [];
+
+		$diff = $this->diff->compare(published: $this->published(), candidate: $after);
+		$summary = $this->diff->summarise(diff: $diff);
+
+		$this->assertStringContainsString('b', $summary);
+		$this->assertStringContainsString('a->b', $summary);
+		$this->assertSame('', $this->diff->summarise(diff: $this->diff->compare(published: $this->published(), candidate: $this->published())));
+	}//end testTheSummaryNamesWhatWentAndIsEmptyOtherwise()
+}//end class


### PR DESCRIPTION
First half of `flow-semantic-versions`: the comparison a semantic version is
derived from, with its spec.

## The rule is about removal

A consumer of a flow can depend on three things — that a step exists, that a
path connects, and that a step still reads the key it read. Every one is broken
by taking something away, and none by adding. So:

| change | verdict |
|---|---|
| removed node | **major** |
| removed edge | **major** |
| removed config key on a **surviving** node | **major** |
| anything added, any value changed, an identical republish | minor |

Changing a **value** can break a consumer too, and is not detectable as such
from the graph. Guessing would produce majors nobody believes, and a version
people ignore carries no information at all. That gap is what the author's
explicit override is for, and why the override only goes **up**: the diff is
evidence, and evidence can be added to but not argued down.

## Two details that would otherwise be wrong

🔴 **A key that went with its node counts once.** It is one change — the node
went — and counting it twice inflates the list the author reads before
publishing, which is the part that makes the verdict credible.

**Two edge dialects, one edge.** The editor writes `from: 'a'` and the dossiq
projections write `from: ['a']`. Both normalise, because reading them as
different would report a removal *and* an addition on a graph nobody touched.
Not hypothetical: both shapes are live in a single flow on the demo instance.

## Why the ordinal survives

The obvious reading of "use semver for flow versions" is to replace the
integer. The cost is concrete:

- `version` is `integer NOT NULL` in **two** tables, one with
  `UNIQUE (flow_uuid, version)`
- `FlowRun.flowVersion` is what a **run pins**, for its whole life, including
  runs suspended for weeks on a human task
- 28 call sites across seven files

All of that migrated to buy a label — and it would put the run pin at the mercy
of a derivation. A bug would then not merely mislabel a version; it would
repoint a run. So the ordinal stays identity and ordering, and semver is an
additional, author-facing fact.

## Verification

10 tests, **5 of which break** under mutation of the removal detection and the
surviving-node guard. 1145 flow unit tests green; PHPCS, PHPStan and Psalm
clean on the new file.

## What is not in this PR

Storage, the publish derivation, the preflight, the back-fill repair and the UI
pill. They are tasks 2 through 7 in the change; this is task 1, which is the
part everything else asks a question of.
