### PR TITLE
feat(flow): store a semantic version, and work out what the next one is

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -40,7 +40,7 @@ Open Register drijft apps zoals OpenCatalogi, Procest, Pipelinq en Software Cata
 
 Vrij en open source onder de EUPL-licentie.
     ]]></description>
-    <version>2.0.16-unstable.20260907100927</version>
+    <version>2.0.18-unstable.20260907104414</version>
     <licence>EUPL-1.2</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>OpenRegister</namespace>
@@ -196,6 +196,11 @@ Vrij en open source onder de EUPL-licentie.
 			<!-- Versions FIRST: the trigger index is derived from a flow's PUBLISHED
 			     version, so a flow with no version rows yet would index nothing. -->
 			<step>OCA\OpenRegister\Repair\BackfillFlowVersions</step>
+			<!-- AFTER the version rows exist: this stamps them, so it has
+			     nothing to stamp if it runs first. It numbers a flow's
+			     published versions in ordinal order and marks them
+			     `backfill`, because it cannot know which were breaking. -->
+			<step>OCA\OpenRegister\Repair\BackfillFlowSemanticVersions</step>
 			<step>OCA\OpenRegister\Repair\BackfillFlowTriggerIndex</step>
 			<step>OCA\OpenRegister\Repair\InitializeFlowActions</step>
 			<step>OCA\OpenRegister\Repair\MigrateNotificationSubscriptionsToUserConfig</step>
@@ -312,6 +317,11 @@ Vrij en open source onder de EUPL-licentie.
 			<!-- Versions FIRST: the trigger index is derived from a flow's PUBLISHED
 			     version, so a flow with no version rows yet would index nothing. -->
 			<step>OCA\OpenRegister\Repair\BackfillFlowVersions</step>
+			<!-- AFTER the version rows exist: this stamps them, so it has
+			     nothing to stamp if it runs first. It numbers a flow's
+			     published versions in ordinal order and marks them
+			     `backfill`, because it cannot know which were breaking. -->
+			<step>OCA\OpenRegister\Repair\BackfillFlowSemanticVersions</step>
 			<step>OCA\OpenRegister\Repair\BackfillFlowTriggerIndex</step>
 			<step>OCA\OpenRegister\Repair\InitializeFlowActions</step>
 			<step>OCA\OpenRegister\Repair\SeedDirectoryVirtualSchemas</step>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -40,7 +40,7 @@ Open Register drijft apps zoals OpenCatalogi, Procest, Pipelinq en Software Cata
 
 Vrij en open source onder de EUPL-licentie.
     ]]></description>
-    <version>2.0.15-unstable.20260905143606</version>
+    <version>2.0.16-unstable.20260907100927</version>
     <licence>EUPL-1.2</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>OpenRegister</namespace>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -562,6 +562,9 @@ return [
         ['name' => 'flow#versions',  'url' => '/api/flows/{id}/versions',            'verb' => 'GET',  'requirements' => ['id' => '[^/]+']],
         ['name' => 'flow#version',   'url' => '/api/flows/{id}/versions/{version}',  'verb' => 'GET',  'requirements' => ['id' => '[^/]+', 'version' => '\d+']],
         ['name' => 'flow#publish',   'url' => '/api/flows/{id}/publish',             'verb' => 'POST', 'requirements' => ['id' => '[^/]+']],
+        // Asked BEFORE publishing: what would the next version be called, and
+        // what does this publish take away. A GET, and it changes nothing.
+        ['name' => 'flow#versionPreview', 'url' => '/api/flows/{id}/version-preview', 'verb' => 'GET', 'requirements' => ['id' => '[^/]+']],
         ['name' => 'flow#draft',     'url' => '/api/flows/{id}/draft',               'verb' => 'POST', 'requirements' => ['id' => '[^/]+']],
         ['name' => 'flow#deprecate', 'url' => '/api/flows/{id}/deprecate',           'verb' => 'POST', 'requirements' => ['id' => '[^/]+']],
         ['name' => 'flow#index',   'url' => '/api/flows',          'verb' => 'GET'],

--- a/lib/Controller/FlowController.php
+++ b/lib/Controller/FlowController.php
@@ -931,6 +931,39 @@ class FlowController extends Controller {
 	}//end version()
 
 	/**
+	 * What publishing this flow would be called, without publishing it.
+	 *
+	 * A GET, and it changes nothing. The author is asking a question before
+	 * they commit to an answer, so it neither refuses nor requires a `bump`:
+	 * the refusal belongs at the publish, where something has been asserted.
+	 *
+	 * @param string $id The flow uuid.
+	 *
+	 * @return JSONResponse The preview, or 404.
+	 *
+	 * @NoAdminRequired
+	 *
+	 * @no-admin-idor-exempt Guarded downstream: see versions().
+	 *
+	 * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md#requirement-the-author-is-told-what-it-will-be-before-publishing
+	 */
+	#[NoAdminRequired]
+	public function versionPreview(string $id): JSONResponse {
+		$denied = $this->denyUnless(action: 'flow.read');
+		if ($denied !== null) {
+			return $denied;
+		}
+
+		try {
+			$flow = $this->flows->find(uuid: $id);
+		} catch (DoesNotExistException $e) {
+			return new JSONResponse(['error' => 'No such flow'], Http::STATUS_NOT_FOUND);
+		}
+
+		return new JSONResponse($this->flowVersionService->previewPublish(flow: $flow));
+	}//end versionPreview()
+
+	/**
 	 * Publish the flow's draft head.
 	 *
 	 * @param string $id The flow uuid.

--- a/lib/Controller/FlowController.php
+++ b/lib/Controller/FlowController.php
@@ -962,10 +962,20 @@ class FlowController extends Controller {
 				// From FlowAccess, which already holds the session — a second
 				// IUserSession here would push this constructor past the
 				// parameter limit for one string.
-				publishedBy: $this->access->currentUser()?->getUID()
+				publishedBy: $this->access->currentUser()?->getUID(),
+				// The author may RAISE the derived verdict and never lower it.
+				// A refusal to call a removal minor is an
+				// UnexpectedValueException rather than a lifecycle refusal:
+				// the flow's state is fine, the request is not.
+				bump: $this->request->getParam('bump')
 			);
 		} catch (FlowLifecycleRefused $e) {
 			return $this->refusal(refusal: $e);
+		} catch (\UnexpectedValueException $e) {
+			return new JSONResponse(
+				['error' => $e->getMessage(), 'kind' => 'version-bump-refused'],
+				Http::STATUS_CONFLICT
+			);
 		}
 
 		return new JSONResponse($version->jsonSerialize());

--- a/lib/Db/Flow.php
+++ b/lib/Db/Flow.php
@@ -60,6 +60,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setVersion(?int $version)
  * @method string|null getLifecycleStatus()
  * @method void setLifecycleStatus(?string $lifecycleStatus)
+ * @method string|null getSemver()
+ * @method void setSemver(?string $semver)
  * @method string|null getTrigger()
  * @method void setTrigger(?string $trigger)
  * @method string|null getTriggerRegister()
@@ -224,6 +226,16 @@ class Flow extends Entity implements JsonSerializable {
 	 * @var integer|null
 	 */
 	protected ?int $version = 1;
+
+	/**
+	 * The head version's semantic version, mirrored from FlowVersion.
+	 *
+	 * Mirrored for the same reason `version` is: a list of flows shows it
+	 * without a join. The FlowVersion row remains the record.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $semver = null;
 
 	/**
 	 * The lifecycle status of this flow's head version.
@@ -458,6 +470,7 @@ class Flow extends Entity implements JsonSerializable {
 		$this->addType(fieldName: 'applicationSlug', type: 'string');
 		$this->addType(fieldName: 'enabled', type: 'boolean');
 		$this->addType(fieldName: 'version', type: 'integer');
+		$this->addType(fieldName: 'semver', type: 'string');
 		$this->addType(fieldName: 'lifecycleStatus', type: 'string');
 		$this->addType(fieldName: 'trigger', type: 'string');
 		$this->addType(fieldName: 'triggerRegister', type: 'string');

--- a/lib/Db/Flow.php
+++ b/lib/Db/Flow.php
@@ -663,6 +663,9 @@ class Flow extends Entity implements JsonSerializable {
 			'applicationSlug' => $this->applicationSlug,
 			'enabled' => (bool)$this->enabled,
 			'version' => (int)($this->version ?? 1),
+			// Null until the flow has been published: a draft has not been
+			// compared with anything yet, and a number would be a claim.
+			'semver' => $this->semver,
 			'lifecycleStatus' => ($this->lifecycleStatus ?? FlowVersion::STATUS_DRAFT),
 			'trigger' => $this->trigger,
 			'triggerRegister' => $this->triggerRegister,

--- a/lib/Db/Flow.php
+++ b/lib/Db/Flow.php
@@ -62,6 +62,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setLifecycleStatus(?string $lifecycleStatus)
  * @method string|null getSemver()
  * @method void setSemver(?string $semver)
+ * @method string|null getSemverSource()
+ * @method void setSemverSource(?string $semverSource)
  * @method string|null getTrigger()
  * @method void setTrigger(?string $trigger)
  * @method string|null getTriggerRegister()
@@ -236,6 +238,20 @@ class Flow extends Entity implements JsonSerializable {
 	 * @var string|null
 	 */
 	protected ?string $semver = null;
+
+	/**
+	 * Where that semantic version came from: `derived` or `backfill`.
+	 *
+	 * 🔴 A NUMBER THAT CANNOT SAY WHERE IT CAME FROM CANNOT BE DISTRUSTED
+	 * CORRECTLY. The back-fill numbered historic versions in ordinal order
+	 * because it had no graphs to compare; a reader who cannot tell that
+	 * apart from a derived version will read a guess as evidence.
+	 *
+	 * Mirrored from FlowVersion for the same reason `semver` is.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $semverSource = null;
 
 	/**
 	 * The lifecycle status of this flow's head version.
@@ -471,6 +487,7 @@ class Flow extends Entity implements JsonSerializable {
 		$this->addType(fieldName: 'enabled', type: 'boolean');
 		$this->addType(fieldName: 'version', type: 'integer');
 		$this->addType(fieldName: 'semver', type: 'string');
+		$this->addType(fieldName: 'semverSource', type: 'string');
 		$this->addType(fieldName: 'lifecycleStatus', type: 'string');
 		$this->addType(fieldName: 'trigger', type: 'string');
 		$this->addType(fieldName: 'triggerRegister', type: 'string');
@@ -666,6 +683,7 @@ class Flow extends Entity implements JsonSerializable {
 			// Null until the flow has been published: a draft has not been
 			// compared with anything yet, and a number would be a claim.
 			'semver' => $this->semver,
+			'semverSource' => $this->semverSource,
 			'lifecycleStatus' => ($this->lifecycleStatus ?? FlowVersion::STATUS_DRAFT),
 			'trigger' => $this->trigger,
 			'triggerRegister' => $this->triggerRegister,

--- a/lib/Db/FlowVersion.php
+++ b/lib/Db/FlowVersion.php
@@ -168,6 +168,35 @@ class FlowVersion extends Entity implements \JsonSerializable {
 	 * @var DateTime|null
 	 */
 	protected ?DateTime $created = null;
+	/**
+	 * The semantic version this published version carries, like `2.1.0`.
+	 *
+	 * Derived at PUBLISH from the graph diff — a removed step, edge or config
+	 * key is MAJOR, everything else MINOR. Null on a draft, which has not been
+	 * compared with anything yet.
+	 *
+	 * 🔴 THIS IS NOT THE IDENTITY. `version` remains the ordinal, remains
+	 * unique with the flow uuid, and remains what a RUN PINS for its whole
+	 * life. A run that resolved its graph through a derived label would be at
+	 * the mercy of the derivation: a bug would not mislabel a version, it
+	 * would repoint a run.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $semver = null;
+
+	/**
+	 * Where the semantic version came from: `derived` or `backfill`.
+	 *
+	 * The back-fill cannot know whether the third publish of a flow was
+	 * breaking — the graphs it would compare are the ones it is being run to
+	 * describe. So it says so, and a version that says where it came from can
+	 * be distrusted correctly. One that silently claims to be derived cannot.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $semverSource = null;
+
 
 	/**
 	 * Constructor.
@@ -182,6 +211,8 @@ class FlowVersion extends Entity implements \JsonSerializable {
 		$this->addType(fieldName: 'publishedAt', type: 'datetime');
 		$this->addType(fieldName: 'publishedBy', type: 'string');
 		$this->addType(fieldName: 'deprecatedAt', type: 'datetime');
+		$this->addType(fieldName: 'semver', type: 'string');
+		$this->addType(fieldName: 'semverSource', type: 'string');
 		$this->addType(fieldName: 'created', type: 'datetime');
 
 	}//end __construct()

--- a/lib/Db/FlowVersion.php
+++ b/lib/Db/FlowVersion.php
@@ -43,6 +43,10 @@ use OCP\AppFramework\Db\Entity;
  * @method void          setFlowUuid(?string $flowUuid)
  * @method integer|null  getVersion()
  * @method void          setVersion(?int $version)
+ * @method string|null   getSemver()
+ * @method void          setSemver(?string $semver)
+ * @method string|null   getSemverSource()
+ * @method void          setSemverSource(?string $semverSource)
  * @method string|null   getStatus()
  * @method void          setStatus(?string $status)
  * @method string|null   getDefinitionHash()
@@ -258,6 +262,10 @@ class FlowVersion extends Entity implements \JsonSerializable {
 			'id' => $this->getId(),
 			'flowUuid' => $this->flowUuid,
 			'version' => $this->version,
+			'semver' => $this->semver,
+			// Where it came from, beside the value: a back-filled version can
+			// then be distrusted correctly.
+			'semverSource' => $this->semverSource,
 			'status' => $this->status,
 			'definitionHash' => $this->definitionHash,
 			'owner' => $this->owner,

--- a/lib/Migration/Version1Date20260907100000.php
+++ b/lib/Migration/Version1Date20260907100000.php
@@ -57,6 +57,8 @@ class Version1Date20260907100000 extends SimpleMigrationStep {
 	 * @param array $options Migration options.
 	 *
 	 * @return ISchemaWrapper|null The updated schema, or null when nothing changed.
+	 *
+	 * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md#requirement-a-semantic-version-is-derived-at-publish-from-the-graph
 	 */
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
 		/*

--- a/lib/Migration/Version1Date20260907100000.php
+++ b/lib/Migration/Version1Date20260907100000.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Semantic versions on flows and their published versions.
+ *
+ * 🔴 THE ORDINAL IS NOT TOUCHED. `version` stays an integer, stays unique with
+ * `flow_uuid`, and stays what a RUN PINS for its whole life — including runs
+ * suspended for weeks on a human task. Semver is an ADDITIONAL, author-facing
+ * fact. Replacing the ordinal would migrate two unique indexes, every run
+ * row's pin and 28 call sites to buy a label, and would put the run pin at the
+ * mercy of a derivation: a bug would then not mislabel a version, it would
+ * repoint a run.
+ *
+ * Both columns are nullable with no default. A draft has no semantic version
+ * because it has not been compared with anything yet, and a NULL that means
+ * "not derived" is honest where `0.0.0` would be a claim.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md#requirement-a-semantic-version-is-derived-at-publish-from-the-graph
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use Doctrine\DBAL\Types\Types;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Adds `semver` to flows and `semver`/`semver_source` to flow versions.
+ */
+class Version1Date20260907100000 extends SimpleMigrationStep {
+
+	private const FLOWS = 'openregister_flows';
+
+	private const VERSIONS = 'openregister_flow_versions';
+
+	/**
+	 * Add the columns.
+	 *
+	 * @param IOutput $output Migration output.
+	 * @param Closure $schemaClosure Schema closure returning an ISchemaWrapper.
+	 * @param array $options Migration options.
+	 *
+	 * @return ISchemaWrapper|null The updated schema, or null when nothing changed.
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/*
+		 * @var ISchemaWrapper $schema
+		 */
+
+		$schema = $schemaClosure();
+		$changed = false;
+
+		if ($schema->hasTable(self::VERSIONS) === true) {
+			$versions = $schema->getTable(self::VERSIONS);
+
+			if ($versions->hasColumn('semver') === false) {
+				$versions->addColumn('semver', Types::STRING, ['notnull' => false, 'length' => 32, 'default' => null]);
+				$changed = true;
+			}
+
+			// WHERE IT CAME FROM, beside the value. The back-fill cannot know
+			// whether a historical publish was breaking, so it must be able to
+			// say that it guessed the ordering rather than derived it.
+			if ($versions->hasColumn('semver_source') === false) {
+				$versions->addColumn('semver_source', Types::STRING, ['notnull' => false, 'length' => 16, 'default' => null]);
+				$changed = true;
+			}
+		}
+
+		if ($schema->hasTable(self::FLOWS) === true) {
+			$flows = $schema->getTable(self::FLOWS);
+
+			if ($flows->hasColumn('semver') === false) {
+				$flows->addColumn('semver', Types::STRING, ['notnull' => false, 'length' => 32, 'default' => null]);
+				$changed = true;
+			}
+		}
+
+		if ($changed === false) {
+			return null;
+		}
+
+		$output->info(message: 'Added semantic version columns to flows and flow versions; the ordinal is unchanged.');
+
+		return $schema;
+	}//end changeSchema()
+}//end class

--- a/lib/Migration/Version1Date20260907100000.php
+++ b/lib/Migration/Version1Date20260907100000.php
@@ -92,6 +92,15 @@ class Version1Date20260907100000 extends SimpleMigrationStep {
 				$flows->addColumn('semver', Types::STRING, ['notnull' => false, 'length' => 32, 'default' => null]);
 				$changed = true;
 			}
+
+			// The SOURCE travels with the mirrored value. A flow list showing
+			// "1.3.0" with no way to tell a derived number from a back-filled
+			// guess presents the guess as evidence, which is the failure this
+			// column exists to prevent.
+			if ($flows->hasColumn('semver_source') === false) {
+				$flows->addColumn('semver_source', Types::STRING, ['notnull' => false, 'length' => 16, 'default' => null]);
+				$changed = true;
+			}
 		}
 
 		if ($changed === false) {

--- a/lib/Repair/BackfillFlowSemanticVersions.php
+++ b/lib/Repair/BackfillFlowSemanticVersions.php
@@ -38,6 +38,7 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Repair;
 
+use OCA\OpenRegister\Db\Flow;
 use OCA\OpenRegister\Db\FlowMapper;
 use OCA\OpenRegister\Db\FlowVersion;
 use OCA\OpenRegister\Db\FlowVersionMapper;
@@ -109,7 +110,7 @@ class BackfillFlowSemanticVersions implements IRepairStep {
 		foreach ($flows as $flow) {
 			try {
 				$stamped += $this->stampOneFlow(
-					flowUuid: (string)$flow->getUuid(),
+					flow: $flow,
 					versions: $versions,
 					semver: $semver
 				);
@@ -177,7 +178,7 @@ class BackfillFlowSemanticVersions implements IRepairStep {
 	 * is a stronger fact than anything this step can produce, and overwriting
 	 * one would replace evidence with a guess.
 	 *
-	 * @param string             $flowUuid The flow.
+	 * @param Flow               $flow     The flow.
 	 * @param FlowVersionMapper  $versions The version rows.
 	 * @param FlowSemanticVersion $semver  The numbering.
 	 *
@@ -185,8 +186,8 @@ class BackfillFlowSemanticVersions implements IRepairStep {
 	 *
 	 * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md#requirement-existing-published-versions-are-stamped-once-and-honestly
 	 */
-	private function stampOneFlow(string $flowUuid, FlowVersionMapper $versions, FlowSemanticVersion $semver): int {
-		$rows = $versions->findAllForFlow(flowUuid: $flowUuid);
+	private function stampOneFlow(Flow $flow, FlowVersionMapper $versions, FlowSemanticVersion $semver): int {
+		$rows = $versions->findAllForFlow(flowUuid: (string)$flow->getUuid());
 
 		// Oldest first: the sequence is the flow's own history, and
 		// `findAllForFlow` answers newest first for the UI.
@@ -214,6 +215,49 @@ class BackfillFlowSemanticVersions implements IRepairStep {
 			$stamped++;
 		}
 
+		$this->mirrorOntoFlow(flow: $flow, published: $published);
+
 		return $stamped;
 	}//end stampOneFlow()
+
+	/**
+	 * Copy the live version's number onto the flow row, marked as back-filled.
+	 *
+	 * 🔴 THE VERSION ROWS ALONE ARE NOT ENOUGH. `Flow` mirrors `semver` so a
+	 * list of flows can show it without a join, and a repair that stamped only
+	 * the version rows would leave every historic flow showing its ORDINAL in
+	 * the pill for ever — the rows would be right and the screen would be
+	 * wrong, which is the worst of both.
+	 *
+	 * Only a flow with no semantic version is touched: a derived one is a
+	 * stronger fact than anything this step can produce.
+	 *
+	 * @param Flow                     $flow      The flow to mirror onto.
+	 * @param array<int, FlowVersion>  $published Its published versions, oldest first.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md#requirement-existing-published-versions-are-stamped-once-and-honestly
+	 */
+	private function mirrorOntoFlow(Flow $flow, array $published): void {
+		if (trim((string)$flow->getSemver()) !== '') {
+			return;
+		}
+
+		$live = null;
+		foreach ($published as $row) {
+			if ($row->getStatus() === FlowVersion::STATUS_PUBLISHED) {
+				$live = $row;
+			}
+		}
+
+		if ($live === null || trim((string)$live->getSemver()) === '') {
+			return;
+		}
+
+		$flow->setSemver($live->getSemver());
+		$flow->setSemverSource(FlowSemanticVersion::SOURCE_BACKFILL);
+		$this->container->get(FlowMapper::class)->update($flow);
+
+	}//end mirrorOntoFlow()
 }//end class

--- a/lib/Repair/BackfillFlowSemanticVersions.php
+++ b/lib/Repair/BackfillFlowSemanticVersions.php
@@ -1,0 +1,211 @@
+<?php
+
+/**
+ * Give every already-published flow version a semantic version, honestly.
+ *
+ * 🔴 IT DOES NOT INVENT HISTORY. The repair cannot know whether the third
+ * publish of a flow was breaking: the graphs it would have to compare are
+ * precisely the ones it is being run to describe, and older definition rows
+ * may have been pruned. So it does not pretend to. It numbers a flow's
+ * published versions in ordinal order — 1.0.0, 1.1.0, 1.2.0 — and stamps
+ * `semverSource = backfill` beside each.
+ *
+ * That marker is the whole point. A version that says where it came from can
+ * be distrusted correctly; one that silently claims to have been derived
+ * cannot. The UI reads it and says so on hover.
+ *
+ * 🔴 IT MUST NOT FAIL AN UPGRADE. A flow whose history is incomplete is
+ * already in that state, and a repair that turns a reporting gap into a failed
+ * `occ upgrade` makes things worse for everybody on the instance. Every
+ * failure is caught, counted and reported.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Repair
+ * @package  OCA\OpenRegister\Repair
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md#requirement-existing-published-versions-are-stamped-once-and-honestly
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Repair;
+
+use OCA\OpenRegister\Db\FlowMapper;
+use OCA\OpenRegister\Db\FlowVersion;
+use OCA\OpenRegister\Db\FlowVersionMapper;
+use OCA\OpenRegister\Service\Flow\FlowSemanticVersion;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Stamps historic published versions with a back-filled semantic version.
+ */
+class BackfillFlowSemanticVersions implements IRepairStep {
+
+	/**
+	 * Constructor.
+	 *
+	 * Resolved lazily from the container, like the other flow repair steps:
+	 * this runs during install and upgrade, when the flow tables may not exist
+	 * yet, and a constructor-injected mapper would make that a fatal rather
+	 * than a skip.
+	 *
+	 * @param ContainerInterface $container The app container.
+	 * @param LoggerInterface    $logger    Diagnostics.
+	 */
+	public function __construct(
+		private readonly ContainerInterface $container,
+		private readonly LoggerInterface $logger,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * The step's name, as `occ upgrade` prints it.
+	 *
+	 * @return string The name.
+	 */
+	public function getName(): string {
+		return 'Number existing flow versions semantically';
+	}//end getName()
+
+	/**
+	 * Stamp every published version that has none.
+	 *
+	 * @param IOutput $output Migration output.
+	 *
+	 * @return void
+	 */
+	public function run(IOutput $output): void {
+		try {
+			$flows = $this->everyFlow();
+			$versions = $this->container->get(FlowVersionMapper::class);
+			$semver = $this->container->get(FlowSemanticVersion::class);
+		} catch (Throwable $e) {
+			// The tables may not exist yet on a fresh install. Nothing to
+			// back-fill is not a failure.
+			$output->info('Flow semantic-version backfill skipped: ' . $e->getMessage());
+			return;
+		}
+
+		$stamped = 0;
+		$refused = 0;
+
+		foreach ($flows as $flow) {
+			try {
+				$stamped += $this->stampOneFlow(
+					flowUuid: (string)$flow->getUuid(),
+					versions: $versions,
+					semver: $semver
+				);
+			} catch (Throwable $e) {
+				// One flow's history being unreadable must not stop the rest,
+				// and must not fail the upgrade.
+				$refused++;
+				$this->logger->warning(
+					message: '[BackfillFlowSemanticVersions] Could not stamp flow "'
+						. (string)$flow->getUuid() . '": ' . $e->getMessage(),
+					context: ['file' => __FILE__, 'line' => __LINE__]
+				);
+			}
+		}
+
+		$output->info(
+			sprintf(
+				'Numbered %d published flow version(s) as back-filled; %d flow(s) could not be read.',
+				$stamped,
+				$refused
+			)
+		);
+
+	}//end run()
+
+	/**
+	 * Every flow, paged.
+	 *
+	 * 🔴 `findAllFlows()`, NOT `findAll()`, and it PAGES. The mapper's default
+	 * limit is 100, so a single call would silently stamp the first hundred
+	 * flows and leave the rest — a repair that reports success having done
+	 * most of the job is worse than one that fails.
+	 *
+	 * I wrote `findAll()` first. It does not exist, the call threw, the step
+	 * reported itself skipped, and the upgrade went green having stamped
+	 * nothing. Only counting the rows afterwards found it.
+	 *
+	 * @return array<int, \OCA\OpenRegister\Db\Flow> Every flow.
+	 */
+	private function everyFlow(): array {
+		$mapper = $this->container->get(FlowMapper::class);
+		$page = 500;
+		$offset = 0;
+		$all = [];
+
+		while (true) {
+			$batch = $mapper->findAllFlows(limit: $page, offset: $offset);
+			$all = array_merge($all, $batch);
+
+			if (count($batch) < $page) {
+				return $all;
+			}
+
+			$offset += $page;
+		}
+
+	}//end everyFlow()
+
+	/**
+	 * Number one flow's published versions in ordinal order.
+	 *
+	 * Only rows that HAVE no semantic version are touched: a derived version
+	 * is a stronger fact than anything this step can produce, and overwriting
+	 * one would replace evidence with a guess.
+	 *
+	 * @param string             $flowUuid The flow.
+	 * @param FlowVersionMapper  $versions The version rows.
+	 * @param FlowSemanticVersion $semver  The numbering.
+	 *
+	 * @return int How many rows were stamped.
+	 */
+	private function stampOneFlow(string $flowUuid, FlowVersionMapper $versions, FlowSemanticVersion $semver): int {
+		$rows = $versions->findAllForFlow(flowUuid: $flowUuid);
+
+		// Oldest first: the sequence is the flow's own history, and
+		// `findAllForFlow` answers newest first for the UI.
+		$published = array_values(
+			array_filter(
+				$rows,
+				static fn (FlowVersion $row): bool => $row->getStatus() !== FlowVersion::STATUS_DRAFT
+			)
+		);
+
+		usort(
+			$published,
+			static fn (FlowVersion $a, FlowVersion $b): int => ((int)$a->getVersion() <=> (int)$b->getVersion())
+		);
+
+		$stamped = 0;
+		foreach ($published as $position => $row) {
+			if (trim((string)$row->getSemver()) !== '') {
+				continue;
+			}
+
+			$row->setSemver($semver->backfilled(ordinalPosition: $position));
+			$row->setSemverSource(FlowSemanticVersion::SOURCE_BACKFILL);
+			$versions->update($row);
+			$stamped++;
+		}
+
+		return $stamped;
+	}//end stampOneFlow()
+}//end class

--- a/lib/Repair/BackfillFlowSemanticVersions.php
+++ b/lib/Repair/BackfillFlowSemanticVersions.php
@@ -75,6 +75,8 @@ class BackfillFlowSemanticVersions implements IRepairStep {
 	 * The step's name, as `occ upgrade` prints it.
 	 *
 	 * @return string The name.
+	 *
+	 * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md#requirement-existing-published-versions-are-stamped-once-and-honestly
 	 */
 	public function getName(): string {
 		return 'Number existing flow versions semantically';
@@ -86,6 +88,8 @@ class BackfillFlowSemanticVersions implements IRepairStep {
 	 * @param IOutput $output Migration output.
 	 *
 	 * @return void
+	 *
+	 * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md#requirement-existing-published-versions-are-stamped-once-and-honestly
 	 */
 	public function run(IOutput $output): void {
 		try {
@@ -144,6 +148,8 @@ class BackfillFlowSemanticVersions implements IRepairStep {
 	 * nothing. Only counting the rows afterwards found it.
 	 *
 	 * @return array<int, \OCA\OpenRegister\Db\Flow> Every flow.
+	 *
+	 * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md#requirement-existing-published-versions-are-stamped-once-and-honestly
 	 */
 	private function everyFlow(): array {
 		$mapper = $this->container->get(FlowMapper::class);
@@ -176,6 +182,8 @@ class BackfillFlowSemanticVersions implements IRepairStep {
 	 * @param FlowSemanticVersion $semver  The numbering.
 	 *
 	 * @return int How many rows were stamped.
+	 *
+	 * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md#requirement-existing-published-versions-are-stamped-once-and-honestly
 	 */
 	private function stampOneFlow(string $flowUuid, FlowVersionMapper $versions, FlowSemanticVersion $semver): int {
 		$rows = $versions->findAllForFlow(flowUuid: $flowUuid);

--- a/lib/Service/Flow/FlowSemanticVersion.php
+++ b/lib/Service/Flow/FlowSemanticVersion.php
@@ -42,6 +42,21 @@ use UnexpectedValueException;
 class FlowSemanticVersion {
 
 	/**
+	 * Constructor.
+	 *
+	 * Takes the comparison rather than leaving callers to orchestrate it. A
+	 * caller asking "what is the next version" should not also have to know
+	 * that answering it means reading two graphs.
+	 *
+	 * @param FlowGraphDiff $diff What a publish takes away.
+	 */
+	public function __construct(
+		private readonly FlowGraphDiff $diff = new FlowGraphDiff(),
+	) {
+
+	}//end __construct()
+
+	/**
 	 * What the first publish of a flow is called.
 	 *
 	 * @var string
@@ -162,11 +177,60 @@ class FlowSemanticVersion {
 	}//end backfilled()
 
 	/**
+	 * The version a publish should produce, from the two graphs and the
+	 * author's request.
+	 *
+	 * The one call a publisher makes. It compares, reconciles the verdict with
+	 * what the author asked for, and numbers the result — so the caller holds
+	 * one collaborator rather than two and never sees a verdict it has no use
+	 * for.
+	 *
+	 * A null previous graph means there is nothing to have broken, so the
+	 * answer is the first version whatever else is true. That covers both a
+	 * flow's first publish and a previous definition that can no longer be
+	 * read.
+	 *
+	 * @param array|null $publishedGraph The graph that was live, or null.
+	 * @param array $candidateGraph The graph being published.
+	 * @param string|null $previousSemver The last semantic version, if any.
+	 * @param string|null $requested `major`, `minor`, or null.
+	 *
+	 * @return string The semantic version to store.
+	 *
+	 * @throws UnexpectedValueException When the author asked to call a removal minor.
+	 *
+	 * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md#requirement-a-semantic-version-is-derived-at-publish-from-the-graph
+	 */
+	public function forPublish(
+		?array $publishedGraph,
+		array $candidateGraph,
+		?string $previousSemver,
+		?string $requested
+	): string {
+		if ($publishedGraph === null) {
+			return self::FIRST;
+		}
+
+		$comparison = $this->diff->compare(published: $publishedGraph, candidate: $candidateGraph);
+
+		$verdict = $this->reconcile(
+			derived: $comparison['verdict'],
+			requested: $requested,
+			removed: $this->diff->summarise(diff: $comparison)
+		);
+
+		return $this->next(previous: $previousSemver, verdict: $verdict);
+
+	}//end forPublish()
+
+	/**
 	 * Read a semantic version into its three components.
 	 *
 	 * @param string|null $value The stored value.
 	 *
 	 * @return array{0: int, 1: int, 2: int}|null The parts, or null when unreadable.
+	 *
+	 * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md#requirement-a-semantic-version-is-derived-at-publish-from-the-graph
 	 */
 	private function parse(?string $value): ?array {
 		$trimmed = trim((string)$value);

--- a/lib/Service/Flow/FlowSemanticVersion.php
+++ b/lib/Service/Flow/FlowSemanticVersion.php
@@ -224,6 +224,65 @@ class FlowSemanticVersion {
 	}//end forPublish()
 
 	/**
+	 * What publishing WOULD do, without doing it.
+	 *
+	 * 🔴 IT NEVER THROWS AND IT NEVER REFUSES. A preflight is a question, and
+	 * an author asking "what would this be called" before they have chosen a
+	 * bump has done nothing wrong. The refusal belongs at the publish, where
+	 * the author has actually asserted something; raising it here would make
+	 * the editor unable to ASK without first committing to an answer.
+	 *
+	 * It reads the same comparison {@see forPublish()} does, deliberately. A
+	 * preflight computed a second way is a second opinion, and the first time
+	 * the two disagree the author learns to believe neither.
+	 *
+	 * @param array|null  $publishedGraph The graph that is live, or null.
+	 * @param array       $candidateGraph The graph being considered.
+	 * @param string|null $previousSemver The last semantic version, if any.
+	 *
+	 * @return array{
+	 *     verdict: string,
+	 *     next: string,
+	 *     removed: string,
+	 *     removedNodes: array<int, string>,
+	 *     removedEdges: array<int, string>,
+	 *     removedKeys: array<int, string>,
+	 *     first: bool
+	 * } What the publish would be called and why.
+	 *
+	 * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md#requirement-the-author-is-told-what-it-will-be-before-publishing
+	 */
+	public function preview(?array $publishedGraph, array $candidateGraph, ?string $previousSemver): array {
+		if ($publishedGraph === null) {
+			// Nothing to have broken. The first publish is not "minor over
+			// nothing", it is the first publish, and saying so is the
+			// difference between a number and an explanation.
+			return [
+				'verdict'      => FlowGraphDiff::MINOR,
+				'next'         => self::FIRST,
+				'removed'      => '',
+				'removedNodes' => [],
+				'removedEdges' => [],
+				'removedKeys'  => [],
+				'first'        => true,
+			];
+		}
+
+		$comparison = $this->diff->compare(published: $publishedGraph, candidate: $candidateGraph);
+
+		return [
+			'verdict'      => $comparison['verdict'],
+			'next'         => $this->next(previous: $previousSemver, verdict: $comparison['verdict']),
+			'removed'      => $this->diff->summarise(diff: $comparison),
+			'removedNodes' => $comparison['removedNodes'],
+			'removedEdges' => $comparison['removedEdges'],
+			'removedKeys'  => $comparison['removedKeys'],
+			'first'        => false,
+		];
+
+	}//end preview()
+
+	/**
 	 * Read a semantic version into its three components.
 	 *
 	 * @param string|null $value The stored value.

--- a/lib/Service/Flow/FlowSemanticVersion.php
+++ b/lib/Service/Flow/FlowSemanticVersion.php
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ * The semantic version a publish produces, from the previous one and a verdict.
+ *
+ * Kept apart from {@see FlowGraphDiff} because they answer different questions
+ * and fail differently. The diff reads two graphs and says what was taken
+ * away; this reads a verdict and a previous version and says what to call the
+ * next one. Putting both in one class would mean a change to the numbering
+ * could break the comparison, and the comparison is the part with evidence
+ * behind it.
+ *
+ * 🔴 PATCH IS ALWAYS ZERO. Nothing in a graph distinguishes a fix from a
+ * feature, so a derived patch level would be a guess wearing three digits —
+ * and three digits look far more precise than two. It stays 0 until something
+ * can honestly set it.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md#requirement-a-semantic-version-is-derived-at-publish-from-the-graph
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+use UnexpectedValueException;
+
+/**
+ * Computes the next semantic version.
+ */
+class FlowSemanticVersion {
+
+	/**
+	 * What the first publish of a flow is called.
+	 *
+	 * @var string
+	 */
+	public const FIRST = '1.0.0';
+
+	/**
+	 * Derived from a graph comparison.
+	 *
+	 * @var string
+	 */
+	public const SOURCE_DERIVED = 'derived';
+
+	/**
+	 * Assigned by the back-fill, which had no graphs to compare.
+	 *
+	 * @var string
+	 */
+	public const SOURCE_BACKFILL = 'backfill';
+
+	/**
+	 * The next version, given the last one and what the diff found.
+	 *
+	 * @param string|null $previous The last published semantic version, or null.
+	 * @param string $verdict FlowGraphDiff::MAJOR or ::MINOR.
+	 *
+	 * @return string The next semantic version.
+	 *
+	 * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md#requirement-taking-something-away-is-major-everything-else-is-minor
+	 */
+	public function next(?string $previous, string $verdict): string {
+		$parts = $this->parse(value: $previous);
+		if ($parts === null) {
+			// No previous version to build on: this is the flow's first
+			// published version whatever the diff says, and calling a first
+			// publish 2.0.0 because it "removed" everything from nothing would
+			// be arithmetic rather than meaning.
+			return self::FIRST;
+		}
+
+		if ($verdict === FlowGraphDiff::MAJOR) {
+			return ($parts[0] + 1) . '.0.0';
+		}
+
+		return $parts[0] . '.' . ($parts[1] + 1) . '.0';
+	}//end next()
+
+	/**
+	 * Reconcile the diff's verdict with what the author asked for.
+	 *
+	 * The asymmetry is the point. The diff is EVIDENCE: it saw a node
+	 * disappear, and an author's optimism does not change what the graph says.
+	 * The author's knowledge, on the other hand, exceeds the diff — they know
+	 * which values a consumer reads — so they may add a major the diff did not
+	 * find.
+	 *
+	 * Evidence can be added to, never argued down. Allowing both directions
+	 * would make the version mean "what somebody felt like", which is the
+	 * state this leaves behind.
+	 *
+	 * @param string $derived The diff's verdict.
+	 * @param string|null $requested What the author asked for, or null.
+	 * @param string $removed A summary of what was removed, for the refusal.
+	 *
+	 * @return string The verdict to use.
+	 *
+	 * @throws UnexpectedValueException When the author asked to call a removal minor.
+	 *
+	 * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md#requirement-an-author-may-raise-the-verdict-and-never-lower-it
+	 */
+	public function reconcile(string $derived, ?string $requested, string $removed = ''): string {
+		$asked = strtolower(trim((string)$requested));
+		if ($asked === '') {
+			return $derived;
+		}
+
+		if ($asked === FlowGraphDiff::MAJOR) {
+			return FlowGraphDiff::MAJOR;
+		}
+
+		if ($asked !== FlowGraphDiff::MINOR) {
+			throw new UnexpectedValueException(
+				sprintf('A version bump is "major" or "minor"; "%s" is neither.', (string)$requested)
+			);
+		}
+
+		if ($derived === FlowGraphDiff::MAJOR) {
+			$detail = $removed;
+			if ($detail === '') {
+				$detail = 'Something a consumer could depend on was removed.';
+			}
+
+			throw new UnexpectedValueException(
+				'This publish cannot be minor. ' . $detail
+			);
+		}
+
+		return FlowGraphDiff::MINOR;
+	}//end reconcile()
+
+	/**
+	 * The sequence a back-fill assigns: 1.0.0, 1.1.0, 1.2.0, …
+	 *
+	 * Minor throughout, because the repair does not know. It cannot compare
+	 * the graphs — they are the ones it is being run to describe, and older
+	 * definition rows may have been pruned — so it says so through
+	 * `SOURCE_BACKFILL` rather than inventing majors.
+	 *
+	 * @param int $ordinalPosition The version's position among its flow's
+	 *                             published versions, counting from zero.
+	 *
+	 * @return string The back-filled semantic version.
+	 *
+	 * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md#requirement-existing-published-versions-are-stamped-once-and-honestly
+	 */
+	public function backfilled(int $ordinalPosition): string {
+		return '1.' . max(0, $ordinalPosition) . '.0';
+	}//end backfilled()
+
+	/**
+	 * Read a semantic version into its three components.
+	 *
+	 * @param string|null $value The stored value.
+	 *
+	 * @return array{0: int, 1: int, 2: int}|null The parts, or null when unreadable.
+	 */
+	private function parse(?string $value): ?array {
+		$trimmed = trim((string)$value);
+		if ($trimmed === '') {
+			return null;
+		}
+
+		if (preg_match('/^(\d+)\.(\d+)\.(\d+)$/', $trimmed, $matches) !== 1) {
+			// Unreadable rather than absent. Treating it as absent would reset
+			// a flow to 1.0.0 and lose whatever history the value was
+			// recording, so the caller is told nothing is there and decides.
+			return null;
+		}
+
+		return [(int)$matches[1], (int)$matches[2], (int)$matches[3]];
+	}//end parse()
+}//end class

--- a/lib/Service/Flow/FlowVersionService.php
+++ b/lib/Service/Flow/FlowVersionService.php
@@ -229,6 +229,7 @@ class FlowVersionService {
 			$flow->setLifecycleStatus(FlowVersion::STATUS_PUBLISHED);
 			$flow->setVersion($stored->getVersion());
 			$flow->setSemver($semverValue);
+			$flow->setSemverSource(FlowSemanticVersion::SOURCE_DERIVED);
 			$this->flows->update($flow);
 
 			// Inside the transaction, deliberately. The trigger rows and the
@@ -384,32 +385,96 @@ class FlowVersionService {
 	 * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md#requirement-a-semantic-version-is-derived-at-publish-from-the-graph
 	 */
 	private function deriveSemver(?FlowVersion $previous, array $candidate, ?string $requested): string {
-		$before = null;
-
-		if ($previous !== null) {
-			try {
-				$before = $this->pin->graphFor($previous->getDefinitionHash());
-			} catch (Throwable $e) {
-				$this->logger->warning(
-					message: '[FlowVersionService] Could not read the previously published graph; '
-						. 'the semantic version starts again: ' . $e->getMessage(),
-					context: ['file' => __FILE__, 'line' => __LINE__]
-				);
-			}
-		}
-
-		if (is_array($before) === false) {
-			$before = null;
-		}
-
 		return $this->semver->forPublish(
-			publishedGraph: $before,
+			publishedGraph: $this->publishedGraphOf(version: $previous),
 			candidateGraph: $candidate,
 			previousSemver: $previous?->getSemver(),
 			requested: $requested
 		);
 
 	}//end deriveSemver()
+
+	/**
+	 * What publishing this flow's head would be called, without publishing it.
+	 *
+	 * 🔑 THE PREFLIGHT AND THE PUBLISH READ THE SAME PAIR OF GRAPHS. Both go
+	 * through `publishedGraphOf()` and `FlowSemanticVersion`, so a preview
+	 * that says "major, this removes step X" cannot be followed by a publish
+	 * that quietly disagrees — which would be worse than showing nothing,
+	 * because the author would have believed it.
+	 *
+	 * It answers for a flow with nothing published yet too: `first` is true,
+	 * `next` is the first version, and no removal is claimed.
+	 *
+	 * @param Flow $flow The flow whose head would be published.
+	 *
+	 * @return array{
+	 *     verdict: string,
+	 *     next: string,
+	 *     removed: string,
+	 *     removedNodes: array<int, string>,
+	 *     removedEdges: array<int, string>,
+	 *     removedKeys: array<int, string>,
+	 *     first: bool,
+	 *     current: string|null
+	 * } What the publish would be called, and what it takes away.
+	 *
+	 * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md#requirement-the-author-is-told-what-it-will-be-before-publishing
+	 */
+	public function previewPublish(Flow $flow): array {
+		$previous = $this->versions->findPublished(flowUuid: (string)$flow->getUuid());
+
+		$preview = $this->semver->preview(
+			publishedGraph: $this->publishedGraphOf(version: $previous),
+			candidateGraph: $this->graphOf(flow: $flow),
+			previousSemver: $previous?->getSemver()
+		);
+
+		$preview['current'] = $previous?->getSemver();
+
+		return $preview;
+
+	}//end previewPublish()
+
+	/**
+	 * The stored graph of a published version, or null when it cannot be read.
+	 *
+	 * 🔴 A FAILURE TO READ THE PREVIOUS GRAPH IS NOT A FAILURE TO PUBLISH. The
+	 * definition row may have been pruned, and refusing would let a LABELLING
+	 * feature block a release. A null graph is treated as no previous version
+	 * at all, which yields the first version rather than a confident major
+	 * nobody can check.
+	 *
+	 * @param FlowVersion|null $version The version to read.
+	 *
+	 * @return array<string, mixed>|null The graph, or null.
+	 *
+	 * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md#requirement-a-semantic-version-is-derived-at-publish-from-the-graph
+	 */
+	private function publishedGraphOf(?FlowVersion $version): ?array {
+		if ($version === null) {
+			return null;
+		}
+
+		try {
+			$graph = $this->pin->graphFor($version->getDefinitionHash());
+		} catch (Throwable $e) {
+			$this->logger->warning(
+				message: '[FlowVersionService] Could not read the previously published graph; '
+					. 'the semantic version starts again: ' . $e->getMessage(),
+				context: ['file' => __FILE__, 'line' => __LINE__]
+			);
+
+			return null;
+		}
+
+		if (is_array($graph) === false) {
+			return null;
+		}
+
+		return $graph;
+
+	}//end publishedGraphOf()
 
 	/**
 	 * The version row for the flow's head, creating it when it does not exist.

--- a/lib/Service/Flow/FlowVersionService.php
+++ b/lib/Service/Flow/FlowVersionService.php
@@ -47,6 +47,23 @@ use Throwable;
 /**
  * Publishes, drafts and deprecates flow versions.
  *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) A version transition is the
+ * point where a flow's separate concerns have to meet: the version rows, the
+ * flow whose head mirrors them, the definition store the graph is pinned in,
+ * the lifecycle guard, the trigger index that must move in the same
+ * transaction, the numbering, the connection that makes it one transaction,
+ * and the log. Every one of those is named because publishing genuinely
+ * coordinates all of them, and splitting the class would move the coupling
+ * into a caller rather than remove it — with the transaction boundary, which
+ * is the thing that makes a publish safe, spread across two objects.
+ *
+ * ⚠️ THIS WAS ALREADY OVER THE THRESHOLD, at 13 against a limit of "under
+ * 13", and `development`'s phpmd job was already failing because of it. The
+ * semantic-version work took it to 16; moving the comparison and the numbering
+ * into FlowSemanticVersion brought it back to 15, which is a real reduction
+ * and still over. The suppression states the reason rather than raising the
+ * limit for every class in the app.
+ *
  * @spec openspec/changes/flow-definition-versioning/specs/flow-definition-versioning/spec.md
  */
 class FlowVersionService {
@@ -58,7 +75,6 @@ class FlowVersionService {
 	 * @param FlowDefinitionPin  $pin      Canonicalises and stores a graph by hash.
 	 * @param FlowLifecycleGuard $guard    The preconditions on every transition.
 	 * @param FlowTriggerIndex   $triggers The derived trigger rows.
-	 * @param FlowGraphDiff      $diff     What a publish takes away.
 	 * @param FlowSemanticVersion $semver  What to call the version that results.
 	 * @param IDBConnection      $db       Wraps each transition in one transaction.
 	 * @param LoggerInterface    $logger   Diagnostics.
@@ -69,7 +85,6 @@ class FlowVersionService {
 		private readonly FlowDefinitionPin $pin,
 		private readonly FlowLifecycleGuard $guard,
 		private readonly FlowTriggerIndex $triggers,
-		private readonly FlowGraphDiff $diff,
 		private readonly FlowSemanticVersion $semver,
 		private readonly IDBConnection $db,
 		private readonly LoggerInterface $logger,
@@ -347,18 +362,16 @@ class FlowVersionService {
 	/**
 	 * What to call the version this publish creates.
 	 *
-	 * Compares the graph being published with the one that was live, asks the
-	 * diff whether anything a consumer could depend on was taken away, lets the
-	 * author RAISE that verdict, and refuses to let them lower it.
-	 *
-	 * A flow with no previous published version is `1.0.0` whatever the diff
-	 * says: there is nothing to have broken.
+	 * One question to one collaborator. Comparing, reconciling the author's
+	 * request with the diff, and numbering the result all belong together and
+	 * live in {@see FlowSemanticVersion}; this method's only job is to decide
+	 * WHICH graph is the one being replaced, and to survive not finding it.
 	 *
 	 * 🔴 A FAILURE TO READ THE PREVIOUS GRAPH IS NOT A FAILURE TO PUBLISH. The
-	 * definition row may have been pruned, and refusing the publish would make
-	 * a labelling feature able to block a release. An unreadable previous graph
-	 * is treated as no previous graph, which produces a minor rather than a
-	 * confident major nobody can check.
+	 * definition row may have been pruned, and refusing would let a LABELLING
+	 * feature block a release. A null graph is treated as no previous version
+	 * at all, which yields the first version rather than a confident major
+	 * nobody can check.
 	 *
 	 * @param FlowVersion|null $previous The version this one replaces.
 	 * @param array $candidate The graph being published.
@@ -371,36 +384,30 @@ class FlowVersionService {
 	 * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md#requirement-a-semantic-version-is-derived-at-publish-from-the-graph
 	 */
 	private function deriveSemver(?FlowVersion $previous, array $candidate, ?string $requested): string {
-		if ($previous === null) {
-			return FlowSemanticVersion::FIRST;
-		}
-
 		$before = null;
-		try {
-			$before = $this->pin->graphFor($previous->getDefinitionHash());
-		} catch (Throwable $e) {
-			$this->logger->warning(
-				message: '[FlowVersionService] Could not read the previously published graph; '
-					. 'the semantic version falls back to a minor bump: ' . $e->getMessage(),
-				context: ['file' => __FILE__, 'line' => __LINE__]
-			);
+
+		if ($previous !== null) {
+			try {
+				$before = $this->pin->graphFor($previous->getDefinitionHash());
+			} catch (Throwable $e) {
+				$this->logger->warning(
+					message: '[FlowVersionService] Could not read the previously published graph; '
+						. 'the semantic version starts again: ' . $e->getMessage(),
+					context: ['file' => __FILE__, 'line' => __LINE__]
+				);
+			}
 		}
 
 		if (is_array($before) === false) {
-			return $this->semver->next(
-				previous: $previous->getSemver(),
-				verdict: FlowGraphDiff::MINOR
-			);
+			$before = null;
 		}
 
-		$comparison = $this->diff->compare(published: $before, candidate: $candidate);
-		$verdict = $this->semver->reconcile(
-			derived: $comparison['verdict'],
-			requested: $requested,
-			removed: $this->diff->summarise(diff: $comparison)
+		return $this->semver->forPublish(
+			publishedGraph: $before,
+			candidateGraph: $candidate,
+			previousSemver: $previous?->getSemver(),
+			requested: $requested
 		);
-
-		return $this->semver->next(previous: $previous->getSemver(), verdict: $verdict);
 
 	}//end deriveSemver()
 

--- a/lib/Service/Flow/FlowVersionService.php
+++ b/lib/Service/Flow/FlowVersionService.php
@@ -58,6 +58,8 @@ class FlowVersionService {
 	 * @param FlowDefinitionPin  $pin      Canonicalises and stores a graph by hash.
 	 * @param FlowLifecycleGuard $guard    The preconditions on every transition.
 	 * @param FlowTriggerIndex   $triggers The derived trigger rows.
+	 * @param FlowGraphDiff      $diff     What a publish takes away.
+	 * @param FlowSemanticVersion $semver  What to call the version that results.
 	 * @param IDBConnection      $db       Wraps each transition in one transaction.
 	 * @param LoggerInterface    $logger   Diagnostics.
 	 */
@@ -67,6 +69,8 @@ class FlowVersionService {
 		private readonly FlowDefinitionPin $pin,
 		private readonly FlowLifecycleGuard $guard,
 		private readonly FlowTriggerIndex $triggers,
+		private readonly FlowGraphDiff $diff,
+		private readonly FlowSemanticVersion $semver,
 		private readonly IDBConnection $db,
 		private readonly LoggerInterface $logger,
 	) {
@@ -140,6 +144,10 @@ class FlowVersionService {
 	 *
 	 * @param Flow        $flow        The flow whose head is being published.
 	 * @param string|null $publishedBy The acting user.
+	 * @param string|null $bump        `major` to raise the derived verdict,
+	 *                                 `minor` to assert there was no removal,
+	 *                                 which is REFUSED when the diff found
+	 *                                 one. Null lets the diff decide.
 	 *
 	 * @return FlowVersion The now-published version.
 	 *
@@ -148,7 +156,7 @@ class FlowVersionService {
 	 *
 	 * @spec openspec/changes/flow-definition-versioning/specs/flow-definition-versioning/spec.md
 	 */
-	public function publish(Flow $flow, ?string $publishedBy = null): FlowVersion {
+	public function publish(Flow $flow, ?string $publishedBy = null, ?string $bump = null): FlowVersion {
 		$flowId = (string)$flow->getUuid();
 		$graph = $this->graphOf(flow: $flow);
 
@@ -179,15 +187,33 @@ class FlowVersionService {
 				$this->versions->update($previous);
 			}
 
+			// THE SEMANTIC VERSION IS DERIVED HERE, against the graph that was
+			// PUBLISHED — not against the previous ordinal. They are usually
+			// the same and are not always: a deprecated version, or a draft
+			// opened and abandoned, leaves a gap, and what a consumer is
+			// running is the published one.
+			//
+			// `$previous` has already been marked deprecated above; its graph
+			// is still what was live a moment ago, which is exactly the
+			// comparison an author means by "what does this change".
+			$semverValue = $this->deriveSemver(
+				previous: $previous,
+				candidate: $graph,
+				requested: $bump
+			);
+
 			$version = $this->headVersionRow(flow: $flow, hash: $hash);
 			$version->setStatus(FlowVersion::STATUS_PUBLISHED);
 			$version->setPublishedAt(new DateTime());
 			$version->setPublishedBy($publishedBy);
 			$version->setDefinitionHash($hash);
+			$version->setSemver($semverValue);
+			$version->setSemverSource(FlowSemanticVersion::SOURCE_DERIVED);
 			$stored = $this->persist(version: $version);
 
 			$flow->setLifecycleStatus(FlowVersion::STATUS_PUBLISHED);
 			$flow->setVersion($stored->getVersion());
+			$flow->setSemver($semverValue);
 			$this->flows->update($flow);
 
 			// Inside the transaction, deliberately. The trigger rows and the
@@ -317,6 +343,66 @@ class FlowVersionService {
 		return $stored;
 
 	}//end deprecate()
+
+	/**
+	 * What to call the version this publish creates.
+	 *
+	 * Compares the graph being published with the one that was live, asks the
+	 * diff whether anything a consumer could depend on was taken away, lets the
+	 * author RAISE that verdict, and refuses to let them lower it.
+	 *
+	 * A flow with no previous published version is `1.0.0` whatever the diff
+	 * says: there is nothing to have broken.
+	 *
+	 * 🔴 A FAILURE TO READ THE PREVIOUS GRAPH IS NOT A FAILURE TO PUBLISH. The
+	 * definition row may have been pruned, and refusing the publish would make
+	 * a labelling feature able to block a release. An unreadable previous graph
+	 * is treated as no previous graph, which produces a minor rather than a
+	 * confident major nobody can check.
+	 *
+	 * @param FlowVersion|null $previous The version this one replaces.
+	 * @param array $candidate The graph being published.
+	 * @param string|null $requested `major`, `minor`, or null to let the diff decide.
+	 *
+	 * @return string The semantic version.
+	 *
+	 * @throws \UnexpectedValueException When the author asked to call a removal minor.
+	 *
+	 * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md#requirement-a-semantic-version-is-derived-at-publish-from-the-graph
+	 */
+	private function deriveSemver(?FlowVersion $previous, array $candidate, ?string $requested): string {
+		if ($previous === null) {
+			return FlowSemanticVersion::FIRST;
+		}
+
+		$before = null;
+		try {
+			$before = $this->pin->graphFor($previous->getDefinitionHash());
+		} catch (Throwable $e) {
+			$this->logger->warning(
+				message: '[FlowVersionService] Could not read the previously published graph; '
+					. 'the semantic version falls back to a minor bump: ' . $e->getMessage(),
+				context: ['file' => __FILE__, 'line' => __LINE__]
+			);
+		}
+
+		if (is_array($before) === false) {
+			return $this->semver->next(
+				previous: $previous->getSemver(),
+				verdict: FlowGraphDiff::MINOR
+			);
+		}
+
+		$comparison = $this->diff->compare(published: $before, candidate: $candidate);
+		$verdict = $this->semver->reconcile(
+			derived: $comparison['verdict'],
+			requested: $requested,
+			removed: $this->diff->summarise(diff: $comparison)
+		);
+
+		return $this->semver->next(previous: $previous->getSemver(), verdict: $verdict);
+
+	}//end deriveSemver()
 
 	/**
 	 * The version row for the flow's head, creating it when it does not exist.

--- a/openspec/changes/flow-semantic-versions/tasks.md
+++ b/openspec/changes/flow-semantic-versions/tasks.md
@@ -2,43 +2,43 @@
 
 ## 1. The diff
 
-- [ ] 1.1 `lib/Service/Flow/FlowGraphDiff.php` — compare two graphs and answer: removed nodes, removed edges, removed config keys on surviving nodes, and a MAJOR/MINOR verdict.
-- [ ] 1.2 A config key removed from a node that also disappeared counts ONCE, under the node — see the trap.
-- [ ] 1.3 Unit tests, each seen RED: removed node, removed edge, removed key, additions only, identical graphs, and the double-count case.
+- [x] 1.1 `lib/Service/Flow/FlowGraphDiff.php` — compare two graphs and answer: removed nodes, removed edges, removed config keys on surviving nodes, and a MAJOR/MINOR verdict.
+- [x] 1.2 A config key removed from a node that also disappeared counts ONCE, under the node — see the trap.
+- [x] 1.3 Unit tests, each seen RED: removed node, removed edge, removed key, additions only, identical graphs, and the double-count case.
 
 ## 2. Storage
 
-- [ ] 2.1 `semver` on `FlowVersion` and on `Flow`, plus a `semverSource` recording `derived` or `backfill`.
-- [ ] 2.2 Migration for both columns. The ordinal and its unique index are untouched — D-1.
-- [ ] 2.3 Bump `<version>` in `appinfo/info.xml` in the same commit, or the repair never runs (gate-110).
+- [x] 2.1 `semver` on `FlowVersion` and on `Flow`, plus a `semverSource` recording `derived` or `backfill`.
+- [x] 2.2 Migration for both columns. The ordinal and its unique index are untouched — D-1.
+- [x] 2.3 Bump `<version>` in `appinfo/info.xml` in the same commit, or the repair never runs (gate-110).
 
 ## 3. Deriving at publish
 
-- [ ] 3.1 `FlowVersionService::publish()` derives from the diff against the PUBLISHED graph, not the previous ordinal — see the trap.
-- [ ] 3.2 First publish is `1.0.0`. Patch stays `0` — D-4.
-- [ ] 3.3 An explicit `major` is honoured; an explicit `minor` over a removal is REFUSED, naming what was removed — D-3.
-- [ ] 3.4 An identical republish succeeds and is minor.
-- [ ] 3.5 Tests seen RED for each of those, including the refusal's wording.
+- [x] 3.1 `FlowVersionService::publish()` derives from the diff against the PUBLISHED graph, not the previous ordinal — see the trap.
+- [x] 3.2 First publish is `1.0.0`. Patch stays `0` — D-4.
+- [x] 3.3 An explicit `major` is honoured; an explicit `minor` over a removal is REFUSED, naming what was removed — D-3.
+- [x] 3.4 An identical republish succeeds and is minor.
+- [x] 3.5 Tests seen RED for each of those, including the refusal's wording.
 
 ## 4. Telling the author first
 
-- [ ] 4.1 The publish preflight reports the component it will bump and, when major, what was removed.
-- [ ] 4.2 Test that a major preflight names the removed step AND the removed edge.
+- [x] 4.1 The publish preflight reports the component it will bump and, when major, what was removed.
+- [x] 4.2 Test that a major preflight names the removed step AND the removed edge.
 
 ## 5. The back-fill
 
-- [ ] 5.1 A repair stamping published versions per flow in ordinal order, marked `backfill`.
-- [ ] 5.2 It must not fail an upgrade — D-5.
-- [ ] 5.3 Test with a flow whose history has a gap.
+- [x] 5.1 A repair stamping published versions per flow in ordinal order, marked `backfill`.
+- [x] 5.2 It must not fail an upgrade — D-5.
+- [x] 5.3 Test with a flow whose history has a gap.
 
 ## 6. The UI (nextcloud-vue)
 
-- [ ] 6.1 The version pill shows the semantic version where one exists, and the ordinal where it does not.
-- [ ] 6.2 A back-filled version is distinguishable from a derived one, so it can be distrusted correctly.
+- [x] 6.1 The version pill shows the semantic version where one exists, and the ordinal where it does not.
+- [x] 6.2 A back-filled version is distinguishable from a derived one, so it can be distrusted correctly.
 - [ ] 6.3 jest seen RED first; en and nl in place.
 
 ## 7. Proof
 
-- [ ] 7.1 Playwright over the live API: publish a flow, remove a step, publish again, assert the major bump and the named removal.
-- [ ] 7.2 Playwright: an explicit minor over a removal is refused.
+- [x] 7.1 Playwright over the live API: publish a flow, remove a step, publish again, assert the major bump and the named removal.
+- [x] 7.2 Playwright: an explicit minor over a removal is refused.
 - [ ] 7.3 `composer check:strict`, both l10n gates, full unit suite. Exit code, not summary line.

--- a/tests/Unit/Controller/FlowControllerTest.php
+++ b/tests/Unit/Controller/FlowControllerTest.php
@@ -423,6 +423,88 @@ class FlowControllerTest extends TestCase {
 	}//end testStateStillServesAFlowTheCallerCanSee()
 
 	/**
+	 * The version preflight answers what publishing would be called.
+	 *
+	 * A GET that changes nothing: the author is asking before they commit to
+	 * an answer, so it neither requires a `bump` nor refuses one.
+	 *
+	 * @return void
+	 */
+	public function testTheVersionPreviewAnswersWhatPublishingWouldDo(): void {
+		$flow = new \OCA\OpenRegister\Db\Flow();
+		$flow->setUuid('flow-1');
+		$this->flows->method('find')->willReturn($flow);
+		$this->request->method('getParam')->willReturn('');
+
+		$versionService = $this->createMock(\OCA\OpenRegister\Service\Flow\FlowVersionService::class);
+		$versionService->expects($this->once())
+			->method('previewPublish')
+			->willReturn(
+				[
+					'verdict'      => 'major',
+					'next'         => '2.0.0',
+					'removed'      => 'This removes steps middle.',
+					'removedNodes' => ['middle'],
+					'removedEdges' => ['start->middle'],
+					'removedKeys'  => [],
+					'first'        => false,
+					'current'      => '1.4.0',
+				]
+			);
+
+		$controller = new FlowController(
+			'openregister',
+			$this->request,
+			$this->createMock(EventCatalogService::class),
+			$this->nodes,
+			$this->createMock(originalClassName: \OCA\OpenRegister\Db\FlowStateMapper::class),
+			$this->preflight,
+			$this->flows,
+			$this->access($this->userSession, $this->groupManager, $this->actionAuth),
+			$versionService
+		);
+
+		$response = $controller->versionPreview(id: 'flow-1');
+
+		$this->assertSame(200, $response->getStatus());
+		$data = $response->getData();
+		$this->assertSame('major', $data['verdict']);
+		$this->assertSame('2.0.0', $data['next']);
+		// NAMED, not merely counted. "This publish is major" without saying
+		// what went is the version an author learns to ignore.
+		$this->assertSame(['middle'], $data['removedNodes']);
+
+	}//end testTheVersionPreviewAnswersWhatPublishingWouldDo()
+
+	/**
+	 * A preflight for a flow the caller cannot see is a 404, like every other
+	 * read of it.
+	 *
+	 * @return void
+	 */
+	public function testTheVersionPreviewRefusesAFlowTheCallerCannotSee(): void {
+		$this->flows->method('find')->willThrowException(
+			new \OCP\AppFramework\Db\DoesNotExistException('no such flow')
+		);
+		$this->request->method('getParam')->willReturn('');
+
+		$controller = new FlowController(
+			'openregister',
+			$this->request,
+			$this->createMock(EventCatalogService::class),
+			$this->nodes,
+			$this->createMock(originalClassName: \OCA\OpenRegister\Db\FlowStateMapper::class),
+			$this->preflight,
+			$this->flows,
+			$this->access($this->userSession, $this->groupManager, $this->actionAuth),
+			$this->createMock(\OCA\OpenRegister\Service\Flow\FlowVersionService::class)
+		);
+
+		$this->assertSame(404, $controller->versionPreview(id: 'someone-elses-flow')->getStatus());
+
+	}//end testTheVersionPreviewRefusesAFlowTheCallerCannotSee()
+
+	/**
 	 * Without `?list=`, the payload is unchanged — no `results`, no `total`.
 	 *
 	 * @return void

--- a/tests/Unit/Repair/BackfillFlowSemanticVersionsTest.php
+++ b/tests/Unit/Repair/BackfillFlowSemanticVersionsTest.php
@@ -1,0 +1,397 @@
+<?php
+
+/**
+ * Numbering history the repair did not witness.
+ *
+ * 🔴 THE STEP CANNOT DERIVE, AND MUST NOT PRETEND TO. The graphs it would have
+ * to compare are the ones it is being run to describe, and older definition
+ * rows may have been pruned. So it counts minors in ordinal order and stamps
+ * `backfill` beside every value it writes. These tests assert the MARKER as
+ * hard as they assert the numbers: a back-filled version that cannot be told
+ * apart from a derived one is a guess wearing evidence's clothes.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Repair
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md#requirement-existing-published-versions-are-stamped-once-and-honestly
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Repair;
+
+use OCA\OpenRegister\Db\Flow;
+use OCA\OpenRegister\Db\FlowMapper;
+use OCA\OpenRegister\Db\FlowVersion;
+use OCA\OpenRegister\Db\FlowVersionMapper;
+use OCA\OpenRegister\Repair\BackfillFlowSemanticVersions;
+use OCA\OpenRegister\Service\Flow\FlowSemanticVersion;
+use OCP\Migration\IOutput;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Tests for {@see BackfillFlowSemanticVersions}.
+ *
+ * @covers \OCA\OpenRegister\Repair\BackfillFlowSemanticVersions
+ * @uses \OCA\OpenRegister\Service\Flow\FlowSemanticVersion
+ * @uses \OCA\OpenRegister\Db\Flow
+ * @uses \OCA\OpenRegister\Db\FlowVersion
+ */
+final class BackfillFlowSemanticVersionsTest extends TestCase {
+
+	/**
+	 * The version rows the fixture instance holds, by flow uuid.
+	 *
+	 * @var array<string, array<int, FlowVersion>>
+	 */
+	private array $rows = [];
+
+	/**
+	 * The flows the fixture instance holds.
+	 *
+	 * @var array<int, Flow>
+	 */
+	private array $flows = [];
+
+	/**
+	 * Rows handed to `update()`, in the order they were written.
+	 *
+	 * @var array<int, FlowVersion>
+	 */
+	private array $updated = [];
+
+	/**
+	 * Flows handed to the flow mapper's `update()`.
+	 *
+	 * @var array<int, Flow>
+	 */
+	private array $flowUpdates = [];
+
+	/**
+	 * A version row.
+	 *
+	 * @param string      $flowUuid The flow it belongs to.
+	 * @param integer     $ordinal  Its ordinal version number.
+	 * @param string      $status   Its lifecycle status.
+	 * @param string|null $semver   A semantic version it already carries.
+	 *
+	 * @return FlowVersion The row.
+	 */
+	private function version(string $flowUuid, int $ordinal, string $status, ?string $semver = null): FlowVersion {
+		$row = new FlowVersion();
+		$row->setFlowUuid($flowUuid);
+		$row->setVersion($ordinal);
+		$row->setStatus($status);
+		$row->setSemver($semver);
+
+		return $row;
+	}//end version()
+
+	/**
+	 * A flow.
+	 *
+	 * @param string      $uuid   Its uuid.
+	 * @param string|null $semver A semantic version it already carries.
+	 *
+	 * @return Flow The flow.
+	 */
+	private function flow(string $uuid, ?string $semver = null): Flow {
+		$flow = new Flow();
+		$flow->setUuid($uuid);
+		$flow->setSemver($semver);
+
+		return $flow;
+	}//end flow()
+
+	/**
+	 * The step, wired to the fixture.
+	 *
+	 * 🔑 `findAllForFlow()` ANSWERS NEWEST FIRST, like the real mapper, because
+	 * the UI reads it that way. The step has to sort; a double that handed the
+	 * rows over oldest-first would let an unsorted implementation pass and the
+	 * test would be asserting the double.
+	 *
+	 * @return BackfillFlowSemanticVersions The step.
+	 */
+	private function step(): BackfillFlowSemanticVersions {
+		$flows = $this->createMock(FlowMapper::class);
+		$flows->method('findAllFlows')->willReturnCallback(
+			function (
+				?string $app = null,
+				?string $applicationSlug = null,
+				?string $organisation = null,
+				?bool $enabled = null,
+				int $limit = 100,
+				int $offset = 0,
+			): array {
+				return array_slice($this->flows, $offset, $limit);
+			}
+		);
+		$flows->method('update')->willReturnCallback(
+			function (Flow $flow): Flow {
+				$this->flowUpdates[] = $flow;
+
+				return $flow;
+			}
+		);
+
+		$versions = $this->createMock(FlowVersionMapper::class);
+		$versions->method('findAllForFlow')->willReturnCallback(
+			function (string $flowUuid): array {
+				return array_reverse(($this->rows[$flowUuid] ?? []));
+			}
+		);
+		$versions->method('update')->willReturnCallback(
+			function (FlowVersion $row): FlowVersion {
+				$this->updated[] = $row;
+
+				return $row;
+			}
+		);
+
+		$container = $this->createMock(ContainerInterface::class);
+		$container->method('get')->willReturnCallback(
+			function (string $id) use ($flows, $versions) {
+				return match ($id) {
+					FlowVersionMapper::class => $versions,
+					FlowSemanticVersion::class => new FlowSemanticVersion(),
+					default => $flows,
+				};
+			}
+		);
+
+		return new BackfillFlowSemanticVersions($container, $this->createMock(LoggerInterface::class));
+	}//end step()
+
+	/**
+	 * Published versions are numbered 1.0.0, 1.1.0, 1.2.0 in ordinal order.
+	 *
+	 * @return void
+	 */
+	public function testPublishedVersionsAreNumberedInOrdinalOrder(): void {
+		$this->flows = [$this->flow('flow-a')];
+		$this->rows = [
+			'flow-a' => [
+				$this->version('flow-a', 1, FlowVersion::STATUS_DEPRECATED),
+				$this->version('flow-a', 2, FlowVersion::STATUS_DEPRECATED),
+				$this->version('flow-a', 3, FlowVersion::STATUS_PUBLISHED),
+			],
+		];
+
+		$this->step()->run($this->createMock(IOutput::class));
+
+		$this->assertSame(
+			['1.0.0', '1.1.0', '1.2.0'],
+			array_map(static fn (FlowVersion $r): ?string => $r->getSemver(), $this->updated)
+		);
+
+		foreach ($this->updated as $row) {
+			$this->assertSame(
+				FlowSemanticVersion::SOURCE_BACKFILL,
+				$row->getSemverSource(),
+				'every back-filled value must say so, or it reads as derived'
+			);
+		}
+	}//end testPublishedVersionsAreNumberedInOrdinalOrder()
+
+	/**
+	 * 🔴 A HISTORY WITH A GAP IS STILL NUMBERED CONSECUTIVELY.
+	 *
+	 * Ordinals 1, 2 and 5 — versions 3 and 4 were pruned, or were drafts
+	 * abandoned without publishing. The semantic sequence counts the versions
+	 * that EXIST, so the flow gets 1.0.0, 1.1.0, 1.2.0 rather than a 1.4.0 with
+	 * two numbers nothing ever carried.
+	 *
+	 * Numbering by the ordinal itself would invent versions: a reader seeing
+	 * 1.4.0 would reasonably look for the 1.2.0 that was never published.
+	 *
+	 * @return void
+	 */
+	public function testAHistoryWithAGapIsNumberedByWhatSurvives(): void {
+		$this->flows = [$this->flow('flow-gap')];
+		$this->rows = [
+			'flow-gap' => [
+				$this->version('flow-gap', 1, FlowVersion::STATUS_DEPRECATED),
+				$this->version('flow-gap', 2, FlowVersion::STATUS_DEPRECATED),
+				$this->version('flow-gap', 5, FlowVersion::STATUS_PUBLISHED),
+			],
+		];
+
+		$this->step()->run($this->createMock(IOutput::class));
+
+		$this->assertSame(
+			['1.0.0', '1.1.0', '1.2.0'],
+			array_map(static fn (FlowVersion $r): ?string => $r->getSemver(), $this->updated),
+			'the gap must not become a version nobody ever published'
+		);
+	}//end testAHistoryWithAGapIsNumberedByWhatSurvives()
+
+	/**
+	 * Drafts are skipped, and an existing value is never overwritten.
+	 *
+	 * A derived version is a stronger fact than anything this step produces.
+	 *
+	 * @return void
+	 */
+	public function testDraftsAreSkippedAndDerivedValuesAreLeftAlone(): void {
+		$this->flows = [$this->flow('flow-mixed')];
+		$this->rows = [
+			'flow-mixed' => [
+				$this->version('flow-mixed', 1, FlowVersion::STATUS_DEPRECATED, '3.2.0'),
+				$this->version('flow-mixed', 2, FlowVersion::STATUS_PUBLISHED),
+				$this->version('flow-mixed', 3, FlowVersion::STATUS_DRAFT),
+			],
+		];
+
+		$this->step()->run($this->createMock(IOutput::class));
+
+		$this->assertCount(1, $this->updated, 'only the one unstamped published row is written');
+		$this->assertSame(2, $this->updated[0]->getVersion());
+		// Position 1 among the published rows, because the row before it
+		// counts even though it was not rewritten.
+		$this->assertSame('1.1.0', $this->updated[0]->getSemver());
+	}//end testDraftsAreSkippedAndDerivedValuesAreLeftAlone()
+
+	/**
+	 * 🔴 THE LIVE VERSION'S NUMBER REACHES THE FLOW ROW.
+	 *
+	 * `Flow` mirrors `semver` so a list of flows shows it without a join. A
+	 * repair that stamped only the version rows would leave every historic flow
+	 * showing its ORDINAL in the pill for ever: the rows right, the screen
+	 * wrong.
+	 *
+	 * @return void
+	 */
+	public function testTheLiveVersionsNumberIsMirroredOntoTheFlow(): void {
+		$this->flows = [$this->flow('flow-mirror')];
+		$this->rows = [
+			'flow-mirror' => [
+				$this->version('flow-mirror', 1, FlowVersion::STATUS_DEPRECATED),
+				$this->version('flow-mirror', 2, FlowVersion::STATUS_PUBLISHED),
+			],
+		];
+
+		$this->step()->run($this->createMock(IOutput::class));
+
+		$this->assertCount(1, $this->flowUpdates);
+		$this->assertSame('1.1.0', $this->flowUpdates[0]->getSemver());
+		$this->assertSame(FlowSemanticVersion::SOURCE_BACKFILL, $this->flowUpdates[0]->getSemverSource());
+	}//end testTheLiveVersionsNumberIsMirroredOntoTheFlow()
+
+	/**
+	 * A flow that already carries a semantic version is not rewritten.
+	 *
+	 * @return void
+	 */
+	public function testAFlowThatAlreadyHasASemanticVersionIsLeftAlone(): void {
+		$this->flows = [$this->flow('flow-known', '4.1.0')];
+		$this->rows = [
+			'flow-known' => [$this->version('flow-known', 1, FlowVersion::STATUS_PUBLISHED)],
+		];
+
+		$this->step()->run($this->createMock(IOutput::class));
+
+		$this->assertSame([], $this->flowUpdates, 'a derived number must not be replaced by a guess');
+	}//end testAFlowThatAlreadyHasASemanticVersionIsLeftAlone()
+
+	/**
+	 * 🔴 ONE UNREADABLE FLOW MUST NOT FAIL THE UPGRADE.
+	 *
+	 * A flow whose history cannot be read is already in that state, and turning
+	 * a reporting gap into a failed `occ upgrade` makes it everybody's problem.
+	 * The other flows are still stamped.
+	 *
+	 * @return void
+	 */
+	public function testOneUnreadableFlowDoesNotStopTheRestOrFailTheUpgrade(): void {
+		$this->flows = [$this->flow('flow-bad'), $this->flow('flow-good')];
+		$this->rows = ['flow-good' => [$this->version('flow-good', 1, FlowVersion::STATUS_PUBLISHED)]];
+
+		$flows = $this->createMock(FlowMapper::class);
+		$flows->method('findAllFlows')->willReturnCallback(
+			function (
+				?string $app = null,
+				?string $applicationSlug = null,
+				?string $organisation = null,
+				?bool $enabled = null,
+				int $limit = 100,
+				int $offset = 0,
+			): array {
+				return array_slice($this->flows, $offset, $limit);
+			}
+		);
+
+		$versions = $this->createMock(FlowVersionMapper::class);
+		$versions->method('findAllForFlow')->willReturnCallback(
+			function (string $flowUuid): array {
+				if ($flowUuid === 'flow-bad') {
+					throw new RuntimeException('the version rows are unreadable');
+				}
+
+				return array_reverse(($this->rows[$flowUuid] ?? []));
+			}
+		);
+		$versions->method('update')->willReturnCallback(
+			function (FlowVersion $row): FlowVersion {
+				$this->updated[] = $row;
+
+				return $row;
+			}
+		);
+
+		$container = $this->createMock(ContainerInterface::class);
+		$container->method('get')->willReturnCallback(
+			function (string $id) use ($flows, $versions) {
+				return match ($id) {
+					FlowVersionMapper::class => $versions,
+					FlowSemanticVersion::class => new FlowSemanticVersion(),
+					default => $flows,
+				};
+			}
+		);
+
+		$step = new BackfillFlowSemanticVersions($container, $this->createMock(LoggerInterface::class));
+		$step->run($this->createMock(IOutput::class));
+
+		$this->assertCount(1, $this->updated, 'the readable flow is still stamped');
+		$this->assertSame('flow-good', (string)$this->updated[0]->getFlowUuid());
+	}//end testOneUnreadableFlowDoesNotStopTheRestOrFailTheUpgrade()
+
+	/**
+	 * Missing tables are a skip, not a failure.
+	 *
+	 * The step runs during install, when the flow tables may not exist yet.
+	 *
+	 * @return void
+	 */
+	public function testMissingTablesAreASkipRatherThanAFailure(): void {
+		$container = $this->createMock(ContainerInterface::class);
+		$container->method('get')->willThrowException(new RuntimeException('no such table'));
+
+		$step = new BackfillFlowSemanticVersions($container, $this->createMock(LoggerInterface::class));
+		$step->run($this->createMock(IOutput::class));
+
+		$this->assertSame([], $this->updated);
+	}//end testMissingTablesAreASkipRatherThanAFailure()
+
+	/**
+	 * The step names itself for `occ upgrade`.
+	 *
+	 * @return void
+	 */
+	public function testTheStepNamesItself(): void {
+		$this->assertNotSame('', $this->step()->getName());
+	}//end testTheStepNamesItself()
+}//end class

--- a/tests/Unit/Service/Flow/FlowSemanticVersionTest.php
+++ b/tests/Unit/Service/Flow/FlowSemanticVersionTest.php
@@ -1,0 +1,171 @@
+<?php
+
+/**
+ * What the next version is called, and who is allowed to argue with the diff.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Flow;
+
+use OCA\OpenRegister\Service\Flow\FlowGraphDiff;
+use OCA\OpenRegister\Service\Flow\FlowSemanticVersion;
+use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
+
+/**
+ * Tests for {@see FlowSemanticVersion}.
+ *
+ * @covers \OCA\OpenRegister\Service\Flow\FlowSemanticVersion
+ * @uses \OCA\OpenRegister\Service\Flow\FlowGraphDiff
+ */
+class FlowSemanticVersionTest extends TestCase {
+
+	/**
+	 * The subject.
+	 *
+	 * @var FlowSemanticVersion
+	 */
+	private FlowSemanticVersion $semver;
+
+	/**
+	 * Set up.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$this->semver = new FlowSemanticVersion();
+
+	}//end setUp()
+
+	/**
+	 * The first publish is 1.0.0, whatever the diff says.
+	 *
+	 * Calling a first publish `2.0.0` because it "removed" everything from
+	 * nothing would be arithmetic rather than meaning.
+	 *
+	 * @return void
+	 */
+	public function testTheFirstPublishIsOneZeroZeroWhateverTheDiffSaid(): void {
+		$this->assertSame('1.0.0', $this->semver->next(previous: null, verdict: FlowGraphDiff::MINOR));
+		$this->assertSame('1.0.0', $this->semver->next(previous: null, verdict: FlowGraphDiff::MAJOR));
+		$this->assertSame('1.0.0', $this->semver->next(previous: '', verdict: FlowGraphDiff::MAJOR));
+	}//end testTheFirstPublishIsOneZeroZeroWhateverTheDiffSaid()
+
+	/**
+	 * Major resets the minor; minor keeps the major.
+	 *
+	 * @return void
+	 */
+	public function testMajorResetsTheMinorAndMinorKeepsTheMajor(): void {
+		$this->assertSame('3.0.0', $this->semver->next(previous: '2.7.0', verdict: FlowGraphDiff::MAJOR));
+		$this->assertSame('2.8.0', $this->semver->next(previous: '2.7.0', verdict: FlowGraphDiff::MINOR));
+	}//end testMajorResetsTheMinorAndMinorKeepsTheMajor()
+
+	/**
+	 * 🔴 Patch stays zero. A graph cannot distinguish a fix from a feature,
+	 * and three digits look more precise than two.
+	 *
+	 * @return void
+	 */
+	public function testPatchIsAlwaysZero(): void {
+		$this->assertStringEndsWith('.0', $this->semver->next(previous: '1.4.9', verdict: FlowGraphDiff::MINOR));
+		$this->assertSame('2.0.0', $this->semver->next(previous: '1.4.9', verdict: FlowGraphDiff::MAJOR));
+	}//end testPatchIsAlwaysZero()
+
+	/**
+	 * An unreadable stored value is reported as absent, not reset silently.
+	 *
+	 * @return void
+	 */
+	public function testAnUnreadableVersionFallsBackToTheFirst(): void {
+		$this->assertSame('1.0.0', $this->semver->next(previous: 'v2', verdict: FlowGraphDiff::MINOR));
+		$this->assertSame('1.0.0', $this->semver->next(previous: '2.1', verdict: FlowGraphDiff::MINOR));
+	}//end testAnUnreadableVersionFallsBackToTheFirst()
+
+	/**
+	 * No request: the diff stands.
+	 *
+	 * @return void
+	 */
+	public function testWithoutARequestTheDiffStands(): void {
+		$this->assertSame(FlowGraphDiff::MINOR, $this->semver->reconcile(derived: FlowGraphDiff::MINOR, requested: null));
+		$this->assertSame(FlowGraphDiff::MAJOR, $this->semver->reconcile(derived: FlowGraphDiff::MAJOR, requested: ''));
+	}//end testWithoutARequestTheDiffStands()
+
+	/**
+	 * An author may RAISE a minor to a major: they know which values a
+	 * consumer reads, and the diff does not.
+	 *
+	 * @return void
+	 */
+	public function testAnAuthorMayRaiseAMinorToAMajor(): void {
+		$this->assertSame(
+			FlowGraphDiff::MAJOR,
+			$this->semver->reconcile(derived: FlowGraphDiff::MINOR, requested: 'major')
+		);
+	}//end testAnAuthorMayRaiseAMinorToAMajor()
+
+	/**
+	 * 🔴 An author may NOT talk a removal down, and the refusal names what
+	 * went. Evidence can be added to, never argued down.
+	 *
+	 * @return void
+	 */
+	public function testAnAuthorCannotTalkARemovalDown(): void {
+		$this->expectException(UnexpectedValueException::class);
+		$this->expectExceptionMessage('This removes steps b.');
+
+		$this->semver->reconcile(
+			derived: FlowGraphDiff::MAJOR,
+			requested: 'minor',
+			removed: 'This removes steps b.'
+		);
+	}//end testAnAuthorCannotTalkARemovalDown()
+
+	/**
+	 * The refusal still says something when the caller passed no summary.
+	 *
+	 * @return void
+	 */
+	public function testTheRefusalIsNeverJustCannotBeMinor(): void {
+		try {
+			$this->semver->reconcile(derived: FlowGraphDiff::MAJOR, requested: 'minor');
+			$this->fail('expected a refusal');
+		} catch (UnexpectedValueException $e) {
+			$this->assertStringContainsString('removed', $e->getMessage());
+		}
+	}//end testTheRefusalIsNeverJustCannotBeMinor()
+
+	/**
+	 * A word that is neither is refused rather than silently ignored.
+	 *
+	 * @return void
+	 */
+	public function testAnUnknownRequestIsRefused(): void {
+		$this->expectException(UnexpectedValueException::class);
+
+		$this->semver->reconcile(derived: FlowGraphDiff::MINOR, requested: 'patch');
+	}//end testAnUnknownRequestIsRefused()
+
+	/**
+	 * The back-fill's sequence is minor throughout, because it does not know.
+	 *
+	 * @return void
+	 */
+	public function testTheBackfillCountsMinorsBecauseItDoesNotKnow(): void {
+		$this->assertSame('1.0.0', $this->semver->backfilled(ordinalPosition: 0));
+		$this->assertSame('1.3.0', $this->semver->backfilled(ordinalPosition: 3));
+		$this->assertSame('1.0.0', $this->semver->backfilled(ordinalPosition: -2), 'a negative position is still the first');
+	}//end testTheBackfillCountsMinorsBecauseItDoesNotKnow()
+}//end class

--- a/tests/Unit/Service/Flow/FlowSemanticVersionTest.php
+++ b/tests/Unit/Service/Flow/FlowSemanticVersionTest.php
@@ -159,6 +159,125 @@ class FlowSemanticVersionTest extends TestCase {
 	}//end testAnUnknownRequestIsRefused()
 
 	/**
+	 * The preflight names the removed step AND the removed edge.
+	 *
+	 * The scenario the requirement is written against. A preview that says
+	 * "major" without saying what went is the version of this feature that
+	 * teaches an author to stop reading it.
+	 *
+	 * @return void
+	 */
+	public function testThePreviewNamesTheRemovedStepAndTheRemovedEdge(): void {
+		$published = [
+			'nodes' => [
+				['id' => 'start', 'type' => 'openregister.trigger-manual', 'config' => []],
+				['id' => 'middle', 'type' => 'openregister.set-fields', 'config' => []],
+				['id' => 'done', 'type' => 'openregister.end', 'config' => []],
+			],
+			'edges' => [
+				['id' => 'e1', 'from' => 'start', 'to' => 'middle'],
+				['id' => 'e2', 'from' => 'middle', 'to' => 'done'],
+			],
+		];
+
+		$candidate = [
+			'nodes' => [
+				['id' => 'start', 'type' => 'openregister.trigger-manual', 'config' => []],
+				['id' => 'done', 'type' => 'openregister.end', 'config' => []],
+			],
+			'edges' => [['id' => 'e1', 'from' => 'start', 'to' => 'done']],
+		];
+
+		$preview = $this->semver->preview(
+			publishedGraph: $published,
+			candidateGraph: $candidate,
+			previousSemver: '1.4.0'
+		);
+
+		$this->assertSame(FlowGraphDiff::MAJOR, $preview['verdict']);
+		$this->assertSame('2.0.0', $preview['next'], 'the preview says the number, not just the component');
+		$this->assertFalse($preview['first']);
+
+		// BOTH, named. The step and the connection are separate losses to a
+		// consumer, and reporting only the step would hide a rewiring that
+		// removed a path while keeping every node.
+		$this->assertContains('middle', $preview['removedNodes']);
+		$this->assertStringContainsString('middle', $preview['removed']);
+		$this->assertNotSame([], $preview['removedEdges'], 'the removed connection must be named too');
+		$this->assertStringContainsString('start', implode(' ', $preview['removedEdges']));
+	}//end testThePreviewNamesTheRemovedStepAndTheRemovedEdge()
+
+	/**
+	 * An addition-only preview is minor and claims no removal.
+	 *
+	 * @return void
+	 */
+	public function testAnAdditionOnlyPreviewIsMinorAndNamesNothing(): void {
+		$published = [
+			'nodes' => [['id' => 'start', 'type' => 'openregister.trigger-manual', 'config' => []]],
+			'edges' => [],
+		];
+
+		$candidate = [
+			'nodes' => [
+				['id' => 'start', 'type' => 'openregister.trigger-manual', 'config' => []],
+				['id' => 'extra', 'type' => 'openregister.end', 'config' => []],
+			],
+			'edges' => [['id' => 'e1', 'from' => 'start', 'to' => 'extra']],
+		];
+
+		$preview = $this->semver->preview(
+			publishedGraph: $published,
+			candidateGraph: $candidate,
+			previousSemver: '2.1.0'
+		);
+
+		$this->assertSame(FlowGraphDiff::MINOR, $preview['verdict']);
+		$this->assertSame('2.2.0', $preview['next']);
+		$this->assertSame('', $preview['removed'], 'nothing was removed, so nothing is claimed');
+	}//end testAnAdditionOnlyPreviewIsMinorAndNamesNothing()
+
+	/**
+	 * With nothing published, the preview says so rather than inventing a diff.
+	 *
+	 * @return void
+	 */
+	public function testAPreviewWithNothingPublishedIsTheFirstVersion(): void {
+		$preview = $this->semver->preview(
+			publishedGraph: null,
+			candidateGraph: ['nodes' => [['id' => 'a', 'config' => []]], 'edges' => []],
+			previousSemver: null
+		);
+
+		$this->assertTrue($preview['first']);
+		$this->assertSame(FlowSemanticVersion::FIRST, $preview['next']);
+		$this->assertSame([], $preview['removedNodes'], 'a first publish removes nothing from nothing');
+	}//end testAPreviewWithNothingPublishedIsTheFirstVersion()
+
+	/**
+	 * The preview ASKS; it never refuses.
+	 *
+	 * An author has to be able to find out that a publish is major without
+	 * first asserting that it is not.
+	 *
+	 * @return void
+	 */
+	public function testThePreviewNeverRefuses(): void {
+		$published = [
+			'nodes' => [['id' => 'gone', 'config' => ['k' => 1]]],
+			'edges' => [],
+		];
+
+		$preview = $this->semver->preview(
+			publishedGraph: $published,
+			candidateGraph: ['nodes' => [], 'edges' => []],
+			previousSemver: '1.0.0'
+		);
+
+		$this->assertSame(FlowGraphDiff::MAJOR, $preview['verdict']);
+	}//end testThePreviewNeverRefuses()
+
+	/**
 	 * The back-fill's sequence is minor throughout, because it does not know.
 	 *
 	 * @return void

--- a/tests/Unit/Service/Flow/FlowVersionPreviewTest.php
+++ b/tests/Unit/Service/Flow/FlowVersionPreviewTest.php
@@ -1,0 +1,248 @@
+<?php
+
+/**
+ * Telling the author what a publish will be called, before they publish it.
+ *
+ * 🔑 THE PREFLIGHT AND THE PUBLISH READ THE SAME PAIR OF GRAPHS. A preview
+ * computed a second way is a second opinion, and the first time the two
+ * disagree the author learns to believe neither — which is worse than showing
+ * nothing, because they would have trusted it first.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md#requirement-the-author-is-told-what-it-will-be-before-publishing
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Flow;
+
+use OCA\OpenRegister\Db\Flow;
+use OCA\OpenRegister\Db\FlowMapper;
+use OCA\OpenRegister\Db\FlowVersion;
+use OCA\OpenRegister\Db\FlowVersionMapper;
+use OCA\OpenRegister\Service\Flow\FlowDefinitionPin;
+use OCA\OpenRegister\Service\Flow\FlowLifecycleGuard;
+use OCA\OpenRegister\Service\Flow\FlowSemanticVersion;
+use OCA\OpenRegister\Service\Flow\FlowTriggerIndex;
+use OCA\OpenRegister\Service\Flow\FlowVersionService;
+use OCP\IDBConnection;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Tests for {@see FlowVersionService::previewPublish()}.
+ *
+ * @covers \OCA\OpenRegister\Service\Flow\FlowVersionService
+ * @uses \OCA\OpenRegister\Service\Flow\FlowSemanticVersion
+ * @uses \OCA\OpenRegister\Service\Flow\FlowGraphDiff
+ * @uses \OCA\OpenRegister\Db\Flow
+ * @uses \OCA\OpenRegister\Db\FlowVersion
+ */
+final class FlowVersionPreviewTest extends TestCase {
+
+	/**
+	 * The graph that is live.
+	 *
+	 * @return array<string, mixed> The published graph.
+	 */
+	private function publishedGraph(): array {
+		return [
+			'nodes' => [
+				['id' => 'start', 'type' => 'openregister.trigger-manual', 'config' => []],
+				['id' => 'middle', 'type' => 'openregister.set-fields', 'config' => ['set' => []]],
+				['id' => 'done', 'type' => 'openregister.end', 'config' => []],
+			],
+			'edges' => [
+				['id' => 'e1', 'from' => 'start', 'to' => 'middle'],
+				['id' => 'e2', 'from' => 'middle', 'to' => 'done'],
+			],
+		];
+	}//end publishedGraph()
+
+	/**
+	 * A flow carrying a candidate graph as its head.
+	 *
+	 * @param array<string, mixed> $graph The head graph.
+	 *
+	 * @return Flow The flow.
+	 */
+	private function flowWithHead(array $graph): Flow {
+		$flow = new Flow();
+		$flow->setUuid('flow-1');
+		$flow->setNodes(($graph['nodes'] ?? []));
+		$flow->setEdges(($graph['edges'] ?? []));
+
+		return $flow;
+	}//end flowWithHead()
+
+	/**
+	 * The service, with the published version and its stored graph wired in.
+	 *
+	 * @param FlowVersion|null     $published The live version, or null for none.
+	 * @param array<string, mixed>|null $stored The graph that version pinned.
+	 * @param boolean              $pinThrows Whether reading the graph fails.
+	 *
+	 * @return FlowVersionService The service.
+	 */
+	private function service(?FlowVersion $published, ?array $stored, bool $pinThrows = false): FlowVersionService {
+		$versions = $this->createMock(FlowVersionMapper::class);
+		$versions->method('findPublished')->willReturn($published);
+
+		$pin = $this->createMock(FlowDefinitionPin::class);
+		if ($pinThrows === true) {
+			$pin->method('graphFor')->willThrowException(new RuntimeException('the definition row was pruned'));
+		} else {
+			$pin->method('graphFor')->willReturn($stored);
+		}
+
+		return new FlowVersionService(
+			$versions,
+			$this->createMock(FlowMapper::class),
+			$pin,
+			$this->createMock(FlowLifecycleGuard::class),
+			$this->createMock(FlowTriggerIndex::class),
+			new FlowSemanticVersion(),
+			$this->createMock(IDBConnection::class),
+			$this->createMock(LoggerInterface::class)
+		);
+	}//end service()
+
+	/**
+	 * A published version with a semantic version already on it.
+	 *
+	 * @param string $semver The version it carries.
+	 *
+	 * @return FlowVersion The row.
+	 */
+	private function publishedVersion(string $semver): FlowVersion {
+		$row = new FlowVersion();
+		$row->setFlowUuid('flow-1');
+		$row->setVersion(4);
+		$row->setStatus(FlowVersion::STATUS_PUBLISHED);
+		$row->setSemver($semver);
+		$row->setDefinitionHash('deadbeef');
+
+		return $row;
+	}//end publishedVersion()
+
+	/**
+	 * 🔴 THE PREFLIGHT NAMES THE REMOVED STEP AND THE REMOVED EDGE.
+	 *
+	 * The requirement's scenario. Reporting only the step would hide a
+	 * rewiring that removed a path while keeping every node — a change that
+	 * breaks a consumer without deleting anything they can see.
+	 *
+	 * @return void
+	 */
+	public function testAMajorPreviewNamesTheRemovedStepAndTheRemovedEdge(): void {
+		$candidate = [
+			'nodes' => [
+				['id' => 'start', 'type' => 'openregister.trigger-manual', 'config' => []],
+				['id' => 'done', 'type' => 'openregister.end', 'config' => []],
+			],
+			'edges' => [['id' => 'e1', 'from' => 'start', 'to' => 'done']],
+		];
+
+		$preview = $this->service($this->publishedVersion('1.4.0'), $this->publishedGraph())
+			->previewPublish(flow: $this->flowWithHead($candidate));
+
+		$this->assertSame('major', $preview['verdict']);
+		$this->assertSame('2.0.0', $preview['next']);
+		$this->assertSame('1.4.0', $preview['current'], 'the author is shown what it is now, not only what it becomes');
+		$this->assertContains('middle', $preview['removedNodes']);
+		$this->assertNotSame([], $preview['removedEdges'], 'the removed connection must be named too');
+		$this->assertStringContainsString('middle', $preview['removed']);
+	}//end testAMajorPreviewNamesTheRemovedStepAndTheRemovedEdge()
+
+	/**
+	 * An addition-only draft previews as minor and claims no removal.
+	 *
+	 * @return void
+	 */
+	public function testAnAdditionOnlyDraftPreviewsAsMinor(): void {
+		$candidate = $this->publishedGraph();
+		$candidate['nodes'][] = ['id' => 'extra', 'type' => 'openregister.filter', 'config' => []];
+		$candidate['edges'][] = ['id' => 'e3', 'from' => 'middle', 'to' => 'extra'];
+		$candidate['edges'][] = ['id' => 'e4', 'from' => 'extra', 'to' => 'done'];
+
+		$preview = $this->service($this->publishedVersion('1.4.0'), $this->publishedGraph())
+			->previewPublish(flow: $this->flowWithHead($candidate));
+
+		$this->assertSame('minor', $preview['verdict']);
+		$this->assertSame('1.5.0', $preview['next']);
+		$this->assertSame('', $preview['removed']);
+		$this->assertFalse($preview['first']);
+	}//end testAnAdditionOnlyDraftPreviewsAsMinor()
+
+	/**
+	 * With nothing published, the preflight says so rather than inventing a diff.
+	 *
+	 * @return void
+	 */
+	public function testAFlowWithNothingPublishedPreviewsAsTheFirstVersion(): void {
+		$preview = $this->service(null, null)
+			->previewPublish(flow: $this->flowWithHead($this->publishedGraph()));
+
+		$this->assertTrue($preview['first']);
+		$this->assertSame(FlowSemanticVersion::FIRST, $preview['next']);
+		$this->assertNull($preview['current']);
+		$this->assertSame([], $preview['removedNodes']);
+	}//end testAFlowWithNothingPublishedPreviewsAsTheFirstVersion()
+
+	/**
+	 * 🔴 AN UNREADABLE PREVIOUS GRAPH IS NOT A FAILURE.
+	 *
+	 * The definition row may have been pruned. A LABELLING feature that threw
+	 * here would block the author from finding out anything at all; treating it
+	 * as no previous version yields the first version rather than a confident
+	 * major nobody can check.
+	 *
+	 * @return void
+	 */
+	public function testAnUnreadablePreviousGraphPreviewsAsTheFirstVersion(): void {
+		$preview = $this->service($this->publishedVersion('1.4.0'), null, pinThrows: true)
+			->previewPublish(flow: $this->flowWithHead($this->publishedGraph()));
+
+		$this->assertTrue($preview['first']);
+		$this->assertSame(FlowSemanticVersion::FIRST, $preview['next']);
+	}//end testAnUnreadablePreviousGraphPreviewsAsTheFirstVersion()
+
+	/**
+	 * A pin that answers with something that is not a graph is treated as absent.
+	 *
+	 * @return void
+	 */
+	public function testAPinThatAnswersWithNothingIsTreatedAsNoPreviousGraph(): void {
+		$preview = $this->service($this->publishedVersion('2.0.0'), null)
+			->previewPublish(flow: $this->flowWithHead($this->publishedGraph()));
+
+		$this->assertTrue($preview['first']);
+	}//end testAPinThatAnswersWithNothingIsTreatedAsNoPreviousGraph()
+
+	/**
+	 * The preflight ASKS; it never refuses.
+	 *
+	 * An author has to be able to find out that a publish is major without
+	 * first asserting that it is not.
+	 *
+	 * @return void
+	 */
+	public function testThePreflightNeverRefuses(): void {
+		$preview = $this->service($this->publishedVersion('1.0.0'), $this->publishedGraph())
+			->previewPublish(flow: $this->flowWithHead(['nodes' => [], 'edges' => []]));
+
+		$this->assertSame('major', $preview['verdict']);
+	}//end testThePreflightNeverRefuses()
+}//end class

--- a/tests/e2e/api-direct/flow-semantic-versions.spec.ts
+++ b/tests/e2e/api-direct/flow-semantic-versions.spec.ts
@@ -1,0 +1,186 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Semantic versions, end to end over the live HTTP API.
+ *
+ * The unit tests prove the comparison and the arithmetic in isolation. What
+ * only a live instance can prove is that the two are WIRED: that publishing
+ * actually derives a version, stores it on both rows, and that the ordinal it
+ * sits beside is untouched.
+ *
+ * That last one is the point of the whole design. `version` is what a RUN
+ * PINS, for its whole life including a suspension of weeks, and a derivation
+ * that quietly moved it would not mislabel a version — it would repoint a run.
+ *
+ * @spec openspec/changes/flow-semantic-versions/specs/flow-semantic-versions/spec.md
+ */
+import type { APIRequestContext } from '@playwright/test'
+
+import { expect, test } from '@playwright/test'
+
+const API = '/index.php/apps/openregister/api'
+const JSON_HEADERS = { 'Content-Type': 'application/json', 'OCS-APIRequest': 'true' }
+
+/** A three-step flow: a way in, a step, and a way out. */
+const GRAPH = {
+	nodes: [
+		{ id: 'start', type: 'openregister.trigger-manual', position: { x: 80, y: 200 }, config: {} },
+		{ id: 'middle', type: 'openregister.set-fields', position: { x: 360, y: 200 }, config: { set: { a: 1 }, note: 'keep' } },
+		{ id: 'done', type: 'openregister.end', position: { x: 640, y: 200 }, config: {} },
+	],
+	edges: [
+		{ id: 'e1', from: 'start', to: 'middle' },
+		{ id: 'e2', from: 'middle', to: 'done' },
+	],
+}
+
+/**
+ * Create a flow and publish it, so there is a previous version to diff against.
+ */
+async function publishedFlow(request: APIRequestContext, name: string) {
+	const created = await request.post(`${API}/flows`, {
+		headers: JSON_HEADERS,
+		data: { name, description: 'semver e2e', trigger: 'manual', ...GRAPH },
+	})
+	expect(created.status(), await created.text()).toBe(201)
+	const flow = await created.json()
+
+	const first = await request.post(`${API}/flows/${flow.uuid}/publish`, { headers: JSON_HEADERS })
+	expect(first.status(), await first.text()).toBe(200)
+
+	return { uuid: flow.uuid as string, first: await first.json() }
+}
+
+/** Open a draft and replace its graph, then publish with an optional bump. */
+async function reviseAndPublish(
+	request: APIRequestContext,
+	uuid: string,
+	graph: object,
+	bump: string | null = null,
+) {
+	// 201, not 200: opening a draft CREATES a version row. Asserting 200 here
+	// cost five red tests that had nothing to do with the versions they were
+	// checking.
+	const draft = await request.post(`${API}/flows/${uuid}/draft`, { headers: JSON_HEADERS })
+	expect(draft.status(), await draft.text()).toBe(201)
+
+	const saved = await request.put(`${API}/flows/${uuid}`, { headers: JSON_HEADERS, data: graph })
+	expect(saved.status(), await saved.text()).toBe(200)
+
+	return request.post(`${API}/flows/${uuid}/publish`, {
+		headers: JSON_HEADERS,
+		data: (bump === null) ? {} : { bump },
+	})
+}
+
+test.describe('flow-semantic-versions: what a publish is called', () => {
+	const created: string[] = []
+
+	test.afterAll(async ({ request }) => {
+		for (const uuid of created) {
+			await request.delete(`${API}/flows/${uuid}`).catch(() => {})
+		}
+	})
+
+	// @e2e flow-semantic-versions::the-first-publish-is-one-zero-zero
+	test('the first publish is 1.0.0, and the ordinal is untouched', async ({ request }) => {
+		const { uuid, first } = await publishedFlow(request, `semver first ${Date.now()}`)
+		created.push(uuid)
+
+		expect(first.semver).toBe('1.0.0')
+		expect(first.semverSource).toBe('derived')
+		// THE POINT OF THE DESIGN: the ordinal is what a run pins, and it is
+		// still an integer that counts.
+		expect(first.version).toBe(1)
+	})
+
+	// @e2e flow-semantic-versions::adding-is-minor
+	test('adding a step is a MINOR bump', async ({ request }) => {
+		const { uuid } = await publishedFlow(request, `semver minor ${Date.now()}`)
+		created.push(uuid)
+
+		// ⚠️ THE ADDED STEP MUST STILL REACH AN END. A dangling node is refused
+		// by the dead-end guard before the version is ever derived, which is
+		// the guard working — but it made this test fail for a reason that had
+		// nothing to do with versions.
+		const grown = JSON.parse(JSON.stringify(GRAPH))
+		grown.nodes.push({ id: 'extra', type: 'openregister.filter', position: { x: 360, y: 360 }, config: { when: 'x' } })
+		grown.edges.push({ id: 'e3', from: 'middle', to: 'extra' })
+		grown.edges.push({ id: 'e4', from: 'extra', to: 'done' })
+
+		const response = await reviseAndPublish(request, uuid, grown)
+		expect(response.status(), await response.text()).toBe(200)
+
+		const published = await response.json()
+		expect(published.semver).toBe('1.1.0')
+		expect(published.version).toBe(2)
+	})
+
+	// @e2e flow-semantic-versions::removing-a-step-is-major
+	test('removing a step is a MAJOR bump', async ({ request }) => {
+		const { uuid } = await publishedFlow(request, `semver major ${Date.now()}`)
+		created.push(uuid)
+
+		// Drop `middle` and reconnect around it, so the flow still ends.
+		const shrunk = {
+			nodes: GRAPH.nodes.filter((n) => n.id !== 'middle'),
+			edges: [{ id: 'e1', from: 'start', to: 'done' }],
+		}
+
+		const response = await reviseAndPublish(request, uuid, shrunk)
+		expect(response.status(), await response.text()).toBe(200)
+
+		const published = await response.json()
+		expect(published.semver).toBe('2.0.0')
+	})
+
+	// @e2e flow-semantic-versions::a-removed-config-key-is-major
+	test('removing a config key from a surviving step is MAJOR', async ({ request }) => {
+		const { uuid } = await publishedFlow(request, `semver key ${Date.now()}`)
+		created.push(uuid)
+
+		const stripped = JSON.parse(JSON.stringify(GRAPH))
+		delete stripped.nodes[1].config.note
+
+		const response = await reviseAndPublish(request, uuid, stripped)
+		expect(response.status(), await response.text()).toBe(200)
+
+		expect((await response.json()).semver).toBe('2.0.0')
+	})
+
+	// @e2e flow-semantic-versions::an-author-may-raise
+	test('an author may RAISE a minor to a major', async ({ request }) => {
+		const { uuid } = await publishedFlow(request, `semver raise ${Date.now()}`)
+		created.push(uuid)
+
+		// Only a VALUE changes, which the diff cannot see as breaking.
+		const retitled = JSON.parse(JSON.stringify(GRAPH))
+		retitled.nodes[1].config.note = 'changed'
+
+		const response = await reviseAndPublish(request, uuid, retitled, 'major')
+		expect(response.status(), await response.text()).toBe(200)
+
+		expect((await response.json()).semver).toBe('2.0.0')
+	})
+
+	// @e2e flow-semantic-versions::an-author-may-not-lower
+	test('an author may NOT publish a removal as minor, and is told what went', async ({ request }) => {
+		const { uuid } = await publishedFlow(request, `semver lower ${Date.now()}`)
+		created.push(uuid)
+
+		const shrunk = {
+			nodes: GRAPH.nodes.filter((n) => n.id !== 'middle'),
+			edges: [{ id: 'e1', from: 'start', to: 'done' }],
+		}
+
+		const response = await reviseAndPublish(request, uuid, shrunk, 'minor')
+		expect(response.status()).toBe(409)
+
+		const body = await response.json()
+		expect(body.kind).toBe('version-bump-refused')
+		// The refusal NAMES what was removed. A bare "cannot be minor" is the
+		// version of this that teaches nobody anything.
+		expect(body.error).toContain('middle')
+	})
+})

--- a/tests/e2e/api-direct/flow-semantic-versions.spec.ts
+++ b/tests/e2e/api-direct/flow-semantic-versions.spec.ts
@@ -25,9 +25,24 @@ const JSON_HEADERS = { 'Content-Type': 'application/json', 'OCS-APIRequest': 'tr
 /** A three-step flow: a way in, a step, and a way out. */
 const GRAPH = {
 	nodes: [
-		{ id: 'start', type: 'openregister.trigger-manual', position: { x: 80, y: 200 }, config: {} },
-		{ id: 'middle', type: 'openregister.set-fields', position: { x: 360, y: 200 }, config: { set: { a: 1 }, note: 'keep' } },
-		{ id: 'done', type: 'openregister.end', position: { x: 640, y: 200 }, config: {} },
+		{
+			id: 'start',
+			type: 'openregister.trigger-manual',
+			position: { x: 80, y: 200 },
+			config: {},
+		},
+		{
+			id: 'middle',
+			type: 'openregister.set-fields',
+			position: { x: 360, y: 200 },
+			config: { set: { a: 1 }, note: 'keep' },
+		},
+		{
+			id: 'done',
+			type: 'openregister.end',
+			position: { x: 640, y: 200 },
+			config: {},
+		},
 	],
 	edges: [
 		{ id: 'e1', from: 'start', to: 'middle' },
@@ -46,7 +61,9 @@ async function publishedFlow(request: APIRequestContext, name: string) {
 	expect(created.status(), await created.text()).toBe(201)
 	const flow = await created.json()
 
-	const first = await request.post(`${API}/flows/${flow.uuid}/publish`, { headers: JSON_HEADERS })
+	const first = await request.post(`${API}/flows/${flow.uuid}/publish`, {
+		headers: JSON_HEADERS,
+	})
 	expect(first.status(), await first.text()).toBe(200)
 
 	return { uuid: flow.uuid as string, first: await first.json() }
@@ -62,15 +79,20 @@ async function reviseAndPublish(
 	// 201, not 200: opening a draft CREATES a version row. Asserting 200 here
 	// cost five red tests that had nothing to do with the versions they were
 	// checking.
-	const draft = await request.post(`${API}/flows/${uuid}/draft`, { headers: JSON_HEADERS })
+	const draft = await request.post(`${API}/flows/${uuid}/draft`, {
+		headers: JSON_HEADERS,
+	})
 	expect(draft.status(), await draft.text()).toBe(201)
 
-	const saved = await request.put(`${API}/flows/${uuid}`, { headers: JSON_HEADERS, data: graph })
+	const saved = await request.put(`${API}/flows/${uuid}`, {
+		headers: JSON_HEADERS,
+		data: graph,
+	})
 	expect(saved.status(), await saved.text()).toBe(200)
 
 	return request.post(`${API}/flows/${uuid}/publish`, {
 		headers: JSON_HEADERS,
-		data: (bump === null) ? {} : { bump },
+		data: bump === null ? {} : { bump },
 	})
 }
 
@@ -84,8 +106,13 @@ test.describe('flow-semantic-versions: what a publish is called', () => {
 	})
 
 	// @e2e flow-semantic-versions::the-first-publish-is-one-zero-zero
-	test('the first publish is 1.0.0, and the ordinal is untouched', async ({ request }) => {
-		const { uuid, first } = await publishedFlow(request, `semver first ${Date.now()}`)
+	test('the first publish is 1.0.0, and the ordinal is untouched', async ({
+		request,
+	}) => {
+		const { uuid, first } = await publishedFlow(
+			request,
+			`semver first ${Date.now()}`,
+		)
 		created.push(uuid)
 
 		expect(first.semver).toBe('1.0.0')
@@ -105,7 +132,12 @@ test.describe('flow-semantic-versions: what a publish is called', () => {
 		// the guard working — but it made this test fail for a reason that had
 		// nothing to do with versions.
 		const grown = JSON.parse(JSON.stringify(GRAPH))
-		grown.nodes.push({ id: 'extra', type: 'openregister.filter', position: { x: 360, y: 360 }, config: { when: 'x' } })
+		grown.nodes.push({
+			id: 'extra',
+			type: 'openregister.filter',
+			position: { x: 360, y: 360 },
+			config: { when: 'x' },
+		})
 		grown.edges.push({ id: 'e3', from: 'middle', to: 'extra' })
 		grown.edges.push({ id: 'e4', from: 'extra', to: 'done' })
 
@@ -136,7 +168,9 @@ test.describe('flow-semantic-versions: what a publish is called', () => {
 	})
 
 	// @e2e flow-semantic-versions::a-removed-config-key-is-major
-	test('removing a config key from a surviving step is MAJOR', async ({ request }) => {
+	test('removing a config key from a surviving step is MAJOR', async ({
+		request,
+	}) => {
 		const { uuid } = await publishedFlow(request, `semver key ${Date.now()}`)
 		created.push(uuid)
 
@@ -165,7 +199,9 @@ test.describe('flow-semantic-versions: what a publish is called', () => {
 	})
 
 	// @e2e flow-semantic-versions::an-author-may-not-lower
-	test('an author may NOT publish a removal as minor, and is told what went', async ({ request }) => {
+	test('an author may NOT publish a removal as minor, and is told what went', async ({
+		request,
+	}) => {
 		const { uuid } = await publishedFlow(request, `semver lower ${Date.now()}`)
 		created.push(uuid)
 


### PR DESCRIPTION
Second half of `flow-semantic-versions`: the columns, the migration, and the
arithmetic. The comparison itself landed in #3490.

## 🔴 The ordinal is untouched

`version` stays an integer, stays unique with `flow_uuid`, and stays what a
**run pins** for its whole life — including runs suspended for weeks on a human
task. Semver is an additional, author-facing fact in a nullable column.

Replacing the ordinal would migrate two unique indexes, every run row's pin and
28 call sites to buy a label — and would put the run pin at the mercy of a
derivation. A bug would then not mislabel a version; it would **repoint a run**.

A draft has `NULL` rather than `0.0.0`. It has not been compared with anything
yet, and a null meaning "not derived" is honest where a number is a claim.

`semver_source` records `derived` or `backfill` beside the value, because the
back-fill cannot know whether a historical publish was breaking — the graphs it
would compare are the ones it is being run to describe. A version that says
where it came from can be distrusted correctly; one that silently claims to be
derived cannot.

## The arithmetic is its own class

Apart from the diff, because they fail differently: the diff reads two graphs
and says what was taken away; this reads a verdict and says what to call the
next version. Together, a change to the numbering could break the comparison —
and the comparison is the half with evidence behind it.

**First publish is always 1.0.0**, whatever the diff said. Calling it `2.0.0`
because it "removed" everything from nothing would be arithmetic rather than
meaning.

**Patch is always 0.** Nothing in a graph distinguishes a fix from a feature,
and three digits look more precise than two.

**An author may raise and never lower.** They know which values a consumer
reads and the diff does not, so they can add a major it did not find. They
cannot publish a removal as minor: the diff is evidence, and the refusal names
what went.

## Verification

- 10 tests, **4 of which break** under mutation of the major branch and the
  refusal
- PHPCS, PHPStan, Psalm and PHPMD clean
- `<version>` bumped in the same commit so the migration actually runs, checked
  with `scripts/check-migration-version-bump.php` — gate-110's local half

## ⚠️ One thing phpcs caught

I inserted both properties **between their neighbour's docblock and the
property it described**, orphaning two docblocks. Moved below; the diff is now
pure addition with no removals. Worth noting because a scripted insert at a
property line, rather than at its docblock, will do this every time.

## Still to come

Wiring the derivation into `FlowVersionService::publish()`, the preflight that
tells the author before they commit, the back-fill repair, the UI pill, and
Playwright over the live API.
