### PR TITLE
fix(e2e): Publish is a menu item, so open the menu

### DIFF
--- a/tests/e2e/ci/flow-controls.spec.ts
+++ b/tests/e2e/ci/flow-controls.spec.ts
@@ -141,6 +141,66 @@ test.use(fs.existsSync(STORAGE_STATE) ? { storageState: STORAGE_STATE } : {})
  * @param locator The themed control to click.
  * @return {Promise<void>}
  */
+/**
+ * Open the sidebar's flow-actions menu, so its items can be clicked.
+ *
+ * WHY THIS TRIES SEVERAL TRIGGERS. The menu that holds Publish is an NcActions,
+ * and which one depends on how the sidebar is hosted: `<CnFlowSidebar />` with
+ * no `embedded` prop puts its items in NcAppSidebar's own menu, while the
+ * embedded variant brings its own `<NcActions aria-label="Flow actions">`. The
+ * two hosts label their trigger differently, and this test cannot see which
+ * rendered without opening one.
+ *
+ * So it tries each candidate and stops at the first that reveals the item. A
+ * failure then names every trigger it tried AND every button actually on the
+ * page, because the previous version of this assertion pointed at a library
+ * version and cost an afternoon.
+ *
+ * @param page The page under test.
+ * @param item The menu item that proves the right menu opened.
+ */
+async function openFlowActionsMenu(page: Page, item: Locator): Promise<void> {
+	if (await item.isVisible().catch(() => false)) {
+		return
+	}
+
+	const triggers = [
+		page.getByRole('button', { name: 'Flow actions' }),
+		page.getByRole('button', {
+			name: /^(Actions|Open actions menu|More actions)$/i,
+		}),
+		page.locator('.app-sidebar-header__menu button').first(),
+	]
+
+	for (const trigger of triggers) {
+		if ((await trigger.count()) === 0) {
+			continue
+		}
+
+		await trigger
+			.first()
+			.click()
+			.catch(() => {})
+		if (await item.isVisible().catch(() => false)) {
+			return
+		}
+	}
+
+	const named = await page.getByRole('button').evaluateAll((nodes) =>
+		nodes
+			.map((n) => (n.getAttribute('aria-label') || n.textContent || '').trim())
+			.filter(Boolean)
+			.slice(0, 30),
+	)
+
+	throw new Error(
+		'could not open the flow-actions menu, so Publish was never reachable. '
+			+ 'Tried: "Flow actions", a generic actions label, and the sidebar '
+			+ 'header menu. Buttons present: '
+			+ JSON.stringify(named),
+	)
+}
+
 async function clickThemed(locator: Locator): Promise<void> {
 	await expect(locator).toBeVisible()
 	await expect(locator).toBeEnabled()
@@ -537,13 +597,21 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 		// lifecycle specs already give: a button that posts and silently fails
 		// looks exactly like one that worked, and the badge only reads
 		// "Published" once the store has re-read the flow from the server.
+		// ⚠️ PUBLISH IS A MENU ITEM, NOT A BUTTON, and the old failure here said
+		// otherwise. It read "Needs @conduction/nextcloud-vue >= 2.24.0" while
+		// the app was on 2.39.0, which sends anyone reading it after a release
+		// that shipped long ago.
+		//
+		// CnFlowSidebar pushes Publish into `flowActions` and renders it as an
+		// NcActionButton inside an NcActions menu — the `#secondary-actions`
+		// slot here, because this app mounts <CnFlowSidebar /> with no
+		// `embedded` prop and NcAppSidebar wraps that slot in its own menu.
+		// CnFlowLifecycleControls says so outright: "WHAT IS DELIBERATELY NOT
+		// HERE — THE VERBS. Publish, Create draft version and Deprecate live in
+		// the header's action menu." So the item cannot be visible until the
+		// menu is opened, and asserting on it directly can only ever time out.
 		const publishButton = page.locator('[data-testid="flow-publish"]')
-		await expect(
-			publishButton,
-			'the editor offers no Publish control, so a flow built here can never '
-				+ 'be run: a draft backs no run, and publishing is the only thing '
-				+ 'that changes that. Needs @conduction/nextcloud-vue >= 2.24.0.',
-		).toBeVisible({ timeout: 10_000 })
+		await openFlowActionsMenu(page, publishButton)
 
 		await clickThemed(publishButton)
 


### PR DESCRIPTION
Closes #3495.

`flow-controls` has failed every development push since `b532c9f` (08:07Z today) and still fails on `853db46`. 1 failed, 74 passed, both attempts.

## The failure message pointed at the wrong thing

```
the editor offers no Publish control … Needs @conduction/nextcloud-vue >= 2.24.0.
Locator: locator('[data-testid="flow-publish"]')
```

`d13b0e5` had already put the app on **2.39.0**, so that condition was satisfied long ago. Anyone reading the message goes looking for a release that shipped weeks back.

## What is actually wrong

`flow-publish` exists in 2.39.0 and it is a **menu item**. `CnFlowSidebar` pushes Publish into `flowActions` and renders it as an `NcActionButton` inside an `NcActions` — the `#secondary-actions` slot here, since this app mounts `<CnFlowSidebar />` with no `embedded` prop and `NcAppSidebar` wraps that slot in its own menu.

`CnFlowLifecycleControls` states it outright:

> **WHAT IS DELIBERATELY NOT HERE — THE VERBS.** Publish, Create draft version and Deprecate live in the header's action menu.

So the item cannot be visible until the menu is opened, and asserting on it directly can only ever time out.

## Two things it is not

Both checked before writing the fix:

- **Not `isDraft`.** It is `(lifecycleStatus || 'draft') === 'draft'`, so a newly created flow defaults to draft and the action *is* pushed.
- **Not `disabled`.** That would render a disabled item, which is still visible. The item is absent, not disabled.

## Why the helper tries several triggers

That is a statement about what I could verify, not a hedge.

The two hosts label their trigger differently, and this workstation cannot run openregister's e2e — its instance carries thirty-odd apps and the shared global setup times out logging in at 30s, twice, before any test starts.

So rather than guess one selector and hope, the helper tries each candidate and stops at the first that reveals the item. If none does, it throws naming **every trigger it tried and every button actually on the page**. The previous assertion pointed at a library version and cost an afternoon; this one will say what is really there.

## How it was checked

eslint and prettier exit 0, and playwright lists the test. The proof is the development push run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
