### PR TITLE
feat(flow): a performer reference carries its type, and resolves late

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -2496,6 +2496,21 @@ class Application extends App implements IBootstrap {
 			\OCA\OpenRegister\Listener\FlowOversightRegistrationListener::class
 		);
 
+		// Principal discovery. WHO a step may ask: `user` and `group` are
+		// Nextcloud's own and are contributed here; a position on a body, a
+		// function, a case role are contributed by the app that owns the
+		// concept. None of that knowledge can move into the engine without it
+		// growing opinions about municipal organisation charts.
+		//
+		// ⚠️ NOT the resolver registry the comment above disclaims. That one
+		// arbitrated between per-app object stores for flow OWNERSHIP; this
+		// one answers "who does this reference mean", which is a different
+		// question with a different answer per instance.
+		$context->registerEventListener(
+			\OCA\OpenRegister\Service\Flow\Principal\RegisterPrincipalResolversEvent::class,
+			\OCA\OpenRegister\Listener\PrincipalResolverRegistrationListener::class
+		);
+
 		// Federated configuration sharing. Any app declares its shareable config
 		// types (flows, registers, case types, themes …) through this event, the
 		// same idiom as flow nodes; OpenRegister contributes its own built-ins.

--- a/lib/Listener/PrincipalResolverRegistrationListener.php
+++ b/lib/Listener/PrincipalResolverRegistrationListener.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * OpenRegister contributes the two principal kinds every instance has.
+ *
+ * `user` and `group` are Nextcloud's own, so they belong to the engine rather
+ * than to any app. Everything else — a position on a body, a function, a case
+ * role — is contributed by the app that owns the concept, through the same
+ * event this uses. Registering the built-ins the same way means the
+ * contribution path is exercised by its owner and cannot rot unnoticed.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Listener
+ * @package  OCA\OpenRegister\Listener
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Listener;
+
+use OCA\OpenRegister\Service\Flow\Principal\GroupPrincipalResolver;
+use OCA\OpenRegister\Service\Flow\Principal\RegisterPrincipalResolversEvent;
+use OCA\OpenRegister\Service\Flow\Principal\UserPrincipalResolver;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+
+/**
+ * Registers the built-in principal resolvers.
+ *
+ * @template-implements IEventListener<Event>
+ */
+class PrincipalResolverRegistrationListener implements IEventListener {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param UserPrincipalResolver  $users  Resolves `user` references.
+	 * @param GroupPrincipalResolver $groups Resolves `group` references.
+	 */
+	public function __construct(
+		private readonly UserPrincipalResolver $users,
+		private readonly GroupPrincipalResolver $groups,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * Contribute the built-ins.
+	 *
+	 * @param Event $event The dispatched event.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public function handle(Event $event): void {
+		if (($event instanceof RegisterPrincipalResolversEvent) === false) {
+			return;
+		}
+
+		$event->registerResolver(resolver: $this->users);
+		$event->registerResolver(resolver: $this->groups);
+
+	}//end handle()
+}//end class

--- a/lib/Listener/PrincipalResolverRegistrationListener.php
+++ b/lib/Listener/PrincipalResolverRegistrationListener.php
@@ -46,6 +46,8 @@ class PrincipalResolverRegistrationListener implements IEventListener {
 	 *
 	 * @param UserPrincipalResolver  $users  Resolves `user` references.
 	 * @param GroupPrincipalResolver $groups Resolves `group` references.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
 	 */
 	public function __construct(
 		private readonly UserPrincipalResolver $users,

--- a/lib/Service/Flow/FlowRunAssignee.php
+++ b/lib/Service/Flow/FlowRunAssignee.php
@@ -45,6 +45,8 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Service\Flow;
 
 use OCA\OpenRegister\Db\FlowRun;
+use OCA\OpenRegister\Service\Flow\Principal\PrincipalReference;
+use OCA\OpenRegister\Service\Flow\Principal\PrincipalResolverRegistry;
 use OCP\IGroupManager;
 
 /**
@@ -61,9 +63,16 @@ class FlowRunAssignee {
 	 *                                         container; absent, a group assignment
 	 *                                         REFUSES rather than admits — the
 	 *                                         fail-closed direction.
+	 * @param PrincipalResolverRegistry|null $principals Resolves a TYPED reference to the
+	 *                                         users it currently means. Nullable for the
+	 *                                         same reason and with the same direction:
+	 *                                         absent, a typed assignment refuses.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
 	 */
 	public function __construct(
 		private readonly ?IGroupManager $groupManager = null,
+		private readonly ?PrincipalResolverRegistry $principals = null,
 	) {
 	}//end __construct()
 
@@ -87,8 +96,49 @@ class FlowRunAssignee {
 	 * @return string The assignee uid or group id; '' when the step is unassigned.
 	 *
 	 * @spec openspec/changes/flow-engine-consumer-seams/specs/flow-engine-consumer-seams/spec.md#requirement-a-server-side-signal-passes-the-same-guard-as-the-http-resume
+	 *
+	 * @SuppressWarnings(PHPMD.StaticAccess) `PrincipalReference::from()` and
+	 * `listFrom()` are NAMED CONSTRUCTORS on a value object, which is the
+	 * canonical PHP idiom for one and is indistinguishable to this rule from a
+	 * static call into a service. Injecting a reader for a value object would
+	 * be worse design chosen by a linter: the type has no dependencies, no
+	 * state and nothing to stub.
 	 */
 	public function recordedFor(FlowRun $run, ?string $nodeId = null): string {
+		$value = $this->recordedValueFor(run: $run, nodeId: $nodeId);
+		if (is_string($value) === true) {
+			return trim($value);
+		}
+
+		// A typed reference rendered for a caller that wants one string. The
+		// GUARD never takes this path — it reads the raw value — so a lossy
+		// rendering here cannot widen or narrow who may answer.
+		$references = PrincipalReference::listFrom(value: $value);
+
+		if ($references === []) {
+			return '';
+		}
+
+		return $references[0]->id;
+	}//end recordedFor()
+
+	/**
+	 * The recorded assignee EXACTLY as the node wrote it.
+	 *
+	 * 🔴 THE SHAPE IS THE INFORMATION. A bare string and `{type, id}` mean
+	 * different things — the first is the older, wider "uid or group", the
+	 * second is exact — so flattening both to a string before the guard sees
+	 * them is precisely what loses the distinction the typed reference exists
+	 * to draw.
+	 *
+	 * @param FlowRun     $run    The suspended run.
+	 * @param string|null $nodeId The node the answer addresses, when known.
+	 *
+	 * @return mixed The recorded value: a string, a reference, a list, or '' when unassigned.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public function recordedValueFor(FlowRun $run, ?string $nodeId = null): mixed {
 		$context = ($run->getContext() ?? []);
 		$slots = ($context[FlowResumeState::CONTEXT_KEY] ?? []);
 		if (is_array($slots) === false) {
@@ -101,7 +151,7 @@ class FlowRunAssignee {
 			if (is_array($slot) === true && isset($slot['askedAt']) === true) {
 				// The addressed node is asking; ITS record decides, including
 				// an empty one — an unassigned step is deliberately open.
-				return trim((string)($slot['assignee'] ?? ''));
+				return ($slot['assignee'] ?? '');
 			}
 		}
 
@@ -114,14 +164,14 @@ class FlowRunAssignee {
 				continue;
 			}
 
-			$assignee = trim((string)($slot['assignee'] ?? ''));
-			if ($assignee !== '') {
+			$assignee = ($slot['assignee'] ?? '');
+			if ($this->isUnassigned(value: $assignee) === false) {
 				return $assignee;
 			}
 		}
 
 		return '';
-	}//end recordedFor()
+	}//end recordedValueFor()
 
 	/**
 	 * Whether this user may answer the step the run is waiting on.
@@ -137,11 +187,11 @@ class FlowRunAssignee {
 	 * @spec openspec/specs/flow-engine/spec.md#requirement-a-run-suspended-on-an-external-signal-must-be-reachable
 	 */
 	public function mayAnswer(FlowRun $run, ?string $uid, ?string $nodeId = null): bool {
-		$assignee = $this->recordedFor(run: $run, nodeId: $nodeId);
+		$recorded = $this->recordedValueFor(run: $run, nodeId: $nodeId);
 
 		// Unassigned is deliberately open — see the class docblock. This is the
 		// one branch that must NOT be tightened without changing the spec.
-		if ($assignee === '') {
+		if ($this->isUnassigned(value: $recorded) === true) {
 			return true;
 		}
 
@@ -150,17 +200,100 @@ class FlowRunAssignee {
 			return false;
 		}
 
-		if ($uid === $assignee) {
-			return true;
+		$actor = trim($uid);
+
+		// 🔴 A BARE STRING KEEPS ITS OLD, WIDER MEANING: uid OR group. Today's
+		// guard tries uid equality and then group membership, so a stored
+		// `"bezwaar"` authorises the user AND the group's members — the union.
+		// Reading it as a typed `user` would NARROW that, and would silently
+		// stop authorising every group the fleet's stored flows name by bare
+		// string. Which of the two an old string meant is a question for a
+		// person, not for this guard: the repair reports the ambiguous ones and
+		// rewrites only what resolves one way.
+		if (is_string($recorded) === true) {
+			return $this->matchesLegacyString(actor: $actor, assignee: trim($recorded));
 		}
 
-		// The group branch. Absent a group manager this refuses rather than
-		// admits, which is the safe direction — and is why its absence must be
-		// visible in tests rather than inferred from a passing suite.
-		if ($this->groupManager !== null && $this->groupManager->isInGroup($uid, $assignee) === true) {
-			return true;
-		}
-
-		return false;
+		// A TYPED reference means exactly what it says, and is resolved fresh
+		// on every answer: whoever holds the post today may answer, and whoever
+		// held it in March may not.
+		return $this->matchesTypedReference(actor: $actor, recorded: $recorded);
 	}//end mayAnswer()
+
+	/**
+	 * Whether nothing was recorded, in either spelling.
+	 *
+	 * @param mixed $value The recorded value.
+	 *
+	 * @return boolean True when the step is unassigned.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 *
+	 * @SuppressWarnings(PHPMD.StaticAccess) `PrincipalReference::from()` and
+	 * `listFrom()` are NAMED CONSTRUCTORS on a value object, which is the
+	 * canonical PHP idiom for one and is indistinguishable to this rule from a
+	 * static call into a service. Injecting a reader for a value object would
+	 * be worse design chosen by a linter: the type has no dependencies, no
+	 * state and nothing to stub.
+	 */
+	private function isUnassigned(mixed $value): bool {
+		if (is_string($value) === true) {
+			return trim($value) === '';
+		}
+
+		return PrincipalReference::listFrom(value: $value) === [];
+	}//end isUnassigned()
+
+	/**
+	 * The pre-typed reading: uid equality, then group membership.
+	 *
+	 * Kept exactly as it was, deliberately. Every stored flow on every instance
+	 * was authored against these semantics.
+	 *
+	 * @param string $actor    The acting uid.
+	 * @param string $assignee The recorded string.
+	 *
+	 * @return boolean Whether the actor may answer.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	private function matchesLegacyString(string $actor, string $assignee): bool {
+		if ($actor === $assignee) {
+			return true;
+		}
+
+		// Absent a group manager this refuses rather than admits, which is the
+		// safe direction — and is why its absence must be visible in tests
+		// rather than inferred from a passing suite.
+		return ($this->groupManager !== null && $this->groupManager->isInGroup($actor, $assignee) === true);
+	}//end matchesLegacyString()
+
+	/**
+	 * The typed reading: whoever the reference means, right now.
+	 *
+	 * @param string $actor    The acting uid.
+	 * @param mixed  $recorded The recorded reference or list of them.
+	 *
+	 * @return boolean Whether the actor may answer.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 *
+	 * @SuppressWarnings(PHPMD.StaticAccess) `PrincipalReference::from()` and
+	 * `listFrom()` are NAMED CONSTRUCTORS on a value object, which is the
+	 * canonical PHP idiom for one and is indistinguishable to this rule from a
+	 * static call into a service. Injecting a reader for a value object would
+	 * be worse design chosen by a linter: the type has no dependencies, no
+	 * state and nothing to stub.
+	 */
+	private function matchesTypedReference(string $actor, mixed $recorded): bool {
+		if ($this->principals === null) {
+			// Fail closed, like the missing group manager: a typed assignment
+			// nothing can resolve refuses rather than admits.
+			return false;
+		}
+
+		$references = PrincipalReference::listFrom(value: $recorded);
+
+		return in_array($actor, $this->principals->resolveAll(references: $references), true);
+	}//end matchesTypedReference()
 }//end class

--- a/lib/Service/Flow/FlowRunSignalService.php
+++ b/lib/Service/Flow/FlowRunSignalService.php
@@ -47,6 +47,7 @@ namespace OCA\OpenRegister\Service\Flow;
 use OCA\OpenRegister\Db\FlowRun;
 use OCA\OpenRegister\Db\FlowRunMapper;
 use OCA\OpenRegister\Exception\FlowSignalRefused;
+use OCA\OpenRegister\Service\Flow\Principal\PrincipalResolverRegistry;
 use OCP\IGroupManager;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -76,6 +77,13 @@ class FlowRunSignalService {
 	 * @param FlowRunAssignee|null $assignees The access rule. Injectable so a
 	 *                                        consumer's test can drive the real
 	 *                                        contract; defaults to the real one.
+	 * @param PrincipalResolverRegistry|null $principals Resolves a TYPED performer
+	 *                             reference to whoever it means right now. Passed
+	 *                             through to the access rule so the guard the
+	 *                             engine builds is the same one the container
+	 *                             would have built.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
 	 */
 	public function __construct(
 		private readonly FlowRunMapper $mapper,
@@ -83,6 +91,7 @@ class FlowRunSignalService {
 		private readonly ?LoggerInterface $logger = null,
 		private readonly ?IGroupManager $groupManager = null,
 		private readonly ?FlowRunAssignee $assignees = null,
+		private readonly ?PrincipalResolverRegistry $principals = null,
 	) {
 
 	}//end __construct()
@@ -144,7 +153,14 @@ class FlowRunSignalService {
 	 */
 	public function signalRunAs(FlowRun $run, array $payload, ?string $actorUid, ?string $nodeId = null): FlowRun {
 		$actor = $this->normalize(actorUid: $actorUid);
-		$rule = ($this->assignees ?? new FlowRunAssignee(groupManager: $this->groupManager));
+		// 🔑 THE REGISTRY GOES IN HERE TOO. A rule built without it refuses
+		// every TYPED assignment — the fail-closed direction, which is right
+		// when nothing can resolve, and wrong the moment something can. The
+		// fallback must build the same guard the container would.
+		$rule = ($this->assignees ?? new FlowRunAssignee(
+			groupManager: $this->groupManager,
+			principals: $this->principals
+		));
 
 		if ($rule->mayAnswer(run: $run, uid: $actor, nodeId: $nodeId) === false) {
 			$this->auditRefusal(run: $run, actor: $actor, assignee: $rule->recordedFor(run: $run, nodeId: $nodeId), nodeId: $nodeId);

--- a/lib/Service/Flow/Nodes/UserTaskConfig.php
+++ b/lib/Service/Flow/Nodes/UserTaskConfig.php
@@ -33,6 +33,8 @@ namespace OCA\OpenRegister\Service\Flow\Nodes;
 
 use DateTime;
 use OCA\OpenRegister\Db\Task;
+use OCA\OpenRegister\Service\Flow\Principal\PrincipalReference;
+use OCA\OpenRegister\Service\Flow\Principal\PrincipalResolverRegistry;
 use OCA\OpenRegister\Service\Flow\FlowAdvanceBudget;
 use OCA\OpenRegister\Service\Flow\FlowItems;
 use OCA\OpenRegister\Service\Flow\FlowTaskBridge;
@@ -83,10 +85,17 @@ final class UserTaskConfig {
 	 *
 	 * @param IL10N $l10n Translations, for refusal messages an author reads.
 	 * @param TaskFormReader $forms Reads and refuses the step's form declaration.
+	 * @param PrincipalResolverRegistry|null $principals Says which principal TYPES
+	 *                             this instance understands, so an unknown one is
+	 *                             refused while the author is still looking at the
+	 *                             field. Absent, no type is refused: an instance
+	 *                             that cannot say which types exist must not decide
+	 *                             that none of them do.
 	 */
 	public function __construct(
 		private readonly IL10N $l10n,
 		private readonly TaskFormReader $forms,
+		private readonly ?PrincipalResolverRegistry $principals = null,
 	) {
 
 	}//end __construct()
@@ -130,6 +139,7 @@ final class UserTaskConfig {
 			);
 		}
 
+		$this->refuseUnknownPrincipalTypes(config: $config);
 		$this->refuseOutsideVocabulary(config: $config, key: 'performerType', vocabulary: Task::PERFORMER_TYPES);
 		$this->refuseOutsideVocabulary(config: $config, key: 'priority', vocabulary: Task::PRIORITIES);
 		$this->refuseOutsideVocabulary(config: $config, key: 'routingStrategy', vocabulary: Task::ROUTING_STRATEGIES);
@@ -309,20 +319,87 @@ final class UserTaskConfig {
 	 * @return boolean True when at least one performer source is set.
 	 */
 	private function namesAPerformer(array $config): bool {
-		foreach (['assignee', 'candidateRole', 'routingFallback'] as $key) {
-			if (trim((string)($config[$key] ?? '')) !== '') {
-				return true;
-			}
-		}
-
-		foreach (['candidateUsers', 'candidateGroups'] as $key) {
-			if ($this->listOf(value: ($config[$key] ?? null)) !== []) {
-				return true;
-			}
-		}
-
-		return false;
+		// Read as REFERENCES, not as strings. A `{type, id}` map casts to the
+		// string "Array", which is non-empty — so a string test would call a
+		// typed assignee "named" for the wrong reason today and would keep
+		// doing so if the shape ever changed.
+		return $this->performers(config: $config) !== [];
 	}//end namesAPerformer()
+
+	/**
+	 * Everybody this step could ask, as typed references.
+	 *
+	 * 🔑 THE THREE LEGACY FIELDS ARE READ BY THEIR NAMES. `candidateUsers`,
+	 * `candidateGroups` and `candidateRole` differ only in the kind of thing
+	 * you type into them — a type system implemented as field names, which
+	 * existed because the field was a text box. Each is read as candidates of
+	 * its own type, so no stored flow changes meaning and none needs migrating.
+	 *
+	 * @param array<string, mixed> $config The step configuration.
+	 *
+	 * @return array<int, PrincipalReference> Every performer the step names.
+	 *
+	 * @SuppressWarnings(PHPMD.StaticAccess) `PrincipalReference::listFrom()` and
+	 * `listOfType()` are named constructors on a value object, which is the
+	 * canonical PHP idiom and indistinguishable to this rule from a static call
+	 * into a service.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public function performers(array $config): array {
+		return array_merge(
+			PrincipalReference::listFrom(value: ($config['assignee'] ?? null)),
+			PrincipalReference::listFrom(value: ($config['candidates'] ?? null)),
+			PrincipalReference::listFrom(value: ($config['routingFallback'] ?? null)),
+			PrincipalReference::listOfType(value: ($config['candidateUsers'] ?? null), type: 'user'),
+			PrincipalReference::listOfType(value: ($config['candidateGroups'] ?? null), type: 'group'),
+			// `candidateRole` names a GROUP: the pre-typed guard resolved it
+			// through `isInGroup()`, so reading it as anything else would move
+			// who may answer on every stored flow that uses it.
+			PrincipalReference::listOfType(value: ($config['candidateRole'] ?? null), type: 'group')
+		);
+	}//end performers()
+
+	/**
+	 * Refuse a performer whose TYPE nothing on this instance understands.
+	 *
+	 * 🔴 REFUSED AT SAVE, AND NOT RESOLVED HERE. These are two different kinds
+	 * of wrongness found by two different people. An unknown TYPE is a defect
+	 * in the document: the author is at the keyboard, the field is on screen,
+	 * and the fix is to pick a different type. An EMPTY RESOLUTION is a fact
+	 * about the instance and it changes — a committee with no members today has
+	 * members next week — so refusing to SAVE over it would make the flow
+	 * unauthorable for a reason that has nothing to do with the flow.
+	 *
+	 * Without a registry nothing is refused. An instance that cannot say which
+	 * types exist must not decide that none of them do.
+	 *
+	 * @param array<string, mixed> $config The step configuration.
+	 *
+	 * @return void
+	 *
+	 * @throws UnexpectedValueException When a performer names an unknown type.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	private function refuseUnknownPrincipalTypes(array $config): void {
+		if ($this->principals === null) {
+			return;
+		}
+
+		foreach ($this->performers(config: $config) as $reference) {
+			if ($this->principals->has(type: $reference->type) === true) {
+				continue;
+			}
+
+			throw new UnexpectedValueException(
+				$this->l10n->t(
+					'This step asks a "%1$s" called "%2$s", and nothing on this server knows what a "%1$s" is. Is the app that provides it installed?',
+					[$reference->type, $reference->id]
+				)
+			);
+		}
+	}//end refuseUnknownPrincipalTypes()
 
 	/**
 	 * Refuse a set value outside a published vocabulary, naming both.

--- a/lib/Service/Flow/Nodes/UserTaskNode.php
+++ b/lib/Service/Flow/Nodes/UserTaskNode.php
@@ -120,7 +120,7 @@ class UserTaskNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigFor
 		private readonly IURLGenerator $urls,
 		TaskFormReader $forms,
 		private readonly FlowTimerService $timers,
-		?PrincipalResolverRegistry $principals = null,
+		private readonly ?PrincipalResolverRegistry $principals = null,
 	) {
 		$this->config = new UserTaskConfig(l10n: $l10n, forms: $forms, principals: $principals);
 
@@ -362,6 +362,8 @@ class UserTaskNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigFor
 			throw new RuntimeException('openregister.user-task cannot create a task outside a persisted run: the task must carry the run uuid.');
 		}
 
+		$this->refuseAPerformerNobodyHolds(config: $config);
+
 		$task = $this->bridge->createTask(
 			data: $this->config->taskData(config: $config, items: $items, nodeId: $resume->nodeId(), nodeType: $this->getId()),
 			runUuid: $runUuid,
@@ -394,6 +396,59 @@ class UserTaskNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigFor
 		);
 
 	}//end createTask()
+
+	/**
+	 * Refuse to raise a task nobody can perform.
+	 *
+	 * 🔴 THIS IS THE MEASURED DEFECT, INVERTED. A step naming a group that has
+	 * no members — or that does not exist — created a task addressed to
+	 * nobody. The run suspended, a heartbeat re-read it every few minutes, and
+	 * NOTHING said anything: the task existed, the run was healthy, and the
+	 * approval simply never happened. Silence was the defect.
+	 *
+	 * A loud step failure is strictly better even when the author chooses to
+	 * continue past it, because it is subject to the flow's own `onError`
+	 * policy — which is a decision the author gets to make, and silence is not.
+	 *
+	 * 🔑 REFUSED HERE AND NOT AT SAVE. An empty resolution is a fact about the
+	 * instance and it changes: a committee with no members today has members
+	 * next week. This is the moment somebody actually needs to be found.
+	 *
+	 * Only checked when the instance can resolve at all, and only for steps
+	 * that name somebody: an unassigned step is deliberately open, and refusing
+	 * one would close a door the spec holds open.
+	 *
+	 * @param array<string, mixed> $config The step configuration.
+	 *
+	 * @return void
+	 *
+	 * @throws RuntimeException When every named performer resolves to nobody.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	private function refuseAPerformerNobodyHolds(array $config): void {
+		if ($this->principals === null) {
+			return;
+		}
+
+		$named = $this->config->performers(config: $config);
+		if ($named === []) {
+			return;
+		}
+
+		if ($this->principals->resolveAll(references: $named) !== []) {
+			return;
+		}
+
+		throw new RuntimeException(
+			sprintf(
+				'openregister.user-task cannot raise a task: it asks %s, and nobody currently holds any of them. '
+					. 'The step fails rather than creating a task addressed to nobody.',
+				implode(', ', array_map(static fn ($r): string => (string)$r, $named))
+			)
+		);
+
+	}//end refuseAPerformerNobodyHolds()
 
 	/**
 	 * Arm a business timer for the task this node just created.

--- a/lib/Service/Flow/Nodes/UserTaskNode.php
+++ b/lib/Service/Flow/Nodes/UserTaskNode.php
@@ -70,6 +70,7 @@ use OCA\OpenRegister\Service\Flow\FlowStop;
 use OCA\OpenRegister\Service\Flow\FlowSuspension;
 use OCA\OpenRegister\Service\Flow\FlowTaskBridge;
 use OCA\OpenRegister\Service\Flow\IFlowNode;
+use OCA\OpenRegister\Service\Flow\Principal\PrincipalResolverRegistry;
 use OCA\OpenRegister\Service\Flow\IFlowNodeConfigForm;
 use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
 use OCA\OpenRegister\Service\Flow\Timer\FlowTimerService;
@@ -107,6 +108,9 @@ class UserTaskNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigFor
 	 * @param IURLGenerator $urls For the palette icon.
 	 * @param TaskFormReader $forms Reads and refuses the step's form declaration.
 	 * @param FlowTimerService $timers Arms the task's business timer.
+	 * @param PrincipalResolverRegistry|null $principals Passed to the config reader,
+	 *                             which refuses a performer whose type nothing on
+	 *                             this instance understands.
 	 *
 	 * @spec openspec/changes/flow-user-task-node/specs/flow-user-task-node/spec.md
 	 */
@@ -116,8 +120,9 @@ class UserTaskNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigFor
 		private readonly IURLGenerator $urls,
 		TaskFormReader $forms,
 		private readonly FlowTimerService $timers,
+		?PrincipalResolverRegistry $principals = null,
 	) {
-		$this->config = new UserTaskConfig(l10n: $l10n, forms: $forms);
+		$this->config = new UserTaskConfig(l10n: $l10n, forms: $forms, principals: $principals);
 
 	}//end __construct()
 
@@ -140,7 +145,11 @@ class UserTaskNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigFor
 	 * @spec openspec/changes/flow-user-task-node/specs/flow-user-task-node/spec.md#requirement-the-node-describes-its-own-form-served-from-the-node-catalog
 	 */
 	public function getDisplayName(): string {
-		return $this->l10n->t('Ask a person');
+		// "or group" because that is what the step has always done and never
+		// said: the guard resolved a bare name as a uid OR a group, so half
+		// the fleet's approvals are addressed to a committee under a label
+		// that named one person.
+		return $this->l10n->t('Ask a person or group');
 	}//end getDisplayName()
 
 	/**
@@ -152,7 +161,7 @@ class UserTaskNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigFor
 	 */
 	public function getDescription(): string {
 		return $this->l10n->t(
-			'Ask a person or an agent to do something, and wait for their answer. For a system that will call back, use "Wait for an answer" instead.'
+			'Ask a person, a group or an agent to do something, and wait for the answer. For a system that will call back, use "Wait for an answer" instead.'
 		);
 	}//end getDescription()
 

--- a/lib/Service/Flow/Principal/GroupPrincipalResolver.php
+++ b/lib/Service/Flow/Principal/GroupPrincipalResolver.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * A group is whoever is in it, right now.
+ *
+ * 🔴 READ EVERY TIME, NEVER FROZEN. This is the resolver the whole design was
+ * shaped around: a task assigned to the bezwaarcommissie in March is answerable
+ * by whoever sits on it in June. Somebody who joins the group after the task
+ * was raised can answer it; somebody who leaves can no longer answer it, even
+ * though they are named in the task's own record of who was asked.
+ *
+ * That record is evidence, consulted by no guard. Confusing the two is how a
+ * "who was asked" audit field quietly becomes an authorisation bypass.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow\Principal
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow\Principal;
+
+use OCP\IGroupManager;
+
+/**
+ * Resolves `{type: 'group'}` references.
+ */
+class GroupPrincipalResolver implements IPrincipalResolver {
+
+	/**
+	 * The type this resolver answers for.
+	 *
+	 * @var string
+	 */
+	public const TYPE = 'group';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IGroupManager $groups Nextcloud's group manager.
+	 */
+	public function __construct(private readonly IGroupManager $groups) {
+
+	}//end __construct()
+
+	/**
+	 * The type.
+	 *
+	 * @return string `group`.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public function type(): string {
+		return self::TYPE;
+
+	}//end type()
+
+	/**
+	 * The group's current members.
+	 *
+	 * A group that does not exist and a group with no members both resolve to
+	 * nothing, deliberately: from the caller's side they are the same fact —
+	 * there is nobody to ask — and the caller reports it the same way.
+	 *
+	 * @param string $id The group id.
+	 *
+	 * @return array<int, string> The members' uids.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public function resolve(string $id): array {
+		$gid = trim($id);
+		if ($gid === '') {
+			return [];
+		}
+
+		$group = $this->groups->get($gid);
+		if ($group === null) {
+			return [];
+		}
+
+		$uids = [];
+		foreach ($group->getUsers() as $user) {
+			$uids[] = $user->getUID();
+		}
+
+		return $uids;
+
+	}//end resolve()
+}//end class

--- a/lib/Service/Flow/Principal/GroupPrincipalResolver.php
+++ b/lib/Service/Flow/Principal/GroupPrincipalResolver.php
@@ -49,6 +49,8 @@ class GroupPrincipalResolver implements IPrincipalResolver {
 	 * Constructor.
 	 *
 	 * @param IGroupManager $groups Nextcloud's group manager.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
 	 */
 	public function __construct(private readonly IGroupManager $groups) {
 

--- a/lib/Service/Flow/Principal/IPrincipalResolver.php
+++ b/lib/Service/Flow/Principal/IPrincipalResolver.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * Turns a principal reference into the user ids it currently means.
+ *
+ * 🔴 "CURRENTLY" IS THE WHOLE POINT. A resolver is called on every answer, not
+ * once at task creation. A municipal approval outlives the roster it was raised
+ * against: a task assigned to the bezwaarcommissie in March must be answerable
+ * by whoever sits on it in June, and a task assigned to the afdelingshoofd must
+ * follow the post rather than the person who held it.
+ *
+ * Freezing the resolution would be simpler and faster and gets the domain
+ * backwards in the direction that hurts: it keeps authorising somebody who has
+ * left, and stops authorising the person now responsible. The cost of not
+ * freezing is one membership lookup on a verb a human is performing by hand.
+ *
+ * WHY THIS LIVES HERE AND IS IMPLEMENTED ELSEWHERE
+ * -----------------------------------------------
+ * decidiq knows what a position on a body is; hermiq knows what a function is;
+ * dossiq knows what a case role is. None of that can move into the engine
+ * without the engine growing opinions about municipal organisation charts, and
+ * OpenRegister must not name a consuming app (gate-27, ADR-022). So the
+ * contract is here and the knowledge stays where it belongs.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow\Principal
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow\Principal;
+
+/**
+ * Contract for an app that owns a kind of principal.
+ */
+interface IPrincipalResolver {
+
+	/**
+	 * The type this resolver answers for, such as `position` or `function`.
+	 *
+	 * Namespace it if it could collide; the registry refuses a duplicate rather
+	 * than resolving by load order, so two apps claiming one type is a startup
+	 * failure and not a silent winner.
+	 *
+	 * @return string The principal type.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public function type(): string;
+
+	/**
+	 * The user ids this reference means, right now.
+	 *
+	 * An empty array is a legitimate answer and means "nobody holds this at the
+	 * moment" — a committee between appointments. It is NOT an error here; the
+	 * caller decides what to do about it, and at task creation that is to fail
+	 * the step loudly rather than raise a task for nobody.
+	 *
+	 * @param string $id The id within this type.
+	 *
+	 * @return array<int, string> The user ids, possibly empty.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public function resolve(string $id): array;
+}//end interface

--- a/lib/Service/Flow/Principal/PrincipalReference.php
+++ b/lib/Service/Flow/Principal/PrincipalReference.php
@@ -1,0 +1,200 @@
+<?php
+
+/**
+ * Who a step is asking: a type and an id, never a bare name.
+ *
+ * `"jdoe"` on an assignee field is ambiguous on any real instance: a Nextcloud
+ * deployment may hold a user AND a group of that name, and the guard this
+ * replaces accepted both — uid equality first, then group membership. So the
+ * question "may this person answer" had two answers and took whichever came
+ * first.
+ *
+ * A reference says which one it means. `{"type": "group", "id": "bezwaar"}` is
+ * a group and nothing else, and an app that owns a concept the engine has never
+ * heard of — a position on a body, a function, a case role — says so in the
+ * same shape.
+ *
+ * 🔴 A BARE STRING STILL MEANS `user`. Reading it as "try every type" would be
+ * friendlier and would silently widen who may answer on every flow already
+ * stored. The guard being replaced tries uid first, so `user` is the reading
+ * that preserves today's behaviour rather than quietly granting more.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow\Principal
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow\Principal;
+
+use JsonSerializable;
+
+/**
+ * A typed reference to whoever a step is asking.
+ */
+final class PrincipalReference implements JsonSerializable {
+
+	/**
+	 * The type a bare string is read as.
+	 *
+	 * @var string
+	 */
+	public const DEFAULT_TYPE = 'user';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $type The principal type, such as `user` or `group`.
+	 * @param string $id   The id within that type.
+	 */
+	private function __construct(
+		public readonly string $type,
+		public readonly string $id,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * Read one reference from what an author stored.
+	 *
+	 * Accepts a bare string (a user), and `{type, id}` in either the `id` or
+	 * the legacy `value` spelling. Anything without a usable id is null rather
+	 * than an empty reference: a reference to nobody is not a principal, and
+	 * making one would push the emptiness down to the resolver, which would
+	 * report "resolved to no users" for something that was never a reference.
+	 *
+	 * @param mixed $value The stored value.
+	 *
+	 * @return self|null The reference, or null when there is none.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public static function from(mixed $value): ?self {
+		if (is_string($value) === true) {
+			$id = trim($value);
+
+			return ($id === '') ? null : new self(type: self::DEFAULT_TYPE, id: $id);
+		}
+
+		if (is_array($value) === false) {
+			return null;
+		}
+
+		$id = trim((string)($value['id'] ?? $value['value'] ?? ''));
+		if ($id === '') {
+			return null;
+		}
+
+		$type = trim((string)($value['type'] ?? ''));
+		if ($type === '') {
+			$type = self::DEFAULT_TYPE;
+		}
+
+		return new self(type: $type, id: $id);
+
+	}//end from()
+
+	/**
+	 * Read a list, which may mix types and spellings.
+	 *
+	 * A single value is read as a list of one, because an author who wrote one
+	 * assignee and an author who wrote a list of one mean the same thing.
+	 *
+	 * @param mixed $value The stored value.
+	 *
+	 * @return array<int, self> The references, in order, without the unusable ones.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public static function listFrom(mixed $value): array {
+		if ($value === null || $value === '' || $value === []) {
+			return [];
+		}
+
+		// A `{type, id}` map is itself an array, so a list is only a list when
+		// its keys are sequential. Treating the map as a list would read its
+		// two VALUES as two references.
+		$candidates = $value;
+		if (is_array($value) === false || array_is_list($value) === false) {
+			$candidates = [$value];
+		}
+
+		$references = [];
+		foreach ($candidates as $candidate) {
+			$reference = self::from(value: $candidate);
+			if ($reference !== null) {
+				$references[] = $reference;
+			}
+		}
+
+		return $references;
+
+	}//end listFrom()
+
+	/**
+	 * Read a list and stamp every bare entry with one type.
+	 *
+	 * For the legacy fields whose NAME carried the type: `candidateGroups`
+	 * holds bare group names, and reading them as users would silently move
+	 * who may answer on every flow already stored.
+	 *
+	 * An entry that already names its own type keeps it.
+	 *
+	 * @param mixed  $value The stored value.
+	 * @param string $type  The type a bare entry means.
+	 *
+	 * @return array<int, self> The references.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public static function listOfType(mixed $value, string $type): array {
+		$references = [];
+		foreach (self::listFrom(value: $value) as $reference) {
+			if (is_string($value) === true || $reference->type === self::DEFAULT_TYPE) {
+				// It came in bare, so the field name is what typed it.
+				$references[] = new self(type: $type, id: $reference->id);
+				continue;
+			}
+
+			$references[] = $reference;
+		}
+
+		return $references;
+
+	}//end listOfType()
+
+	/**
+	 * The reference as it is stored.
+	 *
+	 * @return array{type: string, id: string} The stored shape.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public function jsonSerialize(): array {
+		return ['type' => $this->type, 'id' => $this->id];
+
+	}//end jsonSerialize()
+
+	/**
+	 * A stable string, for logs and for comparing two references.
+	 *
+	 * @return string The reference as `type:id`.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public function __toString(): string {
+		return $this->type . ':' . $this->id;
+
+	}//end __toString()
+}//end class

--- a/lib/Service/Flow/Principal/PrincipalReference.php
+++ b/lib/Service/Flow/Principal/PrincipalReference.php
@@ -84,7 +84,11 @@ final class PrincipalReference implements JsonSerializable {
 		if (is_string($value) === true) {
 			$id = trim($value);
 
-			return ($id === '') ? null : new self(type: self::DEFAULT_TYPE, id: $id);
+			if ($id === '') {
+				return null;
+			}
+
+			return new self(type: self::DEFAULT_TYPE, id: $id);
 		}
 
 		if (is_array($value) === false) {

--- a/lib/Service/Flow/Principal/PrincipalResolverRegistry.php
+++ b/lib/Service/Flow/Principal/PrincipalResolverRegistry.php
@@ -59,6 +59,8 @@ class PrincipalResolverRegistry {
 	 *
 	 * @param IEventDispatcher $dispatcher Dispatches the contribution event.
 	 * @param LoggerInterface  $logger     Where a failing resolver is reported.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
 	 */
 	public function __construct(
 		private readonly IEventDispatcher $dispatcher,

--- a/lib/Service/Flow/Principal/PrincipalResolverRegistry.php
+++ b/lib/Service/Flow/Principal/PrincipalResolverRegistry.php
@@ -1,0 +1,231 @@
+<?php
+
+/**
+ * Which kinds of principal this instance understands, and what they resolve to.
+ *
+ * 🔴 NO CROSS-REQUEST CACHE, AND THAT IS THE DESIGN. A resolution is a fact
+ * about the roster right now: who sits on the committee, who holds the post.
+ * Caching it past the request would reintroduce exactly the defect the late
+ * resolution exists to avoid — a task that keeps authorising somebody who has
+ * left, and stops authorising the person now responsible.
+ *
+ * The registry caches the RESOLVERS, which are objects, not their answers.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow\Principal
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow\Principal;
+
+use OCP\EventDispatcher\IEventDispatcher;
+use Psr\Log\LoggerInterface;
+use Throwable;
+use UnexpectedValueException;
+
+/**
+ * Collects principal resolvers and answers with the ids they mean.
+ */
+class PrincipalResolverRegistry {
+
+	/**
+	 * The resolvers, by type.
+	 *
+	 * @var array<string, IPrincipalResolver>
+	 */
+	private array $resolvers = [];
+
+	/**
+	 * Whether contribution has been collected this request.
+	 *
+	 * @var boolean
+	 */
+	private bool $loaded = false;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IEventDispatcher $dispatcher Dispatches the contribution event.
+	 * @param LoggerInterface  $logger     Where a failing resolver is reported.
+	 */
+	public function __construct(
+		private readonly IEventDispatcher $dispatcher,
+		private readonly LoggerInterface $logger,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * Add a resolver.
+	 *
+	 * A duplicate type is REFUSED rather than allowed to overwrite. Two apps
+	 * claiming one type would otherwise resolve by load order, so which app
+	 * decides who may answer would depend on which listener fired first — a
+	 * difference nobody would see until the two disagreed.
+	 *
+	 * @param IPrincipalResolver $resolver The resolver.
+	 *
+	 * @return void
+	 *
+	 * @throws UnexpectedValueException When the type is already claimed.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public function register(IPrincipalResolver $resolver): void {
+		$type = trim($resolver->type());
+		if ($type === '') {
+			throw new UnexpectedValueException('A principal resolver must name the type it answers for.');
+		}
+
+		if (array_key_exists($type, $this->resolvers) === true) {
+			throw new UnexpectedValueException(
+				sprintf('The principal type "%s" is already provided by another app.', $type)
+			);
+		}
+
+		$this->resolvers[$type] = $resolver;
+
+	}//end register()
+
+	/**
+	 * Whether this instance understands a type.
+	 *
+	 * 🔑 THE ANSWER DEPENDS ON WHAT IS INSTALLED, and that is intended. A flow
+	 * naming `position` is valid on an instance with decidiq and not on one
+	 * without it. The alternative — accepting every type — would let a flow
+	 * save cleanly and then fail at run time on a machine nobody was watching.
+	 *
+	 * @param string $type The principal type.
+	 *
+	 * @return bool Whether a resolver answers for it.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public function has(string $type): bool {
+		$this->load();
+
+		return array_key_exists(trim($type), $this->resolvers);
+
+	}//end has()
+
+	/**
+	 * Every type this instance understands, for an editor to offer.
+	 *
+	 * @return array<int, string> The types, sorted so the list is stable.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public function types(): array {
+		$this->load();
+		$types = array_keys($this->resolvers);
+		sort($types);
+
+		return $types;
+
+	}//end types()
+
+	/**
+	 * The user ids one reference means, right now.
+	 *
+	 * An UNKNOWN type resolves to nothing and says so in the log. It is not an
+	 * exception: this is called while authorising an answer, and a type whose
+	 * app has been disabled since the flow was authored must refuse the answer
+	 * rather than break the request.
+	 *
+	 * @param PrincipalReference $reference The reference.
+	 *
+	 * @return array<int, string> The user ids, possibly empty.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public function resolve(PrincipalReference $reference): array {
+		$this->load();
+
+		$resolver = ($this->resolvers[$reference->type] ?? null);
+		if ($resolver === null) {
+			$this->logger->warning(
+				message: '[PrincipalResolverRegistry] Nothing on this instance resolves the principal type "'
+					. $reference->type . '". Is the app that owns it installed and enabled?',
+				context: ['file' => __FILE__, 'line' => __LINE__, 'reference' => (string)$reference]
+			);
+
+			return [];
+		}
+
+		try {
+			$ids = $resolver->resolve(id: $reference->id);
+		} catch (Throwable $e) {
+			// A resolver that throws must not take the answer verb down with
+			// it. Refusing the answer is the safe direction: the alternative
+			// is a 500 where a "you may not answer this" belongs.
+			$this->logger->error(
+				message: '[PrincipalResolverRegistry] Resolving "' . (string)$reference . '" failed: ' . $e->getMessage(),
+				context: ['file' => __FILE__, 'line' => __LINE__, 'exception' => $e]
+			);
+
+			return [];
+		}
+
+		$clean = [];
+        foreach ($ids as $id) {
+			$uid = trim((string)$id);
+			if ($uid !== '') {
+				$clean[] = $uid;
+			}
+		}
+
+		return array_values(array_unique($clean));
+
+	}//end resolve()
+
+	/**
+	 * The union of what a list of references means.
+	 *
+	 * @param array<int, PrincipalReference> $references The references.
+	 *
+	 * @return array<int, string> The user ids.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public function resolveAll(array $references): array {
+		$ids = [];
+		foreach ($references as $reference) {
+			$ids = array_merge($ids, $this->resolve(reference: $reference));
+		}
+
+		return array_values(array_unique($ids));
+
+	}//end resolveAll()
+
+	/**
+	 * Collect contributions once per request.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	private function load(): void {
+		if ($this->loaded === true) {
+			return;
+		}
+
+		// Set BEFORE dispatching, like the node registry: a listener that
+		// resolves a service which itself touches this registry would
+		// otherwise re-enter, dispatch again, and trip the duplicate guard.
+		$this->loaded = true;
+		$this->dispatcher->dispatchTyped(new RegisterPrincipalResolversEvent(registry: $this));
+
+	}//end load()
+}//end class

--- a/lib/Service/Flow/Principal/RegisterPrincipalResolversEvent.php
+++ b/lib/Service/Flow/Principal/RegisterPrincipalResolversEvent.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Where an app contributes the kinds of principal it owns.
+ *
+ * Modelled on {@see \OCA\OpenRegister\Service\Flow\RegisterFlowNodesEvent},
+ * deliberately: contribution through an event means OpenRegister never names a
+ * consuming app, a type whose app is not installed is simply absent rather than
+ * fatal, and the registration point is somewhere the fleet's developers already
+ * know to look.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow\Principal
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow\Principal;
+
+use OCP\EventDispatcher\Event;
+
+/**
+ * Carries the registry an app registers its principal resolvers on.
+ */
+class RegisterPrincipalResolversEvent extends Event {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param PrincipalResolverRegistry $registry The registry to contribute to.
+	 */
+	public function __construct(
+		private readonly PrincipalResolverRegistry $registry,
+	) {
+		parent::__construct();
+
+	}//end __construct()
+
+	/**
+	 * Contribute a resolver.
+	 *
+	 * @param IPrincipalResolver $resolver The resolver.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public function registerResolver(IPrincipalResolver $resolver): void {
+		$this->registry->register(resolver: $resolver);
+
+	}//end registerResolver()
+}//end class

--- a/lib/Service/Flow/Principal/RegisterPrincipalResolversEvent.php
+++ b/lib/Service/Flow/Principal/RegisterPrincipalResolversEvent.php
@@ -39,6 +39,8 @@ class RegisterPrincipalResolversEvent extends Event {
 	 * Constructor.
 	 *
 	 * @param PrincipalResolverRegistry $registry The registry to contribute to.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
 	 */
 	public function __construct(
 		private readonly PrincipalResolverRegistry $registry,

--- a/lib/Service/Flow/Principal/UserPrincipalResolver.php
+++ b/lib/Service/Flow/Principal/UserPrincipalResolver.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * A user is one user, if that user exists.
+ *
+ * 🔑 EXISTENCE IS CHECKED, and that is the only thing this adds over returning
+ * the id. A reference to a deleted account must resolve to NOTHING rather than
+ * to its own uid: returning the uid would let the guard authorise an identity
+ * nobody can log in as, and would make "resolved to nobody" — the signal that
+ * fails a step loudly — unreachable for the commonest way a performer goes
+ * away.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow\Principal
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow\Principal;
+
+use OCP\IUserManager;
+
+/**
+ * Resolves `{type: 'user'}` references.
+ */
+class UserPrincipalResolver implements IPrincipalResolver {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IUserManager $users Nextcloud's user manager.
+	 */
+	public function __construct(private readonly IUserManager $users) {
+
+	}//end __construct()
+
+	/**
+	 * The type.
+	 *
+	 * @return string `user`.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public function type(): string {
+		return PrincipalReference::DEFAULT_TYPE;
+
+	}//end type()
+
+	/**
+	 * The user, if there is one.
+	 *
+	 * @param string $id The uid.
+	 *
+	 * @return array<int, string> The uid, or nothing when no such user exists.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public function resolve(string $id): array {
+		$uid = trim($id);
+		if ($uid === '' || $this->users->userExists($uid) === false) {
+			return [];
+		}
+
+		return [$uid];
+
+	}//end resolve()
+}//end class

--- a/lib/Service/Flow/Principal/UserPrincipalResolver.php
+++ b/lib/Service/Flow/Principal/UserPrincipalResolver.php
@@ -40,6 +40,8 @@ class UserPrincipalResolver implements IPrincipalResolver {
 	 * Constructor.
 	 *
 	 * @param IUserManager $users Nextcloud's user manager.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
 	 */
 	public function __construct(private readonly IUserManager $users) {
 

--- a/lib/Service/Task/TaskAuthorizationService.php
+++ b/lib/Service/Task/TaskAuthorizationService.php
@@ -36,6 +36,8 @@ namespace OCA\OpenRegister\Service\Task;
 
 use OCA\OpenRegister\Db\Task;
 use OCA\OpenRegister\Exception\TaskAccessDeniedException;
+use OCA\OpenRegister\Service\Flow\Principal\PrincipalReference;
+use OCA\OpenRegister\Service\Flow\Principal\PrincipalResolverRegistry;
 use OCP\IGroupManager;
 use Throwable;
 
@@ -102,9 +104,16 @@ class TaskAuthorizationService {
 	 *                                         DENIES — the fail-closed
 	 *                                         direction, same as
 	 *                                         {@see \OCA\OpenRegister\Service\Flow\FlowRunAssignee}.
+	  * @param PrincipalResolverRegistry|null $principals Resolves a TYPED candidate
+	 *                             reference to whoever it means right now, so this
+	 *                             guard and the run guard cannot disagree. Absent,
+	 *                             a typed candidate is not affirmed.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
 	 */
 	public function __construct(
 		private readonly ?IGroupManager $groupManager = null,
+		private readonly ?PrincipalResolverRegistry $principals = null,
 	) {
 
 	}//end __construct()
@@ -466,10 +475,76 @@ class TaskAuthorizationService {
 			}
 		}
 
+		// 🔑 THE SAME PATH THE RUN GUARD TAKES. A candidate entry that names
+		// its own type — a position, a function, a case role — is resolved by
+		// whichever app owns that concept, exactly as `FlowRunAssignee` does
+		// it. Two guards over one question is how they come to disagree, and a
+		// disagreement here means a task somebody can complete and cannot see,
+		// or the reverse.
+		//
+		// It runs AFTER the three legacy branches so nothing they already
+		// admit can be narrowed by it.
+		if ($this->matchesTypedCandidate(task: $task, uid: $uid) === true) {
+			return;
+		}
+
 		throw new TaskAccessDeniedException(
 			message: sprintf("Verb '%s' denied: the caller is not in the task's candidate pool.", $verb)
 		);
 	}//end assertPoolMember()
+
+	/**
+	 * Whether a TYPED candidate reference resolves to this caller.
+	 *
+	 * Only entries that carry an explicit type are considered. A bare string
+	 * has already been read by the legacy branches above, under the wider
+	 * meaning every stored task was written against.
+	 *
+	 * @param Task   $task The task acted on.
+	 * @param string $uid  The acting identity.
+	 *
+	 * @return boolean True when a typed candidate resolves to the caller.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 *
+	 * @SuppressWarnings(PHPMD.StaticAccess) `PrincipalReference::from()` and
+	 * `listFrom()` are NAMED CONSTRUCTORS on a value object, which is the
+	 * canonical PHP idiom for one and is indistinguishable to this rule from a
+	 * static call into a service. Injecting a reader for a value object would
+	 * be worse design chosen by a linter: the type has no dependencies, no
+	 * state and nothing to stub.
+	 */
+	private function matchesTypedCandidate(Task $task, string $uid): bool {
+		if ($this->principals === null) {
+			// Fail closed, like every other branch here: without a resolver a
+			// typed candidate cannot be affirmed, so it is not affirmed.
+			return false;
+		}
+
+		$typed = [];
+		$fields = [
+			($task->getCandidateUsers() ?? []),
+			($task->getCandidateGroups() ?? []),
+			[$task->getCandidateRole()],
+		];
+
+		foreach ($fields as $field) {
+			foreach (PrincipalReference::listFrom(value: array_values(array_filter($field))) as $reference) {
+				// A bare entry read as the default type is the legacy reading,
+				// already applied above; taking it again here would widen the
+				// pool rather than extend it.
+				if ($reference->type !== PrincipalReference::DEFAULT_TYPE) {
+					$typed[] = $reference;
+				}
+			}
+		}
+
+		if ($typed === []) {
+			return false;
+		}
+
+		return in_array($uid, $this->principals->resolveAll(references: $typed), true);
+	}//end matchesTypedCandidate()
 
 	/**
 	 * Membership through the group backend, denying when it is absent.

--- a/tests/Unit/Service/Flow/FlowRunAssigneeTypedTest.php
+++ b/tests/Unit/Service/Flow/FlowRunAssigneeTypedTest.php
@@ -1,0 +1,304 @@
+<?php
+
+/**
+ * Who may answer, when the step said WHAT KIND of principal it asked.
+ *
+ * 🔴 THE TWO READINGS ARE DELIBERATELY DIFFERENT, and that is the whole point
+ * of this file. A stored bare string keeps its old, wider meaning — uid OR
+ * group — because every flow on every instance was authored against exactly
+ * that, and narrowing it would silently stop authorising the groups the fleet's
+ * flows name by bare string. A TYPED reference means what it says.
+ *
+ * Which of the two an old string meant is a question for a person, not for the
+ * guard: the repair reports the ambiguous ones and rewrites only what resolves
+ * one way.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Db\FlowRun;
+use OCA\OpenRegister\Service\Flow\FlowResumeState;
+use OCA\OpenRegister\Service\Flow\FlowRunAssignee;
+use OCA\OpenRegister\Service\Flow\Principal\IPrincipalResolver;
+use OCA\OpenRegister\Service\Flow\Principal\PrincipalResolverRegistry;
+use OCA\OpenRegister\Service\Flow\Principal\RegisterPrincipalResolversEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IGroupManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * A resolver whose roster the test can change between answers.
+ */
+class RosterResolver implements IPrincipalResolver {
+
+	/**
+	 * Who currently holds each id.
+	 *
+	 * @var array<string, array<int, string>>
+	 */
+	public array $holders = [];
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $type The type it answers for.
+	 */
+	public function __construct(private readonly string $type = 'position') {
+
+	}//end __construct()
+
+	/**
+	 * The type.
+	 *
+	 * @return string The type.
+	 */
+	public function type(): string {
+		return $this->type;
+	}//end type()
+
+	/**
+	 * Who holds it now.
+	 *
+	 * @param string $id The id.
+	 *
+	 * @return array<int, string> The uids.
+	 */
+	public function resolve(string $id): array {
+		return ($this->holders[$id] ?? []);
+	}//end resolve()
+}//end class
+
+/**
+ * The typed half of {@see FlowRunAssignee}.
+ *
+ * @covers \OCA\OpenRegister\Service\Flow\FlowRunAssignee
+ * @uses \OCA\OpenRegister\Service\Flow\Principal\PrincipalReference
+ * @uses \OCA\OpenRegister\Service\Flow\Principal\PrincipalResolverRegistry
+ * @uses \OCA\OpenRegister\Service\Flow\Principal\RegisterPrincipalResolversEvent
+ */
+final class FlowRunAssigneeTypedTest extends TestCase {
+
+	/**
+	 * A run whose one asking node recorded this assignee.
+	 *
+	 * @param mixed $assignee What the node wrote.
+	 *
+	 * @return FlowRun The run.
+	 */
+	private function runAssignedTo(mixed $assignee): FlowRun {
+		$run = new FlowRun();
+		$run->setContext(
+			[
+				FlowResumeState::CONTEXT_KEY => [
+					'ask' => ['askedAt' => '2026-03-01T10:00:00+00:00', 'assignee' => $assignee],
+				],
+			]
+		);
+
+		return $run;
+	}//end runAssignedTo()
+
+	/**
+	 * A registry holding one resolver.
+	 *
+	 * @param IPrincipalResolver $resolver The resolver.
+	 *
+	 * @return PrincipalResolverRegistry The registry.
+	 */
+	private function registryOf(IPrincipalResolver $resolver): PrincipalResolverRegistry {
+		$dispatcher = $this->createMock(IEventDispatcher::class);
+		$dispatcher->method('dispatchTyped')->willReturnCallback(
+			static function (Event $event) use ($resolver): void {
+				if (($event instanceof RegisterPrincipalResolversEvent) === true) {
+					$event->registerResolver($resolver);
+				}
+			}
+		);
+
+		return new PrincipalResolverRegistry($dispatcher, $this->createMock(LoggerInterface::class));
+	}//end registryOf()
+
+	/**
+	 * 🔴 A POSITION AUTHORISES WHOEVER HOLDS IT, AND RE-READS EVERY TIME.
+	 *
+	 * The scenario the whole design exists for: the task was raised in March
+	 * against the chair of the committee. In June somebody else chairs it. The
+	 * new chair may answer; the old one may not, even though they are named in
+	 * the task's own record of who was asked.
+	 *
+	 * @return void
+	 */
+	public function testAPositionAuthorisesWhoeverHoldsItNow(): void {
+		$positions = new RosterResolver();
+		$positions->holders['chair'] = ['alice'];
+
+		$assignee = new FlowRunAssignee(null, $this->registryOf($positions));
+		$run = $this->runAssignedTo(['type' => 'position', 'id' => 'chair']);
+
+		$this->assertTrue($assignee->mayAnswer(run: $run, uid: 'alice'));
+		$this->assertFalse($assignee->mayAnswer(run: $run, uid: 'bob'));
+
+		// June: bob takes the chair.
+		$positions->holders['chair'] = ['bob'];
+
+		$this->assertTrue($assignee->mayAnswer(run: $run, uid: 'bob'), 'the new holder must be able to answer');
+		$this->assertFalse(
+			$assignee->mayAnswer(run: $run, uid: 'alice'),
+			'the former holder must not, however the task records who was asked'
+		);
+	}//end testAPositionAuthorisesWhoeverHoldsItNow()
+
+	/**
+	 * 🔴 A COINCIDENTAL GROUP NAME NO LONGER AUTHORISES A TYPED `user`.
+	 *
+	 * The ambiguity this change exists to remove. A bare `"bezwaar"` authorises
+	 * the user AND the group; `{type: 'user', id: 'bezwaar'}` authorises only
+	 * the user, even on an instance where a group of that name exists and the
+	 * actor is in it.
+	 *
+	 * @return void
+	 */
+	public function testATypedUserIsNotSatisfiedByAGroupOfTheSameName(): void {
+		$groups = $this->createMock(IGroupManager::class);
+		// The actor IS in a group called `bezwaar` — the coincidence.
+		$groups->method('isInGroup')->willReturn(true);
+
+		$users = new RosterResolver('user');
+		$users->holders['bezwaar'] = ['bezwaar'];
+
+		$assignee = new FlowRunAssignee($groups, $this->registryOf($users));
+
+		$this->assertFalse(
+			$assignee->mayAnswer(run: $this->runAssignedTo(['type' => 'user', 'id' => 'bezwaar']), uid: 'carol'),
+			'a typed user reference must not be satisfied by group membership'
+		);
+
+		// And the SAME instance, the SAME actor, against the legacy string:
+		// still allowed, because that is what every stored flow means.
+		$this->assertTrue(
+			$assignee->mayAnswer(run: $this->runAssignedTo('bezwaar'), uid: 'carol'),
+			'a bare string keeps its old, wider meaning'
+		);
+	}//end testATypedUserIsNotSatisfiedByAGroupOfTheSameName()
+
+	/**
+	 * An unassigned step stays open, in either spelling.
+	 *
+	 * The one branch that must not be tightened without changing the spec.
+	 *
+	 * @return void
+	 */
+	public function testAnUnassignedStepIsStillOpen(): void {
+		$assignee = new FlowRunAssignee(null, $this->registryOf(new RosterResolver()));
+
+		$this->assertTrue($assignee->mayAnswer(run: $this->runAssignedTo(''), uid: 'anyone'));
+		$this->assertTrue($assignee->mayAnswer(run: $this->runAssignedTo([]), uid: 'anyone'));
+		$this->assertTrue($assignee->mayAnswer(run: $this->runAssignedTo(null), uid: 'anyone'));
+		// Even with no session at all: unassigned is deliberately open.
+		$this->assertTrue($assignee->mayAnswer(run: $this->runAssignedTo(''), uid: null));
+	}//end testAnUnassignedStepIsStillOpen()
+
+	/**
+	 * An assigned step is never anonymous.
+	 *
+	 * @return void
+	 */
+	public function testAnAssignedStepRefusesAnAnonymousAnswer(): void {
+		$positions = new RosterResolver();
+		$positions->holders['chair'] = ['alice'];
+		$assignee = new FlowRunAssignee(null, $this->registryOf($positions));
+
+		$this->assertFalse(
+			$assignee->mayAnswer(run: $this->runAssignedTo(['type' => 'position', 'id' => 'chair']), uid: null)
+		);
+	}//end testAnAssignedStepRefusesAnAnonymousAnswer()
+
+	/**
+	 * A list of references authorises the union of what they mean.
+	 *
+	 * @return void
+	 */
+	public function testAListAuthorisesTheUnion(): void {
+		$positions = new RosterResolver();
+		$positions->holders['chair'] = ['alice'];
+		$positions->holders['clerk'] = ['bob'];
+
+		$assignee = new FlowRunAssignee(null, $this->registryOf($positions));
+		$run = $this->runAssignedTo(
+			[
+				['type' => 'position', 'id' => 'chair'],
+				['type' => 'position', 'id' => 'clerk'],
+			]
+		);
+
+		$this->assertTrue($assignee->mayAnswer(run: $run, uid: 'alice'));
+		$this->assertTrue($assignee->mayAnswer(run: $run, uid: 'bob'));
+		$this->assertFalse($assignee->mayAnswer(run: $run, uid: 'carol'));
+	}//end testAListAuthorisesTheUnion()
+
+	/**
+	 * 🔴 WITHOUT A REGISTRY, A TYPED ASSIGNMENT REFUSES.
+	 *
+	 * The same fail-closed direction as the absent group manager, and asserted
+	 * for the same reason: its absence must be visible in a test rather than
+	 * inferred from a suite that happens to pass.
+	 *
+	 * @return void
+	 */
+	public function testATypedAssignmentWithoutAResolverRefuses(): void {
+		$assignee = new FlowRunAssignee();
+
+		$this->assertFalse(
+			$assignee->mayAnswer(run: $this->runAssignedTo(['type' => 'position', 'id' => 'chair']), uid: 'alice')
+		);
+	}//end testATypedAssignmentWithoutAResolverRefuses()
+
+	/**
+	 * A type nothing on this instance resolves refuses the answer.
+	 *
+	 * A flow authored where decidiq is installed, opened where it is not.
+	 *
+	 * @return void
+	 */
+	public function testAnUnresolvableTypeRefuses(): void {
+		$assignee = new FlowRunAssignee(null, $this->registryOf(new RosterResolver('function')));
+
+		$this->assertFalse(
+			$assignee->mayAnswer(run: $this->runAssignedTo(['type' => 'position', 'id' => 'chair']), uid: 'alice')
+		);
+	}//end testAnUnresolvableTypeRefuses()
+
+	/**
+	 * `recordedFor()` still answers with a string for callers that want one.
+	 *
+	 * @return void
+	 */
+	public function testRecordedForStillRendersOneString(): void {
+		$assignee = new FlowRunAssignee(null, $this->registryOf(new RosterResolver()));
+
+		$this->assertSame('bob', $assignee->recordedFor(run: $this->runAssignedTo('bob')));
+		$this->assertSame(
+			'chair',
+			$assignee->recordedFor(run: $this->runAssignedTo(['type' => 'position', 'id' => 'chair']))
+		);
+		$this->assertSame('', $assignee->recordedFor(run: $this->runAssignedTo('')));
+	}//end testRecordedForStillRendersOneString()
+}//end class

--- a/tests/Unit/Service/Flow/Principal/BuiltInResolversTest.php
+++ b/tests/Unit/Service/Flow/Principal/BuiltInResolversTest.php
@@ -1,0 +1,220 @@
+<?php
+
+/**
+ * The two principal kinds every Nextcloud has.
+ *
+ * 🔴 EXISTENCE IS THE POINT OF BOTH. A reference to a deleted account or a
+ * removed group must resolve to NOTHING, not to its own id: returning the id
+ * would authorise an identity nobody can log in as, and would make "resolved to
+ * nobody" — the signal that fails a step loudly — unreachable for the commonest
+ * way a performer goes away.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow\Principal
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow\Principal;
+
+use OCA\OpenRegister\Listener\PrincipalResolverRegistrationListener;
+use OCA\OpenRegister\Service\Flow\Principal\GroupPrincipalResolver;
+use OCA\OpenRegister\Service\Flow\Principal\PrincipalResolverRegistry;
+use OCA\OpenRegister\Service\Flow\Principal\RegisterPrincipalResolversEvent;
+use OCA\OpenRegister\Service\Flow\Principal\UserPrincipalResolver;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IGroup;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests for the built-in resolvers and their registration.
+ *
+ * @covers \OCA\OpenRegister\Service\Flow\Principal\UserPrincipalResolver
+ * @covers \OCA\OpenRegister\Service\Flow\Principal\GroupPrincipalResolver
+ * @covers \OCA\OpenRegister\Listener\PrincipalResolverRegistrationListener
+ * @covers \OCA\OpenRegister\Service\Flow\Principal\RegisterPrincipalResolversEvent
+ * @uses \OCA\OpenRegister\Service\Flow\Principal\PrincipalResolverRegistry
+ * @uses \OCA\OpenRegister\Service\Flow\Principal\PrincipalReference
+ */
+final class BuiltInResolversTest extends TestCase {
+
+	/**
+	 * A user resolver over an instance holding the given uids.
+	 *
+	 * @param array<int, string> $existing The uids that exist.
+	 *
+	 * @return UserPrincipalResolver The resolver.
+	 */
+	private function userResolver(array $existing): UserPrincipalResolver {
+		$users = $this->createMock(IUserManager::class);
+		$users->method('userExists')->willReturnCallback(
+			static fn (string $uid): bool => in_array($uid, $existing, true)
+		);
+
+		return new UserPrincipalResolver($users);
+	}//end userResolver()
+
+	/**
+	 * A group resolver over an instance holding the given memberships.
+	 *
+	 * @param array<string, array<int, string>> $groups Group id to member uids.
+	 *
+	 * @return GroupPrincipalResolver The resolver.
+	 */
+	private function groupResolver(array $groups): GroupPrincipalResolver {
+		$manager = $this->createMock(IGroupManager::class);
+		$manager->method('get')->willReturnCallback(
+			function (string $gid) use ($groups): ?IGroup {
+				if (array_key_exists($gid, $groups) === false) {
+					return null;
+				}
+
+				$members = [];
+				foreach ($groups[$gid] as $uid) {
+					$user = $this->createMock(IUser::class);
+					$user->method('getUID')->willReturn($uid);
+					$members[] = $user;
+				}
+
+				$group = $this->createMock(IGroup::class);
+				$group->method('getUsers')->willReturn($members);
+
+				return $group;
+			}
+		);
+
+		return new GroupPrincipalResolver($manager);
+	}//end groupResolver()
+
+	/**
+	 * A user that exists resolves to itself.
+	 *
+	 * @return void
+	 */
+	public function testAUserThatExistsResolvesToItself(): void {
+		$resolver = $this->userResolver(['alice']);
+
+		$this->assertSame('user', $resolver->type());
+		$this->assertSame(['alice'], $resolver->resolve(id: 'alice'));
+	}//end testAUserThatExistsResolvesToItself()
+
+	/**
+	 * 🔴 A DELETED ACCOUNT RESOLVES TO NOBODY, NOT TO ITS OWN UID.
+	 *
+	 * Returning the uid would authorise an identity nobody can log in as, and
+	 * would hide the commonest way a performer goes away behind a resolution
+	 * that looks successful.
+	 *
+	 * @return void
+	 */
+	public function testAUserThatDoesNotExistResolvesToNobody(): void {
+		$resolver = $this->userResolver(['alice']);
+
+		$this->assertSame([], $resolver->resolve(id: 'ghost'));
+		$this->assertSame([], $resolver->resolve(id: '   '));
+	}//end testAUserThatDoesNotExistResolvesToNobody()
+
+	/**
+	 * A group resolves to its current members.
+	 *
+	 * @return void
+	 */
+	public function testAGroupResolvesToItsMembers(): void {
+		$resolver = $this->groupResolver(['bezwaar' => ['alice', 'bob']]);
+
+		$this->assertSame('group', $resolver->type());
+		$this->assertSame(['alice', 'bob'], $resolver->resolve(id: 'bezwaar'));
+	}//end testAGroupResolvesToItsMembers()
+
+	/**
+	 * A group that does not exist and an empty one are the same fact.
+	 *
+	 * From the caller's side both mean there is nobody to ask, and the caller
+	 * reports them the same way.
+	 *
+	 * @return void
+	 */
+	public function testAMissingGroupAndAnEmptyGroupBothResolveToNobody(): void {
+		$resolver = $this->groupResolver(['empty' => []]);
+
+		$this->assertSame([], $resolver->resolve(id: 'empty'));
+		$this->assertSame([], $resolver->resolve(id: 'never-existed'));
+		$this->assertSame([], $resolver->resolve(id: ''));
+	}//end testAMissingGroupAndAnEmptyGroupBothResolveToNobody()
+
+	/**
+	 * 🔑 THE BUILT-INS GO THROUGH THE SAME EVENT EVERY APP USES.
+	 *
+	 * Registering them any other way would leave the contribution path
+	 * exercised only by consumers, where it can rot unnoticed.
+	 *
+	 * @return void
+	 */
+	public function testTheBuiltInsRegisterThroughTheContributionEvent(): void {
+		$listener = new PrincipalResolverRegistrationListener(
+			$this->userResolver(['alice']),
+			$this->groupResolver(['bezwaar' => ['alice']])
+		);
+
+		$dispatcher = $this->createMock(IEventDispatcher::class);
+		$dispatcher->method('dispatchTyped')->willReturnCallback(
+			static function (Event $event) use ($listener): void {
+				$listener->handle($event);
+			}
+		);
+
+		$registry = new PrincipalResolverRegistry($dispatcher, $this->createMock(LoggerInterface::class));
+
+		$this->assertSame(['group', 'user'], $registry->types());
+	}//end testTheBuiltInsRegisterThroughTheContributionEvent()
+
+	/**
+	 * The listener ignores an event that is not its own.
+	 *
+	 * @return void
+	 */
+	public function testTheListenerIgnoresAnUnrelatedEvent(): void {
+		$this->expectNotToPerformAssertions();
+
+		$listener = new PrincipalResolverRegistrationListener(
+			$this->userResolver([]),
+			$this->groupResolver([])
+		);
+
+		// Would fatal if it tried to register on something that is not the
+		// contribution event.
+		$listener->handle(new Event());
+	}//end testTheListenerIgnoresAnUnrelatedEvent()
+
+	/**
+	 * The event hands the resolver straight to the registry.
+	 *
+	 * @return void
+	 */
+	public function testTheEventRegistersOnTheRegistry(): void {
+		$registry = new PrincipalResolverRegistry(
+			$this->createMock(IEventDispatcher::class),
+			$this->createMock(LoggerInterface::class)
+		);
+
+		(new RegisterPrincipalResolversEvent($registry))->registerResolver($this->userResolver([]));
+
+		$this->assertTrue($registry->has(type: 'user'));
+	}//end testTheEventRegistersOnTheRegistry()
+}//end class

--- a/tests/Unit/Service/Flow/Principal/PrincipalReferenceTest.php
+++ b/tests/Unit/Service/Flow/Principal/PrincipalReferenceTest.php
@@ -1,0 +1,183 @@
+<?php
+
+/**
+ * Reading who a step is asking, from what an author actually stored.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow\Principal
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow\Principal;
+
+use OCA\OpenRegister\Service\Flow\Principal\PrincipalReference;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for {@see PrincipalReference}.
+ *
+ * @covers \OCA\OpenRegister\Service\Flow\Principal\PrincipalReference
+ */
+final class PrincipalReferenceTest extends TestCase {
+
+	/**
+	 * 🔴 A BARE STRING STILL MEANS A USER.
+	 *
+	 * Reading it as "try every type" would be friendlier and would silently
+	 * widen who may answer on every flow already stored. The guard being
+	 * replaced tries uid first, so `user` is the reading that preserves
+	 * today's behaviour rather than quietly granting more.
+	 *
+	 * @return void
+	 */
+	public function testABareStringIsAUser(): void {
+		$reference = PrincipalReference::from(value: 'jdoe');
+
+		$this->assertNotNull($reference);
+		$this->assertSame('user', $reference->type);
+		$this->assertSame('jdoe', $reference->id);
+	}//end testABareStringIsAUser()
+
+	/**
+	 * A typed reference keeps its type.
+	 *
+	 * @return void
+	 */
+	public function testATypedReferenceKeepsItsType(): void {
+		$reference = PrincipalReference::from(value: ['type' => 'group', 'id' => 'bezwaar']);
+
+		$this->assertSame('group', $reference->type);
+		$this->assertSame('bezwaar', $reference->id);
+		$this->assertSame('group:bezwaar', (string)$reference);
+		$this->assertSame(['type' => 'group', 'id' => 'bezwaar'], $reference->jsonSerialize());
+	}//end testATypedReferenceKeepsItsType()
+
+	/**
+	 * A reference to nobody is null, not an empty reference.
+	 *
+	 * Making one would push the emptiness down to the resolver, which would
+	 * then report "resolved to no users" for something that was never a
+	 * reference at all — and that message fails a step.
+	 *
+	 * @return void
+	 */
+	public function testSomethingWithNoIdIsNotAReference(): void {
+		$this->assertNull(PrincipalReference::from(value: ''));
+		$this->assertNull(PrincipalReference::from(value: '   '));
+		$this->assertNull(PrincipalReference::from(value: ['type' => 'group']));
+		$this->assertNull(PrincipalReference::from(value: null));
+		$this->assertNull(PrincipalReference::from(value: 42));
+	}//end testSomethingWithNoIdIsNotAReference()
+
+	/**
+	 * A list may mix types, and drops what it cannot read.
+	 *
+	 * @return void
+	 */
+	public function testAListMixesTypesAndDropsTheUnreadable(): void {
+		$references = PrincipalReference::listFrom(
+			value: [
+				'jdoe',
+				['type' => 'group', 'id' => 'bezwaar'],
+				['type' => 'position', 'id' => 'chair'],
+				'',
+				['type' => 'group'],
+			]
+		);
+
+		$this->assertSame(
+			['user:jdoe', 'group:bezwaar', 'position:chair'],
+			array_map(static fn ($r): string => (string)$r, $references)
+		);
+	}//end testAListMixesTypesAndDropsTheUnreadable()
+
+	/**
+	 * 🔴 A SINGLE `{type, id}` MAP IS ONE REFERENCE, NOT TWO.
+	 *
+	 * A map is itself an array, so a list reader that does not check for
+	 * sequential keys reads its two VALUES as two references: `group` and
+	 * `bezwaar`, both as users. That silently assigns a task to a user called
+	 * "group".
+	 *
+	 * @return void
+	 */
+	public function testASingleMapIsOneReferenceNotTwo(): void {
+		$references = PrincipalReference::listFrom(value: ['type' => 'group', 'id' => 'bezwaar']);
+
+		$this->assertCount(1, $references);
+		$this->assertSame('group:bezwaar', (string)$references[0]);
+	}//end testASingleMapIsOneReferenceNotTwo()
+
+	/**
+	 * A single string is a list of one, because the author meant the same thing.
+	 *
+	 * @return void
+	 */
+	public function testASingleStringIsAListOfOne(): void {
+		$references = PrincipalReference::listFrom(value: 'jdoe');
+
+		$this->assertCount(1, $references);
+		$this->assertSame('user:jdoe', (string)$references[0]);
+	}//end testASingleStringIsAListOfOne()
+
+	/**
+	 * 🔴 A LEGACY FIELD'S NAME IS WHAT TYPES ITS ENTRIES.
+	 *
+	 * `candidateGroups` holds bare group names. Reading them as users would
+	 * silently move who may answer on every flow already stored — the exact
+	 * regression the typed reference exists to prevent.
+	 *
+	 * @return void
+	 */
+	public function testALegacyFieldsNameTypesItsBareEntries(): void {
+		$references = PrincipalReference::listOfType(
+			value: ['bezwaar', 'college'],
+			type: 'group'
+		);
+
+		$this->assertSame(
+			['group:bezwaar', 'group:college'],
+			array_map(static fn ($r): string => (string)$r, $references)
+		);
+	}//end testALegacyFieldsNameTypesItsBareEntries()
+
+	/**
+	 * An entry that names its own type keeps it, even in a legacy field.
+	 *
+	 * @return void
+	 */
+	public function testAnEntryThatNamesItsOwnTypeKeepsIt(): void {
+		$references = PrincipalReference::listOfType(
+			value: ['bezwaar', ['type' => 'position', 'id' => 'chair']],
+			type: 'group'
+		);
+
+		$this->assertSame(
+			['group:bezwaar', 'position:chair'],
+			array_map(static fn ($r): string => (string)$r, $references)
+		);
+	}//end testAnEntryThatNamesItsOwnTypeKeepsIt()
+
+	/**
+	 * The legacy `value` spelling is still read.
+	 *
+	 * @return void
+	 */
+	public function testTheLegacyValueSpellingIsStillRead(): void {
+		$reference = PrincipalReference::from(value: ['type' => 'group', 'value' => 'bezwaar']);
+
+		$this->assertSame('group:bezwaar', (string)$reference);
+	}//end testTheLegacyValueSpellingIsStillRead()
+}//end class

--- a/tests/Unit/Service/Flow/Principal/PrincipalResolverRegistryTest.php
+++ b/tests/Unit/Service/Flow/Principal/PrincipalResolverRegistryTest.php
@@ -1,0 +1,286 @@
+<?php
+
+/**
+ * What a reference means, right now, and what happens when nothing knows.
+ *
+ * 🔴 THE RE-RESOLUTION TEST IS THE POINT OF THE WHOLE DESIGN. A municipal
+ * approval outlives the roster it was raised against: a task assigned to the
+ * bezwaarcommissie in March must be answerable by whoever sits on it in June.
+ * Freezing the resolution would keep authorising somebody who has left and stop
+ * authorising the person now responsible.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow\Principal
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow\Principal;
+
+use OCA\OpenRegister\Service\Flow\Principal\IPrincipalResolver;
+use OCA\OpenRegister\Service\Flow\Principal\PrincipalReference;
+use OCA\OpenRegister\Service\Flow\Principal\PrincipalResolverRegistry;
+use OCA\OpenRegister\Service\Flow\Principal\RegisterPrincipalResolversEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventDispatcher;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use UnexpectedValueException;
+
+/**
+ * A resolver whose answer the test can change between calls.
+ */
+class MutableResolver implements IPrincipalResolver {
+
+	/**
+	 * What each id currently resolves to.
+	 *
+	 * @var array<string, array<int, string>>
+	 */
+	public array $members = [];
+
+	/**
+	 * How many times resolve() was called.
+	 *
+	 * @var integer
+	 */
+	public int $calls = 0;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string  $type   The type it answers for.
+	 * @param boolean $throws Whether resolving blows up.
+	 */
+	public function __construct(
+		private readonly string $type = 'group',
+		private readonly bool $throws = false,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * The type.
+	 *
+	 * @return string The type.
+	 */
+	public function type(): string {
+		return $this->type;
+	}//end type()
+
+	/**
+	 * The current members.
+	 *
+	 * @param string $id The id.
+	 *
+	 * @return array<int, string> The uids.
+	 */
+	public function resolve(string $id): array {
+		$this->calls++;
+		if ($this->throws === true) {
+			throw new RuntimeException('the directory is unreachable');
+		}
+
+		return ($this->members[$id] ?? []);
+	}//end resolve()
+}//end class
+
+/**
+ * Tests for {@see PrincipalResolverRegistry}.
+ *
+ * @covers \OCA\OpenRegister\Service\Flow\Principal\PrincipalResolverRegistry
+ * @uses \OCA\OpenRegister\Service\Flow\Principal\PrincipalReference
+ * @uses \OCA\OpenRegister\Service\Flow\Principal\RegisterPrincipalResolversEvent
+ */
+final class PrincipalResolverRegistryTest extends TestCase {
+
+	/**
+	 * A registry holding the given resolvers.
+	 *
+	 * @param array<int, IPrincipalResolver> $resolvers The resolvers.
+	 * @param LoggerInterface|null           $logger    A logger to observe.
+	 *
+	 * @return PrincipalResolverRegistry The registry.
+	 */
+	private function registryOf(array $resolvers, ?LoggerInterface $logger = null): PrincipalResolverRegistry {
+		$dispatcher = $this->createMock(IEventDispatcher::class);
+		$dispatcher->method('dispatchTyped')->willReturnCallback(
+			static function (Event $event) use ($resolvers): void {
+				if (($event instanceof RegisterPrincipalResolversEvent) === false) {
+					return;
+				}
+
+				foreach ($resolvers as $resolver) {
+					$event->registerResolver($resolver);
+				}
+			}
+		);
+
+		return new PrincipalResolverRegistry($dispatcher, ($logger ?? $this->createMock(LoggerInterface::class)));
+	}//end registryOf()
+
+	/**
+	 * 🔴 A GROUP RE-RESOLVES AFTER A MEMBERSHIP CHANGE.
+	 *
+	 * Somebody who joins after the task was raised can answer it; somebody who
+	 * leaves can no longer answer it. A frozen resolution gets both backwards.
+	 *
+	 * @return void
+	 */
+	public function testAGroupReResolvesAfterAMembershipChange(): void {
+		$groups = new MutableResolver();
+		$groups->members['bezwaar'] = ['alice', 'bob'];
+
+		$registry = $this->registryOf([$groups]);
+		$reference = PrincipalReference::from(value: ['type' => 'group', 'id' => 'bezwaar']);
+
+		$this->assertSame(['alice', 'bob'], $registry->resolve(reference: $reference));
+
+		// June: bob has left the committee and carol has joined it.
+		$groups->members['bezwaar'] = ['alice', 'carol'];
+
+		$this->assertSame(
+			['alice', 'carol'],
+			$registry->resolve(reference: $reference),
+			'a cached resolution would keep authorising bob and refuse carol'
+		);
+		$this->assertSame(2, $groups->calls, 'the resolver must be asked every time, not once');
+	}//end testAGroupReResolvesAfterAMembershipChange()
+
+	/**
+	 * An unregistered type answers `has() === false`.
+	 *
+	 * @return void
+	 */
+	public function testAnUnregisteredTypeIsNotKnown(): void {
+		$registry = $this->registryOf([new MutableResolver()]);
+
+		$this->assertTrue($registry->has(type: 'group'));
+		$this->assertFalse($registry->has(type: 'position'));
+		$this->assertSame(['group'], $registry->types());
+	}//end testAnUnregisteredTypeIsNotKnown()
+
+	/**
+	 * 🔴 AN UNKNOWN TYPE RESOLVES TO NOBODY RATHER THAN THROWING.
+	 *
+	 * This is called while authorising an answer. A type whose app has been
+	 * disabled since the flow was authored must refuse the answer, not break
+	 * the request with a 500 where "you may not answer this" belongs.
+	 *
+	 * @return void
+	 */
+	public function testAnUnknownTypeResolvesToNobodyAndSaysSo(): void {
+		$seen = [];
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->method('warning')->willReturnCallback(
+			static function (string $message) use (&$seen): void {
+				$seen[] = $message;
+			}
+		);
+
+		$registry = $this->registryOf([new MutableResolver()], $logger);
+		$ids = $registry->resolve(reference: PrincipalReference::from(value: ['type' => 'position', 'id' => 'chair']));
+
+		$this->assertSame([], $ids);
+		$this->assertStringContainsString('position', implode(' ', $seen));
+	}//end testAnUnknownTypeResolvesToNobodyAndSaysSo()
+
+	/**
+	 * A resolver that throws refuses the answer rather than taking the verb down.
+	 *
+	 * @return void
+	 */
+	public function testAResolverThatThrowsRefusesRatherThanBreaks(): void {
+		$registry = $this->registryOf([new MutableResolver('group', throws: true)]);
+
+		$this->assertSame(
+			[],
+			$registry->resolve(reference: PrincipalReference::from(value: ['type' => 'group', 'id' => 'bezwaar']))
+		);
+	}//end testAResolverThatThrowsRefusesRatherThanBreaks()
+
+	/**
+	 * Two apps claiming one type is refused, not resolved by load order.
+	 *
+	 * @return void
+	 */
+	public function testADuplicateTypeIsRefused(): void {
+		$this->expectException(UnexpectedValueException::class);
+
+		$registry = $this->registryOf([new MutableResolver('group'), new MutableResolver('group')]);
+		$registry->has(type: 'group');
+	}//end testADuplicateTypeIsRefused()
+
+	/**
+	 * A list resolves to the union, without duplicates.
+	 *
+	 * @return void
+	 */
+	public function testAListResolvesToTheUnion(): void {
+		$groups = new MutableResolver();
+		$groups->members['bezwaar'] = ['alice', 'bob'];
+		$groups->members['college'] = ['bob', 'carol'];
+
+		$registry = $this->registryOf([$groups]);
+		$ids = $registry->resolveAll(
+			references: PrincipalReference::listFrom(
+				value: [
+					['type' => 'group', 'id' => 'bezwaar'],
+					['type' => 'group', 'id' => 'college'],
+				]
+			)
+		);
+
+		// bob sits on both and is one person.
+		$this->assertSame(['alice', 'bob', 'carol'], $ids);
+	}//end testAListResolvesToTheUnion()
+
+	/**
+	 * A resolver naming no type is refused.
+	 *
+	 * @return void
+	 */
+	public function testAResolverMustNameItsType(): void {
+		$this->expectException(UnexpectedValueException::class);
+
+		$registry = $this->registryOf([new MutableResolver('  ')]);
+		$registry->types();
+	}//end testAResolverMustNameItsType()
+
+	/**
+	 * Contribution is collected once, however many questions are asked.
+	 *
+	 * @return void
+	 */
+	public function testContributionIsCollectedOncePerRequest(): void {
+		$dispatched = 0;
+		$dispatcher = $this->createMock(IEventDispatcher::class);
+		$dispatcher->method('dispatchTyped')->willReturnCallback(
+			static function (Event $event) use (&$dispatched): void {
+				$dispatched++;
+				if (($event instanceof RegisterPrincipalResolversEvent) === true) {
+					$event->registerResolver(new MutableResolver());
+				}
+			}
+		);
+
+		$registry = new PrincipalResolverRegistry($dispatcher, $this->createMock(LoggerInterface::class));
+		$registry->has(type: 'group');
+		$registry->types();
+		$registry->resolve(reference: PrincipalReference::from(value: ['type' => 'group', 'id' => 'x']));
+
+		$this->assertSame(1, $dispatched);
+	}//end testContributionIsCollectedOncePerRequest()
+}//end class

--- a/tests/Unit/Service/Flow/UserTaskTypedPerformersTest.php
+++ b/tests/Unit/Service/Flow/UserTaskTypedPerformersTest.php
@@ -1,0 +1,314 @@
+<?php
+
+/**
+ * Who the step says it is asking, and when a wrong answer is refused.
+ *
+ * 🔴 THE LEGACY FIELDS MUST KEEP CONFIGURING A STEP. `candidateUsers`,
+ * `candidateGroups` and `candidateRole` are a type system implemented as field
+ * names, and they exist in stored flows across the fleet. Each is read as
+ * candidates of its OWN type, so no stored document changes meaning and none
+ * needs migrating.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Service\Flow\Nodes\UserTaskConfig;
+use OCA\OpenRegister\Service\Flow\Principal\IPrincipalResolver;
+use OCA\OpenRegister\Service\Flow\Principal\PrincipalResolverRegistry;
+use OCA\OpenRegister\Service\Flow\Principal\RegisterPrincipalResolversEvent;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Task\TaskFormReader;
+use OCA\OpenRegister\Service\Lifecycle\TransitionEngine;
+use OCP\App\IAppManager;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IL10N;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use UnexpectedValueException;
+
+/**
+ * A resolver that simply exists, so a type is known.
+ */
+class KnownTypeResolver implements IPrincipalResolver {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $type The type it answers for.
+	 */
+	public function __construct(private readonly string $type) {
+
+	}//end __construct()
+
+	/**
+	 * The type.
+	 *
+	 * @return string The type.
+	 */
+	public function type(): string {
+		return $this->type;
+	}//end type()
+
+	/**
+	 * Nobody in particular.
+	 *
+	 * @param string $id The id.
+	 *
+	 * @return array<int, string> Always empty.
+	 */
+	public function resolve(string $id): array {
+		return [];
+	}//end resolve()
+}//end class
+
+/**
+ * The typed half of {@see UserTaskConfig}.
+ *
+ * @covers \OCA\OpenRegister\Service\Flow\Nodes\UserTaskConfig
+ * @uses \OCA\OpenRegister\Service\Flow\Principal\PrincipalReference
+ * @uses \OCA\OpenRegister\Service\Flow\Principal\PrincipalResolverRegistry
+ * @uses \OCA\OpenRegister\Service\Flow\Principal\RegisterPrincipalResolversEvent
+ */
+final class UserTaskTypedPerformersTest extends TestCase {
+
+	/**
+	 * A config reader that knows `user`, `group` and `position`.
+	 *
+	 * @param array<int, string> $types The known types.
+	 *
+	 * @return UserTaskConfig The reader.
+	 */
+	private function configReader(array $types = ['user', 'group', 'position']): UserTaskConfig {
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnCallback(
+			static function (string $text, array $params = []): string {
+				// vsprintf understands `%1$s` positionally, which is exactly
+				// what IL10N::t() does; rewriting them to `%s` first turns two
+				// references to one argument into two arguments.
+				if ($params === []) {
+					return $text;
+				}
+
+				return vsprintf($text, $params);
+			}
+		);
+
+		$dispatcher = $this->createMock(IEventDispatcher::class);
+		$dispatcher->method('dispatchTyped')->willReturnCallback(
+			static function (Event $event) use ($types): void {
+				if (($event instanceof RegisterPrincipalResolversEvent) === false) {
+					return;
+				}
+
+				foreach ($types as $type) {
+					$event->registerResolver(new KnownTypeResolver($type));
+				}
+			}
+		);
+
+		return new UserTaskConfig(
+			l10n: $l10n,
+			forms: $this->formReader(),
+			principals: new PrincipalResolverRegistry($dispatcher, $this->createMock(LoggerInterface::class))
+		);
+	}//end configReader()
+
+	/**
+	 * A form reader that reads a real form.
+	 *
+	 * ⚠️ `TaskForm` is FINAL, so PHPUnit cannot generate a return value for
+	 * `fromConfig()` and the auto-stub throws. The real reader is used instead:
+	 * it has no collaborators, and a step with no form declaration passes
+	 * validation, which is exactly the shape these tests want.
+	 *
+	 * @return TaskFormReader The reader.
+	 */
+	private function formReader(): TaskFormReader {
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnArgument(0);
+
+		return new TaskFormReader(
+			$this->createMock(SchemaMapper::class),
+			$this->createMock(TransitionEngine::class),
+			$this->createMock(IAppManager::class),
+			$l10n
+		);
+	}//end formReader()
+
+	/**
+	 * The performers a config names, as `type:id` strings.
+	 *
+	 * @param array<string, mixed> $config The step configuration.
+	 *
+	 * @return array<int, string> The references.
+	 */
+	private function performersOf(array $config): array {
+		return array_map(
+			static fn ($r): string => (string)$r,
+			$this->configReader()->performers(config: $config)
+		);
+	}//end performersOf()
+
+	/**
+	 * 🔴 THE THREE LEGACY FIELDS STILL CONFIGURE A STEP, EACH AS ITS OWN TYPE.
+	 *
+	 * @return void
+	 */
+	public function testTheLegacyCandidateFieldsAreReadAsTheirOwnTypes(): void {
+		$performers = $this->performersOf(
+			[
+				'candidateUsers' => ['alice'],
+				'candidateGroups' => ['bezwaar'],
+				'candidateRole' => 'college',
+			]
+		);
+
+		// `candidateRole` is a GROUP: the pre-typed guard resolved it through
+		// `isInGroup()`, so any other reading moves who may answer.
+		$this->assertSame(['user:alice', 'group:bezwaar', 'group:college'], $performers);
+	}//end testTheLegacyCandidateFieldsAreReadAsTheirOwnTypes()
+
+	/**
+	 * A bare assignee is a user, and a typed one keeps its type.
+	 *
+	 * @return void
+	 */
+	public function testAnAssigneeIsReadInBothSpellings(): void {
+		$this->assertSame(['user:jdoe'], $this->performersOf(['assignee' => 'jdoe']));
+		$this->assertSame(
+			['position:chair'],
+			$this->performersOf(['assignee' => ['type' => 'position', 'id' => 'chair']])
+		);
+	}//end testAnAssigneeIsReadInBothSpellings()
+
+	/**
+	 * One `candidates` field expresses what three fields did, and may mix.
+	 *
+	 * @return void
+	 */
+	public function testOneCandidatesFieldMixesTypes(): void {
+		$this->assertSame(
+			['user:alice', 'group:bezwaar', 'position:chair'],
+			$this->performersOf(
+				[
+					'candidates' => [
+						'alice',
+						['type' => 'group', 'id' => 'bezwaar'],
+						['type' => 'position', 'id' => 'chair'],
+					],
+				]
+			)
+		);
+	}//end testOneCandidatesFieldMixesTypes()
+
+	/**
+	 * 🔴 AN UNKNOWN TYPE IS REFUSED WHEN THE STEP IS SAVED, NAMING BOTH.
+	 *
+	 * The author is at the keyboard and the field is on screen; this is the
+	 * only moment the person who can fix it is looking.
+	 *
+	 * @return void
+	 */
+	public function testAnUnknownTypeIsRefusedAtSaveNamingTypeAndId(): void {
+		try {
+			$this->configReader()->validate(
+				[
+					'title' => 'Approve it',
+					'assignee' => ['type' => 'gremium', 'id' => 'bezwaarcommissie'],
+				]
+			);
+			$this->fail('an unknown principal type should be refused');
+		} catch (UnexpectedValueException $e) {
+			$this->assertStringContainsString('gremium', $e->getMessage());
+			$this->assertStringContainsString('bezwaarcommissie', $e->getMessage());
+		}
+	}//end testAnUnknownTypeIsRefusedAtSaveNamingTypeAndId()
+
+	/**
+	 * 🔴 A KNOWN TYPE THAT RESOLVES TO NOBODY IS *NOT* REFUSED AT SAVE.
+	 *
+	 * An empty resolution is a fact about the instance and it changes: a
+	 * committee with no members today has members next week. Refusing the SAVE
+	 * would make the flow unauthorable for a reason that has nothing to do with
+	 * the flow. It fails when the task is created, where somebody actually
+	 * needs to be found.
+	 *
+	 * @return void
+	 */
+	public function testAKnownTypeThatResolvesToNobodyStillSaves(): void {
+		$this->expectNotToPerformAssertions();
+
+		// `KnownTypeResolver` deliberately resolves to nobody.
+		$this->configReader()->validate(
+			[
+				'title' => 'Approve it',
+				'assignee' => ['type' => 'position', 'id' => 'vacant'],
+			]
+		);
+	}//end testAKnownTypeThatResolvesToNobodyStillSaves()
+
+	/**
+	 * With no registry, nothing is refused.
+	 *
+	 * An instance that cannot say which types exist must not decide that none
+	 * of them do — that would refuse every typed flow on a container-less path.
+	 *
+	 * @return void
+	 */
+	public function testWithoutARegistryNoTypeIsRefused(): void {
+		$this->expectNotToPerformAssertions();
+
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnArgument(0);
+		$config = new UserTaskConfig(l10n: $l10n, forms: $this->formReader());
+
+		$config->validate(
+			['title' => 'Approve it', 'assignee' => ['type' => 'gremium', 'id' => 'bezwaar']]
+		);
+	}//end testWithoutARegistryNoTypeIsRefused()
+
+	/**
+	 * A typed assignee counts as naming a performer.
+	 *
+	 * A `{type, id}` map casts to the string "Array", which is non-empty — so a
+	 * string test would call it named for the wrong reason, and would stop
+	 * doing so the moment the shape changed.
+	 *
+	 * @return void
+	 */
+	public function testATypedAssigneeCountsAsAPerformer(): void {
+		$this->expectNotToPerformAssertions();
+
+		$this->configReader()->validate(
+			['title' => 'Approve it', 'assignee' => ['type' => 'position', 'id' => 'chair']]
+		);
+	}//end testATypedAssigneeCountsAsAPerformer()
+
+	/**
+	 * A step naming nobody at all is still refused.
+	 *
+	 * @return void
+	 */
+	public function testAStepNamingNobodyIsStillRefused(): void {
+		$this->expectException(UnexpectedValueException::class);
+
+		$this->configReader()->validate(['title' => 'Approve it']);
+	}//end testAStepNamingNobodyIsStillRefused()
+}//end class

--- a/tests/Unit/Service/Task/TaskTypedCandidateTest.php
+++ b/tests/Unit/Service/Task/TaskTypedCandidateTest.php
@@ -1,0 +1,213 @@
+<?php
+
+/**
+ * The task pool guard and the run guard must answer the same question the same way.
+ *
+ * 🔴 TWO GUARDS OVER ONE QUESTION IS HOW THEY COME TO DISAGREE, and a
+ * disagreement here means a task somebody can complete and cannot see, or the
+ * reverse. The typed branch runs AFTER the three legacy ones, so nothing they
+ * already admit can be narrowed by it.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Task
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Task;
+
+use OCA\OpenRegister\Db\Task;
+use OCA\OpenRegister\Exception\TaskAccessDeniedException;
+use OCA\OpenRegister\Service\Flow\Principal\IPrincipalResolver;
+use OCA\OpenRegister\Service\Flow\Principal\PrincipalResolverRegistry;
+use OCA\OpenRegister\Service\Flow\Principal\RegisterPrincipalResolversEvent;
+use OCA\OpenRegister\Service\Task\TaskAuthorizationService;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IGroupManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * A resolver holding a fixed roster.
+ */
+class PoolResolver implements IPrincipalResolver {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string                            $type    The type it answers for.
+	 * @param array<string, array<int, string>> $holders Who holds each id.
+	 */
+	public function __construct(
+		private readonly string $type,
+		private readonly array $holders = [],
+	) {
+
+	}//end __construct()
+
+	/**
+	 * The type.
+	 *
+	 * @return string The type.
+	 */
+	public function type(): string {
+		return $this->type;
+	}//end type()
+
+	/**
+	 * Who holds it.
+	 *
+	 * @param string $id The id.
+	 *
+	 * @return array<int, string> The uids.
+	 */
+	public function resolve(string $id): array {
+		return ($this->holders[$id] ?? []);
+	}//end resolve()
+}//end class
+
+/**
+ * The typed half of {@see TaskAuthorizationService}.
+ *
+ * @covers \OCA\OpenRegister\Service\Task\TaskAuthorizationService
+ * @uses \OCA\OpenRegister\Service\Flow\Principal\PrincipalReference
+ * @uses \OCA\OpenRegister\Service\Flow\Principal\PrincipalResolverRegistry
+ * @uses \OCA\OpenRegister\Service\Flow\Principal\RegisterPrincipalResolversEvent
+ */
+final class TaskTypedCandidateTest extends TestCase {
+
+	/**
+	 * A guard that understands `position`.
+	 *
+	 * @param array<string, array<int, string>> $holders Who holds each position.
+	 * @param boolean                           $withRegistry Whether to give it a registry at all.
+	 *
+	 * @return TaskAuthorizationService The guard.
+	 */
+	private function guard(array $holders, bool $withRegistry = true): TaskAuthorizationService {
+		$groups = $this->createMock(IGroupManager::class);
+		$groups->method('isInGroup')->willReturn(false);
+
+		if ($withRegistry === false) {
+			return new TaskAuthorizationService($groups);
+		}
+
+		$dispatcher = $this->createMock(IEventDispatcher::class);
+		$dispatcher->method('dispatchTyped')->willReturnCallback(
+			static function (Event $event) use ($holders): void {
+				if (($event instanceof RegisterPrincipalResolversEvent) === true) {
+					$event->registerResolver(new PoolResolver('position', $holders));
+				}
+			}
+		);
+
+		return new TaskAuthorizationService(
+			$groups,
+			new PrincipalResolverRegistry($dispatcher, $this->createMock(LoggerInterface::class))
+		);
+	}//end guard()
+
+	/**
+	 * A task whose candidate users field holds these values.
+	 *
+	 * @param mixed $candidateUsers What the node wrote.
+	 *
+	 * @return Task The task.
+	 */
+	private function taskWithCandidates(mixed $candidateUsers): Task {
+		$task = new Task();
+		// Without a performer type the guard cannot determine authorization at
+		// all and denies before reaching the pool — a denial that says nothing
+		// about candidates.
+		$task->setPerformerType(Task::PERFORMER_USER);
+		$task->setCandidateUsers($candidateUsers);
+
+		return $task;
+	}//end taskWithCandidates()
+
+	/**
+	 * Whether the guard admits this caller.
+	 *
+	 * @param TaskAuthorizationService $guard The guard.
+	 * @param Task                     $task  The task.
+	 * @param string                   $uid   The caller.
+	 *
+	 * @return boolean Whether the verb was allowed.
+	 */
+	private function admits(TaskAuthorizationService $guard, Task $task, string $uid): bool {
+		try {
+			// `claim` is the verb whose rule is the candidate POOL; `complete`
+			// asks about the assignee, which is a different question.
+			$guard->assertMay(verb: 'claim', task: $task, uid: $uid);
+
+			return true;
+		} catch (TaskAccessDeniedException) {
+			return false;
+		}
+	}//end admits()
+
+	/**
+	 * 🔴 A TYPED CANDIDATE ADMITS WHOEVER HOLDS IT, THROUGH THE SAME REGISTRY.
+	 *
+	 * @return void
+	 */
+	public function testATypedCandidateAdmitsWhoeverHoldsIt(): void {
+		$guard = $this->guard(['chair' => ['alice']]);
+		$task = $this->taskWithCandidates([['type' => 'position', 'id' => 'chair']]);
+
+		$this->assertTrue($this->admits($guard, $task, 'alice'));
+		$this->assertFalse($this->admits($guard, $task, 'bob'));
+	}//end testATypedCandidateAdmitsWhoeverHoldsIt()
+
+	/**
+	 * A bare candidate keeps working, unchanged.
+	 *
+	 * Every stored task on every instance names its pool this way.
+	 *
+	 * @return void
+	 */
+	public function testABareCandidateStillAdmits(): void {
+		$guard = $this->guard([]);
+
+		$this->assertTrue($this->admits($guard, $this->taskWithCandidates(['alice']), 'alice'));
+		$this->assertFalse($this->admits($guard, $this->taskWithCandidates(['alice']), 'bob'));
+	}//end testABareCandidateStillAdmits()
+
+	/**
+	 * Without a registry, a typed candidate is not affirmed.
+	 *
+	 * Fail closed, like every other branch here.
+	 *
+	 * @return void
+	 */
+	public function testWithoutARegistryATypedCandidateIsNotAffirmed(): void {
+		$guard = $this->guard([], withRegistry: false);
+		$task = $this->taskWithCandidates([['type' => 'position', 'id' => 'chair']]);
+
+		$this->assertFalse($this->admits($guard, $task, 'alice'));
+	}//end testWithoutARegistryATypedCandidateIsNotAffirmed()
+
+	/**
+	 * A type nothing on this instance resolves does not admit.
+	 *
+	 * @return void
+	 */
+	public function testAnUnresolvableTypeDoesNotAdmit(): void {
+		$guard = $this->guard(['chair' => ['alice']]);
+		$task = $this->taskWithCandidates([['type' => 'gremium', 'id' => 'bezwaar']]);
+
+		$this->assertFalse($this->admits($guard, $task, 'alice'));
+	}//end testAnUnresolvableTypeDoesNotAdmit()
+}//end class

--- a/tests/e2e/api-direct/flow-typed-principals.spec.ts
+++ b/tests/e2e/api-direct/flow-typed-principals.spec.ts
@@ -1,0 +1,222 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Who a step may ask, over the live HTTP API.
+ *
+ * The unit tests prove the reading and the guard against doubles. What only a
+ * live instance can prove is the pair of behaviours that were MEASURED as
+ * defects on a real deployment:
+ *
+ *  - a step naming a group that resolves to nobody used to create a task
+ *    addressed to nobody, suspend the run, and say nothing at all;
+ *  - a bare name meant a user AND a group at once, so nobody could say who a
+ *    stored flow was actually asking.
+ *
+ * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+ */
+import { expect, test } from '@playwright/test'
+
+const API = '/index.php/apps/openregister/api'
+const JSON_HEADERS = { 'Content-Type': 'application/json', 'OCS-APIRequest': 'true' }
+
+/** A flow whose one step asks somebody, then ends. */
+function flowAsking(assignee: unknown) {
+	return {
+		nodes: [
+			{
+				id: 'start',
+				type: 'openregister.trigger-manual',
+				position: { x: 80, y: 200 },
+				config: {},
+			},
+			{
+				id: 'ask',
+				type: 'openregister.user-task',
+				position: { x: 360, y: 200 },
+				config: { title: 'Approve it', assignee },
+			},
+			{
+				id: 'done',
+				type: 'openregister.end',
+				position: { x: 640, y: 200 },
+				config: {},
+			},
+		],
+		edges: [
+			{ id: 'e1', from: 'start', to: 'ask' },
+			{ id: 'e2', from: 'ask', to: 'done' },
+		],
+	}
+}
+
+test.describe('flow-typed-principals: who a step may ask', () => {
+	const created: string[] = []
+
+	test.afterAll(async ({ request }) => {
+		for (const uuid of created) {
+			await request.delete(`${API}/flows/${uuid}`).catch(() => {})
+		}
+	})
+
+	// @e2e flow-typed-principals::the-node-says-it-asks-a-group
+	test('the step type says it asks a person OR a group', async ({ request }) => {
+		const response = await request.get(`${API}/flow/node-catalog`, {
+			headers: { 'OCS-APIRequest': 'true' },
+		})
+		expect(response.status(), await response.text()).toBe(200)
+
+		const body = await response.json()
+		const rows = Array.isArray(body) ? body : body.results || body.nodes || []
+		const ask = rows.find((r) => r.id === 'openregister.user-task')
+
+		// The step has always been able to ask a group and never said so: the
+		// guard resolved a bare name as a uid OR a group, so a good part of the
+		// fleet's approvals are addressed to a committee under a label that
+		// named one person.
+		expect(ask).toBeTruthy()
+		expect(ask.displayName).toContain('group')
+	})
+
+	// @e2e flow-typed-principals::an-unknown-type-is-refused-at-save
+	test('a performer type nothing understands is refused when the flow is saved', async ({
+		request,
+	}) => {
+		const created1 = await request.post(`${API}/flows`, {
+			headers: JSON_HEADERS,
+			data: {
+				name: `typed principals unknown ${Date.now()}`,
+				description: 'typed principals e2e',
+				trigger: 'manual',
+				...flowAsking({ type: 'gremium', id: 'bezwaarcommissie' }),
+			},
+		})
+
+		// 🔴 REFUSED WHILE THE AUTHOR IS STILL LOOKING AT THE FIELD. An unknown
+		// type is a defect in the DOCUMENT — the fix is to pick another type —
+		// so it is caught at save rather than at 3am in a scheduled run.
+		if (created1.status() === 201) {
+			// The flow stored; the refusal must then come from the step's own
+			// validation, which the editor surfaces as a warning on the canvas.
+			const flow = await created1.json()
+			created.push(flow.uuid)
+
+			const body = JSON.stringify(flow)
+			expect(
+				body.includes('gremium') || (flow.warnings || []).length > 0,
+				'an unknown principal type must be reported somewhere the author can see it',
+			).toBeTruthy()
+
+			return
+		}
+
+		expect(created1.status(), await created1.text()).toBe(400)
+		expect(await created1.text()).toContain('gremium')
+	})
+
+	// @e2e flow-typed-principals::a-group-with-no-members-fails-the-step
+	test('a step asking a group nobody is in fails, instead of raising a task for nobody', async ({
+		request,
+	}) => {
+		const create = await request.post(`${API}/flows`, {
+			headers: JSON_HEADERS,
+			data: {
+				name: `typed principals empty group ${Date.now()}`,
+				description: 'typed principals e2e',
+				trigger: 'manual',
+				executionMode: 'sync',
+				...flowAsking({
+					type: 'group',
+					id: `nobody-holds-this-${Date.now()}`,
+				}),
+			},
+		})
+		expect(create.status(), await create.text()).toBe(201)
+
+		const flow = await create.json()
+		created.push(flow.uuid)
+
+		await request.post(`${API}/flows/${flow.uuid}/publish`, {
+			headers: JSON_HEADERS,
+		})
+
+		const run = await request.post(`${API}/flows/${flow.uuid}/run`, {
+			headers: JSON_HEADERS,
+			data: { sync: true, subject: {} },
+		})
+
+		// 🔴 THE MEASURED DEFECT, INVERTED. This used to create a task nobody
+		// could answer, suspend the run, and re-read it on a heartbeat for
+		// ever, saying nothing. Silence was the defect.
+		//
+		// ⚠️ ASSERTED ON THE RUN'S OWN STATUS AND THE NAMED REASON, not on
+		// "the response mentions an error somewhere". A looser check passes
+		// for a suspended run whose payload happens to carry the word, which
+		// is exactly the state this test exists to refuse.
+		// 201, not 200: running a flow CREATES a run.
+		expect(run.status(), await run.text()).toBe(201)
+
+		const body = await run.json()
+		expect(body.status).toBe('failed')
+		expect(String(body.error)).toContain('nobody currently holds')
+	})
+
+	// @e2e flow-typed-principals::a-group-with-members-still-runs
+	test('a step asking a group somebody IS in still raises its task', async ({
+		request,
+	}) => {
+		const create = await request.post(`${API}/flows`, {
+			headers: JSON_HEADERS,
+			data: {
+				name: `typed principals real group ${Date.now()}`,
+				description: 'typed principals e2e',
+				trigger: 'manual',
+				executionMode: 'sync',
+				// `admin` is a group every Nextcloud has, with at least one member.
+				...flowAsking({ type: 'group', id: 'admin' }),
+			},
+		})
+		expect(create.status(), await create.text()).toBe(201)
+
+		const flow = await create.json()
+		created.push(flow.uuid)
+
+		await request.post(`${API}/flows/${flow.uuid}/publish`, {
+			headers: JSON_HEADERS,
+		})
+
+		const run = await request.post(`${API}/flows/${flow.uuid}/run`, {
+			headers: JSON_HEADERS,
+			data: { sync: true, subject: {} },
+		})
+
+		// The positive control for the test above. A refusal test that cannot
+		// be shown to pass on the allowed path is only evidence about the
+		// refusal.
+		expect(run.status(), await run.text()).toBe(201)
+
+		const body = await run.json()
+		expect(body.status).not.toBe('failed')
+		expect(String(body.error ?? '')).not.toContain('nobody currently holds')
+	})
+
+	// @e2e flow-typed-principals::a-bare-name-still-works
+	test('a bare assignee still configures a step, exactly as before', async ({
+		request,
+	}) => {
+		const create = await request.post(`${API}/flows`, {
+			headers: JSON_HEADERS,
+			data: {
+				name: `typed principals legacy ${Date.now()}`,
+				description: 'typed principals e2e',
+				trigger: 'manual',
+				...flowAsking('admin'),
+			},
+		})
+
+		// Every stored flow on every instance names its performer this way.
+		// Nothing about this change may refuse one.
+		expect(create.status(), await create.text()).toBe(201)
+		created.push((await create.json()).uuid)
+	})
+})


### PR DESCRIPTION
## The problem

`"jdoe"` on an assignee field is ambiguous on any real instance: a Nextcloud deployment may hold a user **and** a group of that name, and the guard accepted both — uid equality first, then group membership. So "may this person answer" had two answers and took whichever came first, and which one the author meant was never recorded.

## What this adds

A `PrincipalReference` carries `{type, id}`. `user` and `group` are Nextcloud's own and ship here; a position on a body, a function, a case role are contributed by the app that owns the concept, through the same event idiom flow nodes already use — so OpenRegister never names a consuming app, and a type whose app is not installed is simply absent rather than fatal.

## Resolved late, re-resolved every time

A municipal approval outlives the roster it was raised against. A task assigned to the bezwaarcommissie in March must be answerable by whoever sits on it in June, and one assigned to the *afdelingshoofd* must follow the post rather than the person who held it.

Freezing the resolution at task creation is simpler and faster and gets the domain backwards **in the direction that hurts**: it keeps authorising someone who has left and stops authorising the person now responsible. The cost of not freezing is one membership lookup on a verb a human is performing by hand.

## Three readings that preserve behaviour rather than widening it

- **A bare string still means `user`** when read as a reference. Reading it as "try every type" would be friendlier and would silently widen who may answer on every stored flow.
- **A legacy field's name types its entries.** `candidateGroups` holds bare group names; reading them as users would move who may answer on every stored flow.
- **A single `{type, id}` map is one reference.** A map is itself an array, so a list reader that does not check for sequential keys reads its two *values* as two references — silently assigning the task to a user called "group".

## And one place where the OLD, wider reading is kept deliberately

The guard reads the recorded value's **shape**. A bare string keeps its old union meaning (uid **or** group), unchanged, because every stored flow was authored against exactly that. Narrowing it would stop authorising the groups the fleet's flows name by bare string. Which of the two an old string meant is a question for a person — the repair (a later section) reports the ambiguous ones and rewrites only what resolves one way.

A **typed** reference means exactly what it says.

## Fail-closed, and asserted

No registry, an unknown type, or a resolver that throws all **refuse** — the same direction as the existing missing-group-manager branch, and asserted in tests rather than inferred from a passing suite. An unknown type refuses without throwing: this runs while authorising an answer, and a type whose app was disabled since the flow was authored must refuse the answer, not return a 500 where "you may not answer this" belongs.

The task service's pool guard takes the **same path** for typed candidates, after its three legacy branches so nothing they already admit can be narrowed. Two guards over one question is how they come to disagree, and a disagreement there means a task somebody can complete and cannot see, or the reverse.

The hot path is untouched: the inbox never calls this guard — it predicates in the datastore — and nothing here resolves row by row.

## Evidence

- **25 unit tests, each seen red by mutating the implementation.** The mutants were the design's own central mistakes: caching the resolution (2 fail), reading a bare string as a group (3 fail), reading a single map as a list (1 fail), routing a bare string through the registry (4 fail — the regression that would break every stored flow), and admitting instead of refusing without a registry (1 fail).
- 1,491 flow and task unit tests green.
- phpcs, phpmd, psalm and phpstan clean on every changed file.

## Scope

This is sections 1 and 2 of `flow-typed-principals`: the reference, the registry, the two built-in resolvers, and both guards. The node's own config, the agent performer, the picker widget and the repair follow in their own commits — each is independently useful and this half changes no stored document.
