### PR TITLE
chore(deps): bump @conduction/nextcloud-vue to 2.40.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
-        "@conduction/nextcloud-vue": "^2.39.0",
+        "@conduction/nextcloud-vue": "^2.40.0",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "^2.6.0",
         "@nextcloud/capabilities": "^1.2.1",
@@ -2289,9 +2289,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.39.0",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.39.0.tgz",
-      "integrity": "sha512-LmiQwc2VizxNfdzrVXF/A2NwItjIBg5DGi2EbvkMZwA8wXAgSaDWO2uant5TU+AHXotK5Csfqe0OXSe/b5qJqA==",
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.40.0.tgz",
+      "integrity": "sha512-ZWbBfId51ABXj4DhPwclEZ7tjgKYOJnQf9TNpkz8AhF+sBvE0KjoSEJBsqHs5nKC6hDc0foxIkR36M1YVKv0ag==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
-    "@conduction/nextcloud-vue": "^2.39.0",
+    "@conduction/nextcloud-vue": "^2.40.0",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "^2.6.0",
     "@nextcloud/capabilities": "^1.2.1",


### PR DESCRIPTION
## What it brings

`@conduction/nextcloud-vue` 2.40.0 carries the flow editor halves that read engine features already on openregister's `development`:

- Publish says what the version will be called, and when it is breaking, names what it takes away — it fetches `/flows/{id}/version-preview`
- The step picker groups by the per-node category, in a fixed order
- A health dot before the flow's name, and runs as cards
- A run gets its own sidebar; the version sits in a pill beside the title
- Run honours the flow's execution mode instead of always queueing

Until this lands the picker renders a single `Other` group and the publish dialog cannot fetch its preview. Both are designed fallbacks rather than breaks, but neither is what the author should be looking at.
