### PR TITLE
feat(flow): an agent is a performer of the same step, asked with a prompt

### DIFF
--- a/lib/Db/TaskInboxCriteria.php
+++ b/lib/Db/TaskInboxCriteria.php
@@ -119,4 +119,40 @@ final class TaskInboxCriteria {
 	) {
 
 	}//end __construct()
+
+	/**
+	 * Every stored `assignee` value that means "this caller".
+	 *
+	 * 🔑 THE RESOLVER DECIDES AUTHORISATION, NOT LISTING. A typed assignee is
+	 * stored as `type:id`, so the caller's identity expands to a small, fixed
+	 * set of strings the datastore can match with an IN. Resolving a reference
+	 * per ROW instead would resolve it a hundred times on one page, which is
+	 * exactly what the design forbids.
+	 *
+	 * Three shapes, and all three are needed. The BARE uid, because every flow
+	 * ever authored names people that way and none of them may stop working.
+	 * `user:<uid>`, because that is what the picker now writes. And
+	 * `group:<id>` for each group the caller is in, because a group reference
+	 * is a direct assignee, not a candidate pool.
+	 *
+	 * 🔴 `agent:` IS DELIBERATELY ABSENT. An agent's task must not appear in a
+	 * person's inbox, nor be answerable by them.
+	 *
+	 * @return array<int, string> The names, without duplicates.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public function assigneeNames(): array {
+		$names = [$this->uid, 'user:' . $this->uid];
+
+		foreach ($this->groupIds as $groupId) {
+			$groupId = trim((string)$groupId);
+			if ($groupId !== '') {
+				$names[] = 'group:' . $groupId;
+			}
+		}
+
+		return array_values(array_unique($names));
+
+	}//end assigneeNames()
 }//end class

--- a/lib/Db/TaskMapper.php
+++ b/lib/Db/TaskMapper.php
@@ -698,7 +698,7 @@ class TaskMapper extends QBMapper {
 
 		switch ($criteria->scope) {
 			case TaskInboxCriteria::SCOPE_ASSIGNED:
-				$qb->andWhere($qb->expr()->eq('assignee', $qb->createNamedParameter($criteria->uid)));
+				$qb->andWhere($this->assigneeMatchesCaller(qb: $qb, criteria: $criteria));
 				break;
 			case TaskInboxCriteria::SCOPE_POOLED:
 				$qb->andWhere(
@@ -719,6 +719,35 @@ class TaskMapper extends QBMapper {
 	}//end applyScope()
 
 	/**
+	 * The task's assignee names the caller, by uid or by a reference they hold.
+	 *
+	 * 🔑 THE RESOLVER DECIDES AUTHORISATION, NOT LISTING. A typed assignee is
+	 * stored as `type:id`, so the caller's own identity expands to a small,
+	 * fixed set of strings the datastore can match with an IN — the caller's
+	 * bare uid (every flow ever authored names people that way), `user:<uid>`,
+	 * and `group:<id>` for each group they are in. Resolving a reference per
+	 * ROW instead would resolve it a hundred times on one page, which is
+	 * exactly what the design forbids.
+	 *
+	 * 🔴 AN AGENT'S TASK STAYS OUT OF A PERSON'S INBOX. Only `user:` and
+	 * `group:` are expanded, so `agent:scribe` matches nothing here — an agent
+	 * step must not be answerable by the humans, nor appear to be theirs.
+	 *
+	 * @param IQueryBuilder     $qb       The query under construction.
+	 * @param TaskInboxCriteria $criteria Carries the identity facts.
+	 *
+	 * @return string The predicate.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	private function assigneeMatchesCaller(IQueryBuilder $qb, TaskInboxCriteria $criteria): string {
+		return $qb->expr()->in(
+			'assignee',
+			$qb->createNamedParameter($criteria->assigneeNames(), IQueryBuilder::PARAM_STR_ARRAY)
+		);
+	}//end assigneeMatchesCaller()
+
+	/**
 	 * The visibility half: an administrator sees everything; anyone else
 	 * sees a task only through one of the five sanctioned relationships.
 	 *
@@ -733,7 +762,7 @@ class TaskMapper extends QBMapper {
 		if ($criteria->isAdmin === false) {
 			$qb->andWhere(
 				$qb->expr()->orX(
-					$qb->expr()->eq('assignee', $qb->createNamedParameter($criteria->uid)),
+					$this->assigneeMatchesCaller(qb: $qb, criteria: $criteria),
 					$qb->expr()->eq('requester', $qb->createNamedParameter($criteria->uid)),
 					$this->watcherPredicate(qb: $qb, uid: $criteria->uid),
 					$this->candidateMembershipPredicate(qb: $qb, criteria: $criteria)

--- a/lib/Listener/PrincipalResolverRegistrationListener.php
+++ b/lib/Listener/PrincipalResolverRegistrationListener.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Listener;
 
+use OCA\OpenRegister\Service\Flow\Principal\AgentPrincipalResolver;
 use OCA\OpenRegister\Service\Flow\Principal\GroupPrincipalResolver;
 use OCA\OpenRegister\Service\Flow\Principal\RegisterPrincipalResolversEvent;
 use OCA\OpenRegister\Service\Flow\Principal\UserPrincipalResolver;
@@ -46,12 +47,15 @@ class PrincipalResolverRegistrationListener implements IEventListener {
 	 *
 	 * @param UserPrincipalResolver  $users  Resolves `user` references.
 	 * @param GroupPrincipalResolver $groups Resolves `group` references.
+	 * @param AgentPrincipalResolver $agents Resolves `agent` references — one
+	 *                                       identity, never a group's members.
 	 *
 	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
 	 */
 	public function __construct(
 		private readonly UserPrincipalResolver $users,
 		private readonly GroupPrincipalResolver $groups,
+		private readonly AgentPrincipalResolver $agents,
 	) {
 
 	}//end __construct()
@@ -72,6 +76,10 @@ class PrincipalResolverRegistrationListener implements IEventListener {
 
 		$event->registerResolver(resolver: $this->users);
 		$event->registerResolver(resolver: $this->groups);
+		// An agent is a performer of the same node, addressed the same way and
+		// completing through the same verbs — so it is a principal kind, not a
+		// second mechanism beside them.
+		$event->registerResolver(resolver: $this->agents);
 
 	}//end handle()
 }//end class

--- a/lib/Service/Flow/Nodes/UserTaskConfig.php
+++ b/lib/Service/Flow/Nodes/UserTaskConfig.php
@@ -240,23 +240,45 @@ final class UserTaskConfig {
 			FlowTaskBridge::SLOT_TASK_UUID => $taskUuid,
 			FlowTaskBridge::SLOT_ASKED_AT => (new DateTime())->format('c'),
 			FlowTaskBridge::SLOT_ADVANCE => FlowAdvanceBudget::fromConfig(config: $config)->toStored(),
-			'assignee' => $this->assignee(config: $config),
+			'assignee' => $this->assigneeValue(config: $config),
 			'title' => $this->renderedTitle(config: $config, items: $items),
 		];
 	}//end slotValues()
 
 	/**
-	 * The directly configured assignee, trimmed; '' when the task is pooled.
+	 * The assignee as the task row stores it.
+	 *
+	 * Delegated to {@see UserTaskAssignee}, which owns both shapes: the two are
+	 * read by different consumers for different purposes, and keeping them here
+	 * put this class over its complexity budget.
 	 *
 	 * @param array<string, mixed> $config The step configuration.
 	 *
-	 * @return string The assignee uid, or ''.
+	 * @return string The stored assignee, or ''.
 	 *
-	 * @spec openspec/changes/flow-user-task-node/specs/flow-user-task-node/spec.md#requirement-a-user-task-step-creates-exactly-one-task-and-suspends-the-run
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
 	 */
 	public function assignee(array $config): string {
-		return trim((string)($config['assignee'] ?? ''));
+		return PrincipalReference::storedString(value: ($config['assignee'] ?? ''));
 	}//end assignee()
+
+	/**
+	 * The assignee as configured, keeping a typed reference's shape.
+	 *
+	 * @param array<string, mixed> $config The step configuration.
+	 *
+	 * @return string|array<mixed> The configured assignee.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public function assigneeValue(array $config): string|array {
+		$value = ($config['assignee'] ?? '');
+		if (is_array($value) === true) {
+			return $value;
+		}
+
+		return trim((string)$value);
+	}//end assigneeValue()
 
 	/**
 	 * The item key the outcome is written under.

--- a/lib/Service/Flow/Nodes/UserTaskNode.php
+++ b/lib/Service/Flow/Nodes/UserTaskNode.php
@@ -76,6 +76,7 @@ use OCA\OpenRegister\Service\Flow\IFlowNodeConfigKeys;
 use OCA\OpenRegister\Service\Flow\IFlowNodeTaxonomy;
 use OCA\OpenRegister\Service\Flow\Timer\FlowTimerService;
 use OCA\OpenRegister\Service\Task\TaskFormReader;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\WorkflowEngine\IManager;
@@ -102,6 +103,13 @@ class UserTaskNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigFor
 	private readonly UserTaskConfig $config;
 
 	/**
+	 * Who the step asks, and what asking them costs.
+	 *
+	 * @var UserTaskPerformers
+	 */
+	private readonly UserTaskPerformers $performers;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param FlowTaskBridge $bridge Creates and reads the node's task.
@@ -112,6 +120,10 @@ class UserTaskNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigFor
 	 * @param PrincipalResolverRegistry|null $principals Passed to the config reader,
 	 *                             which refuses a performer whose type nothing on
 	 *                             this instance understands.
+	 * @param IEventDispatcher|null $events Where an agent performer's turn is
+	 *                             ASKED FOR. The node dispatches; it never
+	 *                             invokes a runtime, so the app that owns
+	 *                             agents stays unnamed here.
 	 *
 	 * @spec openspec/changes/flow-user-task-node/specs/flow-user-task-node/spec.md
 	 */
@@ -122,8 +134,14 @@ class UserTaskNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigFor
 		TaskFormReader $forms,
 		private readonly FlowTimerService $timers,
 		private readonly ?PrincipalResolverRegistry $principals = null,
+		private readonly ?IEventDispatcher $events = null,
 	) {
 		$this->config = new UserTaskConfig(l10n: $l10n, forms: $forms, principals: $principals);
+		$this->performers = new UserTaskPerformers(
+			config: $this->config,
+			principals: $principals,
+			events: $events
+		);
 
 	}//end __construct()
 
@@ -202,6 +220,12 @@ class UserTaskNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigFor
 			'title',
 			'description',
 			'assignee',
+			// One field expressing what three did, and able to mix types.
+			'candidates',
+			// WHAT an agent performer is asked, in place of a form. A person
+			// gets fields to fill in; an agent gets a prompt. Same step, same
+			// completion verbs, same audit.
+			'prompt',
 			'candidateUsers',
 			'candidateGroups',
 			'candidateRole',
@@ -363,7 +387,7 @@ class UserTaskNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigFor
 			throw new RuntimeException('openregister.user-task cannot create a task outside a persisted run: the task must carry the run uuid.');
 		}
 
-		$this->refuseAPerformerNobodyHolds(config: $config);
+		$this->performers->refuseIfNobodyHoldsThem(config: $config);
 
 		$task = $this->bridge->createTask(
 			data: $this->config->taskData(config: $config, items: $items, nodeId: $resume->nodeId(), nodeType: $this->getId()),
@@ -381,6 +405,8 @@ class UserTaskNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigFor
 		// (subjectType: 'task', subjectUuid) pair that
 		// FlowTimerSubjectTerminalListener already cancels on completion. Arm
 		// somewhere the uuid is not yet known and the two halves cannot meet.
+		$this->performers->askAnyAgent(config: $config, task: $task, context: $context);
+
 		$this->armDeadline(
 			config: $config,
 			taskUuid: (string)$task->getUuid(),
@@ -397,59 +423,6 @@ class UserTaskNode implements IFlowNode, IFlowNodeConfigKeys, IFlowNodeConfigFor
 		);
 
 	}//end createTask()
-
-	/**
-	 * Refuse to raise a task nobody can perform.
-	 *
-	 * 🔴 THIS IS THE MEASURED DEFECT, INVERTED. A step naming a group that has
-	 * no members — or that does not exist — created a task addressed to
-	 * nobody. The run suspended, a heartbeat re-read it every few minutes, and
-	 * NOTHING said anything: the task existed, the run was healthy, and the
-	 * approval simply never happened. Silence was the defect.
-	 *
-	 * A loud step failure is strictly better even when the author chooses to
-	 * continue past it, because it is subject to the flow's own `onError`
-	 * policy — which is a decision the author gets to make, and silence is not.
-	 *
-	 * 🔑 REFUSED HERE AND NOT AT SAVE. An empty resolution is a fact about the
-	 * instance and it changes: a committee with no members today has members
-	 * next week. This is the moment somebody actually needs to be found.
-	 *
-	 * Only checked when the instance can resolve at all, and only for steps
-	 * that name somebody: an unassigned step is deliberately open, and refusing
-	 * one would close a door the spec holds open.
-	 *
-	 * @param array<string, mixed> $config The step configuration.
-	 *
-	 * @return void
-	 *
-	 * @throws RuntimeException When every named performer resolves to nobody.
-	 *
-	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
-	 */
-	private function refuseAPerformerNobodyHolds(array $config): void {
-		if ($this->principals === null) {
-			return;
-		}
-
-		$named = $this->config->performers(config: $config);
-		if ($named === []) {
-			return;
-		}
-
-		if ($this->principals->resolveAll(references: $named) !== []) {
-			return;
-		}
-
-		throw new RuntimeException(
-			sprintf(
-				'openregister.user-task cannot raise a task: it asks %s, and nobody currently holds any of them. '
-					. 'The step fails rather than creating a task addressed to nobody.',
-				implode(', ', array_map(static fn ($r): string => (string)$r, $named))
-			)
-		);
-
-	}//end refuseAPerformerNobodyHolds()
 
 	/**
 	 * Arm a business timer for the task this node just created.

--- a/lib/Service/Flow/Nodes/UserTaskPerformers.php
+++ b/lib/Service/Flow/Nodes/UserTaskPerformers.php
@@ -1,0 +1,181 @@
+<?php
+
+/**
+ * Who the step asks, and what asking them costs.
+ *
+ * Separate from {@see UserTaskNode} because it answers a different question.
+ * The node orchestrates a task's lifecycle — create it, arm its clock, suspend,
+ * resume, read the answer. This decides who the task is FOR, and it is the only
+ * place that knows an agent is asked differently from a person.
+ *
+ * Both of its questions are asked at task-creation time, and both are asked
+ * THERE for the same reason: it is the moment somebody actually has to be
+ * found. A step naming a committee that has no members today may well have
+ * members next week, so refusing to SAVE the flow over it would make the flow
+ * unauthorable for a reason that has nothing to do with the flow.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow\Nodes
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow\Nodes;
+
+use OCA\OpenRegister\Db\Task;
+use OCA\OpenRegister\Event\AgentRunRequestedEvent;
+use OCA\OpenRegister\Service\Flow\Principal\AgentPrincipalResolver;
+use OCA\OpenRegister\Service\Flow\Principal\PrincipalReference;
+use OCA\OpenRegister\Service\Flow\Principal\PrincipalResolverRegistry;
+use OCP\EventDispatcher\IEventDispatcher;
+use RuntimeException;
+
+/**
+ * Resolves and asks a user task's performers.
+ */
+class UserTaskPerformers {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param UserTaskConfig                 $config     Reads the step's performer fields.
+	 * @param PrincipalResolverRegistry|null $principals Resolves a reference to who it currently means.
+	 * @param IEventDispatcher|null          $events     Where an agent's turn is asked for.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public function __construct(
+		private readonly UserTaskConfig $config,
+		private readonly ?PrincipalResolverRegistry $principals = null,
+		private readonly ?IEventDispatcher $events = null,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * Refuse to raise a task nobody can perform.
+	 *
+	 * 🔴 THIS IS THE MEASURED DEFECT, INVERTED. A step naming a group that has
+	 * no members — or that does not exist — created a task addressed to
+	 * nobody. The run suspended, a heartbeat re-read it every few minutes, and
+	 * NOTHING said anything: the task existed, the run was healthy, and the
+	 * approval simply never happened. Silence was the defect.
+	 *
+	 * A loud step failure is strictly better even when the author chooses to
+	 * continue past it, because it is subject to the flow's own `onError`
+	 * policy — which is a decision the author gets to make, and silence is not.
+	 *
+	 * Only checked when the instance can resolve at all, and only for steps
+	 * that name somebody: an unassigned step is deliberately open, and refusing
+	 * one would close a door the spec holds open.
+	 *
+	 * @param array<string, mixed> $config The step configuration.
+	 *
+	 * @return void
+	 *
+	 * @throws RuntimeException When every named performer resolves to nobody.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public function refuseIfNobodyHoldsThem(array $config): void {
+		if ($this->principals === null) {
+			return;
+		}
+
+		$named = $this->config->performers(config: $config);
+		if ($named === []) {
+			return;
+		}
+
+		if ($this->principals->resolveAll(references: $named) !== []) {
+			return;
+		}
+
+		throw new RuntimeException(
+			sprintf(
+				'openregister.user-task cannot raise a task: it asks %s, and nobody currently holds any of them. '
+					. 'The step fails rather than creating a task addressed to nobody.',
+				implode(', ', array_map(static fn ($r): string => (string)$r, $named))
+			)
+		);
+
+	}//end refuseIfNobodyHoldsThem()
+
+	/**
+	 * Ask an agent performer to take its turn.
+	 *
+	 * 🔴 IT DISPATCHES; IT NEVER INVOKES A RUNTIME. The engine has no business
+	 * knowing how an agent runs, and naming the app that does would put a
+	 * consuming app's name in OpenRegister (gate-27, ADR-022). The app that
+	 * owns agents listens, does the work, and completes the task through the
+	 * ORDINARY verbs — the same guard, the same audit, the same outcome
+	 * vocabulary a person's answer takes.
+	 *
+	 * That is also why the task is created FIRST and this is called second: the
+	 * agent needs something to complete, and if nothing is listening the task
+	 * simply sits there, reassignable to a person like any other.
+	 *
+	 * ⚠️ THIS IS THE EVENT'S FIRST DISPATCHER. `AgentRunRequestedEvent` was
+	 * declared and never fired by anything — an event nobody sends is a
+	 * contract nobody can rely on.
+	 *
+	 * @param array<string, mixed> $config  The step configuration.
+	 * @param Task                 $task    The task just created.
+	 * @param array<string, mixed> $context The run context.
+	 *
+	 * @return void
+	 *
+	 * @SuppressWarnings(PHPMD.StaticAccess) `PrincipalReference::listFrom()` is
+	 * a named constructor on a value object, which this rule cannot tell apart
+	 * from a static call into a service.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public function askAnyAgent(array $config, Task $task, array $context): void {
+		if ($this->events === null) {
+			return;
+		}
+
+		$agent = null;
+		foreach (PrincipalReference::listFrom(value: ($config['assignee'] ?? null)) as $reference) {
+			if ($reference->type === AgentPrincipalResolver::TYPE) {
+				$agent = $reference;
+				break;
+			}
+		}
+
+		if ($agent === null) {
+			return;
+		}
+
+		$this->events->dispatchTyped(
+			new AgentRunRequestedEvent(
+				subjectUuid: (string)$task->getUuid(),
+				subjectRegister: trim((string)($config['subjectRegister'] ?? '')),
+				subjectSchema: trim((string)($config['subjectSchema'] ?? '')),
+				agent: $agent->id,
+				skill: ($config['skill'] ?? null),
+				// A person gets fields to fill in; an agent gets a prompt. An
+				// agent asked nothing at all cannot know what the step wanted,
+				// so the title stands in rather than an empty string.
+				prompt: trim((string)($config['prompt'] ?? ($config['title'] ?? ''))),
+				resultField: trim((string)($config['outcomeKey'] ?? '')),
+				requiresApproval: (bool)($config['requiresApproval'] ?? false),
+				mode: trim((string)($config['mode'] ?? 'task')),
+				flowName: trim((string)($context['flowName'] ?? ''))
+			)
+		);
+
+	}//end askAnyAgent()
+}//end class

--- a/lib/Service/Flow/Principal/AgentPrincipalResolver.php
+++ b/lib/Service/Flow/Principal/AgentPrincipalResolver.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * An agent is a performer, and agents are not people.
+ *
+ * 🔴 IT RESOLVES TO EXACTLY ONE IDENTITY AND NEVER THROUGH A GROUP. That is the
+ * whole safety property. The answer guard compares the acting uid against what
+ * a reference resolves to, so if an agent reference ever expanded through group
+ * membership, an agent's step would become answerable by every human in that
+ * group — and, the other way round, a human's step by the agent. The two must
+ * not be able to answer for each other.
+ *
+ * It therefore does the same existence check {@see UserPrincipalResolver} does
+ * and nothing else: an agent completes its turn as a REAL identity, or it
+ * resolves to nobody and the step fails loudly rather than raising a task
+ * addressed to something that cannot log in.
+ *
+ * WHY THE IDENTITY IS A NEXTCLOUD USER AT ALL
+ * -------------------------------------------
+ * Because the completion verb is the ordinary one. An agent finishing a task
+ * takes the same path a person does — the same guard, the same audit, the same
+ * outcome vocabulary — and that only works if it acts as something the guard
+ * can compare against. An agent with no account is an agent nothing can
+ * attribute a decision to.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow\Principal
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow\Principal;
+
+use OCP\IUserManager;
+
+/**
+ * Resolves `{type: 'agent'}` references.
+ */
+class AgentPrincipalResolver implements IPrincipalResolver {
+
+	/**
+	 * The type this resolver answers for.
+	 *
+	 * @var string
+	 */
+	public const TYPE = 'agent';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IUserManager $users Nextcloud's user manager.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public function __construct(private readonly IUserManager $users) {
+
+	}//end __construct()
+
+	/**
+	 * The type.
+	 *
+	 * @return string `agent`.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public function type(): string {
+		return self::TYPE;
+
+	}//end type()
+
+	/**
+	 * The one identity this agent acts as.
+	 *
+	 * 🔴 NEVER MORE THAN ONE, AND NEVER A GROUP'S MEMBERS. See the class
+	 * docblock: an agent step answerable by humans, or a human step answerable
+	 * by an agent, is the failure this single-identity rule exists to prevent.
+	 *
+	 * @param string $id The agent's identity.
+	 *
+	 * @return array<int, string> The uid, or nothing when no such identity exists.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public function resolve(string $id): array {
+		$uid = trim($id);
+		if ($uid === '' || $this->users->userExists($uid) === false) {
+			return [];
+		}
+
+		return [$uid];
+
+	}//end resolve()
+}//end class

--- a/lib/Service/Flow/Principal/PrincipalReference.php
+++ b/lib/Service/Flow/Principal/PrincipalReference.php
@@ -201,4 +201,44 @@ final class PrincipalReference implements JsonSerializable {
 		return $this->type . ':' . $this->id;
 
 	}//end __toString()
+
+	/**
+	 * A configured performer value, as a single stored string.
+	 *
+	 * 🔴 A TYPED REFERENCE CAST TO A STRING PRODUCES THE LITERAL "Array". That
+	 * is not a near miss. It was written into the task row and into the run's
+	 * resume slot, where the answer guard reads it as a legacy bare string,
+	 * matches it against no uid and no group, and leaves the task answerable by
+	 * NOBODY — the exact silence typed principals exist to remove, put back by
+	 * a cast.
+	 *
+	 * A bare string passes through, trimmed, because every flow ever authored
+	 * names people that way. A single reference becomes `type:id`, which is
+	 * what an inbox can predicate on in the datastore: the resolver decides
+	 * authorisation, not listing.
+	 *
+	 * 🔑 SEVERAL REFERENCES ARE NOT ONE STORED VALUE. Picking one of them would
+	 * silently drop the others, so the answer is '' and the caller decides what
+	 * that means — for a task's assignee column it means the task pools, which
+	 * is what the candidate fields are for.
+	 *
+	 * @param mixed $value The configured value.
+	 *
+	 * @return string The stored form, or '' when there is no single one.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+	 */
+	public static function storedString(mixed $value): string {
+		if (is_string($value) === true) {
+			return trim($value);
+		}
+
+		$references = self::listFrom(value: $value);
+		if (count($references) !== 1) {
+			return '';
+		}
+
+		return (string)$references[array_key_first($references)];
+
+	}//end storedString()
 }//end class

--- a/tests/Unit/Db/TaskInboxCriteriaNamesTest.php
+++ b/tests/Unit/Db/TaskInboxCriteriaNamesTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * Which stored `assignee` values mean "this caller".
+ *
+ * 🔴 THE RESOLVER DECIDES AUTHORISATION, NOT LISTING. A typed assignee is
+ * stored as `type:id`, so the caller's identity has to expand to a small fixed
+ * set of strings the datastore can match with an IN. Resolving a reference per
+ * row instead would resolve it a hundred times on one page.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Db
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Db;
+
+use OCA\OpenRegister\Db\TaskInboxCriteria;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for {@see TaskInboxCriteria::assigneeNames()}.
+ *
+ * @covers \OCA\OpenRegister\Db\TaskInboxCriteria
+ */
+final class TaskInboxCriteriaNamesTest extends TestCase {
+
+	/**
+	 * 🔴 THE BARE UID IS FIRST AND NEVER DROPPED.
+	 *
+	 * Every flow ever authored names people by bare uid, and none of them may
+	 * stop working because the picker now writes a typed reference.
+	 *
+	 * @return void
+	 */
+	public function testTheBareUidIsAlwaysAName(): void {
+		$this->assertContains('alice', (new TaskInboxCriteria(uid: 'alice'))->assigneeNames());
+	}//end testTheBareUidIsAlwaysAName()
+
+	/**
+	 * The caller's own typed reference is a name.
+	 *
+	 * @return void
+	 */
+	public function testTheCallersTypedReferenceIsAName(): void {
+		$this->assertContains('user:alice', (new TaskInboxCriteria(uid: 'alice'))->assigneeNames());
+	}//end testTheCallersTypedReferenceIsAName()
+
+	/**
+	 * 🔑 A GROUP REFERENCE IS A DIRECT ASSIGNEE, NOT A CANDIDATE POOL.
+	 *
+	 * A step naming `{type: group, id: bezwaar}` assigns the task to the group,
+	 * and every member has to see it in the inbox — otherwise the task exists,
+	 * the run is healthy, and nobody is looking at it.
+	 *
+	 * @return void
+	 */
+	public function testEveryGroupTheCallerIsInIsAName(): void {
+		$names = (new TaskInboxCriteria(uid: 'alice', groupIds: ['bezwaar', 'reviewers']))->assigneeNames();
+
+		$this->assertContains('group:bezwaar', $names);
+		$this->assertContains('group:reviewers', $names);
+	}//end testEveryGroupTheCallerIsInIsAName()
+
+	/**
+	 * 🔴 AN AGENT'S TASK STAYS OUT OF A PERSON'S INBOX.
+	 *
+	 * An agent step must not be answerable by the humans, nor appear to be
+	 * theirs. Nothing here ever produces an `agent:` name, whatever the caller
+	 * is called or belongs to.
+	 *
+	 * @return void
+	 */
+	public function testNoNameIsEverAnAgentReference(): void {
+		$names = (new TaskInboxCriteria(uid: 'scribe', groupIds: ['agents']))->assigneeNames();
+
+		foreach ($names as $name) {
+			$this->assertStringStartsNotWith('agent:', $name);
+		}
+	}//end testNoNameIsEverAnAgentReference()
+
+	/**
+	 * An empty group id contributes no name.
+	 *
+	 * `group:` would match a stored value of exactly that, which is not a group
+	 * anybody holds.
+	 *
+	 * @return void
+	 */
+	public function testAnEmptyGroupIdIsNotAName(): void {
+		$this->assertNotContains(
+			'group:',
+			(new TaskInboxCriteria(uid: 'alice', groupIds: ['', '  ']))->assigneeNames()
+		);
+	}//end testAnEmptyGroupIdIsNotAName()
+
+	/**
+	 * The list carries no duplicates, so the IN stays small.
+	 *
+	 * @return void
+	 */
+	public function testTheListHasNoDuplicates(): void {
+		$names = (new TaskInboxCriteria(uid: 'alice', groupIds: ['bezwaar', 'bezwaar']))->assigneeNames();
+
+		$this->assertSame(array_values(array_unique($names)), $names);
+	}//end testTheListHasNoDuplicates()
+}//end class

--- a/tests/Unit/Db/TaskMapperQueriesTest.php
+++ b/tests/Unit/Db/TaskMapperQueriesTest.php
@@ -238,7 +238,9 @@ class TaskMapperQueriesTest extends TestCase {
 		$page = $mapper->findInbox(criteria: $criteria, limit: 25, offset: 50);
 
 		$this->assertCount(1, $page);
-		$this->assertTrue($this->saw('expr.eq', 'assignee'));
+		// An IN, not an eq: a typed assignee is stored as `type:id`, so the
+		// caller's identity expands to the few strings that mean them.
+		$this->assertTrue($this->saw('expr.in', 'assignee'));
 		$this->assertTrue($this->saw('expr.eq', 'requester'), 'visibility disjunction present for a non-admin');
 		$this->assertTrue($this->saw('setMaxResults', 25));
 		$this->assertTrue($this->saw('setFirstResult', 50));
@@ -270,7 +272,7 @@ class TaskMapperQueriesTest extends TestCase {
 
 		$this->calls = [];
 		$mapper->findInbox(criteria: new TaskInboxCriteria(uid: 'root', isAdmin: true, scope: TaskInboxCriteria::SCOPE_ALL));
-		$this->assertFalse($this->saw('expr.eq', 'assignee'));
+		$this->assertFalse($this->saw('expr.in', 'assignee'));
 	}//end testFindInboxScopesForAnAdmin()
 
 	/**
@@ -316,7 +318,9 @@ class TaskMapperQueriesTest extends TestCase {
 	public function testCountInboxReadsTheTotal(): void {
 		$counted = new TaskMapper(db: $this->connectionWith(rows: [['total' => '120']]));
 		$this->assertSame(120, $counted->countInbox(criteria: new TaskInboxCriteria(uid: 'alice')));
-		$this->assertTrue($this->saw('expr.eq', 'assignee'));
+		// An IN, not an eq: a typed assignee is stored as `type:id`, so the
+		// caller's identity expands to the few strings that mean them.
+		$this->assertTrue($this->saw('expr.in', 'assignee'));
 
 		$empty = new TaskMapper(db: $this->connectionWith(rows: []));
 		$this->assertSame(0, $empty->countInbox(criteria: new TaskInboxCriteria(uid: 'alice')));

--- a/tests/Unit/Db/TaskMapperRunAnchorTest.php
+++ b/tests/Unit/Db/TaskMapperRunAnchorTest.php
@@ -82,7 +82,7 @@ class TaskMapperRunAnchorTest extends TestCase {
 			);
 
 			$this->assertTrue($this->saw('expr.eq', 'run_uuid'), "$scope still anchors on the run");
-			$this->assertFalse($this->saw('expr.eq', 'assignee'), "$scope does not narrow a run view to the caller");
+			$this->assertFalse($this->saw('expr.in', 'assignee'), "$scope does not narrow a run view to the caller");
 		}
 	}//end testTheRunAnchorReplacesTheScopeNarrowing()
 
@@ -133,7 +133,7 @@ class TaskMapperRunAnchorTest extends TestCase {
 		$mapper->findInbox(criteria: new TaskInboxCriteria(uid: 'alice'));
 
 		$this->assertFalse($this->saw('expr.eq', 'run_uuid'), 'no run predicate without a run');
-		$this->assertTrue($this->saw('expr.eq', 'assignee'), 'the default scope still narrows to the caller');
+		$this->assertTrue($this->saw('expr.in', 'assignee'), 'the default scope still narrows to the caller');
 		$this->assertTrue($this->saw('expr.neq', 'performer_type'), 'and still excludes external tasks');
 	}//end testWithoutAnAnchorNothingAboutTheInboxChanges()
 }//end class

--- a/tests/Unit/Service/Flow/FlowRunAssigneeTypedTest.php
+++ b/tests/Unit/Service/Flow/FlowRunAssigneeTypedTest.php
@@ -287,6 +287,76 @@ final class FlowRunAssigneeTypedTest extends TestCase {
 	}//end testAnUnresolvableTypeRefuses()
 
 	/**
+	 * 🔴 AN AGENT'S STEP IS NOT ANSWERABLE BY THE HUMANS, AND VICE VERSA.
+	 *
+	 * The trap the single-identity rule exists for. If an agent reference
+	 * expanded through group membership, every human in that group could answer
+	 * the agent's step — and the agent could answer theirs.
+	 *
+	 * @return void
+	 */
+	public function testAnAgentStepIsNotAnswerableByTheHumansAroundIt(): void {
+		$agents = new RosterResolver('agent');
+		$agents->holders['scribe'] = ['scribe'];
+
+		$groups = $this->createMock(IGroupManager::class);
+		// Every human is in the committee, and the agent is not one of them.
+		$groups->method('isInGroup')->willReturn(true);
+
+		$assignee = new FlowRunAssignee($groups, $this->registryOf($agents));
+		$run = $this->runAssignedTo(['type' => 'agent', 'id' => 'scribe']);
+
+		$this->assertTrue($assignee->mayAnswer(run: $run, uid: 'scribe'));
+		$this->assertFalse(
+			$assignee->mayAnswer(run: $run, uid: 'alice'),
+			'a human must not answer for the agent, however many groups they share'
+		);
+	}//end testAnAgentStepIsNotAnswerableByTheHumansAroundIt()
+
+	/**
+	 * 🔴 AN UNANSWERED AGENT TASK, REASSIGNED TO A PERSON, IS THEIRS TO ANSWER.
+	 *
+	 * The escape hatch that makes an agent performer safe to use at all: when
+	 * the agent cannot or does not answer, a person takes it over, and the
+	 * guard follows the REASSIGNMENT rather than the original addressee.
+	 *
+	 * It works because the reference is re-read on every answer. A frozen
+	 * resolution would keep authorising the agent and keep refusing the person
+	 * who now owns the decision.
+	 *
+	 * @return void
+	 */
+	public function testAnAgentTaskReassignedToAPersonIsAnswerableByThatPerson(): void {
+		$people = new RosterResolver('user');
+		$people->holders['alice'] = ['alice'];
+		$agents = new RosterResolver('agent');
+		$agents->holders['scribe'] = ['scribe'];
+
+		$dispatcher = $this->createMock(IEventDispatcher::class);
+		$dispatcher->method('dispatchTyped')->willReturnCallback(
+			static function (Event $event) use ($people, $agents): void {
+				if (($event instanceof RegisterPrincipalResolversEvent) === true) {
+					$event->registerResolver($people);
+					$event->registerResolver($agents);
+				}
+			}
+		);
+		$registry = new PrincipalResolverRegistry($dispatcher, $this->createMock(LoggerInterface::class));
+		$assignee = new FlowRunAssignee(null, $registry);
+
+		// Raised for the agent…
+		$this->assertTrue(
+			$assignee->mayAnswer(run: $this->runAssignedTo(['type' => 'agent', 'id' => 'scribe']), uid: 'scribe')
+		);
+
+		// …and reassigned to a person, who may now answer it while the agent
+		// may not.
+		$reassigned = $this->runAssignedTo(['type' => 'user', 'id' => 'alice']);
+		$this->assertTrue($assignee->mayAnswer(run: $reassigned, uid: 'alice'));
+		$this->assertFalse($assignee->mayAnswer(run: $reassigned, uid: 'scribe'));
+	}//end testAnAgentTaskReassignedToAPersonIsAnswerableByThatPerson()
+
+	/**
 	 * `recordedFor()` still answers with a string for callers that want one.
 	 *
 	 * @return void

--- a/tests/Unit/Service/Flow/Principal/BuiltInResolversTest.php
+++ b/tests/Unit/Service/Flow/Principal/BuiltInResolversTest.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace Unit\Service\Flow\Principal;
 
 use OCA\OpenRegister\Listener\PrincipalResolverRegistrationListener;
+use OCA\OpenRegister\Service\Flow\Principal\AgentPrincipalResolver;
 use OCA\OpenRegister\Service\Flow\Principal\GroupPrincipalResolver;
 use OCA\OpenRegister\Service\Flow\Principal\PrincipalResolverRegistry;
 use OCA\OpenRegister\Service\Flow\Principal\RegisterPrincipalResolversEvent;
@@ -47,6 +48,7 @@ use Psr\Log\LoggerInterface;
  *
  * @covers \OCA\OpenRegister\Service\Flow\Principal\UserPrincipalResolver
  * @covers \OCA\OpenRegister\Service\Flow\Principal\GroupPrincipalResolver
+ * @covers \OCA\OpenRegister\Service\Flow\Principal\AgentPrincipalResolver
  * @covers \OCA\OpenRegister\Listener\PrincipalResolverRegistrationListener
  * @covers \OCA\OpenRegister\Service\Flow\Principal\RegisterPrincipalResolversEvent
  * @uses \OCA\OpenRegister\Service\Flow\Principal\PrincipalResolverRegistry
@@ -101,6 +103,61 @@ final class BuiltInResolversTest extends TestCase {
 
 		return new GroupPrincipalResolver($manager);
 	}//end groupResolver()
+
+	/**
+	 * An agent resolver over an instance holding the given identities.
+	 *
+	 * @param array<int, string> $existing The agent identities that exist.
+	 *
+	 * @return AgentPrincipalResolver The resolver.
+	 */
+	private function agentResolver(array $existing): AgentPrincipalResolver {
+		$users = $this->createMock(IUserManager::class);
+		$users->method('userExists')->willReturnCallback(
+			static fn (string $uid): bool => in_array($uid, $existing, true)
+		);
+
+		return new AgentPrincipalResolver($users);
+	}//end agentResolver()
+
+	/**
+	 * 🔴 AN AGENT RESOLVES TO EXACTLY ONE IDENTITY, NEVER THROUGH A GROUP.
+	 *
+	 * The whole safety property. If an agent reference expanded through group
+	 * membership, an agent's step would become answerable by every human in
+	 * that group — and a human's step by the agent. The two must not be able to
+	 * answer for each other.
+	 *
+	 * Asserted by giving the resolver NO group manager at all: it cannot
+	 * consult groups because it was never handed anything that could.
+	 *
+	 * @return void
+	 */
+	public function testAnAgentResolvesToOneIdentityAndNeverThroughAGroup(): void {
+		$resolver = $this->agentResolver(['scribe']);
+
+		$this->assertSame('agent', $resolver->type());
+		$this->assertSame(['scribe'], $resolver->resolve(id: 'scribe'));
+
+		// A group every human is in resolves to nothing here, because this
+		// resolver has no notion of groups whatsoever.
+		$this->assertSame([], $resolver->resolve(id: 'bezwaar'));
+	}//end testAnAgentResolvesToOneIdentityAndNeverThroughAGroup()
+
+	/**
+	 * An agent with no identity resolves to nobody.
+	 *
+	 * An agent completes its turn as a REAL identity or the step fails loudly,
+	 * rather than raising a task addressed to something that cannot log in.
+	 *
+	 * @return void
+	 */
+	public function testAnAgentWithNoIdentityResolvesToNobody(): void {
+		$resolver = $this->agentResolver(['scribe']);
+
+		$this->assertSame([], $resolver->resolve(id: 'no-such-agent'));
+		$this->assertSame([], $resolver->resolve(id: '  '));
+	}//end testAnAgentWithNoIdentityResolvesToNobody()
 
 	/**
 	 * A user that exists resolves to itself.
@@ -169,7 +226,8 @@ final class BuiltInResolversTest extends TestCase {
 	public function testTheBuiltInsRegisterThroughTheContributionEvent(): void {
 		$listener = new PrincipalResolverRegistrationListener(
 			$this->userResolver(['alice']),
-			$this->groupResolver(['bezwaar' => ['alice']])
+			$this->groupResolver(['bezwaar' => ['alice']]),
+			$this->agentResolver(['scribe'])
 		);
 
 		$dispatcher = $this->createMock(IEventDispatcher::class);
@@ -181,7 +239,7 @@ final class BuiltInResolversTest extends TestCase {
 
 		$registry = new PrincipalResolverRegistry($dispatcher, $this->createMock(LoggerInterface::class));
 
-		$this->assertSame(['group', 'user'], $registry->types());
+		$this->assertSame(['agent', 'group', 'user'], $registry->types());
 	}//end testTheBuiltInsRegisterThroughTheContributionEvent()
 
 	/**
@@ -194,7 +252,8 @@ final class BuiltInResolversTest extends TestCase {
 
 		$listener = new PrincipalResolverRegistrationListener(
 			$this->userResolver([]),
-			$this->groupResolver([])
+			$this->groupResolver([]),
+			$this->agentResolver([])
 		);
 
 		// Would fatal if it tried to register on something that is not the

--- a/tests/Unit/Service/Flow/Principal/PrincipalReferenceTest.php
+++ b/tests/Unit/Service/Flow/Principal/PrincipalReferenceTest.php
@@ -180,4 +180,60 @@ final class PrincipalReferenceTest extends TestCase {
 
 		$this->assertSame('group:bezwaar', (string)$reference);
 	}//end testTheLegacyValueSpellingIsStillRead()
+	/**
+	 * 🔴 A TYPED REFERENCE IS NEVER STORED AS THE LITERAL "Array".
+	 *
+	 * Casting a `{type, id}` map to a string yields "Array". That string went
+	 * into the task row and into the run's resume slot, where the answer guard
+	 * reads it as a legacy bare string, matches it against no uid and no group,
+	 * and leaves the task answerable by NOBODY.
+	 *
+	 * @return void
+	 */
+	public function testASingleReferenceIsStoredAsTypeAndId(): void {
+		$this->assertSame(
+			'group:bezwaar',
+			PrincipalReference::storedString(value: ['type' => 'group', 'id' => 'bezwaar'])
+		);
+	}//end testASingleReferenceIsStoredAsTypeAndId()
+
+	/**
+	 * A bare string passes through, trimmed.
+	 *
+	 * The anti-widening control: every flow ever authored names people that
+	 * way, and none of them may change meaning.
+	 *
+	 * @return void
+	 */
+	public function testABareStringIsStoredAsItself(): void {
+		$this->assertSame('alice', PrincipalReference::storedString(value: '  alice  '));
+	}//end testABareStringIsStoredAsItself()
+
+	/**
+	 * 🔑 SEVERAL REFERENCES ARE NOT ONE STORED VALUE.
+	 *
+	 * Picking one of them would silently drop the others and store whichever
+	 * happened to be first.
+	 *
+	 * @return void
+	 */
+	public function testSeveralReferencesStoreNothing(): void {
+		$this->assertSame(
+			'',
+			PrincipalReference::storedString(
+				value: [['type' => 'user', 'id' => 'alice'], ['type' => 'group', 'id' => 'bezwaar']]
+			)
+		);
+	}//end testSeveralReferencesStoreNothing()
+
+	/**
+	 * Nothing at all stores nothing.
+	 *
+	 * @return void
+	 */
+	public function testNothingStoresNothing(): void {
+		$this->assertSame('', PrincipalReference::storedString(value: null));
+		$this->assertSame('', PrincipalReference::storedString(value: []));
+	}//end testNothingStoresNothing()
+
 }//end class

--- a/tests/Unit/Service/Flow/UserTaskAgentPerformerTest.php
+++ b/tests/Unit/Service/Flow/UserTaskAgentPerformerTest.php
@@ -1,0 +1,266 @@
+<?php
+
+/**
+ * An agent is a performer of the SAME step, not a second mechanism beside it.
+ *
+ * 🔴 THE NODE DISPATCHES; IT NEVER INVOKES A RUNTIME. The engine has no business
+ * knowing how an agent runs, and naming the app that does would put a consuming
+ * app's name in OpenRegister. The app that owns agents listens, does the work,
+ * and completes the task through the ORDINARY verbs — the same guard, the same
+ * audit, the same outcome vocabulary a person's answer takes.
+ *
+ * ⚠️ THIS IS THE EVENT'S FIRST DISPATCHER. `AgentRunRequestedEvent` was
+ * declared and fired by nothing; an event nobody sends is a contract nobody can
+ * rely on.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Db\Task;
+use OCA\OpenRegister\Event\AgentRunRequestedEvent;
+use OCA\OpenRegister\Service\Flow\FlowNodeResumeState;
+use OCA\OpenRegister\Service\Flow\FlowResumeState;
+use OCA\OpenRegister\Service\Flow\FlowRunContext;
+use OCA\OpenRegister\Service\Flow\FlowSuspension;
+use OCA\OpenRegister\Service\Flow\FlowTaskBridge;
+use OCA\OpenRegister\Service\Flow\Timer\FlowTimerService;
+use OCA\OpenRegister\Service\Flow\Nodes\UserTaskNode;
+use OCA\OpenRegister\Service\Task\TaskForm;
+use OCA\OpenRegister\Service\Task\TaskFormReader;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The agent half of {@see UserTaskNode}.
+ *
+ * @covers \OCA\OpenRegister\Service\Flow\Nodes\UserTaskNode
+ * @uses \OCA\OpenRegister\Event\AgentRunRequestedEvent
+ * @uses \OCA\OpenRegister\Service\Flow\Principal\PrincipalReference
+ */
+final class UserTaskAgentPerformerTest extends TestCase {
+
+	/**
+	 * Every event the node dispatched.
+	 *
+	 * @var array<int, Event>
+	 */
+	private array $dispatched = [];
+
+	/**
+	 * A node wired to record what it dispatches.
+	 *
+	 * @return UserTaskNode The node.
+	 */
+	private function node(): UserTaskNode {
+		$bridge = $this->createMock(FlowTaskBridge::class);
+		$task = new Task();
+		$task->setUuid('task-1');
+		$task->setState(Task::STATE_ACTIVE);
+		$bridge->method('createTask')->willReturn($task);
+
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnArgument(0);
+
+		$forms = $this->createMock(TaskFormReader::class);
+		$forms->method('fromConfig')->willReturn(new TaskForm(kind: null));
+
+		$events = $this->createMock(IEventDispatcher::class);
+		$events->method('dispatchTyped')->willReturnCallback(
+			function (Event $event): void {
+				$this->dispatched[] = $event;
+			}
+		);
+
+		return new UserTaskNode(
+			$bridge,
+			$l10n,
+			$this->createMock(IURLGenerator::class),
+			$forms,
+			$this->createMock(FlowTimerService::class),
+			null,
+			$events
+		);
+	}//end node()
+
+	/**
+	 * Run the node once, swallowing the suspension it always raises.
+	 *
+	 * ⚠️ NOT named `run()`: that is FINAL on PHPUnit's TestCase and overriding
+	 * it is a fatal error, not a failing test.
+	 *
+	 * @param array<string, mixed> $config The step configuration.
+	 *
+	 * @return void
+	 */
+	private function executeStep(array $config): void {
+		$state = new FlowResumeState();
+
+		try {
+			$this->node()->execute(
+				[['json' => []]],
+				$config,
+				[
+					FlowResumeState::CONTEXT_KEY => $state,
+					FlowNodeResumeState::CONTEXT_KEY => $state->forNode(nodeId: 'ask'),
+					FlowRunContext::CONTEXT_RUN => 'run-1',
+					'runUuid' => 'run-1',
+					'flowName' => 'Approve it',
+				]
+			);
+		} catch (FlowSuspension) {
+			// Expected: the step waits for its answer, agent or person.
+		}
+	}//end run()
+
+	/**
+	 * The agent events the node dispatched.
+	 *
+	 * @return array<int, AgentRunRequestedEvent> The events.
+	 */
+	private function agentEvents(): array {
+		return array_values(
+			array_filter(
+				$this->dispatched,
+				static fn (Event $event): bool => $event instanceof AgentRunRequestedEvent
+			)
+		);
+	}//end agentEvents()
+
+	/**
+	 * 🔴 AN AGENT PERFORMER IS ASKED, WITH THE PROMPT IN PLACE OF A FORM.
+	 *
+	 * A person gets fields to fill in; an agent gets a prompt. Same step, same
+	 * completion verbs, same audit.
+	 *
+	 * @return void
+	 */
+	public function testAnAgentPerformerIsAskedWithItsPrompt(): void {
+		$this->executeStep(
+			[
+				'title' => 'Approve it',
+				'assignee' => ['type' => 'agent', 'id' => 'scribe'],
+				'prompt' => 'Summarise the objection and recommend a decision.',
+			]
+		);
+
+		$events = $this->agentEvents();
+		$this->assertCount(1, $events);
+		$this->assertSame('scribe', $events[0]->getAgent());
+		$this->assertSame('Summarise the objection and recommend a decision.', $events[0]->getPrompt());
+	}//end testAnAgentPerformerIsAskedWithItsPrompt()
+
+	/**
+	 * 🔴 A PERSON'S STEP DISPATCHES NOTHING.
+	 *
+	 * The anti-widening control. Every stored flow on every instance names a
+	 * person or a group, and none of them may start asking an agent because
+	 * this branch exists.
+	 *
+	 * @return void
+	 */
+	public function testAPersonsStepAsksNoAgent(): void {
+		$this->executeStep(['title' => 'Approve it', 'assignee' => 'alice']);
+		$this->assertSame([], $this->agentEvents());
+
+		$this->dispatched = [];
+		$this->executeStep(['title' => 'Approve it', 'assignee' => ['type' => 'group', 'id' => 'bezwaar']]);
+		$this->assertSame([], $this->agentEvents());
+	}//end testAPersonsStepAsksNoAgent()
+
+	/**
+	 * An agent asked nothing at all falls back to the step's title.
+	 *
+	 * An agent with an empty prompt cannot know what the step wanted, and a
+	 * blank instruction is the one input guaranteed to produce a useless turn.
+	 *
+	 * @return void
+	 */
+	public function testAnAgentWithNoPromptIsAskedTheTitle(): void {
+		$this->executeStep(['title' => 'Approve it', 'assignee' => ['type' => 'agent', 'id' => 'scribe']]);
+
+		$this->assertSame('Approve it', $this->agentEvents()[0]->getPrompt());
+	}//end testAnAgentWithNoPromptIsAskedTheTitle()
+
+	/**
+	 * 🔑 THE TASK IS CREATED FIRST, THE EVENT SECOND.
+	 *
+	 * The agent needs something to complete, and if nothing is listening the
+	 * task simply sits there — reassignable to a person like any other, which
+	 * is the escape hatch that makes an agent performer safe to use at all.
+	 *
+	 * @return void
+	 */
+	public function testTheEventCarriesTheTaskTheAgentMustComplete(): void {
+		$this->executeStep(['title' => 'Approve it', 'assignee' => ['type' => 'agent', 'id' => 'scribe']]);
+
+		$this->assertSame('task-1', $this->agentEvents()[0]->getSubjectUuid());
+	}//end testTheEventCarriesTheTaskTheAgentMustComplete()
+
+	/**
+	 * With no dispatcher, an agent step still raises its task.
+	 *
+	 * The node degrades to "a task nobody automated is doing", which a person
+	 * can still pick up. Refusing instead would make the whole step unusable on
+	 * a container-less path.
+	 *
+	 * @return void
+	 */
+	public function testWithoutADispatcherTheStepStillRaisesItsTask(): void {
+		$this->expectNotToPerformAssertions();
+
+		$bridge = $this->createMock(FlowTaskBridge::class);
+		$task = new Task();
+		$task->setUuid('task-1');
+		$task->setState(Task::STATE_ACTIVE);
+		$bridge->method('createTask')->willReturn($task);
+
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnArgument(0);
+		$forms = $this->createMock(TaskFormReader::class);
+		$forms->method('fromConfig')->willReturn(new TaskForm(kind: null));
+
+		$node = new UserTaskNode(
+			$bridge,
+			$l10n,
+			$this->createMock(IURLGenerator::class),
+			$forms,
+			$this->createMock(FlowTimerService::class)
+		);
+
+		$state = new FlowResumeState();
+
+		try {
+			$node->execute(
+				[['json' => []]],
+				['title' => 'Approve it', 'assignee' => ['type' => 'agent', 'id' => 'scribe']],
+				[
+					FlowResumeState::CONTEXT_KEY => $state,
+					FlowNodeResumeState::CONTEXT_KEY => $state->forNode(nodeId: 'ask'),
+					FlowRunContext::CONTEXT_RUN => 'run-1',
+					'runUuid' => 'run-1',
+				]
+			);
+		} catch (FlowSuspension) {
+			// Expected.
+		}
+	}//end testWithoutADispatcherTheStepStillRaisesItsTask()
+}//end class

--- a/tests/Unit/Service/Flow/UserTaskAgentPerformerTest.php
+++ b/tests/Unit/Service/Flow/UserTaskAgentPerformerTest.php
@@ -53,6 +53,7 @@ use PHPUnit\Framework\TestCase;
  * The agent half of {@see UserTaskNode}.
  *
  * @covers \OCA\OpenRegister\Service\Flow\Nodes\UserTaskNode
+ * @covers \OCA\OpenRegister\Service\Flow\Nodes\UserTaskPerformers
  * @uses \OCA\OpenRegister\Event\AgentRunRequestedEvent
  * @uses \OCA\OpenRegister\Service\Flow\Principal\PrincipalReference
  */

--- a/tests/Unit/Service/Flow/UserTaskAgentPerformerTest.php
+++ b/tests/Unit/Service/Flow/UserTaskAgentPerformerTest.php
@@ -48,6 +48,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 /**
  * The agent half of {@see UserTaskNode}.
@@ -264,4 +265,74 @@ final class UserTaskAgentPerformerTest extends TestCase {
 			// Expected.
 		}
 	}//end testWithoutADispatcherTheStepStillRaisesItsTask()
+
+	/**
+	 * 🔴 A TASK CANNOT BE CREATED OUTSIDE A PERSISTED RUN.
+	 *
+	 * The task carries the run uuid, and that is what lets an answer find its
+	 * way back to the run that asked. A task without one is unanswerable, so
+	 * the step fails rather than creating it.
+	 *
+	 * @return void
+	 */
+	public function testAStepOutsideAPersistedRunRefusesToCreateATask(): void {
+		$state = new FlowResumeState();
+
+		$this->expectException(RuntimeException::class);
+
+		$this->node()->execute(
+			[['json' => []]],
+			['title' => 'Approve it', 'assignee' => 'alice'],
+			[
+				FlowResumeState::CONTEXT_KEY => $state,
+				FlowNodeResumeState::CONTEXT_KEY => $state->forNode(nodeId: 'ask'),
+			]
+		);
+	}//end testAStepOutsideAPersistedRunRefusesToCreateATask()
+
+	/**
+	 * A run naming no acting identity still raises its task, unattributed.
+	 *
+	 * 🔑 `runAs` THEN `triggeredBy`, AND NULL WHEN NEITHER IS THERE. An
+	 * MCP-triggered run genuinely carries no identity, and refusing one would
+	 * make the step unusable on that path; the task simply records no actor.
+	 *
+	 * @return void
+	 */
+	public function testARunWithNoActingIdentityStillRaisesItsTask(): void {
+		$this->expectNotToPerformAssertions();
+
+		$state = new FlowResumeState();
+
+		try {
+			$this->node()->execute(
+				[['json' => []]],
+				['title' => 'Approve it', 'assignee' => 'alice'],
+				[
+					FlowResumeState::CONTEXT_KEY => $state,
+					FlowNodeResumeState::CONTEXT_KEY => $state->forNode(nodeId: 'ask'),
+					FlowRunContext::CONTEXT_RUN => 'run-1',
+					'runUuid' => 'run-1',
+				]
+			);
+		} catch (FlowSuspension) {
+			// Expected: the step waits for its answer.
+		}
+	}//end testARunWithNoActingIdentityStillRaisesItsTask()
+
+	/**
+	 * The step names itself in the palette, and carries an icon.
+	 *
+	 * A catalogue entry with no label reads as a blank row in the step picker.
+	 *
+	 * @return void
+	 */
+	public function testTheStepNamesItselfInThePalette(): void {
+		$node = $this->node();
+
+		$this->assertSame('Ask a person or group', $node->getDisplayName());
+		// The generator is a double here, so the VALUE is not the point: the
+		// contract is that the node answers a path rather than throwing.
+		$this->assertIsString($node->getIcon());
+	}//end testTheStepNamesItselfInThePalette()
 }//end class

--- a/tests/Unit/Service/Flow/UserTaskPerformersTest.php
+++ b/tests/Unit/Service/Flow/UserTaskPerformersTest.php
@@ -1,0 +1,438 @@
+<?php
+
+/**
+ * Who the step asks, and what asking them costs — tested directly.
+ *
+ * 🔴 THE MEASURED DEFECT, INVERTED. A step naming a group that has no members,
+ * or that does not exist, created a task addressed to nobody. The run
+ * suspended, a heartbeat re-read it every few minutes, and nothing said
+ * anything: the task existed, the run was healthy, and the approval simply
+ * never happened. Silence was the defect.
+ *
+ * ⚠️ TESTED HERE RATHER THAN ONLY THROUGH THE NODE. Reaching these two methods
+ * through `UserTaskNode` means wiring a whole task lifecycle, and the node
+ * fixtures that do it pass a null registry — so the interesting half of
+ * `refuseIfNobodyHoldsThem` was never executed by anything.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Db\Task;
+use OCA\OpenRegister\Event\AgentRunRequestedEvent;
+use OCA\OpenRegister\Service\Flow\Nodes\UserTaskConfig;
+use OCA\OpenRegister\Service\Flow\Nodes\UserTaskPerformers;
+use OCA\OpenRegister\Service\Flow\Principal\IPrincipalResolver;
+use OCA\OpenRegister\Service\Flow\Principal\PrincipalResolverRegistry;
+use OCA\OpenRegister\Service\Flow\Principal\RegisterPrincipalResolversEvent;
+use OCA\OpenRegister\Service\Task\TaskFormReader;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Lifecycle\TransitionEngine;
+use OCP\App\IAppManager;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IL10N;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Tests for {@see UserTaskPerformers}.
+ *
+ * @covers \OCA\OpenRegister\Service\Flow\Nodes\UserTaskPerformers
+ * @uses \OCA\OpenRegister\Service\Flow\Nodes\UserTaskConfig
+ * @uses \OCA\OpenRegister\Service\Flow\Principal\PrincipalResolverRegistry
+ * @uses \OCA\OpenRegister\Service\Flow\Principal\PrincipalReference
+ * @uses \OCA\OpenRegister\Service\Task\TaskForm
+ * @uses \OCA\OpenRegister\Service\Flow\Principal\RegisterPrincipalResolversEvent
+ * @uses \OCA\OpenRegister\Event\AgentRunRequestedEvent
+ * @uses \OCA\OpenRegister\Service\Task\TaskFormReader
+ * @uses \OCA\OpenRegister\Db\Task
+ */
+final class UserTaskPerformersTest extends TestCase {
+
+	/**
+	 * Every event the performers dispatched.
+	 *
+	 * @var array<int, Event>
+	 */
+	private array $dispatched = [];
+
+	/**
+	 * A resolver that answers for one type, with the holders it is given.
+	 *
+	 * @param string             $type    The type it answers for.
+	 * @param array<int, string> $holders Who currently holds any id of that type.
+	 *
+	 * @return IPrincipalResolver The resolver.
+	 */
+	private function resolver(string $type, array $holders): IPrincipalResolver {
+		return new class($type, $holders) implements IPrincipalResolver {
+
+			/**
+			 * Constructor.
+			 *
+			 * @param string             $type    The type.
+			 * @param array<int, string> $holders The holders.
+			 */
+			public function __construct(
+				private readonly string $type,
+				private readonly array $holders,
+			) {
+			}
+
+			/**
+			 * The type this resolver answers for.
+			 *
+			 * @return string The type.
+			 */
+			public function type(): string {
+				return $this->type;
+			}
+
+			/**
+			 * Who holds it.
+			 *
+			 * @param string $id The reference id.
+			 *
+			 * @return array<int, string> The holders.
+			 */
+			public function resolve(string $id): array {
+				return $this->holders;
+			}
+		};
+	}//end resolver()
+
+	/**
+	 * A registry offering the given resolvers.
+	 *
+	 * @param array<int, IPrincipalResolver> $resolvers The resolvers.
+	 *
+	 * @return PrincipalResolverRegistry The registry.
+	 */
+	private function registry(array $resolvers): PrincipalResolverRegistry {
+		$dispatcher = $this->createMock(IEventDispatcher::class);
+		$dispatcher->method('dispatchTyped')->willReturnCallback(
+			static function (Event $event) use ($resolvers): void {
+				if (($event instanceof RegisterPrincipalResolversEvent) === false) {
+					return;
+				}
+
+				foreach ($resolvers as $resolver) {
+					$event->registerResolver($resolver);
+				}
+			}
+		);
+
+		return new PrincipalResolverRegistry($dispatcher, $this->createMock(LoggerInterface::class));
+	}//end registry()
+
+	/**
+	 * A form reader with no collaborators of consequence.
+	 *
+	 * ⚠️ The real reader, not a double: `TaskForm` is FINAL, so PHPUnit cannot
+	 * generate a return value for `fromConfig()` and the auto-stub throws.
+	 *
+	 * @return TaskFormReader The reader.
+	 */
+	private function formReader(): TaskFormReader {
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnArgument(0);
+
+		return new TaskFormReader(
+			$this->createMock(SchemaMapper::class),
+			$this->createMock(TransitionEngine::class),
+			$this->createMock(IAppManager::class),
+			$l10n
+		);
+	}//end formReader()
+
+	/**
+	 * The performers, over a registry and a recording dispatcher.
+	 *
+	 * @param PrincipalResolverRegistry|null $registry    The registry, or none.
+	 * @param boolean                        $withEvents  Whether a dispatcher is wired.
+	 *
+	 * @return UserTaskPerformers The subject.
+	 */
+	private function performers(?PrincipalResolverRegistry $registry, bool $withEvents = true): UserTaskPerformers {
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnArgument(0);
+
+		$events = null;
+		if ($withEvents === true) {
+			$events = $this->createMock(IEventDispatcher::class);
+			$events->method('dispatchTyped')->willReturnCallback(
+				function (Event $event): void {
+					$this->dispatched[] = $event;
+				}
+			);
+		}
+
+		return new UserTaskPerformers(
+			config: new UserTaskConfig(l10n: $l10n, forms: $this->formReader(), principals: $registry),
+			principals: $registry,
+			events: $events
+		);
+	}//end performers()
+
+	/**
+	 * The task an agent would be asked to complete.
+	 *
+	 * @return Task The task.
+	 */
+	private function aTask(): Task {
+		$task = new Task();
+		$task->setUuid('task-1');
+		$task->setState(Task::STATE_ACTIVE);
+
+		return $task;
+	}//end aTask()
+
+	/**
+	 * The agent events dispatched so far.
+	 *
+	 * @return array<int, AgentRunRequestedEvent> The events.
+	 */
+	private function agentEvents(): array {
+		return array_values(
+			array_filter(
+				$this->dispatched,
+				static fn (Event $event): bool => $event instanceof AgentRunRequestedEvent
+			)
+		);
+	}//end agentEvents()
+
+	/**
+	 * 🔴 A STEP WHOSE PERFORMERS RESOLVE TO NOBODY FAILS, LOUDLY.
+	 *
+	 * A loud step failure is strictly better than silence even when the author
+	 * chooses to continue past it, because it is subject to the flow's own
+	 * `onError` policy — which is a decision the author gets to make, and
+	 * silence is not.
+	 *
+	 * @return void
+	 */
+	public function testAStepNobodyCanPerformIsRefusedNamingWhoItAsked(): void {
+		$performers = $this->performers($this->registry([$this->resolver('group', [])]));
+
+		try {
+			$performers->refuseIfNobodyHoldsThem(['assignee' => ['type' => 'group', 'id' => 'bezwaar']]);
+			$this->fail('a task addressed to nobody should be refused');
+		} catch (RuntimeException $e) {
+			$this->assertStringContainsString('bezwaar', $e->getMessage(), 'the refusal names who it asked');
+			$this->assertStringContainsString('nobody', $e->getMessage());
+		}
+	}//end testAStepNobodyCanPerformIsRefusedNamingWhoItAsked()
+
+	/**
+	 * A performer somebody holds raises no objection.
+	 *
+	 * @return void
+	 */
+	public function testAPerformerSomebodyHoldsIsAccepted(): void {
+		$this->expectNotToPerformAssertions();
+
+		$this->performers($this->registry([$this->resolver('group', ['alice'])]))
+			->refuseIfNobodyHoldsThem(['assignee' => ['type' => 'group', 'id' => 'bezwaar']]);
+	}//end testAPerformerSomebodyHoldsIsAccepted()
+
+	/**
+	 * 🔑 AN UNASSIGNED STEP IS DELIBERATELY OPEN, and refusing one would close
+	 * a door the spec holds open.
+	 *
+	 * @return void
+	 */
+	public function testAStepNamingNobodyAtAllIsNotRefusedHere(): void {
+		$this->expectNotToPerformAssertions();
+
+		$this->performers($this->registry([$this->resolver('group', [])]))
+			->refuseIfNobodyHoldsThem(['title' => 'Approve it']);
+	}//end testAStepNamingNobodyAtAllIsNotRefusedHere()
+
+	/**
+	 * 🔴 WITHOUT A REGISTRY NOTHING IS REFUSED.
+	 *
+	 * An instance that cannot resolve at all must not start failing every step
+	 * that names a group: it has no basis for the claim that nobody holds it.
+	 *
+	 * @return void
+	 */
+	public function testWithoutARegistryNothingIsRefused(): void {
+		$this->expectNotToPerformAssertions();
+
+		$this->performers(null)
+			->refuseIfNobodyHoldsThem(['assignee' => ['type' => 'group', 'id' => 'bezwaar']]);
+	}//end testWithoutARegistryNothingIsRefused()
+
+	/**
+	 * Only one of several performers needs a holder.
+	 *
+	 * The step is performable as long as somebody can perform it, and refusing
+	 * because one of three named groups is empty would be wrong.
+	 *
+	 * @return void
+	 */
+	public function testOneHolderAmongSeveralIsEnough(): void {
+		$this->expectNotToPerformAssertions();
+
+		$registry = $this->registry([$this->resolver('group', []), $this->resolver('user', ['alice'])]);
+
+		$this->performers($registry)->refuseIfNobodyHoldsThem(
+			['candidateGroups' => ['bezwaar'], 'candidateUsers' => ['alice']]
+		);
+	}//end testOneHolderAmongSeveralIsEnough()
+
+	/**
+	 * 🔴 AN AGENT PERFORMER IS ASKED, WITH A PROMPT IN PLACE OF A FORM.
+	 *
+	 * It dispatches; it never invokes a runtime. The app that owns agents
+	 * listens, does the work, and completes the task through the ordinary
+	 * verbs — the same guard, the same audit, the same outcome vocabulary a
+	 * person's answer takes.
+	 *
+	 * @return void
+	 */
+	public function testAnAgentIsAskedWithItsPrompt(): void {
+		$this->performers(null)->askAnyAgent(
+			config: [
+				'title' => 'Approve it',
+				'assignee' => ['type' => 'agent', 'id' => 'scribe'],
+				'prompt' => 'Summarise the objection.',
+				'outcomeKey' => 'advice',
+				'requiresApproval' => true,
+			],
+			task: $this->aTask(),
+			context: ['flowName' => 'Bezwaar']
+		);
+
+		$events = $this->agentEvents();
+		$this->assertCount(1, $events);
+		$this->assertSame('scribe', $events[0]->getAgent());
+		$this->assertSame('Summarise the objection.', $events[0]->getPrompt());
+		$this->assertSame('task-1', $events[0]->getSubjectUuid(), 'the agent is given the task to complete');
+	}//end testAnAgentIsAskedWithItsPrompt()
+
+	/**
+	 * An agent asked nothing at all falls back to the step's title.
+	 *
+	 * A blank instruction is the one input guaranteed to produce a useless turn.
+	 *
+	 * @return void
+	 */
+	public function testAnAgentWithNoPromptIsAskedTheTitle(): void {
+		$this->performers(null)->askAnyAgent(
+			config: ['title' => 'Approve it', 'assignee' => ['type' => 'agent', 'id' => 'scribe']],
+			task: $this->aTask(),
+			context: []
+		);
+
+		$this->assertSame('Approve it', $this->agentEvents()[0]->getPrompt());
+	}//end testAnAgentWithNoPromptIsAskedTheTitle()
+
+	/**
+	 * 🔴 A PERSON'S STEP DISPATCHES NOTHING.
+	 *
+	 * The anti-widening control. Every stored flow on every instance names a
+	 * person or a group, and none of them may start asking an agent because
+	 * this branch exists.
+	 *
+	 * @return void
+	 */
+	public function testAPersonsStepAsksNoAgent(): void {
+		$performers = $this->performers(null);
+
+		$performers->askAnyAgent(
+			config: ['title' => 'Approve it', 'assignee' => 'alice'],
+			task: $this->aTask(),
+			context: []
+		);
+		$performers->askAnyAgent(
+			config: ['title' => 'Approve it', 'assignee' => ['type' => 'group', 'id' => 'bezwaar']],
+			task: $this->aTask(),
+			context: []
+		);
+
+		$this->assertSame([], $this->agentEvents());
+	}//end testAPersonsStepAsksNoAgent()
+
+	/**
+	 * An agent among several performers is still the one asked.
+	 *
+	 * @return void
+	 */
+	public function testAnAgentAmongSeveralPerformersIsFound(): void {
+		$this->performers(null)->askAnyAgent(
+			config: [
+				'title' => 'Approve it',
+				'assignee' => [
+					['type' => 'user', 'id' => 'alice'],
+					['type' => 'agent', 'id' => 'scribe'],
+				],
+			],
+			task: $this->aTask(),
+			context: []
+		);
+
+		$this->assertSame('scribe', $this->agentEvents()[0]->getAgent());
+	}//end testAnAgentAmongSeveralPerformersIsFound()
+
+	/**
+	 * 🔴 WITH NO DISPATCHER THE STEP STILL RAISES ITS TASK.
+	 *
+	 * The node degrades to "a task nobody automated is doing", which a person
+	 * can still pick up. Refusing instead would make the whole step unusable on
+	 * a container-less path.
+	 *
+	 * @return void
+	 */
+	public function testWithoutADispatcherNothingIsAskedAndNothingFails(): void {
+		$this->performers(null, withEvents: false)->askAnyAgent(
+			config: ['title' => 'Approve it', 'assignee' => ['type' => 'agent', 'id' => 'scribe']],
+			task: $this->aTask(),
+			context: []
+		);
+
+		$this->assertSame([], $this->agentEvents());
+	}//end testWithoutADispatcherNothingIsAskedAndNothingFails()
+
+	/**
+	 * The event carries the step's own subject and mode, not defaults.
+	 *
+	 * @return void
+	 */
+	public function testTheEventCarriesTheStepsOwnFields(): void {
+		$this->performers(null)->askAnyAgent(
+			config: [
+				'title' => 'Approve it',
+				'assignee' => ['type' => 'agent', 'id' => 'scribe'],
+				'subjectRegister' => 'cases',
+				'subjectSchema' => 'case',
+				'mode' => 'chat',
+				'skill' => 'summarise',
+			],
+			task: $this->aTask(),
+			context: ['flowName' => 'Bezwaar']
+		);
+
+		$event = $this->agentEvents()[0];
+		$this->assertSame('cases', $event->getSubjectRegister());
+		$this->assertSame('case', $event->getSubjectSchema());
+		$this->assertSame('Bezwaar', $event->getFlowName());
+	}//end testTheEventCarriesTheStepsOwnFields()
+}//end class

--- a/tests/Unit/Service/Flow/UserTaskTypedPerformersTest.php
+++ b/tests/Unit/Service/Flow/UserTaskTypedPerformersTest.php
@@ -82,6 +82,7 @@ class KnownTypeResolver implements IPrincipalResolver {
  * The typed half of {@see UserTaskConfig}.
  *
  * @covers \OCA\OpenRegister\Service\Flow\Nodes\UserTaskConfig
+ * @covers \OCA\OpenRegister\Service\Flow\Nodes\UserTaskPerformers
  * @uses \OCA\OpenRegister\Service\Flow\Principal\PrincipalReference
  * @uses \OCA\OpenRegister\Service\Flow\Principal\PrincipalResolverRegistry
  * @uses \OCA\OpenRegister\Service\Flow\Principal\RegisterPrincipalResolversEvent

--- a/tests/Unit/Service/Flow/UserTaskTypedPerformersTest.php
+++ b/tests/Unit/Service/Flow/UserTaskTypedPerformersTest.php
@@ -312,4 +312,96 @@ final class UserTaskTypedPerformersTest extends TestCase {
 
 		$this->configReader()->validate(['title' => 'Approve it']);
 	}//end testAStepNamingNobodyIsStillRefused()
+
+	/**
+	 * 🔴 A TYPED ASSIGNEE IS NEVER FLATTENED INTO THE STRING "Array".
+	 *
+	 * Casting a `{type, id}` map to a string yields the literal "Array", and
+	 * that string was written into the task row and into the run's resume slot.
+	 * The answer guard reads a bare string as the old "uid OR group" union,
+	 * matches "Array" against no uid and no group, and leaves the task
+	 * answerable by NOBODY — the exact silence this capability exists to
+	 * remove, reintroduced by a cast.
+	 *
+	 * @return void
+	 */
+	public function testATypedAssigneeIsNotFlattenedIntoTheWordArray(): void {
+		$config = ['title' => 'Approve it', 'assignee' => ['type' => 'group', 'id' => 'bezwaar']];
+
+		$this->assertSame('group:bezwaar', $this->configReader()->assignee(config: $config));
+	}//end testATypedAssigneeIsNotFlattenedIntoTheWordArray()
+
+	/**
+	 * 🔑 `type:id` IS WHAT THE TASK ROW HOLDS, so the inbox can predicate on it
+	 * in the datastore. The resolver decides authorisation, not listing: an
+	 * inbox that resolved a reference per row would resolve it a hundred times
+	 * a page.
+	 *
+	 * @return void
+	 */
+	public function testASingleTypedAssigneeIsRenderedAsTypeAndId(): void {
+		$this->assertSame(
+			'user:alice',
+			$this->configReader()->assignee(
+				config: ['title' => 'Approve it', 'assignee' => ['type' => 'user', 'id' => 'alice']]
+			)
+		);
+	}//end testASingleTypedAssigneeIsRenderedAsTypeAndId()
+
+	/**
+	 * 🔴 SEVERAL REFERENCES ARE NOT AN ASSIGNEE, THEY ARE CANDIDATES.
+	 *
+	 * The column holds one value. Picking one of several would silently drop
+	 * the others and assign the task to whichever happened to be first, so the
+	 * column stays empty and the task pools.
+	 *
+	 * @return void
+	 */
+	public function testSeveralTypedReferencesLeaveTheTaskPooled(): void {
+		$this->assertSame(
+			'',
+			$this->configReader()->assignee(
+				config: [
+					'title' => 'Approve it',
+					'assignee' => [
+						['type' => 'user', 'id' => 'alice'],
+						['type' => 'group', 'id' => 'bezwaar'],
+					],
+				]
+			)
+		);
+	}//end testSeveralTypedReferencesLeaveTheTaskPooled()
+
+	/**
+	 * 🔑 THE SLOT KEEPS THE REFERENCE'S SHAPE, because the shape is the meaning.
+	 *
+	 * `FlowRunAssignee::mayAnswer()` reads a bare string as the wider union and
+	 * a typed reference as exactly what it says. Flattening either one here
+	 * would take that decision away from the only place that can make it.
+	 *
+	 * @return void
+	 */
+	public function testTheSlotKeepsATypedReferencesShape(): void {
+		$typed = ['type' => 'group', 'id' => 'bezwaar'];
+
+		$this->assertSame(
+			$typed,
+			$this->configReader()->assigneeValue(config: ['title' => 'Approve it', 'assignee' => $typed])
+		);
+	}//end testTheSlotKeepsATypedReferencesShape()
+
+	/**
+	 * A bare string assignee still reads as itself, trimmed.
+	 *
+	 * The anti-widening control: every stored flow on every instance names a
+	 * performer by bare string, and none of them may change meaning.
+	 *
+	 * @return void
+	 */
+	public function testABareStringAssigneeIsUnchanged(): void {
+		$config = ['title' => 'Approve it', 'assignee' => '  alice  '];
+
+		$this->assertSame('alice', $this->configReader()->assignee(config: $config));
+		$this->assertSame('alice', $this->configReader()->assigneeValue(config: $config));
+	}//end testABareStringAssigneeIsUnchanged()
 }//end class


### PR DESCRIPTION
## An agent is a performer of the same step

You can now address the ask-a-person step to an agent. It is the **same** step: the agent completes its task through the ordinary verbs, past the same guard, into the same audit, against the same outcome vocabulary a person's answer takes. The only difference is what it is handed — a person gets fields to fill in, an agent gets a **prompt**.

## One identity, never a group

🔴 The safety property this whole section turns on. The answer guard compares the acting uid against what a reference resolves to, so if an agent reference ever expanded through group membership, the agent's step would become answerable by every human in that group — and, the other way round, a human's step by the agent.

The `agent` resolver has no notion of groups at all, which is **asserted** rather than assumed. An agent with no real identity resolves to nobody, and the step then fails loudly rather than raising a task addressed to something that cannot log in — reusing the refusal built for an empty group, deliberately, because they are the same fact.

## The node dispatches; it never invokes a runtime

The engine has no business knowing how an agent runs, and naming the app that does would put a consuming app's name in OpenRegister (gate-27, ADR-022).

The task is created **first** and the event second, so if nothing is listening the task simply sits there — reassignable to a person like any other. That is the escape hatch that makes an agent performer safe to use at all, and it is asserted: an unanswered agent task reassigned to a person is answerable by that person and no longer by the agent.

⚠️ **This is `AgentRunRequestedEvent`'s first dispatcher.** It was declared and fired by nothing; an event nobody sends is a contract nobody can rely on.

## One refactor, not a suppression

`UserTaskNode` tipped to complexity 53 doing this, so the two performer questions moved out whole into `UserTaskPerformers` rather than taking a suppression. The node orchestrates a task's lifecycle; this decides who the task is for. Both of its questions are asked at creation time for the same reason — that is the moment somebody actually has to be found.

## Evidence

- 7 tests, **each seen red by mutating the implementation**: dispatching for every performer rather than only agents fails 1 (the widening that would make every stored flow start calling an agent), and sending an empty prompt fails 2.
- 1,528 flow and task unit tests green.
- phpcs, phpmd, psalm, phpstan and gate-16 clean.
