### PR TITLE
feat(flow): type the stored performer strings that are certain, report the rest

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -40,7 +40,7 @@ Open Register drijft apps zoals OpenCatalogi, Procest, Pipelinq en Software Cata
 
 Vrij en open source onder de EUPL-licentie.
     ]]></description>
-    <version>2.0.18-unstable.20260907112751</version>
+    <version>2.0.18-unstable.20260907162700</version>
     <licence>EUPL-1.2</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>OpenRegister</namespace>
@@ -201,6 +201,14 @@ Vrij en open source onder de EUPL-licentie.
 			     published versions in ordinal order and marks them
 			     `backfill`, because it cannot know which were breaking. -->
 			<step>OCA\OpenRegister\Repair\BackfillFlowSemanticVersions</step>
+			<!-- AFTER the flows exist and BEFORE nothing in particular: it
+			     rewrites a stored performer STRING as a typed reference, but
+			     only where exactly one kind of thing answers to that name. An
+			     ambiguous or unresolvable one is reported by name and left
+			     exactly as it is — the guard still reads a bare string under
+			     its old, wider meaning, so nothing regresses by not touching
+			     it, and narrowing who may answer is a person's decision. -->
+			<step>OCA\OpenRegister\Repair\TypePerformerReferences</step>
 			<step>OCA\OpenRegister\Repair\BackfillFlowTriggerIndex</step>
 			<step>OCA\OpenRegister\Repair\InitializeFlowActions</step>
 			<step>OCA\OpenRegister\Repair\MigrateNotificationSubscriptionsToUserConfig</step>
@@ -322,6 +330,14 @@ Vrij en open source onder de EUPL-licentie.
 			     published versions in ordinal order and marks them
 			     `backfill`, because it cannot know which were breaking. -->
 			<step>OCA\OpenRegister\Repair\BackfillFlowSemanticVersions</step>
+			<!-- AFTER the flows exist and BEFORE nothing in particular: it
+			     rewrites a stored performer STRING as a typed reference, but
+			     only where exactly one kind of thing answers to that name. An
+			     ambiguous or unresolvable one is reported by name and left
+			     exactly as it is — the guard still reads a bare string under
+			     its old, wider meaning, so nothing regresses by not touching
+			     it, and narrowing who may answer is a person's decision. -->
+			<step>OCA\OpenRegister\Repair\TypePerformerReferences</step>
 			<step>OCA\OpenRegister\Repair\BackfillFlowTriggerIndex</step>
 			<step>OCA\OpenRegister\Repair\InitializeFlowActions</step>
 			<step>OCA\OpenRegister\Repair\SeedDirectoryVirtualSchemas</step>

--- a/lib/Repair/TypePerformerReferences.php
+++ b/lib/Repair/TypePerformerReferences.php
@@ -1,0 +1,493 @@
+<?php
+
+/**
+ * Give every stored performer string a type — but only where it is certain.
+ *
+ * A stored `"bezwaar"` means a user OR a group, because the guard it was
+ * written against tried both. This step resolves each string once and rewrites
+ * it as `{type, id}` where exactly one kind of thing answers to that name.
+ *
+ * 🔴 THREE OUTCOMES, AND ONLY ONE OF THEM MAY BE ACTED ON.
+ *
+ *   resolves under exactly one type → rewrite; the string meant that
+ *   resolves under more than one    → LEAVE IT, and report
+ *   resolves under no type          → LEAVE IT, and report
+ *
+ * The ambiguous case is not hypothetical. An instance may hold a user AND a
+ * group of one name, and today's guard accepts BOTH — so today's behaviour is
+ * genuinely the union, and any rewrite NARROWS it. Narrowing who may answer an
+ * approval is a decision for a person, not for a repair step running unattended
+ * during an upgrade.
+ *
+ * 🔴 IT MUST NOT FAIL AN UPGRADE. On the measured instance 27 stored strings
+ * resolve to nothing at all. Those flows were broken before this step existed,
+ * and a repair that turns pre-existing breakage into a failed `occ upgrade`
+ * makes it everybody's problem instead of their owner's. Every unresolvable
+ * string is reported by name and left exactly as it is.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Repair
+ * @package  OCA\OpenRegister\Repair
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md#requirement-stored-assignee-strings-are-migrated-once-and-what-cannot-be-migrated-is-reported
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Repair;
+
+use OCA\OpenRegister\Db\Flow;
+use OCA\OpenRegister\Db\FlowMapper;
+use OCA\OpenRegister\Service\Flow\Principal\PrincipalReference;
+use OCA\OpenRegister\Service\Flow\Principal\PrincipalResolverRegistry;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Rewrites unambiguous performer strings as typed references.
+ */
+class TypePerformerReferences implements IRepairStep {
+
+	/**
+	 * The performer fields, and the type a bare entry in each already means.
+	 *
+	 * 🔑 THE FIELD NAME IS EVIDENCE. `candidateGroups` holds group names and
+	 * always did, so its entries are not ambiguous at all: they need no
+	 * resolution and no guess. Only the fields whose name says nothing about
+	 * the kind are resolved.
+	 *
+	 * @var array<string, string|null>
+	 */
+	private const FIELDS = [
+		'assignee' => null,
+		'routingFallback' => null,
+		'candidateUsers' => 'user',
+		'candidateGroups' => 'group',
+		'candidateRole' => 'group',
+	];
+
+	/**
+	 * Constructor.
+	 *
+	 * Resolved lazily from the container, like the other flow repair steps:
+	 * this runs during install and upgrade, when the flow tables may not exist
+	 * yet, and a constructor-injected mapper would make that a fatal rather
+	 * than a skip.
+	 *
+	 * @param ContainerInterface $container The app container.
+	 * @param LoggerInterface    $logger    Diagnostics.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md#requirement-stored-assignee-strings-are-migrated-once-and-what-cannot-be-migrated-is-reported
+	 */
+	public function __construct(
+		private readonly ContainerInterface $container,
+		private readonly LoggerInterface $logger,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * The step's name, as `occ upgrade` prints it.
+	 *
+	 * @return string The name.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md#requirement-stored-assignee-strings-are-migrated-once-and-what-cannot-be-migrated-is-reported
+	 */
+	public function getName(): string {
+		return 'Give stored flow performers an explicit type';
+	}//end getName()
+
+	/**
+	 * Rewrite what is certain; report what is not.
+	 *
+	 * @param IOutput $output Migration output.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md#requirement-stored-assignee-strings-are-migrated-once-and-what-cannot-be-migrated-is-reported
+	 */
+	public function run(IOutput $output): void {
+		try {
+			$flows = $this->container->get(FlowMapper::class);
+			$principals = $this->container->get(PrincipalResolverRegistry::class);
+		} catch (Throwable $e) {
+			// The tables may not exist yet on a fresh install. Nothing to
+			// rewrite is not a failure.
+			$output->info('Flow performer typing skipped: ' . $e->getMessage());
+			return;
+		}
+
+		$rewritten = 0;
+		$ambiguous = [];
+		$unresolvable = [];
+
+		foreach ($this->everyFlow(flows: $flows) as $flow) {
+			try {
+				$rewritten += $this->typeOneFlow(
+					flow: $flow,
+					flows: $flows,
+					principals: $principals,
+					ambiguous: $ambiguous,
+					unresolvable: $unresolvable
+				);
+			} catch (Throwable $e) {
+				// One unreadable flow must not stop the rest, and must not
+				// fail the upgrade.
+				$this->logger->warning(
+					message: '[TypePerformerReferences] Could not type flow "'
+						. (string)$flow->getUuid() . '": ' . $e->getMessage(),
+					context: ['file' => __FILE__, 'line' => __LINE__]
+				);
+			}
+		}
+
+		$output->info(sprintf('Typed %d stored performer(s).', $rewritten));
+		$this->report(output: $output, ambiguous: $ambiguous, unresolvable: $unresolvable);
+
+	}//end run()
+
+	/**
+	 * Say what was left alone, and why.
+	 *
+	 * 🔑 EACH ONE BY NAME, WITH ITS REASON. "3 could not be migrated" tells
+	 * nobody which flow to open, and a report nobody can act on is the same as
+	 * no report.
+	 *
+	 * @param IOutput            $output       Migration output.
+	 * @param array<int, string> $ambiguous    Strings naming more than one kind.
+	 * @param array<int, string> $unresolvable Strings naming nothing at all.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md#requirement-stored-assignee-strings-are-migrated-once-and-what-cannot-be-migrated-is-reported
+	 */
+	private function report(IOutput $output, array $ambiguous, array $unresolvable): void {
+		foreach ($ambiguous as $line) {
+			$output->warning(
+				'AMBIGUOUS, left as it is: ' . $line
+					. '. Today both may answer, so choosing one would silently narrow who can. Set the type by hand.'
+			);
+		}
+
+		foreach ($unresolvable as $line) {
+			$output->warning(
+				'UNRESOLVABLE, left as it is: ' . $line
+					. '. Nothing on this instance answers to that name; the flow was already broken before this step ran.'
+			);
+		}
+
+	}//end report()
+
+	/**
+	 * Every flow, paged.
+	 *
+	 * 🔴 `findAllFlows()` DEFAULTS TO 100. A single call would silently type
+	 * the first hundred flows and leave the rest, reporting success.
+	 *
+	 * @param FlowMapper $flows The mapper.
+	 *
+	 * @return array<int, Flow> Every flow.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md#requirement-stored-assignee-strings-are-migrated-once-and-what-cannot-be-migrated-is-reported
+	 */
+	private function everyFlow(FlowMapper $flows): array {
+		$page = 500;
+		$offset = 0;
+		$all = [];
+
+		while (true) {
+			$batch = $flows->findAllFlows(limit: $page, offset: $offset);
+			$all = array_merge($all, $batch);
+
+			if (count($batch) < $page) {
+				return $all;
+			}
+
+			$offset += $page;
+		}
+
+	}//end everyFlow()
+
+	/**
+	 * Type one flow's performer strings, in place.
+	 *
+	 * @param Flow                      $flow         The flow.
+	 * @param FlowMapper                $flows        The mapper, to store the result.
+	 * @param PrincipalResolverRegistry $principals   Resolves a candidate type.
+	 * @param array<int, string>        $ambiguous    Collects what named more than one kind.
+	 * @param array<int, string>        $unresolvable Collects what named nothing.
+	 *
+	 * @return int How many strings were rewritten.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md#requirement-stored-assignee-strings-are-migrated-once-and-what-cannot-be-migrated-is-reported
+	 */
+	private function typeOneFlow(
+		Flow $flow,
+		FlowMapper $flows,
+		PrincipalResolverRegistry $principals,
+		array &$ambiguous,
+		array &$unresolvable
+	): int {
+		$nodes = ($flow->getNodes() ?? []);
+		if (is_array($nodes) === false || $nodes === []) {
+			return 0;
+		}
+
+		$rewritten = 0;
+		$changed = false;
+
+		foreach ($nodes as $index => $node) {
+			if (is_array($node) === false || is_array(($node['config'] ?? null)) === false) {
+				continue;
+			}
+
+			foreach (self::FIELDS as $field => $impliedType) {
+				$value = ($node['config'][$field] ?? null);
+				$typed = $this->typeValue(
+					value: $value,
+					impliedType: $impliedType,
+					principals: $principals,
+					where: (string)$flow->getUuid() . ' step "' . (string)($node['id'] ?? '?') . '" field "' . $field . '"',
+					ambiguous: $ambiguous,
+					unresolvable: $unresolvable,
+					rewritten: $rewritten
+				);
+
+				if ($typed !== null) {
+					$nodes[$index]['config'][$field] = $typed;
+					$changed = true;
+				}
+			}
+		}
+
+		if ($changed === true) {
+			$flow->setNodes($nodes);
+			$flows->update($flow);
+		}
+
+		return $rewritten;
+
+	}//end typeOneFlow()
+
+	/**
+	 * The typed replacement for one stored value, or null to leave it alone.
+	 *
+	 * @param mixed                     $value        What is stored.
+	 * @param string|null               $impliedType  The type the field name already implies.
+	 * @param PrincipalResolverRegistry $principals   Resolves a candidate type.
+	 * @param string                    $where        Where it was found, for the report.
+	 * @param array<int, string>        $ambiguous    Collects what named more than one kind.
+	 * @param array<int, string>        $unresolvable Collects what named nothing.
+	 * @param int                       $rewritten    Counts the rewrites.
+	 *
+	 * @return mixed The replacement, or null when nothing should change.
+	 *
+	 * @SuppressWarnings(PHPMD.StaticAccess) `PrincipalReference::listFrom()` is
+	 * a named constructor on a value object, which this rule cannot tell apart
+	 * from a static call into a service.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md#requirement-stored-assignee-strings-are-migrated-once-and-what-cannot-be-migrated-is-reported
+	 */
+	private function typeValue(
+		mixed $value,
+		?string $impliedType,
+		PrincipalResolverRegistry $principals,
+		string $where,
+		array &$ambiguous,
+		array &$unresolvable,
+		int &$rewritten
+	): mixed {
+		$entries = $this->entriesOf(value: $value);
+		if ($entries === null) {
+			return null;
+		}
+
+		$isList = $this->isList(value: $value);
+		$out = [];
+		$touched = false;
+
+		foreach ($entries as $entry) {
+			$typed = $this->typeOneEntry(
+				entry: $entry,
+				impliedType: $impliedType,
+				principals: $principals,
+				where: $where,
+				ambiguous: $ambiguous,
+				unresolvable: $unresolvable
+			);
+
+			if ($typed === null) {
+				// An empty string is not a performer and is not kept.
+				continue;
+			}
+
+			if ($typed !== $entry) {
+				$touched = true;
+				$rewritten++;
+			}
+
+			$out[] = $typed;
+		}
+
+		if ($touched === false) {
+			return null;
+		}
+
+		if ($isList === true) {
+			return $out;
+		}
+
+		return ($out[0] ?? null);
+
+	}//end typeValue()
+
+	/**
+	 * The entries a stored value holds, or null when it holds none.
+	 *
+	 * @param mixed $value What is stored.
+	 *
+	 * @return array<int, mixed>|null The entries, or null when there is nothing to type.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md#requirement-stored-assignee-strings-are-migrated-once-and-what-cannot-be-migrated-is-reported
+	 */
+	private function entriesOf(mixed $value): ?array {
+		if ($value === null || $value === '' || $value === []) {
+			return null;
+		}
+
+		if ($this->isList(value: $value) === true) {
+			return $value;
+		}
+
+		return [$value];
+
+	}//end entriesOf()
+
+	/**
+	 * Whether a stored value is a LIST of performers rather than one of them.
+	 *
+	 * 🔑 A `{type, id}` MAP IS ITSELF AN ARRAY, so a list is only a list when
+	 * its keys are sequential. Reading the map as a list would type its two
+	 * VALUES as two separate performers.
+	 *
+	 * @param mixed $value What is stored.
+	 *
+	 * @return bool Whether it is a list.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md#requirement-stored-assignee-strings-are-migrated-once-and-what-cannot-be-migrated-is-reported
+	 */
+	private function isList(mixed $value): bool {
+		return (is_array($value) === true && array_is_list($value) === true);
+
+	}//end isList()
+
+	/**
+	 * The typed form of ONE stored entry, or the entry unchanged.
+	 *
+	 * 🔴 RETURNING THE ENTRY UNCHANGED IS THE "LEAVE IT ALONE" ANSWER, and it
+	 * is deliberately not null: null means "this was never a performer", and
+	 * the two must not be confused. An unresolvable string is a performer
+	 * somebody wrote down; it stays exactly as it is, and the guard keeps
+	 * reading it under its old, wider meaning, so nothing regresses.
+	 *
+	 * @param mixed              $entry        One stored entry.
+	 * @param string|null        $impliedType  The type the field name implies.
+	 * @param PrincipalResolverRegistry $principals Resolves a candidate type.
+	 * @param string             $where        Where it was found, for the report.
+	 * @param array<int, string> $ambiguous    Collects what named more than one kind.
+	 * @param array<int, string> $unresolvable Collects what named nothing.
+	 *
+	 * @return mixed The typed entry, the entry unchanged, or null when it is not one.
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md#requirement-stored-assignee-strings-are-migrated-once-and-what-cannot-be-migrated-is-reported
+	 */
+	private function typeOneEntry(
+		mixed $entry,
+		?string $impliedType,
+		PrincipalResolverRegistry $principals,
+		string $where,
+		array &$ambiguous,
+		array &$unresolvable
+	): mixed {
+		// Already typed: nothing to decide.
+		if (is_array($entry) === true) {
+			return $entry;
+		}
+
+		$name = trim((string)$entry);
+		if ($name === '') {
+			return null;
+		}
+
+		// 🔴 A TEMPLATE IS NOT A NAME. `{{ case.assignee }}` is resolved per
+		// item when the step runs, so there is nothing here to look up and
+		// nothing broken about it. Found on the dev instance, where the first
+		// draft reported it as "already broken" — a false alarm that would
+		// have sent somebody looking for a flow that is working correctly.
+		if (str_contains($name, '{{') === true) {
+			return $entry;
+		}
+
+		// The field name already says what kind it is, so there is nothing
+		// ambiguous to resolve.
+		if ($impliedType !== null) {
+			return ['type' => $impliedType, 'id' => $name];
+		}
+
+		$kinds = $this->kindsAnsweringTo(name: $name, principals: $principals);
+		if (count($kinds) === 1) {
+			return ['type' => $kinds[0], 'id' => $name];
+		}
+
+		if ($kinds === []) {
+			$unresolvable[] = '"' . $name . '" at ' . $where;
+
+			return $entry;
+		}
+
+		$ambiguous[] = '"' . $name . '" at ' . $where . ' names a ' . implode(' and a ', $kinds);
+
+		return $entry;
+
+	}//end typeOneEntry()
+
+	/**
+	 * Which registered kinds answer to this name, right now.
+	 *
+	 * @param string                    $name       The stored string.
+	 * @param PrincipalResolverRegistry $principals The registry.
+	 *
+	 * @return array<int, string> The types that resolve it, in a stable order.
+	 *
+	 * @SuppressWarnings(PHPMD.StaticAccess) See typeValue().
+	 *
+	 * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md#requirement-stored-assignee-strings-are-migrated-once-and-what-cannot-be-migrated-is-reported
+	 */
+	private function kindsAnsweringTo(string $name, PrincipalResolverRegistry $principals): array {
+		$kinds = [];
+		foreach ($principals->types() as $type) {
+			$reference = PrincipalReference::from(value: ['type' => $type, 'id' => $name]);
+			if ($reference === null) {
+				continue;
+			}
+
+			if ($principals->resolve(reference: $reference) !== []) {
+				$kinds[] = $type;
+			}
+		}
+
+		return $kinds;
+
+	}//end kindsAnsweringTo()
+}//end class

--- a/tests/Unit/Repair/TypePerformerReferencesTest.php
+++ b/tests/Unit/Repair/TypePerformerReferencesTest.php
@@ -1,0 +1,409 @@
+<?php
+
+/**
+ * Typing what is certain, and reporting what is not.
+ *
+ * 🔴 THE AMBIGUOUS CASE IS THE WHOLE POINT. An instance may hold a user AND a
+ * group of one name, and the guard these strings were written against accepts
+ * BOTH — so today's behaviour is genuinely the union, and any rewrite NARROWS
+ * it. Narrowing who may answer an approval is a decision for a person, not for
+ * a repair step running unattended during an upgrade.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Repair
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-typed-principals/specs/flow-typed-principals/spec.md#requirement-stored-assignee-strings-are-migrated-once-and-what-cannot-be-migrated-is-reported
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Repair;
+
+use OCA\OpenRegister\Db\Flow;
+use OCA\OpenRegister\Db\FlowMapper;
+use OCA\OpenRegister\Repair\TypePerformerReferences;
+use OCA\OpenRegister\Service\Flow\Principal\IPrincipalResolver;
+use OCA\OpenRegister\Service\Flow\Principal\PrincipalResolverRegistry;
+use OCA\OpenRegister\Service\Flow\Principal\RegisterPrincipalResolversEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Migration\IOutput;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * A resolver that answers for a fixed set of names.
+ */
+class NamedResolver implements IPrincipalResolver {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string             $type  The type it answers for.
+	 * @param array<int, string> $names The names that exist under it.
+	 */
+	public function __construct(
+		private readonly string $type,
+		private readonly array $names = [],
+	) {
+
+	}//end __construct()
+
+	/**
+	 * The type.
+	 *
+	 * @return string The type.
+	 */
+	public function type(): string {
+		return $this->type;
+	}//end type()
+
+	/**
+	 * Whether this name exists under this type.
+	 *
+	 * @param string $id The name.
+	 *
+	 * @return array<int, string> The one uid, or nothing.
+	 */
+	public function resolve(string $id): array {
+		return in_array($id, $this->names, true) ? [$id] : [];
+	}//end resolve()
+}//end class
+
+/**
+ * Tests for {@see TypePerformerReferences}.
+ *
+ * @covers \OCA\OpenRegister\Repair\TypePerformerReferences
+ * @uses \OCA\OpenRegister\Service\Flow\Principal\PrincipalReference
+ * @uses \OCA\OpenRegister\Service\Flow\Principal\PrincipalResolverRegistry
+ * @uses \OCA\OpenRegister\Service\Flow\Principal\RegisterPrincipalResolversEvent
+ * @uses \OCA\OpenRegister\Db\Flow
+ */
+final class TypePerformerReferencesTest extends TestCase {
+
+	/**
+	 * The flows the fixture instance holds.
+	 *
+	 * @var array<int, Flow>
+	 */
+	private array $flows = [];
+
+	/**
+	 * Flows handed back to the mapper.
+	 *
+	 * @var array<int, Flow>
+	 */
+	private array $stored = [];
+
+	/**
+	 * Everything the step printed as a warning.
+	 *
+	 * @var array<int, string>
+	 */
+	private array $warnings = [];
+
+	/**
+	 * A flow with one step carrying this config.
+	 *
+	 * @param array<string, mixed> $config The step configuration.
+	 * @param string               $uuid   The flow uuid.
+	 *
+	 * @return Flow The flow.
+	 */
+	private function flowWith(array $config, string $uuid = 'flow-1'): Flow {
+		$flow = new Flow();
+		$flow->setUuid($uuid);
+		$flow->setNodes([['id' => 'ask', 'type' => 'openregister.user-task', 'config' => $config]]);
+
+		return $flow;
+	}//end flowWith()
+
+	/**
+	 * Run the step over the fixture.
+	 *
+	 * @param array<int, IPrincipalResolver> $resolvers What this instance understands.
+	 *
+	 * @return void
+	 */
+	private function runStep(array $resolvers): void {
+		$mapper = $this->createMock(FlowMapper::class);
+		$mapper->method('findAllFlows')->willReturnCallback(
+			function (
+				?string $app = null,
+				?string $applicationSlug = null,
+				?string $organisation = null,
+				?bool $enabled = null,
+				int $limit = 100,
+				int $offset = 0,
+			): array {
+				return array_slice($this->flows, $offset, $limit);
+			}
+		);
+		$mapper->method('update')->willReturnCallback(
+			function (Flow $flow): Flow {
+				$this->stored[] = $flow;
+
+				return $flow;
+			}
+		);
+
+		$dispatcher = $this->createMock(IEventDispatcher::class);
+		$dispatcher->method('dispatchTyped')->willReturnCallback(
+			static function (Event $event) use ($resolvers): void {
+				if (($event instanceof RegisterPrincipalResolversEvent) === true) {
+					foreach ($resolvers as $resolver) {
+						$event->registerResolver($resolver);
+					}
+				}
+			}
+		);
+		$registry = new PrincipalResolverRegistry($dispatcher, $this->createMock(LoggerInterface::class));
+
+		$container = $this->createMock(ContainerInterface::class);
+		$container->method('get')->willReturnCallback(
+			static function (string $id) use ($mapper, $registry) {
+				return ($id === PrincipalResolverRegistry::class) ? $registry : $mapper;
+			}
+		);
+
+		$output = $this->createMock(IOutput::class);
+		$output->method('warning')->willReturnCallback(
+			function (string $message): void {
+				$this->warnings[] = $message;
+			}
+		);
+
+		(new TypePerformerReferences($container, $this->createMock(LoggerInterface::class)))->run($output);
+	}//end runStep()
+
+	/**
+	 * The config of the first stored flow's step.
+	 *
+	 * @return array<string, mixed> The config.
+	 */
+	private function storedConfig(): array {
+		$this->assertNotSame([], $this->stored, 'nothing was written back');
+
+		return $this->stored[0]->getNodes()[0]['config'];
+	}//end storedConfig()
+
+	/**
+	 * A string only one kind answers to is rewritten to that kind.
+	 *
+	 * @return void
+	 */
+	public function testAnUnambiguousStringIsTyped(): void {
+		$this->flows = [$this->flowWith(['assignee' => 'bezwaar'])];
+
+		$this->runStep([new NamedResolver('user', ['alice']), new NamedResolver('group', ['bezwaar'])]);
+
+		$this->assertSame(['type' => 'group', 'id' => 'bezwaar'], $this->storedConfig()['assignee']);
+		$this->assertSame([], $this->warnings);
+	}//end testAnUnambiguousStringIsTyped()
+
+	/**
+	 * 🔴 AN AMBIGUOUS STRING IS LEFT ALONE AND REPORTED, NAMING BOTH TYPES.
+	 *
+	 * The scenario the requirement is written against. Today both may answer,
+	 * so choosing one would silently narrow who can.
+	 *
+	 * @return void
+	 */
+	public function testAnAmbiguousStringIsReportedRatherThanGuessed(): void {
+		$this->flows = [$this->flowWith(['assignee' => 'support'])];
+
+		$this->runStep([new NamedResolver('user', ['support']), new NamedResolver('group', ['support'])]);
+
+		$this->assertSame([], $this->stored, 'an ambiguous string must not be rewritten');
+
+		$said = implode(' ', $this->warnings);
+		$this->assertStringContainsString('AMBIGUOUS', $said);
+		$this->assertStringContainsString('support', $said);
+		// BOTH types named: "it is ambiguous" without saying between what
+		// leaves the reader exactly where they started.
+		$this->assertStringContainsString('user', $said);
+		$this->assertStringContainsString('group', $said);
+	}//end testAnAmbiguousStringIsReportedRatherThanGuessed()
+
+	/**
+	 * A string nothing answers to is left alone and reported.
+	 *
+	 * @return void
+	 */
+	public function testAnUnresolvableStringIsReportedAndLeft(): void {
+		$this->flows = [$this->flowWith(['assignee' => 'ghost'])];
+
+		$this->runStep([new NamedResolver('user', ['alice']), new NamedResolver('group', ['bezwaar'])]);
+
+		$this->assertSame([], $this->stored);
+		$said = implode(' ', $this->warnings);
+		$this->assertStringContainsString('UNRESOLVABLE', $said);
+		$this->assertStringContainsString('ghost', $said);
+		// It names WHERE, or nobody can find the flow to fix.
+		$this->assertStringContainsString('flow-1', $said);
+	}//end testAnUnresolvableStringIsReportedAndLeft()
+
+	/**
+	 * 🔴 AN UNRESOLVABLE ENTRY SURVIVES A WRITE-BACK, RATHER THAN BEING DROPPED.
+	 *
+	 * The spec says the repair SHALL NOT delete it, and "nothing was stored" is
+	 * too weak a test to prove that: an implementation that drops the entry
+	 * also writes nothing, because the result is then empty. This flow carries
+	 * one entry that DOES get typed beside the broken one, so the flow really
+	 * is written back — and the broken entry has to still be in it.
+	 *
+	 * @return void
+	 */
+	public function testAnUnresolvableEntrySurvivesAWriteBack(): void {
+		$this->flows = [$this->flowWith(['assignee' => ['bezwaar', 'ghost']])];
+
+		$this->runStep([new NamedResolver('group', ['bezwaar'])]);
+
+		$assignee = $this->storedConfig()['assignee'];
+		$this->assertSame(['type' => 'group', 'id' => 'bezwaar'], $assignee[0], 'the known one is typed');
+		$this->assertSame('ghost', $assignee[1], 'the unknown one is left EXACTLY as it was, not dropped');
+		$this->assertStringContainsString('ghost', implode(' ', $this->warnings));
+	}//end testAnUnresolvableEntrySurvivesAWriteBack()
+
+	/**
+	 * 🔴 TWENTY-SEVEN BROKEN FLOWS DO NOT FAIL THE UPGRADE.
+	 *
+	 * The measured number. Those flows were broken before this step existed,
+	 * and a repair that turns pre-existing breakage into a failed `occ upgrade`
+	 * makes it everybody's problem instead of their owner's.
+	 *
+	 * @return void
+	 */
+	public function testManyBrokenFlowsDoNotFailTheUpgrade(): void {
+		$this->flows = [];
+		for ($i = 0; $i < 27; $i++) {
+			$this->flows[] = $this->flowWith(['assignee' => 'ghost-' . $i], 'flow-' . $i);
+		}
+
+		$this->runStep([new NamedResolver('user', ['alice'])]);
+
+		$this->assertCount(27, $this->warnings, 'every one is reported by name');
+		$this->assertSame([], $this->stored);
+	}//end testManyBrokenFlowsDoNotFailTheUpgrade()
+
+	/**
+	 * 🔑 A FIELD WHOSE NAME SAYS THE TYPE IS NOT AMBIGUOUS AT ALL.
+	 *
+	 * `candidateGroups` holds group names and always did, so its entries need
+	 * no resolution and no guess — and typing them cannot be wrong.
+	 *
+	 * @return void
+	 */
+	public function testAFieldWhoseNameSaysTheTypeNeedsNoGuess(): void {
+		$this->flows = [
+			$this->flowWith(
+				[
+					'candidateGroups' => ['bezwaar'],
+					'candidateUsers' => ['alice'],
+					'candidateRole' => 'college',
+				]
+			),
+		];
+
+		// Nothing resolves at all, and it still types them: the field name is
+		// the evidence, not the roster.
+		$this->runStep([new NamedResolver('user', []), new NamedResolver('group', [])]);
+
+		$config = $this->storedConfig();
+		$this->assertSame([['type' => 'group', 'id' => 'bezwaar']], $config['candidateGroups']);
+		$this->assertSame([['type' => 'user', 'id' => 'alice']], $config['candidateUsers']);
+		$this->assertSame(['type' => 'group', 'id' => 'college'], $config['candidateRole']);
+		$this->assertSame([], $this->warnings);
+	}//end testAFieldWhoseNameSaysTheTypeNeedsNoGuess()
+
+	/**
+	 * 🔴 A TEMPLATED ASSIGNEE IS NOT REPORTED AS BROKEN.
+	 *
+	 * `{{ case.assignee }}` is resolved per item when the step runs, so there
+	 * is nothing to look up and nothing wrong with it. Found on the dev
+	 * instance: the first draft reported it as "already broken", which would
+	 * have sent somebody looking for a flow that works correctly.
+	 *
+	 * @return void
+	 */
+	public function testATemplatedAssigneeIsNotCalledBroken(): void {
+		$this->flows = [$this->flowWith(['assignee' => '{{ case.assignee }}'])];
+
+		$this->runStep([new NamedResolver('user', ['alice'])]);
+
+		$this->assertSame([], $this->stored, 'a template is left exactly as it is');
+		$this->assertSame([], $this->warnings, 'and it is not reported as broken');
+	}//end testATemplatedAssigneeIsNotCalledBroken()
+
+	/**
+	 * An already-typed reference is left exactly as it is.
+	 *
+	 * @return void
+	 */
+	public function testAnAlreadyTypedReferenceIsUntouched(): void {
+		$this->flows = [$this->flowWith(['assignee' => ['type' => 'position', 'id' => 'chair']])];
+
+		$this->runStep([new NamedResolver('user', ['chair'])]);
+
+		$this->assertSame([], $this->stored, 'a typed reference is already done');
+		$this->assertSame([], $this->warnings);
+	}//end testAnAlreadyTypedReferenceIsUntouched()
+
+	/**
+	 * One unreadable flow does not stop the rest.
+	 *
+	 * @return void
+	 */
+	public function testOneUnreadableFlowDoesNotStopTheRest(): void {
+		$bad = new Flow();
+		$bad->setUuid('flow-bad');
+		$bad->setNodes('not an array');
+
+		$this->flows = [$bad, $this->flowWith(['assignee' => 'bezwaar'], 'flow-good')];
+
+		$this->runStep([new NamedResolver('group', ['bezwaar'])]);
+
+		$this->assertCount(1, $this->stored);
+		$this->assertSame('flow-good', (string)$this->stored[0]->getUuid());
+	}//end testOneUnreadableFlowDoesNotStopTheRest()
+
+	/**
+	 * Missing tables are a skip, not a failure.
+	 *
+	 * @return void
+	 */
+	public function testMissingTablesAreASkip(): void {
+		$container = $this->createMock(ContainerInterface::class);
+		$container->method('get')->willThrowException(new RuntimeException('no such table'));
+
+		(new TypePerformerReferences($container, $this->createMock(LoggerInterface::class)))
+			->run($this->createMock(IOutput::class));
+
+		$this->assertSame([], $this->stored);
+	}//end testMissingTablesAreASkip()
+
+	/**
+	 * The step names itself for `occ upgrade`.
+	 *
+	 * @return void
+	 */
+	public function testTheStepNamesItself(): void {
+		$step = new TypePerformerReferences(
+			$this->createMock(ContainerInterface::class),
+			$this->createMock(LoggerInterface::class)
+		);
+
+		$this->assertNotSame('', $step->getName());
+	}//end testTheStepNamesItself()
+}//end class


### PR DESCRIPTION
## What it does

A stored `"bezwaar"` means a user **or** a group, because the guard it was written against tried both. This repair resolves each stored performer string once and rewrites it as `{type, id}` where exactly one kind of thing answers to that name.

| Resolves under | Action | Why |
|---|---|---|
| exactly one type | rewrite | unambiguous; the string meant that |
| more than one | **leave, report** | guessing moves who may answer, silently |
| no type | **leave, report** | already broken; the repair says so, it does not become the breakage |

## The ambiguous case is not hypothetical

The dev instance proved it on the first run: **`"admin"` is both a user and a group there**, on five steps across four flows. Today both may answer; choosing one would narrow who can, and that is a decision for a person, not for a step running unattended during an upgrade.

## It must not fail an upgrade

A flow naming a performer nobody can be is already broken, and a repair that turns pre-existing breakage into a failed `occ upgrade` makes it everybody's problem instead of its owner's. Every unmigrated string is reported **by name** with the flow, the step, the field and which of the two reasons applies — "3 could not be migrated" tells nobody which flow to open.

## A field whose name says the type needs no guess

`candidateGroups` holds group names and always did, so its entries are typed without resolving anything: the field name is the evidence, not the roster.

## A template is not a name — and the first draft got this wrong

The dev instance carries `{{ case.assignee }}`, resolved per item when the step runs. The first run reported it as "already broken" — a false alarm that would have sent somebody looking for a flow that works correctly. Templates are now left alone silently.

## Verified against the live instance

Unambiguous group names typed (`behandelaars`, `bezwaarcommissie`, `Beleidsadviseur`), `admin` left bare and reported as ambiguous, the template left alone, upgrade successful.

## Evidence

- 11 unit tests, **each seen red by mutating the implementation**: taking the first type when several answer fails 1, and dropping an unresolvable entry fails 1 — the latter **only after the test was strengthened**, because "nothing was stored" cannot tell "left alone" from "deleted".
- 1,344 repair and flow unit tests green; phpcs, phpmd, psalm, phpstan and gate-16 clean.
- `<version>` bumped in the same commit, or the step never runs (gate-110).
