### PR TITLE
feat(flow): a run keeps the set of objects it is working with, by role

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -40,7 +40,7 @@ Open Register drijft apps zoals OpenCatalogi, Procest, Pipelinq en Software Cata
 
 Vrij en open source onder de EUPL-licentie.
     ]]></description>
-    <version>2.0.18-unstable.20260907162700</version>
+    <version>2.0.18-unstable.20260907165321</version>
     <licence>EUPL-1.2</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>OpenRegister</namespace>
@@ -209,6 +209,12 @@ Vrij en open source onder de EUPL-licentie.
 			     its old, wider meaning, so nothing regresses by not touching
 			     it, and narrowing who may answer is a person's decision. -->
 			<step>OCA\OpenRegister\Repair\TypePerformerReferences</step>
+			<!-- The one subject an existing run can honestly be said to have
+			     declared: what it fired on. NOTHING is back-filled from the
+			     audit — those declarations would be addressable by `attachTo`,
+			     and a task attached to an object no author declared is worse
+			     than one that fails loudly the first time it is used. -->
+			<step>OCA\OpenRegister\Repair\SeedFlowRunTriggerSubject</step>
 			<step>OCA\OpenRegister\Repair\BackfillFlowTriggerIndex</step>
 			<step>OCA\OpenRegister\Repair\InitializeFlowActions</step>
 			<step>OCA\OpenRegister\Repair\MigrateNotificationSubscriptionsToUserConfig</step>
@@ -338,6 +344,12 @@ Vrij en open source onder de EUPL-licentie.
 			     its old, wider meaning, so nothing regresses by not touching
 			     it, and narrowing who may answer is a person's decision. -->
 			<step>OCA\OpenRegister\Repair\TypePerformerReferences</step>
+			<!-- The one subject an existing run can honestly be said to have
+			     declared: what it fired on. NOTHING is back-filled from the
+			     audit — those declarations would be addressable by `attachTo`,
+			     and a task attached to an object no author declared is worse
+			     than one that fails loudly the first time it is used. -->
+			<step>OCA\OpenRegister\Repair\SeedFlowRunTriggerSubject</step>
 			<step>OCA\OpenRegister\Repair\BackfillFlowTriggerIndex</step>
 			<step>OCA\OpenRegister\Repair\InitializeFlowActions</step>
 			<step>OCA\OpenRegister\Repair\SeedDirectoryVirtualSchemas</step>

--- a/lib/Db/FlowRun.php
+++ b/lib/Db/FlowRun.php
@@ -64,6 +64,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setLog(?array $log)
  * @method string|null getSubjectUuid()
  * @method void setSubjectUuid(?string $subjectUuid)
+ * @method array|null getSubjects()
+ * @method void setSubjects(?array $subjects)
  * @method string|null getSubjectRegister()
  * @method void setSubjectRegister(?string $subjectRegister)
  * @method string|null getSubjectSchema()
@@ -265,6 +267,25 @@ class FlowRun extends Entity implements JsonSerializable {
 	protected ?string $subjectUuid = null;
 
 	/**
+	 * The objects this run DECLARES it is working with, by role.
+	 *
+	 * 🔴 DECLARED, NOT DERIVED. The audit already answers "what did this run
+	 * write", and that cannot serve this purpose: a case flow READS a case it
+	 * never writes, WRITES a task and a document it does not consider subjects,
+	 * and may write one object at three steps for three reasons. The derived
+	 * list is too much and too little at once — and decisively it carries no
+	 * ROLE, so `attachTo: case` has no name to address.
+	 *
+	 * 🔑 ON THE RUN ROW, NOT IN A RESUME SLOT. Slots are per node, and a
+	 * three-week approval must wake up still knowing what its case is.
+	 *
+	 * Shape: `{"case": {"uuid": …, "register": …, "schema": …, "recordedAt": …}}`.
+	 *
+	 * @var array<string, array<string, mixed>>|null
+	 */
+	protected ?array $subjects = null;
+
+	/**
 	 * Register slug of the subject object.
 	 *
 	 * @var string|null
@@ -384,6 +405,7 @@ class FlowRun extends Entity implements JsonSerializable {
 		$this->addType(fieldName: 'context', type: 'json');
 		$this->addType(fieldName: 'log', type: 'json');
 		$this->addType(fieldName: 'subjectUuid', type: 'string');
+		$this->addType(fieldName: 'subjects', type: 'json');
 		$this->addType(fieldName: 'subjectRegister', type: 'string');
 		$this->addType(fieldName: 'subjectSchema', type: 'string');
 		$this->addType(fieldName: 'triggeredBy', type: 'string');
@@ -446,6 +468,7 @@ class FlowRun extends Entity implements JsonSerializable {
 			'context' => ($this->context ?? []),
 			'log' => ($this->log ?? []),
 			'subjectUuid' => $this->subjectUuid,
+			'subjects' => ($this->subjects ?? []),
 			'subjectRegister' => $this->subjectRegister,
 			'subjectSchema' => $this->subjectSchema,
 			'triggeredBy' => $this->triggeredBy,

--- a/lib/Migration/Version1Date20260907170000.php
+++ b/lib/Migration/Version1Date20260907170000.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * The objects a run declares it is working with.
+ *
+ * 🔴 THE SINGLE `subject_uuid` STAYS. It is what a trigger fired on and what
+ * 28 call sites read; replacing it would be a migration of every one of them to
+ * buy a name. `subjects` is an ADDITIONAL, author-facing fact: the set of
+ * objects a flow says it is working with, each under a role its own author
+ * chose.
+ *
+ * Nullable with no default, because a run that has declared nothing has
+ * declared nothing — and a NULL that means "none recorded" is honest where an
+ * empty object would be a claim the author never made.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-run-subjects-and-answers/specs/flow-run-subjects/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use Doctrine\DBAL\Types\Types;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Adds `subjects` to flow runs.
+ */
+class Version1Date20260907170000 extends SimpleMigrationStep {
+
+	private const RUNS = 'openregister_flow_runs';
+
+	/**
+	 * Add the column.
+	 *
+	 * @param IOutput $output Migration output.
+	 * @param Closure $schemaClosure Schema closure returning an ISchemaWrapper.
+	 * @param array $options Migration options.
+	 *
+	 * @return ISchemaWrapper|null The updated schema, or null when nothing changed.
+	 *
+	 * @spec openspec/changes/flow-run-subjects-and-answers/specs/flow-run-subjects/spec.md
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/*
+		 * @var ISchemaWrapper $schema
+		 */
+
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable(self::RUNS) === false) {
+			return null;
+		}
+
+		$runs = $schema->getTable(self::RUNS);
+		if ($runs->hasColumn('subjects') === true) {
+			return null;
+		}
+
+		$runs->addColumn('subjects', Types::JSON, ['notnull' => false, 'default' => null]);
+		$output->info(message: 'Added the declared-subject set to flow runs; subject_uuid is unchanged.');
+
+		return $schema;
+	}//end changeSchema()
+}//end class

--- a/lib/Repair/SeedFlowRunTriggerSubject.php
+++ b/lib/Repair/SeedFlowRunTriggerSubject.php
@@ -1,0 +1,189 @@
+<?php
+
+/**
+ * Give existing runs the one subject they can honestly be said to have declared.
+ *
+ * 🔴 THE `trigger` ENTRY, FROM `subject_uuid`, AND NOTHING ELSE. That column
+ * records what the run actually fired on, so calling it the run's `trigger`
+ * subject states a fact the run already carried.
+ *
+ * 🔴 NOTHING IS BACK-FILLED FROM THE AUDIT. It would be easy to walk what each
+ * run wrote and invent roles for it — and those declarations would then be
+ * ADDRESSABLE by `attachTo`, so a later step could attach a task to an object
+ * no author ever declared a subject. A wrong attachment is worse than a missing
+ * one: the missing one fails loudly the first time somebody uses it.
+ *
+ * 🔴 IT MUST NOT FAIL AN UPGRADE. A run whose row cannot be read is reported
+ * and skipped.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Repair
+ * @package  OCA\OpenRegister\Repair
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-run-subjects-and-answers/specs/flow-run-subjects/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Repair;
+
+use OCA\OpenRegister\Db\FlowRun;
+use OCA\OpenRegister\Db\FlowRunMapper;
+use OCA\OpenRegister\Service\Flow\FlowRunSubjects;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Seeds the `trigger` subject on runs that fired on an object.
+ */
+class SeedFlowRunTriggerSubject implements IRepairStep {
+
+	/**
+	 * Constructor.
+	 *
+	 * Resolved lazily from the container, like the other flow repair steps:
+	 * this runs during install, when the tables may not exist yet.
+	 *
+	 * @param ContainerInterface $container The app container.
+	 * @param LoggerInterface    $logger    Diagnostics.
+	 *
+	 * @spec openspec/changes/flow-run-subjects-and-answers/specs/flow-run-subjects/spec.md
+	 */
+	public function __construct(
+		private readonly ContainerInterface $container,
+		private readonly LoggerInterface $logger,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * The step's name, as `occ upgrade` prints it.
+	 *
+	 * @return string The name.
+	 *
+	 * @spec openspec/changes/flow-run-subjects-and-answers/specs/flow-run-subjects/spec.md
+	 */
+	public function getName(): string {
+		return 'Record what existing runs fired on as their trigger subject';
+	}//end getName()
+
+	/**
+	 * Seed it.
+	 *
+	 * @param IOutput $output Migration output.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-run-subjects-and-answers/specs/flow-run-subjects/spec.md
+	 */
+	public function run(IOutput $output): void {
+		try {
+			$runs = $this->container->get(FlowRunMapper::class);
+			$subjects = new FlowRunSubjects(logger: $this->logger);
+		} catch (Throwable $e) {
+			$output->info('Flow run trigger-subject seeding skipped: ' . $e->getMessage());
+			return;
+		}
+
+		$seeded = 0;
+		$skipped = 0;
+
+		foreach ($this->everyRun(runs: $runs) as $run) {
+			try {
+				$seeded += $this->seedOne(run: $run, runs: $runs, subjects: $subjects);
+			} catch (Throwable $e) {
+				$skipped++;
+				$this->logger->warning(
+					message: '[SeedFlowRunTriggerSubject] Could not seed run "'
+						. (string)$run->getUuid() . '": ' . $e->getMessage(),
+					context: ['file' => __FILE__, 'line' => __LINE__]
+				);
+			}
+		}
+
+		$output->info(
+			sprintf('Recorded a trigger subject on %d run(s); %d could not be read.', $seeded, $skipped)
+		);
+
+	}//end run()
+
+	/**
+	 * Seed one run, if it has something to seed and nothing already.
+	 *
+	 * @param FlowRun         $run      The run.
+	 * @param FlowRunMapper   $runs     The mapper.
+	 * @param FlowRunSubjects $subjects The subject rules.
+	 *
+	 * @return int 1 when it was seeded, 0 otherwise.
+	 *
+	 * @spec openspec/changes/flow-run-subjects-and-answers/specs/flow-run-subjects/spec.md
+	 */
+	private function seedOne(FlowRun $run, FlowRunMapper $runs, FlowRunSubjects $subjects): int {
+		if ($subjects->all(run: $run) !== []) {
+			// Already declared something. A repair must not overwrite what a
+			// flow author said.
+			return 0;
+		}
+
+		$uuid = trim((string)$run->getSubjectUuid());
+		if ($uuid === '') {
+			return 0;
+		}
+
+		$subjects->record(
+			run: $run,
+			role: FlowRunSubjects::ROLE_TRIGGER,
+			uuid: $uuid,
+			register: trim((string)$run->getSubjectRegister()),
+			schema: trim((string)$run->getSubjectSchema())
+		);
+		$runs->update($run);
+
+		return 1;
+
+	}//end seedOne()
+
+	/**
+	 * Every run, paged.
+	 *
+	 * 🔴 A MAPPER'S DEFAULT LIMIT WOULD SILENTLY SEED THE FIRST PAGE and report
+	 * success — the shape that left 119 of 219 flows unversioned once already.
+	 *
+	 * @param FlowRunMapper $runs The mapper.
+	 *
+	 * @return array<int, FlowRun> Every run.
+	 *
+	 * @spec openspec/changes/flow-run-subjects-and-answers/specs/flow-run-subjects/spec.md
+	 */
+	private function everyRun(FlowRunMapper $runs): array {
+		$page = 500;
+		$offset = 0;
+		$all = [];
+
+		while (true) {
+			// 🔴 `findAllRuns()`, NOT `findAll()`. The latter does not exist;
+			// writing it once already produced a repair that threw, reported
+			// itself skipped, and let the upgrade go green having done nothing.
+			$batch = $runs->findAllRuns(limit: $page, offset: $offset);
+			$all = array_merge($all, $batch);
+
+			if (count($batch) < $page) {
+				return $all;
+			}
+
+			$offset += $page;
+		}
+
+	}//end everyRun()
+}//end class

--- a/lib/Service/Flow/FlowRunSubjects.php
+++ b/lib/Service/Flow/FlowRunSubjects.php
@@ -1,0 +1,221 @@
+<?php
+
+/**
+ * The objects a run says it is working with, each under a role.
+ *
+ * 🔴 DECLARED, NOT DERIVED, AND THE TWO COEXIST. The audit trail already
+ * answers "what did this run write", and it cannot serve this purpose: a case
+ * flow READS a case it never writes, WRITES a task and a document it does not
+ * consider subjects, and may write one object at three steps for three
+ * different reasons. The derived list is too much and too little at once — and,
+ * decisively, it carries no ROLE. `attachTo: case` needs a name, and a list of
+ * things that happened has none to give.
+ *
+ * Derived answers the auditor. Declared answers the author.
+ *
+ * WHY A ROLE AND NOT AN INDEX
+ * ---------------------------
+ * `attachTo: 2` would work, would be unreadable, and would break the moment a
+ * step is inserted. A role is the author's own word for what the object is TO
+ * THIS FLOW, which is what later steps actually mean. Roles are per-run and
+ * unconstrained on purpose: `case`, `besluit`, `aanvraag` are all fine, and a
+ * typo is caught by the addressing rule failing loudly rather than by a
+ * registry somebody has to maintain.
+ *
+ * 🔑 IDEMPOTENCY IS NOT OPTIONAL. A user-task node is re-entered on a
+ * heartbeat, by design, with its task still open — so any node that records a
+ * subject is re-entered too. A set that grew on each wake would report a run as
+ * working on the same case forty times.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-run-subjects-and-answers/specs/flow-run-subjects/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Flow;
+
+use DateTime;
+use OCA\OpenRegister\Db\FlowRun;
+use Psr\Log\LoggerInterface;
+use UnexpectedValueException;
+
+/**
+ * Reads and records a run's declared subject set.
+ */
+class FlowRunSubjects {
+
+	/**
+	 * The role a trigger's own object is recorded under.
+	 *
+	 * @var string
+	 */
+	public const ROLE_TRIGGER = 'trigger';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param LoggerInterface|null $logger Where a REPLACEMENT is recorded.
+	 *
+	 * @spec openspec/changes/flow-run-subjects-and-answers/specs/flow-run-subjects/spec.md
+	 */
+	public function __construct(private readonly ?LoggerInterface $logger = null) {
+
+	}//end __construct()
+
+	/**
+	 * Everything the run has declared, by role.
+	 *
+	 * @param FlowRun $run The run.
+	 *
+	 * @return array<string, array<string, mixed>> The declared subjects.
+	 *
+	 * @spec openspec/changes/flow-run-subjects-and-answers/specs/flow-run-subjects/spec.md
+	 */
+	public function all(FlowRun $run): array {
+		$subjects = $run->getSubjects();
+
+		if (is_array($subjects) === false) {
+			return [];
+		}
+
+		return $subjects;
+
+	}//end all()
+
+	/**
+	 * The roles this run currently holds.
+	 *
+	 * @param FlowRun $run The run.
+	 *
+	 * @return array<int, string> The roles, sorted so a refusal reads the same twice.
+	 *
+	 * @spec openspec/changes/flow-run-subjects-and-answers/specs/flow-run-subjects/spec.md
+	 */
+	public function roles(FlowRun $run): array {
+		$roles = array_keys($this->all(run: $run));
+		sort($roles);
+
+		return $roles;
+
+	}//end roles()
+
+	/**
+	 * Record an object under a role, in place on the run.
+	 *
+	 * 🔑 RE-RECORDING THE SAME OBJECT UNDER THE SAME ROLE CHANGES NOTHING, and
+	 * that is what makes this safe on a heartbeat. Only a DIFFERENT object
+	 * under a held role is a replacement.
+	 *
+	 * 🔴 A REPLACEMENT IS ALLOWED AND LOGGED, NEVER REFUSED. Re-pointing a role
+	 * is legitimate — a flow that supersedes a draft decision with a final one
+	 * genuinely means `decision` to be the new object, and refusing would force
+	 * authors into `decision2`. But it is also exactly how a later step
+	 * silently attaches to the wrong record, so the log entry is what makes
+	 * "why is this task on the old decision" answerable in under a minute.
+	 *
+	 * @param FlowRun $run      The run to record on.
+	 * @param string  $role     The author's word for what this object is.
+	 * @param string  $uuid     The object.
+	 * @param string  $register Its register, when known.
+	 * @param string  $schema   Its schema, when known.
+	 *
+	 * @return void
+	 *
+	 * @throws UnexpectedValueException When the role or the uuid is empty.
+	 *
+	 * @spec openspec/changes/flow-run-subjects-and-answers/specs/flow-run-subjects/spec.md
+	 */
+	public function record(
+		FlowRun $run,
+		string $role,
+		string $uuid,
+		string $register = '',
+		string $schema = ''
+	): void {
+		$role = trim($role);
+		$uuid = trim($uuid);
+
+		if ($role === '' || $uuid === '') {
+			throw new UnexpectedValueException(
+				'A declared subject needs both a role and an object; "' . $role . '" => "' . $uuid . '" has one of them.'
+			);
+		}
+
+		$subjects = $this->all(run: $run);
+		$held = ($subjects[$role] ?? null);
+
+		if (is_array($held) === true && trim((string)($held['uuid'] ?? '')) === $uuid) {
+			// The same object under the same role. A heartbeat re-entering the
+			// node must not make the run look like it touched it twice.
+			return;
+		}
+
+		if ($held !== null) {
+			$this->logger?->info(
+				message: '[FlowRunSubjects] Run "' . (string)$run->getUuid() . '" re-pointed the role "'
+					. $role . '" from "' . trim((string)($held['uuid'] ?? '')) . '" to "' . $uuid
+					. '". Anything attached to that role from here on addresses the new object.',
+				context: ['file' => __FILE__, 'line' => __LINE__, 'run' => (string)$run->getUuid()]
+			);
+		}
+
+		$subjects[$role] = [
+			'uuid' => $uuid,
+			'register' => trim($register),
+			'schema' => trim($schema),
+			'recordedAt' => (new DateTime())->format(DATE_ATOM),
+		];
+
+		$run->setSubjects($subjects);
+
+	}//end record()
+
+	/**
+	 * The object a role names, for a step that addresses one.
+	 *
+	 * 🔴 AN UNHELD ROLE FAILS, NAMING WHAT IS HELD. A typo in `attachTo` would
+	 * otherwise attach the task to nothing and leave the author looking for a
+	 * record that was never made — so the refusal lists the roles that exist,
+	 * which is the whole reason no vocabulary has to be registered anywhere.
+	 *
+	 * @param FlowRun $run  The run.
+	 * @param string  $role The role to address.
+	 *
+	 * @return array<string, mixed> The subject entry.
+	 *
+	 * @throws UnexpectedValueException When the run holds no such role.
+	 *
+	 * @spec openspec/changes/flow-run-subjects-and-answers/specs/flow-run-subjects/spec.md
+	 */
+	public function addressed(FlowRun $run, string $role): array {
+		$role = trim($role);
+		$subjects = $this->all(run: $run);
+
+		if (is_array(($subjects[$role] ?? null)) === true) {
+			return $subjects[$role];
+		}
+
+		$held = $this->roles(run: $run);
+		$holds = 'it holds: ' . implode(', ', $held);
+		if ($held === []) {
+			$holds = 'it has declared none';
+		}
+
+		throw new UnexpectedValueException(
+			'This step addresses the subject "' . $role . '", and this run has no such subject — ' . $holds . '.'
+		);
+
+	}//end addressed()
+}//end class

--- a/tests/Unit/Db/FlowRunSerialisationTest.php
+++ b/tests/Unit/Db/FlowRunSerialisationTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * What a run looks like over the API, subjects included.
+ *
+ * 🔑 `subjects` SERIALISES AS AN EMPTY SET, NEVER AS A MISSING KEY. A reader
+ * that has to tell "no subjects" apart from "this build predates subjects"
+ * ends up writing the fallback twice and getting it wrong once.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Db
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-run-subjects-and-answers/specs/flow-run-subjects/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Db;
+
+use DateTime;
+use OCA\OpenRegister\Db\FlowRun;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for {@see FlowRun::jsonSerialize()}.
+ *
+ * @covers \OCA\OpenRegister\Db\FlowRun
+ */
+final class FlowRunSerialisationTest extends TestCase {
+
+	/**
+	 * A run with nothing set serialises without dates and with an empty set.
+	 *
+	 * @return void
+	 */
+	public function testARunWithNoDatesSerialisesThemAsNull(): void {
+		$json = (new FlowRun())->jsonSerialize();
+
+		$this->assertNull($json['resumeAt']);
+		$this->assertNull($json['created']);
+		$this->assertNull($json['updated']);
+		$this->assertSame([], $json['subjects'], 'an empty set, never a missing key');
+	}//end testARunWithNoDatesSerialisesThemAsNull()
+
+	/**
+	 * 🔑 EVERY DATE IS SERIALISED IN ITS OWN RIGHT.
+	 *
+	 * All three are separately nullable, so one of them being formatted is no
+	 * evidence about the other two.
+	 *
+	 * @return void
+	 */
+	public function testEachDateIsFormattedWhenItIsSet(): void {
+		$run = new FlowRun();
+		$run->setResumeAt(new DateTime('2026-01-02T03:04:05+00:00'));
+		$run->setCreated(new DateTime('2026-02-03T04:05:06+00:00'));
+		$run->setUpdated(new DateTime('2026-03-04T05:06:07+00:00'));
+
+		$json = $run->jsonSerialize();
+
+		$this->assertStringStartsWith('2026-01-02T03:04:05', $json['resumeAt']);
+		$this->assertStringStartsWith('2026-02-03T04:05:06', $json['created']);
+		$this->assertStringStartsWith('2026-03-04T05:06:07', $json['updated']);
+	}//end testEachDateIsFormattedWhenItIsSet()
+
+	/**
+	 * A declared subject set survives serialisation, by role.
+	 *
+	 * @return void
+	 */
+	public function testTheDeclaredSubjectsSurviveSerialisation(): void {
+		$run = new FlowRun();
+		$run->setSubjects(['case' => ['uuid' => 'obj-1', 'register' => '3', 'schema' => '7']]);
+
+		$this->assertSame('obj-1', $run->jsonSerialize()['subjects']['case']['uuid']);
+	}//end testTheDeclaredSubjectsSurviveSerialisation()
+}//end class

--- a/tests/Unit/Repair/SeedFlowRunTriggerSubjectTest.php
+++ b/tests/Unit/Repair/SeedFlowRunTriggerSubjectTest.php
@@ -1,0 +1,304 @@
+<?php
+
+/**
+ * Giving existing runs the one subject they can honestly be said to have declared.
+ *
+ * 🔴 A REPAIR STEP RUNS AT `occ upgrade` AND NOWHERE ELSE, and it warns without
+ * failing. That combination is why it is tested here rather than trusted: a
+ * repair that throws reports itself skipped and lets the upgrade go green
+ * having done nothing, which is exactly how thirteen migrations once shipped
+ * and never ran.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Repair
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-run-subjects-and-answers/specs/flow-run-subjects/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Repair;
+
+use OCA\OpenRegister\Db\FlowRun;
+use OCA\OpenRegister\Db\FlowRunMapper;
+use OCA\OpenRegister\Repair\SeedFlowRunTriggerSubject;
+use OCP\Migration\IOutput;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Tests for {@see SeedFlowRunTriggerSubject}.
+ *
+ * @covers \OCA\OpenRegister\Repair\SeedFlowRunTriggerSubject
+ * @uses \OCA\OpenRegister\Service\Flow\FlowRunSubjects
+ * @uses \OCA\OpenRegister\Db\FlowRun
+ */
+final class SeedFlowRunTriggerSubjectTest extends TestCase {
+
+	/**
+	 * Every run the mapper was asked to store.
+	 *
+	 * @var array<int, FlowRun>
+	 */
+	private array $stored = [];
+
+	/**
+	 * Everything the step printed to the upgrade output.
+	 *
+	 * @var array<int, string>
+	 */
+	private array $said = [];
+
+	/**
+	 * The (limit, offset) pairs the mapper was asked for.
+	 *
+	 * @var array<int, array<int, int>>
+	 */
+	private array $pages = [];
+
+	/**
+	 * A run that fired on an object.
+	 *
+	 * @param string $uuid     The run uuid.
+	 * @param string $subject  What it fired on, or '' for nothing.
+	 * @param string $register The subject's register.
+	 * @param string $schema   The subject's schema.
+	 *
+	 * @return FlowRun The run.
+	 */
+	private function aRun(string $uuid, string $subject, string $register = '', string $schema = ''): FlowRun {
+		$run = new FlowRun();
+		$run->setUuid($uuid);
+		$run->setSubjectUuid($subject);
+		$run->setSubjectRegister($register);
+		$run->setSubjectSchema($schema);
+
+		return $run;
+	}//end aRun()
+
+	/**
+	 * The step, over a mapper serving the given pages of runs.
+	 *
+	 * @param array<int, array<int, FlowRun>>|null $pages One entry per page the
+	 *                                                    mapper should serve,
+	 *                                                    or null when the
+	 *                                                    container cannot
+	 *                                                    resolve it at all.
+	 *
+	 * @return SeedFlowRunTriggerSubject The step.
+	 */
+	private function step(?array $pages): SeedFlowRunTriggerSubject {
+		$container = $this->createMock(ContainerInterface::class);
+
+		if ($pages === null) {
+			$container->method('get')->willThrowException(new RuntimeException('no such table'));
+		} else {
+			$mapper = $this->createMock(FlowRunMapper::class);
+			// ⚠️ THE REAL SIGNATURE IS (flowId, status, limit, offset, ...).
+			// Taking the first two arguments as (limit, offset) reads null for
+			// both, which pins the page index at 0 and loops forever — a hang,
+			// not a failure. The step calls it with NAMED arguments, so only
+			// the double can get this wrong.
+			$mapper->method('findAllRuns')->willReturnCallback(
+				function (
+					?string $flowId = null,
+					?string $status = null,
+					int $limit = 50,
+					int $offset = 0
+				) use ($pages): array {
+					$this->pages[] = [$limit, $offset];
+					$index = 0;
+					if ($limit > 0) {
+						$index = intdiv($offset, $limit);
+					}
+
+					return ($pages[$index] ?? []);
+				}
+			);
+			$mapper->method('update')->willReturnCallback(
+				function (FlowRun $run): FlowRun {
+					$this->stored[] = $run;
+
+					return $run;
+				}
+			);
+
+			$container->method('get')->willReturn($mapper);
+		}
+
+		return new SeedFlowRunTriggerSubject(
+			$container,
+			$this->createMock(LoggerInterface::class)
+		);
+	}//end step()
+
+	/**
+	 * An upgrade output that records what it was told.
+	 *
+	 * ⚠️ NOT named `output()`: that is FINAL on PHPUnit's TestCase, and
+	 * overriding it is a fatal error rather than a failing test — the same trap
+	 * `run()` sets, one method along.
+	 *
+	 * @return IOutput The output.
+	 */
+	private function upgradeOutput(): IOutput {
+		$output = $this->createMock(IOutput::class);
+		$output->method('info')->willReturnCallback(
+			function (string $message): void {
+				$this->said[] = $message;
+			}
+		);
+
+		return $output;
+	}//end upgradeOutput()
+
+	/**
+	 * The step has the name `occ upgrade` prints.
+	 *
+	 * @return void
+	 */
+	public function testTheStepIsNamed(): void {
+		$this->assertNotSame('', $this->step([])->getName());
+	}//end testTheStepIsNamed()
+
+	/**
+	 * 🔑 THE `trigger` ENTRY, FROM THE COLUMN THE RUN ALREADY CARRIED.
+	 *
+	 * That column records what the run actually fired on, so calling it the
+	 * run's `trigger` subject states a fact rather than inventing one.
+	 *
+	 * @return void
+	 */
+	public function testARunThatFiredOnAnObjectGetsATriggerSubject(): void {
+		$this->step([[$this->aRun('run-1', 'obj-1', '3', '7')]])->run($this->upgradeOutput());
+
+		$this->assertCount(1, $this->stored);
+		$subjects = $this->stored[0]->getSubjects();
+		$this->assertSame('obj-1', $subjects['trigger']['uuid']);
+		$this->assertSame('3', $subjects['trigger']['register']);
+		$this->assertSame('7', $subjects['trigger']['schema']);
+	}//end testARunThatFiredOnAnObjectGetsATriggerSubject()
+
+	/**
+	 * A run that fired on nothing is left alone.
+	 *
+	 * @return void
+	 */
+	public function testARunThatFiredOnNothingIsLeftAlone(): void {
+		$this->step([[$this->aRun('run-1', '   ')]])->run($this->upgradeOutput());
+
+		$this->assertSame([], $this->stored);
+	}//end testARunThatFiredOnNothingIsLeftAlone()
+
+	/**
+	 * 🔴 A REPAIR MUST NOT OVERWRITE WHAT A FLOW AUTHOR SAID.
+	 *
+	 * A run that already declares a subject keeps it, even when the declared
+	 * role is not `trigger` and the trigger column holds something else.
+	 *
+	 * @return void
+	 */
+	public function testARunThatAlreadyDeclaredSomethingIsNotTouched(): void {
+		$run = $this->aRun('run-1', 'obj-1');
+		$run->setSubjects(['case' => ['uuid' => 'obj-9']]);
+
+		$this->step([[$run]])->run($this->upgradeOutput());
+
+		$this->assertSame([], $this->stored);
+	}//end testARunThatAlreadyDeclaredSomethingIsNotTouched()
+
+	/**
+	 * 🔴 EVERY PAGE, NOT THE FIRST ONE.
+	 *
+	 * A mapper's default limit would silently seed the first page and report
+	 * success — the shape that left 119 of 219 flows unversioned once already.
+	 *
+	 * @return void
+	 */
+	public function testEveryPageIsSeededNotJustTheFirst(): void {
+		$first = [];
+		for ($i = 0; $i < 500; $i++) {
+			$first[] = $this->aRun('run-' . $i, 'obj-' . $i);
+		}
+
+		$this->step([$first, [$this->aRun('run-500', 'obj-500')]])->run($this->upgradeOutput());
+
+		$this->assertCount(501, $this->stored, 'the second page must be read too');
+		$this->assertSame([[500, 0], [500, 500]], $this->pages);
+	}//end testEveryPageIsSeededNotJustTheFirst()
+
+	/**
+	 * 🔴 A RUN THAT CANNOT BE SEEDED IS REPORTED AND SKIPPED, NOT FATAL.
+	 *
+	 * One unreadable row must not abandon every row after it, and must not fail
+	 * the upgrade.
+	 *
+	 * @return void
+	 */
+	public function testOneBadRunDoesNotStopTheRest(): void {
+		$bad = $this->aRun('run-bad', 'obj-bad');
+		// An empty role is refused by FlowRunSubjects, which is the throw this
+		// step has to survive. Recording under the trigger role with an empty
+		// uuid is the same refusal from the other side.
+		$bad->setSubjectUuid('obj-bad');
+
+		$mapperThrows = $this->createMock(FlowRunMapper::class);
+		$mapperThrows->method('findAllRuns')->willReturn([$bad, $this->aRun('run-ok', 'obj-ok')]);
+		$mapperThrows->method('update')->willReturnCallback(
+			function (FlowRun $run): FlowRun {
+				if ((string)$run->getUuid() === 'run-bad') {
+					throw new RuntimeException('row is locked');
+				}
+
+				$this->stored[] = $run;
+
+				return $run;
+			}
+		);
+
+		$container = $this->createMock(ContainerInterface::class);
+		$container->method('get')->willReturn($mapperThrows);
+
+		(new SeedFlowRunTriggerSubject($container, $this->createMock(LoggerInterface::class)))
+			->run($this->upgradeOutput());
+
+		$this->assertCount(1, $this->stored, 'the run after the bad one is still seeded');
+		$this->assertStringContainsString('1 could not be read', implode(' ', $this->said));
+	}//end testOneBadRunDoesNotStopTheRest()
+
+	/**
+	 * 🔴 A MISSING TABLE SKIPS THE STEP, IT DOES NOT FAIL THE UPGRADE.
+	 *
+	 * This runs during install, when the tables may not exist yet.
+	 *
+	 * @return void
+	 */
+	public function testAnUnresolvableMapperSkipsInsteadOfFailing(): void {
+		$this->step(null)->run($this->upgradeOutput());
+
+		$this->assertSame([], $this->stored);
+		$this->assertStringContainsString('skipped', implode(' ', $this->said));
+	}//end testAnUnresolvableMapperSkipsInsteadOfFailing()
+
+	/**
+	 * The step reports what it did, so an upgrade log answers "did it run".
+	 *
+	 * @return void
+	 */
+	public function testItReportsHowManyItSeeded(): void {
+		$this->step([[$this->aRun('run-1', 'obj-1'), $this->aRun('run-2', '')]])->run($this->upgradeOutput());
+
+		$this->assertStringContainsString('1 run(s)', implode(' ', $this->said));
+	}//end testItReportsHowManyItSeeded()
+}//end class

--- a/tests/Unit/Service/Flow/FlowRunSubjectsTest.php
+++ b/tests/Unit/Service/Flow/FlowRunSubjectsTest.php
@@ -1,0 +1,239 @@
+<?php
+
+/**
+ * What a run says it is working with.
+ *
+ * 🔴 IDEMPOTENCY IS NOT OPTIONAL HERE. A user-task node is re-entered on a
+ * heartbeat, by design, with its task still open — so any node that records a
+ * subject is re-entered too. A set that grew on each wake would report a run as
+ * working on the same case forty times.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Flow
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-run-subjects-and-answers/specs/flow-run-subjects/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Flow;
+
+use OCA\OpenRegister\Db\FlowRun;
+use OCA\OpenRegister\Service\Flow\FlowRunSubjects;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use UnexpectedValueException;
+
+/**
+ * Tests for {@see FlowRunSubjects}.
+ *
+ * @covers \OCA\OpenRegister\Service\Flow\FlowRunSubjects
+ * @uses \OCA\OpenRegister\Db\FlowRun
+ */
+final class FlowRunSubjectsTest extends TestCase {
+
+	/**
+	 * Everything the logger was told.
+	 *
+	 * @var array<int, string>
+	 */
+	private array $logged = [];
+
+	/**
+	 * The subject rules, watching the log.
+	 *
+	 * @return FlowRunSubjects The service.
+	 */
+	private function subjects(): FlowRunSubjects {
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->method('info')->willReturnCallback(
+			function (string $message): void {
+				$this->logged[] = $message;
+			}
+		);
+
+		return new FlowRunSubjects($logger);
+	}//end subjects()
+
+	/**
+	 * A run with nothing declared.
+	 *
+	 * ⚠️ NOT named `run()`: that is FINAL on PHPUnit's TestCase, and overriding
+	 * it is a fatal error rather than a failing test.
+	 *
+	 * @return FlowRun The run.
+	 */
+	private function newRun(): FlowRun {
+		$run = new FlowRun();
+		$run->setUuid('run-1');
+
+		return $run;
+	}//end newRun()
+
+	/**
+	 * A run that has declared nothing holds no roles.
+	 *
+	 * @return void
+	 */
+	public function testARunDeclaresNothingUntilAStepSaysSo(): void {
+		$run = $this->newRun();
+
+		$this->assertSame([], $this->subjects()->all(run: $run));
+		$this->assertSame([], $this->subjects()->roles(run: $run));
+	}//end testARunDeclaresNothingUntilAStepSaysSo()
+
+	/**
+	 * Recording puts the object under its role, with where it lives.
+	 *
+	 * @return void
+	 */
+	public function testRecordingPutsTheObjectUnderItsRole(): void {
+		$run = $this->newRun();
+		$this->subjects()->record(run: $run, role: 'case', uuid: 'obj-1', register: 'cases', schema: 'case');
+
+		$recorded = $this->subjects()->all(run: $run)['case'];
+		$this->assertSame('obj-1', $recorded['uuid']);
+		$this->assertSame('cases', $recorded['register']);
+		$this->assertSame('case', $recorded['schema']);
+		$this->assertNotSame('', $recorded['recordedAt']);
+	}//end testRecordingPutsTheObjectUnderItsRole()
+
+	/**
+	 * 🔴 RE-RECORDING THE SAME OBJECT UNDER THE SAME ROLE CHANGES NOTHING.
+	 *
+	 * The heartbeat case. Forty wake-ups must leave one subject, and must not
+	 * log forty replacements either.
+	 *
+	 * @return void
+	 */
+	public function testARefireDoesNotDuplicateOrLog(): void {
+		$run = $this->newRun();
+		$subjects = $this->subjects();
+
+		for ($i = 0; $i < 40; $i++) {
+			$subjects->record(run: $run, role: 'case', uuid: 'obj-1', register: 'cases', schema: 'case');
+		}
+
+		$this->assertSame(['case'], $subjects->roles(run: $run));
+		$this->assertSame([], $this->logged, 're-recording the same object is not a replacement');
+	}//end testARefireDoesNotDuplicateOrLog()
+
+	/**
+	 * 🔴 RE-POINTING A ROLE IS ALLOWED, AND LOGGED.
+	 *
+	 * Superseding a draft decision with a final one genuinely means `decision`
+	 * to be the new object, and refusing would force authors into `decision2`.
+	 * But it is also exactly how a later step silently attaches to the wrong
+	 * record, so the log entry is what makes "why is this task on the old
+	 * decision" answerable in under a minute.
+	 *
+	 * @return void
+	 */
+	public function testAReplacementIsAllowedAndLoggedWithBothObjects(): void {
+		$run = $this->newRun();
+		$subjects = $this->subjects();
+
+		$subjects->record(run: $run, role: 'decision', uuid: 'draft-1');
+		$subjects->record(run: $run, role: 'decision', uuid: 'final-1');
+
+		$this->assertSame('final-1', $subjects->all(run: $run)['decision']['uuid']);
+
+		$said = implode(' ', $this->logged);
+		$this->assertStringContainsString('draft-1', $said, 'the log names what it was');
+		$this->assertStringContainsString('final-1', $said, 'and what it became');
+		$this->assertStringContainsString('decision', $said);
+	}//end testAReplacementIsAllowedAndLoggedWithBothObjects()
+
+	/**
+	 * A role addresses its object.
+	 *
+	 * @return void
+	 */
+	public function testARoleAddressesItsObject(): void {
+		$run = $this->newRun();
+		$subjects = $this->subjects();
+		$subjects->record(run: $run, role: 'case', uuid: 'obj-1', register: 'cases', schema: 'case');
+
+		$this->assertSame('obj-1', $subjects->addressed(run: $run, role: 'case')['uuid']);
+	}//end testARoleAddressesItsObject()
+
+	/**
+	 * 🔴 AN UNHELD ROLE FAILS, NAMING THE ROLES THAT ARE HELD.
+	 *
+	 * A typo in `attachTo` would otherwise attach the task to nothing and leave
+	 * the author looking for a record that was never made. Listing what exists
+	 * is the whole reason no role vocabulary has to be registered anywhere.
+	 *
+	 * @return void
+	 */
+	public function testAnUnheldRoleFailsNamingWhatIsHeld(): void {
+		$run = $this->newRun();
+		$subjects = $this->subjects();
+		$subjects->record(run: $run, role: 'case', uuid: 'obj-1');
+		$subjects->record(run: $run, role: 'besluit', uuid: 'obj-2');
+
+		try {
+			$subjects->addressed(run: $run, role: 'csae');
+			$this->fail('an unheld role should fail');
+		} catch (UnexpectedValueException $e) {
+			$this->assertStringContainsString('csae', $e->getMessage());
+			$this->assertStringContainsString('besluit', $e->getMessage());
+			$this->assertStringContainsString('case', $e->getMessage());
+		}
+	}//end testAnUnheldRoleFailsNamingWhatIsHeld()
+
+	/**
+	 * A run holding nothing says so, rather than listing an empty set.
+	 *
+	 * @return void
+	 */
+	public function testARunHoldingNothingSaysSo(): void {
+		try {
+			$this->subjects()->addressed(run: $this->newRun(), role: 'case');
+			$this->fail('an unheld role should fail');
+		} catch (UnexpectedValueException $e) {
+			$this->assertStringContainsString('declared none', $e->getMessage());
+		}
+	}//end testARunHoldingNothingSaysSo()
+
+	/**
+	 * A role or an object that is empty is refused, not stored.
+	 *
+	 * A subject with no object would be addressable and would attach a task to
+	 * nothing.
+	 *
+	 * @return void
+	 */
+	public function testAnEmptyRoleOrObjectIsRefused(): void {
+		$subjects = $this->subjects();
+
+		$this->expectException(UnexpectedValueException::class);
+		$subjects->record(run: $this->newRun(), role: 'case', uuid: '   ');
+	}//end testAnEmptyRoleOrObjectIsRefused()
+
+	/**
+	 * Several roles coexist, and each addresses its own object.
+	 *
+	 * @return void
+	 */
+	public function testSeveralRolesCoexist(): void {
+		$run = $this->newRun();
+		$subjects = $this->subjects();
+
+		$subjects->record(run: $run, role: 'case', uuid: 'obj-1');
+		$subjects->record(run: $run, role: 'besluit', uuid: 'obj-2');
+		$subjects->record(run: $run, role: 'aanvraag', uuid: 'obj-3');
+
+		$this->assertSame(['aanvraag', 'besluit', 'case'], $subjects->roles(run: $run));
+		$this->assertSame('obj-2', $subjects->addressed(run: $run, role: 'besluit')['uuid']);
+	}//end testSeveralRolesCoexist()
+}//end class


### PR DESCRIPTION
## What it adds

A run now keeps the set of objects it is working with, each under a **role** its own author chose: `{"case": {"uuid": …, "register": …, "schema": …}}`.

## Why declared rather than derived

The audit trail already answers "what did this run write", and it is tempting to reuse that. It cannot serve this purpose, for a reason that only shows up in the flows that need it:

- a case flow **reads** a case it never writes
- it **writes** a task, a document and an audit row it does not consider subjects
- it may write the same object at three steps for three different reasons

The derived list therefore contains too much and too little at once — and, decisively, it carries **no role**. `attachTo: case` needs a name, and a list of things that happened has none to give.

So the two coexist. Derived answers the auditor. Declared answers the author.

## A role, not an index

`attachTo: 2` would work, would be unreadable, and would break the moment a step is inserted. Roles are per-run and unconstrained on purpose — `case`, `besluit`, `aanvraag` are all fine — and a typo is caught by the addressing rule **failing loudly and naming the roles the run holds**, rather than by a registry somebody has to maintain.

## Idempotency is not optional

A user-task node is re-entered on a heartbeat, by design, with its task still open — so any node that records a subject is re-entered too. A set that grew on each wake would report a run as working on the same case forty times. Forty wake-ups leave one subject and log nothing; only a **different** object under a held role is a replacement.

## Replacement is recorded, not refused

Superseding a draft decision with a final one genuinely means `decision` to be the new object, and refusing would force authors into `decision2`. But it is also exactly how a later step silently attaches to the wrong record, so the log entry names both objects and the role — which makes "why is this task on the old decision" answerable in under a minute.

## The repair seeds one thing

The `trigger` entry, from `subject_uuid`, which is a fact the run already carried. 🔴 **Nothing is back-filled from the audit** — those declarations would then be *addressable* by `attachTo`, and a task attached to an object no author ever declared is worse than one that fails loudly the first time somebody uses it.

## Evidence

- 9 unit tests, **each seen red by mutating the implementation**: making a re-fire append fails the heartbeat test, and returning nothing for an unheld role instead of failing fails two.
- phpcs, phpmd, psalm, phpstan and gate-16 clean. The 10 `forUpdate` errors in `tests/Unit/Db` are a pre-existing local-vendor artefact in files this change does not touch, and CI is green on them.
- `<version>` bumped in the same commit, or the repair never runs (gate-110).

## Scope

This is section 2 of `flow-run-subjects-and-answers`. Section 1 (the `answers` bag) already shipped. The nodes that record a subject, `attachTo` on the ask step, and the read-back endpoint follow.
