### PR TITLE
fix(e2e): the step palette moved out of the sidebar, so drive the picker

### DIFF
--- a/tests/e2e/ci/flow-controls.spec.ts
+++ b/tests/e2e/ci/flow-controls.spec.ts
@@ -26,8 +26,8 @@
  *
  * WHAT IT ASSERTS
  * ---------------
- *   1. the sidebar renders on a flow route, with its palette and actions
- *   2. a step can be added from the palette and reaches the canvas
+ *   1. the sidebar renders on a flow route, and the toolbar carries its actions
+ *   2. a step can be added from the toolbar's step picker and reaches the canvas
  *   3. Save persists — the route advances from `new` to the server's uuid
  *   4. Run now creates a run against that flow
  *
@@ -353,10 +353,27 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 			'the flow sidebar did not render — the controls are unreachable again',
 		).toBeVisible()
 
-		const palette = page.locator('.cn-flow-sidebar__palette')
+		// 🔴 THE PALETTE IS NOT IN THE SIDEBAR ANY MORE, since nextcloud-vue
+		// 2.40.0. A live instance serves sixty-five step types, and a
+		// one-per-row list that long in a 300px column is a scroll rather than
+		// a chooser, so it became `CnFlowStepPickerModal`, opened from the
+		// toolbar, where the same entries render as a grid. With it went the
+		// Steps tab and the tab strip.
+		//
+		// `.cn-flow-sidebar__palette` survives ONLY as dead CSS in the sidebar,
+		// which is why the old assertion could never pass again and this job
+		// was red all day: the selector still matched a rule, so it read as a
+		// rendering failure rather than as a retired surface.
+		//
+		// The BUTTON is what belongs in this "the controls exist" block. The
+		// picker itself is opened where the step is added, further down: it is
+		// a modal, and holding one open across the toolbar assertions below
+		// would put a focus trap over every one of them.
+		const addStep = page.locator('[data-testid="flow-add-step"]')
 		await expect(
-			palette,
-			"the step palette did not render, so the empty state's own instruction cannot be followed",
+			addStep,
+			"the toolbar offers no way to add a step, so the empty state's own "
+				+ 'instruction cannot be followed',
 		).toBeVisible()
 
 		// Save and Run live on the canvas toolbar (flow-editor consolidation):
@@ -374,16 +391,6 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 		await expect(toolbar).toBeVisible()
 		await expect(saveButton).toBeVisible()
 		await expect(runButton).toBeVisible()
-
-		// The palette is populated from /api/flow/node-catalog. An empty one
-		// renders the same container, so assert it has entries.
-		await expect
-			.poll(async () => await palette.locator('> *').count(), {
-				message:
-					'the palette rendered but is empty — the node catalog did not load',
-				timeout: 15_000,
-			})
-			.toBeGreaterThan(0)
 
 		// ── THE EDITOR IS INTERACTIVE BEFORE IT IS INITIALISED ──────────────
 		// This wait is the whole reason this spec used to fail 6 runs in 8.
@@ -440,8 +447,44 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 		// succession — terminal -> stop (4eac3a3), then stop -> end (7ba3c21) —
 		// and this locator was left on the middle spelling. That is the whole
 		// reason the job went red: `EndNode::getLabel()` returns `t('End')`, and
-		// the palette has carried no entry called "Stop" since that commit.
-		await clickThemed(palette.getByText('End', { exact: true }).first())
+		// the picker has carried no entry called "Stop" since that commit.
+		await clickThemed(addStep)
+
+		const picker = page.locator('[data-testid="flow-step-picker"]')
+		await expect(
+			picker,
+			"the step picker did not open, so the empty state's own instruction "
+				+ 'cannot be followed',
+		).toBeVisible()
+
+		// The picker is populated from /api/flow/node-catalog. An empty one
+		// renders the same dialog as a full one, so count the ITEMS rather than
+		// the container: without this, "no End step" reads as a catalogue entry
+		// that was removed when in fact nothing loaded at all.
+		await expect
+			.poll(
+				async () =>
+					await picker
+						.locator('[data-testid="flow-step-picker-item"]')
+						.count(),
+				{
+					message:
+						'the step picker opened but offers nothing — the node catalog did not load',
+					timeout: 15_000,
+				},
+			)
+			.toBeGreaterThan(0)
+
+		await clickThemed(
+			picker
+				.locator('[data-testid="flow-step-picker-item"]')
+				.filter({ hasText: 'End' })
+				.first(),
+		)
+		// Picking a step adds it and closes the dialog. Asserted rather than
+		// assumed: a dialog left open is a focus trap over every canvas and
+		// toolbar interaction below.
+		await expect(picker).toBeHidden()
 		const endCard = page.locator('.cn-flow-detail__node', {
 			hasText: 'End',
 		})

--- a/tests/e2e/ci/flow-lock-nodes.spec.ts
+++ b/tests/e2e/ci/flow-lock-nodes.spec.ts
@@ -182,30 +182,63 @@ test('both lock steps are offered in the editor palette and reach the canvas', a
 	// `/flows/new` does not reliably hydrate the canvas.
 	await clickThemed(page.getByRole('button', { name: 'New flow' }))
 
-	const palette = page.locator('.cn-flow-sidebar__palette')
-	await expect(
-		palette,
-		'the step palette did not render, so nothing can be said about what it offers',
-	).toBeVisible()
+	// 🔴 THE PALETTE IS NOT IN THE SIDEBAR ANY MORE, since nextcloud-vue
+	// 2.40.0. A live instance serves sixty-five step types, and a one-per-row
+	// list that long in a 300px column is a scroll rather than a chooser, so it
+	// became `CnFlowStepPickerModal`, opened from the toolbar, where the same
+	// entries render as a grid. With it went the Steps tab and the tab strip.
+	//
+	// `.cn-flow-sidebar__palette` survives ONLY as dead CSS, so the old
+	// assertion could never pass again — it read as "the palette did not
+	// render" on a page that had simply moved it.
+	//
+	// PICKING A STEP CLOSES THE DIALOG (`add()` emits `close`), so the picker
+	// is opened once per node rather than once for the loop.
+	const openPicker = async () => {
+		const addStep = page.locator('[data-testid="flow-add-step"]')
+		await expect(
+			addStep,
+			'the toolbar offers no way to add a step, so nothing can be said about what is on offer',
+		).toBeVisible()
+		await clickThemed(addStep)
 
-	// An empty palette renders the same container as a full one, so the
-	// per-node assertions below would each fail with "not found" and none of
-	// them would say that NOTHING loaded. Establish that first.
-	await expect
-		.poll(async () => await palette.locator('> *').count(), {
-			message:
-				'the palette rendered but is empty — the node catalogue never reached the editor, '
-				+ 'so a missing lock step below would be reported as a lock bug rather than a load failure',
-			timeout: 15_000,
-		})
-		.toBeGreaterThan(0)
+		const picker = page.locator('[data-testid="flow-step-picker"]')
+		await expect(
+			picker,
+			'the step picker did not open, so nothing can be said about what it offers',
+		).toBeVisible()
+
+		// An empty picker renders the same dialog as a full one, so the
+		// per-node assertions below would each fail with "not found" and none
+		// of them would say that NOTHING loaded. Establish that first.
+		await expect
+			.poll(
+				async () =>
+					await picker
+						.locator('[data-testid="flow-step-picker-item"]')
+						.count(),
+				{
+					message:
+						'the picker opened but offers nothing — the node catalogue never reached the editor, '
+						+ 'so a missing lock step below would be reported as a lock bug rather than a load failure',
+					timeout: 15_000,
+				},
+			)
+			.toBeGreaterThan(0)
+
+		return picker
+	}
 
 	// ── 3. PRESENT, AND ADDABLE ─────────────────────────────────────────────
 	for (const node of LOCK_NODES) {
-		const offered = palette.getByText(node.label, { exact: true }).first()
+		const picker = await openPicker()
+		const offered = picker
+			.locator('[data-testid="flow-step-picker-item"]')
+			.filter({ hasText: node.label })
+			.first()
 		await expect(
 			offered,
-			`the palette offers no "${node.label}" step, so a flow author cannot lock anything`,
+			`the picker offers no "${node.label}" step, so a flow author cannot lock anything`,
 		).toBeVisible()
 
 		// "Listed" is not "usable". The failure mode being guarded against
@@ -213,9 +246,10 @@ test('both lock steps are offered in the editor palette and reach the canvas', a
 		// renders and does nothing when picked is the same thing to the person
 		// authoring the flow.
 		await clickThemed(offered)
+		await expect(picker).toBeHidden()
 		await expect(
 			page.locator('.cn-flow-detail__node', { hasText: node.label }),
-			`"${node.label}" is in the palette but never reached the canvas when it was picked`,
+			`"${node.label}" is in the picker but never reached the canvas when it was picked`,
 		).toBeVisible()
 	}
 

--- a/tests/e2e/flow-engine.spec.ts
+++ b/tests/e2e/flow-engine.spec.ts
@@ -810,11 +810,21 @@ test.describe('the Flows page', () => {
 		).toBeVisible({ timeout: 15000 })
 		await expect(page.getByText('No steps yet')).toHaveCount(0)
 
-		// The palette offers the catalogue, and an in-flight catalogue is not
-		// reported as an unreadable one (the failure text used to show on
+		// The step picker offers the catalogue, and an in-flight catalogue is
+		// not reported as an unreadable one (the failure text used to show on
 		// every first paint of this route).
+		//
+		// It was `.cn-flow-sidebar__palette-item` until nextcloud-vue 2.40.0
+		// moved the palette out of the sidebar into `CnFlowStepPickerModal`,
+		// opened from the toolbar. This file is outside `tests/e2e/ci`, which
+		// is the only path CI runs, so the stale locator would have waited out
+		// its timeout for whoever ran it next rather than failing a job.
+		await page.locator('[data-testid="flow-add-step"]').click()
 		await expect(
-			page.locator('.cn-flow-sidebar__palette-item').first(),
+			page
+				.locator('[data-testid="flow-step-picker"]')
+				.locator('[data-testid="flow-step-picker-item"]')
+				.first(),
 		).toBeVisible({ timeout: 15000 })
 		await expect(page.getByText('could not be read')).toHaveCount(0)
 	})


### PR DESCRIPTION
openregister's `quality / E2E Tests (Playwright)` has been red on development all day, on two specs, both waiting 15 seconds for `.cn-flow-sidebar__palette` and reporting "the step palette did not render".

It rendered. It moved.

## What happened

nextcloud-vue 2.40.0 says it in the component's own header:

> ⚠️ **THE PALETTE IS NOT HERE ANY MORE.** A live instance serves SIXTY-FIVE step types, and a one-per-row list that long in a 300px column is a scroll rather than a chooser. It is `CnFlowStepPickerModal`, opened from the toolbar, where the same entries render as a grid. With it went the Steps tab, and with that the tab strip.

Only the CSS rules stayed behind in the sidebar. That is precisely why the failure read as a rendering fault: the class still existed, so nothing in the message pointed at a retirement. The page snapshot in the trace settles it — the sidebar carries a heading and a Runs region and nothing else, and the toolbar carries "Add a step".

Worth noting for the next one of these: `/api/flow/node-catalog` answered 200 with 24 KB of steps on the failing run. The catalogue was fine the whole time.

## The fix

Both CI specs open the picker from the toolbar and assert inside it.

- The **item** count, not the container, is what proves the catalogue loaded. An empty picker renders the same dialog as a full one, so without this a missing lock step reads as a lock bug rather than as a load failure.
- Picking a step closes the dialog (`add()` emits `close`), so `flow-lock-nodes` reopens it per node, and both specs assert the dialog is hidden before touching the canvas. A dialog left open is a focus trap over every interaction after it.
- `flow-controls` opens the picker where the step is **added**, not in the "the controls exist" block. That block asserts the button, which is the control that exists there now.

`tests/e2e/flow-engine.spec.ts` carried the same stale locator. It sits outside `tests/e2e/ci`, the only path CI runs, so it would have waited out its timeout for whoever ran it next rather than failing a job. Fixed with the others.

## Verification

prettier and eslint clean. The two failing specs are the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
