### PR TITLE
fix(e2e): match the step picker's name exactly, not the card loosely

### DIFF
--- a/tests/e2e/ci/flow-controls.spec.ts
+++ b/tests/e2e/ci/flow-controls.spec.ts
@@ -475,10 +475,21 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 			)
 			.toBeGreaterThan(0)
 
+		// MATCH THE NAME EXACTLY, NOT THE CARD LOOSELY. Each card carries the
+		// step's name, its role word, its description and its catalogue id, and
+		// `hasText` is a case-insensitive SUBSTRING match over all of that — so
+		// 'End' also matches "Send email" and any description containing the
+		// word. The first version of this fix used the loose filter, picked a
+		// different step, and failed at the canvas assertion below saying the
+		// step never arrived. It had arrived; it was the wrong one.
 		await clickThemed(
 			picker
 				.locator('[data-testid="flow-step-picker-item"]')
-				.filter({ hasText: 'End' })
+				.filter({
+					has: page.locator('.cn-step-picker__name', {
+						hasText: /^End$/,
+					}),
+				})
 				.first(),
 		)
 		// Picking a step adds it and closes the dialog. Asserted rather than

--- a/tests/e2e/ci/flow-lock-nodes.spec.ts
+++ b/tests/e2e/ci/flow-lock-nodes.spec.ts
@@ -232,9 +232,18 @@ test('both lock steps are offered in the editor palette and reach the canvas', a
 	// ── 3. PRESENT, AND ADDABLE ─────────────────────────────────────────────
 	for (const node of LOCK_NODES) {
 		const picker = await openPicker()
+		// MATCH THE NAME EXACTLY. `hasText` is a case-insensitive SUBSTRING
+		// match over the whole card — name, role word, description and
+		// catalogue id — and "Lock an object" is a substring of "Unlock an
+		// object", so the loose filter matched BOTH of the two steps this file
+		// exists to tell apart.
 		const offered = picker
 			.locator('[data-testid="flow-step-picker-item"]')
-			.filter({ hasText: node.label })
+			.filter({
+				has: page.locator('.cn-step-picker__name', {
+					hasText: new RegExp(`^${node.label}$`),
+				}),
+			})
 			.first()
 		await expect(
 			offered,


### PR DESCRIPTION
#3508 moved these specs onto the step picker and got the hard part right: the picker opens, the catalogue loads, the item is clicked, the dialog closes. Then `flow-controls` failed one assertion later:

```
the step did not reach the canvas
locator('.cn-flow-detail__node').filter({ hasText: 'End' })
```

The step **had** reached the canvas. It was the wrong step.

## What I got wrong

I replaced an exact match with a loose one. The old locator was `palette.getByText('End', { exact: true })`; mine was `.filter({ hasText: 'End' })` over the whole picker item.

Each card carries four things — the step's name, its role word, its description, and its catalogue id — and `hasText` matches case-insensitively as a substring across all of them. Sixty-five steps go through that filter and "End" appears in more than one.

`flow-lock-nodes` had the same defect, and it is sharper there: that file exists to tell **Lock an object** and **Unlock an object** apart, and the first is a substring of the second. The loose filter matched both, and `.first()` decided which step the test was really about.

## The fix

Both now filter on the name element with an anchored regex, so a card's description or id cannot satisfy them:

```ts
.filter({
  has: page.locator('.cn-step-picker__name', { hasText: /^End$/ }),
})
```

## Verification

prettier and eslint clean. The E2E job is `skipping` on a pull request and runs only on the development push, so this is proven on the merge or not at all — which is also how the loose filter got through: #3508's checks were all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
