### PR TITLE
chore(release): 2.1.2-unstable.20260907193008

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -40,7 +40,7 @@ Open Register drijft apps zoals OpenCatalogi, Procest, Pipelinq en Software Cata
 
 Vrij en open source onder de EUPL-licentie.
     ]]></description>
-    <version>2.0.18-unstable.20260907165321</version>
+    <version>2.1.2-unstable.20260907193008</version>
     <licence>EUPL-1.2</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>OpenRegister</namespace>

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.3",
     "info": {
         "title": "openregister",
-        "version": "2.0.15-unstable.20260905143606",
+        "version": "2.1.2-unstable.20260907193008",
         "description": "Open Register",
         "license": {
             "name": "EUPL-1.2"


### PR DESCRIPTION
Version bump for 2.1.2-unstable.20260907193008, opened by the release workflow.

The tag v2.1.2-unstable.20260907193008 already names this commit, so the released
package and its label agree. Merging this brings development up
to the released version.

Raised as a pull request rather than pushed directly because
development requires one; a direct push is rejected with GH013
and takes the release down with it.