### PR TITLE
fix(e2e): three buttons on this page are called "Actions"

### DIFF
--- a/tests/e2e/ci/flow-controls.spec.ts
+++ b/tests/e2e/ci/flow-controls.spec.ts
@@ -164,25 +164,38 @@ async function openFlowActionsMenu(page: Page, item: Locator): Promise<void> {
 		return
 	}
 
-	const triggers = [
+	// 🔴 THREE BUTTONS ON THIS PAGE ARE CALLED "Actions". The canvas has one,
+	// and NcAppSidebar renders one in its header. This used to take `.first()`
+	// of each candidate group, so it opened a menu that does not contain the
+	// flow actions, found no Publish, and moved on having tried ONE of the
+	// three — then waited out the test's whole 45s budget on a page that was
+	// working. The reported failure was the CLEANUP that ran afterwards, which
+	// names neither the menu nor the button.
+	//
+	// So: try every button each selector matches, not just the first, and put
+	// a BOUND on each click. An unbounded click on a control that never becomes
+	// actionable spends the budget that the remaining candidates need.
+	const groups = [
+		page.locator('.app-sidebar-header__menu button'),
 		page.getByRole('button', { name: 'Flow actions' }),
 		page.getByRole('button', {
 			name: /^(Actions|Open actions menu|More actions)$/i,
 		}),
-		page.locator('.app-sidebar-header__menu button').first(),
 	]
 
-	for (const trigger of triggers) {
-		if ((await trigger.count()) === 0) {
-			continue
-		}
+	for (const group of groups) {
+		const count = await group.count().catch(() => 0)
+		for (let i = 0; i < count; i++) {
+			await group
+				.nth(i)
+				.click({ timeout: 5_000 })
+				.catch(() => {})
+			if (await item.isVisible().catch(() => false)) {
+				return
+			}
 
-		await trigger
-			.first()
-			.click()
-			.catch(() => {})
-		if (await item.isVisible().catch(() => false)) {
-			return
+			// Close whatever DID open, so it cannot cover the next candidate.
+			await page.keyboard.press('Escape').catch(() => {})
 		}
 	}
 


### PR DESCRIPTION
With the picker fix (#3508) and the exact-match fix (#3511) in, this spec now builds the flow correctly. The trace proves it — the End step is on the canvas, there is an edge from the start node, and Run is enabled:

```
- group "Edge from start-mtrmn4am to openregister.end-mtrmn4jn-1"
- toolbar "Flow editor":
    - button "Add a step"  - button "Save"  - button "Run"   ← enabled
```

It then times out at 45s, and the error it reports is the **cleanup** that ran afterwards:

```
page.evaluate: Target page, context or browser has been closed
  at deleteFlow (...:221)
```

which names neither the control it was waiting for nor the menu it was waiting in. The last locator in the trace is `[data-testid="flow-publish"]`.

## The cause

**Three buttons on this page are named "Actions"** — the canvas has one, and NcAppSidebar renders one in its header. `openFlowActionsMenu` took `.first()` of each candidate group, so it opened a menu that does not carry the flow actions, found no Publish, and moved on having tried **one of the three**.

Its own carefully-written "could not open the flow-actions menu, buttons present: …" error never fired, because the test budget ran out before the loop finished.

## The fix

- try **every** button each selector matches, not just the first, and press Escape between attempts so a menu that did open cannot cover the next candidate;
- **bound each click at 5s**. An unbounded click on a control that never becomes actionable spends the budget the remaining candidates need — which is how a helper written to name its own failure produced a timeout somewhere else instead.

The sidebar header menu is tried first now, because that is where these actions actually live.

## Note for integriq

`tests/e2e/regression/flows-editor.spec.ts` there carries a copy of this helper with the same `.first()` flaw. It has not bitten yet (that page appears to have one Actions button), but it is the same latent bug.

## Verification

prettier and eslint clean. The E2E job is `skipping` on a pull request and runs only on the development push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
