### PR TITLE
fix(e2e): the Publish menu item opens a dialog, it does not publish

### DIFF
--- a/tests/e2e/ci/flow-controls.spec.ts
+++ b/tests/e2e/ci/flow-controls.spec.ts
@@ -682,11 +682,42 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 
 		await clickThemed(publishButton)
 
+		// 🔴 THE MENU ITEM OPENS A DIALOG; IT DOES NOT PUBLISH. Its handler is
+		// `run: () => { this.publishOpen = true }`, which mounts
+		// `CnFlowPublishDialog` — the confirmation that shows the next version,
+		// what the bump removes, and any refusal. Publishing is what its own
+		// primary button does.
+		//
+		// Without this the spec pressed the menu item, sent NO request at all,
+		// and reported "the POST was rejected or swallowed". The trace is
+		// unambiguous: the only calls in the whole test were the flow's own
+		// POST /api/flows and the cleanup DELETE. There was no publish request
+		// to reject.
+		const publishDialog = page.locator('[data-testid="flow-publish-dialog"]')
+		await expect(
+			publishDialog,
+			'pressing Publish did not open the publish confirmation',
+		).toBeVisible({ timeout: 10_000 })
+
+		// A refusal is a legitimate answer and it renders IN the dialog, so
+		// read it out rather than letting the confirm below time out silently.
+		const refusal = publishDialog.locator('[data-testid="flow-publish-refusal"]')
+		if (await refusal.isVisible().catch(() => false)) {
+			throw new Error(
+				'the publish dialog refused the version bump: '
+					+ ((await refusal.textContent()) ?? '').trim(),
+			)
+		}
+
+		await clickThemed(
+			publishDialog.locator('[data-testid="flow-publish-confirm"]'),
+		)
+
 		await expect(
 			page.locator('[data-testid="flow-lifecycle"]'),
-			'Publish was pressed but the flow never became published — the store '
-				+ 'still shows the draft it started as, so the POST was rejected or '
-				+ 'swallowed',
+			'Publish was confirmed but the flow never became published — the '
+				+ 'store still shows the draft it started as, so the POST was '
+				+ 'rejected or swallowed',
 		).toHaveText('Published', { timeout: 10_000 })
 
 		// 5. RUN NOW CREATES A RUN. Asserted against the API rather than the


### PR DESCRIPTION
With the actions-menu fix (#3517) in, the menu opens and Publish is pressed. The flow then stays a Draft:

```
Publish was pressed but the flow never became published — the store
still shows the draft it started as, so the POST was rejected or swallowed
```

**There was no POST to reject.** The trace's entire request log for this test is the flow's own `POST /api/flows` (201) and the cleanup `DELETE`. Nothing was ever sent to publish.

## Why

The menu item's handler is:

```js
run: () => { this.publishOpen = true }
```

It **opens** `CnFlowPublishDialog` — the confirmation carrying the next version, what the bump removes, and any refusal. Publishing is what that dialog's own primary button does. The spec pressed the opener and then waited for the outcome of a button it never reached.

## The fix

Assert the dialog opens, then confirm through `[data-testid="flow-publish-confirm"]`.

**A refusal is read out rather than waited on.** `flow-publish-refusal` renders in the same dialog when the version bump is declined, and that is a legitimate answer. Without handling it the confirm would sit out its budget and the failure would point at the lifecycle pill instead of the reason printed on screen.

## Where this sits

Fourth in a chain, each one uncovered by fixing the one before:

1. #3508 — the palette moved to a modal off the toolbar (nc-vue 2.40.0)
2. #3511 — my `hasText` filter matched the card loosely and picked the wrong step
3. #3517 — three buttons on the page are named "Actions"; the helper only tried the first
4. this one — the Publish item opens a dialog

Each step got further into the test. The step now reaches the canvas, the flow saves, Run enables, and the menu opens — all visible in the trace.

## Verification

prettier and eslint clean, SPDX header intact. The E2E job is `skipping` on a pull request and runs only on the development push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
