### PR TITLE
fix(e2e): click the button, not the list item it sits in

### DIFF
--- a/tests/e2e/ci/flow-controls.spec.ts
+++ b/tests/e2e/ci/flow-controls.spec.ts
@@ -680,7 +680,25 @@ test('flow controls render, and a flow can be built, saved and run', async ({
 		const publishButton = page.locator('[data-testid="flow-publish"]')
 		await openFlowActionsMenu(page, publishButton)
 
-		await clickThemed(publishButton)
+		// 🔴 CLICK THE BUTTON, NOT THE LIST ITEM. `data-testid` is a
+		// fallthrough attribute on `NcActionButton`, and that component's root
+		// is the `<li>` — the handler is bound to the `<button>` inside it.
+		// `clickThemed` dispatches the event straight at the element it is
+		// given, so aiming it at the `<li>` fires an event nothing listens for:
+		// the menu stayed open with "Publish" plainly in it, and the dialog
+		// never mounted.
+		//
+		// The accessibility tree names it, so drive it the way a screen reader
+		// would. Falls back to the testid's inner button if the role is ever
+		// renamed, and both are scoped to the open menu.
+		const publishItem = page
+			.getByRole('menuitem', { name: 'Publish', exact: true })
+			.first()
+		if (await publishItem.isVisible().catch(() => false)) {
+			await clickThemed(publishItem)
+		} else {
+			await clickThemed(publishButton.locator('button').first())
+		}
 
 		// 🔴 THE MENU ITEM OPENS A DIALOG; IT DOES NOT PUBLISH. Its handler is
 		// `run: () => { this.publishOpen = true }`, which mounts


### PR DESCRIPTION
#3519 made the failure precise — "pressing Publish did not open the publish confirmation" — and the page snapshot shows why it could never open:

```
- button "Actions" [expanded]
- menu "Actions":
    - menuitem "Edit flow"
    - menuitem "Enable"
    - menuitem "Publish"        ← right there, unclicked
```

The menu opened. The item was present. Nothing happened.

## Why

`data-testid` is a **fallthrough attribute** on `NcActionButton`, and that component's root is the `<li>`. The handler is bound to the `<button>` inside it. `clickThemed` dispatches the event straight at the element it is handed, so aiming it at the `<li>` fires an event nothing listens for.

Playwright's own `.click()` would have walked down to a clickable descendant and hidden this — which is exactly the trade this file already documents for preferring a dispatched event over `.click()` on themed controls.

## The fix

Driven through `getByRole('menuitem', { name: 'Publish' })`. The accessibility tree names it, so this is also how a screen-reader user reaches the control. The testid's inner button stays as a fallback if the role is ever renamed.

Same shape as the `flow-settings-name` fix in integriq #1889: **a testid on a wrapper component is not a testid on the control.**

## The chain so far

Five, each uncovered by the one before, each visible only on the development push:

1. #3508 — the palette moved to a modal off the toolbar (nc-vue 2.40.0)
2. #3511 — `hasText` matched the card loosely and picked the wrong step
3. #3517 — three buttons on the page are named "Actions"; only the first was tried
4. #3519 — the Publish item opens a dialog; it does not publish
5. this one — the click landed on the `<li>`, not the `<button>`

## Verification

prettier and eslint clean, SPDX header intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
