### PR TITLE
fix(tests): cap PHPUnit memory and stop resolving app services through the global server

### DIFF
--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -833,7 +833,7 @@ class ObjectsController extends Controller {
 	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
 	 */
 	private function crossTableSearch(array $registers, array $schemas, ObjectService $objectService): JSONResponse {
-		$magicMapper = \OC::$server->get(\OCA\OpenRegister\Db\MagicMapper::class);
+		$magicMapper = $this->container->get(\OCA\OpenRegister\Db\MagicMapper::class);
 		$registerMapper = $this->registerMapper;
 		$schemaMapper = $this->schemaMapper;
 
@@ -935,7 +935,7 @@ class ObjectsController extends Controller {
 		// and an admin is not exempt from the writeOnly render boundary (#389).
 		// No `?? true` fallback: this method sets $query['_rbac'] unconditionally
 		// a few lines above, so the key is always present here.
-		$renderHandler = \OC::$server->get(\OCA\OpenRegister\Service\Object\RenderObject::class);
+		$renderHandler = $this->container->get(\OCA\OpenRegister\Service\Object\RenderObject::class);
 		// No `?? true` on THIS path: `_rbac` is assigned unconditionally above and
 		// the unset() in between does not remove it, so the fallback was dead --
 		// and had it ever fired it would have forced the RBAC strip on exactly the
@@ -1171,7 +1171,7 @@ class ObjectsController extends Controller {
 			// which delegates to the registered provider (object-source-providers).
 			if ($isMagicMapped === true && $schemaEntity->getObjectSource() === null) {
 				// Use MagicMapper for magic-mapped schemas.
-				$magicMapper = \OC::$server->get(\OCA\OpenRegister\Db\MagicMapper::class);
+				$magicMapper = $this->container->get(\OCA\OpenRegister\Db\MagicMapper::class);
 
 				// Build search query with resolved numeric IDs.
 				$query = $objectService->buildSearchQuery(
@@ -1214,7 +1214,7 @@ class ObjectsController extends Controller {
 
 				// Apply complex rendering if needed (extensions, fields, filters).
 				if ($hasComplexRendering === true && is_array($results) === true && empty($results) === false) {
-					$renderHandler = \OC::$server->get(\OCA\OpenRegister\Service\Object\RenderObject::class);
+					$renderHandler = $this->container->get(\OCA\OpenRegister\Service\Object\RenderObject::class);
 					$serializedResults = $renderHandler->renderEntities(
 						entities: $results,
 						_extend: $extend,
@@ -1235,7 +1235,7 @@ class ObjectsController extends Controller {
 					// `$rbac` is `($isAdmin === false)` and gates ONLY the property
 					// `authorization.read` strip — writeOnly strips unconditionally, admin
 					// included (#389/#460).
-					$renderHandler = \OC::$server->get(\OCA\OpenRegister\Service\Object\RenderObject::class);
+					$renderHandler = $this->container->get(\OCA\OpenRegister\Service\Object\RenderObject::class);
 					$renderHandler->redactWriteOnlyFromRows(rows: $results, _rbac: $rbac);
 
 					$serializedResults = [];
@@ -1303,7 +1303,7 @@ class ObjectsController extends Controller {
 				// Get active organisation for debugging metadata.
 				$activeOrganisation = null;
 				try {
-					$organisationService = \OC::$server->get(\OCA\OpenRegister\Service\OrganisationService::class);
+					$organisationService = $this->container->get(\OCA\OpenRegister\Service\OrganisationService::class);
 					$activeOrg = $organisationService?->getActiveOrganisation();
 					$activeOrganisation = $activeOrg?->getUuid();
 				} catch (\Throwable $e) {
@@ -1688,7 +1688,7 @@ class ObjectsController extends Controller {
 			);
 
 			if ($isMagicMapped === true && $schemaEntity->getObjectSource() === null) {
-				$magicMapper = \OC::$server->get(\OCA\OpenRegister\Db\MagicMapper::class);
+				$magicMapper = $this->container->get(\OCA\OpenRegister\Db\MagicMapper::class);
 
 				$countQuery = $query;
 				unset($countQuery['_limit'], $countQuery['_offset'], $countQuery['_page']);
@@ -2215,7 +2215,7 @@ class ObjectsController extends Controller {
 						|| in_array($schemaSlug, $magicMappingSchemas, true) === true)
 					) {
 						// Use MagicMapper for magic-mapped schemas.
-						$magicMapper = \OC::$server->get(\OCA\OpenRegister\Db\MagicMapper::class);
+						$magicMapper = $this->container->get(\OCA\OpenRegister\Db\MagicMapper::class);
 
 						// Build search query with resolved numeric IDs.
 						$query = $objectService->buildSearchQuery(
@@ -2235,7 +2235,7 @@ class ObjectsController extends Controller {
 						// ocon#147) — this direct-magic-mapper path bypasses renderEntity.
 						// `_rbac` (false for an admin) gates only the property
 						// `authorization.read` strip; writeOnly strips unconditionally (#460).
-						$renderHandler = \OC::$server->get(\OCA\OpenRegister\Service\Object\RenderObject::class);
+						$renderHandler = $this->container->get(\OCA\OpenRegister\Service\Object\RenderObject::class);
 						$renderHandler->redactWriteOnlyFromRows(rows: $results, _rbac: $query['_rbac'] ?? true);
 
 						// Convert ObjectEntity array to JSON-serializable format.

--- a/lib/Service/Object/SaveObject.php
+++ b/lib/Service/Object/SaveObject.php
@@ -65,6 +65,7 @@ use OCP\IGroupManager;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserSession;
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Symfony\Component\Uid\Uuid;
@@ -133,6 +134,9 @@ use Twig\Loader\ArrayLoader;
  * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  * @SuppressWarnings(PHPMD.LongVariable)
+ *
+ * @spec openspec/specs/object-lifecycle/spec.md#requirement-declared-initial-lifecycle-state-applied-on-create
+ * @spec openspec/specs/objects-crud/spec.md#requirement-partial-object-updates-are-protected-against-lost-updates
  */
 class SaveObject {
 	private const URL_PATH_IDENTIFIER = 'openregister.objects.show';
@@ -309,6 +313,7 @@ class SaveObject {
 	 * @param \OCA\OpenRegister\Service\ObjectSource\ObjectSourceRegistry|null $objectSourceRegistry Writable object-source provider registry
 	 * @param FieldEncryptionHandler|null $fieldEncryptionHandler Field-level encryption handler
 	 * @param \OCA\OpenRegister\Service\Flow\FlowRunContext|null $runContext The ambient flow-run stack, so the lock guard can tell which run is writing
+	 * @param ContainerInterface|null $container App container, consulted lazily for the retention service (see resolveRetentionService)
 	 *
 	 * @SuppressWarnings(PHPMD.ExcessiveParameterList) Nextcloud DI requires constructor injection
 	 *
@@ -344,9 +349,45 @@ class SaveObject {
 		private readonly ?\OCA\OpenRegister\Service\ObjectSource\ObjectSourceRegistry $objectSourceRegistry = null,
 		private readonly ?FieldEncryptionHandler $fieldEncryptionHandler = null,
 		private readonly ?\OCA\OpenRegister\Service\Flow\FlowRunContext $runContext = null,
+		private readonly ?ContainerInterface $container = null,
 	) {
 		$this->twig = new Environment($arrayLoader);
 	}//end __construct()
+
+	/**
+	 * Resolve the retention service from the app container, or null when there is none.
+	 *
+	 * The retention service is resolved lazily instead of being constructor-injected
+	 * because its dependency graph reaches back into the object mappers this handler
+	 * already owns. It goes through the injected app container, never the global
+	 * server: the global container knows nothing about this app's registrations
+	 * outside a booted Nextcloud, so a lookup there autowires an unbounded
+	 * MagicMapper -> SettingsService -> ValidationOperationsHandler -> ValidateObject
+	 * cycle. That cycle ate 19 GB in a unit-test run on 2026-09-08.
+	 *
+	 * @return \OCA\OpenRegister\Service\RetentionService|null The service, or null when unavailable
+	 *
+	 * @spec openspec/specs/retention-management/spec.md#requirement-objects-must-carry-mdto-compliant-archival-metadata-in-the-retention-field
+	 * @spec openspec/specs/retention-management/spec.md#requirement-the-system-must-calculate-archiefactiedatum-using-configurable-afleidingswijzen
+	 */
+	private function resolveRetentionService(): ?\OCA\OpenRegister\Service\RetentionService {
+		if ($this->container === null) {
+			return null;
+		}
+
+		try {
+			$service = $this->container->get(\OCA\OpenRegister\Service\RetentionService::class);
+		} catch (\Throwable $e) {
+			$this->logger->debug('[SaveObject] RetentionService not available: ' . $e->getMessage());
+			return null;
+		}
+
+		if ($service instanceof \OCA\OpenRegister\Service\RetentionService) {
+			return $service;
+		}
+
+		return null;
+	}//end resolveRetentionService()
 
 	/**
 	 * Get sub-objects created during cascade operations.
@@ -3394,13 +3435,13 @@ class SaveObject {
 		);
 
 		// Apply archival metadata from schema archive configuration.
-		try {
-			$retentionService = \OC::$server->get(\OCA\OpenRegister\Service\RetentionService::class);
-			$preparedObject = $retentionService->applyArchivalMetadata($preparedObject, $schema);
-		} catch (\Throwable $e) {
-			$this->logger->debug(
-				'[SaveObject] RetentionService not available, skipping archival metadata: ' . $e->getMessage()
-			);
+		$retentionService = $this->resolveRetentionService();
+		if ($retentionService !== null) {
+			try {
+				$preparedObject = $retentionService->applyArchivalMetadata($preparedObject, $schema);
+			} catch (\Throwable $e) {
+				$this->logger->debug('[SaveObject] Skipping archival metadata: ' . $e->getMessage());
+			}
 		}
 
 		// If not persisting, return the prepared object.
@@ -5408,18 +5449,18 @@ class SaveObject {
 			folderId: $folderId
 		);
 
-		// Recalculate archiefactiedatum if source property changed.
-		try {
-			$retentionService = \OC::$server->get(\OCA\OpenRegister\Service\RetentionService::class);
-			$preparedObject = $retentionService->recalculateArchiveActionDate(
-				$preparedObject,
-				$schema,
-				$oldObject->getObject()
-			);
-		} catch (\Throwable $e) {
-			$this->logger->debug(
-				'[SaveObject] RetentionService not available for recalculation: ' . $e->getMessage()
-			);
+		// Recalculate the archive action date if a source property changed.
+		$retentionService = $this->resolveRetentionService();
+		if ($retentionService !== null) {
+			try {
+				$preparedObject = $retentionService->recalculateArchiveActionDate(
+					$preparedObject,
+					$schema,
+					$oldObject->getObject()
+				);
+			} catch (\Throwable $e) {
+				$this->logger->debug('[SaveObject] Skipping archive action date recalculation: ' . $e->getMessage());
+			}
 		}
 
 		// Update the object properties.

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -166,6 +166,9 @@ use Symfony\Component\Uid\Uuid;
  * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  * @SuppressWarnings(PHPMD.LongVariable)
+ *
+ * @spec openspec/specs/objects-crud/spec.md#requirement-partial-object-updates-are-protected-against-lost-updates
+ * @spec openspec/specs/object-lifecycle/spec.md#requirement-declared-initial-lifecycle-state-applied-on-create
  */
 class ObjectService implements ObjectServiceInterface
 {
@@ -1740,13 +1743,15 @@ class ObjectService implements ObjectServiceInterface
             // applied defaults), not the pre-save input array, so an email value
             // injected by a default/computed property is also invalidated.
             try {
-                $container = \OC::$server;
-                if ($container !== null) {
-                    $contactMatchingService = $container->get(
-                        \OCA\OpenRegister\Service\ContactMatchingService::class
-                    );
-                    $contactMatchingService->invalidateCacheForObject($savedObject->getObject());
-                }
+                // Through the injected app container, never `\OC::$server`: outside a
+                // booted Nextcloud the global container autowires this app's
+                // services from scratch and recurses through a MagicMapper ->
+                // SettingsService -> ValidationOperationsHandler -> ValidateObject
+                // cycle until memory runs out (19 GB on 2026-09-08).
+                $contactMatchingService = $this->container->get(
+                    \OCA\OpenRegister\Service\ContactMatchingService::class
+                );
+                $contactMatchingService->invalidateCacheForObject($savedObject->getObject());
             } catch (\Throwable $e) {
                 // BUG-OBJ-9 / BUG-OBJ-14: contact-match cache invalidation is a
                 // non-essential post-save side-effect and must NEVER fail the save.
@@ -1777,53 +1782,53 @@ class ObjectService implements ObjectServiceInterface
             // the providers actually match against (design.md D4). Best-effort:
             // never fails the save.
             try {
-                $container = \OC::$server;
-                if ($container !== null) {
-                    $referenceManager = $container->get(\OCP\Collaboration\Reference\IReferenceManager::class);
-                    $formatter = $container->get(\OCA\OpenRegister\Service\Reference\ObjectPreviewFormatter::class);
-                    $deepLinkRegistry = $container->get(\OCA\OpenRegister\Service\DeepLinkRegistryService::class);
+                // Same rule as the contact-match block above: the injected app
+                // container, never `\OC::$server`.
+                $container = $this->container;
+                $referenceManager = $container->get(\OCP\Collaboration\Reference\IReferenceManager::class);
+                $formatter = $container->get(\OCA\OpenRegister\Service\Reference\ObjectPreviewFormatter::class);
+                $deepLinkRegistry = $container->get(\OCA\OpenRegister\Service\DeepLinkRegistryService::class);
 
-                    $invalidationRegisterId = (int)$this->currentRegister?->getId();
-                    $invalidationSchemaId = (int)$this->currentSchema?->getId();
-                    $invalidationUuid = (string)$savedObject->getUuid();
+                $invalidationRegisterId = (int)$this->currentRegister?->getId();
+                $invalidationSchemaId = (int)$this->currentSchema?->getId();
+                $invalidationUuid = (string)$savedObject->getUuid();
 
-                    $invalidatedPrefixes = [];
-                    foreach (
-                        $formatter->buildCanonicalUrls(
-                            registerId: $invalidationRegisterId,
-                            schemaId: $invalidationSchemaId,
-                            uuid: $invalidationUuid
-                        ) as $canonicalUrl
-                    ) {
-                        $prefix = $formatter->resolveCachePrefix(referenceText: $canonicalUrl);
-                        if (isset($invalidatedPrefixes[$prefix]) === false) {
-                            $referenceManager->invalidateCache(cachePrefix: $prefix);
-                            $invalidatedPrefixes[$prefix] = true;
-                        }
-                    }
-
-                    // Flat data shape deep link URL templates resolve placeholders
-                    // against — same shape ObjectPreviewFormatter::buildReference()
-                    // and ObjectSearchResultFormatter::format() build for the same
-                    // purpose: the object's own fields plus the identity triple.
-                    $deepLinkObjectData = array_merge(
-                        $savedObject->getObject(),
-                        [
-                            'uuid' => $invalidationUuid,
-                            'register' => $invalidationRegisterId,
-                            'schema' => $invalidationSchemaId,
-                        ]
-                    );
-
-                    $deepLinkUrl = $deepLinkRegistry->resolveUrl(
+                $invalidatedPrefixes = [];
+                foreach (
+                    $formatter->buildCanonicalUrls(
                         registerId: $invalidationRegisterId,
                         schemaId: $invalidationSchemaId,
-                        objectData: $deepLinkObjectData
-                    );
-                    if ($deepLinkUrl !== null) {
-                        $referenceManager->invalidateCache(cachePrefix: $deepLinkUrl);
+                        uuid: $invalidationUuid
+                    ) as $canonicalUrl
+                ) {
+                    $prefix = $formatter->resolveCachePrefix(referenceText: $canonicalUrl);
+                    if (isset($invalidatedPrefixes[$prefix]) === false) {
+                        $referenceManager->invalidateCache(cachePrefix: $prefix);
+                        $invalidatedPrefixes[$prefix] = true;
                     }
-                }//end if
+                }
+
+                // Flat data shape deep link URL templates resolve placeholders
+                // against — same shape ObjectPreviewFormatter::buildReference()
+                // and ObjectSearchResultFormatter::format() build for the same
+                // purpose: the object's own fields plus the identity triple.
+                $deepLinkObjectData = array_merge(
+                    $savedObject->getObject(),
+                    [
+                        'uuid' => $invalidationUuid,
+                        'register' => $invalidationRegisterId,
+                        'schema' => $invalidationSchemaId,
+                    ]
+                );
+
+                $deepLinkUrl = $deepLinkRegistry->resolveUrl(
+                    registerId: $invalidationRegisterId,
+                    schemaId: $invalidationSchemaId,
+                    objectData: $deepLinkObjectData
+                );
+                if ($deepLinkUrl !== null) {
+                    $referenceManager->invalidateCache(cachePrefix: $deepLinkUrl);
+                }
             } catch (\Throwable $e) {
                 // Smart Picker cache invalidation is a non-essential post-save
                 // side-effect and must NEVER fail the save. Catch \Throwable (the

--- a/lib/Service/TextExtraction/EntityRecognitionHandler.php
+++ b/lib/Service/TextExtraction/EntityRecognitionHandler.php
@@ -35,6 +35,7 @@ use OCA\OpenRegister\Service\Anonymisation\BackendState;
 use OCA\OpenRegister\Service\SettingsService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IDBConnection;
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Uid\Uuid;
 
@@ -55,6 +56,8 @@ use Symfony\Component\Uid\Uuid;
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)   Entity recognition integrates multiple extraction strategies
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) Multiple detection strategies require per-strategy methods
+ *
+ * @spec openspec/specs/text-extraction/spec.md#requirement-file-and-object-chunk-extraction-lifecycle
  */
 class EntityRecognitionHandler {
 	/**
@@ -100,6 +103,7 @@ class EntityRecognitionHandler {
 	 * @param LoggerInterface $logger Logger.
 	 * @param SettingsService $settingsService Settings service.
 	 * @param AnonymisationBackendService $anonymisationBackendService Backend state + ExApp client.
+	 * @param ContainerInterface|null $container App container, consulted lazily for the object mapper.
 	 */
 	public function __construct(
 		private readonly ChunkMapper $chunkMapper,
@@ -109,6 +113,7 @@ class EntityRecognitionHandler {
 		private readonly LoggerInterface $logger,
 		private readonly SettingsService $settingsService,
 		private readonly AnonymisationBackendService $anonymisationBackendService,
+		private readonly ?ContainerInterface $container = null,
 	) {
 	}//end __construct()
 
@@ -1094,8 +1099,16 @@ class EntityRecognitionHandler {
 	 * @return void
 	 */
 	private function populateObjectContextOnRelation(EntityRelation $relation, int $objectId): void {
+		// Resolved lazily through the injected app container (the mapper's own
+		// graph reaches back into this service's collaborators), never through
+		// `\OC::$server`: outside a booted Nextcloud that autowires an unbounded
+		// cycle and eats all memory (19 GB on 2026-09-08).
+		if ($this->container === null) {
+			return;
+		}
+
 		try {
-			$objectMapper = \OC::$server->get(\OCA\OpenRegister\Db\MagicMapper::class);
+			$objectMapper = $this->container->get(\OCA\OpenRegister\Db\MagicMapper::class);
 			$object = $objectMapper->find(
 				$objectId,
 				_rbac: false,

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -61,5 +61,16 @@
 
     <php>
         <env name="PHPUNIT_RUN" value="1"/>
+        <!--
+            Hard memory cap for every PHPUnit run. The CLI php.ini on developer
+            machines sets memory_limit=-1, so a runaway test has nothing to stop
+            it: on 2026-09-08 one test recursed inside the DI container and took
+            19 GB of RAM plus 6 GB of swap before the machine ground to a halt.
+            The whole Unit suite (19,409 tests) peaks at 454 MB without
+            coverage; 2G leaves room for coverage runs and still fails a leak
+            within seconds. Raise it here, with the new measurement, never with
+            -d memory_limit on the command line.
+        -->
+        <ini name="memory_limit" value="2G"/>
     </php>
 </phpunit>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -280,12 +280,6 @@
       <code><![CDATA[$vtodo->{'X-OPENREGISTER-DATA'}]]></code>
     </UndefinedPropertyFetch>
   </file>
-  <file src="lib/Service/TextExtraction/EntityRecognitionHandler.php">
-    <UnusedParam>
-      <code><![CDATA[$objectId]]></code>
-      <code><![CDATA[$relation]]></code>
-    </UnusedParam>
-  </file>
   <file src="lib/Service/TextExtraction/SpreadsheetExtractor.php">
     <StringIncrement>
       <code><![CDATA[$col]]></code>

--- a/tests/Unit/Controller/ObjectsControllerCoverageTest.php
+++ b/tests/Unit/Controller/ObjectsControllerCoverageTest.php
@@ -45,6 +45,13 @@ class ObjectsControllerCoverageTest extends TestCase {
 	private IAppConfig&MockObject $config;
 	private IAppManager&MockObject $appManager;
 	private ContainerInterface&MockObject $container;
+
+	/**
+	 * Services the injected container hands out, keyed by id.
+	 *
+	 * @var array<string, callable>
+	 */
+	private array $services = [];
 	private MagicMapper&MockObject $objectMapper;
 	private RegisterMapper&MockObject $registerMapper;
 	private SchemaMapper&MockObject $schemaMapper;
@@ -64,6 +71,21 @@ class ObjectsControllerCoverageTest extends TestCase {
 		$this->config = $this->createMock(IAppConfig::class);
 		$this->appManager = $this->createMock(IAppManager::class);
 		$this->container = $this->createMock(ContainerInterface::class);
+		// The controller resolves MagicMapper, RenderObject and OrganisationService
+		// through its injected container (never the global server), so the tests
+		// register what they need here instead of on OC::$server.
+		$this->container->method('get')->willReturnCallback(
+			fn (string $id): mixed => isset($this->services[$id]) === true ? ($this->services[$id])() : null
+		);
+
+		// Default collaborators for the magic-mapper list paths. The old global
+		// registry leaked these from one test into the next; each test now has
+		// its own registry, so the defaults are explicit and a test overrides
+		// them by registering its own.
+		$defaultRenderHandler = $this->createMock(\OCA\OpenRegister\Service\Object\RenderObject::class);
+		$defaultRenderHandler->method('renderEntities')->willReturnArgument(0);
+		$this->registerService(\OCA\OpenRegister\Service\Object\RenderObject::class, fn () => $defaultRenderHandler);
+		$this->registerService(OrganisationService::class, fn () => $this->createMock(OrganisationService::class));
 		$this->objectMapper = $this->createMock(MagicMapper::class);
 		$this->registerMapper = $this->createMock(RegisterMapper::class);
 		$this->schemaMapper = $this->createMock(SchemaMapper::class);
@@ -365,7 +387,7 @@ class ObjectsControllerCoverageTest extends TestCase {
 		$magicMapper->method('countObjectsInRegisterSchemaTable')->willReturn(1);
 		$magicMapper->method('getIgnoredFilters')->willReturn([]);
 
-		\OC::$server->registerService(MagicMapper::class, function () use ($magicMapper) {
+		$this->registerService(MagicMapper::class, function () use ($magicMapper) {
 			return $magicMapper;
 		});
 
@@ -373,7 +395,7 @@ class ObjectsControllerCoverageTest extends TestCase {
 		// RenderObject::redactWriteOnlyFromRows (openregister#380 leak fix), so
 		// the container must resolve a RenderObject here as well.
 		$renderHandler = $this->createMock(\OCA\OpenRegister\Service\Object\RenderObject::class);
-		\OC::$server->registerService(\OCA\OpenRegister\Service\Object\RenderObject::class, function () use ($renderHandler) {
+		$this->registerService(\OCA\OpenRegister\Service\Object\RenderObject::class, function () use ($renderHandler) {
 			return $renderHandler;
 		});
 
@@ -420,7 +442,7 @@ class ObjectsControllerCoverageTest extends TestCase {
 		$magicMapper->method('countObjectsInRegisterSchemaTable')->willReturn(1);
 		$magicMapper->method('getIgnoredFilters')->willReturn([]);
 
-		\OC::$server->registerService(MagicMapper::class, function () use ($magicMapper) {
+		$this->registerService(MagicMapper::class, function () use ($magicMapper) {
 			return $magicMapper;
 		});
 
@@ -429,7 +451,7 @@ class ObjectsControllerCoverageTest extends TestCase {
 			['uuid' => 'magic-ext', 'title' => 'Extended', 'relation' => ['uuid' => 'rel-1']],
 		]);
 
-		\OC::$server->registerService(\OCA\OpenRegister\Service\Object\RenderObject::class, function () use ($renderHandler) {
+		$this->registerService(\OCA\OpenRegister\Service\Object\RenderObject::class, function () use ($renderHandler) {
 			return $renderHandler;
 		});
 
@@ -469,7 +491,7 @@ class ObjectsControllerCoverageTest extends TestCase {
 		$magicMapper->method('countObjectsInRegisterSchemaTable')->willReturn(0);
 		$magicMapper->method('getIgnoredFilters')->willReturn(['limit', 'offset']);
 
-		\OC::$server->registerService(MagicMapper::class, function () use ($magicMapper) {
+		$this->registerService(MagicMapper::class, function () use ($magicMapper) {
 			return $magicMapper;
 		});
 
@@ -512,7 +534,7 @@ class ObjectsControllerCoverageTest extends TestCase {
 			'status' => ['active' => 5, 'inactive' => 2],
 		]);
 
-		\OC::$server->registerService(MagicMapper::class, function () use ($magicMapper) {
+		$this->registerService(MagicMapper::class, function () use ($magicMapper) {
 			return $magicMapper;
 		});
 
@@ -554,7 +576,7 @@ class ObjectsControllerCoverageTest extends TestCase {
 		$magicMapper->method('getSimpleFacetsFromRegisterSchemaTable')
 			->willThrowException(new Exception('Column not found'));
 
-		\OC::$server->registerService(MagicMapper::class, function () use ($magicMapper) {
+		$this->registerService(MagicMapper::class, function () use ($magicMapper) {
 			return $magicMapper;
 		});
 
@@ -598,7 +620,7 @@ class ObjectsControllerCoverageTest extends TestCase {
 		$magicMapper->method('countObjectsInRegisterSchemaTable')->willReturn(1);
 		$magicMapper->method('getIgnoredFilters')->willReturn([]);
 
-		\OC::$server->registerService(MagicMapper::class, function () use ($magicMapper) {
+		$this->registerService(MagicMapper::class, function () use ($magicMapper) {
 			return $magicMapper;
 		});
 
@@ -636,7 +658,7 @@ class ObjectsControllerCoverageTest extends TestCase {
 		$magicMapper->method('countObjectsInRegisterSchemaTable')->willReturn(0);
 		$magicMapper->method('getIgnoredFilters')->willReturn([]);
 
-		\OC::$server->registerService(MagicMapper::class, function () use ($magicMapper) {
+		$this->registerService(MagicMapper::class, function () use ($magicMapper) {
 			return $magicMapper;
 		});
 
@@ -675,7 +697,7 @@ class ObjectsControllerCoverageTest extends TestCase {
 		$magicMapper->method('countObjectsInRegisterSchemaTable')->willReturn(0);
 		$magicMapper->method('getIgnoredFilters')->willReturn([]);
 
-		\OC::$server->registerService(MagicMapper::class, function () use ($magicMapper) {
+		$this->registerService(MagicMapper::class, function () use ($magicMapper) {
 			return $magicMapper;
 		});
 
@@ -722,7 +744,7 @@ class ObjectsControllerCoverageTest extends TestCase {
 		$magicMapper->method('countObjectsInRegisterSchemaTable')->willReturn(11);
 		$magicMapper->method('getIgnoredFilters')->willReturn([]);
 
-		\OC::$server->registerService(MagicMapper::class, function () use ($magicMapper) {
+		$this->registerService(MagicMapper::class, function () use ($magicMapper) {
 			return $magicMapper;
 		});
 
@@ -762,7 +784,7 @@ class ObjectsControllerCoverageTest extends TestCase {
 		$magicMapper->method('countObjectsInRegisterSchemaTable')->willReturn(0);
 		$magicMapper->method('getIgnoredFilters')->willReturn([]);
 
-		\OC::$server->registerService(MagicMapper::class, function () use ($magicMapper) {
+		$this->registerService(MagicMapper::class, function () use ($magicMapper) {
 			return $magicMapper;
 		});
 
@@ -800,7 +822,7 @@ class ObjectsControllerCoverageTest extends TestCase {
 		$magicMapper->method('countObjectsInRegisterSchemaTable')->willReturn(0);
 		$magicMapper->method('getIgnoredFilters')->willReturn([]);
 
-		\OC::$server->registerService(MagicMapper::class, function () use ($magicMapper) {
+		$this->registerService(MagicMapper::class, function () use ($magicMapper) {
 			return $magicMapper;
 		});
 
@@ -841,7 +863,7 @@ class ObjectsControllerCoverageTest extends TestCase {
 		// renderEntities returns ObjectEntity instances (not arrays) when extend is used.
 		$renderHandler->method('renderEntities')->willReturn([$objEntity]);
 
-		\OC::$server->registerService(\OCA\OpenRegister\Service\Object\RenderObject::class, function () use ($renderHandler) {
+		$this->registerService(\OCA\OpenRegister\Service\Object\RenderObject::class, function () use ($renderHandler) {
 			return $renderHandler;
 		});
 
@@ -850,7 +872,7 @@ class ObjectsControllerCoverageTest extends TestCase {
 		$magicMapper->method('countObjectsInRegisterSchemaTable')->willReturn(1);
 		$magicMapper->method('getIgnoredFilters')->willReturn([]);
 
-		\OC::$server->registerService(MagicMapper::class, function () use ($magicMapper) {
+		$this->registerService(MagicMapper::class, function () use ($magicMapper) {
 			return $magicMapper;
 		});
 
@@ -896,7 +918,7 @@ class ObjectsControllerCoverageTest extends TestCase {
 		$magicMapper = $this->createMock(MagicMapper::class);
 		$magicMapper->method('searchObjectsInRegisterSchemaTable')->willReturn([$objEntity]);
 
-		\OC::$server->registerService(MagicMapper::class, function () use ($magicMapper) {
+		$this->registerService(MagicMapper::class, function () use ($magicMapper) {
 			return $magicMapper;
 		});
 
@@ -940,7 +962,7 @@ class ObjectsControllerCoverageTest extends TestCase {
 		$magicMapper = $this->createMock(MagicMapper::class);
 		$magicMapper->method('searchObjectsInRegisterSchemaTable')->willReturn([$objEntity]);
 
-		\OC::$server->registerService(MagicMapper::class, function () use ($magicMapper) {
+		$this->registerService(MagicMapper::class, function () use ($magicMapper) {
 			return $magicMapper;
 		});
 
@@ -981,7 +1003,7 @@ class ObjectsControllerCoverageTest extends TestCase {
 		$magicMapper = $this->createMock(MagicMapper::class);
 		$magicMapper->method('searchObjectsInRegisterSchemaTable')->willReturn([$objEntity]);
 
-		\OC::$server->registerService(MagicMapper::class, function () use ($magicMapper) {
+		$this->registerService(MagicMapper::class, function () use ($magicMapper) {
 			return $magicMapper;
 		});
 
@@ -1027,7 +1049,7 @@ class ObjectsControllerCoverageTest extends TestCase {
 		$magicMapper = $this->createMock(MagicMapper::class);
 		$magicMapper->method('searchAcrossMultipleTables')->willReturn([$objEntity]);
 
-		\OC::$server->registerService(MagicMapper::class, function () use ($magicMapper) {
+		$this->registerService(MagicMapper::class, function () use ($magicMapper) {
 			return $magicMapper;
 		});
 
@@ -1093,7 +1115,7 @@ class ObjectsControllerCoverageTest extends TestCase {
 		$magicMapper = $this->createMock(MagicMapper::class);
 		$magicMapper->method('searchAcrossMultipleTables')->willReturn([]);
 
-		\OC::$server->registerService(MagicMapper::class, function () use ($magicMapper) {
+		$this->registerService(MagicMapper::class, function () use ($magicMapper) {
 			return $magicMapper;
 		});
 
@@ -1414,7 +1436,7 @@ class ObjectsControllerCoverageTest extends TestCase {
 		$magicMapper->method('countObjectsInRegisterSchemaTable')->willReturn(0);
 		$magicMapper->method('getIgnoredFilters')->willReturn([]);
 
-		\OC::$server->registerService(MagicMapper::class, function () use ($magicMapper) {
+		$this->registerService(MagicMapper::class, function () use ($magicMapper) {
 			return $magicMapper;
 		});
 
@@ -1422,7 +1444,7 @@ class ObjectsControllerCoverageTest extends TestCase {
 		$orgService->method('getActiveOrganisation')
 			->willThrowException(new Exception('No org'));
 
-		\OC::$server->registerService(OrganisationService::class, function () use ($orgService) {
+		$this->registerService(OrganisationService::class, function () use ($orgService) {
 			return $orgService;
 		});
 
@@ -1640,7 +1662,7 @@ class ObjectsControllerCoverageTest extends TestCase {
 		// Return ignored filters that are NOT control params (no hint generated).
 		$magicMapper->method('getIgnoredFilters')->willReturn(['custom_field', 'another_field']);
 
-		\OC::$server->registerService(MagicMapper::class, function () use ($magicMapper) {
+		$this->registerService(MagicMapper::class, function () use ($magicMapper) {
 			return $magicMapper;
 		});
 
@@ -1689,7 +1711,7 @@ class ObjectsControllerCoverageTest extends TestCase {
 		$magicMapper = $this->createMock(MagicMapper::class);
 		$magicMapper->method('searchAcrossMultipleTables')->willReturn($entities);
 
-		\OC::$server->registerService(MagicMapper::class, function () use ($magicMapper) {
+		$this->registerService(MagicMapper::class, function () use ($magicMapper) {
 			return $magicMapper;
 		});
 
@@ -1734,4 +1756,16 @@ class ObjectsControllerCoverageTest extends TestCase {
 		// With _empty=true, blank values should be preserved.
 		$this->assertArrayHasKey('blank', $data['results'][0]);
 	}
+
+	/**
+	 * Register a factory the injected container will answer with.
+	 *
+	 * @param string   $id      Service id.
+	 * @param callable $factory Factory returning the service.
+	 *
+	 * @return void
+	 */
+	private function registerService(string $id, callable $factory): void {
+		$this->services[$id] = $factory;
+	}//end registerService()
 }

--- a/tests/Unit/Controller/ObjectsControllerWriteOnlyListLeakTest.php
+++ b/tests/Unit/Controller/ObjectsControllerWriteOnlyListLeakTest.php
@@ -75,6 +75,13 @@ class ObjectsControllerWriteOnlyListLeakTest extends TestCase {
 	private IAppConfig&MockObject $config;
 	private IAppManager&MockObject $appManager;
 	private ContainerInterface&MockObject $container;
+
+	/**
+	 * Services the injected container hands out, keyed by id.
+	 *
+	 * @var array<string, callable>
+	 */
+	private array $services = [];
 	private RegisterMapper&MockObject $registerMapper;
 	private SchemaMapper&MockObject $schemaMapper;
 	private AuditTrailMapper&MockObject $auditTrailMapper;
@@ -90,6 +97,12 @@ class ObjectsControllerWriteOnlyListLeakTest extends TestCase {
 		$this->config = $this->createMock(IAppConfig::class);
 		$this->appManager = $this->createMock(IAppManager::class);
 		$this->container = $this->createMock(ContainerInterface::class);
+		// The controller resolves MagicMapper, RenderObject and OrganisationService
+		// through its injected container (never the global server), so the tests
+		// register what they need here instead of on OC::$server.
+		$this->container->method('get')->willReturnCallback(
+			fn (string $id): mixed => isset($this->services[$id]) === true ? ($this->services[$id])() : null
+		);
 		$this->registerMapper = $this->createMock(RegisterMapper::class);
 		$this->schemaMapper = $this->createMock(SchemaMapper::class);
 		$this->auditTrailMapper = $this->createMock(AuditTrailMapper::class);
@@ -257,12 +270,12 @@ class ObjectsControllerWriteOnlyListLeakTest extends TestCase {
 		$magicMapper->method('searchObjectsInRegisterSchemaTable')->willReturn([$this->sourceEntity()]);
 		$magicMapper->method('countObjectsInRegisterSchemaTable')->willReturn(1);
 		$magicMapper->method('getIgnoredFilters')->willReturn([]);
-		\OC::$server->registerService(MagicMapper::class, fn () => $magicMapper);
+		$this->registerService(MagicMapper::class, fn () => $magicMapper);
 
 		// The REAL RenderObject — the whole point of this test. Mocking it here is what
 		// let #460 hide behind a green suite.
 		$renderObject = $this->realRenderObject();
-		\OC::$server->registerService(RenderObject::class, fn () => $renderObject);
+		$this->registerService(RenderObject::class, fn () => $renderObject);
 
 		$controller = new ObjectsController(
 			'openregister',
@@ -375,4 +388,16 @@ class ObjectsControllerWriteOnlyListLeakTest extends TestCase {
 		$this->assertStringNotContainsString(self::SECRET_TOP, $encoded);
 		$this->assertStringNotContainsString(self::SECRET_NESTED, $encoded);
 	}
+
+	/**
+	 * Register a factory the injected container will answer with.
+	 *
+	 * @param string   $id      Service id.
+	 * @param callable $factory Factory returning the service.
+	 *
+	 * @return void
+	 */
+	private function registerService(string $id, callable $factory): void {
+		$this->services[$id] = $factory;
+	}//end registerService()
 }

--- a/tests/Unit/Service/Object/SaveObjectRetentionResolutionTest.php
+++ b/tests/Unit/Service/Object/SaveObjectRetentionResolutionTest.php
@@ -1,0 +1,269 @@
+<?php
+
+/**
+ * SaveObject resolves the retention service through its injected container, never the global server.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Object
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Object;
+
+use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\File\FolderManagementHandler;
+use OCA\OpenRegister\Service\Object\CacheHandler;
+use OCA\OpenRegister\Service\PropertyRbacHandler;
+use OCA\OpenRegister\Service\Object\SaveObject;
+use OCA\OpenRegister\Service\Object\SaveObject\ComputedFieldHandler;
+use OCA\OpenRegister\Service\Object\SaveObject\FilePropertyHandler;
+use OCA\OpenRegister\Service\Object\SaveObject\LinkedEntityPropertyHandler;
+use OCA\OpenRegister\Service\Object\SaveObject\MetadataHydrationHandler;
+use OCA\OpenRegister\Service\Object\TranslationHandler;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCA\OpenRegister\Service\RetentionService;
+use OCA\OpenRegister\Service\SettingsService;
+use OCA\OpenRegister\Service\TmloService;
+use OCA\OpenRegister\Service\TranslationProjectionService;
+use OCA\OpenRegister\Service\TranslationStatusService;
+use OCP\IURLGenerator;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use ReflectionClass;
+use ReflectionMethod;
+use RuntimeException;
+use Twig\Loader\ArrayLoader;
+
+/**
+ * Regression guard for the 2026-09-08 memory blow-up.
+ *
+ * SaveObject used to fetch RetentionService with `\OC::$server->get()`. Outside a
+ * booted Nextcloud that global container knows none of this app's registrations
+ * and autowires from scratch, which recurses through a MagicMapper ->
+ * SettingsService -> ValidationOperationsHandler -> ValidateObject cycle until
+ * memory runs out (19 GB observed). The service is now resolved through the
+ * container injected into the constructor, which a unit test controls.
+ *
+ * @spec openspec/specs/retention-management/spec.md#requirement-objects-must-carry-mdto-compliant-archival-metadata-in-the-retention-field
+ */
+class SaveObjectRetentionResolutionTest extends TestCase {
+
+	/** @var LoggerInterface&MockObject */
+	private LoggerInterface $logger;
+
+	/** @var IURLGenerator&MockObject */
+	private IURLGenerator $urlGenerator;
+
+	/**
+	 * Prepare the shared collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+	}//end setUp()
+
+	/**
+	 * Build a SaveObject with mocked collaborators and the given container.
+	 *
+	 * @param ContainerInterface|null $container The container seam under test.
+	 *
+	 * @return SaveObject
+	 */
+	private function buildHandler(?ContainerInterface $container): SaveObject {
+		return new SaveObject(
+			$this->createMock(MagicMapper::class),
+			$this->createMock(MagicMapper::class),
+			$this->createMock(MetadataHydrationHandler::class),
+			$this->createMock(FilePropertyHandler::class),
+			$this->createMock(LinkedEntityPropertyHandler::class),
+			$this->createMock(IUserSession::class),
+			$this->createMock(AuditTrailMapper::class),
+			$this->createMock(SchemaMapper::class),
+			$this->createMock(RegisterMapper::class),
+			$this->urlGenerator,
+			$this->createMock(OrganisationService::class),
+			$this->createMock(CacheHandler::class),
+			$this->createMock(SettingsService::class),
+			$this->createMock(PropertyRbacHandler::class),
+			$this->createMock(ComputedFieldHandler::class),
+			$this->createMock(TranslationHandler::class),
+			$this->createMock(TranslationProjectionService::class),
+			$this->createMock(TranslationStatusService::class),
+			$this->logger,
+			$this->createMock(TmloService::class),
+			$this->createMock(FolderManagementHandler::class),
+			new ArrayLoader(),
+			container: $container,
+		);
+	}//end buildHandler()
+
+	/**
+	 * Call the private resolver.
+	 *
+	 * @param SaveObject $handler The handler under test.
+	 *
+	 * @return RetentionService|null
+	 */
+	private function resolve(SaveObject $handler): ?RetentionService {
+		$method = new ReflectionMethod(SaveObject::class, 'resolveRetentionService');
+		$method->setAccessible(true);
+		return $method->invoke($handler);
+	}//end resolve()
+
+	/**
+	 * A schema mock with an empty schema object, as the creation path expects.
+	 *
+	 * @return Schema&MockObject
+	 */
+	private function emptySchema(): Schema {
+		$schemaObject = new \stdClass();
+		$schemaObject->properties = [];
+		$schema = $this->getMockBuilder(Schema::class)
+			->onlyMethods(['getConfiguration', 'getProperties', 'getSchemaObject', 'hasPropertyAuthorization'])
+			->getMock();
+		$schema->method('getSchemaObject')->willReturn($schemaObject);
+		$schema->method('getConfiguration')->willReturn([]);
+		$schema->method('getProperties')->willReturn([]);
+		$schema->method('hasPropertyAuthorization')->willReturn(false);
+		$schema->setId(1);
+		return $schema;
+	}//end emptySchema()
+
+	/**
+	 * Without a container there is no retention service, and nothing is logged.
+	 *
+	 * @return void
+	 */
+	public function testNoContainerResolvesToNull(): void {
+		$this->logger->expects($this->never())->method('debug');
+		$this->assertNull($this->resolve($this->buildHandler(null)));
+	}//end testNoContainerResolvesToNull()
+
+	/**
+	 * A container that has the service hands it back.
+	 *
+	 * @return void
+	 */
+	public function testContainerServiceIsReturned(): void {
+		$retention = $this->createMock(RetentionService::class);
+		$container = $this->createMock(ContainerInterface::class);
+		$container->expects($this->once())
+			->method('get')
+			->with(RetentionService::class)
+			->willReturn($retention);
+
+		$this->assertSame($retention, $this->resolve($this->buildHandler($container)));
+	}//end testContainerServiceIsReturned()
+
+	/**
+	 * A container that cannot build the service degrades to null with a debug line, not an exception.
+	 *
+	 * @return void
+	 */
+	public function testContainerFailureDegradesToNull(): void {
+		$container = $this->createMock(ContainerInterface::class);
+		$container->method('get')->willThrowException(new RuntimeException('no such service'));
+		$this->logger->expects($this->once())
+			->method('debug')
+			->with($this->stringContains('no such service'));
+
+		$this->assertNull($this->resolve($this->buildHandler($container)));
+	}//end testContainerFailureDegradesToNull()
+
+	/**
+	 * A container that answers with the wrong type is treated as having no service.
+	 *
+	 * @return void
+	 */
+	public function testWrongTypeFromContainerIsIgnored(): void {
+		$container = $this->createMock(ContainerInterface::class);
+		$container->method('get')->willReturn(new \stdClass());
+
+		$this->assertNull($this->resolve($this->buildHandler($container)));
+	}//end testWrongTypeFromContainerIsIgnored()
+
+	/**
+	 * The creation path applies archival metadata through the injected container.
+	 *
+	 * This is the call that used to go through the global server.
+	 *
+	 * @return void
+	 */
+	public function testCreationAppliesArchivalMetadataThroughInjectedContainer(): void {
+		$schema = $this->emptySchema();
+		$register = $this->getMockBuilder(Register::class)->onlyMethods([])->getMock();
+		$register->setId(1);
+		$register->setSlug('test');
+
+		$retention = $this->createMock(RetentionService::class);
+		$retention->expects($this->once())
+			->method('applyArchivalMetadata')
+			->with($this->isInstanceOf(ObjectEntity::class), $schema)
+			->willReturnCallback(static function (ObjectEntity $entity): ObjectEntity {
+				$entity->setDescription('archived-by-test');
+				return $entity;
+			});
+
+		$container = $this->createMock(ContainerInterface::class);
+		$container->method('get')->with(RetentionService::class)->willReturn($retention);
+
+		$handler = $this->buildHandler($container);
+
+		$cache = new ReflectionClass(SaveObject::class);
+		$property = $cache->getProperty('schemaCache');
+		$property->setAccessible(true);
+		$property->setValue($handler, ['1' => $schema]);
+
+		$this->urlGenerator->method('getAbsoluteURL')->willReturn('http://localhost/test');
+		$this->urlGenerator->method('linkToRoute')->willReturn('/test');
+
+		$method = new ReflectionMethod(SaveObject::class, 'handleObjectCreation');
+		$method->setAccessible(true);
+		$result = $method->invokeArgs(
+			$handler,
+			[1, 1, $register, $schema, ['name' => 'Test'], [], 'test-uuid-123', null, false, false, false]
+		);
+
+		$this->assertInstanceOf(ObjectEntity::class, $result);
+		$this->assertSame('archived-by-test', $result->getDescription());
+	}//end testCreationAppliesArchivalMetadataThroughInjectedContainer()
+
+	/**
+	 * The handler never reaches for the global server again.
+	 *
+	 * A plain source assertion, because the failure mode is a process that eats
+	 * all memory rather than a wrong return value: there is nothing else to assert on.
+	 *
+	 * @return void
+	 */
+	public function testSourceDoesNotConsultTheGlobalServer(): void {
+		$source = file_get_contents((new ReflectionClass(SaveObject::class))->getFileName());
+		$this->assertIsString($source);
+		$this->assertStringNotContainsString(
+			'\\OC::$server',
+			$source,
+			'SaveObject must resolve services through its injected container; the global server autowires an unbounded cycle outside a booted Nextcloud.'
+		);
+	}//end testSourceDoesNotConsultTheGlobalServer()
+}//end class

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -32,6 +32,49 @@ require_once __DIR__ . '/../vendor/autoload.php';
 // live NC beat the stubs to declaring `OC`.
 
 /**
+ * Tell whether a Nextcloud root is an INSTALLED instance, not just a source tree.
+ *
+ * `lib/base.php` from a source tree that was never installed still declares
+ * `OC` and builds `\OC::$server` before it throws "Not installed". That server
+ * cannot be undone (`OC::$server` is a typed static), so from then on every
+ * `\OC::$server->get()` in the code under test hits a container that knows
+ * none of this app's registrations and autowires from scratch. Autowiring the
+ * MagicMapper -> SettingsService -> ValidationOperationsHandler -> ValidateObject
+ * cycle then recurses until memory runs out: one test took 19 GB and 6 GB of swap
+ * on 2026-09-08. So the decision has to be made BEFORE base.php is loaded, and
+ * the only cheap signal is the `installed` flag in config/config.php.
+ *
+ * @param string $ncRoot Candidate Nextcloud root.
+ *
+ * @return bool True when config/config.php declares `installed => true`.
+ */
+function openregister_nc_root_is_installed(string $ncRoot): bool {
+	$configFile = $ncRoot . '/config/config.php';
+	if (is_file($configFile) === false || filesize($configFile) === 0) {
+		return false;
+	}
+
+	// The config file is a plain `$CONFIG = [...]` script; including it in a
+	// closure keeps `$CONFIG` out of the global scope.
+	$config = (static function () use ($configFile): array {
+		$CONFIG = [];
+		try {
+			include $configFile;
+		} catch (\Throwable) {
+			return [];
+		}
+
+		if (is_array($CONFIG) === false) {
+			return [];
+		}
+
+		return $CONFIG;
+	})();
+
+	return ($config['installed'] ?? false) === true;
+}
+
+/**
  * Resolve the Nextcloud installation root.
  *
  * Priority:
@@ -41,7 +84,8 @@ require_once __DIR__ . '/../vendor/autoload.php';
  *   2. Walk up from this file looking for a `lib/base.php` whose
  *      parent also looks like an NC root (must have `apps/` and
  *      `core/` siblings — the source tree shape, not just any random
- *      `lib/base.php`).
+ *      `lib/base.php`) AND is installed (see openregister_nc_root_is_installed).
+ *      A bare source tree is skipped, so the run stays in pure-unit mode.
  *   3. Legacy fallback: `__DIR__ . '/../../../'` (the original behaviour
  *      when openregister is checked out under `apps-extra/`).
  *
@@ -53,7 +97,20 @@ require_once __DIR__ . '/../vendor/autoload.php';
 function openregister_locate_nc_root(): ?string {
 	$explicit = getenv('OPENREGISTER_TEST_NC_ROOT');
 	if (is_string($explicit) === true && $explicit !== '' && is_file($explicit . '/lib/base.php') === true) {
-		return rtrim($explicit, '/');
+		$explicit = rtrim($explicit, '/');
+		if (openregister_nc_root_is_installed($explicit) === false) {
+			fwrite(
+				STDERR,
+				sprintf(
+					"[openregister/tests/bootstrap] OPENREGISTER_TEST_NC_ROOT=%s is not an installed Nextcloud (config/config.php lacks installed => true).\n"
+					. "  Loading it would leave a half-built server container behind. Point it at an installed instance, or unset it for pure-unit mode.\n",
+					$explicit
+				)
+			);
+			exit(1);
+		}
+
+		return $explicit;
 	}
 
 	$dir = __DIR__;
@@ -71,7 +128,13 @@ function openregister_locate_nc_root(): ?string {
 			&& is_dir($dir . '/apps') === true
 			&& is_dir($dir . '/core') === true
 		) {
-			return $dir;
+			// A bare source tree (config.php empty or absent) is not a root we
+			// can boot; the caller reports pure-unit mode once, below.
+			if (openregister_nc_root_is_installed($dir) === true) {
+				return $dir;
+			}
+
+			return null;
 		}
 	}
 
@@ -108,38 +171,24 @@ if ($skipNc === false && defined('OC_CONSOLE') === false) {
 			// Clear hooks for testing.
 			OC_Hook::clear();
 		} catch (\Throwable $e) {
-			// The NC root we found exists but isn't installed (e.g. a
-			// bare server checkout used as the parent of multiple
-			// worktrees). Fall through to pure-unit mode rather than
-			// aborting the test run — the failing message above is
-			// less actionable than the bootstrap message below.
+			// The root passed the installed check but base.php still failed
+			// (unreachable database, broken app, ...). There is no way back
+			// to pure-unit mode from here: `OC::$server` is a typed static
+			// that already holds a half-built container, and the previous
+			// "fall through to composer autoload only" message was a lie
+			// that cost 19 GB of RAM (see openregister_nc_root_is_installed).
+			// Stop the run and say what to do instead.
 			fwrite(
 				STDERR,
 				sprintf(
 					"[openregister/tests/bootstrap] NC root at %s could not be initialised (%s).\n"
-					. "  Falling through to composer autoload only — pure unit tests will run; container-bound tests will fail clearly.\n"
-					. "  Set OPENREGISTER_TEST_SKIP_NC=1 to silence this and skip NC bootstrap entirely.\n",
+					. "  A half-booted server cannot be undone, so the run stops here rather than pretending to be pure-unit.\n"
+					. "  Fix the instance, point OPENREGISTER_TEST_NC_ROOT elsewhere, or set OPENREGISTER_TEST_SKIP_NC=1 for pure-unit mode.\n",
 					$ncRoot,
 					$e->getMessage()
 				)
 			);
-
-			// Say it once, then silence any child process — the same guard the
-			// "no NC root" branch below already carries, which this branch was
-			// missing.
-			//
-			// A `@runInSeparateProcess` test re-runs this bootstrap in a forked
-			// PHPUnit worker, and ANY output from that worker corrupts the
-			// channel PHPUnit uses to read the child's result back. The test
-			// then fails with this very notice as its error message rather than
-			// on its own merits. Observed on
-			// AppHost\BootstrapTest::testSettingsPlaneRegistrationIsLazy, which
-			// never touches the container and passes with the switch set.
-			//
-			// The child inherits this process's environment, so setting the
-			// harness's existing skip switch here keeps the diagnostic for the
-			// human running the suite while making every forked worker quiet.
-			putenv('OPENREGISTER_TEST_SKIP_NC=1');
+			exit(1);
 		}
 	} else {
 		// No NC root in scope — pure unit tests still work via the
@@ -148,8 +197,8 @@ if ($skipNc === false && defined('OC_CONSOLE') === false) {
 		// bootstrapped" error rather than the previous silent skip.
 		fwrite(
 			STDERR,
-			"[openregister/tests/bootstrap] Nextcloud root not found; running with composer autoload only.\n"
-			. "  Set OPENREGISTER_TEST_NC_ROOT to the NC server source root if you need integration/DB tests.\n"
+			"[openregister/tests/bootstrap] No installed Nextcloud root in scope (a bare source tree does not count); running with composer autoload only.\n"
+			. "  Set OPENREGISTER_TEST_NC_ROOT to an installed Nextcloud root if you need integration/DB tests.\n"
 		);
 
 		// Say it once, then silence any child process.


### PR DESCRIPTION
## What happened

On 2026-09-08 a PHPUnit run of `tests/Unit/Search tests/Unit/Service/Object` took 19 GB of RAM and 6 GB of swap on a developer machine before it finished. The CLI php.ini sets `memory_limit=-1`, so nothing stopped it.

## Why

Three things lined up.

1. **The test bootstrap left a half-built server behind.** From a checkout under `apps-extra/`, it found the workspace's `lib/base.php`, loaded it, and caught the `Not installed` exception with a message saying it was falling through to pure-unit mode. It was not: `OC::$server` is a typed static that already held a server container with none of this app's registrations.
2. **Code under test reached for that global container.** `SaveObject`, `ObjectService`, `ObjectsController` and `EntityRecognitionHandler` called `\OC::$server->get()` for app services. A container without the app's factories autowires from scratch, and `MagicMapper -> SettingsService -> ValidationOperationsHandler -> ValidateObject -> MagicMapper` is a constructor cycle. The container has no cycle detection, so it recursed until memory ran out. Inside a booted Nextcloud the app's registered factory for `SettingsService` breaks the cycle, which is why production never sees this.
3. **No memory cap on PHPUnit.**

A per-file sweep of all 1,335 unit test files in that half-booted state found 12 files that hit a 1 GB cap within seconds. All 12 go through one of the four classes above.

## What changed

- `tests/bootstrap.php` only boots a Nextcloud root whose `config/config.php` says `installed => true`. A bare source tree now runs in pure-unit mode, the same mode CI's bare php job uses. An explicit `OPENREGISTER_TEST_NC_ROOT` that is not installed, or a root that fails to boot, stops the run with exit 1 instead of pretending.
- `phpunit.xml` sets `memory_limit=2G`. The whole unit suite peaks at 454 MB without coverage, so a leak fails within seconds while coverage runs keep headroom.
- The four classes resolve services through their injected app container. `ObjectService` and `ObjectsController` already had one; `SaveObject` and `EntityRecognitionHandler` take an optional `ContainerInterface` as a trailing constructor argument, so the existing test constructions still compile.
- `SaveObjectRetentionResolutionTest` pins the new seam, including a source assertion that `SaveObject` never mentions `\OC::$server` again, because the failure mode is a process that eats all memory rather than a wrong return value.
- Two `ObjectsController` tests registered services on the fake global server. They now register them on the container mock they already pass to the controller. Two of those tests had been leaning on registrations leaked from earlier tests in the same process; the coverage test now registers explicit defaults.
- Two stale `UnusedParam` entries left `psalm-baseline.xml`: Psalm could not follow the old global lookup and thought the parameters after it were unused.

## Verified locally

| Check | Result |
|---|---|
| `tests/Unit`, 19,408 tests, pure-unit mode | green, peak 454 MB, 92 s |
| The 12 former offenders, run one process each under the OLD bootstrap against the workspace tree, with the new code | all green, 63 to 79 MB each |
| phpcs, phpstan, psalm, phpmd on the changed lib files | green (phpcs keeps 7 pre-existing missing-`@spec` warnings on untouched getters) |

CI's `E2E` and booted-instance jobs were not run locally.

## Not in this PR

- 107 other `\OC::$server->get()` sites remain in `lib/` across 26 files. They are protected by the bootstrap change, not by a code change.
- 20 of the 21 fleet apps have no PHPUnit memory cap, and 19 boot Nextcloud from the workspace in their test bootstrap. Same hazard class, separate PRs.
- `tests/Unit/CustomSniffs/NoLegacyServerAccessorsSniffTest.php` is skipped and the sniff it tests does not exist in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
