### PR TITLE
docs(flow): record the gate run that closes flow-run-subjects-and-answers

### DIFF
--- a/openspec/changes/flow-run-subjects-and-answers/tasks.md
+++ b/openspec/changes/flow-run-subjects-and-answers/tasks.md
@@ -37,4 +37,13 @@
 
   ⚠️ **Newman, not Playwright.** `playwright.config.ts` excludes `**/api-direct/**` from every project, so a Playwright spec for an HTTP contract runs only when a developer invokes an ad-hoc config by hand and CI executes none of it — a green spec and zero CI coverage look identical from the outside. `tests/newman/openregister-flow-subjects.postman_collection.json`, registered in `run-all.sh`, which `api-test-coverage.yml` runs on every PR. Same move as the `delegation` and `register-descriptors` collections.
 - [x] 6.2 `attachTo` naming an unheld role fails the step and leaves no task — folder 3 of the same collection.
-- [ ] 6.3 `composer check:strict`, both l10n gates, full unit suite. Exit code, not summary line.
+- [x] 6.3 `composer check:strict`, both l10n gates, full unit suite. Exit code, not summary line.
+
+  Measured 2026-09-08, every one by exit code rather than by its summary:
+  `lint` clean, `phpcs` rc=0, `phpmd` swept PER DIRECTORY with the baseline
+  (E=0 — the whole-`lib/` run is OOM-killed and reports that as a pass),
+  `psalm` rc=0, `phpstan` rc=0 ("No errors"), `phpunit` rc=0 over 19,434
+  tests, `test:l10n` rc=0 and `test:l10n:parity` rc=0 across all 36 locales.
+
+  ⚠️ The CLAUDE.md "Known state" note saying `npm run test:l10n` is red at
+  HEAD is STALE: it passes, and the 17 keys it names are present.


### PR DESCRIPTION
## Summary

- Marks task 6.3 of `flow-run-subjects-and-answers` done and records what was actually measured, so the next reader does not have to re-run it to find out.
- Every gate is recorded by exit code rather than by its summary line. That distinction is the point: phpunit has printed `OK` and exited 1 under `failOnRisky`, and phpmd over the whole `lib/` tree is OOM-killed and reports that as a pass, so it is swept per directory with the baseline instead.
- Measured 2026-09-08: lint clean, phpcs 0, phpmd E=0, psalm 0, phpstan 0 ("No errors"), phpunit 0 over 19,434 tests, `test:l10n` 0 and `test:l10n:parity` 0 across all 36 locales.
- Notes that CLAUDE.md's "Known state" claim that `npm run test:l10n` is red at HEAD is stale. It passes, and the 17 keys it names are present. A stale note about a red gate is how a real red one later gets waved through.

## Checks

- Documentation only. No code, no tests, no manifest.

## Test plan

- CI passes
- The change's task list has no open items left

🤖 Generated with [Claude Code](https://claude.com/claude-code)