### PR TITLE
feat(openspec): platform requests from the dossiq competitor analysis

### DIFF
--- a/openspec/changes/activity-leaf/design.md
+++ b/openspec/changes/activity-leaf/design.md
@@ -1,0 +1,31 @@
+# Design: activity leaf merged feed
+
+## D-1: merge at query time, no new table
+
+integration-activity already chose query-time storage. The merged feed
+queries five sources with the same cursor (time, source, id), takes the top
+page across them and returns it. Each source is bounded to the page size, so
+the cost is five bounded reads, not a table scan.
+
+## D-2: reads are hidden by default
+
+The audit trail records reads. A timeline of 15 reads and 2 writes is what
+dossiq shows today and it hides the writes. The feed excludes read entries
+unless the `reads` toggle is on; the toggle is remembered per user.
+
+## D-3: kind vocabulary
+
+`audit`, `file`, `note`, `mail`, `activity`. A row carries the kind, actor,
+time, summary and a deep link to the item (the file, the note, the mail
+thread) when one exists. Summaries come from each source's own renderer;
+the feed does not reinterpret an audit diff.
+
+## D-4: export reuses the formats
+
+CSV through the audit export path; PDF through export-pdf-format with a
+feed template. Both take the active filters.
+
+## D-5: kind
+
+Code, in OpenRegister. Consuming apps replace two tabs with one manifest
+entry, which is config.

--- a/openspec/changes/activity-leaf/proposal.md
+++ b/openspec/changes/activity-leaf/proposal.md
@@ -1,0 +1,47 @@
+# Activity leaf: one merged feed per object
+
+## Why
+
+Round 2 of the dossiq competitor analysis (row A05 in
+`concurrentie-analyse/procest/_round2/compare/findings.md`, placement section
+3, decision D10): every competitor shows one timeline on the case, in reverse
+order, with actor and time, spanning status changes, documents, notes and
+mail. OpenCase and GZAC each have a Log tab
+(`opencase/round2/pages/CaseDetail-Log.md`, `valtimo/round2/pages/CaseDetail-Log.md`);
+Zaaksysteem's Tijdlijn adds filters, a date range and an export
+(`xxllnc-zaken/round2/pages/Case-Tijdlijn.md`).
+
+dossiq's CaseDetail sidebar shows the same OpenRegister audit rows twice
+(History and version history), 15 of 17 rows are reads, and documents, mail
+and notes do not appear (`_round2/dossiq-baseline/case-detail-anatomy.md`).
+The activity leaf already blends NC Activity rows marked `[or:{uuid}]`
+(integration-activity, Blended Feed) but the blend covers the Activity app
+only; audit entries, file events, notes and linked mail are separate lists.
+A merged feed is the same need in every app that mounts a detail page.
+
+## What changes
+
+- The activity leaf's feed for one object merges five sources: the object's
+  audit trail (writes only by default), file events on the object, notes,
+  mail linked to the object, and NC Activity rows, in one reverse
+  chronological list with actor, time, kind and a one-line summary.
+- Filter chips per kind, a date range, and a toggle to include reads.
+- Export of the filtered feed as CSV or PDF through the existing export
+  formats.
+- The feed is a `tab` and a `widget` surface so a manifest places it; a
+  detail page that mounts it drops its separate audit and version tabs.
+
+## Who benefits
+
+dossiq (CaseDetail sidebar), zaakafhandelapp, humaniq, keepiq, opencatalogi,
+every app with a detail page.
+
+## Impact
+
+- Affected specs: integration-activity (delta).
+- Affected code: `lib/Service/Integration/Providers/ActivityProvider.php`
+  (merge), the interaction timeline API (object-interactions, Unified
+  Interaction Timeline API) as one of its sources, the activity leaf's Vue
+  surfaces.
+- Backwards compatible: the NC Activity-only feed remains the default when
+  the consuming manifest asks for it.

--- a/openspec/changes/activity-leaf/specs/integration-activity/spec.md
+++ b/openspec/changes/activity-leaf/specs/integration-activity/spec.md
@@ -1,0 +1,56 @@
+# integration-activity
+
+## ADDED Requirements
+
+### Requirement: The activity leaf merges an object's feed from five sources
+
+The activity leaf SHALL offer a merged feed for one object drawn from the
+object's audit trail, its file events, its notes, mail linked to it and NC
+Activity rows, in one reverse chronological list where each row carries a
+kind, actor, time, summary and a deep link when the item has one. Each
+source SHALL be bounded to the page size and merged on a shared cursor.
+
+#### Scenario: three kinds of write appear as three rows in order
+
+- **GIVEN** an object that was edited, then got a file, then got a note
+- **WHEN** the user opens the merged feed
+- **THEN** the feed shows the note, the file and the edit in that order with their kinds and actors
+- @e2e exclude {proposal only; task 3.2 adds tests/e2e/ci/activity-leaf.spec.ts when the merge ships}
+
+### Requirement: Reads are hidden unless asked for
+
+The merged feed SHALL exclude audit entries of kind read unless the user
+turns on the reads toggle, and SHALL remember the toggle per user.
+
+#### Scenario: a page of reads does not bury one write
+
+- **GIVEN** an object with fifteen read entries and one update entry
+- **WHEN** the feed opens with the toggle off
+- **THEN** the update entry is the only audit row shown
+- @e2e exclude {the read filter is covered by unit tests on the provider}
+
+### Requirement: The feed filters by kind and period and exports
+
+The merged feed SHALL offer filter chips per kind and a date range, and
+SHALL export the filtered feed as CSV and PDF through the existing export
+formats.
+
+#### Scenario: a filtered export holds the filtered rows
+
+- **GIVEN** a feed with two file rows and three note rows
+- **WHEN** the user filters on kind note and exports as CSV
+- **THEN** the file holds three rows, all of kind note
+- @e2e exclude {export contents are covered by unit tests on the exporter}
+
+### Requirement: The merged feed is a tab and a widget surface
+
+The activity leaf SHALL expose the merged feed as a `tab` surface and a
+`widget` surface so that a manifest places it on a detail page in place of
+separate audit and version tabs.
+
+#### Scenario: a manifest replaces two tabs with the feed
+
+- **GIVEN** a consuming app whose detail page declares the activity leaf's `tab` surface and no audit tab
+- **WHEN** a user opens an object's detail page
+- **THEN** one Activity tab renders the merged feed
+- @e2e exclude {leaf placement is asserted by the manifest parity gate and the consuming app's e2e}

--- a/openspec/changes/activity-leaf/tasks.md
+++ b/openspec/changes/activity-leaf/tasks.md
@@ -1,0 +1,17 @@
+# Tasks: activity-leaf
+
+## 1. Merge
+
+- [ ] 1.1 Five-source merge with a shared cursor in `ActivityProvider`.
+- [ ] 1.2 Read entries excluded unless requested; per-user toggle memory.
+
+## 2. Surfaces
+
+- [ ] 2.1 `tab` and `widget` surfaces with kind chips and a date range.
+- [ ] 2.2 CSV and PDF export of the filtered feed.
+
+## 3. Tests
+
+- [ ] 3.1 Unit tests for the merge order, the bound and the read toggle.
+- [ ] 3.2 `tests/e2e/ci/activity-leaf.spec.ts`: edit an object, attach a
+      file, write a note, open the feed, see three rows in reverse order.

--- a/openspec/changes/audit-log-page/design.md
+++ b/openspec/changes/audit-log-page/design.md
@@ -1,0 +1,31 @@
+# Design: audit log page
+
+## D-1: one query, six filters, index-backed
+
+The instance-wide list reads `openregister_audit_trails` with filters on
+user, created range, action, register, schema and object uuid, each backed
+by the indexes enhanced-audit-trail added. Full-text on the change summary
+uses the existing database full-text path. The query is bounded by cursor
+pagination; no count of the whole table is computed on page load.
+
+## D-2: RBAC by object, admin by role
+
+A non-admin's list is the join of the trail with the objects the user may
+read, so the same predicate as object lists. An admin reads the whole trail.
+Entries of deleted objects remain visible to admins only.
+
+## D-3: export is the existing export, filtered
+
+CSV and JSON export call the compliance export with the same filter set, so
+`hash` and `previousHash` are in the file and a reader can verify the chain
+offline. Export is a background job past 10,000 rows, with a notification
+carrying the download.
+
+## D-4: a leaf surface
+
+The audit leaf gains an `index` surface. A manifest places it as a page or
+links it as a card, so a fleet app has an audit page with no code.
+
+## D-5: kind
+
+Code, in OpenRegister. Consuming apps declare the page in config.

--- a/openspec/changes/audit-log-page/proposal.md
+++ b/openspec/changes/audit-log-page/proposal.md
@@ -1,0 +1,45 @@
+# Audit log page: instance-wide, with filters and export
+
+## Why
+
+Round 2 of the dossiq competitor analysis (row B14 in
+`concurrentie-analyse/procest/_round2/compare/tier-b-and-sibling.md`, decision
+D10): every competitor has one page where an administrator or auditor reads
+the whole instance's log. OpenCase has a Transaction log under admin settings
+(`opencase/round2/pages/AdminSettings.md`), GZAC an Admin Logs page
+(`valtimo/round2/pages/Admin-Logs.md`), Zaaksysteem a Logboek
+(`xxllnc-zaken/round2/pages/Logboek.md`) with filters on user, period and
+event type and an export.
+
+dossiq shows the audit per case in the sidebar; its StufAuditLog.vue and
+AiAuditExportController cover one integration each. OpenRegister owns the
+hash-chained audit trail and already exports it for compliance
+(audit-trail-immutable, Audit-Trail Access, Export, and Administrative
+Deletion Surface). What is missing is one page over the whole trail, and a
+leaf surface so a fleet app can place it as a card on its Reports page
+without writing a list.
+
+## What changes
+
+- An `audit` index surface on the audit leaf: a paginated list over the
+  whole instance's audit trail, with filters on actor, period, action,
+  register, schema and object, and full-text on the change summary.
+- The list is scoped by RBAC: a user sees the entries of objects they may
+  read; an admin sees all.
+- Export of the filtered result as CSV or JSON, through the existing export
+  path, so the hash chain fields travel with it.
+- A consuming app places the surface with one manifest entry; dossiq links it
+  as a card on Reports.
+
+## Who benefits
+
+dossiq, zaakafhandelapp, integriq (sync audit), humaniq (payroll audit),
+every app with a compliance duty.
+
+## Impact
+
+- Affected specs: audit-trail-immutable (delta).
+- Affected code: `lib/Controller/AuditTrailController.php` (filters),
+  `lib/Db/AuditTrailMapper.php` (index-backed filter query, see
+  enhanced-audit-trail), the audit leaf's Vue index surface.
+- Backwards compatible: per-object audit endpoints are unchanged.

--- a/openspec/changes/audit-log-page/specs/audit-trail-immutable/spec.md
+++ b/openspec/changes/audit-log-page/specs/audit-trail-immutable/spec.md
@@ -1,0 +1,52 @@
+# audit-trail-immutable
+
+## ADDED Requirements
+
+### Requirement: An instance-wide audit list with filters
+
+The system SHALL expose a cursor-paginated list over the whole audit trail
+with filters on actor, period, action, register, schema and object, and
+full-text on the change summary. A non-admin SHALL see only entries of
+objects they may read; an admin SHALL see every entry, including those of
+deleted objects. The query SHALL be index-backed and SHALL NOT count the
+whole table on page load.
+
+#### Scenario: an admin filters by actor and period
+
+- **GIVEN** an admin and a trail with entries by user A yesterday and by user B today
+- **WHEN** they list with actor A and a period of the last two days
+- **THEN** only A's entries are returned, newest first
+- @e2e exclude {proposal only; task 4.2 adds tests/e2e/ci/audit-log-page.spec.ts when the page ships}
+
+#### Scenario: a handler sees only readable objects' entries
+
+- **GIVEN** a user with read scope on register `cases` only and entries on objects in `cases` and `hr`
+- **WHEN** they list the audit trail
+- **THEN** the `hr` entries are absent
+- @e2e exclude {the RBAC join is covered by unit tests on the mapper}
+
+### Requirement: The filtered audit list exports with its hash chain
+
+The system SHALL export the filtered list as CSV or JSON through the
+compliance export path so that `hash` and `previousHash` are present on
+every row, and SHALL run the export as a background job with a notification
+when the result exceeds 10,000 rows.
+
+#### Scenario: an export carries the chain fields
+
+- **GIVEN** a filtered list of twelve entries
+- **WHEN** the admin exports it as CSV
+- **THEN** the file has twelve rows and the columns `hash` and `previousHash` are filled on each
+- @e2e exclude {proposal only; task 4.2 adds tests/e2e/ci/audit-log-page.spec.ts when the export ships}
+
+### Requirement: The audit list is a leaf surface
+
+The audit leaf SHALL expose the instance-wide list as an `index` surface so
+that a consuming app places it through its manifest and writes no list code.
+
+#### Scenario: a manifest places the audit page
+
+- **GIVEN** a consuming app whose manifest declares a page with `leaf: audit`, surface `index`
+- **WHEN** a user opens that page
+- **THEN** the instance-wide audit list renders with its filter bar
+- @e2e exclude {leaf placement is asserted by the manifest parity gate and the consuming app's e2e}

--- a/openspec/changes/audit-log-page/tasks.md
+++ b/openspec/changes/audit-log-page/tasks.md
@@ -1,0 +1,23 @@
+# Tasks: audit-log-page
+
+## 1. Query
+
+- [ ] 1.1 Filtered, cursor-paginated instance-wide query in
+      `AuditTrailMapper` using the existing indexes.
+- [ ] 1.2 RBAC join for non-admins.
+
+## 2. API and export
+
+- [ ] 2.1 `GET /api/audit-trails` with the six filters and full-text.
+- [ ] 2.2 CSV and JSON export of the filtered result; background job past
+      10,000 rows.
+
+## 3. Surface
+
+- [ ] 3.1 Audit leaf `index` surface with filter bar and export button.
+
+## 4. Tests
+
+- [ ] 4.1 Unit tests for filters, RBAC join and export contents.
+- [ ] 4.2 `tests/e2e/ci/audit-log-page.spec.ts`: as admin, filter by actor
+      and period, see the rows, export and check the hash columns.

--- a/openspec/changes/contacts-leaf-cases-panel/design.md
+++ b/openspec/changes/contacts-leaf-cases-panel/design.md
@@ -1,0 +1,27 @@
+# Design: contacts leaf cases panel and name search
+
+## D-1: the cases panel is the reverse lookup with a surface
+
+`ContactsProvider` already answers "which objects link this contact" through
+the link table (requirement Reverse Lookup). The panel is a read of that
+answer, grouped by schema, joined with the object's title and, when the schema
+declares `x-openregister-lifecycle` or a `status` property, that value. No new
+storage.
+
+## D-2: two leaf surfaces, declared by the consuming app
+
+integration-leaf-foundation lets a provider expose surfaces (`tab`, `widget`,
+`page`). The contacts leaf gains `detail` (one contact, with the cases panel)
+and `index` (the name search). A fleet app places them in its manifest as
+`leaf: contacts` pages; dossiq's future Contacts domain is two manifest
+entries.
+
+## D-3: the search reads the Contacts app, not a copy
+
+The name search queries the address books the current user may read through
+`OCP\Contacts\IManager::search()`, so the permission model stays the Contacts
+app's. Results carry the contact's URI, which the link table already stores.
+
+## D-4: kind
+
+Code, in OpenRegister. The consuming apps ship config only.

--- a/openspec/changes/contacts-leaf-cases-panel/proposal.md
+++ b/openspec/changes/contacts-leaf-cases-panel/proposal.md
@@ -1,0 +1,45 @@
+# Contacts leaf: a cases panel and a name search
+
+## Why
+
+Round 2 of the dossiq competitor analysis (row B01 in
+`concurrentie-analyse/procest/_round2/compare/tier-b-and-sibling.md`, decision
+D10) asks for a contact 360 view: a person or organisation, the cases they are
+party to, their communication and a timeline, found by name. OpenCase offers it
+as the Search citizen and Search company pages
+(`opencase/round2/pages/Search-Citizen.md`, `Search-Company.md`: a 360 view with
+Cases and Documents and a Create case button). Zaaksysteem offers Contactbeeld
+and Contact zoeken (`xxllnc-zaken/round2/pages/ContactBeeld-persoon.md`,
+`ContactZoeken.md`).
+
+dossiq has the API half only: `/api/kcc/voorblad` renders nothing, and the
+contacts leaf, which ADR-066 names as the contact record's surface, lists the
+linked contacts of one object but never the objects of one contact. Reverse
+lookup exists in the provider (integration-contacts, requirement Reverse
+Lookup) and has no page.
+
+## What changes
+
+- The contacts leaf gains a detail surface for one contact with a cases panel:
+  every register object the contact is linked to, grouped by schema, with the
+  link role, the object's title and its status field when the schema declares
+  one.
+- The contacts leaf gains a name search: an index surface that finds a contact
+  by (part of) a name, e-mail address or organisation, backed by the Contacts
+  app's address books the user may read.
+- Both surfaces are leaf surfaces in the sense of integration-leaf-foundation,
+  so a fleet app declares them in its manifest and writes no code.
+
+## Who benefits
+
+dossiq (page Cases, the rung 5 Contacts domain candidate), zaakafhandelapp,
+humaniq (a person's cases and requests), pipelinq (a contact's deals) and
+opencatalogi (a publisher's publications).
+
+## Impact
+
+- Affected specs: integration-contacts (delta).
+- Affected code: `lib/Service/Integration/Providers/ContactsProvider.php`,
+  the contacts leaf's Vue surfaces under `src/integrations/contacts/`,
+  one new route for the name search.
+- Backwards compatible: the sidebar tab and the person chip are unchanged.

--- a/openspec/changes/contacts-leaf-cases-panel/specs/integration-contacts/spec.md
+++ b/openspec/changes/contacts-leaf-cases-panel/specs/integration-contacts/spec.md
@@ -1,0 +1,38 @@
+# integration-contacts
+
+## ADDED Requirements
+
+### Requirement: The contacts leaf offers a detail surface with a cases panel
+
+The contacts leaf SHALL expose a `detail` surface for one contact that lists
+every register object the contact is linked to, grouped by schema, showing
+the link role, the object's title and its status when the schema declares
+one. The list SHALL contain only objects the current user may read.
+
+#### Scenario: a contact linked to two cases shows both
+
+- **GIVEN** a contact linked to two objects of schema `case` with role `requester`
+- **WHEN** the user opens the contact's detail surface
+- **THEN** the cases panel lists both objects under the heading of schema `case`, each with role `requester` and its status
+- @e2e exclude {proposal only; task 3.2 adds tests/e2e/ci/contacts-leaf-cases-panel.spec.ts when the surface ships}
+
+#### Scenario: an object the user may not read stays out of the panel
+
+- **GIVEN** a contact linked to an object in a register the user has no read scope on
+- **WHEN** the user opens the contact's detail surface
+- **THEN** that object is absent and the panel does not reveal its count
+- @e2e exclude {RBAC filtering is asserted in unit tests on the provider}
+
+### Requirement: The contacts leaf offers a name search
+
+The contacts leaf SHALL expose an `index` surface that finds contacts by part
+of a name, an e-mail address or an organisation, querying only the address
+books the current user may read, and SHALL open the detail surface from a
+result.
+
+#### Scenario: a partial name finds the contact
+
+- **GIVEN** a readable address book holding a contact named "Jansen, Piet"
+- **WHEN** the user types "jans" in the name search
+- **THEN** the result list shows that contact and opening it shows the detail surface
+- @e2e exclude {proposal only; task 3.2 adds tests/e2e/ci/contacts-leaf-cases-panel.spec.ts when the surface ships}

--- a/openspec/changes/contacts-leaf-cases-panel/tasks.md
+++ b/openspec/changes/contacts-leaf-cases-panel/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: contacts-leaf-cases-panel
+
+## 1. Provider
+
+- [ ] 1.1 `ContactsProvider::objectsForContact(uri)` groups the reverse
+      lookup by schema and joins title and status.
+- [ ] 1.2 `GET /api/integrations/contacts/search?q=` over
+      `IManager::search()`, limited to readable address books.
+
+## 2. Surfaces
+
+- [ ] 2.1 Detail surface: contact card plus the cases panel.
+- [ ] 2.2 Index surface: name search with a result list that opens the
+      detail surface.
+- [ ] 2.3 Register both as leaf surfaces so a manifest can place them.
+
+## 3. Tests
+
+- [ ] 3.1 Unit tests for grouping and for the readable-address-book bound.
+- [ ] 3.2 `tests/e2e/ci/contacts-leaf-cases-panel.spec.ts`: link a contact
+      to two objects, open the detail surface, see both under their schema.

--- a/openspec/changes/content-search-index/design.md
+++ b/openspec/changes/content-search-index/design.md
@@ -1,0 +1,35 @@
+# Design: content search index
+
+## D-1: one provider, two hit kinds
+
+The unified search provider already exists and is the fleet's only one. A
+file hit is a second result kind from the same provider, not a second
+provider, so the Nextcloud search bar shows one OpenRegister section. Each
+hit carries `kind`, the owning object's deep link, and for a file hit the
+file name and the matching excerpt.
+
+## D-2: scopes are a filter the caller declares
+
+A scope is one of `app:<id>`, `register:<slug>`, `schema:<slug>` or `files`.
+The provider's OCS capability lists the scopes available to the user, so a
+consuming app renders scope chips from the capability, not from a copy. The
+`searchable` flag on a schema still decides exposure.
+
+## D-3: backend when present, database when not
+
+With a configured search backend (search-index) the query goes to the object
+collection and the file collection in one round trip. Without one, object
+data uses the existing database full-text path and file text uses the
+`openregister_file_chunks` table with a `LIKE` over chunk text bounded by the
+same page size. Same contract, different cost; the response names the
+backend so a slow instance is diagnosable.
+
+## D-4: PR 3528 stays the shape
+
+The chunked schema listing from PR 3528 is the loop this change extends; the
+scope filter narrows the schema list before chunking, so a scoped query is
+cheaper, never dearer, than an unscoped one.
+
+## D-5: kind
+
+Code, in OpenRegister. Consuming apps declare offered scopes in config.

--- a/openspec/changes/content-search-index/proposal.md
+++ b/openspec/changes/content-search-index/proposal.md
@@ -1,0 +1,46 @@
+# Content search index: one box, file content and object data, with scopes
+
+## Why
+
+Round 2 of the dossiq competitor analysis (row B02 in
+`concurrentie-analyse/procest/_round2/compare/tier-b-and-sibling.md`, decision
+D10) finds that every competitor searches document content and case data from
+one box. OpenCase runs Elasticsearch over metadata and file content and adds a
+Free text page (`opencase/round2/search-anatomy.md`); GZAC has an optional
+OpenSearch (`valtimo/round2/code-census.md`); Zaaksysteem's Globaal zoeken
+has the scopes Zaken, Organisaties, Medewerkers, Documenten and Objecten
+(`xxllnc-zaken/round2/pages/GlobaalZoeken.md`).
+
+dossiq has zero hits for full-text, Tika or Elasticsearch. OpenRegister owns
+unified search for the fleet (unified-search-provider) and already indexes
+file chunks when a search backend is configured (search-index, FileHandler).
+PR 3528, merged 2026-09-08, keeps the provider working on many-schema
+instances by chunking the schema list; this change builds on that provider,
+it does not replace it.
+
+## What changes
+
+- The unified search provider answers one query over object data and over the
+  extracted text of files attached to objects, and marks each hit with its
+  kind (`object` or `file`).
+- The provider accepts scopes: an owning app, a register, a schema, or `files`.
+  A consuming app declares which scopes its search box offers; the default is
+  every scope the user may read.
+- Instances without a search backend get the same contract over the database
+  (object data through the existing full-text path, file text through the
+  file-chunk table), so the box works everywhere and is fast where a backend
+  is configured.
+
+## Who benefits
+
+dossiq (case and document search from one box), filinq (document intake),
+opencatalogi (publication content), keepiq, larpinq.
+
+## Impact
+
+- Affected specs: unified-search-provider (delta).
+- Affected code: `lib/Service/Search/ObjectsProvider.php` (or its successor
+  after PR 3528), `lib/Service/Search/FileHandler.php`, the provider's OCS
+  capability advertisement.
+- Backwards compatible: a query without scopes behaves as today plus file
+  hits.

--- a/openspec/changes/content-search-index/specs/unified-search-provider/spec.md
+++ b/openspec/changes/content-search-index/specs/unified-search-provider/spec.md
@@ -1,0 +1,46 @@
+# unified-search-provider
+
+## ADDED Requirements
+
+### Requirement: The provider searches file content beside object data
+
+The unified search provider SHALL return hits from the extracted text of
+files attached to register objects beside hits from object data, in one
+result list, each hit carrying a `kind` of `object` or `file`, the owning
+object's deep link and, for a file hit, the file name and a matching excerpt.
+File hits SHALL respect the same RBAC and `searchable` predicate as object
+hits.
+
+#### Scenario: a word that occurs only inside an attached file is found
+
+- **GIVEN** an object of a searchable schema with an attached text file containing "waterschapsheffing" and no object field containing that word
+- **WHEN** the user searches "waterschapsheffing"
+- **THEN** the result list holds one hit of kind `file` naming the file and linking to the object
+- @e2e exclude {proposal only; task 3.2 adds tests/e2e/ci/content-search-index.spec.ts when the provider ships}
+
+### Requirement: The provider accepts scopes and advertises them
+
+The unified search provider SHALL accept zero or more scopes of the form
+`app:<id>`, `register:<slug>`, `schema:<slug>` or `files`, SHALL narrow the
+searched schemas to the scopes before the chunked schema loop, and SHALL
+advertise the scopes available to the current user in its OCS capability.
+
+#### Scenario: a schema scope hides other schemas
+
+- **GIVEN** two searchable schemas `case` and `contact` each holding an object titled "Vergunning"
+- **WHEN** the user searches "Vergunning" with scope `schema:case`
+- **THEN** only the `case` hit is returned
+- @e2e exclude {scope narrowing is asserted in unit tests on the provider}
+
+### Requirement: The same contract holds with and without a search backend
+
+The provider SHALL answer the same query shape whether a search backend is
+configured or not, using the database full-text path and the file-chunk
+table when none is, and SHALL name the backend used in the response.
+
+#### Scenario: an instance without a backend still returns file hits
+
+- **GIVEN** an instance with no search backend configured and an object with an attached file containing "dijkgraaf"
+- **WHEN** the user searches "dijkgraaf"
+- **THEN** a file hit is returned and the response names the database backend
+- @e2e exclude {backend absence is a fixture condition covered by unit tests}

--- a/openspec/changes/content-search-index/tasks.md
+++ b/openspec/changes/content-search-index/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: content-search-index
+
+## 1. Provider
+
+- [ ] 1.1 Add the `kind` field and file hits to the provider's result shape.
+- [ ] 1.2 Parse scopes from the query and narrow the schema list before the
+      PR 3528 chunk loop.
+- [ ] 1.3 Advertise available scopes in the OCS capability.
+
+## 2. Storage paths
+
+- [ ] 2.1 Backend path: query object and file collections in one round trip.
+- [ ] 2.2 Database path: file-chunk `LIKE` bounded by page size; name the
+      backend in the response.
+
+## 3. Tests
+
+- [ ] 3.1 Unit tests for scope parsing and the two paths.
+- [ ] 3.2 `tests/e2e/ci/content-search-index.spec.ts`: attach a text file to
+      an object, search a word from the file, see a file hit that deep-links
+      to the object.

--- a/openspec/changes/favourites-and-recent/design.md
+++ b/openspec/changes/favourites-and-recent/design.md
@@ -1,0 +1,26 @@
+# Design: favourites and recent
+
+## D-1: state beside the object, never in it
+
+A star and a view are facts about a user, not about the object. They live in
+two small tables keyed by (user, object uuid) and never touch the object row,
+so no audit entry, no version, no lock. Deleting an object cascades both
+(object-interactions, Object Deletion Cleanup).
+
+## D-2: lenses are query filters
+
+`_favourite=true` joins the favourites table for the current user;
+`_recent=true` joins the views table and orders by last view descending. Both
+compose with every other filter, so "my favourite open cases" is one query.
+A view is written on the object read that a detail page makes, throttled to
+one row per user, object and minute.
+
+## D-3: the marker rides `@self`
+
+Object reads carry `@self.favourite: true|false` for the current user, so
+`CnDetailPage` can render a star from data it already has. The list read
+carries it too, at the cost of one join.
+
+## D-4: kind
+
+Code, in OpenRegister. Consuming apps add chips in config.

--- a/openspec/changes/favourites-and-recent/proposal.md
+++ b/openspec/changes/favourites-and-recent/proposal.md
@@ -1,0 +1,45 @@
+# Favourites and recently opened objects as index lenses
+
+## Why
+
+Round 2 of the dossiq competitor analysis (row B06 in
+`concurrentie-analyse/procest/_round2/compare/tier-b-and-sibling.md`, decision
+D10): OpenCase has a Favourites page fed by a star on the case and a Recent
+page fed by a per-user view history (`opencase/round2/pages/Favourites.md`,
+`Recent.md`); Zaaksysteem has favourite case types on its dashboard and a
+Favoriet saved search (`xxllnc-zaken/round2/pages/LegacyDashboard.md`,
+`search-anatomy.md`).
+
+dossiq has zero hits for favourite or recent. A star is per user and per
+object, not a property of the object, so it is platform state: writing it
+into the object would change the object's audit trail and version for every
+reader. OpenRegister already keeps per-user, per-object interactions
+(object-interactions: notes, tasks, tags) and is the place for two more.
+
+## What changes
+
+- A per-user star on any object: `PUT` and `DELETE
+  /api/objects/{register}/{schema}/{id}/favourite`, stored outside the object
+  and its audit trail.
+- A per-user view history: opening an object's detail records a view
+  (user, object, time), kept to the last 100 per user.
+- Two index lenses the object query understands: `_favourite=true` and
+  `_recent=true` (ordered by last view), so a consuming app's index page adds
+  a chip with no code.
+- A `favourite` marker on object reads so a detail page can render the star's
+  state without a second call.
+
+## Who benefits
+
+dossiq (Cases page chips Mine, Favourites, Recent), zaakafhandelapp,
+opencatalogi, stackiq, keepiq, and every index page in the fleet.
+
+## Impact
+
+- Affected specs: object-interactions (delta).
+- Affected code: two new tables (`openregister_favourites`,
+  `openregister_object_views`) with a migration, `lib/Service/Interaction/`,
+  `lib/Controller/ObjectsController.php` (marker and lenses), the object
+  query's filter parser.
+- Backwards compatible: the object payload is unchanged; the marker sits in
+  `@self`.

--- a/openspec/changes/favourites-and-recent/specs/object-interactions/spec.md
+++ b/openspec/changes/favourites-and-recent/specs/object-interactions/spec.md
@@ -1,0 +1,44 @@
+# object-interactions
+
+## ADDED Requirements
+
+### Requirement: A user can star an object without changing it
+
+The system SHALL let a user mark any object they may read as a favourite and
+unmark it, storing the mark per user outside the object, so that starring
+writes no audit entry and no version on the object. Object reads and lists
+SHALL carry `@self.favourite` for the current user.
+
+#### Scenario: starring leaves the object untouched
+
+- **GIVEN** an object with three audit entries
+- **WHEN** a user stars it and reads it back
+- **THEN** `@self.favourite` is true and the object still has three audit entries
+- @e2e exclude {proposal only; task 4.2 adds tests/e2e/ci/favourites-and-recent.spec.ts when the endpoints ship}
+
+### Requirement: Opening an object records a per-user view
+
+The system SHALL record a view (user, object, time) when a user reads an
+object's detail, at most once per user, object and minute, keeping the most
+recent 100 views per user.
+
+#### Scenario: repeated reads within a minute count once
+
+- **GIVEN** a user who reads the same object four times in ten seconds
+- **WHEN** their view history is listed
+- **THEN** the object appears once with the time of the first read
+- @e2e exclude {the throttle window is a service boundary covered by unit tests}
+
+### Requirement: Favourites and recent are lenses on the object query
+
+The object query SHALL accept `_favourite=true`, returning only the current
+user's starred objects, and `_recent=true`, returning the current user's
+viewed objects ordered by last view descending, each composing with every
+other filter.
+
+#### Scenario: a favourites chip on an index page
+
+- **GIVEN** a user who starred two of five cases
+- **WHEN** the index page queries with `_favourite=true` and `status=open`
+- **THEN** only the starred cases with status open are returned
+- @e2e exclude {proposal only; task 4.2 adds tests/e2e/ci/favourites-and-recent.spec.ts when the lenses ship}

--- a/openspec/changes/favourites-and-recent/tasks.md
+++ b/openspec/changes/favourites-and-recent/tasks.md
@@ -1,0 +1,23 @@
+# Tasks: favourites-and-recent
+
+## 1. Storage
+
+- [ ] 1.1 Migration for `openregister_favourites` and
+      `openregister_object_views` with (user, object) indexes.
+- [ ] 1.2 Cascade both on object deletion.
+
+## 2. API
+
+- [ ] 2.1 `PUT` and `DELETE .../favourite` endpoints.
+- [ ] 2.2 Record a view on detail reads, throttled per minute.
+- [ ] 2.3 `@self.favourite` marker on reads and lists.
+
+## 3. Query
+
+- [ ] 3.1 `_favourite=true` and `_recent=true` lenses in the filter parser.
+
+## 4. Tests
+
+- [ ] 4.1 Unit tests for the lenses, the throttle and the cascade.
+- [ ] 4.2 `tests/e2e/ci/favourites-and-recent.spec.ts`: star an object,
+      open another, filter by each lens, see the expected rows.

--- a/openspec/changes/files-leaf-save-to-object/design.md
+++ b/openspec/changes/files-leaf-save-to-object/design.md
@@ -1,0 +1,29 @@
+# Design: files leaf save to object
+
+## D-1: one attach path, two entry points
+
+Both actions end in `FileService::attach(objectId, node)`, which is the
+existing validate, write, own, tag pipeline with the node as the source
+instead of an upload. The Talk action first writes the exported chat as a
+`.txt` node in the user's files, then attaches it, so the audit trail shows
+one file event.
+
+## D-2: the picker searches titles the user may write
+
+The picker calls the object search with `_writable: true`, which the RBAC
+layer already resolves, and shows title, schema and register per row. A
+manifest may declare `fileActions.attachTargets: [{ register, schema }]` to
+pin the list; the declaration is read at runtime by the picker, not by the
+Files app.
+
+## D-3: registration through the Nextcloud APIs
+
+The Files action uses `@nextcloud/files` `registerFileAction`; the Talk
+action uses Talk's message and conversation action registration. Both are
+registered from OpenRegister's Files and Talk script entries, so the actions
+exist on every instance that has OpenRegister enabled.
+
+## D-4: kind
+
+Code, in OpenRegister. Consuming apps declare `fileActions.attachTargets`
+in config when they want a narrower picker.

--- a/openspec/changes/files-leaf-save-to-object/proposal.md
+++ b/openspec/changes/files-leaf-save-to-object/proposal.md
@@ -1,0 +1,43 @@
+# Files leaf: save a file or a Talk chat to any register object
+
+## Why
+
+Round 2 of the dossiq competitor analysis (row B05 in
+`concurrentie-analyse/procest/_round2/compare/tier-b-and-sibling.md`, decision
+D10): OpenCase registers a "Save to OpenCase" file action in Nextcloud Files
+and a "Save chat to OpenCase" entry in Talk
+(`opencase/round2/pages/NextcloudFilesIntegration.md`,
+`opencase/round2/menu-tree.md`). A caseworker who receives a file in Files or
+a conversation in Talk attaches it to the case from where they are, without
+opening the case app first.
+
+dossiq registers no files plugin and no talk plugin. The files leaf already
+copies and moves files between objects (file-actions, File Copy Between
+Objects) and Talk rooms already link to objects (integration-talk). What is
+missing is the entry point on the Nextcloud side, and it is the same entry
+point for every fleet app.
+
+## What changes
+
+- OpenRegister registers a Files action "Add to object" on files and folders.
+  It opens a picker that finds a register object by title across the schemas
+  the user may write to, optionally narrowed by app, and attaches the file
+  through the existing files-leaf upsert pipeline.
+- OpenRegister registers a Talk conversation action "Save chat to object"
+  that exports the conversation as a text file and attaches it the same way.
+- A consuming app may pin the picker to its own schemas by declaring
+  `fileActions.attachTargets` in its manifest; without it the picker offers
+  every writable schema with a files leaf.
+
+## Who benefits
+
+dossiq, filinq, keepiq, humaniq, buildiq, and every app that mounts the files
+leaf.
+
+## Impact
+
+- Affected specs: file-actions (delta).
+- Affected code: a Files plugin under `src/files/`, a Talk plugin under
+  `src/talk/`, `lib/Service/File/FileService.php` (attach by object id),
+  one route for the object picker's title search.
+- Backwards compatible: the existing file endpoints are unchanged.

--- a/openspec/changes/files-leaf-save-to-object/specs/file-actions/spec.md
+++ b/openspec/changes/files-leaf-save-to-object/specs/file-actions/spec.md
@@ -1,0 +1,39 @@
+# file-actions
+
+## ADDED Requirements
+
+### Requirement: A Files action attaches a file to a register object
+
+OpenRegister SHALL register a Files action, "Add to object", on files and
+folders, that offers a picker over the register objects the current user may
+write to, optionally narrowed by a consuming app's `fileActions.attachTargets`
+declaration, and SHALL attach the chosen node through the existing file
+upsert pipeline so the attachment is validated, owned, tagged and audited as
+an uploaded file would be.
+
+#### Scenario: a file in Files is attached to a case
+
+- **GIVEN** a user who may write objects of schema `case` and a file in their Files
+- **WHEN** they run "Add to object" on the file and pick a case by its title
+- **THEN** the file appears on the case's files leaf and an audit entry names the user and the file
+- @e2e exclude {proposal only; task 3.2 adds tests/e2e/ci/files-leaf-save-to-object.spec.ts when the plugin ships}
+
+#### Scenario: the picker offers only writable objects
+
+- **GIVEN** a user with read scope on register `archive` and write scope on register `cases`
+- **WHEN** they open the picker
+- **THEN** objects of `archive` are absent from the results
+- @e2e exclude {the writable filter is the RBAC layer's and is covered by unit tests}
+
+### Requirement: A Talk action saves a conversation to a register object
+
+OpenRegister SHALL register a Talk conversation action, "Save chat to
+object", that exports the conversation's messages as a text file and attaches
+that file to the chosen object through the same pipeline as the Files action.
+
+#### Scenario: a chat becomes a file on the object
+
+- **GIVEN** a Talk conversation with three messages and a user who may write to schema `case`
+- **WHEN** they run "Save chat to object" and pick a case
+- **THEN** a text file holding the three messages with their authors and times appears on the case's files leaf
+- @e2e exclude {Talk is not installed on the CI instance; covered by a unit test on the exporter and a manual check}

--- a/openspec/changes/files-leaf-save-to-object/tasks.md
+++ b/openspec/changes/files-leaf-save-to-object/tasks.md
@@ -1,0 +1,19 @@
+# Tasks: files-leaf-save-to-object
+
+## 1. Backend
+
+- [ ] 1.1 `FileService::attach(objectId, node)` reusing the upsert pipeline.
+- [ ] 1.2 Talk chat export to a `.txt` node, then attach.
+- [ ] 1.3 Route for the picker's writable-object title search.
+
+## 2. Plugins
+
+- [ ] 2.1 Files action "Add to object" with the object picker.
+- [ ] 2.2 Talk conversation action "Save chat to object".
+- [ ] 2.3 Read `fileActions.attachTargets` from the consuming manifest.
+
+## 3. Tests
+
+- [ ] 3.1 Unit tests for attach by node and the writable filter.
+- [ ] 3.2 `tests/e2e/ci/files-leaf-save-to-object.spec.ts`: from Files,
+      run the action on a file, pick an object, see the file on the object.

--- a/openspec/changes/generated-identifier/design.md
+++ b/openspec/changes/generated-identifier/design.md
@@ -1,0 +1,36 @@
+# Design: generated identifier
+
+## D-1: annotation shape
+
+`x-openregister-generated: { sequence: 'case', format: 'Z-{year}-{seq:5}',
+resetOn: 'year' }`. `{seq:n}` zero-pads to n digits; `{year}`, `{month}`
+render the creation time; any other text is literal. `resetOn: year` keys
+the counter by year, so `Z-2026-00001` and `Z-2027-00001` are distinct
+counters. Names are English (decision D13).
+
+## D-2: one row per counter, taken under a lock
+
+`openregister_sequences (name, period, value)` with a unique key on
+(name, period). Taking the next value is `UPDATE ... SET value = value + 1
+RETURNING value` on Postgres and a `SELECT ... FOR UPDATE` pair on MariaDB,
+inside the object create transaction. A rolled-back create leaves a gap;
+gaps are allowed, reuse is not.
+
+## D-3: generated once, then frozen
+
+The listener fills the property only when it is empty on create, in the
+same pattern as `LifecycleInitialStateListener`. An update that changes a
+generated property is refused with 422 by a guard on `ObjectUpdatingEvent`.
+An import that supplies a value keeps it and advances the counter to at
+least the parsed `{seq}` of that value, so later creates do not collide.
+
+## D-4: no Twig
+
+A Twig expression runs without a lock and can produce the same value twice
+under load. The sequence is a distinct annotation for that reason, and the
+generated value may still be referenced by computed fields afterwards.
+
+## D-5: kind
+
+Code, in OpenRegister. Consuming apps add the annotation to a property,
+which is config.

--- a/openspec/changes/generated-identifier/proposal.md
+++ b/openspec/changes/generated-identifier/proposal.md
@@ -1,0 +1,48 @@
+# Generated identifier: a sequence and a format on a schema property
+
+## Why
+
+Round 2 of the dossiq competitor analysis (row A13 in
+`concurrentie-analyse/procest/_round2/compare/findings.md`, placement section
+3, decision D10): every competitor numbers a case from a mask or a sequence.
+OpenCase renders the chip `2026-00002` from the mask `yyyy-#####`
+(`opencase/round2/case-detail-anatomy.md`); GZAC keeps a
+`JsonSchemaDocumentDefinitionSequenceRecord` per definition
+(`valtimo/round2/code-census.md`); Zaaksysteem titles the case `Zaak 2`
+(`xxllnc-zaken/round2/case-detail-anatomy.md`).
+
+dossiq's `case.identifier` is free text and shows "-" on 5 of 7 dashboard
+rows; `ComplaintService::generateComplaintNumber` numbers complaints only,
+and the open change email-case-matching assumes a generated `YYYY-NNNN` that
+nothing generates. A number from a sequence is the same need in every fleet
+app that files something: cases, complaints, invoices, tickets, decisions.
+computed-fields owns save-time materialisation of a declared value; a
+sequence is the one value a Twig expression cannot produce safely under
+concurrency, so it becomes a sibling annotation there.
+
+## What changes
+
+- A string property may declare `x-openregister-generated`: a `sequence`
+  name, a `format` with placeholders (`{year}`, `{seq:5}`, a fixed prefix),
+  and a `resetOn` of `never` or `year`.
+- On create, when the property is empty, the system takes the next value of
+  the named sequence under a lock and renders the format. The result is
+  unique per sequence, gap-tolerant, and never reused after a rollback.
+- The property is read-only after generation; an update that changes it is
+  refused. Import may supply a value, which advances the sequence past it.
+- A sequence is shared when two schemas name the same sequence, so a
+  register can number cases and complaints from one counter.
+
+## Who benefits
+
+dossiq (case number), zaakafhandelapp (zaaknummer), decidiq (decision
+number), humaniq (employee number), pipelinq (quote number), keepiq (ticket).
+
+## Impact
+
+- Affected specs: computed-fields (delta).
+- Affected code: schema annotation validation, a new
+  `openregister_sequences` table with a migration, a listener on
+  `ObjectCreatingEvent` beside the lifecycle initial-state listener, the
+  update guard, import handling.
+- Backwards compatible: a schema without the annotation is unchanged.

--- a/openspec/changes/generated-identifier/specs/computed-fields/spec.md
+++ b/openspec/changes/generated-identifier/specs/computed-fields/spec.md
@@ -1,0 +1,58 @@
+# computed-fields
+
+## ADDED Requirements
+
+### Requirement: A property declares a generated identifier from a sequence and a format
+
+A string property MAY declare `x-openregister-generated` with a sequence
+name, a format holding `{seq:n}`, `{year}`, `{month}` and literal text, and
+`resetOn` of `never` or `year`. Schema save SHALL refuse an unknown
+placeholder or a non-string property. On create, when the property is
+empty, the system SHALL take the next value of the sequence under a lock
+within the create transaction and render the format. Values SHALL be unique
+per sequence and period and SHALL never be reused after a rollback.
+
+#### Scenario: two creates get consecutive identifiers
+
+- **GIVEN** schema `case` whose `identifier` declares sequence `case`, format `Z-{year}-{seq:5}`, `resetOn: year`
+- **WHEN** two cases are created in 2026 without an identifier
+- **THEN** their identifiers are `Z-2026-00001` and `Z-2026-00002`
+- @e2e exclude {proposal only; task 3.2 adds tests/e2e/api-direct/generated-identifier.spec.ts when the listener ships}
+
+#### Scenario: parallel creates never collide
+
+- **GIVEN** the same schema
+- **WHEN** fifty cases are created concurrently
+- **THEN** fifty distinct identifiers result
+- @e2e exclude {concurrency is exercised by a dedicated unit test on both databases}
+
+### Requirement: A generated identifier is frozen after creation
+
+An update that changes a generated property SHALL be refused with 422. An
+import or create that supplies a value SHALL keep it and SHALL advance the
+sequence to at least the `{seq}` parsed from that value.
+
+#### Scenario: editing the identifier is refused
+
+- **GIVEN** a case with identifier `Z-2026-00001`
+- **WHEN** a user updates the case with identifier `Z-2026-00009`
+- **THEN** the update is refused with 422 and the identifier is unchanged
+- @e2e exclude {proposal only; task 3.2 adds tests/e2e/api-direct/generated-identifier.spec.ts when the guard ships}
+
+#### Scenario: an imported value advances the counter
+
+- **GIVEN** an import creating a case with identifier `Z-2026-00120`
+- **WHEN** the next case is created without an identifier
+- **THEN** it receives `Z-2026-00121`
+- @e2e exclude {import handling is covered by unit tests on the listener}
+
+### Requirement: Two schemas may share one sequence
+
+Two schemas naming the same sequence SHALL draw from one counter.
+
+#### Scenario: cases and complaints number from one counter
+
+- **GIVEN** schemas `case` and `complaint` both naming sequence `register`
+- **WHEN** a case and then a complaint are created
+- **THEN** the complaint's `{seq}` is one higher than the case's
+- @e2e exclude {shared counters are covered by unit tests on the sequence service}

--- a/openspec/changes/generated-identifier/tasks.md
+++ b/openspec/changes/generated-identifier/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: generated-identifier
+
+## 1. Storage and declaration
+
+- [ ] 1.1 `openregister_sequences` migration with the unique key.
+- [ ] 1.2 Validate `x-openregister-generated` at schema save (string
+      property, known placeholders, `resetOn` in the vocabulary).
+
+## 2. Generation
+
+- [ ] 2.1 Listener on `ObjectCreatingEvent` filling an empty property under
+      the lock, on both databases.
+- [ ] 2.2 Update guard refusing a change to a generated property.
+- [ ] 2.3 Import keeps a supplied value and advances the counter.
+
+## 3. Tests
+
+- [ ] 3.1 Unit tests for the format renderer, the guard and the import
+      advance; a concurrency test creating fifty objects in parallel.
+- [ ] 3.2 `tests/e2e/api-direct/generated-identifier.spec.ts`: create two
+      objects, read consecutive identifiers, try to edit one and get 422.

--- a/openspec/changes/lifecycle-over-reference-field/design.md
+++ b/openspec/changes/lifecycle-over-reference-field/design.md
@@ -1,0 +1,35 @@
+# Design: results, side moves and reopen on graph mode
+
+## D-1: a form is properties, not a new payload
+
+`form: { properties: ['result', 'comment'], required: ['result'] }` names
+existing schema properties. The transition endpoint accepts their values
+beside the action id, validates them against the schema, and saves them in
+the same write as the lifecycle field. The audit entry of the transition
+lists them, so "closed with result granted" is one row.
+
+## D-2: side moves set a second field and freeze the graph
+
+`sideMoves: { suspend: { field: 'suspended', set: true, label: ... },
+resume: { field: 'suspended', set: false } }`. While `suspended` is true the
+engine offers no graph move; `availableActions()` returns `resume` only.
+A term-extension is a side move with a form on a date property and no
+field change, so the same mechanism covers Termijn wijzigen.
+
+## D-3: reopen is a declared exception to terminal lock-out
+
+Terminal graph states lock out non-any moves (object-lifecycle, Terminal
+graph states lock out non-any moves). `reopen: { to: <statusType filter or
+'first'>, requires: 'manage' }` is the one declared exception. It is a
+named action, guarded through the same registry, audited as a reopen.
+
+## D-4: one code path
+
+`availableActions()` and `transition()` keep sharing the derivation; side
+moves and reopen are added to the same list the client already reads, each
+with its `form`, so a client cannot apply an action it was not offered.
+
+## D-5: kind
+
+Code, in OpenRegister. Consuming apps declare `form`, `sideMoves` and
+`reopen` in schema JSON, which is config.

--- a/openspec/changes/lifecycle-over-reference-field/proposal.md
+++ b/openspec/changes/lifecycle-over-reference-field/proposal.md
@@ -1,0 +1,56 @@
+# Lifecycle over a reference field: results, side moves and reopen
+
+## Why
+
+Round 2 of the dossiq competitor analysis (row A02 in
+`concurrentie-analyse/procest/_round2/compare/findings.md`, placement section
+3, decision D10): every competitor drives a case from its page. OpenCase
+offers Close, Reopen, Archive and Create subcase
+(`opencase/round2/case-detail-anatomy.md`); GZAC's kebab has Claimen and
+Dossier verwijderen (`valtimo/round2/case-detail-anatomy.md`); Zaaksysteem
+has Fase afronden, Opschorten, Hervatten, Termijn wijzigen and Vroegtijdig
+afhandelen (`xxllnc-zaken/round2/pages/Case-Zaakacties.md`).
+
+dossiq's CaseDetail declares `lifecycleActions { field: status }` and
+renders nothing, because `case.status` references a `statusType` row
+(triage #1). OpenRegister already answers the core of that: graph mode
+derives transitions from FK-scoped sibling rows (object-lifecycle, Lifecycle
+graph mode derives transitions from FK-scoped siblings) with `case` and
+`statusType` as its worked example. What graph mode cannot express is the
+rest of the competitors' action set: a move that records a result and a
+comment, side moves such as suspend and resume that leave the ordered graph,
+and a reopen from a terminal state. This change adds those three to graph
+mode; the dossiq half is `case-status-onto-engine-lifecycle`, and the
+`CnLifecycleActions` rendering is nextcloud-vue's.
+
+## What changes
+
+- A transition MAY declare a `form`: properties the actor fills when
+  applying it (a result from an enumeration, a comment, a date). The values
+  are written to the object with the move, in one save, and appear in the
+  audit entry of the transition.
+- A `graph` block MAY declare `sideMoves`: named transitions available from
+  any non-terminal state that set a second field (`suspended: true`, with
+  `resumeTo` the state the object returns to) without touching the ordered
+  graph. The engine offers `suspend` when not suspended and `resume` when
+  suspended, and refuses graph moves while suspended.
+  Each side move MAY carry its own `form`.
+- A `graph` block MAY declare `reopen`: a named transition from a terminal
+  state to a declared sibling state, guarded like any other and requiring
+  `manage` by default.
+- `availableActions()` returns the form definition with each action so a
+  client renders the dialog from the answer.
+
+## Who benefits
+
+dossiq, zaakafhandelapp, decidiq (decision states), keepiq (ticket states),
+humaniq (leave requests), any app with a per-type status vocabulary.
+
+## Impact
+
+- Affected specs: object-lifecycle (delta).
+- Affected code: `x-openregister-lifecycle` validation, `TransitionEngine`
+  (form, side moves, reopen), the lifecycle actions endpoint, the audit
+  entry of a transition.
+- Backwards compatible: a graph block without `sideMoves`, `reopen` or
+  `form` behaves as today.

--- a/openspec/changes/lifecycle-over-reference-field/specs/object-lifecycle/spec.md
+++ b/openspec/changes/lifecycle-over-reference-field/specs/object-lifecycle/spec.md
@@ -1,0 +1,63 @@
+# object-lifecycle
+
+## ADDED Requirements
+
+### Requirement: A transition carries a form whose values save with the move
+
+A static transition, a graph block, a side move or a reopen MAY declare a
+`form` naming schema properties and which are required. The transition
+endpoint SHALL accept those values beside the action id, SHALL validate
+them against the schema, SHALL write them in the same save as the lifecycle
+field, and the transition's audit entry SHALL list them.
+`availableActions()` SHALL return each action's form definition.
+
+#### Scenario: closing with a result is one save and one audit entry
+
+- **GIVEN** a `case` whose graph declares a form with required `result` on the move to the terminal status
+- **WHEN** the handler applies that move with `result: 'granted'`
+- **THEN** the case's status and result change in one save and one audit entry lists both
+- @e2e exclude {proposal only; task 3.2 adds tests/e2e/api-direct/lifecycle-graph-side-moves.spec.ts when the engine ships}
+
+#### Scenario: a required form value missing is refused
+
+- **GIVEN** the same case
+- **WHEN** the handler applies the move without `result`
+- **THEN** the transition is refused with 422 naming `result` and the status is unchanged
+- @e2e exclude {form validation is covered by unit tests on TransitionEngine}
+
+### Requirement: Side moves set a second field and freeze the graph while set
+
+A graph block MAY declare `sideMoves`, each naming a boolean field, the
+value it sets and a label. The engine SHALL offer a side move whose field
+is not yet at its value, SHALL refuse every graph move while any side
+move's field is set, and SHALL offer the reversing side move instead.
+
+#### Scenario: a suspended case offers resume only
+
+- **GIVEN** a case at status `In behandeling` with side moves `suspend` (sets `suspended` true) and `resume` (sets it false)
+- **WHEN** the handler applies `suspend` and lists available actions
+- **THEN** the list holds `resume` and no `move-to` action
+- @e2e exclude {proposal only; task 3.2 adds tests/e2e/api-direct/lifecycle-graph-side-moves.spec.ts when the engine ships}
+
+### Requirement: A declared reopen is the only move out of a terminal state
+
+A graph block MAY declare `reopen` with a target sibling and a required
+action, `manage` by default. The engine SHALL offer `reopen` on an object
+in a terminal state to a user who holds that action, SHALL apply it as a
+named transition through the guard registry, and SHALL audit it as a
+reopen. Without a declared reopen, terminal states SHALL stay locked out as
+before.
+
+#### Scenario: a manager reopens a closed case
+
+- **GIVEN** a closed case whose graph declares `reopen` to the first status and a user with `manage`
+- **WHEN** the user applies `reopen`
+- **THEN** the status becomes the first status and the audit entry is of kind reopen
+- @e2e exclude {proposal only; task 3.2 adds tests/e2e/api-direct/lifecycle-graph-side-moves.spec.ts when the engine ships}
+
+#### Scenario: a handler without manage is not offered reopen
+
+- **GIVEN** the same closed case and a user with `update` only
+- **WHEN** they list available actions
+- **THEN** the list is empty
+- @e2e exclude {the guard is covered by unit tests on TransitionEngine}

--- a/openspec/changes/lifecycle-over-reference-field/tasks.md
+++ b/openspec/changes/lifecycle-over-reference-field/tasks.md
@@ -1,0 +1,23 @@
+# Tasks: lifecycle-over-reference-field
+
+## 1. Declaration
+
+- [ ] 1.1 Validate `form`, `sideMoves` and `reopen` in the lifecycle
+      annotation at schema save.
+
+## 2. Engine
+
+- [ ] 2.1 Transition endpoint accepts form values, validates and saves them
+      with the move; audit entry lists them.
+- [ ] 2.2 Side moves offered by the second field's state; graph moves
+      refused while suspended.
+- [ ] 2.3 Reopen from a terminal state, guarded, audited.
+- [ ] 2.4 `availableActions()` carries each action's form.
+
+## 3. Tests
+
+- [ ] 3.1 Unit tests for validation, the suspended freeze, reopen guard and
+      the single-save form write.
+- [ ] 3.2 `tests/e2e/api-direct/lifecycle-graph-side-moves.spec.ts`: seed a
+      case and status types, suspend, see graph moves gone, resume, close
+      with a result, reopen as manager.

--- a/openspec/changes/notes-leaf-rich-text-lock-export/design.md
+++ b/openspec/changes/notes-leaf-rich-text-lock-export/design.md
@@ -1,0 +1,33 @@
+# Design: notes leaf rich text, lock and export
+
+## D-1: Markdown on the wire, sanitised on render
+
+Notes ride `ICommentsManager` (object-interactions, Notes on Objects via
+ICommentsManager). The message stays a string; the leaf stores Markdown and
+renders it through the same sanitiser the collectives leaf uses for its
+preview. Raw HTML in a note is escaped, never rendered.
+
+## D-2: the lock is a comment verb, not a flag on the object
+
+`ICommentsManager` stores a `verb` per comment. A locked note has verb
+`note-locked`, and its message is frozen by the service: an edit or delete on
+a `note-locked` comment is refused with 423. The actor and time of the lock
+are appended as the comment's last edit, so the Comments app shows them too.
+Only the note's author or a user with `manage` on the object may lock.
+
+## D-3: no unlock
+
+A locked note stays locked. Correcting one is a new note that references the
+old one. This mirrors the journal practice the competitors implement and
+keeps the audit honest.
+
+## D-4: the journal sheet is the PDF export format over notes
+
+export-pdf-format already renders an object to PDF from a template. The
+journal sheet is a second template over the object's notes, in order, with
+author, time and lock state; Markdown export is the same data without the
+template.
+
+## D-5: kind
+
+Code, in OpenRegister. Consuming apps get it by mounting the notes leaf.

--- a/openspec/changes/notes-leaf-rich-text-lock-export/proposal.md
+++ b/openspec/changes/notes-leaf-rich-text-lock-export/proposal.md
@@ -1,0 +1,41 @@
+# Notes leaf: rich text, a lock, and a journal sheet export
+
+## Why
+
+Round 2 of the dossiq competitor analysis (row B17 in
+`concurrentie-analyse/procest/_round2/compare/tier-b-and-sibling.md`, decision
+D10): OpenCase's journal notes on a case are rich text, a note can be locked
+so it can no longer be edited, and the notes of a case export as one journal
+sheet (`opencase/round2/pages/CaseDetail-JournalNotes.md`). In Dutch case
+handling a locked note is the record of a contact moment or a decision, which
+must not change after the fact.
+
+dossiq's notes are the OpenRegister notes leaf, which is plain text once
+defect D01 is fixed (M1 6.1). The leaf serves every fleet app, so the three
+features belong on it.
+
+## What changes
+
+- A note's body accepts a bounded Markdown subset (headings, emphasis, lists,
+  links) stored as Markdown and rendered sanitised; the editor is the
+  Nextcloud Text editor when the Text app is present, a Markdown textarea
+  when not.
+- A note can be locked by its author or by a user with `manage` on the
+  object. A locked note cannot be edited or deleted, by anyone, and shows who
+  locked it and when. Locking is audited on the object.
+- The notes of one object export as a journal sheet: a PDF or Markdown
+  document listing every note in order with author, time and lock state,
+  through the existing PDF export format.
+
+## Who benefits
+
+dossiq, zaakafhandelapp, humaniq (personnel file notes), keepiq, integriq
+(sync notes).
+
+## Impact
+
+- Affected specs: object-interactions (delta).
+- Affected code: `lib/Service/Interaction/NoteService.php`, the comment
+  verb storage for the lock flag, the notes leaf Vue surfaces, export-pdf
+  usage.
+- Backwards compatible: an existing plain-text note is valid Markdown.

--- a/openspec/changes/notes-leaf-rich-text-lock-export/specs/object-interactions/spec.md
+++ b/openspec/changes/notes-leaf-rich-text-lock-export/specs/object-interactions/spec.md
@@ -1,0 +1,51 @@
+# object-interactions
+
+## ADDED Requirements
+
+### Requirement: Notes accept a bounded Markdown subset rendered sanitised
+
+A note SHALL accept a Markdown subset (headings, emphasis, lists, links),
+SHALL be stored as Markdown, and SHALL be rendered through a sanitiser so
+that raw HTML is escaped. When the Nextcloud Text app is present the leaf
+SHALL offer its editor; otherwise a Markdown textarea.
+
+#### Scenario: a heading renders and a script tag does not
+
+- **GIVEN** a note whose body is `# Contact\n<script>x()</script>`
+- **WHEN** the note is rendered on the object
+- **THEN** the heading "Contact" renders as a heading and the script tag appears as escaped text
+- @e2e exclude {proposal only; task 4.2 adds tests/e2e/ci/notes-leaf-lock.spec.ts when the leaf ships}
+
+### Requirement: A note can be locked and a locked note is immutable
+
+The author of a note, or a user with `manage` on the object, SHALL be able
+to lock it. A locked note SHALL refuse edit and delete for every user with
+status 423, SHALL display who locked it and when, and SHALL NOT be
+unlockable. Locking SHALL write an audit entry on the object.
+
+#### Scenario: an edit on a locked note is refused
+
+- **GIVEN** a note locked by its author
+- **WHEN** an admin tries to edit its body
+- **THEN** the request is refused with 423 and the body is unchanged
+- @e2e exclude {the guard is covered by unit tests on NoteService}
+
+#### Scenario: a reader cannot lock
+
+- **GIVEN** a user with read scope on the object who did not write the note
+- **WHEN** they try to lock it
+- **THEN** the request is refused with 403
+- @e2e exclude {authorization is covered by unit tests on NoteService}
+
+### Requirement: An object's notes export as a journal sheet
+
+The system SHALL export every note of one object, in chronological order,
+with author, time and lock state, as a PDF through the existing PDF export
+format and as Markdown.
+
+#### Scenario: the sheet lists notes in order with their lock state
+
+- **GIVEN** an object with three notes of which the second is locked
+- **WHEN** the journal sheet is exported as Markdown
+- **THEN** the document lists the three notes in chronological order and marks the second as locked with the locker's name
+- @e2e exclude {export contents are covered by unit tests on the exporter}

--- a/openspec/changes/notes-leaf-rich-text-lock-export/tasks.md
+++ b/openspec/changes/notes-leaf-rich-text-lock-export/tasks.md
@@ -1,0 +1,23 @@
+# Tasks: notes-leaf-rich-text-lock-export
+
+## 1. Rich text
+
+- [ ] 1.1 Markdown subset stored and sanitised on render.
+- [ ] 1.2 Text editor when the Text app is present, textarea otherwise.
+
+## 2. Lock
+
+- [ ] 2.1 `POST .../notes/{id}/lock` sets verb `note-locked`, records actor
+      and time, audits on the object.
+- [ ] 2.2 Edit and delete refused with 423 on a locked note.
+
+## 3. Export
+
+- [ ] 3.1 Journal sheet PDF template and Markdown export over an object's
+      notes.
+
+## 4. Tests
+
+- [ ] 4.1 Unit tests for sanitising, the lock guard and the export order.
+- [ ] 4.2 `tests/e2e/ci/notes-leaf-lock.spec.ts`: write a note with a
+      heading, lock it, see the edit control gone and the lock badge.

--- a/openspec/changes/query-related-schema-rows/design.md
+++ b/openspec/changes/query-related-schema-rows/design.md
@@ -1,0 +1,40 @@
+# Design: related-schema row filter
+
+## D-1: syntax
+
+`?_related[caseProperty][case][propertyDefinition]=<uuid>&_related[caseProperty][case][value][gte]=100`
+reads: objects for which a `caseProperty` row exists whose `case` references
+the object, whose `propertyDefinition` is the uuid and whose `value` is at
+least 100. Conditions inside one `_related` block apply to the same row.
+Two blocks on the same schema are two `EXISTS` clauses, so "has property A
+and has property B" is expressible.
+
+## D-2: SQL
+
+Each block becomes `EXISTS (SELECT 1 FROM objects r WHERE r.schema = ? AND
+r.object->>'case' = o.uuid AND <conditions>)`, with the JSON path expressions
+the field filter already produces. The foreign-key expression index that
+referential-integrity maintains serves the correlation. MariaDB uses the same
+shape with `JSON_EXTRACT`.
+
+## D-3: RBAC on both sides
+
+The related schema's read predicate is applied inside the subquery, so a
+user who may not read `caseProperty` rows cannot infer their values by
+filtering. This is the same predicate injection the main query uses.
+
+## D-4: facets
+
+`_facets[_related][caseProperty][case][value]` returns the value
+distribution across matching rows, bounded by the facet limit. An index page
+renders chips per `propertyDefinition` from it.
+
+## D-5: search backend
+
+With a Solr backend the block translates to a `{!join}` query when the
+related schema is mirrored; otherwise the query falls back to the database
+path for that request and says so in the response.
+
+## D-6: kind
+
+Code, in OpenRegister. Consuming apps use the syntax in config.

--- a/openspec/changes/query-related-schema-rows/proposal.md
+++ b/openspec/changes/query-related-schema-rows/proposal.md
@@ -1,0 +1,46 @@
+# Query: filter on rows of a related schema
+
+## Why
+
+Round 2 of the dossiq competitor analysis (row B15 in
+`concurrentie-analyse/procest/_round2/compare/tier-b-and-sibling.md`, decision
+D10): every competitor searches a case on the properties its case type
+defines. Zaaksysteem filters on custom attributes per Zaaktype beside 55
+system filters (`xxllnc-zaken/round2/search-anatomy.md`); GZAC declares
+search fields on schema paths per case definition
+(`valtimo/round2/pages/CaseDefinition-Dossierlijst.md`); OpenCase searches
+fixed fields (`opencase/round2/pages/Search-Cases.md`).
+
+dossiq stores a case's typed properties as rows of schema `caseProperty`
+(case, propertyDefinition, value), because the property set differs per case
+type. Its Cases filters reach the `case` fields only: a `caseProperty` row is
+not filterable from the case list (M1 9.2). OpenRegister's query filters one
+schema at a time; a filter over a related schema's rows is a query feature,
+and the same shape serves every app that models typed attributes as rows.
+
+## What changes
+
+- The object query accepts a related-row filter: `_related[<schema>][<fk>]`
+  with one or more field conditions, returning the objects for which at least
+  one row of `<schema>` whose `<fk>` references the object matches every
+  condition. Existing operators apply to the row's fields.
+- The filter composes with the object's own filters and with the favourites
+  and recent lenses, and honours RBAC on both schemas.
+- Facets may be requested over a related schema's field with the same syntax,
+  so an index page can offer chips from `propertyDefinition` values.
+- The SQL is an `EXISTS` subquery on the related schema's table, so it is one
+  round trip and index-backed on the foreign key.
+
+## Who benefits
+
+dossiq (Cases advanced search), zaakafhandelapp (zaakeigenschappen),
+humaniq (custom employee fields), stackiq (component attributes),
+opencatalogi.
+
+## Impact
+
+- Affected specs: zoeken-filteren (delta).
+- Affected code: the query filter parser, the Postgres and MariaDB query
+  builders, the facet builder, the Solr backend (translated as a join query
+  where the backend supports it, database fallback where not).
+- Backwards compatible: a query without `_related` is unchanged.

--- a/openspec/changes/query-related-schema-rows/specs/zoeken-filteren/spec.md
+++ b/openspec/changes/query-related-schema-rows/specs/zoeken-filteren/spec.md
@@ -1,0 +1,54 @@
+# zoeken-filteren
+
+## ADDED Requirements
+
+### Requirement: The object query filters on rows of a related schema
+
+The object query SHALL accept `_related[<schema>][<fk>]` blocks holding one
+or more field conditions with the existing operators, and SHALL return the
+objects for which at least one row of `<schema>` whose `<fk>` references the
+object satisfies every condition in the block. Two blocks SHALL be
+independent existence tests. The related schema's read predicate SHALL be
+applied inside the subquery. The clause SHALL be one `EXISTS` subquery per
+block on both supported databases.
+
+#### Scenario: a case is found by a property row's value
+
+- **GIVEN** a `case` object with a `caseProperty` row (`case` = the object, `propertyDefinition` = P, `value` = 120) and another case whose row for P has value 80
+- **WHEN** the case list is queried with `_related[caseProperty][case][propertyDefinition]=P` and `_related[caseProperty][case][value][gte]=100`
+- **THEN** only the first case is returned
+- @e2e exclude {proposal only; task 3.2 adds tests/e2e/ci/query-related-schema-rows.spec.ts when the parser ships}
+
+#### Scenario: an unreadable related row cannot be probed
+
+- **GIVEN** a user with no read scope on `caseProperty`
+- **WHEN** they query cases with a `_related[caseProperty]` block
+- **THEN** no case is returned by that block, and no error reveals the row's existence
+- @e2e exclude {the predicate injection is covered by unit tests on both query builders}
+
+### Requirement: Facets over a related schema's field
+
+The facet request SHALL accept the same `_related` addressing so that an
+index page can show the value distribution of a related field across the
+matching objects, bounded by the facet limit.
+
+#### Scenario: chips from property definitions
+
+- **GIVEN** cases whose `caseProperty` rows for P hold values `A`, `A` and `B`
+- **WHEN** facets are requested for `_related[caseProperty][case][value]`
+- **THEN** the facet lists `A` with count 2 and `B` with count 1
+- @e2e exclude {facet counts are covered by unit tests on the facet builder}
+
+### Requirement: The search backend translates or falls back
+
+With a search backend configured the `_related` block SHALL be translated to
+the backend's join query when the related schema is mirrored, and SHALL
+otherwise fall back to the database path for that request and name the path
+taken in the response.
+
+#### Scenario: an unmirrored related schema falls back
+
+- **GIVEN** a Solr backend and a related schema that is not mirrored
+- **WHEN** a query with a `_related` block on it runs
+- **THEN** the results come from the database path and the response names it
+- @e2e exclude {backend selection is a fixture condition covered by unit tests}

--- a/openspec/changes/query-related-schema-rows/tasks.md
+++ b/openspec/changes/query-related-schema-rows/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: query-related-schema-rows
+
+## 1. Parser and SQL
+
+- [ ] 1.1 Parse `_related[<schema>][<fk>]` blocks with field operators.
+- [ ] 1.2 `EXISTS` subquery on Postgres and MariaDB with RBAC predicate
+      inside.
+- [ ] 1.3 Two blocks on one schema produce two clauses.
+
+## 2. Facets and backend
+
+- [ ] 2.1 Facets over a related field.
+- [ ] 2.2 Solr `{!join}` translation with database fallback and response
+      attribution.
+
+## 3. Tests
+
+- [ ] 3.1 Unit tests on both databases for the clause shape and RBAC.
+- [ ] 3.2 `tests/e2e/ci/query-related-schema-rows.spec.ts`: seed a case with
+      a caseProperty row, filter the case list on the row's value, see the
+      case.

--- a/openspec/changes/rbac-department-role-matrix/design.md
+++ b/openspec/changes/rbac-department-role-matrix/design.md
@@ -1,0 +1,37 @@
+# Design: department by role matrix
+
+## D-1: the matrix compiles to conditional scopes
+
+Each matrix row `{ value: 'VTH', group: 'handlers', actions: ['read', 'handle'] }`
+compiles to a conditional scope on the schema: group `handlers`, actions
+`read` and `handle`, condition `object.<field> == 'VTH'`. Rows sharing a group
+merge into one scope with an `in` condition. Nothing new at enforcement time,
+so PHP and SQL stay identical (rbac-scopes, PHP-side and SQL-side enforcement
+MUST be identical).
+
+## D-2: a user's own departments come from one declared source
+
+`matrix.userSource` is either `{ groupPrefix: 'dept:' }` (the user's
+Nextcloud groups starting with the prefix, prefix stripped) or
+`{ schema: 'person', property: 'department', match: 'userId' }` (the person
+object whose `userId` is the current user). A row may use the wildcard value
+`$self`, which resolves to the user's own departments at query time through
+the existing dynamic-variable mechanism.
+
+## D-3: `handle` is a custom verb
+
+`handle` is not canonical. It is declared through the existing custom-verb
+voting pair, so a consuming app maps it (dossiq: may run transitions and
+claim). Without a voter it resolves to `update`.
+
+## D-4: admin grid
+
+The schema page gains a Rights tab rendering the matrix as a grid of
+departments by role groups with action checkboxes, plus a preview field:
+choose a user, see the scopes the compiler produces. The grid writes the
+`matrix` block; it never writes compiled scopes.
+
+## D-5: kind
+
+Code, in OpenRegister. Consuming apps declare the matrix in their schema
+JSON, so for them it is config.

--- a/openspec/changes/rbac-department-role-matrix/proposal.md
+++ b/openspec/changes/rbac-department-role-matrix/proposal.md
@@ -1,0 +1,44 @@
+# RBAC: a department by role matrix per schema, keyed on an object field
+
+## Why
+
+Round 2 of the dossiq competitor analysis (row B13 in
+`concurrentie-analyse/procest/_round2/compare/tier-b-and-sibling.md`, decision
+D10): every competitor grants rights per case type as a matrix. Zaaksysteem's
+case type editor has a Rechten tab of Afdeling by Rol with four checkboxes
+(search, read, handle, manage) (`xxllnc-zaken/round2/case-type-editor-anatomy.md`);
+OpenCase scopes access by organisation, KLE and sensitivity
+(`opencase/round2/pages/CaseDetail-Access.md`); GZAC stores a permission JSON
+per role (`valtimo/round2/pages/Admin-AccessControl.md`).
+
+dossiq has `roleType.ncGroupId` and OpenRegister RBAC per schema, so a group
+may read every case of a schema or none; it cannot read the cases of its own
+department only. rbac-scopes already has conditional scopes with dynamic
+variables, so the engine can evaluate "object.department equals one of the
+user's departments". What is missing is the matrix as a first-class
+declaration and an admin surface to edit it.
+
+## What changes
+
+- A schema's `authorization` block accepts a `matrix` declaration: a field of
+  the object (`department`), the source of the user's own values (a Nextcloud
+  group prefix, or a property of the user's person object), and rows of
+  (department value, role group, actions). The engine compiles a row into a
+  conditional scope, so enforcement is the existing PHP and SQL path.
+- The declared action set is the canonical verbs plus `handle`, resolved by
+  the existing custom-verb voting so a consuming app can map `handle` to its
+  own transitions.
+- An admin surface on the schema page edits the matrix as a grid and previews
+  the effective scope for a chosen user.
+
+## Who benefits
+
+dossiq (rights per case type), zaakafhandelapp, humaniq (per team), dossiq's
+role-routing-via-or-rbac spec gains the per-department dimension it lacks.
+
+## Impact
+
+- Affected specs: rbac-scopes (delta).
+- Affected code: `lib/Service/Authorization/` (matrix compiler),
+  schema authorization validation, the schema admin Vue page.
+- Backwards compatible: a schema without `matrix` keeps its scopes.

--- a/openspec/changes/rbac-department-role-matrix/specs/rbac-scopes/spec.md
+++ b/openspec/changes/rbac-department-role-matrix/specs/rbac-scopes/spec.md
@@ -1,0 +1,55 @@
+# rbac-scopes
+
+## ADDED Requirements
+
+### Requirement: A schema declares a department by role matrix keyed on an object field
+
+A schema's `authorization` block SHALL accept a `matrix` declaration naming
+an object field, a user source (a group prefix or a person-schema property),
+and rows of (field value, role group, actions). The engine SHALL compile
+each row into a conditional scope on that schema so that enforcement runs
+through the existing PHP and SQL paths and stays identical between them.
+The value `$self` in a row SHALL resolve to the current user's own values
+from the user source at query time.
+
+#### Scenario: a group reads only its department's objects
+
+- **GIVEN** schema `case` with a matrix on field `department`, user source group prefix `dept:`, and a row `$self` for group `handlers` with actions `read`
+- **AND** user A in groups `handlers` and `dept:VTH`, user B in groups `handlers` and `dept:Belastingen`
+- **WHEN** each lists objects of schema `case`
+- **THEN** A sees only cases whose `department` is `VTH` and B only cases whose `department` is `Belastingen`
+- @e2e exclude {proposal only; task 4.2 adds tests/e2e/ci/rbac-department-role-matrix.spec.ts when the compiler ships}
+
+#### Scenario: a matrix naming a missing field is refused
+
+- **GIVEN** a schema save with a matrix on field `afdeling` that the schema does not declare
+- **WHEN** the schema is saved
+- **THEN** the save is refused naming the field
+- @e2e exclude {schema validation is a service boundary covered by unit tests}
+
+### Requirement: The matrix action set includes a resolvable `handle` verb
+
+The matrix SHALL accept the canonical verbs and the custom verb `handle`.
+`handle` SHALL resolve through the existing custom-verb voting pair and
+SHALL fall back to `update` when no voter claims it.
+
+#### Scenario: handle without a voter behaves as update
+
+- **GIVEN** a matrix row granting `handle` and no registered voter for `handle`
+- **WHEN** the user in that row updates an object of their department
+- **THEN** the update is allowed
+- @e2e exclude {verb resolution is covered by unit tests on the authorization service}
+
+### Requirement: An admin edits the matrix as a grid with a per-user preview
+
+The schema admin page SHALL render the matrix as a grid of field values by
+role groups with action checkboxes, SHALL write only the `matrix`
+declaration, and SHALL show, for a chosen user, the scopes the compiler
+produces.
+
+#### Scenario: the preview names the compiled scopes
+
+- **GIVEN** a saved matrix and an admin who picks user A in the preview
+- **WHEN** the preview loads
+- **THEN** it lists one scope per action group with the condition on the field and A's resolved values
+- @e2e exclude {proposal only; task 4.2 adds tests/e2e/ci/rbac-department-role-matrix.spec.ts when the surface ships}

--- a/openspec/changes/rbac-department-role-matrix/tasks.md
+++ b/openspec/changes/rbac-department-role-matrix/tasks.md
@@ -1,0 +1,23 @@
+# Tasks: rbac-department-role-matrix
+
+## 1. Declaration
+
+- [ ] 1.1 Validate `authorization.matrix` at schema save (field exists,
+      userSource shape, actions in the resolvable verb set).
+
+## 2. Compiler
+
+- [ ] 2.1 Compile rows into conditional scopes, merging rows per group.
+- [ ] 2.2 Resolve `$self` through the dynamic-variable mechanism for both
+      user sources.
+- [ ] 2.3 Declare `handle` as a custom verb with an `update` fallback.
+
+## 3. Admin surface
+
+- [ ] 3.1 Rights tab on the schema page: grid editor and per-user preview.
+
+## 4. Tests
+
+- [ ] 4.1 Unit tests: compilation, `$self`, PHP and SQL parity on a matrix.
+- [ ] 4.2 `tests/e2e/ci/rbac-department-role-matrix.spec.ts`: two users in
+      two departments, each sees only their department's cases in the list.

--- a/openspec/changes/registry-subscriptions/design.md
+++ b/openspec/changes/registry-subscriptions/design.md
@@ -1,0 +1,36 @@
+# Design: registry subscriptions
+
+## D-1: the annotation names what the registry owns
+
+`x-openregister-registry: { registry: 'brp', identity: 'bsn', owned:
+['givenNames', 'familyName', 'birthDate', 'address'] }`. Owned properties
+are the ones an inbound update may write; a user edit of an owned property
+on a subscribed object is warned in the UI and audited as a local override.
+Property names are English (decision D13).
+
+## D-2: state lives beside the object
+
+Subscription state, last update time and source live in a small table keyed
+by object uuid, surfaced as `@self.registry`. Requesting a subscription
+writes `requested` and dispatches `RegistrySubscriptionRequestedEvent`;
+the connector confirms with `active` through the inbound endpoint, or reports
+a refusal, which is stored with its reason.
+
+## D-3: the inbound endpoint is narrow
+
+`POST /api/registry/{registry}/updates` takes the identity value, the
+changed owned properties and the registry's own event reference. It resolves
+the object by identity, applies the properties through the ordinary save
+path with the registry as actor, and refuses (422) a property outside
+`owned`. Authentication is the connector's app password or the
+credential-broker grant; the endpoint is not public.
+
+## D-4: freshness is queryable
+
+`_registry[state]=active` and `_registry[updatedBefore]=<date>` are lenses on
+the object query, so a data steward lists stale subscribed persons.
+
+## D-5: kind
+
+Code, in OpenRegister. Consuming apps add the annotation to their schema
+JSON, which is config; integriq ships the connector.

--- a/openspec/changes/registry-subscriptions/proposal.md
+++ b/openspec/changes/registry-subscriptions/proposal.md
@@ -1,0 +1,46 @@
+# Registry subscriptions on stored persons and companies
+
+## Why
+
+Round 2 of the dossiq competitor analysis (row B22 in
+`concurrentie-analyse/procest/_round2/compare/tier-b-and-sibling.md`, decision
+D10): Zaaksysteem keeps a Gegevensmagazijn of persons and organisations with
+an afnemerindicatie per record, so the BRP and KvK push changes and the local
+copy stays current (`xxllnc-zaken/round2/pages/Gegevensmagazijn.md`);
+OpenCase does the same for Danish CPR events (`opencase/round2/code-census.md`).
+
+dossiq's HaalCentraalBrpAdapter and KvkApiAdapter look a person or company up
+and store the answer; nothing subscribes, so a stored person is stale the day
+after (M1 5.11). The row is split: the connector that registers and receives
+the subscription is integriq's; the store that marks an object as subscribed,
+receives an update and shows its freshness is OpenRegister's. This change is
+the OpenRegister half. No existing capability owns a subscription on an
+object, so this is a new capability, `registry-subscriptions`.
+
+## What changes
+
+- A schema may declare `x-openregister-registry`: the registry (`brp`,
+  `kvk`, or another id), the identity property (`bsn`, `kvkNumber`) and the
+  properties the registry owns.
+- An object of such a schema carries `@self.registry`: subscription state
+  (`none`, `requested`, `active`, `ended`), the last update received and its
+  source. A user with `update` may request or end a subscription; the request
+  is an event a connector (integriq) acts on.
+- An inbound update endpoint applies a registry change to the object's
+  registry-owned properties only, audited with the registry as actor, and
+  refuses a change to a property the registry does not own.
+- The object list exposes freshness so an index page can show "updated by
+  BRP on ..." and filter on subscription state.
+
+## Who benefits
+
+dossiq (parties on the case), zaakafhandelapp, humaniq (employee identity
+from BRP), pipelinq (company data from KvK), integriq as the connector.
+
+## Impact
+
+- Affected specs: registry-subscriptions (new capability).
+- Affected code: schema annotation validation, `lib/Service/Registry/`,
+  two endpoints (subscription request and end, inbound update), the
+  `@self.registry` marker, events for the connector.
+- Backwards compatible: a schema without the annotation is unchanged.

--- a/openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md
+++ b/openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md
@@ -1,0 +1,67 @@
+# registry-subscriptions
+
+## ADDED Requirements
+
+### Requirement: A schema declares which registry owns which properties
+
+A schema MAY declare `x-openregister-registry` naming a registry id, an
+identity property and the properties the registry owns. Schema save SHALL
+refuse an annotation whose identity or owned properties the schema does not
+declare.
+
+#### Scenario: an owned property missing from the schema is refused
+
+- **GIVEN** a schema `person` declaring `x-openregister-registry` with owned property `birthDate` that the schema lacks
+- **WHEN** the schema is saved
+- **THEN** the save is refused naming `birthDate`
+- @e2e exclude {schema validation is a service boundary covered by unit tests}
+
+### Requirement: An object carries a subscription state a user can request or end
+
+An object of a registry schema SHALL carry `@self.registry` with state
+`none`, `requested`, `active` or `ended`, the time and source of the last
+registry update, and any refusal reason. A user with `update` on the object
+SHALL be able to request or end the subscription; each SHALL dispatch an
+event for a connector and SHALL be audited.
+
+#### Scenario: requesting a subscription dispatches the event
+
+- **GIVEN** a `person` object with state `none` and a user with `update`
+- **WHEN** they request a subscription
+- **THEN** `@self.registry.state` is `requested` and a `RegistrySubscriptionRequestedEvent` carries the object uuid and identity value
+- @e2e exclude {proposal only; task 4.2 adds tests/e2e/api-direct/registry-subscriptions.spec.ts when the endpoints ship}
+
+### Requirement: An inbound registry update writes owned properties only
+
+The system SHALL expose an authenticated inbound update endpoint per
+registry that resolves the object by identity value, applies the supplied
+owned properties through the ordinary save path with the registry as actor,
+records the update time and event reference, and SHALL refuse with 422 a
+property the annotation does not list as owned.
+
+#### Scenario: a BRP move updates the address and nothing else
+
+- **GIVEN** an active `person` object with owned properties including `address`
+- **WHEN** the connector posts an update with a new `address` and the BRP event reference
+- **THEN** the object's `address` changes, the audit entry names registry `brp` as actor, and `@self.registry.lastUpdate` holds the event reference
+- @e2e exclude {proposal only; task 4.2 adds tests/e2e/api-direct/registry-subscriptions.spec.ts when the endpoint ships}
+
+#### Scenario: an update to a local property is refused
+
+- **GIVEN** the same object, whose `notes` property is not owned
+- **WHEN** the connector posts an update touching `notes`
+- **THEN** the request is refused with 422 naming `notes` and nothing is written
+- @e2e exclude {the owned-property guard is covered by unit tests}
+
+### Requirement: Subscription state and freshness are query lenses
+
+The object query SHALL accept `_registry[state]` and
+`_registry[updatedBefore]` so that stale or unsubscribed registry objects
+can be listed.
+
+#### Scenario: a steward lists stale persons
+
+- **GIVEN** two active persons, one updated a year ago and one yesterday
+- **WHEN** the list is queried with `_registry[state]=active` and `_registry[updatedBefore]` of a month ago
+- **THEN** only the person updated a year ago is returned
+- @e2e exclude {lenses are covered by unit tests on the query parser}

--- a/openspec/changes/registry-subscriptions/tasks.md
+++ b/openspec/changes/registry-subscriptions/tasks.md
@@ -1,0 +1,23 @@
+# Tasks: registry-subscriptions
+
+## 1. Declaration and state
+
+- [ ] 1.1 Validate `x-openregister-registry` at schema save.
+- [ ] 1.2 Subscription state table and `@self.registry` marker.
+
+## 2. Endpoints and events
+
+- [ ] 2.1 Request and end subscription endpoints, dispatching the events.
+- [ ] 2.2 Inbound update endpoint applying owned properties only, audited
+      with the registry as actor.
+
+## 3. Query
+
+- [ ] 3.1 `_registry[state]` and `_registry[updatedBefore]` lenses.
+
+## 4. Tests
+
+- [ ] 4.1 Unit tests for validation, the owned-property guard and lenses.
+- [ ] 4.2 `tests/e2e/api-direct/registry-subscriptions.spec.ts`: request a
+      subscription, post an inbound update, read the changed property and
+      the audit actor.


### PR DESCRIPTION
## Summary

Twelve OpenSpec changes for the OpenRegister findings of the dossiq competitor analysis, round 2 (`concurrentie-analyse/procest/_round2/compare/`: Tier B rows B01, B02, B05, B06, B13, B14, B15 query half, B17, B22 store half, and placement section 3 needs A02, A05, A13). Decision D10: these changes are asked for now. Decision D13: identifiers are English. Proposals only; no code.

Each change has a proposal (which dossiq page needs it, the competitor evidence path, which fleet apps benefit), a design (service, leaf, schema property or endpoint touched, and whether the consuming app ships config or code), tasks, and a spec delta against the capability that owns it. Every requirement has Given/When/Then scenarios with an `@e2e exclude` reason naming the test the tasks add.

| change | owning capability | row |
|---|---|---|
| contacts-leaf-cases-panel | integration-contacts | B01 |
| content-search-index | unified-search-provider (builds on the chunked provider from #3528) | B02 |
| files-leaf-save-to-object | file-actions | B05 |
| favourites-and-recent | object-interactions | B06 |
| rbac-department-role-matrix | rbac-scopes | B13 |
| audit-log-page | audit-trail-immutable | B14 |
| query-related-schema-rows | zoeken-filteren | B15 |
| notes-leaf-rich-text-lock-export | object-interactions | B17 |
| registry-subscriptions | registry-subscriptions (new capability; nothing owns a subscription on an object) | B22 |
| activity-leaf | integration-activity | A05 |
| generated-identifier | computed-fields | A13 |
| lifecycle-over-reference-field | object-lifecycle (graph mode already ships; this adds forms, side moves and reopen) | A02 |

## Verification

- `openspec validate <name> --strict` exits 0 for all twelve (run locally; the sparse clone holds `openspec/` only, so no other check applies).
- The diff touches `openspec/changes/` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
