### PR TITLE
fix(quality): the psalm and phpmd findings my container refactor introduced

### DIFF
--- a/lib/Db/SearchTrailMapper.php
+++ b/lib/Db/SearchTrailMapper.php
@@ -54,6 +54,11 @@ use Symfony\Component\Uid\Uuid;
  *
  * @template-extends QBMapper<SearchTrail>
  *
+ * @SuppressWarnings(PHPMD.ExcessiveClassLength)     A QBMapper for a table the
+ *          search-trail reporting reads through roughly thirty distinct query
+ *          shapes, each a method here. Adding clearAllLogs() for the admin
+ *          endpoint (which called a method that never existed) took the class
+ *          from just under phpmd's 1000-line threshold to just over it.
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)   Search trail tracking requires integration with many components
  */

--- a/lib/Service/Configuration/ImportHandler.php
+++ b/lib/Service/Configuration/ImportHandler.php
@@ -5134,6 +5134,8 @@ class ImportHandler {
 	 * @param array $configData The configuration data.
 	 *
 	 * @return void
+	 *
+	 * @psalm-suppress UndefinedClass OC_App is a Nextcloud server internal with no OCP equivalent for loadApp()
 	 */
 	private function ensureDependenciesForSeedData(array $configData): void {
 		// GUARD: Prevent recursive dependency checking.
@@ -5242,6 +5244,13 @@ class ImportHandler {
 						);
 
 						// Load the app to ensure its services are available.
+						//
+						// OC_App is a Nextcloud server internal with no OCP
+						// equivalent for this call, so psalm cannot see the class
+						// (suppressed on this method's docblock). It exists
+						// whenever this branch can run: the branch is only
+						// reachable through an injected IAppManager, which only a
+						// booted server supplies.
 						\OC_App::loadApp($appId);
 						$this->logger->debug(
 							message: "[ImportHandler] Successfully loaded Nextcloud app '{$appId}'",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -7,27 +7,6 @@
       <code><![CDATA[$container]]></code>
     </UnusedClosureParam>
   </file>
-  <file src="lib/BackgroundJob/DestructionCheckJob.php">
-    <UnusedParam>
-      <code><![CDATA[$actionDate]]></code>
-      <code><![CDATA[$classification]]></code>
-      <code><![CDATA[$listUuid]]></code>
-      <code><![CDATA[$logger]]></code>
-      <code><![CDATA[$logger]]></code>
-      <code><![CDATA[$logger]]></code>
-      <code><![CDATA[$objectCount]]></code>
-      <code><![CDATA[$subject]]></code>
-      <code><![CDATA[$title]]></code>
-      <code><![CDATA[$uuid]]></code>
-    </UnusedParam>
-  </file>
-  <file src="lib/BackgroundJob/DestructionExecutionJob.php">
-    <UnusedParam>
-      <code><![CDATA[$listUuid]]></code>
-      <code><![CDATA[$logger]]></code>
-      <code><![CDATA[$skippedCount]]></code>
-    </UnusedParam>
-  </file>
   <file src="lib/Calendar/RegisterCalendarProvider.php">
     <LessSpecificImplementedReturnType>
       <code><![CDATA[array]]></code>
@@ -162,19 +141,6 @@
     <UndefinedMethod>
       <code><![CDATA[find]]></code>
     </UndefinedMethod>
-    <UnusedParam>
-      <code><![CDATA[$boardId]]></code>
-      <code><![CDATA[$cardId]]></code>
-      <code><![CDATA[$description]]></code>
-      <code><![CDATA[$objectUuid]]></code>
-      <code><![CDATA[$stackId]]></code>
-      <code><![CDATA[$title]]></code>
-    </UnusedParam>
-  </file>
-  <file src="lib/Service/DeckLinkService.php">
-    <UnusedParam>
-      <code><![CDATA[$cardId]]></code>
-    </UnusedParam>
   </file>
   <file src="lib/Service/Edepot/Transport/SftpTransport.php">
     <UndefinedClass>


### PR DESCRIPTION
## Why

The `development` push run for #3532 went red on `PHP Quality (psalm)` and `PHP Quality (phpmd)`. Both findings are mine. psalm was green on the five commits before that merge and red on it.

Both were invisible to #3532's own checks because that PR ran psalm and phpmd per touched file rather than over the tree, and the findings only exist at tree scope.

## psalm, five errors

Four are `UnusedBaselineEntry`: twenty baselined `UnusedParam` entries across `DestructionCheckJob`, `DestructionExecutionJob`, `DeckCardService` and `DeckLinkService` that the refactor made unnecessary, because those parameters are used now. Removed from `psalm-baseline.xml`.

The fifth is `UndefinedClass` for `\OC_App::loadApp()` in `ImportHandler`. The call predates this work, but psalm never reached it: the enclosing branch was only reachable through a container lookup psalm could not type, and injecting `IAppManager` made the branch analysable. `OC_App` is a Nextcloud server internal with no OCP equivalent for `loadApp()`, and it exists whenever that branch can run. Suppressed on the method docblock with the reason, which is the pattern the repo already uses for `SecurityException` and `Transliterator`.

**`UnusedBaselineEntry` only ever appears on a full psalm run.** A per-file run cannot produce it, because psalm has to see the whole baseline used up before it can call an entry extra. That is why #3532 was green locally and red on CI.

## phpmd, one error

`SearchTrailMapper` crossed the 1000-line `ExcessiveClassLength` threshold, at 1015. It gained `clearAllLogs()` in #3532 because the admin endpoint had always called that method and it never existed, so the endpoint threw an `\Error` for an undefined method. Suppressed with that reason, the idiom 74 other classes in this repo already use, rather than adding a baseline entry.

## Verified locally

| Check | Result |
|---|---|
| `psalm --memory-limit=2G`, full tree | No errors found, exit 0 |
| `phpmd lib` both rulesets, with baseline | exit 0, no output |
| `phpcs --standard=phpcs.xml` on both touched files | exit 0 |
| `phpunit tests/Unit --no-coverage` | 19,454 tests, exit 0, peak 454 MB |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
