### PR TITLE
fix(tests): a mid-boot Nextcloud failure warns, it does not abort the suite

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -171,24 +171,29 @@ if ($skipNc === false && defined('OC_CONSOLE') === false) {
 			// Clear hooks for testing.
 			OC_Hook::clear();
 		} catch (\Throwable $e) {
-			// The root passed the installed check but base.php still failed
-			// (unreachable database, broken app, ...). There is no way back
-			// to pure-unit mode from here: `OC::$server` is a typed static
-			// that already holds a half-built container, and the previous
-			// "fall through to composer autoload only" message was a lie
-			// that cost 19 GB of RAM (see openregister_nc_root_is_installed).
-			// Stop the run and say what to do instead.
+			// The tree IS installed, so the dangerous case this guard exists for
+			// (loading a bare source tree) did not happen. base.php still failed
+			// part-way.
+			//
+			// This does NOT abort. `OC::$server` is a typed static, so a half-built
+			// container cannot be unset, and aborting was tried: it turned all six
+			// PHPUnit legs red on a suite that passes (humaniq, 2026-09-08). The
+			// runaway this guard exists for needs an autowiring lookup to reach the
+			// poisoned container, this app has none in lib, and phpunit.xml's 2G cap
+			// bounds one anyway.
+			//
+			// So: say plainly that the container is unreliable, and let the pure unit
+			// tests run. A container-bound test failing loudly is the intended outcome.
 			fwrite(
 				STDERR,
 				sprintf(
-					"[openregister/tests/bootstrap] NC root at %s could not be initialised (%s).\n"
-					. "  A half-booted server cannot be undone, so the run stops here rather than pretending to be pure-unit.\n"
-					. "  Fix the instance, point OPENREGISTER_TEST_NC_ROOT elsewhere, or set OPENREGISTER_TEST_SKIP_NC=1 for pure-unit mode.\n",
+					"[openregister/tests/bootstrap] Nextcloud at %s could not finish booting (%s).\n"
+					. "  \\OC::\$server now holds a HALF-BUILT container and cannot be unset. Pure unit tests\n"
+					. "  continue; anything resolving a service from that container is UNVERIFIED by this run.\n",
 					$ncRoot,
 					$e->getMessage()
 				)
 			);
-			exit(1);
 		}
 	} else {
 		// No NC root in scope — pure unit tests still work via the


### PR DESCRIPTION
## What broke

Earlier today every fleet app got a test-bootstrap guard that loads `lib/base.php` only when `config/config.php` declares `installed => true`. That part is right and stays; it closes the case where loading a bare source tree left a half-built container behind and one test ate 19 GB of RAM. The same change also made the bootstrap `exit(1)` when the tree IS installed and `base.php` throws part-way, and humaniq proved that wrong: on CI its Nextcloud is installed, `base.php` dies on a Doctrine constant the app's vendor and the server's disagree about, and all six PHPUnit legs went red on a suite that is green (fixed in humaniq PR #392).

## Why aborting was the wrong trade

Reaching a half-built container needs an autowiring lookup. This app has none left in `lib` after the container refactor, a phpcs sniff enforces that, and `phpunit.xml` caps memory at 2G, which bounds a runaway even if one appeared. Against that, aborting turns a suite that passes into six red legs. So a mid-boot failure should be loud, not fatal.

## What it does now

The mid-boot `catch` writes a warning to STDERR saying plainly that `\OC::$server` holds a half-built container that cannot be unset, that pure unit tests continue, and that anything resolving a service from that container is unverified by the run. Then it continues. A container-bound test failing loudly is the intended outcome.

## Verification

| check | result |
| --- | --- |
| `php -l tests/bootstrap.php` | exit 0 |
| `phpunit -c phpunit.xml --no-coverage` (19454 tests) | exit 1, 1 failure: `FlowNodeRegistryTest::testAStepThatOverrunsItsCeilingIsStopped`, peak RSS 445 MB |
| that same test alone, on a stashed tree | exit 0 |
| that same test alone, on the patched tree | exit 0 |
| fixture, installed tree whose `base.php` throws | warning printed, bootstrap continued, exit 0 |
| fixture, empty `config.php` | `base.php` never loaded, exit 0 |

The one failure is a wall-clock ceiling assertion that passes in isolation on both trees; the box was under load during the full run. It is not related to this change: locally the bootstrap takes the "no Nextcloud root in scope" branch, which this PR does not touch, so the patched and unpatched runs behave identically.

## Not in this PR

The "not installed" and "no root at all" refusals are unchanged; they are the whole point of the guard and still `exit(1)`. No `lib` code changes, so psalm, phpmd, phpstan and `check:strict` were not run.
