### PR TITLE
fix(tests): load the PHPCS token constants the sniff test depends on

### DIFF
--- a/tests/Unit/CustomSniffs/NoLegacyServerAccessorsSniffTest.php
+++ b/tests/Unit/CustomSniffs/NoLegacyServerAccessorsSniffTest.php
@@ -28,6 +28,19 @@ use PHPUnit\Framework\TestCase;
 // PHPCS has its own autoloader (not exposed via composer's classmap).
 require_once __DIR__ . '/../../../vendor/squizlabs/php_codesniffer/autoload.php';
 
+// PHPCS's T_* token constants, T_ANON_CLASS among them, are defined by
+// top-level define() calls at the bottom of Util/Tokens.php. Nothing here
+// referenced the Tokens class, so on a run where no earlier code happened to
+// autoload it those constants did not exist, and constructing a Ruleset with
+// the Generic standard fataled in ConstructorNameSniff with
+// `Undefined constant "PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\T_ANON_CLASS"`
+// (PHP falling back to a namespace-relative lookup for a missing global).
+//
+// That is environment-dependent, not version-dependent: the failure appeared on
+// CI at exactly the PHPCS version this passes on locally, 3.13.6. Requiring the
+// file makes the constants unconditional instead of incidental.
+require_once __DIR__ . '/../../../vendor/squizlabs/php_codesniffer/src/Util/Tokens.php';
+
 // PHPCS runtime expects these constants to be defined (normally set by its CLI entry point).
 if (defined('PHP_CODESNIFFER_VERBOSITY') === false) {
 	define('PHP_CODESNIFFER_VERBOSITY', 0);


### PR DESCRIPTION
## What broke

All six PHPUnit legs went red on `development` with seven errors, every one the same:

```
Undefined constant "PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\T_ANON_CLASS"
  at ConstructorNameSniff.php:4
  from NoLegacyServerAccessorsSniffTest.php:70   (new Ruleset(...))
```

I revived this test earlier today, in #3532, after reading the local phpcs version and judging its skip stale. That judgement was wrong, and not in the way the old comment suggested.

## Why the old explanation and mine were both wrong

The skip blamed a PHP_CodeSniffer 3.9 bug and said to re-enable at 3.10 or later. Both this machine and CI run **3.13.6**, so the version was never the difference and the test would have been just as broken at 3.9 for a different reason.

The real cause: PHPCS defines its `T_*` token constants with top-level `define()` calls at the bottom of `src/Util/Tokens.php`. Nothing in this test referenced the `Tokens` class, so those constants existed only when some earlier code in the same PHPUnit process happened to autoload that file. Locally something did. On CI nothing did, and PHP fell back to a namespace-relative lookup for the missing global, which is why the message names a constant inside the `Generic\Sniffs\NamingConventions` namespace.

That makes it environment-dependent, not version-dependent, which is exactly why running the test locally could not catch it.

## The fix

Require `src/Util/Tokens.php` alongside the PHPCS autoloader, so the constants are unconditional instead of incidental.

## Verified by mechanism, not by a passing run

A passing local run proves nothing here, since it passed locally before the fix too. So the check is the condition itself:

```
require autoload.php only            ->  defined('T_ANON_CLASS') === false   (CI's condition)
require autoload.php + Util/Tokens   ->  defined('T_ANON_CLASS') === true
```

| Check | Result |
|---|---|
| `tests/Unit/CustomSniffs` | 7 tests, exit 0 |
| full `tests/Unit` | 19,454 tests, exit 0, peak 454 MB |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
