### PR TITLE
fix(audit): the total on an object's audit trail counts the filtered list

### DIFF
--- a/lib/Controller/AuditTrailController.php
+++ b/lib/Controller/AuditTrailController.php
@@ -454,8 +454,15 @@ class AuditTrailController extends Controller {
 				config: $params
 			);
 
-			// Get total count for pagination.
-			$total = $this->logService->count(register: $register, schema: $schema, id: $id);
+			// Get total count for pagination — under the SAME parameters the
+			// page above was fetched with, so `total` and `pages` describe the
+			// list the caller is actually paging through.
+			$total = $this->logService->count(
+				register: $register,
+				schema: $schema,
+				id: $id,
+				config: $params
+			);
 
 			// Return paginated results.
 			return new JSONResponse(

--- a/lib/Service/LogService.php
+++ b/lib/Service/LogService.php
@@ -193,9 +193,18 @@ class LogService {
 	 * Counts total number of audit trail entries for a specific object.
 	 * Validates that the object belongs to the specified register and schema.
 	 *
+	 * The count answers the SAME question the matching getLogs() call asks. A
+	 * count taken without the caller's filters is a count of a different
+	 * result set, and a caller paging on it walks off the end of a list that
+	 * ended pages ago: `?action=update` on an object with 1733 rows returned 7
+	 * of them and reported a total of 1733, which is 87 pages of nothing.
+	 *
 	 * @param string $register The register identifier (slug or ID)
 	 * @param string $schema The schema identifier (slug or ID)
 	 * @param string $id The object ID to count logs for
+	 * @param array $config Configuration array containing:
+	 *                      - filters: (array) The same filters passed to getLogs()
+	 *                      - search: (string|null) The same search term passed to getLogs()
 	 *
 	 * @return int Number of log entries (0 or positive integer)
 	 *
@@ -206,7 +215,7 @@ class LogService {
 	 *
 	 * @spec openspec/changes/retrofit-2026-05-25-bw2-svc-flat-2/tasks.md#task-4
 	 */
-	public function count(string $register, string $schema, string $id): int {
+	public function count(string $register, string $schema, string $id, array $config = []): int {
 		// Step 1: Get the object to ensure it exists.
 		// Include deleted objects so audit trail count is accessible even after soft-delete.
 		// Use findAcrossAllSources to search across all magic tables.
@@ -235,10 +244,15 @@ class LogService {
 			// But we still allow audit trail access for the object.
 		}
 
-		// Step 3: Get all logs for this object using UUID filter.
+		// Step 3: Get the logs this object matches, under the caller's own
+		// filters, with the UUID filter added exactly as getLogs() adds it.
 		// No pagination needed since we're only counting.
+		$filters = $config['filters'] ?? [];
+		$filters['object_uuid'] = $object->getUuid();
+
 		$logs = $this->auditTrailMapper->findAll(
-			filters: ['object_uuid' => $object->getUuid()]
+			filters: $filters,
+			search: $config['search'] ?? null
 		);
 
 		// Step 4: Return count of log entries.

--- a/tests/Unit/Service/LogServiceTest.php
+++ b/tests/Unit/Service/LogServiceTest.php
@@ -149,6 +149,52 @@ class LogServiceTest extends TestCase {
 		$this->assertSame(0, $result);
 	}
 
+	/**
+	 * A count taken without the caller's filters counts a different result set.
+	 *
+	 * The audit-trail endpoint asked for the page WITH the filters and the
+	 * total WITHOUT them, so `?action=update` on an object holding 1733 rows
+	 * returned 7 of them and reported a total of 1733 — 87 pages of nothing for
+	 * anything that pages on the number.
+	 */
+	public function testCountCountsUnderTheCallersFilters(): void {
+		$object = $this->createObjectEntity(42, '1', '2');
+		$object->setUuid('uuid-42');
+		$register = $this->createRegister(1);
+		$schema = $this->createSchema(2);
+
+		$this->objectEntityMapper->method('findAcrossAllSources')->willReturn(['object' => $object]);
+		$this->registerMapper->method('find')->willReturn($register);
+		$this->schemaMapper->method('find')->willReturn($schema);
+
+		$seenFilters = null;
+		$seenSearch = 'not-called';
+		$this->auditTrailMapper->expects($this->once())
+			->method('findAll')
+			->willReturnCallback(
+				function ($limit = null, $offset = null, $filters = [], $sort = null, $search = null) use (&$seenFilters, &$seenSearch) {
+					$seenFilters = $filters;
+					$seenSearch = $search;
+					return ['a', 'b'];
+				}
+			);
+
+		$result = $this->service->count(
+			'1',
+			'2',
+			'42',
+			['filters' => ['action' => 'update'], 'search' => 'needle']
+		);
+
+		$this->assertSame(2, $result);
+		$this->assertSame(
+			['action' => 'update', 'object_uuid' => 'uuid-42'],
+			$seenFilters,
+			'the count must narrow by the same filters the page was fetched with'
+		);
+		$this->assertSame('needle', $seenSearch);
+	}
+
 	public function testGetAllLogsWithDefaults(): void {
 		$this->auditTrailMapper->expects($this->once())
 			->method('findAll')


### PR DESCRIPTION
An object's audit trail returned a page fetched under the caller's filters and a total counted without them, so the two numbers described different result sets.

Measured on a running instance, on a case holding 1733 audit rows:

| request | rows returned | `total` | `pages` |
| --- | --- | --- | --- |
| `…/audit-trails` | 20 | 1733 | 87 |
| `…/audit-trails?action=update` | 7 | 1733 | 87 |

Seven rows, reported as eighty-seven pages. Anything that pages on `total` walks through eighty-six empty ones, and `CnAuditTrailTab` — which decides whether to show Load more by comparing the rows it holds against `total` — offers the button forever on a filtered trail that has nothing more to load.

`LogService::count()` now takes the same `$config` array `getLogs()` takes, and adds the object UUID filter in exactly the place `getLogs()` adds it, so the two cannot narrow differently. The parameter is optional and defaults to the old behaviour, so nothing changes for a caller that does not pass filters. `search` is carried across for the same reason.

**Watched failing before fixing.** With the service reverted and the test kept, `testCountCountsUnderTheCallersFilters` reddens on "the count must narrow by the same filters the page was fetched with" and prints the filters the mapper was actually handed, `action` absent. Restored from a byte copy and diffed; the full `LogServiceTest` is 17 green, `AuditTrailControllerTest` 47, and phpcs, psalm and lint are clean on both changed files.

Found while clearing dossiq's e2e base failures: the case History tab is the caller this misleads.
