### PR TITLE
fix(fleet): resolve connector and credential app ids across the rename

### DIFF
--- a/lib/AppHost/Scheduling/ScheduleActionAllowList.php
+++ b/lib/AppHost/Scheduling/ScheduleActionAllowList.php
@@ -29,6 +29,9 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\AppHost\Scheduling;
 
+use OCA\OpenRegister\Support\FleetAppId;
+use OCP\App\IAppManager;
+
 /**
  * Closed allow-list mapping action types to vetted job classes.
  *
@@ -36,17 +39,46 @@ namespace OCA\OpenRegister\AppHost\Scheduling;
  */
 class ScheduleActionAllowList {
 	/**
-	 * The closed action-type → vetted `jobClass` map.
+	 * The closed action-type → vetted job class map.
 	 *
-	 * Kept as plain strings so referencing this map never autoloads the
-	 * cross-app job class (it is resolved lazily by OpenConnector's JobService
-	 * container at execution time, not by OpenRegister).
+	 * The KEY is manifest data: leaf apps write `action: 'openconnector:…'`
+	 * into their own `src/manifest.json`, so it is a published contract and
+	 * stays spelled as it is — renaming it would silently un-allow-list every
+	 * schedule already declared against it.
+	 *
+	 * The VALUE is a class path RELATIVE to the connector's namespace, because
+	 * that half did move: the class is `OCA\Integriq\Action\…` on
+	 * development and `OCA\OpenConnector\Action\…` on beta/main. It stays a
+	 * plain string so referencing this map never autoloads the cross-app class
+	 * (it is resolved lazily by the connector's JobService container at
+	 * execution time, not by OpenRegister) — which is why the namespace is
+	 * picked from the INSTALLED APP ID rather than by probing `class_exists`.
 	 *
 	 * @var array<string, string>
 	 */
 	private const MAP = [
-		'openconnector:synchronization' => 'OCA\\OpenConnector\\Action\\SynchronizationAction',
+		'openconnector:synchronization' => 'Action\\SynchronizationAction',
 	];
+
+	/**
+	 * Canonical (new) id of the connector app, for {@see FleetAppId}.
+	 *
+	 * @var string
+	 */
+	private const CONNECTOR_APP = 'integriq';
+
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IAppManager $appManager Resolves which connector id is installed.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		private readonly IAppManager $appManager,
+	) {
+	}//end __construct()
 
 	/**
 	 * Resolve an action type to its vetted `jobClass`, or null when not allow-listed.
@@ -58,7 +90,12 @@ class ScheduleActionAllowList {
 	 * @spec openspec/changes/apphost-manifest-schedules/specs/apphost-scheduling/spec.md
 	 */
 	public function resolve(string $action): ?string {
-		return self::MAP[$action] ?? null;
+		$relativeClass = (self::MAP[$action] ?? null);
+		if ($relativeClass === null) {
+			return null;
+		}
+
+		return FleetAppId::className($this->appManager, self::CONNECTOR_APP, $relativeClass);
 	}//end resolve()
 
 	/**

--- a/lib/Repair/RegisterOpenRegisterWithDoriath.php
+++ b/lib/Repair/RegisterOpenRegisterWithDoriath.php
@@ -41,6 +41,7 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Repair;
 
 use OCA\OpenRegister\Service\Credential\DoriathCredentialStore;
+use OCA\OpenRegister\Support\FleetAppId;
 use OCP\App\IAppManager;
 use OCP\IAppConfig;
 use OCP\Migration\IOutput;
@@ -61,11 +62,25 @@ use Throwable;
  */
 class RegisterOpenRegisterWithDoriath implements IRepairStep {
 	/**
-	 * FQCN of Doriath's application service (registration seam).
+	 * The application service (registration seam), RELATIVE to the app namespace.
+	 *
+	 * Relative rather than fully qualified: the credential app is `OCA\Keepiq`
+	 * on development and `OCA\Doriath` on beta/main, so {@see FleetAppId}
+	 * prepends whichever namespace is actually loadable.
 	 *
 	 * @var string
 	 */
-	private const APPLICATION_SERVICE = 'OCA\\Doriath\\Service\\ApplicationService';
+	private const APPLICATION_SERVICE = 'Service\\ApplicationService';
+
+	/**
+	 * Canonical (new) id of the credential app, for {@see FleetAppId}.
+	 *
+	 * The resolver holds the candidate list `['keepiq', 'doriath']`, so this
+	 * names the app rather than a spelling of it and both deployments resolve.
+	 *
+	 * @var string
+	 */
+	private const CREDENTIAL_APP = 'keepiq';
 
 	/**
 	 * RSA modulus size for the generated keypair (Doriath requires >= 4096).
@@ -154,7 +169,11 @@ class RegisterOpenRegisterWithDoriath implements IRepairStep {
 	 * @spec openspec/specs/credential-broker/spec.md
 	 */
 	private function isDoriathAvailable(): bool {
-		if ($this->appManager->isEnabledForUser('doriath') === false) {
+		// The credential app answers to `keepiq` on development and `doriath`
+		// on beta/main. `isEnabledForUser('doriath')` on a keepiq instance
+		// returns FALSE rather than erroring, so this gate silently reported
+		// "no credential app" on every migrated instance.
+		if (FleetAppId::isEnabledForUser($this->appManager, self::CREDENTIAL_APP) === false) {
 			return false;
 		}
 
@@ -326,12 +345,17 @@ class RegisterOpenRegisterWithDoriath implements IRepairStep {
 	 * @spec openspec/specs/credential-broker/spec.md
 	 */
 	protected function resolveApplicationService(): ?object {
-		if (class_exists(self::APPLICATION_SERVICE) === false) {
+		// Resolved through FleetAppId: the class is OCA\Keepiq\Service\* on
+		// development and OCA\Doriath\Service\* on beta/main, with no
+		// compatibility alias between them. `class_exists` on the wrong
+		// spelling is FALSE, which is indistinguishable from "app absent".
+		$className = FleetAppId::resolveClass(self::CREDENTIAL_APP, self::APPLICATION_SERVICE);
+		if ($className === null) {
 			return null;
 		}
 
 		try {
-			return Server::get(self::APPLICATION_SERVICE);
+			return Server::get($className);
 		} catch (Throwable $e) {
 			$this->logger->warning(
 				'[RegisterOpenRegisterWithDoriath] failed to resolve Doriath ApplicationService',

--- a/lib/Service/ConfigurationService.php
+++ b/lib/Service/ConfigurationService.php
@@ -44,6 +44,7 @@ use OCA\OpenRegister\Service\Configuration\GitLabHandler;
 use OCA\OpenRegister\Service\Configuration\ImportHandler;
 use OCA\OpenRegister\Service\Configuration\PreviewHandler;
 use OCA\OpenRegister\Service\Configuration\UploadHandler;
+use OCA\OpenRegister\Support\FleetAppId;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
@@ -302,19 +303,29 @@ class ConfigurationService {
 	 * @spec exclude Facade plumbing: peer-app presence probe (installed-apps check + container resolve), no standalone behavioral contract.
 	 */
 	public function hasOpenConnector(): bool {
-		if (in_array(needle: 'openconnector', haystack: $this->appManager->getInstalledApps()) === true) {
-			try {
-				// Attempt to get the OpenConnector service from the container.
-				$serviceName = 'OCA\OpenConnector\Service\ConfigurationService';
-				$this->openConnectorConfigurationService = $this->container->get($serviceName);
-				return true;
-			} catch (Exception $e) {
-				// If the service is not available, return false.
-				return false;
-			}
+		// Both halves resolve through FleetAppId: the app is `integriq` with
+		// namespace OCA\Integriq on development and `openconnector` with
+		// OCA\OpenConnector on beta/main. A membership test against the id an
+		// instance does not carry is simply false, and `$container->get()` on
+		// the wrong FQCN throws into the catch below — so a stale name here
+		// reported "no connector" instead of failing, and the connector half
+		// of every configuration export was quietly dropped.
+		if (FleetAppId::isInstalled($this->appManager, 'integriq') === false) {
+			return false;
 		}
 
-		return false;
+		$serviceName = FleetAppId::resolveClass('integriq', 'Service\\ConfigurationService');
+		if ($serviceName === null) {
+			return false;
+		}
+
+		try {
+			$this->openConnectorConfigurationService = $this->container->get($serviceName);
+			return true;
+		} catch (Exception $e) {
+			// If the service is not available, return false.
+			return false;
+		}
 	}//end hasOpenConnector()
 
 	/**

--- a/lib/Service/Credential/CredentialStoreResolver.php
+++ b/lib/Service/Credential/CredentialStoreResolver.php
@@ -9,7 +9,8 @@
  * of `DeckLinkService`. Doriath is ELIGIBLE only when ALL of the following
  * hold, evaluated in order and failing closed to the Nextcloud-vault leaf:
  *
- *   1. `IAppManager::isEnabledForUser('doriath')` — the app is enabled;
+ *   1. the credential app is enabled under EITHER of its ids (`keepiq` on
+ *      development, `doriath` on beta/main — see `FleetAppId`);
  *   2. `class_exists` succeeds for every Doriath service class the leaf calls
  *      (no compile-time dependency on the optional app);
  *   3. `method_exists` succeeds for the application-scoped seam methods
@@ -41,6 +42,7 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Service\Credential;
 
+use OCA\OpenRegister\Support\FleetAppId;
 use OCP\App\IAppManager;
 use OCP\IAppConfig;
 use Psr\Log\LoggerInterface;
@@ -50,11 +52,17 @@ use Psr\Log\LoggerInterface;
  */
 class CredentialStoreResolver {
 	/**
-	 * The Doriath app id probed for eligibility.
+	 * Canonical (new) id of the credential app, for {@see FleetAppId}.
+	 *
+	 * The NAMESPACE half of this rename was already handled below; the app ID
+	 * half was not, and it gates everything under it. `isEnabledForUser`
+	 * against the id an instance does not carry returns FALSE rather than
+	 * erroring, so on every migrated instance this resolver returned the vault
+	 * fallback and the namespace probing underneath it never ran at all.
 	 *
 	 * @var string
 	 */
-	public const DORIATH_APP_ID = 'doriath';
+	public const CREDENTIAL_APP = 'keepiq';
 
 	/**
 	 * Credential-app namespaces to probe, NEWEST FIRST.
@@ -153,7 +161,7 @@ class CredentialStoreResolver {
 	 * @spec openspec/specs/credential-broker/spec.md
 	 */
 	public function isDoriathEligible(): bool {
-		if ($this->appManager->isEnabledForUser(self::DORIATH_APP_ID) === false) {
+		if (FleetAppId::isEnabledForUser($this->appManager, self::CREDENTIAL_APP) === false) {
 			return false;
 		}
 

--- a/lib/Service/Credential/DoriathApplicationRegistrar.php
+++ b/lib/Service/Credential/DoriathApplicationRegistrar.php
@@ -42,6 +42,7 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Service\Credential;
 
+use OCA\OpenRegister\Support\FleetAppId;
 use OCP\App\IAppManager;
 use OCP\IAppConfig;
 use OCP\Server;
@@ -59,11 +60,25 @@ use Throwable;
  */
 class DoriathApplicationRegistrar {
 	/**
-	 * FQCN of Doriath's application service (registration seam).
+	 * The application service (registration seam), RELATIVE to the app namespace.
+	 *
+	 * Relative rather than fully qualified: the credential app is `OCA\Keepiq`
+	 * on development and `OCA\Doriath` on beta/main, so {@see FleetAppId}
+	 * prepends whichever namespace is actually loadable.
 	 *
 	 * @var string
 	 */
-	private const APPLICATION_SERVICE = 'OCA\\Doriath\\Service\\ApplicationService';
+	private const APPLICATION_SERVICE = 'Service\\ApplicationService';
+
+	/**
+	 * Canonical (new) id of the credential app, for {@see FleetAppId}.
+	 *
+	 * The resolver holds the candidate list `['keepiq', 'doriath']`, so this
+	 * names the app rather than a spelling of it and both deployments resolve.
+	 *
+	 * @var string
+	 */
+	private const CREDENTIAL_APP = 'keepiq';
 
 	/**
 	 * `IAppConfig` key prefix for a per-app Doriath application UUID.
@@ -161,7 +176,11 @@ class DoriathApplicationRegistrar {
 	 * @spec openspec/specs/credential-broker/spec.md
 	 */
 	private function isDoriathAvailable(): bool {
-		if ($this->appManager->isEnabledForUser('doriath') === false) {
+		// The credential app answers to `keepiq` on development and `doriath`
+		// on beta/main. `isEnabledForUser('doriath')` on a keepiq instance
+		// returns FALSE rather than erroring, so this gate silently reported
+		// "no credential app" on every migrated instance.
+		if (FleetAppId::isEnabledForUser($this->appManager, self::CREDENTIAL_APP) === false) {
 			return false;
 		}
 
@@ -260,13 +279,18 @@ class DoriathApplicationRegistrar {
 	 * @spec openspec/specs/credential-broker/spec.md
 	 */
 	protected function resolveApplicationService(): ?object {
-		if (class_exists(self::APPLICATION_SERVICE) === false) {
+		// Resolved through FleetAppId: the class is OCA\Keepiq\Service\* on
+		// development and OCA\Doriath\Service\* on beta/main, with no
+		// compatibility alias between them. `class_exists` on the wrong
+		// spelling is FALSE, which is indistinguishable from "app absent".
+		$className = FleetAppId::resolveClass(self::CREDENTIAL_APP, self::APPLICATION_SERVICE);
+		if ($className === null) {
 			return null;
 		}
 
 		try {
 			// phpcs:ignore CustomSniffs.Nextcloud.NoServiceLocator.GlobalContainerLookup -- Optional sibling app (keepiq): guarded by class_exists and try/catch, absent on most instances, so it cannot be a constructor dependency.
-			return Server::get(self::APPLICATION_SERVICE);
+			return Server::get($className);
 		} catch (Throwable $e) {
 			$this->logger->warning(
 				'[DoriathApplicationRegistrar] failed to resolve Doriath ApplicationService',

--- a/lib/Service/Credential/DoriathCredentialStore.php
+++ b/lib/Service/Credential/DoriathCredentialStore.php
@@ -52,6 +52,7 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Service\Credential;
 
+use OCA\OpenRegister\Support\FleetAppId;
 use OCP\IAppConfig;
 use OCP\IUserSession;
 use OCP\Security\ICredentialsManager;
@@ -97,25 +98,36 @@ class DoriathCredentialStore implements CredentialStore {
 	public const PRIVATE_KEY_ID = 'openregister/doriath/private-key';
 
 	/**
-	 * FQCN of Doriath's stateless encrypt service (scheme `rsa-oaep-sha256-chunked-v1`).
+	 * Stateless encrypt service (scheme `rsa-oaep-sha256-chunked-v1`), RELATIVE.
+	 *
+	 * Relative rather than fully qualified: the credential app is `OCA\Keepiq`
+	 * on development and `OCA\Doriath` on beta/main, with no compatibility
+	 * alias, so {@see FleetAppId} prepends whichever one actually loads.
 	 *
 	 * @var string
 	 */
-	private const ENCRYPT_SERVICE = 'OCA\\Doriath\\Service\\EncryptService';
+	private const ENCRYPT_SERVICE = 'Service\\EncryptService';
 
 	/**
-	 * FQCN of Doriath's stateless decrypt service.
+	 * Stateless decrypt service, RELATIVE to the credential app's namespace.
 	 *
 	 * @var string
 	 */
-	private const DECRYPT_SERVICE = 'OCA\\Doriath\\Service\\DecryptService';
+	private const DECRYPT_SERVICE = 'Service\\DecryptService';
 
 	/**
-	 * FQCN of Doriath's secret service (application-scoped seam).
+	 * Secret service (application-scoped seam), RELATIVE to the app namespace.
 	 *
 	 * @var string
 	 */
-	private const SECRET_SERVICE = 'OCA\\Doriath\\Service\\SecretService';
+	private const SECRET_SERVICE = 'Service\\SecretService';
+
+	/**
+	 * Canonical (new) id of the credential app, for {@see FleetAppId}.
+	 *
+	 * @var string
+	 */
+	private const CREDENTIAL_APP = 'keepiq';
 
 	/**
 	 * Constructor.
@@ -172,12 +184,12 @@ class DoriathCredentialStore implements CredentialStore {
 			throw new RuntimeException('Credential store is not provisioned');
 		}
 
-		$encryptService = $this->requireDoriathService(className: self::ENCRYPT_SERVICE);
+		$encryptService = $this->requireDoriathService(relativeClass: self::ENCRYPT_SERVICE);
 		$ciphertext = (string)$encryptService->rsaEncrypt($secret, $publicPem);
 
 		$row = $this->lookupRow(uuid: $uuid, applicationId: $applicationId);
 
-		$secretService = $this->requireDoriathService(className: self::SECRET_SERVICE);
+		$secretService = $this->requireDoriathService(relativeClass: self::SECRET_SERVICE);
 		if ($row === null) {
 			$secretService->createByApplication(['name' => $uuid, 'key' => $ciphertext], $applicationId);
 			return;
@@ -263,7 +275,7 @@ class DoriathCredentialStore implements CredentialStore {
 			return;
 		}
 
-		$secretService = $this->requireDoriathService(className: self::SECRET_SERVICE);
+		$secretService = $this->requireDoriathService(relativeClass: self::SECRET_SERVICE);
 
 		$row = $this->lookupRow(uuid: $uuid, applicationId: $applicationId);
 		if ($row === null) {
@@ -294,7 +306,7 @@ class DoriathCredentialStore implements CredentialStore {
 		}
 
 		try {
-			$decryptService = $this->requireDoriathService(className: self::DECRYPT_SERVICE);
+			$decryptService = $this->requireDoriathService(relativeClass: self::DECRYPT_SERVICE);
 			return (string)$decryptService->rsaDecrypt((string)$row->getKey(), $privatePem);
 		} catch (Throwable $e) {
 			$this->logger->warning(
@@ -370,7 +382,7 @@ class DoriathCredentialStore implements CredentialStore {
 	 * @spec openspec/specs/credential-broker/spec.md
 	 */
 	private function lookupRow(string $uuid, string $applicationId): ?object {
-		$secretService = $this->requireDoriathService(className: self::SECRET_SERVICE);
+		$secretService = $this->requireDoriathService(relativeClass: self::SECRET_SERVICE);
 
 		$row = $secretService->getByNameForApplication($uuid, $applicationId);
 		if (is_object($row) === false) {
@@ -410,20 +422,26 @@ class DoriathCredentialStore implements CredentialStore {
 	}//end requireApplicationId()
 
 	/**
-	 * Resolve a Doriath service by FQCN, or null when unavailable.
+	 * Resolve a credential-app service by RELATIVE class name, or null.
 	 *
 	 * `class_exists` + `OCP\Server::get` (Deck-leaf / AnonymisationBackendService
-	 * idiom) so OR carries no compile-time dependency on Doriath. Protected so
-	 * unit tests can substitute contract fakes without the Doriath app present.
+	 * idiom) so OR carries no compile-time dependency on the credential app.
+	 * Protected so unit tests can substitute contract fakes without it present.
 	 *
-	 * @param string $className The Doriath service FQCN.
+	 * Takes the RELATIVE name and lets {@see FleetAppId} pick the namespace:
+	 * the app is `OCA\Keepiq` on development and `OCA\Doriath` on beta/main,
+	 * and `class_exists` on the spelling the instance does not have is FALSE —
+	 * which this method cannot tell apart from "the optional app is absent".
+	 *
+	 * @param string $relativeClass The service class below the app namespace.
 	 *
 	 * @return object|null The resolved service, or null when unavailable.
 	 *
 	 * @spec openspec/specs/credential-broker/spec.md
 	 */
-	protected function resolveDoriathService(string $className): ?object {
-		if (class_exists($className) === false) {
+	protected function resolveDoriathService(string $relativeClass): ?object {
+		$className = FleetAppId::resolveClass(self::CREDENTIAL_APP, $relativeClass);
+		if ($className === null) {
 			return null;
 		}
 
@@ -440,9 +458,9 @@ class DoriathCredentialStore implements CredentialStore {
 	}//end resolveDoriathService()
 
 	/**
-	 * Resolve a Doriath service by FQCN, throwing when unavailable.
+	 * Resolve a credential-app service by RELATIVE name, throwing when absent.
 	 *
-	 * @param string $className The Doriath service FQCN.
+	 * @param string $relativeClass The service class below the app namespace.
 	 *
 	 * @return object The resolved service.
 	 *
@@ -450,8 +468,8 @@ class DoriathCredentialStore implements CredentialStore {
 	 *
 	 * @spec openspec/specs/credential-broker/spec.md
 	 */
-	private function requireDoriathService(string $className): object {
-		$service = $this->resolveDoriathService(className: $className);
+	private function requireDoriathService(string $relativeClass): object {
+		$service = $this->resolveDoriathService(relativeClass: $relativeClass);
 		if ($service === null) {
 			throw new RuntimeException('Credential store backend unavailable');
 		}

--- a/lib/Service/Geo/PdokGeocoder.php
+++ b/lib/Service/Geo/PdokGeocoder.php
@@ -271,7 +271,18 @@ class PdokGeocoder {
 		}
 
 		try {
-			$callService = $this->container->get('OCA\\OpenConnector\\Service\\CallService');
+			// The class is OCA\Integriq\Service\CallService on development and
+			// OCA\OpenConnector\Service\CallService on beta/main. `get()` on
+			// the wrong one throws straight into the catch below, which logs a
+			// warning and returns null — the same shape as "upstream had no
+			// match", so the stale name read as an empty geocoding result.
+			$serviceName = FleetAppId::resolveClass('integriq', 'Service\\CallService');
+			if ($serviceName === null) {
+				$this->logger->info('PDOK geocoding skipped: OpenConnector CallService not loadable');
+				return null;
+			}
+
+			$callService = $this->container->get($serviceName);
 			$response = $callService->call(null, $url, 'GET', ['query' => $params]);
 			return $this->decode(response: $response);
 		} catch (Throwable $e) {

--- a/lib/Service/Integration/ExternalIntegrationRouter.php
+++ b/lib/Service/Integration/ExternalIntegrationRouter.php
@@ -384,6 +384,16 @@ class ExternalIntegrationRouter {
 	 */
 	private function loadSource(string $sourceId, string $providerId) {
 		try {
+			// NOT repointed to OCA\Integriq\Db\SourceMapper: that class does
+			// not exist. The connector REMOVED SourceMapper — its own
+			// SynchronizationService now reimplements
+			// `SourceMapper::findOrCreateByLocation()` over object storage and
+			// its tests record that "OR removed that class". Renaming the
+			// namespace here would swap a lookup that misses for one that
+			// misses identically, while looking fixed. The `get()` throws into
+			// the catch below, which raises `openconnector-source-missing` and
+			// the UI shows "Reconfigure connector" — so this one at least
+			// fails visibly. It needs a real replacement seam, not a rename.
 			$mapper = $this->container->get('OCA\\OpenConnector\\Db\\SourceMapper');
 			$source = null;
 
@@ -542,6 +552,21 @@ class ExternalIntegrationRouter {
 	}//end mockMeta()
 
 	/**
+	 * The connector's CallService FQCN for the id this instance actually has.
+	 *
+	 * The class is OCA\Integriq\Service\CallService on development and
+	 * OCA\OpenConnector\Service\CallService on beta/main. Falls back to the
+	 * canonical spelling when neither loads, so the `get()` below still throws
+	 * into the caller's catch exactly as it does today.
+	 *
+	 * @return string The FQCN to resolve from the container.
+	 */
+	private function callServiceClass(): string {
+		return (FleetAppId::resolveClass('integriq', 'Service\\CallService')
+			?? 'OCA\\Integriq\\Service\\CallService');
+	}//end callServiceClass()
+
+	/**
 	 * Invoke the upstream call via OpenConnector's CallService.
 	 *
 	 * The CallService API has varied across OpenConnector versions;
@@ -559,7 +584,7 @@ class ExternalIntegrationRouter {
 	 *                           caller wraps this as ProviderUnavailableException.
 	 */
 	private function invoke($source, string $method, string $path, array $options): array {
-		$callService = $this->container->get('OCA\\OpenConnector\\Service\\CallService');
+		$callService = $this->container->get($this->callServiceClass());
 
 		if (method_exists($callService, 'call') === true) {
 			$response = $callService->call($source, $path, $method, $options);
@@ -574,7 +599,7 @@ class ExternalIntegrationRouter {
 		}
 
 		throw new RuntimeException(
-			'OpenConnector\\Service\\CallService does not expose a known call/request method.'
+			'The connector CallService does not expose a known call/request method.'
 		);
 	}//end invoke()
 
@@ -594,7 +619,7 @@ class ExternalIntegrationRouter {
 	 *                           wraps this as ProviderUnavailableException.
 	 */
 	private function invokeWithMeta($source, string $method, string $path, array $options): array {
-		$callService = $this->container->get('OCA\\OpenConnector\\Service\\CallService');
+		$callService = $this->container->get($this->callServiceClass());
 
 		if (method_exists($callService, 'call') === true) {
 			$response = $callService->call($source, $path, $method, $options);
@@ -615,7 +640,7 @@ class ExternalIntegrationRouter {
 		}
 
 		throw new RuntimeException(
-			'OCA\\OpenConnector\\Service\\CallService does not expose a known call/request method.'
+			'The connector CallService does not expose a known call/request method.'
 		);
 	}//end invokeWithMeta()
 

--- a/lib/Service/Integration/Providers/BrpPersonProvider.php
+++ b/lib/Service/Integration/Providers/BrpPersonProvider.php
@@ -62,6 +62,7 @@ namespace OCA\OpenRegister\Service\Integration\Providers;
 use OCA\OpenRegister\Exception\ProviderUnavailableException;
 use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
 use OCA\OpenRegister\Service\Integration\ExternalIntegrationRouter;
+use OCA\OpenRegister\Support\FleetAppId;
 use OCP\App\IAppManager;
 use OCP\IL10N;
 use Psr\Log\LoggerInterface;
@@ -91,7 +92,11 @@ class BrpPersonProvider extends AbstractIntegrationProvider {
 	 *
 	 * @var string
 	 */
-	private const REQUIRED_APP = 'openconnector';
+	// The connector answers to `integriq` on development and `openconnector`
+	// on beta/main; FleetAppId holds both spellings, so this names the app
+	// rather than one spelling of it. Never compare it to an id directly —
+	// go through FleetAppId, or the comparison is false on half the fleet.
+	private const REQUIRED_APP = 'integriq';
 
 	/**
 	 * Default field set requested from HaalCentraal. The BRP API requires an
@@ -178,7 +183,11 @@ class BrpPersonProvider extends AbstractIntegrationProvider {
 	 * @return string|null
 	 */
 	public function getRequiredApp(): ?string {
-		return self::REQUIRED_APP;
+		// The id the instance ACTUALLY registered. This value is published
+		// verbatim in the `integrations` capability and consumed client-side
+		// as `isAppInstalled(requiredApp)`, so returning the canonical name
+		// against a beta/main instance would report the connector missing.
+		return (FleetAppId::resolve($this->appManager, self::REQUIRED_APP) ?? self::REQUIRED_APP);
 	}//end getRequiredApp()
 
 	/**
@@ -209,7 +218,7 @@ class BrpPersonProvider extends AbstractIntegrationProvider {
 	 * @return bool
 	 */
 	public function isEnabled(): bool {
-		return $this->appManager->isInstalled(self::REQUIRED_APP);
+		return FleetAppId::isInstalled($this->appManager, self::REQUIRED_APP);
 	}//end isEnabled()
 
 	/**

--- a/lib/Service/Integration/Providers/BrpPersonProvider.php
+++ b/lib/Service/Integration/Providers/BrpPersonProvider.php
@@ -180,13 +180,15 @@ class BrpPersonProvider extends AbstractIntegrationProvider {
 	 * function — OpenConnector carries the `brp-haalcentraal` source +
 	 * OAuth credentials + PKIoverheid client certificate.
 	 *
+	 * Returns the id the instance ACTUALLY registered, not the canonical name.
+	 * The value is published verbatim in the `integrations` capability and
+	 * read back client-side as `isAppInstalled(requiredApp)`, so a spelling the
+	 * instance does not answer to renders "not installed" over a connector that
+	 * is installed and working.
+	 *
 	 * @return string|null
 	 */
 	public function getRequiredApp(): ?string {
-		// The id the instance ACTUALLY registered. This value is published
-		// verbatim in the `integrations` capability and consumed client-side
-		// as `isAppInstalled(requiredApp)`, so returning the canonical name
-		// against a beta/main instance would report the connector missing.
 		return (FleetAppId::resolve($this->appManager, self::REQUIRED_APP) ?? self::REQUIRED_APP);
 	}//end getRequiredApp()
 

--- a/lib/Service/Integration/Providers/KvkProvider.php
+++ b/lib/Service/Integration/Providers/KvkProvider.php
@@ -142,13 +142,15 @@ class KvkProvider extends AbstractIntegrationProvider {
 	 * Nextcloud app that must be installed for this integration to
 	 * function — OpenConnector carries the `kvk` source + credentials.
 	 *
+	 * Returns the id the instance ACTUALLY registered, not the canonical name.
+	 * The value is published verbatim in the `integrations` capability and
+	 * read back client-side as `isAppInstalled(requiredApp)`, so a spelling the
+	 * instance does not answer to renders "not installed" over a connector that
+	 * is installed and working.
+	 *
 	 * @return string|null
 	 */
 	public function getRequiredApp(): ?string {
-		// The id the instance ACTUALLY registered. This value is published
-		// verbatim in the `integrations` capability and consumed client-side
-		// as `isAppInstalled(requiredApp)`, so returning the canonical name
-		// against a beta/main instance would report the connector missing.
 		return (FleetAppId::resolve($this->appManager, self::REQUIRED_APP) ?? self::REQUIRED_APP);
 	}//end getRequiredApp()
 

--- a/lib/Service/Integration/Providers/KvkProvider.php
+++ b/lib/Service/Integration/Providers/KvkProvider.php
@@ -49,6 +49,7 @@ namespace OCA\OpenRegister\Service\Integration\Providers;
 use OCA\OpenRegister\Exception\ProviderUnavailableException;
 use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
 use OCA\OpenRegister\Service\Integration\ExternalIntegrationRouter;
+use OCA\OpenRegister\Support\FleetAppId;
 use OCP\App\IAppManager;
 use OCP\IL10N;
 use Psr\Log\LoggerInterface;
@@ -77,7 +78,11 @@ class KvkProvider extends AbstractIntegrationProvider {
 	 *
 	 * @var string
 	 */
-	private const REQUIRED_APP = 'openconnector';
+	// The connector answers to `integriq` on development and `openconnector`
+	// on beta/main; FleetAppId holds both spellings, so this names the app
+	// rather than one spelling of it. Never compare it to an id directly —
+	// go through FleetAppId, or the comparison is false on half the fleet.
+	private const REQUIRED_APP = 'integriq';
 
 	/**
 	 * Constructor.
@@ -140,7 +145,11 @@ class KvkProvider extends AbstractIntegrationProvider {
 	 * @return string|null
 	 */
 	public function getRequiredApp(): ?string {
-		return self::REQUIRED_APP;
+		// The id the instance ACTUALLY registered. This value is published
+		// verbatim in the `integrations` capability and consumed client-side
+		// as `isAppInstalled(requiredApp)`, so returning the canonical name
+		// against a beta/main instance would report the connector missing.
+		return (FleetAppId::resolve($this->appManager, self::REQUIRED_APP) ?? self::REQUIRED_APP);
 	}//end getRequiredApp()
 
 	/**
@@ -170,7 +179,7 @@ class KvkProvider extends AbstractIntegrationProvider {
 	 * @return bool
 	 */
 	public function isEnabled(): bool {
-		return $this->appManager->isInstalled(self::REQUIRED_APP);
+		return FleetAppId::isInstalled($this->appManager, self::REQUIRED_APP);
 	}//end isEnabled()
 
 	/**

--- a/lib/Service/Integration/Providers/MessageDispatchProvider.php
+++ b/lib/Service/Integration/Providers/MessageDispatchProvider.php
@@ -53,6 +53,7 @@ namespace OCA\OpenRegister\Service\Integration\Providers;
 use OCA\OpenRegister\Exception\ProviderUnavailableException;
 use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
 use OCA\OpenRegister\Service\Integration\ExternalIntegrationRouter;
+use OCA\OpenRegister\Support\FleetAppId;
 use OCP\App\IAppManager;
 use OCP\IL10N;
 use Psr\Log\LoggerInterface;
@@ -84,7 +85,11 @@ class MessageDispatchProvider extends AbstractIntegrationProvider {
 	 *
 	 * @var string
 	 */
-	private const REQUIRED_APP = 'openconnector';
+	// The connector answers to `integriq` on development and `openconnector`
+	// on beta/main; FleetAppId holds both spellings, so this names the app
+	// rather than one spelling of it. Never compare it to an id directly —
+	// go through FleetAppId, or the comparison is false on half the fleet.
+	private const REQUIRED_APP = 'integriq';
 
 	/**
 	 * The fixed allow-list of seeded messaging source slugs a caller may
@@ -173,7 +178,11 @@ class MessageDispatchProvider extends AbstractIntegrationProvider {
 	 * @return string|null
 	 */
 	public function getRequiredApp(): ?string {
-		return self::REQUIRED_APP;
+		// The id the instance ACTUALLY registered. This value is published
+		// verbatim in the `integrations` capability and consumed client-side
+		// as `isAppInstalled(requiredApp)`, so returning the canonical name
+		// against a beta/main instance would report the connector missing.
+		return (FleetAppId::resolve($this->appManager, self::REQUIRED_APP) ?? self::REQUIRED_APP);
 	}//end getRequiredApp()
 
 	/**
@@ -205,7 +214,7 @@ class MessageDispatchProvider extends AbstractIntegrationProvider {
 	 * @return bool
 	 */
 	public function isEnabled(): bool {
-		return $this->appManager->isInstalled(self::REQUIRED_APP);
+		return FleetAppId::isInstalled($this->appManager, self::REQUIRED_APP);
 	}//end isEnabled()
 
 	/**

--- a/lib/Service/Integration/Providers/MessageDispatchProvider.php
+++ b/lib/Service/Integration/Providers/MessageDispatchProvider.php
@@ -175,13 +175,15 @@ class MessageDispatchProvider extends AbstractIntegrationProvider {
 	 * Nextcloud app that must be installed for this integration to function —
 	 * OpenConnector carries the messaging sources + credentials.
 	 *
+	 * Returns the id the instance ACTUALLY registered, not the canonical name.
+	 * The value is published verbatim in the `integrations` capability and
+	 * read back client-side as `isAppInstalled(requiredApp)`, so a spelling the
+	 * instance does not answer to renders "not installed" over a connector that
+	 * is installed and working.
+	 *
 	 * @return string|null
 	 */
 	public function getRequiredApp(): ?string {
-		// The id the instance ACTUALLY registered. This value is published
-		// verbatim in the `integrations` capability and consumed client-side
-		// as `isAppInstalled(requiredApp)`, so returning the canonical name
-		// against a beta/main instance would report the connector missing.
 		return (FleetAppId::resolve($this->appManager, self::REQUIRED_APP) ?? self::REQUIRED_APP);
 	}//end getRequiredApp()
 

--- a/lib/Service/Integration/Providers/OpenCorporatesProvider.php
+++ b/lib/Service/Integration/Providers/OpenCorporatesProvider.php
@@ -143,13 +143,15 @@ class OpenCorporatesProvider extends AbstractIntegrationProvider {
 	 * function — OpenConnector carries the `opencorporates` source +
 	 * credentials.
 	 *
+	 * Returns the id the instance ACTUALLY registered, not the canonical name.
+	 * The value is published verbatim in the `integrations` capability and
+	 * read back client-side as `isAppInstalled(requiredApp)`, so a spelling the
+	 * instance does not answer to renders "not installed" over a connector that
+	 * is installed and working.
+	 *
 	 * @return string|null
 	 */
 	public function getRequiredApp(): ?string {
-		// The id the instance ACTUALLY registered. This value is published
-		// verbatim in the `integrations` capability and consumed client-side
-		// as `isAppInstalled(requiredApp)`, so returning the canonical name
-		// against a beta/main instance would report the connector missing.
 		return (FleetAppId::resolve($this->appManager, self::REQUIRED_APP) ?? self::REQUIRED_APP);
 	}//end getRequiredApp()
 

--- a/lib/Service/Integration/Providers/OpenCorporatesProvider.php
+++ b/lib/Service/Integration/Providers/OpenCorporatesProvider.php
@@ -48,6 +48,7 @@ namespace OCA\OpenRegister\Service\Integration\Providers;
 use OCA\OpenRegister\Exception\ProviderUnavailableException;
 use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
 use OCA\OpenRegister\Service\Integration\ExternalIntegrationRouter;
+use OCA\OpenRegister\Support\FleetAppId;
 use OCP\App\IAppManager;
 use OCP\IL10N;
 use Psr\Log\LoggerInterface;
@@ -77,7 +78,11 @@ class OpenCorporatesProvider extends AbstractIntegrationProvider {
 	 *
 	 * @var string
 	 */
-	private const REQUIRED_APP = 'openconnector';
+	// The connector answers to `integriq` on development and `openconnector`
+	// on beta/main; FleetAppId holds both spellings, so this names the app
+	// rather than one spelling of it. Never compare it to an id directly —
+	// go through FleetAppId, or the comparison is false on half the fleet.
+	private const REQUIRED_APP = 'integriq';
 
 	/**
 	 * Constructor.
@@ -141,7 +146,11 @@ class OpenCorporatesProvider extends AbstractIntegrationProvider {
 	 * @return string|null
 	 */
 	public function getRequiredApp(): ?string {
-		return self::REQUIRED_APP;
+		// The id the instance ACTUALLY registered. This value is published
+		// verbatim in the `integrations` capability and consumed client-side
+		// as `isAppInstalled(requiredApp)`, so returning the canonical name
+		// against a beta/main instance would report the connector missing.
+		return (FleetAppId::resolve($this->appManager, self::REQUIRED_APP) ?? self::REQUIRED_APP);
 	}//end getRequiredApp()
 
 	/**
@@ -172,7 +181,7 @@ class OpenCorporatesProvider extends AbstractIntegrationProvider {
 	 * @return bool
 	 */
 	public function isEnabled(): bool {
-		return $this->appManager->isInstalled(self::REQUIRED_APP);
+		return FleetAppId::isInstalled($this->appManager, self::REQUIRED_APP);
 	}//end isEnabled()
 
 	/**

--- a/lib/Service/Integration/Providers/OpenProjectProvider.php
+++ b/lib/Service/Integration/Providers/OpenProjectProvider.php
@@ -41,6 +41,7 @@ use OCA\OpenRegister\Db\OpenProjectLink;
 use OCA\OpenRegister\Db\OpenProjectLinkMapper;
 use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
 use OCA\OpenRegister\Service\Integration\ExternalIntegrationRouter;
+use OCA\OpenRegister\Support\FleetAppId;
 use OCP\App\IAppManager;
 use OCP\IL10N;
 use Throwable;
@@ -63,7 +64,11 @@ class OpenProjectProvider extends AbstractIntegrationProvider {
 	 *
 	 * @var string
 	 */
-	private const REQUIRED_APP = 'openconnector';
+	// The connector answers to `integriq` on development and `openconnector`
+	// on beta/main; FleetAppId holds both spellings, so this names the app
+	// rather than one spelling of it. Never compare it to an id directly —
+	// go through FleetAppId, or the comparison is false on half the fleet.
+	private const REQUIRED_APP = 'integriq';
 
 	/**
 	 * Constructor.
@@ -100,7 +105,11 @@ class OpenProjectProvider extends AbstractIntegrationProvider {
 	}//end getGroup()
 
 	public function getRequiredApp(): ?string {
-		return self::REQUIRED_APP;
+		// The id the instance ACTUALLY registered. This value is published
+		// verbatim in the `integrations` capability and consumed client-side
+		// as `isAppInstalled(requiredApp)`, so returning the canonical name
+		// against a beta/main instance would report the connector missing.
+		return (FleetAppId::resolve($this->appManager, self::REQUIRED_APP) ?? self::REQUIRED_APP);
 	}//end getRequiredApp()
 
 	public function getStorageStrategy(): string {
@@ -112,7 +121,7 @@ class OpenProjectProvider extends AbstractIntegrationProvider {
 	}//end getOpenConnectorSource()
 
 	public function isEnabled(): bool {
-		return $this->appManager->isInstalled(self::REQUIRED_APP);
+		return FleetAppId::isInstalled($this->appManager, self::REQUIRED_APP);
 	}//end isEnabled()
 
 	/**

--- a/lib/Service/Integration/Providers/OpenProjectProvider.php
+++ b/lib/Service/Integration/Providers/OpenProjectProvider.php
@@ -104,11 +104,18 @@ class OpenProjectProvider extends AbstractIntegrationProvider {
 		return 'external';
 	}//end getGroup()
 
+	/**
+	 * Nextcloud app that must be installed for this integration to function.
+	 *
+	 * Returns the id the instance ACTUALLY registered, not the canonical name.
+	 * The value is published verbatim in the `integrations` capability and
+	 * read back client-side as `isAppInstalled(requiredApp)`, so a spelling the
+	 * instance does not answer to renders "not installed" over a connector that
+	 * is installed and working.
+	 *
+	 * @return string|null
+	 */
 	public function getRequiredApp(): ?string {
-		// The id the instance ACTUALLY registered. This value is published
-		// verbatim in the `integrations` capability and consumed client-side
-		// as `isAppInstalled(requiredApp)`, so returning the canonical name
-		// against a beta/main instance would report the connector missing.
 		return (FleetAppId::resolve($this->appManager, self::REQUIRED_APP) ?? self::REQUIRED_APP);
 	}//end getRequiredApp()
 

--- a/lib/Service/Integration/Providers/XwikiProvider.php
+++ b/lib/Service/Integration/Providers/XwikiProvider.php
@@ -140,13 +140,15 @@ class XwikiProvider extends AbstractIntegrationProvider {
 	 * Nextcloud app that must be installed for this integration to
 	 * function — OpenConnector carries the `xwiki` source + credentials.
 	 *
+	 * Returns the id the instance ACTUALLY registered, not the canonical name.
+	 * The value is published verbatim in the `integrations` capability and
+	 * read back client-side as `isAppInstalled(requiredApp)`, so a spelling the
+	 * instance does not answer to renders "not installed" over a connector that
+	 * is installed and working.
+	 *
 	 * @return string|null
 	 */
 	public function getRequiredApp(): ?string {
-		// The id the instance ACTUALLY registered. This value is published
-		// verbatim in the `integrations` capability and consumed client-side
-		// as `isAppInstalled(requiredApp)`, so returning the canonical name
-		// against a beta/main instance would report the connector missing.
 		return (FleetAppId::resolve($this->appManager, self::REQUIRED_APP) ?? self::REQUIRED_APP);
 	}//end getRequiredApp()
 

--- a/lib/Service/Integration/Providers/XwikiProvider.php
+++ b/lib/Service/Integration/Providers/XwikiProvider.php
@@ -48,6 +48,7 @@ namespace OCA\OpenRegister\Service\Integration\Providers;
 use OCA\OpenRegister\Db\XwikiLinkMapper;
 use OCA\OpenRegister\Service\Integration\AbstractIntegrationProvider;
 use OCA\OpenRegister\Service\Integration\ExternalIntegrationRouter;
+use OCA\OpenRegister\Support\FleetAppId;
 use OCP\App\IAppManager;
 use OCP\IL10N;
 use Throwable;
@@ -70,7 +71,11 @@ class XwikiProvider extends AbstractIntegrationProvider {
 	 *
 	 * @var string
 	 */
-	private const REQUIRED_APP = 'openconnector';
+	// The connector answers to `integriq` on development and `openconnector`
+	// on beta/main; FleetAppId holds both spellings, so this names the app
+	// rather than one spelling of it. Never compare it to an id directly —
+	// go through FleetAppId, or the comparison is false on half the fleet.
+	private const REQUIRED_APP = 'integriq';
 
 	/**
 	 * Constructor.
@@ -138,7 +143,11 @@ class XwikiProvider extends AbstractIntegrationProvider {
 	 * @return string|null
 	 */
 	public function getRequiredApp(): ?string {
-		return self::REQUIRED_APP;
+		// The id the instance ACTUALLY registered. This value is published
+		// verbatim in the `integrations` capability and consumed client-side
+		// as `isAppInstalled(requiredApp)`, so returning the canonical name
+		// against a beta/main instance would report the connector missing.
+		return (FleetAppId::resolve($this->appManager, self::REQUIRED_APP) ?? self::REQUIRED_APP);
 	}//end getRequiredApp()
 
 	/**
@@ -170,7 +179,7 @@ class XwikiProvider extends AbstractIntegrationProvider {
 	 * @return bool
 	 */
 	public function isEnabled(): bool {
-		return $this->appManager->isInstalled(self::REQUIRED_APP);
+		return FleetAppId::isInstalled($this->appManager, self::REQUIRED_APP);
 	}//end isEnabled()
 
 	/**

--- a/lib/Service/OpenProjectLinkService.php
+++ b/lib/Service/OpenProjectLinkService.php
@@ -59,6 +59,7 @@ use OCA\OpenRegister\Db\OpenProjectLinkMapper;
 use OCA\OpenRegister\Exception\ProviderUnavailableException;
 use OCA\OpenRegister\Service\Integration\ExternalIntegrationRouter;
 use OCA\OpenRegister\Service\Integration\Providers\OpenProjectProvider;
+use OCA\OpenRegister\Support\FleetAppId;
 use OCP\App\IAppManager;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
@@ -84,7 +85,11 @@ use Throwable;
  * it would misalign with upstream documentation.
  */
 class OpenProjectLinkService {
-	private const REQUIRED_APP = 'openconnector';
+	// The connector answers to `integriq` on development and `openconnector`
+	// on beta/main; FleetAppId holds both spellings, so this names the app
+	// rather than one spelling of it. Never compare it to an id directly —
+	// go through FleetAppId, or the comparison is false on half the fleet.
+	private const REQUIRED_APP = 'integriq';
 
 	private const STALE_AFTER = 86400;
 	// 24 hours in seconds.
@@ -116,7 +121,7 @@ class OpenProjectLinkService {
 	 * @return bool
 	 */
 	public function isOpenConnectorAvailable(): bool {
-		return $this->appManager->isEnabledForUser(self::REQUIRED_APP);
+		return FleetAppId::isEnabledForUser($this->appManager, self::REQUIRED_APP);
 	}//end isOpenConnectorAvailable()
 
 	/**

--- a/lib/Service/XwikiLinkService.php
+++ b/lib/Service/XwikiLinkService.php
@@ -53,6 +53,7 @@ use OCA\OpenRegister\Db\XwikiLinkMapper;
 use OCA\OpenRegister\Exception\ProviderUnavailableException;
 use OCA\OpenRegister\Service\Integration\ExternalIntegrationRouter;
 use OCA\OpenRegister\Service\Integration\Providers\XwikiProvider;
+use OCA\OpenRegister\Support\FleetAppId;
 use OCP\App\IAppManager;
 use OCP\IUserSession;
 use Psr\Container\ContainerInterface;
@@ -76,7 +77,11 @@ use Throwable;
  * toServiceException/isStale/refreshLink; each is a required face of the xWiki integration surface.
  */
 class XwikiLinkService {
-	private const REQUIRED_APP = 'openconnector';
+	// The connector answers to `integriq` on development and `openconnector`
+	// on beta/main; FleetAppId holds both spellings, so this names the app
+	// rather than one spelling of it. Never compare it to an id directly —
+	// go through FleetAppId, or the comparison is false on half the fleet.
+	private const REQUIRED_APP = 'integriq';
 
 	private const STALE_AFTER = 86400;
 	// 24 hours in seconds.
@@ -107,7 +112,7 @@ class XwikiLinkService {
 	 * @return bool
 	 */
 	public function isOpenConnectorAvailable(): bool {
-		return $this->appManager->isInstalled(self::REQUIRED_APP);
+		return FleetAppId::isInstalled($this->appManager, self::REQUIRED_APP);
 	}//end isOpenConnectorAvailable()
 
 	/**

--- a/lib/Support/FleetAppId.php
+++ b/lib/Support/FleetAppId.php
@@ -71,6 +71,35 @@ final class FleetAppId
 
 
     /**
+     * PHP namespace per candidate id, for the apps OpenRegister names by FQCN.
+     *
+     * A cross-app FQCN is the second half of the rename, and it is the half
+     * that cannot be guessed: `openbuild` shipped `OCA\OpenBuilt` and
+     * `larpingapp` shipped `OCA\DsoNextcloud` before `OCA\LarpingApp`, so
+     * `ucfirst($appId)` is not the rule and never was. Each entry below was
+     * READ from that app's own `appinfo/info.xml` (new) or from a literal this
+     * repo already resolved successfully against a running instance (old).
+     *
+     * Deliberately narrower than {@see self::CANDIDATES}: a canonical name is
+     * listed here only when BOTH its namespaces have been read. An app absent
+     * from this map resolves to null rather than to a guess, because a wrong
+     * FQCN fails exactly as silently as a stale one and looks fixed.
+     *
+     * @var array<string, array<string, string>>
+     */
+    private const NAMESPACES = [
+        'integriq' => [
+            'integriq'      => 'Integriq',
+            'openconnector' => 'OpenConnector',
+        ],
+        'keepiq'   => [
+            'keepiq'  => 'Keepiq',
+            'doriath' => 'Doriath',
+        ],
+    ];
+
+
+    /**
      * The id this instance actually has installed, or null if none is.
      *
      * @param IAppManager $appManager The Nextcloud app manager.
@@ -168,6 +197,99 @@ final class FleetAppId
         return $path;
 
     }//end appPath()
+
+
+    /**
+     * The PHP namespace prefix for one concrete installed id.
+     *
+     * Does NOT touch the autoloader, so a caller that must keep a cross-app
+     * class name as inert data (an allow-list value handed to another app's
+     * job runner, say) can build the name without loading the class.
+     *
+     * @param string $canonical Canonical (new) app name, e.g. 'integriq'.
+     * @param string $id        A concrete id from {@see self::CANDIDATES}.
+     *
+     * @return string|null The namespace prefix ending in a backslash, or null
+     *                     when this repo has not read that app's namespace.
+     */
+    public static function namespaceForId(string $canonical, string $id): ?string
+    {
+        $namespace = (self::NAMESPACES[$canonical][$id] ?? null);
+        if ($namespace === null) {
+            return null;
+        }
+
+        return 'OCA\\'.$namespace.'\\';
+
+    }//end namespaceForId()
+
+
+    /**
+     * Build a cross-app FQCN against the id the instance actually has.
+     *
+     * Resolution is by INSTALLED ID, not by class existence, so the returned
+     * name is inert: nothing is autoloaded and nothing is instantiated. When
+     * the app is absent the canonical (newest) spelling is returned, because a
+     * name handed to an app that is not there is never dereferenced anyway and
+     * the newest spelling is the one the fleet is moving to.
+     *
+     * @param IAppManager $appManager    The Nextcloud app manager.
+     * @param string      $canonical     Canonical (new) app name, e.g. 'integriq'.
+     * @param string      $relativeClass Class path below the namespace, e.g. 'Service\CallService'.
+     *
+     * @return string|null The FQCN, or null when this repo has not read that
+     *                     app's namespace.
+     */
+    public static function className(IAppManager $appManager, string $canonical, string $relativeClass): ?string
+    {
+        if (isset(self::NAMESPACES[$canonical]) === false) {
+            return null;
+        }
+
+        $id = self::resolve(appManager: $appManager, canonical: $canonical);
+        if ($id === null || isset(self::NAMESPACES[$canonical][$id]) === false) {
+            $id = array_key_first(self::NAMESPACES[$canonical]);
+        }
+
+        return self::namespaceForId(canonical: $canonical, id: $id).$relativeClass;
+
+    }//end className()
+
+
+    /**
+     * The first spelling of a cross-app class that is actually loadable.
+     *
+     * Probes by `class_exists` rather than by installed id, which is the right
+     * test for the `class_exists` + `Server::get` seam: what those callers need
+     * to know is not which id is registered but which class the autoloader can
+     * hand back. Returns null when no candidate resolves — the same answer the
+     * caller already handles for "the optional app is not installed".
+     *
+     * @param string $canonical     Canonical (new) app name, e.g. 'keepiq'.
+     * @param string $relativeClass Class path below the namespace, e.g. 'Service\SecretService'.
+     *
+     * @return string|null The loadable FQCN, or null when none is.
+     */
+    public static function resolveClass(string $canonical, string $relativeClass): ?string
+    {
+        foreach (array_keys((self::NAMESPACES[$canonical] ?? [])) as $id) {
+            $className = self::namespaceForId(canonical: $canonical, id: $id).$relativeClass;
+            try {
+                if (class_exists($className) === true) {
+                    return $className;
+                }
+            } catch (Throwable $e) {
+                // A candidate whose autoloader entry throws must not abort the
+                // search — the next spelling may still load.
+                continue;
+            }
+        }
+
+        return null;
+
+    }//end resolveClass()
+
+
 
 
 }//end class

--- a/src/main.js
+++ b/src/main.js
@@ -81,6 +81,38 @@ const GENERIC_INTEGRATION_DESCRIPTORS = [
 	},
 ]
 
+// The connector app answers to `integriq` on development and `openconnector`
+// on beta/main. `requiredApp` is read back by nc-vue as
+// `isAppInstalled(requiredApp)`, which looks the string up in
+// `OC.appswebroots` — so the wrong spelling does not error, it reports the
+// connector as missing and every descriptor below renders its "not installed"
+// state on an instance where the connector is installed and working. Resolve
+// against what the page actually has, newest spelling first.
+const CONNECTOR_APP_IDS = ['integriq', 'openconnector']
+
+/**
+ * The connector app id this instance registered.
+ *
+ * @return {string} The installed id, or the canonical name when neither is
+ *   present (in which case "not installed" is the truthful answer anyway).
+ */
+function connectorAppId() {
+	try {
+		const webroots = (typeof OC !== 'undefined' && OC && OC.appswebroots) || null
+		if (webroots) {
+			const found = CONNECTOR_APP_IDS.find((id) => Object.hasOwn(webroots, id))
+			if (found) {
+				return found
+			}
+		}
+	} catch (e) {
+		// eslint-disable-next-line no-console
+		console.warn('[main] could not resolve the connector app id', e)
+	}
+
+	return CONNECTOR_APP_IDS[0]
+}
+
 try {
 	const registry = window?.OCA?.OpenRegister?.integrations
 	const pending = registry?.register
@@ -92,7 +124,7 @@ try {
 				pending.forEach((descriptor) => {
 					registry.register({
 						...descriptor,
-						requiredApp: 'openconnector',
+						requiredApp: connectorAppId(),
 						group: 'external',
 						tab: CnIntegrationTab,
 						widget: CnIntegrationCard,

--- a/tests/Unit/AppHost/Scheduling/ScheduleActionAllowListTest.php
+++ b/tests/Unit/AppHost/Scheduling/ScheduleActionAllowListTest.php
@@ -18,23 +18,88 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Tests\Unit\AppHost\Scheduling;
 
 use OCA\OpenRegister\AppHost\Scheduling\ScheduleActionAllowList;
+use OCP\App\IAppManager;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Covers the closed action → vetted jobClass map.
+ *
+ * @covers \OCA\OpenRegister\AppHost\Scheduling\ScheduleActionAllowList
+ * @covers \OCA\OpenRegister\Support\FleetAppId
  */
 class ScheduleActionAllowListTest extends TestCase {
 	private ScheduleActionAllowList $allowList;
 
 	protected function setUp(): void {
-		$this->allowList = new ScheduleActionAllowList();
+		$this->allowList = $this->allowListFor(['integriq']);
+	}
+
+	/**
+	 * Build the allow-list against an instance carrying exactly these app ids.
+	 *
+	 * @param list<string> $installed Ids this fake instance has.
+	 *
+	 * @return ScheduleActionAllowList The configured allow-list.
+	 */
+	private function allowListFor(array $installed): ScheduleActionAllowList {
+		$appManager = $this->createMock(IAppManager::class);
+		$appManager->method('isInstalled')->willReturnCallback(
+			static fn (string $id): bool => in_array($id, $installed, true)
+		);
+
+		return new ScheduleActionAllowList($appManager);
 	}
 
 	public function testVettedActionResolvesToServerClass(): void {
 		$this->assertTrue($this->allowList->isAllowed('openconnector:synchronization'));
 		$this->assertSame(
-			'OCA\\OpenConnector\\Action\\SynchronizationAction',
+			'OCA\\Integriq\\Action\\SynchronizationAction',
 			$this->allowList->resolve('openconnector:synchronization')
+		);
+	}
+
+	/**
+	 * The jobClass follows the id the instance ACTUALLY has, not the newest.
+	 *
+	 * This is the assertion that separates a fix from a hard swap: an instance
+	 * still on the connector's beta/main release registers `openconnector` and
+	 * loads `OCA\OpenConnector\…`. Handing its JobService the `OCA\Integriq`
+	 * name would be the same silent miss as before, pointed the other way.
+	 *
+	 * @return void
+	 */
+	public function testVettedActionFollowsTheInstalledConnectorId(): void {
+		$allowList = $this->allowListFor(['openconnector']);
+
+		$this->assertSame(
+			'OCA\\OpenConnector\\Action\\SynchronizationAction',
+			$allowList->resolve('openconnector:synchronization')
+		);
+	}
+
+	/**
+	 * The manifest-facing ACTION KEY is unchanged by the namespace rename.
+	 *
+	 * Leaf apps ship `action: 'openconnector:synchronization'` in their own
+	 * manifests. Renaming that key would un-allow-list every schedule already
+	 * declared against it, so it is pinned here deliberately.
+	 *
+	 * @return void
+	 */
+	public function testTheManifestActionKeyIsUnchanged(): void {
+		$this->assertTrue($this->allowListFor(['integriq'])->isAllowed('openconnector:synchronization'));
+		$this->assertFalse($this->allowListFor(['integriq'])->isAllowed('integriq:synchronization'));
+	}
+
+	/**
+	 * With no connector installed the canonical spelling is returned.
+	 *
+	 * @return void
+	 */
+	public function testResolvesToTheCanonicalNameWhenNoConnectorIsInstalled(): void {
+		$this->assertSame(
+			'OCA\\Integriq\\Action\\SynchronizationAction',
+			$this->allowListFor([])->resolve('openconnector:synchronization')
 		);
 	}
 

--- a/tests/Unit/AppHost/Scheduling/ScheduleReconcilerIoTest.php
+++ b/tests/Unit/AppHost/Scheduling/ScheduleReconcilerIoTest.php
@@ -26,6 +26,7 @@ use OCA\OpenRegister\AppHost\Scheduling\ScheduleActionAllowList;
 use OCA\OpenRegister\AppHost\Scheduling\ScheduleManifestLoader;
 use OCA\OpenRegister\AppHost\Scheduling\ScheduleReconciler;
 use OCA\OpenRegister\Service\ObjectService;
+use OCP\App\IAppManager;
 use OCP\IUserManager;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -49,6 +50,25 @@ class IoProbeReconciler extends ScheduleReconciler {
  */
 class ScheduleReconcilerIoTest extends TestCase {
 	/**
+	 * An allow-list bound to a fake instance that has the connector installed.
+	 *
+	 * `openconnector` rather than `integriq`, because these fixtures assert the
+	 * literal `OCA\OpenConnector\…` jobClass and this keeps that assertion
+	 * about the RECONCILER rather than about which id the resolver picked —
+	 * that choice is covered in ScheduleActionAllowListTest.
+	 *
+	 * @return ScheduleActionAllowList The configured allow-list.
+	 */
+	private function allowList(): ScheduleActionAllowList {
+		$appManager = $this->createMock(IAppManager::class);
+		$appManager->method('isInstalled')->willReturnCallback(
+			static fn (string $id): bool => ($id === 'openconnector')
+		);
+
+		return new ScheduleActionAllowList($appManager);
+	}
+
+	/**
 	 * Build an IoProbeReconciler around a given ObjectService mock.
 	 *
 	 * @param ObjectService $objectService The mocked OR facade.
@@ -64,7 +84,7 @@ class ScheduleReconcilerIoTest extends TestCase {
 			$objectService,
 			$loader,
 			new CronScheduleEvaluator(),
-			new ScheduleActionAllowList(),
+			$this->allowList(),
 			$userManager,
 			$logger
 		);

--- a/tests/Unit/AppHost/Scheduling/ScheduleReconcilerTest.php
+++ b/tests/Unit/AppHost/Scheduling/ScheduleReconcilerTest.php
@@ -23,6 +23,7 @@ use OCA\OpenRegister\AppHost\Scheduling\ScheduleActionAllowList;
 use OCA\OpenRegister\AppHost\Scheduling\ScheduleDescriptor;
 use OCA\OpenRegister\AppHost\Scheduling\ScheduleManifestLoader;
 use OCA\OpenRegister\Service\ObjectService;
+use OCP\App\IAppManager;
 use OCP\IUser;
 use OCP\IUserManager;
 use PHPUnit\Framework\TestCase;
@@ -53,6 +54,25 @@ class ScheduleReconcilerTest extends TestCase {
 	}
 
 	/**
+	 * An allow-list bound to a fake instance that has the connector installed.
+	 *
+	 * `openconnector` rather than `integriq`, because these fixtures assert the
+	 * literal `OCA\OpenConnector\…` jobClass and this keeps that assertion
+	 * about the RECONCILER rather than about which id the resolver picked —
+	 * that choice is covered in ScheduleActionAllowListTest.
+	 *
+	 * @return ScheduleActionAllowList The configured allow-list.
+	 */
+	private function allowList(): ScheduleActionAllowList {
+		$appManager = $this->createMock(IAppManager::class);
+		$appManager->method('isInstalled')->willReturnCallback(
+			static fn (string $id): bool => ($id === 'openconnector')
+		);
+
+		return new ScheduleActionAllowList($appManager);
+	}
+
+	/**
 	 * Build a testable reconciler with overridable I/O and recorded saves.
 	 *
 	 * @param array<int, array<string, mixed>> $virtual Virtual application fixtures.
@@ -65,7 +85,7 @@ class ScheduleReconcilerTest extends TestCase {
 			$this->createMock(ObjectService::class),
 			$this->loader,
 			new CronScheduleEvaluator(),
-			new ScheduleActionAllowList(),
+			$this->allowList(),
 			$this->userManager,
 			$this->createMock(LoggerInterface::class),
 			$virtual,

--- a/tests/Unit/Repair/RegisterOpenRegisterWithDoriathTest.php
+++ b/tests/Unit/Repair/RegisterOpenRegisterWithDoriathTest.php
@@ -191,6 +191,28 @@ class RegisterOpenRegisterWithDoriathTest extends TestCase {
 	}
 
 	/**
+	 * An app manager reporting the credential app under ONE concrete id.
+	 *
+	 * Parameterised by id rather than pinned to `doriath`, because the whole
+	 * defect these tests now guard is directional: a resolver that only handled
+	 * the spelling the fixture happens to use looks correct against that
+	 * fixture and silently reports "no credential app" against the other.
+	 *
+	 * @param bool   $enabled Whether the app is present and enabled at all.
+	 * @param string $appId   The single id this fake instance registered.
+	 *
+	 * @return IAppManager The configured mock.
+	 */
+	private function credentialAppManager(bool $enabled, string $appId = 'keepiq'): IAppManager {
+		$mock = $this->createMock(IAppManager::class);
+		$match = static fn (string $id): bool => ($enabled === true && $id === $appId);
+		$mock->method('isInstalled')->willReturnCallback($match);
+		$mock->method('isEnabledForUser')->willReturnCallback($match);
+
+		return $mock;
+	}
+
+	/**
 	 * Build the repair step with the fixture ApplicationService injected.
 	 *
 	 * @param bool $doriathEnabled Whether IAppManager reports doriath enabled.
@@ -201,9 +223,9 @@ class RegisterOpenRegisterWithDoriathTest extends TestCase {
 		bool $doriathEnabled,
 		IAppConfig $appConfig,
 		ICredentialsManager $credentialsManager,
+		string $appId = 'keepiq',
 	): RegisterOpenRegisterWithDoriath {
-		$appManager = $this->createMock(IAppManager::class);
-		$appManager->method('isEnabledForUser')->with('doriath')->willReturn($doriathEnabled);
+		$appManager = $this->credentialAppManager(enabled: $doriathEnabled, appId: $appId);
 
 		$applicationService = $this->applicationService;
 

--- a/tests/Unit/Service/Credential/CredentialStoreResolverTest.php
+++ b/tests/Unit/Service/Credential/CredentialStoreResolverTest.php
@@ -64,6 +64,66 @@ class CredentialStoreResolverTest extends TestCase {
 	}
 
 	/**
+	 * The app-id gate accepts BOTH spellings of the credential app.
+	 *
+	 * This is the defect the class docblock below already described for the
+	 * namespace half and that the id half still had: the gate asked
+	 * `isEnabledForUser('doriath')`, which on a migrated instance returns FALSE
+	 * rather than erroring. Every instance running `keepiq` therefore fell
+	 * through to the vault leaf, and the namespace probing underneath the gate
+	 * — which was already correct — never ran at all.
+	 *
+	 * Asserted in both directions, because a gate that handled only the id the
+	 * fixture happens to use looks perfectly correct against that fixture.
+	 *
+	 * @param string $appId The single credential-app id the instance carries.
+	 *
+	 * @return void
+	 *
+	 * @dataProvider credentialAppIdProvider
+	 */
+	public function testEitherCredentialAppIdSatisfiesTheGate(string $appId): void {
+		$resolver = $this->makeResolver(
+			doriathEnabled: true,
+			registered: true,
+			secretServiceClass: self::FIXTURE_NS . 'FakeSecretService',
+			appId: $appId
+		);
+
+		$this->assertTrue($resolver->isDoriathEligible(), $appId . ' must satisfy the credential-app gate');
+		$this->assertSame($this->doriathStore, $resolver->resolve());
+	}
+
+	/**
+	 * Both spellings of the credential app id.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public static function credentialAppIdProvider(): array {
+		return [
+			'development (renamed)' => ['keepiq'],
+			'beta/main (retired)' => ['doriath'],
+		];
+	}
+
+	/**
+	 * An instance with NEITHER id falls back to the vault leaf.
+	 *
+	 * @return void
+	 */
+	public function testAnUnrelatedAppIdDoesNotSatisfyTheGate(): void {
+		$resolver = $this->makeResolver(
+			doriathEnabled: true,
+			registered: true,
+			secretServiceClass: self::FIXTURE_NS . 'FakeSecretService',
+			appId: 'some-other-app'
+		);
+
+		$this->assertFalse($resolver->isDoriathEligible());
+		$this->assertSame($this->vaultStore, $resolver->resolve());
+	}
+
+	/**
 	 * Error path: doriath app disabled → vault leaf, nothing else probed.
 	 */
 	public function testDisabledAppFallsBackToVault(): void {
@@ -236,6 +296,28 @@ class CredentialStoreResolverTest extends TestCase {
 	}
 
 	/**
+	 * An app manager reporting the credential app under ONE concrete id.
+	 *
+	 * Parameterised by id rather than pinned to `doriath`, because the whole
+	 * defect these tests now guard is directional: a resolver that only handled
+	 * the spelling the fixture happens to use looks correct against that
+	 * fixture and silently reports "no credential app" against the other.
+	 *
+	 * @param bool   $enabled Whether the app is present and enabled at all.
+	 * @param string $appId   The single id this fake instance registered.
+	 *
+	 * @return IAppManager The configured mock.
+	 */
+	private function credentialAppManager(bool $enabled, string $appId = 'keepiq'): IAppManager {
+		$mock = $this->createMock(IAppManager::class);
+		$match = static fn (string $id): bool => ($enabled === true && $id === $appId);
+		$mock->method('isInstalled')->willReturnCallback($match);
+		$mock->method('isEnabledForUser')->willReturnCallback($match);
+
+		return $mock;
+	}
+
+	/**
 	 * Build a resolver whose class probes point at the test fixtures.
 	 *
 	 * @param bool $doriathEnabled Whether IAppManager reports doriath enabled.
@@ -248,9 +330,9 @@ class CredentialStoreResolverTest extends TestCase {
 		bool $registered,
 		string $secretServiceClass,
 		?array $serviceClasses = null,
+		string $appId = 'keepiq',
 	): CredentialStoreResolver {
-		$appManager = $this->createMock(IAppManager::class);
-		$appManager->method('isEnabledForUser')->with('doriath')->willReturn($doriathEnabled);
+		$appManager = $this->credentialAppManager(enabled: $doriathEnabled, appId: $appId);
 
 		$appConfig = $this->createMock(IAppConfig::class);
 		$appConfig->method('getValueString')->willReturnCallback(

--- a/tests/Unit/Service/Credential/DoriathApplicationRegistrarTest.php
+++ b/tests/Unit/Service/Credential/DoriathApplicationRegistrarTest.php
@@ -186,14 +186,35 @@ class DoriathApplicationRegistrarTest extends TestCase {
 	}
 
 	/**
+	 * An app manager reporting the credential app under ONE concrete id.
+	 *
+	 * Parameterised by id rather than pinned to `doriath`, because the whole
+	 * defect these tests now guard is directional: a resolver that only handled
+	 * the spelling the fixture happens to use looks correct against that
+	 * fixture and silently reports "no credential app" against the other.
+	 *
+	 * @param bool   $enabled Whether the app is present and enabled at all.
+	 * @param string $appId   The single id this fake instance registered.
+	 *
+	 * @return IAppManager The configured mock.
+	 */
+	private function credentialAppManager(bool $enabled, string $appId = 'keepiq'): IAppManager {
+		$mock = $this->createMock(IAppManager::class);
+		$match = static fn (string $id): bool => ($enabled === true && $id === $appId);
+		$mock->method('isInstalled')->willReturnCallback($match);
+		$mock->method('isEnabledForUser')->willReturnCallback($match);
+
+		return $mock;
+	}
+
+	/**
 	 * Build the registrar with the fixture ApplicationService injected.
 	 *
 	 * @param bool $doriathEnabled Whether IAppManager reports doriath enabled.
 	 * @param IAppConfig $appConfig IAppConfig mock.
 	 */
-	private function makeRegistrar(bool $doriathEnabled, IAppConfig $appConfig): DoriathApplicationRegistrar {
-		$appManager = $this->createMock(IAppManager::class);
-		$appManager->method('isEnabledForUser')->with('doriath')->willReturn($doriathEnabled);
+	private function makeRegistrar(bool $doriathEnabled, IAppConfig $appConfig, string $appId = 'keepiq'): DoriathApplicationRegistrar {
+		$appManager = $this->credentialAppManager(enabled: $doriathEnabled, appId: $appId);
 
 		$applicationService = $this->applicationService;
 

--- a/tests/Unit/Service/Credential/DoriathCredentialStoreTest.php
+++ b/tests/Unit/Service/Credential/DoriathCredentialStoreTest.php
@@ -267,15 +267,19 @@ class DoriathCredentialStoreTest extends TestCase {
 
 		$userSession->method('getUser')->willReturn($user);
 
+		// Keyed on the RELATIVE class name: the store no longer hardcodes a
+		// namespace, it hands FleetAppId `Service\SecretService` and lets the
+		// resolver prepend OCA\Keepiq or OCA\Doriath depending on which one
+		// the instance can actually load.
 		$serviceMap = [
-			'OCA\\Doriath\\Service\\SecretService' => $this->secretService,
-			'OCA\\Doriath\\Service\\EncryptService' => $this->encryptService,
-			'OCA\\Doriath\\Service\\DecryptService' => $this->decryptService,
+			'Service\\SecretService' => $this->secretService,
+			'Service\\EncryptService' => $this->encryptService,
+			'Service\\DecryptService' => $this->decryptService,
 		];
 
 		return new class($this->vaultStore, ($credentialsManager ?? $this->credentialsManager), $appConfig, $userSession, $this->createMock(LoggerInterface::class), $serviceMap) extends DoriathCredentialStore {
 			/**
-			 * @param array<string, object> $serviceMap FQCN → fixture instance.
+			 * @param array<string, object> $serviceMap Relative class → fixture instance.
 			 */
 			public function __construct(
 				NextcloudVaultCredentialStore $vaultStore,
@@ -288,8 +292,8 @@ class DoriathCredentialStoreTest extends TestCase {
 				parent::__construct($vaultStore, $credentialsManager, $appConfig, $userSession, $logger);
 			}
 
-			protected function resolveDoriathService(string $className): ?object {
-				return ($this->serviceMap[$className] ?? null);
+			protected function resolveDoriathService(string $relativeClass): ?object {
+				return ($this->serviceMap[$relativeClass] ?? null);
 			}
 		};
 	}

--- a/tests/Unit/Service/Integration/Providers/BrpPersonProviderTest.php
+++ b/tests/Unit/Service/Integration/Providers/BrpPersonProviderTest.php
@@ -97,7 +97,11 @@ class BrpPersonProviderTest extends TestCase {
 		$this->assertSame('BRP Person Register (HaalCentraal)', $this->provider->getLabel());
 		$this->assertSame('AccountSearch', $this->provider->getIcon());
 		$this->assertSame('external', $this->provider->getGroup());
-		$this->assertSame('openconnector', $this->provider->getRequiredApp());
+		// The CANONICAL name: this fixture's app manager reports nothing
+		// installed, so FleetAppId finds neither spelling and falls back.
+		// The installed-id direction is asserted in
+		// LeafProvidersMetadataTest::testOpenProjectProviderMetadata*.
+		$this->assertSame('integriq', $this->provider->getRequiredApp());
 		$this->assertSame('external', $this->provider->getStorageStrategy());
 		$this->assertSame('brp-haalcentraal', $this->provider->getOpenConnectorSource());
 		$this->assertSame('brp-haalcentraal', BrpPersonProvider::SOURCE_ID);
@@ -114,7 +118,9 @@ class BrpPersonProviderTest extends TestCase {
 	}//end testAuthRequirementsAreExternalOAuthAndMtlsViaOpenConnector()
 
 	public function testIsEnabledMirrorsOpenConnectorInstall(): void {
-		$this->appManager->method('isInstalled')->with('openconnector')->willReturn(true);
+		$this->appManager->method('isInstalled')->willReturnCallback(
+			static fn (string $id): bool => ($id === 'openconnector' && true === true)
+		);
 		$this->assertTrue($this->provider->isEnabled());
 	}//end testIsEnabledMirrorsOpenConnectorInstall()
 

--- a/tests/Unit/Service/Integration/Providers/KvkProviderTest.php
+++ b/tests/Unit/Service/Integration/Providers/KvkProviderTest.php
@@ -96,7 +96,11 @@ class KvkProviderTest extends TestCase {
 		$this->assertSame('KvK Company Register', $this->provider->getLabel());
 		$this->assertSame('OfficeBuilding', $this->provider->getIcon());
 		$this->assertSame('external', $this->provider->getGroup());
-		$this->assertSame('openconnector', $this->provider->getRequiredApp());
+		// The CANONICAL name: this fixture's app manager reports nothing
+		// installed, so FleetAppId finds neither spelling and falls back.
+		// The installed-id direction is asserted in
+		// LeafProvidersMetadataTest::testOpenProjectProviderMetadata*.
+		$this->assertSame('integriq', $this->provider->getRequiredApp());
 		$this->assertSame('external', $this->provider->getStorageStrategy());
 		$this->assertSame('kvk', $this->provider->getOpenConnectorSource());
 		$this->assertSame('kvk', KvkProvider::SOURCE_ID);
@@ -112,7 +116,9 @@ class KvkProviderTest extends TestCase {
 	}//end testAuthRequirementsAreExternalApiKeyViaOpenConnector()
 
 	public function testIsEnabledMirrorsOpenConnectorInstall(): void {
-		$this->appManager->method('isInstalled')->with('openconnector')->willReturn(true);
+		$this->appManager->method('isInstalled')->willReturnCallback(
+			static fn (string $id): bool => ($id === 'openconnector' && true === true)
+		);
 		$this->assertTrue($this->provider->isEnabled());
 	}//end testIsEnabledMirrorsOpenConnectorInstall()
 

--- a/tests/Unit/Service/Integration/Providers/LeafProvidersMetadataTest.php
+++ b/tests/Unit/Service/Integration/Providers/LeafProvidersMetadataTest.php
@@ -477,6 +477,11 @@ class LeafProvidersMetadataTest extends TestCase {
 		$this->assertSame('Projects', $provider->getLabel());
 		$this->assertSame('Briefcase', $provider->getIcon());
 		$this->assertSame('external', $provider->getGroup());
+		// The id this instance ACTUALLY registered, not the canonical name:
+		// `requiredApp` is published verbatim in the `integrations` capability
+		// and read client-side as `isAppInstalled(requiredApp)`, so a value the
+		// instance does not answer to renders "not installed" over a connector
+		// that is installed and working.
 		$this->assertSame('openconnector', $provider->getRequiredApp());
 		$this->assertSame('external', $provider->getStorageStrategy());
 		$this->assertSame('openproject', $provider->getOpenConnectorSource());
@@ -486,6 +491,42 @@ class LeafProvidersMetadataTest extends TestCase {
 		$this->assertSame('external', $auth['type']);
 		$this->assertSame('openproject', $auth['source']);
 	}//end testOpenProjectProviderMetadata()
+
+	/**
+	 * The same provider on a MIGRATED instance reports `integriq`.
+	 *
+	 * The mirror of the assertion above, and the one that fails if the fix is a
+	 * hard swap in either direction. Both must hold at once: the fleet is
+	 * mid-rename, so `development` and `beta`/`main` instances coexist and each
+	 * has to see its own connector as present.
+	 *
+	 * @return void
+	 */
+	public function testOpenProjectProviderMetadataOnARenamedInstance(): void {
+		$provider = new OpenProjectProvider(
+			router: $this->createMock(ExternalIntegrationRouter::class),
+			appManager: $this->buildAppManager(['integriq']),
+			l10n: $this->buildL10n(),
+		);
+
+		$this->assertSame('integriq', $provider->getRequiredApp());
+		$this->assertTrue($provider->isEnabled());
+	}//end testOpenProjectProviderMetadataOnARenamedInstance()
+
+	/**
+	 * With NEITHER connector id present the provider reports itself disabled.
+	 *
+	 * @return void
+	 */
+	public function testOpenProjectProviderIsDisabledWithoutAnyConnector(): void {
+		$provider = new OpenProjectProvider(
+			router: $this->createMock(ExternalIntegrationRouter::class),
+			appManager: $this->buildAppManager(['openregister']),
+			l10n: $this->buildL10n(),
+		);
+
+		$this->assertFalse($provider->isEnabled());
+	}//end testOpenProjectProviderIsDisabledWithoutAnyConnector()
 
 	public function testOpenProjectProviderListRoutesThroughExternalRouter(): void {
 		$router = $this->createMock(ExternalIntegrationRouter::class);

--- a/tests/Unit/Service/Integration/Providers/MessageDispatchProviderTest.php
+++ b/tests/Unit/Service/Integration/Providers/MessageDispatchProviderTest.php
@@ -98,7 +98,11 @@ class MessageDispatchProviderTest extends TestCase {
 		$this->assertSame('Outbound messaging (SMS / WhatsApp)', $this->provider->getLabel());
 		$this->assertSame('MessageText', $this->provider->getIcon());
 		$this->assertSame('external', $this->provider->getGroup());
-		$this->assertSame('openconnector', $this->provider->getRequiredApp());
+		// The CANONICAL name: this fixture's app manager reports nothing
+		// installed, so FleetAppId finds neither spelling and falls back.
+		// The installed-id direction is asserted in
+		// LeafProvidersMetadataTest::testOpenProjectProviderMetadata*.
+		$this->assertSame('integriq', $this->provider->getRequiredApp());
 		$this->assertSame('external', $this->provider->getStorageStrategy());
 		// Default advertised source (the real target is per-call).
 		$this->assertSame('whatsapp-cloud-api', $this->provider->getOpenConnectorSource());
@@ -122,7 +126,9 @@ class MessageDispatchProviderTest extends TestCase {
 	}//end testAuthRequirementsAreExternalApiKeyViaOpenConnector()
 
 	public function testIsEnabledMirrorsOpenConnectorInstall(): void {
-		$this->appManager->method('isInstalled')->with('openconnector')->willReturn(true);
+		$this->appManager->method('isInstalled')->willReturnCallback(
+			static fn (string $id): bool => ($id === 'openconnector' && true === true)
+		);
 		$this->assertTrue($this->provider->isEnabled());
 	}//end testIsEnabledMirrorsOpenConnectorInstall()
 

--- a/tests/Unit/Service/Integration/Providers/OpenCorporatesProviderTest.php
+++ b/tests/Unit/Service/Integration/Providers/OpenCorporatesProviderTest.php
@@ -92,7 +92,11 @@ class OpenCorporatesProviderTest extends TestCase {
 		$this->assertSame('OpenCorporates', $this->provider->getLabel());
 		$this->assertSame('Domain', $this->provider->getIcon());
 		$this->assertSame('external', $this->provider->getGroup());
-		$this->assertSame('openconnector', $this->provider->getRequiredApp());
+		// The CANONICAL name: this fixture's app manager reports nothing
+		// installed, so FleetAppId finds neither spelling and falls back.
+		// The installed-id direction is asserted in
+		// LeafProvidersMetadataTest::testOpenProjectProviderMetadata*.
+		$this->assertSame('integriq', $this->provider->getRequiredApp());
 		$this->assertSame('external', $this->provider->getStorageStrategy());
 		$this->assertSame('opencorporates', $this->provider->getOpenConnectorSource());
 		$this->assertSame('opencorporates', OpenCorporatesProvider::SOURCE_ID);
@@ -108,7 +112,9 @@ class OpenCorporatesProviderTest extends TestCase {
 	}//end testAuthRequirementsAreExternalApiKeyViaOpenConnector()
 
 	public function testIsEnabledMirrorsOpenConnectorInstall(): void {
-		$this->appManager->method('isInstalled')->with('openconnector')->willReturn(true);
+		$this->appManager->method('isInstalled')->willReturnCallback(
+			static fn (string $id): bool => ($id === 'openconnector' && true === true)
+		);
 		$this->assertTrue($this->provider->isEnabled());
 	}//end testIsEnabledMirrorsOpenConnectorInstall()
 

--- a/tests/Unit/Service/Integration/Providers/XwikiProviderTest.php
+++ b/tests/Unit/Service/Integration/Providers/XwikiProviderTest.php
@@ -79,7 +79,11 @@ class XwikiProviderTest extends TestCase {
 		$this->assertSame('Articles', $this->provider->getLabel());
 		$this->assertSame('FileDocumentMultiple', $this->provider->getIcon());
 		$this->assertSame('external', $this->provider->getGroup());
-		$this->assertSame('openconnector', $this->provider->getRequiredApp());
+		// The CANONICAL name: this fixture's app manager reports nothing
+		// installed, so FleetAppId finds neither spelling and falls back.
+		// The installed-id direction is asserted in
+		// LeafProvidersMetadataTest::testOpenProjectProviderMetadata*.
+		$this->assertSame('integriq', $this->provider->getRequiredApp());
 		$this->assertSame('external', $this->provider->getStorageStrategy());
 		$this->assertSame('xwiki', $this->provider->getOpenConnectorSource());
 		$this->assertNull($this->provider->requiresPermission());
@@ -95,11 +99,15 @@ class XwikiProviderTest extends TestCase {
 	}//end testAuthRequirementsAreExternalViaOpenConnector()
 
 	public function testIsEnabledMirrorsOpenConnectorInstall(): void {
-		$this->appManager->method('isInstalled')->with('openconnector')->willReturn(true);
+		$this->appManager->method('isInstalled')->willReturnCallback(
+			static fn (string $id): bool => ($id === 'openconnector' && true === true)
+		);
 		$this->assertTrue($this->provider->isEnabled());
 
 		$appManager2 = $this->createMock(IAppManager::class);
-		$appManager2->method('isInstalled')->with('openconnector')->willReturn(false);
+		$appManager2->method('isInstalled')->willReturnCallback(
+			static fn (string $id): bool => ($id === 'openconnector' && false === true)
+		);
 		$l10n = $this->createMock(IL10N::class);
 		$l10n->method('t')->willReturnArgument(0);
 		$disabled = new XwikiProvider($this->router, $appManager2, $l10n);

--- a/tests/Unit/Service/OpenProjectLinkServiceTest.php
+++ b/tests/Unit/Service/OpenProjectLinkServiceTest.php
@@ -104,13 +104,32 @@ class OpenProjectLinkServiceTest extends TestCase {
 		return $user;
 	}//end setupUser()
 
+	/**
+	 * Report the connector app present under ONE concrete id.
+	 *
+	 * Stubs BOTH `isInstalled` and `isEnabledForUser`, because FleetAppId
+	 * resolves the id before it asks whether that id is enabled — stubbing only
+	 * the second returns false for every candidate and the service reads as
+	 * "connector down" no matter which spelling the fixture claims.
+	 *
+	 * @param string $appId   The single connector id this fake instance has.
+	 * @param bool   $present Whether it is present at all.
+	 *
+	 * @return void
+	 */
+	private function connectorInstalledAs(string $appId, bool $present = true): void {
+		$match = static fn (string $id): bool => ($present === true && $id === $appId);
+		$this->appManager->method('isInstalled')->willReturnCallback($match);
+		$this->appManager->method('isEnabledForUser')->willReturnCallback($match);
+	}//end connectorInstalledAs()
+
 	public function testIsOpenConnectorAvailableTrue(): void {
-		$this->appManager->method('isEnabledForUser')->with('openconnector')->willReturn(true);
+		$this->connectorInstalledAs('openconnector', true);
 		$this->assertTrue($this->service->isOpenConnectorAvailable());
 	}//end testIsOpenConnectorAvailableTrue()
 
 	public function testIsOpenConnectorAvailableFalse(): void {
-		$this->appManager->method('isEnabledForUser')->with('openconnector')->willReturn(false);
+		$this->connectorInstalledAs('openconnector', false);
 		$this->assertFalse($this->service->isOpenConnectorAvailable());
 	}//end testIsOpenConnectorAvailableFalse()
 
@@ -146,7 +165,7 @@ class OpenProjectLinkServiceTest extends TestCase {
 	public function testLinkWorkPackagePersistsEvenWhenSourceUnconfigured(): void {
 		$this->setupUser();
 		// OpenConnector unavailable → metadata fetch skipped, link still persisted.
-		$this->appManager->method('isEnabledForUser')->with('openconnector')->willReturn(false);
+		$this->connectorInstalledAs('openconnector', false);
 		$this->mapper->method('findByObjectAndWorkPackage')->with('abc-123', 99)->willReturn(null);
 		$this->mapper->expects($this->once())
 			->method('insert')
@@ -258,7 +277,7 @@ class OpenProjectLinkServiceTest extends TestCase {
 
 	public function testGetLinkedWorkPackagesReturnsRows(): void {
 		// OpenConnector unavailable → no refresh, rows returned as-is.
-		$this->appManager->method('isEnabledForUser')->with('openconnector')->willReturn(false);
+		$this->connectorInstalledAs('openconnector', false);
 
 		$link = new OpenProjectLink();
 		$link->setObjectUuid('abc-123');
@@ -277,14 +296,14 @@ class OpenProjectLinkServiceTest extends TestCase {
 	}//end testGetLinkedWorkPackagesReturnsRows()
 
 	public function testGetLinkedWorkPackagesEmpty(): void {
-		$this->appManager->method('isEnabledForUser')->with('openconnector')->willReturn(false);
+		$this->connectorInstalledAs('openconnector', false);
 		$this->mapper->method('findByObjectUuid')->with('abc-123')->willReturn([]);
 
 		$this->assertSame([], $this->service->getLinkedWorkPackages('abc-123'));
 	}//end testGetLinkedWorkPackagesEmpty()
 
 	public function testGetAvailableWorkPackagesThrowsWhenOpenConnectorUnavailable(): void {
-		$this->appManager->method('isEnabledForUser')->with('openconnector')->willReturn(false);
+		$this->connectorInstalledAs('openconnector', false);
 
 		$this->expectException(Exception::class);
 		$this->expectExceptionCode(503);
@@ -293,7 +312,7 @@ class OpenProjectLinkServiceTest extends TestCase {
 	}//end testGetAvailableWorkPackagesThrowsWhenOpenConnectorUnavailable()
 
 	public function testGetAvailableWorkPackagesSurfaces503OnRouterFailure(): void {
-		$this->appManager->method('isEnabledForUser')->with('openconnector')->willReturn(true);
+		$this->connectorInstalledAs('openconnector', true);
 		$this->router->method('call')->willThrowException(
 			new ProviderUnavailableException(
 				'down',
@@ -308,7 +327,7 @@ class OpenProjectLinkServiceTest extends TestCase {
 	}//end testGetAvailableWorkPackagesSurfaces503OnRouterFailure()
 
 	public function testGetAvailableWorkPackagesNormalisesRows(): void {
-		$this->appManager->method('isEnabledForUser')->with('openconnector')->willReturn(true);
+		$this->connectorInstalledAs('openconnector', true);
 		$this->router->method('call')->willReturn(
 			[
 				'results' => [

--- a/tests/Unit/Service/XwikiLinkServiceTest.php
+++ b/tests/Unit/Service/XwikiLinkServiceTest.php
@@ -102,7 +102,9 @@ class XwikiLinkServiceTest extends TestCase {
 	}//end setupUser()
 
 	private function connectorAvailable(bool $available = true): void {
-		$this->appManager->method('isInstalled')->with('openconnector')->willReturn($available);
+		$this->appManager->method('isInstalled')->willReturnCallback(
+			static fn (string $id): bool => ($id === 'openconnector' && $available === true)
+		);
 	}//end connectorAvailable()
 
 	private function providerResolves(): void {

--- a/tests/Unit/Support/FleetAppIdTest.php
+++ b/tests/Unit/Support/FleetAppIdTest.php
@@ -283,4 +283,167 @@ class FleetAppIdTest extends TestCase
     }//end testAppPathWithoutSuffix()
 
 
+    /**
+     * namespaceForId returns the namespace that app really ships.
+     *
+     * The pairs are asserted as literals on purpose: `ucfirst($appId)` is NOT
+     * the rule (openbuild shipped `OCA\OpenBuilt`), so a derivation here would
+     * be the same guess this map exists to replace.
+     *
+     * @return void
+     */
+    public function testNamespaceForIdReturnsTheReadNamespace(): void
+    {
+        $this->assertSame('OCA\\Integriq\\', FleetAppId::namespaceForId('integriq', 'integriq'));
+        $this->assertSame('OCA\\OpenConnector\\', FleetAppId::namespaceForId('integriq', 'openconnector'));
+        $this->assertSame('OCA\\Keepiq\\', FleetAppId::namespaceForId('keepiq', 'keepiq'));
+        $this->assertSame('OCA\\Doriath\\', FleetAppId::namespaceForId('keepiq', 'doriath'));
+
+    }//end testNamespaceForIdReturnsTheReadNamespace()
+
+
+    /**
+     * An app whose old namespace has NOT been read resolves to null, not a guess.
+     *
+     * This is the property that keeps a wrong repoint out of the codebase: a
+     * guessed FQCN fails exactly as silently as the stale one it replaced, and
+     * looks fixed. Callers get null and handle it as "optional app absent".
+     *
+     * @return void
+     */
+    public function testAnUnreadNamespaceResolvesToNullRatherThanAGuess(): void
+    {
+        $this->assertNull(FleetAppId::namespaceForId('filinq', 'filinq'));
+        $this->assertNull(FleetAppId::className($this->appManager(['filinq']), 'filinq', 'Service\\DocumentService'));
+        $this->assertNull(FleetAppId::resolveClass('filinq', 'Service\\DocumentService'));
+
+    }//end testAnUnreadNamespaceResolvesToNullRatherThanAGuess()
+
+
+    /**
+     * className follows the INSTALLED id in both directions.
+     *
+     * @return void
+     */
+    public function testClassNameFollowsTheInstalledId(): void
+    {
+        $this->assertSame(
+            'OCA\\Integriq\\Action\\SynchronizationAction',
+            FleetAppId::className($this->appManager(['integriq']), 'integriq', 'Action\\SynchronizationAction')
+        );
+
+        $this->assertSame(
+            'OCA\\OpenConnector\\Action\\SynchronizationAction',
+            FleetAppId::className($this->appManager(['openconnector']), 'integriq', 'Action\\SynchronizationAction')
+        );
+
+    }//end testClassNameFollowsTheInstalledId()
+
+
+    /**
+     * className does not autoload: it answers for a class that does not exist.
+     *
+     * The allow-list caller depends on this — it hands the name to another
+     * app's job runner as inert data and must not pull the class in.
+     *
+     * @return void
+     */
+    public function testClassNameDoesNotRequireTheClassToExist(): void
+    {
+        $name = FleetAppId::className($this->appManager(['integriq']), 'integriq', 'Action\\NoSuchActionAnywhere');
+
+        $this->assertSame('OCA\\Integriq\\Action\\NoSuchActionAnywhere', $name);
+        $this->assertFalse(class_exists($name, false));
+
+    }//end testClassNameDoesNotRequireTheClassToExist()
+
+
+    /**
+     * className falls back to the canonical spelling when nothing is installed.
+     *
+     * @return void
+     */
+    public function testClassNameFallsBackToTheCanonicalSpelling(): void
+    {
+        $this->assertSame(
+            'OCA\\Integriq\\Action\\SynchronizationAction',
+            FleetAppId::className($this->appManager([]), 'integriq', 'Action\\SynchronizationAction')
+        );
+
+    }//end testClassNameFallsBackToTheCanonicalSpelling()
+
+
+    /**
+     * resolveClass picks the spelling that is actually loadable.
+     *
+     * Both directions matter. The fixtures below are declared at the bottom of
+     * this file under both namespaces: `OldOnlyProbe` exists only under the
+     * retired spelling, which is the case a hard swap to the new literal would
+     * break, and `BothProbe` exists under both, which pins the newest-first
+     * ordering that makes a migrated instance resolve to its own classes.
+     *
+     * @return void
+     */
+    public function testResolveClassPrefersTheNewestLoadableSpelling(): void
+    {
+        $this->assertSame(
+            'OCA\\Keepiq\\Service\\FleetAppIdBothProbe',
+            FleetAppId::resolveClass('keepiq', 'Service\\FleetAppIdBothProbe')
+        );
+
+        $this->assertSame(
+            'OCA\\Doriath\\Service\\FleetAppIdOldOnlyProbe',
+            FleetAppId::resolveClass('keepiq', 'Service\\FleetAppIdOldOnlyProbe')
+        );
+
+    }//end testResolveClassPrefersTheNewestLoadableSpelling()
+
+
+    /**
+     * resolveClass returns null when no spelling loads.
+     *
+     * @return void
+     */
+    public function testResolveClassReturnsNullWhenNoSpellingLoads(): void
+    {
+        $this->assertNull(FleetAppId::resolveClass('keepiq', 'Service\\FleetAppIdAbsentProbe'));
+
+    }//end testResolveClassReturnsNullWhenNoSpellingLoads()
+
+
+
+}//end class
+
+
+namespace OCA\Keepiq\Service;
+
+/**
+ * Probe fixture present under BOTH spellings (pins newest-first ordering).
+ */
+class FleetAppIdBothProbe
+{
+
+}//end class
+
+
+namespace OCA\Doriath\Service;
+
+/**
+ * Probe fixture present under BOTH spellings (pins newest-first ordering).
+ */
+class FleetAppIdBothProbe
+{
+
+}//end class
+
+
+/**
+ * Probe fixture present ONLY under the retired spelling.
+ *
+ * This is the beta/main instance: a hard swap to `OCA\Keepiq` would miss it
+ * silently, which is the same defect as the stale name it replaced.
+ */
+class FleetAppIdOldOnlyProbe
+{
+
 }//end class


### PR DESCRIPTION
## What this fixes

Twenty-four cross-app lookups in openregister still named the retired ids and namespaces `openconnector` / `OCA\OpenConnector` and `doriath` / `OCA\Doriath`.

None of them failed loudly. `isEnabledForUser('doriath')` against an instance running `keepiq` returns **false**, not an error. `$container->get('OCA\OpenConnector\…')` throws into a catch that exists precisely so openregister stays installable without its optional peer. So each of these read as "the optional app is not installed" on an instance where that app is installed and working.

The widest one was `CredentialStoreResolver`. Its **namespace** probing already handled both spellings, with a docblock recording that it had been measured against a running instance. The **app-id gate above it** did not. So on every migrated instance the gate returned false, the resolver fell through to the Nextcloud-vault leaf, and the namespace probing underneath it never ran at all.

## Approach: resolve, do not swap

Every fixed site routes through `lib/Support/FleetAppId.php` rather than taking the new literal. A hard swap is the same defect pointing the other way: `beta` and `main` deployments still register the old ids, and the fleet is mid-rename, so both kinds of instance exist right now.

`FleetAppId` already resolved the **id** half. This PR adds the **namespace** half:

| method | resolves by | for |
|---|---|---|
| `namespaceForId()` / `className()` | installed app **id**, no autoload | the schedule allow-list, whose value must stay inert data handed to another app's job runner |
| `resolveClass()` | `class_exists` | the `class_exists` + `Server::get` / `container->get` seams, where the question is which class the autoloader can actually return |

The namespace map is deliberately **narrower** than the id map. An entry exists only where both spellings were read — the new one from that app's own `appinfo/info.xml`, the old one from a literal this repo had already resolved against a running instance. An unmapped app returns `null` rather than a guess, because `ucfirst($appId)` is not the rule (`openbuild` shipped `OCA\OpenBuilt`, `larpingapp` shipped `OCA\DsoNextcloud`) and a guessed FQCN fails exactly as silently as the stale one it replaced, while looking fixed.

## Targets verified before repointing

Each target was read in a fresh `development` checkout of the app that owns it, not inferred.

| target | owner | verdict |
|---|---|---|
| `Service\ApplicationService` (+ `register()`, `get()`) | keepiq | exists, signatures match |
| `Service\SecretService` (+ `createByApplication`, `updateByApplication`, `deleteByApplication`, `getByNameForApplication`) | keepiq | exists, all four methods present |
| `Service\EncryptService::rsaEncrypt` | keepiq | exists |
| `Service\DecryptService::rsaDecrypt` | keepiq | exists |
| `Service\CallService::call()` | integriq | exists |
| `Service\ConfigurationService::exportRegister()` | integriq | exists |
| `Action\SynchronizationAction` | integriq | exists |
| `Db\SourceMapper` | integriq | **GONE — not repointed** |

## The site left stale on purpose

`lib/Service/Integration/ExternalIntegrationRouter.php:397` still names `OCA\OpenConnector\Db\SourceMapper`.

The connector **removed** that class. Its own `SynchronizationService` now reimplements `SourceMapper::findOrCreateByLocation()` over object storage, and its `IBabsConnectorServiceTest` records in a comment that "OR removed that class". There is no `lib/Db` in integriq at all, and no `SourceMapper` anywhere in the repo.

Correcting only the namespace would swap a lookup that misses for one that misses identically, while looking fixed. There is no obvious correct target: this needs a replacement seam against the connector's current source API, not a rename. Left in place with an inline comment recording what was read.

It is the least bad of the twenty-four anyway: it is the only one that fails **visibly**. The `get()` throws into a catch that raises `ProviderUnavailableException` with cause `openconnector-source-missing`, and the UI shows "Reconfigure connector".

## Two things worth flagging

**The detector hid this site.** Gate 114's dual-spelling exclusion tested the whole file for the successor name, so the explanatory comment I wrote naming `OCA\Integriq\Db\SourceMapper` switched off the finding for the still-stale line beneath it. The gate has since been scoped to the enclosing statement; under the corrected rule the residual is 1 and it is exactly this line.

**The clean-`development` baseline is 25, not 24.** The same whole-file exclusion was already hiding `DoriathApplicationRegistrar.php:164` (`isEnabledForUser('doriath')`), because that file's own phpcs annotation mentions `keepiq`. It is fixed here — found by reading, not by the gate.

**`src/main.js` fails loud, not silent.** `requiredApp` is read back by nc-vue as `isAppInstalled(requiredApp)` against `OC.appswebroots`, so the stale value rendered a visible "not installed" / "not configured" state over a working connector. The backend half is the same: `IntegrationsCapability` publishes `available` from `isEnabledForUser($requiredApp)`, and the OCS entry wins over the client-side fallback, so both halves had to move together. `getRequiredApp()` now returns the id the instance actually registered.

**One shape mismatch noted but not fixed.** `PdokGeocoder::request()` calls `$callService->call(null, …)`, and integriq's `CallService::call()` takes a non-nullable `ObjectEntity $source`. That is a separate defect from the rename — it needs a real source entity, not a name change — and it is caught by the surrounding `catch (Throwable)`, so it currently returns an empty geocoding result.

## Tests

Every fixed path asserts **both** directions, because a resolver that only handled the spelling a fixture happens to use looks perfectly correct against that fixture.

- `FleetAppIdTest`: namespace pairs asserted as literals (not derived); unmapped app returns null rather than a guess; `className()` follows the installed id and does not autoload; `resolveClass()` prefers the newest loadable spelling, with probe fixtures declared under both namespaces so the old-only case is genuinely exercised.
- `CredentialStoreResolverTest`: data-provider over `keepiq` and `doriath`, plus an unrelated id that must not satisfy the gate.
- `LeafProvidersMetadataTest`: `getRequiredApp()` returns `openconnector` on a beta/main instance and `integriq` on a migrated one.
- `ScheduleActionAllowListTest`: jobClass follows the installed id; the manifest-facing action **key** `openconnector:synchronization` is pinned unchanged, since leaf apps ship it in their own manifests and renaming it would un-allow-list every schedule already declared against it.

**Mutation-checked.** Reverting `CredentialStoreResolver` to the old literal reddens `testEitherCredentialAppIdSatisfiesTheGate[keepiq]` with its own message. On `OpenProjectProvider`, a hard swap to the new literal reddens the beta/main assertion and a revert to the old one reddens the renamed-instance assertion — each direction is guarded by a different test.

## Verification

| check | result |
|---|---|
| `composer lint` | exit 0 |
| `composer check:migration-version` | exit 0 |
| `composer phpcs` | exit 0 |
| `phpmd` (both rulesets) | exit 0 |
| `psalm` | exit 0, no errors |
| `phpstan` | exit 0, no errors |
| `phpunit tests/Unit` | exit 0, 19487 tests |
| `phpunit -c phpunit-integration-providers.xml` (`failOnRisky=true`) | exit 0, 304 tests |
| `eslint src tests scripts` | exit 0, 0 errors |
| `jest` | exit 0, 314 tests |
| gate 114 (corrected) | 25 → 1, the documented gap |

`composer test:all` exits 1 locally on "No code coverage driver available" only; with `--no-coverage` the same suite exits 0. `ScheduleActionAllowListTest` declares `\OCA\OpenRegister\Support\FleetAppId` in its `@covers` so the new static collaborator does not mark it risky under a coverage driver; it is the only touched test carrying coverage metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
