### PR TITLE
chore(gate-115): record the SourceMapper lookup as answered

### DIFF
--- a/lib/Service/Integration/ExternalIntegrationRouter.php
+++ b/lib/Service/Integration/ExternalIntegrationRouter.php
@@ -394,6 +394,15 @@ class ExternalIntegrationRouter {
 			// the catch below, which raises `openconnector-source-missing` and
 			// the UI shows "Reconfigure connector" — so this one at least
 			// fails visibly. It needs a real replacement seam, not a rename.
+			//
+			// @stale-fleet-app-id exclude integriq has no lib/Db/ at all. Re-verified
+			// 2026-09-10: ac47457f deleted SourceMapper with 14 other mapper and
+			// entity shims in the chain-C OpenRegister cutover, and no
+			// OCA\Integriq\Db\SourceMapper was ever added in its place. The only
+			// remaining mention in that repo is a docblock in
+			// SynchronizationService recording that it reimplements the legacy
+			// SourceMapper::findOrCreateByLocation() over object storage. Renaming
+			// the namespace swaps one missing class for another.
 			$mapper = $this->container->get('OCA\\OpenConnector\\Db\\SourceMapper');
 			$source = null;
 


### PR DESCRIPTION
## What

Nine lines of comment. No code changes.

`ExternalIntegrationRouter::loadSource()` asks the container for `OCA\OpenConnector\Db\SourceMapper`. Gate-115 (`stale-fleet-app-id`, shipped today in hydra-gates v1.17.0) reports it as a cross-app lookup naming a retired namespace. The comment beside the line already said why it is not repointed. This adds the machine-readable half, so the gate stops re-raising a question that has an answer.

## What was read

Re-verified 2026-09-10 against a clean `development` clone of integriq:

- integriq has no `lib/Db/` directory at all.
- `ac47457f` ("delete 14 mapper + entity shim files, chain-C cutover complete") removed `SourceMapper`, following `7df241bc` which deleted 15 entities and 15 mappers in the OpenRegister cutover.
- No `OCA\Integriq\Db\SourceMapper` was ever added in its place. The only remaining mention in that repo is a docblock in `SynchronizationService` recording that it reimplements the legacy `SourceMapper::findOrCreateByLocation()` over object storage.

## Why record rather than repoint

Renaming the namespace swaps one missing class for another, on a diff that reads to the next person as a fix already applied.

This is the least bad of the fleet's ten answered findings, because it is the only one that fails *visibly*: the `get()` throws into the catch below, which raises `openconnector-source-missing`, and the UI shows "Reconfigure connector" rather than a generic 500. It still needs a real replacement seam rather than a rename, and the marker records that so the next reader starts from what was already checked.

## How it is recorded

`@stale-fleet-app-id exclude <reason>`, the exclusion convention the rest of the hydra-gates suite already uses, with the reason graded by the shared `exclusion_reason.is_reason_bearing()`. Gate-115 learns to read it in ConductionNL/.github#738, which must merge first: CI resolves hydra-gates at `@main`.

Excluded findings are not hidden. The gate prints them under "recorded with a reason-bearing marker" on every run.

## Not in this PR

The two register-slug findings in `lib/AppHost/Scheduling/ScheduleReconciler.php` (`OC_REGISTER_SLUG = 'openconnector'`, `OB_REGISTER_SLUG = 'openbuild'`). Both slugs are live across the fleet depending on whether a given instance has run the rename repair, so those need a probe for the slug the register actually answers to, not a literal swap.

## Verification

Gate-115 on this branch: `0 cross-app lookup(s)`, `1 finding(s) recorded with a reason-bearing @stale-fleet-app-id exclude marker`, and the 2 slug findings unchanged. `php -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
