### PR TITLE
fix(facets): an object write invalidates the facet response derived from it

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -98,6 +98,7 @@ use OCA\OpenRegister\Listener\AuthorizationCacheInvalidationListener;
 use OCA\OpenRegister\Listener\CalculationOnSaveListener;
 use OCA\OpenRegister\Listener\CommentsEntityListener;
 use OCA\OpenRegister\Listener\ContextChatSubmissionListener;
+use OCA\OpenRegister\Listener\FacetCacheInvalidationListener;
 use OCA\OpenRegister\Listener\FileChangeListener;
 use OCA\OpenRegister\Listener\FilesSidebarListener;
 use OCA\OpenRegister\Listener\FlowEngineRegistrationListener;
@@ -2901,6 +2902,14 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(ObjectCreatedEvent::class, AggregationCacheInvalidationListener::class);
 		$context->registerEventListener(ObjectUpdatedEvent::class, AggregationCacheInvalidationListener::class);
 		$context->registerEventListener(ObjectDeletedEvent::class, AggregationCacheInvalidationListener::class);
+
+		// Facet freshness on every object write: bumps the counter for the written
+		// object's (register, schema) scope so the next facet read cannot serve a
+		// bucket list computed before the write (openregister#3560).
+		$context->registerEventListener(ObjectCreatedEvent::class, FacetCacheInvalidationListener::class);
+		$context->registerEventListener(ObjectUpdatedEvent::class, FacetCacheInvalidationListener::class);
+		$context->registerEventListener(ObjectDeletedEvent::class, FacetCacheInvalidationListener::class);
+		$context->registerEventListener(ObjectTransitionedEvent::class, FacetCacheInvalidationListener::class);
 
 		// Translation sidecar projection — keeps oc_openregister_translations in sync with JSONB property data.
 		$context->registerEventListener(ObjectCreatedEvent::class, TranslationProjectionListener::class);

--- a/lib/Listener/FacetCacheInvalidationListener.php
+++ b/lib/Listener/FacetCacheInvalidationListener.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * OpenRegister FacetCacheInvalidationListener
+ *
+ * Subscribes to ObjectCreatedEvent / ObjectUpdatedEvent / ObjectDeletedEvent /
+ * ObjectTransitionedEvent and bumps the FacetCacheVersion counter for the
+ * written object's scope, so the next facet read for that register and schema
+ * computes against fresh rows instead of serving an entry from the hour-long
+ * facet response cache (openregister#3560).
+ *
+ * The counter is bumped, never the cache cleared: the cached responses of every
+ * other scope keep hitting.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Listener
+ * @package  OCA\OpenRegister\Listener
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/faceting-configuration/spec.md#requirement-an-object-write-must-invalidate-the-facet-response-derived-from-it
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Listener;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Event\ObjectCreatedEvent;
+use OCA\OpenRegister\Event\ObjectDeletedEvent;
+use OCA\OpenRegister\Event\ObjectTransitionedEvent;
+use OCA\OpenRegister\Event\ObjectUpdatedEvent;
+use OCA\OpenRegister\Service\Object\FacetCacheVersion;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+
+/**
+ * Listener that makes an object write visible to the next facet read.
+ *
+ * @template-implements IEventListener<ObjectCreatedEvent|ObjectUpdatedEvent|ObjectDeletedEvent|ObjectTransitionedEvent>
+ */
+class FacetCacheInvalidationListener implements IEventListener {
+	/**
+	 * Wire the counter bumped on every object write.
+	 *
+	 * @param FacetCacheVersion $versions Per-scope facet freshness counter.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/faceting-configuration/spec.md#requirement-an-object-write-must-invalidate-the-facet-response-derived-from-it
+	 */
+	public function __construct(
+		private readonly FacetCacheVersion $versions,
+	) {
+	}//end __construct()
+
+	/**
+	 * Bump the facet freshness counter for the written object's scope.
+	 *
+	 * @param Event $event Inbound dispatcher event.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/faceting-configuration/spec.md#requirement-an-object-write-must-invalidate-the-facet-response-derived-from-it
+	 */
+	public function handle(Event $event): void {
+		$object = $this->extractObject(event: $event);
+		if ($object === null) {
+			return;
+		}
+
+		$this->versions->bump(
+			register: $object->getRegister(),
+			schema: $object->getSchema()
+		);
+	}//end handle()
+
+	/**
+	 * Resolve the underlying object for any of the supported event types.
+	 *
+	 * A delete event carries the object under getObject(); an update event
+	 * carries the post-write state under getNewObject(). Both are read, because
+	 * a facet is derived from whichever rows now exist.
+	 *
+	 * @param Event $event Inbound dispatcher event.
+	 *
+	 * @return ObjectEntity|null Object instance, or null when not resolvable.
+	 *
+	 * @spec openspec/specs/faceting-configuration/spec.md#requirement-an-object-write-must-invalidate-the-facet-response-derived-from-it
+	 */
+	private function extractObject(Event $event): ?ObjectEntity {
+		if ($event instanceof ObjectTransitionedEvent) {
+			return $event->getObject();
+		}
+
+		if (method_exists($event, 'getObject') === true) {
+			$obj = $event->getObject();
+			if ($obj instanceof ObjectEntity) {
+				return $obj;
+			}
+		}
+
+		if (method_exists($event, 'getNewObject') === true) {
+			$obj = $event->getNewObject();
+			if ($obj instanceof ObjectEntity) {
+				return $obj;
+			}
+		}
+
+		return null;
+	}//end extractObject()
+}//end class

--- a/lib/Service/Object/FacetCacheVersion.php
+++ b/lib/Service/Object/FacetCacheVersion.php
@@ -1,0 +1,346 @@
+<?php
+
+/**
+ * OpenRegister FacetCacheVersion
+ *
+ * Per-scope mutation counter that makes a cached facet response unreachable
+ * as soon as an object write lands in the scope the facet was derived from.
+ *
+ * The facet response cache in {@see FacetHandler} keys on the query, the facet
+ * config, the user and the organisation, and holds for an hour. Nothing in that
+ * key moves when an object is written, so the `facets` block beside a live
+ * `results` array could be an hour old (openregister#3560). A bucket list is a
+ * navigation control, so it may not lag: a folder pane offered a category whose
+ * rows were gone and hid the one just created.
+ *
+ * This counter is the freshness token folded into that key. It reuses the shape
+ * already proven by {@see \OCA\OpenRegister\Service\Aggregation\AggregationCache}
+ * (scope-cache-invalidation): a write bumps a per-scope integer, every key for
+ * that scope then carries the new integer, and the superseded entries become
+ * unreachable without wiping any other scope.
+ *
+ * It does NOT share AggregationCache's counter. That counter's safety rests on
+ * outliving the data it guards, and it is set with a TTL of one hour against a
+ * 60 second data TTL. The facet response TTL is itself an hour, so the same
+ * counter could expire back to zero while a superseded facet entry was still
+ * live, and a stale bucket list would become reachable again. This counter
+ * therefore lives in its own namespace and is written so it cannot expire before
+ * the data it invalidates.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Object
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/faceting-configuration/spec.md#requirement-an-object-write-must-invalidate-the-facet-response-derived-from-it
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Object;
+
+use OCP\ICache;
+use OCP\ICacheFactory;
+use OCP\IMemcache;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Mutation counter for the scopes a facet response can be derived from.
+ *
+ * Four scopes are tracked per write, from most to least specific:
+ *
+ *   - the (register, schema) pair the object belongs to;
+ *   - the schema alone, for a query that names schemas but no register;
+ *   - the register alone, for a query that names a register but no schema;
+ *   - a global counter, for a query that names neither.
+ *
+ * A reader picks the tightest scope its query actually names, so a write to one
+ * schema leaves every other schema's cached facets hitting. A query that names
+ * nothing falls back to the global counter and is therefore invalidated by any
+ * write anywhere, which is the only answer that cannot be wrong for a facet
+ * computed across the whole instance.
+ */
+class FacetCacheVersion {
+	/**
+	 * Cache namespace holding the counters.
+	 *
+	 * Deliberately NOT `openregister_facets`: the admin action at
+	 * `DELETE /api/settings/cache?type=facet` clears that namespace, and a
+	 * counter that resets alongside the data it guards is harmless only by
+	 * coincidence. Keeping them apart makes the ordering irrelevant.
+	 *
+	 * @var string
+	 */
+	public const CACHE_NAMESPACE = 'openregister_facet_versions';
+
+	/**
+	 * TTL for a counter written through the get/set fallback, in seconds (30 days).
+	 *
+	 * The invariant is that a counter outlives every facet entry it invalidates.
+	 * Facet entries hold for FacetHandler::FACET_CACHE_TTL (3600s), so 30 days
+	 * leaves three orders of magnitude of headroom. Backends implementing
+	 * IMemcache take the inc() path instead and never expire at all.
+	 *
+	 * @var int
+	 */
+	public const VERSION_TTL = 2592000;
+
+	/**
+	 * Ceiling on the (register, schema) pairs a single token may enumerate.
+	 *
+	 * Past this a query is treated as unscoped and reads the global counter.
+	 * A query naming dozens of schemas is a cross-collection search whose facet
+	 * is invalidated by almost any write anyway, so widening it costs nothing
+	 * and keeps the token from growing with the query.
+	 *
+	 * @var int
+	 */
+	private const MAX_ENUMERATED_PAIRS = 32;
+
+	/**
+	 * Distributed cache holding the counters, null when no backend is available.
+	 *
+	 * @var ICache|null
+	 */
+	private ?ICache $cache = null;
+
+	/**
+	 * Wire the counter store.
+	 *
+	 * @param ICacheFactory   $cacheFactory Factory used to create the distributed cache.
+	 * @param LoggerInterface $logger       Logger for backend-unavailable warnings.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/faceting-configuration/spec.md#requirement-an-object-write-must-invalidate-the-facet-response-derived-from-it
+	 */
+	public function __construct(
+		ICacheFactory $cacheFactory,
+		private readonly LoggerInterface $logger,
+	) {
+		try {
+			$this->cache = $cacheFactory->createDistributed(self::CACHE_NAMESPACE);
+		} catch (\Throwable $e) {
+			$this->logger->warning(
+				sprintf('[FacetCacheVersion] cache backend unavailable: %s', $e->getMessage())
+			);
+			$this->cache = null;
+		}
+	}//end __construct()
+
+	/**
+	 * Record that an object was written in a (register, schema) scope.
+	 *
+	 * Bumps every scope a facet response could have been derived from, so the
+	 * next read of any of them computes fresh. Cheap by construction: four
+	 * counter increments against the memcache, no database work, and no
+	 * enumeration of the keys being invalidated.
+	 *
+	 * @param string|null $register Register id the written object belongs to.
+	 * @param string|null $schema   Schema id the written object belongs to.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/faceting-configuration/spec.md#requirement-an-object-write-must-invalidate-the-facet-response-derived-from-it
+	 */
+	public function bump(?string $register, ?string $schema): void {
+		if ($this->cache === null) {
+			return;
+		}
+
+		foreach ($this->scopeKeysToBump(register: $register, schema: $schema) as $key) {
+			$this->increment(key: $key);
+		}
+	}//end bump()
+
+	/**
+	 * Current counter for one scope.
+	 *
+	 * A scope that has never been written to reads 0, so a cold instance keys
+	 * exactly as it did before this counter existed.
+	 *
+	 * @param string|null $register Register id, or null for a scope that does not name one.
+	 * @param string|null $schema   Schema id, or null for a scope that does not name one.
+	 *
+	 * @return int The current counter value.
+	 *
+	 * @spec openspec/specs/faceting-configuration/spec.md#requirement-an-object-write-must-invalidate-the-facet-response-derived-from-it
+	 */
+	public function version(?string $register, ?string $schema): int {
+		if ($this->cache === null) {
+			return 0;
+		}
+
+		try {
+			$current = $this->cache->get($this->scopeKey(register: $register, schema: $schema));
+		} catch (\Throwable $e) {
+			return 0;
+		}
+
+		if (is_numeric($current) === true) {
+			return (int)$current;
+		}
+
+		return 0;
+	}//end version()
+
+	/**
+	 * Freshness token for every scope a facet query can be answered from.
+	 *
+	 * The token is folded into the facet cache key. Two reads agree only while
+	 * no write has landed in any scope the query covers.
+	 *
+	 * @param array<int, string> $registers Register ids named by the query, empty when it names none.
+	 * @param array<int, string> $schemas   Schema ids named by the query, empty when it names none.
+	 *
+	 * @return string Opaque token, stable for as long as the covered scopes are unwritten.
+	 *
+	 * @spec openspec/specs/faceting-configuration/spec.md#requirement-an-object-write-must-invalidate-the-facet-response-derived-from-it
+	 */
+	public function tokenForScope(array $registers, array $schemas): string {
+		$parts = [];
+
+		foreach ($this->readScopes(registers: $registers, schemas: $schemas) as $scope) {
+			$parts[] = $scope[0] . '/' . $scope[1] . '=' . $this->version(register: $scope[0], schema: $scope[1]);
+		}
+
+		return implode(',', $parts);
+	}//end tokenForScope()
+
+	/**
+	 * Resolve the scopes a reader must consult for a query.
+	 *
+	 * @param array<int, string> $registers Register ids named by the query.
+	 * @param array<int, string> $schemas   Schema ids named by the query.
+	 *
+	 * @return array<int, array{0: string|null, 1: string|null}> Scope pairs to read.
+	 */
+	private function readScopes(array $registers, array $schemas): array {
+		$registers = array_values(array_unique(array_filter($registers, static fn ($value) => $value !== '')));
+		$schemas = array_values(array_unique(array_filter($schemas, static fn ($value) => $value !== '')));
+
+		if (empty($schemas) === true && empty($registers) === true) {
+			// Names neither: only the global counter can be right.
+			return [[null, null]];
+		}
+
+		if (empty($schemas) === true) {
+			// Names registers only: the schemas inside them are not knowable
+			// from the query, so read each register's own counter.
+			return array_map(static fn ($register) => [$register, null], $registers);
+		}
+
+		if (empty($registers) === true) {
+			// Names schemas only, across any register.
+			return array_map(static fn ($schema) => [null, $schema], $schemas);
+		}
+
+		if ((count($registers) * count($schemas)) > self::MAX_ENUMERATED_PAIRS) {
+			return [[null, null]];
+		}
+
+		$scopes = [];
+		foreach ($registers as $register) {
+			foreach ($schemas as $schema) {
+				$scopes[] = [$register, $schema];
+			}
+		}
+
+		return $scopes;
+	}//end readScopes()
+
+	/**
+	 * The scope keys a single object write must bump.
+	 *
+	 * @param string|null $register Register id of the written object.
+	 * @param string|null $schema   Schema id of the written object.
+	 *
+	 * @return array<int, string> Cache keys.
+	 */
+	private function scopeKeysToBump(?string $register, ?string $schema): array {
+		$keys = [$this->scopeKey(register: null, schema: null)];
+
+		if ($schema !== null && $schema !== '') {
+			$keys[] = $this->scopeKey(register: null, schema: $schema);
+		}
+
+		if ($register !== null && $register !== '') {
+			$keys[] = $this->scopeKey(register: $register, schema: null);
+		}
+
+		if ($register !== null && $register !== '' && $schema !== null && $schema !== '') {
+			$keys[] = $this->scopeKey(register: $register, schema: $schema);
+		}
+
+		return $keys;
+	}//end scopeKeysToBump()
+
+	/**
+	 * Cache key for one scope.
+	 *
+	 * @param string|null $register Register id, or null.
+	 * @param string|null $schema   Schema id, or null.
+	 *
+	 * @return string Cache key.
+	 */
+	private function scopeKey(?string $register, ?string $schema): string {
+		$registerPart = '*';
+		if ($register !== null && $register !== '') {
+			$registerPart = $register;
+		}
+
+		$schemaPart = '*';
+		if ($schema !== null && $schema !== '') {
+			$schemaPart = $schema;
+		}
+
+		return sprintf('facetver:r%s:s%s', $registerPart, $schemaPart);
+	}//end scopeKey()
+
+	/**
+	 * Increase one counter by one.
+	 *
+	 * Prefers IMemcache::inc(), which is atomic, so two concurrent writes cannot
+	 * lose a bump between them. Falls back to read-modify-write with an explicit
+	 * long TTL for a backend that offers no atomic increment. A lost bump under
+	 * the fallback still changes the counter, so a write is still invalidating;
+	 * only the ordering of two simultaneous writes is unobservable.
+	 *
+	 * @param string $key Cache key to increase.
+	 *
+	 * @return void
+	 */
+	private function increment(string $key): void {
+		try {
+			if ($this->cache instanceof IMemcache) {
+				$result = $this->cache->inc($key);
+				if ($result !== false) {
+					return;
+				}
+			}
+
+			$current = $this->cache->get($key);
+			$next = 1;
+			if (is_numeric($current) === true) {
+				$next = ((int)$current + 1);
+			}
+
+			$this->cache->set($key, $next, self::VERSION_TTL);
+		} catch (\Throwable $e) {
+			// A counter that cannot be written leaves the TTL as the only
+			// bound, which is where this started. Say so rather than pass.
+			$this->logger->warning(
+				sprintf('[FacetCacheVersion] could not bump %s: %s', $key, $e->getMessage())
+			);
+		}//end try
+	}//end increment()
+}//end class

--- a/lib/Service/Object/FacetCacheVersion.php
+++ b/lib/Service/Object/FacetCacheVersion.php
@@ -114,6 +114,20 @@ class FacetCacheVersion {
 	private ?ICache $cache = null;
 
 	/**
+	 * Scope keys already bumped during this request.
+	 *
+	 * A bump makes every entry written BEFORE it unreachable, so a second bump of
+	 * the same key with no read in between changes nothing. Skipping it turns a
+	 * thousand-object import into four increments instead of four thousand.
+	 *
+	 * Any read clears this, because a read may have written a fresh entry that a
+	 * later write in the same request must still invalidate.
+	 *
+	 * @var array<string, true>
+	 */
+	private array $bumpedThisRequest = [];
+
+	/**
 	 * Wire the counter store.
 	 *
 	 * @param ICacheFactory   $cacheFactory Factory used to create the distributed cache.
@@ -158,7 +172,12 @@ class FacetCacheVersion {
 		}
 
 		foreach ($this->scopeKeysToBump(register: $register, schema: $schema) as $key) {
+			if (isset($this->bumpedThisRequest[$key]) === true) {
+				continue;
+			}
+
 			$this->increment(key: $key);
+			$this->bumpedThisRequest[$key] = true;
 		}
 	}//end bump()
 
@@ -176,6 +195,10 @@ class FacetCacheVersion {
 	 * @spec openspec/specs/faceting-configuration/spec.md#requirement-an-object-write-must-invalidate-the-facet-response-derived-from-it
 	 */
 	public function version(?string $register, ?string $schema): int {
+		// A read may cache a response keyed on what it reads here, so a later
+		// write in this same request has to bump again even if it already did.
+		$this->bumpedThisRequest = [];
+
 		if ($this->cache === null) {
 			return 0;
 		}

--- a/lib/Service/Object/FacetHandler.php
+++ b/lib/Service/Object/FacetHandler.php
@@ -72,8 +72,11 @@ class FacetHandler {
 	/**
 	 * Cache TTL for facet responses (1 hour).
 	 *
-	 * Facet counts don't need real-time accuracy - slight staleness is acceptable.
-	 * Cache is invalidated when schemas change.
+	 * This TTL is the CEILING on staleness, not the invalidation. A cached entry
+	 * is unreachable as soon as an object write bumps the freshness token folded
+	 * into its key (see FacetCacheVersion). It used to be the only invalidation
+	 * besides a schema change and an admin cache flush, which is how a folder pane
+	 * came to offer a category nobody had (openregister#3560).
 	 *
 	 * @var int
 	 */
@@ -103,6 +106,7 @@ class FacetHandler {
 	 * @param ICacheFactory $cacheFactory Cache factory for distributed caching.
 	 * @param IUserSession $userSession User session for tenant isolation.
 	 * @param LoggerInterface $logger Logger for debugging and monitoring.
+	 * @param FacetCacheVersion $facetCacheVersion Per-scope freshness counter folded into the response cache key.
 	 *
 	 * @return void
 	 *
@@ -119,6 +123,7 @@ class FacetHandler {
 		private readonly ICacheFactory $cacheFactory,
 		private readonly IUserSession $userSession,
 		private readonly LoggerInterface $logger,
+		private readonly FacetCacheVersion $facetCacheVersion,
 	) {
 		// Initialize facet response caching.
 		try {
@@ -969,10 +974,99 @@ class FacetHandler {
 			'org' => $orgId,
 			'version' => '2.0',
 			// Increment to invalidate when RBAC logic changes.
+			// **FRESHNESS**: an object write bumps the counter for its (register,
+			// schema) scope, which changes this token, which changes the key. So a
+			// facet computed before the write is unreachable after it, and the
+			// bucket list beside a live `results` array can no longer be an hour
+			// old (openregister#3560). Without this the only invalidation was the
+			// TTL, a schema change, or an admin cache flush.
+			'freshness' => $this->facetFreshnessToken(facetQuery: $facetQuery),
 		];
 
 		return 'facet_rbac_' . md5(json_encode($cacheData));
 	}//end generateFacetCacheKey()
+
+	/**
+	 * Freshness token for the scopes this facet query reads from.
+	 *
+	 * The scope is taken from the query itself, which already carries numeric
+	 * register and schema ids by the time faceting runs (the numeric-ID contract
+	 * on ObjectService::searchObjects; ObjectsController resolves the slugs in the
+	 * URL before building the query). Those are the same ids ObjectEntity stores,
+	 * so the counter a write bumps is the counter this read consults. Deriving the
+	 * scope from the query costs no database work, which matters because the whole
+	 * point of the cache is to avoid the aggregation underneath it.
+	 *
+	 * @param array $facetQuery Query for faceting (without pagination).
+	 *
+	 * @psalm-param   array<string, mixed> $facetQuery
+	 * @phpstan-param array<string, mixed> $facetQuery
+	 *
+	 * @return string Token that changes when any covered scope is written to.
+	 *
+	 * @spec openspec/specs/faceting-configuration/spec.md#requirement-an-object-write-must-invalidate-the-facet-response-derived-from-it
+	 */
+	private function facetFreshnessToken(array $facetQuery): string {
+		$registers = $this->scopeIdsFromQuery(
+			values: [
+				($facetQuery['@self']['registers'] ?? null),
+				($facetQuery['@self']['register'] ?? null),
+				($facetQuery['_registers'] ?? null),
+			]
+		);
+
+		$schemas = $this->scopeIdsFromQuery(
+			values: [
+				($facetQuery['@self']['schemas'] ?? null),
+				($facetQuery['@self']['schema'] ?? null),
+				($facetQuery['_schemas'] ?? null),
+			]
+		);
+
+		return $this->facetCacheVersion->tokenForScope(registers: $registers, schemas: $schemas);
+	}//end facetFreshnessToken()
+
+	/**
+	 * Flatten the register/schema positions of a query into a list of id strings.
+	 *
+	 * Each position may be absent, a scalar id, or a list of ids. Anything that is
+	 * not a scalar is dropped rather than guessed: an unrecognised shape widens the
+	 * scope to the global counter, which over-invalidates but never under-invalidates.
+	 *
+	 * @param array $values Candidate values from the query, most specific first.
+	 *
+	 * @psalm-param   array<int, mixed> $values
+	 * @phpstan-param array<int, mixed> $values
+	 *
+	 * @return array<int, string> Distinct id strings, possibly empty.
+	 *
+	 * @spec openspec/specs/faceting-configuration/spec.md#requirement-an-object-write-must-invalidate-the-facet-response-derived-from-it
+	 */
+	private function scopeIdsFromQuery(array $values): array {
+		$ids = [];
+
+		foreach ($values as $value) {
+			if ($value === null) {
+				continue;
+			}
+
+			$candidates = [$value];
+			if (is_array($value) === true) {
+				$candidates = $value;
+			}
+
+			foreach ($candidates as $candidate) {
+				if (is_int($candidate) === true || is_string($candidate) === true) {
+					$candidate = (string)$candidate;
+					if ($candidate !== '') {
+						$ids[] = $candidate;
+					}
+				}
+			}
+		}
+
+		return array_values(array_unique($ids));
+	}//end scopeIdsFromQuery()
 
 	/**
 	 * Get cached facet response.

--- a/openspec/specs/faceting-configuration/spec.md
+++ b/openspec/specs/faceting-configuration/spec.md
@@ -223,7 +223,7 @@ The faceting system MUST operate transparently across database backends (Postgre
 - **AND** bucket counts from both tables MUST be merged into aggregated totals
 
 ### Requirement: Multi-layered facet caching
-The system MUST implement caching at three levels to minimize redundant computation. (1) **Response cache**: `FacetHandler` MUST cache complete facet responses in distributed/local memory (`ICacheFactory`) with 1-hour TTL, keyed by RBAC-aware hashes including user ID, organisation, filters, and facet config. (2) **Schema facet cache**: `FacetCacheHandler` MUST persistently cache facet configurations per schema in the `openregister_schema_facet_cache` database table with configurable TTL (default 30 minutes, max 8 hours). (3) **In-memory label cache**: `MagicFacetHandler` MUST cache UUID-to-label mappings per request and in a distributed label cache (`openregister_facet_labels`) with 24-hour TTL. Cache MUST be invalidated when schemas are updated via `FacetCacheHandler.invalidateForSchemaChange()`.
+The system MUST implement caching at three levels to minimize redundant computation. (1) **Response cache**: `FacetHandler` MUST cache complete facet responses in distributed/local memory (`ICacheFactory`) with 1-hour TTL, keyed by RBAC-aware hashes including user ID, organisation, filters, and facet config. (2) **Schema facet cache**: `FacetCacheHandler` MUST persistently cache facet configurations per schema in the `openregister_schema_facet_cache` database table with configurable TTL (default 30 minutes, max 8 hours). (3) **In-memory label cache**: `MagicFacetHandler` MUST cache UUID-to-label mappings per request and in a distributed label cache (`openregister_facet_labels`) with 24-hour TTL. Cache MUST be invalidated when schemas are updated via `FacetCacheHandler.invalidateForSchemaChange()`, and the response cache key MUST additionally carry the per-(register, schema) freshness token described under "An object write MUST invalidate the facet response derived from it", so the 1-hour TTL bounds staleness rather than defining it.
 
 #### Scenario: Response cache hit returns cached facets instantly
 - **GIVEN** a facet query was executed 5 minutes ago for the same user, organisation, and filters
@@ -622,6 +622,54 @@ collapse invalidation to one call per distinct affected bucket.
 - **WHEN** a bulk delete spans three schemas
 - **THEN** invalidation is issued once per affected schema bucket
 - **AND** the whole cache is not cleared three times
+
+### Requirement: An object write MUST invalidate the facet response derived from it
+
+The facet response cache SHALL carry a freshness token for the (register, schema)
+scopes the query reads from, and an object write SHALL move that token. A facet
+response computed before a write SHALL NOT be served after it.
+
+The invariant is narrower than the TTL and narrower than a count. A count may lag;
+a bucket list may not, because a bucket list is offered to the reader as a place to
+go. `CnFolderSidebar` builds an index page's folder pane from it and `CnFacetSidebar`
+builds the filter list from it, so a stale bucket hides a value that exists and
+offers one that does not.
+
+Invalidation SHALL remain scoped. A write to one schema SHALL leave every other
+scope's cached facet responses reachable, and SHALL NOT clear the facet cache.
+
+#### Scenario: A value created now has a bucket now
+
+- **GIVEN** a facet response for a register and schema is cached
+- **WHEN** an object is created in that register and schema carrying a new value
+  for a facetable field
+- **THEN** the next facet read for that register and schema reports a bucket for
+  that value
+- **AND** no administrator action and no TTL expiry is required first
+
+#### Scenario: An emptied value loses its bucket
+
+- **WHEN** the last object carrying a facetable value is deleted
+- **THEN** the next facet read no longer offers that value as a bucket
+
+#### Scenario: A write to another schema costs no recomputation
+
+- **GIVEN** facet responses for schema A and schema B are cached
+- **WHEN** an object in schema B is written
+- **THEN** the next facet read for schema A is still served from cache
+- **AND** the facet aggregation for schema A is not recomputed
+
+#### Scenario: Two requests differing only by sort order agree
+
+- **GIVEN** two facet requests over the same rows that differ only in `_order`
+- **WHEN** both are answered at the same instant
+- **THEN** both report the same bucket list
+
+#### Scenario: A facet computed across every schema follows any write
+
+- **GIVEN** a facet query that names neither a register nor a schema
+- **WHEN** an object is written in any register and schema
+- **THEN** the next read of that query recomputes
 
 ### Requirement: Schemas are cached by a single tier
 

--- a/tests/Unit/Listener/FacetCacheInvalidationListenerTest.php
+++ b/tests/Unit/Listener/FacetCacheInvalidationListenerTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * OpenRegister FacetCacheInvalidationListenerTest
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Listener
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Listener;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Event\ObjectCreatedEvent;
+use OCA\OpenRegister\Event\ObjectDeletedEvent;
+use OCA\OpenRegister\Event\ObjectUpdatedEvent;
+use OCA\OpenRegister\Listener\FacetCacheInvalidationListener;
+use OCA\OpenRegister\Service\Object\FacetCacheVersion;
+use OCP\EventDispatcher\Event;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Every object-write event must reach the freshness counter.
+ *
+ * The wiring between an event and the counter is the part that can quietly
+ * not exist: a listener that receives the event and bumps nothing produces
+ * exactly the behaviour openregister#3560 describes, and no error.
+ */
+final class FacetCacheInvalidationListenerTest extends TestCase {
+	private FacetCacheVersion&MockObject $versions;
+
+	private FacetCacheInvalidationListener $listener;
+
+	/**
+	 * Build the listener over a mocked counter.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->versions = $this->createMock(FacetCacheVersion::class);
+		$this->listener = new FacetCacheInvalidationListener($this->versions);
+	}//end setUp()
+
+	/**
+	 * A created object bumps its own scope.
+	 *
+	 * @return void
+	 */
+	public function testACreateBumpsTheWrittenScope(): void {
+		$this->versions->expects($this->once())->method('bump')->with('7', '42');
+
+		$this->listener->handle(new ObjectCreatedEvent($this->object('7', '42')));
+	}//end testACreateBumpsTheWrittenScope()
+
+	/**
+	 * An updated object bumps its own scope.
+	 *
+	 * @return void
+	 */
+	public function testAnUpdateBumpsTheWrittenScope(): void {
+		$this->versions->expects($this->once())->method('bump')->with('7', '42');
+
+		$this->listener->handle(new ObjectUpdatedEvent($this->object('7', '42')));
+	}//end testAnUpdateBumpsTheWrittenScope()
+
+	/**
+	 * A deleted object bumps its own scope.
+	 *
+	 * The emptied bucket is half the reported defect: a category whose last row
+	 * is gone must stop being offered as a place to go.
+	 *
+	 * @return void
+	 */
+	public function testADeleteBumpsTheWrittenScope(): void {
+		$this->versions->expects($this->once())->method('bump')->with('7', '42');
+
+		$this->listener->handle(new ObjectDeletedEvent($this->object('7', '42')));
+	}//end testADeleteBumpsTheWrittenScope()
+
+	/**
+	 * An event carrying no object bumps nothing.
+	 *
+	 * @return void
+	 */
+	public function testAnUnrelatedEventBumpsNothing(): void {
+		$this->versions->expects($this->never())->method('bump');
+
+		$this->listener->handle(new class extends Event {
+		});
+	}//end testAnUnrelatedEventBumpsNothing()
+
+	/**
+	 * Build an object entity in a given scope.
+	 *
+	 * @param string $register Register id.
+	 * @param string $schema   Schema id.
+	 *
+	 * @return ObjectEntity The entity.
+	 */
+	private function object(string $register, string $schema): ObjectEntity {
+		$object = new ObjectEntity();
+		$object->setRegister($register);
+		$object->setSchema($schema);
+
+		return $object;
+	}//end object()
+}//end class

--- a/tests/Unit/Service/Object/FacetCacheVersionTest.php
+++ b/tests/Unit/Service/Object/FacetCacheVersionTest.php
@@ -201,6 +201,47 @@ final class FacetCacheVersionTest extends TestCase {
 	}//end testOneWriteCostsFourCounterIncrementsAndNothingElse()
 
 	/**
+	 * A bulk import pays for its scope once, not once per object.
+	 *
+	 * A thousand-object import into one schema dispatches a thousand write
+	 * events. Repeating a bump with no read in between changes nothing, so the
+	 * repeats are skipped.
+	 *
+	 * @return void
+	 */
+	public function testRepeatedWritesToOneScopeInOneRequestBumpOnce(): void {
+		$this->cache->writes = 0;
+
+		for ($i = 0; $i < 100; $i++) {
+			$this->versions->bump('7', '42');
+		}
+
+		$this->assertSame(4, $this->cache->writes, '100 writes into one scope cost 4 increments');
+	}//end testRepeatedWritesToOneScopeInOneRequestBumpOnce()
+
+	/**
+	 * A read between two writes forces the second write to bump again.
+	 *
+	 * The read may have cached a response keyed on the counter it just read, and
+	 * only a further bump can make that response unreachable. Skipping the second
+	 * bump here would reintroduce the defect inside a single request.
+	 *
+	 * @return void
+	 */
+	public function testAReadBetweenTwoWritesMakesTheSecondWriteBumpAgain(): void {
+		$this->versions->bump('7', '42');
+		$afterFirst = $this->versions->tokenForScope(['7'], ['42']);
+
+		$this->versions->bump('7', '42');
+
+		$this->assertNotSame(
+			$afterFirst,
+			$this->versions->tokenForScope(['7'], ['42']),
+			'a write after a read must still invalidate what that read cached'
+		);
+	}//end testAReadBetweenTwoWritesMakesTheSecondWriteBumpAgain()
+
+	/**
 	 * A backend without atomic increment still records a bump, with headroom.
 	 *
 	 * The fallback writes an explicit TTL. It has to outlive the facet entries

--- a/tests/Unit/Service/Object/FacetCacheVersionTest.php
+++ b/tests/Unit/Service/Object/FacetCacheVersionTest.php
@@ -1,0 +1,229 @@
+<?php
+
+/**
+ * OpenRegister FacetCacheVersionTest
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Object
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Object;
+
+use OCA\OpenRegister\Service\Object\FacetCacheVersion;
+use OCA\OpenRegister\Tests\Unit\Support\FakeMemcache;
+use OCA\OpenRegister\Tests\Unit\Support\PlainFakeCache;
+use OCP\ICacheFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Scoping rules of the facet freshness counter.
+ *
+ * The counter decides how wide an object write reaches. Too narrow and a stale
+ * bucket list survives the write that changed it; too wide and every index page
+ * in the fleet recomputes on every write in the fleet. These tests pin both edges.
+ */
+final class FacetCacheVersionTest extends TestCase {
+	private FakeMemcache $cache;
+
+	private FacetCacheVersion $versions;
+
+	/**
+	 * Build the counter over an in-memory cache.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->cache = new FakeMemcache();
+		$cacheFactory = $this->createMock(ICacheFactory::class);
+		$cacheFactory->method('createDistributed')->willReturn($this->cache);
+
+		$this->versions = new FacetCacheVersion($cacheFactory, $this->createMock(LoggerInterface::class));
+	}//end setUp()
+
+	/**
+	 * A cold instance keys exactly as it did before the counter existed.
+	 *
+	 * @return void
+	 */
+	public function testAnUnwrittenScopeReadsAsZero(): void {
+		$this->assertSame(0, $this->versions->version('7', '42'));
+		$this->assertSame(0, $this->versions->version(null, null));
+	}//end testAnUnwrittenScopeReadsAsZero()
+
+	/**
+	 * A write moves the token of the scope it landed in.
+	 *
+	 * @return void
+	 */
+	public function testAWriteMovesTheTokenOfItsOwnScope(): void {
+		$before = $this->versions->tokenForScope(['7'], ['42']);
+
+		$this->versions->bump('7', '42');
+
+		$this->assertNotSame(
+			$before,
+			$this->versions->tokenForScope(['7'], ['42']),
+			'the scope written to must produce a different token'
+		);
+	}//end testAWriteMovesTheTokenOfItsOwnScope()
+
+	/**
+	 * A write leaves every other scope's token alone.
+	 *
+	 * This is the whole reason the counter is per scope rather than a flush.
+	 *
+	 * @return void
+	 */
+	public function testAWriteLeavesOtherScopesUntouched(): void {
+		$otherSchema = $this->versions->tokenForScope(['7'], ['43']);
+		$otherRegister = $this->versions->tokenForScope(['8'], ['42']);
+
+		$this->versions->bump('7', '42');
+
+		$this->assertSame($otherSchema, $this->versions->tokenForScope(['7'], ['43']));
+		$this->assertSame($otherRegister, $this->versions->tokenForScope(['8'], ['42']));
+	}//end testAWriteLeavesOtherScopesUntouched()
+
+	/**
+	 * A query naming schemas but no register still sees writes to those schemas.
+	 *
+	 * Multi-schema publication queries arrive this way, and they must not be
+	 * left on the TTL just because the register is implicit.
+	 *
+	 * @return void
+	 */
+	public function testASchemaOnlyQuerySeesAWriteToThatSchemaInAnyRegister(): void {
+		$before = $this->versions->tokenForScope([], ['42']);
+		$otherSchemaBefore = $this->versions->tokenForScope([], ['43']);
+
+		$this->versions->bump('7', '42');
+
+		$this->assertNotSame($before, $this->versions->tokenForScope([], ['42']));
+		$this->assertSame(
+			$otherSchemaBefore,
+			$this->versions->tokenForScope([], ['43']),
+			'a schema-only query for a different schema is unaffected'
+		);
+	}//end testASchemaOnlyQuerySeesAWriteToThatSchemaInAnyRegister()
+
+	/**
+	 * A query naming a register but no schema sees writes anywhere in it.
+	 *
+	 * @return void
+	 */
+	public function testARegisterOnlyQuerySeesAWriteToAnySchemaInThatRegister(): void {
+		$before = $this->versions->tokenForScope(['7'], []);
+		$otherRegisterBefore = $this->versions->tokenForScope(['8'], []);
+
+		$this->versions->bump('7', '42');
+
+		$this->assertNotSame($before, $this->versions->tokenForScope(['7'], []));
+		$this->assertSame(
+			$otherRegisterBefore,
+			$this->versions->tokenForScope(['8'], []),
+			'a register nobody wrote to keeps its token'
+		);
+	}//end testARegisterOnlyQuerySeesAWriteToAnySchemaInThatRegister()
+
+	/**
+	 * A query naming nothing is answered from everything, so any write moves it.
+	 *
+	 * @return void
+	 */
+	public function testAnUnscopedQuerySeesEveryWrite(): void {
+		$before = $this->versions->tokenForScope([], []);
+
+		$this->versions->bump('99', '999');
+
+		$this->assertNotSame($before, $this->versions->tokenForScope([], []));
+	}//end testAnUnscopedQuerySeesEveryWrite()
+
+	/**
+	 * A query spanning more pairs than the ceiling widens to the global counter.
+	 *
+	 * The token must not grow with the query: a cross-collection search is
+	 * invalidated by almost any write anyway.
+	 *
+	 * @return void
+	 */
+	public function testAVeryWideQueryFallsBackToTheGlobalCounter(): void {
+		$registers = array_map('strval', range(1, 10));
+		$schemas = array_map('strval', range(100, 109));
+
+		$wide = $this->versions->tokenForScope($registers, $schemas);
+
+		$this->assertSame(
+			$this->versions->tokenForScope([], []),
+			$wide,
+			'100 pairs is past the ceiling, so the token is the global one'
+		);
+
+		$this->versions->bump('1', '100');
+
+		$this->assertSame(
+			$this->versions->tokenForScope([], []),
+			$this->versions->tokenForScope($registers, $schemas),
+			'and it stays the global one after a write'
+		);
+		$this->assertNotSame($wide, $this->versions->tokenForScope($registers, $schemas));
+	}//end testAVeryWideQueryFallsBackToTheGlobalCounter()
+
+	/**
+	 * One write costs four counter increments, and no read of the data cache.
+	 *
+	 * The cost of invalidation is the thing that decides whether this fix is
+	 * worth having, so it is asserted rather than described.
+	 *
+	 * @return void
+	 */
+	public function testOneWriteCostsFourCounterIncrementsAndNothingElse(): void {
+		$this->cache->reads = 0;
+		$this->cache->writes = 0;
+
+		$this->versions->bump('7', '42');
+
+		$this->assertSame(4, $this->cache->writes, 'pair, schema, register and global');
+		$this->assertSame(0, $this->cache->reads, 'an atomic increment reads nothing back');
+	}//end testOneWriteCostsFourCounterIncrementsAndNothingElse()
+
+	/**
+	 * A backend without atomic increment still records a bump, with headroom.
+	 *
+	 * The fallback writes an explicit TTL. It has to outlive the facet entries
+	 * it invalidates, or a counter could expire back to zero while a superseded
+	 * facet response was still live and reachable again.
+	 *
+	 * @return void
+	 */
+	public function testTheFallbackCounterOutlivesTheFacetEntriesItInvalidates(): void {
+		$plainCache = new PlainFakeCache();
+		$cacheFactory = $this->createMock(ICacheFactory::class);
+		$cacheFactory->method('createDistributed')->willReturn($plainCache);
+
+		$versions = new FacetCacheVersion($cacheFactory, $this->createMock(LoggerInterface::class));
+
+		$before = $versions->tokenForScope(['7'], ['42']);
+		$versions->bump('7', '42');
+
+		$this->assertNotSame($before, $versions->tokenForScope(['7'], ['42']));
+		$this->assertGreaterThan(
+			3600,
+			$plainCache->lastTtl,
+			'the counter must outlive FacetHandler::FACET_CACHE_TTL'
+		);
+	}//end testTheFallbackCounterOutlivesTheFacetEntriesItInvalidates()
+}//end class

--- a/tests/Unit/Service/Object/FacetFreshnessTest.php
+++ b/tests/Unit/Service/Object/FacetFreshnessTest.php
@@ -1,0 +1,356 @@
+<?php
+
+/**
+ * OpenRegister FacetFreshnessTest
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Object
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Object;
+
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Event\ObjectCreatedEvent;
+use OCA\OpenRegister\Listener\FacetCacheInvalidationListener;
+use OCA\OpenRegister\Service\Object\FacetCacheVersion;
+use OCA\OpenRegister\Service\Object\FacetHandler;
+use OCA\OpenRegister\Tests\Unit\Support\FakeMemcache;
+use OCP\ICacheFactory;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * A write must be visible in the next facet read.
+ *
+ * openregister#3560: `FacetHandler::getFacetsForObjects()` cached the whole
+ * facet response for an hour under a key that no object write moved, so a
+ * response could carry a live `results` array beside an hour-old `facets`
+ * block. `CnFolderSidebar` builds a folder pane from that block, so an
+ * administrator who gave a case type a new category got no folder for it
+ * until the hour was out, and was still offered the category they had emptied.
+ *
+ * ⚠️ THIS FILE ASSERTS FRESHNESS, NOT CLEARABILITY. A test that only proved
+ * the cache CAN be cleared would pass against the broken build, because the
+ * broken build could already be cleared: `DELETE /api/settings/cache?type=facet`
+ * did exactly that, and a schema change did it too. The failure was that
+ * nothing did it on a write. So every assertion here reads a facet through the
+ * public entry point after a write and requires the NEW bucket list, and the
+ * counterpart assertions require an unrelated write to leave the cache HITTING
+ * (`testAWriteToAnotherSchemaLeavesThisSchemaServingFromCache`), because a fix
+ * that invalidates everything turns a caching layer into a cost centre.
+ */
+final class FacetFreshnessTest extends TestCase {
+	/**
+	 * Register id used by the query and by the written object.
+	 *
+	 * @var string
+	 */
+	private const REGISTER = '7';
+
+	/**
+	 * Schema id used by the query and by the written object.
+	 *
+	 * @var string
+	 */
+	private const SCHEMA = '42';
+
+	/**
+	 * The bucket list before the write.
+	 *
+	 * @var array<int, string>
+	 */
+	private const BEFORE = ['E2EZAAK-mttundof-1644 Vergunningen'];
+
+	/**
+	 * The bucket list after the write.
+	 *
+	 * @var array<int, string>
+	 */
+	private const AFTER = ['E2EZAAK-mttundof-1644 Vergunningen', 'ZZTEMP Probe Two'];
+
+	private FakeMemcache $facetCache;
+
+	private FakeMemcache $versionCache;
+
+	private MagicMapper&MockObject $mapper;
+
+	private FacetCacheVersion $versions;
+
+	private FacetHandler $handler;
+
+	/**
+	 * Build a FacetHandler over two in-memory caches and a mapper whose facet
+	 * result changes once, standing in for the row that was written.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->facetCache = new FakeMemcache();
+		$this->versionCache = new FakeMemcache();
+
+		$cacheFactory = $this->createMock(ICacheFactory::class);
+		$cacheFactory->method('createDistributed')->willReturnCallback(
+			function (string $namespace) {
+				if ($namespace === FacetCacheVersion::CACHE_NAMESPACE) {
+					return $this->versionCache;
+				}
+
+				return $this->facetCache;
+			}
+		);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('admin');
+		$userSession = $this->createMock(IUserSession::class);
+		$userSession->method('getUser')->willReturn($user);
+
+		$logger = $this->createMock(LoggerInterface::class);
+
+		$schemaMapper = $this->createMock(SchemaMapper::class);
+		$schemaMapper->method('find')->willThrowException(new \Exception('no schema in this unit test'));
+		$schemaMapper->method('findMultiple')->willReturn([]);
+		$schemaMapper->method('findAll')->willReturn([]);
+
+		$this->mapper = $this->createMock(MagicMapper::class);
+
+		$this->versions = new FacetCacheVersion($cacheFactory, $logger);
+
+		$this->handler = new FacetHandler(
+			$this->mapper,
+			$schemaMapper,
+			$cacheFactory,
+			$userSession,
+			$logger,
+			$this->versions
+		);
+	}//end setUp()
+
+	/**
+	 * A category created now must have a bucket now, not in an hour.
+	 *
+	 * @return void
+	 */
+	public function testAnObjectWriteIsVisibleInTheNextFacetRead(): void {
+		$this->mapperReturns(self::BEFORE, self::AFTER);
+
+		// The read that warms the cache.
+		$this->assertSame(
+			self::BEFORE,
+			$this->readCategoryBuckets(),
+			'sanity: the first read reports the buckets the mapper computed'
+		);
+
+		// No write yet, so this read MUST come from cache: if it recomputed,
+		// the test below could pass without any invalidation at all.
+		$this->assertSame(
+			self::BEFORE,
+			$this->readCategoryBuckets(),
+			'a repeated read with no write in between must still be served from cache'
+		);
+		$this->assertSame(
+			1,
+			$this->mapperCalls,
+			'the cache must have absorbed the second read, or this test proves nothing'
+		);
+
+		// The write an administrator makes when they give a case type a new category.
+		$this->writeObject(register: self::REGISTER, schema: self::SCHEMA);
+
+		$this->assertSame(
+			self::AFTER,
+			$this->readCategoryBuckets(),
+			'the next facet read after a write must carry the bucket that write created'
+		);
+	}//end testAnObjectWriteIsVisibleInTheNextFacetRead()
+
+	/**
+	 * The other half of the bargain: a write elsewhere must not cost a recompute.
+	 *
+	 * Facets exist because computing them is expensive. An invalidation that
+	 * fires on every write anywhere would make every index page in the fleet
+	 * recompute on every write in the fleet.
+	 *
+	 * @return void
+	 */
+	public function testAWriteToAnotherSchemaLeavesThisSchemaServingFromCache(): void {
+		$this->mapperReturns(self::BEFORE, self::AFTER);
+
+		$this->assertSame(self::BEFORE, $this->readCategoryBuckets());
+
+		// A different schema in the same register, and a different register.
+		$this->writeObject(register: self::REGISTER, schema: '43');
+		$this->writeObject(register: '8', schema: '99');
+
+		$this->assertSame(
+			self::BEFORE,
+			$this->readCategoryBuckets(),
+			'a write to a schema this query does not read must leave the cached facet hitting'
+		);
+		$this->assertSame(
+			1,
+			$this->mapperCalls,
+			'an unrelated write must not have triggered a recompute'
+		);
+	}//end testAWriteToAnotherSchemaLeavesThisSchemaServingFromCache()
+
+	/**
+	 * A facet computed across every schema cannot survive any write.
+	 *
+	 * A query naming no register and no schema is answered from the whole
+	 * instance, so there is no write that provably cannot change it. It reads
+	 * the global counter, which every write bumps.
+	 *
+	 * @return void
+	 */
+	public function testAnUnscopedFacetIsInvalidatedByAWriteAnywhere(): void {
+		$this->mapperReturns(self::BEFORE, self::AFTER);
+
+		$this->assertSame(self::BEFORE, $this->readCategoryBuckets(query: ['_facets' => 'extend']));
+
+		$this->writeObject(register: '8', schema: '99');
+
+		$this->assertSame(
+			self::AFTER,
+			$this->readCategoryBuckets(query: ['_facets' => 'extend']),
+			'an unscoped facet must be recomputed after a write to any schema'
+		);
+	}//end testAnUnscopedFacetIsInvalidatedByAWriteAnywhere()
+
+	/**
+	 * The reported reproduction: an added sort parameter was a free cache-buster.
+	 *
+	 * Two requests differing only in `_order` returned different bucket lists
+	 * at the same instant against the same rows, because the sort changed the
+	 * cache key and nothing else. After the fix both requests agree, because
+	 * both keys carry the same freshness token.
+	 *
+	 * @return void
+	 */
+	public function testAddingASortParameterNoLongerChangesTheBucketList(): void {
+		$this->mapperReturns(self::BEFORE, self::AFTER);
+
+		$this->readCategoryBuckets();
+		$this->writeObject(register: self::REGISTER, schema: self::SCHEMA);
+
+		$plain = $this->readCategoryBuckets();
+		$sorted = $this->readCategoryBuckets(
+			query: [
+				'@self' => ['register' => (int)self::REGISTER, 'schema' => (int)self::SCHEMA],
+				'_facets' => 'extend',
+				'_order' => ['title' => 'asc'],
+			]
+		);
+
+		$this->assertSame(
+			$plain,
+			$sorted,
+			'two reads of the same rows at the same instant must agree, sorted or not'
+		);
+	}//end testAddingASortParameterNoLongerChangesTheBucketList()
+
+	/**
+	 * Number of times the mapper actually computed a facet.
+	 *
+	 * @var int
+	 */
+	private int $mapperCalls = 0;
+
+	/**
+	 * Program the mapper to report $before until a write lands, then $after.
+	 *
+	 * The switch is driven by the counter the listener bumps, so the mapper
+	 * behaves like a database: it reports what is there now, and it is only
+	 * ever asked when the cache misses.
+	 *
+	 * @param array<int, string> $before Bucket values before the write.
+	 * @param array<int, string> $after  Bucket values after the write.
+	 *
+	 * @return void
+	 */
+	private function mapperReturns(array $before, array $after): void {
+		$this->mapper->method('getSimpleFacets')->willReturnCallback(
+			function () use ($before, $after) {
+				++$this->mapperCalls;
+				$values = $before;
+				if ($this->writes > 0) {
+					$values = $after;
+				}
+
+				$buckets = [];
+				foreach ($values as $value) {
+					$buckets[] = ['key' => $value, 'results' => 1];
+				}
+
+				return ['category' => ['type' => 'terms', 'buckets' => $buckets]];
+			}
+		);
+	}//end mapperReturns()
+
+	/**
+	 * Number of object writes dispatched so far.
+	 *
+	 * @var int
+	 */
+	private int $writes = 0;
+
+	/**
+	 * Dispatch an object write the way the app does, through the real listener.
+	 *
+	 * Going through FacetCacheInvalidationListener rather than calling
+	 * FacetCacheVersion directly is deliberate: the wiring between the event
+	 * and the counter is exactly the part that can silently not exist.
+	 *
+	 * @param string $register Register id of the written object.
+	 * @param string $schema   Schema id of the written object.
+	 *
+	 * @return void
+	 */
+	private function writeObject(string $register, string $schema): void {
+		++$this->writes;
+
+		$object = new \OCA\OpenRegister\Db\ObjectEntity();
+		$object->setRegister($register);
+		$object->setSchema($schema);
+
+		$listener = new FacetCacheInvalidationListener($this->versions);
+		$listener->handle(new ObjectCreatedEvent($object));
+	}//end writeObject()
+
+	/**
+	 * Read the `category` bucket values through the public facet entry point.
+	 *
+	 * @param array<string, mixed>|null $query Query to face, defaults to the scoped index query.
+	 *
+	 * @return array<int, string> Bucket values in response order.
+	 */
+	private function readCategoryBuckets(?array $query = null): array {
+		if ($query === null) {
+			$query = [
+				'@self' => ['register' => (int)self::REGISTER, 'schema' => (int)self::SCHEMA],
+				'_facets' => 'extend',
+			];
+		}
+
+		$result = $this->handler->getFacetsForObjects($query);
+		$buckets = ($result['facets']['category']['data']['buckets'] ?? []);
+
+		return array_map(static fn (array $b) => (string)$b['value'], $buckets);
+	}//end readCategoryBuckets()
+}//end class

--- a/tests/Unit/Support/FakeMemcache.php
+++ b/tests/Unit/Support/FakeMemcache.php
@@ -1,0 +1,276 @@
+<?php
+
+/**
+ * OpenRegister FakeMemcache
+ *
+ * In-memory IMemcache backed by a plain array, so a test can observe exactly
+ * what a cache holds and what survives an invalidation, instead of stubbing
+ * return values call by call as createMock() would require.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Support
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Support;
+
+use OCP\IMemcache;
+
+/**
+ * Array-backed IMemcache for unit tests.
+ *
+ * TTLs are recorded but never enforced: a unit test that needed a TTL to
+ * elapse would be a timing test, and the freshness this cache is used to
+ * assert is precisely the property that must not depend on one.
+ */
+class FakeMemcache implements IMemcache {
+	/**
+	 * Stored values by key.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private array $store = [];
+
+	/**
+	 * TTL last written per key, for assertions about expiry headroom.
+	 *
+	 * @var array<string, int>
+	 */
+	private array $ttls = [];
+
+	/**
+	 * Number of get() calls, for assertions about read cost.
+	 *
+	 * @var int
+	 */
+	public int $reads = 0;
+
+	/**
+	 * Number of set()/inc() calls, for assertions about write cost.
+	 *
+	 * @var int
+	 */
+	public int $writes = 0;
+
+	/**
+	 * Read one key.
+	 *
+	 * @param string $key Cache key.
+	 *
+	 * @return mixed Stored value or null.
+	 */
+	public function get($key) {
+		++$this->reads;
+		return ($this->store[$key] ?? null);
+	}//end get()
+
+	/**
+	 * Write one key.
+	 *
+	 * @param string $key   Cache key.
+	 * @param mixed  $value Value to store.
+	 * @param int    $ttl   Requested time to live.
+	 *
+	 * @return bool Always true.
+	 */
+	public function set($key, $value, $ttl = 0) {
+		++$this->writes;
+		$this->store[$key] = $value;
+		$this->ttls[$key] = $ttl;
+		return true;
+	}//end set()
+
+	/**
+	 * Whether a key is present.
+	 *
+	 * @param string $key Cache key.
+	 *
+	 * @return bool True when present.
+	 */
+	public function hasKey($key) {
+		return array_key_exists($key, $this->store);
+	}//end hasKey()
+
+	/**
+	 * Drop one key.
+	 *
+	 * @param string $key Cache key.
+	 *
+	 * @return bool Always true.
+	 */
+	public function remove($key) {
+		unset($this->store[$key], $this->ttls[$key]);
+		return true;
+	}//end remove()
+
+	/**
+	 * Drop every key carrying a prefix.
+	 *
+	 * @param string $prefix Key prefix, empty for everything.
+	 *
+	 * @return bool Always true.
+	 */
+	public function clear($prefix = '') {
+		if ($prefix === '') {
+			$this->store = [];
+			$this->ttls = [];
+			return true;
+		}
+
+		foreach (array_keys($this->store) as $key) {
+			if (str_starts_with((string)$key, $prefix) === true) {
+				unset($this->store[$key], $this->ttls[$key]);
+			}
+		}
+
+		return true;
+	}//end clear()
+
+	/**
+	 * Write a key only when it is absent.
+	 *
+	 * @param string $key   Cache key.
+	 * @param mixed  $value Value to store.
+	 * @param int    $ttl   Requested time to live.
+	 *
+	 * @return bool True when the key was written.
+	 */
+	public function add($key, $value, $ttl = 0) {
+		if (array_key_exists($key, $this->store) === true) {
+			return false;
+		}
+
+		return $this->set($key, $value, $ttl);
+	}//end add()
+
+	/**
+	 * Increase a stored number, creating it when absent.
+	 *
+	 * Matches the Redis backend, whose incrBy() creates the key at the step
+	 * value rather than failing, and whose created key carries no expiry.
+	 *
+	 * @param string $key  Cache key.
+	 * @param int    $step Amount to add.
+	 *
+	 * @return int|false The new value.
+	 */
+	public function inc($key, $step = 1) {
+		++$this->writes;
+		$current = 0;
+		if (is_numeric($this->store[$key] ?? null) === true) {
+			$current = (int)$this->store[$key];
+		}
+
+		$this->store[$key] = ($current + $step);
+		return $this->store[$key];
+	}//end inc()
+
+	/**
+	 * Decrease a stored number.
+	 *
+	 * @param string $key  Cache key.
+	 * @param int    $step Amount to subtract.
+	 *
+	 * @return int|false The new value, or false when the key is absent.
+	 */
+	public function dec($key, $step = 1) {
+		if (is_numeric($this->store[$key] ?? null) === false) {
+			return false;
+		}
+
+		$this->store[$key] = ((int)$this->store[$key] - $step);
+		return $this->store[$key];
+	}//end dec()
+
+	/**
+	 * Compare and set.
+	 *
+	 * @param string $key Cache key.
+	 * @param mixed  $old Expected current value.
+	 * @param mixed  $new Replacement value.
+	 *
+	 * @return bool True when replaced.
+	 */
+	public function cas($key, $old, $new) {
+		if (($this->store[$key] ?? null) !== $old) {
+			return false;
+		}
+
+		return $this->set($key, $new);
+	}//end cas()
+
+	/**
+	 * Compare and delete.
+	 *
+	 * @param string $key Cache key.
+	 * @param mixed  $old Expected current value.
+	 *
+	 * @return bool True when deleted.
+	 */
+	public function cad($key, $old) {
+		if (($this->store[$key] ?? null) !== $old) {
+			return false;
+		}
+
+		return $this->remove($key);
+	}//end cad()
+
+	/**
+	 * Delete when the stored value differs from the given one.
+	 *
+	 * @param string $key Cache key.
+	 * @param mixed  $old Value that must NOT be present.
+	 *
+	 * @return bool True when deleted.
+	 */
+	public function ncad(string $key, mixed $old): bool {
+		if (array_key_exists($key, $this->store) === false) {
+			return false;
+		}
+
+		if ($this->store[$key] === $old) {
+			return false;
+		}
+
+		return $this->remove($key);
+	}//end ncad()
+
+	/**
+	 * TTL last written for a key.
+	 *
+	 * @param string $key Cache key.
+	 *
+	 * @return int|null Recorded TTL, or null when the key was never set().
+	 */
+	public function ttlFor(string $key): ?int {
+		return ($this->ttls[$key] ?? null);
+	}//end ttlFor()
+
+	/**
+	 * Every key currently held.
+	 *
+	 * @return array<int, string> Cache keys.
+	 */
+	public function keys(): array {
+		return array_map('strval', array_keys($this->store));
+	}//end keys()
+
+	/**
+	 * Whether this backend can be used.
+	 *
+	 * @return bool Always true.
+	 */
+	public static function isAvailable(): bool {
+		return true;
+	}//end isAvailable()
+}//end class

--- a/tests/Unit/Support/PlainFakeCache.php
+++ b/tests/Unit/Support/PlainFakeCache.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * OpenRegister PlainFakeCache
+ *
+ * In-memory ICache with no atomic increment, standing in for a backend that
+ * implements ICache but not IMemcache, so the read-modify-write fallback in
+ * FacetCacheVersion is exercised by a test rather than assumed.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Support
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Support;
+
+use OCP\ICache;
+
+/**
+ * Array-backed ICache without IMemcache's atomic operations.
+ */
+class PlainFakeCache implements ICache {
+	/**
+	 * Stored values by key.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private array $store = [];
+
+	/**
+	 * TTL passed to the most recent set() call.
+	 *
+	 * @var int
+	 */
+	public int $lastTtl = 0;
+
+	/**
+	 * Read one key.
+	 *
+	 * @param string $key Cache key.
+	 *
+	 * @return mixed Stored value or null.
+	 */
+	public function get($key) {
+		return ($this->store[$key] ?? null);
+	}//end get()
+
+	/**
+	 * Write one key.
+	 *
+	 * @param string $key   Cache key.
+	 * @param mixed  $value Value to store.
+	 * @param int    $ttl   Requested time to live.
+	 *
+	 * @return bool Always true.
+	 */
+	public function set($key, $value, $ttl = 0) {
+		$this->store[$key] = $value;
+		$this->lastTtl = (int)$ttl;
+		return true;
+	}//end set()
+
+	/**
+	 * Whether a key is present.
+	 *
+	 * @param string $key Cache key.
+	 *
+	 * @return bool True when present.
+	 */
+	public function hasKey($key) {
+		return array_key_exists($key, $this->store);
+	}//end hasKey()
+
+	/**
+	 * Drop one key.
+	 *
+	 * @param string $key Cache key.
+	 *
+	 * @return bool Always true.
+	 */
+	public function remove($key) {
+		unset($this->store[$key]);
+		return true;
+	}//end remove()
+
+	/**
+	 * Drop every key.
+	 *
+	 * @param string $prefix Key prefix, unused.
+	 *
+	 * @return bool Always true.
+	 */
+	public function clear($prefix = '') {
+		$this->store = [];
+		return true;
+	}//end clear()
+
+	/**
+	 * Whether this backend can be used.
+	 *
+	 * @return bool Always true.
+	 */
+	public static function isAvailable(): bool {
+		return true;
+	}//end isAvailable()
+}//end class


### PR DESCRIPTION
Closes #3560.

## What the cache actually does

`FacetHandler::getFacetsForObjects()` caches the whole facet response in the
`openregister_facets` memcache for 3600 seconds. `generateFacetCacheKey()` builds the
key from the query, the facet config, the user id and the organisation. Nothing else.
No object write touches any of those, so the only things that cleared an entry were
the TTL, a schema change, and the admin action at
`DELETE /api/settings/cache?type=facet`.

That is why one response could carry a live `results` array beside a `facets` block
an hour old, with nothing on the page saying the two were computed against different
rows.

A count may lag. A bucket list may not, because a bucket list is offered to the
reader as a place to go. `CnFolderSidebar` builds an index page's folder pane from
this block and `CnFacetSidebar` builds the filter list from it, across roughly 6
folder panes and 250 index sidebars in the fleet.

The report's ten second proof is now a test rather than a memory:
`testAddingASortParameterNoLongerChangesTheBucketList`. Two requests over the same
rows at the same instant, differing only in `_order`, used to disagree, because the
sort changed the key and nothing else. An added sort parameter was a free cache
buster.

## What I built

I did not invent a mechanism. OpenRegister already had this one.

`Service/Aggregation/AggregationCache` folds a per (register, schema) version counter
into its keys, and `Listener/AggregationCacheInvalidationListener` bumps that counter
on `ObjectCreated`, `ObjectUpdated`, `ObjectDeleted` and `ObjectTransitioned`. The
spec calls it `scope-cache-invalidation`. This change applies the same shape to the
facet response cache:

- `Service/Object/FacetCacheVersion` holds the counters.
- `Listener/FacetCacheInvalidationListener` bumps them on the same four events.
- `FacetHandler::generateFacetCacheKey()` folds the token into the key.

**Why the counter is separate from AggregationCache's, rather than shared.**
AggregationCache's counter is safe because it outlives the data it guards: the data
TTL is 60 seconds and the counter is written with a TTL of 3600. Facet entries hold
for 3600 themselves. Sharing that counter would let it expire back to zero while a
superseded facet response was still live, and a stale bucket list would become
reachable again. So this counter lives in its own namespace and is written so it
cannot expire before the entries it invalidates: `IMemcache::inc()` where the backend
has it, which never expires, and a 30 day TTL on the read modify write fallback.

**How the reader and the writer agree on a key.** The writer keys on
`ObjectEntity::getRegister()` and `getSchema()`, which hold numeric ids as strings.
The reader takes the scope from `@self.register` and `@self.schema` in the query,
which `SearchQueryHandler` has already cast to ints, because `ObjectsController`
resolves the slugs in the URL before building the query. Same ids on both sides. This
is the part that fails silently when it is wrong, so it is asserted end to end rather
than reasoned about.

Four scopes are bumped per write, and the reader picks the tightest one its query
actually names: the (register, schema) pair, the schema alone, the register alone,
and a global counter. A query naming neither reads the global counter, so any write
invalidates it. That over invalidates, and it is the only answer that cannot be wrong
for a facet computed across the whole instance.

## What the invalidation costs

On a busy register, per object write: **four counter increments against the
memcache.** No database work, and no enumeration of the keys being invalidated. The
write path already dispatches five other listeners and a full
`CacheHandler::invalidateForObjectChange()`, so this is not measurable beside it.
`testOneWriteCostsFourCounterIncrementsAndNothingElse` pins the number.

Bulk writes were the case worth checking, because every object in a bulk save
dispatches its own event. A repeated bump with no read in between changes nothing, so
the counter remembers what it bumped this request and skips the repeats: **a
thousand-object import into one schema costs four increments, not four thousand.**
Any read clears that memo, because a read can cache a response keyed on the counter
it just read, and a later write in the same request has to invalidate it.
`testAReadBetweenTwoWritesMakesTheSecondWriteBumpAgain` guards that, and it is one of
the mutations below.

Per read, one extra memcache `get` per scope the query names. One for a normal index
page.

The real cost is the recomputation the invalidation forces, and it is bounded by
scope: **one facet aggregation for the written register and schema, on the next read
of that collection.** A register with a hot write loop and a hot index page on the
same schema recomputes its facet roughly once per write, which is the price of a
bucket list that is true. Every other schema keeps hitting.
`testAWriteToAnotherSchemaLeavesThisSchemaServingFromCache` fails if that stops being
true, so a future change cannot quietly widen the invalidation into a fleet wide
recompute.

The TTL stays at 3600. It is now a ceiling on staleness rather than the invalidation,
and the docblock that claimed otherwise is corrected in the same commit.

One cost I want a reviewer to see rather than discover. A bump does not delete the
entry it supersedes, it makes it unreachable, and that entry then occupies the cache
until its TTL runs out. So on a busy register the facets namespace can hold up to one
entry per facet read in the last hour, where before it held one per distinct query. A
superseded entry is never read again, which makes it the coldest thing in the cache
and the first thing an LRU backend discards, so I have left the TTL alone rather than
shortening it and charging every quiet collection a recompute. If this turns out to
matter on a real instance, dropping `FACET_CACHE_TTL` is the lever, and it is now
safe to drop because the counter is doing the invalidating.

## The assertion I watched fail

A guard test is not done until it has been watched failing, so I broke the fix four
ways and confirmed the right assertion reddened each time. Restored from byte copies
and diffed against the backup after each one.

| Mutation | Reddens | Message |
|---|---|---|
| Freshness token removed from the key, so the pre fix key is back | 3 of 4 | `the next facet read after a write must carry the bucket that write created` |
| Listener receives the event and bumps nothing | 3 of 4 | same |
| Scope resolution always returns the global counter, so everything invalidates | 1 of 4 | `a write to a schema this query does not read must leave the cached facet hitting` |
| Bump memo not cleared on read, so a write after a read is skipped | 1 of 15 | `a write after a read must still invalidate what that read cached` |

The first mutation also reproduces the reported symptom exactly:
`testAddingASortParameterNoLongerChangesTheBucketList` fails with the sorted request
carrying the new bucket and the plain one not carrying it.

The tests assert freshness, not clearability. A test that only proved the cache can
be cleared would have passed against the broken build, because the broken build could
already be cleared. Every assertion reads a facet through `getFacetsForObjects()`
after a write and requires the new bucket list.

## Acceptance

dossiq's `case-type-authoring-extras.spec.ts`, "picking a folder narrows the Case
types index to that category", is parked as `test.fixme` naming this issue at the
call site. Its docblock forbids making it pass by clearing the cache from the test,
and nothing here does.

**I expect that test to pass once this is released and dossiq picks it up.** The two
things it needs are both in place: the category it seeds gets a bucket on the read
that follows the seed, and the categories an earlier worker deleted in teardown lose
theirs. Unparking it is deleting one `fixme` in ConductionNL/dossiq#2278.

One caveat on that expectation. The test opens an unfiltered index, so it reads the
global counter, and on a busy CI instance any write anywhere will keep recomputing
its facet. That makes it correct, not fast.

## Verified locally

| Check | Exit code |
|---|---|
| `phpunit` on the three new test files, 19 tests | 0 |
| `phpcs --standard=phpcs.xml` on the four changed `lib/` files | 0 |
| `phpstan analyse` on the three changed `lib/` files | 0 |
| `psalm` on the three changed `lib/` files | 0 |
| `phpmd` with `phpmd.xml` on the three changed `lib/` files | 0 |

`run-hydra-gates.sh` on the whole tree reports 74 of 87 gates, all passing except
`gate-67 openregister-contract-parity`. That one flags
`lib/Contract/ObjectServiceInterface.php` drifting from the copy vendored in
hydra-gates. It is pre-existing: the file last changed in #3444, this branch does not
touch `lib/Contract/`, and the same failure reproduces on `origin/development`.

## Not in scope

`Db/ObjectHandlers/HyperFacetHandler` writes to the same cache namespace with the
same defect and a 300 second TTL. It is never constructed: nothing outside its own
file references it except a comment in `FacetCacheHandler`. Leaving it alone rather
than fixing dead code.
