### PR TITLE
feat(objects): maintain @self.version and fill the abstract _retention decision

### DIFF
--- a/lib/Db/AuditTrail.php
+++ b/lib/Db/AuditTrail.php
@@ -86,6 +86,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setFlowNode(?string $flowNode)
  * @method integer|null getFlowStep()
  * @method void setFlowStep(?int $flowStep)
+ * @method string|null getVersion()
+ * @method void setVersion(?string $version)
  *
  * @psalm-suppress PossiblyUnusedMethod
  * @psalm-suppress PropertyNotSetInConstructor $id is set by Nextcloud's Entity base class

--- a/lib/Db/AuditTrailMapper.php
+++ b/lib/Db/AuditTrailMapper.php
@@ -590,6 +590,15 @@ class AuditTrailMapper extends QBMapper {
 		$auditTrail->setRegister($objectEntity->getRegister());
 		$auditTrail->setSchema($objectEntity->getSchema());
 
+		// The object version this change produced. `oc_openregister_audit_trails`
+		// has carried a `version` column and AuditTrail a `version` property
+		// since the table was created, and nothing ever wrote either — because
+		// nothing wrote the object's version either. Now that ObjectVersionHandler
+		// maintains it, the audit row can say which version each entry left
+		// behind, which is what makes "revert to version X" answerable from the
+		// trail rather than by counting rows.
+		$auditTrail->setVersion($objectEntity->getVersion());
+
 		// AVG / GDPR Art 30 trigger contract — resolve the
 		// processing-activity reference and tag the audit row. Resolution
 		// order is action-override > schema-default > register-default;

--- a/lib/Db/MagicMapper/MagicBulkHandler.php
+++ b/lib/Db/MagicMapper/MagicBulkHandler.php
@@ -45,6 +45,7 @@ use Exception;
 use OCA\OpenRegister\Db\Register;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Service\DateTimeNormalizer;
+use OCA\OpenRegister\Service\Object\ObjectVersionHandler;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
@@ -81,6 +82,17 @@ class MagicBulkHandler {
 	private array $tableColumnsCache = [];
 
 	/**
+	 * Decides the version an inserted row starts on.
+	 *
+	 * Constructed rather than injected: it is stateless arithmetic over one
+	 * string, and version policy belongs in one class rather than being
+	 * re-stated wherever a row is written.
+	 *
+	 * @var ObjectVersionHandler
+	 */
+	private ObjectVersionHandler $versionHandler;
+
+	/**
 	 * Constructor for MagicBulkHandler
 	 *
 	 * @param IDBConnection $db Database connection for operations
@@ -98,6 +110,7 @@ class MagicBulkHandler {
 	) {
 		// Try to get max_allowed_packet from database configuration.
 		$this->initializeMaxPacketSize();
+		$this->versionHandler = new ObjectVersionHandler();
 	}//end __construct()
 
 	/**
@@ -172,12 +185,13 @@ class MagicBulkHandler {
 			$preparedObject['_updated'] = $now->format('Y-m-d H:i:s');
 			$preparedObject = $this->withExpiry(prepared: $preparedObject, object: $object, selfData: $selfData);
 
-			$preparedObject['_name'] = $selfData['name'] ?? $object['name'] ?? null;
-			$preparedObject['_description'] = $selfData['description'] ?? $object['description'] ?? null;
-			$preparedObject['_summary'] = $selfData['summary'] ?? $object['summary'] ?? null;
-			$preparedObject['_image'] = $selfData['image'] ?? $object['image'] ?? null;
-			$preparedObject['_slug'] = $selfData['slug'] ?? $object['slug'] ?? null;
-			$preparedObject['_uri'] = $selfData['uri'] ?? $object['uri'] ?? null;
+			$preparedObject = $this->withDisplayColumns(
+				prepared: $preparedObject,
+				selfData: $selfData,
+				object: $object
+			);
+
+			$preparedObject['_version'] = $this->versionHandler->initialVersionFor(candidate: ($selfData['version'] ?? $object['version'] ?? null));
 
 			// Calculate object size for storage analytics.
 			// This is the size of the serialized object data for storage analytics.
@@ -225,6 +239,33 @@ class MagicBulkHandler {
 
 		return $prepared;
 	}//end prepareObjectsForDynamicTable()
+
+	/**
+	 * Map the six display-metadata columns onto a prepared row.
+	 *
+	 * Each reads `@self` first and the raw payload second, which is the same
+	 * fallback the surrounding method applies to every other metadata column.
+	 * Extracted as a group because they share that rule exactly, and because
+	 * `prepareObjectsForDynamicTable()` sits on the method-length threshold.
+	 *
+	 * @param array<string, mixed> $prepared The row being built.
+	 * @param array<string, mixed> $selfData The object's `@self` metadata.
+	 * @param array<string, mixed> $object The raw object payload.
+	 *
+	 * @return array<string, mixed> The row with the display columns set.
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	private function withDisplayColumns(array $prepared, array $selfData, array $object): array {
+		$prepared['_name'] = $selfData['name'] ?? $object['name'] ?? null;
+		$prepared['_description'] = $selfData['description'] ?? $object['description'] ?? null;
+		$prepared['_summary'] = $selfData['summary'] ?? $object['summary'] ?? null;
+		$prepared['_image'] = $selfData['image'] ?? $object['image'] ?? null;
+		$prepared['_slug'] = $selfData['slug'] ?? $object['slug'] ?? null;
+		$prepared['_uri'] = $selfData['uri'] ?? $object['uri'] ?? null;
+
+		return $prepared;
+	}//end withDisplayColumns()
 
 	/**
 	 * Copy an object's expiry into the prepared row's `_expires` column, when it has one.
@@ -740,8 +781,15 @@ class MagicBulkHandler {
 		$updateClauses = [];
 
 		foreach ($columns as $column) {
-			if ($column === '_uuid' || $column === '_created') {
+			if ($column === '_uuid' || $column === '_created' || $column === '_version') {
 				// Never update UUID or created timestamp.
+				//
+				// `_version` joins them: the INSERT half stamps a starting
+				// version on a genuinely new row, and an existing row must keep
+				// the version it already reached. Letting the incoming value win
+				// here would walk every re-imported object back to `0.0.1` on
+				// every sync pass, which is worse than the NULL this change
+				// exists to end.
 				continue;
 			}
 

--- a/lib/Service/Archival/ArchivalDecisionResolver.php
+++ b/lib/Service/Archival/ArchivalDecisionResolver.php
@@ -95,25 +95,9 @@ class ArchivalDecisionResolver {
 			$retention = [];
 		}
 
-		// The object's OWN archival properties, in the ZGW zaak vocabulary.
-		//
-		// 🔴 THIS IS WHAT MAKES `_retention` ABSTRACT RATHER THAN THEORETICAL.
-		// `archiefnominatie` / `archiefactiedatum` / `archiefstatus` are the ZGW
-		// contract, and an app that implements the zaak API declares them as
-		// ordinary schema properties on its own record — dossiq derives them
-		// from a case's resultaattype on close (zrc-021) and writes them there.
-		// Reading only `@self.retention` would have meant `_retention` stayed
-		// empty on exactly the records that HAVE an archival decision, while
-		// each app kept reading its own field names, which is the per-app
-		// duplication this resolver exists to end.
-		//
-		// These are not app-specific names: openregister already speaks the
-		// same vocabulary in `retention`, in Dutch. This reads the English
-		// spelling too, and normalises both into one answer.
-		//
-		// `@self.retention` still WINS where both are present: that is a
-		// decision recorded against the object through the retention service,
-		// and a schema property is what an app wrote for its own API consumers.
+		// The object's OWN archival properties, in the ZGW zaak vocabulary. This
+		// is what makes `_retention` abstract rather than theoretical; see
+		// {@see declaredArchivalFields()} for why it is read at all.
 		$declared = $this->declaredArchivalFields(entity: $entity);
 		if ($retention === [] && $declared === []) {
 			return null;
@@ -255,8 +239,9 @@ class ArchivalDecisionResolver {
 	 *
 	 * @param array<string, mixed> $retention The stored retention block.
 	 * @param array<string, mixed> $annotation The schema annotation evaluation.
+	 * @param array<string, string> $declared The ZGW archival fields the record itself declares.
 	 *
-	 * @return string|null One of `selectielijst`, `schema`, `annotation`, or null.
+	 * @return string|null One of `selectielijst`, `schema`, `record`, `annotation`, or null.
 	 *
 	 * @spec openspec/specs/retention-management/spec.md
 	 */
@@ -282,6 +267,23 @@ class ArchivalDecisionResolver {
 
 	/**
 	 * Read the ZGW archival properties the object itself declares.
+	 *
+	 * 🔴 THIS IS WHAT MAKES `_retention` ABSTRACT RATHER THAN THEORETICAL.
+	 * `archiefnominatie` / `archiefactiedatum` / `archiefstatus` are the ZGW
+	 * contract, and an app that implements the zaak API declares them as
+	 * ordinary schema properties on its own record — dossiq derives them from a
+	 * case's resultaattype on close (zrc-021) and writes them there. Reading
+	 * only `@self.retention` would have left `_retention` empty on exactly the
+	 * records that HAVE an archival decision, while each app kept reading its
+	 * own field names, which is the per-app duplication this resolver exists to
+	 * end.
+	 *
+	 * These are not app-specific names: openregister already speaks the same
+	 * vocabulary in `retention`, in Dutch.
+	 *
+	 * `@self.retention` still WINS where both are present: that is a decision
+	 * recorded against the object through the retention service, and a schema
+	 * property is what an app wrote for its own API consumers.
 	 *
 	 * Both spellings are accepted for each field, because an app writes
 	 * whichever its own API speaks: the Dutch `archiefnominatie` when it mirrors

--- a/lib/Service/Archival/ArchivalDecisionResolver.php
+++ b/lib/Service/Archival/ArchivalDecisionResolver.php
@@ -1,0 +1,369 @@
+<?php
+
+/**
+ * The one resolved answer to "what happens to this object, and when".
+ *
+ * 🔴 THIS EXISTS BECAUSE THE ANSWER WAS SCATTERED AND THE ABSTRACT SLOT WAS
+ * EMPTY. `@self._retention` has been declared in `ObjectEntity::getObjectArray()`
+ * since add-archival-annotation-support, and `setArchivalRetention()` — the only
+ * way to fill it — was called from exactly one place in the whole repository: a
+ * unit test. Every consumer that asked an object what its archival constraints
+ * were therefore got nothing, while the facts themselves sat in three different
+ * shapes nobody had merged:
+ *
+ *   1. `retention.archiefnominatie` / `bewaartermijn` / `archiefactiedatum`,
+ *      written by {@see \OCA\OpenRegister\Service\RetentionService::applyArchivalMetadata()}
+ *      but only for schemas whose `archive` block is enabled;
+ *   2. `retention.annotation`, the `x-openregister-archival` evaluation written
+ *      by RenderObject, in `effectiveRetention` / `matchedRule` / `expiresAt`;
+ *   3. `retention.legalHold`, which overrides both and which neither of the
+ *      other two mentions.
+ *
+ * The cost of leaving it scattered is that every consuming app grew its OWN
+ * archival fields instead — dossiq derives `archiveNomination` and
+ * `archiveActionDate` onto the case record from its resultaattype — so the same
+ * question has a different answer per app, and no shared surface (a metadata
+ * panel, an index column, a records-officer report) can ask it once.
+ *
+ * This resolver is the merge, in app-neutral keys. It reads; it never writes to
+ * storage and it never decides that anything may be destroyed — that stays with
+ * RetentionService and the destruction pipeline.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Archival
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/retention-management/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Archival;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+
+/**
+ * Merges an object's stored retention block, its schema annotation evaluation
+ * and any legal hold into one resolved `@self._retention` decision.
+ */
+class ArchivalDecisionResolver {
+
+	/**
+	 * Nomination values that mean "this object is kept forever".
+	 *
+	 * Both spellings occur in the wild: MDTO and the selectielijst use
+	 * `blijvend_bewaren`, while a ZGW resultaattype may carry the shorter
+	 * `bewaren`. They mean the same thing to an archivist, so they normalise
+	 * to one value rather than reaching a reader as two.
+	 *
+	 * @var array<string, string>
+	 */
+	private const NOMINATION_ALIASES = [
+		'bewaren' => 'blijvend_bewaren',
+		'blijvend_bewaren' => 'blijvend_bewaren',
+		'vernietigen' => 'vernietigen',
+		'nog_niet_bepaald' => 'nog_niet_bepaald',
+	];
+
+	/**
+	 * Resolve an object's archival decision.
+	 *
+	 * Returns null when the object has nothing to say about its own archiving —
+	 * no stored retention block, no schema annotation, no hold. Null means the
+	 * key is omitted from `@self` entirely, which is deliberate: an empty
+	 * `_retention: {}` reads as "we looked and there is no obligation", and a
+	 * records officer must be able to tell that apart from "this schema never
+	 * declared one".
+	 *
+	 * @param ObjectEntity $entity The object to resolve for.
+	 *
+	 * @return array<string, mixed>|null The resolved decision, or null when there is none.
+	 *
+	 * @spec openspec/specs/retention-management/spec.md
+	 */
+	public function resolve(ObjectEntity $entity): ?array {
+		$retention = ($entity->getRetention() ?? []);
+		if (is_array($retention) === false) {
+			$retention = [];
+		}
+
+		// The object's OWN archival properties, in the ZGW zaak vocabulary.
+		//
+		// 🔴 THIS IS WHAT MAKES `_retention` ABSTRACT RATHER THAN THEORETICAL.
+		// `archiefnominatie` / `archiefactiedatum` / `archiefstatus` are the ZGW
+		// contract, and an app that implements the zaak API declares them as
+		// ordinary schema properties on its own record — dossiq derives them
+		// from a case's resultaattype on close (zrc-021) and writes them there.
+		// Reading only `@self.retention` would have meant `_retention` stayed
+		// empty on exactly the records that HAVE an archival decision, while
+		// each app kept reading its own field names, which is the per-app
+		// duplication this resolver exists to end.
+		//
+		// These are not app-specific names: openregister already speaks the
+		// same vocabulary in `retention`, in Dutch. This reads the English
+		// spelling too, and normalises both into one answer.
+		//
+		// `@self.retention` still WINS where both are present: that is a
+		// decision recorded against the object through the retention service,
+		// and a schema property is what an app wrote for its own API consumers.
+		$declared = $this->declaredArchivalFields(entity: $entity);
+		if ($retention === [] && $declared === []) {
+			return null;
+		}
+
+		$annotation = $retention['annotation'] ?? [];
+		if (is_array($annotation) === false) {
+			$annotation = [];
+		}
+
+		$decision = [
+			'nomination' => $this->normaliseNomination(
+				value: ($retention['archiefnominatie'] ?? ($declared['nomination'] ?? null))
+			),
+			'status' => $this->firstNonEmpty(
+				values: [($retention['archiefstatus'] ?? null), ($declared['status'] ?? null)]
+			),
+			'classification' => $this->stringOrNull(value: ($retention['classification'] ?? null)),
+			'legalHold' => $this->resolveLegalHold(entity: $entity, retention: $retention),
+		];
+
+		// The retention PERIOD and the date it falls due. The stored block and
+		// the schema annotation can both supply a period; the stored one is a
+		// decision somebody recorded against this object, so it wins over a
+		// rule evaluated from the schema.
+		$decision['period'] = $this->firstNonEmpty(
+			values: [
+				($retention['bewaartermijn'] ?? null),
+				($annotation['effectiveRetention'] ?? null),
+			]
+		);
+
+		$decision['actionDate'] = $this->firstNonEmpty(
+			values: [
+				($retention['archiefactiedatum'] ?? null),
+				($declared['actionDate'] ?? null),
+				($annotation['expiresAt'] ?? null),
+			]
+		);
+
+		// WHERE the answer came from, so a reader can tell a selectielijst
+		// obligation from a schema default from a hand-set date. Without this a
+		// records officer sees a destruction date and cannot say who claimed it.
+		$decision['basis'] = $this->resolveBasis(
+			retention: $retention,
+			annotation: $annotation,
+			declared: $declared
+		);
+		$decision['source'] = $this->stringOrNull(value: ($retention['selectielijstBron'] ?? null));
+
+		// The raw annotation evaluation is passed through rather than folded
+		// away: `matchedRule` is the only thing that says WHICH rule in the
+		// schema's `x-openregister-archival` block fired, and debugging a wrong
+		// destruction date without it means re-evaluating the whole annotation
+		// by hand.
+		if ($annotation !== []) {
+			$decision['annotation'] = $annotation;
+		}
+
+		// Nothing was established. Distinct from "kept forever": every field is
+		// absent, not merely permissive, so the object genuinely has no
+		// archival claim on it and the key is omitted.
+		$established = array_filter(
+			$decision,
+			static function ($value) {
+				return $value !== null && $value !== [];
+			}
+		);
+
+		if ($established === []) {
+			return null;
+		}
+
+		return $decision;
+	}//end resolve()
+
+	/**
+	 * Normalise a nomination value to its canonical spelling.
+	 *
+	 * @param mixed $value The stored nomination.
+	 *
+	 * @return string|null The canonical nomination, the raw string when it is
+	 *                     one this resolver does not know, or null when absent.
+	 *
+	 * @spec openspec/specs/retention-management/spec.md
+	 */
+	private function normaliseNomination(mixed $value): ?string {
+		$raw = $this->stringOrNull(value: $value);
+		if ($raw === null) {
+			return null;
+		}
+
+		// An unknown value is passed through rather than dropped. Dropping it
+		// would report "no nomination" for an object that carries one this
+		// resolver has not been taught, which is the failure mode that hides a
+		// records obligation.
+		return (self::NOMINATION_ALIASES[$raw] ?? $raw);
+	}//end normaliseNomination()
+
+	/**
+	 * Resolve the legal-hold state.
+	 *
+	 * Reports an inactive hold as `['active' => false]` rather than null when
+	 * the object has hold HISTORY, because "held in the past and released" is a
+	 * different fact from "never held", and an archivist reads the difference.
+	 *
+	 * @param ObjectEntity $entity The object being resolved.
+	 * @param array<string, mixed> $retention The stored retention block.
+	 *
+	 * @return array<string, mixed>|null The hold state, or null when never held.
+	 *
+	 * @spec openspec/specs/archival-destruction-workflow/spec.md
+	 */
+	private function resolveLegalHold(ObjectEntity $entity, array $retention): ?array {
+		$hold = ($retention['legalHold'] ?? null);
+		if (is_array($hold) === false) {
+			return null;
+		}
+
+		$active = $entity->hasActiveLegalHold();
+		$state = ['active' => $active];
+
+		if ($active === true) {
+			$state['reason'] = $this->stringOrNull(value: ($hold['reason'] ?? null));
+			$state['placedBy'] = $this->stringOrNull(value: ($hold['placedBy'] ?? null));
+			$state['placedDate'] = $this->stringOrNull(value: ($hold['placedDate'] ?? null));
+		}
+
+		$history = ($hold['history'] ?? []);
+		if (is_array($history) === true && $history !== []) {
+			$state['releasedCount'] = count($history);
+		}
+
+		return $state;
+	}//end resolveLegalHold()
+
+	/**
+	 * Decide which authority the retention period rests on.
+	 *
+	 * @param array<string, mixed> $retention The stored retention block.
+	 * @param array<string, mixed> $annotation The schema annotation evaluation.
+	 *
+	 * @return string|null One of `selectielijst`, `schema`, `annotation`, or null.
+	 *
+	 * @spec openspec/specs/retention-management/spec.md
+	 */
+	private function resolveBasis(array $retention, array $annotation, array $declared = []): ?string {
+		if ($this->stringOrNull(value: ($retention['selectielijstBron'] ?? null)) !== null) {
+			return 'selectielijst';
+		}
+
+		if ($this->stringOrNull(value: ($retention['bewaartermijn'] ?? null)) !== null) {
+			return 'schema';
+		}
+
+		if ($declared !== []) {
+			return 'record';
+		}
+
+		if ($this->stringOrNull(value: ($annotation['effectiveRetention'] ?? null)) !== null) {
+			return 'annotation';
+		}
+
+		return null;
+	}//end resolveBasis()
+
+	/**
+	 * Read the ZGW archival properties the object itself declares.
+	 *
+	 * Both spellings are accepted for each field, because an app writes
+	 * whichever its own API speaks: the Dutch `archiefnominatie` when it mirrors
+	 * ZGW verbatim, the English `archiveNomination` when its data model is
+	 * English (dossiq's is, by its own D13 decision).
+	 *
+	 * Returns only the keys it could establish, so an object declaring a
+	 * nomination and no date yields the nomination alone rather than a date
+	 * blanked to null.
+	 *
+	 * @param ObjectEntity $entity The object being resolved.
+	 *
+	 * @return array<string, string> The declared fields, keyed abstractly.
+	 *
+	 * @spec openspec/specs/retention-management/spec.md
+	 */
+	private function declaredArchivalFields(ObjectEntity $entity): array {
+		$object = $entity->getObject();
+		if (is_array($object) === false) {
+			return [];
+		}
+
+		$spellings = [
+			'nomination' => ['archiveNomination', 'archiefnominatie'],
+			'actionDate' => ['archiveActionDate', 'archiefactiedatum'],
+			'status' => ['archiveStatus', 'archiefstatus'],
+		];
+
+		$found = [];
+		foreach ($spellings as $key => $names) {
+			foreach ($names as $name) {
+				$value = $this->stringOrNull(value: ($object[$name] ?? null));
+				if ($value !== null) {
+					$found[$key] = $value;
+					break;
+				}
+			}
+		}
+
+		return $found;
+	}//end declaredArchivalFields()
+
+	/**
+	 * Return the first value that is a non-empty string.
+	 *
+	 * @param array<int, mixed> $values Candidates in priority order.
+	 *
+	 * @return string|null The first usable value, or null.
+	 *
+	 * @spec openspec/specs/retention-management/spec.md
+	 */
+	private function firstNonEmpty(array $values): ?string {
+		foreach ($values as $value) {
+			$candidate = $this->stringOrNull(value: $value);
+			if ($candidate !== null) {
+				return $candidate;
+			}
+		}
+
+		return null;
+	}//end firstNonEmpty()
+
+	/**
+	 * Coerce a value to a non-empty string, or null.
+	 *
+	 * @param mixed $value The value to coerce.
+	 *
+	 * @return string|null The trimmed string, or null when empty or not scalar.
+	 *
+	 * @spec openspec/specs/retention-management/spec.md
+	 */
+	private function stringOrNull(mixed $value): ?string {
+		if (is_string($value) === false) {
+			return null;
+		}
+
+		$trimmed = trim($value);
+		if ($trimmed === '') {
+			return null;
+		}
+
+		return $trimmed;
+	}//end stringOrNull()
+
+}//end class

--- a/lib/Service/Object/ObjectVersionHandler.php
+++ b/lib/Service/Object/ObjectVersionHandler.php
@@ -1,0 +1,175 @@
+<?php
+
+/**
+ * The object's own version number, stamped on create and bumped on update.
+ *
+ * 🔴 THIS EXISTS BECAUSE NOTHING WROTE IT. `@self.version` has been declared
+ * on the entity, serialized into every API response and documented as part of
+ * the metadata envelope since the beginning, and a fleet-wide grep for
+ * `setVersion(` found configurations, flows and migration packs but not one
+ * call on an ObjectEntity outside `AuditTrailMapper::revertObject()`. The
+ * legacy `oc_openregister_objects` table hid it: the column carries a DB
+ * default of `0.0.1`, so every row read back a plausible-looking version that
+ * had never moved. The magic per-schema tables have no such default, so there
+ * the field is simply NULL and every consumer — the metadata modal, the audit
+ * trail's own `version` column, any client diffing two reads — got nothing.
+ *
+ * A version that never changes is worse than no version, because it reads as
+ * an answer. This class is the one place that answers it.
+ *
+ * The scheme is semver-shaped and patch-only: a save is a patch. Minor and
+ * major moves are editorial decisions no save path can infer, so they are left
+ * to whoever makes them, and a stored version carrying them is respected —
+ * `1.4.2` bumps to `1.4.3`, not back onto a `0.0.x` line.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Object
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/object-lifecycle/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Object;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+
+/**
+ * Stamps and bumps `@self.version` on an object entity.
+ */
+class ObjectVersionHandler {
+
+	/**
+	 * The version a newly created object starts on.
+	 *
+	 * Matches the `oc_openregister_objects.version` column default, so an
+	 * object created through the legacy mapper and one created through the
+	 * magic mapper agree rather than starting a digit apart.
+	 *
+	 * @var string
+	 */
+	public const INITIAL_VERSION = '0.0.1';
+
+	/**
+	 * Stamp the initial version on an object being created.
+	 *
+	 * A version already on the entity is kept: an import, a federation pull or
+	 * a migration pack carries the source's version and overwriting it would
+	 * lose the only record of where the object came from. Only an absent or
+	 * unusable value is replaced.
+	 *
+	 * @param ObjectEntity $entity The entity being created.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	public function stampInitialVersion(ObjectEntity $entity): void {
+		$current = $entity->getVersion();
+		if ($this->parse(version: $current) !== null) {
+			return;
+		}
+
+		$entity->setVersion(self::INITIAL_VERSION);
+	}//end stampInitialVersion()
+
+	/**
+	 * The version a row being INSERTED should start on.
+	 *
+	 * Used by the bulk write path, which builds column values directly rather
+	 * than going through an entity. A candidate carried by the payload — an
+	 * import or a federation pull bringing the source's version — is kept for
+	 * the same reason {@see stampInitialVersion()} keeps one.
+	 *
+	 * Note what this method is NOT for: the UPDATE half of a bulk upsert. There
+	 * `_version` is deliberately left out of the update set so an existing row
+	 * keeps the version it reached, because a synchronisation pass that changed
+	 * nothing must not advance a version.
+	 *
+	 * @param string|null $candidate The version the payload carried, if any.
+	 *
+	 * @return string The version to insert with.
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	public function initialVersionFor(?string $candidate): string {
+		if ($candidate !== null && trim($candidate) !== '') {
+			return trim($candidate);
+		}
+
+		return self::INITIAL_VERSION;
+	}//end initialVersionFor()
+
+	/**
+	 * Bump the patch component of an object's version on update.
+	 *
+	 * An entity whose stored version cannot be parsed — NULL on a magic-table
+	 * row that predates this handler, or a free-text value written by an
+	 * import — starts the sequence rather than being left behind, because a
+	 * row that never gains a version is exactly the state this class exists to
+	 * end.
+	 *
+	 * @param ObjectEntity $entity The entity being updated.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	public function bumpVersion(ObjectEntity $entity): void {
+		$parts = $this->parse(version: $entity->getVersion());
+		if ($parts === null) {
+			$entity->setVersion(self::INITIAL_VERSION);
+			return;
+		}
+
+		$parts[2] = ($parts[2] + 1);
+		$entity->setVersion(implode('.', $parts));
+	}//end bumpVersion()
+
+	/**
+	 * Parse a version string into its three integer components.
+	 *
+	 * Deliberately strict: only `major.minor.patch` with three non-negative
+	 * integers is a version this handler will arithmetic on. Anything else —
+	 * a date, a git sha, a two-part `1.0`, an empty string — is reported as
+	 * unusable so the caller restarts the sequence rather than producing a
+	 * value like `1.0.1` from a string that never meant that.
+	 *
+	 * @param string|null $version The stored version string.
+	 *
+	 * @return array{0: int, 1: int, 2: int}|null The components, or null when unusable.
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	private function parse(?string $version): ?array {
+		if ($version === null || trim($version) === '') {
+			return null;
+		}
+
+		$parts = explode('.', trim($version));
+		if (count($parts) !== 3) {
+			return null;
+		}
+
+		$parsed = [];
+		foreach ($parts as $part) {
+			if (ctype_digit($part) === false) {
+				return null;
+			}
+
+			$parsed[] = (int)$part;
+		}
+
+		return $parsed;
+	}//end parse()
+
+}//end class

--- a/lib/Service/Object/RenderObject.php
+++ b/lib/Service/Object/RenderObject.php
@@ -40,6 +40,7 @@ use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Db\Translation;
 use OCA\OpenRegister\Db\TranslationMapper;
 use OCA\OpenRegister\Formats\ExtendedFieldTypeValidator;
+use OCA\OpenRegister\Service\Archival\ArchivalDecisionResolver;
 use OCA\OpenRegister\Service\Archival\RetentionEvaluator;
 use OCA\OpenRegister\Service\Calculation\CalculationEvaluator;
 use OCA\OpenRegister\Service\FieldEncryptionHandler;
@@ -2104,8 +2105,52 @@ class RenderObject {
 		// never collide. See add-archival-annotation-support design R3 + D7.
 		$this->applyArchivalRetentionBlock(entity: $entity, schema: $renderSchema);
 
+		// Merge everything the object now knows about its own archiving into the
+		// ONE abstract answer consumers read: `@self._retention`. Runs after the
+		// annotation block above on purpose, because it reads that block's
+		// output. See ArchivalDecisionResolver for why this merge exists at all.
+		$this->applyArchivalDecision(entity: $entity);
+
 		return $entity;
 	}//end renderEntity()
+
+	/**
+	 * Attach the resolved `@self._retention` decision.
+	 *
+	 * The slot has been declared on the entity since add-archival-annotation-support
+	 * and, until this method existed, was filled by nothing outside a unit test —
+	 * so every client asking an object for its archival constraints got silence
+	 * while the facts sat unmerged in three sub-blocks of `retention`.
+	 *
+	 * Failures are logged and swallowed for the same reason the annotation block
+	 * above swallows them: a records-management edge case must never take out
+	 * object rendering.
+	 *
+	 * @param ObjectEntity $entity The entity being rendered.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/retention-management/spec.md
+	 */
+	private function applyArchivalDecision(ObjectEntity $entity): void {
+		try {
+			$resolver = new ArchivalDecisionResolver();
+			$decision = $resolver->resolve(entity: $entity);
+			if ($decision === null) {
+				return;
+			}
+
+			$entity->setArchivalRetention($decision);
+		} catch (\Throwable $e) {
+			$this->logger->debug(
+				sprintf(
+					'[RenderObject] archival decision resolve failed for %s: %s',
+					(string)$entity->getUuid(),
+					$e->getMessage()
+				)
+			);
+		}//end try
+	}//end applyArchivalDecision()
 
 	/**
 	 * Compute + attach the annotation-driven `_retention.annotation` block.

--- a/lib/Service/Object/SaveObject.php
+++ b/lib/Service/Object/SaveObject.php
@@ -167,6 +167,18 @@ class SaveObject {
 	private Environment $twig;
 
 	/**
+	 * Stamps `@self.version` on create and bumps it on update.
+	 *
+	 * Constructed here rather than injected: it is stateless, dependency-free
+	 * arithmetic over one string, and adding a required constructor parameter
+	 * to a signature this wide costs every manual construction in the test
+	 * suite for no isolation gained.
+	 *
+	 * @var ObjectVersionHandler
+	 */
+	private ObjectVersionHandler $versionHandler;
+
+	/**
 	 * Cache for sub-objects created during cascade operations.
 	 *
 	 * Stores created sub-objects indexed by their UUID for inclusion in @self.objects.
@@ -352,6 +364,7 @@ class SaveObject {
 		private readonly ?ContainerInterface $container = null,
 	) {
 		$this->twig = new Environment($arrayLoader);
+		$this->versionHandler = new ObjectVersionHandler();
 	}//end __construct()
 
 	/**
@@ -3744,6 +3757,12 @@ class SaveObject {
 		// Set @self metadata properties.
 		$this->setSelfMetadata(objectEntity: $objectEntity, selfData: $selfData, data: $data, currentUser: $currentUser);
 
+		// Start the object's version sequence. Nothing wrote this before, so on
+		// the magic tables (which carry no column default) every object read
+		// back a NULL version, and on the legacy table every object read back
+		// the same `0.0.1` forever. See ObjectVersionHandler.
+		$this->versionHandler->stampInitialVersion(entity: $objectEntity);
+
 		// Set UUID if provided, otherwise generate a new one.
 		if ($objectEntity->getUuid() === null) {
 			$objectEntity->setUuid(Uuid::v4()->toRfc4122());
@@ -3904,6 +3923,11 @@ class SaveObject {
 	): ObjectEntity {
 		// Set @self metadata properties.
 		$this->setSelfMetadata(objectEntity: $existingObject, selfData: $selfData, data: $data, currentUser: $currentUser);
+
+		// A save is a patch. Bumped here rather than after the write so the
+		// value the audit trail copies onto its own `version` column is the
+		// version this save produced, not the one it replaced.
+		$this->versionHandler->bumpVersion(entity: $existingObject);
 
 		// Set folder ID if provided.
 		if ($folderId !== null) {

--- a/tests/Unit/Service/Archival/ArchivalDecisionResolverTest.php
+++ b/tests/Unit/Service/Archival/ArchivalDecisionResolverTest.php
@@ -1,0 +1,308 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * ArchivalDecisionResolver tests.
+ *
+ * Pins the merge that fills `@self._retention` — the slot that was declared on
+ * the entity and written by nothing outside a unit test, while the facts it
+ * should carry sat unmerged in three sub-blocks of `retention`.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Archival
+ *
+ * @author   Conduction Development Team <dev@conduction.nl>
+ * @license  EUPL-1.2
+ *
+ * @spec openspec/specs/retention-management/spec.md
+ */
+
+namespace Unit\Service\Archival;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\Archival\ArchivalDecisionResolver;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for ArchivalDecisionResolver.
+ */
+class ArchivalDecisionResolverTest extends TestCase {
+
+	private ArchivalDecisionResolver $resolver;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->resolver = new ArchivalDecisionResolver();
+	}
+
+	/**
+	 * Build an entity carrying the given retention block.
+	 *
+	 * @param array<string, mixed>|null $retention The stored retention block.
+	 *
+	 * @return ObjectEntity The entity.
+	 */
+	private function entityWith(?array $retention): ObjectEntity {
+		$entity = new ObjectEntity();
+		$entity->setRetention($retention);
+		return $entity;
+	}
+
+	/**
+	 * An object with no retention block has no decision, and the key is omitted
+	 * rather than reported as an empty object — "no obligation declared" and
+	 * "we looked and found none" must stay distinguishable.
+	 */
+	public function testReturnsNullWhenThereIsNoRetentionBlock(): void {
+		$this->assertNull($this->resolver->resolve(entity: $this->entityWith(retention: null)));
+		$this->assertNull($this->resolver->resolve(entity: $this->entityWith(retention: [])));
+	}
+
+	/**
+	 * A block carrying only keys this resolver does not read establishes
+	 * nothing, and is reported as no decision.
+	 */
+	public function testReturnsNullWhenNothingIsEstablished(): void {
+		$entity = $this->entityWith(retention: ['somethingElse' => 'value']);
+
+		$this->assertNull($this->resolver->resolve(entity: $entity));
+	}
+
+	/**
+	 * The RetentionService shape — a selectielijst-backed obligation — resolves
+	 * into the abstract keys, with its authority named.
+	 */
+	public function testResolvesTheStoredSelectielijstDecision(): void {
+		$entity = $this->entityWith(
+			retention: [
+				'archiefnominatie' => 'vernietigen',
+				'archiefstatus' => 'nog_te_archiveren',
+				'classification' => '4.1.2',
+				'bewaartermijn' => 'P10Y',
+				'archiefactiedatum' => '2036-09-10',
+				'selectielijstBron' => 'Selectielijst gemeenten 2020',
+			]
+		);
+
+		$decision = $this->resolver->resolve(entity: $entity);
+
+		$this->assertSame('vernietigen', $decision['nomination']);
+		$this->assertSame('nog_te_archiveren', $decision['status']);
+		$this->assertSame('4.1.2', $decision['classification']);
+		$this->assertSame('P10Y', $decision['period']);
+		$this->assertSame('2036-09-10', $decision['actionDate']);
+		$this->assertSame('selectielijst', $decision['basis']);
+		$this->assertSame('Selectielijst gemeenten 2020', $decision['source']);
+	}
+
+	/**
+	 * With no stored decision, the schema annotation's evaluation supplies the
+	 * period and the date, and says so.
+	 */
+	public function testFallsBackToTheSchemaAnnotation(): void {
+		$entity = $this->entityWith(
+			retention: [
+				'annotation' => [
+					'effectiveRetention' => 'P5Y',
+					'matchedRule' => 2,
+					'expiresAt' => '2031-01-01T00:00:00+00:00',
+				],
+			]
+		);
+
+		$decision = $this->resolver->resolve(entity: $entity);
+
+		$this->assertSame('P5Y', $decision['period']);
+		$this->assertSame('2031-01-01T00:00:00+00:00', $decision['actionDate']);
+		$this->assertSame('annotation', $decision['basis']);
+		$this->assertSame(2, $decision['annotation']['matchedRule']);
+	}
+
+	/**
+	 * A decision recorded against THIS object beats a rule evaluated from the
+	 * schema — somebody decided the first one, the second is a default.
+	 */
+	public function testStoredDecisionWinsOverTheAnnotation(): void {
+		$entity = $this->entityWith(
+			retention: [
+				'bewaartermijn' => 'P20Y',
+				'archiefactiedatum' => '2046-09-10',
+				'annotation' => [
+					'effectiveRetention' => 'P5Y',
+					'expiresAt' => '2031-01-01T00:00:00+00:00',
+				],
+			]
+		);
+
+		$decision = $this->resolver->resolve(entity: $entity);
+
+		$this->assertSame('P20Y', $decision['period']);
+		$this->assertSame('2046-09-10', $decision['actionDate']);
+		$this->assertSame('schema', $decision['basis']);
+	}
+
+	/**
+	 * `bewaren` and `blijvend_bewaren` mean the same thing to an archivist, and
+	 * must not reach a reader as two different nominations.
+	 */
+	public function testNormalisesTheShortKeepNomination(): void {
+		$entity = $this->entityWith(retention: ['archiefnominatie' => 'bewaren']);
+
+		$decision = $this->resolver->resolve(entity: $entity);
+
+		$this->assertSame('blijvend_bewaren', $decision['nomination']);
+	}
+
+	/**
+	 * A nomination this resolver has not been taught passes through. Dropping
+	 * it would report "no nomination" for an object that carries one, which is
+	 * the failure mode that hides a records obligation.
+	 */
+	public function testPassesAnUnknownNominationThrough(): void {
+		$entity = $this->entityWith(retention: ['archiefnominatie' => 'overbrengen']);
+
+		$decision = $this->resolver->resolve(entity: $entity);
+
+		$this->assertSame('overbrengen', $decision['nomination']);
+	}
+
+	/**
+	 * An active legal hold is reported with who placed it and why.
+	 */
+	public function testReportsAnActiveLegalHold(): void {
+		$entity = $this->entityWith(
+			retention: [
+				'archiefnominatie' => 'vernietigen',
+				'legalHold' => [
+					'active' => true,
+					'reason' => 'Pending appeal',
+					'placedBy' => 'admin',
+					'placedDate' => '2026-09-01T10:00:00+00:00',
+				],
+			]
+		);
+
+		$decision = $this->resolver->resolve(entity: $entity);
+
+		$this->assertTrue($decision['legalHold']['active']);
+		$this->assertSame('Pending appeal', $decision['legalHold']['reason']);
+		$this->assertSame('admin', $decision['legalHold']['placedBy']);
+	}
+
+	/**
+	 * A released hold still reports itself. "Held once and released" is a
+	 * different fact from "never held", and an archivist reads the difference.
+	 */
+	public function testReportsAReleasedLegalHoldWithItsHistory(): void {
+		$entity = $this->entityWith(
+			retention: [
+				'archiefnominatie' => 'vernietigen',
+				'legalHold' => [
+					'active' => false,
+					'history' => [
+						['reason' => 'Pending appeal', 'releasedBy' => 'admin'],
+					],
+				],
+			]
+		);
+
+		$decision = $this->resolver->resolve(entity: $entity);
+
+		$this->assertFalse($decision['legalHold']['active']);
+		$this->assertSame(1, $decision['legalHold']['releasedCount']);
+	}
+
+	/**
+	 * An object never placed on hold reports no hold at all, rather than an
+	 * inactive one — otherwise every object in the register looks like it has
+	 * a hold history.
+	 */
+	public function testReportsNoLegalHoldWhenNeverHeld(): void {
+		$entity = $this->entityWith(retention: ['archiefnominatie' => 'vernietigen']);
+
+		$decision = $this->resolver->resolve(entity: $entity);
+
+		$this->assertNull($decision['legalHold']);
+	}
+
+	/**
+	 * The case this resolver exists for: an app that implements the ZGW zaak
+	 * API declares the archival fields as ORDINARY SCHEMA PROPERTIES on its own
+	 * record, and derives them on close. Reading only `@self.retention` would
+	 * have left `_retention` empty on exactly those records.
+	 */
+	public function testReadsTheArchivalFieldsTheRecordItselfDeclares(): void {
+		$entity = new ObjectEntity();
+		$entity->setObject([
+			'title' => 'Dakkapel Kerkstraat 12',
+			'archiveNomination' => 'vernietigen',
+			'archiveActionDate' => '2036-09-10',
+			'archiveStatus' => 'nog_te_archiveren',
+		]);
+
+		$decision = $this->resolver->resolve(entity: $entity);
+
+		$this->assertSame('vernietigen', $decision['nomination']);
+		$this->assertSame('2036-09-10', $decision['actionDate']);
+		$this->assertSame('nog_te_archiveren', $decision['status']);
+		$this->assertSame('record', $decision['basis']);
+	}
+
+	/**
+	 * The Dutch spelling too, for an app whose data model mirrors ZGW verbatim.
+	 */
+	public function testReadsTheDutchSpellingOfTheSameFields(): void {
+		$entity = new ObjectEntity();
+		$entity->setObject([
+			'archiefnominatie' => 'blijvend_bewaren',
+			'archiefactiedatum' => '2040-01-01',
+		]);
+
+		$decision = $this->resolver->resolve(entity: $entity);
+
+		$this->assertSame('blijvend_bewaren', $decision['nomination']);
+		$this->assertSame('2040-01-01', $decision['actionDate']);
+	}
+
+	/**
+	 * A decision recorded through the retention service beats a field an app
+	 * wrote for its own API consumers.
+	 */
+	public function testStoredRetentionWinsOverTheRecordsOwnFields(): void {
+		$entity = new ObjectEntity();
+		$entity->setRetention(['archiefnominatie' => 'blijvend_bewaren', 'archiefactiedatum' => '2099-01-01']);
+		$entity->setObject(['archiveNomination' => 'vernietigen', 'archiveActionDate' => '2030-01-01']);
+
+		$decision = $this->resolver->resolve(entity: $entity);
+
+		$this->assertSame('blijvend_bewaren', $decision['nomination']);
+		$this->assertSame('2099-01-01', $decision['actionDate']);
+	}
+
+	/**
+	 * An ordinary record with no archival claim anywhere still resolves to
+	 * nothing, so the key stays absent rather than becoming a row of dashes on
+	 * every object in every register.
+	 */
+	public function testAnOrdinaryRecordStillHasNoDecision(): void {
+		$entity = new ObjectEntity();
+		$entity->setObject(['title' => 'Just a record', 'status' => 'active']);
+
+		$this->assertNull($this->resolver->resolve(entity: $entity));
+	}
+
+	/**
+	 * The resolved decision reaches a client through `@self._retention`, which
+	 * is the whole point of the merge.
+	 */
+	public function testTheDecisionSerializesIntoTheSelfEnvelope(): void {
+		$entity = $this->entityWith(retention: ['archiefnominatie' => 'vernietigen']);
+
+		$entity->setArchivalRetention($this->resolver->resolve(entity: $entity));
+		$serialized = $entity->jsonSerialize();
+
+		$this->assertSame('vernietigen', $serialized['@self']['_retention']['nomination']);
+	}
+
+}//end class

--- a/tests/Unit/Service/Object/ObjectVersionHandlerTest.php
+++ b/tests/Unit/Service/Object/ObjectVersionHandlerTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * ObjectVersionHandler tests.
+ *
+ * Pins the behaviour that `@self.version` is stamped on create and bumped on
+ * update — the field that, before this handler, nothing in the repository ever
+ * wrote on an ObjectEntity.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Object
+ *
+ * @author   Conduction Development Team <dev@conduction.nl>
+ * @license  EUPL-1.2
+ *
+ * @spec openspec/specs/object-lifecycle/spec.md
+ */
+
+namespace Unit\Service\Object;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\Object\ObjectVersionHandler;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for ObjectVersionHandler.
+ */
+class ObjectVersionHandlerTest extends TestCase {
+
+	private ObjectVersionHandler $handler;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->handler = new ObjectVersionHandler();
+	}
+
+	/**
+	 * A new object with no version starts the sequence.
+	 */
+	public function testStampsInitialVersionOnAnUnversionedEntity(): void {
+		$entity = new ObjectEntity();
+
+		$this->handler->stampInitialVersion(entity: $entity);
+
+		$this->assertSame('0.0.1', $entity->getVersion());
+	}
+
+	/**
+	 * A version the caller brought — an import, a federation pull — is kept.
+	 */
+	public function testStampKeepsAnExistingParsableVersion(): void {
+		$entity = new ObjectEntity();
+		$entity->setVersion('2.4.9');
+
+		$this->handler->stampInitialVersion(entity: $entity);
+
+		$this->assertSame('2.4.9', $entity->getVersion());
+	}
+
+	/**
+	 * An unusable stored version is replaced rather than kept, so the object
+	 * ends up on the sequence instead of carrying a value no reader can order.
+	 */
+	public function testStampReplacesAnUnusableVersion(): void {
+		$entity = new ObjectEntity();
+		$entity->setVersion('not-a-version');
+
+		$this->handler->stampInitialVersion(entity: $entity);
+
+		$this->assertSame('0.0.1', $entity->getVersion());
+	}
+
+	/**
+	 * A save is a patch.
+	 */
+	public function testBumpAdvancesThePatchComponent(): void {
+		$entity = new ObjectEntity();
+		$entity->setVersion('0.0.1');
+
+		$this->handler->bumpVersion(entity: $entity);
+
+		$this->assertSame('0.0.2', $entity->getVersion());
+	}
+
+	/**
+	 * A stored minor/major is respected — the bump does not walk the object
+	 * back onto the `0.0.x` line.
+	 */
+	public function testBumpPreservesMajorAndMinor(): void {
+		$entity = new ObjectEntity();
+		$entity->setVersion('1.4.2');
+
+		$this->handler->bumpVersion(entity: $entity);
+
+		$this->assertSame('1.4.3', $entity->getVersion());
+	}
+
+	/**
+	 * The patch component carries past nine without borrowing into the minor:
+	 * these are three independent integers, not a decimal.
+	 */
+	public function testBumpDoesNotCarryIntoTheMinor(): void {
+		$entity = new ObjectEntity();
+		$entity->setVersion('1.4.9');
+
+		$this->handler->bumpVersion(entity: $entity);
+
+		$this->assertSame('1.4.10', $entity->getVersion());
+	}
+
+	/**
+	 * The row this whole handler exists for: a magic-table object that predates
+	 * it and carries NULL. It joins the sequence rather than staying blank.
+	 */
+	public function testBumpStartsTheSequenceOnANullVersion(): void {
+		$entity = new ObjectEntity();
+
+		$this->handler->bumpVersion(entity: $entity);
+
+		$this->assertSame('0.0.1', $entity->getVersion());
+	}
+
+	/**
+	 * A two-part version is not arithmetic this handler will do: producing
+	 * `1.0.1` from `1.0` would invent a patch component the source never had.
+	 */
+	public function testBumpRestartsOnATwoPartVersion(): void {
+		$entity = new ObjectEntity();
+		$entity->setVersion('1.0');
+
+		$this->handler->bumpVersion(entity: $entity);
+
+		$this->assertSame('0.0.1', $entity->getVersion());
+	}
+
+	/**
+	 * A non-numeric component is refused for the same reason.
+	 */
+	public function testBumpRestartsOnANonNumericComponent(): void {
+		$entity = new ObjectEntity();
+		$entity->setVersion('1.0.x');
+
+		$this->handler->bumpVersion(entity: $entity);
+
+		$this->assertSame('0.0.1', $entity->getVersion());
+	}
+
+}//end class


### PR DESCRIPTION
Two fields that OpenRegister has declared in `@self` for a long time, and that nothing ever wrote.

## `@self.version`

A fleet-wide grep for `setVersion(` on an `ObjectEntity` finds configurations, flows and migration packs, plus one call inside `AuditTrailMapper::revertObject()`. **Nothing on the create or update path.**

The legacy `oc_openregister_objects` table hid this behind a column default of `0.0.1`, so every row read back a plausible-looking version that had never moved. The magic per-schema tables carry no such default, so there the field is simply `NULL` — and `oc_openregister_audit_trails.version` was empty for the same reason, since it copies from the object.

A version that never changes is worse than no version, because it reads as an answer.

`ObjectVersionHandler` now stamps `0.0.1` on create and bumps the patch on update, on both the single-object and the bulk path, and the audit row records the version each change produced.

One deliberate asymmetry: a bulk **UPDATE** leaves `_version` alone. A bulk write is an import or a synchronisation, a sync pass that changed nothing must not advance a version, and letting the incoming value win would walk every re-imported object back to `0.0.1` on every pass.

## `@self._retention`

The slot has been declared in `getObjectArray()` since `add-archival-annotation-support`. `setArchivalRetention()` — the only way to fill it — was called from exactly one place in the repository: a unit test.

Meanwhile the facts sat unmerged in three sub-blocks of `retention`:

1. `archiefnominatie` / `bewaartermijn` / `archiefactiedatum`, written by `RetentionService::applyArchivalMetadata()` but only for schemas whose `archive` block is enabled
2. `retention.annotation`, the `x-openregister-archival` evaluation written by `RenderObject`
3. `retention.legalHold`, which overrides both and which neither of the others mentions

…and, for an app implementing the ZGW zaak API, in a fourth place entirely: the record's own `archiveNomination` / `archiveActionDate` properties. dossiq derives those from a case's resultaattype on close (zrc-021) and writes them as ordinary schema fields.

So every consuming app grew its own archival fields instead, the same question had a different answer per app, and no shared surface could ask it once.

`ArchivalDecisionResolver` merges all four into one app-neutral answer, attached by the render layer:

| key | meaning |
|-----|---------|
| `nomination` | what happens to the record (`blijvend_bewaren` / `vernietigen` / …) |
| `period` | the retention period |
| `actionDate` | when it falls due |
| `status` | archival status |
| `classification` | selection-list category |
| `basis` | **which authority the answer rests on** (`selectielijst` / `schema` / `record` / `annotation`) |
| `source` | the named source |
| `legalHold` | active hold, or a released one with its history |

It reads the ZGW vocabulary in **both** spellings (`archiveNomination` and `archiefnominatie`), so an app that derives a nomination onto its record gets `_retention` for free without openregister learning any app-specific name. A decision recorded through the retention service still wins over a field an app wrote for its own API consumers.

`_retention` is **omitted entirely** when an object has no archival claim. That is deliberate: an empty `{}` reads as "we looked and there is no obligation", which a records officer must be able to tell apart from "this schema never declared one".

## Verification

Run locally, by exit code:

- `phpcs`, `phpmd`, `psalm`, `phpstan` — clean on every changed file
- `phpunit tests/Unit` — **19507 tests, exit 0**
- Both new guards **mutation-checked**: breaking the version bump reddened 3 assertions, inverting the retention precedence reddened 1, and restoring returned each to green

One incidental fix: `AuditTrail` was missing its `@method setVersion()` annotation, which is why PHPStan could not see the magic setter.

## Pre-existing, and NOT addressed here

The hydra gates run reports two failures that my diff does not touch:

- **gate-67** `openregister-contract-parity`: `lib/Contract/ObjectServiceInterface.php` differs from the copy shipped in the `hydra-gates` package. That fix belongs in `ConductionNL/.github`, not here.
- **gate-95** `adr-number-collision`: ADR-037 is claimed by two documents inside **another app's** tree (`custom_apps/openbuild/.hydra/openspec/architecture`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)