### PR TITLE
fix(deps): resolve the two high-severity npm advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13152,9 +13152,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -16474,9 +16474,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -25732,9 +25732,9 @@
       "license": "Python-2.0"
     },
     "node_modules/xmlbuilder2/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
`npm audit` reported two high-severity vulnerabilities, both in transitive
dependencies with non-breaking fixes:

- fast-uri 3.1.5 -> 3.1.7 (via @conduction/nextcloud-vue > ajv):
  GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf,
  GHSA-jqff-g426-hqxp — host confusion and SSRF via IDN canonicalization,
  IPv6 normalization, repeated percent-decoding and scheme normalization.
- js-yaml 3.15.1 -> 3.15.2 and 4.3.1 -> 4.3.2 (via babel-plugin-istanbul and
  xmlbuilder2): GHSA-2883-xcg3-v3hh — maxTotalMergeKeys does not limit CPU use
  for empty merge sources.

Applied with a targeted `npm update fast-uri js-yaml`, so the lockfile diff is
only those three entries; the remaining 6 low and 1 moderate findings are left
alone, since the low ones (elliptic) need a breaking
@nextcloud/webpack-vue-config major.

`npm audit --audit-level=high` is now clean and `npm run build` succeeds.
