### PR TITLE
fix(specs): repair the 15 unresolved @spec/@e2e citation targets (gate-46)

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -621,7 +621,7 @@ return [
         // — read-only, object-independent company-lookup leaves. No NC app
         // gate; the OpenConnector `kvk` / `opencorporates` sources carry the
         // base URL + API key. Unconfigured/down → 503 with details.cause.
-        // @spec openspec/changes/integration-kvk-opencorporates/specs/integration-company-lookup/spec.md.
+        // @spec openspec/changes/integration-kvk-opencorporates/specs/integration-company-lookup/spec.md
         ['name' => 'companyLookup#kvkCompany',           'url' => '/api/integrations/kvk/company',            'verb' => 'GET'],
         ['name' => 'companyLookup#kvkSearch',            'url' => '/api/integrations/kvk/search',             'verb' => 'GET'],
         ['name' => 'companyLookup#openCorporatesSearch', 'url' => '/api/integrations/opencorporates/search',  'verb' => 'GET'],
@@ -631,7 +631,7 @@ return [
         // client_credentials secret + PKIoverheid mutual-TLS client certificate
         // (both applied natively by CallService). Unconfigured/down → 503 with
         // details.cause. The BSN travels in the request body only, never logged.
-        // @spec openspec/changes/integration-brp-haalcentraal/specs/integration-person-lookup/spec.md.
+        // @spec openspec/changes/integration-brp-haalcentraal/specs/integration-person-lookup/spec.md
         ['name' => 'personLookup#brpPerson',             'url' => '/api/integrations/brp/person',             'verb' => 'GET'],
         // Outbound-messaging dispatch (external, OpenConnector-routed) —
         // side-effecting send leaf. No NC app gate; the OpenConnector
@@ -642,7 +642,7 @@ return [
         // selection, STOP opt-out, template-approval, 24h session, dedupe,
         // delivery-status); this leaf only POSTs the message. Unconfigured/down
         // → 503 with details.cause.
-        // @spec openspec/changes/messaging-dispatch-leaf/specs/integration-message-dispatch/spec.md.
+        // @spec openspec/changes/messaging-dispatch-leaf/specs/integration-message-dispatch/spec.md
         ['name' => 'messageDispatch#smsSend',            'url' => '/api/integrations/sms/send',               'verb' => 'POST'],
         ['name' => 'messageDispatch#whatsappSend',       'url' => '/api/integrations/whatsapp/send',          'verb' => 'POST'],
         // Cospend (NC Costs) — Tier-2 link-table API. User-scoped (no
@@ -696,7 +696,7 @@ return [
         // route MUST precede the wildcard `/analytics/{reportId}` unlink
         // route, and the app-global `available` picker route MUST precede
         // the per-object wildcard routes.
-        // @spec openspec/changes/integration-analytics/tasks.md.
+        // @spec openspec/changes/archive/2026-06-14-integration-analytics/tasks.md
         ['name' => 'analyticsLinks#available',    'url' => '/api/integrations/analytics/available',                  'verb' => 'GET'],
         ['name' => 'analyticsLinks#index',        'url' => '/api/objects/{register}/{schema}/{id}/analytics',        'verb' => 'GET',    'requirements' => ['id' => '[^/]+']],
         ['name' => 'analyticsLinks#createAndLink','url' => '/api/objects/{register}/{schema}/{id}/analytics/new',    'verb' => 'POST',   'requirements' => ['id' => '[^/]+']],
@@ -707,7 +707,7 @@ return [
         // A leaf (procest SLA dashboard) registers a pre-computed series
         // (labels + datasets); the render layer fetches it as a chart
         // widget. RBAC-scoped inside AnalyticsSeriesService.
-        // @spec openspec/changes/integration-leaf-foundation-shares-analytics/specs/integration-leaf-foundation/spec.md.
+        // @spec openspec/specs/integration-leaf-foundation/spec.md
         ['name' => 'analyticsSeries#register', 'url' => '/api/integrations/analytics/series',              'verb' => 'POST'],
         ['name' => 'analyticsSeries#fetch',    'url' => '/api/integrations/analytics/series/{seriesKey}',  'verb' => 'GET',  'requirements' => ['seriesKey' => '[^/]+']],
 
@@ -716,14 +716,14 @@ return [
         // widget; points queries the RBAC-scoped marker set for a
         // register/schema. RBAC enforced inside MapsOverviewService via the
         // canonical OR read path (_rbac:true for non-admins, fail-closed).
-        // @spec openspec/changes/integration-maps-overview-page-surface/specs/integration-maps-overview/spec.md.
+        // @spec openspec/specs/integration-maps-overview/spec.md
         ['name' => 'mapsOverview#register', 'url' => '/api/integrations/maps/overviews',                            'verb' => 'POST'],
         ['name' => 'mapsOverview#points',   'url' => '/api/integrations/maps/overviews/{register}/{schema}/points', 'verb' => 'GET', 'requirements' => ['register' => '[^/]+', 'schema' => '[^/]+']],
 
         // Public "track your case" token resolve — anonymous, RBAC-scoped
         // public-safe object view minted via the Shares integration
         // provider. Fails closed (404) on unknown/revoked/expired tokens.
-        // @spec openspec/changes/integration-leaf-foundation-shares-analytics/specs/integration-leaf-foundation/spec.md.
+        // @spec openspec/specs/integration-leaf-foundation/spec.md
         ['name' => 'caseToken#resolve', 'url' => '/api/public/case-tokens/{token}', 'verb' => 'GET', 'requirements' => ['token' => '[^/]+']],
 
         // Vocabulary (skos-concept-registers) — public read-only SKOS concept
@@ -743,7 +743,7 @@ return [
         // app-global `types`/`actors` dropdown routes MUST precede the
         // per-object wildcard route so they aren't grabbed as register
         // slugs.
-        // @spec openspec/changes/integration-activity/tasks.md.
+        // @spec openspec/changes/archive/2026-06-14-integration-activity/tasks.md
         ['name' => 'activityLinks#types',  'url' => '/api/integrations/activity/types',                  'verb' => 'GET'],
         ['name' => 'activityLinks#actors', 'url' => '/api/integrations/activity/actors',                 'verb' => 'GET'],
         ['name' => 'activityLinks#index',  'url' => '/api/objects/{register}/{schema}/{id}/activity',    'verb' => 'GET', 'requirements' => ['id' => '[^/]+']],

--- a/tests/e2e/spec-coverage/entity-management-modals.spec.ts
+++ b/tests/e2e/spec-coverage/entity-management-modals.spec.ts
@@ -5,7 +5,7 @@
  * UI-only Playwright e2e tests for spec `entity-management-modals`.
  *
  * TAG CONVENTION: each test carries
- *   @e2e openspec/specs/entity-management-modals/spec.md#<scenario-slug>
+ *   @e2e `openspec/specs/entity-management-modals/spec.md#<scenario-slug>`
  *
  * Methodology: drive the real UI — log in, click buttons, fill forms,
  * assert the rendered DOM.  The OR REST API is used ONLY for test-data

--- a/tests/e2e/spec-coverage/features-roadmap-surface.spec.ts
+++ b/tests/e2e/spec-coverage/features-roadmap-surface.spec.ts
@@ -35,7 +35,8 @@ import type { Page } from '@playwright/test'
  *   4. No `test.skip()`.
  *
  * @e2e openspec/specs/features-roadmap-menu/spec.md#empty-features-manifest
- * @e2e openspec/specs/features-roadmap-menu/spec.md#submit-requires-title-and-body
+ * @e2e openspec/specs/features-roadmap-menu/spec.md#the-header-offers-a-link-to-the-forge-not-a-form
+ * @e2e openspec/specs/features-roadmap-menu/spec.md#nothing-is-submitted-from-the-app
  * @e2e openspec/specs/features-roadmap-menu/spec.md#default-behavior
  */
 import { expect, test } from '@playwright/test'

--- a/tests/e2e/spec-coverage/files-sidebar-tabs.spec.ts
+++ b/tests/e2e/spec-coverage/files-sidebar-tabs.spec.ts
@@ -5,7 +5,7 @@
  * UI-only Playwright e2e tests for spec `files-sidebar-tabs`.
  *
  * TAG CONVENTION: each test carries
- *   @e2e openspec/specs/files-sidebar-tabs/spec.md#<scenario-slug>
+ *   @e2e `openspec/specs/files-sidebar-tabs/spec.md#<scenario-slug>`
  *
  * Methodology: drive the real UI (EntitiesSideBar on /entities,
  * DeletedSideBar on /deleted).

--- a/tests/e2e/spec-coverage/mdm-frontend.spec.ts
+++ b/tests/e2e/spec-coverage/mdm-frontend.spec.ts
@@ -5,7 +5,7 @@
  * Spec-coverage e2e tests for: mdm-frontend (ADR-045 #3).
  *
  * TAG CONVENTION: each test carries
- *   @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#<scenario-slug>
+ *   @e2e `openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#<scenario-slug>`
  *
  * Methodology: drive the real UI. The five MDM views live under the hash-mode
  * router (`/index.php/apps/openregister/<route>`); the shared

--- a/tests/e2e/spec-coverage/mdm-merge-ui.spec.ts
+++ b/tests/e2e/spec-coverage/mdm-merge-ui.spec.ts
@@ -5,7 +5,7 @@
  * Spec-coverage e2e tests for: mdm-merge-ui (ADR-045 follow-on #C).
  *
  * TAG CONVENTION: each test carries
- *   @e2e openspec/changes/mdm-merge-ui/specs/mdm-merge-ui/spec.md#<scenario-slug>
+ *   @e2e `openspec/changes/mdm-merge-ui/specs/mdm-merge-ui/spec.md#<scenario-slug>`
  *
  * Methodology: drive the real UI. When the self-seeding MDM fixture
  * (tests/e2e/mdm-seed.ts, run in globalSetup) has planted a duplicate pair,

--- a/tests/e2e/spec-coverage/mdm-survivorship-override.spec.ts
+++ b/tests/e2e/spec-coverage/mdm-survivorship-override.spec.ts
@@ -5,7 +5,7 @@
  * Spec-coverage e2e tests for: mdm-survivorship-override (ADR-045 follow-on #E).
  *
  * TAG CONVENTION: each test carries
- *   @e2e openspec/changes/mdm-survivorship-override/specs/<capability>/spec.md#<scenario-slug>
+ *   @e2e `openspec/changes/mdm-survivorship-override/specs/<capability>/spec.md#<scenario-slug>`
  *
  * Methodology: drive the real UI. When the self-seeding MDM fixture
  * (tests/e2e/mdm-seed.ts, run in globalSetup) has planted a multi-source

--- a/tests/e2e/spec-coverage/saved-search-views.spec.ts
+++ b/tests/e2e/spec-coverage/saved-search-views.spec.ts
@@ -5,7 +5,7 @@
  * UI-only Playwright e2e tests for spec `saved-search-views`.
  *
  * TAG CONVENTION: each test carries
- *   @e2e openspec/specs/saved-search-views/spec.md#<scenario-slug>
+ *   @e2e `openspec/specs/saved-search-views/spec.md#<scenario-slug>`
  *
  * Methodology: drive the real SearchSideBar.vue UI on the /tables route.
  * The OR REST API is used ONLY for test-data teardown.


### PR DESCRIPTION
`gate-46 spec-anchor-existence` has been **failing on `development` itself**, not just on a PR — 15 unresolved findings from 14 distinct targets, the same count on every run, so every PR inherits a red gate it did not cause.

Three separate causes. **None of them is a missing spec.**

## 1. Seven citations in `routes.php` ended in a full stop

The gate captures `openspec/[^\s\`'"]+`, so a sentence-ending period becomes part of the path and `spec.md.` resolves to nothing.

| Target | Cause | Now points at |
|---|---|---|
| `integration-kvk-opencorporates/.../spec.md.` | period only | same path, no period |
| `integration-brp-haalcentraal/.../spec.md.` | period only | same path, no period |
| `messaging-dispatch-leaf/.../spec.md.` | period only | same path, no period |
| `integration-leaf-foundation-shares-analytics/...` ×2 | archived | `openspec/specs/integration-leaf-foundation/spec.md` |
| `integration-maps-overview-page-surface/...` | archived | `openspec/specs/integration-maps-overview/spec.md` |
| `integration-activity/tasks.md.` | archived | `openspec/changes/archive/2026-06-14-integration-activity/tasks.md` |
| `integration-analytics/tasks.md.` | archived | `openspec/changes/archive/2026-06-14-integration-analytics/tasks.md` |

For the archived ones the rule is **canonical spec where one exists, archive otherwise** — an archive path moves again the next time a change is re-filed, so pointing at the canonical spec is the durable choice. The two whose target is a `tasks.md` get the archive path, because a task list has no canonical home.

## 2. Six format examples were scanned as real citations

Each `tests/e2e/spec-coverage/*.spec.ts` opens with a `TAG CONVENTION` block showing the shape of the tag:

```
 *   @e2e openspec/specs/entity-management-modals/spec.md#<scenario-slug>
```

The gate cannot tell an example from a citation, so it reported `#<scenario-slug>` (and `<capability>`) as an unresolved anchor **on every run, forever** — six of the fifteen findings were this one pattern.

Backticking the example target settles it: the tag regex excludes backticks from the path, so a backticked example does not match at all. It also reads better in a docblock.

## 3. One anchor named a retired scenario

`features-roadmap-surface.spec.ts` cited `#submit-requires-title-and-body`. That scenario is gone, and deliberately: the feature moved from an in-app submit form to a link out to the forge, so a scenario about validating a form's title and body no longer describes anything.

It now cites the two scenarios that replaced it — *The header offers a link to the forge, not a form* and *Nothing is submitted from the app* — both of which the existing test at line 172 already covers.

## Verification

Run the way CI runs it: the gate script from `ConductionNL/.github@main`, **not** the vendored copy.

That distinction matters and cost me a detour — the vendored `hydra-gates` in this repo is older and finds **none** of this, so a local run reports a clean gate while CI reports 15. Measured over every tracked file:

```
before: 15 findings
after:   0 findings
```

No test changed behaviour. The only edits are comment targets and one `php -l`-clean comment block in `appinfo/routes.php`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)