### PR TITLE
feat(registers): resolve a register by any slug it has answered to

### DIFF
--- a/lib/AppHost/Scheduling/ScheduleReconciler.php
+++ b/lib/AppHost/Scheduling/ScheduleReconciler.php
@@ -41,6 +41,7 @@ namespace OCA\OpenRegister\AppHost\Scheduling;
 
 use DateTime;
 use DateTimeInterface;
+use OCA\OpenRegister\Contract\RegisterSlugResolverInterface;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
@@ -56,9 +57,14 @@ use Throwable;
  */
 class ScheduleReconciler {
 	/**
-	 * OpenConnector register slug that owns the `job` schema.
+	 * The CANONICAL slug of the register that owns the `job` schema.
+	 *
+	 * Not the slug to read with. Integriq's repair step renames the register
+	 * from `openconnector` to `integriq` per instance, so both are live across
+	 * the estate at once and this constant is only the question. The answer
+	 * comes from {@see registerSlug()}, which asks what this instance carries.
 	 */
-	private const OC_REGISTER_SLUG = 'openconnector';
+	private const OC_REGISTER_CANONICAL = 'integriq';
 
 	/**
 	 * OpenConnector `job` schema slug.
@@ -73,9 +79,11 @@ class ScheduleReconciler {
 	private const SWEEP_LIMIT = 1000;
 
 	/**
-	 * OpenBuild register slug that owns virtual-app `application` objects.
+	 * The CANONICAL slug of the register that owns virtual-app `application`
+	 * objects. Buildiq's repair step renames it from `openbuild` to `buildiq`;
+	 * see {@see OC_REGISTER_CANONICAL}.
 	 */
-	private const OB_REGISTER_SLUG = 'openbuild';
+	private const OB_REGISTER_CANONICAL = 'buildiq';
 
 	/**
 	 * OpenBuild `application` schema slug.
@@ -104,6 +112,9 @@ class ScheduleReconciler {
 	 *                                           map.
 	 * @param IUserManager $userManager Resolves an owner UID to a live NC user.
 	 * @param LoggerInterface $logger Secret-free diagnostics.
+	 * @param RegisterSlugResolverInterface $slugResolver Resolves a register by
+	 *                                                    whichever slug this
+	 *                                                    instance carries.
 	 */
 	public function __construct(
 		private readonly ObjectService $objectService,
@@ -112,8 +123,49 @@ class ScheduleReconciler {
 		private readonly ScheduleActionAllowList $allowList,
 		private readonly IUserManager $userManager,
 		private readonly LoggerInterface $logger,
+		private readonly RegisterSlugResolverInterface $slugResolver,
 	) {
 	}//end __construct()
+
+	/**
+	 * The slug to read a register with here, or null when it is not here.
+	 *
+	 * Every read below used to name a literal, and a literal the instance had
+	 * renamed did not fail: `ObjectService` found no register, matched no rows,
+	 * and returned an empty set. An empty set is what a healthy empty register
+	 * returns, so the reconciler enumerated nothing, upserted nothing and
+	 * garbage-collected nothing while reporting success. Every AppHost schedule
+	 * stopped firing and the only trace was an `info` line.
+	 *
+	 * The null return is the point: a caller cannot use it by accident, and the
+	 * absence it reports is a real absence under EVERY slug the register has
+	 * answered to rather than a guess about one.
+	 *
+	 * @param string $canonical The canonical register slug.
+	 *
+	 * @return string|null The slug this instance carries, or null.
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	private function registerSlug(string $canonical): ?string {
+		$resolution = $this->slugResolver->resolve(canonical: $canonical);
+		if ($resolution->isResolved() === false) {
+			return null;
+		}
+
+		if ($resolution->isAmbiguous() === true) {
+			// Two rows the rename should have collapsed into one. Reads go to
+			// the canonical row, so the sweep keeps working, but a sweep that
+			// silently picks one of two registers is a sweep whose results
+			// nobody can reproduce.
+			$this->logger->warning(
+				message: '[AppHost\\Scheduling] Reconciling against one of two registers carrying this app\'s slugs',
+				context: ['canonical' => $canonical, 'matched' => $resolution->matched]
+			);
+		}
+
+		return $resolution->slug;
+	}//end registerSlug()
 
 	/**
 	 * Reconcile every declared schedule into an OpenConnector job (never throws).
@@ -467,11 +519,20 @@ class ScheduleReconciler {
 	 * @spec openspec/changes/apphost-manifest-schedules/specs/apphost-scheduling/spec.md
 	 */
 	protected function loadManagedJobs(): ?array {
+		$register = $this->registerSlug(canonical: self::OC_REGISTER_CANONICAL);
+		if ($register === null) {
+			$this->logger->info(
+				message: '[AppHost\\Scheduling] No job register under any known slug; scheduling inert',
+				context: ['canonical' => self::OC_REGISTER_CANONICAL]
+			);
+			return null;
+		}
+
 		try {
 			$rows = $this->objectService->findAll(
 				config: [
 					'filters' => [
-						'register' => self::OC_REGISTER_SLUG,
+						'register' => $register,
 						'schema' => self::OC_JOB_SCHEMA_SLUG,
 					],
 					'limit' => self::SWEEP_LIMIT,
@@ -481,7 +542,7 @@ class ScheduleReconciler {
 		} catch (Throwable $e) {
 			$this->logger->info(
 				message: '[AppHost\\Scheduling] OpenConnector job register/schema unavailable; scheduling inert',
-				context: ['reason' => $e->getMessage()]
+				context: ['register' => $register, 'reason' => $e->getMessage()]
 			);
 			return null;
 		}
@@ -507,6 +568,15 @@ class ScheduleReconciler {
 	 * @spec openspec/changes/apphost-manifest-schedules/specs/apphost-scheduling/spec.md
 	 */
 	protected function loadVirtualApplications(): array {
+		$register = $this->registerSlug(canonical: self::OB_REGISTER_CANONICAL);
+		if ($register === null) {
+			$this->logger->info(
+				message: '[AppHost\\Scheduling] No application register under any known slug; virtual apps skipped',
+				context: ['canonical' => self::OB_REGISTER_CANONICAL]
+			);
+			return [];
+		}
+
 		try {
 			// NOTE: pass ONLY `_rbac: false` (a system sweep must see apps
 			// regardless of owner). Do NOT also pass `_multitenancy: false`:
@@ -517,7 +587,7 @@ class ScheduleReconciler {
 			$rows = $this->objectService->findAll(
 				config: [
 					'filters' => [
-						'register' => self::OB_REGISTER_SLUG,
+						'register' => $register,
 						'schema' => self::OB_APPLICATION_SCHEMA_SLUG,
 					],
 					'limit' => self::SWEEP_LIMIT,
@@ -526,8 +596,8 @@ class ScheduleReconciler {
 			);
 		} catch (Throwable $e) {
 			$this->logger->info(
-				message: '[AppHost\\Scheduling] openbuild application register/schema unavailable; virtual apps skipped',
-				context: ['reason' => $e->getMessage()]
+				message: '[AppHost\\Scheduling] Application register/schema unavailable; virtual apps skipped',
+				context: ['register' => $register, 'reason' => $e->getMessage()]
 			);
 			return [];
 		}//end try
@@ -596,10 +666,19 @@ class ScheduleReconciler {
 	 * @spec openspec/changes/apphost-manifest-schedules/specs/apphost-scheduling/spec.md
 	 */
 	protected function saveJob(array $data, ?string $uuid): void {
+		$register = $this->registerSlug(canonical: self::OC_REGISTER_CANONICAL);
+		if ($register === null) {
+			$this->logger->error(
+				message: '[AppHost\\Scheduling] No job register under any known slug; job not persisted',
+				context: ['reference' => ($data['reference'] ?? ''), 'canonical' => self::OC_REGISTER_CANONICAL]
+			);
+			return;
+		}
+
 		try {
 			$this->objectService->saveObject(
 				object: $data,
-				register: self::OC_REGISTER_SLUG,
+				register: $register,
 				schema: self::OC_JOB_SCHEMA_SLUG,
 				uuid: $uuid,
 				_rbac: false
@@ -666,10 +745,15 @@ class ScheduleReconciler {
 			return [];
 		}
 
+		$register = $this->registerSlug(canonical: self::OB_REGISTER_CANONICAL);
+		if ($register === null) {
+			return [];
+		}
+
 		try {
 			$version = $this->objectService->find(
 				id: $versionId,
-				register: self::OB_REGISTER_SLUG,
+				register: $register,
 				schema: self::OB_APPLICATION_VERSION_SCHEMA_SLUG,
 				_rbac: false
 			);

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -42,6 +42,7 @@ use OCA\OpenRegister\AppHost\Observability\Source\TableMetricSource;
 use OCA\OpenRegister\Capabilities\IntegrationsCapability;
 use OCA\OpenRegister\Capabilities\UrnCapability;
 use OCA\OpenRegister\ContextChat\ContentProviderRegistrationListener;
+use OCA\OpenRegister\Contract\RegisterSlugResolverInterface;
 use OCA\OpenRegister\Controller\AnalyticsSeriesController;
 use OCA\OpenRegister\Controller\CaseTokenController;
 use OCA\OpenRegister\Controller\IntegrationsController;
@@ -232,6 +233,7 @@ use OCA\OpenRegister\Service\OpenProjectLinkService;
 use OCA\OpenRegister\Service\OrganisationService;
 use OCA\OpenRegister\Service\PhotoLinkService;
 use OCA\OpenRegister\Service\Portal\PortalPartyResolver;
+use OCA\OpenRegister\Service\RegisterSlugResolver;
 use OCA\OpenRegister\Service\Schema\SchemaDiffService;
 use OCA\OpenRegister\Service\Schema\SchemaMigrationPlanner;
 use OCA\OpenRegister\Service\Schema\SchemaMigrationService;
@@ -282,6 +284,7 @@ use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\Security\IContentSecurityPolicyManager;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class Application
@@ -430,11 +433,11 @@ class Application extends App implements IBootstrap {
 		// registration the memo would be empty every time and the probe would
 		// re-read the register table once per call site.
 		$context->registerService(
-			\OCA\OpenRegister\Service\RegisterSlugResolver::class,
+			RegisterSlugResolver::class,
 			function ($c) {
-				return new \OCA\OpenRegister\Service\RegisterSlugResolver(
-					registerMapper: $c->get(\OCA\OpenRegister\Db\RegisterMapper::class),
-					logger: $c->get(\Psr\Log\LoggerInterface::class)
+				return new RegisterSlugResolver(
+					registerMapper: $c->get(RegisterMapper::class),
+					logger: $c->get(LoggerInterface::class)
 				);
 			}
 		);
@@ -443,9 +446,9 @@ class Application extends App implements IBootstrap {
 		// the same shared instance, so an app that injects the interface and one
 		// that injects the class share a memo rather than probing twice.
 		$context->registerService(
-			\OCA\OpenRegister\Contract\RegisterSlugResolverInterface::class,
+			RegisterSlugResolverInterface::class,
 			function ($c) {
-				return $c->get(\OCA\OpenRegister\Service\RegisterSlugResolver::class);
+				return $c->get(RegisterSlugResolver::class);
 			}
 		);
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -423,6 +423,32 @@ class Application extends App implements IBootstrap {
 			}
 		);
 
+		// The register-slug resolver MUST be shared. It memoises one indexed
+		// read per candidate list for the life of the request, and a sweep asks
+		// the same question at every call site of the same tick. Nextcloud
+		// auto-wires a fresh instance at every injection point, so without this
+		// registration the memo would be empty every time and the probe would
+		// re-read the register table once per call site.
+		$context->registerService(
+			\OCA\OpenRegister\Service\RegisterSlugResolver::class,
+			function ($c) {
+				return new \OCA\OpenRegister\Service\RegisterSlugResolver(
+					registerMapper: $c->get(\OCA\OpenRegister\Db\RegisterMapper::class),
+					logger: $c->get(\Psr\Log\LoggerInterface::class)
+				);
+			}
+		);
+
+		// The published contract (ADR-084) consuming apps type-hint. Bound to
+		// the same shared instance, so an app that injects the interface and one
+		// that injects the class share a memo rather than probing twice.
+		$context->registerService(
+			\OCA\OpenRegister\Contract\RegisterSlugResolverInterface::class,
+			function ($c) {
+				return $c->get(\OCA\OpenRegister\Service\RegisterSlugResolver::class);
+			}
+		);
+
 		// Register the LanguageMiddleware for Accept-Language header parsing.
 		$context->registerMiddleware(LanguageMiddleware::class);
 

--- a/lib/Contract/RegisterSlugResolution.php
+++ b/lib/Contract/RegisterSlugResolution.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * RegisterSlugResolution: the answer to "which slug does this register
+ * actually answer to on this instance?".
+ *
+ * The type exists so that "not found" cannot be mistaken for "found nothing".
+ * A resolver returning a bare string has to return SOMETHING on a miss, and
+ * whatever it returns is passed straight into a read that then comes back
+ * empty. An empty result set is indistinguishable from a register that holds no
+ * objects, so the caller records "no data" and nobody is alerted. That is the
+ * exact failure this whole mechanism exists to remove, so the absence is a
+ * state the caller has to branch on rather than a string it can use by
+ * accident.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Contract
+ * @package  OCA\OpenRegister\Contract
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Contract;
+
+/**
+ * An immutable register-slug resolution.
+ *
+ * @spec openspec/specs/register-slug-resolution/spec.md
+ */
+final class RegisterSlugResolution {
+
+	/**
+	 * Exactly one candidate slug exists on this instance.
+	 *
+	 * @var string
+	 */
+	public const RESOLVED = 'resolved';
+
+	/**
+	 * No candidate slug exists on this instance.
+	 *
+	 * @var string
+	 */
+	public const ABSENT = 'absent';
+
+	/**
+	 * More than one candidate slug exists on this instance.
+	 *
+	 * The repair steps refuse to merge in this case rather than guessing, so
+	 * the state is reachable and means an operator has to act.
+	 *
+	 * @var string
+	 */
+	public const AMBIGUOUS = 'ambiguous';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string       $canonical  The canonical slug that was asked for.
+	 * @param string|null  $slug       The slug this instance answers to, or null when absent.
+	 * @param string       $state      One of RESOLVED, ABSENT, AMBIGUOUS.
+	 * @param list<string> $candidates The candidate slugs that were probed, newest first.
+	 * @param list<string> $matched    The candidate slugs that exist here, in candidate order.
+	 */
+	public function __construct(
+		public readonly string $canonical,
+		public readonly ?string $slug,
+		public readonly string $state,
+		public readonly array $candidates,
+		public readonly array $matched,
+	) {
+	}//end __construct()
+
+	/**
+	 * Whether a slug was found, whether or not it was the only one.
+	 *
+	 * @return bool True when {@see $slug} is usable.
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public function isResolved(): bool {
+		return $this->slug !== null;
+	}//end isResolved()
+
+	/**
+	 * Whether this register is absent from this instance under every known slug.
+	 *
+	 * @return bool True when nothing matched.
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public function isAbsent(): bool {
+		return $this->state === self::ABSENT;
+	}//end isAbsent()
+
+	/**
+	 * Whether more than one of the register's slugs exists here.
+	 *
+	 * @return bool True when the instance carries two rows the rename should
+	 *              have collapsed into one.
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public function isAmbiguous(): bool {
+		return $this->state === self::AMBIGUOUS;
+	}//end isAmbiguous()
+}//end class

--- a/lib/Contract/RegisterSlugResolverInterface.php
+++ b/lib/Contract/RegisterSlugResolverInterface.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * RegisterSlugResolverInterface: the published probe for "which slug does this
+ * register answer to here?".
+ *
+ * ## Why this is published from OpenRegister and not copied into each app
+ *
+ * Register slugs live in `openregister_registers`. No consuming app can answer
+ * the question without reaching into this app's storage, so every per-app copy
+ * of the answer is a copy of OpenRegister's truth maintained by someone who
+ * does not own it. ADR-084 already settled that argument once for
+ * {@see ObjectServiceInterface}: ten apps hand-rolled a double of
+ * `ObjectService`, declaring between 0 and 13 methods against a real class of
+ * 88, and the fix was one definition owned by the app that implements it.
+ * The same reasoning applies here with less room for doubt, because the
+ * candidate slugs are not derivable. See {@see \OCA\OpenRegister\Support\RegisterSlugAliases}.
+ *
+ * ## What a caller does with the answer
+ *
+ * Ask once, per operation, and branch on the result:
+ *
+ *     $resolution = $resolver->resolve(canonical: 'buildiq');
+ *     if ($resolution->isResolved() === false) {
+ *         // The register is genuinely not here. Say so. Do NOT read with the
+ *         // canonical slug and report the empty result as "no data".
+ *         return ...;
+ *     }
+ *     $rows = $objectService->findAll(config: ['filters' => [
+ *         'register' => $resolution->slug,
+ *         'schema'   => 'job',
+ *     ]]);
+ *
+ * The branch is the point. A caller that skips it and uses `?->slug ?? 'buildiq'`
+ * has reinstated the defect: on an unmigrated instance the read returns zero
+ * rows, and zero rows is what a healthy empty register returns too.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Contract
+ * @package  OCA\OpenRegister\Contract
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Contract;
+
+/**
+ * Resolves a register by any of the slugs it has answered to.
+ *
+ * @spec openspec/specs/register-slug-resolution/spec.md
+ */
+interface RegisterSlugResolverInterface {
+
+	/**
+	 * Which slug this instance's copy of a register actually answers to.
+	 *
+	 * @param string       $canonical  The canonical (current) register slug, e.g. `buildiq`.
+	 * @param list<string> $candidates Explicit candidates, newest first, for a
+	 *                                 register whose rename this app does not
+	 *                                 know about. Empty means "use the declared
+	 *                                 alias list", which is the normal call.
+	 *
+	 * @return RegisterSlugResolution The slug to use, or an explicit absence.
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public function resolve(string $canonical, array $candidates=[]): RegisterSlugResolution;
+
+	/**
+	 * The slug to read with, or null when the register is not on this instance.
+	 *
+	 * The convenience form, for a caller that has nothing useful to say about
+	 * ambiguity. It still cannot fall open: null is the only "not here" answer
+	 * it can give, and null is not a slug any read will accept.
+	 *
+	 * @param string       $canonical  The canonical (current) register slug.
+	 * @param list<string> $candidates Explicit candidates, newest first.
+	 *
+	 * @return string|null The slug to use, or null.
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public function slugOrNull(string $canonical, array $candidates=[]): ?string;
+}//end interface

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -733,7 +733,7 @@ class SettingsController extends Controller {
 	 *
 	 * @return JSONResponse JSON response with type filtering debug information
 	 *
-	 * @psalm-return JSONResponse<200|500,
+	 * @psalm-return JSONResponse<200|404|500,
 	 *     array{error?: string, trace?: string,
 	 *     all_organizations?: array{count: int<0, max>,
 	 *     organizations: array<array{id: int, name: null|string,
@@ -765,8 +765,23 @@ class SettingsController extends Controller {
 			// Get services.
 			$objectService = $this->container->get(\OCA\OpenRegister\Service\ObjectService::class);
 
-			// Set register and schema context.
-			$objectService->setRegister('voorzieningen');
+			// Set register and schema context. The register slug is RESOLVED,
+			// not written: stackiq's repair step renames it from
+			// `voorzieningen` to `stackiq` per instance, and reading with the
+			// name this instance does not carry returns an empty set that this
+			// endpoint would have rendered as "no organisations". That is the
+			// wrong answer for a diagnostic whose whole job is to say whether
+			// filtering works.
+			$slugResolver = $this->container->get(\OCA\OpenRegister\Contract\RegisterSlugResolverInterface::class);
+			$register = $slugResolver->slugOrNull(canonical: 'stackiq');
+			if ($register === null) {
+				return new JSONResponse(
+					data: ['error' => 'No stackiq register on this instance under any of its known slugs.'],
+					statusCode: 404
+				);
+			}
+
+			$objectService->setRegister($register);
 			$objectService->setSchema('organisation');
 
 			$results = [];

--- a/lib/Service/RegisterSlugResolver.php
+++ b/lib/Service/RegisterSlugResolver.php
@@ -1,0 +1,265 @@
+<?php
+
+/**
+ * RegisterSlugResolver: reads which slug a register actually carries here.
+ *
+ * The implementation of {@see RegisterSlugResolverInterface}. It answers from
+ * the `openregister_registers` table and from nothing else.
+ *
+ * It deliberately does NOT consult `IAppManager`. Whether an app is installed
+ * says nothing about which slug its register carries: the app id and the
+ * register slug are moved by two different repair steps, and either can run
+ * first, so an instance running `buildiq` can hold a register row still slugged
+ * `openbuild`. {@see \OCA\OpenRegister\Support\FleetAppId} answers the app-id
+ * question from the app manager; this class answers the slug question from the
+ * register table. Using one to predict the other is how a probe reports a
+ * present register as absent.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+use OCA\OpenRegister\Contract\RegisterSlugResolution;
+use OCA\OpenRegister\Contract\RegisterSlugResolverInterface;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Support\RegisterSlugAliases;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Resolves a register by any of the slugs it has answered to.
+ *
+ * @spec openspec/specs/register-slug-resolution/spec.md
+ */
+class RegisterSlugResolver implements RegisterSlugResolverInterface {
+
+	/**
+	 * Request-scoped memo, keyed by the candidate list.
+	 *
+	 * A sweep asks for the same register on every call site of the same tick.
+	 * The probe is one indexed read, but it is a read per call site, and the
+	 * answer cannot change inside a request.
+	 *
+	 * @var array<string, RegisterSlugResolution>
+	 */
+	private array $memo = [];
+
+	/**
+	 * Constructor.
+	 *
+	 * @param RegisterMapper  $registerMapper Reads the register table.
+	 * @param LoggerInterface $logger         Diagnostics for the ambiguous and failed cases.
+	 */
+	public function __construct(
+		private readonly RegisterMapper $registerMapper,
+		private readonly LoggerInterface $logger,
+	) {
+	}//end __construct()
+
+	/**
+	 * Which slug this instance's copy of a register actually answers to.
+	 *
+	 * @param string       $canonical  The canonical (current) register slug.
+	 * @param list<string> $candidates Explicit candidates, newest first; empty
+	 *                                 means use the declared alias list.
+	 *
+	 * @return RegisterSlugResolution The slug to use, or an explicit absence.
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public function resolve(string $canonical, array $candidates=[]): RegisterSlugResolution {
+		$probe = $this->candidateList(canonical: $canonical, candidates: $candidates);
+		if ($probe === []) {
+			return new RegisterSlugResolution(
+				canonical: $canonical,
+				slug: null,
+				state: RegisterSlugResolution::ABSENT,
+				candidates: [],
+				matched: []
+			);
+		}
+
+		$memoKey = implode('|', $probe);
+		if (isset($this->memo[$memoKey]) === true) {
+			return $this->memo[$memoKey];
+		}
+
+		$matched = $this->matchingSlugs(candidates: $probe);
+		$resolution = $this->interpret(canonical: $canonical, probe: $probe, matched: $matched);
+
+		$this->memo[$memoKey] = $resolution;
+		return $resolution;
+	}//end resolve()
+
+	/**
+	 * The slug to read with, or null when the register is not on this instance.
+	 *
+	 * @param string       $canonical  The canonical (current) register slug.
+	 * @param list<string> $candidates Explicit candidates, newest first.
+	 *
+	 * @return string|null The slug to use, or null.
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public function slugOrNull(string $canonical, array $candidates=[]): ?string {
+		return $this->resolve(canonical: $canonical, candidates: $candidates)->slug;
+	}//end slugOrNull()
+
+	/**
+	 * Build the probe list: canonical first, then its declared aliases.
+	 *
+	 * The canonical slug is always probed first and always present, so a
+	 * migrated instance short-circuits on the first candidate and an explicit
+	 * candidate list cannot accidentally omit the name the caller asked for.
+	 *
+	 * @param string       $canonical  The canonical register slug.
+	 * @param list<string> $candidates Explicit candidates, or empty.
+	 *
+	 * @return list<string> Lower-cased candidates, newest first, deduplicated.
+	 *
+	 * @SuppressWarnings(PHPMD.StaticAccess) RegisterSlugAliases is a final class
+	 *  holding one `const` array and no state. StaticAccess exists to catch a
+	 *  hidden dependency that should have been injected; there is nothing here
+	 *  to inject and nothing a test would want to swap. Making it a service
+	 *  would mean a DI registration and a constructor argument whose only
+	 *  purpose is to reach a compile-time constant, and would let a caller
+	 *  substitute a different alias map, which is precisely the drift the
+	 *  single declared map exists to prevent.
+	 */
+	private function candidateList(string $canonical, array $candidates): array {
+		$key = strtolower(trim($canonical));
+		if ($key === '') {
+			return [];
+		}
+
+		$declared = RegisterSlugAliases::candidatesFor(canonical: $key);
+		if ($candidates !== []) {
+			$declared = $candidates;
+		}
+
+		$probe = [$key];
+		foreach ($declared as $candidate) {
+			$normalised = strtolower(trim((string)$candidate));
+			if ($normalised === '' || in_array($normalised, $probe, true) === true) {
+				continue;
+			}
+
+			$probe[] = $normalised;
+		}
+
+		return $probe;
+	}//end candidateList()
+
+	/**
+	 * Which of the probed slugs exist here, in probe order.
+	 *
+	 * A failure to read is NOT a resolution: it is reported as an empty match
+	 * with an error logged. The caller then reports the register as
+	 * unavailable, which is the honest observable. The one thing that must
+	 * never happen is falling back to the canonical slug and letting the
+	 * resulting empty result set be read as "this register holds nothing".
+	 *
+	 * @param list<string> $candidates The lower-cased probe list.
+	 *
+	 * @return list<string> Matching slugs, in probe order.
+	 */
+	private function matchingSlugs(array $candidates): array {
+		try {
+			$idsBySlug = $this->registerMapper->findIdsBySlugs(slugs: $candidates);
+		} catch (Throwable $e) {
+			$this->logger->error(
+				message: '[RegisterSlugResolver] Could not read register slugs; treating the register as unavailable',
+				context: [
+					'candidates' => $candidates,
+					'reason'     => $e->getMessage(),
+				]
+			);
+			return [];
+		}
+
+		$matched = [];
+		foreach ($candidates as $candidate) {
+			$ids = ($idsBySlug[$candidate] ?? []);
+			if ($ids === []) {
+				continue;
+			}
+
+			if (count($ids) > 1) {
+				$this->logger->warning(
+					message: '[RegisterSlugResolver] More than one register carries the same slug',
+					context: ['slug' => $candidate, 'ids' => $ids]
+				);
+			}
+
+			$matched[] = $candidate;
+		}
+
+		return $matched;
+	}//end matchingSlugs()
+
+	/**
+	 * Turn a match list into a resolution, logging the state that needs an operator.
+	 *
+	 * @param string       $canonical The canonical register slug.
+	 * @param list<string> $probe     The probe list, newest first.
+	 * @param list<string> $matched   The slugs that exist here, in probe order.
+	 *
+	 * @return RegisterSlugResolution The resolution.
+	 */
+	private function interpret(string $canonical, array $probe, array $matched): RegisterSlugResolution {
+		if ($matched === []) {
+			return new RegisterSlugResolution(
+				canonical: $canonical,
+				slug: null,
+				state: RegisterSlugResolution::ABSENT,
+				candidates: $probe,
+				matched: []
+			);
+		}
+
+		if (count($matched) === 1) {
+			return new RegisterSlugResolution(
+				canonical: $canonical,
+				slug: $matched[0],
+				state: RegisterSlugResolution::RESOLVED,
+				candidates: $probe,
+				matched: $matched
+			);
+		}
+
+		// Two rows the rename should have collapsed into one. The repair step
+		// refuses to merge in this case rather than guessing, so this is an
+		// operator's decision, not the resolver's. Reads go to the FIRST
+		// candidate, the canonical migrated row, so that a consumer keeps
+		// working while it is sorted out.
+		$this->logger->warning(
+			message: '[RegisterSlugResolver] A register answers to more than one of its slugs; '
+				. 'reads use the first. Run the owning app\'s register-slug repair step.',
+			context: [
+				'canonical' => $canonical,
+				'matched'   => $matched,
+			]
+		);
+
+		return new RegisterSlugResolution(
+			canonical: $canonical,
+			slug: $matched[0],
+			state: RegisterSlugResolution::AMBIGUOUS,
+			candidates: $probe,
+			matched: $matched
+		);
+	}//end interpret()
+}//end class

--- a/lib/Support/RegisterSlugAliases.php
+++ b/lib/Support/RegisterSlugAliases.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * RegisterSlugAliases: the declared slugs each fleet register has answered to.
+ *
+ * Nine fleet apps ship a repair step that renames their OpenRegister register's
+ * slug. The step is per-instance and runs at repair time, so on any given day
+ * some instances carry the new slug and some still carry the old one. Both are
+ * live across the estate at once, and a consumer that hardcodes either is wrong
+ * on half of it.
+ *
+ * This class is the DECLARED list of what each register has been called. It is
+ * declared rather than derived, and that is the whole point of the file.
+ *
+ * DO NOT DERIVE THESE FROM THE APP RENAME MAP. The register slug and the app id
+ * are different strings that happen to coincide most of the time. `stackiq`
+ * renamed the register `voorzieningen`; its own former app id
+ * `softwarecatalog` was never a register slug on any instance. A resolver keyed
+ * on app-id history offers `softwarecatalog`, matches nothing, and reports the
+ * register absent on precisely the instances where it is present.
+ *
+ * Nor is this list the same shape as {@see FleetAppId}, which answers a
+ * different question with a different source of truth: `IAppManager` for app
+ * ids, the `openregister_registers` table for slugs. An instance can run the
+ * app under its new id while its register row still carries the old slug,
+ * because two separate repair steps move them and either can run first.
+ *
+ * Each entry is NEWEST FIRST. Adding a rename means PREPENDING the new slug,
+ * never replacing the old one: dropping the old slug here is what silently
+ * breaks the consumers this class exists to protect.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Support
+ * @package  OCA\OpenRegister\Support
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Support;
+
+/**
+ * The declared slug history of every renamed fleet register.
+ *
+ * @spec openspec/specs/register-slug-resolution/spec.md
+ */
+final class RegisterSlugAliases {
+
+	/**
+	 * Canonical register slug => every slug that register has answered to,
+	 * newest first.
+	 *
+	 * Transcribed from the `SLUG_MAP` (or `OLD_SLUG`/`NEW_SLUG` pair) of the
+	 * nine shipped repair steps, which are the only authority for what a
+	 * register was called before:
+	 *
+	 *   integriq   openconnector/lib/Repair/MigrateRegisterSlug.php
+	 *   buildiq    openbuild/lib/Repair/MigrateRegisterSlug.php
+	 *   decidiq    decidesk/lib/Repair/MigrateRegisterSlug.php
+	 *   humaniq    hrmq/lib/Repair/MigrateRegisterSlug.php
+	 *   larpinq    larpingapp/lib/Repair/MigrateRegisterSlug.php
+	 *   planninq   planix/lib/Repair/MigrateRegisterSlug.php
+	 *   stackiq    softwarecatalog/lib/Repair/MigrateRegisterSlug.php
+	 *   dossiq     procest/lib/Repair/MigrateRegisterSlug.php
+	 *   learniq    scholiq/lib/Repair/RenameRegisterSlug.php
+	 *
+	 * Note the last line. Eight steps are called `MigrateRegisterSlug`; learniq
+	 * calls its one `RenameRegisterSlug`. A sweep that searched the single
+	 * filename reported learniq as never migrated, which is why this list is
+	 * transcribed from read files rather than from a `find` result.
+	 *
+	 * @var array<string, list<string>>
+	 */
+	private const ALIASES = [
+		'integriq'       => ['integriq', 'openconnector'],
+		'buildiq'        => ['buildiq', 'openbuild'],
+		'decidiq'        => ['decidiq', 'decidesk'],
+		'humaniq'        => ['humaniq', 'hrmq'],
+		'larpinq'        => ['larpinq', 'larpingapp'],
+		'planninq'       => ['planninq', 'planix'],
+		'stackiq'        => ['stackiq', 'voorzieningen'],
+		'dossiq'         => ['dossiq', 'procest'],
+		'dossiq-default' => ['dossiq-default', 'procest-default'],
+		'learniq'        => ['learniq', 'scholiq'],
+	];
+
+	/**
+	 * The candidate slugs for a canonical register slug, newest first.
+	 *
+	 * A slug with no recorded rename returns itself, so a caller never has to
+	 * ask whether the register it wants is one of the renamed ones.
+	 *
+	 * @param string $canonical The canonical (current) register slug.
+	 *
+	 * @return list<string> Candidate slugs, newest first, canonical always first.
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public static function candidatesFor(string $canonical): array {
+		$key = strtolower(trim($canonical));
+		if ($key === '') {
+			return [];
+		}
+
+		return (self::ALIASES[$key] ?? [$key]);
+	}//end candidatesFor()
+
+	/**
+	 * Every slug that is superseded, mapped to the canonical slug replacing it.
+	 *
+	 * Used by the guard that refuses a superseded slug written as a literal.
+	 *
+	 * @return array<string, string> Superseded slug => canonical slug.
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public static function supersededSlugs(): array {
+		$superseded = [];
+		foreach (self::ALIASES as $canonical => $candidates) {
+			foreach ($candidates as $candidate) {
+				if ($candidate === $canonical) {
+					continue;
+				}
+
+				$superseded[$candidate] = $canonical;
+			}
+		}
+
+		return $superseded;
+	}//end supersededSlugs()
+}//end class

--- a/openspec/specs/register-slug-resolution/spec.md
+++ b/openspec/specs/register-slug-resolution/spec.md
@@ -1,0 +1,118 @@
+---
+status: in-progress
+---
+
+# register-slug-resolution Specification
+
+**OpenSpec changes**
+- register-slug-resolution
+
+## Purpose
+
+Defines how a caller finds out which slug a register actually answers to on THIS
+instance, so a cross-app reference resolves rather than assumes.
+
+Nine fleet apps ship a repair step that renames their register's slug:
+`openconnector` to `integriq`, `openbuild` to `buildiq`, `voorzieningen` to
+`stackiq`, and six more. The rename is per-instance and runs at repair time, so
+both the old and the new slug are live across the estate simultaneously,
+whichever a given instance has last repaired. A consumer that hardcodes either
+one is therefore wrong on half the estate.
+
+The behaviour matters because its failure is quiet, and quieter than a 404. A
+register slug that does not resolve does not raise; it produces an empty result
+set, which is indistinguishable from a register that holds no objects. Measured
+on this repository 2026-09-10: `AppHost\Scheduling\ScheduleReconciler` pinned
+`openconnector` and `openbuild` as register slugs across five call sites. On an
+instance that has run either repair step, `loadManagedJobs()` returns no rows
+and `loadVirtualApplications()` returns none, so the reconciler enumerates
+nothing, upserts nothing and garbage-collects nothing. Every AppHost schedule
+stops firing, and the only trace is an `info` line saying the register is
+"unavailable".
+
+## Requirements
+
+### Requirement: A register MUST be resolvable by any slug it has answered to
+
+The system MUST expose a resolver that takes a canonical register slug, reads
+which of that register's known slugs exist on this instance, and returns the one
+that does.
+
+Candidate slugs MUST be declared, never derived from app-id history. The two are
+not the same string: `stackiq` renamed the register `voorzieningen`, having
+never used its own former app id `softwarecatalog` as a slug at all. A resolver
+keyed on the app rename map answers `softwarecatalog`, which no register on any
+instance has ever carried.
+
+#### Scenario: A migrated instance resolves to the new slug
+
+- **GIVEN** an instance whose register row carries slug `buildiq`
+- **WHEN** a caller resolves the canonical slug `buildiq`
+- **THEN** the resolver MUST return `buildiq`
+
+#### Scenario: An unmigrated instance resolves to the old slug
+
+- **GIVEN** an instance whose register row still carries slug `openbuild`
+- **WHEN** a caller resolves the canonical slug `buildiq`
+- **THEN** the resolver MUST return `openbuild`
+
+#### Scenario: A slug that is not the old app id still resolves
+
+- **GIVEN** an instance whose register row carries slug `voorzieningen`
+- **WHEN** a caller resolves the canonical slug `stackiq`
+- **THEN** the resolver MUST return `voorzieningen`
+- **AND** MUST NOT offer `softwarecatalog` as a candidate
+
+### Requirement: An unresolved register MUST be reported as unresolved, never as the canonical slug
+
+When no candidate slug exists on this instance the resolver MUST report the
+absence explicitly and MUST NOT return a slug.
+
+Returning the canonical slug on a miss is the failure this resolver exists to
+remove: the caller passes it to a read, the read returns zero rows, and the
+caller records "no data". The absence MUST be a value the caller has to branch
+on.
+
+#### Scenario: An absent register yields no slug
+
+- **GIVEN** an instance carrying neither `buildiq` nor `openbuild`
+- **WHEN** a caller resolves the canonical slug `buildiq`
+- **THEN** the resolver MUST report the register as absent
+- **AND** MUST NOT return `buildiq`
+
+#### Scenario: Both slugs present is reported, not silently merged
+
+- **GIVEN** an instance carrying BOTH `buildiq` and `openbuild`, which the
+  repair step refuses to merge
+- **WHEN** a caller resolves the canonical slug `buildiq`
+- **THEN** the resolver MUST report the resolution as ambiguous
+- **AND** MUST return the canonical slug so reads stay on the migrated row
+- **AND** MUST log a warning naming both slugs
+
+### Requirement: The resolver MUST read the register table, not the app manager
+
+Register slugs live in `openregister_registers`. Whether an app is installed
+says nothing about which slug its register carries: an instance can run
+`buildiq` with a register row still slugged `openbuild`, because the app id and
+the register slug are migrated by different steps and either can run first.
+
+#### Scenario: An installed app with an unmigrated register
+
+- **GIVEN** an instance where the app id has moved to `buildiq` but the register
+  row still carries `openbuild`
+- **WHEN** a caller resolves the canonical slug `buildiq`
+- **THEN** the resolver MUST return `openbuild`
+
+### Requirement: No code under lib/ MUST pin a superseded register slug
+
+A string literal equal to a superseded register slug, used in register position,
+MUST be rejected. The guard MUST run over the whole of `lib/` rather than over a
+changed diff, because the references it catches were written before the rename
+and will never appear in one.
+
+#### Scenario: A pinned old slug is detected
+
+- **GIVEN** a source file under `lib/` naming `openbuild` as a register
+- **WHEN** the guard runs
+- **THEN** it MUST fail and name the file, the line and the canonical slug to
+  resolve instead

--- a/tests/Unit/AppHost/Scheduling/FakeSlugResolver.php
+++ b/tests/Unit/AppHost/Scheduling/FakeSlugResolver.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * AppHost scheduling: a register-slug resolver bound to a fixed instance state.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\AppHost\Scheduling
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\AppHost\Scheduling;
+
+use OCA\OpenRegister\Contract\RegisterSlugResolution;
+use OCA\OpenRegister\Contract\RegisterSlugResolverInterface;
+use OCA\OpenRegister\Support\RegisterSlugAliases;
+
+/**
+ * Answers as an instance that carries exactly the given register slugs.
+ *
+ * A hand-written double rather than a generated mock because the tests below
+ * are about the DIFFERENCE between a migrated and an unmigrated instance, and
+ * that difference is the resolver's whole behaviour. Stubbing `slugOrNull()` to
+ * return a constant would make every test pass on both.
+ */
+class FakeSlugResolver implements RegisterSlugResolverInterface {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param list<string> $present The register slugs this instance carries.
+	 */
+	public function __construct(private readonly array $present = []) {
+	}//end __construct()
+
+	/**
+	 * Resolve against the fixed instance state.
+	 *
+	 * @param string       $canonical  The canonical register slug.
+	 * @param list<string> $candidates Explicit candidates, newest first.
+	 *
+	 * @return RegisterSlugResolution The resolution.
+	 */
+	public function resolve(string $canonical, array $candidates=[]): RegisterSlugResolution {
+		$probe = $candidates;
+		if ($probe === []) {
+			$probe = RegisterSlugAliases::candidatesFor(canonical: $canonical);
+		}
+
+		$matched = array_values(array_filter(
+			$probe,
+			fn (string $slug): bool => in_array($slug, $this->present, true)
+		));
+
+		$state = RegisterSlugResolution::RESOLVED;
+		if ($matched === []) {
+			$state = RegisterSlugResolution::ABSENT;
+		} else if (count($matched) > 1) {
+			$state = RegisterSlugResolution::AMBIGUOUS;
+		}
+
+		return new RegisterSlugResolution(
+			canonical: $canonical,
+			slug: ($matched[0] ?? null),
+			state: $state,
+			candidates: $probe,
+			matched: $matched
+		);
+	}//end resolve()
+
+	/**
+	 * The slug to read with, or null.
+	 *
+	 * @param string       $canonical  The canonical register slug.
+	 * @param list<string> $candidates Explicit candidates, newest first.
+	 *
+	 * @return string|null The slug, or null.
+	 */
+	public function slugOrNull(string $canonical, array $candidates=[]): ?string {
+		return $this->resolve(canonical: $canonical, candidates: $candidates)->slug;
+	}//end slugOrNull()
+}//end class

--- a/tests/Unit/AppHost/Scheduling/ScheduleReconcilerIoTest.php
+++ b/tests/Unit/AppHost/Scheduling/ScheduleReconcilerIoTest.php
@@ -25,11 +25,14 @@ use OCA\OpenRegister\AppHost\Scheduling\CronScheduleEvaluator;
 use OCA\OpenRegister\AppHost\Scheduling\ScheduleActionAllowList;
 use OCA\OpenRegister\AppHost\Scheduling\ScheduleManifestLoader;
 use OCA\OpenRegister\AppHost\Scheduling\ScheduleReconciler;
+use OCA\OpenRegister\Contract\RegisterSlugResolverInterface;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\App\IAppManager;
 use OCP\IUserManager;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+
+require_once __DIR__ . '/FakeSlugResolver.php';
 
 /**
  * Exposes the protected loadVirtualApplications() seam for direct testing.
@@ -43,6 +46,15 @@ class IoProbeReconciler extends ScheduleReconciler {
 	public function callLoadVirtualApplications(): array {
 		return $this->loadVirtualApplications();
 	}//end callLoadVirtualApplications()
+
+	/**
+	 * Public passthrough to the managed-job read seam.
+	 *
+	 * @return array<string, array<string, mixed>>|null Managed jobs, or null.
+	 */
+	public function callLoadManagedJobs(): ?array {
+		return $this->loadManagedJobs();
+	}//end callLoadManagedJobs()
 }//end class
 
 /**
@@ -75,7 +87,7 @@ class ScheduleReconcilerIoTest extends TestCase {
 	 *
 	 * @return IoProbeReconciler
 	 */
-	private function makeReconciler(ObjectService $objectService): IoProbeReconciler {
+	private function makeReconciler(ObjectService $objectService, ?RegisterSlugResolverInterface $slugResolver=null): IoProbeReconciler {
 		$loader = $this->createMock(originalClassName: ScheduleManifestLoader::class);
 		$userManager = $this->createMock(originalClassName: IUserManager::class);
 		$logger = $this->createMock(originalClassName: LoggerInterface::class);
@@ -86,7 +98,8 @@ class ScheduleReconcilerIoTest extends TestCase {
 			new CronScheduleEvaluator(),
 			$this->allowList(),
 			$userManager,
-			$logger
+			$logger,
+			($slugResolver ?? new FakeSlugResolver(['integriq', 'buildiq']))
 		);
 	}//end makeReconciler()
 
@@ -148,4 +161,135 @@ class ScheduleReconcilerIoTest extends TestCase {
 		$this->assertFalse($captured['rbac']);
 		$this->assertTrue($captured['multitenancy']);
 	}//end testSweepPassesLimitAndRbacFalseOnly()
+	/**
+	 * The read uses the slug this instance carries, not a compiled-in literal.
+	 *
+	 * The unmigrated case: the register row still says `openbuild`, so that is
+	 * what must reach ObjectService. A reconciler pinned to the canonical
+	 * `buildiq` would pass a slug no register carries, get an empty set back,
+	 * and report zero virtual applications, which is exactly what an instance
+	 * with no virtual applications reports.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public function testAnUnmigratedInstanceIsReadWithItsOldSlug(): void {
+		$seen = null;
+		$objectService = $this->createMock(originalClassName: ObjectService::class);
+		$objectService->method('findAll')->willReturnCallback(
+			/**
+			 * @param array<string, mixed> $config Read config.
+			 *
+			 * @return array<int, mixed>
+			 */
+			function (array $config) use (&$seen): array {
+				$seen = ($config['filters']['register'] ?? null);
+				return [];
+			}
+		);
+
+		$reconciler = $this->makeReconciler(
+			objectService: $objectService,
+			slugResolver: new FakeSlugResolver(['openbuild'])
+		);
+		$reconciler->callLoadVirtualApplications();
+
+		$this->assertSame('openbuild', $seen, 'The read must name the slug this instance actually carries.');
+	}//end testAnUnmigratedInstanceIsReadWithItsOldSlug()
+
+	/**
+	 * A migrated instance is read with the new slug.
+	 *
+	 * The other half of the estate, and the half a literal `openbuild` breaks.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public function testAMigratedInstanceIsReadWithItsNewSlug(): void {
+		$seen = null;
+		$objectService = $this->createMock(originalClassName: ObjectService::class);
+		$objectService->method('findAll')->willReturnCallback(
+			/**
+			 * @param array<string, mixed> $config Read config.
+			 *
+			 * @return array<int, mixed>
+			 */
+			function (array $config) use (&$seen): array {
+				$seen = ($config['filters']['register'] ?? null);
+				return [];
+			}
+		);
+
+		$reconciler = $this->makeReconciler(
+			objectService: $objectService,
+			slugResolver: new FakeSlugResolver(['buildiq'])
+		);
+		$reconciler->callLoadVirtualApplications();
+
+		$this->assertSame('buildiq', $seen);
+	}//end testAMigratedInstanceIsReadWithItsNewSlug()
+
+	/**
+	 * An absent register means no read at all, not an empty read.
+	 *
+	 * The distinction is the whole point. An empty read returns `[]`, and `[]`
+	 * is indistinguishable from a register that genuinely holds nothing. Not
+	 * reading is what lets the `info` line say the register is missing rather
+	 * than that there is nothing to schedule.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public function testAnAbsentRegisterIsNotReadAtAll(): void {
+		$objectService = $this->createMock(originalClassName: ObjectService::class);
+		$objectService->expects($this->never())->method('findAll');
+
+		$reconciler = $this->makeReconciler(
+			objectService: $objectService,
+			slugResolver: new FakeSlugResolver([])
+		);
+
+		$this->assertSame([], $reconciler->callLoadVirtualApplications());
+		$this->assertNull($reconciler->callLoadManagedJobs());
+	}//end testAnAbsentRegisterIsNotReadAtAll()
+
+	/**
+	 * The job register is resolved too, not only the application register.
+	 *
+	 * Two registers were pinned in this class and they are renamed by two
+	 * different apps' repair steps, so an instance can be migrated for one and
+	 * not the other. Fixing one and not the other leaves the reconciler just as
+	 * inert on half the cases it was inert on before.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public function testTheJobRegisterIsResolvedIndependently(): void {
+		$seen = null;
+		$objectService = $this->createMock(originalClassName: ObjectService::class);
+		$objectService->method('findAll')->willReturnCallback(
+			/**
+			 * @param array<string, mixed> $config Read config.
+			 *
+			 * @return array<int, mixed>
+			 */
+			function (array $config) use (&$seen): array {
+				$seen = ($config['filters']['register'] ?? null);
+				return [];
+			}
+		);
+
+		// Migrated for buildiq, NOT migrated for integriq.
+		$reconciler = $this->makeReconciler(
+			objectService: $objectService,
+			slugResolver: new FakeSlugResolver(['buildiq', 'openconnector'])
+		);
+		$reconciler->callLoadManagedJobs();
+
+		$this->assertSame('openconnector', $seen);
+	}//end testTheJobRegisterIsResolvedIndependently()
 }//end class

--- a/tests/Unit/AppHost/Scheduling/ScheduleReconcilerTest.php
+++ b/tests/Unit/AppHost/Scheduling/ScheduleReconcilerTest.php
@@ -29,6 +29,7 @@ use OCP\IUserManager;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
+require_once __DIR__ . '/FakeSlugResolver.php';
 require_once __DIR__ . '/TestableReconciler.php';
 
 /**
@@ -88,6 +89,7 @@ class ScheduleReconcilerTest extends TestCase {
 			$this->allowList(),
 			$this->userManager,
 			$this->createMock(LoggerInterface::class),
+			new FakeSlugResolver(['integriq', 'buildiq']),
 			$virtual,
 			$managed
 		);

--- a/tests/Unit/AppHost/Scheduling/TestableReconciler.php
+++ b/tests/Unit/AppHost/Scheduling/TestableReconciler.php
@@ -21,6 +21,7 @@ use OCA\OpenRegister\AppHost\Scheduling\CronScheduleEvaluator;
 use OCA\OpenRegister\AppHost\Scheduling\ScheduleActionAllowList;
 use OCA\OpenRegister\AppHost\Scheduling\ScheduleManifestLoader;
 use OCA\OpenRegister\AppHost\Scheduling\ScheduleReconciler;
+use OCA\OpenRegister\Contract\RegisterSlugResolverInterface;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
@@ -46,6 +47,7 @@ class TestableReconciler extends ScheduleReconciler {
 	 * @param ScheduleActionAllowList $allowList Allow-list.
 	 * @param IUserManager $userManager User manager.
 	 * @param LoggerInterface $logger Logger.
+	 * @param RegisterSlugResolverInterface $slugResolver Register-slug resolver.
 	 * @param array<int, array<string, mixed>> $virtual Virtual application fixtures.
 	 * @param array<string, array<string, mixed>> $managed Managed-job fixtures keyed by reference.
 	 */
@@ -56,10 +58,11 @@ class TestableReconciler extends ScheduleReconciler {
 		ScheduleActionAllowList $allowList,
 		IUserManager $userManager,
 		LoggerInterface $logger,
+		RegisterSlugResolverInterface $slugResolver,
 		private readonly array $virtual,
 		private readonly array $managed,
 	) {
-		parent::__construct($objectService, $manifestLoader, $cron, $allowList, $userManager, $logger);
+		parent::__construct($objectService, $manifestLoader, $cron, $allowList, $userManager, $logger, $slugResolver);
 	}
 
 	protected function loadManagedJobs(): ?array {

--- a/tests/Unit/Controller/SettingsControllerTest.php
+++ b/tests/Unit/Controller/SettingsControllerTest.php
@@ -1663,6 +1663,128 @@ class SettingsControllerTest extends TestCase {
 	}
 
 	/**
+	 * A slug resolver answering as an instance that carries the stackiq register.
+	 *
+	 * The debug endpoint resolves the register rather than naming
+	 * `voorzieningen`, because stackiq's repair step renames that slug per
+	 * instance and a read with the name this instance does not carry returns an
+	 * empty set. This endpoint would then have rendered that as "no
+	 * organisations", the one answer a filtering diagnostic must never invent.
+	 *
+	 * @param string|null $carries The slug this instance carries, or null for none.
+	 *
+	 * @return \OCA\OpenRegister\Contract\RegisterSlugResolverInterface The double.
+	 */
+	private function stackiqSlugResolver(?string $carries = 'stackiq'): \OCA\OpenRegister\Contract\RegisterSlugResolverInterface {
+		$resolver = $this->createMock(\OCA\OpenRegister\Contract\RegisterSlugResolverInterface::class);
+		$resolver->method('slugOrNull')->willReturn($carries);
+		return $resolver;
+	}
+
+	/**
+	 * An absent stackiq register is a 404, not an empty diagnostic.
+	 *
+	 * The distinction this endpoint exists to make. Before the register was
+	 * resolved it named `voorzieningen` outright; on an instance that has run
+	 * stackiq's repair step that slug matches no register, the search returns
+	 * an empty set, and the endpoint answered 200 with zero organisations in
+	 * every bucket: a filtering diagnostic reporting that filtering works
+	 * perfectly on nothing.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public function testDebugTypeFilteringRefusesWhenTheRegisterIsAbsent(): void {
+		$mockObjectService = $this->createMock(\OCA\OpenRegister\Service\ObjectService::class);
+		$mockObjectService->expects($this->never())->method('searchObjectsPaginated');
+
+		$this->container->method('get')
+			->willReturnCallback(function (string $id) use ($mockObjectService) {
+				if ($id === \OCA\OpenRegister\Service\ObjectService::class) {
+					return $mockObjectService;
+				}
+
+				if ($id === \OCA\OpenRegister\Contract\RegisterSlugResolverInterface::class) {
+					return $this->stackiqSlugResolver(carries: null);
+				}
+
+				throw new \Exception("Unknown service: $id");
+			});
+
+		$response = $this->controller->debugTypeFiltering();
+
+		$this->assertSame(404, $response->getStatus());
+		$this->assertArrayHasKey('error', $response->getData());
+	}
+
+	/**
+	 * The read names the slug this instance carries, whichever that is.
+	 *
+	 * Both cases, because only one of them can catch a pinned literal. On an
+	 * UNMIGRATED instance the pinned `voorzieningen` happens to be the right
+	 * answer, so that case passes whether the code resolves or not; measured
+	 * against a mutation that reinstated the literal, the migrated case is the
+	 * only one that reddened. Asserting the unmigrated case alone would be a
+	 * test that cannot fail for the defect it was written for.
+	 *
+	 * @param string $carries  The slug this instance's register row holds.
+	 * @param string $expected The slug the endpoint must read with.
+	 *
+	 * @return void
+	 *
+	 * @dataProvider provideInstanceSlugStates
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public function testDebugTypeFilteringReadsTheSlugTheInstanceCarries(string $carries, string $expected): void {
+		$seen = null;
+		$mockObjectService = $this->createMock(\OCA\OpenRegister\Service\ObjectService::class);
+		$mockObjectService->method('setRegister')->willReturnCallback(
+			function (string|int $register) use (&$seen, $mockObjectService): \OCA\OpenRegister\Service\ObjectService {
+				$seen = $register;
+				return $mockObjectService;
+			}
+		);
+		$mockObjectService->method('searchObjectsPaginated')->willReturn(['results' => []]);
+
+		$mockConnection = $this->createDebugDbConnection([]);
+
+		$this->container->method('get')
+			->willReturnCallback(function (string $id) use ($mockObjectService, $mockConnection, $carries) {
+				if ($id === \OCA\OpenRegister\Service\ObjectService::class) {
+					return $mockObjectService;
+				}
+
+				if ($id === \OCP\IDBConnection::class) {
+					return $mockConnection;
+				}
+
+				if ($id === \OCA\OpenRegister\Contract\RegisterSlugResolverInterface::class) {
+					return $this->stackiqSlugResolver(carries: $carries);
+				}
+
+				throw new \Exception("Unknown service: $id");
+			});
+
+		$this->controller->debugTypeFiltering();
+
+		$this->assertSame($expected, $seen);
+	}
+
+	/**
+	 * The two instance states that are both live across the estate.
+	 *
+	 * @return array<string, array{0: string, 1: string}> Carried slug, expected read slug.
+	 */
+	public static function provideInstanceSlugStates(): array {
+		return [
+			'migrated instance carries stackiq'          => ['stackiq', 'stackiq'],
+			'unmigrated instance carries voorzieningen'  => ['voorzieningen', 'voorzieningen'],
+		];
+	}
+
+	/**
 	 * Test debugTypeFiltering returns results when ObjectService works with empty results
 	 *
 	 * @return void
@@ -1682,6 +1804,10 @@ class SettingsControllerTest extends TestCase {
 
 				if ($id === \OCP\IDBConnection::class) {
 					return $mockConnection;
+				}
+
+				if ($id === \OCA\OpenRegister\Contract\RegisterSlugResolverInterface::class) {
+					return $this->stackiqSlugResolver();
 				}
 
 				throw new \Exception("Unknown service: $id");
@@ -1736,6 +1862,10 @@ class SettingsControllerTest extends TestCase {
 
 				if ($id === \OCP\IDBConnection::class) {
 					return $mockConnection;
+				}
+
+				if ($id === \OCA\OpenRegister\Contract\RegisterSlugResolverInterface::class) {
+					return $this->stackiqSlugResolver();
 				}
 
 				throw new \Exception("Unknown service: $id");
@@ -1798,6 +1928,10 @@ class SettingsControllerTest extends TestCase {
 					return $mockConnection;
 				}
 
+				if ($id === \OCA\OpenRegister\Contract\RegisterSlugResolverInterface::class) {
+					return $this->stackiqSlugResolver();
+				}
+
 				throw new \Exception("Unknown service: $id");
 			});
 
@@ -1823,6 +1957,10 @@ class SettingsControllerTest extends TestCase {
 			->willReturnCallback(function (string $id) use ($mockObjectService) {
 				if ($id === \OCA\OpenRegister\Service\ObjectService::class) {
 					return $mockObjectService;
+				}
+
+				if ($id === \OCA\OpenRegister\Contract\RegisterSlugResolverInterface::class) {
+					return $this->stackiqSlugResolver();
 				}
 
 				throw new \Exception("Unknown service: $id");
@@ -1852,6 +1990,10 @@ class SettingsControllerTest extends TestCase {
 			->willReturnCallback(function (string $id) use ($mockObjectService) {
 				if ($id === \OCA\OpenRegister\Service\ObjectService::class) {
 					return $mockObjectService;
+				}
+
+				if ($id === \OCA\OpenRegister\Contract\RegisterSlugResolverInterface::class) {
+					return $this->stackiqSlugResolver();
 				}
 
 				throw new \Exception("Unknown service: $id");
@@ -1887,6 +2029,10 @@ class SettingsControllerTest extends TestCase {
 
 				if ($id === \OCP\IDBConnection::class) {
 					return $mockConnection;
+				}
+
+				if ($id === \OCA\OpenRegister\Contract\RegisterSlugResolverInterface::class) {
+					return $this->stackiqSlugResolver();
 				}
 
 				throw new \Exception("Unknown service: $id");

--- a/tests/Unit/Service/RegisterSlugResolverTest.php
+++ b/tests/Unit/Service/RegisterSlugResolverTest.php
@@ -1,0 +1,282 @@
+<?php
+
+/**
+ * RegisterSlugResolver resolves a register by whichever slug it carries here.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service;
+
+use OCA\OpenRegister\Contract\RegisterSlugResolution;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Service\RegisterSlugResolver;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Every case here is an instance state that exists in the field right now:
+ * migrated, unmigrated, both, neither. The repair steps are per-instance, so
+ * which one a given deployment is in depends on when it last ran repair.
+ *
+ * @spec openspec/specs/register-slug-resolution/spec.md
+ */
+class RegisterSlugResolverTest extends TestCase {
+
+	/**
+	 * The register mapper double.
+	 *
+	 * @var RegisterMapper&MockObject
+	 */
+	private RegisterMapper $registerMapper;
+
+	/**
+	 * The logger double.
+	 *
+	 * @var LoggerInterface&MockObject
+	 */
+	private LoggerInterface $logger;
+
+	/**
+	 * Build the doubles.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->registerMapper = $this->createMock(RegisterMapper::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+	}//end setUp()
+
+	/**
+	 * An instance carrying only the given slugs.
+	 *
+	 * Mirrors RegisterMapper::findIdsBySlugs(), which answers with EVERY probed
+	 * slug as a key and an empty id list for the ones that do not exist. A
+	 * double that omitted the misses would be easier to write and would hide
+	 * the exact distinction the resolver turns on.
+	 *
+	 * @param list<string> $present Slugs this instance's register table carries.
+	 *
+	 * @return RegisterSlugResolver The resolver under test.
+	 */
+	private function instanceCarrying(array $present): RegisterSlugResolver {
+		$this->registerMapper->method('findIdsBySlugs')->willReturnCallback(
+			/**
+			 * @param array<int,string> $slugs Probed slugs.
+			 *
+			 * @return array<string,array<int,string>>
+			 */
+			static function (array $slugs) use ($present): array {
+				$map = [];
+				foreach ($slugs as $index => $slug) {
+					$lowered = strtolower($slug);
+					$map[$lowered] = [];
+					if (in_array($lowered, $present, true) === true) {
+						$map[$lowered] = [(string)(10 + $index)];
+					}
+				}
+
+				return $map;
+			}
+		);
+
+		return new RegisterSlugResolver(registerMapper: $this->registerMapper, logger: $this->logger);
+	}//end instanceCarrying()
+
+	/**
+	 * A migrated instance resolves to the new slug.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public function testAMigratedInstanceResolvesToTheNewSlug(): void {
+		$resolution = $this->instanceCarrying(['buildiq'])->resolve(canonical: 'buildiq');
+
+		$this->assertSame('buildiq', $resolution->slug);
+		$this->assertSame(RegisterSlugResolution::RESOLVED, $resolution->state);
+		$this->assertTrue($resolution->isResolved());
+	}//end testAMigratedInstanceResolvesToTheNewSlug()
+
+	/**
+	 * An unmigrated instance resolves to the old slug.
+	 *
+	 * This is the half of the estate a literal swap to the new slug would have
+	 * broken, and it breaks the same silent way round: the read simply returns
+	 * nothing.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public function testAnUnmigratedInstanceResolvesToTheOldSlug(): void {
+		$resolution = $this->instanceCarrying(['openbuild'])->resolve(canonical: 'buildiq');
+
+		$this->assertSame('openbuild', $resolution->slug);
+		$this->assertSame(RegisterSlugResolution::RESOLVED, $resolution->state);
+		$this->assertNotSame($resolution->canonical, $resolution->slug, 'This instance has not run the repair step.');
+	}//end testAnUnmigratedInstanceResolvesToTheOldSlug()
+
+	/**
+	 * A consumer pinned to the OLD slug on a MIGRATED instance reads nothing.
+	 *
+	 * The defect, stated as an assertion. `openbuild` is not a slug this
+	 * instance carries, so a caller holding that literal gets no register and
+	 * therefore no rows, with no exception anywhere to notice. The resolver is
+	 * the only thing on this path that can tell the two apart, and it does:
+	 * probing the pinned literal ALONE reports absent, while probing the
+	 * canonical slug resolves.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public function testAPinnedOldSlugOnAMigratedInstanceIsDetectedAsAbsent(): void {
+		$resolver = $this->instanceCarrying(['buildiq']);
+
+		$pinned = $resolver->resolve(canonical: 'openbuild', candidates: ['openbuild']);
+		$this->assertNull($pinned->slug, 'The pinned literal must not resolve on a migrated instance.');
+		$this->assertTrue($pinned->isAbsent());
+		$this->assertSame([], $pinned->matched);
+
+		$resolved = $resolver->resolve(canonical: 'buildiq');
+		$this->assertSame('buildiq', $resolved->slug, 'The same instance answers under the canonical slug.');
+	}//end testAPinnedOldSlugOnAMigratedInstanceIsDetectedAsAbsent()
+
+	/**
+	 * An absent register yields no slug, never the canonical one.
+	 *
+	 * Returning the canonical slug here would be the whole defect reinstated
+	 * inside the fix: the caller would read, get zero rows, and log "no data".
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public function testAnAbsentRegisterYieldsNoSlug(): void {
+		$resolution = $this->instanceCarrying([])->resolve(canonical: 'buildiq');
+
+		$this->assertNull($resolution->slug);
+		$this->assertNotSame('buildiq', $resolution->slug);
+		$this->assertTrue($resolution->isAbsent());
+		$this->assertFalse($resolution->isResolved());
+	}//end testAnAbsentRegisterYieldsNoSlug()
+
+	/**
+	 * Both slugs present is reported as ambiguous and reads stay on the new row.
+	 *
+	 * Reachable because the repair step refuses to merge when both rows exist,
+	 * rather than guessing which one holds the objects.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public function testBothSlugsPresentIsAmbiguousAndPrefersTheCanonical(): void {
+		$this->logger->expects($this->once())->method('warning');
+
+		$resolution = $this->instanceCarrying(['buildiq', 'openbuild'])->resolve(canonical: 'buildiq');
+
+		$this->assertSame('buildiq', $resolution->slug);
+		$this->assertTrue($resolution->isAmbiguous());
+		$this->assertSame(['buildiq', 'openbuild'], $resolution->matched);
+	}//end testBothSlugsPresentIsAmbiguousAndPrefersTheCanonical()
+
+	/**
+	 * A slug that is not the old app id still resolves.
+	 *
+	 * stackiq renamed the register `voorzieningen`. Its former app id
+	 * `softwarecatalog` was never a register slug on any instance, so a probe
+	 * derived from the app rename map matches nothing and calls the register
+	 * absent exactly where it is present.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public function testTheCandidatesAreDeclaredNotDerivedFromAppIds(): void {
+		$resolution = $this->instanceCarrying(['voorzieningen'])->resolve(canonical: 'stackiq');
+
+		$this->assertSame('voorzieningen', $resolution->slug);
+		$this->assertContains('voorzieningen', $resolution->candidates);
+		$this->assertNotContains(
+			'softwarecatalog',
+			$resolution->candidates,
+			'The former APP id was never a register slug; probing it would find nothing.'
+		);
+	}//end testTheCandidatesAreDeclaredNotDerivedFromAppIds()
+
+	/**
+	 * A slug with no recorded rename resolves to itself.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public function testARegisterWithNoRenameResolvesToItself(): void {
+		$resolution = $this->instanceCarrying(['publication'])->resolve(canonical: 'publication');
+
+		$this->assertSame('publication', $resolution->slug);
+		$this->assertSame(['publication'], $resolution->candidates);
+	}//end testARegisterWithNoRenameResolvesToItself()
+
+	/**
+	 * A failed read is an absence, not a guess.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public function testAFailedReadReportsAbsenceAndLogsAnError(): void {
+		$this->registerMapper->method('findIdsBySlugs')->willThrowException(new RuntimeException('db down'));
+		$this->logger->expects($this->once())->method('error');
+
+		$resolver = new RegisterSlugResolver(registerMapper: $this->registerMapper, logger: $this->logger);
+		$resolution = $resolver->resolve(canonical: 'buildiq');
+
+		$this->assertNull($resolution->slug);
+		$this->assertTrue($resolution->isAbsent());
+	}//end testAFailedReadReportsAbsenceAndLogsAnError()
+
+	/**
+	 * The probe is memoised for the life of the request.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public function testTheProbeIsMemoisedPerCandidateList(): void {
+		$this->registerMapper->expects($this->once())
+			->method('findIdsBySlugs')
+			->willReturn(['buildiq' => ['10'], 'openbuild' => []]);
+
+		$resolver = new RegisterSlugResolver(registerMapper: $this->registerMapper, logger: $this->logger);
+
+		$this->assertSame('buildiq', $resolver->slugOrNull(canonical: 'buildiq'));
+		$this->assertSame('buildiq', $resolver->slugOrNull(canonical: 'buildiq'));
+		$this->assertSame('buildiq', $resolver->resolve(canonical: 'BuildIQ')->slug);
+	}//end testTheProbeIsMemoisedPerCandidateList()
+
+	/**
+	 * An empty canonical slug is refused rather than probed.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public function testAnEmptyCanonicalSlugResolvesToNothing(): void {
+		$this->registerMapper->expects($this->never())->method('findIdsBySlugs');
+
+		$resolver = new RegisterSlugResolver(registerMapper: $this->registerMapper, logger: $this->logger);
+		$resolution = $resolver->resolve(canonical: '  ');
+
+		$this->assertNull($resolution->slug);
+		$this->assertTrue($resolution->isAbsent());
+	}//end testAnEmptyCanonicalSlugResolvesToNothing()
+}//end class

--- a/tests/Unit/Support/RegisterSlugPinTest.php
+++ b/tests/Unit/Support/RegisterSlugPinTest.php
@@ -1,0 +1,220 @@
+<?php
+
+/**
+ * No code under lib/ pins a superseded register slug.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Support;
+
+use OCA\OpenRegister\Support\RegisterSlugAliases;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+/**
+ * The case that has never once been caught.
+ *
+ * ## What this guard does NOT catch
+ *
+ * It reads lines, not data flow. A superseded slug that arrives from app config,
+ * from a manifest, or through more than one assignment is invisible to it, and so
+ * is a `match` arm built at run time. That is why the behavioural tests in
+ * ScheduleReconcilerIoTest exist alongside it: this guard stops the literal being
+ * TYPED, and those stop the resolved slug being IGNORED. Measured on the mutation
+ * that reinstated the literal, the unmigrated-instance test still passed, because
+ * on that instance the pinned literal happens to be the right answer. Only the
+ * migrated case failed, and only the migrated case has ever mattered.
+ *
+ * A consumer pinned to a superseded register slug on a MIGRATED instance does
+ * not raise. `openregister_registers` has no row with that slug, so the read
+ * matches nothing and returns an empty result set, which is byte-for-byte what
+ * a healthy, empty register returns. There is no exception, no 404, no log line
+ * that distinguishes the two. Every existing guard in this repository watches
+ * behaviour, and this defect has no behaviour to watch: it is a feature that
+ * quietly stops happening.
+ *
+ * So the guard is static, and it is repo-wide rather than diff-scoped. Diff
+ * scope is right for debt a PR could reasonably be asked to carry; it is wrong
+ * here, because every one of these references was written BEFORE the slug was
+ * renamed and will therefore never appear in a diff. A diff-scoped version of
+ * this test passes on a repository full of the defect.
+ *
+ * @spec openspec/specs/register-slug-resolution/spec.md
+ */
+class RegisterSlugPinTest extends TestCase {
+
+	/**
+	 * Files allowed to name a superseded slug, and why.
+	 *
+	 * Each entry is a genuine exception, not a deferral: these files exist in
+	 * order to name the old slug. Anything else added here should instead be
+	 * calling the resolver.
+	 *
+	 * @var array<string, string>
+	 */
+	private const ALLOWED = [
+		'lib/Support/RegisterSlugAliases.php' => 'the declared alias map itself',
+		'lib/Support/FleetAppId.php'          => 'app ids, not register slugs; a different question with a different source of truth',
+	];
+
+	/**
+	 * Source patterns that put a string literal in REGISTER position.
+	 *
+	 * Deliberately narrow. A slug is only a defect where it identifies a
+	 * register; the same word in a log message, a transport name or an app id
+	 * is not this defect and a guard that flagged it would be turned off.
+	 *
+	 * @var list<string>
+	 */
+	private const REGISTER_POSITION = [
+		'/setRegister\(\s*(?:register:\s*)?\'([a-zA-Z0-9_-]+)\'/',
+		'/\bregister:\s*\'([a-zA-Z0-9_-]+)\'/',
+		'/\'register\'\s*=>\s*\'([a-zA-Z0-9_-]+)\'/',
+		'/\bconst\s+[A-Z0-9_]*REGISTER[A-Z0-9_]*\s*=\s*\'([a-zA-Z0-9_-]+)\'/',
+		'/\$[a-zA-Z0-9_]*(?:[Rr]egister|[Ss]lug)[a-zA-Z0-9_]*\s*=\s*\'([a-zA-Z0-9_-]+)\'/',
+	];
+
+	/**
+	 * No file under lib/ names a superseded register slug in register position.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public function testNoSourceFilePinsASupersededRegisterSlug(): void {
+		$superseded = RegisterSlugAliases::supersededSlugs();
+		$this->assertNotSame([], $superseded, 'The alias map must know at least one rename, or this guard proves nothing.');
+
+		$findings = [];
+		foreach ($this->sourceFiles() as $relative => $absolute) {
+			if (isset(self::ALLOWED[$relative]) === true) {
+				continue;
+			}
+
+			$lines = file($absolute, (FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES));
+			if ($lines === false) {
+				continue;
+			}
+
+			foreach ($lines as $index => $line) {
+				foreach (self::REGISTER_POSITION as $pattern) {
+					if (preg_match($pattern, $line, $matches) !== 1) {
+						continue;
+					}
+
+					$slug = strtolower($matches[1]);
+					if (isset($superseded[$slug]) === false) {
+						continue;
+					}
+
+					$findings[] = sprintf(
+						'%s:%d pins the superseded register slug \'%s\'. Resolve \'%s\' through '
+						. 'RegisterSlugResolverInterface::resolve() instead, and branch on '
+						. 'isResolved(), because reading with a slug this instance does not carry '
+						. 'returns zero rows, not an error.',
+						$relative,
+						($index + 1),
+						$slug,
+						$superseded[$slug]
+					);
+				}
+			}
+		}
+
+		$this->assertSame([], $findings, "Superseded register slugs are pinned:\n" . implode("\n", $findings));
+	}//end testNoSourceFilePinsASupersededRegisterSlug()
+
+	/**
+	 * The guard actually looks at something.
+	 *
+	 * A file walker that silently finds no files is the classic hollow green:
+	 * the assertion above would pass on an empty list forever. This pins the
+	 * walker to a floor well below the real count, so a broken path fails here
+	 * rather than passing there.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public function testTheGuardScansTheSourceTree(): void {
+		$files = $this->sourceFiles();
+
+		$this->assertGreaterThan(500, count($files), 'The walker must see lib/, or the guard above cannot fail.');
+		$this->assertArrayHasKey(
+			'lib/AppHost/Scheduling/ScheduleReconciler.php',
+			$files,
+			'The reconciler is the file this guard was written for; the walker must reach it.'
+		);
+	}//end testTheGuardScansTheSourceTree()
+
+	/**
+	 * The patterns match a pinned slug when one is present.
+	 *
+	 * Watched failing is not enough on its own once the tree is clean: from
+	 * then on the guard passes whether or not its regexes still work. This
+	 * feeds each register-position form a known-bad line and requires a match,
+	 * so a regex that stops matching reddens immediately.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/register-slug-resolution/spec.md
+	 */
+	public function testEachRegisterPositionPatternStillMatches(): void {
+		$samples = [
+			'/setRegister\(\s*(?:register:\s*)?\'([a-zA-Z0-9_-]+)\'/' => "\$objectService->setRegister('voorzieningen');",
+			'/\bregister:\s*\'([a-zA-Z0-9_-]+)\'/'                    => "\$svc->find(id: \$id, register: 'openconnector', schema: 'source');",
+			'/\'register\'\s*=>\s*\'([a-zA-Z0-9_-]+)\'/'              => "'filters' => ['register' => 'openbuild', 'schema' => 'application'],",
+			'/\bconst\s+[A-Z0-9_]*REGISTER[A-Z0-9_]*\s*=\s*\'([a-zA-Z0-9_-]+)\'/' => "\tprivate const OB_REGISTER_SLUG = 'openbuild';",
+			'/\$[a-zA-Z0-9_]*(?:[Rr]egister|[Ss]lug)[a-zA-Z0-9_]*\s*=\s*\'([a-zA-Z0-9_-]+)\'/' => "\t\t\$register = 'openbuild';",
+		];
+
+		$superseded = RegisterSlugAliases::supersededSlugs();
+
+		foreach (self::REGISTER_POSITION as $pattern) {
+			$this->assertArrayHasKey($pattern, $samples, 'Every register-position pattern needs a known-bad sample.');
+			$this->assertSame(
+				1,
+				preg_match($pattern, $samples[$pattern], $matches),
+				'Pattern must match its known-bad sample: ' . $pattern
+			);
+			$this->assertArrayHasKey(
+				strtolower($matches[1]),
+				$superseded,
+				'The sample must capture a slug the alias map calls superseded: ' . $pattern
+			);
+		}
+	}//end testEachRegisterPositionPatternStillMatches()
+
+	/**
+	 * Every PHP file under lib/, keyed by repository-relative path.
+	 *
+	 * @return array<string, string> Relative path => absolute path.
+	 */
+	private function sourceFiles(): array {
+		$root = dirname(__DIR__, 3);
+		$lib = $root . '/lib';
+
+		$files = [];
+		$iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($lib, RecursiveDirectoryIterator::SKIP_DOTS));
+		foreach ($iterator as $file) {
+			if (($file instanceof SplFileInfo) === false || $file->isFile() === false) {
+				continue;
+			}
+
+			if ($file->getExtension() !== 'php') {
+				continue;
+			}
+
+			$path = $file->getPathname();
+			$files[ltrim(str_replace($root, '', $path), '/')] = $path;
+		}
+
+		return $files;
+	}//end sourceFiles()
+}//end class

--- a/tests/Unit/Support/RegisterSlugPinTest.php
+++ b/tests/Unit/Support/RegisterSlugPinTest.php
@@ -97,7 +97,13 @@ class RegisterSlugPinTest extends TestCase {
 				continue;
 			}
 
-			$lines = file($absolute, (FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES));
+			// NOT FILE_SKIP_EMPTY_LINES. Skipping blank lines renumbers every
+			// line after the first one, so `$index + 1` stops being the line
+			// number and becomes the count of non-blank lines. Measured on the
+			// reconciler: a pin on line 590 was reported as line 528, because
+			// 62 blank lines preceded it. A guard that names the wrong line is
+			// a guard whose next reader concludes it is broken.
+			$lines = file($absolute, FILE_IGNORE_NEW_LINES);
 			if ($lines === false) {
 				continue;
 			}


### PR DESCRIPTION
## The problem

Nine fleet apps ship a repair step that renames their OpenRegister register slug. The step runs per instance, at repair time. So both slugs are live across the estate right now, depending on whether a given instance has repaired yet. A consumer that hardcodes either one is wrong on half the estate.

The old-slug case is the quiet one. OpenRegister finds no register, matches no rows, and returns an empty set. An empty set is byte for byte what a healthy empty register returns. There is no exception, no 404, and no log line that separates the two. The caller records "no data" and nobody is alerted.

Measured in this repository: `ScheduleReconciler` pinned `openconnector` and `openbuild` across five call sites. On any instance that has run either repair step it enumerates nothing, upserts nothing, and collects nothing, while reporting success. Every AppHost schedule stops firing.

## What this adds

`RegisterSlugResolverInterface` and its implementation. It reads `openregister_registers` and nothing else.

`RegisterSlugAliases` holds the declared slug history. It is transcribed from the nine repair steps, not derived from the app rename map. That distinction is load bearing. Stackiq renamed the register `voorzieningen`, and never carried `softwarecatalog` as a slug at all. A probe keyed on app-id history offers `softwarecatalog`, matches nothing, and reports the register absent on exactly the instances that have it.

Eight repair steps are called `MigrateRegisterSlug`. Learniq calls its one `RenameRegisterSlug`. A sweep that searched the single filename reported learniq as never migrated, so this list was read from files rather than from a `find` result.

The return type is a resolution, not a string. An absence has to be branched on. Any string a resolver invents on a miss goes straight into a read that comes back empty, which is the defect itself.

## Why it lives here

Register slugs live in this app's table. No consuming app can answer the question without reaching into that storage. Every per-app copy would be a copy of OpenRegister's truth, maintained by someone who does not own it. ADR-084 settled the same argument for `ObjectServiceInterface`, where ten apps had hand rolled doubles declaring between 0 and 13 methods against a real class of 88.

## Proving ground

Adopted here, end to end, in the two places this repo pinned a slug:

- `ScheduleReconciler`, five call sites across two registers renamed by two different apps' steps. An instance can be migrated for one and not the other, so they resolve independently.
- `SettingsController`, the type-filtering diagnostic, which pinned `voorzieningen`. It now answers 404 when the register is absent, instead of rendering an empty read as "no organisations".

Deliberately not adopted in the other affected repos. The design is proved once here first.

## Guards, and watching them fail

`RegisterSlugPinTest` is static and repo wide, not diff scoped. Diff scope is wrong for this defect: every one of these references was written before the rename, so none of them will ever appear in a diff. A diff scoped version passes on a repository full of the defect.

Mutation checked by reinstating the literal at the virtual-app read. Two assertions reddened, and they were the right two:

- `testAMigratedInstanceIsReadWithItsNewSlug` failed, expected `buildiq`, got `openbuild`.
- `RegisterSlugPinTest` failed, naming the file, the line and the canonical slug.

`testAnUnmigratedInstanceIsReadWithItsOldSlug` still passed under that mutation. On an unmigrated instance the pinned literal happens to be the right answer. Only the migrated case can catch this, and that is the case that has never once been caught.

The guard also reported the wrong line number when first watched failing. `FILE_SKIP_EMPTY_LINES` renumbers every line after the first blank one, so a pin on line 590 was reported as 528. Fixed in its own commit. A guard that names the wrong line is a guard whose next reader calls it broken.

## Verification

- phpcs on `lib`: pass.
- phpmd on the changed files, both rulesets: pass.
- phpstan: no errors.
- psalm: exit 0, nothing in the changed files.
- phpunit unit suite: 19507 tests, 47954 assertions, zero failures.

## This PR is blocked on a second one

Gate 67, `openregister-contract-parity`, fails and is correct to fail. ADR-084 requires a published contract to exist in two places: `lib/Contract/` for runtime here, and `hydra-gates/contracts/` so a leaf app's tests can load it. The two new contract files are not yet in the `hydra-gates` package, and the gate requires the copies to be byte identical.

In CI the gate reads the copy shipped from `.github@main`, so this PR stays red until that lands. The change there is additive: two files, copied unmodified. Only openregister has a `lib/Contract/` directory, so no other repo is affected.

Do not merge this before that one.
