### PR TITLE
fix(tests): point the mdm @e2e anchors at their canonical specs

### DIFF
--- a/tests/e2e/spec-coverage/mdm-frontend.spec.ts
+++ b/tests/e2e/spec-coverage/mdm-frontend.spec.ts
@@ -118,8 +118,8 @@ async function gotoScoped(page: Page, route: string): Promise<boolean> {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#mdm-group-appears-in-the-app-navigation
-// @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#each-mdm-route-renders-its-own-view-component
+// @e2e openspec/specs/mdm-frontend/spec.md#mdm-group-appears-in-the-app-navigation
+// @e2e openspec/specs/mdm-frontend/spec.md#each-mdm-route-renders-its-own-view-component
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('mdm-frontend — navigation group', () => {
 	test.use({ storageState: STORAGE_STATE })
@@ -159,8 +159,8 @@ test.describe('mdm-frontend — navigation group', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#schema-select-is-disabled-until-a-register-is-chosen
-// @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#ncselect-carries-an-accessible-label
+// @e2e openspec/specs/mdm-frontend/spec.md#schema-select-is-disabled-until-a-register-is-chosen
+// @e2e openspec/specs/mdm-frontend/spec.md#ncselect-carries-an-accessible-label
 // @e2e openspec/changes/mdm-views-route-scoping-e2e/specs/mdm-views-route-scoping/spec.md#scenario-selects-expose-stable-test-handles
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('mdm-frontend — register/schema selector', () => {
@@ -188,7 +188,7 @@ test.describe('mdm-frontend — register/schema selector', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#selection-persists-across-mdm-views
+// @e2e openspec/specs/mdm-frontend/spec.md#selection-persists-across-mdm-views
 // @e2e openspec/changes/mdm-views-route-scoping-e2e/specs/mdm-views-route-scoping/spec.md#scenario-deep-link-preselects-register-and-schema
 // @e2e openspec/changes/mdm-views-route-scoping-e2e/specs/mdm-views-route-scoping/spec.md#scenario-selecting-a-register-and-schema-updates-the-url
 // ─────────────────────────────────────────────────────────────────────────────
@@ -228,9 +228,9 @@ test.describe('mdm-frontend — selection persistence', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#kpi-cards-and-histogram-reflect-the-stats-envelope
-// @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#lowest-quality-table-lists-scored-objects
-// @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#empty-state-on-an-unscored-schema
+// @e2e openspec/specs/mdm-frontend/spec.md#kpi-cards-and-histogram-reflect-the-stats-envelope
+// @e2e openspec/specs/mdm-frontend/spec.md#lowest-quality-table-lists-scored-objects
+// @e2e openspec/specs/mdm-frontend/spec.md#empty-state-on-an-unscored-schema
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('mdm-frontend — Data Quality dashboard', () => {
 	test.use({ storageState: STORAGE_STATE })
@@ -283,7 +283,7 @@ test.describe('mdm-frontend — Data Quality dashboard', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#candidate-pairs-render-with-score-and-matched-attributes
+// @e2e openspec/specs/mdm-frontend/spec.md#candidate-pairs-render-with-score-and-matched-attributes
 // NOTE: mdm-frontend's original "no-merge-or-write-action-is-present" scenario
 // (DuplicatesIndex is strictly read-only) is superseded by mdm-merge-ui (#C),
 // which adds the per-pair "Merge" action by design — see
@@ -318,8 +318,8 @@ test.describe('mdm-frontend — Duplicate Candidates', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#master-entities-show-quality-columns
-// @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#golden-record-detail-shows-attribute-provenance
+// @e2e openspec/specs/mdm-frontend/spec.md#master-entities-show-quality-columns
+// @e2e openspec/specs/mdm-frontend/spec.md#golden-record-detail-shows-attribute-provenance
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('mdm-frontend — Master entities + golden record', () => {
 	test.use({ storageState: STORAGE_STATE })
@@ -388,8 +388,8 @@ test.describe('mdm-frontend — Master entities + golden record', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#per-webhook-health-counts-render
-// @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#empty-state-when-no-webhooks-are-configured
+// @e2e openspec/specs/mdm-frontend/spec.md#per-webhook-health-counts-render
+// @e2e openspec/specs/mdm-frontend/spec.md#empty-state-when-no-webhooks-are-configured
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('mdm-frontend — Queue / sync health', () => {
 	test.use({ storageState: STORAGE_STATE })

--- a/tests/e2e/spec-coverage/mdm-merge-ui.spec.ts
+++ b/tests/e2e/spec-coverage/mdm-merge-ui.spec.ts
@@ -110,13 +110,13 @@ async function gotoScoped(page: Page, route: string): Promise<boolean> {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// @e2e openspec/changes/mdm-merge-ui/specs/mdm-merge-ui/spec.md#merge-action-is-offered-per-candidate-pair
-// @e2e openspec/changes/mdm-merge-ui/specs/mdm-merge-ui/spec.md#preview-renders-the-projected-survivor
-// @e2e openspec/changes/mdm-merge-ui/specs/mdm-merge-ui/spec.md#reason-is-mandatory
-// @e2e openspec/changes/mdm-merge-ui/specs/mdm-merge-ui/spec.md#reason-selector-is-accessibly-labelled
-// @e2e openspec/changes/mdm-merge-ui/specs/mdm-merge-ui/spec.md#confirming-a-merge-executes-it-and-refreshes-candidates
-// @e2e openspec/changes/mdm-merge-ui/specs/mdm-merge-ui/spec.md#reverse-offered-only-within-the-window
-// @e2e openspec/changes/mdm-merge-ui/specs/mdm-merge-ui/spec.md#reversing-restores-the-objects-and-updates-the-row
+// @e2e openspec/specs/mdm-merge-ui/spec.md#merge-action-is-offered-per-candidate-pair
+// @e2e openspec/specs/mdm-merge-ui/spec.md#preview-renders-the-projected-survivor
+// @e2e openspec/specs/mdm-merge-ui/spec.md#reason-is-mandatory
+// @e2e openspec/specs/mdm-merge-ui/spec.md#reason-selector-is-accessibly-labelled
+// @e2e openspec/specs/mdm-merge-ui/spec.md#confirming-a-merge-executes-it-and-refreshes-candidates
+// @e2e openspec/specs/mdm-merge-ui/spec.md#reverse-offered-only-within-the-window
+// @e2e openspec/specs/mdm-merge-ui/spec.md#reversing-restores-the-objects-and-updates-the-row
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('mdm-merge-ui — duplicate → merge → reverse chain', () => {
 	test.use({ storageState: STORAGE_STATE })
@@ -222,8 +222,8 @@ test.describe('mdm-merge-ui — duplicate → merge → reverse chain', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// @e2e openspec/changes/mdm-merge-ui/specs/mdm-merge-ui/spec.md#merge-operations-list-renders-audit-rows
-// @e2e openspec/changes/mdm-merge-ui/specs/mdm-merge-ui/spec.md#view-is-registered-and-navigable
+// @e2e openspec/specs/mdm-merge-ui/spec.md#merge-operations-list-renders-audit-rows
+// @e2e openspec/specs/mdm-merge-ui/spec.md#view-is-registered-and-navigable
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('mdm-merge-ui — Merge Operations view', () => {
 	test.use({ storageState: STORAGE_STATE })

--- a/tests/e2e/spec-coverage/mdm-survivorship-override.spec.ts
+++ b/tests/e2e/spec-coverage/mdm-survivorship-override.spec.ts
@@ -152,9 +152,9 @@ async function openResolveConflicts(page: Page): Promise<boolean> {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// @e2e openspec/changes/mdm-survivorship-override/specs/mdm-conflict-resolution-ui/spec.md#scenario-only-disagreeing-attributes-are-listed
-// @e2e openspec/changes/mdm-survivorship-override/specs/mdm-conflict-resolution-ui/spec.md#scenario-no-conflicts-renders-an-empty-state
-// @e2e openspec/changes/mdm-survivorship-override/specs/mdm-conflict-resolution-ui/spec.md#scenario-selecting-a-winning-source-enables-save
+// @e2e openspec/specs/mdm-conflict-resolution-ui/spec.md#scenario-only-disagreeing-attributes-are-listed
+// @e2e openspec/specs/mdm-conflict-resolution-ui/spec.md#scenario-no-conflicts-renders-an-empty-state
+// @e2e openspec/specs/mdm-conflict-resolution-ui/spec.md#scenario-selecting-a-winning-source-enables-save
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('mdm-survivorship-override — conflict-resolution modal opens from a golden record', () => {
 	test.use({ storageState: STORAGE_STATE })
@@ -204,7 +204,7 @@ test.describe('mdm-survivorship-override — conflict-resolution modal opens fro
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// @e2e openspec/changes/mdm-survivorship-override/specs/mdm-conflict-resolution-ui/spec.md#scenario-persistent-choice-writes-a-trust-configuration-row
+// @e2e openspec/specs/mdm-conflict-resolution-ui/spec.md#scenario-persistent-choice-writes-a-trust-configuration-row
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('mdm-survivorship-override — persistent outcome', () => {
 	test.use({ storageState: STORAGE_STATE })
@@ -255,8 +255,8 @@ test.describe('mdm-survivorship-override — persistent outcome', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// @e2e openspec/changes/mdm-survivorship-override/specs/mdm-conflict-resolution-ui/spec.md#scenario-one-off-choice-sets-a-per-object-override
-// @e2e openspec/changes/mdm-survivorship-override/specs/mdm-survivorship/spec.md#scenario-per-object-override-wins-over-the-tier-selected-value
+// @e2e openspec/specs/mdm-conflict-resolution-ui/spec.md#scenario-one-off-choice-sets-a-per-object-override
+// @e2e openspec/specs/mdm-survivorship/spec.md#scenario-per-object-override-wins-over-the-tier-selected-value
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('mdm-survivorship-override — one-off outcome', () => {
 	test.use({ storageState: STORAGE_STATE })


### PR DESCRIPTION
Follow-up to #3569, which repaired fifteen citation targets and deliberately left these behind.

## What changed

Twenty-eight `@e2e` anchors under `tests/e2e/spec-coverage/` named a change directory instead of the capability's canonical spec. Each one keeps its fragment; the path prefix is the only thing rewritten.

| Change directory named | Anchors | Now points at |
| --- | ---: | --- |
| `openspec/changes/mdm-frontend/specs/mdm-frontend/` | 13 | `openspec/specs/mdm-frontend/spec.md` |
| `openspec/changes/mdm-merge-ui/specs/mdm-merge-ui/` | 9 | `openspec/specs/mdm-merge-ui/spec.md` |
| `openspec/changes/mdm-survivorship-override/specs/mdm-conflict-resolution-ui/` | 5 | `openspec/specs/mdm-conflict-resolution-ui/spec.md` |
| `openspec/changes/mdm-survivorship-override/specs/mdm-survivorship/` | 1 | `openspec/specs/mdm-survivorship/spec.md` |

All three changes were archived on 2026-07-03, so every one of these paths has already moved once. A spec path is stable; a change path moves on archive, and that move is what broke the fifteen anchors #3569 repaired.

## Why they resolved anyway

Gate-46's capability index spans all three homes of a spec — in flight, archived, canonical — so these twenty-eight were never reported as dangling. The index rescues the reference without making it honest about where the requirement lives. Repointing is what removes the dependency on that rescue.

## No anchor points at a whole file

Every rewritten line keeps its `#scenario-...` fragment, and each fragment was confirmed against a real heading in the canonical spec. An anchor naming a bare `spec.md` resolves and says nothing about which requirement the test covers, which is the shape this work exists to remove.

## Three anchors deliberately left

Three anchors in `mdm-frontend.spec.ts` (lines 164, 192, 193) still name `openspec/changes/mdm-views-route-scoping-e2e/`. That change is live, not archived, and there is no `openspec/specs/mdm-views-route-scoping/spec.md`.

Repointing them there would still pass the gate — the capability index would resolve the canonical-looking path back to the live change directory — producing an anchor that names a file which does not exist and reads as though it does. They move when that change is archived and its spec is promoted.

## Measurement

Run with the gate's own resolver, `scripts/lib/check_spec_anchors.py` from `ConductionNL/.github@main` (freshly cloned, not a vendored copy), over gate-46's full file scope:

```
files in scope: 3713
total findings: 0
@spec findings: 0
@e2e  findings: 0
```

Across 9,948 `@spec` and 163 `@e2e` `openspec/` tags.

The resolver was mutation-checked before the zero was trusted: an invented capability (`openspec/specs/totally-imaginary/spec.md#nope`) and an invented fragment (`openspec/specs/mdm-frontend/spec.md#REQ-999-invented`) were both reported. A checker that watched nothing exits the same way as one that watched and found everything clean, so the zero is a measurement rather than an empty run.

## Follow-up, not in this PR

`HYDRA_GATE_SPEC_ANCHOR_E2E_BLOCKING=1` is the opt-in gate-46 invites once a repo's `@e2e` count reaches zero. It is filed separately because there is currently no way for a repo to set it: `quality.yml` has no input for it and the gate step's `env:` block is fixed, so the opt-in needs a shared-workflow change first. Keeping it out of this PR also keeps the repoints revertable on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)