### PR TITLE
chore(ci): block on unresolved @e2e anchors in gate-46

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -314,6 +314,35 @@ jobs:
       # already carry serious/critical axe violations, so switching it on in
       # the same change as the gates themselves would confuse "this repo has an
       # accessibility defect" with "Nextcloud core does". Separate change.
+      #
+      # Gate-46 blocks on `@e2e` anchors here, not just on `@spec`.
+      #
+      # This is the opt-in the gate itself invites — "set
+      # HYDRA_GATE_SPEC_ANCHOR_E2E_BLOCKING=1 for this repo once they are worked
+      # down" — and it is set only because the count reached zero first. It is
+      # NOT the fleet default and must not become one: #726 counted 194 dangling
+      # @e2e anchors fleet-wide, 154 of them in the four repos with the most
+      # end-to-end coverage, so blocking there would punish exactly the wrong
+      # thing.
+      #
+      # THE MEASUREMENT THAT LICENSES IT, taken with the gate's own resolver
+      # (scripts/lib/check_spec_anchors.py from ConductionNL/.github@main, not a
+      # vendored copy and not a reimplementation) over gate-46's full file scope
+      # of 3,713 files, after #3573 repointed the last 28 change-directory
+      # anchors: 0 unresolved findings across 9,948 @spec and 163 @e2e tags.
+      # The resolver was mutation-checked before the zero was believed — an
+      # invented capability and an invented fragment were both reported — because
+      # a checker that inspects nothing exits exactly like one that inspects
+      # everything and finds it clean.
+      #
+      # WHAT WILL MAKE THIS FAIL, and it is meant to: a new test whose @e2e
+      # anchor names a spec, requirement or scenario that does not exist. Three
+      # anchors still name the live change `mdm-views-route-scoping-e2e`; they
+      # resolve today through gate-46's capability index and will keep resolving
+      # after that change is archived, so they do not put this repo at risk. If
+      # this ever blocks a PR on inherited debt rather than on the PR's own
+      # anchors, revert this one line — that is why it is its own commit.
+      hydra-gates-e2e-anchor-blocking: true
       enable-sbom: true
 
       # ── Frontend Check legs ──────────────────────────────────────────────

--- a/tests/e2e/spec-coverage/mdm-frontend.spec.ts
+++ b/tests/e2e/spec-coverage/mdm-frontend.spec.ts
@@ -118,8 +118,8 @@ async function gotoScoped(page: Page, route: string): Promise<boolean> {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#mdm-group-appears-in-the-app-navigation
-// @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#each-mdm-route-renders-its-own-view-component
+// @e2e openspec/specs/mdm-frontend/spec.md#mdm-group-appears-in-the-app-navigation
+// @e2e openspec/specs/mdm-frontend/spec.md#each-mdm-route-renders-its-own-view-component
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('mdm-frontend — navigation group', () => {
 	test.use({ storageState: STORAGE_STATE })
@@ -159,8 +159,8 @@ test.describe('mdm-frontend — navigation group', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#schema-select-is-disabled-until-a-register-is-chosen
-// @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#ncselect-carries-an-accessible-label
+// @e2e openspec/specs/mdm-frontend/spec.md#schema-select-is-disabled-until-a-register-is-chosen
+// @e2e openspec/specs/mdm-frontend/spec.md#ncselect-carries-an-accessible-label
 // @e2e openspec/changes/mdm-views-route-scoping-e2e/specs/mdm-views-route-scoping/spec.md#scenario-selects-expose-stable-test-handles
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('mdm-frontend — register/schema selector', () => {
@@ -188,7 +188,7 @@ test.describe('mdm-frontend — register/schema selector', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#selection-persists-across-mdm-views
+// @e2e openspec/specs/mdm-frontend/spec.md#selection-persists-across-mdm-views
 // @e2e openspec/changes/mdm-views-route-scoping-e2e/specs/mdm-views-route-scoping/spec.md#scenario-deep-link-preselects-register-and-schema
 // @e2e openspec/changes/mdm-views-route-scoping-e2e/specs/mdm-views-route-scoping/spec.md#scenario-selecting-a-register-and-schema-updates-the-url
 // ─────────────────────────────────────────────────────────────────────────────
@@ -228,9 +228,9 @@ test.describe('mdm-frontend — selection persistence', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#kpi-cards-and-histogram-reflect-the-stats-envelope
-// @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#lowest-quality-table-lists-scored-objects
-// @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#empty-state-on-an-unscored-schema
+// @e2e openspec/specs/mdm-frontend/spec.md#kpi-cards-and-histogram-reflect-the-stats-envelope
+// @e2e openspec/specs/mdm-frontend/spec.md#lowest-quality-table-lists-scored-objects
+// @e2e openspec/specs/mdm-frontend/spec.md#empty-state-on-an-unscored-schema
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('mdm-frontend — Data Quality dashboard', () => {
 	test.use({ storageState: STORAGE_STATE })
@@ -283,7 +283,7 @@ test.describe('mdm-frontend — Data Quality dashboard', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#candidate-pairs-render-with-score-and-matched-attributes
+// @e2e openspec/specs/mdm-frontend/spec.md#candidate-pairs-render-with-score-and-matched-attributes
 // NOTE: mdm-frontend's original "no-merge-or-write-action-is-present" scenario
 // (DuplicatesIndex is strictly read-only) is superseded by mdm-merge-ui (#C),
 // which adds the per-pair "Merge" action by design — see
@@ -318,8 +318,8 @@ test.describe('mdm-frontend — Duplicate Candidates', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#master-entities-show-quality-columns
-// @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#golden-record-detail-shows-attribute-provenance
+// @e2e openspec/specs/mdm-frontend/spec.md#master-entities-show-quality-columns
+// @e2e openspec/specs/mdm-frontend/spec.md#golden-record-detail-shows-attribute-provenance
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('mdm-frontend — Master entities + golden record', () => {
 	test.use({ storageState: STORAGE_STATE })
@@ -388,8 +388,8 @@ test.describe('mdm-frontend — Master entities + golden record', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#per-webhook-health-counts-render
-// @e2e openspec/changes/mdm-frontend/specs/mdm-frontend/spec.md#empty-state-when-no-webhooks-are-configured
+// @e2e openspec/specs/mdm-frontend/spec.md#per-webhook-health-counts-render
+// @e2e openspec/specs/mdm-frontend/spec.md#empty-state-when-no-webhooks-are-configured
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('mdm-frontend — Queue / sync health', () => {
 	test.use({ storageState: STORAGE_STATE })

--- a/tests/e2e/spec-coverage/mdm-merge-ui.spec.ts
+++ b/tests/e2e/spec-coverage/mdm-merge-ui.spec.ts
@@ -110,13 +110,13 @@ async function gotoScoped(page: Page, route: string): Promise<boolean> {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// @e2e openspec/changes/mdm-merge-ui/specs/mdm-merge-ui/spec.md#merge-action-is-offered-per-candidate-pair
-// @e2e openspec/changes/mdm-merge-ui/specs/mdm-merge-ui/spec.md#preview-renders-the-projected-survivor
-// @e2e openspec/changes/mdm-merge-ui/specs/mdm-merge-ui/spec.md#reason-is-mandatory
-// @e2e openspec/changes/mdm-merge-ui/specs/mdm-merge-ui/spec.md#reason-selector-is-accessibly-labelled
-// @e2e openspec/changes/mdm-merge-ui/specs/mdm-merge-ui/spec.md#confirming-a-merge-executes-it-and-refreshes-candidates
-// @e2e openspec/changes/mdm-merge-ui/specs/mdm-merge-ui/spec.md#reverse-offered-only-within-the-window
-// @e2e openspec/changes/mdm-merge-ui/specs/mdm-merge-ui/spec.md#reversing-restores-the-objects-and-updates-the-row
+// @e2e openspec/specs/mdm-merge-ui/spec.md#merge-action-is-offered-per-candidate-pair
+// @e2e openspec/specs/mdm-merge-ui/spec.md#preview-renders-the-projected-survivor
+// @e2e openspec/specs/mdm-merge-ui/spec.md#reason-is-mandatory
+// @e2e openspec/specs/mdm-merge-ui/spec.md#reason-selector-is-accessibly-labelled
+// @e2e openspec/specs/mdm-merge-ui/spec.md#confirming-a-merge-executes-it-and-refreshes-candidates
+// @e2e openspec/specs/mdm-merge-ui/spec.md#reverse-offered-only-within-the-window
+// @e2e openspec/specs/mdm-merge-ui/spec.md#reversing-restores-the-objects-and-updates-the-row
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('mdm-merge-ui — duplicate → merge → reverse chain', () => {
 	test.use({ storageState: STORAGE_STATE })
@@ -222,8 +222,8 @@ test.describe('mdm-merge-ui — duplicate → merge → reverse chain', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// @e2e openspec/changes/mdm-merge-ui/specs/mdm-merge-ui/spec.md#merge-operations-list-renders-audit-rows
-// @e2e openspec/changes/mdm-merge-ui/specs/mdm-merge-ui/spec.md#view-is-registered-and-navigable
+// @e2e openspec/specs/mdm-merge-ui/spec.md#merge-operations-list-renders-audit-rows
+// @e2e openspec/specs/mdm-merge-ui/spec.md#view-is-registered-and-navigable
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('mdm-merge-ui — Merge Operations view', () => {
 	test.use({ storageState: STORAGE_STATE })

--- a/tests/e2e/spec-coverage/mdm-survivorship-override.spec.ts
+++ b/tests/e2e/spec-coverage/mdm-survivorship-override.spec.ts
@@ -152,9 +152,9 @@ async function openResolveConflicts(page: Page): Promise<boolean> {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// @e2e openspec/changes/mdm-survivorship-override/specs/mdm-conflict-resolution-ui/spec.md#scenario-only-disagreeing-attributes-are-listed
-// @e2e openspec/changes/mdm-survivorship-override/specs/mdm-conflict-resolution-ui/spec.md#scenario-no-conflicts-renders-an-empty-state
-// @e2e openspec/changes/mdm-survivorship-override/specs/mdm-conflict-resolution-ui/spec.md#scenario-selecting-a-winning-source-enables-save
+// @e2e openspec/specs/mdm-conflict-resolution-ui/spec.md#scenario-only-disagreeing-attributes-are-listed
+// @e2e openspec/specs/mdm-conflict-resolution-ui/spec.md#scenario-no-conflicts-renders-an-empty-state
+// @e2e openspec/specs/mdm-conflict-resolution-ui/spec.md#scenario-selecting-a-winning-source-enables-save
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('mdm-survivorship-override — conflict-resolution modal opens from a golden record', () => {
 	test.use({ storageState: STORAGE_STATE })
@@ -204,7 +204,7 @@ test.describe('mdm-survivorship-override — conflict-resolution modal opens fro
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// @e2e openspec/changes/mdm-survivorship-override/specs/mdm-conflict-resolution-ui/spec.md#scenario-persistent-choice-writes-a-trust-configuration-row
+// @e2e openspec/specs/mdm-conflict-resolution-ui/spec.md#scenario-persistent-choice-writes-a-trust-configuration-row
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('mdm-survivorship-override — persistent outcome', () => {
 	test.use({ storageState: STORAGE_STATE })
@@ -255,8 +255,8 @@ test.describe('mdm-survivorship-override — persistent outcome', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// @e2e openspec/changes/mdm-survivorship-override/specs/mdm-conflict-resolution-ui/spec.md#scenario-one-off-choice-sets-a-per-object-override
-// @e2e openspec/changes/mdm-survivorship-override/specs/mdm-survivorship/spec.md#scenario-per-object-override-wins-over-the-tier-selected-value
+// @e2e openspec/specs/mdm-conflict-resolution-ui/spec.md#scenario-one-off-choice-sets-a-per-object-override
+// @e2e openspec/specs/mdm-survivorship/spec.md#scenario-per-object-override-wins-over-the-tier-selected-value
 // ─────────────────────────────────────────────────────────────────────────────
 test.describe('mdm-survivorship-override — one-off outcome', () => {
 	test.use({ storageState: STORAGE_STATE })


### PR DESCRIPTION
**Draft, and blocked on two things.** Stacked on #3573 and requires ConductionNL/.github#741. Undraft once both have landed.

## What this is

One line: `hydra-gates-e2e-anchor-blocking: true`.

Gate-46 resolves `@spec` and `@e2e` by identical rules but blocks only on `@spec`. The `@e2e` half is report-only, and the gate itself invites the opt-in once a repo's count is worked down. This is that opt-in.

## The measurement that licenses it

Taken with the gate's own resolver, `scripts/lib/check_spec_anchors.py` from `ConductionNL/.github@main` — a fresh clone, not a vendored copy, and not a reimplementation — over gate-46's full file scope, with #3573 applied:

```
files in scope: 3713
total findings: 0
@spec findings: 0
@e2e  findings: 0
```

Across 9,948 `@spec` and 163 `@e2e` `openspec/` tags.

The resolver was mutation-checked before the zero was believed. `openspec/specs/totally-imaginary/spec.md#nope` reported *target file not found* and `openspec/specs/mdm-frontend/spec.md#REQ-999-invented` reported *anchor not found*. A checker that inspects nothing exits exactly like one that inspects everything and finds it clean.

## What will make this fail, and it is meant to

A new test whose `@e2e` anchor names a spec, requirement or scenario that does not exist. That is the whole point: an anchor that resolves to nothing reads as verified coverage and says nothing.

Three anchors still name the live change `mdm-views-route-scoping-e2e` (see #3573 for why they were left). They resolve today through gate-46's capability index, which spans a spec's in-flight, archived and canonical homes, and will keep resolving after that change is archived. They do not put this repo at risk under the flag.

## Why it is separate from #3573

So it can be reverted on its own. If this ever blocks a PR on inherited debt rather than on that PR's own anchors, reverting one line restores the report-only behaviour without disturbing the repointed anchors.

It also *has* to be separate: until .github#741 merges, `quality.yml@main` does not declare this input, and an undeclared input is a workflow error rather than a no-op. This PR's own CI will be red until then, which is expected and is why it is a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)