### PR TITLE
docs(access-control): say plainly that a schema with no authorization block is open

### DIFF
--- a/docs/Features/access-control.md
+++ b/docs/Features/access-control.md
@@ -303,6 +303,14 @@ A denial on a list is `HTTP 200` with an empty `results` array, not a `403`.
 OpenRegister narrows a list in SQL rather than refusing it, so that enumerating
 a schema cannot tell you what you were not allowed to see.
 
+#### This default is scheduled to change
+
+The `rbac-default-authenticated` change proposes flipping the absent-block
+default, and `rbac-unmarked-schema-audit.md` tracks which schemas still declare
+nothing. Do not wait for it. A schema that names its groups today keeps the
+same behaviour after the flip; one that says nothing gets whatever the flip
+decides.
+
 Next: pick the groups your schema should answer to, then write the block using
 the samples under [Code Examples](#code-examples) below.
 

--- a/docs/Features/access-control.md
+++ b/docs/Features/access-control.md
@@ -225,6 +225,87 @@ graph TB
     style ADMIN fill:#E74C3C
 ```
 
+### A schema with no authorization block is readable by every account that can log in
+
+Read this before you decide your schema does not need a block.
+
+**An absent `authorization` block does not mean "no access". It means open.**
+A schema that declares nothing answers `GET /api/objects/{register}/{schema}`
+with every non-private row, to every caller the login accepted. There is no
+group check, because there is no rule to check against.
+
+This surprises people, so here is the shape of it:
+
+| The schema declares | A list read returns |
+|---|---|
+| No `authorization` at all | Every non-private row, to anyone authenticated |
+| `"read": ["some-group"]` | Rows only to members of that group |
+| `"read": []` | Nothing. An empty list means "grant to nobody" |
+| A block with no `read` key | Nothing, beyond the caller's own rows |
+
+The last two rows are the fail-closed half. Once your block is non-empty,
+OpenRegister denies any action you did not name. So `{"read": ["admins"]}` on
+its own does not leave `create`, `update` and `delete` as they were. It closes
+them to owners and admins. **Name all four actions, or accept that you changed
+the write posture too.**
+
+#### Why the anonymous check reassures you and should not
+
+Point an anonymous request at an unprotected schema and you get an empty list.
+That looks like a working boundary. It is not one. Anonymous callers are empty
+for a different reason: they own no rows and belong to no organisation. Log in
+as any account, including one in no groups at all, and the same endpoint
+returns everything.
+
+Measured on a fleet app in September 2026: an account created with
+`occ user:add` and given no group membership read ten rows of admin-only
+integration status. A wrong password returned 401 and anonymous returned an
+empty list, so the instance looked correctly locked from both ends anyone had
+checked. Access control held at the login line and nowhere past it.
+
+**Test the boundary with an authenticated account that should not pass it.** An
+anonymous probe cannot tell an enforced schema from an open one.
+
+#### `"rbac": true` in the response is not evidence of filtering
+
+The `@self.rbac` field echoes what was asked for, not what happened. It reads
+`true` whenever the caller is not an admin. A schema with no block returns
+`"rbac": true` alongside every row it holds.
+
+To find out whether a schema is actually protected, read the schema itself.
+The schemas API returns the stored block, and `null` there is the open case:
+
+```bash
+curl -s -u admin:… -H 'OCS-APIRequest: true' \
+  'https://your-instance/index.php/apps/openregister/api/schemas?_limit=500' \
+  | jq '.results[] | select(.slug=="yourSchema") | {slug, authorization}'
+```
+
+See [Check Authorization Config](#check-authorization-config) for the same
+lookup through `SchemaMapper` when you are already inside the container.
+
+#### A guard on the page does not guard the data
+
+Leaf apps put admin-only configuration in a register and then hide the page
+behind a route guard or a `permission: "admin"` manifest entry. Both stop the
+page from rendering. Neither narrows a list read, because the rows come from
+OpenRegister and a client cannot restrict a server. If the page is admin-only,
+the schema behind it needs `read` restricted too.
+
+#### The list path evaluates `read`, never `list`
+
+`list` is a real action in the vocabulary, but `GET /api/objects/{register}/{schema}`
+does not use it. It filters on `read`. A block that grants `{"list": [...]}`
+and omits `read` falls into the fail-closed branch and returns the caller's own
+rows only.
+
+A denial on a list is `HTTP 200` with an empty `results` array, not a `403`.
+OpenRegister narrows a list in SQL rather than refusing it, so that enumerating
+a schema cannot tell you what you were not allowed to see.
+
+Next: pick the groups your schema should answer to, then write the block using
+the samples under [Code Examples](#code-examples) below.
+
 ### The action vocabulary: closed by default, extensible by declaration
 
 An `authorization` block may name `create`, `read`, `update` or `delete`, plus


### PR DESCRIPTION
Closes the documentation half of #3561.

## What #3561 asked

The issue reported that `GET /api/objects/dossiq/dossiqIntegration` answered every row to every authenticated account, and named the one thing it had not established: whether a declared `authorization` block would actually narrow a **list** read. That answer decides ownership.

**It does.** So the defect is a missing block in the leaf app, fixed in ConductionNL/dossiq#2344, and what belongs here is the documentation the issue asked for: say plainly that an absent block means open, "because that default is not obvious".

Measured on a dev instance rather than read off the code. Holding owner and organisation constant across two schemas in the same register, so the block is the only variable:

| schema | `read` declares | admin sees | account in no groups sees |
|---|---|---|---|
| `filinq/publicationConsent` | `["docudesk-policy-admins"]` | 13 | **0** |
| `filinq/anonymizationLink` | `["authenticated"]` | 7 | 7 |

Adding that same account to `docudesk-policy-admins` took `publicationConsent` from **0 to 13**, and removing it took it back to 0. The block is honoured on list reads, through `MagicRbacHandler::applyRbacFilters(action: 'read')`.

## What this PR changes

Documentation only. No behaviour change, no code touched.

`docs/Features/access-control.md` already recorded the default, but in passing, inside a section arguing about the `mcp` scope, and in the mermaid flow as "No Filtering (Open Access)". Someone deciding whether their schema needs a block will not find it there. This adds a section that states it where that decision gets made, immediately after the schema authorization diagram.

It carries the four traps that made the original defect hard to see, each of which cost real time:

1. **An anonymous probe reads empty and proves nothing.** Anonymous callers own no rows and belong to no organisation, so they return an empty list whether or not the schema is protected. The instance in #3561 looked correctly locked from both ends anyone had checked: 401 on a wrong password, empty for anonymous. Any account that could log in read everything.
2. **`"rbac": true` echoes the request, not the filtering.** It is set from `$rbac = ($isAdmin === false)` and reads `true` on an unprotected schema returning every row it holds.
3. **A route guard on the page cannot narrow a list.** This is the shape the whole issue is about: the page was admin-only and the rows were not.
4. **The list path evaluates `read`, never `list`.** `list` is in the vocabulary but `objects#index` does not use it, so a block granting `{"list": [...]}` without `read` falls into the fail-closed branch.

It also records the fail-closed half explicitly, as a table: a non-empty block denies any action it does not name, so declaring only `read` moves the write posture as a side effect. That is not obvious either, and it is the mistake a reader who has just been told to add a block is most likely to make next.

The one command cited is checked. An earlier draft invented `occ openregister:schema:show`, which does not exist; the section now uses the schemas API, whose response was read directly during this work, and links to the existing `SchemaMapper` lookup further down the page.

## Worth knowing beyond the docs

Two findings from tracing the path. Neither is changed here and neither is claimed as a defect, but both are the kind of thing that gets rediscovered expensively:

- **Reads were not the only thing open.** With an empty block, `PermissionHandler::hasGroupPermission()` returns `true` for every action, and `enforce_default_closed` defaults to off. Confirmed against the same instance: a `PUT` from a groupless account onto an unprotected row answered **HTTP 200**. The probe wrote identical values, so nothing changed. `DEFAULT_CLOSED_WRITE_ACTIONS` covers `create`, `update` and `delete` but only when an operator has opted in.
- **A list denial is `HTTP 200` with an empty `results`, not a `403`.** That is deliberate, and `ObjectService::paginateObjectSource()` says why: no enumeration oracle. It does mean a leaf app cannot tell "denied" from "empty" without a control, which is why the test in the dossiq PR reads the same endpoint as an admin first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
