### PR TITLE
feat(tasks): a due WINDOW on the inbox, not only overdue

### DIFF
--- a/lib/Controller/TaskController.php
+++ b/lib/Controller/TaskController.php
@@ -43,6 +43,7 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Controller;
 
 use OCA\OpenRegister\Db\Task;
+use DateTime;
 use OCA\OpenRegister\Db\TaskInboxCriteria;
 use OCA\OpenRegister\Exception\TaskAccessDeniedException;
 use OCA\OpenRegister\Exception\TaskConflictException;
@@ -195,6 +196,11 @@ class TaskController extends Controller {
 	 *                             view asks what the run asked, not what it
 	 *                             asked the caller. Visibility still applies.
 	 * @param string|null $overdue 'true' to restrict to derived-overdue tasks.
+	 * @param string|null $dueAfter ISO-8601 instant; only tasks due at or
+	 *                              after it. Pairs with `dueBefore` to make a
+	 *                              window, which `overdue` cannot express.
+	 * @param string|null $dueBefore ISO-8601 instant; only tasks due strictly
+	 *                               before it.
 	 * @param string $sort dueAt|priority|created. A leading `-` inverts
 	 *                     the order (`-dueAt`), so sort and direction travel
 	 *                     as one parameter.
@@ -215,6 +221,8 @@ class TaskController extends Controller {
 		?string $objectUuid = null,
 		?string $runUuid = null,
 		?string $overdue = null,
+		?string $dueAfter = null,
+		?string $dueBefore = null,
 		string $sort = TaskInboxCriteria::SORT_DUE,
 		int $limit = 25,
 		int $offset = 0,
@@ -241,6 +249,15 @@ class TaskController extends Controller {
 			$overdueAt = $this->temporal->now();
 		}
 
+		// A window over the same effective deadline `overdue` uses.
+		$window = $this->dueWindow(dueAfter: $dueAfter, dueBefore: $dueBefore);
+		if ($window['error'] !== null) {
+			return new JSONResponse(['error' => $window['error']], Http::STATUS_BAD_REQUEST);
+		}
+
+		$dueAfterAt = $window['after'];
+		$dueBeforeAt = $window['before'];
+
 		$descending = str_starts_with($sort, '-');
 		$sortKey = ltrim($sort, '-');
 
@@ -255,6 +272,8 @@ class TaskController extends Controller {
 			objectUuid: $objectUuid,
 			runUuid: $this->trimmedOrNull(value: $runUuid),
 			overdueAt: $overdueAt,
+			dueAfter: $dueAfterAt,
+			dueBefore: $dueBeforeAt,
 			sort: $sortKey,
 			sortDescending: $descending,
 		);
@@ -671,6 +690,68 @@ class TaskController extends Controller {
 
 		return $trimmed;
 	}//end trimmedOrNull()
+
+	/**
+	 * An ISO-8601 instant, or null.
+	 *
+	 * Null for an absent value AND for an unparseable one: the caller
+	 * distinguishes the two, because a dropped date filter WIDENS the result
+	 * set and a list quietly showing more than was asked for is worse than a
+	 * refusal.
+	 *
+	 * @param string|null $value The raw query value.
+	 *
+	 * @return DateTime|null The instant, or null.
+	 *
+	 * @spec openspec/changes/flow-task-entity/specs/flow-tasks/spec.md#requirement-the-inbox-answers-what-is-waiting-for-me-in-one-query
+	 */
+	private function parseInstant(?string $value): ?DateTime {
+		$raw = trim((string) ($value ?? ''));
+		if ($raw === '') {
+			return null;
+		}
+
+		try {
+			return new DateTime($raw);
+		} catch (Throwable $e) {
+			return null;
+		}
+	}//end parseInstant()
+
+	/**
+	 * Parse both ends of a due window, or name the one that is wrong.
+	 *
+	 * Extracted from `index()` rather than inlined: two parses and two
+	 * guards took that method's NPath complexity from 162 to 324, over
+	 * phpmd's threshold of 200. The rule is right — `index()` is already a
+	 * long parameter funnel — so the parsing moves out instead of the
+	 * threshold moving up.
+	 *
+	 * 🔴 An UNPARSEABLE instant is REFUSED, not dropped. A dropped date
+	 * filter WIDENS the result set, and a task list quietly showing more
+	 * than was asked for is exactly the failure this endpoint's scope rules
+	 * exist to prevent.
+	 *
+	 * @param string|null $dueAfter  The raw lower bound.
+	 * @param string|null $dueBefore The raw upper bound.
+	 *
+	 * @return array{after: DateTime|null, before: DateTime|null, error: string|null}
+	 *
+	 * @spec openspec/changes/flow-task-entity/specs/flow-tasks/spec.md#requirement-the-inbox-answers-what-is-waiting-for-me-in-one-query
+	 */
+	private function dueWindow(?string $dueAfter, ?string $dueBefore): array {
+		$after = $this->parseInstant(value: $dueAfter);
+		if ($dueAfter !== null && $after === null) {
+			return ['after' => null, 'before' => null, 'error' => 'dueAfter is not a valid instant'];
+		}
+
+		$before = $this->parseInstant(value: $dueBefore);
+		if ($dueBefore !== null && $before === null) {
+			return ['after' => null, 'before' => null, 'error' => 'dueBefore is not a valid instant'];
+		}
+
+		return ['after' => $after, 'before' => $before, 'error' => null];
+	}//end dueWindow()
 
 	/**
 	 * The acting identity, or null without a session.

--- a/lib/Db/TaskInboxCriteria.php
+++ b/lib/Db/TaskInboxCriteria.php
@@ -98,6 +98,15 @@ final class TaskInboxCriteria {
 	 *                                 strictly before this instant — the
 	 *                                 derived-overdue filter, handed the clock
 	 *                                 by TaskTemporalProjection.
+	 * @param DateTime|null $dueAfter When set, only tasks whose effective
+	 *                                deadline is at or after this instant.
+	 *                                Pairs with `dueBefore` to express a
+	 *                                WINDOW ("due this week"), which
+	 *                                `overdueAt` cannot: that one is
+	 *                                open-ended in the past by design.
+	 * @param DateTime|null $dueBefore When set, only tasks whose effective
+	 *                                 deadline is strictly before this
+	 *                                 instant.
 	 * @param string $sort One of the SORT_* values.
 	 * @param bool $sortDescending Whether to invert the sort.
 	 *
@@ -114,6 +123,8 @@ final class TaskInboxCriteria {
 		public readonly ?string $objectUuid = null,
 		public readonly ?string $runUuid = null,
 		public readonly ?DateTime $overdueAt = null,
+		public readonly ?DateTime $dueAfter = null,
+		public readonly ?DateTime $dueBefore = null,
 		public readonly string $sort = self::SORT_DUE,
 		public readonly bool $sortDescending = false,
 	) {

--- a/lib/Db/TaskMapper.php
+++ b/lib/Db/TaskMapper.php
@@ -821,7 +821,55 @@ class TaskMapper extends QBMapper {
 				)
 			);
 		}
+
+		$this->applyDueWindow(qb: $qb, criteria: $criteria);
 	}//end applyFilters()
+
+	/**
+	 * A due WINDOW, over the same effective deadline the overdue filter and
+	 * the projection use.
+	 *
+	 * `overdueAt` cannot express one: it is open-ended in the past by
+	 * design, and "due this week" needs both ends. The COALESCE is shared on
+	 * purpose, so a deadline-less task falls out of a window exactly as it
+	 * falls out of overdue, with no separate null check to keep in step.
+	 *
+	 * Its own method rather than two more branches in `applyFilters()`,
+	 * which phpmd measured at NPath 256 against a threshold of 200 once they
+	 * were inlined. The rule is right: that method is a filter funnel and
+	 * every added branch doubles its paths.
+	 *
+	 * @param IQueryBuilder     $qb       The query being built.
+	 * @param TaskInboxCriteria $criteria The inbox criteria.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-task-entity/specs/flow-tasks/spec.md#requirement-the-inbox-answers-what-is-waiting-for-me-in-one-query
+	 */
+	private function applyDueWindow(IQueryBuilder $qb, TaskInboxCriteria $criteria): void {
+		foreach (
+			[
+				['value' => $criteria->dueAfter, 'operator' => '>='],
+				['value' => $criteria->dueBefore, 'operator' => '<'],
+			] as $bound
+		) {
+			if ($bound['value'] === null) {
+				continue;
+			}
+
+			$qb->andWhere(
+				$qb->createFunction(
+					sprintf(
+						'COALESCE(%s, %s) %s %s',
+						$this->quote(identifier: 'due_at'),
+						$this->quote(identifier: 'expires_at'),
+						$bound['operator'],
+						$qb->createNamedParameter($bound['value'], IQueryBuilder::PARAM_DATETIME_MUTABLE)
+					)
+				)
+			);
+		}
+	}//end applyDueWindow()
 
 	/**
 	 * The caller is in the task's candidate pool (by uid or by group).

--- a/tests/Unit/Controller/TaskControllerTest.php
+++ b/tests/Unit/Controller/TaskControllerTest.php
@@ -522,6 +522,73 @@ class TaskControllerTest extends TestCase {
 	}//end testIndexPassesEveryFilterIntoTheCriteria()
 
 	/**
+	 * A due WINDOW reaches the criteria as two instants.
+	 *
+	 * `overdue` cannot express one: it is open-ended in the past by design,
+	 * and "due this week" needs both ends. Dossiq's task lenses need exactly
+	 * this, and without it that lens has no server-side answer.
+	 *
+	 * @return void
+	 */
+	public function testIndexPassesADueWindowIntoTheCriteria(): void {
+		$this->inbox->expects($this->once())->method('inbox')->willReturnCallback(
+			function (TaskInboxCriteria $criteria): array {
+				$this->assertNotNull($criteria->dueAfter);
+				$this->assertNotNull($criteria->dueBefore);
+				$this->assertSame('2026-09-01', $criteria->dueAfter->format('Y-m-d'));
+				$this->assertSame('2026-09-08', $criteria->dueBefore->format('Y-m-d'));
+				// A window is not the overdue filter, and asking for one must
+				// not quietly switch on the other.
+				$this->assertNull($criteria->overdueAt);
+
+				return ['results' => [], 'total' => 0, 'limit' => 25, 'offset' => 0];
+			}
+		);
+
+		$response = $this->controller->index(
+			dueAfter: '2026-09-01T00:00:00+00:00',
+			dueBefore: '2026-09-08T00:00:00+00:00'
+		);
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}//end testIndexPassesADueWindowIntoTheCriteria()
+
+	/**
+	 * 🔴 An UNPARSEABLE instant is refused, not dropped.
+	 *
+	 * A dropped date filter WIDENS the result set, and a task list quietly
+	 * showing more than was asked for is the failure this endpoint's scope
+	 * rules exist to prevent. Refusing is the only safe direction.
+	 *
+	 * @return void
+	 */
+	public function testIndexRefusesAnUnparseableDueInstant(): void {
+		$this->inbox->expects($this->never())->method('inbox');
+
+		$response = $this->controller->index(dueBefore: 'next tuesday-ish');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+	}//end testIndexRefusesAnUnparseableDueInstant()
+
+	/**
+	 * With no window asked for, the criteria carry none.
+	 *
+	 * @return void
+	 */
+	public function testIndexWithoutADueWindowCarriesNone(): void {
+		$this->inbox->expects($this->once())->method('inbox')->willReturnCallback(
+			function (TaskInboxCriteria $criteria): array {
+				$this->assertNull($criteria->dueAfter);
+				$this->assertNull($criteria->dueBefore);
+
+				return ['results' => [], 'total' => 0, 'limit' => 25, 'offset' => 0];
+			}
+		);
+
+		$this->controller->index();
+	}//end testIndexWithoutADueWindowCarriesNone()
+
+	/**
 	 * With overdue unset the criteria carry no clock instant.
 	 *
 	 * @return void

--- a/tests/Unit/Db/TaskMapperQueriesTest.php
+++ b/tests/Unit/Db/TaskMapperQueriesTest.php
@@ -311,6 +311,59 @@ class TaskMapperQueriesTest extends TestCase {
 	}//end testFindInboxFiltersAndSortsInTheDatastore()
 
 	/**
+	 * A due WINDOW becomes two comparisons over the SAME effective deadline
+	 * the overdue filter uses.
+	 *
+	 * `overdueAt` cannot express a window: it is open-ended in the past by
+	 * design, and "due this week" needs both ends. The COALESCE is shared on
+	 * purpose, so a deadline-less task falls out of a window exactly as it
+	 * falls out of overdue, with no separate null check to keep in step.
+	 *
+	 * @return void
+	 */
+	public function testFindInboxFiltersOnADueWindow(): void {
+		$mapper = new TaskMapper(db: $this->connectionWith());
+
+		$mapper->findInbox(criteria: new TaskInboxCriteria(
+			uid: 'root',
+			isAdmin: true,
+			scope: TaskInboxCriteria::SCOPE_ALL,
+			dueAfter: new DateTime('2026-09-01T00:00:00+00:00'),
+			dueBefore: new DateTime('2026-09-08T00:00:00+00:00'),
+		));
+
+		$ge = array_filter($this->functions, static fn (string $f): bool => str_starts_with($f, 'COALESCE(`due_at`, `expires_at`) >='));
+		$lt = array_filter($this->functions, static fn (string $f): bool => str_starts_with($f, 'COALESCE(`due_at`, `expires_at`) <'));
+		$this->assertNotEmpty($ge, 'dueAfter must become a >= over the effective deadline');
+		$this->assertNotEmpty($lt, 'dueBefore must become a < over the effective deadline');
+	}//end testFindInboxFiltersOnADueWindow()
+
+	/**
+	 * Each end of the window is independent: one without the other filters
+	 * on one side only, rather than being ignored.
+	 *
+	 * @return void
+	 */
+	public function testEachEndOfTheDueWindowStandsAlone(): void {
+		$mapper = new TaskMapper(db: $this->connectionWith());
+
+		$mapper->findInbox(criteria: new TaskInboxCriteria(
+			uid: 'root',
+			isAdmin: true,
+			dueAfter: new DateTime('2026-09-01T00:00:00+00:00'),
+		));
+		$this->assertNotEmpty(array_filter($this->functions, static fn (string $f): bool => str_contains($f, '>=')));
+
+		$this->calls = [];
+		$this->functions = [];
+		$mapper->findInbox(criteria: new TaskInboxCriteria(uid: 'root', isAdmin: true));
+		$this->assertEmpty(
+			array_filter($this->functions, static fn (string $f): bool => str_contains($f, 'COALESCE')),
+			'no window and no overdue means no deadline predicate at all'
+		);
+	}//end testEachEndOfTheDueWindowStandsAlone()
+
+	/**
 	 * countInbox reads the total off the same predicates; no row is zero.
 	 *
 	 * @return void


### PR DESCRIPTION
## What

`overdueAt` is open-ended in the past by design, so the task inbox could answer *"what is late"* and not *"what is due this week"*.

`dueAfter` and `dueBefore` are two nullable instants on `TaskInboxCriteria`, independent of each other, each becoming a comparison over the **same effective deadline** the overdue filter and `TaskTemporalProjection` use: `COALESCE(due_at, expires_at)`.

Sharing that COALESCE is the point — a deadline-less task falls out of a window exactly as it falls out of overdue, with no separate null check to keep in step.

## Why

Dossiq is adopting `entitySource: "tasks"` for its Tasks index. Five of its six lenses map onto the inbox; **"Due this week" had no server-side answer at all.** Computing it in the browser over a paged window silently drops matching rows past the page boundary and shows an empty week that is not empty — the exact failure shape this migration keeps turning up.

## 🔴 An unparseable instant is refused, not dropped

A dropped date filter **widens** the result set, and a task list quietly showing more than was asked for is precisely what this endpoint's scope rules exist to prevent. `dueBefore=next tuesday-ish` answers **400**, and the inbox is never called.

## Two extractions, because phpmd was right

Inlining the parses took `index()` from NPath 162 to **324** against a threshold of 200; inlining the clauses took `applyFilters()` to **256**. Both are funnels where every added branch doubles the paths, so the work moved out into `dueWindow()` and `applyDueWindow()` rather than the threshold moving up.

## Verification

- 41 tests over the mapper and controller; 4809 across `tests/Unit/Db` and `tests/Unit/Controller`, zero failures
- phpcs 0, phpmd clean on all three changed files
- Mutation-checked three ways: dropping the `dueBefore` guard reddens the 400 test, ignoring `dueAfter` reddens two mapper tests, and skipping every bound *after* the refactor still reddens two

## Related

- ConductionNL/nextcloud-vue#1063 — `rowRoute`, and `isTerminal` through the store allowlist (the other two gaps dossiq hit adopting this source)
- ConductionNL/openregister#3575 — `TaskBuilder` reads no `completedAt`, so a migration cannot carry a completion date

🤖 Generated with [Claude Code](https://claude.com/claude-code)
