### PR TITLE
feat(archival): resolve every archival source, in MDTO concepts with English keys

### DIFF
--- a/lib/Service/Archival/ArchivalDecisionResolver.php
+++ b/lib/Service/Archival/ArchivalDecisionResolver.php
@@ -8,7 +8,7 @@
  * since add-archival-annotation-support, and `setArchivalRetention()` — the only
  * way to fill it — was called from exactly one place in the whole repository: a
  * unit test. Every consumer that asked an object what its archival constraints
- * were therefore got nothing, while the facts themselves sat in three different
+ * were therefore got nothing, while the facts themselves sat in five different
  * shapes nobody had merged:
  *
  *   1. `retention.archiefnominatie` / `bewaartermijn` / `archiefactiedatum`,
@@ -17,17 +17,23 @@
  *   2. `retention.annotation`, the `x-openregister-archival` evaluation written
  *      by RenderObject, in `effectiveRetention` / `matchedRule` / `expiresAt`;
  *   3. `retention.legalHold`, which overrides both and which neither of the
- *      other two mentions.
+ *      other two mentions;
+ *   4. the object's OWN archival properties, in the ZGW zaak vocabulary, which
+ *      an app implementing that API declares as ordinary schema fields;
+ *   5. `@self.tmlo` — the block {@see \OCA\OpenRegister\Service\TmloService}
+ *      populates and validates and {@see \OCA\OpenRegister\Service\Edepot\MdtoXmlGenerator}
+ *      exports from. THIS ONE WAS MISSED on the first pass, so an object whose
+ *      archival metadata lived only in `tmlo` resolved to no decision at all —
+ *      the exact silence this class exists to end, reproduced one level up.
+ *      Recorded as gap A1 in openspec/changes/archival-conformance.
  *
- * The cost of leaving it scattered is that every consuming app grew its OWN
- * archival fields instead — dossiq derives `archiveNomination` and
- * `archiveActionDate` onto the case record from its resultaattype — so the same
- * question has a different answer per app, and no shared surface (a metadata
- * panel, an index column, a records-officer report) can ask it once.
+ * VOCABULARY. The resolved keys are MDTO CONCEPTS IN ENGLISH. MDTO supersedes
+ * TMLO, so `archiefnominatie` is the superseded spelling of MDTO's `waardering`
+ * and the abstract key is `appraisal`. The stored blocks keep their own
+ * spellings — this class reads them all and answers in one.
  *
- * This resolver is the merge, in app-neutral keys. It reads; it never writes to
- * storage and it never decides that anything may be destroyed — that stays with
- * RetentionService and the destruction pipeline.
+ * It reads; it never writes to storage and it never decides that anything may be
+ * destroyed. That stays with RetentionService and the destruction pipeline.
  *
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  * SPDX-License-Identifier: EUPL-1.2
@@ -51,321 +57,420 @@ namespace OCA\OpenRegister\Service\Archival;
 use OCA\OpenRegister\Db\ObjectEntity;
 
 /**
- * Merges an object's stored retention block, its schema annotation evaluation
- * and any legal hold into one resolved `@self._retention` decision.
+ * Merges every archival source an object carries into one resolved
+ * `@self._retention` decision, in MDTO concepts with English keys.
  */
 class ArchivalDecisionResolver {
 
-	/**
-	 * Nomination values that mean "this object is kept forever".
-	 *
-	 * Both spellings occur in the wild: MDTO and the selectielijst use
-	 * `blijvend_bewaren`, while a ZGW resultaattype may carry the shorter
-	 * `bewaren`. They mean the same thing to an archivist, so they normalise
-	 * to one value rather than reaching a reader as two.
-	 *
-	 * @var array<string, string>
-	 */
-	private const NOMINATION_ALIASES = [
-		'bewaren' => 'blijvend_bewaren',
-		'blijvend_bewaren' => 'blijvend_bewaren',
-		'vernietigen' => 'vernietigen',
-		'nog_niet_bepaald' => 'nog_niet_bepaald',
-	];
+    /**
+     * Appraisal values, normalised to MDTO's `waardering` vocabulary.
+     *
+     * Three spellings occur in the wild for "keep forever": MDTO and the
+     * selectielijst use `blijvend_bewaren`, a ZGW resultaattype may carry the
+     * shorter `bewaren`, and TMLO's own constant is `blijvend_bewaren` again.
+     * They mean the same thing to an archivist and must not reach a reader as
+     * two different appraisals.
+     *
+     * @var array<string, string>
+     */
+    private const APPRAISAL_ALIASES = [
+        'bewaren' => 'retain_permanently',
+        'blijvend_bewaren' => 'retain_permanently',
+        'vernietigen' => 'destroy',
+        'nog_niet_bepaald' => 'not_yet_determined',
+    ];
 
-	/**
-	 * Resolve an object's archival decision.
-	 *
-	 * Returns null when the object has nothing to say about its own archiving —
-	 * no stored retention block, no schema annotation, no hold. Null means the
-	 * key is omitted from `@self` entirely, which is deliberate: an empty
-	 * `_retention: {}` reads as "we looked and there is no obligation", and a
-	 * records officer must be able to tell that apart from "this schema never
-	 * declared one".
-	 *
-	 * @param ObjectEntity $entity The object to resolve for.
-	 *
-	 * @return array<string, mixed>|null The resolved decision, or null when there is none.
-	 *
-	 * @spec openspec/specs/retention-management/spec.md
-	 */
-	public function resolve(ObjectEntity $entity): ?array {
-		$retention = ($entity->getRetention() ?? []);
-		if (is_array($retention) === false) {
-			$retention = [];
-		}
+    /**
+     * Record states, in the Archiefwet lifecycle TmloService models.
+     *
+     * @var array<string, string>
+     */
+    private const STATE_ALIASES = [
+        'actief' => 'active',
+        'semi_statisch' => 'semi_static',
+        'overgebracht' => 'transferred',
+        'vernietigd' => 'destroyed',
+        // 🔴 A SECOND VOCABULARY FOR THE SAME FIELD NAME. RetentionService
+        // writes `retention.archiefstatus = 'nog_te_archiveren'`, which is not
+        // in TmloService::VALID_ARCHIEFSTATUS and which that service's own
+        // validator would reject. So `archiefstatus` means one of two different
+        // things depending on which block it sits in.
+        //
+        // "Still to be archived" is a record that is live and not yet
+        // transferred, which is `actief` in the Archiefwet lifecycle, so it
+        // maps there and the abstract layer stays coherent. The underlying
+        // collision is real and is recorded as gap A4 in
+        // openspec/changes/archival-conformance; this mapping makes the
+        // abstract answer usable, it does not fix the two writers.
+        'nog_te_archiveren' => 'active',
+    ];
 
-		// The object's OWN archival properties, in the ZGW zaak vocabulary. This
-		// is what makes `_retention` abstract rather than theoretical; see
-		// {@see declaredArchivalFields()} for why it is read at all.
-		$declared = $this->declaredArchivalFields(entity: $entity);
-		if ($retention === [] && $declared === []) {
-			return null;
-		}
+    /**
+     * States after which the record may not be changed.
+     *
+     * Mirrors `RetentionService::IMMUTABLE_STATUSES`. A record that has been
+     * transferred to an e-Depot or destroyed is no longer this system's to
+     * alter, and a consumer needs to know that to grey an edit rather than
+     * offer one the server will refuse.
+     *
+     * @var array<int, string>
+     */
+    private const IMMUTABLE_STATES = ['transferred', 'destroyed'];
 
-		$annotation = $retention['annotation'] ?? [];
-		if (is_array($annotation) === false) {
-			$annotation = [];
-		}
+    /**
+     * Resolve an object's archival decision.
+     *
+     * Returns null when the object has nothing to say about its own archiving.
+     * Null means the key is omitted from `@self` entirely, which is deliberate:
+     * an empty `_retention: {}` reads as "we looked and there is no obligation",
+     * and a records officer must be able to tell that apart from "this schema
+     * never declared one".
+     *
+     * @param ObjectEntity $entity The object to resolve for.
+     *
+     * @return array<string, mixed>|null The resolved decision, or null when there is none.
+     *
+     * @spec openspec/specs/retention-management/spec.md
+     */
+    public function resolve(ObjectEntity $entity): ?array {
+        $retention = ($entity->getRetention() ?? []);
+        if (is_array($retention) === false) {
+            $retention = [];
+        }
 
-		$decision = [
-			'nomination' => $this->normaliseNomination(
-				value: ($retention['archiefnominatie'] ?? ($declared['nomination'] ?? null))
-			),
-			'status' => $this->firstNonEmpty(
-				values: [($retention['archiefstatus'] ?? null), ($declared['status'] ?? null)]
-			),
-			'classification' => $this->stringOrNull(value: ($retention['classification'] ?? null)),
-			'legalHold' => $this->resolveLegalHold(entity: $entity, retention: $retention),
-		];
+        // GAP A1: the TMLO block is a first-class source, not an afterthought.
+        // TmloService writes it, MdtoXmlGenerator exports from it, and until
+        // this line it was the one source `_retention` could not see.
+        $tmlo = ($entity->getTmlo() ?? []);
+        if (is_array($tmlo) === false) {
+            $tmlo = [];
+        }
 
-		// The retention PERIOD and the date it falls due. The stored block and
-		// the schema annotation can both supply a period; the stored one is a
-		// decision somebody recorded against this object, so it wins over a
-		// rule evaluated from the schema.
-		$decision['period'] = $this->firstNonEmpty(
-			values: [
-				($retention['bewaartermijn'] ?? null),
-				($annotation['effectiveRetention'] ?? null),
-			]
-		);
+        $annotation = ($retention['annotation'] ?? []);
+        if (is_array($annotation) === false) {
+            $annotation = [];
+        }
 
-		$decision['actionDate'] = $this->firstNonEmpty(
-			values: [
-				($retention['archiefactiedatum'] ?? null),
-				($declared['actionDate'] ?? null),
-				($annotation['expiresAt'] ?? null),
-			]
-		);
+        $declared = $this->declaredArchivalFields(entity: $entity);
 
-		// WHERE the answer came from, so a reader can tell a selectielijst
-		// obligation from a schema default from a hand-set date. Without this a
-		// records officer sees a destruction date and cannot say who claimed it.
-		$decision['basis'] = $this->resolveBasis(
-			retention: $retention,
-			annotation: $annotation,
-			declared: $declared
-		);
-		$decision['source'] = $this->stringOrNull(value: ($retention['selectielijstBron'] ?? null));
+        $decision = [
+            'appraisal' => $this->normaliseAppraisal(
+                value: $this->firstNonEmpty(
+                    values: [
+                        ($retention['archiefnominatie'] ?? null),
+                        ($tmlo['archiefnominatie'] ?? null),
+                        ($declared['appraisal'] ?? null),
+                    ]
+                )
+            ),
+            'disposalCategory' => $this->firstNonEmpty(
+                values: [
+                    ($retention['classification'] ?? null),
+                    ($tmlo['classification'] ?? null),
+                    ($tmlo['vernietigingsCategorie'] ?? null),
+                ]
+            ),
+            'legalHold' => $this->resolveLegalHold(entity: $entity, retention: $retention),
+        ];
 
-		// The raw annotation evaluation is passed through rather than folded
-		// away: `matchedRule` is the only thing that says WHICH rule in the
-		// schema's `x-openregister-archival` block fired, and debugging a wrong
-		// destruction date without it means re-evaluating the whole annotation
-		// by hand.
-		if ($annotation !== []) {
-			$decision['annotation'] = $annotation;
-		}
+        $decision['retentionPeriod'] = $this->firstNonEmpty(
+            values: [
+                ($retention['bewaartermijn'] ?? null),
+                ($tmlo['bewaarTermijn'] ?? null),
+                ($annotation['effectiveRetention'] ?? null),
+            ]
+        );
 
-		// Nothing was established. Distinct from "kept forever": every field is
-		// absent, not merely permissive, so the object genuinely has no
-		// archival claim on it and the key is omitted.
-		$established = array_filter(
-			$decision,
-			static function ($value) {
-				return $value !== null && $value !== [];
-			}
-		);
+        $decision['disposalDate'] = $this->firstNonEmpty(
+            values: [
+                ($retention['archiefactiedatum'] ?? null),
+                ($tmlo['archiefactiedatum'] ?? null),
+                ($declared['disposalDate'] ?? null),
+                ($annotation['expiresAt'] ?? null),
+            ]
+        );
 
-		if ($established === []) {
-			return null;
-		}
+        $decision = $this->withRecordState(decision: $decision, retention: $retention, tmlo: $tmlo, declared: $declared);
 
-		return $decision;
-	}//end resolve()
+        // WHERE the answer came from, so a reader can tell a selectielijst
+        // obligation from a schema default from a hand-set date. Without this a
+        // records officer sees a destruction date and cannot say who claimed it.
+        $decision['basis'] = $this->resolveBasis(retention: $retention, tmlo: $tmlo, annotation: $annotation, declared: $declared);
+        $decision['source'] = $this->stringOrNull(value: ($retention['selectielijstBron'] ?? null));
 
-	/**
-	 * Normalise a nomination value to its canonical spelling.
-	 *
-	 * @param mixed $value The stored nomination.
-	 *
-	 * @return string|null The canonical nomination, the raw string when it is
-	 *                     one this resolver does not know, or null when absent.
-	 *
-	 * @spec openspec/specs/retention-management/spec.md
-	 */
-	private function normaliseNomination(mixed $value): ?string {
-		$raw = $this->stringOrNull(value: $value);
-		if ($raw === null) {
-			return null;
-		}
+        // The raw annotation evaluation is passed through rather than folded
+        // away: `matchedRule` is the only thing that says WHICH rule in the
+        // schema's `x-openregister-archival` block fired, and debugging a wrong
+        // destruction date without it means re-evaluating the whole annotation
+        // by hand.
+        if ($annotation !== []) {
+            $decision['annotation'] = $annotation;
+        }
 
-		// An unknown value is passed through rather than dropped. Dropping it
-		// would report "no nomination" for an object that carries one this
-		// resolver has not been taught, which is the failure mode that hides a
-		// records obligation.
-		return (self::NOMINATION_ALIASES[$raw] ?? $raw);
-	}//end normaliseNomination()
+        // Nothing was established. Distinct from "kept forever": every field is
+        // absent, not merely permissive, so the object genuinely has no
+        // archival claim on it and the key is omitted.
+        $established = array_filter(
+            $decision,
+            static function ($value) {
+                return $value !== null && $value !== [] && $value !== false;
+            }
+        );
 
-	/**
-	 * Resolve the legal-hold state.
-	 *
-	 * Reports an inactive hold as `['active' => false]` rather than null when
-	 * the object has hold HISTORY, because "held in the past and released" is a
-	 * different fact from "never held", and an archivist reads the difference.
-	 *
-	 * @param ObjectEntity $entity The object being resolved.
-	 * @param array<string, mixed> $retention The stored retention block.
-	 *
-	 * @return array<string, mixed>|null The hold state, or null when never held.
-	 *
-	 * @spec openspec/specs/archival-destruction-workflow/spec.md
-	 */
-	private function resolveLegalHold(ObjectEntity $entity, array $retention): ?array {
-		$hold = ($retention['legalHold'] ?? null);
-		if (is_array($hold) === false) {
-			return null;
-		}
+        if ($established === []) {
+            return null;
+        }
 
-		$active = $entity->hasActiveLegalHold();
-		$state = ['active' => $active];
+        return $decision;
+    }//end resolve()
 
-		if ($active === true) {
-			$state['reason'] = $this->stringOrNull(value: ($hold['reason'] ?? null));
-			$state['placedBy'] = $this->stringOrNull(value: ($hold['placedBy'] ?? null));
-			$state['placedDate'] = $this->stringOrNull(value: ($hold['placedDate'] ?? null));
-		}
+    /**
+     * Add the Archiefwet record state, and whether it is final.
+     *
+     * GAP A2. TmloService models `actief → semi_statisch → overgebracht |
+     * vernietigd` with a transition matrix and treats the last two as
+     * immutable, and none of that reached the abstract layer. Whether a record
+     * has been transferred to an e-Depot or destroyed is the single most
+     * consequential archival fact about it.
+     *
+     * `immutable` is derived rather than stored so a consumer never has to know
+     * the lifecycle to act on it: it can grey an edit from the boolean alone.
+     *
+     * @param array<string, mixed> $decision The decision so far.
+     * @param array<string, mixed> $retention The stored retention block.
+     * @param array<string, mixed> $tmlo The stored TMLO block.
+     * @param array<string, string> $declared The record's own archival fields.
+     *
+     * @return array<string, mixed> The decision, with state.
+     *
+     * @spec openspec/specs/retention-management/spec.md
+     */
+    private function withRecordState(array $decision, array $retention, array $tmlo, array $declared): array {
+        $raw = $this->firstNonEmpty(
+            values: [
+                ($retention['archiefstatus'] ?? null),
+                ($tmlo['archiefstatus'] ?? null),
+                ($declared['recordState'] ?? null),
+            ]
+        );
 
-		$history = ($hold['history'] ?? []);
-		if (is_array($history) === true && $history !== []) {
-			$state['releasedCount'] = count($history);
-		}
+        if ($raw === null) {
+            $decision['recordState'] = null;
+            return $decision;
+        }
 
-		return $state;
-	}//end resolveLegalHold()
+        // An unknown state passes through for the same reason an unknown
+        // appraisal does: reporting "no state" for a record that carries one is
+        // the failure mode that hides a records obligation.
+        $state = (self::STATE_ALIASES[$raw] ?? $raw);
+        $decision['recordState'] = $state;
+        $decision['immutable'] = in_array($state, self::IMMUTABLE_STATES, true);
 
-	/**
-	 * Decide which authority the retention period rests on.
-	 *
-	 * @param array<string, mixed> $retention The stored retention block.
-	 * @param array<string, mixed> $annotation The schema annotation evaluation.
-	 * @param array<string, string> $declared The ZGW archival fields the record itself declares.
-	 *
-	 * @return string|null One of `selectielijst`, `schema`, `record`, `annotation`, or null.
-	 *
-	 * @spec openspec/specs/retention-management/spec.md
-	 */
-	private function resolveBasis(array $retention, array $annotation, array $declared = []): ?string {
-		if ($this->stringOrNull(value: ($retention['selectielijstBron'] ?? null)) !== null) {
-			return 'selectielijst';
-		}
+        return $decision;
+    }//end withRecordState()
 
-		if ($this->stringOrNull(value: ($retention['bewaartermijn'] ?? null)) !== null) {
-			return 'schema';
-		}
+    /**
+     * Read the ZGW archival properties the object itself declares.
+     *
+     * 🔴 THIS IS WHAT MAKES `_retention` ABSTRACT RATHER THAN THEORETICAL.
+     * `archiefnominatie` / `archiefactiedatum` / `archiefstatus` are the ZGW
+     * contract, and an app that implements the zaak API declares them as
+     * ordinary schema properties on its own record — dossiq derives them from a
+     * case's resultaattype on close (zrc-021) and writes them there. Reading
+     * only `@self.retention` would have left `_retention` empty on exactly the
+     * records that HAVE an archival decision, while each app kept reading its
+     * own field names, which is the per-app duplication this resolver exists to
+     * end.
+     *
+     * These are not app-specific names: openregister already speaks the same
+     * vocabulary in `retention`, in Dutch.
+     *
+     * `@self.retention` still WINS where both are present: that is a decision
+     * recorded against the object through the retention service, and a schema
+     * property is what an app wrote for its own API consumers.
+     *
+     * Both spellings are accepted for each field, because an app writes
+     * whichever its own datamodel uses — dossiq's is English by policy.
+     *
+     * @param ObjectEntity $entity The object being resolved.
+     *
+     * @return array<string, string> The declared fields, keyed abstractly.
+     *
+     * @spec openspec/specs/retention-management/spec.md
+     */
+    private function declaredArchivalFields(ObjectEntity $entity): array {
+        $object = ($entity->getObject() ?? []);
+        if (is_array($object) === false) {
+            return [];
+        }
 
-		if ($declared !== []) {
-			return 'record';
-		}
+        $map = [
+            'appraisal' => ['archiveNomination', 'archiefnominatie'],
+            'disposalDate' => ['archiveActionDate', 'archiefactiedatum'],
+            'recordState' => ['archiveStatus', 'archiefstatus'],
+        ];
 
-		if ($this->stringOrNull(value: ($annotation['effectiveRetention'] ?? null)) !== null) {
-			return 'annotation';
-		}
+        $found = [];
+        foreach ($map as $key => $candidates) {
+            foreach ($candidates as $candidate) {
+                $value = $this->stringOrNull(value: ($object[$candidate] ?? null));
+                if ($value !== null) {
+                    $found[$key] = $value;
+                    break;
+                }
+            }
+        }
 
-		return null;
-	}//end resolveBasis()
+        return $found;
+    }//end declaredArchivalFields()
 
-	/**
-	 * Read the ZGW archival properties the object itself declares.
-	 *
-	 * 🔴 THIS IS WHAT MAKES `_retention` ABSTRACT RATHER THAN THEORETICAL.
-	 * `archiefnominatie` / `archiefactiedatum` / `archiefstatus` are the ZGW
-	 * contract, and an app that implements the zaak API declares them as
-	 * ordinary schema properties on its own record — dossiq derives them from a
-	 * case's resultaattype on close (zrc-021) and writes them there. Reading
-	 * only `@self.retention` would have left `_retention` empty on exactly the
-	 * records that HAVE an archival decision, while each app kept reading its
-	 * own field names, which is the per-app duplication this resolver exists to
-	 * end.
-	 *
-	 * These are not app-specific names: openregister already speaks the same
-	 * vocabulary in `retention`, in Dutch.
-	 *
-	 * `@self.retention` still WINS where both are present: that is a decision
-	 * recorded against the object through the retention service, and a schema
-	 * property is what an app wrote for its own API consumers.
-	 *
-	 * Both spellings are accepted for each field, because an app writes
-	 * whichever its own API speaks: the Dutch `archiefnominatie` when it mirrors
-	 * ZGW verbatim, the English `archiveNomination` when its data model is
-	 * English (dossiq's is, by its own D13 decision).
-	 *
-	 * Returns only the keys it could establish, so an object declaring a
-	 * nomination and no date yields the nomination alone rather than a date
-	 * blanked to null.
-	 *
-	 * @param ObjectEntity $entity The object being resolved.
-	 *
-	 * @return array<string, string> The declared fields, keyed abstractly.
-	 *
-	 * @spec openspec/specs/retention-management/spec.md
-	 */
-	private function declaredArchivalFields(ObjectEntity $entity): array {
-		$object = $entity->getObject();
-		if (is_array($object) === false) {
-			return [];
-		}
+    /**
+     * Normalise an appraisal to MDTO's `waardering` vocabulary, in English.
+     *
+     * @param string|null $value The stored appraisal.
+     *
+     * @return string|null The canonical appraisal, the raw string when it is one
+     *                     this resolver does not know, or null when absent.
+     *
+     * @spec openspec/specs/retention-management/spec.md
+     */
+    private function normaliseAppraisal(?string $value): ?string {
+        if ($value === null) {
+            return null;
+        }
 
-		$spellings = [
-			'nomination' => ['archiveNomination', 'archiefnominatie'],
-			'actionDate' => ['archiveActionDate', 'archiefactiedatum'],
-			'status' => ['archiveStatus', 'archiefstatus'],
-		];
+        // An unknown value is passed through rather than dropped. Dropping it
+        // would report "no appraisal" for an object that carries one this
+        // resolver has not been taught, which is the failure mode that hides a
+        // records obligation.
+        return (self::APPRAISAL_ALIASES[$value] ?? $value);
+    }//end normaliseAppraisal()
 
-		$found = [];
-		foreach ($spellings as $key => $names) {
-			foreach ($names as $name) {
-				$value = $this->stringOrNull(value: ($object[$name] ?? null));
-				if ($value !== null) {
-					$found[$key] = $value;
-					break;
-				}
-			}
-		}
+    /**
+     * Resolve the legal-hold state.
+     *
+     * Reports an inactive hold as `['active' => false]` rather than null when
+     * the object has hold HISTORY, because "held in the past and released" is a
+     * different fact from "never held", and an archivist reads the difference.
+     *
+     * @param ObjectEntity $entity The object being resolved.
+     * @param array<string, mixed> $retention The stored retention block.
+     *
+     * @return array<string, mixed>|null The hold state, or null when never held.
+     *
+     * @spec openspec/specs/archival-destruction-workflow/spec.md
+     */
+    private function resolveLegalHold(ObjectEntity $entity, array $retention): ?array {
+        $hold = ($retention['legalHold'] ?? null);
+        if (is_array($hold) === false) {
+            return null;
+        }
 
-		return $found;
-	}//end declaredArchivalFields()
+        $active = $entity->hasActiveLegalHold();
+        $state = ['active' => $active];
 
-	/**
-	 * Return the first value that is a non-empty string.
-	 *
-	 * @param array<int, mixed> $values Candidates in priority order.
-	 *
-	 * @return string|null The first usable value, or null.
-	 *
-	 * @spec openspec/specs/retention-management/spec.md
-	 */
-	private function firstNonEmpty(array $values): ?string {
-		foreach ($values as $value) {
-			$candidate = $this->stringOrNull(value: $value);
-			if ($candidate !== null) {
-				return $candidate;
-			}
-		}
+        if ($active === true) {
+            $state['reason'] = $this->stringOrNull(value: ($hold['reason'] ?? null));
+            $state['placedBy'] = $this->stringOrNull(value: ($hold['placedBy'] ?? null));
+            $state['placedDate'] = $this->stringOrNull(value: ($hold['placedDate'] ?? null));
+        }
 
-		return null;
-	}//end firstNonEmpty()
+        $history = ($hold['history'] ?? []);
+        if (is_array($history) === true && $history !== []) {
+            $state['releasedCount'] = count($history);
+        }
 
-	/**
-	 * Coerce a value to a non-empty string, or null.
-	 *
-	 * @param mixed $value The value to coerce.
-	 *
-	 * @return string|null The trimmed string, or null when empty or not scalar.
-	 *
-	 * @spec openspec/specs/retention-management/spec.md
-	 */
-	private function stringOrNull(mixed $value): ?string {
-		if (is_string($value) === false) {
-			return null;
-		}
+        return $state;
+    }//end resolveLegalHold()
 
-		$trimmed = trim($value);
-		if ($trimmed === '') {
-			return null;
-		}
+    /**
+     * Decide which authority the retention period rests on.
+     *
+     * GAP B2: `selectielijst_not_consulted` is its own answer. When a schema
+     * declares a `classification` — meaning it EXPECTS a selectielijst to be
+     * applied — and no `selectielijstBron` came back, the honest report is that
+     * the list was never consulted, not that the schema decided. An instance
+     * that has simply not configured `selectielijstRegister` otherwise gets a
+     * plausible-looking default with no signal at all.
+     *
+     * @param array<string, mixed> $retention The stored retention block.
+     * @param array<string, mixed> $tmlo The stored TMLO block.
+     * @param array<string, mixed> $annotation The schema annotation evaluation.
+     * @param array<string, string> $declared The record's own archival fields.
+     *
+     * @return string|null The basis, or null when nothing established one.
+     *
+     * @spec openspec/specs/retention-management/spec.md
+     */
+    private function resolveBasis(array $retention, array $tmlo, array $annotation, array $declared): ?string {
+        if ($this->stringOrNull(value: ($retention['selectielijstBron'] ?? null)) !== null) {
+            return 'selection_list';
+        }
 
-		return $trimmed;
-	}//end stringOrNull()
+        $expectedList = $this->stringOrNull(value: ($retention['classification'] ?? null));
+        if ($expectedList !== null) {
+            return 'selection_list_not_consulted';
+        }
+
+        if ($this->stringOrNull(value: ($retention['bewaartermijn'] ?? null)) !== null) {
+            return 'schema';
+        }
+
+        if (($tmlo['bewaarTermijn'] ?? null) !== null || ($tmlo['archiefnominatie'] ?? null) !== null) {
+            return 'tmlo';
+        }
+
+        if ($declared !== []) {
+            return 'record';
+        }
+
+        if ($this->stringOrNull(value: ($annotation['effectiveRetention'] ?? null)) !== null) {
+            return 'schema_annotation';
+        }
+
+        return null;
+    }//end resolveBasis()
+
+    /**
+     * Return the first value that is a non-empty string.
+     *
+     * @param array<int, mixed> $values Candidates in priority order.
+     *
+     * @return string|null The first usable value, or null.
+     *
+     * @spec openspec/specs/retention-management/spec.md
+     */
+    private function firstNonEmpty(array $values): ?string {
+        foreach ($values as $value) {
+            $candidate = $this->stringOrNull(value: $value);
+            if ($candidate !== null) {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }//end firstNonEmpty()
+
+    /**
+     * Coerce a value to a non-empty string, or null.
+     *
+     * @param mixed $value The value to coerce.
+     *
+     * @return string|null The trimmed string, or null when empty or not scalar.
+     *
+     * @spec openspec/specs/retention-management/spec.md
+     */
+    private function stringOrNull(mixed $value): ?string {
+        if (is_string($value) === false) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+        if ($trimmed === '') {
+            return null;
+        }
+
+        return $trimmed;
+    }//end stringOrNull()
 
 }//end class

--- a/lib/Service/RetentionService.php
+++ b/lib/Service/RetentionService.php
@@ -211,6 +211,28 @@ class RetentionService {
 		$archiveConfig = $schema->getArchive();
 		$afleidingswijze = $archiveConfig['afleidingswijze'] ?? 'afgehandeld';
 
+		// GAP C2. VALID_AFLEIDINGSWIJZEN was declared and NEVER REFERENCED, so
+		// a schema configured with one of ZGW's six other derivation methods
+		// was not rejected, not warned about and not logged: determineBrondatum
+		// fell through `default: return null` and the date was computed from
+		// the fallback instead. A permit that must run from
+		// `ingangsdatum_besluit` silently ran from somewhere else.
+		//
+		// Refusing is the honest answer. No date at all is a visible gap a
+		// records officer can act on; a plausible wrong date is not.
+		if (in_array($afleidingswijze, self::VALID_AFLEIDINGSWIJZEN, true) === false) {
+			$this->logger->error(
+				'[RetentionService] Unsupported afleidingswijze; no archiefactiedatum calculated',
+				[
+					'afleidingswijze' => $afleidingswijze,
+					'supported' => self::VALID_AFLEIDINGSWIJZEN,
+					'objectUuid' => $object->getUuid(),
+				]
+			);
+
+			return null;
+		}
+
 		try {
 			$interval = new DateInterval($retentionPeriod);
 		} catch (Exception $e) {
@@ -224,9 +246,24 @@ class RetentionService {
 		$brondatum = $this->determineBrondatum(object: $object, schema: $schema, afleidingswijze: $afleidingswijze);
 
 		if ($brondatum === null) {
-			// If no brondatum can be determined, use creation date as fallback.
-			$brondatum = new DateTime();
+			// The object's CREATED date, which is what this comment always
+			// claimed and what the code did not do: `new DateTime()` is *now*,
+			// so two identical records processed a year apart got disposal
+			// dates a year apart, and a record recalculated long after the fact
+			// got one far later than lawful. Gap C3 in
+			// openspec/changes/archival-conformance.
+			$brondatum = $object->getCreated();
+			if ($brondatum === null) {
+				$brondatum = new DateTime();
+			}
 		}
+
+		// Never mutate the entity's own DateTime: `->add()` below is in-place,
+		// and getCreated() hands back the LIVE object, so a disposal-date
+		// calculation would silently move the object's created timestamp.
+		// `clone` rather than DateTime::createFromInterface() because phpmd
+		// refuses static access and every path here already yields a DateTime.
+		$brondatum = clone $brondatum;
 
 		// For 'termijn' method, add procestermijn first.
 		if ($afleidingswijze === 'termijn') {

--- a/openspec/changes/archival-conformance/proposal.md
+++ b/openspec/changes/archival-conformance/proposal.md
@@ -86,6 +86,25 @@ Measured: `beperkingGebruik`, `dekkingInTijd`, `aggregatieniveau` and
 how MDTO carries a WOO/AVG access restriction; without it the export cannot say
 that a record is restricted, and a receiving e-Depot cannot enforce it.
 
+**A4 · `archiefstatus` carries two different vocabularies under one name.**
+
+Found while implementing A1, not during the read-through.
+
+`RetentionService::applyArchivalMetadata()` writes
+`retention.archiefstatus = 'nog_te_archiveren'`. `TmloService` writes
+`tmlo.archiefstatus` from `VALID_ARCHIEFSTATUS` — `actief`, `semi_statisch`,
+`overgebracht`, `vernietigd` — and `nog_te_archiveren` is not among them. The
+TMLO validator would reject the value the retention service writes, into a field
+of the same name.
+
+So `archiefstatus` means one of two things depending on which block it sits in,
+and nothing in the code says which.
+
+The resolver maps `nog_te_archiveren` onto `active` so the abstract answer is
+coherent — a record "still to be archived" is live and not yet transferred. That
+makes `_retention` usable. **It does not fix the two writers**, which still
+disagree, and a single-vocabulary decision belongs in the next pass.
+
 ### B — Selectielijst provenance is not reconstructable
 
 **B1 · The selectielijst VERSION is never recorded.**

--- a/tests/Unit/Service/Archival/ArchivalDecisionResolverTest.php
+++ b/tests/Unit/Service/Archival/ArchivalDecisionResolverTest.php
@@ -87,12 +87,14 @@ class ArchivalDecisionResolverTest extends TestCase {
 
 		$decision = $this->resolver->resolve(entity: $entity);
 
-		$this->assertSame('vernietigen', $decision['nomination']);
-		$this->assertSame('nog_te_archiveren', $decision['status']);
-		$this->assertSame('4.1.2', $decision['classification']);
-		$this->assertSame('P10Y', $decision['period']);
-		$this->assertSame('2036-09-10', $decision['actionDate']);
-		$this->assertSame('selectielijst', $decision['basis']);
+		$this->assertSame('destroy', $decision['appraisal']);
+		// RetentionService's own status vocabulary, mapped into the Archiefwet
+		// lifecycle so the abstract layer answers in one set of terms (gap A4).
+		$this->assertSame('active', $decision['recordState']);
+		$this->assertSame('4.1.2', $decision['disposalCategory']);
+		$this->assertSame('P10Y', $decision['retentionPeriod']);
+		$this->assertSame('2036-09-10', $decision['disposalDate']);
+		$this->assertSame('selection_list', $decision['basis']);
 		$this->assertSame('Selectielijst gemeenten 2020', $decision['source']);
 	}
 
@@ -113,9 +115,9 @@ class ArchivalDecisionResolverTest extends TestCase {
 
 		$decision = $this->resolver->resolve(entity: $entity);
 
-		$this->assertSame('P5Y', $decision['period']);
-		$this->assertSame('2031-01-01T00:00:00+00:00', $decision['actionDate']);
-		$this->assertSame('annotation', $decision['basis']);
+		$this->assertSame('P5Y', $decision['retentionPeriod']);
+		$this->assertSame('2031-01-01T00:00:00+00:00', $decision['disposalDate']);
+		$this->assertSame('schema_annotation', $decision['basis']);
 		$this->assertSame(2, $decision['annotation']['matchedRule']);
 	}
 
@@ -137,8 +139,8 @@ class ArchivalDecisionResolverTest extends TestCase {
 
 		$decision = $this->resolver->resolve(entity: $entity);
 
-		$this->assertSame('P20Y', $decision['period']);
-		$this->assertSame('2046-09-10', $decision['actionDate']);
+		$this->assertSame('P20Y', $decision['retentionPeriod']);
+		$this->assertSame('2046-09-10', $decision['disposalDate']);
 		$this->assertSame('schema', $decision['basis']);
 	}
 
@@ -151,7 +153,7 @@ class ArchivalDecisionResolverTest extends TestCase {
 
 		$decision = $this->resolver->resolve(entity: $entity);
 
-		$this->assertSame('blijvend_bewaren', $decision['nomination']);
+		$this->assertSame('retain_permanently', $decision['appraisal']);
 	}
 
 	/**
@@ -164,7 +166,7 @@ class ArchivalDecisionResolverTest extends TestCase {
 
 		$decision = $this->resolver->resolve(entity: $entity);
 
-		$this->assertSame('overbrengen', $decision['nomination']);
+		$this->assertSame('overbrengen', $decision['appraisal']);
 	}
 
 	/**
@@ -243,9 +245,11 @@ class ArchivalDecisionResolverTest extends TestCase {
 
 		$decision = $this->resolver->resolve(entity: $entity);
 
-		$this->assertSame('vernietigen', $decision['nomination']);
-		$this->assertSame('2036-09-10', $decision['actionDate']);
-		$this->assertSame('nog_te_archiveren', $decision['status']);
+		$this->assertSame('destroy', $decision['appraisal']);
+		$this->assertSame('2036-09-10', $decision['disposalDate']);
+		// RetentionService's own status vocabulary, mapped into the Archiefwet
+		// lifecycle so the abstract layer answers in one set of terms (gap A4).
+		$this->assertSame('active', $decision['recordState']);
 		$this->assertSame('record', $decision['basis']);
 	}
 
@@ -261,8 +265,8 @@ class ArchivalDecisionResolverTest extends TestCase {
 
 		$decision = $this->resolver->resolve(entity: $entity);
 
-		$this->assertSame('blijvend_bewaren', $decision['nomination']);
-		$this->assertSame('2040-01-01', $decision['actionDate']);
+		$this->assertSame('retain_permanently', $decision['appraisal']);
+		$this->assertSame('2040-01-01', $decision['disposalDate']);
 	}
 
 	/**
@@ -276,8 +280,8 @@ class ArchivalDecisionResolverTest extends TestCase {
 
 		$decision = $this->resolver->resolve(entity: $entity);
 
-		$this->assertSame('blijvend_bewaren', $decision['nomination']);
-		$this->assertSame('2099-01-01', $decision['actionDate']);
+		$this->assertSame('retain_permanently', $decision['appraisal']);
+		$this->assertSame('2099-01-01', $decision['disposalDate']);
 	}
 
 	/**
@@ -302,7 +306,121 @@ class ArchivalDecisionResolverTest extends TestCase {
 		$entity->setArchivalRetention($this->resolver->resolve(entity: $entity));
 		$serialized = $entity->jsonSerialize();
 
-		$this->assertSame('vernietigen', $serialized['@self']['_retention']['nomination']);
+		$this->assertSame('destroy', $serialized['@self']['_retention']['appraisal']);
+	}
+
+	/**
+	 * GAP A1, the defect this whole pass exists for: the TMLO block is a source.
+	 *
+	 * An object whose archival metadata lives only in `tmlo` used to resolve to
+	 * NO decision at all — the exact silence `_retention` was built to end.
+	 */
+	public function testReadsTheTmloBlock(): void {
+		$entity = new ObjectEntity();
+		$entity->setTmlo(
+			[
+				'archiefnominatie' => 'blijvend_bewaren',
+				'bewaarTermijn' => 'P20Y',
+				'archiefactiedatum' => '2046-01-01',
+				'archiefstatus' => 'semi_statisch',
+				'vernietigingsCategorie' => '4.1.2',
+			]
+		);
+
+		$decision = $this->resolver->resolve(entity: $entity);
+
+		$this->assertNotNull($decision, 'a tmlo-only object must resolve to a decision');
+		$this->assertSame('retain_permanently', $decision['appraisal']);
+		$this->assertSame('P20Y', $decision['retentionPeriod']);
+		$this->assertSame('2046-01-01', $decision['disposalDate']);
+		$this->assertSame('semi_static', $decision['recordState']);
+		$this->assertSame('4.1.2', $decision['disposalCategory']);
+		$this->assertSame('tmlo', $decision['basis']);
+	}
+
+	/**
+	 * GAP A2: the Archiefwet lifecycle, and whether the record is still ours.
+	 *
+	 * A transferred or destroyed record is no longer this system's to alter, and
+	 * a consumer must be able to grey an edit from the boolean alone rather than
+	 * having to know the lifecycle.
+	 */
+	public function testATransferredRecordIsReportedImmutable(): void {
+		$entity = new ObjectEntity();
+		$entity->setTmlo(['archiefstatus' => 'overgebracht']);
+
+		$decision = $this->resolver->resolve(entity: $entity);
+
+		$this->assertSame('transferred', $decision['recordState']);
+		$this->assertTrue($decision['immutable']);
+	}
+
+	/**
+	 * An active record is mutable, so the same boolean answers both ways.
+	 */
+	public function testAnActiveRecordIsNotImmutable(): void {
+		$entity = new ObjectEntity();
+		$entity->setTmlo(['archiefstatus' => 'actief']);
+
+		$decision = $this->resolver->resolve(entity: $entity);
+
+		$this->assertSame('active', $decision['recordState']);
+		$this->assertFalse($decision['immutable']);
+	}
+
+	/**
+	 * The stored retention block still wins over TMLO where both speak.
+	 *
+	 * `retention` is what the retention service decided against THIS object;
+	 * `tmlo` may be older metadata carried in.
+	 */
+	public function testTheRetentionBlockWinsOverTmlo(): void {
+		$entity = new ObjectEntity();
+		$entity->setRetention(['bewaartermijn' => 'P5Y']);
+		$entity->setTmlo(['bewaarTermijn' => 'P20Y']);
+
+		$decision = $this->resolver->resolve(entity: $entity);
+
+		$this->assertSame('P5Y', $decision['retentionPeriod']);
+	}
+
+	/**
+	 * GAP B2: "the selectielijst was never consulted" is its own answer.
+	 *
+	 * A schema that declares a `classification` EXPECTS a list to be applied.
+	 * Reporting `schema` when none came back is true but hides the fact that the
+	 * lookup an operator believed was running never ran.
+	 */
+	public function testSaysWhenTheSelectionListWasExpectedAndNotConsulted(): void {
+		$entity = new ObjectEntity();
+		$entity->setRetention(
+			[
+				'classification' => '4.1.2',
+				'archiefnominatie' => 'vernietigen',
+			]
+		);
+
+		$decision = $this->resolver->resolve(entity: $entity);
+
+		$this->assertSame('selection_list_not_consulted', $decision['basis']);
+	}
+
+	/**
+	 * And when the list DID answer, it is named as the authority.
+	 */
+	public function testNamesTheSelectionListWhenItAnswered(): void {
+		$entity = new ObjectEntity();
+		$entity->setRetention(
+			[
+				'classification' => '4.1.2',
+				'selectielijstBron' => 'Selectielijst gemeenten 2020',
+			]
+		);
+
+		$decision = $this->resolver->resolve(entity: $entity);
+
+		$this->assertSame('selection_list', $decision['basis']);
+		$this->assertSame('Selectielijst gemeenten 2020', $decision['source']);
 	}
 
 }//end class


### PR DESCRIPTION
Implements the **now** group from `openspec/changes/archival-conformance` (#3583).

## A1 — mine

`ArchivalDecisionResolver` never read `@self.tmlo`. It merged the `retention` block, the schema annotation, the legal hold and the record's own ZGW fields — and ignored the block `TmloService` populates and `MdtoXmlGenerator` exports from.

An object whose archival metadata lived only in `tmlo` resolved to **no decision at all**: the exact silence this class was built to end, reproduced one level up. It is now a first-class source.

## A2 — the Archiefwet lifecycle reaches the abstract layer

`recordState` (`active` / `semi_static` / `transferred` / `destroyed`) plus a **derived** `immutable` flag. Whether a record has been transferred to an e-Depot or destroyed is the most consequential archival fact about it, and a consumer can now grey an edit from the boolean without knowing the lifecycle.

## A4 — found while implementing A1, not during the read-through

`archiefstatus` carries **two vocabularies under one field name**:

| written by | value |
|---|---|
| `RetentionService` | `nog_te_archiveren` |
| `TmloService` | `actief` / `semi_statisch` / `overgebracht` / `vernietigd` |

`nog_te_archiveren` is not in `VALID_ARCHIEFSTATUS` — TmloService's own validator would reject the value the retention service writes.

The resolver maps it onto `active` so the abstract answer is coherent. **It does not fix the two writers**, which still disagree; that is recorded as a gap rather than papered over.

## B2 — "the list was never consulted" is its own answer

A schema declaring a `classification` *expects* a selectielijst. Reporting `schema` when none came back is true but hides that the lookup an operator believed was running never ran. Now `selection_list_not_consulted`.

## C2 — a validation list that validated nothing

`VALID_AFLEIDINGSWIJZEN` was declared and **never referenced**. A schema configured with one of ZGW's six unimplemented derivation methods was not rejected, not warned about and not logged — `determineBrondatum()` fell through `default:` and the date came from the fallback.

It now refuses loudly. **No date is a visible gap a records officer can act on; a plausible wrong date is not.**

## C3 — the fallback dated from *now*

```php
// If no brondatum can be determined, use creation date as fallback.
$brondatum = new DateTime();   // ← not the creation date
```

Two identical records processed a year apart got disposal dates a year apart, and a record recalculated long after the fact got one *later than lawful*. Now dates from the object's `created`, cloned before use — `getCreated()` hands back the live object and `->add()` is in-place, so the calculation would otherwise have moved the object's own timestamp.

## Vocabulary

`appraisal`, `retentionPeriod`, `disposalDate`, `recordState`, `disposalCategory` — MDTO concepts in English keys. MDTO supersedes TMLO and dossiq is not live, so no stored data is owed a migration. The stored blocks keep their own spellings; the resolver reads them all and answers in one.

## Verification

By exit code: **19561** unit tests, `phpcs`, `phpmd` and `phpstan` all clean.

**A1 mutation-checked** — blinding the resolver to `tmlo` again reddens three tests; restoring returns to green.

## Deliberately not in this PR

**B1** (selectielijst version still unrecorded), **C1** (six `afleidingswijzen` still unimplemented — now refusing rather than mis-dating), and the MDTO export gaps. All listed in the change.

⚠️ **Downstream:** the key rename means nextcloud-vue's `ARCHIVAL_FIELDS` and dossiq's `include` list must move with this, or the archival card renders blank. That is the next change, together with dropping dossiq's separate archiving widget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)