### PR TITLE
docs(leaf-script): repoint the citation from ADR-113 to ADR-115

### DIFF
--- a/lib/Listener/LeafScriptListener.php
+++ b/lib/Listener/LeafScriptListener.php
@@ -27,7 +27,7 @@
  * consumer, `getLeaves()` returned it, gate-24 went green on both halves — and
  * the surface rendered NOTHING, on every consuming page, for as long as leaves
  * have shipped. `humaniq-hours` has been dark on dossiq case pages the whole
- * time. That is the failure shape ADR-113 is about: everything reports success
+ * time. That is the failure shape ADR-115 is about: everything reports success
  * and the feature is absent.
  *
  * WHAT IT LOADS, AND WHERE


### PR DESCRIPTION
## One line, one citation

`LeafScriptListener`'s header comment attributes a decision to ADR-113 that ADR-113 does not make. This repoints that one line to ADR-115. Nothing else in the file changes.

## Why

The comment reads:

> That is the failure shape ADR-113 is about: everything reports success and the feature is absent.

ADR-113 is *"A widget that leans on another app says so, and never renders a number instead"*. Its decision is scoped to manifest widgets and `requiredApp`, and its context names a narrower class: a failed read that renders as a legitimate value.

The dark leaf is not that. Nothing enqueued the client half, so gate-24 compared two declarations that were both real and neither on a page, and passed. That is a check reporting a pass it did not earn, which is a different question from a read coming back wrong.

ADR-115, *"A green instrument is not a present feature"*, is written for exactly this and cites this file's account as its worked example. It is open at **ConductionNL/hydra#654**.

The other four files citing ADR-113 are consistent with it and are left alone.

## Verification

- One occurrence changed, measured before the edit and confirmed in `git diff`.
- `php -l lib/Listener/LeafScriptListener.php` exits 0.
- No em-dash on the added line. The em-dash visible in the surrounding context lines is pre-existing and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
