### PR TITLE
feat(archival): record which selectielijst version a disposal decision rests on

### DIFF
--- a/lib/Service/Archival/ArchivalDecisionResolver.php
+++ b/lib/Service/Archival/ArchivalDecisionResolver.php
@@ -197,6 +197,7 @@ class ArchivalDecisionResolver {
         // records officer sees a destruction date and cannot say who claimed it.
         $decision['basis'] = $this->resolveBasis(retention: $retention, tmlo: $tmlo, annotation: $annotation, declared: $declared);
         $decision['source'] = $this->stringOrNull(value: ($retention['selectielijstBron'] ?? null));
+        $decision = $this->withSourceProvenance(decision: $decision, retention: $retention);
 
         // The raw annotation evaluation is passed through rather than folded
         // away: `matchedRule` is the only thing that says WHICH rule in the
@@ -382,6 +383,39 @@ class ArchivalDecisionResolver {
 
         return $state;
     }//end resolveLegalHold()
+
+    /**
+     * Add the selection list's version and the moment it was consulted.
+     *
+     * GAP B1. The list's NAME is not its VERSION, and the same category
+     * carries different retention periods across selectielijst revisions. A
+     * decision recorded with only the name says which list it came from but
+     * not which list AS IT STOOD, which is the provenance an audit asks for.
+     *
+     * Each key is omitted rather than nulled when nothing was recorded: an
+     * absent key is silence, and a null is a claim that the version was looked
+     * for and found to be nothing.
+     *
+     * @param array $decision  The decision so far
+     * @param array $retention The object's stored retention block
+     *
+     * @return array The decision, with whatever provenance exists
+     *
+     * @spec openspec/specs/archival-destruction-workflow/spec.md
+     */
+    private function withSourceProvenance(array $decision, array $retention): array {
+        $version = $this->stringOrNull(value: ($retention['selectionListVersion'] ?? null));
+        if ($version !== null) {
+            $decision['sourceVersion'] = $version;
+        }
+
+        $consultedAt = $this->stringOrNull(value: ($retention['selectionListConsultedAt'] ?? null));
+        if ($consultedAt !== null) {
+            $decision['sourceConsultedAt'] = $consultedAt;
+        }
+
+        return $decision;
+    }//end withSourceProvenance()
 
     /**
      * Decide which authority the retention period rests on.

--- a/lib/Service/RetentionService.php
+++ b/lib/Service/RetentionService.php
@@ -147,35 +147,26 @@ class RetentionService {
 			return $object;
 		}
 
-		// Try selectielijst lookup first.
-		$classification = $archiveConfig['classification'] ?? null;
-		$selectielijstEntry = null;
-
-		if ($classification !== null) {
-			$selectielijstEntry = $this->lookupSelectielijstEntry(category: $classification);
-		}
-
-		// Determine nominatie and bewaartermijn (default to schema config).
-		$nominatie = $archiveConfig['defaultNominatie'] ?? 'nog_niet_bepaald';
-		$retentionPeriod = $archiveConfig['defaultBewaartermijn'] ?? null;
-		$source = null;
-		if ($selectielijstEntry !== null) {
-			$nominatie = $selectielijstEntry['archiefnominatie'] ?? 'nog_niet_bepaald';
-			$retentionPeriod = $selectielijstEntry['bewaartermijn'] ?? null;
-			$source = $selectielijstEntry['bron'] ?? null;
-		}
-
-		// Apply schema-level override if configured.
-		if (empty($archiveConfig['bewaartermijnOverride']) === false) {
-			$retentionPeriod = $archiveConfig['bewaartermijnOverride'];
-		}
+		$applied = $this->resolveArchivalDefaults(archiveConfig: $archiveConfig);
+		$retentionPeriod = $applied['bewaartermijn'];
 
 		// Build archival metadata.
-		$retention['archiefnominatie'] = $nominatie;
+		$retention['archiefnominatie'] = $applied['archiefnominatie'];
 		$retention['archiefstatus'] = 'nog_te_archiveren';
-		$retention['classification'] = $classification;
+		$retention['classification'] = ($archiveConfig['classification'] ?? null);
 		$retention['bewaartermijn'] = $retentionPeriod;
-		$retention['selectielijstBron'] = $source;
+		$retention['selectielijstBron'] = $applied['selectielijstBron'];
+
+		// GAP B1. WHICH list is not WHICH VERSION OF THAT LIST. The same
+		// category carries different retention periods across revisions, so a
+		// decision recorded with only the list's name cannot be justified once
+		// the list moves. These are English keys beside a Dutch one on purpose:
+		// `selectielijstBron` predates the vocabulary decision and existing
+		// consumers read it, while everything new speaks the abstract layer's
+		// language.
+		foreach ($applied['provenance'] as $key => $value) {
+			$retention[$key] = $value;
+		}
 
 		// Calculate archiefactiedatum if bewaartermijn is set.
 		if ($retentionPeriod !== null) {
@@ -190,6 +181,49 @@ class RetentionService {
 
 		return $object;
 	}//end applyArchivalMetadata()
+
+	/**
+	 * Decide the nominatie, the retention period and where they came from.
+	 *
+	 * Three sources in precedence order: the selectielijst entry the schema's
+	 * classification points at, then the schema's own defaults, then the
+	 * schema's explicit `bewaartermijnOverride`, which wins over both because
+	 * it is a deliberate local decision rather than a fallback.
+	 *
+	 * @param array $archiveConfig The schema's archive block
+	 *
+	 * @return array{archiefnominatie: string, bewaartermijn: string|null, selectielijstBron: string|null, provenance: array<string, string>}
+	 *
+	 * @spec openspec/specs/archival-destruction-workflow/spec.md
+	 */
+	private function resolveArchivalDefaults(array $archiveConfig): array {
+		$applied = [
+			'archiefnominatie' => ($archiveConfig['defaultNominatie'] ?? 'nog_niet_bepaald'),
+			'bewaartermijn' => ($archiveConfig['defaultBewaartermijn'] ?? null),
+			'selectielijstBron' => null,
+			'provenance' => [],
+		];
+
+		$classification = $archiveConfig['classification'] ?? null;
+		$entry = null;
+		if ($classification !== null) {
+			$entry = $this->findSelectielijstEntry(category: $classification);
+		}
+
+		if ($entry !== null) {
+			$data = $entry->getObject();
+			$applied['archiefnominatie'] = ($data['archiefnominatie'] ?? 'nog_niet_bepaald');
+			$applied['bewaartermijn'] = ($data['bewaartermijn'] ?? null);
+			$applied['selectielijstBron'] = ($data['bron'] ?? null);
+			$applied['provenance'] = $this->selectielijstProvenance(entry: $entry);
+		}
+
+		if (empty($archiveConfig['bewaartermijnOverride']) === false) {
+			$applied['bewaartermijn'] = $archiveConfig['bewaartermijnOverride'];
+		}
+
+		return $applied;
+	}//end resolveArchivalDefaults()
 
 	/**
 	 * Calculate archiefactiedatum based on the schema's afleidingswijze.
@@ -435,6 +469,33 @@ class RetentionService {
 	 * @spec openspec/specs/archival-destruction-workflow/spec.md
 	 */
 	public function lookupSelectielijstEntry(string $category): ?array {
+		$entry = $this->findSelectielijstEntry(category: $category);
+
+		if ($entry === null) {
+			return null;
+		}
+
+		return $entry->getObject();
+	}//end lookupSelectielijstEntry()
+
+	/**
+	 * Find the selectielijst entry ENTITY for a categorie code.
+	 *
+	 * Split out from lookupSelectielijstEntry because `getObject()` drops the
+	 * `@self` envelope, and the envelope is where the row's own version and
+	 * update timestamp live. Gap B1 in openspec/changes/archival-conformance:
+	 * without them a disposal decision can say WHICH list it came from but not
+	 * WHICH VERSION OF THAT LIST, and the same category carries different
+	 * retention periods across selectielijst revisions. Five years on, that is
+	 * the difference between a decision you can justify and one you cannot.
+	 *
+	 * @param string $category The selectielijst category code (e.g., B1, A1)
+	 *
+	 * @return ObjectEntity|null The entry, or null when unconfigured or absent
+	 *
+	 * @spec openspec/specs/archival-destruction-workflow/spec.md
+	 */
+	private function findSelectielijstEntry(string $category): ?ObjectEntity {
 		$settings = $this->settingsHandler->getArchivalSettingsOnly();
 
 		$registerId = $settings['selectielijstRegister'] ?? null;
@@ -459,8 +520,7 @@ class RetentionService {
 				return null;
 			}
 
-			$entry = $results[0];
-			return $entry->getObject();
+			return $results[0];
 		} catch (Exception $e) {
 			$this->logger->warning(
 				'[RetentionService] Failed to lookup selectielijst entry for ' . $category,
@@ -468,7 +528,72 @@ class RetentionService {
 			);
 			return null;
 		}//end try
-	}//end lookupSelectielijstEntry()
+	}//end findSelectielijstEntry()
+
+	/**
+	 * Read the provenance of a selectielijst entry: which version, read when.
+	 *
+	 * Three sources, in the order an auditor would trust them:
+	 *
+	 *  1. a `versie` or `version` the row itself declares, which is the list
+	 *     publisher's own numbering and the only one that means anything
+	 *     outside this install;
+	 *  2. failing that, the entry object's own `@self.version`, which says
+	 *     which revision of the stored row was read even when the publisher
+	 *     numbered nothing;
+	 *  3. the moment it was read, always, because a version alone does not say
+	 *     whether the decision predates a later revision.
+	 *
+	 * Returns an empty array rather than nulls when nothing can be
+	 * established: an absent key is honest, and a key holding null reads as a
+	 * recorded answer of "no version".
+	 *
+	 * @param ObjectEntity $entry The selectielijst entry that was applied
+	 *
+	 * @return array<string, string> The provenance keys, possibly empty
+	 *
+	 * @spec openspec/specs/archival-destruction-workflow/spec.md
+	 */
+	private function selectielijstProvenance(ObjectEntity $entry): array {
+		$provenance = ['selectionListConsultedAt' => (new DateTime())->format('c')];
+
+		$data = $entry->getObject();
+		$declared = null;
+		if (is_array($data) === true) {
+			$declared = ($data['versie'] ?? ($data['version'] ?? null));
+		}
+
+		$version = $this->stringOrNull(value: $declared);
+		if ($version === null) {
+			$version = $this->stringOrNull(value: $entry->getVersion());
+		}
+
+		if ($version !== null) {
+			$provenance['selectionListVersion'] = $version;
+		}
+
+		return $provenance;
+	}//end selectielijstProvenance()
+
+	/**
+	 * A non-empty trimmed string, or null.
+	 *
+	 * @param mixed $value The candidate value
+	 *
+	 * @return string|null The string, or null when it says nothing
+	 */
+	private function stringOrNull(mixed $value): ?string {
+		if (is_string($value) === false && is_int($value) === false) {
+			return null;
+		}
+
+		$text = trim((string)$value);
+		if ($text === '') {
+			return null;
+		}
+
+		return $text;
+	}//end stringOrNull()
 
 	/**
 	 * Validate that an object is not in an immutable archival status.

--- a/openspec/changes/archival-conformance/proposal.md
+++ b/openspec/changes/archival-conformance/proposal.md
@@ -243,7 +243,11 @@ Split by cost. Only the first group is proposed for immediate implementation.
 
 ### Next — provenance and derivation
 
-7. **B1** — record the selectielijst version alongside its name.
+7. ~~**B1** — record the selectielijst version alongside its name.~~ **DONE.**
+   `selectionListVersion` and `selectionListConsultedAt` are written beside
+   `selectielijstBron`, taken from the row's own `versie` where it declares
+   one and from the stored entry's `@self.version` where it does not. They
+   surface abstractly as `sourceVersion` and `sourceConsultedAt`.
 8. **C1** — implement the six missing `afleidingswijzen`. C2 makes them refuse
    in the meantime; this makes them work.
 

--- a/tests/Unit/Service/Archival/ArchivalDecisionResolverTest.php
+++ b/tests/Unit/Service/Archival/ArchivalDecisionResolverTest.php
@@ -99,6 +99,55 @@ class ArchivalDecisionResolverTest extends TestCase {
 	}
 
 	/**
+	 * GAP B1: the abstract layer carries the list's version and the moment it
+	 * was consulted, not only its name.
+	 *
+	 * A destruction date justified by a list name alone cannot be defended
+	 * once that list revises, because the same category carries different
+	 * retention periods across revisions.
+	 */
+	public function testCarriesTheSelectionListProvenance(): void {
+		$entity = $this->entityWith(
+			retention: [
+				'archiefnominatie' => 'vernietigen',
+				'bewaartermijn' => 'P10Y',
+				'selectielijstBron' => 'Selectielijst gemeenten 2020',
+				'selectionListVersion' => '2020.2',
+				'selectionListConsultedAt' => '2026-09-10T12:00:00+00:00',
+			]
+		);
+
+		$decision = $this->resolver->resolve(entity: $entity);
+
+		$this->assertSame('Selectielijst gemeenten 2020', $decision['source']);
+		$this->assertSame('2020.2', $decision['sourceVersion']);
+		$this->assertSame('2026-09-10T12:00:00+00:00', $decision['sourceConsultedAt']);
+	}
+
+	/**
+	 * A decision recorded before the provenance keys existed reports no
+	 * version rather than a null one.
+	 *
+	 * An absent key is silence, which is the truth about a decision taken when
+	 * nothing recorded the version. A key holding null is a claim that the
+	 * version was looked for and found to be nothing, which is false.
+	 */
+	public function testOmitsProvenanceItDoesNotHave(): void {
+		$entity = $this->entityWith(
+			retention: [
+				'archiefnominatie' => 'vernietigen',
+				'bewaartermijn' => 'P10Y',
+				'selectielijstBron' => 'Selectielijst gemeenten 2020',
+			]
+		);
+
+		$decision = $this->resolver->resolve(entity: $entity);
+
+		$this->assertArrayNotHasKey('sourceVersion', $decision);
+		$this->assertArrayNotHasKey('sourceConsultedAt', $decision);
+	}
+
+	/**
 	 * With no stored decision, the schema annotation's evaluation supplies the
 	 * period and the date, and says so.
 	 */

--- a/tests/Unit/Service/RetentionServiceTest.php
+++ b/tests/Unit/Service/RetentionServiceTest.php
@@ -103,6 +103,119 @@ class RetentionServiceTest extends TestCase {
 	}//end testApplyArchivalMetadataWithEnabledSchema()
 
 	/**
+	 * GAP B1: the selectielijst VERSION is recorded, not only its name.
+	 *
+	 * The same category carries different retention periods across
+	 * selectielijst revisions, so a decision justified by "Selectielijst
+	 * gemeenten 2020" alone cannot be defended once that list moves. The row's
+	 * own `versie` is what an auditor outside this install can check.
+	 */
+	public function testApplyArchivalMetadataRecordsTheSelectielijstVersion(): void {
+		$object = new ObjectEntity();
+		$object->setRetention([]);
+
+		$schema = $this->createMock(Schema::class);
+		$schema->method('getArchive')->willReturn([
+			'enabled' => true,
+			'classification' => '4.1.2',
+		]);
+
+		$this->stubSelectielijstEntry([
+			'categorie' => '4.1.2',
+			'archiefnominatie' => 'vernietigen',
+			'bewaartermijn' => 'P10Y',
+			'bron' => 'Selectielijst gemeenten 2020',
+			'versie' => '2020.2',
+		]);
+
+		$retention = $this->service->applyArchivalMetadata($object, $schema)->getRetention();
+
+		$this->assertSame('Selectielijst gemeenten 2020', $retention['selectielijstBron']);
+		$this->assertSame('2020.2', $retention['selectionListVersion']);
+		$this->assertNotEmpty($retention['selectionListConsultedAt']);
+	}//end testApplyArchivalMetadataRecordsTheSelectielijstVersion()
+
+	/**
+	 * A row that numbers nothing still says WHICH STORED REVISION was read.
+	 *
+	 * `@self.version` is not the publisher's numbering and does not travel, but
+	 * it separates "the row as it stood then" from "the row as it stands now",
+	 * which is more than the name alone could ever say.
+	 */
+	public function testApplyArchivalMetadataFallsBackToTheStoredRowVersion(): void {
+		$object = new ObjectEntity();
+		$object->setRetention([]);
+
+		$schema = $this->createMock(Schema::class);
+		$schema->method('getArchive')->willReturn([
+			'enabled' => true,
+			'classification' => '4.1.2',
+		]);
+
+		$this->stubSelectielijstEntry(
+			[
+				'categorie' => '4.1.2',
+				'archiefnominatie' => 'vernietigen',
+				'bewaartermijn' => 'P10Y',
+				'bron' => 'Selectielijst gemeenten 2020',
+			],
+			version: '0.0.3'
+		);
+
+		$retention = $this->service->applyArchivalMetadata($object, $schema)->getRetention();
+
+		$this->assertSame('0.0.3', $retention['selectionListVersion']);
+	}//end testApplyArchivalMetadataFallsBackToTheStoredRowVersion()
+
+	/**
+	 * No selectielijst, no provenance keys. An absent key is silence; a key
+	 * holding null is a recorded answer of "no version", which is a different
+	 * and false claim.
+	 */
+	public function testApplyArchivalMetadataOmitsProvenanceWithoutASelectielijst(): void {
+		$object = new ObjectEntity();
+		$object->setRetention([]);
+
+		$schema = $this->createMock(Schema::class);
+		$schema->method('getArchive')->willReturn([
+			'enabled' => true,
+			'defaultNominatie' => 'vernietigen',
+			'defaultBewaartermijn' => 'P5Y',
+		]);
+
+		$this->settingsHandler->method('getArchivalSettingsOnly')->willReturn([
+			'selectielijstRegister' => null,
+			'selectielijstSchema' => null,
+		]);
+
+		$retention = $this->service->applyArchivalMetadata($object, $schema)->getRetention();
+
+		$this->assertArrayNotHasKey('selectionListVersion', $retention);
+		$this->assertArrayNotHasKey('selectionListConsultedAt', $retention);
+	}//end testApplyArchivalMetadataOmitsProvenanceWithoutASelectielijst()
+
+	/**
+	 * Stub a configured selectielijst that answers with one entry.
+	 *
+	 * @param array       $data    The entry's stored object data
+	 * @param string|null $version The entry's own `@self.version`, if any
+	 */
+	private function stubSelectielijstEntry(array $data, ?string $version = null): void {
+		$this->settingsHandler->method('getArchivalSettingsOnly')->willReturn([
+			'selectielijstRegister' => 1,
+			'selectielijstSchema' => 2,
+		]);
+
+		$entry = new ObjectEntity();
+		$entry->setObject($data);
+		if ($version !== null) {
+			$entry->setVersion($version);
+		}
+
+		$this->objectMapper->method('findAll')->willReturn([$entry]);
+	}//end stubSelectielijstEntry()
+
+	/**
 	 * Test that archival metadata is NOT applied when schema has no archive config.
 	 */
 	public function testApplyArchivalMetadataSkipsWhenDisabled(): void {


### PR DESCRIPTION
Gap B1 of `openspec/changes/archival-conformance`.

## The problem

`applyArchivalMetadata` stored the selectielijst's **name** and the category it
matched, and nothing else.

The same category carries different retention periods across revisions of the
same list. So a destruction date taken today can say *which list it came from*
but not *which list as it stood when the decision was made*. Five years on that
is the difference between a disposal you can justify to an auditor and one you
cannot, and it is exactly the provenance ISO 15489 means by a disposition
authority.

## What is recorded now

Three things, in the order an auditor would trust them:

| Source | Why it is preferred in this order |
| --- | --- |
| the row's own `versie` / `version` | the publisher's numbering, the only one that means anything outside this install |
| the stored entry's `@self.version` | cannot travel, but separates the row as it stood from the row as it stands |
| the moment it was consulted | always recorded: a version alone does not say whether a decision predates a later revision |

Stored as `selectionListVersion` and `selectionListConsultedAt` beside the
existing `selectielijstBron`, and surfaced abstractly as `sourceVersion` and
`sourceConsultedAt` beside `source`.

English keys next to a Dutch one is deliberate: `selectielijstBron` predates
the vocabulary decision and existing consumers read it, while everything new
speaks the abstract layer's language.

## Omitted, not nulled

Each key is left out when nothing was recorded. An absent key is silence; a
null is a claim that the version was looked for and found to be nothing, which
for every decision taken before today is false.

## Two refactors, from phpmd rather than taste

`applyArchivalMetadata` and `resolve()` both crossed the cyclomatic, NPath and
method-length thresholds once the provenance went in, and all three were clean
at the branch point. The selectielijst-or-schema decision moves into
`resolveArchivalDefaults`, and the resolver's provenance block into
`withSourceProvenance`. Both read better for it.

`lookupSelectielijstEntry` keeps its contract. It discarded the `@self`
envelope by returning `getObject()`, and the envelope is where the version
lives, so the entity lookup is split out privately and the public method is now
a thin wrapper.

## Verification

| Gate | Result |
| --- | --- |
| phpunit (touched suites) | 112/112 |
| phpcs | exit 0 |
| phpmd, both legs, run directly (`composer phpmd` hits composer's 300s process timeout) | exit 0, zero findings |
| psalm | exit 0, no errors |
| phpstan | exit 0, no errors |

Both new guards were mutation-checked rather than only watched to pass:

- removing the provenance write reddens the version tests
- preferring the stored version over the declared one reddens the declared-version test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
