### PR TITLE
feat(tasks): the notes and calendar leaves, anchored on a task

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -1368,6 +1368,29 @@ return [
 		['name' => 'task#cancel', 'url' => '/api/flow-tasks/{uuid}/cancel', 'verb' => 'POST', 'requirements' => ['uuid' => '[^/]+']],
 		['name' => 'task#checkItem', 'url' => '/api/flow-tasks/{uuid}/checklist/{itemId}', 'verb' => 'PATCH', 'requirements' => ['uuid' => '[^/]+', 'itemId' => '[^/]+']],
 
+		// The notes and calendar leaves, anchored on the TASK. Both leaves
+		// were reachable only under /api/objects/{register}/{schema}/{id},
+		// and a task is not an object: it has no register and no schema, so
+		// a task page had nowhere to hang either one. The STORAGE never
+		// needed them — NoteService and CalendarLinkService are both
+		// addressed by a bare uuid — so these routes carry the same services
+		// behind a different GUARD: the task's own visibility, answering 404
+		// for the unreadable exactly as task#show above does, so the leaf
+		// cannot become the existence oracle the task surface refused to be.
+		// The calendar block mirrors calendarEvents#* verb for verb, `link`
+		// and `unlink` included and with no `update`, because no event
+		// update exists behind the object leaf either.
+		['name' => 'taskNotes#index', 'url' => '/api/flow-tasks/{uuid}/notes', 'verb' => 'GET', 'requirements' => ['uuid' => '[^/]+']],
+		['name' => 'taskNotes#create', 'url' => '/api/flow-tasks/{uuid}/notes', 'verb' => 'POST', 'requirements' => ['uuid' => '[^/]+']],
+		['name' => 'taskNotes#update', 'url' => '/api/flow-tasks/{uuid}/notes/{noteId}', 'verb' => 'PUT', 'requirements' => ['uuid' => '[^/]+', 'noteId' => '[^/]+']],
+		['name' => 'taskNotes#destroy', 'url' => '/api/flow-tasks/{uuid}/notes/{noteId}', 'verb' => 'DELETE', 'requirements' => ['uuid' => '[^/]+', 'noteId' => '[^/]+']],
+		// `link` is registered before `{eventId}` so the literal segment wins.
+		['name' => 'taskEvents#index', 'url' => '/api/flow-tasks/{uuid}/events', 'verb' => 'GET', 'requirements' => ['uuid' => '[^/]+']],
+		['name' => 'taskEvents#create', 'url' => '/api/flow-tasks/{uuid}/events', 'verb' => 'POST', 'requirements' => ['uuid' => '[^/]+']],
+		['name' => 'taskEvents#link', 'url' => '/api/flow-tasks/{uuid}/events/link', 'verb' => 'POST', 'requirements' => ['uuid' => '[^/]+']],
+		['name' => 'taskEvents#unlink', 'url' => '/api/flow-tasks/{uuid}/events/{eventUid}/link', 'verb' => 'DELETE', 'requirements' => ['uuid' => '[^/]+', 'eventUid' => '[^/]+']],
+		['name' => 'taskEvents#destroy', 'url' => '/api/flow-tasks/{uuid}/events/{eventId}', 'verb' => 'DELETE', 'requirements' => ['uuid' => '[^/]+', 'eventId' => '[^/]+']],
+
 		// The portal seam (flow-portal-task): a party OUTSIDE the instance,
 		// authenticated at portaliq's edge, acts here under a signed
 		// X-Portal-Subject assertion, never a Nextcloud session. The subject

--- a/lib/Controller/TaskEventsController.php
+++ b/lib/Controller/TaskEventsController.php
@@ -1,0 +1,383 @@
+<?php
+
+/**
+ * The calendar leaf, anchored on a TASK instead of on an object.
+ *
+ * Why this exists at all. The calendar leaf was reachable only at
+ * `/api/objects/{register}/{schema}/{id}/events`, so a task page could not
+ * carry one: an engine task ({@see \OCA\OpenRegister\Db\Task}) has no
+ * register and no schema, and the object route's first act is to resolve
+ * both. A task with a due date is exactly the thing somebody wants in a
+ * calendar, and it was the one subject that could not be put there.
+ *
+ * Why it is this small. The link layer was already anchor-agnostic.
+ * {@see \OCA\OpenRegister\Service\CalendarLinkService::getLinkedEvents()}
+ * reads by bare uuid, and the calendar provider
+ * ({@see \OCA\OpenRegister\Service\Integration\Providers\CalendarProvider})
+ * already takes `$register, $schema, $objectId` and ignores the first two,
+ * saying so in its own docblock. So a task-anchored event is the same row
+ * in `openregister_calendar_links` as an object-anchored one, written and
+ * read by the same service. Nothing about event handling is reimplemented
+ * here, and nothing may be.
+ *
+ * The verb set mirrors {@see CalendarEventsController} exactly: index,
+ * create, link, unlink, destroy. It is deliberately NOT index/create/
+ * update/destroy, because there is no event UPDATE anywhere behind the
+ * object leaf either. Neither `CalendarLinkService` nor
+ * {@see \OCA\OpenRegister\Service\CalendarEventService} has a method that
+ * rewrites a VEVENT, so an `update` verb here would have to grow its own
+ * event handling, which is the one thing this controller must not do. The
+ * pair that DOES exist, `link` and `unlink`, is what a task page needs
+ * anyway: attach the meeting that already exists, detach it later.
+ *
+ * 🔴 404, NEVER 403, for a task the caller may not read, the same decision
+ * {@see TaskController::show()} makes. A 403 here would confirm that a
+ * guessed uuid names a real task, undoing on the leaf what the task surface
+ * closed. And unlike the object leaf, a `register`/`schema` mismatch cannot
+ * do that confirming for us: the only identifier in the URL is the task's.
+ *
+ * On the WRITE right: reads and writes are both gated on `mayRead()`. The
+ * reasoning is set out once, in {@see TaskNotesController}, and both leaves
+ * follow it so a task cannot be annotated by one audience and scheduled by
+ * another.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-task-entity/specs/flow-tasks/spec.md#requirement-every-lifecycle-verb-is-authorized-fail-closed
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Controller;
+
+use Exception;
+use OCA\OpenRegister\Db\Task;
+use OCA\OpenRegister\Service\CalendarEventService;
+use OCA\OpenRegister\Service\CalendarLinkService;
+use OCA\OpenRegister\Service\Task\TaskAuthorizationService;
+use OCA\OpenRegister\Service\Task\TaskService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IUserSession;
+use Throwable;
+
+/**
+ * REST surface for the calendar leaf on a task.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) The controller mediates
+ * between HTTP, the two calendar services the object leaf already pairs,
+ * and the task resolution plus its authorization. Splitting the guard out
+ * would put the 404 decision in two places, which is how a leaf ends up
+ * answering differently from its neighbour.
+ *
+ * @spec openspec/changes/flow-task-entity/specs/flow-tasks/spec.md#requirement-every-lifecycle-verb-is-authorized-fail-closed
+ */
+class TaskEventsController extends Controller {
+
+	/**
+	 * The body every refusal carries, whether the task is absent or unreadable.
+	 *
+	 * @var array<string, string>
+	 */
+	private const NOT_FOUND = ['error' => 'No such task'];
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $appName The app id.
+	 * @param IRequest $request The request.
+	 * @param TaskService $tasks Resolves a task by uuid.
+	 * @param TaskAuthorizationService $authorization Read-visibility decisions.
+	 * @param CalendarLinkService $links The link-table layer, uuid-anchored.
+	 * @param CalendarEventService $events The VEVENT layer, for the legacy
+	 *                                     X-OPENREGISTER-* strip on destroy.
+	 * @param IUserSession $userSession Names the acting identity.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private readonly TaskService $tasks,
+		private readonly TaskAuthorizationService $authorization,
+		private readonly CalendarLinkService $links,
+		private readonly CalendarEventService $events,
+		private readonly IUserSession $userSession,
+	) {
+		parent::__construct(appName: $appName, request: $request);
+
+	}//end __construct()
+
+	/**
+	 * List the calendar events linked to a task.
+	 *
+	 * @param string $uuid The task uuid.
+	 *
+	 * @return JSONResponse The events and their count; 404 when the task is
+	 *                      absent OR invisible.
+	 *
+	 * @spec openspec/changes/flow-task-entity/specs/flow-tasks/spec.md#requirement-every-lifecycle-verb-is-authorized-fail-closed
+	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	public function index(string $uuid): JSONResponse {
+		$task = $this->readableTask(uuid: $uuid);
+		if ($task === null) {
+			return new JSONResponse(self::NOT_FOUND, Http::STATUS_NOT_FOUND);
+		}
+
+		try {
+			$events = $this->links->getLinkedEvents((string)$task->getUuid());
+		} catch (Exception $failure) {
+			return new JSONResponse(['error' => $failure->getMessage()], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+
+		return new JSONResponse(['results' => $events, 'total' => count($events)]);
+	}//end index()
+
+	/**
+	 * Create a calendar event and link it to a task.
+	 *
+	 * @param string $uuid The task uuid.
+	 *
+	 * @return JSONResponse The link row; 404 when the task is absent OR
+	 *                      invisible, 400 when the summary is missing.
+	 *
+	 * @spec openspec/changes/flow-task-entity/specs/flow-tasks/spec.md#requirement-every-lifecycle-verb-is-authorized-fail-closed
+	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	public function create(string $uuid): JSONResponse {
+		$task = $this->readableTask(uuid: $uuid);
+		if ($task === null) {
+			return new JSONResponse(self::NOT_FOUND, Http::STATUS_NOT_FOUND);
+		}
+
+		$data = $this->request->getParams();
+		if (trim((string)($data['summary'] ?? '')) === '') {
+			return new JSONResponse(['error' => 'Event summary is required'], Http::STATUS_BAD_REQUEST);
+		}
+
+		// The title the event carries into the calendar. A task always has a
+		// uuid and may have no title, so the uuid is the fallback, exactly as
+		// the object leaf falls back from the object's name.
+		$data['objectTitle'] = ($task->getTitle() ?? (string)$task->getUuid());
+
+		try {
+			$link = $this->links->createAndLinkEvent(
+				objectUuid: (string)$task->getUuid(),
+				registerId: (int)$task->getRegisterId(),
+				schemaId: (int)$task->getSchemaId(),
+				eventData: $data
+			);
+		} catch (Exception $failure) {
+			return new JSONResponse(['error' => $failure->getMessage()], Http::STATUS_BAD_REQUEST);
+		}
+
+		return new JSONResponse($link->jsonSerialize(), Http::STATUS_CREATED);
+	}//end create()
+
+	/**
+	 * Link an existing calendar event to a task.
+	 *
+	 * @param string $uuid The task uuid.
+	 *
+	 * @return JSONResponse The link row; 404 when the task is absent OR
+	 *                      invisible, 400 when the event is not named in full.
+	 *
+	 * @spec openspec/changes/flow-task-entity/specs/flow-tasks/spec.md#requirement-every-lifecycle-verb-is-authorized-fail-closed
+	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	public function link(string $uuid): JSONResponse {
+		$task = $this->readableTask(uuid: $uuid);
+		if ($task === null) {
+			return new JSONResponse(self::NOT_FOUND, Http::STATUS_NOT_FOUND);
+		}
+
+		$data = $this->request->getParams();
+		$calendarUri = trim((string)($data['calendarUri'] ?? ''));
+		$eventUid = trim((string)($data['eventUid'] ?? ''));
+
+		if ($calendarUri === '' || $eventUid === '') {
+			return new JSONResponse(['error' => 'calendarUri and eventUid are required'], Http::STATUS_BAD_REQUEST);
+		}
+
+		try {
+			$link = $this->links->linkEvent(
+				objectUuid: (string)$task->getUuid(),
+				registerId: (int)$task->getRegisterId(),
+				schemaId: (int)$task->getSchemaId(),
+				calendarUri: $calendarUri,
+				eventUid: $eventUid
+			);
+		} catch (Exception $failure) {
+			return new JSONResponse(['error' => $failure->getMessage()], Http::STATUS_BAD_REQUEST);
+		}
+
+		return new JSONResponse($link->jsonSerialize(), Http::STATUS_CREATED);
+	}//end link()
+
+	/**
+	 * Unlink a calendar event from a task, leaving the VEVENT alone.
+	 *
+	 * @param string $uuid The task uuid.
+	 * @param string $eventUid The VEVENT uid.
+	 *
+	 * @return JSONResponse Confirmation; 404 when the task is absent OR
+	 *                      invisible.
+	 *
+	 * @spec openspec/changes/flow-task-entity/specs/flow-tasks/spec.md#requirement-every-lifecycle-verb-is-authorized-fail-closed
+	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	public function unlink(string $uuid, string $eventUid): JSONResponse {
+		$task = $this->readableTask(uuid: $uuid);
+		if ($task === null) {
+			return new JSONResponse(self::NOT_FOUND, Http::STATUS_NOT_FOUND);
+		}
+
+		try {
+			$this->links->unlinkEvent(objectUuid: (string)$task->getUuid(), eventUid: $eventUid);
+		} catch (Exception $failure) {
+			return new JSONResponse(['error' => $failure->getMessage()], Http::STATUS_BAD_REQUEST);
+		}
+
+		return new JSONResponse(['success' => true]);
+	}//end unlink()
+
+	/**
+	 * Detach a calendar event from a task by its event URI.
+	 *
+	 * The legacy semantics the object leaf carries: the X-OPENREGISTER-*
+	 * properties come off the VEVENT and the link row goes, but the VEVENT
+	 * itself stays in the calendar. For link-only removal use `unlink`.
+	 *
+	 * @param string $uuid The task uuid.
+	 * @param string $eventId The event URI.
+	 *
+	 * @return JSONResponse Confirmation; 404 when the task is absent OR
+	 *                      invisible, and 404 when no linked event carries
+	 *                      that URI.
+	 *
+	 * @spec openspec/changes/flow-task-entity/specs/flow-tasks/spec.md#requirement-every-lifecycle-verb-is-authorized-fail-closed
+	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	public function destroy(string $uuid, string $eventId): JSONResponse {
+		$task = $this->readableTask(uuid: $uuid);
+		if ($task === null) {
+			return new JSONResponse(self::NOT_FOUND, Http::STATUS_NOT_FOUND);
+		}
+
+		try {
+			$linked = $this->linkedEvent(taskUuid: (string)$task->getUuid(), eventId: $eventId);
+			if ($linked === null) {
+				return new JSONResponse(['error' => 'Event not found'], Http::STATUS_NOT_FOUND);
+			}
+
+			$this->events->unlinkEvent(calendarId: (string)$linked['calendarId'], eventUri: $eventId);
+
+			if ($linked['uid'] !== null) {
+				$this->links->unlinkEvent(
+					objectUuid: (string)$task->getUuid(),
+					eventUid: (string)$linked['uid']
+				);
+			}
+		} catch (Exception $failure) {
+			return new JSONResponse(['error' => $failure->getMessage()], Http::STATUS_BAD_REQUEST);
+		}//end try
+
+		return new JSONResponse(['success' => true]);
+	}//end destroy()
+
+	/**
+	 * The linked event carrying this URI, as calendar id plus uid.
+	 *
+	 * Looked up through the task's OWN linked list rather than by event URI
+	 * alone, which is the guard that keeps `destroy` from reaching an event
+	 * that belongs to some other subject: an id the caller invents resolves
+	 * to null and is answered 404, never unlinked.
+	 *
+	 * @param string $taskUuid The task uuid.
+	 * @param string $eventId The event URI.
+	 *
+	 * @return array{calendarId: mixed, uid: string|null}|null The event, or null.
+	 *
+	 * @spec openspec/changes/flow-task-entity/specs/flow-tasks/spec.md#requirement-every-lifecycle-verb-is-authorized-fail-closed
+	 */
+	private function linkedEvent(string $taskUuid, string $eventId): ?array {
+		foreach ($this->links->getLinkedEvents($taskUuid) as $event) {
+			if (($event['id'] ?? null) !== $eventId) {
+				continue;
+			}
+
+			if (($event['calendarId'] ?? null) === null) {
+				return null;
+			}
+
+			$uid = null;
+			if (isset($event['uid']) === true) {
+				$uid = (string)$event['uid'];
+			}
+
+			return ['calendarId' => $event['calendarId'], 'uid' => $uid];
+		}
+
+		return null;
+	}//end linkedEvent()
+
+	/**
+	 * The task this request may act on, or null.
+	 *
+	 * Fail-closed on every path: absent, invisible and undeterminable all
+	 * return null, and every caller turns null into the same 404.
+	 *
+	 * @param string $uuid The task uuid.
+	 *
+	 * @return Task|null The readable task, or null.
+	 *
+	 * @spec openspec/changes/flow-task-entity/specs/flow-tasks/spec.md#requirement-every-lifecycle-verb-is-authorized-fail-closed
+	 */
+	private function readableTask(string $uuid): ?Task {
+		try {
+			$task = $this->tasks->get(uuid: $uuid);
+		} catch (Throwable) {
+			return null;
+		}
+
+		if ($this->authorization->mayRead(task: $task, uid: $this->uid()) === false) {
+			return null;
+		}
+
+		return $task;
+	}//end readableTask()
+
+	/**
+	 * The acting identity, or null without a session.
+	 *
+	 * @return string|null The uid.
+	 */
+	private function uid(): ?string {
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			return null;
+		}
+
+		return $user->getUID();
+	}//end uid()
+}//end class

--- a/lib/Controller/TaskNotesController.php
+++ b/lib/Controller/TaskNotesController.php
@@ -1,0 +1,292 @@
+<?php
+
+/**
+ * The notes leaf, anchored on a TASK instead of on an object.
+ *
+ * Why this exists at all. The notes leaf was reachable only at
+ * `/api/objects/{register}/{schema}/{id}/notes`, so a task page had nowhere
+ * to hang a note: an engine task (`oc_openregister_tasks`,
+ * {@see \OCA\OpenRegister\Db\Task}) is not an object, has no register and
+ * no schema, and the object route's first act is to resolve all three.
+ *
+ * Why it is this small. The STORAGE was already anchor-agnostic.
+ * {@see \OCA\OpenRegister\Service\NoteService} writes Nextcloud comments
+ * with `object_type = 'openregister'` and `object_id = <uuid string>`; it
+ * takes a bare uuid and asks nothing about what that uuid names. So a task
+ * note and an object note are the same row in the same table, read back by
+ * the same query. Nothing about notes is reimplemented here, and nothing
+ * may be: the moment this controller grows its own note handling, a task
+ * note and an object note stop being the same thing.
+ *
+ * What genuinely differs is the GUARD, and only the guard.
+ * {@see NotesController} resolves an object through `ObjectService` and
+ * answers 404 when it is absent. There is no object to resolve here, so the
+ * gate is the task's own: resolve through
+ * {@see \OCA\OpenRegister\Service\Task\TaskService::get()} and check
+ * visibility with
+ * {@see \OCA\OpenRegister\Service\Task\TaskAuthorizationService::mayRead()}.
+ *
+ * 🔴 404, NEVER 403, for a task the caller may not read. This is the same
+ * decision {@see TaskController::show()} and {@see TaskController::audit()}
+ * already make, and it has to hold here too or the leaf becomes the oracle
+ * the task surface refused to be: a 403 from `/notes` would confirm that a
+ * guessed uuid names a real task, which is exactly what answering 404 to
+ * `/api/flow-tasks/{uuid}` was protecting. One surface answering differently
+ * from its neighbour is how an existence check survives being closed.
+ *
+ * On the WRITE right. Reads and writes are both gated on `mayRead()`,
+ * deliberately, and that is a mirror rather than a new policy.
+ * `TaskAuthorizationService::RULES` names a right for each LIFECYCLE verb
+ * (claim, assign, complete and the rest) and annotating a task is not one
+ * of them; adding a rule for it would be writing a policy no spec states,
+ * and passing an unnamed verb to `assertMay()` fails closed and would leave
+ * the leaf usable by administrators alone. The object leaf's own write
+ * right is "you can read the object", so the task leaf's is "you can read
+ * the task", and the five relationships `mayRead()` admits (assignee, pool
+ * member, requester, watcher, administrator) are precisely the people a
+ * task's notes are for. Widening this beyond visibility, or narrowing it to
+ * the assignee, is a spec change and belongs in the spec first.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/flow-task-entity/specs/flow-tasks/spec.md#requirement-every-lifecycle-verb-is-authorized-fail-closed
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Controller;
+
+use OCA\OpenRegister\Db\Task;
+use OCA\OpenRegister\Service\NoteService;
+use OCA\OpenRegister\Service\Task\TaskAuthorizationService;
+use OCA\OpenRegister\Service\Task\TaskService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IUserSession;
+use Throwable;
+
+/**
+ * REST surface for the notes leaf on a task.
+ *
+ * @spec openspec/changes/flow-task-entity/specs/flow-tasks/spec.md#requirement-every-lifecycle-verb-is-authorized-fail-closed
+ */
+class TaskNotesController extends Controller {
+
+	/**
+	 * The body every refusal carries, whether the task is absent or unreadable.
+	 *
+	 * One constant rather than a literal per verb, because the two cases
+	 * MUST stay indistinguishable on the wire: the day one verb answers
+	 * 'Task not found' and another answers 'Forbidden', the difference
+	 * between them is the existence oracle this controller exists to deny.
+	 *
+	 * @var array<string, string>
+	 */
+	private const NOT_FOUND = ['error' => 'No such task'];
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $appName The app id.
+	 * @param IRequest $request The request.
+	 * @param TaskService $tasks Resolves a task by uuid.
+	 * @param TaskAuthorizationService $authorization Read-visibility decisions.
+	 * @param NoteService $notes The same note storage the object leaf uses.
+	 * @param IUserSession $userSession Names the acting identity.
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private readonly TaskService $tasks,
+		private readonly TaskAuthorizationService $authorization,
+		private readonly NoteService $notes,
+		private readonly IUserSession $userSession,
+	) {
+		parent::__construct(appName: $appName, request: $request);
+
+	}//end __construct()
+
+	/**
+	 * List the notes on a task.
+	 *
+	 * @param string $uuid The task uuid.
+	 *
+	 * @return JSONResponse The notes and their count; 404 when the task is
+	 *                      absent OR invisible.
+	 *
+	 * @spec openspec/changes/flow-task-entity/specs/flow-tasks/spec.md#requirement-every-lifecycle-verb-is-authorized-fail-closed
+	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	public function index(string $uuid): JSONResponse {
+		$task = $this->readableTask(uuid: $uuid);
+		if ($task === null) {
+			return new JSONResponse(self::NOT_FOUND, Http::STATUS_NOT_FOUND);
+		}
+
+		$params = $this->request->getParams();
+		$limit = (int)($params['limit'] ?? 50);
+		$offset = (int)($params['offset'] ?? 0);
+
+		$notes = $this->notes->getNotesForObject((string)$task->getUuid(), $limit, $offset);
+
+		return new JSONResponse(['results' => $notes, 'total' => count($notes)]);
+	}//end index()
+
+	/**
+	 * Write a note on a task.
+	 *
+	 * @param string $uuid The task uuid.
+	 *
+	 * @return JSONResponse The created note; 404 when the task is absent OR
+	 *                      invisible, 400 when the message is missing.
+	 *
+	 * @spec openspec/changes/flow-task-entity/specs/flow-tasks/spec.md#requirement-every-lifecycle-verb-is-authorized-fail-closed
+	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	public function create(string $uuid): JSONResponse {
+		$task = $this->readableTask(uuid: $uuid);
+		if ($task === null) {
+			return new JSONResponse(self::NOT_FOUND, Http::STATUS_NOT_FOUND);
+		}
+
+		$message = $this->message();
+		if ($message === null) {
+			return new JSONResponse(['error' => 'Note message is required'], Http::STATUS_BAD_REQUEST);
+		}
+
+		return new JSONResponse(
+			$this->notes->createNote((string)$task->getUuid(), $message),
+			Http::STATUS_CREATED
+		);
+	}//end create()
+
+	/**
+	 * Rewrite a note on a task.
+	 *
+	 * @param string $uuid The task uuid.
+	 * @param string $noteId The note to rewrite.
+	 *
+	 * @return JSONResponse The updated note; 404 when the task is absent OR
+	 *                      invisible, 400 when the message is missing.
+	 *
+	 * @spec openspec/changes/flow-task-entity/specs/flow-tasks/spec.md#requirement-every-lifecycle-verb-is-authorized-fail-closed
+	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	public function update(string $uuid, string $noteId): JSONResponse {
+		if ($this->readableTask(uuid: $uuid) === null) {
+			return new JSONResponse(self::NOT_FOUND, Http::STATUS_NOT_FOUND);
+		}
+
+		$message = $this->message();
+		if ($message === null) {
+			return new JSONResponse(['error' => 'Note message is required'], Http::STATUS_BAD_REQUEST);
+		}
+
+		return new JSONResponse($this->notes->updateNote((int)$noteId, $message));
+	}//end update()
+
+	/**
+	 * Remove a note from a task.
+	 *
+	 * @param string $uuid The task uuid.
+	 * @param string $noteId The note to remove.
+	 *
+	 * @return JSONResponse Confirmation; 404 when the task is absent OR
+	 *                      invisible.
+	 *
+	 * @spec openspec/changes/flow-task-entity/specs/flow-tasks/spec.md#requirement-every-lifecycle-verb-is-authorized-fail-closed
+	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	public function destroy(string $uuid, string $noteId): JSONResponse {
+		if ($this->readableTask(uuid: $uuid) === null) {
+			return new JSONResponse(self::NOT_FOUND, Http::STATUS_NOT_FOUND);
+		}
+
+		$this->notes->deleteNote((int)$noteId);
+
+		return new JSONResponse(['success' => true]);
+	}//end destroy()
+
+	/**
+	 * The task this request may act on, or null.
+	 *
+	 * Fail-closed on every path: absent, invisible and undeterminable all
+	 * return null, and every caller turns null into the same 404. A
+	 * `Throwable` from the mapper is caught here rather than propagated
+	 * because a lookup that could not answer must not be READ as a
+	 * permission, and because letting it out would put the mapper's message
+	 * (which for a database failure carries SQL and bound parameters) on the
+	 * wire, the finding {@see TaskController} already fixed.
+	 *
+	 * @param string $uuid The task uuid.
+	 *
+	 * @return Task|null The readable task, or null.
+	 *
+	 * @spec openspec/changes/flow-task-entity/specs/flow-tasks/spec.md#requirement-every-lifecycle-verb-is-authorized-fail-closed
+	 */
+	private function readableTask(string $uuid): ?Task {
+		try {
+			$task = $this->tasks->get(uuid: $uuid);
+		} catch (Throwable) {
+			return null;
+		}
+
+		if ($this->authorization->mayRead(task: $task, uid: $this->uid()) === false) {
+			return null;
+		}
+
+		return $task;
+	}//end readableTask()
+
+	/**
+	 * The note body the request carries, or null when it says nothing.
+	 *
+	 * A whitespace-only message is nothing: it is stored as a comment that
+	 * renders blank, which reads on the task as a note somebody wrote and
+	 * the page failed to show.
+	 *
+	 * @return string|null The message, or null.
+	 */
+	private function message(): ?string {
+		$message = trim((string)($this->request->getParams()['message'] ?? ''));
+		if ($message === '') {
+			return null;
+		}
+
+		return $message;
+	}//end message()
+
+	/**
+	 * The acting identity, or null without a session.
+	 *
+	 * @return string|null The uid.
+	 */
+	private function uid(): ?string {
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			return null;
+		}
+
+		return $user->getUID();
+	}//end uid()
+}//end class

--- a/tests/Unit/Controller/TaskEventsControllerTest.php
+++ b/tests/Unit/Controller/TaskEventsControllerTest.php
@@ -1,0 +1,419 @@
+<?php
+
+/**
+ * The task-anchored calendar leaf, and mostly its GUARD.
+ *
+ * The link layer under this controller is the object leaf's link layer,
+ * already proven by its own tests. What is new is the gate in front of it,
+ * so these assertions are about who reaches it and what a refusal says.
+ *
+ * Three properties carry the leaf and each has a test that fails when it
+ * is broken:
+ *
+ * 1. A caller who may not READ the task reaches no verb of the leaf, and
+ *    gets the same 404 body `task#show` answers, so the leaf cannot confirm
+ *    that a guessed uuid names a real task.
+ * 2. Every denial happens BEFORE the calendar services are touched, which
+ *    is what `expects($this->never())` on each of them says. `destroy` is
+ *    the one that matters most: it strips properties off a real VEVENT.
+ * 3. `destroy` reaches only events the TASK is linked to. An event id the
+ *    caller invents resolves to nothing and is answered 404, never
+ *    unlinked from whatever subject actually owns it.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Controller;
+
+use OCA\OpenRegister\Controller\TaskEventsController;
+use OCA\OpenRegister\Db\CalendarLink;
+use OCA\OpenRegister\Db\Task;
+use OCA\OpenRegister\Service\CalendarEventService;
+use OCA\OpenRegister\Service\CalendarLinkService;
+use OCA\OpenRegister\Service\Task\TaskAuthorizationService;
+use OCA\OpenRegister\Service\Task\TaskService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Authorization and HTTP translation for /api/flow-tasks/{uuid}/events.
+ *
+ * @covers \OCA\OpenRegister\Controller\TaskEventsController
+ */
+class TaskEventsControllerTest extends TestCase {
+
+	/**
+	 * Resolves a task by uuid, mocked.
+	 *
+	 * @var TaskService&MockObject
+	 */
+	private TaskService&MockObject $tasks;
+
+	/**
+	 * Read visibility, mocked.
+	 *
+	 * @var TaskAuthorizationService&MockObject
+	 */
+	private TaskAuthorizationService&MockObject $authorization;
+
+	/**
+	 * The link table layer, mocked.
+	 *
+	 * @var CalendarLinkService&MockObject
+	 */
+	private CalendarLinkService&MockObject $links;
+
+	/**
+	 * The VEVENT layer, mocked.
+	 *
+	 * @var CalendarEventService&MockObject
+	 */
+	private CalendarEventService&MockObject $events;
+
+	/**
+	 * Every collaborator mocked, and a session for `alice`.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$this->tasks = $this->createMock(originalClassName: TaskService::class);
+		$this->authorization = $this->createMock(originalClassName: TaskAuthorizationService::class);
+		$this->links = $this->createMock(originalClassName: CalendarLinkService::class);
+		$this->events = $this->createMock(originalClassName: CalendarEventService::class);
+	}//end setUp()
+
+	/**
+	 * A controller whose request carries these parameters.
+	 *
+	 * @param array<string, mixed> $params The request parameters.
+	 *
+	 * @return TaskEventsController The controller under test.
+	 */
+	private function controller(array $params = []): TaskEventsController {
+		$user = $this->createMock(originalClassName: IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$session = $this->createMock(originalClassName: IUserSession::class);
+		$session->method('getUser')->willReturn($user);
+
+		$request = $this->createMock(originalClassName: IRequest::class);
+		$request->method('getParams')->willReturn($params);
+
+		return new TaskEventsController(
+			appName: 'openregister',
+			request: $request,
+			tasks: $this->tasks,
+			authorization: $this->authorization,
+			links: $this->links,
+			events: $this->events,
+			userSession: $session
+		);
+	}//end controller()
+
+	/**
+	 * A task carrying its subject's register and schema.
+	 *
+	 * @return Task The task.
+	 */
+	private function task(): Task {
+		$task = new Task();
+		$task->setUuid('t-1');
+		$task->setTitle('Sign the decision');
+		$task->setRegisterId(4);
+		$task->setSchemaId(9);
+
+		return $task;
+	}//end task()
+
+	/**
+	 * The task resolves and the caller may read it.
+	 *
+	 * @return void
+	 */
+	private function givenReadable(): void {
+		$this->tasks->method('get')->willReturn($this->task());
+		$this->authorization->method('mayRead')->willReturn(true);
+	}//end givenReadable()
+
+	/**
+	 * The task resolves and the caller may NOT read it.
+	 *
+	 * @return void
+	 */
+	private function givenUnreadable(): void {
+		$this->tasks->method('get')->willReturn($this->task());
+		$this->authorization->method('mayRead')->willReturn(false);
+	}//end givenUnreadable()
+
+	/**
+	 * Neither calendar service is reachable at all in this test.
+	 *
+	 * @return void
+	 */
+	private function expectNoCalendarWork(): void {
+		$this->links->expects($this->never())->method('getLinkedEvents');
+		$this->links->expects($this->never())->method('createAndLinkEvent');
+		$this->links->expects($this->never())->method('linkEvent');
+		$this->links->expects($this->never())->method('unlinkEvent');
+		$this->events->expects($this->never())->method('unlinkEvent');
+	}//end expectNoCalendarWork()
+
+	/**
+	 * 🔴 THE test: a caller who may not read the task may not read its
+	 * events, and no calendar is touched.
+	 *
+	 * @return void
+	 */
+	public function testIndexIs404AndReadsNothingForACallerWhoMayNotReadTheTask(): void {
+		$this->givenUnreadable();
+		$this->expectNoCalendarWork();
+
+		$response = $this->controller()->index(uuid: 't-1');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['error' => 'No such task'], $response->getData());
+	}//end testIndexIs404AndReadsNothingForACallerWhoMayNotReadTheTask()
+
+	/**
+	 * The unreadable task and the absent one are indistinguishable.
+	 *
+	 * @return void
+	 */
+	public function testAnAbsentTaskAnswersExactlyAsAnUnreadableOne(): void {
+		$this->expectNoCalendarWork();
+
+		$this->tasks->method('get')->willThrowException(new DoesNotExistException('gone'));
+		$absent = $this->controller()->index(uuid: 't-1');
+
+		$this->tasks = $this->createMock(originalClassName: TaskService::class);
+		$this->givenUnreadable();
+		$hidden = $this->controller()->index(uuid: 't-1');
+
+		$this->assertSame($hidden->getStatus(), $absent->getStatus());
+		$this->assertSame($hidden->getData(), $absent->getData());
+		$this->assertSame(Http::STATUS_NOT_FOUND, $absent->getStatus());
+	}//end testAnAbsentTaskAnswersExactlyAsAnUnreadableOne()
+
+	/**
+	 * A readable task reads the events linked to the TASK's uuid.
+	 *
+	 * @return void
+	 */
+	public function testIndexReadsTheEventsOfTheTaskUuid(): void {
+		$this->givenReadable();
+		$this->links->expects($this->once())->method('getLinkedEvents')
+			->with('t-1')
+			->willReturn([['id' => 'e.ics', 'summary' => 'Review']]);
+
+		$response = $this->controller()->index(uuid: 't-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(1, $response->getData()['total']);
+		$this->assertSame('Review', $response->getData()['results'][0]['summary']);
+	}//end testIndexReadsTheEventsOfTheTaskUuid()
+
+	/**
+	 * A caller who may not read the task may not put an event on it.
+	 *
+	 * @return void
+	 */
+	public function testCreateIs404AndWritesNothingForACallerWhoMayNotReadTheTask(): void {
+		$this->givenUnreadable();
+		$this->expectNoCalendarWork();
+
+		$response = $this->controller(['summary' => 'Sneaky'])->create(uuid: 't-1');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['error' => 'No such task'], $response->getData());
+	}//end testCreateIs404AndWritesNothingForACallerWhoMayNotReadTheTask()
+
+	/**
+	 * A readable task anchors the new event on the TASK's uuid and carries
+	 * the task's own title into the calendar.
+	 *
+	 * @return void
+	 */
+	public function testCreateAnchorsTheEventOnTheTaskUuidAndTitle(): void {
+		$this->givenReadable();
+		$link = $this->createMock(originalClassName: CalendarLink::class);
+		$link->method('jsonSerialize')->willReturn(['id' => 3]);
+
+		$this->links->expects($this->once())->method('createAndLinkEvent')->willReturnCallback(
+			function (string $objectUuid, int $registerId, int $schemaId, array $eventData) use ($link): CalendarLink {
+				$this->assertSame('t-1', $objectUuid);
+				$this->assertSame(4, $registerId);
+				$this->assertSame(9, $schemaId);
+				$this->assertSame('Sign the decision', $eventData['objectTitle']);
+				$this->assertSame('Review', $eventData['summary']);
+
+				return $link;
+			}
+		);
+
+		$response = $this->controller(['summary' => 'Review'])->create(uuid: 't-1');
+
+		$this->assertSame(Http::STATUS_CREATED, $response->getStatus());
+		$this->assertSame(['id' => 3], $response->getData());
+	}//end testCreateAnchorsTheEventOnTheTaskUuidAndTitle()
+
+	/**
+	 * A blank summary is a 400 and writes nothing.
+	 *
+	 * @return void
+	 */
+	public function testABlankSummaryIs400AndWritesNothing(): void {
+		$this->givenReadable();
+		$this->expectNoCalendarWork();
+
+		$response = $this->controller(['summary' => '  '])->create(uuid: 't-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'Event summary is required'], $response->getData());
+	}//end testABlankSummaryIs400AndWritesNothing()
+
+	/**
+	 * A caller who may not read the task may not attach an existing event.
+	 *
+	 * @return void
+	 */
+	public function testLinkIs404AndLinksNothingForACallerWhoMayNotReadTheTask(): void {
+		$this->givenUnreadable();
+		$this->expectNoCalendarWork();
+
+		$response = $this->controller(['calendarUri' => 'personal', 'eventUid' => 'u-1'])->link(uuid: 't-1');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['error' => 'No such task'], $response->getData());
+	}//end testLinkIs404AndLinksNothingForACallerWhoMayNotReadTheTask()
+
+	/**
+	 * A readable task links the named event against its own uuid.
+	 *
+	 * @return void
+	 */
+	public function testLinkAttachesTheEventToTheTaskUuid(): void {
+		$this->givenReadable();
+		$link = $this->createMock(originalClassName: CalendarLink::class);
+		$link->method('jsonSerialize')->willReturn(['id' => 5]);
+		$this->links->expects($this->once())->method('linkEvent')
+			->with('t-1', 4, 9, 'personal', 'u-1')
+			->willReturn($link);
+
+		$response = $this->controller(['calendarUri' => 'personal', 'eventUid' => 'u-1'])->link(uuid: 't-1');
+
+		$this->assertSame(Http::STATUS_CREATED, $response->getStatus());
+		$this->assertSame(['id' => 5], $response->getData());
+	}//end testLinkAttachesTheEventToTheTaskUuid()
+
+	/**
+	 * A half-named event is a 400 and links nothing.
+	 *
+	 * @return void
+	 */
+	public function testAHalfNamedEventIs400AndLinksNothing(): void {
+		$this->givenReadable();
+		$this->expectNoCalendarWork();
+
+		$response = $this->controller(['calendarUri' => 'personal'])->link(uuid: 't-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'calendarUri and eventUid are required'], $response->getData());
+	}//end testAHalfNamedEventIs400AndLinksNothing()
+
+	/**
+	 * A caller who may not read the task may not detach its events.
+	 *
+	 * @return void
+	 */
+	public function testUnlinkIs404AndUnlinksNothingForACallerWhoMayNotReadTheTask(): void {
+		$this->givenUnreadable();
+		$this->expectNoCalendarWork();
+
+		$response = $this->controller()->unlink(uuid: 't-1', eventUid: 'u-1');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['error' => 'No such task'], $response->getData());
+	}//end testUnlinkIs404AndUnlinksNothingForACallerWhoMayNotReadTheTask()
+
+	/**
+	 * A readable task detaches the named event from its own uuid.
+	 *
+	 * @return void
+	 */
+	public function testUnlinkDetachesTheEventFromTheTaskUuid(): void {
+		$this->givenReadable();
+		$this->links->expects($this->once())->method('unlinkEvent')->with('t-1', 'u-1');
+
+		$response = $this->controller()->unlink(uuid: 't-1', eventUid: 'u-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['success' => true], $response->getData());
+	}//end testUnlinkDetachesTheEventFromTheTaskUuid()
+
+	/**
+	 * A caller who may not read the task may not destroy its events. The
+	 * VEVENT layer must not be reached at all: this verb writes to a real
+	 * calendar entry.
+	 *
+	 * @return void
+	 */
+	public function testDestroyIs404AndTouchesNoCalendarForACallerWhoMayNotReadTheTask(): void {
+		$this->givenUnreadable();
+		$this->expectNoCalendarWork();
+
+		$response = $this->controller()->destroy(uuid: 't-1', eventId: 'e.ics');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['error' => 'No such task'], $response->getData());
+	}//end testDestroyIs404AndTouchesNoCalendarForACallerWhoMayNotReadTheTask()
+
+	/**
+	 * An event id the task is not linked to is a 404, and nothing is
+	 * stripped: `destroy` reaches only this task's own linked events.
+	 *
+	 * @return void
+	 */
+	public function testDestroyRefusesAnEventTheTaskIsNotLinkedTo(): void {
+		$this->givenReadable();
+		$this->links->method('getLinkedEvents')->willReturn([['id' => 'mine.ics', 'calendarId' => 2, 'uid' => 'u-1']]);
+		$this->links->expects($this->never())->method('unlinkEvent');
+		$this->events->expects($this->never())->method('unlinkEvent');
+
+		$response = $this->controller()->destroy(uuid: 't-1', eventId: 'someone-elses.ics');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['error' => 'Event not found'], $response->getData());
+	}//end testDestroyRefusesAnEventTheTaskIsNotLinkedTo()
+
+	/**
+	 * A linked event is stripped on the VEVENT and removed from the link
+	 * table, in that order, 200.
+	 *
+	 * @return void
+	 */
+	public function testDestroyStripsTheVeventAndRemovesTheLink(): void {
+		$this->givenReadable();
+		$this->links->method('getLinkedEvents')->willReturn([['id' => 'mine.ics', 'calendarId' => 2, 'uid' => 'u-1']]);
+		$this->events->expects($this->once())->method('unlinkEvent')->with('2', 'mine.ics');
+		$this->links->expects($this->once())->method('unlinkEvent')->with('t-1', 'u-1');
+
+		$response = $this->controller()->destroy(uuid: 't-1', eventId: 'mine.ics');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['success' => true], $response->getData());
+	}//end testDestroyStripsTheVeventAndRemovesTheLink()
+}//end class

--- a/tests/Unit/Controller/TaskNotesControllerTest.php
+++ b/tests/Unit/Controller/TaskNotesControllerTest.php
@@ -1,0 +1,342 @@
+<?php
+
+/**
+ * The task-anchored notes leaf, and mostly its GUARD.
+ *
+ * The storage under this controller is the object leaf's storage, already
+ * proven by its own tests: a note is a Nextcloud comment addressed by a
+ * bare uuid, and nothing here re-tests writing one. What is NEW, and what
+ * these assertions are about, is who may reach it.
+ *
+ * Two properties carry the security of the leaf and each has a test that
+ * fails when it is broken:
+ *
+ * 1. A caller who may not READ the task gets nothing. Not the notes, not a
+ *    403, not a different message — the same 404 body `task#show` answers,
+ *    so the leaf cannot be used to confirm that a guessed uuid names a real
+ *    task. Asserting the status alone would not catch that: a 404 reading
+ *    'Task exists but is forbidden' leaks precisely what the status hides,
+ *    so the BODY is asserted too.
+ *
+ * 2. The refusal happens BEFORE the service is touched. Every denial test
+ *    also asserts `expects($this->never())` on NoteService, because a
+ *    controller that reads the notes and then throws them away has already
+ *    lost: the read is where the cost, the log line and the side effects
+ *    are.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Controller;
+
+use OCA\OpenRegister\Controller\TaskNotesController;
+use OCA\OpenRegister\Db\Task;
+use OCA\OpenRegister\Service\NoteService;
+use OCA\OpenRegister\Service\Task\TaskAuthorizationService;
+use OCA\OpenRegister\Service\Task\TaskService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Authorization and HTTP translation for /api/flow-tasks/{uuid}/notes.
+ *
+ * @covers \OCA\OpenRegister\Controller\TaskNotesController
+ */
+class TaskNotesControllerTest extends TestCase {
+
+	/**
+	 * Resolves a task by uuid, mocked.
+	 *
+	 * @var TaskService&MockObject
+	 */
+	private TaskService&MockObject $tasks;
+
+	/**
+	 * Read visibility, mocked.
+	 *
+	 * @var TaskAuthorizationService&MockObject
+	 */
+	private TaskAuthorizationService&MockObject $authorization;
+
+	/**
+	 * The note storage, mocked — reached only when the guard allows it.
+	 *
+	 * @var NoteService&MockObject
+	 */
+	private NoteService&MockObject $notes;
+
+	/**
+	 * Every collaborator mocked, and a session for `alice`.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$this->tasks = $this->createMock(originalClassName: TaskService::class);
+		$this->authorization = $this->createMock(originalClassName: TaskAuthorizationService::class);
+		$this->notes = $this->createMock(originalClassName: NoteService::class);
+	}//end setUp()
+
+	/**
+	 * A controller whose request carries these parameters.
+	 *
+	 * @param array<string, mixed> $params The request parameters.
+	 *
+	 * @return TaskNotesController The controller under test.
+	 */
+	private function controller(array $params = []): TaskNotesController {
+		$user = $this->createMock(originalClassName: IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$session = $this->createMock(originalClassName: IUserSession::class);
+		$session->method('getUser')->willReturn($user);
+
+		$request = $this->createMock(originalClassName: IRequest::class);
+		$request->method('getParams')->willReturn($params);
+
+		return new TaskNotesController(
+			appName: 'openregister',
+			request: $request,
+			tasks: $this->tasks,
+			authorization: $this->authorization,
+			notes: $this->notes,
+			userSession: $session
+		);
+	}//end controller()
+
+	/**
+	 * A task as the service returns it.
+	 *
+	 * @return Task The task.
+	 */
+	private function task(): Task {
+		$task = new Task();
+		$task->setUuid('t-1');
+		$task->setState(Task::STATE_ACTIVE);
+
+		return $task;
+	}//end task()
+
+	/**
+	 * The task resolves and the caller may read it.
+	 *
+	 * @return void
+	 */
+	private function givenReadable(): void {
+		$this->tasks->method('get')->willReturn($this->task());
+		$this->authorization->method('mayRead')->willReturn(true);
+	}//end givenReadable()
+
+	/**
+	 * The task resolves and the caller may NOT read it.
+	 *
+	 * @return void
+	 */
+	private function givenUnreadable(): void {
+		$this->tasks->method('get')->willReturn($this->task());
+		$this->authorization->method('mayRead')->willReturn(false);
+	}//end givenUnreadable()
+
+	/**
+	 * 🔴 THE test: a caller who may not read the task may not read its notes,
+	 * and the storage is never asked.
+	 *
+	 * @return void
+	 */
+	public function testIndexIs404AndReadsNothingForACallerWhoMayNotReadTheTask(): void {
+		$this->givenUnreadable();
+		$this->notes->expects($this->never())->method('getNotesForObject');
+
+		$response = $this->controller()->index(uuid: 't-1');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['error' => 'No such task'], $response->getData());
+	}//end testIndexIs404AndReadsNothingForACallerWhoMayNotReadTheTask()
+
+	/**
+	 * The unreadable task and the absent one are indistinguishable on the
+	 * wire: same status, same body. A difference between them is an
+	 * existence oracle.
+	 *
+	 * @return void
+	 */
+	public function testAnAbsentTaskAnswersExactlyAsAnUnreadableOne(): void {
+		$this->notes->expects($this->never())->method('getNotesForObject');
+
+		$this->tasks->method('get')->willThrowException(new DoesNotExistException('gone'));
+		$absent = $this->controller()->index(uuid: 't-1');
+
+		$this->tasks = $this->createMock(originalClassName: TaskService::class);
+		$this->givenUnreadable();
+		$hidden = $this->controller()->index(uuid: 't-1');
+
+		$this->assertSame($hidden->getStatus(), $absent->getStatus());
+		$this->assertSame($hidden->getData(), $absent->getData());
+		$this->assertSame(Http::STATUS_NOT_FOUND, $absent->getStatus());
+	}//end testAnAbsentTaskAnswersExactlyAsAnUnreadableOne()
+
+	/**
+	 * The visibility question is asked about the RESOLVED task and the
+	 * SESSION's uid, not about the uuid off the URL.
+	 *
+	 * @return void
+	 */
+	public function testVisibilityIsAskedAboutTheResolvedTaskAndTheSessionUid(): void {
+		$this->tasks->method('get')->willReturn($this->task());
+		$this->authorization->expects($this->once())->method('mayRead')->willReturnCallback(
+			function (Task $task, ?string $uid): bool {
+				$this->assertSame('t-1', $task->getUuid());
+				$this->assertSame('alice', $uid);
+
+				return true;
+			}
+		);
+		$this->notes->method('getNotesForObject')->willReturn([]);
+
+		$this->controller()->index(uuid: 't-1');
+	}//end testVisibilityIsAskedAboutTheResolvedTaskAndTheSessionUid()
+
+	/**
+	 * A readable task reads its notes by the TASK's uuid, paged from the
+	 * query, and answers the same envelope the object leaf answers.
+	 *
+	 * @return void
+	 */
+	public function testIndexReadsTheNotesOfTheTaskUuid(): void {
+		$this->givenReadable();
+		$this->notes->expects($this->once())->method('getNotesForObject')
+			->with('t-1', 5, 10)
+			->willReturn([['id' => 1, 'message' => 'hello']]);
+
+		$response = $this->controller(['limit' => '5', 'offset' => '10'])->index(uuid: 't-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(1, $response->getData()['total']);
+		$this->assertSame('hello', $response->getData()['results'][0]['message']);
+	}//end testIndexReadsTheNotesOfTheTaskUuid()
+
+	/**
+	 * A caller who may not read the task may not WRITE a note on it either,
+	 * and nothing is stored.
+	 *
+	 * @return void
+	 */
+	public function testCreateIs404AndStoresNothingForACallerWhoMayNotReadTheTask(): void {
+		$this->givenUnreadable();
+		$this->notes->expects($this->never())->method('createNote');
+
+		$response = $this->controller(['message' => 'sneaky'])->create(uuid: 't-1');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['error' => 'No such task'], $response->getData());
+	}//end testCreateIs404AndStoresNothingForACallerWhoMayNotReadTheTask()
+
+	/**
+	 * A readable task stores the note against the TASK's uuid, 201.
+	 *
+	 * @return void
+	 */
+	public function testCreateStoresTheNoteAgainstTheTaskUuid(): void {
+		$this->givenReadable();
+		$this->notes->expects($this->once())->method('createNote')
+			->with('t-1', 'looks good')
+			->willReturn(['id' => 7, 'message' => 'looks good']);
+
+		$response = $this->controller(['message' => '  looks good  '])->create(uuid: 't-1');
+
+		$this->assertSame(Http::STATUS_CREATED, $response->getStatus());
+		$this->assertSame(7, $response->getData()['id']);
+	}//end testCreateStoresTheNoteAgainstTheTaskUuid()
+
+	/**
+	 * A blank message is a 400 and stores nothing: a whitespace-only note
+	 * renders as a note the page failed to show.
+	 *
+	 * @return void
+	 */
+	public function testABlankMessageIs400AndStoresNothing(): void {
+		$this->givenReadable();
+		$this->notes->expects($this->never())->method('createNote');
+
+		$response = $this->controller(['message' => '   '])->create(uuid: 't-1');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'Note message is required'], $response->getData());
+	}//end testABlankMessageIs400AndStoresNothing()
+
+	/**
+	 * A caller who may not read the task may not rewrite one of its notes.
+	 *
+	 * @return void
+	 */
+	public function testUpdateIs404AndRewritesNothingForACallerWhoMayNotReadTheTask(): void {
+		$this->givenUnreadable();
+		$this->notes->expects($this->never())->method('updateNote');
+
+		$response = $this->controller(['message' => 'rewritten'])->update(uuid: 't-1', noteId: '7');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['error' => 'No such task'], $response->getData());
+	}//end testUpdateIs404AndRewritesNothingForACallerWhoMayNotReadTheTask()
+
+	/**
+	 * A readable task rewrites the named note, 200.
+	 *
+	 * @return void
+	 */
+	public function testUpdateRewritesTheNamedNote(): void {
+		$this->givenReadable();
+		$this->notes->expects($this->once())->method('updateNote')
+			->with(7, 'rewritten')
+			->willReturn(['id' => 7, 'message' => 'rewritten']);
+
+		$response = $this->controller(['message' => 'rewritten'])->update(uuid: 't-1', noteId: '7');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame('rewritten', $response->getData()['message']);
+	}//end testUpdateRewritesTheNamedNote()
+
+	/**
+	 * A caller who may not read the task may not DELETE one of its notes.
+	 * The one denial where the cost of getting it wrong is not recoverable.
+	 *
+	 * @return void
+	 */
+	public function testDestroyIs404AndDeletesNothingForACallerWhoMayNotReadTheTask(): void {
+		$this->givenUnreadable();
+		$this->notes->expects($this->never())->method('deleteNote');
+
+		$response = $this->controller()->destroy(uuid: 't-1', noteId: '7');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['error' => 'No such task'], $response->getData());
+	}//end testDestroyIs404AndDeletesNothingForACallerWhoMayNotReadTheTask()
+
+	/**
+	 * A readable task deletes the named note, 200.
+	 *
+	 * @return void
+	 */
+	public function testDestroyDeletesTheNamedNote(): void {
+		$this->givenReadable();
+		$this->notes->expects($this->once())->method('deleteNote')->with(7);
+
+		$response = $this->controller()->destroy(uuid: 't-1', noteId: '7');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['success' => true], $response->getData());
+	}//end testDestroyDeletesTheNamedNote()
+}//end class


### PR DESCRIPTION
## What changed

OpenRegister's notes and calendar leaves were reachable only at `/api/objects/{register}/{schema}/{id}/notes` and `/api/objects/{register}/{schema}/{id}/events`. An engine task (`oc_openregister_tasks`, `OCA\OpenRegister\Db\Task`) is not an object: it has no register and no schema, and the object route's first act is to resolve both. So a task page had nowhere to hang a note or an event, which is awkward for the one subject people most want in a calendar.

This adds nine task-anchored routes and the two controllers behind them:

- `/api/flow-tasks/{uuid}/notes` for index, create, update and destroy, served by `TaskNotesController`.
- `/api/flow-tasks/{uuid}/events` for index, create, link, unlink and destroy, served by `TaskEventsController`.

## Why it is small

The storage layer was already anchor agnostic, which is what makes this a guard and not a feature. `NoteService` writes Nextcloud comments with `object_type = 'openregister'` and `object_id = <uuid string>`, taking a bare uuid and asking nothing about what that uuid names. `CalendarLinkService` reads and writes link rows by the same bare uuid. A task note and an object note are therefore the same row in the same table, read back by the same query. Neither controller reimplements any note or event handling, and both delegate every verb to the service the object leaf already uses.

## The guard, which is the only real difference

The object controllers resolve through `ObjectService::setRegister/setSchema/setObject` and answer 404 on a miss. There is no object to resolve here, so both new controllers resolve through `TaskService::get()` and gate on `TaskAuthorizationService::mayRead()`, which is exactly what `TaskController::show()` and `TaskController::audit()` already do.

A task the caller may not read answers 404 with the same body every other task route answers, never 403. That is deliberate and it is tested: a 403 from a leaf would confirm that a guessed uuid names a real task, which is precisely what answering 404 from `/api/flow-tasks/{uuid}` was protecting. The absent task and the unreadable one are asserted to be byte for byte identical on the wire.

## Two judgement calls worth reviewing

Reads and writes share the `mayRead()` gate rather than getting a lifecycle right of their own. `TaskAuthorizationService::RULES` names a right per lifecycle verb (claim, assign, complete and the rest) and annotating a task is not one of them. Adding a rule would be writing a policy no spec states, and passing an unnamed verb to `assertMay()` fails closed, which would leave the leaf usable by administrators alone. The object leaf's own write right is "you can read the object", so the task leaf's is "you can read the task", and the five relationships `mayRead()` admits (assignee, pool member, requester, watcher, administrator) are the people a task's notes are for. Narrowing this to the assignee, or widening it past visibility, is a spec change and should land in the spec first.

The calendar block mirrors `calendarEvents#*` verb for verb, so it carries `link` and `unlink` and no `update`. There is no event update anywhere behind the object leaf either: neither `CalendarLinkService` nor `CalendarEventService` has a method that rewrites a VEVENT, so an `update` verb here would have had to grow its own event handling, which is the one thing these controllers must not do.

## Verification

Five files, 1459 insertions, no deletions.

Quality gates, each exit code read directly rather than from a summary line:

| gate | exit code |
| --- | --- |
| `composer phpcs` | 0 |
| `composer phpmd` | 0 |
| `composer phpstan` | 0 (1722 files, no errors) |
| `composer psalm` | 0 (1724 files, no errors) |
| PHPUnit unit suite | 0 (19588 tests, 48178 assertions) |

Two notes on how those were read. `composer phpmd` needs `COMPOSER_PROCESS_TIMEOUT=0` locally or composer kills it at 300 seconds and reports a failure that is composer's, not phpmd's. `composer test:unit` exits 1 in this workspace on untouched baseline tests too, because no xdebug or pcov is installed and PHPUnit raises a runner warning for the missing coverage driver; with `--no-coverage` the same suite exits 0 with zero failures.

Routing was checked by reflection rather than by eye, because a route naming a method that does not exist is a 500 at runtime and not a 404. All nine new routes resolve to an existing public method, every `{placeholder}` in each url binds to a parameter of that method, and every method declares `#[NoAdminRequired]`.

New tests: 25 tests, 94 assertions, across `TaskNotesControllerTest` (11) and `TaskEventsControllerTest` (14).

## Mutation results

Every test was mutation checked: the behaviour it claims to guard was broken, the run was checked for the right test reddening, then the code was restored and the suite confirmed green. Fourteen mutations were applied and all fourteen reddened, each hitting the intended test.

| mutation | result |
| --- | --- |
| notes: `mayRead` guard removed entirely | 6 failures, including all four denial tests |
| notes: absent task made distinguishable from unreadable | `testAnAbsentTaskAnswersExactlyAsAnUnreadableOne` |
| notes: create anchors on a literal uuid | `testCreateStoresTheNoteAgainstTheTaskUuid` |
| notes: blank message accepted | `testABlankMessageIs400AndStoresNothing` |
| notes: index ignores limit and offset | `testIndexReadsTheNotesOfTheTaskUuid` |
| notes: update skips the task check | `testUpdateIs404AndRewritesNothingForACallerWhoMayNotReadTheTask` |
| notes: destroy skips the task check | `testDestroyIs404AndDeletesNothingForACallerWhoMayNotReadTheTask` |
| events: `mayRead` guard removed entirely | 6 failures, one per verb |
| events: destroy trusts the caller's event id | `testDestroyRefusesAnEventTheTaskIsNotLinkedTo` |
| events: create loses the task's register and schema | `testCreateAnchorsTheEventOnTheTaskUuidAndTitle` |
| events: create sends the uuid as the calendar title | `testCreateAnchorsTheEventOnTheTaskUuidAndTitle` |
| events: blank summary accepted | `testABlankSummaryIs400AndWritesNothing` |
| events: link accepts a half named event | `testAHalfNamedEventIs400AndLinksNothing` |
| events: link anchors on a literal uuid | `testLinkAttachesTheEventToTheTaskUuid` |

The authorization mutations are the ones that matter. Removing the `mayRead` call from either controller reddens every denial test, and each denial test asserts both the wire body and that the underlying service was never reached, so a controller that reads the notes and then throws them away fails too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
