### PR TITLE
feat(metrics): publish the task gauges from OpenRegister's own manifest

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -243,6 +243,7 @@ use OCA\OpenRegister\Service\Schema\SchemaVersioningService;
 use OCA\OpenRegister\Service\SchemaImport\DialectDetector;
 use OCA\OpenRegister\Service\SchemaImport\SchemaImportService;
 use OCA\OpenRegister\Service\Task\TaskInboxService;
+use OCA\OpenRegister\Service\Task\TaskMetricsProvider;
 use OCA\OpenRegister\Service\SchemaImport\ThreeWayMerge;
 use OCA\OpenRegister\Service\Schemas\FacetCacheHandler;
 use OCA\OpenRegister\Service\Schemas\PropertyValidatorHandler;
@@ -3160,6 +3161,24 @@ class Application extends App implements IBootstrap {
 			\OCA\OpenRegister\AppHost\Observability\PrometheusRenderer::class,
 			function (ContainerInterface $container) {
 				return new PrometheusRenderer();
+			}
+		);
+
+		// OpenRegister's own IMetricsProvider, under the alias
+		// ProviderMetricSource looks up for this app id. It carries the one
+		// metric the declarative kinds cannot express: overdue is
+		// COALESCE(due_at, expires_at) < now, and a tableCount filter
+		// compares one column to a literal. Registered here, in OR's own
+		// container, because the source resolves the alias from the CALLING
+		// app's container (#390) and OR is the calling app when it scrapes
+		// itself.
+		$context->registerService(
+			\OCA\OpenRegister\AppHost\IMetricsProvider::class . '::' . self::APP_ID,
+			function (ContainerInterface $container) {
+				return new TaskMetricsProvider(
+					mapper: $container->get(\OCA\OpenRegister\Db\TaskMapper::class),
+					temporal: $container->get(\OCA\OpenRegister\Service\Task\TaskTemporalProjection::class)
+				);
 			}
 		);
 

--- a/lib/Db/TaskMapper.php
+++ b/lib/Db/TaskMapper.php
@@ -803,27 +803,76 @@ class TaskMapper extends QBMapper {
 			$qb->andWhere($qb->expr()->eq('run_uuid', $qb->createNamedParameter($criteria->runUuid)));
 		}
 
-		// Derived overdue as a filter: the SAME comparison
-		// TaskTemporalProjection makes — effective deadline
-		// (due_at, else expires_at) strictly before now — expressed as a
-		// predicate, with the clock instant handed in from that one class.
-		// COALESCE(NULL, NULL) < x is NULL, so deadline-less tasks fall out
-		// without a separate null check.
 		if ($criteria->overdueAt !== null) {
-			$qb->andWhere(
-				$qb->createFunction(
-					sprintf(
-						'COALESCE(%s, %s) < %s',
-						$this->quote(identifier: 'due_at'),
-						$this->quote(identifier: 'expires_at'),
-						$qb->createNamedParameter($criteria->overdueAt, IQueryBuilder::PARAM_DATETIME_MUTABLE)
-					)
-				)
-			);
+			$this->applyOverdue(qb: $qb, now: $criteria->overdueAt);
 		}
 
 		$this->applyDueWindow(qb: $qb, criteria: $criteria);
 	}//end applyFilters()
+
+	/**
+	 * Derived overdue as a predicate: the SAME comparison
+	 * TaskTemporalProjection makes — effective deadline (due_at, else
+	 * expires_at) strictly before the given instant — with the clock handed
+	 * in from that one class. COALESCE(NULL, NULL) < x is NULL, so
+	 * deadline-less tasks fall out without a separate null check.
+	 *
+	 * Its own method because two readers need it: the inbox filter and the
+	 * instance-wide overdue count behind the `openregister_tasks_overdue_total`
+	 * gauge. Written twice it would be two definitions of overdue, which is
+	 * exactly what this class's one derivation exists to prevent.
+	 *
+	 * @param IQueryBuilder $qb The query under construction.
+	 * @param DateTime      $now The clock instant to compare against.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/flow-task-entity/specs/flow-tasks/spec.md#requirement-overdue-is-derived-and-must-not-be-stored
+	 */
+	private function applyOverdue(IQueryBuilder $qb, DateTime $now): void {
+		$qb->andWhere(
+			$qb->createFunction(
+				sprintf(
+					'COALESCE(%s, %s) < %s',
+					$this->quote(identifier: 'due_at'),
+					$this->quote(identifier: 'expires_at'),
+					$qb->createNamedParameter($now, IQueryBuilder::PARAM_DATETIME_MUTABLE)
+				)
+			)
+		);
+	}//end applyOverdue()
+
+	/**
+	 * How many OPEN tasks are overdue, instance-wide.
+	 *
+	 * No visibility predicate on purpose: this is the operator's gauge, not
+	 * an inbox, and a scrape has no user. Openness is `is_terminal = false`,
+	 * the materialised column Task::TERMINAL_STATES is written into, so a
+	 * completed, terminated or disabled task is never counted however long
+	 * its deadline has been past.
+	 *
+	 * @param DateTime $now The clock instant, from TaskTemporalProjection::now().
+	 *
+	 * @return int The count.
+	 *
+	 * @spec openspec/changes/flow-task-entity/specs/flow-tasks/spec.md#requirement-overdue-is-derived-and-must-not-be-stored
+	 */
+	public function countOverdueOpen(DateTime $now): int {
+		$qb = $this->db->getQueryBuilder();
+		$qb->selectAlias($qb->func()->count('id'), 'total')->from($this->getTableName());
+		$qb->andWhere($qb->expr()->eq('is_terminal', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL)));
+		$this->applyOverdue(qb: $qb, now: $now);
+
+		$result = $qb->executeQuery();
+		$row = $result->fetch();
+		$result->closeCursor();
+
+		if ($row === false) {
+			return 0;
+		}
+
+		return (int)$row['total'];
+	}//end countOverdueOpen()
 
 	/**
 	 * A due WINDOW, over the same effective deadline the overdue filter and

--- a/lib/Service/Task/TaskMetricsProvider.php
+++ b/lib/Service/Task/TaskMetricsProvider.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * The overdue-task gauge, published once for the whole instance.
+ *
+ * Tasks are OpenRegister records, so the fleet's task gauges belong here and
+ * are counted at the source rather than re-counted in every leaf app.
+ * `tasks_total` is declarative (a tableCount over `openregister_tasks`,
+ * grouped by `state`) and needs no code. `tasks_overdue_total` cannot be:
+ * overdue is "COALESCE(due_at, expires_at) < now", and the declarative filter
+ * DSL compares ONE column to a LITERAL, so it can express neither the
+ * two-column effective deadline nor the clock. The `provider` escape hatch is
+ * what the engine offers for exactly that, and taking it keeps the comparison
+ * the one `TaskTemporalProjection` and `TaskMapper` already make instead of
+ * approximating it with a second definition.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Task
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/apphost-observability/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Task;
+
+use OCA\OpenRegister\AppHost\IMetricsProvider;
+use OCA\OpenRegister\AppHost\Observability\MetricSample;
+use OCA\OpenRegister\Db\TaskMapper;
+
+/**
+ * Publishes `openregister_tasks_overdue_total`.
+ *
+ * @spec openspec/specs/apphost-observability/spec.md
+ */
+final class TaskMetricsProvider implements IMetricsProvider {
+
+	/**
+	 * The sample name, without the engine's `openregister_` prefix.
+	 *
+	 * It must match the `provider` descriptor's `name` in src/manifest.json:
+	 * the engine renders what the provider returns, so the manifest entry
+	 * documents the metric and this constant produces it.
+	 */
+	public const METRIC_NAME = 'tasks_overdue_total';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param TaskMapper              $mapper   Counts the overdue open rows.
+	 * @param TaskTemporalProjection  $temporal The one clock overdue is read against.
+	 */
+	public function __construct(
+		private readonly TaskMapper $mapper,
+		private readonly TaskTemporalProjection $temporal,
+	) {
+	}//end __construct()
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return MetricSample[] The overdue gauge.
+	 *
+	 * @spec openspec/specs/apphost-observability/spec.md
+	 */
+	public function metrics(): array {
+		$overdue = $this->mapper->countOverdueOpen(now: $this->temporal->now());
+
+		return [
+			new MetricSample(
+				name: self::METRIC_NAME,
+				type: 'gauge',
+				help: 'Open tasks whose effective deadline has passed',
+				samples: [['labels' => [], 'value' => $overdue]]
+			),
+		];
+	}//end metrics()
+}//end class

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -637,7 +637,7 @@
     }
   ],
   "observability": {
-    "_note": "OpenRegister dogfoods its own AppHost observability engine (ADR-040). These descriptors reproduce the output of the now-deleted hand-written HealthController + MetricsController. The /api/health and /api/metrics routes are aliased to AppHost\\Controller\\GenericHealth#index / GenericMetrics#index in appinfo/routes.php, so the engine reads this block at request time. Parity: metric names, types and label keys match the pre-adoption contract; documented intentional improvements are the added health `app` field, the implicit `nextcloud_version` info label, and the objects_total register/schema labels now carrying numeric ids (engine tableCount groupBy) rather than titles.",
+    "_note": "OpenRegister dogfoods its own AppHost observability engine (ADR-040). These descriptors reproduce the output of the now-deleted hand-written HealthController + MetricsController. The /api/health and /api/metrics routes are aliased to AppHost\\Controller\\GenericHealth#index / GenericMetrics#index in appinfo/routes.php, so the engine reads this block at request time. Parity: metric names, types and label keys match the pre-adoption contract; documented intentional improvements are the added health `app` field, the implicit `nextcloud_version` info label, and the objects_total register/schema labels now carrying numeric ids (engine tableCount groupBy) rather than titles. The two task gauges are published here, once for the instance, because tasks are OpenRegister records (oc_openregister_tasks) and no leaf app should re-count them. tasks_total is a plain tableCount grouped by state. tasks_overdue_total is the one metric the declarative kinds cannot express: overdue is COALESCE(due_at, expires_at) < now, and a tableCount filter compares one column to a literal, so it takes the provider escape hatch and reuses TaskMapper::countOverdueOpen() and TaskTemporalProjection::now(). Its name is produced by Service\\Task\\TaskMetricsProvider; this entry documents it.",
     "health": {
       "statusCodePolicy": "adr006",
       "checks": [
@@ -771,6 +771,26 @@
           "labelDefaults": {
             "success": "failure"
           }
+        }
+      },
+      {
+        "name": "tasks_total",
+        "type": "gauge",
+        "help": "Total tasks by state",
+        "source": {
+          "kind": "tableCount",
+          "table": "openregister_tasks",
+          "groupBy": [
+            "state"
+          ]
+        }
+      },
+      {
+        "name": "tasks_overdue_total",
+        "type": "gauge",
+        "help": "Open tasks whose effective deadline has passed",
+        "source": {
+          "kind": "provider"
         }
       }
     ]

--- a/tests/Service/ProductionObservabilityIntegrationTest.php
+++ b/tests/Service/ProductionObservabilityIntegrationTest.php
@@ -179,6 +179,40 @@ class ProductionObservabilityIntegrationTest extends TestCase {
 		}
 	}
 
+	public function testMetricsExposeTheInstanceWideTaskGauges(): void {
+		$body = $this->extractResponseBody($this->metricsController->index());
+
+		// Tasks are OpenRegister records, so both gauges are published here
+		// once for the whole instance rather than re-counted per leaf app.
+		// The total is declarative (tableCount over openregister_tasks);
+		// the overdue gauge comes from TaskMetricsProvider through the
+		// `provider` source, because the declarative filter DSL can express
+		// neither COALESCE(due_at, expires_at) nor the clock.
+		$this->assertStringContainsString(
+			'# TYPE openregister_tasks_total gauge',
+			$body,
+			'metrics output MUST type openregister_tasks_total as a gauge'
+		);
+		$this->assertStringContainsString(
+			'# TYPE openregister_tasks_overdue_total gauge',
+			$body,
+			'the provider-backed overdue gauge MUST reach the exposition'
+		);
+		$this->assertMatchesRegularExpression(
+			'/openregister_tasks_overdue_total \d+/',
+			$body,
+			'openregister_tasks_overdue_total MUST emit a non-negative integer value'
+		);
+
+		// The total is grouped by state, so every labelled line carries the
+		// state label key. A dev env may hold zero tasks, hence the guard.
+		if (preg_match_all('/openregister_tasks_total\{([^}]+)\}/', $body, $matches) > 0) {
+			foreach ($matches[1] as $labels) {
+				$this->assertStringContainsString('state=', $labels, 'the task total MUST be labelled with state');
+			}
+		}
+	}
+
 	public function testMetricsContentTypeIsPrometheus(): void {
 		$response = $this->metricsController->index();
 		$headers = $response->getHeaders();

--- a/tests/Unit/Db/TaskMapperQueriesTest.php
+++ b/tests/Unit/Db/TaskMapperQueriesTest.php
@@ -378,4 +378,26 @@ class TaskMapperQueriesTest extends TestCase {
 		$empty = new TaskMapper(db: $this->connectionWith(rows: []));
 		$this->assertSame(0, $empty->countInbox(criteria: new TaskInboxCriteria(uid: 'alice')));
 	}//end testCountInboxReadsTheTotal()
+
+	/**
+	 * countOverdueOpen is the inbox's overdue comparison without the inbox:
+	 * the SAME COALESCE over the effective deadline, plus the openness guard,
+	 * and no visibility predicate because a metrics scrape has no user.
+	 *
+	 * @return void
+	 */
+	public function testCountOverdueOpenGuardsOnTerminalityAndTheSharedCoalesce(): void {
+		$mapper = new TaskMapper(db: $this->connectionWith(rows: [['total' => '9']]));
+
+		$this->assertSame(9, $mapper->countOverdueOpen(now: new DateTime('2026-09-11T09:00:00+00:00')));
+		$this->assertTrue(
+			(bool)array_filter($this->functions, static fn (string $f): bool => str_starts_with($f, 'COALESCE(`due_at`, `expires_at`) <')),
+			'the gauge MUST use the one effective-deadline comparison, not a second definition of overdue'
+		);
+		$this->assertTrue($this->saw('expr.eq', 'is_terminal'), 'a terminal task is never open, however long its deadline has passed');
+		$this->assertFalse($this->saw('expr.in', 'assignee'), 'an instance-wide gauge MUST NOT be scoped to a caller');
+
+		$empty = new TaskMapper(db: $this->connectionWith(rows: []));
+		$this->assertSame(0, $empty->countOverdueOpen(now: new DateTime('2026-09-11T09:00:00+00:00')));
+	}//end testCountOverdueOpenGuardsOnTerminalityAndTheSharedCoalesce()
 }//end class

--- a/tests/Unit/Service/Task/TaskMetricsProviderTest.php
+++ b/tests/Unit/Service/Task/TaskMetricsProviderTest.php
@@ -1,0 +1,180 @@
+<?php
+
+/**
+ * The overdue-task gauge, and the manifest entry that advertises it.
+ *
+ * Two things can drift apart here and neither would fail loudly at runtime:
+ * the sample name the provider emits versus the `provider` descriptor's name
+ * in src/manifest.json, and the declared task metrics versus the table and
+ * column they read. Both are pinned below, alongside the provider's own
+ * behaviour: it counts through TaskMapper with the clock from
+ * TaskTemporalProjection, and never with a clock of its own.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Task
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Task;
+
+use DateTime;
+use OCA\OpenRegister\AppHost\IMetricsProvider;
+use OCA\OpenRegister\AppHost\Observability\MetricSample;
+use OCA\OpenRegister\AppHost\Observability\ObservabilityManifest;
+use OCA\OpenRegister\Db\TaskMapper;
+use OCA\OpenRegister\Service\Task\TaskMetricsProvider;
+use OCA\OpenRegister\Service\Task\TaskTemporalProjection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \OCA\OpenRegister\Service\Task\TaskMetricsProvider
+ */
+class TaskMetricsProviderTest extends TestCase {
+
+	/**
+	 * OpenRegister's own manifest, parsed.
+	 *
+	 * @return array<string, mixed> The manifest.
+	 */
+	private function manifest(): array {
+		$path = (dirname(__DIR__, 4) . '/src/manifest.json');
+		$this->assertFileExists($path);
+		$decoded = json_decode((string)file_get_contents($path), associative: true);
+		$this->assertIsArray($decoded, 'src/manifest.json MUST be valid JSON');
+
+		return $decoded;
+	}//end manifest()
+
+	/**
+	 * One declared metric, by name.
+	 *
+	 * @param string $name The metric name.
+	 *
+	 * @return array<string, mixed> The descriptor.
+	 */
+	private function declaredMetric(string $name): array {
+		foreach (($this->manifest()['observability']['metrics'] ?? []) as $metric) {
+			if (($metric['name'] ?? null) === $name) {
+				return $metric;
+			}
+		}
+
+		$this->fail(sprintf('src/manifest.json declares no metric named "%s"', $name));
+	}//end declaredMetric()
+
+	/**
+	 * The gauge is one sample, named and typed, carrying the mapper's count.
+	 *
+	 * @return void
+	 */
+	public function testTheGaugeCarriesTheMappersOverdueCount(): void {
+		$mapper = $this->createMock(originalClassName: TaskMapper::class);
+		$mapper->expects($this->once())
+			->method('countOverdueOpen')
+			->willReturn(17);
+
+		$samples = (new TaskMetricsProvider(mapper: $mapper, temporal: new TaskTemporalProjection()))->metrics();
+
+		$this->assertCount(1, $samples);
+		$this->assertInstanceOf(MetricSample::class, $samples[0]);
+		$this->assertSame('tasks_overdue_total', $samples[0]->name);
+		$this->assertSame('gauge', $samples[0]->type);
+		$this->assertSame([['labels' => [], 'value' => 17]], $samples[0]->samples);
+	}//end testTheGaugeCarriesTheMappersOverdueCount()
+
+	/**
+	 * The clock is TaskTemporalProjection's, never one of the provider's own:
+	 * a second clock would be a second definition of overdue.
+	 *
+	 * @return void
+	 */
+	public function testTheClockComesFromTheOneDerivation(): void {
+		$temporal = new TaskTemporalProjection();
+		$seen = null;
+
+		$mapper = $this->createMock(originalClassName: TaskMapper::class);
+		$mapper->method('countOverdueOpen')->willReturnCallback(
+			static function (DateTime $at) use (&$seen): int {
+				$seen = $at;
+
+				return 0;
+			}
+		);
+
+		(new TaskMetricsProvider(mapper: $mapper, temporal: $temporal))->metrics();
+
+		$this->assertInstanceOf(DateTime::class, $seen);
+		$this->assertLessThanOrEqual(
+			5,
+			abs(($seen->getTimestamp() - $temporal->now()->getTimestamp())),
+			'the gauge MUST be counted against TaskTemporalProjection::now(), not a clock of its own'
+		);
+	}//end testTheClockComesFromTheOneDerivation()
+
+	/**
+	 * The provider satisfies the interface the engine resolves by alias.
+	 *
+	 * @return void
+	 */
+	public function testTheProviderIsAnEngineMetricsProvider(): void {
+		$provider = new TaskMetricsProvider(
+			mapper: $this->createMock(originalClassName: TaskMapper::class),
+			temporal: new TaskTemporalProjection()
+		);
+
+		$this->assertInstanceOf(IMetricsProvider::class, $provider);
+	}//end testTheProviderIsAnEngineMetricsProvider()
+
+	/**
+	 * The manifest's `provider` descriptor names the sample the provider
+	 * actually emits. The engine renders the PROVIDER's name, so a drift here
+	 * would publish a metric no dashboard is looking for while the manifest
+	 * kept advertising the old one.
+	 *
+	 * @return void
+	 */
+	public function testTheManifestDescriptorNamesTheSampleTheProviderEmits(): void {
+		$descriptor = $this->declaredMetric(name: TaskMetricsProvider::METRIC_NAME);
+
+		$this->assertSame('gauge', $descriptor['type'] ?? null);
+		$this->assertSame('provider', $descriptor['source']['kind'] ?? null);
+	}//end testTheManifestDescriptorNamesTheSampleTheProviderEmits()
+
+	/**
+	 * The total is a tableCount over the tasks table, grouped by the state
+	 * column that actually exists on it.
+	 *
+	 * @return void
+	 */
+	public function testTheTotalCountsTheTasksTableGroupedByState(): void {
+		$descriptor = $this->declaredMetric(name: 'tasks_total');
+
+		$this->assertSame('gauge', $descriptor['type'] ?? null);
+		$this->assertSame('tableCount', $descriptor['source']['kind'] ?? null);
+		$this->assertSame('openregister_tasks', $descriptor['source']['table'] ?? null);
+		$this->assertSame(['state'], $descriptor['source']['groupBy'] ?? null);
+	}//end testTheTotalCountsTheTasksTableGroupedByState()
+
+	/**
+	 * Both entries survive the engine's own validator, so a scrape renders
+	 * them rather than logging a warning and emitting nothing.
+	 *
+	 * @return void
+	 */
+	public function testBothTaskMetricsParseThroughTheEngineValidator(): void {
+		$parsed = ObservabilityManifest::fromManifest('openregister', $this->manifest());
+
+		$names = array_map(static fn ($descriptor): string => $descriptor->name, $parsed->metrics);
+		$this->assertContains('tasks_total', $names);
+		$this->assertContains(TaskMetricsProvider::METRIC_NAME, $names);
+		$this->assertSame([], $parsed->diagnostics, 'the observability block MUST parse without diagnostics');
+	}//end testBothTaskMetricsParseThroughTheEngineValidator()
+}//end class


### PR DESCRIPTION
## What this does

Adds two Prometheus gauges to OpenRegister's own `observability.metrics` block, so every app's engine tasks are counted once at the source.

- `openregister_tasks_total`, a gauge labelled by `state`.
- `openregister_tasks_overdue_total`, a gauge of open tasks whose effective deadline has passed.

dossiq is deleting its `caseTask` schema, and its `tasks_total` and `tasks_overdue_total` gauges die with it. Tasks are OpenRegister records in `oc_openregister_tasks` now, so the gauges belong here and are published once for the instance rather than re-counted per app.

## Why the two gauges are built differently

`tasks_total` is declarative and needs no code: a `tableCount` over `openregister_tasks` grouped by the `state` column, which holds the `Task::STATES` vocabulary.

`tasks_overdue_total` could not be declarative. The engine defines overdue in exactly one place, `TaskTemporalProjection`, as "effective deadline strictly before now", where the effective deadline is `due_at` or `expires_at` where only that is set. `TaskMapper` expresses the same thing as the SQL predicate `COALESCE(due_at, expires_at) < :now`, and the `overdue` filter on `TaskController::index` takes its clock instant from that same class. The declarative filter DSL compares ONE column to a LITERAL value written into the manifest, so it can express neither the two-column effective deadline nor the clock. Approximating it with `due_at` alone would have been a second, wrong definition of overdue.

So the gauge takes the engine's documented `provider` escape hatch instead, which is one of the five source kinds and exists for precisely this. `Service\Task\TaskMetricsProvider` is registered under the alias `IMetricsProvider::openregister` in OpenRegister's own container, and it reuses the existing definitions rather than restating them:

- the clock comes from `TaskTemporalProjection::now()`,
- the comparison comes from the inbox filter's COALESCE predicate, now factored into `TaskMapper::applyOverdue()` so the inbox and the gauge share one copy,
- openness is `is_terminal = false`, the materialised column that `Task::TERMINAL_STATES` is written into, so a completed, terminated or disabled task is never counted however long its deadline has passed.

The count is instance-wide with no visibility predicate, because a metrics scrape has no user.

## Tests

`tests/Unit/Service/Task/TaskMetricsProviderTest.php` is new, 6 tests. It pins the provider's sample name, type and value; that the clock is `TaskTemporalProjection`'s and not one of the provider's own; that the manifest's `provider` descriptor names the sample the provider actually emits, which is the drift nothing else would catch since the engine renders the provider's name and not the descriptor's; that `tasks_total` names the right table and column; and that both descriptors survive the engine's own validator rather than being dropped into diagnostics.

`TaskMapperQueriesTest` gains one test for `countOverdueOpen`: the shared COALESCE, the terminality guard, and the absence of any caller scoping.

`ProductionObservabilityIntegrationTest` gains one test asserting both gauges reach the Prometheus exposition with the right TYPE lines and the `state` label.

Six mutations, each reddening the intended assertion and no other:

| Mutation | Result |
| --- | --- |
| manifest table `openregister_tasks` to `openregister_objects` | `testTheTotalCountsTheTasksTableGroupedByState` failed |
| manifest `groupBy` `state` to `status` | `testTheTotalCountsTheTasksTableGroupedByState` failed |
| provider `METRIC_NAME` to `tasks_late_total` | 3 tests failed, including the manifest-to-provider name check |
| drop the `is_terminal` guard from `countOverdueOpen` | `testCountOverdueOpenGuardsOnTerminalityAndTheSharedCoalesce` failed |
| replace the COALESCE with a `due_at` only comparison | the new test and the existing inbox filter test both failed |
| scope `countOverdueOpen` to one assignee | `testCountOverdueOpenGuardsOnTerminalityAndTheSharedCoalesce` failed |

## Checks

All exit codes, not summary lines.

| Check | Exit |
| --- | --- |
| `composer phpcs` | 0 |
| `composer phpmd` (with `COMPOSER_PROCESS_TIMEOUT=0`) | 0 |
| `composer phpstan` | 0 |
| `composer psalm` | 0 |
| PHPUnit Unit Tests, 19595 tests, `--no-coverage` | 0 |
| `npm run check:manifest`, Ajv against schema 2.33.0 | 0 |
| `npm run check:json-strict` | 0 |
| hydra gates, `--base origin/development` | 1 |

The gates run fails on gate-67 openregister-contract-parity only, which is red on `development` itself: `lib/Contract/RegisterSlugResolution.php` and `RegisterSlugResolverInterface.php` are not shipped in the hydra-gates contracts directory. That lives in another repo and this branch touches no contract file. gate-16 spec-coverage and gate-96 manifest-copy-style both pass.

The first phpmd run raised four findings, all from this change: a missing import in `Application.php`, `$at` below the minimum variable-name length in two places, and static access to `MetricSample::single`. All four are fixed rather than baselined, which is why the parameter is named `$now` and the sample is constructed with `new`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)