### PR TITLE
chore(deps-dev): bump conduction/hydra-gates from 1.16.1 to 1.18.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6872,16 +6872,16 @@
         },
         {
             "name": "conduction/hydra-gates",
-            "version": "v1.16.1",
+            "version": "v1.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ConductionNL/.github.git",
-                "reference": "bfb34cc6caa9762f6aa3da66f9a2b573f8442358"
+                "reference": "477f930e84f1b3e709d2fb645d7c303d8d39a994"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/bfb34cc6caa9762f6aa3da66f9a2b573f8442358",
-                "reference": "bfb34cc6caa9762f6aa3da66f9a2b573f8442358",
+                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/477f930e84f1b3e709d2fb645d7c303d8d39a994",
+                "reference": "477f930e84f1b3e709d2fb645d7c303d8d39a994",
                 "shasum": ""
             },
             "require": {
@@ -6920,9 +6920,9 @@
             "support": {
                 "docs": "https://github.com/ConductionNL/.github/blob/main/hydra-gates/README.md",
                 "issues": "https://github.com/ConductionNL/.github/issues",
-                "source": "https://github.com/ConductionNL/.github/tree/v1.16.1"
+                "source": "https://github.com/ConductionNL/.github/tree/v1.18.0"
             },
-            "time": "2026-09-07T08:01:54+00:00"
+            "time": "2026-09-10T10:15:53+00:00"
         },
         {
             "name": "consolidation/annotated-command",


### PR DESCRIPTION
Gate 67 (contract parity) is red on `development`. This bump turns it green.

#3571 added two files to `lib/Contract/`: `RegisterSlugResolution.php` and `RegisterSlugResolverInterface.php`. Gate 67 compares them with the copy in the app's own `vendor/`. The locked 1.16.1 predates both files. Version 1.18.0 ships them.

## Verification

- `composer.lock` changes one package entry and nothing else.
- The gate 67 checker, run against the installed 1.18.0, checks four contract files and exits 0. Against 1.16.1 it failed on the two missing files.
- `hydra-gates/quality-config/` is identical in 1.16.1 and 1.18.0. PHPCS, PHPMD and PHPStan results cannot change.

Found while verifying #3601, which shows the same red gate for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
