### PR TITLE
feat(organisation): carry a legal name beside the name it is called by

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -40,7 +40,7 @@ Open Register drijft apps zoals OpenCatalogi, Procest, Pipelinq en Software Cata
 
 Vrij en open source onder de EUPL-licentie.
     ]]></description>
-    <version>2.1.5-unstable.20260910192456</version>
+    <version>2.1.5-unstable.20260911050000</version>
     <licence>EUPL-1.2</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>OpenRegister</namespace>

--- a/lib/Db/Organisation.php
+++ b/lib/Db/Organisation.php
@@ -130,6 +130,9 @@ use Symfony\Component\Uid\Uuid;
  *
  * @SuppressWarnings(PHPMD.TooManyFields)
  * @SuppressWarnings(PHPMD.LongVariable)
+ * @SuppressWarnings(PHPMD.ExcessiveClassLength) One mapped column costs a
+ * property, an accessor pair, a type registration and a serialised key, so the
+ * entity grows with the table. Splitting it would split one row's mapping.
  *
  * @psalm-suppress PropertyNotSetInConstructor $id is set by Nextcloud's Entity base class
  */
@@ -434,21 +437,9 @@ class Organisation extends Entity implements JsonSerializable {
 	/**
 	 * The name the organisation is registered under (statutaire naam).
 	 *
-	 * Distinct from `name`, which is what the organisation is called day to day
-	 * and what every list shows. "Gemeente Voorbeeld" is a name; the legal name
-	 * in the Handelsregister is what a contract, an invoice or a formal letter
-	 * addresses. Several apps kept the two side by side in their own tenant or
-	 * party records, which is why it lives here rather than being re-modelled in
-	 * each of them.
-	 *
-	 * Nullable with no fallback to `name`. A copy of `name` written here would
-	 * read as a legal name someone had verified, and a reader cannot tell the
-	 * two apart afterwards. A consumer that needs something to print falls back
-	 * to `name` itself, at the point of use.
-	 *
-	 * Identity only, never a key: nothing may match, merge or scope on it. Two
-	 * bodies can share a legal name, and the identifiers for that are `kvk`,
-	 * `rsin` and `oin`.
+	 * Distinct from `name`, what every list shows. Never a copy of it: a reader
+	 * needing something to print falls back to `name` at the point of use.
+	 * Identity only, never a key; `kvk`, `rsin` and `oin` are the identifiers.
 	 *
 	 * @var string|null The registered legal name.
 	 */

--- a/lib/Db/Organisation.php
+++ b/lib/Db/Organisation.php
@@ -99,6 +99,8 @@ use Symfony\Component\Uid\Uuid;
  * @method void setRsin(?string $rsin)
  * @method string|null getKvk()
  * @method void setKvk(?string $kvk)
+ * @method string|null getLegalName()
+ * @method void setLegalName(?string $legalName)
  * @method string|null getPki()
  * @method void setPki(?string $pki)
  * @method string|null getImage()
@@ -430,6 +432,29 @@ class Organisation extends Entity implements JsonSerializable {
 	protected ?string $kvk = null;
 
 	/**
+	 * The name the organisation is registered under (statutaire naam).
+	 *
+	 * Distinct from `name`, which is what the organisation is called day to day
+	 * and what every list shows. "Gemeente Voorbeeld" is a name; the legal name
+	 * in the Handelsregister is what a contract, an invoice or a formal letter
+	 * addresses. Several apps kept the two side by side in their own tenant or
+	 * party records, which is why it lives here rather than being re-modelled in
+	 * each of them.
+	 *
+	 * Nullable with no fallback to `name`. A copy of `name` written here would
+	 * read as a legal name someone had verified, and a reader cannot tell the
+	 * two apart afterwards. A consumer that needs something to print falls back
+	 * to `name` itself, at the point of use.
+	 *
+	 * Identity only, never a key: nothing may match, merge or scope on it. Two
+	 * bodies can share a legal name, and the identifiers for that are `kvk`,
+	 * `rsin` and `oin`.
+	 *
+	 * @var string|null The registered legal name.
+	 */
+	protected ?string $legalName = null;
+
+	/**
 	 * PKIoverheid certificate reference.
 	 *
 	 * @var string|null
@@ -605,6 +630,7 @@ class Organisation extends Entity implements JsonSerializable {
 		$this->addType(fieldName: 'tooi', type: 'string');
 		$this->addType(fieldName: 'rsin', type: 'string');
 		$this->addType(fieldName: 'kvk', type: 'string');
+		$this->addType(fieldName: 'legalName', type: 'string');
 		$this->addType(fieldName: 'pki', type: 'string');
 		$this->addType(fieldName: 'image', type: 'string');
 		// Relationship facet.
@@ -1062,6 +1088,7 @@ class Organisation extends Entity implements JsonSerializable {
 			'tooi' => $this->tooi,
 			'rsin' => $this->rsin,
 			'kvk' => $this->kvk,
+			'legalName' => $this->legalName,
 			'pki' => $this->pki,
 			'image' => $this->image,
 			'registrationStatus' => $this->registrationStatus,

--- a/lib/Migration/Version1Date20260911050000.php
+++ b/lib/Migration/Version1Date20260911050000.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Give an organisation a legal name beside the name it is called by.
+ *
+ * dossiq kept its tenants in a `tenant` schema of its own, beside this table,
+ * and is moving them onto Organisation. Measured field by field, the tenant's
+ * identity maps onto columns that already exist: `slug`, `name` for its display
+ * name, `kvk` for its KvK number. One property had nowhere to go, and it is the
+ * one this migration adds: the registered legal name (statutaire naam), which a
+ * welcome letter, a contract or an invoice addresses and which is routinely
+ * different from the name a list shows.
+ *
+ * Nullable with NO default and no backfill from `name`. A copy of `name` written
+ * here would read as a legal name someone had verified, and nothing afterwards
+ * could tell the two apart.
+ *
+ * @category  Migration
+ * @package   OCA\OpenRegister\Migration
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link      https://github.com/ConductionNL/openregister
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Adds the `legal_name` column to `openregister_organisations`.
+ */
+final class Version1Date20260911050000 extends SimpleMigrationStep {
+
+	/**
+	 * The table this migration widens.
+	 *
+	 * @var string
+	 */
+	private const TABLE = 'openregister_organisations';
+
+	/**
+	 * The column this migration adds.
+	 *
+	 * @var string
+	 */
+	private const COLUMN = 'legal_name';
+
+	/**
+	 * Add the column when it is absent.
+	 *
+	 * @param IOutput $output Migration output.
+	 * @param Closure(): ISchemaWrapper $schemaClosure The schema closure.
+	 * @param array<string, mixed> $options Migration options.
+	 *
+	 * @return ISchemaWrapper|null The changed schema, or null when nothing changed.
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/* @var ISchemaWrapper $schema The schema wrapper. */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable(self::TABLE) === false) {
+			$output->warning(message: 'openregister_organisations is absent; skipping the legal_name column');
+
+			return null;
+		}
+
+		$table = $schema->getTable(self::TABLE);
+		if ($table->hasColumn(self::COLUMN) === true) {
+			return null;
+		}
+
+		$table->addColumn(
+			self::COLUMN,
+			Types::STRING,
+			[
+				'notnull' => false,
+				'length' => 255,
+				'comment' => 'The name the organisation is registered under (statutaire naam). '
+					. 'Identity only, never a key: nothing may match, merge or scope on it.',
+			]
+		);
+
+		$output->info(message: 'openregister_organisations: added ' . self::COLUMN);
+
+		return $schema;
+	}//end changeSchema()
+
+}//end class

--- a/tests/Unit/Db/OrganisationTest.php
+++ b/tests/Unit/Db/OrganisationTest.php
@@ -674,4 +674,55 @@ class OrganisationTest extends TestCase {
 		$this->assertSame(72, $serialised['qualityScore']);
 		$this->assertSame('adequate', $serialised['qualityStatus']);
 	}
+
+	/**
+	 * The legal name registers its type under the PROPERTY name.
+	 *
+	 * The same trap as the chain-partner fields: Entity::__call() resolves a
+	 * setter to lcfirst(substr($method, 3)), so a registration under the
+	 * column name `legal_name` would match nothing and the field would never
+	 * be treated as a mapped column.
+	 *
+	 * @return void
+	 */
+	public function testLegalNameFieldTypeIsRegistered(): void {
+		$fieldTypes = $this->organisation->getFieldTypes();
+
+		$this->assertSame('string', $fieldTypes['legalName']);
+	}
+
+	/**
+	 * An organisation with a name and no legal name serialises the legal name as null.
+	 *
+	 * Never a copy of `name`. A copied value would read as a legal name someone
+	 * had verified, and nothing downstream could tell the two apart; a consumer
+	 * that needs something to print falls back to `name` at the point of use.
+	 *
+	 * @return void
+	 */
+	public function testALegalNameIsNeverDerivedFromTheName(): void {
+		$this->organisation->setName('Gemeente Voorbeeld');
+
+		$serialised = $this->organisation->jsonSerialize();
+
+		$this->assertSame('Gemeente Voorbeeld', $serialised['name']);
+		$this->assertArrayHasKey('legalName', $serialised);
+		$this->assertNull($serialised['legalName']);
+	}
+
+	/**
+	 * The legal name round-trips through jsonSerialize, beside the name.
+	 *
+	 * @return void
+	 */
+	public function testLegalNameRoundTrips(): void {
+		$this->organisation->setName('Gemeente Voorbeeld');
+		$this->organisation->setLegalName('Gemeente Voorbeeld (publiekrechtelijk lichaam)');
+
+		$serialised = $this->organisation->jsonSerialize();
+
+		$this->assertSame('Gemeente Voorbeeld', $serialised['name']);
+		$this->assertSame('Gemeente Voorbeeld (publiekrechtelijk lichaam)', $serialised['legalName']);
+		$this->assertTrue(in_array('legalName', array_keys($this->organisation->getUpdatedFields()), true));
+	}
 }

--- a/tests/Unit/Migration/Version1Date20260911050000Test.php
+++ b/tests/Unit/Migration/Version1Date20260911050000Test.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * Unit tests for the organisation legal-name column.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Migration;
+
+use Doctrine\DBAL\Schema\Table;
+use OCA\OpenRegister\Migration\Version1Date20260911050000;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Locks the column's shape and the step's idempotency.
+ */
+class Version1Date20260911050000Test extends TestCase {
+
+	/**
+	 * The column is added nullable, with no default, when it is absent.
+	 *
+	 * Nullable with no default is the point: a default would stamp every
+	 * existing organisation with a legal name nobody entered.
+	 *
+	 * @return void
+	 */
+	public function testTheColumnIsAddedNullableWithNoDefault(): void {
+		$added = [];
+		$table = $this->createMock(Table::class);
+		$table->method('hasColumn')->willReturn(false);
+		$table->method('addColumn')->willReturnCallback(
+			function (string $name, string $type, array $options) use (&$added) {
+				$added[] = ['name' => $name, 'type' => $type, 'options' => $options];
+				return $this->createMock(\Doctrine\DBAL\Schema\Column::class);
+			}
+		);
+
+		$schema = $this->createMock(ISchemaWrapper::class);
+		$schema->method('hasTable')->with('openregister_organisations')->willReturn(true);
+		$schema->method('getTable')->with('openregister_organisations')->willReturn($table);
+
+		$step = new Version1Date20260911050000();
+		$result = $step->changeSchema($this->createMock(IOutput::class), fn () => $schema, []);
+
+		$this->assertSame($schema, $result);
+		$this->assertCount(1, $added);
+		$this->assertSame('legal_name', $added[0]['name']);
+		$this->assertSame(Types::STRING, $added[0]['type']);
+		$this->assertFalse($added[0]['options']['notnull']);
+		$this->assertArrayNotHasKey('default', $added[0]['options']);
+
+	}//end testTheColumnIsAddedNullableWithNoDefault()
+
+	/**
+	 * A column that already exists is left alone, and the run returns null so
+	 * Nextcloud records no schema change.
+	 *
+	 * @return void
+	 */
+	public function testAnExistingColumnIsLeftAlone(): void {
+		$table = $this->createMock(Table::class);
+		$table->method('hasColumn')->with('legal_name')->willReturn(true);
+		$table->expects($this->never())->method('addColumn');
+
+		$schema = $this->createMock(ISchemaWrapper::class);
+		$schema->method('hasTable')->willReturn(true);
+		$schema->method('getTable')->willReturn($table);
+
+		$step = new Version1Date20260911050000();
+
+		$this->assertNull($step->changeSchema($this->createMock(IOutput::class), fn () => $schema, []));
+
+	}//end testAnExistingColumnIsLeftAlone()
+
+	/**
+	 * An instance without the organisations table is skipped, not failed.
+	 *
+	 * @return void
+	 */
+	public function testAMissingTableIsSkipped(): void {
+		$schema = $this->createMock(ISchemaWrapper::class);
+		$schema->method('hasTable')->willReturn(false);
+		$schema->expects($this->never())->method('getTable');
+
+		$step = new Version1Date20260911050000();
+
+		$this->assertNull($step->changeSchema($this->createMock(IOutput::class), fn () => $schema, []));
+
+	}//end testAMissingTableIsSkipped()
+
+}//end class


### PR DESCRIPTION
Unblocks moving dossiq's `tenant` schema onto Organisation (dossiq change `tenancy-onto-openregister-organisation`, decision 2a).

## What the tenant needed

Measured field by field, a dossiq tenant's identity already fits columns this table has: `slug`, `name` for its display name, and `kvk` for its KvK number. So of the two fields the decision said to move, only one needed a change here. `kvkNumber` is a rename onto the existing `kvk`.

The other is the registered legal name (statutaire naam). A welcome letter, a contract or an invoice addresses it, and it routinely differs from the name a list shows. dossiq kept it on its tenant; other fleet apps keep the same pair on their own party records.

## What this adds

`legalName` on the entity, column `legal_name`:

- nullable, with no default and no backfill from `name`. A copied name would read as a legal name someone had verified, and nothing downstream could tell the two apart. A reader that needs something to print falls back to `name` at the point of use.
- identity only. Nothing may match, merge or scope on it. `kvk`, `rsin` and `oin` are the identifiers.

The migration moves `<version>` in the same change, because a migration without a version bump reaches no installed instance.

Adding the column took `Organisation` from 993 to 1020 lines against PHPMD's limit of 1000. The class now suppresses `ExcessiveClassLength` with the reason beside the existing `TooManyFields` one: every mapped column costs a property, an accessor pair, a type registration and a serialised key.

## Deliberately not in this change

The `nc-organisation` projection does not carry `legalName` yet. `SeedDirectoryVirtualSchemas::ensureSchema()` never updates a virtual schema that already exists, so a new projected property would reach fresh installs only, and existing ones would discard it without a word. That needs its own reconcile step.

## Found while reading the lifecycle, not fixed here

`TenantPurgeJob` calls `tenantUsageMapper->deleteOlderThan(new DateTime('2099-12-31'))` for each organisation it purges. `deleteOlderThan()` filters on `period` only, so purging one archived organisation deletes the usage records of every organisation on the instance. It wants its own change.

## Verification

- New tests: 3 on the entity (the type registers under the property name, the legal name is null rather than a copy of `name`, it round-trips) and 3 on the migration (nullable with no default, an existing column left alone, a missing table skipped).
- Each was mutation-checked: dropping the type registration, serialising `legalName ?? name`, making the column `notnull`, and removing the existing-column guard each redden exactly the test named for it. Restored and diffed against a backup after each.
- Exit codes: `composer phpcs` 0, `composer phpmd` 0 (2 before the class-length fix), `composer phpstan` 0, `composer psalm` 0, `composer check:migration-version` 0, PHPUnit unit suite 0 (19,601 tests, 24 skipped, 2 deprecations, all pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)