### PR TITLE
test(text-extraction): stop opening an empty tempnam() file as a zip

### DIFF
--- a/tests/Unit/Service/TextExtractionServiceTest.php
+++ b/tests/Unit/Service/TextExtractionServiceTest.php
@@ -2815,7 +2815,7 @@ class TextExtractionServiceTest extends TestCase {
 		// Create a minimal valid DOCX (ZIP with required files but no text).
 		$tmpZip = tempnam(sys_get_temp_dir(), 'docx');
 		$zip = new \ZipArchive();
-		$zip->open($tmpZip, \ZipArchive::CREATE);
+		$zip->open($tmpZip, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
 		$zip->addFromString('[Content_Types].xml', '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
 			. '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
 			. '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>'
@@ -2850,7 +2850,7 @@ class TextExtractionServiceTest extends TestCase {
 		// Create a minimal valid DOCX with text content.
 		$tmpZip = tempnam(sys_get_temp_dir(), 'docx');
 		$zip = new \ZipArchive();
-		$zip->open($tmpZip, \ZipArchive::CREATE);
+		$zip->open($tmpZip, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
 		$zip->addFromString('[Content_Types].xml', '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
 			. '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
 			. '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>'


### PR DESCRIPTION
The unit suite reported two PHP deprecations. This removes both.

`tempnam()` creates an empty file. PHP 8.3 deprecates opening an existing empty file with `ZipArchive::CREATE` alone. Two tests in `TextExtractionServiceTest` did exactly that.

Adding `ZipArchive::OVERWRITE` treats the placeholder as a new archive. The production code in `SipPackageBuilder` and `FilePublishingHandler` already opens archives this way.

## Verification

- `TextExtractionServiceTest`: 213 tests pass, exit 0, and no deprecations are reported.
- The full unit suite had exactly these two deprecations, out of 19,608 tests.
- Six other test opens use `CREATE` on a fresh path. They never deprecated, so they are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
