### PR TITLE
chore(deps): hydra-gates 1.18.0, so a local gate run agrees with CI

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6872,16 +6872,16 @@
         },
         {
             "name": "conduction/hydra-gates",
-            "version": "v1.16.1",
+            "version": "v1.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ConductionNL/.github.git",
-                "reference": "bfb34cc6caa9762f6aa3da66f9a2b573f8442358"
+                "reference": "477f930e84f1b3e709d2fb645d7c303d8d39a994"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/bfb34cc6caa9762f6aa3da66f9a2b573f8442358",
-                "reference": "bfb34cc6caa9762f6aa3da66f9a2b573f8442358",
+                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/477f930e84f1b3e709d2fb645d7c303d8d39a994",
+                "reference": "477f930e84f1b3e709d2fb645d7c303d8d39a994",
                 "shasum": ""
             },
             "require": {
@@ -6920,9 +6920,9 @@
             "support": {
                 "docs": "https://github.com/ConductionNL/.github/blob/main/hydra-gates/README.md",
                 "issues": "https://github.com/ConductionNL/.github/issues",
-                "source": "https://github.com/ConductionNL/.github/tree/v1.16.1"
+                "source": "https://github.com/ConductionNL/.github/tree/v1.18.0"
             },
-            "time": "2026-09-07T08:01:54+00:00"
+            "time": "2026-09-10T10:15:53+00:00"
         },
         {
             "name": "consolidation/annotated-command",


### PR DESCRIPTION
## Why

Gate 67 (`openregister-contract-parity`) prefers this repo's own `vendor/` copy
of `hydra-gates/contracts/` over the one beside the runner. With 1.16.1 locked,
every **local** run failed it:

```
FAIL lib/Contract/RegisterSlugResolution.php: part of the contract but NOT shipped in hydra-gates/contracts/.
FAIL lib/Contract/RegisterSlugResolverInterface.php: ...
```

CI resolves the gates at `@main` and stayed green, so the two disagreed. Both
files shipped in hydra-gates 1.18.0 (.github#739, documented in .github#749).

## What changes

Only `conduction/hydra-gates` moves in `composer.lock`, 1.16.1 to 1.18.0.

The bump also moves the vendored quality configs that phpstan
(`phpstan-base.neon`) and phpmd (`phpmd-unusedparams.xml`) read, so every
static leg was re-run on it:

| Gate | Result |
| --- | --- |
| Hydra gate 67, from the vendored runner | PASS (was FAIL) |
| phpcs | exit 0 |
| phpmd, both legs | exit 0, zero findings |
| phpstan (result cache cleared) | exit 0, no errors |
| psalm | exit 0, no errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
