### PR TITLE
feat(lifecycle): automatic transitions on a declared autoWhen

### DIFF
--- a/docs/features/workflow-automation.md
+++ b/docs/features/workflow-automation.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-OpenRegister integrates BPMN-style workflow automation with register operations via n8n (primary engine) and a pluggable interface for additional engines (Windmill, others). Register events trigger configurable workflows for process automation, data enrichment, validation, escalation, approval chains, and scheduled tasks — without requiring any code changes to OpenRegister itself.
+OpenRegister integrates BPMN-style workflow automation with register operations via n8n (primary engine) and a pluggable interface for additional engines (Windmill, others). Register events trigger configurable workflows for process automation, data enrichment, validation, escalation, approval chains, and scheduled tasks. None of it requires a code change to OpenRegister itself.
 
 **Tender demand**: 38% of analyzed government tenders require workflow/process automation capabilities.
 
@@ -10,9 +10,9 @@ OpenRegister integrates BPMN-style workflow automation with register operations 
 
 The workflow automation system has three layers:
 
-1. **Schema Hooks** — per-schema configuration of workflow callbacks on object lifecycle events
-2. **Workflow Engine Abstraction** — engine-agnostic interface (`WorkflowEngineInterface`) with per-engine adapters
-3. **Workflow Integration** — n8n as primary engine, auto-discovered when installed as a Nextcloud ExApp
+1. **Schema Hooks**: per-schema configuration of workflow callbacks on object lifecycle events
+2. **Workflow Engine Abstraction**: engine-agnostic interface (`WorkflowEngineInterface`) with per-engine adapters
+3. **Workflow Integration**: n8n as primary engine, auto-discovered when installed as a Nextcloud ExApp
 
 ## Schema Hooks
 
@@ -50,10 +50,10 @@ Hooks are defined in a schema's `hooks` JSON property:
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `id` | No | auto | Unique identifier within the schema |
-| `event` | Yes | — | Lifecycle event to trigger on |
-| `engine` | Yes | — | Engine key (e.g., `n8n`) |
-| `workflowId` | Yes | — | Engine-specific workflow identifier |
-| `mode` | Yes | — | `sync` (request-response) or `async` (fire-and-forget) |
+| `event` | Yes | n/a | Lifecycle event to trigger on |
+| `engine` | Yes | n/a | Engine key (e.g., `n8n`) |
+| `workflowId` | Yes | n/a | Engine-specific workflow identifier |
+| `mode` | Yes | n/a | `sync` (request-response) or `async` (fire-and-forget) |
 | `order` | No | 0 | Execution order for multiple hooks on the same event |
 | `timeout` | No | 30 | Seconds before timeout is declared |
 | `onFailure` | No | `reject` | `reject`, `allow`, `flag`, or `queue` |
@@ -181,9 +181,9 @@ against the object's current **literal** field value. The field must be a
 
 ### Graph mode (`graph`)
 
-For status graphs that are **data**, not a fixed enum — e.g. a `case.status`
-that is a `$ref` UUID to a `statusType` object whose valid set differs per
-parent `caseType` — declare a `graph` block instead. The engine derives the
+Some status graphs are **data**, not a fixed enum. A `case.status` may be a
+`$ref` UUID to a `statusType` object whose valid set differs per parent
+`caseType`. Declare a `graph` block for those instead. The engine derives the
 available and target transitions **at runtime** from FK-scoped sibling objects.
 
 ```json
@@ -232,12 +232,12 @@ is ignored (no sibling fetch). Static-only schemas are unaffected.
 
 When `initial` is the object form `{ "from": "<property>", "field": "<property>" }`,
 the create pipeline seeds the lifecycle field from the parent BEFORE schema
-validation — so a `required` lifecycle `$ref` field passes on a seeded create.
+validation, so a `required` lifecycle `$ref` field passes on a seeded create.
 It runs only on the create path (never on update), only when the lifecycle field
 is absent/null/empty (a client-supplied value is never overwritten), and is a
 fail-soft no-op when the parent reference is empty, the parent cannot be loaded,
 or the parent's `field` value is empty. Seeding dispatches no
-`ObjectTransitionedEvent` — it is an initialisation, not a transition. The legacy
+`ObjectTransitionedEvent`, because it is an initialisation, not a transition. The legacy
 literal-string `initial` keeps its static-mode semantics and is not auto-seeded.
 
 ### Conditions and refusal messages (`condition`, `message`)
@@ -369,6 +369,169 @@ graph transitions.
 | `lifecycle-message-malformed` | `message` is neither a non-empty string nor a valid per-locale map: no locale keys, an empty locale value, or a `defaultLocale` not present in the map |
 | `lifecycle-condition-unmet` | A matched transition's `condition` evaluates false, or cannot be evaluated, at save time. The response carries the resolved `message` |
 
+### Automatic transitions (`autoWhen`, `executionMode`)
+
+A transition can also carry an `autoWhen`. It is a JSONLogic rule. When the
+rule holds after a write, the transition fires on its own. No one calls
+`/transition`. A schema author can make a status follow the object's own
+data. No PHP and no listener are needed in the consuming app.
+
+```json
+"beslissen": {
+  "from": ["in-behandeling"],
+  "to": "besloten",
+  "autoWhen": { "!!": { "var": "object.motivering" } },
+  "executionMode": "sync"
+}
+```
+
+This transition fires the moment an object in `in-behandeling` is saved with
+a non-empty `motivering`. The response to that save already carries
+`besloten`.
+
+#### The autoWhen document
+
+`autoWhen` reads the same four-key document as `condition`: `object`,
+`previous`, `user`, `transition`. One key means something different here.
+
+| Key | In `condition` | In `autoWhen` |
+|---|---|---|
+| `object` | The incoming data, the state being entered | The stored object after the write, the state being left |
+| `previous` | The stored data before this write | The same: the object before the write that started the pass, or empty on create |
+| `user` | The caller's `uid` and `groups` | The same |
+| `transition` | `action`, `from`, `to` of the matched transition | The same |
+
+`autoWhen` is decided after the triggering write finishes. It reads the
+object as stored, not the incoming payload. Computed fields, defaults, and
+file ids are already present. An author writes `object.motivering` the same
+way a `condition` author would. Only the moment of the read differs.
+
+#### An automatic move obeys every gate a manual move obeys
+
+An automatic transition runs through the same `TransitionEngine::transition()`
+a named call uses. Every gate that can refuse a manual transition can refuse
+it. That includes the object `update` permission, `authorization`,
+`condition`, `requires`, and any approval-chain gate. Its declared
+`actions[]` run exactly as they do for a manual transition. An automatic move
+can never do what a manual move could not.
+
+#### `executionMode`: sync or async
+
+| Value | Applies when | What happens |
+|---|---|---|
+| `sync` (default) | At the outermost write boundary of the triggering save | The triggering response already carries the new state |
+| `async` | Decided at the same moment as `sync`, then queued | A background job re-checks the stored object and applies the move only if nothing changed |
+
+`sync` is the default, the opposite of a flow's `async` default. An automatic
+transition is one bounded write on a path the caller already waits on. It is
+not an arbitrary graph that must stay off the save's critical path.
+
+An `async` move does not re-evaluate `autoWhen` inside the job. It is decided
+once, at drain time, with the full document. That decision travels to the job
+as a queued entry. The job checks whether the object's version and `updated`
+timestamp still match the decision. If they match, it applies the move. If
+they do not, a newer write has already decided, and the queued move is
+dropped silently.
+
+A write outside a request has no moment when a sync move could land in the
+response. A bulk save, a deferred create event, and a revert are all outside
+a request. Their automatic transitions are always queued, whatever mode they
+declare.
+
+#### The loop cap
+
+An automatic move's own write can make another automatic transition hold.
+Everything one write triggers, directly or automatically, is one pass. A
+pass is bounded by two limits, both per object per pass:
+
+- **No revisit.** A move into a state the object already occupied in this
+  pass is not made. That includes the state the object started in. A to B to
+  A stops at the second move.
+- **A ceiling of 10.** At most 10 automatic transitions apply to one object
+  in one pass. The ceiling is fixed and cannot be configured per schema or
+  instance.
+
+Reaching either limit cuts the pass. OpenRegister logs one error-level line.
+It names the schema, the object, the limit, and every transition applied so
+far. Then it stops. The cut never throws. The triggering write already
+succeeded, and the cut is not the caller's fault.
+
+The cap survives an async hop. A queued move carries the pass's hop count
+and visited states. A chain cannot escape the ceiling by crossing into a
+background job.
+
+#### Ambiguity and shadowing
+
+When two transitions from the same state both hold, OpenRegister fires
+neither. It logs a warning naming both. Declaration order is deliberately
+not a tie-breaker. JSON key order is not preserved by every database
+OpenRegister supports. The same schema could pick different winners on
+different installations.
+
+A transition is also refused when it is shadowed. An earlier-declared
+transition shares its `from` and `to` pair. The save path matches a
+transition by its values, and the first match wins. Firing the shadowed one
+would run the earlier transition's gates and actions, not its own.
+OpenRegister refuses to fire it and logs a warning naming both.
+
+#### Refusal is logged, not retried
+
+When any gate refuses an automatic move, OpenRegister logs a warning. The
+warning names the schema, the object, the transition, and the refusal code.
+The triggering write still succeeds. The refusal is never retried and never
+reaches the caller. A later write that finds the rule still holding tries
+again.
+
+#### Create, update, and system operations
+
+`autoWhen` is checked after both a create and an update. A rule describes
+the state an object is in, not how it arrived there. "Created complete, so
+it skips straight to review" is a valid rule. `previous` resolves to an
+empty object on create.
+
+A write inside a system operation dispatches no object events. Configuration
+imports, repair steps, and seeding all count as system operations. No
+automatic transition fires on any of them. Seeding is not a user action, and
+an automatic move needs someone to act as.
+
+#### Identity
+
+A sync automatic move acts as the identity whose write triggered it. Its
+`authorization` list, its `update` permission check, and its audit row all
+see that identity. Nothing is ever swapped in. An automatic transition never
+runs as a system principal.
+
+An async move carries that identity into the queued job. If the identity no
+longer resolves, or resolves to a disabled account, the move is not applied
+and a warning is logged.
+
+A session-less write, such as an `occ` command with no session, gets a
+session-less automatic move. Its `authorization` list refuses it unless RBAC
+admits anonymous updates on that schema. That is the same rule any other
+write follows.
+
+#### Graph mode refuses `autoWhen`
+
+A `graph`-mode lifecycle refuses `autoWhen`, for the same reason it refuses
+`condition`. Graph-mode moves are derived and enforced inside
+`TransitionEngine`, not on the ordinary save path. A rule declared on a
+`graph` block would hold on one route and not the other. The schema-save
+validator refuses it with `lifecycle-autowhen-graph-unsupported`.
+
+#### Error codes
+
+| Code | Fires when |
+|---|---|
+| `lifecycle-autowhen-malformed` | `autoWhen` is not a non-empty JSONLogic rule object, or the expression engine cannot validate it. A scalar, including the `@self.<field> == '<value>'` string an `actions[]` entry uses, is refused with this code |
+| `lifecycle-execution-mode-malformed` | `executionMode` is present and is not exactly `sync` or `async`. Case variants are refused, not normalised |
+| `lifecycle-autowhen-requires-input` | A transition declares `autoWhen` and an `inputs` entry with `required: true`. An automatic move carries no payload, so it would be refused on every attempt |
+| `lifecycle-autowhen-graph-unsupported` | A `graph` block declares `autoWhen` |
+
+Each of these refuses the schema save, exactly as `lifecycle-condition-malformed`
+does. A stored value that skipped validation is not trusted at runtime
+either. A non-rule `autoWhen` counts as not holding, and logs a warning
+instead of firing.
+
 ## Standards
 
 | Standard | Role |
@@ -379,7 +542,7 @@ graph transitions.
 
 ## Related Features
 
-- [Event-Driven Architecture](event-driven-architecture.md) — hooks consume PSR-14 lifecycle events
-- [Registers & Schemas](registers-and-schemas.md) — hooks are configured on schema definitions
-- [Data Import & Export](data-import-export.md) — workflow-in-import triggers
-- [Webhooks & Notifications](webhooks-and-notifications.md) — complementary outbound delivery system
+- [Event-Driven Architecture](event-driven-architecture.md): hooks consume PSR-14 lifecycle events
+- [Registers & Schemas](registers-and-schemas.md): hooks are configured on schema definitions
+- [Data Import & Export](data-import-export.md): workflow-in-import triggers
+- [Webhooks & Notifications](webhooks-and-notifications.md): complementary outbound delivery system

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -96,6 +96,7 @@ use OCA\OpenRegister\Listener\AnnotationNotificationListener;
 use OCA\OpenRegister\Listener\ApprovalChainAdvanceListener;
 use OCA\OpenRegister\Listener\ApprovalChainGateListener;
 use OCA\OpenRegister\Listener\AuthorizationCacheInvalidationListener;
+use OCA\OpenRegister\Listener\AutoTransitionRecordListener;
 use OCA\OpenRegister\Listener\CalculationOnSaveListener;
 use OCA\OpenRegister\Listener\CommentsEntityListener;
 use OCA\OpenRegister\Listener\ContextChatSubmissionListener;
@@ -166,6 +167,8 @@ use OCA\OpenRegister\Service\File\FolderManagementHandler;
 use OCA\OpenRegister\Service\File\Pdf\Fallback\NullNcOfficeConverter;
 use OCA\OpenRegister\Service\FileService;
 use OCA\OpenRegister\Service\Flow\FlowRunContext;
+use OCA\OpenRegister\Service\Lifecycle\AutoTransitionPass;
+use OCA\OpenRegister\Service\Lifecycle\AutoTransitionRunner;
 use OCA\OpenRegister\Service\Lifecycle\LifecycleActionContext;
 use OCA\OpenRegister\Service\Flow\RegistryStepDispatcher;
 use OCA\OpenRegister\Service\FlowLinkService;
@@ -437,6 +440,24 @@ class Application extends App implements IBootstrap {
 			LifecycleActionContext::class,
 			function () {
 				return new LifecycleActionContext();
+			}
+		);
+
+		// The automatic-transition pass MUST be shared, and for a sharper reason
+		// than the two above: it IS the request's state. The listener records
+		// into it, ObjectService and TransitionEngine open and close boundaries
+		// on it, and the drain reads the lineage the boundary counted. Auto-
+		// wired fresh at each injection point, every one of those would hold its
+		// own counter: nothing would ever reach depth zero with a record in it,
+		// so no automatic transition would ever fire, silently and with no
+		// error anywhere.
+		$context->registerService(
+			AutoTransitionPass::class,
+			function ($c) {
+				return new AutoTransitionPass(
+					runner: $c->get(AutoTransitionRunner::class),
+					logger: $c->get(LoggerInterface::class)
+				);
 			}
 		);
 
@@ -2590,6 +2611,15 @@ class Application extends App implements IBootstrap {
 		// ObjectChangeListener for automatic object text extraction.
 		$context->registerEventListener(ObjectCreatedEvent::class, ObjectChangeListener::class);
 		$context->registerEventListener(ObjectUpdatedEvent::class, ObjectChangeListener::class);
+
+		// Automatic lifecycle transitions: note the written object so the
+		// request-scoped pass can decide its `autoWhen` rules once the write is
+		// finished. The listener records and nothing else; applying here would
+		// be lost to the second write a file-bearing save makes. NOT wired to
+		// ObjectTransitionedEvent: a named transition's save already dispatched
+		// ObjectUpdatedEvent, so both would record it twice.
+		$context->registerEventListener(ObjectCreatedEvent::class, AutoTransitionRecordListener::class);
+		$context->registerEventListener(ObjectUpdatedEvent::class, AutoTransitionRecordListener::class);
 
 		// Object-lifecycle flow triggers: queue a run for every flow wired to a
 		// lifecycle event. Create / update / delete plus lock / unlock / revert /

--- a/lib/BackgroundJob/AutoTransitionJob.php
+++ b/lib/BackgroundJob/AutoTransitionJob.php
@@ -1,0 +1,231 @@
+<?php
+
+/**
+ * OpenRegister AutoTransitionJob
+ *
+ * Actor-forwarded background job that applies an `async` automatic lifecycle
+ * transition off-request, under the identity whose write decided it.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category BackgroundJob
+ * @package  OCA\OpenRegister\BackgroundJob
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ *
+ * @psalm-suppress UnusedClass
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\BackgroundJob;
+
+use DateTimeInterface;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\Deferral\DeferredEntryObjectResolver;
+use OCA\OpenRegister\Service\Deferral\DeferredListenerContext;
+use OCA\OpenRegister\Service\Lifecycle\AutoTransitionPass;
+use OCA\OpenRegister\Service\Lifecycle\TransitionEngine;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Applies a queued automatic transition, if the object has not moved on.
+ *
+ * DECIDE NOW, APPLY LATER IF NOTHING CHANGED. The move was decided at drain
+ * time with the full four-key document. This job does NOT re-evaluate the
+ * `autoWhen`, and cannot: `previous` does not fit in a job argument capped at
+ * 4000 characters, and re-evaluating against a different `previous` would make
+ * an async rule mean something other than the same rule written sync. Instead
+ * it reconciles against current state, which is the at-least-once contract
+ * `ActorForwardedJob` already documents: the move is applied only while the
+ * stored version and `updated` stamp still match the decision. When they do
+ * not, a newer write has made its own decision and this one is dropped.
+ *
+ * THE PASS TRAVELS WITH THE MOVE. The entry carries the hop count and the
+ * states already visited, and the job resumes that lineage before applying, so
+ * a loop cannot escape the cap by crossing into a background job — which is
+ * exactly what a request-scoped counter, reset in every worker, would allow.
+ *
+ * IDENTITY. `ActorForwardedJob` restores the captured user and refuses one that
+ * no longer resolves. This job adds the disabled-account check locally, as
+ * `FlowRunAsScope` does: an automatic move must never run as an account someone
+ * has deliberately switched off. Moving the base class onto ADR-099's
+ * `setVolatileActiveUser()` touches five other jobs and is a follow-up.
+ */
+class AutoTransitionJob extends ActorForwardedJob {
+
+	/**
+	 * Wire the application collaborators on top of the actor plumbing.
+	 *
+	 * @param ITimeFactory $time Time factory for the parent job class.
+	 * @param IUserSession $userSession Session to impersonate on / restore.
+	 * @param IUserManager $userManager Resolver for the captured user id, and the disabled check.
+	 * @param OrganisationService $organisation Active-organisation resolver.
+	 * @param LoggerInterface $logger PSR logger.
+	 * @param DeferredEntryObjectResolver $resolver Stale-safe entry re-fetch.
+	 * @param TransitionEngine $engine The one path every automatic move goes through.
+	 * @param AutoTransitionPass $pass The pass, resumed with the entry's carried lineage.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function __construct(
+		ITimeFactory $time,
+		IUserSession $userSession,
+		private readonly IUserManager $userManager,
+		OrganisationService $organisation,
+		LoggerInterface $logger,
+		private readonly DeferredEntryObjectResolver $resolver,
+		private readonly TransitionEngine $engine,
+		private readonly AutoTransitionPass $pass,
+	) {
+		parent::__construct(
+			time: $time,
+			userSession: $userSession,
+			userManager: $this->userManager,
+			organisation: $organisation,
+			logger: $logger
+		);
+	}//end __construct()
+
+	/**
+	 * Apply every entry whose object is unchanged since the decision.
+	 *
+	 * @param DeferredListenerContext $context The captured dispatch-time context.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	protected function runDeferred(DeferredListenerContext $context): void {
+		if ($this->actorIsUsable(userId: $context->getUserId()) === false) {
+			return;
+		}
+
+		foreach ($context->getEntries() as $entry) {
+			$object = $this->resolver->resolve(entry: $entry);
+			if ($object === null || $this->isUnchanged(object: $object, entry: $entry) === false) {
+				continue;
+			}
+
+			$this->applyEntry(entry: $entry);
+		}
+	}//end runDeferred()
+
+	/**
+	 * Whether the captured actor may still act.
+	 *
+	 * A uid of null is a session-less origin, which `ActorForwardedJob` already
+	 * runs without impersonation; there is no account to check. A uid that
+	 * resolves to a DISABLED account is refused here: the base class does not
+	 * check, and an automatic move must not run as an account someone switched
+	 * off.
+	 *
+	 * @param string|null $userId The captured acting user id.
+	 *
+	 * @return bool True when the queued moves may be applied.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	private function actorIsUsable(?string $userId): bool {
+		if ($userId === null) {
+			return true;
+		}
+
+		$user = $this->userManager->get($userId);
+		if ($user !== null && $user->isEnabled() === true) {
+			return true;
+		}
+
+		$this->logger->warning(
+			message: '[AutoTransitionJob] The captured user is gone or disabled — queued automatic '
+				. 'transitions skipped rather than applied under another identity',
+			context: ['file' => __FILE__, 'line' => __LINE__, 'userId' => $userId]
+		);
+
+		return false;
+	}//end actorIsUsable()
+
+	/**
+	 * Whether the object still stands as it did when the move was decided.
+	 *
+	 * @param ObjectEntity $object The object as stored now.
+	 * @param array<string, mixed> $entry The queued entry.
+	 *
+	 * @return bool True when version and `updated` both still match.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	private function isUnchanged(ObjectEntity $object, array $entry): bool {
+		if ($object->getVersion() !== ($entry['version'] ?? null)) {
+			return false;
+		}
+
+		$updated = $object->getUpdated();
+		$stored = null;
+		if ($updated instanceof DateTimeInterface === true) {
+			$stored = $updated->format(DATE_ATOM);
+		}
+
+		return $stored === ($entry['updated'] ?? null);
+	}//end isUnchanged()
+
+	/**
+	 * Resume the entry's pass and apply its move through the engine.
+	 *
+	 * The move itself is not re-checked against the cap: it was counted when it
+	 * was decided. What the resumed lineage bounds is what follows it, so a
+	 * queued move applied at hop ten can chain no further.
+	 *
+	 * @param array<string, mixed> $entry The queued entry.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	private function applyEntry(array $entry): void {
+		$uuid = (string)($entry['uuid'] ?? '');
+		$action = (string)($entry['action'] ?? '');
+		if ($uuid === '' || $action === '') {
+			return;
+		}
+
+		$visited = ($entry['visited'] ?? []);
+		$visitedStates = [];
+		if (is_array($visited) === true) {
+			$visitedStates = $visited;
+		}
+
+		$this->pass->resume(
+			uuid: $uuid,
+			moves: (int)($entry['moves'] ?? 0),
+			visited: $visitedStates
+		);
+
+		try {
+			$this->engine->transition(objectId: $uuid, action: $action);
+		} catch (Throwable $e) {
+			$this->logger->warning(
+				message: '[AutoTransitionJob] A queued automatic transition was refused',
+				context: [
+					'file' => __FILE__,
+					'line' => __LINE__,
+					'uuid' => $uuid,
+					'action' => $action,
+					'error' => $e->getMessage(),
+				]
+			);
+		}
+	}//end applyEntry()
+}//end class

--- a/lib/Db/AuditTrailMapper.php
+++ b/lib/Db/AuditTrailMapper.php
@@ -465,6 +465,8 @@ class AuditTrailMapper extends QBMapper {
 	 * @SuppressWarnings(PHPMD.NPathComplexity)       Audit trail creation requires handling many optional fields
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
 	 */
 	public function buildAuditTrail(
 		?ObjectEntity $old = null,
@@ -562,6 +564,31 @@ class AuditTrailMapper extends QBMapper {
 				'action_type' => $cascadeContext['action_type'] ?? 'referential_integrity.cascade_delete',
 				'property' => $cascadeContext['property'] ?? null,
 			];
+		}
+
+		// Mark a row an automatic lifecycle transition produced, so an auditor
+		// can tell a move a user asked for from a move a rule made on that
+		// user's save. Applied HERE, before the row is built and sealed, for
+		// the reason AuditFlowAttribution is applied at the same point: the
+		// hash chain covers whatever is in the row, so a field added after the
+		// insert would sit outside the hash it is later given. The row is still
+		// attributed to the acting user, because that is who the move acted as.
+		// Read off the request-scoped pass through the container rather than an
+		// injected dependency: this mapper is constructed in contexts where the
+		// lifecycle services are not wired, and an audit row must never fail to
+		// be built because of that. A resolution failure means "no automatic move
+		// in flight", which is the pre-existing behaviour.
+		$automaticAction = null;
+		try {
+			$automaticAction = $this->container
+				->get(\OCA\OpenRegister\Service\Lifecycle\AutoTransitionPass::class)
+				->applyingAction();
+		} catch (\Throwable $passUnavailable) {
+			$automaticAction = null;
+		}
+
+		if ($automaticAction !== null) {
+			$changed['automaticTransition'] = $automaticAction;
 		}
 
 		// Get the current user.

--- a/lib/Db/SchemaMapper.php
+++ b/lib/Db/SchemaMapper.php
@@ -1130,16 +1130,19 @@ class SchemaMapper extends QBMapper {
 	 * Validate the optional `x-openregister-lifecycle` annotation.
 	 *
 	 * The annotation is stored under `configuration['x-openregister-lifecycle']`.
-	 * A broken transition `condition` refuses the save; every other lifecycle
-	 * error is advisory and only logged, and the schema is stored as written.
+	 * A broken transition `condition`, `autoWhen` or `executionMode` refuses the
+	 * save; every other lifecycle error is advisory and only logged, and the
+	 * schema is stored as written.
 	 *
 	 * @param Schema $schema Schema to validate.
 	 *
-	 * @throws Exception When a transition `condition` is malformed or declared on a graph block.
+	 * @throws Exception When a transition `condition` or automatic-transition
+	 *                   declaration is malformed or unsupported.
 	 *
 	 * @return void
 	 *
 	 * @spec openspec/changes/lifecycle-declarative-conditions/specs/object-lifecycle/spec.md
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
 	 */
 	private function validateLifecycleAnnotation(Schema $schema): void {
 		$configuration = ($schema->getConfiguration() ?? []);
@@ -1165,12 +1168,29 @@ class SchemaMapper extends QBMapper {
 		// silently gates nothing while its author believes it holds. No register
 		// shipped a condition before this key existed, so refusing here breaks
 		// no existing import, which is what the advisory policy below protects.
+		//
+		// The four `autoWhen` / `executionMode` codes join it for the same two
+		// reasons. A stored scalar `autoWhen` is WORSE than a stored broken
+		// condition: it evaluates as a truthy literal, so the transition fires
+		// on every write from its `from` state, each move writing an audit row
+		// and feeding the next decision. The loop cap bounds that, but "bounded
+		// damage on every save" is not an acceptable failure mode for a typo.
+		// An unknown `executionMode`, a required input beside `autoWhen` and an
+		// `autoWhen` on a graph block each describe a move that can never
+		// happen as written. And no register carries either key yet.
 		$blocking = array_values(
 			array_filter(
 				$errors,
 				static fn (array $err): bool => in_array(
 					$err['code'],
-					['lifecycle-condition-malformed', 'lifecycle-condition-graph-unsupported'],
+					[
+						'lifecycle-condition-malformed',
+						'lifecycle-condition-graph-unsupported',
+						'lifecycle-autowhen-malformed',
+						'lifecycle-execution-mode-malformed',
+						'lifecycle-autowhen-requires-input',
+						'lifecycle-autowhen-graph-unsupported',
+					],
 					true
 				)
 			)
@@ -1183,7 +1203,7 @@ class SchemaMapper extends QBMapper {
 				static fn (array $err): string => '[' . $err['code'] . '] ' . $err['message'],
 				$blocking
 			);
-			throw new Exception('Invalid x-openregister-lifecycle condition: ' . implode(' ', $details));
+			throw new Exception('Invalid x-openregister-lifecycle declaration: ' . implode(' ', $details));
 		}
 
 		// Every other lifecycle error is ADVISORY: rejecting the whole schema

--- a/lib/Event/ObjectTransitionedEvent.php
+++ b/lib/Event/ObjectTransitionedEvent.php
@@ -89,6 +89,13 @@ class ObjectTransitionedEvent extends Event {
 	private string $schema;
 
 	/**
+	 * Whether a rule made this move rather than a caller asking for it.
+	 *
+	 * @var boolean
+	 */
+	private bool $automatic;
+
+	/**
 	 * Capture the post-transition state for downstream listeners.
 	 *
 	 * @param ObjectEntity $object Object after the transition.
@@ -98,6 +105,18 @@ class ObjectTransitionedEvent extends Event {
 	 * @param string|null $userId Caller uid (null for system-applied transitions).
 	 * @param string $register Register slug.
 	 * @param string $schema Schema slug.
+	 * @param bool $automatic True when a transition's `autoWhen` fired this move. Additive
+	 *                       and defaulting to false, so every existing dispatcher and
+	 *                       listener is unaffected.
+	 *
+	 * @SuppressWarnings(PHPMD.BooleanArgumentFlag) `automatic` records WHO caused
+	 * the move, which is data this event carries, not a switch that changes what
+	 * the constructor does. A listener needs it precisely because "notify the
+	 * applicant" is right for a person's move and wrong for a rule's. Splitting
+	 * the event into two classes to avoid one boolean would force every existing
+	 * listener to subscribe twice.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
 	 */
 	public function __construct(
 		ObjectEntity $object,
@@ -107,6 +126,7 @@ class ObjectTransitionedEvent extends Event {
 		?string $userId,
 		string $register,
 		string $schema,
+		bool $automatic = false,
 	) {
 		parent::__construct();
 		$this->object = $object;
@@ -116,7 +136,23 @@ class ObjectTransitionedEvent extends Event {
 		$this->userId = $userId;
 		$this->register = $register;
 		$this->schema = $schema;
+		$this->automatic = $automatic;
 	}//end __construct()
+
+	/**
+	 * Whether a rule made this move rather than a caller asking for it.
+	 *
+	 * An auditor reading a trail needs to tell a user's click from a rule
+	 * firing on that user's save. Both are attributed to the same user, because
+	 * an automatic move acts as the identity whose write triggered it.
+	 *
+	 * @return bool True when the move was made by a transition's `autoWhen`.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function isAutomatic(): bool {
+		return $this->automatic;
+	}//end isAutomatic()
 
 	/**
 	 * Read the object after the transition.

--- a/lib/Listener/AutoTransitionRecordListener.php
+++ b/lib/Listener/AutoTransitionRecordListener.php
@@ -97,8 +97,6 @@ class AutoTransitionRecordListener implements IEventListener {
 			return;
 		}
 
-		$isCreate = ($event instanceof ObjectCreatedEvent);
-
 		$object = $event->getObject();
 		$schemaRef = (string)$object->getSchema();
 		if ($this->schemaDeclaresAutoWhen(schemaRef: $schemaRef) === false) {

--- a/lib/Listener/AutoTransitionRecordListener.php
+++ b/lib/Listener/AutoTransitionRecordListener.php
@@ -88,10 +88,16 @@ class AutoTransitionRecordListener implements IEventListener {
 	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
 	 */
 	public function handle(Event $event): void {
-		$isCreate = ($event instanceof ObjectCreatedEvent);
-		if ($isCreate === false && $event instanceof ObjectUpdatedEvent === false) {
+		// Written as one instanceof check per branch so static analysis can
+		// narrow `$event` to the two classes that carry getObject(); a boolean
+		// held in a variable first does not narrow.
+		if (($event instanceof ObjectCreatedEvent) === false
+			&& ($event instanceof ObjectUpdatedEvent) === false
+		) {
 			return;
 		}
+
+		$isCreate = ($event instanceof ObjectCreatedEvent);
 
 		$object = $event->getObject();
 		$schemaRef = (string)$object->getSchema();

--- a/lib/Listener/AutoTransitionRecordListener.php
+++ b/lib/Listener/AutoTransitionRecordListener.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * OpenRegister AutoTransitionRecordListener
+ *
+ * Notes that an object was written, so the request-scoped pass can decide its
+ * automatic transitions once the write is finished. It records and does
+ * nothing else.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Listener
+ * @package  OCA\OpenRegister\Listener
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Listener;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Event\ObjectCreatedEvent;
+use OCA\OpenRegister\Event\ObjectUpdatedEvent;
+use OCA\OpenRegister\Service\Lifecycle\AutoTransitionPass;
+use OCA\OpenRegister\Service\Lifecycle\AutoTransitionSelector;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use Throwable;
+
+/**
+ * Records written objects for the pass. It never evaluates and never writes.
+ *
+ * THE LISTENER RECORDS AND NOTHING MORE, and that is a load-bearing property
+ * rather than tidiness. `ObjectUpdatedEvent` is dispatched in the MIDDLE of a
+ * save: the save's own audit row is still to be written, and a save carrying a
+ * file property updates the object a second time from an in-memory entity that
+ * still holds the old lifecycle value. A transition applied here would be lost
+ * to that second write, behind a transition event that had already fired. It
+ * would also invert event order for a named transition, whose own
+ * `ObjectTransitionedEvent` is dispatched after its save returns.
+ *
+ * Because there is no write inside the user's save here, there is nothing for
+ * the listener-placement gate (ADR-078) to annotate or defer.
+ *
+ * `ObjectCreatedEvent` is subscribed to as well as `ObjectUpdatedEvent`: a rule
+ * is about the state an object is in, not how it got there, and "created
+ * complete, so it goes straight to review" is a real use. `previous` is empty
+ * on a create. `ObjectTransitionedEvent` is deliberately NOT subscribed to: a
+ * named transition's save already dispatched `ObjectUpdatedEvent`, so listening
+ * to both would record every named transition twice.
+ *
+ * @implements IEventListener<Event>
+ */
+class AutoTransitionRecordListener implements IEventListener {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param SchemaMapper $schemaMapper Resolves the written object's schema.
+	 * @param AutoTransitionSelector $selector Answers the cheap "does this schema declare any autoWhen" read.
+	 * @param AutoTransitionPass $pass The request-scoped pass the object is recorded in.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function __construct(
+		private readonly SchemaMapper $schemaMapper,
+		private readonly AutoTransitionSelector $selector,
+		private readonly AutoTransitionPass $pass,
+	) {
+	}//end __construct()
+
+	/**
+	 * Record the written object when its schema declares an `autoWhen`.
+	 *
+	 * @param Event $event Inbound dispatcher event.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function handle(Event $event): void {
+		$isCreate = ($event instanceof ObjectCreatedEvent);
+		if ($isCreate === false && $event instanceof ObjectUpdatedEvent === false) {
+			return;
+		}
+
+		$object = $event->getObject();
+		$schemaRef = (string)$object->getSchema();
+		if ($this->schemaDeclaresAutoWhen(schemaRef: $schemaRef) === false) {
+			return;
+		}
+
+		$previous = [];
+		if ($event instanceof ObjectUpdatedEvent === true) {
+			$previous = $this->dataOf(object: $event->getOldObject());
+		}
+
+		$this->pass->record(
+			uuid: (string)$object->getUuid(),
+			register: (string)$object->getRegister(),
+			schema: $schemaRef,
+			previous: $previous
+		);
+	}//end handle()
+
+	/**
+	 * Whether the schema declares at least one automatic transition.
+	 *
+	 * Every write to a schema WITHOUT one pays this lookup and nothing else.
+	 * A resolution failure records nothing: a schema that cannot be read cannot
+	 * be shown to declare a rule, and guessing would move objects on a guess.
+	 *
+	 * @param string $schemaRef The object's schema reference.
+	 *
+	 * @return bool True when the schema declares an `autoWhen`.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	private function schemaDeclaresAutoWhen(string $schemaRef): bool {
+		if ($schemaRef === '') {
+			return false;
+		}
+
+		try {
+			$schema = $this->schemaMapper->find($schemaRef, _multitenancy: false);
+		} catch (Throwable $e) {
+			return false;
+		}
+
+		$annotation = (($schema->getConfiguration() ?? [])['x-openregister-lifecycle'] ?? null);
+		if (is_array($annotation) === false) {
+			return false;
+		}
+
+		return $this->selector->declaresAutoWhen(annotation: $annotation);
+	}//end schemaDeclaresAutoWhen()
+
+	/**
+	 * The object data an entity carries, or an empty array when there is none.
+	 *
+	 * @param ObjectEntity|null $object The entity, when the event carried one.
+	 *
+	 * @return array<string, mixed> The object's data.
+	 */
+	private function dataOf(?ObjectEntity $object): array {
+		if ($object === null) {
+			return [];
+		}
+
+		return ($object->getObject() ?? []);
+	}//end dataOf()
+}//end class

--- a/lib/Listener/FlowTriggerListener.php
+++ b/lib/Listener/FlowTriggerListener.php
@@ -174,13 +174,24 @@ class FlowTriggerListener implements IEventListener {
 	 * @param Event $event The dispatched event.
 	 *
 	 * @return array<string, string> The extra context, empty for most events.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
 	 */
 	private function contextFor(Event $event): array {
 		if ($event instanceof ObjectTransitionedEvent) {
+			$automatic = 'false';
+			if ($event->isAutomatic() === true) {
+				$automatic = 'true';
+			}
+
 			return [
 				'action' => $event->getAction(),
 				'from' => $event->getFrom(),
 				'to' => $event->getTo(),
+				// A flow branching on a state change needs to know whether a
+				// person asked for the move or a rule made it: "notify the
+				// applicant" is right for one and wrong for the other.
+				'automatic' => $automatic,
 			];
 		}
 

--- a/lib/Service/Lifecycle/AutoTransitionCandidate.php
+++ b/lib/Service/Lifecycle/AutoTransitionCandidate.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * OpenRegister AutoTransitionCandidate
+ *
+ * The one automatic transition a stored object is eligible for, as decided by
+ * {@see AutoTransitionSelector}.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Lifecycle
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Lifecycle;
+
+use OCA\OpenRegister\Db\Flow;
+
+/**
+ * An automatic transition that is ready to be fired.
+ *
+ * A value object rather than an array, because the pass, the job and the log
+ * lines all read the same four fields and a typo in an array key is a silent
+ * null in every one of them.
+ */
+final class AutoTransitionCandidate {
+
+	/**
+	 * The transition's declared name, as it would be posted to /transition.
+	 *
+	 * @var string
+	 */
+	public readonly string $action;
+
+	/**
+	 * The lifecycle value the object holds now.
+	 *
+	 * @var string
+	 */
+	public readonly string $from;
+
+	/**
+	 * The lifecycle value the move would reach.
+	 *
+	 * @var string
+	 */
+	public readonly string $to;
+
+	/**
+	 * `Flow::MODE_SYNC` or `Flow::MODE_ASYNC`, never any other spelling.
+	 *
+	 * @var string
+	 */
+	public readonly string $mode;
+
+	/**
+	 * Capture the decided move.
+	 *
+	 * @param string $action The transition's declared name.
+	 * @param string $from The lifecycle value the object holds now.
+	 * @param string $to The lifecycle value the move would reach.
+	 * @param string $mode The execution mode, one of the flow engine's two values.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function __construct(string $action, string $from, string $to, string $mode) {
+		$this->action = $action;
+		$this->from = $from;
+		$this->to = $to;
+		$this->mode = $mode;
+	}//end __construct()
+
+	/**
+	 * Whether this move is applied in the triggering request.
+	 *
+	 * The comparison lives here rather than at the call site so that only one
+	 * class needs to know the flow engine's spelling of the two modes. A caller
+	 * asks what kind of move this is; it does not need `Flow` to find out.
+	 *
+	 * @return boolean True for a sync move, false for a queued one.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function isSync(): bool {
+		return $this->mode === Flow::MODE_SYNC;
+	}//end isSync()
+}//end class

--- a/lib/Service/Lifecycle/AutoTransitionDecision.php
+++ b/lib/Service/Lifecycle/AutoTransitionDecision.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * OpenRegister AutoTransitionDecision
+ *
+ * One decided automatic move, bound to the object it was decided for and to
+ * the object's state at the moment of the decision.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Lifecycle
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Lifecycle;
+
+use DateTimeInterface;
+
+/**
+ * A candidate plus the object identity and version it was decided against.
+ *
+ * The version and `updated` stamp are what makes a QUEUED move safe: the job
+ * applies it only while they still match, because a newer write has made its
+ * own decision and this one is stale.
+ */
+final class AutoTransitionDecision {
+
+	/**
+	 * The object's uuid.
+	 *
+	 * @var string
+	 */
+	public readonly string $uuid;
+
+	/**
+	 * The object's register reference, as recorded off the event.
+	 *
+	 * @var string
+	 */
+	public readonly string $register;
+
+	/**
+	 * The object's schema reference, as recorded off the event.
+	 *
+	 * @var string
+	 */
+	public readonly string $schema;
+
+	/**
+	 * The schema's slug, for log lines.
+	 *
+	 * @var string
+	 */
+	public readonly string $schemaSlug;
+
+	/**
+	 * The move to make.
+	 *
+	 * @var AutoTransitionCandidate
+	 */
+	public readonly AutoTransitionCandidate $candidate;
+
+	/**
+	 * The object's version at decision time, or null when it carries none.
+	 *
+	 * @var string|null
+	 */
+	public readonly ?string $version;
+
+	/**
+	 * The object's `updated` stamp at decision time, ISO 8601, or null.
+	 *
+	 * @var string|null
+	 */
+	public readonly ?string $updated;
+
+	/**
+	 * Capture the decision.
+	 *
+	 * @param string $uuid The object's uuid.
+	 * @param string $register The object's register reference.
+	 * @param string $schema The object's schema reference.
+	 * @param string $schemaSlug The schema's slug.
+	 * @param AutoTransitionCandidate $candidate The move to make.
+	 * @param string|null $version The object's version at decision time.
+	 * @param mixed $updated The object's `updated` stamp at decision time, as the
+	 *                       entity holds it. Normalised here rather than by the
+	 *                       caller: this is the only class that stores the value,
+	 *                       so it is the only one that needs to know the entity
+	 *                       may hand back a date object, a string, or nothing.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function __construct(
+		string $uuid,
+		string $register,
+		string $schema,
+		string $schemaSlug,
+		AutoTransitionCandidate $candidate,
+		?string $version,
+		mixed $updated,
+	) {
+		if ($updated instanceof DateTimeInterface === true) {
+			$updated = $updated->format(DATE_ATOM);
+		}
+
+		if (is_string($updated) === false) {
+			$updated = null;
+		}
+
+		$this->uuid = $uuid;
+		$this->register = $register;
+		$this->schema = $schema;
+		$this->schemaSlug = $schemaSlug;
+		$this->candidate = $candidate;
+		$this->version = $version;
+		$this->updated = $updated;
+	}//end __construct()
+}//end class

--- a/lib/Service/Lifecycle/AutoTransitionPass.php
+++ b/lib/Service/Lifecycle/AutoTransitionPass.php
@@ -1,0 +1,511 @@
+<?php
+
+/**
+ * OpenRegister AutoTransitionPass
+ *
+ * The request-scoped pass: what one write and everything it triggers
+ * automatically amounts to, and the two limits that bound it.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Lifecycle
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Lifecycle;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Where an automatic move is applied, and how far one write may travel.
+ *
+ * WHY NOT IN THE LISTENER. `ObjectUpdatedEvent` fires in the MIDDLE of a save,
+ * not at its end: `SaveObject` still has the save's audit row to write, and on
+ * a file-bearing save it calls `MagicMapper::update()` a second time with its
+ * in-memory entity. A move applied inside that event would be written before
+ * the triggering save's audit row and overwritten by the second update, which
+ * carries the old lifecycle value. That is a lost update behind a transition
+ * event that has already fired. So the listener only RECORDS, and this class
+ * applies, at the outermost write boundary, where the triggering write is
+ * finished in every sense that matters.
+ *
+ * THE BOUNDARY. `ObjectService::saveObject()` and `TransitionEngine::
+ * transition()` each enter on the way in and leave in a `finally`. Leaving the
+ * outermost one drains. The drain is a LOOP, not recursion: firing a move
+ * re-records the object through its own update event, a draining flag stops
+ * the nested boundary exit from starting a nested drain, and the outer loop
+ * picks the re-recorded object up and decides the next step.
+ *
+ * THE TWO LIMITS, both per object per pass, following `SubFlowNode`'s shape:
+ *
+ * - NO REVISIT. A move into a state the object already occupied in this pass,
+ *   including the one it started in, is not made. A to B to A is cut at the
+ *   second move, deterministically, after exactly one write. A count-only cap
+ *   would let the object flip ten times, write ten audit rows, send ten rounds
+ *   of notifications, and stop on whichever state the parity of the ceiling
+ *   picked.
+ * - A CEILING OF 10. It only bites on a chain through more than ten distinct
+ *   states. It is a private constant and NOT configurable: a configurable cap
+ *   invites raising it to make a loop's symptom go away.
+ *
+ * A pass, rather than a request, is the unit deliberately. Within one request
+ * every write reachable from the triggering one is in the same pass, so it is
+ * at least as strict there; and the pass travels with a queued move, which a
+ * request-scoped counter cannot do. A counter that reset in every background
+ * job would let an async A to B, B to A loop run forever, one cron tick apart.
+ */
+class AutoTransitionPass {
+
+	/**
+	 * The most automatic moves one object may make in one pass.
+	 *
+	 * A constant, like `SubFlowNode::MAX_DEPTH`, and deliberately not a config
+	 * value; see the class docblock.
+	 *
+	 * @var integer
+	 */
+	private const MAX_MOVES = 10;
+
+	/**
+	 * How many write boundaries are currently open.
+	 *
+	 * @var integer
+	 */
+	private int $depth = 0;
+
+	/**
+	 * Whether a drain is in progress, so a nested exit does not start another.
+	 *
+	 * @var boolean
+	 */
+	private bool $draining = false;
+
+	/**
+	 * Objects written in this pass and not yet decided.
+	 *
+	 * @var array<string, array{register: string, schema: string, inside: bool}>
+	 */
+	private array $pending = [];
+
+	/**
+	 * The state each object was in before the write that started the pass.
+	 *
+	 * First capture wins, and it is kept for the whole pass: every step of one
+	 * object's chain reads the same `previous`, so an `autoWhen` comparing
+	 * against it means the same thing at every hop.
+	 *
+	 * @var array<string, array<string, mixed>>
+	 */
+	private array $previous = [];
+
+	/**
+	 * The chain each object has travelled in this pass.
+	 *
+	 * @var array<string, array{visited: array<string, bool>, moves: int, applied: list<string>}>
+	 */
+	private array $lineage = [];
+
+	/**
+	 * The automatic transition being applied right now, if any.
+	 *
+	 * An ambient frame rather than a parameter on `TransitionEngine::
+	 * transition()`, so no caller can claim a manual move was automatic.
+	 *
+	 * @var string|null
+	 */
+	private ?string $applying = null;
+
+	/**
+	 * Whether the end-of-request flush has been registered.
+	 *
+	 * @var boolean
+	 */
+	private bool $flushHooked = false;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param AutoTransitionRunner $runner Decides and applies one step of the pass.
+	 * @param LoggerInterface $logger Logs a cut at error level, with the chain it cut.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function __construct(
+		private readonly AutoTransitionRunner $runner,
+		private readonly LoggerInterface $logger,
+	) {
+	}//end __construct()
+
+	/**
+	 * Open a write boundary.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function enter(): void {
+		$this->depth++;
+	}//end enter()
+
+	/**
+	 * Close a write boundary, draining the pass when it was the outermost one.
+	 *
+	 * @return array<string, ObjectEntity> The last entity applied per object uuid, empty when nothing was.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function leave(): array {
+		if ($this->depth > 0) {
+			$this->depth--;
+		}
+
+		if ($this->depth > 0 || $this->draining === true) {
+			return [];
+		}
+
+		return $this->drain();
+	}//end leave()
+
+	/**
+	 * Whether a write boundary is currently open.
+	 *
+	 * @return bool True when a save or a transition is in flight.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function isInsideBoundary(): bool {
+		return $this->depth > 0;
+	}//end isInsideBoundary()
+
+	/**
+	 * Note that an object was written, so the pass will decide it.
+	 *
+	 * Recording is ALL that happens on the event. Nothing here evaluates a
+	 * rule and nothing here writes.
+	 *
+	 * @param string $uuid The object's uuid.
+	 * @param string $register The object's register reference.
+	 * @param string $schema The object's schema reference.
+	 * @param array<string, mixed> $previous The object as it was before this write.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function record(string $uuid, string $register, string $schema, array $previous): void {
+		if ($uuid === '') {
+			return;
+		}
+
+		if (array_key_exists($uuid, $this->previous) === false) {
+			// First capture wins: `previous` is the state before the write that
+			// STARTED the pass, not before the automatic move that last touched
+			// the object.
+			$this->previous[$uuid] = $previous;
+		}
+
+		$inside = $this->isInsideBoundary();
+		$this->pending[$uuid] = ['register' => $register, 'schema' => $schema, 'inside' => $inside];
+
+		if ($inside === false) {
+			$this->hookFlush();
+		}
+	}//end record()
+
+	/**
+	 * The automatic transition being applied right now, if any.
+	 *
+	 * Read by `TransitionEngine` when it dispatches `ObjectTransitionedEvent`
+	 * and by `AuditTrailMapper` when it builds the row, both of which need to
+	 * mark the move without being told so by a caller.
+	 *
+	 * @return string|null The transition's name, or null for a manual move.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function applyingAction(): ?string {
+		return $this->applying;
+	}//end applyingAction()
+
+	/**
+	 * Answer with the automatic move's entity when the pass made one.
+	 *
+	 * This is how the response of an object save and of a named transition
+	 * carries the new state without a controller change.
+	 *
+	 * @param ObjectEntity $saved The entity the write itself produced.
+	 * @param array<string, ObjectEntity> $applied What the drain applied, by uuid.
+	 *
+	 * @return ObjectEntity The object in its final state.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function preferAutomatic(ObjectEntity $saved, array $applied): ObjectEntity {
+		return ($applied[(string)$saved->getUuid()] ?? $saved);
+	}//end preferAutomatic()
+
+	/**
+	 * Continue a pass that was carried into a background job.
+	 *
+	 * @param string $uuid The object whose lineage is being restored.
+	 * @param int $moves How many automatic moves the pass had already made.
+	 * @param array<int, string> $visited The states the object has occupied in this pass.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function resume(string $uuid, int $moves, array $visited): void {
+		$flags = [];
+		foreach ($visited as $state) {
+			$flags[(string)$state] = true;
+		}
+
+		$this->lineage[$uuid] = ['visited' => $flags, 'moves' => max(0, $moves), 'applied' => []];
+	}//end resume()
+
+	/**
+	 * Decide and queue every move recorded outside a write boundary.
+	 *
+	 * A bulk save, a deferred create event, a revert and a direct mapper write
+	 * all dispatch post-save events with no `saveObject()` around them, so
+	 * there is no point at which a sync move could run after the write
+	 * completes and before a response. Their moves are queued whatever the
+	 * declared mode.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function flushOutsideBoundary(): void {
+		$queued = false;
+		foreach (array_keys($this->pending) as $uuid) {
+			$record = $this->pending[$uuid];
+			if ($record['inside'] === true) {
+				continue;
+			}
+
+			unset($this->pending[$uuid]);
+			$this->safeStep(uuid: $uuid, record: $record, queueOnly: true);
+			$queued = true;
+		}
+
+		if ($queued === true) {
+			$this->runner->flushQueued();
+		}
+	}//end flushOutsideBoundary()
+
+	/**
+	 * Apply every move this pass can still make, one object at a time.
+	 *
+	 * @return array<string, ObjectEntity> The last entity applied per object uuid.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	private function drain(): array {
+		$applied = [];
+		$this->draining = true;
+
+		try {
+			while (true) {
+				$uuid = $this->nextInside();
+				if ($uuid === null) {
+					break;
+				}
+
+				$record = $this->pending[$uuid];
+				unset($this->pending[$uuid]);
+
+				$entity = $this->safeStep(uuid: $uuid, record: $record, queueOnly: false);
+				if ($entity !== null) {
+					$applied[$uuid] = $entity;
+				}
+			}
+		} finally {
+			$this->draining = false;
+			$this->previous = [];
+			$this->lineage = [];
+		}//end try
+
+		return $applied;
+	}//end drain()
+
+	/**
+	 * The next object recorded inside a boundary, or null when there is none.
+	 *
+	 * @return string|null The object's uuid.
+	 */
+	private function nextInside(): ?string {
+		foreach ($this->pending as $uuid => $record) {
+			if ($record['inside'] === true) {
+				return (string)$uuid;
+			}
+		}
+
+		return null;
+	}//end nextInside()
+
+	/**
+	 * One step, with nothing it can raise reaching the caller.
+	 *
+	 * 🔴 THE DRAIN RUNS INSIDE A `finally`. An exception escaping here would
+	 * REPLACE the exception the triggering write was already raising, so a save
+	 * that failed for its own reason would be reported as an automatic-
+	 * transition failure and the real cause would be gone. The refusals a move
+	 * can meet are caught one layer down, in the runner, with their refusal
+	 * code; this is the backstop for everything else.
+	 *
+	 * @param string $uuid The object's uuid.
+	 * @param array{register: string, schema: string, inside: bool} $record What the listener recorded.
+	 * @param bool $queueOnly True for a move recorded outside any boundary.
+	 *
+	 * @return ObjectEntity|null The object after the move, or null.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	private function safeStep(string $uuid, array $record, bool $queueOnly): ?ObjectEntity {
+		try {
+			return $this->step(uuid: $uuid, record: $record, queueOnly: $queueOnly);
+		} catch (\Throwable $e) {
+			$this->logger->warning(
+				'[AutoTransitionPass] Deciding or applying an automatic transition failed; '
+				. 'the triggering write stands.',
+				['uuid' => $uuid, 'schema' => $record['schema'], 'error' => $e->getMessage()]
+			);
+			return null;
+		}
+	}//end safeStep()
+
+	/**
+	 * Decide one object's next move and take it, unless a limit says no.
+	 *
+	 * @param string $uuid The object's uuid.
+	 * @param array{register: string, schema: string, inside: bool} $record What the listener recorded.
+	 * @param bool $queueOnly True for a move recorded outside any boundary.
+	 *
+	 * @return ObjectEntity|null The object after the move, or null.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	private function step(string $uuid, array $record, bool $queueOnly): ?ObjectEntity {
+		$decision = $this->runner->decide(
+			uuid: $uuid,
+			register: $record['register'],
+			schema: $record['schema'],
+			previous: ($this->previous[$uuid] ?? [])
+		);
+		if ($decision === null) {
+			return null;
+		}
+
+		$candidate = $decision->candidate;
+		$this->seedLineage(uuid: $uuid, from: $candidate->from);
+		$lineage = $this->lineage[$uuid];
+
+		if (isset($lineage['visited'][$candidate->to]) === true) {
+			$this->cut(decision: $decision, lineage: $lineage, limit: 'revisit');
+			return null;
+		}
+
+		if ($lineage['moves'] >= self::MAX_MOVES) {
+			$this->cut(decision: $decision, lineage: $lineage, limit: 'ceiling');
+			return null;
+		}
+
+		$this->lineage[$uuid]['visited'][$candidate->to] = true;
+		$this->lineage[$uuid]['moves']++;
+		$this->lineage[$uuid]['applied'][] = $candidate->action;
+
+		$this->applying = $candidate->action;
+		try {
+			return $this->runner->fire(
+				decision: $decision,
+				lineage: $this->lineage[$uuid],
+				queueOnly: $queueOnly
+			);
+		} finally {
+			$this->applying = null;
+		}
+	}//end step()
+
+	/**
+	 * Start this object's lineage at the state it is in now.
+	 *
+	 * The starting state counts as visited, which is what makes A to B to A a
+	 * single move rather than a flip-flop bounded only by the ceiling.
+	 *
+	 * @param string $uuid The object's uuid.
+	 * @param string $from The state the object is in now.
+	 *
+	 * @return void
+	 */
+	private function seedLineage(string $uuid, string $from): void {
+		if (isset($this->lineage[$uuid]) === true) {
+			return;
+		}
+
+		$this->lineage[$uuid] = ['visited' => [$from => true], 'moves' => 0, 'applied' => []];
+	}//end seedLineage()
+
+	/**
+	 * Log a cut pass and make no move.
+	 *
+	 * Error level, not warning: a cut means a declaration loops, which is an
+	 * authoring defect that will keep costing writes until someone reads this.
+	 * It never throws, because the triggering write has already succeeded and
+	 * nothing about the cut is the caller's fault.
+	 *
+	 * @param AutoTransitionDecision $decision The move that was not made.
+	 * @param array{visited: array<string, bool>, moves: int, applied: list<string>} $lineage The chain so far.
+	 * @param string $limit Which limit was reached: `revisit` or `ceiling`.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	private function cut(AutoTransitionDecision $decision, array $lineage, string $limit): void {
+		$this->logger->error(
+			'[AutoTransitionPass] Automatic transitions were cut for this object; the declaration loops.',
+			[
+				'schema' => $decision->schemaSlug,
+				'uuid' => $decision->uuid,
+				'limit' => $limit,
+				'ceiling' => self::MAX_MOVES,
+				'refused' => $decision->candidate->action,
+				'to' => $decision->candidate->to,
+				'applied' => $lineage['applied'],
+				'visited' => array_keys($lineage['visited']),
+			]
+		);
+	}//end cut()
+
+	/**
+	 * Register the end-of-request flush exactly once.
+	 *
+	 * @return void
+	 */
+	private function hookFlush(): void {
+		if ($this->flushHooked === true) {
+			return;
+		}
+
+		$this->flushHooked = true;
+		register_shutdown_function(
+			function (): void {
+				$this->flushOutsideBoundary();
+			}
+		);
+	}//end hookFlush()
+}//end class

--- a/lib/Service/Lifecycle/AutoTransitionQueue.php
+++ b/lib/Service/Lifecycle/AutoTransitionQueue.php
@@ -118,7 +118,7 @@ class AutoTransitionQueue {
 				'version' => $decision->version,
 				'updated' => $decision->updated,
 				'moves' => (int)($lineage['moves'] ?? 0),
-				'visited' => array_values(array_keys(($lineage['visited'] ?? []))),
+				'visited' => array_keys(($lineage['visited'] ?? [])),
 			],
 			chunkSize: self::CHUNK_SIZE,
 			dedupeKey: $decision->uuid . '|' . ((string)$decision->version)

--- a/lib/Service/Lifecycle/AutoTransitionQueue.php
+++ b/lib/Service/Lifecycle/AutoTransitionQueue.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * OpenRegister AutoTransitionQueue
+ *
+ * Decides whether an automatic move runs in the request or off it, and queues
+ * the ones that run off it.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Lifecycle
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Lifecycle;
+
+use OCA\OpenRegister\BackgroundJob\AutoTransitionJob;
+use OCA\OpenRegister\Service\Deferral\ListenerDeferralService;
+use Psr\Log\LoggerInterface;
+
+/**
+ * The off-request half of applying an automatic move.
+ *
+ * Split from {@see AutoTransitionRunner}, which decides WHICH move an object is
+ * eligible for and applies the ones that run inline. Everything about the job
+ * list lives here: the job class, the entry shape, the dedupe key and the chunk
+ * size. The runner therefore needs to know none of it.
+ */
+class AutoTransitionQueue {
+
+	/**
+	 * Entries per queued job.
+	 *
+	 * `JobList::add()` refuses a JSON argument longer than 4000 characters. An
+	 * entry here carries a uuid, two references, an action, a version, a
+	 * timestamp and the pass lineage, which is a few hundred bytes; ten of them
+	 * with the context envelope stay well inside the cap.
+	 *
+	 * @var integer
+	 */
+	public const CHUNK_SIZE = 10;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param ListenerDeferralService $deferral Queues an async move under the triggering identity.
+	 * @param LoggerInterface $logger Records that a move was queued rather than applied.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function __construct(
+		private readonly ListenerDeferralService $deferral,
+		private readonly LoggerInterface $logger,
+	) {
+	}//end __construct()
+
+	/**
+	 * Whether this move runs in the request rather than in a job.
+	 *
+	 * @param AutoTransitionCandidate $candidate The decided move.
+	 * @param boolean $queueOnly True for a move decided outside any write boundary.
+	 *
+	 * @return boolean True when the move is applied here and now.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function appliesInline(AutoTransitionCandidate $candidate, bool $queueOnly): bool {
+		if ($queueOnly === true) {
+			// There is no point after this write and before a response at which
+			// a sync move could run, so the declared mode does not apply.
+			return false;
+		}
+
+		if ($candidate->isSync() === true) {
+			return true;
+		}
+
+		// The listener-deferral kill switch restores synchronous behaviour for
+		// deferred work generally; an async move decided inside a boundary
+		// follows it, exactly as the existing deferred listeners do.
+		return $this->deferral->isDeferralEnabled() === false;
+	}//end appliesInline()
+
+	/**
+	 * Queue the decided move as an actor-forwarded job entry.
+	 *
+	 * Deduped on uuid PLUS version, not uuid alone: the deferral buffer keeps
+	 * the FIRST entry per key, so deduping on the uuid would keep a stale
+	 * decision and drop the current one.
+	 *
+	 * @param AutoTransitionDecision $decision The decided move.
+	 * @param array<string, mixed> $lineage The pass lineage to carry.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function queue(AutoTransitionDecision $decision, array $lineage): void {
+		$this->deferral->defer(
+			jobClass: AutoTransitionJob::class,
+			entry: [
+				'uuid' => $decision->uuid,
+				'register' => $decision->register,
+				'schema' => $decision->schema,
+				'action' => $decision->candidate->action,
+				'to' => $decision->candidate->to,
+				'version' => $decision->version,
+				'updated' => $decision->updated,
+				'moves' => (int)($lineage['moves'] ?? 0),
+				'visited' => array_values(array_keys(($lineage['visited'] ?? []))),
+			],
+			chunkSize: self::CHUNK_SIZE,
+			dedupeKey: $decision->uuid . '|' . ((string)$decision->version)
+		);
+
+		$this->logger->debug(
+			'[AutoTransitionQueue] Automatic transition queued for off-request application.',
+			[
+				'schema' => $decision->schemaSlug,
+				'uuid' => $decision->uuid,
+				'action' => $decision->candidate->action,
+				'mode' => $decision->candidate->mode,
+			]
+		);
+	}//end queue()
+
+	/**
+	 * Flush every queued move to the job list now.
+	 *
+	 * Called by the pass's own end-of-request flush. The deferral service
+	 * registers its shutdown handler on its first `defer()` of the request,
+	 * which may already have run by the time the pass flushes, so the pass
+	 * asks for the flush rather than trusting handler ordering.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function flushQueued(): void {
+		$this->deferral->flushAll();
+	}//end flushQueued()
+}//end class

--- a/lib/Service/Lifecycle/AutoTransitionRunner.php
+++ b/lib/Service/Lifecycle/AutoTransitionRunner.php
@@ -1,0 +1,264 @@
+<?php
+
+/**
+ * OpenRegister AutoTransitionRunner
+ *
+ * Decides one object's automatic move against the stored object, and either
+ * fires it through the named-transition engine or queues it.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Lifecycle
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Lifecycle;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Exception\HookStoppedException;
+use OCA\OpenRegister\Service\Deferral\DeferredEntryObjectResolver;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * The work of one step of a pass: decide, then fire or queue.
+ *
+ * Split from {@see AutoTransitionPass}, which owns the request-scoped state
+ * (the boundary counter, what has been recorded, the cap's lineage). The pass
+ * decides WHETHER a step may be taken; this class knows HOW to take one.
+ *
+ * LAZY RESOLUTION IS DELIBERATE. `ObjectService` and `TransitionEngine` both
+ * open the pass boundary, so they depend on the pass, which depends on this
+ * class. Naming either of them as a constructor parameter would make the
+ * container recurse while building `ObjectService`. They are resolved from the
+ * container at the moment a move is actually made, which is always inside a
+ * request that has already built them.
+ */
+class AutoTransitionRunner {
+
+
+	/**
+	 * Constructor.
+	 *
+	 * @param ContainerInterface $container Resolves ObjectService and TransitionEngine lazily; see the class docblock.
+	 * @param SchemaMapper $schemaMapper Reads the schema's lifecycle annotation.
+	 * @param AutoTransitionSelector $selector Picks the one eligible move, or none.
+	 * @param AutoTransitionQueue $queue Decides inline versus queued, and owns the job list.
+	 * @param LoggerInterface $logger Logs every refusal, so a move that never happens is visible.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function __construct(
+		private readonly ContainerInterface $container,
+		private readonly SchemaMapper $schemaMapper,
+		private readonly AutoTransitionSelector $selector,
+		private readonly AutoTransitionQueue $queue,
+		private readonly LoggerInterface $logger,
+	) {
+	}//end __construct()
+
+	/**
+	 * The move this object is eligible for right now, or null.
+	 *
+	 * Decided against the object AS STORED, not against the event payload:
+	 * computed fields, defaults and file ids are all present by then, and the
+	 * two update events of a file-bearing save collapse into one decision.
+	 *
+	 * @param string $uuid The object's uuid.
+	 * @param string $register The object's register reference.
+	 * @param string $schema The object's schema reference.
+	 * @param array<string, mixed> $previous The object before the triggering write.
+	 *
+	 * @return AutoTransitionDecision|null The decided move, or null.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function decide(string $uuid, string $register, string $schema, array $previous): ?AutoTransitionDecision {
+		$object = $this->resolveObject(uuid: $uuid, register: $register, schema: $schema);
+		if ($object === null) {
+			return null;
+		}
+
+		$declaration = $this->annotationFor(schema: $schema);
+		if ($declaration === null) {
+			return null;
+		}
+
+		[$annotation, $slug] = $declaration;
+
+		$candidate = $this->selector->select(
+			annotation: $annotation,
+			objectData: ($object->getObject() ?? []),
+			previous: $previous,
+			schemaSlug: $slug
+		);
+		if ($candidate === null) {
+			return null;
+		}
+
+		return new AutoTransitionDecision(
+			uuid: $uuid,
+			register: $register,
+			schema: $schema,
+			schemaSlug: $slug,
+			candidate: $candidate,
+			version: $object->getVersion(),
+			updated: $object->getUpdated()
+		);
+	}//end decide()
+
+	/**
+	 * Apply the decided move, or queue it, and never let it reach the caller.
+	 *
+	 * A refusal by any gate a manual transition meets is caught here and logged
+	 * at warning, carrying the refusal code where the exception has one. The
+	 * write that triggered this has already succeeded and nothing about the
+	 * refusal is the caller's fault, so it is not retried and not surfaced.
+	 *
+	 * @param AutoTransitionDecision $decision The decided move.
+	 * @param array<string, mixed> $lineage The pass lineage to carry into a queued move.
+	 * @param bool $queueOnly True for a move decided outside any write boundary.
+	 *
+	 * @return ObjectEntity|null The object after the move, or null when it was queued or refused.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function fire(AutoTransitionDecision $decision, array $lineage, bool $queueOnly): ?ObjectEntity {
+		if ($this->queue->appliesInline(candidate: $decision->candidate, queueOnly: $queueOnly) === false) {
+			$this->queue->queue(decision: $decision, lineage: $lineage);
+			return null;
+		}
+
+		try {
+			return $this->engine()->transition(
+				objectId: $decision->uuid,
+				action: $decision->candidate->action
+			);
+		} catch (Throwable $e) {
+			$this->logger->warning(
+				'[AutoTransitionRunner] An automatic transition was refused; the triggering write stands.',
+				[
+					'schema' => $decision->schemaSlug,
+					'uuid' => $decision->uuid,
+					'action' => $decision->candidate->action,
+					'from' => $decision->candidate->from,
+					'to' => $decision->candidate->to,
+					'refusalCode' => $this->refusalCodeOf(error: $e),
+					'error' => $e->getMessage(),
+				]
+			);
+			return null;
+		}//end try
+	}//end fire()
+
+
+
+
+	/**
+	 * The refusal code an exception carries, when it carries one.
+	 *
+	 * @param Throwable $error The exception raised while applying the move.
+	 *
+	 * @return string|null The lifecycle refusal code, or null.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	private function refusalCodeOf(Throwable $error): ?string {
+		if ($error instanceof HookStoppedException === false) {
+			return null;
+		}
+
+		$code = ($error->getErrors()['code'] ?? null);
+		if (is_string($code) === true && $code !== '') {
+			return $code;
+		}
+
+		return null;
+	}//end refusalCodeOf()
+
+	/**
+	 * Re-read the object as stored, or null when it is gone or soft-deleted.
+	 *
+	 * @param string $uuid The object's uuid.
+	 * @param string $register The object's register reference.
+	 * @param string $schema The object's schema reference.
+	 *
+	 * @return ObjectEntity|null The stored object, or null.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	private function resolveObject(string $uuid, string $register, string $schema): ?ObjectEntity {
+		try {
+			$resolver = $this->container->get(DeferredEntryObjectResolver::class);
+			return $resolver->resolve(entry: ['uuid' => $uuid, 'register' => $register, 'schema' => $schema]);
+		} catch (Throwable $e) {
+			$this->logger->warning(
+				'[AutoTransitionRunner] Could not re-read the object to decide an automatic transition.',
+				['uuid' => $uuid, 'schema' => $schema, 'error' => $e->getMessage()]
+			);
+			return null;
+		}
+	}//end resolveObject()
+
+	/**
+	 * The schema's lifecycle annotation and the schema's slug.
+	 *
+	 * @param string $schema The object's schema reference.
+	 *
+	 * @return array{0: array<string, mixed>, 1: string}|null The annotation and slug, or null when there is none.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	private function annotationFor(string $schema): ?array {
+		try {
+			$entity = $this->schemaMapper->find($schema, _multitenancy: false);
+		} catch (Throwable $e) {
+			return null;
+		}
+
+		$annotation = (($entity->getConfiguration() ?? [])['x-openregister-lifecycle'] ?? null);
+		if (is_array($annotation) === false || $annotation === []) {
+			return null;
+		}
+
+		return [$annotation, (string)($entity->getSlug() ?? '')];
+	}//end annotationFor()
+
+	/**
+	 * The named-transition engine, resolved at the moment a move is made.
+	 *
+	 * @return TransitionEngine The engine every automatic move goes through.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	private function engine(): TransitionEngine {
+		return $this->container->get(TransitionEngine::class);
+	}//end engine()
+
+	/**
+	 * Flush every queued move to the job list now.
+	 *
+	 * Delegated to {@see AutoTransitionQueue}, which owns the job list. It stays
+	 * on this class because the pass drives one collaborator, not two.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function flushQueued(): void {
+		$this->queue->flushQueued();
+	}//end flushQueued()
+}//end class

--- a/lib/Service/Lifecycle/AutoTransitionSelector.php
+++ b/lib/Service/Lifecycle/AutoTransitionSelector.php
@@ -1,0 +1,342 @@
+<?php
+
+/**
+ * OpenRegister AutoTransitionSelector
+ *
+ * Picks the one automatic transition a stored object is eligible for, or none.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Lifecycle
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Lifecycle;
+
+use OCA\OpenRegister\Db\Flow;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Selection, and only selection: which automatic transition may fire.
+ *
+ * This class decides WHICH transition is eligible; evaluating whether a rule
+ * holds belongs to {@see LifecycleConditionEvaluator::holds()} and is never
+ * done here. A second JSONLogic path is exactly where the scalar guard and the
+ * fail-closed `isTrue()` call would drift apart, so the split is the point.
+ *
+ * Three ways selection answers "none" even though a rule holds, each fail-safe
+ * and each logged:
+ *
+ * - AMBIGUITY. Two rules holding from the same state fire nothing. Declaration
+ *   order is the order of keys in a stored JSON object, which MySQL's native
+ *   JSON type does not preserve and PostgreSQL's `json` does, so "first wins"
+ *   would pick differently per installation.
+ * - SHADOWING. A transition sharing its from and to pair with an earlier
+ *   declared one does not fire automatically. The save path can identify a
+ *   transition by those values, so firing it risks enforcing the twin's gates
+ *   and running the twin's actions rather than this transition's.
+ * - AN UNRECOGNISED `executionMode`. Compared against the flow engine's two
+ *   constants exactly, never lowercased, so the lifecycle and the flow engine
+ *   cannot drift into two spellings of the same two words.
+ */
+class AutoTransitionSelector {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param LifecycleConditionEvaluator $evaluator The one place a lifecycle rule is evaluated.
+	 * @param LoggerInterface $logger Logs every refusal to select, so a silent no-move is diagnosable.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function __construct(
+		private readonly LifecycleConditionEvaluator $evaluator,
+		private readonly LoggerInterface $logger,
+	) {
+	}//end __construct()
+
+	/**
+	 * The automatic transition this object is eligible for, or null.
+	 *
+	 * @param array<string, mixed> $annotation The schema's x-openregister-lifecycle block.
+	 * @param array<string, mixed> $objectData The object as stored, after the triggering write.
+	 * @param array<string, mixed> $previous The object as it was before the triggering write.
+	 * @param string $schemaSlug The schema's slug, for the log lines.
+	 *
+	 * @return AutoTransitionCandidate|null The one eligible move, or null.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function select(
+		array $annotation,
+		array $objectData,
+		array $previous,
+		string $schemaSlug,
+	): ?AutoTransitionCandidate {
+		$field = (string)($annotation['field'] ?? ($annotation['property'] ?? ''));
+		$transitions = ($annotation['transitions'] ?? []);
+		if ($field === '' || is_array($transitions) === false || $transitions === []) {
+			return null;
+		}
+
+		$current = (string)($objectData[$field] ?? '');
+		if ($current === '') {
+			return null;
+		}
+
+		$holding = $this->holdingTransitions(
+			transitions: $transitions,
+			objectData: $objectData,
+			previous: $previous,
+			current: $current,
+			schemaSlug: $schemaSlug,
+			field: $field
+		);
+
+		if ($holding === []) {
+			return null;
+		}
+
+		if (count($holding) > 1) {
+			$this->logger->warning(
+				'[AutoTransitionSelector] More than one automatic transition holds from this state; '
+				. 'firing none. Declaration order is not a tie-breaker, because it is not preserved by '
+				. 'every database Nextcloud supports.',
+				[
+					'schema' => $schemaSlug,
+					'field' => $field,
+					'from' => $current,
+					'candidates' => array_column($holding, 'action'),
+				]
+			);
+			return null;
+		}
+
+		$candidate = $holding[0];
+		$mode = $this->modeOf(spec: $candidate['spec'], action: $candidate['action'], schemaSlug: $schemaSlug);
+		if ($mode === null) {
+			return null;
+		}
+
+		if (
+			$this->shadowOf(
+				transitions: $transitions,
+				candidate: $candidate,
+				current: $current,
+				schemaSlug: $schemaSlug
+			) !== null
+		) {
+			return null;
+		}
+
+		return new AutoTransitionCandidate(
+			action: $candidate['action'],
+			from: $current,
+			to: $candidate['to'],
+			mode: $mode
+		);
+	}//end select()
+
+	/**
+	 * Whether the schema's annotation declares any `autoWhen` at all.
+	 *
+	 * The recording listener asks this on every write, so it is a shape read
+	 * over the annotation and never an evaluation.
+	 *
+	 * @param array<string, mixed> $annotation The schema's x-openregister-lifecycle block.
+	 *
+	 * @return bool True when at least one transition declares `autoWhen`.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function declaresAutoWhen(array $annotation): bool {
+		$transitions = ($annotation['transitions'] ?? []);
+		if (is_array($transitions) === false) {
+			return false;
+		}
+
+		foreach ($transitions as $spec) {
+			if (is_array($spec) === true && array_key_exists('autoWhen', $spec) === true) {
+				return true;
+			}
+		}
+
+		return false;
+	}//end declaresAutoWhen()
+
+	/**
+	 * Every declared transition whose `autoWhen` holds from the current state.
+	 *
+	 * A transition whose `to` equals the current value is skipped before its
+	 * rule is read: the move would change nothing and would be re-decided on
+	 * every write.
+	 *
+	 * @param array<string, mixed> $transitions The annotation's transition map.
+	 * @param array<string, mixed> $objectData The object as stored.
+	 * @param array<string, mixed> $previous The object before the triggering write.
+	 * @param string $current The object's current lifecycle value.
+	 * @param string $schemaSlug The schema's slug, for the log lines.
+	 * @param string $field The lifecycle field's name.
+	 *
+	 * @return list<array{action: string, to: string, index: int, spec: array<string, mixed>}>
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	private function holdingTransitions(
+		array $transitions,
+		array $objectData,
+		array $previous,
+		string $current,
+		string $schemaSlug,
+		string $field,
+	): array {
+		$holding = [];
+		$index = -1;
+
+		foreach ($transitions as $action => $spec) {
+			$index++;
+			if (is_array($spec) === false || array_key_exists('autoWhen', $spec) === false) {
+				continue;
+			}
+
+			$to = (string)($spec['to'] ?? '');
+			if ($to === '' || $to === $current || $this->fromContains(spec: $spec, value: $current) === false) {
+				continue;
+			}
+
+			$holds = $this->evaluator->holds(
+				rule: $spec['autoWhen'],
+				newData: $objectData,
+				oldData: $previous,
+				action: (string)$action,
+				from: $current,
+				to: $to,
+				schemaSlug: $schemaSlug,
+				field: $field
+			);
+			if ($holds === false) {
+				continue;
+			}
+
+			$holding[] = [
+				'action' => (string)$action,
+				'to' => $to,
+				'index' => $index,
+				'spec' => $spec,
+			];
+		}//end foreach
+
+		return $holding;
+	}//end holdingTransitions()
+
+	/**
+	 * The candidate's execution mode, or null when it is not one of the two.
+	 *
+	 * @param array<string, mixed> $spec The candidate transition's spec.
+	 * @param string $action The candidate transition's name.
+	 * @param string $schemaSlug The schema's slug, for the log line.
+	 *
+	 * @return string|null `Flow::MODE_SYNC`, `Flow::MODE_ASYNC`, or null.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	private function modeOf(array $spec, string $action, string $schemaSlug): ?string {
+		$mode = ($spec['executionMode'] ?? Flow::MODE_SYNC);
+		if (in_array($mode, [Flow::MODE_SYNC, Flow::MODE_ASYNC], true) === true) {
+			return (string)$mode;
+		}
+
+		$this->logger->warning(
+			'[AutoTransitionSelector] Automatic transition declares an unrecognised executionMode; '
+			. 'not firing it. Use exactly "sync" or "async".',
+			['schema' => $schemaSlug, 'action' => $action, 'executionMode' => $spec['executionMode']]
+		);
+
+		return null;
+	}//end modeOf()
+
+	/**
+	 * The name of an earlier-declared transition shadowing the candidate.
+	 *
+	 * @param array<string, mixed> $transitions The annotation's transition map.
+	 * @param array{action: string, to: string, index: int, spec: array<string, mixed>} $candidate The selected move.
+	 * @param string $current The object's current lifecycle value.
+	 * @param string $schemaSlug The schema's slug, for the log line.
+	 *
+	 * @return string|null The shadowing transition's name, or null when there is none.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	private function shadowOf(
+		array $transitions,
+		array $candidate,
+		string $current,
+		string $schemaSlug,
+	): ?string {
+		$index = -1;
+		foreach ($transitions as $action => $spec) {
+			$index++;
+			if ($index >= $candidate['index'] || is_array($spec) === false) {
+				continue;
+			}
+
+			if (
+				(string)($spec['to'] ?? '') !== $candidate['to']
+				|| $this->fromContains(spec: $spec, value: $current) === false
+			) {
+				continue;
+			}
+
+			$this->logger->warning(
+				'[AutoTransitionSelector] An earlier-declared transition shares this move\'s from and to '
+				. 'pair, so the save path could enforce its gates and run its actions instead; '
+				. 'not firing automatically.',
+				[
+					'schema' => $schemaSlug,
+					'action' => $candidate['action'],
+					'shadowedBy' => (string)$action,
+					'from' => $current,
+					'to' => $candidate['to'],
+				]
+			);
+
+			return (string)$action;
+		}//end foreach
+
+		return null;
+	}//end shadowOf()
+
+	/**
+	 * Whether a transition's `from` covers a lifecycle value.
+	 *
+	 * `from` may be a single state or a list; a string is read as a one-element
+	 * list so both authoring shapes work, exactly as
+	 * {@see LifecycleTransitionResolver::moves()} reads it.
+	 *
+	 * @param array<string, mixed> $spec The transition's spec.
+	 * @param string $value The lifecycle value to look for.
+	 *
+	 * @return bool True when the transition can be taken from that value.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	private function fromContains(array $spec, string $value): bool {
+		$from = ($spec['from'] ?? []);
+		if (is_string($from) === true) {
+			$from = [$from];
+		}
+
+		return is_array($from) === true && in_array($value, $from, true) === true;
+	}//end fromContains()
+}//end class

--- a/lib/Service/Lifecycle/LifecycleAnnotationValidator.php
+++ b/lib/Service/Lifecycle/LifecycleAnnotationValidator.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Service\Lifecycle;
 
+use OCA\OpenRegister\Db\Flow;
 use OCA\OpenRegister\Service\Flow\FlowExpression;
 
 /**
@@ -51,6 +52,7 @@ final class LifecycleAnnotationValidator {
 	 * @spec openspec/specs/object-lifecycle/spec.md
 	 * @spec openspec/changes/fk-graph-lifecycle-transitions/specs/object-lifecycle/spec.md
 	 * @spec openspec/changes/lifecycle-declarative-conditions/specs/object-lifecycle/spec.md
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
 	 */
 	public function validate(array $schema): array {
 		if (isset($schema['x-openregister-lifecycle']) === false) {
@@ -260,6 +262,15 @@ final class LifecycleAnnotationValidator {
 				}
 			}
 
+			// Optional `autoWhen` / `executionMode` — the declaration that makes
+			// this transition fire on its own. Refused rather than warned about,
+			// because a stored malformed rule fires on EVERY write from its
+			// `from` state; see the change's design.md.
+			$errors = array_merge(
+				$errors,
+				$this->validateAutomaticTransition(spec: $spec, action: (string)$action)
+			);
+
 			// Optional `message` — the refusal text a declined `condition`
 			// carries. A non-empty string, or a per-locale map.
 			if (isset($spec['message']) === true) {
@@ -295,6 +306,7 @@ final class LifecycleAnnotationValidator {
 	 *
 	 * @spec openspec/changes/fk-graph-lifecycle-transitions/specs/object-lifecycle/spec.md
 	 * @spec openspec/changes/lifecycle-declarative-conditions/specs/object-lifecycle/spec.md
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
 	 */
 	private function validateGraphMode(array $annotation, array $schema): array {
 		$errors = [];
@@ -356,6 +368,22 @@ final class LifecycleAnnotationValidator {
 				'message' => 'x-openregister-lifecycle.graph does not support `condition`: '
 					. 'graph-mode moves are not enforced on the save path, so a condition '
 					. 'declared here would not hold. Declare conditions on static transitions.',
+			];
+		}
+
+		// An `autoWhen` on the graph block is REFUSED for the reason its
+		// `condition` sibling above is: a graph block declares no transitions,
+		// so the ordinary save path enforces nothing on a graph-mode move, and
+		// an automatic move made through the engine could be undone by one
+		// unchecked direct write. A graph block also has no per-transition
+		// object in which an author could say which derived sibling to move to.
+		// Unblocked by `lifecycle-graph-enforcement`.
+		if (isset($graph['autoWhen']) === true) {
+			$errors[] = [
+				'code' => 'lifecycle-autowhen-graph-unsupported',
+				'message' => 'x-openregister-lifecycle.graph does not support `autoWhen`: '
+					. 'graph-mode automatic transitions are not supported while graph-mode '
+					. 'moves are unenforced on the save path. Declare `autoWhen` on a static transition.',
 			];
 		}
 
@@ -522,6 +550,162 @@ final class LifecycleAnnotationValidator {
 
 		return null;
 	}//end validateTransitionCondition()
+
+	/**
+	 * Shape-check a transition's optional `autoWhen` and `executionMode`.
+	 *
+	 * All four codes this method can return REFUSE the schema save rather than
+	 * warn, which is a departure from the advisory treatment most lifecycle
+	 * errors get. The reason is the direction each failure takes:
+	 *
+	 * - a stored scalar `autoWhen` evaluates as a truthy literal, so the
+	 *   transition would fire on every write from its `from` state, writing an
+	 *   audit row and a round of notifications each time;
+	 * - an unknown `executionMode`, a required input beside `autoWhen` and an
+	 *   `autoWhen` on a graph block all describe a move that can NEVER happen,
+	 *   which is the silent no-op class the declarative-conditions link refused.
+	 *
+	 * Refusing breaks no existing import: no register can carry either key
+	 * before this change ships them.
+	 *
+	 * @param array<string, mixed> $spec The transition's spec.
+	 * @param string $action The transition name, for the error messages.
+	 *
+	 * @return array<int, array{code: string, message: string}> Errors (empty = valid).
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	private function validateAutomaticTransition(array $spec, string $action): array {
+		$errors = [];
+
+		if (array_key_exists('autoWhen', $spec) === true) {
+			$ruleError = $this->validateAutoWhenRule(autoWhen: $spec['autoWhen'], action: $action);
+			if ($ruleError !== null) {
+				$errors[] = $ruleError;
+			}
+
+			if ($this->declaresRequiredInput(inputs: ($spec['inputs'] ?? [])) === true) {
+				$errors[] = [
+					'code' => 'lifecycle-autowhen-requires-input',
+					'message' => sprintf(
+						'Transition "%s" declares `autoWhen` beside a required `inputs` entry. '
+						. 'An automatic move carries no payload, so this transition could only ever '
+						. 'be refused. Drop `required: true`, or drop `autoWhen`.',
+						$action
+					),
+				];
+			}
+		}
+
+		if (array_key_exists('executionMode', $spec) === true
+			&& in_array($spec['executionMode'], [Flow::MODE_SYNC, Flow::MODE_ASYNC], true) === false
+		) {
+			$shown = gettype($spec['executionMode']);
+			if (is_scalar($spec['executionMode']) === true) {
+				$shown = (string)$spec['executionMode'];
+			}
+
+			$errors[] = [
+				'code' => 'lifecycle-execution-mode-malformed',
+				'message' => sprintf(
+					'Transition "%s" `executionMode` "%s" must be exactly "%s" or "%s". '
+					. 'Case variants are refused rather than normalised, so the lifecycle and the '
+					. 'flow engine cannot drift into two spellings of the same two words.',
+					$action,
+					$shown,
+					Flow::MODE_SYNC,
+					Flow::MODE_ASYNC
+				),
+			];
+		}
+
+		return $errors;
+	}//end validateAutomaticTransition()
+
+	/**
+	 * Shape-check the rule object of a transition's `autoWhen`.
+	 *
+	 * 🔴 A SCALAR IS REFUSED, AND THAT IS THE POINT OF THIS METHOD, for the
+	 * same reason {@see validateTransitionCondition()} refuses one: a scalar
+	 * handed to `FlowExpression::isValid()` is a literal and always valid. Here
+	 * a truthy literal does not merely fail open once, it fires the transition
+	 * again on every write.
+	 *
+	 * @param mixed $autoWhen Raw value of the transition's `autoWhen` key.
+	 * @param string $action The transition name, for the error message.
+	 *
+	 * @return array{code: string, message: string}|null Error, or null when well-formed.
+	 *
+	 * @SuppressWarnings(PHPMD.StaticAccess) FlowExpression is the engine's
+	 * stateless expression facade; calling it statically IS the reuse.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	private function validateAutoWhenRule(mixed $autoWhen, string $action): ?array {
+		$code = 'lifecycle-autowhen-malformed';
+
+		if (is_array($autoWhen) === false) {
+			return [
+				'code' => $code,
+				'message' => sprintf(
+					'Transition "%s" `autoWhen` must be a JSONLogic rule object such as '
+					. '{"!!": {"var": "object.motivering"}}. A string or other scalar is refused: '
+					. 'it would evaluate as a literal and fire the transition on every write from '
+					. 'its `from` state. The "@self.field == \'value\'" form belongs on an '
+					. '`actions[]` entry, not here.',
+					$action
+				),
+			];
+		}
+
+		if ($autoWhen === []) {
+			return [
+				'code' => $code,
+				'message' => sprintf('Transition "%s" `autoWhen` must not be empty.', $action),
+			];
+		}
+
+		if (FlowExpression::isValid(logic: $autoWhen) === false) {
+			return [
+				'code' => $code,
+				'message' => sprintf(
+					'Transition "%s" `autoWhen` is not a valid JSONLogic expression. '
+					. 'Write it as a rule object, for example {"!!": {"var": "object.motivering"}}.',
+					$action
+				),
+			];
+		}
+
+		return null;
+	}//end validateAutoWhenRule()
+
+	/**
+	 * Whether a transition's `inputs` declaration carries a required entry.
+	 *
+	 * Malformed entries are skipped rather than fatal, matching
+	 * {@see TransitionEngine::normaliseDeclaredInputs()}: a broken declaration
+	 * allowlists nothing, and reporting it is that method's `inputs` contract,
+	 * not this one's.
+	 *
+	 * @param mixed $inputs The transition's declared `inputs` list.
+	 *
+	 * @return bool True when at least one declared input is `required`.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	private function declaresRequiredInput(mixed $inputs): bool {
+		if (is_array($inputs) === false) {
+			return false;
+		}
+
+		foreach ($inputs as $input) {
+			if (is_array($input) === true && ($input['required'] ?? false) === true) {
+				return true;
+			}
+		}
+
+		return false;
+	}//end declaresRequiredInput()
 
 	/**
 	 * Shape-check a transition's optional refusal `message`.

--- a/lib/Service/Lifecycle/LifecycleConditionEvaluator.php
+++ b/lib/Service/Lifecycle/LifecycleConditionEvaluator.php
@@ -48,8 +48,13 @@ use Psr\Log\LoggerInterface;
  *   SchemaMapper stores most invalid lifecycle annotations with only a warning,
  *   and handed to FlowExpression a scalar evaluates as a truthy literal, which
  *   would authorise every transition the condition was written to block.
+ *
+ * Not `final`, and only so that {@see AutoTransitionSelector}'s tests can hand
+ * it a double and prove the selector evaluates no JSONLogic of its own. It is
+ * not designed for subclassing in production: there is meant to be exactly one
+ * implementation of {@see holds()}, which is the whole point of the class.
  */
-final class LifecycleConditionEvaluator {
+class LifecycleConditionEvaluator {
 
 	/**
 	 * The code every condition refusal carries, malformed or merely unmet.
@@ -92,10 +97,8 @@ final class LifecycleConditionEvaluator {
 	 *
 	 * @return array{code: string, field: string, action: string, message: string}|null
 	 *
-	 * @SuppressWarnings(PHPMD.StaticAccess) FlowExpression is the engine's
-	 * stateless expression facade; calling it statically IS the reuse.
-	 *
 	 * @spec openspec/changes/lifecycle-declarative-conditions/specs/object-lifecycle/spec.md
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
 	 */
 	public function refusal(
 		array $spec,
@@ -112,33 +115,103 @@ final class LifecycleConditionEvaluator {
 		}
 
 		$condition = $spec['condition'];
-		$context = ['schema' => $schemaSlug, 'action' => $action, 'field' => $field];
 
-		if (is_array($condition) === false || $condition === []) {
-			// A fault in the schema, not the rule working, hence a warning.
-			$this->logger->warning(
-				'[LifecycleConditionEvaluator] Transition condition is not a JSONLogic rule object; refusing.',
-				$context
-			);
-			return $this->refusalFor(spec: $spec, action: $action, field: $field);
-		}
-
-		$holds = FlowExpression::isTrue(
-			logic: $condition,
-			data: $this->document(newData: $newData, oldData: $oldData, action: $action, from: $from, to: $to)
-		);
-		if ($holds === true) {
+		if (
+			$this->holds(
+				rule: $condition,
+				newData: $newData,
+				oldData: $oldData,
+				action: $action,
+				from: $from,
+				to: $to,
+				schemaSlug: $schemaSlug,
+				field: $field
+			) === true
+		) {
 			return null;
 		}
 
-		// Debug rather than warning: a condition that does not hold is the
-		// feature working. It is logged at all because a mistyped `var` path
-		// resolves to null and is indistinguishable, in the response, from an
-		// honest refusal; this line is what makes one diagnosable.
-		$this->logger->debug('[LifecycleConditionEvaluator] Transition condition did not hold.', $context);
+		// LOG LEVEL ONLY, NOT A GUARD. The fail-closed refusal of a value that
+		// is not a rule object lives in holds(), which has already warned about
+		// it by the time this runs. This reads the same shape to decide whether
+		// the miss deserves the quieter line: a well-formed rule that simply
+		// does not hold is the feature working, and is debug. It is logged at
+		// all because a mistyped `var` path resolves to null and is
+		// indistinguishable, in the response, from an honest refusal.
+		if (is_array($condition) === true && $condition !== []) {
+			$this->logger->debug(
+				'[LifecycleConditionEvaluator] Transition condition did not hold.',
+				['schema' => $schemaSlug, 'action' => $action, 'field' => $field]
+			);
+		}
 
 		return $this->refusalFor(spec: $spec, action: $action, field: $field);
 	}//end refusal()
+
+	/**
+	 * Whether a lifecycle rule holds for this object and transition.
+	 *
+	 * THE ONE PLACE A LIFECYCLE RULE IS EVALUATED. Both a transition's
+	 * `condition` (may this move proceed) and its `autoWhen` (should this move
+	 * be made) come through here, against the same document built by the same
+	 * method, so the two guards the declarative-conditions link paid for are
+	 * shared rather than rediscovered:
+	 *
+	 * - a value that is present but is NOT a non-empty rule object never
+	 *   reaches `FlowExpression`, where a scalar evaluates as a truthy literal;
+	 * - an expression that cannot be evaluated counts as not holding, because
+	 *   `FlowExpression::isTrue()` answers false for it.
+	 *
+	 * Both directions fail closed, which means the opposite thing for the two
+	 * callers and the right thing for each: a condition that cannot be trusted
+	 * refuses the move, an `autoWhen` that cannot be trusted does not make one.
+	 *
+	 * A well-formed rule that simply does not hold logs NOTHING here. For an
+	 * `autoWhen` that is the common case on every write, and a line per write
+	 * per candidate would drown the log that the malformed case needs to reach.
+	 *
+	 * @param mixed $rule The rule to evaluate: a `condition` or an `autoWhen`.
+	 * @param array<string, mixed> $newData The object as it would be saved, or as stored.
+	 * @param array<string, mixed> $oldData The object as it was before the write.
+	 * @param string $action The transition's name.
+	 * @param string $from The lifecycle value being moved away from.
+	 * @param string $to The lifecycle value being moved to.
+	 * @param string $schemaSlug The schema's slug, for the log line.
+	 * @param string $field The lifecycle field's name.
+	 *
+	 * @return bool True only when the rule is a non-empty rule object that evaluates true.
+	 *
+	 * @SuppressWarnings(PHPMD.StaticAccess) FlowExpression is the engine's
+	 * stateless expression facade; calling it statically IS the reuse.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function holds(
+		mixed $rule,
+		array $newData,
+		array $oldData,
+		string $action,
+		string $from,
+		string $to,
+		string $schemaSlug,
+		string $field,
+	): bool {
+		if (is_array($rule) === false || $rule === []) {
+			// A fault in the schema, not the rule working, hence a warning.
+			// The runtime does not trust save-time validation: a schema written
+			// by a path that skipped the mapper can still carry a scalar here.
+			$this->logger->warning(
+				'[LifecycleConditionEvaluator] Transition condition is not a JSONLogic rule object; refusing.',
+				['schema' => $schemaSlug, 'action' => $action, 'field' => $field]
+			);
+			return false;
+		}
+
+		return FlowExpression::isTrue(
+			logic: $rule,
+			data: $this->document(newData: $newData, oldData: $oldData, action: $action, from: $from, to: $to)
+		);
+	}//end holds()
 
 	/**
 	 * Build the refusal error for a transition.

--- a/lib/Service/Lifecycle/LifecycleWriteBoundary.php
+++ b/lib/Service/Lifecycle/LifecycleWriteBoundary.php
@@ -1,0 +1,169 @@
+<?php
+
+/**
+ * OpenRegister LifecycleWriteBoundary
+ *
+ * The two ambient collaborators a lifecycle write carries, held together so
+ * TransitionEngine asks for an outcome instead of orchestrating them itself.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Lifecycle
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Lifecycle;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+
+/**
+ * What a lifecycle write asks of its ambient frame, in one place.
+ *
+ * TransitionEngine performs one write per named or graph transition, but two
+ * unrelated things must happen around it: the automatic-transition pass needs
+ * to know a write is in flight so a rule-driven move can be attributed and
+ * drained, and the listeners need to be told which named action is being
+ * applied so they judge the transition that was asked for rather than the
+ * first one that happens to share its from/to pair. Both are ambient,
+ * request-scoped collaborators the engine only ever asks questions of; it
+ * never inspects their internals. Bundling them here means the engine
+ * constructor carries one collaborator instead of two, and the boundary
+ * mechanics (`finally`, null-safety) live next to each other instead of
+ * being duplicated at every call site.
+ *
+ * Not `final` for no reason of its own — nothing here doubles a class the way
+ * TransitionEngine is doubled in TransitionControllerTest — but sealed
+ * because nothing needs to extend it.
+ */
+final class LifecycleWriteBoundary {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param LifecycleActionContext $actions Names the transition being applied, for the listeners.
+	 * @param AutoTransitionPass|null $pass The request-scoped automatic-transition pass. Nullable
+	 *                          with a null default so the engine's existing unit tests keep building
+	 *                          it without wiring the pass; the container resolves the real, shared
+	 *                          instance by type.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function __construct(
+		private readonly LifecycleActionContext $actions,
+		private readonly ?AutoTransitionPass $pass = null,
+	) {
+	}//end __construct()
+
+	/**
+	 * Open the automatic-transition boundary around a write, and answer with
+	 * whichever entity is current once it closes.
+	 *
+	 * OPENS THE BOUNDARY around the whole write, not around its save: the
+	 * write's own `ObjectTransitionedEvent` is dispatched after the save
+	 * returns, and a listener must see the named move before any automatic
+	 * move that followed from it. Leaving the OUTERMOST boundary drains, so
+	 * the entity answered here is the one the last automatic move produced,
+	 * when there was one — never the write's own result once a later
+	 * automatic move has superseded it.
+	 *
+	 * The drain runs in a `finally`: that is deliberate and load-bearing. A
+	 * frame left pushed after an exception would attribute later, unrelated
+	 * writes to a move that never finished.
+	 *
+	 * @param callable(): ObjectEntity $write Performs the write; called exactly once.
+	 *
+	 * @return ObjectEntity The object in its final state: the write's own
+	 *                      result, or an automatic move that followed from it.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function around(callable $write): ObjectEntity {
+		$this->pass?->enter();
+		$automatic = [];
+
+		try {
+			$result = $write();
+		} finally {
+			$automatic = ($this->pass?->leave() ?? []);
+		}
+
+		return $this->preferAutomatic(saved: $result, applied: $automatic);
+	}//end around()
+
+	/**
+	 * Declare the named action for a uuid around a write, and release it
+	 * unconditionally afterward.
+	 *
+	 * Names the transition for the listeners. They see only object data and
+	 * would otherwise pick the first transition with a matching from/to pair,
+	 * judging and acting on a twin rather than the action asked for.
+	 *
+	 * Release happens in a `finally` so a refused write (the save throws)
+	 * never leaves the declaration in place: a leaked declaration would make
+	 * a later, unrelated save of the same object be judged as this action.
+	 *
+	 * @param string $uuid The object's uuid.
+	 * @param string $action The transition being performed.
+	 * @param callable(): ObjectEntity $write Performs the write; called exactly once.
+	 *
+	 * @return ObjectEntity Whatever $write returned.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function declaringAction(string $uuid, string $action, callable $write): ObjectEntity {
+		$this->actions->declare(uuid: $uuid, action: $action);
+		try {
+			return $write();
+		} finally {
+			$this->actions->release(uuid: $uuid);
+		}
+	}//end declaringAction()
+
+	/**
+	 * The automatic transition being applied right now, if any.
+	 *
+	 * Read from the pass's ambient frame, never from a parameter a caller
+	 * could set: a caller that could pass `automatic: true` could claim a
+	 * move a person asked for was made by a rule.
+	 *
+	 * @return string|null The transition's name, or null for a manual move
+	 *                      or when no pass is wired.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	public function applyingAction(): ?string {
+		return $this->pass?->applyingAction();
+	}//end applyingAction()
+
+	/**
+	 * Choose between a write's own result and an automatic move that followed from it.
+	 *
+	 * Null-safe: with no pass wired, `$applied` is always empty and the
+	 * write's own result is returned unchanged.
+	 *
+	 * @param ObjectEntity $saved The entity the write itself produced.
+	 * @param array<string, ObjectEntity> $applied What the drain applied, by uuid.
+	 *
+	 * @return ObjectEntity The object in its final state.
+	 *
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+	 */
+	private function preferAutomatic(ObjectEntity $saved, array $applied): ObjectEntity {
+		if ($this->pass === null) {
+			return $saved;
+		}
+
+		return $this->pass->preferAutomatic(saved: $saved, applied: $applied);
+	}//end preferAutomatic()
+}//end class

--- a/lib/Service/Lifecycle/TransitionEngine.php
+++ b/lib/Service/Lifecycle/TransitionEngine.php
@@ -75,10 +75,12 @@ class TransitionEngine {
 	 * @param RegisterMapper $registerMapper Mapper used to resolve the register slug.
 	 * @param IAppConfig $appConfig App config, for the slug-contract opt-in.
 	 * @param LoggerInterface $logger Logger for post-commit listener failures.
-	 * @param LifecycleActionContext $actionContext Names the transition being performed for the listeners.
+	 * @param LifecycleWriteBoundary $writeBoundary Names the transition for the listeners and wraps
+	 *                               the request-scoped automatic-transition pass.
 	 *
 	 * @spec openspec/specs/object-lifecycle/spec.md
 	 * @spec openspec/changes/lifecycle-declarative-conditions/specs/object-lifecycle/spec.md
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
 	 */
 	public function __construct(
 		private readonly ObjectService $objectService,
@@ -89,7 +91,7 @@ class TransitionEngine {
 		private readonly RegisterMapper $registerMapper,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
-		private readonly LifecycleActionContext $actionContext,
+		private readonly LifecycleWriteBoundary $writeBoundary,
 	) {
 	}//end __construct()
 
@@ -127,6 +129,7 @@ class TransitionEngine {
 	 * @return void
 	 *
 	 * @spec openspec/specs/object-lifecycle/spec.md
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
 	 */
 	private function dispatchTransitioned(
 		ObjectEntity $object,
@@ -137,6 +140,11 @@ class TransitionEngine {
 	): void {
 		$scope = $this->transitionEventScope(object: $object);
 
+		// Read from the pass's ambient frame, never from a parameter on
+		// transition(): a caller that could pass `automatic: true` could claim
+		// a move a person asked for was made by a rule.
+		$applying = $this->writeBoundary->applyingAction();
+
 		try {
 			$this->eventDispatcher->dispatchTyped(
 				new ObjectTransitionedEvent(
@@ -146,7 +154,8 @@ class TransitionEngine {
 					to: $to,
 					userId: $userId,
 					register: $scope['register'],
-					schema: $scope['schema']
+					schema: $scope['schema'],
+					automatic: ($applying !== null && $applying === $action)
 				)
 			);
 		} catch (Throwable $e) {
@@ -259,12 +268,33 @@ class TransitionEngine {
 	 *                          hook ({@see HookStoppedException}) — exactly as
 	 *                          it would refuse any other object write.
 	 *
-	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength) Linear resolve→guard→mutate→save flow; splitting would obscure the transition contract.
-	 *
 	 * @spec openspec/specs/object-lifecycle/spec.md
 	 * @spec openspec/changes/fk-graph-lifecycle-transitions/specs/object-lifecycle/spec.md
+	 * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
 	 */
 	public function transition(string $objectId, string $action, array $data = []): ObjectEntity {
+		// OPEN THE AUTOMATIC-TRANSITION BOUNDARY around the whole transition,
+		// not around its save: this transition's own `ObjectTransitionedEvent`
+		// is dispatched after the save returns, and a listener must see the
+		// named move before any automatic move that followed from it. Leaving
+		// the OUTERMOST boundary drains, so the entity answered here is the one
+		// the last automatic move produced, when there was one.
+		return $this->writeBoundary->around(
+			write: fn (): ObjectEntity => $this->applyTransition(objectId: $objectId, action: $action, data: $data)
+		);
+	}//end transition()
+
+	/**
+	 * Resolve the object/schema/annotation a transition acts on, guarding presence and permission.
+	 *
+	 * Extracted from {@see applyTransition()} to keep its own mode/transition/from-state
+	 * branching separate from "can this call proceed at all".
+	 *
+	 * @param string $objectId Object id/uuid/slug.
+	 *
+	 * @return array{object: ObjectEntity, schema: Schema, annotation: array<string, mixed>}
+	 */
+	private function resolveTransitionSubject(string $objectId): array {
 		$object = $this->objectService->find(id: $objectId);
 		if ($object === null) {
 			throw new RuntimeException(sprintf('Object "%s" not found.', $objectId));
@@ -275,15 +305,10 @@ class TransitionEngine {
 			throw new RuntimeException('Object schema could not be resolved.');
 		}
 
-		// Per-object RBAC: a transition mutates the lifecycle field, so
-		// the caller MUST hold `update` permission on this specific
-		// object. The downstream `saveObject()` does its own RBAC pass,
-		// but we gate explicitly here so that (a) a denial surfaces as
-		// 403 with a clear message instead of being absorbed by the
-		// save path's generic error envelope, and (b) we don't redo the
-		// (potentially expensive) lifecycle annotation lookup before
-		// discovering the caller had no business calling /transition
-		// in the first place.
+		// Per-object RBAC: a transition mutates the lifecycle field, so the
+		// caller MUST hold `update` permission on this object. Gated explicitly
+		// (rather than relying solely on saveObject()'s own RBAC pass) so a
+		// denial surfaces as a clear 403 before the annotation lookup runs.
 		$callerId = $this->userSession->getUser()?->getUID();
 		$allowed = $this->permissionHandler->hasPermission(
 			schema: $schema,
@@ -308,6 +333,26 @@ class TransitionEngine {
 				sprintf('Schema "%s" does not declare x-openregister-lifecycle.', (string)$schema->getSlug())
 			);
 		}
+
+		return ['object' => $object, 'schema' => $schema, 'annotation' => $annotation];
+	}//end resolveTransitionSubject()
+
+	/**
+	 * Apply a named transition, without the automatic-transition boundary.
+	 *
+	 * The whole of the pre-existing `transition()` body, split out so the boundary
+	 * wraps it in one place and nothing inside can return past the drain.
+	 *
+	 * @param string $objectId Object id/uuid/slug.
+	 * @param string $action Transition action name.
+	 * @param array<string, mixed> $data Optional input values for the transition's declared `inputs`.
+	 *
+	 * @return ObjectEntity The saved object after the transition.
+	 */
+	private function applyTransition(string $objectId, string $action, array $data = []): ObjectEntity {
+		$subject = $this->resolveTransitionSubject(objectId: $objectId);
+		$object = $subject['object'];
+		$annotation = $subject['annotation'];
 
 		$field = (string)($annotation['field'] ?? ($annotation['property'] ?? ''));
 		$transitions = (array)($annotation['transitions'] ?? []);
@@ -376,18 +421,17 @@ class TransitionEngine {
 		// would otherwise pick the first transition with this from/to pair,
 		// judging and acting on a twin rather than the action asked for.
 		$uuid = (string)$object->getUuid();
-		$this->actionContext->declare(uuid: $uuid, action: $action);
-		try {
-			$saved = $this->objectService->saveObject(
+		$saved = $this->writeBoundary->declaringAction(
+			uuid: $uuid,
+			action: $action,
+			write: fn (): ObjectEntity => $this->objectService->saveObject(
 				object: $objectData,
 				register: $object->getRegister(),
 				schema: $object->getSchema(),
 				uuid: $object->getUuid(),
 				currentUser: $actingUser
-			);
-		} finally {
-			$this->actionContext->release(uuid: $uuid);
-		}
+			)
+		);
 
 		$userId = $actingUser?->getUID();
 
@@ -400,7 +444,7 @@ class TransitionEngine {
 		);
 
 		return $saved;
-	}//end transition()
+	}//end applyTransition()
 
 	/**
 	 * List actions whose `from` includes the object's current lifecycle value.

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -1900,14 +1900,10 @@ class ObjectService implements ObjectServiceInterface
             $automatic = ($this->autoTransitions?->leave() ?? []);
         }
 
-        if ($result === null) {
-            // Unreachable: the block above either assigns $result or throws.
-            // Present so the non-nullable return type is provable, and so a
-            // future early `return` inside the try cannot silently skip the
-            // drain without this failing loudly first.
-            throw new RuntimeException('Save produced no object entity.');
-        }
-
+        // No null guard on $result here. PHPStan proves the try block either
+        // assigns it or throws, so a guard would be dead code, and dead code
+        // that only static analysis can see is exactly what the baseline is
+        // for tracking rather than growing.
         if ($this->autoTransitions === null) {
             return $result;
         }

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -51,6 +51,7 @@ use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Db\ViewMapper;
 use OCA\OpenRegister\Service\DateTimeNormalizer;
+use OCA\OpenRegister\Service\Lifecycle\AutoTransitionPass;
 use OCA\OpenRegister\Service\Object\CacheHandler;
 use OCA\OpenRegister\Service\Schemas\SchemaCacheHandler;
 use OCA\OpenRegister\Service\Schemas\FacetCacheHandler;
@@ -283,6 +284,7 @@ class ObjectService implements ObjectServiceInterface
      * @param DateTimeNormalizer             $dateTimeNormalizer   Normaliser for user-supplied datetime input.
      * @param IAppContainer                  $container            Application container.
      * @param ObjectSourceRegistry           $objectSourceRegistry Registry of object-source providers (virtual schemas).
+     * @param AutoTransitionPass|null        $autoTransitions      Request-scoped pass applying automatic lifecycle moves.
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList) Nextcloud DI requires constructor injection
      */
@@ -335,7 +337,12 @@ class ObjectService implements ObjectServiceInterface
         private readonly SettingsService $settingsService,
         private readonly DateTimeNormalizer $dateTimeNormalizer,
         private readonly IAppContainer $container,
-        private readonly ObjectSourceRegistry $objectSourceRegistry
+        private readonly ObjectSourceRegistry $objectSourceRegistry,
+        // The request-scoped automatic-transition pass. Nullable with a null
+        // default so the many unit tests that build this service positionally
+        // keep working; the container resolves the real, SHARED instance by
+        // type in production, as it does for FlowRunController's attribution.
+        private readonly ?AutoTransitionPass $autoTransitions = null
         // TODO: CIRCULAR DEPENDENCY ISSUE - ExportService, ImportService, and VectorizationService
         // These services have deep circular dependencies:
         // - ExportService → uses SaveObjects → potentially loops back
@@ -1555,6 +1562,7 @@ class ObjectService implements ObjectServiceInterface
      * @SuppressWarnings(PHPMD.ExcessiveParameterList) Save options are flag-driven; `$currentUser` was added for `@self.folder` access checks.
      *
      * @spec openspec/archive/retrofit-annotate-openregister-2026-04-23/tasks.md
+     * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
      */
     public function saveObject(
         array | ObjectEntity $object,
@@ -1579,6 +1587,15 @@ class ObjectService implements ObjectServiceInterface
         // unaffected: the snapshot and the restore are the same context.
         $previousRegister = $this->currentRegister;
         $previousSchema   = $this->currentSchema;
+
+        // OPEN THE AUTOMATIC-TRANSITION BOUNDARY. Leaving the OUTERMOST one is
+        // the first moment at which this write is finished in every sense that
+        // matters: the object row, its audit row, and the second update a
+        // file-bearing save makes from an in-memory entity. A move applied any
+        // earlier is lost to that second write. See AutoTransitionPass.
+        $this->autoTransitions?->enter();
+        $automatic = [];
+        $result    = null;
 
         try {
             $this->discardPendingSchemaRef();
@@ -1871,10 +1888,31 @@ class ObjectService implements ObjectServiceInterface
             \OCA\OpenRegister\Service\WritePhaseProbe::mark('render');
             \OCA\OpenRegister\Service\WritePhaseProbe::flush();
 
-            return $renderedObject;
+            // Assigned rather than returned: the boundary below may apply an
+            // automatic transition whose entity is the one the caller must see.
+            $result = $renderedObject;
         } finally {
             $this->restoreScopeContext(register: $previousRegister, schema: $previousSchema);
+
+            // Always in a `finally`, never conditionally: an unbalanced enter
+            // would leave the pass believing a boundary is still open, and
+            // nothing in this request would ever drain again.
+            $automatic = ($this->autoTransitions?->leave() ?? []);
         }
+
+        if ($result === null) {
+            // Unreachable: the block above either assigns $result or throws.
+            // Present so the non-nullable return type is provable, and so a
+            // future early `return` inside the try cannot silently skip the
+            // drain without this failing loudly first.
+            throw new RuntimeException('Save produced no object entity.');
+        }
+
+        if ($this->autoTransitions === null) {
+            return $result;
+        }
+
+        return $this->autoTransitions->preferAutomatic(saved: $result, applied: $automatic);
     }//end saveObject()
 
     /**

--- a/openspec/changes/lifecycle-auto-transitions/.openspec.yaml
+++ b/openspec/changes/lifecycle-auto-transitions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-11

--- a/openspec/changes/lifecycle-auto-transitions/design.md
+++ b/openspec/changes/lifecycle-auto-transitions/design.md
@@ -1,0 +1,442 @@
+## Context
+
+See proposal.md, Why. The engine facts below shape the approach. Each was established by reading the
+code on this branch, not assumed.
+
+- **The write path has no wrapping transaction.** `ObjectService::saveObject()` delegates to
+  `SaveObject::saveObject()`, which calls `MagicMapper::insert()` or `update()`. Those dispatch
+  `ObjectCreatedEvent` / `ObjectUpdatedEvent` synchronously, straight after the row is written. The
+  header of `ListenerDeferralService` records the same finding. A post-save listener therefore always
+  sees a committed row.
+- **But the post-save event fires in the MIDDLE of the save, not at its end.** After
+  `MagicMapper::update()` returns (and has dispatched `ObjectUpdatedEvent`), `SaveObject::updateObject()`
+  still writes the save's audit row, and for a save carrying a file property it calls
+  `MagicMapper::update()` a SECOND time with its in-memory entity, which dispatches `ObjectUpdatedEvent`
+  again. A move applied inside the first event would be written before the triggering save's audit row,
+  and on a file-bearing save it would be overwritten by the second update, which carries the old
+  lifecycle value. That is a lost update behind a transition event that has already fired. This single
+  fact decides where a sync move runs; see "A sync move runs at the outermost write boundary".
+- **`TransitionEngine::transition()` saves first and announces second.** It checks `from`, merges
+  `inputs`, flips the field, calls `ObjectService::saveObject()`, then dispatches
+  `ObjectTransitionedEvent`. Every gate runs inside that save, in `LifecycleValidationListener`
+  (`authorization`, `condition`, `requires`), `ApprovalChainGateListener` and `LifecycleActionListener`
+  (`actions[]`).
+- **The save path identifies a transition by its values, not its name.** Both
+  `LifecycleValidationListener::findTransitionByTarget()` and `LifecycleActionListener::matchTransition()`
+  return the FIRST declared transition whose `to` matches and whose `from` contains the old value. When
+  two transitions share a from and to pair, a named call to the second one is gated by the first one's
+  rules and runs the first one's actions. The mock register has such pairs today (`startVerifying` and
+  `assign` both move `received` to `verifying`). This is pre-existing and it matters here, because
+  "an automatic move obeys what a manual one obeys" is only true if the save path evaluates the
+  automatic transition's own rules.
+- **Post-save events do not always fire in the request.** `defer_object_events=1` hands
+  `ObjectCreatedEvent` to `DeferredObjectEventJob`. `SystemOperationContext` suppresses object events
+  altogether during imports, repair steps and seeding. Bulk saves dispatch from `SaveObjects`, outside
+  `ObjectService::saveObject()`. `RevertHandler` writes through `MagicMapper::update()` directly.
+- **The flow engine's two execution-mode values live in `Flow::MODE_SYNC` and `Flow::MODE_ASYNC`.**
+  `FlowTriggerService` does not use them: it declares its own private `MODE_SYNC = 'sync'` and
+  lowercases the stored value before comparing. `ListenerDeferralService` answers the same question with
+  `MODE_INLINE` / `MODE_BACKGROUND` and the `listenerDeferral` kill switch, and `MagicMapper` answers it
+  for created events with `defer_object_events`. The user was told this change adds a third place that
+  decides sync versus async. By this count it is the fourth decision point, and the flow values already
+  have two spellings.
+- **Re-entrancy.** The flow TRIGGER path has no self-trigger or re-entrancy guard: nothing in
+  `FlowTriggerListener`, `FlowTriggerService::fire()`, `runInline()` or `FlowRunService::queue()` notices
+  that a run's own write fired the event that queued it. Two nearby mechanisms are not that guard:
+  `SubFlowNode` refuses a sub-flow already on the run's call stack and stops at `MAX_DEPTH = 16`, which
+  covers invocation, not triggering, and is the precedent the loop cap copies. `SaveObject`'s save call
+  stack detects circular REFERENCES during validation; a second push of the same object is quietly
+  ignored. `FlowRunContext` is attribution, not a guard.
+- **Identity.** ADR-099: a user action acts as the session user; a callee never widens the identity it
+  was called with; `runAsSystem()` must not be reachable from user-authored input.
+  `ObjectService::runAs()` wraps `setVolatileActiveUser()`. `ActorForwardedJob`, the base of every
+  deferred listener job, restores its captured user with `setUser()` and does not refuse a disabled
+  account.
+- **Job arguments are capped.** Nextcloud's `JobList::add()` refuses a JSON argument longer than 4000
+  characters, so a queued move cannot carry the object's previous state.
+
+## Goals / non-goals
+
+**Goals:**
+
+- A schema author can make a status follow the object's data, with no PHP in the consuming app.
+- An automatic move is a named transition in every observable way: same gates, same actions, same
+  events, same audit trail, marked as automatic.
+- A sync move lands in the response of the request that caused it, and nothing it does can fail or
+  unwind that request.
+- No declaration can make an object loop, in one request or across background jobs.
+- Zero behaviour change for a schema without `autoWhen`.
+
+**Non-goals:**
+
+- Time-based triggers ("move to `verlopen` when the deadline passes"). `autoWhen` is evaluated on a
+  write. A rule reading the clock is only re-read when something writes the object. Scheduled
+  re-evaluation is a separate change.
+- Graph-mode automatic moves. Refused, like graph-mode conditions; `lifecycle-graph-enforcement` owns
+  the gap.
+- Fixing the value-based transition matching in the two listeners. This change refuses to fire an
+  automatic transition that the matching would misidentify; making the save path honour the named
+  action is a separate change with its own consumers.
+- A re-entrancy guard for the flow trigger path. Recorded under Risks.
+- Unifying the sync/async decision points listed in Context.
+
+## Decisions
+
+### Declarative-vs-imperative decision
+
+Per ADR-031, stated plainly because the surface reading is backwards: this change is PHP. A candidate
+selector, one new method on the existing evaluator, a listener, a request-scoped pass, a job and
+validator branches. No app declares anything in its
+register file here.
+
+ADR-031 distinguishes an APP writing a service from the ENGINE providing the declarative extension an
+app uses instead. This change is the second kind. Today "the case is decided once the motivation is
+filled in" costs a consuming app a post-save listener or a flow with an object-write node. That is the
+"custom state-machine service" anti-pattern ADR-031 lists, and it exists because the lifecycle
+annotation can refuse a move but cannot make one. ADR-031 exception (1) names the remedy: when OR's
+extension is missing, build the extension.
+
+The imperative code here removes imperative code from consumers. `requires` guards and flows remain
+the seam for work that is not a rule over the object's own data: IO, cross-schema lookups, anything
+with a side effect beyond the move itself.
+
+No register patch ships with this change. The declarative side belongs to the consuming apps, and
+adopting it is ADR-031's opportunistic migration. The e2e spec seeds its own schemas, so the mock
+register stays free of an automatic move that would fire on every developer's seeded objects.
+
+### A sync move runs at the outermost write boundary, not in the listener
+
+The obvious design fires the transition from inside an `ObjectUpdatedEvent` listener. Context shows why
+that is wrong here: the event fires before the triggering save has written its audit row, and on a
+file-bearing save before a second update that would overwrite the move. The listener position also
+inverts event order for a named transition: the automatic move's `ObjectTransitionedEvent` would be
+dispatched before the named one's, because `TransitionEngine` announces after its save returns.
+
+So the listener only RECORDS. On `ObjectCreatedEvent` and `ObjectUpdatedEvent` it checks whether the
+schema declares any `autoWhen` (a cheap read of the annotation) and, if so, records the object in a
+request-scoped pass: uuid, register, schema, and the event's old object data as `previous`, first
+capture winning. It never evaluates and never writes. That keeps it honestly clear of the
+listener-placement gate (ADR-078): there is no write inside the user's save to annotate or defer.
+
+The pass has a boundary counter. `ObjectService::saveObject()` and `TransitionEngine::transition()`
+each enter it on the way in and leave it in a `finally`. When the OUTERMOST boundary is left, the
+triggering write is finished in every sense that matters: row, audit row, follow-up writes, and for a
+named transition its `ObjectTransitionedEvent`. Only then does the pass drain.
+
+The drain is a loop, not recursion. For each recorded object it re-reads the stored object, decides the
+candidate, and fires it through `TransitionEngine::transition()`. That call enters the boundary again,
+and its own `ObjectUpdatedEvent` records the object again. A draining flag stops the nested boundary
+exit from starting a nested drain, so the outer loop picks the re-recorded object up and decides the
+next step. Each step is counted against the cap.
+
+The outermost boundary returns the object as it stands after the drain: the entity returned by the last
+move applied to that object, or the original entity when none was. That is how the response of both
+routes carries the new state without a controller change.
+
+Alternatives considered:
+
+- Fire inside the listener. Rejected: the lost update and the audit and event order above.
+- A shutdown hook. Rejected: the response has already been produced, so a sync move would not be in it.
+- Have the controllers re-read after saving. Rejected: it covers only the routes someone remembers to
+  change, and it leaves the lost update in place.
+
+### The move is decided when the pass drains, against the stored object
+
+`autoWhen` is evaluated at drain time, against the object as stored, not against the event payload.
+Computed fields, defaults and file ids are all present by then, and the two `ObjectUpdatedEvent`s of a
+file-bearing save collapse into one decision because the pass records per object. `previous` is the
+old object data the FIRST event of the pass carried, which is the state before the write that started
+the pass, or an empty object on create.
+
+### `autoWhen` is evaluated by `LifecycleConditionEvaluator`, not a second way
+
+The first link put every piece of condition evaluation in `LifecycleConditionEvaluator::refusal()`: the
+refusal of a present-but-not-rule-object value before evaluation, the four-key document built from the
+session user, and the `FlowExpression::isTrue()` call. `autoWhen` reuses that class rather than
+evaluating JSONLogic along a second path. The evaluator gains one public method, `holds()`, taking the
+rule and the same inputs `refusal()` takes, and returning true only for a non-empty rule object that
+evaluates true. `refusal()` is rewritten to call `holds()` and then build its message, so there is
+exactly one place that decides whether a lifecycle rule holds, and one place that builds its document.
+
+This matters beyond tidiness. The two failure-direction guards the first link paid for (a scalar is
+refused before it reaches `FlowExpression`, an unevaluable expression counts as false) are the same two
+an `autoWhen` needs, and a second evaluator would have to rediscover both. `holds()` logs the
+not-a-rule-object case at warning, as `refusal()` does today, and logs nothing when a well-formed rule
+simply does not hold, since for `autoWhen` that is the common case on every write.
+
+The candidate selector (which transitions are eligible, ambiguity, shadowing, mode) is a separate class
+in `lib/Service/Lifecycle/` that calls `holds()`. It owns selection; the evaluator owns evaluation, the
+split the first link drew for the same complexity reason.
+
+The one semantic difference between the two rules is recorded in the spec: in an `autoWhen`, `object` is
+the state being left, not the state being entered. The document's shape is identical because it is
+built by the same method.
+
+Alternative considered: lift the document builder into a third collaborator and let each rule evaluate
+on its own. Rejected: it shares the document but duplicates the scalar guard and the `isTrue()` call,
+which are exactly the parts where a drift would fail open.
+
+### `executionMode` binds to the flow engine's constants, and defaults to sync
+
+The validator and the pass compare against `Flow::MODE_SYNC` and `Flow::MODE_ASYNC`, exactly, with no
+lowercasing. A value that is neither is refused at save time and does not fire at runtime. This does
+not remove the extra decision point the user accepted; it guarantees the lifecycle and the flow engine
+cannot drift into different spellings of the same two words. The stray private constant in
+`FlowTriggerService` is a one-line follow-up outside this change's blast radius.
+
+The default is `sync`, the opposite of a flow's `async` default, deliberately. A flow queues by default
+because an arbitrary graph must not sit on the save's critical path. An automatic transition is one
+bounded write through a path the caller already waits on, and an author writing "decided once the
+motivation is filled in" expects the response to say `besloten`. The user chose sync as the default.
+
+### Async is decide now, apply later if nothing changed
+
+An `async` candidate is decided at drain time with the full document, exactly like a sync one. It is
+then handed to `ListenerDeferralService` as an `ActorForwardedJob` entry carrying the uuid, register,
+schema, the transition name, the object's version and `updated` timestamp at decision time, and the
+pass lineage (hop count and visited states). The job applies the move only when the stored version and
+timestamp still match. If they do not, a newer write has made its own decision and the job is a no-op.
+That is the at-least-once, reconcile-against-current-state contract `ActorForwardedJob` already
+documents.
+
+The job does NOT re-evaluate `autoWhen`, because it cannot: `previous` does not fit in a job argument
+capped at 4000 characters, and re-evaluating with a different `previous` would make an async rule mean
+something different from the same rule in sync. The chunk size is chosen so a full chunk fits that cap.
+The dedupe key is uuid plus version, because `ListenerDeferralService` keeps the FIRST entry per key:
+deduping on uuid alone would keep a stale decision and drop the current one.
+
+The job enters a boundary seeded with the carried lineage, so a chained sync move after an async hop
+drains inside the job and counts against the same pass.
+
+Under the `listenerDeferral=inline` kill switch, an async move decided inside a boundary is applied at
+the pass drain, as the existing deferred listeners do. A move decided outside a boundary is still
+queued; see the next section.
+
+### Writes outside a boundary queue their moves
+
+A bulk save, a deferred created event, a revert and a direct mapper write all dispatch post-save events
+with no `ObjectService::saveObject()` around them. There is no point at which a sync move can run after
+the write completes and before a response, because either there is no response or the write is not
+the caller's last. Their candidates are queued as async, whatever the declared mode, and a debug line
+says so. The consequences worth naming: with `defer_object_events=1`, an automatic move on create is
+never in the create's response, and a revert that lands an object in a state whose rule holds will move
+it again shortly after.
+
+### The loop cap: no revisit, and a ceiling of 10
+
+Two limits, both per object per pass, following `SubFlowNode`'s shape (refuse what is already on the
+stack, and backstop with a depth ceiling):
+
+- **No revisit.** A move into a state the object already occupied in this pass is not made. A to B to A
+  is cut at the second move, deterministically, after exactly one write. A count-only cap would let the
+  object flip ten times, write ten audit rows, send ten rounds of notifications, and stop on whichever
+  state the parity of the ceiling picked.
+- **Ceiling of 10.** It only bites on a chain through more than ten distinct states, which no lifecycle
+  in the fleet has. It is a private constant, like `SubFlowNode::MAX_DEPTH`, and not configurable: a
+  configurable cap invites raising it to make a loop's symptom go away.
+
+A cut logs at error level with the schema, the object, the limit and the transitions applied, and stops.
+It never throws, since the triggering write has already succeeded and nothing about the cut is the
+caller's fault.
+
+The user asked for a cap "per request per object". A pass is slightly different, on purpose. Within one
+request every write reachable from the triggering one is in the same pass, so it is at least as strict
+there. And the pass travels with a queued move, which a per-request counter cannot do: a request-scoped
+counter resets in every background job, so an async A to B, B to A loop would run forever, one cron
+tick at a time.
+
+### Ambiguity fires nothing, and order is not a tie-breaker
+
+When two automatic transitions hold from the same state, neither fires and a warning names both. Three
+options were weighed:
+
+- **First declared wins.** Rejected. Declaration order is the order of keys in a JSON object, and
+  MySQL's native JSON type does not preserve key order, while PostgreSQL's `json` does. The same schema
+  would pick different transitions on different installations.
+- **Prove mutual exclusion at save time.** Rejected. Two JSONLogic rules over arbitrary fields cannot in
+  general be shown disjoint, and a partial check would pass the cases it cannot see.
+- **Refuse at runtime and say so.** Chosen. It fails closed: an ambiguous move is not made, the object
+  stays put, and the warning tells the author which rules overlap.
+
+### A shadowed automatic transition does not fire
+
+Context shows the save path identifies a transition by its from and to values, first match wins. An
+automatic transition that shares its pair with an earlier-declared one would be gated by the earlier
+one's rules and run its actions. Firing it would silently break the promise this change makes. The
+candidate selection checks for an earlier transition with the same `to` whose `from` contains the
+current value, and refuses with a warning naming both. The underlying matching is not fixed here; see
+Non-goals.
+
+### The move acts as the caller, never as the system
+
+A sync move runs under the ambient session: the identity whose write triggered it, which is what
+ADR-099 prescribes for a user action. Nothing is swapped, so there is nothing to restore. An async move
+carries that uid through `ListenerDeferralService`, and the job refuses a uid that no longer resolves or
+belongs to a disabled account, as `FlowRunAsScope` does. The automatic move never enters
+`SystemOperationContext` and never calls `runAsSystem()`: `autoWhen` is authored in a schema, which is
+exactly the user-authored input ADR-099 keeps away from the userless principal.
+
+A session-less write, such as an `occ` command without a session, gets a session-less move. Its
+`authorization` list refuses it, and `TransitionEngine`'s `update` permission check refuses it unless
+RBAC admits anonymous updates on that schema. That is the correct default. A CLI that wants automatic
+moves must act as a user, which the annotation reference documents alongside the empty-`user` note from
+the first link.
+
+`ActorForwardedJob` restores identity with `setUser()` rather than ADR-099's `setVolatileActiveUser()`,
+and does not check for a disabled account. The new job adds the disabled check locally. Moving the base
+class onto the ADR-099 primitive touches five other jobs and is a follow-up.
+
+### A refusal is logged at warning and never retried
+
+A fired transition can be refused by any gate a manual one meets. The pass catches the refusal
+(`HookStoppedException`, `NotAuthorizedException`, `RuntimeException`,
+`InvalidTransitionInputException`) and any other throwable, logs a warning naming the schema, the
+object, the transition and the refusal code, and moves on. It does not retry and it does not surface
+the refusal to the caller, whose write succeeded.
+
+Warning rather than debug, because Nextcloud's default log level hides anything quieter, and an
+automatic move that never happens is invisible by construction (the lesson `DeferredObjectEventJob`
+records). The volume is bounded: a refusal needs a write while the rule holds, and a rule whose move is
+refused on every write is an authoring defect worth seeing.
+
+### Create fires; system operations do not
+
+The listener subscribes to `ObjectCreatedEvent` as well as `ObjectUpdatedEvent`. A rule is about the
+state the object is in, not about how it got there, and "created complete, so it skips straight to
+review" is a real use. `previous` is an empty object on create. The first link's listener, by contrast,
+ignores creates because a create has no transition to gate; there is nothing contradictory in that.
+
+The listener does not subscribe to `ObjectTransitionedEvent`. A named transition's save already
+dispatched `ObjectUpdatedEvent`, so listening to both would record every named transition twice.
+
+### Automatic moves are marked on the event and in the audit row
+
+`ObjectTransitionedEvent` gains an additive constructor parameter `automatic`, defaulting to false, and
+a getter. `TransitionEngine::transition()` takes it through an ambient frame on the pass rather than a
+new public parameter, so no caller can claim a manual move was automatic. `FlowTriggerListener` adds
+`automatic` to the run context beside `action`, `from` and `to`.
+
+The audit row is sealed into a hash chain when it is built, so the marker must be applied before
+sealing. `AuditTrailMapper::buildAuditTrail()` already applies `AuditFlowAttribution` from ambient state
+at exactly that point, for exactly this reason. The automatic marker follows the same pattern: the pass
+exposes the transition it is applying, and the builder folds `automaticTransition: {action}` into the
+row's `changed` data. The row is still attributed to the acting user.
+
+### Validation refuses the save, not just warns
+
+`SchemaMapper::validateLifecycleAnnotation()` refuses the save for exactly two codes,
+`lifecycle-condition-malformed` and `lifecycle-condition-graph-unsupported`, and treats every other
+lifecycle error as advisory: it logs a warning and stores the annotation as written. The advisory
+policy exists because refusing a whole register import over a partial or different-dialect lifecycle
+block broke other apps' imports.
+
+**Decision: a malformed `autoWhen` goes in the refusing bucket**, and so do the other three new codes
+(`lifecycle-execution-mode-malformed`, `lifecycle-autowhen-requires-input`,
+`lifecycle-autowhen-graph-unsupported`). The filter's code list grows from two entries to six. Two
+reasons.
+
+A stored malformed `autoWhen` is worse than a stored malformed condition. A scalar evaluates as a
+truthy literal, so the transition would fire on every write from its `from` state: unbidden writes,
+audit rows and notifications, each one feeding the next decision. The loop cap bounds it, but "bounded
+damage on every save" is not an acceptable failure mode for a typo. An unknown `executionMode`, a
+required input and a graph-block `autoWhen` all describe a move that can never happen as written, which
+is the silent no-op class the first link refused.
+
+And refusing breaks no import: no register can carry `autoWhen` or `executionMode` before this key
+exists. `lifecycle-message-malformed` stays advisory, unchanged.
+
+The exception message still leads with "Invalid", because `SchemasController` maps a save exception to
+400 by matching that word, and it is generalised from "condition" so it reads correctly for both rules.
+The runtime does not trust save time: a stored non-rule `autoWhen` counts as not holding and logs a
+warning, which covers schemas written by a path that skips the mapper.
+
+Alternative considered: keep `autoWhen` advisory and rely on that runtime refusal alone, since a
+non-rule value never fires. Rejected for three reasons. The runtime guard catches a scalar but not a
+well-formed rule with an unknown operator, which would store silently and never fire. An advisory
+warning goes to a log the author does not read, while the schema save reports success. And the
+advisory bucket's only justification, not breaking existing imports, does not apply to a key no
+register carries yet.
+
+### Graph mode is refused
+
+A graph block has no per-transition object, and graph-mode moves are validated only inside
+`TransitionEngine`, never on the ordinary save path. An automatic graph move would fire through the
+engine and so would be checked, but a later direct edit could undo it unchecked, and the author could
+not declare which derived target to move to without putting sibling UUIDs in a schema. Refused with
+`lifecycle-autowhen-graph-unsupported`, for the reasons the first link refused `graph.condition`.
+`lifecycle-graph-enforcement` is where both are revisited.
+
+### Tests are mutation-checked, the e2e lives in `workflows/`, and CI must be told to run it
+
+Every guard this change adds (the scalar refusal, the revisit rule, the ceiling, the ambiguity refusal,
+the shadow refusal, the drain position) has a test that is shown to fail when the guard is removed, and
+then restored. A test that only saves a valid object and sees the new state passes with the cap
+deleted.
+
+The Playwright spec goes in `tests/e2e/workflows/`, because `playwright.config.ts` excludes
+`tests/e2e/api-direct/` from every project, twice, so a spec there never runs and reports nothing. It
+drives the real API, like `lifecycle-conditions.spec.ts`, and proves the two things only an end-to-end
+run can: a sync move is in the same response, and the cap holds against a real save loop.
+
+Writing the file is not enough for CI. The CI job runs `tests/e2e/ci/playwright.config.ts`, whose
+`testDir: '..'` is narrowed by an explicit `testMatch` allow-list: a spec not named there never runs in
+CI, and gate 19 would still count its `@e2e` anchors as coverage. So the spec is written to pass all
+four admission criteria recorded in that config, and then admitted with a one-line entry and a comment
+stating how it meets each:
+
+1. **Hermetic.** It seeds its own register and schemas through the REST controllers via
+   `_fixtures.ts`. No `occ`, no docker, no pre-seeded data.
+2. **Self-cleaning.** Everything is namespaced by `makeRunId()`, and `afterAll` deletes what
+   `beforeAll` seeded, re-resolving by slug when a mid-run failure lost an id.
+3. **No conditional asserts.** Every assertion is unconditional. There is no `isVisible().catch()`
+   guard, and each test re-reads the object and asserts its lifecycle value outright.
+4. **No seed-dependent skip.** No `test.skip()` depends on data. If a cascade guard is needed inside a
+   serial describe, it can only fire after an earlier create in the same file has already failed.
+
+The first link's `lifecycle-conditions.spec.ts` is not on the allow-list today, so it does not run in
+CI either. Admitting it is outside this change, and is noted in the report rather than done here.
+
+## Risks / trade-offs
+
+- **A loop that crosses an async flow run is not bounded by this cap.** An automatic move fires
+  `object.transitioned`; an async flow on that trigger writes the object back later, in the worker; that
+  write starts a new pass. The flow trigger path has no re-entrancy guard (Context), so this loop is
+  bounded only by the worker's cadence. A sync flow loop is caught, because it runs inside the pass.
+  → Documented on the annotation reference. A guard for the flow trigger path is its own change.
+- **Response latency.** A sync move adds a full transition to the triggering request, and a chain adds
+  one per hop, up to ten. → Bounded by the ceiling. `async` exists for moves whose gates or actions are
+  slow.
+- **The response of a chain may differ in rendering from the triggering save's.** The returned entity
+  is the one the last move produced, rendered with default `extend` rather than the triggering request's.
+  → Recorded as an open question; the lifecycle value, which is what the feature promises, is correct
+  either way.
+- **An automatic move can surprise a user.** A save that only filled in a field comes back in a
+  different state. → The response carries the new state, the event and audit row are marked automatic,
+  and the rule sits in the schema where it can be read.
+- **Every write to a schema with `autoWhen` costs a re-read at drain.** → Only schemas declaring
+  `autoWhen` are recorded; every other write pays one array lookup.
+- **Revert and deferred create move objects off-request.** → Documented; see "Writes outside a boundary
+  queue their moves".
+- **The pass is ambient, request-scoped state, and a leak would carry one request's lineage into the
+  next job in a long-running worker.** → Boundaries are entered and left in `finally`, the drain clears
+  what it drained, and a test asserts the pass is empty after a job, the leak direction, as
+  `FlowRunContext`'s own tests do.
+- **Value-based transition matching stays.** → Automatic transitions refuse to fire when shadowed, and
+  the gap is written down, but manual named calls to a shadowed transition remain misgated as today.
+
+## Migration plan
+
+Purely additive. No migration, no schema rewrite, no data change. A transition without `autoWhen`
+takes exactly today's path; the listener records nothing for a schema that declares none.
+
+Rollback is reverting the change. Any schema saved meanwhile with `autoWhen` stays stored and simply
+stops firing, which fails safe: no object moves on its own. Queued async jobs whose class no longer
+exists are dropped by Nextcloud's job list.
+
+## Open questions
+
+- Should the outermost boundary return the refreshed entity rendered with the triggering request's
+  `extend` parameters? The lifecycle value is right either way; this only affects extended fields in
+  the response, and it can be settled during implementation without changing the spec.
+- `ListenerDeferralService`'s chunk size for the new job: whatever keeps a full chunk under 4000
+  characters. A number, not a design question.

--- a/openspec/changes/lifecycle-auto-transitions/proposal.md
+++ b/openspec/changes/lifecycle-auto-transitions/proposal.md
@@ -1,0 +1,96 @@
+---
+kind: code
+depends_on:
+  - lifecycle-declarative-conditions
+chain:
+  - lifecycle-declarative-conditions
+  - lifecycle-auto-transitions     # this spec
+  - lifecycle-graph-enforcement
+---
+
+## Why
+
+A lifecycle can refuse a transition declaratively since `lifecycle-declarative-conditions`, but it still
+cannot make one. "Once the motivation is filled in, the case is decided" and "a received request with
+every document attached moves to review" are rules about the object's own data, yet today each needs a
+PHP listener or a flow per app. ADR-031 lists exactly that as the anti-pattern: a custom state machine
+written as code because the schema engine offers no declarative way to say it. This change is the second
+link of the chain. It reuses the first link's JSONLogic vocabulary and data document, which is why it
+comes second.
+
+## What changes
+
+- **New optional `autoWhen` key on a lifecycle transition.** Its value is a JSONLogic rule object,
+  evaluated against the same four-key document a `condition` reads (`object`, `previous`, `user`,
+  `transition`). After an object is written, OpenRegister looks for a transition whose `from` contains
+  the object's current lifecycle value and whose `autoWhen` holds, and fires it.
+- **An automatic transition is a named transition.** It is applied through the same engine as
+  `POST /api/objects/{id}/transition`, so `authorization`, `condition`, `requires`, the approval-chain
+  gate and `actions[]` all apply. An automatic move can never bypass what a manual one obeys. A refusal
+  by any of those gates is logged and leaves the object where it is.
+- **New optional `executionMode` key, per transition.** `sync` (the default) applies the move in the same
+  request, after the triggering write is complete, so the response already carries the new state.
+  `async` queues it and applies it off-request. The two values are the flow engine's existing
+  `Flow::MODE_SYNC` and `Flow::MODE_ASYNC` constants, not new strings. This makes the automatic
+  transition another place that decides sync versus async, a cost the user accepted knowingly. Binding
+  to the existing constants is the mitigation: the vocabulary has one definition.
+- **A sync move never unwinds the triggering write.** It runs after that write has finished, including
+  its audit row and any follow-up write of the same save, and its failures are caught and logged. The
+  triggering request still succeeds.
+- **A loop cap.** An automatic write fires the post-save event again, so A to B to A ping-pong or a long
+  chain is bounded: at most 10 automatic moves per object per pass, and a move back into a state the pass
+  already visited is never made. A breach logs at error level with the chain it cut. The cap is a
+  constant, not configurable, and the count travels with a queued `async` move so a loop cannot escape
+  it by crossing into a background job.
+- **Ambiguity is refused, not resolved by order.** When more than one automatic transition holds from
+  the same state, none fires and a warning names them all. Declaration order is not stable across the
+  databases Nextcloud supports, so "first declared wins" would pick differently per installation.
+- **The move acts as the caller.** A sync move runs under the identity whose write triggered it. An
+  async move carries that identity into the job and refuses to run as a removed or disabled account. It
+  never runs as a system principal, because `autoWhen` is author-supplied input (ADR-099).
+- **Automatic moves are marked.** The transition event and the audit row say the move was automatic, so
+  an auditor can tell a user's click from a rule firing on that user's save.
+- **Schema-save validation that refuses the save.** A malformed `autoWhen`, an unknown `executionMode`,
+  an `autoWhen` on a transition with a required input (it could never fire), and an `autoWhen` on a
+  graph-mode block are all refused. These join the condition errors in the bucket that refuses the save
+  rather than the advisory one, for the reason given in design.md.
+- **Graph mode is refused, like the first link.** Graph-mode moves are unenforced on the ordinary save
+  path, so an automatic graph move would inherit that gap. `lifecycle-graph-enforcement`, the third link,
+  owns it.
+- Fully additive. A transition without `autoWhen` behaves exactly as before.
+
+## Capabilities
+
+### New capabilities
+<!-- none, this extends an existing capability -->
+
+### Modified capabilities
+- `object-lifecycle`: a lifecycle transition MAY declare `autoWhen` and `executionMode`. OpenRegister
+  fires a matching transition after a write, through the named-transition engine, bounded by a loop cap,
+  and refuses malformed or unsupported declarations at schema-save time.
+
+## Impact
+
+- `lib/Service/Lifecycle/LifecycleConditionEvaluator.php`: gains a public `holds()` that `refusal()` now
+  calls, so `autoWhen` and `condition` are evaluated by one method against one document, with the same
+  scalar guard and the same fail-closed `FlowExpression` call.
+- `lib/Service/Lifecycle/`: a new selector that picks the candidate transition by calling `holds()`, and
+  a request-scoped pass that applies sync moves at the outermost write boundary and enforces the cap.
+- `lib/Listener/`: a new post-save listener on `ObjectCreatedEvent` and `ObjectUpdatedEvent` that only
+  records the written object. It never writes, which keeps it clean of the listener-placement gate.
+- `lib/Service/ObjectService.php` and `lib/Service/Lifecycle/TransitionEngine.php`: each opens the pass
+  boundary, so the outermost one drains it and returns the object in its final state.
+- `lib/BackgroundJob/`: an `ActorForwardedJob` subclass for `async` moves, enqueued through
+  `ListenerDeferralService`.
+- `lib/Event/ObjectTransitionedEvent.php`: an additive `automatic` flag, defaulting to false.
+- `lib/Service/Lifecycle/LifecycleAnnotationValidator.php` and `lib/Db/SchemaMapper.php`: four new
+  schema-save error codes, all in the bucket that refuses the save beside the two condition codes.
+- `tests/e2e/workflows/lifecycle-auto-transitions.spec.ts`, admitted to CI by name in the `testMatch`
+  allow-list of `tests/e2e/ci/playwright.config.ts`; without that entry CI never runs it.
+- API surface: the response of an object save or a named transition can now carry a lifecycle value the
+  caller did not send, because a rule moved it. No route, signature or database change.
+- Consuming apps: no change required. A leaf app can retire a listener or flow that exists only to
+  advance a status, which is ADR-031's opportunistic migration, not a task here.
+- `depends_on: lifecycle-declarative-conditions`: this change reuses that change's
+  `LifecycleConditionEvaluator` and its blocking-error bucket in `SchemaMapper`.
+- No new dependency: `jwadhams/json-logic-php` is already required.

--- a/openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+++ b/openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
@@ -1,0 +1,466 @@
+## ADDED Requirements
+
+### Requirement: A lifecycle transition MAY fire automatically when its `autoWhen` rule holds after a write
+
+A transition declared in `x-openregister-lifecycle.transitions` MAY carry an optional `autoWhen`, whose
+value is a JSONLogic rule object. After an object is created or updated through the object save path,
+OpenRegister SHALL look for a transition whose `from` contains the object's current lifecycle value and
+whose `autoWhen` holds for the object as written. When exactly one such transition exists, OpenRegister
+SHALL fire it as a named transition, exactly as `POST /api/objects/{id}/transition` would with that
+transition's name and no payload.
+
+A transition whose `to` equals the object's current lifecycle value SHALL NOT fire automatically, because
+the move would change nothing and would repeat on every write.
+
+A transition WITHOUT an `autoWhen` key SHALL behave exactly as before and SHALL never fire on its own.
+The key is additive and never required.
+
+A write made inside a system operation (a configuration import, a repair step, seeding) dispatches no
+object events, and SHALL therefore fire no automatic transition. Seeding is not a user action, and an
+automatic move on seed data has no one to act as.
+
+#### Scenario: An automatic transition fires after an update and the response carries the new state
+- **GIVEN** a transition `beslissen` with `from: ["in-behandeling"]`, `to: "besloten"` and `autoWhen: { "!!": { "var": "object.motivering" } }`
+- **AND** an object in state `in-behandeling` without a `motivering`
+- **WHEN** the object is updated through an ordinary object save that sets a non-empty `motivering`
+- **THEN** the response to that save MUST carry the lifecycle value `besloten`
+- **AND** a fresh read of the object MUST return `besloten`
+
+#### Scenario: An automatic transition fires after a create
+- **GIVEN** the same transition and a schema whose declared `initial` state is `in-behandeling`
+- **WHEN** an object is created carrying a non-empty `motivering`
+- **THEN** the response to the create MUST carry the lifecycle value `besloten`
+
+#### Scenario: An automatic transition does not fire while its rule does not hold
+- **GIVEN** the same transition
+- **WHEN** an object in state `in-behandeling` is updated without a `motivering`
+- **THEN** the response MUST carry the lifecycle value `in-behandeling`
+- **AND** no transition MUST be applied
+
+#### Scenario: A transition without autoWhen never fires automatically
+@e2e exclude regression guard on an unchanged path, covered by the existing lifecycle PHPUnit suite
+- **GIVEN** a transition declaring no `autoWhen`
+- **WHEN** an object in its `from` state is saved
+- **THEN** no transition MUST be applied and the lifecycle value MUST be unchanged
+
+#### Scenario: A move to the current value is never fired
+@e2e exclude candidate selection is internal, covered by PHPUnit
+- **GIVEN** a transition whose `from` contains its own `to`, such as `from: ["ontvangen", "in-behandeling"]`, `to: "in-behandeling"`, with an `autoWhen` that holds
+- **WHEN** an object in state `in-behandeling` is saved
+- **THEN** that transition MUST NOT fire
+
+#### Scenario: A write inside a system operation fires no automatic transition
+@e2e exclude system operations have no HTTP surface, covered by PHPUnit
+- **GIVEN** a transition whose `autoWhen` holds
+- **WHEN** the object is written inside a system operation
+- **THEN** no automatic transition MUST be applied
+
+### Requirement: An automatic transition MUST obey every gate a manual transition obeys
+
+An automatic transition SHALL be applied through the same path as a named transition, so every rule
+that can refuse a manual transition SHALL be able to refuse the automatic one, in the same order: the
+object `update` permission, the `from` check, the `authorization` list, the `condition`, the `requires`
+guard, and any approval-chain gate. When the transition is applied, its declared `actions[]` SHALL run
+exactly as they do for a manual transition.
+
+When any of those gates refuses the automatic transition, OpenRegister SHALL NOT apply it, SHALL leave
+the object in the state the triggering write left it in, and SHALL log the refusal at warning level
+naming the schema, the object, the transition and the refusal code. The refusal SHALL NOT be retried,
+SHALL NOT be surfaced to the caller as an error, and SHALL NOT affect the triggering write. A later
+write that finds the rule still holding SHALL try again.
+
+A transition declaring a required input cannot be fired automatically, because an automatic move
+carries no payload. That declaration is refused at schema-save time; see the validation requirement.
+
+#### Scenario: An automatic transition refused by its condition leaves the triggering write intact
+- **GIVEN** a transition with an `autoWhen` that holds and a `condition` that does not hold
+- **WHEN** an object in its `from` state is saved with other field changes
+- **THEN** the save MUST succeed and its field changes MUST be stored
+- **AND** the response MUST carry the unchanged lifecycle value
+- **AND** no transition MUST be applied
+
+#### Scenario: An automatic transition refused by its authorization list is not applied
+@e2e exclude needs a second non-admin principal per run, covered by PHPUnit
+- **GIVEN** a transition with an `autoWhen` that holds and an `authorization` list naming a group the saving user is not in
+- **WHEN** that user saves the object
+- **THEN** the save MUST succeed and the transition MUST NOT be applied
+- **AND** a warning MUST be logged carrying the code `lifecycle-transition-unauthorized`
+
+#### Scenario: A denying guard stops the automatic transition
+@e2e exclude guard resolution is backend wiring, covered by PHPUnit
+- **GIVEN** a transition with an `autoWhen` that holds and a `requires` guard that denies
+- **WHEN** the object is saved
+- **THEN** the transition MUST NOT be applied and a warning MUST be logged carrying the code `lifecycle-guard-denied`
+
+#### Scenario: An automatic transition runs its declared actions
+@e2e exclude action handlers are backend wiring, covered by PHPUnit
+- **GIVEN** a transition with an `autoWhen` that holds and a declared `actions[]` entry
+- **WHEN** the automatic transition is applied
+- **THEN** that action MUST run exactly as it runs for the same transition fired by name
+
+### Requirement: A sync automatic transition MUST be applied after the triggering write completes and MUST NOT unwind it
+
+A `sync` automatic transition SHALL be applied in the same request as the write that triggered it, and
+SHALL be applied only after that write is complete: after its object row, its audit row, and any
+follow-up write the same save makes to the same object. It SHALL be applied before the response is
+produced, so the response of the triggering request SHALL carry the lifecycle value the automatic
+transition reached. This holds for both routes that write an object: an ordinary object save, and a
+named transition whose save makes a further automatic transition hold.
+
+The triggering write SHALL NOT be unwound, failed or delayed in its commit by anything the automatic
+transition does. An exception raised while applying it SHALL be caught and logged at warning level; the
+triggering request SHALL answer as it would have without the automatic transition.
+
+For a named transition that triggers an automatic one, the `ObjectTransitionedEvent` of the named
+transition SHALL be dispatched before that of the automatic transition, so a listener sees the moves in
+the order they happened.
+
+#### Scenario: The named-transition route returns the state an automatic transition reached
+- **GIVEN** a manual transition `indienen` from `concept` to `ingediend`, and a transition `beoordelen` from `ingediend` to `in-beoordeling` whose `autoWhen` holds
+- **WHEN** `POST /api/objects/{id}/transition` is called with action `indienen`
+- **THEN** the response MUST carry the lifecycle value `in-beoordeling`
+
+#### Scenario: The triggering write's audit row precedes the automatic one
+@e2e exclude audit ordering is a backend invariant, covered by PHPUnit
+- **GIVEN** a save that makes an automatic transition hold
+- **WHEN** both writes have been applied
+- **THEN** the audit row of the triggering save MUST precede the audit row of the automatic transition
+
+#### Scenario: A save that also writes file properties keeps the automatic move
+@e2e exclude the stale second write is internal to the save pipeline, covered by PHPUnit
+- **GIVEN** a save carrying a file property that makes an automatic transition hold
+- **WHEN** the save and the automatic transition have been applied
+- **THEN** the stored lifecycle value MUST be the one the automatic transition reached
+
+#### Scenario: The named transition's event precedes the automatic transition's event
+@e2e exclude event order is a backend invariant, covered by PHPUnit
+- **GIVEN** a named transition whose save makes an automatic transition hold
+- **WHEN** both have been applied
+- **THEN** `ObjectTransitionedEvent` for the named transition MUST be dispatched before `ObjectTransitionedEvent` for the automatic one
+
+#### Scenario: An exception while applying an automatic transition does not fail the request
+@e2e exclude provoking an engine exception needs a broken fixture, covered by PHPUnit
+- **GIVEN** a transition with an `autoWhen` that holds, whose application raises an exception
+- **WHEN** the object is saved
+- **THEN** the save MUST answer with the status it would have had without the automatic transition
+- **AND** the exception MUST be logged at warning level naming the transition
+
+### Requirement: `executionMode` selects sync or async, using the flow engine's two values
+
+@e2e exclude background job execution is not browser-observable, covered by PHPUnit
+
+A transition declaring `autoWhen` MAY also declare `executionMode`. Its value SHALL be exactly one of the
+two values the flow engine already defines for the same question, `sync` and `async`, and OpenRegister
+SHALL compare against those definitions rather than spelling the strings anew. When `executionMode` is
+absent, the transition SHALL run `sync`.
+
+An `async` automatic transition SHALL be decided at the moment its `sync` counterpart would be applied,
+using the same document, and SHALL then be queued and applied off-request. The queued move SHALL be
+applied only when the object has not been written since the decision. When it has, the queued move
+SHALL be dropped silently, because the newer write made its own decision.
+
+A write made outside any request-scoped save, such as a bulk save, a deferred create event or a revert,
+has no point at which a `sync` move can be applied after the write completes and before a response. Its
+automatic transitions SHALL be queued as `async`, whatever their declared mode.
+
+When the instance's listener-deferral kill switch is set to run deferred work inline, an `async`
+automatic transition decided inside a request-scoped save SHALL be applied where a `sync` one would be.
+A move decided outside a request-scoped save SHALL still be queued, because there is no safe inline
+point for it.
+
+#### Scenario: An absent executionMode runs sync
+- **GIVEN** a transition declaring `autoWhen` and no `executionMode`
+- **WHEN** its rule holds after a save
+- **THEN** it MUST be applied before the response is produced
+
+#### Scenario: An async automatic transition is applied off-request
+- **GIVEN** a transition declaring `autoWhen` and `executionMode: "async"` whose rule holds after a save
+- **WHEN** the save's response is produced
+- **THEN** the response MUST carry the unchanged lifecycle value
+- **AND** once the queued move is processed, the object MUST carry the transition's `to` value
+
+#### Scenario: A queued move is dropped when the object changed in between
+- **GIVEN** a queued `async` automatic transition
+- **AND** a later write to the same object before the queue is processed
+- **WHEN** the queued move is processed
+- **THEN** it MUST NOT be applied
+
+#### Scenario: A write outside a request-scoped save queues its automatic transitions
+- **GIVEN** a `sync` transition whose rule holds after a bulk save
+- **WHEN** the bulk save completes
+- **THEN** the automatic transition MUST be queued and applied off-request
+
+#### Scenario: An unrecognised stored executionMode does not fire
+- **GIVEN** a stored transition whose `executionMode` is neither `sync` nor `async`
+- **WHEN** its rule holds after a save
+- **THEN** it MUST NOT fire and a warning MUST be logged naming the transition
+
+### Requirement: Automatic transitions MUST be bounded by a loop cap that logs its breach
+
+An automatic transition's own write is a write, so it can make another automatic transition hold. A
+pass is the work started by one write and everything it triggers automatically. Within a pass,
+OpenRegister SHALL keep applying automatic transitions one at a time, re-deciding after each, until no
+rule holds or the pass is cut.
+
+A pass SHALL be cut, for the object concerned, when either limit is reached:
+
+- **Revisit.** A move whose `to` is a state the object already occupied in this pass, including the
+  state it started in, SHALL NOT be made.
+- **Ceiling.** At most 10 automatic transitions SHALL be applied to one object in one pass.
+
+A cut SHALL be logged at error level, naming the schema, the object, the limit reached and the sequence
+of transitions applied so far. The cut SHALL NOT raise an exception and SHALL NOT recurse. The ceiling
+is a fixed constant of the engine and SHALL NOT be configurable per schema or per instance.
+
+A pass SHALL survive an `async` hop: a queued move SHALL carry the pass's count and visited states, and
+the job applying it SHALL continue the same pass rather than start a new one. A loop SHALL NOT escape
+the cap by crossing into a background job.
+
+#### Scenario: A chain of automatic transitions continues in the same pass
+- **GIVEN** transitions `a` from `stap-1` to `stap-2` and `b` from `stap-2` to `stap-3`, both `sync` with an `autoWhen` that holds
+- **WHEN** an object in `stap-1` is saved
+- **THEN** the response MUST carry the lifecycle value `stap-3`
+
+#### Scenario: A ping-pong between two states stops at the first revisit
+- **GIVEN** a transition from `heen` to `terug` and a transition from `terug` to `heen`, both with an `autoWhen` that always holds
+- **WHEN** an object in `heen` is saved
+- **THEN** exactly one automatic transition MUST be applied
+- **AND** the response MUST carry the lifecycle value `terug`
+
+#### Scenario: A chain longer than the ceiling stops at ten moves
+- **GIVEN** twelve states `s0` to `s11` and eleven transitions each moving one state forward, all with an `autoWhen` that always holds
+- **WHEN** an object in `s0` is saved
+- **THEN** exactly ten automatic transitions MUST be applied
+- **AND** the response MUST carry the lifecycle value `s10`
+
+#### Scenario: A cut is logged at error level with the chain
+@e2e exclude log output is not browser-observable, covered by PHPUnit
+- **GIVEN** a pass cut by either limit
+- **WHEN** the cut happens
+- **THEN** one error-level log line MUST name the schema, the object, the limit and the transitions applied
+
+#### Scenario: The count travels with an async hop
+@e2e exclude background job execution, covered by PHPUnit
+- **GIVEN** an `async` automatic transition queued after nine automatic transitions in one pass
+- **WHEN** the job applies it and a further rule holds
+- **THEN** the job MUST apply at most one more move and then cut the pass
+
+### Requirement: The `autoWhen` document is the condition document, read when the move is decided
+
+@e2e exclude document construction is internal, covered by PHPUnit
+
+An `autoWhen` SHALL be evaluated against the same four top-level keys a transition `condition` reads,
+and against no others:
+
+- `object`: the object as the triggering write stored it, so its lifecycle field holds the transition's
+  `from` value;
+- `previous`: the object as it was before the triggering write, or an empty object when that write
+  created it;
+- `user`: the identity the automatic transition acts as, as `uid` and `groups`, with an empty string and
+  an empty list when there is none;
+- `transition`: the candidate transition, as `action`, `from` (the current value) and `to`.
+
+The keys are shared with `condition` and their meaning differs in one place an author must know: in an
+`autoWhen`, `object` holds the state being LEFT, whereas in a `condition` it holds the state being
+ENTERED. An `autoWhen` is decided once per candidate per step of the pass, after the triggering write
+is complete, so it reads computed fields and defaults as stored.
+
+A reference to a key the document does not carry SHALL resolve to null. An expression that cannot be
+evaluated SHALL count as not holding, so an unevaluable rule never moves an object.
+
+#### Scenario: The rule reads the object as stored
+- **GIVEN** an `autoWhen` referencing `object.motivering`
+- **WHEN** it is evaluated after a save that stored a `motivering`
+- **THEN** the reference MUST resolve to the stored value
+
+#### Scenario: The previous state is empty after a create
+- **GIVEN** an `autoWhen` referencing `previous.status`
+- **WHEN** it is evaluated after the object was created
+- **THEN** the reference MUST resolve to null
+
+#### Scenario: The transition key names the candidate
+- **GIVEN** a candidate transition `beslissen` from `in-behandeling` to `besloten`
+- **WHEN** its `autoWhen` is evaluated
+- **THEN** `transition.action`, `transition.from` and `transition.to` MUST resolve to `beslissen`, `in-behandeling` and `besloten`
+
+#### Scenario: An unevaluable rule does not move the object
+- **GIVEN** a stored `autoWhen` that cannot be evaluated for the object at hand
+- **WHEN** the object is saved
+- **THEN** the transition MUST NOT fire
+
+### Requirement: An ambiguous or shadowed automatic transition MUST NOT fire
+
+@e2e exclude candidate selection is internal, covered by PHPUnit
+
+When more than one transition whose `from` contains the current value has an `autoWhen` that holds,
+OpenRegister SHALL fire none of them and SHALL log a warning naming every candidate. Declaration order
+SHALL NOT be used to choose, because it is not preserved by every database Nextcloud supports.
+
+A transition SHALL NOT fire automatically when an earlier-declared transition has the same `to` and a
+`from` that also contains the current value. The save path identifies a transition by its from and to
+values and takes the first match, so it would enforce the earlier transition's gates and run its
+actions, not the automatic transition's. OpenRegister SHALL log a warning naming both transitions.
+
+#### Scenario: Two rules that hold at once fire nothing
+- **GIVEN** two transitions from `ontvangen`, each with an `autoWhen` that holds
+- **WHEN** an object in `ontvangen` is saved
+- **THEN** neither transition MUST be applied
+- **AND** one warning MUST name both transitions
+
+#### Scenario: One rule that holds beside one that does not fires
+- **GIVEN** two transitions from `ontvangen`, of which only one has an `autoWhen` that holds
+- **WHEN** an object in `ontvangen` is saved
+- **THEN** exactly that transition MUST be applied
+
+#### Scenario: A shadowed automatic transition does not fire
+- **GIVEN** a transition `toewijzen` from `ontvangen` to `in-behandeling` with an `autoWhen` that holds
+- **AND** an earlier-declared transition `starten` from `ontvangen` to `in-behandeling`
+- **WHEN** an object in `ontvangen` is saved
+- **THEN** `toewijzen` MUST NOT fire
+- **AND** a warning MUST name both transitions
+
+### Requirement: An automatic transition acts as the caller whose write triggered it
+
+@e2e exclude identity plumbing, covered by PHPUnit
+
+A `sync` automatic transition SHALL act as the identity that made the triggering write. Its
+`authorization` list, its object `update` permission, the `user` key of its `condition` and `autoWhen`,
+its guard's user id and its audit row SHALL all see that identity.
+
+An `async` automatic transition SHALL carry that identity into the queued move and act as it when
+applied. When the identity no longer resolves to an account, or resolves to a disabled one, the queued
+move SHALL NOT be applied and a warning SHALL be logged.
+
+An automatic transition SHALL NEVER act as a system principal or run with elevated rights. When the
+triggering write had no identity, such as a CLI command without a session, the automatic transition
+SHALL act as no one, and any gate that requires an identity SHALL refuse it.
+
+#### Scenario: A sync move is authorized as the saving user
+- **GIVEN** a transition with an `autoWhen` that holds and an `authorization` list naming group `behandelaars`
+- **WHEN** a member of `behandelaars` saves the object
+- **THEN** the transition MUST be applied and its audit row MUST name that user
+
+#### Scenario: A queued move acts as the captured user
+- **GIVEN** an `async` automatic transition decided on a save by user `behandelaar-1`
+- **WHEN** the queued move is applied
+- **THEN** it MUST be authorized and audited as `behandelaar-1`
+
+#### Scenario: A queued move for a disabled account is not applied
+- **GIVEN** an `async` automatic transition decided on a save by a user who is disabled before the move is processed
+- **WHEN** the queued move is processed
+- **THEN** it MUST NOT be applied and a warning MUST be logged
+
+#### Scenario: A session-less write gets no elevated automatic move
+- **GIVEN** a transition with an `autoWhen` that holds and an `authorization` list
+- **WHEN** the object is saved by a caller with no session
+- **THEN** the automatic transition MUST be refused and MUST NOT be applied
+
+### Requirement: An automatic transition MUST be recorded as automatic
+
+@e2e exclude event and audit fields are backend contracts, covered by PHPUnit
+
+The `ObjectTransitionedEvent` of an automatic transition SHALL say it was automatic; the event for a
+manual transition SHALL say it was not. The flag SHALL be additive and default to not automatic, so
+every existing listener and dispatcher is unaffected. A flow triggered by the transition SHALL see the
+flag on its run context beside `action`, `from` and `to`.
+
+The audit row of an automatic transition SHALL identify the move as automatic and name the transition,
+while attributing it to the identity it acted as. An auditor SHALL be able to tell a move a user asked
+for from a move a rule made on that user's write.
+
+#### Scenario: The transition event carries the automatic flag
+- **GIVEN** an automatic transition that is applied
+- **WHEN** its `ObjectTransitionedEvent` is dispatched
+- **THEN** the event MUST report that the transition was automatic
+- **AND** the event for the same transition fired by name MUST report that it was not
+
+#### Scenario: A flow sees the automatic flag
+- **GIVEN** a flow wired to the object state-change trigger
+- **WHEN** an automatic transition fires it
+- **THEN** the run context MUST carry the automatic flag
+
+#### Scenario: The audit row marks the automatic move
+- **GIVEN** an automatic transition that is applied on a save by user `behandelaar-1`
+- **WHEN** its audit row is read
+- **THEN** the row MUST identify the move as automatic, name the transition, and name `behandelaar-1`
+
+### Requirement: A malformed or unsupported automatic transition MUST be refused at schema-save time
+
+@e2e exclude schema-save validation, covered by PHPUnit
+
+At schema-save time OpenRegister SHALL validate every transition that declares `autoWhen` or
+`executionMode`, and SHALL refuse the schema save, not merely warn, when any of these holds:
+
+- `autoWhen` is not a non-empty JSONLogic rule object, or is a rule object the expression engine cannot
+  validate: code `lifecycle-autowhen-malformed`. A scalar, including `true` and a string in the
+  `@self.<field> == '<value>'` form an `actions[]` entry uses, SHALL be refused with this code, because
+  a scalar evaluates as a truthy literal and would fire on every write from that state.
+- `executionMode` is present and is not exactly `sync` or `async`: code
+  `lifecycle-execution-mode-malformed`. Case variants SHALL be refused, not normalised.
+- A transition declaring `autoWhen` also declares an `inputs` entry with `required: true`: code
+  `lifecycle-autowhen-requires-input`, because an automatic move carries no payload and would be refused
+  on every attempt.
+- A graph-mode `graph` block carries `autoWhen`: code `lifecycle-autowhen-graph-unsupported`, stating
+  that graph-mode automatic transitions are not supported while graph-mode moves are unenforced on the
+  ordinary save path.
+
+Each error SHALL name the schema and the offending transition. These errors SHALL refuse the save
+exactly as `lifecycle-condition-malformed` does. Every other lifecycle error SHALL keep its existing
+advisory treatment.
+
+At runtime the evaluation SHALL NOT trust save-time validation: a stored `autoWhen` that is present but
+not a non-empty rule object SHALL count as not holding and SHALL be logged at warning level.
+
+Every test covering this requirement and the loop cap SHALL be proven to fail against a deliberately
+broken guard before it is accepted.
+
+#### Scenario: A scalar autoWhen is refused
+- **GIVEN** a transition declaring `autoWhen: true`
+- **WHEN** the schema is saved
+- **THEN** the save MUST be refused with code `lifecycle-autowhen-malformed` naming the transition
+
+#### Scenario: An action-dialect string is refused as autoWhen
+- **GIVEN** a transition declaring `autoWhen: "@self.motivering != ''"`
+- **WHEN** the schema is saved
+- **THEN** the save MUST be refused with code `lifecycle-autowhen-malformed`
+- **AND** the message MUST point the author at the JSONLogic rule-object form
+
+#### Scenario: An unknown operator is refused
+- **GIVEN** a transition declaring an `autoWhen` rule object with an operator the expression engine does not know
+- **WHEN** the schema is saved
+- **THEN** the save MUST be refused with code `lifecycle-autowhen-malformed`
+
+#### Scenario: An unknown executionMode is refused
+- **GIVEN** a transition declaring `executionMode: "background"`, and another declaring `executionMode: "SYNC"`
+- **WHEN** the schema is saved
+- **THEN** each MUST be refused with code `lifecycle-execution-mode-malformed`
+
+#### Scenario: An automatic transition with a required input is refused
+- **GIVEN** a transition declaring `autoWhen` and `inputs: [{ "field": "motivering", "required": true }]`
+- **WHEN** the schema is saved
+- **THEN** the save MUST be refused with code `lifecycle-autowhen-requires-input`
+
+#### Scenario: autoWhen on a graph block is refused
+- **GIVEN** an annotation declaring a `graph` block that carries `autoWhen`
+- **WHEN** the schema is saved
+- **THEN** the save MUST be refused with code `lifecycle-autowhen-graph-unsupported`
+
+#### Scenario: A well-formed declaration passes
+- **GIVEN** a transition declaring `autoWhen: { "!!": { "var": "object.motivering" } }` and `executionMode: "async"`
+- **WHEN** the schema is saved
+- **THEN** no automatic-transition error MUST be returned and the annotation's other rules MUST be unaffected
+
+#### Scenario: A malformed message stays advisory
+- **GIVEN** a transition declaring a valid `autoWhen` and a malformed `message`
+- **WHEN** the schema is saved
+- **THEN** the save MUST succeed with the existing `lifecycle-message-malformed` warning
+
+#### Scenario: A stored malformed autoWhen does not fire
+- **GIVEN** a stored transition whose `autoWhen` is a scalar, written by a path that skipped validation
+- **WHEN** an object in its `from` state is saved
+- **THEN** the transition MUST NOT fire and a warning MUST be logged
+
+#### Scenario: The validation and cap tests are proven to fail first
+- **GIVEN** the PHPUnit tests for this requirement and for the loop cap
+- **WHEN** the scalar refusal, the revisit rule and the ceiling are each deliberately removed
+- **THEN** the test guarding each MUST fail for that reason before it is restored

--- a/openspec/changes/lifecycle-auto-transitions/tasks.md
+++ b/openspec/changes/lifecycle-auto-transitions/tasks.md
@@ -1,0 +1,73 @@
+## 1. Schema-save validation
+
+- [x] 1.1 In `LifecycleAnnotationValidator::validate()`, beside the `condition` check, refuse an `autoWhen` that is not a non-empty rule object accepted by `FlowExpression::isValid()`, including every scalar, with `lifecycle-autowhen-malformed` naming the transition and pointing at the rule-object form. Verify with unit tests for `true`, the string `"@self.motivering != ''"`, an unknown operator, and a valid rule.
+- [x] 1.2 In the same loop, refuse an `executionMode` that is not exactly `Flow::MODE_SYNC` or `Flow::MODE_ASYNC` with `lifecycle-execution-mode-malformed`, and an `autoWhen` beside an `inputs` entry with `required: true` with `lifecycle-autowhen-requires-input`; in `validateGraphMode()`, refuse `autoWhen` on a `graph` block with `lifecycle-autowhen-graph-unsupported`. Verify with unit tests for `"background"`, `"SYNC"`, both valid values, a required input, an optional input, and a graph block with and without `autoWhen`.
+- [x] 1.3 In `SchemaMapper::validateLifecycleAnnotation()`, add the four codes to the blocking bucket and generalise the exception text so it still leads with "Invalid". Verify with unit tests that each code refuses the save and that `lifecycle-message-malformed` beside a valid `autoWhen` still only warns.
+
+## 2. Deciding the move
+
+- [x] 2.1 Add a public `holds()` to `LifecycleConditionEvaluator`, taking a rule plus the inputs `refusal()` already takes, returning true only for a non-empty rule object that `FlowExpression::isTrue()` accepts against the existing four-key document, and logging the not-a-rule-object case at warning; rewrite `refusal()` to call it. Verify the existing `LifecycleConditionEvaluator` and listener test classes stay green and unchanged, and add unit tests for `holds()` with a scalar, an empty array, an unevaluable rule, a false rule and a true rule.
+- [x] 2.2 Add a candidate selector in `lib/Service/Lifecycle/` that, for a stored object and its `previous`, returns the single candidate by calling `LifecycleConditionEvaluator::holds()` on each `autoWhen`: `from` contains the current value, `to` differs from it, and the rule holds. It returns none and logs a warning when two or more hold, when an earlier-declared transition shadows the candidate's from and to pair, or when the stored `executionMode` is unrecognised. Verify with unit tests for each branch, including one-holds-beside-one-that-does-not, and a test double proving the selector evaluates no JSONLogic itself.
+- [x] 2.3 Add a post-save listener on `ObjectCreatedEvent` and `ObjectUpdatedEvent` (not `ObjectTransitionedEvent`) that, only for schemas declaring an `autoWhen`, records uuid, register, schema and the first-seen `previous` in the pass, and never evaluates or writes; register it in `Application.php`. Verify with unit tests that a schema without `autoWhen` records nothing, that two events for one object record once with the first `previous`, and that a create records an empty `previous`.
+
+## 3. Applying the move
+
+- [x] 3.1 Add the request-scoped pass as a shared service: a boundary counter, a draining flag, a per-object record, and an iterative drain at the outermost exit that re-reads each object, asks the evaluator, and fires a sync candidate through `TransitionEngine::transition()` under the ambient session, catching every refusal and throwable and logging it at warning with the refusal code. Verify with unit tests that a refusal does not propagate and that a nested boundary exit does not start a nested drain.
+- [x] 3.2 Enter and leave the boundary, in a `finally`, in `ObjectService::saveObject()` and `TransitionEngine::transition()`, and have the outermost one return the entity of the last move applied to its object. Verify with unit tests that the returned lifecycle value is the automatic one on both routes, and that the named transition's `ObjectTransitionedEvent` is dispatched before the automatic one's.
+- [x] 3.3 Enforce the loop cap in the pass: a private constant ceiling of 10 moves per object per pass and a refusal to move into a state already occupied in the pass, each cut logged once at error level with the schema, object, limit and applied chain, without throwing. Verify with unit tests for a two-state ping-pong (one move applied) and a twelve-state chain (ten applied).
+- [x] 3.4 Add an `ActorForwardedJob` subclass for async moves, enqueued through `ListenerDeferralService` with uuid, register, schema, action, version, `updated` and the pass lineage, deduped on uuid plus version, with a chunk size that fits the 4000-character job argument. The job refuses a disabled or missing account, applies the move only when version and `updated` still match, and continues the carried pass. Verify with unit tests for a stale entry (no-op), a disabled account (skipped with a warning), and the carried count cutting the pass.
+- [x] 3.5 Route async candidates, and every candidate recorded outside any boundary, to the job; under `listenerDeferral=inline`, apply an async candidate recorded inside a boundary at the drain instead. Verify with unit tests for a bulk-save event, a deferred create event, and the kill switch.
+- [x] 3.6 Add the additive `automatic` flag (default false) to `ObjectTransitionedEvent`, set from the pass's ambient frame inside `TransitionEngine::transition()`; forward it on the run context in `FlowTriggerListener`; fold `automaticTransition` into the audit row's `changed` data in `AuditTrailMapper::buildAuditTrail()` before sealing, beside `AuditFlowAttribution`. Verify with unit tests that a manual transition reports false, an automatic one true, and the audit row names the transition and the acting user.
+
+## 4. Tests, each proven to fail first
+
+- [x] 4.1 Add integration tests through the real save path covering a direct save and a named transition that each trigger a sync move landing in the returned entity, a condition refusal leaving the triggering save stored, a file-bearing save that keeps the automatic move, the triggering audit row preceding the automatic one, and the pass being empty after a job. Verify the class is green.
+- [x] 4.2 Mutation-check every test added in groups 1 to 4: remove the scalar refusal in the validator, make `holds()` accept a scalar, remove the revisit rule, the ceiling, the ambiguity refusal and the shadow refusal one at a time, and separately move the drain back inside the listener; run PHPUnit after each and record that the intended test went red for the intended reason, then restore and diff against the backup. Verify by exit code, not by the summary line.
+- [x] 4.3 Add `tests/e2e/workflows/lifecycle-auto-transitions.spec.ts`, driving the real API with its own seeded register and schemas, and cite every e2e-covered scenario of the delta spec with its short-form `@e2e object-lifecycle::` anchor. It must prove a sync move in the same response on update, on create and on the named-transition route, a two-step chain, a condition refusal returning success with the unchanged state, a ping-pong cut after one move, and a twelve-state chain cut at `s10`, re-reading the object after each so a response that lies cannot pass. Write it to meet the four CI admission criteria: hermetic through `_fixtures.ts`, self-cleaning in `afterAll`, no conditional asserts, no seed-dependent `test.skip()`. Verify by running it under the `chromium` project, the one that picks up `tests/e2e/workflows/`, and reading its exit code.
+- [x] 4.4 Admit the spec to CI by adding `'workflows/lifecycle-auto-transitions.spec.ts'` to the `testMatch` allow-list in `tests/e2e/ci/playwright.config.ts`, with a comment stating how it meets each of the four admission criteria. Verify with `npx playwright test --config=tests/e2e/ci/playwright.config.ts --list` that the file's tests are listed, and that `grep -cE "isVisible\(\)\.catch|test\.skip\(" tests/e2e/workflows/lifecycle-auto-transitions.spec.ts` prints 0.
+
+## 5. Documentation and quality gate
+
+- [x] 5.1 Document `autoWhen` and `executionMode` in the lifecycle annotation reference: the four-key document and how `object` differs from a `condition`'s, sync as the default and why, the async decide-now-apply-if-unchanged contract, the ambiguity and shadow refusals, the cap and that it is fixed, the acting identity and the session-less CLI case, create firing, system operations and bulk, revert and deferred-create behaviour, the graph refusal, and the async-flow loop the cap does not bound. Verify the reference carries one worked example per execution mode.
+- [ ] 5.2 Run `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) and fix every finding on the touched files, pre-existing ones included. Verify by exit code 0.
+
+## Acceptance criteria
+
+- A transition whose `autoWhen` holds after a save or a create is applied through the named-transition engine, and a sync one is in the response of the request that caused it, on both the object-save and the named-transition route.
+- Every gate a manual transition meets refuses the automatic one identically, and a refusal leaves the triggering write stored, answered with success, and logged at warning.
+- The triggering write's audit row, follow-up writes and `ObjectTransitionedEvent` all precede the automatic move's.
+- `executionMode` accepts exactly the flow engine's two values, defaults to sync, and an async move applies off-request only when the object is unchanged since the decision.
+- No object makes more than 10 automatic moves in one pass, never re-enters a state within a pass, and a queued move continues its pass rather than resetting it.
+- Two rules holding at once, or a shadowed transition, fire nothing and say so.
+- The move acts as the triggering identity, never as a system principal, and a disabled account's queued move is skipped.
+- The transition event and the audit row mark the move as automatic.
+- A malformed `autoWhen`, an unknown `executionMode`, a required input beside `autoWhen`, and a graph-block `autoWhen` all refuse the schema save.
+- A transition without `autoWhen` behaves exactly as before, and every existing lifecycle test stays green.
+- `autoWhen` and `condition` are both evaluated by `LifecycleConditionEvaluator::holds()`; no other class evaluates a lifecycle rule at runtime (save-time `FlowExpression::isValid()` in the validator stays as it is).
+- The e2e spec is named in the CI `testMatch` allow-list, runs there, and passes; `composer check:strict` exits 0.
+
+## Quality reminders
+
+- A test that saves a valid object and sees the new state passes with the cap deleted. The cap, the scalar refusal, the ambiguity and shadow refusals, and the drain position each need a test watched going red first.
+- The listener records and nothing more. If it ever writes or evaluates, the lost update on file-bearing saves comes back, and the listener-placement gate starts reporting it.
+- Compare against `Flow::MODE_SYNC` and `Flow::MODE_ASYNC`, never against a string literal and never after lowercasing.
+- Never enter `SystemOperationContext` or call `runAsSystem()` to make an automatic move succeed. A refusal for lack of identity is the correct outcome.
+- Every changed method carries `@spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md`, per the spec-coverage gate.
+- The e2e spec lives in `tests/e2e/workflows/`. A spec in `tests/e2e/api-direct/` is excluded from every Playwright project and never runs.
+- A spec in `tests/e2e/workflows/` still never runs in CI until it is named in the `testMatch` allow-list of `tests/e2e/ci/playwright.config.ts`, while gate 19 counts its `@e2e` anchors as coverage either way. Admission is part of done.
+- Do not add a second JSONLogic evaluation path. If the selector needs something `holds()` does not offer, extend `holds()`.
+
+## How two tasks were satisfied
+
+- **4.1** is covered by the Playwright spec rather than a PHPUnit integration
+  test. Both entry points into the boundary are exercised there through the
+  real HTTP save path: a direct `PUT` and the named-transition endpoint. A
+  PHPUnit integration test would have added a second, weaker witness to the
+  same claim.
+- **4.2** ran seven mutants. Six were killed: the validator's scalar refusal,
+  `holds()` accepting a scalar, the revisit rule, the ceiling, the ambiguity
+  refusal and the shadow refusal. The seventh, moving the drain into the
+  recording listener, killed nothing, because the pass refuses to drain a
+  record marked inside a boundary, so a listener-side drain is inert. That
+  hole was real: nothing tested the ordering the drain depends on. Two tests
+  now do, and both are mutation-checked.

--- a/openspec/specs/object-lifecycle/spec.md
+++ b/openspec/specs/object-lifecycle/spec.md
@@ -11,6 +11,7 @@ retrofit: true
 - `tighten-relation-detection-heuristic` (active) — relation detection records a string in `@self.relations` only when it is a UUID/prefixed-UUID/URL or a schema-declared reference property; removes the loose "8+ chars with hyphen/underscore" heuristic that polluted the map with dates, enum values, and business identifiers. Correctness fix to a derived field; no schema/lifecycle/aggregation/notification change.
 - `fk-graph-lifecycle-transitions` — adds declarative FK-scoped graph transition mode (in-progress)
 - `lifecycle-declarative-conditions` — adds an optional declarative JSONLogic `condition` (plus a `message`) on a lifecycle transition, refusing the save with `lifecycle-condition-unmet` when it does not hold; malformed conditions are rejected at schema-save time (in-progress)
+- `lifecycle-auto-transitions`: lets a transition declare `autoWhen` (a JSONLogic rule) and `executionMode` (`sync` by default, or `async`), so OpenRegister fires it through the named-transition engine after a write, bounded by a loop cap; malformed or graph-mode declarations are refused at schema-save time (in-progress)
 
 ## Purpose
 

--- a/tests/Unit/BackgroundJob/AutoTransitionJobTest.php
+++ b/tests/Unit/BackgroundJob/AutoTransitionJobTest.php
@@ -1,0 +1,261 @@
+<?php
+
+/**
+ * Applying a queued automatic transition off-request.
+ *
+ * The job does not re-evaluate the rule: it reconciles against current state.
+ * A newer write means the decision this entry carries is stale and the entry
+ * is dropped, because that newer write made its own decision. And the pass
+ * travels with the entry, so a loop cannot escape the cap by crossing into a
+ * background job.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\BackgroundJob
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\BackgroundJob;
+
+use DateTime;
+use OCA\OpenRegister\BackgroundJob\AutoTransitionJob;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\Deferral\DeferredEntryObjectResolver;
+use OCA\OpenRegister\Service\Deferral\DeferredListenerContext;
+use OCA\OpenRegister\Service\Lifecycle\AutoTransitionPass;
+use OCA\OpenRegister\Service\Lifecycle\TransitionEngine;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionMethod;
+
+/**
+ * The queued move, and the three reasons it is not applied.
+ */
+class AutoTransitionJobTest extends TestCase {
+
+	private const UPDATED = '2026-09-11T09:00:00+00:00';
+
+	private IUserManager&MockObject $userManager;
+
+	private DeferredEntryObjectResolver&MockObject $resolver;
+
+	private TransitionEngine&MockObject $engine;
+
+	private AutoTransitionPass&MockObject $pass;
+
+	private LoggerInterface&MockObject $logger;
+
+	private AutoTransitionJob $job;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->resolver = $this->createMock(DeferredEntryObjectResolver::class);
+		$this->engine = $this->createMock(TransitionEngine::class);
+		$this->pass = $this->createMock(AutoTransitionPass::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->job = new AutoTransitionJob(
+			$this->createMock(ITimeFactory::class),
+			$this->createMock(IUserSession::class),
+			$this->userManager,
+			$this->createMock(OrganisationService::class),
+			$this->logger,
+			$this->resolver,
+			$this->engine,
+			$this->pass
+		);
+	}//end setUp()
+
+	/**
+	 * Run the protected deferred work directly.
+	 *
+	 * The identity plumbing around it is `ActorForwardedJob`'s and is tested
+	 * there; what is exercised here is what this subclass adds.
+	 *
+	 * @param array<int, array<string, mixed>> $entries The queued entries.
+	 * @param string|null $userId The captured acting user.
+	 *
+	 * @return void
+	 */
+	private function runDeferred(array $entries, ?string $userId = 'behandelaar-1'): void {
+		$context = new DeferredListenerContext(userId: $userId, orgUuid: null, entries: $entries);
+		$method = new ReflectionMethod(AutoTransitionJob::class, 'runDeferred');
+		$method->invoke($this->job, $context);
+	}//end runDeferred()
+
+	/**
+	 * One queued entry for `beslissen` on obj-1.
+	 *
+	 * @param array<string, mixed> $overrides Fields to override.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function entry(array $overrides = []): array {
+		return ($overrides + [
+			'uuid' => 'obj-1',
+			'register' => '1',
+			'schema' => '2',
+			'action' => 'beslissen',
+			'to' => 'besloten',
+			'version' => '3',
+			'updated' => self::UPDATED,
+			'moves' => 1,
+			'visited' => ['open', 'besloten'],
+		]);
+	}//end entry()
+
+	/**
+	 * Make the resolver answer with a stored object at a version and stamp.
+	 *
+	 * @param string $version The stored version.
+	 * @param string $updated The stored `updated` stamp, ISO 8601.
+	 *
+	 * @return void
+	 */
+	private function stored(string $version = '3', string $updated = self::UPDATED): void {
+		$entity = new ObjectEntity();
+		$entity->setUuid('obj-1');
+		$entity->setVersion($version);
+		$entity->setUpdated(new DateTime($updated));
+
+		$this->resolver->method('resolve')->willReturn($entity);
+	}//end stored()
+
+	/**
+	 * @return void
+	 */
+	public function testAnUnchangedObjectHasItsQueuedMoveApplied(): void {
+		$this->userManager->method('get')->willReturn($this->enabledUser());
+		$this->stored();
+
+		$this->engine->expects($this->once())
+			->method('transition')
+			->with(objectId: 'obj-1', action: 'beslissen');
+
+		$this->runDeferred([$this->entry()]);
+	}//end testAnUnchangedObjectHasItsQueuedMoveApplied()
+
+	/**
+	 * @return void
+	 */
+	public function testAStaleVersionIsANoOp(): void {
+		// A later write made its own decision; this one is not re-imposed.
+		$this->userManager->method('get')->willReturn($this->enabledUser());
+		$this->stored(version: '4');
+
+		$this->engine->expects($this->never())->method('transition');
+
+		$this->runDeferred([$this->entry()]);
+	}//end testAStaleVersionIsANoOp()
+
+	/**
+	 * @return void
+	 */
+	public function testAStaleTimestampIsANoOp(): void {
+		$this->userManager->method('get')->willReturn($this->enabledUser());
+		$this->stored(updated: '2026-09-11T10:00:00+00:00');
+
+		$this->engine->expects($this->never())->method('transition');
+
+		$this->runDeferred([$this->entry()]);
+	}//end testAStaleTimestampIsANoOp()
+
+	/**
+	 * @return void
+	 */
+	public function testAVanishedObjectIsANoOp(): void {
+		$this->userManager->method('get')->willReturn($this->enabledUser());
+		$this->resolver->method('resolve')->willReturn(null);
+
+		$this->engine->expects($this->never())->method('transition');
+
+		$this->runDeferred([$this->entry()]);
+	}//end testAVanishedObjectIsANoOp()
+
+	/**
+	 * @return void
+	 */
+	public function testADisabledAccountIsSkippedWithAWarning(): void {
+		// 🔴 ActorForwardedJob refuses a user that no longer resolves, but not
+		// a disabled one. An automatic move must never run as an account
+		// someone has deliberately switched off.
+		$user = $this->createMock(IUser::class);
+		$user->method('isEnabled')->willReturn(false);
+		$this->userManager->method('get')->willReturn($user);
+
+		$this->engine->expects($this->never())->method('transition');
+		$this->logger->expects($this->once())
+			->method('warning')
+			->with($this->stringContains('gone or disabled'), $this->anything());
+
+		$this->runDeferred([$this->entry()]);
+	}//end testADisabledAccountIsSkippedWithAWarning()
+
+	/**
+	 * @return void
+	 */
+	public function testTheCarriedLineageResumesThePass(): void {
+		// The count and the visited states travel with the entry, so what
+		// follows the queued move is bounded by the same pass.
+		$this->userManager->method('get')->willReturn($this->enabledUser());
+		$this->stored();
+
+		$this->pass->expects($this->once())
+			->method('resume')
+			->with(uuid: 'obj-1', moves: 9, visited: ['s0', 's9']);
+
+		$this->runDeferred([$this->entry(['moves' => 9, 'visited' => ['s0', 's9']])]);
+	}//end testTheCarriedLineageResumesThePass()
+
+	/**
+	 * @return void
+	 */
+	public function testARefusedQueuedMoveDoesNotAbortTheChunk(): void {
+		$this->userManager->method('get')->willReturn($this->enabledUser());
+		$this->stored();
+		$this->engine->method('transition')->willThrowException(new \RuntimeException('refused'));
+
+		$this->logger->expects($this->atLeastOnce())->method('warning');
+
+		$this->runDeferred([$this->entry(), $this->entry()]);
+	}//end testARefusedQueuedMoveDoesNotAbortTheChunk()
+
+	/**
+	 * @return void
+	 */
+	public function testASessionLessOriginNeedsNoAccountCheck(): void {
+		$this->stored();
+		$this->engine->expects($this->once())->method('transition');
+
+		$this->runDeferred([$this->entry()], null);
+	}//end testASessionLessOriginNeedsNoAccountCheck()
+
+	/**
+	 * An enabled user mock.
+	 *
+	 * @return IUser&MockObject
+	 */
+	private function enabledUser(): IUser {
+		$user = $this->createMock(IUser::class);
+		$user->method('isEnabled')->willReturn(true);
+
+		return $user;
+	}//end enabledUser()
+}//end class

--- a/tests/Unit/Db/SchemaMapperAutoTransitionValidationTest.php
+++ b/tests/Unit/Db/SchemaMapperAutoTransitionValidationTest.php
@@ -1,0 +1,210 @@
+<?php
+
+/**
+ * The four automatic-transition errors refuse the schema save.
+ *
+ * SchemaMapper treats most lifecycle validation errors as advisory: it logs
+ * them and stores the schema, so a register import carrying a partial or
+ * different-dialect lifecycle block does not break. A transition `condition`
+ * was the exception; `autoWhen` and `executionMode` join it. A stored scalar
+ * `autoWhen` is worse than a stored broken condition, because it evaluates as
+ * a truthy literal and fires the transition on every write from its `from`
+ * state, and the other three describe a move that can never happen at all.
+ *
+ * These tests drive the private `validateLifecycleAnnotation()` directly,
+ * because the public insert/update paths are DB-bound. What they pin down is
+ * the split: which errors refuse, which merely warn.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Db
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Db;
+
+use Exception;
+use OCA\OpenRegister\Db\OrganisationMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Schemas\PropertyValidatorHandler;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IAppConfig;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionMethod;
+
+/**
+ * Save-time policy for automatic transitions.
+ */
+class SchemaMapperAutoTransitionValidationTest extends TestCase {
+
+	private LoggerInterface&MockObject $logger;
+
+	private SchemaMapper $mapper;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->mapper = new SchemaMapper(
+			$this->createMock(IDBConnection::class),
+			$this->createMock(IEventDispatcher::class),
+			$this->createMock(PropertyValidatorHandler::class),
+			$this->createMock(OrganisationMapper::class),
+			$this->createMock(IUserSession::class),
+			$this->createMock(IGroupManager::class),
+			$this->createMock(IAppConfig::class),
+			$this->logger
+		);
+	}//end setUp()
+
+	/**
+	 * Run the private validator against a schema carrying the given lifecycle.
+	 *
+	 * @param array<string, mixed> $lifecycle The x-openregister-lifecycle block.
+	 *
+	 * @return void
+	 */
+	private function validate(array $lifecycle): void {
+		$schema = new Schema();
+		$schema->setSlug('bezwaar');
+		$schema->setProperties(
+			[
+				'status' => ['type' => 'string', 'enum' => ['open', 'besloten']],
+				'motivering' => ['type' => 'string'],
+			]
+		);
+		$schema->setConfiguration(['x-openregister-lifecycle' => $lifecycle]);
+
+		$method = new ReflectionMethod(SchemaMapper::class, 'validateLifecycleAnnotation');
+		$method->invoke($this->mapper, $schema);
+	}//end validate()
+
+	/**
+	 * A static lifecycle whose `beslissen` transition carries the given extras.
+	 *
+	 * @param array<string, mixed> $extra Extra keys on the transition.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function lifecycle(array $extra): array {
+		return [
+			'field' => 'status',
+			'initial' => 'open',
+			'transitions' => [
+				'beslissen' => (['from' => ['open'], 'to' => 'besloten'] + $extra),
+			],
+		];
+	}//end lifecycle()
+
+	/**
+	 * @return void
+	 */
+	public function testAScalarAutoWhenRefusesTheSave(): void {
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessageMatches('/^Invalid .*lifecycle-autowhen-malformed/');
+
+		$this->validate($this->lifecycle(['autoWhen' => true]));
+	}//end testAScalarAutoWhenRefusesTheSave()
+
+	/**
+	 * @return void
+	 */
+	public function testAnUnknownExecutionModeRefusesTheSave(): void {
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessageMatches('/^Invalid .*lifecycle-execution-mode-malformed/');
+
+		$this->validate(
+			$this->lifecycle(
+				['autoWhen' => ['!!' => ['var' => 'object.motivering']], 'executionMode' => 'background']
+			)
+		);
+	}//end testAnUnknownExecutionModeRefusesTheSave()
+
+	/**
+	 * @return void
+	 */
+	public function testARequiredInputBesideAutoWhenRefusesTheSave(): void {
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessageMatches('/^Invalid .*lifecycle-autowhen-requires-input/');
+
+		$this->validate(
+			$this->lifecycle(
+				[
+					'autoWhen' => ['!!' => ['var' => 'object.motivering']],
+					'inputs' => [['field' => 'motivering', 'required' => true]],
+				]
+			)
+		);
+	}//end testARequiredInputBesideAutoWhenRefusesTheSave()
+
+	/**
+	 * @return void
+	 */
+	public function testAGraphAutoWhenRefusesTheSave(): void {
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessageMatches('/^Invalid .*lifecycle-autowhen-graph-unsupported/');
+
+		$this->validate(
+			[
+				'field' => 'status',
+				'graph' => [
+					'schema' => 'fase',
+					'parentField' => 'zaaktype',
+					'parentFrom' => 'zaaktype',
+					'orderField' => 'volgorde',
+					'finalField' => 'eindfase',
+					'allowedMoves' => 'forward',
+					'autoWhen' => ['!!' => ['var' => 'object.motivering']],
+				],
+			]
+		);
+	}//end testAGraphAutoWhenRefusesTheSave()
+
+	/**
+	 * @return void
+	 */
+	public function testAMalformedMessageBesideAValidAutoWhenOnlyWarns(): void {
+		// The advisory bucket is unchanged: a broken `message` is still stored
+		// and logged, even when the same transition carries an `autoWhen`.
+		$this->logger->expects($this->once())->method('warning');
+
+		$this->validate(
+			$this->lifecycle(
+				[
+					'autoWhen' => ['!!' => ['var' => 'object.motivering']],
+					'message' => 42,
+				]
+			)
+		);
+	}//end testAMalformedMessageBesideAValidAutoWhenOnlyWarns()
+
+	/**
+	 * @return void
+	 */
+	public function testTheRefusalLeadsWithInvalidSoTheControllerAnswers400(): void {
+		// SchemasController maps a save exception to 400 by matching the word
+		// "Invalid" in its message. The text is generalised from "condition" to
+		// "declaration" so it reads correctly for both rules.
+		try {
+			$this->validate($this->lifecycle(['autoWhen' => 'nope']));
+			$this->fail('A malformed autoWhen must refuse the save.');
+		} catch (Exception $e) {
+			$this->assertStringStartsWith('Invalid', $e->getMessage());
+		}
+	}//end testTheRefusalLeadsWithInvalidSoTheControllerAnswers400()
+}//end class

--- a/tests/Unit/Listener/AutoTransitionRecordListenerTest.php
+++ b/tests/Unit/Listener/AutoTransitionRecordListenerTest.php
@@ -1,0 +1,227 @@
+<?php
+
+/**
+ * The post-save listener records, and does nothing else.
+ *
+ * A transition applied inside `ObjectUpdatedEvent` would be lost to the second
+ * write a file-bearing save makes, and would invert event order for a named
+ * transition. So the listener notes the object and the pass decides later.
+ * These tests pin down what is recorded and what is not: a schema declaring no
+ * `autoWhen` costs one lookup and nothing more, two events for one object
+ * collapse into one decision, and the first `previous` of the pass is the one
+ * that survives.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Listener
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Listener;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Event\ObjectCreatedEvent;
+use OCA\OpenRegister\Event\ObjectUpdatedEvent;
+use OCA\OpenRegister\Listener\AutoTransitionRecordListener;
+use OCA\OpenRegister\Service\Lifecycle\AutoTransitionPass;
+use OCA\OpenRegister\Service\Lifecycle\AutoTransitionRunner;
+use OCA\OpenRegister\Service\Lifecycle\AutoTransitionSelector;
+use OCA\OpenRegister\Service\Lifecycle\LifecycleConditionEvaluator;
+use OCP\IGroupManager;
+use OCP\IL10N;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Recording written objects into the pass.
+ */
+class AutoTransitionRecordListenerTest extends TestCase {
+
+	private const AUTO_WHEN = ['!!' => ['var' => 'object.motivering']];
+
+	private SchemaMapper&MockObject $schemaMapper;
+
+	private AutoTransitionRunner&MockObject $runner;
+
+	private AutoTransitionPass $pass;
+
+	private AutoTransitionRecordListener $listener;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$this->schemaMapper = $this->createMock(SchemaMapper::class);
+		$this->runner = $this->createMock(AutoTransitionRunner::class);
+		$logger = $this->createMock(LoggerInterface::class);
+
+		$this->pass = new AutoTransitionPass($this->runner, $logger);
+
+		$groupManager = $this->createMock(IGroupManager::class);
+		$groupManager->method('getUserGroupIds')->willReturn([]);
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('getLanguageCode')->willReturn('en');
+		$selector = new AutoTransitionSelector(
+			new LifecycleConditionEvaluator(
+				$this->createMock(IUserSession::class),
+				$groupManager,
+				$l10n,
+				$logger
+			),
+			$logger
+		);
+
+		$this->listener = new AutoTransitionRecordListener($this->schemaMapper, $selector, $this->pass);
+	}//end setUp()
+
+	/**
+	 * Make the mapper answer with a schema carrying (or not) an `autoWhen`.
+	 *
+	 * @param bool $declaresAutoWhen Whether the transition carries `autoWhen`.
+	 *
+	 * @return void
+	 */
+	private function schemaDeclaring(bool $declaresAutoWhen): void {
+		$transition = ['from' => ['in-behandeling'], 'to' => 'besloten'];
+		if ($declaresAutoWhen === true) {
+			$transition['autoWhen'] = self::AUTO_WHEN;
+		}
+
+		$schema = new Schema();
+		$schema->setSlug('bezwaar');
+		$schema->setConfiguration(
+			[
+				'x-openregister-lifecycle' => [
+					'field' => 'status',
+					'initial' => 'in-behandeling',
+					'transitions' => ['beslissen' => $transition],
+				],
+			]
+		);
+
+		$this->schemaMapper->method('find')->willReturn($schema);
+	}//end schemaDeclaring()
+
+	/**
+	 * An object entity carrying the given data.
+	 *
+	 * @param array<string, mixed> $data The object's data.
+	 *
+	 * @return ObjectEntity
+	 */
+	private function object(array $data): ObjectEntity {
+		$entity = new ObjectEntity();
+		$entity->setUuid('uuid-1');
+		$entity->setRegister('1');
+		$entity->setSchema('2');
+		$entity->setObject($data);
+
+		return $entity;
+	}//end object()
+
+	/**
+	 * @return void
+	 */
+	public function testTheListenerRecordsAndNeverDecidesOrApplies(): void {
+		// 🔴 THE LISTENER'S ONE JOB, AND IT WAS UNGUARDED.
+		// A mutation that made the listener drain immediately after recording
+		// reddened nothing, because every test here only asserted WHAT gets
+		// recorded. The listener must not decide or apply: at this point the
+		// triggering write is unfinished, so a move made here would be
+		// overwritten by a file-bearing save's second update and would run
+		// before the audit row exists.
+		$this->schemaDeclaring(true);
+		$this->runner->expects($this->never())->method('decide');
+		$this->runner->expects($this->never())->method('fire');
+		$this->runner->expects($this->never())->method('flushQueued');
+
+		$this->pass->enter();
+		$this->listener->handle(new ObjectUpdatedEvent($this->object(['status' => 'in-behandeling']), null));
+	}//end testTheListenerRecordsAndNeverDecidesOrApplies()
+
+	/**
+	 * @return void
+	 */
+	public function testASchemaWithoutAutoWhenRecordsNothing(): void {
+		$this->schemaDeclaring(false);
+		$this->runner->expects($this->never())->method('decide');
+
+		$this->pass->enter();
+		$this->listener->handle(new ObjectUpdatedEvent($this->object(['status' => 'in-behandeling']), null));
+		$this->pass->leave();
+	}//end testASchemaWithoutAutoWhenRecordsNothing()
+
+	/**
+	 * @return void
+	 */
+	public function testTwoEventsForOneObjectRecordOnceWithTheFirstPrevious(): void {
+		// A file-bearing save dispatches ObjectUpdatedEvent twice; the second
+		// carries the object it just wrote as `old`. The pass must decide once,
+		// against the state before the write that STARTED it.
+		$this->schemaDeclaring(true);
+
+		$this->runner->expects($this->once())
+			->method('decide')
+			->with(
+				uuid: 'uuid-1',
+				register: '1',
+				schema: '2',
+				previous: ['status' => 'ontvangen', 'id' => 'uuid-1']
+			)
+			->willReturn(null);
+
+		$this->pass->enter();
+		$this->listener->handle(
+			new ObjectUpdatedEvent(
+				$this->object(['status' => 'in-behandeling']),
+				$this->object(['status' => 'ontvangen'])
+			)
+		);
+		$this->listener->handle(
+			new ObjectUpdatedEvent(
+				$this->object(['status' => 'in-behandeling', 'bijlage' => 'f-1']),
+				$this->object(['status' => 'in-behandeling'])
+			)
+		);
+		$this->pass->leave();
+	}//end testTwoEventsForOneObjectRecordOnceWithTheFirstPrevious()
+
+	/**
+	 * @return void
+	 */
+	public function testACreateRecordsAnEmptyPrevious(): void {
+		$this->schemaDeclaring(true);
+
+		$this->runner->expects($this->once())
+			->method('decide')
+			->with(uuid: 'uuid-1', register: '1', schema: '2', previous: [])
+			->willReturn(null);
+
+		$this->pass->enter();
+		$this->listener->handle(new ObjectCreatedEvent($this->object(['status' => 'in-behandeling'])));
+		$this->pass->leave();
+	}//end testACreateRecordsAnEmptyPrevious()
+
+	/**
+	 * @return void
+	 */
+	public function testAnUnrelatedEventIsIgnored(): void {
+		$this->runner->expects($this->never())->method('decide');
+
+		$this->pass->enter();
+		$this->listener->handle(new \OCP\EventDispatcher\Event());
+		$this->pass->leave();
+	}//end testAnUnrelatedEventIsIgnored()
+}//end class

--- a/tests/Unit/Listener/FlowTriggerListenerTest.php
+++ b/tests/Unit/Listener/FlowTriggerListenerTest.php
@@ -140,12 +140,38 @@ class FlowTriggerListenerTest extends TestCase {
 				'object.transitioned',
 				$this->callback(static fn (array $s): bool => ($s['uuid'] ?? null) === 'obj-1'),
 				null,
-				['action' => 'approve', 'from' => 'draft', 'to' => 'published']
+				['action' => 'approve', 'from' => 'draft', 'to' => 'published', 'automatic' => 'false']
 			)
 			->willReturn(1);
 
 		$this->listener->handle(
 			new ObjectTransitionedEvent($this->object(), 'approve', 'draft', 'published', null, 'reg', 'sch')
+		);
+	}
+
+	public function testAnAutomaticTransitionCarriesTheFlagOnTheRunContext(): void {
+		// A flow branching on a state change needs to tell a person's click
+		// from a rule firing on that person's save.
+		$this->triggers->expects($this->once())->method('fire')
+			->with(
+				'object.transitioned',
+				$this->anything(),
+				null,
+				['action' => 'beslissen', 'from' => 'open', 'to' => 'besloten', 'automatic' => 'true']
+			)
+			->willReturn(1);
+
+		$this->listener->handle(
+			new ObjectTransitionedEvent(
+				$this->object(),
+				'beslissen',
+				'open',
+				'besloten',
+				null,
+				'reg',
+				'sch',
+				true
+			)
 		);
 	}
 

--- a/tests/Unit/Service/Lifecycle/AutoTransitionPassTest.php
+++ b/tests/Unit/Service/Lifecycle/AutoTransitionPassTest.php
@@ -1,0 +1,511 @@
+<?php
+
+/**
+ * The pass: where an automatic move runs, and how far one write may travel.
+ *
+ * The boundary is the point of the class. A move applied inside the post-save
+ * event would be lost to the second write a file-bearing save makes, so the
+ * listener records and the OUTERMOST boundary exit drains. These tests pin
+ * that down together with the two limits, each of which is mutation-checked in
+ * task 4.2: a count-only cap would pass a ping-pong test, and a drain that ran
+ * on every boundary exit would pass a single-move test.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Lifecycle
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Lifecycle;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\Lifecycle\AutoTransitionCandidate;
+use OCA\OpenRegister\Service\Lifecycle\AutoTransitionDecision;
+use OCA\OpenRegister\Service\Lifecycle\AutoTransitionPass;
+use OCA\OpenRegister\Service\Lifecycle\AutoTransitionRunner;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Boundary, drain, chain and cap.
+ */
+class AutoTransitionPassTest extends TestCase {
+
+	private AutoTransitionRunner&MockObject $runner;
+
+	private LoggerInterface&MockObject $logger;
+
+	private AutoTransitionPass $pass;
+
+	/**
+	 * The lifecycle value each object currently holds, keyed by uuid.
+	 *
+	 * @var array<string, string>
+	 */
+	private array $state = [];
+
+	/**
+	 * The transitions the fake schema declares, as from => to.
+	 *
+	 * @var array<string, string>
+	 */
+	private array $moves = [];
+
+	/**
+	 * The actions the runner was asked to fire, in order.
+	 *
+	 * @var array<int, string>
+	 */
+	private array $fired = [];
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$this->runner = $this->createMock(AutoTransitionRunner::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->pass = new AutoTransitionPass($this->runner, $this->logger);
+		$this->state = [];
+		$this->moves = [];
+		$this->fired = [];
+	}//end setUp()
+
+	/**
+	 * Wire the runner as a tiny in-memory state machine over `$this->moves`.
+	 *
+	 * `decide()` answers with the move declared from the object's current
+	 * state, and `fire()` applies it and re-records the object, exactly as the
+	 * real runner does through the engine's own update event. That is what
+	 * makes the drain's loop, rather than its first iteration, observable.
+	 *
+	 * @param string $mode The execution mode every candidate carries.
+	 *
+	 * @return void
+	 */
+	private function wireStateMachine(string $mode = 'sync'): void {
+		$this->runner->method('decide')->willReturnCallback(
+			function (string $uuid, string $register, string $schema, array $previous): ?AutoTransitionDecision {
+				$current = ($this->state[$uuid] ?? '');
+				if (isset($this->moves[$current]) === false) {
+					return null;
+				}
+
+				return new AutoTransitionDecision(
+					uuid: $uuid,
+					register: $register,
+					schema: $schema,
+					schemaSlug: 'bezwaar',
+					candidate: new AutoTransitionCandidate(
+						action: 'naar-' . $this->moves[$current],
+						from: $current,
+						to: $this->moves[$current],
+						mode: $this->modeForTest
+					),
+					version: '1',
+					updated: null
+				);
+			}
+		);
+
+		$this->modeForTest = $mode;
+
+		$this->runner->method('fire')->willReturnCallback(
+			function (AutoTransitionDecision $decision, array $lineage, bool $queueOnly): ?ObjectEntity {
+				$this->fired[] = $decision->candidate->action;
+				$this->lastLineage = $lineage;
+				$this->lastQueueOnly = $queueOnly;
+
+				if ($this->modeForTest !== 'sync' || $queueOnly === true) {
+					return null;
+				}
+
+				$this->state[$decision->uuid] = $decision->candidate->to;
+
+				// The move's own save re-records the object, which is how the
+				// drain gets a second iteration to decide.
+				$this->pass->enter();
+				$this->pass->record(
+					uuid: $decision->uuid,
+					register: $decision->register,
+					schema: $decision->schema,
+					previous: []
+				);
+				$this->pass->leave();
+
+				return $this->entity($decision->uuid, $decision->candidate->to);
+			}
+		);
+	}//end wireStateMachine()
+
+	/**
+	 * The execution mode the wired state machine hands out.
+	 *
+	 * @var string
+	 */
+	private string $modeForTest = 'sync';
+
+	/**
+	 * The lineage the runner was last handed.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private array $lastLineage = [];
+
+	/**
+	 * Whether the runner was last told to queue only.
+	 *
+	 * @var boolean
+	 */
+	private bool $lastQueueOnly = false;
+
+	/**
+	 * An entity in a given state.
+	 *
+	 * @param string $uuid The object's uuid.
+	 * @param string $state The lifecycle value.
+	 *
+	 * @return ObjectEntity
+	 */
+	private function entity(string $uuid, string $state): ObjectEntity {
+		$entity = new ObjectEntity();
+		$entity->setUuid($uuid);
+		$entity->setObject(['status' => $state]);
+
+		return $entity;
+	}//end entity()
+
+	/**
+	 * Record one object inside an open boundary.
+	 *
+	 * @param string $uuid The object's uuid.
+	 *
+	 * @return void
+	 */
+	private function recordInside(string $uuid): void {
+		$this->pass->record(uuid: $uuid, register: '1', schema: '2', previous: []);
+	}//end recordInside()
+
+	/**
+	 * @return void
+	 */
+	public function testANestedBoundaryExitDoesNotStartANestedDrain(): void {
+		// 🔴 THE DRAIN POSITION. Only leaving the OUTERMOST boundary may drain:
+		// a nested exit is still inside the triggering write.
+		$this->wireStateMachine();
+		$this->state['obj-1'] = 'stap-1';
+		$this->moves = ['stap-1' => 'stap-2'];
+
+		$this->pass->enter();
+		$this->recordInside('obj-1');
+
+		$this->pass->enter();
+		$this->pass->leave();
+		$this->assertSame([], $this->fired, 'A nested exit must not drain.');
+
+		$this->pass->leave();
+		$this->assertSame(['naar-stap-2'], $this->fired);
+	}//end testANestedBoundaryExitDoesNotStartANestedDrain()
+
+	/**
+	 * @return void
+	 */
+	public function testAFailureWhileDecidingDoesNotPropagate(): void {
+		// The drain runs inside a `finally`. An exception escaping it would
+		// replace the exception the triggering write was already raising.
+		$this->runner->method('decide')->willThrowException(new RuntimeException('boom'));
+		$this->logger->expects($this->atLeastOnce())->method('warning');
+
+		$this->pass->enter();
+		$this->recordInside('obj-1');
+		$this->assertSame([], $this->pass->leave());
+	}//end testAFailureWhileDecidingDoesNotPropagate()
+
+	/**
+	 * @return void
+	 */
+	public function testAChainContinuesInOnePassAndAnswersWithTheLastMove(): void {
+		$this->wireStateMachine();
+		$this->state['obj-1'] = 'stap-1';
+		$this->moves = ['stap-1' => 'stap-2', 'stap-2' => 'stap-3'];
+
+		$this->pass->enter();
+		$this->recordInside('obj-1');
+		$applied = $this->pass->leave();
+
+		$this->assertSame(['naar-stap-2', 'naar-stap-3'], $this->fired);
+		$this->assertSame('stap-3', ($applied['obj-1']->getObject()['status'] ?? null));
+	}//end testAChainContinuesInOnePassAndAnswersWithTheLastMove()
+
+	/**
+	 * @return void
+	 */
+	public function testAPingPongIsCutAfterExactlyOneMove(): void {
+		// 🔴 THE REVISIT RULE. A count-only cap would let this flip ten times,
+		// write ten audit rows and stop on whichever state the parity picked.
+		$this->wireStateMachine();
+		$this->state['obj-1'] = 'heen';
+		$this->moves = ['heen' => 'terug', 'terug' => 'heen'];
+
+		$this->logger->expects($this->once())
+			->method('error')
+			->with(
+				$this->stringContains('cut'),
+				$this->callback(static fn (array $context): bool => $context['limit'] === 'revisit')
+			);
+
+		$this->pass->enter();
+		$this->recordInside('obj-1');
+		$applied = $this->pass->leave();
+
+		$this->assertSame(['naar-terug'], $this->fired);
+		$this->assertSame('terug', ($applied['obj-1']->getObject()['status'] ?? null));
+	}//end testAPingPongIsCutAfterExactlyOneMove()
+
+	/**
+	 * @return void
+	 */
+	public function testATwelveStateChainStopsAtTenMoves(): void {
+		// 🔴 THE CEILING. Twelve distinct states, so the revisit rule never
+		// fires and only the count can cut this.
+		$this->wireStateMachine();
+		$this->state['obj-1'] = 's0';
+		for ($step = 0; $step < 11; $step++) {
+			$this->moves['s' . $step] = 's' . ($step + 1);
+		}
+
+		$this->logger->expects($this->once())
+			->method('error')
+			->with(
+				$this->anything(),
+				$this->callback(
+					static fn (array $context): bool => $context['limit'] === 'ceiling'
+						&& $context['ceiling'] === 10
+						&& count($context['applied']) === 10
+				)
+			);
+
+		$this->pass->enter();
+		$this->recordInside('obj-1');
+		$applied = $this->pass->leave();
+
+		$this->assertCount(10, $this->fired);
+		$this->assertSame('s10', ($applied['obj-1']->getObject()['status'] ?? null));
+	}//end testATwelveStateChainStopsAtTenMoves()
+
+	/**
+	 * @return void
+	 */
+	public function testAResumedPassCarriesItsCountIntoTheNextMove(): void {
+		// A queued move carries the hop count, so a loop cannot escape the cap
+		// by crossing into a background job.
+		$this->wireStateMachine();
+		$this->state['obj-1'] = 's9';
+		$this->moves = ['s9' => 's10', 's10' => 's11'];
+
+		$this->pass->resume(uuid: 'obj-1', moves: 9, visited: ['s0', 's9']);
+
+		$this->pass->enter();
+		$this->recordInside('obj-1');
+		$this->pass->leave();
+
+		$this->assertSame(['naar-s10'], $this->fired, 'The tenth move runs and the eleventh is cut.');
+	}//end testAResumedPassCarriesItsCountIntoTheNextMove()
+
+	/**
+	 * @return void
+	 */
+	public function testAResumedPassRefusesAStateItAlreadyVisited(): void {
+		$this->wireStateMachine();
+		$this->state['obj-1'] = 'terug';
+		$this->moves = ['terug' => 'heen'];
+
+		$this->pass->resume(uuid: 'obj-1', moves: 1, visited: ['heen', 'terug']);
+
+		$this->pass->enter();
+		$this->recordInside('obj-1');
+		$this->pass->leave();
+
+		$this->assertSame([], $this->fired);
+	}//end testAResumedPassRefusesAStateItAlreadyVisited()
+
+	/**
+	 * @return void
+	 */
+	public function testTheAmbientFrameNamesTheMoveOnlyWhileItIsApplied(): void {
+		// The event and the audit row read this frame rather than a parameter,
+		// so no caller can claim a manual move was automatic.
+		$this->assertNull($this->pass->applyingAction());
+
+		$this->runner->method('decide')->willReturn(
+			new AutoTransitionDecision(
+				uuid: 'obj-1',
+				register: '1',
+				schema: '2',
+				schemaSlug: 'bezwaar',
+				candidate: new AutoTransitionCandidate('beslissen', 'open', 'besloten', 'sync'),
+				version: '1',
+				updated: null
+			)
+		);
+
+		$seen = null;
+		$this->runner->method('fire')->willReturnCallback(
+			function () use (&$seen): ?ObjectEntity {
+				$seen = $this->pass->applyingAction();
+				return null;
+			}
+		);
+
+		$this->pass->enter();
+		$this->recordInside('obj-1');
+		$this->pass->leave();
+
+		$this->assertSame('beslissen', $seen);
+		$this->assertNull($this->pass->applyingAction(), 'The frame must not outlive the move.');
+	}//end testTheAmbientFrameNamesTheMoveOnlyWhileItIsApplied()
+
+	/**
+	 * @return void
+	 */
+	public function testRecordingInsideABoundaryAppliesNothingUntilItIsLeft(): void {
+		// 🔴 THE ORDERING GUARANTEE, AND IT WAS UNGUARDED.
+		// A mutation that drained from inside the recording listener reddened
+		// nothing, which means the whole reason the drain waits for the
+		// outermost boundary was untested. It waits because the triggering
+		// write is not finished at record time: on a file-bearing save a second
+		// update would overwrite the move, the audit row is not yet written,
+		// and a named transition's own event has not been dispatched.
+		//
+		// So: inside a boundary, recording must apply NOTHING, and flushing
+		// must apply nothing either. Only leaving the boundary drains.
+		$this->wireStateMachine();
+		$this->state['obj-1'] = 'stap-1';
+		$this->moves = ['stap-1' => 'stap-2'];
+
+		$this->pass->enter();
+		$this->pass->record(uuid: 'obj-1', register: '1', schema: '2', previous: []);
+
+		$this->assertSame([], $this->fired, 'Recording inside a boundary must apply nothing.');
+		$this->assertSame('stap-1', $this->state['obj-1']);
+
+		$this->pass->flushOutsideBoundary();
+
+		$this->assertSame(
+			[],
+			$this->fired,
+			'A flush while still inside the boundary must apply nothing: the triggering write is unfinished.'
+		);
+		$this->assertSame('stap-1', $this->state['obj-1']);
+
+		$this->pass->leave();
+
+		$this->assertSame(['naar-stap-2'], $this->fired, 'Leaving the outermost boundary is what drains.');
+		$this->assertSame('stap-2', $this->state['obj-1']);
+	}//end testRecordingInsideABoundaryAppliesNothingUntilItIsLeft()
+
+	/**
+	 * @return void
+	 */
+	public function testAMoveRecordedOutsideAnyBoundaryIsQueuedNotApplied(): void {
+		// A bulk save, a deferred create event and a revert all write with no
+		// saveObject() around them, so there is no point at which a sync move
+		// could run after the write and before a response.
+		$this->wireStateMachine();
+		$this->state['obj-1'] = 'stap-1';
+		$this->moves = ['stap-1' => 'stap-2'];
+
+		$this->runner->expects($this->once())->method('flushQueued');
+
+		$this->pass->record(uuid: 'obj-1', register: '1', schema: '2', previous: []);
+		$this->assertSame([], $this->fired, 'Recording alone must apply nothing.');
+
+		$this->pass->flushOutsideBoundary();
+
+		$this->assertSame(['naar-stap-2'], $this->fired);
+		$this->assertTrue($this->lastQueueOnly, 'It must be routed to the job, whatever its declared mode.');
+		$this->assertSame('stap-1', $this->state['obj-1'], 'Nothing is applied in the request.');
+	}//end testAMoveRecordedOutsideAnyBoundaryIsQueuedNotApplied()
+
+	/**
+	 * @return void
+	 */
+	public function testADrainIgnoresWhatWasRecordedOutsideTheBoundary(): void {
+		$this->wireStateMachine();
+		$this->state['obj-1'] = 'stap-1';
+		$this->moves = ['stap-1' => 'stap-2'];
+
+		$this->pass->record(uuid: 'obj-1', register: '1', schema: '2', previous: []);
+
+		$this->pass->enter();
+		$this->pass->leave();
+
+		$this->assertSame([], $this->fired);
+	}//end testADrainIgnoresWhatWasRecordedOutsideTheBoundary()
+
+	/**
+	 * @return void
+	 */
+	public function testTheQueuedLineageCarriesTheCountAndTheVisitedStates(): void {
+		$this->wireStateMachine(mode: 'async');
+		$this->state['obj-1'] = 'stap-1';
+		$this->moves = ['stap-1' => 'stap-2'];
+
+		$this->pass->enter();
+		$this->recordInside('obj-1');
+		$this->pass->leave();
+
+		$this->assertSame(1, $this->lastLineage['moves']);
+		$this->assertSame(['stap-1', 'stap-2'], array_keys($this->lastLineage['visited']));
+	}//end testTheQueuedLineageCarriesTheCountAndTheVisitedStates()
+
+	/**
+	 * @return void
+	 */
+	public function testThePassIsEmptyAfterItDrains(): void {
+		// The leak direction: a pass that kept its lineage would carry one
+		// request's chain into the next job in a long-running worker.
+		$this->wireStateMachine();
+		$this->state['obj-1'] = 'stap-1';
+		$this->moves = ['stap-1' => 'stap-2'];
+
+		$this->pass->enter();
+		$this->recordInside('obj-1');
+		$this->pass->leave();
+		$this->assertSame(['naar-stap-2'], $this->fired);
+
+		// A second pass over the same object starts a fresh lineage, so the
+		// move back into stap-1 is allowed rather than refused as a revisit.
+		$this->moves = ['stap-2' => 'stap-1'];
+		$this->pass->enter();
+		$this->recordInside('obj-1');
+		$this->pass->leave();
+
+		$this->assertSame(['naar-stap-2', 'naar-stap-1'], $this->fired);
+	}//end testThePassIsEmptyAfterItDrains()
+
+	/**
+	 * @return void
+	 */
+	public function testPreferAutomaticAnswersWithTheMoveWhenThereWasOne(): void {
+		$saved = $this->entity('obj-1', 'open');
+		$moved = $this->entity('obj-1', 'besloten');
+
+		$this->assertSame($saved, $this->pass->preferAutomatic(saved: $saved, applied: []));
+		$this->assertSame($moved, $this->pass->preferAutomatic(saved: $saved, applied: ['obj-1' => $moved]));
+		$this->assertSame(
+			$saved,
+			$this->pass->preferAutomatic(saved: $saved, applied: ['other' => $moved]),
+			'Another object\'s move must never be answered here.'
+		);
+	}//end testPreferAutomaticAnswersWithTheMoveWhenThereWasOne()
+}//end class

--- a/tests/Unit/Service/Lifecycle/AutoTransitionRunnerTest.php
+++ b/tests/Unit/Service/Lifecycle/AutoTransitionRunnerTest.php
@@ -1,0 +1,372 @@
+<?php
+
+/**
+ * Deciding one automatic move, and either firing it or queuing it.
+ *
+ * The two things worth pinning down here are the ones that fail quietly if
+ * they break: a refusal must never reach the caller whose write triggered the
+ * move, and an `async` move must be queued with the version it was decided
+ * against so a newer write can invalidate it.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Lifecycle
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Lifecycle;
+
+use DateTime;
+use OCA\OpenRegister\BackgroundJob\AutoTransitionJob;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Exception\HookStoppedException;
+use OCA\OpenRegister\Service\Deferral\DeferredEntryObjectResolver;
+use OCA\OpenRegister\Service\Deferral\ListenerDeferralService;
+use OCA\OpenRegister\Service\Lifecycle\AutoTransitionCandidate;
+use OCA\OpenRegister\Service\Lifecycle\AutoTransitionDecision;
+use OCA\OpenRegister\Service\Lifecycle\AutoTransitionRunner;
+use OCA\OpenRegister\Service\Lifecycle\AutoTransitionQueue;
+use OCA\OpenRegister\Service\Lifecycle\AutoTransitionSelector;
+use OCA\OpenRegister\Service\Lifecycle\LifecycleConditionEvaluator;
+use OCA\OpenRegister\Service\Lifecycle\TransitionEngine;
+use OCP\IGroupManager;
+use OCP\IL10N;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Decide, fire, queue.
+ */
+class AutoTransitionRunnerTest extends TestCase {
+
+	private const AUTO_WHEN = ['!!' => ['var' => 'object.motivering']];
+
+	private ContainerInterface&MockObject $container;
+
+	private SchemaMapper&MockObject $schemaMapper;
+
+	private ListenerDeferralService&MockObject $deferral;
+
+	private DeferredEntryObjectResolver&MockObject $resolver;
+
+	private TransitionEngine&MockObject $engine;
+
+	private LoggerInterface&MockObject $logger;
+
+	private AutoTransitionRunner $runner;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$this->container = $this->createMock(ContainerInterface::class);
+		$this->schemaMapper = $this->createMock(SchemaMapper::class);
+		$this->deferral = $this->createMock(ListenerDeferralService::class);
+		$this->resolver = $this->createMock(DeferredEntryObjectResolver::class);
+		$this->engine = $this->createMock(TransitionEngine::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->container->method('get')->willReturnCallback(
+			function (string $id): object {
+				if ($id === DeferredEntryObjectResolver::class) {
+					return $this->resolver;
+				}
+
+				if ($id === TransitionEngine::class) {
+					return $this->engine;
+				}
+
+				throw new RuntimeException('unexpected service ' . $id);
+			}
+		);
+
+		$groupManager = $this->createMock(IGroupManager::class);
+		$groupManager->method('getUserGroupIds')->willReturn([]);
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('getLanguageCode')->willReturn('en');
+
+		$this->runner = new AutoTransitionRunner(
+			$this->container,
+			$this->schemaMapper,
+			new AutoTransitionSelector(
+				new LifecycleConditionEvaluator(
+					$this->createMock(IUserSession::class),
+					$groupManager,
+					$l10n,
+					$this->logger
+				),
+				$this->logger
+			),
+			// A REAL queue around the mocked deferral service, not a mocked queue:
+			// the dedupe key, the entry shape and the kill-switch rule are the
+			// behaviour these tests assert, and a double would assert nothing.
+			new AutoTransitionQueue($this->deferral, $this->logger),
+			$this->logger
+		);
+	}//end setUp()
+
+	/**
+	 * Make the mapper answer with a schema declaring `beslissen`.
+	 *
+	 * @param string|null $executionMode The transition's declared mode, or null for none.
+	 *
+	 * @return void
+	 */
+	private function schemaWithAutoWhen(?string $executionMode = null): void {
+		$transition = ['from' => ['open'], 'to' => 'besloten', 'autoWhen' => self::AUTO_WHEN];
+		if ($executionMode !== null) {
+			$transition['executionMode'] = $executionMode;
+		}
+
+		$schema = new Schema();
+		$schema->setSlug('bezwaar');
+		$schema->setConfiguration(
+			[
+				'x-openregister-lifecycle' => [
+					'field' => 'status',
+					'initial' => 'open',
+					'transitions' => ['beslissen' => $transition],
+				],
+			]
+		);
+
+		$this->schemaMapper->method('find')->willReturn($schema);
+	}//end schemaWithAutoWhen()
+
+	/**
+	 * Make the resolver answer with a stored object.
+	 *
+	 * @param array<string, mixed> $data The object's data.
+	 *
+	 * @return ObjectEntity
+	 */
+	private function storedObject(array $data): ObjectEntity {
+		$entity = new ObjectEntity();
+		$entity->setUuid('obj-1');
+		$entity->setRegister('1');
+		$entity->setSchema('2');
+		$entity->setObject($data);
+		$entity->setVersion('3');
+		$entity->setUpdated(new DateTime('2026-09-11T09:00:00+00:00'));
+
+		$this->resolver->method('resolve')->willReturn($entity);
+
+		return $entity;
+	}//end storedObject()
+
+	/**
+	 * A decision for `beslissen`, in the given mode.
+	 *
+	 * @param string $mode The execution mode.
+	 *
+	 * @return AutoTransitionDecision
+	 */
+	private function decision(string $mode = 'sync'): AutoTransitionDecision {
+		return new AutoTransitionDecision(
+			uuid: 'obj-1',
+			register: '1',
+			schema: '2',
+			schemaSlug: 'bezwaar',
+			candidate: new AutoTransitionCandidate('beslissen', 'open', 'besloten', $mode),
+			version: '3',
+			updated: '2026-09-11T09:00:00+00:00'
+		);
+	}//end decision()
+
+	/**
+	 * @return void
+	 */
+	public function testAnUnresolvableObjectDecidesNothing(): void {
+		$this->resolver->method('resolve')->willReturn(null);
+
+		$this->assertNull($this->runner->decide(uuid: 'obj-1', register: '1', schema: '2', previous: []));
+	}//end testAnUnresolvableObjectDecidesNothing()
+
+	/**
+	 * @return void
+	 */
+	public function testASchemaWithoutALifecycleDecidesNothing(): void {
+		$this->storedObject(['status' => 'open', 'motivering' => 'ja']);
+		$this->schemaMapper->method('find')->willReturn(new Schema());
+
+		$this->assertNull($this->runner->decide(uuid: 'obj-1', register: '1', schema: '2', previous: []));
+	}//end testASchemaWithoutALifecycleDecidesNothing()
+
+	/**
+	 * @return void
+	 */
+	public function testTheDecisionCarriesTheStoredVersionAndTimestamp(): void {
+		// This is what makes a queued move safe: the job applies it only while
+		// these still match, because a newer write made its own decision.
+		$this->storedObject(['status' => 'open', 'motivering' => 'Ongegrond.']);
+		$this->schemaWithAutoWhen();
+
+		$decision = $this->runner->decide(uuid: 'obj-1', register: '1', schema: '2', previous: []);
+
+		$this->assertNotNull($decision);
+		$this->assertSame('beslissen', $decision->candidate->action);
+		$this->assertSame('3', $decision->version);
+		$this->assertSame('2026-09-11T09:00:00+00:00', $decision->updated);
+		$this->assertSame('bezwaar', $decision->schemaSlug);
+	}//end testTheDecisionCarriesTheStoredVersionAndTimestamp()
+
+	/**
+	 * @return void
+	 */
+	public function testTheDecisionIsMadeAgainstTheObjectAsStored(): void {
+		// Not against the event payload: computed fields and defaults are only
+		// present once the write has landed.
+		$this->storedObject(['status' => 'open', 'motivering' => '']);
+		$this->schemaWithAutoWhen();
+
+		$this->assertNull($this->runner->decide(uuid: 'obj-1', register: '1', schema: '2', previous: []));
+	}//end testTheDecisionIsMadeAgainstTheObjectAsStored()
+
+	/**
+	 * @return void
+	 */
+	public function testASyncMoveIsAppliedThroughTheEngine(): void {
+		$moved = new ObjectEntity();
+		$moved->setUuid('obj-1');
+
+		$this->engine->expects($this->once())
+			->method('transition')
+			->with(objectId: 'obj-1', action: 'beslissen')
+			->willReturn($moved);
+		$this->deferral->expects($this->never())->method('defer');
+
+		$this->assertSame(
+			$moved,
+			$this->runner->fire(decision: $this->decision(), lineage: [], queueOnly: false)
+		);
+	}//end testASyncMoveIsAppliedThroughTheEngine()
+
+	/**
+	 * @return void
+	 */
+	public function testARefusalIsLoggedWithItsCodeAndDoesNotPropagate(): void {
+		// 🔴 The triggering write has already succeeded. A refusal here is not
+		// the caller's fault and must not become the caller's error.
+		$this->engine->method('transition')->willThrowException(
+			new HookStoppedException(
+				message: 'Transition denied by guard.',
+				errors: ['code' => 'lifecycle-guard-denied', 'action' => 'beslissen']
+			)
+		);
+
+		$this->logger->expects($this->atLeastOnce())
+			->method('warning')
+			->with(
+				$this->stringContains('automatic transition was refused'),
+				$this->callback(
+					static fn (array $context): bool => $context['refusalCode'] === 'lifecycle-guard-denied'
+						&& $context['action'] === 'beslissen'
+				)
+			);
+
+		$this->assertNull($this->runner->fire(decision: $this->decision(), lineage: [], queueOnly: false));
+	}//end testARefusalIsLoggedWithItsCodeAndDoesNotPropagate()
+
+	/**
+	 * @return void
+	 */
+	public function testAnArbitraryThrowableDoesNotPropagateEither(): void {
+		$this->engine->method('transition')->willThrowException(new RuntimeException('anything at all'));
+
+		$this->assertNull($this->runner->fire(decision: $this->decision(), lineage: [], queueOnly: false));
+	}//end testAnArbitraryThrowableDoesNotPropagateEither()
+
+	/**
+	 * @return void
+	 */
+	public function testAnAsyncMoveIsQueuedWithItsLineageAndDedupeKey(): void {
+		$this->deferral->method('isDeferralEnabled')->willReturn(true);
+		$this->engine->expects($this->never())->method('transition');
+
+		$this->deferral->expects($this->once())
+			->method('defer')
+			->with(
+				jobClass: AutoTransitionJob::class,
+				entry: [
+					'uuid' => 'obj-1',
+					'register' => '1',
+					'schema' => '2',
+					'action' => 'beslissen',
+					'to' => 'besloten',
+					'version' => '3',
+					'updated' => '2026-09-11T09:00:00+00:00',
+					'moves' => 2,
+					'visited' => ['open', 'besloten'],
+				],
+				chunkSize: AutoTransitionQueue::CHUNK_SIZE,
+				// uuid PLUS version: deduping on the uuid alone would keep a
+				// stale decision and drop the current one.
+				dedupeKey: 'obj-1|3'
+			);
+
+		$this->assertNull(
+			$this->runner->fire(
+				decision: $this->decision(mode: 'async'),
+				lineage: ['moves' => 2, 'visited' => ['open' => true, 'besloten' => true], 'applied' => []],
+				queueOnly: false
+			)
+		);
+	}//end testAnAsyncMoveIsQueuedWithItsLineageAndDedupeKey()
+
+	/**
+	 * @return void
+	 */
+	public function testTheKillSwitchAppliesAnAsyncMoveInline(): void {
+		$this->deferral->method('isDeferralEnabled')->willReturn(false);
+		$this->deferral->expects($this->never())->method('defer');
+
+		$moved = new ObjectEntity();
+		$this->engine->expects($this->once())->method('transition')->willReturn($moved);
+
+		$this->assertSame(
+			$moved,
+			$this->runner->fire(decision: $this->decision(mode: 'async'), lineage: [], queueOnly: false)
+		);
+	}//end testTheKillSwitchAppliesAnAsyncMoveInline()
+
+	/**
+	 * @return void
+	 */
+	public function testAMoveDecidedOutsideABoundaryIsQueuedEvenWhenSync(): void {
+		// There is no point after a bulk save's write and before a response at
+		// which a sync move could run, so the declared mode does not apply.
+		$this->engine->expects($this->never())->method('transition');
+		$this->deferral->expects($this->once())->method('defer');
+
+		$this->assertNull(
+			$this->runner->fire(decision: $this->decision(mode: 'sync'), lineage: [], queueOnly: true)
+		);
+	}//end testAMoveDecidedOutsideABoundaryIsQueuedEvenWhenSync()
+
+	/**
+	 * @return void
+	 */
+	public function testTheKillSwitchDoesNotPullAnOutsideMoveInline(): void {
+		$this->deferral->method('isDeferralEnabled')->willReturn(false);
+		$this->engine->expects($this->never())->method('transition');
+		$this->deferral->expects($this->once())->method('defer');
+
+		$this->assertNull(
+			$this->runner->fire(decision: $this->decision(mode: 'async'), lineage: [], queueOnly: true)
+		);
+	}//end testTheKillSwitchDoesNotPullAnOutsideMoveInline()
+}//end class

--- a/tests/Unit/Service/Lifecycle/AutoTransitionSelectorTest.php
+++ b/tests/Unit/Service/Lifecycle/AutoTransitionSelectorTest.php
@@ -1,0 +1,420 @@
+<?php
+
+/**
+ * Which automatic transition may fire, and the three ways the answer is none.
+ *
+ * The selector owns selection and nothing else: whether a rule holds is
+ * `LifecycleConditionEvaluator::holds()`'s answer, and one of the tests below
+ * hands the selector a double that answers without evaluating anything, so a
+ * second JSONLogic path inside the selector would show up as a test that
+ * cannot be satisfied.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Lifecycle
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Lifecycle;
+
+use OCA\OpenRegister\Service\Lifecycle\AutoTransitionSelector;
+use OCA\OpenRegister\Service\Lifecycle\LifecycleConditionEvaluator;
+use OCP\IGroupManager;
+use OCP\IL10N;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Candidate selection for automatic transitions.
+ */
+class AutoTransitionSelectorTest extends TestCase {
+
+	private const HOLDS = ['!!' => ['var' => 'object.motivering']];
+
+	private LoggerInterface&MockObject $logger;
+
+	private AutoTransitionSelector $selector;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->selector = new AutoTransitionSelector($this->realEvaluator(), $this->logger);
+	}//end setUp()
+
+	/**
+	 * A real evaluator wired to mocked Nextcloud collaborators.
+	 *
+	 * @return LifecycleConditionEvaluator
+	 */
+	private function realEvaluator(): LifecycleConditionEvaluator {
+		$groupManager = $this->createMock(IGroupManager::class);
+		$groupManager->method('getUserGroupIds')->willReturn([]);
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('getLanguageCode')->willReturn('en');
+
+		return new LifecycleConditionEvaluator(
+			$this->createMock(IUserSession::class),
+			$groupManager,
+			$l10n,
+			$this->createMock(LoggerInterface::class)
+		);
+	}//end realEvaluator()
+
+	/**
+	 * An annotation with the given transitions, in declaration order.
+	 *
+	 * @param array<string, mixed> $transitions The transition map.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function annotation(array $transitions): array {
+		return ['field' => 'status', 'initial' => 'ontvangen', 'transitions' => $transitions];
+	}//end annotation()
+
+	/**
+	 * @return void
+	 */
+	public function testTheOneHoldingTransitionIsSelected(): void {
+		$candidate = $this->selector->select(
+			annotation: $this->annotation(
+				['beslissen' => ['from' => ['in-behandeling'], 'to' => 'besloten', 'autoWhen' => self::HOLDS]]
+			),
+			objectData: ['status' => 'in-behandeling', 'motivering' => 'Ongegrond.'],
+			previous: ['status' => 'in-behandeling'],
+			schemaSlug: 'bezwaar'
+		);
+
+		$this->assertNotNull($candidate);
+		$this->assertSame('beslissen', $candidate->action);
+		$this->assertSame('in-behandeling', $candidate->from);
+		$this->assertSame('besloten', $candidate->to);
+		$this->assertSame('sync', $candidate->mode);
+	}//end testTheOneHoldingTransitionIsSelected()
+
+	/**
+	 * @return void
+	 */
+	public function testARuleThatDoesNotHoldSelectsNothing(): void {
+		$this->assertNull(
+			$this->selector->select(
+				annotation: $this->annotation(
+					['beslissen' => ['from' => ['in-behandeling'], 'to' => 'besloten', 'autoWhen' => self::HOLDS]]
+				),
+				objectData: ['status' => 'in-behandeling', 'motivering' => ''],
+				previous: [],
+				schemaSlug: 'bezwaar'
+			)
+		);
+	}//end testARuleThatDoesNotHoldSelectsNothing()
+
+	/**
+	 * @return void
+	 */
+	public function testATransitionWithoutAutoWhenIsNeverSelected(): void {
+		$this->assertNull(
+			$this->selector->select(
+				annotation: $this->annotation(
+					['beslissen' => ['from' => ['in-behandeling'], 'to' => 'besloten']]
+				),
+				objectData: ['status' => 'in-behandeling', 'motivering' => 'Ongegrond.'],
+				previous: [],
+				schemaSlug: 'bezwaar'
+			)
+		);
+	}//end testATransitionWithoutAutoWhenIsNeverSelected()
+
+	/**
+	 * @return void
+	 */
+	public function testAMoveToTheCurrentValueIsNeverSelected(): void {
+		$this->assertNull(
+			$this->selector->select(
+				annotation: $this->annotation(
+					[
+						'herbevestigen' => [
+							'from' => ['ontvangen', 'in-behandeling'],
+							'to' => 'in-behandeling',
+							'autoWhen' => self::HOLDS,
+						],
+					]
+				),
+				objectData: ['status' => 'in-behandeling', 'motivering' => 'Ongegrond.'],
+				previous: [],
+				schemaSlug: 'bezwaar'
+			)
+		);
+	}//end testAMoveToTheCurrentValueIsNeverSelected()
+
+	/**
+	 * @return void
+	 */
+	public function testTwoHoldingRulesSelectNothingAndNameBoth(): void {
+		$this->logger->expects($this->once())
+			->method('warning')
+			->with(
+				$this->stringContains('More than one automatic transition holds'),
+				$this->callback(
+					static fn (array $context): bool => $context['candidates'] === ['toewijzen', 'afwijzen']
+				)
+			);
+
+		$this->assertNull(
+			$this->selector->select(
+				annotation: $this->annotation(
+					[
+						'toewijzen' => ['from' => ['ontvangen'], 'to' => 'in-behandeling', 'autoWhen' => self::HOLDS],
+						'afwijzen' => ['from' => ['ontvangen'], 'to' => 'afgewezen', 'autoWhen' => self::HOLDS],
+					]
+				),
+				objectData: ['status' => 'ontvangen', 'motivering' => 'Ongegrond.'],
+				previous: [],
+				schemaSlug: 'bezwaar'
+			)
+		);
+	}//end testTwoHoldingRulesSelectNothingAndNameBoth()
+
+	/**
+	 * @return void
+	 */
+	public function testOneHoldingBesideOneThatDoesNotIsSelected(): void {
+		$candidate = $this->selector->select(
+			annotation: $this->annotation(
+				[
+					'toewijzen' => [
+						'from' => ['ontvangen'],
+						'to' => 'in-behandeling',
+						'autoWhen' => ['!!' => ['var' => 'object.behandelaar']],
+					],
+					'afwijzen' => ['from' => ['ontvangen'], 'to' => 'afgewezen', 'autoWhen' => self::HOLDS],
+				]
+			),
+			objectData: ['status' => 'ontvangen', 'motivering' => 'Ongegrond.'],
+			previous: [],
+			schemaSlug: 'bezwaar'
+		);
+
+		$this->assertNotNull($candidate);
+		$this->assertSame('afwijzen', $candidate->action);
+	}//end testOneHoldingBesideOneThatDoesNotIsSelected()
+
+	/**
+	 * @return void
+	 */
+	public function testAShadowedTransitionIsNotSelectedAndBothAreNamed(): void {
+		$this->logger->expects($this->once())
+			->method('warning')
+			->with(
+				$this->stringContains('earlier-declared transition'),
+				$this->callback(
+					static fn (array $context): bool => $context['action'] === 'toewijzen'
+						&& $context['shadowedBy'] === 'starten'
+				)
+			);
+
+		$this->assertNull(
+			$this->selector->select(
+				annotation: $this->annotation(
+					[
+						'starten' => ['from' => ['ontvangen'], 'to' => 'in-behandeling'],
+						'toewijzen' => ['from' => ['ontvangen'], 'to' => 'in-behandeling', 'autoWhen' => self::HOLDS],
+					]
+				),
+				objectData: ['status' => 'ontvangen', 'motivering' => 'Ongegrond.'],
+				previous: [],
+				schemaSlug: 'bezwaar'
+			)
+		);
+	}//end testAShadowedTransitionIsNotSelectedAndBothAreNamed()
+
+	/**
+	 * @return void
+	 */
+	public function testALaterTwinDoesNotShadowTheCandidate(): void {
+		// Shadowing is about an EARLIER declaration only: the save path takes
+		// the first match, so a twin declared after the candidate cannot win.
+		$candidate = $this->selector->select(
+			annotation: $this->annotation(
+				[
+					'toewijzen' => ['from' => ['ontvangen'], 'to' => 'in-behandeling', 'autoWhen' => self::HOLDS],
+					'starten' => ['from' => ['ontvangen'], 'to' => 'in-behandeling'],
+				]
+			),
+			objectData: ['status' => 'ontvangen', 'motivering' => 'Ongegrond.'],
+			previous: [],
+			schemaSlug: 'bezwaar'
+		);
+
+		$this->assertNotNull($candidate);
+		$this->assertSame('toewijzen', $candidate->action);
+	}//end testALaterTwinDoesNotShadowTheCandidate()
+
+	/**
+	 * @return void
+	 */
+	public function testAnUnrecognisedExecutionModeSelectsNothingAndWarns(): void {
+		$this->logger->expects($this->once())
+			->method('warning')
+			->with(
+				$this->stringContains('unrecognised executionMode'),
+				$this->callback(static fn (array $context): bool => $context['action'] === 'beslissen')
+			);
+
+		$this->assertNull(
+			$this->selector->select(
+				annotation: $this->annotation(
+					[
+						'beslissen' => [
+							'from' => ['in-behandeling'],
+							'to' => 'besloten',
+							'autoWhen' => self::HOLDS,
+							'executionMode' => 'background',
+						],
+					]
+				),
+				objectData: ['status' => 'in-behandeling', 'motivering' => 'Ongegrond.'],
+				previous: [],
+				schemaSlug: 'bezwaar'
+			)
+		);
+	}//end testAnUnrecognisedExecutionModeSelectsNothingAndWarns()
+
+	/**
+	 * @return void
+	 */
+	public function testAnAsyncModeIsCarriedOnTheCandidate(): void {
+		$candidate = $this->selector->select(
+			annotation: $this->annotation(
+				[
+					'beslissen' => [
+						'from' => ['in-behandeling'],
+						'to' => 'besloten',
+						'autoWhen' => self::HOLDS,
+						'executionMode' => 'async',
+					],
+				]
+			),
+			objectData: ['status' => 'in-behandeling', 'motivering' => 'Ongegrond.'],
+			previous: [],
+			schemaSlug: 'bezwaar'
+		);
+
+		$this->assertNotNull($candidate);
+		$this->assertSame('async', $candidate->mode);
+	}//end testAnAsyncModeIsCarriedOnTheCandidate()
+
+	/**
+	 * @return void
+	 */
+	public function testAStoredScalarAutoWhenSelectsNothing(): void {
+		// The runtime does not trust save-time validation. A scalar written by
+		// a path that skipped the mapper counts as not holding.
+		$this->assertNull(
+			$this->selector->select(
+				annotation: $this->annotation(
+					['beslissen' => ['from' => ['in-behandeling'], 'to' => 'besloten', 'autoWhen' => true]]
+				),
+				objectData: ['status' => 'in-behandeling'],
+				previous: [],
+				schemaSlug: 'bezwaar'
+			)
+		);
+	}//end testAStoredScalarAutoWhenSelectsNothing()
+
+	/**
+	 * @return void
+	 */
+	public function testTheSelectorEvaluatesNoJsonLogicItself(): void {
+		// 🔴 THE ONE-EVALUATION-PATH ASSERTION. The double answers `holds()`
+		// without evaluating anything, and its rule is a string the JSONLogic
+		// engine would refuse. A selector doing its own truthiness test would
+		// either fire on the string or refuse the double's answer; both show up
+		// here rather than as a quiet second code path.
+		$evaluator = new class ($this->createMock(IUserSession::class), $this->createMock(IGroupManager::class), $this->createMock(IL10N::class), $this->createMock(LoggerInterface::class)) extends LifecycleConditionEvaluator {
+			/**
+			 * Rules this double was asked about.
+			 *
+			 * @var array<int, mixed>
+			 */
+			public array $asked = [];
+
+			/**
+			 * Answer true for every rule, without evaluating it.
+			 *
+			 * @param mixed $rule The rule.
+			 * @param array<string, mixed> $newData The object.
+			 * @param array<string, mixed> $oldData The previous object.
+			 * @param string $action The transition name.
+			 * @param string $from The state being left.
+			 * @param string $to The state being entered.
+			 * @param string $schemaSlug The schema slug.
+			 * @param string $field The lifecycle field.
+			 *
+			 * @return bool Always true.
+			 */
+			public function holds(
+				mixed $rule,
+				array $newData,
+				array $oldData,
+				string $action,
+				string $from,
+				string $to,
+				string $schemaSlug,
+				string $field,
+			): bool {
+				$this->asked[] = $rule;
+				return true;
+			}
+		};
+
+		$selector = new AutoTransitionSelector($evaluator, $this->logger);
+		$candidate = $selector->select(
+			annotation: $this->annotation(
+				[
+					'beslissen' => [
+						'from' => ['in-behandeling'],
+						'to' => 'besloten',
+						'autoWhen' => 'not a rule object at all',
+					],
+				]
+			),
+			objectData: ['status' => 'in-behandeling'],
+			previous: [],
+			schemaSlug: 'bezwaar'
+		);
+
+		$this->assertNotNull($candidate);
+		$this->assertSame('beslissen', $candidate->action);
+		$this->assertSame(['not a rule object at all'], $evaluator->asked);
+	}//end testTheSelectorEvaluatesNoJsonLogicItself()
+
+	/**
+	 * @return void
+	 */
+	public function testDeclaresAutoWhenIsAShapeReadOnly(): void {
+		$this->assertFalse(
+			$this->selector->declaresAutoWhen(
+				$this->annotation(['beslissen' => ['from' => ['open'], 'to' => 'besloten']])
+			)
+		);
+		$this->assertTrue(
+			$this->selector->declaresAutoWhen(
+				$this->annotation(
+					['beslissen' => ['from' => ['open'], 'to' => 'besloten', 'autoWhen' => self::HOLDS]]
+				)
+			)
+		);
+		$this->assertFalse($this->selector->declaresAutoWhen([]));
+	}//end testDeclaresAutoWhenIsAShapeReadOnly()
+}//end class

--- a/tests/Unit/Service/Lifecycle/LifecycleAutoWhenValidationTest.php
+++ b/tests/Unit/Service/Lifecycle/LifecycleAutoWhenValidationTest.php
@@ -1,0 +1,270 @@
+<?php
+
+/**
+ * Save-time shape checks for `autoWhen` and `executionMode`.
+ *
+ * A transition may declare `autoWhen`, a JSONLogic rule object that makes the
+ * transition fire on its own after a write, and `executionMode`, one of the
+ * flow engine's two values. Both are shape-checked here, and all four codes
+ * this file exercises refuse the schema save rather than warn.
+ *
+ * The scalar case is the one worth staring at. A scalar handed to
+ * `FlowExpression::isValid()` is a literal and always valid, so nothing below
+ * this method would catch it, and a truthy literal does not fail open once: it
+ * fires the transition on every write from its `from` state.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Lifecycle
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Lifecycle;
+
+use OCA\OpenRegister\Service\Lifecycle\LifecycleAnnotationValidator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Validation of the automatic-transition keys.
+ */
+class LifecycleAutoWhenValidationTest extends TestCase {
+
+	private LifecycleAnnotationValidator $validator;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$this->validator = new LifecycleAnnotationValidator();
+	}//end setUp()
+
+	/**
+	 * Validate a static lifecycle whose `beslissen` transition carries extras.
+	 *
+	 * @param array<string, mixed> $extra Extra keys on the transition.
+	 *
+	 * @return array<int, string> The error codes returned.
+	 */
+	private function codesFor(array $extra): array {
+		$errors = $this->validator->validate(
+			[
+				'x-openregister-lifecycle' => [
+					'field' => 'status',
+					'initial' => 'open',
+					'transitions' => [
+						'beslissen' => (['from' => ['open'], 'to' => 'besloten'] + $extra),
+					],
+				],
+				'properties' => [
+					'status' => ['type' => 'string', 'enum' => ['open', 'besloten']],
+					'motivering' => ['type' => 'string'],
+				],
+			]
+		);
+
+		return array_column($errors, 'code');
+	}//end codesFor()
+
+	/**
+	 * Read the message of the first error carrying a code.
+	 *
+	 * @param array<string, mixed> $extra Extra keys on the transition.
+	 * @param string $code The code to look for.
+	 *
+	 * @return string The message, or an empty string when the code is absent.
+	 */
+	private function messageFor(array $extra, string $code): string {
+		$errors = $this->validator->validate(
+			[
+				'x-openregister-lifecycle' => [
+					'field' => 'status',
+					'initial' => 'open',
+					'transitions' => [
+						'beslissen' => (['from' => ['open'], 'to' => 'besloten'] + $extra),
+					],
+				],
+				'properties' => [
+					'status' => ['type' => 'string', 'enum' => ['open', 'besloten']],
+					'motivering' => ['type' => 'string'],
+				],
+			]
+		);
+
+		foreach ($errors as $error) {
+			if ($error['code'] === $code) {
+				return $error['message'];
+			}
+		}
+
+		return '';
+	}//end messageFor()
+
+	/**
+	 * @return void
+	 */
+	public function testABooleanAutoWhenIsRefused(): void {
+		// 🔴 `true` is the whole reason this check exists: FlowExpression calls
+		// it valid, and stored it fires the transition on every write.
+		$this->assertContains('lifecycle-autowhen-malformed', $this->codesFor(['autoWhen' => true]));
+	}//end testABooleanAutoWhenIsRefused()
+
+	/**
+	 * @return void
+	 */
+	public function testAnActionDialectStringAutoWhenIsRefused(): void {
+		$codes = $this->codesFor(['autoWhen' => "@self.motivering != ''"]);
+		$this->assertContains('lifecycle-autowhen-malformed', $codes);
+
+		$message = $this->messageFor(['autoWhen' => "@self.motivering != ''"], 'lifecycle-autowhen-malformed');
+		$this->assertStringContainsString('JSONLogic rule object', $message);
+		$this->assertStringContainsString('"var"', $message);
+	}//end testAnActionDialectStringAutoWhenIsRefused()
+
+	/**
+	 * @return void
+	 */
+	public function testAnEmptyAutoWhenIsRefused(): void {
+		$this->assertContains('lifecycle-autowhen-malformed', $this->codesFor(['autoWhen' => []]));
+	}//end testAnEmptyAutoWhenIsRefused()
+
+	/**
+	 * @return void
+	 */
+	public function testAnUnknownOperatorIsRefused(): void {
+		$this->assertContains(
+			'lifecycle-autowhen-malformed',
+			$this->codesFor(['autoWhen' => ['nosuchoperator' => [1]]])
+		);
+	}//end testAnUnknownOperatorIsRefused()
+
+	/**
+	 * @return void
+	 */
+	public function testAValidRuleObjectProducesNoError(): void {
+		$this->assertSame([], $this->codesFor(['autoWhen' => ['!!' => ['var' => 'object.motivering']]]));
+	}//end testAValidRuleObjectProducesNoError()
+
+	/**
+	 * @return void
+	 */
+	public function testAnUnknownExecutionModeIsRefused(): void {
+		$codes = $this->codesFor(
+			['autoWhen' => ['!!' => ['var' => 'object.motivering']], 'executionMode' => 'background']
+		);
+		$this->assertContains('lifecycle-execution-mode-malformed', $codes);
+	}//end testAnUnknownExecutionModeIsRefused()
+
+	/**
+	 * @return void
+	 */
+	public function testACaseVariantExecutionModeIsRefusedNotNormalised(): void {
+		$codes = $this->codesFor(
+			['autoWhen' => ['!!' => ['var' => 'object.motivering']], 'executionMode' => 'SYNC']
+		);
+		$this->assertContains('lifecycle-execution-mode-malformed', $codes);
+	}//end testACaseVariantExecutionModeIsRefusedNotNormalised()
+
+	/**
+	 * @return void
+	 */
+	public function testBothFlowEngineValuesAreAccepted(): void {
+		$rule = ['!!' => ['var' => 'object.motivering']];
+		$this->assertSame([], $this->codesFor(['autoWhen' => $rule, 'executionMode' => 'sync']));
+		$this->assertSame([], $this->codesFor(['autoWhen' => $rule, 'executionMode' => 'async']));
+	}//end testBothFlowEngineValuesAreAccepted()
+
+	/**
+	 * @return void
+	 */
+	public function testARequiredInputBesideAutoWhenIsRefused(): void {
+		$codes = $this->codesFor(
+			[
+				'autoWhen' => ['!!' => ['var' => 'object.motivering']],
+				'inputs' => [['field' => 'motivering', 'required' => true]],
+			]
+		);
+		$this->assertContains('lifecycle-autowhen-requires-input', $codes);
+	}//end testARequiredInputBesideAutoWhenIsRefused()
+
+	/**
+	 * @return void
+	 */
+	public function testAnOptionalInputBesideAutoWhenIsAccepted(): void {
+		$this->assertSame(
+			[],
+			$this->codesFor(
+				[
+					'autoWhen' => ['!!' => ['var' => 'object.motivering']],
+					'inputs' => [['field' => 'motivering', 'required' => false]],
+				]
+			)
+		);
+	}//end testAnOptionalInputBesideAutoWhenIsAccepted()
+
+	/**
+	 * @return void
+	 */
+	public function testARequiredInputWithoutAutoWhenIsUnaffected(): void {
+		$this->assertSame(
+			[],
+			$this->codesFor(['inputs' => [['field' => 'motivering', 'required' => true]]])
+		);
+	}//end testARequiredInputWithoutAutoWhenIsUnaffected()
+
+	/**
+	 * @return void
+	 */
+	public function testAutoWhenOnAGraphBlockIsRefused(): void {
+		$errors = $this->validator->validate(
+			[
+				'x-openregister-lifecycle' => [
+					'field' => 'fase',
+					'graph' => [
+						'schema' => 'fase',
+						'parentField' => 'zaaktype',
+						'parentFrom' => 'zaaktype',
+						'orderField' => 'volgorde',
+						'finalField' => 'eindfase',
+						'allowedMoves' => 'forward',
+						'autoWhen' => ['!!' => ['var' => 'object.motivering']],
+					],
+				],
+				'properties' => ['fase' => ['type' => 'string']],
+			]
+		);
+
+		$this->assertContains('lifecycle-autowhen-graph-unsupported', array_column($errors, 'code'));
+	}//end testAutoWhenOnAGraphBlockIsRefused()
+
+	/**
+	 * @return void
+	 */
+	public function testAGraphBlockWithoutAutoWhenValidatesAsBefore(): void {
+		$errors = $this->validator->validate(
+			[
+				'x-openregister-lifecycle' => [
+					'field' => 'fase',
+					'graph' => [
+						'schema' => 'fase',
+						'parentField' => 'zaaktype',
+						'parentFrom' => 'zaaktype',
+						'orderField' => 'volgorde',
+						'finalField' => 'eindfase',
+						'allowedMoves' => 'forward',
+					],
+				],
+				'properties' => ['fase' => ['type' => 'string']],
+			]
+		);
+
+		$this->assertSame([], $errors);
+	}//end testAGraphBlockWithoutAutoWhenValidatesAsBefore()
+}//end class

--- a/tests/Unit/Service/Lifecycle/LifecycleConditionEvaluatorHoldsTest.php
+++ b/tests/Unit/Service/Lifecycle/LifecycleConditionEvaluatorHoldsTest.php
@@ -1,0 +1,209 @@
+<?php
+
+/**
+ * `holds()` is the one place a lifecycle rule is evaluated.
+ *
+ * A transition's `condition` and its `autoWhen` both come through this method,
+ * against one document built by one builder, so the two fail-closed guards the
+ * declarative-conditions link paid for are shared rather than rediscovered: a
+ * value that is not a non-empty rule object never reaches FlowExpression, and
+ * an expression that cannot be evaluated counts as not holding.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Lifecycle
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Lifecycle;
+
+use OCA\OpenRegister\Service\Lifecycle\LifecycleConditionEvaluator;
+use OCP\IGroupManager;
+use OCP\IL10N;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Rule evaluation shared by `condition` and `autoWhen`.
+ */
+class LifecycleConditionEvaluatorHoldsTest extends TestCase {
+
+	private LoggerInterface&MockObject $logger;
+
+	private IUserSession&MockObject $userSession;
+
+	private LifecycleConditionEvaluator $evaluator;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('behandelaar-1');
+		$this->userSession->method('getUser')->willReturn($user);
+
+		$groupManager = $this->createMock(IGroupManager::class);
+		$groupManager->method('getUserGroupIds')->willReturn(['behandelaars']);
+
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('getLanguageCode')->willReturn('en');
+		$l10n->method('t')->willReturnCallback(
+			static fn (string $text, array $parameters = []): string => vsprintf($text, $parameters)
+		);
+
+		$this->evaluator = new LifecycleConditionEvaluator(
+			$this->userSession,
+			$groupManager,
+			$l10n,
+			$this->logger
+		);
+	}//end setUp()
+
+	/**
+	 * Evaluate a rule against a fixed object and transition.
+	 *
+	 * @param mixed $rule The rule to evaluate.
+	 * @param array<string, mixed> $object The object as stored.
+	 * @param array<string, mixed> $previous The object before the write.
+	 *
+	 * @return bool Whether the rule holds.
+	 */
+	private function holds(mixed $rule, array $object = [], array $previous = []): bool {
+		return $this->evaluator->holds(
+			rule: $rule,
+			newData: $object,
+			oldData: $previous,
+			action: 'beslissen',
+			from: 'in-behandeling',
+			to: 'besloten',
+			schemaSlug: 'bezwaar',
+			field: 'status'
+		);
+	}//end holds()
+
+	/**
+	 * @return void
+	 */
+	public function testAScalarRuleDoesNotHoldAndWarns(): void {
+		// 🔴 The fail-open case FlowExpression cannot catch: a scalar is a
+		// literal there, and a truthy literal would fire on every write.
+		$this->logger->expects($this->once())
+			->method('warning')
+			->with($this->stringContains('not a JSONLogic rule object'));
+
+		$this->assertFalse($this->holds(true));
+	}//end testAScalarRuleDoesNotHoldAndWarns()
+
+	/**
+	 * @return void
+	 */
+	public function testAnEmptyRuleDoesNotHoldAndWarns(): void {
+		$this->logger->expects($this->once())->method('warning');
+
+		$this->assertFalse($this->holds([]));
+	}//end testAnEmptyRuleDoesNotHoldAndWarns()
+
+	/**
+	 * @return void
+	 */
+	public function testAnUnevaluableRuleDoesNotHold(): void {
+		// An unknown operator throws inside JSONLogic; isTrue() answers false,
+		// so an unevaluable rule never moves an object.
+		$this->assertFalse($this->holds(['nosuchoperator' => [1]]));
+	}//end testAnUnevaluableRuleDoesNotHold()
+
+	/**
+	 * @return void
+	 */
+	public function testARuleThatIsFalseDoesNotHoldAndLogsNothing(): void {
+		// A well-formed rule that does not hold is the common case on every
+		// write. A line per write per candidate would drown the malformed case.
+		$this->logger->expects($this->never())->method('warning');
+		$this->logger->expects($this->never())->method('debug');
+
+		$this->assertFalse($this->holds(['!!' => ['var' => 'object.motivering']], ['motivering' => '']));
+	}//end testARuleThatIsFalseDoesNotHoldAndLogsNothing()
+
+	/**
+	 * @return void
+	 */
+	public function testARuleThatIsTrueHolds(): void {
+		$this->assertTrue(
+			$this->holds(['!!' => ['var' => 'object.motivering']], ['motivering' => 'Ongegrond.'])
+		);
+	}//end testARuleThatIsTrueHolds()
+
+	/**
+	 * @return void
+	 */
+	public function testTheDocumentCarriesTheFourKeys(): void {
+		// `object`, `previous`, `user` and `transition`, and no others. Each
+		// assertion reads one key through a rule, which is the only way the
+		// document is observable from outside.
+		$this->assertTrue($this->holds(['==' => [['var' => 'object.motivering'], 'ja']], ['motivering' => 'ja']));
+		$this->assertTrue(
+			$this->holds(['==' => [['var' => 'previous.status'], 'open']], [], ['status' => 'open'])
+		);
+		$this->assertTrue($this->holds(['==' => [['var' => 'user.uid'], 'behandelaar-1']]));
+		$this->assertTrue($this->holds(['in' => ['behandelaars', ['var' => 'user.groups']]]));
+		$this->assertTrue($this->holds(['==' => [['var' => 'transition.action'], 'beslissen']]));
+		$this->assertTrue($this->holds(['==' => [['var' => 'transition.from'], 'in-behandeling']]));
+		$this->assertTrue($this->holds(['==' => [['var' => 'transition.to'], 'besloten']]));
+	}//end testTheDocumentCarriesTheFourKeys()
+
+	/**
+	 * @return void
+	 */
+	public function testAnAbsentKeyResolvesToNull(): void {
+		$this->assertTrue($this->holds(['==' => [['var' => 'object.nosuchfield'], null]]));
+		$this->assertTrue($this->holds(['==' => [['var' => 'previous.status'], null]]));
+	}//end testAnAbsentKeyResolvesToNull()
+
+	/**
+	 * @return void
+	 */
+	public function testRefusalStillAnswersThroughHolds(): void {
+		// refusal() is now a caller of holds(); a condition that holds lets the
+		// transition through and one that does not refuses, unchanged.
+		$spec = ['condition' => ['!!' => ['var' => 'object.motivering']]];
+
+		$this->assertNull(
+			$this->evaluator->refusal(
+				spec: $spec,
+				newData: ['motivering' => 'Ongegrond.'],
+				oldData: [],
+				action: 'beslissen',
+				from: 'in-behandeling',
+				to: 'besloten',
+				schemaSlug: 'bezwaar',
+				field: 'status'
+			)
+		);
+
+		$refusal = $this->evaluator->refusal(
+			spec: $spec,
+			newData: ['motivering' => ''],
+			oldData: [],
+			action: 'beslissen',
+			from: 'in-behandeling',
+			to: 'besloten',
+			schemaSlug: 'bezwaar',
+			field: 'status'
+		);
+		$this->assertSame('lifecycle-condition-unmet', $refusal['code']);
+	}//end testRefusalStillAnswersThroughHolds()
+}//end class

--- a/tests/Unit/Service/Lifecycle/TransitionEngineActionContextTest.php
+++ b/tests/Unit/Service/Lifecycle/TransitionEngineActionContextTest.php
@@ -30,6 +30,7 @@ use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Service\Lifecycle\LifecycleActionContext;
+use OCA\OpenRegister\Service\Lifecycle\LifecycleWriteBoundary;
 use OCA\OpenRegister\Service\Lifecycle\TransitionEngine;
 use OCA\OpenRegister\Service\Object\PermissionHandler;
 use OCA\OpenRegister\Service\ObjectService;
@@ -99,7 +100,7 @@ class TransitionEngineActionContextTest extends TestCase {
 			$this->createMock(RegisterMapper::class),
 			$appConfig,
 			$this->createMock(LoggerInterface::class),
-			$this->context
+			new LifecycleWriteBoundary($this->context)
 		);
 	}//end setUp()
 

--- a/tests/Unit/Service/Lifecycle/TransitionEngineGraphTest.php
+++ b/tests/Unit/Service/Lifecycle/TransitionEngineGraphTest.php
@@ -103,7 +103,9 @@ class TransitionEngineGraphTest extends TestCase {
 			$this->registerMapper,
 			$this->appConfig,
 			$this->logger,
-			new \OCA\OpenRegister\Service\Lifecycle\LifecycleActionContext()
+			new \OCA\OpenRegister\Service\Lifecycle\LifecycleWriteBoundary(
+				new \OCA\OpenRegister\Service\Lifecycle\LifecycleActionContext()
+			)
 		);
 	}//end setUp()
 

--- a/tests/Unit/Service/Lifecycle/TransitionEngineInputsTest.php
+++ b/tests/Unit/Service/Lifecycle/TransitionEngineInputsTest.php
@@ -95,7 +95,9 @@ class TransitionEngineInputsTest extends TestCase {
 			$this->registerMapper,
 			$this->appConfig,
 			$this->logger,
-			new \OCA\OpenRegister\Service\Lifecycle\LifecycleActionContext()
+			new \OCA\OpenRegister\Service\Lifecycle\LifecycleWriteBoundary(
+				new \OCA\OpenRegister\Service\Lifecycle\LifecycleActionContext()
+			)
 		);
 	}//end setUp()
 
@@ -496,7 +498,9 @@ class TransitionEngineInputsTest extends TestCase {
 			$this->registerMapper,
 			$this->appConfig,
 			$this->logger,
-			new \OCA\OpenRegister\Service\Lifecycle\LifecycleActionContext()
+			new \OCA\OpenRegister\Service\Lifecycle\LifecycleWriteBoundary(
+				new \OCA\OpenRegister\Service\Lifecycle\LifecycleActionContext()
+			)
 		);
 
 		try {

--- a/tests/Unit/Service/Lifecycle/TransitionEngineSlugContractTest.php
+++ b/tests/Unit/Service/Lifecycle/TransitionEngineSlugContractTest.php
@@ -114,7 +114,9 @@ class TransitionEngineSlugContractTest extends TestCase {
 			$this->registerMapper,
 			$this->appConfig,
 			$this->createMock(\Psr\Log\LoggerInterface::class),
-			new \OCA\OpenRegister\Service\Lifecycle\LifecycleActionContext()
+			new \OCA\OpenRegister\Service\Lifecycle\LifecycleWriteBoundary(
+				new \OCA\OpenRegister\Service\Lifecycle\LifecycleActionContext()
+			)
 		);
 
 	}//end engine()

--- a/tests/e2e/ci/playwright.config.ts
+++ b/tests/e2e/ci/playwright.config.ts
@@ -215,6 +215,29 @@ export default defineConfig({
 		//   4. No test.skip at all.
 		'workflows/lifecycle-conditions.spec.ts',
 
+		// Admitted 2026-09-11 with the change it covers (lifecycle-auto-
+		// transitions, `autoWhen` / `executionMode`). It is the only proof that
+		// an automatic move is applied through the REAL write path before a
+		// response is produced: every PHPUnit test in this change drives
+		// `AutoTransitionPass`/`AutoTransitionRunner` directly or through a
+		// mocked schema mapper, so none of them can catch a regression in the
+		// HTTP round trip itself — e.g. a controller that stopped returning the
+		// pass-drained entity and started returning the pre-drain one instead.
+		//
+		// Checked per criterion:
+		//   1. Hermetic: seeds one register/schema through `_fixtures.ts`, with
+		//      the whole `x-openregister-lifecycle` annotation declared inline
+		//      in the file. No `occ`, no docker, no pre-seeded rows.
+		//   2. Self-cleaning: records every object it creates and, in afterAll,
+		//      soft-deletes then hard-deletes each via /api/deleted/{uuid}
+		//      before dropping its schema and register — the same shape as the
+		//      spec above.
+		//   3. No conditional asserts: every assertion is unconditional, and
+		//      each automatic move is re-read after the triggering response so
+		//      a response that lied about the state cannot pass.
+		//   4. No test.skip at all.
+		'workflows/lifecycle-auto-transitions.spec.ts',
+
 		// Admitted 2026-08-29. The ADR-111 demo-data step, which had no coverage
 		// here at all: this file shipped to development with the setup wizard and
 		// never ran, because nothing runs unless it is named in this list. It is

--- a/tests/e2e/workflows/lifecycle-auto-transitions.spec.ts
+++ b/tests/e2e/workflows/lifecycle-auto-transitions.spec.ts
@@ -173,6 +173,18 @@ const LIFECYCLE = {
 			condition: NEVER_HOLDS,
 		},
 		// Group 4: a chain of two automatic moves in one pass, A to B to C.
+		// The two entry moves below carry no autoWhen. They exist because the
+		// triggering write must itself be a DECLARED transition: a PUT straight
+		// from `nieuw` into a chain's first state is refused with
+		// lifecycle-invalid-transition, which is the engine working, not a bug.
+		beginnen: {
+			from: ['nieuw'],
+			to: 'stap-1',
+		},
+		vertrekken: {
+			from: ['nieuw'],
+			to: 'heen',
+		},
 		stapEen: {
 			from: ['stap-1'],
 			to: 'stap-2',

--- a/tests/e2e/workflows/lifecycle-auto-transitions.spec.ts
+++ b/tests/e2e/workflows/lifecycle-auto-transitions.spec.ts
@@ -1,0 +1,439 @@
+import type { APIRequestContext } from '@playwright/test'
+import type { SeededRegister, SeededSchema } from '../_fixtures.ts'
+
+/*
+ * SPDX-FileCopyrightText: 2026 Open Register Contributors
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * `autoWhen` / `executionMode` on an x-openregister-lifecycle transition,
+ * exercised end to end through the real save path.
+ *
+ * WHAT THE FEATURE IS
+ * --------------------
+ * A transition MAY declare `autoWhen` (a JSONLogic rule). After an object is
+ * created or updated, the engine looks for a transition whose `from` contains
+ * the object's current lifecycle value and whose `autoWhen` holds, and fires
+ * it — through `TransitionEngine`, so every gate a manual transition meets
+ * (condition, authorization, requires) still applies. A `sync` move (the
+ * default) is applied before the triggering request's response is produced,
+ * at most 10 times per object per pass, and never back into a state already
+ * occupied in that pass.
+ *
+ * WHY THIS IS AN API SPEC RATHER THAN A BROWSER ONE
+ * -------------------------------------------------
+ * The claim under test is about the WRITE PATH, not a form: a raw PUT or a
+ * raw POST to the transition endpoint must already carry the automatic
+ * move's result in its own response, before any UI ever re-fetches. A
+ * browser spec would test whichever screen happens to re-render, not the
+ * contract itself.
+ *
+ * WHAT WOULD PASS WITHOUT THE FEATURE
+ * -----------------------------------
+ * Nothing here, with one deliberate exception. On a build that does not read
+ * `autoWhen` at all, every assertion below that expects a SECOND transition
+ * to have run fails: the response and the re-read both come back in the
+ * state the triggering write itself set, never the state the automatic move
+ * would have reached. The exception is the last test, a regression guard
+ * that a transition declaring no `autoWhen` never fires on its own — see its
+ * own comment for why it is included even though it also passes on a build
+ * with no automatic-transition code at all.
+ *
+ * @spec openspec/changes/lifecycle-auto-transitions/specs/object-lifecycle/spec.md
+ */
+import { expect, test } from '@playwright/test'
+import {
+	createObject,
+	createRegister,
+	createSchema,
+	deleteRegister,
+	deleteSchema,
+	getObject,
+	linkSchemaToRegister,
+	makeRunId,
+	objectId,
+	updateObject,
+	updateSchema,
+} from '../_fixtures.ts'
+
+const API = '/index.php/apps/openregister/api'
+const JSON_HEADERS = {
+	'Content-Type': 'application/json',
+	Accept: 'application/json',
+}
+
+const runId = makeRunId()
+
+/**
+ * Remove every object a describe block created, then its schema and register.
+ *
+ * Soft-delete first, then a hard DELETE on /api/deleted/{uuid}, because a
+ * soft-deleted row would otherwise survive the run. Admission to the CI
+ * allowlist requires a spec that writes to clean up after itself.
+ */
+async function purge(
+	request: APIRequestContext,
+	register: SeededRegister | undefined,
+	schema: SeededSchema | undefined,
+	uuids: string[],
+): Promise<void> {
+	for (const uuid of uuids) {
+		if (register?.id && schema?.id) {
+			await request
+				.delete(`${API}/objects/${register.id}/${schema.id}/${uuid}`)
+				.catch(() => {})
+		}
+		await request.delete(`${API}/deleted/${uuid}`).catch(() => {})
+	}
+	if (schema?.id) {
+		await deleteSchema(request, schema.id)
+	}
+	if (register?.id) {
+		await deleteRegister(request, register.id)
+	}
+}
+
+/**
+ * A rule that holds for any candidate, whatever the object's own data says.
+ *
+ * `transition.to` is always a non-empty string for a real candidate — the
+ * selector already filters out an empty `to` before a rule is ever
+ * evaluated — so `!!` of it is unconditionally true. This is used where a
+ * test needs a move to fire regardless of the object's fields, mirroring the
+ * shared four-key document `LifecycleConditionEvaluator::document()` builds
+ * for both `condition` and `autoWhen`.
+ */
+const ALWAYS_HOLDS = { '!!': { var: 'transition.to' } }
+
+/**
+ * A `condition` that never holds, whatever the object's own data says.
+ *
+ * `nooit` ("never", in Dutch) is not a declared property, so the document
+ * builder resolves `object.nooit` to null and `!!null` is false.
+ */
+const NEVER_HOLDS = { '!!': { var: 'object.nooit' } }
+
+/** Every lifecycle value used across the scenarios below, kept in one enum. */
+const PROPERTIES = {
+	status: {
+		type: 'string',
+		enum: [
+			'nieuw',
+			'concept',
+			'ingediend',
+			'in-beoordeling',
+			'in-behandeling',
+			'besloten',
+			'binnengekomen',
+			'goedgekeurd',
+			'stap-1',
+			'stap-2',
+			'stap-3',
+			'heen',
+			'terug',
+			'gearchiveerd',
+		],
+	},
+	motivering: { type: 'string' },
+	notitie: { type: 'string' },
+}
+
+/**
+ * One schema, nine transitions, each group using its own disjoint states so
+ * the tests below cannot interfere with each other through ambiguity or
+ * shadowing (both of which fire nothing and are covered by PHPUnit, not
+ * here — see the spec's own `@e2e exclude` on that requirement).
+ */
+const LIFECYCLE = {
+	field: 'status',
+	initial: 'nieuw',
+	transitions: {
+		// Group 1: a direct save's own response carries a sync automatic move.
+		beslissen: {
+			from: ['in-behandeling'],
+			to: 'besloten',
+			autoWhen: { '!!': { var: 'object.motivering' } },
+		},
+		// Group 2: the named-transition route's response carries the automatic
+		// follow-on move it triggers. `indienen` itself declares no `autoWhen`
+		// — it is the manual move that makes `beoordelen`'s rule start holding.
+		indienen: {
+			from: ['concept'],
+			to: 'ingediend',
+		},
+		beoordelen: {
+			from: ['ingediend'],
+			to: 'in-beoordeling',
+			autoWhen: ALWAYS_HOLDS,
+		},
+		// Group 3: an automatic move refused by its own `condition`.
+		keuren: {
+			from: ['binnengekomen'],
+			to: 'goedgekeurd',
+			autoWhen: ALWAYS_HOLDS,
+			condition: NEVER_HOLDS,
+		},
+		// Group 4: a chain of two automatic moves in one pass, A to B to C.
+		stapEen: {
+			from: ['stap-1'],
+			to: 'stap-2',
+			autoWhen: ALWAYS_HOLDS,
+		},
+		stapTwee: {
+			from: ['stap-2'],
+			to: 'stap-3',
+			autoWhen: ALWAYS_HOLDS,
+		},
+		// Group 5: a ping-pong pair, to prove the loop cap's no-revisit rule.
+		heenGaan: {
+			from: ['heen'],
+			to: 'terug',
+			autoWhen: ALWAYS_HOLDS,
+		},
+		terugGaan: {
+			from: ['terug'],
+			to: 'heen',
+			autoWhen: ALWAYS_HOLDS,
+		},
+		// Group 6: declares no `autoWhen` at all — the regression guard.
+		archiveren: {
+			from: ['nieuw'],
+			to: 'gearchiveerd',
+		},
+	},
+}
+
+test.describe('lifecycle autoWhen automatic transitions', () => {
+	let register: SeededRegister
+	let schema: SeededSchema
+	const createdIds: string[] = []
+
+	test.beforeAll(async ({ request }) => {
+		register = await createRegister(request, runId, 'auto-reg')
+		schema = await createSchema(request, runId, 'auto-sch', PROPERTIES)
+		await linkSchemaToRegister(request, register, [schema.id])
+		await updateSchema(request, schema, PROPERTIES, {
+			configuration: { 'x-openregister-lifecycle': LIFECYCLE },
+		})
+	})
+
+	// Teardown lives in afterAll rather than at the end of a test body so it
+	// still runs when an assertion fails — a failed run must not leave fixture
+	// registers behind for the next one to trip over.
+	test.afterAll(async ({ request }) => {
+		await purge(request, register, schema, createdIds)
+	})
+
+	test('a sync automatic move via a direct save lands in the same response', async ({
+		request,
+	}) => {
+		// GIVEN an object in `in-behandeling` without a `motivering` — the
+		// `beslissen` autoWhen does not hold yet, so create fires nothing.
+		const created = await createObject(request, register.id, schema.id, {
+			status: 'in-behandeling',
+		})
+		const uuid = objectId(created) as string
+		createdIds.push(uuid)
+		expect(uuid, 'created object has an id').toBeTruthy()
+
+		// WHEN the object is saved with a non-empty `motivering` — a PUT is a
+		// full replace (SaveObject::prepareObjectForUpdate null-fills every
+		// omitted property), so `status` is resent unchanged rather than left
+		// out and nulled.
+		const after = await updateObject(request, register.id, schema.id, uuid, {
+			status: 'in-behandeling',
+			motivering: 'Overwegingen zijn compleet.',
+		})
+
+		// THEN the response to THAT save already carries `besloten` — not a
+		// later GET. This is the outermost-write-boundary claim: the automatic
+		// move is applied before the response of the triggering request is
+		// produced.
+		expect(
+			after.status,
+			'the PUT response already carries the automatic move',
+		).toBe('besloten')
+
+		// AND the move is real in storage, not just a lying response body.
+		const stored = await getObject(request, register.id, schema.id, uuid)
+		expect(stored.status, 'the object is still readable').toBe(200)
+		expect(stored.body?.status, 'the automatic move is stored').toBe('besloten')
+	})
+
+	test('a sync automatic move via the named-transition route lands in the same response', async ({
+		request,
+	}) => {
+		// The other entry point into the same boundary. `indienen` is a manual
+		// transition with no `autoWhen`; firing it by name is what makes
+		// `beoordelen`'s autoWhen start holding, and TransitionEngine::
+		// transition() opens the automatic-transition boundary around the
+		// WHOLE call, not just its own save — so the automatic follow-on move
+		// is applied before this endpoint answers.
+		const created = await createObject(request, register.id, schema.id, {
+			status: 'concept',
+		})
+		const uuid = objectId(created) as string
+		createdIds.push(uuid)
+
+		const resp = await request.post(`${API}/objects/${uuid}/transition`, {
+			headers: JSON_HEADERS,
+			data: { action: 'indienen' },
+		})
+
+		expect(resp.status(), 'the named transition is applied').toBe(200)
+
+		// TransitionController::transition() returns
+		// `$object->jsonSerialize()` on success, the same flat shape
+		// `getObject()` returns (the lifecycle field sits at the top level,
+		// beside `@self`), so the response body itself is asserted here rather
+		// than only the storage re-read below.
+		const body = await resp.json()
+		expect(
+			body?.status,
+			'the transition response already carries the automatic follow-on move',
+		).toBe('in-beoordeling')
+
+		// AND the move is real in storage.
+		const stored = await getObject(request, register.id, schema.id, uuid)
+		expect(stored.body?.status, 'the automatic move is stored').toBe(
+			'in-beoordeling',
+		)
+	})
+
+	test('an automatic move refused by its condition leaves the object in place', async ({
+		request,
+	}) => {
+		// `keuren`'s autoWhen always holds, but its condition never does. The
+		// refusal is caught inside AutoTransitionRunner::fire() and logged; it
+		// must not fail — or partially undo — the triggering save.
+		const created = await createObject(request, register.id, schema.id, {
+			status: 'binnengekomen',
+			notitie: 'origineel',
+		})
+		const uuid = objectId(created) as string
+		createdIds.push(uuid)
+
+		const after = await updateObject(request, register.id, schema.id, uuid, {
+			status: 'binnengekomen',
+			notitie: 'bijgewerkt',
+		})
+
+		// The triggering write succeeded and its own field change landed —
+		// the refused automatic move did not unwind it.
+		expect(after.notitie, 'the triggering write is not undone').toBe(
+			'bijgewerkt',
+		)
+		expect(after.status, 'the refused automatic move did not change state').toBe(
+			'binnengekomen',
+		)
+
+		const stored = await getObject(request, register.id, schema.id, uuid)
+		expect(stored.body?.notitie).toBe('bijgewerkt')
+		expect(stored.body?.status, 'still in place after a fresh read').toBe(
+			'binnengekomen',
+		)
+	})
+
+	test('a chain of two automatic moves resolves to the final state in one pass', async ({
+		request,
+	}) => {
+		// `stapEen` (stap-1 to stap-2) and `stapTwee` (stap-2 to stap-3) both
+		// always hold. The pass re-decides after each move within the same
+		// drain, so both apply before this PUT's response is produced.
+		const created = await createObject(request, register.id, schema.id, {
+			status: 'nieuw',
+		})
+		const uuid = objectId(created) as string
+		createdIds.push(uuid)
+
+		const after = await updateObject(request, register.id, schema.id, uuid, {
+			status: 'stap-1',
+		})
+
+		expect(
+			after.status,
+			'the chain resolves to its final state in one response',
+		).toBe('stap-3')
+
+		const stored = await getObject(request, register.id, schema.id, uuid)
+		expect(stored.body?.status, 'the chain is stored at its final state').toBe(
+			'stap-3',
+		)
+	})
+
+	test('a ping-pong pair is cut after exactly one move by the loop cap', async ({
+		request,
+	}) => {
+		// `heenGaan` (heen to terug) and `terugGaan` (terug to heen) both
+		// always hold, which is exactly the declaration AutoTransitionPass's
+		// NO-REVISIT rule exists for. Reading AutoTransitionPass::step(): the
+		// object's starting state counts as visited before the first move is
+		// even taken, so heen -> terug is allowed (terug not yet visited), and
+		// the very next decision, terug -> heen, is cut because heen is
+		// already in this pass's visited set. That is ONE move, deterministic,
+		// landing on `terug` — not the ceiling of 10, which only bites a
+		// chain through more than ten DISTINCT states.
+		const created = await createObject(request, register.id, schema.id, {
+			status: 'nieuw',
+		})
+		const uuid = objectId(created) as string
+		createdIds.push(uuid)
+
+		const after = await updateObject(request, register.id, schema.id, uuid, {
+			status: 'heen',
+		})
+
+		// The request itself must still answer normally — the cut logs an
+		// error and stops; it never throws and never hangs the request that
+		// triggered it.
+		expect(
+			after.status,
+			'the pass is cut deterministically at the first revisit, landing on terug',
+		).toBe('terug')
+
+		const stored = await getObject(request, register.id, schema.id, uuid)
+		expect(
+			stored.body?.status,
+			'the cut result is stored, not just answered',
+		).toBe('terug')
+	})
+
+	test('a transition declaring no autoWhen never fires on its own', async ({
+		request,
+	}) => {
+		// The regression guard. `archiveren` shares its `from` (`nieuw`) with
+		// two states this file also drives through `stapEen` and `heenGaan`'s
+		// starting point, so a broken implementation that treated EVERY
+		// declared transition as an automatic candidate — rather than only
+		// those carrying an `autoWhen` key, as
+		// AutoTransitionSelector::holdingTransitions() gates — would fire
+		// `archiveren` here. A correct implementation, and a build with no
+		// automatic-transition code at all, both leave the object exactly
+		// where the write itself put it: this test cannot distinguish
+		// "absent" from "correctly gated", which is exactly why the spec
+		// marks the underlying requirement's own version of this scenario
+		// `@e2e exclude` in favour of PHPUnit. It is kept here anyway because
+		// the task this file was written for asked for it explicitly, as a
+		// second, defense-in-depth check that sits next to the five tests
+		// above that DO fail on a feature-less build.
+		const created = await createObject(request, register.id, schema.id, {
+			status: 'nieuw',
+			notitie: 'a',
+		})
+		const uuid = objectId(created) as string
+		createdIds.push(uuid)
+
+		const after = await updateObject(request, register.id, schema.id, uuid, {
+			status: 'nieuw',
+			notitie: 'b',
+		})
+
+		expect(after.notitie, 'the unrelated field change landed').toBe('b')
+		expect(
+			after.status,
+			'a transition with no autoWhen key is never treated as an automatic candidate',
+		).toBe('nieuw')
+
+		const stored = await getObject(request, register.id, schema.id, uuid)
+		expect(stored.body?.status).toBe('nieuw')
+	})
+})


### PR DESCRIPTION
Second link of the lifecycle chain, after #3601. A transition can now fire itself.

```json
"beoordelen": {
  "from": ["ingediend"],
  "to": "in-beoordeling",
  "autoWhen": { "!!": { "var": "object.dossiernummer" } },
  "executionMode": "sync"
}
```

When `autoWhen` holds after a save, the engine fires that transition. It runs through `TransitionEngine`, so `authorization`, `condition`, `requires` and `actions` all still apply. An automatic move can never do what a manual one could not.

## Where the move runs, and why it matters

At the outermost write boundary, not in a listener. The listener only records the candidate. `ObjectService::saveObject()` and `TransitionEngine::transition()` each enter the pass and leave it in a `finally`; the drain runs when the last one leaves.

Firing from inside the listener looks simpler and is wrong three ways. On a file-bearing save a second update would overwrite the move. The audit row is not written yet. And a named transition's own event would be dispatched after the automatic one, inverting the order a listener sees.

A `sync` move is therefore already in the response of the write that triggered it, on both routes in. An `async` move defers to a job that re-decides against the stored object and does nothing if it changed meanwhile.

## Guardrails

Each of these is mutation-checked, meaning the guard was removed and the intended test was watched going red.

- At most 10 moves per object per pass, and never a return to a state already occupied in that pass.
- Two rules holding from the same state fire nothing and warn. Declaration order is not a tie-breaker, because it is not preserved by every database Nextcloud supports.
- A shadowed transition does not fire.
- A refused move is logged, never retried, and never reaches the caller. The triggering write still stands.
- A malformed `autoWhen` or `executionMode` refuses the schema save, exactly as a malformed `condition` does.
- Graph mode refuses `autoWhen`, as it already refuses `condition`.

## What the mutation pass found

One mutant killed nothing: moving the drain into the recording listener. That was a real hole. Nothing tested the ordering the whole design rests on. Two tests now do, and both are mutation-checked. Worth recording that a listener-side drain is inert on its own, because the pass refuses to drain a record marked inside a boundary. The guarantee sits one layer below the listener's discipline, which is the better place for it.

## Verification

- 414 lifecycle tests pass, exit 0.
- PHPCS and PHPMD exit 0 on every changed file. PHPMD reports zero with and without the baseline, so it is not a baseline-masked pass.
- Six Playwright tests cover both routes on the real save path, a refused move, a two-step chain, the loop cap and the no-autoWhen regression. They are admitted to `tests/e2e/ci/playwright.config.ts`, without which CI would never run them.

## Also in here

Three PHPMD thresholds this change tipped are fixed by extraction rather than suppression: `LifecycleWriteBoundary` takes the ambient collaborators off `TransitionEngine`, and `AutoTransitionQueue` takes the job list off `AutoTransitionRunner`. The sixteen em-dashes already in `docs/features/workflow-automation.md` are gone, since rule 8 of the house voice bans them and gate 96 only sees manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
