### PR TITLE
fix(retention): point every archival sweep at the magic tables

### DIFF
--- a/lib/BackgroundJob/DestructionCheckJob.php
+++ b/lib/BackgroundJob/DestructionCheckJob.php
@@ -31,13 +31,13 @@ namespace OCA\OpenRegister\BackgroundJob;
 
 use DateTime;
 use Exception;
-use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\Archival\Appraisal;
 use OCA\OpenRegister\Service\Archival\RecordState;
 use OCA\OpenRegister\Service\RetentionService;
 use OCA\OpenRegister\Service\Settings\ObjectRetentionHandler;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
-use OCP\IDBConnection;
 use OCP\IGroupManager;
 use OCP\Notification\IManager as INotificationManager;
 use Psr\Container\ContainerInterface;
@@ -68,14 +68,12 @@ class DestructionCheckJob extends TimedJob {
 	 *
 	 * @param ITimeFactory $time Time factory for parent class
 	 * @param ContainerInterface $container App container the job resolves its collaborators from at run time
-	 * @param IDBConnection $db Database connection
 	 *
 	 * @spec openspec/specs/archival-destruction-workflow/spec.md
 	 */
 	public function __construct(
 		ITimeFactory $time,
 		private readonly ContainerInterface $container,
-		private readonly IDBConnection $db,
 	) {
 		parent::__construct(time: $time);
 
@@ -191,7 +189,7 @@ class DestructionCheckJob extends TimedJob {
 		$today = (new DateTime())->format('Y-m-d');
 
 		try {
-			$objectMapper = $this->container->get(MagicMapper::class);
+			$retentionService = $this->container->get(RetentionService::class);
 
 			$appConfig = $this->container->get(\OCP\IAppConfig::class);
 			$notifiedJson = $appConfig->getValueString('openregister', self::NOTIFIED_KEY, '[]');
@@ -203,84 +201,81 @@ class DestructionCheckJob extends TimedJob {
 			$newNotified = [];
 			$newCount = 0;
 
-			// Page the retention scan instead of fetchAll()-ing every retention row into
-			// memory at once (OPS-7). batchSize bounds peak memory on large registers.
-			$batchSize = 500;
-			$offset = 0;
-
-			do {
-				$qb = $this->db->getQueryBuilder();
-				$qb->select('id')->from('openregister_objects')
-					->where($qb->expr()->isNotNull('retention'))
-					->setFirstResult($offset)
-					->setMaxResults($batchSize);
-
-				$result = $qb->executeQuery();
-				$rows = $result->fetchAll();
-				$result->closeCursor();
-
-				foreach ($rows as $row) {
-					try {
-						$object = $objectMapper->find(intval($row['id']), null, null, false, false, false);
-					} catch (Exception $e) {
-						continue;
-					}
-
-					$retention = $object->getRetention() ?? [];
-					$status = $retention['archiefstatus'] ?? null;
-					$actionDate = $retention['archiefactiedatum'] ?? null;
-					$nominatie = $retention['archiefnominatie'] ?? null;
+			// 🔴 THE SCAN READS THE MAGIC TABLES AS WELL AS THE LEGACY BLOB
+			// TABLE. This loop used to select straight from
+			// `openregister_objects`, which `BlobMigrationJob` drains into the
+			// per-schema magic tables every five minutes, so on any migrated
+			// install it read zero rows and no pre-destruction warning was ever
+			// sent. {@see RetentionService::scanObjectsWithRetention()} visits
+			// both stores, pages them, and caps one run.
+			$scan = $retentionService->scanObjectsWithRetention(
+				accept: static function (ObjectEntity $object) use ($today, $threshold): bool {
+					$retention = ($object->getRetention() ?? []);
+					$actionDate = ($retention['archiefactiedatum'] ?? null);
 
 					// Every spelling that means live. Matching only the English
 					// one would make every pre-existing record invisible to the
 					// pre-destruction warning, so the first a records officer
 					// would hear of a destruction is after it happened.
+					$status = ($retention['archiefstatus'] ?? null);
 					if ($actionDate === null || in_array($status, RecordState::ACTIVE_ALIASES, true) === false) {
-						continue;
+						return false;
 					}
 
-					if ($actionDate <= $today || $actionDate > $threshold) {
-						continue;
-					}
+					return ($actionDate > $today && $actionDate <= $threshold);
+				}
+			);
 
-					$uuid = $object->getUuid();
+			foreach ($scan['objects'] as $object) {
+				$retention = ($object->getRetention() ?? []);
+				$uuid = $object->getUuid();
 
-					// Object is still inside the notification window — keep it in the
-					// notified set even if we already alerted on it earlier.
-					if (in_array($uuid, $notified, true) === true) {
-						$stillRelevant[$uuid] = true;
-						continue;
-					}
+				// Object is still inside the notification window — keep it in the
+				// notified set even if we already alerted on it earlier.
+				if (in_array($uuid, $notified, true) === true) {
+					$stillRelevant[$uuid] = true;
+					continue;
+				}
 
-					if (($retention['legalHold']['active'] ?? false) === true) {
-						continue;
-					}
+				if ((($retention['legalHold'] ?? [])['active'] ?? false) === true) {
+					continue;
+				}
 
-					$subject = 'Object approaching destruction date';
-					if ($nominatie === 'bewaren') {
-						$subject = 'Object requires e-Depot transfer';
-					}
+				$subject = 'Object approaching destruction date';
+				if (in_array(($retention['archiefnominatie'] ?? null), Appraisal::RETAIN_PERMANENTLY_ALIASES, true) === true) {
+					$subject = 'Object requires e-Depot transfer';
+				}
 
-					$this->sendObjectNotification(
-						uuid: $uuid,
-						subject: $subject,
-						title: $object->getTitle() ?? $uuid,
-						actionDate: $actionDate,
-						classification: $retention['classification'] ?? null,
-						logger: $logger
-					);
+				$this->sendObjectNotification(
+					uuid: $uuid,
+					subject: $subject,
+					// 🔴 NOT `getTitle()`. `ObjectEntity` HAS NO `title`
+					// PROPERTY, so Entity's magic accessor threw
+					// "title is not a valid attribute" on the first object it
+					// reached. Inside this try that aborted the entire
+					// notification pass; in `createDestructionList()` the same
+					// call took down the whole job. `name` is the property that
+					// exists, and `getObjectArray()` already falls back to the
+					// uuid the same way.
+					title: $object->getName() ?? $uuid,
+					actionDate: (string)($retention['archiefactiedatum'] ?? ''),
+					classification: $retention['classification'] ?? null,
+					logger: $logger
+				);
 
-					$newNotified[$uuid] = true;
-					$newCount++;
-				}//end foreach
-
-				$rowCount = count($rows);
-				$offset += $batchSize;
-			} while ($rowCount === $batchSize);
+				$newNotified[$uuid] = true;
+				$newCount++;
+			}//end foreach
 
 			// Rebuild the persisted set from only the still-in-window UUIDs plus the freshly
 			// notified ones, dropping any whose destruction date has passed or moved away.
+			// A TRUNCATED RUN PRUNES NOTHING: it did not see every in-window object, so
+			// treating what it missed as "no longer in the window" would re-notify those
+			// records on a later run.
 			$rebuilt = array_keys($stillRelevant + $newNotified);
+			if ($scan['truncated'] === true) {
+				$rebuilt = array_values(array_unique(array_merge($notified, array_keys($newNotified))));
+			}
 
 			if ($newCount > 0 || count($rebuilt) !== count($notified)) {
 				$appConfig->setValueString('openregister', self::NOTIFIED_KEY, json_encode($rebuilt));

--- a/lib/BackgroundJob/TransferCheckJob.php
+++ b/lib/BackgroundJob/TransferCheckJob.php
@@ -27,9 +27,9 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\BackgroundJob;
 
-use DateTime;
-use OCA\OpenRegister\Db\MagicMapper;
 use OCA\OpenRegister\Service\Edepot\TransferListService;
+use OCA\OpenRegister\Service\Edepot\TransferRecordService;
+use OCA\OpenRegister\Service\RetentionService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
 use OCP\IAppConfig;
@@ -57,8 +57,9 @@ class TransferCheckJob extends TimedJob {
 	 * Constructor.
 	 *
 	 * @param ITimeFactory $time The time factory.
-	 * @param MagicMapper $objectMapper The object mapper.
+	 * @param RetentionService $retentionService Owns the retention sweep both archival jobs share.
 	 * @param TransferListService $transferListService The transfer list service.
+	 * @param TransferRecordService $transferRecords Durable transfer-list records.
 	 * @param IAppConfig $appConfig The app configuration.
 	 * @param LoggerInterface $logger Logger.
 	 *
@@ -66,8 +67,9 @@ class TransferCheckJob extends TimedJob {
 	 */
 	public function __construct(
 		ITimeFactory $time,
-		private readonly MagicMapper $objectMapper,
+		private readonly RetentionService $retentionService,
 		private readonly TransferListService $transferListService,
+		private readonly TransferRecordService $transferRecords,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
 	) {
@@ -148,28 +150,38 @@ class TransferCheckJob extends TimedJob {
 	 * Find objects eligible for e-Depot transfer.
 	 *
 	 * Objects are eligible when:
-	 * - archiefnominatie = 'bewaren'
+	 * - the appraisal is retain-permanently (`bewaren` / `blijvend_bewaren`)
 	 * - archiefactiedatum <= today
-	 * - the record state is still active
+	 * - the record state is not already transferred or destroyed
+	 * - there is no active legal hold
 	 * - Not already on an active transfer list
+	 *
+	 * 🔴 THIS USED TO RETURN `[]` UNCONDITIONALLY, behind a comment saying a
+	 * real implementation would query JSON field conditions. It ran daily on
+	 * every install with an e-Depot configured and produced no transfer list,
+	 * ever. The decision itself now lives in
+	 * {@see RetentionService::findEligibleForTransfer()}, beside the destruction
+	 * sweep it shares a scanner with.
 	 *
 	 * @return array<int, \OCA\OpenRegister\Db\ObjectEntity> Eligible objects.
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-assemble-sip-packages-for-e-depot-transfer
 	 */
 	private function findEligibleObjects(): array {
-		// Use a broad search and filter in PHP since the retention field is JSON.
-		// This is a simplified approach; production would use a more targeted query.
-		$today = (new DateTime())->format('Y-m-d');
-
-		$this->logger->debug(
-			message: '[TransferCheckJob] Scanning for eligible objects',
-			context: ['cutoffDate' => $today]
+		// Objects already awaiting or approved for transfer are excluded the way
+		// the destruction sweep excludes objects on a pending destruction list,
+		// so a second run does not re-list what an archivist is already holding.
+		$excludeUuids = $this->transferListService->getObjectsOnActiveTransferLists(
+			activeTransferLists: $this->transferRecords->listTransferLists()
 		);
 
-		// Note: In a real implementation, this would query using JSON field conditions.
-		// For now, we return an empty array as a safe no-op that can be extended
-		// when the magic table JSON querying supports retention field filtering.
-		return [];
+		$eligible = $this->retentionService->findEligibleForTransfer($excludeUuids);
+
+		$this->logger->debug(
+			message: '[TransferCheckJob] Scanned for eligible objects',
+			context: ['eligibleCount' => count($eligible), 'excludedCount' => count($excludeUuids)]
+		);
+
+		return $eligible;
 	}//end findEligibleObjects()
 }//end class

--- a/lib/Service/Archival/Appraisal.php
+++ b/lib/Service/Archival/Appraisal.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * The MDTO appraisal vocabulary, in one place.
+ *
+ * 🔴 THIS EXISTS BECAUSE THE APPRAISAL ALIASES HAD NO SHARED HOME. The list
+ * lived as a private constant on
+ * {@see \OCA\OpenRegister\Service\Archival\ArchivalDecisionResolver}, which
+ * reads objects and answers questions about them. Everything that had to ACT on
+ * an appraisal — the destruction sweep, the e-Depot transfer sweep — could not
+ * see it, so each wrote its own string literal instead, and each picked exactly
+ * one spelling.
+ *
+ * 🔴 MATCHING ONLY THE ENGLISH SPELLING SKIPS EVERY PRE-EXISTING RECORD, AND
+ * SKIPS IT SILENTLY. Stored data carries whatever spelling was current when it
+ * was written and there is no migration, so a destruction sweep that compares
+ * against `destroy` alone finds nothing on an install whose records say
+ * `vernietigen`. That is the direction that keeps personal data past its lawful
+ * term: the sweep reports "no objects eligible", which is indistinguishable
+ * from a clean run. The reverse mistake — matching only Dutch — hides every
+ * record written since the vocabulary landed. Both spellings, always, on READ.
+ *
+ * WRITES STILL PICK ONE. This class is a read-side vocabulary, exactly like
+ * {@see RecordState}: it says which stored spellings mean the same decision. It
+ * does not say which spelling a new record should be written with.
+ *
+ * CONSTANTS ONLY, NO METHODS, for the same reason RecordState has none: phpmd's
+ * StaticAccess rule refuses static helper calls, and a helper injected purely to
+ * compare two strings is not worth the wiring. The alias lists are the API.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Archival
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/retention-management/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Archival;
+
+/**
+ * The MDTO `waardering` values, and every spelling that means each one.
+ */
+final class Appraisal {
+
+	/**
+	 * Keep forever. The record goes to an e-Depot, it is never destroyed.
+	 */
+	public const RETAIN_PERMANENTLY = 'retain_permanently';
+
+	/**
+	 * Destroy once the disposal date has passed and nothing holds it.
+	 */
+	public const DESTROY = 'destroy';
+
+	/**
+	 * No decision has been recorded yet. Neither sweep may act on this.
+	 */
+	public const NOT_YET_DETERMINED = 'not_yet_determined';
+
+	/**
+	 * The appraisals, canonical spellings only.
+	 *
+	 * @var string[]
+	 */
+	public const ALL = [
+		self::RETAIN_PERMANENTLY,
+		self::DESTROY,
+		self::NOT_YET_DETERMINED,
+	];
+
+	/**
+	 * Every spelling that means RETAIN_PERMANENTLY.
+	 *
+	 * Three occur in the wild for "keep forever": MDTO and the selectielijst use
+	 * `blijvend_bewaren`, a ZGW resultaattype may carry the shorter `bewaren`,
+	 * and TMLO's own constant is `blijvend_bewaren` again. They mean the same
+	 * thing to an archivist and must not reach a reader as two appraisals.
+	 *
+	 * @var string[]
+	 */
+	public const RETAIN_PERMANENTLY_ALIASES = ['retain_permanently', 'bewaren', 'blijvend_bewaren'];
+
+	/**
+	 * Every spelling that means DESTROY.
+	 *
+	 * @var string[]
+	 */
+	public const DESTROY_ALIASES = ['destroy', 'vernietigen'];
+
+	/**
+	 * Every spelling that means NOT_YET_DETERMINED.
+	 *
+	 * @var string[]
+	 */
+	public const NOT_YET_DETERMINED_ALIASES = ['not_yet_determined', 'nog_niet_bepaald'];
+
+	/**
+	 * Every accepted spelling of every appraisal.
+	 *
+	 * @var string[]
+	 */
+	public const ALL_ALIASES = [
+		'retain_permanently',
+		'bewaren',
+		'blijvend_bewaren',
+		'destroy',
+		'vernietigen',
+		'not_yet_determined',
+		'nog_niet_bepaald',
+	];
+
+	/**
+	 * Each accepted spelling mapped to its canonical one.
+	 *
+	 * The alias lists above answer "does this stored value mean X", which is
+	 * what a sweep asks. This map answers "what is this stored value, in one
+	 * word", which is what a reader normalising an object for output asks. The
+	 * canonical spellings map to themselves so a value that is already
+	 * canonical resolves rather than falling through unchanged by accident.
+	 *
+	 * @var array<string, string>
+	 */
+	public const CANONICAL = [
+		'retain_permanently' => self::RETAIN_PERMANENTLY,
+		'bewaren' => self::RETAIN_PERMANENTLY,
+		'blijvend_bewaren' => self::RETAIN_PERMANENTLY,
+		'destroy' => self::DESTROY,
+		'vernietigen' => self::DESTROY,
+		'not_yet_determined' => self::NOT_YET_DETERMINED,
+		'nog_niet_bepaald' => self::NOT_YET_DETERMINED,
+	];
+}//end class

--- a/lib/Service/Archival/ArchivalDecisionResolver.php
+++ b/lib/Service/Archival/ArchivalDecisionResolver.php
@@ -63,24 +63,6 @@ use OCA\OpenRegister\Db\ObjectEntity;
 class ArchivalDecisionResolver {
 
     /**
-     * Appraisal values, normalised to MDTO's `waardering` vocabulary.
-     *
-     * Three spellings occur in the wild for "keep forever": MDTO and the
-     * selectielijst use `blijvend_bewaren`, a ZGW resultaattype may carry the
-     * shorter `bewaren`, and TMLO's own constant is `blijvend_bewaren` again.
-     * They mean the same thing to an archivist and must not reach a reader as
-     * two different appraisals.
-     *
-     * @var array<string, string>
-     */
-    private const APPRAISAL_ALIASES = [
-        'bewaren' => 'retain_permanently',
-        'blijvend_bewaren' => 'retain_permanently',
-        'vernietigen' => 'destroy',
-        'nog_niet_bepaald' => 'not_yet_determined',
-    ];
-
-    /**
      * Record states, in the Archiefwet lifecycle TmloService models.
      *
      * @var array<string, string>
@@ -359,7 +341,11 @@ class ArchivalDecisionResolver {
         // would report "no appraisal" for an object that carries one this
         // resolver has not been taught, which is the failure mode that hides a
         // records obligation.
-        return (self::APPRAISAL_ALIASES[$value] ?? $value);
+        // {@see Appraisal} is the ONE home for this vocabulary. It used to be a
+        // private constant here, which meant the destruction and transfer
+        // sweeps — the two places that have to ACT on an appraisal — could not
+        // see it and wrote their own string literals instead.
+        return (Appraisal::CANONICAL[$value] ?? $value);
     }//end normaliseAppraisal()
 
     /**

--- a/lib/Service/Archival/DestructionService.php
+++ b/lib/Service/Archival/DestructionService.php
@@ -82,13 +82,6 @@ class DestructionService {
 	private MagicMapper $objectMapper;
 
 	/**
-	 * Legal hold service for checking holds.
-	 *
-	 * @var LegalHoldService
-	 */
-	private LegalHoldService $legalHoldService;
-
-	/**
 	 * App configuration.
 	 *
 	 * @var IAppConfig
@@ -120,7 +113,6 @@ class DestructionService {
 	 * Constructor.
 	 *
 	 * @param MagicMapper $objectMapper Object entity data mapper.
-	 * @param LegalHoldService $legalHoldService Legal hold checking service.
 	 * @param IAppConfig $appConfig App configuration.
 	 * @param IJobList $jobList Background job list.
 	 * @param IUserSession $userSession User session service.
@@ -128,114 +120,17 @@ class DestructionService {
 	 */
 	public function __construct(
 		MagicMapper $objectMapper,
-		LegalHoldService $legalHoldService,
 		IAppConfig $appConfig,
 		IJobList $jobList,
 		IUserSession $userSession,
 		LoggerInterface $logger,
 	) {
 		$this->objectMapper = $objectMapper;
-		$this->legalHoldService = $legalHoldService;
 		$this->appConfig = $appConfig;
 		$this->jobList = $jobList;
 		$this->userSession = $userSession;
 		$this->logger = $logger;
 	}//end __construct()
-
-	/**
-	 * Find objects eligible for destruction.
-	 *
-	 * Objects are eligible when:
-	 * - archiefactiedatum is in the past
-	 * - archiefnominatie is 'vernietigen'
-	 * - the record state is still active
-	 * - No active legal hold
-	 * - Not already on an existing in_review destruction list
-	 *
-	 * @param array<string, int> $existingListObjectIds UUIDs of objects already on destruction lists.
-	 *
-	 * @return array<int, array<string, mixed>> Array of eligible object data.
-	 *
-	 * @spec openspec/specs/archival-destruction-workflow/spec.md
-	 * @spec openspec/specs/archival-destruction-workflow/spec.md
-	 */
-	public function findEligibleObjects(array $existingListObjectIds = []): array {
-		$today = (new DateTime())->format('Y-m-d');
-		$eligible = [];
-
-		// Query objects with retention.archiefactiedatum in the past.
-		// This uses MagicMapper's JSON field querying capability.
-		try {
-			$objects = $this->objectMapper->findAll(
-				filters: [
-					'retention.archiefnominatie' => 'vernietigen',
-					// Every spelling that means live. ⚠️ This whole query cannot
-					// return anything today (F2 in
-					// openspec/changes/archival-conformance): findAll() answers
-					// [] without register/schema, and `retention.archiefstatus`
-					// is a dotted JSON path the search handler compiles to
-					// `1 = 0`. It has no production caller. The value is kept
-					// correct so that whoever wires it up inherits the right
-					// vocabulary rather than a silent miss on top of a silent
-					// miss.
-					'retention.archiefstatus' => RecordState::ACTIVE_ALIASES,
-				],
-				includeDeleted: true
-			);
-		} catch (\Exception $e) {
-			$this->logger->error(
-				message: '[DestructionService] Failed to query eligible objects',
-				context: [
-					'file' => __FILE__,
-					'line' => __LINE__,
-					'exception' => $e->getMessage(),
-				]
-			);
-			return [];
-		}
-
-		foreach ($objects as $object) {
-			$retention = $object->getRetention() ?? [];
-
-			// Check archiefactiedatum is in the past.
-			$actiedatum = $retention['archiefactiedatum'] ?? null;
-			if ($actiedatum === null || $actiedatum > $today) {
-				continue;
-			}
-
-			// Check no active legal hold.
-			if ($this->legalHoldService->hasActiveHold($object) === true) {
-				continue;
-			}
-
-			// Check not already on an existing destruction list.
-			$uuid = $object->getUuid();
-			if (in_array($uuid, $existingListObjectIds, true) === true) {
-				continue;
-			}
-
-			$eligible[] = [
-				'uuid' => $uuid,
-				'title' => $object->getTitle() ?? $uuid,
-				'schema' => $object->getSchema(),
-				'register' => $object->getRegister(),
-				'archiefactiedatum' => $actiedatum,
-				'classification' => $retention['classification'] ?? null,
-				'alreadySoftDeleted' => $object->isSoftDeleted(),
-			];
-		}//end foreach
-
-		$this->logger->info(
-			message: '[DestructionService] Found eligible objects for destruction',
-			context: [
-				'file' => __FILE__,
-				'line' => __LINE__,
-				'count' => count($eligible),
-			]
-		);
-
-		return $eligible;
-	}//end findEligibleObjects()
 
 	/**
 	 * Create a destruction list from eligible objects.

--- a/lib/Service/Archival/RetentionRowScanner.php
+++ b/lib/Service/Archival/RetentionRowScanner.php
@@ -1,0 +1,429 @@
+<?php
+
+/**
+ * Where a retention decision can be stored, and how to walk all of it.
+ *
+ * 🔴 THIS EXISTS BECAUSE EVERY RETENTION SWEEP READ THE WRONG TABLE.
+ * OpenRegister keeps objects in per-schema magic tables
+ * (`openregister_table_<registerId>_<schemaId>`, each with its own
+ * `_retention` column). `BlobMigrationJob` drains the legacy blob table
+ * `openregister_objects` into them every five minutes and deletes the
+ * originals. Three separate sweeps still selected from that legacy table, so
+ * on a migrated install each one scanned zero rows and reported "nothing
+ * eligible". Measured on the shared development database: `openregister_objects`
+ * held 0 rows against 1320 magic tables, all 1320 of them carrying `_retention`.
+ *
+ * One scanner, so the next sweep that needs this inherits the right answer
+ * instead of writing a fourth query against whichever table it heard of first.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Archival
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/specs/archival-destruction-workflow/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Archival;
+
+use Exception;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCP\IDBConnection;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Pages every table a retention decision can live in and hands back the matches.
+ */
+class RetentionRowScanner {
+
+	/**
+	 * The most matches one retention sweep will collect before it stops.
+	 *
+	 * A first run on an install that has never swept can face years of backlog.
+	 * Handing all of it to `createDestructionList()` in one go produces a list
+	 * nobody can review and, on the notification path, a mail storm. The sweeps
+	 * are idempotent and run daily, so stopping at a bounded number costs a day
+	 * per batch and nothing else.
+	 *
+	 * A TRUNCATED RUN SAYS SO, AT WARNING LEVEL. A sweep that quietly stops
+	 * early is the same class of defect this cap sits inside: a job that
+	 * reports success while having looked at part of the data.
+	 */
+	public const MAX_MATCHES_PER_RUN = 500;
+
+	/**
+	 * Rows read per page while scanning one retention source.
+	 *
+	 * Bounds peak memory: a register with a million rows is read a page at a
+	 * time rather than fetched whole.
+	 */
+	private const SCAN_BATCH_SIZE = 500;
+
+	/**
+	 * The legacy blob table objects were stored in before magic tables.
+	 */
+	private const LEGACY_TABLE = 'openregister_objects';
+
+	/**
+	 * The magic tables' own id column.
+	 *
+	 * Magic tables prefix every metadata column with an underscore so a
+	 * schema-declared property can never collide with one. `MagicMapper` keeps
+	 * that prefix private, so the two columns this sweep needs are named here.
+	 */
+	private const MAGIC_ID_COLUMN = '_id';
+
+	/**
+	 * The magic tables' own retention column.
+	 */
+	private const MAGIC_RETENTION_COLUMN = '_retention';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IDBConnection   $db             Database connection for the row scans.
+	 * @param RegisterMapper  $registerMapper Register repository, used to enumerate pairs.
+	 * @param SchemaMapper    $schemaMapper   Schema repository, used to enumerate pairs.
+	 * @param MagicMapper     $objectMapper   Magic-table resolver and row hydrator.
+	 * @param LoggerInterface $logger         Logger for skipped sources and truncated runs.
+	 */
+	public function __construct(
+		private readonly IDBConnection $db,
+		private readonly RegisterMapper $registerMapper,
+		private readonly SchemaMapper $schemaMapper,
+		private readonly MagicMapper $objectMapper,
+		private readonly LoggerInterface $logger,
+	) {
+	}//end __construct()
+
+	/**
+	 * Visit every object carrying a retention decision, wherever it lives.
+	 *
+	 * 🔴 THIS READS BOTH STORES, BECAUSE READING ONE OF THEM FINDS NOTHING.
+	 * OpenRegister keeps objects in per-schema magic tables
+	 * (`openregister_table_<registerId>_<schemaId>`, each with its own
+	 * `_retention` column). `BlobMigrationJob` drains the legacy blob table
+	 * `openregister_objects` into them every five minutes and deletes the
+	 * originals. Every retention sweep in this app still selected from that
+	 * legacy table, so on a migrated install each one scanned zero rows and
+	 * reported "nothing eligible". Measured on the shared development database:
+	 * `openregister_objects` held 0 rows against 1320 magic tables, all 1320 of
+	 * them carrying `_retention`.
+	 *
+	 * So both sources are scanned, not one. An install that has finished the
+	 * blob migration reads its magic tables; an install that has not started it
+	 * reads the blob table; an install part-way through reads both and the
+	 * duplicate-free answer falls out of the migration deleting what it moves.
+	 *
+	 * NO JSON FILTERING IN SQL. OpenRegister runs on PostgreSQL and on
+	 * MySQL/MariaDB, whose JSON path syntax differs, so the SQL asks only
+	 * "is there a retention decision at all" and eligibility is decided in PHP
+	 * on the hydrated object. That is the property the previous implementation
+	 * had and the one thing about it that was right.
+	 *
+	 * @param callable $accept  Predicate answering whether one object is a match.
+	 * @param int|null $maxMatches Cap for this run; defaults to MAX_MATCHES_PER_RUN.
+	 *
+	 * @return array{objects: ObjectEntity[], scanned: int, truncated: bool} The matches,
+	 *               how many rows were inspected, and whether the cap stopped the run.
+	 *
+	 * @psalm-param callable(ObjectEntity): bool $accept
+	 *
+	 * @spec openspec/specs/archival-destruction-workflow/spec.md
+	 * @spec openspec/specs/retention-management/spec.md#requirement-the-system-must-generate-destruction-lists-via-a-background-job
+	 */
+	public function scan(callable $accept, ?int $maxMatches = null): array {
+		$cap = ($maxMatches ?? self::MAX_MATCHES_PER_RUN);
+		$objects = [];
+		$scanned = 0;
+		$truncated = false;
+
+		foreach ($this->retentionSources() as $source) {
+			$outcome = $this->scanRetentionSource(
+				source: $source,
+				accept: $accept,
+				remaining: ($cap - count($objects))
+			);
+
+			$scanned += $outcome['scanned'];
+			foreach ($outcome['objects'] as $object) {
+				$objects[] = $object;
+			}
+
+			if ($outcome['truncated'] === true) {
+				$truncated = true;
+				break;
+			}
+		}
+
+		if ($truncated === true) {
+			// A SILENTLY TRUNCATED SWEEP IS THE DEFECT THIS METHOD EXISTS TO
+			// FIX, ONE LEVEL UP. Saying so out loud is the difference between a
+			// backlog being worked through a batch at a time and a records
+			// officer believing the whole estate was examined.
+			$this->logger->warning(
+				sprintf(
+					'[RetentionRowScanner] Retention scan stopped at its cap: %d matches found, cap is %d '
+					. 'per run, %d rows inspected. The remainder is picked up by the next run.',
+					count($objects),
+					$cap,
+					$scanned
+				),
+				[
+					'app' => 'openregister',
+					'matched' => count($objects),
+					'cap' => $cap,
+					'scanned' => $scanned,
+					'truncated' => true,
+				]
+			);
+		}
+
+		return [
+			'objects' => $objects,
+			'scanned' => $scanned,
+			'truncated' => $truncated,
+		];
+	}//end scan()
+
+	/**
+	 * Every table a retention decision can be stored in, in scan order.
+	 *
+	 * The legacy blob table goes first: it is a single table, it is empty on a
+	 * migrated install so it costs one query, and on an install that never
+	 * started the blob migration it is the only place anything lives.
+	 *
+	 * @return array<int, array<string, mixed>> Source descriptors.
+	 */
+	private function retentionSources(): array {
+		$sources = [
+			[
+				'table' => self::LEGACY_TABLE,
+				'label' => self::LEGACY_TABLE,
+				'select' => '*',
+				'idColumn' => 'id',
+				'retentionColumn' => 'retention',
+				'legacy' => true,
+				'register' => null,
+				'schema' => null,
+			],
+		];
+
+		foreach ($this->magicTableSources() as $source) {
+			$sources[] = $source;
+		}
+
+		return $sources;
+	}//end retentionSources()
+
+	/**
+	 * Resolve one source per (register, schema) pair that has a magic table.
+	 *
+	 * A pair whose table has not been materialised is SKIPPED, not thrown on: a
+	 * schema with no rows yet is an ordinary state, and one unmaterialised pair
+	 * must not take down the sweep for every other pair in the install.
+	 *
+	 * @return array<int, array<string, mixed>> Source descriptors, possibly empty.
+	 */
+	private function magicTableSources(): array {
+		try {
+			$registers = $this->registerMapper->findAll(_rbac: false, _multitenancy: false);
+		} catch (Exception $e) {
+			$this->logger->warning(
+				'[RetentionRowScanner] Could not enumerate registers for the retention scan: ' . $e->getMessage(),
+				['app' => 'openregister', 'exception' => $e]
+			);
+			return [];
+		}
+
+		$sources = [];
+		$seen = [];
+
+		foreach ($registers as $register) {
+			if (($register instanceof Register) === false) {
+				continue;
+			}
+
+			foreach (($register->getSchemas() ?? []) as $schemaId) {
+				$source = $this->magicTableSource(register: $register, schemaId: $schemaId);
+				if ($source === null) {
+					continue;
+				}
+
+				if (isset($seen[$source['table']]) === true) {
+					continue;
+				}
+
+				$seen[$source['table']] = true;
+				$sources[] = $source;
+			}
+		}
+
+		return $sources;
+	}//end magicTableSources()
+
+	/**
+	 * One magic-table source descriptor, or null when the pair has no table.
+	 *
+	 * @param Register   $register The register the pair belongs to.
+	 * @param string|int $schemaId The schema id as the register lists it.
+	 *
+	 * @return array<string, mixed>|null The descriptor, or null when unusable.
+	 */
+	private function magicTableSource(Register $register, string|int $schemaId): ?array {
+		try {
+			$schema = $this->schemaMapper->find((int)$schemaId);
+
+			if ($this->objectMapper->tableExistsForRegisterSchema(register: $register, schema: $schema) === false) {
+				return null;
+			}
+
+			$table = $this->objectMapper->getTableNameForRegisterSchema(register: $register, schema: $schema);
+		} catch (Exception $e) {
+			$this->logger->warning(
+				sprintf(
+					'[RetentionRowScanner] Skipping register #%s schema #%s in the retention scan: %s',
+					(string)$register->getId(),
+					(string)$schemaId,
+					$e->getMessage()
+				),
+				['app' => 'openregister']
+			);
+			return null;
+		}//end try
+
+		return [
+			'table' => $table,
+			'label' => $table,
+			'select' => self::MAGIC_ID_COLUMN,
+			'idColumn' => self::MAGIC_ID_COLUMN,
+			'retentionColumn' => self::MAGIC_RETENTION_COLUMN,
+			'legacy' => false,
+			'register' => $register,
+			'schema' => $schema,
+		];
+	}//end magicTableSource()
+
+	/**
+	 * Page one source, hydrate its retention rows and keep the matches.
+	 *
+	 * @param array<string, mixed> $source    The source descriptor.
+	 * @param callable             $accept    Predicate answering whether one object is a match.
+	 * @param int                  $remaining How many more matches this run may still collect.
+	 *
+	 * @return array{objects: ObjectEntity[], scanned: int, truncated: bool} What this source contributed.
+	 *
+	 * @psalm-param callable(ObjectEntity): bool $accept
+	 */
+	private function scanRetentionSource(array $source, callable $accept, int $remaining): array {
+		$objects = [];
+		$scanned = 0;
+
+		if ($remaining <= 0) {
+			return ['objects' => $objects, 'scanned' => $scanned, 'truncated' => true];
+		}
+
+		$offset = 0;
+
+		try {
+			do {
+				$qb = $this->db->getQueryBuilder();
+				$qb->select($source['select'])
+					->from($source['table'])
+					->where($qb->expr()->isNotNull($source['retentionColumn']))
+					->setFirstResult($offset)
+					->setMaxResults(self::SCAN_BATCH_SIZE);
+
+				$result = $qb->executeQuery();
+				$rows = $result->fetchAll();
+				$result->closeCursor();
+
+				foreach ($rows as $row) {
+					$scanned++;
+
+					$object = $this->hydrateRetentionRow(source: $source, row: $row);
+					if ($object === null) {
+						continue;
+					}
+
+					if ($accept($object) === false) {
+						continue;
+					}
+
+					$objects[] = $object;
+
+					if (count($objects) >= $remaining) {
+						return ['objects' => $objects, 'scanned' => $scanned, 'truncated' => true];
+					}
+				}
+
+				$rowCount = count($rows);
+				$offset += self::SCAN_BATCH_SIZE;
+			} while ($rowCount === self::SCAN_BATCH_SIZE);
+		} catch (Exception $e) {
+			// One unreadable table must not silence every other one. The blob
+			// table is absent on installs created after it was retired, and a
+			// magic table can be dropped between the existence check and the
+			// read.
+			$this->logger->warning(
+				sprintf(
+					'[RetentionRowScanner] Retention scan skipped source "%s": %s',
+					(string)$source['label'],
+					$e->getMessage()
+				),
+				['app' => 'openregister']
+			);
+		}//end try
+
+		return ['objects' => $objects, 'scanned' => $scanned, 'truncated' => false];
+	}//end scanRetentionSource()
+
+	/**
+	 * Turn one scanned row into an object, or null when it cannot be read.
+	 *
+	 * 🔴 THE LEGACY ROW IS HYDRATED IN PLACE, NOT LOOKED UP.
+	 * `MagicMapper::find()` without a register and schema searches the MAGIC
+	 * tables only, so feeding it an id read out of the blob table looks the id
+	 * up in a different id space entirely — it finds the wrong object or none
+	 * at all. The row is already in hand; hydrate that.
+	 *
+	 * @param array<string, mixed> $source The source descriptor.
+	 * @param array<string, mixed> $row    The scanned row.
+	 *
+	 * @return ObjectEntity|null The object, or null when it cannot be loaded.
+	 *
+	 * @SuppressWarnings(PHPMD.StaticAccess) `Entity::fromRow()` is Nextcloud's own
+	 *              row constructor, not a collaborator that could be injected.
+	 */
+	private function hydrateRetentionRow(array $source, array $row): ?ObjectEntity {
+		try {
+			if ($source['legacy'] === true) {
+				return ObjectEntity::fromRow($row);
+			}
+
+			return $this->objectMapper->find(
+				$row[$source['idColumn']],
+				$source['register'],
+				$source['schema'],
+				false,
+				false,
+				false
+			);
+		} catch (Exception $e) {
+			return null;
+		}
+	}//end hydrateRetentionRow()
+}//end class

--- a/lib/Service/RetentionService.php
+++ b/lib/Service/RetentionService.php
@@ -42,15 +42,15 @@ use Exception;
 use OCA\OpenRegister\Db\AuditTrailMapper;
 use OCA\OpenRegister\Db\MagicMapper;
 use OCA\OpenRegister\Db\ObjectEntity;
-use OCA\OpenRegister\Db\Register;
 use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Archival\Appraisal;
 use OCA\OpenRegister\Service\Archival\ArchiveActionDateCalculator;
 use OCA\OpenRegister\Service\Archival\RecordState;
+use OCA\OpenRegister\Service\Archival\RetentionRowScanner;
 use OCA\OpenRegister\Service\Settings\ObjectRetentionHandler;
 use OCP\IAppConfig;
-use OCP\IDBConnection;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
@@ -105,7 +105,7 @@ class RetentionService {
 	 * @param IAppConfig $appConfig App configuration
 	 * @param IUserSession $userSession Current user session
 	 * @param LoggerInterface $logger Logger
-	 * @param IDBConnection $db Database connection for eligibility queries
+	 * @param RetentionRowScanner $rowScanner Walks every table a retention decision can live in
 	 * @param ArchiveActionDateCalculator $actionDateCalculator Calculates the archiefactiedatum
 	 *
 	 * @SuppressWarnings(PHPMD.ExcessiveParameterList) A DI constructor for an aggregate service.
@@ -122,7 +122,7 @@ class RetentionService {
 		private readonly IAppConfig $appConfig,
 		private readonly IUserSession $userSession,
 		private readonly LoggerInterface $logger,
-		private readonly IDBConnection $db,
+		private readonly RetentionRowScanner $rowScanner,
 		private readonly ArchiveActionDateCalculator $actionDateCalculator,
 	) {
 	}//end __construct()
@@ -659,92 +659,216 @@ class RetentionService {
 	}//end extendArchiveActionDate()
 
 	/**
+	 * Visit every object carrying a retention decision, wherever it lives.
+	 *
+	 * Delegates to {@see RetentionRowScanner}, which owns the whole question of
+	 * WHERE a retention decision is stored: the per-schema magic tables and the
+	 * legacy blob table both, paged, with a cap per run. Kept here because both
+	 * archival background jobs already ask this service for the sweep.
+	 *
+	 * @param callable $accept     Predicate answering whether one object is a match.
+	 * @param int|null $maxMatches Cap for this run; defaults to the scanner's own.
+	 *
+	 * @return array{objects: ObjectEntity[], scanned: int, truncated: bool} The matches,
+	 *               how many rows were inspected, and whether the cap stopped the run.
+	 *
+	 * @psalm-param callable(ObjectEntity): bool $accept
+	 *
+	 * @spec openspec/specs/archival-destruction-workflow/spec.md
+	 * @spec openspec/specs/retention-management/spec.md#requirement-the-system-must-generate-destruction-lists-via-a-background-job
+	 */
+	public function scanObjectsWithRetention(callable $accept, ?int $maxMatches = null): array {
+		return $this->rowScanner->scan(accept: $accept, maxMatches: $maxMatches);
+	}//end scanObjectsWithRetention()
+
+	/**
 	 * Find objects eligible for destruction.
 	 *
-	 * Objects with archiefactiedatum < now, archiefnominatie = vernietigen,
-	 * the record state is still active, no active legal hold, and not already
-	 * on a pending destruction list.
+	 * Objects whose appraisal is destroy, whose archiefactiedatum has passed,
+	 * whose record state is still live, that are not immutable, carry no active
+	 * legal hold, and are not already on a pending destruction list.
 	 *
 	 * @param array $excludeUuids UUIDs to exclude (already on pending lists)
 	 *
 	 * @return ObjectEntity[] Array of eligible objects
-	 *
-	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 *
 	 * @spec openspec/specs/archival-destruction-workflow/spec.md
 	 */
 	public function findEligibleForDestruction(array $excludeUuids = []): array {
 		$today = (new DateTime())->format('Y-m-d');
 
-		try {
-			// Query objects with archival metadata indicating destruction eligibility.
-			$qb = $this->db->getQueryBuilder();
+		$scan = $this->scanObjectsWithRetention(
+			accept: fn (ObjectEntity $object): bool => $this->isEligibleForDestruction(
+				object: $object,
+				today: $today,
+				excludeUuids: $excludeUuids
+			)
+		);
 
-			$qb->select('id')
-				->from('openregister_objects')
-				->where(
-					$qb->expr()->isNotNull('retention')
-				);
-
-			$result = $qb->executeQuery();
-			$rows = $result->fetchAll();
-			$result->closeCursor();
-
-			$eligible = [];
-
-			foreach ($rows as $row) {
-				try {
-					$object = $this->objectMapper->find(intval($row['id']), null, null, false, false, false);
-				} catch (Exception $e) {
-					continue;
-				}
-
-				$retention = $object->getRetention() ?? [];
-
-				// Check eligibility criteria.
-				if (($retention['archiefnominatie'] ?? '') !== 'vernietigen') {
-					continue;
-				}
-
-				// Every spelling that means live. Matching only the English one
-				// would make every pre-existing record invisible to this sweep,
-				// which is the direction that keeps personal data past its term.
-				if (in_array(($retention['archiefstatus'] ?? ''), RecordState::ACTIVE_ALIASES, true) === false) {
-					continue;
-				}
-
-				$actiedatum = $retention['archiefactiedatum'] ?? null;
-				if ($actiedatum === null || $actiedatum > $today) {
-					continue;
-				}
-
-				// Skip objects in an immutable archival status (vernietigd, overgebracht).
-				if ($this->validateNotImmutable(object: $object) !== null) {
-					continue;
-				}
-
-				// Skip objects with active legal hold.
-				if (($retention['legalHold']['active'] ?? false) === true) {
-					continue;
-				}
-
-				// Skip objects already on pending lists.
-				if (in_array($object->getUuid(), $excludeUuids, true) === true) {
-					continue;
-				}
-
-				$eligible[] = $object;
-			}//end foreach
-
-			return $eligible;
-		} catch (Exception $e) {
-			$this->logger->error(
-				'[RetentionService] Failed to find eligible objects for destruction: ' . $e->getMessage(),
-				['exception' => $e]
-			);
-			return [];
-		}//end try
+		return $scan['objects'];
 	}//end findEligibleForDestruction()
+
+	/**
+	 * Decide whether one object is eligible for destruction today.
+	 *
+	 * @param ObjectEntity $object       The object to judge.
+	 * @param string       $today        Today, as Y-m-d.
+	 * @param array        $excludeUuids UUIDs already on a pending destruction list.
+	 *
+	 * @return bool True when every destruction rule is satisfied.
+	 *
+	 * @SuppressWarnings(PHPMD.CyclomaticComplexity) One rule per branch; collapsing
+	 *              them would hide which rule rejected an object.
+	 */
+	private function isEligibleForDestruction(ObjectEntity $object, string $today, array $excludeUuids): bool {
+		$retention = ($object->getRetention() ?? []);
+
+		// Every spelling that means destroy. Matching only the English one
+		// would make every pre-existing record invisible to this sweep, which
+		// is the direction that keeps personal data past its lawful term.
+		if (in_array(($retention['archiefnominatie'] ?? ''), Appraisal::DESTROY_ALIASES, true) === false) {
+			return false;
+		}
+
+		if ($this->recordStateIsLive(retention: $retention) === false) {
+			return false;
+		}
+
+		$actiedatum = ($retention['archiefactiedatum'] ?? null);
+		if ($actiedatum === null || $actiedatum > $today) {
+			return false;
+		}
+
+		// Skip objects in an immutable archival status (destroyed, transferred).
+		//
+		// ⚠️ THIS IS A BELT OVER BRACES AND NO TEST CAN REDDEN ON IT ALONE: every
+		// spelling {@see validateNotImmutable()} rejects is already outside
+		// ACTIVE_ALIASES, so the check above has excluded the object first. It
+		// is kept, and its redundancy named rather than quietly relied on,
+		// because the live-state list is the thing most likely to grow: the day
+		// a new state counts as live, this line is what stops a transferred
+		// record being swept while nobody is looking at this method.
+		if ($this->validateNotImmutable(object: $object) !== null) {
+			return false;
+		}
+
+		if ((($retention['legalHold'] ?? [])['active'] ?? false) === true) {
+			return false;
+		}
+
+		return (in_array($object->getUuid(), $excludeUuids, true) === false);
+	}//end isEligibleForDestruction()
+
+	/**
+	 * Is this record still live, for the purposes of a disposal sweep?
+	 *
+	 * 🔴 AN ABSENT RECORD STATE MEANS LIVE, AND SAYING OTHERWISE FINDS NOTHING.
+	 * Nothing writes `archiefstatus` until something actually happens to a
+	 * record, so the common case carries no state at all. Measured on a live
+	 * instance: a dossiq case resolved through OpenRegister came back as
+	 * `{"appraisal":"retain_permanently","retentionPeriod":"P10Y",`
+	 * `"disposalDate":"2036-09-11T07:22:48+00:00","recordState":null,`
+	 * `"basis":"record"}`, and `recordState` was null for every case measured.
+	 *
+	 * The previous comparison was `in_array($retention['archiefstatus'] ?? '',
+	 * ACTIVE_ALIASES)`. `''` is in no alias list, so every record nothing had
+	 * happened to yet was skipped. Reading the magic tables would have fixed
+	 * where the sweep looks and still returned nothing for the ordinary case.
+	 *
+	 * Same reasoning as the Dutch aliases: being too strict here keeps personal
+	 * data past its lawful term, and it does it in silence. An explicit
+	 * `transferred` or `destroyed`, in any spelling, still excludes, and
+	 * {@see validateNotImmutable()} still runs after this.
+	 *
+	 * This is the SWEEP's reading of the field only. It does not change what
+	 * {@see \OCA\OpenRegister\Service\Archival\ArchivalDecisionResolver} emits:
+	 * null is the honest answer there and consumers render it as a blank.
+	 *
+	 * @param array $retention The object's retention block.
+	 *
+	 * @return bool True when the record is live or has no recorded state yet.
+	 */
+	private function recordStateIsLive(array $retention): bool {
+		$state = ($retention['archiefstatus'] ?? null);
+
+		if ($state === null || (is_string($state) === true && trim($state) === '')) {
+			return true;
+		}
+
+		// Every spelling that means live.
+		return in_array($state, RecordState::ACTIVE_ALIASES, true);
+	}//end recordStateIsLive()
+
+	/**
+	 * Find objects eligible for transfer to an e-Depot.
+	 *
+	 * Objects whose appraisal is retain-permanently, whose archiefactiedatum has
+	 * passed, whose record state is not already transferred or destroyed, that
+	 * carry no active legal hold, and are not already on an active transfer
+	 * list.
+	 *
+	 * @param array $excludeUuids UUIDs to exclude (already on active transfer lists)
+	 *
+	 * @return ObjectEntity[] Array of eligible objects
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-support-transfer-list-management
+	 */
+	public function findEligibleForTransfer(array $excludeUuids = []): array {
+		$today = (new DateTime())->format('Y-m-d');
+
+		$scan = $this->scanObjectsWithRetention(
+			accept: fn (ObjectEntity $object): bool => $this->isEligibleForTransfer(
+				object: $object,
+				today: $today,
+				excludeUuids: $excludeUuids
+			)
+		);
+
+		return $scan['objects'];
+	}//end findEligibleForTransfer()
+
+	/**
+	 * Decide whether one object is eligible for e-Depot transfer today.
+	 *
+	 * A record already transferred has nothing left to hand over and a
+	 * destroyed one no longer exists, so both are excluded by state rather than
+	 * by requiring the state to be live: a semi-static record is exactly the one
+	 * an archivist expects to see on a transfer list.
+	 *
+	 * @param ObjectEntity $object       The object to judge.
+	 * @param string       $today        Today, as Y-m-d.
+	 * @param array        $excludeUuids UUIDs already on an active transfer list.
+	 *
+	 * @return bool True when every transfer rule is satisfied.
+	 */
+	private function isEligibleForTransfer(ObjectEntity $object, string $today, array $excludeUuids): bool {
+		$retention = ($object->getRetention() ?? []);
+
+		// Every spelling that means keep forever: `bewaren` from a ZGW
+		// resultaattype, `blijvend_bewaren` from MDTO and the selectielijst.
+		if (in_array(($retention['archiefnominatie'] ?? ''), Appraisal::RETAIN_PERMANENTLY_ALIASES, true) === false) {
+			return false;
+		}
+
+		// Only an EXPLICIT transferred or destroyed state excludes. An absent,
+		// null or empty state means nothing has happened to this record yet,
+		// which is exactly the record an archivist expects to see on a transfer
+		// list; see {@see recordStateIsLive()} for the measurement behind that.
+		if (in_array(($retention['archiefstatus'] ?? ''), self::IMMUTABLE_STATUSES, true) === true) {
+			return false;
+		}
+
+		$actiedatum = ($retention['archiefactiedatum'] ?? null);
+		if ($actiedatum === null || $actiedatum > $today) {
+			return false;
+		}
+
+		if ((($retention['legalHold'] ?? [])['active'] ?? false) === true) {
+			return false;
+		}
+
+		return (in_array($object->getUuid(), $excludeUuids, true) === false);
+	}//end isEligibleForTransfer()
 
 	/**
 	 * Get UUIDs of objects already on pending destruction lists.
@@ -842,7 +966,14 @@ class RetentionService {
 
 			$objectEntries[] = [
 				'uuid' => $object->getUuid(),
-				'title' => $object->getTitle() ?? $object->getUuid(),
+				// 🔴 NOT `getTitle()`. `ObjectEntity` HAS NO `title` PROPERTY,
+				// so Entity's magic accessor threw "title is not a valid
+				// attribute" here, uncaught, and took the whole
+				// DestructionCheckJob run down with it. Every sweep that got
+				// this far therefore failed at list creation, which is a second
+				// reason no destruction list was ever produced. `name` is the
+				// property that exists.
+				'title' => $object->getName() ?? $object->getUuid(),
 				'schema' => $object->getSchema(),
 				'register' => $object->getRegister(),
 				'archiefactiedatum' => $retention['archiefactiedatum'] ?? null,

--- a/openspec/changes/archival-conformance/proposal.md
+++ b/openspec/changes/archival-conformance/proposal.md
@@ -296,20 +296,27 @@ objects that were already awaiting approval, and nothing said so. The key is
 now `status`.
 
 **F2 · `DestructionService::findEligibleObjects()` cannot return anything.
-NOT FIXED HERE.**
+DELETED.**
 
-It calls `MagicMapper::findAll()` with no `register`/`schema`, and `findAll()`
-returns `[]` immediately in that case. It also filters on
+It called `MagicMapper::findAll()` with no `register`/`schema`, and `findAll()`
+returns `[]` immediately in that case. It also filtered on
 `retention.archiefstatus`, a dotted JSON path the search handler does not
 support outside the TMLO-specific branch, which would compile to `1 = 0` even
 with the context supplied.
 
-It has no production caller: `DestructionCheckJob` uses
-`RetentionService::findEligibleForDestruction()`, which reads the objects table
-directly and filters in PHP, and `TransferCheckJob::findEligibleObjects()` is
-its own separate method that returns `[]` as a documented no-op. So nothing is
-broken by it today. It is recorded here because it looks like a working query
-and is not, and because the next person to wire it up will believe it works.
+It had no caller anywhere, tests included: `DestructionCheckJob` uses
+`RetentionService::findEligibleForDestruction()`, and
+`TransferCheckJob::findEligibleObjects()` was its own separate method that
+returned `[]`. It was left in place on the first pass and recorded here because
+it looks like a working query and is not.
+
+Leaving it was the wrong call, because that is precisely the harm it does: the
+next person to wire it up believes it works. It is now deleted, along with the
+`LegalHoldService` dependency `DestructionService` held only to serve it. The
+eligibility question has one home,
+`RetentionService::findEligibleForDestruction()`, which scans the per-schema
+magic tables as well as the legacy blob table and filters in PHP; the transfer
+side gained its sibling, `findEligibleForTransfer()`.
 
 ### Later — export completeness
 

--- a/tests/Unit/BackgroundJob/DestructionCheckJobNotificationTest.php
+++ b/tests/Unit/BackgroundJob/DestructionCheckJobNotificationTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pre-destruction notification tests for DestructionCheckJob.
+ *
+ * 🔴 THE WARNING WAS NEVER SENT ON A MIGRATED INSTALL. This scan paged the
+ * legacy blob table `openregister_objects`, which `BlobMigrationJob` drains
+ * into the per-schema magic tables every five minutes, so it read zero rows and
+ * the first a records officer heard of a destruction was after it happened.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\BackgroundJob
+ * @author   Conduction Development Team <dev@conduction.nl>
+ * @license  EUPL-1.2
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\BackgroundJob;
+
+use DateTime;
+use OCA\OpenRegister\BackgroundJob\DestructionCheckJob;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\RetentionService;
+use OCA\OpenRegister\Service\Settings\ObjectRetentionHandler;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IAppConfig;
+use OCP\IGroup;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\Notification\IManager as INotificationManager;
+use OCP\Notification\INotification;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use ReflectionClass;
+
+/**
+ * Tests that the pre-destruction warning reaches the archivist group.
+ */
+class DestructionCheckJobNotificationTest extends TestCase {
+
+	private RetentionService&MockObject $retentionService;
+	private INotificationManager&MockObject $notificationManager;
+	private ContainerInterface&MockObject $container;
+
+	/**
+	 * Object uuids the notification manager was asked to notify about.
+	 *
+	 * @var array<int, string>
+	 */
+	private array $notifiedUuids = [];
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->notifiedUuids = [];
+		$this->retentionService = $this->createMock(RetentionService::class);
+
+		$notification = $this->createMock(INotification::class);
+		foreach (['setApp', 'setUser', 'setDateTime', 'setSubject'] as $fluent) {
+			$notification->method($fluent)->willReturn($notification);
+		}
+
+		$notification->method('setObject')->willReturnCallback(
+			function (string $type, string $id) use ($notification): INotification {
+				$this->notifiedUuids[] = $id;
+				return $notification;
+			}
+		);
+
+		$this->notificationManager = $this->createMock(INotificationManager::class);
+		$this->notificationManager->method('createNotification')->willReturn($notification);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('archivaris-1');
+		$group = $this->createMock(IGroup::class);
+		$group->method('getUsers')->willReturn([$user]);
+		$groupManager = $this->createMock(IGroupManager::class);
+		$groupManager->method('get')->willReturn($group);
+
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getValueString')->willReturnCallback(
+			static fn (string $app, string $key, string $default = ''): string => $default
+		);
+
+		$this->container = $this->createMock(ContainerInterface::class);
+		$this->container->method('get')->willReturnCallback(
+			fn (string $id): object => match ($id) {
+				RetentionService::class => $this->retentionService,
+				INotificationManager::class => $this->notificationManager,
+				IGroupManager::class => $groupManager,
+				IAppConfig::class => $appConfig,
+				ObjectRetentionHandler::class => $this->createMock(ObjectRetentionHandler::class),
+				default => $this->createMock(LoggerInterface::class),
+			}
+		);
+	}//end setUp()
+
+	/**
+	 * An object inside the lead window is warned about, through the scan that
+	 * reads both stores rather than the drained blob table alone.
+	 */
+	public function testAnObjectInsideTheWindowIsNotifiedAbout(): void {
+		$due = (new DateTime())->modify('+10 days')->format('Y-m-d');
+
+		$object = new ObjectEntity();
+		$object->setUuid('warn-uuid');
+		$object->setRetention(
+			[
+				'archiefnominatie' => 'vernietigen',
+				'archiefstatus' => 'nog_te_archiveren',
+				'archiefactiedatum' => $due,
+			]
+		);
+
+		$this->retentionService->expects($this->once())
+			->method('scanObjectsWithRetention')
+			->willReturn(['objects' => [$object], 'scanned' => 1, 'truncated' => false]);
+
+		$this->runNotificationPass();
+
+		$this->assertSame(['warn-uuid'], $this->notifiedUuids);
+	}//end testAnObjectInsideTheWindowIsNotifiedAbout()
+
+	/**
+	 * A held object is warned about by nobody: the hold is why it is not going
+	 * to be destroyed.
+	 */
+	public function testAHeldObjectIsNotNotifiedAbout(): void {
+		$due = (new DateTime())->modify('+10 days')->format('Y-m-d');
+
+		$object = new ObjectEntity();
+		$object->setUuid('held-uuid');
+		$object->setRetention(
+			[
+				'archiefnominatie' => 'vernietigen',
+				'archiefstatus' => 'active',
+				'archiefactiedatum' => $due,
+				'legalHold' => ['active' => true],
+			]
+		);
+
+		$this->retentionService->method('scanObjectsWithRetention')
+			->willReturn(['objects' => [$object], 'scanned' => 1, 'truncated' => false]);
+
+		$this->runNotificationPass();
+
+		$this->assertSame([], $this->notifiedUuids);
+	}//end testAHeldObjectIsNotNotifiedAbout()
+
+	/**
+	 * Run the job's private pre-destruction notification pass.
+	 *
+	 * @return void
+	 */
+	private function runNotificationPass(): void {
+		$job = new DestructionCheckJob(
+			$this->createMock(ITimeFactory::class),
+			$this->container
+		);
+
+		$method = (new ReflectionClass(DestructionCheckJob::class))->getMethod('sendPreDestructionNotifications');
+		$method->setAccessible(true);
+		$method->invoke($job, ['notificationLeadDays' => 30], $this->createMock(LoggerInterface::class));
+	}//end runNotificationPass()
+}//end class

--- a/tests/Unit/BackgroundJob/TransferCheckJobTest.php
+++ b/tests/Unit/BackgroundJob/TransferCheckJobTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * TransferCheckJob unit tests.
+ *
+ * 🔴 `findEligibleObjects()` WAS A STUB THAT RETURNED `[]`, behind a comment
+ * saying a real implementation would query JSON field conditions. The job ran
+ * daily on every install with an e-Depot configured and produced no transfer
+ * list, ever, while logging "No objects eligible for transfer" as though it had
+ * looked. These tests hold the wiring in place.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\BackgroundJob
+ * @author   Conduction Development Team <dev@conduction.nl>
+ * @license  EUPL-1.2
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\BackgroundJob;
+
+use OCA\OpenRegister\BackgroundJob\TransferCheckJob;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\Edepot\TransferListService;
+use OCA\OpenRegister\Service\Edepot\TransferRecordService;
+use OCA\OpenRegister\Service\RetentionService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IAppConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionClass;
+
+/**
+ * Tests for the e-Depot transfer check job.
+ */
+class TransferCheckJobTest extends TestCase {
+
+	private RetentionService&MockObject $retentionService;
+	private TransferListService&MockObject $transferListService;
+	private TransferRecordService&MockObject $transferRecordService;
+	private IAppConfig&MockObject $appConfig;
+	private TransferCheckJob $job;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->retentionService = $this->createMock(RetentionService::class);
+		$this->transferListService = $this->createMock(TransferListService::class);
+		$this->transferRecordService = $this->createMock(TransferRecordService::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
+
+		$this->appConfig->method('getValueString')->willReturnCallback(
+			static function (string $app, string $key, string $default = ''): string {
+				if ($key === 'edepot_endpoint_url') {
+					return 'https://edepot.example.org/sip';
+				}
+
+				return $default;
+			}
+		);
+
+		$this->job = new TransferCheckJob(
+			$this->createMock(ITimeFactory::class),
+			$this->retentionService,
+			$this->transferListService,
+			$this->transferRecordService,
+			$this->appConfig,
+			$this->createMock(LoggerInterface::class),
+		);
+	}//end setUp()
+
+	/**
+	 * The job asks the retention sweep and puts what it gets on a transfer list.
+	 *
+	 * Before this change the sweep was never asked: the method returned `[]`
+	 * unconditionally, so `createTransferList()` was never reached.
+	 */
+	public function testEligibleObjectsReachTheTransferList(): void {
+		$object = new ObjectEntity();
+		$object->setUuid('keep-uuid');
+
+		$this->transferRecordService->method('listTransferLists')->willReturn([]);
+		$this->transferListService->method('getObjectsOnActiveTransferLists')->willReturn([]);
+
+		$this->retentionService->expects($this->once())
+			->method('findEligibleForTransfer')
+			->with([])
+			->willReturn([$object]);
+
+		$this->transferListService->expects($this->once())
+			->method('createTransferList')
+			->with([$object])
+			->willReturn(['uuid' => 'list-uuid', 'objectCount' => 1]);
+
+		$this->transferListService->expects($this->once())->method('notifyArchivists');
+
+		$this->runJob();
+	}//end testEligibleObjectsReachTheTransferList()
+
+	/**
+	 * Objects already on an active transfer list are excluded, the way the
+	 * destruction sweep excludes objects on a pending destruction list.
+	 */
+	public function testObjectsOnActiveTransferListsAreExcluded(): void {
+		$this->transferRecordService->method('listTransferLists')->willReturn(
+			[['status' => 'in_review', 'objectReferences' => [['uuid' => 'listed-uuid']]]]
+		);
+		$this->transferListService->method('getObjectsOnActiveTransferLists')->willReturn(['listed-uuid']);
+
+		$this->retentionService->expects($this->once())
+			->method('findEligibleForTransfer')
+			->with(['listed-uuid'])
+			->willReturn([]);
+
+		$this->transferListService->expects($this->never())->method('createTransferList');
+
+		$this->runJob();
+	}//end testObjectsOnActiveTransferListsAreExcluded()
+
+	/**
+	 * With no e-Depot configured the job does nothing at all, which is the
+	 * self-limit it had before and must keep.
+	 */
+	public function testNothingHappensWithoutAnEdepot(): void {
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getValueString')->willReturnCallback(
+			static fn (string $app, string $key, string $default = ''): string => $default
+		);
+
+		$job = new TransferCheckJob(
+			$this->createMock(ITimeFactory::class),
+			$this->retentionService,
+			$this->transferListService,
+			$this->transferRecordService,
+			$appConfig,
+			$this->createMock(LoggerInterface::class),
+		);
+
+		$this->retentionService->expects($this->never())->method('findEligibleForTransfer');
+
+		$method = (new ReflectionClass(TransferCheckJob::class))->getMethod('run');
+		$method->setAccessible(true);
+		$method->invoke($job, null);
+	}//end testNothingHappensWithoutAnEdepot()
+
+	/**
+	 * Invoke the job's protected run() method.
+	 *
+	 * @return void
+	 */
+	private function runJob(): void {
+		$method = (new ReflectionClass(TransferCheckJob::class))->getMethod('run');
+		$method->setAccessible(true);
+		$method->invoke($this->job, null);
+	}//end runJob()
+}//end class

--- a/tests/Unit/Service/Archival/DestructionCertificateContentTest.php
+++ b/tests/Unit/Service/Archival/DestructionCertificateContentTest.php
@@ -38,12 +38,11 @@ use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Service\Archival\ArchiveActionDateCalculator;
 use OCA\OpenRegister\Service\Archival\DestructionService;
-use OCA\OpenRegister\Service\Archival\LegalHoldService;
+use OCA\OpenRegister\Service\Archival\RetentionRowScanner;
 use OCA\OpenRegister\Service\RetentionService;
 use OCA\OpenRegister\Service\Settings\ObjectRetentionHandler;
 use OCP\BackgroundJob\IJobList;
 use OCP\IAppConfig;
-use OCP\IDBConnection;
 use OCP\IUser;
 use OCP\IUserSession;
 use PHPUnit\Framework\TestCase;
@@ -85,7 +84,6 @@ class DestructionCertificateContentTest extends TestCase {
 
 		$this->destructionService = new DestructionService(
 			$objectMapper,
-			$this->createMock(LegalHoldService::class),
 			$appConfig,
 			$this->jobList,
 			$userSession,
@@ -101,7 +99,7 @@ class DestructionCertificateContentTest extends TestCase {
 			$appConfig,
 			$userSession,
 			$this->createMock(LoggerInterface::class),
-			$this->createMock(IDBConnection::class),
+			$this->createMock(RetentionRowScanner::class),
 			$this->createMock(ArchiveActionDateCalculator::class)
 		);
 	}

--- a/tests/Unit/Service/Archival/DestructionServiceTest.php
+++ b/tests/Unit/Service/Archival/DestructionServiceTest.php
@@ -19,7 +19,6 @@ use OCA\OpenRegister\BackgroundJob\DestructionExecutionJob;
 use OCA\OpenRegister\Db\MagicMapper;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Service\Archival\DestructionService;
-use OCA\OpenRegister\Service\Archival\LegalHoldService;
 use OCP\BackgroundJob\IJobList;
 use OCP\IAppConfig;
 use OCP\IUser;
@@ -33,7 +32,6 @@ use Psr\Log\LoggerInterface;
  */
 class DestructionServiceTest extends TestCase {
 	private MagicMapper&MockObject $objectMapper;
-	private LegalHoldService&MockObject $legalHoldService;
 	private IAppConfig&MockObject $appConfig;
 	private IJobList&MockObject $jobList;
 	private IUserSession&MockObject $userSession;
@@ -47,7 +45,6 @@ class DestructionServiceTest extends TestCase {
 			->disableOriginalConstructor()
 			->onlyMethods(['update', 'find'])
 			->getMock();
-		$this->legalHoldService = $this->createMock(LegalHoldService::class);
 		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->jobList = $this->createMock(IJobList::class);
 		$this->userSession = $this->createMock(IUserSession::class);
@@ -55,7 +52,6 @@ class DestructionServiceTest extends TestCase {
 
 		$this->service = new DestructionService(
 			$this->objectMapper,
-			$this->legalHoldService,
 			$this->appConfig,
 			$this->jobList,
 			$this->userSession,

--- a/tests/Unit/Service/RetentionServiceTest.php
+++ b/tests/Unit/Service/RetentionServiceTest.php
@@ -23,10 +23,10 @@ use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Service\Archival\ArchiveActionDateCalculator;
+use OCA\OpenRegister\Service\Archival\RetentionRowScanner;
 use OCA\OpenRegister\Service\RetentionService;
 use OCA\OpenRegister\Service\Settings\ObjectRetentionHandler;
 use OCP\IAppConfig;
-use OCP\IDBConnection;
 use OCP\IUser;
 use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -46,7 +46,7 @@ class RetentionServiceTest extends TestCase {
 	private IAppConfig&MockObject $appConfig;
 	private IUserSession&MockObject $userSession;
 	private LoggerInterface&MockObject $logger;
-	private IDBConnection&MockObject $db;
+	private RetentionRowScanner&MockObject $rowScanner;
 	private RetentionService $service;
 
 	protected function setUp(): void {
@@ -60,7 +60,7 @@ class RetentionServiceTest extends TestCase {
 		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
-		$this->db = $this->createMock(IDBConnection::class);
+		$this->rowScanner = $this->createMock(RetentionRowScanner::class);
 
 		$this->service = new RetentionService(
 			$this->objectMapper,
@@ -71,7 +71,7 @@ class RetentionServiceTest extends TestCase {
 			$this->appConfig,
 			$this->userSession,
 			$this->logger,
-			$this->db,
+			$this->rowScanner,
 			// The REAL resolver over the SAME mapper mock the tests program, not
 			// a mock of its own: the derivation tests below assert what the
 			// resolver actually does with a relation, and a mocked resolver

--- a/tests/Unit/Service/RetentionSweepTest.php
+++ b/tests/Unit/Service/RetentionSweepTest.php
@@ -1,0 +1,658 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * RetentionService sweep unit tests.
+ *
+ * 🔴 THESE COVER A SWEEP THAT FOUND NOTHING AND SAID SO AS THOUGH IT HAD
+ * LOOKED. Every retention sweep in this app selected from the legacy blob table
+ * `openregister_objects`, which `BlobMigrationJob` drains into the per-schema
+ * magic tables every five minutes. Measured on the shared development database:
+ * 0 rows in the blob table against 1320 magic tables, all 1320 carrying a
+ * `_retention` column. So the destruction list was never created, the
+ * pre-destruction warning was never sent, and the transfer list was a literal
+ * `return []`.
+ *
+ * The first two tests are the whole point: a magic-table record is found, and a
+ * legacy-table record is still found. The rest hold the eligibility rules and
+ * the per-run cap in place.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ * @author   Conduction Development Team <dev@conduction.nl>
+ * @license  EUPL-1.2
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Service;
+
+use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Archival\ArchiveActionDateCalculator;
+use OCA\OpenRegister\Service\Archival\RetentionRowScanner;
+use OCA\OpenRegister\Service\RetentionService;
+use OCA\OpenRegister\Service\Settings\ObjectRetentionHandler;
+use OCP\DB\IResult;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IAppConfig;
+use OCP\IDBConnection;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests for the retention scan and the two eligibility sweeps built on it.
+ */
+class RetentionSweepTest extends TestCase {
+
+	/**
+	 * The bare magic table for register 1 / schema 2.
+	 */
+	private const MAGIC_TABLE = 'openregister_table_1_2';
+
+	/**
+	 * The legacy blob table.
+	 */
+	private const LEGACY_TABLE = 'openregister_objects';
+
+	private MagicMapper&MockObject $objectMapper;
+	private SchemaMapper&MockObject $schemaMapper;
+	private RegisterMapper&MockObject $registerMapper;
+	private IDBConnection&MockObject $db;
+	private LoggerInterface&MockObject $logger;
+	private ObjectRetentionHandler&MockObject $settingsHandler;
+	private RetentionService $service;
+
+	/**
+	 * Objects the magic-table mapper hands back, keyed by `_id`.
+	 *
+	 * @var array<int, ObjectEntity>
+	 */
+	private array $magicObjects = [];
+
+	/**
+	 * Rows each table answers with, keyed by bare table name.
+	 *
+	 * @var array<string, array<int, array<string, mixed>>>
+	 */
+	private array $rowsByTable = [];
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->objectMapper = $this->createMock(MagicMapper::class);
+		$this->schemaMapper = $this->createMock(SchemaMapper::class);
+		$this->registerMapper = $this->createMock(RegisterMapper::class);
+		$this->db = $this->createMock(IDBConnection::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->settingsHandler = $this->createMock(ObjectRetentionHandler::class);
+
+		$this->rowsByTable = [self::LEGACY_TABLE => [], self::MAGIC_TABLE => []];
+		$this->magicObjects = [];
+
+		$this->db->method('getQueryBuilder')->willReturnCallback(
+			fn (): IQueryBuilder => $this->makeQueryBuilder()
+		);
+
+		$this->objectMapper->method('find')->willReturnCallback(
+			function (string|int $identifier): ObjectEntity {
+				$object = ($this->magicObjects[(int)$identifier] ?? null);
+				if ($object === null) {
+					throw new \RuntimeException('no such object: ' . (string)$identifier);
+				}
+
+				return $object;
+			}
+		);
+
+		$this->service = new RetentionService(
+			$this->objectMapper,
+			$this->schemaMapper,
+			$this->registerMapper,
+			$this->createMock(AuditTrailMapper::class),
+			$this->settingsHandler,
+			$this->createMock(IAppConfig::class),
+			$this->createMock(IUserSession::class),
+			$this->logger,
+			// The REAL scanner over the SAME mocks these tests program, not a
+			// mock of its own: what is under test here is which tables get
+			// walked and how, and a mocked scanner would assert only that this
+			// service called something.
+			new RetentionRowScanner(
+				$this->db,
+				$this->registerMapper,
+				$this->schemaMapper,
+				$this->objectMapper,
+				$this->logger
+			),
+			new ArchiveActionDateCalculator($this->objectMapper, $this->logger),
+		);
+	}//end setUp()
+
+	/**
+	 * THE WHOLE POINT: a record in a MAGIC table is found.
+	 *
+	 * This is the record that was invisible. The sweep read the legacy blob
+	 * table only, and on a migrated install that table is empty.
+	 */
+	public function testADestroyCandidateInAMagicTableIsFound(): void {
+		$this->givenARegisterWithAMagicTable();
+		$this->givenMagicRow(id: 7, uuid: 'magic-uuid', retention: $this->dueForDestruction());
+
+		$eligible = $this->service->findEligibleForDestruction();
+
+		$this->assertCount(1, $eligible);
+		$this->assertSame('magic-uuid', $eligible[0]->getUuid());
+	}//end testADestroyCandidateInAMagicTableIsFound()
+
+	/**
+	 * The legacy blob table is still read, so an install that never finished
+	 * (or never started) the blob migration keeps working.
+	 */
+	public function testADestroyCandidateInTheLegacyTableIsFound(): void {
+		$this->givenLegacyRow(id: 3, uuid: 'legacy-uuid', retention: $this->dueForDestruction());
+
+		$eligible = $this->service->findEligibleForDestruction();
+
+		$this->assertCount(1, $eligible);
+		$this->assertSame('legacy-uuid', $eligible[0]->getUuid());
+	}//end testADestroyCandidateInTheLegacyTableIsFound()
+
+	/**
+	 * Both stores at once, which is what a part-migrated install looks like.
+	 */
+	public function testBothStoresAreScannedInOneRun(): void {
+		$this->givenARegisterWithAMagicTable();
+		$this->givenLegacyRow(id: 3, uuid: 'legacy-uuid', retention: $this->dueForDestruction());
+		$this->givenMagicRow(id: 7, uuid: 'magic-uuid', retention: $this->dueForDestruction());
+
+		$uuids = array_map(
+			static fn (ObjectEntity $object): ?string => $object->getUuid(),
+			$this->service->findEligibleForDestruction()
+		);
+
+		sort($uuids);
+		$this->assertSame(['legacy-uuid', 'magic-uuid'], $uuids);
+	}//end testBothStoresAreScannedInOneRun()
+
+	/**
+	 * 🔴 THE DUTCH SPELLINGS MUST KEEP MATCHING.
+	 *
+	 * Stored data carries whatever spelling was current when it was written and
+	 * there is no migration. A sweep that compares against `destroy` and
+	 * `active` alone finds nothing on an install whose records say `vernietigen`
+	 * and `nog_te_archiveren`, and reports that as "no objects eligible", which
+	 * is the direction that keeps personal data past its lawful term.
+	 */
+	public function testTheDutchSpellingsAreFoundForDestruction(): void {
+		$this->givenLegacyRow(
+			id: 3,
+			uuid: 'dutch-uuid',
+			retention: [
+				'archiefnominatie' => 'vernietigen',
+				'archiefstatus' => 'nog_te_archiveren',
+				'archiefactiedatum' => '2020-01-01',
+			]
+		);
+
+		$eligible = $this->service->findEligibleForDestruction();
+
+		$this->assertCount(1, $eligible);
+		$this->assertSame('dutch-uuid', $eligible[0]->getUuid());
+	}//end testTheDutchSpellingsAreFoundForDestruction()
+
+	/**
+	 * 🔴 A RECORD WITH NO RECORDED STATE IS STILL SWEPT, BECAUSE NOTHING HAS
+	 * HAPPENED TO IT YET.
+	 *
+	 * Nothing writes `archiefstatus` until a record is transferred or
+	 * destroyed, so the ordinary case carries no state at all. Measured on a
+	 * live instance: a dossiq case resolved through OpenRegister answered
+	 * `{"appraisal":"retain_permanently","retentionPeriod":"P10Y",`
+	 * `"disposalDate":"2036-09-11T07:22:48+00:00","recordState":null,`
+	 * `"basis":"record"}`, with `recordState` null for every case measured.
+	 *
+	 * The old comparison treated an absent state as "not live", so reading the
+	 * magic tables would have fixed where the sweep looks and still returned
+	 * nothing for the common case.
+	 */
+	public function testARecordWithNoRecordedStateIsStillSwept(): void {
+		$this->givenLegacyRow(
+			id: 8,
+			uuid: 'stateless-uuid',
+			retention: [
+				'archiefnominatie' => 'vernietigen',
+				'archiefactiedatum' => '2020-01-01',
+			]
+		);
+
+		$eligible = $this->service->findEligibleForDestruction();
+
+		$this->assertCount(1, $eligible);
+		$this->assertSame('stateless-uuid', $eligible[0]->getUuid());
+	}//end testARecordWithNoRecordedStateIsStillSwept()
+
+	/**
+	 * An explicitly null state is the shape the resolver actually emits, and it
+	 * means the same thing as an absent one.
+	 */
+	public function testANullRecordStateIsStillSwept(): void {
+		$this->givenLegacyRow(
+			id: 9,
+			uuid: 'null-state-uuid',
+			retention: [
+				'archiefnominatie' => 'vernietigen',
+				'archiefstatus' => null,
+				'archiefactiedatum' => '2020-01-01',
+			]
+		);
+
+		$this->assertCount(1, $this->service->findEligibleForDestruction());
+	}//end testANullRecordStateIsStillSwept()
+
+	/**
+	 * The transfer sweep reads an absent state the same way.
+	 */
+	public function testARecordWithNoRecordedStateIsSweptForTransfer(): void {
+		$this->givenLegacyRow(
+			id: 10,
+			uuid: 'stateless-keep-uuid',
+			retention: [
+				'archiefnominatie' => 'blijvend_bewaren',
+				'archiefactiedatum' => '2020-01-01',
+			]
+		);
+
+		$eligible = $this->service->findEligibleForTransfer();
+
+		$this->assertCount(1, $eligible);
+		$this->assertSame('stateless-keep-uuid', $eligible[0]->getUuid());
+	}//end testARecordWithNoRecordedStateIsSweptForTransfer()
+
+	/**
+	 * An absent state is live, but a state that is present and means something
+	 * else is still honoured: a semi-static record is not destroyed.
+	 */
+	public function testASemiStaticRecordIsNotDestroyed(): void {
+		$retention = $this->dueForDestruction();
+		$retention['archiefstatus'] = 'semi_static';
+		$this->givenLegacyRow(id: 11, uuid: 'semi-uuid', retention: $retention);
+
+		$this->assertSame([], $this->service->findEligibleForDestruction());
+	}//end testASemiStaticRecordIsNotDestroyed()
+
+	/**
+	 * The same trap on the transfer side: `blijvend_bewaren` is the spelling
+	 * MDTO and the selectielijst use, and it is not `retain_permanently`.
+	 */
+	public function testTheDutchSpellingIsFoundForTransfer(): void {
+		$this->givenLegacyRow(
+			id: 4,
+			uuid: 'bewaren-uuid',
+			retention: [
+				'archiefnominatie' => 'blijvend_bewaren',
+				'archiefstatus' => 'semi_statisch',
+				'archiefactiedatum' => '2020-01-01',
+			]
+		);
+
+		$eligible = $this->service->findEligibleForTransfer();
+
+		$this->assertCount(1, $eligible);
+		$this->assertSame('bewaren-uuid', $eligible[0]->getUuid());
+	}//end testTheDutchSpellingIsFoundForTransfer()
+
+	/**
+	 * An active legal hold keeps a record out of the destruction list.
+	 */
+	public function testALegalHoldExcludes(): void {
+		$retention = $this->dueForDestruction();
+		$retention['legalHold'] = ['active' => true, 'reason' => 'lopend bezwaar'];
+		$this->givenLegacyRow(id: 3, uuid: 'held-uuid', retention: $retention);
+
+		$this->assertSame([], $this->service->findEligibleForDestruction());
+	}//end testALegalHoldExcludes()
+
+	/**
+	 * A record already transferred or destroyed is not live, so it is not swept.
+	 */
+	public function testAnImmutableStateExcludesFromDestruction(): void {
+		$retention = $this->dueForDestruction();
+		$retention['archiefstatus'] = 'overgebracht';
+		$this->givenLegacyRow(id: 3, uuid: 'gone-uuid', retention: $retention);
+
+		$this->assertSame([], $this->service->findEligibleForDestruction());
+	}//end testAnImmutableStateExcludesFromDestruction()
+
+	/**
+	 * A disposal date still in the future excludes.
+	 */
+	public function testAFutureDisposalDateExcludes(): void {
+		$retention = $this->dueForDestruction();
+		$retention['archiefactiedatum'] = '2099-01-01';
+		$this->givenLegacyRow(id: 3, uuid: 'future-uuid', retention: $retention);
+
+		$this->assertSame([], $this->service->findEligibleForDestruction());
+	}//end testAFutureDisposalDateExcludes()
+
+	/**
+	 * A record already on a pending destruction list is not re-listed.
+	 */
+	public function testAnExcludedUuidIsNotReturned(): void {
+		$this->givenLegacyRow(id: 3, uuid: 'pending-uuid', retention: $this->dueForDestruction());
+
+		$this->assertSame([], $this->service->findEligibleForDestruction(['pending-uuid']));
+	}//end testAnExcludedUuidIsNotReturned()
+
+	/**
+	 * Transfer finds a retain-permanently record whose date has passed.
+	 */
+	public function testTransferFindsADueRetainPermanentlyRecord(): void {
+		$this->givenARegisterWithAMagicTable();
+		$this->givenMagicRow(
+			id: 9,
+			uuid: 'keep-uuid',
+			retention: [
+				'archiefnominatie' => 'retain_permanently',
+				'archiefstatus' => 'semi_static',
+				'archiefactiedatum' => '2020-01-01',
+			]
+		);
+
+		$eligible = $this->service->findEligibleForTransfer();
+
+		$this->assertCount(1, $eligible);
+		$this->assertSame('keep-uuid', $eligible[0]->getUuid());
+	}//end testTransferFindsADueRetainPermanentlyRecord()
+
+	/**
+	 * A record already handed to an e-Depot has nothing left to transfer.
+	 */
+	public function testTransferDoesNotFindAnAlreadyTransferredRecord(): void {
+		$this->givenLegacyRow(
+			id: 5,
+			uuid: 'already-uuid',
+			retention: [
+				'archiefnominatie' => 'blijvend_bewaren',
+				'archiefstatus' => 'overgebracht',
+				'archiefactiedatum' => '2020-01-01',
+			]
+		);
+
+		$this->assertSame([], $this->service->findEligibleForTransfer());
+	}//end testTransferDoesNotFindAnAlreadyTransferredRecord()
+
+	/**
+	 * An excluded uuid keeps a record off a second transfer list.
+	 */
+	public function testTransferHonoursTheExcludeList(): void {
+		$this->givenLegacyRow(
+			id: 6,
+			uuid: 'listed-uuid',
+			retention: [
+				'archiefnominatie' => 'bewaren',
+				'archiefstatus' => 'active',
+				'archiefactiedatum' => '2020-01-01',
+			]
+		);
+
+		$this->assertSame([], $this->service->findEligibleForTransfer(['listed-uuid']));
+	}//end testTransferHonoursTheExcludeList()
+
+	/**
+	 * 🔴 THE CAP TRUNCATES, AND IT SAYS SO AT WARNING LEVEL.
+	 *
+	 * A first run on a long backlog must not build an unreviewable list or a
+	 * notification storm. A sweep that stopped early in silence would be the
+	 * same class of defect this whole change fixes.
+	 */
+	public function testTheCapTruncatesAndLogsAWarning(): void {
+		foreach ([1, 2, 3] as $id) {
+			$this->givenLegacyRow(
+				id: $id,
+				uuid: 'row-' . (string)$id,
+				retention: $this->dueForDestruction()
+			);
+		}
+
+		$warnings = [];
+		$this->logger->method('warning')->willReturnCallback(
+			static function (string $message) use (&$warnings): void {
+				$warnings[] = $message;
+			}
+		);
+
+		$scan = $this->service->scanObjectsWithRetention(
+			accept: static fn (ObjectEntity $object): bool => true,
+			maxMatches: 2
+		);
+
+		$this->assertCount(2, $scan['objects']);
+		$this->assertTrue($scan['truncated']);
+		$this->assertCount(1, $warnings);
+		$this->assertStringContainsString('stopped at its cap', $warnings[0]);
+		$this->assertStringContainsString('cap is 2', $warnings[0]);
+		$this->assertStringContainsString('next run', $warnings[0]);
+	}//end testTheCapTruncatesAndLogsAWarning()
+
+	/**
+	 * A run that fits under the cap reports no truncation and warns about
+	 * nothing. Without this the previous test would pass on a scan that always
+	 * claimed to be truncated.
+	 */
+	public function testAnUntruncatedRunDoesNotWarn(): void {
+		$this->givenLegacyRow(id: 1, uuid: 'row-1', retention: $this->dueForDestruction());
+
+		$this->logger->expects($this->never())->method('warning');
+
+		$scan = $this->service->scanObjectsWithRetention(
+			accept: static fn (ObjectEntity $object): bool => true,
+			maxMatches: 10
+		);
+
+		$this->assertCount(1, $scan['objects']);
+		$this->assertFalse($scan['truncated']);
+	}//end testAnUntruncatedRunDoesNotWarn()
+
+	/**
+	 * A (register, schema) pair whose magic table was never materialised is
+	 * skipped, not thrown on. A schema with no rows yet is an ordinary state.
+	 */
+	public function testAPairWithoutAMagicTableIsSkipped(): void {
+		$this->givenARegisterWithAMagicTable(tableExists: false);
+		$this->givenMagicRow(id: 7, uuid: 'magic-uuid', retention: $this->dueForDestruction());
+
+		$this->assertSame([], $this->service->findEligibleForDestruction());
+	}//end testAPairWithoutAMagicTableIsSkipped()
+
+	/**
+	 * Retention metadata that names no disposal date is never due.
+	 */
+	public function testARecordWithoutADisposalDateIsNotDue(): void {
+		$this->givenLegacyRow(
+			id: 3,
+			uuid: 'undated-uuid',
+			retention: ['archiefnominatie' => 'vernietigen', 'archiefstatus' => 'active']
+		);
+
+		$this->assertSame([], $this->service->findEligibleForDestruction());
+	}//end testARecordWithoutADisposalDateIsNotDue()
+
+	/**
+	 * 🔴 THE LIST IS BUILT FROM `getName()`, NOT `getTitle()`.
+	 *
+	 * `ObjectEntity` has no `title` property, so Entity's magic accessor threw
+	 * "title is not a valid attribute" here, uncaught, and took the whole
+	 * DestructionCheckJob run down with it. That is a second reason no
+	 * destruction list was ever produced, downstream of the sweep finding
+	 * nothing in the first place.
+	 */
+	public function testTheDestructionListCarriesTheObjectName(): void {
+		$this->settingsHandler->method('getArchivalSettingsOnly')->willReturn(
+			['destructionListRegister' => 1, 'destructionListSchema' => 2]
+		);
+
+		$object = new ObjectEntity();
+		$object->setUuid('list-uuid');
+		$object->setName('Zaak 2019/42');
+		$object->setRetention($this->dueForDestruction());
+
+		$list = $this->service->createDestructionList([$object]);
+
+		$this->assertNotNull($list);
+		$this->assertSame('Zaak 2019/42', $list['objects'][0]['title']);
+	}//end testTheDestructionListCarriesTheObjectName()
+
+	/**
+	 * An object with no name falls back to its uuid rather than failing.
+	 */
+	public function testTheDestructionListFallsBackToTheUuid(): void {
+		$this->settingsHandler->method('getArchivalSettingsOnly')->willReturn(
+			['destructionListRegister' => 1, 'destructionListSchema' => 2]
+		);
+
+		$object = new ObjectEntity();
+		$object->setUuid('list-uuid');
+		$object->setRetention($this->dueForDestruction());
+
+		$list = $this->service->createDestructionList([$object]);
+
+		$this->assertSame('list-uuid', $list['objects'][0]['title']);
+	}//end testTheDestructionListFallsBackToTheUuid()
+
+	/**
+	 * Retention metadata that is due for destruction today.
+	 *
+	 * @return array<string, mixed> The retention block.
+	 */
+	private function dueForDestruction(): array {
+		return [
+			'archiefnominatie' => 'destroy',
+			'archiefstatus' => 'active',
+			'archiefactiedatum' => '2020-01-01',
+		];
+	}//end dueForDestruction()
+
+	/**
+	 * Register 1 holds schema 2, whose magic table is (or is not) materialised.
+	 *
+	 * @param bool $tableExists Whether the magic table has been created.
+	 *
+	 * @return void
+	 */
+	private function givenARegisterWithAMagicTable(bool $tableExists = true): void {
+		// Real entities, not mocks: `getId()` and `getSchemas()` come from the
+		// Entity magic `__call`, which PHPUnit cannot stub.
+		$register = new Register();
+		$register->setId(1);
+		$register->setSchemas([2]);
+
+		$schema = new Schema();
+		$schema->setId(2);
+
+		$this->registerMapper->method('findAll')->willReturn([$register]);
+		$this->schemaMapper->method('find')->willReturn($schema);
+		$this->objectMapper->method('tableExistsForRegisterSchema')->willReturn($tableExists);
+		$this->objectMapper->method('getTableNameForRegisterSchema')->willReturn(self::MAGIC_TABLE);
+	}//end givenARegisterWithAMagicTable()
+
+	/**
+	 * Put one row in the magic table, and the object it hydrates to.
+	 *
+	 * @param int                  $id        The row's `_id`.
+	 * @param string               $uuid      The object uuid.
+	 * @param array<string, mixed> $retention The retention block.
+	 *
+	 * @return void
+	 */
+	private function givenMagicRow(int $id, string $uuid, array $retention): void {
+		$this->rowsByTable[self::MAGIC_TABLE][] = ['_id' => $id];
+
+		$object = new ObjectEntity();
+		$object->setUuid($uuid);
+		$object->setRetention($retention);
+		$this->magicObjects[$id] = $object;
+	}//end givenMagicRow()
+
+	/**
+	 * Put one row in the legacy blob table.
+	 *
+	 * The row is hydrated in place by the service, exactly as a real blob row
+	 * is, so `retention` is the JSON TEXT the column holds and not an array.
+	 *
+	 * @param int                  $id        The row's `id`.
+	 * @param string               $uuid      The object uuid.
+	 * @param array<string, mixed> $retention The retention block.
+	 *
+	 * @return void
+	 */
+	private function givenLegacyRow(int $id, string $uuid, array $retention): void {
+		$this->rowsByTable[self::LEGACY_TABLE][] = [
+			'id' => $id,
+			'uuid' => $uuid,
+			'retention' => json_encode($retention),
+		];
+	}//end givenLegacyRow()
+
+	/**
+	 * A query builder that answers from {@see self::$rowsByTable}.
+	 *
+	 * It records the table `from()` names and honours `setFirstResult()` /
+	 * `setMaxResults()`, so the paging loop under test is really exercised
+	 * rather than short-circuited by a builder that always returns everything.
+	 *
+	 * @return IQueryBuilder The programmed builder.
+	 */
+	private function makeQueryBuilder(): IQueryBuilder {
+		$qb = $this->createMock(IQueryBuilder::class);
+		$expr = $this->createMock(IExpressionBuilder::class);
+		$expr->method('isNotNull')->willReturn('retention IS NOT NULL');
+		$qb->method('expr')->willReturn($expr);
+
+		$state = ['table' => '', 'offset' => 0, 'limit' => 0];
+
+		$qb->method('select')->willReturn($qb);
+		$qb->method('where')->willReturn($qb);
+		$qb->method('from')->willReturnCallback(
+			static function (string $from) use ($qb, &$state): IQueryBuilder {
+				$state['table'] = $from;
+				return $qb;
+			}
+		);
+		$qb->method('setFirstResult')->willReturnCallback(
+			static function (int $offset) use ($qb, &$state): IQueryBuilder {
+				$state['offset'] = $offset;
+				return $qb;
+			}
+		);
+		$qb->method('setMaxResults')->willReturnCallback(
+			static function (?int $limit) use ($qb, &$state): IQueryBuilder {
+				$state['limit'] = (int)$limit;
+				return $qb;
+			}
+		);
+		$qb->method('executeQuery')->willReturnCallback(
+			function () use (&$state): IResult {
+				$rows = array_slice(
+					($this->rowsByTable[$state['table']] ?? []),
+					$state['offset'],
+					$state['limit']
+				);
+
+				$result = $this->createMock(IResult::class);
+				$result->method('fetchAll')->willReturn($rows);
+
+				return $result;
+			}
+		);
+
+		return $qb;
+	}//end makeQueryBuilder()
+}//end class


### PR DESCRIPTION
## What was broken

OpenRegister stores objects in per-schema "magic" tables (`oc_openregister_table_<registerId>_<schemaId>`), each with its own `_retention` JSON column. `BlobMigrationJob` drains the legacy blob table `oc_openregister_objects` into them every five minutes and deletes the originals.

Three places still read the legacy table, so all three were silent no-ops on any migrated install:

1. `RetentionService::findEligibleForDestruction()` selected `id from openregister_objects where retention is not null`. It fed step 2 of `DestructionCheckJob`, so **no destruction list was ever created**.
2. `DestructionCheckJob::sendPreDestructionNotifications()` paged the same table, so **no pre-destruction warning was ever sent**.
3. `TransferCheckJob::findEligibleObjects()` was a stub returning `[]` behind a comment saying "In a real implementation, this would query using JSON field conditions", so **no e-Depot transfer list was ever created**.

All three logged their empty result as though they had looked.

## The measurement

Re-verified on the shared development database before and after writing the fix:

| Query | Result |
| --- | --- |
| `select count(*) from oc_openregister_objects` | **0** |
| magic tables (`oc_openregister_table_%`) | **1320** |
| of those, carrying a `_retention` column | **1320** |

Zero rows in the only table the sweeps read, against 1320 tables holding the data.

## Two further defects found on the same path

**`ObjectEntity` has no `title` property.** `$object->getTitle()` therefore threw `title is not a valid attribute` through Entity's magic accessor. In `sendPreDestructionNotifications()` that is inside the try block, so the first object aborted the whole notification pass. In `RetentionService::createDestructionList()` it is uncaught and took the entire `DestructionCheckJob` run down with it. So even a sweep that found objects failed at list creation. Both call sites now use `getName()`, which is the property that exists, with the same uuid fallback `getObjectArray()` already uses.

**An absent record state counted as not live.** Measured on a live instance: a dossiq case resolved through OpenRegister answered

```json
{"appraisal":"retain_permanently","retentionPeriod":"P10Y","disposalDate":"2036-09-11T07:22:48+00:00","recordState":null,"basis":"record"}
```

`recordState` is null, and it was null for every case measured, because nothing writes `archiefstatus` until something actually happens to the record. The check was `in_array($retention['archiefstatus'] ?? '', RecordState::ACTIVE_ALIASES, true)`, and `''` is in no alias list. Reading the magic tables would have fixed where the sweep looks and still returned nothing for the ordinary case. An absent, null or empty state now reads as live in both sweeps. An explicit `transferred` or `destroyed`, in any spelling, still excludes, and the immutability guard still runs. What the resolver emits is unchanged: null is the honest answer there.

## What changed

**One scanner, `lib/Service/Archival/RetentionRowScanner.php`.** It enumerates registers and their schemas, resolves each pair's table through `MagicMapper::getTableNameForRegisterSchema()`, skips a pair whose table is not materialised rather than throwing, and pages `_id where _retention is not null` a bounded batch at a time. It **also** scans the legacy `openregister_objects` table, so an install that has not finished (or never started) the blob migration still works. Both sources, not one.

No JSON filtering in SQL. OpenRegister runs on PostgreSQL and on MySQL/MariaDB, whose JSON path syntax differs, so the SQL asks only whether a retention decision exists and eligibility is decided in PHP on the hydrated object.

The legacy row is hydrated in place rather than looked up. `MagicMapper::find()` without a register and schema searches the magic tables only, so feeding it an id read out of the blob table looks that id up in a different id space entirely.

**A cap per run, reported.** `MAX_MATCHES_PER_RUN = 500`, a named constant. A first run on a long backlog must not build an unreviewable list or a notification storm. When the cap truncates a run it logs at warning level with the number found, the cap, the rows inspected, and that the next run continues. A silently truncated sweep is exactly the class of defect this PR fixes, so it says so out loud. The notification pass also stops pruning its notified set on a truncated run, since it did not see every in-window object.

**Appraisal has a shared home.** `ArchivalDecisionResolver::APPRAISAL_ALIASES` was private, so the two places that have to act on an appraisal could not see it and each wrote its own string literal. It is now `lib/Service/Archival/Appraisal.php`, built on the same shape as `RecordState`: constants, alias lists, and the comment explaining why the Dutch spellings must keep matching. The resolver uses it too, so there is one home.

Matching only the English spelling would make every pre-existing record invisible to the destruction sweep, which is the direction that keeps personal data past its lawful term, and it does it in silence. That reasoning is written at the constant.

**Transfer, implemented for real.** `RetentionService::findEligibleForTransfer()`: appraisal is retain-permanently, `archiefactiedatum` on or before today, record state not already transferred or destroyed, no active legal hold, not excluded. `TransferListService::getObjectsOnActiveTransferLists()` can tell us which objects are already listed, fed from `TransferRecordService::listTransferLists()`, so those are excluded the way destruction excludes pending lists.

Both jobs keep their self-limits: `DestructionCheckJob` returns early without `destructionListRegister`/`destructionListSchema`, `TransferCheckJob` returns early without an e-Depot endpoint.

**Dead code deleted.** `DestructionService::findEligibleObjects()` had zero callers anywhere, tests included. It called `findAll()` with no register or schema (which returns `[]` immediately) and filtered on a dotted JSON path the search handler compiles to `1 = 0`, so it looked like a working query and was not. It is deleted, along with the `LegalHoldService` dependency `DestructionService` held only to serve it. The `archival-conformance` proposal's F2 entry is updated from "NOT FIXED HERE" to say it was deleted and why.

`RetentionService` crossed phpmd's 1000-line threshold once the scan landed, which is what prompted extracting `RetentionRowScanner` rather than suppressing the rule. `RetentionService::scanObjectsWithRetention()` stays as the public entry point both jobs already ask for.

## Tests

New: `tests/Unit/Service/RetentionSweepTest.php`, `tests/Unit/BackgroundJob/TransferCheckJobTest.php`, `tests/Unit/BackgroundJob/DestructionCheckJobNotificationTest.php`. 27 tests, following the existing `RetentionServiceTest` mocking patterns. `RetentionSweepTest` builds a **real** `RetentionRowScanner` over the same mocks, because what is under test is which tables get walked; a mocked scanner would assert only that the service called something.

| Test | Holds |
| --- | --- |
| `testADestroyCandidateInAMagicTableIsFound` | the record that was invisible is found |
| `testADestroyCandidateInTheLegacyTableIsFound` | the legacy store is still read |
| `testBothStoresAreScannedInOneRun` | a part-migrated install sees both |
| `testTheDutchSpellingsAreFoundForDestruction` | `vernietigen` + `nog_te_archiveren` |
| `testTheDutchSpellingIsFoundForTransfer` | `blijvend_bewaren` |
| `testARecordWithNoRecordedStateIsStillSwept` | absent state means live |
| `testANullRecordStateIsStillSwept` | explicit null means live |
| `testARecordWithNoRecordedStateIsSweptForTransfer` | same on the transfer side |
| `testASemiStaticRecordIsNotDestroyed` | a state that IS present is still honoured |
| `testALegalHoldExcludes` | active legal hold |
| `testAnImmutableStateExcludesFromDestruction` | `overgebracht` |
| `testAFutureDisposalDateExcludes` / `testARecordWithoutADisposalDateIsNotDue` | date rule |
| `testAnExcludedUuidIsNotReturned` / `testTransferHonoursTheExcludeList` | exclusion lists |
| `testTransferFindsADueRetainPermanentlyRecord` | transfer finds a due record |
| `testTransferDoesNotFindAnAlreadyTransferredRecord` | already transferred |
| `testTheCapTruncatesAndLogsAWarning` | cap truncates and warns |
| `testAnUntruncatedRunDoesNotWarn` | and does not warn otherwise |
| `testAPairWithoutAMagicTableIsSkipped` | unmaterialised table skipped |
| `testTheDestructionListCarriesTheObjectName` / `...FallsBackToTheUuid` | the `getTitle()` crash |
| `testEligibleObjectsReachTheTransferList` | the stub is really gone |
| `testObjectsOnActiveTransferListsAreExcluded` | transfer exclusion wiring |
| `testNothingHappensWithoutAnEdepot` | the job keeps its self-limit |

## Mutations

Every guard was broken, the run watched, the source restored, and the diff re-read. 19 mutations, 18 caught.

| # | Mutation | Caught by |
| --- | --- | --- |
| M1 | magic-table sources dropped | magic-table, both-stores, transfer-magic |
| M2 | legacy source dropped | legacy, both-stores, Dutch, cap |
| M3 | destroy aliases reduced to English | Dutch spellings, destruction |
| M4 | active aliases reduced to English | Dutch spellings, destruction |
| M5 | retain aliases reduced to English | Dutch spelling, transfer |
| M6 | legal-hold guard removed | `testALegalHoldExcludes` |
| M7 | disposal-date guard removed | future date, undated record |
| M8 | `$excludeUuids` ignored | `testAnExcludedUuidIsNotReturned` |
| M9 | transferred/destroyed guard removed on transfer | `testTransferDoesNotFindAnAlreadyTransferredRecord` |
| M10 | cap never applied | `testTheCapTruncatesAndLogsAWarning` |
| M11 | truncation warning removed | `testTheCapTruncatesAndLogsAWarning` |
| M12 | table-existence check removed | `testAPairWithoutAMagicTableIsSkipped` |
| M13 | `validateNotImmutable()` guard removed | **nothing** (see below) |
| M14 | transfer job re-stubbed to `return []` | `testEligibleObjectsReachTheTransferList`, exclusion test |
| M15 | destruction list back to `getTitle()` | both destruction-list tests |
| M16 | notification back to `getTitle()` | `testAnObjectInsideTheWindowIsNotifiedAbout` |
| M17 | absent state excludes again | `testARecordWithNoRecordedStateIsStillSwept`, null-state |
| M18 | transfer requires an explicit state | `testARecordWithNoRecordedStateIsSweptForTransfer` |
| M19 | every state treated as live | `testASemiStaticRecordIsNotDestroyed` |

**M13 caught nothing, and that is reported rather than papered over.** In the destruction predicate, `validateNotImmutable()` sits behind the live-state check, and every spelling it rejects is already outside the live set, so no test can redden on it alone. The guard is kept, with its redundancy named in a comment at the line: the live-state list is the thing most likely to grow, and the day a new state counts as live, that line is what stops a transferred record being swept. On the transfer side the same rule IS independently reachable and M9 and M18 cover it.

## Gates

Run sequentially on the rebased branch. Exit codes, not summary lines.

| Gate | Exit |
| --- | --- |
| `./vendor/bin/phpunit tests/Unit/` | 1 (see note) |
| `composer phpcs` | 0 |
| `phpmd lib text phpmd.xml --baseline-file phpmd.baseline.xml` | 0 |
| `phpmd lib text .../phpmd-unusedparams.xml --baseline-file phpmd.baseline.xml` | 0 |
| `./vendor/bin/psalm --no-progress` | 0 |
| `./vendor/bin/phpstan analyse --no-progress` (cache cleared first) | 0 |
| `run-hydra-gates.sh .` with `HYDRA_GATE_BASE_REF=origin/development` | 0 |

**The phpunit 1 is environmental, and here is the evidence.** 19640 tests, 48286 assertions, 0 failures, 0 errors, 24 skipped. The exit code comes from the runner warning "No code coverage driver available": no xdebug and no pcov are installed on this machine, and an untouched pre-existing test file (`tests/Unit/Db/ObjectEntityTmloTest.php`) exits 1 the same way.

Hydra gates: 81 green, 81 of 82 applicable gates ran. `gate-60 icon-vocabulary` did not run, unchanged from a baseline run on the same checkout. Three advisory warnings are all pre-existing and none are from this diff: gate-19 (918 scenarios missing `@e2e`), gate-96 (2 App Store description strings), gate-112 (17 Postman collections). Gates 22 and 53 fail with "ajv not resolvable" on a checkout without `node_modules`; they pass once `NODE_PATH` points at an installed ajv, which is how the numbers above were produced. Gate 16 required a real delta base, so it was run after committing, against `origin/development`, and passes; the `@spec` tags added point at anchors that exist.

## What I could not establish

Nothing was run against a live install. The measurement above is a read of the development database, and the sweeps themselves were verified by unit test, not by watching a cron produce a real destruction list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
