### PR TITLE
test(archival): e2e coverage for the resolved retention decision, the record-state vocabulary and the Retention settings section

### DIFF
--- a/tests/e2e/_fixtures.ts
+++ b/tests/e2e/_fixtures.ts
@@ -122,6 +122,7 @@ export async function createSchema(
 	runId: string,
 	suffix = 'sch',
 	properties: Record<string, unknown> = twoPropertySchema(),
+	overrides: Record<string, unknown> = {},
 ): Promise<SeededSchema> {
 	const slug = `${runId}-${suffix}`
 	const resp = await request.post(`${API}/schemas`, {
@@ -131,6 +132,13 @@ export async function createSchema(
 			title: `E2E ${suffix}`,
 			description: 'fixture schema',
 			properties,
+			// `overrides` mirrors createRegister's own trailing parameter and
+			// exists for the same reason: a schema-level block that is not a
+			// property — `configuration`, and inside it the
+			// `x-openregister-archival` annotation — cannot be expressed
+			// through `properties`, and a fixture that cannot declare one
+			// cannot seed an archival schema at all.
+			...overrides,
 		},
 	})
 	expect(resp.status(), `createSchema(${slug})`).toBeLessThanOrEqual(201)

--- a/tests/e2e/_list-assertions.ts
+++ b/tests/e2e/_list-assertions.ts
@@ -1,0 +1,150 @@
+import type { Locator, Page } from '@playwright/test'
+
+/*
+ * SPDX-FileCopyrightText: 2026 Open Register Contributors
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Finding a row in a CnIndexPage list, the way a person would.
+ *
+ * WHY A HELPER RATHER THAN `page.getByText(title)`
+ * ------------------------------------------------
+ * Two defects bit the crud specs, both measured on a live instance, and a bare
+ * `page.getByText(title).first()` walks into each of them.
+ *
+ * 1. THE LIST IS PAGED, AND THE NEWEST REGISTER IS LAST.
+ *    `RegistersIndex.paginatedRegisters` slices client-side at 20 rows
+ *    (`registerStore.pagination.limit`) and `filteredRegisters` applies NO
+ *    sort, so a register created just now sits at the END of the list. A fresh
+ *    instance already ships 16 registers, `tests/e2e/ci/object-sharing.spec.ts`
+ *    and `ci/object-shares-tab.spec.ts` each leak one that is never deleted,
+ *    and `archival-retention.spec.ts` leaves one behind that no HTTP caller can
+ *    remove. Past 20 the newest row is on page two and the assertion reports
+ *    "element(s) not found" — which reads like a broken list, not a full one.
+ *    (`SchemasIndex.orderedSchemas` sorts by id DESCENDING, so the sibling list
+ *    puts the newest FIRST and never showed this. The two lists disagree.)
+ *
+ * 2. OPENREGISTER'S OWN NOTIFICATION SATISFIES THE LOCATOR.
+ *    Updating a register publishes a Nextcloud notification whose subject is
+ *    `Register "<title>" was updated`. Its markup sits in the page header,
+ *    hidden until the bell is opened, and BEFORE the app content in DOM order.
+ *    So an unscoped `getByText(title).first()` resolves to that hidden span and
+ *    `toBeVisible()` fails on a row that rendered perfectly:
+ *
+ *      locator resolved to <span class="subject">Register "…" was updated</span>
+ *        - unexpected value "hidden"
+ *
+ *    and an unscoped `toHaveCount(0)` after a delete counts the notification
+ *    and reports 1. The spec's own action creates the thing that breaks it.
+ *
+ * Scoping every list assertion to `[data-testid="cn-index-page"]` kills the
+ * second, and paging forward kills the first.
+ *
+ * ⚠️ THE `.catch(() => false)` BELOW IS NOT A CONDITIONAL ASSERTION. It steers
+ * the paging loop only; neither helper asserts anything about the row. The
+ * caller makes an unconditional `expect(...)` on what comes back, so a row that
+ * is on no page at all still reddens the test, naming the row.
+ */
+import { expect } from '@playwright/test'
+
+/** The CnIndexPage shell that wraps the list, its rows and its pagination. */
+const INDEX_PAGE = '[data-testid="cn-index-page"]'
+
+/**
+ * Upper bound on paging, so a pagination control that never disables its Next
+ * button cannot spin forever. 25 pages is 500 rows at the default page size.
+ */
+const MAX_PAGES = 25
+
+/**
+ * Wait for the index page shell and return it.
+ *
+ * @param  {Page} page The page under test.
+ * @return {Promise<Locator>} The visible CnIndexPage root.
+ */
+async function indexPage(page: Page): Promise<Locator> {
+	const list = page.locator(INDEX_PAGE)
+	await expect(list, 'the index page must render').toBeVisible({
+		timeout: 30_000,
+	})
+	return list
+}
+
+/**
+ * Click through to the next page of the list, if there is one.
+ *
+ * CnPagination renders its nav only when `pages > 1`, and disables Next on the
+ * last page, so both "one page only" and "last page" answer false.
+ *
+ * @param  {Locator} list The CnIndexPage root.
+ * @return {Promise<boolean>} Whether a further page was opened.
+ */
+async function openNextPage(list: Locator): Promise<boolean> {
+	const next = list
+		.locator('[data-testid="cn-pagination"]')
+		.getByRole('button', { name: 'Next', exact: true })
+	if ((await next.count()) === 0) {
+		return false
+	}
+	if (await next.isDisabled()) {
+		return false
+	}
+	await next.click()
+	return true
+}
+
+/**
+ * Resolve a row in the list by its visible text, paging forward until it shows.
+ *
+ * Returns a locator either way: when the text is on no page, the returned
+ * locator resolves to nothing and the caller's `expect(...).toBeVisible()`
+ * fails naming it, which is the honest outcome.
+ *
+ * @param  {Page}   page The page under test, already on the list route.
+ * @param  {string} text The row text to look for (substring match).
+ * @return {Promise<Locator>} The row, scoped to the index page.
+ */
+export async function listRowByText(page: Page, text: string): Promise<Locator> {
+	const list = await indexPage(page)
+	const row = (): Locator => list.getByText(text, { exact: false }).first()
+
+	for (let visited = 0; visited < MAX_PAGES; visited++) {
+		const onThisPage = await row()
+			.isVisible({ timeout: 2_000 })
+			.catch(() => false)
+		if (onThisPage === true) {
+			break
+		}
+		if ((await openNextPage(list)) === false) {
+			break
+		}
+	}
+
+	return row()
+}
+
+/**
+ * Count how many rows across EVERY page carry the given text.
+ *
+ * "Gone from the list" is a claim about the whole list, not about page one, so
+ * a delete assertion has to walk the pages the way a search would.
+ *
+ * @param  {Page}   page The page under test, already on the list route.
+ * @param  {string} text The row text to count (substring match).
+ * @return {Promise<number>} The total across all pages.
+ */
+export async function countListRowsByText(
+	page: Page,
+	text: string,
+): Promise<number> {
+	const list = await indexPage(page)
+	let total = 0
+
+	for (let visited = 0; visited < MAX_PAGES; visited++) {
+		total += await list.getByText(text, { exact: false }).count()
+		if ((await openNextPage(list)) === false) {
+			break
+		}
+	}
+
+	return total
+}

--- a/tests/e2e/archival-retention.spec.ts
+++ b/tests/e2e/archival-retention.spec.ts
@@ -1,0 +1,627 @@
+import type { APIRequestContext } from '@playwright/test'
+
+/*
+ * SPDX-FileCopyrightText: 2026 Open Register Contributors
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * ARCHIVAL AND RETENTION e2e.
+ *
+ * WHY THIS FILE EXISTS
+ * --------------------
+ * A substantial archival implementation shipped with unit tests only. Before
+ * this file, nothing in `tests/e2e/**` exercised it end to end:
+ * `workflows/archival-transfer-hardening.spec.ts` is about the e-Depot
+ * transfer, and all three of its tests skip unless `OR_EDEPOT_*_FIXTURE`
+ * environment variables name pre-existing rows, so on a stock instance it
+ * executes nothing. The resolved archival decision at `@self._retention`, the
+ * record-state vocabulary and the Retention settings section were covered by
+ * no executable end-to-end test at all.
+ *
+ * WHY TWO OF THE THREE GROUPS ASSERT OVER THE API
+ * ----------------------------------------------
+ * There is no UI that renders an archival decision. `git grep` over `src/`
+ * finds no reference to `_retention`, `recordState`, `disposalDate` or
+ * `appraisal` in any `.vue` or `.js` file, so a records officer cannot see a
+ * disposal date, an appraisal or a transferred record's immutability anywhere
+ * in the app. The decision is currently an API-only contract, and an e2e test
+ * cannot assert on screen what the app never draws. The settings group below
+ * IS driven through the browser, because that surface does exist.
+ *
+ * The alternative — filing these under `tests/e2e/api-direct/` per the gate-19
+ * convention — would mean they never execute: `playwright.config.ts` excludes
+ * that directory from the `chromium` project. A test that does not run is the
+ * coverage we already had.
+ *
+ * FIXTURE CLEANUP IS DELIBERATELY PARTIAL
+ * --------------------------------------
+ * `DELETE /api/objects/...` on a schema that declares `x-openregister-archival`
+ * is refused with HTTP 403, which is the whole point of the annotation, so the
+ * seeded archival rows CANNOT be removed over HTTP by any caller — the only
+ * sanctioned path is `occ openregister:objects:purge --apply --force`, which a
+ * remote spec run has no access to. The refusal is asserted as a test below
+ * rather than swallowed in teardown, so the rows that stay behind are evidence
+ * rather than litter, and every entity this file creates carries the suite's
+ * run-unique `e2e-<timestamp>` prefix so a leaked fixture is identifiable.
+ */
+import { expect, test } from '@playwright/test'
+import * as fs from 'fs'
+import * as path from 'path'
+import {
+	createObject,
+	createRegister,
+	createSchema,
+	deleteObject,
+	deleteRegister,
+	deleteSchema,
+	linkSchemaToRegister,
+	makeRunId,
+} from './_fixtures.ts'
+
+const STORAGE_STATE = path.resolve(__dirname, '.auth/admin.json')
+const API = '/index.php/apps/openregister/api'
+const RUN = makeRunId()
+
+/** Slack allowed when comparing a derived disposal date to the row's creation. */
+const DATE_TOLERANCE_MS = 5 * 60_000
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The record-state vocabulary, read from its own authority.
+//
+// `lib/Service/Archival/RecordState.php` says, in its own words, that "READS
+// ACCEPT THE OLD SPELLINGS" and that each state "carries an alias list holding
+// its English name and the Dutch spellings it replaces". That file is the
+// authority for WHICH spellings a stored record may use, so this spec reads the
+// lists out of it rather than restating them: a spelling added there is then
+// covered here the moment it lands, and a spelling REMOVED there reddens this
+// test instead of silently narrowing what the guard recognises.
+//
+// Parsing throws rather than skipping. A skip and a pass look identical in a
+// summary, and a vocabulary test that quietly stopped reading its vocabulary is
+// exactly the failure this file is meant to catch.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const RECORD_STATE_PHP = path.resolve(
+	__dirname,
+	'..',
+	'..',
+	'lib',
+	'Service',
+	'Archival',
+	'RecordState.php',
+)
+
+/**
+ * Read one `public const <NAME> = ['a', 'b'];` string list out of RecordState.php.
+ *
+ * @param  {string} source   The file contents.
+ * @param  {string} constant The constant name.
+ * @return {string[]}        Every single-quoted member, in declaration order.
+ */
+function aliasList(source: string, constant: string): string[] {
+	const block = new RegExp(`const\\s+${constant}\\s*=\\s*\\[([^\\]]*)\\]`).exec(
+		source,
+	)
+	if (block === null) {
+		throw new Error(
+			`RecordState.php no longer declares ${constant}; the record-state `
+				+ 'vocabulary moved and this spec is reading a stale authority.',
+		)
+	}
+	return [...block[1].matchAll(/'([^']+)'/g)].map((m) => m[1])
+}
+
+interface StateCase {
+	/** The spelling as it would be found in stored data. */
+	alias: string
+	/** The canonical English record state it must resolve to. */
+	canonical: string
+	/** Whether a record in that state may no longer be changed. */
+	immutable: boolean
+}
+
+/**
+ * Build one case per accepted spelling, straight from RecordState.php.
+ *
+ * @return {StateCase[]} Every alias of every state.
+ */
+function recordStateCases(): StateCase[] {
+	const source = fs.readFileSync(RECORD_STATE_PHP, 'utf8')
+	const lists: Array<[string, string, boolean]> = [
+		['ACTIVE_ALIASES', 'active', false],
+		['SEMI_STATIC_ALIASES', 'semi_static', false],
+		['TRANSFERRED_ALIASES', 'transferred', true],
+		['DESTROYED_ALIASES', 'destroyed', true],
+	]
+
+	const cases: StateCase[] = []
+	for (const [constant, canonical, immutable] of lists) {
+		const aliases = aliasList(source, constant)
+		// A list that parsed to nothing would make the loop below a no-op and
+		// the whole test vacuously green, which is the shape this suite's own
+		// history warns about. Demand the canonical name plus at least one
+		// superseded spelling — the reason the alias list exists.
+		if (aliases.includes(canonical) === false || aliases.length < 2) {
+			throw new Error(
+				`RecordState::${constant} parsed as [${aliases.join(', ')}] — expected `
+					+ `'${canonical}' plus at least one superseded spelling.`,
+			)
+		}
+		for (const alias of aliases) {
+			cases.push({ alias, canonical, immutable })
+		}
+	}
+	return cases
+}
+
+/**
+ * Spellings `ArchivalDecisionResolver::STATE_ALIASES` does not translate.
+ *
+ * `gearchiveerd` is in `RecordState::SEMI_STATIC_ALIASES` but is absent from the
+ * resolver's own map, so `@self._retention.recordState` answers the stored Dutch
+ * word instead of `semi_static`. Its immutability is still correct, which is why
+ * this is a legibility gap and not a retention one, and it is reported on the PR
+ * rather than fixed here (this branch may not touch `lib/**`).
+ *
+ * The list is NAMED rather than the assertion loosened: a spelling that starts
+ * failing to translate and is not on this list still reddens the test.
+ */
+const UNTRANSLATED_BY_RESOLVER = ['gearchiveerd']
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** The archival annotation the fixture schema declares. */
+function archivalAnnotation(): Record<string, unknown> {
+	return {
+		configuration: {
+			'x-openregister-archival': {
+				retention: {
+					default: 'P30D',
+					rules: [
+						{
+							condition: 'statusCode < 400',
+							retention: 'PT1H',
+							reason: 'successful calls expire within the hour',
+						},
+					],
+				},
+			},
+		},
+	}
+}
+
+/** Schema properties: a title plus the ZGW archival fields the resolver reads. */
+function archivalProperties(): Record<string, unknown> {
+	return {
+		title: { type: 'string', title: 'Title' },
+		statusCode: { type: 'integer', title: 'Status code' },
+		// `archiefnominatie` / `archiefstatus` are the ZGW contract an app
+		// implementing the zaak API declares as ordinary schema properties;
+		// ArchivalDecisionResolver::declaredArchivalFields() reads them.
+		archiefnominatie: { type: 'string', title: 'Archiefnominatie' },
+		archiefstatus: { type: 'string', title: 'Archiefstatus' },
+	}
+}
+
+/** Fetch one object and return its resolved `@self._retention`, or null. */
+async function retentionOf(
+	request: APIRequestContext,
+	registerId: number,
+	schemaId: number,
+	id: string,
+): Promise<Record<string, any> | null> {
+	const resp = await request.get(
+		`${API}/objects/${registerId}/${schemaId}/${id}`,
+		{ headers: { Accept: 'application/json' } },
+	)
+	expect(resp.status(), `GET object ${id}`).toBe(200)
+	const body = await resp.json()
+	return body?.['@self']?._retention ?? null
+}
+
+/** The row's own creation instant, as milliseconds. */
+async function createdAtOf(
+	request: APIRequestContext,
+	registerId: number,
+	schemaId: number,
+	id: string,
+): Promise<number> {
+	const resp = await request.get(
+		`${API}/objects/${registerId}/${schemaId}/${id}`,
+		{ headers: { Accept: 'application/json' } },
+	)
+	expect(resp.status(), `GET object ${id}`).toBe(200)
+	const body = await resp.json()
+	const created = body?.['@self']?.created
+	expect(created, 'the row must report its creation instant').toBeTruthy()
+	return Date.parse(created)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Seeded fixtures: one archival schema, one plain schema, in one register.
+// ─────────────────────────────────────────────────────────────────────────────
+
+let registerId = 0
+let archivalSchemaId = 0
+let plainSchemaId = 0
+let plainObjectId = ''
+
+test.describe('archival — the resolved decision on an annotated schema', () => {
+	test.use({ storageState: STORAGE_STATE })
+
+	test.beforeAll(async ({ request }) => {
+		const register = await createRegister(request, RUN, 'arch-reg')
+		const archival = await createSchema(
+			request,
+			RUN,
+			'arch-sch',
+			archivalProperties(),
+			archivalAnnotation(),
+		)
+		const plain = await createSchema(request, RUN, 'plain-sch', {
+			title: { type: 'string', title: 'Title' },
+		})
+		await linkSchemaToRegister(request, register, [archival.id, plain.id])
+
+		registerId = register.id
+		archivalSchemaId = archival.id
+		plainSchemaId = plain.id
+	})
+
+	test.afterAll(async ({ request }) => {
+		// Best-effort, and deliberately incomplete. The archival rows refuse to
+		// be deleted (asserted below), so the schema and the register refuse to
+		// go with them; the plain schema's own object does come out.
+		if (plainObjectId !== '') {
+			await deleteObject(request, registerId, plainSchemaId, plainObjectId)
+		}
+		await deleteSchema(request, plainSchemaId)
+		await deleteRegister(request, registerId)
+	})
+
+	/**
+	 * The schema annotation alone establishes a decision: no ZGW field on the
+	 * record, so the retention period, the disposal date and the basis all come
+	 * from `x-openregister-archival`, and the rule that fired is named.
+	 *
+	 * @e2e openspec/specs/archival-annotation-vocabulary/spec.md#archival-row-read-shows-the-resolved-decision
+	 */
+	test('a matched annotation rule sets the retention period and derives the disposal date', async ({
+		request,
+	}) => {
+		const object = await createObject(request, registerId, archivalSchemaId, {
+			title: `${RUN} annotation only`,
+			statusCode: 200,
+		})
+		const createdAt = await createdAtOf(
+			request,
+			registerId,
+			archivalSchemaId,
+			object.id,
+		)
+		const decision = await retentionOf(
+			request,
+			registerId,
+			archivalSchemaId,
+			object.id,
+		)
+
+		expect(
+			decision,
+			'an annotated schema must produce a decision',
+		).not.toBeNull()
+		// `statusCode: 200` matches `statusCode < 400`, so the rule's PT1H wins
+		// over the annotation's P30D default.
+		expect(decision?.retentionPeriod).toBe('PT1H')
+		expect(decision?.basis).toBe('schema_annotation')
+		// The rule index is what makes a wrong disposal date traceable.
+		expect(decision?.annotation?.matchedRule).toBe(0)
+		expect(decision?.annotation?.effectiveRetention).toBe('PT1H')
+
+		// The disposal date is DERIVED, not stored: creation plus one hour.
+		expect(
+			decision?.disposalDate,
+			'a decision must carry a disposal date',
+		).toBeTruthy()
+		const disposal = Date.parse(decision?.disposalDate)
+		expect(Math.abs(disposal - (createdAt + 3_600_000))).toBeLessThan(
+			DATE_TOLERANCE_MS,
+		)
+	})
+
+	/**
+	 * The appraisal comes from the record's own ZGW field, the retention period
+	 * from the annotation's default once no rule matches, and both land in the
+	 * one resolved block.
+	 *
+	 * @e2e openspec/specs/archival-annotation-vocabulary/spec.md#archival-row-read-shows-the-resolved-decision
+	 */
+	test('an unmatched rule falls back to the default, and the appraisal is normalised', async ({
+		request,
+	}) => {
+		const object = await createObject(request, registerId, archivalSchemaId, {
+			title: `${RUN} appraised`,
+			statusCode: 500,
+			archiefnominatie: 'vernietigen',
+		})
+		const createdAt = await createdAtOf(
+			request,
+			registerId,
+			archivalSchemaId,
+			object.id,
+		)
+		const decision = await retentionOf(
+			request,
+			registerId,
+			archivalSchemaId,
+			object.id,
+		)
+
+		expect(decision).not.toBeNull()
+		// MDTO concepts in English: `vernietigen` is the stored spelling, and
+		// the abstract answer is `destroy`.
+		expect(decision?.appraisal).toBe('destroy')
+		// No rule matched (500 is not < 400), so the default applies.
+		expect(decision?.retentionPeriod).toBe('P30D')
+		// "No rule matched" reaches the wire in two shapes: the CREATE response
+		// carries `matchedRule: null`, the READ response drops the key entirely
+		// (null-valued keys are stripped on GET). Both mean the same thing and
+		// both must NOT be a rule index, which is what this asserts. The shape
+		// difference between the two responses is reported on the PR.
+		expect(decision?.annotation?.matchedRule ?? null).toBeNull()
+
+		const disposal = Date.parse(decision?.disposalDate)
+		expect(Math.abs(disposal - (createdAt + 30 * 86_400_000))).toBeLessThan(
+			DATE_TOLERANCE_MS,
+		)
+	})
+
+	/**
+	 * Silence is a distinct answer from "nothing to keep": a schema with no
+	 * archival annotation and a record with no archival fields must carry no
+	 * `_retention` key at all.
+	 *
+	 * @e2e openspec/specs/archival-annotation-vocabulary/spec.md#non-archival-schema-read-does-not-show-retention
+	 */
+	test('a schema without the annotation produces no decision at all', async ({
+		request,
+	}) => {
+		const object = await createObject(request, registerId, plainSchemaId, {
+			title: `${RUN} plain`,
+		})
+		plainObjectId = object.id
+
+		const resp = await request.get(
+			`${API}/objects/${registerId}/${plainSchemaId}/${object.id}`,
+			{ headers: { Accept: 'application/json' } },
+		)
+		expect(resp.status()).toBe(200)
+		const body = await resp.json()
+		// Absent, not empty. An empty `_retention: {}` would read as "we looked
+		// and there is no obligation", which is a different fact.
+		expect(Object.hasOwn(body['@self'], '_retention')).toBe(false)
+	})
+
+	/**
+	 * The annotation is not only descriptive: it takes the delete away. This is
+	 * also why the fixtures above cannot be torn down over HTTP.
+	 *
+	 * @e2e openspec/specs/archival-annotation-vocabulary/spec.md#admin-delete-on-an-archival-schema-is-rejected
+	 */
+	test('an archival row refuses to be deleted, and survives the attempt', async ({
+		request,
+	}) => {
+		const object = await createObject(request, registerId, archivalSchemaId, {
+			title: `${RUN} undeletable`,
+			statusCode: 204,
+		})
+
+		const del = await request.delete(
+			`${API}/objects/${registerId}/${archivalSchemaId}/${object.id}`,
+			{ headers: { Accept: 'application/json' } },
+		)
+		expect(del.status(), 'an archival row may not be deleted by a user').toBe(
+			403,
+		)
+		const body = await del.json()
+		// NOTE the shape: the spec requires the structured body
+		// `{error: "SCHEMA_ARCHIVAL_IMMUTABLE", message, schema, operation, hint}`
+		// that `ArchivalImmutableException::toResponseBody()` builds, and this
+		// route does not use it — `error` is the whole prose sentence with the
+		// code glued to its front. Asserted as a substring so this test stays
+		// green both before and after that is corrected; the divergence is
+		// reported on the PR rather than fixed here.
+		expect(String(body?.error)).toContain('SCHEMA_ARCHIVAL_IMMUTABLE')
+
+		// The row is still there, which is the assertion that matters.
+		const after = await request.get(
+			`${API}/objects/${registerId}/${archivalSchemaId}/${object.id}`,
+			{ headers: { Accept: 'application/json' } },
+		)
+		expect(after.status(), 'the refused row must still exist').toBe(200)
+	})
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The record-state vocabulary, in every spelling stored data may carry.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('archival — the record-state vocabulary honours both spellings', () => {
+	test.use({ storageState: STORAGE_STATE })
+
+	let stateRegisterId = 0
+	let stateSchemaId = 0
+
+	test.beforeAll(async ({ request }) => {
+		const register = await createRegister(request, RUN, 'state-reg')
+		const schema = await createSchema(
+			request,
+			RUN,
+			'state-sch',
+			archivalProperties(),
+			archivalAnnotation(),
+		)
+		await linkSchemaToRegister(request, register, [schema.id])
+		stateRegisterId = register.id
+		stateSchemaId = schema.id
+	})
+
+	/**
+	 * Every spelling RecordState accepts must reach the same verdict about
+	 * whether the record may still be changed.
+	 *
+	 * This is the assertion that matters most. Matching only the English
+	 * spellings would make every record written before the vocabulary landed
+	 * look live: a transferred record would read as editable and a destroyed one
+	 * as sweepable, which is the direction that keeps personal data past its
+	 * lawful term. The cases come from RecordState.php itself, so the coverage
+	 * cannot drift away from the authority.
+	 *
+	 * @e2e openspec/specs/archival-annotation-vocabulary/spec.md#archival-row-read-shows-the-resolved-decision
+	 */
+	test('every accepted spelling resolves to its English state with the right immutability', async ({
+		request,
+	}) => {
+		const cases = recordStateCases()
+		// Ten spellings across four states today. Guard the count so a parse
+		// that silently thinned out cannot pass as a full sweep.
+		expect(
+			cases.length,
+			'every state contributes its aliases',
+		).toBeGreaterThanOrEqual(8)
+
+		for (const { alias, canonical, immutable } of cases) {
+			const object = await createObject(
+				request,
+				stateRegisterId,
+				stateSchemaId,
+				{
+					title: `${RUN} state ${alias}`,
+					statusCode: 500,
+					archiefstatus: alias,
+				},
+			)
+			const decision = await retentionOf(
+				request,
+				stateRegisterId,
+				stateSchemaId,
+				object.id,
+			)
+
+			expect(decision, `'${alias}' must establish a decision`).not.toBeNull()
+
+			// The safety-critical half: a transferred or destroyed record is
+			// final, whichever spelling it was stored under, and a live one is
+			// not. This holds for every alias.
+			expect(
+				decision?.immutable,
+				`'${alias}' means ${canonical}, so immutable must be ${immutable}`,
+			).toBe(immutable)
+
+			// The legibility half: the abstract layer answers in English. One
+			// spelling is not yet translated by the resolver (see
+			// UNTRANSLATED_BY_RESOLVER); accept the stored word for THOSE only,
+			// so a new untranslated spelling still fails here.
+			const acceptable = UNTRANSLATED_BY_RESOLVER.includes(alias)
+				? [canonical, alias]
+				: [canonical]
+			expect(
+				acceptable,
+				`'${alias}' must resolve to the canonical '${canonical}'`,
+			).toContain(decision?.recordState)
+		}
+	})
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The Retention settings section — the one archival surface that has a UI.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('retention — the admin settings section persists a change', () => {
+	test.use({ storageState: STORAGE_STATE })
+	// Two full loads of the admin settings page plus two round trips to the
+	// settings API. The config-wide 30s budget covers roughly one such load on a
+	// loaded box, and a test cancelled by the budget reports a bare "Test
+	// timeout" that names nothing — the failure mode this whole suite's comments
+	// warn about. Give the browser leg room the API legs do not need.
+	test.describe.configure({ timeout: 180_000 })
+
+	const ADMIN_SETTINGS = '/index.php/settings/admin/openregister'
+	const FIELD = '#retention-object-archive'
+
+	/**
+	 * Open the Retention section, change the soft-delete-after-inactivity
+	 * period, save, RELOAD, and read the field back off the reloaded page.
+	 *
+	 * The reload is the whole test: without it the assertion would only prove
+	 * the input still holds what was typed into it, which a store that never
+	 * reached the server would satisfy just as well.
+	 *
+	 * @e2e openspec/specs/retention-management/spec.md#update-retention-settings
+	 * @e2e openspec/specs/retention-management/spec.md#read-retention-settings
+	 */
+	test('changing a retention period survives a reload', async ({ page }) => {
+		await page.goto(ADMIN_SETTINGS, {
+			waitUntil: 'domcontentloaded',
+			timeout: 60_000,
+		})
+
+		const section = page
+			.locator('.settings-section')
+			.filter({ hasText: 'Configure data and log retention policies' })
+			.first()
+		await expect(section, 'the Retention section must render').toBeVisible({
+			timeout: 45_000,
+		})
+
+		const field = section.locator(FIELD)
+		await expect(field).toBeVisible({ timeout: 30_000 })
+		const original = await field.inputValue()
+		expect(original, 'the field must load a stored value').not.toBe('')
+
+		// The probe is DERIVED from what was there, never a fixed literal. A
+		// literal that happened to equal the instance's stored value would make
+		// this test pass while proving nothing — it would read back a value
+		// nobody wrote. Adding to the stored number can never collide with it.
+		const probe = String(Number(original) + 1234)
+		expect(probe, 'the probe must differ from the stored value').not.toBe(
+			original,
+		)
+
+		await field.fill(probe)
+
+		// Wait on the PUT itself rather than a toast: the toast is the store's
+		// report of the write, and this test is about the write.
+		const saved = page.waitForResponse(
+			(r) =>
+				r.url().includes('/api/settings/retention')
+				&& r.request().method() === 'PUT',
+			{ timeout: 45_000 },
+		)
+		await section.getByRole('button', { name: 'Save' }).click()
+		expect((await saved).status(), 'the save must succeed').toBe(200)
+
+		await page.reload({ waitUntil: 'domcontentloaded', timeout: 60_000 })
+		const reloaded = page
+			.locator('.settings-section')
+			.filter({ hasText: 'Configure data and log retention policies' })
+			.first()
+		await expect(reloaded.locator(FIELD)).toHaveValue(probe, {
+			timeout: 45_000,
+		})
+
+		// Put the instance back the way it was found — this section is instance
+		// state, not a per-run fixture, so leaving a probe value behind would
+		// change the retention policy of whatever instance ran the suite.
+		const restored = page.waitForResponse(
+			(r) =>
+				r.url().includes('/api/settings/retention')
+				&& r.request().method() === 'PUT',
+			{ timeout: 45_000 },
+		)
+		await reloaded.locator(FIELD).fill(original)
+		await reloaded.getByRole('button', { name: 'Save' }).click()
+		expect((await restored).status(), 'the restore must succeed').toBe(200)
+	})
+})

--- a/tests/e2e/archival-retention.spec.ts
+++ b/tests/e2e/archival-retention.spec.ts
@@ -153,19 +153,13 @@ function recordStateCases(): StateCase[] {
 	return cases
 }
 
-/**
- * Spellings `ArchivalDecisionResolver::STATE_ALIASES` does not translate.
- *
- * `gearchiveerd` is in `RecordState::SEMI_STATIC_ALIASES` but is absent from the
- * resolver's own map, so `@self._retention.recordState` answers the stored Dutch
- * word instead of `semi_static`. Its immutability is still correct, which is why
- * this is a legibility gap and not a retention one, and it is reported on the PR
- * rather than fixed here (this branch may not touch `lib/**`).
- *
- * The list is NAMED rather than the assertion loosened: a spelling that starts
- * failing to translate and is not on this list still reddens the test.
- */
-const UNTRANSLATED_BY_RESOLVER = ['gearchiveerd']
+// NO EXCEPTIONS. This spec used to name `gearchiveerd` as the one spelling the
+// resolver answered in Dutch: it was in `RecordState::SEMI_STATIC_ALIASES` and
+// missing from the resolver's private copy of the map. #3628 removed that copy,
+// so the resolver now reads `RecordState::CANONICAL`, and every spelling must
+// come back canonical. The alias lists this spec reads and the CANONICAL map the
+// resolver reads are still two declarations in one file, so this test is the
+// thing that notices if they drift apart again.
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers
@@ -239,7 +233,21 @@ async function createdAtOf(
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Seeded fixtures: one archival schema, one plain schema, in one register.
+// Seeded fixtures: ONE register, ONE archival schema, ONE plain schema, for the
+// whole file.
+//
+// 🔴 ONE REGISTER IS A BUDGET, NOT TIDINESS. An archival row refuses every HTTP
+// delete, so the register holding it refuses too (409 `register-has-objects`)
+// and this file's fixtures are PERMANENT for the rest of the run. The registers
+// list is sliced client-side at 20 rows per page (`RegistersIndex`
+// `paginatedRegisters`), and a fresh instance already ships 16 registers, so
+// what this file leaves behind is subtracted from a budget of four that later
+// specs share. It used to seed two registers and two archival schemas, one per
+// describe; that took half the budget and, with the two registers
+// `tests/e2e/ci/object-sharing.spec.ts` and `ci/object-shares-tab.spec.ts` also
+// leak, pushed the count to 21 so `crud/register-crud.spec.ts` could not find
+// its own brand-new register on page one. Measured, reproduced, and the reason
+// both describes below now share one register and one archival schema.
 // ─────────────────────────────────────────────────────────────────────────────
 
 let registerId = 0
@@ -247,38 +255,41 @@ let archivalSchemaId = 0
 let plainSchemaId = 0
 let plainObjectId = ''
 
+// File-level, so the record-state describe reuses the same pair rather than
+// seeding a second one.
+test.beforeAll(async ({ request }) => {
+	const register = await createRegister(request, RUN, 'arch-reg')
+	const archival = await createSchema(
+		request,
+		RUN,
+		'arch-sch',
+		archivalProperties(),
+		archivalAnnotation(),
+	)
+	const plain = await createSchema(request, RUN, 'plain-sch', {
+		title: { type: 'string', title: 'Title' },
+	})
+	await linkSchemaToRegister(request, register, [archival.id, plain.id])
+
+	registerId = register.id
+	archivalSchemaId = archival.id
+	plainSchemaId = plain.id
+})
+
+test.afterAll(async ({ request }) => {
+	// Best-effort, and deliberately incomplete. The archival rows refuse to be
+	// deleted (asserted below), so the archival schema and the register refuse to
+	// go with them; the plain schema and its object do come out, which is the
+	// half that CAN be given back.
+	if (plainObjectId !== '') {
+		await deleteObject(request, registerId, plainSchemaId, plainObjectId)
+	}
+	await deleteSchema(request, plainSchemaId)
+	await deleteRegister(request, registerId)
+})
+
 test.describe('archival — the resolved decision on an annotated schema', () => {
 	test.use({ storageState: STORAGE_STATE })
-
-	test.beforeAll(async ({ request }) => {
-		const register = await createRegister(request, RUN, 'arch-reg')
-		const archival = await createSchema(
-			request,
-			RUN,
-			'arch-sch',
-			archivalProperties(),
-			archivalAnnotation(),
-		)
-		const plain = await createSchema(request, RUN, 'plain-sch', {
-			title: { type: 'string', title: 'Title' },
-		})
-		await linkSchemaToRegister(request, register, [archival.id, plain.id])
-
-		registerId = register.id
-		archivalSchemaId = archival.id
-		plainSchemaId = plain.id
-	})
-
-	test.afterAll(async ({ request }) => {
-		// Best-effort, and deliberately incomplete. The archival rows refuse to
-		// be deleted (asserted below), so the schema and the register refuse to
-		// go with them; the plain schema's own object does come out.
-		if (plainObjectId !== '') {
-			await deleteObject(request, registerId, plainSchemaId, plainObjectId)
-		}
-		await deleteSchema(request, plainSchemaId)
-		await deleteRegister(request, registerId)
-	})
 
 	/**
 	 * The schema annotation alone establishes a decision: no ZGW field on the
@@ -450,22 +461,9 @@ test.describe('archival — the resolved decision on an annotated schema', () =>
 test.describe('archival — the record-state vocabulary honours both spellings', () => {
 	test.use({ storageState: STORAGE_STATE })
 
-	let stateRegisterId = 0
-	let stateSchemaId = 0
-
-	test.beforeAll(async ({ request }) => {
-		const register = await createRegister(request, RUN, 'state-reg')
-		const schema = await createSchema(
-			request,
-			RUN,
-			'state-sch',
-			archivalProperties(),
-			archivalAnnotation(),
-		)
-		await linkSchemaToRegister(request, register, [schema.id])
-		stateRegisterId = register.id
-		stateSchemaId = schema.id
-	})
+	// Reuses the file's one archival register and schema. A second pair would
+	// prove nothing this one does not, and would cost another permanent row in
+	// the registers list every later spec has to page past.
 
 	/**
 	 * Every spelling RecordState accepts must reach the same verdict about
@@ -494,8 +492,8 @@ test.describe('archival — the record-state vocabulary honours both spellings',
 		for (const { alias, canonical, immutable } of cases) {
 			const object = await createObject(
 				request,
-				stateRegisterId,
-				stateSchemaId,
+				registerId,
+				archivalSchemaId,
 				{
 					title: `${RUN} state ${alias}`,
 					statusCode: 500,
@@ -504,8 +502,8 @@ test.describe('archival — the record-state vocabulary honours both spellings',
 			)
 			const decision = await retentionOf(
 				request,
-				stateRegisterId,
-				stateSchemaId,
+				registerId,
+				archivalSchemaId,
 				object.id,
 			)
 
@@ -519,17 +517,12 @@ test.describe('archival — the record-state vocabulary honours both spellings',
 				`'${alias}' means ${canonical}, so immutable must be ${immutable}`,
 			).toBe(immutable)
 
-			// The legibility half: the abstract layer answers in English. One
-			// spelling is not yet translated by the resolver (see
-			// UNTRANSLATED_BY_RESOLVER); accept the stored word for THOSE only,
-			// so a new untranslated spelling still fails here.
-			const acceptable = UNTRANSLATED_BY_RESOLVER.includes(alias)
-				? [canonical, alias]
-				: [canonical]
+			// The legibility half: the abstract layer answers in English, for
+			// every spelling, with no exceptions.
 			expect(
-				acceptable,
+				decision?.recordState,
 				`'${alias}' must resolve to the canonical '${canonical}'`,
-			).toContain(decision?.recordState)
+			).toBe(canonical)
 		}
 	})
 })

--- a/tests/e2e/ci/playwright.config.ts
+++ b/tests/e2e/ci/playwright.config.ts
@@ -245,6 +245,39 @@ export default defineConfig({
 		// is a REAL import, measured at 42.8s on dossiq and 49.6s on shillinq,
 		// and it exceeded the 30s default on one run before the annotation.
 		'spec-coverage/demo-data-setup-step.spec.ts',
+
+		// Admitted 2026-09-11 with the archival e2e coverage it carries. Nothing
+		// here touched archival or retention: the resolved `@self._retention`
+		// decision, the record-state vocabulary and the Retention settings section
+		// were unit-tested only, and the one archival spec on disk
+		// (`workflows/archival-transfer-hardening.spec.ts`) skips all three of its
+		// tests unless `OR_EDEPOT_*_FIXTURE` names pre-existing rows, so it
+		// executes nothing on a fresh instance and is correctly NOT admitted.
+		//
+		// Checked per criterion:
+		//   1. Hermetic — seeds its own register, schemas and objects through the
+		//      documented REST controllers. No occ, no docker, no pre-seeded data.
+		//   3. No conditional-assert guards — zero `.catch(() => false)` in any
+		//      assertion. The only `.catch()` calls are inside `_fixtures.ts`
+		//      teardown helpers.
+		//   4. No `test.skip` at all, conditional or otherwise.
+		//
+		// ⚠️ CRITERION 2 IS THE ONE THAT NEEDS SAYING OUT LOUD, because this file
+		// CANNOT fully satisfy it and that is the behaviour under test, not an
+		// oversight. `DELETE /api/objects/...` on a schema declaring
+		// `x-openregister-archival` is refused with 403 for every HTTP caller —
+		// the sanctioned removal path is `occ openregister:objects:purge --apply
+		// --force`, which criterion 1 rightly forbids — so the seeded archival
+		// rows, and the schema and register holding them, stay behind. A spec that
+		// tore them down would be a spec proving the archival gate does not hold.
+		//
+		// This is admissible on the reasoning this config already sets out above:
+		// the CI instance is created and destroyed per run on its own runner with
+		// its own postgres service, so nothing outside the job can see what is
+		// left. Every entity carries the `e2e-<timestamp>` prefix, and the ONE
+		// piece of instance state the file writes — the `objectArchiveRetention`
+		// setting — is read first and written back at the end of the same test.
+		'archival-retention.spec.ts',
 	],
 	globalSetup: path.resolve(__dirname, '../global-setup.ts'),
 	timeout: 45_000,

--- a/tests/e2e/crud/register-crud.spec.ts
+++ b/tests/e2e/crud/register-crud.spec.ts
@@ -31,6 +31,7 @@ import type { APIRequestContext } from '@playwright/test'
 import { expect, test } from '@playwright/test'
 import * as path from 'path'
 import { makeRunId } from '../_fixtures.ts'
+import { countListRowsByText, listRowByText } from '../_list-assertions.ts'
 
 const STORAGE_STATE = path.resolve(__dirname, '..', '.auth', 'admin.json')
 // HASH form — the router runs in hash mode (src/main.js); the path-form URL
@@ -133,15 +134,16 @@ test.describe('register-crud — full create→read→update→delete with persi
 	}) => {
 		test.skip(registerId === null, 'create step did not persist a register')
 		await page.goto(REGISTERS_ROUTE, { waitUntil: 'domcontentloaded' })
-		await expect(page.locator('[data-testid="cn-index-page"]')).toBeVisible({
-			timeout: 30_000,
-		})
 
-		// The register title must be rendered somewhere in the list (table row
-		// or card), NOT just an empty state.
-		await expect(
-			page.getByText(REG_TITLE, { exact: false }).first(),
-		).toBeVisible({ timeout: 20_000 })
+		// The register title must be rendered as a row in the list (table row or
+		// card), NOT just an empty state. Resolved through the shared helper: the
+		// list pages at 20 and does not sort, so the register created a moment
+		// ago is the one most likely to be on page two, and an unscoped locator
+		// would also match this app's own hidden "was updated" notification.
+		// See tests/e2e/_list-assertions.ts.
+		await expect(await listRowByText(page, REG_TITLE)).toBeVisible({
+			timeout: 20_000,
+		})
 	})
 
 	test('UPDATE — edit the title and assert persistence + re-render', async ({
@@ -168,14 +170,11 @@ test.describe('register-crud — full create→read→update→delete with persi
 		expect(put.status(), 'PUT /api/registers/{id}').toBe(200)
 		expect((await put.json()).title).toBe(REG_TITLE_UPDATED)
 
-		// The list view must now show the updated title and no longer the old one.
+		// The list view must now show the updated title.
 		await page.goto(REGISTERS_ROUTE, { waitUntil: 'domcontentloaded' })
-		await expect(page.locator('[data-testid="cn-index-page"]')).toBeVisible({
-			timeout: 30_000,
+		await expect(await listRowByText(page, REG_TITLE_UPDATED)).toBeVisible({
+			timeout: 20_000,
 		})
-		await expect(
-			page.getByText(REG_TITLE_UPDATED, { exact: false }).first(),
-		).toBeVisible({ timeout: 20_000 })
 	})
 
 	test('DELETE — remove the register and assert it is gone from API and list', async ({
@@ -198,14 +197,17 @@ test.describe('register-crud — full create→read→update→delete with persi
 			'deleted register should not return 200',
 		).toBeGreaterThanOrEqual(400)
 
-		// UI: the (updated) title must no longer appear as a row.
+		// UI: the (updated) title must no longer appear as a row on ANY page.
+		// Counted across the pages rather than on page one, and scoped to the
+		// list, because the delete leaves a Nextcloud notification carrying the
+		// same title in the page header and an unscoped count reports 1.
 		await page.goto(REGISTERS_ROUTE, { waitUntil: 'domcontentloaded' })
-		await expect(page.locator('[data-testid="cn-index-page"]')).toBeVisible({
-			timeout: 30_000,
-		})
-		await expect(
-			page.getByText(REG_TITLE_UPDATED, { exact: false }),
-		).toHaveCount(0, { timeout: 20_000 })
+		await expect
+			.poll(async () => countListRowsByText(page, REG_TITLE_UPDATED), {
+				timeout: 20_000,
+				message: 'the deleted register must be gone from every page',
+			})
+			.toBe(0)
 
 		registerId = null
 	})

--- a/tests/e2e/crud/schema-crud.spec.ts
+++ b/tests/e2e/crud/schema-crud.spec.ts
@@ -25,6 +25,7 @@
 import { expect, test } from '@playwright/test'
 import * as path from 'path'
 import { makeRunId, twoPropertySchema } from '../_fixtures.ts'
+import { countListRowsByText, listRowByText } from '../_list-assertions.ts'
 
 const STORAGE_STATE = path.resolve(__dirname, '..', '.auth', 'admin.json')
 // HASH form — the router runs in hash mode (src/main.js); the path-form URL
@@ -83,12 +84,14 @@ test.describe('schema-crud — create→read→update→delete with property per
 
 		// UI: the schema title renders as a row in the schemas table.
 		await page.goto(SCHEMAS_ROUTE, { waitUntil: 'domcontentloaded' })
-		await expect(page.locator('[data-testid="cn-index-page"]')).toBeVisible({
-			timeout: 30_000,
+		// Scoped to the list and paged, via the shared helper: an unscoped
+		// locator also matches this app's own hidden "Schema \"…\" was updated"
+		// notification in the header, which is what made the UPDATE step below
+		// fail with "Received: hidden" on a row that rendered fine.
+		// See tests/e2e/_list-assertions.ts.
+		await expect(await listRowByText(page, SCHEMA_TITLE)).toBeVisible({
+			timeout: 20_000,
 		})
-		await expect(
-			page.getByText(SCHEMA_TITLE, { exact: false }).first(),
-		).toBeVisible({ timeout: 20_000 })
 	})
 
 	test('UPDATE — add a third property and assert it persisted + re-renders', async ({
@@ -126,12 +129,14 @@ test.describe('schema-crud — create→read→update→delete with property per
 
 		// UI still renders the schema row.
 		await page.goto(SCHEMAS_ROUTE, { waitUntil: 'domcontentloaded' })
-		await expect(page.locator('[data-testid="cn-index-page"]')).toBeVisible({
-			timeout: 30_000,
+		// Scoped to the list and paged, via the shared helper: an unscoped
+		// locator also matches this app's own hidden "Schema \"…\" was updated"
+		// notification in the header, which is what made the UPDATE step below
+		// fail with "Received: hidden" on a row that rendered fine.
+		// See tests/e2e/_list-assertions.ts.
+		await expect(await listRowByText(page, SCHEMA_TITLE)).toBeVisible({
+			timeout: 20_000,
 		})
-		await expect(
-			page.getByText(SCHEMA_TITLE, { exact: false }).first(),
-		).toBeVisible({ timeout: 20_000 })
 	})
 
 	test('DELETE — remove the schema and assert it is gone', async ({
@@ -154,12 +159,12 @@ test.describe('schema-crud — create→read→update→delete with property per
 		).toBeGreaterThanOrEqual(400)
 
 		await page.goto(SCHEMAS_ROUTE, { waitUntil: 'domcontentloaded' })
-		await expect(page.locator('[data-testid="cn-index-page"]')).toBeVisible({
-			timeout: 30_000,
-		})
-		await expect(page.getByText(SCHEMA_TITLE, { exact: false })).toHaveCount(0, {
-			timeout: 20_000,
-		})
+		await expect
+			.poll(async () => countListRowsByText(page, SCHEMA_TITLE), {
+				timeout: 20_000,
+				message: 'the deleted schema must be gone from every page',
+			})
+			.toBe(0)
 
 		schemaId = null
 	})


### PR DESCRIPTION
## What was uncovered

openregister's archival implementation shipped with unit tests only. Nothing in `tests/e2e/**` exercised it. The one archival spec already on disk, `tests/e2e/workflows/archival-transfer-hardening.spec.ts`, is about the e-Depot transfer, and all three of its tests skip unless `OR_EDEPOT_*_FIXTURE` names pre-existing rows, so on a stock instance it executes nothing. The resolved decision at `@self._retention`, the record-state vocabulary in `RecordState.php`, and the Retention settings section had no executable end-to-end test.

## What each archival test proves

`tests/e2e/archival-retention.spec.ts`, six tests, admitted to the CI allow-list.

1. **A matched annotation rule sets the retention period and derives the disposal date.** A schema with `x-openregister-archival` (`default P30D`, rule `statusCode < 400 -> PT1H`); an object with `statusCode: 200` resolves to `retentionPeriod: "PT1H"`, `basis: "schema_annotation"`, `annotation.matchedRule: 0`, and a disposal date equal to its own creation plus one hour.
2. **An unmatched rule falls back to the default, and the appraisal is normalised.** `statusCode: 500` takes `P30D`, and the record's ZGW `archiefnominatie: "vernietigen"` resolves to `destroy`.
3. **A schema without the annotation produces no decision at all.** `_retention` is absent, not empty.
4. **An archival row refuses to be deleted and survives the attempt.** 403 naming `SCHEMA_ARCHIVAL_IMMUTABLE`, then a `GET` still answers 200.
5. **Every accepted spelling of every record state resolves to its canonical English state with the right immutability.** The cases are read out of `RecordState.php`'s alias lists, so a spelling added there is covered the moment it lands. Since #3628 there are no exceptions: `gearchiveerd` now resolves to `semi_static` like every other spelling, and the test enforces that for all ten. The alias lists this test reads and the `CANONICAL` map the resolver reads are still two declarations in one file, so this test is what notices if they drift apart again.
6. **The Retention settings section persists a change across a reload,** driven in the browser. The probe value is derived from the stored one, so it can never equal it and pass while proving nothing.

Tests 1 to 5 assert over the API because no UI renders an archival decision: `src/` contains no `_retention`, `recordState`, `disposalDate` or `appraisal`.

## The red CI run, diagnosed

CI failed on `crud/register-crud.spec.ts` READ (`element(s) not found`). Reproduced on an isolated instance by running the full CI allow-list with one worker. That spec has **two independent defects**, and this branch fed one of them.

**1. The registers list pages at 20 and does not sort.** `RegistersIndex.paginatedRegisters` slices client-side at `registerStore.pagination.limit` (20), and `filteredRegisters` keeps the store's order unsorted. `SchemasIndex.orderedSchemas` sorts by id descending, so the sibling list puts the newest first and never shows this. Measured by reading the rendered list:

| registers | list header | pagination | the register created last |
| --- | --- | --- | --- |
| 19 | Showing 19 of 19 | none | rendered |
| 20 | Showing 20 of 20 | none | rendered |
| 21 | Showing 20 of 21 | Page 1 of 2 | rendered (order is not creation order) |
| 22 | Showing 20 of 22 | Page 1 of 2 | not rendered anywhere on the page |

A fresh instance ships 16 registers. `ci/object-sharing.spec.ts` and `ci/object-shares-tab.spec.ts` each create one and never delete it. This spec used to leave **two** behind (an archival register refuses HTTP deletion by design), so `register-crud`'s own register was the 21st row. Past 20, which row falls off page one is not predictable from the test's side, and CI's message is exactly what a row on page two produces.

**2. OpenRegister's own notification satisfies the locator.** Creating or updating a register publishes a Nextcloud notification `Register "<title>" was updated`, whose subject sits hidden in the page header before the app content. An unscoped `page.getByText(title).first()` resolves to that span, so a row that rendered fine fails with `Received: hidden`, and an unscoped `toHaveCount(0)` after a delete counts it and reports 1. **This one fails without this branch**: the unchanged spec, at the development register count (19 during READ, well under the page limit), with notifications cleared beforehand, failed READ with `Received: hidden` twice in two runs. `schema-crud`'s UPDATE step fails the same way in the full run. Which message a given run shows depends on whether the notification markup is in the DOM when the assertion polls.

**So this branch was a contributing cause, not the whole cause.** Without its two rows, CI's count would have been 19 and that particular failure would not have fired; but `register-crud` is flaky on `development` for the second reason regardless.

### The fix, and why at this level

- **This spec now seeds one register and one archival schema for the whole file** instead of one pair per describe. Its permanent footprint drops from two registers to one; one is the floor, since the archival rows it asserts on cannot be deleted by any HTTP caller.
- **`tests/e2e/_list-assertions.ts`** scopes every list assertion to `[data-testid="cn-index-page"]`, which removes the notification false match, and pages forward through `CnPagination` the way a person would, which removes the dependency on page one. `countListRowsByText` counts across every page, so "gone from the list" means gone from the whole list. Both crud specs use it for READ, UPDATE and DELETE.
- The registers list has **no search or filter bar** (`CnIndexPage` renders none and `RegistersIndex` passes no search props), so the `cn-filter-bar-search` route was not available. No test was made to skip and no timeout was widened: the element was not found, so time was not the problem.

A/B on the same instance:

| spec version | registers during READ | result |
| --- | --- | --- |
| unchanged | 19 (development count) | READ fails, `Received: hidden` (twice) |
| unchanged | 25 | READ fails |
| fixed | 19 | 8 of 8 crud tests pass |
| fixed | 25 | 4 of 4 register-crud tests pass |

## Mutation table

Each mutation was watched failing, in the named assertion, and then reverted. `lib/**` mutations were byte-compared against a pre-mutation copy and Apache was reloaded before each run because the image ships `opcache.revalidate_freq = 60`; a mutation that is not live looks exactly like a test that cannot fail.

| Test | Mutation | What caught it |
| --- | --- | --- |
| archival 1 | fixture rule `statusCode < 400` changed to `< 100` | `expected "PT1H", received "P30D"` |
| archival 2 | seeded `archiefnominatie: "bewaren"` | `expected "destroy", received "retain_permanently"` |
| archival 3 | gave the control schema the annotation | `_retention` present: `expected false, received true` |
| archival 4 | seeded the row on the plain schema | `expected 403, received 204` |
| archival 5 | dropped `overgebracht` and `vernietigd` from `RecordState::CANONICAL` (re-run on the merged code) | `'overgebracht' means transferred, so immutable must be true` |
| archival 5 | dropped `gearchiveerd` from `RecordState::CANONICAL` | `'gearchiveerd' must resolve to the canonical 'semi_static'` |
| archival 5 | added a new spelling `gedeponeerd` to `TRANSFERRED_ALIASES` (pre-merge) | `'gedeponeerd' means transferred, so immutable must be true` |
| archival 6 | removed the `appConfig` write in `ObjectRetentionHandler::updateRetentionSettingsOnly()` | reload shows `31536000000`, expected `31536001234` |
| register-crud READ | assert on a title that was never created | scoped locator, after paging: `element(s) not found` |
| register-crud DELETE | skipped the delete and removed the API checks, so only the UI count could notice | `the deleted register must be gone from every page: expected 0, received 1` |
| helper paging | paging disabled, 25 registers | READ fails `element(s) not found`, CI's exact message; with paging on it passes at the same count |

The first attempt at the DELETE mutation was caught by the API "gone" assertion instead of the new UI count, so it proved nothing about the count; it was redone with the API checks removed.

## Gate exit codes

Merged with current `origin/development` (including #3628) before the final runs, on a fresh CI-seeded instance.

| Check | Exit |
| --- | --- |
| CI config, touched specs (`archival-retention`, both crud specs), one worker | **0** (14 passed) |
| root config, same three specs, one worker | **0** (14 passed) |
| CI config, full allow-list, one worker | **1**: 94 passed, 1 skipped (the pre-existing `object-crud` `test.fixme`), 1 failed, see below |
| hydra gates, `HYDRA_GATE_BASE_REF=origin/development` | **0** (82 of 82 applicable) |
| eslint and prettier on every changed file | **0** |

The one full-run failure is `manifest-shell.spec.ts:181`, untouched by this branch and by the merge. It loads 18 routes as full documents on a fixed 180s budget. The trace shows it reached the 18th and last route at 172s (about 10s per load at a load average near 30 on 14 cores) and the budget ran out there, with every earlier route rendered and no assertion failed. Re-run alone it passes in 114s, and it passed in 138s in the earlier full run. A load-sensitive budget, reported rather than widened here.

## Findings, reported rather than fixed

1. **The archival delete refusal does not send its structured body.** `DELETE /api/objects/...` on an archival schema answers `{"error": "SCHEMA_ARCHIVAL_IMMUTABLE: Schema ..."}` because `ObjectsController::destroy()` has no `catch (ArchivalImmutableException)` and falls to the generic handler. A fix is coming separately. Archival test 4 asserts the code as a substring, so it is green before and after that fix; it does not assert the structured body, and can be tightened once it lands.
2. ~~`gearchiveerd` was not translated by the resolver~~: fixed by #3628, and test 5 now enforces it.
3. **Creating and reading the same object return different `_retention` shapes**: the create response keeps null-valued keys such as `matchedRule: null`, the read response drops them.
4. **An archival fixture cannot be cleaned up by any HTTP caller**, which is why this spec leaves one register per run.
5. **The registers list shows at most 20 rows, unsorted, while the schemas list shows the newest first.** A person who creates their 21st register may not see it without paging, with no cue that it is on page two.
6. **`ci/object-sharing.spec.ts` and `ci/object-shares-tab.spec.ts` never delete the register they create.** They are two of the four rows that filled the list.
7. **`manifest-shell.spec.ts:181` has no margin under load**, as described above.

## Not covered, and why

- `ArchiveActionDateCalculator`'s nine afleidingswijzen: no HTTP surface reaches them.
- The immutability enforcement itself (HTTP 409 on a transferred record): it reads `@self.retention.archiefstatus`, which the object API does not let a caller set.
- Legal holds, and the `basis` values that depend on stored blocks that are not writable over HTTP.

## Instance recipe

An isolated `nextcloud:34-apache` plus `pgvector/pgvector:pg16` compose project on `127.0.0.1:8171`, this clone bind-mounted as `custom_apps/openregister`, `appstoreenabled=false`, and the CI seed reproduced: `e2e-owner` and `e2e-other` accounts, the `e2e-grantees` group, firstrunwizard disabled, and `setup/action/skip-demo-data`. Never `:8080`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
