### PR TITLE
chore(lifecycle): tick the quality task that was run but not recorded

### DIFF
--- a/openspec/changes/lifecycle-auto-transitions/tasks.md
+++ b/openspec/changes/lifecycle-auto-transitions/tasks.md
@@ -29,7 +29,7 @@
 ## 5. Documentation and quality gate
 
 - [x] 5.1 Document `autoWhen` and `executionMode` in the lifecycle annotation reference: the four-key document and how `object` differs from a `condition`'s, sync as the default and why, the async decide-now-apply-if-unchanged contract, the ambiguity and shadow refusals, the cap and that it is fixed, the acting identity and the session-less CLI case, create firing, system operations and bulk, revert and deferred-create behaviour, the graph refusal, and the async-flow loop the cap does not bound. Verify the reference carries one worked example per execution mode.
-- [ ] 5.2 Run `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) and fix every finding on the touched files, pre-existing ones included. Verify by exit code 0.
+- [x] 5.2 Run `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) and fix every finding on the touched files, pre-existing ones included. Verify by exit code 0.
 
 ## Acceptance criteria
 
@@ -71,3 +71,9 @@
   record marked inside a boundary, so a listener-side drain is inert. That
   hole was real: nothing tested the ordering the drain depends on. Two tests
   now do, and both are mutation-checked.
+
+- **5.2** was run as its individual tools rather than the `composer check:strict`
+  wrapper, which dies on composer's own 300 second process timeout on a repo this
+  size. PHPCS, PHPMD (both rulesets), PHPStan, Psalm and the 19,779-test unit
+  suite each exit 0 on `development` at 3bf4a357, and CI's six PHP Quality jobs
+  agree on the same commit.


### PR DESCRIPTION
Bookkeeping only. No code changes.

Task 5.2 of `lifecycle-auto-transitions` merged unticked, so the change read 17 of 18 while the gate had in fact been run. Found by rechecking the session against the repository instead of against my own summary of it.

The note now records how it was satisfied, which is not exactly what the task text says. `composer check:strict` runs its tools through composer, and composer's 300 second process timeout kills PHPMD on a repo this size before it finishes. So the tools were run individually.

On `development` at `3bf4a357`:

| Tool | Result |
|---|---|
| PHPCS | exit 0 |
| PHPMD (both rulesets) | exit 0 |
| PHPStan | No errors, exit 0 |
| Psalm | exit 0 |
| PHPUnit | 19,779 tests, 0 failures, exit 0 |

CI's six PHP Quality jobs on the same commit agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
