### PR TITLE
docs(archival): the Now group has been done for days, and this list said otherwise

### DIFF
--- a/openspec/changes/archival-conformance/proposal.md
+++ b/openspec/changes/archival-conformance/proposal.md
@@ -249,17 +249,33 @@ Split by cost. Only the first group is proposed for immediate implementation.
 
 ### Now — the abstract layer tells the truth
 
-1. **A1** — `ArchivalDecisionResolver` reads `@self.tmlo` alongside the other four
-   sources.
-2. **A2** — `recordState` in `_retention`, resolved from the TMLO lifecycle, with
-   `overgebracht` / `vernietigd` marked immutable so a consumer can grey an edit.
-3. **B2** — when a selectielijst was expected and not consulted, say so in
-   `basis` rather than reporting `schema`.
-4. **C2** — wire `VALID_AFLEIDINGSWIJZEN` up, or delete it. A configured method
-   the code cannot honour must refuse loudly; today it is silently mis-dated.
-5. **C3** — date the fallback from the object's `created`, which is what the
-   comment already claims, not from `new DateTime()`.
-6. Vocabulary → **MDTO concepts, English keys**, per the table above.
+**ALL SIX ARE DONE.** They landed across #3584 and the changes listed below, and
+this list said "proposed" long after the code said otherwise. Verified in the
+tree on 2026-09-11, each against the file that implements it:
+
+1. ~~**A1** — `ArchivalDecisionResolver` reads `@self.tmlo` alongside the other
+   four sources.~~ **DONE.** `ArchivalDecisionResolver::resolve()` reads
+   `$entity->getTmlo()` as its fifth source.
+2. ~~**A2** — `recordState` in `_retention`, resolved from the TMLO lifecycle,
+   with `overgebracht` / `vernietigd` marked immutable.~~ **DONE.** The resolver
+   emits `recordState` and derives `immutable` from `IMMUTABLE_STATES`, so a
+   consumer never has to know the vocabulary to grey an edit.
+3. ~~**B2** — when a selectielijst was expected and not consulted, say so in
+   `basis`.~~ **DONE.** `basis` answers `selection_list_not_consulted` rather
+   than reporting `schema`.
+4. ~~**C2** — wire `VALID_AFLEIDINGSWIJZEN` up, or delete it.~~ **DONE.** It is
+   referenced, and an unsupported method now refuses loudly instead of being
+   silently mis-dated.
+5. ~~**C3** — date the fallback from the object's `created`.~~ **DONE.**
+   `brondatumFallback()` reads `$object->getCreated()`. `new DateTime()` remains
+   only for a record with no creation date at all.
+6. ~~Vocabulary → **MDTO concepts, English keys**.~~ **DONE.** `RecordState` and
+   `Appraisal` are the two vocabularies, each holding the Dutch spellings as
+   aliases so stored data keeps resolving.
+
+**A3 is NOT done** and is tracked under "Later" with D1: `beperkingGebruik`,
+`openbaarheid`, `aggregatieniveau` and `dekkingInTijd` still have no writer, so
+nothing populates them to export.
 
 ### Next — provenance and derivation
 


### PR DESCRIPTION
`openspec/changes/archival-conformance/proposal.md` listed six findings as
proposed work. All six have been implemented, some of them days ago. A proposal
that lags its own code makes the next reader either re-implement something or
re-measure it to find out.

Each is now marked done against the file that implements it, verified in the
tree on 2026-09-11 rather than recalled:

| Finding | Evidence |
| --- | --- |
| A1, the resolver reads `@self.tmlo` | `ArchivalDecisionResolver::resolve()` reads `getTmlo()` as its fifth source |
| A2, `recordState` plus immutability | the resolver emits `recordState` and derives `immutable` from `IMMUTABLE_STATES` |
| B2, say when a selection list was not consulted | `basis` answers `selection_list_not_consulted` |
| C2, honour `VALID_AFLEIDINGSWIJZEN` | referenced, and an unsupported method refuses loudly |
| C3, date the fallback from `created` | `brondatumFallback()` reads `getCreated()` |
| the vocabulary move | `RecordState` and `Appraisal`, each carrying the Dutch spellings as aliases |

## A3 is called out as still open

It reads as though A1 and A2 covered it. They did not: `beperkingGebruik`,
`openbaarheid`, `aggregatieniveau` and `dekkingInTijd` have no writer anywhere
in the app, so there is nothing to export. That is now stated where someone
looking at the abstract layer will see it.

Documentation only. Gate 46 (spec anchor existence) reports zero findings on the
changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
