### PR TITLE
fix(archival): one record-state alias map, because the second copy had drifted

### DIFF
--- a/lib/Service/Archival/ArchivalDecisionResolver.php
+++ b/lib/Service/Archival/ArchivalDecisionResolver.php
@@ -63,44 +63,21 @@ use OCA\OpenRegister\Db\ObjectEntity;
 class ArchivalDecisionResolver {
 
     /**
-     * Record states, in the Archiefwet lifecycle TmloService models.
+     * The record-state vocabulary lives in RecordState, not here.
      *
-     * @var array<string, string>
+     * 🔴 THIS CLASS USED TO KEEP ITS OWN COPY, AND THE COPY HAD DRIFTED. It
+     * knew `actief`, `semi_statisch`, `overgebracht`, `vernietigd` and
+     * `nog_te_archiveren`, but not `gearchiveerd`, which RecordState has always
+     * listed as semi-static. A record stored with that spelling resolved to the
+     * raw Dutch word, so a consumer comparing against `semi_static` saw no
+     * match, from the one layer whose job is to hand out a single vocabulary.
+     *
+     * The Dutch spellings are a compatibility shim for stored data, not a
+     * translation between two live conventions: RetentionService now writes the
+     * English lifecycle. TmloService keeps its own Dutch spellings for
+     * `tmlo.archiefstatus`, which is a separate block with its own transition
+     * matrix and its own MDTO export mapping.
      */
-    private const STATE_ALIASES = [
-        'actief' => 'active',
-        'semi_statisch' => 'semi_static',
-        'overgebracht' => 'transferred',
-        'vernietigd' => 'destroyed',
-        // 🔴 A SECOND VOCABULARY FOR THE SAME FIELD NAME. RetentionService
-        // writes `retention.archiefstatus = 'nog_te_archiveren'`, which is not
-        // in TmloService::VALID_ARCHIEFSTATUS and which that service's own
-        // validator would reject. So `archiefstatus` means one of two different
-        // things depending on which block it sits in.
-        //
-        // "Still to be archived" is a record that is live and not yet
-        // transferred, which is `actief` in the Archiefwet lifecycle, so it
-        // maps there and the abstract layer stays coherent. The underlying
-        // collision is real and is recorded as gap A4 in
-        // openspec/changes/archival-conformance; this mapping makes the
-        // abstract answer usable, it does not fix the two writers.
-        'nog_te_archiveren' => 'active',
-        // GAP A4 IS NOW FIXED AT THE WRITER. RetentionService writes
-        // RecordState::ACTIVE and the rest of the Archiefwet lifecycle in
-        // English, sharing one vocabulary with this layer. The Dutch keys above
-        // stay because stored data is not migrated: they are a compatibility
-        // shim for records written before the change, not a translation between
-        // two live conventions. TmloService keeps its own Dutch spellings for
-        // `tmlo.archiefstatus`, which is its own block with its own transition
-        // matrix and its own MDTO export mapping; that is a separate move.
-        //
-        // The English spellings map to themselves so a stored value that is
-        // already canonical still resolves rather than falling through.
-        'active' => 'active',
-        'semi_static' => 'semi_static',
-        'transferred' => 'transferred',
-        'destroyed' => 'destroyed',
-    ];
 
     /**
      * States after which the record may not be changed.
@@ -260,7 +237,7 @@ class ArchivalDecisionResolver {
         // An unknown state passes through for the same reason an unknown
         // appraisal does: reporting "no state" for a record that carries one is
         // the failure mode that hides a records obligation.
-        $state = (self::STATE_ALIASES[$raw] ?? $raw);
+        $state = (RecordState::CANONICAL[$raw] ?? $raw);
         $decision['recordState'] = $state;
         $decision['immutable'] = in_array($state, self::IMMUTABLE_STATES, true);
 

--- a/lib/Service/Archival/RecordState.php
+++ b/lib/Service/Archival/RecordState.php
@@ -135,6 +135,36 @@ final class RecordState {
 	public const IMMUTABLE_ALIASES = ['transferred', 'overgebracht', 'destroyed', 'vernietigd'];
 
 	/**
+	 * Every accepted spelling, mapped to the state it means.
+	 *
+	 * 🔴 ONE HOME, BECAUSE A SECOND COPY DRIFTS. ArchivalDecisionResolver
+	 * carried its own private alias map and it had already drifted: it knew
+	 * `actief`, `semi_statisch`, `overgebracht`, `vernietigd` and
+	 * `nog_te_archiveren`, but NOT `gearchiveerd`, which this class has always
+	 * listed as semi-static. A record stored with that spelling resolved to
+	 * the raw Dutch word in `_retention.recordState`, so a consumer comparing
+	 * against `semi_static` saw no match and the abstract layer, whose whole
+	 * job is to hand out one vocabulary, handed out two.
+	 *
+	 * A spelling this map does not know passes through unchanged rather than
+	 * being forced to a state nobody stored.
+	 *
+	 * @var array<string,string>
+	 */
+	public const CANONICAL = [
+		'active' => self::ACTIVE,
+		'actief' => self::ACTIVE,
+		'nog_te_archiveren' => self::ACTIVE,
+		'semi_static' => self::SEMI_STATIC,
+		'semi_statisch' => self::SEMI_STATIC,
+		'gearchiveerd' => self::SEMI_STATIC,
+		'transferred' => self::TRANSFERRED,
+		'overgebracht' => self::TRANSFERRED,
+		'destroyed' => self::DESTROYED,
+		'vernietigd' => self::DESTROYED,
+	];
+
+	/**
 	 * Every accepted spelling of every state.
 	 *
 	 * @var string[]

--- a/tests/Unit/Service/Archival/ArchivalDecisionResolverTest.php
+++ b/tests/Unit/Service/Archival/ArchivalDecisionResolverTest.php
@@ -22,6 +22,7 @@ namespace Unit\Service\Archival;
 
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Service\Archival\ArchivalDecisionResolver;
+use OCA\OpenRegister\Service\Archival\RecordState;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -470,6 +471,89 @@ class ArchivalDecisionResolverTest extends TestCase {
 
 		$this->assertSame('selection_list', $decision['basis']);
 		$this->assertSame('Selectielijst gemeenten 2020', $decision['source']);
+	}
+
+	/**
+	 * EVERY SPELLING RecordState ACCEPTS RESOLVES TO ITS ENGLISH STATE.
+	 *
+	 * This resolver used to keep its own alias map, and the copy had drifted:
+	 * `gearchiveerd` was listed as semi-static by RecordState and was missing
+	 * here, so a record stored with it answered the raw Dutch word from the one
+	 * layer whose job is to hand out a single vocabulary. The two lists are now
+	 * one list, and this walks it so a future addition to RecordState that is
+	 * not understood here fails instead of passing through.
+	 *
+	 * @dataProvider storedStateProvider
+	 *
+	 * @param string $stored The spelling as stored on the record.
+	 *
+	 * @spec openspec/specs/archival-annotation-vocabulary/spec.md
+	 */
+	public function testEveryStoredSpellingResolvesToItsEnglishState(
+		string $stored
+	): void {
+		$entity = $this->entityWith(
+			retention: [
+				'archiefnominatie' => 'vernietigen',
+				'archiefstatus' => $stored,
+			]
+		);
+
+		$decision = $this->resolver->resolve(entity: $entity);
+
+		$this->assertNotNull($decision);
+		$this->assertContains(
+			$decision['recordState'],
+			RecordState::ALL,
+			sprintf(
+				'the stored spelling "%s" is accepted by RecordState, so it must resolve to one '
+				. 'of the English states and not to itself; it resolved to "%s"',
+				$stored,
+				$decision['recordState']
+			)
+		);
+	}
+
+	/**
+	 * Every spelling RecordState says it accepts.
+	 *
+	 * 🔴 THIS READS `ALL_ALIASES`, NOT `CANONICAL`, AND THE DIFFERENCE IS THE
+	 * WHOLE TEST. Deriving the cases from the same map the assertion checks
+	 * would be a tautology: delete a spelling from `CANONICAL` and the test
+	 * would simply run one case fewer and stay green, which is exactly how the
+	 * `gearchiveerd` gap survived in the first place. `ALL_ALIASES` is the
+	 * independent claim about what stored data may contain, so a spelling that
+	 * is accepted there and unmapped here now fails.
+	 *
+	 * @return array<string, array{0: string}> The cases.
+	 */
+	public static function storedStateProvider(): array {
+		$cases = [];
+		foreach (RecordState::ALL_ALIASES as $stored) {
+			$cases[$stored] = [$stored];
+		}
+
+		return $cases;
+	}
+
+	/**
+	 * A spelling nobody declared passes through rather than being forced into a
+	 * state the record does not carry. Guessing here would be worse than not
+	 * answering: it would report a lifecycle position nobody wrote.
+	 */
+	public function testAnUnknownSpellingIsNotForcedIntoAState(): void {
+		$decision = $this->resolver->resolve(
+			entity: $this->entityWith(
+				retention: [
+					'archiefnominatie' => 'vernietigen',
+					'archiefstatus' => 'in_de_kast',
+				]
+			)
+		);
+
+		$this->assertNotNull($decision);
+		$this->assertSame('in_de_kast', $decision['recordState']);
+		$this->assertFalse($decision['immutable']);
 	}
 
 }//end class


### PR DESCRIPTION
## The defect

`ArchivalDecisionResolver` kept its own private `STATE_ALIASES` while
`RecordState` existed as the one home for this vocabulary. The copy was already
behind: it knew `actief`, `semi_statisch`, `overgebracht`, `vernietigd` and
`nog_te_archiveren`, but **not `gearchiveerd`**, which `RecordState` has always
listed as semi-static.

A record stored with that spelling therefore resolved to the raw Dutch word in
`@self._retention.recordState`. A consumer comparing against `semi_static` saw
no match, from the one layer whose entire job is to hand out a single
vocabulary.

Immutability was unaffected, because semi-static is not immutable, so this is
legibility rather than retention. It is still exactly the drift the abstract
layer exists to prevent.

Found by the archival e2e work in #3619, which asserted the resolved value and
got Dutch back.

## The fix

`RecordState::CANONICAL` maps every accepted spelling to its state, and the
resolver reads it. The private map is gone. An unknown spelling still passes
through unchanged rather than being forced into a state nobody stored: guessing
would report a lifecycle position that was never written.

## The test walks the OTHER list, and that is the point

`storedStateProvider()` reads `RecordState::ALL_ALIASES`, not `CANONICAL`.

Deriving the cases from the map under test is a tautology, and my first version
did exactly that: deleting `gearchiveerd` from `CANONICAL` simply ran one case
fewer and stayed green. That is how this gap survived in the first place.
Reading the independent list means a spelling accepted there and unmapped here
fails by name:

```
the stored spelling "gearchiveerd" is accepted by RecordState, so it must
resolve to one of the English states and not to itself; it resolved to
"gearchiveerd"
```

## Verification

| Gate | Result |
| --- | --- |
| phpunit, whole unit suite | 19817, exit 0 |
| phpcs (CI scope, `lib`) | exit 0 |
| phpstan, cache cleared first | exit 0 |
| phpmd, both legs | exit 0 |
| gate-16 spec-coverage | count=0 |

| Mutation | Reddens |
| --- | --- |
| remove `gearchiveerd` from `CANONICAL` | that data set, naming the spelling |
| force an unknown spelling to `ACTIVE` | the pass-through test |

Both restored byte-identical afterwards.

Psalm exits 2 on this machine, reporting OCP classes that are present in
`vendor/nextcloud/ocp` as undefined. It does the same on a pristine checkout of
`development` with my changes stashed, so that verdict is the environment, not
this change. CI's own psalm leg is the authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
