### PR TITLE
fix(objects): a refused archival delete answers the body its spec promised

### DIFF
--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -38,6 +38,7 @@ use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Exception\AppendOnlyException;
+use OCA\OpenRegister\Exception\ArchivalImmutableException;
 use OCA\OpenRegister\Exception\CustomValidationException;
 use OCA\OpenRegister\Exception\ExportTooLargeException;
 use OCA\OpenRegister\Exception\FolderAccessDeniedException;
@@ -3498,6 +3499,21 @@ class ObjectsController extends Controller {
 
 			// Return 204 No Content for successful delete (REST convention).
 			return new JSONResponse(data: null, statusCode: 204);
+		} catch (ArchivalImmutableException $exception) {
+			// 🔴 THE REFUSAL HAS A WIRE CONTRACT AND THIS ENDPOINT WAS NOT
+			// HONOURING IT. `ArchivalImmutableException::toResponseBody()`
+			// exists and DeletedController and BulkController both use it, but
+			// this catch was missing here, so a refusal on the endpoint clients
+			// actually call fell through to the generic handler and answered
+			// `{"error": "SCHEMA_ARCHIVAL_IMMUTABLE: Schema ... declares ..."}`
+			// as one flattened string. A client following the spec and testing
+			// `body.error === 'SCHEMA_ARCHIVAL_IMMUTABLE'` matched nothing, and
+			// `schema`, `operation` and `hint` were not there to read at all.
+			//
+			// 403, not the trait's 405: the spec says 403 and the route already
+			// answered 403 through the generic path, so the status stays put
+			// and only the body becomes what was promised.
+			return new JSONResponse(data: $exception->toResponseBody(), statusCode: Http::STATUS_FORBIDDEN);
 		} catch (AppendOnlyException $exception) {
 			// Reject delete on append-only schema with HTTP 405.
 			return new JSONResponse(data: $exception->toResponseBody(), statusCode: Http::STATUS_METHOD_NOT_ALLOWED);

--- a/tests/Unit/Controller/ObjectsControllerArchivalRefusalTest.php
+++ b/tests/Unit/Controller/ObjectsControllerArchivalRefusalTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit\Controller;
+
+use OCA\OpenRegister\Controller\ObjectsController;
+use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Exception\ArchivalImmutableException;
+use OCA\OpenRegister\Service\ExportService;
+use OCA\OpenRegister\Service\ImportService;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\WebhookService;
+use OCP\App\IAppManager;
+use OCP\AppFramework\Http;
+use OCP\IAppConfig;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * A refused delete on an archival schema answers the contract it published.
+ *
+ * `ArchivalImmutableException` carries `toResponseBody()` precisely so a client
+ * can branch on `error`, name the `schema` and show the `hint`. DeletedController
+ * and BulkController both catch it; ObjectsController did not, so on the endpoint
+ * clients actually call the refusal fell through to the generic handler and
+ * arrived as one flattened string. A client following the spec and testing
+ * `body.error === 'SCHEMA_ARCHIVAL_IMMUTABLE'` matched nothing.
+ *
+ * @package Unit\Controller
+ */
+class ObjectsControllerArchivalRefusalTest extends TestCase {
+
+	private ObjectsController $controller;
+	private ObjectService&MockObject $objectService;
+
+	/**
+	 * Build the controller with the collaborators destroy() actually reaches.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$userSession = $this->createMock(IUserSession::class);
+		$userSession->method('getUser')->willReturn($this->createMock(IUser::class));
+		$groupManager = $this->createMock(IGroupManager::class);
+		$groupManager->method('getUserGroupIds')->willReturn(['users']);
+
+		$this->objectService = $this->createMock(ObjectService::class);
+
+		$this->controller = new ObjectsController(
+			'openregister',
+			$this->createMock(IRequest::class),
+			$this->createMock(IAppConfig::class),
+			$this->createMock(IAppManager::class),
+			$this->createMock(ContainerInterface::class),
+			$this->createMock(RegisterMapper::class),
+			$this->createMock(SchemaMapper::class),
+			$this->createMock(AuditTrailMapper::class),
+			$this->objectService,
+			$userSession,
+			$groupManager,
+			$this->createMock(ExportService::class),
+			$this->createMock(ImportService::class),
+			$this->createMock(WebhookService::class),
+			$this->createMock(LoggerInterface::class)
+		);
+	}
+
+	/**
+	 * The refusal answers 403 with the whole structured body, not a string.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/archival-annotation-vocabulary/spec.md
+	 */
+	public function testARefusedArchivalDeleteAnswersItsStructuredBody(): void {
+		$this->objectService->method('deleteObject')->willThrowException(
+			new ArchivalImmutableException(schemaIdentifier: 'call_log', operation: 'delete')
+		);
+
+		$response = $this->controller->destroy(
+			id: 'abc',
+			register: 'logs',
+			schema: 'call_log',
+			objectService: $this->objectService
+		);
+		$body = $response->getData();
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertIsArray($body, 'the body must be the structured refusal, not a flattened string');
+		$this->assertSame('SCHEMA_ARCHIVAL_IMMUTABLE', ($body['error'] ?? null));
+		$this->assertSame('call_log', ($body['schema'] ?? null));
+		$this->assertSame('delete', ($body['operation'] ?? null));
+		$this->assertArrayHasKey('hint', $body, 'the hint tells the caller how to proceed lawfully');
+		$this->assertArrayHasKey('message', $body);
+	}
+}//end class


### PR DESCRIPTION
## The defect

The archival spec is explicit: a user-driven delete on an archival schema is
refused with **403** and the structured body

```json
{ "error": "SCHEMA_ARCHIVAL_IMMUTABLE", "message": "...", "schema": "...", "operation": "delete", "hint": "..." }
```

`ArchivalImmutableException::toResponseBody()` builds exactly that, and
`DeletedController` and `BulkController` both catch it and send it.

`ObjectsController::destroy()` did not catch it. On the endpoint clients
actually call, the refusal fell through to the generic handler and arrived as
one flattened string:

```json
{ "error": "SCHEMA_ARCHIVAL_IMMUTABLE: Schema \"x\" declares ..." }
```

A client following the spec and testing `body.error === 'SCHEMA_ARCHIVAL_IMMUTABLE'`
matched nothing, and `schema`, `operation` and the `hint` (which tells a caller
how to proceed lawfully) were not there to read.

Found by the archival e2e work in #3619.

## The fix

One `catch (ArchivalImmutableException)` returning `toResponseBody()` with 403.

The status stays 403: the spec says 403, and the route already answered 403
through the generic path. `HandlesExceptionsTrait` maps this exception to 405,
which disagrees with the spec, but that trait is not on this path and changing
its mapping is a separate question. Only the body changes here.

## Verification

A new `ObjectsControllerArchivalRefusalTest` drives `destroy()` with an
`ObjectService` that refuses, and asserts the status and every key of the body.

| Mutation | Result |
| --- | --- |
| delete the new catch | reddens on the status assertion; restored byte-identical |

| Gate | Result |
| --- | --- |
| phpunit, `tests/Unit/Controller` + `tests/Unit/Service/Archival` | 3341, exit 0 |
| phpcs | exit 0 |
| phpstan, cache cleared first | exit 0 |
| phpmd | exit 0 |
| gate-16 spec-coverage | count=0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
