### PR TITLE
fix(errors): an archival refusal is 403 everywhere, including the fallback

### DIFF
--- a/lib/Controller/Trait/HandlesExceptionsTrait.php
+++ b/lib/Controller/Trait/HandlesExceptionsTrait.php
@@ -69,10 +69,10 @@ trait HandlesExceptionsTrait {
 	 *
 	 * Typed map (tasks.md 1.2 / ADR-051):
 	 *   - not-found shapes                → 404
-	 *   - forbidden shapes                → 403
+	 *   - forbidden shapes, archival      → 403
 	 *   - validation shapes               → 422 (typed) / 400 (InvalidArgumentException)
 	 *   - conflict shapes                 → 409
-	 *   - append-only / archival shapes   → 405
+	 *   - append-only shapes              → 405
 	 *   - foundation/config unavailable   → 503
 	 *   - anything else                   → 500 with a generic body; the real
 	 *     message is logged server-side only (leak-safe).
@@ -138,9 +138,18 @@ trait HandlesExceptionsTrait {
 		// Conflict → 409.
 		MultipleObjectsReturnedException::class => Http::STATUS_CONFLICT,
 		DatabaseConstraintException::class => Http::STATUS_CONFLICT,
-		// Append-only / archival immutability → 405.
+		// Append-only → 405: the resource type supports no such operation at all.
 		AppendOnlyException::class => Http::STATUS_METHOD_NOT_ALLOWED,
-		ArchivalImmutableException::class => Http::STATUS_METHOD_NOT_ALLOWED,
+		// Archival immutability → 403, NOT 405, and the two are not a family.
+		// The archival spec says 403, and every controller that catches this
+		// exception explicitly (BulkController, DeletedController,
+		// SchemasController, ObjectsController) answers 403. This fallback was
+		// the only place that said 405, so a refusal reaching it contradicted
+		// every other refusal for the same record. It is also the more honest
+		// code: the operation exists and is allowed in general, it is refused
+		// for THIS record because the law keeps it, and the body's `hint` says
+		// how deletion lawfully happens instead.
+		ArchivalImmutableException::class => Http::STATUS_FORBIDDEN,
 		// Foundation / configuration unavailable (ADR-049 fail-closed) → 503.
 		FoundationUnavailableException::class => Http::STATUS_SERVICE_UNAVAILABLE,
 		ConfigurationMissingException::class => Http::STATUS_SERVICE_UNAVAILABLE,

--- a/tests/Unit/Controller/HandlesExceptionsTraitTest.php
+++ b/tests/Unit/Controller/HandlesExceptionsTraitTest.php
@@ -21,6 +21,7 @@ use OCA\OpenRegister\AppHost\Exception\ConfigurationMissingException;
 use OCA\OpenRegister\AppHost\Exception\FoundationUnavailableException;
 use OCA\OpenRegister\Controller\Trait\HandlesExceptionsTrait;
 use OCA\OpenRegister\Exception\AppendOnlyException;
+use OCA\OpenRegister\Exception\ArchivalImmutableException;
 use OCA\OpenRegister\Exception\CustomValidationException;
 use OCA\OpenRegister\Exception\NotAuthorizedException;
 use OCA\OpenRegister\Exception\ValidationException;
@@ -77,6 +78,13 @@ class HandlesExceptionsTraitTest extends TestCase {
 			'bad argument → 400' => [new \InvalidArgumentException('bad input'), Http::STATUS_BAD_REQUEST],
 			'conflict → 409' => [new MultipleObjectsReturnedException('two'), Http::STATUS_CONFLICT],
 			'append-only → 405' => [new AppendOnlyException('my-schema'), Http::STATUS_METHOD_NOT_ALLOWED],
+			// 403, like every controller that catches it explicitly and like the
+			// archival spec. This fallback used to say 405, so a refusal that
+			// reached it contradicted every other refusal for the same record.
+			'archival refusal → 403' => [
+				new ArchivalImmutableException(schemaIdentifier: 'call_log', operation: 'delete'),
+				Http::STATUS_FORBIDDEN,
+			],
 			'foundation → 503' => [new FoundationUnavailableException(appId: 'myapp'), Http::STATUS_SERVICE_UNAVAILABLE],
 			'config missing → 503' => [new ConfigurationMissingException(appId: 'myapp', configKey: 'register'), Http::STATUS_SERVICE_UNAVAILABLE],
 		];


### PR DESCRIPTION
## The inconsistency

`HandlesExceptionsTrait` grouped `ArchivalImmutableException` with
`AppendOnlyException` and mapped both to **405**.

Every controller that catches the archival exception explicitly answers **403**,
and so does the archival spec:

| Site | Status |
| --- | --- |
| `BulkController` | 403 |
| `DeletedController` | 403 |
| `SchemasController` | 403 |
| `ObjectsController::destroy()` (#3629) | 403 |
| the archival spec | 403 |
| `HandlesExceptionsTrait` fallback | **405** |

So a refusal that reached the fallback contradicted every other refusal for the
same record.

## Why the grouping was wrong, not just inconsistent

The two exceptions are not a family. Append-only means the resource type
supports no such operation at all, which is exactly what 405 says. An archival
record's delete exists and is allowed in general; it is refused for **this**
record because the law keeps it, and the body's `hint` says how deletion
lawfully happens instead. That is 403.

`AppendOnlyException` stays at 405.

## Verification

`HandlesExceptionsTraitTest` gains an `archival refusal → 403` case beside the
existing append-only one.

| Mutation | Result |
| --- | --- |
| put 405 back | reddens exactly that data set; restored byte-identical |

| Gate | Result |
| --- | --- |
| phpunit, whole unit suite | 19839, exit 0 |
| phpcs | exit 0 |
| gate-16 spec-coverage | count=0 |

No test, Newman collection or `openapi.json` entry expected 405 for this
refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
