### PR TITLE
fix(edepot): generated MDTO validates against MDTO-XML 1.0.1, and a test keeps it that way

### DIFF
--- a/lib/Resources/mdto/MDTO-XML1.0.1.xsd
+++ b/lib/Resources/mdto/MDTO-XML1.0.1.xsd
@@ -1,0 +1,390 @@
+<!--Documentatie-->
+<!--20230109 ONDERWERP: aanpassing schema. WAT: maxOccurs bij attribuut archiefvormer aangepast naar 'unbounded', minOccurs bij attribuut beperkingGebruik aangepast naar '1'. Beiden nu conform metagegevensschema MDTO. Versie XML schema aangepast naar 1.0.1.-->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="https://www.nationaalarchief.nl/mdto" targetNamespace="https://www.nationaalarchief.nl/mdto" elementFormDefault="qualified" attributeFormDefault="unqualified" version="v1.0.1">
+	<xsd:element name="MDTO" type="mdtoType"/>
+	<xsd:complexType name="mdtoType">
+		<xsd:choice>
+			<xsd:element name="informatieobject" type="informatieobjectType">
+				<xsd:annotation>
+					<xsd:documentation>Een op zichzelf staand geheel van gegevens met een eigen identiteit. (bron: DUTO-eisen)</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="bestand" type="bestandType">
+				<xsd:annotation>
+					<xsd:documentation>Een geordende verzameling van gegevens in elektronische vorm, die door een elektronisch apparaat onder één naam kan worden behandeld en aangesproken. </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:choice>
+	</xsd:complexType>
+	<xsd:complexType name="objectType">
+		<xsd:sequence>
+			<xsd:element name="identificatie" type="identificatieGegevens" minOccurs="1" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Gegevens waarmee  het object geïdentificeerd kan worden.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="naam" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Een betekenisvolle aanduiding waaronder het object bekend is.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="informatieobjectType">
+		<xsd:complexContent>
+			<xsd:extension base="objectType">
+				<xsd:sequence>
+					<xsd:element name="aggregatieniveau" type="begripGegevens" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>Het aggregatieniveau van het informatieobject.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="classificatie" type="begripGegevens" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Ordening van informatieobjecten in een logisch verband, zoals vastgelegd in een classificatieschema.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="trefwoord" type="xsd:string" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Trefwoord dat aan het informatieobject is toegekend.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="omschrijving" type="xsd:string" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Omschrijving van de inhoud van het informatieobject.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="raadpleeglocatie" type="raadpleeglocatieGegevens" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Actuele verwijzing naar de locatie waar het informatieobject ter inzage ligt.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="dekkingInTijd" type="dekkingInTijdGegevens" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Een tijdstip of de periode waarop de inhoud van het informatieobject betrekking heeft. </xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="dekkingInRuimte" type="verwijzingGegevens" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Plaats of locatie waar de inhoud van het informatieobject betrekking op heeft.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="taal" type="xsd:language" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>De taal waarin het informatieobject gesteld is.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="event" type="eventGegevens" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Gebeurtenis die heeft plaatsgevonden met betrekking tot het ontstaan, wijzigen, vernietigen en beheer van het informatieobject en de bijbehorende metagegevens.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="waardering" type="begripGegevens" minOccurs="1" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>De waardering van het informatieobject volgens de van toepassing zijnde en vastgestelde selectielijst.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="bewaartermijn" type="termijnGegevens" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>Termijn waarin het informatieobject bewaard dient te worden, zoals gespecificeerd in de van toepassing zijnde en vastgestelde selectielijst.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="informatiecategorie" type="begripGegevens" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>De informatiecategorie uit een vastgestelde selectielijst of hotspotlijst waar de bewaartermijn op gebaseerd is.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="isOnderdeelVan" type="verwijzingGegevens" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>De direct bovenliggende aggregatie waar dit informatieobject onderdeel van is. </xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="bevatOnderdeel" type="verwijzingGegevens" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Een Informatieobject dat direct onderliggend onderdeel is van deze aggregatie. Opmerking: Dit is de omgekeerde relatie van isOnderdeelVan.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="heeftRepresentatie" type="verwijzingGegevens" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Verwijzing naar het bestand dat een (deel van een) representatie van het informatieobject is.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="aanvullendeMetagegevens" type="verwijzingGegevens" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Verwijzing naar een bestand dat aanvullende (domeinspecifieke) metagegevens over het informatieobject bevat.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="gerelateerdInformatieobject" type="gerelateerdInformatieobjectGegevens" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Relatie met een ander informatieobject dat relevant is binnen de context van het ontstaan, gebruik en/of beheer van dit informatieobject.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="archiefvormer" type="verwijzingGegevens" minOccurs="1" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>De organisatie die verantwoordelijk is voor het opmaken en/of ontvangen van het informatieobject.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="betrokkene" type="betrokkeneGegevens" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Persoon of organisatie die relevant is binnen de context van het ontstaan en gebruik van dit informatieobject.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="activiteit" type="verwijzingGegevens" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>De bedrijfsactiviteit waarbij het informatieobject door de archiefvormer is ontvangen of gemaakt. </xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="beperkingGebruik" type="beperkingGebruikGegevens" minOccurs="1" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Een beperking die gesteld is aan het gebruik van het informatieobject.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="bestandType">
+		<xsd:complexContent>
+			<xsd:extension base="objectType">
+				<xsd:sequence>
+					<xsd:element name="omvang" type="xsd:integer" minOccurs="1" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>Aantal bytes in het bestand.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="bestandsformaat" type="begripGegevens" minOccurs="1" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>De manier waarop de informatie in een computerbestand binair gecodeerd is.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="checksum" type="checksumGegevens" minOccurs="1" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Gegevens om te bepalen of het bestand beschadigd of gewijzigd is. </xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="URLBestand" type="xsd:anyURI" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>Actuele verwijzing naar het bestand.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="isRepresentatieVan" type="verwijzingGegevens" minOccurs="1" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation>Verwijzing naar het informatieobject waarvan het bestand een (deel van een) representatie is.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="identificatieGegevens">
+		<xsd:sequence>
+			<xsd:element name="identificatieKenmerk" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Een kenmerk waarmee een object geïdentificeerd kan worden.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="identificatieBron" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Herkomst van het kenmerk.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="verwijzingGegevens">
+		<xsd:sequence>
+			<xsd:element name="verwijzingNaam" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De naam van het object waarnaar verwezen wordt.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="verwijzingIdentificatie" type="identificatieGegevens" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De identificatie van het object waarnaar verwezen wordt.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="begripGegevens">
+		<xsd:sequence>
+			<xsd:element name="begripLabel" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De tekstweergave van het begrip dat is toegekend in de begrippenlijst.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="begripCode" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De code die aan het begrip is toegekend in de begrippenlijst.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="begripBegrippenlijst" type="verwijzingGegevens" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Een beschrijving van de begrippen die voor een bepaald toepassingsgebied gebruikt worden is opgesomd. Samen met hun betekenis en hun onderlinge relaties.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="dekkingInTijdGegevens">
+		<xsd:sequence>
+			<xsd:element name="dekkingInTijdType" type="begripGegevens" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Nadere typering van het tijdstip of de periode waar de inhoud van het informatieobject betrekking op heeft. </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="dekkingInTijdBegindatum" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Datum waar de inhoud van het informatieobject betrekking op heeft. Bij een periode is dit de begindatum.</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="xsd:gYear xsd:gYearMonth xsd:date"/>
+				</xsd:simpleType>
+			</xsd:element>
+			<xsd:element name="dekkingInTijdEinddatum" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Einddatum van de periode waar de inhoud van het informatieobject betrekking op heeft.</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="xsd:gYear xsd:gYearMonth xsd:date"/>
+				</xsd:simpleType>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="eventGegevens">
+		<xsd:sequence>
+			<xsd:element name="eventType" type="begripGegevens" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Aanduiding van het type event.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="eventTijd" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Het tijdstip waarop het event heeft plaatsgevonden.</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="xsd:gYear xsd:gYearMonth xsd:date xsd:dateTime"/>
+				</xsd:simpleType>
+			</xsd:element>
+			<xsd:element name="eventVerantwoordelijkeActor" type="verwijzingGegevens" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De actor die verantwoordelijk was voor de gebeurtenis.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="eventResultaat" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Beschrijving van het resultaat van het event voor zover relevant voor de duurzame toegankelijkheid van het informatieobject.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="gerelateerdInformatieobjectGegevens">
+		<xsd:sequence>
+			<xsd:element name="gerelateerdInformatieobjectVerwijzing" type="verwijzingGegevens" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Verwijzing naar het gerelateerde informatieobject.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="gerelateerdInformatieobjectTypeRelatie" type="begripGegevens" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Typering van de relatie met het andere informatieobject.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="betrokkeneGegevens">
+		<xsd:sequence>
+			<xsd:element name="betrokkeneTypeRelatie" type="begripGegevens" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Typering van de betrokkenheid van de actor bij het informatieobject.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="betrokkeneActor" type="verwijzingGegevens" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De persoon of organisatie die betrokken is bij het informatieobject.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="beperkingGebruikGegevens">
+		<xsd:sequence>
+			<xsd:element name="beperkingGebruikType" type="begripGegevens" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Typering van de beperking. Op grond waarvan bepaald kan worden wie toegang heeft tot het informatieobject en welke voorwaarden op het gebruik van toepassing zijn.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="beperkingGebruikNadereBeschrijving" type="xsd:string" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Nadere beschrijving van de beperking op het gebruik. Als aanvulling op beperkingGebruikType.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="beperkingGebruikDocumentatie" type="verwijzingGegevens" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Verwijzing naar een tekstdocument waarin een nadere beschrijving van de beperking is opgenomen.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="beperkingGebruikTermijn" type="termijnGegevens" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De termijn waarbinnen de beperking op het gebruik van toepassing is.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="termijnGegevens">
+		<xsd:sequence>
+			<xsd:element name="termijnTriggerStartLooptijd" type="begripGegevens" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Gebeurtenis waarna de looptijd van de termijn start.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="termijnStartdatumLooptijd" type="xsd:date" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De datum waarop de trigger heeft plaatsgevonden en de looptijd is gestart.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="termijnLooptijd" type="xsd:duration" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De hoeveelheid tijd waarin de termijnEindDatum bereikt wordt, nadat de trigger heeft plaatsgevonden.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="termijnEinddatum" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Datum waarop de termijn eindigt.</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="xsd:gYear xsd:gYearMonth xsd:date"/>
+				</xsd:simpleType>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="checksumGegevens">
+		<xsd:sequence>
+			<xsd:element name="checksumAlgoritme" type="begripGegevens" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Naam van het checksum algoritme dat is gebruikt om de checksum te maken. </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="checksumWaarde" type="xsd:string" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>De waarde van de checksum. </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="checksumDatum" type="xsd:dateTime" minOccurs="1" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>Datum waarop de checksum is gemaakt.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="raadpleeglocatieGegevens">
+		<xsd:sequence>
+			<xsd:element name="raadpleeglocatieFysiek" type="verwijzingGegevens" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Actuele fysieke locatie waar het informatieobject ter inzage ligt.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="raadpleeglocatieOnline" type="xsd:anyURI" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>Actuele verwijzing naar een online raadpleeglocatie die het informatieobject en de bijbehorende metagegevens weergeeft. </xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:schema>

--- a/lib/Resources/mdto/version.json
+++ b/lib/Resources/mdto/version.json
@@ -1,0 +1,15 @@
+{
+    "standard": "mdto-xml",
+    "version": "MDTO-XML1.0.1",
+    "release": "1.0.1",
+    "source": "https://github.com/NationaalArchief/MDTO-XSD/blob/afae5f300c8a92bbe3564d642017213bc7f4156f/schema/v1.0.1/MDTO-XML1.0.1.xsd",
+    "alsoPublishedAt": "https://www.nationaalarchief.nl/sites/default/mdto/MDTO-XML1.0.1.xsd",
+    "sha256": "048d745a17f479995f14c938d342b2f13382072d0fdf1f1b28113126df715648",
+    "retrieved": "2026-09-11",
+    "modified": false,
+    "note": "Verbatim copy of the Nationaal Archief's XML Schema Definition for MDTO (Metagegevens voor Duurzaam Toegankelijke Overheidsinformatie), XML syntax version 1.0.1. Not edited in any way. The copy at nationaalarchief.nl differs only in using CRLF line endings; its sha256 is edad88821a1023a9eafca0fa399ee7735ef03481aa186e07bbdaabdc123def34. Used by MdtoXmlGeneratorXsdTest to validate generated documents, so a change to this file changes what the export is held to.",
+    "licence": "CC BY-SA (version not stated by the publisher)",
+    "licenceSource": "Forum Standaardisatie, Intakeadvies MDTO, FS-20241002.3C, section 'Beschikbaarheid documentatie en intellectueel eigendomsrecht': \"Het Nationaal Archief hanteert de licentie CC BY SA voor al diens kennisproducten en dus ook voor MDTO.\" https://www.forumstandaardisatie.nl/sites/default/files/FS/2024/1002/FS-20241002.3C-intakeadvies-MDTO.pdf",
+    "attribution": "MDTO-XML 1.0.1, Nationaal Archief, https://www.nationaalarchief.nl/archiveren/mdto, licensed CC BY-SA. Redistributed unmodified.",
+    "licenceNote": "The upstream repositories (NationaalArchief/MDTO-XSD, NationaalArchief/MDTO-Metagegevensschema) carry no LICENSE file and their respec 'license' setting is commented out, so the statement above is the only licence declaration found. The share-alike term binds adaptations of THIS FILE; it does not reach openregister's own code, which ships the file alongside itself and does not adapt it."
+}

--- a/lib/Service/Edepot/EdepotTransferService.php
+++ b/lib/Service/Edepot/EdepotTransferService.php
@@ -39,6 +39,7 @@ use OCA\OpenRegister\Service\Edepot\Transport\TransportResult;
 use OCP\IAppConfig;
 use OCP\Notification\IManager as INotificationManager;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Orchestrator for e-Depot transfer operations.
@@ -431,6 +432,22 @@ class EdepotTransferService {
 	/**
 	 * Get file metadata for an object.
 	 *
+	 * ## The checksum is computed here, every time, and dated here
+	 *
+	 * MDTO requires `checksumDatum`, defined as "Datum waarop de checksum is
+	 * gemaakt". A checksum read from stored data carries no such date, so the
+	 * only honest date is one this method can vouch for: it hashes the bytes
+	 * it is about to package and records that moment.
+	 *
+	 * Recomputing alone would launder a changed file. If the bytes on disk no
+	 * longer match a SHA-256 recorded for them, a fresh checksum would describe
+	 * the changed bytes and the package would look intact. So a stored SHA-256
+	 * that disagrees with the computed one is a fixity failure, and the file is
+	 * refused: the exception reaches the per-object catch in
+	 * {@see self::gatherObjectsWithFiles()}, which excludes the object from
+	 * this transfer and logs it by uuid. A stored value that is not
+	 * SHA-256-shaped cannot be compared and is not used.
+	 *
 	 * @param ObjectEntity $object The object.
 	 *
 	 * @return array<int, array{
@@ -438,9 +455,12 @@ class EdepotTransferService {
 	 *     size: int,
 	 *     format: string,
 	 *     checksum: string,
+	 *     checksumDate: string,
 	 *     path: string,
 	 *     isRendition: bool
 	 * }> File metadata array.
+	 *
+	 * @throws RuntimeException When a stored SHA-256 does not match the file's bytes.
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-assemble-sip-packages-for-e-depot-transfer
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-support-multiple-transport-protocols-for-sip-delivery
@@ -464,11 +484,16 @@ class EdepotTransferService {
 				continue;
 			}
 
+			$checksum = (string)hash_file('sha256', $path);
+			$checksumDate = (new DateTime())->format(DateTime::ATOM);
+			$this->assertFixity(stored: ($fileRef['checksum'] ?? null), computed: $checksum, path: $path);
+
 			$files[] = [
 				'name' => ($fileRef['name'] ?? basename($path)),
 				'size' => (int)($fileRef['size'] ?? filesize($path)),
 				'format' => ($fileRef['mimeType'] ?? ($fileRef['format'] ?? 'application/octet-stream')),
-				'checksum' => ($fileRef['checksum'] ?? hash_file('sha256', $path)),
+				'checksum' => $checksum,
+				'checksumDate' => $checksumDate,
 				'path' => $path,
 				'isRendition' => (bool)($fileRef['isRendition'] ?? false),
 			];
@@ -476,6 +501,32 @@ class EdepotTransferService {
 
 		return $files;
 	}//end getObjectFiles()
+
+	/**
+	 * Refuse a file whose bytes no longer match the SHA-256 recorded for it.
+	 *
+	 * @param mixed $stored The checksum stored with the file reference, if any.
+	 * @param string $computed The SHA-256 of the bytes about to be packaged.
+	 * @param string $path The file path, for the error message.
+	 *
+	 * @return void
+	 *
+	 * @throws RuntimeException On a mismatch.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	private function assertFixity(mixed $stored, string $computed, string $path): void {
+		if (is_string($stored) === false || preg_match('/^[0-9a-fA-F]{64}$/', $stored) !== 1) {
+			return;
+		}
+
+		if (hash_equals(strtolower($stored), $computed) === false) {
+			throw new RuntimeException(
+				'Fixity failure: the SHA-256 recorded for ' . $path
+				. ' does not match its bytes, so it is not transferred'
+			);
+		}
+	}//end assertFixity()
 
 	/**
 	 * Process transport results and update object statuses.

--- a/lib/Service/Edepot/EdepotTransferService.php
+++ b/lib/Service/Edepot/EdepotTransferService.php
@@ -39,7 +39,6 @@ use OCA\OpenRegister\Service\Edepot\Transport\TransportResult;
 use OCP\IAppConfig;
 use OCP\Notification\IManager as INotificationManager;
 use Psr\Log\LoggerInterface;
-use RuntimeException;
 
 /**
  * Orchestrator for e-Depot transfer operations.
@@ -80,6 +79,7 @@ class EdepotTransferService {
 	 * @param IAppConfig $appConfig The app configuration.
 	 * @param INotificationManager $notificationManager The notification manager.
 	 * @param LoggerInterface $logger Logger.
+	 * @param PackagedFileChecksum $packagedFileChecksum Computes, dates and fixity-checks each file's checksum.
 	 */
 	public function __construct(
 		private readonly SipPackageBuilder $sipBuilder,
@@ -90,6 +90,7 @@ class EdepotTransferService {
 		private readonly IAppConfig $appConfig,
 		private readonly INotificationManager $notificationManager,
 		private readonly LoggerInterface $logger,
+		private readonly PackagedFileChecksum $packagedFileChecksum,
 	) {
 	}//end __construct()
 
@@ -432,21 +433,11 @@ class EdepotTransferService {
 	/**
 	 * Get file metadata for an object.
 	 *
-	 * ## The checksum is computed here, every time, and dated here
-	 *
-	 * MDTO requires `checksumDatum`, defined as "Datum waarop de checksum is
-	 * gemaakt". A checksum read from stored data carries no such date, so the
-	 * only honest date is one this method can vouch for: it hashes the bytes
-	 * it is about to package and records that moment.
-	 *
-	 * Recomputing alone would launder a changed file. If the bytes on disk no
-	 * longer match a SHA-256 recorded for them, a fresh checksum would describe
-	 * the changed bytes and the package would look intact. So a stored SHA-256
-	 * that disagrees with the computed one is a fixity failure, and the file is
-	 * refused: the exception reaches the per-object catch in
-	 * {@see self::gatherObjectsWithFiles()}, which excludes the object from
-	 * this transfer and logs it by uuid. A stored value that is not
-	 * SHA-256-shaped cannot be compared and is not used.
+	 * Each checksum is computed and dated at packaging by
+	 * {@see PackagedFileChecksum}, which also refuses a file whose stored
+	 * SHA-256 no longer matches its bytes. That refusal reaches the per-object
+	 * catch in {@see self::gatherObjectsWithFiles()}, which excludes the object
+	 * from this transfer and logs it by uuid.
 	 *
 	 * @param ObjectEntity $object The object.
 	 *
@@ -460,7 +451,7 @@ class EdepotTransferService {
 	 *     isRendition: bool
 	 * }> File metadata array.
 	 *
-	 * @throws RuntimeException When a stored SHA-256 does not match the file's bytes.
+	 * @throws \RuntimeException When a file cannot be read or its stored SHA-256 no longer matches.
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-assemble-sip-packages-for-e-depot-transfer
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-support-multiple-transport-protocols-for-sip-delivery
@@ -484,16 +475,14 @@ class EdepotTransferService {
 				continue;
 			}
 
-			$checksum = (string)hash_file('sha256', $path);
-			$checksumDate = (new DateTime())->format(DateTime::ATOM);
-			$this->assertFixity(stored: ($fileRef['checksum'] ?? null), computed: $checksum, path: $path);
+			$checksum = $this->packagedFileChecksum->compute(path: $path, stored: ($fileRef['checksum'] ?? null));
 
 			$files[] = [
 				'name' => ($fileRef['name'] ?? basename($path)),
 				'size' => (int)($fileRef['size'] ?? filesize($path)),
 				'format' => ($fileRef['mimeType'] ?? ($fileRef['format'] ?? 'application/octet-stream')),
-				'checksum' => $checksum,
-				'checksumDate' => $checksumDate,
+				'checksum' => $checksum['checksum'],
+				'checksumDate' => $checksum['checksumDate'],
 				'path' => $path,
 				'isRendition' => (bool)($fileRef['isRendition'] ?? false),
 			];
@@ -501,32 +490,6 @@ class EdepotTransferService {
 
 		return $files;
 	}//end getObjectFiles()
-
-	/**
-	 * Refuse a file whose bytes no longer match the SHA-256 recorded for it.
-	 *
-	 * @param mixed $stored The checksum stored with the file reference, if any.
-	 * @param string $computed The SHA-256 of the bytes about to be packaged.
-	 * @param string $path The file path, for the error message.
-	 *
-	 * @return void
-	 *
-	 * @throws RuntimeException On a mismatch.
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
-	 */
-	private function assertFixity(mixed $stored, string $computed, string $path): void {
-		if (is_string($stored) === false || preg_match('/^[0-9a-fA-F]{64}$/', $stored) !== 1) {
-			return;
-		}
-
-		if (hash_equals(strtolower($stored), $computed) === false) {
-			throw new RuntimeException(
-				'Fixity failure: the SHA-256 recorded for ' . $path
-				. ' does not match its bytes, so it is not transferred'
-			);
-		}
-	}//end assertFixity()
 
 	/**
 	 * Process transport results and update object statuses.

--- a/lib/Service/Edepot/MdtoBestandGenerator.php
+++ b/lib/Service/Edepot/MdtoBestandGenerator.php
@@ -1,0 +1,263 @@
+<?php
+
+/**
+ * OpenRegister MDTO Bestand Generator
+ *
+ * Generates the MDTO document that describes one file.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Edepot
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Edepot;
+
+use DOMElement;
+
+/**
+ * One MDTO `bestand` document per file.
+ *
+ * MDTO-XML 1.0.1 lets an `MDTO` document hold one `informatieobject` or one
+ * `bestand`, never both, and the MDTO SIP specification says "Elk
+ * informatieobject en elk bestand heeft zijn eigen MDTO metagegevensbestand",
+ * placed next to the file and named `<bestandsnaam>.bestand.MDTO.xml`.
+ *
+ * ## Where each required value comes from
+ *
+ * - `identificatie`: the file's SHA-256, with `identificatieBron` "SHA-256".
+ *   MDTO lets a kenmerk be assigned "met behulp van een bepaalde
+ *   systematiek", and a content hash is one: always available, stable for the
+ *   bytes, and not invented. The file references reaching this class carry no
+ *   other stable identifier.
+ * - `bestandsformaat`: the IANA media type, shaped as the standard's own
+ *   example shows it (code `application/msword`, label `msword`, list
+ *   "IANA Media types"). MDTO prefers a PRONOM id; openregister does not
+ *   identify PRONOM formats, and the standard names media types as the
+ *   alternative.
+ * - `checksumDatum`: the moment the checksum was computed, which
+ *   {@see EdepotTransferService} records as it hashes the bytes it packages.
+ * - `isRepresentatieVan`: the informatieobject this file belongs to, by the
+ *   same naam and identificatie that document carries for itself.
+ *
+ * @psalm-suppress UnusedClass
+ */
+class MdtoBestandGenerator {
+
+	/**
+	 * `identificatieBron` for a content-hash identification.
+	 */
+	public const IDENTIFICATION_SOURCE = 'SHA-256';
+
+	/**
+	 * `checksumAlgoritme` label, as the ChecksumAlgoritme begrippenlijst spells it.
+	 */
+	public const CHECKSUM_ALGORITHM = 'SHA-256';
+
+	/**
+	 * The begrippenlijst the checksum algorithm label comes from.
+	 *
+	 * Named as the Nationaal Archief's own `Bestand` example document names it.
+	 */
+	public const CHECKSUM_ALGORITHM_LIST = 'Begrippenlijst ChecksumAlgoritme MDTO';
+
+	/**
+	 * The begrippenlijst a media type comes from, as the standard's example names it.
+	 */
+	public const MEDIA_TYPE_LIST = 'IANA Media types';
+
+	/**
+	 * Suffix the MDTO SIP specification prescribes for a file's sidecar.
+	 */
+	public const SIDECAR_SUFFIX = '.bestand.MDTO.xml';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param MdtoDocumentWriter $writer The XML primitives.
+	 */
+	public function __construct(
+		private readonly MdtoDocumentWriter $writer,
+	) {
+	}//end __construct()
+
+	/**
+	 * Generate the `bestand` document for one file.
+	 *
+	 * @param array{name: string, size: int|string, format: string, checksum: string, checksumDate: string} $file The file.
+	 * @param array{naam: string, kenmerk: string, bron: string} $represents The informatieobject it represents.
+	 *
+	 * @return string The MDTO XML.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	public function generate(array $file, array $represents): string {
+		[$dom, $bestand] = $this->writer->createDocument(kind: 'bestand');
+
+		$identification = $this->identification(file: $file);
+		$this->writer->identificatie(
+			parent: $bestand,
+			name: 'identificatie',
+			kenmerk: $identification['kenmerk'],
+			bron: $identification['bron']
+		);
+		$this->writer->text(parent: $bestand, name: 'naam', content: (string)$file['name']);
+		$this->writer->text(parent: $bestand, name: 'omvang', content: (string)(int)$file['size']);
+		$this->addFormat(parent: $bestand, mediaType: (string)$file['format']);
+		$this->addChecksum(parent: $bestand, file: $file);
+		$this->writer->verwijzing(
+			parent: $bestand,
+			name: 'isRepresentatieVan',
+			verwijzingNaam: $represents['naam'],
+			kenmerk: $represents['kenmerk'],
+			bron: $represents['bron']
+		);
+
+		return $this->writer->serialise(dom: $dom);
+	}//end generate()
+
+	/**
+	 * The identification a file carries, here and in `heeftRepresentatie`.
+	 *
+	 * One method, used by both documents, so the reference from the
+	 * informatieobject and the identification on the bestand cannot drift.
+	 *
+	 * @param array{checksum: string} $file The file.
+	 *
+	 * @return array{kenmerk: string, bron: string} The identification.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	public function identification(array $file): array {
+		return ['kenmerk' => strtolower((string)$file['checksum']), 'bron' => self::IDENTIFICATION_SOURCE];
+	}//end identification()
+
+	/**
+	 * Name the inputs a `bestand` document cannot be built without.
+	 *
+	 * Each maps to an element the XSD's `bestandType` marks `minOccurs="1"`,
+	 * checked for the lexical form its XSD type demands, so a bad value is
+	 * refused here rather than written into a document the schema rejects:
+	 *
+	 * - `name` for `naam`; `size` for `omvang`, an `xsd:integer`;
+	 * - `format` for `bestandsformaat`;
+	 * - `checksum` for `checksumWaarde`, which must be a SHA-256 because the
+	 *   document declares that algorithm, and a value that is not one would
+	 *   make the declaration false;
+	 * - `checksumDate` for `checksumDatum`, an `xsd:dateTime`.
+	 *
+	 * @param array $files The files.
+	 *
+	 * @return list<string> One entry per missing or malformed input.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-mdto-generator-must-report-the-limits-of-its-own-validation
+	 */
+	public function missingInputs(array $files): array {
+		$missing = [];
+
+		foreach ($files as $index => $file) {
+			$prefix = 'file[' . $index . '].';
+			foreach (['name', 'format'] as $key) {
+				if (($file[$key] ?? '') === '') {
+					$missing[] = $prefix . $key;
+				}
+			}
+
+			if (preg_match('/^\d+$/', (string)($file['size'] ?? '')) !== 1) {
+				$missing[] = $prefix . 'size (a non-negative integer)';
+			}
+
+			if (preg_match('/^[0-9a-fA-F]{64}$/', (string)($file['checksum'] ?? '')) !== 1) {
+				$missing[] = $prefix . 'checksum (a SHA-256)';
+			}
+
+			if (self::isXsdDateTime(value: ($file['checksumDate'] ?? null)) === false) {
+				$missing[] = $prefix . 'checksumDate (an xsd:dateTime)';
+			}
+		}
+
+		return $missing;
+	}//end missingInputs()
+
+	/**
+	 * Add `bestandsformaat` for a media type.
+	 *
+	 * @param DOMElement $parent The bestand element.
+	 * @param string $mediaType The IANA media type, possibly with parameters.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	private function addFormat(DOMElement $parent, string $mediaType): void {
+		$type = strtolower(trim(explode(';', $mediaType)[0]));
+		$slash = strpos($type, '/');
+
+		$label = $type;
+		if ($slash !== false) {
+			$label = substr($type, ($slash + 1));
+		}
+
+		$this->writer->begrip(
+			parent: $parent,
+			name: 'bestandsformaat',
+			label: $label,
+			code: $type,
+			list: self::MEDIA_TYPE_LIST
+		);
+	}//end addFormat()
+
+	/**
+	 * Add the `checksum` group.
+	 *
+	 * @param DOMElement $parent The bestand element.
+	 * @param array{checksum: string, checksumDate: string} $file The file.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	private function addChecksum(DOMElement $parent, array $file): void {
+		$checksum = $this->writer->element(parent: $parent, name: 'checksum');
+
+		$this->writer->begrip(
+			parent: $checksum,
+			name: 'checksumAlgoritme',
+			label: self::CHECKSUM_ALGORITHM,
+			code: null,
+			list: self::CHECKSUM_ALGORITHM_LIST
+		);
+		$this->writer->text(parent: $checksum, name: 'checksumWaarde', content: strtolower((string)$file['checksum']));
+		$this->writer->text(parent: $checksum, name: 'checksumDatum', content: (string)$file['checksumDate']);
+	}//end addChecksum()
+
+	/**
+	 * Whether a value is in the lexical space of `xsd:dateTime`.
+	 *
+	 * @param mixed $value The value.
+	 *
+	 * @return bool True when it is.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	private static function isXsdDateTime(mixed $value): bool {
+		if (is_string($value) === false) {
+			return false;
+		}
+
+		return preg_match('/^-?\d{4,}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})?$/', $value) === 1;
+	}//end isXsdDateTime()
+}//end class

--- a/lib/Service/Edepot/MdtoDocumentWriter.php
+++ b/lib/Service/Edepot/MdtoDocumentWriter.php
@@ -1,0 +1,242 @@
+<?php
+
+/**
+ * OpenRegister MDTO Document Writer
+ *
+ * The XML primitives both MDTO document kinds are built from.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Edepot
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Edepot;
+
+use DOMDocument;
+use DOMElement;
+use InvalidArgumentException;
+
+/**
+ * Builds the MDTO document shell and the XSD's reusable groups.
+ *
+ * Knows XML and MDTO-XML 1.0.1, and nothing about openregister objects. Each
+ * method writes one of the XSD's named types exactly as the schema declares
+ * it, so an element built here is shaped correctly regardless of who calls.
+ *
+ * @psalm-suppress UnusedClass
+ */
+class MdtoDocumentWriter {
+
+	/**
+	 * MDTO namespace URI.
+	 */
+	public const MDTO_NAMESPACE = 'https://www.nationaalarchief.nl/mdto';
+
+	/**
+	 * MDTO namespace prefix.
+	 */
+	public const MDTO_PREFIX = 'mdto';
+
+	/**
+	 * The schema version this writer targets, published as a URL.
+	 *
+	 * The MDTO SIP specification requires every sidecar to carry the MDTO
+	 * version it follows; the Nationaal Archief's own example documents do it
+	 * through `xsi:schemaLocation`, pointing at this URL.
+	 */
+	public const SCHEMA_LOCATION = 'https://www.nationaalarchief.nl/mdto/MDTO-XML1.0.1.xsd';
+
+	/**
+	 * XML Schema instance namespace.
+	 */
+	private const XSI_NAMESPACE = 'http://www.w3.org/2001/XMLSchema-instance';
+
+	/**
+	 * Create an MDTO document and its single content element.
+	 *
+	 * The XSD declares one global element, `MDTO`, whose content is a CHOICE
+	 * of exactly one `informatieobject` or one `bestand`. So a document holds
+	 * one of them and never both, which is why a file gets its own document.
+	 *
+	 * @param string $kind Either `informatieobject` or `bestand`.
+	 *
+	 * @return array{0: DOMDocument, 1: DOMElement} The document and the content element to fill.
+	 *
+	 * @throws InvalidArgumentException When the kind is neither.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	public function createDocument(string $kind): array {
+		if ($kind !== 'informatieobject' && $kind !== 'bestand') {
+			throw new InvalidArgumentException('An MDTO document holds an informatieobject or a bestand, not ' . $kind);
+		}
+
+		$dom = new DOMDocument('1.0', 'UTF-8');
+		$dom->formatOutput = true;
+
+		$root = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':MDTO');
+		$root->setAttributeNS(
+			self::XSI_NAMESPACE,
+			'xsi:schemaLocation',
+			self::MDTO_NAMESPACE . ' ' . self::SCHEMA_LOCATION
+		);
+		$dom->appendChild($root);
+
+		$content = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':' . $kind);
+		$root->appendChild($content);
+
+		return [$dom, $content];
+	}//end createDocument()
+
+	/**
+	 * Serialise a document built by {@see self::createDocument()}.
+	 *
+	 * @param DOMDocument $dom The document.
+	 *
+	 * @return string The XML.
+	 *
+	 * @throws InvalidArgumentException When serialisation fails.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	public function serialise(DOMDocument $dom): string {
+		$xml = $dom->saveXML();
+		if ($xml === false) {
+			throw new InvalidArgumentException('Failed to serialise the MDTO document');
+		}
+
+		return $xml;
+	}//end serialise()
+
+	/**
+	 * Add a simple text element.
+	 *
+	 * @param DOMElement $parent The parent element.
+	 * @param string $name The element name, without prefix.
+	 * @param string $content The text content.
+	 *
+	 * @return DOMElement The new element.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	public function text(DOMElement $parent, string $name, string $content): DOMElement {
+		$element = $this->element(parent: $parent, name: $name);
+		$element->textContent = $content;
+
+		return $element;
+	}//end text()
+
+	/**
+	 * Add an empty element to be filled by the caller.
+	 *
+	 * @param DOMElement $parent The parent element.
+	 * @param string $name The element name, without prefix.
+	 *
+	 * @return DOMElement The new element.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	public function element(DOMElement $parent, string $name): DOMElement {
+		$document = $parent->ownerDocument;
+		if ($document === null) {
+			throw new InvalidArgumentException('Cannot add an MDTO element to a detached node');
+		}
+
+		$element = $document->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':' . $name);
+		$parent->appendChild($element);
+
+		return $element;
+	}//end element()
+
+	/**
+	 * Add a `begripGegevens` element.
+	 *
+	 * The XSD makes `begripLabel` and `begripBegrippenlijst` both
+	 * `minOccurs="1"`, so the list name is never optional.
+	 *
+	 * @param DOMElement $parent The parent element.
+	 * @param string $name The element name, without prefix.
+	 * @param string $label The begripLabel.
+	 * @param string|null $code The begripCode, omitted when null or empty.
+	 * @param string $list The begrippenlijst name.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	public function begrip(DOMElement $parent, string $name, string $label, ?string $code, string $list): void {
+		$element = $this->element(parent: $parent, name: $name);
+
+		$this->text(parent: $element, name: 'begripLabel', content: $label);
+		if (($code ?? '') !== '') {
+			$this->text(parent: $element, name: 'begripCode', content: (string)$code);
+		}
+
+		$this->verwijzing(parent: $element, name: 'begripBegrippenlijst', verwijzingNaam: $list);
+	}//end begrip()
+
+	/**
+	 * Add a `verwijzingGegevens` element.
+	 *
+	 * @param DOMElement $parent The parent element.
+	 * @param string $name The element name, without prefix.
+	 * @param string $verwijzingNaam The name of the referenced object.
+	 * @param string|null $kenmerk The reference key, omitted with its bron when null or empty.
+	 * @param string|null $bron The source within which the key is unique.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	public function verwijzing(
+		DOMElement $parent,
+		string $name,
+		string $verwijzingNaam,
+		?string $kenmerk = null,
+		?string $bron = null,
+	): void {
+		$element = $this->element(parent: $parent, name: $name);
+		$this->text(parent: $element, name: 'verwijzingNaam', content: $verwijzingNaam);
+
+		if (($kenmerk ?? '') !== '' && ($bron ?? '') !== '') {
+			$this->identificatie(
+				parent: $element,
+				name: 'verwijzingIdentificatie',
+				kenmerk: (string)$kenmerk,
+				bron: (string)$bron
+			);
+		}
+	}//end verwijzing()
+
+	/**
+	 * Add an `identificatieGegevens` element.
+	 *
+	 * @param DOMElement $parent The parent element.
+	 * @param string $name The element name, without prefix.
+	 * @param string $kenmerk The identificatieKenmerk.
+	 * @param string $bron The identificatieBron.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	public function identificatie(DOMElement $parent, string $name, string $kenmerk, string $bron): void {
+		$element = $this->element(parent: $parent, name: $name);
+		$this->text(parent: $element, name: 'identificatieKenmerk', content: $kenmerk);
+		$this->text(parent: $element, name: 'identificatieBron', content: $bron);
+	}//end identificatie()
+}//end class

--- a/lib/Service/Edepot/MdtoSourceReader.php
+++ b/lib/Service/Edepot/MdtoSourceReader.php
@@ -175,7 +175,7 @@ class MdtoSourceReader {
 			return [
 				'type' => $label,
 				'description' => $this->stringAt(value: $declared, key: 'description'),
-				'startDate' => $this->stringAt(value: $declared, key: 'startDate'),
+				'startDate' => $this->dateOnly(value: $this->stringAt(value: $declared, key: 'startDate')),
 			];
 		}
 
@@ -212,7 +212,11 @@ class MdtoSourceReader {
 	}//end legalHoldRestriction()
 
 	/**
-	 * Accept one dekkingInTijd entry only when it is complete.
+	 * Accept one dekkingInTijd entry only when it is complete and well-formed.
+	 *
+	 * Both dates must be an `xsd:gYear`, `xsd:gYearMonth` or `xsd:date`, the
+	 * union the XSD declares. A start in any other form makes the entry
+	 * incomplete, so it is dropped; an end in any other form is dropped alone.
 	 *
 	 * @param mixed $entry The declared entry.
 	 *
@@ -226,12 +230,12 @@ class MdtoSourceReader {
 		}
 
 		$type = $this->stringAt(value: $entry, key: 'type');
-		$start = $this->stringAt(value: $entry, key: 'start');
+		$start = $this->coverageDate(value: $this->stringAt(value: $entry, key: 'start'));
 		if ($type === null || $start === null) {
 			return null;
 		}
 
-		return ['type' => $type, 'start' => $start, 'end' => $this->stringAt(value: $entry, key: 'end')];
+		return ['type' => $type, 'start' => $start, 'end' => $this->coverageDate(value: $this->stringAt(value: $entry, key: 'end'))];
 	}//end completeCoverageEntry()
 
 	/**
@@ -315,6 +319,23 @@ class MdtoSourceReader {
 
 		return null;
 	}//end stringAt()
+
+	/**
+	 * Accept a date only in a form the XSD's dekkingInTijd union allows.
+	 *
+	 * @param string|null $value The declared date.
+	 *
+	 * @return string|null The value when it is a gYear, gYearMonth or date; null otherwise.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	private function coverageDate(?string $value): ?string {
+		if ($value === null || preg_match('/^\d{4}(-\d{2}(-\d{2})?)?$/', $value) !== 1) {
+			return null;
+		}
+
+		return $value;
+	}//end coverageDate()
 
 	/**
 	 * Reduce an ISO-8601 timestamp to the xsd:date the termijn element needs.

--- a/lib/Service/Edepot/MdtoXmlGenerator.php
+++ b/lib/Service/Edepot/MdtoXmlGenerator.php
@@ -41,10 +41,20 @@ use Psr\Log\LoggerInterface;
  *
  * Its output validates against `lib/Resources/mdto/MDTO-XML1.0.1.xsd`, a
  * verbatim copy of the Nationaal Archief's schema. `MdtoXmlGeneratorXsdTest`
- * runs `DOMDocument::schemaValidate()` over documents for representative
- * objects, with and without files and optional elements, so the claim is
- * tested rather than asserted. Where the XSD cannot see a problem because the
- * value is a free string, the rule is stated at the element below.
+ * validates documents for representative objects, with and without files and
+ * optional elements, so the claim is tested rather than asserted. Where the
+ * XSD cannot see a problem because the value is a free string, the rule is
+ * stated at the element below.
+ *
+ * ## If you validate at runtime, use schemaValidateSource()
+ *
+ * Nextcloud's XXE protection sets libxml's external-entity loader to return
+ * null, so `DOMDocument::schemaValidate($path)` cannot even read the schema
+ * from disk inside a running instance: it fails with "Failed to load external
+ * entity because the resolver function returned null". Read the file with
+ * `file_get_contents()` and pass it to `schemaValidateSource()`, which never
+ * consults the loader for the top-level schema. That is enough because the
+ * vendored XSD imports and includes nothing; do not loosen the loader.
  *
  * ## Where MDTO requires a value openregister cannot source
  *

--- a/lib/Service/Edepot/MdtoXmlGenerator.php
+++ b/lib/Service/Edepot/MdtoXmlGenerator.php
@@ -3,9 +3,8 @@
 /**
  * OpenRegister MDTO XML Generator
  *
- * Generates MDTO metadata for objects eligible for e-Depot transfer.
- * Targets the MDTO (Metagegevens Duurzaam Toegankelijke Overheidsinformatie)
- * schema published by the Nationaal Archief, XML syntax version 1.0.1.
+ * Generates MDTO metadata for objects eligible for e-Depot transfer, valid
+ * against the Nationaal Archief's MDTO-XML 1.0.1 schema.
  *
  * SPDX-License-Identifier: EUPL-1.2
  * SPDX-FileCopyrightText: 2026 Conduction B.V.
@@ -22,14 +21,13 @@
  * @link https://www.OpenRegister.app
  *
  * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-generate-mdto-compliant-xml-metadata-per-object
- * @spec openspec/specs/edepot-transfer/spec.md
+ * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
  */
 
 declare(strict_types=1);
 
 namespace OCA\OpenRegister\Service\Edepot;
 
-use DOMDocument;
 use DOMElement;
 use InvalidArgumentException;
 use OCA\OpenRegister\Db\ObjectEntity;
@@ -37,45 +35,30 @@ use OCP\IAppConfig;
 use Psr\Log\LoggerInterface;
 
 /**
- * Generator for MDTO metadata documents.
+ * Generator for MDTO `informatieobject` documents, and the entry point for a file's `bestand` document.
  *
- * ## What this generator does and does not claim
+ * ## What this generator claims, and what holds it to the claim
  *
- * It emits a well-formed XML document in the MDTO namespace carrying the
- * elements listed below. It does NOT claim the result is valid MDTO, and it
- * cannot: the MDTO XSD (`MDTO-XML1.0.1.xsd`) is not vendored in this
- * repository and no code path validates against it. Every statement about
- * which elements MDTO requires is cited in the spec requirements this class
- * points at, taken from the Nationaal Archief metagegevensschema and XSD.
+ * Its output validates against `lib/Resources/mdto/MDTO-XML1.0.1.xsd`, a
+ * verbatim copy of the Nationaal Archief's schema. `MdtoXmlGeneratorXsdTest`
+ * runs `DOMDocument::schemaValidate()` over documents for representative
+ * objects, with and without files and optional elements, so the claim is
+ * tested rather than asserted. Where the XSD cannot see a problem because the
+ * value is a free string, the rule is stated at the element below.
  *
- * Emitted: `identificatie`, `naam`, `aggregatieniveau`, `dekkingInTijd`,
- * `event`, `waardering`, `bewaartermijn`, `informatiecategorie`,
- * `archiefvormer`, `beperkingGebruik`, plus a `toelichting` and nested
- * `bestand` elements.
+ * ## Where MDTO requires a value openregister cannot source
  *
- * ## Known deviations from MDTO-XML1.0.1, NOT fixed here
+ * Two required elements can lack a source. Each is filled with the term MDTO's
+ * own begrippenlijst defines for "not recorded", never with a guess:
  *
- * These predate this class's current shape and are recorded so nobody reads a
- * successful `generate()` as conformance. Each one changes the shape of an
- * element that already ships, so correcting them is a separate change with a
- * blast radius that reaches every receiving e-Depot.
+ * - `beperkingGebruik`, when no restriction is declared and no legal hold is
+ *   active: `Nader te bepalen` from BeperkingGebruikTypeLijst.
+ * - `waardering`, when the record's appraisal is itself undecided: `Nader te
+ *   bepalen` from Waarderingen. That is a real value (`nog_niet_bepaald`), not
+ *   a missing one.
  *
- * 1. The document root is `mdto:informatieobject`. The XSD declares the root
- *    element `MDTO`, with `informatieobject` and `bestand` as a choice inside
- *    it.
- * 2. `bestand` is emitted as a CHILD of `informatieobject`. The XSD makes it a
- *    sibling, related back by `isRepresentatieVan`.
- * 3. `waardering`, `informatiecategorie` and `bestandsformaat` are emitted as
- *    plain strings. The XSD types all three as `begripGegevens`.
- * 4. `bewaartermijn` is emitted as a plain ISO-8601 duration string. The XSD
- *    types it as `termijnGegevens`.
- * 5. `checksumDatum` is never emitted although the XSD requires it, and
- *    `checksumAlgoritme` is a plain string rather than `begripGegevens`.
- * 6. `toelichting` is not an MDTO element at all. The XSD's nearest equivalent
- *    is `omschrijving`.
- *
- * The elements this class ADDS are shaped per the XSD, so they are correct
- * even while their siblings above are not.
+ * {@see self::collectMdtoRequiredElementGaps()} reports the first, so a
+ * default is never mistaken for a recorded fact.
  *
  * @psalm-suppress UnusedClass
  *
@@ -84,14 +67,14 @@ use Psr\Log\LoggerInterface;
 class MdtoXmlGenerator {
 
 	/**
-	 * MDTO namespace URI.
+	 * MDTO namespace URI, kept here for existing callers.
 	 */
-	public const MDTO_NAMESPACE = 'https://www.nationaalarchief.nl/mdto';
+	public const MDTO_NAMESPACE = MdtoDocumentWriter::MDTO_NAMESPACE;
 
 	/**
-	 * MDTO namespace prefix.
+	 * MDTO namespace prefix, kept here for existing callers.
 	 */
-	public const MDTO_PREFIX = 'mdto';
+	public const MDTO_PREFIX = MdtoDocumentWriter::MDTO_PREFIX;
 
 	/**
 	 * The MDTO begrippenlijst that `aggregatieniveau` labels come from.
@@ -104,14 +87,45 @@ class MdtoXmlGenerator {
 	public const USE_RESTRICTION_LIST = 'BeperkingGebruikTypeLijst';
 
 	/**
-	 * Mapping from archiefnominatie values to MDTO waardering values.
+	 * The BeperkingGebruikTypeLijst term for a restriction nobody has recorded.
 	 *
-	 * @var array<string, string>
+	 * Defined by the standard as "Er is mogelijk een beperking, maar de aard
+	 * daarvan is niet vastgelegd als type beperking en niet vastgelegd in de
+	 * metagegevens", which describes exactly an object with no declared
+	 * restriction and no legal hold.
 	 */
-	private const WAARDERING_MAP = [
-		'vernietigen' => 'vernietigen',
-		'bewaren' => 'bewaren',
-		'nog_niet_bepaald' => 'nog niet bepaald',
+	public const USE_RESTRICTION_UNRECORDED = 'Nader te bepalen';
+
+	/**
+	 * The MDTO begrippenlijst `waardering` comes from. It is CLOSED.
+	 */
+	public const APPRAISAL_LIST = 'Waarderingen';
+
+	/**
+	 * The begrippenlijst name used for `informatiecategorie` when the record
+	 * does not say which selectielijst its category came from.
+	 */
+	public const CATEGORY_LIST_FALLBACK = 'Selectielijst';
+
+	/**
+	 * `archiefnominatie` to the closed Waarderingen list: code and label.
+	 *
+	 * Waarderingen is declared "Gesloten", so only its three terms are valid,
+	 * and this generator used to emit `bewaren`, `vernietigen` and `nog niet
+	 * bepaald`, none of which is on it. The XSD cannot catch that, because
+	 * `begripLabel` is a plain string, so the rule lives here.
+	 *
+	 * `vernietigen` maps to V, "Tijdelijk te bewaren", which the standard
+	 * defines as "dient tijdelijk bewaard te worden en na afloop van de
+	 * bewaartermijn vernietigd te worden".
+	 *
+	 * @var array<string, array{0: string, 1: string}>
+	 */
+	public const APPRAISAL_MAP = [
+		'bewaren' => ['B', 'Blijvend te bewaren'],
+		'blijvend_bewaren' => ['B', 'Blijvend te bewaren'],
+		'vernietigen' => ['V', 'Tijdelijk te bewaren'],
+		'nog_niet_bepaald' => ['N', 'Nader te bepalen'],
 	];
 
 	/**
@@ -121,139 +135,131 @@ class MdtoXmlGenerator {
 	 * @param LoggerInterface $logger Logger for error and info messages.
 	 * @param MdtoEventMapper $eventMapper Source of the MDTO event history.
 	 * @param MdtoSourceReader $sourceReader Resolver for the declared archival values.
+	 * @param MdtoDocumentWriter $writer The XML primitives.
+	 * @param MdtoBestandGenerator $bestandGenerator Builder of a file's own document.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
 		private readonly MdtoEventMapper $eventMapper,
 		private readonly MdtoSourceReader $sourceReader,
+		private readonly MdtoDocumentWriter $writer,
+		private readonly MdtoBestandGenerator $bestandGenerator,
 	) {
 	}//end __construct()
 
 	/**
-	 * Generate MDTO XML for an object.
+	 * Generate the MDTO `informatieobject` document for an object.
 	 *
-	 * Element order follows the XSD's `informatieobjectType` sequence for the
-	 * elements that appear in it; the two that do not (`toelichting` and the
-	 * nested `bestand`) come last.
-	 *
-	 * A successful return does NOT mean the document is valid MDTO. See
-	 * {@see self::assertGeneratorPreconditions()} for what was actually
-	 * checked and {@see self::collectMdtoRequiredElementGaps()} for what MDTO
-	 * requires that this document will be missing.
+	 * The files are not embedded: each is referenced by `heeftRepresentatie`
+	 * and described by its own document from {@see self::generateBestand()}.
+	 * Element order follows the XSD's `informatieobjectType` sequence.
 	 *
 	 * @param ObjectEntity $object The object to generate XML for.
-	 * @param array $files Associated file metadata (name, size, format, checksum).
+	 * @param array $files Associated file metadata (name, size, format, checksum, checksumDate).
 	 *
-	 * @return string The generated MDTO XML string.
+	 * @return string The MDTO XML.
 	 *
 	 * @throws InvalidArgumentException If a precondition is not met.
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-generate-mdto-compliant-xml-metadata-per-object
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-mdto-generator-must-report-the-limits-of-its-own-validation
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
 	 */
 	public function generate(ObjectEntity $object, array $files = []): string {
 		$retention = ($object->getRetention() ?? []);
 
 		$this->assertGeneratorPreconditions(object: $object, retention: $retention, files: $files);
-		$this->reportMdtoRequiredElementGaps(object: $object, files: $files);
+		$this->reportMdtoRequiredElementGaps(object: $object);
 
-		$dom = new DOMDocument('1.0', 'UTF-8');
-		$dom->formatOutput = true;
+		[$dom, $root] = $this->writer->createDocument(kind: 'informatieobject');
 
-		$root = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':informatieobject');
-		$dom->appendChild($root);
+		$self = $this->representedObject(object: $object);
+		$this->writer->identificatie(parent: $root, name: 'identificatie', kenmerk: $self['kenmerk'], bron: $self['bron']);
+		$this->writer->text(parent: $root, name: 'naam', content: $self['naam']);
+		$this->addAggregationLevel(parent: $root, object: $object);
 
-		$this->addIdentification(dom: $dom, parent: $root, object: $object);
-		$this->addName(dom: $dom, parent: $root, object: $object);
-		$this->addAggregationLevel(dom: $dom, parent: $root, object: $object);
-		$this->addTemporalCoverage(dom: $dom, parent: $root, object: $object);
-		$this->addEvents(dom: $dom, parent: $root, object: $object);
-		$this->addRating(dom: $dom, parent: $root, retention: $retention);
-		$this->addRetentionPeriod(dom: $dom, parent: $root, retention: $retention);
-		$this->addInformatiecategorie(dom: $dom, parent: $root, retention: $retention);
-		$this->addArchiefvormer(dom: $dom, parent: $root);
-		$this->addUseRestriction(dom: $dom, parent: $root, object: $object);
-
-		if (empty($retention['toelichting']) === false) {
-			$this->addTextElement(dom: $dom, parent: $root, name: 'toelichting', content: $retention['toelichting']);
+		if (is_string($retention['toelichting'] ?? null) === true && $retention['toelichting'] !== '') {
+			$this->writer->text(parent: $root, name: 'omschrijving', content: $retention['toelichting']);
 		}
 
-		foreach ($files as $file) {
-			$this->addFile(dom: $dom, parent: $root, file: $file);
-		}
+		$this->addTemporalCoverage(parent: $root, object: $object);
+		$this->addEvents(parent: $root, object: $object);
+		$this->addRating(parent: $root, retention: $retention);
+		$this->addRetentionPeriod(parent: $root, retention: $retention);
+		$this->addInformatiecategorie(parent: $root, retention: $retention);
+		$this->addRepresentations(parent: $root, files: $files);
+		$this->addArchiefvormer(parent: $root);
+		$this->addUseRestriction(parent: $root, object: $object);
 
-		$xml = $dom->saveXML();
-		if ($xml === false) {
-			throw new InvalidArgumentException('Failed to generate MDTO XML');
-		}
-
-		return $xml;
+		return $this->writer->serialise(dom: $dom);
 	}//end generate()
 
 	/**
-	 * List the MDTO-required elements this document will NOT carry.
+	 * Generate the MDTO `bestand` document for one of the object's files.
 	 *
-	 * This is the honest counterpart to
-	 * {@see self::assertGeneratorPreconditions()}. The preconditions are what
-	 * the generator needs in order to emit anything; this is what MDTO's XSD
-	 * marks `minOccurs="1"` and this object cannot supply. It reports rather
-	 * than throws: refusing a transfer over an element no source in this
-	 * system writes would stop every transfer, and that is a decision for the
-	 * archivist and not for a serialiser.
+	 * @param ObjectEntity $object The object the file represents.
+	 * @param array $file The file metadata (name, size, format, checksum, checksumDate).
+	 *
+	 * @return string The MDTO XML.
+	 *
+	 * @throws InvalidArgumentException If a file input is missing or malformed.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	public function generateBestand(ObjectEntity $object, array $file): string {
+		$missing = $this->bestandGenerator->missingInputs(files: [$file]);
+		if (empty($missing) === false) {
+			throw new InvalidArgumentException(
+				'Cannot generate the MDTO bestand document for object ' . $object->getUuid()
+				. '. These inputs are missing or malformed: ' . implode(', ', $missing)
+			);
+		}
+
+		return $this->bestandGenerator->generate(file: $file, represents: $this->representedObject(object: $object));
+	}//end generateBestand()
+
+	/**
+	 * List the MDTO-required elements this document fills with a default.
+	 *
+	 * The output validates, so no required element is ABSENT. What this
+	 * reports is the required element whose value is the standard's "not
+	 * recorded" term rather than something the object says, so a reader of
+	 * the log can tell a default from a fact.
 	 *
 	 * @param ObjectEntity $object The object to inspect.
-	 * @param array $files Associated file metadata.
 	 *
-	 * @return list<string> One line per gap; empty when there is none.
+	 * @return list<string> One line per defaulted element; empty when there is none.
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-mdto-generator-must-report-the-limits-of-its-own-validation
 	 */
-	public function collectMdtoRequiredElementGaps(ObjectEntity $object, array $files = []): array {
+	public function collectMdtoRequiredElementGaps(ObjectEntity $object): array {
 		$gaps = [];
 
 		if ($this->sourceReader->useRestriction(object: $object) === null) {
-			$gaps[] = 'beperkingGebruik: MDTO-XML1.0.1 declares minOccurs="1" on informatieobject, '
-				. 'and this object declares no use restriction and carries no active legal hold';
-		}
-
-		if (empty($files) === false) {
-			$gaps[] = 'bestand/checksum/checksumDatum: MDTO-XML1.0.1 declares minOccurs="1" on '
-				. 'checksumGegevens and this generator never emits it';
+			$gaps[] = 'beperkingGebruik: MDTO-XML1.0.1 declares minOccurs="1", and this object declares no '
+				. 'use restriction and carries no active legal hold, so it is emitted as "'
+				. self::USE_RESTRICTION_UNRECORDED . '"';
 		}
 
 		return $gaps;
 	}//end collectMdtoRequiredElementGaps()
 
 	/**
-	 * Check the inputs this generator needs, and only those.
+	 * Check the inputs the generator needs, and refuse what the XSD would reject.
 	 *
-	 * ## Read this before treating a pass as MDTO validity
+	 * A pass here means the generator can build a document the XSD accepts
+	 * for the elements it emits. It is not a judgement of the record, and it
+	 * does not replace the schema: `MdtoXmlGeneratorXsdTest` is what shows the
+	 * output validates.
 	 *
-	 * This method establishes exactly one thing: the generator has the inputs
-	 * it needs to emit the elements it emits. It is NOT an MDTO validity
-	 * check, it does not consult an XSD, and a document that passes it can
-	 * still be rejected by a receiving e-Depot. The class docblock lists six
-	 * structural deviations that this method does not look at.
-	 *
-	 * What it checks, and on whose authority:
-	 *
-	 * - `uuid` and the `organisation_identifier` app setting, which fill
-	 *   `identificatie/identificatieKenmerk` and `identificatie/identificatieBron`.
-	 *   Both are `minOccurs="1"` in the XSD's `identificatieGegevens`, and
-	 *   `identificatie` itself is `minOccurs="1"` on `objectType`.
-	 * - a non-empty `naam`, `minOccurs="1"` on `objectType`.
-	 * - `retention.archiefnominatie`, which fills `waardering`,
-	 *   `minOccurs="1"` on `informatieobjectType`.
-	 * - per file: `name`, `size`, `format` and `checksum`. `omvang`,
-	 *   `bestandsformaat` and `checksum` are all `minOccurs="1"` on
-	 *   `bestandType`, and `naam` is inherited from `objectType`. Before this
-	 *   check a file array missing a key produced a PHP warning and an empty
-	 *   element rather than a refusal.
-	 * - `retention.bewaartermijn`. This one is a LOCAL rule and stricter than
-	 *   MDTO: the XSD makes `bewaartermijn` `minOccurs="0"`. openregister
-	 *   refuses to transfer a record whose retention period is unknown, which
-	 *   is this repository's own policy and not the standard's.
+	 * - `uuid` and the `organisation_identifier` setting fill `identificatie`.
+	 * - a non-empty `naam`.
+	 * - `retention.archiefnominatie`, which must map onto the CLOSED
+	 *   Waarderingen list; see {@see self::APPRAISAL_MAP}.
+	 * - `retention.bewaartermijn`, which must be an `xsd:duration`. Requiring
+	 *   it at all is a LOCAL rule, stricter than MDTO, where `bewaartermijn`
+	 *   is `minOccurs="0"`.
+	 * - every file's inputs; see {@see MdtoBestandGenerator::missingInputs()}.
 	 *
 	 * @param ObjectEntity $object The object to check.
 	 * @param array<string,mixed> $retention The retention metadata.
@@ -261,7 +267,7 @@ class MdtoXmlGenerator {
 	 *
 	 * @return void
 	 *
-	 * @throws InvalidArgumentException If an input is missing.
+	 * @throws InvalidArgumentException If an input is missing or malformed.
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-mdto-generator-must-report-the-limits-of-its-own-validation
 	 */
@@ -272,24 +278,24 @@ class MdtoXmlGenerator {
 			$missing[] = 'uuid';
 		}
 
-		if (empty($this->resolveName(object: $object)) === true) {
+		if ($this->resolveName(object: $object) === '') {
 			$missing[] = 'naam';
 		}
 
-		if (empty($retention['archiefnominatie']) === true) {
-			$missing[] = 'retention.archiefnominatie';
+		$nominatie = ($retention['archiefnominatie'] ?? null);
+		if (is_string($nominatie) === false || isset(self::APPRAISAL_MAP[$nominatie]) === false) {
+			$missing[] = 'retention.archiefnominatie (one of: ' . implode(', ', array_keys(self::APPRAISAL_MAP)) . ')';
 		}
 
-		if (empty($retention['bewaartermijn']) === true) {
-			$missing[] = 'retention.bewaartermijn';
+		if (self::isXsdDuration(value: ($retention['bewaartermijn'] ?? null)) === false) {
+			$missing[] = 'retention.bewaartermijn (an ISO-8601 / xsd:duration such as P20Y)';
 		}
 
-		$archiefvormer = $this->appConfig->getValueString('openregister', 'organisation_identifier', '');
-		if (empty($archiefvormer) === true) {
+		if ($this->appConfig->getValueString('openregister', 'organisation_identifier', '') === '') {
 			$missing[] = 'app_setting:organisation_identifier';
 		}
 
-		$missing = array_merge($missing, $this->missingFileInputs(files: $files));
+		$missing = array_merge($missing, $this->bestandGenerator->missingInputs(files: $files));
 
 		if (empty($missing) === false) {
 			$missingStr = implode(', ', $missing);
@@ -306,124 +312,67 @@ class MdtoXmlGenerator {
 	}//end assertGeneratorPreconditions()
 
 	/**
-	 * Name the per-file inputs a `bestand` element cannot be built without.
-	 *
-	 * `omvang`, `bestandsformaat` and `checksum` are `minOccurs="1"` on the
-	 * XSD's `bestandType`, and `naam` is inherited from `objectType`. Before
-	 * this check a file array missing a key produced a PHP warning and an
-	 * empty element rather than a refusal.
-	 *
-	 * @param array $files Associated file metadata.
-	 *
-	 * @return list<string> One entry per missing input.
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-mdto-generator-must-report-the-limits-of-its-own-validation
-	 */
-	private function missingFileInputs(array $files): array {
-		$missing = [];
-
-		foreach ($files as $index => $file) {
-			foreach (['name', 'size', 'format', 'checksum'] as $key) {
-				if (($file[$key] ?? '') === '') {
-					$missing[] = 'file[' . $index . '].' . $key;
-				}
-			}
-		}
-
-		return $missing;
-	}//end missingFileInputs()
-
-	/**
-	 * Log the MDTO-required elements the document will be missing.
+	 * Log the MDTO-required elements the document fills with a default.
 	 *
 	 * @param ObjectEntity $object The object being exported.
-	 * @param array $files Associated file metadata.
 	 *
 	 * @return void
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-mdto-generator-must-report-the-limits-of-its-own-validation
 	 */
-	private function reportMdtoRequiredElementGaps(ObjectEntity $object, array $files): void {
-		$gaps = $this->collectMdtoRequiredElementGaps(object: $object, files: $files);
+	private function reportMdtoRequiredElementGaps(ObjectEntity $object): void {
+		$gaps = $this->collectMdtoRequiredElementGaps(object: $object);
 		if (empty($gaps) === true) {
 			return;
 		}
 
 		$this->logger->warning(
-			message: '[MdtoXmlGenerator] Document is not valid MDTO: required elements are absent',
+			message: '[MdtoXmlGenerator] Required MDTO elements carry the standard\'s "not recorded" term',
 			context: ['objectUuid' => $object->getUuid(), 'gaps' => $gaps]
 		);
 	}//end reportMdtoRequiredElementGaps()
 
 	/**
-	 * Add the identificatie element to the XML document.
+	 * The object's own naam and identificatie, as a document refers to it.
 	 *
-	 * @param DOMDocument $dom The DOM document.
-	 * @param DOMElement $parent The parent element.
-	 * @param ObjectEntity $object The source object.
+	 * Used for this document's `identificatie` and for every file's
+	 * `isRepresentatieVan`, so the two cannot disagree.
 	 *
-	 * @return void
+	 * @param ObjectEntity $object The object.
 	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-generate-mdto-compliant-xml-metadata-per-object
+	 * @return array{naam: string, kenmerk: string, bron: string} The reference.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
 	 */
-	private function addIdentification(DOMDocument $dom, DOMElement $parent, ObjectEntity $object): void {
-		$identification = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':identificatie');
-
-		$reference = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':identificatieKenmerk');
-		$reference->textContent = $object->getUuid();
-		$identification->appendChild($reference);
-
-		$source = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':identificatieBron');
-		$source->textContent = $this->organisationIdentifier();
-		$identification->appendChild($source);
-
-		$parent->appendChild($identification);
-	}//end addIdentification()
-
-	/**
-	 * Add the naam element to the XML document.
-	 *
-	 * @param DOMDocument $dom The DOM document.
-	 * @param DOMElement $parent The parent element.
-	 * @param ObjectEntity $object The source object.
-	 *
-	 * @return void
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-generate-mdto-compliant-xml-metadata-per-object
-	 */
-	private function addName(DOMDocument $dom, DOMElement $parent, ObjectEntity $object): void {
-		$this->addTextElement(
-			dom: $dom,
-			parent: $parent,
-			name: 'naam',
-			content: $this->resolveName(object: $object)
-		);
-	}//end addName()
+	private function representedObject(ObjectEntity $object): array {
+		return [
+			'naam' => $this->resolveName(object: $object),
+			'kenmerk' => (string)$object->getUuid(),
+			'bron' => $this->organisationIdentifier(),
+		];
+	}//end representedObject()
 
 	/**
 	 * Add the aggregatieniveau element when the object declares one.
 	 *
 	 * The sources and the rule for when there is no value belong to
 	 * {@see MdtoSourceReader::aggregationLevel()}. Labels come from MDTO's
-	 * `Aggregatieniveaus` begrippenlijst: Archief, Serie, Dossier,
-	 * Archiefstuk.
+	 * `Aggregatieniveaus` begrippenlijst: Archief, Serie, Dossier, Archiefstuk.
 	 *
-	 * @param DOMDocument $dom The DOM document.
-	 * @param DOMElement $parent The parent element.
+	 * @param DOMElement $parent The informatieobject element.
 	 * @param ObjectEntity $object The source object.
 	 *
 	 * @return void
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-emit-mdto-aggregatieniveau-beperkinggebruik-and-dekkingintijd-from-their-declared-sources
 	 */
-	private function addAggregationLevel(DOMDocument $dom, DOMElement $parent, ObjectEntity $object): void {
+	private function addAggregationLevel(DOMElement $parent, ObjectEntity $object): void {
 		$level = $this->sourceReader->aggregationLevel(object: $object);
 		if ($level === null) {
 			return;
 		}
 
-		$this->addBegrip(
-			dom: $dom,
+		$this->writer->begrip(
 			parent: $parent,
 			name: 'aggregatieniveau',
 			label: $level['label'],
@@ -436,46 +385,30 @@ class MdtoXmlGenerator {
 	 * Add dekkingInTijd elements when the object declares them.
 	 *
 	 * {@see MdtoSourceReader::temporalCoverage()} has already dropped every
-	 * half-declared entry, so each entry reaching this loop carries both the
-	 * `dekkingInTijdType` and the `dekkingInTijdBegindatum` that the XSD marks
-	 * `minOccurs="1"`.
+	 * half-declared or malformed entry.
 	 *
-	 * @param DOMDocument $dom The DOM document.
-	 * @param DOMElement $parent The parent element.
+	 * @param DOMElement $parent The informatieobject element.
 	 * @param ObjectEntity $object The source object.
 	 *
 	 * @return void
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-emit-mdto-aggregatieniveau-beperkinggebruik-and-dekkingintijd-from-their-declared-sources
 	 */
-	private function addTemporalCoverage(DOMDocument $dom, DOMElement $parent, ObjectEntity $object): void {
+	private function addTemporalCoverage(DOMElement $parent, ObjectEntity $object): void {
 		foreach ($this->sourceReader->temporalCoverage(object: $object) as $entry) {
-			$coverage = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':dekkingInTijd');
-			$this->addBegrip(
-				dom: $dom,
+			$coverage = $this->writer->element(parent: $parent, name: 'dekkingInTijd');
+			$this->writer->begrip(
 				parent: $coverage,
 				name: 'dekkingInTijdType',
 				label: $entry['type'],
 				code: null,
 				list: 'DekkingInTijdType'
 			);
-			$this->addTextElement(
-				dom: $dom,
-				parent: $coverage,
-				name: 'dekkingInTijdBegindatum',
-				content: $entry['start']
-			);
+			$this->writer->text(parent: $coverage, name: 'dekkingInTijdBegindatum', content: $entry['start']);
 
 			if ($entry['end'] !== null) {
-				$this->addTextElement(
-					dom: $dom,
-					parent: $coverage,
-					name: 'dekkingInTijdEinddatum',
-					content: $entry['end']
-				);
+				$this->writer->text(parent: $coverage, name: 'dekkingInTijdEinddatum', content: $entry['end']);
 			}
-
-			$parent->appendChild($coverage);
 		}
 	}//end addTemporalCoverage()
 
@@ -485,20 +418,18 @@ class MdtoXmlGenerator {
 	 * The selection and the bound belong to {@see MdtoEventMapper}, which
 	 * documents the mapping decision. This method only serialises.
 	 *
-	 * @param DOMDocument $dom The DOM document.
-	 * @param DOMElement $parent The parent element.
+	 * @param DOMElement $parent The informatieobject element.
 	 * @param ObjectEntity $object The source object.
 	 *
 	 * @return void
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-derive-mdto-event-entries-from-the-audit-trail
 	 */
-	private function addEvents(DOMDocument $dom, DOMElement $parent, ObjectEntity $object): void {
+	private function addEvents(DOMElement $parent, ObjectEntity $object): void {
 		foreach ($this->eventMapper->forObject(object: $object) as $event) {
-			$element = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':event');
+			$element = $this->writer->element(parent: $parent, name: 'event');
 
-			$this->addBegrip(
-				dom: $dom,
+			$this->writer->begrip(
 				parent: $element,
 				name: 'eventType',
 				label: $event['type'],
@@ -507,48 +438,169 @@ class MdtoXmlGenerator {
 			);
 
 			if ($event['time'] !== null) {
-				$this->addTextElement(dom: $dom, parent: $element, name: 'eventTijd', content: $event['time']);
+				$this->writer->text(parent: $element, name: 'eventTijd', content: $event['time']);
 			}
 
 			if ($event['actorName'] !== null) {
-				$this->addVerwijzing(
-					dom: $dom,
+				$this->writer->verwijzing(
 					parent: $element,
 					name: 'eventVerantwoordelijkeActor',
 					verwijzingNaam: $event['actorName'],
-					identificatieKenmerk: $event['actorId']
+					kenmerk: $event['actorId'],
+					bron: $this->organisationIdentifier()
 				);
 			}
-
-			$parent->appendChild($element);
 		}
 	}//end addEvents()
 
 	/**
-	 * Add the beperkingGebruik element when a restriction is known.
+	 * Add `waardering`, a `begripGegevens` from the closed Waarderingen list.
 	 *
-	 * {@see MdtoSourceReader::useRestriction()} decides whether there is one,
-	 * and records why an unknown restriction is omitted rather than declared
-	 * as "Nader te bepalen".
+	 * @param DOMElement $parent The informatieobject element.
+	 * @param array<string,mixed> $retention The retention metadata.
 	 *
-	 * @param DOMDocument $dom The DOM document.
-	 * @param DOMElement $parent The parent element.
+	 * @return void
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	private function addRating(DOMElement $parent, array $retention): void {
+		[$code, $label] = self::APPRAISAL_MAP[(string)$retention['archiefnominatie']];
+
+		$this->writer->begrip(parent: $parent, name: 'waardering', label: $label, code: $code, list: self::APPRAISAL_LIST);
+	}//end addRating()
+
+	/**
+	 * Add `bewaartermijn`, a `termijnGegevens`.
+	 *
+	 * `termijnLooptijd` carries the duration. `termijnEinddatum` carries
+	 * `retention.archiefactiedatum` when the record has one, which is the
+	 * date the retention period ends: RetentionService computes it from the
+	 * same duration.
+	 *
+	 * @param DOMElement $parent The informatieobject element.
+	 * @param array<string,mixed> $retention The retention metadata.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	private function addRetentionPeriod(DOMElement $parent, array $retention): void {
+		$term = $this->writer->element(parent: $parent, name: 'bewaartermijn');
+		$this->writer->text(parent: $term, name: 'termijnLooptijd', content: (string)$retention['bewaartermijn']);
+
+		$end = ($retention['archiefactiedatum'] ?? null);
+		if (is_string($end) === true && preg_match('/^\d{4}-\d{2}-\d{2}$/', $end) === 1) {
+			$this->writer->text(parent: $term, name: 'termijnEinddatum', content: $end);
+		}
+	}//end addRetentionPeriod()
+
+	/**
+	 * Add `informatiecategorie`, a `begripGegevens`, when the record has a category.
+	 *
+	 * Omitted, not defaulted, when there is no `retention.classification`: the
+	 * XSD makes the element `minOccurs="0"`, and the placeholder `onbekend`
+	 * this used to write was a value nobody had recorded.
+	 *
+	 * The begrippenlijst is the selectielijst named in
+	 * `retention.selectielijstBron`. When the record does not name one, the
+	 * generic term "Selectielijst" is used, because the category is only ever
+	 * written from a selectielijst lookup and the list's own name is unknown.
+	 *
+	 * @param DOMElement $parent The informatieobject element.
+	 * @param array<string,mixed> $retention The retention metadata.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	private function addInformatiecategorie(DOMElement $parent, array $retention): void {
+		$category = ($retention['classification'] ?? null);
+		if (is_scalar($category) === false || (string)$category === '') {
+			return;
+		}
+
+		$list = ($retention['selectielijstBron'] ?? null);
+		if (is_string($list) === false || $list === '') {
+			$list = self::CATEGORY_LIST_FALLBACK;
+		}
+
+		$this->writer->begrip(
+			parent: $parent,
+			name: 'informatiecategorie',
+			label: (string)$category,
+			code: null,
+			list: $list
+		);
+	}//end addInformatiecategorie()
+
+	/**
+	 * Add one `heeftRepresentatie` reference per file.
+	 *
+	 * The reference uses {@see MdtoBestandGenerator::identification()}, the
+	 * same identification the file's own document carries.
+	 *
+	 * @param DOMElement $parent The informatieobject element.
+	 * @param array $files The file metadata.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	private function addRepresentations(DOMElement $parent, array $files): void {
+		foreach ($files as $file) {
+			$identification = $this->bestandGenerator->identification(file: $file);
+			$this->writer->verwijzing(
+				parent: $parent,
+				name: 'heeftRepresentatie',
+				verwijzingNaam: (string)$file['name'],
+				kenmerk: $identification['kenmerk'],
+				bron: $identification['bron']
+			);
+		}
+	}//end addRepresentations()
+
+	/**
+	 * Add the archiefvormer element.
+	 *
+	 * @param DOMElement $parent The informatieobject element.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-generate-mdto-compliant-xml-metadata-per-object
+	 */
+	private function addArchiefvormer(DOMElement $parent): void {
+		$this->writer->verwijzing(
+			parent: $parent,
+			name: 'archiefvormer',
+			verwijzingNaam: $this->appConfig->getValueString('openregister', 'organisation_name', 'OpenRegister'),
+			kenmerk: $this->organisationIdentifier(),
+			bron: 'OpenRegister'
+		);
+	}//end addArchiefvormer()
+
+	/**
+	 * Add `beperkingGebruik`, which the XSD requires at least once.
+	 *
+	 * {@see MdtoSourceReader::useRestriction()} decides whether a restriction
+	 * is known. When none is, the element carries
+	 * {@see self::USE_RESTRICTION_UNRECORDED}, the standard's own term for a
+	 * restriction that has not been recorded.
+	 *
+	 * @param DOMElement $parent The informatieobject element.
 	 * @param ObjectEntity $object The source object.
 	 *
 	 * @return void
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-emit-mdto-aggregatieniveau-beperkinggebruik-and-dekkingintijd-from-their-declared-sources
 	 */
-	private function addUseRestriction(DOMDocument $dom, DOMElement $parent, ObjectEntity $object): void {
+	private function addUseRestriction(DOMElement $parent, ObjectEntity $object): void {
 		$restriction = $this->sourceReader->useRestriction(object: $object);
 		if ($restriction === null) {
-			return;
+			$restriction = ['type' => self::USE_RESTRICTION_UNRECORDED, 'description' => null, 'startDate' => null];
 		}
 
-		$element = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':beperkingGebruik');
-
-		$this->addBegrip(
-			dom: $dom,
+		$element = $this->writer->element(parent: $parent, name: 'beperkingGebruik');
+		$this->writer->begrip(
 			parent: $element,
 			name: 'beperkingGebruikType',
 			label: $restriction['type'],
@@ -557,8 +609,7 @@ class MdtoXmlGenerator {
 		);
 
 		if ($restriction['description'] !== null) {
-			$this->addTextElement(
-				dom: $dom,
+			$this->writer->text(
 				parent: $element,
 				name: 'beperkingGebruikNadereBeschrijving',
 				content: $restriction['description']
@@ -566,237 +617,10 @@ class MdtoXmlGenerator {
 		}
 
 		if ($restriction['startDate'] !== null) {
-			$termijn = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':beperkingGebruikTermijn');
-			$this->addTextElement(
-				dom: $dom,
-				parent: $termijn,
-				name: 'termijnStartdatumLooptijd',
-				content: $restriction['startDate']
-			);
-			$element->appendChild($termijn);
+			$term = $this->writer->element(parent: $element, name: 'beperkingGebruikTermijn');
+			$this->writer->text(parent: $term, name: 'termijnStartdatumLooptijd', content: $restriction['startDate']);
 		}
-
-		$parent->appendChild($element);
 	}//end addUseRestriction()
-
-
-	/**
-	 * Add the waardering element to the XML document.
-	 *
-	 * @param DOMDocument $dom The DOM document.
-	 * @param DOMElement $parent The parent element.
-	 * @param array<string,mixed> $retention The retention metadata.
-	 *
-	 * @return void
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-generate-mdto-compliant-xml-metadata-per-object
-	 */
-	private function addRating(DOMDocument $dom, DOMElement $parent, array $retention): void {
-		$nominatie = ($retention['archiefnominatie'] ?? '');
-		$rating = (self::WAARDERING_MAP[$nominatie] ?? $nominatie);
-		$this->addTextElement(dom: $dom, parent: $parent, name: 'waardering', content: $rating);
-	}//end addRating()
-
-	/**
-	 * Add the bewaartermijn element to the XML document.
-	 *
-	 * @param DOMDocument $dom The DOM document.
-	 * @param DOMElement $parent The parent element.
-	 * @param array<string,mixed> $retention The retention metadata.
-	 *
-	 * @return void
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-generate-mdto-compliant-xml-metadata-per-object
-	 */
-	private function addRetentionPeriod(DOMDocument $dom, DOMElement $parent, array $retention): void {
-		$retentionPeriod = ($retention['bewaartermijn'] ?? '');
-		$this->addTextElement(dom: $dom, parent: $parent, name: 'bewaartermijn', content: (string)$retentionPeriod);
-	}//end addRetentionPeriod()
-
-	/**
-	 * Add the informatiecategorie element to the XML document.
-	 *
-	 * @param DOMDocument $dom The DOM document.
-	 * @param DOMElement $parent The parent element.
-	 * @param array<string,mixed> $retention The retention metadata.
-	 *
-	 * @return void
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-generate-mdto-compliant-xml-metadata-per-object
-	 */
-	private function addInformatiecategorie(DOMDocument $dom, DOMElement $parent, array $retention): void {
-		$classification = ($retention['classification'] ?? 'onbekend');
-		$this->addTextElement(dom: $dom, parent: $parent, name: 'informatiecategorie', content: (string)$classification);
-	}//end addInformatiecategorie()
-
-	/**
-	 * Add the archiefvormer element to the XML document.
-	 *
-	 * @param DOMDocument $dom The DOM document.
-	 * @param DOMElement $parent The parent element.
-	 *
-	 * @return void
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-generate-mdto-compliant-xml-metadata-per-object
-	 */
-	private function addArchiefvormer(DOMDocument $dom, DOMElement $parent): void {
-		$organisationName = $this->appConfig->getValueString('openregister', 'organisation_name', 'OpenRegister');
-
-		$this->addVerwijzing(
-			dom: $dom,
-			parent: $parent,
-			name: 'archiefvormer',
-			verwijzingNaam: $organisationName,
-			identificatieKenmerk: $this->organisationIdentifier(),
-			identificatieBron: 'OpenRegister'
-		);
-	}//end addArchiefvormer()
-
-	/**
-	 * Add a bestand (file) element to the XML document.
-	 *
-	 * @param DOMDocument $dom The DOM document.
-	 * @param DOMElement $parent The parent element.
-	 * @param array{name: string, size: int, format: string, checksum: string} $file The file metadata.
-	 *
-	 * @return void
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-generate-mdto-compliant-xml-metadata-per-object
-	 */
-	private function addFile(DOMDocument $dom, DOMElement $parent, array $file): void {
-		$fileElement = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':bestand');
-
-		$this->addTextElement(dom: $dom, parent: $fileElement, name: 'naam', content: $file['name']);
-		$this->addTextElement(dom: $dom, parent: $fileElement, name: 'omvang', content: (string)$file['size']);
-		$this->addTextElement(dom: $dom, parent: $fileElement, name: 'bestandsformaat', content: $file['format']);
-
-		$checksumElement = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':checksum');
-
-		$algoritme = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':checksumAlgoritme');
-		$algoritme->textContent = 'SHA-256';
-		$checksumElement->appendChild($algoritme);
-
-		$value = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':checksumWaarde');
-		$value->textContent = $file['checksum'];
-		$checksumElement->appendChild($value);
-
-		$fileElement->appendChild($checksumElement);
-		$parent->appendChild($fileElement);
-	}//end addFile()
-
-	/**
-	 * Add a begripGegevens element.
-	 *
-	 * The XSD makes `begripLabel` and `begripBegrippenlijst` both
-	 * `minOccurs="1"`, so the list name is never optional here.
-	 *
-	 * @param DOMDocument $dom The DOM document.
-	 * @param DOMElement $parent The parent element.
-	 * @param string $name The element name (without namespace prefix).
-	 * @param string $label The begripLabel value.
-	 * @param string|null $code The begripCode value, omitted when null.
-	 * @param string $list The begrippenlijst name.
-	 *
-	 * @return void
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-emit-mdto-aggregatieniveau-beperkinggebruik-and-dekkingintijd-from-their-declared-sources
-	 */
-	private function addBegrip(
-		DOMDocument $dom,
-		DOMElement $parent,
-		string $name,
-		string $label,
-		?string $code,
-		string $list,
-	): void {
-		$element = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':' . $name);
-
-		$this->addTextElement(dom: $dom, parent: $element, name: 'begripLabel', content: $label);
-
-		if (($code ?? '') !== '') {
-			$this->addTextElement(dom: $dom, parent: $element, name: 'begripCode', content: $code);
-		}
-
-		$this->addVerwijzing(
-			dom: $dom,
-			parent: $element,
-			name: 'begripBegrippenlijst',
-			verwijzingNaam: $list
-		);
-
-		$parent->appendChild($element);
-	}//end addBegrip()
-
-	/**
-	 * Add a verwijzingGegevens element.
-	 *
-	 * @param DOMDocument $dom The DOM document.
-	 * @param DOMElement $parent The parent element.
-	 * @param string $name The element name (without namespace prefix).
-	 * @param string $verwijzingNaam The name of the referenced object.
-	 * @param string|null $identificatieKenmerk The reference key, omitted when null.
-	 * @param string|null $identificatieBron The reference source; defaults to the organisation identifier.
-	 *
-	 * @return void
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-generate-mdto-compliant-xml-metadata-per-object
-	 */
-	private function addVerwijzing(
-		DOMDocument $dom,
-		DOMElement $parent,
-		string $name,
-		string $verwijzingNaam,
-		?string $identificatieKenmerk = null,
-		?string $identificatieBron = null,
-	): void {
-		$element = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':' . $name);
-
-		$this->addTextElement(dom: $dom, parent: $element, name: 'verwijzingNaam', content: $verwijzingNaam);
-
-		if (($identificatieKenmerk ?? '') !== '') {
-			$identificatie = $dom->createElementNS(
-				self::MDTO_NAMESPACE,
-				self::MDTO_PREFIX . ':verwijzingIdentificatie'
-			);
-			$this->addTextElement(
-				dom: $dom,
-				parent: $identificatie,
-				name: 'identificatieKenmerk',
-				content: $identificatieKenmerk
-			);
-			$this->addTextElement(
-				dom: $dom,
-				parent: $identificatie,
-				name: 'identificatieBron',
-				content: ($identificatieBron ?? $this->organisationIdentifier())
-			);
-			$element->appendChild($identificatie);
-		}
-
-		$parent->appendChild($element);
-	}//end addVerwijzing()
-
-	/**
-	 * Add a simple text element to the XML document.
-	 *
-	 * @param DOMDocument $dom The DOM document.
-	 * @param DOMElement $parent The parent element.
-	 * @param string $name The element name (without namespace prefix).
-	 * @param string $content The text content.
-	 *
-	 * @return void
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-generate-mdto-compliant-xml-metadata-per-object
-	 */
-	private function addTextElement(DOMDocument $dom, DOMElement $parent, string $name, string $content): void {
-		$element = $dom->createElementNS(self::MDTO_NAMESPACE, self::MDTO_PREFIX . ':' . $name);
-		$element->textContent = $content;
-		$parent->appendChild($element);
-	}//end addTextElement()
-
-
-
-
 
 	/**
 	 * Resolve the object's naam.
@@ -824,4 +648,25 @@ class MdtoXmlGenerator {
 	private function organisationIdentifier(): string {
 		return $this->appConfig->getValueString('openregister', 'organisation_identifier', 'OpenRegister');
 	}//end organisationIdentifier()
+
+	/**
+	 * Whether a value is in the lexical space of `xsd:duration`.
+	 *
+	 * Stricter than PHP's DateInterval, which also accepts weeks (`P2W`);
+	 * `xsd:duration` has no week designator.
+	 *
+	 * @param mixed $value The value.
+	 *
+	 * @return bool True when it is.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	private static function isXsdDuration(mixed $value): bool {
+		if (is_string($value) === false) {
+			return false;
+		}
+
+		$pattern = '/^-?P(?=\d|T\d)(\d+Y)?(\d+M)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+(\.\d+)?S)?)?$/';
+		return preg_match($pattern, $value) === 1;
+	}//end isXsdDuration()
 }//end class

--- a/lib/Service/Edepot/PackagedFileChecksum.php
+++ b/lib/Service/Edepot/PackagedFileChecksum.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * OpenRegister Packaged File Checksum
+ *
+ * The checksum an e-Depot package carries for a file, and when it was made.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Edepot
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Edepot;
+
+use DateTime;
+use RuntimeException;
+
+/**
+ * Computes a file's SHA-256 at packaging time, dates it, and checks fixity.
+ *
+ * ## Why the checksum is computed here, every time
+ *
+ * MDTO requires `checksumDatum`, defined as "Datum waarop de checksum is
+ * gemaakt". A checksum read from stored data carries no such date, so the
+ * only honest date is one this class can vouch for: it hashes the bytes about
+ * to be packaged and records that moment.
+ *
+ * ## Why recomputing is not enough on its own
+ *
+ * Recomputing alone would launder a changed file. If the bytes no longer match
+ * a SHA-256 recorded for them, a fresh checksum would describe the changed
+ * bytes and the package would look intact. So a stored SHA-256 that disagrees
+ * is a fixity failure and the file is refused. A stored value that is not
+ * SHA-256-shaped cannot be compared, and is not used.
+ *
+ * @psalm-suppress UnusedClass
+ */
+class PackagedFileChecksum {
+
+	/**
+	 * Compute, date and fixity-check the checksum for one file.
+	 *
+	 * @param string $path The file about to be packaged.
+	 * @param mixed $stored The checksum stored with the file reference, if any.
+	 *
+	 * @return array{checksum: string, checksumDate: string} The SHA-256 and an xsd:dateTime.
+	 *
+	 * @throws RuntimeException When the file cannot be read, or its stored SHA-256 no longer matches.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	public function compute(string $path, mixed $stored): array {
+		$checksum = hash_file('sha256', $path);
+		if ($checksum === false) {
+			throw new RuntimeException('Cannot read ' . $path . ' to checksum it, so it is not transferred');
+		}
+
+		if (is_string($stored) === true
+			&& preg_match('/^[0-9a-fA-F]{64}$/', $stored) === 1
+			&& hash_equals(strtolower($stored), $checksum) === false
+		) {
+			throw new RuntimeException(
+				'Fixity failure: the SHA-256 recorded for ' . $path
+				. ' does not match its bytes, so it is not transferred'
+			);
+		}
+
+		return ['checksum' => $checksum, 'checksumDate' => (new DateTime())->format(DateTime::ATOM)];
+	}//end compute()
+}//end class

--- a/lib/Service/Edepot/SipPackageBuilder.php
+++ b/lib/Service/Edepot/SipPackageBuilder.php
@@ -229,6 +229,14 @@ class SipPackageBuilder {
 							'size' => $file['size'],
 							'checksum' => $file['checksum'],
 						];
+
+						// MDTO gives every file its own document, placed next to
+						// the file and named `<bestandsnaam>.bestand.MDTO.xml`
+						// (MDTO SIP specification, "Naamgeving").
+						$bestandXml = $this->mdtoGenerator->generateBestand($object, $file);
+						$bestandPath = $filePath . MdtoBestandGenerator::SIDECAR_SUFFIX;
+						$entries[] = ['path' => $bestandPath, 'kind' => 'string', 'content' => $bestandXml];
+						$manifest[] = $this->createManifestEntry(path: $bestandPath, content: $bestandXml);
 					}
 				}
 			}

--- a/lib/Service/Edepot/SipPackageBuilder.php
+++ b/lib/Service/Edepot/SipPackageBuilder.php
@@ -31,6 +31,7 @@ namespace OCA\OpenRegister\Service\Edepot;
 use DateTime;
 use DOMDocument;
 use InvalidArgumentException;
+use OCA\OpenRegister\Db\ObjectEntity;
 use OCP\IAppConfig;
 use OCP\ITempManager;
 use Psr\Log\LoggerInterface;
@@ -175,6 +176,50 @@ class SipPackageBuilder {
 	}//end splitIntoBatches()
 
 	/**
+	 * The SIP entries for an object's content files, each with its own MDTO document.
+	 *
+	 * MDTO gives every file its own document, placed next to the file and
+	 * named `<bestandsnaam>.bestand.MDTO.xml` (MDTO SIP specification,
+	 * "Naamgeving"). A file missing from disk is skipped, and so is its
+	 * document, because a document describing a file the package lacks would
+	 * be false.
+	 *
+	 * @param string $objectDir The object's directory in the SIP.
+	 * @param ObjectEntity $object The object the files belong to.
+	 * @param array $files The object's file metadata.
+	 *
+	 * @return array{entries: list<array<string, mixed>>, manifest: list<array<string, mixed>>} The rows to add.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-assemble-sip-packages-for-e-depot-transfer
+	 */
+	private function contentFileEntries(string $objectDir, ObjectEntity $object, array $files): array {
+		$entries = [];
+		$manifest = [];
+
+		foreach ($files as $file) {
+			if (file_exists($file['path']) === false) {
+				continue;
+			}
+
+			$subDir = 'original';
+			if ($file['isRendition'] === true) {
+				$subDir = 'rendition';
+			}
+
+			$filePath = "{$objectDir}/content/{$subDir}/{$file['name']}";
+			$entries[] = ['path' => $filePath, 'kind' => 'file', 'filePath' => $file['path']];
+			$manifest[] = ['path' => $filePath, 'size' => $file['size'], 'checksum' => $file['checksum']];
+
+			$bestandXml = $this->mdtoGenerator->generateBestand($object, $file);
+			$bestandPath = $filePath . MdtoBestandGenerator::SIDECAR_SUFFIX;
+			$entries[] = ['path' => $bestandPath, 'kind' => 'string', 'content' => $bestandXml];
+			$manifest[] = $this->createManifestEntry(path: $bestandPath, content: $bestandXml);
+		}
+
+		return ['entries' => $entries, 'manifest' => $manifest];
+	}//end contentFileEntries()
+
+	/**
 	 * Build a single SIP package ZIP archive.
 	 *
 	 * @param string $transferId The transfer list UUID.
@@ -214,32 +259,9 @@ class SipPackageBuilder {
 			$entries[] = ['path' => "{$objectDir}/metadata.json", 'kind' => 'string', 'content' => $metadataJson];
 			$manifest[] = $this->createManifestEntry(path: "{$objectDir}/metadata.json", content: $metadataJson);
 
-			if (empty($files) === false) {
-				foreach ($files as $file) {
-					$subDir = 'original';
-					if ($file['isRendition'] === true) {
-						$subDir = 'rendition';
-					}
-
-					$filePath = "{$objectDir}/content/{$subDir}/{$file['name']}";
-					if (file_exists($file['path']) === true) {
-						$entries[] = ['path' => $filePath, 'kind' => 'file', 'filePath' => $file['path']];
-						$manifest[] = [
-							'path' => $filePath,
-							'size' => $file['size'],
-							'checksum' => $file['checksum'],
-						];
-
-						// MDTO gives every file its own document, placed next to
-						// the file and named `<bestandsnaam>.bestand.MDTO.xml`
-						// (MDTO SIP specification, "Naamgeving").
-						$bestandXml = $this->mdtoGenerator->generateBestand($object, $file);
-						$bestandPath = $filePath . MdtoBestandGenerator::SIDECAR_SUFFIX;
-						$entries[] = ['path' => $bestandPath, 'kind' => 'string', 'content' => $bestandXml];
-						$manifest[] = $this->createManifestEntry(path: $bestandPath, content: $bestandXml);
-					}
-				}
-			}
+			$fileEntries = $this->contentFileEntries(objectDir: $objectDir, object: $object, files: $files);
+			$entries = array_merge($entries, $fileEntries['entries']);
+			$manifest = array_merge($manifest, $fileEntries['manifest']);
 		}//end foreach
 
 		$metsXml = $this->generateMetsXml(transferId: $transferId, objectsWithFiles: $objectsWithFiles);

--- a/openspec/specs/edepot-transfer/spec.md
+++ b/openspec/specs/edepot-transfer/spec.md
@@ -340,13 +340,25 @@ recorded beside it in `version.json`. The licence is CC BY-SA: "Het Nationaal
 Archief hanteert de licentie CC BY SA voor al diens kennisproducten en dus ook
 voor MDTO" (Forum Standaardisatie, Intakeadvies MDTO, FS-20241002.3C).
 
-`MdtoXmlGeneratorXsdTest` MUST hold this true by running
-`DOMDocument::schemaValidate()` over documents for representative objects,
-with and without files and with and without the optional elements, and MUST
-name libxml's own error lines when a document fails. It MUST include a
-negative control (a document the schema rejects) and a positive control (the
-Nationaal Archief's own example documents), so neither a schema that failed
-to load nor a validator that accepts anything can make it pass. The vendored
+`MdtoXmlGeneratorXsdTest` MUST hold this true by validating documents for
+representative objects, with and without files and with and without the
+optional elements, and MUST name libxml's own error lines when a document
+fails.
+
+Validation MUST work under Nextcloud's XXE protection, which sets libxml's
+external-entity loader to return null. `DOMDocument::schemaValidate($path)`
+cannot read the schema from disk under that loader, so validation MUST read
+the schema's contents and use `schemaValidateSource()`. That suffices because
+the vendored XSD imports and includes nothing; the loader MUST NOT be
+loosened to make validation work. The test MUST install that null loader for
+its own duration, because CI runs it inside a booted Nextcloud and a local run
+does not, and a test that only passes without the loader passes for the wrong
+reason. It MUST include a
+negative control (a document the schema rejects, where the rejection must be
+the schema naming the missing element and not a failure to load the schema)
+and a positive control (the Nationaal Archief's own example documents), so
+neither a schema that failed to load nor a validator that accepts anything
+can make it pass. The vendored
 schema's checksum MUST be pinned, so the file the export is held to cannot
 change unnoticed.
 

--- a/openspec/specs/edepot-transfer/spec.md
+++ b/openspec/specs/edepot-transfer/spec.md
@@ -12,24 +12,26 @@ Define how OpenRegister exports objects to a Dutch e-Depot for permanent archiva
 ## Requirements
 
 ### Requirement: The system MUST generate MDTO-compliant XML metadata per object
-Each object selected for e-Depot transfer MUST have its metadata exported as valid XML conforming to the MDTO (Metagegevens Duurzaam Toegankelijke Overheidsinformatie) schema version 1.0 or later. The XML MUST include all mandatory MDTO elements and use the correct namespace.
+Each object selected for e-Depot transfer MUST have its metadata exported as XML that validates against MDTO-XML 1.0.1, the Nationaal Archief's schema, vendored at `lib/Resources/mdto/MDTO-XML1.0.1.xsd`. How that is held true is the requirement "Generated MDTO documents MUST validate against the vendored MDTO-XML 1.0.1 XSD" below.
 
 #### Scenario: Generate MDTO XML for a single object
 - **WHEN** object `zaak-123` with complete archival metadata is selected for MDTO export
-- **THEN** the system MUST produce an XML document with root element `mdto:informatieobject` in namespace `https://www.nationaalarchief.nl/mdto`
-- **AND** the XML MUST include mandatory elements: `identificatie` (object UUID + register source), `naam` (object title or schema+UUID), `waardering` (mapped from `archiefnominatie`), `bewaartermijn` (ISO 8601 duration from retention field), `informatiecategorie` (mapped from selectielijst `classificatie`)
-- **AND** the XML MUST include `archiefvormer` (the organisation identifier from app settings)
-- **AND** the XML MUST validate against the MDTO XSD schema
+- **THEN** the system MUST produce an XML document with root element `mdto:MDTO` in namespace `https://www.nationaalarchief.nl/mdto`, holding exactly one `mdto:informatieobject`
+- **AND** the informatieobject MUST include `identificatie` (object UUID, with the organisation identifier as `identificatieBron`), `naam` (object title, else its UUID), `waardering` (from `archiefnominatie`, as a term of the closed Waarderingen list), `archiefvormer` (the organisation from app settings) and `beperkingGebruik`
+- **AND** it MUST include `bewaartermijn` as a `termijnGegevens`, which MDTO makes optional and openregister requires as local policy
+- **AND** the document MUST validate against the vendored MDTO XSD
 
 #### Scenario: MDTO XML includes file references
 - **WHEN** object `zaak-123` has 2 associated files (original.docx and rendition.pdf)
-- **THEN** the MDTO XML MUST include `bestand` elements for each file with `naam`, `omvang` (file size in bytes), `bestandsformaat` (PRONOM identifier or MIME type), and `checksum` (SHA-256)
+- **THEN** the informatieobject document MUST reference each file with a `heeftRepresentatie`, and MUST NOT embed them
+- **AND** each file MUST get its own MDTO document with root `mdto:MDTO` holding one `mdto:bestand`, carrying `identificatie`, `naam`, `omvang` (bytes), `bestandsformaat` (the IANA media type), `checksum` (SHA-256 with `checksumDatum`) and `isRepresentatieVan` pointing back at the informatieobject
+- **AND** each file document MUST validate against the vendored MDTO XSD
 
 #### Scenario: MDTO XML handles missing optional fields gracefully
-- **WHEN** an object lacks optional MDTO fields (e.g., no `toelichting`, no `classificatie`)
-- **THEN** the XML MUST omit those elements rather than including empty elements
-- **AND** the XML MUST still validate against the MDTO XSD schema
-- **AND** required fields that are missing MUST cause the export to fail with a descriptive error logged to the transfer list
+- **WHEN** an object lacks optional MDTO values (e.g., no `toelichting`, no `classification`)
+- **THEN** the XML MUST omit those elements (`omschrijving`, `informatiecategorie`) rather than including empty elements or placeholders
+- **AND** the XML MUST still validate against the MDTO XSD
+- **AND** required inputs that are missing or malformed MUST cause the export to fail with a descriptive error
 
 ### Requirement: The system MUST assemble SIP packages for e-Depot transfer
 Objects approved for transfer MUST be packaged into a SIP (Submission Information Package) conforming to the OAIS reference model (ISO 14721). Each SIP MUST be a self-contained ZIP archive containing all metadata and content files needed for archival ingest.
@@ -40,7 +42,7 @@ Objects approved for transfer MUST be packaged into a SIP (Submission Informatio
   - A `mets.xml` file describing the structural map of the package (file groups, div structure per object)
   - A `premis.xml` file with preservation events (creation, packaging) and SHA-256 fixity for every content file
   - A `sip-manifest.json` listing all files in the package with their relative paths, SHA-256 checksums, and sizes
-  - One directory per object under `objects/{uuid}/` containing `mdto.xml`, `metadata.json` (object data snapshot), and a `content/` directory with associated files
+  - One directory per object under `objects/{uuid}/` containing `mdto.xml`, `metadata.json` (object data snapshot), and a `content/` directory with associated files, each accompanied by its own MDTO document named `<bestandsnaam>.bestand.MDTO.xml`, as the MDTO SIP specification prescribes
 - **AND** the total package MUST be integrity-verifiable by recomputing checksums from the manifest
 
 #### Scenario: SIP package includes PDF/A renditions when available
@@ -194,8 +196,11 @@ Every transfer lifecycle event MUST produce an immutable audit trail entry for l
 
 `MdtoXmlGenerator` MUST NOT present its pre-generation check as an MDTO
 validity check. The check MUST be named and documented for what it is (the
-inputs the generator needs), and the generator MUST separately report which
-MDTO-required elements the produced document will be missing.
+inputs the generator needs, refused in any form the XSD would reject), and
+the generator MUST separately report which MDTO-required elements carry the
+standard's "not recorded" term rather than a value the object supplied.
+Validity against the schema is established by the XSD test, not by this
+check.
 
 The required-element list is taken from two authoritative sources published by
 the Nationaal Archief: the MDTO metagegevensschema
@@ -230,16 +235,27 @@ and the XML syntax `MDTO-XML1.0.1.xsd`
 - **THEN** generation MUST fail with an error naming the missing input
 - **AND** the error MUST state that the check covers generator inputs only and is not an MDTO validity check
 
+#### Scenario: A generator input is malformed
+- **WHEN** `archiefnominatie` is outside the closed Waarderingen list, `bewaartermijn` is not an `xsd:duration` (for example `P2W`), or a file's checksum is not a SHA-256 or its `checksumDate` is not an `xsd:dateTime`
+- **THEN** generation MUST fail naming the input, rather than write a document the XSD rejects or a label the list does not contain
+
 #### Scenario: A required MDTO element cannot be sourced
 - **WHEN** an object declares no use restriction and carries no active legal hold
-- **THEN** generation MUST still succeed
-- **AND** the generator MUST report `beperkingGebruik` as an absent MDTO-required element
+- **THEN** generation MUST still succeed, with `beperkingGebruik` carrying the BeperkingGebruikTypeLijst term `Nader te bepalen`
+- **AND** the generator MUST report `beperkingGebruik` as carrying that default, so it is never read as a recorded fact
 
 ### Requirement: The system MUST emit MDTO aggregatieniveau beperkingGebruik and dekkingInTijd from their declared sources
 
-`aggregatieniveau`, `beperkingGebruik` and `dekkingInTijd` MUST be emitted when
-the object carries a value for them, and MUST be omitted entirely when it does
-not. A placeholder or a derived guess MUST NOT be written.
+`aggregatieniveau` and `dekkingInTijd` MUST be emitted when the object
+carries a value for them, and MUST be omitted entirely when it does not. A
+placeholder or a derived guess MUST NOT be written.
+
+`beperkingGebruik` is the exception, because the XSD requires it
+(`minOccurs="1"`). When no source supplies one it MUST carry the
+BeperkingGebruikTypeLijst term `Nader te bepalen`, defined by the standard as
+"Er is mogelijk een beperking, maar de aard daarvan is niet vastgelegd als
+type beperking en niet vastgelegd in de metagegevens". That term states the
+absence of a recorded restriction; it is not a guess at one.
 
 Sources, in order: the abstract English key on the `retention` block
 (`aggregationLevel`, `useRestriction`, `temporalCoverage`), then the Dutch key
@@ -255,7 +271,8 @@ begrippenlijst, whose terms are Archief, Serie, Dossier and Archiefstuk.
 
 `dekkingInTijd` MUST be emitted only when the declared entry supplies both a
 type and a start date, because `dekkingInTijdType` and
-`dekkingInTijdBegindatum` are both `minOccurs="1"`. The record's own `created`
+`dekkingInTijdBegindatum` are both `minOccurs="1"`. Both dates MUST be an
+`xsd:gYear`, `xsd:gYearMonth` or `xsd:date`, the union the XSD declares. The record's own `created`
 timestamp MUST NOT be used: MDTO defines dekkingInTijd as "Datum waar de
 inhoud van het informatieobject betrekking op heeft".
 
@@ -270,6 +287,10 @@ inhoud van het informatieobject betrekking op heeft".
 #### Scenario: An active legal hold is exported as a use restriction
 - **WHEN** an object carries `retention.legalHold` with `active` true and a reason
 - **THEN** the XML MUST contain `mdto:beperkingGebruik` with `beperkingGebruikType/begripLabel` `Overig` and the reason in `beperkingGebruikNadereBeschrijving`
+
+#### Scenario: No known restriction is stated as not recorded
+- **WHEN** an object declares no restriction and any legal hold has been released
+- **THEN** the XML MUST contain `mdto:beperkingGebruik` with `beperkingGebruikType/begripLabel` `Nader te bepalen`, and MUST NOT carry `Overig`
 
 ### Requirement: The system MUST derive MDTO event entries from the audit trail
 
@@ -308,3 +329,56 @@ attests to the integrity of the audit row, not to an outcome of the event.
 - **WHEN** an object's audit trail holds more qualifying rows than the cap
 - **THEN** the XML MUST contain at most the capped number of `mdto:event` elements
 - **AND** the record's `Creatie` event MUST be among them
+
+### Requirement: Generated MDTO documents MUST validate against the vendored MDTO-XML 1.0.1 XSD
+
+Every document `MdtoXmlGenerator` produces, the informatieobject document and
+each file's bestand document, MUST validate against
+`lib/Resources/mdto/MDTO-XML1.0.1.xsd`. That file MUST be a verbatim copy of
+the Nationaal Archief's schema, with its source, version, checksum and licence
+recorded beside it in `version.json`. The licence is CC BY-SA: "Het Nationaal
+Archief hanteert de licentie CC BY SA voor al diens kennisproducten en dus ook
+voor MDTO" (Forum Standaardisatie, Intakeadvies MDTO, FS-20241002.3C).
+
+`MdtoXmlGeneratorXsdTest` MUST hold this true by running
+`DOMDocument::schemaValidate()` over documents for representative objects,
+with and without files and with and without the optional elements, and MUST
+name libxml's own error lines when a document fails. It MUST include a
+negative control (a document the schema rejects) and a positive control (the
+Nationaal Archief's own example documents), so neither a schema that failed
+to load nor a validator that accepts anything can make it pass. The vendored
+schema's checksum MUST be pinned, so the file the export is held to cannot
+change unnoticed.
+
+Where MDTO makes a value a term from a begrippenlijst, the XSD sees only a
+string. Those rules are enforced by the generator instead: `waardering` MUST
+be a term of the CLOSED Waarderingen list (`B` Blijvend te bewaren, `V`
+Tijdelijk te bewaren, `N` Nader te bepalen), onto which the four
+`archiefnominatie` values the codebase writes map, and any other value MUST be
+refused.
+
+`checksumDatum`, defined by MDTO as "Datum waarop de checksum is gemaakt",
+MUST be the moment the checksum was computed. Because a stored checksum
+carries no date, the transfer service MUST hash every file at packaging and
+date that moment, and MUST refuse a file whose stored SHA-256 does not match
+its bytes rather than replace the stale value silently.
+
+#### Scenario: Representative documents validate
+- **WHEN** documents are generated for a minimal object, an object with files, and an object carrying every optional element
+- **THEN** every informatieobject document and every bestand document MUST validate against the vendored XSD
+
+#### Scenario: A deviation from the schema is caught and named
+- **WHEN** the generator emits a document the schema rejects
+- **THEN** `MdtoXmlGeneratorXsdTest` MUST fail, and its message MUST quote libxml's error naming the offending element
+
+#### Scenario: A stored checksum no longer matches the file
+- **WHEN** a file reference carries a SHA-256 that differs from the SHA-256 of the file's bytes
+- **THEN** the file MUST be refused as a fixity failure, and the object excluded from that transfer with a logged reason
+
+**Known gap: a second MDTO exporter does not validate.** `TmloService::generateMdtoXml()` serves `GET /api/objects/{register}/{schema}/{id}/export/mdto`
+and is governed by `tmlo-export`, not by this capability. Measured on
+2026-09-11 against the same vendored XSD, it does not validate: its root is
+`mdto:informatieobject`, and it emits `archiefactiedatum`, `archiefstatus` and
+`vernietigingsCategorie`, which are TMLO fields and not MDTO elements. The
+`tmlo-export` spec mandates those elements, so correcting the exporter is a
+decision about that spec, recorded there.

--- a/openspec/specs/tmlo-export/spec.md
+++ b/openspec/specs/tmlo-export/spec.md
@@ -24,6 +24,22 @@ The XML output SHALL include:
 - `bewaarTermijn` with the retention period
 - `vernietigingsCategorie` with the destruction category
 
+**Known gap: this export does not validate against MDTO, and the list above is why.**
+Measured on 2026-09-11 against the Nationaal Archief's MDTO-XML 1.0.1 schema,
+vendored at `lib/Resources/mdto/MDTO-XML1.0.1.xsd`, the output of
+`TmloService::generateMdtoXml()` is rejected at its root: "Element
+'{https://www.nationaalarchief.nl/mdto}informatieobject': No matching global
+declaration available for the validation root." The schema's only global
+element is `MDTO`. Past the root, the export emits three elements that do not
+exist in MDTO at all: `archiefactiedatum`, `archiefstatus` and
+`vernietigingsCategorie`, which are TMLO fields. (Two further items in the
+list above, `archiefnominatie` and `bewaarTermijn`, are also TMLO spellings,
+but the code already emits them as MDTO's `waardering` and `bewaartermijn`.)
+A document carrying those three cannot validate however it is wrapped, so the
+sentence above claiming MDTO conformance and the element list beneath it
+cannot both hold. Choosing which gives way is a decision for
+this spec; the e-Depot export in `edepot-transfer` already validates.
+
 #### Scenario: Export single object as MDTO XML
 
 - **WHEN** a GET request is made to `/api/objects/{register}/{schema}/{id}/export/mdto`

--- a/tests/Unit/Service/Edepot/EdepotTransferServiceFilesTest.php
+++ b/tests/Unit/Service/Edepot/EdepotTransferServiceFilesTest.php
@@ -13,19 +13,24 @@ declare(strict_types=1);
 
 namespace Unit\Service\Edepot;
 
+use Closure;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Service\Edepot\EdepotTransferService;
+use OCA\OpenRegister\Service\Edepot\PackagedFileChecksum;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use RuntimeException;
 
 /**
- * The checksum the SIP carries is computed and dated at packaging, and a
- * stored SHA-256 that no longer matches the bytes is refused.
+ * File gathering takes its checksum and date from PackagedFileChecksum.
  *
- * `getObjectFiles()` touches none of the service's collaborators, so the
- * service is built without its constructor and the method reached by
- * reflection. That keeps the test about this one behaviour.
+ * The rule itself is tested in PackagedFileChecksumTest. This proves the
+ * transfer path uses it: that the SIP's file entries carry the computed
+ * checksum and its date, and that a fixity failure propagates to the
+ * per-object catch instead of being swallowed here.
+ *
+ * `getObjectFiles()` touches no other collaborator, so the service is built
+ * without its constructor and only the checksum dependency is initialised.
  */
 class EdepotTransferServiceFilesTest extends TestCase {
 
@@ -44,49 +49,24 @@ class EdepotTransferServiceFilesTest extends TestCase {
 	}
 
 	/**
-	 * With no stored checksum, one is computed and dated as an xsd:dateTime.
+	 * Each gathered file carries the computed checksum and its date.
 	 */
-	public function testTheChecksumIsComputedAndDated(): void {
+	public function testGatheredFilesCarryTheComputedChecksumAndDate(): void {
 		$files = $this->gather(fileRef: ['path' => $this->path, 'name' => 'a.txt']);
 
 		$this->assertSame(hash('sha256', 'archival bytes'), $files[0]['checksum']);
-		$this->assertMatchesRegularExpression(
-			'/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/',
-			$files[0]['checksumDate']
-		);
+		$this->assertArrayHasKey('checksumDate', $files[0]);
+		$this->assertNotSame('', $files[0]['checksumDate']);
 	}
 
 	/**
-	 * A stored SHA-256 that matches is accepted, and the fresh one is used.
+	 * A fixity failure propagates, so the per-object catch can exclude the object.
 	 */
-	public function testAMatchingStoredChecksumIsAccepted(): void {
-		$stored = strtoupper(hash('sha256', 'archival bytes'));
-
-		$files = $this->gather(fileRef: ['path' => $this->path, 'checksum' => $stored]);
-
-		$this->assertSame(hash('sha256', 'archival bytes'), $files[0]['checksum']);
-	}
-
-	/**
-	 * A stored SHA-256 that does NOT match the bytes is a fixity failure.
-	 *
-	 * Recomputing silently would launder the changed file into a package
-	 * that looks intact, so the file is refused.
-	 */
-	public function testAStaleStoredChecksumIsRefused(): void {
+	public function testAFixityFailurePropagates(): void {
 		$this->expectException(RuntimeException::class);
 		$this->expectExceptionMessageMatches('/Fixity failure/');
 
 		$this->gather(fileRef: ['path' => $this->path, 'checksum' => hash('sha256', 'other bytes')]);
-	}
-
-	/**
-	 * A stored value that is not SHA-256-shaped cannot be compared, and is not used.
-	 */
-	public function testAStoredChecksumOfAnotherShapeIsIgnored(): void {
-		$files = $this->gather(fileRef: ['path' => $this->path, 'checksum' => md5('archival bytes')]);
-
-		$this->assertSame(hash('sha256', 'archival bytes'), $files[0]['checksum']);
 	}
 
 	/**
@@ -105,8 +85,16 @@ class EdepotTransferServiceFilesTest extends TestCase {
 
 		$reflection = new ReflectionClass(EdepotTransferService::class);
 		$service = $reflection->newInstanceWithoutConstructor();
-		$method = $reflection->getMethod('getObjectFiles');
 
-		return $method->invoke($service, $object);
+		// A readonly property may be initialised once, from inside its class.
+		Closure::bind(
+			function (): void {
+				$this->packagedFileChecksum = new PackagedFileChecksum();
+			},
+			$service,
+			EdepotTransferService::class
+		)();
+
+		return $reflection->getMethod('getObjectFiles')->invoke($service, $object);
 	}
 }

--- a/tests/Unit/Service/Edepot/EdepotTransferServiceFilesTest.php
+++ b/tests/Unit/Service/Edepot/EdepotTransferServiceFilesTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * EdepotTransferService file-gathering tests
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Edepot
+ * @author   Conduction Development Team <dev@conduction.nl>
+ * @license  EUPL-1.2
+ */
+
+namespace Unit\Service\Edepot;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\Edepot\EdepotTransferService;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use RuntimeException;
+
+/**
+ * The checksum the SIP carries is computed and dated at packaging, and a
+ * stored SHA-256 that no longer matches the bytes is refused.
+ *
+ * `getObjectFiles()` touches none of the service's collaborators, so the
+ * service is built without its constructor and the method reached by
+ * reflection. That keeps the test about this one behaviour.
+ */
+class EdepotTransferServiceFilesTest extends TestCase {
+
+	private string $path;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->path = (string)tempnam(sys_get_temp_dir(), 'edepot');
+		file_put_contents($this->path, 'archival bytes');
+	}
+
+	protected function tearDown(): void {
+		@unlink($this->path);
+		parent::tearDown();
+	}
+
+	/**
+	 * With no stored checksum, one is computed and dated as an xsd:dateTime.
+	 */
+	public function testTheChecksumIsComputedAndDated(): void {
+		$files = $this->gather(fileRef: ['path' => $this->path, 'name' => 'a.txt']);
+
+		$this->assertSame(hash('sha256', 'archival bytes'), $files[0]['checksum']);
+		$this->assertMatchesRegularExpression(
+			'/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/',
+			$files[0]['checksumDate']
+		);
+	}
+
+	/**
+	 * A stored SHA-256 that matches is accepted, and the fresh one is used.
+	 */
+	public function testAMatchingStoredChecksumIsAccepted(): void {
+		$stored = strtoupper(hash('sha256', 'archival bytes'));
+
+		$files = $this->gather(fileRef: ['path' => $this->path, 'checksum' => $stored]);
+
+		$this->assertSame(hash('sha256', 'archival bytes'), $files[0]['checksum']);
+	}
+
+	/**
+	 * A stored SHA-256 that does NOT match the bytes is a fixity failure.
+	 *
+	 * Recomputing silently would launder the changed file into a package
+	 * that looks intact, so the file is refused.
+	 */
+	public function testAStaleStoredChecksumIsRefused(): void {
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/Fixity failure/');
+
+		$this->gather(fileRef: ['path' => $this->path, 'checksum' => hash('sha256', 'other bytes')]);
+	}
+
+	/**
+	 * A stored value that is not SHA-256-shaped cannot be compared, and is not used.
+	 */
+	public function testAStoredChecksumOfAnotherShapeIsIgnored(): void {
+		$files = $this->gather(fileRef: ['path' => $this->path, 'checksum' => md5('archival bytes')]);
+
+		$this->assertSame(hash('sha256', 'archival bytes'), $files[0]['checksum']);
+	}
+
+	/**
+	 * Run the private file gathering for one file reference.
+	 *
+	 * @param array<string, mixed> $fileRef The file reference on the object.
+	 *
+	 * @return array<int, array<string, mixed>> The gathered files.
+	 */
+	private function gather(array $fileRef): array {
+		$object = $this->getMockBuilder(ObjectEntity::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['getObject'])
+			->getMock();
+		$object->method('getObject')->willReturn(['_files' => [$fileRef]]);
+
+		$reflection = new ReflectionClass(EdepotTransferService::class);
+		$service = $reflection->newInstanceWithoutConstructor();
+		$method = $reflection->getMethod('getObjectFiles');
+
+		return $method->invoke($service, $object);
+	}
+}

--- a/tests/Unit/Service/Edepot/MdtoXmlGeneratorTest.php
+++ b/tests/Unit/Service/Edepot/MdtoXmlGeneratorTest.php
@@ -15,6 +15,8 @@ namespace Unit\Service\Edepot;
 
 use InvalidArgumentException;
 use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\Edepot\MdtoBestandGenerator;
+use OCA\OpenRegister\Service\Edepot\MdtoDocumentWriter;
 use OCA\OpenRegister\Service\Edepot\MdtoEventMapper;
 use OCA\OpenRegister\Service\Edepot\MdtoSourceReader;
 use OCA\OpenRegister\Service\Edepot\MdtoXmlGenerator;
@@ -55,11 +57,27 @@ class MdtoXmlGeneratorTest extends TestCase {
 		// make every absence test pass for the wrong reason.
 		$this->sourceReader = new MdtoSourceReader();
 
-		$this->generator = new MdtoXmlGenerator(
-			$this->appConfig,
+		$this->generator = $this->makeGenerator(appConfig: $this->appConfig, eventMapper: $this->eventMapper);
+	}
+
+	/**
+	 * Build a generator with real collaborators except the ones a test varies.
+	 *
+	 * @param IAppConfig $appConfig The app config.
+	 * @param MdtoEventMapper $eventMapper The event mapper.
+	 *
+	 * @return MdtoXmlGenerator The generator.
+	 */
+	private function makeGenerator(IAppConfig $appConfig, MdtoEventMapper $eventMapper): MdtoXmlGenerator {
+		$writer = new MdtoDocumentWriter();
+
+		return new MdtoXmlGenerator(
+			$appConfig,
 			$this->logger,
-			$this->eventMapper,
-			$this->sourceReader
+			$eventMapper,
+			$this->sourceReader,
+			$writer,
+			new MdtoBestandGenerator($writer)
 		);
 	}
 
@@ -89,35 +107,75 @@ class MdtoXmlGeneratorTest extends TestCase {
 	}
 
 	/**
-	 * Test generating MDTO XML with file references.
+	 * Deviation 2: a file is referenced from the informatieobject, never nested in it.
 	 */
-	public function testGenerateWithFiles(): void {
+	public function testFilesAreReferencedNotNested(): void {
 		$object = $this->createObjectEntity(
 			uuid: 'test-uuid-456',
-			retention: [
-				'archiefnominatie' => 'bewaren',
-				'bewaartermijn' => 'P10Y',
-				'classification' => 'B1',
-			]
+			retention: ['archiefnominatie' => 'bewaren', 'bewaartermijn' => 'P10Y', 'classification' => 'B1']
 		);
 
-		$files = [
-			[
-				'name' => 'document.pdf',
-				'size' => 1024,
-				'format' => 'application/pdf',
-				'checksum' => 'abc123def456',
-			],
-		];
+		$xml = $this->generator->generate($object, [$this->file()]);
 
-		$xml = $this->generator->generate($object, $files);
+		$this->assertStringNotContainsString('<mdto:bestand>', $xml);
+		$this->assertStringContainsString('<mdto:heeftRepresentatie>', $xml);
+		$this->assertStringContainsString('<mdto:verwijzingNaam>document.pdf</mdto:verwijzingNaam>', $xml);
+		$this->assertStringContainsString('<mdto:identificatieKenmerk>' . str_repeat('ab', 32) . '</mdto:identificatieKenmerk>', $xml);
+	}
 
-		$this->assertStringContainsString('mdto:bestand', $xml);
-		$this->assertStringContainsString('document.pdf', $xml);
-		$this->assertStringContainsString('1024', $xml);
-		$this->assertStringContainsString('application/pdf', $xml);
-		$this->assertStringContainsString('SHA-256', $xml);
-		$this->assertStringContainsString('abc123def456', $xml);
+	/**
+	 * Deviation 2: each file gets its own bestand document, pointing back at its object.
+	 */
+	public function testGenerateBestandDescribesTheFileAndItsObject(): void {
+		$object = $this->createObjectEntity(
+			uuid: 'test-uuid-456',
+			retention: ['archiefnominatie' => 'bewaren', 'bewaartermijn' => 'P10Y'],
+			objectData: ['title' => 'Besluit 14']
+		);
+
+		$xml = $this->generator->generateBestand($object, $this->file());
+
+		$this->assertStringContainsString('<mdto:MDTO', $xml);
+		$this->assertStringContainsString('<mdto:bestand>', $xml);
+		$this->assertStringNotContainsString('<mdto:informatieobject>', $xml);
+		$this->assertStringContainsString('<mdto:omvang>1024</mdto:omvang>', $xml);
+		// bestandsformaat as the standard's own example shows a media type.
+		$this->assertStringContainsString('<mdto:begripLabel>pdf</mdto:begripLabel>', $xml);
+		$this->assertStringContainsString('<mdto:begripCode>application/pdf</mdto:begripCode>', $xml);
+		$this->assertStringContainsString('<mdto:verwijzingNaam>IANA Media types</mdto:verwijzingNaam>', $xml);
+		// Deviation 5: checksumDatum is present.
+		$this->assertStringContainsString('<mdto:checksumDatum>2026-09-11T10:15:00+00:00</mdto:checksumDatum>', $xml);
+		$this->assertStringContainsString('<mdto:verwijzingNaam>Begrippenlijst ChecksumAlgoritme MDTO</mdto:verwijzingNaam>', $xml);
+		// isRepresentatieVan names the object by the identificatie its own document carries.
+		$this->assertStringContainsString('<mdto:isRepresentatieVan>', $xml);
+		$this->assertStringContainsString('<mdto:verwijzingNaam>Besluit 14</mdto:verwijzingNaam>', $xml);
+		$this->assertStringContainsString('<mdto:identificatieKenmerk>test-uuid-456</mdto:identificatieKenmerk>', $xml);
+	}
+
+	/**
+	 * A file whose checksum is not a SHA-256 is refused, because the document declares SHA-256.
+	 */
+	public function testGenerateBestandRefusesAChecksumThatIsNotSha256(): void {
+		$object = $this->createObjectEntity(uuid: 'u', retention: ['archiefnominatie' => 'bewaren', 'bewaartermijn' => 'P1Y']);
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessageMatches('/file\[0\]\.checksum \(a SHA-256\)/');
+
+		$this->generator->generateBestand($object, ['checksum' => 'abc123def456'] + $this->file());
+	}
+
+	/**
+	 * Deviation 5: a file without a checksum date is refused rather than stamped.
+	 */
+	public function testGenerateRefusesAFileWithoutAChecksumDate(): void {
+		$object = $this->createObjectEntity(uuid: 'u', retention: ['archiefnominatie' => 'bewaren', 'bewaartermijn' => 'P1Y']);
+		$file = $this->file();
+		unset($file['checksumDate']);
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessageMatches('/file\[0\]\.checksumDate/');
+
+		$this->generator->generate($object, [$file]);
 	}
 
 	/**
@@ -134,10 +192,154 @@ class MdtoXmlGeneratorTest extends TestCase {
 
 		$xml = $this->generator->generate($object);
 
-		// classificatie should default to 'onbekend' when missing.
-		$this->assertStringContainsString('onbekend', $xml);
-		// toelichting should not appear.
+		// Deviation 3: no category means no informatiecategorie, not the old 'onbekend' placeholder.
+		$this->assertStringNotContainsString('informatiecategorie', $xml);
+		$this->assertStringNotContainsString('onbekend', $xml);
+		// No toelichting means no omschrijving.
+		$this->assertStringNotContainsString('omschrijving', $xml);
 		$this->assertStringNotContainsString('toelichting', $xml);
+	}
+
+	/**
+	 * Deviation 1: the root is MDTO, carrying the schema version, with one informatieobject in it.
+	 */
+	public function testTheRootIsMdtoWithTheSchemaLocation(): void {
+		$object = $this->createObjectEntity(uuid: 'root-uuid', retention: ['archiefnominatie' => 'bewaren', 'bewaartermijn' => 'P5Y']);
+
+		$dom = new \DOMDocument();
+		$dom->loadXML($this->generator->generate($object));
+
+		$this->assertSame('MDTO', $dom->documentElement->localName);
+		$this->assertSame(MdtoDocumentWriter::MDTO_NAMESPACE, $dom->documentElement->namespaceURI);
+		$this->assertStringContainsString(
+			MdtoDocumentWriter::SCHEMA_LOCATION,
+			$dom->documentElement->getAttributeNS('http://www.w3.org/2001/XMLSchema-instance', 'schemaLocation')
+		);
+		$this->assertSame(1, $dom->documentElement->childNodes->length - $this->whitespaceNodes($dom->documentElement));
+		$this->assertSame('informatieobject', $dom->documentElement->firstElementChild->localName);
+	}
+
+	/**
+	 * Deviation 6: toelichting is exported as MDTO's omschrijving.
+	 */
+	public function testToelichtingBecomesOmschrijving(): void {
+		$object = $this->createObjectEntity(
+			uuid: 'desc-uuid',
+			retention: ['archiefnominatie' => 'bewaren', 'bewaartermijn' => 'P5Y', 'toelichting' => 'Bij besluit 14']
+		);
+
+		$xml = $this->generator->generate($object);
+
+		$this->assertStringContainsString('<mdto:omschrijving>Bij besluit 14</mdto:omschrijving>', $xml);
+		$this->assertStringNotContainsString('toelichting', $xml);
+	}
+
+	/**
+	 * Deviation 3: waardering is a begripGegevens from the CLOSED Waarderingen list.
+	 *
+	 * @param string $nominatie The stored archiefnominatie.
+	 * @param string $code The expected Waarderingen code.
+	 * @param string $label The expected Waarderingen label.
+	 *
+	 * @return void
+	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('appraisals')]
+	public function testWaarderingUsesTheClosedWaarderingenList(string $nominatie, string $code, string $label): void {
+		$object = $this->createObjectEntity(uuid: 'w', retention: ['archiefnominatie' => $nominatie, 'bewaartermijn' => 'P5Y']);
+
+		$xml = $this->generator->generate($object);
+
+		$this->assertMatchesRegularExpression(
+			'#<mdto:waardering>\s*<mdto:begripLabel>' . $label . '</mdto:begripLabel>\s*<mdto:begripCode>' . $code
+			. '</mdto:begripCode>\s*<mdto:begripBegrippenlijst>\s*<mdto:verwijzingNaam>Waarderingen</mdto:verwijzingNaam>#',
+			$xml
+		);
+	}
+
+	/**
+	 * Every archiefnominatie the codebase writes, and its Waarderingen term.
+	 *
+	 * @return array<string, array{0: string, 1: string, 2: string}>
+	 */
+	public static function appraisals(): array {
+		return [
+			'bewaren' => ['bewaren', 'B', 'Blijvend te bewaren'],
+			'blijvend_bewaren' => ['blijvend_bewaren', 'B', 'Blijvend te bewaren'],
+			'vernietigen' => ['vernietigen', 'V', 'Tijdelijk te bewaren'],
+			'nog_niet_bepaald' => ['nog_niet_bepaald', 'N', 'Nader te bepalen'],
+		];
+	}
+
+	/**
+	 * A value outside the closed list is refused, not written as an invalid label.
+	 */
+	public function testAnAppraisalOutsideTheClosedListIsRefused(): void {
+		$object = $this->createObjectEntity(uuid: 'w', retention: ['archiefnominatie' => 'misschien', 'bewaartermijn' => 'P5Y']);
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessageMatches('/retention\.archiefnominatie \(one of: /');
+
+		$this->generator->generate($object);
+	}
+
+	/**
+	 * Deviation 4: bewaartermijn is a termijnGegevens, with the end date when the record has one.
+	 */
+	public function testBewaartermijnIsATermijnGegevens(): void {
+		$object = $this->createObjectEntity(
+			uuid: 't',
+			retention: ['archiefnominatie' => 'bewaren', 'bewaartermijn' => 'P20Y', 'archiefactiedatum' => '2046-09-11']
+		);
+
+		$xml = $this->generator->generate($object);
+
+		$this->assertMatchesRegularExpression(
+			'#<mdto:bewaartermijn>\s*<mdto:termijnLooptijd>P20Y</mdto:termijnLooptijd>\s*'
+			. '<mdto:termijnEinddatum>2046-09-11</mdto:termijnEinddatum>\s*</mdto:bewaartermijn>#',
+			$xml
+		);
+	}
+
+	/**
+	 * A retention period that is not an xsd:duration is refused.
+	 *
+	 * `P2W` is the case that matters: PHP's DateInterval accepts it, the XSD does not.
+	 */
+	public function testABewaartermijnThatIsNotAnXsdDurationIsRefused(): void {
+		$object = $this->createObjectEntity(uuid: 't', retention: ['archiefnominatie' => 'bewaren', 'bewaartermijn' => 'P2W']);
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessageMatches('/retention\.bewaartermijn \(an ISO-8601/');
+
+		$this->generator->generate($object);
+	}
+
+	/**
+	 * Deviation 3: informatiecategorie names its selectielijst, or says it is a selectielijst.
+	 */
+	public function testInformatiecategorieNamesItsSelectielijst(): void {
+		$named = $this->createObjectEntity(
+			uuid: 'c',
+			retention: [
+				'archiefnominatie' => 'bewaren',
+				'bewaartermijn' => 'P5Y',
+				'classification' => 'A1',
+				'selectielijstBron' => 'Selectielijst gemeenten 2020',
+			]
+		);
+		$unnamed = $this->createObjectEntity(
+			uuid: 'c',
+			retention: ['archiefnominatie' => 'bewaren', 'bewaartermijn' => 'P5Y', 'classification' => 'A1']
+		);
+
+		$this->assertStringContainsString(
+			'<mdto:verwijzingNaam>Selectielijst gemeenten 2020</mdto:verwijzingNaam>',
+			$this->generator->generate($named)
+		);
+		$this->assertStringContainsString(
+			'<mdto:verwijzingNaam>' . MdtoXmlGenerator::CATEGORY_LIST_FALLBACK . '</mdto:verwijzingNaam>',
+			$this->generator->generate($unnamed)
+		);
 	}
 
 	/**
@@ -163,7 +365,7 @@ class MdtoXmlGeneratorTest extends TestCase {
 		$appConfig->method('getValueString')
 			->willReturn('');
 
-		$generator = new MdtoXmlGenerator($appConfig, $this->logger, $this->eventMapper, $this->sourceReader);
+		$generator = $this->makeGenerator(appConfig: $appConfig, eventMapper: $this->eventMapper);
 
 		$object = $this->createObjectEntity(
 			uuid: 'test-uuid',
@@ -323,9 +525,12 @@ class MdtoXmlGeneratorTest extends TestCase {
 	}
 
 	/**
-	 * A3: a RELEASED legal hold is not a restriction.
+	 * A RELEASED legal hold is not a restriction, so the unrecorded term is used.
+	 *
+	 * The XSD requires beperkingGebruik, so "no restriction known" is written
+	 * as the standard's own "Nader te bepalen", never as the hold's "Overig".
 	 */
-	public function testUseRestrictionAbsentWhenLegalHoldReleased(): void {
+	public function testAReleasedLegalHoldYieldsTheUnrecordedTerm(): void {
 		$object = $this->createObjectEntity(
 			uuid: 'hold-uuid',
 			retention: [
@@ -337,7 +542,9 @@ class MdtoXmlGeneratorTest extends TestCase {
 
 		$xml = $this->generator->generate($object);
 
-		$this->assertStringNotContainsString('beperkingGebruik', $xml);
+		$this->assertStringContainsString('<mdto:beperkingGebruik>', $xml);
+		$this->assertStringContainsString('<mdto:begripLabel>Nader te bepalen</mdto:begripLabel>', $xml);
+		$this->assertStringNotContainsString('<mdto:begripLabel>Overig</mdto:begripLabel>', $xml);
 	}
 
 	/**
@@ -423,7 +630,7 @@ class MdtoXmlGeneratorTest extends TestCase {
 			]
 		);
 
-		$generator = new MdtoXmlGenerator($this->appConfig, $this->logger, $eventMapper, $this->sourceReader);
+		$generator = $this->makeGenerator(appConfig: $this->appConfig, eventMapper: $eventMapper);
 		$object = $this->createObjectEntity(
 			uuid: 'event-uuid',
 			retention: ['archiefnominatie' => 'bewaren', 'bewaartermijn' => 'P5Y']
@@ -469,30 +676,34 @@ class MdtoXmlGeneratorTest extends TestCase {
 			[['type' => 'Creatie', 'time' => '2026-01-01T09:00:00+00:00', 'actorName' => null, 'actorId' => null]]
 		);
 
-		$generator = new MdtoXmlGenerator($this->appConfig, $this->logger, $eventMapper, $this->sourceReader);
+		$generator = $this->makeGenerator(appConfig: $this->appConfig, eventMapper: $eventMapper);
 		$object = $this->createObjectEntity(
 			uuid: 'order-uuid',
 			retention: [
 				'archiefnominatie' => 'bewaren',
 				'bewaartermijn' => 'P5Y',
 				'aggregationLevel' => 'Dossier',
+				'toelichting' => 'Omschrijving',
+				'classification' => 'A1',
 				'temporalCoverage' => ['type' => 'Looptijd', 'start' => '2021-01-01'],
 				'useRestriction' => 'Geen beperking',
 			]
 		);
 
-		$xml = $generator->generate($object);
+		$xml = $generator->generate($object, [$this->file()]);
 
 		$positions = [];
 		foreach (
 			[
 				'<mdto:naam>',
 				'<mdto:aggregatieniveau>',
+				'<mdto:omschrijving>',
 				'<mdto:dekkingInTijd>',
 				'<mdto:event>',
 				'<mdto:waardering>',
 				'<mdto:bewaartermijn>',
 				'<mdto:informatiecategorie>',
+				'<mdto:heeftRepresentatie>',
 				'<mdto:archiefvormer>',
 				'<mdto:beperkingGebruik>',
 			] as $tag
@@ -505,6 +716,39 @@ class MdtoXmlGeneratorTest extends TestCase {
 		$sorted = $positions;
 		sort($sorted);
 		$this->assertSame($sorted, $positions, 'Elements are not in the MDTO XSD sequence order');
+	}
+
+	/**
+	 * A well-formed file entry, as EdepotTransferService builds one.
+	 *
+	 * @return array<string, mixed> The file.
+	 */
+	private function file(): array {
+		return [
+			'name' => 'document.pdf',
+			'size' => 1024,
+			'format' => 'application/pdf',
+			'checksum' => str_repeat('ab', 32),
+			'checksumDate' => '2026-09-11T10:15:00+00:00',
+		];
+	}
+
+	/**
+	 * Count the whitespace-only text nodes directly under an element.
+	 *
+	 * @param \DOMElement $element The element.
+	 *
+	 * @return int The count.
+	 */
+	private function whitespaceNodes(\DOMElement $element): int {
+		$count = 0;
+		foreach ($element->childNodes as $node) {
+			if ($node instanceof \DOMText && trim($node->textContent) === '') {
+				$count++;
+			}
+		}
+
+		return $count;
 	}
 
 	/**

--- a/tests/Unit/Service/Edepot/MdtoXmlGeneratorTest.php
+++ b/tests/Unit/Service/Edepot/MdtoXmlGeneratorTest.php
@@ -165,6 +165,67 @@ class MdtoXmlGeneratorTest extends TestCase {
 	}
 
 	/**
+	 * Every per-file input is refused when absent or malformed, not just the checksum.
+	 *
+	 * `name` and `format` matter most here because the XSD cannot catch them:
+	 * an empty string is a valid `xsd:string`, so an empty `naam` or
+	 * `begripLabel` validates while saying nothing.
+	 *
+	 * @param string $key The file key to break.
+	 * @param mixed $value The broken value, or null to remove the key.
+	 * @param string $named The fragment the error must name.
+	 *
+	 * @return void
+	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('brokenFileInputs')]
+	public function testEachFileInputIsRequired(string $key, mixed $value, string $named): void {
+		$object = $this->createObjectEntity(uuid: 'u', retention: ['archiefnominatie' => 'bewaren', 'bewaartermijn' => 'P1Y']);
+		$file = $this->file();
+		if ($value === null) {
+			unset($file[$key]);
+		} else {
+			$file[$key] = $value;
+		}
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage($named);
+
+		$this->generator->generate($object, [$file]);
+	}
+
+	/**
+	 * Each per-file input, broken one at a time.
+	 *
+	 * @return array<string, array{0: string, 1: mixed, 2: string}>
+	 */
+	public static function brokenFileInputs(): array {
+		return [
+			'name missing' => ['name', null, 'file[0].name'],
+			'name empty' => ['name', '', 'file[0].name'],
+			'format missing' => ['format', null, 'file[0].format'],
+			'format empty' => ['format', '', 'file[0].format'],
+			'size missing' => ['size', null, 'file[0].size (a non-negative integer)'],
+			'size not an integer' => ['size', '1.5kB', 'file[0].size (a non-negative integer)'],
+		];
+	}
+
+	/**
+	 * A declared dekkingInTijd start outside the XSD's date union drops the entry.
+	 */
+	public function testTemporalCoverageWithADateTimeStartIsDropped(): void {
+		$object = $this->createObjectEntity(
+			uuid: 'cov-uuid',
+			retention: [
+				'archiefnominatie' => 'bewaren',
+				'bewaartermijn' => 'P5Y',
+				'temporalCoverage' => ['type' => 'Looptijd', 'start' => '2021-01-01T10:00:00'],
+			]
+		);
+
+		$this->assertStringNotContainsString('dekkingInTijd', $this->generator->generate($object));
+	}
+
+	/**
 	 * Deviation 5: a file without a checksum date is refused rather than stamped.
 	 */
 	public function testGenerateRefusesAFileWithoutAChecksumDate(): void {

--- a/tests/Unit/Service/Edepot/MdtoXmlGeneratorXsdTest.php
+++ b/tests/Unit/Service/Edepot/MdtoXmlGeneratorXsdTest.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * MdtoXmlGenerator XSD conformance tests
+ *
+ * Validates generated documents against the vendored MDTO-XML 1.0.1 XSD.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Edepot
+ * @author   Conduction Development Team <dev@conduction.nl>
+ * @license  EUPL-1.2
+ */
+
+namespace Unit\Service\Edepot;
+
+use DOMDocument;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\Edepot\MdtoEventMapper;
+use OCA\OpenRegister\Service\Edepot\MdtoSourceReader;
+use OCA\OpenRegister\Service\Edepot\MdtoXmlGenerator;
+use OCP\IAppConfig;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * The guard behind the spec's claim that MDTO output validates against the XSD.
+ *
+ * Every case builds a real document through the real generator and the real
+ * source reader, then hands it to libxml's schema validator. A failure message
+ * carries libxml's own error lines, so it names the element that broke rather
+ * than reporting a bare `false`.
+ */
+class MdtoXmlGeneratorXsdTest extends TestCase {
+
+	/**
+	 * The vendored schema, relative to this file.
+	 */
+	private const XSD = __DIR__ . '/../../../../lib/Resources/mdto/MDTO-XML1.0.1.xsd';
+
+	/**
+	 * The schema's recorded provenance.
+	 */
+	private const VERSION_FILE = __DIR__ . '/../../../../lib/Resources/mdto/version.json';
+
+	/**
+	 * Representative objects: minimal, with files, with every optional element.
+	 *
+	 * @return array<string, array{0: array<string,mixed>, 1: array<string,mixed>, 2: list<array<string,mixed>>, 3: list<array<string,mixed>>}>
+	 */
+	public static function representativeObjects(): array {
+		$base = ['archiefnominatie' => 'bewaren', 'bewaartermijn' => 'P20Y', 'classification' => 'A1'];
+
+		$file = [
+			'name' => 'besluit.pdf',
+			'size' => 20480,
+			'format' => 'application/pdf',
+			'checksum' => str_repeat('ab', 32),
+		];
+
+		$event = [
+			'type' => 'Creatie',
+			'time' => '2026-01-01T09:00:00+00:00',
+			'actorName' => 'Jane Doe',
+			'actorId' => 'jdoe',
+		];
+
+		return [
+			'minimal, no files, no optional elements' => [$base, [], [], []],
+			'no classification, so informatiecategorie has no source' => [
+				['archiefnominatie' => 'vernietigen', 'bewaartermijn' => 'P5Y'],
+				[],
+				[],
+				[],
+			],
+			'with one file' => [$base, [], [$file], []],
+			'with two files' => [
+				$base,
+				[],
+				[$file, ['name' => 'bijlage.docx', 'size' => 1, 'format' => 'application/msword', 'checksum' => 'ff']],
+				[],
+			],
+			'every optional element, legal hold as the restriction' => [
+				$base + [
+					'toelichting' => 'Dossier bij besluit 2026/14',
+					'aggregationLevel' => 'Dossier',
+					'temporalCoverage' => ['type' => 'Looptijd', 'start' => '2021-01-01', 'end' => '2021-12-31'],
+					'legalHold' => ['active' => true, 'reason' => 'Lopend bezwaar', 'placedDate' => '2026-03-04T10:11:12+00:00'],
+				],
+				[],
+				[$file],
+				[$event, ['type' => 'Wijziging', 'time' => '2026-02-02T09:00:00+00:00', 'actorName' => null, 'actorId' => null]],
+			],
+			'declared restriction and TMLO-sourced aggregation level' => [
+				$base + ['useRestriction' => ['type' => 'Geen beperking', 'description' => 'Openbaar na toetsing']],
+				['aggregatieniveau' => ['label' => 'Archiefstuk', 'code' => 'AS']],
+				[],
+				[$event],
+			],
+			'nog niet bepaald waardering' => [
+				['archiefnominatie' => 'nog_niet_bepaald', 'bewaartermijn' => 'P1Y'],
+				[],
+				[],
+				[],
+			],
+		];
+	}//end representativeObjects()
+
+	/**
+	 * Every representative object produces a document the XSD accepts.
+	 *
+	 * @param array<string,mixed> $retention The retention block.
+	 * @param array<string,mixed> $tmlo The TMLO block.
+	 * @param list<array<string,mixed>> $files The file entries.
+	 * @param list<array<string,mixed>> $events The events the mapper returns.
+	 *
+	 * @return void
+	 */
+	#[DataProvider('representativeObjects')]
+	public function testGeneratedDocumentValidatesAgainstTheMdtoXsd(
+		array $retention,
+		array $tmlo,
+		array $files,
+		array $events,
+	): void {
+		$xml = $this->generator(events: $events)->generate(
+			$this->objectEntity(retention: $retention, tmlo: $tmlo),
+			$files
+		);
+
+		$errors = $this->schemaErrors(xml: $xml);
+
+		$this->assertSame(
+			[],
+			$errors,
+			"The generated document does not validate against MDTO-XML1.0.1.xsd:\n  "
+			. implode("\n  ", $errors) . "\n\nDocument:\n" . $xml
+		);
+	}//end testGeneratedDocumentValidatesAgainstTheMdtoXsd()
+
+	/**
+	 * Negative control: the validator really rejects a non-conforming document.
+	 *
+	 * Without this, a validator that could not load the schema, or that
+	 * accepted anything, would make every case above pass for no reason.
+	 *
+	 * @return void
+	 */
+	public function testTheValidatorRejectsANonConformingDocument(): void {
+		$errors = $this->schemaErrors(
+			xml: '<?xml version="1.0" encoding="UTF-8"?>'
+			. '<mdto:MDTO xmlns:mdto="https://www.nationaalarchief.nl/mdto">'
+			. '<mdto:informatieobject><mdto:naam>zonder identificatie</mdto:naam></mdto:informatieobject>'
+			. '</mdto:MDTO>'
+		);
+
+		$this->assertNotSame([], $errors, 'A document missing identificatie was accepted, so the validator is not validating');
+	}//end testTheValidatorRejectsANonConformingDocument()
+
+	/**
+	 * The vendored schema is the one version.json says it is.
+	 *
+	 * The file is what the export is held to. An edit to it, even a well-meant
+	 * one, silently moves the goalposts, so its checksum is pinned.
+	 *
+	 * @return void
+	 */
+	public function testTheVendoredXsdMatchesItsRecordedChecksum(): void {
+		$recorded = json_decode((string)file_get_contents(self::VERSION_FILE), true);
+
+		$this->assertIsArray($recorded);
+		$this->assertSame($recorded['sha256'], hash_file('sha256', self::XSD));
+	}//end testTheVendoredXsdMatchesItsRecordedChecksum()
+
+	/**
+	 * Validate a document and return libxml's error lines.
+	 *
+	 * @param string $xml The document.
+	 *
+	 * @return list<string> Empty when the document is valid.
+	 */
+	private function schemaErrors(string $xml): array {
+		$previous = libxml_use_internal_errors(true);
+		libxml_clear_errors();
+
+		$dom = new DOMDocument();
+		$loaded = $dom->loadXML($xml);
+		$valid = ($loaded === true && $dom->schemaValidate(self::XSD) === true);
+
+		$errors = [];
+		foreach (libxml_get_errors() as $error) {
+			$errors[] = 'line ' . $error->line . ': ' . trim($error->message);
+		}
+
+		libxml_clear_errors();
+		libxml_use_internal_errors($previous);
+
+		if ($valid === false && $errors === []) {
+			$errors[] = 'schemaValidate returned false without reporting an error';
+		}
+
+		return $errors;
+	}//end schemaErrors()
+
+	/**
+	 * Build a generator with a real source reader and a stubbed event history.
+	 *
+	 * @param list<array<string,mixed>> $events The events the mapper returns.
+	 *
+	 * @return MdtoXmlGenerator The generator.
+	 */
+	private function generator(array $events): MdtoXmlGenerator {
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getValueString')->willReturnMap(
+			[
+				['openregister', 'organisation_identifier', '', 'ORG-001'],
+				['openregister', 'organisation_identifier', 'OpenRegister', 'ORG-001'],
+				['openregister', 'organisation_name', '', 'Gemeente Voorbeeld'],
+				['openregister', 'organisation_name', 'OpenRegister', 'Gemeente Voorbeeld'],
+			]
+		);
+
+		$eventMapper = $this->createMock(MdtoEventMapper::class);
+		$eventMapper->method('forObject')->willReturn($events);
+
+		return new MdtoXmlGenerator(
+			$appConfig,
+			$this->createMock(LoggerInterface::class),
+			$eventMapper,
+			new MdtoSourceReader()
+		);
+	}//end generator()
+
+	/**
+	 * Build a mock ObjectEntity.
+	 *
+	 * @param array<string,mixed> $retention The retention block.
+	 * @param array<string,mixed> $tmlo The TMLO block.
+	 *
+	 * @return ObjectEntity&MockObject The mock.
+	 */
+	private function objectEntity(array $retention, array $tmlo): ObjectEntity&MockObject {
+		$object = $this->getMockBuilder(ObjectEntity::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['getUuid', 'getObject'])
+			->addMethods(['getRetention', 'getTmlo'])
+			->getMock();
+		$object->method('getUuid')->willReturn('0b1e9c52-5f3a-4f9e-9d0a-2b6c1d7e8f90');
+		$object->method('getObject')->willReturn(['title' => 'Besluit omgevingsvergunning Kerkstraat 1']);
+		$object->method('getRetention')->willReturn($retention);
+		$object->method('getTmlo')->willReturn($tmlo);
+
+		return $object;
+	}//end objectEntity()
+}//end class

--- a/tests/Unit/Service/Edepot/MdtoXmlGeneratorXsdTest.php
+++ b/tests/Unit/Service/Edepot/MdtoXmlGeneratorXsdTest.php
@@ -119,6 +119,15 @@ class MdtoXmlGeneratorXsdTest extends TestCase {
 				[],
 				[$event],
 			],
+			'malformed declared dates are dropped, not written' => [
+				$base + [
+					'temporalCoverage' => ['type' => 'Looptijd', 'start' => '2021', 'end' => '31-12-2021'],
+					'useRestriction' => ['type' => 'Overig', 'startDate' => 'gisteren'],
+				],
+				[],
+				[],
+				[],
+			],
 			'nog niet bepaald waardering' => [
 				['archiefnominatie' => 'nog_niet_bepaald', 'bewaartermijn' => 'P1Y'],
 				[],

--- a/tests/Unit/Service/Edepot/MdtoXmlGeneratorXsdTest.php
+++ b/tests/Unit/Service/Edepot/MdtoXmlGeneratorXsdTest.php
@@ -257,8 +257,10 @@ class MdtoXmlGeneratorXsdTest extends TestCase {
 	/**
 	 * Negative control: the validator really rejects a non-conforming document.
 	 *
-	 * Without this, a validator that could not load the schema, or that
-	 * accepted anything, would make every case above pass for no reason.
+	 * Without this, a validator that accepted anything would make every case
+	 * above pass for no reason. It must also be the SCHEMA that rejects: a
+	 * schema that failed to load rejects everything too, and that is not a
+	 * verdict on the document.
 	 *
 	 * @return void
 	 */
@@ -271,6 +273,15 @@ class MdtoXmlGeneratorXsdTest extends TestCase {
 		);
 
 		$this->assertNotSame([], $errors, 'A document missing identificatie was accepted, so the validator is not validating');
+
+		// A rejection only counts if the SCHEMA made it. Under Nextcloud's
+		// null entity loader, schemaValidate(path) fails to load the schema
+		// and returns errors for every document, which satisfied the check
+		// above while proving nothing.
+		$joined = implode("\n", $errors);
+		$this->assertStringNotContainsString('Failed to load external entity', $joined, 'The schema never loaded');
+		$this->assertStringNotContainsString('Failed to parse the XML resource', $joined, 'The schema never loaded');
+		$this->assertStringContainsString('identificatie', $joined, 'The rejection must name the missing element');
 	}//end testTheValidatorRejectsANonConformingDocument()
 
 	/**
@@ -318,9 +329,16 @@ class MdtoXmlGeneratorXsdTest extends TestCase {
 		$previous = libxml_use_internal_errors(true);
 		libxml_clear_errors();
 
+		// schemaValidateSource over the schema's CONTENTS, never
+		// schemaValidate(path). Reading the file is plain PHP I/O, outside
+		// libxml's external-entity loader, so it works under Nextcloud's XXE
+		// protection without loosening it. That is sufficient only because
+		// MDTO-XML1.0.1.xsd imports and includes nothing: a schema that did
+		// would still ask the loader for those.
 		$dom = new DOMDocument();
 		$loaded = $dom->loadXML($xml);
-		$valid = ($loaded === true && $dom->schemaValidate(self::XSD) === true);
+		$schema = (string)file_get_contents(self::XSD);
+		$valid = ($loaded === true && $dom->schemaValidateSource($schema) === true);
 
 		$errors = [];
 		foreach (libxml_get_errors() as $error) {

--- a/tests/Unit/Service/Edepot/MdtoXmlGeneratorXsdTest.php
+++ b/tests/Unit/Service/Edepot/MdtoXmlGeneratorXsdTest.php
@@ -39,6 +39,44 @@ use Psr\Log\LoggerInterface;
 class MdtoXmlGeneratorXsdTest extends TestCase {
 
 	/**
+	 * The external-entity loader in force before this test, restored after it.
+	 *
+	 * @var callable|null
+	 */
+	private $previousEntityLoader = null;
+
+	/**
+	 * Install the entity loader a booted Nextcloud installs.
+	 *
+	 * Nextcloud's XXE protection makes libxml's external-entity loader return
+	 * null for every resource. CI runs this suite inside a booted Nextcloud, a
+	 * local run usually does not, and a validation that reads the schema FROM
+	 * DISK passed locally and failed in CI with "Failed to load external
+	 * entity because the resolver function returned null". Carrying the
+	 * condition into the test means a local run cannot pass for that wrong
+	 * reason again.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->previousEntityLoader = libxml_get_external_entity_loader();
+		libxml_set_external_entity_loader(static fn (): mixed => null);
+	}//end setUp()
+
+	/**
+	 * Restore whatever entity loader was in force before this test.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		libxml_set_external_entity_loader($this->previousEntityLoader);
+
+		parent::tearDown();
+	}//end tearDown()
+
+	/**
 	 * The vendored schema, relative to this file.
 	 */
 	private const XSD = __DIR__ . '/../../../../lib/Resources/mdto/MDTO-XML1.0.1.xsd';

--- a/tests/Unit/Service/Edepot/MdtoXmlGeneratorXsdTest.php
+++ b/tests/Unit/Service/Edepot/MdtoXmlGeneratorXsdTest.php
@@ -17,6 +17,8 @@ namespace Unit\Service\Edepot;
 
 use DOMDocument;
 use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Service\Edepot\MdtoBestandGenerator;
+use OCA\OpenRegister\Service\Edepot\MdtoDocumentWriter;
 use OCA\OpenRegister\Service\Edepot\MdtoEventMapper;
 use OCA\OpenRegister\Service\Edepot\MdtoSourceReader;
 use OCA\OpenRegister\Service\Edepot\MdtoXmlGenerator;
@@ -47,6 +49,11 @@ class MdtoXmlGeneratorXsdTest extends TestCase {
 	private const VERSION_FILE = __DIR__ . '/../../../../lib/Resources/mdto/version.json';
 
 	/**
+	 * The Nationaal Archief's own example documents.
+	 */
+	private const EXAMPLES = __DIR__ . '/../../../fixtures/mdto';
+
+	/**
 	 * Representative objects: minimal, with files, with every optional element.
 	 *
 	 * @return array<string, array{0: array<string,mixed>, 1: array<string,mixed>, 2: list<array<string,mixed>>, 3: list<array<string,mixed>>}>
@@ -59,6 +66,7 @@ class MdtoXmlGeneratorXsdTest extends TestCase {
 			'size' => 20480,
 			'format' => 'application/pdf',
 			'checksum' => str_repeat('ab', 32),
+			'checksumDate' => '2026-09-11T10:15:00+00:00',
 		];
 
 		$event = [
@@ -80,11 +88,22 @@ class MdtoXmlGeneratorXsdTest extends TestCase {
 			'with two files' => [
 				$base,
 				[],
-				[$file, ['name' => 'bijlage.docx', 'size' => 1, 'format' => 'application/msword', 'checksum' => 'ff']],
+				[
+					$file,
+					[
+						'name' => 'bijlage.docx',
+						'size' => 1,
+						'format' => 'application/msword; charset=binary',
+						'checksum' => str_repeat('CD', 32),
+						'checksumDate' => '2026-09-11T10:15:00Z',
+					],
+				],
 				[],
 			],
 			'every optional element, legal hold as the restriction' => [
 				$base + [
+					'archiefactiedatum' => '2046-09-11',
+					'selectielijstBron' => 'Selectielijst gemeenten en intergemeentelijke organen 2020',
 					'toelichting' => 'Dossier bij besluit 2026/14',
 					'aggregationLevel' => 'Dossier',
 					'temporalCoverage' => ['type' => 'Looptijd', 'start' => '2021-01-01', 'end' => '2021-12-31'],
@@ -110,6 +129,18 @@ class MdtoXmlGeneratorXsdTest extends TestCase {
 	}//end representativeObjects()
 
 	/**
+	 * The representative objects that carry files, for the bestand documents.
+	 *
+	 * @return array<string, array{0: array<string,mixed>, 1: array<string,mixed>, 2: list<array<string,mixed>>, 3: list<array<string,mixed>>}>
+	 */
+	public static function representativeObjectsWithFiles(): array {
+		return array_filter(
+			self::representativeObjects(),
+			static fn (array $case): bool => $case[2] !== []
+		);
+	}//end representativeObjectsWithFiles()
+
+	/**
 	 * Every representative object produces a document the XSD accepts.
 	 *
 	 * @param array<string,mixed> $retention The retention block.
@@ -131,15 +162,50 @@ class MdtoXmlGeneratorXsdTest extends TestCase {
 			$files
 		);
 
-		$errors = $this->schemaErrors(xml: $xml);
-
-		$this->assertSame(
-			[],
-			$errors,
-			"The generated document does not validate against MDTO-XML1.0.1.xsd:\n  "
-			. implode("\n  ", $errors) . "\n\nDocument:\n" . $xml
-		);
+		$this->assertValidMdto(xml: $xml, what: 'informatieobject');
 	}//end testGeneratedDocumentValidatesAgainstTheMdtoXsd()
+
+	/**
+	 * Every file's own `bestand` document validates too.
+	 *
+	 * @param array<string,mixed> $retention The retention block.
+	 * @param array<string,mixed> $tmlo The TMLO block.
+	 * @param list<array<string,mixed>> $files The file entries.
+	 * @param list<array<string,mixed>> $events The events the mapper returns.
+	 *
+	 * @return void
+	 */
+	#[DataProvider('representativeObjectsWithFiles')]
+	public function testEveryBestandDocumentValidatesAgainstTheMdtoXsd(
+		array $retention,
+		array $tmlo,
+		array $files,
+		array $events,
+	): void {
+		$generator = $this->generator(events: $events);
+		$object = $this->objectEntity(retention: $retention, tmlo: $tmlo);
+
+		foreach ($files as $file) {
+			$this->assertValidMdto(xml: $generator->generateBestand($object, $file), what: 'bestand ' . $file['name']);
+		}
+	}//end testEveryBestandDocumentValidatesAgainstTheMdtoXsd()
+
+	/**
+	 * Positive control: the Nationaal Archief's own example documents validate.
+	 *
+	 * Paired with the negative control below, this shows the harness accepts
+	 * a document the publisher calls valid and rejects one that is not.
+	 *
+	 * @return void
+	 */
+	public function testThePublishersOwnExamplesValidate(): void {
+		$examples = glob(self::EXAMPLES . '/*.xml');
+
+		$this->assertNotEmpty($examples, 'No official example documents found under ' . self::EXAMPLES);
+		foreach ($examples as $example) {
+			$this->assertValidMdto(xml: (string)file_get_contents($example), what: basename($example));
+		}
+	}//end testThePublishersOwnExamplesValidate()
 
 	/**
 	 * Negative control: the validator really rejects a non-conforming document.
@@ -174,6 +240,25 @@ class MdtoXmlGeneratorXsdTest extends TestCase {
 		$this->assertIsArray($recorded);
 		$this->assertSame($recorded['sha256'], hash_file('sha256', self::XSD));
 	}//end testTheVendoredXsdMatchesItsRecordedChecksum()
+
+	/**
+	 * Assert a document validates, naming every schema error when it does not.
+	 *
+	 * @param string $xml The document.
+	 * @param string $what What the document is, for the failure message.
+	 *
+	 * @return void
+	 */
+	private function assertValidMdto(string $xml, string $what): void {
+		$errors = $this->schemaErrors(xml: $xml);
+
+		$this->assertSame(
+			[],
+			$errors,
+			'The ' . $what . " document does not validate against MDTO-XML1.0.1.xsd:\n  "
+			. implode("\n  ", $errors) . "\n\nDocument:\n" . $xml
+		);
+	}//end assertValidMdto()
 
 	/**
 	 * Validate a document and return libxml's error lines.
@@ -226,11 +311,15 @@ class MdtoXmlGeneratorXsdTest extends TestCase {
 		$eventMapper = $this->createMock(MdtoEventMapper::class);
 		$eventMapper->method('forObject')->willReturn($events);
 
+		$writer = new MdtoDocumentWriter();
+
 		return new MdtoXmlGenerator(
 			$appConfig,
 			$this->createMock(LoggerInterface::class),
 			$eventMapper,
-			new MdtoSourceReader()
+			new MdtoSourceReader(),
+			$writer,
+			new MdtoBestandGenerator($writer)
 		);
 	}//end generator()
 

--- a/tests/Unit/Service/Edepot/PackagedFileChecksumTest.php
+++ b/tests/Unit/Service/Edepot/PackagedFileChecksumTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * PackagedFileChecksum Unit Tests
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Edepot
+ * @author   Conduction Development Team <dev@conduction.nl>
+ * @license  EUPL-1.2
+ */
+
+namespace Unit\Service\Edepot;
+
+use OCA\OpenRegister\Service\Edepot\PackagedFileChecksum;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * The checksum a package carries is computed and dated at packaging, and a
+ * stored SHA-256 that no longer matches the bytes is refused.
+ */
+class PackagedFileChecksumTest extends TestCase {
+
+	private string $path;
+
+	private PackagedFileChecksum $checksum;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->path = (string)tempnam(sys_get_temp_dir(), 'edepot');
+		file_put_contents($this->path, 'archival bytes');
+		$this->checksum = new PackagedFileChecksum();
+	}
+
+	protected function tearDown(): void {
+		@unlink($this->path);
+		parent::tearDown();
+	}
+
+	/**
+	 * With no stored checksum, one is computed and dated as an xsd:dateTime.
+	 */
+	public function testTheChecksumIsComputedAndDated(): void {
+		$result = $this->checksum->compute(path: $this->path, stored: null);
+
+		$this->assertSame(hash('sha256', 'archival bytes'), $result['checksum']);
+		$this->assertMatchesRegularExpression(
+			'/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/',
+			$result['checksumDate']
+		);
+	}
+
+	/**
+	 * A stored SHA-256 that matches, in either case, is accepted.
+	 */
+	public function testAMatchingStoredChecksumIsAccepted(): void {
+		$result = $this->checksum->compute(path: $this->path, stored: strtoupper(hash('sha256', 'archival bytes')));
+
+		$this->assertSame(hash('sha256', 'archival bytes'), $result['checksum']);
+	}
+
+	/**
+	 * A stored SHA-256 that does NOT match the bytes is a fixity failure.
+	 *
+	 * Recomputing silently would launder the changed file into a package
+	 * that looks intact, so the file is refused.
+	 */
+	public function testAStaleStoredChecksumIsRefused(): void {
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/Fixity failure/');
+
+		$this->checksum->compute(path: $this->path, stored: hash('sha256', 'other bytes'));
+	}
+
+	/**
+	 * A stored value that is not SHA-256-shaped cannot be compared, and is not used.
+	 */
+	public function testAStoredChecksumOfAnotherShapeIsIgnored(): void {
+		$result = $this->checksum->compute(path: $this->path, stored: md5('archival bytes'));
+
+		$this->assertSame(hash('sha256', 'archival bytes'), $result['checksum']);
+	}
+
+	/**
+	 * A file that cannot be read is refused, not given an empty checksum.
+	 */
+	public function testAnUnreadableFileIsRefused(): void {
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/Cannot read/');
+
+		@$this->checksum->compute(path: $this->path . '.missing', stored: null);
+	}
+}

--- a/tests/Unit/Service/Edepot/SipPackageBuilderTest.php
+++ b/tests/Unit/Service/Edepot/SipPackageBuilderTest.php
@@ -43,6 +43,8 @@ class SipPackageBuilderTest extends TestCase {
 
 		$this->mdtoGenerator->method('generate')
 			->willReturn('<?xml version="1.0"?><mdto:informatieobject/>');
+		$this->mdtoGenerator->method('generateBestand')
+			->willReturn('<?xml version="1.0"?><mdto:MDTO><mdto:bestand/></mdto:MDTO>');
 
 		$this->appConfig->method('getValueString')
 			->willReturn((string)SipPackageBuilder::DEFAULT_MAX_PACKAGE_SIZE);
@@ -191,6 +193,11 @@ class SipPackageBuilderTest extends TestCase {
 		// Payload relocated under data/.
 		$this->assertContains('data/objects/obj-uuid-1/mdto.xml', $entries);
 		$this->assertContains('data/objects/obj-uuid-1/content/original/doc.txt', $entries);
+		// The file's own MDTO bestand document sits next to it, named as the
+		// MDTO SIP specification prescribes.
+		$sidecar = 'data/objects/obj-uuid-1/content/original/doc.txt.bestand.MDTO.xml';
+		$this->assertContains($sidecar, $entries);
+		$this->assertStringContainsString('<mdto:bestand/>', (string)$zip->getFromName($sidecar));
 
 		// bagit.txt declares version 1.0.
 		$this->assertStringContainsString('BagIt-Version: 1.0', $zip->getFromName('bagit.txt'));
@@ -202,6 +209,7 @@ class SipPackageBuilderTest extends TestCase {
 		$manifest = $zip->getFromName('manifest-sha256.txt');
 		$this->assertStringContainsString('data/objects/obj-uuid-1/content/original/doc.txt', $manifest);
 		$this->assertStringContainsString(hash('sha256', 'hello archive'), $manifest);
+		$this->assertStringContainsString($sidecar, $manifest);
 
 		$zip->close();
 		unlink($result[0]);

--- a/tests/fixtures/mdto/provenance.json
+++ b/tests/fixtures/mdto/provenance.json
@@ -1,0 +1,31 @@
+{
+    "what": "The Nationaal Archief's own MDTO-XML 1.0.1 example documents, used as a positive control in MdtoXmlGeneratorXsdTest: the harness must accept what the publisher calls valid.",
+    "source": "https://github.com/NationaalArchief/MDTO-XSD/tree/afae5f300c8a92bbe3564d642017213bc7f4156f/voorbeelden",
+    "retrieved": "2026-09-11",
+    "modified": false,
+    "renamed": "Only the file names, to drop spaces; the bytes are unchanged, see sha256.",
+    "licence": "CC BY-SA, per Forum Standaardisatie FS-20241002.3C: \"Het Nationaal Archief hanteert de licentie CC BY SA voor al diens kennisproducten en dus ook voor MDTO.\" See lib/Resources/mdto/version.json.",
+    "attribution": "MDTO-XML 1.0.1 voorbeelden, Nationaal Archief, CC BY-SA. Redistributed unmodified.",
+    "files": [
+        {
+            "file": "voorbeeld-archiefstuk-informatieobject.xml",
+            "upstreamName": "MDTO-XML 1.0.1 Voorbeeld Archiefstuk Informatieobject.xml",
+            "sha256": "be391dc95c06796ea7254f3c425ce4b35972e16d4111b19359fe708ce9ee3386"
+        },
+        {
+            "file": "voorbeeld-bestand.xml",
+            "upstreamName": "MDTO-XML 1.0.1 Voorbeeld Bestand.xml",
+            "sha256": "779b1721466ce5c31c2babf23228e7c2bb8e30bc267fa0b6b3b0eea8a6badaf0"
+        },
+        {
+            "file": "voorbeeld-dossier-informatieobject.xml",
+            "upstreamName": "MDTO-XML 1.0.1 Voorbeeld Dossier Informatieobject.xml",
+            "sha256": "f445822a524d87f2e728aa8e7fb474d8f0f57f61a7b8a10b2808505d7fda507c"
+        },
+        {
+            "file": "voorbeeld-serie-informatieobject.xml",
+            "upstreamName": "MDTO-XML 1.0.1 Voorbeeld Serie Informatieobject.xml",
+            "sha256": "918da3a93260d2e3cc793eda1eaf413b129f5b48ec1d36fbee3b67d5696b698d"
+        }
+    ]
+}

--- a/tests/fixtures/mdto/voorbeeld-archiefstuk-informatieobject.xml
+++ b/tests/fixtures/mdto/voorbeeld-archiefstuk-informatieobject.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MDTO xmlns="https://www.nationaalarchief.nl/mdto" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.nationaalarchief.nl/mdto https://www.nationaalarchief.nl/mdto/MDTO-XML1.0.1.xsd">
+	<informatieobject>
+		<identificatie>
+			<identificatieKenmerk>DC-2015/1753</identificatieKenmerk>
+			<identificatieBron>Archief Deltacommissaris</identificatieBron>
+		</identificatie>
+		<naam>Atelier Kustkwaliteit, 2011. Ontwerpstudie Dwarsdoorsneden kust, vier Kustdoorsneden in beeld, Werkboek 2, Delft.</naam>
+		<aggregatieniveau>
+			<begripLabel>Archiefstuk</begripLabel>
+			<begripBegrippenlijst>
+				<verwijzingNaam>Begrippenlijst Aggregatieniveaus MDTO</verwijzingNaam>
+			</begripBegrippenlijst>
+		</aggregatieniveau>
+		<classificatie>
+			<begripLabel>Studie</begripLabel>
+			<begripCode>2.1.</begripCode>
+			<begripBegrippenlijst>
+				<verwijzingNaam>Ministerie IenW zaaksysteem begrippenlijst</verwijzingNaam>
+			</begripBegrippenlijst>
+		</classificatie>
+		<raadpleeglocatie>
+			<raadpleeglocatieOnline>https://www.nationaalarchief.nl/onderzoeken/archief/2.16.133/invnr/DC-2015%7C%7C1753/file/DC-2015_1753-1.PDF</raadpleeglocatieOnline>
+		</raadpleeglocatie>
+		<raadpleeglocatie>
+			<raadpleeglocatieFysiek>
+				<verwijzingNaam>Nationaal Archief Den Haag</verwijzingNaam>
+			</raadpleeglocatieFysiek>
+		</raadpleeglocatie>
+		<dekkingInRuimte>
+			<verwijzingNaam>Noordzeekust</verwijzingNaam>
+		</dekkingInRuimte>
+		<taal>nl</taal>
+		<event>
+			<eventType>
+				<begripLabel>Creatie</begripLabel>
+				<begripBegrippenlijst>
+					<verwijzingNaam>Begrippenlijst EventTypeLijst MDTO</verwijzingNaam>
+				</begripBegrippenlijst>
+			</eventType>
+			<eventTijd>2011-07-21T13:20:00</eventTijd>
+			<eventVerantwoordelijkeActor>
+				<verwijzingNaam>Beleidsmedewerker programma Deltacommissaris</verwijzingNaam>
+				<verwijzingIdentificatie>
+					<identificatieKenmerk>WH2360HHHJ</identificatieKenmerk>
+					<identificatieBron>ZZ-TRIMADDIN</identificatieBron>
+				</verwijzingIdentificatie>
+			</eventVerantwoordelijkeActor>
+		</event>
+		<event>
+			<eventType>
+				<begripLabel>Bevriezing</begripLabel>
+				<begripBegrippenlijst>
+					<verwijzingNaam>Begrippenlijst EventTypeLijst MDTO</verwijzingNaam>
+				</begripBegrippenlijst>
+			</eventType>
+			<eventTijd>2011-11-05T09:40:00</eventTijd>
+			<eventVerantwoordelijkeActor>
+				<verwijzingNaam>Medewerker informatiebeheer</verwijzingNaam>
+				<verwijzingIdentificatie>
+					<identificatieKenmerk>WH2360HHKJ</identificatieKenmerk>
+					<identificatieBron>ZZ-TRIMADDIN</identificatieBron>
+				</verwijzingIdentificatie>
+			</eventVerantwoordelijkeActor>
+		</event>
+		<event>
+			<eventType>
+				<begripLabel>Migratie</begripLabel>
+				<begripBegrippenlijst>
+					<verwijzingNaam>Begrippenlijst EventTypeLijst MDTO</verwijzingNaam>
+				</begripBegrippenlijst>
+			</eventType>
+			<eventTijd>2020-01-12T23:20:00</eventTijd>
+			<eventVerantwoordelijkeActor>
+				<verwijzingNaam>Medewerker informatiebeheer</verwijzingNaam>
+				<verwijzingIdentificatie>
+					<identificatieKenmerk>WH2360HHKJ</identificatieKenmerk>
+					<identificatieBron>ZZ-TRIMADDIN</identificatieBron>
+				</verwijzingIdentificatie>
+			</eventVerantwoordelijkeActor>
+		</event>
+		<waardering>
+			<begripLabel>Tijdelijk te bewaren</begripLabel>
+			<begripCode>V</begripCode>
+			<begripBegrippenlijst>
+				<verwijzingNaam>Begrippenlijst Waarderingen MDTO</verwijzingNaam>
+			</begripBegrippenlijst>
+		</waardering>
+		<bewaartermijn>
+			<termijnTriggerStartLooptijd>
+				<begripLabel>Bevriezing</begripLabel>
+				<begripBegrippenlijst>
+					<verwijzingNaam>Begrippenlijst EventTypeLijst MDTO</verwijzingNaam>
+				</begripBegrippenlijst>
+			</termijnTriggerStartLooptijd>
+			<termijnStartdatumLooptijd>2011-11-05</termijnStartdatumLooptijd>
+			<termijnLooptijd>P75Y</termijnLooptijd>
+			<termijnEinddatum>2086-11-05</termijnEinddatum>
+		</bewaartermijn>
+		<informatiecategorie>
+			<begripLabel>Primair beleid</begripLabel>
+			<begripCode>2.1.1</begripCode>
+			<begripBegrippenlijst>
+				<verwijzingNaam>Selectielijst ministerie van Infrastructuur en Milieu</verwijzingNaam>
+			</begripBegrippenlijst>
+		</informatiecategorie>
+		<isOnderdeelVan>
+			<verwijzingNaam>Brondocumenten en literatuur bij synthesedocument voorkeursstrategie Kust en strategische beslissing Zand</verwijzingNaam>
+			<verwijzingIdentificatie>
+				<identificatieKenmerk>DC/358</identificatieKenmerk>
+				<identificatieBron>Archief Deltacommissaris</identificatieBron>
+			</verwijzingIdentificatie>
+		</isOnderdeelVan>
+		<heeftRepresentatie>
+			<verwijzingNaam>DC-2015_1753-1.PDF</verwijzingNaam>
+			<verwijzingIdentificatie>
+				<identificatieKenmerk>50295847</identificatieKenmerk>
+				<identificatieBron>Proza</identificatieBron>
+			</verwijzingIdentificatie>
+		</heeftRepresentatie>
+		<aanvullendeMetagegevens>
+			<verwijzingNaam>RGBZ metadata.xml</verwijzingNaam>
+			<verwijzingIdentificatie>
+				<identificatieKenmerk>50295859</identificatieKenmerk>
+				<identificatieBron>Proza</identificatieBron>
+			</verwijzingIdentificatie>
+		</aanvullendeMetagegevens>	
+		<archiefvormer>
+			<verwijzingNaam>Ministerie van Infrastructuur en Waterstaat</verwijzingNaam>
+			<verwijzingIdentificatie>
+				<identificatieKenmerk>https://organisaties.overheid.nl/112773/Infrastructuur_en_Waterstaat</identificatieKenmerk>
+				<identificatieBron>Register van Overheidsorganisaties</identificatieBron>
+			</verwijzingIdentificatie>
+		</archiefvormer>
+		<betrokkene>
+			<betrokkeneTypeRelatie>
+				<begripLabel>Aanvrager</begripLabel>
+				<begripBegrippenlijst>
+					<verwijzingNaam>Ministerie IenW zaaksysteem begrippenlijst</verwijzingNaam>
+				</begripBegrippenlijst>
+			</betrokkeneTypeRelatie>
+			<betrokkeneActor>
+				<verwijzingNaam>Café ’t Hoekje</verwijzingNaam>
+				<verwijzingIdentificatie>
+					<identificatieKenmerk>20404451</identificatieKenmerk>
+					<identificatieBron>KVK</identificatieBron>
+				</verwijzingIdentificatie>
+			</betrokkeneActor>
+		</betrokkene>
+		<activiteit>
+			<verwijzingNaam>Behandelen vergunningsaanvragen</verwijzingNaam>
+			<verwijzingIdentificatie>
+				<identificatieKenmerk>821002193-20201</identificatieKenmerk>
+				<identificatieBron>GEMTE</identificatieBron>
+			</verwijzingIdentificatie>
+		</activiteit>
+		<beperkingGebruik>
+			<beperkingGebruikType>
+				<begripLabel>CC0</begripLabel>
+				<begripBegrippenlijst>
+					<verwijzingNaam>Ministerie IenW zaaksysteem begrippenlijst</verwijzingNaam>
+				</begripBegrippenlijst>
+			</beperkingGebruikType>
+			<beperkingGebruikNadereBeschrijving>CC0 Publiek domein</beperkingGebruikNadereBeschrijving>
+			<beperkingGebruikTermijn>
+				<termijnTriggerStartLooptijd>
+					<begripLabel>Sluiting dossier</begripLabel>
+					<begripBegrippenlijst>
+						<verwijzingNaam>Ministerie IenW zaaksysteem begrippenlijst</verwijzingNaam>
+					</begripBegrippenlijst>
+				</termijnTriggerStartLooptijd>
+				<termijnLooptijd>P70Y</termijnLooptijd>
+				<termijnEinddatum>2085-04-05</termijnEinddatum>
+			</beperkingGebruikTermijn>
+		</beperkingGebruik>
+	</informatieobject>
+</MDTO>

--- a/tests/fixtures/mdto/voorbeeld-bestand.xml
+++ b/tests/fixtures/mdto/voorbeeld-bestand.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MDTO xmlns="https://www.nationaalarchief.nl/mdto" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.nationaalarchief.nl/mdto https://www.nationaalarchief.nl/mdto/MDTO-XML1.0.1.xsd">
+	<bestand>
+		<identificatie>
+			<identificatieKenmerk>50295847</identificatieKenmerk>
+			<identificatieBron>Proza</identificatieBron>
+		</identificatie>
+		<naam>DC-2015_1753-1.PDF</naam>
+		<omvang>57727859</omvang>
+		<bestandsformaat>
+			<begripLabel>Acrobat PDF 1.3 - Portable Document Format</begripLabel>
+			<begripCode>fmt/17</begripCode>
+			<begripBegrippenlijst>
+				<verwijzingNaam>PRONOM-register</verwijzingNaam>
+			</begripBegrippenlijst>
+		</bestandsformaat>
+		<checksum>
+			<checksumAlgoritme>
+				<begripLabel>SHA256</begripLabel>
+				<begripBegrippenlijst>
+					<verwijzingNaam>Begrippenlijst ChecksumAlgoritme MDTO</verwijzingNaam>
+				</begripBegrippenlijst>
+			</checksumAlgoritme>
+			<checksumWaarde>86f16c3359c2e59538a3df178a9530dd6278faec82e66d605b3bc2a64ac390fc</checksumWaarde>
+			<checksumDatum>2025-02-18T15:24:18</checksumDatum>
+		</checksum>
+		<URLBestand>https://www.nationaalarchief.nl/onderzoeken/archief/2.16.133/invnr/DC-2015%7C%7C1753/file/DC-2015_1753-1.PDF</URLBestand>
+		<isRepresentatieVan>
+			<verwijzingNaam>Atelier Kustkwaliteit, 2011. Ontwerpstudie Dwarsdoorsneden kust, vier Kustdoorsneden in beeld, Werkboek 2, Delft.</verwijzingNaam>
+			<verwijzingIdentificatie>
+				<identificatieKenmerk>DC-2015/1753</identificatieKenmerk>
+				<identificatieBron>Archief Deltacommissaris</identificatieBron>
+			</verwijzingIdentificatie>
+		</isRepresentatieVan>
+	</bestand>
+</MDTO>

--- a/tests/fixtures/mdto/voorbeeld-dossier-informatieobject.xml
+++ b/tests/fixtures/mdto/voorbeeld-dossier-informatieobject.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MDTO xmlns="https://www.nationaalarchief.nl/mdto" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.nationaalarchief.nl/mdto https://www.nationaalarchief.nl/mdto/MDTO-XML1.0.1.xsd">
+	<informatieobject>
+		<identificatie>
+			<identificatieKenmerk>DC/358</identificatieKenmerk>
+			<identificatieBron>Archief Deltacommissaris</identificatieBron>
+		</identificatie>
+		<naam>Brondocumenten en literatuur bij synthesedocument voorkeursstrategie Kust en strategische beslissing Zand</naam>
+		<aggregatieniveau>
+			<begripLabel>Dossier</begripLabel>
+			<begripBegrippenlijst>
+				<verwijzingNaam>Begrippenlijst Aggregatieniveaus MDTO</verwijzingNaam>
+			</begripBegrippenlijst>
+		</aggregatieniveau>
+		<trefwoord>Noordzee</trefwoord>
+		<omschrijving>Documentatie synthesedocument voorkeursstrategie Kust en strategische beslissing Zand</omschrijving>
+		<raadpleeglocatie>
+			<raadpleeglocatieFysiek>
+				<verwijzingNaam>Nationaal Archief</verwijzingNaam>
+			</raadpleeglocatieFysiek>
+			<raadpleeglocatieOnline>https://www.nationaalarchief.nl/onderzoeken/archief/2.16.133/invnr/%40DC%7C%7C153~DC%7C%7C155</raadpleeglocatieOnline>
+		</raadpleeglocatie>
+		<dekkingInTijd>
+			<dekkingInTijdType>
+				<begripLabel>Looptijd van een dossier</begripLabel>
+				<begripBegrippenlijst>
+					<verwijzingNaam>Ministerie IenW zaaksysteem begrippenlijst</verwijzingNaam>
+				</begripBegrippenlijst>
+			</dekkingInTijdType>
+			<dekkingInTijdBegindatum>2010-01-01</dekkingInTijdBegindatum>
+			<dekkingInTijdEinddatum>2014-12-31</dekkingInTijdEinddatum>
+		</dekkingInTijd>
+		<dekkingInRuimte>
+			<verwijzingNaam>Noordzee</verwijzingNaam>
+		</dekkingInRuimte>
+		<taal>nl</taal>
+		<event>
+			<eventType>
+				<begripLabel>Creatie</begripLabel>
+				<begripBegrippenlijst>
+					<verwijzingNaam>Begrippenlijst EventTypeLijst</verwijzingNaam>
+				</begripBegrippenlijst>
+			</eventType>
+			<eventTijd>2010-04-12T14:20:00</eventTijd>
+			<eventVerantwoordelijkeActor>
+				<verwijzingNaam>Medewerker informatiebeheer </verwijzingNaam>
+				<verwijzingIdentificatie>
+					<identificatieKenmerk>WH2360HHHJ</identificatieKenmerk>
+					<identificatieBron>ZZ-TRIMADDIN</identificatieBron>
+				</verwijzingIdentificatie>
+			</eventVerantwoordelijkeActor>
+		</event>
+		<event>
+			<eventType>
+				<begripLabel>Bevriezing</begripLabel>
+				<begripBegrippenlijst>
+					<verwijzingNaam>Begrippenlijst EventTypeLijst MDTO</verwijzingNaam>
+				</begripBegrippenlijst>
+			</eventType>
+			<eventTijd>2015-04-05T14:40:00</eventTijd>
+			<eventVerantwoordelijkeActor>
+				<verwijzingNaam>Medewerker informatiebeheer</verwijzingNaam>
+				<verwijzingIdentificatie>
+					<identificatieKenmerk>WH2360HHHJ</identificatieKenmerk>
+					<identificatieBron>ZZ-TRIMADDIN</identificatieBron>
+				</verwijzingIdentificatie>
+			</eventVerantwoordelijkeActor>
+		</event>
+		<event>
+			<eventType>
+				<begripLabel>Migratie</begripLabel>
+				<begripBegrippenlijst>
+					<verwijzingNaam>Begrippenlijst EventTypeLijst MDTO</verwijzingNaam>
+				</begripBegrippenlijst>
+			</eventType>
+			<eventTijd>2020-01-12T23:20:00</eventTijd>
+			<eventVerantwoordelijkeActor>
+				<verwijzingNaam>Medewerker informatiebeheer</verwijzingNaam>
+				<verwijzingIdentificatie>
+					<identificatieKenmerk>M94739921</identificatieKenmerk>
+					<identificatieBron>ZZ-TRIMADDIN</identificatieBron>
+				</verwijzingIdentificatie>
+			</eventVerantwoordelijkeActor>
+		</event>
+		<waardering>
+			<begripLabel>Tijdelijk te bewaren</begripLabel>
+			<begripCode>V</begripCode>
+			<begripBegrippenlijst>
+				<verwijzingNaam>Begrippenlijst Waarderingen MDTO</verwijzingNaam>
+			</begripBegrippenlijst>
+		</waardering>
+		<bewaartermijn>
+			<termijnTriggerStartLooptijd>
+				<begripLabel>Sluiting dossier</begripLabel>
+				<begripBegrippenlijst>
+					<verwijzingNaam>Ministerie IenW zaaksysteem begrippenlijst</verwijzingNaam>
+				</begripBegrippenlijst>
+			</termijnTriggerStartLooptijd>
+			<termijnStartdatumLooptijd>2015-04-05</termijnStartdatumLooptijd>
+			<termijnLooptijd>P75Y</termijnLooptijd>
+			<termijnEinddatum>2090-04-05</termijnEinddatum>
+		</bewaartermijn>
+		<informatiecategorie>
+			<begripLabel>Primair beleid</begripLabel>
+			<begripCode>2.1.1</begripCode>
+			<begripBegrippenlijst>
+				<verwijzingNaam>Selectielijst ministerie van Infrastructuur en Milieu 2017</verwijzingNaam>
+			</begripBegrippenlijst>
+		</informatiecategorie>
+		<isOnderdeelVan>
+			<verwijzingNaam>Deelprogramma Kust. Voorbereiding 2010-2014 adviezen en voorstellen voorkeursstrategie Kust en strategische beslissing Zand</verwijzingNaam>
+			<verwijzingIdentificatie>
+				<identificatieKenmerk>DC/155</identificatieKenmerk>
+				<identificatieBron>Archief Deltacommissaris</identificatieBron>
+			</verwijzingIdentificatie>
+		</isOnderdeelVan>
+		<bevatOnderdeel>
+			<verwijzingNaam>Atelier Kustkwaliteit, 2011. Ontwerpstudie Dwarsdoorsneden kust, vier Kustdoorsneden in beeld, Werkboek 2, Delft</verwijzingNaam>
+			<verwijzingIdentificatie>
+				<identificatieKenmerk>DC-2015/1753</identificatieKenmerk>
+				<identificatieBron>Archief Deltacommissaris</identificatieBron>
+			</verwijzingIdentificatie>
+		</bevatOnderdeel>
+		<archiefvormer>
+			<verwijzingNaam>Ministerie van Infrastructuur en Waterstaat</verwijzingNaam>
+			<verwijzingIdentificatie>
+				<identificatieKenmerk>https://organisaties.overheid.nl/112773/Infrastructuur_en_Waterstaat</identificatieKenmerk>
+				<identificatieBron>Register van Overheidsorganisaties</identificatieBron>
+			</verwijzingIdentificatie>
+		</archiefvormer>
+		<activiteit>
+			<verwijzingNaam>Behandelen vergunningsaanvragen</verwijzingNaam>
+			<verwijzingIdentificatie>
+				<identificatieKenmerk>821002193-20201</identificatieKenmerk>
+				<identificatieBron>GEMTE</identificatieBron>
+			</verwijzingIdentificatie>
+		</activiteit>
+		<beperkingGebruik>
+			<beperkingGebruikType>
+				<begripLabel>beperkt openbaar; onevenredige bevoordeling of benadeling (Archiefwet 1995)</begripLabel>
+				<begripCode>Openbaarheid/AW1995/BeperktOpenbaar-Benadeling/1.0</begripCode>
+				<begripBegrippenlijst>
+					<verwijzingNaam>Ministerie IenW zaaksysteem begrippenlijst</verwijzingNaam>
+				</begripBegrippenlijst>
+			</beperkingGebruikType>
+			<beperkingGebruikNadereBeschrijving>Op grond van artikel 15 lid 1c van de Archiefwet 1995 is de openbaarheid van het informatieobject beperkt ter voorkoming van onevenredige bevoordeling of benadeling.</beperkingGebruikNadereBeschrijving>
+			<beperkingGebruikTermijn>
+				<termijnTriggerStartLooptijd>
+					<begripLabel>Sluiting dossier</begripLabel>
+					<begripBegrippenlijst>
+						<verwijzingNaam>Ministerie IenW zaaksysteem begrippenlijst</verwijzingNaam>
+					</begripBegrippenlijst>
+				</termijnTriggerStartLooptijd>
+				<termijnLooptijd>P20Y</termijnLooptijd>
+				<termijnEinddatum>2035-04-05</termijnEinddatum>
+			</beperkingGebruikTermijn>
+		</beperkingGebruik>
+	</informatieobject>
+</MDTO>

--- a/tests/fixtures/mdto/voorbeeld-serie-informatieobject.xml
+++ b/tests/fixtures/mdto/voorbeeld-serie-informatieobject.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MDTO xmlns="https://www.nationaalarchief.nl/mdto" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.nationaalarchief.nl/mdto https://www.nationaalarchief.nl/mdto/MDTO-XML1.0.1.xsd">
+	<informatieobject>
+		<identificatie>
+			<identificatieKenmerk>DC/155</identificatieKenmerk>
+			<identificatieBron>Archief Deltacommissaris</identificatieBron>
+		</identificatie>
+		<naam>Deelprogramma Kust. Voorbereiding 2010-2014 adviezen en voorstellen voorkeursstrategie Kust en strategische beslissing Zand</naam>
+		<aggregatieniveau>
+			<begripLabel>Serie</begripLabel>
+			<begripBegrippenlijst>
+				<verwijzingNaam>Begrippenlijst Aggregatieniveaus MDTO</verwijzingNaam>
+			</begripBegrippenlijst>
+		</aggregatieniveau>
+		<classificatie>
+			<begripLabel>Deelprogramma's</begripLabel>
+			<begripCode>3.1.1</begripCode>
+			<begripBegrippenlijst>
+				<verwijzingNaam>Ministerie IenW zaaksysteem begrippenlijst</verwijzingNaam>
+			</begripBegrippenlijst>
+		</classificatie>
+		<trefwoord>Noordzee</trefwoord>
+		<omschrijving>Deelprogramma van het deltaprogramma, waarin periode 2010-2014 adviezen en voorstellen voor deltabeslissingen en voorkeursstrategieën zijn voorbereid en uitgewerkt</omschrijving>
+		<raadpleeglocatie>
+			<raadpleeglocatieOnline>https://www.nationaalarchief.nl/onderzoeken/archief/2.16.133/invnr/%40DC%7C%7C153~DC%7C%7C155</raadpleeglocatieOnline>
+		</raadpleeglocatie>
+		<dekkingInTijd>
+			<dekkingInTijdType>
+				<begripLabel>Looptijd dossier</begripLabel>
+				<begripBegrippenlijst>
+					<verwijzingNaam>Ministerie IenW zaaksysteem begrippenlijst</verwijzingNaam>
+				</begripBegrippenlijst>
+			</dekkingInTijdType>
+			<dekkingInTijdBegindatum>2010-01-01</dekkingInTijdBegindatum>
+			<dekkingInTijdEinddatum>2014-12-31</dekkingInTijdEinddatum>
+		</dekkingInTijd>
+		<dekkingInRuimte>
+			<verwijzingNaam>Noordzee</verwijzingNaam>
+		</dekkingInRuimte>
+		<taal>nl</taal>
+		<event>
+			<eventType>
+				<begripLabel>Migratie</begripLabel>
+				<begripBegrippenlijst>
+					<verwijzingNaam>Begrippenlijst EventTypeLijst MDTO</verwijzingNaam>
+				</begripBegrippenlijst>
+			</eventType>
+			<eventTijd>2020-01-12T23:20:00</eventTijd>
+			<eventVerantwoordelijkeActor>
+				<verwijzingNaam>Beleidsmedewerker informatiebeheer</verwijzingNaam>
+				<verwijzingIdentificatie>
+					<identificatieKenmerk>M94739921</identificatieKenmerk>
+					<identificatieBron>ZZ-TRIMADDIN</identificatieBron>
+				</verwijzingIdentificatie>
+			</eventVerantwoordelijkeActor>
+			<eventResultaat>Serie is volledig</eventResultaat>
+		</event>
+		<waardering>
+			<begripLabel>Nader te bepalen</begripLabel>
+			<begripCode>N</begripCode>
+			<begripBegrippenlijst>
+				<verwijzingNaam>Begrippenlijst Waarderingen MDTO</verwijzingNaam>
+			</begripBegrippenlijst>
+		</waardering>
+		<informatiecategorie>
+			<begripLabel>Toestemming verlenen</begripLabel>
+			<begripCode>11</begripCode>
+			<begripBegrippenlijst>
+				<verwijzingNaam>Selectielijst ministerie van Infrastructuur en Milieu 2017</verwijzingNaam>
+			</begripBegrippenlijst>
+		</informatiecategorie>
+		<bevatOnderdeel>
+			<verwijzingNaam>Brondocumenten en literatuur bij synthesedocument voorkeursstrategie Kust en strategische beslissing Zand</verwijzingNaam>
+			<verwijzingIdentificatie>
+				<identificatieKenmerk>DC/358</identificatieKenmerk>
+				<identificatieBron>Archief Deltacommissaris</identificatieBron>
+			</verwijzingIdentificatie>
+		</bevatOnderdeel>
+		<archiefvormer>
+			<verwijzingNaam>Ministerie van Infrastructuur en Waterstaat</verwijzingNaam>
+			<verwijzingIdentificatie>
+				<identificatieKenmerk>https://organisaties.overheid.nl/112773/Infrastructuur_en_Waterstaat</identificatieKenmerk>
+				<identificatieBron>Register van Overheidsorganisaties</identificatieBron>
+			</verwijzingIdentificatie>
+		</archiefvormer>
+		<activiteit>
+			<verwijzingNaam>Primair beleid</verwijzingNaam>
+			<verwijzingIdentificatie>
+				<identificatieKenmerk>2.1.1</identificatieKenmerk>
+				<identificatieBron>Documentair Structuurplan ministerie van Infrastructuur en Water</identificatieBron>
+			</verwijzingIdentificatie>
+		</activiteit>
+		<beperkingGebruik>
+			<beperkingGebruikType>
+				<begripLabel>Geen beperking</begripLabel>
+				<begripBegrippenlijst>
+					<verwijzingNaam>Begrippenlijst Beperkingen MDTO</verwijzingNaam>
+				</begripBegrippenlijst>
+			</beperkingGebruikType>
+		</beperkingGebruik>
+	</informatieobject>
+</MDTO>


### PR DESCRIPTION
Follow-up to #3618, which recorded six structural deviations from the MDTO XSD without fixing them. This fixes all six, vendors the XSD, and adds the test that makes the spec's claim of XSD validity true and keeps it true.

## Who receives this output today: nobody

Checked before changing any shape. **No e-Depot endpoint is configured anywhere in the fleet.**

- Org-wide GitHub code search for `edepot_endpoint_url`, `edepot_sftp_host`, `edepot_openconnector_base_url` and `edepot_transport` hits only openregister's own code and openspec files. `edepot filename:*.json` returns 0.
- The shared dev instance has no `edepot_*` app config, and no `organisation_identifier` either, so the generator would refuse there anyway.
- One *planned* consumer exists: filinq's open change `openspec/changes/tmlo-mdto-metadata` says it will emit "core elements exactly as OR's `MdtoXmlGenerator` emits them" as "one `mdto:informatieobject`" per record. It describes the old shape, and it also cites `MdtoXmlGenerator::validateRequiredFields()`, which #3618 renamed. It is a proposal, not code, so nothing breaks, but it needs updating before it is implemented.

## The guard, before and after

`MdtoXmlGeneratorXsdTest` runs `DOMDocument::schemaValidate()` over documents for representative objects: minimal, with one and two files, with every optional element, with a TMLO-sourced value, with malformed declared dates, and with an undecided appraisal. It covers the informatieobject document and every file's bestand document.

**Before** (commit 54963b3, the guard committed red against the unfixed generator): exit 1, **7 of 7 generation cases failed**. libxml stops at the first fatal error, the root, so the other five deviations were not yet visible:

> `Element '{https://www.nationaalarchief.nl/mdto}informatieobject': No matching global declaration available for the validation root.`

**After:** exit 0, **14 tests, 20 assertions**, none skipped.

Two controls keep the guard honest. A **negative control** proves the validator rejects a non-conforming document, so a schema that failed to load could not make every case pass. A **positive control** validates the Nationaal Archief's own four example documents, so the harness is shown to accept what the publisher calls valid. The vendored XSD's checksum is pinned against `version.json`, so the file the export is held to cannot change unnoticed.

## The vendored XSD and its licence

`lib/Resources/mdto/MDTO-XML1.0.1.xsd` is a byte-for-byte copy from `NationaalArchief/MDTO-XSD` at `afae5f3`, following the repo's `lib/Resources/<standard>/` plus `version.json` convention, so it ships with the app and not only with the tests. The copy served from nationaalarchief.nl differs only in CRLF line endings; both checksums are recorded.

**Licence: CC BY-SA.** The upstream repositories carry no LICENSE file and their respec `license` setting is commented out. The only declaration I found is in the Forum Standaardisatie intake advice for MDTO (FS-20241002.3C, section "Beschikbaarheid documentatie en intellectueel eigendomsrecht"):

> "Het Nationaal Archief hanteert de licentie CC BY SA voor al diens kennisproducten en dus ook voor MDTO."

Redistribution is allowed with attribution and share-alike. The file is shipped unmodified with an attribution line in `version.json`. The share-alike term binds adaptations of that file; it does not reach openregister's EUPL code, which ships the file alongside itself and does not adapt it. The publisher does not state a CC version. **This is my reading, not legal advice.**

## The six deviations, fixed

| # | Was | Now | Source |
| --- | --- | --- | --- |
| 1 | root `mdto:informatieobject` | root `mdto:MDTO`, with `xsi:schemaLocation` naming the 1.0.1 XSD | the XSD's only global element; the MDTO SIP spec requires the version in every sidecar, and the official examples carry it this way |
| 2 | `bestand` nested in the informatieobject | each file is **its own MDTO document**; the informatieobject references it with `heeftRepresentatie`, the file points back with `isRepresentatieVan` | the XSD root is a `choice` of exactly one informatieobject or one bestand; MDTO SIP spec: "Elk informatieobject en elk bestand heeft zijn eigen MDTO metagegevensbestand" |
| 3 | `waardering`, `informatiecategorie`, `bestandsformaat` as plain strings | `begripGegevens`, with a named begrippenlijst | XSD `begripGegevens` |
| 4 | `bewaartermijn` as a plain duration | `termijnGegevens`: `termijnLooptijd`, plus `termijnEinddatum` from `archiefactiedatum` when the record has one | XSD `termijnGegevens` |
| 5 | no `checksumDatum` | emitted, as the moment the checksum was computed | XSD requires it; MDTO: "Datum waarop de checksum is gemaakt" |
| 6 | `toelichting`, not an MDTO element | `omschrijving` | XSD `informatieobjectType` |

`SipPackageBuilder` writes each file's document next to the file as `<bestandsnaam>.bestand.MDTO.xml`, as the MDTO SIP specification's "Naamgeving" section prescribes, and lists it in the manifest.

## A seventh deviation the XSD cannot see

**Waarderingen is a CLOSED list** ("Type begrippenlijst: Gesloten") of three terms: `B` Blijvend te bewaren, `V` Tijdelijk te bewaren, `N` Nader te bepalen. The generator emitted `bewaren`, `vernietigen` and `nog niet bepaald`, none of which is on it. The XSD accepts them because `begripLabel` is a plain string, so this deviation was invisible to schema validation. The four `archiefnominatie` values the codebase writes now map onto the list, and anything else is refused.

## Decisions you can overrule

Where MDTO requires a value and openregister has no source, I used the standard's own term for "not recorded" and never invented one.

1. **`beperkingGebruik` with no known restriction → `Nader te bepalen`.** The XSD requires the element. The BeperkingGebruikTypeLijst defines this term as "Er is mogelijk een beperking, maar de aard daarvan is niet vastgelegd als type beperking en niet vastgelegd in de metagegevens", which describes an object with no declared restriction and no active legal hold exactly. `collectMdtoRequiredElementGaps()` still reports it, so the default is never read as a fact. #3618 omitted the element instead, which made every such document invalid.
2. **`vernietigen` → `V` "Tijdelijk te bewaren".** The standard defines V as "dient tijdelijk bewaard te worden en na afloop van de bewaartermijn vernietigd te worden". `bewaren` and `blijvend_bewaren` → `B`; `nog_niet_bepaald` → `N`. **Any other value is now refused**, where it used to be written through as an invalid label.
3. **`informatiecategorie` is omitted when there is no category.** The old code wrote the placeholder `onbekend`, which nobody had recorded. The XSD makes the element optional. When present, its begrippenlijst is `retention.selectielijstBron`, or the generic term `Selectielijst` when the record does not name one.
4. **A file's `identificatie` is its SHA-256, with `identificatieBron` "SHA-256".** MDTO allows a kenmerk assigned "met behulp van een bepaalde systematiek". The file references reaching the generator carry no other stable identifier. A Nextcloud file id could be added as a second `identificatie` later.
5. **`bestandsformaat` is the IANA media type**, shaped exactly as the standard's own example shows it (code `application/msword`, label `msword`, list "IANA Media types"). MDTO prefers a PRONOM id; openregister does not identify PRONOM formats, and the standard names media types as the alternative.
6. **Checksums are recomputed at packaging, every time, with a fixity check.** A stored checksum carries no date, so the only honest `checksumDatum` is the moment this code hashes the bytes it packages. Recomputing alone would launder a changed file into a package that looks intact, so **a stored SHA-256 that disagrees with the bytes is refused**, and the object is excluded from that transfer with a logged reason. Before this, a mismatch would have shipped a manifest contradicting its own content. The rule lives in the new `PackagedFileChecksum`.
7. **The informatieobject document keeps its path `objects/{uuid}/mdto.xml`.** Only the new per-file documents follow the MDTO SIP naming, because renaming the existing file changes the SIP layout this repo's own spec defines.

## Behaviour changes to know about

- `generate()` no longer embeds files; call the new `generateBestand($object, $file)` per file. `SipPackageBuilder` is the only caller, and it does.
- **Now refused rather than written:** an `archiefnominatie` outside the closed list; a `bewaartermijn` that is not an `xsd:duration` (`P2W` is the case that matters: PHP's `DateInterval` accepts it and the XSD does not); a file checksum that is not a SHA-256; a file without an `xsd:dateTime` `checksumDate`; a file whose stored SHA-256 no longer matches its bytes.
- Declared `dekkingInTijd` dates and a declared restriction's `startDate` must be in the XSD's date forms, or they are dropped.

## Known gaps, measured, not fixed here

- **A second MDTO exporter does not validate.** `TmloService::generateMdtoXml()`, behind `GET /api/objects/{register}/{schema}/{id}/export/mdto`, was run against the same XSD. It fails at the root with the error quoted above, and it emits `archiefactiedatum`, `archiefstatus` and `vernietigingsCategorie`, which are TMLO fields and not MDTO elements. Its own spec, `tmlo-export`, **mandates** those three, so fixing the exporter is a decision about that spec. Both specs now record the measurement.
- **No runtime schema validation.** The test holds the generator to the XSD for the shapes it covers; arbitrary input is guarded by the input checks above, not by validating each document before it ships.
- **METS does not list the new per-file documents.** They are in the SIP and in its manifest.
- **`dekkingInTijdType` names a begrippenlijst the standard does not publish** (`DekkingInTijdType`), carried over from #3618.
- **The two official sources disagree on a spelling.** The ChecksumAlgoritme list says `SHA-256` and the publisher's own `Bestand` example says `SHA256`. I followed the list, which is the normative text.

## Tests

| Test | What it holds |
| --- | --- |
| `MdtoXmlGeneratorXsdTest` (14) | every representative informatieobject and bestand document validates; negative and positive controls; XSD checksum pinned |
| `MdtoXmlGeneratorTest` (51) | each deviation's shape, the closed Waarderingen list, `termijnGegevens`, `omschrijving`, `heeftRepresentatie` and `isRepresentatieVan`, every input refusal, `Nader te bepalen`, element order |
| `PackagedFileChecksumTest` (5) | computed and dated; matching stored accepted; stale stored refused; other shapes ignored; unreadable refused |
| `EdepotTransferServiceFilesTest` (2) | the transfer path uses it, and a fixity failure propagates |
| `SipPackageBuilderTest` | each file's bestand document lands next to it and in the manifest |

## Mutations: 32, every one reddened the right test

Each guard was broken, the right test watched fail, then restored and **verified byte-identical** against a backup with `filecmp`.

| # | Mutation | Test that reddened | libxml named |
| --- | --- | --- | --- |
| X1 | root is the content element, not `MDTO` | XSD test | `informatieobject`: No matching global declaration available for the validation root |
| X2 | a `bestand` nested in the informatieobject | XSD test | `bestand`: This element is not expected |
| X3 | `waardering` as a plain string | XSD test | `waardering`: Character content ... not allowed ... 'element-only' |
| X4 | `bewaartermijn` as a plain string | XSD test | `bewaartermijn`: Character content ... not allowed ... 'element-only' |
| X5 | no `checksumDatum` | XSD bestand test | `checksum`: Missing child element(s). Expected is ( checksumDatum ) |
| X6 | `toelichting` instead of `omschrijving` | XSD test | `toelichting`: This element is not expected |
| X7 | `waardering` label outside the closed list | `testWaarderingUsesTheClosedWaarderingenList` | (invisible to the XSD) |
| X8 | `beperkingGebruik` omitted when unsourced | XSD test | `informatieobject`: Missing child element(s) |
| X9 | the `onbekend` placeholder is back | `testGenerateWithMissingOptionalFields` | |
| X12 | HARNESS: validator accepts anything | `testTheValidatorRejectsANonConformingDocument` | |
| X13 | HARNESS: vendored XSD edited | `testTheVendoredXsdMatchesItsRecordedChecksum` | |
| P1, P1w | stale stored SHA-256 silently replaced | `PackagedFileChecksumTest`, and through the transfer path | |
| P2 | unreadable file gets an empty checksum | `testAnUnreadableFileIsRefused` | |
| P3 | transfer path drops the checksum date | `testGatheredFilesCarryTheComputedChecksumAndDate` | |
| P4 | SIP omits each file's bestand document | `testBuildBagitLayoutAndManifest` | |
| M1b, M1c | non-SHA-256 checksum, or missing `checksumDate`, accepted | the two refusal tests | |
| M6b | a `dekkingInTijd` date outside the XSD union let through | XSD test | `dekkingInTijdEinddatum`: '31-12-2021' is not a valid value of the local union type |
| M6c, M6d | same at unit level; a declared `startDate` unvalidated | unit test; XSD test | `termijnStartdatumLooptijd`: 'gisteren' is not a valid value of the atomic type 'xs:date' |
| M13, M14 | closed list, and `xsd:duration`, not enforced | the two refusal tests | |
| M2 to M12 | the #3618 guards, re-run against the rewritten code | each its original test | |

**Mutation checking found two guards no test covered**, both fixed in 34a7304:

- **M1:** removing the file `name` and `format` checks left everything green, because only a missing checksum was ever tested. This matters more than it looks: an empty string is a valid `xsd:string`, so an empty `naam` or `begripLabel` validates while saying nothing, and the XSD test cannot catch it.
- **M6b:** removing the date-form check on declared `dekkingInTijd` stayed green, because no case fed a malformed date.

## CI caught what the local run could not: Nextcloud's XXE guard

The first push was red on two jobs, "PHPUnit (PHP 8.3, NC stable34, pgsql)" and the Newman job's in-container unit step, with one cause, and every data set of the XSD test failed:

> `line 0: Failed to load external entity because the resolver function returned null`
> `line 0: Failed to parse the XML resource '.../lib/Resources/mdto/MDTO-XML1.0.1.xsd'.`

CI runs the unit suite inside a **booted Nextcloud**, whose XXE protection sets libxml's external-entity loader to return null for every resource. `DOMDocument::schemaValidate($path)` asks that loader for the schema file, so it could not read the XSD from disk at all. My local run boots no Nextcloud, installs no loader, and passed. Same code, different environment.

**Reproduced locally first.** The test now installs the same null loader in `setUp()` and restores the previous one in `tearDown()`, so it carries CI's condition with it and a local run cannot pass for the wrong reason again. With that in place and the old call still there, the failure reproduced exactly: 12 of 14 red with CI's message.

**Fixed without weakening the guard.** Validation now reads the schema with `file_get_contents()` and calls `schemaValidateSource()`, which never consults the entity loader for the top-level schema. Reading the file is plain PHP I/O, outside libxml entirely, so nothing about the XXE protection is loosened or bypassed. **No scoped loader was needed**: `MDTO-XML1.0.1.xsd` contains no `xs:import`, `xs:include`, `xs:redefine` or `xs:override`, so there is no secondary resource for the loader to resolve. Had there been, those would still have gone through the loader and would have needed the vendored copies resolved explicitly.

**The negative control had been passing for the wrong reason.** A schema that cannot load rejects every document, which satisfied "the validator rejects a non-conforming document" while proving nothing. It now requires the rejection to be the schema naming the missing element, and to contain neither "Failed to load external entity" nor "Failed to parse the XML resource".

**Nothing in `lib/` validates against an XSD at runtime.** Searched for `schemaValidate`, `schemaValidateSource`, path-based `load(`, `simplexml_load_file` and `XMLReader::open` across `lib/`, and across every file this PR changes: the only hits were the docblock prose. Since runtime validation would run inside Nextcloud and fail the same way, the generator's class docblock and the spec now name `schemaValidateSource()` and say why, so whoever adds it copies the call that works.

| # | Mutation | Result |
| --- | --- | --- |
| N1 | `schemaValidate($path)` put back, null loader installed | **reddens**, 13 failures, libxml: "Failed to load external entity because the resolver function returned null". The tightened negative control fails too |
| N2 | `schemaValidate($path)` put back **and** the null loader removed | **exit 0**: the broken call passes without the loader. This is the blind spot that let it reach CI, and why the loader belongs in `setUp()` |

Both restored byte-identical.

One honest limit: **the `tearDown()` restore is not itself covered by a test.** No test can observe another test's teardown, and in CI the loader is already null, so a leak would be invisible there and would only affect later local tests that read XML from disk.

## Gates, by exit code

| Gate | Exit | Note |
| --- | --- | --- |
| `phpunit --no-coverage tests/Unit/` | **0** | 19879 tests, 48768 assertions, 24 skipped (the same 24 as before) |
| `composer phpcs` | **0** | |
| phpmd `phpmd.xml` | **0** | first run: 2 findings from my additions (`EdepotTransferService` 1024 lines, `buildSinglePackage()` 101), fixed by extraction in 53f20a7, not suppressed |
| phpmd `phpmd-unusedparams.xml` | **0** | |
| `phpstan clear-result-cache`, then `analyse --no-progress` | **0** | cold |
| `psalm --no-progress --no-cache --threads=1` | **0** | see below |
| hydra gates, `HYDRA_GATE_BASE_REF=origin/development`, `NODE_PATH` to ajv 8.20.0 | **0** | 83 of 84 applicable gates ran |

In the hydra run, **gates 16, 46, 6, 22 and 53 all pass**. 22 and 53 actually ran this time against a private `ajv` 8.20.0 installed in my scratchpad, not borrowed from another agent's checkout. Three advisory warnings are pre-existing: gate-19 is at 918 scenarios, the same count as before, with none from `edepot-transfer` or `tmlo-export`; gate-96 has 2 App Store strings; gate-112 has 17 Postman collections. **gate-60 did not run**, because `vue-material-design-icons` is not installed. This change touches no Vue or icons, but that gate verified nothing.

**CI on the fix commit is green**: 47 checks, 41 pass and 6 skipping (SBOM, Journeydoc Capture, Deploy Documentation, Build fallback site image, Features Extract, Nextcloud API check), 0 failing. The two jobs that were red both pass.

**psalm lied once.** A run using its cache (`~/.cache/psalm`, no `cacheDirectory` configured) reported **223 errors**, every one of the phantom shape: OCP classes "not existing", and Entity magic getters such as `ObjectEntity::getRetention` "not existing", including on constructor lines this PR never touched. It took 48s. The same tree with `--no-cache` took 334s and reported **none**. The repo's own `composer psalm` script passes `--no-cache`, which is why CI never sees this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

