### PR TITLE
fix(import): keep the register-schema link when a version check skips the schema (WOO-563)

### DIFF
--- a/lib/Service/Configuration/ImportHandler.php
+++ b/lib/Service/Configuration/ImportHandler.php
@@ -921,8 +921,9 @@ class ImportHandler {
 				if (isset($data['schemas']) === true && is_array($data['schemas']) === true) {
 					$existingSchemaIds = $existingRegister->getSchemas();
 					if (is_array($existingSchemaIds) === true && $existingSchemaIds !== []) {
-						$data['schemas'] = array_values(
-							array_unique(array_merge($existingSchemaIds, $data['schemas']))
+						$data['schemas'] = $this->unionSchemaIds(
+							currentIds: $existingSchemaIds,
+							incomingIds: $data['schemas']
 						);
 					}
 				}
@@ -975,6 +976,33 @@ class ImportHandler {
 	}//end importRegister()
 
 	/**
+	 * Merge two schema-id lists, keeping every id either side can prove.
+	 *
+	 * ONE implementation of the union rule, called from both places that need
+	 * it: the full register update and the version-gated skip path. They used
+	 * to carry a copy each, with different `array_unique` flags — harmless for
+	 * the ids actually stored (ints, or numeric strings after a JSON round
+	 * trip) but exactly the shape that rots, since the rule is stated at length
+	 * beside each copy. #2935 was this rule holding in one place and not
+	 * another.
+	 *
+	 * The rule: union, never replace. A link this run can prove gets added, a
+	 * link it merely cannot see is left alone. The failure direction is then a
+	 * STALE link, which `occ openregister:registers:relink-schemas` reports and
+	 * repairs; replacing instead loses reachable data with no error anywhere.
+	 *
+	 * @param array $currentIds  The ids the register already lists.
+	 * @param array $incomingIds The ids this import resolved.
+	 *
+	 * @return array The merged list, de-duplicated and re-indexed.
+	 *
+	 * @spec openspec/specs/data-import-export/spec.md
+	 */
+	private function unionSchemaIds(array $currentIds, array $incomingIds): array {
+		return array_values(array_unique(array_merge($currentIds, $incomingIds)));
+	}//end unionSchemaIds()
+
+	/**
 	 * Attach the schema ids this import resolved to an existing register,
 	 * without ever removing a link the register already holds.
 	 *
@@ -999,6 +1027,7 @@ class ImportHandler {
 	 *
 	 * @spec openspec/specs/data-import-export/spec.md
 	 */
+
 	private function linkImportedSchemas(Register $register, mixed $importedSchemaIds): Register {
 		if (is_array($importedSchemaIds) === false || $importedSchemaIds === []) {
 			return $register;
@@ -1009,8 +1038,14 @@ class ImportHandler {
 			$currentIds = [];
 		}
 
-		$merged = array_values(array_unique(array_merge($currentIds, $importedSchemaIds), SORT_REGULAR));
-		if (count($merged) === count($currentIds)) {
+		$merged = $this->unionSchemaIds(currentIds: $currentIds, incomingIds: $importedSchemaIds);
+
+		// Compare against the DEDUPED current list, not the raw one. Comparing
+		// against the raw list would report "something changed" for a register
+		// whose stored list already held a duplicate, and write a silently
+		// de-duplicated row from a path whose whole premise is that it writes
+		// nothing. Repairing that duplicate is not this path's job.
+		if ($merged === array_values(array_unique($currentIds))) {
 			// Nothing new to link — leave the row untouched.
 			return $register;
 		}

--- a/lib/Service/Configuration/ImportHandler.php
+++ b/lib/Service/Configuration/ImportHandler.php
@@ -842,6 +842,39 @@ class ImportHandler {
 			}//end try
 
 			if ($existingRegister !== null) {
+				// A SKIPPED REGISTER UPDATE MUST STILL ADOPT THE SCHEMAS THIS
+				// RUN CREATED.
+				//
+				// The version gate below is about the register's OWN fields
+				// (title, description, …): nothing to write when the incoming
+				// definition is not newer. It is NOT about the schema links.
+				// `$data['schemas']` arriving here is the id list the schema
+				// pass just resolved, and that pass creates rows whatever the
+				// register version says — a register.d fragment adds a schema
+				// without ever touching the register's version. Returning on
+				// the version gate without that list therefore leaves those
+				// brand-new schema rows attached to nothing.
+				//
+				// That orphaning is what makes the NEXT import fork a twin.
+				// `computeRegisterScopedSchemaIds()` builds each slug's
+				// candidate set from the register's stored `schemas` list, so
+				// the missing ids are missing from the set too;
+				// `findBySlugInIds()` cannot see the app's own row, and the
+				// register-scoped branch of resolveExistingSchemaForImport()
+				// concludes — correctly, from what it was given — that the
+				// target register does not own this slug yet and creates a new
+				// schema. Every re-import repeats it. That is how one
+				// opencatalogi install reached 92 schemas with 25 slugs
+				// duplicated and page/menu/glossary present three times over
+				// (28 Aug / 3 Sep / 4 Sep), each copy identical but for its
+				// uuid: the slugs that STAYED in the register's list
+				// (publication, document) upserted correctly, and only the
+				// unlinked ones forked. See WOO-563 and
+				// ImportHandlerRegisterSchemaLinkOnVersionSkipTest.
+				//
+				// Union, never replace, for the same reason the update path
+				// below unions (#2935): a link this run can prove gets added,
+				// a link it merely cannot see is left alone.
 				// Compare versions using version_compare for proper semver comparison.
 				$existingVersion = $existingRegister->getVersion() ?? '0.0.0';
 				if ($force === false && version_compare($data['version'], $existingVersion, '<=') === true) {
@@ -849,8 +882,16 @@ class ImportHandler {
 						message: '[ImportHandler] Skipping register import as existing version is newer or equal.',
 						context: ['file' => __FILE__, 'line' => __LINE__]
 					);
+
+					// Skip the register's own fields, NOT its schema links.
+					// The full-update path below already unions them (#2935);
+					// this path is the one that used to drop them, so it needs
+					// the same union before it returns.
 					// Even though we're skipping the update, we still need to add it to the map.
-					return $existingRegister;
+					return $this->linkImportedSchemas(
+						register: $existingRegister,
+						importedSchemaIds: ($data['schemas'] ?? null)
+					);
 				}
 
 				// NEVER DROP A SCHEMA LINK THIS IMPORT COULD NOT RE-ESTABLISH.
@@ -932,6 +973,64 @@ class ImportHandler {
 			throw new Exception('Failed to import register: ' . $e->getMessage());
 		}//end try
 	}//end importRegister()
+
+	/**
+	 * Attach the schema ids this import resolved to an existing register,
+	 * without ever removing a link the register already holds.
+	 *
+	 * Called from the version-gated skip path, which is the one that used to
+	 * drop them (the full-update path has unioned since #2935). The schema
+	 * pass creates rows independently of the register's version — an app that
+	 * adds a schema through a `register.d` fragment routinely leaves the
+	 * register's own `version` untouched — so a register that returns early
+	 * from the version gate without adopting those ids leaves them orphaned,
+	 * and the next import cannot resolve them (see the comment at the call
+	 * site, and WOO-563).
+	 *
+	 * Union semantics, matching the update path: an id this run proved is
+	 * added, and an id the register already lists is kept even when this run
+	 * could not see it. Persists only when the merge actually adds something,
+	 * so a no-op import stays a no-op write.
+	 *
+	 * @param Register   $register          The register already stored.
+	 * @param mixed      $importedSchemaIds The `schemas` value this import resolved (an id list, or null).
+	 *
+	 * @return Register The register, updated in the database when links were added.
+	 *
+	 * @spec openspec/specs/data-import-export/spec.md
+	 */
+	private function linkImportedSchemas(Register $register, mixed $importedSchemaIds): Register {
+		if (is_array($importedSchemaIds) === false || $importedSchemaIds === []) {
+			return $register;
+		}
+
+		$currentIds = $register->getSchemas();
+		if (is_array($currentIds) === false) {
+			$currentIds = [];
+		}
+
+		$merged = array_values(array_unique(array_merge($currentIds, $importedSchemaIds), SORT_REGULAR));
+		if (count($merged) === count($currentIds)) {
+			// Nothing new to link — leave the row untouched.
+			return $register;
+		}
+
+		$this->logger->info(
+			message: '[ImportHandler] Linking schemas created by this import to the existing register.',
+			context: [
+				'file' => __FILE__,
+				'line' => __LINE__,
+				'registerId' => $register->getId(),
+				'registerSlug' => $register->getSlug(),
+				'schemasBefore' => count($currentIds),
+				'schemasAfter' => count($merged),
+			]
+		);
+
+		$register->setSchemas($merged);
+
+		return $this->registerMapper->update($register);
+	}//end linkImportedSchemas()
 
 	/**
 	 * Import a single mapping from configuration data.

--- a/lib/Service/Configuration/ImportHandler.php
+++ b/lib/Service/Configuration/ImportHandler.php
@@ -1064,7 +1064,17 @@ class ImportHandler {
 
 		$register->setSchemas($merged);
 
-		return $this->registerMapper->update($register);
+		// Persist, but hand back the entity we mutated rather than update()'s
+		// return value. QBMapper::update() returns that same instance, so the
+		// two are identical at runtime; the difference is the declared type.
+		// update() is typed as the generic Entity, and a test double that never
+		// configured it returns a bare Entity stub, which the Register return
+		// type here then rejects with a TypeError — on a path that, before
+		// WOO-563, never wrote at all and so never met that stub
+		// (ImportServiceRegisterAutoCreateTest, CI run of #3638).
+		$this->registerMapper->update($register);
+
+		return $register;
 	}//end linkImportedSchemas()
 
 	/**

--- a/tests/Unit/Service/Configuration/ImportHandlerRegisterSchemaLinkOnVersionSkipTest.php
+++ b/tests/Unit/Service/Configuration/ImportHandlerRegisterSchemaLinkOnVersionSkipTest.php
@@ -1,0 +1,461 @@
+<?php
+
+/**
+ * Unit tests for WOO-563: a register whose own version is not newer must still
+ * adopt the schema ids the same import just created.
+ *
+ * The bug this pins: `ImportHandler::importRegister()` returned on the version
+ * gate before attaching `$data['schemas']`, so schemas created by the schema
+ * pass stayed orphaned. `computeRegisterScopedSchemaIds()` then built the next
+ * import's candidate set from that stale list, `findBySlugInIds()` could not
+ * see the app's own row, and the register-scoped resolution branch created a
+ * TWIN schema instead of updating in place — once per import, forever. One
+ * opencatalogi install reached 92 schemas with 25 slugs duplicated and
+ * page/menu/glossary present three times over, each copy identical but for its
+ * uuid.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Configuration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Configuration;
+
+use GuzzleHttp\Client;
+use OCA\OpenRegister\Db\Configuration;
+use OCA\OpenRegister\Db\ConfigurationMapper;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\MappingMapper;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Configuration\ImportHandler;
+use OCA\OpenRegister\Service\Configuration\UploadHandler;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IAppConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionClass;
+
+/**
+ * The fake persistence layer keeps the SAME object identities across several
+ * `importFromJson()` calls, which is the only way to observe behaviour that
+ * only appears on a RE-import. Stateless mocks cannot express it.
+ */
+class ImportHandlerRegisterSchemaLinkOnVersionSkipTest extends TestCase {
+
+	/** @var SchemaMapper&MockObject */
+	private SchemaMapper $schemaMapper;
+
+	/** @var RegisterMapper&MockObject */
+	private RegisterMapper $registerMapper;
+
+	private ImportHandler $handler;
+
+	/** @var array<int, Schema> id => Schema, the fake schemas "table". */
+	private array $schemaStore = [];
+
+	/** @var array<string, Register> slug(lower) => Register, the fake registers "table". */
+	private array $registerStore = [];
+
+	private int $nextSchemaId = 100;
+
+	private int $nextRegisterId = 200;
+
+	/** Number of RegisterMapper::update() calls, to prove a no-op stays a no-op. */
+	private int $registerUpdateCalls = 0;
+
+	/**
+	 * Wire an ImportHandler over in-memory schema/register "tables" that
+	 * behave like the queries this code path relies on.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->schemaMapper = $this->createMock(SchemaMapper::class);
+		$this->registerMapper = $this->createMock(RegisterMapper::class);
+
+		$objectEntityMapper = $this->createMock(MagicMapper::class);
+		$configurationMapper = $this->createMock(ConfigurationMapper::class);
+		$mappingMapper = $this->createMock(MappingMapper::class);
+		$client = $this->createMock(Client::class);
+		$appConfig = $this->createMock(IAppConfig::class);
+		$logger = $this->createMock(LoggerInterface::class);
+		$uploadHandler = $this->createMock(UploadHandler::class);
+		$objectService = $this->createMock(ObjectService::class);
+
+		$appConfig->method('getValueString')->willReturn('');
+		$appConfig->method('setValueString')->willReturn(true);
+		$mappingMapper->method('getSlugToIdMap')->willReturn([]);
+
+		// --- SchemaMapper fake -------------------------------------------------
+
+		$this->schemaMapper->method('getSlugToIdMap')->willReturn([]);
+
+		$this->schemaMapper->method('findBySlugInIds')->willReturnCallback(
+			function (string $slug, array $schemaIds): ?Schema {
+				foreach ($schemaIds as $id) {
+					$candidate = ($this->schemaStore[$id] ?? null);
+					if ($candidate !== null && strtolower((string)$candidate->getSlug()) === strtolower($slug)) {
+						return $candidate;
+					}
+				}
+
+				return null;
+			}
+		);
+
+		$this->schemaMapper->method('findByApplicationAndSlug')->willReturnCallback(
+			function (string $slug, string $application): ?Schema {
+				foreach ($this->schemaStore as $candidate) {
+					if (strtolower((string)$candidate->getSlug()) === strtolower($slug)
+						&& (string)$candidate->getApplication() === $application
+					) {
+						return $candidate;
+					}
+				}
+
+				return null;
+			}
+		);
+
+		$this->schemaMapper->method('find')->willReturnCallback(
+			function (string $id): Schema {
+				foreach ($this->schemaStore as $candidate) {
+					if (strtolower((string)$candidate->getSlug()) === strtolower($id)) {
+						return $candidate;
+					}
+				}
+
+				throw new DoesNotExistException('schema not found: ' . $id);
+			}
+		);
+
+		$this->schemaMapper->method('createFromArray')->willReturnCallback(
+			function (array $data): Schema {
+				$id = $this->nextSchemaId++;
+				$schema = new Schema();
+				$schema->setSlug($data['slug']);
+				$schema->setTitle($data['title'] ?? $data['slug']);
+				$schema->setVersion($data['version'] ?? '1.0.0');
+				$schema->setProperties($data['properties'] ?? []);
+				$this->setEntityId($schema, $id);
+				$this->schemaStore[$id] = $schema;
+				return $schema;
+			}
+		);
+
+		$this->schemaMapper->method('updateFromArray')->willReturnCallback(
+			function (int $id, array $data): Schema {
+				$schema = $this->schemaStore[$id];
+				if (isset($data['version']) === true) {
+					$schema->setVersion($data['version']);
+				}
+
+				if (isset($data['properties']) === true) {
+					$schema->setProperties($data['properties']);
+				}
+
+				return $schema;
+			}
+		);
+
+		$this->schemaMapper->method('update')->willReturnArgument(0);
+
+		// --- RegisterMapper fake -----------------------------------------------
+
+		$this->registerMapper->method('find')->willReturnCallback(
+			function (string $id): Register {
+				$existing = ($this->registerStore[strtolower($id)] ?? null);
+				if ($existing !== null) {
+					return $existing;
+				}
+
+				throw new DoesNotExistException('register not found: ' . $id);
+			}
+		);
+
+		$this->registerMapper->method('createFromArray')->willReturnCallback(
+			function (array $data): Register {
+				$id = $this->nextRegisterId++;
+				$register = new Register();
+				$register->setSlug($data['slug']);
+				$register->setVersion($data['version'] ?? '1.0.0');
+				$register->setSchemas($data['schemas'] ?? []);
+				$this->setEntityId($register, $id);
+				$this->registerStore[strtolower($data['slug'])] = $register;
+				return $register;
+			}
+		);
+
+		$this->registerMapper->method('updateFromArray')->willReturnCallback(
+			function (int $id, array $data): Register {
+				foreach ($this->registerStore as $register) {
+					if ($register->getId() === $id) {
+						if (isset($data['schemas']) === true) {
+							$register->setSchemas($data['schemas']);
+						}
+
+						if (isset($data['version']) === true) {
+							$register->setVersion($data['version']);
+						}
+
+						return $register;
+					}
+				}
+
+				throw new DoesNotExistException('register id not found: ' . $id);
+			}
+		);
+
+		$this->registerMapper->method('update')->willReturnCallback(
+			function (Register $register): Register {
+				$this->registerUpdateCalls++;
+				return $register;
+			}
+		);
+
+		$this->handler = new ImportHandler(
+			schemaMapper:        $this->schemaMapper,
+			registerMapper:      $this->registerMapper,
+			objectEntityMapper:  $objectEntityMapper,
+			configurationMapper: $configurationMapper,
+			mappingMapper:       $mappingMapper,
+			client:              $client,
+			appConfig:           $appConfig,
+			logger:              $logger,
+			appDataPath:         '/tmp',
+			uploadHandler:       $uploadHandler,
+			objectService:       $objectService
+		);
+
+	}//end setUp()
+
+	/**
+	 * Set the integer id on an Entity instance via reflection.
+	 *
+	 * @param object $entity The entity to stamp.
+	 * @param int    $id     The id to set.
+	 */
+	private function setEntityId(object $entity, int $id): void {
+		$ref = new ReflectionClass($entity);
+		$prop = $ref->getProperty('id');
+		$prop->setAccessible(true);
+		$prop->setValue($entity, $id);
+
+	}//end setEntityId()
+
+	/**
+	 * Build a minimal Configuration entity.
+	 *
+	 * @param int    $id  The configuration id.
+	 * @param string $app The owning app id.
+	 *
+	 * @return Configuration The entity.
+	 */
+	private function makeConfiguration(int $id, string $app = 'opencatalogi'): Configuration {
+		$config = new Configuration();
+		$config->setApp($app);
+		$config->setRegisters([]);
+		$config->setSchemas([]);
+		$config->setObjects([]);
+		$this->setEntityId($config, $id);
+		return $config;
+	}//end makeConfiguration()
+
+	/**
+	 * Build a one-register payload declaring the given schema slugs.
+	 *
+	 * The register version is passed separately from the schema version so a
+	 * test can hold the register at a version the gate will skip while the
+	 * schema set grows — exactly what a `register.d` fragment does.
+	 *
+	 * @param string        $registerSlug    The register slug.
+	 * @param string        $registerVersion The register's declared version.
+	 * @param array<string> $schemaSlugs     The schema slugs the register declares.
+	 * @param string        $schemaVersion   The version every schema is declared at.
+	 *
+	 * @return array The import payload.
+	 */
+	private function makePayload(
+		string $registerSlug,
+		string $registerVersion,
+		array $schemaSlugs,
+		string $schemaVersion = '1.0.0',
+	): array {
+		$schemas = [];
+		foreach ($schemaSlugs as $schemaSlug) {
+			$schemas[$schemaSlug] = [
+				'slug' => $schemaSlug,
+				'title' => ucfirst($schemaSlug),
+				'version' => $schemaVersion,
+				'properties' => ['name' => ['type' => 'string', 'title' => 'Name']],
+			];
+		}
+
+		return [
+			'appId' => 'opencatalogi',
+			'version' => '1.0.0',
+			'components' => [
+				'schemas' => $schemas,
+				'registers' => [
+					$registerSlug => [
+						'slug' => $registerSlug,
+						'title' => ucfirst($registerSlug),
+						'version' => $registerVersion,
+						'schemas' => $schemaSlugs,
+					],
+				],
+			],
+		];
+
+	}//end makePayload()
+
+	/**
+	 * Run one import as app `opencatalogi`.
+	 *
+	 * @param array $payload The payload to import.
+	 *
+	 * @return array The import result.
+	 */
+	private function import(array $payload): array {
+		return $this->handler->importFromJson(
+			data:          $payload,
+			configuration: $this->makeConfiguration(1),
+			owner:         'opencatalogi',
+			appId:         'opencatalogi',
+			version:       '1.0.0'
+		);
+
+	}//end import()
+
+	/**
+	 * THE FIX. A register that already exists at the SAME version still adopts
+	 * the schema ids this import created, instead of returning from the
+	 * version gate and leaving them orphaned.
+	 */
+	public function testVersionSkippedRegisterAdoptsSchemasCreatedByThisImport(): void {
+		// First import: register created at 1.0.0 with `publication` only.
+		$this->import($this->makePayload('publication', '1.0.0', ['publication']));
+
+		$register = $this->registerStore['publication'];
+		$publicationId = $this->schemaStore[array_key_first($this->schemaStore)]->getId();
+		$this->assertSame([$publicationId], $register->getSchemas());
+
+		// Second import: the register version is UNCHANGED (the gate will skip
+		// it) but a register.d fragment added `page`.
+		$result = $this->import($this->makePayload('publication', '1.0.0', ['publication', 'page']));
+
+		$pageId = null;
+		foreach ($this->schemaStore as $id => $schema) {
+			if ($schema->getSlug() === 'page') {
+				$pageId = $id;
+			}
+		}
+
+		$this->assertNotNull($pageId, 'the import created a `page` schema');
+		$this->assertContains(
+			$pageId,
+			$this->registerStore['publication']->getSchemas(),
+			'the version-skipped register must still link the schema this import created'
+		);
+		$this->assertContains($publicationId, $this->registerStore['publication']->getSchemas());
+		$this->assertCount(2, $result['schemas']);
+
+	}//end testVersionSkippedRegisterAdoptsSchemasCreatedByThisImport()
+
+	/**
+	 * THE REPRODUCTION (WOO-563). Importing the SAME payload three times, with
+	 * the register held at one version the whole way, must leave exactly one
+	 * schema row per slug. Before the fix the second and third runs each
+	 * forked a twin — same slug, same owner, same version, new uuid — which is
+	 * how page/menu/glossary ended up on the instance three times over.
+	 */
+	public function testRepeatedImportAtTheSameRegisterVersionDoesNotForkTwins(): void {
+		$payloadSeed = $this->makePayload('publication', '1.0.0', ['publication']);
+		$payloadFull = $this->makePayload('publication', '1.0.0', ['publication', 'page', 'menu', 'glossary']);
+
+		$this->import($payloadSeed);
+		$this->import($payloadFull);
+		$this->import($payloadFull);
+		$this->import($payloadFull);
+
+		$bySlug = [];
+		foreach ($this->schemaStore as $schema) {
+			$bySlug[(string)$schema->getSlug()][] = $schema->getId();
+		}
+
+		foreach (['publication', 'page', 'menu', 'glossary'] as $slug) {
+			$this->assertArrayHasKey($slug, $bySlug);
+			$this->assertCount(
+				1,
+				$bySlug[$slug],
+				sprintf('slug `%s` forked into %d rows', $slug, count($bySlug[$slug] ?? []))
+			);
+		}
+
+		$this->assertCount(4, $this->schemaStore, 'four slugs must mean four schema rows');
+		$this->assertCount(4, $this->registerStore['publication']->getSchemas());
+
+	}//end testRepeatedImportAtTheSameRegisterVersionDoesNotForkTwins()
+
+	/**
+	 * The link is a UNION, never a replace: a schema the register already owns
+	 * but this import does not mention stays linked (#2935).
+	 */
+	public function testVersionSkippedImportNeverDropsAnExistingLink(): void {
+		$this->import($this->makePayload('publication', '1.0.0', ['publication']));
+
+		// A schema linked by something other than this configuration.
+		$foreign = new Schema();
+		$foreign->setSlug('legacy-thing');
+		$foreign->setVersion('1.0.0');
+		$this->setEntityId($foreign, 900);
+		$this->schemaStore[900] = $foreign;
+
+		$register = $this->registerStore['publication'];
+		$register->setSchemas(array_merge($register->getSchemas(), [900]));
+
+		// Re-import at the same register version, WITHOUT mentioning 900.
+		$this->import($this->makePayload('publication', '1.0.0', ['publication', 'page']));
+
+		$this->assertContains(
+			900,
+			$this->registerStore['publication']->getSchemas(),
+			'a link this import could not see must be left alone, not dropped'
+		);
+
+	}//end testVersionSkippedImportNeverDropsAnExistingLink()
+
+	/**
+	 * A genuinely unchanged re-import must not write the register row: the
+	 * link step persists only when the union actually adds an id.
+	 */
+	public function testUnchangedReimportDoesNotWriteTheRegister(): void {
+		$payload = $this->makePayload('publication', '1.0.0', ['publication']);
+		$this->import($payload);
+
+		$callsAfterFirstImport = $this->registerUpdateCalls;
+		$this->import($payload);
+
+		$this->assertSame(
+			$callsAfterFirstImport,
+			$this->registerUpdateCalls,
+			'an import that changes nothing must not write the register row'
+		);
+
+	}//end testUnchangedReimportDoesNotWriteTheRegister()
+
+}//end class

--- a/tests/Unit/Service/Configuration/ImportHandlerRegisterSchemaLinkOnVersionSkipTest.php
+++ b/tests/Unit/Service/Configuration/ImportHandlerRegisterSchemaLinkOnVersionSkipTest.php
@@ -131,10 +131,12 @@ class ImportHandlerRegisterSchemaLinkOnVersionSkipTest extends TestCase {
 			}
 		);
 
+		// Same parameter-name contract as the RegisterMapper::find() double
+		// below — SchemaMapper::find() additionally takes `$_extend`.
 		$this->schemaMapper->method('find')->willReturnCallback(
-			function (string $id): Schema {
+			function (string|int $id, ?array $_extend = [], bool $_rbac = true, bool $_multitenancy = true): Schema {
 				foreach ($this->schemaStore as $candidate) {
-					if (strtolower((string)$candidate->getSlug()) === strtolower($id)) {
+					if (strtolower((string)$candidate->getSlug()) === strtolower((string)$id)) {
 						return $candidate;
 					}
 				}
@@ -176,9 +178,18 @@ class ImportHandlerRegisterSchemaLinkOnVersionSkipTest extends TestCase {
 
 		// --- RegisterMapper fake -----------------------------------------------
 
+		// The signature must mirror RegisterMapper::find() down to the parameter
+		// NAMES. Production calls it as
+		// `find(id: …, _rbac: false, _multitenancy: false)`, and PHPUnit
+		// forwards an invocation's named arguments to the callback as named
+		// arguments. A closure taking only `$id` therefore dies on "Unknown
+		// named parameter $_rbac" — an Error, not a DoesNotExistException, so
+		// the catch below it does not see it and the whole register import is
+		// skipped by the per-register Throwable guard. The test then looks like
+		// the fix failed when it was never reached.
 		$this->registerMapper->method('find')->willReturnCallback(
-			function (string $id): Register {
-				$existing = ($this->registerStore[strtolower($id)] ?? null);
+			function (string|int $id, bool $_rbac = true, bool $_multitenancy = true): Register {
+				$existing = ($this->registerStore[strtolower((string)$id)] ?? null);
 				if ($existing !== null) {
 					return $existing;
 				}


### PR DESCRIPTION
## The bug

An import that re-ran with an **unchanged register version** took the version-gate skip path *before* the register-schema link was written. The schema pass creates rows regardless of the register's version — an app that adds a schema through a `register.d` fragment routinely leaves the register's own `version` untouched — so those brand-new schema rows were left attached to nothing.

That orphaning is what forks a twin on the *next* import. `computeRegisterScopedSchemaIds()` builds each slug's candidate set from the register's stored `schemas` list, so the missing ids are missing from the candidate set too. `findBySlugInIds()` then cannot see the app's own row, and the register-scoped branch concludes — correctly, from what it was given — that the register does not own this slug yet, and creates a new schema. Every re-import repeats it.

That is how one OpenCatalogi install reached 92 schemas with 25 slugs duplicated, `page` / `menu` / `glossary` present three times over (28 Aug, 3 Sep, 4 Sep), each copy identical but for its uuid. The slugs that stayed in the register's list upserted correctly; only the unlinked ones forked.

Found during the WOO-556 test round as finding B8.

## The fix

The version gate is about the register's **own fields** (title, description, …): there is nothing to write when the incoming definition is not newer. It was never about the schema links. The skip path now adopts the ids this import resolved before returning.

Union semantics, matching the full-update path (#2935): an id this run proved gets added, and an id the register already lists is kept even when this run could not see it. It persists only when the merge actually adds something, so an unchanged re-import stays a no-op write.

## Evidence

Four unit tests over an in-memory schema/register store, which is the only way to observe behaviour that appears solely on a *re*-import:

- a version-skipped register adopts the schema this import created
- importing the same payload four times leaves exactly one row per slug (the WOO-563 reproduction)
- the link is a union, never a replace
- an unchanged re-import writes the register zero times

Run with `--bootstrap apps-extra/.worktrees/phpunit-bootstrap-openregister.php`, which is required from a worktree: Nextcloud's app autoloader maps `OCA\OpenRegister\` to the **installed** app directory, so without it the suite silently tests the live checkout and a green run proves nothing.

| Check | Result |
| --- | --- |
| The four new tests, with the fix | 4 passed, 17 assertions |
| The same tests, with `HEAD~1`'s ImportHandler restored | 2 failed, exactly the twin-fork and missing-link cases |
| `tests/Unit/Service/Configuration/` | 409 passed, 1 skipped |
| `php -l`, phpcs, psalm, phpmd on the changed file | clean |

The second commit fixes the test doubles, which declared `find(string $id)` while the real mappers take extra parameters that production passes by name. PHPUnit forwards named arguments to the callback, so the closure died on `Unknown named parameter $_rbac` — an `Error`, which the `DoesNotExistException` catch does not see, so the per-register `Throwable` guard swallowed the whole register import and the suite read as "the fix does not work".

The first commit's message says the work was unverified. That caveat is superseded by this PR: it was committed mid-crash to preserve the work, and the verification above has since been done.

## Not covered here

Existing installations still carry their duplicates. This PR stops new ones; it does not clean up what is already there. The cleanup advice is tracked on [WOO-563](https://conduction.atlassian.net/browse/WOO-563).

Refs: [WOO-563](https://conduction.atlassian.net/browse/WOO-563), parent [WOO-556](https://conduction.atlassian.net/browse/WOO-556)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WOO-563]: https://conduction.atlassian.net/browse/WOO-563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ