### PR TITLE
fix(objects): keep the instant of a date-time with a non-UTC offset (WOO-567)

### DIFF
--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -40,6 +40,8 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Db;
 
 use DateTime;
+use DateTimeImmutable;
+use DateTimeZone;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Exception;
 use OCA\OpenRegister\Db\MagicMapper\MagicBulkHandler;
@@ -3735,8 +3737,8 @@ class MagicMapper extends AbstractObjectMapper {
 					// as UTC (WOO-567). Done inline rather than through
 					// DateTimeNormalizer so this path keeps working without a
 					// resolvable container.
-					$value = \DateTimeImmutable::createFromInterface($value)
-						->setTimezone(new \DateTimeZone(DateTimeNormalizer::DATABASE_TIMEZONE))
+					$value = DateTimeImmutable::createFromInterface($value)
+						->setTimezone(new DateTimeZone(DateTimeNormalizer::DATABASE_TIMEZONE))
 						->format(DateTimeNormalizer::DATABASE_FORMAT);
 				} elseif (is_string($value) === true) {
 					// Delegate string parsing to DateTimeNormalizer so that empty/whitespace
@@ -3865,10 +3867,10 @@ class MagicMapper extends AbstractObjectMapper {
 						// from a client that sends an offset.
 						$isCalendarDate = ($propertyFormat === 'date');
 						if ($value instanceof \DateTimeInterface) {
-							$moment = \DateTimeImmutable::createFromInterface($value);
+							$moment = DateTimeImmutable::createFromInterface($value);
 							if ($isCalendarDate === false) {
 								$moment = $moment->setTimezone(
-									new \DateTimeZone(DateTimeNormalizer::DATABASE_TIMEZONE)
+									new DateTimeZone(DateTimeNormalizer::DATABASE_TIMEZONE)
 								);
 							}
 

--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -3854,17 +3854,32 @@ class MagicMapper extends AbstractObjectMapper {
 					// Normalise date/date-time properties to Y-m-d H:i:s for MySQL DATETIME columns.
 					$propertyFormat = $propertyConfig['format'] ?? null;
 					if (in_array($propertyFormat, ['date-time', 'date'], true) === true && $value !== null) {
+						// `date` and `date-time` are NOT the same thing here.
+						// A date-time names an instant, so a non-UTC offset has
+						// to be applied before storing (WOO-567). A `date` names
+						// a calendar DAY and has no instant, so converting it
+						// through a timezone is a category error that can move
+						// it: `2026-10-20T00:00:00+02:00` becomes 2026-10-19 in
+						// UTC, and `2026-10-20T23:30:00-05:00` becomes
+						// 2026-10-21. A due date must survive being submitted
+						// from a client that sends an offset.
+						$isCalendarDate = ($propertyFormat === 'date');
 						if ($value instanceof \DateTimeInterface) {
-							// Convert to the column's timezone before formatting,
-							// for the same reason as the metadata fields above
-							// (WOO-567).
-							$value = \DateTimeImmutable::createFromInterface($value)
-								->setTimezone(new \DateTimeZone(DateTimeNormalizer::DATABASE_TIMEZONE))
-								->format(DateTimeNormalizer::DATABASE_FORMAT);
+							$moment = \DateTimeImmutable::createFromInterface($value);
+							if ($isCalendarDate === false) {
+								$moment = $moment->setTimezone(
+									new \DateTimeZone(DateTimeNormalizer::DATABASE_TIMEZONE)
+								);
+							}
+
+							$value = $moment->format(DateTimeNormalizer::DATABASE_FORMAT);
 						} elseif (is_string($value) === true) {
-							$value = $this->container
-								->get(DateTimeNormalizer::class)
-								->formatForDatabase($value);
+							$normalizer = $this->container->get(DateTimeNormalizer::class);
+							if ($isCalendarDate === true) {
+								$value = $normalizer->formatDateForDatabase($value);
+							} else {
+								$value = $normalizer->formatForDatabase($value);
+							}
 						}
 					}
 

--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -59,6 +59,7 @@ use OCA\OpenRegister\Event\ObjectUpdatedEvent;
 use OCA\OpenRegister\Event\ObjectUpdatingEvent;
 use OCA\OpenRegister\Exception\HookStoppedException;
 use OCA\OpenRegister\Exception\ObjectExistsException;
+use OCA\OpenRegister\Service\DateTimeNormalizer;
 use OCA\OpenRegister\Service\SettingsService;
 use OCA\OpenRegister\Support\QueryLimit;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -3728,13 +3729,22 @@ class MagicMapper extends AbstractObjectMapper {
 				}
 
 				if ($value instanceof \DateTimeInterface) {
-					$value = $value->format('Y-m-d H:i:s');
+					// Convert to the column's timezone BEFORE formatting: format()
+					// renders in whatever timezone the instance carries, so a
+					// non-UTC one was written as its own clock time and read back
+					// as UTC (WOO-567). Done inline rather than through
+					// DateTimeNormalizer so this path keeps working without a
+					// resolvable container.
+					$value = \DateTimeImmutable::createFromInterface($value)
+						->setTimezone(new \DateTimeZone(DateTimeNormalizer::DATABASE_TIMEZONE))
+						->format(DateTimeNormalizer::DATABASE_FORMAT);
 				} elseif (is_string($value) === true) {
 					// Delegate string parsing to DateTimeNormalizer so that empty/whitespace
-					// input becomes null rather than silently becoming "now". The outer
+					// input becomes null rather than silently becoming "now", and a
+					// non-UTC offset is converted rather than dropped. The outer
 					// default-to-now logic for absent created/updated is preserved above.
 					$value = $this->container
-						->get(\OCA\OpenRegister\Service\DateTimeNormalizer::class)
+						->get(DateTimeNormalizer::class)
 						->formatForDatabase($value);
 				}
 			}
@@ -3845,10 +3855,15 @@ class MagicMapper extends AbstractObjectMapper {
 					$propertyFormat = $propertyConfig['format'] ?? null;
 					if (in_array($propertyFormat, ['date-time', 'date'], true) === true && $value !== null) {
 						if ($value instanceof \DateTimeInterface) {
-							$value = $value->format('Y-m-d H:i:s');
+							// Convert to the column's timezone before formatting,
+							// for the same reason as the metadata fields above
+							// (WOO-567).
+							$value = \DateTimeImmutable::createFromInterface($value)
+								->setTimezone(new \DateTimeZone(DateTimeNormalizer::DATABASE_TIMEZONE))
+								->format(DateTimeNormalizer::DATABASE_FORMAT);
 						} elseif (is_string($value) === true) {
 							$value = $this->container
-								->get(\OCA\OpenRegister\Service\DateTimeNormalizer::class)
+								->get(DateTimeNormalizer::class)
 								->formatForDatabase($value);
 						}
 					}

--- a/lib/Db/MagicMapper/MagicSearchHandler.php
+++ b/lib/Db/MagicMapper/MagicSearchHandler.php
@@ -2424,7 +2424,11 @@ class MagicSearchHandler {
 							$value = $normalised->format('Y-m-d');
 						}
 					} elseif ($propertyFormat === 'date-time') {
-						$value = $this->dateTimeNormalizer->formatForIso8601($value);
+						// The column is a DATETIME and carries no offset, so the value
+						// must be read back in the timezone the write path stored it
+						// in (UTC) rather than in the server's `date.timezone`
+						// (WOO-567).
+						$value = $this->dateTimeNormalizer->formatDatabaseValueForIso8601($value);
 					}
 				}
 

--- a/lib/Db/MagicMapper/MagicStatisticsHandler.php
+++ b/lib/Db/MagicMapper/MagicStatisticsHandler.php
@@ -671,7 +671,9 @@ class MagicStatisticsHandler {
 							$value = $normalised->format('Y-m-d');
 						}
 					} elseif ($propertyFormat === 'date-time') {
-						$value = $this->dateTimeNormalizer->formatForIso8601($value);
+						// Offset-less DATETIME column value: interpret it in the
+						// timezone the write path stored it in (WOO-567).
+						$value = $this->dateTimeNormalizer->formatDatabaseValueForIso8601($value);
 					}
 				}
 

--- a/lib/Service/DateTimeNormalizer.php
+++ b/lib/Service/DateTimeNormalizer.php
@@ -34,6 +34,7 @@ namespace OCA\OpenRegister\Service;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use DateTimeZone;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
@@ -57,6 +58,19 @@ class DateTimeNormalizer {
 	public const DATABASE_FORMAT = 'Y-m-d H:i:s';
 
 	/**
+	 * Timezone the offset-less database datetime columns are expressed in.
+	 *
+	 * A `date`/`date-time` schema property is backed by a DATETIME column
+	 * (`timestamp without time zone` on PostgreSQL), which stores a clock time
+	 * and no offset. Both directions of the round-trip therefore have to agree
+	 * on one timezone for that clock time, and that timezone is UTC — never the
+	 * server's `date.timezone`, which differs per deployment.
+	 *
+	 * @var string
+	 */
+	public const DATABASE_TIMEZONE = 'UTC';
+
+	/**
 	 * Constructor.
 	 *
 	 * @param LoggerInterface $logger Logger for debug-level notices on parse failures.
@@ -69,7 +83,13 @@ class DateTimeNormalizer {
 	/**
 	 * Normalise user-supplied input to `DateTimeImmutable` or `null`.
 	 *
-	 * @param mixed $value Value to normalise (string, null, DateTimeInterface, or anything else).
+	 * @param mixed             $value          Value to normalise (string, null, DateTimeInterface, or anything else).
+	 * @param DateTimeZone|null $assumeTimezone Timezone to attribute to a string that carries no
+	 *                                          offset or timezone name of its own. A string that
+	 *                                          does carry one keeps it, and a `DateTimeInterface`
+	 *                                          is never re-zoned. Defaults to PHP's
+	 *                                          `date_default_timezone_get()`, which is what
+	 *                                          `new DateTimeImmutable()` would use anyway.
 	 *
 	 * @return DateTimeImmutable|null A `DateTimeImmutable` when parseable, otherwise `null`.
 	 *
@@ -77,7 +97,7 @@ class DateTimeNormalizer {
 	 *
 	 * @spec openspec/specs/datetime-input-handling/spec.md
 	 */
-	public function normalize(mixed $value): ?DateTimeImmutable {
+	public function normalize(mixed $value, ?DateTimeZone $assumeTimezone = null): ?DateTimeImmutable {
 		if ($value === null) {
 			return null;
 		}
@@ -104,7 +124,10 @@ class DateTimeNormalizer {
 		}
 
 		try {
-			return new DateTimeImmutable($trimmed);
+			// `DateTimeImmutable` applies the second argument ONLY when the string
+			// itself carries no offset or timezone name, which is exactly the
+			// "naive database column value" case the callers need it for.
+			return new DateTimeImmutable($trimmed, $assumeTimezone);
 		} catch (Throwable $e) {
 			$this->logger->debug(
 				message: '[DateTimeNormalizer] Unparseable datetime string',
@@ -122,19 +145,29 @@ class DateTimeNormalizer {
 	/**
 	 * Format user-supplied input as a database datetime string.
 	 *
+	 * The value is converted to `self::DATABASE_TIMEZONE` BEFORE it is rendered.
+	 * `format()` renders a `DateTimeImmutable` in whatever timezone that instance
+	 * carries, so rendering `2026-10-20T00:00:00+02:00` directly produced
+	 * `2026-10-20 00:00:00` — the offset silently discarded rather than applied.
+	 * The read path then interpreted that offset-less column value as UTC, so the
+	 * instant came back two hours later than it was sent (WOO-567: a WMEBV
+	 * objection deadline in the Portaliq inbox shifted from 00:00 to 02:00).
+	 * Converting first stores `2026-10-19 22:00:00`, the same instant.
+	 *
 	 * @param mixed $value Value to normalise and format.
 	 *
-	 * @return string|null `Y-m-d H:i:s`-formatted string, or `null` for empty/invalid input.
+	 * @return string|null `Y-m-d H:i:s`-formatted string in `self::DATABASE_TIMEZONE`,
+	 *                     or `null` for empty/invalid input.
 	 *
 	 * @spec openspec/specs/datetime-input-handling/spec.md
 	 */
 	public function formatForDatabase(mixed $value): ?string {
-		$datetime = $this->normalize(value: $value);
+		$datetime = $this->normalize(value: $value, assumeTimezone: $this->databaseTimezone());
 		if ($datetime === null) {
 			return null;
 		}
 
-		return $datetime->format(self::DATABASE_FORMAT);
+		return $datetime->setTimezone($this->databaseTimezone())->format(self::DATABASE_FORMAT);
 	}//end formatForDatabase()
 
 	/**
@@ -154,4 +187,40 @@ class DateTimeNormalizer {
 
 		return $datetime->format(DateTimeInterface::ATOM);
 	}//end formatForIso8601()
+
+	/**
+	 * Format a value read back from a database datetime column as ISO 8601.
+	 *
+	 * The counterpart of `formatForDatabase()`. A DATETIME column carries no
+	 * offset, so the string the driver hands back (`2026-10-19 22:00:00`) is
+	 * naive and `formatForIso8601()` would attribute the server's
+	 * `date.timezone` to it. That happens to be right on a UTC server and wrong
+	 * everywhere else, which would re-open WOO-567 on any deployment whose PHP
+	 * timezone is not UTC. Read paths that pull a `date-time` property straight
+	 * out of its column MUST use this method so the stored instant survives
+	 * regardless of how the server is configured.
+	 *
+	 * @param mixed $value Column value to interpret and format.
+	 *
+	 * @return string|null ISO 8601 string with offset, or `null` for empty/invalid input.
+	 *
+	 * @spec openspec/specs/datetime-input-handling/spec.md
+	 */
+	public function formatDatabaseValueForIso8601(mixed $value): ?string {
+		$datetime = $this->normalize(value: $value, assumeTimezone: $this->databaseTimezone());
+		if ($datetime === null) {
+			return null;
+		}
+
+		return $datetime->format(DateTimeInterface::ATOM);
+	}//end formatDatabaseValueForIso8601()
+
+	/**
+	 * The timezone offset-less database datetime columns are expressed in.
+	 *
+	 * @return DateTimeZone The `self::DATABASE_TIMEZONE` zone.
+	 */
+	private function databaseTimezone(): DateTimeZone {
+		return new DateTimeZone(self::DATABASE_TIMEZONE);
+	}//end databaseTimezone()
 }//end class

--- a/lib/Service/DateTimeNormalizer.php
+++ b/lib/Service/DateTimeNormalizer.php
@@ -189,6 +189,37 @@ class DateTimeNormalizer {
 	}//end formatForIso8601()
 
 	/**
+	 * Format a `format: date` value for its database column.
+	 *
+	 * The counterpart of `formatForDatabase()` for values that name a calendar
+	 * DAY rather than an instant. Deliberately does NOT convert to
+	 * `self::DATABASE_TIMEZONE`: a date has no instant, so converting it is a
+	 * category error that can move it to the previous or next day. A client
+	 * that sends `2026-10-20T00:00:00+02:00` for a due date means the 20th, and
+	 * UTC conversion would store the 19th; `2026-10-20T23:30:00-05:00` would
+	 * store the 21st.
+	 *
+	 * The wall-clock reading is kept as given, which is also what this method
+	 * did before WOO-567 split the two formats apart — so `date` behaviour is
+	 * unchanged by that fix, which is the point.
+	 *
+	 * @param mixed $value Value to normalise and format.
+	 *
+	 * @return string|null `Y-m-d H:i:s`-formatted string preserving the given
+	 *                     calendar day, or `null` for empty/invalid input.
+	 *
+	 * @spec openspec/specs/datetime-input-handling/spec.md
+	 */
+	public function formatDateForDatabase(mixed $value): ?string {
+		$datetime = $this->normalize(value: $value, assumeTimezone: $this->databaseTimezone());
+		if ($datetime === null) {
+			return null;
+		}
+
+		return $datetime->format(self::DATABASE_FORMAT);
+	}//end formatDateForDatabase()
+
+	/**
 	 * Format a value read back from a database datetime column as ISO 8601.
 	 *
 	 * The counterpart of `formatForDatabase()`. A DATETIME column carries no

--- a/openspec/specs/datetime-input-handling/spec.md
+++ b/openspec/specs/datetime-input-handling/spec.md
@@ -39,6 +39,10 @@ then format as `Y-m-d H:i:s`, returning `null` for empty/invalid input.
 `formatForIso8601(mixed $value): ?string` MUST normalize then format as ISO 8601 with
 timezone offset (`DateTimeInterface::ATOM`), returning `null` for empty/invalid input.
 
+`normalize()` MUST accept an optional `?DateTimeZone $assumeTimezone`. It MUST be applied
+ONLY to a string that carries no offset or timezone name of its own; a string that carries
+one keeps it, and a `DateTimeInterface` is never re-zoned.
+
 #### Scenario: Empty and whitespace input normalizes to null
 - **GIVEN** the value `''`, a whitespace-only string, or `null`
 - **WHEN** `normalize()` is called
@@ -55,4 +59,43 @@ timezone offset (`DateTimeInterface::ATOM`), returning `null` for empty/invalid 
 - **WHEN** `normalize()` is called
 - **THEN** it MUST return `null`
 - **AND** a debug-level log entry MUST be written
+
+### Requirement: Database Datetime Columns Are UTC
+
+A `date` / `date-time` schema property is backed by a DATETIME column
+(`timestamp without time zone` on PostgreSQL) that stores a clock time and carries no
+offset. Both directions of the round-trip MUST therefore agree on ONE timezone for that
+clock time, and that timezone MUST be UTC — never the server's `date.timezone`, which
+differs per deployment.
+
+`formatForDatabase()` MUST convert the normalized value to UTC BEFORE rendering it as
+`Y-m-d H:i:s`, so that a non-UTC offset is APPLIED rather than discarded. Rendering
+directly is forbidden: `format()` renders in whatever timezone the instance carries, so
+`2026-10-20T00:00:00+02:00` produced `2026-10-20 00:00:00` and the read path then read
+that offset-less value back as UTC, moving the instant two hours forward.
+
+The system MUST provide `formatDatabaseValueForIso8601(mixed $value): ?string` as the read
+counterpart. It MUST interpret an offset-less column value as UTC and format it as ISO 8601
+with offset. Every read path that lifts a `date-time` property straight out of its column
+MUST use it rather than `formatForIso8601()`, whose naive-string behaviour depends on the
+server's configured timezone.
+
+#### Scenario: A non-UTC offset is converted, not dropped
+- **GIVEN** the `date-time` value `2026-10-20T00:00:00+02:00`
+- **WHEN** `formatForDatabase()` is called
+- **THEN** it MUST return `2026-10-19 22:00:00`
+- **AND** a negative offset MUST shift the other way: `2026-10-20T00:00:00-05:00` MUST
+  return `2026-10-20 05:00:00`
+
+#### Scenario: An offset-less column value is read back as UTC
+- **GIVEN** the column value `2026-10-19 22:00:00`
+- **WHEN** `formatDatabaseValueForIso8601()` is called
+- **THEN** it MUST return `2026-10-19T22:00:00+00:00`
+
+#### Scenario: The round-trip preserves the instant regardless of server timezone
+- **GIVEN** a `date-time` value with any offset
+- **AND** a server whose `date.timezone` is not UTC
+- **WHEN** the value is written with `formatForDatabase()` and read back with
+  `formatDatabaseValueForIso8601()`
+- **THEN** the result MUST denote the SAME INSTANT as the input
 

--- a/tests/Unit/Service/DateTimeNormalizerTest.php
+++ b/tests/Unit/Service/DateTimeNormalizerTest.php
@@ -298,4 +298,53 @@ class DateTimeNormalizerTest extends TestCase {
 		);
 	}//end testNormalizeAppliesAssumedTimezoneOnlyToNaiveStrings()
 
+	/**
+	 * A `format: date` value names a calendar DAY, so the UTC conversion the
+	 * date-time path needs must NOT be applied to it. Converting moves the day
+	 * in both directions — `2026-10-20T00:00:00+02:00` would store the 19th and
+	 * `2026-10-20T23:30:00-05:00` the 21st — which would silently move a due
+	 * date for any client that sends an offset.
+	 *
+	 * @dataProvider calendarDateProvider
+	 */
+	public function testACalendarDateKeepsItsDayWhateverOffsetItArrivesWith(
+		string $input,
+		string $expectedDay
+	): void {
+		$formatted = $this->normalizer->formatDateForDatabase($input);
+
+		$this->assertNotNull($formatted);
+		$this->assertSame(
+			$expectedDay,
+			substr($formatted, 0, 10),
+			sprintf('`%s` must still be stored on %s', $input, $expectedDay)
+		);
+	}//end testACalendarDateKeepsItsDayWhateverOffsetItArrivesWith()
+
+	public static function calendarDateProvider(): array {
+		return [
+			'bare date' => ['2026-10-20', '2026-10-20'],
+			'midnight with a positive offset' => ['2026-10-20T00:00:00+02:00', '2026-10-20'],
+			'late evening with a negative offset' => ['2026-10-20T23:30:00-05:00', '2026-10-20'],
+			'explicit utc' => ['2026-10-20T00:00:00Z', '2026-10-20'],
+		];
+	}//end calendarDateProvider()
+
+	/**
+	 * The contrast that makes the split meaningful: the SAME input, read as a
+	 * date-time, does move — because a date-time names an instant and the
+	 * offset has to be applied for that instant to survive the offset-less
+	 * column.
+	 */
+	public function testTheSameInputAsADateTimeIsConvertedNotPreserved(): void {
+		$this->assertSame(
+			'2026-10-19 22:00:00',
+			$this->normalizer->formatForDatabase('2026-10-20T00:00:00+02:00')
+		);
+		$this->assertSame(
+			'2026-10-20 00:00:00',
+			$this->normalizer->formatDateForDatabase('2026-10-20T00:00:00+02:00')
+		);
+	}//end testTheSameInputAsADateTimeIsConvertedNotPreserved()
+
 }//end class

--- a/tests/Unit/Service/DateTimeNormalizerTest.php
+++ b/tests/Unit/Service/DateTimeNormalizerTest.php
@@ -7,6 +7,7 @@ namespace OCA\OpenRegister\Tests\Unit\Service;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
+use DateTimeZone;
 use OCA\OpenRegister\Service\DateTimeNormalizer;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -159,5 +160,142 @@ class DateTimeNormalizerTest extends TestCase {
 		$this->logger->expects($this->once())->method('debug');
 		$this->assertNull($this->normalizer->formatForIso8601('not-a-date'));
 	}//end testFormatForIso8601OnGarbledReturnsNull()
+
+	// ------------------------------------------------------------------
+	// WOO-567 — a date-time with a non-UTC offset must keep its INSTANT
+	// across the database round-trip. `format()` renders in whatever
+	// timezone the instance carries, so rendering `…T00:00:00+02:00`
+	// straight to `Y-m-d H:i:s` dropped the offset instead of applying
+	// it, and the offset-less column value was then read back as UTC —
+	// moving a WMEBV objection deadline two hours forward.
+	// ------------------------------------------------------------------
+
+	/**
+	 * @dataProvider offsetToUtcProvider
+	 */
+	public function testFormatForDatabaseConvertsOffsetToUtc(string $input, string $expected): void {
+		$this->assertSame($expected, $this->normalizer->formatForDatabase($input));
+	}//end testFormatForDatabaseConvertsOffsetToUtc()
+
+	public static function offsetToUtcProvider(): array {
+		return [
+			// The reported case: a +02:00 deadline must move BACK two hours in
+			// the column, not keep its clock time.
+			'positive offset' => ['2026-10-20T00:00:00+02:00', '2026-10-19 22:00:00'],
+			'positive offset midday' => ['2026-09-08T10:46:00+02:00', '2026-09-08 08:46:00'],
+			// A negative offset must move forward, proving the conversion is
+			// signed and not a hardcoded European shift.
+			'negative offset' => ['2026-10-20T00:00:00-05:00', '2026-10-20 05:00:00'],
+			// Already UTC, in both spellings: unchanged.
+			'explicit utc offset' => ['2026-10-20T00:00:00+00:00', '2026-10-20 00:00:00'],
+			'zulu' => ['2026-10-20T00:00:00Z', '2026-10-20 00:00:00'],
+			// A naive value carries no offset, so it is taken as already being
+			// in the column's timezone and is not shifted.
+			'naive datetime' => ['2026-10-20 00:00:00', '2026-10-20 00:00:00'],
+			'date only' => ['2026-10-20', '2026-10-20 00:00:00'],
+		];
+	}//end offsetToUtcProvider()
+
+	public function testFormatForDatabaseConvertsDateTimeObjectToUtc(): void {
+		$value = new DateTimeImmutable('2026-10-20T00:00:00+02:00');
+		$this->assertSame('2026-10-19 22:00:00', $this->normalizer->formatForDatabase($value));
+
+		$mutable = new DateTime('2026-10-20T00:00:00-05:00');
+		$this->assertSame('2026-10-20 05:00:00', $this->normalizer->formatForDatabase($mutable));
+	}//end testFormatForDatabaseConvertsDateTimeObjectToUtc()
+
+	public function testFormatDatabaseValueForIso8601ReadsNaiveColumnAsUtc(): void {
+		$this->assertSame(
+			'2026-10-19T22:00:00+00:00',
+			$this->normalizer->formatDatabaseValueForIso8601('2026-10-19 22:00:00')
+		);
+	}//end testFormatDatabaseValueForIso8601ReadsNaiveColumnAsUtc()
+
+	public function testFormatDatabaseValueForIso8601OnEmptyReturnsNull(): void {
+		$this->assertNull($this->normalizer->formatDatabaseValueForIso8601(''));
+		$this->assertNull($this->normalizer->formatDatabaseValueForIso8601(null));
+		$this->assertNull($this->normalizer->formatDatabaseValueForIso8601('   '));
+	}//end testFormatDatabaseValueForIso8601OnEmptyReturnsNull()
+
+	/**
+	 * The end-to-end contract: write then read must land on the same instant.
+	 *
+	 * @dataProvider roundTripProvider
+	 */
+	public function testWriteThenReadPreservesTheInstant(string $input): void {
+		$stored = $this->normalizer->formatForDatabase($input);
+		$this->assertIsString($stored);
+
+		$readBack = $this->normalizer->formatDatabaseValueForIso8601($stored);
+		$this->assertIsString($readBack);
+
+		$this->assertSame(
+			(new DateTimeImmutable($input))->getTimestamp(),
+			(new DateTimeImmutable($readBack))->getTimestamp(),
+			'The round-trip moved the instant for input ' . $input
+		);
+	}//end testWriteThenReadPreservesTheInstant()
+
+	public static function roundTripProvider(): array {
+		return [
+			'positive offset' => ['2026-10-20T00:00:00+02:00'],
+			'negative offset' => ['2026-10-20T00:00:00-05:00'],
+			'half-hour offset' => ['2026-10-20T00:00:00+05:30'],
+			'zulu' => ['2026-10-20T00:00:00Z'],
+			'winter time' => ['2026-01-15T09:30:00+01:00'],
+		];
+	}//end roundTripProvider()
+
+	/**
+	 * The round-trip must not depend on the server's `date.timezone`: the
+	 * column carries no offset, so both directions have to agree on UTC
+	 * rather than on whatever PHP happens to default to.
+	 *
+	 * @dataProvider serverTimezoneProvider
+	 */
+	public function testRoundTripIsIndependentOfServerTimezone(string $serverTimezone): void {
+		$original = date_default_timezone_get();
+		date_default_timezone_set($serverTimezone);
+
+		try {
+			$stored = $this->normalizer->formatForDatabase('2026-10-20T00:00:00+02:00');
+			$this->assertSame('2026-10-19 22:00:00', $stored);
+
+			$this->assertSame(
+				'2026-10-19T22:00:00+00:00',
+				$this->normalizer->formatDatabaseValueForIso8601($stored)
+			);
+		} finally {
+			date_default_timezone_set($original);
+		}
+	}//end testRoundTripIsIndependentOfServerTimezone()
+
+	public static function serverTimezoneProvider(): array {
+		return [
+			'utc' => ['UTC'],
+			'amsterdam' => ['Europe/Amsterdam'],
+			'new york' => ['America/New_York'],
+			'kathmandu' => ['Asia/Kathmandu'],
+		];
+	}//end serverTimezoneProvider()
+
+	public function testNormalizeAppliesAssumedTimezoneOnlyToNaiveStrings(): void {
+		$utc = new DateTimeZone('UTC');
+
+		// Naive: the assumed timezone is applied.
+		$naive = $this->normalizer->normalize('2026-10-20 00:00:00', $utc);
+		$this->assertInstanceOf(DateTimeImmutable::class, $naive);
+		$this->assertSame('+00:00', $naive->format('P'));
+
+		// Offset-bearing: the string's own offset wins, and the instant is
+		// whatever the caller sent.
+		$explicit = $this->normalizer->normalize('2026-10-20T00:00:00+02:00', $utc);
+		$this->assertInstanceOf(DateTimeImmutable::class, $explicit);
+		$this->assertSame('+02:00', $explicit->format('P'));
+		$this->assertSame(
+			(new DateTimeImmutable('2026-10-19T22:00:00Z'))->getTimestamp(),
+			$explicit->getTimestamp()
+		);
+	}//end testNormalizeAppliesAssumedTimezoneOnlyToNaiveStrings()
 
 }//end class


### PR DESCRIPTION
## The bug

A `format: date-time` value written with a non-UTC offset came back with the **offset replaced and the clock time untouched**, so the instant silently moved:

```
PATCH {"receivedAt":"2026-09-08T10:46:00+02:00"}   → response echoes +02:00
GET   same object                                   → "2026-09-08T10:46:00+00:00"
```

Two hours later than what was sent. For a WMEBV objection term (art. 2:10) surfaced as a deadline in the Portaliq inbox, that is a legally relevant shift, not a display quirk. Found in the WOO-556 round as finding B23.

**Why.** `format()` renders a `DateTimeImmutable` in whatever timezone the instance carries, so `2026-10-20T00:00:00+02:00` was written to the DATETIME column as `2026-10-20 00:00:00` — the offset discarded rather than applied. The column carries no offset, and the read path then attributed one to that naive value, so the round-trip lost the instant.

## The fix

One rule, applied at both ends: **the offset-less datetime column is UTC.**

- Write: convert to UTC *before* formatting, so `10:46+02:00` stores `08:46:00`.
- Read: interpret the column value as UTC via a new `formatDatabaseValueForIso8601()`, rather than attributing the server's `date.timezone` to it.

That second half matters more than it looks. Using the existing `formatForIso8601()` on a column value happens to be right on a UTC-configured server and wrong everywhere else, which would have re-opened this bug on any deployment whose PHP timezone is not UTC. Both database read paths (`MagicSearchHandler`, `MagicStatisticsHandler`) now use the new method; `formatForIso8601()` stays for values that carry their own offset.

`normalize()` gains an optional `assumeTimezone`, applied by `DateTimeImmutable` only when the string carries no offset of its own — exactly the naive-column case. A string that carries an offset keeps it, and a `DateTimeInterface` is never re-zoned.

## Evidence

**On the running dev instance**, against the same object, before and after copying the four changed files into the live checkout:

| | PATCH sent | GET returns | Instant |
| --- | --- | --- | --- |
| Before | `10:46:00+02:00` | `10:46:00+00:00` | **shifted +2h** |
| After | `10:46:00+02:00` | `08:46:00+00:00` | preserved |
| After | `10:46:00-05:00` | `15:46:00+00:00` | preserved |

The live checkout was restored afterwards with a targeted `git show HEAD:<path>`, and the test object was set back to its original value.

**Unit**: 44 tests, 90 assertions pass. Restoring `HEAD~1`'s `DateTimeNormalizer` makes 15 of them fail, including the exact `2026-10-19 22:00:00` vs `2026-10-20 00:00:00` case — so the suite pins the behaviour rather than passing either way.

`php -l`, phpcs and phpmd are clean on all four changed files.

## Reviewer notes

- The `MagicMapper` write paths convert inline rather than through `DateTimeNormalizer`, so they keep working without a resolvable container. That is deliberate and commented at both sites, but it does mean the constant is shared while the conversion is not.
- `formatForIso8601()` now has no callers left inside `lib/`. It is public API and other consumers may use it, so it is kept.
- The first commit's message says the work was unverified — it was committed mid-crash to preserve it. That caveat is superseded by the evidence above.

## Not covered here

**Existing stored values may already be wrong.** Anything written before this fix with a non-UTC offset is sitting in the column as its original clock time, so reading it back as UTC now reports the same wrong instant it always did. Whether that needs a migration or an `occ` repair is not settled and is not in this PR — it needs a decision about which deployments and which registers are affected. Tracked on [WOO-567](https://conduction.atlassian.net/browse/WOO-567).

Refs: [WOO-567](https://conduction.atlassian.net/browse/WOO-567), parent [WOO-556](https://conduction.atlassian.net/browse/WOO-556)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WOO-567]: https://conduction.atlassian.net/browse/WOO-567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ