### PR TITLE
fix(patch): re-encode the string-typed values the read path decoded

### DIFF
--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -5013,6 +5013,13 @@ class ObjectsController extends Controller {
 			return $mergedData;
 		}
 
+		// A container may answer with something other than a converter, or with
+		// nothing at all. Returning the data unchanged keeps the pre-existing
+		// refusal; calling a method on null would turn a patch into a fatal.
+		if (($converter instanceof SchemaTypeConverter) === false) {
+			return $mergedData;
+		}
+
 		return $converter->restoreStringTypedValues(
 			data: $mergedData,
 			properties: ($schemaEntity->getProperties() ?? []),

--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -36,6 +36,7 @@ use DateTime;
 use OCA\OpenRegister\Db\AuditTrailMapper;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Exception\AppendOnlyException;
 use OCA\OpenRegister\Exception\ArchivalImmutableException;
@@ -53,6 +54,7 @@ use OCA\OpenRegister\Exception\ValidationException;
 use OCA\OpenRegister\Service\ExportService;
 use OCA\OpenRegister\Service\FileService;
 use OCA\OpenRegister\Service\ImportService;
+use OCA\OpenRegister\Service\Object\SchemaTypeConverter;
 use OCA\OpenRegister\Service\ObjectService;
 use OCA\OpenRegister\Service\WebhookService;
 use OCP\App\IAppManager;
@@ -3145,6 +3147,15 @@ class ObjectsController extends Controller {
 			// Get the existing object data and merge with patch data.
 			$existingData = $existingObject->getObject();
 			$mergedData = array_merge($existingData ?? [], $patchData);
+
+			// The read decoded, so the write re-encodes. Only keys the caller
+			// did NOT send are restored — see restoreStringTypedValues().
+			$mergedData = $this->restoreStringTypedValues(
+				mergedData: $mergedData,
+				schemaEntity: $resolved['schemaEntity'],
+				suppliedKeys: array_keys($patchData)
+			);
+
 			// Use the object service to validate and update the object.
 			$objectEntity = $objectService->saveObject(
 				register: $resolved['register'],
@@ -3357,6 +3368,14 @@ class ObjectsController extends Controller {
 			// Merge existing data with patch data (patch semantics).
 			$existingData = $existingObject->getObject();
 			$mergedData = array_merge($existingData ?? [], $patchData);
+
+			// The read decoded, so the write re-encodes. Only keys the caller
+			// did NOT send are restored — see restoreStringTypedValues().
+			$mergedData = $this->restoreStringTypedValues(
+				mergedData: $mergedData,
+				schemaEntity: $resolved['schemaEntity'],
+				suppliedKeys: array_keys($patchData)
+			);
 
 			$objectService->clearCreatedSubObjects();
 
@@ -4956,6 +4975,50 @@ class ObjectsController extends Controller {
 
 		return $flowContext->currentRunUuid();
 	}//end callerRunUuid()
+
+	/**
+	 * Restore the stored form of string-typed properties the read path decoded.
+	 *
+	 * ONE helper for both patch doors, and it holds no rule of its own: the
+	 * rule lives in `SchemaTypeConverter::restoreStringTypedValues()`, beside
+	 * the decode it undoes. All this does is find the schema's property
+	 * declarations and say which keys the caller sent.
+	 *
+	 * Why it is needed at all: the magic-table read decodes a `type: string`
+	 * value that looks like JSON, so `$existingObject->getObject()` hands back
+	 * an ARRAY where the schema declares a string. Merging that array into the
+	 * payload and saving it makes validation refuse a PATCH that never
+	 * mentioned the property — the "only the provided fields change" promise in
+	 * this method's own docblock, broken by a property nobody named.
+	 *
+	 * If the schema entity is not resolvable the data is returned unchanged,
+	 * leaving today's loud validation refusal in place rather than guessing.
+	 *
+	 * @param array $mergedData   The merged object data about to be saved.
+	 * @param mixed $schemaEntity The resolved schema entity, or whatever resolution produced.
+	 * @param array $suppliedKeys Keys the caller actually sent in the patch payload.
+	 *
+	 * @return array The data with untouched string-typed JSON values restored.
+	 *
+	 * @spec openspec/specs/schema-driven-read-coercion/spec.md
+	 */
+	private function restoreStringTypedValues(array $mergedData, mixed $schemaEntity, array $suppliedKeys): array {
+		if (($schemaEntity instanceof Schema) === false) {
+			return $mergedData;
+		}
+
+		try {
+			$converter = $this->container->get(SchemaTypeConverter::class);
+		} catch (NotFoundExceptionInterface|ContainerExceptionInterface $unavailable) {
+			return $mergedData;
+		}
+
+		return $converter->restoreStringTypedValues(
+			data: $mergedData,
+			properties: ($schemaEntity->getProperties() ?? []),
+			suppliedKeys: $suppliedKeys
+		);
+	}//end restoreStringTypedValues()
 
 	/**
 	 * Refuse a write to a locked object, or return null when it may proceed.

--- a/lib/Service/Object/SchemaTypeConverter.php
+++ b/lib/Service/Object/SchemaTypeConverter.php
@@ -142,6 +142,126 @@ class SchemaTypeConverter {
 	}//end convertString()
 
 	/**
+	 * Re-encode the string-typed properties that the read path decoded.
+	 *
+	 * This is the inverse of `convertString()`'s decode branch, and it lives
+	 * beside it deliberately: a decode with its encode written somewhere else
+	 * drifts, and that drift is the defect this closes. `convertString()`
+	 * decodes any `type: string` value that looks like a JSON array or object,
+	 * so a read hands back an ARRAY where the schema declares a string. Every
+	 * read-merge-save cycle then feeds that array straight back into validation,
+	 * which refuses it — so a PATCH that never mentioned the property fails
+	 * because of it, and the "a key absent from the payload leaves the stored
+	 * value untouched" promise breaks.
+	 *
+	 * WHICH KEYS. Only the ones the caller did NOT supply. `$suppliedKeys` are
+	 * skipped on purpose: this method restores the shape of values nobody
+	 * touched, which is the promise being repaired. A caller that deliberately
+	 * passes an array for a `type: string` property still gets the same loud
+	 * validation refusal it gets today. Silently rewriting a value the caller
+	 * chose would replace a visible refusal with an invisible transform, which
+	 * is the worse of the two failures.
+	 *
+	 * WHICH TYPES. Every declared type that `convertValue()` routes to
+	 * `convertString()` — so `string`, the extended field types, and anything
+	 * unknown, but never `array`, `object`, `number`, `integer` or `boolean`. A
+	 * union that admits `array` or `object` is left alone: the array form is
+	 * valid there, so there is nothing to restore.
+	 *
+	 * WHICH DEPTH. Top level only, because that is the only depth the read
+	 * decodes: the magic-table read applies `convertValue()` once per column,
+	 * i.e. once per declared property. A `type: string` nested inside an
+	 * `object` property was never decoded and must not be encoded here.
+	 *
+	 * A non-array value is left untouched — there is nothing to re-encode — and
+	 * so is a value `json_encode()` refuses. Both fall through to validation,
+	 * which is the failure direction this method must preserve: loud, not
+	 * silent.
+	 *
+	 * @param array $data         The object data about to be saved.
+	 * @param array $properties   The schema's property definitions, keyed by property name.
+	 * @param array $suppliedKeys Keys the caller actually sent; these are left exactly as merged.
+	 *
+	 * @return array The data with untouched string-typed JSON values restored to their stored form.
+	 *
+	 * @spec openspec/specs/schema-driven-read-coercion/spec.md
+	 */
+	public function restoreStringTypedValues(array $data, array $properties, array $suppliedKeys=[]): array {
+		foreach ($data as $key => $value) {
+			if (is_array($value) === false) {
+				continue;
+			}
+
+			if (in_array($key, $suppliedKeys, true) === true) {
+				continue;
+			}
+
+			if (array_key_exists($key, $properties) === false || is_array($properties[$key]) === false) {
+				continue;
+			}
+
+			if ($this->isStringTyped(declaredType: ($properties[$key]['type'] ?? 'string')) === false) {
+				continue;
+			}
+
+			// Flags chosen to match what wrote these values in the first place:
+			// JavaScript's JSON.stringify escapes neither slashes nor non-ASCII,
+			// and consuming apps store `JSON.stringify(...)` into these columns.
+			$encoded = json_encode($value, (JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+			if ($encoded === false) {
+				continue;
+			}
+
+			$data[$key] = $encoded;
+		}//end foreach
+
+		return $data;
+	}//end restoreStringTypedValues()
+
+	/**
+	 * Whether a declared schema type is one `convertValue()` routes to `convertString()`.
+	 *
+	 * Mirrors the dispatch table in `convertValue()` rather than listing the
+	 * string-ish types: the decode happens in the `default` arm, so the set is
+	 * "everything that is not one of the five typed arms". `null` members of a
+	 * union are ignored, since `type: ['string', 'null']` is still a string
+	 * property; a union of nothing but `null` is not.
+	 *
+	 * @param mixed $declaredType The schema's declared type: a string, or a union as an array.
+	 *
+	 * @return bool True when a value of this type would have been JSON-decoded on read.
+	 *
+	 * @spec openspec/specs/schema-driven-read-coercion/spec.md
+	 */
+	private function isStringTyped(mixed $declaredType): bool {
+		$types = $declaredType;
+		if (is_array($types) === false) {
+			$types = [$types];
+		}
+
+		$named = [];
+		foreach ($types as $type) {
+			if (is_string($type) === false || strtolower($type) === 'null') {
+				continue;
+			}
+
+			$named[] = strtolower($type);
+		}
+
+		if ($named === []) {
+			return false;
+		}
+
+		foreach ($named as $type) {
+			if (in_array($type, ['array', 'object', 'number', 'integer', 'boolean'], true) === true) {
+				return false;
+			}
+		}
+
+		return true;
+	}//end isStringTyped()
+
+	/**
 	 * Convert a value to the `boolean` schema type.
 	 *
 	 * Native bools pass through. Strings `'true'`, `'1'`, `'yes'` are truthy

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -5595,9 +5595,10 @@ class ObjectService implements ObjectServiceInterface
      * permissions, so the defect would come back for exactly the callers least
      * able to diagnose it.
      *
-     * If the schema cannot be resolved the data is returned unchanged, which
-     * leaves the pre-existing loud validation refusal in place. That is the
-     * intended failure direction: never swallow, never silently rewrite.
+     * If the schema or the converter cannot be resolved the data is returned
+     * unchanged, which leaves the pre-existing loud validation refusal in
+     * place. That is the intended failure direction: never swallow, never
+     * silently rewrite.
      *
      * @param array        $data         The merged object data about to be saved.
      * @param ObjectEntity $existing     The object as it was read.
@@ -5620,20 +5621,20 @@ class ObjectService implements ObjectServiceInterface
                 _rbac: false,
                 _multitenancy: false
             );
-        } catch (\Throwable $schemaError) {
+
+            $converter = $this->container->get(SchemaTypeConverter::class);
+        } catch (\Throwable $restoreError) {
             $this->logger->warning(
-                message: '[ObjectService] Could not resolve schema to restore string-typed values',
+                message: '[ObjectService] Could not restore string-typed values before the save',
                 context: [
                     'file' => __FILE__,
                     'line' => __LINE__,
                     'schema' => $schemaId,
-                    'exception' => $schemaError->getMessage(),
+                    'exception' => $restoreError->getMessage(),
                 ]
             );
             return $data;
         }
-
-        $converter = $this->container->get(SchemaTypeConverter::class);
 
         return $converter->restoreStringTypedValues(
             data: $data,

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -67,6 +67,7 @@ use OCA\OpenRegister\Service\Object\SaveObject;
 use OCA\OpenRegister\Service\ObjectServiceMapperAdapter;
 use OCA\OpenRegister\Service\RegisterScopedSchemaResolver;
 use OCA\OpenRegister\Service\Object\SaveObjects;
+use OCA\OpenRegister\Service\Object\SchemaTypeConverter;
 use OCA\OpenRegister\Service\Object\SearchQueryHandler;
 use OCA\OpenRegister\Service\Object\ValidateObject;
 use OCA\OpenRegister\Service\Object\LockHandler;
@@ -5509,6 +5510,18 @@ class ObjectService implements ObjectServiceInterface
                 patch: $data
             );
 
+            // The read decoded, so the write has to re-encode. A `type: string`
+            // property whose stored value looks like JSON comes back from
+            // getObject() as an ARRAY (SchemaTypeConverter::convertString), and
+            // feeding that array back in makes validation refuse a patch that
+            // never mentioned the property. Only keys the caller did NOT supply
+            // are restored — see restoreStringTypedValues() for why.
+            $merged = $this->restoreStringTypedValues(
+                data: $merged,
+                existing: $existing,
+                suppliedKeys: array_keys($data)
+            );
+
             // Address the save at the object we actually resolved, not at whatever
             // form of the identifier the caller happened to hold.
             $merged['id'] = ($existing->getUuid() ?? $objectId);
@@ -5567,6 +5580,67 @@ class ObjectService implements ObjectServiceInterface
 
         return $stored;
     }//end mergePatchData()
+
+    /**
+     * Restore the stored form of string-typed properties the read path decoded.
+     *
+     * Thin resolver around `SchemaTypeConverter::restoreStringTypedValues()`,
+     * which owns the rule. All this does is find the schema whose property
+     * declarations say which keys are string-typed.
+     *
+     * The schema lookup runs with RBAC and multitenancy off: it reads type
+     * declarations to persist an object correctly, not data on the caller's
+     * behalf, and `saveObject()` still applies every check to the write itself.
+     * Leaving them on would make the repair depend on the caller's schema
+     * permissions, so the defect would come back for exactly the callers least
+     * able to diagnose it.
+     *
+     * If the schema cannot be resolved the data is returned unchanged, which
+     * leaves the pre-existing loud validation refusal in place. That is the
+     * intended failure direction: never swallow, never silently rewrite.
+     *
+     * @param array        $data         The merged object data about to be saved.
+     * @param ObjectEntity $existing     The object as it was read.
+     * @param array        $suppliedKeys Keys the caller actually sent.
+     *
+     * @return array The data with untouched string-typed JSON values restored.
+     *
+     * @spec openspec/specs/schema-driven-read-coercion/spec.md
+     */
+    private function restoreStringTypedValues(array $data, ObjectEntity $existing, array $suppliedKeys): array
+    {
+        $schemaId = $existing->getSchema();
+        if ($schemaId === null) {
+            return $data;
+        }
+
+        try {
+            $schema = $this->schemaMapper->find(
+                $schemaId,
+                _rbac: false,
+                _multitenancy: false
+            );
+        } catch (\Throwable $schemaError) {
+            $this->logger->warning(
+                message: '[ObjectService] Could not resolve schema to restore string-typed values',
+                context: [
+                    'file' => __FILE__,
+                    'line' => __LINE__,
+                    'schema' => $schemaId,
+                    'exception' => $schemaError->getMessage(),
+                ]
+            );
+            return $data;
+        }
+
+        $converter = $this->container->get(SchemaTypeConverter::class);
+
+        return $converter->restoreStringTypedValues(
+            data: $data,
+            properties: ($schema->getProperties() ?? []),
+            suppliedKeys: $suppliedKeys
+        );
+    }//end restoreStringTypedValues()
 
     /**
      * Build search query from request parameters

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -5636,6 +5636,13 @@ class ObjectService implements ObjectServiceInterface
             return $data;
         }
 
+        // A container may answer with something other than a converter, or with
+        // nothing at all. Returning the data unchanged keeps the pre-existing
+        // refusal; calling a method on null would turn a patch into a fatal.
+        if (($converter instanceof SchemaTypeConverter) === false) {
+            return $data;
+        }
+
         return $converter->restoreStringTypedValues(
             data: $data,
             properties: ($schema->getProperties() ?? []),

--- a/openspec/specs/schema-driven-read-coercion/spec.md
+++ b/openspec/specs/schema-driven-read-coercion/spec.md
@@ -68,6 +68,34 @@ When the schema declares a property as `type: string`, the converter SHALL retur
 - **WHEN** the schema property is `{ "type": "string" }` and the row contains the string `'[1,2,3]'`
 - **THEN** the returned property value is the array `[1, 2, 3]` (preserves historical behavior for schemas with mismatched type declarations)
 
+### Requirement: A decoded `string` property is restored before a write
+
+The decode above is only safe if it has an inverse. A read hands back an array for a `type: string` property, so any read-merge-save cycle feeds that array into validation, which refuses it. The converter SHALL therefore expose `restoreStringTypedValues()`, and every merging write path (`ObjectService::patchObject()`, `ObjectsController::patch()`, `ObjectsController::postPatch()`) SHALL call it after its merge and before its save.
+
+@e2e exclude backend write-path symmetry, covered by PHPUnit and by a live probe against both patch doors.
+
+The restore SHALL apply only to keys the caller did NOT supply, and only to declared types the converter routes through its string path. It MUST encode with `JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE`, so the stored bytes match what `JSON.stringify()` wrote. It MUST NOT descend below the top level, because the read decodes one column per declared property and nothing deeper. Where it cannot answer confidently it MUST return the data unchanged, leaving the validation refusal in place rather than guessing.
+
+#### Scenario: A patch that never mentions the property leaves it as stored
+
+- **WHEN** a `{ "type": "string" }` property holds `'[{"status":"open"}]'` and a caller patches only `title`
+- **THEN** the save receives that property as the string `'[{"status":"open"}]'`, byte-identical to what was stored
+
+#### Scenario: An array the caller supplied is refused, not rewritten
+
+- **WHEN** a caller patches a `{ "type": "string" }` property with an array value
+- **THEN** the array reaches validation unchanged and the write is refused with a type error
+
+#### Scenario: A property the schema really calls an array is untouched
+
+- **WHEN** a `{ "type": "array" }` property holds `["a", "b"]` and a caller patches only `title`
+- **THEN** the save receives that property as the array `["a", "b"]`
+
+#### Scenario: A union that admits arrays is untouched
+
+- **WHEN** a property declares `{ "type": ["string", "array"] }` and holds an array
+- **THEN** the value is left as an array, because the array form is valid there
+
 ### Requirement: `boolean` properties always return PHP `bool`
 
 When the schema declares a property as `type: boolean`, the converter SHALL return a PHP `bool` for any non-null value. The conversion SHALL accept:

--- a/tests/Unit/Controller/ObjectsControllerPatchStringTypedJsonTest.php
+++ b/tests/Unit/Controller/ObjectsControllerPatchStringTypedJsonTest.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * ObjectsController PATCH: a `type: string` property whose stored value is JSON.
+ *
+ * The magic-table read decodes such a value (SchemaTypeConverter::convertString),
+ * so `$existingObject->getObject()` hands back an ARRAY where the schema declares
+ * a string. Both patch doors on this controller merge that array into the payload
+ * and save it, so validation refuses the write because of a property the caller
+ * never mentioned — the opposite of the "only the provided fields are updated"
+ * promise in patch()'s own docblock.
+ *
+ * These tests pin the re-encode that closes the seam, and its deliberate limit:
+ * a value the CALLER supplied is never rewritten, so a caller that passes an
+ * array for a string property keeps the loud refusal it gets today.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+namespace Unit\Controller;
+
+use OCA\OpenRegister\Controller\ObjectsController;
+use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\ExportService;
+use OCA\OpenRegister\Service\ImportService;
+use OCA\OpenRegister\Service\Object\SchemaTypeConverter;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\WebhookService;
+use OCP\App\IAppManager;
+use OCP\IAppConfig;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit tests for the string-typed JSON restore on both PATCH doors.
+ */
+class ObjectsControllerPatchStringTypedJsonTest extends TestCase {
+	/**
+	 * The stored form: what a consuming app wrote with JSON.stringify(), and
+	 * what the untouched property must still be after the patch.
+	 */
+	private const STORED = '[{"status":"open","at":"2026-09-11"},{"status":"closed","at":"2026-09-12"}]';
+
+	private ObjectsController $controller;
+	private IRequest&MockObject $request;
+	private ContainerInterface&MockObject $container;
+	private ObjectService&MockObject $objectService;
+	private IUserSession&MockObject $userSession;
+	private IGroupManager&MockObject $groupManager;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->container = $this->createMock(ContainerInterface::class);
+		$this->objectService = $this->createMock(ObjectService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+
+		// The container answers with the REAL converter: the encode half of the
+		// rule is the thing under test, so mocking it would test nothing. The
+		// controller also asks the container for 'userId' after a save.
+		$this->container->method('get')->willReturnCallback(
+			static function (string $id): mixed {
+				if ($id === SchemaTypeConverter::class) {
+					return new SchemaTypeConverter();
+				}
+
+				return 'admin';
+			}
+		);
+
+		$this->controller = new ObjectsController(
+			'openregister',
+			$this->request,
+			$this->createMock(IAppConfig::class),
+			$this->createMock(IAppManager::class),
+			$this->container,
+			$this->createMock(RegisterMapper::class),
+			$this->createMock(SchemaMapper::class),
+			$this->createMock(AuditTrailMapper::class),
+			$this->objectService,
+			$this->userSession,
+			$this->groupManager,
+			$this->createMock(ExportService::class),
+			$this->createMock(ImportService::class),
+			$this->createMock(WebhookService::class),
+			$this->createMock(LoggerInterface::class)
+		);
+	}//end setUp()
+
+	/**
+	 * Stub the world around one patch and capture what reaches saveObject().
+	 *
+	 * @param array<string, mixed> $storedObject The object as the read hands it back.
+	 * @param array<string, mixed> $properties   The schema's property declarations.
+	 * @param array<string, mixed> $patchData    The caller's payload.
+	 * @param array<string, mixed> $captured     Filled with the data saveObject() was handed.
+	 *
+	 * @return void
+	 */
+	private function stubPatch(array $storedObject, array $properties, array $patchData, ?array &$captured): void {
+		$user = $this->createMock(IUser::class);
+		$this->userSession->method('getUser')->willReturn($user);
+		$this->groupManager->method('getUserGroupIds')->willReturn(['admin']);
+
+		$schema = new Schema();
+		$schema->setId(2);
+		$schema->setProperties($properties);
+
+		$existingObject = new ObjectEntity();
+		$existingObject->setUuid('uuid-123');
+		$existingObject->setObject($storedObject);
+
+		$this->objectService->method('setRegister')->willReturnSelf();
+		$this->objectService->method('setSchema')->willReturnSelf();
+		$this->objectService->method('getRegister')->willReturn(1);
+		$this->objectService->method('getSchema')->willReturn(2);
+		$this->objectService->method('getCurrentSchemaEntity')->willReturn($schema);
+		$this->objectService->method('findSilent')->willReturn($existingObject);
+		$this->objectService->method('unlockObject')->willReturn(true);
+
+		$this->request->method('getParams')->willReturn($patchData);
+		$this->request->method('getHeader')->willReturn('application/json');
+		$this->request->method('getParam')->willReturnCallback(
+			static fn (string $key, $default = null) => $default
+		);
+
+		$saved = new ObjectEntity();
+		$saved->setUuid('uuid-123');
+		$saved->setObject($patchData);
+
+		$this->objectService->method('saveObject')->willReturnCallback(
+			// `object` is saveObject()'s first parameter; the controller calls
+			// it with named arguments, which PHP binds onto the mock's own
+			// signature, so position 0 is still the payload.
+			static function (mixed ...$arguments) use (&$captured, $saved): ObjectEntity {
+				$captured = $arguments[0];
+
+				return $saved;
+			}
+		);
+	}//end stubPatch()
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	private function stringSchemaProperties(): array {
+		return [
+			'title' => ['type' => 'string'],
+			'statusHistory' => ['type' => 'string'],
+		];
+	}//end stringSchemaProperties()
+
+	public function testPatchRestoresAStringTypedJsonPropertyTheCallerNeverMentioned(): void {
+		$captured = null;
+		$this->stubPatch(
+			// json_decode() is what the read path did to the stored string.
+			['title' => 'Old', 'statusHistory' => json_decode(self::STORED, true)],
+			$this->stringSchemaProperties(),
+			['title' => 'probe'],
+			$captured
+		);
+
+		$result = $this->controller->patch('1', '2', 'uuid-123', $this->objectService);
+
+		$this->assertSame(200, $result->getStatus());
+		$this->assertNotNull($captured, 'the merged payload reached saveObject()');
+		$this->assertSame('probe', $captured['title']);
+		$this->assertSame(
+			self::STORED,
+			$captured['statusHistory'],
+			'without the restore this arrives as an array and validation refuses a patch that never named it'
+		);
+	}//end testPatchRestoresAStringTypedJsonPropertyTheCallerNeverMentioned()
+
+	public function testPostPatchRestoresAStringTypedJsonPropertyTheCallerNeverMentioned(): void {
+		$captured = null;
+		$this->stubPatch(
+			['title' => 'Old', 'statusHistory' => json_decode(self::STORED, true)],
+			$this->stringSchemaProperties(),
+			['title' => 'probe'],
+			$captured
+		);
+
+		$result = $this->controller->postPatch('1', '2', 'uuid-123', $this->objectService);
+
+		$this->assertSame(200, $result->getStatus());
+		$this->assertNotNull($captured, 'the multipart patch door reached saveObject() too');
+		$this->assertSame(
+			self::STORED,
+			$captured['statusHistory'],
+			'the second patch door carried the identical defect and must carry the identical fix'
+		);
+	}//end testPostPatchRestoresAStringTypedJsonPropertyTheCallerNeverMentioned()
+
+	public function testPatchLeavesAnArrayTheCallerSuppliedAloneSoValidationStillRefusesIt(): void {
+		$captured = null;
+		$this->stubPatch(
+			['title' => 'Old', 'statusHistory' => json_decode(self::STORED, true)],
+			$this->stringSchemaProperties(),
+			['statusHistory' => [['status' => 'open']]],
+			$captured
+		);
+
+		$this->controller->patch('1', '2', 'uuid-123', $this->objectService);
+
+		$this->assertNotNull($captured);
+		$this->assertSame(
+			[['status' => 'open']],
+			$captured['statusHistory'],
+			'a caller that passes an array deliberately keeps its visible refusal rather than a silent rewrite'
+		);
+	}//end testPatchLeavesAnArrayTheCallerSuppliedAloneSoValidationStillRefusesIt()
+
+	public function testPatchDoesNotEncodeAPropertyTheSchemaReallyCallsAnArray(): void {
+		$captured = null;
+		$this->stubPatch(
+			['title' => 'Old', 'tags' => ['a', 'b']],
+			['title' => ['type' => 'string'], 'tags' => ['type' => 'array']],
+			['title' => 'probe'],
+			$captured
+		);
+
+		$this->controller->patch('1', '2', 'uuid-123', $this->objectService);
+
+		$this->assertNotNull($captured);
+		$this->assertSame(['a', 'b'], $captured['tags']);
+	}//end testPatchDoesNotEncodeAPropertyTheSchemaReallyCallsAnArray()
+}//end class

--- a/tests/Unit/Controller/ObjectsControllerPatchStringTypedJsonTest.php
+++ b/tests/Unit/Controller/ObjectsControllerPatchStringTypedJsonTest.php
@@ -232,6 +232,48 @@ class ObjectsControllerPatchStringTypedJsonTest extends TestCase {
 		);
 	}//end testPatchLeavesAnArrayTheCallerSuppliedAloneSoValidationStillRefusesIt()
 
+	public function testAContainerThatAnswersWithNoConverterLeavesThePatchAloneRatherThanFatal(): void {
+		// A container can answer with null. Calling a method on that would turn
+		// a patch into a fatal error, which is a worse failure than the
+		// validation refusal this whole change exists to remove.
+		$emptyContainer = $this->createMock(ContainerInterface::class);
+		$emptyContainer->method('get')->willReturn(null);
+
+		$this->controller = new ObjectsController(
+			'openregister',
+			$this->request,
+			$this->createMock(IAppConfig::class),
+			$this->createMock(IAppManager::class),
+			$emptyContainer,
+			$this->createMock(RegisterMapper::class),
+			$this->createMock(SchemaMapper::class),
+			$this->createMock(AuditTrailMapper::class),
+			$this->objectService,
+			$this->userSession,
+			$this->groupManager,
+			$this->createMock(ExportService::class),
+			$this->createMock(ImportService::class),
+			$this->createMock(WebhookService::class),
+			$this->createMock(LoggerInterface::class)
+		);
+
+		$captured = null;
+		$this->stubPatch(
+			['title' => 'Old', 'statusHistory' => json_decode(self::STORED, true)],
+			$this->stringSchemaProperties(),
+			['title' => 'probe'],
+			$captured
+		);
+
+		$result = $this->controller->patch('1', '2', 'uuid-123', $this->objectService);
+
+		$this->assertSame(200, $result->getStatus(), 'the patch ran rather than fatalling');
+		$this->assertIsArray(
+			$captured['statusHistory'],
+			'nothing was restored, so the caller keeps the behaviour it had before this change'
+		);
+	}//end testAContainerThatAnswersWithNoConverterLeavesThePatchAloneRatherThanFatal()
+
 	public function testPatchDoesNotEncodeAPropertyTheSchemaReallyCallsAnArray(): void {
 		$captured = null;
 		$this->stubPatch(

--- a/tests/Unit/Service/Object/SchemaTypeConverterTest.php
+++ b/tests/Unit/Service/Object/SchemaTypeConverterTest.php
@@ -251,4 +251,137 @@ class SchemaTypeConverterTest extends TestCase {
 		$rrule = 'FREQ=WEEKLY;BYDAY=MO;COUNT=10';
 		$this->assertSame($rrule, $this->converter->convertValue($rrule, 'recurrence'));
 	}//end testRecurrenceTypeReturnsRruleUnchanged()
+
+	/*
+		====================================================================
+	 * restoreStringTypedValues — the inverse of the decode above
+	 *
+	 * The decode has to have an encode or a read-merge-save cycle feeds an
+	 * array back into a property the schema calls a string, and validation
+	 * refuses a write that never mentioned it.
+	 * ==================================================================== */
+
+	public function testADecodedStringPropertyIsReEncodedWhenTheCallerDidNotTouchIt(): void {
+		$stored = json_encode([['status' => 'open'], ['status' => 'closed']]);
+		$decoded = $this->converter->convertValue($stored, 'string');
+		$this->assertIsArray($decoded, 'precondition: the read path decodes this');
+
+		$restored = $this->converter->restoreStringTypedValues(
+			['title' => 'probe', 'notes' => $decoded],
+			['title' => ['type' => 'string'], 'notes' => ['type' => 'string']],
+			['title']
+		);
+
+		$this->assertSame($stored, $restored['notes'], 'the untouched value goes back as it was stored');
+		$this->assertSame('probe', $restored['title']);
+	}//end testADecodedStringPropertyIsReEncodedWhenTheCallerDidNotTouchIt()
+
+	public function testAnArrayTheCallerSuppliedIsLeftAloneSoValidationStillRefusesIt(): void {
+		$restored = $this->converter->restoreStringTypedValues(
+			['notes' => [['status' => 'open']]],
+			['notes' => ['type' => 'string']],
+			['notes']
+		);
+
+		$this->assertIsArray(
+			$restored['notes'],
+			'a value the caller passed deliberately must keep its loud refusal, not be silently rewritten'
+		);
+	}//end testAnArrayTheCallerSuppliedIsLeftAloneSoValidationStillRefusesIt()
+
+	public function testAnArrayTypedPropertyIsNeverEncoded(): void {
+		$restored = $this->converter->restoreStringTypedValues(
+			['tags' => ['a', 'b']],
+			['tags' => ['type' => 'array']],
+			[]
+		);
+
+		$this->assertSame(['a', 'b'], $restored['tags']);
+	}//end testAnArrayTypedPropertyIsNeverEncoded()
+
+	public function testAUnionOfStringAndNullIsStillStringTyped(): void {
+		$restored = $this->converter->restoreStringTypedValues(
+			['notes' => ['a' => 1]],
+			['notes' => ['type' => ['string', 'null']]],
+			[]
+		);
+
+		$this->assertSame('{"a":1}', $restored['notes']);
+	}//end testAUnionOfStringAndNullIsStillStringTyped()
+
+	public function testAUnionThatAdmitsArrayIsLeftAlone(): void {
+		$restored = $this->converter->restoreStringTypedValues(
+			['notes' => ['a' => 1]],
+			['notes' => ['type' => ['string', 'array']]],
+			[]
+		);
+
+		$this->assertSame(['a' => 1], $restored['notes'], 'the array form is valid there, so there is nothing to restore');
+	}//end testAUnionThatAdmitsArrayIsLeftAlone()
+
+	public function testAScalarIsUntouchedWhateverItsDeclaredType(): void {
+		$restored = $this->converter->restoreStringTypedValues(
+			['notes' => 'plain text', 'count' => 3, 'flag' => true, 'empty' => null],
+			[
+				'notes' => ['type' => 'string'],
+				'count' => ['type' => 'integer'],
+				'flag' => ['type' => 'boolean'],
+				'empty' => ['type' => 'string'],
+			],
+			[]
+		);
+
+		$this->assertSame(
+			['notes' => 'plain text', 'count' => 3, 'flag' => true, 'empty' => null],
+			$restored
+		);
+	}//end testAScalarIsUntouchedWhateverItsDeclaredType()
+
+	public function testAPropertyTheSchemaDoesNotDeclareIsLeftAlone(): void {
+		$restored = $this->converter->restoreStringTypedValues(
+			['stray' => ['a' => 1]],
+			['notes' => ['type' => 'string']],
+			[]
+		);
+
+		$this->assertSame(['a' => 1], $restored['stray'], 'no declaration, no claim about the stored shape');
+	}//end testAPropertyTheSchemaDoesNotDeclareIsLeftAlone()
+
+	public function testNestingBelowTheTopLevelIsNotTouched(): void {
+		// The read applies convertValue() once per column, so only the top
+		// level was ever decoded. A `type: string` nested inside an object
+		// property was stored as written and must stay that way.
+		$restored = $this->converter->restoreStringTypedValues(
+			['contact' => ['name' => 'A', 'history' => ['x']]],
+			['contact' => ['type' => 'object']],
+			[]
+		);
+
+		$this->assertSame(['name' => 'A', 'history' => ['x']], $restored['contact']);
+	}//end testNestingBelowTheTopLevelIsNotTouched()
+
+	public function testTheEncodingMatchesWhatJavaScriptWroteIn(): void {
+		// Consuming apps store `JSON.stringify(...)`, which escapes neither
+		// slashes nor non-ASCII. Re-encoding with PHP's defaults would hand
+		// back a different string for the same value.
+		$restored = $this->converter->restoreStringTypedValues(
+			['notes' => ['url' => 'https://example.org/a/b', 'who' => 'Renée']],
+			['notes' => ['type' => 'string']],
+			[]
+		);
+
+		$this->assertSame('{"url":"https://example.org/a/b","who":"Renée"}', $restored['notes']);
+	}//end testTheEncodingMatchesWhatJavaScriptWroteIn()
+
+	public function testARoundTripThroughBothHalvesReturnsTheStoredString(): void {
+		$stored = '[{"status":"open","at":"2026-09-11"},{"status":"closed","at":"2026-09-12"}]';
+
+		$restored = $this->converter->restoreStringTypedValues(
+			['notes' => $this->converter->convertValue($stored, 'string')],
+			['notes' => ['type' => 'string']],
+			[]
+		);
+
+		$this->assertSame($stored, $restored['notes'], 'decode then encode is the identity for what a read handed back');
+	}//end testARoundTripThroughBothHalvesReturnsTheStoredString()
 }//end class

--- a/tests/Unit/Service/ObjectServicePatchObjectTest.php
+++ b/tests/Unit/Service/ObjectServicePatchObjectTest.php
@@ -90,6 +90,9 @@ class ObjectServicePatchObjectTest extends TestCase {
 	/** @var MockObject&IAppContainer */
 	private $container;
 
+	/** What the container hands back for SchemaTypeConverter::class. */
+	private mixed $converterAnswer = null;
+
 	private Register $register;
 
 	private Schema $schema;
@@ -104,11 +107,13 @@ class ObjectServicePatchObjectTest extends TestCase {
 		$this->container = $this->createMock(IAppContainer::class);
 
 		// The container answers with the REAL converter: the encode half of the
-		// rule is the thing under test, so mocking it would test nothing.
+		// rule is the thing under test, so mocking it would test nothing. A
+		// test that needs a container with no converter overwrites the answer.
+		$this->converterAnswer = new SchemaTypeConverter();
 		$this->container->method('get')->willReturnCallback(
-			static function (string $id): mixed {
+			function (string $id): mixed {
 				if ($id === SchemaTypeConverter::class) {
-					return new SchemaTypeConverter();
+					return $this->converterAnswer;
 				}
 
 				throw new \RuntimeException('unexpected container lookup: ' . $id);
@@ -358,19 +363,31 @@ class ObjectServicePatchObjectTest extends TestCase {
 	 *
 	 * @param array<string, mixed> $storedObject The object as a read hands it back.
 	 * @param array<string, mixed> $properties   The schema's property declarations.
-	 * @param array<string, mixed> $patch        The caller's partial payload.
+	 * @param array<string, mixed> $patch             The caller's partial payload.
+	 * @param bool                 $schemaLookupFails Make the schema lookup throw.
+	 * @param string|null          $schemaId          The schema the stored object names.
 	 *
 	 * @return array<string, mixed>|null The payload as the save pipeline saw it.
 	 */
-	private function payloadReachingTheSave(array $storedObject, array $properties, array $patch): ?array {
-		$schema = new Schema();
-		$schema->setId(2);
-		$schema->setProperties($properties);
-		$this->schemaMapper->method('find')->willReturn($schema);
+	private function payloadReachingTheSave(
+		array $storedObject,
+		array $properties,
+		array $patch,
+		bool $schemaLookupFails = false,
+		?string $schemaId = '2'
+	): ?array {
+		if ($schemaLookupFails === true) {
+			$this->schemaMapper->method('find')->willThrowException(new \RuntimeException('schema gone'));
+		} else {
+			$schema = new Schema();
+			$schema->setId(2);
+			$schema->setProperties($properties);
+			$this->schemaMapper->method('find')->willReturn($schema);
+		}
 
 		$existing = new ObjectEntity();
 		$existing->setUuid('u-1');
-		$existing->setSchema('2');
+		$existing->setSchema($schemaId);
 		$existing->setObject($storedObject);
 
 		$this->objectMapper->method('find')->willReturn($existing);
@@ -430,6 +447,52 @@ class ObjectServicePatchObjectTest extends TestCase {
 		);
 
 	}//end testAnArrayTheCallerSuppliedReachesValidationUnchanged()
+
+	public function testASchemaThatWillNotResolveLeavesTheMergedDataAlone(): void {
+		$seen = $this->payloadReachingTheSave(
+			['title' => 'Alpha', 'statusHistory' => [['status' => 'open']]],
+			['title' => ['type' => 'string'], 'statusHistory' => ['type' => 'string']],
+			['title' => 'probe'],
+			schemaLookupFails: true
+		);
+
+		$this->assertNotNull($seen);
+		$this->assertSame(
+			[['status' => 'open']],
+			$seen['statusHistory'],
+			'no schema, no claim: the caller keeps the behaviour it had before this change'
+		);
+
+	}//end testASchemaThatWillNotResolveLeavesTheMergedDataAlone()
+
+	public function testAnObjectWithNoSchemaLeavesTheMergedDataAlone(): void {
+		$seen = $this->payloadReachingTheSave(
+			['title' => 'Alpha', 'statusHistory' => [['status' => 'open']]],
+			['title' => ['type' => 'string'], 'statusHistory' => ['type' => 'string']],
+			['title' => 'probe'],
+			schemaId: null
+		);
+
+		$this->assertNotNull($seen);
+		$this->assertSame([['status' => 'open']], $seen['statusHistory']);
+
+	}//end testAnObjectWithNoSchemaLeavesTheMergedDataAlone()
+
+	public function testAContainerThatAnswersWithNoConverterDoesNotFatal(): void {
+		// Calling a method on null would turn a patch into a fatal error, which
+		// is a worse failure than the refusal this change exists to remove.
+		$this->converterAnswer = null;
+
+		$seen = $this->payloadReachingTheSave(
+			['title' => 'Alpha', 'statusHistory' => [['status' => 'open']]],
+			['title' => ['type' => 'string'], 'statusHistory' => ['type' => 'string']],
+			['title' => 'probe']
+		);
+
+		$this->assertNotNull($seen, 'the patch ran rather than fatalling');
+		$this->assertSame([['status' => 'open']], $seen['statusHistory']);
+
+	}//end testAContainerThatAnswersWithNoConverterDoesNotFatal()
 
 	public function testAnArrayTypedPropertyIsNotEncodedByTheRestore(): void {
 		$seen = $this->payloadReachingTheSave(

--- a/tests/Unit/Service/ObjectServicePatchObjectTest.php
+++ b/tests/Unit/Service/ObjectServicePatchObjectTest.php
@@ -45,6 +45,7 @@ use OCA\OpenRegister\Service\Object\RenderObject;
 use OCA\OpenRegister\Service\Object\RevertHandler;
 use OCA\OpenRegister\Service\Object\SaveObject;
 use OCA\OpenRegister\Service\Object\SaveObjects;
+use OCA\OpenRegister\Service\Object\SchemaTypeConverter;
 use OCA\OpenRegister\Service\Object\SearchQueryHandler;
 use OCA\OpenRegister\Service\Object\UtilityHandler;
 use OCA\OpenRegister\Service\Object\ValidateObject;
@@ -83,6 +84,12 @@ class ObjectServicePatchObjectTest extends TestCase {
 	/** @var MockObject&PermissionHandler */
 	private $permissionHandler;
 
+	/** @var MockObject&SchemaMapper */
+	private $schemaMapper;
+
+	/** @var MockObject&IAppContainer */
+	private $container;
+
 	private Register $register;
 
 	private Schema $schema;
@@ -93,6 +100,20 @@ class ObjectServicePatchObjectTest extends TestCase {
 		$this->objectMapper = $this->createMock(MagicMapper::class);
 		$this->cascadingHandler = $this->createMock(CascadingHandler::class);
 		$this->permissionHandler = $this->createMock(PermissionHandler::class);
+		$this->schemaMapper = $this->createMock(SchemaMapper::class);
+		$this->container = $this->createMock(IAppContainer::class);
+
+		// The container answers with the REAL converter: the encode half of the
+		// rule is the thing under test, so mocking it would test nothing.
+		$this->container->method('get')->willReturnCallback(
+			static function (string $id): mixed {
+				if ($id === SchemaTypeConverter::class) {
+					return new SchemaTypeConverter();
+				}
+
+				throw new \RuntimeException('unexpected container lookup: ' . $id);
+			}
+		);
 
 		$this->register = new Register();
 		$this->register->setId(1);
@@ -124,7 +145,7 @@ class ObjectServicePatchObjectTest extends TestCase {
 			$this->cascadingHandler,
 			$this->createMock(MigrationHandler::class),
 			$this->createMock(RegisterMapper::class),
-			$this->createMock(SchemaMapper::class),
+			$this->schemaMapper,
 			$this->createMock(ViewMapper::class),
 			$this->objectMapper,
 			$this->createMock(FileService::class),
@@ -137,7 +158,7 @@ class ObjectServicePatchObjectTest extends TestCase {
 			$this->createMock(CacheHandler::class),
 			$this->createMock(SettingsService::class),
 			$this->createMock(DateTimeNormalizer::class),
-			$this->createMock(IAppContainer::class),
+			$this->container,
 			$this->createMock(ObjectSourceRegistry::class)
 		);
 
@@ -322,6 +343,105 @@ class ObjectServicePatchObjectTest extends TestCase {
 		$this->assertSame('u-1', $seen['id'], 'the save is addressed at the object that was resolved');
 
 	}//end testTheMergedResultIsWhatTravelsOnToTheSave()
+
+	// ── The decode/encode seam ──────────────────────────────────────────
+	//
+	// The read path decodes: SchemaTypeConverter::convertString() turns a
+	// `type: string` value that looks like JSON into an ARRAY. So
+	// $existing->getObject() hands back an array where the schema says string,
+	// the merge puts it straight back, and validation refuses the save —
+	// failing a patch because of a property the caller never mentioned. These
+	// pin the re-encode that closes the seam, and the limit on it.
+
+	/**
+	 * Run a patch far enough to observe the payload that reaches the save.
+	 *
+	 * @param array<string, mixed> $storedObject The object as a read hands it back.
+	 * @param array<string, mixed> $properties   The schema's property declarations.
+	 * @param array<string, mixed> $patch        The caller's partial payload.
+	 *
+	 * @return array<string, mixed>|null The payload as the save pipeline saw it.
+	 */
+	private function payloadReachingTheSave(array $storedObject, array $properties, array $patch): ?array {
+		$schema = new Schema();
+		$schema->setId(2);
+		$schema->setProperties($properties);
+		$this->schemaMapper->method('find')->willReturn($schema);
+
+		$existing = new ObjectEntity();
+		$existing->setUuid('u-1');
+		$existing->setSchema('2');
+		$existing->setObject($storedObject);
+
+		$this->objectMapper->method('find')->willReturn($existing);
+		$this->setProperty('currentRegister', $this->register);
+		$this->setProperty('currentSchema', $this->schema);
+
+		$seen = null;
+		$this->cascadingHandler->method('handlePreValidationCascading')->willReturnCallback(
+			static function (array $object, ?Schema $schema = null, ?string $uuid = null) use (&$seen): array {
+				$seen = $object;
+
+				return [$object, $uuid];
+			}
+		);
+
+		try {
+			$this->service->patchObject(objectId: 'u-1', data: $patch);
+		} catch (Throwable $e) {
+			// Expected — the rest of the save pipeline is mocked out.
+		}
+
+		return $seen;
+	}//end payloadReachingTheSave()
+
+	public function testAStringTypedPropertyHoldingJsonSurvivesAPatchThatNeverMentionsIt(): void {
+		$stored = '[{"status":"open","at":"2026-09-11"},{"status":"closed","at":"2026-09-12"}]';
+
+		$seen = $this->payloadReachingTheSave(
+			// What a read actually hands back: the JSON-looking string decoded.
+			['title' => 'Alpha', 'statusHistory' => json_decode($stored, true)],
+			['title' => ['type' => 'string'], 'statusHistory' => ['type' => 'string']],
+			['title' => 'probe']
+		);
+
+		$this->assertNotNull($seen, 'the merged payload reached the save pipeline');
+		$this->assertSame('probe', $seen['title']);
+		$this->assertSame(
+			$stored,
+			$seen['statusHistory'],
+			'without the re-encode this arrives as an array and validation refuses a patch that never named it'
+		);
+
+	}//end testAStringTypedPropertyHoldingJsonSurvivesAPatchThatNeverMentionsIt()
+
+	public function testAnArrayTheCallerSuppliedReachesValidationUnchanged(): void {
+		$seen = $this->payloadReachingTheSave(
+			['title' => 'Alpha', 'statusHistory' => [['status' => 'open']]],
+			['title' => ['type' => 'string'], 'statusHistory' => ['type' => 'string']],
+			['statusHistory' => [['status' => 'closed']]]
+		);
+
+		$this->assertNotNull($seen);
+		$this->assertSame(
+			[['status' => 'closed']],
+			$seen['statusHistory'],
+			'a caller that passes an array for a string property keeps its loud refusal rather than a silent rewrite'
+		);
+
+	}//end testAnArrayTheCallerSuppliedReachesValidationUnchanged()
+
+	public function testAnArrayTypedPropertyIsNotEncodedByTheRestore(): void {
+		$seen = $this->payloadReachingTheSave(
+			['title' => 'Alpha', 'tags' => ['a', 'b']],
+			['title' => ['type' => 'string'], 'tags' => ['type' => 'array']],
+			['title' => 'probe']
+		);
+
+		$this->assertNotNull($seen);
+		$this->assertSame(['a', 'b'], $seen['tags'], 'the restore must not reach properties the schema really does call arrays');
+
+	}//end testAnArrayTypedPropertyIsNotEncodedByTheRestore()
 
 	// ── Attribution and enforcement (REQ-OWN-013) ───────────────────────
 


### PR DESCRIPTION
## What broke

`patchObject()` documents one promise above all others: a key absent from the payload leaves the stored value untouched. That promise did not hold for a property the schema declares `type: string` whose stored value is JSON.

The read path decodes on purpose. `SchemaTypeConverter::convertString()` decodes any `type: string` value that starts with `[` or `{`, a compatibility window for schemas that historically stored array data in a string column. So `$existing->getObject()` hands back an array where the schema says string.

`patchObject()` merged that array back in and saved it. Validation refused the save:

```
patchObject(uuid, ['title' => 'probe'])
→ ValidationException: Property 'notes' should be type 'string or null' but is 'array'.
```

A patch that never mentioned the property failed because of it.

`ObjectsController::patch()` and `ObjectsController::postPatch()` carried the identical defect independently. Neither calls `patchObject()`; each does its own `array_merge($existingObject->getObject(), $patchData)`. The same PATCH over HTTP answered 400 with the same message.

This is a live defect, not a theoretical one. dossiq's `CaseFieldWriter::write()` already takes the `patchObject()` branch on `development`, and its four callers are flow handlers. dossiq's sub-case modal creates cases with `statusHistory: JSON.stringify([...])`. Every case created that way refused every later flow-handler write, inside a handler, where it reads as "the flow did nothing".

## The fix

The decode now has an encode, and the encode lives beside it: `SchemaTypeConverter::restoreStringTypedValues()`. Two halves of one rule in one file cannot drift apart, which is how this defect was born.

All three patch doors call it after their merge and before their save. The rule exists once, and the call sites only answer the one question the converter cannot: which keys did the caller actually send.

## Three decisions, and why

**Only keys the caller did not supply are restored.** The promise being repaired is about untouched keys, so that is the exact scope of the repair. A caller that deliberately passes an array for a `type: string` property keeps the loud validation refusal it gets today. The alternative, encoding every such property including ones the caller passed, would swap a visible refusal for a silent rewrite of somebody's own value. A schema-type mismatch in a caller is a bug worth seeing.

**The converter is the home, not `mergePatchData()`.** `mergePatchData()` is one door's merge, and the controller's two doors do not use it, so a rule living there would need a second copy. The converter already owns the decode. Putting the inverse anywhere else guarantees that a future change to the decode leaves the encode behind.

**A scalar merged value is left alone, and nesting is not touched.** There is nothing to re-encode in a scalar. Nesting stops at the top level because that is the only depth the read decodes: the magic-table read applies `convertValue()` once per column, so once per declared property. A `type: string` nested inside an `object` property was never decoded and must not be encoded.

The encode uses `JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE`, which is what wrote these values in: consuming apps store `JSON.stringify(...)`, and that escapes neither slashes nor non-ASCII.

## Which direction this can fail

This is the foundation repository, so the failure direction matters more than the fix.

The change only ever turns an array into a string, only for a property the schema declares string-ish, and only when the caller did not mention that property. Everything else falls through untouched: a scalar, an `array` or `object` typed property, a union that admits arrays, a property the schema does not declare, a key the caller sent.

Every path that cannot answer confidently returns the data unchanged, which leaves today's loud validation refusal in place. That includes a schema that will not resolve, a container that cannot hand over the converter, and a value `json_encode()` refuses. Nothing is swallowed and nothing is silently rewritten. The worst case is the behaviour you already have.

## Verified live

Against localhost:8080, openregister 2.0.18-unstable, with a fixture register whose `notes` property is declared `type: string` and holds `[{"status":"open","at":"2026-09-11","note":"café / bar"},{"status":"closed","at":"2026-09-12"}]`.

Before, all three doors refuse:

```
patchObject(uuid, ['title' => 'probe-before'])
→ ValidationException: Property 'notes' should be type 'string or null' but is 'array'.

PATCH /api/objects/patchencodeprobe/patchencodeprobe/{uuid}  {"title":"probe-before"}
→ HTTP 400  Property 'notes' should be type 'string or null' but is 'array'.

POST  /api/objects/patchencodeprobe/patchencodeprobe/{uuid}  (multipart, title only)
→ HTTP 400  Property 'notes' should be type 'string or null' but is 'array'.
```

After, all three succeed and the untouched property is byte-identical in the database, non-ASCII and unescaped slash included:

```
patchObject untouched → OK, notes back as the stored string
PATCH title only      → HTTP 200
POST  title only      → HTTP 200
psql: notes = [{"status":"open","at":"2026-09-11","note":"café / bar"},{"status":"closed","at":"2026-09-12"}]
diff raw-before raw-after → BYTE_IDENTICAL
```

The limit holds live too. A caller that passes `notes` as an array still gets HTTP 400 with the same message, before and after.

## The tests were watched failing

13 new tests. On unpatched code they fail, and they fail for the right reason:

```
1) ObjectServicePatchObjectTest::testAStringTypedPropertyHoldingJsonSurvivesAPatchThatNeverMentionsIt
without the re-encode this arrives as an array and validation refuses a patch that never named it
2) ObjectsControllerPatchStringTypedJsonTest::testPatchRestoresAStringTypedJsonPropertyTheCallerNeverMentioned
3) ObjectsControllerPatchStringTypedJsonTest::testPostPatchRestoresAStringTypedJsonPropertyTheCallerNeverMentioned
plus 10 errors: Call to undefined method SchemaTypeConverter::restoreStringTypedValues()

Tests: 90, Assertions: 112, Errors: 10, Failures: 3.   exit 2
```

Patched:

```
OK (90 tests, 123 assertions)   exit 0
```

And a mutation check, because a wiring test that passes on the converter alone proves nothing about the wiring. With the converter fixed but the three call sites reverted:

```
Tests: 90, Assertions: 123, Failures: 3.   exit 1
```

Exactly the three door tests, which is what they are for.

## Not in this PR

Four more read-merge-save sites share this shape: `ObjectServiceMapperAdapter::updateFromArray(patch: true)`, `HandoffService`, `TaskFormCompletion` and `MergeService`. Each needs its own answer to "which keys did the caller supply", and the adapter is better fixed by delegating to `patchObject()`, which changes its merge semantics from shallow to RFC 7386. That is a behaviour change on a published surface and deserves its own PR rather than a rider on this one.

The two controller doors still carry their own `array_merge` instead of calling `patchObject()`. Collapsing them would also change HTTP PATCH from shallow merge to recursive merge with null-clear semantics. Same reasoning: real improvement, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
