### PR TITLE
fix: the four product defects the dark test suites were hiding

### DIFF
--- a/lib/Controller/BulkController.php
+++ b/lib/Controller/BulkController.php
@@ -196,6 +196,33 @@ class BulkController extends Controller {
 	}//end checkRegisterManagePermission()
 
 	/**
+	 * Find the first schema of a register the current user may not manage.
+	 *
+	 * Walks the register's own `schemas` list, the set a register-wide delete
+	 * empties. A listed id that does not resolve is skipped: it has no table the
+	 * delete could reach, and the service skips it the same way.
+	 *
+	 * @param Register $register The register about to be emptied.
+	 *
+	 * @return string|null The id of the first unmanageable schema, or null when all pass.
+	 */
+	private function firstUnmanageableSchemaOf(Register $register): ?string {
+		foreach ($register->getSchemas() as $schemaId) {
+			try {
+				$schema = $this->schemaMapper->find((int)$schemaId);
+			} catch (\Throwable $e) {
+				continue;
+			}
+
+			if ($this->checkSchemaManagePermission(schema: $schema) === false) {
+				return (string)$schemaId;
+			}
+		}
+
+		return null;
+	}//end firstUnmanageableSchemaOf()
+
+	/**
 	 * Resolve a register/schema path pair to numeric ids.
 	 *
 	 * This method used to hold its own copy of the resolution logic. That copy
@@ -809,7 +836,7 @@ class BulkController extends Controller {
 	 *
 	 * @return JSONResponse JSON response with register delete result
 	 *
-	 * @spec openspec/changes/retrofit-2026-05-24-b-ctrl-object-data/tasks.md#task-15
+	 * @spec openspec/specs/archival-annotation-vocabulary/spec.md#requirement-schema-wide-object-deletion-is-refused-on-an-archival-schema
 	 */
 	public function deleteRegister(string $register): JSONResponse {
 		try {
@@ -841,11 +868,28 @@ class BulkController extends Controller {
 				);
 			}
 
+			// Managing the register is not enough: this empties every schema the
+			// register lists, so each must pass the same manage gate that
+			// delete-objects applies to one schema. Resolved exactly as
+			// SchemaDeletionService::resolveSchemasOfRegister() resolves the set it
+			// deletes (the register's list; an id nothing answers to is skipped).
+			$unmanageable = $this->firstUnmanageableSchemaOf(register: $registerEntity);
+			if ($unmanageable !== null) {
+				return new JSONResponse(
+					data: ['error' => 'User does not have permission to manage schema ' . $unmanageable . ' of this register'],
+					statusCode: Http::STATUS_FORBIDDEN
+				);
+			}
+
+			// Same normalisation as deleteSchemaObjects(): a form or query request
+			// delivers the string "true".
+			$hardDelete = filter_var(($this->request->getParams()['hardDelete'] ?? false), FILTER_VALIDATE_BOOLEAN);
+
 			// Set register context.
 			$this->objectService->setRegister($register);
 
 			// Perform register deletion operation.
-			$result = $this->objectService->deleteObjectsByRegister((int)$register);
+			$result = $this->objectService->deleteObjectsByRegister(registerId: (int)$register, hardDelete: $hardDelete);
 
 			return new JSONResponse(
 				data: [
@@ -854,8 +898,14 @@ class BulkController extends Controller {
 					'deleted_count' => $result['deleted_count'],
 					'deleted_uuids' => $result['deleted_uuids'],
 					'register_id' => $result['register_id'],
+					'hard_delete' => $hardDelete,
 				]
 			);
+		} catch (ArchivalImmutableException $e) {
+			// A schema of the register holds legally retained records, and the whole
+			// request was refused before any row was touched. A deliberate refusal,
+			// so it is not left to the generic handler below to report as a 500.
+			return new JSONResponse(data: $e->toResponseBody(), statusCode: Http::STATUS_FORBIDDEN);
 		} catch (Exception $e) {
 			return new JSONResponse(
 				data: ['error' => 'Register objects deletion failed: ' . $e->getMessage()],

--- a/lib/Db/SearchTrail.php
+++ b/lib/Db/SearchTrail.php
@@ -81,6 +81,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setCreated(?DateTime $created)
  * @method string|null getOrganisation()
  * @method void setOrganisation(?string $organisation)
+ * @method bool|null getPublishedOnly()
+ * @method void setPublishedOnly(?bool $publishedOnly)
  *
  * @psalm-suppress PropertyNotSetInConstructor $id is set by Nextcloud's Entity base class
  */
@@ -269,6 +271,20 @@ class SearchTrail extends Entity implements JsonSerializable {
 	protected ?array $sortParameters = null;
 
 	/**
+	 * Whether the search was limited to published objects (historical)
+	 *
+	 * Read-only history. Object-level `published` metadata was retired
+	 * (openspec deprecate-published-metadata), so nothing writes this any
+	 * more and new rows take the column default. The `published_only` column
+	 * itself was deliberately kept as historical tracking data, and the
+	 * mapper selects `*`, so the entity MUST still declare it: without it
+	 * `fromRow()` throws on every stored trail and the list endpoint 500s.
+	 *
+	 * @var boolean|null Whether the search was limited to published objects
+	 */
+	protected ?bool $publishedOnly = null;
+
+	/**
 	 * Search execution type (sync or async)
 	 *
 	 * @var string|null Search execution type (sync or async)
@@ -314,6 +330,8 @@ class SearchTrail extends Entity implements JsonSerializable {
 	 * Constructor for the SearchTrail class
 	 *
 	 * Sets up field types for all properties
+	 *
+	 * @spec openspec/specs/zoeken-filteren/spec.md#requirement-saved-searches-and-search-trails
 	 */
 	public function __construct() {
 		$this->addType(fieldName: 'uuid', type: 'string');
@@ -342,7 +360,7 @@ class SearchTrail extends Entity implements JsonSerializable {
 		$this->addType(fieldName: 'facetableRequested', type: 'boolean');
 		$this->addType(fieldName: 'filters', type: 'json');
 		$this->addType(fieldName: 'sortParameters', type: 'json');
-
+		$this->addType(fieldName: 'publishedOnly', type: 'boolean');
 		$this->addType(fieldName: 'executionType', type: 'string');
 		$this->addType(fieldName: 'created', type: 'datetime');
 		$this->addType(fieldName: 'organisationId', type: 'string');

--- a/lib/Service/File/DeleteFileHandler.php
+++ b/lib/Service/File/DeleteFileHandler.php
@@ -87,9 +87,12 @@ class DeleteFileHandler {
 		// A Node is used as it is. Only a path or an id is resolved, and only
 		// those are cast for the log line: a Files Node is not Stringable, so
 		// casting before this check killed every Node caller (MergeHandler).
+		$fileName = '';
 		if ($file instanceof Node === true) {
 			$fileName = $file->getName();
-		} else {
+		}
+
+		if ($file instanceof Node === false) {
 			$fileName = (string)$file;
 			$file = $this->readFileHandler->getFile(object: $object, file: $file);
 		}

--- a/lib/Service/File/DeleteFileHandler.php
+++ b/lib/Service/File/DeleteFileHandler.php
@@ -81,16 +81,16 @@ class DeleteFileHandler {
 	 *
 	 * @psalm-param Node|string|int $file
 	 *
-	 * @spec openspec/specs/file-actions/spec.md
+	 * @spec openspec/specs/file-actions/spec.md#requirement-file-update-and-delete-enforce-per-action-node-permissions
 	 */
 	public function deleteFile(Node|string|int $file, ?ObjectEntity $object = null): bool {
-		// Determine file name for error logging.
-		$fileName = (string)$file;
+		// A Node is used as it is. Only a path or an id is resolved, and only
+		// those are cast for the log line: a Files Node is not Stringable, so
+		// casting before this check killed every Node caller (MergeHandler).
 		if ($file instanceof Node === true) {
 			$fileName = $file->getName();
-		}
-
-		if ($file instanceof Node === false) {
+		} else {
+			$fileName = (string)$file;
 			$file = $this->readFileHandler->getFile(object: $object, file: $file);
 		}
 

--- a/lib/Service/Oas/OasRequestValidator.php
+++ b/lib/Service/Oas/OasRequestValidator.php
@@ -31,6 +31,8 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Service\Oas;
 
+use Opis\JsonSchema\Errors\ErrorFormatter;
+use Opis\JsonSchema\Errors\ValidationError;
 use Opis\JsonSchema\Validator;
 
 /**
@@ -46,18 +48,24 @@ class OasRequestValidator {
 	 *
 	 * @return array<int, array{path: string, message: string}>
 	 *
-	 * @spec openspec/changes/retrofit-2026-05-25-bw-svc-mid2/tasks.md#task-8
+	 * @spec openspec/specs/oas-validation/spec.md#requirement-request-validation-against-oas-schema
 	 */
 	public function validate(mixed $body, array $schema): array {
 		// The opis/json-schema library operates on object-shaped values; convert
 		// the schema + body via JSON round-trip so we get the right
 		// PHP shape (stdClass for objects, array for lists).
-		$schemaJson = (string)json_encode($schema);
+		$schemaJson = (string)json_encode($this->bindLocalDynamicRefs(schema: $schema));
 		$schemaObj = json_decode($schemaJson);
 		$bodyJson = (string)json_encode($body);
 		$bodyObj = json_decode($bodyJson);
 
+		// Validation MUST NOT write into the data it judges. opis applies
+		// `default` values by default, and a default injected inside an
+		// `if`/`then` branch is then refused by `unevaluatedProperties` as a
+		// property the caller never sent. The OAS 3.1 meta-schema does exactly
+		// that with a query parameter's `allowEmptyValue`.
 		$validator = new Validator();
+		$validator->parser()->setOption('allowDefaults', false);
 		$result = $validator->validate(data: $bodyObj, schema: $schemaObj);
 		if ($result->isValid() === true) {
 			return [];
@@ -118,11 +126,12 @@ class OasRequestValidator {
 			$message = (string)$error->keyword();
 		}
 
-		if (method_exists($error, 'message') === true) {
-			$msg = $error->message();
-			if (is_string($msg) === true && $msg !== '') {
-				$message = $msg;
-			}
+		// `message()` is a TEMPLATE ("The required properties ({missing}) are
+		// missing"); the formatter fills its placeholders from the error's args.
+		// Reporting the raw template told a reader which rule failed but never
+		// which property, type or keyword it failed on.
+		if ($error instanceof ValidationError === true) {
+			$message = (new ErrorFormatter())->formatErrorMessage(error: $error);
 		}
 
 		$errorPath = '/';
@@ -147,4 +156,101 @@ class OasRequestValidator {
 		}
 
 	}//end collectErrors()
+
+	/**
+	 * Bind each `$dynamicRef: "#name"` to the `$dynamicAnchor` it names.
+	 *
+	 * The opis/json-schema 2.x library resolves `$dynamicRef` through its
+	 * `$recursiveRef` machinery, which only looks for the anchor on schema
+	 * RESOURCE roots. The OpenAPI 3.1 meta-schema declares
+	 * `$dynamicAnchor: meta` inside `$defs/schema`, not on a root, so opis
+	 * bound every `{$dynamicRef: "#meta"}` to the document root and demanded
+	 * `openapi` and `info` inside each parameter's schema.
+	 *
+	 * For a schema that is ONE resource (no nested `$id`), the dynamic scope
+	 * holds nothing but that resource, so a JSON Schema 2020-12 validator
+	 * resolves `#name` to the single place that resource declares
+	 * `$dynamicAnchor: name`. Rewriting the reference to a plain `$ref` at
+	 * that JSON pointer gives the same answer without depending on opis's
+	 * dynamic scope. Anything that is not that unambiguous case (nested
+	 * resources, an anchor declared twice or not at all) is left untouched.
+	 *
+	 * @param array $schema The decoded schema.
+	 *
+	 * @return array The schema with local dynamic references bound.
+	 *
+	 * @spec openspec/specs/oas-validation/spec.md#requirement-request-validation-against-oas-schema
+	 */
+	private function bindLocalDynamicRefs(array $schema): array {
+		$anchors = [];
+		$nestedIds = 0;
+		$this->collectDynamicAnchors(node: $schema, pointer: '', anchors: $anchors, nestedIds: $nestedIds);
+		if ($nestedIds > 0 || $anchors === []) {
+			return $schema;
+		}
+
+		$targets = [];
+		foreach ($anchors as $name => $pointers) {
+			if (count($pointers) === 1) {
+				$targets['#' . $name] = '#' . $pointers[0];
+			}
+		}
+
+		return $this->rewriteDynamicRefs(node: $schema, targets: $targets);
+	}//end bindLocalDynamicRefs()
+
+	/**
+	 * Record where each `$dynamicAnchor` is declared, and count nested `$id`s.
+	 *
+	 * @param mixed  $node      The schema node being walked.
+	 * @param string $pointer   The JSON pointer of that node ('' is the root).
+	 * @param array  $anchors   Anchor name => list of JSON pointers (by reference).
+	 * @param int    $nestedIds Number of `$id`s below the root (by reference).
+	 *
+	 * @return void
+	 */
+	private function collectDynamicAnchors(mixed $node, string $pointer, array &$anchors, int &$nestedIds): void {
+		if (is_array($node) === false) {
+			return;
+		}
+
+		if ($pointer !== '' && isset($node['$id']) === true) {
+			$nestedIds++;
+		}
+
+		if (isset($node['$dynamicAnchor']) === true && is_string($node['$dynamicAnchor']) === true) {
+			$anchors[$node['$dynamicAnchor']][] = $pointer;
+		}
+
+		foreach ($node as $key => $child) {
+			$segment = str_replace(['~', '/'], ['~0', '~1'], (string)$key);
+			$this->collectDynamicAnchors(node: $child, pointer: $pointer . '/' . $segment, anchors: $anchors, nestedIds: $nestedIds);
+		}
+	}//end collectDynamicAnchors()
+
+	/**
+	 * Replace `$dynamicRef` values that have a bound target with a plain `$ref`.
+	 *
+	 * @param mixed $node    The schema node being rewritten.
+	 * @param array $targets `#name` => `#/json/pointer`.
+	 *
+	 * @return mixed The rewritten node.
+	 */
+	private function rewriteDynamicRefs(mixed $node, array $targets): mixed {
+		if (is_array($node) === false) {
+			return $node;
+		}
+
+		$ref = $node['$dynamicRef'] ?? null;
+		if (is_string($ref) === true && isset($targets[$ref]) === true) {
+			unset($node['$dynamicRef']);
+			$node['$ref'] = $targets[$ref];
+		}
+
+		foreach ($node as $key => $child) {
+			$node[$key] = $this->rewriteDynamicRefs(node: $child, targets: $targets);
+		}
+
+		return $node;
+	}//end rewriteDynamicRefs()
 }//end class

--- a/lib/Service/OasService.php
+++ b/lib/Service/OasService.php
@@ -231,14 +231,20 @@ class OasService {
 		// document failed its own meta-schema check on them, and a client
 		// that resolves them against the page rather than the server lands
 		// on the wrong host. Anchor them to this instance, as the server is.
-		$flow = &$this->oas['components']['securitySchemes']['oauth2']['flows']['authorizationCode'];
-		foreach (['authorizationUrl', 'tokenUrl', 'refreshUrl'] as $urlKey) {
-			if (isset($flow[$urlKey]) === true && str_starts_with((string)$flow[$urlKey], '/') === true) {
-				$flow[$urlKey] = $this->urlGenerator->getAbsoluteURL((string)$flow[$urlKey]);
+		// Read, rewrite, write back, rather than taking a reference into the
+		// array: psalm refuses to analyse a reference into a property
+		// (UnsupportedPropertyReferenceUsage), and a guard it cannot analyse
+		// is a guard nobody checks.
+		$flow = ($this->oas['components']['securitySchemes']['oauth2']['flows']['authorizationCode'] ?? null);
+		if (is_array($flow) === true) {
+			foreach (['authorizationUrl', 'tokenUrl', 'refreshUrl'] as $urlKey) {
+				if (isset($flow[$urlKey]) === true && str_starts_with((string)$flow[$urlKey], '/') === true) {
+					$flow[$urlKey] = $this->urlGenerator->getAbsoluteURL((string)$flow[$urlKey]);
+				}
 			}
-		}
 
-		unset($flow);
+			$this->oas['components']['securitySchemes']['oauth2']['flows']['authorizationCode'] = $flow;
+		}
 
 		// Step 6: If specific register requested, update info section with register details.
 		if ($registerId !== null) {

--- a/lib/Service/OasService.php
+++ b/lib/Service/OasService.php
@@ -183,6 +183,7 @@ class OasService {
 	 * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
 	 *
 	 * @spec openspec/specs/oas-generation/spec.md
+	 * @spec openspec/specs/oas-validation/spec.md#requirement-server-url-is-absolute
 	 */
 	public function createOas(?string $registerId = null, bool $strict = false): array {
 		// Reset the validation report at the start of every generation pass.
@@ -224,6 +225,20 @@ class OasService {
 				'description' => 'OpenRegister API Server',
 			],
 		];
+
+		// The OAuth flow URLs ship relative in BaseOas.json. The OAS 3.1
+		// meta-schema types them `format: uri` (absolute), so every generated
+		// document failed its own meta-schema check on them, and a client
+		// that resolves them against the page rather than the server lands
+		// on the wrong host. Anchor them to this instance, as the server is.
+		$flow = &$this->oas['components']['securitySchemes']['oauth2']['flows']['authorizationCode'];
+		foreach (['authorizationUrl', 'tokenUrl', 'refreshUrl'] as $urlKey) {
+			if (isset($flow[$urlKey]) === true && str_starts_with((string)$flow[$urlKey], '/') === true) {
+				$flow[$urlKey] = $this->urlGenerator->getAbsoluteURL((string)$flow[$urlKey]);
+			}
+		}
+
+		unset($flow);
 
 		// Step 6: If specific register requested, update info section with register details.
 		if ($registerId !== null) {

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -5160,26 +5160,36 @@ class ObjectService implements ObjectServiceInterface
     /**
      * Delete all objects belonging to a specific register
      *
-     * This method efficiently deletes all objects that belong to the specified register.
-     * It uses bulk operations for optimal performance and maintains data integrity.
+     * Empties every magic table of every schema the register lists, in one
+     * transaction, snapshotting each object to the audit trail first. Refuses the
+     * whole request with ArchivalImmutableException, before touching any row, when
+     * any of those schemas is archival. The work lives in SchemaDeletionService,
+     * resolved lazily for the reason deleteObjectsBySchema() gives.
      *
-     * @param int $registerId The ID of the register whose objects should be deleted
+     * @param int  $registerId The ID of the register whose objects should be deleted
+     * @param bool $hardDelete Whether to force hard delete (default: false)
      *
      * @return (int|string[])[]
      *
-     * @throws \Exception If the deletion operation fails
+     * @throws \OCA\OpenRegister\Exception\ArchivalImmutableException If any schema of the register is archival
+     * @throws \Exception If the deletion operation fails (nothing is deleted)
      *
      * @phpstan-return array{deleted_count: int, deleted_uuids: array<int, string>, register_id: int}
      *
      * @psalm-return array{deleted_count: int<min, max>, deleted_uuids: array<int, string>, register_id: int}
      *
-     * @spec exclude Deprecated throwing stub; register-wide delete awaits MagicMapper reimplementation (blob table retired).
+     * @SuppressWarnings(PHPMD.BooleanArgumentFlag) The hard/soft toggle mirrors the mapper primitive it wraps.
+     *
+     * @spec openspec/specs/archival-annotation-vocabulary/spec.md#requirement-schema-wide-object-deletion-is-refused-on-an-archival-schema
      */
-    public function deleteObjectsByRegister(int $registerId): array
+    public function deleteObjectsByRegister(int $registerId, bool $hardDelete=false): array
     {
-        // TODO: Reimplement using MagicMapper for register-wide delete on magic tables.
-        throw new RuntimeException(
-            'deleteObjectsByRegister needs reimplementation using MagicMapper (blob objects table retired)'
+        $register = $this->registerMapper->find(id: $registerId);
+        $schemaDeletionService = $this->container->get(\OCA\OpenRegister\Service\SchemaDeletionService::class);
+
+        return $schemaDeletionService->deleteObjectsByRegister(
+            register: $register,
+            hardDelete: $hardDelete
         );
     }//end deleteObjectsByRegister()
 

--- a/lib/Service/SchemaDeletionService.php
+++ b/lib/Service/SchemaDeletionService.php
@@ -97,6 +97,13 @@ class SchemaDeletionService {
 	public const TRIGGER_BULK_DELETE = 'bulk_schema_delete';
 
 	/**
+	 * Trigger context for objects removed via the bulk delete-register endpoint.
+	 *
+	 * @var string
+	 */
+	public const TRIGGER_BULK_REGISTER_DELETE = 'bulk_register_delete';
+
+	/**
 	 * Objects snapshotted + audited per batch.
 	 *
 	 * ADR-009 (bounded per-object work): the object set is read and audited in
@@ -182,6 +189,128 @@ class SchemaDeletionService {
 		];
 
 	}//end deleteObjectsBySchema()
+
+	/**
+	 * Resolve the schemas a register lists, the way the retention sweep does.
+	 *
+	 * Mirrors `RetentionRowScanner::magicTableSources()`: the register's own
+	 * `schemas` list is the authority for which (register, schema) pairs exist.
+	 * A listed id that no schema answers to is skipped with a warning rather than
+	 * thrown on, because it cannot have a magic table this service could reach.
+	 *
+	 * Public so the controller can gate every schema on its manage permission
+	 * against exactly the set this service is about to empty.
+	 *
+	 * @param Register $register The register.
+	 *
+	 * @return array<int, Schema> The resolvable schemas, in the register's order.
+	 *
+	 * @spec openspec/specs/archival-annotation-vocabulary/spec.md#requirement-schema-wide-object-deletion-is-refused-on-an-archival-schema
+	 */
+	public function resolveSchemasOfRegister(Register $register): array {
+		$schemas = [];
+		foreach ($register->getSchemas() as $schemaId) {
+			try {
+				$schemas[] = $this->schemaMapper->find(id: (int)$schemaId);
+			} catch (Throwable $e) {
+				$this->logger->warning(
+					message: '[SchemaDeletionService] Register lists a schema that does not resolve; skipped',
+					context: [
+						'file' => __FILE__,
+						'line' => __LINE__,
+						'registerId' => (int)$register->getId(),
+						'schemaId' => (string)$schemaId,
+						'error' => $e->getMessage(),
+					]
+				);
+			}
+		}
+
+		return $schemas;
+	}//end resolveSchemasOfRegister()
+
+	/**
+	 * Delete every object of every schema a register lists, without deleting either.
+	 *
+	 * Backs `POST /api/bulk/{register}/delete-register`, which until now called a
+	 * stub that threw on every request. It runs the same audited per-pair delete
+	 * as {@see self::deleteObjectsBySchema()}, over the pairs
+	 * {@see self::resolveSchemasOfRegister()} names.
+	 *
+	 * ARCHIVAL SCHEMAS REFUSE THE WHOLE REQUEST, AND THEY DO IT FIRST. Every schema
+	 * is checked before any row is touched: checked inside the loop instead, a
+	 * register listing a plain schema ahead of an archival one would be half emptied
+	 * by the time the refusal came. There is no override, for the reason
+	 * {@see self::deleteObjectsBySchema()} gives: this is an HTTP door.
+	 *
+	 * ONE TRANSACTION. The pairs are emptied together or not at all, like phase 1
+	 * of {@see self::cascadeDeleteSchema()}.
+	 *
+	 * @param Register $register The register whose objects are deleted.
+	 * @param bool $hardDelete True to remove the rows, false to soft-delete them.
+	 * @param string $triggeredBy Audit trigger context.
+	 *
+	 * @throws ArchivalImmutableException If any schema of the register is archival (nothing is deleted).
+	 * @throws \Exception If a delete fails (everything is rolled back).
+	 *
+	 * @return array{deleted_count: int, deleted_uuids: array<int, string>, register_id: int} The deletion result.
+	 *
+	 * @SuppressWarnings(PHPMD.BooleanArgumentFlag) The hard/soft toggle mirrors the mapper primitive it wraps.
+	 *
+	 * @spec openspec/specs/archival-annotation-vocabulary/spec.md#requirement-schema-wide-object-deletion-is-refused-on-an-archival-schema
+	 */
+	public function deleteObjectsByRegister(
+		Register $register,
+		bool $hardDelete = false,
+		string $triggeredBy = self::TRIGGER_BULK_REGISTER_DELETE,
+	): array {
+		$schemas = $this->resolveSchemasOfRegister(register: $register);
+
+		foreach ($schemas as $schema) {
+			$this->rejectIfArchivalImmutable(schema: $schema, operation: 'delete');
+		}
+
+		$deletedCount = 0;
+		$deletedUuids = [];
+
+		$this->db->beginTransaction();
+		try {
+			foreach ($schemas as $schema) {
+				$result = $this->deleteObjectsOfPair(
+					register: $register,
+					schema: $schema,
+					hardDelete: $hardDelete,
+					triggeredBy: $triggeredBy
+				);
+
+				$deletedCount += $result['deleted_count'];
+				$deletedUuids = array_merge($deletedUuids, $result['deleted_uuids']);
+			}
+
+			$this->db->commit();
+		} catch (Throwable $e) {
+			$this->db->rollBack();
+
+			$this->logger->error(
+				message: '[SchemaDeletionService] Register-wide delete rolled back',
+				context: [
+					'file' => __FILE__,
+					'line' => __LINE__,
+					'registerId' => (int)$register->getId(),
+					'error' => $e->getMessage(),
+				]
+			);
+
+			throw $e;
+		}//end try
+
+		return [
+			'deleted_count' => $deletedCount,
+			'deleted_uuids' => $deletedUuids,
+			'register_id' => (int)$register->getId(),
+		];
+
+	}//end deleteObjectsByRegister()
 
 	/**
 	 * Cascade-delete a schema: its objects, its magic tables, and the schema itself.

--- a/tests/Integration/Pdf/AnonymisationFlowTest.php
+++ b/tests/Integration/Pdf/AnonymisationFlowTest.php
@@ -97,7 +97,10 @@ class AnonymisationFlowTest extends TestCase {
 			$this->markTestSkipped('smalot/pdfparser is not installed; skip integration test (composer install pending).');
 		}
 
-		if (class_exists(\Ddn\Sapp\PDFDoc::class) === false && class_exists('Ddn\\Sapp\\PDFDoc') === false) {
+		// The package's namespace is lower-case `ddn\sapp`, and Composer's PSR-4
+		// lookup is case-sensitive: probing `Ddn\Sapp\PDFDoc` never autoloads,
+		// so this guard skipped the whole file on every install that HAD sapp.
+		if (class_exists(\ddn\sapp\PDFDoc::class) === false) {
 			$this->markTestSkipped('ddn/sapp is not installed; skip integration test (composer install pending).');
 		}
 

--- a/tests/Unit/Controller/BulkControllerTest.php
+++ b/tests/Unit/Controller/BulkControllerTest.php
@@ -1327,6 +1327,81 @@ class BulkControllerTest extends TestCase {
 		$this->assertStringContainsString('Register delete error', $data['error']);
 	}
 
+	/**
+	 * An archival schema in the register is a deliberate 403, not a 500.
+	 *
+	 * @return void
+	 */
+	public function testDeleteRegisterRefusesAnArchivalRegisterWith403(): void {
+		$this->stubAdminUser();
+		$this->stubRegisterLookup(1);
+		$this->objectService->method('setRegister')->willReturnSelf();
+		$this->objectService->method('deleteObjectsByRegister')
+			->willThrowException(new ArchivalImmutableException(schemaIdentifier: 'retained-case', operation: 'delete'));
+
+		$result = $this->controller->deleteRegister('1');
+
+		$this->assertEquals(Http::STATUS_FORBIDDEN, $result->getStatus());
+		$this->assertSame('SCHEMA_ARCHIVAL_IMMUTABLE', $result->getData()['error']);
+		$this->assertSame('retained-case', $result->getData()['schema']);
+	}
+
+	/**
+	 * Managing the register is not enough: every schema it empties must be manageable.
+	 *
+	 * @return void
+	 */
+	public function testDeleteRegisterRefusesWhenOneOfItsSchemasIsNotManageable(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$this->userSession->method('getUser')->willReturn($user);
+		$this->groupManager->method('isAdmin')->with('alice')->willReturn(false);
+		$this->groupManager->method('getUserGroupIds')->willReturn(['editors']);
+
+		$register = new Register();
+		$register->setId(1);
+		$register->setAuthorization(['manage' => ['editors']]);
+		$register->setSchemas([42, 43]);
+		$this->registerMapper->method('find')->willReturn($register);
+
+		$manageable = new Schema();
+		$manageable->setId(42);
+		$manageable->setAuthorization(['manage' => ['editors']]);
+		// No manage rule: admin-only, so alice may not empty it.
+		$locked = new Schema();
+		$locked->setId(43);
+		$this->schemaMapper->method('find')->willReturnCallback(
+			static fn (int|string $id): Schema => ((int)$id === 42 ? $manageable : $locked)
+		);
+
+		$this->objectService->expects($this->never())->method('deleteObjectsByRegister');
+
+		$result = $this->controller->deleteRegister('1');
+
+		$this->assertEquals(Http::STATUS_FORBIDDEN, $result->getStatus());
+		$this->assertStringContainsString('43', $result->getData()['error']);
+	}
+
+	/**
+	 * The hard/soft choice reaches the service, as it does on delete-objects.
+	 *
+	 * @return void
+	 */
+	public function testDeleteRegisterPassesHardDeleteThrough(): void {
+		$this->stubAdminUser();
+		$this->stubRegisterLookup(1);
+		$this->request->method('getParams')->willReturn(['hardDelete' => 'true']);
+		$this->objectService->method('setRegister')->willReturnSelf();
+		$this->objectService->expects($this->once())
+			->method('deleteObjectsByRegister')
+			->with(1, true)
+			->willReturn(['deleted_count' => 0, 'deleted_uuids' => [], 'register_id' => 1]);
+
+		$result = $this->controller->deleteRegister('1');
+
+		$this->assertEquals(Http::STATUS_OK, $result->getStatus());
+	}
+
 	// ========================================================================
 	// runSchemaValidation() tests
 	// ========================================================================

--- a/tests/Unit/Db/SearchTrailTest.php
+++ b/tests/Unit/Db/SearchTrailTest.php
@@ -340,4 +340,38 @@ class SearchTrailTest extends TestCase {
 		$this->assertSame(2, $json['schema']);
 		$this->assertSame('GET', $json['httpMethod']);
 	}
+
+	/**
+	 * Every column of `openregister_search_trails` MUST hydrate.
+	 *
+	 * `Entity::fromRow()` calls a setter for each column in the row and throws
+	 * `BadFunctionCallException` for a column the entity does not declare. The
+	 * mapper selects `*`, so one undeclared column makes every read of every
+	 * stored trail throw: `published_only` did exactly that, and
+	 * `GET /api/search-trails` answered 500 as soon as one trail row existed.
+	 *
+	 * The list is the live table as a fully migrated install creates it
+	 * (read from information_schema on Nextcloud 34 + postgres 16). Adding a
+	 * column in a migration without declaring it on the entity reddens this.
+	 *
+	 * @return void
+	 */
+	public function testFromRowHydratesEveryColumnOfTheTable(): void {
+		$columns = [
+			'id', 'uuid', 'search_term', 'query_parameters', 'filters', 'sort_parameters',
+			'result_count', 'total_results', 'register', 'schema', 'register_uuid',
+			'schema_uuid', 'user', 'user_name', 'session', 'ip_address', 'user_agent',
+			'request_uri', 'http_method', 'response_time', 'page', 'limit', 'offset',
+			'facets_requested', 'facetable_requested', 'published_only', 'execution_type',
+			'organisation_id', 'organisation_id_type', 'created', 'expires', 'size',
+		];
+		$row = array_fill_keys($columns, null);
+		$row['id'] = 7;
+		$row['published_only'] = true;
+
+		$trail = SearchTrail::fromRow($row);
+
+		$this->assertSame(7, $trail->getId());
+		$this->assertTrue($trail->getPublishedOnly(), 'historical published_only value MUST survive hydration');
+	}
 }

--- a/tests/Unit/Service/File/DeleteFileHandlerTest.php
+++ b/tests/Unit/Service/File/DeleteFileHandlerTest.php
@@ -118,4 +118,34 @@ class DeleteFileHandlerTest extends TestCase {
 
 		$this->handler->deleteFile(file: 42, object: $this->createMock(ObjectEntity::class));
 	}//end testDeleteRefusedWithoutDeletePermission()
+
+	// =========================================================================
+	// deleteFile - a Node is deleted as a Node
+	// =========================================================================
+
+	/**
+	 * A Node argument MUST be deleted directly, never cast to string.
+	 *
+	 * The docblock has always promised Node|string|int. The handler cast the
+	 * argument to string for its log line BEFORE asking whether it was a Node,
+	 * and a Files Node is not Stringable, so every Node caller died with
+	 * "Object of class OC\Files\Node\File could not be converted to string".
+	 * MergeHandler passes Nodes, so merging objects that carry files broke.
+	 *
+	 * @return void
+	 */
+	public function testDeleteAcceptsANodeWithoutResolvingIt(): void {
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn(42);
+		$file->method('getName')->willReturn('test.pdf');
+		$file->method('isDeletable')->willReturn(true);
+		$file->expects($this->once())->method('delete');
+
+		// A Node needs no lookup; resolving it again would be wasted work.
+		$this->readFileHandler->expects($this->never())->method('getFile');
+
+		$result = $this->handler->deleteFile(file: $file, object: $this->createMock(ObjectEntity::class));
+
+		$this->assertTrue($result);
+	}//end testDeleteAcceptsANodeWithoutResolvingIt()
 }//end class

--- a/tests/Unit/Service/Oas/OasRequestValidatorTest.php
+++ b/tests/Unit/Service/Oas/OasRequestValidatorTest.php
@@ -103,4 +103,155 @@ class OasRequestValidatorTest extends TestCase {
 
 	}//end testEachErrorHasPathAndMessage()
 
+	/**
+	 * Build a minimal OpenAPI 3.1 document around a list of parameters.
+	 *
+	 * @param array $parameters The operation's parameters.
+	 *
+	 * @return array The document.
+	 */
+	private function oasDocument(array $parameters): array {
+		return [
+			'openapi' => '3.1.0',
+			'info' => ['title' => 'Probe', 'version' => '1.0.0'],
+			'paths' => [
+				'/items/{id}' => [
+					'get' => [
+						'parameters' => $parameters,
+						'responses' => ['200' => ['description' => 'OK']],
+					],
+				],
+			],
+		];
+
+	}//end oasDocument()
+
+	/**
+	 * Load the vendored OpenAPI 3.1 meta-schema that OasService validates against.
+	 *
+	 * @return array The decoded meta-schema.
+	 */
+	private function oasMetaSchema(): array {
+		$path = __DIR__ . '/../../../../lib/Service/Resources/meta/openapi-3.1.0.json';
+		$meta = json_decode((string)file_get_contents($path), true);
+		$this->assertIsArray($meta, 'the vendored meta-schema MUST decode');
+		return $meta;
+
+	}//end oasMetaSchema()
+
+	/**
+	 * A textbook-valid OAS 3.1 document with parameters MUST pass the meta-schema.
+	 *
+	 * Every OAS report with parameters used to carry 14 false errors: opis
+	 * bound the parameter's `schema: {$dynamicRef: "#meta"}` to the document
+	 * ROOT (demanding `openapi` inside every parameter schema), and injected
+	 * `default` values into the data so `unevaluatedProperties` then refused
+	 * the `allowEmptyValue` it had just added itself.
+	 *
+	 * @return void
+	 */
+	public function testValidOasDocumentWithParametersPassesTheMetaSchema(): void {
+		$document = $this->oasDocument(
+			[
+				['name' => 'id', 'in' => 'path', 'required' => true, 'schema' => ['type' => 'string']],
+				['name' => '_extend', 'in' => 'query', 'required' => false, 'schema' => ['type' => 'string'], 'example' => 'a,b'],
+			]
+		);
+
+		$errors = $this->validator->validate(body: $document, schema: $this->oasMetaSchema());
+
+		$this->assertSame([], $errors, 'a valid OAS 3.1 document MUST report zero errors; got: ' . json_encode($errors));
+
+	}//end testValidOasDocumentWithParametersPassesTheMetaSchema()
+
+	/**
+	 * The meta-schema check MUST still catch a genuinely broken parameter.
+	 *
+	 * Guards the fix from the other side: a validator that accepts everything
+	 * would also pass the test above.
+	 *
+	 * @return void
+	 */
+	public function testOasParameterWithoutNameIsStillRejected(): void {
+		$document = $this->oasDocument(
+			[
+				['name' => 'id', 'in' => 'path', 'required' => true, 'schema' => ['type' => 'string']],
+				['in' => 'query', 'schema' => ['type' => 'string']],
+			]
+		);
+
+		$errors = $this->validator->validate(body: $document, schema: $this->oasMetaSchema());
+		$messages = array_column($errors, 'message');
+
+		$this->assertContains('The required properties (name) are missing', $messages);
+
+	}//end testOasParameterWithoutNameIsStillRejected()
+
+	/**
+	 * A `$dynamicRef` MUST bind to the `$dynamicAnchor` its schema declares.
+	 *
+	 * @return void
+	 */
+	public function testDynamicRefBindsToItsDeclaredAnchorNotTheRoot(): void {
+		$schema = [
+			'$schema' => 'https://json-schema.org/draft/2020-12/schema',
+			'$id' => 'https://example.test/tree',
+			'type' => 'object',
+			'required' => ['kind'],
+			'properties' => ['child' => ['$dynamicRef' => '#node']],
+			'$defs' => ['node' => ['$dynamicAnchor' => 'node', 'type' => ['object', 'boolean']]],
+		];
+
+		// `child` is a plain object: valid against $defs/node, invalid against
+		// the root (which requires `kind`).
+		$this->assertSame([], $this->validator->validate(body: ['kind' => 'a', 'child' => ['x' => 1]], schema: $schema));
+		$this->assertNotEmpty($this->validator->validate(body: ['kind' => 'a', 'child' => 'leaf'], schema: $schema));
+
+	}//end testDynamicRefBindsToItsDeclaredAnchorNotTheRoot()
+
+	/**
+	 * A `default` MUST NOT be written into the data being validated.
+	 *
+	 * @return void
+	 */
+	public function testDefaultsAreNotInjectedIntoTheValidatedData(): void {
+		$schema = [
+			'type' => 'object',
+			'properties' => ['in' => ['type' => 'string']],
+			'if' => ['properties' => ['in' => ['const' => 'query']], 'required' => ['in']],
+			'then' => ['properties' => ['allowEmptyValue' => ['default' => false, 'type' => 'boolean']]],
+			'unevaluatedProperties' => false,
+		];
+
+		$this->assertSame([], $this->validator->validate(body: ['in' => 'query'], schema: $schema));
+
+	}//end testDefaultsAreNotInjectedIntoTheValidatedData()
+
+	/**
+	 * Error messages MUST be filled in, never raw `{keyword}` templates.
+	 *
+	 * @return void
+	 */
+	public function testErrorMessagesCarryNoUnfilledPlaceholders(): void {
+		$schema = [
+			'type' => 'object',
+			'required' => ['title'],
+			'properties' => ['title' => ['type' => 'string'], 'age' => ['type' => 'integer']],
+		];
+
+		// Not `[]`: an empty PHP array encodes as a JSON list, which fails on
+		// type before `required` is ever reached.
+		$errors = array_merge(
+			$this->validator->validate(body: ['age' => 3], schema: $schema),
+			$this->validator->validate(body: ['title' => 'x', 'age' => 'old'], schema: $schema)
+		);
+
+		$this->assertNotEmpty($errors);
+		foreach ($errors as $error) {
+			$this->assertDoesNotMatchRegularExpression('/\{[a-z]+\}/i', $error['message'], 'unfilled placeholder in: ' . $error['message']);
+		}
+
+		$this->assertContains('The required properties (title) are missing', array_column($errors, 'message'));
+
+	}//end testErrorMessagesCarryNoUnfilledPlaceholders()
 }//end class

--- a/tests/Unit/Service/OasServiceTest.php
+++ b/tests/Unit/Service/OasServiceTest.php
@@ -196,13 +196,36 @@ class OasServiceTest extends TestCase {
 		$this->registerMapper->method('findAll')->willReturn([$register]);
 		$this->schemaMapper->method('findMultiple')->willReturn([]);
 		$this->urlGenerator->method('getAbsoluteURL')
-			->with('/apps/openregister/api')
-			->willReturn('https://example.com/apps/openregister/api');
+			->willReturnCallback(static fn (string $path): string => 'https://example.com' . $path);
 
 		$oas = $this->service->createOas();
 
 		$this->assertSame('https://example.com/apps/openregister/api', $oas['servers'][0]['url']);
 		$this->assertSame('OpenRegister API Server', $oas['servers'][0]['description']);
+	}
+
+	/**
+	 * The OAuth flow URLs MUST be absolute, anchored to this instance.
+	 *
+	 * They ship relative in BaseOas.json, and the OAS 3.1 meta-schema types
+	 * them `format: uri`, so every generated document failed its own
+	 * meta-schema check on them.
+	 *
+	 * @return void
+	 */
+	public function testCreateOasAnchorsTheOAuthFlowUrlsToTheInstance(): void {
+		$register = $this->createRegister(1, 'TestReg', []);
+
+		$this->registerMapper->method('findAll')->willReturn([$register]);
+		$this->schemaMapper->method('findMultiple')->willReturn([]);
+		$this->urlGenerator->method('getAbsoluteURL')
+			->willReturnCallback(static fn (string $path): string => 'https://example.com' . $path);
+
+		$flow = $this->service->createOas()['components']['securitySchemes']['oauth2']['flows']['authorizationCode'];
+
+		$this->assertSame('https://example.com/apps/oauth2/authorize', $flow['authorizationUrl']);
+		$this->assertSame('https://example.com/apps/oauth2/api/v1/token', $flow['tokenUrl']);
+		$this->assertSame('https://example.com/apps/oauth2/api/v1/token', $flow['refreshUrl']);
 	}
 
 	public function testCreateOasMultipleRegistersDeduplicateSchemas(): void {

--- a/tests/Unit/Service/ObjectServiceDeleteByRegisterTest.php
+++ b/tests/Unit/Service/ObjectServiceDeleteByRegisterTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * ObjectService::deleteObjectsByRegister() delegation test.
+ *
+ * The method was a stub that threw "deleteObjectsByRegister needs
+ * reimplementation using MagicMapper (blob objects table retired)", and it is
+ * routed as `POST /api/bulk/{register}/delete-register`, so that endpoint
+ * failed on every request. It now hands the register to SchemaDeletionService,
+ * the single implementation of schema-wide object deletion.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service;
+
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\SchemaDeletionService;
+use OCP\AppFramework\IAppContainer;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * The register-wide delete reaches SchemaDeletionService.
+ */
+class ObjectServiceDeleteByRegisterTest extends TestCase {
+
+	/**
+	 * The register is resolved and handed over with the hard/soft choice intact.
+	 *
+	 * @return void
+	 */
+	public function testDeleteObjectsByRegisterDelegatesToSchemaDeletionService(): void {
+		$register = new Register();
+		$register->setId(7);
+
+		$registerMapper = $this->createMock(RegisterMapper::class);
+		$registerMapper->method('find')->willReturn($register);
+
+		$result = ['deleted_count' => 2, 'deleted_uuids' => ['u1', 'u2'], 'register_id' => 7];
+
+		$deletion = $this->createMock(SchemaDeletionService::class);
+		$deletion->expects($this->once())
+			->method('deleteObjectsByRegister')
+			->with($register, true)
+			->willReturn($result);
+
+		$container = $this->createMock(IAppContainer::class);
+		$container->method('get')->with(SchemaDeletionService::class)->willReturn($deletion);
+
+		$service = (new ReflectionClass(ObjectService::class))->newInstanceWithoutConstructor();
+		foreach (['registerMapper' => $registerMapper, 'container' => $container] as $name => $value) {
+			(new ReflectionClass(ObjectService::class))->getProperty($name)->setValue($service, $value);
+		}
+
+		$this->assertSame($result, $service->deleteObjectsByRegister(registerId: 7, hardDelete: true));
+
+	}//end testDeleteObjectsByRegisterDelegatesToSchemaDeletionService()
+}//end class

--- a/tests/Unit/Service/SchemaDeletionRegisterDeleteTest.php
+++ b/tests/Unit/Service/SchemaDeletionRegisterDeleteTest.php
@@ -1,0 +1,319 @@
+<?php
+
+/**
+ * SchemaDeletionService register-wide delete tests.
+ *
+ * `POST /api/bulk/{register}/delete-register` called a stub that threw
+ * "deleteObjectsByRegister needs reimplementation using MagicMapper" on every
+ * request. The register-wide delete now runs on the magic tables, through the
+ * same audited per-pair delete the schema-wide route uses, and it keeps the
+ * two guarantees a destructive bulk route owes:
+ *
+ * - ARCHIVAL IMMUTABILITY is checked for EVERY schema of the register before
+ *   ANY row is touched, so one retained schema refuses the whole request
+ *   instead of leaving the register half emptied.
+ * - It is ONE transaction, so a failure on the third table does not leave the
+ *   first two deleted.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service;
+
+use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\MagicMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Register;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Exception\ArchivalImmutableException;
+use OCA\OpenRegister\Service\SchemaDeletionService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IDBConnection;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionClass;
+use RuntimeException;
+
+/**
+ * The register-wide delete on the magic tables.
+ */
+class SchemaDeletionRegisterDeleteTest extends TestCase {
+
+	private const REGISTER_ID = 7;
+
+	/**
+	 * The real archival annotation, exactly as a schema descriptor declares it.
+	 *
+	 * @var array<string, array<string, array<string, string>>>
+	 */
+	private const ARCHIVAL_CONFIGURATION = [
+		'x-openregister-archival' => ['retention' => ['default' => 'P10Y']],
+	];
+
+	/**
+	 * @var IDBConnection&MockObject
+	 */
+	private IDBConnection $db;
+
+	/**
+	 * @var MagicMapper&MockObject
+	 */
+	private MagicMapper $magicMapper;
+
+	/**
+	 * @var SchemaMapper&MockObject
+	 */
+	private SchemaMapper $schemaMapper;
+
+	/**
+	 * @var AuditTrailMapper&MockObject
+	 */
+	private AuditTrailMapper $auditTrailMapper;
+
+	private SchemaDeletionService $service;
+
+	/**
+	 * Schemas the schema mapper resolves, by id.
+	 *
+	 * @var array<int, Schema>
+	 */
+	private array $schemas = [];
+
+	/**
+	 * Objects each schema's magic table holds, by schema id.
+	 *
+	 * @var array<int, array<int, ObjectEntity>>
+	 */
+	private array $rows = [];
+
+	/**
+	 * Wire the real service up with mocked collaborators.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->db = $this->createMock(IDBConnection::class);
+		$this->magicMapper = $this->createMock(MagicMapper::class);
+		$this->schemaMapper = $this->createMock(SchemaMapper::class);
+		$this->auditTrailMapper = $this->createMock(AuditTrailMapper::class);
+
+		$this->schemaMapper->method('find')->willReturnCallback(
+			function (int|string $id): Schema {
+				if (isset($this->schemas[(int)$id]) === false) {
+					throw new DoesNotExistException('no schema ' . $id);
+				}
+
+				return $this->schemas[(int)$id];
+			}
+		);
+		$this->magicMapper->method('tableExistsForRegisterSchema')->willReturnCallback(
+			fn (Register $register, Schema $schema): bool => isset($this->rows[(int)$schema->getId()])
+		);
+		$this->magicMapper->method('findAllInRegisterSchemaTable')->willReturnCallback(
+			function (Register $register, Schema $schema, ?int $limit = null, ?int $offset = null): array {
+				// One chunk per table: a second read (offset > 0) returns nothing.
+				if ((int)$offset > 0) {
+					return [];
+				}
+
+				return $this->rows[(int)$schema->getId()] ?? [];
+			}
+		);
+
+		$this->service = new SchemaDeletionService(
+			$this->db,
+			$this->magicMapper,
+			$this->createMock(RegisterMapper::class),
+			$this->schemaMapper,
+			$this->auditTrailMapper,
+			$this->createMock(LoggerInterface::class)
+		);
+
+	}//end setUp()
+
+	/**
+	 * Inject an id into an entity (Entity::$id is protected).
+	 *
+	 * @param object $entity The entity.
+	 * @param int    $id     The id to inject.
+	 *
+	 * @return mixed The same entity.
+	 */
+	private function makeEntity(object $entity, int $id): mixed {
+		$property = (new ReflectionClass($entity))->getProperty('id');
+		$property->setAccessible(true);
+		$property->setValue($entity, $id);
+
+		return $entity;
+	}//end makeEntity()
+
+	/**
+	 * Build the register, listing the given schema ids.
+	 *
+	 * @param array<int, int> $schemaIds The schema ids the register lists.
+	 *
+	 * @return Register The register.
+	 */
+	private function register(array $schemaIds): Register {
+		$register = $this->makeEntity(new Register(), self::REGISTER_ID);
+		$register->setSchemas($schemaIds);
+
+		return $register;
+	}//end register()
+
+	/**
+	 * Declare a schema, and the rows its magic table holds (null: no table).
+	 *
+	 * @param int                     $id       The schema id.
+	 * @param array<int, string>|null $uuids    UUIDs of the rows, or null for no table.
+	 * @param bool                    $archival Whether it declares `x-openregister-archival`.
+	 *
+	 * @return void
+	 */
+	private function givenSchema(int $id, ?array $uuids, bool $archival = false): void {
+		$schema = $this->makeEntity(new Schema(), $id);
+		$schema->setSlug('schema-' . $id);
+		$schema->setTitle('Schema ' . $id);
+		if ($archival === true) {
+			$schema->setConfiguration(self::ARCHIVAL_CONFIGURATION);
+		}
+
+		$this->schemas[$id] = $schema;
+
+		if ($uuids === null) {
+			return;
+		}
+
+		$this->rows[$id] = array_map(
+			static function (string $uuid) use ($id): ObjectEntity {
+				$object = new ObjectEntity();
+				$object->setUuid($uuid);
+				$object->setRegister((string)self::REGISTER_ID);
+				$object->setSchema((string)$id);
+				$object->setObject(['name' => $uuid]);
+
+				return $object;
+			},
+			$uuids
+		);
+	}//end givenSchema()
+
+	/**
+	 * Every schema of the register is emptied, every object audited, in one transaction.
+	 *
+	 * @return void
+	 */
+	public function testDeletesEveryPairOfTheRegisterAndAuditsEachObject(): void {
+		$this->givenSchema(id: 42, uuids: ['a-1', 'a-2']);
+		$this->givenSchema(id: 43, uuids: ['b-1']);
+		// Listed but never materialised: an ordinary state, skipped rather than thrown on.
+		$this->givenSchema(id: 44, uuids: null);
+
+		$this->magicMapper->method('deleteObjectsBySchema')->willReturnCallback(
+			fn (Register $register, Schema $schema, bool $hardDelete): int => count($this->rows[(int)$schema->getId()])
+		);
+		$this->auditTrailMapper->expects($this->exactly(3))->method('createAuditTrailEntry');
+		$this->db->expects($this->once())->method('beginTransaction');
+		$this->db->expects($this->once())->method('commit');
+		$this->db->expects($this->never())->method('rollBack');
+
+		$result = $this->service->deleteObjectsByRegister(register: $this->register([42, 43, 44]));
+
+		$this->assertSame(3, $result['deleted_count']);
+		$this->assertSame(['a-1', 'a-2', 'b-1'], $result['deleted_uuids']);
+		$this->assertSame(self::REGISTER_ID, $result['register_id']);
+
+	}//end testDeletesEveryPairOfTheRegisterAndAuditsEachObject()
+
+	/**
+	 * One archival schema refuses the WHOLE request, before any row is touched.
+	 *
+	 * The plain schema is listed first on purpose: a per-schema check inside the
+	 * delete loop would already have emptied it by the time it reached the
+	 * archival one.
+	 *
+	 * @return void
+	 */
+	public function testOneArchivalSchemaRefusesTheWholeRegisterAndDeletesNothing(): void {
+		$this->givenSchema(id: 42, uuids: ['a-1']);
+		$this->givenSchema(id: 43, uuids: ['b-1'], archival: true);
+
+		$this->magicMapper->expects($this->never())->method('deleteObjectsBySchema');
+		$this->auditTrailMapper->expects($this->never())->method('createAuditTrailEntry');
+		$this->db->expects($this->never())->method('beginTransaction');
+
+		try {
+			$this->service->deleteObjectsByRegister(register: $this->register([42, 43]));
+			$this->fail('Expected ArchivalImmutableException');
+		} catch (ArchivalImmutableException $e) {
+			$this->assertSame(403, $e->getCode());
+			$this->assertSame('schema-43', $e->toResponseBody()['schema']);
+		}
+
+	}//end testOneArchivalSchemaRefusesTheWholeRegisterAndDeletesNothing()
+
+	/**
+	 * A failure on a later table rolls the earlier ones back.
+	 *
+	 * @return void
+	 */
+	public function testAFailureOnALaterTableRollsEverythingBack(): void {
+		$this->givenSchema(id: 42, uuids: ['a-1']);
+		$this->givenSchema(id: 43, uuids: ['b-1']);
+
+		$this->magicMapper->method('deleteObjectsBySchema')->willReturnCallback(
+			static function (Register $register, Schema $schema, bool $hardDelete): int {
+				if ((int)$schema->getId() === 43) {
+					throw new RuntimeException('disk full');
+				}
+
+				return 1;
+			}
+		);
+		$this->db->expects($this->once())->method('beginTransaction');
+		$this->db->expects($this->once())->method('rollBack');
+		$this->db->expects($this->never())->method('commit');
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('disk full');
+
+		$this->service->deleteObjectsByRegister(register: $this->register([42, 43]));
+
+	}//end testAFailureOnALaterTableRollsEverythingBack()
+
+	/**
+	 * A register that lists a schema id nothing answers to still deletes the rest.
+	 *
+	 * @return void
+	 */
+	public function testAnUnresolvableSchemaIdIsSkipped(): void {
+		$this->givenSchema(id: 42, uuids: ['a-1']);
+
+		$this->magicMapper->method('deleteObjectsBySchema')->willReturn(1);
+
+		$result = $this->service->deleteObjectsByRegister(register: $this->register([42, 999]));
+
+		$this->assertSame(1, $result['deleted_count']);
+		$this->assertSame(['a-1'], $result['deleted_uuids']);
+
+	}//end testAnUnresolvableSchemaIdIsSkipped()
+}//end class


### PR DESCRIPTION
## What this fixes

openregister's `phpunit.xml` sets `defaultTestSuite="Unit Tests"`, and CI runs `phpunit -c phpunit.xml`, so only `tests/Unit` ever executes. The Db, Service and Integration suites, about 2,020 tests, have never run anywhere automated. A measurement run of those suites inside a real Nextcloud found 760 red results. Most are test rot, but six are real defects in shipped code.

This PR fixes the four distinct defects, deletes a stray file, and repairs one skip that was lying. It does not wire the suites into CI: that is a separate decision, and it needs the rot cleared first.

## 1. Search trails: a 500 on every list

`SearchTrail` lost its `publishedOnly` attribute in the 2026-03-17 branch overwrite, while the `published_only` column stayed. `Entity::fromRow()` throws `BadFunctionCallException` for a column the entity does not declare, and the mapper selects `*`, so reading any stored trail threw. Reproduced over HTTP: with one row in the table, `GET /api/search-trails` answers 500. It now answers 200.

**Entity or column?** The entity. The attribute went away as part of retiring object-level published metadata, but that change's own spec lists `SearchTrailMapper.published_only` as out of scope, kept as historical tracking data. The column stays, so the entity has to know about it. Nothing writes it any more, and new rows take the column default.

The guard hydrates a row carrying every column of the live table, so the next migration that adds a column without declaring it reddens.

## 2. File delete: a Node cast to string

`DeleteFileHandler::deleteFile()` accepts `Node|string|int` and cast the argument to string for its log line before asking whether it was a Node. A Files Node is not Stringable, so every Node caller died with "Object of class OC\Files\Node\File could not be converted to string". `MergeHandler` passes Nodes, so merging objects that carry files broke. The existing unit test had routed around the defect by passing an id.

## 3. OAS validation: valid documents rejected, messages unfilled

Every OAS report on a document with parameters carried 14 false errors, with messages like "The required properties ({missing}) are missing". Three causes, three fixes:

- opis resolves `$dynamicRef` through its `$recursiveRef` machinery, which only finds an anchor on a resource root. The OAS 3.1 meta-schema declares `$dynamicAnchor: meta` inside `$defs/schema`, so every parameter schema was validated against the document root and had to carry `openapi` and `info`. The validator now binds a `$dynamicRef` to the single anchor a one-resource schema declares, which is what a 2020-12 validator resolves it to. Ambiguous cases are left alone.
- opis writes `default` values into the data it validates. A default injected inside an `if`/`then` branch is then refused by `unevaluatedProperties`, which is how `allowEmptyValue` appeared on query parameters nobody sent one for. Defaults are off for validation now.
- `collectErrors()` reported `message()`, which is a template. It reports the formatted message now.

With the validator honest, the next real finding surfaced: the OAuth flow URLs ship relative while the meta-schema types them `format: uri`. `createOas()` anchors them to the instance, the same way it already does for the server URL.

## 4. Register-wide delete: a stub behind a live route

`POST /api/bulk/{register}/delete-register` called `ObjectService::deleteObjectsByRegister()`, a stub that threw "needs reimplementation using MagicMapper" on every request.

**Implement or refuse honestly?** Implement. `SchemaDeletionService` already owns the audited per-pair delete and the archival gate, and `RetentionRowScanner` already resolves a register to its magic tables, so this was resolution plus aggregation, not new machinery. A routed bulk endpoint that refuses forever is a dead route, and the frontend action menu offers it.

What a destructive whole-register route owes, and now pays:

- Archival immutability is checked for every schema of the register **before any row is touched**. One archival schema refuses the whole request with 403 `SCHEMA_ARCHIVAL_IMMUTABLE`. Checked inside the delete loop instead, a register listing a plain schema ahead of an archival one would be half emptied by the time the refusal arrived.
- All pairs are emptied in one transaction, so a failure on a later table rolls the earlier ones back.
- RBAC: the controller already required manage on the register. It now also requires manage on every schema the register lists, the gate `delete-objects` applies to one schema, and returns 403 naming the first schema that fails.
- `hardDelete` is accepted and normalised as on `delete-objects`. The default stays a soft delete.

Verified on a live instance: a register holding an archival schema answers 403 and keeps every row, and a plain register answers 200 and empties, with one audit entry per object.

## Also here

- The repository root tracked a 0-byte file named `--help`, committed with #3382. Nothing references it as a file, so it is gone.
- `AnonymisationFlowTest` probed `Ddn\Sapp\PDFDoc` while the package declares `ddn\sapp\`. PSR-4 lookup is case-sensitive, so the file skipped with "ddn/sapp is not installed" on every install that had it. With the probe fixed it reaches its next guard, which is honest: no fixture PDFs are checked in, so both tests still skip and now say why.

## Tests

Every fix has a test that fails before it and passes after, and every one was mutation-checked by reverting the fix line and watching the right test redden.

| Fix | Test | Mutation |
|---|---|---|
| 1 | `SearchTrailTest::testFromRowHydratesEveryColumnOfTheTable` | property removed, test errors with the production message |
| 2 | `DeleteFileHandlerTest::testDeleteAcceptsANodeWithoutResolvingIt` | cast moved back in front of the check |
| 3 | 6 tests in `OasRequestValidatorTest` and `OasServiceTest` | each of the four fixes reverted separately |
| 4 | 4 tests in `SchemaDeletionRegisterDeleteTest`, 1 in `ObjectServiceDeleteByRegisterTest`, 3 in `BulkControllerTest` | archival pre-check removed, pre-check moved into the loop, rollback removed, manage gate removed, archival catch removed, stub restored |

## Dark-suite files, before and after

Run inside a throwaway Nextcloud 34 with openregister enabled, on postgres 16.

| File | Before | After |
|---|---|---|
| `tests/Service/ServicesIntegrationTest.php` | 108 tests, 4 errors, 6 failures | 108 tests, 1 error, 6 failures |
| `tests/Service/FileActionsLifecycleIntegrationTest.php` | 1 test, 1 error | green |
| `tests/Service/OasValidationIntegrationTest.php` | 12 tests, 1 failure | green |
| `tests/Service/ObjectServiceIntegrationTest.php` | 64 tests, 8 errors, 1 failure | 64 tests, 7 errors, 1 failure |
| `tests/Integration/Pdf/AnonymisationFlowTest.php` | 2 skipped, false reason | 2 skipped, true reason |

The errors and failures left in those two files are pre-existing rot of other kinds, out of scope here.

## Gates, by exit code

| Gate | Exit |
|---|---|
| `phpunit --no-coverage tests/Unit/` | 0 (19,856 tests, 24 skipped) |
| `composer phpcs` | 0 |
| `phpmd lib text phpmd.xml` | 0 |
| `phpmd lib text phpmd-unusedparams.xml` | 0 |
| `phpstan analyse` (cold cache, private tmpDir) | 0, no errors |
| `hydra-gates` with `HYDRA_GATE_BASE_REF=origin/development` | 0, all 85 applicable gates ran and passed |

The first phpmd run failed on an `ElseExpression` this PR introduced, fixed in its own commit. The first hydra run exited 2 on gates 22 and 53 because ajv was not installed in the clone. After `npm install` both pass, and that is the run in the table.

The Unit suite also ran inside the Nextcloud container: 8 failures there, all environmental. Seven `MigrationVersionBumpCheckTest` cases shell out to `git`, which the Nextcloud image does not ship, and one flow timing test passes on its own and fails under machine load.

## Reviewing this

Start with fix 4: it is the only one that changes who may destroy data. The question worth your attention is whether requiring manage on every schema of the register is the right bar, or whether manage on the register alone should carry it.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
