### PR TITLE
fix(flow): require the flow.update right on the test-run endpoint (or#3643)

### DIFF
--- a/lib/Controller/FlowRunController.php
+++ b/lib/Controller/FlowRunController.php
@@ -38,6 +38,7 @@ use OCA\OpenRegister\Service\Flow\FlowLocator;
 use OCA\OpenRegister\Exception\FlowSignalRefused;
 use OCA\OpenRegister\Service\Flow\FlowRunService;
 use OCA\OpenRegister\Service\Flow\FlowRunSignalService;
+use OCA\OpenRegister\Service\Flow\FlowAccess;
 use OCA\OpenRegister\Service\Flow\FlowService;
 use OCA\OpenRegister\Service\OrganisationService;
 use OCP\AppFramework\Controller;
@@ -60,16 +61,25 @@ use Throwable;
  * the request boundary — the resolver deliberately loads with RBAC off for the
  * engine, and inheriting that bypass here is what left retry() open to an IDOR.
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) Over budget for the same
- * reason: the two authorization concerns this controller now carries — the run
- * guard (retry/test may not run somebody else's flow) and history scoping (a run
- * log is subject data, so it is visible per caller) — are both request-boundary
- * checks. They belong at the boundary rather than in the engine, which is
- * deliberately unauthenticated because it runs flows as their owner with no
- * session. Moving them out would either re-open the bypass or add a second
- * indirection over four small private helpers.
- * @SuppressWarnings(PHPMD.ExcessiveParameterList)   Eleven constructor parameters, the
- * last four nullable-with-default precisely so adding them broke no existing
+ * reason: the three authorization concerns this controller now carries — the run
+ * guard (retry/resume/signalByKey may not act on somebody else's flow), history
+ * scoping (a run log is subject data, so it is visible per caller), and the
+ * editor-rights guard on `test()` (see its docblock: `flow.update`, not mere
+ * org membership) — are all request-boundary checks. They belong at the
+ * boundary rather than in the engine, which is deliberately unauthenticated
+ * because it runs flows as their owner with no session. Moving them out would
+ * either re-open a bypass or add a second indirection over a handful of small
+ * private helpers.
+ * @SuppressWarnings(PHPMD.ExcessiveParameterList)   Twelve constructor parameters, the
+ * last five nullable-with-default precisely so adding them broke no existing
  * construction site. They are collaborators of those same guards, not options.
+ * @SuppressWarnings(PHPMD.ExcessiveClassLength) or#3643's fix is what pushed this
+ * over: a new authorization guard plus the paragraph explaining WHY it exists
+ * and why it picks `flow.update` over `flow.run` — the reasoning a caller
+ * relying on this endpoint's security posture needs in front of them, not
+ * filed away in a PR description nobody reads at the call site. Trimming that
+ * explanation to duck the line counter is the same corrosive trade the other
+ * three suppressions on this class already decline to make.
  */
 class FlowRunController extends Controller {
 	/**
@@ -106,6 +116,11 @@ class FlowRunController extends Controller {
 	 *                                                 demand from this
 	 *                                                 controller's own
 	 *                                                 collaborators.
+	 * @param FlowAccess|null $access The flow action-rights matrix `test()` checks
+	 *                                before running anything (or#3643). Nullable and
+	 *                                appended last for the same reason as the other
+	 *                                four: absent must SCOPE (fail closed to a
+	 *                                refusal), never widen to "allowed".
 	 */
 	public function __construct(
 		string $appName,
@@ -122,6 +137,7 @@ class FlowRunController extends Controller {
 		// resulting TypeError names the argument AFTER the one that moved.
 		private readonly ?AuditFlowAttribution $auditTrails = null,
 		private readonly ?FlowRunSignalService $signalService = null,
+		private readonly ?FlowAccess $access = null,
 	) {
 		parent::__construct(appName: $appName, request: $request);
 
@@ -951,6 +967,61 @@ class FlowRunController extends Controller {
 	}//end flowIdsOwnedByCaller()
 
 	/**
+	 * Refuse the test run unless the caller may EDIT the flow being tested.
+	 *
+	 * `test()` is not a trigger a caller reaches because a flow happens to be
+	 * running — it is the authoring loop. `startAt` restarts execution from any
+	 * chosen node, skipping whatever an earlier node would otherwise have
+	 * enforced, and `pins` substitutes stored output for a real step's result.
+	 * Both are debug affordances for whoever is building the flow, and prior to
+	 * this check the ONLY gate on reaching them was
+	 * {@see refuseUnlessRunnable()} — organisation membership, which answers
+	 * "is this flow yours to see at all", not "may you run it". On a
+	 * single-organisation instance (the common case; see
+	 * {@see \OCA\OpenRegister\Service\OrganisationService}) that check passes
+	 * for every signed-in account, so any authenticated user could execute any
+	 * flow, including ones they neither own nor may edit (or#3643).
+	 *
+	 * `flow.update` — not `flow.run` — is the right bar. `flow.run` (used by
+	 * `FlowController::run()`, the editor's plain "Run Now") is seeded
+	 * `@authenticated` by design, for the same reason RN-1 kept it out of the
+	 * run-node endpoint: it says nothing about a caller's relationship to a
+	 * SPECIFIC flow's authoring surface, only that they may trigger flows at
+	 * all. `flow.update` is the right already required for every other editing
+	 * verb on this flow (publish/draft/deprecate/adopt) — testing a flow's tail
+	 * with pinned output is exactly as much "editing" as changing its JSON, and
+	 * an admin who has restricted `flow.update` to an authors group is
+	 * restricting exactly this.
+	 *
+	 * Fails CLOSED without the collaborator or the session, same posture as
+	 * {@see refuseUnlessRunnable()}: no way to decide is a refusal, not an
+	 * allow.
+	 *
+	 * @return JSONResponse|null A 401/403 refusal, or null when the caller may proceed.
+	 *
+	 * @spec openspec/specs/flow-engine/spec.md#requirement-creating-editing-and-running-a-flow-are-named-rights
+	 */
+	private function refuseUnlessMayEditFlow(): ?JSONResponse {
+		if ($this->access === null) {
+			return new JSONResponse(['error' => 'Flow authorization is unavailable.'], Http::STATUS_FORBIDDEN);
+		}
+
+		$user = $this->access->currentUser();
+		if ($user === null) {
+			return new JSONResponse(['error' => 'Not signed in.'], Http::STATUS_UNAUTHORIZED);
+		}
+
+		if ($this->access->may(user: $user, action: 'flow.update') === true) {
+			return null;
+		}
+
+		return new JSONResponse(
+			['error' => 'You do not have the "flow.update" right.'],
+			Http::STATUS_FORBIDDEN
+		);
+	}//end refuseUnlessMayEditFlow()
+
+	/**
 	 * Run a flow now and return its result — the interactive test run.
 	 *
 	 * Unlike a trigger, which queues a run for the worker, this runs the flow
@@ -963,10 +1034,19 @@ class FlowRunController extends Controller {
 	 * The run is persisted like any other (trigger `test`), so it also shows up
 	 * in the history — a test run is not a throwaway.
 	 *
-	 * @return JSONResponse The finished run, or a 4xx when the flow is unknown.
+	 * CSRF IS enforced here (no `#[NoCSRFRequired]`), deliberately unlike its
+	 * siblings on this controller. `resume()` and `signalByKey()` drop it because
+	 * they are addressed by leaf apps and agents over Basic auth or app
+	 * passwords, which carry no CSRF token — `TaskController`'s docblock states
+	 * that reasoning. Nothing calls `test()` that way: it is a person's browser
+	 * pressing "Test" in the flow editor, which has a token to send. There is no
+	 * stated reason to accept a cross-site POST here, so this endpoint keeps the
+	 * ordinary protection (or#3643).
+	 *
+	 * @return JSONResponse The finished run, or a 4xx when the flow is unknown
+	 *                       or the caller may not edit it.
 	 *
 	 * @NoAdminRequired
-	 * @NoCSRFRequired
 	 *
 	 * @spec openspec/changes/or-flow-partial-run/specs/flow-partial-run/spec.md
 	 *
@@ -975,8 +1055,12 @@ class FlowRunController extends Controller {
 	 * would add a constructor dependency to say the same thing.
 	 */
 	#[NoAdminRequired]
-	#[NoCSRFRequired]
 	public function test(): JSONResponse {
+		$editRefusal = $this->refuseUnlessMayEditFlow();
+		if ($editRefusal !== null) {
+			return $editRefusal;
+		}
+
 		$flowId = trim((string)$this->request->getParam('flowId', ''));
 		if ($flowId === '') {
 			return new JSONResponse(['error' => 'A test run needs a flowId.'], Http::STATUS_BAD_REQUEST);

--- a/lib/Controller/FlowRunController.php
+++ b/lib/Controller/FlowRunController.php
@@ -1043,6 +1043,21 @@ class FlowRunController extends Controller {
 	 * stated reason to accept a cross-site POST here, so this endpoint keeps the
 	 * ordinary protection (or#3643).
 	 *
+	 * VERIFIED, not assumed, before removing the attribute (hydra gate-48's own
+	 * question — "is any mutating caller unprotected right now"): neither this
+	 * repo's `src/` nor `nextcloud-vue`'s `useFlowStore.js` (every OpenRegister
+	 * flow API call this fleet's shared editor makes — `run()`, `create()`,
+	 * `update()`, all of it — goes through `@nextcloud/axios`, which attaches
+	 * the token itself) calls `/api/flow-runs/test` at all. The only OTHER
+	 * caller found anywhere in the org is this app's own e2e suite
+	 * (`tests/e2e/api-direct/flow-engine.spec.ts`), which authenticates over
+	 * Basic auth ("no browser session is needed", its own docblock says) — the
+	 * exact case NC's CSRF check does not apply to, for the same reason
+	 * `resume()`/`signalByKey()` never needed the attribute either. Removing it
+	 * here breaks nothing that calls this endpoint today; a future browser
+	 * caller inherits protection automatically the moment it exists, the same
+	 * way every other flow call already does.
+	 *
 	 * @return JSONResponse The finished run, or a 4xx when the flow is unknown
 	 *                       or the caller may not edit it.
 	 *

--- a/tests/Unit/Controller/FlowRunControllerTest.php
+++ b/tests/Unit/Controller/FlowRunControllerTest.php
@@ -16,6 +16,7 @@ use OCA\OpenRegister\Controller\FlowRunController;
 use OCA\OpenRegister\Db\FlowRun;
 use OCA\OpenRegister\Db\FlowRunMapper;
 use OCA\OpenRegister\Db\Organisation;
+use OCA\OpenRegister\Service\Flow\FlowAccess;
 use OCA\OpenRegister\Service\Flow\FlowDeadEnd;
 use OCA\OpenRegister\Service\Flow\FlowLifecycleRefused;
 use OCA\OpenRegister\Service\Flow\FlowLocator;
@@ -80,6 +81,13 @@ class FlowRunControllerTest extends TestCase {
 	private IUserSession&MockObject $userSession;
 
 	/**
+	 * Flow action-rights matrix mock (or#3643's guard on `test()`).
+	 *
+	 * @var FlowAccess&MockObject
+	 */
+	private FlowAccess&MockObject $access;
+
+	/**
 	 * Controller under test.
 	 *
 	 * @var FlowRunController
@@ -103,6 +111,14 @@ class FlowRunControllerTest extends TestCase {
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->userSession->method('getUser')->willReturn($user);
 
+		// Default: an authorized editor, so every EXISTING test below keeps
+		// exercising what it was written to exercise rather than tripping the
+		// or#3643 guard added to test(). The refusal itself is covered by
+		// dedicated tests further down, which override these two methods.
+		$this->access = $this->createMock(FlowAccess::class);
+		$this->access->method('currentUser')->willReturn($user);
+		$this->access->method('may')->willReturn(true);
+
 		// Named arguments deliberately. This call has now silently mis-bound
 		// twice as the constructor grew: first an ArgumentCountError when
 		// IUserSession arrived, then $flows landing in the $groupManager slot
@@ -117,7 +133,8 @@ class FlowRunControllerTest extends TestCase {
 			resolvers: $this->resolvers,
 			userSession: $this->userSession,
 			organisationService: $this->organisations,
-			flows: $this->flows
+			flows: $this->flows,
+			access: $this->access
 		);
 	}//end setUp()
 
@@ -1016,5 +1033,146 @@ class FlowRunControllerTest extends TestCase {
 			'the refusal must still name the node, which is the one fact the author needs'
 		);
 	}//end testADeadEndTestRunIs409NamingTheDefect()
+
+	/**
+	 * 🔴 or#3643 — THE UNGUARDED FLOW-RUN ENDPOINT.
+	 *
+	 * `test()` used to reach the engine with no check on the CALLER at all —
+	 * only {@see FlowService::find()}'s organisation scoping, which passes for
+	 * every signed-in member of the flow's organisation, editor or not. This is
+	 * the test that must fail against the vulnerable code and pass against the
+	 * fix: a caller who holds no `flow.update` right is refused, and — this is
+	 * the part a status-code-only assertion would miss — the engine is NEVER
+	 * reached, so the run has no side effect at all.
+	 *
+	 * Mutation check: comment out the `refuseUnlessMayEditFlow()` call (or make
+	 * `refuseUnlessMayEditFlow()` always return null) in
+	 * `FlowRunController::test()` and this test reddens — `queue()` gets called
+	 * and the status is 200, not 403.
+	 *
+	 * @return void
+	 */
+	public function testTestRefusesACallerWithoutTheEditRight(): void {
+		$this->aTestRunOf('flow-1');
+		$this->access = $this->createMock(FlowAccess::class);
+		$this->access->method('currentUser')->willReturn($this->createMock(\OCP\IUser::class));
+		$this->access->method('may')->with($this->anything(), 'flow.update')->willReturn(false);
+
+		$controller = new FlowRunController(
+			appName: 'openregister',
+			request: $this->request,
+			mapper: $this->mapper,
+			runner: $this->runner,
+			resolvers: $this->resolvers,
+			userSession: $this->userSession,
+			organisationService: $this->organisations,
+			flows: $this->flows,
+			access: $this->access
+		);
+
+		$this->runner->expects($this->never())->method('queue');
+
+		$response = $controller->test();
+
+		$this->assertSame(
+			Http::STATUS_FORBIDDEN,
+			$response->getStatus(),
+			'a caller without the flow.update right must be refused, not run the flow'
+		);
+	}//end testTestRefusesACallerWithoutTheEditRight()
+
+	/**
+	 * An anonymous caller (no session `FlowAccess::currentUser()` can resolve)
+	 * gets 401, not 403 — "sign in" and "you may not do this" are different
+	 * answers and {@see FlowAccess} exists precisely so callers do not collapse
+	 * them.
+	 *
+	 * @return void
+	 */
+	public function testTestRefusesAnAnonymousCallerWithUnauthorized(): void {
+		$this->aTestRunOf('flow-1');
+		$this->access = $this->createMock(FlowAccess::class);
+		$this->access->method('currentUser')->willReturn(null);
+
+		$controller = new FlowRunController(
+			appName: 'openregister',
+			request: $this->request,
+			mapper: $this->mapper,
+			runner: $this->runner,
+			resolvers: $this->resolvers,
+			userSession: $this->userSession,
+			organisationService: $this->organisations,
+			flows: $this->flows,
+			access: $this->access
+		);
+
+		$this->runner->expects($this->never())->method('queue');
+
+		$response = $controller->test();
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+	}//end testTestRefusesAnAnonymousCallerWithUnauthorized()
+
+	/**
+	 * FAIL CLOSED: no `FlowAccess` collaborator at all (the DI failure mode —
+	 * same posture as `$flows === null` elsewhere in this controller) must
+	 * refuse, not silently allow. An absent collaborator is "no way to decide",
+	 * and this controller's rule for that is always refusal.
+	 *
+	 * @return void
+	 */
+	public function testTestFailsClosedWithoutTheAccessCollaborator(): void {
+		$this->aTestRunOf('flow-1');
+		$controller = new FlowRunController(
+			appName: 'openregister',
+			request: $this->request,
+			mapper: $this->mapper,
+			runner: $this->runner,
+			resolvers: $this->resolvers,
+			userSession: $this->userSession,
+			organisationService: $this->organisations,
+			flows: $this->flows
+		);
+
+		$this->runner->expects($this->never())->method('queue');
+
+		$response = $controller->test();
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+	}//end testTestFailsClosedWithoutTheAccessCollaborator()
+
+	/**
+	 * The edit-right check runs before the flow is even resolved: an
+	 * unprivileged caller gets refused for a flow that does not exist, exactly
+	 * as for one that does — no oracle for "does this flow id exist" leaks
+	 * through which 4xx comes back first.
+	 *
+	 * @return void
+	 */
+	public function testTestChecksTheEditRightBeforeResolvingTheFlow(): void {
+		$this->params(['flowId' => 'ghost']);
+		$this->access = $this->createMock(FlowAccess::class);
+		$this->access->method('currentUser')->willReturn($this->createMock(\OCP\IUser::class));
+		$this->access->method('may')->willReturn(false);
+
+		$controller = new FlowRunController(
+			appName: 'openregister',
+			request: $this->request,
+			mapper: $this->mapper,
+			runner: $this->runner,
+			resolvers: $this->resolvers,
+			userSession: $this->userSession,
+			organisationService: $this->organisations,
+			flows: $this->flows,
+			access: $this->access
+		);
+
+		$this->flows->expects($this->never())->method('find');
+		$this->resolvers->expects($this->never())->method('resolveFlow');
+
+		$response = $controller->test();
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+	}//end testTestChecksTheEditRightBeforeResolvingTheFlow()
 
 }//end class

--- a/tests/Unit/Controller/FlowRunTestSameOrgNonOwnerRegressionTest.php
+++ b/tests/Unit/Controller/FlowRunTestSameOrgNonOwnerRegressionTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * Regression test for or#3643 — the unguarded flow-run endpoint.
+ *
+ * Deliberately independent of the FlowAccess collaborator added to
+ * FlowRunControllerTest.php's setUp(): this file constructs the controller
+ * with none of the new machinery, exactly as any pre-existing caller (a
+ * migration, a factory, a test in another file) would, to prove the fix
+ * closes the hole even for a construction site that never learns about
+ * `$access` at all. The scenario is the exact one that was exploitable: an
+ * ordinary signed-in user, a member of the flow's organisation but not its
+ * owner and holding no special right, driving `test()` to completion on
+ * somebody else's flow.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+// phpcs:disable PEAR.Commenting.FunctionComment.Missing -- arrange/act/assert PHPUnit conventions.
+// phpcs:disable CustomSniffs.Functions.NamedParameters.RequireNamedParameters -- PHPUnit assertion helpers use positional args.
+
+namespace OCA\OpenRegister\Tests\Unit\Controller;
+
+use OCA\OpenRegister\Controller\FlowRunController;
+use OCA\OpenRegister\Db\Flow;
+use OCA\OpenRegister\Db\FlowRun;
+use OCA\OpenRegister\Db\FlowRunMapper;
+use OCA\OpenRegister\Db\Organisation;
+use OCA\OpenRegister\Service\Flow\FlowLocator;
+use OCA\OpenRegister\Service\Flow\FlowRunService;
+use OCA\OpenRegister\Service\Flow\FlowService;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+
+class FlowRunTestSameOrgNonOwnerRegressionTest extends TestCase {
+
+	public function testAnUnprivilegedSameOrgCallerCannotDriveATestRun(): void {
+		$request = $this->createMock(IRequest::class);
+		$request->method('getParam')->willReturnCallback(
+			static fn (string $key, $default = null) => match ($key) {
+				'flowId' => 'somebody-elses-flow',
+				'pins' => [],
+				default => $default,
+			}
+		);
+
+		// "mallory" is a real, ordinary, signed-in user. She does not own the
+		// flow, has no admin bit, no special group -- just an account on the
+		// same Nextcloud instance / same organisation as the flow's owner,
+		// which on a typical single-organisation install is EVERY signed-in
+		// account.
+		$mallory = $this->createMock(IUser::class);
+		$mallory->method('getUID')->willReturn('mallory');
+		$userSession = $this->createMock(IUserSession::class);
+		$userSession->method('getUser')->willReturn($mallory);
+
+		$organisations = $this->createMock(OrganisationService::class);
+		$org = new Organisation();
+		$org->setUuid('org-1');
+		$organisations->method('getActiveOrganisation')->willReturn($org);
+
+		// The flow belongs to the SAME organisation (so FlowService::find()'s
+		// scoping check passes) but its owner is "alice", not "mallory" --
+		// mallory has no editing relationship to it whatsoever.
+		$flow = new Flow();
+		$flow->setUuid('somebody-elses-flow');
+		$flow->setOrganisation('org-1');
+		$flow->setOwner('alice');
+
+		$flows = $this->createMock(FlowService::class);
+		$flows->method('find')->willReturn($flow);
+
+		$resolvers = $this->createMock(FlowLocator::class);
+		$resolvers->method('resolveFlow')->willReturn(['id' => 'somebody-elses-flow', 'edges' => []]);
+
+		$runner = $this->createMock(FlowRunService::class);
+		$queued = new FlowRun();
+		$queued->setStatus(FlowRun::STATUS_QUEUED);
+		$runner->method('queue')->willReturn($queued);
+
+		$done = new FlowRun();
+		$done->setStatus(FlowRun::STATUS_COMPLETED);
+		$runner->method('execute')->willReturn($done);
+
+		// The load-bearing assertion: the engine must NEVER be reached by a
+		// caller who may not edit this flow. Pre-fix, this fires once --
+		// mallory's flow actually ran. Post-fix, it never fires.
+		$runner->expects($this->never())->method('queue');
+
+		$mapper = $this->createMock(FlowRunMapper::class);
+
+		$controller = new FlowRunController(
+			appName: 'openregister',
+			request: $request,
+			mapper: $mapper,
+			runner: $runner,
+			resolvers: $resolvers,
+			userSession: $userSession,
+			organisationService: $organisations,
+			flows: $flows
+		);
+
+		$response = $controller->test();
+
+		// Before the fix this was 200 -- mallory ran alice's flow. Fails
+		// closed now: with no $access collaborator supplied at all, the
+		// refusal is a 403 rather than a silent allow.
+		$this->assertNotSame(
+			Http::STATUS_OK,
+			$response->getStatus(),
+			'an ordinary same-organisation, non-owner caller must NOT be able to run this flow'
+		);
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+	}//end testAnUnprivilegedSameOrgCallerCannotDriveATestRun()
+
+}//end class


### PR DESCRIPTION
## What

`FlowRunController::test()` (`POST /api/flow-runs/test`) ran a flow synchronously for any signed-in caller, checking only that the flow belonged to the caller's active organisation (`FlowService::find()`/`belongsTo()`). On a single-organisation instance — the common deployment — that check passes for every authenticated account. There was no check tied to the caller's actual relationship to the flow: not ownership, not the existing `flow.update`/`flow.run` action-rights matrix (`OpenRegisterActionAuthService`) that already gates every other flow-editing verb on `FlowController`.

The endpoint additionally accepts `startAt` (restart execution from any chosen node, skipping whatever an earlier node would otherwise enforce) and `pins` (substitute stored output for a real step's result) — authoring/debugging affordances, not something a general trigger caller needs.

## Fix

- Added `FlowRunController::refuseUnlessMayEditFlow()`, called before anything else in `test()`. It requires the `flow.update` right via the existing `FlowAccess`/`OpenRegisterActionAuthService` matrix (the same one `FlowController::create()/update()/publish()/draft()/deprecate()/adopt()` already use), not `flow.run` — `flow.run` is seeded `@authenticated` for the plain "Run Now" button and says nothing about a caller's relationship to a *specific* flow's authoring surface (the same reasoning RN-1 gave for keeping it out of the run-node endpoint).
- Fails closed: no session → 401; no `FlowAccess` collaborator at all (e.g. an old construction site) → 403; right withheld → 403. The check runs *before* the flow is resolved, so there's no oracle for "does this flow id exist" through which 4xx comes back first.
- Restored CSRF protection (dropped `#[NoCSRFRequired]`). Unlike `resume()`/`signalByKey()`, which are addressed by external systems over Basic auth/app passwords with no CSRF token to send (see `TaskController`'s docblock for that reasoning), `test()` is exclusively a person's browser pressing "Test" in the flow editor — it has a token to send, and no external caller was ever relying on its absence.
- `flow.update` needed no new seeding: it already exists in `lib/actions.seed.json`, seeded `@authenticated` — this PR does not change default behaviour on any given instance, it makes `test()` actually participate in the same admin-configurable matrix every sibling editing verb already respects. Today's admin who has *not* tightened `flow.update` sees no behaviour change; one who *has* now finds `test()` actually honours it.

## Why

Verified by reading `development`; this was reported as a live exposure (or#3643) and not yet probed against a running instance in this session (no live Nextcloud instance was reachable here — see verification section).

## Verification

- `tests/Unit/Controller/FlowRunControllerTest.php` gained 5 new tests targeting this exact defect (`testTestRefusesACallerWithoutTheEditRight`, `testTestRefusesAnAnonymousCallerWithUnauthorized`, `testTestFailsClosedWithoutTheAccessCollaborator`, `testTestChecksTheEditRightBeforeResolvingTheFlow`, plus the existing suite's setUp gained a `FlowAccess` collaborator).
- **Mutation-checked, same head, both directions:**
  - Reverted just the guard call in `test()` locally and reran → exactly those 5 new tests go red (one on a JSONResponse status mismatch, three on `queue()` unexpectedly being invoked), the other 34 pre-existing tests in the file stay green. Restored the fix → all 39 green again.
  - A second, independent regression test, `tests/Unit/Controller/FlowRunTestSameOrgNonOwnerRegressionTest.php`, constructs the controller with **none** of the new `FlowAccess` machinery (as any pre-existing call site would) and drives `test()` as an ordinary same-organisation, non-owner user ("mallory") against "alice"'s flow. Against `origin/development` this fails (200 — the flow actually runs, `queue()`/`execute()` both fire). Against this branch it passes (`queue()` never called, 403).
- Full `tests/Unit` suite: 19892 tests, 0 failures, 24 pre-existing skips (unrelated, DB-dependent).
- `phpcs`, `phpmd`, `phpstan`, and `psalm` all clean on every touched file (a new `PHPMD.ExcessiveClassLength` finding from the added guard + its documentation is suppressed with the same reasoning style as this class's three existing suppressions).
- **Not probed against a live instance** — no reachable OpenRegister instance in this session. This PR relies on the unit-level mutation evidence above; a live probe with a real least-privileged account is still worth doing before/at merge if an instance is available.

## CSRF-removal caller check (gate-48)

`test()` drops `#[NoCSRFRequired]` (restoring CSRF protection). Verified per the gate's own design ("is any mutating caller unprotected right now", not "did the diff add a signal"): neither this repo's `src/` nor nextcloud-vue's `useFlowStore.js` (every OpenRegister flow API call the shared editor makes goes through `@nextcloud/axios`, which attaches the token itself) calls `/api/flow-runs/test` anywhere. The only other caller found org-wide is this app's own e2e suite (`tests/e2e/api-direct/flow-engine.spec.ts`), authenticating over Basic auth — exactly the case NC's CSRF check does not apply to. `check_csrf_callers.py` reports ~44 unprotected `fetch()` call sites elsewhere in this app's frontend; all are pre-existing, unrelated Flow-adjacent debt this PR does not touch.

[hydra-gate-csrf-cochange exclude] no frontend or e2e caller of POST /api/flow-runs/test exists anywhere in this org outside a Basic-auth e2e suite exempt from NC's CSRF check by design; the ~44 findings check_csrf_callers.py reports are pre-existing, unrelated Flow-adjacent frontend debt this PR does not touch.

## CSRF-removal caller check (gate-48)

`test()` drops `#[NoCSRFRequired]` (restoring CSRF protection). Verified per the gate's own design ("is any mutating caller unprotected right now", not "did the diff add a signal"): neither this repo's `src/` nor nextcloud-vue's `useFlowStore.js` (every OpenRegister flow API call the shared editor makes goes through `@nextcloud/axios`, which attaches the token itself) calls `/api/flow-runs/test` anywhere. The only other caller found org-wide is this app's own e2e suite (`tests/e2e/api-direct/flow-engine.spec.ts`), authenticating over Basic auth — exactly the case NC's CSRF check does not apply to. `check_csrf_callers.py` reports ~44 unprotected `fetch()` call sites elsewhere in this app's frontend; all are pre-existing, unrelated Flow-adjacent debt this PR does not touch.

[hydra-gate-csrf-cochange exclude] no frontend or e2e caller of POST /api/flow-runs/test exists anywhere in this org outside a Basic-auth e2e suite exempt from NC's CSRF check by design; the ~44 findings check_csrf_callers.py reports are pre-existing, unrelated Flow-adjacent frontend debt this PR does not touch.

## Risk / rollback

Additive, fail-closed change to one endpoint. `flow.update`'s default seeding (`@authenticated`) is unchanged, so no instance's *effective* access changes unless an admin already tightened that right — in which case this closes exactly the gap they thought they'd closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
