### PR TITLE
fix(filters): both filter spellings mean the same filter, and an unknown key warns

### DIFF
--- a/lib/Controller/AggregationController.php
+++ b/lib/Controller/AggregationController.php
@@ -45,14 +45,17 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Controller;
 
 use InvalidArgumentException;
+use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Exception\NotAuthorizedException;
 use OCA\OpenRegister\Service\Aggregation\AggregationQuery;
 use OCA\OpenRegister\Service\Aggregation\AggregationRunner;
 use OCA\OpenRegister\Service\Aggregation\TimeseriesRequestValidator;
+use OCA\OpenRegister\Support\FilterParams;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
 
 class AggregationController extends Controller {
@@ -63,15 +66,88 @@ class AggregationController extends Controller {
 	 * @param IRequest $request The current request.
 	 * @param AggregationRunner $runner The aggregation runner.
 	 * @param TimeseriesRequestValidator $validator Ad-hoc request validator.
+	 * @param LoggerInterface|null $logger Where the unknown-filter-key warning goes (optional).
 	 */
 	public function __construct(
 		string $appName,
 		IRequest $request,
 		private readonly AggregationRunner $runner,
 		private readonly TimeseriesRequestValidator $validator,
+		private readonly ?LoggerInterface $logger = null,
 	) {
 		parent::__construct(appName: $appName, request: $request);
 	}//end __construct()
+
+	/**
+	 * Read this request's filter map in BOTH spellings.
+	 *
+	 * The aggregations have always read `filter[x]=v` and dropped a bare
+	 * `x=v`, while object search did the opposite, so one query answered two
+	 * different numbers depending on which sibling endpoint served it and
+	 * neither errored (openregister#3611). A bare key now joins the filter
+	 * map here, on one condition: it must name a property the schema
+	 * declares. A parameter that names nothing (a cache-buster, a stray
+	 * `v=2`) is still ignored, exactly as before, because turning those into
+	 * filters would silently zero every widget that carries one.
+	 *
+	 * Whatever the endpoint could not make sense of is logged once, naming
+	 * the keys, the endpoint and the schema. A warning, not a refusal: a 400
+	 * would break every caller on the old spelling in the same minute.
+	 *
+	 * The schema is looked up only when the request carries something that
+	 * could be a filter, so the common control-params-only request pays
+	 * nothing. The lookup is the register-scoped one `runAdhocByRef()` will
+	 * repeat, so both resolve the same schema.
+	 *
+	 * @param string $action The controller action, keying its control params.
+	 * @param string $register Register reference from the URL.
+	 * @param string $schema Schema reference from the URL.
+	 * @param Schema|null $schemaEntity Already-resolved schema, when the caller has one.
+	 *
+	 * @return array<string, mixed> The normalised filter map.
+	 *
+	 * @throws RuntimeException When the schema cannot be resolved.
+	 *
+	 * @spec openspec/specs/zoeken-filteren/spec.md#requirement-both-filter-spellings-mean-the-same-filter-on-object-search-and-the-aggregations
+	 */
+	private function resolveFilter(
+		string $action,
+		string $register,
+		string $schema,
+		?Schema $schemaEntity = null,
+	): array {
+		$bracket = (array)($this->request->getParam(FilterParams::FILTER_KEY, []));
+		$params = $this->request->getParams();
+		$controlParams = FilterParams::AGGREGATION_CONTROL_PARAMS[$action];
+
+		if ($bracket === []
+			&& FilterParams::hasBareCandidates(params: $params, controlParams: $controlParams) === false
+		) {
+			return [];
+		}
+
+		$resolvedSchema = $schemaEntity;
+		if ($resolvedSchema === null) {
+			$resolvedSchema = $this->runner->findSchema(schemaRef: $schema, registerRef: $register);
+		}
+
+		$normalised = FilterParams::forAggregation(
+			bracket: $bracket,
+			params: $params,
+			controlParams: $controlParams,
+			properties: ($resolvedSchema->getProperties() ?? [])
+		);
+
+		FilterParams::warnUnknownKeys(
+			logger: $this->logger,
+			keys: $normalised['unknown'],
+			endpoint: 'aggregation#' . $action,
+			register: $register,
+			schema: $schema
+		);
+
+		return $normalised['filter'];
+	}//end resolveFilter()
 
 	/**
 	 * Run a named aggregation declared on the schema.
@@ -105,10 +181,10 @@ class AggregationController extends Controller {
 			// context: `$currentUser` is the only placeholder the resolver
 			// knows, so a per-tenant figure declared once could not be asked
 			// for per tenant.
-			$extraFilter = $this->request->getParam('filter', []);
-			if (is_array($extraFilter) === false) {
-				$extraFilter = [];
-			}
+			//
+			// Both spellings narrow: `filter[administrationId]=X` and a bare
+			// `administrationId=X` reach the runner as the same constraint.
+			$extraFilter = $this->resolveFilter(action: 'aggregate', register: $register, schema: $schema);
 
 			$result = $this->runner->run(
 				registerRef: $register,
@@ -161,8 +237,13 @@ class AggregationController extends Controller {
 	public function value(string $register, string $schema): JSONResponse {
 		$metric = (string)$this->request->getParam('metric', 'count');
 		$field = $this->request->getParam('field');
-		$filter = (array)($this->request->getParam('filter', []));
 		$metrics = $this->parseMetricsParam();
+
+		try {
+			$filter = $this->resolveFilter(action: 'value', register: $register, schema: $schema);
+		} catch (RuntimeException $e) {
+			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_NOT_FOUND);
+		}
 
 		$resolvedField = $field;
 		if ($field === '') {
@@ -292,12 +373,17 @@ class AggregationController extends Controller {
 	public function grouped(string $register, string $schema): JSONResponse {
 		$metric = (string)$this->request->getParam('metric', 'count');
 		$field = $this->request->getParam('field');
-		$filter = (array)($this->request->getParam('filter', []));
 		$metrics = $this->parseMetricsParam();
 
 		$groupFields = $this->parseGroupByParam();
 		if (count($groupFields) === 0) {
 			return new JSONResponse(['error' => 'groupBy is required'], Http::STATUS_BAD_REQUEST);
+		}
+
+		try {
+			$filter = $this->resolveFilter(action: 'grouped', register: $register, schema: $schema);
+		} catch (RuntimeException $e) {
+			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_NOT_FOUND);
 		}
 
 		// A single field keeps the pre-existing `{field: ...}` shape
@@ -454,7 +540,12 @@ class AggregationController extends Controller {
 			'to' => $this->request->getParam('to'),
 			'metric' => $this->request->getParam('metric', 'count'),
 			'metricField' => $this->request->getParam('metricField'),
-			'filter' => (array)($this->request->getParam('filter', [])),
+			'filter' => $this->resolveFilter(
+				action: 'timeseries',
+				register: $register,
+				schema: $schema,
+				schemaEntity: $schemaEntity
+			),
 			'cumulative' => $this->request->getParam('cumulative', false),
 		];
 

--- a/lib/Controller/AggregationController.php
+++ b/lib/Controller/AggregationController.php
@@ -58,6 +58,16 @@ use OCP\IRequest;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) The count went to the
+ * threshold when reading both filter spellings (openregister#3611) added three
+ * references: `FilterParams` for the grammar, `Schema` to pass the already
+ * resolved entity into it, and a logger for the one warning an unknown key
+ * raises. The cheap way back under the limit is to re-resolve the schema
+ * instead of passing it, which would let the validator police one schema's
+ * property list while the aggregate ran over another's, and that is exactly
+ * the mismatch `timeseries()` resolves the schema up front to avoid.
+ */
 class AggregationController extends Controller {
 	/**
 	 * Constructor.

--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -36,6 +36,7 @@ use DateTime;
 use OCA\OpenRegister\Db\AuditTrailMapper;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Exception\AppendOnlyException;
 use OCA\OpenRegister\Exception\ArchivalImmutableException;
@@ -55,6 +56,7 @@ use OCA\OpenRegister\Service\FileService;
 use OCA\OpenRegister\Service\ImportService;
 use OCA\OpenRegister\Service\ObjectService;
 use OCA\OpenRegister\Service\WebhookService;
+use OCA\OpenRegister\Support\FilterParams;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -1045,6 +1047,47 @@ class ObjectsController extends Controller {
 	}//end resolveRegisterSchemaIds()
 
 	/**
+	 * Log one warning for the filter keys that name no property of the schema.
+	 *
+	 * Such a filter answers `1 = 0`, so the caller gets an empty list that is
+	 * indistinguishable from a schema with no matching rows. That silence is
+	 * what made openregister#3611 invisible for as long as it was: humaniq's
+	 * hours widget summed the empty set and would have rendered `0` hours on
+	 * every object. The warning names the keys, the endpoint and the schema so
+	 * the mistake is visible in the log without refusing the request.
+	 *
+	 * @param array<string, mixed> $query The query from `buildSearchQuery()`.
+	 * @param Schema|null $schemaEntity The resolved schema, when there is one.
+	 * @param string $register The register reference from the URL.
+	 * @param string $schema The schema reference from the URL.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/zoeken-filteren/spec.md#requirement-both-filter-spellings-mean-the-same-filter-on-object-search-and-the-aggregations
+	 */
+	private function warnUnknownFilterKeys(
+		array $query,
+		?Schema $schemaEntity,
+		string $register,
+		string $schema,
+	): void {
+		if ($schemaEntity === null) {
+			return;
+		}
+
+		FilterParams::warnUnknownKeys(
+			logger: $this->logger,
+			keys: FilterParams::unknownObjectFilterKeys(
+				query: $query,
+				properties: ($schemaEntity->getProperties() ?? [])
+			),
+			endpoint: 'objects#index',
+			register: $register,
+			schema: $schema
+		);
+	}//end warnUnknownFilterKeys()
+
+	/**
 	 * Retrieves a list of all objects for a specific register and schema
 	 *
 	 * This method returns a paginated list of objects that match the specified register and schema.
@@ -1179,6 +1222,13 @@ class ObjectsController extends Controller {
 					requestParams: $this->request->getParams(),
 					register: $resolved['register'],
 					schema: $resolved['schema']
+				);
+
+				$this->warnUnknownFilterKeys(
+					query: $query,
+					schemaEntity: $schemaEntity,
+					register: $register,
+					schema: $schema
 				);
 
 				// Pass RBAC and multitenancy settings to the query.
@@ -1335,6 +1385,13 @@ class ObjectsController extends Controller {
 				if (empty($ignoredFilters) === false) {
 					$responseData['@self']['ignoredFilters'] = $ignoredFilters;
 
+					// `filter` is deliberately NOT in this list. It used to be,
+					// and the hint it produced sent callers the wrong way:
+					// `filter[x]` is now the bracket filter spelling, while
+					// `_filter` is the response field-exclusion parameter, so
+					// "did you mean _filter?" turned a scoped query into an
+					// unscoped one. openbuild followed exactly that advice and
+					// measured `_filter[applicationUuid]` returning every row.
 					$controlParams = [
 						'limit',
 						'offset',
@@ -1344,7 +1401,6 @@ class ObjectsController extends Controller {
 						'search',
 						'extend',
 						'fields',
-						'filter',
 						'unset',
 					];
 					$mistakenParams = array_intersect($ignoredFilters, $controlParams);
@@ -1432,6 +1488,13 @@ class ObjectsController extends Controller {
 			requestParams: $this->request->getParams(),
 			register: $resolved['register'],
 			schema: $resolved['schema']
+		);
+
+		$this->warnUnknownFilterKeys(
+			query: $query,
+			schemaEntity: ($resolved['schemaEntity'] ?? null),
+			register: $register,
+			schema: $schema
 		);
 
 		// **INTELLIGENT SOURCE SELECTION**: ObjectService automatically chooses optimal source.

--- a/lib/Db/MagicMapper/MagicSearchHandler.php
+++ b/lib/Db/MagicMapper/MagicSearchHandler.php
@@ -49,6 +49,7 @@ use OCA\OpenRegister\Exception\EncryptedFieldFilterException;
 use OCA\OpenRegister\Exception\UnknownMetadataFieldException;
 use OCA\OpenRegister\Service\DateTimeNormalizer;
 use OCA\OpenRegister\Service\Object\SchemaTypeConverter;
+use OCA\OpenRegister\Support\FilterParams;
 use OCA\OpenRegister\Support\QueryLimit;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
@@ -1285,11 +1286,12 @@ class MagicSearchHandler {
 			'_multitenancy_explicit',
 			'_fuzzy',
 			'_empty',
-			'register',
-			'schema',
-			'registers',
-			'schemas',
-			'extend',
+			// The non-underscore tail lives in FilterParams, because the
+			// filter-spelling normalisation has to exclude exactly the same
+			// names (openregister#3611). Two hand-kept copies of this list
+			// would drift, and the way they drift is a context parameter read
+			// as a property filter, which answers `1 = 0` and says nothing.
+			...FilterParams::OBJECT_CONTEXT_PARAMS,
 		];
 	}//end getReservedParams()
 

--- a/lib/Service/Object/SearchQueryHandler.php
+++ b/lib/Service/Object/SearchQueryHandler.php
@@ -35,6 +35,7 @@ use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Db\ViewMapper;
 use OCA\OpenRegister\Service\SearchTrailService;
 use OCA\OpenRegister\Service\SettingsService;
+use OCA\OpenRegister\Support\FilterParams;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
 
@@ -151,6 +152,49 @@ class SearchQueryHandler {
 	}//end schemaHasObjectSource()
 
 	/**
+	 * Whether the target schema declares a property literally named `filter`.
+	 *
+	 * Only such a schema can mean `filter[x]=v` as a filter on its own `filter`
+	 * property, so only there is the bracket spelling left alone. A list of
+	 * schemas (cross-table search) counts when any one of them declares it. A
+	 * schema that cannot be resolved does not, so the lift applies.
+	 *
+	 * A SYSTEM-level structural lookup, like {@see schemaHasObjectSource()}: it
+	 * decides how the parameters are parsed and returns no schema data, so it
+	 * bypasses RBAC and multitenancy. The data read stays checked downstream.
+	 *
+	 * @param int|string|array|null $schema The schema id/slug, or a list of them.
+	 *
+	 * @return bool True when a target schema declares a `filter` property.
+	 *
+	 * @spec openspec/specs/zoeken-filteren/spec.md#requirement-both-filter-spellings-mean-the-same-filter-on-object-search-and-the-aggregations
+	 */
+	private function schemaDeclaresFilterProperty(int|string|array|null $schema): bool {
+		if ($schema === null) {
+			return false;
+		}
+
+		$schemaRefs = [$schema];
+		if (is_array($schema) === true) {
+			$schemaRefs = $schema;
+		}
+
+		foreach ($schemaRefs as $schemaRef) {
+			try {
+				$entity = $this->schemaMapper->find(id: $schemaRef, _rbac: false, _multitenancy: false);
+			} catch (\Throwable $e) {
+				continue;
+			}
+
+			if (array_key_exists(FilterParams::FILTER_KEY, ($entity->getProperties() ?? [])) === true) {
+				return true;
+			}
+		}
+
+		return false;
+	}//end schemaDeclaresFilterProperty()
+
+	/**
 	 * Build search query from request parameters
 	 *
 	 * Converts HTTP request parameters into a structured query array for searchObjectsPaginated.
@@ -249,15 +293,24 @@ class SearchQueryHandler {
 			$fixedParams[$key] = $value;
 		}//end foreach
 
+		// STEP 1b: the bracket spelling. `filter[x]=v` means `x=v` here, as it
+		// does on the aggregation endpoints (openregister#3611). Before this,
+		// `filter` was read as a property filter on a property literally named
+		// `filter`, which no schema has, so every such query returned the empty
+		// set. The one schema this must not touch is one that really declares a
+		// `filter` property: there the old meaning is the right one.
+		if (is_array($fixedParams[FilterParams::FILTER_KEY] ?? null) === true
+			&& $this->schemaDeclaresFilterProperty(schema: $schema) === false
+		) {
+			$fixedParams = FilterParams::liftBracketFilter(params: $fixedParams);
+		}
+
 		// STEP 2: Remove system parameters that shouldn't be used as filters.
 		$params = $fixedParams;
-		unset(
-			$params['id'],
-			$params['_route'],
-			$params['rbac'],
-			$params['multi'],
-			$params['deleted']
-		);
+		unset($params['_route']);
+		foreach (FilterParams::OBJECT_SYSTEM_PARAMS as $systemParam) {
+			unset($params[$systemParam]);
+		}
 
 		// Build the query structure for searchObjectsPaginated.
 		$query = [];

--- a/lib/Support/FilterParams.php
+++ b/lib/Support/FilterParams.php
@@ -174,7 +174,7 @@ final class FilterParams {
 	 * @spec openspec/specs/zoeken-filteren/spec.md#requirement-both-filter-spellings-mean-the-same-filter-on-object-search-and-the-aggregations
 	 */
 	public static function forAggregation(array $bracket, array $params, array $controlParams, array $properties): array {
-		$reserved = array_merge($controlParams, self::AGGREGATION_ROUTE_PARAMS, [self::FILTER_KEY]);
+		$reserved = self::reservedForAggregation(controlParams: $controlParams);
 		$filter = [];
 		$unknown = [];
 
@@ -220,7 +220,7 @@ final class FilterParams {
 	 * @return bool True when at least one parameter is a candidate filter name.
 	 */
 	public static function hasBareCandidates(array $params, array $controlParams): bool {
-		$reserved = array_merge($controlParams, self::AGGREGATION_ROUTE_PARAMS, [self::FILTER_KEY]);
+		$reserved = self::reservedForAggregation(controlParams: $controlParams);
 		foreach (array_keys($params) as $key) {
 			if (self::isFilterName(key: $key, reserved: $reserved) === true) {
 				return true;
@@ -310,6 +310,23 @@ final class FilterParams {
 			]
 		);
 	}//end warnUnknownKeys()
+
+	/**
+	 * The names an aggregation action never reads as a filter: its own control
+	 * parameters, the route placeholders, and `filter` itself.
+	 *
+	 * One builder for both readers on purpose. {@see hasBareCandidates()}
+	 * decides whether the schema is worth resolving and {@see forAggregation()}
+	 * decides what filters; if those two disagreed, a key could be called a
+	 * candidate and then dropped, or skipped before it was ever considered.
+	 *
+	 * @param string[] $controlParams The action's control parameters.
+	 *
+	 * @return string[] Every name that is never a filter on this action.
+	 */
+	private static function reservedForAggregation(array $controlParams): array {
+		return array_merge($controlParams, self::AGGREGATION_ROUTE_PARAMS, [self::FILTER_KEY]);
+	}//end reservedForAggregation()
 
 	/**
 	 * Whether a request key can name a property filter at all.

--- a/lib/Support/FilterParams.php
+++ b/lib/Support/FilterParams.php
@@ -1,0 +1,329 @@
+<?php
+
+/**
+ * FilterParams: one filter grammar for object search and the aggregations.
+ *
+ * @category Support
+ * @package  OCA\OpenRegister\Support
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @spec openspec/specs/zoeken-filteren/spec.md#requirement-both-filter-spellings-mean-the-same-filter-on-object-search-and-the-aggregations
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Support;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Normalises the two ways a caller can spell a property filter, `x=v` and
+ * `filter[x]=v`, so object search and the aggregation endpoints read both.
+ *
+ * WHY THIS EXISTS. The two sibling endpoints disagreed, and each answered the
+ * other's spelling with a confident wrong number (openregister#3611):
+ *
+ *   - Object search (`/api/objects/{register}/{schema}`) read only the bare
+ *     spelling. `filter[origin]=manual` became a filter on a property literally
+ *     named `filter`, which no schema has, so every such query returned the
+ *     empty set. A caller summing those rows rendered 0.
+ *   - The aggregations (`/api/objects/aggregations/...`) read only the bracket
+ *     spelling. A bare `origin=manual` was dropped, so the caller got the figure
+ *     for the whole schema while believing it had scoped the query.
+ *
+ * Both failures were silent. This class makes the known-property case agree and
+ * gives the unknown-key case a warning, without refusing anything: a 400 would
+ * break every caller on the wrong spelling at the same moment.
+ *
+ * WHAT STAYS AS IT WAS. A key that names no property keeps the result its
+ * endpoint already gave it, and is logged. That is deliberate: a bare query
+ * parameter the aggregations never read (a cache-buster, a stray `v=2`) must
+ * not start zeroing a KPI tile. Only a key that names a declared property is
+ * newly honoured on the endpoint that used to ignore it.
+ *
+ * Kept static on the same terms as {@see QueryLimit}: both read paths have to
+ * reach the SAME answer, and one pure function reachable by name from both is
+ * the property being bought.
+ *
+ * @psalm-suppress UnusedClass Referenced from the query paths; psalm's
+ *  entry-point analysis does not follow the controllers that reach them.
+ */
+final class FilterParams {
+
+	/**
+	 * The request parameter that carries the bracket spelling, `filter[x]=v`.
+	 */
+	public const FILTER_KEY = 'filter';
+
+	/**
+	 * Non-underscore parameters that carry object-search CONTEXT, not a filter.
+	 *
+	 * Also the tail of `MagicSearchHandler::getReservedParams()`, which reads
+	 * this constant, so the search handler and this class cannot drift apart.
+	 *
+	 * @var string[]
+	 */
+	public const OBJECT_CONTEXT_PARAMS = ['register', 'schema', 'registers', 'schemas', 'extend'];
+
+	/**
+	 * Parameters `SearchQueryHandler::buildSearchQuery()` strips before it
+	 * reads filters. They steer the request (`deleted` includes soft-deleted
+	 * rows, `rbac`/`multi` are ignored for security) and are never filters.
+	 *
+	 * @var string[]
+	 */
+	public const OBJECT_SYSTEM_PARAMS = ['id', 'rbac', 'multi', 'deleted'];
+
+	/**
+	 * Route placeholders every aggregation route carries. `IRequest::getParams()`
+	 * merges URL parameters in with the query string, so without this a schema
+	 * slug would be read as a filter on a property called `schema`.
+	 *
+	 * @var string[]
+	 */
+	public const AGGREGATION_ROUTE_PARAMS = ['register', 'schema'];
+
+	/**
+	 * The control parameters each aggregation action reads by name, taken
+	 * from `AggregationController`. None of them is ever a filter, on either
+	 * spelling of the endpoint; a property that shares one of these names can
+	 * only be filtered as `filter[name]`.
+	 *
+	 * `aggregate` carries `name` because its route has a `{name}` placeholder,
+	 * and most fleet schemas declare a `name` property.
+	 *
+	 * @var array<string, string[]>
+	 */
+	public const AGGREGATION_CONTROL_PARAMS = [
+		'aggregate'  => ['filter', 'name'],
+		'value'      => ['filter', 'metric', 'field', 'metrics'],
+		'grouped'    => ['filter', 'metric', 'field', 'metrics', 'groupBy', 'sort', 'limit'],
+		'timeseries' => ['filter', 'field', 'interval', 'from', 'to', 'metric', 'metricField', 'cumulative'],
+	];
+
+	/**
+	 * Lift `filter[x]=v` into a bare `x=v` for the object-search grammar.
+	 *
+	 * Runs on the parameters AFTER `buildSearchQuery()` has undone PHP's
+	 * dot-mangling, so a bracket key is taken literally, as it arrived. A
+	 * nested bracket (`filter[address][city]=v`) lifts to the same nested shape
+	 * the bare dot spelling (`address.city=v`) produces. When both spellings
+	 * name one key, the bracket value wins.
+	 *
+	 * A key that is not a filter under the bare spelling stays behind in
+	 * `filter`: an underscore-prefixed key, a context or system parameter, or a
+	 * numeric key. The spelling is not a way to reach a control parameter, and
+	 * the leftover `filter` keeps the result such a request gave before.
+	 *
+	 * @param array<array-key, mixed> $params The request parameters.
+	 *
+	 * @return array<array-key, mixed> The parameters with the bracket keys lifted.
+	 *
+	 * @spec openspec/specs/zoeken-filteren/spec.md#requirement-both-filter-spellings-mean-the-same-filter-on-object-search-and-the-aggregations
+	 */
+	public static function liftBracketFilter(array $params): array {
+		$bracket = ($params[self::FILTER_KEY] ?? null);
+		if (is_array($bracket) === false || $bracket === [] || array_is_list($bracket) === true) {
+			return $params;
+		}
+
+		$reserved = array_merge(self::OBJECT_CONTEXT_PARAMS, self::OBJECT_SYSTEM_PARAMS);
+		$leftover = [];
+		foreach ($bracket as $key => $value) {
+			if (self::isFilterName(key: $key, reserved: $reserved) === false) {
+				$leftover[$key] = $value;
+				continue;
+			}
+
+			$params[$key] = $value;
+		}
+
+		unset($params[self::FILTER_KEY]);
+		if ($leftover !== []) {
+			$params[self::FILTER_KEY] = $leftover;
+		}
+
+		return $params;
+	}//end liftBracketFilter()
+
+	/**
+	 * Build an aggregation's filter map from both spellings.
+	 *
+	 * The bracket map passes through exactly as the endpoint always read it.
+	 * A bare key joins it only when it names a declared property of the schema
+	 * and is not one of the action's control parameters. When both spellings
+	 * name one key, the bracket value wins.
+	 *
+	 * Keys that name no property come back in `unknown` for the caller to log:
+	 * a bare one was ignored, as it always was, and a bracket one still filters
+	 * on a column the rows do not have, so it still matches nothing.
+	 *
+	 * @param array<array-key, mixed> $bracket       The `filter[...]` map.
+	 * @param array<array-key, mixed> $params        Every request parameter.
+	 * @param string[]                $controlParams The action's control parameters.
+	 * @param array<array-key, mixed> $properties    The schema's declared properties.
+	 *
+	 * @return array{filter: array<array-key, mixed>, unknown: list<string>}
+	 *
+	 * @spec openspec/specs/zoeken-filteren/spec.md#requirement-both-filter-spellings-mean-the-same-filter-on-object-search-and-the-aggregations
+	 */
+	public static function forAggregation(array $bracket, array $params, array $controlParams, array $properties): array {
+		$reserved = array_merge($controlParams, self::AGGREGATION_ROUTE_PARAMS, [self::FILTER_KEY]);
+		$filter = [];
+		$unknown = [];
+
+		foreach ($params as $key => $value) {
+			if (self::isFilterName(key: $key, reserved: $reserved) === false) {
+				continue;
+			}
+
+			if (array_key_exists($key, $properties) === false) {
+				$unknown[] = (string)$key;
+				continue;
+			}
+
+			$filter[$key] = $value;
+		}
+
+		foreach ($bracket as $key => $value) {
+			$filter[$key] = $value;
+			if (is_string($key) === true
+				&& $key !== ''
+				&& str_starts_with($key, '_') === false
+				&& array_key_exists($key, $properties) === false
+			) {
+				$unknown[] = $key;
+			}
+		}
+
+		return [
+			'filter'  => $filter,
+			'unknown' => array_values(array_unique($unknown)),
+		];
+	}//end forAggregation()
+
+	/**
+	 * Whether any parameter could become a bare aggregation filter.
+	 *
+	 * Lets the controller skip the schema lookup on the common request that
+	 * carries only control parameters.
+	 *
+	 * @param array<array-key, mixed> $params        Every request parameter.
+	 * @param string[]                $controlParams The action's control parameters.
+	 *
+	 * @return bool True when at least one parameter is a candidate filter name.
+	 */
+	public static function hasBareCandidates(array $params, array $controlParams): bool {
+		$reserved = array_merge($controlParams, self::AGGREGATION_ROUTE_PARAMS, [self::FILTER_KEY]);
+		foreach (array_keys($params) as $key) {
+			if (self::isFilterName(key: $key, reserved: $reserved) === true) {
+				return true;
+			}
+		}
+
+		return false;
+	}//end hasBareCandidates()
+
+	/**
+	 * The object-field filter keys of a built search query that name no
+	 * property of the schema.
+	 *
+	 * Mirrors `MagicSearchHandler::isObjectFieldFilterKey()`: `@self`, every
+	 * underscore-prefixed key and every context parameter are not object-field
+	 * filters. What is left and is not a declared property is exactly the set
+	 * the search handler answers with `1 = 0`.
+	 *
+	 * @param array<array-key, mixed> $query      The query from `buildSearchQuery()`.
+	 * @param array<array-key, mixed> $properties The schema's declared properties.
+	 *
+	 * @return list<string> The unknown keys, in query order.
+	 *
+	 * @spec openspec/specs/zoeken-filteren/spec.md#requirement-both-filter-spellings-mean-the-same-filter-on-object-search-and-the-aggregations
+	 */
+	public static function unknownObjectFilterKeys(array $query, array $properties): array {
+		$unknown = [];
+		foreach (array_keys($query) as $key) {
+			$key = (string)$key;
+			if ($key === '@self'
+				|| str_starts_with($key, '_') === true
+				|| in_array($key, self::OBJECT_CONTEXT_PARAMS, true) === true
+				|| array_key_exists($key, $properties) === true
+			) {
+				continue;
+			}
+
+			$unknown[] = $key;
+		}
+
+		return $unknown;
+	}//end unknownObjectFilterKeys()
+
+	/**
+	 * Log ONE warning naming every filter key that named no property.
+	 *
+	 * This is what makes the silent failure loud without breaking a caller.
+	 * It is a warning and not a refusal on purpose; turning it into an HTTP 400
+	 * is the follow-up once the logs show no caller depends on the old answer.
+	 *
+	 * @param LoggerInterface|null $logger   Where to write; null writes nothing.
+	 * @param string[]             $keys     The unknown keys.
+	 * @param string               $endpoint The route name, e.g. `objects#index`.
+	 * @param string               $register The register reference from the URL.
+	 * @param string               $schema   The schema reference from the URL.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/zoeken-filteren/spec.md#requirement-both-filter-spellings-mean-the-same-filter-on-object-search-and-the-aggregations
+	 */
+	public static function warnUnknownKeys(
+		?LoggerInterface $logger,
+		array $keys,
+		string $endpoint,
+		string $register,
+		string $schema,
+	): void {
+		if ($logger === null || $keys === []) {
+			return;
+		}
+
+		$logger->warning(
+			sprintf(
+				'[OpenRegister] %s: filter key(s) "%s" name no property of schema "%s" in register "%s", so they do not'
+				. ' filter on a property. Check the spelling; an unknown filter key is meant to become an HTTP 400.',
+				$endpoint,
+				implode('", "', $keys),
+				$schema,
+				$register
+			),
+			[
+				'app'      => 'openregister',
+				'endpoint' => $endpoint,
+				'register' => $register,
+				'schema'   => $schema,
+				'keys'     => array_values($keys),
+			]
+		);
+	}//end warnUnknownKeys()
+
+	/**
+	 * Whether a request key can name a property filter at all.
+	 *
+	 * @param int|string $key      The request key.
+	 * @param string[]   $reserved Names that are never filters on this endpoint.
+	 *
+	 * @return bool False for numeric, empty, underscore-prefixed and reserved keys.
+	 */
+	private static function isFilterName(int|string $key, array $reserved): bool {
+		if (is_string($key) === false || $key === '' || str_starts_with($key, '_') === true) {
+			return false;
+		}
+
+		return in_array($key, $reserved, true) === false;
+	}//end isFilterName()
+}//end class

--- a/openspec/specs/zoeken-filteren/spec.md
+++ b/openspec/specs/zoeken-filteren/spec.md
@@ -89,6 +89,53 @@ A filter value MAY also be the literal string `IS NULL` or `IS NOT NULL` (`?assi
 - **THEN** `MagicSearchHandler.applyObjectFilters()` MUST add `WHERE 1 = 0` to ensure zero results
 - **AND** the property name MUST be tracked in `ignoredFilters` for client feedback in the response
 
+### Requirement: Both filter spellings mean the same filter on object search and the aggregations
+
+A property filter MAY be written bare (`?origin=manual`) or bracketed (`?filter[origin]=manual`), and both spellings MUST mean the same filter on `GET /api/objects/{register}/{schema}` and on every `GET /api/objects/aggregations/{register}/{schema}/…` surface. Before this, each endpoint read one spelling and answered the other with a plausible wrong number: object search read `filter[origin]` as a filter on a property literally named `filter`, which no schema declares, so every such query returned the empty set, and the aggregations dropped a bare key and returned the figure for the whole schema. Neither failed loudly, and a caller that summed the empty set rendered a `0` indistinguishable from a real one.
+
+Reserved parameters are never filters, on either spelling: every underscore-prefixed parameter (`_limit`, `_order`, `_search`, …), the object-search context parameters (`register`, `schema`, `registers`, `schemas`, `extend`) and the system parameters `id`, `rbac`, `multi`, `deleted`, plus each aggregation action's own control parameters (`metric`, `field`, `metrics`, `groupBy`, `sort`, `limit`, `interval`, `from`, `to`, `metricField`, `cumulative`, and `name` on the declared-aggregation route). A property that shares one of those names can only be filtered with the bracket spelling. `filter[_limit]` is not a way to reach a control parameter either: the bracket spelling is lifted only for keys that could be bare filters.
+
+On the aggregations, a bare key joins the filter map ONLY when it names a property the schema declares. A bare parameter that names nothing keeps being ignored, because a cache-buster or a stray `v=2` must not start filtering and answer `0` where a widget used to read a total. A bracket key that names no property keeps matching no rows, as it already did.
+
+An unrecognised filter key MUST be logged once per request as a warning naming the keys, the endpoint and the schema, and MUST NOT be refused: every caller on the wrong spelling would break in the same minute. Refusing it with HTTP 400 is the follow-up once the logs show no caller depends on the old answer.
+
+The ad-hoc aggregation cache key MUST be derived from the NORMALISED filter map, so two spellings of one query share an entry and two different queries never do. Deriving it from the parameters the endpoint happened to recognise is what let `?origin=manual` and `?origin=nonsense` answer each other's cached figure.
+
+#### Scenario: The bracket spelling filters object search
+- **GIVEN** schema `TimeEntry` with property `origin` and 9 objects, 8 of them `origin = manual`
+- **WHEN** the client calls `GET /api/objects/humaniq/TimeEntry?filter[origin]=manual`
+- **THEN** the response MUST carry the same 8 results as `?origin=manual`
+- **AND** `filter` MUST NOT appear in `@self.ignoredFilters`
+- @e2e exclude Backend query-grammar normalisation on an HTTP read path; verified by PHPUnit unit tests over the query builder and the controller, no browser flow.
+
+#### Scenario: The bare spelling filters an aggregation
+- **GIVEN** the same schema and rows
+- **WHEN** the client calls `GET /api/objects/aggregations/humaniq/TimeEntry/value?metric=count&origin=manual`
+- **THEN** the value MUST be `8`, the same figure `filter[origin]=manual` returns
+- @e2e exclude Backend query-grammar normalisation on an HTTP read path; verified by PHPUnit unit tests over the controller and the aggregation query, no browser flow.
+
+#### Scenario: A control parameter is never read as a filter
+- **GIVEN** a schema that declares properties named `limit` and `name`
+- **WHEN** the client calls the grouped aggregation with `?groupBy=status&limit=5`
+- **THEN** `limit` MUST steer the top-N and MUST NOT become a filter on the `limit` property
+- **AND** only `filter[limit]=5` MUST filter on that property
+- @e2e exclude Backend parameter classification; verified by PHPUnit unit tests, no browser flow.
+
+#### Scenario: An unknown filter key warns and changes nothing
+- **GIVEN** schema `TimeEntry`, which declares no property `origni`
+- **WHEN** the client calls either endpoint with `?origni=manual`
+- **THEN** the endpoint MUST answer exactly what it answered before this requirement: no rows from object search, the unscoped figure from the aggregations
+- **AND** exactly one warning MUST be logged naming `origni`, the endpoint and the schema
+- **AND** the response MUST NOT be an HTTP 400
+- @e2e exclude Backend logging and result-preservation on an HTTP read path; verified by PHPUnit unit tests with a logger spy, no browser flow.
+
+#### Scenario: The aggregation cache key follows the normalised filter
+- **GIVEN** an ad-hoc aggregation over schema `TimeEntry`
+- **WHEN** one caller asks `?filter[origin]=manual` and another asks `?origin=manual`
+- **THEN** both MUST resolve to the same cache key
+- **AND** `?origin=manual` and `?origin=migration` MUST resolve to different cache keys
+- @e2e exclude Backend cache-key derivation; verified by PHPUnit unit tests over AggregationCache, no browser flow.
+
 ### Requirement: JSON array and object property filtering
 The system MUST support filtering on `type: array` (JSONB array columns) using PostgreSQL's `@>` containment operator, and on `type: object` properties using JSON path extraction. This enables filtering on multi-valued and nested structured properties.
 

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -46,11 +46,25 @@
          Unlike FleetAppId this one is not temporary — the `_limit` grammar is
          permanent — so it earns its place on the merit of the first paragraph
          alone rather than on being short-lived. -->
+    <!-- StaticAccess: a third exception, on the terms QueryLimit set.
+
+         `\OCA\OpenRegister\Support\FilterParams` answers one question about
+         request parameters: which of them are property filters, and under
+         which of the two spellings. It holds no state, has no collaborators,
+         and takes everything it needs as arguments.
+
+         It exists because two sibling endpoints answered that question
+         differently and each returned a confident wrong number for the
+         other's spelling (openregister#3611). The property being bought is
+         that object search, the four aggregation actions and the magic search
+         handler cannot disagree again: a service would let one of them be
+         constructed with a different implementation, which is the drift the
+         class was written to end. -->
     <rule ref="rulesets/cleancode.xml/StaticAccess">
         <properties>
             <property
                 name="exceptions"
-                value="\OCA\OpenRegister\Support\FleetAppId,\OCA\OpenRegister\Support\QueryLimit"/>
+                value="\OCA\OpenRegister\Support\FleetAppId,\OCA\OpenRegister\Support\QueryLimit,\OCA\OpenRegister\Support\FilterParams"/>
         </properties>
     </rule>
 </ruleset>

--- a/tests/Unit/Controller/AggregationControllerFilterSpellingTest.php
+++ b/tests/Unit/Controller/AggregationControllerFilterSpellingTest.php
@@ -1,0 +1,353 @@
+<?php
+
+/**
+ * Unit tests for the filter spelling the aggregation endpoints accept
+ * (openregister#3611): `filter[x]=v` and a bare `x=v` must mean one filter,
+ * and the cache key must follow the normalised map rather than the parameters
+ * the endpoint happened to recognise.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * @spec openspec/specs/zoeken-filteren/spec.md#requirement-both-filter-spellings-mean-the-same-filter-on-object-search-and-the-aggregations
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Controller;
+
+use OCA\OpenRegister\Controller\AggregationController;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Service\Aggregation\AggregationCache;
+use OCA\OpenRegister\Service\Aggregation\AggregationQuery;
+use OCA\OpenRegister\Service\Aggregation\AggregationRunner;
+use OCA\OpenRegister\Service\Aggregation\TimeseriesRequestValidator;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCP\ICache;
+use OCP\ICacheFactory;
+use OCP\IRequest;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @coversDefaultClass \OCA\OpenRegister\Controller\AggregationController
+ */
+class AggregationControllerFilterSpellingTest extends TestCase {
+
+	/**
+	 * The schema under test. `limit` is declared on purpose: it is a
+	 * grouped-aggregation control parameter AND a plausible property name, and
+	 * only the bracket spelling may filter on it.
+	 *
+	 * @var array<string, array<string, string>>
+	 */
+	private const PROPERTIES = [
+		'origin' => ['type' => 'string'],
+		'hours' => ['type' => 'number'],
+		'limit' => ['type' => 'integer'],
+	];
+
+	/**
+	 * A runner whose schema lookup answers with {@see PROPERTIES}, and whose
+	 * `runAdhocByRef()` records the query it was asked to execute.
+	 *
+	 * @param AggregationQuery|null $captured Receives the executed query.
+	 * @param array<string, mixed>  $envelope The result envelope to answer with.
+	 *
+	 * @return AggregationRunner
+	 */
+	private function makeRunner(?AggregationQuery &$captured, array $envelope = ['value' => 0, 'backend' => 'postgres', 'cached' => false]): AggregationRunner {
+		$schema = $this->createMock(Schema::class);
+		$schema->method('getProperties')->willReturn(self::PROPERTIES);
+
+		$runner = $this->createMock(AggregationRunner::class);
+		$runner->method('findSchema')->willReturn($schema);
+		$runner->method('runAdhocByRef')->willReturnCallback(
+			function ($reg, $sch, AggregationQuery $query) use (&$captured, $envelope) {
+				$captured = $query;
+				return $envelope;
+			}
+		);
+
+		return $runner;
+	}//end makeRunner()
+
+	/**
+	 * A request serving one parameter map through both `getParam()` and
+	 * `getParams()`, so the two readings cannot disagree.
+	 *
+	 * @param array<string, mixed> $params The request parameters.
+	 *
+	 * @return IRequest
+	 */
+	private function makeRequest(array $params): IRequest {
+		$request = $this->createMock(IRequest::class);
+		$request->method('getParam')->willReturnCallback(
+			static function (string $name, $default = null) use ($params) {
+				return array_key_exists($name, $params) ? $params[$name] : $default;
+			}
+		);
+		$request->method('getParams')->willReturn($params);
+
+		return $request;
+	}//end makeRequest()
+
+	/**
+	 * Build the controller.
+	 *
+	 * @param array<string, mixed>  $params The request parameters.
+	 * @param AggregationRunner     $runner The runner double.
+	 * @param LoggerInterface|null  $logger The logger double, when asserted on.
+	 *
+	 * @return AggregationController
+	 */
+	private function makeController(array $params, AggregationRunner $runner, ?LoggerInterface $logger = null): AggregationController {
+		return new AggregationController(
+			'openregister',
+			$this->makeRequest($params),
+			$runner,
+			$this->createMock(TimeseriesRequestValidator::class),
+			($logger ?? $this->createMock(LoggerInterface::class))
+		);
+	}//end makeController()
+
+	/**
+	 * Call `value()` and return the query the runner was asked to execute.
+	 *
+	 * @param array<string, mixed> $params The request parameters.
+	 * @param LoggerInterface|null $logger The logger double, when asserted on.
+	 *
+	 * @return AggregationQuery|null
+	 */
+	private function captureValueQuery(array $params, ?LoggerInterface $logger = null): ?AggregationQuery {
+		$captured = null;
+		$params = ($params + ['register' => 'humaniq', 'schema' => 'TimeEntry']);
+		$this->makeController($params, $this->makeRunner($captured), $logger)->value('humaniq', 'TimeEntry');
+
+		return $captured;
+	}//end captureValueQuery()
+
+	/**
+	 * The defect itself: a bare key was dropped, so the caller got the figure
+	 * for the whole schema while believing the query was scoped.
+	 *
+	 * @return void
+	 */
+	public function testBareKeyReachesTheAggregationFilter(): void {
+		$query = $this->captureValueQuery(['metric' => 'count', 'origin' => 'manual']);
+
+		$this->assertSame(['origin' => 'manual'], $query?->filter);
+	}//end testBareKeyReachesTheAggregationFilter()
+
+	/**
+	 * The bracket spelling keeps working and produces the same filter map as
+	 * the bare one, which is the whole point of the fix.
+	 *
+	 * @return void
+	 */
+	public function testBracketKeyProducesTheSameFilterAsTheBareKey(): void {
+		$bare = $this->captureValueQuery(['metric' => 'count', 'origin' => 'manual']);
+		$bracketed = $this->captureValueQuery(['metric' => 'count', 'filter' => ['origin' => 'manual']]);
+
+		$this->assertSame(['origin' => 'manual'], $bracketed?->filter);
+		$this->assertSame($bare?->filter, $bracketed?->filter);
+	}//end testBracketKeyProducesTheSameFilterAsTheBareKey()
+
+	/**
+	 * An operator filter reads the same in both spellings too.
+	 *
+	 * @return void
+	 */
+	public function testOperatorFilterReadsTheSameInBothSpellings(): void {
+		$bare = $this->captureValueQuery(['metric' => 'count', 'hours' => ['gte' => '2']]);
+		$bracketed = $this->captureValueQuery(['metric' => 'count', 'filter' => ['hours' => ['gte' => '2']]]);
+
+		$this->assertSame(['hours' => ['gte' => '2']], $bare?->filter);
+		$this->assertSame($bare?->filter, $bracketed?->filter);
+	}//end testOperatorFilterReadsTheSameInBothSpellings()
+
+	/**
+	 * A control parameter never becomes a filter, even when the schema
+	 * declares a property of that name. `limit` is the top-N of a grouped
+	 * aggregation; `filter[limit]` is the only way to filter on the property.
+	 *
+	 * @return void
+	 */
+	public function testGroupedControlParamsAreNotFilters(): void {
+		$captured = null;
+		$params = [
+			'register' => 'humaniq',
+			'schema' => 'TimeEntry',
+			'groupBy' => 'origin',
+			'metric' => 'count',
+			'sort' => 'desc',
+			'limit' => '5',
+		];
+		$runner = $this->makeRunner($captured, ['groups' => [], 'backend' => 'postgres', 'cached' => false]);
+
+		$this->makeController($params, $runner)->grouped('humaniq', 'TimeEntry');
+
+		$this->assertSame([], $captured?->filter, 'sort/limit/groupBy/metric steer the query, they do not filter it');
+		$this->assertSame(5, ($captured?->groupBy['limit'] ?? null), 'limit must still reach the groupBy spec');
+	}//end testGroupedControlParamsAreNotFilters()
+
+	/**
+	 * The bracket spelling is how a property that shares a control-parameter
+	 * name is filtered.
+	 *
+	 * @return void
+	 */
+	public function testBracketSpellingCanFilterAPropertyNamedLikeAControlParam(): void {
+		$captured = null;
+		$params = [
+			'register' => 'humaniq',
+			'schema' => 'TimeEntry',
+			'groupBy' => 'origin',
+			'metric' => 'count',
+			'limit' => '5',
+			'filter' => ['limit' => '3'],
+		];
+		$runner = $this->makeRunner($captured, ['groups' => [], 'backend' => 'postgres', 'cached' => false]);
+
+		$this->makeController($params, $runner)->grouped('humaniq', 'TimeEntry');
+
+		$this->assertSame(['limit' => '3'], $captured?->filter);
+		$this->assertSame(5, ($captured?->groupBy['limit'] ?? null));
+	}//end testBracketSpellingCanFilterAPropertyNamedLikeAControlParam()
+
+	/**
+	 * A bare key that names no property keeps being ignored, so a figure a
+	 * widget already showed does not change, and it is logged exactly once
+	 * naming the key, the endpoint and the schema.
+	 *
+	 * @return void
+	 */
+	public function testUnknownBareKeyIsWarnedAndDoesNotFilter(): void {
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->once())
+			->method('warning')
+			->with(
+				$this->logicalAnd(
+					$this->stringContains('origni'),
+					$this->stringContains('aggregation#value'),
+					$this->stringContains('TimeEntry')
+				),
+				$this->anything()
+			);
+
+		$query = $this->captureValueQuery(['metric' => 'count', 'origni' => 'manual'], $logger);
+
+		$this->assertSame([], $query?->filter, 'an unknown key must not silently scope the query to nothing');
+	}//end testUnknownBareKeyIsWarnedAndDoesNotFilter()
+
+	/**
+	 * A correct request logs nothing. A warning that fires on correct requests
+	 * is a warning nobody reads.
+	 *
+	 * @return void
+	 */
+	public function testAKnownKeyLogsNothing(): void {
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->never())->method('warning');
+
+		$this->captureValueQuery(['metric' => 'count', 'filter' => ['origin' => 'manual']], $logger);
+	}//end testAKnownKeyLogsNothing()
+
+	/**
+	 * The declared-aggregation route narrows on both spellings too, and its
+	 * `{name}` placeholder is never read as a filter.
+	 *
+	 * @return void
+	 */
+	public function testNamedAggregationNarrowsOnTheBareSpelling(): void {
+		$schema = $this->createMock(Schema::class);
+		$schema->method('getProperties')->willReturn(self::PROPERTIES);
+		$runner = $this->createMock(AggregationRunner::class);
+		$runner->method('findSchema')->willReturn($schema);
+
+		$captured = null;
+		$runner->method('run')->willReturnCallback(
+			function (...$args) use (&$captured) {
+				$captured = ($args[5] ?? null);
+				return ['value' => 1, 'backend' => 'postgres'];
+			}
+		);
+
+		$params = ['register' => 'humaniq', 'schema' => 'TimeEntry', 'name' => 'totals', 'origin' => 'manual'];
+		$this->makeController($params, $runner)->aggregate('humaniq', 'TimeEntry', 'totals');
+
+		$this->assertSame(['origin' => 'manual'], $captured);
+	}//end testNamedAggregationNarrowsOnTheBareSpelling()
+
+	/**
+	 * The cache key is derived from the normalised filter, so the two
+	 * spellings of one query share an entry.
+	 *
+	 * @return void
+	 */
+	public function testTwoSpellingsOfOneQueryShareACacheKey(): void {
+		$bare = $this->cacheKeyFor(['metric' => 'count', 'origin' => 'manual']);
+		$bracketed = $this->cacheKeyFor(['metric' => 'count', 'filter' => ['origin' => 'manual']]);
+
+		$this->assertSame($bare, $bracketed);
+	}//end testTwoSpellingsOfOneQueryShareACacheKey()
+
+	/**
+	 * Two different queries never share one. This is the half that was broken:
+	 * an unrecognised parameter left the key identical, so `?origin=manual`
+	 * and `?origin=nonsense` both answered 9 with `cached: true`.
+	 *
+	 * @return void
+	 */
+	public function testTwoDifferentQueriesGetDifferentCacheKeys(): void {
+		$manual = $this->cacheKeyFor(['metric' => 'count', 'origin' => 'manual']);
+		$migration = $this->cacheKeyFor(['metric' => 'count', 'origin' => 'migration']);
+		$unfiltered = $this->cacheKeyFor(['metric' => 'count']);
+
+		$this->assertNotSame($manual, $migration);
+		$this->assertNotSame($manual, $unfiltered);
+	}//end testTwoDifferentQueriesGetDifferentCacheKeys()
+
+	/**
+	 * The cache key a request would read: the real {@see AggregationCache}
+	 * over the query the controller builds. Going through the cache rather
+	 * than comparing filter maps is deliberate, because the key is what
+	 * decides whose figure a caller is served.
+	 *
+	 * @param array<string, mixed> $params The request parameters.
+	 *
+	 * @return string The cache key.
+	 */
+	private function cacheKeyFor(array $params): string {
+		$query = $this->captureValueQuery($params);
+		$this->assertInstanceOf(AggregationQuery::class, $query);
+
+		$captured = '';
+		$backend = $this->createMock(ICache::class);
+		$backend->method('set')->willReturnCallback(
+			static function (string $key) use (&$captured) {
+				$captured = $key;
+				return true;
+			}
+		);
+		$factory = $this->createMock(ICacheFactory::class);
+		$factory->method('createDistributed')->willReturn($backend);
+
+		$cache = new AggregationCache(
+			$factory,
+			$this->createMock(IUserSession::class),
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(OrganisationService::class)
+		);
+		$cache->setAdhoc('humaniq', 'TimeEntry', $query, ['value' => 1]);
+
+		return $captured;
+	}//end cacheKeyFor()
+}//end class

--- a/tests/Unit/Service/Object/SearchQueryHandlerFilterSpellingTest.php
+++ b/tests/Unit/Service/Object/SearchQueryHandlerFilterSpellingTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * Unit tests for the bracket filter spelling on object search
+ * (openregister#3611).
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Object
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * @spec openspec/specs/zoeken-filteren/spec.md#requirement-both-filter-spellings-mean-the-same-filter-on-object-search-and-the-aggregations
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Object;
+
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Db\ViewMapper;
+use OCA\OpenRegister\Service\Object\SearchQueryHandler;
+use OCA\OpenRegister\Service\SearchTrailService;
+use OCA\OpenRegister\Service\SettingsService;
+use OCP\IRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * `filter[origin]=manual` used to become a filter on a property literally
+ * named `filter`, which no schema declares, so EVERY such query answered
+ * `1 = 0` and returned the empty set. humaniq's hours widget spelled its
+ * filter that way and would have rendered 0 hours on every object.
+ *
+ * @coversDefaultClass \OCA\OpenRegister\Service\Object\SearchQueryHandler
+ */
+class SearchQueryHandlerFilterSpellingTest extends TestCase {
+
+	/**
+	 * A handler whose schema lookup answers with the given properties.
+	 *
+	 * @param array<string, mixed> $properties The schema's declared properties.
+	 *
+	 * @return SearchQueryHandler
+	 */
+	private function makeHandler(array $properties = ['origin' => ['type' => 'string']]): SearchQueryHandler {
+		$schema = $this->createMock(Schema::class);
+		$schema->method('getProperties')->willReturn($properties);
+		$schema->method('getObjectSource')->willReturn(null);
+
+		$schemaMapper = $this->createMock(SchemaMapper::class);
+		$schemaMapper->method('find')->willReturn($schema);
+
+		return new SearchQueryHandler(
+			$this->createMock(ViewMapper::class),
+			$schemaMapper,
+			$this->createMock(SettingsService::class),
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(IRequest::class),
+			$this->createMock(SearchTrailService::class)
+		);
+	}//end makeHandler()
+
+	/**
+	 * The bracket spelling reaches the query as an ordinary property filter.
+	 *
+	 * @return void
+	 */
+	public function testBracketFilterBecomesAPropertyFilter(): void {
+		$query = $this->makeHandler()->buildSearchQuery(
+			['filter' => ['origin' => 'manual'], '_limit' => '200'],
+			1,
+			777
+		);
+
+		$this->assertSame('manual', ($query['origin'] ?? null));
+		$this->assertArrayNotHasKey('filter', $query, 'the empty-set filter on a property called `filter` must be gone');
+		$this->assertSame('200', $query['_limit']);
+	}//end testBracketFilterBecomesAPropertyFilter()
+
+	/**
+	 * Both spellings build the same query, which is the contract the two
+	 * sibling endpoints broke.
+	 *
+	 * @return void
+	 */
+	public function testBothSpellingsBuildTheSameQuery(): void {
+		$bracketed = $this->makeHandler()->buildSearchQuery(['filter' => ['origin' => 'manual']], 1, 777);
+		$bare = $this->makeHandler()->buildSearchQuery(['origin' => 'manual'], 1, 777);
+
+		$this->assertSame($bare, $bracketed);
+	}//end testBothSpellingsBuildTheSameQuery()
+
+	/**
+	 * A schema that really declares a `filter` property keeps the old
+	 * meaning: there, `filter[x]=v` IS a filter on that property.
+	 *
+	 * @return void
+	 */
+	public function testASchemaDeclaringAFilterPropertyKeepsTheOldMeaning(): void {
+		$query = $this->makeHandler(['filter' => ['type' => 'object'], 'origin' => ['type' => 'string']])
+			->buildSearchQuery(['filter' => ['origin' => 'manual']], 1, 777);
+
+		$this->assertSame(['origin' => 'manual'], ($query['filter'] ?? null));
+		$this->assertArrayNotHasKey('origin', $query);
+	}//end testASchemaDeclaringAFilterPropertyKeepsTheOldMeaning()
+
+	/**
+	 * The bracket spelling is not a way to reach a control parameter: an
+	 * underscore-prefixed key stays where it was and never becomes `_limit`.
+	 *
+	 * @return void
+	 */
+	public function testAnUnderscoreKeyInsideTheBracketFilterIsNotLifted(): void {
+		$query = $this->makeHandler()->buildSearchQuery(
+			['filter' => ['_limit' => '1', 'origin' => 'manual']],
+			1,
+			777
+		);
+
+		$this->assertSame('manual', ($query['origin'] ?? null));
+		$this->assertSame(['_limit' => '1'], ($query['filter'] ?? null));
+		$this->assertArrayNotHasKey('_limit', $query, 'a filter spelling must not set a control parameter');
+	}//end testAnUnderscoreKeyInsideTheBracketFilterIsNotLifted()
+
+	/**
+	 * A metadata key inside the bracket filter lands in `@self`, exactly where
+	 * the bare spelling puts it.
+	 *
+	 * @return void
+	 */
+	public function testAMetadataKeyInsideTheBracketFilterLandsInSelf(): void {
+		$query = $this->makeHandler()->buildSearchQuery(['filter' => ['owner' => 'alice']], 1, 777);
+
+		$this->assertSame('alice', ($query['@self']['owner'] ?? null));
+	}//end testAMetadataKeyInsideTheBracketFilterLandsInSelf()
+
+	/**
+	 * A nested bracket filter keeps the nested shape the bare dot spelling
+	 * produces, so `filter[address][city]` and `address.city` agree.
+	 *
+	 * @return void
+	 */
+	public function testANestedBracketFilterKeepsItsShape(): void {
+		$query = $this->makeHandler(['address' => ['type' => 'object']])
+			->buildSearchQuery(['filter' => ['address' => ['city' => 'Utrecht']]], 1, 777);
+
+		$this->assertSame(['city' => 'Utrecht'], ($query['address'] ?? null));
+	}//end testANestedBracketFilterKeepsItsShape()
+}//end class

--- a/tests/Unit/Support/FilterParamsTest.php
+++ b/tests/Unit/Support/FilterParamsTest.php
@@ -1,0 +1,327 @@
+<?php
+
+/**
+ * Unit tests for the filter-spelling grammar (openregister#3611).
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Support
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * @spec openspec/specs/zoeken-filteren/spec.md#requirement-both-filter-spellings-mean-the-same-filter-on-object-search-and-the-aggregations
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Support;
+
+use OCA\OpenRegister\Support\FilterParams;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * The two spellings of a property filter, `x=v` and `filter[x]=v`, and the
+ * rules that keep a control parameter out of both.
+ *
+ * @coversDefaultClass \OCA\OpenRegister\Support\FilterParams
+ */
+class FilterParamsTest extends TestCase {
+
+	/**
+	 * The bracket spelling lifts to the bare one, which is the grammar object
+	 * search reads. Before this it stayed under `filter` and became a filter on
+	 * a property no schema declares, so the query returned the empty set.
+	 *
+	 * @return void
+	 */
+	public function testBracketFilterLiftsToBareKeys(): void {
+		$lifted = FilterParams::liftBracketFilter(
+			params: [
+				'filter' => ['origin' => 'manual', 'hours' => ['gte' => '2']],
+				'_limit' => '200',
+			]
+		);
+
+		$this->assertSame('manual', $lifted['origin'] ?? null);
+		$this->assertSame(['gte' => '2'], $lifted['hours'] ?? null);
+		$this->assertArrayNotHasKey('filter', $lifted, 'the lifted map must not stay behind as a property filter');
+		$this->assertSame('200', $lifted['_limit'], 'a control parameter passes through untouched');
+	}//end testBracketFilterLiftsToBareKeys()
+
+	/**
+	 * Both spellings of one key: the bracket value wins, and there is exactly
+	 * one filter left, not two.
+	 *
+	 * @return void
+	 */
+	public function testBracketWinsOverTheBareSpellingOfTheSameKey(): void {
+		$lifted = FilterParams::liftBracketFilter(
+			params: ['origin' => 'migration', 'filter' => ['origin' => 'manual']]
+		);
+
+		$this->assertSame('manual', $lifted['origin']);
+	}//end testBracketWinsOverTheBareSpellingOfTheSameKey()
+
+	/**
+	 * The bracket spelling is not a back door to a control parameter. An
+	 * underscore-prefixed or context key stays under `filter`, which keeps the
+	 * answer such a request already got.
+	 *
+	 * @return void
+	 */
+	public function testControlParamsAreNeverLiftedOutOfTheBracketFilter(): void {
+		$lifted = FilterParams::liftBracketFilter(
+			params: ['filter' => ['_limit' => '1', 'schemas' => '2,3', 'origin' => 'manual']]
+		);
+
+		$this->assertSame('manual', $lifted['origin'] ?? null);
+		$this->assertSame(['_limit' => '1', 'schemas' => '2,3'], $lifted['filter'] ?? null);
+	}//end testControlParamsAreNeverLiftedOutOfTheBracketFilter()
+
+	/**
+	 * A schema that really declares a `filter` property keeps the old meaning,
+	 * and the caller decides that; the lift itself leaves a non-map `filter`
+	 * (a scalar, or a plain list) exactly as it found it.
+	 *
+	 * @return void
+	 */
+	public function testANonMapFilterParamIsLeftAlone(): void {
+		$this->assertSame(['filter' => 'draft'], FilterParams::liftBracketFilter(params: ['filter' => 'draft']));
+		$this->assertSame(['filter' => ['a', 'b']], FilterParams::liftBracketFilter(params: ['filter' => ['a', 'b']]));
+	}//end testANonMapFilterParamIsLeftAlone()
+
+	/**
+	 * The aggregation side of the same rule: a bare key that names a declared
+	 * property joins the filter map, and the bracket spelling of the same query
+	 * produces the identical map.
+	 *
+	 * @return void
+	 */
+	public function testBothSpellingsProduceTheSameAggregationFilter(): void {
+		$properties = ['origin' => ['type' => 'string']];
+
+		$bare = FilterParams::forAggregation(
+			bracket: [],
+			params: ['register' => 'humaniq', 'schema' => 'TimeEntry', 'metric' => 'count', 'origin' => 'manual'],
+			controlParams: FilterParams::AGGREGATION_CONTROL_PARAMS['value'],
+			properties: $properties
+		);
+		$bracketed = FilterParams::forAggregation(
+			bracket: ['origin' => 'manual'],
+			params: ['register' => 'humaniq', 'schema' => 'TimeEntry', 'metric' => 'count'],
+			controlParams: FilterParams::AGGREGATION_CONTROL_PARAMS['value'],
+			properties: $properties
+		);
+
+		$this->assertSame(['origin' => 'manual'], $bare['filter']);
+		$this->assertSame($bare['filter'], $bracketed['filter']);
+		$this->assertSame([], $bare['unknown']);
+	}//end testBothSpellingsProduceTheSameAggregationFilter()
+
+	/**
+	 * Two different queries stay different. This is the half that keeps the
+	 * cache key honest: the normalised map is what the key is built from, so a
+	 * map that collapsed `manual` and `migration` into one would serve one
+	 * caller the other's figure.
+	 *
+	 * @return void
+	 */
+	public function testDifferentValuesProduceDifferentFilterMaps(): void {
+		$properties = ['origin' => ['type' => 'string']];
+		$controlParams = FilterParams::AGGREGATION_CONTROL_PARAMS['value'];
+
+		$manual = FilterParams::forAggregation(bracket: [], params: ['origin' => 'manual'], controlParams: $controlParams, properties: $properties);
+		$migration = FilterParams::forAggregation(bracket: [], params: ['origin' => 'migration'], controlParams: $controlParams, properties: $properties);
+
+		$this->assertNotSame($manual['filter'], $migration['filter']);
+	}//end testDifferentValuesProduceDifferentFilterMaps()
+
+	/**
+	 * A control parameter is never a filter, even when the schema declares a
+	 * property of that name. `limit` steers the top-N of a grouped
+	 * aggregation; only `filter[limit]` can filter on the property.
+	 *
+	 * @return void
+	 */
+	public function testAggregationControlParamsAreNeverFilters(): void {
+		$properties = [
+			'limit' => ['type' => 'integer'],
+			'name' => ['type' => 'string'],
+			'status' => ['type' => 'string'],
+		];
+
+		$normalised = FilterParams::forAggregation(
+			bracket: [],
+			params: [
+				'register' => 'reg',
+				'schema' => 'sch',
+				'groupBy' => 'status',
+				'metric' => 'count',
+				'sort' => 'desc',
+				'limit' => '5',
+				'_route' => 'openregister.aggregation.grouped',
+			],
+			controlParams: FilterParams::AGGREGATION_CONTROL_PARAMS['grouped'],
+			properties: $properties
+		);
+
+		$this->assertSame([], $normalised['filter']);
+		$this->assertSame([], $normalised['unknown'], 'a control parameter is not an unknown filter key either');
+	}//end testAggregationControlParamsAreNeverFilters()
+
+	/**
+	 * `name` is a control parameter on the declared-aggregation route only,
+	 * because that route has a `{name}` placeholder. On `value` it is an
+	 * ordinary property filter.
+	 *
+	 * @return void
+	 */
+	public function testNameIsAControlParamOnlyOnTheDeclaredAggregationRoute(): void {
+		$properties = ['name' => ['type' => 'string']];
+
+		$onAggregate = FilterParams::forAggregation(
+			bracket: [],
+			params: ['name' => 'totalOpen'],
+			controlParams: FilterParams::AGGREGATION_CONTROL_PARAMS['aggregate'],
+			properties: $properties
+		);
+		$onValue = FilterParams::forAggregation(
+			bracket: [],
+			params: ['name' => 'totalOpen'],
+			controlParams: FilterParams::AGGREGATION_CONTROL_PARAMS['value'],
+			properties: $properties
+		);
+
+		$this->assertSame([], $onAggregate['filter']);
+		$this->assertSame(['name' => 'totalOpen'], $onValue['filter']);
+	}//end testNameIsAControlParamOnlyOnTheDeclaredAggregationRoute()
+
+	/**
+	 * A bare key that names no property is NOT promoted to a filter: it keeps
+	 * being ignored, as it always was, so a cache-buster cannot start scoping a
+	 * query to nothing. It is reported for the log.
+	 *
+	 * @return void
+	 */
+	public function testAnUnknownBareKeyIsReportedAndNotFiltered(): void {
+		$normalised = FilterParams::forAggregation(
+			bracket: [],
+			params: ['origni' => 'manual', 'v' => '2'],
+			controlParams: FilterParams::AGGREGATION_CONTROL_PARAMS['value'],
+			properties: ['origin' => ['type' => 'string']]
+		);
+
+		$this->assertSame([], $normalised['filter'], 'an unknown bare key must not change the rows the query sees');
+		$this->assertSame(['origni', 'v'], $normalised['unknown']);
+	}//end testAnUnknownBareKeyIsReportedAndNotFiltered()
+
+	/**
+	 * A bracket key that names no property still reaches the filter map, which
+	 * is what it always did, and is reported too.
+	 *
+	 * @return void
+	 */
+	public function testAnUnknownBracketKeyKeepsItsOldEffectAndIsReported(): void {
+		$normalised = FilterParams::forAggregation(
+			bracket: ['origni' => 'manual'],
+			params: [],
+			controlParams: FilterParams::AGGREGATION_CONTROL_PARAMS['value'],
+			properties: ['origin' => ['type' => 'string']]
+		);
+
+		$this->assertSame(['origni' => 'manual'], $normalised['filter']);
+		$this->assertSame(['origni'], $normalised['unknown']);
+	}//end testAnUnknownBracketKeyKeepsItsOldEffectAndIsReported()
+
+	/**
+	 * The object-search side of "names no property": `@self`, every
+	 * underscore-prefixed key and every context parameter are not filters, so
+	 * they are never reported.
+	 *
+	 * @return void
+	 */
+	public function testUnknownObjectFilterKeysSkipsMetadataAndContext(): void {
+		$unknown = FilterParams::unknownObjectFilterKeys(
+			query: [
+				'@self' => ['register' => 1],
+				'_limit' => '20',
+				'registers' => '1,2',
+				'origin' => 'manual',
+				'origni' => 'manual',
+			],
+			properties: ['origin' => ['type' => 'string']]
+		);
+
+		$this->assertSame(['origni'], $unknown);
+	}//end testUnknownObjectFilterKeysSkipsMetadataAndContext()
+
+	/**
+	 * One warning per request, naming every key, the endpoint and the schema.
+	 *
+	 * @return void
+	 */
+	public function testWarnUnknownKeysLogsOnceNamingKeyEndpointAndSchema(): void {
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->once())
+			->method('warning')
+			->with(
+				$this->logicalAnd(
+					$this->stringContains('origni'),
+					$this->stringContains('objects#index'),
+					$this->stringContains('TimeEntry')
+				),
+				$this->callback(
+					static function (array $context): bool {
+						return ($context['keys'] ?? null) === ['origni', 'hoursx']
+							&& ($context['endpoint'] ?? null) === 'objects#index'
+							&& ($context['schema'] ?? null) === 'TimeEntry';
+					}
+				)
+			);
+
+		FilterParams::warnUnknownKeys(
+			logger: $logger,
+			keys: ['origni', 'hoursx'],
+			endpoint: 'objects#index',
+			register: 'humaniq',
+			schema: 'TimeEntry'
+		);
+	}//end testWarnUnknownKeysLogsOnceNamingKeyEndpointAndSchema()
+
+	/**
+	 * Nothing to report, nothing logged: a correct request must not produce
+	 * noise, or the warning stops being read.
+	 *
+	 * @return void
+	 */
+	public function testWarnUnknownKeysIsSilentWithoutFindings(): void {
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->never())->method('warning');
+
+		FilterParams::warnUnknownKeys(logger: $logger, keys: [], endpoint: 'objects#index', register: 'humaniq', schema: 'TimeEntry');
+	}//end testWarnUnknownKeysIsSilentWithoutFindings()
+
+	/**
+	 * The lookup that lets the aggregation controller skip resolving the
+	 * schema when nothing in the request could be a filter.
+	 *
+	 * @return void
+	 */
+	public function testHasBareCandidatesIgnoresControlAndRouteParams(): void {
+		$controlParams = FilterParams::AGGREGATION_CONTROL_PARAMS['value'];
+
+		$this->assertFalse(
+			FilterParams::hasBareCandidates(
+				params: ['register' => 'reg', 'schema' => 'sch', 'metric' => 'count', 'field' => 'hours', '_route' => 'x'],
+				controlParams: $controlParams
+			)
+		);
+		$this->assertTrue(
+			FilterParams::hasBareCandidates(params: ['metric' => 'count', 'origin' => 'manual'], controlParams: $controlParams)
+		);
+	}//end testHasBareCandidatesIgnoresControlAndRouteParams()
+}//end class


### PR DESCRIPTION
## Two sibling endpoints, opposite filter grammars, no error either way

`/api/objects/{register}/{schema}` and `/api/objects/aggregations/{register}/{schema}/…` disagreed about how a filter is spelled, and each answered the other's spelling with a confident wrong number. Measured on the dev instance before this change (humaniq register, `TimeEntry`, ground truth 9 rows, 8 of them `origin=manual`):

| query | aggregations `value` | objects row count | truth |
|---|---|---|---|
| `filter[origin]=manual` | 8 correct | 0 wrong | 8 |
| `origin=manual` | 9 wrong, filter dropped | 8 correct | 8 |
| `filter[origin]=migration` | 1 correct | 0 wrong | 1 |
| `origin=nonsense` | 9 with `cached: true` | n/a | 0 |

Object search read `filter[origin]` as a filter on a property literally named `filter`, which no schema in the fleet declares, so every such query returned the empty set. The aggregations dropped a bare key and returned the figure for the whole schema. Neither path errored, and a caller that summed the empty set rendered a `0` no different from a real one. That is what humaniq's hours widget did (ConductionNL/humaniq#412 fixed the caller).

## What this changes

Both endpoints now read both spellings, and they mean the same filter.

- `SearchQueryHandler::buildSearchQuery()` lifts `filter[x]=v` into the bare `x=v` it already understood, so every object-search surface built on it gains the spelling. The one schema this leaves alone is a schema that really declares a property called `filter`, where the old reading is the right one.
- `AggregationController` reads a bare key into the filter map on all four actions (`value`, `grouped`, `timeseries`, and the declared-aggregation route, where it narrows exactly as `filter[...]` does).
- The ad-hoc cache key follows, because the controller hands the runner the normalised map and the key is derived from it. `?origin=manual` and `?origin=migration` no longer share an entry, and the two spellings of one query do share one.
- The `@self.hint` on an ignored filter no longer suggests `_filter` for a `filter` key. That advice was actively wrong: `_filter` is response field exclusion, and openbuild followed the hint and measured `_filter[applicationUuid]` returning every row.
- An unrecognised filter key is logged once per request as a warning naming the keys, the endpoint and the schema.

## The two decisions a reviewer will want to argue with

**A warning, not a 400.** Every caller on the wrong spelling gets a silently wrong answer today, so refusing an unknown key would break all of them fleet-wide in the same minute, which is the same mistake as shipping a new gate blocking. The 400 is the intended follow-up once the logs show no caller depends on the old behaviour.

**Only a DECLARED property is newly honoured.** On the aggregations, a bare key joins the filter map only when the schema declares a property of that name. A bare parameter that names nothing keeps being ignored, exactly as before. Without that condition a cache-buster, a stray `v=2`, or any junk query parameter would become a filter matching no rows and answer `0` where a widget used to read a total, turning a fix into a fleet-wide outage of KPI tiles. The cost of the condition is that an unknown key still means two different things on the two endpoints (no rows on object search, ignored on the aggregations). It is logged rather than silent, and the follow-up 400 is where that asymmetry goes away.

## The reserved-param list, as found in the code

Never a filter on either spelling, and `filter[_limit]` is not a way in either:

- object search: every `_`-prefixed parameter (`MagicSearchHandler::getReservedParams()`: `_limit`, `_offset`, `_page`, `_order`, `_sort`, `_search`, `_extend`, `_fields`, `_filter`, `_unset`, `_facets`, `_facetable`, `_aggregations`, `_debug`, `_rbac`, `_multitenancy`, `_validation`, `_events`, `_register`, `_schema`, `_schemas`, `_ids`, `_count`, `_includeDeleted`, `_relations_contains`, `_multitenancy_explicit`, `_fuzzy`, `_empty`), the context parameters `register`, `schema`, `registers`, `schemas`, `extend`, and the system parameters `buildSearchQuery()` strips: `id`, `_route`, `rbac`, `multi`, `deleted`. The metadata names (`uuid`, `owner`, `organisation`, `application`, `created`, `updated`) still route to `@self`, under both spellings.
- aggregations, from `AggregationController` itself: the route placeholders `register` and `schema`, plus `name` on the declared-aggregation route; `value`: `metric`, `field`, `metrics`; `grouped`: those plus `groupBy`, `sort`, `limit`; `timeseries`: `field`, `interval`, `from`, `to`, `metric`, `metricField`, `cumulative`.

The non-underscore context list now has one home: `FilterParams::OBJECT_CONTEXT_PARAMS`, read by `MagicSearchHandler::getReservedParams()`. Two hand-kept copies would drift, and the way they drift is a context parameter read as a property filter, which answers `1 = 0` and says nothing.

## Fleet callers whose results change

Six callers, all in shillinq, pass `params: { filter: { … } }` to the objects endpoint, which axios serialises as `filter[x]=v`. Each gets rows where it got the empty set. This is a fix, and it is still a behaviour change:

- `src/components/purchase-order/PurchaseOrderDetail.vue:344` (`GoodsReceiptNote`, `poIds`) and `:355` (`ThreeWayMatch`, `matchedPoIds`)
- `src/components/goods-receipt-note/GoodsReceiptNoteDetail.vue:264` (`GoodsReceiptLine`, `grnId`) and `:297` (`ThreeWayMatch`, `grnIds`)
- `src/components/goods-receipt-note/GoodsReceiptNoteForm.vue:331` (`PurchaseOrderLine`, `poId`)
- `src/components/supplier-invoice/SupplierInvoiceDetail.vue:299` (`ThreeWayMatch`, `invoiceId`)

Each sits behind an empty-state placeholder today, so the visible change is a list that fills in.

No aggregation caller changes. Every one of them (nextcloud-vue `fetchAggregate`, `CnStatWidget`, `CnStatsBlockWidget`, `CnChartWidget`, `CnWorkspaceFilterWidget`, shillinq's two narrowing calls, opencatalogi's dashboard count) sends `filter[...]` plus control parameters only, and no bare parameter that names a schema property.

Three callers already worked around the defect and keep working unchanged: humaniq `src/integrations/hoursApi.js`, openbuild `ExportJobsList.vue`, planix `CnProjectsWidget.vue`. Their comments now describe a grammar that is no longer one-sided.

Scope note: this sweep read the local fleet clones (shillinq at 2026-09-08, nextcloud-vue at 2026-09-10), so a caller added after those dates is not in the list.

## Tests, each mutation-checked

`tests/Unit/Support/FilterParamsTest.php`, `tests/Unit/Controller/AggregationControllerFilterSpellingTest.php`, `tests/Unit/Service/Object/SearchQueryHandlerFilterSpellingTest.php`: 30 new tests covering both spellings on both endpoints, the control parameters, the unknown-key warning, and the cache key taken from the real `AggregationCache` rather than from a filter map.

Every guard was broken on purpose and watched to fail, then restored and diffed against a backup taken first:

| mutation | reddened | other 50 tests |
|---|---|---|
| object search stops lifting `filter[x]` | the 5 lift tests (the "schema declares `filter`" test stays green, correctly) | green |
| the aggregations stop reading bare keys | 9, including both cache-key tests | green |
| the filter is dropped from the cache-key hash | only `AggregationCacheTest::testDifferentFiltersProduceDifferentKeys` | green |
| the filter is dropped from both cache-key slots | 3, including `testTwoDifferentQueriesGetDifferentCacheKeys` | green |
| control parameters are no longer reserved | 6 | green |
| the unknown-key warning never fires | 2 | green |
| an unknown bare key is honoured as a filter | 2 | green |

The fifth mutation found a real defect in the first draft: the candidate check and the filter builder each kept their own copy of the reserved list, so unreserving a control parameter in one left the other short-circuiting and the guard stayed green. Both now read one builder, and the mutation reddens.

## Verification

- `COMPOSER_PROCESS_TIMEOUT=0 composer check:strict`: see the exit code in the PR discussion below.
- `vendor/bin/hydra-gates --base origin/development`: no FAIL.
- The table at the top was reproduced read-only against the shared dev instance at `localhost:8080` BEFORE the change. The branch is not deployed there, so the after column is from the unit tests, not from a live instance.

Spec: `openspec/specs/zoeken-filteren/spec.md` gains "Both filter spellings mean the same filter on object search and the aggregations", with the reserved-parameter rule, the declared-property condition, the warn-not-refuse rule and the cache-key rule, and five scenarios.

Refs #3611

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Verification

| Check | Result |
|---|---|
| hydra-gates | 105 run, exit 0, no FAIL; gate-16 and gate-46 PASS |
| phpunit | 19,870 tests, 48,747 assertions, **0 failures**, 30 more than `development`'s 19,840 |
| phpstan on the five touched files | `[OK] No errors` |
| eslint / phpcs / phpmd / psalm / lint | clean |
| em-dashes added | 0 |

`composer check:strict` exits 1 on this branch, and it exits 1 on `development` too. Both reasons are pre-existing and neither is this change:

- **phpstan** reports 1000+ errors repo-wide, capped at the first 1000, in `Db/`, `Controller/`, `BackgroundJob/` and elsewhere. Identical on `development`. Run against only the files this change touches it reports `[OK] No errors`.
- **phpunit** exits 1 on the single test-runner warning "No code coverage driver available", with `failOnWarning="false"` and zero failing tests. `development` exits 1 the same way with the same warning and the same 24 skips.

Mutation-checked rather than assumed:

- Making `liftBracketFilter` a no-op reddens exactly five tests across the unit and handler suites, and only those.
- Making the aggregation cache key constant reddens `testTwoDifferentQueriesGetDifferentCacheKeys`. Neutralising only the `filter` argument, or only `name`, does not: the key is over-determined and either carrier alone still distinguishes two queries, which is why the invariant holds.

## Fleet impact: none, measured

No app in `apps-extra` sends the bracket spelling to the objects endpoint any more; the one that did was humaniq's hours widget, already fixed. In the other direction the shared library helper `flattenAggFilter` emits `filter[k]` and `filter[k][op]`, the spelling the aggregations already read, so all 26 manifest stats-blocks and every chart and stat widget are unaffected. The nested operator form is covered by `testOperatorFilterReadsTheSameInBothSpellings`.
