### PR TITLE
fix(tmlo): one MDTO exporter, and a mets.xml that lists what the package ships

### DIFF
--- a/lib/Service/Edepot/MdtoDocumentWriter.php
+++ b/lib/Service/Edepot/MdtoDocumentWriter.php
@@ -141,6 +141,30 @@ class MdtoDocumentWriter {
 	}//end text()
 
 	/**
+	 * Add a text element, or nothing when there is no content.
+	 *
+	 * MDTO's rule for an optional element is the same everywhere: write it
+	 * when the object supplies a value, omit it entirely otherwise, never an
+	 * empty element. Having it in one place keeps that rule from drifting
+	 * between the elements that follow it.
+	 *
+	 * @param DOMElement $parent The parent element.
+	 * @param string $name The element name, without prefix.
+	 * @param string|null $content The text content, or null to write nothing.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	public function textIfPresent(DOMElement $parent, string $name, ?string $content): void {
+		if ($content === null) {
+			return;
+		}
+
+		$this->text(parent: $parent, name: $name, content: $content);
+	}//end textIfPresent()
+
+	/**
 	 * Add an empty element to be filled by the caller.
 	 *
 	 * @param DOMElement $parent The parent element.

--- a/lib/Service/Edepot/MdtoPreconditions.php
+++ b/lib/Service/Edepot/MdtoPreconditions.php
@@ -1,0 +1,242 @@
+<?php
+
+/**
+ * OpenRegister MDTO Preconditions
+ *
+ * What must be true before a document is generated, and what MDTO requires
+ * that the object cannot supply.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Edepot
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-mdto-generator-must-report-the-limits-of-its-own-validation
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Edepot;
+
+use InvalidArgumentException;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCP\IAppConfig;
+use Psr\Log\LoggerInterface;
+
+/**
+ * The checks that stand between an object and a document.
+ *
+ * Separate from {@see MdtoXmlGenerator} because they answer a different
+ * question: that one knows how to write MDTO, this one knows what must hold
+ * before it is worth writing, and what the standard requires that openregister
+ * cannot answer. Keeping them apart is also what lets the transfer rule and
+ * the serialising rules differ, which is the distinction the TMLO export
+ * endpoint depends on.
+ *
+ * @psalm-suppress UnusedClass
+ */
+class MdtoPreconditions {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IAppConfig $appConfig The app configuration for organisation settings.
+	 * @param LoggerInterface $logger Logger for error and warning messages.
+	 * @param MdtoSourceReader $sourceReader Resolver for the declared archival values.
+	 * @param MdtoBestandGenerator $bestandGenerator Owner of the per-file input rules.
+	 */
+	public function __construct(
+		private readonly IAppConfig $appConfig,
+		private readonly LoggerInterface $logger,
+		private readonly MdtoSourceReader $sourceReader,
+		private readonly MdtoBestandGenerator $bestandGenerator,
+	) {
+	}//end __construct()
+
+	/**
+	 * Refuse to TRANSFER a record whose retention period is unknown.
+	 *
+	 * This is openregister's own policy, not MDTO's. The standard marks
+	 * `bewaartermijn` "Verplicht: Ja, indien bekend", so {@see MdtoXmlGenerator::generate()}
+	 * omits the element when there is no period, which keeps an export honest
+	 * and is what the `/export/mdto` endpoint needs. Handing a record to an
+	 * e-Depot without saying how long it must be kept is a different act, and
+	 * the packaging path refuses it by calling this first.
+	 *
+	 * Separating the two is what lets one generator serve both callers. While
+	 * the rule lived inside `generate()`, exporting the metadata of a record
+	 * with no retention period was impossible.
+	 *
+	 * @param ObjectEntity $object The object about to be packaged.
+	 *
+	 * @return void
+	 *
+	 * @throws InvalidArgumentException When the object has no retention period.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-mdto-generator-must-report-the-limits-of-its-own-validation
+	 */
+	public function assertTransferPreconditions(ObjectEntity $object): void {
+		if ($this->sourceReader->coreFacts(object: $object)['retentionPeriod'] === null) {
+			throw new InvalidArgumentException(
+				'Cannot transfer object ' . $object->getUuid()
+				. ' to an e-Depot: it has no retention period. MDTO allows the element to be absent;'
+				. ' openregister refuses the transfer.'
+			);
+		}
+	}//end assertTransferPreconditions()
+
+
+	/**
+	 * List the MDTO-required elements this document fills with a default.
+	 *
+	 * The output validates, so no required element is ABSENT. What this
+	 * reports is the required element whose value is the standard's "not
+	 * recorded" term rather than something the object says, so a reader of
+	 * the log can tell a default from a fact.
+	 *
+	 * @param ObjectEntity $object The object to inspect.
+	 *
+	 * @return list<string> One line per defaulted element; empty when there is none.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-mdto-generator-must-report-the-limits-of-its-own-validation
+	 */
+	public function collectMdtoRequiredElementGaps(ObjectEntity $object): array {
+		$gaps = [];
+
+		if ($this->sourceReader->useRestriction(object: $object) === null) {
+			$gaps[] = 'beperkingGebruik: MDTO-XML1.0.1 declares minOccurs="1", and this object declares no '
+				. 'use restriction and carries no active legal hold, so it is emitted as "'
+				. MdtoXmlGenerator::USE_RESTRICTION_UNRECORDED . '"';
+		}
+
+		return $gaps;
+	}//end collectMdtoRequiredElementGaps()
+
+
+	/**
+	 * Check the inputs the generator needs, and refuse what the XSD would reject.
+	 *
+	 * A pass here means the generator can build a document the XSD accepts
+	 * for the elements it emits. It is not a judgement of the record, and it
+	 * does not replace the schema: `MdtoXmlGeneratorXsdTest` is what shows the
+	 * output validates.
+	 *
+	 * - `uuid` and the `organisation_identifier` setting fill `identificatie`.
+	 * - a non-empty `naam`.
+	 * - the appraisal, which must map onto the CLOSED Waarderingen list; see
+	 *   {@see MdtoXmlGenerator::APPRAISAL_MAP}.
+	 * - the retention period, WHEN the object has one, which must then be an
+	 *   `xsd:duration`. Its absence is not refused here: MDTO marks
+	 *   `bewaartermijn` "Verplicht: Ja, indien bekend" and `minOccurs="0"`, so
+	 *   a record whose period is unknown is exported without the element.
+	 *   Refusing to TRANSFER such a record is a separate, local policy, and it
+	 *   lives at the transfer boundary in {@see EdepotTransferService}.
+	 *
+	 * Both are read through {@see MdtoSourceReader}, so they are found in the
+	 * `retention` block or the `tmlo` block, whichever the object carries.
+	 * - every file's inputs; see {@see MdtoBestandGenerator::missingInputs()}.
+	 *
+	 * @param ObjectEntity $object The object to check.
+	 * @param array $files Associated file metadata.
+	 *
+	 * @return void
+	 *
+	 * @throws InvalidArgumentException If an input is missing or malformed.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-mdto-generator-must-report-the-limits-of-its-own-validation
+	 */
+	public function assertGeneratorPreconditions(ObjectEntity $object, array $files): void {
+		$missing = [];
+
+		if (empty($object->getUuid()) === true) {
+			$missing[] = 'uuid';
+		}
+
+		if ($this->sourceReader->name(object: $object) === '') {
+			$missing[] = 'naam';
+		}
+
+		$facts = $this->sourceReader->coreFacts(object: $object);
+		$nominatie = $facts['appraisal'];
+		if ($nominatie === null || isset(MdtoXmlGenerator::APPRAISAL_MAP[$nominatie]) === false) {
+			$missing[] = 'archiefnominatie (one of: ' . implode(', ', array_keys(MdtoXmlGenerator::APPRAISAL_MAP)) . ')';
+		}
+
+		$period = $facts['retentionPeriod'];
+		if ($period !== null && self::isXsdDuration(value: $period) === false) {
+			$missing[] = 'bewaartermijn (an ISO-8601 / xsd:duration such as P20Y)';
+		}
+
+		if ($this->appConfig->getValueString('openregister', 'organisation_identifier', '') === '') {
+			$missing[] = 'app_setting:organisation_identifier';
+		}
+
+		$missing = array_merge($missing, $this->bestandGenerator->missingInputs(files: $files));
+
+		if (empty($missing) === false) {
+			$missingStr = implode(', ', $missing);
+			$this->logger->error(
+				message: '[MdtoXmlGenerator] Cannot generate MDTO XML, inputs missing: ' . $missingStr,
+				context: ['objectUuid' => $object->getUuid()]
+			);
+			throw new InvalidArgumentException(
+				'Cannot generate MDTO XML for object ' . $object->getUuid()
+				. '. These generator inputs are missing: ' . $missingStr
+				. '. This check covers the generator inputs only and is not an MDTO validity check.'
+			);
+		}
+	}//end assertGeneratorPreconditions()
+
+
+	/**
+	 * Log the MDTO-required elements the document fills with a default.
+	 *
+	 * @param ObjectEntity $object The object being exported.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-mdto-generator-must-report-the-limits-of-its-own-validation
+	 */
+	public function reportMdtoRequiredElementGaps(ObjectEntity $object): void {
+		$gaps = $this->collectMdtoRequiredElementGaps(object: $object);
+		if (empty($gaps) === true) {
+			return;
+		}
+
+		$this->logger->warning(
+			message: '[MdtoXmlGenerator] Required MDTO elements carry the standard\'s "not recorded" term',
+			context: ['objectUuid' => $object->getUuid(), 'gaps' => $gaps]
+		);
+	}//end reportMdtoRequiredElementGaps()
+
+
+	/**
+	 * Whether a value is in the lexical space of `xsd:duration`.
+	 *
+	 * Stricter than PHP's DateInterval, which also accepts weeks (`P2W`);
+	 * `xsd:duration` has no week designator.
+	 *
+	 * @param mixed $value The value.
+	 *
+	 * @return bool True when it is.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	private static function isXsdDuration(mixed $value): bool {
+		if (is_string($value) === false) {
+			return false;
+		}
+
+		$pattern = '/^-?P(?=\d|T\d)(\d+Y)?(\d+M)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+(\.\d+)?S)?)?$/';
+		return preg_match($pattern, $value) === 1;
+	}//end isXsdDuration()
+}//end class

--- a/lib/Service/Edepot/MdtoSourceReader.php
+++ b/lib/Service/Edepot/MdtoSourceReader.php
@@ -85,6 +85,21 @@ class MdtoSourceReader {
 	public const CATEGORY_LIST_FALLBACK = 'Selectielijst';
 
 	/**
+	 * An `xsd:date`.
+	 */
+	private const XSD_DATE = '/^(\d{4}-\d{2}-\d{2})$/';
+
+	/**
+	 * The `xsd:gYear`, `xsd:gYearMonth` or `xsd:date` union the XSD declares.
+	 */
+	private const XSD_DATE_UNION = '/^(\d{4}(?:-\d{2}(?:-\d{2})?)?)$/';
+
+	/**
+	 * The date at the head of an ISO-8601 timestamp.
+	 */
+	private const XSD_DATE_PREFIX = '/^(\d{4}-\d{2}-\d{2})/';
+
+	/**
 	 * The appraisal decision, MDTO's `waardering`.
 	 *
 	 * @param ObjectEntity $object The object to read.
@@ -125,12 +140,8 @@ class MdtoSourceReader {
 	 */
 	public function disposalDate(ObjectEntity $object): ?string {
 		$value = $this->declaredValue(object: $object, abstractKey: 'archiefactiedatum', tmloKey: 'archiefactiedatum');
-		$date = $this->nonEmptyString(value: $value);
-		if ($date === null || preg_match('/^\d{4}-\d{2}-\d{2}$/', $date) !== 1) {
-			return null;
-		}
 
-		return $date;
+		return $this->matchOrNull(value: $value, pattern: self::XSD_DATE);
 	}//end disposalDate()
 
 	/**
@@ -478,11 +489,7 @@ class MdtoSourceReader {
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
 	 */
 	private function coverageDate(?string $value): ?string {
-		if ($value === null || preg_match('/^\d{4}(-\d{2}(-\d{2})?)?$/', $value) !== 1) {
-			return null;
-		}
-
-		return $value;
+		return $this->matchOrNull(value: $value, pattern: self::XSD_DATE_UNION);
 	}//end coverageDate()
 
 	/**
@@ -495,14 +502,29 @@ class MdtoSourceReader {
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-emit-mdto-aggregatieniveau-beperkinggebruik-and-dekkingintijd-from-their-declared-sources
 	 */
 	private function dateOnly(mixed $value): ?string {
-		if (is_string($value) === false || $value === '') {
-			return null;
-		}
-
-		if (preg_match('/^(\d{4}-\d{2}-\d{2})/', $value, $matches) !== 1) {
-			return null;
-		}
-
-		return $matches[1];
+		return $this->matchOrNull(value: $value, pattern: self::XSD_DATE_PREFIX);
 	}//end dateOnly()
+
+	/**
+	 * Return a value's first capture group when it matches, else null.
+	 *
+	 * One place where a stored value is checked against the lexical form its
+	 * XSD type demands, so a date can only reach a document in a form the
+	 * schema accepts.
+	 *
+	 * @param mixed $value The stored value.
+	 * @param string $pattern The pattern, whose first group is the result.
+	 *
+	 * @return string|null The matched text, or null when it does not match.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	private function matchOrNull(mixed $value, string $pattern): ?string {
+		$text = $this->nonEmptyString(value: $value);
+		if ($text !== null && preg_match($pattern, $text, $matches) === 1) {
+			return $matches[1];
+		}
+
+		return null;
+	}//end matchOrNull()
 }//end class

--- a/lib/Service/Edepot/MdtoSourceReader.php
+++ b/lib/Service/Edepot/MdtoSourceReader.php
@@ -107,7 +107,9 @@ class MdtoSourceReader {
 	 *
 	 * @param ObjectEntity $object The object to read.
 	 *
-	 * @return array{appraisal: string|null, retentionPeriod: string|null, disposalDate: string|null, disposalCategory: array{label: string, list: string}|null, classification: string|null, description: string|null} The facts.
+	 * @return array{appraisal: string|null, retentionPeriod: string|null,
+	 *     disposalDate: string|null, disposalCategory: array{label: string, list: string}|null,
+	 *     classification: string|null, description: string|null} The facts.
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
 	 */

--- a/lib/Service/Edepot/MdtoSourceReader.php
+++ b/lib/Service/Edepot/MdtoSourceReader.php
@@ -50,6 +50,14 @@ use OCA\OpenRegister\Db\ObjectEntity;
  * 2. The `tmlo` block under the Dutch key (`aggregatieniveau`,
  *    `dekkingInTijd`, `beperkingGebruik`).
  *
+ * The same two layers carry the CORE archival facts, which is what lets one
+ * generator serve both exports. An object written through the retention
+ * pipeline keeps them in `retention`; an object written through TMLO keeps
+ * them in `tmlo`, under TMLO's own spellings (`bewaarTermijn` with its
+ * capital T, `vernietigingsCategorie` for the disposal category). Reading
+ * both here is why `MdtoXmlGenerator` is the only implementation of the
+ * format and `TmloService` no longer has a second one.
+ *
  * Measured on 2026-09-11: NOTHING in this repository writes either key for any
  * of the three, so on current data all three elements are absent. They are
  * read rather than derived because no other stored field answers the
@@ -69,6 +77,146 @@ class MdtoSourceReader {
 	 * legal-hold type, so this is the term the standard provides for the case.
 	 */
 	public const USE_RESTRICTION_OTHER = 'Overig';
+
+	/**
+	 * The begrippenlijst name used for `informatiecategorie` when the record
+	 * does not say which selectielijst its category came from.
+	 */
+	public const CATEGORY_LIST_FALLBACK = 'Selectielijst';
+
+	/**
+	 * The appraisal decision, MDTO's `waardering`.
+	 *
+	 * @param ObjectEntity $object The object to read.
+	 *
+	 * @return string|null The stored archiefnominatie, or null when neither block carries one.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	public function appraisal(ObjectEntity $object): ?string {
+		$value = $this->declaredValue(object: $object, abstractKey: 'archiefnominatie', tmloKey: 'archiefnominatie');
+
+		return $this->nonEmptyString(value: $value);
+	}//end appraisal()
+
+	/**
+	 * The retention period, MDTO's `bewaartermijn`.
+	 *
+	 * @param ObjectEntity $object The object to read.
+	 *
+	 * @return string|null An ISO-8601 duration, or null when neither block carries one.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	public function retentionPeriod(ObjectEntity $object): ?string {
+		$value = $this->declaredValue(object: $object, abstractKey: 'bewaartermijn', tmloKey: 'bewaarTermijn');
+
+		return $this->nonEmptyString(value: $value);
+	}//end retentionPeriod()
+
+	/**
+	 * The date the retention period ends, MDTO's `termijnEinddatum`.
+	 *
+	 * @param ObjectEntity $object The object to read.
+	 *
+	 * @return string|null An xsd:date, or null when there is none in that form.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	public function disposalDate(ObjectEntity $object): ?string {
+		$value = $this->declaredValue(object: $object, abstractKey: 'archiefactiedatum', tmloKey: 'archiefactiedatum');
+		$date = $this->nonEmptyString(value: $value);
+		if ($date === null || preg_match('/^\d{4}-\d{2}-\d{2}$/', $date) !== 1) {
+			return null;
+		}
+
+		return $date;
+	}//end disposalDate()
+
+	/**
+	 * The disposal category and the list it came from, MDTO's `informatiecategorie`.
+	 *
+	 * TMLO calls this `vernietigingsCategorie`; the retention block calls it
+	 * `classification`. They are the same fact, the selectielijst category
+	 * that decides disposal, which is why MDTO has one element for it.
+	 *
+	 * @param ObjectEntity $object The object to read.
+	 *
+	 * @return array{label: string, list: string}|null The category, or null when there is none.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	public function disposalCategory(ObjectEntity $object): ?array {
+		$value = $this->declaredValue(
+			object: $object,
+			abstractKey: 'classification',
+			tmloKey: 'vernietigingsCategorie'
+		);
+
+		$label = $this->nonEmptyString(value: $value);
+		if ($label === null) {
+			return null;
+		}
+
+		$retention = ($object->getRetention() ?? []);
+		$list = $this->nonEmptyString(value: ($retention['selectielijstBron'] ?? null));
+
+		return ['label' => $label, 'list' => ($list ?? self::CATEGORY_LIST_FALLBACK)];
+	}//end disposalCategory()
+
+	/**
+	 * The classification scheme code, MDTO's `classificatie`.
+	 *
+	 * Only the TMLO block carries this as a fact of its own. In the retention
+	 * block `classification` is the disposal category, which is a different
+	 * element; see {@see self::disposalCategory()}.
+	 *
+	 * @param ObjectEntity $object The object to read.
+	 *
+	 * @return string|null The code, or null when the TMLO block carries none.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	public function classification(ObjectEntity $object): ?string {
+		$tmlo = ($object->getTmlo() ?? []);
+		if (is_array($tmlo) === false) {
+			return null;
+		}
+
+		return $this->nonEmptyString(value: ($tmlo['classification'] ?? null));
+	}//end classification()
+
+	/**
+	 * The free-text description, MDTO's `omschrijving`.
+	 *
+	 * @param ObjectEntity $object The object to read.
+	 *
+	 * @return string|null The text, or null when neither block carries one.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	public function description(ObjectEntity $object): ?string {
+		$value = $this->declaredValue(object: $object, abstractKey: 'toelichting', tmloKey: 'toelichting');
+
+		return $this->nonEmptyString(value: $value);
+	}//end description()
+
+	/**
+	 * A scalar read back as a non-empty string.
+	 *
+	 * @param mixed $value The stored value.
+	 *
+	 * @return string|null The string, or null when it is absent or empty.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	private function nonEmptyString(mixed $value): ?string {
+		if (is_scalar($value) === false || (string)$value === '') {
+			return null;
+		}
+
+		return (string)$value;
+	}//end nonEmptyString()
 
 	/**
 	 * Resolve the object's aggregatieniveau.

--- a/lib/Service/Edepot/MdtoSourceReader.php
+++ b/lib/Service/Edepot/MdtoSourceReader.php
@@ -69,6 +69,16 @@ use OCA\OpenRegister\Db\ObjectEntity;
 class MdtoSourceReader {
 
 	/**
+	 * Constructor.
+	 *
+	 * @param MdtoValueReader $values The primitives every archival read shares.
+	 */
+	public function __construct(
+		private readonly MdtoValueReader $values,
+	) {
+	}//end __construct()
+
+	/**
 	 * The `beperkingGebruikType` label used for an active legal hold.
 	 *
 	 * "Overig" is the BeperkingGebruikTypeLijst term for a restriction that is
@@ -84,65 +94,42 @@ class MdtoSourceReader {
 	 */
 	public const CATEGORY_LIST_FALLBACK = 'Selectielijst';
 
-	/**
-	 * An `xsd:date`.
-	 */
-	private const XSD_DATE = '/^(\d{4}-\d{2}-\d{2})$/';
 
 	/**
-	 * The `xsd:gYear`, `xsd:gYearMonth` or `xsd:date` union the XSD declares.
-	 */
-	private const XSD_DATE_UNION = '/^(\d{4}(?:-\d{2}(?:-\d{2})?)?)$/';
-
-	/**
-	 * The date at the head of an ISO-8601 timestamp.
-	 */
-	private const XSD_DATE_PREFIX = '/^(\d{4}-\d{2}-\d{2})/';
-
-	/**
-	 * The appraisal decision, MDTO's `waardering`.
+	 * The core archival facts, from whichever block carries them.
+	 *
+	 * One read rather than six, because they are one question: what does this
+	 * object say about its own archiving. An object written through the
+	 * retention pipeline keeps them in `retention`; one written through TMLO
+	 * keeps them in `tmlo` under TMLO's spellings, and `vernietigingsCategorie`
+	 * and `classification` are the disposal category and the classification
+	 * scheme, which MDTO keeps as separate elements.
 	 *
 	 * @param ObjectEntity $object The object to read.
 	 *
-	 * @return string|null The stored archiefnominatie, or null when neither block carries one.
+	 * @return array{appraisal: string|null, retentionPeriod: string|null, disposalDate: string|null, disposalCategory: array{label: string, list: string}|null, classification: string|null, description: string|null} The facts.
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
 	 */
-	public function appraisal(ObjectEntity $object): ?string {
-		$value = $this->declaredValue(object: $object, abstractKey: 'archiefnominatie', tmloKey: 'archiefnominatie');
-
-		return $this->nonEmptyString(value: $value);
-	}//end appraisal()
-
-	/**
-	 * The retention period, MDTO's `bewaartermijn`.
-	 *
-	 * @param ObjectEntity $object The object to read.
-	 *
-	 * @return string|null An ISO-8601 duration, or null when neither block carries one.
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
-	 */
-	public function retentionPeriod(ObjectEntity $object): ?string {
-		$value = $this->declaredValue(object: $object, abstractKey: 'bewaartermijn', tmloKey: 'bewaarTermijn');
-
-		return $this->nonEmptyString(value: $value);
-	}//end retentionPeriod()
-
-	/**
-	 * The date the retention period ends, MDTO's `termijnEinddatum`.
-	 *
-	 * @param ObjectEntity $object The object to read.
-	 *
-	 * @return string|null An xsd:date, or null when there is none in that form.
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
-	 */
-	public function disposalDate(ObjectEntity $object): ?string {
-		$value = $this->declaredValue(object: $object, abstractKey: 'archiefactiedatum', tmloKey: 'archiefactiedatum');
-
-		return $this->matchOrNull(value: $value, pattern: self::XSD_DATE);
-	}//end disposalDate()
+	public function coreFacts(ObjectEntity $object): array {
+		return [
+			'appraisal' => $this->values->text(
+				value: $this->values->declared(object: $object, abstractKey: 'archiefnominatie', tmloKey: 'archiefnominatie')
+			),
+			'retentionPeriod' => $this->values->text(
+				value: $this->values->declared(object: $object, abstractKey: 'bewaartermijn', tmloKey: 'bewaarTermijn')
+			),
+			'disposalDate' => $this->values->matching(
+				value: $this->values->declared(object: $object, abstractKey: 'archiefactiedatum', tmloKey: 'archiefactiedatum'),
+				pattern: MdtoValueReader::XSD_DATE
+			),
+			'disposalCategory' => $this->disposalCategory(object: $object),
+			'classification' => $this->values->textAt(value: $object->getTmlo(), key: 'classification'),
+			'description' => $this->values->text(
+				value: $this->values->declared(object: $object, abstractKey: 'toelichting', tmloKey: 'toelichting')
+			),
+		];
+	}//end coreFacts()
 
 	/**
 	 * The disposal category and the list it came from, MDTO's `informatiecategorie`.
@@ -157,77 +144,50 @@ class MdtoSourceReader {
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
 	 */
-	public function disposalCategory(ObjectEntity $object): ?array {
-		$value = $this->declaredValue(
-			object: $object,
-			abstractKey: 'classification',
-			tmloKey: 'vernietigingsCategorie'
+	private function disposalCategory(ObjectEntity $object): ?array {
+		$label = $this->values->text(
+			value: $this->values->declared(object: $object, abstractKey: 'classification', tmloKey: 'vernietigingsCategorie')
 		);
-
-		$label = $this->nonEmptyString(value: $value);
 		if ($label === null) {
 			return null;
 		}
 
-		$retention = ($object->getRetention() ?? []);
-		$list = $this->nonEmptyString(value: ($retention['selectielijstBron'] ?? null));
+		$list = $this->values->textAt(value: $object->getRetention(), key: 'selectielijstBron');
 
 		return ['label' => $label, 'list' => ($list ?? self::CATEGORY_LIST_FALLBACK)];
 	}//end disposalCategory()
 
 	/**
-	 * The classification scheme code, MDTO's `classificatie`.
+	 * The object's naam.
 	 *
-	 * Only the TMLO block carries this as a fact of its own. In the retention
-	 * block `classification` is the disposal category, which is a different
-	 * element; see {@see self::disposalCategory()}.
-	 *
-	 * @param ObjectEntity $object The object to read.
-	 *
-	 * @return string|null The code, or null when the TMLO block carries none.
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
-	 */
-	public function classification(ObjectEntity $object): ?string {
-		$tmlo = ($object->getTmlo() ?? []);
-		if (is_array($tmlo) === false) {
-			return null;
-		}
-
-		return $this->nonEmptyString(value: ($tmlo['classification'] ?? null));
-	}//end classification()
-
-	/**
-	 * The free-text description, MDTO's `omschrijving`.
+	 * The object's own data first, then the entity's `name` column, then the
+	 * uuid. The column matters: an object exported through the TMLO endpoint
+	 * carries its name there rather than in its data, and reading only the
+	 * data would have labelled every such record with its uuid.
 	 *
 	 * @param ObjectEntity $object The object to read.
 	 *
-	 * @return string|null The text, or null when neither block carries one.
+	 * @return string The name, empty when nothing supplies one.
 	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-generate-mdto-compliant-xml-metadata-per-object
 	 */
-	public function description(ObjectEntity $object): ?string {
-		$value = $this->declaredValue(object: $object, abstractKey: 'toelichting', tmloKey: 'toelichting');
+	public function name(ObjectEntity $object): string {
+		$data = ($object->getObject() ?? []);
+		$name = ($this->values->textAt(value: $data, key: 'title')
+			?? $this->values->textAt(value: $data, key: 'naam')
+			?? $this->values->textAt(value: $data, key: 'name')
+			?? $this->values->text(value: $object->getName())
+			?? $this->values->text(value: $object->getUuid()));
 
-		return $this->nonEmptyString(value: $value);
-	}//end description()
+		return ($name ?? '');
+	}//end name()
 
-	/**
-	 * A scalar read back as a non-empty string.
-	 *
-	 * @param mixed $value The stored value.
-	 *
-	 * @return string|null The string, or null when it is absent or empty.
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
-	 */
-	private function nonEmptyString(mixed $value): ?string {
-		if (is_scalar($value) === false || (string)$value === '') {
-			return null;
-		}
 
-		return (string)$value;
-	}//end nonEmptyString()
+
+
+
+
+
 
 	/**
 	 * Resolve the object's aggregatieniveau.
@@ -239,18 +199,18 @@ class MdtoSourceReader {
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-emit-mdto-aggregatieniveau-beperkinggebruik-and-dekkingintijd-from-their-declared-sources
 	 */
 	public function aggregationLevel(ObjectEntity $object): ?array {
-		$declared = $this->declaredValue(
+		$declared = $this->values->declared(
 			object: $object,
 			abstractKey: 'aggregationLevel',
 			tmloKey: 'aggregatieniveau'
 		);
 
-		$label = $this->labelOf(value: $declared);
+		$label = $this->values->label(value: $declared);
 		if ($label === null) {
 			return null;
 		}
 
-		return ['label' => $label, 'code' => $this->codeOf(value: $declared)];
+		return ['label' => $label, 'code' => $this->values->textAt(value: $declared, key: 'code')];
 	}//end aggregationLevel()
 
 	/**
@@ -272,7 +232,7 @@ class MdtoSourceReader {
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-emit-mdto-aggregatieniveau-beperkinggebruik-and-dekkingintijd-from-their-declared-sources
 	 */
 	public function temporalCoverage(ObjectEntity $object): array {
-		$declared = $this->declaredValue(
+		$declared = $this->values->declared(
 			object: $object,
 			abstractKey: 'temporalCoverage',
 			tmloKey: 'dekkingInTijd'
@@ -323,18 +283,21 @@ class MdtoSourceReader {
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-emit-mdto-aggregatieniveau-beperkinggebruik-and-dekkingintijd-from-their-declared-sources
 	 */
 	public function useRestriction(ObjectEntity $object): ?array {
-		$declared = $this->declaredValue(
+		$declared = $this->values->declared(
 			object: $object,
 			abstractKey: 'useRestriction',
 			tmloKey: 'beperkingGebruik'
 		);
 
-		$label = $this->labelOf(value: $declared);
+		$label = $this->values->label(value: $declared);
 		if ($label !== null) {
 			return [
 				'type' => $label,
-				'description' => $this->stringAt(value: $declared, key: 'description'),
-				'startDate' => $this->dateOnly(value: $this->stringAt(value: $declared, key: 'startDate')),
+				'description' => $this->values->textAt(value: $declared, key: 'description'),
+				'startDate' => $this->values->matching(
+					value: $this->values->textAt(value: $declared, key: 'startDate'),
+					pattern: MdtoValueReader::XSD_DATE_PREFIX
+				),
 			];
 		}
 
@@ -358,7 +321,7 @@ class MdtoSourceReader {
 		}
 
 		$description = 'Legal hold';
-		$reason = $this->stringAt(value: $hold, key: 'reason');
+		$reason = $this->values->textAt(value: $hold, key: 'reason');
 		if ($reason !== null) {
 			$description = 'Legal hold: ' . $reason;
 		}
@@ -366,7 +329,10 @@ class MdtoSourceReader {
 		return [
 			'type' => self::USE_RESTRICTION_OTHER,
 			'description' => $description,
-			'startDate' => $this->dateOnly(value: ($hold['placedDate'] ?? null)),
+			'startDate' => $this->values->matching(
+				value: ($hold['placedDate'] ?? null),
+				pattern: MdtoValueReader::XSD_DATE_PREFIX
+			),
 		];
 	}//end legalHoldRestriction()
 
@@ -388,143 +354,27 @@ class MdtoSourceReader {
 			return null;
 		}
 
-		$type = $this->stringAt(value: $entry, key: 'type');
-		$start = $this->coverageDate(value: $this->stringAt(value: $entry, key: 'start'));
+		$type = $this->values->textAt(value: $entry, key: 'type');
+		$start = $this->values->matching(
+			value: $this->values->textAt(value: $entry, key: 'start'),
+			pattern: MdtoValueReader::XSD_DATE_UNION
+		);
 		if ($type === null || $start === null) {
 			return null;
 		}
 
-		return ['type' => $type, 'start' => $start, 'end' => $this->coverageDate(value: $this->stringAt(value: $entry, key: 'end'))];
+		$end = $this->values->matching(
+			value: $this->values->textAt(value: $entry, key: 'end'),
+			pattern: MdtoValueReader::XSD_DATE_UNION
+		);
+
+		return ['type' => $type, 'start' => $start, 'end' => $end];
 	}//end completeCoverageEntry()
 
-	/**
-	 * Read a declared archival value from the abstract or the TMLO block.
-	 *
-	 * @param ObjectEntity $object The source object.
-	 * @param string $abstractKey The English key on the retention block.
-	 * @param string $tmloKey The Dutch key on the TMLO block.
-	 *
-	 * @return mixed The declared value, or null when neither block carries one.
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-emit-mdto-aggregatieniveau-beperkinggebruik-and-dekkingintijd-from-their-declared-sources
-	 */
-	private function declaredValue(ObjectEntity $object, string $abstractKey, string $tmloKey): mixed {
-		$retention = ($object->getRetention() ?? []);
-		if (isset($retention[$abstractKey]) === true) {
-			return $retention[$abstractKey];
-		}
 
-		$tmlo = ($object->getTmlo() ?? []);
-		if (is_array($tmlo) === true && isset($tmlo[$tmloKey]) === true) {
-			return $tmlo[$tmloKey];
-		}
 
-		return null;
-	}//end declaredValue()
 
-	/**
-	 * Read the begripLabel out of a declared value.
-	 *
-	 * A declared value may be a bare label string or an array carrying a
-	 * `label` or `type` key. Anything else yields null and the caller omits
-	 * the element.
-	 *
-	 * @param mixed $value The declared value.
-	 *
-	 * @return string|null The label, or null when there is none.
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-emit-mdto-aggregatieniveau-beperkinggebruik-and-dekkingintijd-from-their-declared-sources
-	 */
-	private function labelOf(mixed $value): ?string {
-		if (is_string($value) === true && $value !== '') {
-			return $value;
-		}
 
-		return ($this->stringAt(value: $value, key: 'label') ?? $this->stringAt(value: $value, key: 'type'));
-	}//end labelOf()
 
-	/**
-	 * Read the begripCode out of a declared value.
-	 *
-	 * @param mixed $value The declared value.
-	 *
-	 * @return string|null The code, or null when there is none.
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-emit-mdto-aggregatieniveau-beperkinggebruik-and-dekkingintijd-from-their-declared-sources
-	 */
-	private function codeOf(mixed $value): ?string {
-		return $this->stringAt(value: $value, key: 'code');
-	}//end codeOf()
 
-	/**
-	 * Read a non-empty string at a key of an array value.
-	 *
-	 * @param mixed $value The value, which need not be an array.
-	 * @param string $key The key to read.
-	 *
-	 * @return string|null The string, or null when it is absent or empty.
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-emit-mdto-aggregatieniveau-beperkinggebruik-and-dekkingintijd-from-their-declared-sources
-	 */
-	private function stringAt(mixed $value, string $key): ?string {
-		if (is_array($value) === false) {
-			return null;
-		}
-
-		$candidate = ($value[$key] ?? null);
-		if (is_string($candidate) === true && $candidate !== '') {
-			return $candidate;
-		}
-
-		return null;
-	}//end stringAt()
-
-	/**
-	 * Accept a date only in a form the XSD's dekkingInTijd union allows.
-	 *
-	 * @param string|null $value The declared date.
-	 *
-	 * @return string|null The value when it is a gYear, gYearMonth or date; null otherwise.
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
-	 */
-	private function coverageDate(?string $value): ?string {
-		return $this->matchOrNull(value: $value, pattern: self::XSD_DATE_UNION);
-	}//end coverageDate()
-
-	/**
-	 * Reduce an ISO-8601 timestamp to the xsd:date the termijn element needs.
-	 *
-	 * @param mixed $value The stored timestamp.
-	 *
-	 * @return string|null The date part, or null when the value is unusable.
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-emit-mdto-aggregatieniveau-beperkinggebruik-and-dekkingintijd-from-their-declared-sources
-	 */
-	private function dateOnly(mixed $value): ?string {
-		return $this->matchOrNull(value: $value, pattern: self::XSD_DATE_PREFIX);
-	}//end dateOnly()
-
-	/**
-	 * Return a value's first capture group when it matches, else null.
-	 *
-	 * One place where a stored value is checked against the lexical form its
-	 * XSD type demands, so a date can only reach a document in a form the
-	 * schema accepts.
-	 *
-	 * @param mixed $value The stored value.
-	 * @param string $pattern The pattern, whose first group is the result.
-	 *
-	 * @return string|null The matched text, or null when it does not match.
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
-	 */
-	private function matchOrNull(mixed $value, string $pattern): ?string {
-		$text = $this->nonEmptyString(value: $value);
-		if ($text !== null && preg_match($pattern, $text, $matches) === 1) {
-			return $matches[1];
-		}
-
-		return null;
-	}//end matchOrNull()
 }//end class

--- a/lib/Service/Edepot/MdtoValueReader.php
+++ b/lib/Service/Edepot/MdtoValueReader.php
@@ -1,0 +1,167 @@
+<?php
+
+/**
+ * OpenRegister MDTO Value Reader
+ *
+ * Reads raw archival values out of an object's blocks, in the lexical forms
+ * MDTO's XSD types accept.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Edepot
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenRegister.app
+ *
+ * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Edepot;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+
+/**
+ * The primitives every archival read shares.
+ *
+ * Two layers carry the facts: the `retention` block under the abstract
+ * English key, and the `tmlo` block under TMLO's own Dutch spelling. Reading
+ * both is what lets one generator serve the e-Depot export and the TMLO
+ * export endpoint.
+ *
+ * Kept apart from {@see MdtoSourceReader} because these answer "what does the
+ * object literally store", while that answers "what does MDTO get". A value
+ * only leaves here in a form the schema's type accepts, so a malformed date
+ * cannot reach a document.
+ *
+ * @psalm-suppress UnusedClass
+ */
+class MdtoValueReader {
+
+	/**
+	 * An `xsd:date`.
+	 */
+	public const XSD_DATE = '/^(\d{4}-\d{2}-\d{2})$/';
+
+	/**
+	 * The `xsd:gYear`, `xsd:gYearMonth` or `xsd:date` union the XSD declares.
+	 */
+	public const XSD_DATE_UNION = '/^(\d{4}(?:-\d{2}(?:-\d{2})?)?)$/';
+
+	/**
+	 * The date at the head of an ISO-8601 timestamp.
+	 */
+	public const XSD_DATE_PREFIX = '/^(\d{4}-\d{2}-\d{2})/';
+
+	/**
+	 * Read a declared value from the retention block, else the TMLO block.
+	 *
+	 * @param ObjectEntity $object The source object.
+	 * @param string $abstractKey The English key on the retention block.
+	 * @param string $tmloKey The Dutch key on the TMLO block.
+	 *
+	 * @return mixed The declared value, or null when neither block carries one.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-emit-mdto-aggregatieniveau-beperkinggebruik-and-dekkingintijd-from-their-declared-sources
+	 */
+	public function declared(ObjectEntity $object, string $abstractKey, string $tmloKey): mixed {
+		$retention = ($object->getRetention() ?? []);
+		if (is_array($retention) === true && isset($retention[$abstractKey]) === true) {
+			return $retention[$abstractKey];
+		}
+
+		return $this->valueAt(value: $object->getTmlo(), key: $tmloKey);
+	}//end declared()
+
+	/**
+	 * A scalar read back as a non-empty string.
+	 *
+	 * @param mixed $value The stored value.
+	 *
+	 * @return string|null The string, or null when it is absent or empty.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-emit-mdto-aggregatieniveau-beperkinggebruik-and-dekkingintijd-from-their-declared-sources
+	 */
+	public function text(mixed $value): ?string {
+		if (is_scalar($value) === false || (string)$value === '') {
+			return null;
+		}
+
+		return (string)$value;
+	}//end text()
+
+	/**
+	 * Read a value at a key, when the container is an array.
+	 *
+	 * @param mixed $value The container, which need not be an array.
+	 * @param string $key The key to read.
+	 *
+	 * @return mixed The value, or null.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-emit-mdto-aggregatieniveau-beperkinggebruik-and-dekkingintijd-from-their-declared-sources
+	 */
+	public function valueAt(mixed $value, string $key): mixed {
+		if (is_array($value) === false) {
+			return null;
+		}
+
+		return ($value[$key] ?? null);
+	}//end at()
+
+	/**
+	 * Read a non-empty string at a key of an array value.
+	 *
+	 * @param mixed $value The container, which need not be an array.
+	 * @param string $key The key to read.
+	 *
+	 * @return string|null The string, or null when it is absent or empty.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-emit-mdto-aggregatieniveau-beperkinggebruik-and-dekkingintijd-from-their-declared-sources
+	 */
+	public function textAt(mixed $value, string $key): ?string {
+		return $this->text(value: $this->valueAt(value: $value, key: $key));
+	}//end textAt()
+
+	/**
+	 * The begripLabel of a declared value, which may be a bare string.
+	 *
+	 * @param mixed $value The declared value.
+	 *
+	 * @return string|null The label, or null when there is none.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-emit-mdto-aggregatieniveau-beperkinggebruik-and-dekkingintijd-from-their-declared-sources
+	 */
+	public function label(mixed $value): ?string {
+		return ($this->text(value: $value) ?? $this->textAt(value: $value, key: 'label') ?? $this->textAt(value: $value, key: 'type'));
+	}//end label()
+
+	/**
+	 * Return a value's first capture group when it matches, else null.
+	 *
+	 * One place where a stored value is checked against the lexical form its
+	 * XSD type demands.
+	 *
+	 * @param mixed $value The stored value.
+	 * @param string $pattern The pattern, whose first group is the result.
+	 *
+	 * @return string|null The matched text, or null when it does not match.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
+	 */
+	public function matching(mixed $value, string $pattern): ?string {
+		$text = $this->text(value: $value);
+		if ($text !== null && preg_match($pattern, $text, $matches) === 1) {
+			return $matches[1];
+		}
+
+		return null;
+	}//end matching()
+}//end class

--- a/lib/Service/Edepot/MdtoXmlGenerator.php
+++ b/lib/Service/Edepot/MdtoXmlGenerator.php
@@ -240,7 +240,7 @@ class MdtoXmlGenerator {
 	/**
 	 * Refuse to TRANSFER a record whose retention period is unknown.
 	 *
-	 * openregister's own policy, not MDTO's. The standard marks
+	 * This is openregister's own policy, not MDTO's. The standard marks
 	 * `bewaartermijn` "Verplicht: Ja, indien bekend", so {@see self::generate()}
 	 * omits the element when there is no period, which keeps an export honest
 	 * and is what the `/export/mdto` endpoint needs. Handing a record to an

--- a/lib/Service/Edepot/MdtoXmlGenerator.php
+++ b/lib/Service/Edepot/MdtoXmlGenerator.php
@@ -196,10 +196,11 @@ class MdtoXmlGenerator {
 		$this->addAggregationLevel(parent: $root, object: $object);
 		$this->addClassification(parent: $root, object: $object);
 
-		$description = $this->sourceReader->description(object: $object);
-		if ($description !== null) {
-			$this->writer->text(parent: $root, name: 'omschrijving', content: $description);
-		}
+		$this->writer->textIfPresent(
+			parent: $root,
+			name: 'omschrijving',
+			content: $this->sourceReader->description(object: $object)
+		);
 
 		$this->addTemporalCoverage(parent: $root, object: $object);
 		$this->addEvents(parent: $root, object: $object);
@@ -425,15 +426,12 @@ class MdtoXmlGenerator {
 	 */
 	private function addAggregationLevel(DOMElement $parent, ObjectEntity $object): void {
 		$level = $this->sourceReader->aggregationLevel(object: $object);
-		if ($level === null) {
-			return;
-		}
 
-		$this->writer->begrip(
+		$this->addOptionalBegrip(
 			parent: $parent,
 			name: 'aggregatieniveau',
-			label: $level['label'],
-			code: $level['code'],
+			label: ($level['label'] ?? null),
+			code: ($level['code'] ?? null),
 			list: self::AGGREGATION_LEVEL_LIST
 		);
 	}//end addAggregationLevel()
@@ -463,9 +461,7 @@ class MdtoXmlGenerator {
 			);
 			$this->writer->text(parent: $coverage, name: 'dekkingInTijdBegindatum', content: $entry['start']);
 
-			if ($entry['end'] !== null) {
-				$this->writer->text(parent: $coverage, name: 'dekkingInTijdEinddatum', content: $entry['end']);
-			}
+			$this->writer->textIfPresent(parent: $coverage, name: 'dekkingInTijdEinddatum', content: $entry['end']);
 		}
 	}//end addTemporalCoverage()
 
@@ -494,9 +490,7 @@ class MdtoXmlGenerator {
 				list: MdtoEventMapper::EVENT_TYPE_LIST
 			);
 
-			if ($event['time'] !== null) {
-				$this->writer->text(parent: $element, name: 'eventTijd', content: $event['time']);
-			}
+			$this->writer->textIfPresent(parent: $element, name: 'eventTijd', content: $event['time']);
 
 			if ($event['actorName'] !== null) {
 				$this->writer->verwijzing(
@@ -549,13 +543,8 @@ class MdtoXmlGenerator {
 		}
 
 		$term = $this->writer->element(parent: $parent, name: 'bewaartermijn');
-		if ($period !== null) {
-			$this->writer->text(parent: $term, name: 'termijnLooptijd', content: $period);
-		}
-
-		if ($end !== null) {
-			$this->writer->text(parent: $term, name: 'termijnEinddatum', content: $end);
-		}
+		$this->writer->textIfPresent(parent: $term, name: 'termijnLooptijd', content: $period);
+		$this->writer->textIfPresent(parent: $term, name: 'termijnEinddatum', content: $end);
 	}//end addRetentionPeriod()
 
 	/**
@@ -575,16 +564,13 @@ class MdtoXmlGenerator {
 	 */
 	private function addInformatiecategorie(DOMElement $parent, ObjectEntity $object): void {
 		$category = $this->sourceReader->disposalCategory(object: $object);
-		if ($category === null) {
-			return;
-		}
 
-		$this->writer->begrip(
+		$this->addOptionalBegrip(
 			parent: $parent,
 			name: 'informatiecategorie',
-			label: $category['label'],
+			label: ($category['label'] ?? null),
 			code: null,
-			list: $category['list']
+			list: ($category['list'] ?? self::CATEGORY_LIST_FALLBACK)
 		);
 	}//end addInformatiecategorie()
 
@@ -602,19 +588,45 @@ class MdtoXmlGenerator {
 	 * @spec openspec/specs/tmlo-export/spec.md#requirement-mdto-compliant-xml-export
 	 */
 	private function addClassification(DOMElement $parent, ObjectEntity $object): void {
-		$code = $this->sourceReader->classification(object: $object);
-		if ($code === null) {
-			return;
-		}
-
-		$this->writer->begrip(
+		$this->addOptionalBegrip(
 			parent: $parent,
 			name: 'classificatie',
-			label: $code,
+			label: $this->sourceReader->classification(object: $object),
 			code: null,
 			list: self::CLASSIFICATION_LIST
 		);
 	}//end addClassification()
+
+	/**
+	 * Add a `begripGegevens` element, or nothing when there is no label.
+	 *
+	 * Every optional begrip element follows the same rule: emit it when the
+	 * object supplies a term, omit it entirely otherwise, never a placeholder.
+	 * One method so that rule cannot drift between the three.
+	 *
+	 * @param DOMElement $parent The informatieobject element.
+	 * @param string $name The element name, without prefix.
+	 * @param string|null $label The term, or null to omit the element.
+	 * @param string|null $code The code, omitted when null.
+	 * @param string $list The begrippenlijst name.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-emit-mdto-aggregatieniveau-beperkinggebruik-and-dekkingintijd-from-their-declared-sources
+	 */
+	private function addOptionalBegrip(
+		DOMElement $parent,
+		string $name,
+		?string $label,
+		?string $code,
+		string $list,
+	): void {
+		if ($label === null) {
+			return;
+		}
+
+		$this->writer->begrip(parent: $parent, name: $name, label: $label, code: $code, list: $list);
+	}//end addOptionalBegrip()
 
 	/**
 	 * Add one `heeftRepresentatie` reference per file.
@@ -691,13 +703,11 @@ class MdtoXmlGenerator {
 			list: self::USE_RESTRICTION_LIST
 		);
 
-		if ($restriction['description'] !== null) {
-			$this->writer->text(
-				parent: $element,
-				name: 'beperkingGebruikNadereBeschrijving',
-				content: $restriction['description']
-			);
-		}
+		$this->writer->textIfPresent(
+			parent: $element,
+			name: 'beperkingGebruikNadereBeschrijving',
+			content: $restriction['description']
+		);
 
 		if ($restriction['startDate'] !== null) {
 			$term = $this->writer->element(parent: $element, name: 'beperkingGebruikTermijn');

--- a/lib/Service/Edepot/MdtoXmlGenerator.php
+++ b/lib/Service/Edepot/MdtoXmlGenerator.php
@@ -156,6 +156,7 @@ class MdtoXmlGenerator {
 	 * @param MdtoSourceReader $sourceReader Resolver for the declared archival values.
 	 * @param MdtoDocumentWriter $writer The XML primitives.
 	 * @param MdtoBestandGenerator $bestandGenerator Builder of a file's own document.
+	 * @param MdtoPreconditions $preconditions What must hold before a document is worth writing.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,
@@ -164,6 +165,7 @@ class MdtoXmlGenerator {
 		private readonly MdtoSourceReader $sourceReader,
 		private readonly MdtoDocumentWriter $writer,
 		private readonly MdtoBestandGenerator $bestandGenerator,
+		private readonly MdtoPreconditions $preconditions,
 	) {
 	}//end __construct()
 
@@ -185,34 +187,66 @@ class MdtoXmlGenerator {
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
 	 */
 	public function generate(ObjectEntity $object, array $files = []): string {
-		$this->assertGeneratorPreconditions(object: $object, files: $files);
-		$this->reportMdtoRequiredElementGaps(object: $object);
+		$this->preconditions->assertGeneratorPreconditions(object: $object, files: $files);
+		$this->preconditions->reportMdtoRequiredElementGaps(object: $object);
 
 		[$dom, $root] = $this->writer->createDocument(kind: 'informatieobject');
 
+		$facts = $this->sourceReader->coreFacts(object: $object);
 		$self = $this->representedObject(object: $object);
 		$this->writer->identificatie(parent: $root, name: 'identificatie', kenmerk: $self['kenmerk'], bron: $self['bron']);
 		$this->writer->text(parent: $root, name: 'naam', content: $self['naam']);
 		$this->addAggregationLevel(parent: $root, object: $object);
-		$this->addClassification(parent: $root, object: $object);
+		$this->addClassification(parent: $root, facts: $facts);
 
 		$this->writer->textIfPresent(
 			parent: $root,
 			name: 'omschrijving',
-			content: $this->sourceReader->description(object: $object)
+			content: $facts['description']
 		);
 
 		$this->addTemporalCoverage(parent: $root, object: $object);
 		$this->addEvents(parent: $root, object: $object);
-		$this->addRating(parent: $root, object: $object);
-		$this->addRetentionPeriod(parent: $root, object: $object);
-		$this->addInformatiecategorie(parent: $root, object: $object);
+		$this->addRating(parent: $root, facts: $facts);
+		$this->addRetentionPeriod(parent: $root, facts: $facts);
+		$this->addInformatiecategorie(parent: $root, facts: $facts);
 		$this->addRepresentations(parent: $root, files: $files);
 		$this->addArchiefvormer(parent: $root);
 		$this->addUseRestriction(parent: $root, object: $object);
 
 		return $this->writer->serialise(dom: $dom);
 	}//end generate()
+
+	/**
+	 * Refuse to TRANSFER a record whose retention period is unknown.
+	 *
+	 * Delegates to {@see MdtoPreconditions::assertTransferPreconditions()};
+	 * kept on the generator because the packaging path already holds one.
+	 *
+	 * @param ObjectEntity $object The object about to be packaged.
+	 *
+	 * @return void
+	 *
+	 * @throws InvalidArgumentException When the object has no retention period.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-mdto-generator-must-report-the-limits-of-its-own-validation
+	 */
+	public function assertTransferPreconditions(ObjectEntity $object): void {
+		$this->preconditions->assertTransferPreconditions(object: $object);
+	}//end assertTransferPreconditions()
+
+	/**
+	 * List the MDTO-required elements a document fills with a default.
+	 *
+	 * @param ObjectEntity $object The object to inspect.
+	 *
+	 * @return list<string> One line per defaulted element; empty when there is none.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-mdto-generator-must-report-the-limits-of-its-own-validation
+	 */
+	public function collectMdtoRequiredElementGaps(ObjectEntity $object): array {
+		return $this->preconditions->collectMdtoRequiredElementGaps(object: $object);
+	}//end collectMdtoRequiredElementGaps()
 
 	/**
 	 * Generate the MDTO `bestand` document for one of the object's files.
@@ -238,157 +272,9 @@ class MdtoXmlGenerator {
 		return $this->bestandGenerator->generate(file: $file, represents: $this->representedObject(object: $object));
 	}//end generateBestand()
 
-	/**
-	 * Refuse to TRANSFER a record whose retention period is unknown.
-	 *
-	 * This is openregister's own policy, not MDTO's. The standard marks
-	 * `bewaartermijn` "Verplicht: Ja, indien bekend", so {@see self::generate()}
-	 * omits the element when there is no period, which keeps an export honest
-	 * and is what the `/export/mdto` endpoint needs. Handing a record to an
-	 * e-Depot without saying how long it must be kept is a different act, and
-	 * the packaging path refuses it by calling this first.
-	 *
-	 * Separating the two is what lets one generator serve both callers. While
-	 * the rule lived inside `generate()`, exporting the metadata of a record
-	 * with no retention period was impossible.
-	 *
-	 * @param ObjectEntity $object The object about to be packaged.
-	 *
-	 * @return void
-	 *
-	 * @throws InvalidArgumentException When the object has no retention period.
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-mdto-generator-must-report-the-limits-of-its-own-validation
-	 */
-	public function assertTransferPreconditions(ObjectEntity $object): void {
-		if ($this->sourceReader->retentionPeriod(object: $object) === null) {
-			throw new InvalidArgumentException(
-				'Cannot transfer object ' . $object->getUuid()
-				. ' to an e-Depot: it has no retention period. MDTO allows the element to be absent;'
-				. ' openregister refuses the transfer.'
-			);
-		}
-	}//end assertTransferPreconditions()
 
-	/**
-	 * List the MDTO-required elements this document fills with a default.
-	 *
-	 * The output validates, so no required element is ABSENT. What this
-	 * reports is the required element whose value is the standard's "not
-	 * recorded" term rather than something the object says, so a reader of
-	 * the log can tell a default from a fact.
-	 *
-	 * @param ObjectEntity $object The object to inspect.
-	 *
-	 * @return list<string> One line per defaulted element; empty when there is none.
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-mdto-generator-must-report-the-limits-of-its-own-validation
-	 */
-	public function collectMdtoRequiredElementGaps(ObjectEntity $object): array {
-		$gaps = [];
 
-		if ($this->sourceReader->useRestriction(object: $object) === null) {
-			$gaps[] = 'beperkingGebruik: MDTO-XML1.0.1 declares minOccurs="1", and this object declares no '
-				. 'use restriction and carries no active legal hold, so it is emitted as "'
-				. self::USE_RESTRICTION_UNRECORDED . '"';
-		}
 
-		return $gaps;
-	}//end collectMdtoRequiredElementGaps()
-
-	/**
-	 * Check the inputs the generator needs, and refuse what the XSD would reject.
-	 *
-	 * A pass here means the generator can build a document the XSD accepts
-	 * for the elements it emits. It is not a judgement of the record, and it
-	 * does not replace the schema: `MdtoXmlGeneratorXsdTest` is what shows the
-	 * output validates.
-	 *
-	 * - `uuid` and the `organisation_identifier` setting fill `identificatie`.
-	 * - a non-empty `naam`.
-	 * - the appraisal, which must map onto the CLOSED Waarderingen list; see
-	 *   {@see self::APPRAISAL_MAP}.
-	 * - the retention period, WHEN the object has one, which must then be an
-	 *   `xsd:duration`. Its absence is not refused here: MDTO marks
-	 *   `bewaartermijn` "Verplicht: Ja, indien bekend" and `minOccurs="0"`, so
-	 *   a record whose period is unknown is exported without the element.
-	 *   Refusing to TRANSFER such a record is a separate, local policy, and it
-	 *   lives at the transfer boundary in {@see EdepotTransferService}.
-	 *
-	 * Both are read through {@see MdtoSourceReader}, so they are found in the
-	 * `retention` block or the `tmlo` block, whichever the object carries.
-	 * - every file's inputs; see {@see MdtoBestandGenerator::missingInputs()}.
-	 *
-	 * @param ObjectEntity $object The object to check.
-	 * @param array $files Associated file metadata.
-	 *
-	 * @return void
-	 *
-	 * @throws InvalidArgumentException If an input is missing or malformed.
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-mdto-generator-must-report-the-limits-of-its-own-validation
-	 */
-	private function assertGeneratorPreconditions(ObjectEntity $object, array $files): void {
-		$missing = [];
-
-		if (empty($object->getUuid()) === true) {
-			$missing[] = 'uuid';
-		}
-
-		if ($this->resolveName(object: $object) === '') {
-			$missing[] = 'naam';
-		}
-
-		$nominatie = $this->sourceReader->appraisal(object: $object);
-		if ($nominatie === null || isset(self::APPRAISAL_MAP[$nominatie]) === false) {
-			$missing[] = 'archiefnominatie (one of: ' . implode(', ', array_keys(self::APPRAISAL_MAP)) . ')';
-		}
-
-		$period = $this->sourceReader->retentionPeriod(object: $object);
-		if ($period !== null && self::isXsdDuration(value: $period) === false) {
-			$missing[] = 'bewaartermijn (an ISO-8601 / xsd:duration such as P20Y)';
-		}
-
-		if ($this->appConfig->getValueString('openregister', 'organisation_identifier', '') === '') {
-			$missing[] = 'app_setting:organisation_identifier';
-		}
-
-		$missing = array_merge($missing, $this->bestandGenerator->missingInputs(files: $files));
-
-		if (empty($missing) === false) {
-			$missingStr = implode(', ', $missing);
-			$this->logger->error(
-				message: '[MdtoXmlGenerator] Cannot generate MDTO XML, inputs missing: ' . $missingStr,
-				context: ['objectUuid' => $object->getUuid()]
-			);
-			throw new InvalidArgumentException(
-				'Cannot generate MDTO XML for object ' . $object->getUuid()
-				. '. These generator inputs are missing: ' . $missingStr
-				. '. This check covers the generator inputs only and is not an MDTO validity check.'
-			);
-		}
-	}//end assertGeneratorPreconditions()
-
-	/**
-	 * Log the MDTO-required elements the document fills with a default.
-	 *
-	 * @param ObjectEntity $object The object being exported.
-	 *
-	 * @return void
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-mdto-generator-must-report-the-limits-of-its-own-validation
-	 */
-	private function reportMdtoRequiredElementGaps(ObjectEntity $object): void {
-		$gaps = $this->collectMdtoRequiredElementGaps(object: $object);
-		if (empty($gaps) === true) {
-			return;
-		}
-
-		$this->logger->warning(
-			message: '[MdtoXmlGenerator] Required MDTO elements carry the standard\'s "not recorded" term',
-			context: ['objectUuid' => $object->getUuid(), 'gaps' => $gaps]
-		);
-	}//end reportMdtoRequiredElementGaps()
 
 	/**
 	 * The object's own naam and identificatie, as a document refers to it.
@@ -404,7 +290,7 @@ class MdtoXmlGenerator {
 	 */
 	private function representedObject(ObjectEntity $object): array {
 		return [
-			'naam' => $this->resolveName(object: $object),
+			'naam' => $this->sourceReader->name(object: $object),
 			'kenmerk' => (string)$object->getUuid(),
 			'bron' => $this->organisationIdentifier(),
 		];
@@ -508,14 +394,14 @@ class MdtoXmlGenerator {
 	 * Add `waardering`, a `begripGegevens` from the closed Waarderingen list.
 	 *
 	 * @param DOMElement $parent The informatieobject element.
-	 * @param ObjectEntity $object The source object.
+	 * @param array $facts The object's core archival facts.
 	 *
 	 * @return void
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
 	 */
-	private function addRating(DOMElement $parent, ObjectEntity $object): void {
-		[$code, $label] = self::APPRAISAL_MAP[(string)$this->sourceReader->appraisal(object: $object)];
+	private function addRating(DOMElement $parent, array $facts): void {
+		[$code, $label] = self::APPRAISAL_MAP[(string)$facts['appraisal']];
 
 		$this->writer->begrip(parent: $parent, name: 'waardering', label: $label, code: $code, list: self::APPRAISAL_LIST);
 	}//end addRating()
@@ -529,15 +415,15 @@ class MdtoXmlGenerator {
 	 * duration, and the TMLO block stores it under the same name.
 	 *
 	 * @param DOMElement $parent The informatieobject element.
-	 * @param ObjectEntity $object The source object.
+	 * @param array $facts The object's core archival facts.
 	 *
 	 * @return void
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
 	 */
-	private function addRetentionPeriod(DOMElement $parent, ObjectEntity $object): void {
-		$period = $this->sourceReader->retentionPeriod(object: $object);
-		$end = $this->sourceReader->disposalDate(object: $object);
+	private function addRetentionPeriod(DOMElement $parent, array $facts): void {
+		$period = $facts['retentionPeriod'];
+		$end = $facts['disposalDate'];
 		if ($period === null && $end === null) {
 			return;
 		}
@@ -556,14 +442,14 @@ class MdtoXmlGenerator {
 	 * {@see MdtoSourceReader::disposalCategory()}.
 	 *
 	 * @param DOMElement $parent The informatieobject element.
-	 * @param ObjectEntity $object The source object.
+	 * @param array $facts The object's core archival facts.
 	 *
 	 * @return void
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
 	 */
-	private function addInformatiecategorie(DOMElement $parent, ObjectEntity $object): void {
-		$category = $this->sourceReader->disposalCategory(object: $object);
+	private function addInformatiecategorie(DOMElement $parent, array $facts): void {
+		$category = $facts['disposalCategory'];
 
 		$this->addOptionalBegrip(
 			parent: $parent,
@@ -581,17 +467,17 @@ class MdtoXmlGenerator {
 	 * and the selectielijst category as separate elements, and so does TMLO.
 	 *
 	 * @param DOMElement $parent The informatieobject element.
-	 * @param ObjectEntity $object The source object.
+	 * @param array $facts The object's core archival facts.
 	 *
 	 * @return void
 	 *
 	 * @spec openspec/specs/tmlo-export/spec.md#requirement-mdto-compliant-xml-export
 	 */
-	private function addClassification(DOMElement $parent, ObjectEntity $object): void {
+	private function addClassification(DOMElement $parent, array $facts): void {
 		$this->addOptionalBegrip(
 			parent: $parent,
 			name: 'classificatie',
-			label: $this->sourceReader->classification(object: $object),
+			label: $facts['classification'],
 			code: null,
 			list: self::CLASSIFICATION_LIST
 		);
@@ -715,26 +601,6 @@ class MdtoXmlGenerator {
 		}
 	}//end addUseRestriction()
 
-	/**
-	 * Resolve the object's naam.
-	 *
-	 * The object's own data first, then the entity's `name` column, then the
-	 * uuid. The column matters: an object exported through the TMLO endpoint
-	 * carries its name there rather than in its data, and reading only the
-	 * data would have labelled every such record with its uuid.
-	 *
-	 * @param ObjectEntity $object The source object.
-	 *
-	 * @return string The name, empty when nothing supplies one.
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-generate-mdto-compliant-xml-metadata-per-object
-	 */
-	private function resolveName(ObjectEntity $object): string {
-		$data = ($object->getObject() ?? []);
-		$title = ($data['title'] ?? $data['naam'] ?? $data['name'] ?? $object->getName() ?? $object->getUuid() ?? '');
-
-		return (string)$title;
-	}//end resolveName()
 
 	/**
 	 * The configured organisation identifier.
@@ -747,24 +613,4 @@ class MdtoXmlGenerator {
 		return $this->appConfig->getValueString('openregister', 'organisation_identifier', 'OpenRegister');
 	}//end organisationIdentifier()
 
-	/**
-	 * Whether a value is in the lexical space of `xsd:duration`.
-	 *
-	 * Stricter than PHP's DateInterval, which also accepts weeks (`P2W`);
-	 * `xsd:duration` has no week designator.
-	 *
-	 * @param mixed $value The value.
-	 *
-	 * @return bool True when it is.
-	 *
-	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
-	 */
-	private static function isXsdDuration(mixed $value): bool {
-		if (is_string($value) === false) {
-			return false;
-		}
-
-		$pattern = '/^-?P(?=\d|T\d)(\d+Y)?(\d+M)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+(\.\d+)?S)?)?$/';
-		return preg_match($pattern, $value) === 1;
-	}//end isXsdDuration()
 }//end class

--- a/lib/Service/Edepot/MdtoXmlGenerator.php
+++ b/lib/Service/Edepot/MdtoXmlGenerator.php
@@ -32,7 +32,6 @@ use DOMElement;
 use InvalidArgumentException;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCP\IAppConfig;
-use Psr\Log\LoggerInterface;
 
 /**
  * Generator for MDTO `informatieobject` documents, and the entry point for a file's `bestand` document.
@@ -151,7 +150,6 @@ class MdtoXmlGenerator {
 	 * Constructor.
 	 *
 	 * @param IAppConfig $appConfig The app configuration for organisation settings.
-	 * @param LoggerInterface $logger Logger for error and info messages.
 	 * @param MdtoEventMapper $eventMapper Source of the MDTO event history.
 	 * @param MdtoSourceReader $sourceReader Resolver for the declared archival values.
 	 * @param MdtoDocumentWriter $writer The XML primitives.
@@ -160,7 +158,6 @@ class MdtoXmlGenerator {
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,
-		private readonly LoggerInterface $logger,
 		private readonly MdtoEventMapper $eventMapper,
 		private readonly MdtoSourceReader $sourceReader,
 		private readonly MdtoDocumentWriter $writer,

--- a/lib/Service/Edepot/MdtoXmlGenerator.php
+++ b/lib/Service/Edepot/MdtoXmlGenerator.php
@@ -115,7 +115,16 @@ class MdtoXmlGenerator {
 	 * The begrippenlijst name used for `informatiecategorie` when the record
 	 * does not say which selectielijst its category came from.
 	 */
-	public const CATEGORY_LIST_FALLBACK = 'Selectielijst';
+	public const CATEGORY_LIST_FALLBACK = MdtoSourceReader::CATEGORY_LIST_FALLBACK;
+
+	/**
+	 * The begrippenlijst name used for `classificatie`.
+	 *
+	 * MDTO leaves this list free. openregister does not record which scheme a
+	 * TMLO classification code came from, so the element names the kind of
+	 * list it is rather than claiming a specific one.
+	 */
+	public const CLASSIFICATION_LIST = 'Classificatieschema';
 
 	/**
 	 * `archiefnominatie` to the closed Waarderingen list: code and label.
@@ -176,9 +185,7 @@ class MdtoXmlGenerator {
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
 	 */
 	public function generate(ObjectEntity $object, array $files = []): string {
-		$retention = ($object->getRetention() ?? []);
-
-		$this->assertGeneratorPreconditions(object: $object, retention: $retention, files: $files);
+		$this->assertGeneratorPreconditions(object: $object, files: $files);
 		$this->reportMdtoRequiredElementGaps(object: $object);
 
 		[$dom, $root] = $this->writer->createDocument(kind: 'informatieobject');
@@ -187,16 +194,18 @@ class MdtoXmlGenerator {
 		$this->writer->identificatie(parent: $root, name: 'identificatie', kenmerk: $self['kenmerk'], bron: $self['bron']);
 		$this->writer->text(parent: $root, name: 'naam', content: $self['naam']);
 		$this->addAggregationLevel(parent: $root, object: $object);
+		$this->addClassification(parent: $root, object: $object);
 
-		if (is_string($retention['toelichting'] ?? null) === true && $retention['toelichting'] !== '') {
-			$this->writer->text(parent: $root, name: 'omschrijving', content: $retention['toelichting']);
+		$description = $this->sourceReader->description(object: $object);
+		if ($description !== null) {
+			$this->writer->text(parent: $root, name: 'omschrijving', content: $description);
 		}
 
 		$this->addTemporalCoverage(parent: $root, object: $object);
 		$this->addEvents(parent: $root, object: $object);
-		$this->addRating(parent: $root, retention: $retention);
-		$this->addRetentionPeriod(parent: $root, retention: $retention);
-		$this->addInformatiecategorie(parent: $root, retention: $retention);
+		$this->addRating(parent: $root, object: $object);
+		$this->addRetentionPeriod(parent: $root, object: $object);
+		$this->addInformatiecategorie(parent: $root, object: $object);
 		$this->addRepresentations(parent: $root, files: $files);
 		$this->addArchiefvormer(parent: $root);
 		$this->addUseRestriction(parent: $root, object: $object);
@@ -227,6 +236,38 @@ class MdtoXmlGenerator {
 
 		return $this->bestandGenerator->generate(file: $file, represents: $this->representedObject(object: $object));
 	}//end generateBestand()
+
+	/**
+	 * Refuse to TRANSFER a record whose retention period is unknown.
+	 *
+	 * openregister's own policy, not MDTO's. The standard marks
+	 * `bewaartermijn` "Verplicht: Ja, indien bekend", so {@see self::generate()}
+	 * omits the element when there is no period, which keeps an export honest
+	 * and is what the `/export/mdto` endpoint needs. Handing a record to an
+	 * e-Depot without saying how long it must be kept is a different act, and
+	 * the packaging path refuses it by calling this first.
+	 *
+	 * Separating the two is what lets one generator serve both callers. While
+	 * the rule lived inside `generate()`, exporting the metadata of a record
+	 * with no retention period was impossible.
+	 *
+	 * @param ObjectEntity $object The object about to be packaged.
+	 *
+	 * @return void
+	 *
+	 * @throws InvalidArgumentException When the object has no retention period.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-mdto-generator-must-report-the-limits-of-its-own-validation
+	 */
+	public function assertTransferPreconditions(ObjectEntity $object): void {
+		if ($this->sourceReader->retentionPeriod(object: $object) === null) {
+			throw new InvalidArgumentException(
+				'Cannot transfer object ' . $object->getUuid()
+				. ' to an e-Depot: it has no retention period. MDTO allows the element to be absent;'
+				. ' openregister refuses the transfer.'
+			);
+		}
+	}//end assertTransferPreconditions()
 
 	/**
 	 * List the MDTO-required elements this document fills with a default.
@@ -264,15 +305,20 @@ class MdtoXmlGenerator {
 	 *
 	 * - `uuid` and the `organisation_identifier` setting fill `identificatie`.
 	 * - a non-empty `naam`.
-	 * - `retention.archiefnominatie`, which must map onto the CLOSED
-	 *   Waarderingen list; see {@see self::APPRAISAL_MAP}.
-	 * - `retention.bewaartermijn`, which must be an `xsd:duration`. Requiring
-	 *   it at all is a LOCAL rule, stricter than MDTO, where `bewaartermijn`
-	 *   is `minOccurs="0"`.
+	 * - the appraisal, which must map onto the CLOSED Waarderingen list; see
+	 *   {@see self::APPRAISAL_MAP}.
+	 * - the retention period, WHEN the object has one, which must then be an
+	 *   `xsd:duration`. Its absence is not refused here: MDTO marks
+	 *   `bewaartermijn` "Verplicht: Ja, indien bekend" and `minOccurs="0"`, so
+	 *   a record whose period is unknown is exported without the element.
+	 *   Refusing to TRANSFER such a record is a separate, local policy, and it
+	 *   lives at the transfer boundary in {@see EdepotTransferService}.
+	 *
+	 * Both are read through {@see MdtoSourceReader}, so they are found in the
+	 * `retention` block or the `tmlo` block, whichever the object carries.
 	 * - every file's inputs; see {@see MdtoBestandGenerator::missingInputs()}.
 	 *
 	 * @param ObjectEntity $object The object to check.
-	 * @param array<string,mixed> $retention The retention metadata.
 	 * @param array $files Associated file metadata.
 	 *
 	 * @return void
@@ -281,7 +327,7 @@ class MdtoXmlGenerator {
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-mdto-generator-must-report-the-limits-of-its-own-validation
 	 */
-	private function assertGeneratorPreconditions(ObjectEntity $object, array $retention, array $files): void {
+	private function assertGeneratorPreconditions(ObjectEntity $object, array $files): void {
 		$missing = [];
 
 		if (empty($object->getUuid()) === true) {
@@ -292,13 +338,14 @@ class MdtoXmlGenerator {
 			$missing[] = 'naam';
 		}
 
-		$nominatie = ($retention['archiefnominatie'] ?? null);
-		if (is_string($nominatie) === false || isset(self::APPRAISAL_MAP[$nominatie]) === false) {
-			$missing[] = 'retention.archiefnominatie (one of: ' . implode(', ', array_keys(self::APPRAISAL_MAP)) . ')';
+		$nominatie = $this->sourceReader->appraisal(object: $object);
+		if ($nominatie === null || isset(self::APPRAISAL_MAP[$nominatie]) === false) {
+			$missing[] = 'archiefnominatie (one of: ' . implode(', ', array_keys(self::APPRAISAL_MAP)) . ')';
 		}
 
-		if (self::isXsdDuration(value: ($retention['bewaartermijn'] ?? null)) === false) {
-			$missing[] = 'retention.bewaartermijn (an ISO-8601 / xsd:duration such as P20Y)';
+		$period = $this->sourceReader->retentionPeriod(object: $object);
+		if ($period !== null && self::isXsdDuration(value: $period) === false) {
+			$missing[] = 'bewaartermijn (an ISO-8601 / xsd:duration such as P20Y)';
 		}
 
 		if ($this->appConfig->getValueString('openregister', 'organisation_identifier', '') === '') {
@@ -467,14 +514,14 @@ class MdtoXmlGenerator {
 	 * Add `waardering`, a `begripGegevens` from the closed Waarderingen list.
 	 *
 	 * @param DOMElement $parent The informatieobject element.
-	 * @param array<string,mixed> $retention The retention metadata.
+	 * @param ObjectEntity $object The source object.
 	 *
 	 * @return void
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
 	 */
-	private function addRating(DOMElement $parent, array $retention): void {
-		[$code, $label] = self::APPRAISAL_MAP[(string)$retention['archiefnominatie']];
+	private function addRating(DOMElement $parent, ObjectEntity $object): void {
+		[$code, $label] = self::APPRAISAL_MAP[(string)$this->sourceReader->appraisal(object: $object)];
 
 		$this->writer->begrip(parent: $parent, name: 'waardering', label: $label, code: $code, list: self::APPRAISAL_LIST);
 	}//end addRating()
@@ -482,24 +529,31 @@ class MdtoXmlGenerator {
 	/**
 	 * Add `bewaartermijn`, a `termijnGegevens`.
 	 *
-	 * `termijnLooptijd` carries the duration. `termijnEinddatum` carries
-	 * `retention.archiefactiedatum` when the record has one, which is the
-	 * date the retention period ends: RetentionService computes it from the
-	 * same duration.
+	 * `termijnLooptijd` carries the duration. `termijnEinddatum` carries the
+	 * archiefactiedatum when the record has one, which is the date the
+	 * retention period ends: RetentionService computes it from the same
+	 * duration, and the TMLO block stores it under the same name.
 	 *
 	 * @param DOMElement $parent The informatieobject element.
-	 * @param array<string,mixed> $retention The retention metadata.
+	 * @param ObjectEntity $object The source object.
 	 *
 	 * @return void
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
 	 */
-	private function addRetentionPeriod(DOMElement $parent, array $retention): void {
-		$term = $this->writer->element(parent: $parent, name: 'bewaartermijn');
-		$this->writer->text(parent: $term, name: 'termijnLooptijd', content: (string)$retention['bewaartermijn']);
+	private function addRetentionPeriod(DOMElement $parent, ObjectEntity $object): void {
+		$period = $this->sourceReader->retentionPeriod(object: $object);
+		$end = $this->sourceReader->disposalDate(object: $object);
+		if ($period === null && $end === null) {
+			return;
+		}
 
-		$end = ($retention['archiefactiedatum'] ?? null);
-		if (is_string($end) === true && preg_match('/^\d{4}-\d{2}-\d{2}$/', $end) === 1) {
+		$term = $this->writer->element(parent: $parent, name: 'bewaartermijn');
+		if ($period !== null) {
+			$this->writer->text(parent: $term, name: 'termijnLooptijd', content: $period);
+		}
+
+		if ($end !== null) {
 			$this->writer->text(parent: $term, name: 'termijnEinddatum', content: $end);
 		}
 	}//end addRetentionPeriod()
@@ -507,41 +561,60 @@ class MdtoXmlGenerator {
 	/**
 	 * Add `informatiecategorie`, a `begripGegevens`, when the record has a category.
 	 *
-	 * Omitted, not defaulted, when there is no `retention.classification`: the
-	 * XSD makes the element `minOccurs="0"`, and the placeholder `onbekend`
-	 * this used to write was a value nobody had recorded.
-	 *
-	 * The begrippenlijst is the selectielijst named in
-	 * `retention.selectielijstBron`. When the record does not name one, the
-	 * generic term "Selectielijst" is used, because the category is only ever
-	 * written from a selectielijst lookup and the list's own name is unknown.
+	 * Omitted, not defaulted, when there is none: the XSD makes the element
+	 * `minOccurs="0"`, and the placeholder `onbekend` this used to write was a
+	 * value nobody had recorded. The source and its begrippenlijst belong to
+	 * {@see MdtoSourceReader::disposalCategory()}.
 	 *
 	 * @param DOMElement $parent The informatieobject element.
-	 * @param array<string,mixed> $retention The retention metadata.
+	 * @param ObjectEntity $object The source object.
 	 *
 	 * @return void
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-generated-mdto-documents-must-validate-against-the-vendored-mdto-xml-1-0-1-xsd
 	 */
-	private function addInformatiecategorie(DOMElement $parent, array $retention): void {
-		$category = ($retention['classification'] ?? null);
-		if (is_scalar($category) === false || (string)$category === '') {
+	private function addInformatiecategorie(DOMElement $parent, ObjectEntity $object): void {
+		$category = $this->sourceReader->disposalCategory(object: $object);
+		if ($category === null) {
 			return;
-		}
-
-		$list = ($retention['selectielijstBron'] ?? null);
-		if (is_string($list) === false || $list === '') {
-			$list = self::CATEGORY_LIST_FALLBACK;
 		}
 
 		$this->writer->begrip(
 			parent: $parent,
 			name: 'informatiecategorie',
-			label: (string)$category,
+			label: $category['label'],
 			code: null,
-			list: $list
+			list: $category['list']
 		);
 	}//end addInformatiecategorie()
+
+	/**
+	 * Add `classificatie` when the object carries a classification code.
+	 *
+	 * This is not the disposal category: MDTO keeps the classification scheme
+	 * and the selectielijst category as separate elements, and so does TMLO.
+	 *
+	 * @param DOMElement $parent The informatieobject element.
+	 * @param ObjectEntity $object The source object.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/tmlo-export/spec.md#requirement-mdto-compliant-xml-export
+	 */
+	private function addClassification(DOMElement $parent, ObjectEntity $object): void {
+		$code = $this->sourceReader->classification(object: $object);
+		if ($code === null) {
+			return;
+		}
+
+		$this->writer->begrip(
+			parent: $parent,
+			name: 'classificatie',
+			label: $code,
+			code: null,
+			list: self::CLASSIFICATION_LIST
+		);
+	}//end addClassification()
 
 	/**
 	 * Add one `heeftRepresentatie` reference per file.
@@ -635,6 +708,11 @@ class MdtoXmlGenerator {
 	/**
 	 * Resolve the object's naam.
 	 *
+	 * The object's own data first, then the entity's `name` column, then the
+	 * uuid. The column matters: an object exported through the TMLO endpoint
+	 * carries its name there rather than in its data, and reading only the
+	 * data would have labelled every such record with its uuid.
+	 *
 	 * @param ObjectEntity $object The source object.
 	 *
 	 * @return string The name, empty when nothing supplies one.
@@ -643,7 +721,7 @@ class MdtoXmlGenerator {
 	 */
 	private function resolveName(ObjectEntity $object): string {
 		$data = ($object->getObject() ?? []);
-		$title = ($data['title'] ?? $data['naam'] ?? $data['name'] ?? $object->getUuid() ?? '');
+		$title = ($data['title'] ?? $data['naam'] ?? $data['name'] ?? $object->getName() ?? $object->getUuid() ?? '');
 
 		return (string)$title;
 	}//end resolveName()

--- a/lib/Service/Edepot/SipPackageBuilder.php
+++ b/lib/Service/Edepot/SipPackageBuilder.php
@@ -539,42 +539,14 @@ class SipPackageBuilder {
 			$objectDiv->setAttribute('TYPE', 'object');
 			$rootDiv->appendChild($objectDiv);
 
-			foreach ($files as $file) {
-				$fileId = 'FILE-' . $fileCounter;
-				$fileCounter++;
-
-				$isRendition = ($file['isRendition'] === true);
-				$subDir = 'original';
-				if ($isRendition === true) {
-					$subDir = 'rendition';
-				}
-
-				$filePath = "objects/{$uuid}/content/{$subDir}/{$file['name']}";
-
-				$fileElement = $dom->createElementNS(self::METS_NAMESPACE, 'mets:file');
-				$fileElement->setAttribute('ID', $fileId);
-				$fileElement->setAttribute('SIZE', (string)$file['size']);
-				$fileElement->setAttribute('MIMETYPE', $file['format']);
-				$fileElement->setAttribute('CHECKSUM', $file['checksum']);
-				$fileElement->setAttribute('CHECKSUMTYPE', 'SHA-256');
-
-				$fLocat = $dom->createElementNS(self::METS_NAMESPACE, 'mets:FLocat');
-				$fLocat->setAttribute('LOCTYPE', 'URL');
-				$fLocat->setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', $filePath);
-				$fileElement->appendChild($fLocat);
-
-				if ($isRendition === true) {
-					$renditionGrp->appendChild($fileElement);
-				}
-
-				if ($isRendition === false) {
-					$originalGrp->appendChild($fileElement);
-				}
-
-				$fptr = $dom->createElementNS(self::METS_NAMESPACE, 'mets:fptr');
-				$fptr->setAttribute('FILEID', $fileId);
-				$objectDiv->appendChild($fptr);
-			}//end foreach
+			$fileCounter = $this->appendContentFiles(
+				dom: $dom,
+				groups: ['original' => $originalGrp, 'rendition' => $renditionGrp],
+				objectDiv: $objectDiv,
+				uuid: (string)$uuid,
+				files: $files,
+				fileCounter: $fileCounter
+			);
 
 			$fileCounter = $this->appendMetadataFiles(
 				dom: $dom,
@@ -587,6 +559,62 @@ class SipPackageBuilder {
 
 		return $dom->saveXML();
 	}//end generateMetsXml()
+
+	/**
+	 * List an object's content files in the METS file section.
+	 *
+	 * @param DOMDocument $dom The METS document.
+	 * @param array<string,DOMElement> $groups The ORIGINAL and RENDITION file groups.
+	 * @param DOMElement $objectDiv The object's div, which points at them.
+	 * @param string $uuid The object uuid, for the file paths.
+	 * @param array $files The object's file metadata.
+	 * @param int $fileCounter The running METS file id counter.
+	 *
+	 * @return int The counter after these files.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-assemble-sip-packages-for-e-depot-transfer
+	 */
+	private function appendContentFiles(
+		DOMDocument $dom,
+		array $groups,
+		DOMElement $objectDiv,
+		string $uuid,
+		array $files,
+		int $fileCounter,
+	): int {
+		foreach ($files as $file) {
+			$fileId = 'FILE-' . $fileCounter;
+			$fileCounter++;
+
+			$subDir = 'original';
+			if ($file['isRendition'] === true) {
+				$subDir = 'rendition';
+			}
+
+			$element = $dom->createElementNS(self::METS_NAMESPACE, 'mets:file');
+			$element->setAttribute('ID', $fileId);
+			$element->setAttribute('SIZE', (string)$file['size']);
+			$element->setAttribute('MIMETYPE', $file['format']);
+			$element->setAttribute('CHECKSUM', $file['checksum']);
+			$element->setAttribute('CHECKSUMTYPE', 'SHA-256');
+
+			$locat = $dom->createElementNS(self::METS_NAMESPACE, 'mets:FLocat');
+			$locat->setAttribute('LOCTYPE', 'URL');
+			$locat->setAttributeNS(
+				'http://www.w3.org/1999/xlink',
+				'xlink:href',
+				"objects/{$uuid}/content/{$subDir}/{$file['name']}"
+			);
+			$element->appendChild($locat);
+			$groups[$subDir]->appendChild($element);
+
+			$pointer = $dom->createElementNS(self::METS_NAMESPACE, 'mets:fptr');
+			$pointer->setAttribute('FILEID', $fileId);
+			$objectDiv->appendChild($pointer);
+		}
+
+		return $fileCounter;
+	}//end appendContentFiles()
 
 	/**
 	 * List an object's MDTO documents in the METS file section.

--- a/lib/Service/Edepot/SipPackageBuilder.php
+++ b/lib/Service/Edepot/SipPackageBuilder.php
@@ -251,6 +251,11 @@ class SipPackageBuilder {
 			$uuid = $object->getUuid();
 			$objectDir = "objects/{$uuid}";
 
+			// The retention period is required to TRANSFER, though MDTO allows
+			// the element to be absent. Asking here keeps the export endpoint
+			// able to serialise a record whose period is unknown.
+			$this->mdtoGenerator->assertTransferPreconditions($object);
+
 			$mdtoXml = $this->mdtoGenerator->generate($object, $files);
 			$entries[] = ['path' => "{$objectDir}/mdto.xml", 'kind' => 'string', 'content' => $mdtoXml];
 			$manifest[] = $this->createManifestEntry(path: "{$objectDir}/mdto.xml", content: $mdtoXml);

--- a/lib/Service/Edepot/SipPackageBuilder.php
+++ b/lib/Service/Edepot/SipPackageBuilder.php
@@ -188,13 +188,14 @@ class SipPackageBuilder {
 	 * @param ObjectEntity $object The object the files belong to.
 	 * @param array $files The object's file metadata.
 	 *
-	 * @return array{entries: list<array<string, mixed>>, manifest: list<array<string, mixed>>} The rows to add.
+	 * @return array{entries: list<array<string, mixed>>, manifest: list<array<string, mixed>>, metadata: list<array<string, mixed>>} The rows to add.
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-assemble-sip-packages-for-e-depot-transfer
 	 */
 	private function contentFileEntries(string $objectDir, ObjectEntity $object, array $files): array {
 		$entries = [];
 		$manifest = [];
+		$metadata = [];
 
 		foreach ($files as $file) {
 			if (file_exists($file['path']) === false) {
@@ -214,9 +215,10 @@ class SipPackageBuilder {
 			$bestandPath = $filePath . MdtoBestandGenerator::SIDECAR_SUFFIX;
 			$entries[] = ['path' => $bestandPath, 'kind' => 'string', 'content' => $bestandXml];
 			$manifest[] = $this->createManifestEntry(path: $bestandPath, content: $bestandXml);
+			$metadata[] = $this->createManifestEntry(path: $bestandPath, content: $bestandXml);
 		}
 
-		return ['entries' => $entries, 'manifest' => $manifest];
+		return ['entries' => $entries, 'manifest' => $manifest, 'metadata' => $metadata];
 	}//end contentFileEntries()
 
 	/**
@@ -244,6 +246,9 @@ class SipPackageBuilder {
 		// an in-memory string or an on-disk file, with its logical SIP path.
 		$entries = [];
 		$manifest = [];
+		// The MDTO documents the package ships, per object, so mets.xml can
+		// list them. A manifest that omits files it ships is not a manifest.
+		$metadataFiles = [];
 
 		foreach ($objectsWithFiles as $item) {
 			$object = $item['object'];
@@ -259,6 +264,7 @@ class SipPackageBuilder {
 			$mdtoXml = $this->mdtoGenerator->generate($object, $files);
 			$entries[] = ['path' => "{$objectDir}/mdto.xml", 'kind' => 'string', 'content' => $mdtoXml];
 			$manifest[] = $this->createManifestEntry(path: "{$objectDir}/mdto.xml", content: $mdtoXml);
+			$metadataFiles[$uuid][] = $this->createManifestEntry(path: "{$objectDir}/mdto.xml", content: $mdtoXml);
 
 			$metadataJson = json_encode($object->jsonSerialize(), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
 			$entries[] = ['path' => "{$objectDir}/metadata.json", 'kind' => 'string', 'content' => $metadataJson];
@@ -267,9 +273,14 @@ class SipPackageBuilder {
 			$fileEntries = $this->contentFileEntries(objectDir: $objectDir, object: $object, files: $files);
 			$entries = array_merge($entries, $fileEntries['entries']);
 			$manifest = array_merge($manifest, $fileEntries['manifest']);
+			$metadataFiles[$uuid] = array_merge(($metadataFiles[$uuid] ?? []), $fileEntries['metadata']);
 		}//end foreach
 
-		$metsXml = $this->generateMetsXml(transferId: $transferId, objectsWithFiles: $objectsWithFiles);
+		$metsXml = $this->generateMetsXml(
+			transferId: $transferId,
+			objectsWithFiles: $objectsWithFiles,
+			metadataFiles: $metadataFiles
+		);
 		$entries[] = ['path' => 'mets.xml', 'kind' => 'string', 'content' => $metsXml];
 		$manifest[] = $this->createManifestEntry(path: 'mets.xml', content: $metsXml);
 
@@ -480,7 +491,7 @@ class SipPackageBuilder {
 	 *
 	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-generate-mdto-compliant-xml-metadata-per-object
 	 */
-	private function generateMetsXml(string $transferId, array $objectsWithFiles): string {
+	private function generateMetsXml(string $transferId, array $objectsWithFiles, array $metadataFiles = []): string {
 		$dom = new DOMDocument('1.0', 'UTF-8');
 		$dom->formatOutput = true;
 
@@ -499,6 +510,13 @@ class SipPackageBuilder {
 		$renditionGrp = $dom->createElementNS(self::METS_NAMESPACE, 'mets:fileGrp');
 		$renditionGrp->setAttribute('USE', 'RENDITION');
 		$fileSec->appendChild($renditionGrp);
+
+		// The MDTO documents travel in the package too: the object's own and
+		// one per file. Leaving them out of fileSec made mets.xml describe
+		// less than the package contains.
+		$metadataGrp = $dom->createElementNS(self::METS_NAMESPACE, 'mets:fileGrp');
+		$metadataGrp->setAttribute('USE', 'METADATA');
+		$fileSec->appendChild($metadataGrp);
 
 		$structMap = $dom->createElementNS(self::METS_NAMESPACE, 'mets:structMap');
 		$structMap->setAttribute('TYPE', 'physical');
@@ -554,6 +572,28 @@ class SipPackageBuilder {
 				$fptr = $dom->createElementNS(self::METS_NAMESPACE, 'mets:fptr');
 				$fptr->setAttribute('FILEID', $fileId);
 				$objectDiv->appendChild($fptr);
+			}//end foreach
+
+			foreach (($metadataFiles[$uuid] ?? []) as $metadataFile) {
+				$metadataId = 'MD-' . $fileCounter;
+				$fileCounter++;
+
+				$metadataElement = $dom->createElementNS(self::METS_NAMESPACE, 'mets:file');
+				$metadataElement->setAttribute('ID', $metadataId);
+				$metadataElement->setAttribute('SIZE', (string)$metadataFile['size']);
+				$metadataElement->setAttribute('MIMETYPE', 'application/xml');
+				$metadataElement->setAttribute('CHECKSUM', $metadataFile['checksum']);
+				$metadataElement->setAttribute('CHECKSUMTYPE', 'SHA-256');
+
+				$metadataLocat = $dom->createElementNS(self::METS_NAMESPACE, 'mets:FLocat');
+				$metadataLocat->setAttribute('LOCTYPE', 'URL');
+				$metadataLocat->setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', $metadataFile['path']);
+				$metadataElement->appendChild($metadataLocat);
+				$metadataGrp->appendChild($metadataElement);
+
+				$metadataPointer = $dom->createElementNS(self::METS_NAMESPACE, 'mets:fptr');
+				$metadataPointer->setAttribute('FILEID', $metadataId);
+				$objectDiv->appendChild($metadataPointer);
 			}//end foreach
 		}//end foreach
 

--- a/lib/Service/Edepot/SipPackageBuilder.php
+++ b/lib/Service/Edepot/SipPackageBuilder.php
@@ -274,7 +274,7 @@ class SipPackageBuilder {
 			$fileEntries = $this->contentFileEntries(objectDir: $objectDir, object: $object, files: $files);
 			$entries = array_merge($entries, $fileEntries['entries']);
 			$manifest = array_merge($manifest, $fileEntries['manifest']);
-			$metadataFiles[$uuid] = array_merge(($metadataFiles[$uuid] ?? []), $fileEntries['metadata']);
+			$metadataFiles[$uuid] = array_merge($metadataFiles[$uuid], $fileEntries['metadata']);
 		}//end foreach
 
 		$metsXml = $this->generateMetsXml(

--- a/lib/Service/Edepot/SipPackageBuilder.php
+++ b/lib/Service/Edepot/SipPackageBuilder.php
@@ -30,6 +30,7 @@ namespace OCA\OpenRegister\Service\Edepot;
 
 use DateTime;
 use DOMDocument;
+use DOMElement;
 use InvalidArgumentException;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCP\IAppConfig;
@@ -575,31 +576,62 @@ class SipPackageBuilder {
 				$objectDiv->appendChild($fptr);
 			}//end foreach
 
-			foreach (($metadataFiles[$uuid] ?? []) as $metadataFile) {
-				$metadataId = 'MD-' . $fileCounter;
-				$fileCounter++;
-
-				$metadataElement = $dom->createElementNS(self::METS_NAMESPACE, 'mets:file');
-				$metadataElement->setAttribute('ID', $metadataId);
-				$metadataElement->setAttribute('SIZE', (string)$metadataFile['size']);
-				$metadataElement->setAttribute('MIMETYPE', 'application/xml');
-				$metadataElement->setAttribute('CHECKSUM', $metadataFile['checksum']);
-				$metadataElement->setAttribute('CHECKSUMTYPE', 'SHA-256');
-
-				$metadataLocat = $dom->createElementNS(self::METS_NAMESPACE, 'mets:FLocat');
-				$metadataLocat->setAttribute('LOCTYPE', 'URL');
-				$metadataLocat->setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', $metadataFile['path']);
-				$metadataElement->appendChild($metadataLocat);
-				$metadataGrp->appendChild($metadataElement);
-
-				$metadataPointer = $dom->createElementNS(self::METS_NAMESPACE, 'mets:fptr');
-				$metadataPointer->setAttribute('FILEID', $metadataId);
-				$objectDiv->appendChild($metadataPointer);
-			}//end foreach
+			$fileCounter = $this->appendMetadataFiles(
+				dom: $dom,
+				group: $metadataGrp,
+				objectDiv: $objectDiv,
+				rows: ($metadataFiles[$uuid] ?? []),
+				fileCounter: $fileCounter
+			);
 		}//end foreach
 
 		return $dom->saveXML();
 	}//end generateMetsXml()
+
+	/**
+	 * List an object's MDTO documents in the METS file section.
+	 *
+	 * @param DOMDocument $dom The METS document.
+	 * @param DOMElement $group The METADATA file group.
+	 * @param DOMElement $objectDiv The object's div, which points at them.
+	 * @param array $rows The manifest rows for this object's MDTO documents.
+	 * @param int $fileCounter The running METS file id counter.
+	 *
+	 * @return int The counter after these files.
+	 *
+	 * @spec openspec/specs/edepot-transfer/spec.md#requirement-the-system-must-assemble-sip-packages-for-e-depot-transfer
+	 */
+	private function appendMetadataFiles(
+		DOMDocument $dom,
+		DOMElement $group,
+		DOMElement $objectDiv,
+		array $rows,
+		int $fileCounter,
+	): int {
+		foreach ($rows as $row) {
+			$metadataId = 'MD-' . $fileCounter;
+			$fileCounter++;
+
+			$element = $dom->createElementNS(self::METS_NAMESPACE, 'mets:file');
+			$element->setAttribute('ID', $metadataId);
+			$element->setAttribute('SIZE', (string)$row['size']);
+			$element->setAttribute('MIMETYPE', 'application/xml');
+			$element->setAttribute('CHECKSUM', $row['checksum']);
+			$element->setAttribute('CHECKSUMTYPE', 'SHA-256');
+
+			$locat = $dom->createElementNS(self::METS_NAMESPACE, 'mets:FLocat');
+			$locat->setAttribute('LOCTYPE', 'URL');
+			$locat->setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', $row['path']);
+			$element->appendChild($locat);
+			$group->appendChild($element);
+
+			$pointer = $dom->createElementNS(self::METS_NAMESPACE, 'mets:fptr');
+			$pointer->setAttribute('FILEID', $metadataId);
+			$objectDiv->appendChild($pointer);
+		}
+
+		return $fileCounter;
+	}//end appendMetadataFiles()
 
 	/**
 	 * Generate PREMIS XML preservation metadata.

--- a/lib/Service/Edepot/SipPackageBuilder.php
+++ b/lib/Service/Edepot/SipPackageBuilder.php
@@ -486,6 +486,7 @@ class SipPackageBuilder {
 	 *
 	 * @param string $transferId The transfer list UUID.
 	 * @param array<int,array<string,mixed>> $objectsWithFiles Objects and their file metadata.
+	 * @param array<string,array<int,array<string,mixed>>> $metadataFiles The MDTO documents the package ships, keyed by object uuid.
 	 *
 	 * @return string The METS XML string.
 	 *

--- a/lib/Service/TmloService.php
+++ b/lib/Service/TmloService.php
@@ -34,7 +34,6 @@ namespace OCA\OpenRegister\Service;
 use DateInterval;
 use DateTime;
 use DOMDocument;
-use DOMElement;
 use Exception;
 use InvalidArgumentException;
 use OCA\OpenRegister\Db\ObjectEntity;
@@ -42,6 +41,7 @@ use OCA\OpenRegister\Db\Register;
 use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Edepot\MdtoXmlGenerator;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -73,6 +73,16 @@ class TmloService {
 	 * MDTO XML namespace
 	 */
 	public const MDTO_NAMESPACE = 'https://www.nationaalarchief.nl/mdto';
+
+	/**
+	 * Namespace of the batch envelope, which is openregister's, not MDTO's.
+	 */
+	public const EXPORT_NAMESPACE = 'https://www.openregister.app/mdto-export';
+
+	/**
+	 * Prefix of the batch envelope element.
+	 */
+	public const EXPORT_PREFIX = 'or';
 
 	/**
 	 * All valid archiefnominatie values
@@ -128,6 +138,7 @@ class TmloService {
 	 * @param RegisterMapper $registerMapper Register mapper for fetching registers
 	 * @param SchemaMapper $schemaMapper Schema mapper for fetching schemas
 	 * @param LoggerInterface $logger Logger interface
+	 * @param MdtoXmlGenerator $mdtoGenerator The one implementation of the MDTO format
 	 *
 	 * @spec openspec/changes/retrofit-2026-05-24-tmlo-metadata/tasks.md#task-1
 	 */
@@ -135,6 +146,7 @@ class TmloService {
 		private readonly RegisterMapper $registerMapper,
 		private readonly SchemaMapper $schemaMapper,
 		private readonly LoggerInterface $logger,
+		private readonly MdtoXmlGenerator $mdtoGenerator,
 	) {
 	}//end __construct()
 
@@ -382,7 +394,25 @@ class TmloService {
 	}//end validateStatusTransition()
 
 	/**
-	 * Generate MDTO-compliant XML for a single object.
+	 * Generate the MDTO document for a single object.
+	 *
+	 * ## One implementation of the format, not two
+	 *
+	 * This used to build its own DOM, and the result did not validate: its
+	 * root was `mdto:informatieobject` where the XSD declares `MDTO`, and it
+	 * emitted `archiefactiedatum`, `archiefstatus` and `vernietigingsCategorie`,
+	 * none of which is an MDTO element. It now delegates to
+	 * {@see MdtoXmlGenerator}, which is held to the vendored XSD by a test, so
+	 * this endpoint and the e-Depot export cannot drift apart again.
+	 *
+	 * The TMLO facts are not lost. {@see \OCA\OpenRegister\Service\Edepot\MdtoSourceReader}
+	 * reads the `tmlo` block as well as the `retention` block, so
+	 * `bewaarTermijn` becomes `bewaartermijn/termijnLooptijd`,
+	 * `archiefactiedatum` becomes `bewaartermijn/termijnEinddatum`,
+	 * `vernietigingsCategorie` becomes `informatiecategorie` and
+	 * `classification` becomes `classificatie`. Only `archiefstatus` has no
+	 * MDTO element, and MDTO expresses that lifecycle through `event`
+	 * instead, which the generator derives from the audit trail.
 	 *
 	 * @param ObjectEntity $object The object to export
 	 *
@@ -390,7 +420,7 @@ class TmloService {
 	 *
 	 * @throws InvalidArgumentException If the object has no TMLO metadata
 	 *
-	 * @spec exclude Owned by tmlo-export spec REQ "MDTO-compliant XML export" (single object); not foundation behaviour.
+	 * @spec openspec/specs/tmlo-export/spec.md#requirement-mdto-compliant-xml-export
 	 */
 	public function generateMdtoXml(ObjectEntity $object): string {
 		$tmlo = $object->getTmlo();
@@ -400,30 +430,33 @@ class TmloService {
 			);
 		}
 
-		$dom = new DOMDocument('1.0', 'UTF-8');
-		$dom->formatOutput = true;
-
-		$root = $this->createMdtoObjectElement(dom: $dom, object: $object, tmlo: $tmlo);
-		$dom->appendChild($root);
-
-		return $dom->saveXML();
+		return $this->mdtoGenerator->generate($object);
 	}//end generateMdtoXml()
 
 	/**
-	 * Generate MDTO-compliant XML for multiple objects.
+	 * Generate MDTO documents for multiple objects, in one envelope.
+	 *
+	 * MDTO has no batch container: an `MDTO` document holds exactly one
+	 * informatieobject or one bestand. So the envelope element is openregister's
+	 * own, in openregister's own namespace, and every child of it is a
+	 * complete, valid MDTO document. Nothing here claims the envelope is MDTO,
+	 * which is the mistake the previous `mdto:informatieobjecten` wrapper made
+	 * by putting a made-up element in the MDTO namespace.
+	 *
+	 * An object without TMLO metadata is skipped rather than failing the batch.
 	 *
 	 * @param ObjectEntity[] $objects Array of objects to export
 	 *
-	 * @return string The MDTO XML string with multiple objects
+	 * @return string The envelope XML
 	 *
-	 * @spec exclude Owned by tmlo-export spec REQ "MDTO-compliant XML export" (batch); not foundation behaviour.
+	 * @spec openspec/specs/tmlo-export/spec.md#requirement-mdto-compliant-xml-export
 	 */
 	public function generateBatchMdtoXml(array $objects): string {
 		$dom = new DOMDocument('1.0', 'UTF-8');
 		$dom->formatOutput = true;
 
-		$collection = $dom->createElementNS(self::MDTO_NAMESPACE, 'mdto:informatieobjecten');
-		$dom->appendChild($collection);
+		$envelope = $dom->createElementNS(self::EXPORT_NAMESPACE, self::EXPORT_PREFIX . ':mdtoExport');
+		$dom->appendChild($envelope);
 
 		foreach ($objects as $object) {
 			$tmlo = $object->getTmlo();
@@ -431,154 +464,14 @@ class TmloService {
 				continue;
 			}
 
-			$element = $this->createMdtoObjectElement(dom: $dom, object: $object, tmlo: $tmlo);
-			$collection->appendChild($element);
+			$document = new DOMDocument('1.0', 'UTF-8');
+			$document->loadXML($this->mdtoGenerator->generate($object));
+
+			$imported = $dom->importNode($document->documentElement, true);
+			$envelope->appendChild($imported);
 		}
 
-		return $dom->saveXML();
+		return (string)$dom->saveXML();
 	}//end generateBatchMdtoXml()
 
-	/**
-	 * Create a single MDTO object XML element.
-	 *
-	 * @param DOMDocument $dom The DOM document
-	 * @param ObjectEntity $object The object entity
-	 * @param array $tmlo The TMLO metadata array
-	 *
-	 * @return DOMElement The MDTO object element
-	 *
-	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
-	 */
-	private function createMdtoObjectElement(DOMDocument $dom, ObjectEntity $object, array $tmlo): DOMElement {
-		$root = $dom->createElementNS(self::MDTO_NAMESPACE, 'mdto:informatieobject');
-
-		// Identificatie.
-		$idElement = $dom->createElementNS(self::MDTO_NAMESPACE, 'mdto:identificatie');
-		$idReference = $dom->createElementNS(
-			self::MDTO_NAMESPACE,
-			'mdto:identificatieKenmerk',
-			$this->xmlEscape(value: $object->getUuid() ?? '')
-		);
-		$idSource = $dom->createElementNS(self::MDTO_NAMESPACE, 'mdto:identificatieBron', 'OpenRegister');
-		$idElement->appendChild($idReference);
-		$idElement->appendChild($idSource);
-		$root->appendChild($idElement);
-
-		// Naam.
-		$name = $dom->createElementNS(
-			self::MDTO_NAMESPACE,
-			'mdto:naam',
-			$this->xmlEscape(value: $object->getName() ?? $object->getUuid() ?? '')
-		);
-		$root->appendChild($name);
-
-		// TMLO fields.
-		if (($tmlo['classification'] ?? null) !== null) {
-			$classEl = $dom->createElementNS(self::MDTO_NAMESPACE, 'mdto:classificatie');
-			$classCode = $dom->createElementNS(
-				self::MDTO_NAMESPACE,
-				'mdto:classificatieCode',
-				$this->xmlEscape(value: $tmlo['classification'])
-			);
-			$classEl->appendChild($classCode);
-			$root->appendChild($classEl);
-		}
-
-		if (($tmlo['archiefnominatie'] ?? null) !== null) {
-			$root->appendChild(
-				$dom->createElementNS(
-					self::MDTO_NAMESPACE,
-					'mdto:waardering',
-					$this->mapArchiveNomination(nominatie: $tmlo['archiefnominatie'])
-				)
-			);
-		}
-
-		if (($tmlo['archiefactiedatum'] ?? null) !== null) {
-			$root->appendChild(
-				$dom->createElementNS(
-					self::MDTO_NAMESPACE,
-					'mdto:archiefactiedatum',
-					$this->xmlEscape(value: $tmlo['archiefactiedatum'])
-				)
-			);
-		}
-
-		if (($tmlo['archiefstatus'] ?? null) !== null) {
-			$root->appendChild(
-				$dom->createElementNS(
-					self::MDTO_NAMESPACE,
-					'mdto:archiefstatus',
-					$this->mapArchiefstatus(status: $tmlo['archiefstatus'])
-				)
-			);
-		}
-
-		if (($tmlo['bewaarTermijn'] ?? null) !== null) {
-			$root->appendChild(
-				$dom->createElementNS(
-					self::MDTO_NAMESPACE,
-					'mdto:bewaartermijn',
-					$this->xmlEscape(value: $tmlo['bewaarTermijn'])
-				)
-			);
-		}
-
-		if (($tmlo['vernietigingsCategorie'] ?? null) !== null) {
-			$root->appendChild(
-				$dom->createElementNS(
-					self::MDTO_NAMESPACE,
-					'mdto:vernietigingsCategorie',
-					$this->xmlEscape(value: $tmlo['vernietigingsCategorie'])
-				)
-			);
-		}
-
-		return $root;
-	}//end createMdtoObjectElement()
-
-	/**
-	 * Map TMLO archiefnominatie to MDTO waardering value.
-	 *
-	 * @param string $nominatie The TMLO archiefnominatie value
-	 *
-	 * @return string The MDTO waardering value
-	 */
-	private function mapArchiveNomination(string $nominatie): string {
-		$mapping = [
-			self::ARCHIEFNOMINATIE_BLIJVEND_BEWAREN => 'bewaren',
-			self::ARCHIEFNOMINATIE_VERNIETIGEN => 'vernietigen',
-		];
-
-		return ($mapping[$nominatie] ?? $nominatie);
-	}//end mapArchiefnominatie()
-
-	/**
-	 * Map TMLO archiefstatus to MDTO archiefstatus value.
-	 *
-	 * @param string $status The TMLO archiefstatus value
-	 *
-	 * @return string The MDTO archiefstatus value
-	 */
-	private function mapArchiefstatus(string $status): string {
-		$mapping = [
-			self::ARCHIEFSTATUS_ACTIEF => 'in bewerking',
-			self::ARCHIEFSTATUS_SEMI_STATISCH => 'afgesloten',
-			self::ARCHIEFSTATUS_OVERGEBRACHT => 'overgebracht',
-			self::ARCHIEFSTATUS_VERNIETIGD => 'vernietigd',
-		];
-
-		return ($mapping[$status] ?? $status);
-	}//end mapArchiefstatus()
-
-	/**
-	 * Escape a string for safe XML inclusion.
-	 *
-	 * @param string $value The value to escape
-	 *
-	 * @return string The escaped value
-	 */
-	private function xmlEscape(string $value): string {
-		return htmlspecialchars($value, ENT_XML1 | ENT_QUOTES, 'UTF-8');
-	}//end xmlEscape()
 }//end class

--- a/openspec/specs/edepot-transfer/spec.md
+++ b/openspec/specs/edepot-transfer/spec.md
@@ -18,7 +18,7 @@ Each object selected for e-Depot transfer MUST have its metadata exported as XML
 - **WHEN** object `zaak-123` with complete archival metadata is selected for MDTO export
 - **THEN** the system MUST produce an XML document with root element `mdto:MDTO` in namespace `https://www.nationaalarchief.nl/mdto`, holding exactly one `mdto:informatieobject`
 - **AND** the informatieobject MUST include `identificatie` (object UUID, with the organisation identifier as `identificatieBron`), `naam` (object title, else its UUID), `waardering` (from `archiefnominatie`, as a term of the closed Waarderingen list), `archiefvormer` (the organisation from app settings) and `beperkingGebruik`
-- **AND** it MUST include `bewaartermijn` as a `termijnGegevens`, which MDTO makes optional and openregister requires as local policy
+- **AND** it MUST include `bewaartermijn` as a `termijnGegevens` when the record has a retention period, which MDTO makes optional
 - **AND** the document MUST validate against the vendored MDTO XSD
 
 #### Scenario: MDTO XML includes file references
@@ -227,8 +227,11 @@ and the XML syntax `MDTO-XML1.0.1.xsd`
   `isRepresentatieVan` are all `minOccurs="1"`, and `checksumGegevens`
   requires `checksumAlgoritme`, `checksumWaarde` and `checksumDatum`.
 - `bewaartermijn` is `minOccurs="0"` and the schema states "Verplicht | Ja,
-  indien bekend". openregister's stricter refusal to export without one is a
-  LOCAL policy and MUST be documented as such rather than attributed to MDTO.
+  indien bekend", so an export without one is valid and the element is simply
+  omitted. openregister's refusal to TRANSFER a record whose retention period
+  is unknown is a LOCAL policy, stated below as its own precondition, and MUST
+  NOT be attributed to MDTO or enforced while merely serialising: the
+  `tmlo-export` endpoint serialises records that have no retention period yet.
 
 #### Scenario: A generator input is missing
 - **WHEN** an object has no `retention.archiefnominatie`, or a file entry has no `checksum`
@@ -383,14 +386,23 @@ its bytes rather than replace the stale value silently.
 - **WHEN** the generator emits a document the schema rejects
 - **THEN** `MdtoXmlGeneratorXsdTest` MUST fail, and its message MUST quote libxml's error naming the offending element
 
+#### Scenario: A record with no retention period is not transferred
+- **WHEN** a record whose retention period is unknown is packaged for an e-Depot
+- **THEN** the packaging path MUST refuse it, through a precondition separate from serialising
+- **AND** exporting that same record as MDTO MUST still succeed, without a `bewaartermijn` element
+
+#### Scenario: Every MDTO document the package ships is listed in mets.xml
+- **WHEN** a SIP is built for an object with one file
+- **THEN** `mets.xml` MUST list the object's `mdto.xml` and the file's `<bestandsnaam>.bestand.MDTO.xml` in a METADATA file group, with size and checksum
+- **AND** the object's div MUST point at them
+
 #### Scenario: A stored checksum no longer matches the file
 - **WHEN** a file reference carries a SHA-256 that differs from the SHA-256 of the file's bytes
 - **THEN** the file MUST be refused as a fixity failure, and the object excluded from that transfer with a logged reason
 
-**Known gap: a second MDTO exporter does not validate.** `TmloService::generateMdtoXml()` serves `GET /api/objects/{register}/{schema}/{id}/export/mdto`
-and is governed by `tmlo-export`, not by this capability. Measured on
-2026-09-11 against the same vendored XSD, it does not validate: its root is
-`mdto:informatieobject`, and it emits `archiefactiedatum`, `archiefstatus` and
-`vernietigingsCategorie`, which are TMLO fields and not MDTO elements. The
-`tmlo-export` spec mandates those elements, so correcting the exporter is a
-decision about that spec, recorded there.
+**RESOLVED: there is one MDTO exporter.** `TmloService::generateMdtoXml()`,
+behind `GET /api/tmlo/{register}/{schema}/{id}/export`, used to be a second
+implementation and did not validate. It now delegates to `MdtoXmlGenerator`,
+so both exports are the same format and the same test holds them. See
+`tmlo-export`, whose requirement no longer asks for TMLO field names in MDTO
+output.

--- a/openspec/specs/tmlo-export/spec.md
+++ b/openspec/specs/tmlo-export/spec.md
@@ -11,49 +11,87 @@ TBD - created by archiving change tmlo-metadata. Update Purpose after archive.
 ## Requirements
 ### Requirement: MDTO-compliant XML export
 
-The system SHALL provide an XML export of objects with their TMLO metadata in MDTO-compliant format. The export SHALL conform to the MDTO XML schema (Metadatastandaard voor Duurzaam Toegankelijke Overheidsinformatie).
+The system SHALL provide an XML export of objects with their TMLO metadata as
+MDTO, valid against MDTO-XML 1.0.1 as vendored at
+`lib/Resources/mdto/MDTO-XML1.0.1.xsd`.
+
+There SHALL be one implementation of the MDTO format. This export and the
+e-Depot export in `edepot-transfer` both go through `MdtoXmlGenerator`, so a
+change to the format reaches both, and neither can drift into a shape the
+schema rejects while the other stays valid.
+
+**MDTO output carries MDTO elements.** This requirement used to list
+`archiefnominatie`, `archiefactiedatum`, `archiefstatus`, `bewaarTermijn` and
+`vernietigingsCategorie`, which are TMLO field names, and three of them are
+not MDTO elements at all. That list is what made the output invalid. TMLO
+remains how the facts are STORED; MDTO is how they are EXPORTED, and the two
+are different vocabularies. Each stored fact SHALL be exported under the MDTO
+element that carries it:
+
+| TMLO field | MDTO element |
+| --- | --- |
+| `archiefnominatie` | `waardering`, as a term of the closed Waarderingen list |
+| `bewaarTermijn` | `bewaartermijn/termijnLooptijd` |
+| `archiefactiedatum` | `bewaartermijn/termijnEinddatum` |
+| `vernietigingsCategorie` | `informatiecategorie`, the selectielijst category that decides disposal |
+| `classification` | `classificatie`, the classification scheme code |
+| `archiefstatus` | none: MDTO has no such element |
+
+`archiefstatus` is the one fact with no MDTO element, and it is not lost.
+MDTO expresses the same lifecycle as `event` (Overbrenging, Vernietigen),
+which the generator derives from the audit trail, and openregister exposes it
+abstractly as `_retention.status` from the `RecordState` vocabulary. A
+consumer that needs the raw TMLO field SHALL read the object's `tmlo` block
+or the abstract answer; it SHALL NOT be added back to the MDTO output, because
+a document carrying it cannot validate.
 
 The XML output SHALL include:
-- Root element with MDTO namespace
-- `identificatie` with the object UUID
-- `naam` with the object name
-- `classificatie` with the classification code
-- `archiefnominatie` with the archival nomination
-- `archiefactiedatum` with the archival action date
-- `archiefstatus` mapping TMLO values to MDTO equivalents
-- `bewaarTermijn` with the retention period
-- `vernietigingsCategorie` with the destruction category
+- Root element `MDTO` in the MDTO namespace, holding exactly one
+  `informatieobject`, carrying the schema version in `xsi:schemaLocation`
+- `identificatie` with the object UUID and the organisation as its source
+- `naam` with the object's name, from its data, else the entity's name, else
+  its UUID
+- `waardering`, which MDTO requires
+- `beperkingGebruik`, which MDTO requires
+- the elements in the table above, each when the object carries the fact
 
-**Known gap: this export does not validate against MDTO, and the list above is why.**
-Measured on 2026-09-11 against the Nationaal Archief's MDTO-XML 1.0.1 schema,
-vendored at `lib/Resources/mdto/MDTO-XML1.0.1.xsd`, the output of
-`TmloService::generateMdtoXml()` is rejected at its root: "Element
-'{https://www.nationaalarchief.nl/mdto}informatieobject': No matching global
-declaration available for the validation root." The schema's only global
-element is `MDTO`. Past the root, the export emits three elements that do not
-exist in MDTO at all: `archiefactiedatum`, `archiefstatus` and
-`vernietigingsCategorie`, which are TMLO fields. (Two further items in the
-list above, `archiefnominatie` and `bewaarTermijn`, are also TMLO spellings,
-but the code already emits them as MDTO's `waardering` and `bewaartermijn`.)
-A document carrying those three cannot validate however it is wrapped, so the
-sentence above claiming MDTO conformance and the element list beneath it
-cannot both hold. Choosing which gives way is a decision for
-this spec; the e-Depot export in `edepot-transfer` already validates.
+An object whose appraisal is unknown SHALL be refused rather than exported
+without `waardering`, which is `minOccurs="1"`. An object whose retention
+period is unknown SHALL still be exported, without `bewaartermijn`, which
+MDTO marks "Verplicht: Ja, indien bekend"; refusing such a record is a
+transfer-time policy and belongs to `edepot-transfer`.
 
 #### Scenario: Export single object as MDTO XML
 
-- **WHEN** a GET request is made to `/api/objects/{register}/{schema}/{id}/export/mdto`
+- **WHEN** a GET request is made to `/api/tmlo/{register}/{schema}/{id}/export`
 - **THEN** the response SHALL be an XML document with Content-Type `application/xml`
-- **THEN** the XML SHALL contain the object's TMLO metadata in MDTO format
+- **AND** the document SHALL validate against the vendored MDTO XSD
+- **AND** each TMLO fact SHALL appear under the MDTO element that carries it, per the table above
 
 #### Scenario: Export object without TMLO metadata
 
 - **WHEN** an export is requested for an object with no TMLO metadata
 - **THEN** the response SHALL return a 422 error indicating TMLO metadata is required for MDTO export
 
+### Requirement: Batch export uses an envelope that does not claim to be MDTO
+
+MDTO has no batch container: an `MDTO` document holds exactly one
+informatieobject or one bestand. A batch export SHALL therefore wrap complete
+MDTO documents in an envelope element of openregister's own, in
+openregister's own namespace, and SHALL NOT invent an element in the MDTO
+namespace. The previous `mdto:informatieobjecten` wrapper did exactly that.
+
+Every child of the envelope SHALL be a complete MDTO document that validates
+on its own. An object without TMLO metadata SHALL be skipped rather than
+failing the batch.
+
+#### Scenario: Batch envelope carries whole MDTO documents
+- **WHEN** two objects with TMLO metadata are exported as a batch
+- **THEN** the envelope element MUST be in openregister's namespace, not MDTO's
+- **AND** it MUST contain one `mdto:MDTO` document per object, each valid against the vendored XSD
+
 #### Scenario: Batch export objects as MDTO XML
 
-- **WHEN** a GET request is made to `/api/objects/{register}/{schema}/export/mdto` with optional query filters
-- **THEN** the response SHALL be an XML document containing multiple object elements
-- **THEN** each object SHALL include its TMLO metadata in MDTO format
-
+- **WHEN** a GET request is made to `/api/tmlo/{register}/{schema}/export` with optional query filters
+- **THEN** the response SHALL be an XML document whose root is openregister's envelope element
+- **AND** it SHALL contain one complete MDTO document per exported object

--- a/tests/Unit/Service/Edepot/MdtoXmlGeneratorTest.php
+++ b/tests/Unit/Service/Edepot/MdtoXmlGeneratorTest.php
@@ -813,6 +813,98 @@ class MdtoXmlGeneratorTest extends TestCase {
 	}
 
 	/**
+	 * MDTO allows an unknown retention period, so the element is omitted.
+	 */
+	public function testBewaartermijnIsOmittedWhenUnknown(): void {
+		$object = $this->createObjectEntity(uuid: 'no-term', retention: ['archiefnominatie' => 'bewaren']);
+
+		$xml = $this->generator->generate($object);
+
+		$this->assertStringNotContainsString('bewaartermijn', $xml);
+		$this->assertStringContainsString('<mdto:waardering>', $xml);
+	}
+
+	/**
+	 * Transferring without a retention period is refused, which is local policy.
+	 */
+	public function testTransferPreconditionsRefuseAnUnknownRetentionPeriod(): void {
+		$object = $this->createObjectEntity(uuid: 'no-term', retention: ['archiefnominatie' => 'bewaren']);
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessageMatches('/no retention period/');
+
+		$this->generator->assertTransferPreconditions($object);
+	}
+
+	/**
+	 * A record that has a retention period passes the transfer precondition.
+	 */
+	public function testTransferPreconditionsAcceptAKnownRetentionPeriod(): void {
+		$object = $this->createObjectEntity(
+			uuid: 'term',
+			retention: ['archiefnominatie' => 'bewaren', 'bewaartermijn' => 'P5Y']
+		);
+
+		$this->generator->assertTransferPreconditions($object);
+
+		$this->expectNotToPerformAssertions();
+	}
+
+	/**
+	 * The core archival facts are read from the TMLO block as well.
+	 *
+	 * This is what lets the TMLO export endpoint share this generator.
+	 */
+	public function testCoreFactsAreReadFromTheTmloBlock(): void {
+		$object = $this->createObjectEntity(
+			uuid: 'tmlo-uuid',
+			retention: [],
+			objectData: [],
+			tmlo: [
+				'archiefnominatie' => 'vernietigen',
+				'bewaarTermijn' => 'P7Y',
+				'archiefactiedatum' => '2033-01-01',
+				'vernietigingsCategorie' => '1.1.3',
+				'classification' => '1.1',
+			]
+		);
+
+		$xml = $this->generator->generate($object);
+
+		$this->assertStringContainsString('<mdto:begripLabel>Tijdelijk te bewaren</mdto:begripLabel>', $xml);
+		$this->assertStringContainsString('<mdto:termijnLooptijd>P7Y</mdto:termijnLooptijd>', $xml);
+		$this->assertStringContainsString('<mdto:termijnEinddatum>2033-01-01</mdto:termijnEinddatum>', $xml);
+		// vernietigingsCategorie is the disposal category, MDTO's informatiecategorie.
+		$this->assertMatchesRegularExpression(
+			'#<mdto:informatiecategorie>\s*<mdto:begripLabel>1\.1\.3</mdto:begripLabel>#',
+			$xml
+		);
+		// classification is the classification scheme code, a different element.
+		$this->assertMatchesRegularExpression(
+			'#<mdto:classificatie>\s*<mdto:begripLabel>1\.1</mdto:begripLabel>#',
+			$xml
+		);
+	}
+
+	/**
+	 * naam falls back to the entity's own name column before the uuid.
+	 */
+	public function testNaamFallsBackToTheEntityName(): void {
+		$object = $this->getMockBuilder(ObjectEntity::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['getUuid', 'getObject'])
+			->addMethods(['getRetention', 'getTmlo', 'getName'])
+			->getMock();
+		$object->method('getUuid')->willReturn('name-uuid');
+		$object->method('getObject')->willReturn([]);
+		$object->method('getName')->willReturn('Besluit 14');
+		$object->method('getRetention')->willReturn(['archiefnominatie' => 'bewaren', 'bewaartermijn' => 'P5Y']);
+		$object->method('getTmlo')->willReturn([]);
+
+		$this->assertStringContainsString('<mdto:naam>Besluit 14</mdto:naam>', $this->generator->generate($object));
+	}
+
+	/**
 	 * Create a mock ObjectEntity with the given data.
 	 *
 	 * @param string $uuid The UUID.

--- a/tests/Unit/Service/Edepot/MdtoXmlGeneratorTest.php
+++ b/tests/Unit/Service/Edepot/MdtoXmlGeneratorTest.php
@@ -78,7 +78,6 @@ class MdtoXmlGeneratorTest extends TestCase {
 
 		return new MdtoXmlGenerator(
 			$appConfig,
-			$this->logger,
 			$eventMapper,
 			$this->sourceReader,
 			$writer,

--- a/tests/Unit/Service/Edepot/MdtoXmlGeneratorTest.php
+++ b/tests/Unit/Service/Edepot/MdtoXmlGeneratorTest.php
@@ -338,7 +338,7 @@ class MdtoXmlGeneratorTest extends TestCase {
 		$object = $this->createObjectEntity(uuid: 'w', retention: ['archiefnominatie' => 'misschien', 'bewaartermijn' => 'P5Y']);
 
 		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessageMatches('/retention\.archiefnominatie \(one of: /');
+		$this->expectExceptionMessageMatches('/archiefnominatie \(one of: /');
 
 		$this->generator->generate($object);
 	}
@@ -370,7 +370,7 @@ class MdtoXmlGeneratorTest extends TestCase {
 		$object = $this->createObjectEntity(uuid: 't', retention: ['archiefnominatie' => 'bewaren', 'bewaartermijn' => 'P2W']);
 
 		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessageMatches('/retention\.bewaartermijn \(an ISO-8601/');
+		$this->expectExceptionMessageMatches('/bewaartermijn \(an ISO-8601/');
 
 		$this->generator->generate($object);
 	}
@@ -413,7 +413,7 @@ class MdtoXmlGeneratorTest extends TestCase {
 		);
 
 		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessageMatches('/retention\.archiefnominatie/');
+		$this->expectExceptionMessageMatches('/archiefnominatie/');
 
 		$this->generator->generate($object);
 	}

--- a/tests/Unit/Service/Edepot/MdtoXmlGeneratorTest.php
+++ b/tests/Unit/Service/Edepot/MdtoXmlGeneratorTest.php
@@ -18,7 +18,9 @@ use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Service\Edepot\MdtoBestandGenerator;
 use OCA\OpenRegister\Service\Edepot\MdtoDocumentWriter;
 use OCA\OpenRegister\Service\Edepot\MdtoEventMapper;
+use OCA\OpenRegister\Service\Edepot\MdtoPreconditions;
 use OCA\OpenRegister\Service\Edepot\MdtoSourceReader;
+use OCA\OpenRegister\Service\Edepot\MdtoValueReader;
 use OCA\OpenRegister\Service\Edepot\MdtoXmlGenerator;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -55,7 +57,7 @@ class MdtoXmlGeneratorTest extends TestCase {
 		// A REAL source reader, not a mock: which values are found and which
 		// are absent is precisely what these tests assert, and a stub would
 		// make every absence test pass for the wrong reason.
-		$this->sourceReader = new MdtoSourceReader();
+		$this->sourceReader = new MdtoSourceReader(new MdtoValueReader());
 
 		$this->generator = $this->makeGenerator(appConfig: $this->appConfig, eventMapper: $this->eventMapper);
 	}
@@ -70,6 +72,9 @@ class MdtoXmlGeneratorTest extends TestCase {
 	 */
 	private function makeGenerator(IAppConfig $appConfig, MdtoEventMapper $eventMapper): MdtoXmlGenerator {
 		$writer = new MdtoDocumentWriter();
+		$sourceReader = new MdtoSourceReader(new MdtoValueReader());
+		$bestandGenerator = new MdtoBestandGenerator($writer);
+		$preconditions = new MdtoPreconditions($appConfig, $this->createMock(LoggerInterface::class), $sourceReader, $bestandGenerator);
 
 		return new MdtoXmlGenerator(
 			$appConfig,
@@ -77,7 +82,8 @@ class MdtoXmlGeneratorTest extends TestCase {
 			$eventMapper,
 			$this->sourceReader,
 			$writer,
-			new MdtoBestandGenerator($writer)
+			new MdtoBestandGenerator($writer),
+			$preconditions
 		);
 	}
 

--- a/tests/Unit/Service/Edepot/MdtoXmlGeneratorXsdTest.php
+++ b/tests/Unit/Service/Edepot/MdtoXmlGeneratorXsdTest.php
@@ -20,7 +20,9 @@ use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Service\Edepot\MdtoBestandGenerator;
 use OCA\OpenRegister\Service\Edepot\MdtoDocumentWriter;
 use OCA\OpenRegister\Service\Edepot\MdtoEventMapper;
+use OCA\OpenRegister\Service\Edepot\MdtoPreconditions;
 use OCA\OpenRegister\Service\Edepot\MdtoSourceReader;
+use OCA\OpenRegister\Service\Edepot\MdtoValueReader;
 use OCA\OpenRegister\Service\Edepot\MdtoXmlGenerator;
 use OCP\IAppConfig;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -377,14 +379,18 @@ class MdtoXmlGeneratorXsdTest extends TestCase {
 		$eventMapper->method('forObject')->willReturn($events);
 
 		$writer = new MdtoDocumentWriter();
+		$sourceReader = new MdtoSourceReader(new MdtoValueReader());
+		$bestandGenerator = new MdtoBestandGenerator($writer);
+		$preconditions = new MdtoPreconditions($appConfig, $this->createMock(LoggerInterface::class), $sourceReader, $bestandGenerator);
 
 		return new MdtoXmlGenerator(
 			$appConfig,
 			$this->createMock(LoggerInterface::class),
 			$eventMapper,
-			new MdtoSourceReader(),
+			$sourceReader,
 			$writer,
-			new MdtoBestandGenerator($writer)
+			$bestandGenerator,
+			$preconditions
 		);
 	}//end generator()
 

--- a/tests/Unit/Service/Edepot/MdtoXmlGeneratorXsdTest.php
+++ b/tests/Unit/Service/Edepot/MdtoXmlGeneratorXsdTest.php
@@ -385,7 +385,6 @@ class MdtoXmlGeneratorXsdTest extends TestCase {
 
 		return new MdtoXmlGenerator(
 			$appConfig,
-			$this->createMock(LoggerInterface::class),
 			$eventMapper,
 			$sourceReader,
 			$writer,

--- a/tests/Unit/Service/Edepot/SipPackageBuilderTest.php
+++ b/tests/Unit/Service/Edepot/SipPackageBuilderTest.php
@@ -141,6 +141,36 @@ class SipPackageBuilderTest extends TestCase {
 	}
 
 	/**
+	 * A record with no retention period is not transferred.
+	 *
+	 * MDTO allows `bewaartermijn` to be absent and the generator omits it, so
+	 * the refusal has to be its own precondition. Without it, openregister
+	 * would hand an e-Depot a record without saying how long to keep it.
+	 *
+	 * @return void
+	 */
+	public function testBuildRefusesAnObjectWithoutARetentionPeriod(): void {
+		$tempFile = tempnam(sys_get_temp_dir(), 'sip') . '.zip';
+		$this->tempManager->method('getTemporaryFile')->willReturn($tempFile);
+
+		$this->mdtoGenerator->method('assertTransferPreconditions')
+			->willThrowException(new \InvalidArgumentException('it has no retention period'));
+
+		$object = $this->getMockBuilder(ObjectEntity::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['jsonSerialize'])
+			->onlyMethods(['getUuid'])
+			->getMock();
+		$object->method('getUuid')->willReturn('obj-uuid-1');
+		$object->method('jsonSerialize')->willReturn(['uuid' => 'obj-uuid-1']);
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessageMatches('/no retention period/');
+
+		$this->builder->build('transfer-x', [['object' => $object, 'files' => []]], 0, 'zip');
+	}
+
+	/**
 	 * BagIt (RFC 8493) output: content under data/, complete manifest, tag
 	 * files. archival-transfer-hardening OR-AD-1.
 	 */
@@ -210,6 +240,17 @@ class SipPackageBuilderTest extends TestCase {
 		$this->assertStringContainsString('data/objects/obj-uuid-1/content/original/doc.txt', $manifest);
 		$this->assertStringContainsString(hash('sha256', 'hello archive'), $manifest);
 		$this->assertStringContainsString($sidecar, $manifest);
+
+		// mets.xml must describe everything the package ships, the MDTO
+		// documents included, or it describes less than is there.
+		$mets = (string)$zip->getFromName('data/mets.xml');
+		$this->assertStringContainsString('USE="METADATA"', $mets);
+		$this->assertStringContainsString('objects/obj-uuid-1/mdto.xml', $mets);
+		$this->assertStringContainsString(
+			'objects/obj-uuid-1/content/original/doc.txt.bestand.MDTO.xml',
+			$mets
+		);
+		$this->assertStringContainsString('MIMETYPE="application/xml"', $mets);
 
 		$zip->close();
 		unlink($result[0]);

--- a/tests/Unit/Service/TmloExportTest.php
+++ b/tests/Unit/Service/TmloExportTest.php
@@ -26,7 +26,13 @@ use InvalidArgumentException;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Edepot\MdtoBestandGenerator;
+use OCA\OpenRegister\Service\Edepot\MdtoDocumentWriter;
+use OCA\OpenRegister\Service\Edepot\MdtoEventMapper;
+use OCA\OpenRegister\Service\Edepot\MdtoSourceReader;
+use OCA\OpenRegister\Service\Edepot\MdtoXmlGenerator;
 use OCA\OpenRegister\Service\TmloService;
+use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
@@ -50,10 +56,37 @@ class TmloExportTest extends TestCase {
 	 * @return void
 	 */
 	protected function setUp(): void {
+		// A REAL MdtoXmlGenerator, because the point of this change is that
+		// this endpoint emits the same format as the e-Depot export. A mock
+		// would assert only that a string came back.
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getValueString')->willReturnMap(
+			[
+				['openregister', 'organisation_identifier', '', 'ORG-001'],
+				['openregister', 'organisation_identifier', 'OpenRegister', 'ORG-001'],
+				['openregister', 'organisation_name', '', 'Gemeente Voorbeeld'],
+				['openregister', 'organisation_name', 'OpenRegister', 'Gemeente Voorbeeld'],
+			]
+		);
+
+		$eventMapper = $this->createMock(MdtoEventMapper::class);
+		$eventMapper->method('forObject')->willReturn([]);
+
+		$writer = new MdtoDocumentWriter();
+		$generator = new MdtoXmlGenerator(
+			$appConfig,
+			$this->createMock(LoggerInterface::class),
+			$eventMapper,
+			new MdtoSourceReader(),
+			$writer,
+			new MdtoBestandGenerator($writer)
+		);
+
 		$this->service = new TmloService(
 			$this->createMock(RegisterMapper::class),
 			$this->createMock(SchemaMapper::class),
-			$this->createMock(LoggerInterface::class)
+			$this->createMock(LoggerInterface::class),
+			$generator
 		);
 	}//end setUp()
 
@@ -78,12 +111,19 @@ class TmloExportTest extends TestCase {
 		$xml = $this->service->generateMdtoXml($object);
 
 		$this->assertStringContainsString('<?xml', $xml);
-		$this->assertStringContainsString('mdto:informatieobject', $xml);
+		$this->assertStringContainsString('<mdto:MDTO', $xml);
+		$this->assertStringContainsString('<mdto:informatieobject>', $xml);
 		$this->assertStringContainsString('test-uuid-123', $xml);
 		$this->assertStringContainsString('Test Object', $xml);
-		$this->assertStringContainsString('1.1', $xml);
-		$this->assertStringContainsString('2030-01-01', $xml);
-		$this->assertStringContainsString('P7Y', $xml);
+		// TMLO's own fields, each under the MDTO element that carries it.
+		$this->assertStringContainsString('<mdto:classificatie>', $xml);
+		$this->assertStringContainsString('<mdto:begripLabel>1.1</mdto:begripLabel>', $xml);
+		$this->assertStringContainsString('<mdto:termijnLooptijd>P7Y</mdto:termijnLooptijd>', $xml);
+		$this->assertStringContainsString('<mdto:termijnEinddatum>2030-01-01</mdto:termijnEinddatum>', $xml);
+		// archiefstatus is not an MDTO element and is not smuggled in.
+		$this->assertStringNotContainsString('archiefstatus', $xml);
+		$this->assertStringNotContainsString('semi_statisch', $xml);
+		$this->assertStringNotContainsString('vernietigingsCategorie', $xml);
 	}//end testGenerateMdtoXmlFullObject()
 
 	/**
@@ -117,8 +157,33 @@ class TmloExportTest extends TestCase {
 
 		$xml = $this->service->generateMdtoXml($object);
 
-		$this->assertStringContainsString('bewaren', $xml);
+		// The CLOSED Waarderingen list, not TMLO's own spelling.
+		$this->assertStringContainsString('<mdto:begripLabel>Blijvend te bewaren</mdto:begripLabel>', $xml);
+		$this->assertStringContainsString('<mdto:begripCode>B</mdto:begripCode>', $xml);
+		$this->assertStringContainsString('<mdto:verwijzingNaam>Waarderingen</mdto:verwijzingNaam>', $xml);
+		// No bewaarTermijn on this object, and MDTO allows the element to be absent.
+		$this->assertStringNotContainsString('bewaartermijn', $xml);
 	}//end testGenerateMdtoXmlMapsArchiefnominatie()
+
+	/**
+	 * An object whose appraisal is unknown cannot be valid MDTO, and is refused.
+	 *
+	 * `waardering` is minOccurs="1". The previous exporter emitted a document
+	 * without it, which no e-Depot could accept.
+	 *
+	 * @return void
+	 */
+	public function testGenerateMdtoXmlRefusesAnObjectWithoutAnAppraisal(): void {
+		$object = new ObjectEntity();
+		$object->setUuid('uuid-no-appraisal');
+		$object->setName('No appraisal');
+		$object->setTmlo(['archiefstatus' => 'actief']);
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessageMatches('/archiefnominatie \(one of: /');
+
+		$this->service->generateMdtoXml($object);
+	}//end testGenerateMdtoXmlRefusesAnObjectWithoutAnAppraisal()
 
 	/**
 	 * Test generateBatchMdtoXml with multiple objects.
@@ -132,6 +197,7 @@ class TmloExportTest extends TestCase {
 		$object1->setTmlo([
 			'archiefstatus' => 'actief',
 			'classification' => '1.1',
+			'archiefnominatie' => 'blijvend_bewaren',
 		]);
 
 		$object2 = new ObjectEntity();
@@ -140,12 +206,17 @@ class TmloExportTest extends TestCase {
 		$object2->setTmlo([
 			'archiefstatus' => 'semi_statisch',
 			'classification' => '2.1',
+			'archiefnominatie' => 'vernietigen',
 		]);
 
 		$xml = $this->service->generateBatchMdtoXml([$object1, $object2]);
 
 		$this->assertStringContainsString('<?xml', $xml);
-		$this->assertStringContainsString('mdto:informatieobjecten', $xml);
+		// The envelope is openregister's own element, not a made-up MDTO one.
+		$this->assertStringContainsString('<or:mdtoExport', $xml);
+		$this->assertStringContainsString('https://www.openregister.app/mdto-export', $xml);
+		$this->assertStringNotContainsString('informatieobjecten', $xml);
+		$this->assertSame(2, substr_count($xml, '<mdto:MDTO'));
 		$this->assertStringContainsString('uuid-1', $xml);
 		$this->assertStringContainsString('uuid-2', $xml);
 	}//end testGenerateBatchMdtoXml()
@@ -159,7 +230,7 @@ class TmloExportTest extends TestCase {
 		$withTmlo = new ObjectEntity();
 		$withTmlo->setUuid('uuid-with');
 		$withTmlo->setName('With TMLO');
-		$withTmlo->setTmlo(['archiefstatus' => 'actief']);
+		$withTmlo->setTmlo(['archiefstatus' => 'actief', 'archiefnominatie' => 'blijvend_bewaren']);
 
 		$withoutTmlo = new ObjectEntity();
 		$withoutTmlo->setUuid('uuid-without');
@@ -180,7 +251,8 @@ class TmloExportTest extends TestCase {
 		$xml = $this->service->generateBatchMdtoXml([]);
 
 		$this->assertStringContainsString('<?xml', $xml);
-		$this->assertStringContainsString('mdto:informatieobjecten', $xml);
+		$this->assertStringContainsString('<or:mdtoExport', $xml);
+		$this->assertStringNotContainsString('<mdto:MDTO', $xml);
 	}//end testGenerateBatchMdtoXmlEmpty()
 
 	/**
@@ -195,6 +267,7 @@ class TmloExportTest extends TestCase {
 		$object->setTmlo([
 			'classification' => '1.1 & 2.2',
 			'archiefstatus' => 'actief',
+			'archiefnominatie' => 'blijvend_bewaren',
 		]);
 
 		$xml = $this->service->generateMdtoXml($object);

--- a/tests/Unit/Service/TmloExportTest.php
+++ b/tests/Unit/Service/TmloExportTest.php
@@ -29,7 +29,9 @@ use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Service\Edepot\MdtoBestandGenerator;
 use OCA\OpenRegister\Service\Edepot\MdtoDocumentWriter;
 use OCA\OpenRegister\Service\Edepot\MdtoEventMapper;
+use OCA\OpenRegister\Service\Edepot\MdtoPreconditions;
 use OCA\OpenRegister\Service\Edepot\MdtoSourceReader;
+use OCA\OpenRegister\Service\Edepot\MdtoValueReader;
 use OCA\OpenRegister\Service\Edepot\MdtoXmlGenerator;
 use OCA\OpenRegister\Service\TmloService;
 use OCP\IAppConfig;
@@ -73,13 +75,17 @@ class TmloExportTest extends TestCase {
 		$eventMapper->method('forObject')->willReturn([]);
 
 		$writer = new MdtoDocumentWriter();
+		$sourceReader = new MdtoSourceReader(new MdtoValueReader());
+		$bestandGenerator = new MdtoBestandGenerator($writer);
+		$preconditions = new MdtoPreconditions($appConfig, $this->createMock(LoggerInterface::class), $sourceReader, $bestandGenerator);
 		$generator = new MdtoXmlGenerator(
 			$appConfig,
 			$this->createMock(LoggerInterface::class),
 			$eventMapper,
-			new MdtoSourceReader(),
+			$sourceReader,
 			$writer,
-			new MdtoBestandGenerator($writer)
+			$bestandGenerator,
+			$preconditions
 		);
 
 		$this->service = new TmloService(

--- a/tests/Unit/Service/TmloExportTest.php
+++ b/tests/Unit/Service/TmloExportTest.php
@@ -80,7 +80,6 @@ class TmloExportTest extends TestCase {
 		$preconditions = new MdtoPreconditions($appConfig, $this->createMock(LoggerInterface::class), $sourceReader, $bestandGenerator);
 		$generator = new MdtoXmlGenerator(
 			$appConfig,
-			$this->createMock(LoggerInterface::class),
 			$eventMapper,
 			$sourceReader,
 			$writer,

--- a/tests/Unit/Service/TmloMdtoExportXsdTest.php
+++ b/tests/Unit/Service/TmloMdtoExportXsdTest.php
@@ -21,7 +21,9 @@ use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Service\Edepot\MdtoBestandGenerator;
 use OCA\OpenRegister\Service\Edepot\MdtoDocumentWriter;
 use OCA\OpenRegister\Service\Edepot\MdtoEventMapper;
+use OCA\OpenRegister\Service\Edepot\MdtoPreconditions;
 use OCA\OpenRegister\Service\Edepot\MdtoSourceReader;
+use OCA\OpenRegister\Service\Edepot\MdtoValueReader;
 use OCA\OpenRegister\Service\Edepot\MdtoXmlGenerator;
 use OCA\OpenRegister\Service\TmloService;
 use OCP\IAppConfig;
@@ -83,6 +85,9 @@ class TmloMdtoExportXsdTest extends TestCase {
 		);
 
 		$writer = new MdtoDocumentWriter();
+		$sourceReader = new MdtoSourceReader(new MdtoValueReader());
+		$bestandGenerator = new MdtoBestandGenerator($writer);
+		$preconditions = new MdtoPreconditions($appConfig, $this->createMock(LoggerInterface::class), $sourceReader, $bestandGenerator);
 
 		$this->service = new TmloService(
 			$this->createMock(RegisterMapper::class),
@@ -92,9 +97,10 @@ class TmloMdtoExportXsdTest extends TestCase {
 				$appConfig,
 				$this->createMock(LoggerInterface::class),
 				$eventMapper,
-				new MdtoSourceReader(),
+				new MdtoSourceReader(new MdtoValueReader()),
 				$writer,
-				new MdtoBestandGenerator($writer)
+				new MdtoBestandGenerator($writer),
+				$preconditions
 			)
 		);
 	}//end setUp()

--- a/tests/Unit/Service/TmloMdtoExportXsdTest.php
+++ b/tests/Unit/Service/TmloMdtoExportXsdTest.php
@@ -148,7 +148,15 @@ class TmloMdtoExportXsdTest extends TestCase {
 
 		$envelope = new DOMDocument();
 		$this->assertTrue($envelope->loadXML($xml));
-		$this->assertSame(TmloService::EXPORT_NAMESPACE, $envelope->documentElement->namespaceURI);
+		// The LITERAL namespace, not the constant: asserting against the
+		// constant under test compares a value with itself, and a change that
+		// pointed the envelope back at the MDTO namespace would pass.
+		$this->assertSame('https://www.openregister.app/mdto-export', $envelope->documentElement->namespaceURI);
+		$this->assertNotSame(
+			'https://www.nationaalarchief.nl/mdto',
+			$envelope->documentElement->namespaceURI,
+			'The envelope is openregister\'s own element and must not claim to be MDTO'
+		);
 
 		$children = 0;
 		foreach ($envelope->documentElement->childNodes as $child) {

--- a/tests/Unit/Service/TmloMdtoExportXsdTest.php
+++ b/tests/Unit/Service/TmloMdtoExportXsdTest.php
@@ -95,7 +95,6 @@ class TmloMdtoExportXsdTest extends TestCase {
 			$this->createMock(LoggerInterface::class),
 			new MdtoXmlGenerator(
 				$appConfig,
-				$this->createMock(LoggerInterface::class),
 				$eventMapper,
 				new MdtoSourceReader(new MdtoValueReader()),
 				$writer,

--- a/tests/Unit/Service/TmloMdtoExportXsdTest.php
+++ b/tests/Unit/Service/TmloMdtoExportXsdTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * TMLO MDTO export XSD conformance tests
+ *
+ * @category Tests
+ * @package  OCA\OpenRegister\Tests\Unit\Service
+ * @author   Conduction Development Team <dev@conduction.nl>
+ * @license  EUPL-1.2
+ */
+
+namespace OCA\OpenRegister\Tests\Unit\Service;
+
+use DOMDocument;
+use DOMElement;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Edepot\MdtoBestandGenerator;
+use OCA\OpenRegister\Service\Edepot\MdtoDocumentWriter;
+use OCA\OpenRegister\Service\Edepot\MdtoEventMapper;
+use OCA\OpenRegister\Service\Edepot\MdtoSourceReader;
+use OCA\OpenRegister\Service\Edepot\MdtoXmlGenerator;
+use OCA\OpenRegister\Service\TmloService;
+use OCP\IAppConfig;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * What `GET /api/tmlo/{register}/{schema}/{id}/export` produces must validate.
+ *
+ * This endpoint had its own MDTO implementation and its output was rejected by
+ * the schema at the root element. It now shares the e-Depot generator, and this
+ * holds that true from the endpoint's own side, so a change to either cannot
+ * quietly break the other.
+ */
+class TmloMdtoExportXsdTest extends TestCase {
+
+	/**
+	 * The vendored schema, relative to this file.
+	 */
+	private const XSD = __DIR__ . '/../../../lib/Resources/mdto/MDTO-XML1.0.1.xsd';
+
+	private TmloService $service;
+
+	/**
+	 * The external-entity loader in force before this test.
+	 *
+	 * @var callable|null
+	 */
+	private $previousEntityLoader = null;
+
+	/**
+	 * Build the service, under the entity loader a booted Nextcloud installs.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		// CI runs this suite inside a booted Nextcloud, whose XXE protection
+		// makes libxml's external-entity loader return null for everything. A
+		// validation that reads the schema FROM DISK passes locally and fails
+		// there, so the condition is carried in the test.
+		$this->previousEntityLoader = libxml_get_external_entity_loader();
+		libxml_set_external_entity_loader(static fn (): mixed => null);
+
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getValueString')->willReturnMap(
+			[
+				['openregister', 'organisation_identifier', '', 'ORG-001'],
+				['openregister', 'organisation_identifier', 'OpenRegister', 'ORG-001'],
+				['openregister', 'organisation_name', '', 'Gemeente Voorbeeld'],
+				['openregister', 'organisation_name', 'OpenRegister', 'Gemeente Voorbeeld'],
+			]
+		);
+
+		$eventMapper = $this->createMock(MdtoEventMapper::class);
+		$eventMapper->method('forObject')->willReturn(
+			[['type' => 'Creatie', 'time' => '2026-01-01T09:00:00+00:00', 'actorName' => 'Jane Doe', 'actorId' => 'jdoe']]
+		);
+
+		$writer = new MdtoDocumentWriter();
+
+		$this->service = new TmloService(
+			$this->createMock(RegisterMapper::class),
+			$this->createMock(SchemaMapper::class),
+			$this->createMock(LoggerInterface::class),
+			new MdtoXmlGenerator(
+				$appConfig,
+				$this->createMock(LoggerInterface::class),
+				$eventMapper,
+				new MdtoSourceReader(),
+				$writer,
+				new MdtoBestandGenerator($writer)
+			)
+		);
+	}//end setUp()
+
+	/**
+	 * Restore the entity loader that was in force before this test.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		libxml_set_external_entity_loader($this->previousEntityLoader);
+
+		parent::tearDown();
+	}//end tearDown()
+
+	/**
+	 * A full TMLO record exports as a document the schema accepts.
+	 *
+	 * @return void
+	 */
+	public function testSingleExportValidates(): void {
+		$xml = $this->service->generateMdtoXml($this->tmloObject());
+
+		$this->assertValidMdto(xml: $xml, what: 'single export');
+	}
+
+	/**
+	 * A TMLO record with only the mandatory appraisal still validates.
+	 *
+	 * @return void
+	 */
+	public function testMinimalExportValidates(): void {
+		$object = new ObjectEntity();
+		$object->setUuid('4d1f0f4e-6b1a-4a5e-9a5c-70d3f6d4a111');
+		$object->setName('Minimaal');
+		$object->setTmlo(['archiefnominatie' => 'vernietigen', 'archiefstatus' => 'actief']);
+
+		$this->assertValidMdto(xml: $this->service->generateMdtoXml($object), what: 'minimal export');
+	}
+
+	/**
+	 * Every child of the batch envelope is a complete, valid MDTO document.
+	 *
+	 * The envelope itself is openregister's own element and is not claimed to
+	 * be MDTO, so it is the children that are validated, each on its own.
+	 *
+	 * @return void
+	 */
+	public function testEveryDocumentInTheBatchEnvelopeValidates(): void {
+		$xml = $this->service->generateBatchMdtoXml([$this->tmloObject(), $this->tmloObject('Tweede')]);
+
+		$envelope = new DOMDocument();
+		$this->assertTrue($envelope->loadXML($xml));
+		$this->assertSame(TmloService::EXPORT_NAMESPACE, $envelope->documentElement->namespaceURI);
+
+		$children = 0;
+		foreach ($envelope->documentElement->childNodes as $child) {
+			if ($child instanceof DOMElement === false) {
+				continue;
+			}
+
+			$children++;
+			$document = new DOMDocument('1.0', 'UTF-8');
+			$document->appendChild($document->importNode($child, true));
+			$this->assertValidMdto(xml: (string)$document->saveXML(), what: 'batch child ' . $children);
+		}
+
+		$this->assertSame(2, $children, 'The envelope did not carry one document per object');
+	}
+
+	/**
+	 * Assert a document validates, naming every schema error when it does not.
+	 *
+	 * @param string $xml The document.
+	 * @param string $what What the document is, for the failure message.
+	 *
+	 * @return void
+	 */
+	private function assertValidMdto(string $xml, string $what): void {
+		$previous = libxml_use_internal_errors(true);
+		libxml_clear_errors();
+
+		$dom = new DOMDocument();
+		$loaded = $dom->loadXML($xml);
+		// schemaValidateSource over the schema's CONTENTS: reading the file is
+		// plain PHP I/O, outside libxml's entity loader.
+		$valid = ($loaded === true && $dom->schemaValidateSource((string)file_get_contents(self::XSD)) === true);
+
+		$errors = [];
+		foreach (libxml_get_errors() as $error) {
+			$errors[] = 'line ' . $error->line . ': ' . trim($error->message);
+		}
+
+		libxml_clear_errors();
+		libxml_use_internal_errors($previous);
+
+		if ($valid === false && $errors === []) {
+			$errors[] = 'schemaValidate returned false without reporting an error';
+		}
+
+		$this->assertSame(
+			[],
+			$errors,
+			'The ' . $what . " does not validate against MDTO-XML1.0.1.xsd:\n  "
+			. implode("\n  ", $errors) . "\n\nDocument:\n" . $xml
+		);
+	}
+
+	/**
+	 * A record carrying the full TMLO field set.
+	 *
+	 * @param string $name The object's name.
+	 *
+	 * @return ObjectEntity The object.
+	 */
+	private function tmloObject(string $name = 'Besluit omgevingsvergunning'): ObjectEntity {
+		$object = new ObjectEntity();
+		$object->setUuid('0b1e9c52-5f3a-4f9e-9d0a-2b6c1d7e8f90');
+		$object->setName($name);
+		$object->setTmlo(
+			[
+				'classification' => '1.1',
+				'archiefnominatie' => 'blijvend_bewaren',
+				'archiefactiedatum' => '2030-01-01',
+				'archiefstatus' => 'semi_statisch',
+				'bewaarTermijn' => 'P7Y',
+				'vernietigingsCategorie' => '1.1.3',
+			]
+		);
+
+		return $object;
+	}
+}

--- a/tests/Unit/Service/TmloServiceTest.php
+++ b/tests/Unit/Service/TmloServiceTest.php
@@ -27,6 +27,7 @@ use OCA\OpenRegister\Db\Register;
 use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Edepot\MdtoXmlGenerator;
 use OCA\OpenRegister\Service\TmloService;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -79,7 +80,8 @@ class TmloServiceTest extends TestCase {
 		$this->service = new TmloService(
 			$this->registerMapper,
 			$this->schemaMapper,
-			$this->logger
+			$this->logger,
+			$this->createMock(MdtoXmlGenerator::class)
 		);
 	}//end setUp()
 


### PR DESCRIPTION
Follow-up to #3635, which left a second MDTO exporter behind. `TmloService::generateMdtoXml()`, serving `GET /api/tmlo/{register}/{schema}/{id}/export`, had its own implementation of the format and its output did not validate. It now goes through the conformant `MdtoXmlGenerator`.

## The defect

Measured against the vendored MDTO-XML 1.0.1 XSD, the endpoint's output was rejected at its root:

> `Element '{https://www.nationaalarchief.nl/mdto}informatieobject': No matching global declaration available for the validation root.`

Past the root it emitted `archiefactiedatum`, `archiefstatus` and `vernietigingsCategorie`, which are TMLO field names, not MDTO elements. The `tmlo-export` spec **required** exactly those, so the spec is what made the document invalid, and fixing the code alone would have left the spec asking for the wrong thing.

## One implementation of the format

`TmloService` no longer builds a DOM. It delegates, so this endpoint and the e-Depot export are the same format and cannot drift apart, the way `RecordState` is one home for the record-state vocabulary.

What made that possible: `MdtoSourceReader` now reads the core archival facts from the `tmlo` block as well as the `retention` block. TMLO is how the facts are STORED, MDTO is how they are EXPORTED, and conflating the two was the defect. Each fact keeps its meaning under the element that carries it:

| TMLO field | MDTO element |
| --- | --- |
| `archiefnominatie` | `waardering`, a term of the closed Waarderingen list |
| `bewaarTermijn` | `bewaartermijn/termijnLooptijd` |
| `archiefactiedatum` | `bewaartermijn/termijnEinddatum` |
| `vernietigingsCategorie` | `informatiecategorie`, the selectielijst category that decides disposal |
| `classification` | `classificatie`, the classification scheme code, an element the generator now emits |
| `archiefstatus` | none |

**Where `archiefstatus` belongs instead.** It is the one fact with no MDTO element, and it is not lost. MDTO expresses that lifecycle as `event` (Overbrenging, Vernietigen), which the generator already derives from the audit trail, and openregister exposes it abstractly as `_retention.status` from the `RecordState` vocabulary. A consumer that wants the raw TMLO field reads the object's `tmlo` block. The spec now says so, and says it must not be added back, because a document carrying it cannot validate.

## Batch export stops inventing an MDTO element

MDTO has no batch container: an `MDTO` document holds exactly one informatieobject or one bestand. The old wrapper was `mdto:informatieobjecten`, a made-up element in the Nationaal Archief's namespace. The envelope is now openregister's own element in openregister's own namespace, and every child of it is a complete, valid MDTO document. Nothing claims the envelope is MDTO.

## Two rules moved to where they belong

- **The retention period is no longer required to serialise.** MDTO marks `bewaartermijn` "Verplicht: Ja, indien bekend" and `minOccurs="0"`, so a record whose period is unknown is exported without the element. Refusing to TRANSFER such a record is a different act, and is now an explicit precondition the packaging path calls. While that rule lived inside `generate()`, this endpoint could not export a record that simply has no retention period yet.
- **`naam` falls back to the entity's own `name` column** before the uuid. TMLO objects carry their name there, and reading only the object data labelled every one of them with its uuid.

## The METS gap, closed

`mets.xml` did not list the per-file `<bestandsnaam>.bestand.MDTO.xml` documents #3635 added, nor the object's own `mdto.xml`. A manifest that omits files the package ships is the same class of defect as the missing `checksumDatum`. There is now a `METADATA` file group listing each with size and checksum, and the object's div points at them.

## Tests

`TmloMdtoExportXsdTest` validates what the endpoint produces, single and batch, with the **null external-entity loader installed in `setUp()`** and restored in `tearDown()`, because CI runs the suite inside a booted Nextcloud whose XXE guard blocks a path-based schema load. The batch case validates each child of the envelope on its own, since the envelope is deliberately not MDTO.

New and changed cases elsewhere: the core facts read from the TMLO block; `classificatie` and `informatiecategorie` as separate elements; `bewaartermijn` omitted when unknown; the transfer precondition accepted and refused; `naam` from the entity column; an object with no appraisal refused, because `waardering` is `minOccurs="1"` and the old exporter emitted documents without it; the METS metadata group; and the SIP refusing an object with no retention period.

## Mutations

Each guard broken, the right test watched to fail, restored, and verified byte-identical.

| # | Mutation | Test that reddened |
| --- | --- | --- |
| A1 | the endpoint goes back to a root of `mdto:informatieobject` | `testSingleExportValidates`, libxml: "No matching global declaration available for the validation root" |
| A2 | the batch envelope claims the MDTO namespace again | `testEveryDocumentInTheBatchEnvelopeValidates` |
| A3, A3b | `archiefstatus` emitted into the document again | the XSD test (libxml: "This element is not expected") and the field-mapping test |
| A4 | the TMLO block is no longer read for the core facts | `testCoreFactsAreReadFromTheTmloBlock` |
| A5 | `vernietigingsCategorie` no longer becomes `informatiecategorie` | same |
| A6 | `classification` no longer becomes `classificatie` | same |
| A7, A7b | the transfer precondition dropped, and the packaging path stops asking | the generator and SIP builder tests |
| A8 | `bewaartermijn` required to serialise again | `testBewaartermijnIsOmittedWhenUnknown` |
| A9 | `naam` stops falling back to the entity name | `testNaamFallsBackToTheEntityName` |
| A10 | `mets.xml` stops listing the MDTO documents | `testBuildBagitLayoutAndManifest` |
| A11 | the endpoint validates from a PATH, with the loader in place | `testSingleExportValidates`, libxml: "resolver function returned null" |
| A11b | the same path-based call WITHOUT the loader | **green, which is the point**: that is the blind spot the loader in `setUp()` exists to close |

**A2 initially stayed green**, and that was a real hole: the test compared the envelope against `TmloService::EXPORT_NAMESPACE`, the very constant the mutation changed, so a value was being compared with itself. It now asserts the literal namespace and that it is not MDTO's.

## Gates, by exit code

All seven green, on the tree after merging `origin/development`.

| Gate | Exit |
| --- | --- |
| `phpunit --no-coverage tests/Unit/` | **0** (19964 tests, 24 pre-existing skips) |
| `composer phpcs` | **0** |
| phpmd `phpmd.xml` | **0** |
| phpmd `phpmd-unusedparams.xml` | **0** |
| `phpstan` (cache cleared first) | **0** |
| `psalm --no-cache` | **0** |
| hydra gates, base `origin/development` | **0** (gates 6, 16, 22, 46, 53 pass; 81 of 82 applicable ran) |

Three advisory warnings are pre-existing and unchanged: gate-19 at 918 scenarios with none from `tmlo-export` or `edepot-transfer`, gate-96 at 2 strings, gate-112 at 17 collections.

## What the gates caught, and what I did about it

Worth recording, because in two cases my first fix made things worse.

- **phpcs** flagged a docblock starting lowercase, a missing `@param`, and a 223-character line. Fixed.
- **phpmd** flagged two classes over the complexity threshold. My first attempt moved methods around inside them and complexity went **up**, from 50 to 53, because an added method brings its own baseline. The second attempt split along a real seam instead: `MdtoValueReader` holds the primitives every archival read shares, `MdtoPreconditions` holds what must be true before a document is worth writing, and the six single-fact readers became one `coreFacts()` read. `generateMetsXml` lost both element loops; phpmd counts a method's docblock in its length, which is why 94 lines of body read as 108.
- **A scoped phpmd run of mine reported nothing and exited 0 while analysing nothing**, because phpmd takes `<paths> <format> <ruleset>` and I passed four positional arguments. The full run is what found the truth. Paths must be comma-separated.
- **phpstan** found a `$logger` that `MdtoXmlGenerator` no longer reads, and a `?? []` on a key the line above always sets. Both removed rather than suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
